### PR TITLE
fix: reconcile stale live thread projections

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -2018,9 +2018,21 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           ),
           (
             'thread-queued-oldest', 'project-runtime-candidates', 'Queued',
-            '{"provider":"codex","model":"gpt-5-codex"}', NULL, NULL, NULL,
+            '{"provider":"codex","model":"gpt-5-codex"}', NULL, NULL, 'turn-queued',
             '2026-07-21T00:00:00.000Z', '2026-07-21T00:00:00.000Z', NULL, NULL
           )
+      `;
+      yield* sql`
+        INSERT INTO projection_turns (
+          thread_id, turn_id, pending_message_id, source_proposed_plan_thread_id,
+          source_proposed_plan_id, assistant_message_id, state, requested_at,
+          started_at, completed_at, checkpoint_turn_count, checkpoint_ref,
+          checkpoint_status, checkpoint_files_json
+        ) VALUES (
+          'thread-queued-oldest', 'turn-queued', NULL, NULL,
+          NULL, NULL, 'pending', '2026-07-21T00:00:00.000Z',
+          NULL, NULL, 0, NULL, 'missing', '[]'
+        )
       `;
       yield* sql`
         INSERT INTO projection_thread_sessions (

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -2015,6 +2015,11 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
             'thread-unbound-oldest', 'project-runtime-candidates', 'Unbound',
             '{"provider":"codex","model":"gpt-5-codex"}', NULL, NULL, NULL,
             '2026-07-22T00:00:00.000Z', '2026-07-22T00:00:00.000Z', NULL, NULL
+          ),
+          (
+            'thread-queued-oldest', 'project-runtime-candidates', 'Queued',
+            '{"provider":"codex","model":"gpt-5-codex"}', NULL, NULL, NULL,
+            '2026-07-21T00:00:00.000Z', '2026-07-21T00:00:00.000Z', NULL, NULL
           )
       `;
       yield* sql`
@@ -2041,20 +2046,28 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           (
             'thread-unbound-oldest', 'running', 'codex', NULL, NULL,
             'full-access', 'turn-unbound', NULL, '2026-07-22T00:00:00.000Z'
+          ),
+          (
+            'thread-queued-oldest', 'starting', 'codex', NULL, NULL,
+            'full-access', NULL, NULL, '2026-07-21T00:00:00.000Z'
           )
       `;
       yield* sql`
         INSERT INTO provider_session_runtime (
           thread_id, provider_name, adapter_key, runtime_mode, status,
-          lifecycle_generation, last_seen_at
+          lifecycle_generation, last_seen_at, runtime_payload_json
         ) VALUES
           (
             'thread-stale-running', 'codex', 'codex', 'full-access', 'running',
-            'generation-stale', '2026-07-23T00:00:00.000Z'
+            'generation-stale', '2026-07-23T00:00:00.000Z', NULL
           ),
           (
             'thread-fresh-running', 'codex', 'codex', 'full-access', 'running',
-            'generation-fresh', '2026-07-23T09:59:00.000Z'
+            'generation-fresh', '2026-07-23T09:59:00.000Z', NULL
+          ),
+          (
+            'thread-queued-oldest', 'codex', 'codex', 'full-access', 'starting',
+            'generation-queued', '2026-07-21T00:00:00.000Z', '{}'
           )
         ON CONFLICT (thread_id) DO UPDATE SET
           provider_name = excluded.provider_name,
@@ -2062,7 +2075,8 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           runtime_mode = excluded.runtime_mode,
           status = excluded.status,
           lifecycle_generation = excluded.lifecycle_generation,
-          last_seen_at = excluded.last_seen_at
+          last_seen_at = excluded.last_seen_at,
+          runtime_payload_json = excluded.runtime_payload_json
       `;
 
       const candidates = yield* snapshotQuery.listStaleInFlightThreadIds({

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -920,24 +920,12 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         WHERE threads.deleted_at IS NULL
           AND threads.archived_at IS NULL
           AND (
-            sessions.status IN ('starting', 'running')
-            OR (
+            (
               sessions.active_turn_id IS NOT NULL
               AND sessions.status <> 'error'
             )
-            OR latest_turn.state IN ('pending', 'running')
-          )
-          AND NOT (
-            sessions.status = 'starting'
-            AND sessions.active_turn_id IS NULL
-            AND (
-              latest_turn.state IS NULL
-              OR latest_turn.state NOT IN ('pending', 'running')
-            )
-            AND (
-              runtime.runtime_payload_json IS NULL
-              OR json_extract(runtime.runtime_payload_json, '$.activeTurnId') IS NULL
-            )
+            OR latest_turn.state = 'running'
+            OR json_extract(runtime.runtime_payload_json, '$.activeTurnId') IS NOT NULL
           )
           AND COALESCE(sessions.updated_at, threads.updated_at) <= ${updatedBefore}
         ORDER BY COALESCE(sessions.updated_at, threads.updated_at) ASC, threads.thread_id ASC

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -927,6 +927,18 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             )
             OR latest_turn.state IN ('pending', 'running')
           )
+          AND NOT (
+            sessions.status = 'starting'
+            AND sessions.active_turn_id IS NULL
+            AND (
+              latest_turn.state IS NULL
+              OR latest_turn.state NOT IN ('pending', 'running')
+            )
+            AND (
+              runtime.runtime_payload_json IS NULL
+              OR json_extract(runtime.runtime_payload_json, '$.activeTurnId') IS NULL
+            )
+          )
           AND COALESCE(sessions.updated_at, threads.updated_at) <= ${updatedBefore}
         ORDER BY COALESCE(sessions.updated_at, threads.updated_at) ASC, threads.thread_id ASC
         LIMIT ${Math.max(1, Math.min(1_000, Math.floor(limit)))}

--- a/apps/server/src/provider/Layers/ProviderRuntimeReconciler.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRuntimeReconciler.test.ts
@@ -79,7 +79,7 @@ function readyProviderSession(): ProviderSession {
 }
 
 describe("ProviderRuntimeReconcilerLive", () => {
-  it("persists an interrupted terminal state when the live provider has already settled", async () => {
+  it("retries a stale repair without duplicating its visible recovery activity", async () => {
     const commands: OrchestrationCommand[] = [];
     const reconcileSettledOpenTurns = vi.fn();
 
@@ -135,9 +135,13 @@ describe("ProviderRuntimeReconcilerLive", () => {
     await Effect.gen(function* () {
       const reconciler = yield* ProviderRuntimeReconciler;
       yield* reconciler.reconcileNow;
+      // The projection can remain stale for another observation cycle.
+      yield* reconciler.reconcileNow;
     }).pipe(Effect.provide(layer), Effect.runPromise);
 
     expect(commands.map((command) => command.type)).toEqual([
+      "thread.activity.append",
+      "thread.session.set",
       "thread.activity.append",
       "thread.session.set",
     ]);
@@ -159,6 +163,17 @@ describe("ProviderRuntimeReconcilerLive", () => {
         lastError: null,
       });
     }
-    expect(reconcileSettledOpenTurns).toHaveBeenCalledOnce();
+    const activityCommands = commands.filter(
+      (command): command is Extract<OrchestrationCommand, { type: "thread.activity.append" }> =>
+        command.type === "thread.activity.append",
+    );
+    const sessionCommands = commands.filter(
+      (command): command is Extract<OrchestrationCommand, { type: "thread.session.set" }> =>
+        command.type === "thread.session.set",
+    );
+    expect(activityCommands[0]?.activity.id).toBe(activityCommands[1]?.activity.id);
+    expect(activityCommands[0]?.commandId).not.toBe(activityCommands[1]?.commandId);
+    expect(sessionCommands[0]?.commandId).not.toBe(sessionCommands[1]?.commandId);
+    expect(reconcileSettledOpenTurns).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/server/src/provider/Layers/ProviderRuntimeReconciler.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRuntimeReconciler.test.ts
@@ -143,6 +143,7 @@ describe("ProviderRuntimeReconcilerLive", () => {
       providerSession = {
         ...providerSession,
         status: "error",
+        activeTurnId: TURN_ID,
         lastError: "Provider stream failed.",
       };
       yield* reconciler.reconcileNow;

--- a/apps/server/src/provider/Layers/ProviderRuntimeReconciler.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRuntimeReconciler.test.ts
@@ -54,10 +54,10 @@ function staleShellSnapshot(): OrchestrationShellSnapshot {
         },
         session: {
           threadId: THREAD_ID,
-          status: "running",
+          status: "ready",
           providerName: "codex",
           runtimeMode: "full-access",
-          activeTurnId: TURN_ID,
+          activeTurnId: null,
           lastError: null,
           updatedAt,
         },
@@ -79,7 +79,7 @@ function readyProviderSession(): ProviderSession {
 }
 
 describe("ProviderRuntimeReconcilerLive", () => {
-  it("retries a stale repair without duplicating its visible recovery activity", async () => {
+  it("retries a terminal-session turn repair without reopening the session", async () => {
     const commands: OrchestrationCommand[] = [];
     const reconcileSettledOpenTurns = vi.fn();
 
@@ -106,8 +106,8 @@ describe("ProviderRuntimeReconcilerLive", () => {
           {
             threadId: THREAD_ID,
             provider: "codex" as const,
-            status: "running" as const,
-            runtimePayload: { activeTurnId: TURN_ID },
+            status: "stopped" as const,
+            runtimePayload: { activeTurnId: null },
           },
         ]),
     } as unknown as ProviderSessionDirectoryShape;
@@ -151,14 +151,14 @@ describe("ProviderRuntimeReconcilerLive", () => {
       expect(activityCommand.activity.kind).toBe("provider.runtime.reconciled");
       expect(activityCommand.activity.summary).toContain("recovered");
       expect(activityCommand.activity.payload).toMatchObject({
-        action: "settle-interrupted",
+        action: "settle-terminal-projection",
       });
     }
     const sessionCommand = commands[1];
     expect(sessionCommand?.type).toBe("thread.session.set");
     if (sessionCommand?.type === "thread.session.set") {
       expect(sessionCommand.session).toMatchObject({
-        status: "interrupted",
+        status: "ready",
         activeTurnId: null,
         lastError: null,
       });

--- a/apps/server/src/provider/Layers/ProviderRuntimeReconciler.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRuntimeReconciler.test.ts
@@ -82,6 +82,8 @@ describe("ProviderRuntimeReconcilerLive", () => {
   it("retries a terminal-session turn repair without reopening the session", async () => {
     const commands: OrchestrationCommand[] = [];
     const reconcileSettledOpenTurns = vi.fn();
+    let bindingStatus: "stopped" | "error" = "stopped";
+    let providerSession = readyProviderSession();
 
     const engine = {
       dispatch: (command: OrchestrationCommand) =>
@@ -106,13 +108,13 @@ describe("ProviderRuntimeReconcilerLive", () => {
           {
             threadId: THREAD_ID,
             provider: "codex" as const,
-            status: "stopped" as const,
+            status: bindingStatus,
             runtimePayload: { activeTurnId: null },
           },
         ]),
     } as unknown as ProviderSessionDirectoryShape;
     const provider = {
-      listSessions: () => Effect.succeed([readyProviderSession()]),
+      listSessions: () => Effect.succeed([providerSession]),
       getRuntimeEventPumpHealth: () =>
         Effect.succeed([
           {
@@ -137,9 +139,18 @@ describe("ProviderRuntimeReconcilerLive", () => {
       yield* reconciler.reconcileNow;
       // The projection can remain stale for another observation cycle.
       yield* reconciler.reconcileNow;
+      bindingStatus = "error";
+      providerSession = {
+        ...providerSession,
+        status: "error",
+        lastError: "Provider stream failed.",
+      };
+      yield* reconciler.reconcileNow;
     }).pipe(Effect.provide(layer), Effect.runPromise);
 
     expect(commands.map((command) => command.type)).toEqual([
+      "thread.activity.append",
+      "thread.session.set",
       "thread.activity.append",
       "thread.session.set",
       "thread.activity.append",
@@ -163,6 +174,22 @@ describe("ProviderRuntimeReconcilerLive", () => {
         lastError: null,
       });
     }
+    const errorActivityCommand = commands[4];
+    expect(errorActivityCommand?.type).toBe("thread.activity.append");
+    if (errorActivityCommand?.type === "thread.activity.append") {
+      expect(errorActivityCommand.activity.payload).toMatchObject({
+        action: "settle-error",
+      });
+    }
+    const errorSessionCommand = commands[5];
+    expect(errorSessionCommand?.type).toBe("thread.session.set");
+    if (errorSessionCommand?.type === "thread.session.set") {
+      expect(errorSessionCommand.session).toMatchObject({
+        status: "error",
+        activeTurnId: TURN_ID,
+        lastError: "Provider stream failed.",
+      });
+    }
     const activityCommands = commands.filter(
       (command): command is Extract<OrchestrationCommand, { type: "thread.activity.append" }> =>
         command.type === "thread.activity.append",
@@ -174,6 +201,6 @@ describe("ProviderRuntimeReconcilerLive", () => {
     expect(activityCommands[0]?.activity.id).toBe(activityCommands[1]?.activity.id);
     expect(activityCommands[0]?.commandId).not.toBe(activityCommands[1]?.commandId);
     expect(sessionCommands[0]?.commandId).not.toBe(sessionCommands[1]?.commandId);
-    expect(reconcileSettledOpenTurns).toHaveBeenCalledTimes(2);
+    expect(reconcileSettledOpenTurns).toHaveBeenCalledTimes(3);
   });
 });

--- a/apps/server/src/provider/Layers/ProviderRuntimeReconciler.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRuntimeReconciler.test.ts
@@ -173,6 +173,7 @@ describe("ProviderRuntimeReconcilerLive", () => {
         status: "ready",
         activeTurnId: null,
         lastError: null,
+        updatedAt: "2026-07-23T19:00:00.000Z",
       });
     }
     const errorActivityCommand = commands[4];

--- a/apps/server/src/provider/Layers/ProviderRuntimeReconciler.ts
+++ b/apps/server/src/provider/Layers/ProviderRuntimeReconciler.ts
@@ -34,13 +34,10 @@ export interface ProviderRuntimeReconcilerLiveOptions {
   readonly candidateLimit?: number;
 }
 
-function reconciliationKey(
-  plan: ProviderRuntimeReconciliationPlan,
-  observationSequence: number,
-): string {
+function reconciliationKey(plan: ProviderRuntimeReconciliationPlan): string {
   return [
     "provider-runtime-reconcile",
-    observationSequence,
+    plan.provider,
     plan.action,
     plan.threadId,
     plan.projectedTurnId ?? "none",
@@ -75,12 +72,16 @@ const make = (options?: ProviderRuntimeReconcilerLiveOptions) =>
       plan: ProviderRuntimeReconciliationPlan,
       runtimeMode: RuntimeMode,
       now: string,
-      observationSequence: number,
     ) {
-      const key = reconciliationKey(plan, observationSequence);
+      const key = reconciliationKey(plan);
+      // Command ids identify attempts because timestamps can legitimately
+      // change between retries. The activity id identifies the semantic repair,
+      // allowing projectors to suppress a repeated visible recovery while a
+      // failed or lagging session update remains safe to retry.
+      const attemptKey = `${key}:${crypto.randomUUID()}`;
       yield* orchestrationEngine.dispatch({
         type: "thread.activity.append",
-        commandId: CommandId.makeUnsafe(`${key}:activity`),
+        commandId: CommandId.makeUnsafe(`${attemptKey}:activity`),
         threadId: plan.threadId,
         activity: {
           id: EventId.makeUnsafe(`${key}:activity`),
@@ -104,7 +105,7 @@ const make = (options?: ProviderRuntimeReconcilerLiveOptions) =>
       });
       yield* orchestrationEngine.dispatch({
         type: "thread.session.set",
-        commandId: CommandId.makeUnsafe(`${key}:session`),
+        commandId: CommandId.makeUnsafe(`${attemptKey}:session`),
         threadId: plan.threadId,
         session: {
           threadId: plan.threadId,
@@ -121,20 +122,18 @@ const make = (options?: ProviderRuntimeReconcilerLiveOptions) =>
 
     const reconcileNow = Effect.gen(function* () {
       const nowMs = Date.now();
-      const [candidateThreadIds, snapshotSequence, bindings, liveSessions, pumpHealth] =
-        yield* Effect.all(
-          [
-            projectionSnapshotQuery.listStaleInFlightThreadIds({
-              updatedBefore: new Date(nowMs - staleAfterMs).toISOString(),
-              limit: candidateLimit,
-            }),
-            projectionSnapshotQuery.getSnapshotSequence(),
-            directory.listBindings(),
-            providerService.listSessions(),
-            providerService.getRuntimeEventPumpHealth?.() ?? Effect.succeed([]),
-          ],
-          { concurrency: 5 },
-        );
+      const [candidateThreadIds, bindings, liveSessions, pumpHealth] = yield* Effect.all(
+        [
+          projectionSnapshotQuery.listStaleInFlightThreadIds({
+            updatedBefore: new Date(nowMs - staleAfterMs).toISOString(),
+            limit: candidateLimit,
+          }),
+          directory.listBindings(),
+          providerService.listSessions(),
+          providerService.getRuntimeEventPumpHealth?.() ?? Effect.succeed([]),
+        ],
+        { concurrency: 5 },
+      );
       if (candidateThreadIds.length === 0) return;
       const threads = (yield* Effect.forEach(
         candidateThreadIds,
@@ -162,12 +161,7 @@ const make = (options?: ProviderRuntimeReconcilerLiveOptions) =>
         (plan) => {
           const thread = threadById.get(plan.threadId);
           if (!thread) return Effect.void;
-          return applyPlan(
-            plan,
-            thread.session?.runtimeMode ?? thread.runtimeMode,
-            now,
-            snapshotSequence.snapshotSequence,
-          ).pipe(
+          return applyPlan(plan, thread.session?.runtimeMode ?? thread.runtimeMode, now).pipe(
             Effect.catchCause((cause) =>
               Effect.logWarning("provider.runtime_reconciliation.plan_failed", {
                 threadId: plan.threadId,

--- a/apps/server/src/provider/Layers/ProviderRuntimeReconciler.ts
+++ b/apps/server/src/provider/Layers/ProviderRuntimeReconciler.ts
@@ -112,9 +112,11 @@ const make = (options?: ProviderRuntimeReconcilerLiveOptions) =>
           status:
             plan.action === "align-running-turn"
               ? "running"
-              : plan.action === "settle-terminal-projection"
-                ? plan.terminalSession.status
-                : "interrupted",
+              : plan.action === "settle-error"
+                ? "error"
+                : plan.action === "settle-terminal-projection"
+                  ? plan.terminalSession.status
+                  : "interrupted",
           providerName:
             plan.action === "settle-terminal-projection"
               ? plan.terminalSession.providerName
@@ -126,14 +128,18 @@ const make = (options?: ProviderRuntimeReconcilerLiveOptions) =>
           activeTurnId:
             plan.action === "align-running-turn"
               ? plan.runtimeTurnId
-              : plan.action === "settle-terminal-projection" &&
-                  plan.terminalSession.status === "error"
-                ? plan.terminalSession.activeTurnId
-                : null,
+              : plan.action === "settle-error"
+                ? plan.projectedTurnId
+                : plan.action === "settle-terminal-projection" &&
+                    plan.terminalSession.status === "error"
+                  ? plan.terminalSession.activeTurnId
+                  : null,
           lastError:
-            plan.action === "settle-terminal-projection"
-              ? plan.terminalSession.lastError
-              : null,
+            plan.action === "settle-error"
+              ? plan.errorMessage
+              : plan.action === "settle-terminal-projection"
+                ? plan.terminalSession.lastError
+                : null,
           updatedAt: now,
         },
         createdAt: now,

--- a/apps/server/src/provider/Layers/ProviderRuntimeReconciler.ts
+++ b/apps/server/src/provider/Layers/ProviderRuntimeReconciler.ts
@@ -109,11 +109,31 @@ const make = (options?: ProviderRuntimeReconcilerLiveOptions) =>
         threadId: plan.threadId,
         session: {
           threadId: plan.threadId,
-          status: plan.action === "align-running-turn" ? "running" : "interrupted",
-          providerName: plan.provider,
-          runtimeMode,
-          activeTurnId: plan.action === "align-running-turn" ? plan.runtimeTurnId : null,
-          lastError: null,
+          status:
+            plan.action === "align-running-turn"
+              ? "running"
+              : plan.action === "settle-terminal-projection"
+                ? plan.terminalSession.status
+                : "interrupted",
+          providerName:
+            plan.action === "settle-terminal-projection"
+              ? plan.terminalSession.providerName
+              : plan.provider,
+          runtimeMode:
+            plan.action === "settle-terminal-projection"
+              ? plan.terminalSession.runtimeMode
+              : runtimeMode,
+          activeTurnId:
+            plan.action === "align-running-turn"
+              ? plan.runtimeTurnId
+              : plan.action === "settle-terminal-projection" &&
+                  plan.terminalSession.status === "error"
+                ? plan.terminalSession.activeTurnId
+                : null,
+          lastError:
+            plan.action === "settle-terminal-projection"
+              ? plan.terminalSession.lastError
+              : null,
           updatedAt: now,
         },
         createdAt: now,

--- a/apps/server/src/provider/Layers/ProviderRuntimeReconciler.ts
+++ b/apps/server/src/provider/Layers/ProviderRuntimeReconciler.ts
@@ -35,14 +35,13 @@ export interface ProviderRuntimeReconcilerLiveOptions {
 }
 
 function reconciliationKey(plan: ProviderRuntimeReconciliationPlan): string {
-  return [
-    "provider-runtime-reconcile",
+  return `provider-runtime-reconcile:${JSON.stringify([
     plan.provider,
     plan.action,
     plan.threadId,
-    plan.projectedTurnId ?? "none",
-    plan.runtimeTurnId ?? "none",
-  ].join(":");
+    plan.projectedTurnId,
+    plan.runtimeTurnId,
+  ])}`;
 }
 
 const make = (options?: ProviderRuntimeReconcilerLiveOptions) =>
@@ -140,7 +139,10 @@ const make = (options?: ProviderRuntimeReconcilerLiveOptions) =>
               : plan.action === "settle-terminal-projection"
                 ? plan.terminalSession.lastError
                 : null,
-          updatedAt: now,
+          updatedAt:
+            plan.action === "settle-terminal-projection"
+              ? plan.terminalSession.updatedAt
+              : now,
         },
         createdAt: now,
       });

--- a/apps/server/src/provider/providerRuntimeReconciliation.test.ts
+++ b/apps/server/src/provider/providerRuntimeReconciliation.test.ts
@@ -304,26 +304,37 @@ describe("planProviderRuntimeReconciliation", () => {
     ]);
   });
 
-  it("does not reopen a settled session because its latest turn is stale", () => {
-    const plans = planProviderRuntimeReconciliation({
-      threads: [
-        threadShell({
-          session: {
-            ...threadShell().session!,
-            status: "interrupted",
-            activeTurnId: null,
-          },
-        }),
-      ],
-      bindings: [binding(null)],
-      liveSessions: [liveSession({ status: "ready" })],
-      pumpHealth: [],
-      nowMs: NOW,
-      staleAfterMs: 10_000,
-    });
+  it.each(["ready", "interrupted", "stopped", "error"] as const)(
+    "settles a stale running turn without reopening its %s session",
+    (status) => {
+      const terminalSession = {
+        ...threadShell().session!,
+        status,
+        activeTurnId: null,
+      };
+      const plans = planProviderRuntimeReconciliation({
+        threads: [
+          threadShell({
+            session: terminalSession,
+          }),
+        ],
+        bindings: [binding(null)],
+        liveSessions: [liveSession({ status: "ready" })],
+        pumpHealth: [],
+        nowMs: NOW,
+        staleAfterMs: 10_000,
+      });
 
-    expect(plans).toEqual([]);
-  });
+      expect(plans).toEqual([
+        expect.objectContaining({
+          action: "settle-terminal-projection",
+          projectedTurnId: OLD_TURN_ID,
+          runtimeTurnId: null,
+          terminalSession,
+        }),
+      ]);
+    },
+  );
 
   it("records degraded pump evidence in the reconciliation reason", () => {
     const plans = planProviderRuntimeReconciliation({

--- a/apps/server/src/provider/providerRuntimeReconciliation.test.ts
+++ b/apps/server/src/provider/providerRuntimeReconciliation.test.ts
@@ -84,6 +84,7 @@ function liveSession(input: {
   readonly status: ProviderSession["status"];
   readonly activeTurnId?: TurnId;
   readonly provider?: ProviderSession["provider"];
+  readonly lastError?: string;
 }): ProviderSession {
   return {
     provider: input.provider ?? "codex",
@@ -91,6 +92,7 @@ function liveSession(input: {
     runtimeMode: "full-access",
     threadId: THREAD_ID,
     ...(input.activeTurnId !== undefined ? { activeTurnId: input.activeTurnId } : {}),
+    ...(input.lastError !== undefined ? { lastError: input.lastError } : {}),
     createdAt: "2026-07-23T19:00:00.000Z",
     updatedAt: "2026-07-23T20:00:25.000Z",
   };
@@ -152,21 +154,28 @@ describe("planProviderRuntimeReconciliation", () => {
     ]);
   });
 
-  it("trusts a terminal live status over stale active-turn metadata", () => {
+  it("trusts a terminal live error over stale active-turn metadata", () => {
     expect(
       planProviderRuntimeReconciliation({
         threads: [threadShell()],
         bindings: [binding()],
-        liveSessions: [liveSession({ status: "error", activeTurnId: OLD_TURN_ID })],
+        liveSessions: [
+          liveSession({
+            status: "error",
+            activeTurnId: OLD_TURN_ID,
+            lastError: "Provider process exited.",
+          }),
+        ],
         pumpHealth: [],
         nowMs: NOW,
         staleAfterMs: 10_000,
       }),
     ).toEqual([
       expect.objectContaining({
-        action: "settle-interrupted",
+        action: "settle-error",
         projectedTurnId: OLD_TURN_ID,
         runtimeTurnId: null,
+        errorMessage: "Provider process exited.",
       }),
     ]);
   });
@@ -304,6 +313,33 @@ describe("planProviderRuntimeReconciliation", () => {
     ]);
   });
 
+  it("retains a running latest turn when its starting session update was partial", () => {
+    const plans = planProviderRuntimeReconciliation({
+      threads: [
+        threadShell({
+          session: {
+            ...threadShell().session!,
+            status: "starting",
+            activeTurnId: null,
+          },
+        }),
+      ],
+      bindings: [binding(null)],
+      liveSessions: [liveSession({ status: "ready" })],
+      pumpHealth: [],
+      nowMs: NOW,
+      staleAfterMs: 10_000,
+    });
+
+    expect(plans).toEqual([
+      expect.objectContaining({
+        action: "settle-interrupted",
+        projectedTurnId: OLD_TURN_ID,
+        runtimeTurnId: null,
+      }),
+    ]);
+  });
+
   it.each(["ready", "interrupted", "stopped", "error"] as const)(
     "settles a stale running turn without reopening its %s session",
     (status) => {
@@ -335,6 +371,39 @@ describe("planProviderRuntimeReconciliation", () => {
       ]);
     },
   );
+
+  it("does not let stale readiness complete a turn after a live provider error", () => {
+    const plans = planProviderRuntimeReconciliation({
+      threads: [
+        threadShell({
+          session: {
+            ...threadShell().session!,
+            status: "ready",
+            activeTurnId: null,
+          },
+        }),
+      ],
+      bindings: [binding(null)],
+      liveSessions: [
+        liveSession({
+          status: "error",
+          lastError: "Provider stream failed.",
+        }),
+      ],
+      pumpHealth: [],
+      nowMs: NOW,
+      staleAfterMs: 10_000,
+    });
+
+    expect(plans).toEqual([
+      expect.objectContaining({
+        action: "settle-error",
+        projectedTurnId: OLD_TURN_ID,
+        runtimeTurnId: null,
+        errorMessage: "Provider stream failed.",
+      }),
+    ]);
+  });
 
   it("records degraded pump evidence in the reconciliation reason", () => {
     const plans = planProviderRuntimeReconciliation({

--- a/apps/server/src/provider/providerRuntimeReconciliation.test.ts
+++ b/apps/server/src/provider/providerRuntimeReconciliation.test.ts
@@ -246,6 +246,85 @@ describe("planProviderRuntimeReconciliation", () => {
     expect(settledWithoutSession).toEqual([]);
   });
 
+  it("does not recover a queued startup that has no concrete in-flight turn", () => {
+    const plans = planProviderRuntimeReconciliation({
+      threads: [
+        threadShell({
+          latestTurn: {
+            ...threadShell().latestTurn!,
+            state: "completed",
+            completedAt: "2026-07-23T20:00:05.000Z",
+          },
+          session: {
+            ...threadShell().session!,
+            status: "starting",
+            activeTurnId: null,
+          },
+        }),
+      ],
+      bindings: [binding(null)],
+      liveSessions: [liveSession({ status: "ready" })],
+      pumpHealth: [],
+      nowMs: NOW,
+      staleAfterMs: 10_000,
+    });
+
+    expect(plans).toEqual([]);
+  });
+
+  it("aligns a queued startup when the live provider has acquired a turn", () => {
+    const plans = planProviderRuntimeReconciliation({
+      threads: [
+        threadShell({
+          latestTurn: {
+            ...threadShell().latestTurn!,
+            state: "completed",
+            completedAt: "2026-07-23T20:00:05.000Z",
+          },
+          session: {
+            ...threadShell().session!,
+            status: "starting",
+            activeTurnId: null,
+          },
+        }),
+      ],
+      bindings: [binding(LIVE_TURN_ID)],
+      liveSessions: [liveSession({ status: "running", activeTurnId: LIVE_TURN_ID })],
+      pumpHealth: [],
+      nowMs: NOW,
+      staleAfterMs: 10_000,
+    });
+
+    expect(plans).toEqual([
+      expect.objectContaining({
+        action: "align-running-turn",
+        projectedTurnId: null,
+        runtimeTurnId: LIVE_TURN_ID,
+      }),
+    ]);
+  });
+
+  it("does not reopen a settled session because its latest turn is stale", () => {
+    const plans = planProviderRuntimeReconciliation({
+      threads: [
+        threadShell({
+          session: {
+            ...threadShell().session!,
+            status: "interrupted",
+            activeTurnId: null,
+          },
+        }),
+      ],
+      bindings: [binding(null)],
+      liveSessions: [liveSession({ status: "ready" })],
+      pumpHealth: [],
+      nowMs: NOW,
+      staleAfterMs: 10_000,
+    });
+
+    expect(plans).toEqual([]);
+  });
+
   it("records degraded pump evidence in the reconciliation reason", () => {
     const plans = planProviderRuntimeReconciliation({
       threads: [threadShell()],

--- a/apps/server/src/provider/providerRuntimeReconciliation.test.ts
+++ b/apps/server/src/provider/providerRuntimeReconciliation.test.ts
@@ -424,12 +424,37 @@ describe("planProviderRuntimeReconciliation", () => {
 
     expect(plans).toEqual([
       expect.objectContaining({
-        action: "settle-error",
+        action: "settle-interrupted",
         projectedTurnId: OLD_TURN_ID,
         runtimeTurnId: null,
-        errorMessage: "Provider stream failed.",
       }),
     ]);
+  });
+
+  it("does not attribute a live provider error to a different projected turn", () => {
+    const plans = planProviderRuntimeReconciliation({
+      threads: [threadShell()],
+      bindings: [binding(LIVE_TURN_ID)],
+      liveSessions: [
+        liveSession({
+          status: "error",
+          activeTurnId: LIVE_TURN_ID,
+          lastError: "Newer provider turn failed.",
+        }),
+      ],
+      pumpHealth: [],
+      nowMs: NOW,
+      staleAfterMs: 10_000,
+    });
+
+    expect(plans).toEqual([
+      expect.objectContaining({
+        action: "settle-interrupted",
+        projectedTurnId: OLD_TURN_ID,
+        runtimeTurnId: null,
+      }),
+    ]);
+    expect(plans[0]?.reason).toContain(LIVE_TURN_ID);
   });
 
   it("prefers a recovered live session over a stale durable binding error", () => {

--- a/apps/server/src/provider/providerRuntimeReconciliation.test.ts
+++ b/apps/server/src/provider/providerRuntimeReconciliation.test.ts
@@ -340,6 +340,33 @@ describe("planProviderRuntimeReconciliation", () => {
     ]);
   });
 
+  it("settles a running latest turn projected under an idle session", () => {
+    const plans = planProviderRuntimeReconciliation({
+      threads: [
+        threadShell({
+          session: {
+            ...threadShell().session!,
+            status: "idle",
+            activeTurnId: null,
+          },
+        }),
+      ],
+      bindings: [binding(null)],
+      liveSessions: [liveSession({ status: "ready" })],
+      pumpHealth: [],
+      nowMs: NOW,
+      staleAfterMs: 10_000,
+    });
+
+    expect(plans).toEqual([
+      expect.objectContaining({
+        action: "settle-interrupted",
+        projectedTurnId: OLD_TURN_ID,
+        runtimeTurnId: null,
+      }),
+    ]);
+  });
+
   it.each(["ready", "interrupted", "stopped", "error"] as const)(
     "settles a stale running turn without reopening its %s session",
     (status) => {
@@ -401,6 +428,39 @@ describe("planProviderRuntimeReconciliation", () => {
         projectedTurnId: OLD_TURN_ID,
         runtimeTurnId: null,
         errorMessage: "Provider stream failed.",
+      }),
+    ]);
+  });
+
+  it("prefers a recovered live session over a stale durable binding error", () => {
+    const terminalSession = {
+      ...threadShell().session!,
+      status: "ready" as const,
+      activeTurnId: null,
+    };
+    const plans = planProviderRuntimeReconciliation({
+      threads: [threadShell({ session: terminalSession })],
+      bindings: [
+        {
+          ...binding(null),
+          status: "error",
+          runtimePayload: {
+            activeTurnId: null,
+            lastError: "Previous provider failure.",
+          },
+        },
+      ],
+      liveSessions: [liveSession({ status: "ready" })],
+      pumpHealth: [],
+      nowMs: NOW,
+      staleAfterMs: 10_000,
+    });
+
+    expect(plans).toEqual([
+      expect.objectContaining({
+        action: "settle-terminal-projection",
+        projectedTurnId: OLD_TURN_ID,
+        terminalSession,
       }),
     ]);
   });

--- a/apps/server/src/provider/providerRuntimeReconciliation.ts
+++ b/apps/server/src/provider/providerRuntimeReconciliation.ts
@@ -120,6 +120,14 @@ function bindingLastError(binding: ProviderRuntimeBinding): string | null {
     : null;
 }
 
+function bindingActiveTurnId(binding: ProviderRuntimeBinding): string | null {
+  const payload = binding.runtimePayload;
+  if (typeof payload !== "object" || payload === null || !("activeTurnId" in payload)) {
+    return null;
+  }
+  return typeof payload.activeTurnId === "string" ? payload.activeTurnId : null;
+}
+
 export function planProviderRuntimeReconciliation(input: {
   readonly threads: ReadonlyArray<OrchestrationThreadShell>;
   readonly bindings: ReadonlyArray<ProviderRuntimeBinding>;
@@ -184,6 +192,23 @@ export function planProviderRuntimeReconciliation(input: {
     if (!liveSessionSettled && !missingLiveSession && !bindingSettled) continue;
 
     if (liveSession?.status === "error" || (missingLiveSession && binding.status === "error")) {
+      const errorTurnId =
+        liveSession?.status === "error"
+          ? (liveSession.activeTurnId ?? null)
+          : bindingActiveTurnId(binding);
+      if (errorTurnId !== projectedTurnId) {
+        plans.push({
+          action: "settle-interrupted",
+          threadId: thread.id,
+          provider: binding.provider,
+          projectedTurnId,
+          runtimeTurnId: null,
+          reason:
+            `The provider reported an error for turn '${errorTurnId ?? "unknown"}', which cannot ` +
+            `be safely attributed to projected turn '${projectedTurnId}'.${detail}`,
+        });
+        continue;
+      }
       const errorMessage =
         liveSession?.lastError ??
         bindingLastError(binding) ??

--- a/apps/server/src/provider/providerRuntimeReconciliation.ts
+++ b/apps/server/src/provider/providerRuntimeReconciliation.ts
@@ -8,6 +8,7 @@
  * @module providerRuntimeReconciliation
  */
 import type {
+  OrchestrationSession,
   OrchestrationThreadShell,
   ProviderSession,
   ThreadId,
@@ -35,19 +36,41 @@ export type ProviderRuntimeReconciliationPlan =
       readonly projectedTurnId: TurnId | null;
       readonly runtimeTurnId: null;
       readonly reason: string;
+    }
+  | {
+      readonly action: "settle-terminal-projection";
+      readonly threadId: ThreadId;
+      readonly provider: ProviderRuntimeBinding["provider"];
+      readonly projectedTurnId: TurnId;
+      readonly runtimeTurnId: null;
+      readonly terminalSession: TerminalProjectedSession;
+      readonly reason: string;
     };
+
+type TerminalProjectedSession = Omit<OrchestrationSession, "status"> & {
+  readonly status: "ready" | "interrupted" | "stopped" | "error";
+};
+
+function terminalProjectedSession(
+  thread: OrchestrationThreadShell,
+): TerminalProjectedSession | null {
+  const session = thread.session;
+  if (session === null) return null;
+
+  switch (session.status) {
+    case "ready":
+    case "interrupted":
+    case "stopped":
+    case "error":
+      return { ...session, status: session.status };
+    case "starting":
+    case "running":
+      return null;
+  }
+}
 
 function projectedInFlightTurnId(thread: OrchestrationThreadShell): TurnId | null {
   const session = thread.session;
-  if (
-    session !== null &&
-    (session.status === "ready" ||
-      session.status === "interrupted" ||
-      session.status === "stopped" ||
-      session.status === "error")
-  ) {
-    return null;
-  }
   // A queued start has no provider turn yet. Falling back to latestTurn here
   // can attach the new request to an older terminal (or ingestion-lagged) turn.
   if (session?.status === "starting" && session.activeTurnId === null) {
@@ -133,6 +156,24 @@ export function planProviderRuntimeReconciliation(input: {
     const bindingSettled = binding.status === "stopped" || binding.status === "error";
 
     if (!liveSessionSettled && !missingLiveSession && !bindingSettled) continue;
+
+    const terminalSession = terminalProjectedSession(thread);
+    if (terminalSession !== null) {
+      plans.push({
+        action: "settle-terminal-projection",
+        threadId: thread.id,
+        provider: binding.provider,
+        projectedTurnId,
+        runtimeTurnId: null,
+        terminalSession,
+        reason: liveSessionSettled
+          ? `The live provider session is '${liveSession.status}', but terminal projection '${terminalSession.status}' still has a running turn.${detail}`
+          : bindingSettled
+            ? `The durable provider binding is '${binding.status}', but terminal projection '${terminalSession.status}' still has a running turn.${detail}`
+            : `Terminal projection '${terminalSession.status}' still has a running turn, but the provider Adapter no longer owns a live session.${detail}`,
+      });
+      continue;
+    }
 
     plans.push({
       action: "settle-interrupted",

--- a/apps/server/src/provider/providerRuntimeReconciliation.ts
+++ b/apps/server/src/provider/providerRuntimeReconciliation.ts
@@ -72,6 +72,7 @@ function terminalProjectedSession(
     case "stopped":
     case "error":
       return { ...session, status: session.status };
+    case "idle":
     case "starting":
     case "running":
       return null;
@@ -177,11 +178,12 @@ export function planProviderRuntimeReconciliation(input: {
         liveSession.status === "closed" ||
         liveSession.status === "error");
     const missingLiveSession = liveSession === undefined;
-    const bindingSettled = binding.status === "stopped" || binding.status === "error";
+    const bindingSettled =
+      missingLiveSession && (binding.status === "stopped" || binding.status === "error");
 
     if (!liveSessionSettled && !missingLiveSession && !bindingSettled) continue;
 
-    if (liveSession?.status === "error" || binding.status === "error") {
+    if (liveSession?.status === "error" || (missingLiveSession && binding.status === "error")) {
       const errorMessage =
         liveSession?.lastError ??
         bindingLastError(binding) ??

--- a/apps/server/src/provider/providerRuntimeReconciliation.ts
+++ b/apps/server/src/provider/providerRuntimeReconciliation.ts
@@ -37,15 +37,25 @@ export type ProviderRuntimeReconciliationPlan =
       readonly reason: string;
     };
 
-function hasProjectedInFlightTurn(thread: OrchestrationThreadShell): boolean {
-  return (
-    thread.session?.status === "starting" ||
-    thread.session?.status === "running" ||
-    (thread.session !== null &&
-      thread.session.status !== "error" &&
-      thread.session.activeTurnId !== null) ||
-    thread.latestTurn?.state === "running"
-  );
+function projectedInFlightTurnId(thread: OrchestrationThreadShell): TurnId | null {
+  const session = thread.session;
+  if (
+    session !== null &&
+    (session.status === "ready" ||
+      session.status === "interrupted" ||
+      session.status === "stopped" ||
+      session.status === "error")
+  ) {
+    return null;
+  }
+  // A queued start has no provider turn yet. Falling back to latestTurn here
+  // can attach the new request to an older terminal (or ingestion-lagged) turn.
+  if (session?.status === "starting" && session.activeTurnId === null) {
+    return null;
+  }
+  return session?.activeTurnId ?? (thread.latestTurn?.state === "running"
+    ? thread.latestTurn.turnId
+    : null);
 }
 
 function projectedLifecycleAgeMs(thread: OrchestrationThreadShell, nowMs: number): number {
@@ -82,7 +92,6 @@ export function planProviderRuntimeReconciliation(input: {
   const plans: ProviderRuntimeReconciliationPlan[] = [];
 
   for (const thread of input.threads) {
-    if (!hasProjectedInFlightTurn(thread)) continue;
     if (projectedLifecycleAgeMs(thread, input.nowMs) < staleAfterMs) continue;
 
     // Native child threads share a parent session and intentionally have no
@@ -90,7 +99,7 @@ export function planProviderRuntimeReconciliation(input: {
     const binding = bindingByThreadId.get(thread.id);
     if (!binding) continue;
 
-    const projectedTurnId = thread.session?.activeTurnId ?? thread.latestTurn?.turnId ?? null;
+    const projectedTurnId = projectedInFlightTurnId(thread);
     const liveSession = liveSessionByThreadId.get(thread.id);
     const liveTurnId = liveSession?.activeTurnId ?? null;
     const detail = pumpDetail(binding.provider, healthByProvider);
@@ -110,6 +119,9 @@ export function planProviderRuntimeReconciliation(input: {
       continue;
     }
 
+    // Settling a projection is only safe when it names a concrete in-flight
+    // turn. ProviderCommandReactor owns failures before a start acquires one.
+    if (projectedTurnId === null) continue;
     if (liveSession?.status === "connecting") continue;
 
     const liveSessionSettled =

--- a/apps/server/src/provider/providerRuntimeReconciliation.ts
+++ b/apps/server/src/provider/providerRuntimeReconciliation.ts
@@ -45,6 +45,15 @@ export type ProviderRuntimeReconciliationPlan =
       readonly runtimeTurnId: null;
       readonly terminalSession: TerminalProjectedSession;
       readonly reason: string;
+    }
+  | {
+      readonly action: "settle-error";
+      readonly threadId: ThreadId;
+      readonly provider: ProviderRuntimeBinding["provider"];
+      readonly projectedTurnId: TurnId;
+      readonly runtimeTurnId: null;
+      readonly errorMessage: string;
+      readonly reason: string;
     };
 
 type TerminalProjectedSession = Omit<OrchestrationSession, "status"> & {
@@ -73,7 +82,11 @@ function projectedInFlightTurnId(thread: OrchestrationThreadShell): TurnId | nul
   const session = thread.session;
   // A queued start has no provider turn yet. Falling back to latestTurn here
   // can attach the new request to an older terminal (or ingestion-lagged) turn.
-  if (session?.status === "starting" && session.activeTurnId === null) {
+  if (
+    session?.status === "starting" &&
+    session.activeTurnId === null &&
+    thread.latestTurn?.state !== "running"
+  ) {
     return null;
   }
   return session?.activeTurnId ?? (thread.latestTurn?.state === "running"
@@ -93,6 +106,17 @@ function pumpDetail(
   const health = healthByProvider.get(provider);
   if (!health || health.status === "healthy") return "";
   return ` The ${provider} runtime-event pump is ${health.status}.`;
+}
+
+function bindingLastError(binding: ProviderRuntimeBinding): string | null {
+  const payload = binding.runtimePayload;
+  if (typeof payload !== "object" || payload === null || !("lastError" in payload)) {
+    return null;
+  }
+  const lastError = payload.lastError;
+  return typeof lastError === "string" && lastError.trim().length > 0
+    ? lastError.trim()
+    : null;
 }
 
 export function planProviderRuntimeReconciliation(input: {
@@ -156,6 +180,26 @@ export function planProviderRuntimeReconciliation(input: {
     const bindingSettled = binding.status === "stopped" || binding.status === "error";
 
     if (!liveSessionSettled && !missingLiveSession && !bindingSettled) continue;
+
+    if (liveSession?.status === "error" || binding.status === "error") {
+      const errorMessage =
+        liveSession?.lastError ??
+        bindingLastError(binding) ??
+        "Provider runtime reported an error while reconciling a stale turn.";
+      plans.push({
+        action: "settle-error",
+        threadId: thread.id,
+        provider: binding.provider,
+        projectedTurnId,
+        runtimeTurnId: null,
+        errorMessage,
+        reason:
+          liveSession?.status === "error"
+            ? `The live provider session failed while the projection still had running turn '${projectedTurnId}'.${detail}`
+            : `The durable provider binding failed while the projection still had running turn '${projectedTurnId}'.${detail}`,
+      });
+      continue;
+    }
 
     const terminalSession = terminalProjectedSession(thread);
     if (terminalSession !== null) {

--- a/apps/server/src/wsCompatibility.test.ts
+++ b/apps/server/src/wsCompatibility.test.ts
@@ -2,6 +2,7 @@ import {
   WS_PROTOCOL_EPOCH,
   WS_PROTOCOL_MAX_REVISION,
   WS_PROTOCOL_MIN_REVISION,
+  WS_SERVER_CAPABILITIES,
 } from "@synara/contracts";
 import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
@@ -20,7 +21,7 @@ describe("WebSocket compatibility bootstrap", () => {
         minRevision: WS_PROTOCOL_MIN_REVISION,
         maxRevision: WS_PROTOCOL_MAX_REVISION,
         clientBuild: "test-client",
-        requiredCapabilities: ["orchestration.cursor-safe-streams"],
+        requiredCapabilities: [...WS_SERVER_CAPABILITIES],
       }),
     );
 
@@ -31,6 +32,7 @@ describe("WebSocket compatibility bootstrap", () => {
     expect(result.serverBuild.length).toBeGreaterThan(0);
     expect(result.serverInstanceId.length).toBeGreaterThan(0);
     expect(result.capabilities).toContain("orchestration.cursor-safe-streams");
+    expect(result.capabilities).toContain("orchestration.thread-detail-snapshot");
   });
 
   it("returns terminal update guidance and rejects feature calls without negotiated query data", async () => {

--- a/apps/server/src/wsRequestAdmission.test.ts
+++ b/apps/server/src/wsRequestAdmission.test.ts
@@ -7,6 +7,9 @@ import { classifyWsRequest, makeWsRequestAdmission } from "./wsRequestAdmission"
 describe("WsRequestAdmission", () => {
   it("keeps lightweight shell reads out of the expensive lane", () => {
     expect(classifyWsRequest(ORCHESTRATION_WS_METHODS.getShellSnapshot)).toBe("standard");
+    expect(classifyWsRequest(ORCHESTRATION_WS_METHODS.getThreadDetailSnapshot)).toBe(
+      "expensive-read",
+    );
     expect(classifyWsRequest(ORCHESTRATION_WS_METHODS.getTurnDiff)).toBe("expensive-read");
     expect(classifyWsRequest(ORCHESTRATION_WS_METHODS.repairState)).toBe("expensive-read");
     expect(classifyWsRequest(WS_METHODS.terminalAckOutput)).toBe("control");

--- a/apps/server/src/wsRequestAdmission.ts
+++ b/apps/server/src/wsRequestAdmission.ts
@@ -26,6 +26,7 @@ const CONTROL_METHODS = new Set<string>([
 
 const EXPENSIVE_READ_METHODS = new Set<string>([
   ORCHESTRATION_WS_METHODS.getSnapshot,
+  ORCHESTRATION_WS_METHODS.getThreadDetailSnapshot,
   ORCHESTRATION_WS_METHODS.repairState,
   ORCHESTRATION_WS_METHODS.getTurnDiff,
   ORCHESTRATION_WS_METHODS.getFullThreadDiff,

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -783,6 +783,13 @@ const makeWsRpcHandlersLayer = () =>
             projectionReadModelQuery.getShellSnapshot(),
             "Failed to load orchestration shell snapshot",
           ),
+        [ORCHESTRATION_WS_METHODS.getThreadDetailSnapshot]: (input) =>
+          rpcEffect(
+            projectionReadModelQuery.getThreadDetailSnapshotById(input.threadId).pipe(
+              Effect.map(Option.getOrNull),
+            ),
+            "Failed to load orchestration thread detail snapshot",
+          ),
         [ORCHESTRATION_WS_METHODS.repairState]: () =>
           rpcEffect(orchestrationEngine.repairState(), "Failed to repair orchestration state"),
         [ORCHESTRATION_WS_METHODS.getTurnDiff]: (input) =>

--- a/apps/web/src/components/EventRouter.browser.tsx
+++ b/apps/web/src/components/EventRouter.browser.tsx
@@ -60,6 +60,12 @@ let subscribeThreadRequests: ThreadId[] = [];
 let replayEvents: OrchestrationEvent[] = [];
 let replayRequestCursors: number[] = [];
 let getThreadDetailSnapshotRequestCount = 0;
+let delayNextThreadDetailSnapshotResponse = false;
+let pendingThreadDetailSnapshotResponse: {
+  readonly client: EffectRpcWebSocketClient;
+  readonly requestId: string;
+  readonly result: unknown;
+} | null = null;
 
 const wsLink = ws.link(/ws(s)?:\/\/.*/);
 
@@ -295,7 +301,20 @@ const worker = setupWorker(
         });
         return;
       }
-      sendEffectRpcExit(client, request.id, resolveWsRpc(method, requestBody));
+      const result = resolveWsRpc(method, requestBody);
+      if (
+        method === ORCHESTRATION_WS_METHODS.getThreadDetailSnapshot &&
+        delayNextThreadDetailSnapshotResponse
+      ) {
+        delayNextThreadDetailSnapshotResponse = false;
+        pendingThreadDetailSnapshotResponse = {
+          client,
+          requestId: request.id,
+          result,
+        };
+        return;
+      }
+      sendEffectRpcExit(client, request.id, result);
     });
   }),
   http.get("*/attachments/:attachmentId", () => new HttpResponse(null, { status: 204 })),
@@ -331,9 +350,9 @@ async function mountApp(options?: {
           expectedThread.messages.every((message) => hydratedMessageIdSet.has(message.id)),
         ).toBe(true);
       },
-      // The first Chromium/MSW mount can spend more than 20 seconds compiling
+      // The first Chromium/MSW mount can spend more than 40 seconds compiling
       // the full desktop route graph on a cold Windows dev cache.
-      { timeout: 40_000, interval: 16 },
+      { timeout: 60_000, interval: 16 },
     );
   } catch (cause) {
     await screen.unmount();
@@ -378,6 +397,15 @@ function sendThreadSnapshotPush(threadId: ThreadId, snapshotSequence: number) {
       thread: getThreadDetailFromFixtureSnapshot(threadId),
     },
   });
+}
+
+function sendPendingThreadDetailSnapshotResponse() {
+  const pending = pendingThreadDetailSnapshotResponse;
+  if (pending === null) {
+    throw new Error("No delayed thread-detail snapshot response is pending");
+  }
+  pendingThreadDetailSnapshotResponse = null;
+  sendEffectRpcExit(pending.client, pending.requestId, pending.result);
 }
 
 function sendShellEventPush(event: OrchestrationShellStreamEvent) {
@@ -445,6 +473,8 @@ describe("EventRouter scoped orchestration sync", () => {
     replayEvents = [];
     replayRequestCursors = [];
     getThreadDetailSnapshotRequestCount = 0;
+    delayNextThreadDetailSnapshotResponse = false;
+    pendingThreadDetailSnapshotResponse = null;
   });
 
   afterEach(() => {
@@ -904,6 +934,94 @@ describe("EventRouter scoped orchestration sync", () => {
         },
         { timeout: 10_000, interval: 16 },
       );
+    } finally {
+      fixture = buildFixture();
+      await mounted.cleanup();
+    }
+  }, 60_000);
+
+  it("does not apply a delayed projection snapshot behind the live thread cursor", async () => {
+    const turnId = TurnId.makeUnsafe("turn-delayed-projection");
+    const startedAt = "2026-03-04T12:00:04.000Z";
+    fixture = {
+      ...fixture,
+      snapshot: createSnapshot({
+        latestTurn: {
+          turnId,
+          state: "running",
+          requestedAt: startedAt,
+          startedAt,
+          completedAt: null,
+          assistantMessageId: null,
+        },
+        session: {
+          threadId: THREAD_ID,
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "full-access",
+          activeTurnId: turnId,
+          lastError: null,
+          updatedAt: startedAt,
+        },
+        updatedAt: startedAt,
+      }),
+    };
+
+    const mounted = await mountApp();
+
+    try {
+      delayNextThreadDetailSnapshotResponse = true;
+      await vi.waitFor(
+        () => {
+          expect(getThreadDetailSnapshotRequestCount).toBeGreaterThan(0);
+          expect(pendingThreadDetailSnapshotResponse).not.toBeNull();
+        },
+        { timeout: 10_000, interval: 16 },
+      );
+
+      const completedAt = "2026-03-04T12:00:09.000Z";
+      sendThreadEventPush({
+        sequence: 2,
+        eventId: EventId.makeUnsafe("event-delayed-projection-session-ready"),
+        aggregateKind: "thread",
+        aggregateId: THREAD_ID,
+        occurredAt: completedAt,
+        commandId: null,
+        causationEventId: null,
+        correlationId: null,
+        metadata: {},
+        type: "thread.session-set",
+        payload: {
+          threadId: THREAD_ID,
+          session: {
+            threadId: THREAD_ID,
+            status: "ready",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: completedAt,
+          },
+        },
+      });
+
+      await vi.waitFor(() => {
+        const thread = getThreadFromState(useStore.getState(), THREAD_ID);
+        expect(thread?.latestTurn?.state).toBe("completed");
+        expect(thread?.session?.orchestrationStatus).toBe("ready");
+      });
+
+      sendPendingThreadDetailSnapshotResponse();
+      // Let the RPC continuation run before asserting that the older snapshot
+      // did not roll back the just-applied stream event.
+      await new Promise<void>((resolve) => window.setTimeout(resolve, 100));
+
+      expect(pendingThreadDetailSnapshotResponse).toBeNull();
+      const thread = getThreadFromState(useStore.getState(), THREAD_ID);
+      expect(thread?.latestTurn?.state).toBe("completed");
+      expect(thread?.latestTurn?.completedAt).toBe(completedAt);
+      expect(thread?.session?.orchestrationStatus).toBe("ready");
+      expect(thread?.session?.activeTurnId).toBeUndefined();
     } finally {
       fixture = buildFixture();
       await mounted.cleanup();

--- a/apps/web/src/components/EventRouter.browser.tsx
+++ b/apps/web/src/components/EventRouter.browser.tsx
@@ -801,6 +801,129 @@ describe("EventRouter scoped orchestration sync", () => {
     }
   }, 60_000);
 
+  it("runs one terminal reconciliation when the final assistant event is absent", async () => {
+    const turnId = TurnId.makeUnsafe("turn-terminal-fence");
+    const finalMessageId = MessageId.makeUnsafe("msg-terminal-fence-final");
+    const startedAt = "2026-03-04T12:00:04.000Z";
+    fixture = {
+      ...fixture,
+      snapshot: createSnapshot({
+        latestTurn: {
+          turnId,
+          state: "running",
+          requestedAt: startedAt,
+          startedAt,
+          completedAt: null,
+          assistantMessageId: null,
+        },
+        session: {
+          threadId: THREAD_ID,
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "full-access",
+          activeTurnId: turnId,
+          lastError: null,
+          updatedAt: startedAt,
+        },
+        updatedAt: startedAt,
+      }),
+    };
+    const mounted = await mountApp();
+
+    try {
+      const completedAt = "2026-03-04T12:00:09.000Z";
+      const currentThread = getThreadDetailFromFixtureSnapshot(THREAD_ID);
+      fixture = {
+        ...fixture,
+        snapshot: {
+          ...fixture.snapshot,
+          snapshotSequence: 3,
+          updatedAt: completedAt,
+          threads: [
+            {
+              ...currentThread,
+              latestTurn: {
+                turnId,
+                state: "completed",
+                requestedAt: startedAt,
+                startedAt,
+                completedAt,
+                assistantMessageId: finalMessageId,
+              },
+              messages: [
+                ...currentThread.messages,
+                {
+                  id: finalMessageId,
+                  role: "assistant",
+                  text: "Recovered after the terminal fence.",
+                  turnId,
+                  streaming: false,
+                  source: "native",
+                  createdAt: completedAt,
+                  updatedAt: completedAt,
+                },
+              ],
+              session: {
+                threadId: THREAD_ID,
+                status: "ready",
+                providerName: "codex",
+                runtimeMode: "full-access",
+                activeTurnId: null,
+                lastError: null,
+                updatedAt: completedAt,
+              },
+              updatedAt: completedAt,
+            },
+          ],
+        },
+      };
+
+      sendThreadEventPush({
+        sequence: 2,
+        eventId: EventId.makeUnsafe("event-terminal-fence-session-ready"),
+        aggregateKind: "thread",
+        aggregateId: THREAD_ID,
+        occurredAt: completedAt,
+        commandId: null,
+        causationEventId: null,
+        correlationId: null,
+        metadata: {},
+        type: "thread.session-set",
+        payload: {
+          threadId: THREAD_ID,
+          session: {
+            threadId: THREAD_ID,
+            status: "ready",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: completedAt,
+          },
+        },
+      });
+
+      await vi.waitFor(() => {
+        const thread = getThreadFromState(useStore.getState(), THREAD_ID);
+        expect(thread?.latestTurn?.state).toBe("completed");
+        expect(thread?.messages.some((message) => message.id === finalMessageId)).toBe(false);
+      });
+      await vi.waitFor(
+        () => {
+          const thread = getThreadFromState(useStore.getState(), THREAD_ID);
+          expect(getThreadDetailSnapshotRequestCount).toBeGreaterThan(0);
+          expect(thread?.messages.find((message) => message.id === finalMessageId)?.text).toBe(
+            "Recovered after the terminal fence.",
+          );
+        },
+        { timeout: 10_000, interval: 16 },
+      );
+    } finally {
+      fixture = buildFixture();
+      await mounted.cleanup();
+    }
+  }, 60_000);
+
   it("reconciles a missed completion from the authoritative thread projection", async () => {
     const turnId = TurnId.makeUnsafe("turn-missed-completion");
     const progressMessageId = MessageId.makeUnsafe("msg-missed-completion-progress");

--- a/apps/web/src/components/EventRouter.browser.tsx
+++ b/apps/web/src/components/EventRouter.browser.tsx
@@ -790,6 +790,17 @@ describe("EventRouter scoped orchestration sync", () => {
     }
   });
 
+  it("does not poll a converged terminal thread projection", async () => {
+    const mounted = await mountApp();
+
+    try {
+      await new Promise<void>((resolve) => window.setTimeout(resolve, 5_200));
+      expect(getThreadDetailSnapshotRequestCount).toBe(0);
+    } finally {
+      await mounted.cleanup();
+    }
+  }, 60_000);
+
   it("reconciles a missed completion from the authoritative thread projection", async () => {
     const turnId = TurnId.makeUnsafe("turn-missed-completion");
     const progressMessageId = MessageId.makeUnsafe("msg-missed-completion-progress");
@@ -910,8 +921,44 @@ describe("EventRouter scoped orchestration sync", () => {
         },
       };
 
-      // Deliberately do not push the terminal message/session events. The
-      // periodic scoped projection read must converge the live renderer.
+      // Deliver only the terminal session transition, not the final message.
+      // The reducer now considers the session and turn terminal, but the stale
+      // streaming message must keep projection repair eligible until the
+      // authoritative detail snapshot closes it.
+      sendThreadEventPush({
+        sequence: 3,
+        eventId: EventId.makeUnsafe("event-missed-completion-session-ready"),
+        aggregateKind: "thread",
+        aggregateId: THREAD_ID,
+        occurredAt: completedAt,
+        commandId: null,
+        causationEventId: null,
+        correlationId: null,
+        metadata: {},
+        type: "thread.session-set",
+        payload: {
+          threadId: THREAD_ID,
+          session: {
+            threadId: THREAD_ID,
+            status: "ready",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: completedAt,
+          },
+        },
+      });
+
+      await vi.waitFor(() => {
+        const thread = getThreadFromState(useStore.getState(), THREAD_ID);
+        expect(thread?.latestTurn?.state).toBe("completed");
+        expect(thread?.session?.orchestrationStatus).toBe("ready");
+        expect(
+          thread?.messages.find((message) => message.id === progressMessageId)?.streaming,
+        ).toBe(true);
+      });
+
       await vi.waitFor(
         () => {
           const thread = getThreadFromState(useStore.getState(), THREAD_ID);

--- a/apps/web/src/components/EventRouter.browser.tsx
+++ b/apps/web/src/components/EventRouter.browser.tsx
@@ -59,6 +59,7 @@ const subscribeThreadRequestCountById = new Map<ThreadId, number>();
 let subscribeThreadRequests: ThreadId[] = [];
 let replayEvents: OrchestrationEvent[] = [];
 let replayRequestCursors: number[] = [];
+let getThreadDetailSnapshotRequestCount = 0;
 
 const wsLink = ws.link(/ws(s)?:\/\/.*/);
 
@@ -167,6 +168,19 @@ function resolveWsRpc(tag: string, body?: unknown): unknown {
   }
   if (tag === ORCHESTRATION_WS_METHODS.getSnapshot) {
     return fixture.snapshot;
+  }
+  if (tag === ORCHESTRATION_WS_METHODS.getThreadDetailSnapshot) {
+    getThreadDetailSnapshotRequestCount += 1;
+    const request = body as { readonly threadId?: ThreadId } | null;
+    const thread = request?.threadId
+      ? findThreadDetailFromFixtureSnapshot(request.threadId)
+      : null;
+    return thread
+      ? {
+          snapshotSequence: fixture.snapshot.snapshotSequence,
+          thread,
+        }
+      : null;
   }
   if (tag === ORCHESTRATION_WS_METHODS.replayEvents) {
     const request = body as { readonly fromSequenceExclusive?: unknown } | null;
@@ -317,7 +331,9 @@ async function mountApp(options?: {
           expectedThread.messages.every((message) => hydratedMessageIdSet.has(message.id)),
         ).toBe(true);
       },
-      { timeout: 20_000, interval: 16 },
+      // The first Chromium/MSW mount can spend more than 20 seconds compiling
+      // the full desktop route graph on a cold Windows dev cache.
+      { timeout: 40_000, interval: 16 },
     );
   } catch (cause) {
     await screen.unmount();
@@ -428,6 +444,7 @@ describe("EventRouter scoped orchestration sync", () => {
     subscribeThreadRequests = [];
     replayEvents = [];
     replayRequestCursors = [];
+    getThreadDetailSnapshotRequestCount = 0;
   });
 
   afterEach(() => {
@@ -742,6 +759,156 @@ describe("EventRouter scoped orchestration sync", () => {
       await mounted.cleanup();
     }
   });
+
+  it("reconciles a missed completion from the authoritative thread projection", async () => {
+    const turnId = TurnId.makeUnsafe("turn-missed-completion");
+    const progressMessageId = MessageId.makeUnsafe("msg-missed-completion-progress");
+    const finalMessageId = MessageId.makeUnsafe("msg-missed-completion-final");
+    const startedAt = "2026-03-04T12:00:04.000Z";
+    fixture = {
+      ...fixture,
+      snapshot: createSnapshot({
+        latestTurn: {
+          turnId,
+          state: "running",
+          requestedAt: startedAt,
+          startedAt,
+          completedAt: null,
+          assistantMessageId: null,
+        },
+        session: {
+          threadId: THREAD_ID,
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "full-access",
+          activeTurnId: turnId,
+          lastError: null,
+          updatedAt: startedAt,
+        },
+        updatedAt: startedAt,
+      }),
+    };
+
+    const mounted = await mountApp();
+
+    try {
+      sendThreadEventPush({
+        sequence: 2,
+        eventId: EventId.makeUnsafe("event-missed-completion-progress"),
+        aggregateKind: "thread",
+        aggregateId: THREAD_ID,
+        occurredAt: "2026-03-04T12:00:05.000Z",
+        commandId: null,
+        causationEventId: null,
+        correlationId: null,
+        metadata: {},
+        type: "thread.message-sent",
+        payload: {
+          threadId: THREAD_ID,
+          messageId: progressMessageId,
+          role: "assistant",
+          text: "Cloning repository…",
+          turnId,
+          source: "native",
+          streaming: true,
+          createdAt: "2026-03-04T12:00:05.000Z",
+          updatedAt: "2026-03-04T12:00:05.000Z",
+        },
+      });
+
+      await vi.waitFor(() => {
+        const thread = getThreadFromState(useStore.getState(), THREAD_ID);
+        expect(thread?.messages.find((message) => message.id === progressMessageId)?.text).toBe(
+          "Cloning repository…",
+        );
+      });
+
+      const completedAt = "2026-03-04T12:00:09.000Z";
+      const currentThread = getThreadDetailFromFixtureSnapshot(THREAD_ID);
+      fixture = {
+        ...fixture,
+        snapshot: {
+          ...fixture.snapshot,
+          snapshotSequence: 4,
+          updatedAt: completedAt,
+          threads: [
+            {
+              ...currentThread,
+              latestTurn: {
+                turnId,
+                state: "completed",
+                requestedAt: startedAt,
+                startedAt,
+                completedAt,
+                assistantMessageId: finalMessageId,
+              },
+              messages: [
+                ...currentThread.messages,
+                {
+                  id: progressMessageId,
+                  role: "assistant",
+                  text: "Cloning repository… done.",
+                  turnId,
+                  streaming: false,
+                  source: "native",
+                  createdAt: "2026-03-04T12:00:05.000Z",
+                  updatedAt: "2026-03-04T12:00:08.000Z",
+                },
+                {
+                  id: finalMessageId,
+                  role: "assistant",
+                  text: "Repository cloned successfully.",
+                  turnId,
+                  streaming: false,
+                  source: "native",
+                  createdAt: completedAt,
+                  updatedAt: completedAt,
+                },
+              ],
+              session: {
+                threadId: THREAD_ID,
+                status: "ready",
+                providerName: "codex",
+                runtimeMode: "full-access",
+                activeTurnId: null,
+                lastError: null,
+                updatedAt: completedAt,
+              },
+              updatedAt: completedAt,
+            },
+          ],
+        },
+      };
+
+      // Deliberately do not push the terminal message/session events. The
+      // periodic scoped projection read must converge the live renderer.
+      await vi.waitFor(
+        () => {
+          const thread = getThreadFromState(useStore.getState(), THREAD_ID);
+          expect(getThreadDetailSnapshotRequestCount).toBeGreaterThan(0);
+          expect(thread?.latestTurn?.state).toBe("completed");
+          expect(thread?.session?.orchestrationStatus).toBe("ready");
+          expect(thread?.session?.activeTurnId).toBeUndefined();
+          expect(
+            thread?.messages.filter((message) => message.id === progressMessageId),
+          ).toHaveLength(1);
+          expect(
+            thread?.messages.find((message) => message.id === progressMessageId)?.streaming,
+          ).toBe(false);
+          expect(thread?.messages.filter((message) => message.id === finalMessageId)).toHaveLength(
+            1,
+          );
+          expect(thread?.messages.find((message) => message.id === finalMessageId)?.text).toBe(
+            "Repository cloned successfully.",
+          );
+        },
+        { timeout: 10_000, interval: 16 },
+      );
+    } finally {
+      fixture = buildFixture();
+      await mounted.cleanup();
+    }
+  }, 60_000);
 
   it("flushes only the first assistant chunk immediately for a message", async () => {
     const mounted = await mountApp();

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -908,6 +908,15 @@ function shouldReconcileThreadProjection(threadId: ThreadId): boolean {
   );
 }
 
+function isTerminalThreadSessionStatus(status: string): boolean {
+  return (
+    status === "ready" ||
+    status === "interrupted" ||
+    status === "stopped" ||
+    status === "error"
+  );
+}
+
 /**
  * Frees the detail of threads whose stream lease just dropped and that nothing
  * else owns. Batched into one store write because every write re-runs the
@@ -1000,6 +1009,7 @@ function EventRouter() {
     const threadSnapshotRequestInFlight = new Set<ThreadId>();
     const threadReplayRequestInFlight = new Set<ThreadId>();
     const threadProjectionReconcileInFlight = new Map<ThreadId, number>();
+    const threadProjectionTerminalFencePending = new Set<ThreadId>();
     const threadSubscriptionGenerationById = new Map<ThreadId, number>();
     const nextThreadProjectionReconcileAtById = new Map<ThreadId, number>();
     let nextThreadSubscriptionGeneration = 0;
@@ -1010,6 +1020,7 @@ function EventRouter() {
       pendingThreadEventsById.set(threadId, []);
       threadSnapshotRequestInFlight.delete(threadId);
       threadProjectionReconcileInFlight.delete(threadId);
+      threadProjectionTerminalFencePending.delete(threadId);
       nextThreadSubscriptionGeneration += 1;
       threadSubscriptionGenerationById.set(threadId, nextThreadSubscriptionGeneration);
       nextThreadProjectionReconcileAtById.set(
@@ -1056,6 +1067,7 @@ function EventRouter() {
         threadSnapshotRequestInFlight.delete(threadId);
         threadReplayRequestInFlight.delete(threadId);
         threadProjectionReconcileInFlight.delete(threadId);
+        threadProjectionTerminalFencePending.delete(threadId);
         threadSubscriptionGenerationById.delete(threadId);
         nextThreadProjectionReconcileAtById.delete(threadId);
         subscribedThreadIds.delete(threadId);
@@ -1162,6 +1174,7 @@ function EventRouter() {
         threadSnapshotRequestInFlight.clear();
         threadReplayRequestInFlight.clear();
         threadProjectionReconcileInFlight.clear();
+        threadProjectionTerminalFencePending.clear();
         threadSubscriptionGenerationById.clear();
         nextThreadProjectionReconcileAtById.clear();
         const previousThreadIds = [...subscribedThreadIds];
@@ -1347,6 +1360,7 @@ function EventRouter() {
         return;
       }
       threadProjectionReconcileInFlight.set(threadId, subscriptionGeneration);
+      let projectionConfirmed = false;
       try {
         const snapshot = await api.orchestration.getThreadDetailSnapshot({ threadId });
         if (
@@ -1382,6 +1396,7 @@ function EventRouter() {
         syncServerThreadDetailHotPath(snapshot.thread);
         reconcilePromotedDraftFromThreadDetail(snapshot.thread);
         flushThreadBuffer(threadId, snapshot.snapshotSequence);
+        projectionConfirmed = true;
         if (projectionSettlesCurrentTurn) {
           // Mirror terminal-event invalidation when recovery came from the
           // projection rather than the live stream.
@@ -1395,7 +1410,13 @@ function EventRouter() {
           threadProjectionReconcileInFlight.delete(threadId);
         }
         if (threadSubscriptionGenerationById.get(threadId) === subscriptionGeneration) {
-          if (shouldReconcileThreadProjection(threadId)) {
+          if (projectionConfirmed) {
+            threadProjectionTerminalFencePending.delete(threadId);
+          }
+          if (
+            threadProjectionTerminalFencePending.has(threadId) ||
+            shouldReconcileThreadProjection(threadId)
+          ) {
             nextThreadProjectionReconcileAtById.set(
               threadId,
               Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
@@ -1446,6 +1467,18 @@ function EventRouter() {
       if (
         item.kind === "thread-upserted" &&
         subscribedThreadIds.has(item.thread.id) &&
+        item.thread.session !== null &&
+        isTerminalThreadSessionStatus(item.thread.session.status)
+      ) {
+        threadProjectionTerminalFencePending.add(item.thread.id);
+        nextThreadProjectionReconcileAtById.set(
+          item.thread.id,
+          Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
+        );
+      }
+      if (
+        item.kind === "thread-upserted" &&
+        subscribedThreadIds.has(item.thread.id) &&
         !threadSnapshotSequenceById.has(item.thread.id)
       ) {
         void requestThreadSnapshot(item.thread.id);
@@ -1478,6 +1511,16 @@ function EventRouter() {
       }
 
       const threadId = ThreadId.makeUnsafe(String(item.event.aggregateId));
+      if (
+        item.event.type === "thread.session-set" &&
+        isTerminalThreadSessionStatus(item.event.payload.session.status)
+      ) {
+        threadProjectionTerminalFencePending.add(threadId);
+        nextThreadProjectionReconcileAtById.set(
+          threadId,
+          Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
+        );
+      }
       const latestThreadSequence = threadSnapshotSequenceById.get(threadId);
       if (latestThreadSequence === undefined) {
         const pendingThreadEvents = pendingThreadEventsById.get(threadId) ?? [];
@@ -1716,7 +1759,10 @@ function EventRouter() {
             void replayThreadEvents(threadId).catch(() => undefined);
           }
         }
-        if (!shouldReconcileThreadProjection(threadId)) {
+        if (
+          !threadProjectionTerminalFencePending.has(threadId) &&
+          !shouldReconcileThreadProjection(threadId)
+        ) {
           nextThreadProjectionReconcileAtById.delete(threadId);
           continue;
         }
@@ -1744,6 +1790,7 @@ function EventRouter() {
       pendingGitInvalidationThreadIds = new Set();
       pendingStudioOutputInvalidationThreadIds = new Set();
       threadProjectionReconcileInFlight.clear();
+      threadProjectionTerminalFencePending.clear();
       threadSubscriptionGenerationById.clear();
       nextThreadProjectionReconcileAtById.clear();
       domainEventFlushThrottler.cancel();

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -118,6 +118,7 @@ import {
 const SHELL_SNAPSHOT_BOOTSTRAP_FALLBACK_DELAY_MS = 1_500;
 const THREAD_DETAIL_CATCHUP_INTERVAL_MS = 1_500;
 const THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS = 4_500;
+const THREAD_DETAIL_PROJECTION_RECONCILE_MAX_CONCURRENCY = 2;
 const PENDING_SHELL_EVENT_BUFFER_LIMIT = 1_024;
 const PENDING_THREAD_EVENT_BUFFER_LIMIT = 512;
 const IMMEDIATE_ASSISTANT_FLUSH_ID_LIMIT = 512;
@@ -988,8 +989,10 @@ function EventRouter() {
     const pendingThreadEventsById = new Map<ThreadId, OrchestrationEvent[]>();
     const threadSnapshotRequestInFlight = new Set<ThreadId>();
     const threadReplayRequestInFlight = new Set<ThreadId>();
-    const threadProjectionReconcileInFlight = new Set<ThreadId>();
+    const threadProjectionReconcileInFlight = new Map<ThreadId, number>();
+    const threadSubscriptionGenerationById = new Map<ThreadId, number>();
     const nextThreadProjectionReconcileAtById = new Map<ThreadId, number>();
+    let nextThreadSubscriptionGeneration = 0;
     let reconcileThreadSubscriptionsChain = Promise.resolve();
 
     const beginThreadSubscription = (threadId: ThreadId) => {
@@ -997,6 +1000,8 @@ function EventRouter() {
       pendingThreadEventsById.set(threadId, []);
       threadSnapshotRequestInFlight.delete(threadId);
       threadProjectionReconcileInFlight.delete(threadId);
+      nextThreadSubscriptionGeneration += 1;
+      threadSubscriptionGenerationById.set(threadId, nextThreadSubscriptionGeneration);
       nextThreadProjectionReconcileAtById.set(
         threadId,
         Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
@@ -1041,6 +1046,7 @@ function EventRouter() {
         threadSnapshotRequestInFlight.delete(threadId);
         threadReplayRequestInFlight.delete(threadId);
         threadProjectionReconcileInFlight.delete(threadId);
+        threadSubscriptionGenerationById.delete(threadId);
         nextThreadProjectionReconcileAtById.delete(threadId);
         subscribedThreadIds.delete(threadId);
       }
@@ -1146,6 +1152,7 @@ function EventRouter() {
         threadSnapshotRequestInFlight.clear();
         threadReplayRequestInFlight.clear();
         threadProjectionReconcileInFlight.clear();
+        threadSubscriptionGenerationById.clear();
         nextThreadProjectionReconcileAtById.clear();
         const previousThreadIds = [...subscribedThreadIds];
         subscribedThreadIds.clear();
@@ -1320,19 +1327,22 @@ function EventRouter() {
     };
 
     const reconcileThreadProjection = async (threadId: ThreadId): Promise<void> => {
+      const subscriptionGeneration = threadSubscriptionGenerationById.get(threadId);
       if (
         disposed ||
         !subscribedThreadIds.has(threadId) ||
+        subscriptionGeneration === undefined ||
         threadProjectionReconcileInFlight.has(threadId)
       ) {
         return;
       }
-      threadProjectionReconcileInFlight.add(threadId);
+      threadProjectionReconcileInFlight.set(threadId, subscriptionGeneration);
       try {
         const snapshot = await api.orchestration.getThreadDetailSnapshot({ threadId });
         if (
           snapshot === null ||
           disposed ||
+          threadSubscriptionGenerationById.get(threadId) !== subscriptionGeneration ||
           !canApplyThreadSnapshot({ threadId, leasedThreadIds: subscribedThreadIds })
         ) {
           return;
@@ -1371,11 +1381,15 @@ function EventRouter() {
           domainEventFlushThrottler.maybeExecute();
         }
       } finally {
-        threadProjectionReconcileInFlight.delete(threadId);
-        nextThreadProjectionReconcileAtById.set(
-          threadId,
-          Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
-        );
+        if (threadProjectionReconcileInFlight.get(threadId) === subscriptionGeneration) {
+          threadProjectionReconcileInFlight.delete(threadId);
+        }
+        if (threadSubscriptionGenerationById.get(threadId) === subscriptionGeneration) {
+          nextThreadProjectionReconcileAtById.set(
+            threadId,
+            Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
+          );
+        }
       }
     };
 
@@ -1674,6 +1688,12 @@ function EventRouter() {
       void loadShellSnapshotOnce().catch(() => undefined);
     }, SHELL_SNAPSHOT_BOOTSTRAP_FALLBACK_DELAY_MS);
     const threadDetailCatchupInterval = window.setInterval(() => {
+      const now = Date.now();
+      let availableProjectionReconcileSlots = Math.max(
+        0,
+        THREAD_DETAIL_PROJECTION_RECONCILE_MAX_CONCURRENCY -
+          threadProjectionReconcileInFlight.size,
+      );
       for (const threadId of subscribedThreadIds) {
         if (shouldPollThreadDetailCatchup(threadId)) {
           if (!threadSnapshotSequenceById.has(threadId)) {
@@ -1681,13 +1701,17 @@ function EventRouter() {
           } else {
             void replayThreadEvents(threadId).catch(() => undefined);
           }
-          if (
-            Date.now() >=
-            (nextThreadProjectionReconcileAtById.get(threadId) ??
-              Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS)
-          ) {
-            void reconcileThreadProjection(threadId).catch(() => undefined);
-          }
+        }
+        const nextProjectionReconcileAt =
+          nextThreadProjectionReconcileAtById.get(threadId);
+        if (
+          availableProjectionReconcileSlots > 0 &&
+          !threadProjectionReconcileInFlight.has(threadId) &&
+          nextProjectionReconcileAt !== undefined &&
+          now >= nextProjectionReconcileAt
+        ) {
+          availableProjectionReconcileSlots -= 1;
+          void reconcileThreadProjection(threadId).catch(() => undefined);
         }
       }
     }, THREAD_DETAIL_CATCHUP_INTERVAL_MS);
@@ -1702,6 +1726,7 @@ function EventRouter() {
       pendingGitInvalidationThreadIds = new Set();
       pendingStudioOutputInvalidationThreadIds = new Set();
       threadProjectionReconcileInFlight.clear();
+      threadSubscriptionGenerationById.clear();
       nextThreadProjectionReconcileAtById.clear();
       domainEventFlushThrottler.cancel();
       reconcileThreadSubscriptionsRef.current = null;

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -898,6 +898,16 @@ function shouldPollThreadDetailCatchup(threadId: ThreadId): boolean {
   );
 }
 
+function shouldReconcileThreadProjection(threadId: ThreadId): boolean {
+  const thread = getThreadFromState(useStore.getState(), threadId);
+  return (
+    thread?.session?.orchestrationStatus === "starting" ||
+    thread?.session?.orchestrationStatus === "running" ||
+    thread?.latestTurn?.state === "running" ||
+    thread?.messages.some((message) => message.role === "assistant" && message.streaming) === true
+  );
+}
+
 /**
  * Frees the detail of threads whose stream lease just dropped and that nothing
  * else owns. Batched into one store write because every write re-runs the
@@ -1385,10 +1395,14 @@ function EventRouter() {
           threadProjectionReconcileInFlight.delete(threadId);
         }
         if (threadSubscriptionGenerationById.get(threadId) === subscriptionGeneration) {
-          nextThreadProjectionReconcileAtById.set(
-            threadId,
-            Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
-          );
+          if (shouldReconcileThreadProjection(threadId)) {
+            nextThreadProjectionReconcileAtById.set(
+              threadId,
+              Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
+            );
+          } else {
+            nextThreadProjectionReconcileAtById.delete(threadId);
+          }
         }
       }
     };
@@ -1701,6 +1715,10 @@ function EventRouter() {
           } else {
             void replayThreadEvents(threadId).catch(() => undefined);
           }
+        }
+        if (!shouldReconcileThreadProjection(threadId)) {
+          nextThreadProjectionReconcileAtById.delete(threadId);
+          continue;
         }
         const nextProjectionReconcileAt =
           nextThreadProjectionReconcileAtById.get(threadId);

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1380,6 +1380,8 @@ function EventRouter() {
           return;
         }
         const currentThread = getThreadFromState(useStore.getState(), threadId);
+        const projectionRepairsTerminalFence =
+          threadProjectionTerminalFencePending.has(threadId);
         const projectionSettlesCurrentTurn =
           currentThread?.latestTurn?.state === "running" &&
           snapshot.thread.latestTurn !== null &&
@@ -1397,7 +1399,7 @@ function EventRouter() {
         reconcilePromotedDraftFromThreadDetail(snapshot.thread);
         flushThreadBuffer(threadId, snapshot.snapshotSequence);
         projectionConfirmed = true;
-        if (projectionSettlesCurrentTurn) {
+        if (projectionSettlesCurrentTurn || projectionRepairsTerminalFence) {
           // Mirror terminal-event invalidation when recovery came from the
           // projection rather than the live stream.
           needsProviderInvalidation = true;

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -117,6 +117,7 @@ import {
 
 const SHELL_SNAPSHOT_BOOTSTRAP_FALLBACK_DELAY_MS = 1_500;
 const THREAD_DETAIL_CATCHUP_INTERVAL_MS = 1_500;
+const THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS = 4_500;
 const PENDING_SHELL_EVENT_BUFFER_LIMIT = 1_024;
 const PENDING_THREAD_EVENT_BUFFER_LIMIT = 512;
 const IMMEDIATE_ASSISTANT_FLUSH_ID_LIMIT = 512;
@@ -987,12 +988,19 @@ function EventRouter() {
     const pendingThreadEventsById = new Map<ThreadId, OrchestrationEvent[]>();
     const threadSnapshotRequestInFlight = new Set<ThreadId>();
     const threadReplayRequestInFlight = new Set<ThreadId>();
+    const threadProjectionReconcileInFlight = new Set<ThreadId>();
+    const nextThreadProjectionReconcileAtById = new Map<ThreadId, number>();
     let reconcileThreadSubscriptionsChain = Promise.resolve();
 
     const beginThreadSubscription = (threadId: ThreadId) => {
       threadSnapshotSequenceById.delete(threadId);
       pendingThreadEventsById.set(threadId, []);
       threadSnapshotRequestInFlight.delete(threadId);
+      threadProjectionReconcileInFlight.delete(threadId);
+      nextThreadProjectionReconcileAtById.set(
+        threadId,
+        Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
+      );
     };
 
     const flushThreadBuffer = (threadId: ThreadId, snapshotSequence: number) => {
@@ -1032,6 +1040,8 @@ function EventRouter() {
         pendingThreadEventsById.delete(threadId);
         threadSnapshotRequestInFlight.delete(threadId);
         threadReplayRequestInFlight.delete(threadId);
+        threadProjectionReconcileInFlight.delete(threadId);
+        nextThreadProjectionReconcileAtById.delete(threadId);
         subscribedThreadIds.delete(threadId);
       }
       // A retention eviction can refresh a thread whose lease is dropping in the
@@ -1135,6 +1145,8 @@ function EventRouter() {
         pendingThreadEventsById.clear();
         threadSnapshotRequestInFlight.clear();
         threadReplayRequestInFlight.clear();
+        threadProjectionReconcileInFlight.clear();
+        nextThreadProjectionReconcileAtById.clear();
         const previousThreadIds = [...subscribedThreadIds];
         subscribedThreadIds.clear();
         // Reconnect drops every lease at once, so the reconcile below sees no
@@ -1307,6 +1319,59 @@ function EventRouter() {
         });
     };
 
+    const reconcileThreadProjection = async (threadId: ThreadId): Promise<void> => {
+      if (
+        disposed ||
+        !subscribedThreadIds.has(threadId) ||
+        threadProjectionReconcileInFlight.has(threadId)
+      ) {
+        return;
+      }
+      threadProjectionReconcileInFlight.add(threadId);
+      try {
+        const snapshot = await api.orchestration.getThreadDetailSnapshot({ threadId });
+        if (
+          snapshot === null ||
+          disposed ||
+          !canApplyThreadSnapshot({ threadId, leasedThreadIds: subscribedThreadIds })
+        ) {
+          return;
+        }
+        const currentSequence = threadSnapshotSequenceById.get(threadId) ?? -1;
+        const currentThread = getThreadFromState(useStore.getState(), threadId);
+        const projectionSettlesCurrentTurn =
+          currentThread?.latestTurn?.state === "running" &&
+          snapshot.thread.latestTurn !== null &&
+          snapshot.thread.latestTurn.turnId === currentThread.latestTurn.turnId &&
+          snapshot.thread.latestTurn.state !== "running" &&
+          snapshot.thread.latestTurn.completedAt !== null;
+        threadSnapshotSequenceById.set(
+          threadId,
+          Math.max(currentSequence, snapshot.snapshotSequence),
+        );
+        // Apply even when the cursor did not advance. The projection is
+        // authoritative and can repair a client that advanced its cursor while
+        // dropping or failing to reduce one of the corresponding live events.
+        syncServerThreadDetailHotPath(snapshot.thread);
+        reconcilePromotedDraftFromThreadDetail(snapshot.thread);
+        flushThreadBuffer(threadId, snapshot.snapshotSequence);
+        if (projectionSettlesCurrentTurn) {
+          // Mirror terminal-event invalidation when recovery came from the
+          // projection rather than the live stream.
+          needsProviderInvalidation = true;
+          pendingGitInvalidationThreadIds.add(threadId);
+          pendingStudioOutputInvalidationThreadIds.add(threadId);
+          domainEventFlushThrottler.maybeExecute();
+        }
+      } finally {
+        threadProjectionReconcileInFlight.delete(threadId);
+        nextThreadProjectionReconcileAtById.set(
+          threadId,
+          Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
+        );
+      }
+    };
+
     const domainEventFlushThrottler = new Throttler(
       () => {
         flushPendingDomainEvents();
@@ -1367,6 +1432,10 @@ function EventRouter() {
           return;
         }
         threadSnapshotSequenceById.set(threadId, item.snapshot.snapshotSequence);
+        nextThreadProjectionReconcileAtById.set(
+          threadId,
+          Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
+        );
         syncServerThreadDetailHotPath(item.snapshot.thread);
         reconcilePromotedDraftFromThreadDetail(item.snapshot.thread);
         flushThreadBuffer(threadId, item.snapshot.snapshotSequence);
@@ -1388,6 +1457,10 @@ function EventRouter() {
         return;
       }
       threadSnapshotSequenceById.set(threadId, item.event.sequence);
+      nextThreadProjectionReconcileAtById.set(
+        threadId,
+        Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
+      );
       queueDomainEvent(item.event);
     });
     const unsubThreadStreamFailure = onThreadStreamFailure((failure) => {
@@ -1601,6 +1674,13 @@ function EventRouter() {
           } else {
             void replayThreadEvents(threadId).catch(() => undefined);
           }
+          if (
+            Date.now() >=
+            (nextThreadProjectionReconcileAtById.get(threadId) ??
+              Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS)
+          ) {
+            void reconcileThreadProjection(threadId).catch(() => undefined);
+          }
         }
       }
     }, THREAD_DETAIL_CATCHUP_INTERVAL_MS);
@@ -1614,6 +1694,8 @@ function EventRouter() {
       needsBroadGitInvalidation = false;
       pendingGitInvalidationThreadIds = new Set();
       pendingStudioOutputInvalidationThreadIds = new Set();
+      threadProjectionReconcileInFlight.clear();
+      nextThreadProjectionReconcileAtById.clear();
       domainEventFlushThrottler.cancel();
       reconcileThreadSubscriptionsRef.current = null;
       void api.orchestration.unsubscribeShell().catch(() => undefined);

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1338,6 +1338,13 @@ function EventRouter() {
           return;
         }
         const currentSequence = threadSnapshotSequenceById.get(threadId) ?? -1;
+        // The RPC response can race a newer stream event. An older projection is
+        // authoritative only for its own fence; applying it after the live cursor
+        // advances would roll the thread back and the already-consumed event is no
+        // longer buffered to restore it.
+        if (snapshot.snapshotSequence < currentSequence) {
+          return;
+        }
         const currentThread = getThreadFromState(useStore.getState(), threadId);
         const projectionSettlesCurrentTurn =
           currentThread?.latestTurn?.state === "running" &&

--- a/apps/web/src/storeNormalization.ts
+++ b/apps/web/src/storeNormalization.ts
@@ -859,6 +859,19 @@ export function mergeReadModelThreadDetailWithLiveHotPath(
     return incoming;
   }
 
+  const incomingSettlesLocalTurn =
+    previousThread.latestTurn?.state === "running" &&
+    incoming.latestTurn !== null &&
+    incoming.latestTurn.turnId === previousThread.latestTurn.turnId &&
+    incoming.latestTurn.state !== "running" &&
+    incoming.latestTurn.completedAt !== null;
+  if (incomingSettlesLocalTurn) {
+    // A scoped projection refresh is authoritative for a terminal transition.
+    // Do not preserve stale local streaming flags or client-only message rows
+    // after the server has settled the exact turn they belonged to.
+    return incoming;
+  }
+
   const preserveRunningTurn = shouldPreserveRunningTurn(previousThread, incoming);
   const messages = mergeReadModelMessagesWithLiveHotPath(incoming.messages, previousThread);
   const session = mergeReadModelSessionWithLiveHotPath(incoming.session, previousThread, {

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -404,7 +404,7 @@ describe("deriveWorkLogEntries", () => {
   it("hides repeated non-adjacent recovery rows for the same provider turn", () => {
     const recoveryPayload = {
       provider: "codex",
-      action: "settle-interrupted",
+      action: "settle-terminal-projection",
       projectedTurnId: "turn-stale",
       runtimeTurnId: null,
     };

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -545,6 +545,40 @@ describe("deriveWorkLogEntries", () => {
     ]);
   });
 
+  it("keeps reconciliation rows with delimiter-shaped but distinct turn ids", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "recovery-delimited-projected",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "provider.runtime.reconciled",
+        summary: "Realigned a delimited projected turn",
+        payload: {
+          provider: "codex",
+          action: "align-running-turn",
+          projectedTurnId: "turn:a",
+          runtimeTurnId: "turn-b",
+        },
+      }),
+      makeActivity({
+        id: "recovery-delimited-runtime",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "provider.runtime.reconciled",
+        summary: "Realigned a delimited runtime turn",
+        payload: {
+          provider: "codex",
+          action: "align-running-turn",
+          projectedTurnId: "turn",
+          runtimeTurnId: "a:turn-b",
+        },
+      }),
+    ];
+
+    expect(deriveWorkLogEntries(activities, undefined).map((entry) => entry.id)).toEqual([
+      "recovery-delimited-projected",
+      "recovery-delimited-runtime",
+    ]);
+  });
+
   it("omits ExitPlanMode lifecycle entries once the plan card is shown", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -465,6 +465,18 @@ describe("deriveWorkLogEntries", () => {
         },
       }),
       makeActivity({
+        id: "error-turn-b",
+        createdAt: "2026-02-23T00:00:02.500Z",
+        kind: "provider.runtime.reconciled",
+        summary: "Errored turn B",
+        payload: {
+          provider: "codex",
+          action: "settle-error",
+          projectedTurnId: "turn-b",
+          runtimeTurnId: null,
+        },
+      }),
+      makeActivity({
         id: "align-turn-b",
         createdAt: "2026-02-23T00:00:03.000Z",
         kind: "provider.runtime.reconciled",
@@ -495,6 +507,7 @@ describe("deriveWorkLogEntries", () => {
     expect(entries.map((entry) => entry.id)).toEqual([
       "settle-turn-a",
       "settle-turn-b",
+      "error-turn-b",
       "align-turn-b",
       "align-turn-b-new-runtime",
     ]);

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -401,6 +401,137 @@ describe("deriveWorkLogEntries", () => {
     ]);
   });
 
+  it("hides repeated non-adjacent recovery rows for the same provider turn", () => {
+    const recoveryPayload = {
+      provider: "codex",
+      action: "settle-interrupted",
+      projectedTurnId: "turn-stale",
+      runtimeTurnId: null,
+    };
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "recovery-first",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "provider.runtime.reconciled",
+        summary: "Synara recovered a stale running state",
+        turnId: "turn-stale",
+        payload: recoveryPayload,
+      }),
+      makeActivity({
+        id: "unrelated-progress",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "task.progress",
+        summary: "Continuing work",
+      }),
+      makeActivity({
+        id: "recovery-repeat",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        kind: "provider.runtime.reconciled",
+        summary: "Synara recovered a stale running state",
+        turnId: "turn-stale",
+        payload: recoveryPayload,
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+
+    expect(entries.map((entry) => entry.id)).toEqual(["recovery-first", "unrelated-progress"]);
+  });
+
+  it("keeps recovery rows for different turns, actions, or runtime turns", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "settle-turn-a",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "provider.runtime.reconciled",
+        summary: "Recovered turn A",
+        payload: {
+          provider: "codex",
+          action: "settle-interrupted",
+          projectedTurnId: "turn-a",
+          runtimeTurnId: null,
+        },
+      }),
+      makeActivity({
+        id: "settle-turn-b",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "provider.runtime.reconciled",
+        summary: "Recovered turn B",
+        payload: {
+          provider: "codex",
+          action: "settle-interrupted",
+          projectedTurnId: "turn-b",
+          runtimeTurnId: null,
+        },
+      }),
+      makeActivity({
+        id: "align-turn-b",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        kind: "provider.runtime.reconciled",
+        summary: "Realigned turn B",
+        payload: {
+          provider: "codex",
+          action: "align-running-turn",
+          projectedTurnId: "turn-b",
+          runtimeTurnId: "turn-live-1",
+        },
+      }),
+      makeActivity({
+        id: "align-turn-b-new-runtime",
+        createdAt: "2026-02-23T00:00:04.000Z",
+        kind: "provider.runtime.reconciled",
+        summary: "Realigned turn B again",
+        payload: {
+          provider: "codex",
+          action: "align-running-turn",
+          projectedTurnId: "turn-b",
+          runtimeTurnId: "turn-live-2",
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+
+    expect(entries.map((entry) => entry.id)).toEqual([
+      "settle-turn-a",
+      "settle-turn-b",
+      "align-turn-b",
+      "align-turn-b-new-runtime",
+    ]);
+  });
+
+  it("does not collapse recovery rows whose identity payload is incomplete", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "malformed-recovery-1",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "provider.runtime.reconciled",
+        summary: "Recovered an unknown turn",
+        payload: {
+          provider: "codex",
+          action: "settle-interrupted",
+        },
+      }),
+      makeActivity({
+        id: "malformed-recovery-2",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "provider.runtime.reconciled",
+        summary: "Recovered an unknown turn",
+        payload: {
+          provider: "codex",
+          action: "settle-interrupted",
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+
+    expect(entries.map((entry) => entry.id)).toEqual([
+      "malformed-recovery-1",
+      "malformed-recovery-2",
+    ]);
+  });
+
   it("omits ExitPlanMode lifecycle entries once the plan card is shown", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -537,7 +537,9 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   if (toolDetails) {
     entry.toolDetails = toolDetails;
   }
-  const collapseKey = deriveToolLifecycleCollapseKey(entry);
+  const collapseKey =
+    deriveProviderRuntimeReconciliationCollapseKey(activity, payload) ??
+    deriveToolLifecycleCollapseKey(entry);
   if (collapseKey) {
     entry.collapseKey = collapseKey;
   }
@@ -546,6 +548,35 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
     entry.collapseCommand = collapseCommand;
   }
   return entry;
+}
+
+function deriveProviderRuntimeReconciliationCollapseKey(
+  activity: OrchestrationThreadActivity,
+  payload: Record<string, unknown> | null,
+): string | undefined {
+  if (activity.kind !== "provider.runtime.reconciled") {
+    return undefined;
+  }
+  const provider = asTrimmedString(payload?.provider);
+  const action = asTrimmedString(payload?.action);
+  const projectedTurnId =
+    asTrimmedString(payload?.projectedTurnId) ?? activity.turnId ?? undefined;
+  const runtimeTurnId = asTrimmedString(payload?.runtimeTurnId);
+  if (
+    !provider ||
+    !projectedTurnId ||
+    (action !== "settle-interrupted" && action !== "align-running-turn") ||
+    (action === "align-running-turn" && !runtimeTurnId)
+  ) {
+    return undefined;
+  }
+  return [
+    "provider-runtime-reconcile",
+    provider,
+    action,
+    projectedTurnId,
+    runtimeTurnId ?? "none",
+  ].join(":");
 }
 
 function deriveToolLifecycleStatus(
@@ -682,7 +713,23 @@ function collapseDerivedWorkLogEntries(
   // separate completed row. The id is unique per call, so distinct calls of the
   // same tool never merge into each other.
   const stableToolIndexByKey = new Map<string, number>();
+  // Older servers included the current observation sequence in recovery ids,
+  // so the same repair could be persisted more than once while projections
+  // converged. Preserve the first row for each semantic repair and hide only
+  // exact repeats; different turns/actions remain independently visible.
+  const seenRuntimeReconciliationKeys = new Set<string>();
   for (const entry of entries) {
+    const runtimeReconciliationKey = entry.collapseKey?.startsWith(
+      "provider-runtime-reconcile:",
+    )
+      ? entry.collapseKey
+      : undefined;
+    if (runtimeReconciliationKey !== undefined) {
+      if (seenRuntimeReconciliationKeys.has(runtimeReconciliationKey)) {
+        continue;
+      }
+      seenRuntimeReconciliationKeys.add(runtimeReconciliationKey);
+    }
     const previous = collapsed.at(-1);
     if (previous && shouldCollapseRuntimeWarningEntries(previous, entry)) {
       collapsed[collapsed.length - 1] = mergeRuntimeWarningEntries(previous, entry);

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -565,7 +565,9 @@ function deriveProviderRuntimeReconciliationCollapseKey(
   if (
     !provider ||
     !projectedTurnId ||
-    (action !== "settle-interrupted" && action !== "align-running-turn") ||
+    (action !== "settle-interrupted" &&
+      action !== "settle-terminal-projection" &&
+      action !== "align-running-turn") ||
     (action === "align-running-turn" && !runtimeTurnId)
   ) {
     return undefined;

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -567,6 +567,7 @@ function deriveProviderRuntimeReconciliationCollapseKey(
     !projectedTurnId ||
     (action !== "settle-interrupted" &&
       action !== "settle-terminal-projection" &&
+      action !== "settle-error" &&
       action !== "align-running-turn") ||
     (action === "align-running-turn" && !runtimeTurnId)
   ) {

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -573,13 +573,12 @@ function deriveProviderRuntimeReconciliationCollapseKey(
   ) {
     return undefined;
   }
-  return [
-    "provider-runtime-reconcile",
+  return `provider-runtime-reconcile:${JSON.stringify([
     provider,
     action,
     projectedTurnId,
-    runtimeTurnId ?? "none",
-  ].join(":");
+    runtimeTurnId ?? null,
+  ])}`;
 }
 
 function deriveToolLifecycleStatus(

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -678,6 +678,8 @@ export function createWsNativeApi(): NativeApi {
     orchestration: {
       getSnapshot: () => transport.request(ORCHESTRATION_WS_METHODS.getSnapshot),
       getShellSnapshot: () => transport.request(ORCHESTRATION_WS_METHODS.getShellSnapshot),
+      getThreadDetailSnapshot: (input) =>
+        transport.request(ORCHESTRATION_WS_METHODS.getThreadDetailSnapshot, input),
       dispatchCommand: (command) => {
         return transport.request(ORCHESTRATION_WS_METHODS.dispatchCommand, {
           command: omitNullUserInputAnswers(command),

--- a/apps/web/src/wsTransport.test.ts
+++ b/apps/web/src/wsTransport.test.ts
@@ -20,11 +20,13 @@ import {
   getStreamCapacityRetryDelayMs,
   getStreamDuplicateRetryDelayMs,
   getStreamFailureCode,
+  getThreadSnapshotBootstrapRetryDelayMs,
   getTerminalCompatibilityError,
   isTerminalCompatibilityFailure,
   makeFeatureSocketUrl,
   makeRequestAbortScope,
   MAX_STREAM_DUPLICATE_RETRY_ATTEMPTS,
+  MAX_THREAD_SNAPSHOT_BOOTSTRAP_RETRY_ATTEMPTS,
   resolveStreamAdmissionRetry,
   shouldReconnectAfterStreamFailure,
   threadStreamInputsEqual,
@@ -91,6 +93,7 @@ interface WsTransportInternals {
   readonly streamSettled: Map<string, Promise<void>>;
   readonly streamCapacityRetries: Map<string, number>;
   readonly streamDuplicateRetries: Map<string, number>;
+  readonly streamThreadBootstrapRetries: Map<string, number>;
   readonly streamCapacityRetryTimers: Map<string, number>;
   readonly activeThreadStreamInputs: Map<string, unknown>;
   readonly threadSubscriptions: Map<string, unknown>;
@@ -117,6 +120,7 @@ function makeBareTransport(): {
     streamSettled: new Map(),
     streamCapacityRetries: new Map(),
     streamDuplicateRetries: new Map(),
+    streamThreadBootstrapRetries: new Map(),
     streamCapacityRetryTimers: new Map(),
     activeThreadStreamInputs: new Map(),
     threadSubscriptions: new Map(),
@@ -263,6 +267,34 @@ describe("WsTransport", () => {
     });
     expect(
       resolveStreamAdmissionRetry(duplicate, 0, MAX_STREAM_DUPLICATE_RETRY_ATTEMPTS),
+    ).toBeNull();
+  });
+
+  it("retries a missing draft snapshot until its projection becomes visible", () => {
+    const projectionLag = Cause.fail({
+      code: "THREAD_SNAPSHOT_NOT_FOUND",
+      retryable: false,
+    });
+
+    expect(getThreadSnapshotBootstrapRetryDelayMs(projectionLag, 0)).toBe(100);
+    expect(resolveStreamAdmissionRetry(projectionLag, 0, 0, 0)).toEqual({
+      kind: "thread-bootstrap",
+      attempt: 1,
+      delayMs: 100,
+    });
+    expect(
+      getThreadSnapshotBootstrapRetryDelayMs(
+        projectionLag,
+        MAX_THREAD_SNAPSHOT_BOOTSTRAP_RETRY_ATTEMPTS,
+      ),
+    ).toBeNull();
+    expect(
+      resolveStreamAdmissionRetry(
+        projectionLag,
+        0,
+        0,
+        MAX_THREAD_SNAPSHOT_BOOTSTRAP_RETRY_ATTEMPTS,
+      ),
     ).toBeNull();
   });
 

--- a/apps/web/src/wsTransport.ts
+++ b/apps/web/src/wsTransport.ts
@@ -270,6 +270,9 @@ const RETRYABLE_STREAM_DUPLICATE_ERROR_CODES = new Set([
 ]);
 const DEFAULT_STREAM_DUPLICATE_RETRY_MS = 250;
 export const MAX_STREAM_DUPLICATE_RETRY_ATTEMPTS = 5;
+const THREAD_SNAPSHOT_BOOTSTRAP_ERROR_CODE = "THREAD_SNAPSHOT_NOT_FOUND";
+const DEFAULT_THREAD_SNAPSHOT_BOOTSTRAP_RETRY_MS = 100;
+export const MAX_THREAD_SNAPSHOT_BOOTSTRAP_RETRY_ATTEMPTS = 12;
 
 /**
  * Duplicate rejections arrive marked `retryable: false` because one socket may
@@ -297,14 +300,42 @@ export function getStreamDuplicateRetryDelayMs(
   return null;
 }
 
+/**
+ * A visible local draft subscribes before its `thread.create` projection exists
+ * so it cannot miss the first provider events. The event journal and projection
+ * commit independently, leaving a short window where that valid subscription
+ * receives THREAD_SNAPSHOT_NOT_FOUND. Retry only that admission race in place;
+ * bounded attempts still surface genuinely missing or deleted thread ids.
+ */
+export function getThreadSnapshotBootstrapRetryDelayMs(
+  cause: Cause.Cause<unknown>,
+  previousAttempts: number,
+): number | null {
+  if (previousAttempts >= MAX_THREAD_SNAPSHOT_BOOTSTRAP_RETRY_ATTEMPTS) return null;
+  for (const reason of cause.reasons) {
+    if (!Cause.isFailReason(reason)) continue;
+    const error = reason.error;
+    if (!error || typeof error !== "object") continue;
+    const code = "code" in error ? error.code : undefined;
+    if (code !== THREAD_SNAPSHOT_BOOTSTRAP_ERROR_CODE) continue;
+    const retryAfterMs = "retryAfterMs" in error ? error.retryAfterMs : undefined;
+    return typeof retryAfterMs === "number" && retryAfterMs > 0
+      ? retryAfterMs
+      : DEFAULT_THREAD_SNAPSHOT_BOOTSTRAP_RETRY_MS;
+  }
+  return null;
+}
+
 export type StreamAdmissionRetry =
   | { readonly kind: "capacity"; readonly attempt: number; readonly delayMs: number }
-  | { readonly kind: "duplicate"; readonly attempt: number; readonly delayMs: number };
+  | { readonly kind: "duplicate"; readonly attempt: number; readonly delayMs: number }
+  | { readonly kind: "thread-bootstrap"; readonly attempt: number; readonly delayMs: number };
 
 export function resolveStreamAdmissionRetry(
   cause: Cause.Cause<unknown>,
   capacityAttempts: number,
   duplicateAttempts: number,
+  threadBootstrapAttempts = 0,
 ): StreamAdmissionRetry | null {
   const capacityDelayMs = getStreamCapacityRetryDelayMs(cause);
   if (capacityDelayMs !== null) {
@@ -315,13 +346,22 @@ export function resolveStreamAdmissionRetry(
     };
   }
   const duplicateDelayMs = getStreamDuplicateRetryDelayMs(cause, duplicateAttempts);
-  if (duplicateDelayMs === null) {
-    return null;
+  if (duplicateDelayMs !== null) {
+    return {
+      kind: "duplicate",
+      attempt: duplicateAttempts + 1,
+      delayMs: duplicateDelayMs,
+    };
   }
+  const threadBootstrapDelayMs = getThreadSnapshotBootstrapRetryDelayMs(
+    cause,
+    threadBootstrapAttempts,
+  );
+  if (threadBootstrapDelayMs === null) return null;
   return {
-    kind: "duplicate",
-    attempt: duplicateAttempts + 1,
-    delayMs: duplicateDelayMs,
+    kind: "thread-bootstrap",
+    attempt: threadBootstrapAttempts + 1,
+    delayMs: threadBootstrapDelayMs,
   };
 }
 
@@ -416,6 +456,7 @@ export class WsTransport {
   private readonly streamSettled = new Map<string, Promise<void>>();
   private readonly streamCapacityRetries = new Map<string, number>();
   private readonly streamDuplicateRetries = new Map<string, number>();
+  private readonly streamThreadBootstrapRetries = new Map<string, number>();
   private readonly streamCapacityRetryTimers = new Map<string, number>();
   private readonly activeThreadStreamInputs = new Map<string, unknown>();
   private shellSubscribed = false;
@@ -761,6 +802,7 @@ export class WsTransport {
     this.clearStreamCapacityRetryTimer(key);
     this.streamCapacityRetries.delete(key);
     this.streamDuplicateRetries.delete(key);
+    this.streamThreadBootstrapRetries.delete(key);
   }
 
   private resetAllStreamCapacityRetries(): void {
@@ -770,6 +812,7 @@ export class WsTransport {
     this.streamCapacityRetryTimers.clear();
     this.streamCapacityRetries.clear();
     this.streamDuplicateRetries.clear();
+    this.streamThreadBootstrapRetries.clear();
   }
 
   private setCompatibilityIssue(issue: WsCompatibilityError | null): void {
@@ -1046,6 +1089,9 @@ export class WsTransport {
           if (this.streamDuplicateRetries.has(key)) {
             this.streamDuplicateRetries.delete(key);
           }
+          if (this.streamThreadBootstrapRetries.has(key)) {
+            this.streamThreadBootstrapRetries.delete(key);
+          }
           listener(event);
         }),
       ),
@@ -1068,12 +1114,15 @@ export class WsTransport {
               exit.cause,
               this.streamCapacityRetries.get(key) ?? 0,
               this.streamDuplicateRetries.get(key) ?? 0,
+              this.streamThreadBootstrapRetries.get(key) ?? 0,
             );
             if (admissionRetry !== null) {
               const retries =
                 admissionRetry.kind === "capacity"
                   ? this.streamCapacityRetries
-                  : this.streamDuplicateRetries;
+                  : admissionRetry.kind === "duplicate"
+                    ? this.streamDuplicateRetries
+                    : this.streamThreadBootstrapRetries;
               retries.set(key, admissionRetry.attempt);
               this.clearStreamCapacityRetryTimer(key);
               const timeoutId = window.setTimeout(
@@ -1137,6 +1186,7 @@ export class WsTransport {
     if (options?.resetCapacityRetry !== false) {
       this.streamCapacityRetries.delete(key);
       this.streamDuplicateRetries.delete(key);
+      this.streamThreadBootstrapRetries.delete(key);
     }
     this.activeThreadStreamInputs.delete(key);
     const cleanup = this.streamCleanups.get(key);

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -25,6 +25,13 @@ export default mergeConfig(
         provider: playwright(),
         instances: [{ browser: "chromium" }],
         headless: true,
+        api: {
+          // Vitest's default 63315 falls inside common Windows/Hyper-V
+          // excluded-port ranges. Keep the local browser harness on IPv4 and
+          // allow CI or developers to override the fallback port.
+          host: process.env.VITEST_BROWSER_API_HOST ?? "127.0.0.1",
+          port: Number(process.env.VITEST_BROWSER_API_PORT ?? 51_100),
+        },
       },
       testTimeout: 30_000,
       hookTimeout: 30_000,

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -33,8 +33,10 @@ export default mergeConfig(
           port: Number(process.env.VITEST_BROWSER_API_PORT ?? 51_100),
         },
       },
-      testTimeout: 30_000,
-      hookTimeout: 30_000,
+      // The full desktop route graph can take more than 30 seconds to compile
+      // on a cold Windows cache before an individual browser test can proceed.
+      testTimeout: 90_000,
+      hookTimeout: 90_000,
     },
   }),
 );

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -162,6 +162,8 @@ import type {
   ClientOrchestrationCommand,
   OrchestrationGetFullThreadDiffInput,
   OrchestrationGetFullThreadDiffResult,
+  OrchestrationGetThreadDetailSnapshotInput,
+  OrchestrationGetThreadDetailSnapshotResult,
   OrchestrationImportThreadInput,
   OrchestrationImportThreadResult,
   OrchestrationListProviderDeliveryBlockersInput,
@@ -710,6 +712,9 @@ export interface NativeApi {
   orchestration: {
     getSnapshot: () => Promise<OrchestrationReadModel>;
     getShellSnapshot: () => Promise<OrchestrationShellSnapshot>;
+    getThreadDetailSnapshot: (
+      input: OrchestrationGetThreadDetailSnapshotInput,
+    ) => Promise<OrchestrationGetThreadDetailSnapshotResult>;
     dispatchCommand: (command: ClientOrchestrationCommand) => Promise<{ sequence: number }>;
     importThread: (
       input: OrchestrationImportThreadInput,

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -32,6 +32,7 @@ import {
 export const ORCHESTRATION_WS_METHODS = {
   getSnapshot: "orchestration.getSnapshot",
   getShellSnapshot: "orchestration.getShellSnapshot",
+  getThreadDetailSnapshot: "orchestration.getThreadDetailSnapshot",
   dispatchCommand: "orchestration.dispatchCommand",
   importThread: "orchestration.importThread",
   repairState: "orchestration.repairState",
@@ -2426,6 +2427,16 @@ export const OrchestrationSubscribeThreadInput = Schema.Struct({
 });
 export type OrchestrationSubscribeThreadInput = typeof OrchestrationSubscribeThreadInput.Type;
 
+export const OrchestrationGetThreadDetailSnapshotInput = OrchestrationSubscribeThreadInput;
+export type OrchestrationGetThreadDetailSnapshotInput =
+  typeof OrchestrationGetThreadDetailSnapshotInput.Type;
+
+export const OrchestrationGetThreadDetailSnapshotResult = Schema.NullOr(
+  OrchestrationThreadDetailSnapshot,
+);
+export type OrchestrationGetThreadDetailSnapshotResult =
+  typeof OrchestrationGetThreadDetailSnapshotResult.Type;
+
 export const OrchestrationImportThreadInput = Schema.Struct({
   threadId: ThreadId,
   externalId: TrimmedNonEmptyString,
@@ -2450,6 +2461,10 @@ export const OrchestrationRpcSchemas = {
   getShellSnapshot: {
     input: OrchestrationGetShellSnapshotInput,
     output: OrchestrationGetShellSnapshotResult,
+  },
+  getThreadDetailSnapshot: {
+    input: OrchestrationGetThreadDetailSnapshotInput,
+    output: OrchestrationGetThreadDetailSnapshotResult,
   },
   repairState: {
     input: OrchestrationRepairStateInput,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -260,6 +260,15 @@ export const WsOrchestrationGetFullThreadDiffRpc = Rpc.make(
   },
 );
 
+export const WsOrchestrationGetThreadDetailSnapshotRpc = Rpc.make(
+  ORCHESTRATION_WS_METHODS.getThreadDetailSnapshot,
+  {
+    payload: OrchestrationRpcSchemas.getThreadDetailSnapshot.input,
+    success: OrchestrationRpcSchemas.getThreadDetailSnapshot.output,
+    error: WsRpcError,
+  },
+);
+
 export const WsOrchestrationReplayEventsRpc = Rpc.make(ORCHESTRATION_WS_METHODS.replayEvents, {
   payload: OrchestrationRpcSchemas.replayEvents.input,
   success: OrchestrationRpcSchemas.replayEvents.output,
@@ -975,6 +984,7 @@ export const WsFeatureRpcGroup = RpcGroup.make(
   WsOrchestrationImportThreadRpc,
   WsOrchestrationGetSnapshotRpc,
   WsOrchestrationGetShellSnapshotRpc,
+  WsOrchestrationGetThreadDetailSnapshotRpc,
   WsOrchestrationRepairStateRpc,
   WsOrchestrationGetTurnDiffRpc,
   WsOrchestrationGetFullThreadDiffRpc,

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -26,6 +26,7 @@ import {
   OrchestrationUnsubscribeThreadInput,
   ORCHESTRATION_WS_CHANNELS,
   OrchestrationGetFullThreadDiffInput,
+  OrchestrationGetThreadDetailSnapshotInput,
   OrchestrationGetShellSnapshotInput,
   OrchestrationRepairStateInput,
   ORCHESTRATION_WS_METHODS,
@@ -286,6 +287,10 @@ const WebSocketRequestBody = Schema.Union([
   tagRequestBody(ORCHESTRATION_WS_METHODS.importThread, OrchestrationImportThreadInput),
   tagRequestBody(ORCHESTRATION_WS_METHODS.getSnapshot, OrchestrationGetSnapshotInput),
   tagRequestBody(ORCHESTRATION_WS_METHODS.getShellSnapshot, OrchestrationGetShellSnapshotInput),
+  tagRequestBody(
+    ORCHESTRATION_WS_METHODS.getThreadDetailSnapshot,
+    OrchestrationGetThreadDetailSnapshotInput,
+  ),
   tagRequestBody(ORCHESTRATION_WS_METHODS.repairState, OrchestrationRepairStateInput),
   tagRequestBody(ORCHESTRATION_WS_METHODS.getTurnDiff, OrchestrationGetTurnDiffInput),
   tagRequestBody(ORCHESTRATION_WS_METHODS.getFullThreadDiff, OrchestrationGetFullThreadDiffInput),

--- a/packages/contracts/src/wsCompatibility.ts
+++ b/packages/contracts/src/wsCompatibility.ts
@@ -26,6 +26,7 @@ export const WS_COMPATIBILITY_QUERY = {
 
 export const WS_SERVER_CAPABILITIES = [
   "orchestration.cursor-safe-streams",
+  "orchestration.thread-detail-snapshot",
   "rpc.typed-errors",
 ] as const;
 


### PR DESCRIPTION
## Summary
- reconcile missed thread completion from the authoritative projection
- avoid false stale recovery for queued starts without a concrete turn
- deduplicate repeated historical recovery rows

## Validation
- focused server, work-log, transport, and browser recovery tests passed