### PR TITLE
feat(keybindings): thread action, composer, and history commands

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -28,7 +28,39 @@ See the full schema for more details: [`packages/contracts/src/keybindings.ts`](
   { "key": "mod+shift+n", "command": "chat.newLocal", "when": "!terminalFocus" },
   { "key": "mod+shift+t", "command": "chat.newTerminal", "when": "!terminalFocus" },
   { "key": "cmd+l", "command": "composer.focus.toggle", "when": "!terminalFocus" },
-  { "key": "mod+o", "command": "editor.openFavorite" }
+  { "key": "mod+enter", "command": "thread.approval.accept", "when": "!terminalFocus || isMac" },
+  {
+    "key": "mod+shift+enter",
+    "command": "thread.approval.acceptForSession",
+    "when": "!terminalFocus || isMac"
+  },
+  {
+    "key": "mod+backspace",
+    "command": "thread.approval.decline",
+    "when": "!terminalFocus || isMac"
+  },
+  { "key": "mod+shift+p", "command": "thread.planMode.toggle", "when": "!terminalFocus || isMac" },
+  { "key": "mod+shift+f", "command": "thread.fastMode.toggle", "when": "!terminalFocus || isMac" },
+  { "key": "alt+shift+]", "command": "thread.effort.next", "when": "!terminalFocus" },
+  { "key": "alt+shift+[", "command": "thread.effort.previous", "when": "!terminalFocus" },
+  {
+    "key": "mod+shift+d",
+    "command": "composer.dictation.toggle",
+    "when": "!terminalFocus || isMac"
+  },
+  { "key": "mod+o", "command": "editor.openFavorite" },
+  { "key": "cmd+[", "command": "history.back", "when": "isElectron" },
+  { "key": "cmd+]", "command": "history.forward", "when": "isElectron" },
+  {
+    "key": "alt+arrowleft",
+    "command": "history.back",
+    "when": "isElectron && !isMac && !terminalFocus"
+  },
+  {
+    "key": "alt+arrowright",
+    "command": "history.forward",
+    "when": "isElectron && !isMac && !terminalFocus"
+  }
 ]
 ```
 
@@ -56,6 +88,16 @@ Invalid rules are ignored. Invalid config files are ignored. Warnings are logged
 - `chat.newLocal`: create a new chat thread for the active project in a new environment (local/worktree determined by app settings (default `local`))
 - `chat.newTerminal`: create a new terminal-first thread preserving the active thread's branch/worktree state
 - `composer.focus.toggle`: focus or blur the chat prompt composer
+- `composer.send`: send the composer contents to the active thread (no default binding)
+- `composer.dictation.toggle`: start or stop voice dictation in the composer
+- `thread.approval.accept`: accept the pending approval request in the active thread
+- `thread.approval.acceptForSession`: accept the pending approval request for the rest of the session
+- `thread.approval.decline`: decline the pending approval request in the active thread
+- `thread.planMode.toggle`: switch the composer between plan mode and the default interaction mode
+- `thread.fastMode.toggle`: enable/disable fast mode when the selected model supports it
+- `thread.effort.next` / `thread.effort.previous`: cycle the reasoning effort level for the selected model
+- `thread.fork`: fork the current thread from its latest state (no default binding)
+- `history.back` / `history.forward`: navigate the in-app view history (desktop app)
 - `editor.openFavorite`: open current project/worktree in the last-used editor
 - `script.{id}.run`: run a project script by id (for example `script.test.run`)
 
@@ -82,6 +124,9 @@ Currently available context keys:
 
 - `terminalFocus`
 - `terminalOpen`
+- `terminalWorkspaceOpen`
+- `isMac` (true when the app runs on macOS)
+- `isElectron` (true when running in the Synara desktop app)
 
 Supported operators:
 

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -91,6 +91,24 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "alt+]", command: "model.next", when: "!terminalFocus" },
   { key: "alt+[", command: "model.previous", when: "!terminalFocus" },
   { key: "mod+shift+e", command: "traitsPicker.toggle", when: "!terminalFocus" },
+  // Approval chords only act while an approval is actually pending; otherwise the
+  // event falls through untouched, so Mod+Enter/Mod+Backspace keep their normal
+  // meaning in the composer. Same `|| isMac` escape hatch as the creation chords.
+  { key: "mod+enter", command: "thread.approval.accept", when: "!terminalFocus || isMac" },
+  {
+    key: "mod+shift+enter",
+    command: "thread.approval.acceptForSession",
+    when: "!terminalFocus || isMac",
+  },
+  { key: "mod+backspace", command: "thread.approval.decline", when: "!terminalFocus || isMac" },
+  { key: "mod+shift+p", command: "thread.planMode.toggle", when: "!terminalFocus || isMac" },
+  { key: "mod+shift+f", command: "thread.fastMode.toggle", when: "!terminalFocus || isMac" },
+  // Alt chords reach the PTY as escape sequences, so these stay strictly guarded.
+  { key: "alt+shift+]", command: "thread.effort.next", when: "!terminalFocus" },
+  { key: "alt+shift+[", command: "thread.effort.previous", when: "!terminalFocus" },
+  { key: "mod+shift+d", command: "composer.dictation.toggle", when: "!terminalFocus || isMac" },
+  // `composer.send` and `thread.fork` ship without default chords (macro pads and
+  // power users bind them via keybindings.json).
   { key: "mod+shift+u", command: "settings.usage", when: "!terminalFocus" },
   // New thread (chat.new) is the primary create action; it falls back to the most
   // recent project when no project is active.
@@ -125,6 +143,17 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+shift+]", command: "chat.visible.next", when: "!terminalFocus" },
   { key: "mod+shift+[", command: "chat.visible.previous", when: "!terminalFocus" },
   { key: "mod+o", command: "editor.openFavorite" },
+  // App history navigation, promoted from hard-coded Electron-only chords so it is
+  // remappable like everything else. `isElectron` keeps the browser's own native
+  // Cmd+[ / Alt+Arrow history behavior untouched outside the installed app.
+  { key: "cmd+[", command: "history.back", when: "isElectron" },
+  { key: "cmd+]", command: "history.forward", when: "isElectron" },
+  { key: "alt+arrowleft", command: "history.back", when: "isElectron && !isMac && !terminalFocus" },
+  {
+    key: "alt+arrowright",
+    command: "history.forward",
+    when: "isElectron && !isMac && !terminalFocus",
+  },
 ];
 
 function normalizeKeyToken(token: string): string {

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -114,6 +114,24 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "alt+]", command: "model.next", when: "!terminalFocus" },
   { key: "alt+[", command: "model.previous", when: "!terminalFocus" },
   { key: "mod+shift+e", command: "traitsPicker.toggle", when: "!terminalFocus" },
+  // Approval chords only act while an approval is actually pending; otherwise the
+  // event falls through untouched, so Mod+Enter/Mod+Backspace keep their normal
+  // meaning in the composer. Same `|| isMac` escape hatch as the creation chords.
+  { key: "mod+enter", command: "thread.approval.accept", when: "!terminalFocus || isMac" },
+  {
+    key: "mod+shift+enter",
+    command: "thread.approval.acceptForSession",
+    when: "!terminalFocus || isMac",
+  },
+  { key: "mod+backspace", command: "thread.approval.decline", when: "!terminalFocus || isMac" },
+  { key: "mod+shift+p", command: "thread.planMode.toggle", when: "!terminalFocus || isMac" },
+  { key: "mod+shift+f", command: "thread.fastMode.toggle", when: "!terminalFocus || isMac" },
+  // Alt chords reach the PTY as escape sequences, so these stay strictly guarded.
+  { key: "alt+shift+]", command: "thread.effort.next", when: "!terminalFocus" },
+  { key: "alt+shift+[", command: "thread.effort.previous", when: "!terminalFocus" },
+  { key: "mod+shift+d", command: "composer.dictation.toggle", when: "!terminalFocus || isMac" },
+  // `composer.send` and `thread.fork` ship without default chords (macro pads and
+  // power users bind them via keybindings.json).
   { key: "mod+shift+u", command: "settings.usage", when: "!terminalFocus" },
   // New thread (chat.new) is the primary create action; it falls back to the most
   // recent project when no project is active.
@@ -148,6 +166,17 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+shift+]", command: "chat.visible.next", when: "!terminalFocus" },
   { key: "mod+shift+[", command: "chat.visible.previous", when: "!terminalFocus" },
   { key: "mod+o", command: "editor.openFavorite" },
+  // App history navigation, promoted from hard-coded Electron-only chords so it is
+  // remappable like everything else. `isElectron` keeps the browser's own native
+  // Cmd+[ / Alt+Arrow history behavior untouched outside the installed app.
+  { key: "cmd+[", command: "history.back", when: "isElectron" },
+  { key: "cmd+]", command: "history.forward", when: "isElectron" },
+  { key: "alt+arrowleft", command: "history.back", when: "isElectron && !isMac && !terminalFocus" },
+  {
+    key: "alt+arrowright",
+    command: "history.forward",
+    when: "isElectron && !isMac && !terminalFocus",
+  },
 ];
 
 function normalizeKeyToken(token: string): string {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -486,7 +486,7 @@ import {
   CHAT_COLUMN_GUTTER_CLASS_NAME,
   ENVIRONMENT_CONTENT_INSET_MOTION_CLASS,
 } from "./chat/composerPickerStyles";
-import { getComposerTraitSelection } from "./chat/composerTraits";
+import { getComposerTraitSelection, resolveEffortCommitOptionId } from "./chat/composerTraits";
 import { resolveRuntimeModelDescriptor } from "./chat/runtimeModelCapabilities";
 import { ProjectPicker } from "./chat/ProjectPicker";
 import { FolderClosed } from "./FolderClosed";
@@ -547,6 +547,7 @@ import {
 import {
   buildModelSelection,
   buildNextProviderOptions,
+  buildProviderOptionPatch,
   mergeDynamicModelOptions,
   type ProviderModelOption,
 } from "../providerModelOptions";
@@ -8798,6 +8799,10 @@ export default function ChatView({
     selectedProviderModelOptions,
     selectedRuntimeModel,
   );
+  // Recomputed every render (plain derivation, not memoized), so the thread-action
+  // shortcut listener reads it through a ref instead of resubscribing per render.
+  const composerTraitSelectionRef = useRef(composerTraitSelection);
+  composerTraitSelectionRef.current = composerTraitSelection;
   const runtimeUsageContextWindow = useMemo(
     () =>
       activeContextWindow ??
@@ -9455,6 +9460,7 @@ export default function ChatView({
   );
 
   const {
+    createForkThreadFromSlashCommand,
     handleForkTargetSelection,
     handleReviewTargetSelection,
     isSlashStatusDialogOpen,
@@ -9515,6 +9521,153 @@ export default function ChatView({
     setComposerDraftProviderModelOptions,
     editorActions: slashEditorActions,
   });
+
+  // Thread-action shortcuts (approvals, plan/fast mode, effort cycling, send,
+  // dictation, fork) live in a second capture listener because several of their
+  // handlers are declared after the primary shortcut listener above.
+  useEffect(() => {
+    if (surfaceMode === "split" && !isFocusedPane) {
+      return;
+    }
+
+    const handler = (event: globalThis.KeyboardEvent) => {
+      if (!activeThreadId || event.defaultPrevented || event.repeat) return;
+      const command = resolveShortcutCommand(event, keybindings, {
+        context: {
+          terminalFocus: isTerminalFocused(),
+          terminalOpen: Boolean(terminalState.terminalOpen),
+          terminalWorkspaceOpen,
+          terminalWorkspaceTerminalOnly: terminalState.workspaceLayout === "terminal-only",
+          terminalWorkspaceTerminalTabActive,
+          terminalWorkspaceChatTabActive,
+        },
+      });
+      if (!command) return;
+
+      if (
+        command === "thread.approval.accept" ||
+        command === "thread.approval.acceptForSession" ||
+        command === "thread.approval.decline"
+      ) {
+        // Without a pending approval the chord falls through untouched, so
+        // Mod+Enter/Mod+Backspace keep their normal meaning in the composer.
+        if (!activePendingApproval) return;
+        if (respondingRequestIds.includes(activePendingApproval.requestId)) return;
+        event.preventDefault();
+        event.stopPropagation();
+        const decision: ProviderApprovalDecision =
+          command === "thread.approval.accept"
+            ? "accept"
+            : command === "thread.approval.acceptForSession"
+              ? "acceptForSession"
+              : "decline";
+        void onRespondToApproval(activePendingApproval.requestId, decision);
+        return;
+      }
+
+      if (command === "thread.planMode.toggle") {
+        event.preventDefault();
+        event.stopPropagation();
+        toggleInteractionMode();
+        return;
+      }
+
+      if (command === "thread.fastMode.toggle") {
+        if (!composerTraitSelectionRef.current.caps.supportsFastMode) return;
+        event.preventDefault();
+        event.stopPropagation();
+        toggleFastMode();
+        return;
+      }
+
+      if (command === "thread.effort.next" || command === "thread.effort.previous") {
+        const selection = composerTraitSelectionRef.current;
+        if (selection.ultrathinkPromptControlled) return;
+        // Prompt-injected levels (e.g. Claude ultrathink) rewrite the prompt instead
+        // of committing a provider option, so cycling skips them.
+        const cycle = selection.effortLevels
+          .filter((option) => !selection.promptInjectedValues.includes(option.value))
+          .map((option) => option.value);
+        if (cycle.length < 2) return;
+        event.preventDefault();
+        event.stopPropagation();
+        const direction = command === "thread.effort.next" ? 1 : -1;
+        const currentIndex = selection.effort ? cycle.indexOf(selection.effort) : -1;
+        const baseIndex = currentIndex === -1 ? (direction === 1 ? -1 : 0) : currentIndex;
+        const nextValue = cycle[(baseIndex + direction + cycle.length) % cycle.length];
+        if (nextValue === undefined) return;
+        setComposerDraftProviderModelOptions(
+          threadId,
+          selectedProvider,
+          buildNextProviderOptions(
+            selectedProvider,
+            selectedProviderModelOptions,
+            buildProviderOptionPatch(
+              selectedProvider,
+              resolveEffortCommitOptionId(selectedProvider, selection.primarySelectDescriptor?.id),
+              nextValue,
+            ),
+          ),
+          { persistSticky: true },
+        );
+        scheduleComposerFocus();
+        return;
+      }
+
+      if (command === "composer.send") {
+        if (!composerSendState.hasSendableContent) return;
+        event.preventDefault();
+        event.stopPropagation();
+        void onSendRef.current(undefined, "queue");
+        return;
+      }
+
+      if (command === "composer.dictation.toggle") {
+        if (!showVoiceNotesControl || isComposerApprovalState || isSendBusy || isConnecting) return;
+        event.preventDefault();
+        event.stopPropagation();
+        toggleComposerVoiceRecording();
+        return;
+      }
+
+      if (command === "thread.fork") {
+        event.preventDefault();
+        event.stopPropagation();
+        // Surfaces its own "Fork is unavailable" toast for non-server threads.
+        void createForkThreadFromSlashCommand();
+        return;
+      }
+    };
+    window.addEventListener("keydown", handler, { capture: true });
+    return () => window.removeEventListener("keydown", handler, { capture: true });
+  }, [
+    activePendingApproval,
+    activeThreadId,
+    composerSendState,
+    createForkThreadFromSlashCommand,
+    isComposerApprovalState,
+    isConnecting,
+    isFocusedPane,
+    isSendBusy,
+    keybindings,
+    onRespondToApproval,
+    respondingRequestIds,
+    scheduleComposerFocus,
+    selectedProvider,
+    selectedProviderModelOptions,
+    setComposerDraftProviderModelOptions,
+    showVoiceNotesControl,
+    surfaceMode,
+    terminalState.terminalOpen,
+    terminalState.workspaceLayout,
+    terminalWorkspaceChatTabActive,
+    terminalWorkspaceOpen,
+    terminalWorkspaceTerminalTabActive,
+    threadId,
+    toggleComposerVoiceRecording,
+    toggleFastMode,
+    toggleInteractionMode,
+  ]);
 
   const onSelectComposerItem = useCallback(
     (item: ComposerCommandItem) => {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -520,7 +520,7 @@ import {
   CHAT_COLUMN_GUTTER_CLASS_NAME,
   ENVIRONMENT_CONTENT_INSET_MOTION_CLASS,
 } from "./chat/composerPickerStyles";
-import { getComposerTraitSelection } from "./chat/composerTraits";
+import { getComposerTraitSelection, resolveEffortCommitOptionId } from "./chat/composerTraits";
 import { resolveRuntimeModelDescriptor } from "./chat/runtimeModelCapabilities";
 import { ProjectPicker } from "./chat/ProjectPicker";
 import { FolderClosed } from "./FolderClosed";
@@ -572,7 +572,13 @@ import {
   resolveDiffEnvironmentState,
   resolveThreadEnvironmentMode,
 } from "../lib/threadEnvironment";
-import { buildModelSelection, buildNextProviderOptions } from "../providerModelOptions";
+import {
+  buildModelSelection,
+  buildNextProviderOptions,
+  buildProviderOptionPatch,
+  mergeDynamicModelOptions,
+  type ProviderModelOption,
+} from "../providerModelOptions";
 import {
   isDuplicateProjectCreateError,
   waitForRecoverableProjectForDuplicateCreate,
@@ -8935,6 +8941,15 @@ export default function ChatView({
     selectedProviderModelOptions,
     selectedRuntimeModel,
   );
+  // Recomputed every render (plain derivation, not memoized), so the thread-action
+  // shortcut listener reads it through a ref instead of resubscribing per render.
+  // Refreshed in a layout effect rather than during render: writing a ref while
+  // rendering bails the whole component out of the React Compiler, which
+  // `chatHotPath.compiler.test.ts` forbids for this file.
+  const composerTraitSelectionRef = useRef(composerTraitSelection);
+  useLayoutEffect(() => {
+    composerTraitSelectionRef.current = composerTraitSelection;
+  });
   const runtimeUsageContextWindow = useMemo(
     () =>
       activeContextWindow ??
@@ -9600,6 +9615,7 @@ export default function ChatView({
   );
 
   const {
+    createForkThreadFromSlashCommand,
     handleForkTargetSelection,
     handleReviewTargetSelection,
     isSlashStatusDialogOpen,
@@ -9672,6 +9688,175 @@ export default function ChatView({
       handleStandaloneSlashCommand,
     };
   });
+
+  // Thread-action shortcuts (approvals, plan/fast mode, effort cycling, send,
+  // dictation, fork) live in a second capture listener because several of their
+  // handlers are declared after the primary shortcut listener above.
+  useEffect(() => {
+    if (surfaceMode === "split" && !isFocusedPane) {
+      return;
+    }
+
+    const handler = (event: globalThis.KeyboardEvent) => {
+      if (!activeThreadId || event.defaultPrevented || event.repeat) return;
+      const command = resolveShortcutCommand(event, keybindings, {
+        context: {
+          terminalFocus: isTerminalFocused(),
+          terminalOpen: Boolean(terminalState.terminalOpen),
+          terminalWorkspaceOpen,
+          terminalWorkspaceTerminalOnly: terminalState.workspaceLayout === "terminal-only",
+          terminalWorkspaceTerminalTabActive,
+          terminalWorkspaceChatTabActive,
+        },
+      });
+      if (!command) return;
+
+      if (
+        command === "thread.approval.accept" ||
+        command === "thread.approval.acceptForSession" ||
+        command === "thread.approval.decline"
+      ) {
+        // Without a pending approval the chord falls through untouched, so
+        // Mod+Enter/Mod+Backspace keep their normal meaning in the composer.
+        if (!activePendingApproval) return;
+        if (
+          respondingRequestKeys.includes(
+            pendingRequestInstanceKey(
+              activePendingApproval.requestId,
+              activePendingApproval.lifecycleGeneration,
+            ),
+          )
+        )
+          return;
+        // Mirrors the approval panel, which hides "accept for session" when the
+        // provider does not offer it; the chord must not send it either.
+        if (
+          command === "thread.approval.acceptForSession" &&
+          activePendingApproval.sessionApprovalAvailable === false
+        )
+          return;
+        event.preventDefault();
+        event.stopPropagation();
+        const decision: ProviderApprovalDecision =
+          command === "thread.approval.accept"
+            ? "accept"
+            : command === "thread.approval.acceptForSession"
+              ? "acceptForSession"
+              : "decline";
+        void onRespondToApproval(
+          activePendingApproval.requestId,
+          decision,
+          activePendingApproval.lifecycleGeneration,
+          activePendingApproval.requestKind,
+        );
+        return;
+      }
+
+      if (command === "thread.planMode.toggle") {
+        event.preventDefault();
+        event.stopPropagation();
+        toggleInteractionMode();
+        return;
+      }
+
+      if (command === "thread.fastMode.toggle") {
+        if (!composerTraitSelectionRef.current.caps.supportsFastMode) return;
+        event.preventDefault();
+        event.stopPropagation();
+        toggleFastMode();
+        return;
+      }
+
+      if (command === "thread.effort.next" || command === "thread.effort.previous") {
+        const selection = composerTraitSelectionRef.current;
+        if (selection.ultrathinkPromptControlled) return;
+        // Prompt-injected levels (e.g. Claude ultrathink) rewrite the prompt instead
+        // of committing a provider option, so cycling skips them.
+        const cycle = selection.effortLevels
+          .filter((option) => !selection.promptInjectedValues.includes(option.value))
+          .map((option) => option.value);
+        if (cycle.length < 2) return;
+        event.preventDefault();
+        event.stopPropagation();
+        const direction = command === "thread.effort.next" ? 1 : -1;
+        const currentIndex = selection.effort ? cycle.indexOf(selection.effort) : -1;
+        const baseIndex = currentIndex === -1 ? (direction === 1 ? -1 : 0) : currentIndex;
+        const nextValue = cycle[(baseIndex + direction + cycle.length) % cycle.length];
+        if (nextValue === undefined) return;
+        setComposerDraftProviderModelOptions(
+          threadId,
+          selectedProvider,
+          buildNextProviderOptions(
+            selectedProvider,
+            selectedProviderModelOptions,
+            buildProviderOptionPatch(
+              selectedProvider,
+              resolveEffortCommitOptionId(selectedProvider, selection.primarySelectDescriptor?.id),
+              nextValue,
+            ),
+          ),
+          { persistSticky: true },
+        );
+        scheduleComposerFocus();
+        return;
+      }
+
+      if (command === "composer.send") {
+        if (!composerSendState.hasSendableContent) return;
+        const lateSendHandlers = lateComposerSendHandlersRef.current;
+        if (!lateSendHandlers) return;
+        event.preventDefault();
+        event.stopPropagation();
+        void lateSendHandlers.send(undefined, "queue");
+        return;
+      }
+
+      if (command === "composer.dictation.toggle") {
+        if (!showVoiceNotesControl || isComposerApprovalState || isSendBusy || isConnecting) return;
+        event.preventDefault();
+        event.stopPropagation();
+        toggleComposerVoiceRecording();
+        return;
+      }
+
+      if (command === "thread.fork") {
+        event.preventDefault();
+        event.stopPropagation();
+        // Surfaces its own "Fork is unavailable" toast for non-server threads.
+        void createForkThreadFromSlashCommand();
+        return;
+      }
+    };
+    window.addEventListener("keydown", handler, { capture: true });
+    return () => window.removeEventListener("keydown", handler, { capture: true });
+  }, [
+    activePendingApproval,
+    activeThreadId,
+    composerSendState,
+    createForkThreadFromSlashCommand,
+    isComposerApprovalState,
+    isConnecting,
+    isFocusedPane,
+    isSendBusy,
+    keybindings,
+    onRespondToApproval,
+    respondingRequestKeys,
+    scheduleComposerFocus,
+    selectedProvider,
+    selectedProviderModelOptions,
+    setComposerDraftProviderModelOptions,
+    showVoiceNotesControl,
+    surfaceMode,
+    terminalState.terminalOpen,
+    terminalState.workspaceLayout,
+    terminalWorkspaceChatTabActive,
+    terminalWorkspaceOpen,
+    terminalWorkspaceTerminalTabActive,
+    threadId,
+    toggleComposerVoiceRecording,
+    toggleFastMode,
+    toggleInteractionMode,
+  ]);
 
   const onSelectComposerItem = useCallback(
     (item: ComposerCommandItem) => {

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -31,7 +31,11 @@ import {
 } from "../../providerModelOptions";
 import { COMPOSER_PICKER_TRIGGER_TEXT_CLASS_NAME } from "./composerPickerStyles";
 import { ComposerPickerMenuPopup } from "./ComposerPickerMenuPopup";
-import { getComposerTraitSelection, hasVisibleComposerTraitControls } from "./composerTraits";
+import {
+  getComposerTraitSelection,
+  hasVisibleComposerTraitControls,
+  resolveEffortCommitOptionId,
+} from "./composerTraits";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { ShortcutKbd } from "../ui/shortcut-kbd";
 
@@ -302,15 +306,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
         onSelectionComplete?.();
         return;
       }
-      const optionId =
-        primarySelectDescriptor?.id ??
-        (provider === "kilo" || provider === "opencode"
-          ? "variant"
-          : provider === "pi"
-            ? "thinkingLevel"
-            : provider === "claudeAgent"
-              ? "effort"
-              : "reasoningEffort");
+      const optionId = resolveEffortCommitOptionId(provider, primarySelectDescriptor?.id);
       commitTrait(buildProviderOptionPatch(provider, optionId, nextOption.value));
     },
     [

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -36,6 +36,7 @@ import {
   getComposerTraitSelection,
   hasVisibleComposerTraitControls,
   resolveComposerTraitStatusLabel,
+  resolveEffortCommitOptionId,
   showsComposerFastModeBadge,
   supportsComposerFastModeControl,
 } from "./composerTraits";
@@ -356,15 +357,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
       onSelectionComplete?.();
       return;
     }
-    const optionId =
-      primarySelectDescriptorId ??
-      (provider === "kilo" || provider === "opencode"
-        ? "variant"
-        : provider === "pi"
-          ? "thinkingLevel"
-          : provider === "claudeAgent"
-            ? "effort"
-            : "reasoningEffort");
+    const optionId = resolveEffortCommitOptionId(provider, primarySelectDescriptorId);
     commitTrait(buildProviderOptionPatch(provider, optionId, nextOption.value));
   };
 

--- a/apps/web/src/components/chat/composerTraits.test.ts
+++ b/apps/web/src/components/chat/composerTraits.test.ts
@@ -1,0 +1,20 @@
+import { assert, describe, it } from "vitest";
+
+import { resolveEffortCommitOptionId } from "./composerTraits";
+
+describe("resolveEffortCommitOptionId", () => {
+  it("prefers the primary select descriptor id when present", () => {
+    assert.strictEqual(resolveEffortCommitOptionId("codex", "thinkingBudget"), "thinkingBudget");
+    assert.strictEqual(resolveEffortCommitOptionId("kilo", "customVariant"), "customVariant");
+  });
+
+  it("falls back to the per-provider effort option id", () => {
+    assert.strictEqual(resolveEffortCommitOptionId("kilo", undefined), "variant");
+    assert.strictEqual(resolveEffortCommitOptionId("opencode", undefined), "variant");
+    assert.strictEqual(resolveEffortCommitOptionId("pi", undefined), "thinkingLevel");
+    assert.strictEqual(resolveEffortCommitOptionId("claudeAgent", undefined), "effort");
+    assert.strictEqual(resolveEffortCommitOptionId("codex", undefined), "reasoningEffort");
+    assert.strictEqual(resolveEffortCommitOptionId("cursor", undefined), "reasoningEffort");
+    assert.strictEqual(resolveEffortCommitOptionId("grok", undefined), "reasoningEffort");
+  });
+});

--- a/apps/web/src/components/chat/composerTraits.ts
+++ b/apps/web/src/components/chat/composerTraits.ts
@@ -180,6 +180,25 @@ export function getComposerTraitSelection(
   };
 }
 
+// Resolves which provider option id an effort-level change commits to. Kept beside
+// `getComposerTraitSelection` so the traits picker and keyboard effort cycling agree
+// on the per-provider fallbacks when no primary select descriptor is available.
+export function resolveEffortCommitOptionId(
+  provider: ProviderKind,
+  primarySelectDescriptorId: string | undefined,
+): string {
+  return (
+    primarySelectDescriptorId ??
+    (provider === "kilo" || provider === "opencode"
+      ? "variant"
+      : provider === "pi"
+        ? "thinkingLevel"
+        : provider === "claudeAgent"
+          ? "effort"
+          : "reasoningEffort")
+  );
+}
+
 export function hasVisibleComposerTraitControls(
   selection: Pick<
     ReturnType<typeof getComposerTraitSelection>,

--- a/apps/web/src/components/chat/composerTraits.ts
+++ b/apps/web/src/components/chat/composerTraits.ts
@@ -221,6 +221,25 @@ export function showsComposerFastModeBadge(
   return supportsComposerFastModeControl(selection) && selection.fastModeEnabled;
 }
 
+// Resolves which provider option id an effort-level change commits to. Kept beside
+// `getComposerTraitSelection` so the traits picker and keyboard effort cycling agree
+// on the per-provider fallbacks when no primary select descriptor is available.
+export function resolveEffortCommitOptionId(
+  provider: ProviderKind,
+  primarySelectDescriptorId: string | undefined,
+): string {
+  return (
+    primarySelectDescriptorId ??
+    (provider === "kilo" || provider === "opencode"
+      ? "variant"
+      : provider === "pi"
+        ? "thinkingLevel"
+        : provider === "claudeAgent"
+          ? "effort"
+          : "reasoningEffort")
+  );
+}
+
 export function hasVisibleComposerTraitControls(
   selection: Pick<
     ReturnType<typeof getComposerTraitSelection>,

--- a/apps/web/src/hooks/useComposerSlashCommands.ts
+++ b/apps/web/src/hooks/useComposerSlashCommands.ts
@@ -1003,6 +1003,7 @@ export function useComposerSlashCommands(input: {
   );
 
   return {
+    createForkThreadFromSlashCommand,
     handleForkTargetSelection,
     handleReviewTargetSelection,
     isSlashStatusDialogOpen,

--- a/apps/web/src/hooks/useComposerSlashCommands.ts
+++ b/apps/web/src/hooks/useComposerSlashCommands.ts
@@ -1009,6 +1009,7 @@ export function useComposerSlashCommands(input: {
   );
 
   return {
+    createForkThreadFromSlashCommand,
     handleForkTargetSelection,
     handleReviewTargetSelection,
     isSlashStatusDialogOpen,

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -181,6 +181,46 @@ const DEFAULT_BINDINGS = compile([
     whenAst: whenNot(whenIdentifier("terminalFocus")),
   },
   {
+    shortcut: modShortcut("enter"),
+    command: "thread.approval.accept",
+    whenAst: whenCreationAllowed,
+  },
+  {
+    shortcut: modShortcut("enter", { shiftKey: true }),
+    command: "thread.approval.acceptForSession",
+    whenAst: whenCreationAllowed,
+  },
+  {
+    shortcut: modShortcut("backspace"),
+    command: "thread.approval.decline",
+    whenAst: whenCreationAllowed,
+  },
+  {
+    shortcut: modShortcut("p", { shiftKey: true }),
+    command: "thread.planMode.toggle",
+    whenAst: whenCreationAllowed,
+  },
+  {
+    shortcut: modShortcut("f", { shiftKey: true }),
+    command: "thread.fastMode.toggle",
+    whenAst: whenCreationAllowed,
+  },
+  {
+    shortcut: modShortcut("]", { altKey: true, shiftKey: true, modKey: false }),
+    command: "thread.effort.next",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
+  {
+    shortcut: modShortcut("[", { altKey: true, shiftKey: true, modKey: false }),
+    command: "thread.effort.previous",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
+  {
+    shortcut: modShortcut("d", { shiftKey: true }),
+    command: "composer.dictation.toggle",
+    whenAst: whenCreationAllowed,
+  },
+  {
     shortcut: modShortcut("l", { metaKey: true, modKey: false }),
     command: "composer.focus.toggle",
     whenAst: whenNot(whenIdentifier("terminalFocus")),
@@ -326,6 +366,32 @@ const DEFAULT_BINDINGS = compile([
     whenAst: whenNot(whenIdentifier("terminalFocus")),
   },
   { shortcut: modShortcut("o"), command: "editor.openFavorite" },
+  {
+    shortcut: modShortcut("[", { metaKey: true, modKey: false }),
+    command: "history.back",
+    whenAst: whenIdentifier("isElectron"),
+  },
+  {
+    shortcut: modShortcut("]", { metaKey: true, modKey: false }),
+    command: "history.forward",
+    whenAst: whenIdentifier("isElectron"),
+  },
+  {
+    shortcut: modShortcut("arrowleft", { altKey: true, modKey: false }),
+    command: "history.back",
+    whenAst: whenAnd(
+      whenIdentifier("isElectron"),
+      whenAnd(whenNot(whenIdentifier("isMac")), whenNot(whenIdentifier("terminalFocus"))),
+    ),
+  },
+  {
+    shortcut: modShortcut("arrowright", { altKey: true, modKey: false }),
+    command: "history.forward",
+    whenAst: whenAnd(
+      whenIdentifier("isElectron"),
+      whenAnd(whenNot(whenIdentifier("isMac")), whenNot(whenIdentifier("terminalFocus"))),
+    ),
+  },
 ]);
 
 describe("isTerminalToggleShortcut", () => {
@@ -1439,6 +1505,244 @@ describe("resolveShortcutCommand", () => {
         },
       ),
       "chat.newCursor",
+    );
+  });
+
+  it("resolves thread action commands with the macOS terminal-focus escape hatch", () => {
+    const macChat = { platform: "MacIntel", context: { terminalFocus: false } } as const;
+    const macTerminal = { platform: "MacIntel", context: { terminalFocus: true } } as const;
+    const linuxTerminal = { platform: "Linux", context: { terminalFocus: true } } as const;
+
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "enter", metaKey: true }), DEFAULT_BINDINGS, macChat),
+      "thread.approval.accept",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "enter", metaKey: true }), DEFAULT_BINDINGS, macTerminal),
+      "thread.approval.accept",
+    );
+    assert.isNull(
+      resolveShortcutCommand(
+        event({ key: "enter", ctrlKey: true }),
+        DEFAULT_BINDINGS,
+        linuxTerminal,
+      ),
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "enter", metaKey: true, shiftKey: true }),
+        DEFAULT_BINDINGS,
+        macChat,
+      ),
+      "thread.approval.acceptForSession",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "backspace", metaKey: true }), DEFAULT_BINDINGS, macChat),
+      "thread.approval.decline",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "p", metaKey: true, shiftKey: true }),
+        DEFAULT_BINDINGS,
+        macChat,
+      ),
+      "thread.planMode.toggle",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "f", metaKey: true, shiftKey: true }),
+        DEFAULT_BINDINGS,
+        macChat,
+      ),
+      "thread.fastMode.toggle",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "d", metaKey: true, shiftKey: true }),
+        DEFAULT_BINDINGS,
+        macChat,
+      ),
+      "composer.dictation.toggle",
+    );
+  });
+
+  it("resolves effort cycling outside terminal focus", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "]", altKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+      "thread.effort.next",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "[", altKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+      "thread.effort.previous",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "’", code: "BracketRight", altKey: true, shiftKey: true }),
+        DEFAULT_BINDINGS,
+        { platform: "MacIntel", context: { terminalFocus: false } },
+      ),
+      "thread.effort.next",
+    );
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "]", altKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: true },
+      }),
+    );
+  });
+
+  it("falls back to thread action defaults when runtime config is missing them", () => {
+    const legacyBindings = DEFAULT_BINDINGS.filter(
+      (binding) =>
+        binding.command !== "thread.approval.accept" &&
+        binding.command !== "thread.approval.acceptForSession" &&
+        binding.command !== "thread.approval.decline" &&
+        binding.command !== "thread.planMode.toggle" &&
+        binding.command !== "thread.fastMode.toggle" &&
+        binding.command !== "thread.effort.next" &&
+        binding.command !== "thread.effort.previous" &&
+        binding.command !== "composer.dictation.toggle",
+    );
+    const macChat = { platform: "MacIntel", context: { terminalFocus: false } } as const;
+
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "enter", metaKey: true }), legacyBindings, macChat),
+      "thread.approval.accept",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "enter", metaKey: true, shiftKey: true }),
+        legacyBindings,
+        macChat,
+      ),
+      "thread.approval.acceptForSession",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "backspace", metaKey: true }), legacyBindings, macChat),
+      "thread.approval.decline",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "p", metaKey: true, shiftKey: true }),
+        legacyBindings,
+        macChat,
+      ),
+      "thread.planMode.toggle",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "f", metaKey: true, shiftKey: true }),
+        legacyBindings,
+        macChat,
+      ),
+      "thread.fastMode.toggle",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "]", altKey: true, shiftKey: true }),
+        legacyBindings,
+        macChat,
+      ),
+      "thread.effort.next",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "[", altKey: true, shiftKey: true }),
+        legacyBindings,
+        macChat,
+      ),
+      "thread.effort.previous",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "d", metaKey: true, shiftKey: true }),
+        legacyBindings,
+        macChat,
+      ),
+      "composer.dictation.toggle",
+    );
+  });
+
+  it("resolves history navigation only inside the desktop app", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "[", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false, isElectron: true },
+      }),
+      "history.back",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "]", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false, isElectron: true },
+      }),
+      "history.forward",
+    );
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "[", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false, isElectron: false },
+      }),
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "arrowleft", altKey: true }), DEFAULT_BINDINGS, {
+        platform: "Linux",
+        context: { terminalFocus: false, isElectron: true },
+      }),
+      "history.back",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "arrowright", altKey: true }), DEFAULT_BINDINGS, {
+        platform: "Linux",
+        context: { terminalFocus: false, isElectron: true },
+      }),
+      "history.forward",
+    );
+    // Alt+Arrow stays free on macOS (word navigation) and in browser tabs.
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "arrowleft", altKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false, isElectron: true },
+      }),
+    );
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "arrowleft", altKey: true }), DEFAULT_BINDINGS, {
+        platform: "Linux",
+        context: { terminalFocus: false, isElectron: false },
+      }),
+    );
+  });
+
+  it("falls back to history navigation defaults when runtime config is missing them", () => {
+    const legacyBindings = DEFAULT_BINDINGS.filter(
+      (binding) => binding.command !== "history.back" && binding.command !== "history.forward",
+    );
+
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "[", metaKey: true }), legacyBindings, {
+        platform: "MacIntel",
+        context: { terminalFocus: false, isElectron: true },
+      }),
+      "history.back",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "arrowright", altKey: true }), legacyBindings, {
+        platform: "Linux",
+        context: { terminalFocus: false, isElectron: true },
+      }),
+      "history.forward",
+    );
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "[", metaKey: true }), legacyBindings, {
+        platform: "MacIntel",
+        context: { terminalFocus: false, isElectron: false },
+      }),
     );
   });
 });

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -294,6 +294,46 @@ const DEFAULT_BINDINGS = compile([
     whenAst: whenNot(whenIdentifier("terminalFocus")),
   },
   {
+    shortcut: modShortcut("enter"),
+    command: "thread.approval.accept",
+    whenAst: whenCreationAllowed,
+  },
+  {
+    shortcut: modShortcut("enter", { shiftKey: true }),
+    command: "thread.approval.acceptForSession",
+    whenAst: whenCreationAllowed,
+  },
+  {
+    shortcut: modShortcut("backspace"),
+    command: "thread.approval.decline",
+    whenAst: whenCreationAllowed,
+  },
+  {
+    shortcut: modShortcut("p", { shiftKey: true }),
+    command: "thread.planMode.toggle",
+    whenAst: whenCreationAllowed,
+  },
+  {
+    shortcut: modShortcut("f", { shiftKey: true }),
+    command: "thread.fastMode.toggle",
+    whenAst: whenCreationAllowed,
+  },
+  {
+    shortcut: modShortcut("]", { altKey: true, shiftKey: true, modKey: false }),
+    command: "thread.effort.next",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
+  {
+    shortcut: modShortcut("[", { altKey: true, shiftKey: true, modKey: false }),
+    command: "thread.effort.previous",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
+  {
+    shortcut: modShortcut("d", { shiftKey: true }),
+    command: "composer.dictation.toggle",
+    whenAst: whenCreationAllowed,
+  },
+  {
     shortcut: modShortcut("l", { metaKey: true, modKey: false }),
     command: "composer.focus.toggle",
     whenAst: whenNot(whenIdentifier("terminalFocus")),
@@ -444,6 +484,32 @@ const DEFAULT_BINDINGS = compile([
     whenAst: whenNot(whenIdentifier("terminalFocus")),
   },
   { shortcut: modShortcut("o"), command: "editor.openFavorite" },
+  {
+    shortcut: modShortcut("[", { metaKey: true, modKey: false }),
+    command: "history.back",
+    whenAst: whenIdentifier("isElectron"),
+  },
+  {
+    shortcut: modShortcut("]", { metaKey: true, modKey: false }),
+    command: "history.forward",
+    whenAst: whenIdentifier("isElectron"),
+  },
+  {
+    shortcut: modShortcut("arrowleft", { altKey: true, modKey: false }),
+    command: "history.back",
+    whenAst: whenAnd(
+      whenIdentifier("isElectron"),
+      whenAnd(whenNot(whenIdentifier("isMac")), whenNot(whenIdentifier("terminalFocus"))),
+    ),
+  },
+  {
+    shortcut: modShortcut("arrowright", { altKey: true, modKey: false }),
+    command: "history.forward",
+    whenAst: whenAnd(
+      whenIdentifier("isElectron"),
+      whenAnd(whenNot(whenIdentifier("isMac")), whenNot(whenIdentifier("terminalFocus"))),
+    ),
+  },
 ]);
 
 describe("isTerminalToggleShortcut", () => {
@@ -1655,6 +1721,244 @@ describe("resolveShortcutCommand", () => {
         },
       ),
       "chat.newCursor",
+    );
+  });
+
+  it("resolves thread action commands with the macOS terminal-focus escape hatch", () => {
+    const macChat = { platform: "MacIntel", context: { terminalFocus: false } } as const;
+    const macTerminal = { platform: "MacIntel", context: { terminalFocus: true } } as const;
+    const linuxTerminal = { platform: "Linux", context: { terminalFocus: true } } as const;
+
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "enter", metaKey: true }), DEFAULT_BINDINGS, macChat),
+      "thread.approval.accept",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "enter", metaKey: true }), DEFAULT_BINDINGS, macTerminal),
+      "thread.approval.accept",
+    );
+    assert.isNull(
+      resolveShortcutCommand(
+        event({ key: "enter", ctrlKey: true }),
+        DEFAULT_BINDINGS,
+        linuxTerminal,
+      ),
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "enter", metaKey: true, shiftKey: true }),
+        DEFAULT_BINDINGS,
+        macChat,
+      ),
+      "thread.approval.acceptForSession",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "backspace", metaKey: true }), DEFAULT_BINDINGS, macChat),
+      "thread.approval.decline",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "p", metaKey: true, shiftKey: true }),
+        DEFAULT_BINDINGS,
+        macChat,
+      ),
+      "thread.planMode.toggle",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "f", metaKey: true, shiftKey: true }),
+        DEFAULT_BINDINGS,
+        macChat,
+      ),
+      "thread.fastMode.toggle",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "d", metaKey: true, shiftKey: true }),
+        DEFAULT_BINDINGS,
+        macChat,
+      ),
+      "composer.dictation.toggle",
+    );
+  });
+
+  it("resolves effort cycling outside terminal focus", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "]", altKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+      "thread.effort.next",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "[", altKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+      "thread.effort.previous",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "’", code: "BracketRight", altKey: true, shiftKey: true }),
+        DEFAULT_BINDINGS,
+        { platform: "MacIntel", context: { terminalFocus: false } },
+      ),
+      "thread.effort.next",
+    );
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "]", altKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: true },
+      }),
+    );
+  });
+
+  it("falls back to thread action defaults when runtime config is missing them", () => {
+    const legacyBindings = DEFAULT_BINDINGS.filter(
+      (binding) =>
+        binding.command !== "thread.approval.accept" &&
+        binding.command !== "thread.approval.acceptForSession" &&
+        binding.command !== "thread.approval.decline" &&
+        binding.command !== "thread.planMode.toggle" &&
+        binding.command !== "thread.fastMode.toggle" &&
+        binding.command !== "thread.effort.next" &&
+        binding.command !== "thread.effort.previous" &&
+        binding.command !== "composer.dictation.toggle",
+    );
+    const macChat = { platform: "MacIntel", context: { terminalFocus: false } } as const;
+
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "enter", metaKey: true }), legacyBindings, macChat),
+      "thread.approval.accept",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "enter", metaKey: true, shiftKey: true }),
+        legacyBindings,
+        macChat,
+      ),
+      "thread.approval.acceptForSession",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "backspace", metaKey: true }), legacyBindings, macChat),
+      "thread.approval.decline",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "p", metaKey: true, shiftKey: true }),
+        legacyBindings,
+        macChat,
+      ),
+      "thread.planMode.toggle",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "f", metaKey: true, shiftKey: true }),
+        legacyBindings,
+        macChat,
+      ),
+      "thread.fastMode.toggle",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "]", altKey: true, shiftKey: true }),
+        legacyBindings,
+        macChat,
+      ),
+      "thread.effort.next",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "[", altKey: true, shiftKey: true }),
+        legacyBindings,
+        macChat,
+      ),
+      "thread.effort.previous",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "d", metaKey: true, shiftKey: true }),
+        legacyBindings,
+        macChat,
+      ),
+      "composer.dictation.toggle",
+    );
+  });
+
+  it("resolves history navigation only inside the desktop app", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "[", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false, isElectron: true },
+      }),
+      "history.back",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "]", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false, isElectron: true },
+      }),
+      "history.forward",
+    );
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "[", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false, isElectron: false },
+      }),
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "arrowleft", altKey: true }), DEFAULT_BINDINGS, {
+        platform: "Linux",
+        context: { terminalFocus: false, isElectron: true },
+      }),
+      "history.back",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "arrowright", altKey: true }), DEFAULT_BINDINGS, {
+        platform: "Linux",
+        context: { terminalFocus: false, isElectron: true },
+      }),
+      "history.forward",
+    );
+    // Alt+Arrow stays free on macOS (word navigation) and in browser tabs.
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "arrowleft", altKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false, isElectron: true },
+      }),
+    );
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "arrowleft", altKey: true }), DEFAULT_BINDINGS, {
+        platform: "Linux",
+        context: { terminalFocus: false, isElectron: false },
+      }),
+    );
+  });
+
+  it("falls back to history navigation defaults when runtime config is missing them", () => {
+    const legacyBindings = DEFAULT_BINDINGS.filter(
+      (binding) => binding.command !== "history.back" && binding.command !== "history.forward",
+    );
+
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "[", metaKey: true }), legacyBindings, {
+        platform: "MacIntel",
+        context: { terminalFocus: false, isElectron: true },
+      }),
+      "history.back",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "arrowright", altKey: true }), legacyBindings, {
+        platform: "Linux",
+        context: { terminalFocus: false, isElectron: true },
+      }),
+      "history.forward",
+    );
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "[", metaKey: true }), legacyBindings, {
+        platform: "MacIntel",
+        context: { terminalFocus: false, isElectron: false },
+      }),
     );
   });
 });

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -7,6 +7,7 @@ import {
   THREAD_JUMP_KEYBINDING_COMMANDS,
   type ThreadJumpKeybindingCommand,
 } from "@synara/contracts";
+import { isElectron } from "./env";
 import { isMacPlatform } from "./lib/utils";
 
 export interface ShortcutEventLike {
@@ -77,6 +78,13 @@ const whenThreadJumpAvailable = whenAnd(
 // the terminal on macOS while still yielding the chord to the shell on Linux/Windows,
 // where `mod` is Ctrl and keys like Ctrl+N are real shell input that must pass through.
 const whenCreationAllowed = whenOr(whenNotTerminalFocus, whenIdentifier("isMac"));
+// Thread-action chords (approvals, plan/fast mode, dictation) are mod-based too and
+// reuse `whenCreationAllowed` for the same PTY reasoning.
+const whenIsElectron = whenIdentifier("isElectron");
+const whenNonMacHistoryNavAllowed = whenAnd(
+  whenIsElectron,
+  whenAnd(whenNot(whenIdentifier("isMac")), whenNotTerminalFocus),
+);
 
 export const DEFAULT_SHORTCUT_FALLBACKS: ResolvedKeybindingsConfig = [
   {
@@ -163,6 +171,46 @@ export const DEFAULT_SHORTCUT_FALLBACKS: ResolvedKeybindingsConfig = [
     shortcut: commandShortcut("e", { shiftKey: true }),
     whenAst: whenNotTerminalFocus,
   },
+  {
+    command: "thread.approval.accept",
+    shortcut: commandShortcut("enter"),
+    whenAst: whenCreationAllowed,
+  },
+  {
+    command: "thread.approval.acceptForSession",
+    shortcut: commandShortcut("enter", { shiftKey: true }),
+    whenAst: whenCreationAllowed,
+  },
+  {
+    command: "thread.approval.decline",
+    shortcut: commandShortcut("backspace"),
+    whenAst: whenCreationAllowed,
+  },
+  {
+    command: "thread.planMode.toggle",
+    shortcut: commandShortcut("p", { shiftKey: true }),
+    whenAst: whenCreationAllowed,
+  },
+  {
+    command: "thread.fastMode.toggle",
+    shortcut: commandShortcut("f", { shiftKey: true }),
+    whenAst: whenCreationAllowed,
+  },
+  {
+    command: "thread.effort.next",
+    shortcut: commandShortcut("]", { altKey: true, shiftKey: true, modKey: false }),
+    whenAst: whenNotTerminalFocus,
+  },
+  {
+    command: "thread.effort.previous",
+    shortcut: commandShortcut("[", { altKey: true, shiftKey: true, modKey: false }),
+    whenAst: whenNotTerminalFocus,
+  },
+  {
+    command: "composer.dictation.toggle",
+    shortcut: commandShortcut("d", { shiftKey: true }),
+    whenAst: whenCreationAllowed,
+  },
   // Cmd-only instead of mod so Ctrl+L remains available to shells on non-macOS.
   {
     command: "composer.focus.toggle",
@@ -237,6 +285,28 @@ export const DEFAULT_SHORTCUT_FALLBACKS: ResolvedKeybindingsConfig = [
     command: "terminal.workspace.chat",
     shortcut: commandShortcut("2"),
     whenAst: whenIdentifier("terminalWorkspaceOpen"),
+  },
+  // App history navigation is installed-app only by default: in a normal browser tab
+  // these chords are the browser's own native history navigation and stay untouched.
+  {
+    command: "history.back",
+    shortcut: commandShortcut("[", { metaKey: true, modKey: false }),
+    whenAst: whenIsElectron,
+  },
+  {
+    command: "history.forward",
+    shortcut: commandShortcut("]", { metaKey: true, modKey: false }),
+    whenAst: whenIsElectron,
+  },
+  {
+    command: "history.back",
+    shortcut: commandShortcut("arrowleft", { altKey: true, modKey: false }),
+    whenAst: whenNonMacHistoryNavAllowed,
+  },
+  {
+    command: "history.forward",
+    shortcut: commandShortcut("arrowright", { altKey: true, modKey: false }),
+    whenAst: whenNonMacHistoryNavAllowed,
   },
 ];
 
@@ -334,13 +404,15 @@ function resolvePlatform(options: ShortcutMatchOptions | undefined): string {
 }
 
 function resolveContext(options: ShortcutMatchOptions | undefined): ShortcutMatchContext {
-  // `isMac` is derived from the resolved platform so `when` clauses can gate on it
-  // (e.g. `whenCreationAllowed`) without every dispatch site having to thread the flag
-  // through `context`. An explicit `context.isMac` still wins via the spread below.
+  // `isMac` is derived from the resolved platform and `isElectron` from the preload
+  // bridge so `when` clauses can gate on them (e.g. `whenCreationAllowed`, the
+  // history-navigation defaults) without every dispatch site having to thread the
+  // flags through `context`. Explicit context values still win via the spread below.
   return {
     terminalFocus: false,
     terminalOpen: false,
     isMac: isMacPlatform(resolvePlatform(options)),
+    isElectron,
     ...options?.context,
   };
 }

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -10,6 +10,7 @@ import {
   type ThreadJumpKeybindingCommand,
 } from "@synara/contracts";
 import { isKeyboardShortcutsHelpChord } from "@synara/shared/browserShortcuts";
+import { isElectron } from "./env";
 import { isMacPlatform, isWindowsPlatform } from "./lib/utils";
 
 export interface ShortcutEventLike {
@@ -81,6 +82,13 @@ const whenThreadJumpAvailable = whenAnd(
 // the terminal on macOS while still yielding the chord to the shell on Linux/Windows,
 // where `mod` is Ctrl and keys like Ctrl+N are real shell input that must pass through.
 const whenCreationAllowed = whenOr(whenNotTerminalFocus, whenIdentifier("isMac"));
+// Thread-action chords (approvals, plan/fast mode, dictation) are mod-based too and
+// reuse `whenCreationAllowed` for the same PTY reasoning.
+const whenIsElectron = whenIdentifier("isElectron");
+const whenNonMacHistoryNavAllowed = whenAnd(
+  whenIsElectron,
+  whenAnd(whenNot(whenIdentifier("isMac")), whenNotTerminalFocus),
+);
 
 export const DEFAULT_SHORTCUT_FALLBACKS: ResolvedKeybindingsConfig = [
   {
@@ -166,6 +174,46 @@ export const DEFAULT_SHORTCUT_FALLBACKS: ResolvedKeybindingsConfig = [
     command: "traitsPicker.toggle",
     shortcut: commandShortcut("e", { shiftKey: true }),
     whenAst: whenNotTerminalFocus,
+  },
+  {
+    command: "thread.approval.accept",
+    shortcut: commandShortcut("enter"),
+    whenAst: whenCreationAllowed,
+  },
+  {
+    command: "thread.approval.acceptForSession",
+    shortcut: commandShortcut("enter", { shiftKey: true }),
+    whenAst: whenCreationAllowed,
+  },
+  {
+    command: "thread.approval.decline",
+    shortcut: commandShortcut("backspace"),
+    whenAst: whenCreationAllowed,
+  },
+  {
+    command: "thread.planMode.toggle",
+    shortcut: commandShortcut("p", { shiftKey: true }),
+    whenAst: whenCreationAllowed,
+  },
+  {
+    command: "thread.fastMode.toggle",
+    shortcut: commandShortcut("f", { shiftKey: true }),
+    whenAst: whenCreationAllowed,
+  },
+  {
+    command: "thread.effort.next",
+    shortcut: commandShortcut("]", { altKey: true, shiftKey: true, modKey: false }),
+    whenAst: whenNotTerminalFocus,
+  },
+  {
+    command: "thread.effort.previous",
+    shortcut: commandShortcut("[", { altKey: true, shiftKey: true, modKey: false }),
+    whenAst: whenNotTerminalFocus,
+  },
+  {
+    command: "composer.dictation.toggle",
+    shortcut: commandShortcut("d", { shiftKey: true }),
+    whenAst: whenCreationAllowed,
   },
   // Cmd-only instead of mod so Ctrl+L remains available to shells on non-macOS.
   {
@@ -263,6 +311,28 @@ export const DEFAULT_SHORTCUT_FALLBACKS: ResolvedKeybindingsConfig = [
     shortcut: commandShortcut("2"),
     whenAst: whenIdentifier("terminalWorkspaceOpen"),
   },
+  // App history navigation is installed-app only by default: in a normal browser tab
+  // these chords are the browser's own native history navigation and stay untouched.
+  {
+    command: "history.back",
+    shortcut: commandShortcut("[", { metaKey: true, modKey: false }),
+    whenAst: whenIsElectron,
+  },
+  {
+    command: "history.forward",
+    shortcut: commandShortcut("]", { metaKey: true, modKey: false }),
+    whenAst: whenIsElectron,
+  },
+  {
+    command: "history.back",
+    shortcut: commandShortcut("arrowleft", { altKey: true, modKey: false }),
+    whenAst: whenNonMacHistoryNavAllowed,
+  },
+  {
+    command: "history.forward",
+    shortcut: commandShortcut("arrowright", { altKey: true, modKey: false }),
+    whenAst: whenNonMacHistoryNavAllowed,
+  },
 ];
 
 const TERMINAL_WORD_BACKWARD = "\u001bb";
@@ -359,13 +429,15 @@ function resolvePlatform(options: ShortcutMatchOptions | undefined): string {
 }
 
 function resolveContext(options: ShortcutMatchOptions | undefined): ShortcutMatchContext {
-  // `isMac` is derived from the resolved platform so `when` clauses can gate on it
-  // (e.g. `whenCreationAllowed`) without every dispatch site having to thread the flag
-  // through `context`. An explicit `context.isMac` still wins via the spread below.
+  // `isMac` is derived from the resolved platform and `isElectron` from the preload
+  // bridge so `when` clauses can gate on them (e.g. `whenCreationAllowed`, the
+  // history-navigation defaults) without every dispatch site having to thread the
+  // flags through `context`. Explicit context values still win via the spread below.
   return {
     terminalFocus: false,
     terminalOpen: false,
     isMac: isMacPlatform(resolvePlatform(options)),
+    isElectron,
     ...options?.context,
   };
 }

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -12,7 +12,6 @@ import ShortcutsDialog from "../components/ShortcutsDialog";
 import { RecentViewSwitcher } from "../components/RecentViewSwitcher";
 import { shouldRenderTerminalWorkspace } from "../components/ChatView.logic";
 import ThreadSidebar from "../components/Sidebar";
-import { isElectron } from "../env";
 import { useHandleNewChat } from "../hooks/useHandleNewChat";
 import { useHandleNewStudioChat } from "../hooks/useHandleNewStudioChat";
 import { useTemporaryThreadLifecycle } from "../hooks/useTemporaryThreadLifecycle";
@@ -161,38 +160,6 @@ function ThreadRetentionMaintenanceToast() {
   return null;
 }
 
-function resolveBrowserNavigationShortcut(
-  event: KeyboardEvent,
-  platform: string,
-): "back" | "forward" | null {
-  const isMac = /Mac|iPhone|iPad|iPod/i.test(platform);
-  const key = event.key.toLowerCase();
-
-  if (
-    isMac &&
-    event.metaKey &&
-    !event.ctrlKey &&
-    !event.altKey &&
-    !event.shiftKey &&
-    (key === "[" || key === "]")
-  ) {
-    return key === "[" ? "back" : "forward";
-  }
-
-  if (
-    !isMac &&
-    event.altKey &&
-    !event.metaKey &&
-    !event.ctrlKey &&
-    !event.shiftKey &&
-    (event.key === "ArrowLeft" || event.key === "ArrowRight")
-  ) {
-    return event.key === "ArrowLeft" ? "back" : "forward";
-  }
-
-  return null;
-}
-
 function isRecentViewSwitcherCommitKey(event: KeyboardEvent): boolean {
   return event.key === "Enter" || event.key === " " || event.key === "Spacebar";
 }
@@ -325,22 +292,6 @@ function ChatRouteGlobalShortcuts() {
         return;
       }
 
-      const appNavigationShortcut = isElectron
-        ? resolveBrowserNavigationShortcut(event, platform)
-        : null;
-      if (appNavigationShortcut) {
-        event.preventDefault();
-        event.stopPropagation();
-        const navigationState = resolveAppNavigationState();
-        if (appNavigationShortcut === "back" && navigationState.canGoBack) {
-          goBackInAppHistory();
-        }
-        if (appNavigationShortcut === "forward" && navigationState.canGoForward) {
-          goForwardInAppHistory();
-        }
-        return;
-      }
-
       if (event.key === "Escape" && selectedThreadIdsSize > 0) {
         event.preventDefault();
         clearSelection();
@@ -363,6 +314,19 @@ function ChatRouteGlobalShortcuts() {
         // Ignore auto-repeat: holding Ctrl+Tab should not race-advance the selection.
         if (event.repeat) return;
         openOrAdvanceRecentSwitcher(command === "view.recent.next" ? "next" : "previous");
+        return;
+      }
+
+      if (command === "history.back" || command === "history.forward") {
+        event.preventDefault();
+        event.stopPropagation();
+        const navigationState = resolveAppNavigationState();
+        if (command === "history.back" && navigationState.canGoBack) {
+          goBackInAppHistory();
+        }
+        if (command === "history.forward" && navigationState.canGoForward) {
+          goForwardInAppHistory();
+        }
         return;
       }
 
@@ -466,7 +430,6 @@ function ChatRouteGlobalShortcuts() {
     keybindings,
     latestUsableProjectId,
     openOrAdvanceRecentSwitcher,
-    platform,
     providerStatuses,
     refreshProviderStatuses,
     recentSwitcherState,

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -12,7 +12,6 @@ import ShortcutsDialog from "../components/ShortcutsDialog";
 import { RecentViewSwitcher } from "../components/RecentViewSwitcher";
 import { shouldRenderTerminalWorkspace } from "../components/ChatView.logic";
 import ThreadSidebar from "../components/Sidebar";
-import { isElectron } from "../env";
 import { useHandleNewChat } from "../hooks/useHandleNewChat";
 import { useHandleNewStudioChat } from "../hooks/useHandleNewStudioChat";
 import { useTemporaryThreadLifecycle } from "../hooks/useTemporaryThreadLifecycle";
@@ -160,38 +159,6 @@ function ThreadRetentionMaintenanceToast() {
       });
     });
   }, []);
-
-  return null;
-}
-
-function resolveBrowserNavigationShortcut(
-  event: KeyboardEvent,
-  platform: string,
-): "back" | "forward" | null {
-  const isMac = /Mac|iPhone|iPad|iPod/i.test(platform);
-  const key = event.key.toLowerCase();
-
-  if (
-    isMac &&
-    event.metaKey &&
-    !event.ctrlKey &&
-    !event.altKey &&
-    !event.shiftKey &&
-    (key === "[" || key === "]")
-  ) {
-    return key === "[" ? "back" : "forward";
-  }
-
-  if (
-    !isMac &&
-    event.altKey &&
-    !event.metaKey &&
-    !event.ctrlKey &&
-    !event.shiftKey &&
-    (event.key === "ArrowLeft" || event.key === "ArrowRight")
-  ) {
-    return event.key === "ArrowLeft" ? "back" : "forward";
-  }
 
   return null;
 }
@@ -346,22 +313,6 @@ function ChatRouteGlobalShortcuts() {
         return;
       }
 
-      const appNavigationShortcut = isElectron
-        ? resolveBrowserNavigationShortcut(event, platform)
-        : null;
-      if (appNavigationShortcut) {
-        event.preventDefault();
-        event.stopPropagation();
-        const navigationState = resolveAppNavigationState();
-        if (appNavigationShortcut === "back" && navigationState.canGoBack) {
-          goBackInAppHistory();
-        }
-        if (appNavigationShortcut === "forward" && navigationState.canGoForward) {
-          goForwardInAppHistory();
-        }
-        return;
-      }
-
       if (event.key === "Escape" && selectedThreadIdsSize > 0) {
         event.preventDefault();
         clearSelection();
@@ -384,6 +335,19 @@ function ChatRouteGlobalShortcuts() {
         // Ignore auto-repeat: holding Ctrl+Tab should not race-advance the selection.
         if (event.repeat) return;
         openOrAdvanceRecentSwitcher(command === "view.recent.next" ? "next" : "previous");
+        return;
+      }
+
+      if (command === "history.back" || command === "history.forward") {
+        event.preventDefault();
+        event.stopPropagation();
+        const navigationState = resolveAppNavigationState();
+        if (command === "history.back" && navigationState.canGoBack) {
+          goBackInAppHistory();
+        }
+        if (command === "history.forward" && navigationState.canGoForward) {
+          goForwardInAppHistory();
+        }
         return;
       }
 
@@ -487,7 +451,6 @@ function ChatRouteGlobalShortcuts() {
     keybindings,
     latestUsableProjectId,
     openOrAdvanceRecentSwitcher,
-    platform,
     providerStatuses,
     refreshProviderStatuses,
     recentSwitcherState,

--- a/apps/web/src/shortcutsSheet.ts
+++ b/apps/web/src/shortcutsSheet.ts
@@ -138,6 +138,56 @@ const AVAILABLE_NOW_DEFINITIONS: readonly ShortcutDefinition[] = [
     description: "Focus or blur the chat prompt composer.",
   },
   {
+    command: "thread.approval.accept",
+    label: "Approve request",
+    description: "Accept the pending approval request in the active thread.",
+  },
+  {
+    command: "thread.approval.acceptForSession",
+    label: "Approve for session",
+    description: "Accept the pending approval request for the rest of the session.",
+  },
+  {
+    command: "thread.approval.decline",
+    label: "Decline request",
+    description: "Decline the pending approval request in the active thread.",
+  },
+  {
+    command: "thread.planMode.toggle",
+    label: "Toggle plan mode",
+    description: "Switch the composer between plan mode and the default interaction mode.",
+  },
+  {
+    command: "thread.fastMode.toggle",
+    label: "Toggle fast mode",
+    description: "Enable or disable fast mode when the selected model supports it.",
+  },
+  {
+    command: "thread.effort.next",
+    label: "Next reasoning effort",
+    description: "Cycle to the next reasoning effort level for the selected model.",
+  },
+  {
+    command: "thread.effort.previous",
+    label: "Previous reasoning effort",
+    description: "Cycle to the previous reasoning effort level for the selected model.",
+  },
+  {
+    command: "composer.send",
+    label: "Send message",
+    description: "Send the composer contents to the active thread.",
+  },
+  {
+    command: "composer.dictation.toggle",
+    label: "Toggle dictation",
+    description: "Start or stop voice dictation in the composer.",
+  },
+  {
+    command: "thread.fork",
+    label: "Fork thread",
+    description: "Create a fork of the current thread from its latest state.",
+  },
+  {
     command: "terminal.toggle",
     label: "Toggle terminal",
     description: "Show or hide the terminal surface for the active thread.",
@@ -166,6 +216,16 @@ const AVAILABLE_NOW_DEFINITIONS: readonly ShortcutDefinition[] = [
     command: "editor.openFavorite",
     label: "Open in favorite editor",
     description: "Send the current thread or workspace target to your preferred editor.",
+  },
+  {
+    command: "history.back",
+    label: "Go back",
+    description: "Navigate back through the in-app view history.",
+  },
+  {
+    command: "history.forward",
+    label: "Go forward",
+    description: "Navigate forward through the in-app view history.",
   },
 ] as const;
 

--- a/apps/web/src/shortcutsSheet.ts
+++ b/apps/web/src/shortcutsSheet.ts
@@ -162,6 +162,56 @@ const AVAILABLE_NOW_DEFINITIONS: readonly ShortcutDefinition[] = [
     description: "Focus or blur the chat prompt composer.",
   },
   {
+    command: "thread.approval.accept",
+    label: "Approve request",
+    description: "Accept the pending approval request in the active thread.",
+  },
+  {
+    command: "thread.approval.acceptForSession",
+    label: "Approve for session",
+    description: "Accept the pending approval request for the rest of the session.",
+  },
+  {
+    command: "thread.approval.decline",
+    label: "Decline request",
+    description: "Decline the pending approval request in the active thread.",
+  },
+  {
+    command: "thread.planMode.toggle",
+    label: "Toggle plan mode",
+    description: "Switch the composer between plan mode and the default interaction mode.",
+  },
+  {
+    command: "thread.fastMode.toggle",
+    label: "Toggle fast mode",
+    description: "Enable or disable fast mode when the selected model supports it.",
+  },
+  {
+    command: "thread.effort.next",
+    label: "Next reasoning effort",
+    description: "Cycle to the next reasoning effort level for the selected model.",
+  },
+  {
+    command: "thread.effort.previous",
+    label: "Previous reasoning effort",
+    description: "Cycle to the previous reasoning effort level for the selected model.",
+  },
+  {
+    command: "composer.send",
+    label: "Send message",
+    description: "Send the composer contents to the active thread.",
+  },
+  {
+    command: "composer.dictation.toggle",
+    label: "Toggle dictation",
+    description: "Start or stop voice dictation in the composer.",
+  },
+  {
+    command: "thread.fork",
+    label: "Fork thread",
+    description: "Create a fork of the current thread from its latest state.",
+  },
+  {
     command: "terminal.toggle",
     label: "Toggle terminal",
     description: "Show or hide the terminal surface for the active thread.",
@@ -195,6 +245,16 @@ const AVAILABLE_NOW_DEFINITIONS: readonly ShortcutDefinition[] = [
     command: "git.commitAndPush",
     label: "Commit and push",
     description: "Commit pending changes and push the active thread's repo.",
+  },
+  {
+    command: "history.back",
+    label: "Go back",
+    description: "Navigate back through the in-app view history.",
+  },
+  {
+    command: "history.forward",
+    label: "Go forward",
+    description: "Navigate forward through the in-app view history.",
   },
 ] as const;
 

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -31,6 +31,16 @@ const STATIC_KEYBINDING_COMMANDS = [
   "model.next",
   "model.previous",
   "traitsPicker.toggle",
+  "thread.approval.accept",
+  "thread.approval.acceptForSession",
+  "thread.approval.decline",
+  "thread.planMode.toggle",
+  "thread.fastMode.toggle",
+  "thread.effort.next",
+  "thread.effort.previous",
+  "thread.fork",
+  "composer.send",
+  "composer.dictation.toggle",
   "settings.usage",
   "chat.new",
   "chat.newLatestProject",
@@ -55,6 +65,8 @@ const STATIC_KEYBINDING_COMMANDS = [
   "chat.visible.next",
   "chat.visible.previous",
   "editor.openFavorite",
+  "history.back",
+  "history.forward",
 ] as const;
 
 // Shared list of numbered thread-jump commands used by the web shortcut UI.

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -42,6 +42,16 @@ const STATIC_KEYBINDING_COMMANDS = [
   "model.next",
   "model.previous",
   "traitsPicker.toggle",
+  "thread.approval.accept",
+  "thread.approval.acceptForSession",
+  "thread.approval.decline",
+  "thread.planMode.toggle",
+  "thread.fastMode.toggle",
+  "thread.effort.next",
+  "thread.effort.previous",
+  "thread.fork",
+  "composer.send",
+  "composer.dictation.toggle",
   "settings.usage",
   "chat.new",
   "chat.newLatestProject",
@@ -67,6 +77,8 @@ const STATIC_KEYBINDING_COMMANDS = [
   "chat.visible.previous",
   "editor.openFavorite",
   "git.commitAndPush",
+  "history.back",
+  "history.forward",
 ] as const;
 
 // Shared list of numbered thread-jump commands used by the web shortcut UI.


### PR DESCRIPTION
Implements the command layer proposed in #375.

## What's new

New remappable commands, wired through the existing pipeline (contracts whitelist → server `DEFAULT_KEYBINDINGS` → web fallbacks → capture-phase dispatch):

| Command | Default | Notes |
| --- | --- | --- |
| `thread.approval.accept` | `mod+enter` | Responds to the pending approval request in the active thread — works for every provider since it goes through `thread.approval.respond` |
| `thread.approval.acceptForSession` | `mod+shift+enter` | |
| `thread.approval.decline` | `mod+backspace` | |
| `thread.planMode.toggle` | `mod+shift+p` | Toggles plan ↔ default interaction mode |
| `thread.fastMode.toggle` | `mod+shift+f` | No-op unless the selected model supports fast mode |
| `thread.effort.next` / `previous` | `alt+shift+]` / `alt+shift+[` | Cycles the provider's effort levels; skips prompt-injected levels (e.g. Claude ultrathink) and defers while an ultrathink prompt controls effort |
| `composer.dictation.toggle` | `mod+shift+d` | |
| `composer.send`, `thread.fork` | none | Bindable via `keybindings.json` — meant for macro pads / power users, so no chord is spent by default |
| `history.back` / `history.forward` | `cmd+[` / `cmd+]` (+ `alt+arrow` on non-mac) | Promotes the previously hardcoded Electron-only browser-navigation shortcut into real commands, gated by a new `isElectron` context key so browser tabs keep native history behavior |

## Implementation notes

- Mod-based thread-action chords reuse the same `!terminalFocus || isMac` escape hatch as the creation chords (Cmd chords never reach xterm on macOS).
- The approval chords only claim the key while an approval is actually pending — otherwise `mod+enter`/`mod+backspace` fall through untouched.
- The per-provider effort option-id fallback that lived inline in `TraitsPicker` is extracted to `resolveEffortCommitOptionId` in `composerTraits.ts` so the picker and the shortcut share one source of truth.
- Thread-action dispatch lives in a second capture listener in `ChatView` (mirroring the existing one) because several of its handlers are declared after the primary listener.
- Shortcut sheet entries added; unbound commands stay hidden until the user binds them (existing behavior).

## Testing

- New unit tests: default-chord resolution + fallback recovery + `isElectron` gating in `apps/web/src/keybindings.test.ts`; `resolveEffortCommitOptionId` provider mapping in `composerTraits.test.ts`. Server default persistence is covered by the existing round-trip test (29 passing).
- `bun fmt`, `bun lint` (0 errors), `bun typecheck` (8/8) all pass. Full server suite passes; the 5 web store test files currently failing on `main` fail identically with and without this change.

## Heads up

#374 also touches `KEYBINDINGS.md` — happy to rebase whichever lands second.