### PR TITLE
feat(automations): one-click approval for blocked automations

### DIFF
--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -252,9 +252,10 @@ describe("automationApprovalGaps", () => {
     expect(gaps.acknowledgedRisks).toEqual([]);
   });
 
-  it("does not block an auto worktree on local-checkout", () => {
-    // worktreeMode "auto" only needs local-checkout if the server fails to create a worktree
-    // at runtime, so a normal auto run must not be flagged or have local-checkout persisted.
+  it("does not block an auto worktree but covers its fallback on approve", () => {
+    // worktreeMode "auto" is not a definite blocker, so the banner stays full-access only and
+    // Run now is not disabled for it. But approving persists local-checkout too, so the
+    // runtime worktree-creation fallback is covered once the user has approved.
     const gaps = automationApprovalGaps({
       ...base,
       runtimeMode: "full-access",
@@ -263,7 +264,7 @@ describe("automationApprovalGaps", () => {
       acknowledgedRisks: [],
     });
     expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
-    expect(gaps.acknowledgedRisks).toEqual(["full-access"]);
+    expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "local-checkout"]));
   });
 
   it("needs no approval for an approval-required auto automation", () => {

--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -208,8 +208,8 @@ describe("automationApprovalGaps", () => {
       runtimeMode: "full-access",
       acknowledgedRisks: [],
     });
-    expect(gaps.risks).toEqual(["full-access"]);
     expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+    expect(gaps.acknowledgedRisks).toEqual(["full-access"]);
   });
 
   it("requires local-checkout approval for a local worktree", () => {
@@ -218,7 +218,8 @@ describe("automationApprovalGaps", () => {
       worktreeMode: "local",
       acknowledgedRisks: [],
     });
-    expect(gaps.risks).toEqual(["local-checkout"]);
+    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["local-checkout"]);
+    expect(gaps.acknowledgedRisks).toEqual(["local-checkout"]);
   });
 
   it("reports both blocking risks together", () => {
@@ -228,34 +229,40 @@ describe("automationApprovalGaps", () => {
       worktreeMode: "local",
       acknowledgedRisks: [],
     });
-    expect(new Set(gaps.risks)).toEqual(new Set(["full-access", "local-checkout"]));
+    expect(new Set(gaps.warnings.map((warning) => warning.id))).toEqual(
+      new Set(["full-access", "local-checkout"]),
+    );
+    expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "local-checkout"]));
   });
 
-  it("clears once the risks are acknowledged", () => {
+  it("clears the banner once the risks are acknowledged", () => {
     const gaps = automationApprovalGaps({
       ...base,
       runtimeMode: "full-access",
       worktreeMode: "local",
       acknowledgedRisks: ["full-access", "local-checkout"],
     });
-    expect(gaps.risks).toEqual([]);
     expect(gaps.warnings).toEqual([]);
+    expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "local-checkout"]));
   });
 
   it("needs no approval for an approval-required worktree automation", () => {
     const gaps = automationApprovalGaps({ ...base, acknowledgedRisks: [] });
-    expect(gaps.risks).toEqual([]);
+    expect(gaps.warnings).toEqual([]);
+    expect(gaps.acknowledgedRisks).toEqual([]);
   });
 
-  it("does not treat a fast interval as a run blocker", () => {
-    // fast-interval only caps cadence; it never blocks a run, so an otherwise-approved
-    // automation needs no approval even with a sub-minute interval.
+  it("does not show a fast interval as a run blocker but persists it on approve", () => {
+    // fast-interval never blocks a run, so it is not in the banner warnings. But it must be
+    // persisted alongside full-access, or automation.update would reject the sub-minute
+    // schedule and the one-click approval would fail to save.
     const gaps = automationApprovalGaps({
       ...base,
       schedule: { type: "interval", everySeconds: 15 },
       runtimeMode: "full-access",
-      acknowledgedRisks: ["full-access"],
+      acknowledgedRisks: [],
     });
-    expect(gaps.risks).toEqual([]);
+    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+    expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "fast-interval"]));
   });
 });

--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -278,17 +278,19 @@ describe("automationApprovalGaps", () => {
     expect(gaps.acknowledgedRisks).toEqual([]);
   });
 
-  it("does not show a fast interval as a run blocker but persists it on approve", () => {
-    // fast-interval never blocks a run, so it is not in the banner warnings. But it must be
-    // persisted alongside full-access, or automation.update would reject the sub-minute
-    // schedule and the one-click approval would fail to save.
+  it("surfaces and persists the fast-loop risk when approving for another blocker", () => {
+    // fast-interval never blocks a run on its own, but when the banner is already shown for a
+    // run blocker, approving also persists fast-interval (or automation.update would reject
+    // the sub-minute schedule). It is therefore surfaced too, so consent is transparent.
     const gaps = automationApprovalGaps({
       ...base,
       schedule: { type: "interval", everySeconds: 15 },
       runtimeMode: "full-access",
       acknowledgedRisks: [],
     });
-    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+    expect(new Set(gaps.warnings.map((warning) => warning.id))).toEqual(
+      new Set(["full-access", "fast-recurring-interval"]),
+    );
     expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "fast-interval"]));
   });
 });

--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -252,6 +252,31 @@ describe("automationApprovalGaps", () => {
     expect(gaps.acknowledgedRisks).toEqual([]);
   });
 
+  it("does not block an auto worktree on local-checkout", () => {
+    // worktreeMode "auto" only needs local-checkout if the server fails to create a worktree
+    // at runtime, so a normal auto run must not be flagged or have local-checkout persisted.
+    const gaps = automationApprovalGaps({
+      ...base,
+      runtimeMode: "full-access",
+      worktreeMode: "auto",
+      mode: "standalone",
+      acknowledgedRisks: [],
+    });
+    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+    expect(gaps.acknowledgedRisks).toEqual(["full-access"]);
+  });
+
+  it("needs no approval for an approval-required auto automation", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      worktreeMode: "auto",
+      mode: "standalone",
+      acknowledgedRisks: [],
+    });
+    expect(gaps.warnings).toEqual([]);
+    expect(gaps.acknowledgedRisks).toEqual([]);
+  });
+
   it("does not show a fast interval as a run blocker but persists it on approve", () => {
     // fast-interval never blocks a run, so it is not in the banner warnings. But it must be
     // persisted alongside full-access, or automation.update would reject the sub-minute

--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import {
   acknowledgedWarningIdsForAutomaticChatAutomation,
   acknowledgedRiskIdsForDraft,
+  automationApprovalGaps,
   buildAutomationDraftWarnings,
   hasBlockingAutomationDraftWarnings,
   warningIdsForAcknowledgedRisks,
@@ -189,5 +190,72 @@ describe("automation draft warnings", () => {
 
     expect(warnings.map((warning) => warning.id)).not.toContain("local-checkout");
     expect(warnings.map((warning) => warning.id)).not.toContain("worktree-cleanup");
+  });
+});
+
+describe("automationApprovalGaps", () => {
+  const base = {
+    schedule: { type: "daily" as const, timeOfDay: "09:00" },
+    mode: "standalone" as const,
+    runtimeMode: "approval-required" as const,
+    worktreeMode: "worktree" as const,
+    prompt: "Check the build.",
+  };
+
+  it("requires full-access approval when unacknowledged", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      runtimeMode: "full-access",
+      acknowledgedRisks: [],
+    });
+    expect(gaps.risks).toEqual(["full-access"]);
+    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+  });
+
+  it("requires local-checkout approval for a local worktree", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      worktreeMode: "local",
+      acknowledgedRisks: [],
+    });
+    expect(gaps.risks).toEqual(["local-checkout"]);
+  });
+
+  it("reports both blocking risks together", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      runtimeMode: "full-access",
+      worktreeMode: "local",
+      acknowledgedRisks: [],
+    });
+    expect(new Set(gaps.risks)).toEqual(new Set(["full-access", "local-checkout"]));
+  });
+
+  it("clears once the risks are acknowledged", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      runtimeMode: "full-access",
+      worktreeMode: "local",
+      acknowledgedRisks: ["full-access", "local-checkout"],
+    });
+    expect(gaps.risks).toEqual([]);
+    expect(gaps.warnings).toEqual([]);
+  });
+
+  it("needs no approval for an approval-required worktree automation", () => {
+    const gaps = automationApprovalGaps({ ...base, acknowledgedRisks: [] });
+    expect(gaps.risks).toEqual([]);
+  });
+
+  it("does not treat a fast interval as a run blocker", () => {
+    // fast-interval only caps cadence; it never blocks a run, so an otherwise-approved
+    // automation needs no approval even with a sub-minute interval.
+    const gaps = automationApprovalGaps({
+      ...base,
+      schedule: { type: "interval", everySeconds: 15 },
+      runtimeMode: "full-access",
+      acknowledgedRisks: ["full-access"],
+    });
+    expect(gaps.risks).toEqual([]);
   });
 });

--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -252,6 +252,31 @@ describe("automationApprovalGaps", () => {
     expect(gaps.acknowledgedRisks).toEqual([]);
   });
 
+  it("does not block a heartbeat on local-checkout but persists it on approve", () => {
+    // Heartbeat reuses the target thread (no local env), so local-checkout never blocks the
+    // run. It is still persisted on approve so automation.update accepts a local heartbeat.
+    const gaps = automationApprovalGaps({
+      ...base,
+      runtimeMode: "full-access",
+      worktreeMode: "local",
+      mode: "heartbeat",
+      acknowledgedRisks: [],
+    });
+    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+    expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "local-checkout"]));
+  });
+
+  it("needs no approval for an approval-required local heartbeat", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      worktreeMode: "local",
+      mode: "heartbeat",
+      acknowledgedRisks: [],
+    });
+    expect(gaps.warnings).toEqual([]);
+    expect(gaps.acknowledgedRisks).toEqual([]);
+  });
+
   it("does not block an auto worktree but covers its fallback on approve", () => {
     // worktreeMode "auto" is not a definite blocker, so the banner stays full-access only and
     // Run now is not disabled for it. But approving persists local-checkout too, so the

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -175,35 +175,45 @@ export function automationApprovalGaps(input: {
   readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
 } {
   const acknowledged = new Set(input.acknowledgedRisks);
-  const required: AutomationAcknowledgedRiskId[] = [];
-  if (input.runtimeMode === "full-access") {
-    required.push("full-access");
+  // Definite run blockers the server enforces up front (riskAcknowledgementError): full
+  // access runtime and an explicit local checkout. These drive the banner and the Run-now
+  // disable. "auto" is not a definite blocker, so a normal auto run is never blocked here.
+  const blocking = new Set<AutomationAcknowledgedRiskId>();
+  if (input.runtimeMode === "full-access" && !acknowledged.has("full-access")) {
+    blocking.add("full-access");
   }
-  if (input.worktreeMode === "local") {
-    required.push("local-checkout");
+  if (input.worktreeMode === "local" && !acknowledged.has("local-checkout")) {
+    blocking.add("local-checkout");
+  }
+  if (blocking.size === 0) {
+    // Nothing blocks the run, so no approval is surfaced and nothing new is persisted.
+    return { warnings: [], acknowledgedRisks: input.acknowledgedRisks };
+  }
+  const warnings = buildAutomationDraftWarnings({
+    schedule: input.schedule,
+    mode: input.mode,
+    runtimeMode: input.runtimeMode,
+    worktreeMode: input.worktreeMode,
+    hasEphemeralContext: false,
+    generatedConfidence: null,
+    generatedNeedsConfirmation: false,
+    prompt: input.prompt,
+  }).filter((warning) => blocking.has(warning.id as AutomationAcknowledgedRiskId));
+  // Persist every risk the config requires so the automation is fully runnable: local
+  // checkout is included for "auto" too, so a runtime worktree-creation fallback is covered
+  // once approved, plus fast-interval for a sub-minute schedule (automation.update would
+  // otherwise reject it).
+  const required = new Set<AutomationAcknowledgedRiskId>(input.acknowledgedRisks);
+  if (input.runtimeMode === "full-access") {
+    required.add("full-access");
+  }
+  if (input.worktreeMode === "local" || input.worktreeMode === "auto") {
+    required.add("local-checkout");
   }
   if (input.schedule.type === "interval" && input.schedule.everySeconds < 60) {
-    required.push("fast-interval");
+    required.add("fast-interval");
   }
-  // Run-blocking risks (everything required except fast-interval) still needing consent.
-  const blocking = new Set(
-    required.filter((risk) => risk !== "fast-interval" && !acknowledged.has(risk)),
-  );
-  const warnings =
-    blocking.size === 0
-      ? []
-      : buildAutomationDraftWarnings({
-          schedule: input.schedule,
-          mode: input.mode,
-          runtimeMode: input.runtimeMode,
-          worktreeMode: input.worktreeMode,
-          hasEphemeralContext: false,
-          generatedConfidence: null,
-          generatedNeedsConfirmation: false,
-          prompt: input.prompt,
-        }).filter((warning) => blocking.has(warning.id as AutomationAcknowledgedRiskId));
-  const acknowledgedRisks = Array.from(new Set([...input.acknowledgedRisks, ...required]));
-  return { warnings, acknowledgedRisks };
+  return { warnings, acknowledgedRisks: Array.from(required) };
 }
 
 export function acknowledgedRiskIdsForDraft(

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -178,7 +178,9 @@ export function automationApprovalGaps(input: {
   // Definite run blockers the server enforces up front (riskAcknowledgementError): full
   // access runtime and an explicit local checkout. These drive the banner and the Run-now
   // disable. "auto" is not a definite blocker, so a normal auto run is never blocked here.
-  const blocking = new Set<AutomationAcknowledgedRiskId>();
+  // Narrowed to the two ids that are both run blockers and valid warning ids, so the set can
+  // seed the display warning ids below.
+  const blocking = new Set<"full-access" | "local-checkout">();
   if (input.runtimeMode === "full-access" && !acknowledged.has("full-access")) {
     blocking.add("full-access");
   }
@@ -189,6 +191,17 @@ export function automationApprovalGaps(input: {
     // Nothing blocks the run, so no approval is surfaced and nothing new is persisted.
     return { warnings: [], acknowledgedRisks: input.acknowledgedRisks };
   }
+  // Display the blocking risks, plus the fast-recurring-loop risk when a sub-minute schedule
+  // means approving will also acknowledge it — so the user sees everything they consent to,
+  // not just the run blockers.
+  const displayIds = new Set<AutomationDraftWarningId>(blocking);
+  if (
+    input.schedule.type === "interval" &&
+    input.schedule.everySeconds < 60 &&
+    !acknowledged.has("fast-interval")
+  ) {
+    displayIds.add("fast-recurring-interval");
+  }
   const warnings = buildAutomationDraftWarnings({
     schedule: input.schedule,
     mode: input.mode,
@@ -198,7 +211,7 @@ export function automationApprovalGaps(input: {
     generatedConfidence: null,
     generatedNeedsConfirmation: false,
     prompt: input.prompt,
-  }).filter((warning) => blocking.has(warning.id as AutomationAcknowledgedRiskId));
+  }).filter((warning) => displayIds.has(warning.id));
   // Persist every risk the config requires so the automation is fully runnable: local
   // checkout is included for "auto" too, so a runtime worktree-creation fallback is covered
   // once approved, plus fast-interval for a sub-minute schedule (automation.update would

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -161,9 +161,13 @@ const RUN_BLOCKING_WARNING_IDS: ReadonlySet<AutomationDraftWarningId> = new Set(
   "local-checkout",
 ]);
 
-// Computes the approval an existing automation still needs before it can run: the
-// run-blocking risks it carries that have not yet been acknowledged. Returns the missing
-// warnings (for display) and the risk ids to persist. Empty when nothing is required.
+// Computes the approval an existing automation still needs before it can run.
+// `warnings` are the run-blocking risks that have not been acknowledged — they drive the
+// approval banner (empty means no approval needed). `acknowledgedRisks` is the full set to
+// persist when approving: every risk the config requires, merged with what is already
+// acknowledged. It includes fast-interval when the schedule is sub-minute, because
+// automation.update revalidates the whole definition and rejects such a schedule unless
+// fast-interval is acknowledged — so a banner approval would otherwise fail to save.
 export function automationApprovalGaps(input: {
   readonly schedule: AutomationSchedule;
   readonly mode: AutomationMode;
@@ -173,10 +177,10 @@ export function automationApprovalGaps(input: {
   readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
 }): {
   readonly warnings: readonly AutomationDraftWarning[];
-  readonly risks: readonly AutomationAcknowledgedRiskId[];
+  readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
 } {
   const acknowledged = new Set(input.acknowledgedRisks);
-  const warnings = buildAutomationDraftWarnings({
+  const requiredWarnings = buildAutomationDraftWarnings({
     schedule: input.schedule,
     mode: input.mode,
     runtimeMode: input.runtimeMode,
@@ -185,17 +189,23 @@ export function automationApprovalGaps(input: {
     generatedConfidence: null,
     generatedNeedsConfirmation: false,
     prompt: input.prompt,
-  }).filter(
+  }).filter((warning) => warning.requiresAcknowledgement);
+  const warnings = requiredWarnings.filter(
     (warning) =>
-      warning.requiresAcknowledgement &&
       RUN_BLOCKING_WARNING_IDS.has(warning.id) &&
       // full-access and local-checkout warning ids map 1:1 to their risk ids.
       !acknowledged.has(warning.id as AutomationAcknowledgedRiskId),
   );
-  return {
-    warnings,
-    risks: warnings.map((warning) => warning.id as AutomationAcknowledgedRiskId),
-  };
+  const acknowledgedRisks = Array.from(
+    new Set([
+      ...input.acknowledgedRisks,
+      ...acknowledgedRiskIdsForDraft(
+        requiredWarnings,
+        new Set(requiredWarnings.map((warning) => warning.id)),
+      ),
+    ]),
+  );
+  return { warnings, acknowledgedRisks };
 }
 
 export function acknowledgedRiskIdsForDraft(

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -37,7 +37,7 @@ export interface AutomationDraftWarning {
   readonly requiresAcknowledgement: boolean;
 }
 
-type AutomationAcknowledgedRiskId = "full-access" | "local-checkout" | "fast-interval";
+export type AutomationAcknowledgedRiskId = "full-access" | "local-checkout" | "fast-interval";
 
 export interface AutomationCreationDraft {
   readonly source: AutomationCreationDraftSource;
@@ -151,6 +151,51 @@ export function buildAutomationDraftWarnings(input: {
     });
   }
   return warnings;
+}
+
+// The server refuses to start a run only for these two risks (full-access runtime and a
+// local checkout); fast-interval merely caps the cadence, so it never blocks a run and is
+// intentionally excluded from approval detection.
+const RUN_BLOCKING_WARNING_IDS: ReadonlySet<AutomationDraftWarningId> = new Set([
+  "full-access",
+  "local-checkout",
+]);
+
+// Computes the approval an existing automation still needs before it can run: the
+// run-blocking risks it carries that have not yet been acknowledged. Returns the missing
+// warnings (for display) and the risk ids to persist. Empty when nothing is required.
+export function automationApprovalGaps(input: {
+  readonly schedule: AutomationSchedule;
+  readonly mode: AutomationMode;
+  readonly runtimeMode: RuntimeMode;
+  readonly worktreeMode: AutomationWorktreeMode;
+  readonly prompt: string;
+  readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
+}): {
+  readonly warnings: readonly AutomationDraftWarning[];
+  readonly risks: readonly AutomationAcknowledgedRiskId[];
+} {
+  const acknowledged = new Set(input.acknowledgedRisks);
+  const warnings = buildAutomationDraftWarnings({
+    schedule: input.schedule,
+    mode: input.mode,
+    runtimeMode: input.runtimeMode,
+    worktreeMode: input.worktreeMode,
+    hasEphemeralContext: false,
+    generatedConfidence: null,
+    generatedNeedsConfirmation: false,
+    prompt: input.prompt,
+  }).filter(
+    (warning) =>
+      warning.requiresAcknowledgement &&
+      RUN_BLOCKING_WARNING_IDS.has(warning.id) &&
+      // full-access and local-checkout warning ids map 1:1 to their risk ids.
+      !acknowledged.has(warning.id as AutomationAcknowledgedRiskId),
+  );
+  return {
+    warnings,
+    risks: warnings.map((warning) => warning.id as AutomationAcknowledgedRiskId),
+  };
 }
 
 export function acknowledgedRiskIdsForDraft(

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -153,21 +153,16 @@ export function buildAutomationDraftWarnings(input: {
   return warnings;
 }
 
-// The server refuses to start a run only for these two risks (full-access runtime and a
-// local checkout); fast-interval merely caps the cadence, so it never blocks a run and is
-// intentionally excluded from approval detection.
-const RUN_BLOCKING_WARNING_IDS: ReadonlySet<AutomationDraftWarningId> = new Set([
-  "full-access",
-  "local-checkout",
-]);
-
-// Computes the approval an existing automation still needs before it can run.
-// `warnings` are the run-blocking risks that have not been acknowledged — they drive the
-// approval banner (empty means no approval needed). `acknowledgedRisks` is the full set to
-// persist when approving: every risk the config requires, merged with what is already
-// acknowledged. It includes fast-interval when the schedule is sub-minute, because
-// automation.update revalidates the whole definition and rejects such a schedule unless
-// fast-interval is acknowledged — so a banner approval would otherwise fail to save.
+// Computes the approval an existing automation still needs before it can run, matching the
+// server gate exactly. `warnings` are the run-blocking risks not yet acknowledged and drive
+// the approval banner (empty means no approval is needed). `acknowledgedRisks` is the full
+// set to persist when approving, merged with what is already acknowledged.
+//
+// Only full-access runtime and an explicit local checkout (worktreeMode "local") block a
+// run. worktreeMode "auto" is excluded on purpose: the server needs local-checkout for auto
+// only when it cannot create a worktree at runtime (a conditional fallback), so a normal
+// auto run must not be blocked. fast-interval never blocks a run, but it is still persisted
+// on approve so automation.update (which revalidates a sub-minute schedule) accepts the save.
 export function automationApprovalGaps(input: {
   readonly schedule: AutomationSchedule;
   readonly mode: AutomationMode;
@@ -180,31 +175,34 @@ export function automationApprovalGaps(input: {
   readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
 } {
   const acknowledged = new Set(input.acknowledgedRisks);
-  const requiredWarnings = buildAutomationDraftWarnings({
-    schedule: input.schedule,
-    mode: input.mode,
-    runtimeMode: input.runtimeMode,
-    worktreeMode: input.worktreeMode,
-    hasEphemeralContext: false,
-    generatedConfidence: null,
-    generatedNeedsConfirmation: false,
-    prompt: input.prompt,
-  }).filter((warning) => warning.requiresAcknowledgement);
-  const warnings = requiredWarnings.filter(
-    (warning) =>
-      RUN_BLOCKING_WARNING_IDS.has(warning.id) &&
-      // full-access and local-checkout warning ids map 1:1 to their risk ids.
-      !acknowledged.has(warning.id as AutomationAcknowledgedRiskId),
+  const required: AutomationAcknowledgedRiskId[] = [];
+  if (input.runtimeMode === "full-access") {
+    required.push("full-access");
+  }
+  if (input.worktreeMode === "local") {
+    required.push("local-checkout");
+  }
+  if (input.schedule.type === "interval" && input.schedule.everySeconds < 60) {
+    required.push("fast-interval");
+  }
+  // Run-blocking risks (everything required except fast-interval) still needing consent.
+  const blocking = new Set(
+    required.filter((risk) => risk !== "fast-interval" && !acknowledged.has(risk)),
   );
-  const acknowledgedRisks = Array.from(
-    new Set([
-      ...input.acknowledgedRisks,
-      ...acknowledgedRiskIdsForDraft(
-        requiredWarnings,
-        new Set(requiredWarnings.map((warning) => warning.id)),
-      ),
-    ]),
-  );
+  const warnings =
+    blocking.size === 0
+      ? []
+      : buildAutomationDraftWarnings({
+          schedule: input.schedule,
+          mode: input.mode,
+          runtimeMode: input.runtimeMode,
+          worktreeMode: input.worktreeMode,
+          hasEphemeralContext: false,
+          generatedConfidence: null,
+          generatedNeedsConfirmation: false,
+          prompt: input.prompt,
+        }).filter((warning) => blocking.has(warning.id as AutomationAcknowledgedRiskId));
+  const acknowledgedRisks = Array.from(new Set([...input.acknowledgedRisks, ...required]));
   return { warnings, acknowledgedRisks };
 }
 

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -184,7 +184,13 @@ export function automationApprovalGaps(input: {
   if (input.runtimeMode === "full-access" && !acknowledged.has("full-access")) {
     blocking.add("full-access");
   }
-  if (input.worktreeMode === "local" && !acknowledged.has("local-checkout")) {
+  if (
+    input.worktreeMode === "local" &&
+    // Heartbeat runs reuse the target thread and never resolve a local/worktree environment,
+    // so local-checkout consent cannot block them; only standalone runs are gated at dispatch.
+    input.mode === "standalone" &&
+    !acknowledged.has("local-checkout")
+  ) {
     blocking.add("local-checkout");
   }
   if (blocking.size === 0) {

--- a/apps/web/src/routes/-automations.shared.tsx
+++ b/apps/web/src/routes/-automations.shared.tsx
@@ -23,6 +23,7 @@ import {
   ComposerPickerMenuSubPopup,
 } from "~/components/chat/ComposerPickerMenuPopup";
 import { ProviderModelPicker } from "~/components/chat/ProviderModelPicker";
+import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { Dialog, DialogPopup, DialogTitle } from "~/components/ui/dialog";
 import {
@@ -642,6 +643,50 @@ export function maxIterationOptions(
     return MAX_ITERATION_PRESETS;
   }
   return [{ value, label: maxIterationLabel(value) }, ...MAX_ITERATION_PRESETS];
+}
+
+// Shown at the top of an automation's detail panel when it still needs a one-time risk
+// approval before it can run. Approving persists on the automation, so it never asks again.
+export function AutomationApprovalBanner({
+  warnings,
+  busy,
+  onApprove,
+  onApproveAndRun,
+}: {
+  readonly warnings: readonly AutomationDraftWarning[];
+  readonly busy: boolean;
+  readonly onApprove: () => void;
+  readonly onApproveAndRun: () => void;
+}) {
+  if (warnings.length === 0) {
+    return null;
+  }
+  return (
+    <Alert variant="warning">
+      <AlertTitle>Approval needed to run</AlertTitle>
+      <AlertDescription>
+        <span>
+          This automation needs your approval once before it can run. It won&apos;t ask again.
+        </span>
+        <ul className="flex flex-col gap-1.5">
+          {warnings.map((warning) => (
+            <li key={warning.id} className="text-xs">
+              <span className="font-medium text-foreground/90">{warning.title}</span>
+              <span className="block">{warning.detail}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={onApprove}>
+            Approve
+          </Button>
+          <Button type="button" size="sm" disabled={busy} onClick={onApproveAndRun}>
+            Approve &amp; run now
+          </Button>
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
 }
 
 export function AutomationModelPicker({

--- a/apps/web/src/routes/_chat.automations.$automationId.tsx
+++ b/apps/web/src/routes/_chat.automations.$automationId.tsx
@@ -485,7 +485,9 @@ function AutomationDetailView() {
               <AutomationApprovalBanner
                 warnings={approvalGaps.warnings}
                 busy={approvalBusy}
-                onApprove={() => void approveAutomationRisks()}
+                // Swallow the rejection here; the mutation's onError already toasts. Without
+                // this, void-ing the rejected promise would surface an unhandled rejection.
+                onApprove={() => void approveAutomationRisks().catch(() => undefined)}
                 onApproveAndRun={() => void handleApproveAndRunNow()}
               />
               <DetailGroup title="Status">

--- a/apps/web/src/routes/_chat.automations.$automationId.tsx
+++ b/apps/web/src/routes/_chat.automations.$automationId.tsx
@@ -268,14 +268,14 @@ function AutomationDetailView() {
     prompt: definition.prompt,
     acknowledgedRisks: definition.acknowledgedRisks,
   });
-  const approveAutomationRisks = () => {
-    const acknowledgedRisks = Array.from(
-      new Set([...definition.acknowledgedRisks, ...approvalGaps.risks]),
-    );
-    // Records consent only. Pause/resume stays a separate, explicit action so approving
-    // never silently re-enables an automation the user deliberately paused.
-    return updateMutation.mutateAsync({ id: definition.id, acknowledgedRisks });
-  };
+  const approveAutomationRisks = () =>
+    // Records consent only, persisting the full required risk set so the update validates.
+    // Pause/resume stays a separate, explicit action so approving never silently re-enables
+    // an automation the user deliberately paused.
+    updateMutation.mutateAsync({
+      id: definition.id,
+      acknowledgedRisks: approvalGaps.acknowledgedRisks,
+    });
   const handleApproveAndRunNow = async () => {
     try {
       await approveAutomationRisks();
@@ -460,7 +460,14 @@ function AutomationDetailView() {
                   type="button"
                   size="sm"
                   className="ml-1.5"
-                  disabled={runNowMutation.isPending || approvalGaps.warnings.length > 0}
+                  disabled={
+                    runNowMutation.isPending ||
+                    // Stay disabled while an approval update is in flight: the cache merges
+                    // acknowledgedRisks optimistically, so warnings clears before the server
+                    // persists and a run dispatched in that window hits the old definition.
+                    updateMutation.isPending ||
+                    approvalGaps.warnings.length > 0
+                  }
                   title={
                     approvalGaps.warnings.length > 0 ? "Approve the automation first" : undefined
                   }

--- a/apps/web/src/routes/_chat.automations.$automationId.tsx
+++ b/apps/web/src/routes/_chat.automations.$automationId.tsx
@@ -29,6 +29,7 @@ import { SidebarHeaderNavigationControls } from "~/components/SidebarHeaderNavig
 import { Button } from "~/components/ui/button";
 import { SidebarInset } from "~/components/ui/sidebar";
 import {
+  automationApprovalGaps,
   hasBlockingAutomationDraftWarnings,
   warningIdsForAcknowledgedRisks,
   type AutomationDraftWarning,
@@ -55,6 +56,7 @@ import { ensureNativeApi } from "~/nativeApi";
 import { useStore } from "~/store";
 import {
   type AutomationFormState,
+  AutomationApprovalBanner,
   AutomationDialog,
   AutomationModelPicker,
   acknowledgedRiskIdsForFormWarnings,
@@ -256,6 +258,34 @@ function AutomationDetailView() {
   const patch = (input: Omit<AutomationUpdateInput, "id">) =>
     updateMutation.mutate({ id: definition.id, ...input });
 
+  // One-time risk approval surfaced at the top of the panel when an already-created
+  // automation still needs it (e.g. created via the API). Persists on the automation.
+  const approvalGaps = automationApprovalGaps({
+    schedule: definition.schedule,
+    mode: definition.mode,
+    runtimeMode: definition.runtimeMode,
+    worktreeMode: definition.worktreeMode,
+    prompt: definition.prompt,
+    acknowledgedRisks: definition.acknowledgedRisks,
+  });
+  const approveAutomationRisks = () => {
+    const acknowledgedRisks = Array.from(
+      new Set([...definition.acknowledgedRisks, ...approvalGaps.risks]),
+    );
+    // Records consent only. Pause/resume stays a separate, explicit action so approving
+    // never silently re-enables an automation the user deliberately paused.
+    return updateMutation.mutateAsync({ id: definition.id, acknowledgedRisks });
+  };
+  const handleApproveAndRunNow = async () => {
+    try {
+      await approveAutomationRisks();
+    } catch {
+      return; // update failed; the mutation already surfaced the error toast
+    }
+    runNowMutation.mutate(definition);
+  };
+  const approvalBusy = updateMutation.isPending || runNowMutation.isPending;
+
   // Applying a new model selection (model swap or a capability tweak) refreshes the saved
   // provider start options the same way the model picker does, then patches both at once.
   const applyModelSelection = (nextModelSelection: ModelSelection) => {
@@ -430,7 +460,10 @@ function AutomationDetailView() {
                   type="button"
                   size="sm"
                   className="ml-1.5"
-                  disabled={runNowMutation.isPending}
+                  disabled={runNowMutation.isPending || approvalGaps.warnings.length > 0}
+                  title={
+                    approvalGaps.warnings.length > 0 ? "Approve the automation first" : undefined
+                  }
                   onClick={() => runNowMutation.mutate(definition)}
                 >
                   <CentralIcon name="play" className="size-4" />
@@ -442,6 +475,12 @@ function AutomationDetailView() {
 
           <div className="min-h-0 flex-1 overflow-y-auto border-l border-[var(--app-surface-divider)]">
             <div className="flex flex-col gap-6 px-4 py-8">
+              <AutomationApprovalBanner
+                warnings={approvalGaps.warnings}
+                busy={approvalBusy}
+                onApprove={() => void approveAutomationRisks()}
+                onApproveAndRun={() => void handleApproveAndRunNow()}
+              />
               <DetailGroup title="Status">
                 <DetailRow label="Status">
                   <StatusValue>


### PR DESCRIPTION
## What

Automations created through the API (for example by an agent inserting rows directly) land with no risk acknowledgement (`acknowledgedRisks: []`) and get stuck with an opaque **"Failed to create automation thread"** and no in-app way to approve. This surfaces the approval where you hit the wall and makes it one click.

## How it works

- **`automationApprovalGaps()`** (`automationDraft.ts`) detects, matching the server gate, what an existing automation still needs: the run-blocking risks (`warnings`, for the banner) and the full set to persist on approve (`acknowledgedRisks`).
- **`AutomationApprovalBanner`** (`Alert variant="warning"`, so it gets `role="alert"` + the shared warning styling) renders at the top of the automation detail panel with **Approve** and **Approve & run now**.
- Approving writes the acknowledgement through the normal `automation.update` API. It's **persisted on the automation and one-time** — never per run, never asks again.
- The header **Run now** is disabled while approval is pending (incl. the in-flight update), so it can't dead-end on the opaque error.
- Approving records **consent only**; pause/resume stays a separate explicit action.

### Detection mirrors the server's actual run gate
- **full-access** and an explicit **local checkout** (standalone) are run-blocking → shown in the banner.
- **worktreeMode "auto"** is *not* a definite blocker (the server only needs local-checkout for auto on a runtime worktree-creation fallback), so a normal auto run is never over-blocked — but approving persists local-checkout anyway so the fallback is covered.
- **heartbeat** runs reuse the target thread and never resolve a local env, so local-checkout never blocks them.
- **fast-interval** never blocks a run; it isn't shown on its own, but when the banner is already up for a blocker and the schedule is sub-minute, it's surfaced and persisted (so `automation.update` accepts the schedule) rather than acknowledged silently.

## Testing

- `automationDraft.test.ts`: full coverage of `automationApprovalGaps` (full-access, local standalone, auto, heartbeat, fast-interval, cleared-once-acknowledged).
- `bun fmt`, `bun lint` (0 errors), `bun typecheck` (8/8), automation tests green.

## Known follow-ups (server-side — out of scope for this UI PR; see open review threads)

The review surfaced that the server's risk gate is **enforced inconsistently**: `validateRiskAcknowledgements` runs at create/update but **not** in the run-dispatch path (`runNow` / `runDueDefinition` → `dispatchRun`), and only `local-checkout` is enforced at run (for standalone, via `resolveThreadEnvironment`). So:

1. **Enforce the acknowledgement gate at run/dispatch**, so an enabled but unacknowledged automation can't be dispatched without consent (currently the scheduler dispatches it; full-access is never re-checked at run). This makes "approval needed to run" uniformly true.
2. **Consistent create-time validation** for `standalone + auto` (the client already detects it).
3. An enabled sub-minute schedule with `maxIterations` above the fast-loop cap is rejected by `validateSchedulePolicy` regardless of acknowledgement (a fundamentally invalid-to-enable config).
4. **Standing per-project consent** so an agent's automations are pre-approved (zero clicks after one opt-in).

I'll follow up with a focused server PR for 1–3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
