### PR TITLE
fix: preserve Windows Ctrl-minus zoom

### DIFF
--- a/apps/desktop/src/browserManager.test.ts
+++ b/apps/desktop/src/browserManager.test.ts
@@ -176,4 +176,49 @@ describe("DesktopBrowserManager repeated workflow characterization", () => {
       expect(manager.getState({ threadId: THREAD_ID }).tabs).toHaveLength(beforeSchemeDenial);
     }
   });
+
+  it("gives the shell first refusal on browser guest keyboard input", () => {
+    const beforeInputEvent = vi.fn((event: Electron.Event) => {
+      event.preventDefault();
+      return true;
+    });
+    const manager = new DesktopBrowserManager({ beforeInputEvent });
+    const initial = manager.open({ threadId: THREAD_ID });
+    const tabId = initial.activeTabId;
+    expect(tabId).not.toBeNull();
+    if (!tabId) return;
+
+    const tabContents = new FakeWebContents();
+    asCharacterizationAccess(manager).configureRuntimeWebContents({
+      key: `thread-1:${tabId}`,
+      threadId: THREAD_ID,
+      tabId,
+      webContents: tabContents as unknown as WebContents,
+      view: null,
+      ownsWebContents: false,
+      listenerDisposers: [],
+    });
+    const event = {
+      preventDefault: vi.fn(),
+      defaultPrevented: false,
+    };
+    const input = {
+      type: "keyDown",
+      key: "-",
+      code: "Minus",
+      isAutoRepeat: false,
+      isComposing: false,
+      shift: false,
+      control: true,
+      alt: false,
+      meta: false,
+      location: 0,
+      modifiers: ["control"],
+    };
+
+    tabContents.emit("before-input-event", event, input);
+
+    expect(beforeInputEvent).toHaveBeenCalledWith(event, input);
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+  });
 });

--- a/apps/desktop/src/browserManager.ts
+++ b/apps/desktop/src/browserManager.ts
@@ -111,6 +111,10 @@ export interface BrowserUseCdpEvent {
   params?: unknown;
 }
 
+export interface DesktopBrowserManagerOptions {
+  beforeInputEvent?: (event: Electron.Event, input: Electron.Input) => boolean;
+}
+
 function createBrowserTab(url = ABOUT_BLANK_URL): BrowserTabState {
   return {
     id: Crypto.randomUUID(),
@@ -271,6 +275,8 @@ export class DesktopBrowserManager {
     inactiveTabBudgetEvictions: 0,
     warmInactiveRuntimeCount: 0,
   };
+
+  constructor(private readonly options: DesktopBrowserManagerOptions = {}) {}
 
   setWindow(window: BrowserWindow | null): void {
     this.window = window;
@@ -1448,8 +1454,12 @@ export class DesktopBrowserManager {
     this.configureWindowOpenHandling(webContents, runtime, runtime.listenerDisposers);
 
     // The native page owns keyboard focus while browsing, so the renderer never sees the
-    // copy-link chord. Intercept it here, copy the live URL, and let the shell toast.
+    // shell's physical zoom fallback or copy-link chord. Give the shell first refusal,
+    // then handle browser-local chords here.
     const beforeInputEvent = (event: Electron.Event, input: Electron.Input) => {
+      if (this.options.beforeInputEvent?.(event, input)) {
+        return;
+      }
       if (input.type !== "keyDown") {
         return;
       }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -136,6 +136,7 @@ import {
 import { registerDesktopVoiceTranscriptionHandler } from "./voiceTranscription";
 import {
   resolveDesktopMenuAccelerator,
+  resolveDesktopPhysicalZoomAction,
   resolveKeyboardShortcutsMenuAccelerator,
   shouldUseNativeZoomMenuRoles,
 } from "./menuShortcuts";
@@ -1317,6 +1318,25 @@ function attachDesktopZoomFactorSync(window: BrowserWindow): void {
   window.webContents.on("did-finish-load", notify);
 }
 
+function adjustWebContentsZoom(webContents: Electron.WebContents, multiplier: number): void {
+  const nextZoomFactor = Math.min(
+    DESKTOP_MENU_MAX_ZOOM_FACTOR,
+    Math.max(DESKTOP_MENU_MIN_ZOOM_FACTOR, webContents.getZoomFactor() * multiplier),
+  );
+  webContents.setZoomFactor(nextZoomFactor);
+}
+
+function attachDesktopPhysicalZoomShortcuts(window: BrowserWindow): void {
+  window.webContents.on("before-input-event", (event, input) => {
+    if (resolveDesktopPhysicalZoomAction(process.platform, input) !== "zoomOut") {
+      return;
+    }
+
+    event.preventDefault();
+    adjustWebContentsZoom(window.webContents, 1 / DESKTOP_MENU_ZOOM_FACTOR_STEP);
+  });
+}
+
 function resetWindowZoomFromMenu(): void {
   resolveMenuTargetWindow()?.webContents.setZoomFactor(1);
 }
@@ -1324,11 +1344,7 @@ function resetWindowZoomFromMenu(): void {
 function adjustWindowZoomFromMenu(multiplier: number): void {
   const webContents = resolveMenuTargetWindow()?.webContents;
   if (!webContents) return;
-  const nextZoomFactor = Math.min(
-    DESKTOP_MENU_MAX_ZOOM_FACTOR,
-    Math.max(DESKTOP_MENU_MIN_ZOOM_FACTOR, webContents.getZoomFactor() * multiplier),
-  );
-  webContents.setZoomFactor(nextZoomFactor);
+  adjustWebContentsZoom(webContents, multiplier);
 }
 
 // A configured app-update.yml (or the mock-updates flag) is the prerequisite for any
@@ -3815,6 +3831,7 @@ function createWindow(): BrowserWindow {
   browserManager.setWindow(window);
   attachDesktopZoomFactorSync(window);
   attachRendererCrashRecovery(window);
+  attachDesktopPhysicalZoomShortcuts(window);
 
   window.webContents.on("context-menu", (event, params) => {
     event.preventDefault();

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -49,6 +49,7 @@ import {
 } from "electron-updater";
 
 import type { ContextMenuItem } from "@synara/contracts";
+import { isKeyboardShortcutsHelpChord } from "@synara/shared/browserShortcuts";
 import { getMacTrafficLightPosition } from "@synara/shared/desktopChrome";
 import {
   SYNARA_DESKTOP_UPDATE_CHANNEL,
@@ -328,6 +329,29 @@ let unreadBackgroundNotificationCount = 0;
 let browserPerfInterval: ReturnType<typeof setInterval> | null = null;
 const browserManager = new DesktopBrowserManager({
   beforeInputEvent: (event, input) => {
+    if (
+      isKeyboardShortcutsHelpChord(
+        {
+          type: input.type,
+          key: input.key,
+          code: input.code,
+          meta: input.meta,
+          ctrl: input.control,
+          shift: input.shift,
+          alt: input.alt,
+          repeat: input.isAutoRepeat,
+        },
+        {
+          isMac: process.platform === "darwin",
+          isWindows: process.platform === "win32",
+        },
+      )
+    ) {
+      event.preventDefault();
+      dispatchMenuAction("show-shortcuts");
+      return true;
+    }
+
     const target = resolveMenuTargetWindow()?.webContents;
     return target ? handleDesktopPhysicalZoomShortcut(event, input, target) : false;
   },

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -135,6 +135,7 @@ import {
 } from "./updateState";
 import { registerDesktopVoiceTranscriptionHandler } from "./voiceTranscription";
 import {
+  applyDesktopPhysicalZoomAction,
   resolveDesktopMenuAccelerator,
   resolveDesktopPhysicalZoomAction,
   resolveKeyboardShortcutsMenuAccelerator,
@@ -325,7 +326,12 @@ let backendLogSink: RotatingFileSink | null = null;
 let restoreStdIoCapture: (() => void) | null = null;
 let unreadBackgroundNotificationCount = 0;
 let browserPerfInterval: ReturnType<typeof setInterval> | null = null;
-const browserManager = new DesktopBrowserManager();
+const browserManager = new DesktopBrowserManager({
+  beforeInputEvent: (event, input) => {
+    const target = resolveMenuTargetWindow()?.webContents;
+    return target ? handleDesktopPhysicalZoomShortcut(event, input, target) : false;
+  },
+});
 let browserUsePipeServer: BrowserUsePipeServer | null = null;
 let appSnapManager: DesktopAppSnapManager | null = null;
 let configuredUpdaterCacheDirName: string | null = null;
@@ -1326,14 +1332,24 @@ function adjustWebContentsZoom(webContents: Electron.WebContents, multiplier: nu
   webContents.setZoomFactor(nextZoomFactor);
 }
 
+function handleDesktopPhysicalZoomShortcut(
+  event: Electron.Event,
+  input: Electron.Input,
+  target: Electron.WebContents,
+): boolean {
+  const action = resolveDesktopPhysicalZoomAction(process.platform, input);
+  if (!action || target.isDestroyed()) {
+    return false;
+  }
+
+  event.preventDefault();
+  applyDesktopPhysicalZoomAction(target, action);
+  return true;
+}
+
 function attachDesktopPhysicalZoomShortcuts(window: BrowserWindow): void {
   window.webContents.on("before-input-event", (event, input) => {
-    if (resolveDesktopPhysicalZoomAction(process.platform, input) !== "zoomOut") {
-      return;
-    }
-
-    event.preventDefault();
-    adjustWebContentsZoom(window.webContents, 1 / DESKTOP_MENU_ZOOM_FACTOR_STEP);
+    handleDesktopPhysicalZoomShortcut(event, input, window.webContents);
   });
 }
 

--- a/apps/desktop/src/menuShortcuts.test.ts
+++ b/apps/desktop/src/menuShortcuts.test.ts
@@ -1,9 +1,10 @@
 // FILE: menuShortcuts.test.ts
 // Purpose: Verifies desktop menu accelerator choices that affect native keyboard behavior.
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
+  applyDesktopPhysicalZoomAction,
   resolveDesktopMenuAccelerator,
   resolveDesktopPhysicalZoomAction,
   resolveKeyboardShortcutsMenuAccelerator,
@@ -90,6 +91,20 @@ describe("resolveDesktopPhysicalZoomAction", () => {
     expect(
       resolveDesktopPhysicalZoomAction("linux", { ...windowsCtrlInput, code: "Minus" }),
     ).toBeNull();
+  });
+});
+
+describe("applyDesktopPhysicalZoomAction", () => {
+  it("uses Electron's native half-level zoom-out step", () => {
+    const target = {
+      getZoomLevel: vi.fn(() => 1.25),
+      setZoomLevel: vi.fn(),
+    };
+
+    applyDesktopPhysicalZoomAction(target, "zoomOut");
+
+    expect(target.getZoomLevel).toHaveBeenCalledOnce();
+    expect(target.setZoomLevel).toHaveBeenCalledWith(0.75);
   });
 });
 

--- a/apps/desktop/src/menuShortcuts.test.ts
+++ b/apps/desktop/src/menuShortcuts.test.ts
@@ -21,9 +21,9 @@ describe("resolveDesktopPhysicalZoomAction", () => {
   };
 
   it("handles both physical minus keys as zoom-out on Windows", () => {
-    expect(
-      resolveDesktopPhysicalZoomAction("win32", { ...windowsCtrlInput, code: "Minus" }),
-    ).toBe("zoomOut");
+    expect(resolveDesktopPhysicalZoomAction("win32", { ...windowsCtrlInput, code: "Minus" })).toBe(
+      "zoomOut",
+    );
     expect(
       resolveDesktopPhysicalZoomAction("win32", {
         ...windowsCtrlInput,
@@ -53,11 +53,42 @@ describe("resolveDesktopPhysicalZoomAction", () => {
         shift: true,
       }),
     ).toBeNull();
+    expect(
+      resolveDesktopPhysicalZoomAction("win32", {
+        ...windowsCtrlInput,
+        code: "Minus",
+        alt: true,
+      }),
+    ).toBeNull();
+    expect(
+      resolveDesktopPhysicalZoomAction("win32", {
+        ...windowsCtrlInput,
+        code: "Minus",
+        meta: true,
+      }),
+    ).toBeNull();
   });
 
-  it("leaves macOS keyboard handling unchanged", () => {
+  it("only handles Windows Ctrl key-down events", () => {
+    expect(
+      resolveDesktopPhysicalZoomAction("win32", {
+        ...windowsCtrlInput,
+        type: "keyUp",
+        code: "Minus",
+      }),
+    ).toBeNull();
+    expect(
+      resolveDesktopPhysicalZoomAction("win32", {
+        ...windowsCtrlInput,
+        control: false,
+        code: "Minus",
+      }),
+    ).toBeNull();
     expect(
       resolveDesktopPhysicalZoomAction("darwin", { ...windowsCtrlInput, code: "Minus" }),
+    ).toBeNull();
+    expect(
+      resolveDesktopPhysicalZoomAction("linux", { ...windowsCtrlInput, code: "Minus" }),
     ).toBeNull();
   });
 });

--- a/apps/desktop/src/menuShortcuts.test.ts
+++ b/apps/desktop/src/menuShortcuts.test.ts
@@ -5,9 +5,62 @@ import { describe, expect, it } from "vitest";
 
 import {
   resolveDesktopMenuAccelerator,
+  resolveDesktopPhysicalZoomAction,
   resolveKeyboardShortcutsMenuAccelerator,
   shouldUseNativeZoomMenuRoles,
 } from "./menuShortcuts";
+
+describe("resolveDesktopPhysicalZoomAction", () => {
+  const windowsCtrlInput = {
+    type: "keyDown",
+    key: "",
+    control: true,
+    meta: false,
+    shift: false,
+    alt: false,
+  };
+
+  it("handles both physical minus keys as zoom-out on Windows", () => {
+    expect(
+      resolveDesktopPhysicalZoomAction("win32", { ...windowsCtrlInput, code: "Minus" }),
+    ).toBe("zoomOut");
+    expect(
+      resolveDesktopPhysicalZoomAction("win32", {
+        ...windowsCtrlInput,
+        code: "NumpadSubtract",
+      }),
+    ).toBe("zoomOut");
+  });
+
+  it("uses the translated minus value for Windows layouts whose physical code is Slash", () => {
+    expect(
+      resolveDesktopPhysicalZoomAction("win32", {
+        ...windowsCtrlInput,
+        key: "-",
+        code: "Slash",
+      }),
+    ).toBe("zoomOut");
+  });
+
+  it("does not intercept slash or modified minus chords", () => {
+    expect(
+      resolveDesktopPhysicalZoomAction("win32", { ...windowsCtrlInput, code: "Slash" }),
+    ).toBeNull();
+    expect(
+      resolveDesktopPhysicalZoomAction("win32", {
+        ...windowsCtrlInput,
+        code: "Minus",
+        shift: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("leaves macOS keyboard handling unchanged", () => {
+    expect(
+      resolveDesktopPhysicalZoomAction("darwin", { ...windowsCtrlInput, code: "Minus" }),
+    ).toBeNull();
+  });
+});
 
 describe("resolveDesktopMenuAccelerator", () => {
   it("disables custom native menu accelerators on Linux", () => {

--- a/apps/desktop/src/menuShortcuts.ts
+++ b/apps/desktop/src/menuShortcuts.ts
@@ -17,6 +17,11 @@ export interface DesktopKeyboardInput {
 
 export type DesktopPhysicalZoomAction = "zoomOut" | null;
 
+export interface DesktopNativeZoomTarget {
+  getZoomLevel(): number;
+  setZoomLevel(level: number): void;
+}
+
 export function resolveDesktopPhysicalZoomAction(
   platform: NodeJS.Platform,
   input: DesktopKeyboardInput,
@@ -34,6 +39,17 @@ export function resolveDesktopPhysicalZoomAction(
 
   const isMinusKey = input.key === "-" || input.code === "Minus" || input.code === "NumpadSubtract";
   return isMinusKey ? "zoomOut" : null;
+}
+
+export function applyDesktopPhysicalZoomAction(
+  target: DesktopNativeZoomTarget,
+  action: Exclude<DesktopPhysicalZoomAction, null>,
+): void {
+  if (action === "zoomOut") {
+    // Electron's native zoomOut role subtracts half a zoom level. Reuse that
+    // exact step so alternating native zoom-in and fallback zoom-out cannot drift.
+    target.setZoomLevel(target.getZoomLevel() - 0.5);
+  }
 }
 
 export function resolveDesktopMenuAccelerator(

--- a/apps/desktop/src/menuShortcuts.ts
+++ b/apps/desktop/src/menuShortcuts.ts
@@ -5,6 +5,38 @@
 
 import type { MenuItemConstructorOptions } from "electron";
 
+export interface DesktopKeyboardInput {
+  type: string;
+  key: string;
+  code?: string;
+  control: boolean;
+  meta: boolean;
+  shift: boolean;
+  alt: boolean;
+}
+
+export type DesktopPhysicalZoomAction = "zoomOut" | null;
+
+export function resolveDesktopPhysicalZoomAction(
+  platform: NodeJS.Platform,
+  input: DesktopKeyboardInput,
+): DesktopPhysicalZoomAction {
+  if (
+    platform !== "win32" ||
+    input.type !== "keyDown" ||
+    !input.control ||
+    input.meta ||
+    input.shift ||
+    input.alt
+  ) {
+    return null;
+  }
+
+  const isMinusKey =
+    input.key === "-" || input.code === "Minus" || input.code === "NumpadSubtract";
+  return isMinusKey ? "zoomOut" : null;
+}
+
 export function resolveDesktopMenuAccelerator(
   platform: NodeJS.Platform,
   accelerator: MenuItemConstructorOptions["accelerator"],

--- a/apps/desktop/src/menuShortcuts.ts
+++ b/apps/desktop/src/menuShortcuts.ts
@@ -32,8 +32,7 @@ export function resolveDesktopPhysicalZoomAction(
     return null;
   }
 
-  const isMinusKey =
-    input.key === "-" || input.code === "Minus" || input.code === "NumpadSubtract";
+  const isMinusKey = input.key === "-" || input.code === "Minus" || input.code === "NumpadSubtract";
   return isMinusKey ? "zoomOut" : null;
 }
 

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -12,6 +12,7 @@ import {
   isChatNewShortcut,
   isChatNewChatShortcut,
   isDiffToggleShortcut,
+  isKeyboardShortcutsHelpShortcut,
   isOpenFavoriteEditorShortcut,
   isSidebarToggleShortcut,
   isTerminalClearShortcut,
@@ -39,6 +40,59 @@ function event(overrides: Partial<ShortcutEventLike> = {}): ShortcutEventLike {
     ...overrides,
   };
 }
+
+describe("isKeyboardShortcutsHelpShortcut", () => {
+  it("does not mistake the physical minus keys for shortcuts help on Windows", () => {
+    assert.isFalse(
+      isKeyboardShortcutsHelpShortcut(
+        event({ ctrlKey: true, key: "/", code: "Minus" }),
+        "Win32",
+      ),
+    );
+    assert.isFalse(
+      isKeyboardShortcutsHelpShortcut(
+        event({ ctrlKey: true, key: "/", code: "NumpadSubtract" }),
+        "Win32",
+      ),
+    );
+    assert.isFalse(
+      isKeyboardShortcutsHelpShortcut(
+        event({ ctrlKey: true, key: "-", code: "Slash" }),
+        "Win32",
+      ),
+    );
+  });
+
+  it("recognizes the physical slash keys on Windows", () => {
+    assert.isTrue(
+      isKeyboardShortcutsHelpShortcut(
+        event({ ctrlKey: true, key: "/", code: "Slash" }),
+        "Win32",
+      ),
+    );
+    assert.isTrue(
+      isKeyboardShortcutsHelpShortcut(
+        event({ ctrlKey: true, key: "/", code: "NumpadDivide" }),
+        "Win32",
+      ),
+    );
+  });
+
+  it("uses Cmd+/ on macOS without accepting Ctrl+/", () => {
+    assert.isTrue(
+      isKeyboardShortcutsHelpShortcut(
+        event({ metaKey: true, key: "/", code: "Slash" }),
+        "MacIntel",
+      ),
+    );
+    assert.isFalse(
+      isKeyboardShortcutsHelpShortcut(
+        event({ ctrlKey: true, key: "/", code: "Slash" }),
+        "MacIntel",
+      ),
+    );
+  });
+});
 
 function modShortcut(
   key: string,

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -76,6 +76,12 @@ describe("isKeyboardShortcutsHelpShortcut", () => {
         "MacIntel",
       ),
     );
+    assert.isTrue(
+      isKeyboardShortcutsHelpShortcut(
+        event({ metaKey: true, key: "/", code: "Minus" }),
+        "MacIntel",
+      ),
+    );
     assert.isFalse(
       isKeyboardShortcutsHelpShortcut(
         event({ ctrlKey: true, key: "/", code: "Slash" }),
@@ -88,6 +94,18 @@ describe("isKeyboardShortcutsHelpShortcut", () => {
     assert.isTrue(
       isKeyboardShortcutsHelpShortcut(
         event({ ctrlKey: true, key: "/", code: "Slash" }),
+        "Linux x86_64",
+      ),
+    );
+    assert.isTrue(
+      isKeyboardShortcutsHelpShortcut(
+        event({ ctrlKey: true, key: "/", code: "Minus" }),
+        "Linux x86_64",
+      ),
+    );
+    assert.isTrue(
+      isKeyboardShortcutsHelpShortcut(
+        event({ ctrlKey: true, key: "/", code: "NumpadSubtract" }),
         "Linux x86_64",
       ),
     );

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -44,10 +44,7 @@ function event(overrides: Partial<ShortcutEventLike> = {}): ShortcutEventLike {
 describe("isKeyboardShortcutsHelpShortcut", () => {
   it("does not mistake the physical minus keys for shortcuts help on Windows", () => {
     assert.isFalse(
-      isKeyboardShortcutsHelpShortcut(
-        event({ ctrlKey: true, key: "/", code: "Minus" }),
-        "Win32",
-      ),
+      isKeyboardShortcutsHelpShortcut(event({ ctrlKey: true, key: "/", code: "Minus" }), "Win32"),
     );
     assert.isFalse(
       isKeyboardShortcutsHelpShortcut(
@@ -56,19 +53,13 @@ describe("isKeyboardShortcutsHelpShortcut", () => {
       ),
     );
     assert.isFalse(
-      isKeyboardShortcutsHelpShortcut(
-        event({ ctrlKey: true, key: "-", code: "Slash" }),
-        "Win32",
-      ),
+      isKeyboardShortcutsHelpShortcut(event({ ctrlKey: true, key: "-", code: "Slash" }), "Win32"),
     );
   });
 
   it("recognizes the physical slash keys on Windows", () => {
     assert.isTrue(
-      isKeyboardShortcutsHelpShortcut(
-        event({ ctrlKey: true, key: "/", code: "Slash" }),
-        "Win32",
-      ),
+      isKeyboardShortcutsHelpShortcut(event({ ctrlKey: true, key: "/", code: "Slash" }), "Win32"),
     );
     assert.isTrue(
       isKeyboardShortcutsHelpShortcut(
@@ -89,6 +80,49 @@ describe("isKeyboardShortcutsHelpShortcut", () => {
       isKeyboardShortcutsHelpShortcut(
         event({ ctrlKey: true, key: "/", code: "Slash" }),
         "MacIntel",
+      ),
+    );
+  });
+
+  it("uses Ctrl+/ on Linux without accepting Meta+/", () => {
+    assert.isTrue(
+      isKeyboardShortcutsHelpShortcut(
+        event({ ctrlKey: true, key: "/", code: "Slash" }),
+        "Linux x86_64",
+      ),
+    );
+    assert.isFalse(
+      isKeyboardShortcutsHelpShortcut(
+        event({ metaKey: true, key: "/", code: "Slash" }),
+        "Linux x86_64",
+      ),
+    );
+  });
+
+  it("ignores key-up, auto-repeat, and modified slash events", () => {
+    const platform = "Win32";
+    assert.isFalse(
+      isKeyboardShortcutsHelpShortcut(
+        event({ type: "keyup", ctrlKey: true, key: "/", code: "Slash" }),
+        platform,
+      ),
+    );
+    assert.isFalse(
+      isKeyboardShortcutsHelpShortcut(
+        event({ repeat: true, ctrlKey: true, key: "/", code: "Slash" }),
+        platform,
+      ),
+    );
+    assert.isFalse(
+      isKeyboardShortcutsHelpShortcut(
+        event({ ctrlKey: true, shiftKey: true, key: "/", code: "Slash" }),
+        platform,
+      ),
+    );
+    assert.isFalse(
+      isKeyboardShortcutsHelpShortcut(
+        event({ ctrlKey: true, altKey: true, key: "/", code: "Slash" }),
+        platform,
       ),
     );
   });

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -738,31 +738,19 @@ export function isKeyboardShortcutsHelpShortcut(
 
   // On some Windows layouts Ctrl+- reports the physical Slash code. The
   // translated key is authoritative here so the browser can retain zoom-out.
-  if (
-    event.key === "-" ||
-    event.code === "Minus" ||
-    event.code === "NumpadSubtract"
-  ) {
+  if (event.key === "-" || event.code === "Minus" || event.code === "NumpadSubtract") {
     return false;
   }
 
   if (isMacPlatform(platform)) {
-    return (
-      event.metaKey &&
-      !event.ctrlKey &&
-      (event.code === "Slash" || event.key === "/")
-    );
+    return event.metaKey && !event.ctrlKey && (event.code === "Slash" || event.key === "/");
   }
 
   if (!event.ctrlKey || event.metaKey) {
     return false;
   }
 
-  return (
-    event.code === "Slash" ||
-    event.code === "NumpadDivide" ||
-    event.key === "/"
-  );
+  return event.code === "Slash" || event.code === "NumpadDivide" || event.key === "/";
 }
 
 export function terminalNavigationShortcutData(

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -9,6 +9,7 @@ import {
   THREAD_JUMP_KEYBINDING_COMMANDS,
   type ThreadJumpKeybindingCommand,
 } from "@synara/contracts";
+import { isKeyboardShortcutsHelpChord } from "@synara/shared/browserShortcuts";
 import { isMacPlatform, isWindowsPlatform } from "./lib/utils";
 
 export interface ShortcutEventLike {
@@ -727,34 +728,22 @@ export function isKeyboardShortcutsHelpShortcut(
   event: ShortcutEventLike,
   platform = navigator.platform,
 ): boolean {
-  if (
-    (event.type !== undefined && event.type !== "keydown") ||
-    event.shiftKey ||
-    event.altKey ||
-    event.repeat
-  ) {
-    return false;
-  }
-
-  // On some Windows layouts Ctrl+- reports "/" for the translated key while
-  // retaining a physical minus code. Outside Windows, "/" remains authoritative
-  // so remapped and non-US layouts keep the shortcuts-help chord.
-  if (
-    event.key === "-" ||
-    (isWindowsPlatform(platform) && (event.code === "Minus" || event.code === "NumpadSubtract"))
-  ) {
-    return false;
-  }
-
-  if (isMacPlatform(platform)) {
-    return event.metaKey && !event.ctrlKey && (event.code === "Slash" || event.key === "/");
-  }
-
-  if (!event.ctrlKey || event.metaKey) {
-    return false;
-  }
-
-  return event.code === "Slash" || event.code === "NumpadDivide" || event.key === "/";
+  return isKeyboardShortcutsHelpChord(
+    {
+      key: event.key,
+      meta: event.metaKey,
+      ctrl: event.ctrlKey,
+      shift: event.shiftKey,
+      alt: event.altKey,
+      ...(event.type !== undefined ? { type: event.type } : {}),
+      ...(event.code !== undefined ? { code: event.code } : {}),
+      ...(event.repeat !== undefined ? { repeat: event.repeat } : {}),
+    },
+    {
+      isMac: isMacPlatform(platform),
+      isWindows: isWindowsPlatform(platform),
+    },
+  );
 }
 
 export function terminalNavigationShortcutData(

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -9,7 +9,7 @@ import {
   THREAD_JUMP_KEYBINDING_COMMANDS,
   type ThreadJumpKeybindingCommand,
 } from "@synara/contracts";
-import { isMacPlatform } from "./lib/utils";
+import { isMacPlatform, isWindowsPlatform } from "./lib/utils";
 
 export interface ShortcutEventLike {
   type?: string;
@@ -736,9 +736,13 @@ export function isKeyboardShortcutsHelpShortcut(
     return false;
   }
 
-  // On some Windows layouts Ctrl+- reports the physical Slash code. The
-  // translated key is authoritative here so the browser can retain zoom-out.
-  if (event.key === "-" || event.code === "Minus" || event.code === "NumpadSubtract") {
+  // On some Windows layouts Ctrl+- reports "/" for the translated key while
+  // retaining a physical minus code. Outside Windows, "/" remains authoritative
+  // so remapped and non-US layouts keep the shortcuts-help chord.
+  if (
+    event.key === "-" ||
+    (isWindowsPlatform(platform) && (event.code === "Minus" || event.code === "NumpadSubtract"))
+  ) {
     return false;
   }
 

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -19,6 +19,7 @@ export interface ShortcutEventLike {
   ctrlKey: boolean;
   shiftKey: boolean;
   altKey: boolean;
+  repeat?: boolean;
 }
 
 export interface ShortcutMatchContext {
@@ -720,6 +721,48 @@ export function isTerminalClearShortcut(event: ShortcutEventLike): boolean {
   const key = event.key.toLowerCase();
 
   return key === "l" && event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey;
+}
+
+export function isKeyboardShortcutsHelpShortcut(
+  event: ShortcutEventLike,
+  platform = navigator.platform,
+): boolean {
+  if (
+    (event.type !== undefined && event.type !== "keydown") ||
+    event.shiftKey ||
+    event.altKey ||
+    event.repeat
+  ) {
+    return false;
+  }
+
+  // On some Windows layouts Ctrl+- reports the physical Slash code. The
+  // translated key is authoritative here so the browser can retain zoom-out.
+  if (
+    event.key === "-" ||
+    event.code === "Minus" ||
+    event.code === "NumpadSubtract"
+  ) {
+    return false;
+  }
+
+  if (isMacPlatform(platform)) {
+    return (
+      event.metaKey &&
+      !event.ctrlKey &&
+      (event.code === "Slash" || event.key === "/")
+    );
+  }
+
+  if (!event.ctrlKey || event.metaKey) {
+    return false;
+  }
+
+  return (
+    event.code === "Slash" ||
+    event.code === "NumpadDivide" ||
+    event.key === "/"
+  );
 }
 
 export function terminalNavigationShortcutData(

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -30,7 +30,10 @@ import { isTerminalFocused } from "../lib/terminalFocus";
 import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 import { startFreshChatForActiveSurface } from "../lib/startContainerChat";
 import { isOrdinarySpaceProject } from "../lib/spaces";
-import { resolveShortcutCommand } from "../keybindings";
+import {
+  isKeyboardShortcutsHelpShortcut,
+  resolveShortcutCommand,
+} from "../keybindings";
 import { useStore } from "../store";
 import { useSpacesUiStore } from "../spacesUiStore";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
@@ -339,13 +342,7 @@ function ChatRouteGlobalShortcuts() {
         return;
       }
 
-      const isShortcutsHelpShortcut =
-        (event.metaKey || event.ctrlKey) &&
-        !event.shiftKey &&
-        !event.altKey &&
-        !event.repeat &&
-        (event.key === "/" || event.code === "Slash");
-      if (isShortcutsHelpShortcut) {
+      if (isKeyboardShortcutsHelpShortcut(event, platform)) {
         event.preventDefault();
         event.stopPropagation();
         setShortcutsDialogOpen(true);

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -30,10 +30,7 @@ import { isTerminalFocused } from "../lib/terminalFocus";
 import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 import { startFreshChatForActiveSurface } from "../lib/startContainerChat";
 import { isOrdinarySpaceProject } from "../lib/spaces";
-import {
-  isKeyboardShortcutsHelpShortcut,
-  resolveShortcutCommand,
-} from "../keybindings";
+import { isKeyboardShortcutsHelpShortcut, resolveShortcutCommand } from "../keybindings";
 import { useStore } from "../store";
 import { useSpacesUiStore } from "../spacesUiStore";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";

--- a/packages/shared/src/browserShortcuts.test.ts
+++ b/packages/shared/src/browserShortcuts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isBrowserCopyLinkChord } from "./browserShortcuts";
+import { isBrowserCopyLinkChord, isKeyboardShortcutsHelpChord } from "./browserShortcuts";
 
 describe("isBrowserCopyLinkChord", () => {
   it("matches Cmd+Shift+C on macOS only", () => {
@@ -31,5 +31,61 @@ describe("isBrowserCopyLinkChord", () => {
     expect(
       isBrowserCopyLinkChord({ meta: true, ctrl: false, shift: true, alt: false, key: "v" }, true),
     ).toBe(false);
+  });
+});
+
+describe("isKeyboardShortcutsHelpChord", () => {
+  const baseChord = {
+    type: "keyDown",
+    key: "/",
+    code: "Slash",
+    meta: false,
+    ctrl: false,
+    shift: false,
+    alt: false,
+    repeat: false,
+  };
+
+  it("matches the platform modifier and slash keys", () => {
+    expect(
+      isKeyboardShortcutsHelpChord({ ...baseChord, meta: true }, { isMac: true, isWindows: false }),
+    ).toBe(true);
+    expect(
+      isKeyboardShortcutsHelpChord(
+        { ...baseChord, ctrl: true, code: "NumpadDivide" },
+        { isMac: false, isWindows: true },
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects Windows physical minus codes without changing other platforms", () => {
+    expect(
+      isKeyboardShortcutsHelpChord(
+        { ...baseChord, ctrl: true, code: "Minus" },
+        { isMac: false, isWindows: true },
+      ),
+    ).toBe(false);
+    expect(
+      isKeyboardShortcutsHelpChord(
+        { ...baseChord, ctrl: true, code: "Minus" },
+        { isMac: false, isWindows: false },
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects translated minus, repeat, key-up, and modified chords", () => {
+    const platform = { isMac: false, isWindows: true };
+    expect(
+      isKeyboardShortcutsHelpChord({ ...baseChord, ctrl: true, key: "-", code: "Slash" }, platform),
+    ).toBe(false);
+    expect(isKeyboardShortcutsHelpChord({ ...baseChord, ctrl: true, repeat: true }, platform)).toBe(
+      false,
+    );
+    expect(
+      isKeyboardShortcutsHelpChord({ ...baseChord, ctrl: true, type: "keyUp" }, platform),
+    ).toBe(false);
+    expect(isKeyboardShortcutsHelpChord({ ...baseChord, ctrl: true, alt: true }, platform)).toBe(
+      false,
+    );
   });
 });

--- a/packages/shared/src/browserShortcuts.ts
+++ b/packages/shared/src/browserShortcuts.ts
@@ -13,6 +13,14 @@ export interface BrowserShortcutChord {
   readonly shift: boolean;
   readonly alt: boolean;
   readonly key: string;
+  readonly code?: string;
+  readonly type?: string;
+  readonly repeat?: boolean;
+}
+
+export interface KeyboardShortcutPlatform {
+  readonly isMac: boolean;
+  readonly isWindows: boolean;
 }
 
 // Copy-link chord: Cmd+Shift+C on macOS, Ctrl+Shift+C elsewhere.
@@ -24,4 +32,34 @@ export function isBrowserCopyLinkChord(chord: BrowserShortcutChord, isMac: boole
     return false;
   }
   return isMac ? chord.meta && !chord.ctrl : chord.ctrl && !chord.meta;
+}
+
+export function isKeyboardShortcutsHelpChord(
+  chord: BrowserShortcutChord,
+  platform: KeyboardShortcutPlatform,
+): boolean {
+  if (
+    (chord.type !== undefined && chord.type.toLowerCase() !== "keydown") ||
+    chord.shift ||
+    chord.alt ||
+    chord.repeat
+  ) {
+    return false;
+  }
+
+  // Some Windows layouts translate Ctrl+- to "/" while retaining the physical
+  // minus code. Outside Windows, "/" stays authoritative for remapped layouts.
+  if (
+    chord.key === "-" ||
+    (platform.isWindows && (chord.code === "Minus" || chord.code === "NumpadSubtract"))
+  ) {
+    return false;
+  }
+
+  const isSlash = chord.code === "Slash" || chord.code === "NumpadDivide" || chord.key === "/";
+  if (!isSlash) {
+    return false;
+  }
+
+  return platform.isMac ? chord.meta && !chord.ctrl : chord.ctrl && !chord.meta;
 }


### PR DESCRIPTION
## Summary
- distinguish Ctrl-minus from Ctrl-slash on Windows keyboards
- preserve desktop zoom-out while keeping shortcut help on Ctrl-slash

## Validation
- desktop shortcut tests: 10 passed
- web keybinding tests passed in the integrated checkout