### PR TITLE
fix: make Bun installs use the isolated linker

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[install]
+linker = "isolated"


### PR DESCRIPTION
# Summary
- Make the Bun install layout explicit for this monorepo instead of relying on Bun version defaults
- Prevent workspace `prepare` scripts from failing when `@effect/language-service` expects a workspace-local `./node_modules/typescript`
- Keep the existing Bun 1.3.9 project expectation while making installs more robust for contributors on older or migrated setups

# Changes
- Add a root `bunfig.toml` with `install.linker = "isolated"`
- Align the workspace install layout with what the existing `effect-language-service patch` prepare scripts already assume
- Avoid the `scripts/node_modules/typescript/package.json` lookup failure during `bun install`

# Testing
- `bun install` - Pass
- `bun run fmt` - Pass
- `bun run lint` - Pass with existing repository warnings and no errors
- `bun run typecheck` - Pass

# Notes
- The repository already declares `bun@1.3.9` in `package.json` and `.mise.toml`; this change makes the required monorepo install layout explicit instead of relying on Bun defaults
