### PR TITLE
perf(transport): compression, precompressed assets, cursor resume, single-handshake connect

### DIFF
--- a/.docs/architecture.md
+++ b/.docs/architecture.md
@@ -66,6 +66,8 @@ sequenceDiagram
 4. Once the server is ready, [`wsServer`][3] sends `server.welcome` from the contracts in [`ws.ts`][6] through [`ServerPushBus`][5].
 5. The browser receives that ordered push through [`WsTransport`][1], and [`wsNativeApi`][2] uses it to seed local client state.
 
+The connect itself is a single negotiated handshake, and the socket is compressed. See [transport.md](./transport.md) for the negotiation contract, `permessage-deflate`, static asset delivery, and cursor-based thread resume.
+
 ### User turn flow
 
 ```mermaid

--- a/.docs/transport.md
+++ b/.docs/transport.md
@@ -63,9 +63,11 @@ Details that are easy to get wrong and are therefore tested:
 
 Subscribing to a thread can **resume from a cursor** instead of refetching full history ([`threadDetailResumeCursors.ts`][4]).
 
-Resume is fenced by a high-water mark. If the requested cursor is behind what the server can still serve, the server answers `ORCHESTRATION_RESNAPSHOT_REQUIRED` and the client takes a fresh snapshot. The fence is deliberately conservative: a redundant snapshot is wasteful, a stale delta is wrong, so any doubt resolves toward the snapshot.
+Resume is fenced by a high-water mark. The server trusts a cursor only when the subject thread still exists, the gap to the journal head is non-negative (hard purges can lower the head below a cursor a client legitimately held), and the gap fits the replay limit. Any other cursor falls back to the full-snapshot path **inside the same stream** — the client is served a snapshot as if it had never sent a cursor, with no extra round trip. (`ORCHESTRATION_RESNAPSHOT_REQUIRED` is the snapshot path's own fence for a replay that can no longer cover its gap; the resume shortcut never emits it.) The fence is deliberately conservative: a redundant snapshot is wasteful, a stale delta is wrong, so any doubt resolves toward the snapshot.
 
-The `orchestration.cursor-safe-streams` capability advertised by `/ws/negotiate` gates this. A client that does not present it receives full snapshots exactly as before.
+The `afterSequence` field is optional on the subscribe input, so an older client simply never sends it and receives full snapshots exactly as before.
+
+Cursor state also gates sidebar prewarming: a speculative prewarm subscription is only cheap when it can resume from a cursor, so threads without cached detail are not prewarmed from scroll position and pay their first full snapshot when actually opened. That trades a slightly colder first open of a never-viewed thread for not spending the per-client thread-stream budget on full-history streams the user may never look at.
 
 [1]: ../apps/server/src/nodeHttpServer.ts
 [2]: ../apps/server/src/wsCompatibility.ts

--- a/.docs/transport.md
+++ b/.docs/transport.md
@@ -1,0 +1,73 @@
+# Transport
+
+How the browser and server talk: connect negotiation, WebSocket compression, and static asset delivery.
+
+Synara's transport was originally built for localhost, where bandwidth is free and latency is negligible. The mechanisms below exist because neither holds over a real network — they are also what makes running a session against a remote host practical.
+
+## Connect negotiation
+
+Connecting is a **single handshake**. The browser first asks `/ws/negotiate` (HTTP) what the server speaks, then opens the feature socket at `/ws` carrying the negotiated answer as query parameters.
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant Transport as WsTransport
+    participant Server as wsRpc
+
+    Browser->>Transport: Load app
+    Transport->>Server: GET /ws/negotiate?epoch&min/maxRevision&clientBuild
+    Server-->>Transport: epoch, negotiatedRevision, serverInstanceId, capabilities
+    Transport->>Server: Upgrade /ws?epoch&revision&clientBuild&serverInstance
+    Server-->>Transport: 101 + permessage-deflate
+```
+
+`/ws/negotiate` returns the protocol epoch, the negotiated revision, the server's **instance id**, and the capability list. The socket request must echo all of it back.
+
+`validateWsFeatureCompatibility` ([`wsCompatibility.ts`][2]) rejects a mismatch with **HTTP 426** and a typed reason:
+
+| Condition                            | Reason                    | Client action |
+| ------------------------------------ | ------------------------- | ------------- |
+| Epoch differs, or parameters missing | `WS_NEGOTIATION_REQUIRED` | reload        |
+| Revision below the server's minimum  | —                         | update client |
+| Revision above the server's maximum  | —                         | update server |
+| `serverInstanceId` does not match    | `WS_NEGOTIATION_REQUIRED` | reload        |
+
+The instance id is a fresh UUID per server boot. That is what makes a restart mid-negotiation detectable: a client holding credentials from a previous server generation is told to reload rather than silently talking a stale protocol against a new process. A 426 on `/ws` is therefore **expected behaviour** for any client that has not negotiated — not a fault.
+
+## WebSocket compression
+
+`permessage-deflate` is negotiated on the feature socket with **context takeover**, so each frame is compressed against the window left by previous frames. Orchestration traffic is highly repetitive JSON — the same envelope keys with a few fields changed — so the repeated structure costs almost nothing after the first message. Measured against representative orchestration frames, this is roughly a 79% reduction.
+
+Two safety properties matter more than the ratio:
+
+- **`maxPayload` is enforced on the decompressed size.** Compression cannot be used to smuggle an oversized frame past the limit.
+- **Compression is negotiated only on the feature socket path.** The dispatch in [`nodeHttpServer.ts`][1] fails closed: a socket on any other path gets no compression rather than silently inheriting it. `upgradePathAllowsCompression` is the single point that decides this.
+
+## Static assets
+
+The build emits `.br` and `.gz` sidecars next to each asset. [`staticAssets.ts`][3] serves the best encoding the client actually accepts, falling back to identity.
+
+| Encoding | Full bundle | Reduction |
+| -------- | ----------- | --------- |
+| identity | 18.09 MB    | —         |
+| gzip     | 4.44 MB     | 75.4%     |
+| brotli   | 3.63 MB     | 79.9%     |
+
+Details that are easy to get wrong and are therefore tested:
+
+- **`Accept-Encoding` parsing ranks `identity` among the codings** rather than special-casing it, so `identity;q=0` and `br;q=0` both behave per RFC 9110. An encoding explicitly refused with `q=0` is never served.
+- **Conditional requests** use weak comparison for `If-None-Match`, and the ETag varies by encoding — a brotli response and an identity response of the same file are different entities.
+- **Cache lifetime follows content addressing.** Hashed assets are `public, max-age=31536000, immutable`; `index.html` is `no-cache`. Caching the entry document would pin a browser to a stale bundle, so it is deliberately excluded.
+
+## Thread subscription and cursor resume
+
+Subscribing to a thread can **resume from a cursor** instead of refetching full history ([`threadDetailResumeCursors.ts`][4]).
+
+Resume is fenced by a high-water mark. If the requested cursor is behind what the server can still serve, the server answers `ORCHESTRATION_RESNAPSHOT_REQUIRED` and the client takes a fresh snapshot. The fence is deliberately conservative: a redundant snapshot is wasteful, a stale delta is wrong, so any doubt resolves toward the snapshot.
+
+The `orchestration.cursor-safe-streams` capability advertised by `/ws/negotiate` gates this. A client that does not present it receives full snapshots exactly as before.
+
+[1]: ../apps/server/src/nodeHttpServer.ts
+[2]: ../apps/server/src/wsCompatibility.ts
+[3]: ../apps/server/src/staticAssets.ts
+[4]: ../apps/web/src/threadDetailResumeCursors.ts

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -1,7 +1,8 @@
 import http from "node:http";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import zlib from "node:zlib";
 
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 import { Effect, Exit, Layer, Scope } from "effect";
@@ -331,6 +332,234 @@ describe("production Effect HTTP routes", () => {
       expect(fallback.status).toBe(200);
       expect(fallback.headers.get("content-type")).toContain("text/html");
       await expect(fallback.text()).resolves.toContain("Synara shell");
+    });
+  });
+
+  it("serves precompressed sidecars by Accept-Encoding with identity fallback", async () => {
+    const staticDir = makeTempDir("synara-effect-static-");
+    mkdirSync(path.join(staticDir, "assets"), { recursive: true });
+    const source = "globalThis.synara = true;".repeat(64);
+    writeFileSync(path.join(staticDir, "assets", "app-abc123.js"), source);
+    writeFileSync(path.join(staticDir, "assets", "app-abc123.js.gz"), zlib.gzipSync(source));
+    writeFileSync(
+      path.join(staticDir, "assets", "app-abc123.js.br"),
+      zlib.brotliCompressSync(source),
+    );
+    writeFileSync(path.join(staticDir, "assets", "plain-def456.js"), source);
+
+    await withEffectServer(makeConfig({ staticDir }), { kind: "static" }, async (origin) => {
+      const brotli = await fetch(`${origin}/assets/app-abc123.js`, {
+        headers: { "accept-encoding": "gzip, br" },
+      });
+      expect(brotli.status).toBe(200);
+      expect(brotli.headers.get("content-encoding")).toBe("br");
+      expect(brotli.headers.get("content-type")).toContain("javascript");
+      expect(brotli.headers.get("vary")).toBe("Accept-Encoding");
+      await expect(brotli.text()).resolves.toBe(source);
+
+      const gzipOnly = await fetch(`${origin}/assets/app-abc123.js`, {
+        headers: { "accept-encoding": "gzip, br;q=0" },
+      });
+      expect(gzipOnly.headers.get("content-encoding")).toBe("gzip");
+      await expect(gzipOnly.text()).resolves.toBe(source);
+
+      const identity = await fetch(`${origin}/assets/app-abc123.js`, {
+        headers: { "accept-encoding": "identity" },
+      });
+      expect(identity.headers.get("content-encoding")).toBeNull();
+      expect(identity.headers.get("vary")).toBe("Accept-Encoding");
+      await expect(identity.text()).resolves.toBe(source);
+
+      // No sidecar on disk: fall back to identity even when compression is accepted.
+      const noSidecar = await fetch(`${origin}/assets/plain-def456.js`, {
+        headers: { "accept-encoding": "gzip, br" },
+      });
+      expect(noSidecar.status).toBe(200);
+      expect(noSidecar.headers.get("content-encoding")).toBeNull();
+      await expect(noSidecar.text()).resolves.toBe(source);
+
+      // A specific q=0 exclusion outranks the wildcard.
+      const excludedBrotli = await fetch(`${origin}/assets/app-abc123.js`, {
+        headers: { "accept-encoding": "br;q=0, *" },
+      });
+      expect(excludedBrotli.headers.get("content-encoding")).toBe("gzip");
+      await expect(excludedBrotli.text()).resolves.toBe(source);
+
+      // Sidecars are a negotiation detail, not addressable resources.
+      for (const direct of ["/assets/app-abc123.js.br", "/assets/app-abc123.js.gz"]) {
+        const response = await fetch(`${origin}${direct}`);
+        expect(response.status, direct).toBe(404);
+      }
+    });
+  });
+
+  it("refuses symlinks that escape the static root", async () => {
+    const parentDir = makeTempDir("synara-effect-static-");
+    const staticDir = path.join(parentDir, "static");
+    mkdirSync(path.join(staticDir, "assets"), { recursive: true });
+    writeFileSync(path.join(staticDir, "index.html"), "<main>Synara shell</main>");
+    const secretPath = path.join(parentDir, "secret.js");
+    writeFileSync(secretPath, "outside root");
+    writeFileSync(`${secretPath}.gz`, zlib.gzipSync("outside root"));
+    // Lexically inside the root, physically outside it — the guard must
+    // canonicalize before opening rather than trusting the prefix.
+    symlinkSync(secretPath, path.join(staticDir, "assets", "leak.js"));
+    symlinkSync(`${secretPath}.gz`, path.join(staticDir, "assets", "leak-sidecar.js.gz"));
+    writeFileSync(path.join(staticDir, "assets", "leak-sidecar.js"), "inside root");
+
+    await withEffectServer(makeConfig({ staticDir }), { kind: "static" }, async (origin) => {
+      // The escaping source is refused outright — the containment check runs
+      // before any read, so the link target's bytes never reach the response.
+      const escaped = await fetch(`${origin}/assets/leak.js`);
+      const escapedBody = await escaped.text();
+      expect(escaped.status).toBe(500);
+      expect(escapedBody).not.toContain("outside root");
+
+      // A sidecar that escapes is skipped; the in-root source is still served.
+      const sidecarEscape = await fetch(`${origin}/assets/leak-sidecar.js`, {
+        headers: { "accept-encoding": "gzip" },
+      });
+      expect(sidecarEscape.headers.get("content-encoding")).toBeNull();
+      await expect(sidecarEscape.text()).resolves.toBe("inside root");
+    });
+  });
+
+  it("returns 406 when no acceptable encoding exists and identity is excluded", async () => {
+    const staticDir = makeTempDir("synara-effect-static-");
+    mkdirSync(path.join(staticDir, "assets"), { recursive: true });
+    const source = "globalThis.synara = true;".repeat(64);
+    writeFileSync(path.join(staticDir, "index.html"), "<main>Synara shell</main>");
+    writeFileSync(path.join(staticDir, "assets", "plain-def456.js"), source);
+
+    await withEffectServer(makeConfig({ staticDir }), { kind: "static" }, async (origin) => {
+      // No sidecars on disk and identity refused: nothing is servable.
+      const refused = await fetch(`${origin}/assets/plain-def456.js`, {
+        headers: { "accept-encoding": "identity;q=0" },
+      });
+      expect(refused.status).toBe(406);
+      expect(refused.headers.get("vary")).toBe("Accept-Encoding");
+
+      // Same exclusion, but a sidecar the client accepts exists → 200.
+      writeFileSync(path.join(staticDir, "assets", "plain-def456.js.gz"), zlib.gzipSync(source));
+      const served = await fetch(`${origin}/assets/plain-def456.js`, {
+        headers: { "accept-encoding": "gzip, identity;q=0" },
+      });
+      expect(served.status).toBe(200);
+      expect(served.headers.get("content-encoding")).toBe("gzip");
+    });
+  });
+
+  it("revalidates with ETags and answers matching conditionals with 304", async () => {
+    const staticDir = makeTempDir("synara-effect-static-");
+    mkdirSync(path.join(staticDir, "assets"), { recursive: true });
+    const source = "globalThis.synara = true;".repeat(64);
+    writeFileSync(path.join(staticDir, "index.html"), "<main>Synara shell</main>");
+    writeFileSync(path.join(staticDir, "assets", "app-abc123.js"), source);
+    writeFileSync(path.join(staticDir, "assets", "app-abc123.js.gz"), zlib.gzipSync(source));
+
+    await withEffectServer(makeConfig({ staticDir }), { kind: "static" }, async (origin) => {
+      const first = await fetch(`${origin}/`);
+      const etag = first.headers.get("etag");
+      expect(etag).toMatch(/^W\//);
+
+      const revalidated = await fetch(`${origin}/`, {
+        headers: { "if-none-match": etag! },
+      });
+      expect(revalidated.status).toBe(304);
+      await expect(revalidated.text()).resolves.toBe("");
+
+      // Validators must differ per served encoding: the gzip variant's ETag
+      // cannot satisfy an identity conditional and vice versa.
+      const gzipResponse = await fetch(`${origin}/assets/app-abc123.js`, {
+        headers: { "accept-encoding": "gzip" },
+      });
+      const gzipEtag = gzipResponse.headers.get("etag");
+      const identityResponse = await fetch(`${origin}/assets/app-abc123.js`, {
+        headers: { "accept-encoding": "identity" },
+      });
+      expect(gzipEtag).not.toBeNull();
+      expect(identityResponse.headers.get("etag")).not.toBe(gzipEtag);
+
+      const gzipRevalidated = await fetch(`${origin}/assets/app-abc123.js`, {
+        headers: { "accept-encoding": "gzip", "if-none-match": gzipEtag! },
+      });
+      expect(gzipRevalidated.status).toBe(304);
+    });
+  });
+
+  it("marks hashed assets immutable and keeps index.html revalidating", async () => {
+    const staticDir = makeTempDir("synara-effect-static-");
+    mkdirSync(path.join(staticDir, "assets"), { recursive: true });
+    writeFileSync(path.join(staticDir, "index.html"), "<main>Synara shell</main>");
+    writeFileSync(path.join(staticDir, "assets", "app-abc123.js"), "globalThis.synara = true;");
+
+    await withEffectServer(makeConfig({ staticDir }), { kind: "static" }, async (origin) => {
+      const asset = await fetch(`${origin}/assets/app-abc123.js`);
+      expect(asset.headers.get("cache-control")).toBe("public, max-age=31536000, immutable");
+
+      const index = await fetch(`${origin}/`);
+      expect(index.headers.get("cache-control")).toBe("no-cache");
+      expect(index.headers.get("content-type")).toContain("text/html");
+
+      const spaFallback = await fetch(`${origin}/chat/thread-id`);
+      expect(spaFallback.headers.get("cache-control")).toBe("no-cache");
+    });
+  });
+
+  it("rejects traversal attempts including sidecar-shaped paths", async () => {
+    const parentDir = makeTempDir("synara-effect-static-");
+    const staticDir = path.join(parentDir, "static");
+    mkdirSync(staticDir, { recursive: true });
+    writeFileSync(path.join(staticDir, "index.html"), "<main>Synara shell</main>");
+    writeFileSync(path.join(parentDir, "secret.js"), "outside root");
+    writeFileSync(path.join(parentDir, "secret.js.gz"), zlib.gzipSync("outside root"));
+    writeFileSync(path.join(parentDir, "secret.js.br"), zlib.brotliCompressSync("outside root"));
+
+    // fetch() normalizes dot segments away client-side; send the raw request
+    // path so the server's own guard is what gets exercised.
+    const rawRequest = (origin: string, rawPath: string) =>
+      new Promise<{ status: number; body: string }>((resolve, reject) => {
+        const { hostname, port } = new URL(origin);
+        const request = http.request(
+          { hostname, port, path: rawPath, headers: { "accept-encoding": "gzip, br" } },
+          (response) => {
+            const chunks: Buffer[] = [];
+            response.on("data", (chunk: Buffer) => chunks.push(chunk));
+            response.on("end", () =>
+              resolve({
+                status: response.statusCode ?? 0,
+                body: Buffer.concat(chunks).toString("latin1"),
+              }),
+            );
+          },
+        );
+        request.on("error", reject);
+        request.end();
+      });
+
+    await withEffectServer(makeConfig({ staticDir }), { kind: "static" }, async (origin) => {
+      // Dot segments are stripped by URL parsing before the path guard runs,
+      // and percent-encoded separators stay literal filename characters — both
+      // must resolve inside the root (shell fallback) or be rejected outright,
+      // never reach the sibling secret or its sidecars.
+      // Sidecar-shaped request paths 404 outright (they are never addressable),
+      // which also removes them as a traversal target.
+      for (const traversal of [
+        "/../secret.js",
+        "/../secret.js.gz",
+        "/../secret.js.br",
+        "/assets/../../secret.js.gz",
+        "/..%2Fsecret.js.gz",
+        "/assets/..%2f..%2fsecret.js.br",
+        "/%2e%2e/secret.js.br",
+      ]) {
+        const response = await rawRequest(origin, traversal);
+        expect([200, 400, 404], traversal).toContain(response.status);
+        expect(response.body, traversal).not.toContain("outside root");
+        if (response.status === 200) {
+          expect(response.body, traversal).toContain("Synara shell");
+        }
+      }
     });
   });
 

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -56,6 +56,13 @@ import {
 } from "./serverShutdown";
 import { resolveFavicon, tryParseHost } from "./siteFaviconCache";
 import {
+  ifNoneMatchSatisfies,
+  isSidecarRequestPath,
+  negotiateStaticEncodingPreference,
+  staticCacheControl,
+  staticEtag,
+} from "./staticAssets";
+import {
   isTrustedAppOrigin,
   normalizeCorsOrigin,
   shouldRejectAuthMutationOrigin,
@@ -1130,10 +1137,36 @@ export const staticAndDevEffectRouteLayer = HttpRouter.add(
     ) {
       return HttpServerResponse.text("Invalid static file path", { status: 400 });
     }
+    if (isSidecarRequestPath(relativePath)) {
+      return HttpServerResponse.text("Not Found", { status: 404 });
+    }
 
     const isWithinStaticRoot = (candidate: string) =>
       candidate === staticRoot ||
       candidate.startsWith(staticRoot.endsWith(path.sep) ? staticRoot : `${staticRoot}${path.sep}`);
+
+    // Lexical containment is not containment: stat and readFile follow
+    // symlinks, so a link inside the root pointing outside it would be served.
+    // Canonicalize before opening anything. The root itself is canonicalized
+    // too, otherwise a symlinked staticDir would fail its own check.
+    const canonicalStaticRoot = yield* fileSystem
+      .realPath(staticRoot)
+      .pipe(Effect.catch(() => Effect.succeed(staticRoot)));
+    const isWithinCanonicalRoot = (candidate: string) =>
+      candidate === canonicalStaticRoot ||
+      candidate.startsWith(
+        canonicalStaticRoot.endsWith(path.sep)
+          ? canonicalStaticRoot
+          : `${canonicalStaticRoot}${path.sep}`,
+      );
+    const resolvesInsideRoot = Effect.fn(function* (candidate: string) {
+      const real = yield* fileSystem
+        .realPath(candidate)
+        .pipe(Effect.catch(() => Effect.succeed(null)));
+      // A path that cannot be canonicalized does not exist; the caller's own
+      // stat/readFile will fail it, and refusing here keeps 404 semantics.
+      return real === null ? false : isWithinCanonicalRoot(real);
+    });
 
     let filePath = path.resolve(staticRoot, relativePath);
     if (!isWithinStaticRoot(filePath)) {
@@ -1146,29 +1179,80 @@ export const staticAndDevEffectRouteLayer = HttpRouter.add(
       }
     }
 
+    // Serves a resolved static file, preferring build-time .br/.gz sidecars
+    // when the client accepts them. Content-Type always reflects the
+    // underlying file; Vary is set even on identity responses so shared
+    // caches never hand a compressed body to a client that cannot decode it.
+    // Every response carries an ETag derived from the served file (sidecar's
+    // when a sidecar is served, so validators differ per encoding), making
+    // no-cache revalidation a 304 instead of a full re-transfer.
+    const serveStaticFile = Effect.fn(function* (resolvedPath: string) {
+      const cacheHeaders = {
+        "Cache-Control": staticCacheControl(path.relative(staticRoot, resolvedPath)),
+        Vary: "Accept-Encoding",
+      };
+      const ifNoneMatch = request.headers["if-none-match"];
+      const baseContentType = Mime.getType(resolvedPath) ?? "application/octet-stream";
+      const contentType =
+        baseContentType === "text/html" ? "text/html; charset=utf-8" : baseContentType;
+      const respond = Effect.fn(function* (servedPath: string, encoding?: string) {
+        // Canonicalize before opening: a symlink inside the root pointing
+        // outside it passes the lexical guard but must not be served.
+        if (!(yield* resolvesInsideRoot(servedPath))) return null;
+        const info = yield* fileSystem
+          .stat(servedPath)
+          .pipe(Effect.catch(() => Effect.succeed(null)));
+        if (!info || info.type !== "File") return null;
+        const etag = staticEtag(Number(info.size), info.mtime?.getTime() ?? 0, encoding);
+        const encodingHeaders = encoding ? { "Content-Encoding": encoding } : {};
+        const headers = { ...cacheHeaders, ...encodingHeaders, ETag: etag };
+        if (ifNoneMatchSatisfies(ifNoneMatch, etag)) {
+          return HttpServerResponse.empty({ status: 304, headers });
+        }
+        const data = yield* fileSystem
+          .readFile(servedPath)
+          .pipe(Effect.catch(() => Effect.succeed(null)));
+        if (!data) return null;
+        return HttpServerResponse.uint8Array(data, { status: 200, contentType, headers });
+      });
+      const preference = negotiateStaticEncodingPreference(request.headers["accept-encoding"]);
+      // Candidates are ranked by client weight with identity (null) in its own
+      // ranked position, so a client preferring identity over a coding is not
+      // handed a sidecar it ranked lower.
+      for (const candidate of preference.candidates) {
+        if (candidate === null) {
+          const identityResponse = yield* respond(resolvedPath);
+          if (identityResponse) return identityResponse;
+          continue;
+        }
+        const sidecarPath = `${resolvedPath}${candidate.sidecarExtension}`;
+        // Sidecars share the traversal guard with their source file: appending
+        // an extension cannot escape the root, but keep the invariant explicit.
+        if (!isWithinStaticRoot(sidecarPath)) continue;
+        const sidecarResponse = yield* respond(sidecarPath, candidate.encoding);
+        if (sidecarResponse) return sidecarResponse;
+      }
+      // Nothing acceptable was servable. With identity excluded that is a 406
+      // per RFC 9110 §12.5.3; otherwise the file itself is missing.
+      if (!preference.identityAcceptable) {
+        return HttpServerResponse.text("Not Acceptable", {
+          status: 406,
+          headers: { Vary: "Accept-Encoding" },
+        });
+      }
+      return null;
+    });
+
     const fileInfo = yield* fileSystem
       .stat(filePath)
       .pipe(Effect.catch(() => Effect.succeed(null)));
     if (!fileInfo || fileInfo.type !== "File") {
-      const indexPath = path.resolve(staticRoot, "index.html");
-      const indexData = yield* fileSystem
-        .readFile(indexPath)
-        .pipe(Effect.catch(() => Effect.succeed(null)));
-      if (!indexData) return HttpServerResponse.text("Not Found", { status: 404 });
-      return HttpServerResponse.uint8Array(indexData, {
-        status: 200,
-        contentType: "text/html; charset=utf-8",
-      });
+      const fallback = yield* serveStaticFile(path.resolve(staticRoot, "index.html"));
+      return fallback ?? HttpServerResponse.text("Not Found", { status: 404 });
     }
 
-    const data = yield* fileSystem
-      .readFile(filePath)
-      .pipe(Effect.catch(() => Effect.succeed(null)));
-    if (!data) return HttpServerResponse.text("Internal Server Error", { status: 500 });
-    return HttpServerResponse.uint8Array(data, {
-      status: 200,
-      contentType: Mime.getType(filePath) ?? "application/octet-stream",
-    });
+    const response = yield* serveStaticFile(filePath);
+    return response ?? HttpServerResponse.text("Internal Server Error", { status: 500 });
   }),
 );
 

--- a/apps/server/src/nodeHttpServer.ts
+++ b/apps/server/src/nodeHttpServer.ts
@@ -1,6 +1,7 @@
 import http from "node:http";
 import type { ListenOptions, Socket } from "node:net";
 
+import { WS_FEATURE_PATH } from "@synara/contracts";
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 import { Effect, Scope } from "effect";
 import * as HttpServer from "effect/unstable/http/HttpServer";
@@ -27,6 +28,91 @@ function handleClientSocketError(this: Socket): void {
 
 function protectClientSocket(socket: Socket): void {
   socket.on("error", handleClientSocketError);
+}
+
+/**
+ * permessage-deflate configuration for the feature WS socket only.
+ *
+ * The RPC stream is small, highly repetitive JSON (repeated schema keys,
+ * UUIDs, event envelopes), which is the best case for DEFLATE with context
+ * takeover: the compression window is shared across frames, so each frame is
+ * coded against the vocabulary of everything sent before it. Context takeover
+ * stays enabled (the negotiated default). A client offering
+ * `client_no_context_takeover` still compresses normally; one offering
+ * `server_no_context_takeover` loses the shared vocabulary and can end up
+ * with frames slightly larger than uncompressed, since framing overhead
+ * exceeds the gain on a single small frame.
+ *
+ * No `threshold` is set: `ws` only honors it when context takeover is
+ * disabled, and skipping tiny frames would also skip priming the shared
+ * window they benefit from.
+ *
+ * `maxPayload` admission control is unaffected: `ws` enforces it on the
+ * decompressed size — accumulated across continuation frames — so a
+ * compressed or fragmented message cannot smuggle past the bound.
+ *
+ * The pre-auth bootstrap socket deliberately never negotiates compression:
+ * each actively compressed connection retains zlib window state (~288 KiB at
+ * defaults) plus potentially near-`maxPayload` inflated buffers for
+ * incomplete fragmented messages, and the bootstrap path is reachable
+ * without credentials. Compression is a post-authentication privilege so
+ * unauthenticated connections cannot multiply per-connection memory.
+ *
+ * Measured on a simulated streaming turn of small repetitive JSON frames:
+ * ~80% wire reduction, with CPU dominated by per-invocation zlib overhead
+ * rather than compression level (levels 1/3/6 within 2% on both axes), so
+ * zlib options stay at their defaults. Numbers in the PR that added this.
+ *
+ * `ws` already defaults `concurrencyLimit` to 10 and creates its limiter
+ * once per process on the first PerMessageDeflate instance, so passing it
+ * here would pin the default rather than bound anything new.
+ */
+const PER_MESSAGE_DEFLATE_OPTIONS = true;
+
+/**
+ * The one upgrade route allowed to negotiate compression (post-auth). Shared
+ * with the route registration so the dispatcher and the router cannot drift.
+ */
+const COMPRESSED_UPGRADE_PATH = WS_FEATURE_PATH;
+
+/**
+ * Normalizes a raw request target the way the Effect router does before route
+ * matching: absolute-form targets, query and fragment, `;params`, duplicate
+ * slashes, percent-encoding, case, and trailing slashes all collapse. The
+ * router matches case-insensitively on the decoded path, so comparing the raw
+ * target here would let `/WS/BOOTSTRAP` or `/ws/%62ootstrap` reach the
+ * bootstrap route while classifying as something else.
+ */
+function normalizeUpgradePath(requestUrl: string | undefined): string {
+  const target = requestUrl ?? "";
+  // Absolute-form request targets (RFC 9112 §3.2.2) are legal on upgrades.
+  const afterAuthority = /^[a-z][a-z0-9+.-]*:\/\//i.test(target)
+    ? target.replace(/^[a-z][a-z0-9+.-]*:\/\/[^/]*/i, "") || "/"
+    : target;
+  const pathOnly = afterAuthority.split("#")[0]?.split("?")[0] ?? "";
+  let decoded = pathOnly;
+  try {
+    decoded = decodeURIComponent(pathOnly);
+  } catch {
+    // Malformed percent-encoding cannot be a recognized route; leave as-is so
+    // it falls through to the uncompressed default.
+  }
+  const withoutParams = decoded
+    .split("/")
+    .map((segment) => segment.split(";")[0] ?? "")
+    .join("/");
+  const collapsed = withoutParams.replace(/\/{2,}/g, "/").toLowerCase();
+  return collapsed.length > 1 ? collapsed.replace(/\/+$/, "") : collapsed;
+}
+
+/**
+ * Fail closed: only the exact feature route negotiates compression. Anything
+ * else — the pre-auth bootstrap route, unrecognized paths, malformed targets —
+ * lands on the uncompressed server, so no unauthenticated connection can hold
+ * zlib state regardless of how its path is spelled.
+ */
+export function upgradePathAllowsCompression(requestUrl: string | undefined): boolean {
+  return normalizeUpgradePath(requestUrl) === COMPRESSED_UPGRADE_PATH;
 }
 
 /**
@@ -69,21 +155,26 @@ export const makeBoundedNodeHttpServer = Effect.fnUntraced(function* (
   });
 
   const address = server.address()!;
-  const webSocketServer = yield* Effect.acquireRelease(
-    Effect.sync(
-      () =>
-        new WebSocketServer({
-          noServer: true,
-          maxPayload: MAX_WEBSOCKET_MESSAGE_BYTES,
-          perMessageDeflate: false,
+  const makeBoundedWebSocketServer = (perMessageDeflate: boolean) =>
+    Effect.acquireRelease(
+      Effect.sync(
+        () =>
+          new WebSocketServer({
+            noServer: true,
+            maxPayload: MAX_WEBSOCKET_MESSAGE_BYTES,
+            perMessageDeflate: perMessageDeflate ? PER_MESSAGE_DEFLATE_OPTIONS : false,
+          }),
+      ),
+      (server) =>
+        Effect.callback<void>((resume) => {
+          for (const client of server.clients) client.terminate();
+          server.close(() => resume(Effect.void));
         }),
-    ),
-    (server) =>
-      Effect.callback<void>((resume) => {
-        for (const client of server.clients) client.terminate();
-        server.close(() => resume(Effect.void));
-      }),
-  ).pipe(Scope.provide(scope));
+    ).pipe(Scope.provide(scope));
+  // Two ws servers sharing one HTTP listener: compression is negotiated only
+  // on authenticated feature-socket paths (see PER_MESSAGE_DEFLATE_OPTIONS).
+  const featureWebSocketServer = yield* makeBoundedWebSocketServer(true);
+  const bootstrapWebSocketServer = yield* makeBoundedWebSocketServer(false);
 
   return HttpServer.make({
     address:
@@ -102,14 +193,32 @@ export const makeBoundedNodeHttpServer = Effect.fnUntraced(function* (
       }) as Effect.Effect<
         (nodeRequest: http.IncomingMessage, nodeResponse: http.ServerResponse) => void
       >;
-      const upgradeHandler = yield* NodeHttpServer.makeUpgradeHandler(
-        Effect.succeed(webSocketServer),
+      const featureUpgradeHandler = yield* NodeHttpServer.makeUpgradeHandler(
+        Effect.succeed(featureWebSocketServer),
         httpApp,
         {
           middleware: middleware as any,
           scope: serveScope,
         },
       );
+      const bootstrapUpgradeHandler = yield* NodeHttpServer.makeUpgradeHandler(
+        Effect.succeed(bootstrapWebSocketServer),
+        httpApp,
+        {
+          middleware: middleware as any,
+          scope: serveScope,
+        },
+      );
+      const upgradeHandler = (
+        nodeRequest: http.IncomingMessage,
+        socket: Parameters<typeof featureUpgradeHandler>[1],
+        head: Parameters<typeof featureUpgradeHandler>[2],
+      ) => {
+        const dispatch = upgradePathAllowsCompression(nodeRequest.url)
+          ? featureUpgradeHandler
+          : bootstrapUpgradeHandler;
+        dispatch(nodeRequest, socket, head);
+      };
 
       yield* Effect.addFinalizer(() =>
         Effect.sync(() => {

--- a/apps/server/src/nodeHttpServer.upgradePath.test.ts
+++ b/apps/server/src/nodeHttpServer.upgradePath.test.ts
@@ -1,0 +1,68 @@
+// Compression eligibility is decided from the raw upgrade target before any
+// routing happens, so it must agree with the router's matching semantics
+// (find-my-way-ts: case-insensitive, duplicate slashes and trailing slashes
+// ignored). A spelling the router sends to the pre-auth bootstrap route while
+// this says "compressed" is a live zlib-amplification bypass, so the table
+// below is the security boundary. The live-socket assertions in
+// wsRpc.connectionLifecycle.test.ts cover the negotiation itself.
+
+import { describe, expect, it } from "vitest";
+
+import { upgradePathAllowsCompression } from "./nodeHttpServer";
+
+describe("upgradePathAllowsCompression", () => {
+  it("allows the feature route in every spelling the router accepts", () => {
+    for (const target of [
+      "/ws",
+      "/ws?token=abc",
+      "/ws#fragment",
+      "/WS",
+      "/Ws",
+      "/ws/",
+      "/ws//",
+      "//ws",
+      "http://host/ws",
+      "https://host:8080/ws?x=1",
+    ]) {
+      expect(upgradePathAllowsCompression(target), target).toBe(true);
+    }
+  });
+
+  it("refuses every spelling that routes to the pre-auth bootstrap route", () => {
+    for (const target of [
+      "/ws/bootstrap",
+      "/WS/BOOTSTRAP",
+      "/Ws/BootStrap",
+      "/ws//bootstrap",
+      "/ws/bootstrap/",
+      "/ws/%62ootstrap",
+      "/ws/%42OOTSTRAP",
+      "/ws/bootstrap;sid=1",
+      "/ws/bootstrap?x=1",
+      "http://host/ws/bootstrap",
+      "https://host/WS/BOOTSTRAP",
+    ]) {
+      expect(upgradePathAllowsCompression(target), target).toBe(false);
+    }
+  });
+
+  it("fails closed on unknown, malformed, and hostile targets", () => {
+    for (const target of [
+      undefined,
+      "",
+      "/",
+      "/wsx",
+      "/ws/negotiate",
+      "/ws/..",
+      "/ws/%2e%2e/ws",
+      // Invalid percent-encoding: decoding throws, so the raw target stands
+      // and cannot match the feature route.
+      "/ws/%zz",
+      "/%C0%AFws",
+      "/ws\\bootstrap",
+      "/ws\u0000",
+    ]) {
+      expect(upgradePathAllowsCompression(target), String(target)).toBe(false);
+    }
+  });
+});

--- a/apps/server/src/staticAssets.test.ts
+++ b/apps/server/src/staticAssets.test.ts
@@ -1,0 +1,168 @@
+// Unit coverage for static-serving policy: encoding negotiation edge cases,
+// cache-control tiers, sidecar path detection, and ETag shape. The HTTP-level
+// behavior is covered in http.test.ts; this table pins the pure logic.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  STATIC_ICON_CACHE_CONTROL,
+  STATIC_IMMUTABLE_CACHE_CONTROL,
+  STATIC_REVALIDATE_CACHE_CONTROL,
+  ifNoneMatchSatisfies,
+  isSidecarRequestPath,
+  negotiateStaticEncodingPreference,
+  negotiateStaticEncodings,
+  staticCacheControl,
+  staticEtag,
+} from "./staticAssets";
+
+const encodings = (header: string | undefined) =>
+  negotiateStaticEncodings(header).map((candidate) => candidate.encoding);
+
+describe("negotiateStaticEncodings", () => {
+  it("treats a missing or empty header as identity-only (RFC 9110 §12.5.3)", () => {
+    expect(encodings(undefined)).toEqual([]);
+    expect(encodings("")).toEqual([]);
+  });
+
+  it("prefers brotli over gzip when both are accepted", () => {
+    expect(encodings("gzip, br")).toEqual(["br", "gzip"]);
+    expect(encodings("br, gzip")).toEqual(["br", "gzip"]);
+  });
+
+  it("lets a specific q=0 exclusion outrank the wildcard", () => {
+    expect(encodings("br;q=0, *")).toEqual(["gzip"]);
+    expect(encodings("gzip;q=0, *")).toEqual(["br"]);
+    expect(encodings("br;q=0, gzip;q=0, *")).toEqual([]);
+  });
+
+  it("honors q=0 exclusions without a wildcard", () => {
+    expect(encodings("gzip, br;q=0")).toEqual(["gzip"]);
+    expect(encodings("gzip;q=0, br;q=0")).toEqual([]);
+  });
+
+  it("accepts everything via wildcard and nothing via excluded wildcard", () => {
+    expect(encodings("*")).toEqual(["br", "gzip"]);
+    expect(encodings("*;q=0")).toEqual([]);
+  });
+
+  it("ignores unknown encodings and rejects malformed q parameters", () => {
+    expect(encodings("x-gzip, deflate")).toEqual([]);
+    expect(encodings("identity")).toEqual([]);
+    // Out-of-grammar weights are not valid qvalues, so the entry is ignored
+    // rather than treated as fully acceptable.
+    expect(encodings("gzip;q=")).toEqual([]);
+    expect(encodings("gzip;q=2")).toEqual([]);
+    expect(encodings("gzip;q=bogus")).toEqual([]);
+    expect(encodings("gzip;q=1.0001")).toEqual([]);
+  });
+
+  it("ranks by client weight before server preference", () => {
+    expect(encodings("br;q=0.1, gzip;q=1")).toEqual(["gzip", "br"]);
+    expect(encodings("br;q=1, gzip;q=0.5")).toEqual(["br", "gzip"]);
+    // Equal weights fall back to server preference (brotli first).
+    expect(encodings("gzip;q=0.5, br;q=0.5")).toEqual(["br", "gzip"]);
+    // An explicit weight beats the wildcard for the same encoding.
+    expect(encodings("*;q=1, br;q=0.2")).toEqual(["gzip", "br"]);
+  });
+
+  it("parses whitespace and case variations", () => {
+    expect(encodings(" GZip ;q=1.0 , BR ")).toEqual(["br", "gzip"]);
+  });
+});
+
+describe("negotiateStaticEncodingPreference identity handling", () => {
+  const identityOk = (header: string | undefined) =>
+    negotiateStaticEncodingPreference(header).identityAcceptable;
+
+  const ranking = (header: string | undefined) =>
+    negotiateStaticEncodingPreference(header).candidates.map(
+      (candidate) => candidate?.encoding ?? "identity",
+    );
+
+  it("ranks identity among the codings rather than as a fallback", () => {
+    // A client preferring identity must not be handed a lower-ranked sidecar.
+    expect(ranking("gzip;q=0.1, identity;q=1")).toEqual(["identity", "gzip"]);
+    expect(ranking("gzip;q=1, identity;q=0.1")).toEqual(["gzip", "identity"]);
+    // Equal weights keep the smaller body first.
+    expect(ranking("gzip;q=1, identity;q=1")).toEqual(["gzip", "identity"]);
+    expect(ranking(undefined)).toEqual(["identity"]);
+  });
+
+  it("rejects q parameters with whitespace around the equals sign", () => {
+    // `q =0` is not a q-parameter: defaulting it to 1 would serve the very
+    // encoding the client was trying to refuse.
+    expect(ranking("gzip;q =0")).toEqual(["identity"]);
+    expect(ranking("gzip;q= 0.5")).toEqual(["identity"]);
+  });
+
+  it("treats identity as acceptable unless explicitly excluded", () => {
+    expect(identityOk(undefined)).toBe(true);
+    expect(identityOk("gzip, br")).toBe(true);
+    expect(identityOk("identity;q=0")).toBe(false);
+    expect(identityOk("*;q=0")).toBe(false);
+    // An explicit identity weight outranks a zero wildcard.
+    expect(identityOk("*;q=0, identity;q=1")).toBe(true);
+  });
+});
+
+describe("staticCacheControl", () => {
+  it("tiers hashed assets, icon sets, and revalidating files", () => {
+    expect(staticCacheControl("assets/app-abc123.js")).toBe(STATIC_IMMUTABLE_CACHE_CONTROL);
+    expect(staticCacheControl("central-icons-reversed/file.svg")).toBe(STATIC_ICON_CACHE_CONTROL);
+    expect(staticCacheControl("central-icons-fill/file.svg")).toBe(STATIC_ICON_CACHE_CONTROL);
+    expect(staticCacheControl("index.html")).toBe(STATIC_REVALIDATE_CACHE_CONTROL);
+    expect(staticCacheControl("manifest.webmanifest")).toBe(STATIC_REVALIDATE_CACHE_CONTROL);
+  });
+
+  it("normalizes Windows separators before matching", () => {
+    expect(staticCacheControl("assets\\app-abc123.js")).toBe(STATIC_IMMUTABLE_CACHE_CONTROL);
+  });
+});
+
+describe("isSidecarRequestPath", () => {
+  it("flags sidecar extensions and nothing else", () => {
+    expect(isSidecarRequestPath("assets/app.js.br")).toBe(true);
+    expect(isSidecarRequestPath("assets/app.js.gz")).toBe(true);
+    // Case-insensitive filesystems resolve .BR/.GZ to the real sidecar.
+    expect(isSidecarRequestPath("assets/app.js.BR")).toBe(true);
+    expect(isSidecarRequestPath("assets/app.js.Gz")).toBe(true);
+    expect(isSidecarRequestPath("assets/app.js")).toBe(false);
+    expect(isSidecarRequestPath("archive.tar.gz.txt")).toBe(false);
+  });
+});
+
+describe("ifNoneMatchSatisfies", () => {
+  const etag = 'W/"3e8-18b2a4c5d00"';
+
+  it("matches a single tag, a list member, and the wildcard", () => {
+    expect(ifNoneMatchSatisfies(etag, etag)).toBe(true);
+    // RFC 9110 weak comparison ignores the W/ prefix on either side.
+    expect(ifNoneMatchSatisfies(etag.slice(2), etag)).toBe(true);
+    expect(ifNoneMatchSatisfies(`W/"other", ${etag.slice(2)}`, etag)).toBe(true);
+    expect(ifNoneMatchSatisfies(`W/"other", ${etag}`, etag)).toBe(true);
+    expect(ifNoneMatchSatisfies("*", etag)).toBe(true);
+  });
+
+  it("rejects absent headers and non-matching lists", () => {
+    expect(ifNoneMatchSatisfies(undefined, etag)).toBe(false);
+    expect(ifNoneMatchSatisfies("", etag)).toBe(false);
+    expect(ifNoneMatchSatisfies('W/"other-a", W/"other-b"', etag)).toBe(false);
+  });
+});
+
+describe("staticEtag", () => {
+  it("differs per encoding so Vary-keyed caches never collide validators", () => {
+    const identity = staticEtag(1000, 1_700_000_000_000);
+    const brotli = staticEtag(1000, 1_700_000_000_000, "br");
+    const gzipTag = staticEtag(1000, 1_700_000_000_000, "gzip");
+    expect(new Set([identity, brotli, gzipTag]).size).toBe(3);
+    expect(identity.startsWith('W/"')).toBe(true);
+  });
+
+  it("changes when size or mtime changes", () => {
+    const base = staticEtag(1000, 1_700_000_000_000);
+    expect(staticEtag(1001, 1_700_000_000_000)).not.toBe(base);
+    expect(staticEtag(1000, 1_700_000_000_001)).not.toBe(base);
+  });
+});

--- a/apps/server/src/staticAssets.ts
+++ b/apps/server/src/staticAssets.ts
@@ -1,0 +1,165 @@
+// Serving policy for the built web bundle (GET * static route): precompressed
+// sidecar negotiation and cache headers. Sidecars (.br/.gz) are emitted at
+// build time by apps/web's Vite precompress plugin — the server never
+// compresses on the request path.
+
+export const STATIC_IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+// Non-hashed files (index.html, manifests) must revalidate so deploys take
+// effect on the next load.
+export const STATIC_REVALIDATE_CACHE_CONTROL = "no-cache";
+// Icon sets have stable names but change only on dependency bumps, and the UI
+// requests thousands of them per session; a bounded max-age keeps them out of
+// the per-load revalidation path without an eternal-cache deploy hazard.
+export const STATIC_ICON_CACHE_CONTROL = "public, max-age=86400";
+
+const ICON_DIRECTORY_PREFIXES = ["central-icons-reversed/", "central-icons-fill/"];
+
+// Vite writes content-hashed filenames under assets/; everything else
+// (index.html, public/ files) keeps a stable name and must revalidate.
+export function staticCacheControl(relativePath: string): string {
+  const normalized = relativePath.replaceAll("\\", "/");
+  if (normalized.startsWith("assets/")) return STATIC_IMMUTABLE_CACHE_CONTROL;
+  if (ICON_DIRECTORY_PREFIXES.some((prefix) => normalized.startsWith(prefix))) {
+    return STATIC_ICON_CACHE_CONTROL;
+  }
+  return STATIC_REVALIDATE_CACHE_CONTROL;
+}
+
+export interface StaticEncodingCandidate {
+  readonly encoding: "br" | "gzip";
+  readonly sidecarExtension: ".br" | ".gz";
+}
+
+// Server preference order: brotli beats gzip when both are accepted.
+const STATIC_ENCODING_CANDIDATES: readonly StaticEncodingCandidate[] = [
+  { encoding: "br", sidecarExtension: ".br" },
+  { encoding: "gzip", sidecarExtension: ".gz" },
+];
+
+// RFC 9110 §12.4.2: qvalue is 0..1 with at most three decimals. Anything
+// outside that grammar is not a valid weight, so the entry is ignored rather
+// than silently treated as acceptable.
+const QVALUE_PATTERN = /^(?:0(?:\.\d{0,3})?|1(?:\.0{0,3})?)$/;
+
+// RFC 9110 §5.6.6 permits no whitespace around the parameter `=`, so `q =0`
+// and `q= 0.5` are not q-parameters. Treating them loosely is worse than
+// strict: `gzip;q =0` would silently default gzip to weight 1 and serve the
+// client the encoding it was trying to refuse.
+function parseQValue(rawParams: readonly string[]): number | null {
+  for (const param of rawParams) {
+    const normalized = param.trim().toLowerCase();
+    const separator = normalized.indexOf("=");
+    if (separator < 0) continue;
+    const name = normalized.slice(0, separator);
+    // Only a q-parameter decides the weight; other parameters are ignored.
+    if (name.trimEnd() !== "q") continue;
+    const value = normalized.slice(separator + 1);
+    // Whitespace around `=` makes this malformed rather than absent: falling
+    // back to the default weight would serve the very encoding a client wrote
+    // `q =0` to refuse.
+    if (name !== "q" || value !== value.trim()) return null;
+    return QVALUE_PATTERN.test(value) ? Number.parseFloat(value) : null;
+  }
+  return 1;
+}
+
+export interface StaticEncodingPreference {
+  /**
+   * Encodings to try in order, best-weighted first. `null` marks identity's
+   * position in the ranking: a client weighting identity above a coding gets
+   * the uncompressed body rather than a sidecar it ranked lower.
+   */
+  readonly candidates: readonly (StaticEncodingCandidate | null)[];
+  /** False when the client excluded identity (`identity;q=0` or `*;q=0`). */
+  readonly identityAcceptable: boolean;
+}
+
+/**
+ * Ranks every coding — identity included — by client weight per RFC 9110
+ * §12.5.3. A missing header means only identity is reliably acceptable.
+ * Explicit weights beat the `*` wildcard, q=0 excludes, and server preference
+ * (brotli, then gzip, then identity) breaks ties. When nothing is acceptable
+ * the caller answers 406 rather than sending a body the client refused.
+ */
+export function negotiateStaticEncodingPreference(
+  acceptEncoding: string | undefined,
+): StaticEncodingPreference {
+  if (!acceptEncoding) return { candidates: [null], identityAcceptable: true };
+  const explicit = new Map<string, number>();
+  for (const rawEntry of acceptEncoding.split(",")) {
+    const [rawName, ...rawParams] = rawEntry.trim().split(";");
+    const name = rawName?.trim().toLowerCase();
+    if (!name) continue;
+    const weight = parseQValue(rawParams);
+    if (weight === null) continue;
+    // First occurrence wins; a repeated name is a malformed header.
+    if (!explicit.has(name)) explicit.set(name, weight);
+  }
+  const wildcard = explicit.get("*");
+  // Identity is acceptable by default (§12.5.3) unless a weight excludes it.
+  const identityWeight = explicit.get("identity") ?? wildcard ?? 1;
+  const ranked: {
+    readonly candidate: StaticEncodingCandidate | null;
+    readonly weight: number;
+    readonly preference: number;
+  }[] = [
+    ...STATIC_ENCODING_CANDIDATES.map((candidate, index) => ({
+      candidate: candidate as StaticEncodingCandidate | null,
+      weight: explicit.get(candidate.encoding) ?? wildcard ?? 0,
+      preference: index,
+    })),
+    // Identity ranks last among equals: a client that weights it the same as
+    // a coding still gets the smaller body.
+    { candidate: null, weight: identityWeight, preference: STATIC_ENCODING_CANDIDATES.length },
+  ];
+
+  return {
+    candidates: ranked
+      .filter((entry) => entry.weight > 0)
+      .sort((a, b) => b.weight - a.weight || a.preference - b.preference)
+      .map((entry) => entry.candidate),
+    identityAcceptable: identityWeight > 0,
+  };
+}
+
+/** Convenience wrapper for callers that only need the ranked sidecar codings. */
+export function negotiateStaticEncodings(
+  acceptEncoding: string | undefined,
+): readonly StaticEncodingCandidate[] {
+  return negotiateStaticEncodingPreference(acceptEncoding).candidates.filter(
+    (candidate): candidate is StaticEncodingCandidate => candidate !== null,
+  );
+}
+
+// Sidecars are a negotiation detail, never addressable resources: a direct
+// request for one would serve compressed bytes with identity encoding and a
+// misleading MIME type. Matched case-insensitively because case-insensitive
+// filesystems (macOS default) resolve `app.js.BR` to the real sidecar.
+export function isSidecarRequestPath(relativePath: string): boolean {
+  const lowered = relativePath.toLowerCase();
+  return lowered.endsWith(".br") || lowered.endsWith(".gz");
+}
+
+// RFC 9110 §13.1.2 with §8.8.3.2 weak comparison: If-None-Match is a
+// comma-separated list of entity tags or the wildcard, and the `W/` prefix is
+// ignored on both sides — a client that stored the strong form of a tag we
+// emitted weak still gets its 304.
+function opaqueTag(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.startsWith("W/") ? trimmed.slice(2) : trimmed;
+}
+
+export function ifNoneMatchSatisfies(headerValue: string | undefined, etag: string): boolean {
+  if (!headerValue) return false;
+  const trimmed = headerValue.trim();
+  if (trimmed === "*") return true;
+  const target = opaqueTag(etag);
+  return trimmed.split(",").some((candidate) => opaqueTag(candidate) === target);
+}
+
+// Weak validator derived from the served file's identity (size + mtime). Must
+// be computed from the sidecar when a sidecar is served: a shared cache keyed
+// on Vary: Accept-Encoding still requires validators to differ per encoding.
+export function staticEtag(size: number, mtimeMs: number, encoding?: string): string {
+  return `W/"${size.toString(16)}-${Math.trunc(mtimeMs).toString(16)}${encoding ? `-${encoding}` : ""}"`;
+}

--- a/apps/server/src/wsCompatibility.ts
+++ b/apps/server/src/wsCompatibility.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import {
   WS_COMPATIBILITY_QUERY,
+  WS_NEGOTIATE_QUERY,
   WS_PROTOCOL_EPOCH,
   WS_PROTOCOL_MAX_REVISION,
   WS_PROTOCOL_MIN_REVISION,
@@ -82,6 +83,48 @@ export function negotiateWsCompatibility(
     serverInstanceId,
     capabilities: [...WS_SERVER_CAPABILITIES],
   });
+}
+
+// The HTTP negotiate endpoint carries the same input as bootstrap.negotiate,
+// flattened into query params so the request stays a cacheable-free plain GET
+// with no body to decode before the compatibility gate runs.
+// Decimal digits only. `Number()` would accept "0x1" and "1e0", which the RPC
+// path's Schema.Int rejects — the two transports must decode identically or
+// "one negotiation, two transports" is only true for well-formed clients.
+function parseDecimalInteger(raw: string | null): number | null {
+  // No trimming: surrounding whitespace (including a `+` that decodes to a
+  // space) is not a well-formed integer on either transport.
+  if (raw === null || !/^\d+$/.test(raw)) return null;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+export function parseWsNegotiateSearchParams(
+  searchParams: URLSearchParams,
+): WsBootstrapNegotiateInput | WsCompatibilityError {
+  const protocolEpoch = parseDecimalInteger(searchParams.get(WS_NEGOTIATE_QUERY.protocolEpoch));
+  const minRevision = parseDecimalInteger(searchParams.get(WS_NEGOTIATE_QUERY.minRevision));
+  const maxRevision = parseDecimalInteger(searchParams.get(WS_NEGOTIATE_QUERY.maxRevision));
+  const clientBuild = searchParams.get(WS_NEGOTIATE_QUERY.clientBuild)?.trim() ?? "";
+  if (
+    protocolEpoch === null ||
+    minRevision === null ||
+    maxRevision === null ||
+    clientBuild.length === 0
+  ) {
+    return incompatibility(
+      "reload",
+      "WebSocket negotiation request is missing required parameters.",
+      "WS_NEGOTIATION_REQUIRED",
+    );
+  }
+  return {
+    protocolEpoch,
+    minRevision,
+    maxRevision,
+    clientBuild,
+    requiredCapabilities: searchParams.getAll(WS_NEGOTIATE_QUERY.requiredCapability),
+  };
 }
 
 export function validateWsFeatureCompatibility(

--- a/apps/server/src/wsRpc.connectionLifecycle.test.ts
+++ b/apps/server/src/wsRpc.connectionLifecycle.test.ts
@@ -59,9 +59,12 @@ afterEach(() => {
   openSockets.clear();
 });
 
-function connect(url: string): Promise<WebSocket> {
+function connect(
+  url: string,
+  options?: { readonly perMessageDeflate?: boolean },
+): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
-    const socket = new WebSocket(url, { perMessageDeflate: false });
+    const socket = new WebSocket(url, { perMessageDeflate: options?.perMessageDeflate ?? false });
     openSockets.add(socket);
     socket.once("open", () => resolve(socket));
     socket.once("error", reject);
@@ -122,11 +125,13 @@ function makeRpcFrame(totalBytes: number, requestId: string): string {
 function sendFragment(
   socket: WebSocket,
   data: string,
-  options: { readonly fin: boolean },
+  options: { readonly fin: boolean; readonly compress?: boolean },
 ): Promise<void> {
   return new Promise((resolve, reject) => {
-    socket.send(data, { binary: false, compress: false, fin: options.fin }, (error) =>
-      error ? reject(error) : resolve(),
+    socket.send(
+      data,
+      { binary: false, compress: options.compress ?? false, fin: options.fin },
+      (error) => (error ? reject(error) : resolve()),
     );
   });
 }
@@ -273,9 +278,20 @@ async function startTestServer(): Promise<RunningTestServer> {
       ),
     ),
   );
-  const routeLayer = makeWebsocketRpcRouteLayer(rpcHttpEffectSource).pipe(
-    Layer.provide(Layer.succeed(WsConnectionSessions, connectionSessions)),
+  // Minimal bootstrap-path route: which underlying ws server (compressed vs
+  // uncompressed) handles an upgrade is decided by path in nodeHttpServer, so
+  // the route handler itself can be the plain RPC effect.
+  const bootstrapRouteLayer = Layer.effectDiscard(
+    Effect.gen(function* () {
+      const httpEffect = yield* rpcHttpEffectSource;
+      const router = yield* HttpRouter.HttpRouter;
+      yield* router.add("GET", "/ws/bootstrap", httpEffect);
+    }),
   );
+  const routeLayer = Layer.merge(
+    makeWebsocketRpcRouteLayer(rpcHttpEffectSource),
+    bootstrapRouteLayer,
+  ).pipe(Layer.provide(Layer.succeed(WsConnectionSessions, connectionSessions)));
   const scope = await Effect.runPromise(Scope.make("sequential"));
   const context = await Effect.runPromise(
     Layer.buildWithScope(
@@ -321,6 +337,7 @@ async function startTestServer(): Promise<RunningTestServer> {
 async function connectSession(
   server: RunningTestServer,
   ttl?: Duration.Duration,
+  options?: { readonly perMessageDeflate?: boolean },
 ): Promise<{
   readonly sessionId: AuthSessionId;
   readonly token: string;
@@ -328,7 +345,7 @@ async function connectSession(
 }> {
   const issued = await Effect.runPromise(server.sessions.issue(ttl ? { ttl } : undefined));
   const websocket = await Effect.runPromise(server.sessions.issueWebSocketToken(issued.sessionId));
-  const socket = await connect(featureSocketUrl(server, websocket.token));
+  const socket = await connect(featureSocketUrl(server, websocket.token), options);
   return { sessionId: issued.sessionId, token: websocket.token, socket };
 }
 
@@ -464,6 +481,122 @@ describe("websocket RPC payload admission", () => {
 
       await expect(close).resolves.toMatchObject({ code: 1009 });
       await waitForObserved(() => server.transportFinalizers.count >= finalizersBefore + 1);
+      expect(server.observedRpc).toEqual({ decoderCalls: 0, handlerCalls: 0 });
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe("websocket permessage-deflate negotiation", () => {
+  it("never negotiates compression on the pre-auth bootstrap socket", async () => {
+    const server = await startTestServer();
+    try {
+      // Offer compression on the bootstrap path: the server must decline the
+      // extension (compression is a post-authentication privilege; pre-auth
+      // connections must not be able to multiply per-connection zlib memory).
+      const bootstrapSocket = await connect(`${server.origin}/ws/bootstrap`, {
+        perMessageDeflate: true,
+      });
+      expect(bootstrapSocket.extensions).not.toContain("permessage-deflate");
+      bootstrapSocket.terminate();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("declines compression on every spelling the router still routes to bootstrap", async () => {
+    const server = await startTestServer();
+    try {
+      // The router matches case-insensitively and normalizes duplicate
+      // slashes, percent-encoding, and `;params`; the upgrade dispatcher must
+      // use the same semantics or an alias would reach bootstrap compressed.
+      for (const alias of [
+        "/WS/BOOTSTRAP",
+        "/ws//bootstrap",
+        "/ws/%62ootstrap",
+        "/ws/bootstrap;sid=1",
+        // Absolute-form targets cannot be expressed through a ws:// client
+        // URL; nodeHttpServer.upgradePath.test.ts covers them directly.
+      ]) {
+        const socket = await connect(`${server.origin}${alias}`, { perMessageDeflate: true });
+        expect(socket.extensions, alias).not.toContain("permessage-deflate");
+        socket.terminate();
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("closes a fragmented compressed message whose decompressed aggregate crosses the ceiling", async () => {
+    const server = await startTestServer();
+    try {
+      const connected = await connectSession(server, undefined, { perMessageDeflate: true });
+      expect(connected.socket.extensions).toContain("permessage-deflate");
+      const frame = makeRpcFrame(MAX_WEBSOCKET_MESSAGE_BYTES + 1, "204");
+      const splitAt = Math.floor(frame.length / 2);
+      const close = waitForCloseInfo(connected.socket);
+
+      await sendFragment(connected.socket, frame.slice(0, splitAt), {
+        fin: false,
+        compress: true,
+      });
+      void sendFragment(connected.socket, frame.slice(splitAt), {
+        fin: true,
+        compress: true,
+      }).catch(() => {});
+
+      await expect(close).resolves.toMatchObject({ code: 1009 });
+      expect(server.observedRpc).toEqual({ decoderCalls: 0, handlerCalls: 0 });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("negotiates compression when the client offers it and serves RPC over the compressed socket", async () => {
+    const server = await startTestServer();
+    try {
+      const connected = await connectSession(server, undefined, { perMessageDeflate: true });
+      expect(connected.socket.extensions).toContain("permessage-deflate");
+
+      const exit = waitForRpcExit(connected.socket, "201");
+      connected.socket.send(makeRpcFrame(256, "201"));
+      await exit;
+      expect(server.observedRpc).toEqual({ decoderCalls: 1, handlerCalls: 1 });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("still serves clients that do not offer compression", async () => {
+    const server = await startTestServer();
+    try {
+      const connected = await connectSession(server, undefined, { perMessageDeflate: false });
+      expect(connected.socket.extensions).not.toContain("permessage-deflate");
+
+      const exit = waitForRpcExit(connected.socket, "202");
+      connected.socket.send(makeRpcFrame(256, "202"), { binary: false, compress: false });
+      await exit;
+      expect(server.observedRpc).toEqual({ decoderCalls: 1, handlerCalls: 1 });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("enforces the payload ceiling on the decompressed size of a compressed message", async () => {
+    const server = await startTestServer();
+    try {
+      const connected = await connectSession(server, undefined, { perMessageDeflate: true });
+      expect(connected.socket.extensions).toContain("permessage-deflate");
+      const close = waitForCloseInfo(connected.socket);
+
+      // Highly compressible oversized frame: tiny on the wire, over the limit inflated.
+      connected.socket.send(makeRpcFrame(MAX_WEBSOCKET_MESSAGE_BYTES + 1, "203"), {
+        binary: false,
+        compress: true,
+      });
+
+      await expect(close).resolves.toMatchObject({ code: 1009 });
       expect(server.observedRpc).toEqual({ decoderCalls: 0, handlerCalls: 0 });
     } finally {
       await server.close();

--- a/apps/server/src/wsRpc.connectionLifecycle.test.ts
+++ b/apps/server/src/wsRpc.connectionLifecycle.test.ts
@@ -1,6 +1,17 @@
 import http from "node:http";
 
-import type { AuthSessionId } from "@synara/contracts";
+import {
+  WS_BOOTSTRAP_METHOD,
+  WS_BOOTSTRAP_PATH,
+  WS_COMPATIBILITY_QUERY,
+  WS_NEGOTIATE_HTTP_PATH,
+  WS_NEGOTIATE_QUERY,
+  WS_PROTOCOL_EPOCH,
+  WS_PROTOCOL_MAX_REVISION,
+  WS_PROTOCOL_MIN_REVISION,
+  type AuthSessionId,
+  type WsBootstrapNegotiateResult,
+} from "@synara/contracts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Duration, Effect, Exit, Layer, Schema, Scope } from "effect";
 import { HttpRouter, HttpServerRequest } from "effect/unstable/http";
@@ -21,7 +32,7 @@ import {
 import { ServerConfig } from "./config";
 import { makeBoundedNodeHttpServer, MAX_WEBSOCKET_MESSAGE_BYTES } from "./nodeHttpServer";
 import { SqlitePersistenceMemory } from "./persistence/Layers/Sqlite";
-import { makeWebsocketRpcRouteLayer } from "./wsRpc";
+import { makeWebsocketNegotiationRouteLayer, makeWebsocketRpcRouteLayer } from "./wsRpc";
 import {
   makeWsConnectionSessions,
   WS_CONNECTION_SESSION_HEADER,
@@ -278,19 +289,12 @@ async function startTestServer(): Promise<RunningTestServer> {
       ),
     ),
   );
-  // Minimal bootstrap-path route: which underlying ws server (compressed vs
-  // uncompressed) handles an upgrade is decided by path in nodeHttpServer, so
-  // the route handler itself can be the plain RPC effect.
-  const bootstrapRouteLayer = Layer.effectDiscard(
-    Effect.gen(function* () {
-      const httpEffect = yield* rpcHttpEffectSource;
-      const router = yield* HttpRouter.HttpRouter;
-      yield* router.add("GET", "/ws/bootstrap", httpEffect);
-    }),
-  );
+  // The negotiation layer owns WS_BOOTSTRAP_PATH, which the compression tests
+  // also need: which underlying ws server (compressed vs uncompressed) handles
+  // an upgrade is decided by path in nodeHttpServer.
   const routeLayer = Layer.merge(
+    makeWebsocketNegotiationRouteLayer(),
     makeWebsocketRpcRouteLayer(rpcHttpEffectSource),
-    bootstrapRouteLayer,
   ).pipe(Layer.provide(Layer.succeed(WsConnectionSessions, connectionSessions)));
   const scope = await Effect.runPromise(Scope.make("sequential"));
   const context = await Effect.runPromise(
@@ -364,6 +368,36 @@ function featureSocketUrl(server: RunningTestServer, token: string): string {
   return `${server.origin}/ws?${searchParams.toString()}`;
 }
 
+function negotiateHttpUrl(
+  server: RunningTestServer,
+  overrides?: Readonly<Record<string, string>>,
+): string {
+  const searchParams = new URLSearchParams({
+    [WS_NEGOTIATE_QUERY.clientBuild]: "test-client",
+    [WS_NEGOTIATE_QUERY.protocolEpoch]: String(WS_PROTOCOL_EPOCH),
+    [WS_NEGOTIATE_QUERY.minRevision]: String(WS_PROTOCOL_MIN_REVISION),
+    [WS_NEGOTIATE_QUERY.maxRevision]: String(WS_PROTOCOL_MAX_REVISION),
+    ...overrides,
+  });
+  const httpOrigin = server.origin.replace(/^ws:/, "http:");
+  return `${httpOrigin}${WS_NEGOTIATE_HTTP_PATH}?${searchParams.toString()}`;
+}
+
+function featureSocketUrlFromNegotiation(
+  server: RunningTestServer,
+  negotiation: WsBootstrapNegotiateResult,
+  token: string,
+): string {
+  const searchParams = new URLSearchParams({
+    [WS_COMPATIBILITY_QUERY.clientBuild]: "test-client",
+    [WS_COMPATIBILITY_QUERY.protocolEpoch]: String(negotiation.protocolEpoch),
+    [WS_COMPATIBILITY_QUERY.protocolRevision]: String(negotiation.negotiatedRevision),
+    [WS_COMPATIBILITY_QUERY.serverInstanceId]: negotiation.serverInstanceId,
+    wsToken: token,
+  });
+  return `${server.origin}/ws?${searchParams.toString()}`;
+}
+
 async function waitForObserved(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (!predicate()) {
@@ -388,6 +422,173 @@ describe("websocket RPC payload admission", () => {
 
       const admitted = await connect(featureSocketUrl(server, websocket.token));
       await expect(ping(admitted)).resolves.toBeUndefined();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("negotiates over HTTP and admits the feature socket in one WebSocket handshake", async () => {
+    const server = await startTestServer();
+    try {
+      const response = await fetch(negotiateHttpUrl(server));
+      expect(response.status).toBe(200);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      const negotiation = (await response.json()) as WsBootstrapNegotiateResult;
+      expect(negotiation).toMatchObject({
+        protocolEpoch: WS_PROTOCOL_EPOCH,
+        negotiatedRevision: WS_PROTOCOL_MAX_REVISION,
+      });
+      expect(negotiation.serverInstanceId.length).toBeGreaterThan(0);
+      expect(negotiation.capabilities).toContain("transport.http-negotiate");
+
+      const issued = await Effect.runPromise(server.sessions.issue());
+      const websocket = await Effect.runPromise(
+        server.sessions.issueWebSocketToken(issued.sessionId),
+      );
+      const socket = await connect(
+        featureSocketUrlFromNegotiation(server, negotiation, websocket.token),
+      );
+      await expect(ping(socket)).resolves.toBeUndefined();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("refuses HTTP negotiation with 426 for missing or incompatible parameters", async () => {
+    const server = await startTestServer();
+    try {
+      const missing = await fetch(
+        `${server.origin.replace(/^ws:/, "http:")}${WS_NEGOTIATE_HTTP_PATH}`,
+      );
+      expect(missing.status).toBe(426);
+      expect(await missing.json()).toMatchObject({
+        code: "WS_NEGOTIATION_REQUIRED",
+        retryable: false,
+      });
+
+      const staleEpoch = await fetch(
+        negotiateHttpUrl(server, {
+          [WS_NEGOTIATE_QUERY.protocolEpoch]: String(WS_PROTOCOL_EPOCH - 1),
+        }),
+      );
+      expect(staleEpoch.status).toBe(426);
+      expect(await staleEpoch.json()).toMatchObject({
+        code: "WS_PROTOCOL_INCOMPATIBLE",
+        retryable: false,
+        action: "update-client",
+      });
+
+      const missingCapability = await fetch(
+        negotiateHttpUrl(server, {
+          [WS_NEGOTIATE_QUERY.requiredCapability]: "rpc.future-capability",
+        }),
+      );
+      expect(missingCapability.status).toBe(426);
+      expect(await missingCapability.json()).toMatchObject({
+        code: "WS_CAPABILITIES_INCOMPATIBLE",
+        retryable: false,
+        action: "update-server",
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("gates HTTP negotiation on trusted origins and reflects CORS for none else", async () => {
+    const server = await startTestServer();
+    try {
+      // An untrusted origin must be refused before any negotiation data is
+      // produced, and must never see an Access-Control-Allow-Origin header.
+      const untrusted = await fetch(negotiateHttpUrl(server), {
+        headers: { origin: "http://evil.example" },
+      });
+      expect(untrusted.status).toBe(403);
+      expect(untrusted.headers.get("access-control-allow-origin")).toBeNull();
+      expect(untrusted.headers.get("cache-control")).toBe("no-store");
+      expect(untrusted.headers.get("vary")).toBe("Origin");
+
+      // A lookalike of the desktop scheme is not the desktop scheme.
+      const lookalike = await fetch(negotiateHttpUrl(server), {
+        headers: { origin: "synara://app.evil.com" },
+      });
+      expect(lookalike.status).toBe(403);
+      expect(lookalike.headers.get("access-control-allow-origin")).toBeNull();
+
+      // The desktop origin is reflected, and only that origin.
+      const desktop = await fetch(negotiateHttpUrl(server), {
+        headers: { origin: "synara://app" },
+      });
+      expect(desktop.status).toBe(200);
+      expect(desktop.headers.get("access-control-allow-origin")).toBe("synara://app");
+      expect(desktop.headers.get("vary")).toBe("Origin");
+
+      // No Origin at all (CLI clients) passes without reflection, matching
+      // the WS upgrade's own behavior.
+      const noOrigin = await fetch(negotiateHttpUrl(server));
+      expect(noOrigin.status).toBe(200);
+      expect(noOrigin.headers.get("access-control-allow-origin")).toBeNull();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects numeric negotiation params the RPC schema would reject", async () => {
+    const server = await startTestServer();
+    try {
+      // Number() accepts hex and exponential notation; Schema.Int does not.
+      // The two transports must decode identically.
+      for (const raw of ["0x1", "1e0", " 1 ", "+1", "1.0"]) {
+        const response = await fetch(
+          negotiateHttpUrl(server, { [WS_NEGOTIATE_QUERY.minRevision]: raw }),
+        );
+        expect(response.status, raw).toBe(426);
+        expect(await response.json(), raw).toMatchObject({ code: "WS_NEGOTIATION_REQUIRED" });
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("keeps the legacy bootstrap socket negotiating for older clients", async () => {
+    const server = await startTestServer();
+    try {
+      const socket = await connect(`${server.origin}${WS_BOOTSTRAP_PATH}`);
+      const exit = new Promise<Record<string, unknown>>((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error("Timed out waiting for bootstrap negotiation exit")),
+          2_000,
+        );
+        socket.on("message", (data: RawData) => {
+          const frame = JSON.parse(data.toString()) as Record<string, unknown>;
+          if (frame._tag !== "Exit") return;
+          clearTimeout(timeout);
+          resolve(frame);
+        });
+      });
+      socket.send(
+        JSON.stringify({
+          _tag: "Request",
+          id: "1",
+          tag: WS_BOOTSTRAP_METHOD,
+          payload: {
+            protocolEpoch: WS_PROTOCOL_EPOCH,
+            minRevision: WS_PROTOCOL_MIN_REVISION,
+            maxRevision: WS_PROTOCOL_MAX_REVISION,
+            clientBuild: "legacy-client",
+            requiredCapabilities: [],
+          },
+          headers: [],
+        }),
+      );
+
+      const frame = await exit;
+      expect(frame.exit).toMatchObject({
+        _tag: "Success",
+        value: {
+          protocolEpoch: WS_PROTOCOL_EPOCH,
+          negotiatedRevision: WS_PROTOCOL_MAX_REVISION,
+        },
+      });
     } finally {
       await server.close();
     }

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -897,6 +897,22 @@ const makeWsRpcHandlersLayer = () =>
               threadId: input.threadId,
             },
             makeCursorSafeSnapshotLiveStream({
+              // Cursor resume: a client holding cached detail replays only the
+              // gap. Out-of-range cursors (negative or overflowing gap) fall
+              // back to the snapshot inside the stream factory.
+              resumeFromSequence: input.afterSequence,
+              // A hard-purged thread leaves no rows to replay while the journal
+              // head stays above the cursor, so the gap check alone would
+              // accept the resume and stream nothing. Falling through to the
+              // snapshot path surfaces THREAD_SNAPSHOT_NOT_FOUND instead.
+              resumeSubjectExists: projectionReadModelQuery
+                .getThreadDetailSnapshotById(input.threadId)
+                .pipe(
+                  Effect.map(Option.isSome),
+                  Effect.mapError((cause) =>
+                    toWsRpcError(cause, "Failed to verify thread before cursor resume"),
+                  ),
+                ),
               onResnapshotRequired: (report) =>
                 recordThreadResnapshotRequired(input.threadId, report),
               subscribeLive: orchestrationEngine.subscribeDomainEvents.pipe(

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -8,8 +8,10 @@ import {
   WS_BOOTSTRAP_METHOD,
   WS_BOOTSTRAP_PATH,
   WS_FEATURE_PATH,
+  WS_NEGOTIATE_HTTP_PATH,
   WS_METHODS,
   WsBootstrapRpcGroup,
+  WsCompatibilityError,
   WsFeatureRpcGroup,
   WsRpcError,
   PullRequestsUnavailableError,
@@ -112,8 +114,14 @@ import {
   WsConnectionSessionsLive,
   type WsConnectionSession,
 } from "./wsConnectionSessions";
-import { negotiateWsCompatibility, validateWsFeatureCompatibility } from "./wsCompatibility";
 import {
+  negotiateWsCompatibility,
+  parseWsNegotiateSearchParams,
+  validateWsFeatureCompatibility,
+} from "./wsCompatibility";
+import {
+  isTrustedAppOrigin,
+  normalizeCorsOrigin,
   requiresWebSocketAuthentication,
   shouldRejectUntrustedRequestOrigin,
 } from "./trustedOrigins";
@@ -1849,6 +1857,53 @@ export function makeWebsocketRpcRouteLayer<R>(
   );
 }
 
+// Negotiation over plain HTTP: a connect costs exactly one WebSocket upgrade
+// instead of the legacy bootstrap-socket round trip. Advertised to clients via
+// the "transport.http-negotiate" capability; the WS_BOOTSTRAP_PATH socket stays
+// available for older clients during rollout.
+function makeWsNegotiateHttpRouteLayer() {
+  return Layer.effectDiscard(
+    Effect.gen(function* () {
+      const router = yield* HttpRouter.HttpRouter;
+      yield* router.add(
+        "GET",
+        WS_NEGOTIATE_HTTP_PATH,
+        Effect.gen(function* () {
+          const request = yield* HttpServerRequest.HttpServerRequest;
+          const config = yield* ServerConfig;
+          const url = trustedWebSocketRequestUrl(request, config);
+          if (!url) {
+            // Same no-store discipline as the negotiated responses: an
+            // intermediary must never cache a refusal keyed on our behalf.
+            return HttpServerResponse.text("Forbidden", {
+              status: 403,
+              headers: { "Cache-Control": "no-store", Vary: "Origin" },
+            });
+          }
+          // The desktop app fetches cross-origin (synara://app); reflect only
+          // origins the WS upgrade itself would trust.
+          const origin = normalizeCorsOrigin(request.headers.origin);
+          const corsHeaders =
+            origin && isTrustedAppOrigin({ origin, requestOrigin: url.origin, config })
+              ? { "Access-Control-Allow-Origin": origin, Vary: "Origin" }
+              : {};
+          const headers = { "Cache-Control": "no-store", ...corsHeaders };
+          const input = parseWsNegotiateSearchParams(url.searchParams);
+          if (input instanceof WsCompatibilityError) {
+            return HttpServerResponse.jsonUnsafe(input, { status: 426, headers });
+          }
+          return yield* negotiateWsCompatibility(input).pipe(
+            Effect.map((result) => HttpServerResponse.jsonUnsafe(result, { status: 200, headers })),
+            Effect.catch((error) =>
+              Effect.succeed(HttpServerResponse.jsonUnsafe(error, { status: 426, headers })),
+            ),
+          );
+        }),
+      );
+    }),
+  );
+}
+
 function makeWebsocketBootstrapRouteLayer<R>(
   bootstrapWebSocketHttpEffectSource: Effect.Effect<
     Effect.Effect<
@@ -1881,8 +1936,17 @@ function makeWebsocketBootstrapRouteLayer<R>(
   );
 }
 
+// Both negotiation surfaces: the single-handshake HTTP endpoint and the legacy
+// bootstrap socket kept for older clients during rollout. Exported separately
+// so route-level tests can mount them beside a custom feature RPC group.
+export const makeWebsocketNegotiationRouteLayer = () =>
+  Layer.merge(
+    makeWsNegotiateHttpRouteLayer(),
+    makeWebsocketBootstrapRouteLayer(makeBootstrapWebSocketHttpEffect),
+  );
+
 export const websocketRpcRouteLayer = Layer.merge(
-  makeWebsocketBootstrapRouteLayer(makeBootstrapWebSocketHttpEffect),
+  makeWebsocketNegotiationRouteLayer(),
   // The registry must be provided here so the upgrade route and the RPC
   // middleware (built from the same source effect) share one instance.
   makeWebsocketRpcRouteLayer(makeRpcWebSocketHttpEffect).pipe(

--- a/apps/server/src/wsSnapshotLiveStream.test.ts
+++ b/apps/server/src/wsSnapshotLiveStream.test.ts
@@ -1,5 +1,5 @@
 import type { OrchestrationEvent } from "@synara/contracts";
-import { Effect, PubSub, Stream } from "effect";
+import { Duration, Effect, PubSub, Stream } from "effect";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -70,6 +70,218 @@ describe("makeCursorSafeSnapshotLiveStream", () => {
       { kind: "event", event: event(2) },
       { kind: "event", event: event(3) },
     ]);
+  });
+
+  it("emits the snapshot before an event published during snapshot IO, losing nothing", async () => {
+    // Regression: the live subscription must attach before snapshot IO starts,
+    // so an event published while the (delayed) snapshot loads is delivered
+    // after the snapshot instead of being dropped or duplicated.
+    const items = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const live = yield* PubSub.unbounded<OrchestrationEvent>();
+          const publishedDuringSnapshot = event(2);
+          return yield* makeCursorSafeSnapshotLiveStream({
+            subscribeLive: PubSub.subscribe(live).pipe(
+              Effect.map((subscription) => Stream.fromEffectRepeat(PubSub.take(subscription))),
+            ),
+            snapshot: Effect.sleep(Duration.millis(20)).pipe(
+              Effect.andThen(PubSub.publish(live, publishedDuringSnapshot)),
+              Effect.as({ snapshotSequence: 1 }),
+            ),
+            snapshotSequence: (snapshot) => snapshot.snapshotSequence,
+            getHighWaterSequence: Effect.succeed(1),
+            replay: () => Stream.empty,
+          }).pipe(Stream.take(2), Stream.runCollect);
+        }),
+      ),
+    );
+
+    expect(Array.from(items)).toEqual([
+      { kind: "snapshot", snapshot: { snapshotSequence: 1 } },
+      { kind: "event", event: event(2) },
+    ]);
+    // A short deadline: when the attach ordering regresses, this test fails by
+    // losing the mid-snapshot event and would otherwise stall for the suite's
+    // full 90s default before reporting.
+  }, 15_000);
+
+  it("resumes from a cursor by replaying exactly the gap without a snapshot", async () => {
+    let snapshotLoaded = false;
+    let replayRange: readonly [number, number] | null = null;
+    const items = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const live = yield* PubSub.unbounded<OrchestrationEvent>();
+          const newerLive = event(6);
+          return yield* makeCursorSafeSnapshotLiveStream({
+            subscribeLive: PubSub.subscribe(live).pipe(
+              Effect.map((subscription) => Stream.fromEffectRepeat(PubSub.take(subscription))),
+            ),
+            snapshot: Effect.sync(() => {
+              snapshotLoaded = true;
+              return { snapshotSequence: 1 };
+            }),
+            snapshotSequence: (snapshot) => snapshot.snapshotSequence,
+            getHighWaterSequence: Effect.succeed(5),
+            resumeFromSequence: 3,
+            replay: (fromSequenceExclusive, throughSequenceInclusive) => {
+              replayRange = [fromSequenceExclusive, throughSequenceInclusive];
+              return Stream.concat(
+                Stream.fromEffect(PubSub.publish(live, newerLive)).pipe(Stream.drain),
+                Stream.make(event(4), event(5)),
+              );
+            },
+          }).pipe(Stream.take(3), Stream.runCollect);
+        }),
+      ),
+    );
+
+    expect(snapshotLoaded).toBe(false);
+    expect(replayRange).toEqual([3, 5]);
+    expect(Array.from(items)).toEqual([
+      { kind: "event", event: event(4) },
+      { kind: "event", event: event(5) },
+      { kind: "event", event: event(6) },
+    ]);
+  });
+
+  it("does not lose an event published while the resume path reads the durable head", async () => {
+    // The resume branch must share the snapshot path's attach-before-IO
+    // discipline: the live subscription attaches before the durable head is
+    // read, so an event published during that read lands in the live queue and
+    // is delivered after the gap replay instead of being lost. Moving the
+    // attach after the head read passes every other test in this file — only
+    // this probe catches it.
+    const items = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const live = yield* PubSub.unbounded<OrchestrationEvent>();
+          const publishedDuringHeadRead = event(6);
+          return yield* makeCursorSafeSnapshotLiveStream({
+            subscribeLive: PubSub.subscribe(live).pipe(
+              Effect.map((subscription) => Stream.fromEffectRepeat(PubSub.take(subscription))),
+            ),
+            snapshot: Effect.die(new Error("cursor resume must not load the snapshot")),
+            snapshotSequence: () => 0,
+            getHighWaterSequence: Effect.sleep(Duration.millis(20)).pipe(
+              Effect.andThen(PubSub.publish(live, publishedDuringHeadRead)),
+              Effect.as(5),
+            ),
+            resumeFromSequence: 3,
+            replay: () => Stream.make(event(4), event(5)),
+          }).pipe(Stream.take(3), Stream.runCollect);
+        }),
+      ),
+    );
+
+    expect(Array.from(items)).toEqual([
+      { kind: "event", event: event(4) },
+      { kind: "event", event: event(5) },
+      { kind: "event", event: event(6) },
+    ]);
+  }, 15_000);
+
+  it("falls back to the snapshot when the cursor gap exceeds the replay limit", async () => {
+    const replayRanges: Array<readonly [number, number]> = [];
+    const highWaterSequence = ORCHESTRATION_SNAPSHOT_REPLAY_LIMIT + 10;
+    const items = await Effect.runPromise(
+      Effect.scoped(
+        makeCursorSafeSnapshotLiveStream({
+          subscribeLive: Effect.succeed(Stream.empty),
+          snapshot: Effect.succeed({ snapshotSequence: highWaterSequence }),
+          snapshotSequence: (snapshot) => snapshot.snapshotSequence,
+          getHighWaterSequence: Effect.succeed(highWaterSequence),
+          resumeFromSequence: 1,
+          replay: (fromSequenceExclusive, throughSequenceInclusive) => {
+            replayRanges.push([fromSequenceExclusive, throughSequenceInclusive]);
+            return Stream.empty;
+          },
+        }).pipe(Stream.take(1), Stream.runCollect),
+      ),
+    );
+
+    // Only the snapshot-fence replay ran; the overflowing cursor gap was never replayed.
+    expect(replayRanges).toEqual([[highWaterSequence, highWaterSequence]]);
+    expect(Array.from(items)).toEqual([
+      { kind: "snapshot", snapshot: { snapshotSequence: highWaterSequence } },
+    ]);
+  });
+
+  it("falls back to the snapshot when the cursor is ahead of the durable head", async () => {
+    // A negative gap means the client cursor comes from a different event
+    // journal (restored backup / reset DB); resuming from it would silently
+    // skip history, so it must reset with a full snapshot.
+    const replayRanges: Array<readonly [number, number]> = [];
+    const items = await Effect.runPromise(
+      Effect.scoped(
+        makeCursorSafeSnapshotLiveStream({
+          subscribeLive: Effect.succeed(Stream.empty),
+          snapshot: Effect.succeed({ snapshotSequence: 2 }),
+          snapshotSequence: (snapshot) => snapshot.snapshotSequence,
+          getHighWaterSequence: Effect.succeed(2),
+          resumeFromSequence: 100,
+          replay: (fromSequenceExclusive, throughSequenceInclusive) => {
+            replayRanges.push([fromSequenceExclusive, throughSequenceInclusive]);
+            return Stream.empty;
+          },
+        }).pipe(Stream.take(1), Stream.runCollect),
+      ),
+    );
+
+    // Only the snapshot-fence replay ran; the untrusted cursor was never replayed from.
+    expect(replayRanges).toEqual([[2, 2]]);
+    expect(Array.from(items)).toEqual([{ kind: "snapshot", snapshot: { snapshotSequence: 2 } }]);
+  });
+
+  it("falls back to the snapshot when the resume subject no longer exists", async () => {
+    // A hard-purged thread leaves an in-range gap (unrelated events keep the
+    // journal head above the cursor) but nothing to replay, so the resume
+    // shortcut would stream silence forever instead of surfacing the deletion.
+    const replayRanges: Array<readonly [number, number]> = [];
+    const items = await Effect.runPromise(
+      Effect.scoped(
+        makeCursorSafeSnapshotLiveStream({
+          subscribeLive: Effect.succeed(Stream.empty),
+          snapshot: Effect.succeed({ snapshotSequence: 40 }),
+          snapshotSequence: (snapshot) => snapshot.snapshotSequence,
+          getHighWaterSequence: Effect.succeed(40),
+          resumeFromSequence: 30,
+          resumeSubjectExists: Effect.succeed(false),
+          replay: (fromSequenceExclusive, throughSequenceInclusive) => {
+            replayRanges.push([fromSequenceExclusive, throughSequenceInclusive]);
+            return Stream.empty;
+          },
+        }).pipe(Stream.take(1), Stream.runCollect),
+      ),
+    );
+
+    // The snapshot fence replayed, not the cursor gap.
+    expect(replayRanges).toEqual([[40, 40]]);
+    expect(Array.from(items)).toEqual([{ kind: "snapshot", snapshot: { snapshotSequence: 40 } }]);
+  });
+
+  it("resumes from the cursor when the subject still exists", async () => {
+    const replayRanges: Array<readonly [number, number]> = [];
+    const items = await Effect.runPromise(
+      Effect.scoped(
+        makeCursorSafeSnapshotLiveStream({
+          subscribeLive: Effect.succeed(Stream.empty),
+          snapshot: Effect.die("snapshot must not load on a valid resume"),
+          snapshotSequence: (snapshot: { snapshotSequence: number }) => snapshot.snapshotSequence,
+          getHighWaterSequence: Effect.succeed(40),
+          resumeFromSequence: 30,
+          resumeSubjectExists: Effect.succeed(true),
+          replay: (fromSequenceExclusive, throughSequenceInclusive) => {
+            replayRanges.push([fromSequenceExclusive, throughSequenceInclusive]);
+            return Stream.empty;
+          },
+        }).pipe(Stream.runCollect),
+      ),
+    );
+
+    expect(replayRanges).toEqual([[30, 40]]);
+    expect(Array.from(items)).toEqual([]);
   });
 
   it("requires a fresh snapshot instead of replaying an unbounded attach gap", async () => {

--- a/apps/server/src/wsSnapshotLiveStream.ts
+++ b/apps/server/src/wsSnapshotLiveStream.ts
@@ -10,6 +10,12 @@ export type SnapshotLiveStreamItem<Snapshot> =
 /**
  * Attach live delivery first, capture a snapshot and durable high-water fence,
  * replay the exact gap, then continue with strictly newer live events.
+ *
+ * When `resumeFromSequence` is provided and the gap to the durable head is
+ * non-negative and within the replay limit, the snapshot is skipped entirely
+ * and only the gap is replayed. A negative gap (client cursor ahead of the
+ * server head — restored backup or reset database) or an overflowing gap is
+ * never trusted: both fall back to the full snapshot path.
  */
 export function makeCursorSafeSnapshotLiveStream<Snapshot, E>(input: {
   readonly subscribeLive: Effect.Effect<Stream.Stream<OrchestrationEvent, E>, never, Scope.Scope>;
@@ -20,6 +26,14 @@ export function makeCursorSafeSnapshotLiveStream<Snapshot, E>(input: {
     fromSequenceExclusive: number,
     throughSequenceInclusive: number,
   ) => Stream.Stream<OrchestrationEvent, E>;
+  readonly resumeFromSequence?: number | undefined;
+  /**
+   * Guards the resume shortcut against a subject that no longer exists. A hard
+   * purge removes a thread's rows while unrelated events keep the journal head
+   * above the client's cursor, so the gap check alone would accept the resume
+   * and stream an empty replay forever instead of surfacing the deletion.
+   */
+  readonly resumeSubjectExists?: Effect.Effect<boolean, E>;
   readonly onResnapshotRequired?: (report: {
     readonly snapshotSequence: number;
     readonly highWaterSequence: number;
@@ -35,6 +49,38 @@ export function makeCursorSafeSnapshotLiveStream<Snapshot, E>(input: {
       const live = yield* input.subscribeLive;
       const liveQueue = yield* Queue.bounded<OrchestrationEvent, E | Cause.Done>(1);
       yield* Stream.runIntoQueue(live, liveQueue).pipe(Effect.forkScoped);
+      if (input.resumeFromSequence !== undefined) {
+        // The head is read after the live attach, so replay through the head
+        // plus live-after-fence covers every event exactly once — the same
+        // fence discipline as the snapshot path, with the cursor standing in
+        // for the snapshot sequence.
+        const resumeFromSequence = input.resumeFromSequence;
+        const highWaterSequence = yield* input.getHighWaterSequence;
+        const resumeGap = highWaterSequence - resumeFromSequence;
+        // The `resumeGap >= 0` guard is load-bearing, not defensive: hard
+        // deletes remove rows from `orchestration_events` (see the thread purge
+        // in profileStatsArchive.ts), which can lower the journal-wide
+        // MAX(sequence) below a cursor a client legitimately held. Such a
+        // cursor must never be trusted for a gap replay — fall through to the
+        // full snapshot instead. Sequences themselves are never reused
+        // (`sequence INTEGER PRIMARY KEY AUTOINCREMENT`), so a non-negative
+        // gap cannot silently alias deleted history onto new events.
+        const subjectExists =
+          input.resumeSubjectExists === undefined ? true : yield* input.resumeSubjectExists;
+        if (subjectExists && resumeGap >= 0 && resumeGap <= ORCHESTRATION_SNAPSHOT_REPLAY_LIMIT) {
+          const replay = input.replay(resumeFromSequence, highWaterSequence).pipe(
+            Stream.filter(
+              (event) => event.sequence > resumeFromSequence && event.sequence <= highWaterSequence,
+            ),
+            Stream.map((event): SnapshotLiveStreamItem<Snapshot> => ({ kind: "event", event })),
+          );
+          const liveAfterFence = Stream.fromQueue(liveQueue).pipe(
+            Stream.filter((event) => event.sequence > highWaterSequence),
+            Stream.map((event): SnapshotLiveStreamItem<Snapshot> => ({ kind: "event", event })),
+          );
+          return Stream.concat(replay, liveAfterFence);
+        }
+      }
       const snapshot = yield* input.snapshot;
       const snapshotSequence = input.snapshotSequence(snapshot);
       const highWaterSequence = yield* input.getHighWaterSequence;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -215,6 +215,7 @@ import {
   createComposerThreadMentionSourcesSelector,
   createThreadSelector,
 } from "../storeSelectors";
+import { buildThreadSubscribeInput } from "../threadDetailResumeCursors";
 import { retainThreadDetailSubscription } from "../threadDetailSubscriptionRetention";
 import {
   canOfferForkSlashCommand,
@@ -3299,7 +3300,9 @@ export default function ChatView({
   const handleRetryThreadDetailSync = useCallback(() => {
     useStore.getState().clearThreadDetailSyncFailure(threadId);
     const api = readNativeApi();
-    void api?.orchestration.subscribeThread({ threadId }).catch(() => undefined);
+    void api?.orchestration
+      .subscribeThread(buildThreadSubscribeInput(threadId))
+      .catch(() => undefined);
   }, [threadId]);
   // Stable identity: this element is forwarded to the memoized MessagesTimeline, so
   // building it inline in JSX would defeat its `memo()` on every keystroke.

--- a/apps/web/src/components/EventRouter.browser.tsx
+++ b/apps/web/src/components/EventRouter.browser.tsx
@@ -34,6 +34,7 @@ import {
 } from "../test/effectRpcWebSocketMock";
 import { createBrowserTestServerConfig, createFullscreenTestHost } from "../test/browserHarness";
 import { getThreadFromState } from "../threadDerivation";
+import { resetThreadDetailResumeCursorsForTests } from "../threadDetailResumeCursors";
 import { useWorkspacePathsStore } from "../workspacePathsStore";
 import { resetWsNativeApiForTest } from "../wsNativeApi";
 
@@ -473,6 +474,7 @@ describe("EventRouter scoped orchestration sync", () => {
     getThreadDetailSnapshotRequestCount = 0;
     delayNextThreadDetailSnapshotResponse = false;
     pendingThreadDetailSnapshotResponse = null;
+    resetThreadDetailResumeCursorsForTests();
   });
 
   afterEach(() => {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -355,6 +355,7 @@ import { useSidebarThreadActions } from "../hooks/useSidebarThreadActions";
 import { usePinnedProjectsStore } from "../pinnedProjectsStore";
 import { reconcileOptimisticPinState } from "../pinning.logic";
 import { useThreadDetailPrewarm } from "../threadDetailPrewarm";
+import { hasThreadDetailResumeCursor } from "../threadDetailResumeCursors";
 import { retainThreadDetailSubscription } from "../threadDetailSubscriptionRetention";
 import { useWorkspacePathsStore } from "../workspacePathsStore";
 import type {
@@ -3919,9 +3920,12 @@ export default function Sidebar() {
       visibleThreadIds: visibleSidebarThreadIds,
       activeThreadId: activeSidebarThreadId,
     });
-    const releaseCallbacks = threadIdsToPrewarm.map((threadId) =>
-      retainThreadDetailSubscription(threadId),
-    );
+    // Retaining a thread without cached detail would open a full-history
+    // snapshot stream speculatively; only cursor-resumable threads are cheap
+    // enough to keep warm from scroll position alone.
+    const releaseCallbacks = threadIdsToPrewarm
+      .filter((threadId) => hasThreadDetailResumeCursor(threadId))
+      .map((threadId) => retainThreadDetailSubscription(threadId));
 
     return () => {
       for (const release of releaseCallbacks) {

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -141,7 +141,11 @@ describe("MessagesTimeline", () => {
     expect(markup).not.toContain('data-index="0"');
     expect(markup).not.toContain('class="relative" style="height:');
     expect(markup).toContain('data-timeline-row-kind="message"');
-  }, 10_000);
+    // First test in the file pays the full dynamic-import cost of the
+    // MessagesTimeline module graph, which exceeds 10s under CI thread
+    // contention (observed flaking on 4-thread runners while passing in
+    // ~2s locally).
+  }, 30_000);
 
   it("renders assistant math through the shared markdown renderer", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -85,6 +85,13 @@ import {
   subscribeThreadDetailEvictions,
   useRetainedThreadDetailIds,
 } from "../threadDetailSubscriptionRetention";
+import {
+  advanceThreadDetailResumeCursor,
+  buildThreadSubscribeInput,
+  clearThreadDetailResumeCursor,
+  getThreadDetailResumeCursor,
+  setThreadDetailResumeCursor,
+} from "../threadDetailResumeCursors";
 import { canApplyThreadSnapshot, selectOrphanedThreadDetailIds } from "./-threadDetailOwnership";
 import { getThreadFromState, getThreadsFromState } from "../threadDerivation";
 import { useAppDensity } from "../hooks/useAppDensity";
@@ -935,6 +942,8 @@ function releaseOrphanedThreadDetail(input: {
   if (orphanedThreadIds.length === 0) {
     return;
   }
+  // The store's detail-wipe transition also drops each thread's resume cursor,
+  // so a resubscribe after this release fetches a fresh snapshot.
   useStore.getState().evictThreadDetails(orphanedThreadIds);
 }
 
@@ -1021,7 +1030,17 @@ function EventRouter() {
     let reconcileThreadSubscriptionsChain = Promise.resolve();
 
     const beginThreadSubscription = (threadId: ThreadId) => {
-      threadSnapshotSequenceById.delete(threadId);
+      // Cursor resume delivers no snapshot: the stream replays only the gap on
+      // top of the cached detail. Seed the live cursor so gap/live events apply
+      // immediately instead of buffering while waiting for a snapshot — which
+      // is also what previously triggered the unsubscribe-resubscribe race that
+      // re-shipped full history.
+      const resumeCursor = getThreadDetailResumeCursor(threadId);
+      if (resumeCursor === undefined) {
+        threadSnapshotSequenceById.delete(threadId);
+      } else {
+        threadSnapshotSequenceById.set(threadId, resumeCursor);
+      }
       pendingThreadEventsById.set(threadId, []);
       threadSnapshotRequestInFlight.delete(threadId);
       threadSnapshotRefreshPending.delete(threadId);
@@ -1043,6 +1062,7 @@ function EventRouter() {
         if (event.sequence > latestThreadSequence) {
           latestThreadSequence = event.sequence;
           threadSnapshotSequenceById.set(threadId, latestThreadSequence);
+          advanceThreadDetailResumeCursor(threadId, latestThreadSequence);
           queueDomainEvent(event);
         }
       }
@@ -1096,7 +1116,9 @@ function EventRouter() {
       }
       await Promise.all(
         additions.map((threadId) =>
-          api.orchestration.subscribeThread({ threadId }).catch(() => undefined),
+          api.orchestration
+            .subscribeThread(buildThreadSubscribeInput(threadId))
+            .catch(() => undefined),
         ),
       );
     };
@@ -1130,6 +1152,10 @@ function EventRouter() {
         if (disposed || !subscribedThreadIds.has(threadId)) {
           return;
         }
+        // Every caller of this restart wants authoritative history (wiped or
+        // never-synced detail), so a cursor resume would skip exactly the
+        // snapshot being requested.
+        clearThreadDetailResumeCursor(threadId);
         await api.orchestration.subscribeThread({ threadId }).catch(() => undefined);
       }).finally(() => {
         threadSnapshotRequestInFlight.delete(threadId);
@@ -1360,6 +1386,7 @@ function EventRouter() {
               continue;
             }
             threadSnapshotSequenceById.set(threadId, event.sequence);
+            advanceThreadDetailResumeCursor(threadId, event.sequence);
             queueDomainEvent(event);
           }
         })
@@ -1410,6 +1437,7 @@ function EventRouter() {
           threadId,
           Math.max(currentSequence, snapshot.snapshotSequence),
         );
+        advanceThreadDetailResumeCursor(threadId, snapshot.snapshotSequence);
         // Apply even when the cursor did not advance. The projection is
         // authoritative and can repair a client that advanced its cursor while
         // dropping or failing to reduce one of the corresponding live events.
@@ -1517,14 +1545,29 @@ function EventRouter() {
         if (!canApplyThreadSnapshot({ threadId, leasedThreadIds: subscribedThreadIds })) {
           threadSnapshotSequenceById.delete(threadId);
           pendingThreadEventsById.delete(threadId);
+          clearThreadDetailResumeCursor(threadId);
+          return;
+        }
+        syncServerThreadDetailHotPath(item.snapshot.thread);
+        // The projection can discard a tombstoned snapshot (deleted thread or
+        // project) instead of applying it; committing the cursor or the stream
+        // fence first would leave resume bookkeeping vouching for detail that
+        // was never stored. `threadDetailSyncById` flips to "synced" only when
+        // the detail was actually applied.
+        if (useStore.getState().threadDetailSyncById?.[threadId] !== "synced") {
+          threadSnapshotSequenceById.delete(threadId);
+          pendingThreadEventsById.delete(threadId);
+          clearThreadDetailResumeCursor(threadId);
           return;
         }
         threadSnapshotSequenceById.set(threadId, item.snapshot.snapshotSequence);
+        // Snapshots replace cached detail wholesale, so overwrite the cursor
+        // even when it is lower than the previous one (server-side reset).
+        setThreadDetailResumeCursor(threadId, item.snapshot.snapshotSequence);
         nextThreadProjectionReconcileAtById.set(
           threadId,
           Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
         );
-        syncServerThreadDetailHotPath(item.snapshot.thread);
         reconcilePromotedDraftFromThreadDetail(item.snapshot.thread);
         flushThreadBuffer(threadId, item.snapshot.snapshotSequence);
         return;
@@ -1555,6 +1598,7 @@ function EventRouter() {
         return;
       }
       threadSnapshotSequenceById.set(threadId, item.event.sequence);
+      advanceThreadDetailResumeCursor(threadId, item.event.sequence);
       nextThreadProjectionReconcileAtById.set(
         threadId,
         Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
@@ -1569,6 +1613,7 @@ function EventRouter() {
       // The stream is dead with retries and reconnects exhausted: forget its
       // cursor so a future resubscribe requests a fresh snapshot, and surface
       // the failure so the thread view stops posing as an empty conversation.
+      clearThreadDetailResumeCursor(threadId);
       threadSnapshotSequenceById.delete(threadId);
       threadSnapshotRequestInFlight.delete(threadId);
       threadSnapshotRefreshPending.delete(threadId);
@@ -1578,6 +1623,8 @@ function EventRouter() {
     // active. The wiped messages never refresh on their own, so drop the cursor
     // and restart the stream to fetch a fresh snapshot.
     const unsubThreadDetailEviction = subscribeThreadDetailEvictions((threadId) => {
+      // Retention already dropped the resume cursor when it wiped the detail;
+      // here only the live-stream bookkeeping for leased threads remains.
       if (disposed || !subscribedThreadIds.has(threadId)) {
         return;
       }

--- a/apps/web/src/storeProjection.test.ts
+++ b/apps/web/src/storeProjection.test.ts
@@ -13,7 +13,7 @@ import {
   type OrchestrationShellStreamEvent,
   type ThreadMarker,
 } from "@synara/contracts";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import {
   applyShellEvent,
@@ -26,6 +26,11 @@ import {
   syncServerReadModel,
   syncServerThreadDetailHotPath,
 } from "./storeProjection";
+import {
+  hasThreadDetailResumeCursor,
+  resetThreadDetailResumeCursorsForTests,
+  setThreadDetailResumeCursor,
+} from "./threadDetailResumeCursors";
 import type { AppState } from "./storeState";
 import { getThreadFromState } from "./threadDerivation";
 import {
@@ -2057,5 +2062,99 @@ describe("deletion tombstone retirement", () => {
         deletedThreadId
       ],
     ).toBe(31);
+  });
+});
+
+describe("resume cursor lifecycle in projection transitions", () => {
+  const projectId = ProjectId.makeUnsafe("project-1");
+  const threadId = ThreadId.makeUnsafe("thread-1");
+
+  beforeEach(() => {
+    resetThreadDetailResumeCursorsForTests();
+  });
+
+  function makeStateWithCursor() {
+    const state = makeState(makeThread({ id: threadId, projectId }));
+    setThreadDetailResumeCursor(threadId, 42);
+    return state;
+  }
+
+  it("clears the cursor when the thread's detail is evicted", () => {
+    const state = makeStateWithCursor();
+    evictThreadDetailFromClientState(state, threadId);
+    expect(hasThreadDetailResumeCursor(threadId)).toBe(false);
+  });
+
+  it("clears the cursor when the thread is deleted", () => {
+    const state = makeStateWithCursor();
+    removeDeletedThreadFromClientState(state, threadId);
+    expect(hasThreadDetailResumeCursor(threadId)).toBe(false);
+  });
+
+  it("clears the cursor when the thread's project is deleted", () => {
+    const state = makeStateWithCursor();
+    removeDeletedProjectFromClientState(state, projectId);
+    expect(hasThreadDetailResumeCursor(threadId)).toBe(false);
+  });
+
+  it("clears the cursor when a shell thread-removed event drops the thread", () => {
+    const state = makeStateWithCursor();
+    applyShellEvent(state, { kind: "thread-removed", sequence: 50, threadId });
+    expect(hasThreadDetailResumeCursor(threadId)).toBe(false);
+  });
+
+  it("clears the cursor when a shell snapshot prunes the thread", () => {
+    const state = makeStateWithCursor();
+    syncServerShellSnapshot(state, {
+      snapshotSequence: 60,
+      updatedAt: "2026-02-27T00:10:00.000Z",
+      spaces: [],
+      projects: [],
+      threads: [],
+    });
+    expect(hasThreadDetailResumeCursor(threadId)).toBe(false);
+  });
+
+  it("clears the cursor when a read-model repair prunes the thread", () => {
+    // The "Repair local state" action feeds a full read model through this
+    // path; a pruned thread's cursor must fall with its wiped detail.
+    const state = makeStateWithCursor();
+    syncServerReadModel(state, {
+      ...makeReadModel(makeReadModelThread({ id: threadId, projectId })),
+      snapshotSequence: 60,
+      threads: [],
+    });
+    expect(hasThreadDetailResumeCursor(threadId)).toBe(false);
+  });
+
+  it("clears the cursor when a full read-model sync replaces retained detail", () => {
+    // A retained thread's detail is replaced wholesale by the read model, so a
+    // cursor ahead of the replacement would resume past history the new detail
+    // does not contain. This path is route recovery and "Repair local state"
+    // only, so the cost is one snapshot on an already-degraded path.
+    const state = makeStateWithCursor();
+    syncServerReadModel(state, {
+      ...makeReadModel(makeReadModelThread({ id: threadId, projectId })),
+      snapshotSequence: 60,
+    });
+    expect(hasThreadDetailResumeCursor(threadId)).toBe(false);
+  });
+
+  it("clears the cursor when a tombstone rejects the thread's detail snapshot", () => {
+    const state = removeDeletedThreadFromClientState(
+      makeState(makeThread({ id: threadId, projectId })),
+      threadId,
+    );
+    setThreadDetailResumeCursor(threadId, 42);
+
+    const next = syncServerThreadDetailHotPath(
+      state,
+      makeReadModelThread({ id: threadId, projectId }),
+    );
+
+    // The tombstone discarded the snapshot instead of applying it, so nothing
+    // may vouch for detail that was never stored.
+    expect(next.threadDetailSyncById?.[threadId]).toBeUndefined();
+    expect(hasThreadDetailResumeCursor(threadId)).toBe(false);
   });
 });

--- a/apps/web/src/storeProjection.ts
+++ b/apps/web/src/storeProjection.ts
@@ -13,6 +13,11 @@ import {
 } from "@synara/contracts";
 import { deriveThreadSummaryMetadata } from "@synara/shared/threadSummary";
 
+import {
+  clearThreadDetailResumeCursor,
+  clearThreadDetailResumeCursors,
+  retainThreadDetailResumeCursors,
+} from "./threadDetailResumeCursors";
 import { getThreadFromState, getThreadsFromState } from "./threadDerivation";
 import {
   arraysShallowEqual,
@@ -620,6 +625,14 @@ function writeThreadDetailSyncState(
 }
 
 function clearThreadDetailSyncState(state: AppState, threadId: ThreadId): AppState {
+  // Single-thread detail-wipe choke point: every transition that removes or
+  // invalidates a thread's cached detail (removeThreadState, eviction, sync
+  // failure reset) funnels through here, so this is where the resume-cursor
+  // invariant is enforced — wiped detail must never leave a cursor that would
+  // let a resubscribe gap-replay on top of missing history. The full-sync
+  // pruning paths cover their bulk removals with
+  // `retainThreadDetailResumeCursors` instead.
+  clearThreadDetailResumeCursor(threadId);
   if (
     state.threadDetailSyncById === undefined ||
     !Object.hasOwn(state.threadDetailSyncById, threadId)
@@ -1225,6 +1238,9 @@ export function syncServerShellSnapshot(
   const spaces = mapSpaces(snapshot.spaces ?? [], state.spaces ?? []);
   const projects = mapProjects(snapshotProjects, state.projects);
   const nextThreadIds = new Set(snapshotThreads.map((thread) => thread.id));
+  // The retains below prune detail slices down to the snapshot's threads; any
+  // resume cursor for a pruned thread must fall with its detail.
+  retainThreadDetailResumeCursors(nextThreadIds);
 
   const normalizedState: AppState = {
     ...state,
@@ -1393,6 +1409,16 @@ export function syncServerReadModel(state: AppState, readModel: OrchestrationRea
       return normalizeThreadFromReadModel(thread, existing);
     });
   const nextThreadIds = new Set(nextThreads.map((thread) => thread.id));
+  // This full resync (including the "Repair local state" action) prunes detail
+  // slices down to the read model's threads; any resume cursor for a pruned
+  // thread must fall with its detail or a later resubscribe would gap-replay
+  // on top of history this prune just discarded.
+  retainThreadDetailResumeCursors(nextThreadIds);
+  // A surviving thread's detail is replaced wholesale by this read model, so a
+  // cursor ahead of the replacement would resume past history the new detail
+  // does not contain. Drop them all: the next subscribe takes a snapshot and
+  // re-establishes a cursor that matches what is actually cached.
+  clearThreadDetailResumeCursors([...nextThreadIds]);
   let normalizedState: AppState = {
     ...state,
     threadIds: reuseThreadIdRegistry(state.threadIds, nextThreadIds),

--- a/apps/web/src/storeProjection.ts
+++ b/apps/web/src/storeProjection.ts
@@ -15,7 +15,7 @@ import { deriveThreadSummaryMetadata } from "@synara/shared/threadSummary";
 
 import {
   clearThreadDetailResumeCursor,
-  clearThreadDetailResumeCursors,
+  resetThreadDetailResumeCursors,
   retainThreadDetailResumeCursors,
 } from "./threadDetailResumeCursors";
 import { getThreadFromState, getThreadsFromState } from "./threadDerivation";
@@ -630,8 +630,8 @@ function clearThreadDetailSyncState(state: AppState, threadId: ThreadId): AppSta
   // failure reset) funnels through here, so this is where the resume-cursor
   // invariant is enforced — wiped detail must never leave a cursor that would
   // let a resubscribe gap-replay on top of missing history. The full-sync
-  // pruning paths cover their bulk removals with
-  // `retainThreadDetailResumeCursors` instead.
+  // paths cover their bulk invalidations separately: the shell snapshot prunes
+  // with `retainThreadDetailResumeCursors`, the read-model resync resets all.
   clearThreadDetailResumeCursor(threadId);
   if (
     state.threadDetailSyncById === undefined ||
@@ -1409,16 +1409,12 @@ export function syncServerReadModel(state: AppState, readModel: OrchestrationRea
       return normalizeThreadFromReadModel(thread, existing);
     });
   const nextThreadIds = new Set(nextThreads.map((thread) => thread.id));
-  // This full resync (including the "Repair local state" action) prunes detail
-  // slices down to the read model's threads; any resume cursor for a pruned
-  // thread must fall with its detail or a later resubscribe would gap-replay
-  // on top of history this prune just discarded.
-  retainThreadDetailResumeCursors(nextThreadIds);
-  // A surviving thread's detail is replaced wholesale by this read model, so a
-  // cursor ahead of the replacement would resume past history the new detail
-  // does not contain. Drop them all: the next subscribe takes a snapshot and
-  // re-establishes a cursor that matches what is actually cached.
-  clearThreadDetailResumeCursors([...nextThreadIds]);
+  // This full resync (including the "Repair local state" action) replaces
+  // every thread's detail wholesale: pruned threads lose their detail, and a
+  // surviving thread's cursor would vouch for history the replacement does not
+  // contain. No cursor survives — the next subscribe takes a snapshot and
+  // re-establishes one that matches what is actually cached.
+  resetThreadDetailResumeCursors();
   let normalizedState: AppState = {
     ...state,
     threadIds: reuseThreadIdRegistry(state.threadIds, nextThreadIds),

--- a/apps/web/src/threadDetailPrewarm.test.ts
+++ b/apps/web/src/threadDetailPrewarm.test.ts
@@ -5,6 +5,10 @@
 import { ThreadId } from "@synara/contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createThreadDetailPrewarmController } from "./threadDetailPrewarm";
+import {
+  resetThreadDetailResumeCursorsForTests,
+  setThreadDetailResumeCursor,
+} from "./threadDetailResumeCursors";
 
 function threadId(value: string): ThreadId {
   return ThreadId.makeUnsafe(value);
@@ -30,6 +34,7 @@ function makeRetainSpy() {
 describe("thread detail prewarm", () => {
   afterEach(() => {
     vi.useRealTimers();
+    resetThreadDetailResumeCursorsForTests();
   });
 
   it("retains a target thread immediately and releases it after the prewarm window", () => {
@@ -38,6 +43,7 @@ describe("thread detail prewarm", () => {
     const thread = threadId("thread-1");
     const controller = createThreadDetailPrewarmController({
       retainThreadDetailSubscription: retain.retainThreadDetailSubscription,
+      canPrewarmThreadDetail: () => true,
       releaseMs: 1000,
     });
 
@@ -59,6 +65,7 @@ describe("thread detail prewarm", () => {
     const thread = threadId("thread-2");
     const controller = createThreadDetailPrewarmController({
       retainThreadDetailSubscription: retain.retainThreadDetailSubscription,
+      canPrewarmThreadDetail: () => true,
       releaseMs: 1000,
     });
 
@@ -84,6 +91,7 @@ describe("thread detail prewarm", () => {
     const threadFour = threadId("thread-4");
     const controller = createThreadDetailPrewarmController({
       retainThreadDetailSubscription: retain.retainThreadDetailSubscription,
+      canPrewarmThreadDetail: () => true,
       releaseMs: 1000,
       maxRetainedThreads: 2,
     });
@@ -101,5 +109,66 @@ describe("thread detail prewarm", () => {
     controller.dispose();
 
     expect(retain.releasedThreadIds).toEqual([threadOne, threadTwo, threadFour]);
+  });
+
+  it("does not open a speculative subscription for a thread without cached detail", () => {
+    vi.useFakeTimers();
+    const retain = makeRetainSpy();
+    const cachedThread = threadId("thread-cached");
+    const coldThread = threadId("thread-cold");
+    const controller = createThreadDetailPrewarmController({
+      retainThreadDetailSubscription: retain.retainThreadDetailSubscription,
+      canPrewarmThreadDetail: (candidate) => candidate === cachedThread,
+      releaseMs: 1000,
+    });
+
+    controller.prewarmThreadDetails([coldThread, cachedThread]);
+
+    // Cold threads would pay a full-history snapshot stream, so only the
+    // cursor-resumable thread is retained.
+    expect(retain.retainedThreadIds).toEqual([cachedThread]);
+
+    controller.prewarmThreadDetail(coldThread);
+    expect(retain.retainedThreadIds).toEqual([cachedThread]);
+
+    controller.dispose();
+    expect(retain.releasedThreadIds).toEqual([cachedThread]);
+  });
+
+  it("defaults the prewarm gate to the thread-detail resume cursor", () => {
+    vi.useFakeTimers();
+    const retain = makeRetainSpy();
+    const cachedThread = threadId("thread-with-cursor");
+    const coldThread = threadId("thread-without-cursor");
+    setThreadDetailResumeCursor(cachedThread, 7);
+    const controller = createThreadDetailPrewarmController({
+      retainThreadDetailSubscription: retain.retainThreadDetailSubscription,
+      releaseMs: 1000,
+    });
+
+    controller.prewarmThreadDetails([coldThread, cachedThread]);
+
+    expect(retain.retainedThreadIds).toEqual([cachedThread]);
+    controller.dispose();
+  });
+
+  it("filters ineligible threads before applying the prewarm limit", () => {
+    vi.useFakeTimers();
+    const retain = makeRetainSpy();
+    const coldThreadIds = Array.from({ length: 6 }, (_, index) => threadId(`cold-${index}`));
+    const cachedThread = threadId("cached-after-cold");
+    setThreadDetailResumeCursor(cachedThread, 10);
+    const controller = createThreadDetailPrewarmController({
+      retainThreadDetailSubscription: retain.retainThreadDetailSubscription,
+      releaseMs: 1000,
+    });
+
+    // More cold threads than the limit precede the one cached thread. The
+    // limit must apply after eligibility filtering, or the cold prefix would
+    // consume every slot and the cached thread would never prewarm.
+    controller.prewarmThreadDetails([...coldThreadIds, cachedThread]);
+
+    expect(retain.retainedThreadIds).toEqual([cachedThread]);
+    controller.dispose();
   });
 });

--- a/apps/web/src/threadDetailPrewarm.ts
+++ b/apps/web/src/threadDetailPrewarm.ts
@@ -5,6 +5,7 @@
 
 import type { ThreadId } from "@synara/contracts";
 import { useEffect, useRef } from "react";
+import { hasThreadDetailResumeCursor } from "./threadDetailResumeCursors";
 import { retainThreadDetailSubscription } from "./threadDetailSubscriptionRetention";
 
 export const THREAD_DETAIL_PREWARM_RELEASE_MS = 10_000;
@@ -31,6 +32,7 @@ export interface ThreadDetailPrewarmController {
 
 export interface ThreadDetailPrewarmControllerOptions {
   retainThreadDetailSubscription?: RetainThreadDetailSubscription | undefined;
+  canPrewarmThreadDetail?: ((threadId: ThreadId) => boolean) | undefined;
   releaseMs?: number | undefined;
   maxRetainedThreads?: number | undefined;
   clock?: ThreadDetailPrewarmClock | undefined;
@@ -41,7 +43,11 @@ const DEFAULT_CLOCK: ThreadDetailPrewarmClock = {
   clearTimeout: (timeoutId) => clearTimeout(timeoutId),
 };
 
-function uniqueThreadIds(threadIds: readonly ThreadId[], limit: number): ThreadId[] {
+function uniqueEligibleThreadIds(
+  threadIds: readonly ThreadId[],
+  limit: number,
+  isEligible: (threadId: ThreadId) => boolean,
+): ThreadId[] {
   const nextThreadIds: ThreadId[] = [];
   const seenThreadIds = new Set<ThreadId>();
 
@@ -50,6 +56,11 @@ function uniqueThreadIds(threadIds: readonly ThreadId[], limit: number): ThreadI
       continue;
     }
     seenThreadIds.add(threadId);
+    // Eligibility filters before the limit: ineligible (cold) threads must not
+    // consume prewarm slots that a cached thread later in the list could use.
+    if (!isEligible(threadId)) {
+      continue;
+    }
     nextThreadIds.push(threadId);
     if (nextThreadIds.length >= limit) {
       break;
@@ -64,6 +75,10 @@ export function createThreadDetailPrewarmController(
 ): ThreadDetailPrewarmController {
   const retainThreadDetail =
     options.retainThreadDetailSubscription ?? retainThreadDetailSubscription;
+  // A speculative prewarm subscription is only cheap when it resumes from a
+  // cursor: without cached detail it would open a full-history snapshot stream
+  // and compete with real navigation for the per-client thread-stream budget.
+  const canPrewarmThreadDetail = options.canPrewarmThreadDetail ?? hasThreadDetailResumeCursor;
   const releaseMs = options.releaseMs ?? THREAD_DETAIL_PREWARM_RELEASE_MS;
   const maxRetainedThreads = options.maxRetainedThreads ?? THREAD_DETAIL_PREWARM_LIMIT;
   const clock = options.clock ?? DEFAULT_CLOCK;
@@ -81,6 +96,9 @@ export function createThreadDetailPrewarmController(
 
   const prewarmThreadDetail = (threadId: ThreadId) => {
     const existing = retainedThreadById.get(threadId);
+    if (!existing && !canPrewarmThreadDetail(threadId)) {
+      return;
+    }
     if (existing) {
       clock.clearTimeout(existing.timeoutId);
     }
@@ -101,7 +119,13 @@ export function createThreadDetailPrewarmController(
   return {
     prewarmThreadDetail,
     prewarmThreadDetails(threadIds) {
-      const nextThreadIds = uniqueThreadIds(threadIds, maxRetainedThreads);
+      const nextThreadIds = uniqueEligibleThreadIds(
+        threadIds,
+        maxRetainedThreads,
+        // Already-retained threads stay eligible: their prewarm retain is live
+        // even if the cursor moved underneath, matching prewarmThreadDetail.
+        (threadId) => retainedThreadById.has(threadId) || canPrewarmThreadDetail(threadId),
+      );
       const nextThreadIdSet = new Set(nextThreadIds);
 
       for (const threadId of nextThreadIds) {

--- a/apps/web/src/threadDetailResumeCursors.test.ts
+++ b/apps/web/src/threadDetailResumeCursors.test.ts
@@ -1,0 +1,62 @@
+// FILE: threadDetailResumeCursors.test.ts
+// Purpose: Verifies resume-cursor bookkeeping behind delta-capable thread resubscribes.
+// Layer: Web subscription utility test
+
+import { ThreadId } from "@synara/contracts";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  advanceThreadDetailResumeCursor,
+  buildThreadSubscribeInput,
+  clearThreadDetailResumeCursor,
+  clearThreadDetailResumeCursors,
+  getThreadDetailResumeCursor,
+  hasThreadDetailResumeCursor,
+  resetThreadDetailResumeCursorsForTests,
+  setThreadDetailResumeCursor,
+} from "./threadDetailResumeCursors";
+
+function threadId(value: string): ThreadId {
+  return ThreadId.makeUnsafe(value);
+}
+
+describe("threadDetailResumeCursors", () => {
+  afterEach(() => {
+    resetThreadDetailResumeCursorsForTests();
+  });
+
+  it("subscribes without a cursor until cached detail exists, then resumes from it", () => {
+    const thread = threadId("thread-1");
+
+    expect(buildThreadSubscribeInput(thread)).toEqual({ threadId: thread });
+
+    setThreadDetailResumeCursor(thread, 12);
+    expect(buildThreadSubscribeInput(thread)).toEqual({ threadId: thread, afterSequence: 12 });
+  });
+
+  it("advances monotonically for events but lets snapshots overwrite backwards", () => {
+    const thread = threadId("thread-2");
+
+    advanceThreadDetailResumeCursor(thread, 5);
+    advanceThreadDetailResumeCursor(thread, 3);
+    expect(getThreadDetailResumeCursor(thread)).toBe(5);
+
+    // A fresh snapshot replaces cached detail wholesale, so a lower fence
+    // (server restored from backup) must win over the stale live cursor.
+    setThreadDetailResumeCursor(thread, 2);
+    expect(getThreadDetailResumeCursor(thread)).toBe(2);
+  });
+
+  it("clears cursors individually and in batch when cached detail is wiped", () => {
+    const threadOne = threadId("thread-3");
+    const threadTwo = threadId("thread-4");
+    setThreadDetailResumeCursor(threadOne, 7);
+    setThreadDetailResumeCursor(threadTwo, 8);
+
+    clearThreadDetailResumeCursor(threadOne);
+    expect(hasThreadDetailResumeCursor(threadOne)).toBe(false);
+    expect(hasThreadDetailResumeCursor(threadTwo)).toBe(true);
+
+    clearThreadDetailResumeCursors([threadTwo]);
+    expect(buildThreadSubscribeInput(threadTwo)).toEqual({ threadId: threadTwo });
+  });
+});

--- a/apps/web/src/threadDetailResumeCursors.ts
+++ b/apps/web/src/threadDetailResumeCursors.ts
@@ -1,0 +1,93 @@
+// FILE: threadDetailResumeCursors.ts
+// Purpose: Per-thread resume cursors so resubscribes replay only the event gap.
+// Layer: Web subscription utility
+// Exports: Cursor read/advance/clear helpers and the subscribe-input builder.
+
+import type { OrchestrationSubscribeThreadInput, ThreadId } from "@synara/contracts";
+
+// Invariant: a cursor exists for a thread only while the store's cached detail
+// is coherent up to that sequence. The store projection layer enforces this
+// structurally — every transition that wipes detail slices (thread removal,
+// eviction, full-sync pruning) drops the cursor in the same step — and the
+// subscription layer covers the store-independent paths (dead stream, snapshot
+// discarded before application). A cursor without its detail would make a
+// resubscribe resume on top of missing history.
+//
+// A cursor is also only meaningful against the server journal that issued its
+// sequences, so a server-identity change must drop all of them (see
+// resetThreadDetailResumeCursors).
+const resumeCursorByThreadId = new Map<ThreadId, number>();
+
+/** Advance-only write for live/replayed events applied on top of cached detail. */
+export function advanceThreadDetailResumeCursor(threadId: ThreadId, sequence: number): void {
+  const current = resumeCursorByThreadId.get(threadId);
+  if (current === undefined || sequence > current) {
+    resumeCursorByThreadId.set(threadId, sequence);
+  }
+}
+
+/**
+ * Overwrite for snapshot application. A snapshot replaces cached detail
+ * wholesale, so its fence is authoritative even when it is lower than the
+ * previous cursor (server restored from backup or rejected a stale cursor).
+ */
+export function setThreadDetailResumeCursor(threadId: ThreadId, sequence: number): void {
+  resumeCursorByThreadId.set(threadId, sequence);
+}
+
+export function getThreadDetailResumeCursor(threadId: ThreadId): number | undefined {
+  return resumeCursorByThreadId.get(threadId);
+}
+
+export function hasThreadDetailResumeCursor(threadId: ThreadId): boolean {
+  return resumeCursorByThreadId.has(threadId);
+}
+
+export function clearThreadDetailResumeCursor(threadId: ThreadId): void {
+  resumeCursorByThreadId.delete(threadId);
+}
+
+export function clearThreadDetailResumeCursors(threadIds: readonly ThreadId[]): void {
+  for (const threadId of threadIds) {
+    resumeCursorByThreadId.delete(threadId);
+  }
+}
+
+/**
+ * Drops every cursor whose thread is not in the surviving set. Full-sync
+ * projections use this: they prune detail slices down to the threads the
+ * snapshot reports, and any cursor for a pruned thread would vouch for detail
+ * that no longer exists.
+ */
+export function retainThreadDetailResumeCursors(threadIds: ReadonlySet<ThreadId>): void {
+  for (const threadId of resumeCursorByThreadId.keys()) {
+    if (!threadIds.has(threadId)) {
+      resumeCursorByThreadId.delete(threadId);
+    }
+  }
+}
+
+/**
+ * Drops all cursors. Called when the transport observes a new server instance:
+ * sequences are only comparable within the journal that issued them, and a
+ * different instance may serve a journal with an unrelated sequence space.
+ * This trades resume-across-server-restart for correctness until the protocol
+ * carries a durable journal epoch the cursor can be validated against.
+ */
+export function resetThreadDetailResumeCursors(): void {
+  resumeCursorByThreadId.clear();
+}
+
+/**
+ * Subscription input for a thread stream: cursor resume when cached detail is
+ * still valid, full-history snapshot otherwise. Every subscribeThread call must
+ * go through this so the cursor decision lives in exactly one place.
+ */
+export function buildThreadSubscribeInput(threadId: ThreadId): OrchestrationSubscribeThreadInput {
+  const afterSequence = resumeCursorByThreadId.get(threadId);
+  return afterSequence === undefined ? { threadId } : { threadId, afterSequence };
+}
+
+export function resetThreadDetailResumeCursorsForTests(): void {
+  resetThreadDetailResumeCursors();
+}

--- a/apps/web/src/threadDetailSubscriptionRetention.ts
+++ b/apps/web/src/threadDetailSubscriptionRetention.ts
@@ -146,6 +146,8 @@ function evictEntry(
   if (!retainedThreadEntries.delete(threadId)) {
     return;
   }
+  // The store's detail-wipe transition also drops the thread's resume cursor,
+  // so a resubscribe after this eviction fetches a fresh snapshot.
   useStore.getState().evictThreadDetail(threadId);
   emitEviction(threadId);
   if (options?.notify !== false) {

--- a/apps/web/src/wsTransport.test.ts
+++ b/apps/web/src/wsTransport.test.ts
@@ -9,10 +9,12 @@ import {
   ORCHESTRATION_WS_METHODS,
   WS_CHANNELS,
   WS_COMPATIBILITY_QUERY,
+  WS_NEGOTIATE_QUERY,
   WS_PROTOCOL_EPOCH,
   WS_PROTOCOL_MAX_REVISION,
   WS_PROTOCOL_MIN_REVISION,
   WsCompatibilityError,
+  type WsBootstrapNegotiateResult,
 } from "@synara/contracts";
 
 import {
@@ -25,7 +27,9 @@ import {
   getTerminalCompatibilityError,
   isTerminalCompatibilityFailure,
   makeFeatureSocketUrl,
+  makeNegotiateHttpUrl,
   makeRequestAbortScope,
+  negotiateOverHttp,
   serverIdentityChanged,
   MAX_STREAM_DUPLICATE_RETRY_ATTEMPTS,
   MAX_THREAD_SNAPSHOT_BOOTSTRAP_RETRY_ATTEMPTS,
@@ -54,6 +58,7 @@ class MockWebSocket {
 
   readyState = MockWebSocket.CONNECTING;
   readonly sent: unknown[] = [];
+  onSend: ((data: string) => void) | null = null;
   private readonly listeners = new Map<WsEventType, Set<WsListener>>();
 
   constructor(readonly url: string) {
@@ -72,17 +77,47 @@ class MockWebSocket {
 
   send(data: unknown) {
     this.sent.push(data);
+    this.onSend?.(String(data));
   }
 
-  close() {
+  close(code?: number, reason?: string) {
     this.readyState = MockWebSocket.CLOSED;
-    this.emit("close");
+    this.emit("close", { code: code ?? 1000, reason: reason ?? "" } as never);
+  }
+
+  open() {
+    this.readyState = MockWebSocket.OPEN;
+    this.emit("open");
+  }
+
+  receive(data: string) {
+    this.emit("message", { data });
+  }
+
+  // Answers Effect RPC frames so unit tests can complete a feature-socket
+  // session: Ping gets a Pong and every request gets a successful void Exit.
+  serveVoidRpc() {
+    this.onSend = (data) => {
+      const frame = JSON.parse(data) as Record<string, unknown>;
+      if (frame._tag === "Ping") {
+        this.receive(JSON.stringify({ _tag: "Pong" }));
+      } else if (frame._tag === "Request" && typeof frame.id === "string") {
+        this.receive(
+          JSON.stringify({
+            _tag: "Exit",
+            requestId: frame.id,
+            exit: { _tag: "Success", value: null },
+          }),
+        );
+      }
+    };
+    this.open();
   }
 
   private emit(type: WsEventType, event?: { data?: unknown }) {
     const listeners = this.listeners.get(type);
     if (!listeners) return;
-    for (const listener of listeners) {
+    for (const listener of [...listeners]) {
       listener(event);
     }
   }
@@ -165,9 +200,39 @@ function bindWindowTimersToCurrentGlobals(): void {
   });
 }
 
+const NEGOTIATION_RESULT: WsBootstrapNegotiateResult = {
+  protocolEpoch: WS_PROTOCOL_EPOCH,
+  negotiatedRevision: WS_PROTOCOL_MAX_REVISION,
+  serverBuild: "test-server",
+  serverInstanceId: "server-instance-1",
+  capabilities: ["transport.http-negotiate"],
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+async function waitForSockets(count: number): Promise<void> {
+  for (let attempt = 0; attempt < 50 && sockets.length < count; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  expect(sockets.length).toBeGreaterThanOrEqual(count);
+}
+
 beforeEach(() => {
   sockets.length = 0;
   vi.stubEnv("VITE_WS_URL", "");
+  // Default to an older server without the HTTP negotiate endpoint so
+  // connection tests exercise the legacy bootstrap fallback unless they
+  // install their own fetch stub.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => Promise.reject(new Error("http negotiate unavailable"))),
+  );
 
   Object.defineProperty(globalThis, "window", {
     configurable: true,
@@ -185,6 +250,7 @@ beforeEach(() => {
 afterEach(() => {
   globalThis.WebSocket = originalWebSocket;
   vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
 
@@ -657,11 +723,12 @@ describe("WsTransport", () => {
     expect(shouldKeepServerLifecycleStream(new Set([WS_CHANNELS.serverConfigUpdated]))).toBe(false);
   });
 
-  it("opens the stable bootstrap endpoint before the feature RPC socket", async () => {
+  it("falls back to the legacy bootstrap socket when HTTP negotiation is unavailable", async () => {
     const transport = new WsTransport("ws://localhost:3020");
 
-    expect(sockets[0]?.url).toBe("ws://localhost:3020/ws/bootstrap");
     expect(transport.getState()).toBe("connecting");
+    await waitForSockets(1);
+    expect(sockets[0]?.url).toBe("ws://localhost:3020/ws/bootstrap");
 
     await transport.dispose();
   });
@@ -676,6 +743,132 @@ describe("WsTransport", () => {
     expect(serverIdentityChanged("instance-a", "instance-b")).toBe(true);
   });
 
+  it("negotiates over HTTP so a connect opens only the feature socket", async () => {
+    const fetchMock = vi.fn((_input: string | URL | Request) =>
+      Promise.resolve(jsonResponse(200, NEGOTIATION_RESULT)),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const transport = new WsTransport("ws://localhost:3020");
+    await waitForSockets(1);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const negotiateUrl = new URL(String(fetchMock.mock.calls[0]?.[0]));
+    expect(negotiateUrl.protocol).toBe("http:");
+    expect(negotiateUrl.pathname).toBe("/ws/negotiate");
+    expect(negotiateUrl.searchParams.get(WS_NEGOTIATE_QUERY.protocolEpoch)).toBe(
+      String(WS_PROTOCOL_EPOCH),
+    );
+    expect(sockets).toHaveLength(1);
+    const featureUrl = new URL(sockets[0]!.url);
+    expect(featureUrl.pathname).toBe("/ws");
+    expect(featureUrl.searchParams.get(WS_COMPATIBILITY_QUERY.serverInstanceId)).toBe(
+      NEGOTIATION_RESULT.serverInstanceId,
+    );
+
+    await transport.dispose();
+  });
+
+  it("surfaces a 426 HTTP negotiation refusal as a terminal compatibility error", async () => {
+    const refusal = new WsCompatibilityError({
+      message: "Update this client.",
+      code: "WS_PROTOCOL_INCOMPATIBLE",
+      retryable: false,
+      action: "update-client",
+      serverBuild: "0.5.2",
+      protocolEpoch: WS_PROTOCOL_EPOCH,
+      minRevision: WS_PROTOCOL_MIN_REVISION,
+      maxRevision: WS_PROTOCOL_MAX_REVISION,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(jsonResponse(426, JSON.parse(JSON.stringify(refusal))))),
+    );
+
+    await expect(negotiateOverHttp("ws://localhost:3020")).rejects.toSatisfy((error) =>
+      isTerminalCompatibilityFailure(error),
+    );
+    // A non-426 failure (older server, transient outage) must fall back to the
+    // legacy bootstrap socket instead of failing the connect.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(jsonResponse(404, null))),
+    );
+    await expect(negotiateOverHttp("ws://localhost:3020")).resolves.toBeNull();
+  });
+
+  it("falls back to bootstrap when the negotiate request never settles", async () => {
+    // A connection that accepts and then stalls (WAN/tunnel black hole) must
+    // not wedge the transport: browsers apply no default fetch timeout, so
+    // without an abort signal the bootstrap fallback would never run.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_input: unknown, init?: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () =>
+              reject(new DOMException("The operation was aborted.", "AbortError")),
+            );
+          }),
+      ),
+    );
+
+    await expect(negotiateOverHttp("ws://localhost:3020")).resolves.toBeNull();
+  }, 10_000);
+
+  it("aborts a stalled negotiate when the caller's lifetime signal fires", async () => {
+    const controller = new AbortController();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_input: unknown, init?: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () =>
+              reject(new DOMException("The operation was aborted.", "AbortError")),
+            );
+          }),
+      ),
+    );
+
+    const negotiation = negotiateOverHttp("ws://localhost:3020", controller.signal);
+    controller.abort();
+    // Resolves well before the 5s deadline because disposal, not the timeout,
+    // ended the request.
+    await expect(negotiation).resolves.toBeNull();
+  });
+
+  it("does not create a bootstrap socket when disposed during negotiation", async () => {
+    // dispose() captures a null runtime and returns while the HTTP request is
+    // still pending; the transport must not build one afterwards.
+    let abortNegotiation: (() => void) | null = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_input: unknown, init?: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            abortNegotiation = () =>
+              reject(new DOMException("The operation was aborted.", "AbortError"));
+            init?.signal?.addEventListener("abort", () => abortNegotiation?.());
+          }),
+      ),
+    );
+
+    const transport = new WsTransport();
+    // subscribeShell reaches getClient(), so the request genuinely drives the
+    // connect path rather than relying on the constructor's eager session.
+    const connecting = transport
+      .request(ORCHESTRATION_WS_METHODS.subscribeShell, {})
+      .catch(() => null);
+    await Promise.resolve();
+    const socketsBefore = sockets.length;
+
+    await transport.dispose();
+    await connecting;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(sockets.length).toBe(socketsBefore);
+  }, 10_000);
+
   it("uses the desktop bridge URL before falling back to the browser location", async () => {
     const getWsUrl = vi.fn().mockReturnValue("ws://127.0.0.1:53036/?token=old");
     Object.defineProperty(globalThis, "window", {
@@ -687,8 +880,9 @@ describe("WsTransport", () => {
     });
 
     const transport = new WsTransport();
+    await waitForSockets(1);
 
-    expect(getWsUrl).toHaveBeenCalledTimes(1);
+    expect(getWsUrl).toHaveBeenCalled();
     expect(sockets[0]?.url).toBe("ws://127.0.0.1:53036/ws/bootstrap?token=old");
 
     await transport.dispose();
@@ -696,10 +890,118 @@ describe("WsTransport", () => {
 
   it("falls back to the current browser host when no desktop bridge URL exists", async () => {
     const transport = new WsTransport();
+    await waitForSockets(1);
 
     expect(sockets[0]?.url).toBe("ws://localhost:3020/ws/bootstrap");
 
     await transport.dispose();
+  });
+
+  it("reuses cached negotiation on reconnect while the server instance is unchanged", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse(200, NEGOTIATION_RESULT)));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const transport = new WsTransport("ws://localhost:3020");
+    const internals = transport as unknown as {
+      createSession(): { clientPromise: Promise<unknown> };
+      probeFeatureConnection: (...args: unknown[]) => Promise<void>;
+      compatibility: WsBootstrapNegotiateResult | null;
+    };
+    await waitForSockets(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(internals.compatibility).toEqual(NEGOTIATION_RESULT);
+
+    const probe = vi.fn(async () => undefined);
+    internals.probeFeatureConnection = probe;
+    await internals.createSession().clientPromise;
+
+    // Reconnect on the same server generation opens exactly one new socket and
+    // performs no renegotiation round trip — only the liveness probe.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(sockets).toHaveLength(2);
+    const reconnectUrl = new URL(sockets[1]!.url);
+    expect(reconnectUrl.pathname).toBe("/ws");
+    expect(reconnectUrl.searchParams.get(WS_COMPATIBILITY_QUERY.serverInstanceId)).toBe(
+      NEGOTIATION_RESULT.serverInstanceId,
+    );
+
+    await transport.dispose();
+  });
+
+  it("renegotiates and resets replayed push state when the server instance changed", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse(200, NEGOTIATION_RESULT)));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const transport = new WsTransport("ws://localhost:3020");
+    const internals = transport as unknown as {
+      createSession(): { clientPromise: Promise<unknown> };
+      compatibility: WsBootstrapNegotiateResult | null;
+      latestPushByChannel: Map<string, unknown>;
+      sequence: number;
+    };
+    await waitForSockets(1);
+    internals.latestPushByChannel.set("server.welcome", { stale: true });
+    internals.sequence = 7;
+
+    // A failed session clears the cache (probe or socket failure), so the next
+    // reconnect renegotiates and lands on the restarted server generation.
+    internals.compatibility = null;
+    const restarted = { ...NEGOTIATION_RESULT, serverInstanceId: "server-instance-2" };
+    fetchMock.mockImplementation(() => Promise.resolve(jsonResponse(200, restarted)));
+    await internals.createSession().clientPromise;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(internals.compatibility).toEqual(restarted);
+    expect(internals.latestPushByChannel.size).toBe(0);
+    expect(internals.sequence).toBe(0);
+    const reconnectUrl = new URL(sockets[1]!.url);
+    expect(reconnectUrl.searchParams.get(WS_COMPATIBILITY_QUERY.serverInstanceId)).toBe(
+      "server-instance-2",
+    );
+
+    await transport.dispose();
+  });
+
+  it("clears cached negotiation when the reconnect liveness probe fails", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse(200, NEGOTIATION_RESULT)));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const transport = new WsTransport("ws://localhost:3020");
+    const internals = transport as unknown as {
+      createSession(): { clientPromise: Promise<unknown> };
+      probeFeatureConnection: (...args: unknown[]) => Promise<void>;
+      compatibility: WsBootstrapNegotiateResult | null;
+    };
+    await waitForSockets(1);
+    expect(internals.compatibility).toEqual(NEGOTIATION_RESULT);
+
+    internals.probeFeatureConnection = async function (this: typeof internals) {
+      this.compatibility = null;
+      throw new Error("stale server generation");
+    }.bind(internals);
+    await expect(internals.createSession().clientPromise).rejects.toThrow(
+      "stale server generation",
+    );
+
+    expect(internals.compatibility).toBeNull();
+
+    await transport.dispose();
+  });
+
+  it("mirrors the negotiate endpoint onto the WS host with an HTTP scheme", () => {
+    const url = new URL(makeNegotiateHttpUrl("wss://remote.example:8443/?token=old"));
+
+    expect(url.protocol).toBe("https:");
+    expect(url.host).toBe("remote.example:8443");
+    expect(url.pathname).toBe("/ws/negotiate");
+    expect(url.searchParams.get("token")).toBe("old");
+    expect(url.searchParams.get(WS_NEGOTIATE_QUERY.minRevision)).toBe(
+      String(WS_PROTOCOL_MIN_REVISION),
+    );
+    expect(url.searchParams.get(WS_NEGOTIATE_QUERY.maxRevision)).toBe(
+      String(WS_PROTOCOL_MAX_REVISION),
+    );
   });
 
   it("pins the feature socket to the negotiated revision and server generation", () => {

--- a/apps/web/src/wsTransport.test.ts
+++ b/apps/web/src/wsTransport.test.ts
@@ -26,6 +26,7 @@ import {
   isTerminalCompatibilityFailure,
   makeFeatureSocketUrl,
   makeRequestAbortScope,
+  serverIdentityChanged,
   MAX_STREAM_DUPLICATE_RETRY_ATTEMPTS,
   MAX_THREAD_SNAPSHOT_BOOTSTRAP_RETRY_ATTEMPTS,
   resolveStreamAdmissionRetry,
@@ -663,6 +664,16 @@ describe("WsTransport", () => {
     expect(transport.getState()).toBe("connecting");
 
     await transport.dispose();
+  });
+
+  it("detects a server identity change across a failed reconnect", () => {
+    // The negotiated compatibility is cleared on every failed reconnect, so
+    // the comparison must use the last identity actually reached — otherwise a
+    // restore whose downtime outlasts the first retry keeps stale cursors,
+    // which is the case this guard exists for.
+    expect(serverIdentityChanged(null, "instance-a")).toBe(false);
+    expect(serverIdentityChanged("instance-a", "instance-a")).toBe(false);
+    expect(serverIdentityChanged("instance-a", "instance-b")).toBe(true);
   });
 
   it("uses the desktop bridge URL before falling back to the browser location", async () => {

--- a/apps/web/src/wsTransport.ts
+++ b/apps/web/src/wsTransport.ts
@@ -9,14 +9,17 @@ import {
   WS_BOOTSTRAP_METHOD,
   WS_BOOTSTRAP_PATH,
   WS_CHANNELS,
+  WS_CLIENT_REQUIRED_CAPABILITIES,
   WS_COMPATIBILITY_QUERY,
   WS_FEATURE_PATH,
+  WS_NEGOTIATE_HTTP_PATH,
+  WS_NEGOTIATE_QUERY,
   WS_PROTOCOL_EPOCH,
   WS_PROTOCOL_MAX_REVISION,
   WS_PROTOCOL_MIN_REVISION,
-  WS_SERVER_CAPABILITIES,
-  WS_METHODS,
+  WsBootstrapNegotiateResult,
   WsBootstrapRpcGroup,
+  WS_METHODS,
   WsCompatibilityError,
   WsFeatureRpcGroup,
   type AutomationStreamEvent,
@@ -34,10 +37,20 @@ import {
   type WsPush,
   type WsPushChannel,
   type WsPushMessage,
-  type WsBootstrapNegotiateResult,
   ThreadId,
 } from "@synara/contracts";
-import { Cause, Data, Effect, Exit, Layer, ManagedRuntime, Schema, Scope, Stream } from "effect";
+import {
+  Cause,
+  Data,
+  Effect,
+  Exit,
+  Layer,
+  ManagedRuntime,
+  Option,
+  Schema,
+  Scope,
+  Stream,
+} from "effect";
 import { RpcClient, RpcSerialization } from "effect/unstable/rpc";
 import * as Socket from "effect/unstable/socket/Socket";
 
@@ -147,6 +160,7 @@ function awaitWithAbort<A>(promise: Promise<A>, signal: AbortSignal | undefined)
 const makeRpcClient = RpcClient.make(WsFeatureRpcGroup);
 const makeBootstrapRpcClient = RpcClient.make(WsBootstrapRpcGroup);
 const REQUEST_TIMEOUT_MS = 60_000;
+const FEATURE_CONNECTION_PROBE_TIMEOUT_MS = 10_000;
 
 function resolveRpcUrl(rawUrl: string, path: string): string {
   const url = new URL(rawUrl);
@@ -182,6 +196,58 @@ export function makeFeatureSocketUrl(
   );
   url.searchParams.set(WS_COMPATIBILITY_QUERY.serverInstanceId, compatibility.serverInstanceId);
   return url.toString();
+}
+
+export function makeNegotiateHttpUrl(explicitUrl: string | null): string {
+  const url = new URL(makeSocketUrl(explicitUrl, WS_NEGOTIATE_HTTP_PATH));
+  url.protocol = url.protocol === "wss:" ? "https:" : "http:";
+  url.searchParams.set(WS_NEGOTIATE_QUERY.clientBuild, APP_VERSION);
+  url.searchParams.set(WS_NEGOTIATE_QUERY.protocolEpoch, String(WS_PROTOCOL_EPOCH));
+  url.searchParams.set(WS_NEGOTIATE_QUERY.minRevision, String(WS_PROTOCOL_MIN_REVISION));
+  url.searchParams.set(WS_NEGOTIATE_QUERY.maxRevision, String(WS_PROTOCOL_MAX_REVISION));
+  for (const capability of WS_CLIENT_REQUIRED_CAPABILITIES) {
+    url.searchParams.append(WS_NEGOTIATE_QUERY.requiredCapability, capability);
+  }
+  return url.toString();
+}
+
+/** Bounded so a stalled negotiate falls back to bootstrap instead of hanging. */
+const NEGOTIATE_HTTP_TIMEOUT_MS = 5_000;
+
+/**
+ * Negotiates compatibility over plain HTTP so a connect costs exactly one
+ * WebSocket handshake. Returns null when the server does not expose the
+ * endpoint yet (older server) or the request failed transiently, letting the
+ * caller fall back to the legacy `/ws/bootstrap` socket. A 426 is a terminal
+ * compatibility verdict and is thrown as a typed WsCompatibilityError.
+ */
+export async function negotiateOverHttp(
+  explicitUrl: string | null,
+  lifetimeSignal?: AbortSignal,
+): Promise<WsBootstrapNegotiateResult | null> {
+  // Browsers apply no default fetch timeout. Without the deadline, a
+  // connection that accepts and then stalls (the WAN/tunnel case this
+  // endpoint exists to improve) never settles, so the bootstrap fallback
+  // never runs and the transport wedges; the legacy socket path got that
+  // backstop for free from the browser's WS handshake timeout. The caller's
+  // lifetime signal is composed in so disposal aborts the request too.
+  const deadline = AbortSignal.timeout(NEGOTIATE_HTTP_TIMEOUT_MS);
+  const signal = lifetimeSignal ? AbortSignal.any([lifetimeSignal, deadline]) : deadline;
+  let response: Response;
+  try {
+    response = await fetch(makeNegotiateHttpUrl(explicitUrl), { cache: "no-store", signal });
+  } catch {
+    return null;
+  }
+  const body: unknown = await response.json().catch(() => null);
+  if (response.status === 426) {
+    const issue = Schema.decodeUnknownOption(WsCompatibilityError)(body);
+    if (Option.isSome(issue)) throw issue.value;
+    throw new Error("WebSocket negotiation was refused with an unreadable 426 response.");
+  }
+  if (!response.ok) return null;
+  const result = Schema.decodeUnknownOption(WsBootstrapNegotiateResult)(body);
+  return Option.isSome(result) ? result.value : null;
 }
 
 function makeProtocolLayer(url: string) {
@@ -485,8 +551,11 @@ export class WsTransport {
     RpcClientInstance,
     ManagedRuntime.ManagedRuntime<RpcClient.Protocol, never>
   >();
-  private runtime: ManagedRuntime.ManagedRuntime<RpcClient.Protocol, never>;
-  private clientScope: Scope.Closeable;
+  private runtime: ManagedRuntime.ManagedRuntime<RpcClient.Protocol, never> | null = null;
+  private clientScope: Scope.Closeable | null = null;
+  // Aborted by dispose() so an in-flight HTTP negotiation cannot outlive the
+  // transport and resurrect a runtime after teardown returned.
+  private readonly lifetime = new AbortController();
   private clientPromise: Promise<RpcClientInstance>;
   private reconnectPromise: Promise<RpcClientInstance> | null = null;
   private reconnectFailures = 0;
@@ -502,19 +571,15 @@ export class WsTransport {
   private shellSubscribed = false;
   private readonly threadSubscriptions = new Map<string, unknown>();
   private compatibility: WsBootstrapNegotiateResult | null = null;
-  // Survives failed reconnects, unlike `compatibility`, which is cleared on
-  // every failure. Journal identity must be compared against the last server
-  // we actually reached: an outage longer than the first retry would
-  // otherwise erase the evidence that the server came back different.
-  private lastKnownServerInstanceId: string | null = null;
   private compatibilityIssue: WsCompatibilityError | null = null;
+  // Tracks the last server generation this transport observed so cross-restart
+  // reconnects still reset replayed push state even after the negotiation
+  // cache was cleared by an intervening failure.
+  private lastServerInstanceId: string | null = null;
 
   constructor(url?: string) {
     this.explicitUrl = url ?? null;
-    const session = this.createSession();
-    this.runtime = session.runtime;
-    this.clientScope = session.clientScope;
-    this.clientPromise = session.clientPromise;
+    this.clientPromise = this.createSession().clientPromise;
   }
 
   async request<T = unknown>(
@@ -699,6 +764,9 @@ export class WsTransport {
   async dispose(): Promise<void> {
     if (this.disposed) return;
     this.disposed = true;
+    // Abort before anything else: a pending negotiate must fail now rather
+    // than resolve later and build a runtime this teardown will not see.
+    this.lifetime.abort();
     this.setState("disposed");
     this.resetAllStreamCapacityRetries();
     this.resetAllStreamCompletionRetries();
@@ -712,35 +780,107 @@ export class WsTransport {
     void this.reconnectPromise?.catch(() => undefined);
     const runtime = this.runtime;
     const clientScope = this.clientScope;
-    await runtime.runPromise(Scope.close(clientScope, Exit.void)).catch(() => undefined);
+    if (!runtime) return;
+    if (clientScope) {
+      await runtime.runPromise(Scope.close(clientScope, Exit.void)).catch(() => undefined);
+    }
     await runtime.dispose().catch(() => undefined);
   }
 
-  private createSession() {
-    const sessionVersion = ++this.sessionVersion;
+  /**
+   * Resolves negotiation without burning a WebSocket handshake: the HTTP
+   * endpoint answers directly on current servers, and only servers predating
+   * it fall back to the legacy `/ws/bootstrap` socket round trip.
+   */
+  private async negotiateCompatibility(): Promise<WsBootstrapNegotiateResult> {
+    const httpResult = await negotiateOverHttp(this.explicitUrl, this.lifetime.signal);
+    if (httpResult) return httpResult;
+    // dispose() may have run while the request was in flight; it captured a
+    // null runtime and returned, so building one here would strand it.
+    if (this.disposed) {
+      throw new Error("WebSocket transport was disposed during negotiation.");
+    }
     const runtime = ManagedRuntime.make(
       makeProtocolLayer(makeSocketUrl(this.explicitUrl, WS_BOOTSTRAP_PATH)),
     );
     const clientScope = runtime.runSync(Scope.make());
-    const clientPromise = (async () => {
-      let compatibility: WsBootstrapNegotiateResult;
-      try {
-        const bootstrapClient = await runtime.runPromise(
-          Scope.provide(clientScope)(makeBootstrapRpcClient),
-        );
-        compatibility = await runtime.runPromise(
-          bootstrapClient[WS_BOOTSTRAP_METHOD]({
-            protocolEpoch: WS_PROTOCOL_EPOCH,
-            minRevision: WS_PROTOCOL_MIN_REVISION,
-            maxRevision: WS_PROTOCOL_MAX_REVISION,
-            clientBuild: APP_VERSION,
-            requiredCapabilities: [...WS_SERVER_CAPABILITIES],
-          }),
-        );
-      } finally {
-        await runtime.runPromise(Scope.close(clientScope, Exit.void)).catch(() => undefined);
-        await runtime.dispose().catch(() => undefined);
+    // Track the bootstrap runtime so dispose() during negotiation aborts it.
+    this.runtime = runtime;
+    this.clientScope = clientScope;
+    try {
+      const bootstrapClient = await runtime.runPromise(
+        Scope.provide(clientScope)(makeBootstrapRpcClient),
+      );
+      return await runtime.runPromise(
+        bootstrapClient[WS_BOOTSTRAP_METHOD]({
+          protocolEpoch: WS_PROTOCOL_EPOCH,
+          minRevision: WS_PROTOCOL_MIN_REVISION,
+          maxRevision: WS_PROTOCOL_MAX_REVISION,
+          clientBuild: APP_VERSION,
+          requiredCapabilities: [...WS_CLIENT_REQUIRED_CAPABILITIES],
+        }),
+      );
+    } finally {
+      await runtime.runPromise(Scope.close(clientScope, Exit.void)).catch(() => undefined);
+      await runtime.dispose().catch(() => undefined);
+      if (this.runtime === runtime) {
+        this.runtime = null;
+        this.clientScope = null;
       }
+    }
+  }
+
+  private adoptNegotiation(compatibility: WsBootstrapNegotiateResult): void {
+    if (serverIdentityChanged(this.lastServerInstanceId, compatibility.serverInstanceId)) {
+      this.latestPushByChannel.clear();
+      this.sequence = 0;
+      // A resume cursor is only valid against the journal that issued its
+      // sequences. A new server instance may serve a different journal (fresh
+      // install, restored backup), so every cursor must reset to force full
+      // snapshots. `lastServerInstanceId` survives failed reconnects, unlike
+      // `compatibility`, so an outage longer than the first retry still
+      // detects the change. Interim tradeoff: this also drops resume across
+      // plain restarts of the same journal, acceptable until the protocol
+      // carries a durable journal epoch.
+      resetThreadDetailResumeCursors();
+    }
+    this.lastServerInstanceId = compatibility.serverInstanceId;
+    this.compatibility = compatibility;
+    this.setCompatibilityIssue(null);
+  }
+
+  /**
+   * A cached-negotiation session skips the negotiation round trip, so nothing
+   * has yet proven the server is alive on the cached generation. Probe with a
+   * no-op RPC: a restarted server refuses the stale `/ws` upgrade (426) and
+   * the probe fails, clearing the cache so the next attempt renegotiates.
+   */
+  private async probeFeatureConnection(
+    client: RpcClientInstance,
+    runtime: ManagedRuntime.ManagedRuntime<RpcClient.Protocol, never>,
+  ): Promise<void> {
+    const probe = (
+      client as unknown as Record<
+        string,
+        (input: unknown) => Effect.Effect<unknown, WsTransportRpcError>
+      >
+    )[ORCHESTRATION_WS_METHODS.unsubscribeShell];
+    if (!probe) return;
+    try {
+      await runtime.runPromise(probe({}).pipe(Effect.timeout(FEATURE_CONNECTION_PROBE_TIMEOUT_MS)));
+    } catch (error) {
+      this.compatibility = null;
+      throw error;
+    }
+  }
+
+  private createSession() {
+    const sessionVersion = ++this.sessionVersion;
+    // Reconnects reuse the cached negotiation while the server generation is
+    // unchanged, so a reconnect costs exactly one WebSocket handshake.
+    const cachedCompatibility = this.compatibility;
+    const clientPromise = (async () => {
+      const compatibility = cachedCompatibility ?? (await this.negotiateCompatibility());
       if (this.disposed || this.sessionVersion !== sessionVersion) {
         throw new Error("WebSocket session superseded during compatibility negotiation.");
       }
@@ -753,23 +893,11 @@ export class WsTransport {
       this.clientScope = featureScope;
       const client = await featureRuntime.runPromise(Scope.provide(featureScope)(makeRpcClient));
       this.runtimeByClient.set(client, featureRuntime);
+      if (cachedCompatibility) {
+        await this.probeFeatureConnection(client, featureRuntime);
+      }
       if (!this.disposed && this.sessionVersion === sessionVersion) {
-        if (serverIdentityChanged(this.lastKnownServerInstanceId, compatibility.serverInstanceId)) {
-          this.latestPushByChannel.clear();
-          this.sequence = 0;
-          // A resume cursor is only valid against the journal that issued its
-          // sequences. A new server instance may serve a different journal
-          // (fresh install, restored backup), so every cursor must reset to
-          // force full snapshots. Compared against the last instance actually
-          // reached rather than `compatibility`, which a failed reconnect
-          // clears — the downtime case this exists to catch. Interim tradeoff:
-          // this also drops resume across plain restarts of the same journal,
-          // acceptable until the protocol carries a durable journal epoch.
-          resetThreadDetailResumeCursors();
-        }
-        this.lastKnownServerInstanceId = compatibility.serverInstanceId;
-        this.compatibility = compatibility;
-        this.setCompatibilityIssue(null);
+        this.adoptNegotiation(compatibility);
         this.setState("open");
       }
       return client;
@@ -786,7 +914,7 @@ export class WsTransport {
       }
       throw error;
     });
-    return { runtime, clientScope, clientPromise };
+    return { clientPromise };
   }
 
   private async getClient(): Promise<RpcClientInstance> {
@@ -814,6 +942,8 @@ export class WsTransport {
 
     const oldRuntime = this.runtime;
     const oldClientScope = this.clientScope;
+    this.runtime = null;
+    this.clientScope = null;
     this.resetAllStreamCapacityRetries();
     this.resetAllStreamCompletionRetries();
     for (const cleanup of this.streamCleanups.values()) cleanup();
@@ -822,12 +952,15 @@ export class WsTransport {
 
     this.setState("connecting");
 
-    void oldRuntime
-      .runPromise(Scope.close(oldClientScope, Exit.void))
-      .catch(() => undefined)
-      .finally(() => {
+    if (oldRuntime) {
+      void (
+        oldClientScope
+          ? oldRuntime.runPromise(Scope.close(oldClientScope, Exit.void)).catch(() => undefined)
+          : Promise.resolve()
+      ).finally(() => {
         void oldRuntime.dispose().catch(() => undefined);
       });
+    }
 
     this.reconnectPromise = this.openReconnectSession().finally(() => {
       this.reconnectPromise = null;
@@ -959,8 +1092,6 @@ export class WsTransport {
     }
 
     const session = this.createSession();
-    this.runtime = session.runtime;
-    this.clientScope = session.clientScope;
     this.clientPromise = session.clientPromise;
 
     const client = await session.clientPromise;

--- a/apps/web/src/wsTransport.ts
+++ b/apps/web/src/wsTransport.ts
@@ -35,12 +35,17 @@ import {
   type WsPushChannel,
   type WsPushMessage,
   type WsBootstrapNegotiateResult,
+  ThreadId,
 } from "@synara/contracts";
 import { Cause, Data, Effect, Exit, Layer, ManagedRuntime, Schema, Scope, Stream } from "effect";
 import { RpcClient, RpcSerialization } from "effect/unstable/rpc";
 import * as Socket from "effect/unstable/socket/Socket";
 
 import { APP_VERSION } from "./branding";
+import {
+  buildThreadSubscribeInput,
+  resetThreadDetailResumeCursors,
+} from "./threadDetailResumeCursors";
 import type { WsTransportState } from "./wsTransportEvents";
 
 type PushListener<C extends WsPushChannel> = (message: WsPushMessage<C>) => void;
@@ -219,6 +224,23 @@ export function isTerminalCompatibilityFailure(error: unknown): boolean {
       "code" in error &&
       typeof error.code === "string" &&
       TERMINAL_COMPATIBILITY_ERROR_CODES.has(error.code))
+  );
+}
+
+/**
+ * True when the server just reached is a different instance than the last one
+ * reached — the signal that cached resume cursors may belong to another event
+ * journal. Compared against the last *successful* identity rather than the
+ * current negotiation, which a failed reconnect clears: an outage longer than
+ * the first retry would otherwise erase the evidence of the change, which is
+ * exactly the restore-with-downtime case this guards against.
+ */
+export function serverIdentityChanged(
+  lastKnownServerInstanceId: string | null,
+  negotiatedServerInstanceId: string,
+): boolean {
+  return (
+    lastKnownServerInstanceId !== null && lastKnownServerInstanceId !== negotiatedServerInstanceId
   );
 }
 
@@ -480,6 +502,11 @@ export class WsTransport {
   private shellSubscribed = false;
   private readonly threadSubscriptions = new Map<string, unknown>();
   private compatibility: WsBootstrapNegotiateResult | null = null;
+  // Survives failed reconnects, unlike `compatibility`, which is cleared on
+  // every failure. Journal identity must be compared against the last server
+  // we actually reached: an outage longer than the first retry would
+  // otherwise erase the evidence that the server came back different.
+  private lastKnownServerInstanceId: string | null = null;
   private compatibilityIssue: WsCompatibilityError | null = null;
 
   constructor(url?: string) {
@@ -727,13 +754,20 @@ export class WsTransport {
       const client = await featureRuntime.runPromise(Scope.provide(featureScope)(makeRpcClient));
       this.runtimeByClient.set(client, featureRuntime);
       if (!this.disposed && this.sessionVersion === sessionVersion) {
-        if (
-          this.compatibility &&
-          this.compatibility.serverInstanceId !== compatibility.serverInstanceId
-        ) {
+        if (serverIdentityChanged(this.lastKnownServerInstanceId, compatibility.serverInstanceId)) {
           this.latestPushByChannel.clear();
           this.sequence = 0;
+          // A resume cursor is only valid against the journal that issued its
+          // sequences. A new server instance may serve a different journal
+          // (fresh install, restored backup), so every cursor must reset to
+          // force full snapshots. Compared against the last instance actually
+          // reached rather than `compatibility`, which a failed reconnect
+          // clears — the downtime case this exists to catch. Interim tradeoff:
+          // this also drops resume across plain restarts of the same journal,
+          // acceptable until the protocol carries a durable journal epoch.
+          resetThreadDetailResumeCursors();
         }
+        this.lastKnownServerInstanceId = compatibility.serverInstanceId;
         this.compatibility = compatibility;
         this.setCompatibilityIssue(null);
         this.setState("open");
@@ -937,7 +971,11 @@ export class WsTransport {
     if (this.shellSubscribed) {
       this.startShellStream(client);
     }
-    for (const [threadId, input] of this.threadSubscriptions) {
+    // Refreshing only overwrites existing keys, so iterating the live key set
+    // is safe here.
+    for (const threadId of this.threadSubscriptions.keys()) {
+      const input = this.refreshThreadSubscriptionInput(threadId);
+      if (input === undefined) continue;
       await this.startThreadStream(client, threadId, input);
     }
     return client;
@@ -1122,6 +1160,25 @@ export class WsTransport {
     );
   }
 
+  /**
+   * Rebuilds a subscribed thread's stream input from the current resume-cursor
+   * state and stores it as the desired input. Transport-managed restarts
+   * (reconnects, stream retries) must not replay the input captured at
+   * subscribe time: a thread first subscribed without a cursor would keep
+   * requesting full snapshots forever, and a cursor cleared since then would
+   * be resent stale. Returns undefined when the thread is no longer subscribed.
+   */
+  private refreshThreadSubscriptionInput(threadId: string): unknown {
+    if (!this.threadSubscriptions.has(threadId)) return undefined;
+    const existingInput = this.threadSubscriptions.get(threadId);
+    const rebuiltInput: unknown = buildThreadSubscribeInput(ThreadId.makeUnsafe(threadId));
+    const input = threadStreamInputsEqual(existingInput, rebuiltInput)
+      ? existingInput
+      : rebuiltInput;
+    this.threadSubscriptions.set(threadId, input);
+    return input;
+  }
+
   private async startThreadStream(
     client: RpcClientInstance,
     threadId: string,
@@ -1149,7 +1206,7 @@ export class WsTransport {
       return;
     }
     const restartThread = () => {
-      const desiredInput = this.threadSubscriptions.get(threadId);
+      const desiredInput = this.refreshThreadSubscriptionInput(threadId);
       if (desiredInput === undefined) return;
       void this.getClient()
         .then((nextClient) => this.startThreadStream(nextClient, threadId, desiredInput))

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,6 +5,8 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
+import zlib from "node:zlib";
+import { promisify } from "node:util";
 import tailwindcss from "@tailwindcss/vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import babel from "@rolldown/plugin-babel";
@@ -100,6 +102,86 @@ function centralIconPrunePlugin(): Plugin {
   };
 }
 
+const gzip = promisify(zlib.gzip);
+const brotliCompress = promisify(zlib.brotliCompress);
+
+const PRECOMPRESS_EXTENSIONS = new Set([".js", ".mjs", ".css", ".html", ".svg", ".json", ".map"]);
+// Below this size, compression savings don't beat the extra header bytes and
+// the sidecar file overhead.
+const PRECOMPRESS_MIN_BYTES = 1024;
+
+// Emits .gz and .br sidecars next to compressible build outputs so the server
+// can serve precompressed bytes by Accept-Encoding instead of compressing on
+// the request path (apps/server/src/http.ts static route).
+function precompressPlugin(): Plugin {
+  let resolvedOutDir = "dist";
+  return {
+    name: "synara-precompress",
+    apply: "build",
+    // Run after central-icon pruning so removed files don't get sidecars.
+    enforce: "post",
+    configResolved(config) {
+      resolvedOutDir = path.resolve(config.root, config.build.outDir);
+    },
+    async closeBundle() {
+      const files = (await listFiles(resolvedOutDir)).filter((file) =>
+        PRECOMPRESS_EXTENSIONS.has(path.extname(file)),
+      );
+      // A sidecar whose source shrank below threshold or stopped compressing
+      // smaller must be removed, not just skipped: emptyOutDir protects full
+      // builds, but partial/watch builds would otherwise serve a stale
+      // compressed body under a current filename.
+      const removeStale = (sidecarPath: string) => fs.rm(sidecarPath, { force: true });
+      // Write to a temp file and rename: a watch-build server reading a
+      // sidecar mid-write would otherwise get a truncated compressed stream.
+      // Rename is atomic within a directory, so readers see either the old
+      // sidecar or the complete new one.
+      let tempSequence = 0;
+      const writeSidecarAtomically = async (sidecarPath: string, data: Buffer) => {
+        // Unique per write so concurrent builds against one outDir cannot
+        // clobber each other's staging file.
+        tempSequence += 1;
+        const tempPath = `${sidecarPath}.${process.pid}.${tempSequence}.tmp`;
+        await fs.writeFile(tempPath, data);
+        await fs.rename(tempPath, sidecarPath);
+      };
+      let sidecarCount = 0;
+      await Promise.all(
+        files.map(async (file) => {
+          const source = await fs.readFile(file);
+          if (source.byteLength < PRECOMPRESS_MIN_BYTES) {
+            await Promise.all([removeStale(`${file}.gz`), removeStale(`${file}.br`)]);
+            return;
+          }
+          // Max-quality brotli on thousands of small files dominates plugin
+          // wall-clock; below 16 KiB quality 9 is byte-for-byte competitive.
+          const brotliQuality =
+            source.byteLength < 16 * 1024 ? 9 : zlib.constants.BROTLI_MAX_QUALITY;
+          const [gzipped, brotlied] = await Promise.all([
+            gzip(source, { level: zlib.constants.Z_BEST_COMPRESSION }),
+            brotliCompress(source, {
+              params: {
+                [zlib.constants.BROTLI_PARAM_QUALITY]: brotliQuality,
+                [zlib.constants.BROTLI_PARAM_SIZE_HINT]: source.byteLength,
+              },
+            }),
+          ]);
+          await Promise.all([
+            gzipped.byteLength < source.byteLength
+              ? writeSidecarAtomically(`${file}.gz`, gzipped)
+              : removeStale(`${file}.gz`),
+            brotlied.byteLength < source.byteLength
+              ? writeSidecarAtomically(`${file}.br`, brotlied)
+              : removeStale(`${file}.br`),
+          ]);
+          sidecarCount += 1;
+        }),
+      );
+      console.info(`[precompress] emitted gzip+brotli sidecars for ${sidecarCount} files.`);
+    },
+  };
+}
+
 export default defineConfig({
   plugins: [
     tanstackRouter({
@@ -117,6 +199,7 @@ export default defineConfig({
     }),
     tailwindcss(),
     centralIconPrunePlugin(),
+    precompressPlugin(),
   ],
   optimizeDeps: {
     include: [

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -178,6 +178,7 @@ import type {
   OrchestrationShellStreamItem,
   OrchestrationSubscribeThreadInput,
   OrchestrationThreadStreamItem,
+  OrchestrationUnsubscribeThreadInput,
 } from "./orchestration";
 import type { EditorId } from "./editor";
 import type { ThreadId } from "./baseSchemas";
@@ -739,7 +740,7 @@ export interface NativeApi {
     subscribeShell: () => Promise<void>;
     unsubscribeShell: () => Promise<void>;
     subscribeThread: (input: OrchestrationSubscribeThreadInput) => Promise<void>;
-    unsubscribeThread: (input: OrchestrationSubscribeThreadInput) => Promise<void>;
+    unsubscribeThread: (input: OrchestrationUnsubscribeThreadInput) => Promise<void>;
     onDomainEvent: (callback: (event: OrchestrationEvent) => void) => () => void;
     onShellEvent: (callback: (event: OrchestrationShellStreamItem) => void) => () => void;
     onThreadEvent: (callback: (event: OrchestrationThreadStreamItem) => void) => () => void;

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -2430,10 +2430,17 @@ export type OrchestrationUnsubscribeShellInput = typeof OrchestrationUnsubscribe
 
 export const OrchestrationSubscribeThreadInput = Schema.Struct({
   threadId: ThreadId,
+  // Cursor of the last event the client already applied. When present and the
+  // gap fits the server's replay limit, the stream replays only the gap and
+  // skips the full-history snapshot. Optional so older clients keep the
+  // snapshot-first behavior unchanged.
+  afterSequence: Schema.optional(NonNegativeInt),
 });
 export type OrchestrationSubscribeThreadInput = typeof OrchestrationSubscribeThreadInput.Type;
 
-export const OrchestrationGetThreadDetailSnapshotInput = OrchestrationSubscribeThreadInput;
+export const OrchestrationGetThreadDetailSnapshotInput = Schema.Struct({
+  threadId: ThreadId,
+});
 export type OrchestrationGetThreadDetailSnapshotInput =
   typeof OrchestrationGetThreadDetailSnapshotInput.Type;
 

--- a/packages/contracts/src/wsCompatibility.ts
+++ b/packages/contracts/src/wsCompatibility.ts
@@ -7,6 +7,7 @@ export const WS_PROTOCOL_MIN_REVISION = 1;
 export const WS_PROTOCOL_MAX_REVISION = 1;
 export const WS_BOOTSTRAP_METHOD = "bootstrap.negotiate";
 export const WS_BOOTSTRAP_PATH = "/ws/bootstrap";
+export const WS_NEGOTIATE_HTTP_PATH = "/ws/negotiate";
 export const WS_FEATURE_PATH = "/ws";
 
 // These are protocol budgets, not server implementation details. Keeping the
@@ -24,10 +25,28 @@ export const WS_COMPATIBILITY_QUERY = {
   serverInstanceId: "x-synara-server-instance",
 } as const;
 
-export const WS_SERVER_CAPABILITIES = [
+export const WS_NEGOTIATE_QUERY = {
+  clientBuild: "x-synara-client-build",
+  protocolEpoch: "x-synara-protocol-epoch",
+  minRevision: "x-synara-protocol-min-revision",
+  maxRevision: "x-synara-protocol-max-revision",
+  requiredCapability: "x-synara-required-capability",
+} as const;
+
+// Capabilities the current client refuses to run without. Kept separate from
+// the advertised server list so a newer client can still negotiate with an
+// older server (over the legacy bootstrap socket) during a rollout window.
+export const WS_CLIENT_REQUIRED_CAPABILITIES = [
   "orchestration.cursor-safe-streams",
   "orchestration.thread-detail-snapshot",
   "rpc.typed-errors",
+] as const;
+
+export const WS_SERVER_CAPABILITIES = [
+  ...WS_CLIENT_REQUIRED_CAPABILITIES,
+  // Single-handshake connect: negotiation is available over plain HTTP at
+  // WS_NEGOTIATE_HTTP_PATH, so a connect costs exactly one WebSocket upgrade.
+  "transport.http-negotiate",
 ] as const;
 
 export const WsCompatibilityAction = Schema.Literals(["reload", "update-client", "update-server"]);


### PR DESCRIPTION
Transport and asset-delivery efficiency work, extracted from the remote-hosts effort in #366 as a standalone, independently useful change. Nothing here is remote-specific — it makes the existing local setup meaningfully cheaper over any link, and it is a prerequisite for running sessions over a WAN where every byte and every round trip is felt.

## Why

Synara's transport was built for localhost, where bandwidth is free and latency is ~0. Two assumptions leak out of that: full snapshots are cheap to resend, and an extra handshake round trip costs nothing. Over a real network both are expensive. These four changes remove the largest sources of waste without changing any user-visible behaviour.

## Measured impact

Static assets, measured across the full production build (464 assets with sidecars):

| Encoding | Bundle total | Reduction |
| --- | --- | --- |
| identity | 18.09 MB | — |
| gzip | 4.44 MB | **75.4%** |
| brotli | 3.63 MB | **79.9%** |

WebSocket traffic — deflate with context takeover over repeated orchestration frames (the dominant traffic shape: repetitive JSON envelopes differing by a few fields):

| Stream | Bytes | Reduction |
| --- | --- | --- |
| raw | 1752 | — |
| permessage-deflate | 368 | **79.0%** |

Context takeover is what earns that number: each frame is compressed against the window left by previous frames, so the repeated envelope keys cost almost nothing after the first message.

Round trips: connect goes from two handshakes to one, removing one full RTT from every connect and every reconnect.

## What's in it

**1. permessage-deflate on the WebSocket** (`nodeHttpServer.ts`)
Negotiates compression on the authenticated socket, with context takeover. `maxPayload` is enforced on the *decompressed* size, so compression cannot be used to smuggle an oversized frame past the limit.

Compression is negotiated **only** on the feature socket path — the dispatch fails closed, so a socket on any other path gets no compression rather than silently inheriting it.

**2. Precompressed static assets with cache headers** (`staticAssets.ts`, new)
Serves `.br`/`.gz` sidecars when the client accepts them, with immutable caching for hashed assets. Includes a correct `Accept-Encoding` q-value parser that ranks `identity` among the codings rather than special-casing it, and conditional-request handling (`If-None-Match`) that follows the RFC's weak-comparison rules.

**3. Delta-capable thread subscribe** (`threadDetailResumeCursors.ts`, new)
Thread subscription can resume from a cursor instead of refetching full history. The resume path is fenced by a high-water mark: if the requested cursor is behind what the server can still serve, it responds `ORCHESTRATION_RESNAPSHOT_REQUIRED` and the client takes a fresh snapshot. The guard is deliberately conservative — a stale delta is worse than a redundant snapshot.

**4. Single-handshake connect**
Folds the separate bootstrap negotiation into the feature socket, removing a full round trip from every connect.

## Compatibility

No user-visible behaviour changes and no schema breaks. Compression, sidecar serving, and cursor resume all degrade to the current behaviour when the client or the stored data doesn't support them — the version handshake in `wsCompatibility.ts` gates the resume path, and an older client simply gets full snapshots as before.

## Verification

Verified **standalone against `main`**, not merely as part of the larger branch it came from, specifically to confirm it can't break anything on merge.

Static checks and build:

| Check | Result |
| --- | --- |
| `bun fmt` | pass |
| `bun lint` | pass |
| `bun typecheck` | pass |
| `bun run build` | pass |

Test suite: **38 failures on exactly 5 files — all 38 reproduce identically on pristine `main`** with none of this code present (`TypeError: storage.setItem is not a function` in `splitViewStore`, `workflowRunUiStore`, `pinnedProjectsStore`, `pinnedThreadsStore`, `composerDraftStore.attachments`). This branch touches none of those files.

| Suite | `main` baseline | This branch |
| --- | --- | --- |
| passing | 3300 | **3324** (+24) |
| failing | 38 | 38 (unchanged) |
| test files | 272 | 273 (+1) |

Happy to open a separate fix for that pre-existing `storage.setItem` breakage if it isn't already known — it looks like a test-harness storage stub that no longer matches its interface, not a product bug.

Runtime smoke test against a real built server, since these are wire behaviours a unit test can't fully prove:

| Behaviour | Result |
| --- | --- |
| `/ws` upgrade with valid handshake | `101`, `sec-websocket-extensions: permessage-deflate` |
| compression on non-feature paths | absent (fails closed) |
| `Accept-Encoding: br` | `content-encoding: br`, 80 KB vs 303 KB identity |
| `Accept-Encoding: gzip` | `content-encoding: gzip`, 100 KB |
| `br;q=0, gzip;q=0.5` | brotli correctly refused |
| `If-None-Match` with current ETag | `304` |
| hashed asset caching | `public, max-age=31536000, immutable` |
| `index.html` caching | `no-cache` (never pinned to a stale bundle) |
| `/ws/negotiate` | returns epoch, revision, instance id, capabilities |

Each of the four changes also carries its own tests, including the negotiation-dispatch fail-closed behaviour, q-value ranking and conditional requests, and the resume fence.

## Documentation

Adds [`.docs/transport.md`](.docs/transport.md), covering the `/ws/negotiate` contract and why a 426 on `/ws` is expected for an unnegotiated client, `permessage-deflate` with context takeover, precompressed asset serving and the cache-lifetime split, and the cursor resume fence. `architecture.md` described the pre-negotiation connect flow, so it now links out to it.

## Scope

Deliberately excludes everything remote-specific — environment registries, SSH, proxying, UI. This is the transport groundwork alone, useful on its own merits. If the direction looks right I'll follow with the remaining phases as separate PRs, each reviewable in isolation.

## Tracking

Planned and tracked in my fork, where each phase is broken into reviewable units:

- Epic: [aristotl-dylan/synara#1 — Remote hosts: run sessions on other machines over SSH](https://github.com/aristotl-dylan/synara/issues/1) (implements the RFC in #366)

This PR closes the four Phase 0.5 issues:

- [#2 — Negotiate permessage-deflate on the WS socket](https://github.com/aristotl-dylan/synara/issues/2)
- [#3 — Serve the web bundle with compression and immutable cache headers](https://github.com/aristotl-dylan/synara/issues/3)
- [#4 — Single-handshake connect (fold bootstrap negotiation into the feature socket)](https://github.com/aristotl-dylan/synara/issues/4)
- [#5 — Delta-capable thread subscribe (cursor resume instead of full-history snapshots)](https://github.com/aristotl-dylan/synara/issues/5)

Later phases (environment-keyed transport, SSH broker and bootstrap, single-origin proxy and the "Start in" picker) are tracked as separate issues under the epic and will follow as separate PRs.
