### PR TITLE
fix(typecheck): restore green typecheck on main

### DIFF
--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -168,8 +168,8 @@ function makeFakeCodexAdapter(provider: ProviderKind = "codex") {
       Effect.succeed({ threadId, turns: [] }),
   );
 
-  const compactThread = vi.fn((_threadId: ThreadId): Effect.Effect<void, ProviderAdapterError> =>
-    Effect.void,
+  const compactThread = vi.fn(
+    (_threadId: ThreadId): Effect.Effect<void, ProviderAdapterError> => Effect.void,
   );
 
   const stopAll = vi.fn(
@@ -1101,7 +1101,10 @@ routing.layer("ProviderServiceLive routing", (it) => {
         assert.equal(payload !== null && typeof payload === "object", true);
         if (payload !== null && typeof payload === "object" && !Array.isArray(payload)) {
           assert.equal((payload as Record<string, unknown>).activeTurnId, null);
-          assert.equal((payload as Record<string, unknown>).lastRuntimeEvent, "thread.state.changed");
+          assert.equal(
+            (payload as Record<string, unknown>).lastRuntimeEvent,
+            "thread.state.changed",
+          );
         }
       }
     }),
@@ -1143,7 +1146,10 @@ routing.layer("ProviderServiceLive routing", (it) => {
         assert.equal(payload !== null && typeof payload === "object", true);
         if (payload !== null && typeof payload === "object" && !Array.isArray(payload)) {
           assert.equal((payload as Record<string, unknown>).activeTurnId, turn.turnId);
-          assert.equal((payload as Record<string, unknown>).lastRuntimeEvent, "thread.state.changed");
+          assert.equal(
+            (payload as Record<string, unknown>).lastRuntimeEvent,
+            "thread.state.changed",
+          );
         }
       }
     }),
@@ -1426,58 +1432,60 @@ routing.layer("ProviderServiceLive routing", (it) => {
 
 const idleCleanup = makeProviderServiceLayer({ runtimeIdleStopMs: 100 });
 idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
-  it.effect("stops idle ready runtime using the persisted cursor when the live snapshot omits it", () =>
-    Effect.gen(function* () {
-      const provider = yield* ProviderService;
-      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+  it.effect(
+    "stops idle ready runtime using the persisted cursor when the live snapshot omits it",
+    () =>
+      Effect.gen(function* () {
+        const provider = yield* ProviderService;
+        const runtimeRepository = yield* ProviderSessionRuntimeRepository;
 
-      const session = yield* provider.startSession(asThreadId("thread-idle-persisted-cursor"), {
-        provider: "codex",
-        threadId: asThreadId("thread-idle-persisted-cursor"),
-        runtimeMode: "full-access",
-      });
+        const session = yield* provider.startSession(asThreadId("thread-idle-persisted-cursor"), {
+          provider: "codex",
+          threadId: asThreadId("thread-idle-persisted-cursor"),
+          runtimeMode: "full-access",
+        });
 
-      const persistedBefore = yield* runtimeRepository.getByThreadId({
-        threadId: session.threadId,
-      });
-      assert.equal(Option.isSome(persistedBefore), true);
-      if (Option.isSome(persistedBefore)) {
-        assert.deepEqual(persistedBefore.value.resumeCursor, session.resumeCursor);
-      }
+        const persistedBefore = yield* runtimeRepository.getByThreadId({
+          threadId: session.threadId,
+        });
+        assert.equal(Option.isSome(persistedBefore), true);
+        if (Option.isSome(persistedBefore)) {
+          assert.deepEqual(persistedBefore.value.resumeCursor, session.resumeCursor);
+        }
 
-      idleCleanup.codex.updateSession(session.threadId, (existing) => {
-        const { resumeCursor: _omittedResumeCursor, ...withoutResumeCursor } = existing;
-        return withoutResumeCursor;
-      });
-      yield* idleCleanup.codex.waitForRuntimeSubscribers();
-      idleCleanup.codex.emit({
-        type: "turn.completed",
-        eventId: asEventId("runtime-idle-persisted-cursor-complete"),
-        provider: "codex",
-        createdAt: "2026-02-27T00:04:00.000Z",
-        threadId: session.threadId,
-        payload: { state: "completed" },
-      });
+        idleCleanup.codex.updateSession(session.threadId, (existing) => {
+          const { resumeCursor: _omittedResumeCursor, ...withoutResumeCursor } = existing;
+          return withoutResumeCursor;
+        });
+        yield* idleCleanup.codex.waitForRuntimeSubscribers();
+        idleCleanup.codex.emit({
+          type: "turn.completed",
+          eventId: asEventId("runtime-idle-persisted-cursor-complete"),
+          provider: "codex",
+          createdAt: "2026-02-27T00:04:00.000Z",
+          threadId: session.threadId,
+          payload: { state: "completed" },
+        });
 
-      yield* waitUntil(
-        () => idleCleanup.codex.stopSession.mock.calls.length > 0,
-        500,
-        20,
-        "idle runtime stop",
-      );
+        yield* waitUntil(
+          () => idleCleanup.codex.stopSession.mock.calls.length > 0,
+          500,
+          20,
+          "idle runtime stop",
+        );
 
-      assert.equal(idleCleanup.codex.stopSession.mock.calls.length, 1);
-      assert.deepEqual(idleCleanup.codex.stopSession.mock.calls[0]?.[0], session.threadId);
+        assert.equal(idleCleanup.codex.stopSession.mock.calls.length, 1);
+        assert.deepEqual(idleCleanup.codex.stopSession.mock.calls[0]?.[0], session.threadId);
 
-      const persistedAfter = yield* runtimeRepository.getByThreadId({
-        threadId: session.threadId,
-      });
-      assert.equal(Option.isSome(persistedAfter), true);
-      if (Option.isSome(persistedAfter)) {
-        assert.equal(persistedAfter.value.status, "stopped");
-        assert.deepEqual(persistedAfter.value.resumeCursor, session.resumeCursor);
-      }
-    }),
+        const persistedAfter = yield* runtimeRepository.getByThreadId({
+          threadId: session.threadId,
+        });
+        assert.equal(Option.isSome(persistedAfter), true);
+        if (Option.isSome(persistedAfter)) {
+          assert.equal(persistedAfter.value.status, "stopped");
+          assert.deepEqual(persistedAfter.value.resumeCursor, session.resumeCursor);
+        }
+      }),
   );
 
   it.effect("clears a pending idle stop before dispatching new turn work", () =>
@@ -1606,9 +1614,7 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
       const runtimeRepository = yield* ProviderSessionRuntimeRepository;
       const threadId = asThreadId("thread-idle-fired-new-turn");
       let listSessionsStarted = false;
-      let releaseListSessions:
-        | ((sessions: ReadonlyArray<ProviderSession>) => void)
-        | undefined;
+      let releaseListSessions: ((sessions: ReadonlyArray<ProviderSession>) => void) | undefined;
 
       idleCleanup.codex.stopSession.mockClear();
       const session = yield* provider.startSession(threadId, {
@@ -1672,7 +1678,7 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
 
       const release = releaseListSessions;
       assert.equal(typeof release, "function");
-      release([staleReadySession]);
+      release!([staleReadySession]);
       yield* Fiber.join(sendTurnFiber);
       yield* sleep(100);
 
@@ -1828,9 +1834,7 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
       const runtimeRepository = yield* ProviderSessionRuntimeRepository;
       const threadId = asThreadId("thread-idle-stop-remove-race");
       let listSessionsStarted = false;
-      let releaseListSessions:
-        | ((sessions: ReadonlyArray<ProviderSession>) => void)
-        | undefined;
+      let releaseListSessions: ((sessions: ReadonlyArray<ProviderSession>) => void) | undefined;
 
       const session = yield* provider.startSession(threadId, {
         provider: "codex",
@@ -1884,7 +1888,7 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
       const stopFiber = yield* provider.stopSession({ threadId }).pipe(Effect.forkChild);
       const release = releaseListSessions;
       assert.equal(typeof release, "function");
-      release([staleReadySession]);
+      release!([staleReadySession]);
       yield* Fiber.join(stopFiber);
 
       const binding = yield* directory.getBinding(threadId);
@@ -1898,9 +1902,7 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
       const runtimeRepository = yield* ProviderSessionRuntimeRepository;
       const threadId = asThreadId("thread-idle-runtime-stop-race");
       let listSessionsStarted = false;
-      let releaseListSessions:
-        | ((sessions: ReadonlyArray<ProviderSession>) => void)
-        | undefined;
+      let releaseListSessions: ((sessions: ReadonlyArray<ProviderSession>) => void) | undefined;
 
       const session = yield* provider.startSession(threadId, {
         provider: "codex",
@@ -1959,7 +1961,7 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
       const stopFiber = yield* provider.stopRuntimeSession({ threadId }).pipe(Effect.forkChild);
       const release = releaseListSessions;
       assert.equal(typeof release, "function");
-      release([staleReadySession]);
+      release!([staleReadySession]);
       yield* Fiber.join(stopFiber);
 
       assert.equal(idleCleanup.codex.stopSession.mock.calls.length, 1);

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -311,12 +311,9 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     ): Effect.Effect<A, E, R> =>
       Effect.suspend(() => {
         const existingIdleStop = runtimeIdleStopsInFlight.get(threadId);
-        const displacedIdleStop =
-          existingIdleStop !== undefined || runtimeIdleTimers.has(threadId);
+        const displacedIdleStop = existingIdleStop !== undefined || runtimeIdleTimers.has(threadId);
         const waitForExistingIdleStop =
-          existingIdleStop !== undefined
-            ? Effect.promise(() => existingIdleStop)
-            : Effect.void;
+          existingIdleStop !== undefined ? Effect.promise(() => existingIdleStop) : Effect.void;
         return waitForExistingIdleStop.pipe(
           Effect.tap(() => Effect.sync(() => clearRuntimeIdleTimer(threadId))),
           Effect.flatMap(() => waitForRuntimeIdleStop(threadId)),
@@ -482,22 +479,22 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         const activeTurnId =
           event.type === "turn.started"
             ? (event.turnId ?? null)
-          : event.type === "thread.state.changed" && event.payload.state === "compacted"
+            : event.type === "thread.state.changed" && event.payload.state === "compacted"
               ? (event.turnId ?? currentActiveTurnId)
-            : event.type === "turn.completed" ||
-                event.type === "turn.aborted" ||
-                (event.type === "thread.state.changed" &&
-                  (event.payload.state === "archived" ||
-                    event.payload.state === "closed" ||
-                    event.payload.state === "error")) ||
-                event.type === "session.exited" ||
-                event.type === "runtime.error" ||
-                (event.type === "session.state.changed" &&
-                  (event.payload.state === "ready" ||
-                    event.payload.state === "stopped" ||
-                    event.payload.state === "error"))
-              ? null
-              : currentActiveTurnId;
+              : event.type === "turn.completed" ||
+                  event.type === "turn.aborted" ||
+                  (event.type === "thread.state.changed" &&
+                    (event.payload.state === "archived" ||
+                      event.payload.state === "closed" ||
+                      event.payload.state === "error")) ||
+                  event.type === "session.exited" ||
+                  event.type === "runtime.error" ||
+                  (event.type === "session.state.changed" &&
+                    (event.payload.state === "ready" ||
+                      event.payload.state === "stopped" ||
+                      event.payload.state === "error"))
+                ? null
+                : currentActiveTurnId;
         const lastError = runtimeLastErrorForEvent(event);
         const resumeCursor = yield* refreshResumeCursorFromActiveSession(event, binding);
 
@@ -1064,7 +1061,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
       });
 
     const stopRuntimeSessionInternal = (
-      rawInput,
+      rawInput: Parameters<NonNullable<ProviderServiceShape["stopRuntimeSession"]>>[0],
       expectedIdleGeneration?: symbol,
     ): ReturnType<NonNullable<ProviderServiceShape["stopRuntimeSession"]>> =>
       Effect.gen(function* () {
@@ -1124,8 +1121,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
 
     const stopRuntimeSession: NonNullable<ProviderServiceShape["stopRuntimeSession"]> = (
       rawInput,
-    ) =>
-      stopRuntimeSessionInternal(rawInput);
+    ) => stopRuntimeSessionInternal(rawInput);
 
     stopIdleRuntimeSession = (threadId, generation) => {
       const stopEffect = Effect.gen(function* () {

--- a/apps/web/src/lib/toolCallDetails.ts
+++ b/apps/web/src/lib/toolCallDetails.ts
@@ -46,7 +46,9 @@ export interface DeriveWorkLogToolDetailsInput {
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === "object" && !Array.isArray(value) ? value : null;
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
 }
 
 function asTrimmedString(value: unknown): string | null {
@@ -314,9 +316,7 @@ function collectEditEntries(value: unknown, target: WorkLogToolEditDetails[]) {
   }
 }
 
-function dedupeEditEntries(
-  edits: ReadonlyArray<WorkLogToolEditDetails>,
-): WorkLogToolEditDetails[] {
+function dedupeEditEntries(edits: ReadonlyArray<WorkLogToolEditDetails>): WorkLogToolEditDetails[] {
   const seen = new Set<string>();
   const deduped: WorkLogToolEditDetails[] = [];
   for (const edit of edits) {
@@ -446,11 +446,11 @@ export function mergeWorkLogToolDetails(
   return {
     kind: right.kind,
     title: right.title || left.title,
-    ...(right.command ?? left.command ? { command: right.command ?? left.command } : {}),
+    ...((right.command ?? left.command) ? { command: right.command ?? left.command } : {}),
     ...(output ? { output } : {}),
-    ...(right.diff ?? left.diff ? { diff: right.diff ?? left.diff } : {}),
-    ...(right.content ?? left.content ? { content: right.content ?? left.content } : {}),
-    ...(right.edits ?? left.edits ? { edits: right.edits ?? left.edits } : {}),
+    ...((right.diff ?? left.diff) ? { diff: right.diff ?? left.diff } : {}),
+    ...((right.content ?? left.content) ? { content: right.content ?? left.content } : {}),
+    ...((right.edits ?? left.edits) ? { edits: right.edits ?? left.edits } : {}),
     ...(files ? { files } : {}),
   };
 }

--- a/packages/shared/src/windowsProcess.ts
+++ b/packages/shared/src/windowsProcess.ts
@@ -21,10 +21,10 @@ type SpawnSyncLike = (
 ) => { stdout?: string | null; status?: number | null; error?: Error | undefined };
 
 export interface WindowsSafeProcessInput {
-  readonly platform?: NodeJS.Platform;
-  readonly cwd?: string;
-  readonly env?: NodeJS.ProcessEnv;
-  readonly spawnSync?: SpawnSyncLike;
+  readonly platform?: NodeJS.Platform | undefined;
+  readonly cwd?: string | undefined;
+  readonly env?: NodeJS.ProcessEnv | undefined;
+  readonly spawnSync?: SpawnSyncLike | undefined;
 }
 
 export interface WindowsSafeProcessCommand {
@@ -67,9 +67,7 @@ export function isWindowsBatchCommand(command: string): boolean {
 
 function quoteWindowsBatchToken(token: string, label: string): string {
   if (WINDOWS_BATCH_UNSAFE_TOKEN_PATTERN.test(token)) {
-    throw new Error(
-      `Cannot safely execute Windows batch ${label} containing line breaks.`,
-    );
+    throw new Error(`Cannot safely execute Windows batch ${label} containing line breaks.`);
   }
   const escaped = token
     .replace(/%/g, "%%")
@@ -132,7 +130,8 @@ export function resolveWindowsCommandPath(
     return command;
   }
 
-  const candidates = (result.stdout ?? "")
+  const stdout = typeof result.stdout === "string" ? result.stdout : "";
+  const candidates = stdout
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean);


### PR DESCRIPTION
`bun typecheck` currently fails on `main` with 9 errors across `shared`, `server`, and `web`. All are type-level fixes; no runtime behavior changes.

- **shared/windowsProcess.ts** — `result.stdout` was typed `any` (via the injectable `spawnSync`), so the `.map`/`.find` callbacks were implicit-any; coerce it to a string first. Also widen `WindowsSafeProcessInput`'s optional fields to `T | undefined` so callers can pass `{ cwd, env }` under `exactOptionalPropertyTypes` (fixes the `processRunner` / `AcpSessionRuntime` / `opencodeRuntime` call sites).
- **server/ProviderService.ts** — annotate `stopRuntimeSessionInternal`'s `rawInput` (was implicit any) with the parameter type of `stopRuntimeSession`.
- **server/ProviderService.test.ts** — assert the captured `releaseListSessions` is present before invoking (the existing `typeof === "function"` check already guarantees it at runtime).
- **web/toolCallDetails.ts** — cast the narrowed `object` to `Record<string, unknown>` in `asRecord`.

Verified: `bun fmt`, `bun lint` (0 errors), `bun typecheck` (8/8 green), and the ProviderService suite (37/37) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)