### PR TITLE
Redesign profile analytics

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -4068,7 +4068,8 @@ describe("ProviderCommandReactor", () => {
         (await readHarnessThread(harness))?.activities.some(
           (activity) =>
             activity.kind === "provider.turn.start.failed" &&
-            activity.payload?.settlementStatus === "uncertain",
+            (activity.payload as { readonly settlementStatus?: string } | undefined)
+              ?.settlementStatus === "uncertain",
         ),
       ),
     );

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -710,9 +710,7 @@ const make = Effect.gen(function* () {
         lastError: input.detail,
         updatedAt: input.createdAt,
       },
-      ...(input.expectedSession !== undefined
-        ? { expectedSession: input.expectedSession }
-        : {}),
+      ...(input.expectedSession !== undefined ? { expectedSession: input.expectedSession } : {}),
       createdAt: input.createdAt,
     });
   });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1123,7 +1123,7 @@ const make = Effect.gen(function* () {
       thread.session && thread.session.status !== "stopped" && activeSessionBeforeEnsure
         ? thread.id
         : null;
-    if (existingSessionThreadId) {
+    if (thread.session && thread.session.status !== "stopped" && activeSessionBeforeEnsure) {
       const runtimeModeChanged = desiredRuntimeMode !== thread.session?.runtimeMode;
       const providerChanged =
         requestedModelSelection !== undefined &&

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1802,6 +1802,7 @@ describe("hasServerAcknowledgedLocalDispatch", () => {
             role: "user",
             text: "an unrelated message",
             createdAt: "2026-04-13T00:00:00.000Z",
+            streaming: false,
           },
         ],
         session: {
@@ -1880,6 +1881,7 @@ describe("hasServerAcknowledgedLocalDispatch", () => {
             role: "user",
             text: "the submitted message",
             createdAt: "2026-04-13T00:00:01.000Z",
+            streaming: false,
           },
         ],
         session: {

--- a/apps/web/src/components/EventRouter.browser.tsx
+++ b/apps/web/src/components/EventRouter.browser.tsx
@@ -24,8 +24,11 @@ import { render } from "vitest-browser-react";
 const threadSnapshotFailureListeners = vi.hoisted(
   () =>
     new Set<
-      (failure: { readonly threadId: string; readonly code: string | null; readonly error: Error }) =>
-        void
+      (failure: {
+        readonly threadId: string;
+        readonly code: string | null;
+        readonly error: Error;
+      }) => void
     >(),
 );
 
@@ -34,7 +37,7 @@ vi.mock("../wsNativeApi", async (importOriginal) => {
   return {
     ...actual,
     onThreadStreamFailure: (
-      listener: (typeof threadSnapshotFailureListeners extends Set<infer T> ? T : never),
+      listener: typeof threadSnapshotFailureListeners extends Set<infer T> ? T : never,
     ) => {
       threadSnapshotFailureListeners.add(listener);
       return () => threadSnapshotFailureListeners.delete(listener);

--- a/apps/web/src/components/profile/InsightProgressRings.tsx
+++ b/apps/web/src/components/profile/InsightProgressRings.tsx
@@ -1,0 +1,98 @@
+// FILE: InsightProgressRings.tsx
+// Purpose: Compact, theme-aware dotted rings for percentage insights. The SVG
+// is decorative; the figure caption provides the accessible summary.
+// Layer: web profile feature.
+
+import { useId, useMemo } from "react";
+import { cn } from "~/lib/utils";
+import { polarToCartesian } from "./profileChartGeometry";
+import { PROFILE_RING_ACCENT, PROFILE_RING_TRACK } from "./profileChartPalette";
+import type { ProfileInsightRing } from "./profileSelectors";
+
+const VIEW = 140;
+const CX = VIEW / 2;
+const CY = VIEW / 2;
+const RADIUS = 52;
+const DOT_COUNT = 48;
+const DOT_RADIUS = 2.6;
+
+interface InsightProgressRingsProps {
+  readonly rings: ReadonlyArray<ProfileInsightRing>;
+  readonly className?: string;
+}
+
+export function InsightProgressRings({ rings, className }: InsightProgressRingsProps) {
+  if (rings.length === 0) {
+    return (
+      <div className={cn("grid grid-cols-2 gap-4", className)}>
+        <ProgressRing
+          ring={{ id: "provider", label: "—", detail: "No provider data yet", percent: 0 }}
+        />
+        <ProgressRing
+          ring={{ id: "reasoning", label: "—", detail: "No reasoning data yet", percent: 0 }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn("grid gap-4", rings.length === 1 ? "grid-cols-1" : "grid-cols-2", className)}
+    >
+      {rings.map((ring) => (
+        <ProgressRing key={ring.id} ring={ring} />
+      ))}
+    </div>
+  );
+}
+
+function ProgressRing({ ring }: { ring: ProfileInsightRing }) {
+  const titleId = useId();
+  const filled = Math.round((Math.min(100, Math.max(0, ring.percent)) / 100) * DOT_COUNT);
+
+  const dots = useMemo(() => {
+    return Array.from({ length: DOT_COUNT }, (_, index) => {
+      // Start at 12 o'clock, go clockwise.
+      const angle = (index / DOT_COUNT) * 360;
+      const point = polarToCartesian(CX, CY, RADIUS, angle);
+      return { ...point, filled: index < filled };
+    });
+  }, [filled]);
+
+  const percentLabel = formatRingPercent(ring.percent);
+
+  return (
+    <figure className="flex flex-col items-center gap-2 text-center" aria-labelledby={titleId}>
+      <div className="relative size-[118px] sm:size-[128px]">
+        <svg viewBox={`0 0 ${VIEW} ${VIEW}`} className="size-full" aria-hidden="true">
+          {dots.map((dot, index) => (
+            <circle
+              key={index}
+              cx={dot.x}
+              cy={dot.y}
+              r={DOT_RADIUS}
+              fill={dot.filled ? PROFILE_RING_ACCENT : PROFILE_RING_TRACK}
+              className="transition-[fill] duration-300 ease-out motion-reduce:transition-none"
+            />
+          ))}
+        </svg>
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center px-3">
+          <span className="text-2xl font-semibold tracking-tight tabular-nums text-foreground">
+            {percentLabel}
+          </span>
+          <span className="mt-0.5 line-clamp-2 text-[11px] leading-tight text-muted-foreground">
+            {ring.label}
+          </span>
+        </div>
+      </div>
+      <figcaption id={titleId} className="text-xs text-muted-foreground">
+        {ring.detail}: {ring.label}, {percentLabel}
+      </figcaption>
+    </figure>
+  );
+}
+
+function formatRingPercent(value: number): string {
+  const rounded = Math.round(value);
+  return `${rounded}%`;
+}

--- a/apps/web/src/components/profile/ModelUsageDonut.tsx
+++ b/apps/web/src/components/profile/ModelUsageDonut.tsx
@@ -1,0 +1,246 @@
+// FILE: ModelUsageDonut.tsx
+// Purpose: Lightweight, theme-aware model usage donut with an accessible text legend.
+// Lightweight SVG (no chart library) so the profile page stays fast.
+// Layer: web profile feature.
+
+import { useId, useMemo, useState } from "react";
+import type { ProviderKind } from "@synara/contracts";
+import { ProviderIcon } from "~/components/ProviderIcon";
+import { CentralIcon } from "~/lib/central-icons";
+import { cn } from "~/lib/utils";
+import { layoutDonutSegments } from "./profileChartGeometry";
+import { profileModelColorAt } from "./profileChartPalette";
+import { formatCompact, formatNumber } from "./profileFormatting";
+import type { ProfileModelUsageEntry } from "./profileSelectors";
+
+const VIEW = 160;
+const CX = VIEW / 2;
+const CY = VIEW / 2;
+const OUTER = 68;
+const INNER = 46;
+
+interface ModelUsageDonutProps {
+  readonly entries: ReadonlyArray<ProfileModelUsageEntry>;
+  readonly metric: "tokens" | "turns";
+  readonly totalWeight: number | null;
+  /** Cap how many legend rows / slices are shown (rest collapsed into Other). */
+  readonly maxSlices?: number;
+  readonly className?: string;
+}
+
+interface Slice {
+  readonly key: string;
+  readonly label: string;
+  readonly provider: ProviderKind | "unknown" | "mixed";
+  readonly percent: number;
+  readonly weight: number | null;
+  readonly color: string;
+}
+
+export function ModelUsageDonut({
+  entries,
+  metric,
+  totalWeight,
+  maxSlices = 6,
+  className,
+}: ModelUsageDonutProps) {
+  const chartId = useId().replace(/:/g, "");
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+
+  const slices = useMemo(() => buildSlices(entries, maxSlices), [entries, maxSlices]);
+
+  const segments = useMemo(
+    () =>
+      layoutDonutSegments(
+        slices.map((slice) => ({
+          key: slice.key,
+          value: slice.weight ?? slice.percent,
+        })),
+        {
+          cx: CX,
+          cy: CY,
+          innerRadius: INNER,
+          outerRadius: OUTER,
+          gapDegrees: 4,
+          startAngle: 0,
+        },
+      ),
+    [slices],
+  );
+
+  const centerValue = formatCenterValue({ metric, totalWeight, slices });
+  const centerLabel = metric === "tokens" ? "tokens" : "turns";
+  const activeKey = hoveredKey;
+
+  if (slices.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center gap-6 sm:flex-row sm:items-center sm:gap-8",
+        className,
+      )}
+    >
+      <div className="relative size-42 shrink-0 sm:size-44">
+        <svg viewBox={`0 0 ${VIEW} ${VIEW}`} className="size-full" aria-hidden="true">
+          {/* Soft track ring behind segments */}
+          <circle
+            cx={CX}
+            cy={CY}
+            r={(OUTER + INNER) / 2}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={OUTER - INNER}
+            className="text-muted/40"
+          />
+
+          {segments.map((segment) => {
+            const slice = slices.find((entry) => entry.key === segment.key);
+            if (!slice) {
+              return null;
+            }
+            const isDimmed = activeKey !== null && activeKey !== segment.key;
+            return (
+              <path
+                key={segment.key}
+                d={segment.path}
+                fill={slice.color}
+                className="origin-center transition-opacity duration-200 ease-out motion-reduce:transition-none"
+                style={{ opacity: isDimmed ? 0.22 : 1 }}
+                onMouseEnter={() => setHoveredKey(segment.key)}
+                onMouseLeave={() => setHoveredKey(null)}
+              />
+            );
+          })}
+        </svg>
+
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center text-center">
+          <span className="text-xl font-semibold tracking-tight tabular-nums text-foreground">
+            {centerValue}
+          </span>
+          <span className="text-[11px] text-muted-foreground">{centerLabel}</span>
+        </div>
+      </div>
+
+      <ul className="flex w-full min-w-0 flex-1 flex-col gap-2.5">
+        {slices.map((slice) => {
+          const isDimmed = activeKey !== null && activeKey !== slice.key;
+          return (
+            <li key={slice.key}>
+              <button
+                type="button"
+                className={cn(
+                  "flex w-full min-w-0 items-center justify-between gap-3 rounded-md text-left transition-opacity duration-200 ease-out motion-reduce:transition-none",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
+                  isDimmed && "opacity-35",
+                )}
+                onMouseEnter={() => setHoveredKey(slice.key)}
+                onMouseLeave={() => setHoveredKey(null)}
+                onFocus={() => setHoveredKey(slice.key)}
+                onBlur={() => setHoveredKey(null)}
+                aria-label={`${slice.label}: ${formatPercent(slice.percent)}`}
+              >
+                <span className="flex min-w-0 items-center gap-2.5">
+                  <span
+                    className="size-2.5 shrink-0 rounded-full"
+                    style={{ backgroundColor: slice.color }}
+                    aria-hidden
+                  />
+                  {slice.provider !== "unknown" && slice.provider !== "mixed" ? (
+                    <ProviderIcon provider={slice.provider} className="size-3.5 shrink-0" />
+                  ) : (
+                    <CentralIcon
+                      name="chart-2"
+                      className="size-3.5 shrink-0 text-muted-foreground"
+                    />
+                  )}
+                  <span className="truncate text-sm text-foreground">{slice.label}</span>
+                </span>
+                <span className="flex shrink-0 items-baseline gap-2 tabular-nums">
+                  {slice.weight !== null ? (
+                    <span className="text-sm text-muted-foreground">
+                      {metric === "tokens"
+                        ? formatCompact(slice.weight)
+                        : formatNumber(slice.weight)}
+                    </span>
+                  ) : null}
+                  <span className="text-sm font-medium text-foreground">
+                    {formatPercent(slice.percent)}
+                  </span>
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function buildSlices(entries: ReadonlyArray<ProfileModelUsageEntry>, maxSlices: number): Slice[] {
+  if (entries.length === 0) {
+    return [];
+  }
+
+  const ranked = [...entries].sort((a, b) => b.percent - a.percent);
+  const head = ranked.slice(0, Math.max(1, maxSlices - (ranked.length > maxSlices ? 1 : 0)));
+  const tail = ranked.slice(head.length);
+
+  const slices: Slice[] = head.map((entry, index) => ({
+    key: `${entry.provider}:${entry.model}`,
+    label: entry.model,
+    provider: entry.provider,
+    percent: entry.percent,
+    weight: entry.weight,
+    color: profileModelColorAt(index),
+  }));
+
+  if (tail.length > 0) {
+    const percent = tail.reduce((sum, entry) => sum + entry.percent, 0);
+    const weights = tail.map((entry) => entry.weight);
+    const weight = weights.every((value) => value !== null)
+      ? weights.reduce<number>((sum, value) => sum + (value ?? 0), 0)
+      : null;
+    slices.push({
+      key: "other",
+      label: tail.length === 1 ? tail[0]!.model : `Other (${tail.length})`,
+      provider: tail.length === 1 ? tail[0]!.provider : "mixed",
+      percent,
+      weight,
+      color: profileModelColorAt(slices.length),
+    });
+  }
+
+  return slices;
+}
+
+function formatCenterValue({
+  metric,
+  totalWeight,
+  slices,
+}: {
+  metric: "tokens" | "turns";
+  totalWeight: number | null;
+  slices: ReadonlyArray<Slice>;
+}): string {
+  if (totalWeight !== null) {
+    return metric === "tokens" ? formatCompact(totalWeight) : formatNumber(totalWeight);
+  }
+  const fromSlices = slices.reduce<number | null>((sum, slice) => {
+    if (sum === null || slice.weight === null) {
+      return null;
+    }
+    return sum + slice.weight;
+  }, 0);
+  if (fromSlices !== null && fromSlices > 0) {
+    return metric === "tokens" ? formatCompact(fromSlices) : formatNumber(fromSlices);
+  }
+  return "—";
+}
+
+function formatPercent(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? `${rounded}%` : `${rounded.toFixed(1)}%`;
+}

--- a/apps/web/src/components/profile/TokenSparkline.tsx
+++ b/apps/web/src/components/profile/TokenSparkline.tsx
@@ -1,0 +1,66 @@
+// FILE: TokenSparkline.tsx
+// Purpose: Compact monospace-style bar sparkline for lifetime token (or prompt)
+// trend under the profile stat tile. Built from heatmap day counts.
+// Layer: web profile feature.
+
+import { useMemo } from "react";
+import { cn } from "~/lib/utils";
+import { normalizeSparklineHeights } from "./profileChartGeometry";
+
+interface TokenSparklineProps {
+  readonly values: ReadonlyArray<number>;
+  readonly className?: string;
+  readonly "aria-label"?: string;
+}
+
+export function TokenSparkline({
+  values,
+  className,
+  "aria-label": ariaLabel = "Recent activity trend",
+}: TokenSparklineProps) {
+  const heights = useMemo(() => normalizeSparklineHeights(values), [values]);
+
+  if (heights.length === 0) {
+    return null;
+  }
+
+  const peakIndex = findPeakIndex(values);
+
+  return (
+    <div
+      role="img"
+      aria-label={ariaLabel}
+      className={cn("flex h-7 w-full items-end gap-px", className)}
+    >
+      {heights.map((height, index) => {
+        const isPeak = index === peakIndex && values[index]! > 0;
+        return (
+          <div
+            key={index}
+            className={cn(
+              "min-h-px min-w-[2px] flex-1 rounded-[1px] transition-colors duration-200 ease-out motion-reduce:transition-none",
+              isPeak
+                ? "bg-[var(--info)]"
+                : "bg-[color-mix(in_srgb,var(--info)_42%,transparent)] dark:bg-[color-mix(in_srgb,var(--info)_55%,transparent)]",
+              height === 0 && "bg-muted/70 dark:bg-white/[0.06]",
+            )}
+            style={{ height: height === 0 ? "14%" : `${Math.round(height * 100)}%` }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function findPeakIndex(values: ReadonlyArray<number>): number {
+  let peak = -1;
+  let peakValue = -1;
+  for (let i = 0; i < values.length; i++) {
+    const value = values[i]!;
+    if (value > peakValue) {
+      peakValue = value;
+      peak = i;
+    }
+  }
+  return peak;
+}

--- a/apps/web/src/components/profile/profileChartGeometry.test.ts
+++ b/apps/web/src/components/profile/profileChartGeometry.test.ts
@@ -1,0 +1,91 @@
+// FILE: profileChartGeometry.test.ts
+// Purpose: Unit coverage for profile donut / sparkline geometry helpers.
+// Layer: web profile feature tests.
+
+import { describe, expect, it } from "vitest";
+import {
+  clampPercent,
+  donutSegmentPath,
+  layoutDonutSegments,
+  normalizeSparklineHeights,
+  polarToCartesian,
+} from "./profileChartGeometry";
+
+describe("polarToCartesian", () => {
+  it("places 0° at 12 o'clock", () => {
+    const point = polarToCartesian(0, 0, 10, 0);
+    expect(point.x).toBeCloseTo(0, 5);
+    expect(point.y).toBeCloseTo(-10, 5);
+  });
+});
+
+describe("donutSegmentPath", () => {
+  it("returns null for zero sweep", () => {
+    expect(donutSegmentPath(50, 50, 20, 40, 10, 10)).toBeNull();
+  });
+
+  it("emits a closed path for a partial sector", () => {
+    const path = donutSegmentPath(50, 50, 20, 40, 0, 90);
+    expect(path).toMatch(/^M /);
+    expect(path).toContain("A 40 40");
+    expect(path).toContain("A 20 20");
+    expect(path?.endsWith("Z")).toBe(true);
+  });
+});
+
+describe("layoutDonutSegments", () => {
+  it("lays out proportional segments with gaps", () => {
+    const segments = layoutDonutSegments(
+      [
+        { key: "a", value: 75 },
+        { key: "b", value: 25 },
+      ],
+      { cx: 50, cy: 50, innerRadius: 20, outerRadius: 40, gapDegrees: 4 },
+    );
+    expect(segments).toHaveLength(2);
+    expect(segments[0]!.key).toBe("a");
+    expect(segments[0]!.percent).toBeCloseTo(75, 5);
+    expect(segments[1]!.percent).toBeCloseTo(25, 5);
+    // Drawable sweep is 360 - total gap; both segments leave room for gaps.
+    const totalSweep = segments.reduce(
+      (sum, segment) => sum + (segment.endAngle - segment.startAngle),
+      0,
+    );
+    expect(totalSweep).toBeLessThan(360);
+    expect(totalSweep).toBeGreaterThan(340);
+  });
+
+  it("ignores non-positive weights", () => {
+    expect(
+      layoutDonutSegments(
+        [
+          { key: "a", value: 0 },
+          { key: "b", value: -1 },
+        ],
+        { cx: 0, cy: 0, innerRadius: 1, outerRadius: 2 },
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("normalizeSparklineHeights", () => {
+  it("scales peak to 1 and zeros empty days", () => {
+    expect(normalizeSparklineHeights([0, 50, 100], { minVisible: 0.1 })).toEqual([0, 0.5, 1]);
+  });
+
+  it("enforces a minimum visible height for tiny positive values", () => {
+    const heights = normalizeSparklineHeights([1, 100], { minVisible: 0.1 });
+    expect(heights[0]).toBe(0.1);
+    expect(heights[1]).toBe(1);
+  });
+});
+
+describe("clampPercent", () => {
+  it("clamps finite values into 0–100", () => {
+    expect(clampPercent(-5)).toBe(0);
+    expect(clampPercent(150)).toBe(100);
+    expect(clampPercent(42.2)).toBe(42.2);
+    expect(clampPercent(null)).toBeNull();
+    expect(clampPercent(Number.NaN)).toBeNull();
+  });
+});

--- a/apps/web/src/components/profile/profileChartGeometry.ts
+++ b/apps/web/src/components/profile/profileChartGeometry.ts
@@ -1,0 +1,168 @@
+// FILE: profileChartGeometry.ts
+// Purpose: Pure SVG geometry helpers for profile charts (donut arcs, polar
+// coordinates, sparkline bar heights). No React — safe for unit tests.
+// Layer: web profile feature.
+
+/** Convert polar coordinates to SVG cartesian (0° at 12 o'clock, clockwise). */
+export function polarToCartesian(
+  cx: number,
+  cy: number,
+  radius: number,
+  angleDeg: number,
+): { x: number; y: number } {
+  const rad = ((angleDeg - 90) * Math.PI) / 180;
+  return {
+    x: cx + radius * Math.cos(rad),
+    y: cy + radius * Math.sin(rad),
+  };
+}
+
+/**
+ * Closed annulus sector path for a donut segment.
+ * Angles are degrees, 0 at 12 o'clock, sweeping clockwise.
+ * Returns null when the sweep is degenerate.
+ */
+export function donutSegmentPath(
+  cx: number,
+  cy: number,
+  innerRadius: number,
+  outerRadius: number,
+  startAngle: number,
+  endAngle: number,
+): string | null {
+  const sweep = endAngle - startAngle;
+  if (!(sweep > 0) || !(outerRadius > innerRadius) || !(innerRadius >= 0)) {
+    return null;
+  }
+
+  // Full circle needs two arcs — a single 360° arc is invalid in SVG.
+  if (sweep >= 359.999) {
+    const mid = startAngle + 180;
+    const outerA = polarToCartesian(cx, cy, outerRadius, startAngle);
+    const outerB = polarToCartesian(cx, cy, outerRadius, mid);
+    const outerC = polarToCartesian(cx, cy, outerRadius, startAngle + 360);
+    const innerA = polarToCartesian(cx, cy, innerRadius, startAngle + 360);
+    const innerB = polarToCartesian(cx, cy, innerRadius, mid);
+    const innerC = polarToCartesian(cx, cy, innerRadius, startAngle);
+    return [
+      `M ${outerA.x} ${outerA.y}`,
+      `A ${outerRadius} ${outerRadius} 0 1 1 ${outerB.x} ${outerB.y}`,
+      `A ${outerRadius} ${outerRadius} 0 1 1 ${outerC.x} ${outerC.y}`,
+      `L ${innerA.x} ${innerA.y}`,
+      `A ${innerRadius} ${innerRadius} 0 1 0 ${innerB.x} ${innerB.y}`,
+      `A ${innerRadius} ${innerRadius} 0 1 0 ${innerC.x} ${innerC.y}`,
+      "Z",
+    ].join(" ");
+  }
+
+  const largeArc = sweep > 180 ? 1 : 0;
+  // Clockwise: outer arc sweeps with sweep-flag 1; inner returns with 0.
+  const outerStart = polarToCartesian(cx, cy, outerRadius, startAngle);
+  const outerEnd = polarToCartesian(cx, cy, outerRadius, endAngle);
+  const innerEnd = polarToCartesian(cx, cy, innerRadius, endAngle);
+  const innerStart = polarToCartesian(cx, cy, innerRadius, startAngle);
+
+  return [
+    `M ${outerStart.x} ${outerStart.y}`,
+    `A ${outerRadius} ${outerRadius} 0 ${largeArc} 1 ${outerEnd.x} ${outerEnd.y}`,
+    `L ${innerEnd.x} ${innerEnd.y}`,
+    `A ${innerRadius} ${innerRadius} 0 ${largeArc} 0 ${innerStart.x} ${innerStart.y}`,
+    "Z",
+  ].join(" ");
+}
+
+export interface DonutSegmentLayout {
+  readonly key: string;
+  readonly startAngle: number;
+  readonly endAngle: number;
+  readonly percent: number;
+  readonly path: string;
+}
+
+/**
+ * Layout donut segments from relative weights (percentages or absolute counts).
+ * `gapDegrees` is the empty gap between segments (split evenly on both sides).
+ */
+export function layoutDonutSegments(
+  entries: ReadonlyArray<{ key: string; value: number }>,
+  options: {
+    readonly cx: number;
+    readonly cy: number;
+    readonly innerRadius: number;
+    readonly outerRadius: number;
+    readonly gapDegrees?: number;
+    readonly startAngle?: number;
+  },
+): ReadonlyArray<DonutSegmentLayout> {
+  const positive = entries.filter((entry) => Number.isFinite(entry.value) && entry.value > 0);
+  const total = positive.reduce((sum, entry) => sum + entry.value, 0);
+  if (total <= 0 || positive.length === 0) {
+    return [];
+  }
+
+  const gapDegrees = Number.isFinite(options.gapDegrees) ? Math.max(0, options.gapDegrees ?? 3) : 3;
+  const startAngle = options.startAngle ?? 0;
+  // Cap total gap so a single tiny segment still has room.
+  const totalGap = Math.min(gapDegrees * positive.length, 36);
+  const gapPerSegment = positive.length > 1 ? totalGap / positive.length : 0;
+  const drawable = 360 - totalGap;
+
+  let cursor = startAngle;
+  const segments: DonutSegmentLayout[] = [];
+
+  for (const entry of positive) {
+    const sweep = (entry.value / total) * drawable;
+    const segmentStart = cursor + gapPerSegment / 2;
+    const segmentEnd = segmentStart + sweep;
+    const path = donutSegmentPath(
+      options.cx,
+      options.cy,
+      options.innerRadius,
+      options.outerRadius,
+      segmentStart,
+      segmentEnd,
+    );
+    if (path) {
+      segments.push({
+        key: entry.key,
+        startAngle: segmentStart,
+        endAngle: segmentEnd,
+        percent: (entry.value / total) * 100,
+        path,
+      });
+    }
+    cursor = segmentEnd + gapPerSegment / 2;
+  }
+
+  return segments;
+}
+
+/** Normalize values to 0–1 bar heights for sparklines (peak = 1). */
+export function normalizeSparklineHeights(
+  values: ReadonlyArray<number>,
+  options?: { readonly minVisible?: number },
+): ReadonlyArray<number> {
+  const minVisible = options?.minVisible ?? 0.08;
+  if (values.length === 0) {
+    return [];
+  }
+  const finiteValues = values.map((value) => (Number.isFinite(value) ? value : 0));
+  const peak = Math.max(...finiteValues, 0);
+  if (peak <= 0) {
+    return values.map(() => 0);
+  }
+  return finiteValues.map((value) => {
+    if (value <= 0) {
+      return 0;
+    }
+    return Math.max(minVisible, value / peak);
+  });
+}
+
+/** Clamp a percentage into a safe 0–100 ring fill. */
+export function clampPercent(value: number | null | undefined): number | null {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return null;
+  }
+  return Math.min(100, Math.max(0, value));
+}

--- a/apps/web/src/components/profile/profileChartPalette.ts
+++ b/apps/web/src/components/profile/profileChartPalette.ts
@@ -1,0 +1,23 @@
+// FILE: profileChartPalette.ts
+// Purpose: Theme-aware palette for model-mix charts. Keep chart colors tied to
+// semantic app tokens so light and dark themes remain centrally controlled.
+// Layer: web profile feature.
+
+/** Semantic tokens are resolved by the active light/dark theme. */
+export const PROFILE_MODEL_COLORS: readonly string[] = [
+  "var(--info)",
+  "var(--success)",
+  "var(--warning)",
+  "var(--destructive)",
+  "var(--foreground)",
+  "var(--muted-foreground)",
+];
+
+export function profileModelColorAt(index: number): string {
+  const palette = PROFILE_MODEL_COLORS;
+  return palette[index % palette.length] ?? "var(--info)";
+}
+
+/** Dotted progress-ring accent (matches profile heatmap accent family). */
+export const PROFILE_RING_ACCENT = "var(--info)";
+export const PROFILE_RING_TRACK = "color-mix(in srgb, var(--muted-foreground) 28%, transparent)";

--- a/apps/web/src/components/profile/profileSelectors.test.ts
+++ b/apps/web/src/components/profile/profileSelectors.test.ts
@@ -8,7 +8,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   selectProfileHeatmap,
+  selectProfileInsightRings,
   selectProfileModelUsage,
+  selectProfileSparkline,
   selectProfileTopProvider,
 } from "./profileSelectors";
 
@@ -43,8 +45,8 @@ const baseStats = {
   insights: {
     topProvider: "codex",
     topProviderPercent: 66.7,
-    topReasoning: null,
-    topReasoningPercent: null,
+    topReasoning: "high",
+    topReasoningPercent: 54.2,
     skillsExplored: 0,
     totalSkillsUsed: 0,
   },
@@ -94,8 +96,22 @@ describe("profile selectors", () => {
       unit: "tokens",
     });
     expect(selectProfileModelUsage(baseStats, tokenStats)).toEqual({
-      entries: tokenStats.models,
+      entries: [
+        {
+          provider: "claudeAgent",
+          model: "claude-sonnet-4-6",
+          percent: 83.3,
+          weight: 5000,
+        },
+        {
+          provider: "codex",
+          model: "gpt-5-codex",
+          percent: 16.7,
+          weight: 1000,
+        },
+      ],
       metric: "tokens",
+      totalWeight: 6000,
     });
   });
 
@@ -110,15 +126,95 @@ describe("profile selectors", () => {
       unit: "prompts",
     });
     expect(selectProfileModelUsage(baseStats, null)).toEqual({
-      entries: baseStats.providerModels,
+      entries: [
+        {
+          provider: "codex",
+          model: "gpt-5-codex",
+          percent: 66.7,
+          weight: 2,
+        },
+        {
+          provider: "claudeAgent",
+          model: "claude-sonnet-4-6",
+          percent: 33.3,
+          weight: 1,
+        },
+      ],
       metric: "turns",
+      totalWeight: 3,
     });
   });
 
   it("falls back to turn-based model usage when token telemetry has no model rows", () => {
     expect(selectProfileModelUsage(baseStats, { ...tokenStats, models: [] })).toEqual({
-      entries: baseStats.providerModels,
+      entries: [
+        {
+          provider: "codex",
+          model: "gpt-5-codex",
+          percent: 66.7,
+          weight: 2,
+        },
+        {
+          provider: "claudeAgent",
+          model: "claude-sonnet-4-6",
+          percent: 33.3,
+          weight: 1,
+        },
+      ],
       metric: "turns",
+      totalWeight: 3,
     });
+  });
+
+  it("builds a sparkline window from the preferred heatmap series", () => {
+    expect(selectProfileSparkline(baseStats, tokenStats, 28)).toEqual({
+      values: [6000],
+      unit: "tokens",
+      hasActivity: true,
+    });
+    expect(selectProfileSparkline(baseStats, null, 28)).toEqual({
+      values: [3],
+      unit: "prompts",
+      hasActivity: true,
+    });
+  });
+
+  it("selects percentage insight rings for provider and reasoning", () => {
+    expect(selectProfileInsightRings(baseStats, tokenStats)).toEqual({
+      rings: [
+        {
+          id: "provider",
+          label: "Claude",
+          detail: "Most used provider",
+          percent: 83.3,
+        },
+        {
+          id: "reasoning",
+          label: "High",
+          detail: "Most used reasoning",
+          percent: 54.2,
+        },
+      ],
+    });
+  });
+
+  it("omits insight rings when percentages are missing", () => {
+    const statsWithoutShares = {
+      ...baseStats,
+      insights: {
+        ...baseStats.insights,
+        topProvider: null,
+        topProviderPercent: null,
+        topReasoning: null,
+        topReasoningPercent: null,
+      },
+    } satisfies ProfileStats;
+    expect(
+      selectProfileInsightRings(statsWithoutShares, {
+        ...tokenStats,
+        topProvider: null,
+        topProviderPercent: null,
+      }),
+    ).toEqual({ rings: [] });
   });
 });

--- a/apps/web/src/components/profile/profileSelectors.ts
+++ b/apps/web/src/components/profile/profileSelectors.ts
@@ -9,6 +9,7 @@ import type {
   ProfileTokenStats,
   ProviderKind,
 } from "@synara/contracts";
+import { clampPercent } from "./profileChartGeometry";
 
 export interface ProfileHeatmapSelection {
   readonly cells: ReadonlyArray<ProfileHeatmapCell>;
@@ -26,11 +27,33 @@ export interface ProfileModelUsageEntry {
   readonly provider: ProviderKind | "unknown";
   readonly model: string;
   readonly percent: number;
+  /** Absolute weight when known (tokens or turns); used for donut center totals. */
+  readonly weight: number | null;
 }
 
 export interface ProfileModelUsageSelection {
   readonly entries: ReadonlyArray<ProfileModelUsageEntry>;
   readonly metric: "tokens" | "turns";
+  /** Sum of entry weights when every row has a weight; null otherwise. */
+  readonly totalWeight: number | null;
+}
+
+export interface ProfileSparklineSelection {
+  readonly values: ReadonlyArray<number>;
+  readonly unit: "tokens" | "prompts";
+  /** True when at least one day in the window has activity. */
+  readonly hasActivity: boolean;
+}
+
+export interface ProfileInsightRing {
+  readonly id: "provider" | "reasoning";
+  readonly label: string;
+  readonly detail: string;
+  readonly percent: number;
+}
+
+export interface ProfileInsightRingsSelection {
+  readonly rings: ReadonlyArray<ProfileInsightRing>;
 }
 
 // Prefer tokens/day when available; fall back to prompt counts while token stats load.
@@ -72,7 +95,118 @@ export function selectProfileModelUsage(
   tokenStats: ProfileTokenStats | null,
 ): ProfileModelUsageSelection {
   if (tokenStats?.available && tokenStats.models.length > 0) {
-    return { entries: tokenStats.models, metric: "tokens" };
+    const entries = tokenStats.models.map((entry) => ({
+      provider: entry.provider,
+      model: entry.model,
+      percent: entry.percent,
+      weight: entry.tokens,
+    }));
+    return {
+      entries,
+      metric: "tokens",
+      totalWeight: sumWeights(entries),
+    };
   }
-  return { entries: stats.providerModels, metric: "turns" };
+  const entries = stats.providerModels.map((entry) => ({
+    provider: entry.provider,
+    model: entry.model,
+    percent: entry.percent,
+    weight: entry.turnCount,
+  }));
+  return {
+    entries,
+    metric: "turns",
+    totalWeight: sumWeights(entries),
+  };
+}
+
+/**
+ * Last N days of heatmap counts for a lifetime-token (or prompt) sparkline.
+ * Uses the same tokens-first series as the activity heatmap.
+ */
+export function selectProfileSparkline(
+  stats: ProfileStats,
+  tokenStats: ProfileTokenStats | null,
+  dayCount = 28,
+): ProfileSparklineSelection {
+  const heatmap = selectProfileHeatmap(stats, tokenStats);
+  const window = heatmap.cells.slice(-Math.max(1, dayCount));
+  const values = window.map((cell) => cell.count);
+  return {
+    values,
+    unit: heatmap.unit,
+    hasActivity: values.some((value) => value > 0),
+  };
+}
+
+/**
+ * Pull percentage-based insights into Progress Ring candidates.
+ * Only includes rings with a real 0–100 share (provider / reasoning).
+ */
+export function selectProfileInsightRings(
+  stats: ProfileStats,
+  tokenStats: ProfileTokenStats | null,
+): ProfileInsightRingsSelection {
+  const topProvider = selectProfileTopProvider(stats, tokenStats);
+  const rings: ProfileInsightRing[] = [];
+
+  const providerPercent = clampPercent(topProvider.percent);
+  if (topProvider.provider && providerPercent !== null && providerPercent > 0) {
+    rings.push({
+      id: "provider",
+      label: formatProviderKindLabel(topProvider.provider),
+      detail: "Most used provider",
+      percent: providerPercent,
+    });
+  }
+
+  const reasoningPercent = clampPercent(stats.insights.topReasoningPercent);
+  if (stats.insights.topReasoning && reasoningPercent !== null && reasoningPercent > 0) {
+    rings.push({
+      id: "reasoning",
+      label: capitalizeWord(stats.insights.topReasoning),
+      detail: "Most used reasoning",
+      percent: reasoningPercent,
+    });
+  }
+
+  return { rings };
+}
+
+function sumWeights(entries: ReadonlyArray<{ weight: number | null }>): number | null {
+  let total = 0;
+  for (const entry of entries) {
+    if (entry.weight === null || !Number.isFinite(entry.weight)) {
+      return null;
+    }
+    total += entry.weight;
+  }
+  return total;
+}
+
+export function formatProviderKindLabel(provider: ProviderKind): string {
+  switch (provider) {
+    case "codex":
+      return "Codex";
+    case "claudeAgent":
+      return "Claude";
+    case "cursor":
+      return "Cursor";
+    case "antigravity":
+      return "Antigravity";
+    case "grok":
+      return "Grok";
+    case "droid":
+      return "Droid";
+    case "kilo":
+      return "Kilo";
+    case "opencode":
+      return "OpenCode";
+    case "pi":
+      return "Pi";
+  }
+}
+
+function capitalizeWord(value: string): string {
+  return value.length > 0 ? value[0]!.toUpperCase() + value.slice(1) : value;
 }

--- a/apps/web/src/components/settings/ProfileSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProfileSettingsPanel.tsx
@@ -2,24 +2,29 @@
 // Purpose: Local-first profile / stats dashboard rendered inside Settings → Profile. Core
 // stats render instantly from a fast SQL RPC; lifetime/peak token figures and the tokens/day
 // heatmap stream in from a second DB-backed RPC. Centered, low-chrome layout
-// with an explicit edit mode for the local name + handle.
+// with an explicit edit mode for the local name + handle. Chart accents use
+// lightweight SVG (donut mix, insight rings, token sparkline) rather than a chart library.
 // Layer: web profile feature (settings panel body).
 
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { type ProfileStats, type ProfileTokenStats, type ProviderKind } from "@synara/contracts";
+import { type ProfileStats, type ProfileTokenStats } from "@synara/contracts";
 import {
   serverProfileStatsQueryOptions,
   serverProfileTokenStatsQueryOptions,
 } from "~/lib/serverReactQuery";
 import { CentralIcon } from "~/lib/central-icons";
-import { ProviderIcon } from "~/components/ProviderIcon";
 import { Button } from "~/components/ui/button";
 import { Skeleton } from "~/components/ui/skeleton";
 import { ActivityHeatmap } from "../profile/ActivityHeatmap";
+import { InsightProgressRings } from "../profile/InsightProgressRings";
+import { ModelUsageDonut } from "../profile/ModelUsageDonut";
 import {
+  formatProviderKindLabel,
   selectProfileHeatmap,
+  selectProfileInsightRings,
   selectProfileModelUsage,
+  selectProfileSparkline,
   selectProfileTopProvider,
 } from "../profile/profileSelectors";
 import { ShareDialog } from "../profile/ShareDialog";
@@ -35,6 +40,7 @@ import {
   formatNumber,
   toDisplayName,
 } from "../profile/profileFormatting";
+import { TokenSparkline } from "../profile/TokenSparkline";
 
 export function ProfileSettingsPanel() {
   const coreQuery = useQuery(serverProfileStatsQueryOptions());
@@ -85,163 +91,201 @@ function ProfileContent({
   const heatmap = selectProfileHeatmap(stats, tokenStats);
   const topProvider = selectProfileTopProvider(stats, tokenStats);
   const modelUsage = selectProfileModelUsage(stats, tokenStats);
+  const sparkline = selectProfileSparkline(stats, tokenStats, 28);
+  const insightRings = selectProfileInsightRings(stats, tokenStats);
   const peakHourLabel = formatPeakHourLabel(stats.activeHours.startHour);
   const mostWorkedProjectLabel = formatMostWorkedProjectLabel(stats.mostWorkedProject);
 
   return (
-    <div className="flex min-w-0 flex-col gap-7">
-      {/* Action row */}
-      <div className="flex items-center justify-end gap-2">
-        <Button variant="outline" size="sm" onClick={() => setShareOpen(true)}>
-          <CentralIcon name="share-os" />
-          Share
-        </Button>
-        <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>
-          <CentralIcon name="pencil" />
-          Edit
-        </Button>
-      </div>
-
-      {/* Centered identity header */}
-      <header className="flex flex-col items-center gap-3 text-center">
-        <ProfileAvatar
-          initials={stats.identity.initials}
-          color={avatarColor}
-          image={avatarImage}
-          className="size-16 shadow-sm"
-          textClassName="text-xl"
-        />
-        <div className="flex flex-col items-center gap-1.5">
-          <h2 className="text-2xl font-semibold tracking-tight">{name}</h2>
-          <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
-            <span>{handle}</span>
-            <span aria-hidden>·</span>
-            <span className="rounded-full border px-1.5 py-px text-xs text-muted-foreground">
-              Synara
-            </span>
+    <div className="flex min-w-0 flex-col gap-5">
+      {/* Profile overview */}
+      <section className="overflow-hidden rounded-lg border border-border/60 bg-background/30">
+        <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between sm:p-5">
+          <header className="flex min-w-0 items-center gap-3">
+            <ProfileAvatar
+              initials={stats.identity.initials}
+              color={avatarColor}
+              image={avatarImage}
+              className="size-12 shadow-sm sm:size-14"
+              textClassName="text-lg"
+            />
+            <div className="flex min-w-0 flex-col gap-1">
+              <h2 className="truncate text-lg font-semibold tracking-tight text-foreground">
+                {name}
+              </h2>
+              <div className="flex items-center gap-1.5 truncate text-xs text-muted-foreground">
+                <span>{handle}</span>
+                <span aria-hidden>·</span>
+                <span className="rounded-full border px-1.5 py-px text-xs text-muted-foreground">
+                  Synara
+                </span>
+              </div>
+            </div>
+          </header>
+          <div className="flex shrink-0 gap-2">
+            <Button variant="outline" size="sm" onClick={() => setShareOpen(true)}>
+              <CentralIcon name="share-os" />
+              Share
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>
+              <CentralIcon name="pencil" />
+              Edit
+            </Button>
           </div>
         </div>
-      </header>
 
-      {/* Stat tiles */}
-      <div className="grid grid-cols-2 divide-x divide-y divide-border/50 overflow-hidden rounded-2xl border border-border/60 sm:grid-cols-3 lg:grid-cols-5 lg:divide-y-0">
-        <StatTile
-          label="Lifetime tokens"
-          value={tokensPending ? null : formatCompact(tokenStats?.lifetimeTotalTokens ?? null)}
-        />
-        <StatTile
-          label="Peak day"
-          value={tokensPending ? null : formatCompact(tokenStats?.peakDayTokens ?? null)}
-        />
-        <StatTile label="Total prompts" value={formatNumber(stats.activity.totalPromptsSent)} />
-        <StatTile label="Current streak" value={formatDays(stats.activity.currentStreakDays)} />
-        <StatTile label="Longest streak" value={formatDays(stats.activity.longestStreakDays)} />
-      </div>
-
-      {/* Heatmap */}
-      <section className="flex min-w-0 flex-col gap-3">
-        <h3 className="text-sm font-medium">Activity</h3>
-        {tokensPending ? (
-          <Skeleton className="h-28 w-full rounded-lg" />
-        ) : (
-          <ActivityHeatmap
-            cells={heatmap.cells}
-            fill
-            radius={5}
-            gap={3}
-            tooltip
-            tooltipUnit={heatmap.unit}
-            showMonths
-            monthsPosition="bottom"
+        {/* Primary metrics */}
+        <div className="grid grid-cols-2 divide-x divide-y divide-border/50 sm:grid-cols-4 sm:divide-y-0">
+          <StatTile
+            label="Lifetime tokens"
+            value={tokensPending ? null : formatCompact(tokenStats?.lifetimeTotalTokens ?? null)}
+            footer={
+              tokensPending ? (
+                <Skeleton className="h-7 w-full rounded-sm" />
+              ) : (
+                <TokenSparkline
+                  values={sparkline.values}
+                  aria-label={
+                    sparkline.unit === "tokens"
+                      ? "Daily token usage, last 28 days"
+                      : "Daily prompt activity, last 28 days"
+                  }
+                />
+              )
+            }
           />
-        )}
+
+          <StatTile label="Total prompts" value={formatNumber(stats.activity.totalPromptsSent)} />
+          <StatTile label="Current streak" value={formatDays(stats.activity.currentStreakDays)} />
+          <StatTile label="Longest streak" value={formatDays(stats.activity.longestStreakDays)} />
+        </div>
       </section>
 
-      {/* Insights + plugins */}
-      <div className="grid gap-x-12 gap-y-7 md:grid-cols-2">
-        <section className="flex flex-col gap-3">
-          <h3 className="text-sm font-medium">Activity insights</h3>
-          <dl className="flex flex-col gap-2.5">
-            <InsightRow
-              label="Most used provider"
-              value={
-                topProvider.provider
-                  ? `${formatProviderLabel(topProvider.provider)}${
-                      topProvider.percent !== null ? ` · ${topProvider.percent}%` : ""
-                    }`
-                  : "—"
-              }
+      {/* Activity */}
+      <section className="flex min-w-0 flex-col gap-2">
+        <div className="flex items-baseline justify-between gap-3">
+          <h3 className="text-sm font-medium">Activity</h3>
+          <span className="text-xs text-muted-foreground">Daily activity</span>
+        </div>
+        <div className="rounded-lg border border-border/60 p-4 sm:p-5">
+          {tokensPending ? (
+            <Skeleton className="h-28 w-full rounded-lg" />
+          ) : (
+            <ActivityHeatmap
+              cells={heatmap.cells}
+              fill
+              radius={5}
+              gap={3}
+              tooltip
+              tooltipUnit={heatmap.unit}
+              showMonths
+              monthsPosition="bottom"
             />
-            <InsightRow
-              label="Most used reasoning"
-              value={
-                stats.insights.topReasoning
-                  ? `${capitalize(stats.insights.topReasoning)}${
-                      stats.insights.topReasoningPercent !== null
-                        ? ` · ${stats.insights.topReasoningPercent}%`
-                        : ""
-                    }`
-                  : "—"
-              }
-            />
-            <InsightRow label="Most active hour" value={peakHourLabel} />
-            <InsightRow label="Most worked project" value={mostWorkedProjectLabel} />
-            <InsightRow
-              label="Skills explored"
-              value={formatNumber(stats.insights.skillsExplored)}
-            />
-            <InsightRow
-              label="Total skills used"
-              value={formatNumber(stats.insights.totalSkillsUsed)}
-            />
-            <InsightRow label="Total threads" value={formatNumber(stats.activity.totalThreads)} />
-          </dl>
+          )}
+        </div>
+      </section>
+
+      {/* Insights + skills */}
+      <div className="grid gap-5 lg:grid-cols-2">
+        <section className="flex flex-col gap-2">
+          <h3 className="text-sm font-medium">Insights</h3>
+          <div className="flex flex-col gap-4 rounded-lg border border-border/60 p-4 sm:p-5">
+            <InsightProgressRings rings={insightRings.rings} />
+            <dl className="flex flex-col gap-2.5">
+              {/* Rings already carry provider / reasoning share — only fall back to rows when missing. */}
+              {!insightRings.rings.some((ring) => ring.id === "provider") ? (
+                <InsightRow
+                  label="Most used provider"
+                  value={
+                    topProvider.provider
+                      ? `${formatProviderKindLabel(topProvider.provider)}${
+                          topProvider.percent !== null
+                            ? ` · ${formatSharePercent(topProvider.percent)}`
+                            : ""
+                        }`
+                      : "—"
+                  }
+                />
+              ) : null}
+              {!insightRings.rings.some((ring) => ring.id === "reasoning") ? (
+                <InsightRow
+                  label="Most used reasoning"
+                  value={
+                    stats.insights.topReasoning
+                      ? `${capitalize(stats.insights.topReasoning)}${
+                          stats.insights.topReasoningPercent !== null
+                            ? ` · ${formatSharePercent(stats.insights.topReasoningPercent)}`
+                            : ""
+                        }`
+                      : "—"
+                  }
+                />
+              ) : null}
+              <InsightRow label="Most active hour" value={peakHourLabel} />
+              <InsightRow label="Most worked project" value={mostWorkedProjectLabel} />
+              <InsightRow
+                label="Skills explored"
+                value={formatNumber(stats.insights.skillsExplored)}
+              />
+              <InsightRow
+                label="Total skills used"
+                value={formatNumber(stats.insights.totalSkillsUsed)}
+              />
+              <InsightRow label="Total threads" value={formatNumber(stats.activity.totalThreads)} />
+            </dl>
+          </div>
         </section>
 
-        <section className="flex flex-col gap-3">
-          <h3 className="text-sm font-medium">Most used plugins</h3>
-          {stats.skills.length > 0 ? (
-            <ul className="flex flex-col gap-2.5">
-              {stats.skills.slice(0, 6).map((skill) => (
-                <li
-                  key={`${skill.kind}:${skill.name}`}
-                  className="flex items-center justify-between gap-3"
-                >
-                  <span className="flex min-w-0 items-center gap-2.5">
-                    <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-muted/60">
-                      <CentralIcon
-                        name={skill.kind === "agent" ? "agent" : "building-blocks"}
-                        className="size-3"
-                      />
+        <section className="flex flex-col gap-2">
+          <h3 className="text-sm font-medium">Skills and agents</h3>
+          <div className="rounded-lg border border-border/60 p-4 sm:p-5">
+            {stats.skills.length > 0 ? (
+              <ul className="flex flex-col gap-2.5">
+                {stats.skills.slice(0, 6).map((skill) => (
+                  <li
+                    key={`${skill.kind}:${skill.name}`}
+                    className="flex items-center justify-between gap-3"
+                  >
+                    <span className="flex min-w-0 items-center gap-2.5">
+                      <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-muted/60">
+                        <CentralIcon
+                          name={skill.kind === "agent" ? "agent" : "building-blocks"}
+                          className="size-3"
+                        />
+                      </span>
+                      <span className="truncate text-sm">{skill.displayName}</span>
                     </span>
-                    <span className="truncate text-sm">{skill.displayName}</span>
-                  </span>
-                  <span className="shrink-0 text-sm tabular-nums text-muted-foreground">
-                    {formatNumber(skill.runCount)} runs
-                  </span>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p className="text-sm text-muted-foreground">No skills or agents used yet.</p>
-          )}
+                    <span className="shrink-0 text-sm tabular-nums text-muted-foreground">
+                      {formatNumber(skill.runCount)} runs
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">No skills or agents used yet.</p>
+            )}
+          </div>
         </section>
       </div>
 
       {/* Model usage */}
-      <section className="flex flex-col gap-3">
-        <h3 className="text-sm font-medium">Model usage</h3>
+      <section className="flex flex-col gap-2">
+        <div className="flex items-baseline justify-between gap-3">
+          <h3 className="text-sm font-medium">Model usage</h3>
+          {modelUsage.entries.length > 0 ? (
+            <span className="text-xs text-muted-foreground">
+              by {modelUsage.metric === "tokens" ? "tokens" : "turns"}
+            </span>
+          ) : null}
+        </div>
         {modelUsage.entries.length > 0 ? (
-          <ul className="grid grid-cols-1 gap-x-12 gap-y-3 sm:grid-cols-2">
-            {modelUsage.entries.slice(0, 6).map((entry) => (
-              <ModelUsageRow
-                key={`${entry.provider}:${entry.model}`}
-                provider={entry.provider}
-                model={entry.model}
-                percent={entry.percent}
-              />
-            ))}
-          </ul>
+          <div className="rounded-lg border border-border/60 p-4 sm:p-5">
+            <ModelUsageDonut
+              entries={modelUsage.entries}
+              metric={modelUsage.metric}
+              totalWeight={modelUsage.totalWeight}
+            />
+          </div>
         ) : (
           <p className="text-sm text-muted-foreground">No model activity yet.</p>
         )}
@@ -284,15 +328,24 @@ function ProfileContent({
 
 // ── Small pieces ───────────────────────────────────────────────────────
 
-function StatTile({ label, value }: { label: string; value: string | null }) {
+function StatTile({
+  label,
+  value,
+  footer,
+}: {
+  label: string;
+  value: string | null;
+  footer?: ReactNode;
+}) {
   return (
-    <div className="flex flex-col items-center gap-0.5 px-3 py-3">
+    <div className="flex flex-col items-center gap-1.5 px-3 py-3">
       {value === null ? (
         <Skeleton className="h-4 w-12" />
       ) : (
         <span className="text-sm font-normal tabular-nums text-foreground">{value}</span>
       )}
       <span className="text-sm font-normal text-muted-foreground">{label}</span>
+      {footer ? <div className="mt-0.5 w-full max-w-30">{footer}</div> : null}
     </div>
   );
 }
@@ -327,59 +380,9 @@ function formatMostWorkedProjectLabel(project: ProfileStats["mostWorkedProject"]
   return `${project.title} · ${formatNumber(project.promptCount)} ${promptLabel}`;
 }
 
-function formatProviderLabel(provider: ProviderKind): string {
-  switch (provider) {
-    case "codex":
-      return "Codex";
-    case "claudeAgent":
-      return "Claude";
-    case "cursor":
-      return "Cursor";
-    case "antigravity":
-      return "Antigravity";
-    case "grok":
-      return "Grok";
-    case "droid":
-      return "Droid";
-    case "kilo":
-      return "Kilo";
-    case "opencode":
-      return "OpenCode";
-    case "pi":
-      return "Pi";
-  }
-}
-
-function ModelUsageRow({
-  provider,
-  model,
-  percent,
-}: {
-  provider: ProviderKind | "unknown";
-  model: string;
-  percent: number;
-}) {
-  return (
-    <li className="flex flex-col gap-1.5">
-      <div className="flex items-center justify-between gap-3 text-sm">
-        <span className="flex min-w-0 items-center gap-2">
-          {provider !== "unknown" ? (
-            <ProviderIcon provider={provider} className="size-3.5 shrink-0" />
-          ) : (
-            <CentralIcon name="chart-2" className="size-3.5 shrink-0 text-muted-foreground" />
-          )}
-          <span className="truncate">{model}</span>
-        </span>
-        <span className="shrink-0 tabular-nums text-muted-foreground">{percent}%</span>
-      </div>
-      <div className="h-1 w-full overflow-hidden rounded-full bg-muted">
-        <div
-          className="h-full rounded-full bg-[var(--info)]"
-          style={{ width: `${Math.min(100, Math.max(2, percent))}%` }}
-        />
-      </div>
-    </li>
-  );
+function formatSharePercent(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? `${rounded}%` : `${rounded.toFixed(1)}%`;
 }
 
 function ProfileSkeleton() {
@@ -390,12 +393,13 @@ function ProfileSkeleton() {
         <Skeleton className="h-6 w-40" />
         <Skeleton className="h-3 w-24" />
       </div>
-      <Skeleton className="h-[72px] w-full rounded-2xl" />
+      <Skeleton className="h-18 w-full rounded-2xl" />
       <Skeleton className="h-24 w-full rounded-lg" />
       <div className="grid w-full gap-7 md:grid-cols-2">
         <Skeleton className="h-40 w-full rounded-lg" />
         <Skeleton className="h-40 w-full rounded-lg" />
       </div>
+      <Skeleton className="h-48 w-full rounded-2xl" />
     </div>
   );
 }


### PR DESCRIPTION
## What Changed

- Redesigned the profile analytics panel with model usage and token visualizations.
- Added lightweight SVG components for:
  - Model usage donut charts
  - Token usage sparklines
  - Provider and reasoning progress rings
- Extracted shared chart geometry and palette helpers.
- Extended profile selector test coverage.

## Why

The existing profile analytics view presented usage data as basic progress bars, which made comparisons and trends difficult to read. This change gives the profile page clearer visual summaries while keeping the implementation lightweight and dependency-free.

The chart calculations are isolated in reusable helpers, and the selectors/components include focused tests for the new behavior.

## UI Changes

This PR updates the profile analytics UI with new charts and visual summaries.

| Before | After |
| :---: | :---: |
| <img height="520" alt="Before" src="https://github.com/user-attachments/assets/93784ec7-ae2b-473d-8f00-10ade234a048" />  | <img height="520" alt="After" src="https://github.com/user-attachments/assets/eb7f6915-1aaa-4d86-9ac4-b7cecf01e707" /> |

video for animation/interaction changes

https://github.com/user-attachments/assets/6c463733-7238-41fc-8400-6adaff61da32


## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes