### PR TITLE
fix: polish composer command menu states

### DIFF
--- a/apps/web/src/components/chat/ComposerCommandMenu.browser.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.browser.tsx
@@ -44,20 +44,23 @@ describe("ComposerCommandMenu empty states", () => {
     ["mention", "mention", "Searching mentions..."],
     ["skill", "skill", "Loading skills..."],
     ["slash command", "slash-command", "Loading commands..."],
-  ] as const)("shows the %s loading label before results are available", async (_label, triggerKind, text) => {
-    const menu = await mountMenu({ isLoading: true, triggerKind });
+  ] as const)(
+    "shows the %s loading label before results are available",
+    async (_label, triggerKind, text) => {
+      const menu = await mountMenu({ isLoading: true, triggerKind });
 
-    try {
-      await expect.element(page.getByText(text, { exact: true })).toBeVisible();
-      if (triggerKind === "mention") {
-        await expect.element(page.getByText("Files", { exact: true })).toBeVisible();
-      } else {
-        expect(document.querySelector('[data-slot="command-list"]')).toBeNull();
+      try {
+        await expect.element(page.getByText(text, { exact: true })).toBeVisible();
+        if (triggerKind === "mention") {
+          await expect.element(page.getByText("Files", { exact: true })).toBeVisible();
+        } else {
+          expect(document.querySelector('[data-slot="command-list"]')).toBeNull();
+        }
+      } finally {
+        await menu.cleanup();
       }
-    } finally {
-      await menu.cleanup();
-    }
-  });
+    },
+  );
 
   it("uses the supplied empty copy after loading completes", async () => {
     const menu = await mountMenu({

--- a/apps/web/src/components/chat/ComposerCommandMenu.browser.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.browser.tsx
@@ -1,0 +1,78 @@
+import "../../index.css";
+
+import { page } from "vitest/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { ComposerCommandMenu } from "./ComposerCommandMenu";
+
+async function mountMenu(input: {
+  isLoading: boolean;
+  triggerKind: "mention" | "skill" | "slash-command" | null;
+  emptyStateText?: string;
+}) {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const screen = await render(
+    <ComposerCommandMenu
+      items={[]}
+      resolvedTheme="dark"
+      isLoading={input.isLoading}
+      triggerKind={input.triggerKind}
+      emptyStateText={input.emptyStateText}
+      activeItemId={null}
+      onHighlightedItemChange={vi.fn()}
+      onSelect={vi.fn()}
+    />,
+    { container: host },
+  );
+
+  return {
+    cleanup: async () => {
+      await screen.unmount();
+      host.remove();
+    },
+  };
+}
+
+describe("ComposerCommandMenu empty states", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it.each([
+    ["mention", "mention", "Searching mentions..."],
+    ["skill", "skill", "Loading skills..."],
+    ["slash command", "slash-command", "Loading commands..."],
+  ] as const)("shows the %s loading label before results are available", async (_label, triggerKind, text) => {
+    const menu = await mountMenu({ isLoading: true, triggerKind });
+
+    try {
+      await expect.element(page.getByText(text, { exact: true })).toBeVisible();
+      if (triggerKind === "mention") {
+        await expect.element(page.getByText("Files", { exact: true })).toBeVisible();
+      } else {
+        expect(document.querySelector('[data-slot="command-list"]')).toBeNull();
+      }
+    } finally {
+      await menu.cleanup();
+    }
+  });
+
+  it("uses the supplied empty copy after loading completes", async () => {
+    const menu = await mountMenu({
+      isLoading: false,
+      triggerKind: "slash-command",
+      emptyStateText: "No commands are available for this provider.",
+    });
+
+    try {
+      await expect
+        .element(page.getByText("No commands are available for this provider.", { exact: true }))
+        .toBeVisible();
+      expect(document.body.textContent).not.toContain("Loading commands...");
+    } finally {
+      await menu.cleanup();
+    }
+  });
+});

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -331,6 +331,7 @@ export function ComposerCommandMenu(props: {
     props.triggerKind,
     props.groupSlashCommandSections ?? true,
   );
+  const shouldRenderList = props.items.length > 0 || props.triggerKind === "mention";
 
   useEffect(() => {
     if (!props.activeItemId) {
@@ -353,54 +354,63 @@ export function ComposerCommandMenu(props: {
       }}
     >
       <div className={COMPOSER_COMMAND_MENU_SURFACE_CLASS_NAME}>
-        <CommandList className="max-h-72 scroll-py-1 p-1">
-          {groups.map((group, groupIndex) => (
-            <div key={group.id}>
-              {groupIndex > 0 ? <CommandSeparator className="my-0.5" /> : null}
-              <CommandGroup>
-                {group.label ? (
-                  <CommandGroupLabel className={COMPOSER_COMMAND_GROUP_LABEL_CLASSNAME}>
-                    {group.label}
-                  </CommandGroupLabel>
-                ) : null}
-                {group.items.map((item) => (
-                  <ComposerCommandMenuItem
-                    key={item.id}
-                    item={item}
-                    resolvedTheme={props.resolvedTheme}
-                    isActive={props.activeItemId === item.id}
+        {shouldRenderList ? (
+          <CommandList className="max-h-72 scroll-py-1 p-1">
+            {groups.map((group, groupIndex) => (
+              <div key={group.id}>
+                {groupIndex > 0 ? <CommandSeparator className="my-0.5" /> : null}
+                <CommandGroup>
+                  {group.label ? (
+                    <CommandGroupLabel className={COMPOSER_COMMAND_GROUP_LABEL_CLASSNAME}>
+                      {group.label}
+                    </CommandGroupLabel>
+                  ) : null}
+                  {group.items.map((item) => (
+                    <ComposerCommandMenuItem
+                      key={item.id}
+                      item={item}
+                      resolvedTheme={props.resolvedTheme}
+                      isActive={props.activeItemId === item.id}
                     itemRef={(node) => {
                       itemRefs.current[item.id] = node;
                     }}
-                    onHighlight={props.onHighlightedItemChange}
-                    onSelect={props.onSelect}
-                  />
-                ))}
-              </CommandGroup>
-            </div>
-          ))}
-          {props.triggerKind === "mention" ? (
-            <>
-              {groups.length > 0 ? <CommandSeparator className="my-0.5" /> : null}
-              {/* This footer is informational copy, not a selectable result group. */}
-              <div className="pt-0.5 pb-2">
-                <p
-                  className={cn(
-                    COMPOSER_COMMAND_GROUP_LABEL_CLASSNAME,
-                    "px-2 py-0 font-medium text-muted-foreground text-xs",
-                  )}
-                >
-                  Files
-                </p>
-                <p className="px-2 pt-0.5 text-[11px] text-muted-foreground/55">
-                  Type to search for files
-                </p>
+                      onHighlight={props.onHighlightedItemChange}
+                      onSelect={props.onSelect}
+                    />
+                  ))}
+                </CommandGroup>
               </div>
-            </>
-          ) : null}
-        </CommandList>
+            ))}
+            {props.triggerKind === "mention" ? (
+              <>
+                {groups.length > 0 ? <CommandSeparator className="my-0.5" /> : null}
+                {/* This footer is informational copy, not a selectable result group. */}
+                <div className="pt-0.5 pb-2">
+                  <p
+                    className={cn(
+                      COMPOSER_COMMAND_GROUP_LABEL_CLASSNAME,
+                      "px-2 py-0 font-medium text-muted-foreground text-xs",
+                    )}
+                  >
+                    Files
+                  </p>
+                  <p className="px-2 pt-0.5 text-[11px] text-muted-foreground/55">
+                    Type to search for files
+                  </p>
+                </div>
+              </>
+            ) : null}
+          </CommandList>
+        ) : null}
         {props.items.length === 0 && (
-          <p className="px-2 py-1.5 text-muted-foreground/50 text-[11px]">
+          <p
+            className={cn(
+              "text-muted-foreground/50 text-[11px]",
+              props.isLoading
+                ? "flex h-[calc(1.625rem+0.5rem)] items-center px-2 text-left"
+                : "px-2 py-1.5",
+            )}
+          >
             {props.isLoading
               ? props.triggerKind === "mention"
                 ? "Searching mentions..."

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -371,9 +371,9 @@ export function ComposerCommandMenu(props: {
                       item={item}
                       resolvedTheme={props.resolvedTheme}
                       isActive={props.activeItemId === item.id}
-                    itemRef={(node) => {
-                      itemRefs.current[item.id] = node;
-                    }}
+                      itemRef={(node) => {
+                        itemRefs.current[item.id] = node;
+                      }}
                       onHighlight={props.onHighlightedItemChange}
                       onSelect={props.onSelect}
                     />


### PR DESCRIPTION
## Summary
- render explicit loading and empty states for slash, mention, and skill menus
- keep mention file guidance visible without rendering an empty result list

## Validation
- focused browser tests: 4 passed in the integrated checkout