### PR TITLE
fix: stop invalid keybindings toast on every launch

### DIFF
--- a/apps/server/scripts/proof-issue-330.ts
+++ b/apps/server/scripts/proof-issue-330.ts
@@ -203,12 +203,12 @@ const program = Effect.gen(function* () {
     `  has invalid.command:        ${flags.invalid}  (want false)`,
     "",
     beforeState.issues.length > 0 &&
-      afterState.issues.length === 0 &&
-      flags.browserToggle &&
-      flags.terminalSplit &&
-      !flags.rightPanel &&
-      !flags.preview &&
-      !flags.invalid
+    afterState.issues.length === 0 &&
+    flags.browserToggle &&
+    flags.terminalSplit &&
+    !flags.rightPanel &&
+    !flags.preview &&
+    !flags.invalid
       ? "OVERALL: PASS"
       : "OVERALL: FAIL",
     "",

--- a/apps/server/scripts/proof-issue-330.ts
+++ b/apps/server/scripts/proof-issue-330.ts
@@ -120,16 +120,17 @@ const program = Effect.gen(function* () {
   const afterState = yield* keybindings.loadConfigState;
   const afterPersisted = yield* Schema.decodeUnknownEffect(KeybindingsConfigJson)(afterRaw);
 
+  const interestingCommands = new Set([
+    "terminal.toggle",
+    "browser.toggle",
+    "terminal.split",
+    "rightPanel.toggle",
+    "terminal.splitVertical",
+    "preview.toggle",
+    "invalid.command",
+  ]);
   const interesting = afterPersisted.filter((entry) =>
-    [
-      "terminal.toggle",
-      "browser.toggle",
-      "terminal.split",
-      "rightPanel.toggle",
-      "terminal.splitVertical",
-      "preview.toggle",
-      "invalid.command",
-    ].includes(String(entry.command)),
+    interestingCommands.has(String(entry.command)),
   );
 
   const afterReport = [
@@ -172,14 +173,15 @@ const program = Effect.gen(function* () {
     "",
   ].join("\n");
 
+  const commandOf = (entry: { command: unknown }) => String(entry.command);
   const flags = {
-    terminalToggle: afterPersisted.some((e) => e.command === "terminal.toggle"),
-    browserToggle: afterPersisted.some((e) => e.command === "browser.toggle"),
-    terminalSplit: afterPersisted.some((e) => e.command === "terminal.split"),
-    rightPanel: afterPersisted.some((e) => e.command === "rightPanel.toggle"),
-    splitVertical: afterPersisted.some((e) => e.command === "terminal.splitVertical"),
-    preview: afterPersisted.some((e) => e.command === "preview.toggle"),
-    invalid: afterPersisted.some((e) => e.command === "invalid.command"),
+    terminalToggle: afterPersisted.some((e) => commandOf(e) === "terminal.toggle"),
+    browserToggle: afterPersisted.some((e) => commandOf(e) === "browser.toggle"),
+    terminalSplit: afterPersisted.some((e) => commandOf(e) === "terminal.split"),
+    rightPanel: afterPersisted.some((e) => commandOf(e) === "rightPanel.toggle"),
+    splitVertical: afterPersisted.some((e) => commandOf(e) === "terminal.splitVertical"),
+    preview: afterPersisted.some((e) => commandOf(e) === "preview.toggle"),
+    invalid: afterPersisted.some((e) => commandOf(e) === "invalid.command"),
   };
 
   const summary = [

--- a/apps/server/scripts/proof-issue-330.ts
+++ b/apps/server/scripts/proof-issue-330.ts
@@ -1,0 +1,236 @@
+// FILE: proof-issue-330.ts
+// Purpose: Strong before/after proof for #330 — dirty keybindings.json, issues before
+//          startup sync, cleaned file + zero issues after.
+// Run from apps/server:
+//   bun scripts/proof-issue-330.ts
+// Writes to repo .synara-pr-dilip/issue-330/
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { KeybindingsConfig } from "@synara/contracts";
+import { Effect, FileSystem, Layer, Path, Schema } from "effect";
+import * as FS from "node:fs";
+import * as NodePath from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ServerConfig } from "../src/config.ts";
+import { Keybindings, KeybindingsLive } from "../src/keybindings.ts";
+
+const repoRoot = NodePath.resolve(NodePath.dirname(fileURLToPath(import.meta.url)), "../../..");
+const OUT_DIR = NodePath.join(repoRoot, ".synara-pr-dilip/issue-330");
+
+const KeybindingsConfigJson = Schema.fromJsonString(KeybindingsConfig);
+
+const DIRTY_CONFIG = [
+  { key: "mod+j", command: "terminal.toggle" },
+  { key: "mod+b", command: "rightPanel.toggle" },
+  { key: "mod+shift+\\", command: "terminal.splitVertical" },
+  { key: "mod+p", command: "preview.toggle" },
+  { key: "mod+x", command: "invalid.command" },
+] as const;
+
+function formatIssues(
+  issues: ReadonlyArray<{ kind: string; index?: number; message: string }>,
+): string {
+  if (issues.length === 0) return "  (none)";
+  return issues
+    .map((issue, i) => {
+      const indexPart = typeof issue.index === "number" ? ` index=${issue.index}` : "";
+      const firstLine = issue.message.split("\n")[0] ?? issue.message;
+      return `  ${i + 1}. [${issue.kind}]${indexPart}\n     ${firstLine}`;
+    })
+    .join("\n");
+}
+
+function formatCommands(
+  rules: ReadonlyArray<{ key?: string; command: string; shortcut?: { key: string } }>,
+): string {
+  if (rules.length === 0) return "  (none)";
+  return rules
+    .map((rule) => {
+      const key = rule.key ?? (rule.shortcut ? `…+${rule.shortcut.key}` : "?");
+      return `  - ${key} → ${rule.command}`;
+    })
+    .join("\n");
+}
+
+const makeKeybindingsLayer = () =>
+  KeybindingsLive.pipe(
+    Layer.provideMerge(
+      Layer.fresh(
+        ServerConfig.layerTest(process.cwd(), {
+          prefix: "synara-issue-330-proof-",
+        }),
+      ),
+    ),
+  );
+
+const program = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const { keybindingsConfigPath } = yield* ServerConfig;
+  const keybindings = yield* Keybindings;
+
+  yield* fs.makeDirectory(path.dirname(keybindingsConfigPath), { recursive: true });
+  const dirtyJson = `${JSON.stringify([...DIRTY_CONFIG], null, 2)}\n`;
+  yield* fs.writeFileString(keybindingsConfigPath, dirtyJson);
+
+  // ── BEFORE: load only (no startup rewrite) ─────────────────────────────
+  const beforeRaw = yield* fs.readFileString(keybindingsConfigPath);
+  const beforeState = yield* keybindings.loadConfigState;
+  const beforeValidCommands = beforeState.keybindings
+    .filter((entry) =>
+      ["terminal.toggle", "browser.toggle", "terminal.split"].includes(entry.command),
+    )
+    .map((entry) => ({
+      command: entry.command,
+      shortcut: entry.shortcut,
+    }));
+
+  const beforeReport = [
+    "══════════════════════════════════════════════════════════════",
+    "  ISSUE #330 PROOF — BEFORE (dirty config, no startup rewrite)",
+    "══════════════════════════════════════════════════════════════",
+    "",
+    "keybindings.json path:",
+    `  ${keybindingsConfigPath}`,
+    "",
+    "FILE CONTENTS (on disk):",
+    beforeRaw.trimEnd(),
+    "",
+    'ISSUES reported to UI (drives "Invalid keybindings configuration" toast):',
+    `  count = ${beforeState.issues.length}`,
+    formatIssues(beforeState.issues),
+    "",
+    "VALID COMMANDS active in runtime (invalid rows ignored but STILL ON DISK):",
+    formatCommands(beforeValidCommands),
+    "",
+    "ON-DISK COMMANDS (unfiltered):",
+    ...DIRTY_CONFIG.map((row) => `  - ${row.key} → ${row.command}`),
+    "",
+    "PROBLEM: Without rewrite, the next app launch reloads this same file and",
+    "toasts again forever (old code skipped sync when issues.length > 0).",
+    "",
+  ].join("\n");
+
+  // ── APPLY FIX PATH: startup sync rewrites cleaned config ───────────────
+  yield* keybindings.syncDefaultKeybindingsOnStartup;
+
+  // ── AFTER: load again ──────────────────────────────────────────────────
+  const afterRaw = yield* fs.readFileString(keybindingsConfigPath);
+  const afterState = yield* keybindings.loadConfigState;
+  const afterPersisted = yield* Schema.decodeUnknownEffect(KeybindingsConfigJson)(afterRaw);
+
+  const interesting = afterPersisted.filter((entry) =>
+    [
+      "terminal.toggle",
+      "browser.toggle",
+      "terminal.split",
+      "rightPanel.toggle",
+      "terminal.splitVertical",
+      "preview.toggle",
+      "invalid.command",
+    ].includes(String(entry.command)),
+  );
+
+  const afterReport = [
+    "══════════════════════════════════════════════════════════════",
+    "  ISSUE #330 PROOF — AFTER (startup sync rewrite)",
+    "══════════════════════════════════════════════════════════════",
+    "",
+    "keybindings.json path:",
+    `  ${keybindingsConfigPath}`,
+    "",
+    "FILE CONTENTS (on disk after rewrite, first 80 lines / interesting only below):",
+    afterRaw.trimEnd().split("\n").slice(0, 80).join("\n"),
+    afterRaw.split("\n").length > 80 ? "  … (file continues with backfilled defaults)" : "",
+    "",
+    "ISSUES reported to UI:",
+    `  count = ${afterState.issues.length}`,
+    formatIssues(afterState.issues),
+    "",
+    "PERSISTED COMMANDS of interest:",
+    formatCommands(
+      interesting.map((entry) => ({
+        key: entry.key,
+        command: String(entry.command),
+      })),
+    ),
+    "",
+    "TRANSFORMATIONS:",
+    "  rightPanel.toggle      → browser.toggle   (alias)",
+    "  terminal.splitVertical → terminal.split   (alias)",
+    "  preview.toggle         → DROPPED (retired)",
+    "  invalid.command        → DROPPED (invalid)",
+    "  terminal.toggle        → kept",
+    "",
+    "SECOND-LOAD CHECK (simulates next app launch):",
+    `  issues.count = ${afterState.issues.length}  (must be 0 → no recurring toast)`,
+    "",
+    afterState.issues.length === 0
+      ? "RESULT: PASS — cleaned config persists; toast source is gone."
+      : "RESULT: FAIL — issues still present.",
+    "",
+  ].join("\n");
+
+  const flags = {
+    terminalToggle: afterPersisted.some((e) => e.command === "terminal.toggle"),
+    browserToggle: afterPersisted.some((e) => e.command === "browser.toggle"),
+    terminalSplit: afterPersisted.some((e) => e.command === "terminal.split"),
+    rightPanel: afterPersisted.some((e) => e.command === "rightPanel.toggle"),
+    splitVertical: afterPersisted.some((e) => e.command === "terminal.splitVertical"),
+    preview: afterPersisted.some((e) => e.command === "preview.toggle"),
+    invalid: afterPersisted.some((e) => e.command === "invalid.command"),
+  };
+
+  const summary = [
+    "══════════════════════════════════════════════════════════════",
+    "  SUMMARY",
+    "══════════════════════════════════════════════════════════════",
+    "",
+    `Before issues: ${beforeState.issues.length}`,
+    `After issues:  ${afterState.issues.length}`,
+    "",
+    "Before on-disk commands:",
+    ...DIRTY_CONFIG.map((row) => `  ${row.command}`),
+    "",
+    "After on-disk flags:",
+    `  has terminal.toggle:        ${flags.terminalToggle}`,
+    `  has browser.toggle:         ${flags.browserToggle}`,
+    `  has terminal.split:         ${flags.terminalSplit}`,
+    `  has rightPanel.toggle:      ${flags.rightPanel}  (want false)`,
+    `  has terminal.splitVertical: ${flags.splitVertical}  (want false)`,
+    `  has preview.toggle:         ${flags.preview}  (want false)`,
+    `  has invalid.command:        ${flags.invalid}  (want false)`,
+    "",
+    beforeState.issues.length > 0 &&
+      afterState.issues.length === 0 &&
+      flags.browserToggle &&
+      flags.terminalSplit &&
+      !flags.rightPanel &&
+      !flags.preview &&
+      !flags.invalid
+      ? "OVERALL: PASS"
+      : "OVERALL: FAIL",
+    "",
+  ].join("\n");
+
+  FS.mkdirSync(OUT_DIR, { recursive: true });
+  FS.writeFileSync(NodePath.join(OUT_DIR, "before-output.txt"), beforeReport, "utf8");
+  FS.writeFileSync(NodePath.join(OUT_DIR, "after-output.txt"), afterReport, "utf8");
+  FS.writeFileSync(NodePath.join(OUT_DIR, "summary.txt"), summary, "utf8");
+  FS.writeFileSync(
+    NodePath.join(OUT_DIR, "dirty-config.json"),
+    `${JSON.stringify([...DIRTY_CONFIG], null, 2)}\n`,
+    "utf8",
+  );
+  FS.writeFileSync(NodePath.join(OUT_DIR, "cleaned-config-snippet.json"), afterRaw, "utf8");
+
+  // Combined human report
+  const combined = `${beforeReport}\n${afterReport}\n${summary}`;
+  FS.writeFileSync(NodePath.join(OUT_DIR, "FULL-PROOF.txt"), combined, "utf8");
+
+  console.log(combined);
+  console.log(`Wrote proof files to: ${OUT_DIR}`);
+}).pipe(Effect.provide(makeKeybindingsLayer()), Effect.provide(NodeServices.layer));
+
+await Effect.runPromise(program);

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -363,6 +363,30 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
+  // Malformed whole-file JSON must not be rewritten on startup (#339 review): the cleaned
+  // path is an empty rule set, and writing it would erase the user's file.
+  it.effect("does not rewrite malformed keybindings config on startup sync", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const { keybindingsConfigPath } = yield* ServerConfig;
+      const malformed = "{ not-json";
+      yield* fs.writeFileString(keybindingsConfigPath, malformed);
+
+      yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings;
+        yield* keybindings.syncDefaultKeybindingsOnStartup;
+      });
+
+      assert.equal(yield* fs.readFileString(keybindingsConfigPath), malformed);
+
+      const configState = yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings;
+        return yield* keybindings.loadConfigState;
+      });
+      assert.equal(configState.issues[0]?.kind, "keybindings.malformed-config");
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
   // Regression for #330: invalid/retired entries used to skip startup rewrite forever,
   // so the Invalid keybindings toast reappeared on every launch.
   it.effect("rewrites invalid and retired keybindings on startup so issues do not persist", () =>

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -396,9 +396,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
           (entry) => entry.command === "browser.toggle" && entry.shortcut.key === "b",
         ),
       );
-      assert.isTrue(
-        afterSync.keybindings.some((entry) => entry.command === "terminal.split"),
-      );
+      assert.isTrue(afterSync.keybindings.some((entry) => entry.command === "terminal.split"));
       assert.isFalse(
         afterSync.keybindings.some((entry) => String(entry.command) === "preview.toggle"),
       );

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -414,10 +414,10 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
           (entry) => entry.key === "mod+shift+\\" && entry.command === "terminal.split",
         ),
       );
-      assert.isFalse(persisted.some((entry) => entry.command === "preview.toggle"));
-      assert.isFalse(persisted.some((entry) => entry.command === "invalid.command"));
-      assert.isFalse(persisted.some((entry) => entry.command === "rightPanel.toggle"));
-      assert.isFalse(persisted.some((entry) => entry.command === "terminal.splitVertical"));
+      assert.isFalse(persisted.some((entry) => String(entry.command) === "preview.toggle"));
+      assert.isFalse(persisted.some((entry) => String(entry.command) === "invalid.command"));
+      assert.isFalse(persisted.some((entry) => String(entry.command) === "rightPanel.toggle"));
+      assert.isFalse(persisted.some((entry) => String(entry.command) === "terminal.splitVertical"));
 
       // Second load after rewrite stays clean (no recurring toast source).
       const secondLoad = yield* Effect.gen(function* () {

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -363,6 +363,73 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
+  // Regression for #330: invalid/retired entries used to skip startup rewrite forever,
+  // so the Invalid keybindings toast reappeared on every launch.
+  it.effect("rewrites invalid and retired keybindings on startup so issues do not persist", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const { keybindingsConfigPath } = yield* ServerConfig;
+      yield* fs.writeFileString(
+        keybindingsConfigPath,
+        JSON.stringify([
+          { key: "mod+j", command: "terminal.toggle" },
+          { key: "mod+b", command: "rightPanel.toggle" },
+          { key: "mod+shift+\\", command: "terminal.splitVertical" },
+          { key: "mod+p", command: "preview.toggle" },
+          { key: "mod+x", command: "invalid.command" },
+        ]),
+      );
+
+      yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings;
+        yield* keybindings.syncDefaultKeybindingsOnStartup;
+      });
+
+      const afterSync = yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings;
+        return yield* keybindings.loadConfigState;
+      });
+      assert.deepEqual(afterSync.issues, []);
+      assert.isTrue(afterSync.keybindings.some((entry) => entry.command === "terminal.toggle"));
+      assert.isTrue(
+        afterSync.keybindings.some(
+          (entry) => entry.command === "browser.toggle" && entry.shortcut.key === "b",
+        ),
+      );
+      assert.isTrue(
+        afterSync.keybindings.some((entry) => entry.command === "terminal.split"),
+      );
+      assert.isFalse(
+        afterSync.keybindings.some((entry) => String(entry.command) === "preview.toggle"),
+      );
+      assert.isFalse(
+        afterSync.keybindings.some((entry) => String(entry.command) === "invalid.command"),
+      );
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      assert.isTrue(persisted.some((entry) => entry.command === "terminal.toggle"));
+      assert.isTrue(
+        persisted.some((entry) => entry.key === "mod+b" && entry.command === "browser.toggle"),
+      );
+      assert.isTrue(
+        persisted.some(
+          (entry) => entry.key === "mod+shift+\\" && entry.command === "terminal.split",
+        ),
+      );
+      assert.isFalse(persisted.some((entry) => entry.command === "preview.toggle"));
+      assert.isFalse(persisted.some((entry) => entry.command === "invalid.command"));
+      assert.isFalse(persisted.some((entry) => entry.command === "rightPanel.toggle"));
+      assert.isFalse(persisted.some((entry) => entry.command === "terminal.splitVertical"));
+
+      // Second load after rewrite stays clean (no recurring toast source).
+      const secondLoad = yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings;
+        return yield* keybindings.loadConfigState;
+      });
+      assert.deepEqual(secondLoad.issues, []);
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
   it.effect("migrates legacy command palette keybindings without startup issues", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -380,6 +380,30 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
+  // Malformed whole-file JSON must not be rewritten on startup (#339 review): the cleaned
+  // path is an empty rule set, and writing it would erase the user's file.
+  it.effect("does not rewrite malformed keybindings config on startup sync", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const { keybindingsConfigPath } = yield* ServerConfig;
+      const malformed = "{ not-json";
+      yield* fs.writeFileString(keybindingsConfigPath, malformed);
+
+      yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings;
+        yield* keybindings.syncDefaultKeybindingsOnStartup;
+      });
+
+      assert.equal(yield* fs.readFileString(keybindingsConfigPath), malformed);
+
+      const configState = yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings;
+        return yield* keybindings.loadConfigState;
+      });
+      assert.equal(configState.issues[0]?.kind, "keybindings.malformed-config");
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
   // Regression for #330: invalid/retired entries used to skip startup rewrite forever,
   // so the Invalid keybindings toast reappeared on every launch.
   it.effect("rewrites invalid and retired keybindings on startup so issues do not persist", () =>

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -380,6 +380,73 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
+  // Regression for #330: invalid/retired entries used to skip startup rewrite forever,
+  // so the Invalid keybindings toast reappeared on every launch.
+  it.effect("rewrites invalid and retired keybindings on startup so issues do not persist", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const { keybindingsConfigPath } = yield* ServerConfig;
+      yield* fs.writeFileString(
+        keybindingsConfigPath,
+        JSON.stringify([
+          { key: "mod+j", command: "terminal.toggle" },
+          { key: "mod+b", command: "rightPanel.toggle" },
+          { key: "mod+shift+\\", command: "terminal.splitVertical" },
+          { key: "mod+p", command: "preview.toggle" },
+          { key: "mod+x", command: "invalid.command" },
+        ]),
+      );
+
+      yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings;
+        yield* keybindings.syncDefaultKeybindingsOnStartup;
+      });
+
+      const afterSync = yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings;
+        return yield* keybindings.loadConfigState;
+      });
+      assert.deepEqual(afterSync.issues, []);
+      assert.isTrue(afterSync.keybindings.some((entry) => entry.command === "terminal.toggle"));
+      assert.isTrue(
+        afterSync.keybindings.some(
+          (entry) => entry.command === "browser.toggle" && entry.shortcut.key === "b",
+        ),
+      );
+      assert.isTrue(
+        afterSync.keybindings.some((entry) => entry.command === "terminal.split"),
+      );
+      assert.isFalse(
+        afterSync.keybindings.some((entry) => String(entry.command) === "preview.toggle"),
+      );
+      assert.isFalse(
+        afterSync.keybindings.some((entry) => String(entry.command) === "invalid.command"),
+      );
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      assert.isTrue(persisted.some((entry) => entry.command === "terminal.toggle"));
+      assert.isTrue(
+        persisted.some((entry) => entry.key === "mod+b" && entry.command === "browser.toggle"),
+      );
+      assert.isTrue(
+        persisted.some(
+          (entry) => entry.key === "mod+shift+\\" && entry.command === "terminal.split",
+        ),
+      );
+      assert.isFalse(persisted.some((entry) => entry.command === "preview.toggle"));
+      assert.isFalse(persisted.some((entry) => entry.command === "invalid.command"));
+      assert.isFalse(persisted.some((entry) => entry.command === "rightPanel.toggle"));
+      assert.isFalse(persisted.some((entry) => entry.command === "terminal.splitVertical"));
+
+      // Second load after rewrite stays clean (no recurring toast source).
+      const secondLoad = yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings;
+        return yield* keybindings.loadConfigState;
+      });
+      assert.deepEqual(secondLoad.issues, []);
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
   it.effect("migrates legacy command palette keybindings without startup issues", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -413,9 +413,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
           (entry) => entry.command === "browser.toggle" && entry.shortcut.key === "b",
         ),
       );
-      assert.isTrue(
-        afterSync.keybindings.some((entry) => entry.command === "terminal.split"),
-      );
+      assert.isTrue(afterSync.keybindings.some((entry) => entry.command === "terminal.split"));
       assert.isFalse(
         afterSync.keybindings.some((entry) => String(entry.command) === "preview.toggle"),
       );

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -431,10 +431,10 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
           (entry) => entry.key === "mod+shift+\\" && entry.command === "terminal.split",
         ),
       );
-      assert.isFalse(persisted.some((entry) => entry.command === "preview.toggle"));
-      assert.isFalse(persisted.some((entry) => entry.command === "invalid.command"));
-      assert.isFalse(persisted.some((entry) => entry.command === "rightPanel.toggle"));
-      assert.isFalse(persisted.some((entry) => entry.command === "terminal.splitVertical"));
+      assert.isFalse(persisted.some((entry) => String(entry.command) === "preview.toggle"));
+      assert.isFalse(persisted.some((entry) => String(entry.command) === "invalid.command"));
+      assert.isFalse(persisted.some((entry) => String(entry.command) === "rightPanel.toggle"));
+      assert.isFalse(persisted.some((entry) => String(entry.command) === "terminal.splitVertical"));
 
       // Second load after rewrite stays clean (no recurring toast source).
       const secondLoad = yield* Effect.gen(function* () {

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -1004,10 +1004,28 @@ const makeKeybindings = Effect.gen(function* () {
       }
 
       const runtimeConfig = yield* loadRuntimeCustomKeybindingsConfig();
-      // Always continue from the cleaned/migrated rule set. Previously we bailed out when
-      // issues existed, which left invalid entries on disk and re-toasted every launch (#330).
+      // Malformed whole-file configs must not be rewritten: the cleaned path yields an empty
+      // rule set, and persisting that would erase the user's file. Only drop invalid *entries*.
+      const hasMalformedConfig = runtimeConfig.issues.some(
+        (issue) => issue.kind === "keybindings.malformed-config",
+      );
+      if (hasMalformedConfig) {
+        yield* Effect.logWarning(
+          "skipping startup keybindings default sync because config is malformed",
+          {
+            path: keybindingsConfigPath,
+            issues: runtimeConfig.issues,
+          },
+        );
+        yield* Cache.invalidate(resolvedConfigCache, resolvedConfigCacheKey);
+        return;
+      }
+
+      // Always continue from the cleaned/migrated rule set for invalid entries / aliases (#330).
       const customConfig = runtimeConfig.keybindings;
-      const droppedInvalidCount = runtimeConfig.issues.length;
+      const droppedInvalidCount = runtimeConfig.issues.filter(
+        (issue) => issue.kind === "keybindings.invalid-entry",
+      ).length;
       if (droppedInvalidCount > 0) {
         yield* Effect.logWarning("dropping invalid keybinding entries from user config", {
           path: keybindingsConfigPath,

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -566,12 +566,16 @@ const LEGACY_KEYBINDING_COMMAND_ALIASES = {
   "reasoningPicker.toggle": "traitsPicker.toggle",
   "thread.previous": "chat.visible.previous",
   "thread.next": "chat.visible.next",
+  // Pre-rename dock/panel commands still present in older userdata configs.
+  "rightPanel.toggle": "browser.toggle",
+  "terminal.splitVertical": "terminal.split",
 } as const satisfies Record<string, KeybindingRule["command"]>;
 
 // Commands removed without a direct replacement are dropped during startup so
-// persisted configs from older releases do not produce validation warnings.
+// persisted configs from older releases do not produce validation warnings / toasts (#330).
 const RETIRED_LEGACY_KEYBINDING_COMMANDS = new Set(["chat.newGemini"]);
-const RETIRED_LEGACY_KEYBINDING_COMMAND_PATTERN = /^(?:composer\.)?modelPicker\.jump\.[1-9]$/;
+const RETIRED_LEGACY_KEYBINDING_COMMAND_PATTERN =
+  /^(?:composer\.)?modelPicker\.jump\.[1-9]$|^preview\.(?:toggle|refresh|focusUrl|zoomIn|zoomOut|resetZoom)$/;
 const OUTDATED_RECENT_VIEW_TERMINAL_GUARD = "!terminalFocus";
 const RECENT_VIEW_SHORTCUT_BY_COMMAND: Partial<Record<KeybindingRule["command"], string>> = {
   "view.recent.next": "ctrl+tab",
@@ -1000,18 +1004,18 @@ const makeKeybindings = Effect.gen(function* () {
       }
 
       const runtimeConfig = yield* loadRuntimeCustomKeybindingsConfig();
-      if (runtimeConfig.issues.length > 0) {
-        yield* Effect.logWarning(
-          "skipping startup keybindings default sync because config has issues",
-          {
-            path: keybindingsConfigPath,
-            issues: runtimeConfig.issues,
-          },
-        );
-        yield* Cache.invalidate(resolvedConfigCache, resolvedConfigCacheKey);
-        return;
-      }
+      // Always continue from the cleaned/migrated rule set. Previously we bailed out when
+      // issues existed, which left invalid entries on disk and re-toasted every launch (#330).
       const customConfig = runtimeConfig.keybindings;
+      const droppedInvalidCount = runtimeConfig.issues.length;
+      if (droppedInvalidCount > 0) {
+        yield* Effect.logWarning("dropping invalid keybinding entries from user config", {
+          path: keybindingsConfigPath,
+          issueCount: droppedInvalidCount,
+          issues: runtimeConfig.issues,
+          retainedRuleCount: customConfig.length,
+        });
+      }
       const existingCommands = new Set(customConfig.map((entry) => entry.command));
       const missingDefaults: KeybindingRule[] = [];
       const shortcutConflictWarnings: Array<{
@@ -1048,26 +1052,30 @@ const makeKeybindings = Effect.gen(function* () {
           reason: "shortcut context already used by existing rule",
         });
       }
-      if (missingDefaults.length === 0) {
-        if (
-          runtimeConfig.migratedLegacyCommandCount > 0 ||
-          runtimeConfig.migratedDefaultRuleCount > 0 ||
-          runtimeConfig.migratedConfigShape
-        ) {
-          yield* writeConfigAtomically(customConfig);
-        }
+
+      const migratedKeybindingCount =
+        runtimeConfig.migratedLegacyCommandCount + runtimeConfig.migratedDefaultRuleCount;
+      const shouldRewrite =
+        droppedInvalidCount > 0 ||
+        migratedKeybindingCount > 0 ||
+        runtimeConfig.migratedConfigShape ||
+        missingDefaults.length > 0;
+
+      if (!shouldRewrite) {
         yield* Cache.invalidate(resolvedConfigCache, resolvedConfigCacheKey);
         return;
       }
 
-      const matchingDefaults = DEFAULT_KEYBINDINGS.filter((defaultRule) =>
-        customConfig.some((entry) => isSameKeybindingRule(entry, defaultRule)),
-      ).map((rule) => rule.command);
-      if (matchingDefaults.length > 0) {
-        yield* Effect.logWarning("default keybinding rule already defined in user config", {
-          path: keybindingsConfigPath,
-          commands: matchingDefaults,
-        });
+      if (missingDefaults.length > 0) {
+        const matchingDefaults = DEFAULT_KEYBINDINGS.filter((defaultRule) =>
+          customConfig.some((entry) => isSameKeybindingRule(entry, defaultRule)),
+        ).map((rule) => rule.command);
+        if (matchingDefaults.length > 0) {
+          yield* Effect.logWarning("default keybinding rule already defined in user config", {
+            path: keybindingsConfigPath,
+            commands: matchingDefaults,
+          });
+        }
       }
 
       const nextConfig = [...customConfig, ...missingDefaults];
@@ -1082,12 +1090,17 @@ const makeKeybindings = Effect.gen(function* () {
         });
       }
 
-      const migratedKeybindingCount =
-        runtimeConfig.migratedLegacyCommandCount + runtimeConfig.migratedDefaultRuleCount;
       if (migratedKeybindingCount > 0) {
         yield* Effect.logInfo("migrated keybinding config entries", {
           path: keybindingsConfigPath,
           count: migratedKeybindingCount,
+        });
+      }
+      if (droppedInvalidCount > 0) {
+        yield* Effect.logInfo("rewrote keybindings config without invalid entries", {
+          path: keybindingsConfigPath,
+          droppedIssueCount: droppedInvalidCount,
+          retainedRuleCount: customConfig.length,
         });
       }
       yield* writeConfigAtomically(cappedConfig);

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -589,12 +589,16 @@ const LEGACY_KEYBINDING_COMMAND_ALIASES = {
   "reasoningPicker.toggle": "traitsPicker.toggle",
   "thread.previous": "chat.visible.previous",
   "thread.next": "chat.visible.next",
+  // Pre-rename dock/panel commands still present in older userdata configs.
+  "rightPanel.toggle": "browser.toggle",
+  "terminal.splitVertical": "terminal.split",
 } as const satisfies Record<string, KeybindingRule["command"]>;
 
 // Commands removed without a direct replacement are dropped during startup so
-// persisted configs from older releases do not produce validation warnings.
+// persisted configs from older releases do not produce validation warnings / toasts (#330).
 const RETIRED_LEGACY_KEYBINDING_COMMANDS = new Set(["chat.newGemini"]);
-const RETIRED_LEGACY_KEYBINDING_COMMAND_PATTERN = /^(?:composer\.)?modelPicker\.jump\.[1-9]$/;
+const RETIRED_LEGACY_KEYBINDING_COMMAND_PATTERN =
+  /^(?:composer\.)?modelPicker\.jump\.[1-9]$|^preview\.(?:toggle|refresh|focusUrl|zoomIn|zoomOut|resetZoom)$/;
 const OUTDATED_RECENT_VIEW_TERMINAL_GUARD = "!terminalFocus";
 const OUTDATED_SIDEBAR_SEARCH_SHORTCUT = "mod+k";
 const RECENT_VIEW_SHORTCUT_BY_COMMAND: Partial<Record<KeybindingRule["command"], string>> = {
@@ -1047,18 +1051,18 @@ const makeKeybindings = Effect.gen(function* () {
       }
 
       const runtimeConfig = yield* loadRuntimeCustomKeybindingsConfig();
-      if (runtimeConfig.issues.length > 0) {
-        yield* Effect.logWarning(
-          "skipping startup keybindings default sync because config has issues",
-          {
-            path: keybindingsConfigPath,
-            issues: runtimeConfig.issues,
-          },
-        );
-        yield* Cache.invalidate(resolvedConfigCache, resolvedConfigCacheKey);
-        return;
-      }
+      // Always continue from the cleaned/migrated rule set. Previously we bailed out when
+      // issues existed, which left invalid entries on disk and re-toasted every launch (#330).
       const customConfig = runtimeConfig.keybindings;
+      const droppedInvalidCount = runtimeConfig.issues.length;
+      if (droppedInvalidCount > 0) {
+        yield* Effect.logWarning("dropping invalid keybinding entries from user config", {
+          path: keybindingsConfigPath,
+          issueCount: droppedInvalidCount,
+          issues: runtimeConfig.issues,
+          retainedRuleCount: customConfig.length,
+        });
+      }
       const existingCommands = new Set(customConfig.map((entry) => entry.command));
       const missingDefaults: KeybindingRule[] = [];
       const shortcutConflictWarnings: Array<{
@@ -1095,26 +1099,30 @@ const makeKeybindings = Effect.gen(function* () {
           reason: "shortcut context already used by existing rule",
         });
       }
-      if (missingDefaults.length === 0) {
-        if (
-          runtimeConfig.migratedLegacyCommandCount > 0 ||
-          runtimeConfig.migratedDefaultRuleCount > 0 ||
-          runtimeConfig.migratedConfigShape
-        ) {
-          yield* writeConfigAtomically(customConfig);
-        }
+
+      const migratedKeybindingCount =
+        runtimeConfig.migratedLegacyCommandCount + runtimeConfig.migratedDefaultRuleCount;
+      const shouldRewrite =
+        droppedInvalidCount > 0 ||
+        migratedKeybindingCount > 0 ||
+        runtimeConfig.migratedConfigShape ||
+        missingDefaults.length > 0;
+
+      if (!shouldRewrite) {
         yield* Cache.invalidate(resolvedConfigCache, resolvedConfigCacheKey);
         return;
       }
 
-      const matchingDefaults = DEFAULT_KEYBINDINGS.filter((defaultRule) =>
-        customConfig.some((entry) => isSameKeybindingRule(entry, defaultRule)),
-      ).map((rule) => rule.command);
-      if (matchingDefaults.length > 0) {
-        yield* Effect.logWarning("default keybinding rule already defined in user config", {
-          path: keybindingsConfigPath,
-          commands: matchingDefaults,
-        });
+      if (missingDefaults.length > 0) {
+        const matchingDefaults = DEFAULT_KEYBINDINGS.filter((defaultRule) =>
+          customConfig.some((entry) => isSameKeybindingRule(entry, defaultRule)),
+        ).map((rule) => rule.command);
+        if (matchingDefaults.length > 0) {
+          yield* Effect.logWarning("default keybinding rule already defined in user config", {
+            path: keybindingsConfigPath,
+            commands: matchingDefaults,
+          });
+        }
       }
 
       const nextConfig = [...customConfig, ...missingDefaults];
@@ -1129,12 +1137,17 @@ const makeKeybindings = Effect.gen(function* () {
         });
       }
 
-      const migratedKeybindingCount =
-        runtimeConfig.migratedLegacyCommandCount + runtimeConfig.migratedDefaultRuleCount;
       if (migratedKeybindingCount > 0) {
         yield* Effect.logInfo("migrated keybinding config entries", {
           path: keybindingsConfigPath,
           count: migratedKeybindingCount,
+        });
+      }
+      if (droppedInvalidCount > 0) {
+        yield* Effect.logInfo("rewrote keybindings config without invalid entries", {
+          path: keybindingsConfigPath,
+          droppedIssueCount: droppedInvalidCount,
+          retainedRuleCount: customConfig.length,
         });
       }
       yield* writeConfigAtomically(cappedConfig);

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -1051,10 +1051,28 @@ const makeKeybindings = Effect.gen(function* () {
       }
 
       const runtimeConfig = yield* loadRuntimeCustomKeybindingsConfig();
-      // Always continue from the cleaned/migrated rule set. Previously we bailed out when
-      // issues existed, which left invalid entries on disk and re-toasted every launch (#330).
+      // Malformed whole-file configs must not be rewritten: the cleaned path yields an empty
+      // rule set, and persisting that would erase the user's file. Only drop invalid *entries*.
+      const hasMalformedConfig = runtimeConfig.issues.some(
+        (issue) => issue.kind === "keybindings.malformed-config",
+      );
+      if (hasMalformedConfig) {
+        yield* Effect.logWarning(
+          "skipping startup keybindings default sync because config is malformed",
+          {
+            path: keybindingsConfigPath,
+            issues: runtimeConfig.issues,
+          },
+        );
+        yield* Cache.invalidate(resolvedConfigCache, resolvedConfigCacheKey);
+        return;
+      }
+
+      // Always continue from the cleaned/migrated rule set for invalid entries / aliases (#330).
       const customConfig = runtimeConfig.keybindings;
-      const droppedInvalidCount = runtimeConfig.issues.length;
+      const droppedInvalidCount = runtimeConfig.issues.filter(
+        (issue) => issue.kind === "keybindings.invalid-entry",
+      ).length;
       if (droppedInvalidCount > 0) {
         yield* Effect.logWarning("dropping invalid keybinding entries from user config", {
           path: keybindingsConfigPath,

--- a/apps/web/src/lib/toolCallLabel.ts
+++ b/apps/web/src/lib/toolCallLabel.ts
@@ -122,10 +122,7 @@ const BROWSER_TOOL_NAME_SET = new Set<string>(BROWSER_TOOL_NAMES);
 const SYNARA_BROWSER_TOOL_PRESENTATIONS = Object.fromEntries(
   BROWSER_TOOL_NAMES.map((toolName) => {
     const title = BROWSER_TOOL_TITLES[toolName];
-    return [
-      `synara_${toolName}`,
-      { running: title, completed: title, failed: title },
-    ];
+    return [`synara_${toolName}`, { running: title, completed: title, failed: title }];
   }),
 ) as Record<SynaraBrowserToolName, SynaraMcpToolPresentation>;
 


### PR DESCRIPTION
## Summary

Stops the **Invalid keybindings configuration** toast from reappearing on every app launch when `keybindings.json` still contains retired or invalid commands.

Closes #330

## Problem

On launch, Synara loads `~/.synara/userdata/keybindings.json`. Invalid `command` values are ignored at runtime and reported as config issues (UI toast). Previously, when **any** issues existed, `syncDefaultKeybindingsOnStartup` **bailed out** and never rewrote the file:

```text
skipping startup keybindings default sync because config has issues
```

So the dirty file stayed on disk → next launch → same toast forever. Reinstalling the app does not clear userdata.

## Root cause

1. Invalid / retired entries were filtered only in memory.
2. Startup sync refused to persist when `issues.length > 0`.
3. Some older command names (`rightPanel.toggle`, `terminal.splitVertical`, `preview.*`) were not migrated/dropped.

## Solution

| Change | Detail |
|--------|--------|
| Startup rewrite | Always use the cleaned/migrated rule set; **persist** when invalids drop, aliases apply, shape migrates, or defaults backfill |
| Aliases | `rightPanel.toggle` → `browser.toggle`; `terminal.splitVertical` → `terminal.split` |
| Retired (drop) | `preview.toggle` / `refresh` / `focusUrl` / `zoomIn` / `zoomOut` / `resetZoom` (plus existing `modelPicker.jump.[1-9]`) |
| Logging | Clear warn/info when dropping invalids and rewriting the file |

## Evidence (before / after)

Runnable proof against the real keybindings service:

```bash
cd apps/server && bun scripts/proof-issue-330.ts
```

| Metric | Before (load only) | After (`syncDefaultKeybindingsOnStartup`) |
|--------|--------------------|-------------------------------------------|
| Issues (toast source) | **1** (`invalid.command`) | **0** |
| `rightPanel.toggle` on disk | present | **→ `browser.toggle`** |
| `terminal.splitVertical` on disk | present | **→ `terminal.split`** |
| `preview.toggle` on disk | present | **dropped** |
| `invalid.command` on disk | present | **dropped** |
| Next launch | toast again | **clean** |

**Headline from live proof run:**

```text
Before issues: 1
After issues:  0
OVERALL: PASS
```

Dirty input used in the proof:

```json
[
  { "key": "mod+j", "command": "terminal.toggle" },
  { "key": "mod+b", "command": "rightPanel.toggle" },
  { "key": "mod+shift+\\", "command": "terminal.splitVertical" },
  { "key": "mod+p", "command": "preview.toggle" },
  { "key": "mod+x", "command": "invalid.command" }
]
```

## Test plan

- [x] `bunx vitest run apps/server/src/keybindings.test.ts` — **30/30 pass**
- [x] Regression: *rewrites invalid and retired keybindings on startup so issues do not persist*
- [x] Proof script: `cd apps/server && bun scripts/proof-issue-330.ts` → **OVERALL: PASS**
- [ ] Manual (optional): seed userdata with the dirty JSON above, launch once with this build, confirm toast does not return on second launch

## Files

- `apps/server/src/keybindings.ts`
- `apps/server/src/keybindings.test.ts`
- `apps/server/scripts/proof-issue-330.ts` (re-runnable evidence)