### PR TITLE
fix: recover provider status after reconnect

### DIFF
--- a/apps/web/src/hooks/useProviderStatusRefresh.ts
+++ b/apps/web/src/hooks/useProviderStatusRefresh.ts
@@ -6,10 +6,10 @@
 
 import { useEffect } from "react";
 import { type QueryClient, useQueryClient } from "@tanstack/react-query";
-import type { ServerConfig, ServerProviderStatus } from "@synara/contracts";
+import type { ServerProviderStatus } from "@synara/contracts";
 import { toastManager } from "../components/ui/toast";
 import { readNativeApi } from "../nativeApi";
-import { serverQueryKeys } from "../lib/serverReactQuery";
+import { reconcileServerProviderStatuses } from "../lib/serverReactQuery";
 
 export type RefreshProviderStatusesOptions = {
   readonly silent?: boolean;
@@ -23,9 +23,7 @@ function writeProviderStatusesToConfigCache(
   queryClient: QueryClient,
   providers: readonly ServerProviderStatus[],
 ) {
-  queryClient.setQueryData<ServerConfig>(serverQueryKeys.config(), (current) =>
-    current ? { ...current, providers } : current,
-  );
+  return reconcileServerProviderStatuses(queryClient, providers);
 }
 
 /**
@@ -39,7 +37,7 @@ export function useRefreshProviderStatusesNow(): RefreshProviderStatusesNow {
     if (!api) return null;
     try {
       const result = await api.server.refreshProviders();
-      writeProviderStatusesToConfigCache(queryClient, result.providers);
+      await writeProviderStatusesToConfigCache(queryClient, result.providers);
       return result.providers;
     } catch (error) {
       if (!options?.silent) {
@@ -97,7 +95,7 @@ export function useProviderStatusRefresh(options: ProviderStatusRefreshOptions):
           if (disposed) {
             return;
           }
-          writeProviderStatusesToConfigCache(queryClient, result.providers);
+          return writeProviderStatusesToConfigCache(queryClient, result.providers);
         })
         .catch(() => undefined);
     };

--- a/apps/web/src/lib/serverReactQuery.test.ts
+++ b/apps/web/src/lib/serverReactQuery.test.ts
@@ -2,16 +2,102 @@
 // Purpose: Locks down server React Query polling profiles and cache options.
 // Layer: Web data-fetching unit tests
 
+import type { ServerConfig, ServerProviderStatus } from "@synara/contracts";
+import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, it } from "vitest";
 
 import {
   LOCAL_SERVERS_VISIBLE_REFETCH_INTERVAL_MS,
+  reconcileServerProviderStatuses,
+  serverConfigQueryOptions,
   serverAllProviderUsageQueryOptions,
   serverLocalServersQueryOptions,
   serverProviderUsageSnapshotQueryOptions,
   serverQueryKeys,
   sidebarLocalServersQueryOptions,
 } from "./serverReactQuery";
+
+const READY_CODEX_STATUS = {
+  provider: "codex",
+  status: "ready",
+  available: true,
+  authStatus: "authenticated",
+  checkedAt: "2026-07-26T16:41:38.945Z",
+} satisfies ServerProviderStatus;
+
+function makeServerConfig(providers: readonly ServerProviderStatus[]): ServerConfig {
+  return {
+    cwd: "G:\\synara",
+    homeDir: "C:\\Users\\tester",
+    chatWorkspaceRoot: "C:\\Users\\tester\\Documents\\Synara",
+    studioWorkspaceRoot: "C:\\Users\\tester\\Documents\\Synara\\Studio",
+    worktreesDir: "C:\\SynaraDev\\worktrees",
+    keybindingsConfigPath: "C:\\SynaraDev\\keybindings.json",
+    keybindings: [],
+    issues: [],
+    providers,
+    availableEditors: [],
+  };
+}
+
+describe("server provider status reconciliation", () => {
+  it("applies a missed live snapshot after the config projection hydrates", async () => {
+    const queryClient = new QueryClient();
+    let resolveConfig!: (config: ServerConfig) => void;
+    const configProjection = new Promise<ServerConfig>((resolve) => {
+      resolveConfig = resolve;
+    });
+
+    const reconciliation = reconcileServerProviderStatuses(queryClient, [READY_CODEX_STATUS], {
+      loadConfig: () => configProjection,
+    });
+
+    expect(queryClient.getQueryData(serverQueryKeys.config())).toBeUndefined();
+
+    resolveConfig(makeServerConfig([]));
+    await reconciliation;
+
+    expect(queryClient.getQueryData<ServerConfig>(serverQueryKeys.config())?.providers).toEqual([
+      READY_CODEX_STATUS,
+    ]);
+  });
+
+  it("keeps the newest provider snapshot when hydration overlaps multiple events", async () => {
+    const queryClient = new QueryClient();
+    let resolveConfig!: (config: ServerConfig) => void;
+    const configProjection = new Promise<ServerConfig>((resolve) => {
+      resolveConfig = resolve;
+    });
+    const unavailableStatus = {
+      ...READY_CODEX_STATUS,
+      status: "warning",
+      available: false,
+      authStatus: "unknown",
+      checkedAt: "2026-07-26T16:40:00.000Z",
+    } satisfies ServerProviderStatus;
+
+    const first = reconcileServerProviderStatuses(queryClient, [unavailableStatus], {
+      loadConfig: () => configProjection,
+    });
+    const second = reconcileServerProviderStatuses(queryClient, [READY_CODEX_STATUS], {
+      loadConfig: () => configProjection,
+    });
+
+    resolveConfig(makeServerConfig([]));
+    await Promise.all([first, second]);
+
+    expect(queryClient.getQueryData<ServerConfig>(serverQueryKeys.config())?.providers).toEqual([
+      READY_CODEX_STATUS,
+    ]);
+  });
+
+  it("marks server config for reconnect and focus refresh", () => {
+    const options = serverConfigQueryOptions();
+
+    expect(options.refetchOnReconnect).toBe(true);
+    expect(options.refetchOnWindowFocus).toBe(true);
+  });
+});
 
 describe("serverLocalServersQueryOptions", () => {
   it("uses the visible polling interval by default", () => {

--- a/apps/web/src/lib/serverReactQuery.test.ts
+++ b/apps/web/src/lib/serverReactQuery.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from "vitest";
 import {
   LOCAL_SERVERS_VISIBLE_REFETCH_INTERVAL_MS,
   reconcileServerProviderStatuses,
-  serverConfigQueryOptions,
+  refreshServerConfigAfterTransportOpen,
   serverAllProviderUsageQueryOptions,
   serverLocalServersQueryOptions,
   serverProviderUsageSnapshotQueryOptions,
@@ -91,11 +91,52 @@ describe("server provider status reconciliation", () => {
     ]);
   });
 
-  it("marks server config for reconnect and focus refresh", () => {
-    const options = serverConfigQueryOptions();
+  it("keeps a provider snapshot that arrives during reconnect config refresh", async () => {
+    const queryClient = new QueryClient();
+    const unavailableStatus = {
+      ...READY_CODEX_STATUS,
+      status: "warning",
+      available: false,
+      authStatus: "unknown",
+      checkedAt: "2026-07-26T16:40:00.000Z",
+    } satisfies ServerProviderStatus;
+    queryClient.setQueryData(serverQueryKeys.config(), makeServerConfig([unavailableStatus]));
+    let resolveConfig!: (config: ServerConfig) => void;
+    const configProjection = new Promise<ServerConfig>((resolve) => {
+      resolveConfig = resolve;
+    });
 
-    expect(options.refetchOnReconnect).toBe(true);
-    expect(options.refetchOnWindowFocus).toBe(true);
+    const refresh = refreshServerConfigAfterTransportOpen(queryClient, {
+      loadConfig: () => configProjection,
+    });
+    await reconcileServerProviderStatuses(queryClient, [READY_CODEX_STATUS]);
+    resolveConfig(makeServerConfig([unavailableStatus]));
+    await refresh;
+
+    expect(queryClient.getQueryData<ServerConfig>(serverQueryKeys.config())?.providers).toEqual([
+      READY_CODEX_STATUS,
+    ]);
+  });
+
+  it("accepts reconnect config when no newer provider snapshot arrives", async () => {
+    const queryClient = new QueryClient();
+    const unavailableStatus = {
+      ...READY_CODEX_STATUS,
+      status: "warning",
+      available: false,
+      authStatus: "unknown",
+      checkedAt: "2026-07-26T16:40:00.000Z",
+    } satisfies ServerProviderStatus;
+    queryClient.setQueryData(serverQueryKeys.config(), makeServerConfig([unavailableStatus]));
+    await reconcileServerProviderStatuses(queryClient, [unavailableStatus]);
+
+    await refreshServerConfigAfterTransportOpen(queryClient, {
+      loadConfig: async () => makeServerConfig([READY_CODEX_STATUS]),
+    });
+
+    expect(queryClient.getQueryData<ServerConfig>(serverQueryKeys.config())?.providers).toEqual([
+      READY_CODEX_STATUS,
+    ]);
   });
 });
 

--- a/apps/web/src/lib/serverReactQuery.ts
+++ b/apps/web/src/lib/serverReactQuery.ts
@@ -44,15 +44,27 @@ export function serverConfigQueryOptions() {
       return api.server.getConfig();
     },
     staleTime: Infinity,
-    refetchOnWindowFocus: true,
-    refetchOnReconnect: true,
   });
 }
 
-const latestProviderStatusesByQueryClient = new WeakMap<
-  QueryClient,
-  readonly ServerProviderStatus[]
->();
+interface ProviderStatusSnapshot {
+  readonly revision: number;
+  readonly providers: readonly ServerProviderStatus[];
+}
+
+const latestProviderStatusSnapshotByQueryClient = new WeakMap<QueryClient, ProviderStatusSnapshot>();
+
+function recordProviderStatusSnapshot(
+  queryClient: QueryClient,
+  providers: readonly ServerProviderStatus[],
+): ProviderStatusSnapshot {
+  const snapshot = {
+    revision: (latestProviderStatusSnapshotByQueryClient.get(queryClient)?.revision ?? 0) + 1,
+    providers,
+  };
+  latestProviderStatusSnapshotByQueryClient.set(queryClient, snapshot);
+  return snapshot;
+}
 
 /**
  * Folds an authoritative provider snapshot into server.config. Provider streams
@@ -66,7 +78,7 @@ export async function reconcileServerProviderStatuses(
     readonly loadConfig?: () => Promise<ServerConfig>;
   },
 ): Promise<void> {
-  latestProviderStatusesByQueryClient.set(queryClient, providers);
+  recordProviderStatusSnapshot(queryClient, providers);
 
   let applied = false;
   queryClient.setQueryData<ServerConfig>(serverQueryKeys.config(), (current) => {
@@ -84,11 +96,42 @@ export async function reconcileServerProviderStatuses(
         staleTime: 0,
       }));
   const hydratedConfig = await loadConfig();
-  const latestProviders = latestProviderStatusesByQueryClient.get(queryClient) ?? providers;
+  const latestProviders =
+    latestProviderStatusSnapshotByQueryClient.get(queryClient)?.providers ?? providers;
   queryClient.setQueryData<ServerConfig>(serverQueryKeys.config(), (current) => ({
     ...(current ?? hydratedConfig),
     providers: latestProviders,
   }));
+}
+
+/**
+ * Refreshes the config projection when the WebSocket reopens without letting
+ * the response overwrite a provider snapshot that arrived while it was in flight.
+ */
+export async function refreshServerConfigAfterTransportOpen(
+  queryClient: QueryClient,
+  options?: {
+    readonly loadConfig?: () => Promise<ServerConfig>;
+  },
+): Promise<void> {
+  const providerRevisionAtStart =
+    latestProviderStatusSnapshotByQueryClient.get(queryClient)?.revision ?? 0;
+  const loadConfig =
+    options?.loadConfig ??
+    (() =>
+      queryClient.fetchQuery({
+        ...serverConfigQueryOptions(),
+        staleTime: 0,
+      }));
+  const config = await loadConfig();
+  const latestProviderSnapshot = latestProviderStatusSnapshotByQueryClient.get(queryClient);
+  queryClient.setQueryData<ServerConfig>(serverQueryKeys.config(), {
+    ...config,
+    providers:
+      latestProviderSnapshot && latestProviderSnapshot.revision > providerRevisionAtStart
+        ? latestProviderSnapshot.providers
+        : config.providers,
+  });
 }
 
 export function serverAuthSessionQueryOptions() {

--- a/apps/web/src/lib/serverReactQuery.ts
+++ b/apps/web/src/lib/serverReactQuery.ts
@@ -1,6 +1,8 @@
 import type {
   ProviderKind,
+  ServerConfig,
   ServerListProviderUsageInput,
+  ServerProviderStatus,
   ServerStopLocalServerInput,
   ThreadId,
 } from "@synara/contracts";
@@ -42,7 +44,51 @@ export function serverConfigQueryOptions() {
       return api.server.getConfig();
     },
     staleTime: Infinity,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
   });
+}
+
+const latestProviderStatusesByQueryClient = new WeakMap<
+  QueryClient,
+  readonly ServerProviderStatus[]
+>();
+
+/**
+ * Folds an authoritative provider snapshot into server.config. Provider streams
+ * can win the race against the initial config query, so retain the latest
+ * snapshot and apply it after config hydration instead of dropping it.
+ */
+export async function reconcileServerProviderStatuses(
+  queryClient: QueryClient,
+  providers: readonly ServerProviderStatus[],
+  options?: {
+    readonly loadConfig?: () => Promise<ServerConfig>;
+  },
+): Promise<void> {
+  latestProviderStatusesByQueryClient.set(queryClient, providers);
+
+  let applied = false;
+  queryClient.setQueryData<ServerConfig>(serverQueryKeys.config(), (current) => {
+    if (!current) return current;
+    applied = true;
+    return { ...current, providers };
+  });
+  if (applied) return;
+
+  const loadConfig =
+    options?.loadConfig ??
+    (() =>
+      queryClient.fetchQuery({
+        ...serverConfigQueryOptions(),
+        staleTime: 0,
+      }));
+  const hydratedConfig = await loadConfig();
+  const latestProviders = latestProviderStatusesByQueryClient.get(queryClient) ?? providers;
+  queryClient.setQueryData<ServerConfig>(serverQueryKeys.config(), (current) => ({
+    ...(current ?? hydratedConfig),
+    providers: latestProviders,
+  }));
 }
 
 export function serverAuthSessionQueryOptions() {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -44,6 +44,7 @@ import type { FeedbackThreadContext } from "../feedback";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import {
   reconcileServerProviderStatuses,
+  refreshServerConfigAfterTransportOpen,
   serverConfigQueryOptions,
   serverQueryKeys,
   serverSettingsQueryOptions,
@@ -1554,14 +1555,7 @@ function EventRouter() {
         previousProviderDiscoveryFingerprint !== nextProviderDiscoveryFingerprint;
       providerDiscoveryInvalidationFingerprint = nextProviderDiscoveryFingerprint;
 
-      if (!currentConfig) {
-        void reconcileServerProviderStatuses(queryClient, payload.providers).catch(() => undefined);
-        return;
-      }
-      queryClient.setQueryData(serverQueryKeys.config(), {
-        ...currentConfig,
-        providers: payload.providers,
-      });
+      void reconcileServerProviderStatuses(queryClient, payload.providers).catch(() => undefined);
       if (shouldInvalidateProviderDiscovery) {
         // Model and agent discovery can depend on auth, availability, and installed versions,
         // but not on every provider-status timestamp replay.
@@ -1587,12 +1581,7 @@ function EventRouter() {
         if (state !== "open") return;
         // Reopening the socket is a projection boundary. React Query otherwise
         // keeps the previous infinite-stale config and can strand "Checking".
-        void queryClient
-          .fetchQuery({
-            ...serverConfigQueryOptions(),
-            staleTime: 0,
-          })
-          .catch(() => undefined);
+        void refreshServerConfigAfterTransportOpen(queryClient).catch(() => undefined);
       },
       { replayCurrent: true },
     );

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -43,6 +43,7 @@ import { useFeedbackDialogStore } from "../feedbackDialogStore";
 import type { FeedbackThreadContext } from "../feedback";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import {
+  reconcileServerProviderStatuses,
   serverConfigQueryOptions,
   serverQueryKeys,
   serverSettingsQueryOptions,
@@ -66,6 +67,7 @@ import {
 } from "../wsNativeApi";
 import {
   addWsCompatibilityIssueListener,
+  addWsTransportStateListener,
   readLatestWsCompatibilityIssue,
 } from "../wsTransportEvents";
 import { providerQueryKeys } from "../lib/providerReactQuery";
@@ -1553,7 +1555,7 @@ function EventRouter() {
       providerDiscoveryInvalidationFingerprint = nextProviderDiscoveryFingerprint;
 
       if (!currentConfig) {
-        void queryClient.fetchQuery(serverConfigQueryOptions()).catch(() => undefined);
+        void reconcileServerProviderStatuses(queryClient, payload.providers).catch(() => undefined);
         return;
       }
       queryClient.setQueryData(serverQueryKeys.config(), {
@@ -1580,6 +1582,20 @@ function EventRouter() {
         });
       }
     });
+    const unsubWsTransportState = addWsTransportStateListener(
+      (state) => {
+        if (state !== "open") return;
+        // Reopening the socket is a projection boundary. React Query otherwise
+        // keeps the previous infinite-stale config and can strand "Checking".
+        void queryClient
+          .fetchQuery({
+            ...serverConfigQueryOptions(),
+            staleTime: 0,
+          })
+          .catch(() => undefined);
+      },
+      { replayCurrent: true },
+    );
     const unsubServerSettingsUpdated = onServerSettingsUpdated((payload) => {
       queryClient.setQueryData(serverQueryKeys.settings(), payload.settings);
       void queryClient.invalidateQueries({
@@ -1638,6 +1654,7 @@ function EventRouter() {
       unsubWelcome();
       unsubServerConfigUpdated();
       unsubProviderStatusesUpdated();
+      unsubWsTransportState();
       unsubServerSettingsUpdated();
     };
   }, [

--- a/apps/web/src/wsTransportEvents.test.ts
+++ b/apps/web/src/wsTransportEvents.test.ts
@@ -1,0 +1,20 @@
+// FILE: wsTransportEvents.test.ts
+// Purpose: Locks down transport-state replay used for projection reconciliation.
+// Layer: Web transport utility unit tests
+
+import { describe, expect, it, vi } from "vitest";
+
+import { addWsTransportStateListener, emitWsTransportState } from "./wsTransportEvents";
+
+describe("WebSocket transport state events", () => {
+  it("replays an already-open transport to a late reconciliation listener", () => {
+    emitWsTransportState("open");
+    const listener = vi.fn();
+
+    const unsubscribe = addWsTransportStateListener(listener, { replayCurrent: true });
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith("open");
+    unsubscribe();
+  });
+});

--- a/apps/web/src/wsTransportEvents.ts
+++ b/apps/web/src/wsTransportEvents.ts
@@ -11,6 +11,7 @@ export const SYNARA_WS_TRANSPORT_STATE_EVENT = "synara:ws-transport-state";
 export const SYNARA_WS_COMPATIBILITY_ISSUE_EVENT = "synara:ws-compatibility-issue";
 
 let latestCompatibilityIssue: WsCompatibilityError | null = null;
+let latestTransportState: WsTransportState | null = null;
 
 export interface WsTransportStateEventDetail {
   state: WsTransportState;
@@ -22,6 +23,7 @@ export interface WsCompatibilityIssueEventDetail {
 
 // Emits a browser-local event without leaking transport internals into UI code.
 export function emitWsTransportState(state: WsTransportState): void {
+  latestTransportState = state;
   if (
     typeof window === "undefined" ||
     typeof window.dispatchEvent !== "function" ||
@@ -40,7 +42,11 @@ export function emitWsTransportState(state: WsTransportState): void {
 // Subscribes to the shared transport state event. Returns an idempotent cleanup.
 export function addWsTransportStateListener(
   listener: (state: WsTransportState) => void,
+  options?: { readonly replayCurrent?: boolean },
 ): () => void {
+  if (options?.replayCurrent && latestTransportState) {
+    listener(latestTransportState);
+  }
   if (typeof window === "undefined" || typeof window.addEventListener !== "function") {
     return () => undefined;
   }


### PR DESCRIPTION
## Summary
- reconcile provider statuses after hydration races
- refresh infinite-stale server config when the socket reopens
- add transport-state replay coverage

## Validation
- focused query and transport event tests passed