### PR TITLE
feat: configure queue or steer follow-ups

### DIFF
--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -10,6 +10,7 @@ import {
   AppSettingsSchema,
   CUSTOM_MODEL_EDITOR_PROVIDER_SETTINGS,
   DEFAULT_CHAT_FONT_SIZE_PX,
+  DEFAULT_FOLLOW_UP_BEHAVIOR,
   DEFAULT_SIDEBAR_PROJECT_SORT_ORDER,
   DEFAULT_TERMINAL_FONT_SIZE_PX,
   DEFAULT_SIDEBAR_THREAD_SORT_ORDER,
@@ -32,6 +33,7 @@ import {
   normalizeTerminalFontSizePx,
   patchCustomModels,
   resolveAppModelSelection,
+  resolveFollowUpDispatchMode,
   resolveTerminalFontFamilyStack,
 } from "./appSettings";
 
@@ -54,6 +56,40 @@ describe("normalizeCustomModelSlugs", () => {
     expect(normalizeCustomModelSlugs(["claude/custom-sonnet"], "claudeAgent")).toEqual([
       "claude/custom-sonnet",
     ]);
+  });
+});
+
+describe("resolveFollowUpDispatchMode", () => {
+  it("uses the selected behavior only while a turn is live", () => {
+    expect(
+      resolveFollowUpDispatchMode({
+        behavior: "steer",
+        hasLiveTurn: false,
+      }),
+    ).toBe("queue");
+    expect(
+      resolveFollowUpDispatchMode({
+        behavior: "steer",
+        hasLiveTurn: true,
+      }),
+    ).toBe("steer");
+  });
+
+  it("uses Ctrl/Cmd+Enter as a one-message inversion", () => {
+    expect(
+      resolveFollowUpDispatchMode({
+        behavior: "queue",
+        hasLiveTurn: true,
+        useOppositeBehavior: true,
+      }),
+    ).toBe("steer");
+    expect(
+      resolveFollowUpDispatchMode({
+        behavior: "steer",
+        hasLiveTurn: true,
+        useOppositeBehavior: true,
+      }),
+    ).toBe("queue");
   });
 });
 
@@ -826,6 +862,7 @@ describe("AppSettingsSchema", () => {
       appSnapShortcut: { kind: "both-option-keys" },
       appSnapPlaySound: true,
       enableAssistantStreaming: true,
+      followUpBehavior: DEFAULT_FOLLOW_UP_BEHAVIOR,
       sidebarProjectSortOrder: DEFAULT_SIDEBAR_PROJECT_SORT_ORDER,
       sidebarThreadSortOrder: DEFAULT_SIDEBAR_THREAD_SORT_ORDER,
       showStudioSection: true,

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -86,6 +86,9 @@ export const DEFAULT_SIDEBAR_PROJECT_SORT_ORDER: SidebarProjectSortOrder = "manu
 export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at"]);
 export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;
 export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "updated_at";
+export const FollowUpBehavior = Schema.Literals(["queue", "steer"]);
+export type FollowUpBehavior = typeof FollowUpBehavior.Type;
+export const DEFAULT_FOLLOW_UP_BEHAVIOR: FollowUpBehavior = "queue";
 
 export const UiDensity = Schema.Literals(UI_DENSITY_MODES);
 export type UiDensity = typeof UiDensity.Type;
@@ -227,6 +230,7 @@ export const AppSettingsSchema = Schema.Struct({
   showEnvironmentMarkers: Schema.Boolean.pipe(withDefaults(() => true)),
   showEnvironmentInstructions: Schema.Boolean.pipe(withDefaults(() => true)),
   showEnvironmentNotepad: Schema.Boolean.pipe(withDefaults(() => true)),
+  followUpBehavior: FollowUpBehavior.pipe(withDefaults(() => DEFAULT_FOLLOW_UP_BEHAVIOR)),
   enableAssistantStreaming: Schema.Boolean.pipe(withDefaults(() => true)),
   enableProviderUpdateChecks: Schema.Boolean.pipe(withDefaults(() => true)),
   enableNativeFontSmoothing: Schema.Boolean.pipe(withDefaults(getDefaultNativeFontSmoothing)),
@@ -1134,6 +1138,24 @@ export function resolveAssistantDeliveryMode(
   settings: Pick<AppSettings, "enableAssistantStreaming">,
 ): AssistantDeliveryMode {
   return settings.enableAssistantStreaming ? "streaming" : "buffered";
+}
+
+/**
+ * Resolves the dispatch mode for a composer submit. The preference applies only
+ * while a turn is live; Ctrl/Cmd+Enter temporarily selects the opposite mode.
+ */
+export function resolveFollowUpDispatchMode(input: {
+  behavior: FollowUpBehavior;
+  hasLiveTurn: boolean;
+  useOppositeBehavior?: boolean;
+}): FollowUpBehavior {
+  if (!input.hasLiveTurn) {
+    return "queue";
+  }
+  if (!input.useOppositeBehavior) {
+    return input.behavior;
+  }
+  return input.behavior === "queue" ? "steer" : "queue";
 }
 
 export function getCustomBinaryPathForProvider(

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -3413,6 +3413,51 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("steers a running turn when Follow-up behavior is set to Steer", async () => {
+    localStorage.setItem("synara:app-settings:v1", JSON.stringify({ followUpBehavior: "steer" }));
+    useComposerDraftStore.getState().setPrompt(THREAD_ID, "steer this running turn");
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-running-steer-setting" as MessageId,
+        targetText: "running steer setting target",
+        sessionStatus: "running",
+      }),
+    });
+
+    try {
+      const composerForm = await waitForElement(
+        () => document.querySelector<HTMLFormElement>('form[data-chat-composer-form="true"]'),
+        "Unable to find composer form.",
+      );
+      composerForm.requestSubmit();
+
+      await vi.waitFor(
+        () => {
+          const turnStart = wsRequests
+            .map(readDispatchedCommand)
+            .find(
+              (command) =>
+                command?.type === "thread.turn.start" &&
+                command.dispatchMode === "steer" &&
+                typeof command.message === "object" &&
+                command.message !== null &&
+                "text" in command.message &&
+                typeof command.message.text === "string" &&
+                command.message.text.includes("steer this running turn"),
+            );
+          expect(turnStart).toBeTruthy();
+          expect(document.querySelector('[data-testid="queued-follow-up-row"]')).toBeNull();
+          expect(document.body.textContent).toContain("Steering conversation");
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("keeps queued follow-ups when you switch threads and come back", async () => {
     useComposerDraftStore.getState().setPrompt(THREAD_ID, "queue survives thread switch");
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -323,6 +323,7 @@ import {
   getProviderStartOptions,
   resolveAppModelSelection,
   resolveAssistantDeliveryMode,
+  resolveFollowUpDispatchMode,
   useAppSettings,
 } from "../appSettings";
 import { isTerminalFocused } from "../lib/terminalFocus";
@@ -6665,7 +6666,10 @@ export default function ChatView({
 
   const onSend = async (
     e?: { preventDefault: () => void },
-    dispatchMode: "queue" | "steer" = "queue",
+    dispatchMode: "queue" | "steer" = resolveFollowUpDispatchMode({
+      behavior: settings.followUpBehavior,
+      hasLiveTurn,
+    }),
     queuedTurn?: QueuedComposerChatTurn,
   ): Promise<boolean> => {
     e?.preventDefault();
@@ -9645,7 +9649,14 @@ export default function ChatView({
       !menuIsActive &&
       extractChatAutomationInvocation(snapshot.value) !== null
     ) {
-      void onSend(undefined, event.metaKey || event.ctrlKey ? "steer" : "queue");
+      void onSend(
+        undefined,
+        resolveFollowUpDispatchMode({
+          behavior: settings.followUpBehavior,
+          hasLiveTurn,
+          useOppositeBehavior: event.metaKey || event.ctrlKey,
+        }),
+      );
       return true;
     }
 
@@ -9748,7 +9759,14 @@ export default function ChatView({
         setComposerDraftPromptHistorySavedDraft(threadId, null);
       }
       expectedPromptHistoryPromptRef.current = null;
-      void onSend(undefined, event.metaKey || event.ctrlKey ? "steer" : "queue");
+      void onSend(
+        undefined,
+        resolveFollowUpDispatchMode({
+          behavior: settings.followUpBehavior,
+          hasLiveTurn,
+          useOppositeBehavior: event.metaKey || event.ctrlKey,
+        }),
+      );
       return true;
     }
     return false;

--- a/apps/web/src/components/SettingsSidebarNav.test.tsx
+++ b/apps/web/src/components/SettingsSidebarNav.test.tsx
@@ -30,6 +30,11 @@ describe("rankSettingsSearchEntries", () => {
     expect(results.some((entry) => entry.id === "behavior:diff-line-wrapping")).toBe(true);
   });
 
+  it("indexes the follow-up Queue and Steer preference", () => {
+    const results = rankSettingsSearchEntries("steer", 12);
+    expect(results.some((entry) => entry.id === "behavior:follow-up-behavior")).toBe(true);
+  });
+
   it("includes the activity toasts notification row", () => {
     const results = rankSettingsSearchEntries("toasts", 12);
     expect(results.some((entry) => entry.id === "notifications:activity-toasts")).toBe(true);

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -11,6 +11,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import {
   type AppSettings,
+  type FollowUpBehavior,
   DEFAULT_UI_DENSITY,
   type UiDensity,
   MAX_CHAT_FONT_SIZE_PX,
@@ -161,6 +162,11 @@ const SIDEBAR_THREAD_SORT_ORDER_LABELS = {
   created_at: "Newest first",
 } as const;
 
+const FOLLOW_UP_BEHAVIOR_OPTIONS = [
+  { value: "queue", label: "Queue" },
+  { value: "steer", label: "Steer" },
+] as const satisfies ReadonlyArray<{ value: FollowUpBehavior; label: string }>;
+
 // ── Settings UI primitives ────────────────────────────────────────────────
 
 // Shared settings controls live in ~/components/settings/SettingControls.
@@ -255,6 +261,7 @@ function SettingsRouteView() {
     ...(settings.enableAssistantStreaming !== defaults.enableAssistantStreaming
       ? ["Assistant output"]
       : []),
+    ...(settings.followUpBehavior !== defaults.followUpBehavior ? ["Follow-up behavior"] : []),
     ...(settings.enableAppSnap !== defaults.enableAppSnap ? ["AppSnap"] : []),
     ...(!sameAppSnapShortcut(settings.appSnapShortcut, defaults.appSnapShortcut)
       ? ["AppSnap shortcut"]
@@ -911,6 +918,31 @@ function SettingsRouteView() {
   const renderBehaviorPanel = () => (
     <div className="space-y-6">
       <SettingsSection title="Runtime behavior">
+        <SettingsRow
+          title="Follow-up behavior"
+          description="Choose whether messages sent during an active turn wait in the queue or steer the current run. Ctrl/Cmd+Enter uses the opposite behavior for one message."
+          resetAction={
+            settings.followUpBehavior !== defaults.followUpBehavior ? (
+              <SettingResetButton
+                label="follow-up behavior"
+                onClick={() =>
+                  updateSettings({
+                    followUpBehavior: defaults.followUpBehavior,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <SettingsSegmentedControl
+              value={settings.followUpBehavior}
+              onValueChange={(value) => updateSettings({ followUpBehavior: value })}
+              ariaLabel="Follow-up behavior"
+              options={FOLLOW_UP_BEHAVIOR_OPTIONS}
+            />
+          }
+        />
+
         {renderBooleanSettingRow({
           settingKey: "enableAssistantStreaming",
           title: "Assistant output",

--- a/apps/web/src/settingsNavigation.ts
+++ b/apps/web/src/settingsNavigation.ts
@@ -89,7 +89,7 @@ export const SETTINGS_NAV_ITEMS: readonly SettingsNavItem[] = [
     id: "behavior",
     group: "app",
     label: "Behavior",
-    description: "Streaming, diff handling, and destructive confirmations.",
+    description: "Follow-ups, streaming, diff handling, and destructive confirmations.",
     icon: "settings-slider-hor",
     eyebrow: "Interaction rules",
   },

--- a/apps/web/src/settingsSearchIndex.ts
+++ b/apps/web/src/settingsSearchIndex.ts
@@ -246,6 +246,13 @@ export const SETTINGS_SEARCH_ENTRIES: readonly SettingsSearchEntry[] = [
 
   // ── Behavior ──────────────────────────────────────────────────────────────────
   {
+    id: "behavior:follow-up-behavior",
+    section: "behavior",
+    title: "Follow-up behavior",
+    keywords:
+      "Choose whether messages sent during an active turn wait in the queue or steer the current run. Ctrl Cmd Enter opposite send",
+  },
+  {
     id: "behavior:assistant-output",
     section: "behavior",
     title: "Assistant output",


### PR DESCRIPTION
## Summary
- add a Follow-up behavior setting for Queue versus Steer
- apply the setting to normal sends and Enter shortcuts
- keep Ctrl+Enter as the one-message opposite behavior

## Validation
- focused settings and ChatView browser tests passed in the integrated checkout