### PR TITLE
fix(web): collapse Cursor model variants by default

### DIFF
--- a/apps/web/scripts/proof-issue-333-cursor.ts
+++ b/apps/web/scripts/proof-issue-333-cursor.ts
@@ -38,7 +38,13 @@ function parseCursorCliModels(stdout: string): ProviderModelDescriptor[] {
     if (lower.includes("grok") || lower.includes("xai")) {
       upstreamProviderId = "xai";
       upstreamProviderName = "xAI";
-    } else if (lower.includes("claude") || lower.includes("opus") || lower.includes("sonnet") || lower.includes("fable") || lower.includes("haiku")) {
+    } else if (
+      lower.includes("claude") ||
+      lower.includes("opus") ||
+      lower.includes("sonnet") ||
+      lower.includes("fable") ||
+      lower.includes("haiku")
+    ) {
       upstreamProviderId = "anthropic";
       upstreamProviderName = "Anthropic";
     } else if (lower.includes("gpt") || lower.includes("codex") || lower.includes("composer")) {
@@ -126,7 +132,10 @@ const report = [
       upstreamProviderId: m.upstreamProviderId,
       upstreamProviderName: m.upstreamProviderName,
     })),
-  ).flatMap((g) => [`  [${g.label ?? g.key}]`, ...g.options.map((o) => `    ${o.slug} (${o.name})`)]),
+  ).flatMap((g) => [
+    `  [${g.label ?? g.key}]`,
+    ...g.options.map((o) => `    ${o.slug} (${o.name})`),
+  ]),
   "",
   "AFTER xAI group options:",
   ...groupProviderModelOptions(
@@ -136,7 +145,10 @@ const report = [
       upstreamProviderId: m.upstreamProviderId,
       upstreamProviderName: m.upstreamProviderName,
     })),
-  ).flatMap((g) => [`  [${g.label ?? g.key}]`, ...g.options.map((o) => `    ${o.slug} (${o.name})`)]),
+  ).flatMap((g) => [
+    `  [${g.label ?? g.key}]`,
+    ...g.options.map((o) => `    ${o.slug} (${o.name})`),
+  ]),
   "",
   xaiBefore.length > xaiAfter.length && xaiAfter.length === 1
     ? "RESULT: PASS — xAI Grok collapsed from multiple effort rows to one base model."

--- a/apps/web/scripts/proof-issue-333-cursor.ts
+++ b/apps/web/scripts/proof-issue-333-cursor.ts
@@ -1,0 +1,158 @@
+// Run: cd apps/web && bun scripts/proof-issue-333-cursor.ts
+import { spawnSync } from "node:child_process";
+import * as FS from "node:fs";
+import * as Path from "node:path";
+import {
+  collapseCursorModelVariants,
+  mergeCursorModelVariantsWithBaseControls,
+} from "../src/cursorModelVariants.ts";
+import type { ProviderModelDescriptor } from "@synara/contracts";
+import { groupProviderModelOptions } from "../src/providerModelOptions.ts";
+
+// Local-only output (gitignored via .synara-*/). No personal paths in the report body.
+const outDir = Path.resolve("../../.synara-pr/issue-333");
+FS.mkdirSync(outDir, { recursive: true });
+
+function stripAnsi(text: string): string {
+  return text.replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+function parseCursorCliModels(stdout: string): ProviderModelDescriptor[] {
+  const models: ProviderModelDescriptor[] = [];
+  for (const line of stripAnsi(stdout).split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed === "Available models" || trimmed.startsWith("Tip:")) continue;
+    // format: "slug - Display Name"  (display may include "(default)")
+    const sep = trimmed.indexOf(" - ");
+    if (sep <= 0) continue;
+    const slug = trimmed.slice(0, sep).trim();
+    const name = trimmed
+      .slice(sep + 3)
+      .replace(/\s*\(default\)\s*$/iu, "")
+      .trim();
+    if (!slug) continue;
+    // Heuristic upstream from slug/name (CLI list has no provider meta)
+    let upstreamProviderId: string | undefined;
+    let upstreamProviderName: string | undefined;
+    const lower = `${slug} ${name}`.toLowerCase();
+    if (lower.includes("grok") || lower.includes("xai")) {
+      upstreamProviderId = "xai";
+      upstreamProviderName = "xAI";
+    } else if (lower.includes("claude") || lower.includes("opus") || lower.includes("sonnet") || lower.includes("fable") || lower.includes("haiku")) {
+      upstreamProviderId = "anthropic";
+      upstreamProviderName = "Anthropic";
+    } else if (lower.includes("gpt") || lower.includes("codex") || lower.includes("composer")) {
+      upstreamProviderId = "openai";
+      upstreamProviderName = "OpenAI";
+    } else if (lower.includes("gemini")) {
+      upstreamProviderId = "google";
+      upstreamProviderName = "Google";
+    }
+    models.push({
+      slug,
+      name,
+      ...(upstreamProviderId ? { upstreamProviderId } : {}),
+      ...(upstreamProviderName ? { upstreamProviderName } : {}),
+    });
+  }
+  return models;
+}
+
+// OLD behavior (what merge used to do)
+function mergeOldStyle(models: ReadonlyArray<ProviderModelDescriptor>): ProviderModelDescriptor[] {
+  const collapsed = collapseCursorModelVariants(models);
+  const seen = new Set<string>();
+  const out: ProviderModelDescriptor[] = [];
+  for (const model of [...collapsed, ...models]) {
+    const key = model.slug.trim().toLowerCase();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push(model);
+  }
+  return out;
+}
+
+const result = spawnSync("cursor-agent", ["--list-models"], {
+  encoding: "utf8",
+  env: process.env,
+  timeout: 30_000,
+});
+if (result.status !== 0) {
+  console.error("cursor-agent --list-models failed:", result.stderr || result.stdout);
+  process.exit(1);
+}
+
+const rawModels = parseCursorCliModels(result.stdout || "");
+const before = mergeOldStyle(rawModels);
+const after = mergeCursorModelVariantsWithBaseControls(rawModels); // now collapse-only
+
+const xaiBefore = before.filter(
+  (m) => m.upstreamProviderId === "xai" || /grok/i.test(m.slug) || /grok/i.test(m.name),
+);
+const xaiAfter = after.filter(
+  (m) => m.upstreamProviderId === "xai" || /grok/i.test(m.slug) || /grok/i.test(m.name),
+);
+
+const report = [
+  "══════════════════════════════════════════════════════════════",
+  "  #333 LIVE CURSOR CLI PROOF (authenticated cursor-agent)",
+  "══════════════════════════════════════════════════════════════",
+  "",
+  `cursor-agent --list-models total parsed: ${rawModels.length}`,
+  `Grok/xAI raw CLI rows: ${rawModels.filter((m) => /grok/i.test(m.slug)).length}`,
+  "",
+  "RAW CLI Grok rows:",
+  ...rawModels.filter((m) => /grok/i.test(m.slug)).map((m) => `  ${m.slug}  (${m.name})`),
+  "",
+  "── BEFORE (old merge: collapsed base + every raw variant) ──",
+  `  total picker rows: ${before.length}`,
+  `  xAI/Grok picker rows: ${xaiBefore.length}`,
+  ...xaiBefore.map((m) => `    - ${m.slug}  |  ${m.name}`),
+  "",
+  "── AFTER (fix: collapse only) ──",
+  `  total picker rows: ${after.length}`,
+  `  xAI/Grok picker rows: ${xaiAfter.length}`,
+  ...xaiAfter.map((m) => {
+    const efforts = (m.supportedReasoningEfforts ?? []).map((e) => e.value).join(",");
+    return `    - ${m.slug}  |  ${m.name}  | efforts=[${efforts}]`;
+  }),
+  "",
+  "── GROUPING (how submenu labels) ──",
+  "BEFORE xAI group options:",
+  ...groupProviderModelOptions(
+    xaiBefore.map((m) => ({
+      slug: m.slug,
+      name: m.name,
+      upstreamProviderId: m.upstreamProviderId,
+      upstreamProviderName: m.upstreamProviderName,
+    })),
+  ).flatMap((g) => [`  [${g.label ?? g.key}]`, ...g.options.map((o) => `    ${o.slug} (${o.name})`)]),
+  "",
+  "AFTER xAI group options:",
+  ...groupProviderModelOptions(
+    xaiAfter.map((m) => ({
+      slug: m.slug,
+      name: m.name,
+      upstreamProviderId: m.upstreamProviderId,
+      upstreamProviderName: m.upstreamProviderName,
+    })),
+  ).flatMap((g) => [`  [${g.label ?? g.key}]`, ...g.options.map((o) => `    ${o.slug} (${o.name})`)]),
+  "",
+  xaiBefore.length > xaiAfter.length && xaiAfter.length === 1
+    ? "RESULT: PASS — xAI Grok collapsed from multiple effort rows to one base model."
+    : xaiAfter.length < xaiBefore.length
+      ? `RESULT: PASS — xAI/Grok rows reduced ${xaiBefore.length} → ${xaiAfter.length}`
+      : `RESULT: CHECK — before=${xaiBefore.length} after=${xaiAfter.length}`,
+  "",
+].join("\n");
+
+FS.writeFileSync(Path.join(outDir, "live-cli-proof.txt"), report, "utf8");
+FS.writeFileSync(
+  Path.join(outDir, "raw-cli-models.json"),
+  JSON.stringify(rawModels, null, 2) + "\n",
+);
+FS.writeFileSync(Path.join(outDir, "before-catalog.json"), JSON.stringify(before, null, 2) + "\n");
+FS.writeFileSync(Path.join(outDir, "after-catalog.json"), JSON.stringify(after, null, 2) + "\n");
+console.log(report);
+// Relative path only — never log absolute home directories in proof output.
+console.log("Wrote proofs to .synara-pr/issue-333/");

--- a/apps/web/scripts/proof-issue-333-cursor.ts
+++ b/apps/web/scripts/proof-issue-333-cursor.ts
@@ -2,10 +2,7 @@
 import { spawnSync } from "node:child_process";
 import * as FS from "node:fs";
 import * as Path from "node:path";
-import {
-  collapseCursorModelVariants,
-  mergeCursorModelVariantsWithBaseControls,
-} from "../src/cursorModelVariants.ts";
+import { collapseCursorModelVariants } from "../src/cursorModelVariants.ts";
 import type { ProviderModelDescriptor } from "@synara/contracts";
 import { groupProviderModelOptions } from "../src/providerModelOptions.ts";
 
@@ -90,7 +87,7 @@ if (result.status !== 0) {
 
 const rawModels = parseCursorCliModels(result.stdout || "");
 const before = mergeOldStyle(rawModels);
-const after = mergeCursorModelVariantsWithBaseControls(rawModels); // now collapse-only
+const after = collapseCursorModelVariants(rawModels);
 
 const xaiBefore = before.filter(
   (m) => m.upstreamProviderId === "xai" || /grok/i.test(m.slug) || /grok/i.test(m.name),

--- a/apps/web/scripts/screenshot-issue-333.ts
+++ b/apps/web/scripts/screenshot-issue-333.ts
@@ -5,14 +5,18 @@ import { chromium } from "playwright";
 
 // Local-only output (gitignored via .synara-*/).
 const outDir = Path.resolve("../../.synara-pr/issue-333");
-const before = JSON.parse(FS.readFileSync(Path.join(outDir, "before-catalog.json"), "utf8")) as Array<{
+const before = JSON.parse(
+  FS.readFileSync(Path.join(outDir, "before-catalog.json"), "utf8"),
+) as Array<{
   slug: string;
   name: string;
   upstreamProviderId?: string;
   upstreamProviderName?: string;
   supportedReasoningEfforts?: Array<{ value: string }>;
 }>;
-const after = JSON.parse(FS.readFileSync(Path.join(outDir, "after-catalog.json"), "utf8")) as typeof before;
+const after = JSON.parse(
+  FS.readFileSync(Path.join(outDir, "after-catalog.json"), "utf8"),
+) as typeof before;
 
 function groupByProvider(models: typeof before) {
   const groups = new Map<string, typeof before>();
@@ -79,7 +83,10 @@ function pageHtml(title: string, xaiOnly: boolean) {
 </body></html>`;
 }
 
-FS.writeFileSync(Path.join(outDir, "compare-xai.html"), pageHtml("Issue #333 — xAI / Grok (live cursor-agent)", true));
+FS.writeFileSync(
+  Path.join(outDir, "compare-xai.html"),
+  pageHtml("Issue #333 — xAI / Grok (live cursor-agent)", true),
+);
 FS.writeFileSync(
   Path.join(outDir, "compare-full.html"),
   pageHtml("Issue #333 — full Cursor catalog (live cursor-agent)", false),

--- a/apps/web/scripts/screenshot-issue-333.ts
+++ b/apps/web/scripts/screenshot-issue-333.ts
@@ -1,0 +1,107 @@
+// Run from apps/web: bun scripts/screenshot-issue-333.ts
+import * as FS from "node:fs";
+import * as Path from "node:path";
+import { chromium } from "playwright";
+
+// Local-only output (gitignored via .synara-*/).
+const outDir = Path.resolve("../../.synara-pr/issue-333");
+const before = JSON.parse(FS.readFileSync(Path.join(outDir, "before-catalog.json"), "utf8")) as Array<{
+  slug: string;
+  name: string;
+  upstreamProviderId?: string;
+  upstreamProviderName?: string;
+  supportedReasoningEfforts?: Array<{ value: string }>;
+}>;
+const after = JSON.parse(FS.readFileSync(Path.join(outDir, "after-catalog.json"), "utf8")) as typeof before;
+
+function groupByProvider(models: typeof before) {
+  const groups = new Map<string, typeof before>();
+  for (const m of models) {
+    const label = m.upstreamProviderName || m.upstreamProviderId || "Other";
+    if (!groups.has(label)) groups.set(label, []);
+    groups.get(label)!.push(m);
+  }
+  return groups;
+}
+
+function renderList(title: string, models: typeof before, xaiOnly: boolean) {
+  const groups = groupByProvider(models);
+  let html = `<div class="panel"><h2>${title}</h2><p class="meta">${models.length} picker rows</p>`;
+  for (const [label, opts] of groups) {
+    const isXai = /xai/i.test(label);
+    if (xaiOnly && !isXai) continue;
+    html += `<div class="group ${isXai ? "xai" : ""}"><div class="group-label">${label}</div><ul>`;
+    for (const o of opts) {
+      const efforts = (o.supportedReasoningEfforts || []).map((e) => e.value).join(", ");
+      html += `<li><span class="name">${escapeHtml(o.name)}</span><span class="slug">${escapeHtml(o.slug)}</span>`;
+      if (efforts) html += `<span class="efforts">efforts: ${escapeHtml(efforts)}</span>`;
+      html += `</li>`;
+    }
+    html += `</ul></div>`;
+  }
+  html += `</div>`;
+  return html;
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+const styles = `
+  body { font-family: ui-sans-serif, system-ui, sans-serif; background: #0f0f10; color: #f3f3f3; margin: 0; padding: 24px; }
+  h1 { font-size: 18px; font-weight: 600; margin: 0 0 16px; }
+  .row { display: flex; gap: 20px; align-items: flex-start; }
+  .panel { flex: 1; background: #1a1a1c; border: 1px solid #2e2e32; border-radius: 12px; padding: 16px; max-height: 1100px; overflow: auto; }
+  h2 { font-size: 14px; margin: 0 0 4px; }
+  .meta { color: #9ca3af; font-size: 12px; margin: 0 0 12px; }
+  .group { margin-bottom: 14px; }
+  .group-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: #9ca3af; margin-bottom: 6px; }
+  .group.xai .group-label { color: #a78bfa; }
+  .group.xai { outline: 1px solid #6d28d9; border-radius: 8px; padding: 8px; background: #1f1530; }
+  ul { list-style: none; margin: 0; padding: 0; }
+  li { padding: 8px 10px; border-radius: 8px; margin-bottom: 4px; background: #242428; display: flex; flex-direction: column; gap: 2px; }
+  .name { font-size: 13px; font-weight: 500; }
+  .slug { font-size: 11px; color: #9ca3af; font-family: ui-monospace, monospace; }
+  .efforts { font-size: 11px; color: #86efac; }
+`;
+
+function pageHtml(title: string, xaiOnly: boolean) {
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"/><style>${styles}</style></head><body>
+  <h1>${title}</h1>
+  <div class="row">
+    ${renderList(`BEFORE — ${before.length} rows (base + raw variants)`, before, xaiOnly)}
+    ${renderList(`AFTER — ${after.length} rows (collapsed)`, after, xaiOnly)}
+  </div>
+</body></html>`;
+}
+
+FS.writeFileSync(Path.join(outDir, "compare-xai.html"), pageHtml("Issue #333 — xAI / Grok (live cursor-agent)", true));
+FS.writeFileSync(
+  Path.join(outDir, "compare-full.html"),
+  pageHtml("Issue #333 — full Cursor catalog (live cursor-agent)", false),
+);
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage({ viewport: { width: 1400, height: 900 } });
+await page.goto(`file://${Path.join(outDir, "compare-xai.html")}`);
+await page.waitForTimeout(400);
+await page.screenshot({ path: Path.join(outDir, "before-after-xai.png"), fullPage: true });
+await page.goto(`file://${Path.join(outDir, "compare-full.html")}`);
+await page.waitForTimeout(400);
+await page.screenshot({ path: Path.join(outDir, "before-after-full.png"), fullPage: true });
+await browser.close();
+
+// Relative paths only — never log absolute home directories.
+console.log("Screenshots:");
+console.log("  .synara-pr/issue-333/before-after-xai.png");
+console.log("  .synara-pr/issue-333/before-after-full.png");
+console.log(
+  "xAI rows before/after:",
+  before.filter((m) => m.upstreamProviderId === "xai").length,
+  "→",
+  after.filter((m) => m.upstreamProviderId === "xai").length,
+);

--- a/apps/web/src/cursorModelVariants.test.ts
+++ b/apps/web/src/cursorModelVariants.test.ts
@@ -15,6 +15,12 @@ describe("normalizeCursorModelVariantBaseId", () => {
       "claude-opus-4-6",
     );
     expect(normalizeCursorModelVariantBaseId("claude-5-sonnet-max-fast")).toBe("claude-sonnet-5");
+    // Live Cursor Agent CLI naming for xAI Grok (effort is a suffix, not a separate model).
+    expect(normalizeCursorModelVariantBaseId("cursor-grok-4.5-high")).toBe("cursor-grok-4.5");
+    expect(normalizeCursorModelVariantBaseId("cursor-grok-4.5-medium-fast")).toBe(
+      "cursor-grok-4.5",
+    );
+    expect(normalizeCursorModelVariantBaseId("cursor-grok-4.5-low")).toBe("cursor-grok-4.5");
   });
 });
 
@@ -51,6 +57,53 @@ describe("collapseCursorModelVariants", () => {
         supportsThinkingToggle: true,
       },
     ]);
+  });
+
+  // Live CLI lists effort as suffix rows (cursor-grok-4.5-high, …); picker must collapse to one base.
+  it("collapses live cursor-grok-4.5 effort rows into one xAI model with traits", () => {
+    const collapsed = collapseCursorModelVariants([
+      {
+        slug: "cursor-grok-4.5-high",
+        name: "Cursor Grok 4.5",
+        upstreamProviderId: "xai",
+        upstreamProviderName: "xAI",
+        supportedReasoningEfforts: [{ value: "high", label: "High" }],
+        defaultReasoningEffort: "high",
+      },
+      {
+        slug: "cursor-grok-4.5-medium",
+        name: "Cursor Grok 4.5 Medium",
+        upstreamProviderId: "xai",
+        upstreamProviderName: "xAI",
+        supportedReasoningEfforts: [{ value: "medium", label: "Medium" }],
+        defaultReasoningEffort: "medium",
+      },
+      {
+        slug: "cursor-grok-4.5-low-fast",
+        name: "Cursor Grok 4.5 Low Fast",
+        upstreamProviderId: "xai",
+        upstreamProviderName: "xAI",
+        supportedReasoningEfforts: [{ value: "low", label: "Low" }],
+        defaultReasoningEffort: "low",
+        supportsFastMode: true,
+      },
+    ]);
+
+    expect(collapsed).toHaveLength(1);
+    expect(collapsed[0]).toMatchObject({
+      slug: "cursor-grok-4.5",
+      name: "Cursor Grok 4.5",
+      upstreamProviderId: "xai",
+      upstreamProviderName: "xAI",
+      supportedReasoningEfforts: [
+        { value: "high", label: "High", isDefault: true },
+        { value: "medium", label: "Medium" },
+        { value: "low", label: "Low" },
+      ],
+      defaultReasoningEffort: "high",
+      supportsFastMode: true,
+    });
+    expect(collapsed.some((model) => /-high$|-medium$|-low$/.test(model.slug))).toBe(false);
   });
 
   it("collapses Cursor CLI variants into one model with trait capabilities", () => {

--- a/apps/web/src/lib/toolCallLabel.ts
+++ b/apps/web/src/lib/toolCallLabel.ts
@@ -122,10 +122,7 @@ const BROWSER_TOOL_NAME_SET = new Set<string>(BROWSER_TOOL_NAMES);
 const SYNARA_BROWSER_TOOL_PRESENTATIONS = Object.fromEntries(
   BROWSER_TOOL_NAMES.map((toolName) => {
     const title = BROWSER_TOOL_TITLES[toolName];
-    return [
-      `synara_${toolName}`,
-      { running: title, completed: title, failed: title },
-    ];
+    return [`synara_${toolName}`, { running: title, completed: title, failed: title }];
   }),
 ) as Record<SynaraBrowserToolName, SynaraMcpToolPresentation>;
 


### PR DESCRIPTION
## Summary

Default Cursor model catalog now **collapses** CLI/ACP variants into one row per base model. Reasoning effort (and other traits) stay in the traits controls instead of flooding the picker.

Closes #333

## Problem

`mergeCursorModelVariantsWithBaseControls` kept **collapsed bases and every raw CLI variant** (`-high`, `-medium`, `-xhigh`, `-fast-*`, …). Under provider groups like **xAI**, that meant:

- "High" / "Medium" appeared as **separate model rows**
- The same efforts also appeared in the **traits** control
- Selection often failed to route to the intended model

## Solution

| Area | Change |
|------|--------|
| Default catalog | Collapse only (`collapseCursorModelVariants`) |
| Call sites | `ChatView` + `useProviderModelCatalog` use collapse when the expanded flag is off |
| Expanded mode | Unchanged: `show-expanded-cursor-model-variants` still shows every raw row |
| Compatibility | `mergeCursorModelVariantsWithBaseControls` now aliases collapse (same default behavior) |
| Tests | xAI/Grok multi-effort fixtures assert one base row + effort traits |
| Proof scripts | Re-runnable live CLI proof + optional screenshot helper |

## Evidence (before / after)

Live proof against authenticated `cursor-agent --list-models` (189 models parsed):

| Metric | Before (old merge) | After (collapse only) |
|--------|--------------------|------------------------|
| Total picker rows | **212** | **35** |
| xAI / Grok rows | **7** (base + every effort/fast variant) | **1** (`grok-4.5`) |
| Efforts on base | n/a (split across rows) | `[xhigh, medium, high]` |

### Raw CLI Grok rows (input)

```text
grok-4.5-xhigh
grok-4.5-fast-xhigh
grok-4.5-medium
grok-4.5-fast-medium
grok-4.5-high
grok-4.5-fast-high
```

### Grouped picker (xAI)

**Before**

```text
[xAI]
  grok-4.5
  grok-4.5-xhigh
  grok-4.5-fast-xhigh
  grok-4.5-medium
  grok-4.5-fast-medium
  grok-4.5-high
  grok-4.5-fast-high
```

**After**

```text
[xAI]
  grok-4.5   (efforts: xhigh, medium, high)
```

```text
RESULT: PASS — xAI Grok collapsed from multiple effort rows to one base model.
```

### Screenshots

xAI-only compare:

![xAI before/after](https://files.catbox.moe/7ms07g.png)

Full catalog compare:

![full catalog before/after](https://files.catbox.moe/9wb840.png)

### Re-run

```bash
# Requires cursor-agent on PATH and authenticated session
cd apps/web && bun scripts/proof-issue-333-cursor.ts
# Optional visual (uses catalogs from the proof run)
bun scripts/screenshot-issue-333.ts
```

## Test plan

- [x] `bunx vitest run apps/web/src/cursorModelVariants.test.ts` — **5/5 pass**
- [x] Live CLI proof: total 212 → 35; xAI 7 → 1 with efforts on base
- [x] Expanded feature flag path left intact (raw variants when enabled)
- [ ] Manual (optional): Cursor thread → model picker → xAI shows one Grok row; set effort via traits

## Files

- `apps/web/src/cursorModelVariants.ts`
- `apps/web/src/cursorModelVariants.test.ts`
- `apps/web/src/components/ChatView.tsx`
- `apps/web/src/hooks/useProviderModelCatalog.ts`
- `apps/web/scripts/proof-issue-333-cursor.ts`
- `apps/web/scripts/screenshot-issue-333.ts`