### PR TITLE
fix(terminal): replay cold restores at recovered grid

### DIFF
--- a/apps/server/src/terminal/Layers/Manager.test.ts
+++ b/apps/server/src/terminal/Layers/Manager.test.ts
@@ -24,6 +24,10 @@ import {
 } from "./Manager";
 import type { ProcessTreeKiller } from "../processTreeKiller";
 import { Effect, Encoding } from "effect";
+import {
+  createTerminalHistoryMetadata,
+  terminalHistoryMetadataPath,
+} from "../terminalHistoryRecord";
 
 class FakePtyProcess implements PtyProcess {
   readonly writes: string[] = [];
@@ -419,6 +423,9 @@ describe("TerminalManager", () => {
     await waitFor(() => fs.existsSync(historyLogPath(logsDir)));
     await manager.clear({ threadId: "thread-1" });
     await waitFor(() => fs.readFileSync(historyLogPath(logsDir), "utf8") === "");
+    expect(
+      JSON.parse(fs.readFileSync(terminalHistoryMetadataPath(historyLogPath(logsDir)), "utf8")),
+    ).toEqual(createTerminalHistoryMetadata("", 100, 24));
 
     expect(events.some((event) => event.type === "cleared")).toBe(true);
     expect(
@@ -444,6 +451,7 @@ describe("TerminalManager", () => {
 
       expect(fs.statSync(logsDir).mode & 0o777).toBe(0o700);
       expect(fs.statSync(historyPath).mode & 0o777).toBe(0o600);
+      expect(fs.statSync(terminalHistoryMetadataPath(historyPath)).mode & 0o777).toBe(0o600);
 
       manager.dispose();
     },
@@ -466,6 +474,133 @@ describe("TerminalManager", () => {
       manager.dispose();
     },
   );
+
+  it("restores validated source dimensions and identity through open snapshots", async () => {
+    const history = "recovered history\n";
+    const { manager } = makeManager(5, {
+      prepareLogs: (directory) => {
+        const historyPath = historyLogPath(directory);
+        fs.writeFileSync(historyPath, history);
+        fs.writeFileSync(
+          terminalHistoryMetadataPath(historyPath),
+          JSON.stringify(createTerminalHistoryMetadata(history, 77, 19)),
+        );
+      },
+    });
+    const snapshot = await manager.open(openInput({ cols: 120, rows: 30 }));
+    expect(snapshot.history).toBe(history);
+    expect(snapshot.recoveredCols).toBe(77);
+    expect(snapshot.recoveredRows).toBe(19);
+    expect(snapshot.historyRecordIdentity).toBe(
+      createTerminalHistoryMetadata(history, 77, 19).recordIdentity,
+    );
+    manager.dispose();
+  });
+
+  it("invalidates recovered dimensions after live output and reopens updated history dimensionless", async () => {
+    const recoveredHistory = "recovered history\n";
+    const liveOutput = "live after recovery\n";
+    const { manager, ptyAdapter, logsDir } = makeManager(5, {
+      prepareLogs: (directory) => {
+        const historyPath = historyLogPath(directory);
+        fs.writeFileSync(historyPath, recoveredHistory);
+        fs.writeFileSync(
+          terminalHistoryMetadataPath(historyPath),
+          JSON.stringify(createTerminalHistoryMetadata(recoveredHistory, 77, 19)),
+        );
+      },
+    });
+    const events: TerminalEvent[] = [];
+    manager.on("event", (event) => events.push(event));
+
+    const initialSnapshot = await manager.open(openInput({ cols: 120, rows: 30 }));
+    expect(initialSnapshot.history).toBe(recoveredHistory);
+    expect(initialSnapshot.recoveredCols).toBe(77);
+    expect(initialSnapshot.recoveredRows).toBe(19);
+    expect(initialSnapshot.historyRecordIdentity).toBeTypeOf("string");
+
+    const process = ptyAdapter.processes[0];
+    expect(process).toBeDefined();
+    if (!process) return;
+    process.emitData(liveOutput);
+    await waitFor(() =>
+      events.some((event) => event.type === "output" && event.data === liveOutput),
+    );
+    const expectedHistory = `${recoveredHistory}${liveOutput}`;
+    await waitFor(() => fs.readFileSync(historyLogPath(logsDir), "utf8") === expectedHistory);
+
+    const reopenedSnapshot = await manager.open(openInput({ cols: 120, rows: 30 }));
+    expect(reopenedSnapshot.history).toBe(expectedHistory);
+    expect(reopenedSnapshot.recoveredCols).toBeUndefined();
+    expect(reopenedSnapshot.recoveredRows).toBeUndefined();
+    expect(reopenedSnapshot.historyRecordIdentity).toBeUndefined();
+
+    manager.dispose();
+  });
+
+  it("persists reattach dimensions-only changes with a new record identity", async () => {
+    const { manager, ptyAdapter, logsDir } = makeManager();
+    await manager.open(openInput({ cols: 100, rows: 24 }));
+    ptyAdapter.processes[0]?.emitData("same bytes\n");
+    const metadataPath = terminalHistoryMetadataPath(historyLogPath(logsDir));
+    await waitFor(() => fs.existsSync(metadataPath));
+    const first = JSON.parse(fs.readFileSync(metadataPath, "utf8")) as {
+      recordIdentity: string;
+    };
+    await manager.open(openInput({ cols: 120, rows: 40 }));
+    await waitFor(() => {
+      const current = JSON.parse(fs.readFileSync(metadataPath, "utf8")) as {
+        cols: number;
+        recordIdentity: string;
+      };
+      return current.cols === 120 && current.recordIdentity !== first.recordIdentity;
+    });
+    manager.dispose();
+  });
+
+  it("rewrites normalized legacy bytes and hashes the exact capped source", async () => {
+    const raw = "drop\nkeep-1\n\u001b[2Jkeep-2\n";
+    const expected = "keep-1\nkeep-2\n";
+    const { manager, logsDir } = makeManager(2, {
+      prepareLogs: (directory) => {
+        const historyPath = historyLogPath(directory);
+        fs.writeFileSync(historyPath, raw);
+        fs.writeFileSync(
+          terminalHistoryMetadataPath(historyPath),
+          JSON.stringify(createTerminalHistoryMetadata(raw, 77, 19)),
+        );
+      },
+    });
+
+    const snapshot = await manager.open(openInput());
+    const historyPath = historyLogPath(logsDir);
+    const metadataPath = terminalHistoryMetadataPath(historyPath);
+    expect(snapshot.history).toBe(expected);
+    expect(snapshot.recoveredCols).toBeUndefined();
+    expect(snapshot.recoveredRows).toBeUndefined();
+    expect(snapshot.historyRecordIdentity).toBeUndefined();
+    expect(fs.readFileSync(historyPath, "utf8")).toBe(expected);
+    expect(fs.existsSync(metadataPath)).toBe(false);
+
+    await manager.resize({ threadId: "thread-1", cols: 100, rows: 24 });
+    await waitFor(() => fs.existsSync(metadataPath));
+    expect(fs.readFileSync(historyPath, "utf8")).toBe(expected);
+    expect(JSON.parse(fs.readFileSync(metadataPath, "utf8"))).toEqual(
+      createTerminalHistoryMetadata(expected, 100, 24),
+    );
+    manager.dispose();
+  });
+
+  it("removes sidecar and history when close deletes history", async () => {
+    const { manager, ptyAdapter, logsDir } = makeManager();
+    await manager.open(openInput());
+    ptyAdapter.processes[0]?.emitData("delete me\n");
+    const historyPath = historyLogPath(logsDir);
+    await waitFor(() => fs.existsSync(terminalHistoryMetadataPath(historyPath)));
+    await manager.close({ threadId: "thread-1", deleteHistory: true });
+    expect(fs.existsSync(terminalHistoryMetadataPath(historyPath))).toBe(false);
+    expect(fs.existsSync(historyPath)).toBe(false);
+  });
 
   it("keeps pty reads paused until renderer output ACKs drain", async () => {
     const { manager, ptyAdapter } = makeManager();
@@ -952,16 +1087,60 @@ describe("TerminalManager", () => {
 
     defaultProcess.emitData("default\n");
     sidecarProcess.emitData("sidecar\n");
-    await waitFor(() => fs.existsSync(multiTerminalHistoryLogPath(logsDir, "thread-1", "default")));
-    await waitFor(() => fs.existsSync(multiTerminalHistoryLogPath(logsDir, "thread-1", "sidecar")));
+    const defaultHistoryPath = multiTerminalHistoryLogPath(logsDir, "thread-1", "default");
+    const sidecarHistoryPath = multiTerminalHistoryLogPath(logsDir, "thread-1", "sidecar");
+    await waitFor(() => fs.existsSync(defaultHistoryPath));
+    await waitFor(() => fs.existsSync(sidecarHistoryPath));
+    expect(fs.existsSync(terminalHistoryMetadataPath(defaultHistoryPath))).toBe(true);
+    expect(fs.existsSync(terminalHistoryMetadataPath(sidecarHistoryPath))).toBe(true);
 
     await manager.close({ threadId: "thread-1", deleteHistory: true });
 
     expect(defaultProcess.killed).toBe(true);
     expect(sidecarProcess.killed).toBe(true);
-    expect(fs.existsSync(multiTerminalHistoryLogPath(logsDir, "thread-1", "default"))).toBe(false);
-    expect(fs.existsSync(multiTerminalHistoryLogPath(logsDir, "thread-1", "sidecar"))).toBe(false);
+    expect(fs.existsSync(defaultHistoryPath)).toBe(false);
+    expect(fs.existsSync(sidecarHistoryPath)).toBe(false);
+    expect(fs.existsSync(terminalHistoryMetadataPath(defaultHistoryPath))).toBe(false);
+    expect(fs.existsSync(terminalHistoryMetadataPath(sidecarHistoryPath))).toBe(false);
 
+    manager.dispose();
+  });
+
+  it("deletes orphaned thread metadata temporaries without touching adjacent artifacts", async () => {
+    const { manager, logsDir } = makeManager();
+    const ownedHistoryPath = multiTerminalHistoryLogPath(logsDir, "thread-1", "sidecar");
+    const ownedMetadataTemp = `${terminalHistoryMetadataPath(ownedHistoryPath)}.tmp-4100-7`;
+    const adjacentMetadataTemp = `${terminalHistoryMetadataPath(
+      multiTerminalHistoryLogPath(logsDir, "thread-10", "sidecar"),
+    )}.tmp-4100-7`;
+    const unknownSuffix = `${terminalHistoryMetadataPath(ownedHistoryPath)}.tmp-4100-7.keep`;
+    fs.writeFileSync(ownedMetadataTemp, "orphaned metadata");
+    fs.writeFileSync(adjacentMetadataTemp, "adjacent thread");
+    fs.writeFileSync(unknownSuffix, "unknown transaction suffix");
+
+    await manager.close({ threadId: "thread-1", deleteHistory: true });
+
+    expect(fs.existsSync(ownedMetadataTemp)).toBe(false);
+    expect(fs.readFileSync(adjacentMetadataTemp, "utf8")).toBe("adjacent thread");
+    expect(fs.readFileSync(unknownSuffix, "utf8")).toBe("unknown transaction suffix");
+    manager.dispose();
+  });
+
+  it("deletes orphaned thread history temporaries without touching adjacent artifacts", async () => {
+    const { manager, logsDir } = makeManager();
+    const ownedHistoryPath = historyLogPath(logsDir, "thread-1");
+    const ownedHistoryTemp = `${ownedHistoryPath}.tmp-4200-8`;
+    const adjacentHistoryTemp = `${historyLogPath(logsDir, "thread-10")}.tmp-4200-8`;
+    const unknownSuffix = `${ownedHistoryPath}.tmp-manual`;
+    fs.writeFileSync(ownedHistoryTemp, "orphaned history");
+    fs.writeFileSync(adjacentHistoryTemp, "adjacent thread");
+    fs.writeFileSync(unknownSuffix, "unknown transaction suffix");
+
+    await manager.close({ threadId: "thread-1", deleteHistory: true });
+
+    expect(fs.existsSync(ownedHistoryTemp)).toBe(false);
+    expect(fs.readFileSync(adjacentHistoryTemp, "utf8")).toBe("adjacent thread");
+    expect(fs.readFileSync(unknownSuffix, "utf8")).toBe("unknown transaction suffix");
     manager.dispose();
   });
 
@@ -1092,8 +1271,12 @@ describe("TerminalManager", () => {
     const snapshot = await manager.open(openInput());
 
     expect(snapshot.history).toBe("legacy-line\n");
+    expect(snapshot.recoveredCols).toBeUndefined();
+    expect(snapshot.recoveredRows).toBeUndefined();
+    expect(snapshot.historyRecordIdentity).toBeUndefined();
     expect(fs.existsSync(nextPath)).toBe(true);
     expect(fs.readFileSync(nextPath, "utf8")).toBe("legacy-line\n");
+    expect(fs.existsSync(terminalHistoryMetadataPath(nextPath))).toBe(false);
     expect(fs.existsSync(legacyPath)).toBe(false);
     if (process.platform !== "win32") {
       expect(fs.statSync(nextPath).mode & 0o777).toBe(0o600);

--- a/apps/server/src/terminal/Layers/Manager.ts
+++ b/apps/server/src/terminal/Layers/Manager.ts
@@ -60,6 +60,14 @@ import {
 } from "../terminalHistory";
 import { createTerminalModeReplayTracker } from "../terminalModeReplay";
 import {
+  createTerminalHistoryMetadata,
+  deleteTerminalHistoryRecord,
+  readTerminalHistoryRecord,
+  writeDimensionlessTerminalHistory,
+  writeTerminalHistoryRecord,
+  type TerminalHistoryRecord,
+} from "../terminalHistoryRecord";
+import {
   defaultProcessTreeKiller,
   parseProcessChildrenMap,
   type ProcessChildrenMap,
@@ -850,6 +858,48 @@ function toSafeTerminalId(terminalId: string): string {
   return Encoding.encodeBase64Url(terminalId);
 }
 
+const TERMINAL_HISTORY_TEMP_SUFFIX_PATTERN = /\.tmp-\d+-\d+$/;
+const TERMINAL_ID_FILE_SEGMENT_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+function classifyThreadHistoryArtifact(
+  fileName: string,
+  threadId: string,
+): "metadata" | "history" | null {
+  let finalName = fileName;
+  const tempSuffix = finalName.match(TERMINAL_HISTORY_TEMP_SUFFIX_PATTERN)?.[0];
+  if (tempSuffix) {
+    finalName = finalName.slice(0, -tempSuffix.length);
+  }
+
+  const metadataSuffix = ".meta.json";
+  const isMetadata = finalName.endsWith(metadataSuffix);
+  if (isMetadata) {
+    finalName = finalName.slice(0, -metadataSuffix.length);
+  }
+
+  const encodedThreadName = toSafeThreadId(threadId);
+  const encodedDefaultHistoryName = `${encodedThreadName}.log`;
+  const encodedTerminalPrefix = `${encodedThreadName}_`;
+  const encodedTerminalId =
+    finalName.startsWith(encodedTerminalPrefix) && finalName.endsWith(".log")
+      ? finalName.slice(encodedTerminalPrefix.length, -".log".length)
+      : null;
+  const isEncodedThreadHistory =
+    finalName === encodedDefaultHistoryName ||
+    (encodedTerminalId !== null && TERMINAL_ID_FILE_SEGMENT_PATTERN.test(encodedTerminalId));
+
+  if (isMetadata) {
+    return isEncodedThreadHistory ? "metadata" : null;
+  }
+  if (tempSuffix) {
+    return isEncodedThreadHistory ? "history" : null;
+  }
+  if (isEncodedThreadHistory || finalName === `${legacySafeThreadId(threadId)}.log`) {
+    return "history";
+  }
+  return null;
+}
+
 function toSessionKey(threadId: string, terminalId: string): string {
   return `${threadId}\u0000${terminalId}`;
 }
@@ -909,6 +959,9 @@ function cliKindFromRuntimeEnv(
 
 function resetSessionHistory(session: TerminalSessionState): void {
   session.history.reset();
+  session.recoveredCols = null;
+  session.recoveredRows = null;
+  session.historyRecordIdentity = null;
   session.pendingHistoryControlSequence = "";
   session.pendingInputBuffer = "";
   session.managedAgentRunning = false;
@@ -983,7 +1036,10 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
    * than a string so the O(maxBytes) history cap only runs when the debounced
    * write actually fires (≈4/s) — never on the per-flush hot path.
    */
-  private readonly pendingPersistHistory = new Map<string, () => string>();
+  private readonly pendingPersistHistory = new Map<
+    string,
+    () => { history: string; cols: number; rows: number }
+  >();
   private readonly persistedHistoryByKey = new Map<string, string>();
   private persistTempCounter = 0;
   private readonly threadLocks = new Map<string, Promise<void>>();
@@ -1061,7 +1117,7 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
       const existing = this.sessions.get(sessionKey);
       if (!existing) {
         await this.flushPersistQueue(input.threadId, input.terminalId);
-        const history = await this.readHistory(input.threadId, input.terminalId);
+        const recovered = await this.readHistory(input.threadId, input.terminalId);
         const cols = input.cols ?? DEFAULT_OPEN_COLS;
         const rows = input.rows ?? DEFAULT_OPEN_ROWS;
         const session: TerminalSessionState = {
@@ -1070,7 +1126,10 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
           cwd: input.cwd,
           status: "starting",
           pid: null,
-          history: TerminalHistoryBuffer.fromString(history, this.historyLimits()),
+          history: TerminalHistoryBuffer.fromString(recovered.history, this.historyLimits()),
+          recoveredCols: recovered.recoveredCols ?? null,
+          recoveredRows: recovered.recoveredRows ?? null,
+          historyRecordIdentity: recovered.historyRecordIdentity ?? null,
           pendingHistoryControlSequence: "",
           exitCode: null,
           exitSignal: null,
@@ -1142,6 +1201,8 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
           existing.threadId,
           existing.terminalId,
           existing.history.toString(),
+          existing.cols,
+          existing.rows,
         );
       } else if (existing.status === "exited" || existing.status === "error") {
         existing.runtimeEnv = nextRuntimeEnv;
@@ -1150,6 +1211,8 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
           existing.threadId,
           existing.terminalId,
           existing.history.toString(),
+          existing.cols,
+          existing.rows,
         );
       } else if (runtimeEnvChanged) {
         existing.runtimeEnv = nextRuntimeEnv;
@@ -1175,6 +1238,7 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
         existing.process.resize(targetCols, targetRows);
         existing.modeReplayTracker?.resize(targetCols, targetRows);
         existing.updatedAt = new Date().toISOString();
+        this.queuePersist(existing);
       }
 
       // Drain any batched-but-unparsed output so the reconnect snapshot carries
@@ -1245,6 +1309,7 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
     session.updatedAt = new Date().toISOString();
     session.process.resize(input.cols, input.rows);
     session.modeReplayTracker?.resize(input.cols, input.rows);
+    this.queuePersist(session);
   }
 
   async clear(raw: TerminalClearInput): Promise<void> {
@@ -1253,7 +1318,13 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
       const session = this.requireSession(input.threadId, input.terminalId);
       resetSessionHistory(session);
       session.updatedAt = new Date().toISOString();
-      await this.persistHistory(input.threadId, input.terminalId, session.history.toString());
+      await this.persistHistory(
+        input.threadId,
+        input.terminalId,
+        session.history.toString(),
+        session.cols,
+        session.rows,
+      );
       this.emitEvent({
         type: "cleared",
         threadId: input.threadId,
@@ -1280,6 +1351,9 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
           status: "starting",
           pid: null,
           history: new TerminalHistoryBuffer(this.historyLimits()),
+          recoveredCols: null,
+          recoveredRows: null,
+          historyRecordIdentity: null,
           pendingHistoryControlSequence: "",
           exitCode: null,
           exitSignal: null,
@@ -1332,7 +1406,13 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
       const rows = input.rows ?? session.rows;
 
       resetSessionHistory(session);
-      await this.persistHistory(input.threadId, input.terminalId, session.history.toString());
+      await this.persistHistory(
+        input.threadId,
+        input.terminalId,
+        session.history.toString(),
+        cols,
+        rows,
+      );
       await this.startSession(session, { ...input, cols, rows }, "restarted");
       return this.snapshot(session);
     });
@@ -1613,6 +1693,9 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
       }
     }
     if (sanitized.visibleText.length > 0) {
+      session.recoveredCols = null;
+      session.recoveredRows = null;
+      session.historyRecordIdentity = null;
       session.history.append(sanitized.visibleText);
       this.queuePersist(session);
       const normalizedSignature = normalizeProviderOutputSignature(sanitized.visibleText);
@@ -1992,6 +2075,8 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
         session.threadId,
         session.terminalId,
         session.history.toString(),
+        session.cols,
+        session.rows,
       ).finally(() => {
         this.persistedHistoryByKey.delete(key);
       });
@@ -2007,7 +2092,11 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
    */
   private queuePersist(session: TerminalSessionState): void {
     const persistenceKey = toSessionKey(session.threadId, session.terminalId);
-    this.pendingPersistHistory.set(persistenceKey, () => session.history.toString());
+    this.pendingPersistHistory.set(persistenceKey, () => ({
+      history: session.history.toString(),
+      cols: session.cols,
+      rows: session.rows,
+    }));
     this.schedulePersist(session.threadId, session.terminalId);
   }
 
@@ -2015,40 +2104,40 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
     threadId: string,
     terminalId: string,
     history: string,
+    cols: number,
+    rows: number,
   ): Promise<void> {
     const persistenceKey = toSessionKey(threadId, terminalId);
     this.clearPersistTimer(threadId, terminalId);
     this.pendingPersistHistory.delete(persistenceKey);
-    await this.enqueuePersistWrite(threadId, terminalId, history);
+    await this.enqueuePersistWrite(threadId, terminalId, history, cols, rows);
   }
 
   private enqueuePersistWrite(
     threadId: string,
     terminalId: string,
     history: string,
+    cols: number,
+    rows: number,
   ): Promise<void> {
     const persistenceKey = toSessionKey(threadId, terminalId);
     const task = async () => {
-      if (this.persistedHistoryByKey.get(persistenceKey) === history) {
+      const expected = createTerminalHistoryMetadata(history, cols, rows);
+      if (this.persistedHistoryByKey.get(persistenceKey) === expected.recordIdentity) {
         return;
       }
       // Atomic replace: write a temp file then rename, so a crash mid-write can
       // never leave a torn history file. History is byte-capped, so this writes
       // at most ~historyByteLimit bytes regardless of total output volume.
       const finalPath = this.historyPath(threadId, terminalId);
-      const tempPath = `${finalPath}.tmp-${process.pid}-${(this.persistTempCounter += 1)}`;
-      try {
-        await fs.promises.writeFile(tempPath, history, {
-          encoding: "utf8",
-          mode: PRIVATE_FILE_MODE,
-        });
-        await fs.promises.rename(tempPath, finalPath);
-        await repairPrivateFile(finalPath);
-        this.persistedHistoryByKey.set(persistenceKey, history);
-      } catch (error) {
-        await fs.promises.rm(tempPath, { force: true }).catch(() => undefined);
-        throw error;
-      }
+      const metadata = await writeTerminalHistoryRecord(
+        finalPath,
+        history,
+        cols,
+        rows,
+        (targetPath) => `${targetPath}.tmp-${process.pid}-${(this.persistTempCounter += 1)}`,
+      );
+      this.persistedHistoryByKey.set(persistenceKey, metadata.recordIdentity);
     };
     const previous = this.persistQueues.get(persistenceKey) ?? Promise.resolve();
     const next = previous
@@ -2085,7 +2174,8 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
       const materialize = this.pendingPersistHistory.get(persistenceKey);
       if (materialize === undefined) return;
       this.pendingPersistHistory.delete(persistenceKey);
-      void this.enqueuePersistWrite(threadId, terminalId, materialize());
+      const record = materialize();
+      void this.enqueuePersistWrite(threadId, terminalId, record.history, record.cols, record.rows);
     }, this.persistDebounceMs);
     timer.unref?.();
     this.persistTimers.set(persistenceKey, timer);
@@ -2099,24 +2189,34 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
     this.persistTimers.delete(persistenceKey);
   }
 
-  private async readHistory(threadId: string, terminalId: string): Promise<string> {
+  private async readHistory(threadId: string, terminalId: string): Promise<TerminalHistoryRecord> {
     const nextPath = this.historyPath(threadId, terminalId);
     const persistenceKey = toSessionKey(threadId, terminalId);
     try {
-      const raw = await fs.promises.readFile(nextPath, "utf8");
-      await repairPrivateFile(nextPath);
-      const capped = capHistoryByLimits(sanitizePersistedTerminalHistory(raw), {
-        maxLines: this.historyLineLimit,
-        maxBytes: this.historyByteLimit,
-      });
-      if (capped !== raw) {
-        await fs.promises.writeFile(nextPath, capped, {
-          encoding: "utf8",
-          mode: PRIVATE_FILE_MODE,
-        });
+      const record = await readTerminalHistoryRecord(nextPath, (raw) =>
+        capHistoryByLimits(sanitizePersistedTerminalHistory(raw), {
+          maxLines: this.historyLineLimit,
+          maxBytes: this.historyByteLimit,
+        }),
+      );
+      if (!record) throw Object.assign(new Error("missing history"), { code: "ENOENT" });
+      if (record.historyWasNormalized) {
+        await writeDimensionlessTerminalHistory(
+          nextPath,
+          record.history,
+          (targetPath) => `${targetPath}.tmp-${process.pid}-${(this.persistTempCounter += 1)}`,
+        );
       }
-      this.persistedHistoryByKey.set(persistenceKey, capped);
-      return capped;
+      this.persistedHistoryByKey.set(persistenceKey, record.historyRecordIdentity ?? "");
+      return {
+        history: record.history,
+        ...(record.recoveredCols !== undefined && record.recoveredRows !== undefined
+          ? { recoveredCols: record.recoveredCols, recoveredRows: record.recoveredRows }
+          : {}),
+        ...(record.historyRecordIdentity
+          ? { historyRecordIdentity: record.historyRecordIdentity }
+          : {}),
+      };
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
         throw error;
@@ -2124,7 +2224,7 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
     }
 
     if (terminalId !== DEFAULT_TERMINAL_ID) {
-      return "";
+      return { history: "" };
     }
 
     const legacyPath = this.legacyHistoryPath(threadId);
@@ -2141,7 +2241,7 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
         mode: PRIVATE_FILE_MODE,
       });
       await repairPrivateFile(nextPath);
-      this.persistedHistoryByKey.set(persistenceKey, capped);
+      this.persistedHistoryByKey.set(persistenceKey, "");
       try {
         await fs.promises.rm(legacyPath, { force: true });
       } catch (cleanupError) {
@@ -2151,11 +2251,11 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
         });
       }
 
-      return capped;
+      return { history: capped };
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") {
         this.persistedHistoryByKey.set(persistenceKey, "");
-        return "";
+        return { history: "" };
       }
       throw error;
     }
@@ -2163,7 +2263,7 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
 
   private async deleteHistory(threadId: string, terminalId: string): Promise<void> {
     this.persistedHistoryByKey.delete(toSessionKey(threadId, terminalId));
-    const deletions = [fs.promises.rm(this.historyPath(threadId, terminalId), { force: true })];
+    const deletions = [deleteTerminalHistoryRecord(this.historyPath(threadId, terminalId))];
     if (terminalId === DEFAULT_TERMINAL_ID) {
       deletions.push(fs.promises.rm(this.legacyHistoryPath(threadId), { force: true }));
     }
@@ -2186,7 +2286,14 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
       const materialize = this.pendingPersistHistory.get(persistenceKey);
       if (materialize !== undefined) {
         this.pendingPersistHistory.delete(persistenceKey);
-        await this.enqueuePersistWrite(threadId, terminalId, materialize());
+        const record = materialize();
+        await this.enqueuePersistWrite(
+          threadId,
+          terminalId,
+          record.history,
+          record.cols,
+          record.rows,
+        );
       }
 
       const pending = this.persistQueues.get(persistenceKey);
@@ -2411,7 +2518,6 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
   }
 
   private async deleteAllHistoryForThread(threadId: string): Promise<void> {
-    const threadPrefix = `${toSafeThreadId(threadId)}_`;
     for (const key of [...this.persistedHistoryByKey.keys()]) {
       if (key.startsWith(`${threadId}\u0000`)) {
         this.persistedHistoryByKey.delete(key);
@@ -2419,17 +2525,26 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
     }
     try {
       const entries = await fs.promises.readdir(this.logsDir, { withFileTypes: true });
-      const removals = entries
-        .filter((entry) => entry.isFile())
-        .map((entry) => entry.name)
-        .filter(
-          (name) =>
-            name === `${toSafeThreadId(threadId)}.log` ||
-            name === `${legacySafeThreadId(threadId)}.log` ||
-            name.startsWith(threadPrefix),
-        )
-        .map((name) => fs.promises.rm(path.join(this.logsDir, name), { force: true }));
-      await Promise.all(removals);
+      const fileNames = entries.filter((entry) => entry.isFile()).map((entry) => entry.name);
+      const artifacts = fileNames.map((name) => ({
+        name,
+        kind: classifyThreadHistoryArtifact(name, threadId),
+      }));
+      const metadataNames = artifacts
+        .filter((artifact) => artifact.kind === "metadata")
+        .map((artifact) => artifact.name);
+      const historyNames = artifacts
+        .filter((artifact) => artifact.kind === "history")
+        .map((artifact) => artifact.name);
+      // Delete metadata finals and transaction temporaries first so an
+      // interrupted clear can expose, at worst, dimensionless history. Then
+      // delete the matching history finals and transaction temporaries.
+      await Promise.all(
+        metadataNames.map((name) => fs.promises.rm(path.join(this.logsDir, name), { force: true })),
+      );
+      await Promise.all(
+        historyNames.map((name) => fs.promises.rm(path.join(this.logsDir, name), { force: true })),
+      );
     } catch (error) {
       this.logger.warn("failed to delete terminal histories for thread", {
         threadId,
@@ -2455,6 +2570,12 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
       status: session.status,
       pid: session.pid,
       history: session.history.toString(),
+      ...(session.recoveredCols !== null && session.recoveredRows !== null
+        ? { recoveredCols: session.recoveredCols, recoveredRows: session.recoveredRows }
+        : {}),
+      ...(session.historyRecordIdentity
+        ? { historyRecordIdentity: session.historyRecordIdentity }
+        : {}),
       ...(replayPreamble.length > 0 ? { replayPreamble } : {}),
       exitCode: session.exitCode,
       exitSignal: session.exitSignal,

--- a/apps/server/src/terminal/Services/Manager.ts
+++ b/apps/server/src/terminal/Services/Manager.ts
@@ -37,6 +37,11 @@ export interface TerminalSessionState {
   pid: number | null;
   /** Append-optimized scrollback buffer (sanitized visible text, capped on read). */
   history: TerminalHistoryBuffer;
+  /** Validated source grid associated with the recovered on-disk history. */
+  recoveredCols: number | null;
+  recoveredRows: number | null;
+  /** Stable identity of the exact recovered bytes and source dimensions. */
+  historyRecordIdentity: string | null;
   pendingHistoryControlSequence: string;
   exitCode: number | null;
   exitSignal: number | null;

--- a/apps/server/src/terminal/terminalHistoryRecord.test.ts
+++ b/apps/server/src/terminal/terminalHistoryRecord.test.ts
@@ -1,0 +1,209 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createTerminalHistoryMetadata,
+  deleteTerminalHistoryRecord,
+  readTerminalHistoryRecord,
+  terminalHistoryMetadataPath,
+  writeDimensionlessTerminalHistory,
+  writeTerminalHistoryRecord,
+} from "./terminalHistoryRecord";
+
+const directories: string[] = [];
+
+function fixture(): {
+  directory: string;
+  historyPath: string;
+  nextTempPath: (path: string) => string;
+} {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "synara-history-record-"));
+  directories.push(directory);
+  let counter = 0;
+  return {
+    directory,
+    historyPath: path.join(directory, "terminal.log"),
+    nextTempPath: (target) => `${target}.tmp-${++counter}`,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    directories
+      .splice(0)
+      .map((directory) => fs.promises.rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("terminalHistoryRecord", () => {
+  it("round-trips exact UTF-8 bytes, dimensions, digest, and stable identity", async () => {
+    const { historyPath, nextTempPath } = fixture();
+    const history = "ASCII 中 e\u0301 👩‍💻\n\u001b[31mred\u001b[0m";
+    const metadata = await writeTerminalHistoryRecord(historyPath, history, 91, 27, nextTempPath);
+    expect(metadata.byteLength).toBe(Buffer.byteLength(history, "utf8"));
+    expect(metadata.sha256).toBe(createTerminalHistoryMetadata(history, 91, 27).sha256);
+    expect(await readTerminalHistoryRecord(historyPath, (value) => value)).toEqual({
+      history,
+      recoveredCols: 91,
+      recoveredRows: 27,
+      historyRecordIdentity: metadata.recordIdentity,
+    });
+  });
+
+  it("changes identity for bytes or dimensions and preserves identity otherwise", () => {
+    const first = createTerminalHistoryMetadata("same", 80, 24);
+    expect(createTerminalHistoryMetadata("same", 80, 24).recordIdentity).toBe(first.recordIdentity);
+    expect(createTerminalHistoryMetadata("changed", 80, 24).recordIdentity).not.toBe(
+      first.recordIdentity,
+    );
+    expect(createTerminalHistoryMetadata("same", 81, 24).recordIdentity).not.toBe(
+      first.recordIdentity,
+    );
+  });
+
+  it.each([
+    ["missing", null],
+    ["truncated", '{"version":1'],
+    [
+      "unsupported",
+      JSON.stringify({
+        version: 2,
+        cols: 80,
+        rows: 24,
+        byteLength: 4,
+        sha256: "a".repeat(64),
+        recordIdentity: "b".repeat(64),
+      }),
+    ],
+    [
+      "invalid dimensions",
+      JSON.stringify({
+        version: 1,
+        cols: 2,
+        rows: 24,
+        byteLength: 4,
+        sha256: "a".repeat(64),
+        recordIdentity: "b".repeat(64),
+      }),
+    ],
+    [
+      "invalid digest",
+      JSON.stringify({
+        version: 1,
+        cols: 80,
+        rows: 24,
+        byteLength: 4,
+        sha256: "no",
+        recordIdentity: "b".repeat(64),
+      }),
+    ],
+    ["excessive", "x".repeat(4_097)],
+  ])("falls back to legacy history for %s metadata", async (_name, sidecar) => {
+    const { historyPath } = fixture();
+    fs.writeFileSync(historyPath, "safe");
+    if (sidecar !== null) fs.writeFileSync(terminalHistoryMetadataPath(historyPath), sidecar);
+    expect(await readTerminalHistoryRecord(historyPath, (value) => value)).toEqual({
+      history: "safe",
+    });
+  });
+
+  it("treats new metadata with old changed history as dimensionless", async () => {
+    const { historyPath } = fixture();
+    const metadata = createTerminalHistoryMetadata("new", 100, 30);
+    fs.writeFileSync(terminalHistoryMetadataPath(historyPath), JSON.stringify(metadata));
+    fs.writeFileSync(historyPath, "old");
+    expect(await readTerminalHistoryRecord(historyPath, (value) => value)).toEqual({
+      history: "old",
+    });
+  });
+
+  it("commits metadata before history and safely exposes an interrupted write", async () => {
+    const { historyPath, nextTempPath } = fixture();
+    fs.writeFileSync(historyPath, "old");
+    const expectedMetadata = createTerminalHistoryMetadata("new", 100, 30);
+    await expect(
+      writeTerminalHistoryRecord(historyPath, "new", 100, 30, nextTempPath, () => {
+        expect(
+          JSON.parse(fs.readFileSync(terminalHistoryMetadataPath(historyPath), "utf8")),
+        ).toEqual(expectedMetadata);
+        expect(fs.readFileSync(historyPath, "utf8")).toBe("old");
+        throw new Error("interrupted after metadata");
+      }),
+    ).rejects.toThrow("interrupted after metadata");
+    expect(await readTerminalHistoryRecord(historyPath, (value) => value)).toEqual({
+      history: "old",
+    });
+  });
+
+  it("accepts new metadata with unchanged history for a dimensions-only commit", async () => {
+    const { historyPath } = fixture();
+    fs.writeFileSync(historyPath, "same");
+    const metadata = createTerminalHistoryMetadata("same", 120, 40);
+    fs.writeFileSync(terminalHistoryMetadataPath(historyPath), JSON.stringify(metadata));
+    expect(await readTerminalHistoryRecord(historyPath, (value) => value)).toMatchObject({
+      recoveredCols: 120,
+      recoveredRows: 40,
+    });
+  });
+
+  it("returns no record for old metadata with missing history", async () => {
+    const { historyPath } = fixture();
+    fs.writeFileSync(
+      terminalHistoryMetadataPath(historyPath),
+      JSON.stringify(createTerminalHistoryMetadata("gone", 80, 24)),
+    );
+    expect(await readTerminalHistoryRecord(historyPath, (value) => value)).toBeNull();
+  });
+
+  it("reports normalization without trusting metadata for different source bytes", async () => {
+    const { historyPath } = fixture();
+    fs.writeFileSync(historyPath, "unsafe");
+    fs.writeFileSync(
+      terminalHistoryMetadataPath(historyPath),
+      JSON.stringify(createTerminalHistoryMetadata("safe", 80, 24)),
+    );
+    expect(await readTerminalHistoryRecord(historyPath, () => "safe")).toEqual({
+      history: "safe",
+      historyWasNormalized: true,
+    });
+  });
+
+  it("rewrites a normalized legacy source metadata-first and keeps it dimensionless", async () => {
+    const { historyPath, nextTempPath } = fixture();
+    await writeTerminalHistoryRecord(historyPath, "unsafe", 80, 24, nextTempPath);
+    await writeDimensionlessTerminalHistory(historyPath, "safe", nextTempPath);
+    expect(fs.readFileSync(historyPath, "utf8")).toBe("safe");
+    expect(fs.existsSync(terminalHistoryMetadataPath(historyPath))).toBe(false);
+    expect(await readTerminalHistoryRecord(historyPath, (value) => value)).toEqual({
+      history: "safe",
+    });
+  });
+
+  it("survives native replacement and cleans private temporary files", async () => {
+    const { directory, historyPath, nextTempPath } = fixture();
+    await writeTerminalHistoryRecord(historyPath, "old", 80, 24, nextTempPath);
+    await writeTerminalHistoryRecord(historyPath, "new", 100, 30, nextTempPath);
+    expect(fs.readFileSync(historyPath, "utf8")).toBe("new");
+    expect(fs.readdirSync(directory).some((name) => name.includes(".tmp-"))).toBe(false);
+  });
+
+  it("leaves readable dimensionless history when deletion stops after metadata", async () => {
+    const { historyPath, nextTempPath } = fixture();
+    await writeTerminalHistoryRecord(historyPath, "keep", 80, 24, nextTempPath);
+    await expect(
+      deleteTerminalHistoryRecord(historyPath, () => {
+        throw new Error("interrupted delete");
+      }),
+    ).rejects.toThrow("interrupted delete");
+    expect(fs.existsSync(terminalHistoryMetadataPath(historyPath))).toBe(false);
+    expect(await readTerminalHistoryRecord(historyPath, (value) => value)).toEqual({
+      history: "keep",
+    });
+    await deleteTerminalHistoryRecord(historyPath);
+    expect(fs.existsSync(historyPath)).toBe(false);
+    expect(fs.existsSync(terminalHistoryMetadataPath(historyPath))).toBe(false);
+  });
+});

--- a/apps/server/src/terminal/terminalHistoryRecord.ts
+++ b/apps/server/src/terminal/terminalHistoryRecord.ts
@@ -1,0 +1,226 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+
+import {
+  TERMINAL_MAX_COLS,
+  TERMINAL_MAX_ROWS,
+  TERMINAL_MIN_COLS,
+  TERMINAL_MIN_ROWS,
+} from "@synara/contracts";
+
+import { PRIVATE_FILE_MODE, repairPrivateFile } from "../privatePathPermissions";
+
+const METADATA_VERSION = 1;
+const MAX_METADATA_BYTES = 4_096;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+
+export interface TerminalHistoryRecord {
+  history: string;
+  recoveredCols?: number;
+  recoveredRows?: number;
+  historyRecordIdentity?: string;
+  /** True when the on-disk source needed sanitizing or capping before use. */
+  historyWasNormalized?: boolean;
+}
+
+export interface TerminalHistoryRecordMetadata {
+  version: 1;
+  cols: number;
+  rows: number;
+  byteLength: number;
+  sha256: string;
+  recordIdentity: string;
+}
+
+export function terminalHistoryMetadataPath(historyPath: string): string {
+  return `${historyPath}.meta.json`;
+}
+
+function digest(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function recordIdentity(cols: number, rows: number, byteLength: number, sha256: string): string {
+  return createHash("sha256")
+    .update(`${METADATA_VERSION}\0${cols}\0${rows}\0${byteLength}\0${sha256}`)
+    .digest("hex");
+}
+
+function validDimension(value: unknown, min: number, max: number): value is number {
+  return Number.isInteger(value) && Number(value) >= min && Number(value) <= max;
+}
+
+export function createTerminalHistoryMetadata(
+  history: string,
+  cols: number,
+  rows: number,
+): TerminalHistoryRecordMetadata {
+  if (
+    !validDimension(cols, TERMINAL_MIN_COLS, TERMINAL_MAX_COLS) ||
+    !validDimension(rows, TERMINAL_MIN_ROWS, TERMINAL_MAX_ROWS)
+  ) {
+    throw new RangeError("Terminal history dimensions are out of bounds");
+  }
+  const bytes = Buffer.from(history, "utf8");
+  const sha256 = digest(bytes);
+  return {
+    version: METADATA_VERSION,
+    cols,
+    rows,
+    byteLength: bytes.byteLength,
+    sha256,
+    recordIdentity: recordIdentity(cols, rows, bytes.byteLength, sha256),
+  };
+}
+
+function parseMetadata(raw: Buffer, historyBytes: Buffer): TerminalHistoryRecordMetadata | null {
+  if (raw.byteLength === 0 || raw.byteLength > MAX_METADATA_BYTES) return null;
+  let value: unknown;
+  try {
+    value = JSON.parse(raw.toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const metadata = value as Record<string, unknown>;
+  if (
+    metadata.version !== METADATA_VERSION ||
+    !validDimension(metadata.cols, TERMINAL_MIN_COLS, TERMINAL_MAX_COLS) ||
+    !validDimension(metadata.rows, TERMINAL_MIN_ROWS, TERMINAL_MAX_ROWS) ||
+    !Number.isSafeInteger(metadata.byteLength) ||
+    Number(metadata.byteLength) < 0 ||
+    Number(metadata.byteLength) !== historyBytes.byteLength ||
+    typeof metadata.sha256 !== "string" ||
+    !SHA256_PATTERN.test(metadata.sha256) ||
+    typeof metadata.recordIdentity !== "string" ||
+    !SHA256_PATTERN.test(metadata.recordIdentity)
+  ) {
+    return null;
+  }
+  const sha256 = digest(historyBytes);
+  const expectedIdentity = recordIdentity(
+    metadata.cols,
+    metadata.rows,
+    historyBytes.byteLength,
+    sha256,
+  );
+  if (metadata.sha256 !== sha256 || metadata.recordIdentity !== expectedIdentity) return null;
+  return metadata as unknown as TerminalHistoryRecordMetadata;
+}
+
+async function readBoundedMetadata(metadataPath: string): Promise<Buffer | null> {
+  const handle = await fs.promises.open(metadataPath, "r");
+  try {
+    const buffer = Buffer.allocUnsafe(MAX_METADATA_BYTES + 1);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.byteLength, 0);
+    if (bytesRead === 0 || bytesRead > MAX_METADATA_BYTES) return null;
+    return buffer.subarray(0, bytesRead);
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function readTerminalHistoryRecord(
+  historyPath: string,
+  normalizeHistory: (raw: string) => string,
+): Promise<TerminalHistoryRecord | null> {
+  let rawHistory: string;
+  try {
+    rawHistory = await fs.promises.readFile(historyPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  await repairPrivateFile(historyPath);
+  const history = normalizeHistory(rawHistory);
+  const historyWasNormalized = history !== rawHistory;
+  const historyBytes = Buffer.from(history, "utf8");
+  let metadata: TerminalHistoryRecordMetadata | null = null;
+  try {
+    const metadataPath = terminalHistoryMetadataPath(historyPath);
+    await repairPrivateFile(metadataPath);
+    if (!historyWasNormalized) {
+      const rawMetadata = await readBoundedMetadata(metadataPath);
+      if (rawMetadata) metadata = parseMetadata(rawMetadata, historyBytes);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      metadata = null;
+    }
+  }
+  return metadata
+    ? {
+        history,
+        recoveredCols: metadata.cols,
+        recoveredRows: metadata.rows,
+        historyRecordIdentity: metadata.recordIdentity,
+      }
+    : {
+        history,
+        ...(historyWasNormalized ? { historyWasNormalized: true } : {}),
+      };
+}
+
+async function atomicWrite(
+  finalPath: string,
+  contents: string,
+  nextTempPath: (finalPath: string) => string,
+): Promise<void> {
+  const tempPath = nextTempPath(finalPath);
+  let handle: fs.promises.FileHandle | null = null;
+  try {
+    handle = await fs.promises.open(tempPath, "wx", PRIVATE_FILE_MODE);
+    await handle.writeFile(contents, "utf8");
+    await handle.sync();
+    await handle.close();
+    handle = null;
+    await fs.promises.rename(tempPath, finalPath);
+    await repairPrivateFile(finalPath);
+  } catch (error) {
+    await handle?.close().catch(() => undefined);
+    await fs.promises.rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function writeTerminalHistoryRecord(
+  historyPath: string,
+  history: string,
+  cols: number,
+  rows: number,
+  nextTempPath: (finalPath: string) => string,
+  afterMetadataWritten?: () => void | Promise<void>,
+): Promise<TerminalHistoryRecordMetadata> {
+  const metadata = createTerminalHistoryMetadata(history, cols, rows);
+  await atomicWrite(
+    terminalHistoryMetadataPath(historyPath),
+    JSON.stringify(metadata),
+    nextTempPath,
+  );
+  await afterMetadataWritten?.();
+  await atomicWrite(historyPath, history, nextTempPath);
+  return metadata;
+}
+
+/**
+ * Replace a legacy/damaged history source without blessing it with recovered
+ * dimensions. Metadata is removed first so every interrupted state remains a
+ * readable dimensionless log.
+ */
+export async function writeDimensionlessTerminalHistory(
+  historyPath: string,
+  history: string,
+  nextTempPath: (finalPath: string) => string,
+): Promise<void> {
+  await fs.promises.rm(terminalHistoryMetadataPath(historyPath), { force: true });
+  await atomicWrite(historyPath, history, nextTempPath);
+}
+
+export async function deleteTerminalHistoryRecord(
+  historyPath: string,
+  afterMetadataDeleted?: () => void | Promise<void>,
+): Promise<void> {
+  await fs.promises.rm(terminalHistoryMetadataPath(historyPath), { force: true });
+  await afterMetadataDeleted?.();
+  await fs.promises.rm(historyPath, { force: true });
+}

--- a/apps/web/src/components/terminal/terminalRuntime.ts
+++ b/apps/web/src/components/terminal/terminalRuntime.ts
@@ -53,6 +53,18 @@ import type {
 } from "./terminalRuntimeTypes";
 import { waitForTerminalFontReady } from "./terminalFontSettle";
 import { observeTerminalWriteParsed } from "./terminalPerformance";
+import {
+  applyReplayOnce,
+  createRecoveredGridOutputBuffer,
+  hasRecoveredGrid,
+  RecoveredGridFinalizationError,
+  replaySnapshotAtBackendOpenGrid,
+  replaySnapshotAtDestinationGrid,
+  replaySnapshotAtRecoveredGrid,
+  shouldReplayColdSnapshot,
+  snapshotHasReplayPayload,
+  snapshotReplayIdentity,
+} from "./terminalSnapshotReplay";
 
 const ENABLE_TERMINAL_WEBGL = true;
 const VISUAL_RESIZE_MIN_INTERVAL_MS = 64;
@@ -61,8 +73,14 @@ const WRITE_BATCH_SIZE_LIMIT = 262_144;
 const WRITE_BATCH_MAX_LATENCY_MS = 50;
 const LINK_MATCH_CACHE_LIMIT = 512;
 const OPEN_SNAPSHOT_RECONCILE_DELAY_MS = 250;
+const TERMINAL_ACK_MAX_BYTES = 8_388_608;
 const TERMINAL_TEXT_ENCODER = new TextEncoder();
 const TERMINAL_PARKING_CONTAINER_ID = "synara-terminal-parking";
+const recoveredGridOutputBuffers = new WeakMap<
+  TerminalRuntimeEntry,
+  ReturnType<typeof createRecoveredGridOutputBuffer>
+>();
+const recoveredGridClearsPending = new WeakSet<TerminalRuntimeEntry>();
 
 type SynaraTerminalOptions = NonNullable<ConstructorParameters<typeof Terminal>[0]> & {
   fontWeight?: string | number;
@@ -84,19 +102,24 @@ function terminalByteLength(data: string): number {
 }
 
 function acknowledgeParsedOutput(entry: TerminalRuntimeEntry, bytes: number): void {
-  if (bytes <= 0) return;
+  if (!Number.isSafeInteger(bytes) || bytes <= 0) return;
   const api = readNativeApi();
   if (!api) return;
   const ackOutput = api.terminal.ackOutput;
   if (typeof ackOutput !== "function") return;
 
-  void ackOutput({
-    threadId: entry.threadId,
-    terminalId: entry.terminalId,
-    bytes,
-  }).catch(() => {
-    // Flow control is best-effort; reconnect/replay will recover from a missed ACK.
-  });
+  let remaining = bytes;
+  while (remaining > 0) {
+    const chunk = Math.min(remaining, TERMINAL_ACK_MAX_BYTES);
+    remaining -= chunk;
+    void ackOutput({
+      threadId: entry.threadId,
+      terminalId: entry.terminalId,
+      bytes: chunk,
+    }).catch(() => {
+      // Flow control is best-effort; reconnect/replay will recover from a missed ACK.
+    });
+  }
 }
 
 function setRuntimeStatus(
@@ -146,19 +169,10 @@ function scheduleFontSettleRefit(entry: TerminalRuntimeEntry): void {
   });
 }
 
-function resetForSnapshotReplay(entry: TerminalRuntimeEntry): void {
+function prepareForSnapshotReplay(entry: TerminalRuntimeEntry): void {
   entry.titleInputBuffer = "";
   entry.linkMatchCache.clear();
   clearPendingWrites(entry);
-  entry.terminal.write("\u001bc");
-}
-
-function snapshotReplayPayload(snapshot: TerminalSessionSnapshot): string {
-  return `${snapshot.replayPreamble ?? ""}${snapshot.history}`;
-}
-
-function snapshotHasReplayPayload(snapshot: TerminalSessionSnapshot): boolean {
-  return snapshot.history.length > 0 || (snapshot.replayPreamble?.length ?? 0) > 0;
 }
 
 function clamp(value: number, min: number, max: number): number {
@@ -180,6 +194,66 @@ function fitTerminal(entry: TerminalRuntimeEntry): void {
   }
 }
 
+function measureTerminalFit(
+  entry: TerminalRuntimeEntry,
+): { cols: number; rows: number } | undefined {
+  const dimensions = entry.fitAddon.proposeDimensions();
+  if (!dimensions || !Number.isFinite(dimensions.cols) || !Number.isFinite(dimensions.rows)) {
+    return undefined;
+  }
+
+  return {
+    cols: clamp(Math.trunc(dimensions.cols), TERMINAL_MIN_COLS, TERMINAL_MAX_COLS),
+    rows: clamp(Math.trunc(dimensions.rows), TERMINAL_MIN_ROWS, TERMINAL_MAX_ROWS),
+  };
+}
+
+function hasRetainedRecoveredOutput(entry: TerminalRuntimeEntry): boolean {
+  return recoveredGridOutputBuffers.has(entry);
+}
+
+function discardRecoveredGridOutput(
+  entry: TerminalRuntimeEntry,
+  outputBuffer: ReturnType<typeof createRecoveredGridOutputBuffer>,
+  count = outputBuffer.size(),
+): void {
+  const discardedBytes = outputBuffer
+    .drainPrefix(count)
+    .reduce((total, output) => total + output.byteLength, 0);
+  acknowledgeParsedOutput(entry, discardedBytes);
+}
+
+function applyPendingRecoveredGridClear(entry: TerminalRuntimeEntry): boolean {
+  if (!recoveredGridClearsPending.delete(entry)) return false;
+  entry.terminal.clear();
+  entry.terminal.write("\u001bc");
+  return true;
+}
+
+function restoreBackendOpenGridAfterClear(entry: TerminalRuntimeEntry): boolean {
+  const backendOpenDimensions = entry.backendOpenDimensions;
+  if (!backendOpenDimensions) return false;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      if (
+        entry.terminal.cols !== backendOpenDimensions.cols ||
+        entry.terminal.rows !== backendOpenDimensions.rows
+      ) {
+        entry.terminal.resize(backendOpenDimensions.cols, backendOpenDimensions.rows);
+      }
+    } catch {
+      // Verify below; a resize can throw after partially applying dimensions.
+    }
+    if (
+      entry.terminal.cols === backendOpenDimensions.cols &&
+      entry.terminal.rows === backendOpenDimensions.rows
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function buildOpenInput(entry: TerminalRuntimeEntry) {
   return {
     threadId: entry.threadId,
@@ -195,15 +269,180 @@ function replaySnapshot(
   entry: TerminalRuntimeEntry,
   snapshot: TerminalSessionSnapshot,
   onParsed?: () => void,
+  options?: { allowExistingOutput?: boolean; allowRecoveredGrid?: boolean },
 ): void {
-  resetForSnapshotReplay(entry);
-  const payload = snapshotReplayPayload(snapshot);
-  if (payload.length > 0) {
-    setRuntimeStatus(entry, "replaying");
-    entry.terminal.write(payload, onParsed);
+  const retainedOutputBuffer = recoveredGridOutputBuffers.get(entry);
+  const retryingRetainedOutput = retainedOutputBuffer !== undefined;
+  const clearPendingAtRequest = recoveredGridClearsPending.has(entry);
+  const retainedOutputBoundary = clearPendingAtRequest ? 0 : (retainedOutputBuffer?.size() ?? 0);
+  const replayCandidate = clearPendingAtRequest
+    ? { ...snapshot, history: "", replayPreamble: "" }
+    : snapshot;
+  const recoveredSnapshot =
+    ((options?.allowRecoveredGrid ?? true) || retryingRetainedOutput) &&
+    hasRecoveredGrid(replayCandidate) &&
+    entry.backendOpenDimensions
+      ? replayCandidate
+      : null;
+  const retainedDimensionlessSnapshot =
+    retryingRetainedOutput && !hasRecoveredGrid(replayCandidate) && entry.backendOpenDimensions
+      ? replayCandidate
+      : null;
+  const outputEventVersionAtRequest = entry.outputEventVersion;
+
+  // Retained output can only be released after replay at a grid that is known
+  // to match the backend. A dimensionless snapshot is authoritative after the
+  // Manager invalidates recovered-grid metadata on fresh live output.
+  if (
+    retryingRetainedOutput &&
+    !recoveredSnapshot &&
+    !retainedDimensionlessSnapshot &&
+    !clearPendingAtRequest
+  ) {
+    setRuntimeStatus(entry, "error");
     return;
   }
-  onParsed?.();
+
+  const replay = async (): Promise<void> => {
+    if (recoveredSnapshot || retainedDimensionlessSnapshot || clearPendingAtRequest) {
+      if (
+        entry.disposed ||
+        !entry.opened ||
+        (retainedOutputBuffer && recoveredGridOutputBuffers.get(entry) !== retainedOutputBuffer) ||
+        (!retryingRetainedOutput &&
+          ((!options?.allowExistingOutput && outputEventVersionAtRequest !== 0) ||
+            entry.outputEventVersion !== outputEventVersionAtRequest))
+      ) {
+        throw new Error("Terminal replay was aborted");
+      }
+
+      prepareForSnapshotReplay(entry);
+      cancelScheduledVisualResize(entry);
+      const outputBuffer = retainedOutputBuffer ?? createRecoveredGridOutputBuffer();
+      recoveredGridOutputBuffers.set(entry, outputBuffer);
+      entry.recoveredGridReplayInProgress = true;
+      setRuntimeStatus(entry, "replaying");
+      let releaseBufferedOutput = false;
+      try {
+        await settleBackendResizesForRecovery(entry);
+        if (
+          entry.disposed ||
+          !entry.opened ||
+          (!retryingRetainedOutput && entry.outputEventVersion !== outputEventVersionAtRequest)
+        ) {
+          releaseBufferedOutput = true;
+          throw new Error("Terminal replay was aborted");
+        }
+
+        const backendOpenDimensions = entry.backendOpenDimensions;
+        if (!backendOpenDimensions) {
+          throw new RecoveredGridFinalizationError(
+            "Terminal replay has no verified backend-open grid",
+            new Error("Missing backend-open dimensions"),
+          );
+        }
+
+        if (recoveredGridClearsPending.has(entry)) {
+          if (!restoreBackendOpenGridAfterClear(entry)) {
+            throw new RecoveredGridFinalizationError(
+              "Terminal clear could not restore the backend-open grid",
+              new Error("Backend-open grid restoration failed"),
+            );
+          }
+        } else if (recoveredSnapshot) {
+          await replaySnapshotAtRecoveredGrid({
+            terminal: entry.terminal,
+            snapshot: recoveredSnapshot,
+            backendOpenDimensions,
+            measureFinalGrid: () => measureTerminalFit(entry),
+            resizeBackend: async ({ cols, rows }) => {
+              const api = readNativeApi();
+              if (!api) throw new Error("Terminal backend is unavailable");
+              await api.terminal.resize({
+                threadId: entry.threadId,
+                terminalId: entry.terminalId,
+                cols,
+                rows,
+              });
+              entry.lastSentResize = { cols, rows };
+              entry.backendOpenDimensions = { cols, rows };
+            },
+            isActive: () =>
+              !entry.disposed &&
+              entry.opened &&
+              entry.outputEventVersion === outputEventVersionAtRequest,
+          });
+        } else if (retainedDimensionlessSnapshot) {
+          await replaySnapshotAtBackendOpenGrid({
+            terminal: entry.terminal,
+            snapshot: retainedDimensionlessSnapshot,
+            backendOpenDimensions,
+          });
+          // The Manager flushes output before returning its snapshot. Bytes
+          // retained when that response arrived are already represented by the
+          // authoritative history and must be ACKed, not rendered a second time.
+          // A concurrent clear already discarded the superseded prefix itself.
+          if (!recoveredGridClearsPending.has(entry)) {
+            discardRecoveredGridOutput(entry, outputBuffer, retainedOutputBoundary);
+          }
+          if (entry.outputEventVersion !== outputEventVersionAtRequest) {
+            releaseBufferedOutput = true;
+            throw new Error("Terminal replay was aborted");
+          }
+        }
+        releaseBufferedOutput = true;
+      } catch (error) {
+        releaseBufferedOutput = !(error instanceof RecoveredGridFinalizationError);
+        if (!releaseBufferedOutput && !entry.disposed) setRuntimeStatus(entry, "error");
+        throw error;
+      } finally {
+        if (
+          (releaseBufferedOutput || entry.disposed) &&
+          recoveredGridOutputBuffers.get(entry) === outputBuffer
+        ) {
+          recoveredGridOutputBuffers.delete(entry);
+        }
+        entry.recoveredGridReplayInProgress = false;
+        if (releaseBufferedOutput && !entry.disposed) {
+          if (applyPendingRecoveredGridClear(entry)) setRuntimeStatus(entry, "ready");
+          for (const output of outputBuffer.drain()) {
+            scheduleWrite(entry, output.data, output.byteLength);
+          }
+        }
+      }
+      return;
+    }
+
+    if (
+      entry.disposed ||
+      !entry.opened ||
+      (!options?.allowExistingOutput && outputEventVersionAtRequest !== 0) ||
+      entry.outputEventVersion !== outputEventVersionAtRequest
+    ) {
+      throw new Error("Terminal replay was aborted");
+    }
+    prepareForSnapshotReplay(entry);
+    if (snapshotHasReplayPayload(snapshot)) setRuntimeStatus(entry, "replaying");
+    await new Promise<void>((resolve, reject) => {
+      try {
+        replaySnapshotAtDestinationGrid(entry.terminal, snapshot, resolve);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  };
+
+  void snapshotReplayIdentity(snapshot)
+    .then((identity) => applyReplayOnce(entry, identity, replay))
+    .then(() => {
+      if (clearPendingAtRequest) entry.appliedHistoryRecordIdentity = null;
+      onParsed?.();
+    })
+    .catch(() => {
+      if (!entry.disposed && entry.outputEventVersion === outputEventVersionAtRequest) {
+        setRuntimeStatus(entry, "error");
+      }
+    });
 }
 
 function clearBackendResizeTimer(entry: TerminalRuntimeEntry): void {
@@ -295,19 +534,57 @@ function flushPendingResize(entry: TerminalRuntimeEntry): void {
 
   entry.pendingResize = null;
   entry.lastSentResize = pendingResize;
-  void api.terminal
-    .resize({
-      threadId: entry.threadId,
-      terminalId: entry.terminalId,
-      cols: pendingResize.cols,
-      rows: pendingResize.rows,
+  const resizeEpoch = entry.backendResizeEpoch;
+  const previousSettlement = entry.backendResizeSettlement ?? Promise.resolve();
+  let trackedSettlement!: Promise<void>;
+  trackedSettlement = previousSettlement
+    .catch(() => undefined)
+    .then(async () => {
+      if (entry.disposed || entry.backendResizeEpoch !== resizeEpoch) {
+        const current = entry.lastSentResize;
+        if (current && current.cols === pendingResize.cols && current.rows === pendingResize.rows) {
+          entry.lastSentResize = null;
+        }
+        return;
+      }
+      try {
+        await api.terminal.resize({
+          threadId: entry.threadId,
+          terminalId: entry.terminalId,
+          cols: pendingResize.cols,
+          rows: pendingResize.rows,
+        });
+        entry.backendOpenDimensions = pendingResize;
+      } catch {
+        const current = entry.lastSentResize;
+        if (current && current.cols === pendingResize.cols && current.rows === pendingResize.rows) {
+          entry.lastSentResize = null;
+        }
+      }
     })
-    .catch(() => {
-      const current = entry.lastSentResize;
-      if (current && current.cols === pendingResize.cols && current.rows === pendingResize.rows) {
-        entry.lastSentResize = null;
+    .finally(() => {
+      if (entry.backendResizeSettlement === trackedSettlement) {
+        entry.backendResizeSettlement = null;
       }
     });
+  entry.backendResizeSettlement = trackedSettlement;
+}
+
+async function settleBackendResizesForRecovery(entry: TerminalRuntimeEntry): Promise<void> {
+  clearBackendResizeTimer(entry);
+  entry.pendingResize = null;
+  entry.backendResizeEpoch += 1;
+  const settlement = entry.backendResizeSettlement;
+  if (settlement) await settlement;
+  const current = entry.lastSentResize;
+  if (
+    current &&
+    entry.backendOpenDimensions &&
+    (current.cols !== entry.backendOpenDimensions.cols ||
+      current.rows !== entry.backendOpenDimensions.rows)
+  ) {
+    entry.lastSentResize = null;
+  }
 }
 
 function queueBackendResize(entry: TerminalRuntimeEntry, cols: number, rows: number): void {
@@ -331,7 +608,9 @@ function runTerminalResize(
   entry: TerminalRuntimeEntry,
   options?: { clearTextureAtlas?: boolean; refresh?: boolean; dispatchBackend?: boolean },
 ): void {
-  if (!entry.container || !entry.viewState.isVisible) return;
+  if (!entry.container || !entry.viewState.isVisible || entry.recoveredGridReplayInProgress) {
+    return;
+  }
 
   const { clearTextureAtlas = false, refresh = false, dispatchBackend = true } = options ?? {};
   const buffer = entry.terminal.buffer.active;
@@ -703,11 +982,12 @@ function reconcileTerminalSnapshot(entry: TerminalRuntimeEntry): void {
         return;
       }
 
-      if (entry.outputEventVersion !== outputEventVersionAtRequest) {
+      const retainedOutput = hasRetainedRecoveredOutput(entry);
+      if (entry.outputEventVersion !== outputEventVersionAtRequest && !retainedOutput) {
         return;
       }
 
-      if (snapshotHasReplayPayload(snapshot)) {
+      if (snapshotHasReplayPayload(snapshot) || retainedOutput) {
         replaySnapshot(entry, snapshot, () => {
           if (!entry.disposed && entry.snapshotReconcileRequestId === requestId) {
             setRuntimeStatus(entry, "ready");
@@ -815,6 +1095,13 @@ export function createRuntimeEntry(config: TerminalRuntimeConfig): TerminalRunti
     visualResizeTimer: null,
     lastVisualResizeAt: 0,
     lastSentResize: null,
+    backendOpenDimensions: null,
+    backendResizeEpoch: 0,
+    backendResizeSettlement: null,
+    appliedHistoryRecordIdentity: null,
+    pendingHistoryRecordIdentity: null,
+    pendingHistoryReplayPromise: null,
+    recoveredGridReplayInProgress: false,
     pendingResize: null,
     writeRafHandle: null,
     writeFlushTimeout: null,
@@ -1006,18 +1293,43 @@ export function createRuntimeEntry(config: TerminalRuntimeConfig): TerminalRunti
     entry.terminalId,
     (event) => {
       if (event.type === "output") {
-        setRuntimeStatus(entry, "ready");
+        const outputBuffer = recoveredGridOutputBuffers.get(entry);
+        if (!outputBuffer || entry.recoveredGridReplayInProgress) {
+          setRuntimeStatus(entry, "ready");
+        }
         entry.outputEventVersion += 1;
-        scheduleWrite(entry, event.data, event.byteLength ?? terminalByteLength(event.data));
+        entry.appliedHistoryRecordIdentity = null;
+        const output = {
+          data: event.data,
+          byteLength: event.byteLength ?? terminalByteLength(event.data),
+        };
+        if (outputBuffer) {
+          outputBuffer.enqueue(output);
+        } else {
+          scheduleWrite(entry, output.data, output.byteLength);
+        }
         return;
       }
 
       if (event.type === "started" || event.type === "restarted") {
         entry.hasHandledExit = false;
+        const retainedOutput = hasRetainedRecoveredOutput(entry);
         const shouldReplaySnapshot =
-          event.type === "restarted" || snapshotHasReplayPayload(event.snapshot);
+          retainedOutput || event.type === "restarted" || snapshotHasReplayPayload(event.snapshot);
         if (shouldReplaySnapshot) {
-          replaySnapshot(entry, event.snapshot, () => setRuntimeStatus(entry, "ready"));
+          const allowRecoveredGrid =
+            event.type === "restarted" ||
+            retainedOutput ||
+            !hasRecoveredGrid(event.snapshot) ||
+            shouldReplayColdSnapshot(event.snapshot, 0, entry.outputEventVersion);
+          if (event.type === "started" && hasRecoveredGrid(event.snapshot) && !allowRecoveredGrid) {
+            setRuntimeStatus(entry, "ready");
+            return;
+          }
+          replaySnapshot(entry, event.snapshot, () => setRuntimeStatus(entry, "ready"), {
+            allowExistingOutput: event.type === "restarted",
+            allowRecoveredGrid,
+          });
         } else {
           setRuntimeStatus(entry, "ready");
         }
@@ -1025,9 +1337,29 @@ export function createRuntimeEntry(config: TerminalRuntimeConfig): TerminalRunti
       }
 
       if (event.type === "cleared") {
+        entry.outputEventVersion += 1;
+        entry.appliedHistoryRecordIdentity = null;
         entry.titleInputBuffer = "";
         entry.linkMatchCache.clear();
         clearPendingWrites(entry);
+        const retainedOutputBuffer = recoveredGridOutputBuffers.get(entry);
+        if (retainedOutputBuffer) {
+          // A backend clear supersedes output received before it. Discard those
+          // retained bytes, then either clear immediately at the known backend
+          // grid or defer the clear until a recovered-grid retry is safe.
+          discardRecoveredGridOutput(entry, retainedOutputBuffer);
+          recoveredGridClearsPending.add(entry);
+          if (!entry.recoveredGridReplayInProgress) {
+            if (restoreBackendOpenGridAfterClear(entry)) {
+              recoveredGridOutputBuffers.delete(entry);
+              applyPendingRecoveredGridClear(entry);
+              setRuntimeStatus(entry, "ready");
+            } else {
+              setRuntimeStatus(entry, "error");
+            }
+          }
+          return;
+        }
         terminal.clear();
         terminal.write("\u001bc");
         return;
@@ -1093,14 +1425,20 @@ function openTerminal(entry: TerminalRuntimeEntry): void {
   setRuntimeStatus(entry, "connecting");
   const outputEventVersionAtOpen = entry.outputEventVersion;
   const openInput = buildOpenInput(entry);
+  entry.backendOpenDimensions = { cols: openInput.cols, rows: openInput.rows };
 
   void api.terminal
     .open(openInput)
     .then((snapshot) => {
       if (entry.disposed) return;
+      const retainedOutput = hasRetainedRecoveredOutput(entry);
       if (
-        snapshotHasReplayPayload(snapshot) &&
-        entry.outputEventVersion === outputEventVersionAtOpen
+        shouldReplayColdSnapshot(
+          snapshot,
+          outputEventVersionAtOpen,
+          entry.outputEventVersion,
+          retainedOutput,
+        )
       ) {
         replaySnapshot(entry, snapshot, () => setRuntimeStatus(entry, "ready"));
       } else if (entry.outputEventVersion === outputEventVersionAtOpen) {
@@ -1109,17 +1447,23 @@ function openTerminal(entry: TerminalRuntimeEntry): void {
           if (
             entry.disposed ||
             !entry.opened ||
-            entry.outputEventVersion !== outputEventVersionAtOpen
+            (entry.outputEventVersion !== outputEventVersionAtOpen &&
+              !hasRetainedRecoveredOutput(entry))
           ) {
             return;
           }
           void api.terminal
             .open(openInput)
             .then((nextSnapshot) => {
+              const retainedOutput = hasRetainedRecoveredOutput(entry);
+              if (entry.disposed) return;
               if (
-                entry.disposed ||
-                entry.outputEventVersion !== outputEventVersionAtOpen ||
-                !snapshotHasReplayPayload(nextSnapshot)
+                !shouldReplayColdSnapshot(
+                  nextSnapshot,
+                  outputEventVersionAtOpen,
+                  entry.outputEventVersion,
+                  retainedOutput,
+                )
               ) {
                 return;
               }
@@ -1209,6 +1553,11 @@ export function disposeRuntimeEntry(entry: TerminalRuntimeEntry): void {
   // Closing a terminal should not synchronously paint queued output into a buffer
   // that is about to be destroyed; acknowledge and drop it to keep close latency low.
   clearPendingWrites(entry);
+  const retainedOutputBuffer = recoveredGridOutputBuffers.get(entry);
+  if (retainedOutputBuffer) discardRecoveredGridOutput(entry, retainedOutputBuffer);
+  recoveredGridOutputBuffers.delete(entry);
+  recoveredGridClearsPending.delete(entry);
+  entry.recoveredGridReplayInProgress = false;
   entry.unsubscribeTerminalEvents?.();
   entry.unsubscribeTerminalEvents = null;
   entry.querySuppressionDispose?.();

--- a/apps/web/src/components/terminal/terminalRuntimeTypes.ts
+++ b/apps/web/src/components/terminal/terminalRuntimeTypes.ts
@@ -76,6 +76,13 @@ export interface TerminalRuntimeEntry {
   visualResizeTimer: number | null;
   lastVisualResizeAt: number;
   lastSentResize: { cols: number; rows: number } | null;
+  backendOpenDimensions: { cols: number; rows: number } | null;
+  backendResizeEpoch: number;
+  backendResizeSettlement: Promise<void> | null;
+  appliedHistoryRecordIdentity: string | null;
+  pendingHistoryRecordIdentity: string | null;
+  pendingHistoryReplayPromise: Promise<void> | null;
+  recoveredGridReplayInProgress: boolean;
   pendingResize: { cols: number; rows: number } | null;
   writeRafHandle: number | null;
   writeFlushTimeout: number | null;

--- a/apps/web/src/components/terminal/terminalSnapshotReplay.browser.tsx
+++ b/apps/web/src/components/terminal/terminalSnapshotReplay.browser.tsx
@@ -793,7 +793,10 @@ describe("recovered terminal snapshot replay in real xterm", () => {
             byteLength: 23,
           });
           await waitForCondition(
-            () => entry.pendingWriteBytes === 0,
+            () =>
+              acknowledgedBytes.includes(23) &&
+              entry.pendingWriteBytes === 0 &&
+              bufferText(entry.terminal).includes("LIVE-NORMAL-AFTER-CLEAR"),
             "normal post-clear output parsing",
           );
 

--- a/apps/web/src/components/terminal/terminalSnapshotReplay.browser.tsx
+++ b/apps/web/src/components/terminal/terminalSnapshotReplay.browser.tsx
@@ -1,0 +1,1497 @@
+// FILE: terminalSnapshotReplay.browser.tsx
+// Purpose: Native Chromium proof for recovered-grid replay using real xterm parsing.
+// Layer: Terminal browser integration tests
+
+import { FitAddon } from "@xterm/addon-fit";
+import { Terminal } from "@xterm/xterm";
+import "@xterm/xterm/css/xterm.css";
+import type { NativeApi, TerminalEvent, TerminalSessionSnapshot } from "@synara/contracts";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  applyReplayOnce,
+  createRecoveredGridOutputBuffer,
+  type ReplayIdentityState,
+  replaySnapshotAtDestinationGrid,
+  replaySnapshotAtRecoveredGrid,
+  shouldReplayColdSnapshot,
+} from "./terminalSnapshotReplay";
+import {
+  attachRuntimeToContainer,
+  createRuntimeEntry,
+  disposeRuntimeEntry,
+} from "./terminalRuntime";
+
+const terminals: Terminal[] = [];
+const hosts: HTMLDivElement[] = [];
+
+interface TerminalHarness {
+  fitAddon: FitAddon;
+  host: HTMLDivElement;
+  terminal: Terminal;
+}
+
+function createTerminal(cols = 80, rows = 12, width = 800, height = 300): TerminalHarness {
+  const host = document.createElement("div");
+  host.style.cssText = [
+    "position:absolute",
+    "left:0",
+    "top:0",
+    `width:${width}px`,
+    `height:${height}px`,
+  ].join(";");
+  document.body.append(host);
+  hosts.push(host);
+
+  const terminal = new Terminal({ cols, rows, scrollback: 500, allowProposedApi: true });
+  const fitAddon = new FitAddon();
+  terminals.push(terminal);
+  terminal.loadAddon(fitAddon);
+  terminal.open(host);
+  return { fitAddon, host, terminal };
+}
+
+function write(terminal: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => terminal.write(data, resolve));
+}
+
+function nextAnimationFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+function restoreWindowNativeApi(previousNativeApi: NativeApi | undefined): void {
+  if (previousNativeApi === undefined) {
+    delete window.nativeApi;
+    return;
+  }
+  window.nativeApi = previousNativeApi;
+}
+
+async function waitForCondition(
+  condition: () => boolean,
+  description: string,
+  timeoutMs = 3_000,
+): Promise<void> {
+  const deadline = performance.now() + timeoutMs;
+  while (!condition()) {
+    if (performance.now() >= deadline) throw new Error(`Timed out waiting for ${description}`);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function bufferText(terminal: Terminal): string {
+  const buffer = terminal.buffer.active;
+  const lines: string[] = [];
+  for (let index = 0; index < buffer.length; index += 1) {
+    lines.push(buffer.getLine(index)?.translateToString(true) ?? "");
+  }
+  return lines.join("\n");
+}
+
+function hasWrappedLine(terminal: Terminal): boolean {
+  const buffer = terminal.buffer.active;
+  for (let index = 0; index < buffer.length; index += 1) {
+    if (buffer.getLine(index)?.isWrapped) return true;
+  }
+  return false;
+}
+
+function hasAnsiRedCell(terminal: Terminal): boolean {
+  const buffer = terminal.buffer.active;
+  const reusableCell = buffer.getNullCell();
+  for (let row = 0; row < buffer.length; row += 1) {
+    const line = buffer.getLine(row);
+    if (!line) continue;
+    for (let column = 0; column < terminal.cols; column += 1) {
+      const cell = line.getCell(column, reusableCell);
+      if (cell?.getChars() === "r" && cell.isFgPalette() && cell.getFgColor() === 1) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function dimensionedSnapshot(
+  cols: number,
+  rows: number,
+  identity = "a".repeat(64),
+  history = complexHistory(),
+): TerminalSessionSnapshot & { recoveredCols: number; recoveredRows: number } {
+  return {
+    threadId: "thread",
+    terminalId: "default",
+    cwd: "C:\\project",
+    status: "running",
+    pid: 1,
+    history,
+    recoveredCols: cols,
+    recoveredRows: rows,
+    historyRecordIdentity: identity,
+    exitCode: null,
+    exitSignal: null,
+    updatedAt: new Date(0).toISOString(),
+  };
+}
+
+function legacySnapshot(history: string): TerminalSessionSnapshot {
+  return {
+    threadId: "thread",
+    terminalId: "default",
+    cwd: "C:\\project",
+    status: "running",
+    pid: 1,
+    history,
+    exitCode: null,
+    exitSignal: null,
+    updatedAt: new Date(0).toISOString(),
+  };
+}
+
+function complexHistory(): string {
+  return [
+    "ASCII 中 e\u0301 👩‍💻 \u001b[31mred\u001b[0m\r\n",
+    `${"wrapped-content-".repeat(12)}\r\n`,
+    "\u001b[4;7Hcursor",
+  ].join("");
+}
+
+async function seedDirtyDestination(terminal: Terminal, suffix: string): Promise<void> {
+  await write(
+    terminal,
+    [
+      `SCROLLBACK-SENTINEL-${suffix}\r\n`,
+      ...Array.from({ length: 45 }, (_, index) => `old-${suffix}-${index}\r\n`),
+      `DIRTY-DESTINATION-${suffix}`,
+    ].join(""),
+  );
+}
+
+afterEach(() => {
+  terminals.splice(0).forEach((terminal) => terminal.dispose());
+  hosts.splice(0).forEach((host) => host.remove());
+});
+
+describe("recovered terminal snapshot replay in real xterm", () => {
+  it.each([
+    ["shrink", 24, 8],
+    ["grow", 120, 20],
+    ["equal", 80, 12],
+  ])(
+    "replays a cold %s restore at its source grid without erasing scrollback",
+    async (name, sourceCols, sourceRows) => {
+      const { terminal } = createTerminal(80, 12);
+      await seedDirtyDestination(terminal, name);
+      const writes: string[] = [];
+      const backendResizes: Array<{ cols: number; rows: number }> = [];
+      const originalWrite = terminal.write.bind(terminal);
+      terminal.write = ((data: string | Uint8Array, callback?: () => void) => {
+        if (typeof data === "string") writes.push(data);
+        originalWrite(data, callback);
+      }) as Terminal["write"];
+
+      await replaySnapshotAtRecoveredGrid({
+        terminal,
+        snapshot: dimensionedSnapshot(sourceCols, sourceRows),
+        backendOpenDimensions: { cols: 80, rows: 12 },
+        measureFinalGrid: () => ({ cols: 80, rows: 12 }),
+        resizeBackend: async (dimensions) => {
+          backendResizes.push(dimensions);
+        },
+      });
+
+      const text = bufferText(terminal);
+      expect(text).toContain(`SCROLLBACK-SENTINEL-${name}`);
+      expect(text).not.toContain(`DIRTY-DESTINATION-${name}`);
+      expect(text).toContain("ASCII");
+      expect(text).toContain("中");
+      expect(text).toContain("é");
+      expect(text).toContain("👩‍💻");
+      expect(text).toContain("red");
+      expect(text).toContain("wrapped-content-");
+      expect(terminal.buffer.active.baseY).toBeGreaterThan(0);
+      expect(hasWrappedLine(terminal)).toBe(true);
+      expect(hasAnsiRedCell(terminal)).toBe(true);
+      expect(terminal.buffer.active.cursorX).toBe(12);
+      expect(terminal.buffer.active.cursorY).toBe(3);
+      expect(writes[0]).toBe("\u001b[2J\u001b[H");
+      expect(writes.every((value) => !value.includes("\u001b[3J"))).toBe(true);
+      expect(backendResizes).toEqual([]);
+    },
+  );
+
+  it("waits for clear parsing, fits one changed container, and sends one final backend resize", async () => {
+    const { fitAddon, host, terminal } = createTerminal(80, 12, 960, 360);
+    await nextAnimationFrame();
+    fitAddon.fit();
+    const backendOpenDimensions = { cols: terminal.cols, rows: terminal.rows };
+    expect(backendOpenDimensions.cols).toBeGreaterThan(0);
+    expect(backendOpenDimensions.rows).toBeGreaterThan(0);
+
+    host.style.width = "620px";
+    host.style.height = "230px";
+    await nextAnimationFrame();
+
+    const order: string[] = [];
+    const backendResizes: Array<{ cols: number; rows: number }> = [];
+    const originalWrite = terminal.write.bind(terminal);
+    let firstWrite = true;
+    terminal.write = ((data: string | Uint8Array, callback?: () => void) => {
+      if (firstWrite) {
+        firstWrite = false;
+        originalWrite(data, () => {
+          setTimeout(() => {
+            order.push("clear-parsed");
+            callback?.();
+          }, 20);
+        });
+        return;
+      }
+      order.push("history-write");
+      originalWrite(data, callback);
+    }) as Terminal["write"];
+    const originalResize = terminal.resize.bind(terminal);
+    terminal.resize = ((cols: number, rows: number) => {
+      order.push(`local:${cols}x${rows}`);
+      originalResize(cols, rows);
+    }) as Terminal["resize"];
+    let fitCalls = 0;
+
+    await replaySnapshotAtRecoveredGrid({
+      terminal,
+      snapshot: dimensionedSnapshot(40, 8),
+      backendOpenDimensions,
+      measureFinalGrid: () => {
+        fitCalls += 1;
+        return fitAddon.proposeDimensions();
+      },
+      resizeBackend: async (dimensions) => {
+        backendResizes.push(dimensions);
+        order.push("backend");
+      },
+    });
+
+    const finalDimensions = { cols: terminal.cols, rows: terminal.rows };
+    expect(host.getBoundingClientRect().width).toBe(620);
+    expect(host.getBoundingClientRect().height).toBe(230);
+    expect(finalDimensions).not.toEqual(backendOpenDimensions);
+    expect(order.indexOf("clear-parsed")).toBeLessThan(order.indexOf("local:40x8"));
+    expect(order.indexOf("history-write")).toBeGreaterThan(order.indexOf("local:40x8"));
+    expect(fitCalls).toBe(1);
+    expect(backendResizes).toEqual([finalDimensions]);
+  });
+
+  it("keeps legacy dimensionless replay on the destination grid", async () => {
+    const { terminal } = createTerminal(72, 11);
+    const history = `legacy-destination\r\n${"legacy-wrap-".repeat(12)}`;
+    await new Promise<void>((resolve) => {
+      replaySnapshotAtDestinationGrid(terminal, legacySnapshot(history), resolve);
+    });
+
+    expect(terminal.cols).toBe(72);
+    expect(terminal.rows).toBe(11);
+    expect(bufferText(terminal)).toContain("legacy-destination");
+    expect(hasWrappedLine(terminal)).toBe(true);
+  });
+
+  it("keeps a warm live terminal on its current grid and output path", async () => {
+    const { terminal } = createTerminal(76, 13);
+    await write(terminal, "WARM-LIVE-OUTPUT");
+    const snapshot = dimensionedSnapshot(30, 8, "b".repeat(64), "COLD-HISTORY");
+
+    const coldReplaySelected = shouldReplayColdSnapshot(snapshot, 7, 8);
+    expect(shouldReplayColdSnapshot(snapshot, 7, 7)).toBe(false);
+    if (coldReplaySelected) {
+      await replaySnapshotAtRecoveredGrid({
+        terminal,
+        snapshot,
+        backendOpenDimensions: { cols: 76, rows: 13 },
+        measureFinalGrid: () => ({ cols: 76, rows: 13 }),
+        resizeBackend: async () => undefined,
+      });
+    }
+
+    expect(coldReplaySelected).toBe(false);
+    expect(terminal.cols).toBe(76);
+    expect(terminal.rows).toBe(13);
+    expect(bufferText(terminal)).toContain("WARM-LIVE-OUTPUT");
+    expect(bufferText(terminal)).not.toContain("COLD-HISTORY");
+  });
+
+  it("deduplicates concurrent RPC and push delivery but applies a new equal-text record", async () => {
+    const { terminal } = createTerminal(80, 12);
+    const state: ReplayIdentityState = {
+      appliedHistoryRecordIdentity: null,
+      pendingHistoryRecordIdentity: null,
+      pendingHistoryReplayPromise: null,
+    };
+    const backendResizes: Array<{ cols: number; rows: number }> = [];
+    const history = "IDENTITY-REPLAY";
+    let replayCalls = 0;
+    const replay = (snapshot: ReturnType<typeof dimensionedSnapshot>) => async () => {
+      replayCalls += 1;
+      await replaySnapshotAtRecoveredGrid({
+        terminal,
+        snapshot,
+        backendOpenDimensions: { cols: 80, rows: 12 },
+        measureFinalGrid: () => ({ cols: 80, rows: 12 }),
+        resizeBackend: async (dimensions) => {
+          backendResizes.push(dimensions);
+        },
+      });
+    };
+    const firstSnapshot = dimensionedSnapshot(40, 8, "c".repeat(64), history);
+
+    const [rpcApplied, pushApplied] = await Promise.all([
+      applyReplayOnce(state, firstSnapshot.historyRecordIdentity, replay(firstSnapshot)),
+      applyReplayOnce(state, firstSnapshot.historyRecordIdentity, replay(firstSnapshot)),
+    ]);
+    const changedGridSnapshot = dimensionedSnapshot(50, 9, "d".repeat(64), history);
+    const changedGridApplied = await applyReplayOnce(
+      state,
+      changedGridSnapshot.historyRecordIdentity,
+      replay(changedGridSnapshot),
+    );
+
+    expect([rpcApplied, pushApplied].toSorted()).toEqual([false, true]);
+    expect(changedGridApplied).toBe(true);
+    expect(replayCalls).toBe(2);
+    expect(backendResizes).toEqual([]);
+    expect(bufferText(terminal)).toContain(history);
+  });
+
+  it("restores the final grid before releasing live output from an invalidated parse", async () => {
+    const { terminal } = createTerminal(90, 14);
+    const state: ReplayIdentityState = {
+      appliedHistoryRecordIdentity: null,
+      pendingHistoryRecordIdentity: null,
+      pendingHistoryReplayPromise: null,
+    };
+    const snapshot = dimensionedSnapshot(32, 8, "e".repeat(64), "RETRY-SUCCEEDED");
+    const backendResizes: Array<{ cols: number; rows: number }> = [];
+    const order: string[] = [];
+    let backendDimensions = { cols: 90, rows: 14 };
+    let active = true;
+    let attempt = 0;
+    let historyWrites = 0;
+    let activeOutputBuffer: ReturnType<typeof createRecoveredGridOutputBuffer> | null = null;
+    const originalWrite = terminal.write.bind(terminal);
+    terminal.write = ((data: string | Uint8Array, callback?: () => void) => {
+      if (data === snapshot.history) {
+        historyWrites += 1;
+        originalWrite(data, callback);
+        if (attempt === 1) {
+          activeOutputBuffer?.enqueue({ data: "\r\nLIVE-ONE", byteLength: 10 });
+          activeOutputBuffer?.enqueue({ data: "\r\nLIVE-二", byteLength: 10 });
+          active = false;
+          order.push("history-started-and-invalidated");
+        }
+        return;
+      }
+      originalWrite(data, callback);
+    }) as Terminal["write"];
+    const replay = async () => {
+      attempt += 1;
+      const outputBuffer = createRecoveredGridOutputBuffer();
+      activeOutputBuffer = outputBuffer;
+      try {
+        await replaySnapshotAtRecoveredGrid({
+          terminal,
+          snapshot,
+          backendOpenDimensions: backendDimensions,
+          measureFinalGrid: () => {
+            order.push("measure:80x12");
+            return { cols: 80, rows: 12 };
+          },
+          resizeBackend: async (dimensions) => {
+            backendResizes.push(dimensions);
+            backendDimensions = dimensions;
+            order.push(`backend:${dimensions.cols}x${dimensions.rows}`);
+          },
+          isActive: () => active,
+        });
+      } finally {
+        activeOutputBuffer = null;
+        for (const output of outputBuffer.drain()) {
+          order.push(`live:${output.data.trim()}@${terminal.cols}x${terminal.rows}`);
+          await write(terminal, output.data);
+        }
+      }
+    };
+
+    await expect(applyReplayOnce(state, snapshot.historyRecordIdentity, replay)).rejects.toThrow(
+      "aborted",
+    );
+    expect(terminal.cols).toBe(80);
+    expect(terminal.rows).toBe(12);
+    expect(backendResizes).toEqual([{ cols: 80, rows: 12 }]);
+    expect(bufferText(terminal)).toContain("LIVE-ONE");
+    expect(bufferText(terminal)).toContain("LIVE-二");
+    expect(order.indexOf("backend:80x12")).toBeLessThan(order.indexOf("live:LIVE-ONE@80x12"));
+    expect(state).toEqual({
+      appliedHistoryRecordIdentity: null,
+      pendingHistoryRecordIdentity: null,
+      pendingHistoryReplayPromise: null,
+    });
+
+    active = true;
+    expect(await applyReplayOnce(state, snapshot.historyRecordIdentity, replay)).toBe(true);
+    expect(await applyReplayOnce(state, snapshot.historyRecordIdentity, replay)).toBe(false);
+    expect(historyWrites).toBe(2);
+    expect(backendResizes).toEqual([{ cols: 80, rows: 12 }]);
+    expect(state.appliedHistoryRecordIdentity).toBe(snapshot.historyRecordIdentity);
+  });
+
+  it.each(["throws", "is unavailable"])(
+    "falls back before releasing invalidating live output when fit measurement %s",
+    async (measurementFailure) => {
+      const { terminal } = createTerminal(90, 14);
+      const snapshot = dimensionedSnapshot(32, 8, "f".repeat(64), "RECOVERED-HISTORY");
+      const outputBuffer = createRecoveredGridOutputBuffer();
+      const backendResizes: Array<{ cols: number; rows: number }> = [];
+      const order: string[] = [];
+      let active = true;
+      const originalWrite = terminal.write.bind(terminal);
+      terminal.write = ((data: string | Uint8Array, callback?: () => void) => {
+        if (typeof data === "string") {
+          order.push(`write:${data.trim()}@${terminal.cols}x${terminal.rows}`);
+        }
+        if (data === snapshot.history) {
+          originalWrite(data, () => {
+            outputBuffer.enqueue({ data: "\r\nLIVE-A", byteLength: 8 });
+            outputBuffer.enqueue({ data: "\r\nLIVE-β", byteLength: 9 });
+            active = false;
+            callback?.();
+          });
+          return;
+        }
+        originalWrite(data, callback);
+      }) as Terminal["write"];
+
+      try {
+        await expect(
+          replaySnapshotAtRecoveredGrid({
+            terminal,
+            snapshot,
+            backendOpenDimensions: { cols: 90, rows: 14 },
+            measureFinalGrid: () => {
+              order.push("measure");
+              if (measurementFailure === "throws") throw new Error("renderer unavailable");
+              return undefined;
+            },
+            resizeBackend: async (dimensions) => {
+              backendResizes.push(dimensions);
+            },
+            isActive: () => active,
+          }),
+        ).rejects.toThrow("aborted");
+      } finally {
+        for (const output of outputBuffer.drain()) await write(terminal, output.data);
+      }
+
+      expect(terminal.cols).toBe(90);
+      expect(terminal.rows).toBe(14);
+      expect(backendResizes).toEqual([]);
+      expect(bufferText(terminal)).toContain("RECOVERED-HISTORY");
+      expect(bufferText(terminal)).toContain("LIVE-A");
+      expect(bufferText(terminal)).toContain("LIVE-β");
+      expect(order).toContain("write:RECOVERED-HISTORY@32x8");
+      expect(order).toContain("write:LIVE-A@90x14");
+      expect(order).toContain("write:LIVE-β@90x14");
+      expect(order.indexOf("measure")).toBeLessThan(order.indexOf("write:LIVE-A@90x14"));
+      expect(order.indexOf("write:LIVE-A@90x14")).toBeLessThan(order.indexOf("write:LIVE-β@90x14"));
+    },
+  );
+
+  it("detects a no-op measured fit and releases live output only after fallback", async () => {
+    const { terminal } = createTerminal(90, 14);
+    const snapshot = dimensionedSnapshot(32, 8, "1".repeat(64), "NO-OP-HISTORY");
+    const outputBuffer = createRecoveredGridOutputBuffer();
+    const order: string[] = [];
+    let ignoreMeasuredResize = true;
+    let active = true;
+    const originalResize = terminal.resize.bind(terminal);
+    terminal.resize = ((cols: number, rows: number) => {
+      if (cols === 80 && rows === 12 && ignoreMeasuredResize) {
+        ignoreMeasuredResize = false;
+        order.push("measured-resize-no-op");
+        return;
+      }
+      originalResize(cols, rows);
+      order.push(`resize:${cols}x${rows}`);
+    }) as Terminal["resize"];
+    const originalWrite = terminal.write.bind(terminal);
+    terminal.write = ((data: string | Uint8Array, callback?: () => void) => {
+      if (typeof data === "string") {
+        order.push(`write:${data.trim()}@${terminal.cols}x${terminal.rows}`);
+      }
+      if (data === snapshot.history) {
+        originalWrite(data, () => {
+          outputBuffer.enqueue({ data: "\r\nLIVE-AFTER-NO-OP", byteLength: 18 });
+          active = false;
+          callback?.();
+        });
+        return;
+      }
+      originalWrite(data, callback);
+    }) as Terminal["write"];
+
+    try {
+      await expect(
+        replaySnapshotAtRecoveredGrid({
+          terminal,
+          snapshot,
+          backendOpenDimensions: { cols: 90, rows: 14 },
+          measureFinalGrid: () => ({ cols: 80, rows: 12 }),
+          resizeBackend: async () => {
+            order.push("backend");
+          },
+          isActive: () => active,
+        }),
+      ).rejects.toThrow("aborted");
+    } finally {
+      for (const output of outputBuffer.drain()) await write(terminal, output.data);
+    }
+
+    expect(terminal.cols).toBe(90);
+    expect(terminal.rows).toBe(14);
+    expect(order).toContain("measured-resize-no-op");
+    expect(order).toContain("resize:90x14");
+    expect(order).toContain("write:LIVE-AFTER-NO-OP@90x14");
+    expect(order).not.toContain("backend");
+    expect(order.indexOf("resize:90x14")).toBeLessThan(
+      order.indexOf("write:LIVE-AFTER-NO-OP@90x14"),
+    );
+  });
+
+  it.each(["before applying", "after partial application"])(
+    "restores when staging resize throws %s before releasing output",
+    async (failurePoint) => {
+      const { terminal } = createTerminal(90, 14);
+      const snapshot = dimensionedSnapshot(32, 8, "2".repeat(64), "MUST-NOT-PARSE");
+      const outputBuffer = createRecoveredGridOutputBuffer();
+      outputBuffer.enqueue({ data: "LIVE-AFTER-STAGING-FAILURE", byteLength: 26 });
+      const order: string[] = [];
+      let failStaging = true;
+      const originalResize = terminal.resize.bind(terminal);
+      terminal.resize = ((cols: number, rows: number) => {
+        if (failStaging) {
+          failStaging = false;
+          if (failurePoint === "after partial application") originalResize(cols, 14);
+          order.push(`staging-failed:${terminal.cols}x${terminal.rows}`);
+          throw new Error(`staging failed ${failurePoint}`);
+        }
+        originalResize(cols, rows);
+        order.push(`resize:${cols}x${rows}`);
+      }) as Terminal["resize"];
+      const originalWrite = terminal.write.bind(terminal);
+      terminal.write = ((data: string | Uint8Array, callback?: () => void) => {
+        if (typeof data === "string") {
+          order.push(`write:${data.trim()}@${terminal.cols}x${terminal.rows}`);
+        }
+        originalWrite(data, callback);
+      }) as Terminal["write"];
+
+      try {
+        await expect(
+          replaySnapshotAtRecoveredGrid({
+            terminal,
+            snapshot,
+            backendOpenDimensions: { cols: 90, rows: 14 },
+            measureFinalGrid: () => {
+              order.push("measure");
+              return { cols: 80, rows: 12 };
+            },
+            resizeBackend: async () => {
+              order.push("backend");
+            },
+          }),
+        ).rejects.toThrow(`staging failed ${failurePoint}`);
+      } finally {
+        for (const output of outputBuffer.drain()) await write(terminal, output.data);
+      }
+
+      expect(terminal.cols).toBe(90);
+      expect(terminal.rows).toBe(14);
+      expect(order).toContain(
+        failurePoint === "after partial application"
+          ? "staging-failed:32x14"
+          : "staging-failed:90x14",
+      );
+      expect(order).toContain("write:LIVE-AFTER-STAGING-FAILURE@90x14");
+      expect(order).not.toContain("write:MUST-NOT-PARSE");
+      expect(order).not.toContain("measure");
+      expect(order).not.toContain("backend");
+      if (failurePoint === "after partial application") {
+        expect(order).toContain("resize:90x14");
+      }
+    },
+  );
+
+  it.each(["started", "restarted", "cleared"] as const)(
+    "handles retained runtime output through a later %s event and resumes normal delivery",
+    async (retryEventType) => {
+      const host = document.createElement("div");
+      host.style.cssText = "position:absolute;left:0;top:0;width:900px;height:320px;display:block;";
+      document.body.append(host);
+      hosts.push(host);
+
+      let terminalEventListener: ((event: TerminalEvent) => void) | undefined;
+      const backendResizes: Array<{ cols: number; rows: number }> = [];
+      const acknowledgedBytes: number[] = [];
+      const initialSnapshot = dimensionedSnapshot(80, 24, "0".repeat(64), "");
+      const nativeApi = {
+        terminal: {
+          open: async () => initialSnapshot,
+          write: async () => undefined,
+          ackOutput: async (input: { bytes: number }) => {
+            acknowledgedBytes.push(input.bytes);
+          },
+          resize: async (dimensions: { cols: number; rows: number }) => {
+            backendResizes.push(dimensions);
+          },
+          clear: async () => undefined,
+          restart: async () => initialSnapshot,
+          close: async () => undefined,
+          onEvent: (listener: (event: TerminalEvent) => void) => {
+            terminalEventListener = listener;
+            return () => {
+              if (terminalEventListener === listener) terminalEventListener = undefined;
+            };
+          },
+        },
+      } as unknown as NativeApi;
+      const previousNativeApi = window.nativeApi;
+      window.nativeApi = nativeApi;
+
+      const entry = createRuntimeEntry({
+        runtimeKey: "thread::default",
+        threadId: "thread",
+        terminalId: "default",
+        terminalLabel: "Terminal",
+        cwd: "C:\\project",
+        callbacks: {
+          onSessionExited: () => undefined,
+          onTerminalMetadataChange: () => undefined,
+          onTerminalActivityChange: () => undefined,
+        },
+      });
+      const originalResize = entry.terminal.resize.bind(entry.terminal);
+      const originalWrite = entry.terminal.write.bind(entry.terminal);
+
+      try {
+        attachRuntimeToContainer(entry, { autoFocus: false, isVisible: true }, host);
+        await waitForCondition(
+          () => entry.opened && entry.runtimeStatus === "ready",
+          "initial terminal open",
+        );
+        expect(terminalEventListener).toBeTypeOf("function");
+        const backendOpenDimensions = entry.backendOpenDimensions;
+        expect(backendOpenDimensions).not.toBeNull();
+        if (!backendOpenDimensions) throw new Error("missing backend-open dimensions");
+
+        const snapshot = dimensionedSnapshot(
+          32,
+          8,
+          retryEventType === "started"
+            ? "3".repeat(64)
+            : retryEventType === "restarted"
+              ? "4".repeat(64)
+              : "5".repeat(64),
+          "RUNTIME-RECOVERED-HISTORY",
+        );
+        let rejectFallback = true;
+        let historyWrites = 0;
+        let authoritativeHistoryWrites = 0;
+        const authoritativeHistory = [
+          snapshot.history,
+          "\r\nLIVE-BEFORE-UNSAFE",
+          "\r\nLIVE-AFTER-UNSAFE",
+        ].join("");
+        const authoritativeSnapshot = legacySnapshot(authoritativeHistory);
+        entry.fitAddon.proposeDimensions = () => undefined;
+        entry.terminal.resize = ((cols: number, rows: number) => {
+          if (
+            rejectFallback &&
+            cols === backendOpenDimensions.cols &&
+            rows === backendOpenDimensions.rows
+          ) {
+            return;
+          }
+          originalResize(cols, rows);
+        }) as Terminal["resize"];
+        entry.terminal.write = ((data: string | Uint8Array, callback?: () => void) => {
+          if (data === snapshot.history) {
+            historyWrites += 1;
+            originalWrite(data, () => {
+              if (historyWrites === 1) {
+                terminalEventListener?.({
+                  type: "output",
+                  threadId: "thread",
+                  terminalId: "default",
+                  createdAt: new Date(1).toISOString(),
+                  data: "\r\nLIVE-BEFORE-UNSAFE",
+                  byteLength: 20,
+                });
+              }
+              callback?.();
+            });
+            return;
+          }
+          if (data === authoritativeHistory) {
+            authoritativeHistoryWrites += 1;
+          }
+          originalWrite(data, callback);
+        }) as Terminal["write"];
+
+        terminalEventListener?.({
+          type: "started",
+          threadId: "thread",
+          terminalId: "default",
+          createdAt: new Date(2).toISOString(),
+          snapshot,
+        });
+        await waitForCondition(
+          () => historyWrites === 1 && entry.pendingHistoryReplayPromise === null,
+          "unsafe replay rejection",
+        );
+        expect(entry.appliedHistoryRecordIdentity).toBeNull();
+        expect(bufferText(entry.terminal)).not.toContain("LIVE-BEFORE-UNSAFE");
+
+        terminalEventListener?.({
+          type: "output",
+          threadId: "thread",
+          terminalId: "default",
+          createdAt: new Date(3).toISOString(),
+          data: "\r\nLIVE-AFTER-UNSAFE",
+          byteLength: 19,
+        });
+        expect(bufferText(entry.terminal)).not.toContain("LIVE-AFTER-UNSAFE");
+        expect(entry.runtimeStatus).toBe("error");
+
+        rejectFallback = false;
+        if (retryEventType === "cleared") {
+          terminalEventListener?.({
+            type: "cleared",
+            threadId: "thread",
+            terminalId: "default",
+            createdAt: new Date(4).toISOString(),
+          });
+          await waitForCondition(
+            () =>
+              entry.runtimeStatus === "ready" &&
+              entry.terminal.cols === backendOpenDimensions.cols &&
+              entry.terminal.rows === backendOpenDimensions.rows,
+            "retained output clear recovery",
+          );
+          terminalEventListener?.({
+            type: "output",
+            threadId: "thread",
+            terminalId: "default",
+            createdAt: new Date(5).toISOString(),
+            data: "LIVE-NORMAL-AFTER-CLEAR",
+            byteLength: 23,
+          });
+          await waitForCondition(
+            () => entry.pendingWriteBytes === 0,
+            "normal post-clear output parsing",
+          );
+
+          const text = bufferText(entry.terminal);
+          expect(text).not.toContain("LIVE-BEFORE-UNSAFE");
+          expect(text).not.toContain("LIVE-AFTER-UNSAFE");
+          expect(text).toContain("LIVE-NORMAL-AFTER-CLEAR");
+          expect(entry.appliedHistoryRecordIdentity).toBeNull();
+          expect(historyWrites).toBe(1);
+          expect(backendResizes).toEqual([]);
+          expect(acknowledgedBytes).toContain(39);
+          expect(acknowledgedBytes).toContain(23);
+          return;
+        }
+
+        terminalEventListener?.({
+          type: retryEventType,
+          threadId: "thread",
+          terminalId: "default",
+          createdAt: new Date(4).toISOString(),
+          snapshot: authoritativeSnapshot,
+        });
+        await waitForCondition(
+          () =>
+            entry.pendingHistoryReplayPromise === null &&
+            entry.appliedHistoryRecordIdentity?.startsWith("legacy:") === true,
+          "retained dimensionless authoritative retry",
+        );
+        await waitForCondition(() => entry.pendingWriteBytes === 0, "retained output parsing");
+
+        terminalEventListener?.({
+          type: "output",
+          threadId: "thread",
+          terminalId: "default",
+          createdAt: new Date(5).toISOString(),
+          data: "\r\nLIVE-NORMAL-AFTER-RETRY",
+          byteLength: 25,
+        });
+        await waitForCondition(
+          () => entry.pendingWriteBytes === 0,
+          "normal post-retry output parsing",
+        );
+
+        const text = bufferText(entry.terminal);
+        const beforeIndex = text.indexOf("LIVE-BEFORE-UNSAFE");
+        const afterIndex = text.indexOf("LIVE-AFTER-UNSAFE");
+        const normalIndex = text.indexOf("LIVE-NORMAL-AFTER-RETRY");
+        expect(beforeIndex).toBeGreaterThanOrEqual(0);
+        expect(afterIndex).toBeGreaterThan(beforeIndex);
+        expect(normalIndex).toBeGreaterThan(afterIndex);
+        expect(text.split("LIVE-BEFORE-UNSAFE")).toHaveLength(2);
+        expect(text.split("LIVE-AFTER-UNSAFE")).toHaveLength(2);
+        expect(historyWrites).toBe(1);
+        expect(authoritativeHistoryWrites).toBe(1);
+        expect(backendResizes).toEqual([]);
+        expect(acknowledgedBytes).toContain(39);
+        expect(acknowledgedBytes).toContain(25);
+      } finally {
+        entry.terminal.resize = originalResize as Terminal["resize"];
+        entry.terminal.write = originalWrite as Terminal["write"];
+        disposeRuntimeEntry(entry);
+        restoreWindowNativeApi(previousNativeApi);
+        document.getElementById("synara-terminal-parking")?.remove();
+      }
+    },
+  );
+
+  it.each(["no-op", "partial"] as const)(
+    "rejects a silent %s recovered-grid staging resize before real xterm parses history",
+    async (failureMode) => {
+      const { terminal } = createTerminal(90, 14);
+      const originalResize = terminal.resize.bind(terminal);
+      const originalWrite = terminal.write.bind(terminal);
+      const snapshot = dimensionedSnapshot(32, 8, "6".repeat(64), "MUST-NOT-PARSE");
+      let failStaging = true;
+      let historyWrites = 0;
+      terminal.resize = ((cols: number, rows: number) => {
+        if (failStaging && cols === snapshot.recoveredCols && rows === snapshot.recoveredRows) {
+          if (failureMode === "partial") originalResize(cols, terminal.rows);
+          return;
+        }
+        originalResize(cols, rows);
+      }) as Terminal["resize"];
+      terminal.write = ((data: string | Uint8Array, callback?: () => void) => {
+        if (data === snapshot.history) historyWrites += 1;
+        originalWrite(data, callback);
+      }) as Terminal["write"];
+
+      await expect(
+        replaySnapshotAtRecoveredGrid({
+          terminal,
+          snapshot,
+          backendOpenDimensions: { cols: 90, rows: 14 },
+          measureFinalGrid: () => ({ cols: 90, rows: 14 }),
+          resizeBackend: async () => undefined,
+        }),
+      ).rejects.toThrow("staging resize did not reach");
+      expect({ cols: terminal.cols, rows: terminal.rows }).toEqual({ cols: 90, rows: 14 });
+      expect(historyWrites).toBe(0);
+
+      failStaging = false;
+      await replaySnapshotAtRecoveredGrid({
+        terminal,
+        snapshot,
+        backendOpenDimensions: { cols: 90, rows: 14 },
+        measureFinalGrid: () => ({ cols: 90, rows: 14 }),
+        resizeBackend: async () => undefined,
+      });
+      expect(historyWrites).toBe(1);
+    },
+  );
+
+  it.each(["push-before-rpc", "rpc-before-push"] as const)(
+    "deduplicates concurrent and sequential legacy delivery in %s order and replays changed history",
+    async (deliveryOrder) => {
+      const host = document.createElement("div");
+      host.style.cssText = "position:absolute;left:0;top:0;width:900px;height:320px;display:block;";
+      document.body.append(host);
+      hosts.push(host);
+
+      const firstSnapshot = legacySnapshot("LEGACY-HISTORY-A");
+      const changedSnapshot = legacySnapshot("LEGACY-HISTORY-B");
+      let resolveInitialOpen: ((snapshot: TerminalSessionSnapshot) => void) | undefined;
+      const initialOpen = new Promise<TerminalSessionSnapshot>((resolve) => {
+        resolveInitialOpen = resolve;
+      });
+      let openCalls = 0;
+      let terminalEventListener: ((event: TerminalEvent) => void) | undefined;
+      const nativeApi = {
+        terminal: {
+          open: () => {
+            openCalls += 1;
+            return openCalls === 1 ? initialOpen : Promise.resolve(firstSnapshot);
+          },
+          write: async () => undefined,
+          ackOutput: async () => undefined,
+          resize: async () => undefined,
+          clear: async () => undefined,
+          restart: async () => firstSnapshot,
+          close: async () => undefined,
+          onEvent: (listener: (event: TerminalEvent) => void) => {
+            terminalEventListener = listener;
+            return () => {
+              if (terminalEventListener === listener) terminalEventListener = undefined;
+            };
+          },
+        },
+      } as unknown as NativeApi;
+      const previousNativeApi = window.nativeApi;
+      window.nativeApi = nativeApi;
+      const entry = createRuntimeEntry({
+        runtimeKey: `thread::dedup-${deliveryOrder}`,
+        threadId: "thread",
+        terminalId: `dedup-${deliveryOrder}`,
+        terminalLabel: "Terminal",
+        cwd: "C:\\project",
+        callbacks: {
+          onSessionExited: () => undefined,
+          onTerminalMetadataChange: () => undefined,
+          onTerminalActivityChange: () => undefined,
+        },
+      });
+      const originalWrite = entry.terminal.write.bind(entry.terminal);
+      const writes: string[] = [];
+      entry.terminal.write = ((data: string | Uint8Array, callback?: () => void) => {
+        if (typeof data === "string") writes.push(data);
+        originalWrite(data, callback);
+      }) as Terminal["write"];
+      const push = (snapshot: TerminalSessionSnapshot) =>
+        terminalEventListener?.({
+          type: "started",
+          threadId: "thread",
+          terminalId: entry.terminalId,
+          createdAt: new Date().toISOString(),
+          snapshot,
+        });
+
+      try {
+        attachRuntimeToContainer(entry, { autoFocus: false, isVisible: true }, host);
+        await waitForCondition(
+          () => terminalEventListener !== undefined && entry.opened,
+          "legacy runtime subscription",
+        );
+
+        if (deliveryOrder === "push-before-rpc") {
+          push(firstSnapshot);
+          resolveInitialOpen?.(firstSnapshot);
+        } else {
+          resolveInitialOpen?.(firstSnapshot);
+          await waitForCondition(
+            () => writes.filter((write) => write === firstSnapshot.history).length === 1,
+            "initial RPC legacy replay",
+          );
+          push(firstSnapshot);
+        }
+        await waitForCondition(
+          () =>
+            entry.pendingHistoryReplayPromise === null &&
+            writes.filter((write) => write === firstSnapshot.history).length === 1,
+          "deduplicated legacy replay",
+        );
+
+        // Exercise sequential delivery after the concurrent/order-specific pair.
+        push(firstSnapshot);
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        expect(writes.filter((write) => write === "\u001bc")).toHaveLength(1);
+        expect(writes.filter((write) => write === firstSnapshot.history)).toHaveLength(1);
+
+        push(changedSnapshot);
+        await waitForCondition(
+          () => writes.filter((write) => write === changedSnapshot.history).length === 1,
+          "changed legacy replay",
+        );
+        expect(writes.filter((write) => write === "\u001bc")).toHaveLength(2);
+        expect(writes.filter((write) => write === changedSnapshot.history)).toHaveLength(1);
+      } finally {
+        entry.terminal.write = originalWrite as Terminal["write"];
+        disposeRuntimeEntry(entry);
+        restoreWindowNativeApi(previousNativeApi);
+        document.getElementById("synara-terminal-parking")?.remove();
+      }
+    },
+  );
+
+  it.each(["resolves", "rejects"] as const)(
+    "settles a dispatched ordinary backend resize that %s before recovered-grid staging",
+    async (settlementMode) => {
+      const host = document.createElement("div");
+      host.style.cssText = "position:absolute;left:0;top:0;width:900px;height:320px;display:block;";
+      document.body.append(host);
+      hosts.push(host);
+
+      let terminalEventListener: ((event: TerminalEvent) => void) | undefined;
+      let ordinaryTarget: { cols: number; rows: number } | null = null;
+      let resolveOrdinary: (() => void) | undefined;
+      let rejectOrdinary: ((error: Error) => void) | undefined;
+      const resizeInputs: Array<{ cols: number; rows: number }> = [];
+      const order: string[] = [];
+      const nativeApi = {
+        terminal: {
+          open: async () => legacySnapshot(""),
+          write: async () => undefined,
+          ackOutput: async () => undefined,
+          resize: async (input: { cols: number; rows: number }) => {
+            resizeInputs.push({ cols: input.cols, rows: input.rows });
+            if (
+              ordinaryTarget &&
+              input.cols === ordinaryTarget.cols &&
+              input.rows === ordinaryTarget.rows
+            ) {
+              order.push("ordinary-dispatched");
+              await new Promise<void>((resolve, reject) => {
+                resolveOrdinary = resolve;
+                rejectOrdinary = reject;
+              });
+            }
+          },
+          clear: async () => undefined,
+          restart: async () => legacySnapshot(""),
+          close: async () => undefined,
+          onEvent: (listener: (event: TerminalEvent) => void) => {
+            terminalEventListener = listener;
+            return () => {
+              if (terminalEventListener === listener) terminalEventListener = undefined;
+            };
+          },
+        },
+      } as unknown as NativeApi;
+      const previousNativeApi = window.nativeApi;
+      window.nativeApi = nativeApi;
+      const entry = createRuntimeEntry({
+        runtimeKey: `thread::resize-${settlementMode}`,
+        threadId: "thread",
+        terminalId: `resize-${settlementMode}`,
+        terminalLabel: "Terminal",
+        cwd: "C:\\project",
+        callbacks: {
+          onSessionExited: () => undefined,
+          onTerminalMetadataChange: () => undefined,
+          onTerminalActivityChange: () => undefined,
+        },
+      });
+      const originalFit = entry.fitAddon.fit.bind(entry.fitAddon);
+      const originalWrite = entry.terminal.write.bind(entry.terminal);
+      const recoverySnapshot = dimensionedSnapshot(
+        32,
+        8,
+        settlementMode === "resolves" ? "7".repeat(64) : "8".repeat(64),
+        `RECOVERY-AFTER-ORDINARY-${settlementMode}`,
+      );
+      entry.terminal.write = ((data: string | Uint8Array, callback?: () => void) => {
+        if (data === recoverySnapshot.history) order.push("history");
+        originalWrite(data, callback);
+      }) as Terminal["write"];
+
+      try {
+        attachRuntimeToContainer(entry, { autoFocus: false, isVisible: true }, host);
+        await waitForCondition(
+          () => entry.opened && entry.runtimeStatus === "ready",
+          "ordinary-resize runtime open",
+        );
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        resizeInputs.length = 0;
+        const initialBackend = entry.backendOpenDimensions;
+        expect(initialBackend).not.toBeNull();
+        if (!initialBackend) throw new Error("missing initial backend dimensions");
+        ordinaryTarget = {
+          cols: Math.min(initialBackend.cols + 7, 512),
+          rows: Math.min(initialBackend.rows + 2, 256),
+        };
+        const expectedBackend = settlementMode === "resolves" ? ordinaryTarget : initialBackend;
+        entry.fitAddon.fit = () => {
+          if (!ordinaryTarget) return;
+          entry.terminal.resize(ordinaryTarget.cols, ordinaryTarget.rows);
+        };
+        entry.fitAddon.proposeDimensions = () => expectedBackend;
+        window.dispatchEvent(new Event("focus"));
+        await waitForCondition(
+          () => order.includes("ordinary-dispatched") && entry.backendResizeSettlement !== null,
+          "ordinary backend resize dispatch",
+        );
+
+        terminalEventListener?.({
+          type: "started",
+          threadId: "thread",
+          terminalId: entry.terminalId,
+          createdAt: new Date().toISOString(),
+          snapshot: recoverySnapshot,
+        });
+        await waitForCondition(
+          () => entry.pendingHistoryReplayPromise !== null,
+          "recovery waiting for ordinary resize",
+        );
+        expect(order).not.toContain("history");
+
+        order.push(`ordinary-${settlementMode}`);
+        if (settlementMode === "resolves") {
+          resolveOrdinary?.();
+        } else {
+          rejectOrdinary?.(new Error("ordinary resize rejected"));
+        }
+        await waitForCondition(
+          () => entry.appliedHistoryRecordIdentity === recoverySnapshot.historyRecordIdentity,
+          "recovery after ordinary resize settlement",
+        );
+
+        expect(entry.backendOpenDimensions).toEqual(expectedBackend);
+        expect({ cols: entry.terminal.cols, rows: entry.terminal.rows }).toEqual(expectedBackend);
+        expect(entry.backendResizeSettlement).toBeNull();
+        expect(resizeInputs).toEqual([ordinaryTarget]);
+        expect(order.indexOf(`ordinary-${settlementMode}`)).toBeLessThan(order.indexOf("history"));
+      } finally {
+        entry.fitAddon.fit = originalFit;
+        entry.terminal.write = originalWrite as Terminal["write"];
+        disposeRuntimeEntry(entry);
+        restoreWindowNativeApi(previousNativeApi);
+        document.getElementById("synara-terminal-parking")?.remove();
+      }
+    },
+  );
+
+  it("converges before draining output emitted during the final recovery backend resize", async () => {
+    const host = document.createElement("div");
+    host.style.cssText = "position:absolute;left:0;top:0;width:900px;height:320px;display:block;";
+    document.body.append(host);
+    hosts.push(host);
+
+    let terminalEventListener: ((event: TerminalEvent) => void) | undefined;
+    let deferResize = false;
+    let resolveResize: (() => void) | undefined;
+    const resizeInputs: Array<{ cols: number; rows: number }> = [];
+    const acknowledgedBytes: number[] = [];
+    const nativeApi = {
+      terminal: {
+        open: async () => legacySnapshot(""),
+        write: async () => undefined,
+        ackOutput: async (input: { bytes: number }) => {
+          acknowledgedBytes.push(input.bytes);
+        },
+        resize: async (input: { cols: number; rows: number }) => {
+          if (!deferResize) return;
+          resizeInputs.push({ cols: input.cols, rows: input.rows });
+          await new Promise<void>((resolve) => {
+            resolveResize = resolve;
+          });
+        },
+        clear: async () => undefined,
+        restart: async () => legacySnapshot(""),
+        close: async () => undefined,
+        onEvent: (listener: (event: TerminalEvent) => void) => {
+          terminalEventListener = listener;
+          return () => {
+            if (terminalEventListener === listener) terminalEventListener = undefined;
+          };
+        },
+      },
+    } as unknown as NativeApi;
+    const previousNativeApi = window.nativeApi;
+    window.nativeApi = nativeApi;
+    const entry = createRuntimeEntry({
+      runtimeKey: "thread::final-resize-output",
+      threadId: "thread",
+      terminalId: "final-resize-output",
+      terminalLabel: "Terminal",
+      cwd: "C:\\project",
+      callbacks: {
+        onSessionExited: () => undefined,
+        onTerminalMetadataChange: () => undefined,
+        onTerminalActivityChange: () => undefined,
+      },
+    });
+    const snapshot = dimensionedSnapshot(32, 8, "9".repeat(64), "RECOVERED-BEFORE-LIVE");
+
+    try {
+      attachRuntimeToContainer(entry, { autoFocus: false, isVisible: true }, host);
+      await waitForCondition(
+        () => entry.opened && entry.runtimeStatus === "ready",
+        "final-resize runtime open",
+      );
+      const initialBackend = entry.backendOpenDimensions;
+      expect(initialBackend).not.toBeNull();
+      if (!initialBackend) throw new Error("missing initial backend dimensions");
+      const finalDimensions = {
+        cols: Math.min(initialBackend.cols + 5, 512),
+        rows: Math.min(initialBackend.rows + 2, 256),
+      };
+      entry.fitAddon.proposeDimensions = () => finalDimensions;
+      deferResize = true;
+
+      terminalEventListener?.({
+        type: "started",
+        threadId: "thread",
+        terminalId: entry.terminalId,
+        createdAt: new Date().toISOString(),
+        snapshot,
+      });
+      await waitForCondition(() => resizeInputs.length === 1, "final recovery backend resize");
+      terminalEventListener?.({
+        type: "output",
+        threadId: "thread",
+        terminalId: entry.terminalId,
+        createdAt: new Date().toISOString(),
+        data: "\r\nLIVE-DURING-FINAL",
+        byteLength: 20,
+      });
+      resolveResize?.();
+
+      await waitForCondition(
+        () => entry.pendingHistoryReplayPromise === null && entry.pendingWriteBytes === 0,
+        "live output after final resize",
+      );
+      const text = bufferText(entry.terminal);
+      expect(entry.backendOpenDimensions).toEqual(finalDimensions);
+      expect({ cols: entry.terminal.cols, rows: entry.terminal.rows }).toEqual(finalDimensions);
+      expect(entry.appliedHistoryRecordIdentity).toBeNull();
+      expect(text.split("LIVE-DURING-FINAL")).toHaveLength(2);
+      expect(text.indexOf("RECOVERED-BEFORE-LIVE")).toBeLessThan(text.indexOf("LIVE-DURING-FINAL"));
+      expect(resizeInputs).toEqual([finalDimensions]);
+      expect(acknowledgedBytes).toEqual([20]);
+    } finally {
+      disposeRuntimeEntry(entry);
+      restoreWindowNativeApi(previousNativeApi);
+      document.getElementById("synara-terminal-parking")?.remove();
+    }
+  });
+
+  it("applies a clear received at the staged grid before releasing post-clear output", async () => {
+    const host = document.createElement("div");
+    host.style.cssText = "position:absolute;left:0;top:0;width:900px;height:320px;display:block;";
+    document.body.append(host);
+    hosts.push(host);
+
+    let terminalEventListener: ((event: TerminalEvent) => void) | undefined;
+    const acknowledgedBytes: number[] = [];
+    const nativeApi = {
+      terminal: {
+        open: async () => legacySnapshot(""),
+        write: async () => undefined,
+        ackOutput: async (input: { bytes: number }) => {
+          acknowledgedBytes.push(input.bytes);
+        },
+        resize: async () => undefined,
+        clear: async () => undefined,
+        restart: async () => legacySnapshot(""),
+        close: async () => undefined,
+        onEvent: (listener: (event: TerminalEvent) => void) => {
+          terminalEventListener = listener;
+          return () => {
+            if (terminalEventListener === listener) terminalEventListener = undefined;
+          };
+        },
+      },
+    } as unknown as NativeApi;
+    const previousNativeApi = window.nativeApi;
+    window.nativeApi = nativeApi;
+    const entry = createRuntimeEntry({
+      runtimeKey: "thread::clear-during-replay",
+      threadId: "thread",
+      terminalId: "clear-during-replay",
+      terminalLabel: "Terminal",
+      cwd: "C:\\project",
+      callbacks: {
+        onSessionExited: () => undefined,
+        onTerminalMetadataChange: () => undefined,
+        onTerminalActivityChange: () => undefined,
+      },
+    });
+    const originalWrite = entry.terminal.write.bind(entry.terminal);
+    const snapshot = dimensionedSnapshot(32, 8, "a".repeat(64), "CLEARED-HISTORY");
+
+    try {
+      attachRuntimeToContainer(entry, { autoFocus: false, isVisible: true }, host);
+      await waitForCondition(
+        () => entry.opened && entry.runtimeStatus === "ready",
+        "clear-during-replay runtime open",
+      );
+      const backendOpenDimensions = entry.backendOpenDimensions;
+      expect(backendOpenDimensions).not.toBeNull();
+      if (!backendOpenDimensions) throw new Error("missing backend dimensions");
+      entry.fitAddon.proposeDimensions = () => backendOpenDimensions;
+      entry.terminal.write = ((data: string | Uint8Array, callback?: () => void) => {
+        if (data !== snapshot.history) {
+          originalWrite(data, callback);
+          return;
+        }
+        originalWrite(data, () => {
+          terminalEventListener?.({
+            type: "output",
+            threadId: "thread",
+            terminalId: entry.terminalId,
+            createdAt: new Date().toISOString(),
+            data: "PRE-CLEAR",
+            byteLength: 9,
+          });
+          terminalEventListener?.({
+            type: "cleared",
+            threadId: "thread",
+            terminalId: entry.terminalId,
+            createdAt: new Date().toISOString(),
+          });
+          terminalEventListener?.({
+            type: "output",
+            threadId: "thread",
+            terminalId: entry.terminalId,
+            createdAt: new Date().toISOString(),
+            data: "POST-CLEAR",
+            byteLength: 10,
+          });
+          callback?.();
+        });
+      }) as Terminal["write"];
+
+      terminalEventListener?.({
+        type: "started",
+        threadId: "thread",
+        terminalId: entry.terminalId,
+        createdAt: new Date().toISOString(),
+        snapshot,
+      });
+      await waitForCondition(
+        () =>
+          entry.pendingHistoryReplayPromise === null &&
+          entry.pendingWriteBytes === 0 &&
+          acknowledgedBytes.includes(10),
+        "clear during recovered-grid replay",
+      );
+
+      const text = bufferText(entry.terminal);
+      expect(text).not.toContain("CLEARED-HISTORY");
+      expect(text).not.toContain("PRE-CLEAR");
+      expect(text.split("POST-CLEAR")).toHaveLength(2);
+      expect({ cols: entry.terminal.cols, rows: entry.terminal.rows }).toEqual(
+        backendOpenDimensions,
+      );
+      expect(entry.appliedHistoryRecordIdentity).toBeNull();
+      expect(acknowledgedBytes).toEqual([9, 10]);
+    } finally {
+      entry.terminal.write = originalWrite as Terminal["write"];
+      disposeRuntimeEntry(entry);
+      restoreWindowNativeApi(previousNativeApi);
+      document.getElementById("synara-terminal-parking")?.remove();
+    }
+  });
+
+  it.each(["clear", "dispose"] as const)(
+    "chunks the exact retained byte total when an unsafe replay is released by %s",
+    async (releaseMode) => {
+      const host = document.createElement("div");
+      host.style.cssText = "position:absolute;left:0;top:0;width:900px;height:320px;display:block;";
+      document.body.append(host);
+      hosts.push(host);
+
+      let terminalEventListener: ((event: TerminalEvent) => void) | undefined;
+      const acknowledgedBytes: number[] = [];
+      const nativeApi = {
+        terminal: {
+          open: async () => legacySnapshot(""),
+          write: async () => undefined,
+          ackOutput: async (input: { bytes: number }) => {
+            acknowledgedBytes.push(input.bytes);
+          },
+          resize: async () => undefined,
+          clear: async () => undefined,
+          restart: async () => legacySnapshot(""),
+          close: async () => undefined,
+          onEvent: (listener: (event: TerminalEvent) => void) => {
+            terminalEventListener = listener;
+            return () => {
+              if (terminalEventListener === listener) terminalEventListener = undefined;
+            };
+          },
+        },
+      } as unknown as NativeApi;
+      const previousNativeApi = window.nativeApi;
+      window.nativeApi = nativeApi;
+      const entry = createRuntimeEntry({
+        runtimeKey: `thread::ack-${releaseMode}`,
+        threadId: "thread",
+        terminalId: `ack-${releaseMode}`,
+        terminalLabel: "Terminal",
+        cwd: "C:\\project",
+        callbacks: {
+          onSessionExited: () => undefined,
+          onTerminalMetadataChange: () => undefined,
+          onTerminalActivityChange: () => undefined,
+        },
+      });
+      const originalResize = entry.terminal.resize.bind(entry.terminal);
+      let rejectFallback = true;
+      let disposed = false;
+
+      try {
+        attachRuntimeToContainer(entry, { autoFocus: false, isVisible: true }, host);
+        await waitForCondition(
+          () => entry.opened && entry.runtimeStatus === "ready",
+          "chunked-ack runtime open",
+        );
+        const backendOpenDimensions = entry.backendOpenDimensions;
+        expect(backendOpenDimensions).not.toBeNull();
+        if (!backendOpenDimensions) throw new Error("missing backend dimensions");
+        entry.fitAddon.proposeDimensions = () => undefined;
+        entry.terminal.resize = ((cols: number, rows: number) => {
+          if (
+            rejectFallback &&
+            cols === backendOpenDimensions.cols &&
+            rows === backendOpenDimensions.rows
+          ) {
+            return;
+          }
+          originalResize(cols, rows);
+        }) as Terminal["resize"];
+
+        terminalEventListener?.({
+          type: "started",
+          threadId: "thread",
+          terminalId: entry.terminalId,
+          createdAt: new Date().toISOString(),
+          snapshot: dimensionedSnapshot(32, 8, "b".repeat(64), "UNSAFE-HISTORY"),
+        });
+        await waitForCondition(
+          () => entry.runtimeStatus === "error" && entry.pendingHistoryReplayPromise === null,
+          "unsafe replay retention",
+        );
+        const retainedByteTotal = 8_388_608 * 2 + 17;
+        terminalEventListener?.({
+          type: "output",
+          threadId: "thread",
+          terminalId: entry.terminalId,
+          createdAt: new Date().toISOString(),
+          data: "HELD-LARGE-OUTPUT",
+          byteLength: retainedByteTotal,
+        });
+
+        rejectFallback = false;
+        if (releaseMode === "clear") {
+          terminalEventListener?.({
+            type: "cleared",
+            threadId: "thread",
+            terminalId: entry.terminalId,
+            createdAt: new Date().toISOString(),
+          });
+          await waitForCondition(() => entry.runtimeStatus === "ready", "unsafe replay clear");
+        } else {
+          disposeRuntimeEntry(entry);
+          disposed = true;
+        }
+
+        expect(acknowledgedBytes).toEqual([8_388_608, 8_388_608, 17]);
+        expect(acknowledgedBytes.every((bytes) => bytes <= 8_388_608)).toBe(true);
+        expect(acknowledgedBytes.reduce((total, bytes) => total + bytes, 0)).toBe(
+          retainedByteTotal,
+        );
+      } finally {
+        entry.terminal.resize = originalResize as Terminal["resize"];
+        if (!disposed) disposeRuntimeEntry(entry);
+        restoreWindowNativeApi(previousNativeApi);
+        document.getElementById("synara-terminal-parking")?.remove();
+      }
+    },
+  );
+});

--- a/apps/web/src/components/terminal/terminalSnapshotReplay.test.ts
+++ b/apps/web/src/components/terminal/terminalSnapshotReplay.test.ts
@@ -1,0 +1,653 @@
+import type { TerminalSessionSnapshot } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+  applyReplayOnce,
+  createRecoveredGridOutputBuffer,
+  RecoveredGridFinalizationError,
+  type ReplayIdentityState,
+  replaySnapshotAtBackendOpenGrid,
+  replaySnapshotAtDestinationGrid,
+  replaySnapshotAtRecoveredGrid,
+  shouldReplayColdSnapshot,
+  snapshotReplayIdentity,
+} from "./terminalSnapshotReplay";
+
+function dimensionedSnapshot(
+  cols = 80,
+  rows = 24,
+): TerminalSessionSnapshot & { recoveredCols: number; recoveredRows: number } {
+  return {
+    threadId: "thread",
+    terminalId: "default",
+    cwd: "/tmp",
+    status: "running",
+    pid: 1,
+    history: "history",
+    recoveredCols: cols,
+    recoveredRows: rows,
+    historyRecordIdentity: "a".repeat(64),
+    exitCode: null,
+    exitSignal: null,
+    updatedAt: new Date(0).toISOString(),
+  };
+}
+
+function legacySnapshot(): TerminalSessionSnapshot {
+  return {
+    threadId: "thread",
+    terminalId: "default",
+    cwd: "/tmp",
+    status: "running",
+    pid: 1,
+    history: "history",
+    exitCode: null,
+    exitSignal: null,
+    updatedAt: new Date(0).toISOString(),
+  };
+}
+
+describe("replaySnapshotAtRecoveredGrid", () => {
+  it.each([
+    [60, 15],
+    [120, 40],
+    [100, 30],
+  ])("barriers clear and replay at a %sx%s source grid", async (cols, rows) => {
+    const calls: string[] = [];
+    const terminal = {
+      cols: 100,
+      rows: 30,
+      resize(nextCols: number, nextRows: number) {
+        this.cols = nextCols;
+        this.rows = nextRows;
+        calls.push(`resize:${nextCols}x${nextRows}`);
+      },
+      write(data: string, callback?: () => void) {
+        calls.push(`write:${data}`);
+        queueMicrotask(() => {
+          calls.push("parsed");
+          callback?.();
+        });
+      },
+    };
+
+    await replaySnapshotAtRecoveredGrid({
+      terminal,
+      snapshot: dimensionedSnapshot(cols, rows),
+      backendOpenDimensions: { cols: 100, rows: 30 },
+      measureFinalGrid: () => {
+        calls.push("fit");
+        return { cols: 100, rows: 30 };
+      },
+      resizeBackend: async () => {
+        calls.push("backend");
+      },
+    });
+
+    expect(calls).toEqual([
+      "write:\u001b[2J\u001b[H",
+      "parsed",
+      `resize:${cols}x${rows}`,
+      "write:history",
+      "parsed",
+      "fit",
+      ...(cols === 100 && rows === 30 ? [] : ["resize:100x30"]),
+    ]);
+    expect(calls.join("|")).not.toContain("\u001b[3J");
+  });
+
+  it("sends exactly one final backend resize when final differs from open", async () => {
+    const resizes: Array<{ cols: number; rows: number }> = [];
+    const terminal = {
+      cols: 100,
+      rows: 30,
+      resize(cols: number, rows: number) {
+        this.cols = cols;
+        this.rows = rows;
+      },
+      write(_data: string, callback?: () => void) {
+        callback?.();
+      },
+    };
+
+    await replaySnapshotAtRecoveredGrid({
+      terminal,
+      snapshot: dimensionedSnapshot(),
+      backendOpenDimensions: { cols: 100, rows: 30 },
+      measureFinalGrid: () => ({ cols: 110, rows: 35 }),
+      resizeBackend: async (value) => {
+        resizes.push(value);
+      },
+    });
+
+    expect(resizes).toEqual([{ cols: 110, rows: 35 }]);
+  });
+
+  it("aborts after the clear barrier without staging or fitting", async () => {
+    const calls: string[] = [];
+    const terminal = {
+      cols: 100,
+      rows: 30,
+      resize() {
+        calls.push("resize");
+      },
+      write(_data: string, callback?: () => void) {
+        calls.push("write");
+        callback?.();
+      },
+    };
+
+    await expect(
+      replaySnapshotAtRecoveredGrid({
+        terminal,
+        snapshot: dimensionedSnapshot(),
+        backendOpenDimensions: { cols: 100, rows: 30 },
+        measureFinalGrid: () => {
+          calls.push("fit");
+          return { cols: 100, rows: 30 };
+        },
+        resizeBackend: async () => {
+          calls.push("backend");
+        },
+        isActive: () => false,
+      }),
+    ).rejects.toThrow("aborted");
+    expect(calls).toEqual(["write"]);
+  });
+
+  it.each(["throws", "is unavailable"])(
+    "restores the backend-open grid before live output drains when fit measurement %s",
+    async (measurementFailure) => {
+      const calls: string[] = [];
+      const outputBuffer = createRecoveredGridOutputBuffer();
+      let active = true;
+      const terminal = {
+        cols: 100,
+        rows: 30,
+        resize(cols: number, rows: number) {
+          this.cols = cols;
+          this.rows = rows;
+          calls.push(`resize:${cols}x${rows}`);
+        },
+        write(data: string, callback?: () => void) {
+          calls.push(`write:${data}@${this.cols}x${this.rows}`);
+          if (data === "history") {
+            outputBuffer.enqueue({ data: "LIVE-A", byteLength: 6 });
+            outputBuffer.enqueue({ data: "LIVE-β", byteLength: 7 });
+            active = false;
+          }
+          callback?.();
+        },
+      };
+
+      try {
+        await expect(
+          replaySnapshotAtRecoveredGrid({
+            terminal,
+            snapshot: dimensionedSnapshot(40, 8),
+            backendOpenDimensions: { cols: 100, rows: 30 },
+            measureFinalGrid: () => {
+              calls.push("measure");
+              if (measurementFailure === "throws") throw new Error("fit failed");
+              return undefined;
+            },
+            resizeBackend: async () => {
+              calls.push("backend");
+            },
+            isActive: () => active,
+          }),
+        ).rejects.toThrow("aborted");
+      } finally {
+        for (const output of outputBuffer.drain()) terminal.write(output.data);
+      }
+
+      expect(terminal).toMatchObject({ cols: 100, rows: 30 });
+      expect(calls).toContain("write:history@40x8");
+      expect(calls).toContain("write:LIVE-A@100x30");
+      expect(calls).toContain("write:LIVE-β@100x30");
+      expect(calls.indexOf("resize:100x30")).toBeLessThan(calls.indexOf("write:LIVE-A@100x30"));
+      expect(calls).not.toContain("backend");
+    },
+  );
+
+  it("detects a no-op measured resize and restores the backend-open grid", async () => {
+    const calls: string[] = [];
+    let ignoreMeasuredResize = true;
+    const terminal = {
+      cols: 100,
+      rows: 30,
+      resize(cols: number, rows: number) {
+        if (cols === 110 && rows === 35 && ignoreMeasuredResize) {
+          ignoreMeasuredResize = false;
+          calls.push("measured-no-op");
+          return;
+        }
+        this.cols = cols;
+        this.rows = rows;
+        calls.push(`resize:${cols}x${rows}`);
+      },
+      write(_data: string, callback?: () => void) {
+        callback?.();
+      },
+    };
+
+    await replaySnapshotAtRecoveredGrid({
+      terminal,
+      snapshot: dimensionedSnapshot(40, 8),
+      backendOpenDimensions: { cols: 100, rows: 30 },
+      measureFinalGrid: () => ({ cols: 110, rows: 35 }),
+      resizeBackend: async () => {
+        calls.push("backend");
+      },
+    });
+
+    expect(terminal).toMatchObject({ cols: 100, rows: 30 });
+    expect(calls).toEqual(["resize:40x8", "measured-no-op", "resize:100x30"]);
+  });
+
+  it.each(["throws", "partially applies"])(
+    "restores the backend-open grid when staging resize %s",
+    async (stagingFailure) => {
+      const calls: string[] = [];
+      let staging = true;
+      const terminal = {
+        cols: 100,
+        rows: 30,
+        resize(cols: number, rows: number) {
+          if (staging) {
+            staging = false;
+            if (stagingFailure === "partially applies") this.cols = cols;
+            calls.push(`staging-failed:${this.cols}x${this.rows}`);
+            throw new Error("staging failed");
+          }
+          this.cols = cols;
+          this.rows = rows;
+          calls.push(`resize:${cols}x${rows}`);
+        },
+        write(data: string, callback?: () => void) {
+          calls.push(`write:${data}`);
+          callback?.();
+        },
+      };
+
+      await expect(
+        replaySnapshotAtRecoveredGrid({
+          terminal,
+          snapshot: dimensionedSnapshot(40, 8),
+          backendOpenDimensions: { cols: 100, rows: 30 },
+          measureFinalGrid: () => {
+            calls.push("measure");
+            return { cols: 110, rows: 35 };
+          },
+          resizeBackend: async () => {
+            calls.push("backend");
+          },
+        }),
+      ).rejects.toThrow("staging failed");
+
+      expect(terminal).toMatchObject({ cols: 100, rows: 30 });
+      expect(calls).not.toContain("measure");
+      expect(calls).not.toContain("write:history");
+      expect(calls).not.toContain("backend");
+    },
+  );
+
+  it.each(["no-op", "partially applies"] as const)(
+    "rejects when staging silently %s, restores the backend grid, and permits retry",
+    async (stagingFailure) => {
+      const snapshot = dimensionedSnapshot(40, 8);
+      const state: ReplayIdentityState = {
+        appliedHistoryRecordIdentity: null,
+        pendingHistoryRecordIdentity: null,
+        pendingHistoryReplayPromise: null,
+      };
+      const calls: string[] = [];
+      let failStaging = true;
+      const terminal = {
+        cols: 100,
+        rows: 30,
+        resize(cols: number, rows: number) {
+          calls.push(`resize:${cols}x${rows}`);
+          if (failStaging && cols === 40 && rows === 8) {
+            if (stagingFailure === "partially applies") this.cols = cols;
+            return;
+          }
+          this.cols = cols;
+          this.rows = rows;
+        },
+        write(data: string, callback?: () => void) {
+          calls.push(`write:${data}`);
+          callback?.();
+        },
+      };
+      const replay = () =>
+        replaySnapshotAtRecoveredGrid({
+          terminal,
+          snapshot,
+          backendOpenDimensions: { cols: 100, rows: 30 },
+          measureFinalGrid: () => ({ cols: 110, rows: 35 }),
+          resizeBackend: async () => {
+            calls.push("backend");
+          },
+        });
+
+      await expect(applyReplayOnce(state, snapshot.historyRecordIdentity, replay)).rejects.toThrow(
+        "staging resize did not reach",
+      );
+      expect(terminal).toMatchObject({ cols: 100, rows: 30 });
+      expect(calls).not.toContain("write:history");
+      expect(calls).not.toContain("backend");
+      expect(state.appliedHistoryRecordIdentity).toBeNull();
+
+      failStaging = false;
+      expect(await applyReplayOnce(state, snapshot.historyRecordIdentity, replay)).toBe(true);
+      expect(state.appliedHistoryRecordIdentity).toBe(snapshot.historyRecordIdentity);
+      expect(calls.filter((call) => call === "write:history")).toHaveLength(1);
+    },
+  );
+
+  it("marks output unsafe when a partial staging resize cannot restore the fallback", async () => {
+    let resizeCalls = 0;
+    const terminal = {
+      cols: 100,
+      rows: 30,
+      resize(cols: number) {
+        resizeCalls += 1;
+        if (resizeCalls === 1) this.cols = cols;
+        throw new Error("resize unavailable");
+      },
+      write(_data: string, callback?: () => void) {
+        callback?.();
+      },
+    };
+
+    await expect(
+      replaySnapshotAtRecoveredGrid({
+        terminal,
+        snapshot: dimensionedSnapshot(40, 8),
+        backendOpenDimensions: { cols: 100, rows: 30 },
+        measureFinalGrid: () => undefined,
+        resizeBackend: async () => undefined,
+      }),
+    ).rejects.toBeInstanceOf(RecoveredGridFinalizationError);
+    expect(terminal).toMatchObject({ cols: 40, rows: 30 });
+    expect(resizeCalls).toBe(3);
+  });
+
+  it("restores the backend-open grid after the only backend resize rejects", async () => {
+    let backendResizeCalls = 0;
+    const terminal = {
+      cols: 100,
+      rows: 30,
+      resize(cols: number, rows: number) {
+        this.cols = cols;
+        this.rows = rows;
+      },
+      write(_data: string, callback?: () => void) {
+        callback?.();
+      },
+    };
+
+    await expect(
+      replaySnapshotAtRecoveredGrid({
+        terminal,
+        snapshot: dimensionedSnapshot(40, 8),
+        backendOpenDimensions: { cols: 100, rows: 30 },
+        measureFinalGrid: () => ({ cols: 110, rows: 35 }),
+        resizeBackend: async () => {
+          backendResizeCalls += 1;
+          throw new Error("backend resize failed");
+        },
+      }),
+    ).rejects.toThrow("backend resize failed");
+
+    expect(backendResizeCalls).toBe(1);
+    expect(terminal).toMatchObject({ cols: 100, rows: 30 });
+  });
+
+  it("finalizes an invalidated staged replay before releasing every live byte and permits retry", async () => {
+    const snapshot = dimensionedSnapshot(40, 8);
+    const state: ReplayIdentityState = {
+      appliedHistoryRecordIdentity: null,
+      pendingHistoryRecordIdentity: null,
+      pendingHistoryReplayPromise: null,
+    };
+    const calls: string[] = [];
+    const releasedOutputs: Array<{ data: string; byteLength: number }> = [];
+    const backendResizes: Array<{ cols: number; rows: number }> = [];
+    let backendDimensions = { cols: 100, rows: 30 };
+    let active = true;
+    let attempt = 0;
+    let activeOutputBuffer: ReturnType<typeof createRecoveredGridOutputBuffer> | null = null;
+    const terminal = {
+      cols: 100,
+      rows: 30,
+      resize(cols: number, rows: number) {
+        this.cols = cols;
+        this.rows = rows;
+        calls.push(`local:${cols}x${rows}`);
+      },
+      write(data: string, callback?: () => void) {
+        calls.push(`write:${data}@${this.cols}x${this.rows}`);
+        if (data === snapshot.history && attempt === 1) {
+          queueMicrotask(() => {
+            activeOutputBuffer?.enqueue({ data: "LIVE-A", byteLength: 6 });
+            activeOutputBuffer?.enqueue({ data: "LIVE-β", byteLength: 7 });
+            active = false;
+            calls.push("history-parsed-and-invalidated");
+            callback?.();
+          });
+          return;
+        }
+        queueMicrotask(() => callback?.());
+      },
+    };
+
+    const replay = async () => {
+      attempt += 1;
+      const outputBuffer = createRecoveredGridOutputBuffer();
+      activeOutputBuffer = outputBuffer;
+      try {
+        await replaySnapshotAtRecoveredGrid({
+          terminal,
+          snapshot,
+          backendOpenDimensions: backendDimensions,
+          measureFinalGrid: () => {
+            calls.push("fit");
+            return { cols: 110, rows: 35 };
+          },
+          resizeBackend: async (dimensions) => {
+            backendResizes.push(dimensions);
+            backendDimensions = dimensions;
+            calls.push(`backend:${dimensions.cols}x${dimensions.rows}`);
+          },
+          isActive: () => active,
+        });
+      } finally {
+        activeOutputBuffer = null;
+        for (const output of outputBuffer.drain()) {
+          releasedOutputs.push(output);
+          terminal.write(output.data);
+        }
+      }
+    };
+
+    await expect(applyReplayOnce(state, snapshot.historyRecordIdentity, replay)).rejects.toThrow(
+      "aborted",
+    );
+    expect(terminal).toMatchObject({ cols: 110, rows: 35 });
+    expect(backendResizes).toEqual([{ cols: 110, rows: 35 }]);
+    expect(releasedOutputs).toEqual([
+      { data: "LIVE-A", byteLength: 6 },
+      { data: "LIVE-β", byteLength: 7 },
+    ]);
+    expect(calls.indexOf("backend:110x35")).toBeLessThan(calls.indexOf("write:LIVE-A@110x35"));
+    expect(calls).toContain("write:history@40x8");
+    expect(state).toEqual({
+      appliedHistoryRecordIdentity: null,
+      pendingHistoryRecordIdentity: null,
+      pendingHistoryReplayPromise: null,
+    });
+
+    active = true;
+    expect(await applyReplayOnce(state, snapshot.historyRecordIdentity, replay)).toBe(true);
+    expect(await applyReplayOnce(state, snapshot.historyRecordIdentity, replay)).toBe(false);
+    expect(backendResizes).toEqual([{ cols: 110, rows: 35 }]);
+    expect(state.appliedHistoryRecordIdentity).toBe(snapshot.historyRecordIdentity);
+  });
+});
+
+describe("destination and warm replay compatibility", () => {
+  it("keeps legacy history on the destination grid", () => {
+    const writes: string[] = [];
+    const terminal = {
+      cols: 100,
+      rows: 30,
+      resize() {
+        throw new Error("legacy replay must not stage a recovered grid");
+      },
+      write(data: string, callback?: () => void) {
+        writes.push(data);
+        callback?.();
+      },
+    };
+
+    replaySnapshotAtDestinationGrid(terminal, legacySnapshot());
+
+    expect(terminal.cols).toBe(100);
+    expect(terminal.rows).toBe(30);
+    expect(writes).toEqual(["\u001bc", "history"]);
+  });
+
+  it("does not select cold replay after live output advances", () => {
+    const snapshot = dimensionedSnapshot();
+    expect(shouldReplayColdSnapshot(snapshot, 0, 0)).toBe(true);
+    expect(shouldReplayColdSnapshot(snapshot, 4, 4)).toBe(false);
+    expect(shouldReplayColdSnapshot(snapshot, 4, 5)).toBe(false);
+    expect(shouldReplayColdSnapshot(snapshot, 4, 5, true)).toBe(true);
+    expect(shouldReplayColdSnapshot({ ...snapshot, history: "" }, 4, 5, true)).toBe(true);
+    expect(shouldReplayColdSnapshot(legacySnapshot(), 4, 5, true)).toBe(true);
+  });
+
+  it("replays authoritative dimensionless history only after restoring the backend-open grid", async () => {
+    const calls: string[] = [];
+    const terminal = {
+      cols: 40,
+      rows: 8,
+      resize(cols: number, rows: number) {
+        this.cols = cols;
+        this.rows = rows;
+        calls.push(`resize:${cols}x${rows}`);
+      },
+      write(data: string, callback?: () => void) {
+        calls.push(`write:${data}@${this.cols}x${this.rows}`);
+        callback?.();
+      },
+    };
+
+    await replaySnapshotAtBackendOpenGrid({
+      terminal,
+      snapshot: legacySnapshot(),
+      backendOpenDimensions: { cols: 100, rows: 30 },
+    });
+
+    expect(terminal).toMatchObject({ cols: 100, rows: 30 });
+    expect(calls).toEqual(["resize:100x30", "write:\u001bc@100x30", "write:history@100x30"]);
+  });
+
+  it("uses stable content identities for legacy replay and separates changed content or grids", async () => {
+    const first = legacySnapshot();
+    const samePayload = { ...legacySnapshot(), updatedAt: new Date(1).toISOString() };
+    const changedPayload = { ...legacySnapshot(), history: "history changed" };
+    const firstGrid = { ...dimensionedSnapshot(80, 24), historyRecordIdentity: undefined };
+    const changedGrid = { ...firstGrid, recoveredCols: 81 };
+
+    expect(await snapshotReplayIdentity(first)).toBe(await snapshotReplayIdentity(samePayload));
+    expect(await snapshotReplayIdentity(changedPayload)).not.toBe(
+      await snapshotReplayIdentity(first),
+    );
+    expect(await snapshotReplayIdentity(changedGrid)).not.toBe(
+      await snapshotReplayIdentity(firstGrid),
+    );
+  });
+});
+
+describe("applyReplayOnce", () => {
+  it("deduplicates concurrent RPC/push delivery and retries failures", async () => {
+    const state: ReplayIdentityState = {
+      appliedHistoryRecordIdentity: null,
+      pendingHistoryRecordIdentity: null,
+      pendingHistoryReplayPromise: null,
+    };
+    let releaseFirst: (() => void) | undefined;
+    let calls = 0;
+    const first = applyReplayOnce(state, "same", async () => {
+      calls += 1;
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+    });
+    const duplicate = applyReplayOnce(state, "same", async () => {
+      calls += 1;
+    });
+    await Promise.resolve();
+    expect(calls).toBe(1);
+    releaseFirst?.();
+    expect(await first).toBe(true);
+    expect(await duplicate).toBe(false);
+    expect(calls).toBe(1);
+
+    expect(
+      await applyReplayOnce(state, "same-text-new-grid", async () => {
+        calls += 1;
+      }),
+    ).toBe(true);
+    await expect(
+      applyReplayOnce(state, "retry", async () => {
+        throw new Error("parse failed");
+      }),
+    ).rejects.toThrow("parse failed");
+    expect(
+      await applyReplayOnce(state, "retry", async () => {
+        calls += 1;
+      }),
+    ).toBe(true);
+    expect(calls).toBe(3);
+  });
+
+  it("keeps unsafe buffered output ordered and the record retryable until recovery", async () => {
+    const state: ReplayIdentityState = {
+      appliedHistoryRecordIdentity: null,
+      pendingHistoryRecordIdentity: null,
+      pendingHistoryReplayPromise: null,
+    };
+    const outputBuffer = createRecoveredGridOutputBuffer();
+    const released: string[] = [];
+    let finalizationIsSafe = false;
+    const replay = async () => {
+      if (!finalizationIsSafe) {
+        throw new RecoveredGridFinalizationError("unsafe grid", new Error("resize failed"));
+      }
+      released.push(...outputBuffer.drain().map((output) => output.data));
+    };
+
+    outputBuffer.enqueue({ data: "LIVE-BEFORE-FAILURE", byteLength: 19 });
+    await expect(applyReplayOnce(state, "retained", replay)).rejects.toBeInstanceOf(
+      RecoveredGridFinalizationError,
+    );
+    outputBuffer.enqueue({ data: "LIVE-AFTER-FAILURE", byteLength: 18 });
+
+    expect(released).toEqual([]);
+    expect(state).toEqual({
+      appliedHistoryRecordIdentity: null,
+      pendingHistoryRecordIdentity: null,
+      pendingHistoryReplayPromise: null,
+    });
+
+    finalizationIsSafe = true;
+    expect(await applyReplayOnce(state, "retained", replay)).toBe(true);
+    expect(await applyReplayOnce(state, "retained", replay)).toBe(false);
+    expect(released).toEqual(["LIVE-BEFORE-FAILURE", "LIVE-AFTER-FAILURE"]);
+    expect(state.appliedHistoryRecordIdentity).toBe("retained");
+  });
+});

--- a/apps/web/src/components/terminal/terminalSnapshotReplay.ts
+++ b/apps/web/src/components/terminal/terminalSnapshotReplay.ts
@@ -1,0 +1,325 @@
+import type { TerminalSessionSnapshot } from "@synara/contracts";
+
+export interface SnapshotReplayTerminal {
+  cols: number;
+  rows: number;
+  resize(cols: number, rows: number): void;
+  write(data: string, callback?: () => void): void;
+}
+
+export interface TerminalGridDimensions {
+  cols: number;
+  rows: number;
+}
+
+export class RecoveredGridFinalizationError extends Error {
+  override readonly cause: unknown;
+
+  constructor(message: string, cause: unknown) {
+    super(message);
+    this.name = "RecoveredGridFinalizationError";
+    this.cause = cause;
+  }
+}
+
+export interface DeferredTerminalOutput {
+  data: string;
+  byteLength: number;
+}
+
+export interface RecoveredGridOutputBuffer {
+  enqueue(output: DeferredTerminalOutput): void;
+  drain(): DeferredTerminalOutput[];
+  drainPrefix(count: number): DeferredTerminalOutput[];
+  size(): number;
+}
+
+/**
+ * Hold live output while xterm is temporarily staged at a recovered grid.
+ * Draining is explicit so the runtime can release every byte only after the
+ * local and backend grids have converged again.
+ */
+export function createRecoveredGridOutputBuffer(): RecoveredGridOutputBuffer {
+  const queued: DeferredTerminalOutput[] = [];
+  return {
+    enqueue(output) {
+      queued.push(output);
+    },
+    drain() {
+      return queued.splice(0, queued.length);
+    },
+    drainPrefix(count) {
+      return queued.splice(0, Math.max(0, Math.min(queued.length, Math.trunc(count))));
+    },
+    size() {
+      return queued.length;
+    },
+  };
+}
+
+export function hasRecoveredGrid(
+  snapshot: TerminalSessionSnapshot,
+): snapshot is TerminalSessionSnapshot & { recoveredCols: number; recoveredRows: number } {
+  return snapshot.recoveredCols !== undefined && snapshot.recoveredRows !== undefined;
+}
+
+export function snapshotReplayPayload(snapshot: TerminalSessionSnapshot): string {
+  return `${snapshot.replayPreamble ?? ""}${snapshot.history}`;
+}
+
+export function snapshotHasReplayPayload(snapshot: TerminalSessionSnapshot): boolean {
+  return snapshot.history.length > 0 || (snapshot.replayPreamble?.length ?? 0) > 0;
+}
+
+export async function snapshotReplayIdentity(snapshot: TerminalSessionSnapshot): Promise<string> {
+  if (snapshot.historyRecordIdentity) return snapshot.historyRecordIdentity;
+  const recoveredGridPrefix = hasRecoveredGrid(snapshot)
+    ? `${snapshot.recoveredCols}x${snapshot.recoveredRows}\u0000`
+    : "";
+  const payload = new TextEncoder().encode(
+    `${recoveredGridPrefix}${snapshotReplayPayload(snapshot)}`,
+  );
+  const digest = await crypto.subtle.digest("SHA-256", payload);
+  return `legacy:${Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("")}`;
+}
+
+export function shouldReplayColdSnapshot(
+  snapshot: TerminalSessionSnapshot,
+  outputEventVersionAtOpen: number,
+  currentOutputEventVersion: number,
+  hasRetainedRecoveredOutput = false,
+): boolean {
+  if (hasRetainedRecoveredOutput) return true;
+  return (
+    snapshotHasReplayPayload(snapshot) &&
+    outputEventVersionAtOpen === 0 &&
+    currentOutputEventVersion === 0
+  );
+}
+
+/** Preserve the pre-existing destination-grid replay behavior for legacy logs. */
+export function replaySnapshotAtDestinationGrid(
+  terminal: SnapshotReplayTerminal,
+  snapshot: TerminalSessionSnapshot,
+  onParsed?: () => void,
+): void {
+  const payload = snapshotReplayPayload(snapshot);
+  if (payload.length > 0) {
+    terminal.write("\u001bc");
+    terminal.write(payload, onParsed);
+    return;
+  }
+  terminal.write("\u001bc", onParsed);
+}
+
+function writeAndWait(terminal: SnapshotReplayTerminal, data: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    try {
+      terminal.write(data, resolve);
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+function gridsMatch(left: TerminalGridDimensions, right: TerminalGridDimensions): boolean {
+  return left.cols === right.cols && left.rows === right.rows;
+}
+
+function currentGrid(terminal: SnapshotReplayTerminal): TerminalGridDimensions {
+  return { cols: terminal.cols, rows: terminal.rows };
+}
+
+function isUsableGrid(dimensions: TerminalGridDimensions | undefined): boolean {
+  return (
+    dimensions !== undefined &&
+    Number.isSafeInteger(dimensions.cols) &&
+    Number.isSafeInteger(dimensions.rows) &&
+    dimensions.cols > 0 &&
+    dimensions.rows > 0
+  );
+}
+
+function tryResizeLocalGrid(
+  terminal: SnapshotReplayTerminal,
+  dimensions: TerminalGridDimensions,
+): unknown | null {
+  try {
+    if (!gridsMatch(currentGrid(terminal), dimensions)) {
+      terminal.resize(dimensions.cols, dimensions.rows);
+    }
+  } catch (error) {
+    return error;
+  }
+
+  return gridsMatch(currentGrid(terminal), dimensions)
+    ? null
+    : new Error(`Terminal resize did not reach ${dimensions.cols}x${dimensions.rows}`);
+}
+
+function restoreBackendOpenGrid(
+  terminal: SnapshotReplayTerminal,
+  backendOpenDimensions: TerminalGridDimensions,
+  cause: unknown,
+  existingFailure?: unknown,
+): void {
+  const firstFailure = existingFailure ?? tryResizeLocalGrid(terminal, backendOpenDimensions);
+  if (firstFailure === null) return;
+
+  // A partially applied xterm resize can throw after changing one dimension.
+  // Retry the known backend grid once; output remains buffered unless the
+  // dimensions can then be verified exactly.
+  const retryFailure = tryResizeLocalGrid(terminal, backendOpenDimensions);
+  if (retryFailure === null) return;
+
+  throw new RecoveredGridFinalizationError(
+    "Terminal replay could not restore the backend-open grid",
+    { cause, firstFailure, retryFailure },
+  );
+}
+
+function ensureBackendOpenGrid(
+  terminal: SnapshotReplayTerminal,
+  backendOpenDimensions: TerminalGridDimensions,
+): void {
+  const failure = tryResizeLocalGrid(terminal, backendOpenDimensions);
+  if (failure === null) return;
+  restoreBackendOpenGrid(terminal, backendOpenDimensions, failure, failure);
+}
+
+export async function replaySnapshotAtBackendOpenGrid(options: {
+  terminal: SnapshotReplayTerminal;
+  snapshot: TerminalSessionSnapshot;
+  backendOpenDimensions: TerminalGridDimensions;
+}): Promise<void> {
+  const { terminal, snapshot, backendOpenDimensions } = options;
+  ensureBackendOpenGrid(terminal, backendOpenDimensions);
+  await writeAndWait(terminal, "\u001bc");
+  ensureBackendOpenGrid(terminal, backendOpenDimensions);
+  const payload = snapshotReplayPayload(snapshot);
+  if (payload.length > 0) await writeAndWait(terminal, payload);
+}
+
+async function finalizeRecoveredGrid(options: {
+  terminal: SnapshotReplayTerminal;
+  backendOpenDimensions: TerminalGridDimensions;
+  measureFinalGrid: () => TerminalGridDimensions | undefined;
+  resizeBackend: (dimensions: TerminalGridDimensions) => Promise<void>;
+}): Promise<void> {
+  const { terminal, backendOpenDimensions, measureFinalGrid, resizeBackend } = options;
+  let measuredDimensions: TerminalGridDimensions | undefined;
+  try {
+    const proposedDimensions = measureFinalGrid();
+    if (isUsableGrid(proposedDimensions)) measuredDimensions = proposedDimensions;
+  } catch {
+    // Container or renderer measurement is best-effort during recovery. The
+    // backend-open grid is the deterministic destination when it is unavailable.
+  }
+
+  const destinationDimensions = measuredDimensions ?? backendOpenDimensions;
+  const destinationFailure = tryResizeLocalGrid(terminal, destinationDimensions);
+  if (destinationFailure !== null) {
+    restoreBackendOpenGrid(terminal, backendOpenDimensions, destinationFailure, destinationFailure);
+    return;
+  }
+
+  if (gridsMatch(destinationDimensions, backendOpenDimensions)) return;
+
+  try {
+    await resizeBackend(destinationDimensions);
+  } catch (error) {
+    // If the only backend resize cannot be confirmed, return xterm to the grid
+    // the backend was known to use before allowing buffered output to drain.
+    restoreBackendOpenGrid(terminal, backendOpenDimensions, error);
+    throw error;
+  }
+}
+
+export async function replaySnapshotAtRecoveredGrid(options: {
+  terminal: SnapshotReplayTerminal;
+  snapshot: TerminalSessionSnapshot & { recoveredCols: number; recoveredRows: number };
+  backendOpenDimensions: TerminalGridDimensions;
+  measureFinalGrid: () => TerminalGridDimensions | undefined;
+  resizeBackend: (dimensions: TerminalGridDimensions) => Promise<void>;
+  isActive?: () => boolean;
+}): Promise<void> {
+  const { terminal, snapshot, backendOpenDimensions, measureFinalGrid, resizeBackend } = options;
+  const isActive = options.isActive ?? (() => true);
+
+  // ED 2 clears only the viewport. Deliberately omit ED 3 so existing scrollback
+  // remains available, then wait for xterm's parser before a potentially lossy shrink.
+  await writeAndWait(terminal, "\u001b[2J\u001b[H");
+  if (!isActive()) throw new Error("Terminal replay was aborted");
+
+  let replayFailed = false;
+  let replayFailure: unknown;
+  try {
+    terminal.resize(snapshot.recoveredCols, snapshot.recoveredRows);
+    if (terminal.cols !== snapshot.recoveredCols || terminal.rows !== snapshot.recoveredRows) {
+      throw new Error(
+        `Terminal staging resize did not reach ${snapshot.recoveredCols}x${snapshot.recoveredRows}`,
+      );
+    }
+    await writeAndWait(terminal, snapshotReplayPayload(snapshot));
+  } catch (error) {
+    replayFailed = true;
+    replayFailure = error;
+  }
+
+  // Staging and parsing are both guarded. Finalization either verifies a
+  // measured destination, verifies the backend-open fallback, or throws the
+  // sentinel error that tells the runtime to keep live output buffered.
+  await finalizeRecoveredGrid({
+    terminal,
+    backendOpenDimensions,
+    measureFinalGrid: replayFailed ? () => undefined : measureFinalGrid,
+    resizeBackend,
+  });
+
+  if (replayFailed) throw replayFailure;
+  if (!isActive()) throw new Error("Terminal replay was aborted");
+}
+
+export interface ReplayIdentityState {
+  appliedHistoryRecordIdentity: string | null;
+  pendingHistoryRecordIdentity: string | null;
+  pendingHistoryReplayPromise: Promise<void> | null;
+}
+
+export async function applyReplayOnce(
+  state: ReplayIdentityState,
+  identity: string | undefined,
+  replay: () => Promise<void>,
+): Promise<boolean> {
+  if (identity && state.appliedHistoryRecordIdentity === identity) {
+    return false;
+  }
+
+  const pendingReplay = state.pendingHistoryReplayPromise;
+  if (pendingReplay) {
+    if (identity && state.pendingHistoryRecordIdentity === identity) {
+      await pendingReplay;
+      return false;
+    }
+    await pendingReplay.catch(() => undefined);
+    return applyReplayOnce(state, identity, replay);
+  }
+
+  if (identity) state.pendingHistoryRecordIdentity = identity;
+  const replayPromise = Promise.resolve().then(replay);
+  state.pendingHistoryReplayPromise = replayPromise;
+  try {
+    await replayPromise;
+    if (identity) state.appliedHistoryRecordIdentity = identity;
+    return true;
+  } finally {
+    if (state.pendingHistoryReplayPromise === replayPromise) {
+      state.pendingHistoryReplayPromise = null;
+    }
+    if (identity && state.pendingHistoryRecordIdentity === identity) {
+      state.pendingHistoryRecordIdentity = null;
+    }
+  }
+}

--- a/packages/contracts/src/terminal.test.ts
+++ b/packages/contracts/src/terminal.test.ts
@@ -212,6 +212,56 @@ describe("TerminalSessionSnapshot", () => {
       }),
     ).toBe(true);
   });
+
+  it("accepts optional recovered grid dimensions and stable record identity", () => {
+    expect(
+      decodes(TerminalSessionSnapshot, {
+        threadId: "thread-1",
+        terminalId: DEFAULT_TERMINAL_ID,
+        cwd: "/tmp/project",
+        status: "running",
+        pid: 1234,
+        history: "hello\n",
+        recoveredCols: 80,
+        recoveredRows: 24,
+        historyRecordIdentity: "a".repeat(64),
+        exitCode: null,
+        exitSignal: null,
+        updatedAt: new Date().toISOString(),
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects invalid, partial, and malformed recovered records", () => {
+    const base = {
+      threadId: "thread-1",
+      terminalId: DEFAULT_TERMINAL_ID,
+      cwd: "/tmp/project",
+      status: "running",
+      pid: 1234,
+      history: "hello\n",
+      exitCode: null,
+      exitSignal: null,
+      updatedAt: new Date().toISOString(),
+    };
+    expect(decodes(TerminalSessionSnapshot, { ...base, recoveredCols: 2 })).toBe(false);
+    expect(decodes(TerminalSessionSnapshot, { ...base, recoveredCols: 80 })).toBe(false);
+    expect(
+      decodes(TerminalSessionSnapshot, {
+        ...base,
+        recoveredCols: 80,
+        recoveredRows: 24,
+      }),
+    ).toBe(false);
+    expect(
+      decodes(TerminalSessionSnapshot, {
+        ...base,
+        recoveredCols: 80,
+        recoveredRows: 24,
+        historyRecordIdentity: "not-a-sha256",
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("TerminalEvent", () => {

--- a/packages/contracts/src/terminal.ts
+++ b/packages/contracts/src/terminal.ts
@@ -1,4 +1,4 @@
-import { Schema } from "effect";
+import { Option, Schema, SchemaIssue } from "effect";
 import { ProcessEnvRecord, TrimmedNonEmptyString } from "./baseSchemas";
 
 export const DEFAULT_TERMINAL_ID = "default";
@@ -93,6 +93,8 @@ export type TerminalCloseInput = Schema.Codec.Encoded<typeof TerminalCloseInput>
 export const TerminalSessionStatus = Schema.Literals(["starting", "running", "exited", "error"]);
 export type TerminalSessionStatus = typeof TerminalSessionStatus.Type;
 
+const TerminalHistoryRecordIdentitySchema = Schema.String.check(Schema.isPattern(/^[a-f0-9]{64}$/));
+
 export const TerminalSessionSnapshot = Schema.Struct({
   threadId: Schema.String.check(Schema.isNonEmpty()),
   terminalId: Schema.String.check(Schema.isNonEmpty()),
@@ -100,11 +102,33 @@ export const TerminalSessionSnapshot = Schema.Struct({
   status: TerminalSessionStatus,
   pid: Schema.NullOr(Schema.Int.check(Schema.isGreaterThan(0))),
   history: Schema.String,
+  recoveredCols: Schema.optional(TerminalColsSchema),
+  recoveredRows: Schema.optional(TerminalRowsSchema),
+  historyRecordIdentity: Schema.optional(TerminalHistoryRecordIdentitySchema),
   replayPreamble: Schema.optional(Schema.String.check(Schema.isMaxLength(4_096))),
   exitCode: Schema.NullOr(Schema.Int),
   exitSignal: Schema.NullOr(Schema.Int),
   updatedAt: Schema.String,
-});
+}).check(
+  Schema.makeFilter(
+    (snapshot) => {
+      const recoveredFieldCount = [
+        snapshot.recoveredCols,
+        snapshot.recoveredRows,
+        snapshot.historyRecordIdentity,
+      ].filter((value) => value !== undefined).length;
+      return (
+        recoveredFieldCount === 0 ||
+        recoveredFieldCount === 3 ||
+        new SchemaIssue.InvalidValue(Option.some(snapshot), {
+          message:
+            "Recovered terminal columns, rows, and history record identity must be provided together.",
+        })
+      );
+    },
+    { identifier: "TerminalRecoveredHistoryRecord" },
+  ),
+);
 export type TerminalSessionSnapshot = typeof TerminalSessionSnapshot.Type;
 
 const TerminalEventBaseSchema = Schema.Struct({


### PR DESCRIPTION
## Summary

- persist terminal history with its source columns and rows while retaining legacy dimensionless records
- stage cold restores at the recovered grid, clear before shrink, suppress transient backend resize, replay, then perform one final fit
- deduplicate RPC/push restore delivery and preserve FIFO live output during recovery

## Isolation

This PR owns only the recovered-grid replay work from #415. It does not include Windows shell-selection policy, transcript scrolling/virtualization, process snapshots, or other release-plan changes.

## Verification

- contracts: 24/24
- terminal history persistence: 16/16
- web unit: 21/21
- stable Chromium/xterm: 26/26
- `bun fmt`: passed
- `bun lint`: passed with 0 errors
- `bun typecheck`: 8/8 packages passed
- exact 12-file scope and whitespace checks passed

Closes #415