### PR TITLE
Fix Git writing model picker for OpenCode and Kilo discovery

### DIFF
--- a/apps/server/src/git/Layers/GitManager.ts
+++ b/apps/server/src/git/Layers/GitManager.ts
@@ -6,6 +6,7 @@ import type {
   GitActionProgressEvent,
   GitActionProgressPhase,
   GitStackedAction,
+  ModelSelection,
   ProviderStartOptions,
 } from "@t3tools/contracts";
 import {
@@ -25,6 +26,7 @@ import {
 import { GitCore } from "../Services/GitCore.ts";
 import { GitHubCli, type GitHubPullRequestSummary } from "../Services/GitHubCli.ts";
 import { TextGeneration } from "../Services/TextGeneration.ts";
+import { buildGitTextGenerationCallInput } from "../textGenerationSelection.ts";
 import { ServerConfig } from "../../config.ts";
 
 const COMMIT_TIMEOUT_MS = 10 * 60_000;
@@ -73,6 +75,13 @@ interface BranchHeadContext {
   headRepositoryNameWithOwner: string | null;
   headRepositoryOwnerLogin: string | null;
   isCrossRepository: boolean;
+}
+
+interface GitTextGenerationParams {
+  textGenerationModel?: string | undefined;
+  textGenerationModelSelection?: ModelSelection | undefined;
+  codexHomePath?: string | undefined;
+  providerOptions?: ProviderStartOptions | undefined;
 }
 
 interface FailedLocalHandoffRecovery {
@@ -1156,17 +1165,16 @@ export const makeGitManager = Effect.gen(function* () {
       return "main";
     });
 
-  const resolveCommitAndBranchSuggestion = (input: {
-    cwd: string;
-    branch: string | null;
-    commitMessage?: string;
-    codexHomePath?: string;
-    providerOptions?: ProviderStartOptions;
-    /** When true, also produce a semantic feature branch name. */
-    includeBranch?: boolean;
-    filePaths?: readonly string[];
-    model?: string;
-  }) =>
+  const resolveCommitAndBranchSuggestion = (
+    input: {
+      cwd: string;
+      branch: string | null;
+      commitMessage?: string;
+      /** When true, also produce a semantic feature branch name. */
+      includeBranch?: boolean;
+      filePaths?: readonly string[];
+    } & GitTextGenerationParams,
+  ) =>
     Effect.gen(function* () {
       const context = yield* gitCore.prepareCommitContext(input.cwd, input.filePaths);
       if (!context) {
@@ -1191,10 +1199,8 @@ export const makeGitManager = Effect.gen(function* () {
           branch: input.branch,
           stagedSummary: limitContext(context.stagedSummary, 8_000),
           stagedPatch: limitContext(context.stagedPatch, 50_000),
-          ...(input.codexHomePath ? { codexHomePath: input.codexHomePath } : {}),
-          ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
           ...(input.includeBranch ? { includeBranch: true } : {}),
-          ...(input.model ? { model: input.model } : {}),
+          ...buildGitTextGenerationCallInput(input),
         })
         .pipe(
           Effect.map((result) => sanitizeCommitMessage(result)),
@@ -1227,9 +1233,7 @@ export const makeGitManager = Effect.gen(function* () {
     commitMessage?: string,
     preResolvedSuggestion?: CommitAndBranchSuggestion,
     filePaths?: readonly string[],
-    codexHomePath?: string,
-    providerOptions?: ProviderStartOptions,
-    model?: string,
+    textGenerationParams?: GitTextGenerationParams,
     progressReporter?: GitActionProgressReporter,
     actionId?: string,
   ) =>
@@ -1259,9 +1263,7 @@ export const makeGitManager = Effect.gen(function* () {
           branch,
           ...(commitMessage ? { commitMessage } : {}),
           ...(filePaths ? { filePaths } : {}),
-          ...(codexHomePath ? { codexHomePath } : {}),
-          ...(providerOptions ? { providerOptions } : {}),
-          ...(model ? { model } : {}),
+          ...(textGenerationParams ?? {}),
         });
       }
       if (!suggestion) {
@@ -1341,9 +1343,7 @@ export const makeGitManager = Effect.gen(function* () {
   const runPrStep = (
     cwd: string,
     fallbackBranch: string | null,
-    codexHomePath?: string,
-    providerOptions?: ProviderStartOptions,
-    model?: string,
+    textGenerationParams?: GitTextGenerationParams,
   ) =>
     Effect.gen(function* () {
       const details = yield* gitCore.statusDetails(cwd);
@@ -1394,9 +1394,7 @@ export const makeGitManager = Effect.gen(function* () {
         commitSummary: limitContext(rangeContext.commitSummary, 20_000),
         diffSummary: limitContext(rangeContext.diffSummary, 20_000),
         diffPatch: limitContext(rangeContext.diffPatch, 60_000),
-        ...(codexHomePath ? { codexHomePath } : {}),
-        ...(providerOptions ? { providerOptions } : {}),
-        ...(model ? { model } : {}),
+        ...buildGitTextGenerationCallInput(textGenerationParams ?? {}),
       });
 
       const bodyFile = path.join(tempDir, `t3code-pr-body-${process.pid}-${randomUUID()}.md`);
@@ -1508,9 +1506,12 @@ export const makeGitManager = Effect.gen(function* () {
     const generated = yield* textGeneration.generateDiffSummary({
       cwd: input.cwd,
       patch,
-      ...(input.codexHomePath ? { codexHomePath: input.codexHomePath } : {}),
-      ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
-      ...(input.textGenerationModel ? { model: input.textGenerationModel } : {}),
+      ...buildGitTextGenerationCallInput({
+        textGenerationModel: input.textGenerationModel,
+        textGenerationModelSelection: input.textGenerationModelSelection,
+        codexHomePath: input.codexHomePath,
+        providerOptions: input.providerOptions,
+      }),
     });
 
     return {
@@ -2476,9 +2477,7 @@ The local stash entry was kept for recovery.`,
     branch: string | null,
     commitMessage?: string,
     filePaths?: readonly string[],
-    codexHomePath?: string,
-    providerOptions?: ProviderStartOptions,
-    model?: string,
+    textGenerationParams?: GitTextGenerationParams,
     options?: FeatureBranchStepOptions,
   ) =>
     Effect.gen(function* () {
@@ -2487,10 +2486,8 @@ The local stash entry was kept for recovery.`,
         branch,
         ...(commitMessage ? { commitMessage } : {}),
         ...(filePaths ? { filePaths } : {}),
-        ...(codexHomePath ? { codexHomePath } : {}),
-        ...(providerOptions ? { providerOptions } : {}),
         includeBranch: true,
-        ...(model ? { model } : {}),
+        ...(textGenerationParams ?? {}),
       });
       if (!suggestion && !options?.allowCommittedHead) {
         return yield* gitManagerError(
@@ -2612,6 +2609,12 @@ The local stash entry was kept for recovery.`,
 
       const runAction = Effect.gen(function* () {
         const initialStatus = yield* gitCore.statusDetails(input.cwd);
+        const textGenerationParams: GitTextGenerationParams = {
+          textGenerationModel: input.textGenerationModel,
+          textGenerationModelSelection: input.textGenerationModelSelection,
+          codexHomePath: input.codexHomePath,
+          providerOptions: input.providerOptions,
+        };
         const wantsCommit = isCommitAction(input.action);
         const wantsPush =
           input.action === "push" ||
@@ -2677,9 +2680,7 @@ The local stash entry was kept for recovery.`,
             initialStatus.branch,
             input.commitMessage,
             input.filePaths,
-            input.codexHomePath,
-            input.providerOptions,
-            input.textGenerationModel,
+            textGenerationParams,
             {
               allowCommittedHead: !wantsCommit,
               restoreOriginalBranchRef: committedHeadRestoreRef,
@@ -2704,9 +2705,7 @@ The local stash entry was kept for recovery.`,
                 commitMessageForStep,
                 preResolvedCommitSuggestion,
                 input.filePaths,
-                input.codexHomePath,
-                input.providerOptions,
-                input.textGenerationModel,
+                textGenerationParams,
                 options?.progressReporter,
                 progress.actionId,
               );
@@ -2741,13 +2740,7 @@ The local stash entry was kept for recovery.`,
                 Effect.flatMap(() =>
                   Effect.gen(function* () {
                     currentPhase = "pr";
-                    return yield* runPrStep(
-                      input.cwd,
-                      currentBranch,
-                      input.codexHomePath,
-                      input.providerOptions,
-                      input.textGenerationModel,
-                    );
+                    return yield* runPrStep(input.cwd, currentBranch, textGenerationParams);
                   }),
                 ),
               )

--- a/apps/server/src/git/Layers/ProviderTextGeneration.test.ts
+++ b/apps/server/src/git/Layers/ProviderTextGeneration.test.ts
@@ -146,6 +146,28 @@ describe("ProviderTextGenerationLive", () => {
     expect(cursor.generateDiffSummary).not.toHaveBeenCalled();
   });
 
+  it("routes explicit Kilo model selections through Kilo text generation", async () => {
+    const { layer, codex, kilo, opencode } = makeProviderTextGenerationTestLayer();
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const textGeneration = yield* TextGeneration;
+        yield* textGeneration.generateDiffSummary({
+          cwd: "/repo",
+          patch: "diff --git a/file.ts b/file.ts",
+          modelSelection: {
+            provider: "kilo",
+            model: "kilo/kilo-auto/free",
+          },
+        });
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(kilo.generateDiffSummary).toHaveBeenCalledTimes(1);
+    expect(opencode.generateDiffSummary).not.toHaveBeenCalled();
+    expect(codex.generateDiffSummary).not.toHaveBeenCalled();
+  });
+
   it("routes explicit OpenCode model selections and preserves provider options", async () => {
     const { layer, codex, cursor, opencode } = makeProviderTextGenerationTestLayer();
 

--- a/apps/server/src/git/textGenerationSelection.ts
+++ b/apps/server/src/git/textGenerationSelection.ts
@@ -35,3 +35,25 @@ export function resolveTextGenerationInputForSelection(
     ...(providerOptions ? { providerOptions } : {}),
   };
 }
+
+export function buildGitTextGenerationCallInput(input: {
+  readonly textGenerationModel?: string | undefined;
+  readonly textGenerationModelSelection?: ModelSelection | undefined;
+  readonly codexHomePath?: string | undefined;
+  readonly providerOptions?: ProviderStartOptions | undefined;
+}): {
+  readonly model?: string;
+  readonly modelSelection?: ModelSelection;
+  readonly codexHomePath?: string;
+  readonly providerOptions?: ProviderStartOptions;
+} {
+  const modelSelection = input.textGenerationModelSelection;
+  const model = input.textGenerationModel?.trim() || modelSelection?.model;
+
+  return {
+    ...(model ? { model } : {}),
+    ...(modelSelection ? { modelSelection } : {}),
+    ...(input.codexHomePath ? { codexHomePath: input.codexHomePath } : {}),
+    ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
+  };
+}

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -117,6 +117,26 @@ describe("getGitTextGenerationModelOptions", () => {
     expect(options.some((option) => option.slug === "openrouter/gpt-oss-120b")).toBe(true);
   });
 
+  it("prefers runtime-discovered OpenCode and Kilo models for git writing settings", () => {
+    const options = getGitTextGenerationModelOptions(
+      {
+        customCodexModels: [],
+        customKiloModels: [],
+        customOpenCodeModels: [],
+        textGenerationModel: "openrouter/custom-model",
+        textGenerationProvider: "opencode",
+      },
+      {
+        opencode: [{ slug: "openrouter/gpt-oss-120b", name: "GPT OSS 120B" }],
+        kilo: [{ slug: "kilo/kilo-auto/free", name: "Kilo Auto Free" }],
+      },
+    );
+
+    expect(options.some((option) => option.slug === "openrouter/gpt-oss-120b")).toBe(true);
+    expect(options.some((option) => option.slug === "kilo/kilo-auto/free")).toBe(true);
+    expect(options.some((option) => option.slug === "openrouter/custom-model")).toBe(true);
+  });
+
   it("preserves a currently selected transient git writing model", () => {
     const options = getGitTextGenerationModelOptions({
       customCodexModels: [],

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -773,6 +773,19 @@ export function getAppModelOptions(
   return options;
 }
 
+type GitTextGenerationDiscoveredProvider = "codex" | "kilo" | "opencode";
+
+export function mapCatalogModelOptionsToAppModelOptions(
+  provider: GitTextGenerationDiscoveredProvider,
+  options: ReadonlyArray<ProviderModelOption & { isCustom?: boolean }>,
+): AppModelOption[] {
+  return options.map((option) => ({
+    ...option,
+    provider,
+    isCustom: option.isCustom ?? false,
+  }));
+}
+
 export function getGitTextGenerationModelOptions(
   settings: Pick<
     AppSettings,
@@ -782,11 +795,23 @@ export function getGitTextGenerationModelOptions(
     | "textGenerationModel"
     | "textGenerationProvider"
   >,
+  discoveredOptionsByProvider?: Partial<
+    Record<
+      GitTextGenerationDiscoveredProvider,
+      ReadonlyArray<ProviderModelOption & { isCustom?: boolean }>
+    >
+  >,
 ): AppModelOption[] {
   const options = [
-    ...getAppModelOptions("codex", settings.customCodexModels),
-    ...getAppModelOptions("kilo", settings.customKiloModels),
-    ...getAppModelOptions("opencode", settings.customOpenCodeModels),
+    ...(discoveredOptionsByProvider?.codex
+      ? mapCatalogModelOptionsToAppModelOptions("codex", discoveredOptionsByProvider.codex)
+      : getAppModelOptions("codex", settings.customCodexModels)),
+    ...(discoveredOptionsByProvider?.kilo
+      ? mapCatalogModelOptionsToAppModelOptions("kilo", discoveredOptionsByProvider.kilo)
+      : getAppModelOptions("kilo", settings.customKiloModels)),
+    ...(discoveredOptionsByProvider?.opencode
+      ? mapCatalogModelOptionsToAppModelOptions("opencode", discoveredOptionsByProvider.opencode)
+      : getAppModelOptions("opencode", settings.customOpenCodeModels)),
   ];
   const deduped: AppModelOption[] = [];
   const seen = new Set<string>();

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -3,10 +3,12 @@
 // Layer: Header action control
 // Depends on: git React Query hooks, native shell bridges, and shared picker/menu primitives.
 
+import { DEFAULT_GIT_TEXT_GENERATION_MODEL } from "@t3tools/contracts";
 import type {
   GitActionProgressEvent,
   GitStackedAction,
   GitStatusResult,
+  ModelSelection,
   ThreadId,
 } from "@t3tools/contracts";
 import { useIsMutating, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -315,6 +317,13 @@ export default function GitActionsControl({
   const isPanel = variant === "panel";
   const { settings } = useAppSettings();
   const providerOptions = useMemo(() => getProviderStartOptions(settings), [settings]);
+  const gitTextGenerationModelSelection = useMemo(
+    (): ModelSelection => ({
+      provider: settings.textGenerationProvider ?? "codex",
+      model: settings.textGenerationModel ?? DEFAULT_GIT_TEXT_GENERATION_MODEL,
+    }),
+    [settings.textGenerationModel, settings.textGenerationProvider],
+  );
   const activeThread = useStore(
     useMemo(() => createThreadSelector(activeThreadId), [activeThreadId]),
   );
@@ -385,6 +394,7 @@ export default function GitActionsControl({
       queryClient,
       codexHomePath: settings.codexHomePath || null,
       model: settings.textGenerationModel ?? null,
+      modelSelection: gitTextGenerationModelSelection,
       ...(providerOptions ? { providerOptions } : {}),
     }),
   );

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -1,6 +1,7 @@
 import type {
   GitReadWorkingTreeDiffInput,
   GitStackedAction,
+  ModelSelection,
   NativeApi,
   ProviderStartOptions,
 } from "@t3tools/contracts";
@@ -32,6 +33,7 @@ export const gitQueryKeys = {
   diffSummary: (
     cacheScope: string | null,
     model: string | null,
+    modelSelectionKey: string | null,
     codexHomePath: string | null,
     providerOptionsKey: string | null,
     patchKey: string | null,
@@ -41,6 +43,7 @@ export const gitQueryKeys = {
       "diff-summary",
       cacheScope,
       model,
+      modelSelectionKey,
       codexHomePath,
       providerOptionsKey,
       patchKey,
@@ -180,6 +183,7 @@ export function gitSummarizeDiffQueryOptions(input: {
   cacheScope?: string | null;
   patch: string | null;
   model?: string | null;
+  modelSelection?: ModelSelection | null;
   codexHomePath?: string | null;
   providerOptions?: ProviderStartOptions | null;
   enabled?: boolean;
@@ -192,11 +196,13 @@ export function gitSummarizeDiffQueryOptions(input: {
       : null;
 
   const providerOptionsKey = input.providerOptions ? JSON.stringify(input.providerOptions) : null;
+  const modelSelectionKey = input.modelSelection ? JSON.stringify(input.modelSelection) : null;
 
   return queryOptions({
     queryKey: gitQueryKeys.diffSummary(
       input.cacheScope ?? input.cwd,
       input.model ?? null,
+      modelSelectionKey,
       input.codexHomePath ?? null,
       providerOptionsKey,
       patchKey,
@@ -211,6 +217,7 @@ export function gitSummarizeDiffQueryOptions(input: {
         patch: normalizedPatch,
         ...(input.codexHomePath ? { codexHomePath: input.codexHomePath } : {}),
         ...(input.model ? { textGenerationModel: input.model } : {}),
+        ...(input.modelSelection ? { textGenerationModelSelection: input.modelSelection } : {}),
         ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
       });
     },
@@ -331,6 +338,7 @@ export function gitRunStackedActionMutationOptions(input: {
   cwd: string | null;
   queryClient: QueryClient;
   model?: string | null;
+  modelSelection?: ModelSelection | null;
   codexHomePath?: string | null;
   providerOptions?: ProviderStartOptions | null;
 }) {
@@ -358,6 +366,7 @@ export function gitRunStackedActionMutationOptions(input: {
         ...(filePaths ? { filePaths } : {}),
         ...(input.codexHomePath ? { codexHomePath: input.codexHomePath } : {}),
         ...(input.model ? { textGenerationModel: input.model } : {}),
+        ...(input.modelSelection ? { textGenerationModelSelection: input.modelSelection } : {}),
         ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
       }),
   });

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -60,6 +60,7 @@ import {
 } from "../appSettings";
 import { APP_VERSION } from "../branding";
 import { useDesktopTopBarTrafficLightGutterClassName } from "../hooks/useDesktopTopBarGutter";
+import { useProviderModelCatalog } from "../hooks/useProviderModelCatalog";
 import { ProviderOptionLabel } from "../components/ProviderIcon";
 import {
   Autocomplete,
@@ -134,6 +135,7 @@ import {
 } from "../lib/serverReactQuery";
 import { cn, isMacPlatform } from "../lib/utils";
 import { unarchiveThreadFromClient } from "../lib/threadArchive";
+import { resolveProviderDiscoveryCwd } from "../lib/providerDiscovery";
 import { ensureNativeApi, readNativeApi } from "../nativeApi";
 import {
   buildNotificationSettingsSupportText,
@@ -859,26 +861,50 @@ function SettingsRouteView() {
     textGenerationModel,
     textGenerationProvider,
   } = settings;
+  const currentGitTextGenerationProvider = textGenerationProvider ?? "codex";
+  const currentGitTextGenerationModel = textGenerationModel ?? DEFAULT_GIT_TEXT_GENERATION_MODEL;
+  const gitWritingModelHintByProvider = useMemo<Partial<Record<ProviderKind, string | null>>>(
+    () => ({ [currentGitTextGenerationProvider]: currentGitTextGenerationModel }),
+    [currentGitTextGenerationModel, currentGitTextGenerationProvider],
+  );
+  const providerModelDiscoveryCwd = resolveProviderDiscoveryCwd({
+    activeThreadWorktreePath: null,
+    activeProjectCwd: null,
+    serverCwd: serverConfigQuery.data?.cwd ?? null,
+  });
+  const { modelOptionsByProvider: gitWritingCatalogOptionsByProvider } = useProviderModelCatalog({
+    selectedProvider: currentGitTextGenerationProvider,
+    discoveryEnabled: activeSection === "models",
+    cwd: providerModelDiscoveryCwd,
+    modelHintByProvider: gitWritingModelHintByProvider,
+  });
   const gitTextGenerationModelOptions = useMemo(
     () =>
-      getGitTextGenerationModelOptions({
-        customCodexModels,
-        customKiloModels,
-        customOpenCodeModels,
-        textGenerationModel,
-        textGenerationProvider,
-      }),
+      getGitTextGenerationModelOptions(
+        {
+          customCodexModels,
+          customKiloModels,
+          customOpenCodeModels,
+          textGenerationModel,
+          textGenerationProvider,
+        },
+        {
+          codex: gitWritingCatalogOptionsByProvider.codex,
+          kilo: gitWritingCatalogOptionsByProvider.kilo,
+          opencode: gitWritingCatalogOptionsByProvider.opencode,
+        },
+      ),
     [
       customCodexModels,
       customKiloModels,
       customOpenCodeModels,
+      gitWritingCatalogOptionsByProvider.codex,
+      gitWritingCatalogOptionsByProvider.kilo,
+      gitWritingCatalogOptionsByProvider.opencode,
       textGenerationModel,
       textGenerationProvider,
     ],
   );
-  const currentGitTextGenerationProvider = settings.textGenerationProvider ?? "codex";
-  const currentGitTextGenerationModel =
-    settings.textGenerationModel ?? DEFAULT_GIT_TEXT_GENERATION_MODEL;
   const currentGitTextGenerationValue = `${currentGitTextGenerationProvider}:${currentGitTextGenerationModel}`;
   const defaultGitTextGenerationProvider = defaults.textGenerationProvider ?? "codex";
   const defaultGitTextGenerationModel =

--- a/packages/contracts/src/git.test.ts
+++ b/packages/contracts/src/git.test.ts
@@ -83,6 +83,21 @@ describe("GitRunStackedActionInput", () => {
 
     expect(parsed.codexHomePath).toBe("/tmp/custom-codex-home");
   });
+
+  it("accepts an optional textGenerationModelSelection for provider routing", () => {
+    const parsed = decodeRunStackedActionInput({
+      actionId: "action-3",
+      cwd: "/repo",
+      action: "commit",
+      textGenerationModelSelection: {
+        provider: "opencode",
+        model: "openrouter/gpt-oss-120b",
+      },
+    });
+
+    expect(parsed.textGenerationModelSelection?.provider).toBe("opencode");
+    expect(parsed.textGenerationModelSelection?.model).toBe("openrouter/gpt-oss-120b");
+  });
 });
 
 describe("GitSummarizeDiffInput", () => {

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -1,7 +1,7 @@
 import { Option, Schema } from "effect";
 import { NonNegativeInt, PositiveInt, TrimmedNonEmptyString } from "./baseSchemas";
 import { DEFAULT_GIT_TEXT_GENERATION_MODEL } from "./model";
-import { ProviderStartOptions } from "./orchestration";
+import { ModelSelection, ProviderStartOptions } from "./orchestration";
 
 const TrimmedNonEmptyStringSchema = TrimmedNonEmptyString;
 
@@ -110,6 +110,7 @@ export const GitSummarizeDiffInput = Schema.Struct({
   textGenerationModel: Schema.optional(TrimmedNonEmptyStringSchema).pipe(
     Schema.withConstructorDefault(() => Option.some(DEFAULT_GIT_TEXT_GENERATION_MODEL)),
   ),
+  textGenerationModelSelection: Schema.optional(ModelSelection),
 });
 export type GitSummarizeDiffInput = typeof GitSummarizeDiffInput.Type;
 
@@ -127,6 +128,7 @@ export const GitRunStackedActionInput = Schema.Struct({
   textGenerationModel: Schema.optional(TrimmedNonEmptyStringSchema).pipe(
     Schema.withConstructorDefault(() => Option.some(DEFAULT_GIT_TEXT_GENERATION_MODEL)),
   ),
+  textGenerationModelSelection: Schema.optional(ModelSelection),
 });
 export type GitRunStackedActionInput = typeof GitRunStackedActionInput.Type;
 


### PR DESCRIPTION
## Summary
- Wire runtime-discovered OpenCode and Kilo models into the Settings → Models **Git writing model** dropdown (same discovery path the composer already uses).
- Pass the selected git-writing `textGenerationModelSelection` through git actions so commit/PR generation routes to OpenCode/Kilo instead of misrouting via slug heuristics and surfacing **Action failed**.
- Fix CI blockers: `exactOptionalPropertyTypes` on git text-generation params, diff-summary React Query cache keys for model selection, and value import for `DEFAULT_GIT_TEXT_GENERATION_MODEL`.

## Context
Fixes #289. The reporter confirmed composer model discovery works; only the Git writing picker was stale. Their follow-up showed the custom-slug workaround still failed because git actions did not carry provider selection.

## Test plan
- [x] Open Settings → Models on a machine with OpenCode configured; wait a moment and confirm the Git writing model dropdown lists live OpenCode models (not just `OpenAI GPT-5`).
- [x] Select an OpenCode git-writing model and run Commit (with AI message) — should succeed instead of **Action failed**.
- [x] Repeat with a Kilo git-writing model.
- [x] `bun run fmt:check`, `bun run typecheck`, and targeted vitest on `apps/web/src/appSettings.test.ts`, `packages/contracts/src/git.test.ts`, `apps/server/src/git/Layers/ProviderTextGeneration.test.ts`, `apps/server/src/git/Layers/GitManager.test.ts`

## Status
Rebased on latest `upstream/main` (includes #297, #298, #292). Single squashed commit; CI pending.

## Demo
Demo recording:

https://github.com/user-attachments/assets/3d4abe70-f3ca-4918-9f89-b1862dfdf14d