### PR TITLE
Add inline pull request review comments

### DIFF
--- a/apps/server/src/git/Layers/GitHubCli.test.ts
+++ b/apps/server/src/git/Layers/GitHubCli.test.ts
@@ -276,7 +276,7 @@ layer("GitHubCliLive", (it) => {
     }),
   );
 
-  it.effect("returns root comments of unresolved review threads only", () =>
+  it.effect("returns timeline roots and preserves grouped review threads", () =>
     Effect.gen(function* () {
       mockedRunProcess.mockResolvedValueOnce({
         stdout: JSON.stringify({
@@ -286,7 +286,12 @@ layer("GitHubCliLive", (it) => {
                 reviewThreads: {
                   nodes: [
                     {
+                      id: "PRRT_11",
                       isResolved: false,
+                      path: "CursorAcpCommand.ts",
+                      line: 18,
+                      originalLine: 17,
+                      diffSide: "RIGHT",
                       comments: {
                         nodes: [
                           {
@@ -301,7 +306,12 @@ layer("GitHubCliLive", (it) => {
                       },
                     },
                     {
+                      id: "PRRT_12",
                       isResolved: true,
+                      path: "CursorAcpCommand.ts",
+                      line: null,
+                      originalLine: 9,
+                      diffSide: "LEFT",
                       comments: {
                         nodes: [
                           {
@@ -356,6 +366,50 @@ layer("GitHubCliLive", (it) => {
           createdAt: "2026-07-01T10:00:00Z",
         },
       ]);
+      assert.deepStrictEqual(
+        result.threads.map((thread) => ({
+          id: thread.id,
+          path: thread.path,
+          line: thread.line,
+          side: thread.side,
+          isResolved: thread.isResolved,
+          comments: thread.comments.map((comment) => ({
+            id: comment.id,
+            author: comment.author?.login ?? null,
+            body: comment.body,
+          })),
+        })),
+        [
+          {
+            id: "PRRT_11",
+            path: "CursorAcpCommand.ts",
+            line: 18,
+            side: "RIGHT",
+            isResolved: false,
+            comments: [
+              {
+                id: "PRRC_11",
+                author: "codex-bot",
+                body: "Avoid returning shims directly",
+              },
+            ],
+          },
+          {
+            id: "PRRT_12",
+            path: "CursorAcpCommand.ts",
+            line: 9,
+            side: "LEFT",
+            isResolved: true,
+            comments: [
+              {
+                id: "PRRC_12",
+                author: "codex-bot",
+                body: "Already handled",
+              },
+            ],
+          },
+        ],
+      );
       assert.equal(result.truncated, false);
 
       const [command, args, options] = mockedRunProcess.mock.calls[0] ?? [];
@@ -1292,6 +1346,87 @@ layer("GitHubCliLive", (it) => {
       // The body must never appear in argv — it travels over stdin.
       expect(mockedRunProcess.mock.calls[0]?.[2]).toEqual(
         expect.objectContaining({ stdin: "Looks good!\n\nShipping it." }),
+      );
+    }),
+  );
+
+  it.effect("reads the live head and submits one review payload over stdin", () =>
+    Effect.gen(function* () {
+      mockedRunProcess
+        .mockResolvedValueOnce({
+          stdout: "abc123\n",
+          stderr: "",
+          code: 0,
+          signal: null,
+          timedOut: false,
+        })
+        .mockResolvedValueOnce({
+          stdout: "{}",
+          stderr: "",
+          code: 0,
+          signal: null,
+          timedOut: false,
+        });
+      const gh = yield* GitHubCli;
+      assert.strictEqual(
+        yield* gh.getPullRequestHeadSha({
+          cwd: "/repo",
+          repository: "acme/app",
+          number: 9,
+        }),
+        "abc123",
+      );
+      yield* gh.submitPullRequestReview({
+        cwd: "/repo",
+        repository: "acme/app",
+        number: 9,
+        headSha: "abc123",
+        event: "REQUEST_CHANGES",
+        body: "Please fix this.",
+        comments: [
+          {
+            path: "src/a.ts",
+            line: 7,
+            side: "RIGHT",
+            body: "This can fail.",
+          },
+        ],
+      });
+
+      expect(mockedRunProcess.mock.calls[0]?.[1]).toEqual([
+        "api",
+        "--hostname",
+        "github.com",
+        "repos/acme/app/pulls/9",
+        "--jq",
+        ".head.sha",
+      ]);
+      expect(mockedRunProcess.mock.calls[1]?.[1]).toEqual([
+        "api",
+        "--hostname",
+        "github.com",
+        "--method",
+        "POST",
+        "repos/acme/app/pulls/9/reviews",
+        "--input",
+        "-",
+      ]);
+      expect(mockedRunProcess.mock.calls[1]?.[2]).toEqual(
+        expect.objectContaining({
+          stdin: JSON.stringify({
+            commit_id: "abc123",
+            event: "REQUEST_CHANGES",
+            body: "Please fix this.",
+            comments: [
+              {
+                path: "src/a.ts",
+                line: 7,
+                side: "RIGHT",
+                body: "This can fail.",
+              },
+            ],
+          }),
+        }),
       );
     }),
   );

--- a/apps/server/src/git/Layers/GitHubCli.ts
+++ b/apps/server/src/git/Layers/GitHubCli.ts
@@ -11,6 +11,7 @@ import {
   type PullRequestCommit,
   type PullRequestLabel,
   type PullRequestMergeCapabilities,
+  type PullRequestReviewThread,
 } from "@synara/contracts";
 import { githubAvatarUrlForLogin } from "@synara/shared/githubAvatar";
 import {
@@ -291,8 +292,13 @@ const PULL_REQUEST_REVIEW_THREADS_QUERY = `query($owner: String!, $repo: String!
     pullRequest(number: $number) {
       reviewThreads(first: $first, after: $after) {
         nodes {
+          id
           isResolved
-          comments(first: 1) {
+          path
+          line
+          originalLine
+          diffSide
+          comments(first: 50) {
             nodes {
               id
               body
@@ -332,7 +338,12 @@ const RawReviewThreadCommentSchema = Schema.Struct({
 });
 
 const RawReviewThreadSchema = Schema.Struct({
+  id: Schema.optional(Schema.NullOr(Schema.String)),
   isResolved: Schema.optional(Schema.NullOr(Schema.Boolean)),
+  path: Schema.optional(Schema.NullOr(Schema.String)),
+  line: Schema.optional(Schema.NullOr(Schema.Number)),
+  originalLine: Schema.optional(Schema.NullOr(Schema.Number)),
+  diffSide: Schema.optional(Schema.NullOr(Schema.String)),
   comments: Schema.optional(
     Schema.NullOr(
       Schema.Struct({
@@ -670,6 +681,58 @@ function normalizePullRequestReviewComments(
     });
   }
   return comments;
+}
+
+function normalizePullRequestReviewThreads(
+  raw: Schema.Schema.Type<typeof RawReviewThreadsResponseSchema>,
+): PullRequestReviewThread[] {
+  const threads = raw.data?.repository?.pullRequest?.reviewThreads?.nodes ?? [];
+  return threads.flatMap((thread) => {
+    if (!thread) return [];
+    const id = thread.id?.trim();
+    const path = thread.path?.trim();
+    const line = thread.line ?? thread.originalLine;
+    const side = thread.diffSide;
+    if (
+      !id ||
+      !path ||
+      typeof line !== "number" ||
+      !Number.isInteger(line) ||
+      line <= 0 ||
+      (side !== "LEFT" && side !== "RIGHT")
+    ) {
+      return [];
+    }
+    return [
+      {
+        id,
+        path,
+        line,
+        side,
+        isResolved: thread.isResolved === true,
+        comments: (thread.comments?.nodes ?? []).flatMap((comment) => {
+          if (!comment) return [];
+          const login = comment.author?.login?.trim();
+          return [
+            {
+              id: comment.id,
+              author: login
+                ? {
+                    login,
+                    name: null,
+                    avatarUrl: githubAvatarUrlForLogin(login),
+                    url: null,
+                  }
+                : null,
+              body: comment.body ?? "",
+              createdAt: comment.createdAt?.trim() || null,
+              url: comment.url ?? null,
+            },
+          ];
+        }),
+      },
+    ];
+  });
 }
 
 function getGraphQlErrorDetail(
@@ -1214,6 +1277,58 @@ const makeGitHubCli = Effect.sync(() => {
           ),
         ),
       ),
+    getPullRequestHeadSha: (input) =>
+      validateRepository(input.repository, "getPullRequestHeadSha").pipe(
+        Effect.flatMap((repository) =>
+          execute({
+            cwd: input.cwd,
+            args: [
+              "api",
+              "--hostname",
+              GITHUB_HOST,
+              `repos/${repository}/pulls/${input.number}`,
+              "--jq",
+              ".head.sha",
+            ],
+          }),
+        ),
+        Effect.flatMap((result) => {
+          const headSha = result.stdout.trim();
+          return headSha.length > 0
+            ? Effect.succeed(headSha)
+            : Effect.fail(
+                new GitHubCliError({
+                  operation: "getPullRequestHeadSha",
+                  detail: "GitHub returned an empty pull request head commit.",
+                }),
+              );
+        }),
+      ),
+    submitPullRequestReview: (input) =>
+      validateRepository(input.repository, "submitPullRequestReview").pipe(
+        Effect.flatMap((repository) =>
+          execute({
+            cwd: input.cwd,
+            args: [
+              "api",
+              "--hostname",
+              GITHUB_HOST,
+              "--method",
+              "POST",
+              `repos/${repository}/pulls/${input.number}/reviews`,
+              "--input",
+              "-",
+            ],
+            stdin: JSON.stringify({
+              commit_id: input.headSha,
+              event: input.event,
+              ...(input.body.trim().length > 0 ? { body: input.body } : {}),
+              comments: input.comments,
+            }),
+          }),
+        ),
+        Effect.asVoid,
+      ),
     runPullRequestAction: (input) =>
       validateRepository(input.repository, "runPullRequestAction").pipe(
         Effect.flatMap((repository) => {
@@ -1314,6 +1429,7 @@ const makeGitHubCli = Effect.sync(() => {
     getPullRequestReviewComments: (input) =>
       Effect.gen(function* () {
         const comments: GitPullRequestComment[] = [];
+        const threads: PullRequestReviewThread[] = [];
         let after: string | null = null;
         let fetchedPages = 0;
         let truncated = false;
@@ -1358,17 +1474,19 @@ const makeGitHubCli = Effect.sync(() => {
           }
 
           const remaining = PULL_REQUEST_REVIEW_COMMENT_LIMIT - comments.length;
-          const pageComments = normalizePullRequestReviewComments(decoded);
-          if (pageComments.length > remaining) {
-            truncated = true;
+          if (remaining > 0) {
+            const pageComments = normalizePullRequestReviewComments(decoded);
+            if (pageComments.length > remaining) {
+              truncated = true;
+            }
+            comments.push(...pageComments.slice(0, remaining));
           }
-          comments.push(...pageComments.slice(0, Math.max(remaining, 0)));
+          threads.push(...normalizePullRequestReviewThreads(decoded));
 
           const pageInfo = getPullRequestReviewThreadsPageInfo(decoded);
           const canFetchNextPage =
             pageInfo.hasNextPage &&
             pageInfo.endCursor !== null &&
-            comments.length < PULL_REQUEST_REVIEW_COMMENT_LIMIT &&
             fetchedPages < PULL_REQUEST_REVIEW_THREAD_PAGE_LIMIT;
           // hasNextPage alone marks truncation: a null endCursor still means threads remain,
           // we just cannot page to them.
@@ -1378,7 +1496,7 @@ const makeGitHubCli = Effect.sync(() => {
           after = canFetchNextPage ? pageInfo.endCursor : null;
         } while (after !== null);
 
-        return { comments, truncated };
+        return { comments, threads, truncated };
       }),
     getRepositoryCloneUrls: (input) =>
       validateRepository(input.repository, "getRepositoryCloneUrls").pipe(

--- a/apps/server/src/git/Services/GitHubCli.ts
+++ b/apps/server/src/git/Services/GitHubCli.ts
@@ -18,6 +18,9 @@ import type {
   PullRequestLabel,
   PullRequestMergeCapabilities,
   PullRequestMergeMethod,
+  PullRequestReviewEvent,
+  PullRequestReviewSide,
+  PullRequestReviewThread,
   PullRequestState,
 } from "@synara/contracts";
 
@@ -62,6 +65,7 @@ export interface GitHubRepositoryCloneUrls {
 
 export interface GitHubPullRequestReviewCommentsResult {
   readonly comments: ReadonlyArray<GitPullRequestComment>;
+  readonly threads: ReadonlyArray<PullRequestReviewThread>;
   readonly truncated: boolean;
 }
 
@@ -187,6 +191,27 @@ export interface GitHubCliShape {
     readonly repository: string;
     readonly number: number;
   }) => Effect.Effect<{ readonly patch: string; readonly truncated: boolean }, GitHubCliError>;
+
+  readonly getPullRequestHeadSha: (input: {
+    readonly cwd: string;
+    readonly repository: string;
+    readonly number: number;
+  }) => Effect.Effect<string, GitHubCliError>;
+
+  readonly submitPullRequestReview: (input: {
+    readonly cwd: string;
+    readonly repository: string;
+    readonly number: number;
+    readonly headSha: string;
+    readonly event: PullRequestReviewEvent;
+    readonly body: string;
+    readonly comments: ReadonlyArray<{
+      readonly path: string;
+      readonly line: number;
+      readonly side: PullRequestReviewSide;
+      readonly body: string;
+    }>;
+  }) => Effect.Effect<void, GitHubCliError>;
 
   readonly runPullRequestAction: (input: {
     readonly cwd: string;

--- a/apps/server/src/git/testing/fakeGitHubCli.ts
+++ b/apps/server/src/git/testing/fakeGitHubCli.ts
@@ -12,6 +12,8 @@ import type {
   GitPullRequestCheck,
   GitPullRequestComment,
   PullRequestMergeCapabilities,
+  PullRequestReviewEvent,
+  PullRequestReviewThread,
 } from "@synara/contracts";
 
 import { GitHubCliError } from "../Errors.ts";
@@ -47,6 +49,7 @@ export interface FakeGhScenario {
   repositoryCloneUrls?: Record<string, { url: string; sshUrl: string }>;
   pullRequestChecks?: GitPullRequestCheck[];
   pullRequestReviewComments?: GitPullRequestComment[];
+  pullRequestReviewThreads?: PullRequestReviewThread[];
   pullRequestReviewCommentsTruncated?: boolean;
   failWith?: GitHubCliError;
   reviewCommentsError?: GitHubCliError;
@@ -58,6 +61,18 @@ export interface FakeGhScenario {
   reviewRequestedPullRequestNumbers?: number[];
   mergeCapabilities?: PullRequestMergeCapabilities;
   pullRequestDiff?: { patch: string; truncated: boolean };
+  pullRequestHeadSha?: string;
+  submittedReviews?: Array<{
+    headSha: string;
+    event: PullRequestReviewEvent;
+    body: string;
+    comments: ReadonlyArray<{
+      path: string;
+      line: number;
+      side: "LEFT" | "RIGHT";
+      body: string;
+    }>;
+  }>;
 }
 
 export type FakePullRequest = NonNullable<FakeGhScenario["pullRequest"]>;
@@ -321,6 +336,22 @@ export function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
         ghCalls.push(`pr diff ${input.number} --repo ${input.repository}`);
         return Effect.succeed(scenario.pullRequestDiff ?? { patch: "", truncated: false });
       },
+      getPullRequestHeadSha: (input) => {
+        ghCalls.push(`pr head ${input.number} --repo ${input.repository}`);
+        return scenario.failWith
+          ? Effect.fail(scenario.failWith)
+          : Effect.succeed(scenario.pullRequestHeadSha ?? "head-sha");
+      },
+      submitPullRequestReview: (input) => {
+        ghCalls.push(`pr review ${input.number} --repo ${input.repository} --event ${input.event}`);
+        scenario.submittedReviews?.push({
+          headSha: input.headSha,
+          event: input.event,
+          body: input.body,
+          comments: input.comments,
+        });
+        return scenario.failWith ? Effect.fail(scenario.failWith) : Effect.void;
+      },
       runPullRequestAction: (input) => {
         ghCalls.push(
           `pr action ${input.action} ${input.number} --repo ${input.repository}${input.mergeMethod ? ` --${input.mergeMethod}` : ""}`,
@@ -422,6 +453,7 @@ export function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
           ? Effect.fail(scenario.reviewCommentsError)
           : Effect.succeed({
               comments: scenario.pullRequestReviewComments ?? [],
+              threads: scenario.pullRequestReviewThreads ?? [],
               truncated: scenario.pullRequestReviewCommentsTruncated ?? false,
             });
       },

--- a/apps/server/src/persistence/Layers/PullRequestReviewDraftStore.test.ts
+++ b/apps/server/src/persistence/Layers/PullRequestReviewDraftStore.test.ts
@@ -1,0 +1,123 @@
+import { assert, it } from "@effect/vitest";
+import { Effect, Layer, Option } from "effect";
+
+import { PullRequestReviewDraftStore } from "../Services/PullRequestReviewDraftStore.ts";
+import { PullRequestReviewDraftStoreLive } from "./PullRequestReviewDraftStore.ts";
+import { SqlitePersistenceMemory } from "./Sqlite.ts";
+
+const layer = it.layer(
+  PullRequestReviewDraftStoreLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
+);
+
+layer("PullRequestReviewDraftStore", (it) => {
+  it.effect("preserves complete anchors and shares them by GitHub PR identity", () =>
+    Effect.gen(function* () {
+      const store = yield* PullRequestReviewDraftStore;
+      const created = yield* store.create({
+        repository: "Acme/Widgets",
+        number: 42,
+        headSha: "head-a",
+        patchSignature: "patch-a",
+        path: "src/widget.ts",
+        line: 17,
+        side: "RIGHT",
+        body: "Keep this check.",
+      });
+
+      const listed = yield* store.list({ repository: "acme/widgets", number: 42 });
+      assert.strictEqual(listed.length, 1);
+      assert.deepStrictEqual(listed[0], created);
+      assert.deepStrictEqual(
+        {
+          headSha: listed[0]?.headSha,
+          patchSignature: listed[0]?.patchSignature,
+          path: listed[0]?.path,
+          line: listed[0]?.line,
+          side: listed[0]?.side,
+          body: listed[0]?.body,
+        },
+        {
+          headSha: "head-a",
+          patchSignature: "patch-a",
+          path: "src/widget.ts",
+          line: 17,
+          side: "RIGHT",
+          body: "Keep this check.",
+        },
+      );
+      assert.deepStrictEqual(yield* store.list({ repository: "acme/widgets", number: 43 }), []);
+      assert.deepStrictEqual(
+        yield* store.listByIds({
+          repository: "acme/widgets",
+          number: 42,
+          ids: [created.id, "missing"],
+        }),
+        [created],
+      );
+      assert.deepStrictEqual(
+        yield* store.listByIds({
+          repository: "acme/widgets",
+          number: 42,
+          ids: [],
+        }),
+        [],
+      );
+    }),
+  );
+
+  it.effect("scopes updates and deletes to repository and pull request", () =>
+    Effect.gen(function* () {
+      const store = yield* PullRequestReviewDraftStore;
+      const draft = yield* store.create({
+        repository: "acme/scope",
+        number: 7,
+        headSha: "head",
+        patchSignature: "patch",
+        path: "a.ts",
+        line: 1,
+        side: "LEFT",
+        body: "Before",
+      });
+
+      assert.strictEqual(
+        Option.isNone(
+          yield* store.update({
+            repository: "acme/scope",
+            number: 8,
+            id: draft.id,
+            body: "Wrong PR",
+          }),
+        ),
+        true,
+      );
+      assert.strictEqual(
+        yield* store.delete({
+          repository: "acme/other",
+          number: 7,
+          id: draft.id,
+        }),
+        false,
+      );
+      const updated = yield* store.update({
+        repository: "acme/scope",
+        number: 7,
+        id: draft.id,
+        body: "After",
+      });
+      assert.strictEqual(Option.isSome(updated), true);
+      if (Option.isSome(updated)) {
+        assert.strictEqual(updated.value.body, "After");
+        assert.strictEqual(updated.value.createdAt, draft.createdAt);
+      }
+      assert.strictEqual(
+        yield* store.delete({
+          repository: "acme/scope",
+          number: 7,
+          id: draft.id,
+        }),
+        true,
+      );
+      assert.deepStrictEqual(yield* store.list({ repository: "acme/scope", number: 7 }), []);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Layers/PullRequestReviewDraftStore.ts
+++ b/apps/server/src/persistence/Layers/PullRequestReviewDraftStore.ts
@@ -1,0 +1,188 @@
+import { randomUUID } from "node:crypto";
+
+import { PullRequestReviewDraft } from "@synara/contracts";
+import { Effect, Layer, Option, Schema } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { toPersistenceDecodeCauseError, toPersistenceSqlError } from "../Errors.ts";
+import {
+  PullRequestReviewDraftStore,
+  type PullRequestReviewDraftIdentity,
+  type PullRequestReviewDraftStoreShape,
+} from "../Services/PullRequestReviewDraftStore.ts";
+
+interface DraftRow {
+  readonly id: string;
+  readonly repository: string;
+  readonly number: number;
+  readonly headSha: string;
+  readonly patchSignature: string;
+  readonly path: string;
+  readonly line: number;
+  readonly side: string;
+  readonly body: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+const decodeDraft = Schema.decodeUnknownEffect(PullRequestReviewDraft);
+
+const decodeRows = (label: string, rows: ReadonlyArray<DraftRow>) =>
+  Effect.forEach(rows, (row) => decodeDraft(row)).pipe(
+    Effect.mapError(toPersistenceDecodeCauseError(`${label}:decodeRows`)),
+  );
+
+const makePullRequestReviewDraftStore = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const selectDrafts = (
+    input: PullRequestReviewDraftIdentity & {
+      readonly id?: string;
+      readonly ids?: ReadonlyArray<string>;
+    },
+  ) => sql<DraftRow>`
+    SELECT
+      id,
+      repository,
+      pull_request_number AS "number",
+      head_sha AS "headSha",
+      patch_signature AS "patchSignature",
+      path,
+      line,
+      side,
+      body,
+      created_at AS "createdAt",
+      updated_at AS "updatedAt"
+    FROM pull_request_review_drafts
+    WHERE repository = ${input.repository}
+      AND pull_request_number = ${input.number}
+      ${input.id === undefined ? sql`` : sql`AND id = ${input.id}`}
+      ${input.ids === undefined ? sql`` : sql`AND id IN ${sql.in(input.ids)}`}
+    ORDER BY created_at ASC, id ASC
+  `;
+
+  const list: PullRequestReviewDraftStoreShape["list"] = (input) =>
+    selectDrafts(input).pipe(
+      Effect.mapError(toPersistenceSqlError("PullRequestReviewDraftStore.list:query")),
+      Effect.flatMap((rows) => decodeRows("PullRequestReviewDraftStore.list", rows)),
+    );
+
+  const listByIds: PullRequestReviewDraftStoreShape["listByIds"] = (input) =>
+    input.ids.length === 0
+      ? Effect.succeed([])
+      : selectDrafts(input).pipe(
+          Effect.mapError(toPersistenceSqlError("PullRequestReviewDraftStore.listByIds:query")),
+          Effect.flatMap((rows) => decodeRows("PullRequestReviewDraftStore.listByIds", rows)),
+        );
+
+  const create: PullRequestReviewDraftStoreShape["create"] = (input) =>
+    Effect.gen(function* () {
+      const timestamp = new Date().toISOString();
+      const draft = {
+        id: randomUUID(),
+        repository: input.repository,
+        number: input.number,
+        headSha: input.headSha,
+        patchSignature: input.patchSignature,
+        path: input.path,
+        line: input.line,
+        side: input.side,
+        body: input.body,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      } satisfies PullRequestReviewDraft;
+      yield* sql`
+        INSERT INTO pull_request_review_drafts (
+          id,
+          repository,
+          pull_request_number,
+          head_sha,
+          patch_signature,
+          path,
+          line,
+          side,
+          body,
+          created_at,
+          updated_at
+        )
+        VALUES (
+          ${draft.id},
+          ${draft.repository},
+          ${draft.number},
+          ${draft.headSha},
+          ${draft.patchSignature},
+          ${draft.path},
+          ${draft.line},
+          ${draft.side},
+          ${draft.body},
+          ${draft.createdAt},
+          ${draft.updatedAt}
+        )
+      `.pipe(Effect.mapError(toPersistenceSqlError("PullRequestReviewDraftStore.create:query")));
+      return draft;
+    });
+
+  const update: PullRequestReviewDraftStoreShape["update"] = (input) =>
+    Effect.gen(function* () {
+      const updatedAt = new Date().toISOString();
+      const rows = yield* sql<DraftRow>`
+        UPDATE pull_request_review_drafts
+        SET body = ${input.body}, updated_at = ${updatedAt}
+        WHERE id = ${input.id}
+          AND repository = ${input.repository}
+          AND pull_request_number = ${input.number}
+        RETURNING
+          id,
+          repository,
+          pull_request_number AS "number",
+          head_sha AS "headSha",
+          patch_signature AS "patchSignature",
+          path,
+          line,
+          side,
+          body,
+          created_at AS "createdAt",
+          updated_at AS "updatedAt"
+      `.pipe(Effect.mapError(toPersistenceSqlError("PullRequestReviewDraftStore.update:query")));
+      const drafts = yield* decodeRows("PullRequestReviewDraftStore.update", rows);
+      return Option.fromNullishOr(drafts[0]);
+    });
+
+  const deleteDraft: PullRequestReviewDraftStoreShape["delete"] = (input) =>
+    sql`
+      DELETE FROM pull_request_review_drafts
+      WHERE id = ${input.id}
+        AND repository = ${input.repository}
+        AND pull_request_number = ${input.number}
+      RETURNING id
+    `.pipe(
+      Effect.map((rows) => rows.length > 0),
+      Effect.mapError(toPersistenceSqlError("PullRequestReviewDraftStore.delete:query")),
+    );
+
+  const deleteMany: PullRequestReviewDraftStoreShape["deleteMany"] = (input) =>
+    input.ids.length === 0
+      ? Effect.void
+      : sql`
+          DELETE FROM pull_request_review_drafts
+          WHERE repository = ${input.repository}
+            AND pull_request_number = ${input.number}
+            AND id IN ${sql.in(input.ids)}
+        `.pipe(
+          Effect.asVoid,
+          Effect.mapError(toPersistenceSqlError("PullRequestReviewDraftStore.deleteMany:query")),
+        );
+
+  return {
+    list,
+    listByIds,
+    create,
+    update,
+    delete: deleteDraft,
+    deleteMany,
+  } satisfies PullRequestReviewDraftStoreShape;
+});
+
+export const PullRequestReviewDraftStoreLive = Layer.effect(
+  PullRequestReviewDraftStore,
+  makePullRequestReviewDraftStore,
+);

--- a/apps/server/src/persistence/Migrations.test.ts
+++ b/apps/server/src/persistence/Migrations.test.ts
@@ -289,10 +289,11 @@ managedAttachmentsLegacyLayer("managed attachment migration after private migrat
         [85, "AutomationSettings"],
         [86, "NormalizeStudioThreadWorkspaces"],
         [87, "DropUnusedOrchestrationEventIndexes"],
+        [88, "PullRequestReviewDrafts"],
       ]);
 
       const tracker = yield* trackerRows(sql);
-      assert.deepStrictEqual(tracker.slice(-34), [
+      assert.deepStrictEqual(tracker.slice(-35), [
         { migration_id: 54, name: "DurableProviderCommandDelivery" },
         { migration_id: 55, name: "ManagedAttachments" },
         { migration_id: 56, name: "CommandReceiptFingerprints" },
@@ -327,6 +328,7 @@ managedAttachmentsLegacyLayer("managed attachment migration after private migrat
         { migration_id: 85, name: "AutomationSettings" },
         { migration_id: 86, name: "NormalizeStudioThreadWorkspaces" },
         { migration_id: 87, name: "DropUnusedOrchestrationEventIndexes" },
+        { migration_id: 88, name: "PullRequestReviewDrafts" },
       ]);
       const preserved = yield* sql<{ readonly count: number }>`
         SELECT COUNT(*) AS count FROM orchestration_consumer_state
@@ -406,6 +408,7 @@ agentGatewayRetentionLegacyLayer(
           [85, "AutomationSettings"],
           [86, "NormalizeStudioThreadWorkspaces"],
           [87, "DropUnusedOrchestrationEventIndexes"],
+          [88, "PullRequestReviewDrafts"],
         ]);
 
         const columns = yield* sql<{ readonly name: string }>`
@@ -488,11 +491,12 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
         [85, "AutomationSettings"],
         [86, "NormalizeStudioThreadWorkspaces"],
         [87, "DropUnusedOrchestrationEventIndexes"],
+        [88, "PullRequestReviewDrafts"],
       ]);
 
       const tracker = yield* trackerRows(sql);
       assert.deepStrictEqual(
-        tracker.slice(-18).map((row) => [row.migration_id, row.name]),
+        tracker.slice(-19).map((row) => [row.migration_id, row.name]),
         [
           [70, "AgentGatewayOperations"],
           [71, "ProjectionThreadsGatewayProvenance"],
@@ -512,6 +516,7 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
           [85, "AutomationSettings"],
           [86, "NormalizeStudioThreadWorkspaces"],
           [87, "DropUnusedOrchestrationEventIndexes"],
+          [88, "PullRequestReviewDrafts"],
         ],
       );
 
@@ -589,11 +594,12 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
         [85, "AutomationSettings"],
         [86, "NormalizeStudioThreadWorkspaces"],
         [87, "DropUnusedOrchestrationEventIndexes"],
+        [88, "PullRequestReviewDrafts"],
       ]);
 
       const tracker = yield* trackerRows(sql);
       assert.deepStrictEqual(
-        tracker.slice(-14).map((row) => [row.migration_id, row.name]),
+        tracker.slice(-15).map((row) => [row.migration_id, row.name]),
         [
           [74, "ExternalMcpIntegrations"],
           [75, "ExternalMcpActiveCapacity"],
@@ -609,6 +615,7 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
           [85, "AutomationSettings"],
           [86, "NormalizeStudioThreadWorkspaces"],
           [87, "DropUnusedOrchestrationEventIndexes"],
+          [88, "PullRequestReviewDrafts"],
         ],
       );
       const preservedSpaces = yield* sql<{ readonly spaceId: string }>`

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -103,6 +103,7 @@ import Migration0084 from "./Migrations/084_AutomationNotificationPolicy.ts";
 import Migration0085 from "./Migrations/085_AutomationSettings.ts";
 import Migration0086 from "./Migrations/086_NormalizeStudioThreadWorkspaces.ts";
 import Migration0087 from "./Migrations/087_DropUnusedOrchestrationEventIndexes.ts";
+import Migration0088 from "./Migrations/088_PullRequestReviewDrafts.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -205,6 +206,7 @@ export const migrationEntries = [
   [85, "AutomationSettings", Migration0085],
   [86, "NormalizeStudioThreadWorkspaces", Migration0086],
   [87, "DropUnusedOrchestrationEventIndexes", Migration0087],
+  [88, "PullRequestReviewDrafts", Migration0088],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/088_PullRequestReviewDrafts.ts
+++ b/apps/server/src/persistence/Migrations/088_PullRequestReviewDrafts.ts
@@ -1,0 +1,27 @@
+import { Effect } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    CREATE TABLE IF NOT EXISTS pull_request_review_drafts (
+      id TEXT PRIMARY KEY,
+      repository TEXT NOT NULL COLLATE NOCASE,
+      pull_request_number INTEGER NOT NULL CHECK (pull_request_number > 0),
+      head_sha TEXT NOT NULL,
+      patch_signature TEXT NOT NULL,
+      path TEXT NOT NULL,
+      line INTEGER NOT NULL CHECK (line > 0),
+      side TEXT NOT NULL CHECK (side IN ('LEFT', 'RIGHT')),
+      body TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_pull_request_review_drafts_identity
+    ON pull_request_review_drafts(repository, pull_request_number, created_at, id)
+  `;
+});

--- a/apps/server/src/persistence/Services/PullRequestReviewDraftStore.ts
+++ b/apps/server/src/persistence/Services/PullRequestReviewDraftStore.ts
@@ -1,0 +1,48 @@
+import type { PullRequestReviewDraft, PullRequestReviewDraftCreateInput } from "@synara/contracts";
+import { ServiceMap } from "effect";
+import type { Effect, Option } from "effect";
+
+import type { PersistenceDecodeError, PersistenceSqlError } from "../Errors.ts";
+
+export interface PullRequestReviewDraftIdentity {
+  readonly repository: string;
+  readonly number: number;
+}
+
+export interface PullRequestReviewDraftStoreShape {
+  readonly list: (
+    input: PullRequestReviewDraftIdentity,
+  ) => Effect.Effect<
+    ReadonlyArray<PullRequestReviewDraft>,
+    PersistenceSqlError | PersistenceDecodeError
+  >;
+  readonly listByIds: (
+    input: PullRequestReviewDraftIdentity & { readonly ids: ReadonlyArray<string> },
+  ) => Effect.Effect<
+    ReadonlyArray<PullRequestReviewDraft>,
+    PersistenceSqlError | PersistenceDecodeError
+  >;
+  readonly create: (
+    input: Omit<PullRequestReviewDraftCreateInput, "projectId">,
+  ) => Effect.Effect<PullRequestReviewDraft, PersistenceSqlError | PersistenceDecodeError>;
+  readonly update: (
+    input: PullRequestReviewDraftIdentity & {
+      readonly id: string;
+      readonly body: string;
+    },
+  ) => Effect.Effect<
+    Option.Option<PullRequestReviewDraft>,
+    PersistenceSqlError | PersistenceDecodeError
+  >;
+  readonly delete: (
+    input: PullRequestReviewDraftIdentity & { readonly id: string },
+  ) => Effect.Effect<boolean, PersistenceSqlError>;
+  readonly deleteMany: (
+    input: PullRequestReviewDraftIdentity & { readonly ids: ReadonlyArray<string> },
+  ) => Effect.Effect<void, PersistenceSqlError>;
+}
+
+export class PullRequestReviewDraftStore extends ServiceMap.Service<
+  PullRequestReviewDraftStore,
+  PullRequestReviewDraftStoreShape
+>()("synara/persistence/Services/PullRequestReviewDraftStore/PullRequestReviewDraftStore") {}

--- a/apps/server/src/pullRequests/Layers/PullRequestService.ts
+++ b/apps/server/src/pullRequests/Layers/PullRequestService.ts
@@ -24,6 +24,10 @@ import {
   type ProjectPullRequestPinsShape,
 } from "../../persistence/Services/ProjectPullRequestPins";
 import {
+  PullRequestReviewDraftStore,
+  type PullRequestReviewDraftStoreShape,
+} from "../../persistence/Services/PullRequestReviewDraftStore";
+import {
   buildPullRequestListEntry,
   isValidGitHubRepositoryNameWithOwner,
   isViewerReviewRequested,
@@ -69,6 +73,7 @@ export interface PullRequestServiceDependencies {
   readonly homeDir: string;
   readonly github: GitHubCliShape;
   readonly pins: ProjectPullRequestPinsShape;
+  readonly reviewDrafts?: PullRequestReviewDraftStoreShape;
   /**
    * Live (non-soft-deleted) projects. Deliberately not the full read model: the PR
    * service only ever reads `snapshot.projects`, and hydrating every thread body for a
@@ -562,6 +567,7 @@ export const makePullRequestService = (
     const operations = makePullRequestOperations({
       github: dependencies.github,
       pins: dependencies.pins,
+      ...(dependencies.reviewDrafts ? { reviewDrafts: dependencies.reviewDrafts } : {}),
       findProject,
       validateRepository: validatePullRequestRepository,
       validateProjectRepository: validateProjectPullRequestRepository,
@@ -584,11 +590,13 @@ export const PullRequestServiceLive = Layer.effect(
     const git = yield* GitCore;
     const github = yield* GitHubCli;
     const pins = yield* ProjectPullRequestPins;
+    const reviewDrafts = yield* PullRequestReviewDraftStore;
     const projection = yield* ProjectionSnapshotQuery;
     return yield* makePullRequestService({
       homeDir: config.homeDir,
       github,
       pins,
+      reviewDrafts,
       listProjects: () =>
         projection
           .getShellSnapshot()

--- a/apps/server/src/pullRequests/Services/PullRequestService.ts
+++ b/apps/server/src/pullRequests/Services/PullRequestService.ts
@@ -7,6 +7,15 @@ import type {
   PullRequestDiffResult,
   PullRequestReviewRequestCountInput,
   PullRequestReviewRequestCountResult,
+  PullRequestReviewDraftCreateInput,
+  PullRequestReviewDraftDeleteInput,
+  PullRequestReviewDraftDeleteResult,
+  PullRequestReviewDraftListInput,
+  PullRequestReviewDraftListResult,
+  PullRequestReviewDraftResult,
+  PullRequestReviewDraftUpdateInput,
+  PullRequestReviewSubmitInput,
+  PullRequestReviewSubmitResult,
   PullRequestSetPinnedInput,
   PullRequestSetPinnedResult,
   PullRequestsListInput,
@@ -28,6 +37,21 @@ export interface PullRequestServiceShape {
   readonly comment: (
     input: PullRequestCommentInput,
   ) => Effect.Effect<PullRequestActionResult, unknown>;
+  readonly listReviewDrafts: (
+    input: PullRequestReviewDraftListInput,
+  ) => Effect.Effect<PullRequestReviewDraftListResult, unknown>;
+  readonly createReviewDraft: (
+    input: PullRequestReviewDraftCreateInput,
+  ) => Effect.Effect<PullRequestReviewDraftResult, unknown>;
+  readonly updateReviewDraft: (
+    input: PullRequestReviewDraftUpdateInput,
+  ) => Effect.Effect<PullRequestReviewDraftResult, unknown>;
+  readonly deleteReviewDraft: (
+    input: PullRequestReviewDraftDeleteInput,
+  ) => Effect.Effect<PullRequestReviewDraftDeleteResult, unknown>;
+  readonly submitReview: (
+    input: PullRequestReviewSubmitInput,
+  ) => Effect.Effect<PullRequestReviewSubmitResult, unknown>;
   readonly setPinned: (
     input: PullRequestSetPinnedInput,
   ) => Effect.Effect<PullRequestSetPinnedResult, unknown>;

--- a/apps/server/src/pullRequests/pullRequestOperations.test.ts
+++ b/apps/server/src/pullRequests/pullRequestOperations.test.ts
@@ -1,10 +1,17 @@
-import { ProjectId, type OrchestrationProject } from "@synara/contracts";
-import { Deferred, Effect, Fiber } from "effect";
+import { createHash } from "node:crypto";
+
+import {
+  ProjectId,
+  type OrchestrationProject,
+  type PullRequestReviewDraft,
+} from "@synara/contracts";
+import { Deferred, Effect, Fiber, Option } from "effect";
 import { describe, expect, it } from "vitest";
 
 import type { GitHubPullRequestDetailData } from "../git/Services/GitHubCli";
-import { createGitHubCliWithFakeGh } from "../git/testing/fakeGitHubCli";
+import { createGitHubCliWithFakeGh, type FakeGhScenario } from "../git/testing/fakeGitHubCli";
 import type { ProjectPullRequestPinsShape } from "../persistence/Services/ProjectPullRequestPins";
+import type { PullRequestReviewDraftStoreShape } from "../persistence/Services/PullRequestReviewDraftStore";
 import { makePullRequestOperations } from "./pullRequestOperations";
 
 const now = "2026-07-15T00:00:00.000Z";
@@ -51,6 +58,132 @@ const detail: GitHubPullRequestDetailData = {
   commits: [],
 };
 
+const pins: ProjectPullRequestPinsShape = {
+  listByProjectIds: () => Effect.succeed([]),
+  setPinned: () => Effect.void,
+};
+
+function makeDraft(
+  input: Pick<
+    PullRequestReviewDraft,
+    "id" | "headSha" | "patchSignature" | "path" | "line" | "side"
+  >,
+): PullRequestReviewDraft {
+  return {
+    ...input,
+    repository: "acme/widgets",
+    number: 42,
+    body: `Comment ${input.id}`,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function makeDraftStore(initialDrafts: PullRequestReviewDraft[]): {
+  drafts: PullRequestReviewDraft[];
+  service: PullRequestReviewDraftStoreShape;
+} {
+  const state = { drafts: [...initialDrafts] };
+  return {
+    get drafts() {
+      return state.drafts;
+    },
+    service: {
+      list: ({ repository, number }) =>
+        Effect.succeed(
+          state.drafts.filter(
+            (draft) =>
+              draft.repository.toLowerCase() === repository.toLowerCase() &&
+              draft.number === number,
+          ),
+        ),
+      listByIds: ({ repository, number, ids }) => {
+        const selectedIds = new Set(ids);
+        return Effect.succeed(
+          state.drafts.filter(
+            (draft) =>
+              selectedIds.has(draft.id) &&
+              draft.repository.toLowerCase() === repository.toLowerCase() &&
+              draft.number === number,
+          ),
+        );
+      },
+      create: (input) =>
+        Effect.sync(() => {
+          const created = {
+            ...input,
+            id: `draft-${state.drafts.length + 1}`,
+            createdAt: now,
+            updatedAt: now,
+          } satisfies PullRequestReviewDraft;
+          state.drafts.push(created);
+          return created;
+        }),
+      update: (input) =>
+        Effect.sync(() => {
+          const index = state.drafts.findIndex(
+            (draft) =>
+              draft.id === input.id &&
+              draft.repository.toLowerCase() === input.repository.toLowerCase() &&
+              draft.number === input.number,
+          );
+          if (index < 0) return Option.none();
+          const draft = { ...state.drafts[index]!, body: input.body, updatedAt: now };
+          state.drafts[index] = draft;
+          return Option.some(draft);
+        }),
+      delete: (input) =>
+        Effect.sync(() => {
+          const before = state.drafts.length;
+          state.drafts = state.drafts.filter(
+            (draft) =>
+              !(
+                draft.id === input.id &&
+                draft.repository.toLowerCase() === input.repository.toLowerCase() &&
+                draft.number === input.number
+              ),
+          );
+          return state.drafts.length < before;
+        }),
+      deleteMany: (input) =>
+        Effect.sync(() => {
+          const ids = new Set(input.ids);
+          state.drafts = state.drafts.filter(
+            (draft) =>
+              !(
+                ids.has(draft.id) &&
+                draft.repository.toLowerCase() === input.repository.toLowerCase() &&
+                draft.number === input.number
+              ),
+          );
+        }),
+    },
+  };
+}
+
+function makeOperations(input: {
+  github: ReturnType<typeof createGitHubCliWithFakeGh>["service"];
+  reviewDrafts?: PullRequestReviewDraftStoreShape;
+}) {
+  return makePullRequestOperations({
+    github: input.github,
+    pins,
+    ...(input.reviewDrafts ? { reviewDrafts: input.reviewDrafts } : {}),
+    findProject: () => Effect.succeed(project),
+    validateRepository: (repository) => Effect.succeed(repository),
+    validateProjectRepository: (_project, repository) => Effect.succeed(repository),
+    loadMergeCapabilities: () =>
+      Effect.succeed({
+        merge: true,
+        squash: true,
+        rebase: true,
+        deleteBranchOnMerge: false,
+      }),
+    withGitHubRead: (effect) => effect,
+    finalizeMutationCaches: () => Effect.void,
+  });
+}
+
 describe("makePullRequestOperations", () => {
   it("starts detail, merge-capability, and review-comment reads together", async () => {
     await Effect.runPromise(
@@ -67,16 +200,16 @@ describe("makePullRequestOperations", () => {
               return value;
             });
           const base = createGitHubCliWithFakeGh().service;
-          const pins: ProjectPullRequestPinsShape = {
-            listByProjectIds: () => Effect.succeed([]),
-            setPinned: () => Effect.void,
-          };
           const operations = makePullRequestOperations({
             github: {
               ...base,
               getPullRequestDetail: () => waitForRelease(detailStarted, detail),
               getPullRequestReviewComments: () =>
-                waitForRelease(commentsStarted, { comments: [], truncated: false }),
+                waitForRelease(commentsStarted, {
+                  comments: [],
+                  threads: [],
+                  truncated: false,
+                }),
             },
             pins,
             findProject: () => Effect.succeed(project),
@@ -107,5 +240,288 @@ describe("makePullRequestOperations", () => {
         }),
       ),
     );
+  });
+
+  it("returns remote review threads with pull request detail", async () => {
+    const thread = {
+      id: "thread-1",
+      path: "src/a.ts",
+      line: 12,
+      side: "RIGHT" as const,
+      isResolved: true,
+      comments: [
+        {
+          id: "comment-1",
+          author: null,
+          body: "Remote context",
+          createdAt: now,
+          url: null,
+        },
+      ],
+    };
+    const base = createGitHubCliWithFakeGh({
+      pullRequestDetail: detail,
+      pullRequestReviewThreads: [thread],
+    }).service;
+
+    const result = await Effect.runPromise(
+      makeOperations({ github: base }).detail({
+        projectId: project.id,
+        repository: "acme/widgets",
+        number: 42,
+      }),
+    );
+
+    expect(result.reviewThreads).toEqual([thread]);
+  });
+
+  it("blocks the whole review when the head changed and keeps every draft", async () => {
+    const patch = "diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n-old\n+new";
+    const signature = createHash("sha256").update(patch).digest("hex");
+    const store = makeDraftStore([
+      makeDraft({
+        id: "stale",
+        headSha: "old-head",
+        patchSignature: signature,
+        path: "a.ts",
+        line: 1,
+        side: "RIGHT",
+      }),
+      makeDraft({
+        id: "also-stale",
+        headSha: "old-head",
+        patchSignature: signature,
+        path: "a.ts",
+        line: 1,
+        side: "LEFT",
+      }),
+    ]);
+    const submittedReviews: NonNullable<FakeGhScenario["submittedReviews"]> = [];
+    const github = createGitHubCliWithFakeGh({
+      pullRequestHeadSha: "new-head",
+      pullRequestDiff: { patch, truncated: false },
+      submittedReviews,
+    }).service;
+
+    const result = await Effect.runPromise(
+      makeOperations({ github, reviewDrafts: store.service }).submitReview({
+        projectId: project.id,
+        repository: "acme/widgets",
+        number: 42,
+        event: "COMMENT",
+        body: "",
+        draftIds: ["stale", "also-stale"],
+      }),
+    );
+
+    expect(result).toEqual({
+      status: "blocked",
+      submittedDraftIds: [],
+      staleDraftIds: ["stale", "also-stale"],
+      invalidDraftIds: [],
+    });
+    expect(submittedReviews).toEqual([]);
+    expect(store.drafts).toHaveLength(2);
+  });
+
+  it("blocks one invalid line without submitting or deleting valid drafts", async () => {
+    const patch = "diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n-old\n+new";
+    const signature = createHash("sha256").update(patch).digest("hex");
+    const store = makeDraftStore([
+      makeDraft({
+        id: "valid",
+        headSha: "head",
+        patchSignature: signature,
+        path: "a.ts",
+        line: 1,
+        side: "RIGHT",
+      }),
+      makeDraft({
+        id: "invalid",
+        headSha: "head",
+        patchSignature: signature,
+        path: "a.ts",
+        line: 99,
+        side: "RIGHT",
+      }),
+    ]);
+    const submittedReviews: NonNullable<FakeGhScenario["submittedReviews"]> = [];
+    const github = createGitHubCliWithFakeGh({
+      pullRequestHeadSha: "head",
+      pullRequestDiff: { patch, truncated: false },
+      submittedReviews,
+    }).service;
+
+    const result = await Effect.runPromise(
+      makeOperations({ github, reviewDrafts: store.service }).submitReview({
+        projectId: project.id,
+        repository: "acme/widgets",
+        number: 42,
+        event: "COMMENT",
+        body: "",
+        draftIds: ["valid", "invalid"],
+      }),
+    );
+
+    expect(result.invalidDraftIds).toEqual(["invalid"]);
+    expect(submittedReviews).toEqual([]);
+    expect(store.drafts.map((draft) => draft.id)).toEqual(["valid", "invalid"]);
+  });
+
+  it("blocks every inline draft when GitHub truncates the live patch", async () => {
+    const patch = "diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n-old\n+new";
+    const signature = createHash("sha256").update(patch).digest("hex");
+    const store = makeDraftStore([
+      makeDraft({
+        id: "first",
+        headSha: "head",
+        patchSignature: signature,
+        path: "a.ts",
+        line: 1,
+        side: "RIGHT",
+      }),
+      makeDraft({
+        id: "second",
+        headSha: "head",
+        patchSignature: signature,
+        path: "a.ts",
+        line: 1,
+        side: "LEFT",
+      }),
+    ]);
+    const submittedReviews: NonNullable<FakeGhScenario["submittedReviews"]> = [];
+    const github = createGitHubCliWithFakeGh({
+      pullRequestHeadSha: "head",
+      pullRequestDiff: { patch, truncated: true },
+      submittedReviews,
+    }).service;
+
+    const result = await Effect.runPromise(
+      makeOperations({ github, reviewDrafts: store.service }).submitReview({
+        projectId: project.id,
+        repository: "acme/widgets",
+        number: 42,
+        event: "COMMENT",
+        body: "",
+        draftIds: ["first", "second"],
+      }),
+    );
+
+    expect(result).toEqual({
+      status: "blocked",
+      submittedDraftIds: [],
+      staleDraftIds: [],
+      invalidDraftIds: ["first", "second"],
+    });
+    expect(submittedReviews).toEqual([]);
+    expect(store.drafts).toHaveLength(2);
+  });
+
+  it("submits one review and deletes only included drafts after success", async () => {
+    const patch = "diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n-old\n+new";
+    const signature = createHash("sha256").update(patch).digest("hex");
+    const store = makeDraftStore([
+      makeDraft({
+        id: "included",
+        headSha: "head",
+        patchSignature: signature,
+        path: "a.ts",
+        line: 1,
+        side: "RIGHT",
+      }),
+      makeDraft({
+        id: "saved",
+        headSha: "head",
+        patchSignature: signature,
+        path: "a.ts",
+        line: 1,
+        side: "LEFT",
+      }),
+    ]);
+    const submittedReviews: NonNullable<FakeGhScenario["submittedReviews"]> = [];
+    const github = createGitHubCliWithFakeGh({
+      pullRequestHeadSha: "head",
+      pullRequestDiff: { patch, truncated: false },
+      submittedReviews,
+    }).service;
+
+    const result = await Effect.runPromise(
+      makeOperations({ github, reviewDrafts: store.service }).submitReview({
+        projectId: project.id,
+        repository: "acme/widgets",
+        number: 42,
+        event: "REQUEST_CHANGES",
+        body: "Please fix this.",
+        draftIds: ["included"],
+      }),
+    );
+
+    expect(result.status).toBe("submitted");
+    expect(submittedReviews).toEqual([
+      {
+        headSha: "head",
+        event: "REQUEST_CHANGES",
+        body: "Please fix this.",
+        comments: [
+          {
+            path: "a.ts",
+            line: 1,
+            side: "RIGHT",
+            body: "Comment included",
+          },
+        ],
+      },
+    ]);
+    expect(store.drafts.map((draft) => draft.id)).toEqual(["saved"]);
+  });
+
+  it("allows body-only decisions and rejects an empty comment review", async () => {
+    const submittedReviews: NonNullable<FakeGhScenario["submittedReviews"]> = [];
+    const github = createGitHubCliWithFakeGh({
+      pullRequestHeadSha: "head",
+      pullRequestDiff: { patch: "", truncated: false },
+      submittedReviews,
+    }).service;
+    const store = makeDraftStore([]);
+    const operations = makeOperations({ github, reviewDrafts: store.service });
+
+    await expect(
+      Effect.runPromise(
+        operations.submitReview({
+          projectId: project.id,
+          repository: "acme/widgets",
+          number: 42,
+          event: "COMMENT",
+          body: "",
+          draftIds: [],
+        }),
+      ),
+    ).rejects.toThrow("needs a body");
+    const approval = await Effect.runPromise(
+      operations.submitReview({
+        projectId: project.id,
+        repository: "acme/widgets",
+        number: 42,
+        event: "APPROVE",
+        body: "",
+        draftIds: [],
+      }),
+    );
+    const changeRequest = await Effect.runPromise(
+      operations.submitReview({
+        projectId: project.id,
+        repository: "acme/widgets",
+        number: 42,
+        event: "REQUEST_CHANGES",
+        body: "Please revise this.",
+        draftIds: [],
+      }),
+    );
+
+    expect(approval.status).toBe("submitted");
+    expect(changeRequest.status).toBe("submitted");
+    expect(submittedReviews).toHaveLength(2);
+    expect(submittedReviews[0]?.comments).toEqual([]);
+    expect(submittedReviews[1]?.comments).toEqual([]);
   });
 });

--- a/apps/server/src/pullRequests/pullRequestOperations.ts
+++ b/apps/server/src/pullRequests/pullRequestOperations.ts
@@ -1,20 +1,34 @@
+import { createHash } from "node:crypto";
+
 import type { OrchestrationProject, PullRequestDetail } from "@synara/contracts";
 import { githubAvatarUrlForLogin } from "@synara/shared/githubAvatar";
-import { Effect } from "effect";
+import { Effect, Option } from "effect";
 
 import type { GitHubCliShape } from "../git/Services/GitHubCli";
 import type { ProjectPullRequestPinsShape } from "../persistence/Services/ProjectPullRequestPins";
+import type { PullRequestReviewDraftStoreShape } from "../persistence/Services/PullRequestReviewDraftStore";
 import { isPullRequestMergeMethodAllowed } from "../pullRequests.logic";
 import type { PullRequestServiceShape } from "./Services/PullRequestService";
+import { validateInlineComments } from "./validateInlineComments";
 
 type PullRequestOperations = Pick<
   PullRequestServiceShape,
-  "detail" | "diff" | "action" | "comment" | "setPinned"
+  | "detail"
+  | "diff"
+  | "action"
+  | "comment"
+  | "setPinned"
+  | "listReviewDrafts"
+  | "createReviewDraft"
+  | "updateReviewDraft"
+  | "deleteReviewDraft"
+  | "submitReview"
 >;
 
 export function makePullRequestOperations(dependencies: {
   github: GitHubCliShape;
   pins: ProjectPullRequestPinsShape;
+  reviewDrafts?: PullRequestReviewDraftStoreShape;
   findProject: (
     projectId: Parameters<PullRequestServiceShape["detail"]>[0]["projectId"],
   ) => Effect.Effect<OrchestrationProject, unknown>;
@@ -61,7 +75,12 @@ export function makePullRequestOperations(dependencies: {
             .pipe(
               Effect.map((result) => ({ ...result, incomplete: false })),
               Effect.catch(() =>
-                Effect.succeed({ comments: [], truncated: false, incomplete: true }),
+                Effect.succeed({
+                  comments: [],
+                  threads: [],
+                  truncated: false,
+                  incomplete: true,
+                }),
               ),
             ),
         ],
@@ -97,6 +116,7 @@ export function makePullRequestOperations(dependencies: {
         comments,
         commentsTruncated: reviewCommentsResult.truncated,
         commentsIncomplete: reviewCommentsResult.incomplete,
+        reviewThreads: reviewCommentsResult.threads,
         mergeCapabilities,
       } satisfies PullRequestDetail;
     });
@@ -110,13 +130,30 @@ export function makePullRequestOperations(dependencies: {
     Effect.gen(function* () {
       const project = yield* dependencies.findProject(input.projectId);
       const repository = yield* dependencies.validateProjectRepository(project, input.repository);
-      return yield* dependencies.withGitHubRead(
-        dependencies.github.getPullRequestDiff({
-          cwd: project.workspaceRoot,
-          repository,
-          number: input.number,
-        }),
+      const [diffResult, headSha] = yield* Effect.all(
+        [
+          dependencies.withGitHubRead(
+            dependencies.github.getPullRequestDiff({
+              cwd: project.workspaceRoot,
+              repository,
+              number: input.number,
+            }),
+          ),
+          dependencies.withGitHubRead(
+            dependencies.github.getPullRequestHeadSha({
+              cwd: project.workspaceRoot,
+              repository,
+              number: input.number,
+            }),
+          ),
+        ],
+        { concurrency: 2 },
       );
+      return {
+        ...diffResult,
+        headSha,
+        patchSignature: createHash("sha256").update(diffResult.patch).digest("hex"),
+      };
     });
 
   const action: PullRequestServiceShape["action"] = (input) =>
@@ -205,5 +242,190 @@ export function makePullRequestOperations(dependencies: {
       };
     });
 
-  return { detail, diff, action, comment, setPinned };
+  const loadReviewContext = (input: {
+    readonly projectId: Parameters<PullRequestServiceShape["detail"]>[0]["projectId"];
+    readonly repository: string;
+    readonly number: number;
+  }) =>
+    Effect.gen(function* () {
+      const reviewDrafts = dependencies.reviewDrafts;
+      if (!reviewDrafts) {
+        return yield* Effect.fail(new Error("Pull request review drafts are unavailable."));
+      }
+      const project = yield* dependencies.findProject(input.projectId);
+      const repository = yield* dependencies.validateProjectRepository(project, input.repository);
+      return { project, repository, reviewDrafts };
+    });
+
+  const listReviewDrafts: PullRequestServiceShape["listReviewDrafts"] = (input) =>
+    Effect.gen(function* () {
+      const { repository, reviewDrafts } = yield* loadReviewContext(input);
+      const drafts = yield* reviewDrafts.list({ repository, number: input.number });
+      return { drafts };
+    });
+
+  const createReviewDraft: PullRequestServiceShape["createReviewDraft"] = (input) =>
+    Effect.gen(function* () {
+      const { repository, reviewDrafts } = yield* loadReviewContext(input);
+      const draft = yield* reviewDrafts.create({
+        repository,
+        number: input.number,
+        headSha: input.headSha,
+        patchSignature: input.patchSignature,
+        path: input.path,
+        line: input.line,
+        side: input.side,
+        body: input.body,
+      });
+      return { draft };
+    });
+
+  const updateReviewDraft: PullRequestServiceShape["updateReviewDraft"] = (input) =>
+    Effect.gen(function* () {
+      const { repository, reviewDrafts } = yield* loadReviewContext(input);
+      const updated = yield* reviewDrafts.update({
+        repository,
+        number: input.number,
+        id: input.id,
+        body: input.body,
+      });
+      if (Option.isNone(updated)) {
+        return yield* Effect.fail(new Error("Pull request review draft not found."));
+      }
+      return { draft: updated.value };
+    });
+
+  const deleteReviewDraft: PullRequestServiceShape["deleteReviewDraft"] = (input) =>
+    Effect.gen(function* () {
+      const { repository, reviewDrafts } = yield* loadReviewContext(input);
+      const deleted = yield* reviewDrafts.delete({
+        repository,
+        number: input.number,
+        id: input.id,
+      });
+      if (!deleted) {
+        return yield* Effect.fail(new Error("Pull request review draft not found."));
+      }
+      return { deletedId: input.id };
+    });
+
+  const submitReview: PullRequestServiceShape["submitReview"] = (input) =>
+    Effect.gen(function* () {
+      const { project, repository, reviewDrafts } = yield* loadReviewContext(input);
+      const body = input.body ?? "";
+      const requestedDraftIds = [...new Set(input.draftIds)];
+      const storedDrafts = yield* reviewDrafts.listByIds({
+        repository,
+        number: input.number,
+        ids: requestedDraftIds,
+      });
+      const draftsById = new Map(storedDrafts.map((draft) => [draft.id, draft]));
+      const missingDraftIds = requestedDraftIds.filter((id) => !draftsById.has(id));
+      const selectedDrafts = requestedDraftIds.flatMap((id) => {
+        const draft = draftsById.get(id);
+        return draft ? [draft] : [];
+      });
+
+      if (missingDraftIds.length > 0) {
+        return {
+          status: "blocked" as const,
+          submittedDraftIds: [],
+          staleDraftIds: [],
+          invalidDraftIds: missingDraftIds,
+        };
+      }
+      if (input.event === "COMMENT" && body.trim().length === 0 && selectedDrafts.length === 0) {
+        return yield* Effect.fail(
+          new Error("A comment review needs a body or at least one line comment."),
+        );
+      }
+
+      const diffResult =
+        selectedDrafts.length > 0
+          ? yield* dependencies.withGitHubRead(
+              dependencies.github.getPullRequestDiff({
+                cwd: project.workspaceRoot,
+                repository,
+                number: input.number,
+              }),
+            )
+          : null;
+      // Read the head after the patch. If a push happened while the patch loaded, the
+      // stored head and patch signature cannot both match and the whole batch blocks.
+      const headSha = yield* dependencies.withGitHubRead(
+        dependencies.github.getPullRequestHeadSha({
+          cwd: project.workspaceRoot,
+          repository,
+          number: input.number,
+        }),
+      );
+      const patchSignature =
+        diffResult === null ? null : createHash("sha256").update(diffResult.patch).digest("hex");
+      const staleDraftIds = selectedDrafts
+        .filter((draft) => draft.headSha !== headSha || draft.patchSignature !== patchSignature)
+        .map((draft) => draft.id);
+      const staleDraftIdSet = new Set(staleDraftIds);
+      let invalidDraftIds: ReadonlyArray<string>;
+      if (diffResult?.truncated === true) {
+        invalidDraftIds = selectedDrafts.map((draft) => draft.id);
+      } else if (diffResult === null) {
+        invalidDraftIds = [];
+      } else {
+        invalidDraftIds = validateInlineComments(
+          diffResult.patch,
+          selectedDrafts.filter((draft) => !staleDraftIdSet.has(draft.id)),
+        );
+      }
+      if (staleDraftIds.length > 0 || invalidDraftIds.length > 0) {
+        return {
+          status: "blocked" as const,
+          submittedDraftIds: [],
+          staleDraftIds,
+          invalidDraftIds,
+        };
+      }
+
+      yield* dependencies.github.submitPullRequestReview({
+        cwd: project.workspaceRoot,
+        repository,
+        number: input.number,
+        headSha,
+        event: input.event,
+        body,
+        comments: selectedDrafts.map((draft) => ({
+          path: draft.path,
+          line: draft.line,
+          side: draft.side,
+          body: draft.body,
+        })),
+      });
+      const submittedDraftIds = selectedDrafts.map((draft) => draft.id);
+      yield* reviewDrafts.deleteMany({
+        repository,
+        number: input.number,
+        ids: submittedDraftIds,
+      });
+      yield* dependencies.finalizeMutationCaches(repository, input.number, {
+        invalidateReviewMatches: false,
+      });
+      return {
+        status: "submitted" as const,
+        submittedDraftIds,
+        staleDraftIds: [],
+        invalidDraftIds: [],
+      };
+    });
+
+  return {
+    detail,
+    diff,
+    action,
+    comment,
+    setPinned,
+    listReviewDrafts,
+    createReviewDraft,
+    updateReviewDraft,
+    deleteReviewDraft,
+    submitReview,
+  };
 }

--- a/apps/server/src/pullRequests/validateInlineComments.test.ts
+++ b/apps/server/src/pullRequests/validateInlineComments.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { validateInlineComments } from "./validateInlineComments";
+
+const patch = [
+  "diff --git a/src/a.ts b/src/a.ts",
+  "--- a/src/a.ts",
+  "+++ b/src/a.ts",
+  "@@ -10,4 +10,4 @@",
+  " context",
+  "-old",
+  "+new",
+  " context",
+  "--- looks like a header",
+  "+++ also looks like a header",
+  "diff --git a/src/deleted.ts b/src/deleted.ts",
+  "--- a/src/deleted.ts",
+  "+++ /dev/null",
+  "@@ -1 +0,0 @@",
+  "-gone",
+].join("\n");
+
+describe("validateInlineComments", () => {
+  it("accepts changed lines on their GitHub diff side", () => {
+    expect(
+      validateInlineComments(patch, [
+        { id: "left", path: "src/a.ts", line: 11, side: "LEFT" },
+        { id: "right", path: "src/a.ts", line: 11, side: "RIGHT" },
+        { id: "deleted", path: "src/deleted.ts", line: 1, side: "LEFT" },
+        { id: "header-left", path: "src/a.ts", line: 13, side: "LEFT" },
+        { id: "header-right", path: "src/a.ts", line: 13, side: "RIGHT" },
+        { id: "context-left", path: "src/a.ts", line: 10, side: "LEFT" },
+        { id: "context-right", path: "src/a.ts", line: 10, side: "RIGHT" },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("returns every invalid draft id without dropping valid drafts", () => {
+    expect(
+      validateInlineComments(patch, [
+        { id: "valid", path: "src/a.ts", line: 11, side: "RIGHT" },
+        { id: "wrong-side", path: "src/deleted.ts", line: 1, side: "RIGHT" },
+        { id: "context", path: "src/a.ts", line: 10, side: "RIGHT" },
+        { id: "missing", path: "src/missing.ts", line: 1, side: "RIGHT" },
+      ]),
+    ).toEqual(["wrong-side", "missing"]);
+  });
+});

--- a/apps/server/src/pullRequests/validateInlineComments.ts
+++ b/apps/server/src/pullRequests/validateInlineComments.ts
@@ -1,0 +1,36 @@
+import { parsePatchFiles } from "@pierre/diffs";
+import type { PullRequestReviewDraft, PullRequestReviewSide } from "@synara/contracts";
+
+type InlineAnchor = Pick<PullRequestReviewDraft, "id" | "path" | "line" | "side">;
+
+function anchorKey(path: string, line: number, side: PullRequestReviewSide): string {
+  return `${path}\u0000${line}\u0000${side}`;
+}
+
+function collectInlineCommentAnchors(patch: string): ReadonlySet<string> {
+  const anchors = new Set<string>();
+  for (const parsedPatch of parsePatchFiles(patch)) {
+    for (const file of parsedPatch.files) {
+      for (const hunk of file.hunks) {
+        for (let offset = 0; offset < hunk.deletionCount; offset += 1) {
+          anchors.add(anchorKey(file.name, hunk.deletionStart + offset, "LEFT"));
+        }
+        for (let offset = 0; offset < hunk.additionCount; offset += 1) {
+          anchors.add(anchorKey(file.name, hunk.additionStart + offset, "RIGHT"));
+        }
+      }
+    }
+  }
+
+  return anchors;
+}
+
+export function validateInlineComments(
+  patch: string,
+  drafts: ReadonlyArray<InlineAnchor>,
+): ReadonlyArray<string> {
+  const anchors = collectInlineCommentAnchors(patch);
+  return drafts.flatMap((draft) =>
+    anchors.has(anchorKey(draft.path, draft.line, draft.side)) ? [] : [draft.id],
+  );
+}

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -43,6 +43,7 @@ import { ExternalMcpGatewayLive } from "./externalMcp/Layers/ExternalMcpGateway"
 import { ServerEnvironmentLive } from "./environment/Layers/ServerEnvironment";
 import { AutomationRepositoryLive } from "./persistence/Layers/AutomationRepository";
 import { ProjectPullRequestPinsLive } from "./persistence/Layers/ProjectPullRequestPins";
+import { PullRequestReviewDraftStoreLive } from "./persistence/Layers/PullRequestReviewDraftStore";
 import { ProjectionTurnRepositoryLive } from "./persistence/Layers/ProjectionTurns";
 import { OrchestrationEventDeliveryRepositoryLive } from "./persistence/Layers/OrchestrationEventDeliveries";
 import { ProviderRuntimeEventRepositoryLive } from "./persistence/Layers/ProviderRuntimeEvents";
@@ -178,6 +179,7 @@ export function makeServerRuntimeServicesLayer(
   const pullRequestServiceLayer = PullRequestServiceLive.pipe(
     Layer.provideMerge(GitLayerLive),
     Layer.provideMerge(ProjectPullRequestPinsLive),
+    Layer.provideMerge(PullRequestReviewDraftStoreLive),
     Layer.provideMerge(OrchestrationLayerLive),
   );
 
@@ -195,6 +197,7 @@ export function makeServerRuntimeServicesLayer(
     externalMcpGatewayLayer,
     providerHealthLayer,
     ProjectPullRequestPinsLive,
+    PullRequestReviewDraftStoreLive,
     pullRequestServiceLayer,
     orchestrationReactorLayer,
     providerCommandReactorLayer,

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -1147,6 +1147,31 @@ const makeWsRpcHandlersLayer = () =>
           pullRequestsEffect(pullRequests.comment(input), "Could not post the comment"),
         [WS_METHODS.pullRequestsSetPinned]: (input) =>
           rpcEffect(pullRequests.setPinned(input), "Failed to update pull request pin"),
+        [WS_METHODS.pullRequestsReviewDraftsList]: (input) =>
+          pullRequestsEffect(
+            pullRequests.listReviewDrafts(input),
+            "Failed to load pull request review drafts",
+          ),
+        [WS_METHODS.pullRequestsReviewDraftCreate]: (input) =>
+          pullRequestsEffect(
+            pullRequests.createReviewDraft(input),
+            "Failed to save pull request review draft",
+          ),
+        [WS_METHODS.pullRequestsReviewDraftUpdate]: (input) =>
+          pullRequestsEffect(
+            pullRequests.updateReviewDraft(input),
+            "Failed to update pull request review draft",
+          ),
+        [WS_METHODS.pullRequestsReviewDraftDelete]: (input) =>
+          pullRequestsEffect(
+            pullRequests.deleteReviewDraft(input),
+            "Failed to delete pull request review draft",
+          ),
+        [WS_METHODS.pullRequestsReviewSubmit]: (input) =>
+          pullRequestsEffect(
+            pullRequests.submitReview(input),
+            "Failed to submit pull request review",
+          ),
         [WS_METHODS.gitListBranches]: (input) =>
           rpcEffect(git.listBranches(input), "Failed to list branches"),
         [WS_METHODS.gitCreateWorktree]: (input) =>

--- a/apps/web/src/components/DiffPanelFileList.tsx
+++ b/apps/web/src/components/DiffPanelFileList.tsx
@@ -2,13 +2,14 @@
 // Purpose: Multi-file diff list for the review panel, including per-file actions and previews.
 // Layer: Diff panel UI
 
+import type { DiffLineAnnotation } from "@pierre/diffs";
 import type { FileDiffMetadata } from "@pierre/diffs/react";
 import { isSupportedLocalImagePath } from "@synara/shared/localPreviewFiles";
-import { type MouseEvent as ReactMouseEvent } from "react";
+import { type MouseEvent as ReactMouseEvent, type ReactNode } from "react";
 import { ChevronDownIcon, CopyIcon, EllipsisIcon, MessageCircleIcon } from "~/lib/icons";
 
 import { buildFileDiffRenderKey, resolveFileDiffPath } from "~/lib/diffRendering";
-import { FileDiffCard, FileDiffSurface } from "./chat/FileDiffView";
+import { FileDiffCard, FileDiffSurface, type DiffLineCommentAnchor } from "./chat/FileDiffView";
 import { LocalImagePreview } from "./LocalImagePreview";
 import { PanelStateMessage } from "./chat/PanelStateMessage";
 import { ComposerPickerMenuPopup } from "./chat/ComposerPickerMenuPopup";
@@ -96,7 +97,7 @@ function DiffFileCollapseChevron(props: { collapsed: boolean }) {
   );
 }
 
-const DiffPanelFileRow = function DiffPanelFileRow(props: {
+function DiffPanelFileRow<TAnnotation>(props: {
   fileDiff: FileDiffMetadata;
   resolvedTheme: "light" | "dark";
   diffRenderMode: DiffRenderMode;
@@ -105,6 +106,9 @@ const DiffPanelFileRow = function DiffPanelFileRow(props: {
   isCollapsed: boolean;
   onToggleFileCollapsed: (fileKey: string) => void;
   chatActions?: DiffFileChatActions | undefined;
+  lineAnnotations?: ReadonlyArray<DiffLineAnnotation<TAnnotation>>;
+  renderAnnotation?: (data: TAnnotation) => ReactNode;
+  onStartLineComment?: (anchor: DiffLineCommentAnchor) => void;
 }) {
   const filePath = resolveFileDiffPath(props.fileDiff);
   const fileKey = buildFileDiffRenderKey(props.fileDiff);
@@ -155,6 +159,9 @@ const DiffPanelFileRow = function DiffPanelFileRow(props: {
         overflow={props.diffWordWrap ? "wrap" : "scroll"}
         collapsed={props.isCollapsed}
         renderHeaderTrailing={renderHeaderTrailing}
+        {...(props.lineAnnotations ? { lineAnnotations: props.lineAnnotations } : {})}
+        {...(props.renderAnnotation ? { renderAnnotation: props.renderAnnotation } : {})}
+        {...(props.onStartLineComment ? { onStartLineComment: props.onStartLineComment } : {})}
       />
       {shouldPreviewImage ? (
         <LocalImagePreview
@@ -167,9 +174,9 @@ const DiffPanelFileRow = function DiffPanelFileRow(props: {
       ) : null}
     </div>
   );
-};
+}
 
-export const DiffPanelFileList = function DiffPanelFileList(props: {
+export const DiffPanelFileList = function DiffPanelFileList<TAnnotation = undefined>(props: {
   renderableFiles: ReadonlyArray<FileDiffMetadata>;
   resolvedTheme: "light" | "dark";
   diffRenderMode: DiffRenderMode;
@@ -178,6 +185,9 @@ export const DiffPanelFileList = function DiffPanelFileList(props: {
   collapsedFiles: ReadonlySet<string>;
   onToggleFileCollapsed: (fileKey: string) => void;
   chatActions?: DiffFileChatActions | undefined;
+  lineAnnotations?: ReadonlyMap<string, ReadonlyArray<DiffLineAnnotation<TAnnotation>>>;
+  renderAnnotation?: (data: TAnnotation) => ReactNode;
+  onStartLineComment?: (anchor: DiffLineCommentAnchor) => void;
 }) {
   if (props.renderableFiles.length === 0) {
     return (
@@ -193,6 +203,8 @@ export const DiffPanelFileList = function DiffPanelFileList(props: {
     <FileDiffSurface className="h-full min-h-0 overflow-auto px-2 pb-2">
       {props.renderableFiles.map((fileDiff) => {
         const fileKey = buildFileDiffRenderKey(fileDiff);
+        const filePath = resolveFileDiffPath(fileDiff);
+        const lineAnnotations = props.lineAnnotations?.get(filePath);
         // Include render mode so @pierre/diffs remounts when stacked ↔ split changes
         // (diffStyle is effectively mount-time config on FileDiff).
         const themedFileKey = `${fileKey}:${props.resolvedTheme}:${props.diffRenderMode}`;
@@ -206,7 +218,10 @@ export const DiffPanelFileList = function DiffPanelFileList(props: {
             workspaceRoot={props.workspaceRoot}
             isCollapsed={props.collapsedFiles.has(fileKey)}
             onToggleFileCollapsed={props.onToggleFileCollapsed}
-            chatActions={props.chatActions}
+            {...(props.chatActions ? { chatActions: props.chatActions } : {})}
+            {...(lineAnnotations ? { lineAnnotations } : {})}
+            {...(props.renderAnnotation ? { renderAnnotation: props.renderAnnotation } : {})}
+            {...(props.onStartLineComment ? { onStartLineComment: props.onStartLineComment } : {})}
           />
         );
       })}

--- a/apps/web/src/components/DiffPanelPatchViewport.tsx
+++ b/apps/web/src/components/DiffPanelPatchViewport.tsx
@@ -3,127 +3,149 @@
 //          patch or display settings change, not on unrelated chat activity.
 // Layer: Diff panel UI
 
+import type { DiffLineAnnotation } from "@pierre/diffs";
 import type { FileDiffMetadata } from "@pierre/diffs/react";
-import { memo } from "react";
+import { memo, type ReactNode } from "react";
 import { cn } from "~/lib/utils";
 import type { RenderablePatch } from "~/lib/diffRendering";
 import { DiffPanelFileList, type DiffFileChatActions } from "./DiffPanelFileList";
 import { DiffPanelLoadingState } from "./DiffPanelShell";
+import type { DiffLineCommentAnchor } from "./chat/FileDiffView";
 import { PanelStateMessage } from "./chat/PanelStateMessage";
 
 type DiffRenderMode = "stacked" | "split";
 
-export const DiffPanelPatchViewport = memo(
-  function DiffPanelPatchViewport(props: {
-    renderablePatch: RenderablePatch | null;
-    renderableFiles: ReadonlyArray<FileDiffMetadata>;
-    resolvedTheme: "light" | "dark";
-    diffRenderMode: DiffRenderMode;
-    diffWordWrap: boolean;
-    workspaceRoot: string | null;
-    collapsedFiles: ReadonlySet<string>;
-    onToggleFileCollapsed: (fileKey: string) => void;
-    chatActions?: DiffFileChatActions | undefined;
-    isLoading: boolean;
-    hasNoChanges: boolean;
-    error: string | null;
-    loadingLabel: string;
-    emptyLabel: string;
-    unavailableLabel: string;
-    viewKind: "repo" | "turn";
-  }) {
-    const viewportClassName = "flex h-full min-h-0 w-full flex-1 flex-col";
+interface DiffPanelPatchViewportProps<TAnnotation = undefined> {
+  renderablePatch: RenderablePatch | null;
+  renderableFiles: ReadonlyArray<FileDiffMetadata>;
+  resolvedTheme: "light" | "dark";
+  diffRenderMode: DiffRenderMode;
+  diffWordWrap: boolean;
+  workspaceRoot: string | null;
+  collapsedFiles: ReadonlySet<string>;
+  onToggleFileCollapsed: (fileKey: string) => void;
+  chatActions?: DiffFileChatActions | undefined;
+  lineAnnotations?: ReadonlyMap<string, ReadonlyArray<DiffLineAnnotation<TAnnotation>>>;
+  renderAnnotation?: (data: TAnnotation) => ReactNode;
+  onStartLineComment?: (anchor: DiffLineCommentAnchor) => void;
+  isLoading: boolean;
+  hasNoChanges: boolean;
+  error: string | null;
+  loadingLabel: string;
+  emptyLabel: string;
+  unavailableLabel: string;
+  viewKind: "repo" | "turn";
+}
 
-    if (props.error && !props.renderablePatch) {
-      return (
-        <div className={viewportClassName}>
-          <PanelStateMessage
-            density="compact"
-            fill="flex"
-            className="items-start justify-start px-3 pt-3"
-          >
-            <p className="text-left text-[11px] text-red-500/80">{props.error}</p>
-          </PanelStateMessage>
-        </div>
-      );
-    }
+function DiffPanelPatchViewportView<TAnnotation = undefined>(
+  props: DiffPanelPatchViewportProps<TAnnotation>,
+) {
+  const viewportClassName = "flex h-full min-h-0 w-full flex-1 flex-col";
 
-    if (!props.renderablePatch) {
-      if (props.isLoading) {
-        return (
-          <div className={viewportClassName}>
-            <DiffPanelLoadingState label={props.loadingLabel} />
-          </div>
-        );
-      }
-      return (
-        <div className={viewportClassName}>
-          <PanelStateMessage density="compact" fill="flex">
-            <p>
-              {props.hasNoChanges
-                ? props.emptyLabel
-                : props.viewKind === "repo"
-                  ? props.unavailableLabel
-                  : "No patch available for this selection."}
-            </p>
-          </PanelStateMessage>
-        </div>
-      );
-    }
-
-    if (props.renderablePatch.kind === "files") {
-      return (
-        <div className={viewportClassName}>
-          <DiffPanelFileList
-            renderableFiles={props.renderableFiles}
-            resolvedTheme={props.resolvedTheme}
-            diffRenderMode={props.diffRenderMode}
-            diffWordWrap={props.diffWordWrap}
-            workspaceRoot={props.workspaceRoot}
-            collapsedFiles={props.collapsedFiles}
-            onToggleFileCollapsed={props.onToggleFileCollapsed}
-            chatActions={props.chatActions}
-          />
-        </div>
-      );
-    }
-
+  if (props.error && !props.renderablePatch) {
     return (
-      <div className={cn(viewportClassName, "overflow-auto p-2")}>
-        <div className="space-y-2">
-          <p className="text-[11px] text-muted-foreground/75">{props.renderablePatch.reason}</p>
-          <pre
-            className={cn(
-              "max-h-[72vh] rounded-md border border-border/70 bg-background/70 p-3 font-mono text-[11px] leading-relaxed text-muted-foreground/90",
-              props.diffWordWrap
-                ? "overflow-auto whitespace-pre-wrap wrap-break-word"
-                : "overflow-auto",
-            )}
-          >
-            {props.renderablePatch.text}
-          </pre>
-        </div>
+      <div className={viewportClassName}>
+        <PanelStateMessage
+          density="compact"
+          fill="flex"
+          className="items-start justify-start px-3 pt-3"
+        >
+          <p className="text-left text-[11px] text-red-500/80">{props.error}</p>
+        </PanelStateMessage>
       </div>
     );
-  },
-  (previous, next) => {
+  }
+
+  if (!props.renderablePatch) {
+    if (props.isLoading) {
+      return (
+        <div className={viewportClassName}>
+          <DiffPanelLoadingState label={props.loadingLabel} />
+        </div>
+      );
+    }
     return (
-      previous.renderablePatch === next.renderablePatch &&
-      previous.renderableFiles === next.renderableFiles &&
-      previous.resolvedTheme === next.resolvedTheme &&
-      previous.diffRenderMode === next.diffRenderMode &&
-      previous.diffWordWrap === next.diffWordWrap &&
-      previous.workspaceRoot === next.workspaceRoot &&
-      previous.collapsedFiles === next.collapsedFiles &&
-      previous.onToggleFileCollapsed === next.onToggleFileCollapsed &&
-      previous.chatActions === next.chatActions &&
-      previous.isLoading === next.isLoading &&
-      previous.hasNoChanges === next.hasNoChanges &&
-      previous.error === next.error &&
-      previous.loadingLabel === next.loadingLabel &&
-      previous.emptyLabel === next.emptyLabel &&
-      previous.unavailableLabel === next.unavailableLabel &&
-      previous.viewKind === next.viewKind
+      <div className={viewportClassName}>
+        <PanelStateMessage density="compact" fill="flex">
+          <p>
+            {props.hasNoChanges
+              ? props.emptyLabel
+              : props.viewKind === "repo"
+                ? props.unavailableLabel
+                : "No patch available for this selection."}
+          </p>
+        </PanelStateMessage>
+      </div>
     );
-  },
-);
+  }
+
+  if (props.renderablePatch.kind === "files") {
+    return (
+      <div className={viewportClassName}>
+        <DiffPanelFileList
+          renderableFiles={props.renderableFiles}
+          resolvedTheme={props.resolvedTheme}
+          diffRenderMode={props.diffRenderMode}
+          diffWordWrap={props.diffWordWrap}
+          workspaceRoot={props.workspaceRoot}
+          collapsedFiles={props.collapsedFiles}
+          onToggleFileCollapsed={props.onToggleFileCollapsed}
+          {...(props.chatActions ? { chatActions: props.chatActions } : {})}
+          {...(props.lineAnnotations ? { lineAnnotations: props.lineAnnotations } : {})}
+          {...(props.renderAnnotation ? { renderAnnotation: props.renderAnnotation } : {})}
+          {...(props.onStartLineComment ? { onStartLineComment: props.onStartLineComment } : {})}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn(viewportClassName, "overflow-auto p-2")}>
+      <div className="space-y-2">
+        <p className="text-[11px] text-muted-foreground/75">{props.renderablePatch.reason}</p>
+        <pre
+          className={cn(
+            "max-h-[72vh] rounded-md border border-border/70 bg-background/70 p-3 font-mono text-[11px] leading-relaxed text-muted-foreground/90",
+            props.diffWordWrap
+              ? "overflow-auto whitespace-pre-wrap wrap-break-word"
+              : "overflow-auto",
+          )}
+        >
+          {props.renderablePatch.text}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+function areDiffPanelPatchViewportPropsEqual<TAnnotation>(
+  previous: DiffPanelPatchViewportProps<TAnnotation>,
+  next: DiffPanelPatchViewportProps<TAnnotation>,
+): boolean {
+  return (
+    previous.renderablePatch === next.renderablePatch &&
+    previous.renderableFiles === next.renderableFiles &&
+    previous.resolvedTheme === next.resolvedTheme &&
+    previous.diffRenderMode === next.diffRenderMode &&
+    previous.diffWordWrap === next.diffWordWrap &&
+    previous.workspaceRoot === next.workspaceRoot &&
+    previous.collapsedFiles === next.collapsedFiles &&
+    previous.onToggleFileCollapsed === next.onToggleFileCollapsed &&
+    previous.chatActions === next.chatActions &&
+    previous.lineAnnotations === next.lineAnnotations &&
+    previous.renderAnnotation === next.renderAnnotation &&
+    previous.onStartLineComment === next.onStartLineComment &&
+    previous.isLoading === next.isLoading &&
+    previous.hasNoChanges === next.hasNoChanges &&
+    previous.error === next.error &&
+    previous.loadingLabel === next.loadingLabel &&
+    previous.emptyLabel === next.emptyLabel &&
+    previous.unavailableLabel === next.unavailableLabel &&
+    previous.viewKind === next.viewKind
+  );
+}
+
+export const DiffPanelPatchViewport = memo(
+  DiffPanelPatchViewportView,
+  areDiffPanelPatchViewportPropsEqual,
+) as typeof DiffPanelPatchViewportView;

--- a/apps/web/src/components/chat/FileDiffView.test.tsx
+++ b/apps/web/src/components/chat/FileDiffView.test.tsx
@@ -1,0 +1,91 @@
+import type { DiffLineAnnotation, SelectedLineRange } from "@pierre/diffs";
+import type { FileDiffMetadata } from "@pierre/diffs/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fileDiffCalls = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+
+vi.mock("@pierre/diffs/react", () => ({
+  FileDiff: (props: Record<string, unknown>) => {
+    fileDiffCalls.push(props);
+    return <div data-testid="file-diff" />;
+  },
+  Virtualizer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import { FileDiffCard } from "./FileDiffView";
+
+const fileDiff = {
+  name: "b/src/example.ts",
+  type: "change",
+  hunks: [],
+  splitLineCount: 0,
+  unifiedLineCount: 0,
+  isPartial: true,
+  deletionLines: [],
+  additionLines: [],
+} as unknown as FileDiffMetadata;
+
+describe("FileDiffCard line comments", () => {
+  beforeEach(() => {
+    fileDiffCalls.length = 0;
+  });
+
+  it("keeps line comment features disabled when their props are omitted", () => {
+    renderToStaticMarkup(<FileDiffCard fileDiff={fileDiff} theme="dark" />);
+
+    const call = fileDiffCalls[0];
+    expect(call?.lineAnnotations).toBeUndefined();
+    expect(call?.renderAnnotation).toBeUndefined();
+    expect(call?.options).not.toHaveProperty("enableGutterUtility");
+    expect(call?.options).not.toHaveProperty("onGutterUtilityClick");
+  });
+
+  it.each([
+    ["deletions", "LEFT"],
+    ["additions", "RIGHT"],
+    [undefined, "RIGHT"],
+  ] as const)("maps a %s gutter line to the %s review side", (side, expectedSide) => {
+    const onStartLineComment = vi.fn();
+    const annotations: ReadonlyArray<DiffLineAnnotation<{ id: string }>> = [
+      { lineNumber: 12, side: "additions", metadata: { id: "note-1" } },
+    ];
+    const renderAnnotation = vi.fn(() => null);
+
+    renderToStaticMarkup(
+      <FileDiffCard
+        fileDiff={fileDiff}
+        theme="light"
+        lineAnnotations={annotations}
+        renderAnnotation={renderAnnotation}
+        onStartLineComment={onStartLineComment}
+      />,
+    );
+
+    const call = fileDiffCalls[0];
+    if (!call) {
+      throw new Error("Expected FileDiff to render");
+    }
+    expect(call?.lineAnnotations).toEqual(annotations);
+    expect(call?.lineAnnotations).not.toBe(annotations);
+    expect(call?.renderAnnotation).not.toBe(renderAnnotation);
+    expect(call?.options).toHaveProperty("enableGutterUtility", true);
+
+    const pierreRenderAnnotation = call.renderAnnotation as (
+      annotation: DiffLineAnnotation<{ id: string }>,
+    ) => React.ReactNode;
+    pierreRenderAnnotation(annotations[0]!);
+    expect(renderAnnotation).toHaveBeenCalledWith({ id: "note-1" });
+
+    const onGutterUtilityClick = (
+      call.options as { onGutterUtilityClick: (range: SelectedLineRange) => void }
+    ).onGutterUtilityClick;
+    onGutterUtilityClick({ start: 12, end: 12, ...(side ? { side } : {}) });
+
+    expect(onStartLineComment).toHaveBeenCalledWith({
+      path: "src/example.ts",
+      line: 12,
+      side: expectedSide,
+    });
+  });
+});

--- a/apps/web/src/components/chat/FileDiffView.tsx
+++ b/apps/web/src/components/chat/FileDiffView.tsx
@@ -6,10 +6,15 @@
 // Layer: Chat/diff UI primitives
 // Depends on: @pierre/diffs FileDiff/Virtualizer, diffRendering (theme + unsafeCSS), FileDiffHeader
 
+import type { DiffLineAnnotation, SelectedLineRange } from "@pierre/diffs";
 import { FileDiff, type FileDiffMetadata, Virtualizer } from "@pierre/diffs/react";
-import { type ReactNode } from "react";
+import { type ReactNode, useCallback, useMemo } from "react";
 
-import { buildDiffPanelUnsafeCSS, resolveDiffThemeName } from "~/lib/diffRendering";
+import {
+  buildDiffPanelUnsafeCSS,
+  resolveDiffThemeName,
+  resolveFileDiffPath,
+} from "~/lib/diffRendering";
 import { cn } from "~/lib/utils";
 import { FileDiffHeader } from "./FileDiffHeader";
 
@@ -36,18 +41,56 @@ export function FileDiffSurface(props: { className?: string; children: ReactNode
 // A single themed file diff with Synara's custom file header. Bakes in the shared
 // `unsafeCSS` theming so every surface renders with the chat code font and
 // themed addition/deletion backgrounds.
-export function FileDiffCard(props: {
+export interface DiffLineCommentAnchor {
+  path: string;
+  line: number;
+  side: "LEFT" | "RIGHT";
+}
+
+export interface FileDiffCardProps<TAnnotation = undefined> {
   fileDiff: FileDiffMetadata;
   theme: "light" | "dark";
   diffStyle?: "unified" | "split";
   overflow?: "scroll" | "wrap";
   collapsed?: boolean;
+  lineAnnotations?: ReadonlyArray<DiffLineAnnotation<TAnnotation>>;
+  renderAnnotation?: (data: TAnnotation) => ReactNode;
+  onStartLineComment?: (anchor: DiffLineCommentAnchor) => void;
   /** Trailing header chrome (actions menu, collapse chevron). */
   renderHeaderTrailing?: () => ReactNode;
-}) {
+}
+
+export function FileDiffCard<TAnnotation = undefined>(props: FileDiffCardProps<TAnnotation>) {
+  const filePath = resolveFileDiffPath(props.fileDiff);
+  const lineAnnotations = useMemo(
+    () => (props.lineAnnotations ? [...props.lineAnnotations] : undefined),
+    [props.lineAnnotations],
+  );
+  const { renderAnnotation } = props;
+  const handleRenderAnnotation = useCallback(
+    (annotation: DiffLineAnnotation<TAnnotation>) =>
+      annotation.metadata !== undefined && renderAnnotation
+        ? renderAnnotation(annotation.metadata)
+        : null,
+    [renderAnnotation],
+  );
+  const { onStartLineComment } = props;
+  const handleGutterUtilityClick = useCallback(
+    (range: SelectedLineRange) => {
+      onStartLineComment?.({
+        path: filePath,
+        line: range.start,
+        side: range.side === "deletions" ? "LEFT" : "RIGHT",
+      });
+    },
+    [filePath, onStartLineComment],
+  );
+
   return (
-    <FileDiff
+    <FileDiff<TAnnotation>
       fileDiff={props.fileDiff}
+      {...(lineAnnotations ? { lineAnnotations } : {})}
+      {...(renderAnnotation ? { renderAnnotation: handleRenderAnnotation } : {})}
       options={{
         diffStyle: props.diffStyle ?? "unified",
         lineDiffType: "none",
@@ -55,6 +98,12 @@ export function FileDiffCard(props: {
         theme: resolveDiffThemeName(props.theme),
         themeType: props.theme,
         unsafeCSS: buildDiffPanelUnsafeCSS(props.theme),
+        ...(onStartLineComment
+          ? {
+              enableGutterUtility: true,
+              onGutterUtilityClick: handleGutterUtilityClick,
+            }
+          : {}),
         ...(props.collapsed !== undefined ? { collapsed: props.collapsed } : {}),
       }}
       renderCustomHeader={(fileDiff) => (

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
@@ -20,6 +20,8 @@ import { PullRequestDiffStat } from "./PullRequestDiffStat";
 import { PullRequestMetaLine } from "./PullRequestMetaLine";
 import { PR_META_TEXT_CLASS_NAME } from "./pullRequestText";
 import { PullRequestWarningNote } from "./PullRequestWarningNote";
+import { PullRequestReviewSubmitBar } from "./review/PullRequestReviewSubmitBar";
+import { usePullRequestReview } from "./review/usePullRequestReview";
 
 export function PullRequestCodeTab({
   input,
@@ -31,6 +33,7 @@ export function PullRequestCodeTab({
   const { resolvedTheme } = useTheme();
   const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(() => new Set());
   const diffQuery = useQuery(pullRequestDiffQueryOptions(input));
+  const review = usePullRequestReview({ target: input, detail, diff: diffQuery.data });
 
   const renderablePatch = getRenderablePatch(
     diffQuery.data?.patch,
@@ -82,6 +85,9 @@ export function PullRequestCodeTab({
                 return next;
               })
             }
+            lineAnnotations={review.annotationsByFile}
+            renderAnnotation={review.renderAnnotation}
+            onStartLineComment={review.startDraft}
             isLoading={diffQuery.isFetching}
             hasNoChanges={diffQuery.isSuccess && !renderablePatch}
             error={
@@ -97,6 +103,14 @@ export function PullRequestCodeTab({
             viewKind="repo"
           />
         )}
+        <PullRequestReviewSubmitBar
+          target={input}
+          drafts={review.currentDrafts}
+          staleDrafts={review.staleDrafts}
+          loading={review.isLoading}
+          busy={review.busy}
+          onDeleteDraft={review.deleteDraft}
+        />
       </div>
     </DiffWorkerPoolProvider>
   );

--- a/apps/web/src/components/pullRequest/review/PullRequestReviewAnnotation.tsx
+++ b/apps/web/src/components/pullRequest/review/PullRequestReviewAnnotation.tsx
@@ -1,0 +1,159 @@
+import type { PullRequestReviewDraft } from "@synara/contracts";
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "~/components/ui/button";
+import { CheckIcon, MessageCircleIcon, Trash2 } from "~/lib/icons";
+import { cn } from "~/lib/utils";
+import type { PullRequestReviewAnchor, PullRequestReviewAnnotationData } from "./reviewAnnotations";
+
+const ANNOTATION_SHELL =
+  "mx-2 my-1 overflow-hidden rounded-lg border border-border/60 bg-card text-foreground shadow-xs";
+
+function CommentEditor(props: {
+  initialBody?: string;
+  busy: boolean;
+  saveLabel: string;
+  onSave: (body: string) => void;
+  onCancel: () => void;
+}) {
+  const [body, setBody] = useState(props.initialBody ?? "");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const trimmed = body.trim();
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  return (
+    <div className={cn(ANNOTATION_SHELL, "p-2.5")}>
+      <textarea
+        ref={textareaRef}
+        aria-label="Inline review comment"
+        value={body}
+        disabled={props.busy}
+        placeholder="Leave a review comment…"
+        onChange={(event) => setBody(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") props.onCancel();
+          if ((event.metaKey || event.ctrlKey) && event.key === "Enter" && trimmed) {
+            event.preventDefault();
+            props.onSave(trimmed);
+          }
+        }}
+        className="min-h-24 w-full resize-y rounded-md border border-border/60 bg-background px-3 py-2 text-[13px] leading-5 outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+      />
+      <div className="mt-2 flex justify-end gap-1.5">
+        <Button size="xs" variant="ghost" disabled={props.busy} onClick={props.onCancel}>
+          Cancel
+        </Button>
+        <Button size="xs" disabled={props.busy || !trimmed} onClick={() => props.onSave(trimmed)}>
+          {props.saveLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function SavedDraft(props: {
+  draft: PullRequestReviewDraft;
+  busy: boolean;
+  onUpdate: (draft: PullRequestReviewDraft, body: string) => void;
+  onDelete: (draft: PullRequestReviewDraft) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  if (editing) {
+    return (
+      <CommentEditor
+        initialBody={props.draft.body}
+        busy={props.busy}
+        saveLabel="Update"
+        onCancel={() => setEditing(false)}
+        onSave={(body) => {
+          props.onUpdate(props.draft, body);
+          setEditing(false);
+        }}
+      />
+    );
+  }
+  return (
+    <div className={ANNOTATION_SHELL}>
+      <div className="flex items-center gap-1.5 border-b border-border/40 px-3 py-1.5 text-[11px] text-muted-foreground">
+        <MessageCircleIcon className="size-3.5" />
+        <span className="font-medium uppercase tracking-wide">Pending review</span>
+        <div className="ms-auto flex gap-1">
+          <Button size="xs" variant="ghost" disabled={props.busy} onClick={() => setEditing(true)}>
+            Edit
+          </Button>
+          <Button
+            size="icon-xs"
+            variant="ghost"
+            aria-label="Delete review comment"
+            disabled={props.busy}
+            className="hover:text-destructive"
+            onClick={() => props.onDelete(props.draft)}
+          >
+            <Trash2 className="size-3" />
+          </Button>
+        </div>
+      </div>
+      <p className="whitespace-pre-wrap break-words px-3 py-2.5 text-[13px] leading-5">
+        {props.draft.body}
+      </p>
+    </div>
+  );
+}
+
+export function PullRequestReviewAnnotation(props: {
+  data: PullRequestReviewAnnotationData;
+  busy: boolean;
+  onCreate: (anchor: PullRequestReviewAnchor, body: string) => void;
+  onCancelCreate: () => void;
+  onUpdate: (draft: PullRequestReviewDraft, body: string) => void;
+  onDelete: (draft: PullRequestReviewDraft) => void;
+}) {
+  if (props.data.kind === "new-draft") {
+    const anchor = props.data.anchor;
+    return (
+      <CommentEditor
+        busy={props.busy}
+        saveLabel="Add comment"
+        onCancel={props.onCancelCreate}
+        onSave={(body) => props.onCreate(anchor, body)}
+      />
+    );
+  }
+
+  if (props.data.kind === "draft") {
+    return (
+      <SavedDraft
+        draft={props.data.draft}
+        busy={props.busy}
+        onUpdate={props.onUpdate}
+        onDelete={props.onDelete}
+      />
+    );
+  }
+
+  const thread = props.data.thread;
+  return (
+    <div className={cn(ANNOTATION_SHELL, thread.isResolved && "opacity-70")}>
+      <div className="flex items-center gap-1.5 border-b border-border/40 px-3 py-1.5 text-[11px] text-muted-foreground">
+        <CheckIcon className="size-3" />
+        <span className="font-medium uppercase tracking-wide">GitHub review</span>
+        {thread.isResolved ? <span className="ms-auto text-success">Resolved</span> : null}
+      </div>
+      <div className="divide-y divide-border/40">
+        {thread.comments.map((comment) => (
+          <div key={comment.id} className="px-3 py-2.5">
+            <div className="text-[11px] font-medium text-muted-foreground">
+              {comment.author?.login ?? "Unknown reviewer"}
+            </div>
+            <p className="mt-1 whitespace-pre-wrap break-words text-[13px] leading-5">
+              {comment.body}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/pullRequest/review/PullRequestReviewSubmitBar.tsx
+++ b/apps/web/src/components/pullRequest/review/PullRequestReviewSubmitBar.tsx
@@ -1,0 +1,188 @@
+import type {
+  PullRequestDetailInput,
+  PullRequestReviewDraft,
+  PullRequestReviewEvent,
+} from "@synara/contracts";
+import { pluralize } from "@synara/shared/text";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+
+import { Button } from "~/components/ui/button";
+import { Popover, PopoverClose, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
+import { GitPullRequestIcon, TriangleAlertIcon } from "~/lib/icons";
+import { pullRequestReviewSubmitMutationOptions } from "~/lib/pullRequestReactQuery";
+
+const REVIEW_EVENTS: ReadonlyArray<{
+  value: PullRequestReviewEvent;
+  label: string;
+}> = [
+  { value: "COMMENT", label: "Comment" },
+  { value: "APPROVE", label: "Approve" },
+  { value: "REQUEST_CHANGES", label: "Request changes" },
+];
+
+export function PullRequestReviewSubmitBar(props: {
+  target: PullRequestDetailInput;
+  drafts: ReadonlyArray<PullRequestReviewDraft>;
+  staleDrafts: ReadonlyArray<PullRequestReviewDraft>;
+  loading: boolean;
+  busy: boolean;
+  onDeleteDraft: (draft: PullRequestReviewDraft) => void;
+}) {
+  const queryClient = useQueryClient();
+  const mutation = useMutation(pullRequestReviewSubmitMutationOptions(queryClient));
+  const [open, setOpen] = useState(false);
+  const [event, setEvent] = useState<PullRequestReviewEvent>("COMMENT");
+  const [body, setBody] = useState("");
+  const result = mutation.data;
+  const blockedIds = useMemo(
+    () => new Set([...(result?.staleDraftIds ?? []), ...(result?.invalidDraftIds ?? [])]),
+    [result],
+  );
+  const canSubmit =
+    !props.loading &&
+    props.staleDrafts.length === 0 &&
+    (event !== "COMMENT" || body.trim().length > 0 || props.drafts.length > 0);
+
+  const submit = () => {
+    if (!canSubmit) return;
+    mutation.mutate(
+      {
+        ...props.target,
+        event,
+        body: body.trim(),
+        draftIds: props.drafts.map((draft) => draft.id),
+      },
+      {
+        onSuccess: (next) => {
+          if (next.status === "submitted") {
+            setBody("");
+            setOpen(false);
+          }
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="flex shrink-0 items-center gap-2 border-t border-border/60 bg-background px-3 py-2">
+      <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+        {props.staleDrafts.length > 0
+          ? `${props.staleDrafts.length} stale review ${pluralize(props.staleDrafts.length, "comment")} must be removed or recreated.`
+          : `${props.drafts.length} pending review ${pluralize(props.drafts.length, "comment")}`}
+      </span>
+      {props.staleDrafts.length > 0 ? (
+        <TriangleAlertIcon className="size-4 shrink-0 text-warning" />
+      ) : null}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger
+          render={
+            <Button size="sm" disabled={props.loading}>
+              <GitPullRequestIcon className="size-3.5" />
+              Review changes
+            </Button>
+          }
+        />
+        <PopoverPopup
+          align="end"
+          side="top"
+          sideOffset={8}
+          className="w-80 max-w-[calc(100vw-1rem)]"
+        >
+          <div className="space-y-3">
+            <label className="block text-xs font-medium text-foreground">
+              Decision
+              <select
+                value={event}
+                disabled={mutation.isPending}
+                onChange={(changeEvent) =>
+                  setEvent(changeEvent.target.value as PullRequestReviewEvent)
+                }
+                className="mt-1.5 h-8 w-full rounded-md border border-border bg-background px-2 text-xs outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                {REVIEW_EVENTS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <textarea
+              aria-label="Review summary"
+              value={body}
+              disabled={mutation.isPending}
+              placeholder="Optional review summary"
+              onChange={(changeEvent) => setBody(changeEvent.target.value)}
+              className="min-h-24 w-full resize-y rounded-md border border-border bg-background px-3 py-2 text-[13px] outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            <p className="text-[11px] text-muted-foreground">
+              {props.drafts.length} inline {pluralize(props.drafts.length, "comment")} will be
+              included.
+            </p>
+            {props.staleDrafts.length > 0 ? (
+              <div className="space-y-2">
+                <p className="text-[11px] text-warning">
+                  Submission is blocked because the loaded patch no longer matches saved comments.
+                </p>
+                <ul className="max-h-40 space-y-1.5 overflow-y-auto">
+                  {props.staleDrafts.map((draft) => (
+                    <li
+                      key={draft.id}
+                      className="flex items-start gap-2 rounded-md border border-border/70 bg-muted/35 px-2 py-1.5"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-[11px] font-medium text-foreground">
+                          {draft.path}:{draft.line}
+                        </p>
+                        <p className="line-clamp-2 text-[11px] text-muted-foreground">
+                          {draft.body}
+                        </p>
+                      </div>
+                      <Button
+                        size="xs"
+                        variant="ghost"
+                        disabled={props.busy}
+                        onClick={() => props.onDeleteDraft(draft)}
+                      >
+                        Remove
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+            {result?.status === "blocked" ? (
+              <p className="text-[11px] text-destructive">
+                GitHub received nothing. {blockedIds.size} {pluralize(blockedIds.size, "comment")}{" "}
+                need action.
+              </p>
+            ) : null}
+            {mutation.isError ? (
+              <p className="text-[11px] text-destructive">
+                {mutation.error instanceof Error
+                  ? mutation.error.message
+                  : "Could not submit the review."}
+              </p>
+            ) : null}
+            <div className="flex justify-end gap-1.5">
+              <PopoverClose
+                render={
+                  <Button size="xs" variant="ghost" disabled={mutation.isPending}>
+                    Cancel
+                  </Button>
+                }
+              />
+              <Button
+                size="xs"
+                disabled={!canSubmit || mutation.isPending || props.busy}
+                onClick={submit}
+              >
+                Submit review
+              </Button>
+            </div>
+          </div>
+        </PopoverPopup>
+      </Popover>
+    </div>
+  );
+}

--- a/apps/web/src/components/pullRequest/review/reviewAnnotations.ts
+++ b/apps/web/src/components/pullRequest/review/reviewAnnotations.ts
@@ -1,0 +1,39 @@
+import type { AnnotationSide, DiffLineAnnotation } from "@pierre/diffs";
+import type {
+  PullRequestReviewDraft,
+  PullRequestReviewSide,
+  PullRequestReviewThread,
+} from "@synara/contracts";
+
+export interface PullRequestReviewAnchor {
+  path: string;
+  line: number;
+  side: PullRequestReviewSide;
+}
+
+export type PullRequestReviewAnnotationData =
+  | {
+      kind: "new-draft";
+      anchor: PullRequestReviewAnchor;
+    }
+  | {
+      kind: "draft";
+      draft: PullRequestReviewDraft;
+    }
+  | {
+      kind: "remote-thread";
+      thread: PullRequestReviewThread;
+    };
+
+export type PullRequestReviewAnnotationsByFile = ReadonlyMap<
+  string,
+  ReadonlyArray<DiffLineAnnotation<PullRequestReviewAnnotationData>>
+>;
+
+export function toDiffAnnotationSide(side: PullRequestReviewSide): AnnotationSide {
+  return side === "LEFT" ? "deletions" : "additions";
+}
+
+export function reviewAnchorKey(anchor: PullRequestReviewAnchor): string {
+  return `${anchor.path}\u0000${String(anchor.line)}\u0000${anchor.side}`;
+}

--- a/apps/web/src/components/pullRequest/review/usePullRequestReview.tsx
+++ b/apps/web/src/components/pullRequest/review/usePullRequestReview.tsx
@@ -1,0 +1,150 @@
+import type { DiffLineAnnotation } from "@pierre/diffs";
+import type {
+  PullRequestDetail,
+  PullRequestDetailInput,
+  PullRequestDiffResult,
+  PullRequestReviewDraft,
+} from "@synara/contracts";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
+
+import {
+  pullRequestReviewDraftCreateMutationOptions,
+  pullRequestReviewDraftDeleteMutationOptions,
+  pullRequestReviewDraftsQueryOptions,
+  pullRequestReviewDraftUpdateMutationOptions,
+} from "~/lib/pullRequestReactQuery";
+import { PullRequestReviewAnnotation } from "./PullRequestReviewAnnotation";
+import {
+  type PullRequestReviewAnchor,
+  type PullRequestReviewAnnotationData,
+  type PullRequestReviewAnnotationsByFile,
+  toDiffAnnotationSide,
+} from "./reviewAnnotations";
+
+const EMPTY_REVIEW_DRAFTS: ReadonlyArray<PullRequestReviewDraft> = Object.freeze([]);
+
+function pushAnnotation(
+  map: Map<string, DiffLineAnnotation<PullRequestReviewAnnotationData>[]>,
+  path: string,
+  annotation: DiffLineAnnotation<PullRequestReviewAnnotationData>,
+): void {
+  const current = map.get(path);
+  if (current) current.push(annotation);
+  else map.set(path, [annotation]);
+}
+
+export function usePullRequestReview(input: {
+  target: PullRequestDetailInput;
+  detail: PullRequestDetail;
+  diff: PullRequestDiffResult | undefined;
+}) {
+  const queryClient = useQueryClient();
+  const [pendingAnchor, setPendingAnchor] = useState<PullRequestReviewAnchor | null>(null);
+  const headSha = input.diff?.headSha ?? "";
+  const patchSignature = input.diff?.patchSignature ?? "";
+  const draftsQuery = useQuery(
+    pullRequestReviewDraftsQueryOptions(input.target, Boolean(headSha && patchSignature)),
+  );
+  const createMutation = useMutation(pullRequestReviewDraftCreateMutationOptions(queryClient));
+  const updateMutation = useMutation(pullRequestReviewDraftUpdateMutationOptions(queryClient));
+  const deleteMutation = useMutation(pullRequestReviewDraftDeleteMutationOptions(queryClient));
+  const drafts = draftsQuery.data?.drafts ?? EMPTY_REVIEW_DRAFTS;
+  const { currentDrafts, staleDrafts } = useMemo(() => {
+    const current: PullRequestReviewDraft[] = [];
+    const stale: PullRequestReviewDraft[] = [];
+    for (const draft of drafts) {
+      if (draft.headSha === headSha && draft.patchSignature === patchSignature) {
+        current.push(draft);
+      } else {
+        stale.push(draft);
+      }
+    }
+    return { currentDrafts: current, staleDrafts: stale };
+  }, [drafts, headSha, patchSignature]);
+
+  const annotationsByFile = useMemo<PullRequestReviewAnnotationsByFile>(() => {
+    const map = new Map<string, DiffLineAnnotation<PullRequestReviewAnnotationData>[]>();
+    for (const draft of currentDrafts) {
+      pushAnnotation(map, draft.path, {
+        side: toDiffAnnotationSide(draft.side),
+        lineNumber: draft.line,
+        metadata: { kind: "draft", draft },
+      });
+    }
+    for (const thread of input.detail.reviewThreads ?? []) {
+      if (!thread.path || thread.line === null || !thread.side) continue;
+      pushAnnotation(map, thread.path, {
+        side: toDiffAnnotationSide(thread.side),
+        lineNumber: thread.line,
+        metadata: { kind: "remote-thread", thread },
+      });
+    }
+    if (pendingAnchor) {
+      pushAnnotation(map, pendingAnchor.path, {
+        side: toDiffAnnotationSide(pendingAnchor.side),
+        lineNumber: pendingAnchor.line,
+        metadata: { kind: "new-draft", anchor: pendingAnchor },
+      });
+    }
+    return map;
+  }, [currentDrafts, input.detail.reviewThreads, pendingAnchor]);
+
+  const createDraft = useCallback(
+    (anchor: PullRequestReviewAnchor, body: string) => {
+      if (!headSha || !patchSignature) return;
+      createMutation.mutate(
+        {
+          ...input.target,
+          headSha,
+          patchSignature,
+          path: anchor.path,
+          line: anchor.line,
+          side: anchor.side,
+          body,
+        },
+        { onSuccess: () => setPendingAnchor(null) },
+      );
+    },
+    [createMutation, headSha, input.target, patchSignature],
+  );
+
+  const updateDraft = useCallback(
+    (draft: PullRequestReviewDraft, body: string) => {
+      updateMutation.mutate({ ...input.target, id: draft.id, body });
+    },
+    [input.target, updateMutation],
+  );
+  const deleteDraft = useCallback(
+    (draft: PullRequestReviewDraft) => {
+      deleteMutation.mutate({ ...input.target, id: draft.id });
+    },
+    [deleteMutation, input.target],
+  );
+  const busy = createMutation.isPending || updateMutation.isPending || deleteMutation.isPending;
+  const renderAnnotation = useCallback(
+    (data: PullRequestReviewAnnotationData) => (
+      <PullRequestReviewAnnotation
+        data={data}
+        busy={busy}
+        onCreate={createDraft}
+        onCancelCreate={() => setPendingAnchor(null)}
+        onUpdate={updateDraft}
+        onDelete={deleteDraft}
+      />
+    ),
+    [busy, createDraft, deleteDraft, updateDraft],
+  );
+
+  return {
+    annotationsByFile,
+    startDraft: setPendingAnchor,
+    renderAnnotation,
+    drafts,
+    currentDrafts,
+    staleDrafts,
+    deleteDraft,
+    busy,
+    isLoading: draftsQuery.isPending,
+  };
+}

--- a/apps/web/src/lib/pullRequestMutationOptions.ts
+++ b/apps/web/src/lib/pullRequestMutationOptions.ts
@@ -2,6 +2,11 @@ import type {
   ProjectId,
   PullRequestActionInput,
   PullRequestCommentInput,
+  PullRequestReviewDraftCreateInput,
+  PullRequestReviewDraftDeleteInput,
+  PullRequestReviewDraftListInput,
+  PullRequestReviewDraftUpdateInput,
+  PullRequestReviewSubmitInput,
   PullRequestSetPinnedInput,
   PullRequestState,
 } from "@synara/contracts";
@@ -54,7 +59,69 @@ export const pullRequestMutationKeys = {
   setPinned: ["pull-requests", "set-pinned"] as const,
   comment: ["pull-requests", "comment"] as const,
   forceRefresh: ["pull-requests", "force-refresh"] as const,
+  createReviewDraft: ["pull-requests", "review-drafts", "create"] as const,
+  updateReviewDraft: ["pull-requests", "review-drafts", "update"] as const,
+  deleteReviewDraft: ["pull-requests", "review-drafts", "delete"] as const,
+  submitReview: ["pull-requests", "review", "submit"] as const,
 };
+
+function refreshReviewDrafts(
+  queryClient: QueryClient,
+  input: PullRequestReviewDraftListInput,
+): Promise<void> {
+  return queryClient.invalidateQueries({
+    queryKey: pullRequestQueryKeys.reviewDrafts(input),
+    exact: true,
+  });
+}
+
+export function pullRequestReviewDraftCreateMutationOptions(queryClient: QueryClient) {
+  return mutationOptions({
+    mutationKey: pullRequestMutationKeys.createReviewDraft,
+    networkMode: "always",
+    mutationFn: (input: PullRequestReviewDraftCreateInput) =>
+      ensureNativeApi().pullRequests.createReviewDraft(input),
+    onSettled: (_result, _error, input) => refreshReviewDrafts(queryClient, input),
+  });
+}
+
+export function pullRequestReviewDraftUpdateMutationOptions(queryClient: QueryClient) {
+  return mutationOptions({
+    mutationKey: pullRequestMutationKeys.updateReviewDraft,
+    networkMode: "always",
+    mutationFn: (input: PullRequestReviewDraftUpdateInput) =>
+      ensureNativeApi().pullRequests.updateReviewDraft(input),
+    onSettled: (_result, _error, input) => refreshReviewDrafts(queryClient, input),
+  });
+}
+
+export function pullRequestReviewDraftDeleteMutationOptions(queryClient: QueryClient) {
+  return mutationOptions({
+    mutationKey: pullRequestMutationKeys.deleteReviewDraft,
+    networkMode: "always",
+    mutationFn: (input: PullRequestReviewDraftDeleteInput) =>
+      ensureNativeApi().pullRequests.deleteReviewDraft(input),
+    onSettled: (_result, _error, input) => refreshReviewDrafts(queryClient, input),
+  });
+}
+
+export function pullRequestReviewSubmitMutationOptions(queryClient: QueryClient) {
+  return mutationOptions({
+    mutationKey: pullRequestMutationKeys.submitReview,
+    networkMode: "always",
+    mutationFn: (input: PullRequestReviewSubmitInput) =>
+      ensureNativeApi().pullRequests.submitReview(input),
+    onSettled: async (_result, _error, input) => {
+      await Promise.all([
+        refreshReviewDrafts(queryClient, input),
+        queryClient.invalidateQueries({
+          queryKey: pullRequestQueryKeys.detail(input),
+          exact: true,
+        }),
+      ]);
+    },
+  });
+}
 
 function refreshPullRequestReviewRequestCounts(queryClient: QueryClient): void {
   // This global sidebar badge is passive UI. Mark it stale and refresh active observers without

--- a/apps/web/src/lib/pullRequestQueryOptions.ts
+++ b/apps/web/src/lib/pullRequestQueryOptions.ts
@@ -2,6 +2,7 @@ import type {
   ProjectId,
   PullRequestDetailInput,
   PullRequestInvolvement,
+  PullRequestReviewDraftListInput,
   PullRequestState,
 } from "@synara/contracts";
 import { queryOptions, type QueryClient } from "@tanstack/react-query";
@@ -37,6 +38,8 @@ export const pullRequestQueryKeys = {
       input?.repository ?? null,
       input?.number ?? null,
     ] as const,
+  reviewDrafts: (input: PullRequestReviewDraftListInput | null) =>
+    ["pull-requests", "review-drafts", input?.repository ?? null, input?.number ?? null] as const,
 };
 
 export const PULL_REQUEST_STATES: readonly PullRequestState[] = ["open", "closed", "merged"];
@@ -161,5 +164,22 @@ export function pullRequestDiffQueryOptions(input: PullRequestDetailInput | null
     gcTime: 60_000,
     refetchOnWindowFocus: false,
     refetchOnReconnect: true,
+  });
+}
+
+export function pullRequestReviewDraftsQueryOptions(
+  input: PullRequestReviewDraftListInput | null,
+  enabled = true,
+) {
+  return queryOptions({
+    queryKey: pullRequestQueryKeys.reviewDrafts(input),
+    queryFn: () => {
+      if (!input) throw new Error("Pull request review drafts are unavailable.");
+      return ensureNativeApi().pullRequests.listReviewDrafts(input);
+    },
+    enabled: enabled && input !== null,
+    staleTime: 10_000,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: "always",
   });
 }

--- a/apps/web/src/lib/pullRequestReactQuery.review.test.ts
+++ b/apps/web/src/lib/pullRequestReactQuery.review.test.ts
@@ -1,0 +1,94 @@
+import type { ProjectId } from "@synara/contracts";
+import { QueryClient } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import * as nativeApi from "../nativeApi";
+import {
+  pullRequestQueryKeys,
+  pullRequestReviewDraftCreateMutationOptions,
+  pullRequestReviewSubmitMutationOptions,
+} from "./pullRequestReactQuery";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const projectId = "project-a" as ProjectId;
+const target = { projectId, repository: "acme/widgets", number: 42 } as const;
+
+describe("pull request review React Query", () => {
+  it("shares a draft query across local projects for the same GitHub pull request", () => {
+    expect(pullRequestQueryKeys.reviewDrafts(target)).toEqual(
+      pullRequestQueryKeys.reviewDrafts({ ...target, projectId: "project-b" as ProjectId }),
+    );
+  });
+
+  it("saves a draft through the pull request API and refreshes the exact draft query", async () => {
+    const queryClient = new QueryClient();
+    const key = pullRequestQueryKeys.reviewDrafts(target);
+    queryClient.setQueryData(key, { drafts: [] });
+    const createReviewDraft = vi.fn(async (input) => ({
+      draft: {
+        id: "draft-1",
+        repository: input.repository,
+        number: input.number,
+        headSha: input.headSha,
+        patchSignature: input.patchSignature,
+        path: input.path,
+        line: input.line,
+        side: input.side,
+        body: input.body,
+        createdAt: "2026-07-26T00:00:00.000Z",
+        updatedAt: "2026-07-26T00:00:00.000Z",
+      },
+    }));
+    vi.spyOn(nativeApi, "ensureNativeApi").mockReturnValue({
+      pullRequests: { createReviewDraft },
+    } as never);
+    const mutation = queryClient
+      .getMutationCache()
+      .build(queryClient, pullRequestReviewDraftCreateMutationOptions(queryClient));
+
+    await mutation.execute({
+      ...target,
+      headSha: "head-1",
+      patchSignature: "patch-1",
+      path: "src/app.ts",
+      line: 12,
+      side: "RIGHT",
+      body: "Keep this guard.",
+    });
+
+    expect(createReviewDraft).toHaveBeenCalledOnce();
+    expect(queryClient.getQueryState(key)?.isInvalidated).toBe(true);
+  });
+
+  it("keeps blocked review drafts cached while marking them stale for a refetch", async () => {
+    const queryClient = new QueryClient();
+    const key = pullRequestQueryKeys.reviewDrafts(target);
+    const cached = { drafts: [{ id: "draft-1" }] };
+    queryClient.setQueryData(key, cached);
+    const submitReview = vi.fn(async () => ({
+      status: "blocked" as const,
+      submittedDraftIds: [],
+      staleDraftIds: ["draft-1"],
+      invalidDraftIds: [],
+    }));
+    vi.spyOn(nativeApi, "ensureNativeApi").mockReturnValue({
+      pullRequests: { submitReview },
+    } as never);
+    const mutation = queryClient
+      .getMutationCache()
+      .build(queryClient, pullRequestReviewSubmitMutationOptions(queryClient));
+
+    await mutation.execute({
+      ...target,
+      event: "COMMENT",
+      body: "",
+      draftIds: ["draft-1"],
+    });
+
+    expect(queryClient.getQueryData(key)).toEqual(cached);
+    expect(queryClient.getQueryState(key)?.isInvalidated).toBe(true);
+  });
+});

--- a/apps/web/src/lib/pullRequestReactQuery.ts
+++ b/apps/web/src/lib/pullRequestReactQuery.ts
@@ -7,6 +7,7 @@ export {
   pullRequestDiffQueryOptions,
   pullRequestQueryErrorState,
   pullRequestQueryKeys,
+  pullRequestReviewDraftsQueryOptions,
   pullRequestReviewRequestCountQueryOptions,
   pullRequestsExactInvolvementQueryOptions,
   pullRequestsListQueryOptions,
@@ -19,6 +20,10 @@ export {
   pullRequestActionMutationOptions,
   pullRequestCommentMutationOptions,
   pullRequestMutationKeys,
+  pullRequestReviewDraftCreateMutationOptions,
+  pullRequestReviewDraftDeleteMutationOptions,
+  pullRequestReviewDraftUpdateMutationOptions,
+  pullRequestReviewSubmitMutationOptions,
   pullRequestsForceRefreshMutationOptions,
   pullRequestSetPinnedMutationOptions,
 } from "./pullRequestMutationOptions";

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -560,6 +560,16 @@ export function createWsNativeApi(): NativeApi {
         transport.request(WS_METHODS.pullRequestsAction, input, { timeoutMs: null }),
       comment: (input) => transport.request(WS_METHODS.pullRequestsComment, input),
       setPinned: (input) => transport.request(WS_METHODS.pullRequestsSetPinned, input),
+      listReviewDrafts: (input) =>
+        transport.request(WS_METHODS.pullRequestsReviewDraftsList, input),
+      createReviewDraft: (input) =>
+        transport.request(WS_METHODS.pullRequestsReviewDraftCreate, input),
+      updateReviewDraft: (input) =>
+        transport.request(WS_METHODS.pullRequestsReviewDraftUpdate, input),
+      deleteReviewDraft: (input) =>
+        transport.request(WS_METHODS.pullRequestsReviewDraftDelete, input),
+      submitReview: (input) =>
+        transport.request(WS_METHODS.pullRequestsReviewSubmit, input, { timeoutMs: null }),
     },
     contextMenu: {
       show: async <T extends string>(

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -89,8 +89,17 @@ import type {
   PullRequestDetail,
   PullRequestDetailInput,
   PullRequestDiffResult,
+  PullRequestReviewDraftCreateInput,
+  PullRequestReviewDraftDeleteInput,
+  PullRequestReviewDraftDeleteResult,
+  PullRequestReviewDraftListInput,
+  PullRequestReviewDraftListResult,
+  PullRequestReviewDraftResult,
+  PullRequestReviewDraftUpdateInput,
   PullRequestReviewRequestCountInput,
   PullRequestReviewRequestCountResult,
+  PullRequestReviewSubmitInput,
+  PullRequestReviewSubmitResult,
   PullRequestSetPinnedInput,
   PullRequestSetPinnedResult,
   PullRequestsListInput,
@@ -632,6 +641,19 @@ export interface NativeApi {
     action: (input: PullRequestActionInput) => Promise<PullRequestActionResult>;
     comment: (input: PullRequestCommentInput) => Promise<PullRequestActionResult>;
     setPinned: (input: PullRequestSetPinnedInput) => Promise<PullRequestSetPinnedResult>;
+    listReviewDrafts: (
+      input: PullRequestReviewDraftListInput,
+    ) => Promise<PullRequestReviewDraftListResult>;
+    createReviewDraft: (
+      input: PullRequestReviewDraftCreateInput,
+    ) => Promise<PullRequestReviewDraftResult>;
+    updateReviewDraft: (
+      input: PullRequestReviewDraftUpdateInput,
+    ) => Promise<PullRequestReviewDraftResult>;
+    deleteReviewDraft: (
+      input: PullRequestReviewDraftDeleteInput,
+    ) => Promise<PullRequestReviewDraftDeleteResult>;
+    submitReview: (input: PullRequestReviewSubmitInput) => Promise<PullRequestReviewSubmitResult>;
   };
   contextMenu: {
     show: <T extends string>(

--- a/packages/contracts/src/pullRequests.test.ts
+++ b/packages/contracts/src/pullRequests.test.ts
@@ -4,6 +4,7 @@ import { Schema } from "effect";
 import {
   PullRequestCommentInput,
   PullRequestDetail,
+  PullRequestDiffResult,
   PullRequestListEntry,
   PullRequestReviewRequestCountResult,
   PullRequestSetPinnedInput,
@@ -11,6 +12,7 @@ import {
 
 const decodeListEntry = Schema.decodeUnknownSync(PullRequestListEntry);
 const decodeDetail = Schema.decodeUnknownSync(PullRequestDetail);
+const decodeDiff = Schema.decodeUnknownSync(PullRequestDiffResult);
 const decodeCommentInput = Schema.decodeUnknownSync(PullRequestCommentInput);
 const decodeSetPinnedInput = Schema.decodeUnknownSync(PullRequestSetPinnedInput);
 const decodeReviewRequestCountResult = Schema.decodeUnknownSync(
@@ -54,7 +56,7 @@ describe("PullRequestListEntry", () => {
 });
 
 describe("PullRequestDetail", () => {
-  it("defaults mergeability for a real pre-field detail payload", () => {
+  it("defaults additive fields for a real pre-field detail payload", () => {
     const decoded = decodeDetail({
       projectId: "project-1",
       projectTitle: "Project One",
@@ -96,6 +98,18 @@ describe("PullRequestDetail", () => {
     });
 
     expect(decoded.mergeability).toBe("unknown");
+    expect(decoded.reviewThreads).toEqual([]);
+  });
+});
+
+describe("PullRequestDiffResult", () => {
+  it("defaults head metadata for an older server payload", () => {
+    expect(decodeDiff({ patch: "diff", truncated: false })).toEqual({
+      patch: "diff",
+      truncated: false,
+      headSha: "",
+      patchSignature: "",
+    });
   });
 });
 

--- a/packages/contracts/src/pullRequests.ts
+++ b/packages/contracts/src/pullRequests.ts
@@ -75,6 +75,46 @@ export const PullRequestComment = Schema.Struct({
 });
 export type PullRequestComment = typeof PullRequestComment.Type;
 
+export const PullRequestReviewSide = Schema.Literals(["LEFT", "RIGHT"]);
+export type PullRequestReviewSide = typeof PullRequestReviewSide.Type;
+
+export const PullRequestReviewEvent = Schema.Literals(["COMMENT", "APPROVE", "REQUEST_CHANGES"]);
+export type PullRequestReviewEvent = typeof PullRequestReviewEvent.Type;
+
+export const PullRequestReviewDraft = Schema.Struct({
+  id: TrimmedNonEmptyString,
+  repository: TrimmedNonEmptyString,
+  number: PositiveInt,
+  headSha: TrimmedNonEmptyString,
+  patchSignature: TrimmedNonEmptyString,
+  path: TrimmedNonEmptyString,
+  line: PositiveInt,
+  side: PullRequestReviewSide,
+  body: TrimmedNonEmptyString.check(Schema.isMaxLength(65_536)),
+  createdAt: IsoDateTime,
+  updatedAt: IsoDateTime,
+});
+export type PullRequestReviewDraft = typeof PullRequestReviewDraft.Type;
+
+export const PullRequestReviewThreadComment = Schema.Struct({
+  id: TrimmedNonEmptyString,
+  author: Schema.NullOr(PullRequestActor),
+  body: Schema.String,
+  createdAt: Schema.NullOr(IsoDateTime),
+  url: Schema.NullOr(Schema.String),
+});
+export type PullRequestReviewThreadComment = typeof PullRequestReviewThreadComment.Type;
+
+export const PullRequestReviewThread = Schema.Struct({
+  id: TrimmedNonEmptyString,
+  path: TrimmedNonEmptyString,
+  line: PositiveInt,
+  side: PullRequestReviewSide,
+  isResolved: Schema.Boolean,
+  comments: Schema.Array(PullRequestReviewThreadComment),
+});
+export type PullRequestReviewThread = typeof PullRequestReviewThread.Type;
+
 export const PullRequestCommit = Schema.Struct({
   oid: TrimmedNonEmptyString,
   messageHeadline: Schema.String,
@@ -217,6 +257,9 @@ export const PullRequestDetail = Schema.Struct({
   comments: Schema.Array(PullRequestComment),
   commentsTruncated: Schema.Boolean,
   commentsIncomplete: Schema.Boolean,
+  reviewThreads: Schema.optional(Schema.Array(PullRequestReviewThread)).pipe(
+    Schema.withDecodingDefault(() => []),
+  ),
   commits: Schema.Array(PullRequestCommit),
   mergeCapabilities: PullRequestMergeCapabilities,
 });
@@ -225,6 +268,8 @@ export type PullRequestDetail = typeof PullRequestDetail.Type;
 export const PullRequestDiffResult = Schema.Struct({
   patch: Schema.String,
   truncated: Schema.Boolean,
+  headSha: Schema.optional(Schema.String).pipe(Schema.withDecodingDefault(() => "")),
+  patchSignature: Schema.optional(Schema.String).pipe(Schema.withDecodingDefault(() => "")),
 });
 export type PullRequestDiffResult = typeof PullRequestDiffResult.Type;
 
@@ -246,6 +291,72 @@ export const PullRequestCommentInput = Schema.Struct({
   body: TrimmedNonEmptyString.check(Schema.isMaxLength(65536)),
 });
 export type PullRequestCommentInput = typeof PullRequestCommentInput.Type;
+
+export const PullRequestReviewDraftListInput = Schema.Struct({
+  projectId: ProjectId,
+  repository: TrimmedNonEmptyString,
+  number: PositiveInt,
+});
+export type PullRequestReviewDraftListInput = typeof PullRequestReviewDraftListInput.Type;
+
+export const PullRequestReviewDraftListResult = Schema.Struct({
+  drafts: Schema.Array(PullRequestReviewDraft),
+});
+export type PullRequestReviewDraftListResult = typeof PullRequestReviewDraftListResult.Type;
+
+export const PullRequestReviewDraftCreateInput = Schema.Struct({
+  ...PullRequestReviewDraftListInput.fields,
+  headSha: TrimmedNonEmptyString,
+  patchSignature: TrimmedNonEmptyString,
+  path: TrimmedNonEmptyString,
+  line: PositiveInt,
+  side: PullRequestReviewSide,
+  body: TrimmedNonEmptyString.check(Schema.isMaxLength(65_536)),
+});
+export type PullRequestReviewDraftCreateInput = typeof PullRequestReviewDraftCreateInput.Type;
+
+export const PullRequestReviewDraftUpdateInput = Schema.Struct({
+  ...PullRequestReviewDraftListInput.fields,
+  id: TrimmedNonEmptyString,
+  body: TrimmedNonEmptyString.check(Schema.isMaxLength(65_536)),
+});
+export type PullRequestReviewDraftUpdateInput = typeof PullRequestReviewDraftUpdateInput.Type;
+
+export const PullRequestReviewDraftDeleteInput = Schema.Struct({
+  ...PullRequestReviewDraftListInput.fields,
+  id: TrimmedNonEmptyString,
+});
+export type PullRequestReviewDraftDeleteInput = typeof PullRequestReviewDraftDeleteInput.Type;
+
+export const PullRequestReviewDraftResult = Schema.Struct({
+  draft: PullRequestReviewDraft,
+});
+export type PullRequestReviewDraftResult = typeof PullRequestReviewDraftResult.Type;
+
+export const PullRequestReviewDraftDeleteResult = Schema.Struct({
+  deletedId: TrimmedNonEmptyString,
+});
+export type PullRequestReviewDraftDeleteResult = typeof PullRequestReviewDraftDeleteResult.Type;
+
+export const PullRequestReviewSubmitInput = Schema.Struct({
+  ...PullRequestReviewDraftListInput.fields,
+  event: PullRequestReviewEvent,
+  body: Schema.optional(Schema.String.check(Schema.isMaxLength(65_536))).pipe(
+    Schema.withDecodingDefault(() => ""),
+  ),
+  draftIds: Schema.optional(
+    Schema.Array(TrimmedNonEmptyString).check(Schema.isMaxLength(500)),
+  ).pipe(Schema.withDecodingDefault(() => [])),
+});
+export type PullRequestReviewSubmitInput = typeof PullRequestReviewSubmitInput.Type;
+
+export const PullRequestReviewSubmitResult = Schema.Struct({
+  status: Schema.Literals(["submitted", "blocked"]),
+  submittedDraftIds: Schema.Array(TrimmedNonEmptyString),
+  staleDraftIds: Schema.Array(TrimmedNonEmptyString),
+  invalidDraftIds: Schema.Array(TrimmedNonEmptyString),
+});
+export type PullRequestReviewSubmitResult = typeof PullRequestReviewSubmitResult.Type;
 
 export const PullRequestSetPinnedInput = Schema.Struct({
   projectId: ProjectId,

--- a/packages/contracts/src/rpc.test.ts
+++ b/packages/contracts/src/rpc.test.ts
@@ -8,6 +8,11 @@ import {
   WsFeatureRpcGroup,
   WsProjectsDiscoverScriptsRpc,
   WsPullRequestsReviewRequestCountRpc,
+  WsPullRequestsReviewDraftsListRpc,
+  WsPullRequestsReviewDraftCreateRpc,
+  WsPullRequestsReviewDraftUpdateRpc,
+  WsPullRequestsReviewDraftDeleteRpc,
+  WsPullRequestsReviewSubmitRpc,
   WsRpcError,
   WsRpcGroup,
 } from "./rpc";
@@ -42,5 +47,15 @@ describe("WS RPC contracts", () => {
 
   it("exports the count-only pull request review RPC", () => {
     expect(WsPullRequestsReviewRequestCountRpc).toBeDefined();
+  });
+
+  it("exports review draft and submit RPCs through the pull request group", () => {
+    expect(WsPullRequestsReviewDraftsListRpc).toBeDefined();
+    expect(WsPullRequestsReviewDraftCreateRpc).toBeDefined();
+    expect(WsPullRequestsReviewDraftUpdateRpc).toBeDefined();
+    expect(WsPullRequestsReviewDraftDeleteRpc).toBeDefined();
+    expect(WsPullRequestsReviewSubmitRpc).toBeDefined();
+    expect(WsFeatureRpcGroup.requests.has("pullRequests.reviewDrafts.list")).toBe(true);
+    expect(WsFeatureRpcGroup.requests.has("pullRequests.review.submit")).toBe(true);
   });
 });

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -81,8 +81,17 @@ import {
   PullRequestDetail,
   PullRequestDetailInput,
   PullRequestDiffResult,
+  PullRequestReviewDraftCreateInput,
+  PullRequestReviewDraftDeleteInput,
+  PullRequestReviewDraftDeleteResult,
+  PullRequestReviewDraftListInput,
+  PullRequestReviewDraftListResult,
+  PullRequestReviewDraftResult,
+  PullRequestReviewDraftUpdateInput,
   PullRequestReviewRequestCountInput,
   PullRequestReviewRequestCountResult,
+  PullRequestReviewSubmitInput,
+  PullRequestReviewSubmitResult,
   PullRequestSetPinnedInput,
   PullRequestSetPinnedResult,
   PullRequestsListInput,
@@ -537,6 +546,45 @@ export const WsPullRequestsSetPinnedRpc = Rpc.make(WS_METHODS.pullRequestsSetPin
   payload: PullRequestSetPinnedInput,
   success: PullRequestSetPinnedResult,
   error: WsRpcError,
+});
+
+export const WsPullRequestsReviewDraftsListRpc = Rpc.make(WS_METHODS.pullRequestsReviewDraftsList, {
+  payload: PullRequestReviewDraftListInput,
+  success: PullRequestReviewDraftListResult,
+  error: PullRequestsRpcError,
+});
+
+export const WsPullRequestsReviewDraftCreateRpc = Rpc.make(
+  WS_METHODS.pullRequestsReviewDraftCreate,
+  {
+    payload: PullRequestReviewDraftCreateInput,
+    success: PullRequestReviewDraftResult,
+    error: PullRequestsRpcError,
+  },
+);
+
+export const WsPullRequestsReviewDraftUpdateRpc = Rpc.make(
+  WS_METHODS.pullRequestsReviewDraftUpdate,
+  {
+    payload: PullRequestReviewDraftUpdateInput,
+    success: PullRequestReviewDraftResult,
+    error: PullRequestsRpcError,
+  },
+);
+
+export const WsPullRequestsReviewDraftDeleteRpc = Rpc.make(
+  WS_METHODS.pullRequestsReviewDraftDelete,
+  {
+    payload: PullRequestReviewDraftDeleteInput,
+    success: PullRequestReviewDraftDeleteResult,
+    error: PullRequestsRpcError,
+  },
+);
+
+export const WsPullRequestsReviewSubmitRpc = Rpc.make(WS_METHODS.pullRequestsReviewSubmit, {
+  payload: PullRequestReviewSubmitInput,
+  success: PullRequestReviewSubmitResult,
+  error: PullRequestsRpcError,
 });
 
 export const WsGitListBranchesRpc = Rpc.make(WS_METHODS.gitListBranches, {
@@ -1027,6 +1075,11 @@ export const WsFeatureRpcGroup = RpcGroup.make(
   WsPullRequestsActionRpc,
   WsPullRequestsCommentRpc,
   WsPullRequestsSetPinnedRpc,
+  WsPullRequestsReviewDraftsListRpc,
+  WsPullRequestsReviewDraftCreateRpc,
+  WsPullRequestsReviewDraftUpdateRpc,
+  WsPullRequestsReviewDraftDeleteRpc,
+  WsPullRequestsReviewSubmitRpc,
   WsGitListBranchesRpc,
   WsGitCreateWorktreeRpc,
   WsGitCreateDetachedWorktreeRpc,

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -116,7 +116,12 @@ import {
   PullRequestActionInput,
   PullRequestCommentInput,
   PullRequestDetailInput,
+  PullRequestReviewDraftCreateInput,
+  PullRequestReviewDraftDeleteInput,
+  PullRequestReviewDraftListInput,
+  PullRequestReviewDraftUpdateInput,
   PullRequestReviewRequestCountInput,
+  PullRequestReviewSubmitInput,
   PullRequestSetPinnedInput,
   PullRequestsListInput,
 } from "./pullRequests";
@@ -185,6 +190,11 @@ export const WS_METHODS = {
   pullRequestsAction: "pullRequests.action",
   pullRequestsComment: "pullRequests.comment",
   pullRequestsSetPinned: "pullRequests.setPinned",
+  pullRequestsReviewDraftsList: "pullRequests.reviewDrafts.list",
+  pullRequestsReviewDraftCreate: "pullRequests.reviewDrafts.create",
+  pullRequestsReviewDraftUpdate: "pullRequests.reviewDrafts.update",
+  pullRequestsReviewDraftDelete: "pullRequests.reviewDrafts.delete",
+  pullRequestsReviewSubmit: "pullRequests.review.submit",
 
   // Terminal methods
   terminalOpen: "terminal.open",
@@ -359,6 +369,11 @@ const WebSocketRequestBody = Schema.Union([
   tagRequestBody(WS_METHODS.pullRequestsAction, PullRequestActionInput),
   tagRequestBody(WS_METHODS.pullRequestsComment, PullRequestCommentInput),
   tagRequestBody(WS_METHODS.pullRequestsSetPinned, PullRequestSetPinnedInput),
+  tagRequestBody(WS_METHODS.pullRequestsReviewDraftsList, PullRequestReviewDraftListInput),
+  tagRequestBody(WS_METHODS.pullRequestsReviewDraftCreate, PullRequestReviewDraftCreateInput),
+  tagRequestBody(WS_METHODS.pullRequestsReviewDraftUpdate, PullRequestReviewDraftUpdateInput),
+  tagRequestBody(WS_METHODS.pullRequestsReviewDraftDelete, PullRequestReviewDraftDeleteInput),
+  tagRequestBody(WS_METHODS.pullRequestsReviewSubmit, PullRequestReviewSubmitInput),
 
   // Terminal methods
   tagRequestBody(WS_METHODS.terminalOpen, TerminalOpenInput),


### PR DESCRIPTION
# Description

Adds inline pull-request review comments to the existing Code view.

- Groups GitHub review threads with their diff locations.
- Stores draft comments locally so they survive reloads.
- Shows draft and existing review annotations in the diff.
- Submits one GitHub review with an approve, comment, or request-changes state.
- Checks the live pull-request head and patch before submission. Stale or invalid drafts stay local and Synara reports them instead of posting them.

This is a focused transplant from the Synara fork. It excludes the fork's Kanban board, walkthrough, caching changes, and remote-runtime work.

Related issue: none.

No new external dependencies are required.

## Test Plan

How to test:

- Open a GitHub pull request in the Code tab.
- Add, edit, and delete inline draft comments.
- Reload and confirm that drafts persist.
- Submit a comment, approval, and request-changes review.
- Move the pull-request head or target an invalid hunk and confirm that Synara blocks stale or invalid drafts and keeps them local.
- Run:
  - `cd apps/server && bun run test -- src/git/Layers/GitHubCli.test.ts src/persistence/Layers/PullRequestReviewDraftStore.test.ts src/persistence/Migrations.test.ts src/pullRequests/pullRequestOperations.test.ts src/pullRequests/validateInlineComments.test.ts`
  - `cd apps/web && bun run test -- src/components/chat/FileDiffView.test.tsx src/lib/pullRequestReactQuery.review.test.ts`
  - `cd packages/contracts && bun run test -- src/pullRequests.test.ts src/rpc.test.ts`
  - `bun fmt`
  - `bun lint`
  - `bun typecheck`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have walked through my test plan
- [ ] I have made corresponding changes to the documentation (no documentation change is needed)
- [x] I have added tests to cover new or changed behavior
