### PR TITLE
feat: show Pull in Environment panel when behind upstream

### DIFF
--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -13,6 +13,7 @@ import {
   resolvePullActionAvailability,
   resolveQuickAction,
   shouldOfferCreateBranchPrompt,
+  shouldShowEnvironmentPanelPullRow,
   summarizeGitResult,
 } from "./GitActionsControl.logic";
 
@@ -428,6 +429,11 @@ describe("when: branch is behind upstream", () => {
     assert.deepEqual(availability, { canRun: true, hint: null });
   });
 
+  it("shouldShowEnvironmentPanelPullRow promotes the Pull primary row", () => {
+    const quick = resolveQuickAction(status({ behindCount: 2 }), false);
+    assert.equal(shouldShowEnvironmentPanelPullRow(quick), true);
+  });
+
   it("buildMenuItems disables push and create PR", () => {
     const items = buildMenuItems(status({ behindCount: 1, pr: null }), false);
     assert.deepEqual(items, [
@@ -494,6 +500,11 @@ describe("when: branch is up to date", () => {
       canRun: false,
       hint: "Branch is already up to date.",
     });
+  });
+
+  it("shouldShowEnvironmentPanelPullRow stays hidden", () => {
+    const quick = resolveQuickAction(status({ aheadCount: 0, behindCount: 0 }), false);
+    assert.equal(shouldShowEnvironmentPanelPullRow(quick), false);
   });
 });
 

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -431,7 +431,21 @@ describe("when: branch is behind upstream", () => {
 
   it("shouldShowEnvironmentPanelPullRow promotes the Pull primary row", () => {
     const quick = resolveQuickAction(status({ behindCount: 2 }), false);
-    assert.equal(shouldShowEnvironmentPanelPullRow(quick), true);
+    assert.equal(
+      shouldShowEnvironmentPanelPullRow({ quickAction: quick, isPullRunning: false }),
+      true,
+    );
+  });
+
+  it("shouldShowEnvironmentPanelPullRow keeps the Pull row visible while pulling", () => {
+    const busyQuickAction = resolveQuickAction(status({ behindCount: 2 }), true);
+    assert.equal(
+      shouldShowEnvironmentPanelPullRow({
+        quickAction: busyQuickAction,
+        isPullRunning: true,
+      }),
+      true,
+    );
   });
 
   it("buildMenuItems disables push and create PR", () => {
@@ -504,7 +518,10 @@ describe("when: branch is up to date", () => {
 
   it("shouldShowEnvironmentPanelPullRow stays hidden", () => {
     const quick = resolveQuickAction(status({ aheadCount: 0, behindCount: 0 }), false);
-    assert.equal(shouldShowEnvironmentPanelPullRow(quick), false);
+    assert.equal(
+      shouldShowEnvironmentPanelPullRow({ quickAction: quick, isPullRunning: false }),
+      false,
+    );
   });
 });
 

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -473,9 +473,14 @@ export function resolvePullActionAvailability(input: {
   return { canRun: true, hint: null };
 }
 
-/** Environment panel should promote Pull as the primary row when that is the quick action. */
-export function shouldShowEnvironmentPanelPullRow(quickAction: GitQuickAction): boolean {
-  return quickAction.kind === "run_pull" && !quickAction.disabled;
+/** Environment panel should promote Pull while it is available or already running. */
+export function shouldShowEnvironmentPanelPullRow(input: {
+  quickAction: GitQuickAction;
+  isPullRunning: boolean;
+}): boolean {
+  return (
+    input.isPullRunning || (input.quickAction.kind === "run_pull" && !input.quickAction.disabled)
+  );
 }
 
 export function shouldOfferCreateBranchPrompt(input: {

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -473,6 +473,11 @@ export function resolvePullActionAvailability(input: {
   return { canRun: true, hint: null };
 }
 
+/** Environment panel should promote Pull as the primary row when that is the quick action. */
+export function shouldShowEnvironmentPanelPullRow(quickAction: GitQuickAction): boolean {
+  return quickAction.kind === "run_pull" && !quickAction.disabled;
+}
+
 export function shouldOfferCreateBranchPrompt(input: {
   activeWorktreePath: string | null;
   gitStatus: Pick<GitStatusResult, "branch" | "hasUpstream"> | null;

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -39,6 +39,7 @@ import {
   resolveCreatePrActionAvailability,
   resolveQuickAction,
   resolvePullActionAvailability,
+  shouldShowEnvironmentPanelPullRow,
   shouldOfferCreateBranchPrompt,
   summarizeGitResult,
 } from "./GitActionsControl.logic";
@@ -104,8 +105,8 @@ interface GitActionsControlProps {
   gitCwd: string | null;
   activeThreadId: ThreadId | null;
   hideQuickActionLabel?: boolean;
-  // `header` renders the split quick-action button; `panel` collapses every git
-  // action into a single "Commit and Push" Environment panel row + dropdown.
+  // `header` renders the split quick-action button; `panel` collapses git actions into
+  // an Environment row + dropdown, promoting Pull as the primary row when behind upstream.
   variant?: "header" | "panel";
   // Lets a parent capture "run commit & push for this instance's repo" so a global
   // keyboard shortcut can trigger it without duplicating the action logic. Called with
@@ -1666,6 +1667,57 @@ export default function GitActionsControl({
   );
 
   if (isPanel) {
+    const showPanelPullRow = shouldShowEnvironmentPanelPullRow(quickAction);
+    const panelGitActionsMenu = (
+      <Menu
+        onOpenChange={(open) => {
+          if (open) void invalidateGitQueries(queryClient);
+        }}
+      >
+        <MenuTrigger
+          render={
+            <button
+              type="button"
+              className={cn(
+                ENVIRONMENT_ROW_CLASS_NAME,
+                showPanelPullRow
+                  ? "w-auto shrink-0 px-1.5"
+                  : shouldDimPanelCommitPushRow && "opacity-55",
+              )}
+              aria-label={
+                showPanelPullRow
+                  ? "Git action options"
+                  : shouldDimPanelCommitPushRow
+                    ? "Commit and Push unavailable; open Git actions menu"
+                    : "Commit and Push"
+              }
+              title={
+                showPanelPullRow
+                  ? "More Git actions"
+                  : shouldDimPanelCommitPushRow
+                    ? "Commit and Push unavailable. Open for more Git actions."
+                    : "Commit and Push"
+              }
+            />
+          }
+          disabled={showPanelPullRow ? isGitActionRunning : undefined}
+        >
+          {showPanelPullRow ? (
+            <EnvironmentRowChevron />
+          ) : (
+            <EnvironmentRowBody
+              icon={<GitActionGlyph name="push" className={ENVIRONMENT_ROW_ICON_CLASS_NAME} />}
+              label="Commit and Push"
+              trailing={<EnvironmentRowChevron />}
+            />
+          )}
+        </MenuTrigger>
+        <ComposerPickerMenuPopup align="start" side="bottom" className="w-60 min-w-60">
+          {gitMenuContent}
+        </ComposerPickerMenuPopup>
+      </Menu>
+    );
+
     return (
       <>
         {!isRepo ? (
@@ -1675,43 +1727,25 @@ export default function GitActionsControl({
             disabled={initMutation.isPending}
             onClick={() => initMutation.mutate()}
           />
-        ) : (
-          <Menu
-            onOpenChange={(open) => {
-              if (open) void invalidateGitQueries(queryClient);
-            }}
-          >
-            <MenuTrigger
-              render={
-                <button
-                  type="button"
-                  className={cn(
-                    ENVIRONMENT_ROW_CLASS_NAME,
-                    shouldDimPanelCommitPushRow && "opacity-55",
-                  )}
-                  aria-label={
-                    shouldDimPanelCommitPushRow
-                      ? "Commit and Push unavailable; open Git actions menu"
-                      : "Commit and Push"
-                  }
-                  title={
-                    shouldDimPanelCommitPushRow
-                      ? "Commit and Push unavailable. Open for more Git actions."
-                      : "Commit and Push"
-                  }
-                />
-              }
+        ) : showPanelPullRow ? (
+          <div className="flex w-full items-center">
+            <button
+              type="button"
+              className={cn(ENVIRONMENT_ROW_CLASS_NAME, "min-w-0 flex-1")}
+              aria-label="Pull"
+              title="Pull"
+              disabled={isGitActionRunning}
+              onClick={runQuickAction}
             >
               <EnvironmentRowBody
-                icon={<GitActionGlyph name="push" className={ENVIRONMENT_ROW_ICON_CLASS_NAME} />}
-                label="Commit and Push"
-                trailing={<EnvironmentRowChevron />}
+                icon={<GitActionGlyph name="sync" className={ENVIRONMENT_ROW_ICON_CLASS_NAME} />}
+                label={isPullRunning ? "Pulling..." : "Pull"}
               />
-            </MenuTrigger>
-            <ComposerPickerMenuPopup align="start" side="bottom" className="w-60 min-w-60">
-              {gitMenuContent}
-            </ComposerPickerMenuPopup>
-          </Menu>
+            </button>
+            {panelGitActionsMenu}
+          </div>
+        ) : (
+          panelGitActionsMenu
         )}
         {gitActionDialogs}
       </>

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1667,7 +1667,10 @@ export default function GitActionsControl({
   );
 
   if (isPanel) {
-    const showPanelPullRow = shouldShowEnvironmentPanelPullRow(quickAction);
+    const showPanelPullRow = shouldShowEnvironmentPanelPullRow({
+      quickAction,
+      isPullRunning,
+    });
     const panelGitActionsMenu = (
       <Menu
         onOpenChange={(open) => {

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1703,7 +1703,6 @@ export default function GitActionsControl({
               }
             />
           }
-          disabled={showPanelPullRow ? isGitActionRunning : undefined}
         >
           {showPanelPullRow ? (
             <EnvironmentRowChevron />


### PR DESCRIPTION
## What changed

Promotes **Pull** as the primary Environment-panel Git action when the current branch is behind upstream, while keeping the action visible as **Pulling…** during the in-flight pull. The chevron continues to expose the complete Git action menu.

## Verification

- Rebasing onto current `main` completed without conflicts.
- Effective diff is limited to the three `GitActionsControl` files.
- Focused GitActionsControl suite: 88/88 passing.
- `git diff --check`: clean.

Internal rebased continuation of #480 so the existing contributor fork does not need to be force-updated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes in GitActionsControl panel layout and a small pure helper; pull behavior reuses existing quick-action and mutation paths.
> 
> **Overview**
> When the branch is **behind upstream**, the Environment panel (`variant="panel"`) no longer uses a single **Commit and Push** menu row as the only control. It shows a **Pull** primary row (wired to the existing quick action / sync flow, including **Pulling…** while a pull is in flight) beside a compact chevron that still opens the full Git actions menu.
> 
> Visibility is driven by a new **`shouldShowEnvironmentPanelPullRow`** helper in `GitActionsControl.logic`, which is true when pull is the enabled quick action or a pull is already running. Other panel states keep the previous **Commit and Push** row behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bd9f4bb84e7a6dbafdd37b9a1ee548edba1b58e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->