### PR TITLE
feat: simplify model effort controls

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -443,13 +443,9 @@ import type { MessagesTimelineController } from "./chat/MessagesTimeline";
 import { buildTurnDiffSummaryByAssistantMessageId } from "./chat/MessagesTimeline.logic";
 import { deriveAgentActivityTimelineState } from "./chat/agentActivity.logic";
 import { ExpandedImagePreview } from "./chat/ExpandedImagePreview";
-import {
-  AVAILABLE_PROVIDER_OPTIONS,
-  ProviderModelPicker,
-  resolveProviderModelLabel,
-} from "./chat/ProviderModelPicker";
+import { AVAILABLE_PROVIDER_OPTIONS, resolveProviderModelLabel } from "./chat/ProviderModelPicker";
 import { ComposerModelEffortPicker } from "./chat/ComposerModelEffortPicker";
-import { resolveTraitsTriggerSummary, TraitsPicker } from "./chat/TraitsPicker";
+import { resolveTraitsTriggerSummary } from "./chat/TraitsPicker";
 import { ComposerCommandItem, ComposerCommandMenu } from "./chat/ComposerCommandMenu";
 import {
   ComposerLocalDirectoryMenu,
@@ -3766,10 +3762,6 @@ export default function ChatView({
         altKey: false,
         modKey: true,
       }),
-    [keybindings],
-  );
-  const traitsPickerShortcutLabel = useMemo(
-    () => shortcutLabelForCommand(keybindings, "traitsPicker.toggle"),
     [keybindings],
   );
   const onToggleDiff = useCallback(() => {
@@ -8631,7 +8623,6 @@ export default function ChatView({
       }),
     [runtimeUsageContextWindow, composerTraitSelection.contextWindow, selectedProvider],
   );
-  const useSplitComposerPickerControls = isLocalDraftThread && !hasThreadStarted;
   const composerFooterControlsPlan = useMemo(
     () => composerFooterPlanForTier(composerFooterTier, Boolean(runtimeUsageContextWindow)),
     [composerFooterTier, runtimeUsageContextWindow],
@@ -8657,7 +8648,6 @@ export default function ChatView({
     composerFooterModelLabel,
     composerFooterTraitsSummary.summaryText,
     Boolean(runtimeUsageContextWindow),
-    useSplitComposerPickerControls,
   ].join(":");
   useLayoutEffect(() => {
     composerFooterDemotionWidthsRef.current = [];
@@ -8670,8 +8660,6 @@ export default function ChatView({
   useLayoutEffect(() => {
     composerFooterLayoutSyncRef.current?.();
   }, [composerFooterTier]);
-  const composerModelPickerWidthClassName = isComposerFooterCompact ? "w-32" : "w-36 sm:w-44";
-  const composerOptionsPickerWidthClassName = isComposerFooterCompact ? "w-28" : "w-32";
   const composerModelEffortPickerWidthClassName = isComposerFooterCompact ? "w-40" : "w-44 sm:w-52";
   const isComposerModelEffortPickerOpen = isModelPickerOpen || isTraitsPickerOpen;
   const handleComposerModelEffortPickerOpenChange = useCallback(
@@ -8686,56 +8674,11 @@ export default function ChatView({
     [handleModelPickerOpenChange],
   );
   const composerPickerControls = showComposerModelBootstrapSkeleton ? (
-    useSplitComposerPickerControls ? (
-      <>
-        {selectedProviderRuntimeModelDiscoveryPending ? (
-          <ComposerModelLoadingControl widthClassName={composerModelPickerWidthClassName} />
-        ) : (
-          <ComposerControlSkeleton widthClassName={composerModelPickerWidthClassName} />
-        )}
-        <ComposerControlSkeleton widthClassName={composerOptionsPickerWidthClassName} />
-      </>
-    ) : selectedProviderRuntimeModelDiscoveryPending ? (
+    selectedProviderRuntimeModelDiscoveryPending ? (
       <ComposerModelLoadingControl widthClassName={composerModelEffortPickerWidthClassName} />
     ) : (
       <ComposerControlSkeleton widthClassName={composerModelEffortPickerWidthClassName} />
     )
-  ) : useSplitComposerPickerControls ? (
-    <>
-      <ProviderModelPicker
-        compact={isComposerFooterCompact}
-        hideLabel={!composerFooterControlsPlan.showModelLabel}
-        provider={selectedProvider}
-        model={selectedModelForPickerWithCustomFallback}
-        lockedProvider={lockedProvider}
-        providers={providerStatuses}
-        modelOptionsByProvider={modelOptionsByProvider}
-        loadingModelProviders={loadingModelProviders}
-        hiddenProviders={settings.hiddenProviders}
-        providerOrder={settings.providerOrder}
-        onProviderModelChange={onProviderModelSelect}
-        onSelectionCommitted={scheduleComposerFocus}
-        open={isModelPickerOpen}
-        onOpenChange={handleModelPickerOpenChange}
-        shortcutLabel={modelPickerShortcutLabel}
-      />
-      <TraitsPicker
-        provider={selectedProvider}
-        threadId={threadId}
-        model={selectedModelForPickerWithCustomFallback}
-        runtimeModel={selectedRuntimeModel}
-        runtimeModels={runtimeModelsByProvider[selectedProvider]}
-        runtimeAgents={dynamicAgents}
-        modelOptions={selectedProviderModelOptions}
-        prompt={prompt}
-        onPromptChange={setPromptFromTraits}
-        open={isTraitsPickerOpen}
-        onOpenChange={handleTraitsPickerOpenChange}
-        onSelectionCommitted={scheduleComposerFocus}
-        shortcutLabel={traitsPickerShortcutLabel}
-        hideLabel={!composerFooterControlsPlan.showTraitsLabel}
-      />
-    </>
   ) : (
     <ComposerModelEffortPicker
       compact={isComposerFooterCompact}

--- a/apps/web/src/components/chat/ComposerModelEffortPicker.browser.tsx
+++ b/apps/web/src/components/chat/ComposerModelEffortPicker.browser.tsx
@@ -2,40 +2,83 @@ import "../../index.css";
 
 import { type ModelSlug, ThreadId } from "@synara/contracts";
 import { page } from "vitest/browser";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 
+import { useComposerDraftStore } from "../../composerDraftStore";
+import { resetComposerDraftStore } from "../../composerDraftStoreTestFixtures";
 import { ComposerModelEffortPicker } from "./ComposerModelEffortPicker";
 
 const THREAD_ID = ThreadId.makeUnsafe("thread-grok-model-effort-picker");
 const GROK_4_5 = "grok-4.5" as ModelSlug;
+const CODEX_THREAD_ID = ThreadId.makeUnsafe("thread-codex-model-effort-picker");
+const CODEX_GPT_5_2 = "gpt-5.2" as ModelSlug;
+
+function renderGrokPicker() {
+  return render(
+    <ComposerModelEffortPicker
+      provider="grok"
+      model={GROK_4_5}
+      lockedProvider={null}
+      modelOptionsByProvider={{
+        claudeAgent: [],
+        codex: [],
+        cursor: [],
+        antigravity: [],
+        grok: [{ slug: GROK_4_5, name: "Grok 4.5" }],
+        droid: [],
+        kilo: [],
+        opencode: [],
+        pi: [],
+      }}
+      hideStatusLabel
+      onProviderModelChange={vi.fn()}
+      threadId={THREAD_ID}
+      modelOptions={undefined}
+      prompt=""
+      onPromptChange={vi.fn()}
+    />,
+  );
+}
+
+function renderCodexPicker() {
+  return render(
+    <ComposerModelEffortPicker
+      provider="codex"
+      model={CODEX_GPT_5_2}
+      lockedProvider={null}
+      modelOptionsByProvider={{
+        claudeAgent: [],
+        codex: [{ slug: CODEX_GPT_5_2, name: "GPT-5.2" }],
+        cursor: [],
+        antigravity: [],
+        grok: [],
+        droid: [],
+        kilo: [],
+        opencode: [],
+        pi: [],
+      }}
+      hideStatusLabel
+      onProviderModelChange={vi.fn()}
+      threadId={CODEX_THREAD_ID}
+      modelOptions={{ reasoningEffort: "xhigh", fastMode: false }}
+      prompt=""
+      onPromptChange={vi.fn()}
+    />,
+  );
+}
 
 describe("ComposerModelEffortPicker", () => {
-  it("keeps Grok effort visible in compact layouts before runtime discovery", async () => {
-    const screen = await render(
-      <ComposerModelEffortPicker
-        provider="grok"
-        model={GROK_4_5}
-        lockedProvider={null}
-        modelOptionsByProvider={{
-          claudeAgent: [],
-          codex: [],
-          cursor: [],
-          antigravity: [],
-          grok: [{ slug: GROK_4_5, name: "Grok 4.5" }],
-          droid: [],
-          kilo: [],
-          opencode: [],
-          pi: [],
-        }}
-        hideStatusLabel
-        onProviderModelChange={vi.fn()}
-        threadId={THREAD_ID}
-        modelOptions={undefined}
-        prompt=""
-        onPromptChange={vi.fn()}
-      />,
-    );
+  beforeEach(() => {
+    resetComposerDraftStore();
+  });
+
+  afterEach(() => {
+    resetComposerDraftStore();
+  });
+
+  it("maps Grok's provider-specific effort ladder onto the universal slider", async () => {
+    const screen = await renderGrokPicker();
 
     try {
       const trigger = page.getByRole("button", { name: "Change model and reasoning" });
@@ -43,10 +86,107 @@ describe("ComposerModelEffortPicker", () => {
       expect(trigger.element().querySelector('[data-slot="central-icon"]')).not.toBeNull();
 
       await trigger.click();
-      await expect.element(page.getByRole("menuitemradio", { name: "None" })).toBeVisible();
-      await expect.element(page.getByRole("menuitemradio", { name: "Low" })).toBeVisible();
-      await expect.element(page.getByRole("menuitemradio", { name: "Medium" })).toBeVisible();
-      await expect.element(page.getByRole("menuitemradio", { name: "High" })).toBeVisible();
+      await expect.element(page.getByText("Advanced", { exact: true })).toBeVisible();
+      await expect.element(page.getByRole("button", { name: "Fast mode" })).not.toBeInTheDocument();
+      const effortSlider = page.getByRole("slider", { name: "Effort" });
+      await expect.element(effortSlider).toBeVisible();
+      await expect.element(effortSlider).toHaveAttribute("min", "0");
+      await expect.element(effortSlider).toHaveAttribute("max", "3");
+      await expect.element(effortSlider).toHaveAttribute("step", "0.01");
+      await expect.element(effortSlider).toHaveAttribute("aria-valuetext", "Low");
+      expect(document.querySelector(".composer-effort-slider-electric-field")).toBeNull();
+      expect(document.querySelector(".composer-effort-slider-thumb svg")).toBeNull();
+
+      await effortSlider.fill("1.6");
+      await expect
+        .poll(() => {
+          const selection =
+            useComposerDraftStore.getState().draftsByThreadId[THREAD_ID]?.modelSelectionByProvider
+              .grok;
+          return selection?.provider === "grok" ? selection.options?.reasoningEffort : undefined;
+        })
+        .toBe("medium");
+      await expect.element(effortSlider).toBeVisible();
+    } finally {
+      await screen.unmount();
+    }
+  });
+
+  it("expands named controls inline and returns to the direct slider", async () => {
+    const screen = await renderGrokPicker();
+
+    try {
+      await page.getByRole("button", { name: "Change model and reasoning" }).click();
+      const advancedToggle = page.getByRole("menuitem", { name: "Advanced" });
+      await advancedToggle.click();
+
+      await expect.element(page.getByRole("slider", { name: "Effort" })).not.toBeInTheDocument();
+      await expect.element(page.getByText("Model", { exact: true })).toBeVisible();
+      await expect.element(page.getByText("Effort", { exact: true }).first()).toBeVisible();
+
+      advancedToggle.element().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await expect.element(page.getByRole("slider", { name: "Effort" })).toBeVisible();
+    } finally {
+      await screen.unmount();
+    }
+  });
+
+  it("keeps the Fast Mode quick toggle beside Advanced for supported models", async () => {
+    const screen = await renderCodexPicker();
+
+    try {
+      await page.getByRole("button", { name: "Change model and reasoning" }).click();
+      const fastModeToggle = page.getByRole("button", { name: "Fast mode" });
+      await expect.element(fastModeToggle).toHaveAttribute("aria-pressed", "false");
+      await expect.element(fastModeToggle).toHaveTextContent("Fast");
+
+      const fastModeButton = fastModeToggle.element();
+      const advancedLabel = page.getByText("Advanced", { exact: true }).element();
+      const advancedRow = advancedLabel.closest<HTMLElement>('[role="menuitem"]');
+      const fastModeIcon = fastModeButton.querySelector<HTMLElement>(
+        '[data-slot="fast-mode-icon"]',
+      );
+      const fastModeLabel = fastModeButton.querySelector<HTMLElement>(
+        '[data-slot="fast-mode-label"]',
+      );
+      expect(advancedRow).not.toBeNull();
+      expect(fastModeIcon).not.toBeNull();
+      expect(fastModeLabel).not.toBeNull();
+
+      const centerY = (element: HTMLElement) => {
+        const bounds = element.getBoundingClientRect();
+        return bounds.top + bounds.height / 2;
+      };
+      const buttonBounds = fastModeButton.getBoundingClientRect();
+      const iconBounds = fastModeIcon!.getBoundingClientRect();
+      const labelBounds = fastModeLabel!.getBoundingClientRect();
+      const contentCenterX =
+        (Math.min(iconBounds.left, labelBounds.left) +
+          Math.max(iconBounds.right, labelBounds.right)) /
+        2;
+      expect(Math.abs(centerY(advancedRow!) - centerY(fastModeButton))).toBeLessThanOrEqual(0.5);
+      expect(Math.abs(centerY(advancedLabel) - centerY(fastModeButton))).toBeLessThanOrEqual(0.5);
+      expect(Math.abs(centerY(fastModeButton) - centerY(fastModeIcon!))).toBeLessThanOrEqual(0.5);
+      expect(Math.abs(centerY(fastModeButton) - centerY(fastModeLabel!))).toBeLessThanOrEqual(0.5);
+      expect(
+        Math.abs(buttonBounds.left + buttonBounds.width / 2 - contentCenterX),
+      ).toBeLessThanOrEqual(0.5);
+
+      await fastModeToggle.click();
+      await expect
+        .poll(() => {
+          const selection =
+            useComposerDraftStore.getState().draftsByThreadId[CODEX_THREAD_ID]
+              ?.modelSelectionByProvider.codex;
+          return selection?.provider === "codex" ? selection.options?.fastMode : undefined;
+        })
+        .toBe(true);
+      await expect.element(page.getByRole("slider", { name: "Effort" })).toBeVisible();
+
+      advancedRow!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await expect.element(page.getByText("Model", { exact: true })).toBeVisible();
+      await expect.element(page.getByText("Effort", { exact: true }).first()).toBeVisible();
+      await expect.element(page.getByText("Speed", { exact: true })).not.toBeInTheDocument();
     } finally {
       await screen.unmount();
     }

--- a/apps/web/src/components/chat/ComposerModelEffortPicker.tsx
+++ b/apps/web/src/components/chat/ComposerModelEffortPicker.tsx
@@ -19,7 +19,9 @@ import { ChevronDownIcon, FastModeIcon, SettingsIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
 import { type ProviderModelOption } from "../../providerModelOptions";
 import { Button } from "../ui/button";
-import { Menu, MenuSeparator, MenuSub, MenuSubTrigger, MenuTrigger } from "../ui/menu";
+import { DisclosureChevron } from "../ui/DisclosureChevron";
+import { DisclosureRegion } from "../ui/DisclosureRegion";
+import { Menu, MenuItem, MenuSeparator, MenuSub, MenuSubTrigger, MenuTrigger } from "../ui/menu";
 import { ShortcutKbd } from "../ui/shortcut-kbd";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { PROVIDER_ICON_COMPONENT_BY_PROVIDER } from "../ProviderIcon";
@@ -35,7 +37,7 @@ import {
   ProviderModelMenuItems,
   resolveProviderModelLabel,
 } from "./ProviderModelPicker";
-import { TraitsMenuContent } from "./TraitsPicker";
+import { ComposerFastModeToggle, TraitsMenuContent } from "./TraitsPicker";
 
 type ComposerModelEffortPickerProps = {
   // Model picker data.
@@ -72,17 +74,20 @@ type ComposerModelEffortPickerProps = {
 };
 
 // Renders a single composer trigger that combines model selection, reasoning
-// effort, and the optional speed/fast-mode toggle. The primary menu hosts the
-// reasoning radio group (with fast mode as an icon toggle in its Effort
-// header); the model is reachable via a sub-menu so the footer stays compact.
+// effort, and speed. Providers with a real effort ladder open on the direct
+// slider; Advanced expands the named controls in the same popup.
 export function ComposerModelEffortPicker(props: ComposerModelEffortPickerProps) {
   const { onOpenChange, open } = props;
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const isMenuOpen = open ?? uncontrolledOpen;
 
   const setMenuOpen = (nextOpen: boolean) => {
     if (open === undefined) {
       setUncontrolledOpen(nextOpen);
+    }
+    if (!nextOpen) {
+      setAdvancedOpen(false);
     }
     onOpenChange?.(nextOpen);
   };
@@ -116,6 +121,9 @@ export function ComposerModelEffortPicker(props: ComposerModelEffortPickerProps)
 
   const supportsFastModeControl = fastModeDescriptor !== null || caps.supportsFastMode;
   const hasTraitsTopSection = hasVisibleComposerTraitControls(traitSelection);
+  const hasEffortControl = effortLevels.length > 0;
+  const supportsDirectEffortSlider =
+    effortLevels.length > 1 && props.provider !== "kilo" && props.provider !== "opencode";
 
   const effortLabel = effort
     ? (effortLevels.find((level) => level.value === effort)?.label ?? effort)
@@ -201,6 +209,107 @@ export function ComposerModelEffortPicker(props: ComposerModelEffortPickerProps)
     </span>
   );
 
+  const namedControls = (
+    <>
+      <MenuSub>
+        <MenuSubTrigger>
+          <span className="min-w-0 flex-1 truncate">Model</span>
+          <span className="max-w-28 truncate text-muted-foreground">{modelLabel}</span>
+        </MenuSubTrigger>
+        <ComposerPickerMenuSubPopup
+          fixedWidth
+          className={COMPOSER_PICKER_MODEL_SUBMENU_HEIGHT_CLASS_NAME}
+        >
+          <ProviderModelMenuItems
+            provider={props.provider}
+            model={props.model}
+            lockedProvider={props.lockedProvider}
+            {...(props.providers ? { providers: props.providers } : {})}
+            modelOptionsByProvider={props.modelOptionsByProvider}
+            {...(props.loadingModelProviders
+              ? { loadingModelProviders: props.loadingModelProviders }
+              : {})}
+            {...(props.hiddenProviders ? { hiddenProviders: props.hiddenProviders } : {})}
+            {...(props.providerOrder ? { providerOrder: props.providerOrder } : {})}
+            {...(props.disabled !== undefined ? { disabled: props.disabled } : {})}
+            onProviderModelChange={props.onProviderModelChange}
+            onAfterSelection={handleAfterModelSelection}
+          />
+        </ComposerPickerMenuSubPopup>
+      </MenuSub>
+
+      {hasEffortControl ? (
+        <MenuSub>
+          <MenuSubTrigger>
+            <span className="min-w-0 flex-1 truncate">
+              {props.provider === "kilo" || props.provider === "opencode" ? "Variant" : "Effort"}
+            </span>
+            <span className="max-w-24 truncate text-muted-foreground">
+              {effortLabel ?? "Default"}
+            </span>
+          </MenuSubTrigger>
+          <ComposerPickerMenuSubPopup fixedWidth>
+            <TraitsMenuContent
+              provider={props.provider}
+              threadId={props.threadId}
+              model={props.model}
+              {...(props.runtimeModel ? { runtimeModel: props.runtimeModel } : {})}
+              modelOptions={props.modelOptions}
+              prompt={props.prompt}
+              onPromptChange={props.onPromptChange}
+              includeFastMode={false}
+              effortPresentation="radio"
+              sections={["effort"]}
+              onSelectionComplete={handleAfterTraitsSelection}
+            />
+          </ComposerPickerMenuSubPopup>
+        </MenuSub>
+      ) : null}
+
+      {supportsFastModeControl && !supportsDirectEffortSlider ? (
+        <MenuSub>
+          <MenuSubTrigger>
+            <span className="min-w-0 flex-1 truncate">Speed</span>
+            <span className="max-w-24 truncate text-muted-foreground">
+              {fastModeEnabled ? "Fast" : "Standard"}
+            </span>
+          </MenuSubTrigger>
+          <ComposerPickerMenuSubPopup fixedWidth>
+            <TraitsMenuContent
+              provider={props.provider}
+              threadId={props.threadId}
+              model={props.model}
+              {...(props.runtimeModel ? { runtimeModel: props.runtimeModel } : {})}
+              modelOptions={props.modelOptions}
+              prompt={props.prompt}
+              onPromptChange={props.onPromptChange}
+              includeFastMode
+              sections={["speed"]}
+              onSelectionComplete={handleAfterTraitsSelection}
+            />
+          </ComposerPickerMenuSubPopup>
+        </MenuSub>
+      ) : null}
+
+      {hasTraitsTopSection ? (
+        <TraitsMenuContent
+          provider={props.provider}
+          threadId={props.threadId}
+          model={props.model}
+          {...(props.runtimeModel ? { runtimeModel: props.runtimeModel } : {})}
+          {...(props.runtimeModels !== undefined ? { runtimeModels: props.runtimeModels } : {})}
+          {...(props.runtimeAgents !== undefined ? { runtimeAgents: props.runtimeAgents } : {})}
+          modelOptions={props.modelOptions}
+          prompt={props.prompt}
+          onPromptChange={props.onPromptChange}
+          includeFastMode={false}
+          sections={["thinking", "context", "agent"]}
+          onSelectionComplete={handleAfterTraitsSelection}
+        />
+      ) : null}
+    </>
+  );
+
   return (
     <Menu
       open={isMenuOpen}
@@ -233,52 +342,56 @@ export function ComposerModelEffortPicker(props: ComposerModelEffortPickerProps)
         <MenuTrigger render={triggerButton}>{triggerContent}</MenuTrigger>
       )}
       <ComposerPickerMenuPopup align="end" side="top" fixedWidth>
-        {hasTraitsTopSection ? (
-          <TraitsMenuContent
-            provider={props.provider}
-            threadId={props.threadId}
-            model={props.model}
-            {...(props.runtimeModel ? { runtimeModel: props.runtimeModel } : {})}
-            {...(props.runtimeModels !== undefined ? { runtimeModels: props.runtimeModels } : {})}
-            {...(props.runtimeAgents !== undefined ? { runtimeAgents: props.runtimeAgents } : {})}
-            modelOptions={props.modelOptions}
-            prompt={props.prompt}
-            onPromptChange={props.onPromptChange}
-            onSelectionComplete={handleAfterTraitsSelection}
-          />
-        ) : null}
-
-        {hasTraitsTopSection ? <MenuSeparator /> : null}
-
-        <MenuSub>
-          <MenuSubTrigger>
-            <ProviderIcon
-              aria-hidden="true"
-              className={cn("size-3 shrink-0", getProviderIconClassName(activeProvider))}
-            />
-            <span className="truncate">{modelLabel}</span>
-          </MenuSubTrigger>
-          <ComposerPickerMenuSubPopup
-            fixedWidth
-            className={COMPOSER_PICKER_MODEL_SUBMENU_HEIGHT_CLASS_NAME}
-          >
-            <ProviderModelMenuItems
-              provider={props.provider}
-              model={props.model}
-              lockedProvider={props.lockedProvider}
-              {...(props.providers ? { providers: props.providers } : {})}
-              modelOptionsByProvider={props.modelOptionsByProvider}
-              {...(props.loadingModelProviders
-                ? { loadingModelProviders: props.loadingModelProviders }
-                : {})}
-              {...(props.hiddenProviders ? { hiddenProviders: props.hiddenProviders } : {})}
-              {...(props.providerOrder ? { providerOrder: props.providerOrder } : {})}
-              {...(props.disabled !== undefined ? { disabled: props.disabled } : {})}
-              onProviderModelChange={props.onProviderModelChange}
-              onAfterSelection={handleAfterModelSelection}
-            />
-          </ComposerPickerMenuSubPopup>
-        </MenuSub>
+        {supportsDirectEffortSlider ? (
+          <>
+            <DisclosureRegion open={advancedOpen}>
+              {namedControls}
+              <MenuSeparator />
+            </DisclosureRegion>
+            <MenuItem
+              closeOnClick={false}
+              aria-expanded={advancedOpen}
+              onClick={() => setAdvancedOpen((current) => !current)}
+            >
+              <SettingsIcon aria-hidden="true" className="size-3 shrink-0 opacity-65" />
+              <span
+                className={cn("min-w-0 truncate", supportsFastModeControl ? undefined : "flex-1")}
+              >
+                Advanced
+              </span>
+              <DisclosureChevron
+                open={advancedOpen}
+                className={supportsFastModeControl ? undefined : "ms-auto"}
+              />
+              {supportsFastModeControl ? (
+                <ComposerFastModeToggle
+                  provider={props.provider}
+                  threadId={props.threadId}
+                  model={props.model}
+                  modelOptions={props.modelOptions}
+                  enabled={fastModeEnabled}
+                  className="ms-auto"
+                />
+              ) : null}
+            </MenuItem>
+            <DisclosureRegion open={!advancedOpen}>
+              <TraitsMenuContent
+                provider={props.provider}
+                threadId={props.threadId}
+                model={props.model}
+                {...(props.runtimeModel ? { runtimeModel: props.runtimeModel } : {})}
+                modelOptions={props.modelOptions}
+                prompt={props.prompt}
+                onPromptChange={props.onPromptChange}
+                includeFastMode={false}
+                effortPresentation="slider"
+                sections={["effort"]}
+              />
+            </DisclosureRegion>
+          </>
+        ) : (
+          namedControls
+        )}
       </ComposerPickerMenuPopup>
     </Menu>
   );

--- a/apps/web/src/components/chat/TraitsPicker.browser.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.browser.tsx
@@ -207,35 +207,29 @@ describe("TraitsPicker (Claude)", () => {
     });
   });
 
-  it("shows only the provided effort options", async () => {
+  it("maps the provided Claude effort ladder onto slider steps", async () => {
     await using _ = await mountClaudePicker({
       model: "claude-sonnet-4-6",
     });
 
     await page.getByRole("button").click();
 
-    await vi.waitFor(() => {
-      const text = document.body.textContent ?? "";
-      expect(text).toContain("Low");
-      expect(text).toContain("Medium");
-      expect(text).toContain("High");
-      expect(text).toContain("Max");
-      expect(text).toContain("Ultrathink");
-    });
+    const slider = page.getByRole("slider", { name: "Effort" });
+    await expect.element(slider).toHaveAttribute("min", "0");
+    await expect.element(slider).toHaveAttribute("max", "4");
+    await expect.element(slider).toHaveAttribute("aria-valuetext", "High");
   });
 
-  it("shows Extra High for Claude Opus 4.7", async () => {
+  it("includes every Claude Opus 4.7 effort in the slider", async () => {
     await using _ = await mountClaudePicker({
       model: "claude-opus-4-7",
     });
 
     await page.getByRole("button").click();
 
-    await vi.waitFor(() => {
-      const text = document.body.textContent ?? "";
-      expect(text).toContain("Extra High");
-      expect(text).toContain("Max");
-    });
+    const slider = page.getByRole("slider", { name: "Effort" });
+    await expect.element(slider).toHaveAttribute("max", "6");
+    await expect.element(slider).toHaveAttribute("aria-valuetext", "High");
   });
 
   it("shows a th  inking on/off dropdown for Haiku", async () => {
@@ -275,6 +269,10 @@ describe("TraitsPicker (Claude)", () => {
       expect(text).toContain("Effort");
       expect(text).toContain("Remove Ultrathink from the prompt to change effort.");
       expect(text).not.toContain("Fallback Effort");
+      expect(
+        document.body.querySelector<HTMLInputElement>('[role="slider"], input[type="range"]')
+          ?.disabled,
+      ).toBe(true);
     });
   });
 
@@ -285,15 +283,17 @@ describe("TraitsPicker (Claude)", () => {
     });
 
     await page.getByRole("button").click();
-    await page.getByRole("menuitemradio", { name: "Max" }).click();
+    await page.getByRole("slider", { name: "Effort" }).fill("3");
 
-    expect(
-      useComposerDraftStore.getState().stickyModelSelectionByProvider.claudeAgent,
-    ).toMatchObject({
-      provider: "claudeAgent",
-      options: {
-        effort: "max",
-      },
+    await vi.waitFor(() => {
+      expect(
+        useComposerDraftStore.getState().stickyModelSelectionByProvider.claudeAgent,
+      ).toMatchObject({
+        provider: "claudeAgent",
+        options: {
+          effort: "max",
+        },
+      });
     });
   });
 
@@ -429,23 +429,20 @@ describe("TraitsPicker (Codex)", () => {
     });
   });
 
-  it("shows only the provided effort options", async () => {
+  it("maps Codex effort capabilities onto slider steps", async () => {
     await using _ = await mountCodexPicker({
       options: { fastMode: false },
     });
 
     await page.getByRole("button").click();
 
-    await vi.waitFor(() => {
-      const text = document.body.textContent ?? "";
-      expect(text).toContain("Low");
-      expect(text).toContain("Medium");
-      expect(text).toContain("High");
-      expect(text).toContain("Extra High");
-    });
+    const slider = page.getByRole("slider", { name: "Effort" });
+    await expect.element(slider).toHaveAttribute("min", "0");
+    await expect.element(slider).toHaveAttribute("max", "3");
+    await expect.element(slider).toHaveAttribute("aria-valuetext", "Medium");
   });
 
-  it("closes after clicking the already-selected effort", async () => {
+  it("keeps the picker open while changing Codex effort", async () => {
     await using _ = await mountCodexPicker({
       options: { reasoningEffort: "medium", fastMode: false },
     });
@@ -456,10 +453,14 @@ describe("TraitsPicker (Codex)", () => {
       expect(document.body.textContent ?? "").toContain("Effort");
     });
 
-    await page.getByRole("menuitemradio", { name: "Medium" }).click();
+    await page.getByRole("slider", { name: "Effort" }).fill("2");
 
     await vi.waitFor(() => {
-      expect(document.body.textContent ?? "").not.toContain("Effort");
+      expect(document.body.textContent ?? "").toContain("Effort");
+      expect(useComposerDraftStore.getState().stickyModelSelectionByProvider.codex).toMatchObject({
+        provider: "codex",
+        options: { reasoningEffort: "high" },
+      });
     });
   });
 
@@ -590,9 +591,10 @@ describe("TraitsPicker (Cursor)", () => {
       expect(text).toContain("Effort");
       expect(text).toContain("300K");
       expect(text).toContain("1M");
-      expect(text).toContain("Extra High");
-      expect(text).toContain("Max");
     });
+    const slider = page.getByRole("slider", { name: "Effort" });
+    await expect.element(slider).toHaveAttribute("max", "4");
+    await expect.element(slider).toHaveAttribute("aria-valuetext", "High");
   });
 });
 

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -11,7 +11,17 @@ import {
   type ThreadId,
 } from "@synara/contracts";
 import { applyClaudePromptEffortPrefix } from "@synara/shared/model";
-import { memo, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
 import { ChevronDownIcon, FastModeIcon, FastModeOutlineIcon, SettingsIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
 import { Button } from "../ui/button";
@@ -150,12 +160,18 @@ export function resolveTraitsTriggerSummary(options: {
   };
 }
 
-// Compact icon toggle for fast mode, docked at the far right of the Effort
-// section header. Outline zap (Central reversed set) = default speed, filled
-// zap (Central fill set) = fast mode on. Toggling keeps the menu open so the
-// state flip is visible in place.
-function FastModeToggle({ enabled, onToggle }: { enabled: boolean; onToggle: () => void }) {
-  const Icon = enabled ? FastModeIcon : FastModeOutlineIcon;
+// Compact fast-mode toggle. The text label keeps the control legible at picker
+// scale while the speedometer and theme-accent surface communicate its state.
+// Toggling keeps the menu open so the result remains visible in place.
+function FastModeToggle({
+  enabled,
+  onToggle,
+  className,
+}: {
+  enabled: boolean;
+  onToggle: () => void;
+  className?: string;
+}) {
   return (
     <Tooltip>
       <TooltipTrigger
@@ -164,18 +180,42 @@ function FastModeToggle({ enabled, onToggle }: { enabled: boolean; onToggle: () 
             type="button"
             aria-label="Fast mode"
             aria-pressed={enabled}
-            className="-my-1 flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors hover:bg-[color-mix(in_srgb,var(--foreground)_6%,transparent)]"
-            onClick={onToggle}
+            className={cn(
+              "flex h-6 shrink-0 self-center cursor-pointer items-center justify-center gap-1 rounded-md border px-1.5 text-[11px] font-medium leading-none outline-none transition-[background-color,border-color,color,box-shadow,transform] duration-150 ease-out focus-visible:ring-1 focus-visible:ring-[var(--color-border-focus)] active:scale-[0.97] motion-reduce:transition-none",
+              enabled
+                ? "border-[color-mix(in_srgb,var(--color-text-accent)_34%,transparent)] bg-[color-mix(in_srgb,var(--color-text-accent)_12%,transparent)] text-[var(--color-text-accent)] shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--color-text-accent)_7%,transparent)] hover:bg-[color-mix(in_srgb,var(--color-text-accent)_16%,transparent)]"
+                : "border-[color-mix(in_srgb,var(--foreground)_12%,transparent)] bg-[color-mix(in_srgb,var(--foreground)_3%,transparent)] text-muted-foreground hover:border-[color-mix(in_srgb,var(--foreground)_20%,transparent)] hover:bg-[color-mix(in_srgb,var(--foreground)_7%,transparent)] hover:text-foreground",
+              className,
+            )}
+            onPointerDown={(event) => event.stopPropagation()}
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggle();
+            }}
           />
         }
       >
-        <Icon
+        <span
           aria-hidden="true"
-          className={cn(
-            "size-3.5",
-            enabled ? "text-[hsl(var(--chart-4))]" : "text-muted-foreground/70",
-          )}
-        />
+          data-slot="fast-mode-icon"
+          className="relative flex size-4 shrink-0 items-center justify-center"
+        >
+          <FastModeOutlineIcon
+            className={cn(
+              "absolute inset-0 size-4 transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none",
+              enabled ? "-translate-y-0.5 scale-90 opacity-0" : "scale-100 opacity-100",
+            )}
+          />
+          <FastModeIcon
+            className={cn(
+              "absolute inset-0 size-4 transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none",
+              enabled ? "scale-100 opacity-100" : "translate-y-0.5 scale-90 opacity-0",
+            )}
+          />
+        </span>
+        <span data-slot="fast-mode-label" className="leading-none">
+          Fast
+        </span>
       </TooltipTrigger>
       <TooltipPopup side="top" variant="picker">
         {enabled ? "Fast mode on" : "Fast mode off"}
@@ -184,11 +224,270 @@ function FastModeToggle({ enabled, onToggle }: { enabled: boolean; onToggle: () 
   );
 }
 
+export function ComposerFastModeToggle({
+  provider,
+  threadId,
+  model,
+  modelOptions,
+  enabled,
+  className,
+}: {
+  provider: ProviderKind;
+  threadId: ThreadId;
+  model: string;
+  modelOptions: ProviderOptions | null | undefined;
+  enabled: boolean;
+  className?: string;
+}) {
+  const setProviderModelOptions = useComposerDraftStore((store) => store.setProviderModelOptions);
+  const handleToggle = useCallback(() => {
+    setProviderModelOptions(
+      threadId,
+      provider,
+      buildNextProviderOptions(provider, modelOptions, { fastMode: !enabled }),
+      { model, persistSticky: true },
+    );
+  }, [enabled, model, modelOptions, provider, setProviderModelOptions, threadId]);
+
+  return <FastModeToggle enabled={enabled} onToggle={handleToggle} className={className} />;
+}
+
 interface TraitRadioOption {
   value: string;
   label: string;
   isDefault?: boolean;
   description?: string | null;
+}
+
+function TraitSliderSection({
+  label,
+  labelTrailing,
+  note,
+  value,
+  options,
+  disabled,
+  onValueChange,
+}: {
+  label: string;
+  labelTrailing?: ReactNode;
+  note?: ReactNode;
+  value: string;
+  options: ReadonlyArray<TraitRadioOption>;
+  disabled?: boolean;
+  onValueChange: (value: string) => void;
+}) {
+  const selectedIndex = Math.max(
+    0,
+    options.findIndex((option) => option.value === value),
+  );
+  const maxIndex = Math.max(0, options.length - 1);
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const pointerActiveRef = useRef(false);
+  const shellRef = useRef<HTMLDivElement>(null);
+  const sliderRef = useRef<HTMLInputElement>(null);
+  const trackWidthRef = useRef(0);
+  const snapFrameRef = useRef<number | null>(null);
+  const visualIndex = dragIndex ?? selectedIndex;
+  const selectedOption = options[visualIndex];
+  const isMaximumReasoning = maxIndex > 0 && visualIndex === maxIndex;
+
+  const applyVisualPosition = useCallback(
+    (position: number) => {
+      const shell = shellRef.current;
+      const trackWidth = trackWidthRef.current;
+      if (!shell || trackWidth <= 0) return;
+
+      const clampedPosition = Math.min(maxIndex, Math.max(0, position));
+      const progress = maxIndex === 0 ? 1 : clampedPosition / maxIndex;
+      const thumbRadius = 12;
+      const thumbX = thumbRadius + progress * Math.max(0, trackWidth - thumbRadius * 2);
+
+      shell.style.setProperty("--effort-thumb-x", `${thumbX}px`);
+      shell.style.setProperty("--effort-fill-scale", String(thumbX / trackWidth));
+    },
+    [maxIndex],
+  );
+
+  useLayoutEffect(() => {
+    const shell = shellRef.current;
+    const slider = sliderRef.current;
+    if (!shell || !slider) return;
+
+    const syncVisualPosition = (width: number) => {
+      trackWidthRef.current = width;
+      const position = pointerActiveRef.current ? Number(slider.value) : selectedIndex;
+      applyVisualPosition(position);
+    };
+
+    if (!pointerActiveRef.current) {
+      slider.value = String(selectedIndex);
+      setDragIndex(null);
+    }
+    syncVisualPosition(shell.getBoundingClientRect().width);
+
+    if (typeof ResizeObserver === "undefined") return;
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      if (entry) syncVisualPosition(entry.contentRect.width);
+    });
+    resizeObserver.observe(shell);
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [applyVisualPosition, selectedIndex]);
+
+  useEffect(
+    () => () => {
+      if (snapFrameRef.current !== null) {
+        cancelAnimationFrame(snapFrameRef.current);
+      }
+    },
+    [],
+  );
+
+  const commitPosition = (position: number) => {
+    const nextIndex = Math.min(maxIndex, Math.max(0, Math.round(position)));
+    const nextOption = options[nextIndex];
+    if (sliderRef.current) {
+      sliderRef.current.value = String(nextIndex);
+    }
+    setDragIndex(nextIndex);
+    if (nextOption) {
+      onValueChange(nextOption.value);
+    }
+    return nextIndex;
+  };
+
+  const commitKeyboardStep = (event: KeyboardEvent<HTMLInputElement>) => {
+    const direction =
+      event.key === "ArrowRight" || event.key === "ArrowUp"
+        ? 1
+        : event.key === "ArrowLeft" || event.key === "ArrowDown"
+          ? -1
+          : 0;
+    const nextIndex =
+      event.key === "Home"
+        ? 0
+        : event.key === "End"
+          ? maxIndex
+          : direction === 0
+            ? null
+            : Math.min(maxIndex, Math.max(0, visualIndex + direction));
+    if (nextIndex === null) return;
+    event.preventDefault();
+    commitPosition(nextIndex);
+    applyVisualPosition(nextIndex);
+  };
+
+  return (
+    <MenuGroup>
+      <MenuGroupLabel className="flex items-center justify-between gap-2">
+        <span>{label}</span>
+        <span className="flex min-w-0 items-center gap-2">
+          <span
+            className="max-w-24 truncate text-[var(--color-text-foreground-secondary)]"
+            title={
+              selectedOption?.isDefault
+                ? `${selectedOption.label} (default)`
+                : selectedOption?.label
+            }
+          >
+            {selectedOption?.label}
+          </span>
+          {labelTrailing}
+        </span>
+      </MenuGroupLabel>
+      {note}
+      <div className="px-2 pb-2.5 pt-1">
+        <div
+          ref={shellRef}
+          className="composer-effort-slider-shell relative flex h-9 items-center"
+          data-max-reasoning={isMaximumReasoning ? "true" : undefined}
+          data-dragging={isDragging ? "true" : undefined}
+        >
+          <div aria-hidden="true" className="composer-effort-slider-visual absolute inset-x-0">
+            <div className="composer-effort-slider-fill" />
+            <div className="composer-effort-slider-ticks">
+              {options.map((option, optionIndex) => (
+                <span
+                  key={option.value}
+                  style={{ "--effort-tick-delay": `${36 + optionIndex * 42}ms` } as CSSProperties}
+                  className={cn(
+                    "composer-effort-slider-tick",
+                    optionIndex <= visualIndex && "composer-effort-slider-tick--active",
+                  )}
+                />
+              ))}
+            </div>
+          </div>
+          <div aria-hidden="true" className="composer-effort-slider-thumb">
+            <span className="composer-effort-slider-thumb-core" />
+          </div>
+          <input
+            ref={sliderRef}
+            type="range"
+            min={0}
+            max={maxIndex}
+            step={0.01}
+            defaultValue={selectedIndex}
+            disabled={disabled}
+            aria-label={label}
+            aria-valuetext={selectedOption?.label ?? value}
+            data-max-reasoning={isMaximumReasoning ? "true" : undefined}
+            className="composer-effort-slider absolute inset-0 z-4 h-full w-full cursor-pointer appearance-none bg-transparent opacity-0 focus-visible:outline-none disabled:cursor-not-allowed"
+            onPointerDown={(event) => {
+              pointerActiveRef.current = true;
+              shellRef.current?.setAttribute("data-dragging", "true");
+              setIsDragging(true);
+              if (snapFrameRef.current !== null) {
+                cancelAnimationFrame(snapFrameRef.current);
+                snapFrameRef.current = null;
+              }
+              event.currentTarget.setPointerCapture?.(event.pointerId);
+              setDragIndex(Math.round(Number(event.currentTarget.value)));
+            }}
+            onPointerUp={(event) => {
+              pointerActiveRef.current = false;
+              shellRef.current?.removeAttribute("data-dragging");
+              setIsDragging(false);
+              const nextIndex = commitPosition(Number(event.currentTarget.value));
+              snapFrameRef.current = requestAnimationFrame(() => {
+                applyVisualPosition(nextIndex);
+                snapFrameRef.current = null;
+              });
+              event.currentTarget.releasePointerCapture?.(event.pointerId);
+            }}
+            onPointerCancel={() => {
+              pointerActiveRef.current = false;
+              shellRef.current?.removeAttribute("data-dragging");
+              setIsDragging(false);
+              setDragIndex(null);
+              if (sliderRef.current) {
+                sliderRef.current.value = String(selectedIndex);
+              }
+              applyVisualPosition(selectedIndex);
+            }}
+            onKeyDown={commitKeyboardStep}
+            onInput={(event) => {
+              const nextPosition = Number(event.currentTarget.value);
+              applyVisualPosition(nextPosition);
+              setDragIndex((currentIndex) => {
+                const nextIndex = Math.min(maxIndex, Math.max(0, Math.round(nextPosition)));
+                return currentIndex === nextIndex ? currentIndex : nextIndex;
+              });
+            }}
+            onChange={(event) => {
+              const nextPosition = Number(event.currentTarget.value);
+              if (!pointerActiveRef.current) {
+                const nextIndex = commitPosition(nextPosition);
+                applyVisualPosition(nextIndex);
+              }
+            }}
+          />
+        </div>
+      </div>
+    </MenuGroup>
+  );
 }
 
 // Shared layout for one composer trait section: a labeled radio group whose rows
@@ -269,6 +568,8 @@ export interface TraitsMenuContentProps {
   prompt: string;
   onPromptChange: (prompt: string) => void;
   includeFastMode?: boolean;
+  effortPresentation?: "radio" | "slider";
+  sections?: ReadonlyArray<"thinking" | "context" | "effort" | "speed" | "agent">;
   modelOptions?: ProviderOptions | null | undefined;
   onSelectionComplete?: () => void;
 }
@@ -282,6 +583,8 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
   prompt,
   onPromptChange,
   includeFastMode: includeFastModeProp,
+  effortPresentation = "slider",
+  sections,
   modelOptions,
   onSelectionComplete,
 }: TraitsMenuContentProps) {
@@ -303,29 +606,35 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
     fastModeDescriptor,
     promptInjectedValues,
   } = getComposerTraitSelection(provider, model, prompt, modelOptions, runtimeModel);
-  const hasVisibleControls = hasVisibleComposerTraitControls(
-    { caps, effortLevels, thinkingEnabled, contextWindowOptions, fastModeDescriptor },
-    { includeFastMode },
-  );
+  const includesSection = (section: "thinking" | "context" | "effort" | "speed" | "agent") =>
+    sections === undefined || sections.includes(section);
   const supportsFastModeControl = fastModeDescriptor !== null || caps.supportsFastMode;
-  // Fast mode rides the Effort header as a compact icon toggle whenever an
-  // effort section exists; fast-only models (no effort levels) keep the
-  // standalone radio section instead.
+  const showThinking = includesSection("thinking") && thinkingEnabled !== null;
+  const showContext = includesSection("context") && contextWindowOptions.length > 1;
+  const showEffort = includesSection("effort") && effortLevels.length > 0;
+  // Fast mode rides the slider header only in the standalone traits picker.
+  // The combined Model/Effort menu gives Speed its own explicit submenu.
   const showsFastModeEffortToggle =
-    includeFastMode && supportsFastModeControl && effortLevels.length > 0;
+    includeFastMode &&
+    effortPresentation === "slider" &&
+    supportsFastModeControl &&
+    showEffort &&
+    includesSection("speed");
+  const showSpeed =
+    includesSection("speed") &&
+    includeFastMode &&
+    supportsFastModeControl &&
+    !showsFastModeEffortToggle;
   const agentOptions = getAgentOptions(provider, runtimeAgents);
   const defaultAgent = defaultAgentForProvider(provider);
   const selectedAgent = getSelectedAgentValue(provider, modelOptions);
-  const hasAgentControls = agentOptions.length > 0 && defaultAgent !== null;
-  const hasPriorContextWindowSection = thinkingEnabled !== null;
+  const showAgent = includesSection("agent") && agentOptions.length > 0 && defaultAgent !== null;
+  const hasVisibleControls = showThinking || showContext || showEffort || showSpeed;
   // Both descriptor ids are resolved up here rather than inline. React Compiler cannot lower a `??`
   // in an object-key position, and it cannot match an optional-chained expression in a dependency
   // list to its own inferred scope — either one makes it skip this component entirely.
   const contextWindowTraitId = contextWindowDescriptor?.id ?? "contextWindow";
   const primarySelectDescriptorId = primarySelectDescriptor?.id;
-  const hasPriorEffortSection = thinkingEnabled !== null || contextWindowOptions.length > 1;
-  const hasPriorFastModeSection =
-    thinkingEnabled !== null || effortLevels.length > 0 || contextWindowOptions.length > 1;
 
   // Single home for committing a trait change: merge the patch into the provider
   // options, persist it as sticky, and close the menu. Every section funnels here.
@@ -349,7 +658,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
   // `getComposerTraitSelection` call, which React Compiler memoizes as a single scope, so no
   // hand-written dependency list can match it and the validator refuses to compile the component at
   // all. Letting the compiler own this memoization is what gets the whole file optimized.
-  const handleEffortChange = (value: string) => {
+  const handleEffortChange = (value: string, options?: { keepMenuOpen?: boolean }) => {
     if (ultrathinkPromptControlled) return;
     if (!value) return;
     const nextOption = effortLevels.find((option) => option.value === value);
@@ -360,7 +669,9 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
           ? ULTRATHINK_PROMPT_PREFIX
           : applyClaudePromptEffortPrefix(prompt, "ultrathink");
       onPromptChange(nextPrompt);
-      onSelectionComplete?.();
+      if (!options?.keepMenuOpen) {
+        onSelectionComplete?.();
+      }
       return;
     }
     const optionId =
@@ -372,16 +683,16 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
           : provider === "claudeAgent"
             ? "effort"
             : "reasoningEffort");
-    commitTrait(buildProviderOptionPatch(provider, optionId, nextOption.value));
+    commitTrait(buildProviderOptionPatch(provider, optionId, nextOption.value), options);
   };
 
-  if (!hasVisibleControls && !hasAgentControls) {
+  if (!hasVisibleControls && !showAgent) {
     return null;
   }
 
   return (
     <>
-      {thinkingEnabled !== null ? (
+      {showThinking ? (
         <TraitRadioSection
           label="Thinking"
           value={thinkingEnabled ? "on" : "off"}
@@ -393,9 +704,9 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
           onSelectionComplete={onSelectionComplete}
         />
       ) : null}
-      {contextWindowOptions.length > 1 ? (
+      {showContext ? (
         <>
-          {hasPriorContextWindowSection ? <MenuDivider /> : null}
+          {showThinking ? <MenuDivider /> : null}
           <TraitRadioSection
             label={contextWindowDescriptor?.label ?? "Context"}
             value={contextWindow ?? defaultContextWindow ?? ""}
@@ -409,44 +720,58 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
           />
         </>
       ) : null}
-      {effortLevels.length > 0 ? (
+      {showEffort ? (
         <>
-          {hasPriorEffortSection ? <MenuDivider /> : null}
-          <TraitRadioSection
-            label={provider === "kilo" || provider === "opencode" ? "Variant" : "Effort"}
-            labelTrailing={
-              showsFastModeEffortToggle ? (
-                <FastModeToggle
-                  enabled={fastModeEnabled}
-                  onToggle={() =>
-                    commitTrait({ fastMode: !fastModeEnabled }, { keepMenuOpen: true })
-                  }
-                />
-              ) : undefined
-            }
-            note={
-              ultrathinkPromptControlled ? (
-                <div className="px-2 pb-1.5 text-muted-foreground/80 text-xs">
-                  Remove Ultrathink from the prompt to change effort.
-                </div>
-              ) : undefined
-            }
-            value={effort ?? ""}
-            disabled={ultrathinkPromptControlled}
-            options={effortLevels.map((option) => ({
-              value: option.value,
-              label: option.label,
-              isDefault: option.value === defaultEffort,
-              description: option.description ?? null,
-            }))}
-            onValueChange={handleEffortChange}
-            onSelectionComplete={onSelectionComplete}
-          />
+          {showThinking || showContext ? <MenuDivider /> : null}
+          {provider === "kilo" || provider === "opencode" || effortPresentation === "radio" ? (
+            <TraitRadioSection
+              label={provider === "kilo" || provider === "opencode" ? "Variant" : "Effort"}
+              value={effort ?? ""}
+              options={effortLevels.map((option) => ({
+                value: option.value,
+                label: option.label,
+                isDefault: option.value === defaultEffort,
+                description: option.description ?? null,
+              }))}
+              onValueChange={handleEffortChange}
+              onSelectionComplete={onSelectionComplete}
+            />
+          ) : (
+            <TraitSliderSection
+              label="Effort"
+              labelTrailing={
+                showsFastModeEffortToggle ? (
+                  <FastModeToggle
+                    enabled={fastModeEnabled}
+                    onToggle={() =>
+                      commitTrait({ fastMode: !fastModeEnabled }, { keepMenuOpen: true })
+                    }
+                  />
+                ) : undefined
+              }
+              note={
+                ultrathinkPromptControlled ? (
+                  <div className="px-2 pb-1.5 text-muted-foreground/80 text-xs">
+                    Remove Ultrathink from the prompt to change effort.
+                  </div>
+                ) : undefined
+              }
+              value={effort ?? defaultEffort ?? effortLevels[0]?.value ?? ""}
+              disabled={ultrathinkPromptControlled}
+              options={effortLevels.map((option) => ({
+                value: option.value,
+                label: option.label,
+                isDefault: option.value === defaultEffort,
+                description: option.description ?? null,
+              }))}
+              onValueChange={(value) => handleEffortChange(value, { keepMenuOpen: true })}
+            />
+          )}
         </>
       ) : null}
-      {includeFastMode && supportsFastModeControl && !showsFastModeEffortToggle ? (
+      {showSpeed ? (
         <>
-          {hasPriorFastModeSection ? <MenuDivider /> : null}
+          {showThinking || showContext || showEffort ? <MenuDivider /> : null}
           <TraitRadioSection
             label="Speed"
             value={fastModeEnabled ? "on" : "off"}
@@ -459,9 +784,9 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
           />
         </>
       ) : null}
-      {hasAgentControls ? (
+      {showAgent ? (
         <>
-          {hasVisibleControls ? <MenuDivider /> : null}
+          {showThinking || showContext || showEffort || showSpeed ? <MenuDivider /> : null}
           <TraitRadioSection
             label={provider === "kilo" ? "Mode" : "Agent"}
             value={selectedAgent ?? defaultAgent ?? ""}
@@ -600,7 +925,7 @@ export const TraitsPicker = memo(function TraitsPicker({
           <>
             <span className="shrink-0 text-muted-foreground/45">·</span>
             <span className="inline-flex shrink-0 items-center gap-1">
-              <FastModeIcon aria-hidden="true" className="size-3 text-[hsl(var(--chart-4))]" />
+              <FastModeIcon aria-hidden="true" className="size-3 text-[var(--color-text-accent)]" />
               <span>Fast</span>
             </span>
           </>
@@ -624,7 +949,7 @@ export const TraitsPicker = memo(function TraitsPicker({
           <>
             <span className="text-muted-foreground/45">·</span>
             <span className="inline-flex items-center gap-1">
-              <FastModeIcon aria-hidden="true" className="size-3 text-[hsl(var(--chart-4))]" />
+              <FastModeIcon aria-hidden="true" className="size-3 text-[var(--color-text-accent)]" />
               <span>Fast</span>
             </span>
           </>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -459,6 +459,389 @@
   transform: scale(1.08);
 }
 
+/* Composer reasoning slider: custom visual track/thumb under a transparent
+   native range. This keeps keyboard/accessibility semantics while giving
+   Electron's WebKit renderer a thick, smoothly animated surface. */
+.composer-effort-slider-visual {
+  height: 12px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--foreground) 7%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--foreground) 11%, transparent);
+  box-shadow:
+    inset 0 2px 4px color-mix(in srgb, black 24%, transparent),
+    0 1px 0 color-mix(in srgb, white 5%, transparent);
+  transition:
+    filter 180ms ease,
+    box-shadow 220ms ease;
+}
+
+.composer-effort-slider-fill {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-start: 0;
+  width: 100%;
+  min-width: 1px;
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    oklch(0.58 0.23 288) 0%,
+    oklch(0.68 0.22 305) 48%,
+    oklch(0.78 0.17 325) 100%
+  );
+  box-shadow:
+    inset 0 1px 1px color-mix(in srgb, white 24%, transparent),
+    0 0 12px color-mix(in srgb, oklch(0.7 0.2 310) 34%, transparent);
+  transform: scaleX(var(--effort-fill-scale, 0));
+  transform-origin: left center;
+  will-change: transform;
+}
+
+.composer-effort-slider-ticks {
+  position: absolute;
+  inset: 0 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.composer-effort-slider-tick {
+  width: 4px;
+  height: 4px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--foreground) 25%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, black 8%, transparent);
+  transition:
+    background 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.composer-effort-slider-tick--active {
+  background: color-mix(in srgb, white 76%, oklch(0.83 0.13 319));
+  box-shadow: 0 0 5px color-mix(in srgb, oklch(0.8 0.15 320) 72%, transparent);
+  transform: scale(1.08);
+}
+
+.composer-effort-slider-thumb {
+  pointer-events: none;
+  position: absolute;
+  top: 50%;
+  left: 0;
+  z-index: 3;
+  width: 26px;
+  height: 26px;
+  transform: translate3d(var(--effort-thumb-x, 12px), -50%, 0) translateX(-50%);
+  will-change: transform;
+}
+
+.composer-effort-slider-thumb-core {
+  position: absolute;
+  inset: 0;
+  border: 3px solid color-mix(in srgb, white 90%, transparent);
+  border-radius: 999px;
+  background: linear-gradient(145deg, white 8%, oklch(0.94 0.035 302) 90%);
+  box-shadow:
+    0 3px 9px rgba(15, 8, 35, 0.48),
+    0 0 0 1px color-mix(in srgb, oklch(0.66 0.18 303) 28%, transparent);
+  transition:
+    transform 180ms cubic-bezier(0.2, 0.9, 0.2, 1),
+    box-shadow 220ms ease,
+    background 220ms ease;
+}
+
+.composer-effort-slider-shell:not([data-dragging="true"]) .composer-effort-slider-fill {
+  transition: transform 180ms cubic-bezier(0.22, 0.86, 0.3, 1);
+}
+
+.composer-effort-slider-shell:not([data-dragging="true"]) .composer-effort-slider-thumb {
+  transition: transform 180ms cubic-bezier(0.22, 0.86, 0.3, 1);
+}
+
+.composer-effort-slider-shell:has(.composer-effort-slider:hover) .composer-effort-slider-visual,
+.composer-effort-slider-shell:has(.composer-effort-slider:focus-visible)
+  .composer-effort-slider-visual {
+  filter: saturate(1.14) brightness(1.05);
+  box-shadow:
+    inset 0 2px 4px color-mix(in srgb, black 24%, transparent),
+    0 0 0 1px color-mix(in srgb, oklch(0.72 0.18 310) 25%, transparent),
+    0 0 18px color-mix(in srgb, oklch(0.68 0.2 305) 17%, transparent);
+}
+
+.composer-effort-slider-shell:has(.composer-effort-slider:hover) .composer-effort-slider-thumb-core,
+.composer-effort-slider-shell:has(.composer-effort-slider:focus-visible)
+  .composer-effort-slider-thumb-core {
+  transform: scale(1.08);
+}
+
+.composer-effort-slider-shell:has(.composer-effort-slider:active)
+  .composer-effort-slider-thumb-core {
+  transform: scale(1.15);
+  box-shadow:
+    0 2px 7px rgba(15, 8, 35, 0.4),
+    0 0 0 5px color-mix(in srgb, oklch(0.72 0.18 310) 17%, transparent),
+    0 0 20px color-mix(in srgb, oklch(0.7 0.2 315) 30%, transparent);
+}
+
+.composer-effort-slider-shell:has(.composer-effort-slider:disabled) {
+  opacity: 0.45;
+}
+
+.composer-effort-slider::-webkit-slider-runnable-track {
+  height: 12px;
+  border: 0;
+  background: transparent;
+}
+
+.composer-effort-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 26px;
+  height: 26px;
+  margin-top: -7px;
+}
+
+.composer-effort-slider::-moz-range-track {
+  height: 12px;
+  border: 0;
+  background: transparent;
+}
+
+.composer-effort-slider::-moz-range-thumb {
+  width: 26px;
+  height: 26px;
+  border: 0;
+  background: transparent;
+}
+
+/* Theme-aware refinement: the selected theme owns the effort accent. Reaching
+   the maximum produces one kinetic lock sequence—sweep, ticks, thumb snap—
+   and then settles into a quiet static state. */
+.composer-effort-slider-shell {
+  --effort-accent: var(--color-text-accent, var(--ring));
+  --effort-accent-soft: color-mix(in srgb, var(--effort-accent) 24%, transparent);
+}
+
+.composer-effort-slider-visual {
+  height: 10px;
+}
+
+.composer-effort-slider-fill {
+  overflow: hidden;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--effort-accent) 68%, var(--color-background-surface)) 0%,
+    var(--effort-accent) 100%
+  );
+  box-shadow:
+    inset 0 1px 1px color-mix(in srgb, white 20%, transparent),
+    0 0 9px var(--effort-accent-soft);
+}
+
+.composer-effort-slider-tick {
+  width: 3px;
+  height: 3px;
+}
+
+.composer-effort-slider-tick--active {
+  background: color-mix(in srgb, white 76%, var(--effort-accent));
+  box-shadow: 0 0 4px color-mix(in srgb, var(--effort-accent) 58%, transparent);
+}
+
+.composer-effort-slider-thumb {
+  width: 24px;
+  height: 24px;
+  will-change: transform;
+}
+
+.composer-effort-slider-thumb-core {
+  border-width: 2px;
+  border-color: color-mix(in srgb, white 74%, var(--effort-accent));
+  background: color-mix(in srgb, white 92%, var(--effort-accent));
+  box-shadow:
+    0 2px 6px color-mix(in srgb, black 30%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--effort-accent) 16%, transparent);
+}
+
+.composer-effort-slider-shell:has(.composer-effort-slider:hover) .composer-effort-slider-visual,
+.composer-effort-slider-shell:has(.composer-effort-slider:focus-visible)
+  .composer-effort-slider-visual {
+  filter: saturate(1.06) brightness(1.03);
+  box-shadow:
+    inset 0 2px 3px color-mix(in srgb, black 22%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--effort-accent) 22%, transparent),
+    0 0 12px color-mix(in srgb, var(--effort-accent) 13%, transparent);
+}
+
+.composer-effort-slider-shell:has(.composer-effort-slider:hover) .composer-effort-slider-thumb-core,
+.composer-effort-slider-shell:has(.composer-effort-slider:focus-visible)
+  .composer-effort-slider-thumb-core {
+  transform: scale(1.06);
+}
+
+.composer-effort-slider-shell:has(.composer-effort-slider:active)
+  .composer-effort-slider-thumb-core {
+  transform: scale(1.1);
+  box-shadow:
+    0 2px 7px color-mix(in srgb, black 34%, transparent),
+    0 0 0 4px color-mix(in srgb, var(--effort-accent) 15%, transparent),
+    0 0 15px color-mix(in srgb, var(--effort-accent) 22%, transparent);
+}
+
+.composer-effort-slider::-webkit-slider-runnable-track {
+  height: 10px;
+}
+
+.composer-effort-slider::-webkit-slider-thumb {
+  width: 24px;
+  height: 24px;
+  margin-top: -7px;
+}
+
+.composer-effort-slider::-moz-range-track {
+  height: 10px;
+}
+
+.composer-effort-slider::-moz-range-thumb {
+  width: 24px;
+  height: 24px;
+}
+
+.composer-effort-slider-shell[data-max-reasoning="true"] .composer-effort-slider-fill {
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--effort-accent) 66%, var(--color-background-surface)) 0%,
+    var(--effort-accent) 58%,
+    color-mix(in srgb, white 36%, var(--effort-accent)) 100%
+  );
+  box-shadow:
+    inset 0 1px 1px color-mix(in srgb, white 24%, transparent),
+    0 0 12px color-mix(in srgb, var(--effort-accent) 28%, transparent);
+  animation: none;
+}
+
+.composer-effort-slider-shell[data-max-reasoning="true"]:not([data-dragging="true"])
+  .composer-effort-slider-fill::after {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  inset-block: -2px;
+  left: 0;
+  width: 38%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in srgb, white 68%, var(--effort-accent)),
+    transparent
+  );
+  filter: blur(2px);
+  opacity: 0;
+  transform: translateX(-125%);
+  animation: composer-effort-lock-sweep 620ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.composer-effort-slider-shell[data-max-reasoning="true"]:not([data-dragging="true"])
+  .composer-effort-slider-thumb::before {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  inset: -4px;
+  border: 1px solid color-mix(in srgb, var(--effort-accent) 52%, transparent);
+  border-radius: 999px;
+  opacity: 0;
+  transform: scale(0.72);
+  animation: composer-effort-lock-ring 520ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.composer-effort-slider-shell[data-max-reasoning="true"] .composer-effort-slider-thumb-core {
+  border-color: color-mix(in srgb, white 74%, var(--effort-accent));
+  background: color-mix(in srgb, white 90%, var(--effort-accent));
+  box-shadow:
+    0 0 0 4px color-mix(in srgb, var(--effort-accent) 15%, transparent),
+    0 0 19px color-mix(in srgb, var(--effort-accent) 44%, transparent);
+  animation: none;
+}
+
+.composer-effort-slider-shell[data-max-reasoning="true"]:not([data-dragging="true"])
+  .composer-effort-slider-thumb-core {
+  animation: composer-effort-lock-snap 420ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.composer-effort-slider-shell[data-max-reasoning="true"]:not([data-dragging="true"])
+  .composer-effort-slider-tick--active {
+  animation: composer-effort-lock-tick 260ms ease-out both;
+  animation-delay: var(--effort-tick-delay, 0ms);
+}
+
+@keyframes composer-effort-lock-sweep {
+  0% {
+    opacity: 0;
+    transform: translateX(-125%);
+  }
+  22% {
+    opacity: 0.82;
+  }
+  100% {
+    opacity: 0;
+    transform: translateX(270%);
+  }
+}
+
+@keyframes composer-effort-lock-ring {
+  0% {
+    opacity: 0;
+    transform: scale(0.72);
+  }
+  28% {
+    opacity: 0.72;
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.32);
+  }
+}
+
+@keyframes composer-effort-lock-snap {
+  0% {
+    transform: scale(0.92);
+  }
+  58% {
+    transform: scale(1.075);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes composer-effort-lock-tick {
+  0% {
+    opacity: 0.45;
+    transform: scale(0.72);
+  }
+  68% {
+    opacity: 1;
+    transform: scale(1.42);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1.08);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .composer-effort-slider-fill::after,
+  .composer-effort-slider-thumb::before,
+  .composer-effort-slider-thumb-core,
+  .composer-effort-slider-tick {
+    animation: none;
+  }
+
+  .composer-effort-slider-fill::after,
+  .composer-effort-slider-thumb::before {
+    opacity: 0;
+  }
+}
+
 /* Theme settings color picker: keep react-colorful aligned with the compact popover. */
 .theme-color-picker .react-colorful {
   width: 100%;

--- a/apps/web/src/lib/icons.tsx
+++ b/apps/web/src/lib/icons.tsx
@@ -259,9 +259,8 @@ export const Undo2Icon = adaptIcon(IconArrowBackUp);
 export const WorktreeIcon = centralIconWrapper("arrow-split-right");
 export const XIcon = adaptIcon(IconX);
 export const ZapIcon = adaptIcon(IconBolt);
-// Single source for the fast-mode glyph. Every fast-mode affordance (composer
-// trait badges, the effort-header toggle, the /fast command) renders this one solid
-// lightning bolt from the Central fill set instead of mixing Tabler/Ionicons bolts.
-export const FastModeIcon: LucideIcon = centralIconWrapper("zap", "fill");
-// Outline twin of FastModeIcon (Central reversed set) for the inactive toggle state.
-export const FastModeOutlineIcon: LucideIcon = centralIconWrapper("zap");
+// Single source for the fast-mode glyph. A high-reading speedometer keeps every
+// fast-mode affordance explicit without leaning on the more playful lightning
+// metaphor. The neutral twin shows the needle at standard speed in toggles.
+export const FastModeIcon: LucideIcon = centralIconWrapper("speed-high");
+export const FastModeOutlineIcon: LucideIcon = centralIconWrapper("speed-middle");


### PR DESCRIPTION
## Status

This UI branch predates substantial composer/provider work on `main` and needs to be refreshed before it is review-ready. The current GitHub Actions run is `action_required` and produced no jobs, so it is **not** being treated as a passing or failing validation signal.

The feature intent remains narrow: simplify how users choose a model, reasoning effort, and fast mode without changing provider/runtime semantics.

## Problem

The composer exposed model, effort, and speed through controls that were visually and structurally separate. That made a common task—choose a model and tune its reasoning level—feel more fragmented than necessary, and the old effort presentation did not scale especially well across provider-specific effort ladders.

## What this PR changes

- uses the combined `ComposerModelEffortPicker` consistently instead of splitting model and traits controls for fresh draft threads;
- represents supported ordered effort ladders with one accessible range control;
- keeps Kilo/OpenCode variant-style choices as named options rather than forcing them into the slider metaphor;
- moves detailed Model/Effort/Speed controls behind an inline **Advanced** disclosure;
- keeps Fast mode as a compact, explicit quick toggle when the selected provider/model supports it;
- removes the separate Speed row from the direct-slider presentation;
- uses theme-aware slider chrome instead of the earlier electric/lightning visual treatment;
- preserves keyboard/range semantics through a native range input underneath the custom visual track.

## Behavior

### Default view

For providers with a real ordered effort ladder:

1. open the combined model/reasoning picker;
2. adjust effort directly with the slider;
3. toggle Fast mode without leaving the picker when supported;
4. expand **Advanced** only when named Model/Effort controls are needed.

### Providers without a suitable slider

Providers such as Kilo/OpenCode keep their named variant/options UI. Fast-only models keep an explicit speed control rather than an artificial effort scale.

## Why this approach

The change is presentation-only: provider capability data remains authoritative. The slider maps onto the effort options already exposed by each provider instead of inventing a global numeric reasoning scale.

Using a native range input preserves keyboard and accessibility behavior while custom visuals can follow the active Synara theme.

## Original focused validation

The original branch was exercised with focused picker/browser coverage, including:

- provider-specific effort ladders mapped to slider steps;
- draft-store persistence after slider changes;
- Advanced disclosure open/close behavior;
- Fast mode toggling while the picker stays open;
- Claude/Codex/Cursor effort option coverage;
- Ultrathink-controlled disabled state;
- Kilo/OpenCode named-option fallback.

A fresh full validation run is required after reconciling this branch with current `main`.

## Risks to check during refresh

- composer footer layout has changed since this branch was created;
- current provider capability/discovery code may expose new option shapes;
- slider behavior must not regress pointer, keyboard, reduced-motion, or compact-layout behavior;
- no current `main` composer improvements should be replaced with older component versions.

## Out of scope

- changing provider model catalogs or reasoning semantics;
- adding new provider capabilities;
- changing persisted model-option contracts;
- redesigning the rest of the composer.