### PR TITLE
feat: show Pull in Environment panel when behind upstream

### DIFF
--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -13,6 +13,7 @@ import {
   resolvePullActionAvailability,
   resolveQuickAction,
   shouldOfferCreateBranchPrompt,
+  shouldShowEnvironmentPanelPullRow,
   summarizeGitResult,
 } from "./GitActionsControl.logic";
 
@@ -428,6 +429,11 @@ describe("when: branch is behind upstream", () => {
     assert.deepEqual(availability, { canRun: true, hint: null });
   });
 
+  it("shouldShowEnvironmentPanelPullRow promotes the Pull primary row", () => {
+    const quick = resolveQuickAction(status({ behindCount: 2 }), false);
+    assert.equal(shouldShowEnvironmentPanelPullRow(quick), true);
+  });
+
   it("buildMenuItems disables push and create PR", () => {
     const items = buildMenuItems(status({ behindCount: 1, pr: null }), false);
     assert.deepEqual(items, [
@@ -494,6 +500,11 @@ describe("when: branch is up to date", () => {
       canRun: false,
       hint: "Branch is already up to date.",
     });
+  });
+
+  it("shouldShowEnvironmentPanelPullRow stays hidden", () => {
+    const quick = resolveQuickAction(status({ aheadCount: 0, behindCount: 0 }), false);
+    assert.equal(shouldShowEnvironmentPanelPullRow(quick), false);
   });
 });
 

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -431,7 +431,21 @@ describe("when: branch is behind upstream", () => {
 
   it("shouldShowEnvironmentPanelPullRow promotes the Pull primary row", () => {
     const quick = resolveQuickAction(status({ behindCount: 2 }), false);
-    assert.equal(shouldShowEnvironmentPanelPullRow(quick), true);
+    assert.equal(
+      shouldShowEnvironmentPanelPullRow({ quickAction: quick, isPullRunning: false }),
+      true,
+    );
+  });
+
+  it("shouldShowEnvironmentPanelPullRow keeps the Pull row visible while pulling", () => {
+    const busyQuickAction = resolveQuickAction(status({ behindCount: 2 }), true);
+    assert.equal(
+      shouldShowEnvironmentPanelPullRow({
+        quickAction: busyQuickAction,
+        isPullRunning: true,
+      }),
+      true,
+    );
   });
 
   it("buildMenuItems disables push and create PR", () => {
@@ -504,7 +518,10 @@ describe("when: branch is up to date", () => {
 
   it("shouldShowEnvironmentPanelPullRow stays hidden", () => {
     const quick = resolveQuickAction(status({ aheadCount: 0, behindCount: 0 }), false);
-    assert.equal(shouldShowEnvironmentPanelPullRow(quick), false);
+    assert.equal(
+      shouldShowEnvironmentPanelPullRow({ quickAction: quick, isPullRunning: false }),
+      false,
+    );
   });
 });
 

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -473,9 +473,14 @@ export function resolvePullActionAvailability(input: {
   return { canRun: true, hint: null };
 }
 
-/** Environment panel should promote Pull as the primary row when that is the quick action. */
-export function shouldShowEnvironmentPanelPullRow(quickAction: GitQuickAction): boolean {
-  return quickAction.kind === "run_pull" && !quickAction.disabled;
+/** Environment panel should promote Pull while it is available or already running. */
+export function shouldShowEnvironmentPanelPullRow(input: {
+  quickAction: GitQuickAction;
+  isPullRunning: boolean;
+}): boolean {
+  return (
+    input.isPullRunning || (input.quickAction.kind === "run_pull" && !input.quickAction.disabled)
+  );
 }
 
 export function shouldOfferCreateBranchPrompt(input: {

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -473,6 +473,11 @@ export function resolvePullActionAvailability(input: {
   return { canRun: true, hint: null };
 }
 
+/** Environment panel should promote Pull as the primary row when that is the quick action. */
+export function shouldShowEnvironmentPanelPullRow(quickAction: GitQuickAction): boolean {
+  return quickAction.kind === "run_pull" && !quickAction.disabled;
+}
+
 export function shouldOfferCreateBranchPrompt(input: {
   activeWorktreePath: string | null;
   gitStatus: Pick<GitStatusResult, "branch" | "hasUpstream"> | null;

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -39,6 +39,7 @@ import {
   resolveCreatePrActionAvailability,
   resolveQuickAction,
   resolvePullActionAvailability,
+  shouldShowEnvironmentPanelPullRow,
   shouldOfferCreateBranchPrompt,
   summarizeGitResult,
 } from "./GitActionsControl.logic";
@@ -104,8 +105,8 @@ interface GitActionsControlProps {
   gitCwd: string | null;
   activeThreadId: ThreadId | null;
   hideQuickActionLabel?: boolean;
-  // `header` renders the split quick-action button; `panel` collapses every git
-  // action into a single "Commit and Push" Environment panel row + dropdown.
+  // `header` renders the split quick-action button; `panel` collapses git actions into
+  // an Environment row + dropdown, promoting Pull as the primary row when behind upstream.
   variant?: "header" | "panel";
   // Lets a parent capture "run commit & push for this instance's repo" so a global
   // keyboard shortcut can trigger it without duplicating the action logic. Called with
@@ -1666,6 +1667,57 @@ export default function GitActionsControl({
   );
 
   if (isPanel) {
+    const showPanelPullRow = shouldShowEnvironmentPanelPullRow(quickAction);
+    const panelGitActionsMenu = (
+      <Menu
+        onOpenChange={(open) => {
+          if (open) void invalidateGitQueries(queryClient);
+        }}
+      >
+        <MenuTrigger
+          render={
+            <button
+              type="button"
+              className={cn(
+                ENVIRONMENT_ROW_CLASS_NAME,
+                showPanelPullRow
+                  ? "w-auto shrink-0 px-1.5"
+                  : shouldDimPanelCommitPushRow && "opacity-55",
+              )}
+              aria-label={
+                showPanelPullRow
+                  ? "Git action options"
+                  : shouldDimPanelCommitPushRow
+                    ? "Commit and Push unavailable; open Git actions menu"
+                    : "Commit and Push"
+              }
+              title={
+                showPanelPullRow
+                  ? "More Git actions"
+                  : shouldDimPanelCommitPushRow
+                    ? "Commit and Push unavailable. Open for more Git actions."
+                    : "Commit and Push"
+              }
+            />
+          }
+          disabled={showPanelPullRow ? isGitActionRunning : undefined}
+        >
+          {showPanelPullRow ? (
+            <EnvironmentRowChevron />
+          ) : (
+            <EnvironmentRowBody
+              icon={<GitActionGlyph name="push" className={ENVIRONMENT_ROW_ICON_CLASS_NAME} />}
+              label="Commit and Push"
+              trailing={<EnvironmentRowChevron />}
+            />
+          )}
+        </MenuTrigger>
+        <ComposerPickerMenuPopup align="start" side="bottom" className="w-60 min-w-60">
+          {gitMenuContent}
+        </ComposerPickerMenuPopup>
+      </Menu>
+    );
+
     return (
       <>
         {!isRepo ? (
@@ -1675,43 +1727,25 @@ export default function GitActionsControl({
             disabled={initMutation.isPending}
             onClick={() => initMutation.mutate()}
           />
-        ) : (
-          <Menu
-            onOpenChange={(open) => {
-              if (open) void invalidateGitQueries(queryClient);
-            }}
-          >
-            <MenuTrigger
-              render={
-                <button
-                  type="button"
-                  className={cn(
-                    ENVIRONMENT_ROW_CLASS_NAME,
-                    shouldDimPanelCommitPushRow && "opacity-55",
-                  )}
-                  aria-label={
-                    shouldDimPanelCommitPushRow
-                      ? "Commit and Push unavailable; open Git actions menu"
-                      : "Commit and Push"
-                  }
-                  title={
-                    shouldDimPanelCommitPushRow
-                      ? "Commit and Push unavailable. Open for more Git actions."
-                      : "Commit and Push"
-                  }
-                />
-              }
+        ) : showPanelPullRow ? (
+          <div className="flex w-full items-center">
+            <button
+              type="button"
+              className={cn(ENVIRONMENT_ROW_CLASS_NAME, "min-w-0 flex-1")}
+              aria-label="Pull"
+              title="Pull"
+              disabled={isGitActionRunning}
+              onClick={runQuickAction}
             >
               <EnvironmentRowBody
-                icon={<GitActionGlyph name="push" className={ENVIRONMENT_ROW_ICON_CLASS_NAME} />}
-                label="Commit and Push"
-                trailing={<EnvironmentRowChevron />}
+                icon={<GitActionGlyph name="sync" className={ENVIRONMENT_ROW_ICON_CLASS_NAME} />}
+                label={isPullRunning ? "Pulling..." : "Pull"}
               />
-            </MenuTrigger>
-            <ComposerPickerMenuPopup align="start" side="bottom" className="w-60 min-w-60">
-              {gitMenuContent}
-            </ComposerPickerMenuPopup>
-          </Menu>
+            </button>
+            {panelGitActionsMenu}
+          </div>
+        ) : (
+          panelGitActionsMenu
         )}
         {gitActionDialogs}
       </>

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1667,7 +1667,10 @@ export default function GitActionsControl({
   );
 
   if (isPanel) {
-    const showPanelPullRow = shouldShowEnvironmentPanelPullRow(quickAction);
+    const showPanelPullRow = shouldShowEnvironmentPanelPullRow({
+      quickAction,
+      isPullRunning,
+    });
     const panelGitActionsMenu = (
       <Menu
         onOpenChange={(open) => {


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

When the current branch is behind upstream, the Environment panel git row now promotes **Pull** as the primary action (click runs pull; chevron still opens the full git menu). When up to date, it still shows the existing **Commit and Push** menu row.

## Why

After finishing a task and switching back to `main`, the Environment panel only showed a dimmed “Commit and Push” row. Pull already existed in the header quick action and buried in the dropdown, but it was not visible as a primary Environment action. This matches the header behavior for the common “switch to main and pull” flow.

## UI Changes

- **Before:** Environment panel always labeled the git row “Commit and Push” (often dimmed when behind).
- **After:** When behind upstream, the row becomes **Pull** with a sync icon; trailing chevron still opens other git actions.

(Screenshots not attached — happy to add if useful.)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
