### PR TITLE
fix(web): cap stacked composer panel lists so large agent fleets can't hide the composer

### DIFF
--- a/apps/web/src/components/chat/ActiveTaskListCard.tsx
+++ b/apps/web/src/components/chat/ActiveTaskListCard.tsx
@@ -26,6 +26,7 @@ import {
   COMPOSER_STACKED_PANEL_FOOTER_ROW_CLASS_NAME,
   COMPOSER_STACKED_PANEL_ICON_BUTTON_CLASS_NAME,
   COMPOSER_STACKED_PANEL_ICON_CLASS_NAME,
+  COMPOSER_STACKED_PANEL_SCROLL_REGION_CLASS_NAME,
 } from "./composerStackedPanelStyles";
 
 interface ActiveTaskListCardProps {
@@ -106,7 +107,13 @@ export function ActiveTaskListCard({
 
       {compact ? null : (
         <>
-          <ol className={cn("space-y-0", COMPOSER_STACKED_PANEL_BODY_PADDING_CLASS_NAME)}>
+          <ol
+            className={cn(
+              "space-y-0",
+              COMPOSER_STACKED_PANEL_BODY_PADDING_CLASS_NAME,
+              COMPOSER_STACKED_PANEL_SCROLL_REGION_CLASS_NAME,
+            )}
+          >
             {activeTaskList.tasks.map((task, index) => {
               const occurrence = (taskOccurrenceCount.get(task.task) ?? 0) + 1;
               taskOccurrenceCount.set(task.task, occurrence);

--- a/apps/web/src/components/chat/ComposerSubagentStrip.tsx
+++ b/apps/web/src/components/chat/ComposerSubagentStrip.tsx
@@ -38,6 +38,7 @@ import {
   COMPOSER_STACKED_PANEL_BODY_PADDING_CLASS_NAME,
   COMPOSER_STACKED_PANEL_ICON_BUTTON_CLASS_NAME,
   COMPOSER_STACKED_PANEL_ICON_CLASS_NAME,
+  COMPOSER_STACKED_PANEL_SCROLL_REGION_CLASS_NAME,
 } from "./composerStackedPanelStyles";
 
 interface ComposerSubagentStripProps {
@@ -117,7 +118,13 @@ export const ComposerSubagentStrip = function ComposerSubagentStrip({
       </ComposerStackedPanelHeaderRow>
 
       <DisclosureRegion open={!compact}>
-        <div className={cn("space-y-0", COMPOSER_STACKED_PANEL_BODY_PADDING_CLASS_NAME)}>
+        <div
+          className={cn(
+            "space-y-0",
+            COMPOSER_STACKED_PANEL_BODY_PADDING_CLASS_NAME,
+            COMPOSER_STACKED_PANEL_SCROLL_REGION_CLASS_NAME,
+          )}
+        >
           {items.map((item) =>
             item.kind === "parent" ? (
               <div

--- a/apps/web/src/components/chat/WorkflowRunCard.tsx
+++ b/apps/web/src/components/chat/WorkflowRunCard.tsx
@@ -53,6 +53,7 @@ import {
   COMPOSER_STACKED_PANEL_BODY_PADDING_CLASS_NAME,
   COMPOSER_STACKED_PANEL_ICON_BUTTON_CLASS_NAME,
   COMPOSER_STACKED_PANEL_ICON_CLASS_NAME,
+  COMPOSER_STACKED_PANEL_SCROLL_REGION_CLASS_NAME,
 } from "./composerStackedPanelStyles";
 
 interface WorkflowRunCardProps {
@@ -478,7 +479,10 @@ export function WorkflowRunCard({
               ))}
             </div>
           ) : null}
-          <div className="space-y-0" data-testid="workflow-phase-group">
+          <div
+            className={cn("space-y-0", COMPOSER_STACKED_PANEL_SCROLL_REGION_CLASS_NAME)}
+            data-testid="workflow-phase-group"
+          >
             {visibleGroups ? (
               visibleGroups.length > 0 ? (
                 visibleGroups.map(({ phase, agents }) => (

--- a/apps/web/src/components/chat/composerStackedPanelStyles.test.ts
+++ b/apps/web/src/components/chat/composerStackedPanelStyles.test.ts
@@ -9,6 +9,7 @@ import {
   COMPOSER_STACKED_PANEL_ICON_CLASS_NAME,
   COMPOSER_STACKED_PANEL_LABEL_CLASS_NAME,
   COMPOSER_STACKED_PANEL_ROW_CLASS_NAME,
+  COMPOSER_STACKED_PANEL_SCROLL_REGION_CLASS_NAME,
 } from "./composerStackedPanelStyles";
 
 describe("composerStackedPanelStyles", () => {
@@ -23,6 +24,11 @@ describe("composerStackedPanelStyles", () => {
     expect(COMPOSER_STACKED_PANEL_ROW_CLASS_NAME).toContain("px-2.5");
     expect(COMPOSER_STACKED_PANEL_ROW_CLASS_NAME).toContain("py-1.5");
     expect(COMPOSER_STACKED_PANEL_ROW_CLASS_NAME).toContain("text-[12px]");
+  });
+
+  it("keeps unbounded row lists capped so large agent fleets cannot push the composer off-screen", () => {
+    expect(COMPOSER_STACKED_PANEL_SCROLL_REGION_CLASS_NAME).toContain("max-h-");
+    expect(COMPOSER_STACKED_PANEL_SCROLL_REGION_CLASS_NAME).toContain("overflow-y-auto");
   });
 
   it("keeps icon and label treatments aligned across stacked panels", () => {

--- a/apps/web/src/components/chat/composerStackedPanelStyles.ts
+++ b/apps/web/src/components/chat/composerStackedPanelStyles.ts
@@ -62,6 +62,16 @@ export const COMPOSER_STACKED_PANEL_META_CLASS_NAME =
 /** Horizontal padding for multi-line stacked panel bodies. */
 export const COMPOSER_STACKED_PANEL_BODY_PADDING_CLASS_NAME = "px-2.5 pb-1.5";
 
+/**
+ * Bounded scroll region for unbounded row lists inside stacked panels (subagent
+ * strip, workflow agent list). Panels sit in normal flow above the composer, so
+ * without a cap a large agent fleet grows the panel past the viewport and pushes
+ * the composer input off-screen; capping here keeps the layout shift constant
+ * regardless of row count.
+ */
+export const COMPOSER_STACKED_PANEL_SCROLL_REGION_CLASS_NAME =
+  "max-h-56 overflow-y-auto overscroll-contain";
+
 /** Footer/meta row below stacked panel content (background agents). */
 export const COMPOSER_STACKED_PANEL_FOOTER_ROW_CLASS_NAME =
   "flex items-center justify-between gap-2 px-2.5 py-1.5 text-[11px] text-muted-foreground/70";


### PR DESCRIPTION
## What Changed

Added a shared scroll-region token (`max-h-56 overflow-y-auto overscroll-contain`) in `composerStackedPanelStyles.ts` and applied it to the three unbounded row lists stacked above the composer:

- the subagent strip body (`ComposerSubagentStrip.tsx`)
- the workflow run card's agent list (`WorkflowRunCard.tsx` — phase pills and header stay fixed, only rows scroll)
- the active task list (`ActiveTaskListCard.tsx`)

Also pinned the cap with a style-token regression test alongside the existing ones.

## Why

These panels render in normal document flow above the composer input, so their height directly displaces the transcript and composer. A turn that spawns many subagents (e.g. 20+ parallel Task-tool agents) grows the strip one row per agent until the composer input is pushed entirely off-screen and the thread becomes unusable while the agents run.

Capping the list height keeps the layout shift constant regardless of agent/task count: the panel occupies at most ~14rem and scrolls internally. A bounded in-flow region was chosen over converting the panels to a floating overlay because the stacked-panel system is built around normal flow (fused borders, `-mb-px` seams, and the composer's ResizeObserver-based footer/scroll measurement all assume it), so an overlay would be a much more invasive change for the same user-facing outcome.

## UI Changes

Before: with ~20 running subagents the strip grows unbounded and pushes the composer off-screen (reproduced by spawning 20 parallel Task-tool subagents that sleep).

After: the same run keeps the strip at a fixed ~14rem with internal scrolling; composer stays visible and usable.

(Screenshots can be added on request — the repro is: spawn 20 parallel Task-tool subagents that each `sleep 90`.)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes