### PR TITLE
feat: show universal live tool activity

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1755,6 +1755,8 @@ export default function ChatView({
   // `foo?.bar` read inside a memo makes React Compiler infer `foo` as the dependency, which
   // no longer matches the hand-written `foo?.bar` dep and bails the whole component out.
   const activeLatestTurnId = activeLatestTurn?.turnId ?? null;
+  const activeLatestTurnState = activeLatestTurn?.state ?? null;
+  const activeLatestTurnCompletedAt = activeLatestTurn?.completedAt ?? null;
   const threadActivities = activeThread?.activities ?? EMPTY_ACTIVITIES;
   const hasLiveTurnTail = hasLiveTurnTailWork({
     latestTurn: activeLatestTurn,
@@ -2271,10 +2273,20 @@ export default function ChatView({
   }, [activeLatestTurnId, activeThread?.messages]);
   const rawWorkLogEntries = useMemo(
     () =>
-      deriveWorkLogEntries(threadActivities, activeLatestTurn?.turnId ?? undefined, {
+      deriveWorkLogEntries(threadActivities, activeLatestTurnId ?? undefined, {
         visibleTurnIds: workLogVisibleTurnIds,
+        activeTurnId: latestTurnLive ? activeLatestTurnId : null,
+        latestTurnState: activeLatestTurnState,
+        latestTurnCompletedAt: activeLatestTurnCompletedAt,
       }),
-    [activeLatestTurn?.turnId, threadActivities, workLogVisibleTurnIds],
+    [
+      activeLatestTurnCompletedAt,
+      activeLatestTurnId,
+      activeLatestTurnState,
+      latestTurnLive,
+      threadActivities,
+      workLogVisibleTurnIds,
+    ],
   );
   const hasWorkLogSubagents = useMemo(
     () => rawWorkLogEntries.some((entry) => (entry.subagents?.length ?? 0) > 0),
@@ -2359,6 +2371,12 @@ export default function ChatView({
   const stripSourceLatestTurnId = stripParentThread
     ? (stripParentThread.latestTurn?.turnId ?? null)
     : (activeLatestTurn?.turnId ?? null);
+  const stripSourceLatestTurnState = stripParentThread
+    ? (stripParentThread.latestTurn?.state ?? null)
+    : activeLatestTurnState;
+  const stripSourceLatestTurnCompletedAt = stripParentThread
+    ? (stripParentThread.latestTurn?.completedAt ?? null)
+    : activeLatestTurnCompletedAt;
   const stripVisibleTurnIds = useMemo(() => {
     if (!stripParentThread) {
       return workLogVisibleTurnIds;
@@ -2387,8 +2405,18 @@ export default function ChatView({
     () =>
       deriveWorkLogEntries(stripSourceActivities, stripSourceLatestTurnId ?? undefined, {
         visibleTurnIds: stripVisibleTurnIds,
+        activeTurnId: stripLiveTurnId,
+        latestTurnState: stripSourceLatestTurnState,
+        latestTurnCompletedAt: stripSourceLatestTurnCompletedAt,
       }),
-    [stripSourceActivities, stripSourceLatestTurnId, stripVisibleTurnIds],
+    [
+      stripLiveTurnId,
+      stripSourceActivities,
+      stripSourceLatestTurnCompletedAt,
+      stripSourceLatestTurnId,
+      stripSourceLatestTurnState,
+      stripVisibleTurnIds,
+    ],
   );
   const hasStripWorkLogSubagents = useMemo(
     () => stripRawWorkLogEntries.some((entry) => (entry.subagents?.length ?? 0) > 0),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1755,6 +1755,7 @@ export default function ChatView({
   // `foo?.bar` read inside a memo makes React Compiler infer `foo` as the dependency, which
   // no longer matches the hand-written `foo?.bar` dep and bails the whole component out.
   const activeLatestTurnId = activeLatestTurn?.turnId ?? null;
+  const activeLatestTurnStartedAt = activeLatestTurn?.startedAt ?? null;
   const activeLatestTurnState = activeLatestTurn?.state ?? null;
   const activeLatestTurnCompletedAt = activeLatestTurn?.completedAt ?? null;
   const threadActivities = activeThread?.activities ?? EMPTY_ACTIVITIES;
@@ -2276,12 +2277,14 @@ export default function ChatView({
       deriveWorkLogEntries(threadActivities, activeLatestTurnId ?? undefined, {
         visibleTurnIds: workLogVisibleTurnIds,
         activeTurnId: latestTurnLive ? activeLatestTurnId : null,
+        activeTurnStartedAt: activeLatestTurnStartedAt,
         latestTurnState: activeLatestTurnState,
         latestTurnCompletedAt: activeLatestTurnCompletedAt,
       }),
     [
       activeLatestTurnCompletedAt,
       activeLatestTurnId,
+      activeLatestTurnStartedAt,
       activeLatestTurnState,
       latestTurnLive,
       threadActivities,
@@ -2374,6 +2377,9 @@ export default function ChatView({
   const stripSourceLatestTurnState = stripParentThread
     ? (stripParentThread.latestTurn?.state ?? null)
     : activeLatestTurnState;
+  const stripSourceLatestTurnStartedAt = stripParentThread
+    ? (stripParentThread.latestTurn?.startedAt ?? null)
+    : activeLatestTurnStartedAt;
   const stripSourceLatestTurnCompletedAt = stripParentThread
     ? (stripParentThread.latestTurn?.completedAt ?? null)
     : activeLatestTurnCompletedAt;
@@ -2406,6 +2412,7 @@ export default function ChatView({
       deriveWorkLogEntries(stripSourceActivities, stripSourceLatestTurnId ?? undefined, {
         visibleTurnIds: stripVisibleTurnIds,
         activeTurnId: stripLiveTurnId,
+        activeTurnStartedAt: stripSourceLatestTurnStartedAt,
         latestTurnState: stripSourceLatestTurnState,
         latestTurnCompletedAt: stripSourceLatestTurnCompletedAt,
       }),
@@ -2414,6 +2421,7 @@ export default function ChatView({
       stripSourceActivities,
       stripSourceLatestTurnCompletedAt,
       stripSourceLatestTurnId,
+      stripSourceLatestTurnStartedAt,
       stripSourceLatestTurnState,
       stripVisibleTurnIds,
     ],

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -235,6 +235,55 @@ describe("computeStableMessagesTimelineRows", () => {
     expect(second.result[0]).toBe(enrichedRows[0]);
   });
 
+  it("replaces work rows when live activity settles without a final tool event", () => {
+    const firstRow: WorkTimelineRow = {
+      kind: "work",
+      id: "work-group-live-activity",
+      createdAt: "2026-05-09T10:00:00.000Z",
+      groupedEntries: [
+        {
+          id: "activity-command",
+          createdAt: "2026-05-09T10:00:00.000Z",
+          label: "Bash",
+          tone: "tool",
+          itemType: "command_execution",
+          liveActivity: {
+            state: "running_tool",
+            label: "Bash",
+            startedAt: "2026-05-09T10:00:00.000Z",
+            lastActivityAt: "2026-05-09T10:00:01.000Z",
+            detail: "Running",
+            progress: 0.5,
+            elapsedSeconds: 1,
+          },
+        },
+      ],
+    };
+    const first = computeStableMessagesTimelineRows([firstRow], emptyStableRows());
+    const settledRow: WorkTimelineRow = {
+      ...firstRow,
+      groupedEntries: [
+        {
+          ...firstRow.groupedEntries[0]!,
+          liveActivity: {
+            state: "completed",
+            label: "Bash completed",
+            startedAt: "2026-05-09T10:00:00.000Z",
+            lastActivityAt: "2026-05-09T10:00:05.000Z",
+            detail: "Done",
+            progress: 1,
+            elapsedSeconds: 5,
+          },
+        },
+      ],
+    };
+
+    const second = computeStableMessagesTimelineRows([settledRow], first);
+
+    expect(second).not.toBe(first);
+    expect(second.result[0]).toBe(settledRow);
+  });
+
   it("reuses worktree-setup rows until a step status or open state changes", () => {
     const makeRow = (
       status: "active" | "done",

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -972,6 +972,23 @@ function workLogToolDetailsEqual(a: WorkLogEntry["toolDetails"], b: WorkLogEntry
   );
 }
 
+function workLogLiveActivitiesEqual(
+  a: WorkLogEntry["liveActivity"],
+  b: WorkLogEntry["liveActivity"],
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.state === b.state &&
+    a.label === b.label &&
+    a.startedAt === b.startedAt &&
+    a.lastActivityAt === b.lastActivityAt &&
+    a.detail === b.detail &&
+    a.progress === b.progress &&
+    a.elapsedSeconds === b.elapsedSeconds
+  );
+}
+
 function workLogEntryContentEqual(a: WorkLogEntry, b: WorkLogEntry): boolean {
   return (
     a.id === b.id &&
@@ -995,6 +1012,7 @@ function workLogEntryContentEqual(a: WorkLogEntry, b: WorkLogEntry): boolean {
     workLogSubagentsEqual(a.subagents, b.subagents) &&
     workLogAutomationsEqual(a.automation, b.automation) &&
     workLogSynaraThreadCreationsEqual(a.synaraThreadCreation, b.synaraThreadCreation) &&
+    workLogLiveActivitiesEqual(a.liveActivity, b.liveActivity) &&
     workLogToolDetailsEqual(a.toolDetails, b.toolDetails)
   );
 }

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1142,6 +1142,53 @@ describe("MessagesTimeline", () => {
     expect(markup).not.toContain("h-px flex-1 bg-border");
   });
 
+  it("does not reserve a timestamp footer between live status updates and Thinking", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const activeTurnId = TurnId.makeUnsafe("turn-live-status");
+    const assistantCreatedAt = "2026-03-17T19:12:29.000Z";
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...makeTimelineBaseProps()}
+        isWorking
+        activeTurnInProgress
+        activeTurnId={activeTurnId}
+        activeTurnStartedAt="2026-03-17T19:12:28.000Z"
+        timelineEntries={[
+          {
+            id: "entry-tasks-updated",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.500Z",
+            entry: {
+              id: "work-tasks-updated",
+              createdAt: "2026-03-17T19:12:28.500Z",
+              label: "Tasks updated",
+              tone: "info",
+              turnId: activeTurnId,
+            },
+          },
+          {
+            id: "entry-live-assistant",
+            kind: "message",
+            createdAt: assistantCreatedAt,
+            message: {
+              id: MessageId.makeUnsafe("message-live-assistant"),
+              role: "assistant",
+              text: "",
+              createdAt: assistantCreatedAt,
+              streaming: false,
+              turnId: activeTurnId,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Tasks updated");
+    expect(markup).toContain("Thinking");
+    expect(markup).not.toContain(formatShortTimestamp(assistantCreatedAt, "locale"));
+    expect(markup).toMatch(/class="[^"]*\bpb-1\b[^"]*" data-timeline-row-kind="message"/);
+  });
+
   it("folds work log summaries above the next assistant message footer", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const markup = renderToStaticMarkup(

--- a/apps/web/src/components/chat/MessagesTimeline.toolDetails.browser.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.toolDetails.browser.tsx
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { render } from "vitest-browser-react";
 
 import { MessagesTimeline } from "./MessagesTimeline";
+import { TimelineWorkEntryRow } from "./TimelineWorkEntryRow";
 
 function ToolDetailsTimeline() {
   return (
@@ -53,6 +54,37 @@ function ToolDetailsTimeline() {
       resolvedTheme="dark"
       timestampFormat="locale"
       workspaceRoot={undefined}
+    />
+  );
+}
+
+function LiveActivityTimeline() {
+  const nowMs = Date.now();
+  return (
+    <TimelineWorkEntryRow
+      workEntry={{
+        id: "work-live-activity",
+        createdAt: "2026-03-17T19:12:28.000Z",
+        label: "Bash",
+        tone: "tool",
+        itemType: "command_execution",
+        toolTitle: "Running command",
+        command: "bun install",
+        liveActivity: {
+          state: "running_tool",
+          label: "Running bun install",
+          startedAt: new Date(nowMs - 134_000).toISOString(),
+          lastActivityAt: new Date(nowMs - 2_000).toISOString(),
+          detail: "Resolving packages",
+          progress: 0.42,
+          elapsedSeconds: 132,
+        },
+      }}
+      chatMetaFontSizePx={12}
+      textFontSizePx={13}
+      density="compact"
+      onImageExpand={() => {}}
+      markdownCwd={undefined}
     />
   );
 }
@@ -147,6 +179,40 @@ describe("MessagesTimeline tool details", () => {
     } finally {
       window.requestAnimationFrame = originalRequestAnimationFrame;
       window.cancelAnimationFrame = originalCancelAnimationFrame;
+      await screen.unmount();
+      host.remove();
+      await settleLayout();
+    }
+  });
+
+  it("keeps live activity compact and reveals technical metadata on demand", async () => {
+    const host = createTimelineHost();
+    const screen = await render(<LiveActivityTimeline />, { container: host });
+
+    try {
+      expect(document.body.textContent ?? "").toContain("Running command · bun install");
+      expect(document.body.textContent ?? "").toContain("Active");
+      expect(document.body.textContent ?? "").toContain("2m 14s elapsed");
+      expect(document.body.textContent ?? "").toContain("42%");
+      expect(document.body.textContent ?? "").not.toContain("Resolving packages");
+      const displayText = document.querySelector("[data-work-entry-display-text='true']");
+      const activityMeta = document.querySelector("[data-live-activity-meta='true']");
+      expect(displayText?.closest("p")).toBe(activityMeta?.closest("p"));
+      expect(displayText?.closest("p")?.textContent ?? "").toContain(
+        "Running command · bun install · Active",
+      );
+
+      const trigger = document.querySelector<HTMLButtonElement>(
+        '[data-tool-detail-trigger="true"]',
+      );
+      expect(trigger).not.toBeNull();
+      trigger?.click();
+
+      await expect.poll(() => document.body.textContent ?? "").toContain("Resolving packages");
+      expect(document.body.textContent ?? "").toContain("Activity");
+      expect(document.body.textContent ?? "").toContain("Running tool");
+      expect(document.body.textContent ?? "").toContain("42%");
+    } finally {
       await screen.unmount();
       host.remove();
       await settleLayout();

--- a/apps/web/src/components/chat/MessagesTimeline.toolDetails.browser.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.toolDetails.browser.tsx
@@ -352,6 +352,7 @@ describe("MessagesTimeline tool details", () => {
       document.querySelector<HTMLButtonElement>("button")?.click();
       expect(openFile).toHaveBeenCalledWith("src/app.ts");
       expect(document.querySelector("[data-tool-details-inline='true']")).toBeNull();
+      expect(document.body.textContent ?? "").toContain("Completed file read · Read file app.ts");
     } finally {
       await screen.unmount();
       host.remove();

--- a/apps/web/src/components/chat/MessagesTimeline.toolDetails.browser.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.toolDetails.browser.tsx
@@ -8,6 +8,7 @@ import { TurnId } from "@synara/contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 
+import { WorkspaceFileOpenerContext } from "../../lib/workspaceFileOpener";
 import { formatTimestamp } from "../../timestampFormat";
 import { MessagesTimeline } from "./MessagesTimeline";
 import { TimelineWorkEntryRow } from "./TimelineWorkEntryRow";
@@ -227,6 +228,7 @@ describe("MessagesTimeline tool details", () => {
 
   it("keeps agent activity as the primary action when live metadata is present", async () => {
     const onOpenAgentActivity = vi.fn();
+    const nowMs = Date.now();
     const host = createTimelineHost();
     const screen = await render(
       <TimelineWorkEntryRow
@@ -240,8 +242,8 @@ describe("MessagesTimeline tool details", () => {
           liveActivity: {
             state: "running_tool",
             label: "Agent task",
-            startedAt: "2026-03-17T19:12:28.000Z",
-            lastActivityAt: "2026-03-17T19:12:29.000Z",
+            startedAt: new Date(nowMs - 2_000).toISOString(),
+            lastActivityAt: new Date(nowMs - 1_000).toISOString(),
           },
         }}
         chatMetaFontSizePx={12}
@@ -260,6 +262,8 @@ describe("MessagesTimeline tool details", () => {
       document.querySelector<HTMLButtonElement>("button")?.click();
       expect(onOpenAgentActivity).toHaveBeenCalledWith("agent-live-activity");
       expect(document.querySelector("[data-tool-details-inline='true']")).toBeNull();
+      expect(document.body.textContent ?? "").toContain("Running agent · Agent task");
+      expect(document.body.textContent ?? "").toContain("Active");
     } finally {
       await screen.unmount();
       host.remove();
@@ -305,6 +309,48 @@ describe("MessagesTimeline tool details", () => {
       expect(fileRow).not.toBeNull();
       fileRow?.click();
       expect(onOpenTurnDiff).toHaveBeenCalledWith(turnId, "src/app.ts");
+      expect(document.querySelector("[data-tool-details-inline='true']")).toBeNull();
+    } finally {
+      await screen.unmount();
+      host.remove();
+      await settleLayout();
+    }
+  });
+
+  it("preserves the file-open action for activity-only read rows", async () => {
+    const openFile = vi.fn(() => true);
+    const host = createTimelineHost();
+    const screen = await render(
+      <WorkspaceFileOpenerContext.Provider value={{ openFile }}>
+        <TimelineWorkEntryRow
+          workEntry={{
+            id: "read-live-activity",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            label: "Read file",
+            tone: "tool",
+            requestKind: "file-read",
+            detail: "src/app.ts",
+            liveActivity: {
+              state: "completed",
+              label: "Read file",
+              lastActivityAt: "2026-03-17T19:12:29.000Z",
+            },
+          }}
+          chatMetaFontSizePx={12}
+          textFontSizePx={13}
+          density="compact"
+          onImageExpand={() => {}}
+          markdownCwd={undefined}
+          timestampFormat="locale"
+        />
+      </WorkspaceFileOpenerContext.Provider>,
+      { container: host },
+    );
+
+    try {
+      expect(document.querySelector("[data-tool-detail-trigger='true']")).toBeNull();
+      document.querySelector<HTMLButtonElement>("button")?.click();
+      expect(openFile).toHaveBeenCalledWith("src/app.ts");
       expect(document.querySelector("[data-tool-details-inline='true']")).toBeNull();
     } finally {
       await screen.unmount();

--- a/apps/web/src/components/chat/MessagesTimeline.toolDetails.browser.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.toolDetails.browser.tsx
@@ -4,9 +4,11 @@
 
 import "../../index.css";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { TurnId } from "@synara/contracts";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 
+import { formatTimestamp } from "../../timestampFormat";
 import { MessagesTimeline } from "./MessagesTimeline";
 import { TimelineWorkEntryRow } from "./TimelineWorkEntryRow";
 
@@ -85,6 +87,7 @@ function LiveActivityTimeline() {
       density="compact"
       onImageExpand={() => {}}
       markdownCwd={undefined}
+      timestampFormat="24-hour"
     />
   );
 }
@@ -212,6 +215,97 @@ describe("MessagesTimeline tool details", () => {
       expect(document.body.textContent ?? "").toContain("Activity");
       expect(document.body.textContent ?? "").toContain("Running tool");
       expect(document.body.textContent ?? "").toContain("42%");
+      for (const time of document.querySelectorAll<HTMLTimeElement>("time[datetime]")) {
+        expect(time.textContent).toBe(formatTimestamp(time.dateTime, "24-hour"));
+      }
+    } finally {
+      await screen.unmount();
+      host.remove();
+      await settleLayout();
+    }
+  });
+
+  it("keeps agent activity as the primary action when live metadata is present", async () => {
+    const onOpenAgentActivity = vi.fn();
+    const host = createTimelineHost();
+    const screen = await render(
+      <TimelineWorkEntryRow
+        workEntry={{
+          id: "agent-live-activity",
+          createdAt: "2026-03-17T19:12:28.000Z",
+          label: "Agent task",
+          tone: "tool",
+          itemType: "collab_agent_tool_call",
+          detail: "Review the implementation",
+          liveActivity: {
+            state: "running_tool",
+            label: "Agent task",
+            startedAt: "2026-03-17T19:12:28.000Z",
+            lastActivityAt: "2026-03-17T19:12:29.000Z",
+          },
+        }}
+        chatMetaFontSizePx={12}
+        textFontSizePx={13}
+        density="compact"
+        onImageExpand={() => {}}
+        markdownCwd={undefined}
+        onOpenAgentActivity={onOpenAgentActivity}
+        timestampFormat="locale"
+      />,
+      { container: host },
+    );
+
+    try {
+      expect(document.querySelector("[data-tool-detail-trigger='true']")).toBeNull();
+      document.querySelector<HTMLButtonElement>("button")?.click();
+      expect(onOpenAgentActivity).toHaveBeenCalledWith("agent-live-activity");
+      expect(document.querySelector("[data-tool-details-inline='true']")).toBeNull();
+    } finally {
+      await screen.unmount();
+      host.remove();
+      await settleLayout();
+    }
+  });
+
+  it("opens the turn diff for activity-only file rows", async () => {
+    const onOpenTurnDiff = vi.fn();
+    const turnId = TurnId.makeUnsafe("turn-file-activity");
+    const host = createTimelineHost();
+    const screen = await render(
+      <TimelineWorkEntryRow
+        workEntry={{
+          id: "file-live-activity",
+          createdAt: "2026-03-17T19:12:28.000Z",
+          label: "Edited file",
+          tone: "tool",
+          itemType: "file_change",
+          changedFiles: ["src/app.ts"],
+          liveActivity: {
+            state: "completed",
+            label: "Edited file",
+            lastActivityAt: "2026-03-17T19:12:29.000Z",
+          },
+        }}
+        chatMetaFontSizePx={12}
+        textFontSizePx={13}
+        density="compact"
+        onImageExpand={() => {}}
+        markdownCwd={undefined}
+        turnId={turnId}
+        onOpenTurnDiff={onOpenTurnDiff}
+        timestampFormat="locale"
+      />,
+      { container: host },
+    );
+
+    try {
+      const fileRow = document.querySelector<HTMLButtonElement>(
+        "[data-file-change-row='true']",
+      );
+      expect(fileRow).not.toBeNull();
+      fileRow?.click();
+      expect(onOpenTurnDiff).toHaveBeenCalledWith(turnId, "src/app.ts");
+      expect(document.querySelector("[data-tool-details-inline='true']")).toBeNull();
     } finally {
       await screen.unmount();
       host.remove();

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -954,11 +954,16 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       className={cn(
         CHAT_COLUMN_FRAME_CLASS_NAME,
         "px-1 transition-colors duration-500",
-        row.kind === "work" ||
-          row.kind === "working-header" ||
-          (row.kind === "message" && row.message.role === "assistant")
-          ? "pb-2"
-          : "pb-4",
+        row.kind === "working" ||
+          (row.kind === "message" &&
+            row.message.role === "assistant" &&
+            row.assistantTurnInProgress)
+          ? "pb-1"
+          : row.kind === "work" ||
+              row.kind === "working-header" ||
+              (row.kind === "message" && row.message.role === "assistant")
+            ? "pb-2"
+            : "pb-4",
         row.kind === "message" && row.message.role === "assistant" ? "group/assistant" : null,
         row.kind === "message" && row.message.id === highlightedMessageId
           ? "rounded-xl bg-[var(--color-background-elevated-secondary)]"
@@ -1391,7 +1396,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
           // so a live turn reads as one block, not a stack of timestamped
           // fragments. `showAssistantCopyButton` is exactly the terminal-message
           // signal (see deriveTerminalAssistantMessageIds).
-          const isTerminalAssistantMessage = row.showAssistantCopyButton;
+          const isTerminalAssistantMessage =
+            row.showAssistantCopyButton && !row.assistantTurnInProgress;
           const assistantMeta = [
             isTerminalAssistantMessage
               ? formatShortTimestamp(row.message.createdAt, timestampFormat)
@@ -1541,7 +1547,16 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                     </div>
                   )}
                 {!hasCollapsedWork && display.statusEntries.length > 0 && (
-                  <div className={cn("space-y-0.5", placement === "leading" ? "mb-2" : "mt-2")}>
+                  <div
+                    className={cn(
+                      "space-y-0.5",
+                      placement === "leading"
+                        ? row.assistantTurnInProgress
+                          ? "mb-0.5"
+                          : "mb-2"
+                        : "mt-2",
+                    )}
+                  >
                     {display.statusEntries.map((workEntry) => (
                       <TimelineWorkEntryRow
                         key={`${placement}-status-row:${row.message.id}:${workEntry.id}`}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -994,6 +994,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
               density={prefersCompactWorkEntryRow(workEntry) ? "compact" : "default"}
               markdownCwd={markdownCwd}
               onImageExpand={onImageExpand}
+              timestampFormat={timestampFormat}
               {...(onOpenAgentActivity ? { onOpenAgentActivity } : {})}
               {...(onOpenAutomation ? { onOpenAutomation } : {})}
             />
@@ -1447,6 +1448,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                 markdownCwd={markdownCwd}
                 onImageExpand={onImageExpand}
                 onOpenTurnDiff={onOpenTurnDiff}
+                timestampFormat={timestampFormat}
                 {...(onOpenAgentActivity ? { onOpenAgentActivity } : {})}
                 {...(onOpenAutomation ? { onOpenAutomation } : {})}
                 {...(turnSummary?.turnId ? { turnId: turnSummary.turnId } : {})}
@@ -1566,6 +1568,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                         density={prefersCompactWorkEntryRow(workEntry) ? "compact" : "default"}
                         markdownCwd={markdownCwd}
                         onImageExpand={onImageExpand}
+                        timestampFormat={timestampFormat}
                         {...(onOpenAgentActivity ? { onOpenAgentActivity } : {})}
                         {...(onOpenAutomation ? { onOpenAutomation } : {})}
                       />
@@ -1585,6 +1588,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                 density={prefersCompactWorkEntryRow(item.entry) ? "compact" : "default"}
                 markdownCwd={markdownCwd}
                 onImageExpand={onImageExpand}
+                timestampFormat={timestampFormat}
                 {...(onOpenAgentActivity ? { onOpenAgentActivity } : {})}
                 {...(onOpenAutomation ? { onOpenAutomation } : {})}
               />

--- a/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
+++ b/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
@@ -17,6 +17,7 @@ import {
 } from "react";
 
 import { basenameOfPath } from "~/file-icons";
+import type { TimestampFormat } from "../../appSettings";
 import {
   ArrowUpCircleIcon,
   BackgroundTrayIcon,
@@ -433,6 +434,7 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
   onOpenTurnDiff?: (turnId: TurnId, filePath?: string) => void;
   onOpenAgentActivity?: (activityId: string) => void;
   onOpenAutomation?: (automationId: string) => void;
+  timestampFormat: TimestampFormat;
 }) {
   // Defaults are applied in the body (not in the destructuring pattern): a default
   // value inside a destructuring pattern makes React Compiler bail out on the whole
@@ -449,6 +451,7 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
     onOpenTurnDiff,
     onOpenAgentActivity,
     onOpenAutomation,
+    timestampFormat,
   } = props;
   const textFontSizePx = textFontSizePxProp ?? chatMetaFontSizePx;
   const density = densityProp ?? "default";
@@ -510,7 +513,9 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
   const openAgentActivity = canOpenAgentActivity
     ? () => onOpenAgentActivity?.(workEntry.id)
     : undefined;
-  const canOpenToolDetails = Boolean(workEntry.toolDetails || workEntry.liveActivity);
+  const hasToolDetails = Boolean(workEntry.toolDetails);
+  const canOpenToolDetails =
+    !canOpenAgentActivity && Boolean(workEntry.toolDetails || workEntry.liveActivity);
   // File-read rows open the referenced file in the in-app viewer when the
   // hosting surface provides an opener (right-dock file pane / editor pane).
   const opener = useWorkspaceFileOpener();
@@ -598,7 +603,7 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
                 compact={compact}
               />
             );
-            if (canOpenToolDetails) {
+            if (hasToolDetails || (canOpenToolDetails && !canOpenEditedDiff)) {
               return (
                 <ToolDetailsDisclosure
                   key={`${workEntry.id}:${changedFilePath}`}
@@ -608,6 +613,7 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
                   tooltip={<span className="whitespace-pre-wrap">{changedFilePath}</span>}
                   summaryClassName={editedRowClassName}
                   dataFileChangeRow
+                  timestampFormat={timestampFormat}
                 >
                   {editedRowChildren}
                 </ToolDetailsDisclosure>
@@ -710,6 +716,7 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
                 details={workEntry.toolDetails}
                 activity={workEntry.liveActivity}
                 compact={compact}
+                timestampFormat={timestampFormat}
                 tooltip={toolRowTooltipContent(rawCommand, displayText, displayText)}
               >
                 {rowContentChildren}
@@ -841,6 +848,7 @@ function ToolDetailsDisclosure(props: {
   details?: TimelineWorkEntry["toolDetails"] | undefined;
   activity?: TimelineWorkEntry["liveActivity"] | undefined;
   summaryClassName?: string | undefined;
+  timestampFormat: TimestampFormat;
   tooltip?: ReactNode;
 }) {
   const summaryClassName =
@@ -921,7 +929,11 @@ function ToolDetailsDisclosure(props: {
           contentClassName={cn("min-w-0 pt-2", props.compact ? "ml-5" : "ml-7")}
         >
           <div data-tool-details-inline="true">
-            <ToolCallDetailsContent details={props.details} activity={props.activity} />
+            <ToolCallDetailsContent
+              details={props.details}
+              activity={props.activity}
+              timestampFormat={props.timestampFormat}
+            />
           </div>
         </DisclosureRegion>
       ) : null}

--- a/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
+++ b/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
@@ -39,7 +39,10 @@ import {
 import { describeLinkChip } from "~/lib/linkChips";
 import { cn } from "~/lib/utils";
 
-import { isFileChangeWorkLogEntry, type WorkLogEntry } from "../../session-logic";
+import {
+  isFileChangeWorkLogEntry,
+  type WorkLogEntry,
+} from "../../session-logic";
 import {
   formatAgentActivityEntryPreview,
   isAgentActivityWorkEntry,
@@ -71,6 +74,11 @@ import {
   sanitizeSynaraMcpToolPreview,
   type SynaraMcpToolStatus,
 } from "../../lib/toolCallLabel";
+import {
+  formatLiveActivityMeta,
+  formatLiveActivityPrimary,
+  useLiveActivityNow,
+} from "../../lib/liveActivityPresentation";
 import { openWorkspaceFileReference, useWorkspaceFileOpener } from "../../lib/workspaceFileOpener";
 
 const TRANSCRIPT_DISCLOSURE_TRANSITION_MS = 220;
@@ -476,7 +484,7 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
         status: toolWorkEntryStatus(workEntry),
       })
     : rawPreview;
-  const displayText = webFetchUrl
+  const defaultDisplayText = webFetchUrl
     ? describeLinkChip(webFetchUrl).label
     : isReasoningUpdateWorkEntry(workEntry) && preview
       ? preview
@@ -486,6 +494,14 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
     Boolean(preview) &&
     normalizeToolTextForComparison(heading) !== normalizeToolTextForComparison(preview ?? "");
   const rawCommand = workEntry.rawCommand ?? workEntry.command;
+  const displayText = workEntry.liveActivity
+    ? formatLiveActivityPrimary({
+        activity: workEntry.liveActivity,
+        entry: workEntry,
+        heading,
+        rawCommand,
+      })
+    : defaultDisplayText;
   const hoverText =
     rawCommand ?? (showInlineAgentTaskPreview ? heading : (webFetchUrl ?? displayText));
   const changedFiles = workEntry.changedFiles ?? [];
@@ -494,7 +510,7 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
   const openAgentActivity = canOpenAgentActivity
     ? () => onOpenAgentActivity?.(workEntry.id)
     : undefined;
-  const canOpenToolDetails = Boolean(workEntry.toolDetails);
+  const canOpenToolDetails = Boolean(workEntry.toolDetails || workEntry.liveActivity);
   // File-read rows open the referenced file in the in-app viewer when the
   // hosting surface provides an opener (right-dock file pane / editor pane).
   const opener = useWorkspaceFileOpener();
@@ -508,6 +524,10 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
         : EMPTY_FILE_DIFF_STATS,
     [workEntry],
   );
+  const liveActivityNowMs = useLiveActivityNow(workEntry.liveActivity);
+  const liveActivityMetaText = workEntry.liveActivity
+    ? formatLiveActivityMeta(workEntry.liveActivity, liveActivityNowMs)
+    : null;
 
   // A created-automation row renders as its own card instead of a tool-call line.
   // Kept after the hooks above so the early return never changes hook order.
@@ -578,11 +598,12 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
                 compact={compact}
               />
             );
-            if (canOpenToolDetails && workEntry.toolDetails) {
+            if (canOpenToolDetails) {
               return (
                 <ToolDetailsDisclosure
                   key={`${workEntry.id}:${changedFilePath}`}
                   details={workEntry.toolDetails}
+                  activity={workEntry.liveActivity}
                   compact={compact}
                   tooltip={<span className="whitespace-pre-wrap">{changedFilePath}</span>}
                   summaryClassName={editedRowClassName}
@@ -675,15 +696,19 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
                     style={{ fontSize: `${rowFontSizePx}px` }}
                   >
                     <span data-work-entry-display-text="true">{displayText}</span>
+                    {liveActivityMetaText ? (
+                      <span data-live-activity-meta="true"> · {liveActivityMetaText}</span>
+                    ) : null}
                   </p>
                 )}
               </div>
             </>
           );
-          if (canOpenToolDetails && workEntry.toolDetails) {
+          if (canOpenToolDetails) {
             return (
               <ToolDetailsDisclosure
                 details={workEntry.toolDetails}
+                activity={workEntry.liveActivity}
                 compact={compact}
                 tooltip={toolRowTooltipContent(rawCommand, displayText, displayText)}
               >
@@ -813,7 +838,8 @@ function ToolDetailsDisclosure(props: {
   children: ReactNode;
   compact: boolean;
   dataFileChangeRow?: boolean | undefined;
-  details: NonNullable<TimelineWorkEntry["toolDetails"]>;
+  details?: TimelineWorkEntry["toolDetails"] | undefined;
+  activity?: TimelineWorkEntry["liveActivity"] | undefined;
   summaryClassName?: string | undefined;
   tooltip?: ReactNode;
 }) {
@@ -895,7 +921,7 @@ function ToolDetailsDisclosure(props: {
           contentClassName={cn("min-w-0 pt-2", props.compact ? "ml-5" : "ml-7")}
         >
           <div data-tool-details-inline="true">
-            <ToolCallDetailsContent details={props.details} />
+            <ToolCallDetailsContent details={props.details} activity={props.activity} />
           </div>
         </DisclosureRegion>
       ) : null}

--- a/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
+++ b/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
@@ -514,8 +514,6 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
     ? () => onOpenAgentActivity?.(workEntry.id)
     : undefined;
   const hasToolDetails = Boolean(workEntry.toolDetails);
-  const canOpenToolDetails =
-    !canOpenAgentActivity && Boolean(workEntry.toolDetails || workEntry.liveActivity);
   // File-read rows open the referenced file in the in-app viewer when the
   // hosting surface provides an opener (right-dock file pane / editor pane).
   const opener = useWorkspaceFileOpener();
@@ -561,6 +559,9 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
       ? extractFilePathFromDetail(workEntry.detail)
       : null;
   const canOpenReadFile = readFilePath !== null;
+  const canOpenToolDetails =
+    !canOpenAgentActivity &&
+    Boolean(workEntry.toolDetails || (workEntry.liveActivity && !canOpenReadFile));
   const openReadFile = readFilePath
     ? () => openWorkspaceFileReference(opener, readFilePath)
     : undefined;
@@ -675,7 +676,12 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
                       className="truncate font-medium leading-5 text-muted-foreground/72"
                       style={{ fontSize: `${rowFontSizePx}px` }}
                     >
-                      {heading}
+                      <span data-work-entry-display-text="true">
+                        {workEntry.liveActivity ? displayText : heading}
+                      </span>
+                      {liveActivityMetaText ? (
+                        <span data-live-activity-meta="true"> · {liveActivityMetaText}</span>
+                      ) : null}
                     </p>
                     <ChatMarkdown
                       text={preview ?? ""}

--- a/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
+++ b/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
@@ -502,6 +502,7 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
         activity: workEntry.liveActivity,
         entry: workEntry,
         heading,
+        displayTarget: showInlineAgentTaskPreview ? heading : defaultDisplayText,
         rawCommand,
       })
     : defaultDisplayText;

--- a/apps/web/src/components/chat/ToolCallDetailsDialog.tsx
+++ b/apps/web/src/components/chat/ToolCallDetailsDialog.tsx
@@ -11,7 +11,9 @@ import type { TimestampFormat } from "../../appSettings";
 import type { WorkLogToolDetails, WorkLogToolOutputDetails } from "../../lib/toolCallDetails";
 import type { WorkLogLiveActivity } from "../../workLog";
 import {
-  liveActivityElapsedMs,
+  formatLiveActivityElapsed,
+  formatLiveActivityProgress,
+  formatLiveActivityStateLabel,
   useLiveActivityNow,
 } from "../../lib/liveActivityPresentation";
 import { formatTimestamp } from "../../timestampFormat";
@@ -127,25 +129,6 @@ function formatActivityTimestamp(value: string, timestampFormat: TimestampFormat
   return formatTimestamp(value, timestampFormat);
 }
 
-function formatActivityElapsed(activity: WorkLogLiveActivity, nowMs: number): string | null {
-  const elapsedMs = liveActivityElapsedMs(activity, nowMs);
-  if (elapsedMs === null) {
-    return null;
-  }
-  const wholeSeconds = Math.floor(elapsedMs / 1_000);
-  if (wholeSeconds < 60) return `${wholeSeconds}s`;
-  const hours = Math.floor(wholeSeconds / 3_600);
-  const minutes = Math.floor((wholeSeconds % 3_600) / 60);
-  const seconds = wholeSeconds % 60;
-  if (hours > 0) return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
-  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
-}
-
-function formatActivityProgress(progress: number): string {
-  const percent = progress >= 0 && progress <= 1 ? progress * 100 : progress;
-  return `${Math.round(Math.min(100, Math.max(0, percent)))}%`;
-}
-
 function LiveActivityMetadata({
   activity,
   timestampFormat,
@@ -153,20 +136,11 @@ function LiveActivityMetadata({
   activity: WorkLogLiveActivity;
   timestampFormat: TimestampFormat;
 }) {
-  const stateLabel = {
-    starting: "Starting",
-    thinking: "Thinking",
-    running_tool: "Running tool",
-    waiting: "Waiting",
-    streaming: "Streaming",
-    completed: "Completed",
-    failed: "Failed",
-    cancelled: "Cancelled",
-  }[activity.state];
+  const stateLabel = formatLiveActivityStateLabel(activity.state);
   const nowMs = useLiveActivityNow(activity);
-  const elapsed = formatActivityElapsed(activity, nowMs);
+  const elapsed = formatLiveActivityElapsed(activity, nowMs);
   const progress =
-    activity.progress !== undefined ? formatActivityProgress(activity.progress) : null;
+    activity.progress !== undefined ? formatLiveActivityProgress(activity.progress) : null;
 
   return (
     <ToolDetailSection title="Activity">

--- a/apps/web/src/components/chat/ToolCallDetailsDialog.tsx
+++ b/apps/web/src/components/chat/ToolCallDetailsDialog.tsx
@@ -8,6 +8,11 @@ import type { ReactNode } from "react";
 import { createMarkdownCodeFence, formatShellTranscript } from "~/lib/toolCallDetailsFormatting";
 import { cn } from "~/lib/utils";
 import type { WorkLogToolDetails, WorkLogToolOutputDetails } from "../../lib/toolCallDetails";
+import type { WorkLogLiveActivity } from "../../workLog";
+import {
+  liveActivityElapsedMs,
+  useLiveActivityNow,
+} from "../../lib/liveActivityPresentation";
 import ChatMarkdown from "../ChatMarkdown";
 
 const DETAIL_HEADER_CLASS_NAME = "border-b border-border/45 px-3 py-2 text-[10px] font-medium";
@@ -16,8 +21,14 @@ const DETAIL_CODE_BLOCK_CLASS_NAME =
 const TOOL_DETAILS_MARKDOWN_CLASS_NAME =
   "text-[length:var(--app-font-size-ui,12px)] leading-relaxed";
 
-export function ToolCallDetailsContent({ details }: { details: WorkLogToolDetails | undefined }) {
-  if (!details) {
+export function ToolCallDetailsContent({
+  details,
+  activity,
+}: {
+  details: WorkLogToolDetails | undefined;
+  activity?: WorkLogLiveActivity | undefined;
+}) {
+  if (!details && !activity) {
     return (
       <div className="rounded-lg border border-border/45 bg-background/60 px-3 py-2 text-sm text-muted-foreground">
         No detailed payload was available for this tool call.
@@ -27,7 +38,9 @@ export function ToolCallDetailsContent({ details }: { details: WorkLogToolDetail
 
   return (
     <>
-      {details.command ? (
+      {activity ? <LiveActivityMetadata activity={activity} /> : null}
+
+      {details?.command ? (
         <div className="space-y-2">
           <MarkdownToolCodeBlock language="bash">
             {formatShellTranscript(details.command, details.output)}
@@ -36,7 +49,7 @@ export function ToolCallDetailsContent({ details }: { details: WorkLogToolDetail
         </div>
       ) : null}
 
-      {details.files?.length ? (
+      {details?.files?.length ? (
         <ToolDetailSection title="Files">
           <div className="flex flex-wrap gap-1.5">
             {details.files.map((file) => (
@@ -52,13 +65,13 @@ export function ToolCallDetailsContent({ details }: { details: WorkLogToolDetail
         </ToolDetailSection>
       ) : null}
 
-      {details.diff ? (
+      {details?.diff ? (
         <ToolDetailSection title="Diff">
           <DiffCodeBlock>{details.diff}</DiffCodeBlock>
         </ToolDetailSection>
       ) : null}
 
-      {details.edits?.length ? (
+      {details?.edits?.length ? (
         <ToolDetailSection title="Edits">
           <div className="space-y-3">
             {details.edits.map((edit, index) => (
@@ -89,14 +102,101 @@ export function ToolCallDetailsContent({ details }: { details: WorkLogToolDetail
         </ToolDetailSection>
       ) : null}
 
-      {details.content ? (
+      {details?.content ? (
         <ToolDetailSection title="Written Content">
           <MarkdownToolCodeBlock language="text">{details.content}</MarkdownToolCodeBlock>
         </ToolDetailSection>
       ) : null}
 
-      {details.output && !details.command ? <ToolOutputSection output={details.output} /> : null}
+      {details?.output && !details.command ? <ToolOutputSection output={details.output} /> : null}
     </>
+  );
+}
+
+function formatActivityTimestamp(value: string): string {
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    return value;
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(timestamp);
+}
+
+function formatActivityElapsed(activity: WorkLogLiveActivity, nowMs: number): string | null {
+  const elapsedMs = liveActivityElapsedMs(activity, nowMs);
+  if (elapsedMs === null) {
+    return null;
+  }
+  const wholeSeconds = Math.floor(elapsedMs / 1_000);
+  if (wholeSeconds < 60) return `${wholeSeconds}s`;
+  const hours = Math.floor(wholeSeconds / 3_600);
+  const minutes = Math.floor((wholeSeconds % 3_600) / 60);
+  const seconds = wholeSeconds % 60;
+  if (hours > 0) return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}
+
+function formatActivityProgress(progress: number): string {
+  const percent = progress >= 0 && progress <= 1 ? progress * 100 : progress;
+  return `${Math.round(Math.min(100, Math.max(0, percent)))}%`;
+}
+
+function LiveActivityMetadata({ activity }: { activity: WorkLogLiveActivity }) {
+  const stateLabel = {
+    starting: "Starting",
+    thinking: "Thinking",
+    running_tool: "Running tool",
+    waiting: "Waiting",
+    streaming: "Streaming",
+    completed: "Completed",
+    failed: "Failed",
+    cancelled: "Cancelled",
+  }[activity.state];
+  const nowMs = useLiveActivityNow(activity);
+  const elapsed = formatActivityElapsed(activity, nowMs);
+  const progress =
+    activity.progress !== undefined ? formatActivityProgress(activity.progress) : null;
+
+  return (
+    <ToolDetailSection title="Activity">
+      <dl className="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-3 gap-y-1.5 rounded-lg border border-border/45 bg-background/60 px-3 py-2.5 text-[11px]">
+        <dt className="text-muted-foreground/56">Status</dt>
+        <dd className="text-foreground/84">{stateLabel}</dd>
+        <dt className="text-muted-foreground/56">Started</dt>
+        <dd className="text-foreground/84">
+          <time dateTime={activity.startedAt} title={activity.startedAt}>
+            {formatActivityTimestamp(activity.startedAt)}
+          </time>
+        </dd>
+        <dt className="text-muted-foreground/56">Last activity</dt>
+        <dd className="text-foreground/84">
+          <time dateTime={activity.lastActivityAt} title={activity.lastActivityAt}>
+            {formatActivityTimestamp(activity.lastActivityAt)}
+          </time>
+        </dd>
+        {elapsed ? (
+          <>
+            <dt className="text-muted-foreground/56">Elapsed</dt>
+            <dd className="tabular-nums text-foreground/84">{elapsed}</dd>
+          </>
+        ) : null}
+        {progress ? (
+          <>
+            <dt className="text-muted-foreground/56">Progress</dt>
+            <dd className="tabular-nums text-foreground/84">{progress}</dd>
+          </>
+        ) : null}
+        {activity.detail ? (
+          <>
+            <dt className="text-muted-foreground/56">Detail</dt>
+            <dd className="break-words text-foreground/84">{activity.detail}</dd>
+          </>
+        ) : null}
+      </dl>
+    </ToolDetailSection>
   );
 }
 

--- a/apps/web/src/components/chat/ToolCallDetailsDialog.tsx
+++ b/apps/web/src/components/chat/ToolCallDetailsDialog.tsx
@@ -7,12 +7,14 @@
 import type { ReactNode } from "react";
 import { createMarkdownCodeFence, formatShellTranscript } from "~/lib/toolCallDetailsFormatting";
 import { cn } from "~/lib/utils";
+import type { TimestampFormat } from "../../appSettings";
 import type { WorkLogToolDetails, WorkLogToolOutputDetails } from "../../lib/toolCallDetails";
 import type { WorkLogLiveActivity } from "../../workLog";
 import {
   liveActivityElapsedMs,
   useLiveActivityNow,
 } from "../../lib/liveActivityPresentation";
+import { formatTimestamp } from "../../timestampFormat";
 import ChatMarkdown from "../ChatMarkdown";
 
 const DETAIL_HEADER_CLASS_NAME = "border-b border-border/45 px-3 py-2 text-[10px] font-medium";
@@ -24,9 +26,11 @@ const TOOL_DETAILS_MARKDOWN_CLASS_NAME =
 export function ToolCallDetailsContent({
   details,
   activity,
+  timestampFormat,
 }: {
   details: WorkLogToolDetails | undefined;
   activity?: WorkLogLiveActivity | undefined;
+  timestampFormat: TimestampFormat;
 }) {
   if (!details && !activity) {
     return (
@@ -38,7 +42,9 @@ export function ToolCallDetailsContent({
 
   return (
     <>
-      {activity ? <LiveActivityMetadata activity={activity} /> : null}
+      {activity ? (
+        <LiveActivityMetadata activity={activity} timestampFormat={timestampFormat} />
+      ) : null}
 
       {details?.command ? (
         <div className="space-y-2">
@@ -113,16 +119,12 @@ export function ToolCallDetailsContent({
   );
 }
 
-function formatActivityTimestamp(value: string): string {
+function formatActivityTimestamp(value: string, timestampFormat: TimestampFormat): string {
   const timestamp = Date.parse(value);
   if (Number.isNaN(timestamp)) {
     return value;
   }
-  return new Intl.DateTimeFormat(undefined, {
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  }).format(timestamp);
+  return formatTimestamp(value, timestampFormat);
 }
 
 function formatActivityElapsed(activity: WorkLogLiveActivity, nowMs: number): string | null {
@@ -144,7 +146,13 @@ function formatActivityProgress(progress: number): string {
   return `${Math.round(Math.min(100, Math.max(0, percent)))}%`;
 }
 
-function LiveActivityMetadata({ activity }: { activity: WorkLogLiveActivity }) {
+function LiveActivityMetadata({
+  activity,
+  timestampFormat,
+}: {
+  activity: WorkLogLiveActivity;
+  timestampFormat: TimestampFormat;
+}) {
   const stateLabel = {
     starting: "Starting",
     thinking: "Thinking",
@@ -165,16 +173,20 @@ function LiveActivityMetadata({ activity }: { activity: WorkLogLiveActivity }) {
       <dl className="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-3 gap-y-1.5 rounded-lg border border-border/45 bg-background/60 px-3 py-2.5 text-[11px]">
         <dt className="text-muted-foreground/56">Status</dt>
         <dd className="text-foreground/84">{stateLabel}</dd>
-        <dt className="text-muted-foreground/56">Started</dt>
-        <dd className="text-foreground/84">
-          <time dateTime={activity.startedAt} title={activity.startedAt}>
-            {formatActivityTimestamp(activity.startedAt)}
-          </time>
-        </dd>
+        {activity.startedAt ? (
+          <>
+            <dt className="text-muted-foreground/56">Started</dt>
+            <dd className="text-foreground/84">
+              <time dateTime={activity.startedAt} title={activity.startedAt}>
+                {formatActivityTimestamp(activity.startedAt, timestampFormat)}
+              </time>
+            </dd>
+          </>
+        ) : null}
         <dt className="text-muted-foreground/56">Last activity</dt>
         <dd className="text-foreground/84">
           <time dateTime={activity.lastActivityAt} title={activity.lastActivityAt}>
-            {formatActivityTimestamp(activity.lastActivityAt)}
+            {formatActivityTimestamp(activity.lastActivityAt, timestampFormat)}
           </time>
         </dd>
         {elapsed ? (

--- a/apps/web/src/lib/liveActivityPresentation.test.ts
+++ b/apps/web/src/lib/liveActivityPresentation.test.ts
@@ -73,4 +73,17 @@ describe("live activity presentation", () => {
       "Completed · 2m 14s elapsed · 100%",
     );
   });
+
+  it("does not invent elapsed time when a terminal event has no known start", () => {
+    const activity: WorkLogLiveActivity = {
+      state: "completed",
+      label: "Deploy",
+      lastActivityAt: "2026-07-26T14:02:14.000Z",
+    };
+
+    expect(liveActivityElapsedMs(activity, Date.parse("2026-07-26T14:03:00.000Z"))).toBeNull();
+    expect(formatLiveActivityMeta(activity, Date.parse("2026-07-26T14:03:00.000Z"))).toBe(
+      "Completed",
+    );
+  });
 });

--- a/apps/web/src/lib/liveActivityPresentation.test.ts
+++ b/apps/web/src/lib/liveActivityPresentation.test.ts
@@ -42,6 +42,20 @@ describe("live activity presentation", () => {
     ).toBe("Running command · PowerShell");
   });
 
+  it("preserves the existing target for non-command activity", () => {
+    expect(
+      formatLiveActivityPrimary({
+        activity: runningActivity({
+          state: "completed",
+          label: "Read",
+        }),
+        entry: { requestKind: "file-read" },
+        heading: "Read",
+        displayTarget: "Read app.ts",
+      }),
+    ).toBe("Completed file read · Read app.ts");
+  });
+
   it("renders recent activity and elapsed time from one normalized state", () => {
     const activity = runningActivity();
     const nowMs = Date.parse("2026-07-26T14:02:14.000Z");

--- a/apps/web/src/lib/liveActivityPresentation.test.ts
+++ b/apps/web/src/lib/liveActivityPresentation.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorkLogLiveActivity } from "../workLog";
+import {
+  formatLiveActivityMeta,
+  formatLiveActivityPrimary,
+  friendlyLiveCommandTarget,
+  liveActivityElapsedMs,
+} from "./liveActivityPresentation";
+
+const STARTED_AT = "2026-07-26T14:00:00.000Z";
+
+function runningActivity(
+  overrides: Partial<WorkLogLiveActivity> = {},
+): WorkLogLiveActivity {
+  return {
+    state: "running_tool",
+    label: "Bash",
+    startedAt: STARTED_AT,
+    lastActivityAt: "2026-07-26T14:02:11.000Z",
+    elapsedSeconds: 131,
+    ...overrides,
+  };
+}
+
+describe("live activity presentation", () => {
+  it("uses a friendly PowerShell name instead of leaking the full wrapper command", () => {
+    const command =
+      '"C:\\Users\\Example\\AppData\\Local\\Microsoft\\WindowsApps\\pwsh.exe" -Command "powershell -NoProfile -Command \\"1..8\\""';
+
+    expect(friendlyLiveCommandTarget(command)).toBe("PowerShell");
+    expect(
+      formatLiveActivityPrimary({
+        activity: runningActivity(),
+        entry: { itemType: "command_execution" },
+        heading: "Running command",
+        rawCommand: command,
+      }),
+    ).toBe("Running command · PowerShell");
+  });
+
+  it("renders recent activity and elapsed time from one normalized state", () => {
+    const activity = runningActivity();
+    const nowMs = Date.parse("2026-07-26T14:02:14.000Z");
+
+    expect(liveActivityElapsedMs(activity, nowMs)).toBe(134_000);
+    expect(formatLiveActivityMeta(activity, nowMs)).toBe(
+      "Active 3s ago · 2m 14s elapsed",
+    );
+  });
+
+  it("reports quiet live tools without claiming they are frozen", () => {
+    expect(
+      formatLiveActivityMeta(
+        runningActivity({
+          lastActivityAt: "2026-07-26T14:01:44.000Z",
+          elapsedSeconds: 104,
+        }),
+        Date.parse("2026-07-26T14:02:14.000Z"),
+      ),
+    ).toBe("No activity for 30s · 2m 14s elapsed");
+  });
+
+  it("keeps progress and terminal states provider-agnostic", () => {
+    const completed = runningActivity({
+      state: "completed",
+      lastActivityAt: "2026-07-26T14:02:14.000Z",
+      elapsedSeconds: 134,
+      progress: 1,
+    });
+
+    expect(formatLiveActivityMeta(completed, Date.parse("2026-07-26T14:03:00.000Z"))).toBe(
+      "Completed · 2m 14s elapsed · 100%",
+    );
+  });
+});

--- a/apps/web/src/lib/liveActivityPresentation.test.ts
+++ b/apps/web/src/lib/liveActivityPresentation.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from "vitest";
 import type { WorkLogLiveActivity } from "../workLog";
 import {
   formatLiveActivityMeta,
+  formatLiveActivityElapsed,
   formatLiveActivityPrimary,
+  formatLiveActivityProgress,
+  formatLiveActivityStateLabel,
   friendlyLiveCommandTarget,
   liveActivityElapsedMs,
 } from "./liveActivityPresentation";
@@ -85,5 +88,18 @@ describe("live activity presentation", () => {
     expect(formatLiveActivityMeta(activity, Date.parse("2026-07-26T14:03:00.000Z"))).toBe(
       "Completed",
     );
+  });
+
+  it("shares normalized state, elapsed, and progress labels across activity surfaces", () => {
+    const activity = runningActivity({
+      state: "running_tool",
+      progress: 0.42,
+    });
+
+    expect(formatLiveActivityStateLabel(activity.state)).toBe("Running tool");
+    expect(
+      formatLiveActivityElapsed(activity, Date.parse("2026-07-26T14:02:14.000Z")),
+    ).toBe("2m 14s");
+    expect(formatLiveActivityProgress(activity.progress ?? 0)).toBe("42%");
   });
 });

--- a/apps/web/src/lib/liveActivityPresentation.ts
+++ b/apps/web/src/lib/liveActivityPresentation.ts
@@ -2,7 +2,7 @@
 // Purpose: Provider-agnostic labels and live timing for normalized transcript activity.
 // Layer: Web presentation helper
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 
 import type { WorkLogEntry, WorkLogLiveActivity } from "../workLog";
 import { formatClockDuration } from "../session-logic";
@@ -10,6 +10,43 @@ import { deriveReadableCommandDisplay } from "./toolCallLabel";
 
 const NO_ACTIVITY_THRESHOLD_MS = 30_000;
 const LIVE_ACTIVITY_TICK_MS = 1_000;
+const liveActivityClockListeners = new Set<() => void>();
+let liveActivityClockIntervalId: number | null = null;
+let liveActivityClockNowMs = Date.now();
+
+function emitLiveActivityClockTick(): void {
+  liveActivityClockNowMs = Date.now();
+  for (const listener of liveActivityClockListeners) {
+    listener();
+  }
+}
+
+function subscribeLiveActivityClock(listener: () => void): () => void {
+  liveActivityClockListeners.add(listener);
+  if (liveActivityClockListeners.size === 1) {
+    liveActivityClockNowMs = Date.now();
+    liveActivityClockIntervalId = window.setInterval(
+      emitLiveActivityClockTick,
+      LIVE_ACTIVITY_TICK_MS,
+    );
+  }
+
+  return () => {
+    liveActivityClockListeners.delete(listener);
+    if (liveActivityClockListeners.size === 0 && liveActivityClockIntervalId !== null) {
+      window.clearInterval(liveActivityClockIntervalId);
+      liveActivityClockIntervalId = null;
+    }
+  };
+}
+
+function subscribeInactiveLiveActivityClock(): () => void {
+  return () => {};
+}
+
+function getLiveActivityClockSnapshot(): number {
+  return liveActivityClockNowMs;
+}
 
 export function isLiveActivityInProgress(activity: WorkLogLiveActivity): boolean {
   return (
@@ -22,17 +59,13 @@ export function isLiveActivityInProgress(activity: WorkLogLiveActivity): boolean
 }
 
 export function useLiveActivityNow(activity: WorkLogLiveActivity | undefined): number {
-  const [nowMs, setNowMs] = useState(() => Date.now());
   const inProgress = activity ? isLiveActivityInProgress(activity) : false;
-
-  useEffect(() => {
-    setNowMs(Date.now());
-    if (!inProgress) return;
-    const intervalId = window.setInterval(() => setNowMs(Date.now()), LIVE_ACTIVITY_TICK_MS);
-    return () => window.clearInterval(intervalId);
-  }, [inProgress]);
-
-  return nowMs;
+  const nowMs = useSyncExternalStore(
+    inProgress ? subscribeLiveActivityClock : subscribeInactiveLiveActivityClock,
+    getLiveActivityClockSnapshot,
+    getLiveActivityClockSnapshot,
+  );
+  return inProgress ? nowMs : Date.now();
 }
 
 function parseTimestamp(value: string): number | null {

--- a/apps/web/src/lib/liveActivityPresentation.ts
+++ b/apps/web/src/lib/liveActivityPresentation.ts
@@ -163,13 +163,14 @@ export function formatLiveActivityPrimary(input: {
   activity: WorkLogLiveActivity;
   entry: Pick<WorkLogEntry, "itemType" | "requestKind">;
   heading: string;
+  displayTarget?: string | undefined;
   rawCommand?: string | undefined;
 }): string {
   const subject = activitySubject(input.entry);
   const lead = activityStateLead(input.activity, subject);
   const target = input.rawCommand
     ? friendlyLiveCommandTarget(input.rawCommand)
-    : (input.activity.label || input.heading).trim();
+    : (input.displayTarget || input.activity.label || input.heading).trim();
   return target ? `${lead} · ${target}` : lead;
 }
 

--- a/apps/web/src/lib/liveActivityPresentation.ts
+++ b/apps/web/src/lib/liveActivityPresentation.ts
@@ -1,0 +1,189 @@
+// FILE: liveActivityPresentation.ts
+// Purpose: Provider-agnostic labels and live timing for normalized transcript activity.
+// Layer: Web presentation helper
+
+import { useEffect, useState } from "react";
+
+import type { WorkLogEntry, WorkLogLiveActivity } from "../workLog";
+import { formatClockDuration } from "../session-logic";
+import { deriveReadableCommandDisplay } from "./toolCallLabel";
+
+const NO_ACTIVITY_THRESHOLD_MS = 30_000;
+const LIVE_ACTIVITY_TICK_MS = 1_000;
+
+export function isLiveActivityInProgress(activity: WorkLogLiveActivity): boolean {
+  return (
+    activity.state === "starting" ||
+    activity.state === "thinking" ||
+    activity.state === "running_tool" ||
+    activity.state === "waiting" ||
+    activity.state === "streaming"
+  );
+}
+
+export function useLiveActivityNow(activity: WorkLogLiveActivity | undefined): number {
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  const inProgress = activity ? isLiveActivityInProgress(activity) : false;
+
+  useEffect(() => {
+    setNowMs(Date.now());
+    if (!inProgress) return;
+    const intervalId = window.setInterval(() => setNowMs(Date.now()), LIVE_ACTIVITY_TICK_MS);
+    return () => window.clearInterval(intervalId);
+  }, [inProgress]);
+
+  return nowMs;
+}
+
+function parseTimestamp(value: string): number | null {
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+export function liveActivityElapsedMs(
+  activity: WorkLogLiveActivity,
+  nowMs: number,
+): number | null {
+  const startedAtMs = parseTimestamp(activity.startedAt);
+  const lastActivityAtMs = parseTimestamp(activity.lastActivityAt);
+  const reportedElapsedMs =
+    activity.elapsedSeconds !== undefined && activity.elapsedSeconds >= 0
+      ? activity.elapsedSeconds * 1_000
+      : null;
+
+  if (isLiveActivityInProgress(activity)) {
+    if (reportedElapsedMs !== null && lastActivityAtMs !== null) {
+      return reportedElapsedMs + Math.max(0, nowMs - lastActivityAtMs);
+    }
+    return startedAtMs === null ? null : Math.max(0, nowMs - startedAtMs);
+  }
+
+  if (reportedElapsedMs !== null) return reportedElapsedMs;
+  if (startedAtMs === null || lastActivityAtMs === null || lastActivityAtMs < startedAtMs) {
+    return null;
+  }
+  return lastActivityAtMs - startedAtMs;
+}
+
+function firstCommandExecutable(rawCommand: string): string {
+  const trimmed = rawCommand.trim();
+  const match = /^(?:"([^"]+)"|'([^']+)'|(\S+))/u.exec(trimmed);
+  const executable = match?.[1] ?? match?.[2] ?? match?.[3] ?? "";
+  return executable.split(/[\\/]/u).at(-1)?.toLowerCase() ?? "";
+}
+
+export function friendlyLiveCommandTarget(rawCommand: string): string {
+  const executable = firstCommandExecutable(rawCommand);
+  if (
+    executable === "pwsh" ||
+    executable === "pwsh.exe" ||
+    executable === "powershell" ||
+    executable === "powershell.exe"
+  ) {
+    return "PowerShell";
+  }
+  if (executable === "cmd" || executable === "cmd.exe") {
+    return "Command Prompt";
+  }
+
+  const target = deriveReadableCommandDisplay(rawCommand, true).target.trim();
+  return target.length <= 72 ? target : `${target.slice(0, 69).trimEnd()}…`;
+}
+
+function activitySubject(entry: Pick<WorkLogEntry, "itemType" | "requestKind">): string {
+  if (entry.requestKind === "command" || entry.itemType === "command_execution") return "command";
+  if (entry.requestKind === "file-read") return "file read";
+  if (entry.requestKind === "file-change" || entry.itemType === "file_change") return "edit";
+  if (entry.itemType === "web_search") return "search";
+  if (entry.itemType === "collab_agent_tool_call") return "agent";
+  return "tool";
+}
+
+function activityStateLead(
+  activity: WorkLogLiveActivity,
+  subject: string,
+): string {
+  switch (activity.state) {
+    case "starting":
+      return `Starting ${subject}`;
+    case "thinking":
+      return "Thinking";
+    case "running_tool":
+      return `Running ${subject}`;
+    case "waiting":
+      return "Waiting";
+    case "streaming":
+      return "Streaming";
+    case "completed":
+      return `Completed ${subject}`;
+    case "failed":
+      return `Failed ${subject}`;
+    case "cancelled":
+      return `Cancelled ${subject}`;
+  }
+}
+
+export function formatLiveActivityPrimary(input: {
+  activity: WorkLogLiveActivity;
+  entry: Pick<WorkLogEntry, "itemType" | "requestKind">;
+  heading: string;
+  rawCommand?: string | undefined;
+}): string {
+  const subject = activitySubject(input.entry);
+  const lead = activityStateLead(input.activity, subject);
+  const target = input.rawCommand
+    ? friendlyLiveCommandTarget(input.rawCommand)
+    : (input.activity.label || input.heading).trim();
+  return target ? `${lead} · ${target}` : lead;
+}
+
+function formatActivityProgress(progress: number): string {
+  const percent = progress >= 0 && progress <= 1 ? progress * 100 : progress;
+  return `${Math.round(Math.min(100, Math.max(0, percent)))}%`;
+}
+
+export function formatLiveActivityMeta(
+  activity: WorkLogLiveActivity,
+  nowMs: number,
+): string | null {
+  const parts: string[] = [];
+  const elapsedMs = liveActivityElapsedMs(activity, nowMs);
+  const lastActivityAtMs = parseTimestamp(activity.lastActivityAt);
+
+  if (isLiveActivityInProgress(activity)) {
+    if (lastActivityAtMs !== null) {
+      const idleMs = Math.max(0, nowMs - lastActivityAtMs);
+      parts.push(
+        idleMs >= NO_ACTIVITY_THRESHOLD_MS
+          ? `No activity for ${formatClockDuration(idleMs)}`
+          : idleMs < 1_000
+            ? "Active now"
+            : `Active ${formatClockDuration(idleMs)} ago`,
+      );
+    }
+  } else {
+    switch (activity.state) {
+      case "completed":
+        parts.push("Completed");
+        break;
+      case "failed":
+        parts.push("Failed");
+        break;
+      case "cancelled":
+        parts.push("Cancelled");
+        break;
+      default:
+        parts.push(activityStateLead(activity, "tool"));
+        break;
+    }
+  }
+
+  if (elapsedMs !== null) {
+    parts.push(`${formatClockDuration(elapsedMs)} elapsed`);
+  }
+  if (activity.progress !== undefined) {
+    parts.push(formatActivityProgress(activity.progress));
+  }
+
+  return parts.length > 0 ? parts.join(" · ") : null;
+}

--- a/apps/web/src/lib/liveActivityPresentation.ts
+++ b/apps/web/src/lib/liveActivityPresentation.ts
@@ -68,7 +68,10 @@ export function useLiveActivityNow(activity: WorkLogLiveActivity | undefined): n
   return inProgress ? nowMs : Date.now();
 }
 
-function parseTimestamp(value: string): number | null {
+function parseTimestamp(value: string | undefined): number | null {
+  if (!value) {
+    return null;
+  }
   const timestamp = Date.parse(value);
   return Number.isNaN(timestamp) ? null : timestamp;
 }

--- a/apps/web/src/lib/liveActivityPresentation.ts
+++ b/apps/web/src/lib/liveActivityPresentation.ts
@@ -173,9 +173,40 @@ export function formatLiveActivityPrimary(input: {
   return target ? `${lead} · ${target}` : lead;
 }
 
-function formatActivityProgress(progress: number): string {
+export function formatLiveActivityProgress(progress: number): string {
   const percent = progress >= 0 && progress <= 1 ? progress * 100 : progress;
   return `${Math.round(Math.min(100, Math.max(0, percent)))}%`;
+}
+
+export function formatLiveActivityStateLabel(
+  state: WorkLogLiveActivity["state"],
+): string {
+  switch (state) {
+    case "starting":
+      return "Starting";
+    case "thinking":
+      return "Thinking";
+    case "running_tool":
+      return "Running tool";
+    case "waiting":
+      return "Waiting";
+    case "streaming":
+      return "Streaming";
+    case "completed":
+      return "Completed";
+    case "failed":
+      return "Failed";
+    case "cancelled":
+      return "Cancelled";
+  }
+}
+
+export function formatLiveActivityElapsed(
+  activity: WorkLogLiveActivity,
+  nowMs: number,
+): string | null {
+  const elapsedMs = liveActivityElapsedMs(activity, nowMs);
+  return elapsedMs === null ? null : formatClockDuration(elapsedMs);
 }
 
 export function formatLiveActivityMeta(
@@ -183,7 +214,7 @@ export function formatLiveActivityMeta(
   nowMs: number,
 ): string | null {
   const parts: string[] = [];
-  const elapsedMs = liveActivityElapsedMs(activity, nowMs);
+  const elapsed = formatLiveActivityElapsed(activity, nowMs);
   const lastActivityAtMs = parseTimestamp(activity.lastActivityAt);
 
   if (isLiveActivityInProgress(activity)) {
@@ -200,13 +231,13 @@ export function formatLiveActivityMeta(
   } else {
     switch (activity.state) {
       case "completed":
-        parts.push("Completed");
+        parts.push(formatLiveActivityStateLabel(activity.state));
         break;
       case "failed":
-        parts.push("Failed");
+        parts.push(formatLiveActivityStateLabel(activity.state));
         break;
       case "cancelled":
-        parts.push("Cancelled");
+        parts.push(formatLiveActivityStateLabel(activity.state));
         break;
       default:
         parts.push(activityStateLead(activity, "tool"));
@@ -214,11 +245,11 @@ export function formatLiveActivityMeta(
     }
   }
 
-  if (elapsedMs !== null) {
-    parts.push(`${formatClockDuration(elapsedMs)} elapsed`);
+  if (elapsed !== null) {
+    parts.push(`${elapsed} elapsed`);
   }
   if (activity.progress !== undefined) {
-    parts.push(formatActivityProgress(activity.progress));
+    parts.push(formatLiveActivityProgress(activity.progress));
   }
 
   return parts.length > 0 ? parts.join(" · ") : null;

--- a/apps/web/src/lib/toolCallLabel.test.ts
+++ b/apps/web/src/lib/toolCallLabel.test.ts
@@ -131,6 +131,12 @@ describe("deriveSynaraMcpToolTitle", () => {
         status: "failed",
       }),
     ).toBe("Synara couldn't create threads");
+    expect(
+      deriveSynaraMcpToolTitle({
+        toolName: "synara_create_thread",
+        status: "cancelled",
+      }),
+    ).toBe("Synara stopped creating a thread");
   });
 
   it("turns provider-specific create-thread identifiers into activity sentences", () => {

--- a/apps/web/src/lib/toolCallLabel.ts
+++ b/apps/web/src/lib/toolCallLabel.ts
@@ -358,7 +358,7 @@ function resolveSynaraMcpToolPresentation(
   return null;
 }
 
-export type SynaraMcpToolStatus = "running" | "completed" | "failed";
+export type SynaraMcpToolStatus = "running" | "completed" | "failed" | "cancelled";
 
 export interface SynaraMcpToolTitleInput {
   readonly toolName?: string | null | undefined;
@@ -386,6 +386,10 @@ export function deriveSynaraMcpToolTitle(input: SynaraMcpToolTitleInput): string
       return presentation.completed;
     case "failed":
       return presentation.failed;
+    case "cancelled":
+      return presentation.running.startsWith("Synara is ")
+        ? `Synara stopped ${presentation.running.slice("Synara is ".length)}`
+        : `Cancelled ${presentation.running}`;
   }
 }
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -36,6 +36,8 @@ export {
   type TimelineEntry,
   type WorkLogAutomation,
   type WorkLogEntry,
+  type WorkLogLiveActivity,
+  type WorkLogLiveActivityState,
   type WorkLogSubagent,
   type WorkLogSubagentAction,
   type WorkLogSynaraCreatedThread,

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -1298,6 +1298,69 @@ describe("deriveWorkLogEntries", () => {
     });
   });
 
+  it("does not correlate placeholder command starts through ambiguous adjacency", () => {
+    const entries = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "parallel-placeholder-a",
+          createdAt: "2026-02-23T00:00:01.000Z",
+          kind: "tool.started",
+          summary: "Ran command started",
+          payload: {
+            itemType: "command_execution",
+            title: "Ran command",
+            data: {
+              item: {
+                type: "commandExecution",
+                id: "parallel-call-a",
+                status: "inProgress",
+              },
+            },
+          },
+        }),
+        makeActivity({
+          id: "parallel-placeholder-b",
+          createdAt: "2026-02-23T00:00:02.000Z",
+          kind: "tool.started",
+          summary: "Ran command started",
+          payload: {
+            itemType: "command_execution",
+            title: "Ran command",
+            data: {
+              item: {
+                type: "commandExecution",
+                id: "parallel-call-b",
+                status: "inProgress",
+              },
+            },
+          },
+        }),
+        makeActivity({
+          id: "ambiguous-command-update",
+          createdAt: "2026-02-23T00:00:03.000Z",
+          kind: "tool.updated",
+          summary: "Ran command",
+          payload: {
+            itemType: "command_execution",
+            title: "Ran command",
+            data: {
+              item: {
+                type: "commandExecution",
+                command: "echo ambiguous",
+                status: "inProgress",
+              },
+            },
+          },
+        }),
+      ],
+      undefined,
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.command).toBe("echo ambiguous");
+    expect(entries[0]?.liveActivity?.startedAt).toBeUndefined();
+  });
+
   it("does not revive turnless historical activity during a later active turn", () => {
     const entries = deriveWorkLogEntries(
       [
@@ -1931,6 +1994,128 @@ describe("deriveWorkLogEntries", () => {
     expect(entries[0]?.toolStatus).toBe("completed");
   });
 
+  it("preserves cancellation when an owning turn aborts", () => {
+    const turnId = TurnId.makeUnsafe("turn-with-cancelled-synara-tool");
+    const entries = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "cancelled-synara-start",
+          createdAt: "2026-02-23T00:00:01.000Z",
+          kind: "tool.started",
+          summary: "Synara create thread",
+          turnId,
+          payload: {
+            itemType: "mcp_tool_call",
+            title: "Synara create thread",
+            data: {
+              toolCallId: "cancelled-synara-call",
+              toolName: "mcp__synara__synara_create_thread",
+            },
+          },
+        }),
+        makeActivity({
+          id: "owning-turn-aborted",
+          createdAt: "2026-02-23T00:00:04.000Z",
+          kind: "turn.aborted",
+          summary: "Turn aborted",
+          tone: "info",
+          turnId,
+        }),
+      ],
+      turnId,
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.liveActivity?.state).toBe("cancelled");
+    expect(entries[0]?.toolStatus).toBe("cancelled");
+  });
+
+  it("treats an explicitly interrupted tool completion as cancelled", () => {
+    const entries = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "interrupted-tool",
+          createdAt: "2026-02-23T00:00:01.000Z",
+          kind: "tool.completed",
+          summary: "Synara create thread",
+          payload: {
+            itemType: "mcp_tool_call",
+            title: "Synara create thread",
+            status: "interrupted",
+            data: {
+              toolCallId: "interrupted-synara-call",
+              toolName: "mcp__synara__synara_create_thread",
+            },
+          },
+        }),
+      ],
+      undefined,
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.liveActivity?.state).toBe("cancelled");
+    expect(entries[0]?.toolStatus).toBe("cancelled");
+  });
+
+  it("does not revive a terminal tool when late progress arrives", () => {
+    const entries = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "late-progress-start",
+          createdAt: "2026-02-23T00:00:01.000Z",
+          kind: "tool.started",
+          summary: "Deploy",
+          payload: {
+            itemType: "dynamic_tool_call",
+            title: "Deploy",
+            data: {
+              toolCallId: "late-progress-call",
+            },
+          },
+        }),
+        makeActivity({
+          id: "late-progress-complete",
+          createdAt: "2026-02-23T00:00:03.000Z",
+          kind: "tool.completed",
+          summary: "Deploy completed",
+          payload: {
+            itemType: "dynamic_tool_call",
+            title: "Deploy",
+            status: "completed",
+            data: {
+              toolCallId: "late-progress-call",
+            },
+          },
+        }),
+        makeActivity({
+          id: "late-progress-update",
+          createdAt: "2026-02-23T00:00:04.000Z",
+          kind: "tool.updated",
+          summary: "Deploy",
+          payload: {
+            itemType: "dynamic_tool_call",
+            title: "Deploy",
+            detail: "Late metadata",
+            data: {
+              toolCallId: "late-progress-call",
+              summary: "Late metadata",
+            },
+          },
+        }),
+      ],
+      undefined,
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.toolStatus).toBe("completed");
+    expect(entries[0]?.liveActivity).toMatchObject({
+      state: "completed",
+      lastActivityAt: "2026-02-23T00:00:03.000Z",
+      elapsedSeconds: 2,
+      detail: "Late metadata",
+    });
+  });
+
   it("settles orphaned activity from latest-turn state after a reconnect gap", () => {
     const turnId = TurnId.makeUnsafe("turn-with-reconnect-gap");
     const entries = deriveWorkLogEntries(
@@ -2084,10 +2269,12 @@ describe("deriveWorkLogEntries", () => {
       }),
     ];
 
-    expect(deriveWorkLogEntries(activities, undefined)[0]?.liveActivity).toMatchObject({
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.liveActivity).toMatchObject({
       state: "cancelled",
       progress: 0.01,
     });
+    expect(entry?.toolStatus).toBe("cancelled");
   });
 
   it("uses MCP tool names from preserved payload data", () => {

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -1224,6 +1224,123 @@ describe("deriveWorkLogEntries", () => {
     expect(deriveWorkLogEntries(activities, undefined)).toEqual([]);
   });
 
+  it("retains a filtered Codex command start timestamp after lifecycle correlation", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "codex-start-no-command",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Ran command started",
+        payload: {
+          itemType: "command_execution",
+          status: "inProgress",
+          title: "Ran command",
+          data: {
+            item: {
+              type: "commandExecution",
+              id: "call_command_arrives_later",
+              status: "inProgress",
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "codex-command-update",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.updated",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          status: "inProgress",
+          title: "Ran command",
+          data: {
+            item: {
+              type: "commandExecution",
+              id: "call_command_arrives_later",
+              command: "git status --short",
+              status: "inProgress",
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "codex-command-complete",
+        createdAt: "2026-02-23T00:00:06.000Z",
+        kind: "tool.completed",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          status: "completed",
+          title: "Ran command",
+          data: {
+            item: {
+              type: "commandExecution",
+              id: "call_command_arrives_later",
+              command: "git status --short",
+              status: "completed",
+            },
+          },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      command: "git status --short",
+      liveActivity: {
+        state: "completed",
+        startedAt: "2026-02-23T00:00:01.000Z",
+        lastActivityAt: "2026-02-23T00:00:06.000Z",
+        elapsedSeconds: 5,
+      },
+    });
+  });
+
+  it("does not revive turnless historical activity during a later active turn", () => {
+    const entries = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "historical-turnless-tool",
+          createdAt: "2026-02-23T00:00:01.000Z",
+          kind: "tool.started",
+          summary: "Historical tool",
+          payload: {
+            itemType: "dynamic_tool_call",
+            title: "Historical tool",
+            data: {
+              toolCallId: "historical-turnless-call",
+            },
+          },
+        }),
+        makeActivity({
+          id: "current-turnless-tool",
+          createdAt: "2026-02-23T00:00:11.000Z",
+          kind: "tool.started",
+          summary: "Current tool",
+          payload: {
+            itemType: "dynamic_tool_call",
+            title: "Current tool",
+            data: {
+              toolCallId: "current-turnless-call",
+            },
+          },
+        }),
+      ],
+      undefined,
+      {
+        activeTurnId: TurnId.makeUnsafe("later-turn"),
+        activeTurnStartedAt: "2026-02-23T00:00:10.000Z",
+        latestTurnState: "running",
+      },
+    );
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0]?.liveActivity?.state).toBe("cancelled");
+    expect(entries[1]?.liveActivity?.state).toBe("running_tool");
+  });
+
   it("reads Codex commandActions from the raw data envelope", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -1606,6 +1606,69 @@ describe("deriveWorkLogEntries", () => {
     });
   });
 
+  it("merges provider tool lifecycle updates into one universal live activity", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "activity-start",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Bash started",
+        payload: {
+          itemType: "command_execution",
+          title: "Bash",
+          data: {
+            toolCallId: "install-dependencies",
+            command: "bun install",
+          },
+        },
+      }),
+      makeActivity({
+        id: "activity-progress",
+        createdAt: "2026-02-23T00:02:15.000Z",
+        kind: "tool.updated",
+        summary: "Bash",
+        payload: {
+          itemType: "command_execution",
+          title: "Bash",
+          detail: "Resolving packages",
+          data: {
+            toolCallId: "install-dependencies",
+            summary: "Resolving packages",
+            elapsedSeconds: 134,
+            progress: 0.42,
+          },
+        },
+      }),
+      makeActivity({
+        id: "activity-complete",
+        createdAt: "2026-02-23T00:02:16.000Z",
+        kind: "tool.completed",
+        summary: "Bash completed",
+        payload: {
+          itemType: "command_execution",
+          title: "Bash",
+          status: "completed",
+          data: {
+            toolCallId: "install-dependencies",
+          },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.liveActivity).toEqual({
+      state: "completed",
+      label: "Bash",
+      startedAt: "2026-02-23T00:00:01.000Z",
+      lastActivityAt: "2026-02-23T00:02:16.000Z",
+      detail: "Resolving packages",
+      progress: 0.42,
+      elapsedSeconds: 135,
+    });
+  });
+
   it("uses MCP tool names from preserved payload data", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -1928,6 +1928,7 @@ describe("deriveWorkLogEntries", () => {
       lastActivityAt: "2026-02-23T00:00:06.000Z",
       elapsedSeconds: 5,
     });
+    expect(entries[0]?.toolStatus).toBe("completed");
   });
 
   it("settles orphaned activity from latest-turn state after a reconnect gap", () => {
@@ -1963,6 +1964,7 @@ describe("deriveWorkLogEntries", () => {
       lastActivityAt: "2026-02-23T00:00:04.000Z",
       elapsedSeconds: 3,
     });
+    expect(entries[0]?.toolStatus).toBe("failed");
   });
 
   it("advances retained elapsed time across metadata-only updates", () => {

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -1669,6 +1669,121 @@ describe("deriveWorkLogEntries", () => {
     });
   });
 
+  it("correlates Claude progress events by toolUseId with the surrounding lifecycle", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "claude-tool-start",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Bash started",
+        payload: {
+          itemType: "command_execution",
+          title: "Bash",
+          data: {
+            toolCallId: "claude-bash-call",
+            command: "sleep 1",
+          },
+        },
+      }),
+      makeActivity({
+        id: "claude-tool-progress",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.updated",
+        summary: "Bash",
+        payload: {
+          itemType: "mcp_tool_call",
+          title: "Bash",
+          detail: "Still running",
+          data: {
+            toolUseId: "claude-bash-call",
+            toolName: "Bash",
+          },
+        },
+      }),
+      makeActivity({
+        id: "claude-tool-complete",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        kind: "tool.completed",
+        summary: "Bash completed",
+        payload: {
+          itemType: "command_execution",
+          title: "Bash",
+          status: "completed",
+          data: {
+            toolCallId: "claude-bash-call",
+          },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.liveActivity).toMatchObject({
+      state: "completed",
+      startedAt: "2026-02-23T00:00:01.000Z",
+      lastActivityAt: "2026-02-23T00:00:03.000Z",
+      detail: "Still running",
+      elapsedSeconds: 2,
+    });
+  });
+
+  it("preserves terminal failure detail in live activity metadata", () => {
+    const entries = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "failed-tool",
+          createdAt: "2026-02-23T00:00:03.000Z",
+          kind: "tool.completed",
+          summary: "Deploy failed",
+          payload: {
+            itemType: "dynamic_tool_call",
+            title: "Deploy",
+            status: "failed",
+            detail: "Permission denied",
+            data: {
+              toolCallId: "failed-deploy",
+            },
+          },
+        }),
+      ],
+      undefined,
+    );
+
+    expect(entries[0]?.liveActivity).toMatchObject({
+      state: "failed",
+      detail: "Permission denied",
+    });
+  });
+
+  it("leaves completion-only tool duration unknown without start evidence", () => {
+    const entries = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "completion-only-tool",
+          createdAt: "2026-02-23T00:00:03.000Z",
+          kind: "tool.completed",
+          summary: "Deploy completed",
+          payload: {
+            itemType: "dynamic_tool_call",
+            title: "Deploy",
+            status: "completed",
+            data: {
+              toolCallId: "completion-only-deploy",
+            },
+          },
+        }),
+      ],
+      undefined,
+    );
+
+    expect(entries[0]?.liveActivity).toEqual({
+      state: "completed",
+      label: "Deploy",
+      lastActivityAt: "2026-02-23T00:00:03.000Z",
+    });
+  });
+
   it("normalizes canonical declined status and percentage fields", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -1669,6 +1669,31 @@ describe("deriveWorkLogEntries", () => {
     });
   });
 
+  it("normalizes canonical declined status and percentage fields", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "activity-declined",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.completed",
+        summary: "Tool call declined",
+        payload: {
+          itemType: "dynamic_tool_call",
+          status: "declined",
+          title: "Deploy",
+          data: {
+            toolCallId: "declined-deploy",
+            percent: 1,
+          },
+        },
+      }),
+    ];
+
+    expect(deriveWorkLogEntries(activities, undefined)[0]?.liveActivity).toMatchObject({
+      state: "cancelled",
+      progress: 0.01,
+    });
+  });
+
   it("uses MCP tool names from preserved payload data", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -1728,6 +1728,168 @@ describe("deriveWorkLogEntries", () => {
     });
   });
 
+  it("preserves command semantics while a Claude progress placeholder is live", () => {
+    const entries = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "claude-command-start",
+          createdAt: "2026-02-23T00:00:01.000Z",
+          kind: "tool.started",
+          summary: "Bash started",
+          payload: {
+            itemType: "command_execution",
+            title: "Bash",
+            data: {
+              toolCallId: "claude-live-command",
+              command: "sleep 5",
+            },
+          },
+        }),
+        makeActivity({
+          id: "claude-command-progress",
+          createdAt: "2026-02-23T00:00:02.000Z",
+          kind: "tool.updated",
+          summary: "Bash",
+          payload: {
+            itemType: "mcp_tool_call",
+            title: "Bash",
+            data: {
+              toolUseId: "claude-live-command",
+              toolName: "Bash",
+            },
+          },
+        }),
+      ],
+      undefined,
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      itemType: "command_execution",
+      command: "sleep 5",
+      liveActivity: {
+        state: "running_tool",
+      },
+    });
+  });
+
+  it("settles orphaned tool activity when its owning turn completes", () => {
+    const turnId = TurnId.makeUnsafe("turn-with-orphaned-tool");
+    const entries = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "orphaned-command-start",
+          createdAt: "2026-02-23T00:00:01.000Z",
+          kind: "tool.started",
+          summary: "Bash started",
+          turnId,
+          payload: {
+            itemType: "command_execution",
+            title: "Bash",
+            data: {
+              toolCallId: "orphaned-command",
+              command: "sleep 5",
+            },
+          },
+        }),
+        makeActivity({
+          id: "owning-turn-complete",
+          createdAt: "2026-02-23T00:00:06.000Z",
+          kind: "turn.completed",
+          summary: "Turn completed",
+          tone: "info",
+          turnId,
+        }),
+      ],
+      turnId,
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.liveActivity).toMatchObject({
+      state: "completed",
+      startedAt: "2026-02-23T00:00:01.000Z",
+      lastActivityAt: "2026-02-23T00:00:06.000Z",
+      elapsedSeconds: 5,
+    });
+  });
+
+  it("settles orphaned activity from latest-turn state after a reconnect gap", () => {
+    const turnId = TurnId.makeUnsafe("turn-with-reconnect-gap");
+    const entries = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "reconnected-command-start",
+          createdAt: "2026-02-23T00:00:01.000Z",
+          kind: "tool.started",
+          summary: "Bash started",
+          turnId,
+          payload: {
+            itemType: "command_execution",
+            title: "Bash",
+            data: {
+              toolCallId: "reconnected-command",
+              command: "sleep 5",
+            },
+          },
+        }),
+      ],
+      turnId,
+      {
+        activeTurnId: null,
+        latestTurnState: "error",
+        latestTurnCompletedAt: "2026-02-23T00:00:04.000Z",
+      },
+    );
+
+    expect(entries[0]?.liveActivity).toMatchObject({
+      state: "failed",
+      lastActivityAt: "2026-02-23T00:00:04.000Z",
+      elapsedSeconds: 3,
+    });
+  });
+
+  it("advances retained elapsed time across metadata-only updates", () => {
+    const entries = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "elapsed-progress",
+          createdAt: "2026-02-23T00:00:10.000Z",
+          kind: "tool.updated",
+          summary: "Deploy",
+          payload: {
+            itemType: "dynamic_tool_call",
+            title: "Deploy",
+            data: {
+              toolCallId: "deploy-with-sparse-elapsed",
+              elapsedSeconds: 10,
+            },
+          },
+        }),
+        makeActivity({
+          id: "metadata-only-progress",
+          createdAt: "2026-02-23T00:00:15.000Z",
+          kind: "tool.updated",
+          summary: "Deploy",
+          payload: {
+            itemType: "dynamic_tool_call",
+            title: "Deploy",
+            data: {
+              toolCallId: "deploy-with-sparse-elapsed",
+              summary: "Still working",
+            },
+          },
+        }),
+      ],
+      undefined,
+    );
+
+    expect(entries[0]?.liveActivity).toMatchObject({
+      state: "running_tool",
+      lastActivityAt: "2026-02-23T00:00:15.000Z",
+      elapsedSeconds: 15,
+    });
+  });
+
   it("preserves terminal failure detail in live activity metadata", () => {
     const entries = deriveWorkLogEntries(
       [

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -601,7 +601,9 @@ function deriveWorkLogLiveActivity(
   const state: WorkLogLiveActivityState = isFailedToolLifecyclePayload(payload)
     ? "failed"
     : normalizedStatus &&
-        ["cancelled", "canceled", "killed", "stopped", "aborted"].includes(normalizedStatus)
+        ["cancelled", "canceled", "declined", "killed", "stopped", "aborted"].includes(
+          normalizedStatus,
+        )
       ? "cancelled"
       : activity.kind === "tool.completed" ||
           (normalizedStatus &&
@@ -611,7 +613,7 @@ function deriveWorkLogLiveActivity(
   const detail =
     asTrimmedString(data?.summary) ??
     (activity.kind === "tool.updated" ? asTrimmedString(payload?.detail) : null);
-  const progress = firstFiniteNumber(payload?.progress, data?.progress, data?.percent);
+  const progress = deriveWorkLogLiveActivityProgress(payload, data);
   const elapsedSeconds = firstFiniteNumber(payload?.elapsedSeconds, data?.elapsedSeconds);
 
   return {
@@ -623,6 +625,19 @@ function deriveWorkLogLiveActivity(
     ...(progress !== undefined ? { progress } : {}),
     ...(elapsedSeconds !== undefined ? { elapsedSeconds } : {}),
   };
+}
+
+function deriveWorkLogLiveActivityProgress(
+  payload: Record<string, unknown> | null,
+  data: Record<string, unknown> | null,
+): number | undefined {
+  const progress = firstFiniteNumber(payload?.progress, data?.progress);
+  if (progress !== undefined) {
+    return progress;
+  }
+
+  const percent = firstFiniteNumber(data?.percent);
+  return percent === undefined ? undefined : percent / 100;
 }
 
 function isFailedToolLifecyclePayload(payload: Record<string, unknown> | null): boolean {

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -54,6 +54,7 @@ export interface WorkLogEntry {
   toolName?: string;
   toolCallId?: string;
   toolStatus?: SynaraMcpToolStatus;
+  liveActivity?: WorkLogLiveActivity;
   toolDetails?: WorkLogToolDetails;
   itemType?: ToolLifecycleItemType;
   requestKind?: WorkLogRequestKind;
@@ -68,6 +69,26 @@ export interface WorkLogEntry {
   // Provider-native event type carried through the activity payload (e.g.
   // "background_tasks_changed") so the timeline can pick a specific icon.
   nativeEventType?: string;
+}
+
+export type WorkLogLiveActivityState =
+  | "starting"
+  | "thinking"
+  | "running_tool"
+  | "waiting"
+  | "streaming"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export interface WorkLogLiveActivity {
+  state: WorkLogLiveActivityState;
+  label: string;
+  startedAt: string;
+  lastActivityAt: string;
+  detail?: string;
+  progress?: number;
+  elapsedSeconds?: number;
 }
 
 // Created-automation rows render as a dedicated card (icon + name + cadence + Open)
@@ -516,6 +537,10 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   if (readableTitle) {
     entry.toolTitle = readableTitle;
   }
+  const liveActivity = deriveWorkLogLiveActivity(activity, payload, entry);
+  if (liveActivity) {
+    entry.liveActivity = liveActivity;
+  }
   if (
     entry.detail &&
     normalizeToolTextForComparison(entry.detail) ===
@@ -555,6 +580,49 @@ function deriveToolLifecycleStatus(
   if (!isRenderableToolLifecycleActivity(activityKind)) return undefined;
   if (isFailedToolLifecyclePayload(payload)) return "failed";
   return activityKind === "tool.completed" ? "completed" : "running";
+}
+
+function deriveWorkLogLiveActivity(
+  activity: OrchestrationThreadActivity,
+  payload: Record<string, unknown> | null,
+  entry: WorkLogEntry,
+): WorkLogLiveActivity | undefined {
+  if (!isRenderableToolLifecycleActivity(activity.kind)) {
+    return undefined;
+  }
+
+  const data = asRecord(payload?.data);
+  const stateRecord = asRecord(data?.state);
+  const rawOutput = asRecord(data?.rawOutput);
+  const rawStatus = [payload?.status, data?.status, stateRecord?.status, rawOutput?.status].find(
+    (value): value is string => typeof value === "string" && value.trim().length > 0,
+  );
+  const normalizedStatus = rawStatus?.trim().toLowerCase();
+  const state: WorkLogLiveActivityState = isFailedToolLifecyclePayload(payload)
+    ? "failed"
+    : normalizedStatus &&
+        ["cancelled", "canceled", "killed", "stopped", "aborted"].includes(normalizedStatus)
+      ? "cancelled"
+      : activity.kind === "tool.completed" ||
+          (normalizedStatus &&
+            ["completed", "complete", "success", "succeeded"].includes(normalizedStatus))
+        ? "completed"
+        : "running_tool";
+  const detail =
+    asTrimmedString(data?.summary) ??
+    (activity.kind === "tool.updated" ? asTrimmedString(payload?.detail) : null);
+  const progress = firstFiniteNumber(payload?.progress, data?.progress, data?.percent);
+  const elapsedSeconds = firstFiniteNumber(payload?.elapsedSeconds, data?.elapsedSeconds);
+
+  return {
+    state,
+    label: entry.toolTitle ?? entry.label,
+    startedAt: activity.createdAt,
+    lastActivityAt: activity.createdAt,
+    ...(detail ? { detail } : {}),
+    ...(progress !== undefined ? { progress } : {}),
+    ...(elapsedSeconds !== undefined ? { elapsedSeconds } : {}),
+  };
 }
 
 function isFailedToolLifecyclePayload(payload: Record<string, unknown> | null): boolean {
@@ -841,6 +909,7 @@ function mergeDerivedWorkLogEntries(
   const toolName = next.toolName ?? previous.toolName;
   const toolCallId = next.toolCallId ?? previous.toolCallId;
   const toolStatus = next.toolStatus ?? previous.toolStatus;
+  const liveActivity = mergeWorkLogLiveActivity(previous.liveActivity, next.liveActivity);
   const toolDetails = mergeWorkLogToolDetails(previous.toolDetails, next.toolDetails);
   const turnId = next.turnId ?? previous.turnId;
   return {
@@ -862,7 +931,42 @@ function mergeDerivedWorkLogEntries(
     ...(toolName ? { toolName } : {}),
     ...(toolCallId ? { toolCallId } : {}),
     ...(toolStatus ? { toolStatus } : {}),
+    ...(liveActivity ? { liveActivity } : {}),
     ...(toolDetails ? { toolDetails } : {}),
+  };
+}
+
+function mergeWorkLogLiveActivity(
+  previous: WorkLogLiveActivity | undefined,
+  next: WorkLogLiveActivity | undefined,
+): WorkLogLiveActivity | undefined {
+  if (!previous) return next;
+  if (!next) return previous;
+  const lifecycleElapsedSeconds =
+    (Date.parse(next.lastActivityAt) - Date.parse(previous.startedAt)) / 1_000;
+  const terminalElapsedSeconds =
+    next.state === "completed" || next.state === "failed" || next.state === "cancelled"
+      ? Math.max(
+          0,
+          Number.isFinite(lifecycleElapsedSeconds) ? lifecycleElapsedSeconds : 0,
+          next.elapsedSeconds ?? 0,
+          previous.elapsedSeconds ?? 0,
+        )
+      : undefined;
+  return {
+    state: next.state,
+    label: next.label || previous.label,
+    startedAt: previous.startedAt,
+    lastActivityAt: next.lastActivityAt,
+    ...(next.detail || previous.detail ? { detail: next.detail ?? previous.detail } : {}),
+    ...(next.progress !== undefined || previous.progress !== undefined
+      ? { progress: next.progress ?? previous.progress }
+      : {}),
+    ...(terminalElapsedSeconds !== undefined
+      ? { elapsedSeconds: terminalElapsedSeconds }
+      : next.elapsedSeconds !== undefined || previous.elapsedSeconds !== undefined
+        ? { elapsedSeconds: next.elapsedSeconds ?? previous.elapsedSeconds }
+        : {}),
   };
 }
 
@@ -963,6 +1067,12 @@ function asTrimmedString(value: unknown): string | null {
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+function firstFiniteNumber(...values: unknown[]): number | undefined {
+  return values.find(
+    (value): value is number => typeof value === "number" && Number.isFinite(value),
+  );
 }
 
 function normalizeCollabIdentifier(value: string | null | undefined): string | null {

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -1,6 +1,7 @@
 import {
   isToolLifecycleItemType,
   STUDIO_OUTPUTS_ACTIVITY_KIND,
+  type OrchestrationLatestTurnState,
   type OrchestrationThreadActivity,
   type ProviderKind,
   type ToolLifecycleItemType,
@@ -242,6 +243,9 @@ export function deriveWorkLogEntries(
   latestTurnId: TurnId | undefined,
   options: {
     visibleTurnIds?: ReadonlySet<TurnId | string>;
+    activeTurnId?: TurnId | null;
+    latestTurnState?: OrchestrationLatestTurnState | null;
+    latestTurnCompletedAt?: string | null;
   } = {},
 ): WorkLogEntry[] {
   const visibleTurnIds = options.visibleTurnIds;
@@ -273,7 +277,12 @@ export function deriveWorkLogEntries(
   // GitHub icon, user-input rows -> question / submit glyphs). Stripping
   // `toolName` here previously made those icon checks dead code, leaving the
   // generic wrench.
-  return collapseDerivedWorkLogEntries(entries).map(
+  return reconcileSettledLiveActivities(
+    collapseDerivedWorkLogEntries(entries),
+    ordered,
+    latestTurnId,
+    options,
+  ).map(
     ({
       collapseCommand: _collapseCommand,
       collapseKey: _collapseKey,
@@ -919,8 +928,17 @@ function mergeDerivedWorkLogEntries(
   const rawCommand = next.rawCommand ?? previous.rawCommand;
   const preview = next.preview ?? previous.preview;
   const toolTitle = mergeWorkLogToolTitle(previous, next);
-  const itemType = next.itemType ?? previous.itemType;
-  const requestKind = next.requestKind ?? previous.requestKind;
+  const preservePreviousToolSemantics =
+    next.activityKind === "tool.updated" &&
+    next.itemType === "mcp_tool_call" &&
+    previous.itemType !== undefined &&
+    previous.itemType !== "mcp_tool_call";
+  const itemType = preservePreviousToolSemantics
+    ? previous.itemType
+    : (next.itemType ?? previous.itemType);
+  const requestKind = preservePreviousToolSemantics
+    ? previous.requestKind
+    : (next.requestKind ?? previous.requestKind);
   const subagents = next.subagents ?? previous.subagents;
   const subagentAction = next.subagentAction ?? previous.subagentAction;
   const synaraThreadCreation = next.synaraThreadCreation ?? previous.synaraThreadCreation;
@@ -965,10 +983,18 @@ function mergeWorkLogLiveActivity(
   const lifecycleElapsedSeconds = startedAt
     ? (Date.parse(next.lastActivityAt) - Date.parse(startedAt)) / 1_000
     : undefined;
+  const activityDeltaSeconds =
+    (Date.parse(next.lastActivityAt) - Date.parse(previous.lastActivityAt)) / 1_000;
+  const carriedElapsedSeconds =
+    next.elapsedSeconds === undefined &&
+    previous.elapsedSeconds !== undefined &&
+    Number.isFinite(activityDeltaSeconds)
+      ? previous.elapsedSeconds + Math.max(0, activityDeltaSeconds)
+      : previous.elapsedSeconds;
   const elapsedCandidates = [
     lifecycleElapsedSeconds,
     next.elapsedSeconds,
-    previous.elapsedSeconds,
+    carriedElapsedSeconds,
   ].filter((value): value is number => value !== undefined && Number.isFinite(value));
   const terminalElapsedSeconds =
     next.state === "completed" || next.state === "failed" || next.state === "cancelled"
@@ -987,10 +1013,144 @@ function mergeWorkLogLiveActivity(
       : {}),
     ...(terminalElapsedSeconds !== undefined
       ? { elapsedSeconds: terminalElapsedSeconds }
-      : next.elapsedSeconds !== undefined || previous.elapsedSeconds !== undefined
-        ? { elapsedSeconds: next.elapsedSeconds ?? previous.elapsedSeconds }
+      : next.elapsedSeconds !== undefined || carriedElapsedSeconds !== undefined
+        ? { elapsedSeconds: next.elapsedSeconds ?? carriedElapsedSeconds }
         : {}),
   };
+}
+
+function reconcileSettledLiveActivities(
+  entries: ReadonlyArray<DerivedWorkLogEntry>,
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+  latestTurnId: TurnId | undefined,
+  options: {
+    activeTurnId?: TurnId | null;
+    latestTurnState?: OrchestrationLatestTurnState | null;
+    latestTurnCompletedAt?: string | null;
+  },
+): DerivedWorkLogEntry[] {
+  const terminalByTurnId = new Map<
+    TurnId | string,
+    {
+      state: Extract<WorkLogLiveActivityState, "completed" | "failed" | "cancelled">;
+      settledAt: string;
+    }
+  >();
+  for (const activity of activities) {
+    if (activity.turnId === null) {
+      continue;
+    }
+    if (activity.kind === "turn.aborted") {
+      terminalByTurnId.set(activity.turnId, {
+        state: "cancelled",
+        settledAt: activity.createdAt,
+      });
+    } else if (activity.kind === "turn.completed") {
+      terminalByTurnId.set(activity.turnId, {
+        state: activity.tone === "error" ? "failed" : "completed",
+        settledAt: activity.createdAt,
+      });
+    }
+  }
+
+  const latestTerminalState =
+    options.latestTurnState === "completed"
+      ? "completed"
+      : options.latestTurnState === "error"
+        ? "failed"
+        : options.latestTurnState === "interrupted"
+          ? "cancelled"
+          : null;
+  if (
+    latestTurnId &&
+    latestTerminalState &&
+    options.latestTurnCompletedAt &&
+    !terminalByTurnId.has(latestTurnId)
+  ) {
+    terminalByTurnId.set(latestTurnId, {
+      state: latestTerminalState,
+      settledAt: options.latestTurnCompletedAt,
+    });
+  }
+
+  const hasActiveTurnContext = options.activeTurnId !== undefined;
+  return entries.map((entry) => {
+    const liveActivity = entry.liveActivity;
+    if (!liveActivity || !isInProgressLiveActivityState(liveActivity.state)) {
+      return entry;
+    }
+
+    const terminal = entry.turnId ? terminalByTurnId.get(entry.turnId) : undefined;
+    if (terminal) {
+      return {
+        ...entry,
+        liveActivity: settleWorkLogLiveActivity(
+          liveActivity,
+          terminal.state,
+          terminal.settledAt,
+        ),
+      };
+    }
+
+    if (!hasActiveTurnContext) {
+      return entry;
+    }
+    if (
+      options.activeTurnId !== null &&
+      (entry.turnId === undefined ||
+        entry.turnId === null ||
+        entry.turnId === options.activeTurnId)
+    ) {
+      return entry;
+    }
+
+    return {
+      ...entry,
+      liveActivity: settleWorkLogLiveActivity(
+        liveActivity,
+        latestTurnId && entry.turnId === latestTurnId && latestTerminalState
+          ? latestTerminalState
+          : "cancelled",
+        latestTurnId &&
+          entry.turnId === latestTurnId &&
+          options.latestTurnCompletedAt
+          ? options.latestTurnCompletedAt
+          : liveActivity.lastActivityAt,
+      ),
+    };
+  });
+}
+
+function isInProgressLiveActivityState(state: WorkLogLiveActivityState): boolean {
+  return (
+    state === "starting" ||
+    state === "thinking" ||
+    state === "running_tool" ||
+    state === "waiting" ||
+    state === "streaming"
+  );
+}
+
+function settleWorkLogLiveActivity(
+  activity: WorkLogLiveActivity,
+  state: Extract<WorkLogLiveActivityState, "completed" | "failed" | "cancelled">,
+  settledAt: string,
+): WorkLogLiveActivity {
+  const activityAtMs = Date.parse(activity.lastActivityAt);
+  const settledAtMs = Date.parse(settledAt);
+  const lastActivityAt =
+    Number.isFinite(activityAtMs) &&
+    Number.isFinite(settledAtMs) &&
+    settledAtMs >= activityAtMs
+      ? settledAt
+      : activity.lastActivityAt;
+  return (
+    mergeWorkLogLiveActivity(activity, {
+      state,
+      label: activity.label,
+      lastActivityAt,
+    }) ?? activity
+  );
 }
 
 function mergeWorkLogToolTitle(

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -150,6 +150,7 @@ interface DerivedWorkLogEntry extends WorkLogEntry {
   toolName?: string;
   runtimeWarningRepeatCount?: number;
   runtimeWarningMessage?: string;
+  suppressStandaloneCommandStart?: boolean;
 }
 
 export function isFileChangeWorkLogEntry(
@@ -244,6 +245,7 @@ export function deriveWorkLogEntries(
   options: {
     visibleTurnIds?: ReadonlySet<TurnId | string>;
     activeTurnId?: TurnId | null;
+    activeTurnStartedAt?: string | null;
     latestTurnState?: OrchestrationLatestTurnState | null;
     latestTurnCompletedAt?: string | null;
   } = {},
@@ -268,7 +270,6 @@ export function deriveWorkLogEntries(
     // Server-side Studio output attribution is environment-panel data, not transcript work.
     .filter((activity) => activity.kind !== STUDIO_OUTPUTS_ACTIVITY_KIND)
     .filter((activity) => !isPlanBoundaryToolActivity(activity))
-    .filter((activity) => !isUninformativeCommandStartActivity(activity))
     .map(toDerivedWorkLogEntry);
   // Strip the derivation-only helpers that exist solely on DerivedWorkLogEntry.
   // `toolName` and `activityKind` are intentionally kept: they are public
@@ -282,15 +283,18 @@ export function deriveWorkLogEntries(
     ordered,
     latestTurnId,
     options,
-  ).map(
-    ({
-      collapseCommand: _collapseCommand,
-      collapseKey: _collapseKey,
-      runtimeWarningMessage: _runtimeWarningMessage,
-      runtimeWarningRepeatCount: _runtimeWarningRepeatCount,
-      ...entry
-    }) => entry,
-  );
+  )
+    .filter((entry) => !isUninformativeCommandStartEntry(entry))
+    .map(
+      ({
+        collapseCommand: _collapseCommand,
+        collapseKey: _collapseKey,
+        runtimeWarningMessage: _runtimeWarningMessage,
+        runtimeWarningRepeatCount: _runtimeWarningRepeatCount,
+        suppressStandaloneCommandStart: _suppressStandaloneCommandStart,
+        ...entry
+      }) => entry,
+    );
 }
 
 function shouldKeepActivityForWorkLog(
@@ -327,20 +331,11 @@ function isQuietTurnLifecycleActivity(activity: OrchestrationThreadActivity): bo
   return activity.tone !== "error";
 }
 
-function isUninformativeCommandStartActivity(activity: OrchestrationThreadActivity): boolean {
-  if (activity.kind !== "tool.started") {
-    return false;
-  }
-  const payload =
-    activity.payload && typeof activity.payload === "object"
-      ? (activity.payload as Record<string, unknown>)
-      : null;
-  if (extractWorkLogItemType(payload) !== "command_execution") {
-    return false;
-  }
-  const commandAction = extractPrimaryCommandAction(payload);
-  const commandPreview = extractToolCommand(payload, commandAction);
-  return !commandAction && !commandPreview.command;
+function isUninformativeCommandStartEntry(entry: DerivedWorkLogEntry): boolean {
+  return (
+    entry.activityKind === "tool.started" &&
+    entry.suppressStandaloneCommandStart === true
+  );
 }
 
 function isPlanBoundaryToolActivity(activity: OrchestrationThreadActivity): boolean {
@@ -505,6 +500,14 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   }
   if (requestKind) {
     entry.requestKind = requestKind;
+  }
+  if (
+    activity.kind === "tool.started" &&
+    itemType === "command_execution" &&
+    !commandAction &&
+    !commandPreview.command
+  ) {
+    entry.suppressStandaloneCommandStart = true;
   }
   const subagents = extractCollabSubagents(payload);
   if (subagents.length > 0) {
@@ -1025,6 +1028,7 @@ function reconcileSettledLiveActivities(
   latestTurnId: TurnId | undefined,
   options: {
     activeTurnId?: TurnId | null;
+    activeTurnStartedAt?: string | null;
     latestTurnState?: OrchestrationLatestTurnState | null;
     latestTurnCompletedAt?: string | null;
   },
@@ -1074,6 +1078,9 @@ function reconcileSettledLiveActivities(
   }
 
   const hasActiveTurnContext = options.activeTurnId !== undefined;
+  const activeTurnStartedAtMs = options.activeTurnStartedAt
+    ? Date.parse(options.activeTurnStartedAt)
+    : Number.NaN;
   return entries.map((entry) => {
     const liveActivity = entry.liveActivity;
     if (!liveActivity || !isInProgressLiveActivityState(liveActivity.state)) {
@@ -1095,11 +1102,15 @@ function reconcileSettledLiveActivities(
     if (!hasActiveTurnContext) {
       return entry;
     }
+    const entryLastActivityAtMs = Date.parse(liveActivity.lastActivityAt);
+    const turnlessEntryBelongsToActiveTurn =
+      (entry.turnId === undefined || entry.turnId === null) &&
+      Number.isFinite(activeTurnStartedAtMs) &&
+      Number.isFinite(entryLastActivityAtMs) &&
+      entryLastActivityAtMs >= activeTurnStartedAtMs;
     if (
       options.activeTurnId !== null &&
-      (entry.turnId === undefined ||
-        entry.turnId === null ||
-        entry.turnId === options.activeTurnId)
+      (entry.turnId === options.activeTurnId || turnlessEntryBelongsToActiveTurn)
     ) {
       return entry;
     }

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -84,7 +84,7 @@ export type WorkLogLiveActivityState =
 export interface WorkLogLiveActivity {
   state: WorkLogLiveActivityState;
   label: string;
-  startedAt: string;
+  startedAt?: string;
   lastActivityAt: string;
   detail?: string;
   progress?: number;
@@ -612,15 +612,19 @@ function deriveWorkLogLiveActivity(
         : "running_tool";
   const detail =
     asTrimmedString(data?.summary) ??
-    (activity.kind === "tool.updated" ? asTrimmedString(payload?.detail) : null);
+    (activity.kind === "tool.updated"
+      ? asTrimmedString(payload?.detail)
+      : state === "failed" || state === "cancelled"
+        ? (entry.detail ?? null)
+        : null);
   const progress = deriveWorkLogLiveActivityProgress(payload, data);
   const elapsedSeconds = firstFiniteNumber(payload?.elapsedSeconds, data?.elapsedSeconds);
 
   return {
     state,
     label: entry.toolTitle ?? entry.label,
-    startedAt: activity.createdAt,
     lastActivityAt: activity.createdAt,
+    ...(activity.kind === "tool.started" ? { startedAt: activity.createdAt } : {}),
     ...(detail ? { detail } : {}),
     ...(progress !== undefined ? { progress } : {}),
     ...(elapsedSeconds !== undefined ? { elapsedSeconds } : {}),
@@ -957,22 +961,26 @@ function mergeWorkLogLiveActivity(
 ): WorkLogLiveActivity | undefined {
   if (!previous) return next;
   if (!next) return previous;
-  const lifecycleElapsedSeconds =
-    (Date.parse(next.lastActivityAt) - Date.parse(previous.startedAt)) / 1_000;
+  const startedAt = previous.startedAt ?? next.startedAt;
+  const lifecycleElapsedSeconds = startedAt
+    ? (Date.parse(next.lastActivityAt) - Date.parse(startedAt)) / 1_000
+    : undefined;
+  const elapsedCandidates = [
+    lifecycleElapsedSeconds,
+    next.elapsedSeconds,
+    previous.elapsedSeconds,
+  ].filter((value): value is number => value !== undefined && Number.isFinite(value));
   const terminalElapsedSeconds =
     next.state === "completed" || next.state === "failed" || next.state === "cancelled"
-      ? Math.max(
-          0,
-          Number.isFinite(lifecycleElapsedSeconds) ? lifecycleElapsedSeconds : 0,
-          next.elapsedSeconds ?? 0,
-          previous.elapsedSeconds ?? 0,
-        )
+      ? elapsedCandidates.length > 0
+        ? Math.max(0, ...elapsedCandidates)
+        : undefined
       : undefined;
   return {
     state: next.state,
     label: next.label || previous.label,
-    startedAt: previous.startedAt,
     lastActivityAt: next.lastActivityAt,
+    ...(startedAt ? { startedAt } : {}),
     ...(next.detail || previous.detail ? { detail: next.detail ?? previous.detail } : {}),
     ...(next.progress !== undefined || previous.progress !== undefined
       ? { progress: next.progress ?? previous.progress }
@@ -1583,7 +1591,9 @@ function extractToolName(payload: Record<string, unknown> | null): string | null
 function extractToolCallId(payload: Record<string, unknown> | null): string | null {
   const data = asRecord(payload?.data);
   const item = asRecord(data?.item);
-  return asTrimmedString(data?.toolCallId ?? data?.callID ?? data?.callId ?? item?.id);
+  return asTrimmedString(
+    data?.toolCallId ?? data?.toolUseId ?? data?.callID ?? data?.callId ?? item?.id,
+  );
 }
 
 function stripTrailingExitCode(value: string): {

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -1091,6 +1091,7 @@ function reconcileSettledLiveActivities(
     if (terminal) {
       return {
         ...entry,
+        toolStatus: terminal.state === "failed" ? "failed" : "completed",
         liveActivity: settleWorkLogLiveActivity(
           liveActivity,
           terminal.state,
@@ -1115,13 +1116,16 @@ function reconcileSettledLiveActivities(
       return entry;
     }
 
+    const settledState =
+      latestTurnId && entry.turnId === latestTurnId && latestTerminalState
+        ? latestTerminalState
+        : "cancelled";
     return {
       ...entry,
+      toolStatus: settledState === "failed" ? "failed" : "completed",
       liveActivity: settleWorkLogLiveActivity(
         liveActivity,
-        latestTurnId && entry.turnId === latestTurnId && latestTerminalState
-          ? latestTerminalState
-          : "cancelled",
+        settledState,
         latestTurnId &&
           entry.turnId === latestTurnId &&
           options.latestTurnCompletedAt

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -591,6 +591,7 @@ function deriveToolLifecycleStatus(
 ): SynaraMcpToolStatus | undefined {
   if (!isRenderableToolLifecycleActivity(activityKind)) return undefined;
   if (isFailedToolLifecyclePayload(payload)) return "failed";
+  if (isCancelledToolLifecyclePayload(payload)) return "cancelled";
   return activityKind === "tool.completed" ? "completed" : "running";
 }
 
@@ -612,10 +613,7 @@ function deriveWorkLogLiveActivity(
   const normalizedStatus = rawStatus?.trim().toLowerCase();
   const state: WorkLogLiveActivityState = isFailedToolLifecyclePayload(payload)
     ? "failed"
-    : normalizedStatus &&
-        ["cancelled", "canceled", "declined", "killed", "stopped", "aborted"].includes(
-          normalizedStatus,
-        )
+    : isCancelledToolLifecyclePayload(payload)
       ? "cancelled"
       : activity.kind === "tool.completed" ||
           (normalizedStatus &&
@@ -677,6 +675,25 @@ function isFailedToolLifecyclePayload(payload: Record<string, unknown> | null): 
     rawOutput?.isError,
     rawOutput?.is_error,
   ].some((flag) => flag === true || flag === 1 || flag === "true");
+}
+
+function isCancelledToolLifecyclePayload(payload: Record<string, unknown> | null): boolean {
+  const data = asRecord(payload?.data);
+  const state = asRecord(data?.state);
+  const rawOutput = asRecord(data?.rawOutput);
+  return [payload?.status, data?.status, state?.status, rawOutput?.status].some(
+    (status) =>
+      typeof status === "string" &&
+      [
+        "cancelled",
+        "canceled",
+        "declined",
+        "interrupted",
+        "killed",
+        "stopped",
+        "aborted",
+      ].includes(status.trim().toLowerCase()),
+  );
 }
 
 function summarizeToolPayloadOutput(payload: Record<string, unknown> | null): string | null {
@@ -901,6 +918,9 @@ function shouldCollapseToolLifecycleEntries(
   if (previous.activityKind === "tool.completed") {
     return false;
   }
+  if (previous.suppressStandaloneCommandStart && next.toolCallId === undefined) {
+    return false;
+  }
   if (previous.collapseKey !== undefined && previous.collapseKey === next.collapseKey) {
     if (previous.collapseKey.startsWith("tool:")) {
       return true;
@@ -948,7 +968,14 @@ function mergeDerivedWorkLogEntries(
   const collapseKey = next.collapseKey ?? previous.collapseKey;
   const toolName = next.toolName ?? previous.toolName;
   const toolCallId = next.toolCallId ?? previous.toolCallId;
-  const toolStatus = next.toolStatus ?? previous.toolStatus;
+  const preservePreviousTerminalState =
+    previous.liveActivity !== undefined &&
+    !isInProgressLiveActivityState(previous.liveActivity.state) &&
+    next.liveActivity !== undefined &&
+    isInProgressLiveActivityState(next.liveActivity.state);
+  const toolStatus = preservePreviousTerminalState
+    ? previous.toolStatus
+    : (next.toolStatus ?? previous.toolStatus);
   const liveActivity = mergeWorkLogLiveActivity(previous.liveActivity, next.liveActivity);
   const toolDetails = mergeWorkLogToolDetails(previous.toolDetails, next.toolDetails);
   const turnId = next.turnId ?? previous.turnId;
@@ -982,6 +1009,18 @@ function mergeWorkLogLiveActivity(
 ): WorkLogLiveActivity | undefined {
   if (!previous) return next;
   if (!next) return previous;
+  if (
+    !isInProgressLiveActivityState(previous.state) &&
+    isInProgressLiveActivityState(next.state)
+  ) {
+    return {
+      ...previous,
+      ...(next.detail || previous.detail ? { detail: next.detail ?? previous.detail } : {}),
+      ...(next.progress !== undefined || previous.progress !== undefined
+        ? { progress: next.progress ?? previous.progress }
+        : {}),
+    };
+  }
   const startedAt = previous.startedAt ?? next.startedAt;
   const lifecycleElapsedSeconds = startedAt
     ? (Date.parse(next.lastActivityAt) - Date.parse(startedAt)) / 1_000
@@ -1091,7 +1130,12 @@ function reconcileSettledLiveActivities(
     if (terminal) {
       return {
         ...entry,
-        toolStatus: terminal.state === "failed" ? "failed" : "completed",
+        toolStatus:
+          terminal.state === "failed"
+            ? "failed"
+            : terminal.state === "cancelled"
+              ? "cancelled"
+              : "completed",
         liveActivity: settleWorkLogLiveActivity(
           liveActivity,
           terminal.state,
@@ -1122,7 +1166,12 @@ function reconcileSettledLiveActivities(
         : "cancelled";
     return {
       ...entry,
-      toolStatus: settledState === "failed" ? "failed" : "completed",
+      toolStatus:
+        settledState === "failed"
+          ? "failed"
+          : settledState === "cancelled"
+            ? "cancelled"
+            : "completed",
       liveActivity: settleWorkLogLiveActivity(
         liveActivity,
         settledState,


### PR DESCRIPTION
## Summary
- merge provider tool lifecycle events into one live activity
- show compact progress, state, and elapsed time
- expose technical metadata on demand

## Validation
- focused work-log, presentation, timeline, and browser detail tests passed