### PR TITLE
feat(web): add optional advanced effort slider

### DIFF
--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -806,6 +806,7 @@ describe("AppSettingsSchema", () => {
       enableAppSnap: false,
       appSnapPlaySound: true,
       enableAssistantStreaming: true,
+      enableAdvancedEffortSlider: false,
       sidebarProjectSortOrder: DEFAULT_SIDEBAR_PROJECT_SORT_ORDER,
       sidebarThreadSortOrder: DEFAULT_SIDEBAR_THREAD_SORT_ORDER,
       showStudioSection: true,

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -215,6 +215,9 @@ export const AppSettingsSchema = Schema.Struct({
   showEnvironmentInstructions: Schema.Boolean.pipe(withDefaults(() => true)),
   showEnvironmentNotepad: Schema.Boolean.pipe(withDefaults(() => true)),
   enableAssistantStreaming: Schema.Boolean.pipe(withDefaults(() => true)),
+  // Optional composer control. The familiar effort menu remains the default;
+  // this only swaps its presentation for a direct manipulation slider.
+  enableAdvancedEffortSlider: Schema.Boolean.pipe(withDefaults(() => false)),
   enableProviderUpdateChecks: Schema.Boolean.pipe(withDefaults(() => true)),
   enableNativeFontSmoothing: Schema.Boolean.pipe(withDefaults(getDefaultNativeFontSmoothing)),
   enableTaskCompletionToasts: Schema.Boolean.pipe(withDefaults(() => true)),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -9440,6 +9440,7 @@ export default function ChatView({
         modelOptions={selectedProviderModelOptions}
         prompt={prompt}
         onPromptChange={setPromptFromTraits}
+        useAdvancedEffortSlider={settings.enableAdvancedEffortSlider}
         open={isTraitsPickerOpen}
         onOpenChange={handleTraitsPickerOpenChange}
         onSelectionCommitted={scheduleComposerFocus}
@@ -9474,6 +9475,7 @@ export default function ChatView({
       modelOptions={selectedProviderModelOptions}
       prompt={prompt}
       onPromptChange={setPromptFromTraits}
+      useAdvancedEffortSlider={settings.enableAdvancedEffortSlider}
       onProviderModelChange={onProviderModelSelect}
       onSelectionCommitted={scheduleComposerFocus}
       open={isComposerModelEffortPickerOpen}

--- a/apps/web/src/components/chat/ComposerModelEffortPicker.tsx
+++ b/apps/web/src/components/chat/ComposerModelEffortPicker.tsx
@@ -64,6 +64,7 @@ type ComposerModelEffortPickerProps = {
   modelOptions: ProviderModelOptions[ProviderKind] | undefined;
   prompt: string;
   onPromptChange: (prompt: string) => void;
+  useAdvancedEffortSlider?: boolean;
 
   // Shared menu control.
   open?: boolean;
@@ -243,6 +244,7 @@ export function ComposerModelEffortPicker(props: ComposerModelEffortPickerProps)
             modelOptions={props.modelOptions}
             prompt={props.prompt}
             onPromptChange={props.onPromptChange}
+            useAdvancedEffortSlider={props.useAdvancedEffortSlider}
             onSelectionComplete={handleAfterTraitsSelection}
           />
         ) : null}

--- a/apps/web/src/components/chat/TraitsPicker.browser.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.browser.tsx
@@ -328,7 +328,11 @@ describe("TraitsPicker (Claude)", () => {
 
 // ── Codex TraitsPicker tests ──────────────────────────────────────────
 
-async function mountCodexPicker(props: { model?: string; options?: CodexModelOptions }) {
+async function mountCodexPicker(props: {
+  model?: string;
+  options?: CodexModelOptions;
+  useAdvancedEffortSlider?: boolean;
+}) {
   const threadId = ThreadId.makeUnsafe("thread-codex-traits");
   const model = props.model ?? DEFAULT_MODEL_BY_PROVIDER.codex;
   const draftsByThreadId: Record<ThreadId, ComposerThreadDraftState> = {
@@ -376,6 +380,7 @@ async function mountCodexPicker(props: { model?: string; options?: CodexModelOpt
       prompt=""
       modelOptions={props.options}
       onPromptChange={() => {}}
+      useAdvancedEffortSlider={props.useAdvancedEffortSlider}
     />,
     { container: host },
   );
@@ -442,6 +447,22 @@ describe("TraitsPicker (Codex)", () => {
       expect(text).toContain("Medium");
       expect(text).toContain("High");
       expect(text).toContain("Extra High");
+    });
+  });
+
+  it("renders the direct effort slider only when enabled", async () => {
+    await using _ = await mountCodexPicker({
+      options: { reasoningEffort: "medium", fastMode: false },
+      useAdvancedEffortSlider: true,
+    });
+
+    await page.getByRole("button").click();
+
+    await vi.waitFor(() => {
+      expect(
+        document.body.querySelector('input[type="range"][aria-label="Effort: Medium"]'),
+      ).not.toBeNull();
+      expect(document.body.querySelector('[role="menuitemradio"]')).toBeNull();
     });
   });
 

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -191,6 +191,135 @@ interface TraitRadioOption {
   description?: string | null;
 }
 
+// A direct-manipulation alternative to the standard effort radio list. It intentionally
+// uses the provider's already-normalized capability ladder: no arbitrary numeric effort
+// values are introduced, and models with fewer/more runtime-discovered levels adapt
+// automatically. The invisible native range input keeps keyboard and screen-reader
+// semantics while the rail, dots, and thumb carry Synara's compact picker styling.
+function AdvancedEffortSliderSection({
+  label,
+  labelTrailing,
+  value,
+  options,
+  onValueChange,
+}: {
+  label: string;
+  labelTrailing?: ReactNode;
+  value: string;
+  options: ReadonlyArray<TraitRadioOption>;
+  onValueChange: (value: string) => void;
+}) {
+  const selectedIndex = Math.max(
+    0,
+    options.findIndex((option) => option.value === value),
+  );
+  const lastIndex = Math.max(0, options.length - 1);
+  const [previewIndex, setPreviewIndex] = useState(selectedIndex);
+  const previewIndexRef = useRef(selectedIndex);
+  const lastCommittedIndexRef = useRef(selectedIndex);
+
+  useEffect(() => {
+    previewIndexRef.current = selectedIndex;
+    lastCommittedIndexRef.current = selectedIndex;
+    setPreviewIndex(selectedIndex);
+  }, [selectedIndex]);
+
+  const activeIndex = Math.min(Math.max(previewIndex, 0), lastIndex);
+  const selectedOption = options[activeIndex] ?? options[0];
+  const thumbPercent = lastIndex === 0 ? 0 : (activeIndex / lastIndex) * 100;
+
+  const previewValue = (nextIndex: number) => {
+    const boundedIndex = Math.min(Math.max(nextIndex, 0), lastIndex);
+    previewIndexRef.current = boundedIndex;
+    setPreviewIndex(boundedIndex);
+  };
+
+  const commitPreview = (nextIndex = previewIndexRef.current) => {
+    const boundedIndex = Math.min(Math.max(nextIndex, 0), lastIndex);
+    const nextOption = options[boundedIndex];
+    if (!nextOption || boundedIndex === lastCommittedIndexRef.current) return;
+    lastCommittedIndexRef.current = boundedIndex;
+    onValueChange(nextOption.value);
+  };
+
+  if (!selectedOption || options.length < 2) {
+    return null;
+  }
+
+  return (
+    <MenuGroup>
+      <div className="mx-2 mb-2 overflow-hidden rounded-xl border border-border/70 bg-[linear-gradient(135deg,color-mix(in_srgb,var(--primary)_12%,var(--background)),var(--background)_64%)] shadow-[0_1px_0_color-mix(in_srgb,var(--foreground)_7%,transparent)_inset]">
+        <div className="flex items-start gap-2 px-2.5 pb-1 pt-2.5">
+          <div className="min-w-0 flex-1">
+            <MenuGroupLabel className="p-0 text-[11px]">{label}</MenuGroupLabel>
+            <p className="mt-0.5 text-[10px] text-muted-foreground/70">Drag or tap a notch</p>
+          </div>
+          <div className="flex shrink-0 items-center gap-1.5">
+            <span className="inline-flex h-6 w-[4.75rem] items-center justify-center gap-1.5 rounded-full border border-primary/20 bg-primary/10 px-2 text-[11px] font-medium text-primary shadow-[0_1px_0_color-mix(in_srgb,var(--background)_60%,transparent)_inset]">
+              <span aria-hidden="true" className="size-1.5 rounded-full bg-primary shadow-[0_0_0_3px_color-mix(in_srgb,var(--primary)_15%,transparent)]" />
+              <span className="truncate">{selectedOption.label}</span>
+            </span>
+            {labelTrailing}
+          </div>
+        </div>
+        <div className="px-2.5 pb-2.5">
+          <div className="relative h-10 rounded-lg border border-border/60 bg-background/55 px-3 shadow-[0_1px_0_color-mix(in_srgb,var(--foreground)_5%,transparent)_inset] focus-within:border-primary/45 focus-within:ring-2 focus-within:ring-primary/20">
+            <div className="absolute inset-x-4 top-1/2 h-1.5 -translate-y-1/2 rounded-full bg-muted-foreground/15 shadow-[0_1px_1px_color-mix(in_srgb,var(--foreground)_12%,transparent)_inset]">
+              <div className="relative h-full">
+                <div
+                  aria-hidden="true"
+                  className="h-full rounded-full bg-[linear-gradient(90deg,hsl(var(--primary)/0.6),hsl(var(--primary)))]"
+                  style={{ width: `${thumbPercent}%` }}
+                />
+                <div
+                  aria-hidden="true"
+                  className="pointer-events-none absolute inset-0 flex items-center justify-between"
+                >
+                  {options.map((option, index) => (
+                    <span
+                      key={option.value}
+                      className={cn(
+                        "size-2 rounded-full border-2 border-background",
+                        index <= activeIndex
+                          ? "bg-primary shadow-[0_0_0_1px_hsl(var(--primary)/0.35)]"
+                          : "bg-muted-foreground/35",
+                      )}
+                    />
+                  ))}
+                </div>
+                <div
+                  aria-hidden="true"
+                  className="pointer-events-none absolute top-1/2 z-10 flex size-[18px] -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-2 border-background bg-primary shadow-[0_2px_8px_hsl(var(--primary)/0.32)]"
+                  style={{ left: `${thumbPercent}%` }}
+                >
+                  <span className="size-1.5 rounded-full bg-background/90" />
+                </div>
+              </div>
+            </div>
+            <input
+              aria-label={`${label}: ${selectedOption.label}`}
+              className="absolute inset-0 z-20 h-full w-full cursor-pointer appearance-none opacity-0"
+              max={lastIndex}
+              min={0}
+              onBlur={(event) => commitPreview(Number(event.currentTarget.value))}
+              onChange={(event) => previewValue(Number(event.currentTarget.value))}
+              onKeyUp={(event) => commitPreview(Number(event.currentTarget.value))}
+              onPointerUp={(event) => commitPreview(Number(event.currentTarget.value))}
+              step={1}
+              type="range"
+              value={activeIndex}
+            />
+          </div>
+          <div className="mt-1.5 flex items-center justify-between px-0.5 text-[10px] font-medium text-muted-foreground/70">
+            <span>{options[0]?.label}</span>
+            <span>{options[lastIndex]?.label}</span>
+          </div>
+        </div>
+      </div>
+    </MenuGroup>
+  );
+}
+
 // Shared layout for one composer trait section: a labeled radio group whose rows
 // optionally show a "(default)" suffix and a right-side description tooltip.
 // `onSelectionComplete` runs on every row click (not just on value change) so
@@ -269,6 +398,7 @@ export interface TraitsMenuContentProps {
   prompt: string;
   onPromptChange: (prompt: string) => void;
   includeFastMode?: boolean;
+  useAdvancedEffortSlider?: boolean;
   modelOptions?: ProviderOptions | null | undefined;
   onSelectionComplete?: () => void;
 }
@@ -283,6 +413,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
   prompt,
   onPromptChange,
   includeFastMode = true,
+  useAdvancedEffortSlider = false,
   modelOptions,
   onSelectionComplete,
 }: TraitsMenuContentProps) {
@@ -340,8 +471,8 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
     [threadId, provider, modelOptions, model, setProviderModelOptions, onSelectionComplete],
   );
 
-  const handleEffortChange = useCallback(
-    (value: string) => {
+  const changeEffort = useCallback(
+    (value: string, keepMenuOpen = false) => {
       if (ultrathinkPromptControlled) return;
       if (!value) return;
       const nextOption = effortLevels.find((option) => option.value === value);
@@ -364,7 +495,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
             : provider === "claudeAgent"
               ? "effort"
               : "reasoningEffort");
-      commitTrait(buildProviderOptionPatch(provider, optionId, nextOption.value));
+      commitTrait(buildProviderOptionPatch(provider, optionId, nextOption.value), { keepMenuOpen });
     },
     [
       ultrathinkPromptControlled,
@@ -378,6 +509,17 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
       commitTrait,
     ],
   );
+
+  const handleEffortChange = useCallback((value: string) => changeEffort(value), [changeEffort]);
+  const advancedEffortLevels = effortLevels.filter(
+    (option) => !promptInjectedValues.includes(option.value),
+  );
+  const showAdvancedEffortSlider =
+    useAdvancedEffortSlider &&
+    provider !== "kilo" &&
+    provider !== "opencode" &&
+    !ultrathinkPromptControlled &&
+    advancedEffortLevels.length > 1;
 
   if (!hasVisibleControls && !hasAgentControls) {
     return null;
@@ -418,36 +560,63 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
       {effortLevels.length > 0 ? (
         <>
           {hasPriorEffortSection ? <MenuDivider /> : null}
-          <TraitRadioSection
-            label={provider === "kilo" || provider === "opencode" ? "Variant" : "Effort"}
-            labelTrailing={
-              showsFastModeEffortToggle ? (
-                <FastModeToggle
-                  enabled={fastModeEnabled}
-                  onToggle={() =>
-                    commitTrait({ fastMode: !fastModeEnabled }, { keepMenuOpen: true })
-                  }
-                />
-              ) : undefined
-            }
-            note={
-              ultrathinkPromptControlled ? (
-                <div className="px-2 pb-1.5 text-muted-foreground/80 text-xs">
-                  Remove Ultrathink from the prompt to change effort.
-                </div>
-              ) : undefined
-            }
-            value={effort ?? ""}
-            disabled={ultrathinkPromptControlled}
-            options={effortLevels.map((option) => ({
-              value: option.value,
-              label: option.label,
-              isDefault: option.value === defaultEffort,
-              description: option.description ?? null,
-            }))}
-            onValueChange={handleEffortChange}
-            onSelectionComplete={onSelectionComplete}
-          />
+          {showAdvancedEffortSlider ? (
+            <AdvancedEffortSliderSection
+              key={`${provider}:${model ?? "unknown"}:${advancedEffortLevels
+                .map((option) => option.value)
+                .join(",")}`}
+              label="Effort"
+              labelTrailing={
+                showsFastModeEffortToggle ? (
+                  <FastModeToggle
+                    enabled={fastModeEnabled}
+                    onToggle={() =>
+                      commitTrait({ fastMode: !fastModeEnabled }, { keepMenuOpen: true })
+                    }
+                  />
+                ) : undefined
+              }
+              value={effort ?? defaultEffort ?? advancedEffortLevels[0]?.value ?? ""}
+              options={advancedEffortLevels.map((option) => ({
+                value: option.value,
+                label: option.label,
+                isDefault: option.value === defaultEffort,
+                description: option.description ?? null,
+              }))}
+              onValueChange={(value) => changeEffort(value, true)}
+            />
+          ) : (
+            <TraitRadioSection
+              label={provider === "kilo" || provider === "opencode" ? "Variant" : "Effort"}
+              labelTrailing={
+                showsFastModeEffortToggle ? (
+                  <FastModeToggle
+                    enabled={fastModeEnabled}
+                    onToggle={() =>
+                      commitTrait({ fastMode: !fastModeEnabled }, { keepMenuOpen: true })
+                    }
+                  />
+                ) : undefined
+              }
+              note={
+                ultrathinkPromptControlled ? (
+                  <div className="px-2 pb-1.5 text-muted-foreground/80 text-xs">
+                    Remove Ultrathink from the prompt to change effort.
+                  </div>
+                ) : undefined
+              }
+              value={effort ?? ""}
+              disabled={ultrathinkPromptControlled}
+              options={effortLevels.map((option) => ({
+                value: option.value,
+                label: option.label,
+                isDefault: option.value === defaultEffort,
+                description: option.description ?? null,
+              }))}
+              onValueChange={handleEffortChange}
+              onSelectionComplete={onSelectionComplete}
+            />
+          )}
         </>
       ) : null}
       {includeFastMode && supportsFastModeControl && !showsFastModeEffortToggle ? (
@@ -498,6 +667,7 @@ export const TraitsPicker = memo(function TraitsPicker({
   prompt,
   onPromptChange,
   includeFastMode = true,
+  useAdvancedEffortSlider = false,
   modelOptions,
   open,
   onOpenChange,
@@ -685,6 +855,7 @@ export const TraitsPicker = memo(function TraitsPicker({
           prompt={prompt}
           onPromptChange={onPromptChange}
           includeFastMode={includeFastMode}
+          useAdvancedEffortSlider={useAdvancedEffortSlider}
           modelOptions={modelOptions}
           onSelectionComplete={handleSelectionComplete}
         />

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -1080,6 +1080,9 @@ function SettingsRouteView() {
     ...(settings.enableAssistantStreaming !== defaults.enableAssistantStreaming
       ? ["Assistant output"]
       : []),
+    ...(settings.enableAdvancedEffortSlider !== defaults.enableAdvancedEffortSlider
+      ? ["Advanced effort slider"]
+      : []),
     ...(settings.enableAppSnap !== defaults.enableAppSnap ? ["AppSnap"] : []),
     ...(settings.appSnapPlaySound !== defaults.appSnapPlaySound ? ["AppSnap capture sound"] : []),
     ...(settings.enableProviderUpdateChecks !== defaults.enableProviderUpdateChecks
@@ -2476,6 +2479,15 @@ function SettingsRouteView() {
           description: "Show token-by-token output while a response is in progress.",
           resetLabel: "assistant output",
           ariaLabel: "Stream assistant messages",
+        })}
+
+        {renderBooleanSettingRow({
+          settingKey: "enableAdvancedEffortSlider",
+          title: "Advanced effort slider",
+          description:
+            "Use a direct, draggable effort control for models with multiple reasoning levels. Turn it off to keep the standard effort list.",
+          resetLabel: "advanced effort slider",
+          ariaLabel: "Use the advanced reasoning effort slider",
         })}
 
         {renderBooleanSettingRow({


### PR DESCRIPTION
## What changed

Adds an optional direct-manipulation effort slider to the composer.

- Adds the **Advanced effort slider** setting under Runtime behavior.
- Keeps the existing effort radio list as the default experience.
- Shows a compact slider card with provider-defined effort levels, a current-level indicator, keyboard support, and stable layout.
- Uses local preview state while dragging and persists the selected effort when the interaction completes.
- Falls back to the standard picker for provider variants and Claude's prompt-controlled Ultrathink mode.
- Preserves the existing fast-mode control.

## Why

Models with multiple reasoning levels benefit from a faster, more visual way to tune effort, without changing the default experience for users who prefer the existing list.

## Screenshots

Screenshots of the composer control and its opt-in setting are attached below.

## Validation

- `bun run test -- src/appSettings.test.ts` — 56 passed
- `bun run test:browser -- src/components/chat/TraitsPicker.browser.tsx` — 24 passed