### PR TITLE
feat(server): fetch Linear/GitHub issues for composer references

### DIFF
--- a/apps/server/src/git/Layers/GitHubCli.ts
+++ b/apps/server/src/git/Layers/GitHubCli.ts
@@ -23,6 +23,8 @@ import { GitHubCliError } from "../Errors.ts";
 import {
   GitHubCli,
   PULL_REQUEST_SUMMARY_JSON_FIELDS,
+  type GitHubIssueDetail,
+  type GitHubIssueSummary,
   type GitHubRepositoryCloneUrls,
   type GitHubCliShape,
   type GitHubPullRequestDetailData,
@@ -39,6 +41,17 @@ export const PULL_REQUEST_LIST_JSON_FIELDS =
   "number,title,url,author,headRefName,baseRefName,state,isDraft,additions,deletions,updatedAt,createdAt,reviewDecision,reviewRequests,labels,mergedAt,mergeable";
 export const PULL_REQUEST_DETAIL_JSON_FIELDS =
   "number,title,body,url,author,state,isDraft,mergeable,mergeStateStatus,additions,deletions,changedFiles,headRefName,baseRefName,reviewDecision,reviewRequests,reviews,comments,statusCheckRollup,commits,labels,maintainerCanModify,createdAt,updatedAt,mergedAt,closedAt";
+export const ISSUE_LIST_JSON_FIELDS = "number,title,url,body,state,updatedAt";
+export const ISSUE_DETAIL_JSON_FIELDS = "number,title,url,body,state,updatedAt";
+
+const RawGitHubIssueSchema = Schema.Struct({
+  number: Schema.Number,
+  title: Schema.String,
+  url: Schema.String,
+  body: Schema.optionalKey(Schema.NullOr(Schema.String)),
+  state: Schema.String,
+  updatedAt: Schema.optionalKey(Schema.NullOr(Schema.String)),
+});
 
 function normalizeGitHubCliError(operation: "execute" | "stdout", error: unknown): GitHubCliError {
   if (error instanceof Error) {
@@ -719,7 +732,9 @@ function decodeGitHubJson<S extends Schema.Top>(
     | "getPullRequestDetail"
     | "getPullRequestListItem"
     | "listReviewRequestedPullRequestNumbers"
-    | "getRepositoryMergeCapabilities",
+    | "getRepositoryMergeCapabilities"
+    | "listRepositoryIssues"
+    | "getIssue",
   invalidDetail: string,
 ): Effect.Effect<S["Type"], GitHubCliError, S["DecodingServices"]> {
   return Schema.decodeEffect(Schema.fromJsonString(schema))(raw).pipe(
@@ -1148,6 +1163,94 @@ const makeGitHubCli = Effect.sync(() => {
           ),
         ),
         Effect.map(normalizePullRequestDetail),
+      ),
+    listRepositoryIssues: (input) =>
+      validateRepository(input.repository, "listRepositoryIssues").pipe(
+        Effect.flatMap((repository) => {
+          const query = input.query?.trim() ?? "";
+          const searchArgs =
+            query.length > 0
+              ? query.match(/^\d+$/)
+                ? ["--search", `${query} in:title,body`]
+                : ["--search", query]
+              : [];
+          return execute({
+            cwd: input.cwd,
+            args: [
+              "issue",
+              "list",
+              "--repo",
+              repositorySelector(repository),
+              "--state",
+              "open",
+              "--limit",
+              String(input.limit ?? 20),
+              ...searchArgs,
+              "--json",
+              ISSUE_LIST_JSON_FIELDS,
+            ],
+          });
+        }),
+        Effect.flatMap((result) => {
+          const trimmed = result.stdout.trim();
+          if (trimmed.length === 0) {
+            return Effect.succeed([] as ReadonlyArray<GitHubIssueSummary>);
+          }
+          return decodeGitHubJson(
+            trimmed,
+            Schema.Array(RawGitHubIssueSchema),
+            "listRepositoryIssues",
+            "GitHub CLI returned invalid issue list JSON.",
+          ).pipe(
+            Effect.map((entries) =>
+              entries.map(
+                (entry): GitHubIssueSummary => ({
+                  number: entry.number,
+                  title: entry.title,
+                  url: entry.url,
+                  body: entry.body ?? "",
+                  state: entry.state.toUpperCase() === "CLOSED" ? "CLOSED" : "OPEN",
+                  updatedAt: entry.updatedAt ?? "",
+                }),
+              ),
+            ),
+          );
+        }),
+      ),
+    getIssue: (input) =>
+      validateRepository(input.repository, "getIssue").pipe(
+        Effect.flatMap((repository) =>
+          execute({
+            cwd: input.cwd,
+            args: [
+              "issue",
+              "view",
+              String(input.number),
+              "--repo",
+              repositorySelector(repository),
+              "--json",
+              ISSUE_DETAIL_JSON_FIELDS,
+            ],
+          }),
+        ),
+        Effect.flatMap((result) =>
+          decodeGitHubJson(
+            result.stdout.trim(),
+            RawGitHubIssueSchema,
+            "getIssue",
+            "GitHub CLI returned invalid issue detail JSON.",
+          ),
+        ),
+        Effect.map(
+          (entry): GitHubIssueDetail => ({
+            number: entry.number,
+            title: entry.title,
+            url: entry.url,
+            body: entry.body ?? "",
+            state: entry.state.toUpperCase() === "CLOSED" ? "CLOSED" : "OPEN",
+            updatedAt: entry.updatedAt ?? "",
+          }),
+        ),
       ),
     getRepositoryMergeCapabilities: (input) =>
       validateRepository(input.repository, "getRepositoryMergeCapabilities").pipe(

--- a/apps/server/src/git/Services/GitHubCli.ts
+++ b/apps/server/src/git/Services/GitHubCli.ts
@@ -119,6 +119,24 @@ export interface GitHubPullRequestDetailData {
   readonly commits: ReadonlyArray<PullRequestCommit>;
 }
 
+export interface GitHubIssueSummary {
+  readonly number: number;
+  readonly title: string;
+  readonly url: string;
+  readonly body: string;
+  readonly state: "OPEN" | "CLOSED";
+  readonly updatedAt: string;
+}
+
+export interface GitHubIssueDetail {
+  readonly number: number;
+  readonly title: string;
+  readonly body: string;
+  readonly url: string;
+  readonly state: "OPEN" | "CLOSED";
+  readonly updatedAt: string;
+}
+
 /**
  * GitHubCliShape - Service API for executing GitHub CLI commands.
  */
@@ -176,6 +194,19 @@ export interface GitHubCliShape {
     readonly repository: string;
     readonly number: number;
   }) => Effect.Effect<GitHubPullRequestDetailData, GitHubCliError>;
+
+  readonly listRepositoryIssues: (input: {
+    readonly cwd: string;
+    readonly repository: string;
+    readonly query?: string;
+    readonly limit?: number;
+  }) => Effect.Effect<ReadonlyArray<GitHubIssueSummary>, GitHubCliError>;
+
+  readonly getIssue: (input: {
+    readonly cwd: string;
+    readonly repository: string;
+    readonly number: number;
+  }) => Effect.Effect<GitHubIssueDetail, GitHubCliError>;
 
   readonly getRepositoryMergeCapabilities: (input: {
     readonly cwd: string;

--- a/apps/server/src/git/testing/fakeGitHubCli.ts
+++ b/apps/server/src/git/testing/fakeGitHubCli.ts
@@ -22,6 +22,8 @@ import {
 } from "../Layers/GitHubCli.ts";
 import {
   type GitHubCliShape,
+  type GitHubIssueDetail,
+  type GitHubIssueSummary,
   type GitHubPullRequestDetailData,
   type GitHubPullRequestListItem,
   type GitHubPullRequestSummary,
@@ -58,6 +60,8 @@ export interface FakeGhScenario {
   reviewRequestedPullRequestNumbers?: number[];
   mergeCapabilities?: PullRequestMergeCapabilities;
   pullRequestDiff?: { patch: string; truncated: boolean };
+  repositoryIssues?: GitHubIssueSummary[];
+  issueDetail?: GitHubIssueDetail;
 }
 
 export type FakePullRequest = NonNullable<FakeGhScenario["pullRequest"]>;
@@ -304,6 +308,29 @@ export function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
                 operation: "getPullRequestDetail",
                 detail: "Fake pull request detail was not configured.",
               }),
+            );
+      },
+      listRepositoryIssues: (input) => {
+        ghCalls.push(
+          `issue list --repo ${input.repository}${input.query ? ` --search ${input.query}` : ""}`,
+        );
+        return scenario.failWith
+          ? Effect.fail(scenario.failWith)
+          : Effect.succeed(scenario.repositoryIssues ?? []);
+      },
+      getIssue: (input) => {
+        ghCalls.push(`issue view ${input.number} --repo ${input.repository}`);
+        const issue =
+          scenario.issueDetail ??
+          scenario.repositoryIssues?.find((entry) => entry.number === input.number);
+        return issue
+          ? Effect.succeed(issue)
+          : Effect.fail(
+              scenario.failWith ??
+                new GitHubCliError({
+                  operation: "getIssue",
+                  detail: "Fake issue detail was not configured.",
+                }),
             );
       },
       getRepositoryMergeCapabilities: (input) => {

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -40,6 +40,7 @@ import { ProjectionTurnRepositoryLive } from "./persistence/Layers/ProjectionTur
 import { OrchestrationEventDeliveryRepositoryLive } from "./persistence/Layers/OrchestrationEventDeliveries";
 import { ManagedAttachmentCleanupLive } from "./managedAttachmentCleanup";
 import { PullRequestServiceLive } from "./pullRequests/Layers/PullRequestService";
+import { WorkItemServiceLive } from "./workItems/Layers/WorkItemService";
 
 export { makeServerProviderLayer } from "./provider/runtimeLayer";
 
@@ -134,6 +135,10 @@ export function makeServerRuntimeServicesLayer() {
     Layer.provideMerge(ProjectPullRequestPinsLive),
     Layer.provideMerge(OrchestrationLayerLive),
   );
+  const workItemServiceLayer = WorkItemServiceLive.pipe(
+    Layer.provideMerge(GitLayerLive),
+    Layer.provideMerge(ServerSettingsLive),
+  );
 
   return Layer.mergeAll(
     automationServiceLayer,
@@ -143,6 +148,7 @@ export function makeServerRuntimeServicesLayer() {
     AutomationRepositoryLive,
     ProjectPullRequestPinsLive,
     pullRequestServiceLayer,
+    workItemServiceLayer,
     orchestrationReactorLayer,
     providerCommandReactorLayer,
     threadDeletionReactorLayer,

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -52,6 +52,7 @@ import { ManagedAttachmentCleanupLive } from "./managedAttachmentCleanup";
 import { PullRequestServiceLive } from "./pullRequests/Layers/PullRequestService";
 import { ProviderHealthLive } from "./provider/Layers/ProviderHealth";
 import { makeServerProviderLayer } from "./provider/runtimeLayer";
+import { WorkItemServiceLive } from "./workItems/Layers/WorkItemService";
 
 export { makeServerProviderLayer } from "./provider/runtimeLayer";
 
@@ -182,6 +183,10 @@ export function makeServerRuntimeServicesLayer(
     Layer.provideMerge(ProjectPullRequestPinsLive),
     Layer.provideMerge(OrchestrationLayerLive),
   );
+  const workItemServiceLayer = WorkItemServiceLive.pipe(
+    Layer.provideMerge(GitLayerLive),
+    Layer.provideMerge(ServerSettingsLive),
+  );
 
   return Layer.mergeAll(
     agentGatewayCredentialsLayer,
@@ -199,6 +204,7 @@ export function makeServerRuntimeServicesLayer(
     providerHealthLayer,
     ProjectPullRequestPinsLive,
     pullRequestServiceLayer,
+    workItemServiceLayer,
     orchestrationReactorLayer,
     providerCommandReactorLayer,
     threadDeletionReactorLayer,

--- a/apps/server/src/workItems/Layers/WorkItemService.ts
+++ b/apps/server/src/workItems/Layers/WorkItemService.ts
@@ -1,0 +1,520 @@
+// FILE: WorkItemService.ts
+// Purpose: Resolve Linear / GitHub issue / PR references for the composer picker.
+// Layer: Server service
+
+import {
+  WorkItemsUnavailableError,
+  type WorkItemAuthStatus,
+  type WorkItemReference,
+  type WorkItemSearchHit,
+  type WorkItemSource,
+  type WorkItemsAuthStatusResult,
+  type WorkItemsGetResult,
+  type WorkItemsSearchResult,
+} from "@synara/contracts";
+import { Effect, Layer } from "effect";
+
+import { GitHubCliError } from "../../git/Errors";
+import { GitHubCli } from "../../git/Services/GitHubCli";
+import { ServerSettingsService } from "../../serverSettings";
+import {
+  getLinearIssue,
+  LinearClientError,
+  linearIssueBodyPreview,
+  searchLinearIssues,
+  validateLinearApiKey,
+} from "../linearClient";
+import { WorkItemService } from "../Services/WorkItemService";
+
+const BODY_PREVIEW_MAX = 80;
+const BODY_MAX = 12_000;
+
+function truncateBody(body: string): string {
+  const normalized = body.replace(/\r\n/g, "\n").replace(/^\n+|\n+$/g, "");
+  return normalized.length <= BODY_MAX ? normalized : `${normalized.slice(0, BODY_MAX - 1)}…`;
+}
+
+function bodyPreview(body: string): string {
+  const normalized = body.replace(/\s+/g, " ").trim();
+  if (normalized.length === 0) return "";
+  return normalized.length > BODY_PREVIEW_MAX
+    ? `${normalized.slice(0, BODY_PREVIEW_MAX - 1)}…`
+    : normalized;
+}
+
+function parseGitHubUrl(raw: string): {
+  source: "github-issue" | "github-pr";
+  repository: string;
+  number: number;
+} | null {
+  let href = raw.trim();
+  if (!/^https?:\/\//i.test(href)) href = `https://${href.replace(/^\/+/, "")}`;
+  let parsed: URL;
+  try {
+    parsed = new URL(href);
+  } catch {
+    return null;
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (host !== "github.com" && host !== "www.github.com") return null;
+  const parts = parsed.pathname.split("/").filter(Boolean);
+  const [owner, repo, kind, numberRaw] = parts;
+  if (!owner || !repo || !numberRaw || !/^\d+$/.test(numberRaw)) return null;
+  const number = Number(numberRaw);
+  if (kind === "issues") {
+    return { source: "github-issue", repository: `${owner}/${repo}`, number };
+  }
+  if (kind === "pull") {
+    return { source: "github-pr", repository: `${owner}/${repo}`, number };
+  }
+  return null;
+}
+
+function parseLinearUrl(raw: string): { identifier: string } | null {
+  let href = raw.trim();
+  if (!/^https?:\/\//i.test(href)) href = `https://${href.replace(/^\/+/, "")}`;
+  let parsed: URL;
+  try {
+    parsed = new URL(href);
+  } catch {
+    return null;
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (host !== "linear.app" && !host.endsWith(".linear.app")) return null;
+  const parts = parsed.pathname.split("/").filter(Boolean);
+  const issueIndex = parts.findIndex((part) => part === "issue");
+  const identifier = issueIndex >= 0 ? parts[issueIndex + 1] : null;
+  if (!identifier || !/^[A-Za-z]+-\d+$/.test(identifier)) return null;
+  return { identifier: identifier.toUpperCase() };
+}
+
+function mapGitHubAuth(error: GitHubCliError): WorkItemAuthStatus {
+  if (error.reason === "not-installed") return "gh-not-installed";
+  if (error.reason === "not-authenticated") return "gh-not-authenticated";
+  return "unavailable";
+}
+
+function mapLinearAuth(error: LinearClientError): WorkItemAuthStatus {
+  if (error.reason === "missing-key") return "linear-key-missing";
+  if (error.reason === "invalid-key") return "linear-key-invalid";
+  return "unavailable";
+}
+
+function unavailable(authStatus: WorkItemAuthStatus, message: string): WorkItemsUnavailableError {
+  const reason =
+    authStatus === "ready" ? "unavailable" : (authStatus as WorkItemsUnavailableError["reason"]);
+  return new WorkItemsUnavailableError({ reason, message });
+}
+
+function requireRepository(
+  repository: string | null | undefined,
+): Effect.Effect<string, WorkItemsUnavailableError> {
+  const trimmed = repository?.trim() ?? "";
+  if (trimmed.length === 0) {
+    return Effect.fail(
+      unavailable(
+        "unavailable",
+        "Select a GitHub repository (open a project with a git remote) to browse issues and PRs.",
+      ),
+    );
+  }
+  return Effect.succeed(trimmed);
+}
+
+function emptySearch(authStatus: WorkItemAuthStatus, message: string): WorkItemsSearchResult {
+  return { items: [], authStatus, message };
+}
+
+function emptyGet(authStatus: WorkItemAuthStatus, message: string): WorkItemsGetResult {
+  return { item: null, authStatus, message };
+}
+
+function catchGitHubSearch(error: unknown): WorkItemsSearchResult {
+  if (error instanceof GitHubCliError) {
+    return emptySearch(mapGitHubAuth(error), error.detail);
+  }
+  return emptySearch(
+    "unavailable",
+    error instanceof Error ? error.message : "Failed to search GitHub work items.",
+  );
+}
+
+function catchGitHubGet(error: unknown): WorkItemsGetResult {
+  if (error instanceof GitHubCliError) {
+    return emptyGet(mapGitHubAuth(error), error.detail);
+  }
+  return emptyGet(
+    "unavailable",
+    error instanceof Error ? error.message : "Failed to load GitHub work item.",
+  );
+}
+
+function catchLinearSearch(error: unknown): WorkItemsSearchResult {
+  if (error instanceof LinearClientError) {
+    return emptySearch(mapLinearAuth(error), error.message);
+  }
+  return emptySearch(
+    "unavailable",
+    error instanceof Error ? error.message : "Failed to search Linear.",
+  );
+}
+
+function catchLinearGet(error: unknown): WorkItemsGetResult {
+  if (error instanceof LinearClientError) {
+    return emptyGet(mapLinearAuth(error), error.message);
+  }
+  return emptyGet(
+    "unavailable",
+    error instanceof Error ? error.message : "Failed to load Linear issue.",
+  );
+}
+
+export const WorkItemServiceLive = Layer.effect(
+  WorkItemService,
+  Effect.gen(function* () {
+    const github = yield* GitHubCli;
+    const serverSettings = yield* ServerSettingsService;
+
+    const readLinearApiKey = serverSettings.getSettings.pipe(
+      Effect.mapError((error) =>
+        unavailable("unavailable", error.message || "Failed to load settings."),
+      ),
+      Effect.map((settings) => settings.integrations.linearApiKey.trim()),
+    );
+
+    const githubAuthProbe = (cwd: string): Effect.Effect<WorkItemsAuthStatusResult> =>
+      github.getViewerLogin({ cwd }).pipe(
+        Effect.map(
+          (): WorkItemsAuthStatusResult => ({
+            provider: "github",
+            authStatus: "ready",
+            message: null,
+          }),
+        ),
+        Effect.catch((error) =>
+          Effect.succeed({
+            provider: "github" as const,
+            authStatus:
+              error instanceof GitHubCliError ? mapGitHubAuth(error) : ("unavailable" as const),
+            message:
+              error instanceof GitHubCliError
+                ? error.detail
+                : error instanceof Error
+                  ? error.message
+                  : "GitHub is unavailable.",
+          }),
+        ),
+      );
+
+    const linearAuthProbe = (): Effect.Effect<WorkItemsAuthStatusResult> =>
+      readLinearApiKey.pipe(
+        Effect.flatMap((apiKey) => {
+          if (apiKey.length === 0) {
+            return Effect.succeed({
+              provider: "linear" as const,
+              authStatus: "linear-key-missing" as const,
+              message: "Add a Linear API key in Settings to search issues.",
+            });
+          }
+          return Effect.tryPromise({
+            try: () => validateLinearApiKey(apiKey),
+            catch: (error) => error,
+          }).pipe(
+            Effect.map(
+              (): WorkItemsAuthStatusResult => ({
+                provider: "linear",
+                authStatus: "ready",
+                message: null,
+              }),
+            ),
+            Effect.catch((error) =>
+              Effect.succeed({
+                provider: "linear" as const,
+                authStatus:
+                  error instanceof LinearClientError
+                    ? mapLinearAuth(error)
+                    : ("unavailable" as const),
+                message:
+                  error instanceof Error ? error.message : "Linear is unavailable.",
+              }),
+            ),
+          );
+        }),
+      );
+
+    const searchGitHubIssues = (input: {
+      cwd: string;
+      repository: string;
+      query: string;
+      limit: number;
+    }): Effect.Effect<WorkItemsSearchResult> =>
+      github.listRepositoryIssues(input).pipe(
+        Effect.map(
+          (issues): WorkItemsSearchResult => ({
+            authStatus: "ready",
+            message: null,
+            items: issues.map(
+              (issue): WorkItemSearchHit => ({
+                source: "github-issue",
+                id: String(issue.number),
+                url: issue.url,
+                title: issue.title,
+                identifier: `#${issue.number}`,
+                bodyPreview: bodyPreview(issue.body),
+                repository: input.repository,
+              }),
+            ),
+          }),
+        ),
+        Effect.catch((error) => Effect.succeed(catchGitHubSearch(error))),
+      );
+
+    const searchGitHubPullRequests = (input: {
+      cwd: string;
+      repository: string;
+      query: string;
+      limit: number;
+    }): Effect.Effect<WorkItemsSearchResult> =>
+      github
+        .listRepositoryPullRequests({
+          cwd: input.cwd,
+          repository: input.repository,
+          state: "open",
+          involvement: "all",
+          viewer: "",
+          limit: input.limit,
+        })
+        .pipe(
+          Effect.map((batch): WorkItemsSearchResult => {
+            const query = input.query.trim().toLowerCase();
+            const entries = batch.entries.filter((entry) => {
+              if (query.length === 0) return true;
+              if (query.startsWith("#") && String(entry.number) === query.slice(1)) return true;
+              if (/^\d+$/.test(query) && String(entry.number) === query) return true;
+              return (
+                entry.title.toLowerCase().includes(query) ||
+                String(entry.number).includes(query) ||
+                entry.headBranch.toLowerCase().includes(query)
+              );
+            });
+            return {
+              authStatus: "ready",
+              message: null,
+              items: entries.map(
+                (entry): WorkItemSearchHit => ({
+                  source: "github-pr",
+                  id: String(entry.number),
+                  url: entry.url,
+                  title: entry.title,
+                  identifier: `#${entry.number}`,
+                  bodyPreview: "",
+                  repository: input.repository,
+                }),
+              ),
+            };
+          }),
+          Effect.catch((error) => Effect.succeed(catchGitHubSearch(error))),
+        );
+
+    const searchLinear = (input: {
+      query: string;
+      limit: number;
+    }): Effect.Effect<WorkItemsSearchResult> =>
+      readLinearApiKey.pipe(
+        Effect.flatMap((apiKey) => {
+          if (apiKey.length === 0) {
+            return Effect.succeed(
+              emptySearch(
+                "linear-key-missing",
+                "Add a Linear API key in Settings to search issues.",
+              ),
+            );
+          }
+          return Effect.tryPromise({
+            try: () =>
+              searchLinearIssues({
+                apiKey,
+                query: input.query,
+                limit: input.limit,
+              }),
+            catch: (error) => error,
+          }).pipe(
+            Effect.map(
+              (issues): WorkItemsSearchResult => ({
+                authStatus: "ready",
+                message: null,
+                items: issues.map(
+                  (issue): WorkItemSearchHit => ({
+                    source: "linear-issue",
+                    id: issue.id,
+                    url: issue.url,
+                    title: issue.title,
+                    identifier: issue.identifier,
+                    bodyPreview: linearIssueBodyPreview(issue),
+                    repository: null,
+                  }),
+                ),
+              }),
+            ),
+            Effect.catch((error) => Effect.succeed(catchLinearSearch(error))),
+          );
+        }),
+      );
+
+    const getGitHubIssue = (input: {
+      cwd: string;
+      repository: string;
+      number: number;
+    }): Effect.Effect<WorkItemsGetResult> =>
+      github.getIssue(input).pipe(
+        Effect.map(
+          (issue): WorkItemsGetResult => ({
+            authStatus: "ready",
+            message: null,
+            item: {
+              source: "github-issue",
+              id: String(issue.number),
+              url: issue.url,
+              title: issue.title,
+              identifier: `#${issue.number}`,
+              body: truncateBody(issue.body),
+              bodyPreview: bodyPreview(issue.body),
+              repository: input.repository,
+            } satisfies WorkItemReference,
+          }),
+        ),
+        Effect.catch((error) => Effect.succeed(catchGitHubGet(error))),
+      );
+
+    const getGitHubPullRequest = (input: {
+      cwd: string;
+      repository: string;
+      number: number;
+    }): Effect.Effect<WorkItemsGetResult> =>
+      github.getPullRequestDetail(input).pipe(
+        Effect.map(
+          (detail): WorkItemsGetResult => ({
+            authStatus: "ready",
+            message: null,
+            item: {
+              source: "github-pr",
+              id: String(detail.number),
+              url: detail.url,
+              title: detail.title,
+              identifier: `#${detail.number}`,
+              body: truncateBody(detail.body),
+              bodyPreview: bodyPreview(detail.body),
+              repository: input.repository,
+            } satisfies WorkItemReference,
+          }),
+        ),
+        Effect.catch((error) => Effect.succeed(catchGitHubGet(error))),
+      );
+
+    const getLinear = (reference: string): Effect.Effect<WorkItemsGetResult> =>
+      readLinearApiKey.pipe(
+        Effect.flatMap((apiKey) => {
+          if (apiKey.length === 0) {
+            return Effect.succeed(
+              emptyGet(
+                "linear-key-missing",
+                "Add a Linear API key in Settings to attach Linear issues.",
+              ),
+            );
+          }
+          return Effect.tryPromise({
+            try: () => getLinearIssue({ apiKey, reference }),
+            catch: (error) => error,
+          }).pipe(
+            Effect.map((issue): WorkItemsGetResult => {
+              if (!issue) {
+                return emptyGet("ready", `Linear issue not found: ${reference}`);
+              }
+              const body = truncateBody(issue.description ?? "");
+              return {
+                authStatus: "ready",
+                message: null,
+                item: {
+                  source: "linear-issue",
+                  id: issue.id,
+                  url: issue.url,
+                  title: issue.title,
+                  identifier: issue.identifier,
+                  body,
+                  bodyPreview: bodyPreview(body),
+                  repository: null,
+                },
+              };
+            }),
+            Effect.catch((error) => Effect.succeed(catchLinearGet(error))),
+          );
+        }),
+      );
+
+    return {
+      search: (input) => {
+        if (input.source === "linear-issue") {
+          return searchLinear({ query: input.query, limit: input.limit });
+        }
+        return requireRepository(input.repository).pipe(
+          Effect.flatMap((repository) =>
+            input.source === "github-issue"
+              ? searchGitHubIssues({
+                  cwd: input.cwd,
+                  repository,
+                  query: input.query,
+                  limit: input.limit,
+                })
+              : searchGitHubPullRequests({
+                  cwd: input.cwd,
+                  repository,
+                  query: input.query,
+                  limit: input.limit,
+                }),
+          ),
+        );
+      },
+      get: (input) => {
+        const reference = input.reference.trim();
+        const githubFromUrl = parseGitHubUrl(reference);
+        const linearFromUrl = parseLinearUrl(reference);
+
+        let source: WorkItemSource | null = input.source ?? null;
+        if (!source) {
+          if (githubFromUrl) source = githubFromUrl.source;
+          else if (linearFromUrl || /^[A-Za-z]+-\d+$/.test(reference)) source = "linear-issue";
+        }
+
+        if (!source) {
+          return Effect.succeed(
+            emptyGet(
+              "unavailable",
+              "Could not determine whether this reference is a GitHub or Linear work item.",
+            ),
+          );
+        }
+
+        if (source === "linear-issue") {
+          return getLinear(linearFromUrl?.identifier ?? reference);
+        }
+
+        const number = githubFromUrl?.number ?? (/^\d+$/.test(reference) ? Number(reference) : NaN);
+        if (!Number.isFinite(number) || number <= 0) {
+          return Effect.succeed(
+            emptyGet("unavailable", "Provide a GitHub issue/PR number or URL."),
+          );
+        }
+
+        return requireRepository(githubFromUrl?.repository ?? input.repository).pipe(
+          Effect.flatMap((repository) =>
+            source === "github-issue"
+              ? getGitHubIssue({ cwd: input.cwd, repository, number })
+              : getGitHubPullRequest({ cwd: input.cwd, repository, number }),
+          ),
+        );
+      },
+      authStatus: (input) =>
+        input.provider === "github" ? githubAuthProbe(input.cwd) : linearAuthProbe(),
+    };
+  }),
+);

--- a/apps/server/src/workItems/Services/WorkItemService.ts
+++ b/apps/server/src/workItems/Services/WorkItemService.ts
@@ -1,0 +1,30 @@
+/**
+ * WorkItemService - Fetch Linear / GitHub issues and PRs for composer references.
+ */
+import { ServiceMap } from "effect";
+import type { Effect } from "effect";
+import type {
+  WorkItemsAuthStatusInput,
+  WorkItemsAuthStatusResult,
+  WorkItemsGetInput,
+  WorkItemsGetResult,
+  WorkItemsSearchInput,
+  WorkItemsSearchResult,
+  WorkItemsUnavailableError,
+} from "@synara/contracts";
+
+export interface WorkItemServiceShape {
+  readonly search: (
+    input: WorkItemsSearchInput,
+  ) => Effect.Effect<WorkItemsSearchResult, WorkItemsUnavailableError>;
+  readonly get: (
+    input: WorkItemsGetInput,
+  ) => Effect.Effect<WorkItemsGetResult, WorkItemsUnavailableError>;
+  readonly authStatus: (
+    input: WorkItemsAuthStatusInput,
+  ) => Effect.Effect<WorkItemsAuthStatusResult, WorkItemsUnavailableError>;
+}
+
+export class WorkItemService extends ServiceMap.Service<WorkItemService, WorkItemServiceShape>()(
+  "synara/workItems/Services/WorkItemService",
+) {}

--- a/apps/server/src/workItems/WorkItemService.test.ts
+++ b/apps/server/src/workItems/WorkItemService.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+
+import { createGitHubCliWithFakeGh } from "../git/testing/fakeGitHubCli";
+import { GitHubCli } from "../git/Services/GitHubCli";
+import { ServerSettingsService } from "../serverSettings";
+import { WorkItemServiceLive } from "./Layers/WorkItemService";
+import { WorkItemService } from "./Services/WorkItemService";
+
+describe("WorkItemService", () => {
+  it.effect("lists GitHub issues from gh", () =>
+    Effect.gen(function* () {
+      const { service: github } = createGitHubCliWithFakeGh({
+        repositoryIssues: [
+          {
+            number: 12,
+            title: "Broken login",
+            url: "https://github.com/acme/app/issues/12",
+            body: "Cannot sign in",
+            state: "OPEN",
+            updatedAt: "2026-07-01T00:00:00Z",
+          },
+        ],
+      });
+
+      const layer = WorkItemServiceLive.pipe(
+        Layer.provide(Layer.succeed(GitHubCli, github)),
+        Layer.provide(ServerSettingsService.layerTest({})),
+      );
+
+      const result = yield* Effect.gen(function* () {
+        const workItems = yield* WorkItemService;
+        return yield* workItems.search({
+          cwd: "/tmp/repo",
+          repository: "acme/app",
+          source: "github-issue",
+          query: "",
+          limit: 20,
+        });
+      }).pipe(Effect.provide(layer));
+
+      expect(result.authStatus).toBe("ready");
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.identifier).toBe("#12");
+      expect(result.items[0]?.title).toBe("Broken login");
+    }),
+  );
+
+  it.effect("loads a pull request detail as a work item", () =>
+    Effect.gen(function* () {
+      const { service: github } = createGitHubCliWithFakeGh({
+        pullRequestDetail: {
+          number: 7,
+          title: "Add feature",
+          body: "Implements the feature",
+          url: "https://github.com/acme/app/pull/7",
+          author: null,
+          state: "open",
+          isDraft: false,
+          mergeable: "MERGEABLE",
+          mergeability: "mergeable",
+          mergeStateStatus: "CLEAN",
+          reviewDecision: null,
+          additions: 1,
+          deletions: 0,
+          changedFiles: 1,
+          headBranch: "feat",
+          baseBranch: "main",
+          createdAt: "2026-07-01T00:00:00Z",
+          updatedAt: "2026-07-01T00:00:00Z",
+          mergedAt: null,
+          closedAt: null,
+          maintainerCanModify: true,
+          reviewers: [],
+          labels: [],
+          checks: [],
+          comments: [],
+          commits: [],
+        },
+      });
+
+      const layer = WorkItemServiceLive.pipe(
+        Layer.provide(Layer.succeed(GitHubCli, github)),
+        Layer.provide(ServerSettingsService.layerTest({})),
+      );
+
+      const result = yield* Effect.gen(function* () {
+        const workItems = yield* WorkItemService;
+        return yield* workItems.get({
+          cwd: "/tmp/repo",
+          repository: "acme/app",
+          source: "github-pr",
+          reference: "7",
+        });
+      }).pipe(Effect.provide(layer));
+
+      expect(result.item?.source).toBe("github-pr");
+      expect(result.item?.identifier).toBe("#7");
+      expect(result.item?.body).toContain("Implements the feature");
+    }),
+  );
+
+  it.effect("reports missing Linear API key", () =>
+    Effect.gen(function* () {
+      const { service: github } = createGitHubCliWithFakeGh();
+      const layer = WorkItemServiceLive.pipe(
+        Layer.provide(Layer.succeed(GitHubCli, github)),
+        Layer.provide(ServerSettingsService.layerTest({ integrations: { linearApiKey: "" } })),
+      );
+
+      const result = yield* Effect.gen(function* () {
+        const workItems = yield* WorkItemService;
+        return yield* workItems.search({
+          cwd: "/tmp/repo",
+          repository: null,
+          source: "linear-issue",
+          query: "login",
+          limit: 10,
+        });
+      }).pipe(Effect.provide(layer));
+
+      expect(result.authStatus).toBe("linear-key-missing");
+      expect(result.items).toHaveLength(0);
+    }),
+  );
+});

--- a/apps/server/src/workItems/linearClient.test.ts
+++ b/apps/server/src/workItems/linearClient.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { LinearClientError, linearIssueBodyPreview } from "./linearClient";
+
+describe("linearClient helpers", () => {
+  it("formats body previews", () => {
+    expect(
+      linearIssueBodyPreview({
+        id: "1",
+        identifier: "ENG-1",
+        title: "Title",
+        description: "Hello   world\n\nmore",
+        url: "https://linear.app/x/issue/ENG-1",
+      }),
+    ).toBe("Hello world more");
+  });
+
+  it("exposes typed LinearClientError reasons", () => {
+    const error = new LinearClientError("missing-key", "missing");
+    expect(error.reason).toBe("missing-key");
+    expect(error.message).toBe("missing");
+  });
+});

--- a/apps/server/src/workItems/linearClient.ts
+++ b/apps/server/src/workItems/linearClient.ts
@@ -1,0 +1,210 @@
+// FILE: linearClient.ts
+// Purpose: Thin Linear GraphQL client for reading issues used as composer references.
+// Layer: Server integration
+
+import { Schema } from "effect";
+
+const LINEAR_API_URL = "https://api.linear.app/graphql";
+const BODY_PREVIEW_MAX = 80;
+
+const LinearIssueNodeSchema = Schema.Struct({
+  id: Schema.String,
+  identifier: Schema.String,
+  title: Schema.String,
+  description: Schema.NullOr(Schema.String),
+  url: Schema.String,
+});
+
+const LinearIssueConnectionSchema = Schema.Struct({
+  nodes: Schema.Array(LinearIssueNodeSchema),
+});
+
+const LinearSearchResponseSchema = Schema.Struct({
+  data: Schema.optionalKey(
+    Schema.Struct({
+      searchIssues: Schema.optionalKey(LinearIssueConnectionSchema),
+      issues: Schema.optionalKey(LinearIssueConnectionSchema),
+      issue: Schema.optionalKey(Schema.NullOr(LinearIssueNodeSchema)),
+      viewer: Schema.optionalKey(
+        Schema.Struct({
+          id: Schema.String,
+        }),
+      ),
+    }),
+  ),
+  errors: Schema.optionalKey(
+    Schema.Array(
+      Schema.Struct({
+        message: Schema.String,
+      }),
+    ),
+  ),
+});
+
+export type LinearIssueNode = typeof LinearIssueNodeSchema.Type;
+
+export class LinearClientError extends Error {
+  readonly reason: "missing-key" | "invalid-key" | "unavailable";
+
+  constructor(reason: LinearClientError["reason"], message: string) {
+    super(message);
+    this.name = "LinearClientError";
+    this.reason = reason;
+  }
+}
+
+function formatBodyPreview(description: string | null): string {
+  const normalized = (description ?? "").replace(/\s+/g, " ").trim();
+  if (normalized.length === 0) {
+    return "";
+  }
+  return normalized.length > BODY_PREVIEW_MAX
+    ? `${normalized.slice(0, BODY_PREVIEW_MAX - 1)}…`
+    : normalized;
+}
+
+async function linearGraphql(input: {
+  apiKey: string;
+  query: string;
+  variables?: Record<string, unknown>;
+}): Promise<typeof LinearSearchResponseSchema.Type> {
+  const apiKey = input.apiKey.trim();
+  if (apiKey.length === 0) {
+    throw new LinearClientError("missing-key", "Add a Linear API key in Settings to search issues.");
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(LINEAR_API_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: apiKey,
+      },
+      body: JSON.stringify({
+        query: input.query,
+        variables: input.variables ?? {},
+      }),
+    });
+  } catch (error) {
+    throw new LinearClientError(
+      "unavailable",
+      error instanceof Error ? `Linear request failed: ${error.message}` : "Linear request failed.",
+    );
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    throw new LinearClientError(
+      "invalid-key",
+      "Linear API key is invalid. Update it in Settings and try again.",
+    );
+  }
+
+  if (!response.ok) {
+    throw new LinearClientError(
+      "unavailable",
+      `Linear API returned HTTP ${response.status}.`,
+    );
+  }
+
+  const json: unknown = await response.json();
+  const decoded = Schema.decodeUnknownSync(LinearSearchResponseSchema)(json);
+  const firstError = decoded.errors?.[0]?.message;
+  if (firstError) {
+    const lower = firstError.toLowerCase();
+    if (lower.includes("authentication") || lower.includes("unauthorized")) {
+      throw new LinearClientError("invalid-key", firstError);
+    }
+    throw new LinearClientError("unavailable", firstError);
+  }
+  return decoded;
+}
+
+export async function validateLinearApiKey(apiKey: string): Promise<void> {
+  await linearGraphql({
+    apiKey,
+    query: `query { viewer { id } }`,
+  });
+}
+
+const ISSUE_FIELDS = `
+  id
+  identifier
+  title
+  description
+  url
+`;
+
+export async function searchLinearIssues(input: {
+  apiKey: string;
+  query: string;
+  limit: number;
+}): Promise<ReadonlyArray<LinearIssueNode>> {
+  const term = input.query.trim();
+  const first = Math.min(Math.max(input.limit, 1), 50);
+
+  if (term.length === 0) {
+    const decoded = await linearGraphql({
+      apiKey: input.apiKey,
+      query: `
+        query RecentIssues($first: Int!) {
+          issues(first: $first, orderBy: updatedAt) {
+            nodes { ${ISSUE_FIELDS} }
+          }
+        }
+      `,
+      variables: { first },
+    });
+    return decoded.data?.issues?.nodes ?? [];
+  }
+
+  const decoded = await linearGraphql({
+    apiKey: input.apiKey,
+    query: `
+      query SearchIssues($term: String!, $first: Int!) {
+        searchIssues(term: $term, first: $first) {
+          nodes { ${ISSUE_FIELDS} }
+        }
+      }
+    `,
+    variables: { term, first },
+  });
+  return decoded.data?.searchIssues?.nodes ?? [];
+}
+
+export async function getLinearIssue(input: {
+  apiKey: string;
+  reference: string;
+}): Promise<LinearIssueNode | null> {
+  const reference = input.reference.trim();
+  if (reference.length === 0) {
+    return null;
+  }
+
+  // Prefer direct issue(id); fall back to search for TEAM-123 identifiers.
+  const isIdentifier = /^[A-Za-z]+-\d+$/.test(reference);
+  const decoded = await linearGraphql({
+    apiKey: input.apiKey,
+    query: `
+      query IssueById($id: String!) {
+        issue(id: $id) { ${ISSUE_FIELDS} }
+      }
+    `,
+    variables: { id: reference },
+  });
+
+  const issue = decoded.data?.issue ?? null;
+  if (issue) return issue;
+
+  if (!isIdentifier) return null;
+  const hits = await searchLinearIssues({
+    apiKey: input.apiKey,
+    query: reference,
+    limit: 10,
+  });
+  return hits.find((hit) => hit.identifier.toUpperCase() === reference.toUpperCase()) ?? null;
+}
+
+export function linearIssueBodyPreview(issue: LinearIssueNode): string {
+  return formatBodyPreview(issue.description);
+}

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -13,6 +13,7 @@ import {
   WsFeatureRpcGroup,
   WsRpcError,
   PullRequestsUnavailableError,
+  WorkItemsUnavailableError,
   type GitActionProgressEvent,
   type OrchestrationCommand,
   type OrchestrationEvent,
@@ -105,6 +106,7 @@ import { bufferLiveUiStream, type LiveUiStreamDropReport } from "./wsStreamBackp
 import { makeCursorSafeSnapshotLiveStream } from "./wsSnapshotLiveStream";
 import { PullRequestService } from "./pullRequests/Services/PullRequestService";
 import { resolveGitHubRepository } from "./pullRequests/repositoryResolution";
+import { WorkItemService } from "./workItems/Services/WorkItemService";
 
 const MAX_DIAGNOSTIC_CHILD_PROCESSES = 80;
 const MAX_DIAGNOSTIC_ARGS_CHARS = 500;
@@ -287,6 +289,7 @@ const makeWsRpcHandlersLayer = () =>
       const providerCommandReactor = yield* ProviderCommandReactor;
       const path = yield* Path.Path;
       const pullRequests = yield* PullRequestService;
+      const workItems = yield* WorkItemService;
       const profileStatsQuery = yield* ProfileStatsQuery;
       const projectionReadModelQuery = yield* ProjectionSnapshotQuery;
       const providerAdapterRegistry = yield* ProviderAdapterRegistry;
@@ -949,6 +952,30 @@ const makeWsRpcHandlersLayer = () =>
           pullRequestsEffect(pullRequests.comment(input), "Could not post the comment"),
         [WS_METHODS.pullRequestsSetPinned]: (input) =>
           rpcEffect(pullRequests.setPinned(input), "Failed to update pull request pin"),
+        [WS_METHODS.workItemsSearch]: (input) =>
+          workItems.search(input).pipe(
+            Effect.mapError((cause) =>
+              cause instanceof WorkItemsUnavailableError
+                ? cause
+                : toWsRpcError(cause, "Failed to search work items"),
+            ),
+          ),
+        [WS_METHODS.workItemsGet]: (input) =>
+          workItems.get(input).pipe(
+            Effect.mapError((cause) =>
+              cause instanceof WorkItemsUnavailableError
+                ? cause
+                : toWsRpcError(cause, "Failed to load work item"),
+            ),
+          ),
+        [WS_METHODS.workItemsAuthStatus]: (input) =>
+          workItems.authStatus(input).pipe(
+            Effect.mapError((cause) =>
+              cause instanceof WorkItemsUnavailableError
+                ? cause
+                : toWsRpcError(cause, "Failed to check work item auth"),
+            ),
+          ),
         [WS_METHODS.gitListBranches]: (input) =>
           rpcEffect(git.listBranches(input), "Failed to list branches"),
         [WS_METHODS.gitCreateWorktree]: (input) =>

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -15,6 +15,7 @@ import {
   WsFeatureRpcGroup,
   WsRpcError,
   PullRequestsUnavailableError,
+  WorkItemsUnavailableError,
   type GitActionProgressEvent,
   type OrchestrationCommand,
   type OrchestrationEvent,
@@ -129,6 +130,7 @@ import { bufferLiveUiStream, type LiveUiStreamDropReport } from "./wsStreamBackp
 import { makeCursorSafeSnapshotLiveStream } from "./wsSnapshotLiveStream";
 import { PullRequestService } from "./pullRequests/Services/PullRequestService";
 import { resolveGitHubRepository } from "./pullRequests/repositoryResolution";
+import { WorkItemService } from "./workItems/Services/WorkItemService";
 
 export function canManageExternalMcp(role: "owner" | "client"): boolean {
   return role === "owner";
@@ -317,6 +319,7 @@ const makeWsRpcHandlersLayer = () =>
       const providerCommandReactor = yield* ProviderCommandReactor;
       const path = yield* Path.Path;
       const pullRequests = yield* PullRequestService;
+      const workItems = yield* WorkItemService;
       const profileStatsQuery = yield* ProfileStatsQuery;
       const projectionReadModelQuery = yield* ProjectionSnapshotQuery;
       const providerAdapterRegistry = yield* ProviderAdapterRegistry;
@@ -1171,6 +1174,30 @@ const makeWsRpcHandlersLayer = () =>
           pullRequestsEffect(pullRequests.comment(input), "Could not post the comment"),
         [WS_METHODS.pullRequestsSetPinned]: (input) =>
           rpcEffect(pullRequests.setPinned(input), "Failed to update pull request pin"),
+        [WS_METHODS.workItemsSearch]: (input) =>
+          workItems.search(input).pipe(
+            Effect.mapError((cause) =>
+              cause instanceof WorkItemsUnavailableError
+                ? cause
+                : toWsRpcError(cause, "Failed to search work items"),
+            ),
+          ),
+        [WS_METHODS.workItemsGet]: (input) =>
+          workItems.get(input).pipe(
+            Effect.mapError((cause) =>
+              cause instanceof WorkItemsUnavailableError
+                ? cause
+                : toWsRpcError(cause, "Failed to load work item"),
+            ),
+          ),
+        [WS_METHODS.workItemsAuthStatus]: (input) =>
+          workItems.authStatus(input).pipe(
+            Effect.mapError((cause) =>
+              cause instanceof WorkItemsUnavailableError
+                ? cause
+                : toWsRpcError(cause, "Failed to check work item auth"),
+            ),
+          ),
         [WS_METHODS.gitListBranches]: (input) =>
           rpcEffect(git.listBranches(input), "Failed to list branches"),
         [WS_METHODS.gitCreateWorktree]: (input) =>

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -16,6 +16,7 @@ export * from "./stats";
 export * from "./settings";
 export * from "./git";
 export * from "./pullRequests";
+export * from "./workItemReferences";
 export * from "./orchestration";
 export * from "./editor";
 export * from "./environment";

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -28,6 +28,7 @@ export * from "./stats";
 export * from "./settings";
 export * from "./git";
 export * from "./pullRequests";
+export * from "./workItemReferences";
 export * from "./orchestration";
 export * from "./editor";
 export * from "./environment";

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -85,6 +85,14 @@ import type {
   PullRequestsListResult,
 } from "./pullRequests";
 import type {
+  WorkItemsAuthStatusInput,
+  WorkItemsAuthStatusResult,
+  WorkItemsGetInput,
+  WorkItemsGetResult,
+  WorkItemsSearchInput,
+  WorkItemsSearchResult,
+} from "./workItemReferences";
+import type {
   ProjectCreateLocalFilePreviewGrantInput,
   ProjectCreateLocalFilePreviewGrantResult,
   ProjectDevServerEvent,
@@ -587,6 +595,11 @@ export interface NativeApi {
     action: (input: PullRequestActionInput) => Promise<PullRequestActionResult>;
     comment: (input: PullRequestCommentInput) => Promise<PullRequestActionResult>;
     setPinned: (input: PullRequestSetPinnedInput) => Promise<PullRequestSetPinnedResult>;
+  };
+  workItems: {
+    search: (input: WorkItemsSearchInput) => Promise<WorkItemsSearchResult>;
+    get: (input: WorkItemsGetInput) => Promise<WorkItemsGetResult>;
+    authStatus: (input: WorkItemsAuthStatusInput) => Promise<WorkItemsAuthStatusResult>;
   };
   contextMenu: {
     show: <T extends string>(

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -97,6 +97,14 @@ import type {
   PullRequestsListResult,
 } from "./pullRequests";
 import type {
+  WorkItemsAuthStatusInput,
+  WorkItemsAuthStatusResult,
+  WorkItemsGetInput,
+  WorkItemsGetResult,
+  WorkItemsSearchInput,
+  WorkItemsSearchResult,
+} from "./workItemReferences";
+import type {
   ProjectCreateLocalFilePreviewGrantInput,
   ProjectCreateLocalFilePreviewGrantResult,
   ProjectDevServerEvent,
@@ -638,6 +646,11 @@ export interface NativeApi {
     action: (input: PullRequestActionInput) => Promise<PullRequestActionResult>;
     comment: (input: PullRequestCommentInput) => Promise<PullRequestActionResult>;
     setPinned: (input: PullRequestSetPinnedInput) => Promise<PullRequestSetPinnedResult>;
+  };
+  workItems: {
+    search: (input: WorkItemsSearchInput) => Promise<WorkItemsSearchResult>;
+    get: (input: WorkItemsGetInput) => Promise<WorkItemsGetResult>;
+    authStatus: (input: WorkItemsAuthStatusInput) => Promise<WorkItemsAuthStatusResult>;
   };
   contextMenu: {
     show: <T extends string>(

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -77,6 +77,15 @@ import {
   PullRequestsListResult,
   PullRequestsUnavailableError,
 } from "./pullRequests";
+import {
+  WorkItemsAuthStatusInput,
+  WorkItemsAuthStatusResult,
+  WorkItemsGetInput,
+  WorkItemsGetResult,
+  WorkItemsSearchInput,
+  WorkItemsSearchResult,
+  WorkItemsUnavailableError,
+} from "./workItemReferences";
 import { KeybindingRule } from "./keybindings";
 import {
   ClientOrchestrationCommand,
@@ -510,6 +519,26 @@ export const WsPullRequestsSetPinnedRpc = Rpc.make(WS_METHODS.pullRequestsSetPin
   payload: PullRequestSetPinnedInput,
   success: PullRequestSetPinnedResult,
   error: WsRpcError,
+});
+
+const WorkItemsRpcError = Schema.Union([WorkItemsUnavailableError, WsRpcError]);
+
+export const WsWorkItemsSearchRpc = Rpc.make(WS_METHODS.workItemsSearch, {
+  payload: WorkItemsSearchInput,
+  success: WorkItemsSearchResult,
+  error: WorkItemsRpcError,
+});
+
+export const WsWorkItemsGetRpc = Rpc.make(WS_METHODS.workItemsGet, {
+  payload: WorkItemsGetInput,
+  success: WorkItemsGetResult,
+  error: WorkItemsRpcError,
+});
+
+export const WsWorkItemsAuthStatusRpc = Rpc.make(WS_METHODS.workItemsAuthStatus, {
+  payload: WorkItemsAuthStatusInput,
+  success: WorkItemsAuthStatusResult,
+  error: WorkItemsRpcError,
 });
 
 export const WsGitListBranchesRpc = Rpc.make(WS_METHODS.gitListBranches, {
@@ -950,6 +979,9 @@ export const WsFeatureRpcGroup = RpcGroup.make(
   WsPullRequestsActionRpc,
   WsPullRequestsCommentRpc,
   WsPullRequestsSetPinnedRpc,
+  WsWorkItemsSearchRpc,
+  WsWorkItemsGetRpc,
+  WsWorkItemsAuthStatusRpc,
   WsGitListBranchesRpc,
   WsGitCreateWorktreeRpc,
   WsGitCreateDetachedWorktreeRpc,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -89,6 +89,15 @@ import {
   PullRequestsListResult,
   PullRequestsUnavailableError,
 } from "./pullRequests";
+import {
+  WorkItemsAuthStatusInput,
+  WorkItemsAuthStatusResult,
+  WorkItemsGetInput,
+  WorkItemsGetResult,
+  WorkItemsSearchInput,
+  WorkItemsSearchResult,
+  WorkItemsUnavailableError,
+} from "./workItemReferences";
 import { KeybindingRule } from "./keybindings";
 import {
   ClientOrchestrationCommand,
@@ -537,6 +546,26 @@ export const WsPullRequestsSetPinnedRpc = Rpc.make(WS_METHODS.pullRequestsSetPin
   payload: PullRequestSetPinnedInput,
   success: PullRequestSetPinnedResult,
   error: WsRpcError,
+});
+
+const WorkItemsRpcError = Schema.Union([WorkItemsUnavailableError, WsRpcError]);
+
+export const WsWorkItemsSearchRpc = Rpc.make(WS_METHODS.workItemsSearch, {
+  payload: WorkItemsSearchInput,
+  success: WorkItemsSearchResult,
+  error: WorkItemsRpcError,
+});
+
+export const WsWorkItemsGetRpc = Rpc.make(WS_METHODS.workItemsGet, {
+  payload: WorkItemsGetInput,
+  success: WorkItemsGetResult,
+  error: WorkItemsRpcError,
+});
+
+export const WsWorkItemsAuthStatusRpc = Rpc.make(WS_METHODS.workItemsAuthStatus, {
+  payload: WorkItemsAuthStatusInput,
+  success: WorkItemsAuthStatusResult,
+  error: WorkItemsRpcError,
 });
 
 export const WsGitListBranchesRpc = Rpc.make(WS_METHODS.gitListBranches, {
@@ -1027,6 +1056,9 @@ export const WsFeatureRpcGroup = RpcGroup.make(
   WsPullRequestsActionRpc,
   WsPullRequestsCommentRpc,
   WsPullRequestsSetPinnedRpc,
+  WsWorkItemsSearchRpc,
+  WsWorkItemsGetRpc,
+  WsWorkItemsAuthStatusRpc,
   WsGitListBranchesRpc,
   WsGitCreateWorktreeRpc,
   WsGitCreateDetachedWorktreeRpc,

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -90,6 +90,12 @@ export const SkillsServerSettings = Schema.Struct({
 });
 export type SkillsServerSettings = typeof SkillsServerSettings.Type;
 
+/** Third-party integrations used by composer work-item references (Linear, etc.). */
+export const IntegrationsServerSettings = Schema.Struct({
+  linearApiKey: StringSetting.pipe(Schema.withDecodingDefault(() => "")),
+});
+export type IntegrationsServerSettings = typeof IntegrationsServerSettings.Type;
+
 export const ServerSettings = Schema.Struct({
   enableAssistantStreaming: Schema.Boolean.pipe(Schema.withDecodingDefault(() => true)),
   enableProviderUpdateChecks: Schema.Boolean.pipe(Schema.withDecodingDefault(() => true)),
@@ -113,6 +119,7 @@ export const ServerSettings = Schema.Struct({
     pi: PiServerProviderSettings.pipe(Schema.withDecodingDefault(() => ({}))),
   }).pipe(Schema.withDecodingDefault(() => ({}))),
   skills: SkillsServerSettings.pipe(Schema.withDecodingDefault(() => ({}))),
+  integrations: IntegrationsServerSettings.pipe(Schema.withDecodingDefault(() => ({}))),
 });
 export type ServerSettings = typeof ServerSettings.Type;
 
@@ -195,6 +202,11 @@ export const ServerSettingsPatch = Schema.Struct({
   skills: Schema.optionalKey(
     Schema.Struct({
       disabled: Schema.optionalKey(Schema.Array(Schema.String.check(Schema.isMaxLength(256)))),
+    }),
+  ),
+  integrations: Schema.optionalKey(
+    Schema.Struct({
+      linearApiKey: Schema.optionalKey(StringSetting),
     }),
   ),
 });

--- a/packages/contracts/src/workItemReferences.ts
+++ b/packages/contracts/src/workItemReferences.ts
@@ -1,0 +1,103 @@
+import { Schema } from "effect";
+
+import { PositiveInt, TrimmedNonEmptyString, TrimmedString } from "./baseSchemas";
+
+export const WorkItemSource = Schema.Literals(["github-issue", "github-pr", "linear-issue"]);
+export type WorkItemSource = typeof WorkItemSource.Type;
+
+export const WorkItemAuthProvider = Schema.Literals(["github", "linear"]);
+export type WorkItemAuthProvider = typeof WorkItemAuthProvider.Type;
+
+export const WorkItemAuthStatus = Schema.Literals([
+  "ready",
+  "gh-not-installed",
+  "gh-not-authenticated",
+  "linear-key-missing",
+  "linear-key-invalid",
+  "unavailable",
+]);
+export type WorkItemAuthStatus = typeof WorkItemAuthStatus.Type;
+
+/** Full work-item payload attached to a composer draft and injected into the prompt. */
+export const WorkItemReference = Schema.Struct({
+  source: WorkItemSource,
+  id: TrimmedNonEmptyString,
+  url: TrimmedNonEmptyString,
+  title: TrimmedNonEmptyString,
+  identifier: TrimmedNonEmptyString,
+  body: Schema.String,
+  bodyPreview: TrimmedString,
+  repository: Schema.NullOr(TrimmedNonEmptyString),
+});
+export type WorkItemReference = typeof WorkItemReference.Type;
+
+/** Compact list row shown in the reference picker before a full fetch. */
+export const WorkItemSearchHit = Schema.Struct({
+  source: WorkItemSource,
+  id: TrimmedNonEmptyString,
+  url: TrimmedNonEmptyString,
+  title: TrimmedNonEmptyString,
+  identifier: TrimmedNonEmptyString,
+  bodyPreview: TrimmedString,
+  repository: Schema.NullOr(TrimmedNonEmptyString),
+});
+export type WorkItemSearchHit = typeof WorkItemSearchHit.Type;
+
+export const WorkItemsSearchInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+  repository: Schema.NullOr(TrimmedNonEmptyString),
+  source: WorkItemSource,
+  query: TrimmedString.pipe(Schema.withDecodingDefault(() => "")),
+  limit: PositiveInt.pipe(Schema.withDecodingDefault(() => 20)),
+});
+export type WorkItemsSearchInput = typeof WorkItemsSearchInput.Type;
+
+export const WorkItemsSearchResult = Schema.Struct({
+  items: Schema.Array(WorkItemSearchHit),
+  authStatus: WorkItemAuthStatus,
+  message: Schema.NullOr(Schema.String),
+});
+export type WorkItemsSearchResult = typeof WorkItemsSearchResult.Type;
+
+export const WorkItemsGetInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+  repository: Schema.NullOr(TrimmedNonEmptyString),
+  source: Schema.optionalKey(WorkItemSource),
+  /** Stable id (issue number, PR number, Linear UUID/identifier) or a full URL. */
+  reference: TrimmedNonEmptyString,
+});
+export type WorkItemsGetInput = typeof WorkItemsGetInput.Type;
+
+export const WorkItemsGetResult = Schema.Struct({
+  item: Schema.NullOr(WorkItemReference),
+  authStatus: WorkItemAuthStatus,
+  message: Schema.NullOr(Schema.String),
+});
+export type WorkItemsGetResult = typeof WorkItemsGetResult.Type;
+
+export const WorkItemsAuthStatusInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+  provider: WorkItemAuthProvider,
+});
+export type WorkItemsAuthStatusInput = typeof WorkItemsAuthStatusInput.Type;
+
+export const WorkItemsAuthStatusResult = Schema.Struct({
+  provider: WorkItemAuthProvider,
+  authStatus: WorkItemAuthStatus,
+  message: Schema.NullOr(Schema.String),
+});
+export type WorkItemsAuthStatusResult = typeof WorkItemsAuthStatusResult.Type;
+
+export class WorkItemsUnavailableError extends Schema.TaggedErrorClass<WorkItemsUnavailableError>()(
+  "WorkItemsUnavailableError",
+  {
+    reason: Schema.Literals([
+      "gh-not-installed",
+      "gh-not-authenticated",
+      "linear-key-missing",
+      "linear-key-invalid",
+      "unavailable",
+    ]),
+    message: Schema.String,
+  },
+) {}

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -117,6 +117,11 @@ import {
   PullRequestSetPinnedInput,
   PullRequestsListInput,
 } from "./pullRequests";
+import {
+  WorkItemsAuthStatusInput,
+  WorkItemsGetInput,
+  WorkItemsSearchInput,
+} from "./workItemReferences";
 
 // ── WebSocket RPC Method Names ───────────────────────────────────────
 
@@ -176,6 +181,11 @@ export const WS_METHODS = {
   pullRequestsAction: "pullRequests.action",
   pullRequestsComment: "pullRequests.comment",
   pullRequestsSetPinned: "pullRequests.setPinned",
+
+  // Composer work-item references (Linear / GitHub issue / PR)
+  workItemsSearch: "workItems.search",
+  workItemsGet: "workItems.get",
+  workItemsAuthStatus: "workItems.authStatus",
 
   // Terminal methods
   terminalOpen: "terminal.open",
@@ -339,6 +349,11 @@ const WebSocketRequestBody = Schema.Union([
   tagRequestBody(WS_METHODS.pullRequestsAction, PullRequestActionInput),
   tagRequestBody(WS_METHODS.pullRequestsComment, PullRequestCommentInput),
   tagRequestBody(WS_METHODS.pullRequestsSetPinned, PullRequestSetPinnedInput),
+
+  // Composer work-item references
+  tagRequestBody(WS_METHODS.workItemsSearch, WorkItemsSearchInput),
+  tagRequestBody(WS_METHODS.workItemsGet, WorkItemsGetInput),
+  tagRequestBody(WS_METHODS.workItemsAuthStatus, WorkItemsAuthStatusInput),
 
   // Terminal methods
   tagRequestBody(WS_METHODS.terminalOpen, TerminalOpenInput),

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -125,6 +125,11 @@ import {
   ExternalMcpRefreshPairingInput,
   ExternalMcpRevokeIntegrationInput,
 } from "./externalMcp";
+import {
+  WorkItemsAuthStatusInput,
+  WorkItemsGetInput,
+  WorkItemsSearchInput,
+} from "./workItemReferences";
 
 // ── WebSocket RPC Method Names ───────────────────────────────────────
 
@@ -185,6 +190,11 @@ export const WS_METHODS = {
   pullRequestsAction: "pullRequests.action",
   pullRequestsComment: "pullRequests.comment",
   pullRequestsSetPinned: "pullRequests.setPinned",
+
+  // Composer work-item references (Linear / GitHub issue / PR)
+  workItemsSearch: "workItems.search",
+  workItemsGet: "workItems.get",
+  workItemsAuthStatus: "workItems.authStatus",
 
   // Terminal methods
   terminalOpen: "terminal.open",
@@ -359,6 +369,11 @@ const WebSocketRequestBody = Schema.Union([
   tagRequestBody(WS_METHODS.pullRequestsAction, PullRequestActionInput),
   tagRequestBody(WS_METHODS.pullRequestsComment, PullRequestCommentInput),
   tagRequestBody(WS_METHODS.pullRequestsSetPinned, PullRequestSetPinnedInput),
+
+  // Composer work-item references
+  tagRequestBody(WS_METHODS.workItemsSearch, WorkItemsSearchInput),
+  tagRequestBody(WS_METHODS.workItemsGet, WorkItemsGetInput),
+  tagRequestBody(WS_METHODS.workItemsAuthStatus, WorkItemsAuthStatusInput),
 
   // Terminal methods
   tagRequestBody(WS_METHODS.terminalOpen, TerminalOpenInput),


### PR DESCRIPTION
<!--
Stacked contribution for #422 (part 1 of 2).
Backend/contracts only — no UI in this PR.
A follow-up PR adds the composer picker, chips, prompt expansion, and Settings UI.
-->

## What Changed

Adds a tightly scoped **work-item reference fetch** path so Synara can resolve ticket context for the composer (UI lands in the stacked follow-up):

- Contracts for `WorkItemReference` / search hits plus RPCs:
  - `workItems.search`
  - `workItems.get`
  - `workItems.authStatus`
- GitHub issue list/view helpers on the existing `gh` CLI layer (reuses current GitHub auth; no new PAT UI)
- Linear read client using an optional personal API key stored in `serverSettings.integrations.linearApiKey`
- `WorkItemService` wired into server layers + WS RPC handlers
- Focused unit tests for GitHub search/get and Linear missing-key behavior

**Out of scope here (follow-up PR):** composer picker/chips, prompt expansion, Settings UI, screenshots.

## Why

Copy/pasting Linear/GitHub ticket text into chats is lossy and slow. This PR only adds the server capability to resolve those references. It deliberately avoids an Issues sidebar, worktree-from-ticket flows, Linear OAuth, or writeback.

Tracked in #422.

## UI Changes

None in this PR (server/contracts only). UI + before/after screenshots are in the stacked follow-up.

## Checklist

- [x] This PR is small and focused *(backend-only slice of #422; UI split out)*
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes *(N/A — no UI)*
- [x] I included a video for animation/interaction changes *(N/A)*

## Test plan

- [x] `cd apps/server && bun run test src/workItems/WorkItemService.test.ts src/workItems/linearClient.test.ts`
- [ ] With `gh` authenticated, call `workItems.search` / `workItems.get` for a repo issue (via follow-up UI or RPC client)
- [ ] With no Linear key, `workItems.authStatus({ provider: "linear" })` reports `linear-key-missing`
- [ ] Existing pull-request / git flows still work (`gh` helpers remain additive)


Made with [Cursor](https://cursor.com)