### PR TITLE
feat: publish Linux .deb desktop artifacts in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,7 +305,8 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: desktop-${{ matrix.platform }}-${{ matrix.arch }}
+          # Include target so AppImage + deb (same platform/arch) do not collide.
+          name: desktop-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}
           path: release-publish/*
           if-no-files-found: error
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,10 +151,15 @@ jobs:
             platform: mac
             target: dmg
             arch: x64
-          - label: Linux x64
+          - label: Linux x64 AppImage
             runner: ubuntu-24.04
             platform: linux
             target: AppImage
+            arch: x64
+          - label: Linux x64 deb
+            runner: ubuntu-24.04
+            platform: linux
+            target: deb
             arch: x64
           - label: Windows x64
             runner: windows-2022
@@ -282,6 +287,7 @@ jobs:
             "release/*.dmg" \
             "release/*.zip" \
             "release/*.AppImage" \
+            "release/*.deb" \
             "release/*.exe" \
             "release/*.blockmap" \
             "release/latest*.yml"; do
@@ -463,6 +469,7 @@ jobs:
             release-assets/*.dmg
             release-assets/*.zip
             release-assets/*.AppImage
+            release-assets/*.deb
             release-assets/*.exe
             release-assets/*.blockmap
             release-assets/*.yml
@@ -489,6 +496,7 @@ jobs:
             release-assets/*.dmg
             release-assets/*.zip
             release-assets/*.AppImage
+            release-assets/*.deb
             release-assets/*.exe
             release-assets/*.blockmap
           )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,10 +172,15 @@ jobs:
             platform: mac
             target: dmg
             arch: x64
-          - label: Linux x64
+          - label: Linux x64 AppImage
             runner: ubuntu-24.04
             platform: linux
             target: AppImage
+            arch: x64
+          - label: Linux x64 deb
+            runner: ubuntu-24.04
+            platform: linux
+            target: deb
             arch: x64
           - label: Windows x64
             runner: windows-2022
@@ -325,6 +330,7 @@ jobs:
             "release/*.dmg" \
             "release/*.zip" \
             "release/*.AppImage" \
+            "release/*.deb" \
             "release/*.exe" \
             "release/*.blockmap" \
             "release/latest*.yml"; do
@@ -541,6 +547,7 @@ jobs:
             release-assets/*.dmg
             release-assets/*.zip
             release-assets/*.AppImage
+            release-assets/*.deb
             release-assets/*.exe
             release-assets/*.blockmap
             release-assets/*.yml
@@ -568,6 +575,7 @@ jobs:
             release-assets/*.dmg
             release-assets/*.zip
             release-assets/*.AppImage
+            release-assets/*.deb
             release-assets/*.exe
             release-assets/*.blockmap
           )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,7 +386,8 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: desktop-${{ matrix.platform }}-${{ matrix.arch }}
+          # Include target so AppImage + deb (same platform/arch) do not collide.
+          name: desktop-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}
           path: release-publish/*
           if-no-files-found: error
 

--- a/apps/web/src/lib/toolCallLabel.ts
+++ b/apps/web/src/lib/toolCallLabel.ts
@@ -122,10 +122,7 @@ const BROWSER_TOOL_NAME_SET = new Set<string>(BROWSER_TOOL_NAMES);
 const SYNARA_BROWSER_TOOL_PRESENTATIONS = Object.fromEntries(
   BROWSER_TOOL_NAMES.map((toolName) => {
     const title = BROWSER_TOOL_TITLES[toolName];
-    return [
-      `synara_${toolName}`,
-      { running: title, completed: title, failed: title },
-    ];
+    return [`synara_${toolName}`, { running: title, completed: title, failed: title }];
   }),
 ) as Record<SynaraBrowserToolName, SynaraMcpToolPresentation>;
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -13,6 +13,7 @@ This document covers build-only native validation and publishing desktop release
   - macOS `arm64` DMG
   - macOS `x64` DMG
   - Linux `x64` AppImage
+  - Linux `x64` `.deb`
   - Windows `x64` NSIS installer
 - Publishes one versioned GitHub Release with all produced files.
   - Versions with a suffix after `X.Y.Z` (for example `1.2.3-alpha.1`) are published as GitHub prereleases.
@@ -37,7 +38,7 @@ This document covers build-only native validation and publishing desktop release
   - `SYNARA_DESKTOP_UPDATE_REPOSITORY` (format `owner/repo`), if set.
   - otherwise `GITHUB_REPOSITORY` from GitHub Actions.
 - Required Synara release assets for updater:
-  - platform installers (`.exe`, `.dmg`, `.AppImage`, plus macOS `.zip` for Squirrel.Mac update payloads)
+  - platform installers (`.exe`, `.dmg`, `.AppImage`, `.deb`, plus macOS `.zip` for Squirrel.Mac update payloads)
   - `synara-mac.yml`, `synara.yml`, and `synara-linux.yml` metadata
   - the compatibility release also retains `latest-mac.yml`, `latest.yml`, and `latest-linux.yml`
   - `*.blockmap` files, except the macOS update `.zip.blockmap` removed after zip repack

--- a/docs/release.md
+++ b/docs/release.md
@@ -13,6 +13,7 @@ This document covers build-only native validation and publishing desktop release
   - macOS `arm64` DMG
   - macOS `x64` DMG
   - Linux `x64` AppImage
+  - Linux `x64` `.deb`
   - Windows `x64` NSIS installer
 - Publishes one versioned GitHub Release with all produced files.
   - Versions with a suffix after `X.Y.Z` (for example `1.2.3-alpha.1`) are published as GitHub prereleases.
@@ -38,7 +39,7 @@ This document covers build-only native validation and publishing desktop release
   - `SYNARA_DESKTOP_UPDATE_REPOSITORY` (format `owner/repo`), if set.
   - otherwise `GITHUB_REPOSITORY` from GitHub Actions.
 - Required Synara release assets for updater:
-  - platform installers (`.exe`, `.dmg`, `.AppImage`, plus macOS `.zip` for Squirrel.Mac update payloads)
+  - platform installers (`.exe`, `.dmg`, `.AppImage`, `.deb`, plus macOS `.zip` for Squirrel.Mac update payloads)
   - `synara-mac.yml`, `synara.yml`, and `synara-linux.yml` metadata
   - every stable release includes both `synara-mac.yml`, `synara.yml`, `synara-linux.yml` and `latest-mac.yml`, `latest.yml`, `latest-linux.yml`
   - `*.blockmap` files, except the macOS update `.zip.blockmap` removed after zip repack

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "dist:desktop:dmg:arm64": "node scripts/build-desktop-artifact.ts --platform mac --target dmg --arch arm64",
     "dist:desktop:dmg:x64": "node scripts/build-desktop-artifact.ts --platform mac --target dmg --arch x64",
     "dist:desktop:linux": "node scripts/build-desktop-artifact.ts --platform linux --target AppImage --arch x64",
+    "dist:desktop:linux:deb": "node scripts/build-desktop-artifact.ts --platform linux --target deb --arch x64",
     "dist:desktop:win": "node scripts/build-desktop-artifact.ts --platform win --target nsis --arch x64",
     "release:smoke": "node scripts/release-smoke.ts",
     "release:smoke:mac-update": "node scripts/smoke-mac-update-artifact.ts",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "dist:desktop:dmg:arm64": "node scripts/build-desktop-artifact.ts --platform mac --target dmg --arch arm64",
     "dist:desktop:dmg:x64": "node scripts/build-desktop-artifact.ts --platform mac --target dmg --arch x64",
     "dist:desktop:linux": "node scripts/build-desktop-artifact.ts --platform linux --target AppImage --arch x64",
+    "dist:desktop:linux:deb": "node scripts/build-desktop-artifact.ts --platform linux --target deb --arch x64",
     "dist:desktop:win": "node scripts/build-desktop-artifact.ts --platform win --target nsis --arch x64",
     "release:smoke": "node scripts/release-smoke.ts",
     "release:smoke:mac-update": "node scripts/smoke-mac-update-artifact.ts",

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -878,7 +878,7 @@ const buildDesktopArtifactCli = Command.make("build-desktop-artifact", {
   ),
   target: Flag.string("target").pipe(
     Flag.withDescription(
-      "Artifact target, for example dmg/AppImage/nsis (env: SYNARA_DESKTOP_TARGET).",
+      "Artifact target, for example dmg/AppImage/deb/nsis (env: SYNARA_DESKTOP_TARGET).",
     ),
     Flag.optional,
   ),

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -1178,7 +1178,7 @@ const buildDesktopArtifactCli = Command.make("build-desktop-artifact", {
   ),
   target: Flag.string("target").pipe(
     Flag.withDescription(
-      "Artifact target, for example dmg/AppImage/nsis (env: SYNARA_DESKTOP_TARGET).",
+      "Artifact target, for example dmg/AppImage/deb/nsis (env: SYNARA_DESKTOP_TARGET).",
     ),
     Flag.optional,
   ),


### PR DESCRIPTION
## Summary

Adds **`.deb`** packaging for Linux desktop releases alongside the existing **AppImage**, so Ubuntu/Debian users can install with `dpkg` / `apt`.

Closes #201

## Problem

Linux desktop releases currently ship only an **AppImage** (`x64`). Debian/Ubuntu users prefer a native `.deb`.

## Solution

| Area | Change |
|------|--------|
| Release matrix | Second Linux x64 job: `target: deb` (AppImage job kept) |
| Collect assets | `release/*.deb` |
| Publish release | `release-assets/*.deb` |
| Updater mirror payloads | include `*.deb` |
| Scripts | `bun run dist:desktop:linux:deb` |
| Docs | `docs/release.md` lists `.deb` |
| CLI help | `build-desktop-artifact` mentions `deb` as a target |

No product/UI changes. Existing `scripts/build-desktop-artifact.ts` already passes the electron-builder target through; `deb` is a supported linux target.

## Evidence (before / after)

| | Before (`main`) | After (this PR) |
|--|-----------------|-----------------|
| Release matrix | 1× Linux **AppImage** only | AppImage **+** **deb** (x64) |
| Collect / publish / mirror | `*.AppImage` only | + `*.deb` |
| npm scripts | `dist:desktop:linux` → AppImage | + `dist:desktop:linux:deb` |
| Release docs | AppImage only | documents `.deb` |

### Matrix (after)

```yaml
- label: Linux x64 AppImage
  target: AppImage
- label: Linux x64 deb
  target: deb
```

### Local / CI note

Full electron-builder `.deb` production is validated on **Linux CI** at release time (same pattern as AppImage). This PR wires the pipeline end-to-end; the first `.deb` artifact appears on the next release run.

## Test plan

- [x] Diff review: matrix, collect globs, publish files, mirror payloads all include `.deb`
- [x] `package.json` script points at `build-desktop-artifact.ts --platform linux --target deb --arch x64`
- [ ] CI release dry-run / next tag: confirm `*.deb` appears under release assets
- [ ] Optional (Linux host): `bun run dist:desktop:linux:deb` produces a package under `release/`

## Files

- `.github/workflows/release.yml`
- `package.json`
- `docs/release.md`
- `scripts/build-desktop-artifact.ts`