### PR TITLE
refactor(provider/acp): generalize session lifecycle helpers

### DIFF
--- a/apps/server/src/provider/Layers/DroidAdapter.ts
+++ b/apps/server/src/provider/Layers/DroidAdapter.ts
@@ -111,8 +111,8 @@ import {
   makeDroidAcpRuntime,
   type DroidAcpRuntimeSettings,
 } from "../acp/DroidAcpSupport.ts";
-import { makeDroidSessionTeardownGate } from "../acp/DroidSessionTeardownGate.ts";
-import { cancelDroidTurnAndWait } from "../acp/DroidTurnCancellation.ts";
+import { makeSessionTeardownGate } from "../acp/SessionTeardownGate.ts";
+import { cancelTurnAndWait } from "../acp/TurnCancellation.ts";
 import {
   elicitationQuestionsFromRequest,
   elicitationResponseFromAnswers,
@@ -392,7 +392,7 @@ export function makeDroidAdapter(
       options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
 
     const sessions = new Map<ThreadId, DroidSessionContext>();
-    const sessionTeardownGate = makeDroidSessionTeardownGate();
+    const sessionTeardownGate = makeSessionTeardownGate();
     const modelDiscoveryCache = new Map<
       string,
       { readonly expiresAt: number; readonly result: ProviderListModelsResult }
@@ -642,7 +642,7 @@ export function makeDroidAdapter(
       promptFiber: Fiber.Fiber<void, never> | undefined,
     ) =>
       Effect.gen(function* () {
-        const result = yield* cancelDroidTurnAndWait({
+        const result = yield* cancelTurnAndWait({
           cancel: ctx.acp.cancel,
           promptFiber,
           graceMs: DROID_CANCEL_GRACE_MS,

--- a/apps/server/src/provider/acp/AcpConfigOptions.ts
+++ b/apps/server/src/provider/acp/AcpConfigOptions.ts
@@ -1,0 +1,65 @@
+/**
+ * Provider-neutral ACP session-config interpretation, shared by the Droid and
+ * OMP ACP support modules.
+ *
+ * @module AcpConfigOptions
+ */
+import { type ProviderModelDescriptor } from "@synara/contracts";
+import type * as Acp from "@agentclientprotocol/sdk";
+
+export function availableAuthMethodIds(
+  initializeResult: Acp.InitializeResponse,
+): ReadonlySet<string> {
+  return new Set((initializeResult.authMethods ?? []).map((method) => method.id.trim()));
+}
+
+export function flattenConfigOptions(
+  options: Acp.SessionConfigSelectOptions,
+): ReadonlyArray<Acp.SessionConfigSelectOption> {
+  return options.flatMap((entry) => ("options" in entry ? entry.options : [entry]));
+}
+
+export function findSelectConfig(
+  options: ReadonlyArray<Acp.SessionConfigOption>,
+  input: { readonly id: string; readonly category: string },
+): Extract<Acp.SessionConfigOption, { readonly type: "select" }> | undefined {
+  return options.find(
+    (option): option is Extract<Acp.SessionConfigOption, { readonly type: "select" }> =>
+      option.type === "select" && (option.id === input.id || option.category === input.category),
+  );
+}
+
+export function buildAcpModelDescriptor(
+  model: Acp.SessionConfigSelectOption,
+  levelOption: Extract<Acp.SessionConfigOption, { readonly type: "select" }> | undefined,
+): ProviderModelDescriptor {
+  const efforts = levelOption ? flattenConfigOptions(levelOption.options) : [];
+  const optionDescriptors = levelOption
+    ? [
+        {
+          id: "reasoningEffort",
+          label: levelOption.name,
+          type: "select" as const,
+          options: efforts.map((effort) => ({
+            id: effort.value,
+            label: effort.name,
+            ...(effort.description ? { description: effort.description } : {}),
+          })),
+          ...(levelOption.currentValue ? { currentValue: levelOption.currentValue } : {}),
+        },
+      ]
+    : undefined;
+  return {
+    slug: model.value,
+    name: model.name,
+    ...(model.description ? { description: model.description } : {}),
+    supportedReasoningEfforts: efforts.map((effort) => ({
+      value: effort.value,
+      label: effort.name,
+      ...(effort.description ? { description: effort.description } : {}),
+    })),
+    ...(optionDescriptors ? { optionDescriptors } : {}),
+    supportsFastMode: false,
+    supportsThinkingToggle: false,
+  };
+}

--- a/apps/server/src/provider/acp/DroidAcpSupport.ts
+++ b/apps/server/src/provider/acp/DroidAcpSupport.ts
@@ -24,6 +24,12 @@ import {
   type AcpSessionRuntimeShape,
   type AcpSpawnInput,
 } from "./AcpSessionRuntime.ts";
+import {
+  availableAuthMethodIds,
+  buildAcpModelDescriptor,
+  findSelectConfig,
+  flattenConfigOptions,
+} from "./AcpConfigOptions.ts";
 
 export interface DroidAcpRuntimeSettings {
   readonly appendSystemPrompt?: string;
@@ -126,10 +132,6 @@ export function buildDroidAcpSpawnInput(
   };
 }
 
-function availableAuthMethodIds(initializeResult: Acp.InitializeResponse): ReadonlySet<string> {
-  return new Set((initializeResult.authMethods ?? []).map((method) => method.id.trim()));
-}
-
 export const resolveDroidAcpAuthMethodId = (
   initializeResult: Acp.InitializeResponse,
 ): Effect.Effect<string, AcpErrors.AcpError> =>
@@ -224,57 +226,6 @@ export function applyDroidAcpInteractionMode<E>(input: {
   );
 }
 
-export function flattenDroidConfigOptions(
-  options: Acp.SessionConfigSelectOptions,
-): ReadonlyArray<Acp.SessionConfigSelectOption> {
-  return options.flatMap((entry) => ("options" in entry ? entry.options : [entry]));
-}
-
-function findDroidSelectConfig(
-  options: ReadonlyArray<Acp.SessionConfigOption>,
-  input: { readonly id: string; readonly category: string },
-): Extract<Acp.SessionConfigOption, { readonly type: "select" }> | undefined {
-  return options.find(
-    (option): option is Extract<Acp.SessionConfigOption, { readonly type: "select" }> =>
-      option.type === "select" && (option.id === input.id || option.category === input.category),
-  );
-}
-
-function droidModelDescriptor(
-  model: Acp.SessionConfigSelectOption,
-  reasoning: Extract<Acp.SessionConfigOption, { readonly type: "select" }> | undefined,
-): ProviderModelDescriptor {
-  const efforts = reasoning ? flattenDroidConfigOptions(reasoning.options) : [];
-  const optionDescriptors = reasoning
-    ? [
-        {
-          id: "reasoningEffort",
-          label: reasoning.name,
-          type: "select" as const,
-          options: efforts.map((effort) => ({
-            id: effort.value,
-            label: effort.name,
-            ...(effort.description ? { description: effort.description } : {}),
-          })),
-          ...(reasoning.currentValue ? { currentValue: reasoning.currentValue } : {}),
-        },
-      ]
-    : undefined;
-  return {
-    slug: model.value,
-    name: model.name,
-    ...(model.description ? { description: model.description } : {}),
-    supportedReasoningEfforts: efforts.map((effort) => ({
-      value: effort.value,
-      label: effort.name,
-      ...(effort.description ? { description: effort.description } : {}),
-    })),
-    ...(optionDescriptors ? { optionDescriptors } : {}),
-    supportsFastMode: false,
-    supportsThinkingToggle: false,
-  };
-}
-
 /**
  * Reads the model catalog from ACP and reselects each model so Droid returns that
  * model's current reasoning choices. Discovery runs in a disposable session.
@@ -284,7 +235,7 @@ export function discoverDroidAcpModels(
 ): Effect.Effect<ProviderListModelsResult, AcpErrors.AcpError> {
   return Effect.gen(function* () {
     const initialOptions = yield* runtime.getConfigOptions;
-    const modelConfig = findDroidSelectConfig(initialOptions, {
+    const modelConfig = findSelectConfig(initialOptions, {
       id: DROID_MODEL_CONFIG_ID,
       category: "model",
     });
@@ -296,27 +247,27 @@ export function discoverDroidAcpModels(
     }
 
     const originalModel = modelConfig.currentValue;
-    const originalReasoning = findDroidSelectConfig(initialOptions, {
+    const originalReasoning = findSelectConfig(initialOptions, {
       id: DROID_REASONING_EFFORT_CONFIG_ID,
       category: "thought_level",
     })?.currentValue;
-    const models = flattenDroidConfigOptions(modelConfig.options);
+    const models = flattenConfigOptions(modelConfig.options);
     const descriptors = yield* Effect.forEach(
       models,
       (model) =>
         runtime.setConfigOption(modelConfig.id, model.value).pipe(
           Effect.andThen(runtime.getConfigOptions),
           Effect.map((updatedOptions) =>
-            droidModelDescriptor(
+            buildAcpModelDescriptor(
               model,
-              findDroidSelectConfig(updatedOptions, {
+              findSelectConfig(updatedOptions, {
                 id: DROID_REASONING_EFFORT_CONFIG_ID,
                 category: "thought_level",
               }),
             ),
           ),
           // A newly announced model should remain selectable even if its option probe fails.
-          Effect.catch(() => Effect.succeed(droidModelDescriptor(model, undefined))),
+          Effect.catch(() => Effect.succeed(buildAcpModelDescriptor(model, undefined))),
         ),
       { concurrency: 1 },
     );

--- a/apps/server/src/provider/acp/SessionTeardownGate.test.ts
+++ b/apps/server/src/provider/acp/SessionTeardownGate.test.ts
@@ -2,13 +2,13 @@ import { ThreadId } from "@synara/contracts";
 import { Deferred, Effect, Fiber } from "effect";
 import { describe, expect, it } from "vitest";
 
-import { makeDroidSessionTeardownGate } from "./DroidSessionTeardownGate.ts";
+import { makeSessionTeardownGate } from "./SessionTeardownGate.ts";
 
-describe("DroidSessionTeardownGate", () => {
+describe("SessionTeardownGate", () => {
   it("blocks replacement work until the tracked teardown completes", async () => {
     await Effect.runPromise(
       Effect.gen(function* () {
-        const gate = makeDroidSessionTeardownGate();
+        const gate = makeSessionTeardownGate();
         const threadId = ThreadId.makeUnsafe("thread-1");
         const completion = yield* Deferred.make<void>();
         let replacementStarted = false;
@@ -37,7 +37,7 @@ describe("DroidSessionTeardownGate", () => {
   it("does not let stale cleanup clear a newer teardown gate", async () => {
     await Effect.runPromise(
       Effect.gen(function* () {
-        const gate = makeDroidSessionTeardownGate();
+        const gate = makeSessionTeardownGate();
         const threadId = ThreadId.makeUnsafe("thread-1");
         const oldCompletion = yield* Deferred.make<void>();
         const newCompletion = yield* Deferred.make<void>();

--- a/apps/server/src/provider/acp/SessionTeardownGate.ts
+++ b/apps/server/src/provider/acp/SessionTeardownGate.ts
@@ -1,11 +1,11 @@
-// FILE: DroidSessionTeardownGate.ts
-// Purpose: Prevents a replacement Droid ACP runtime from starting before its predecessor exits.
+// FILE: SessionTeardownGate.ts
+// Purpose: Prevents a replacement ACP runtime from starting before its predecessor exits.
 // Layer: Provider ACP lifecycle coordination
 
 import type { ThreadId } from "@synara/contracts";
 import { Deferred, Effect } from "effect";
 
-export interface DroidSessionTeardownGate {
+export interface SessionTeardownGate {
   readonly track: (threadId: ThreadId, completion: Deferred.Deferred<void>) => void;
   readonly isPending: (threadId: ThreadId) => boolean;
   readonly awaitPending: (threadId: ThreadId) => Effect.Effect<void>;
@@ -15,7 +15,7 @@ export interface DroidSessionTeardownGate {
   ) => Effect.Effect<void>;
 }
 
-export function makeDroidSessionTeardownGate(): DroidSessionTeardownGate {
+export function makeSessionTeardownGate(): SessionTeardownGate {
   const pendingByThreadId = new Map<ThreadId, Deferred.Deferred<void>>();
 
   return {

--- a/apps/server/src/provider/acp/TurnCancellation.test.ts
+++ b/apps/server/src/provider/acp/TurnCancellation.test.ts
@@ -1,15 +1,15 @@
 import { Deferred, Effect, Fiber } from "effect";
 import { describe, expect, it } from "vitest";
 
-import { cancelDroidTurnAndWait } from "./DroidTurnCancellation.ts";
+import { cancelTurnAndWait } from "./TurnCancellation.ts";
 
-describe("cancelDroidTurnAndWait", () => {
-  it("keeps the prompt fiber alive until Droid settles it", async () => {
+describe("cancelTurnAndWait", () => {
+  it("keeps the prompt fiber alive until the provider settles it", async () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const promptComplete = yield* Deferred.make<void>();
         const promptFiber = yield* Deferred.await(promptComplete).pipe(Effect.forkChild);
-        const cancellationFiber = yield* cancelDroidTurnAndWait({
+        const cancellationFiber = yield* cancelTurnAndWait({
           cancel: Effect.void,
           promptFiber,
           graceMs: 5_000,
@@ -31,7 +31,7 @@ describe("cancelDroidTurnAndWait", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const promptFiber = yield* Effect.never.pipe(Effect.forkChild);
-        const result = yield* cancelDroidTurnAndWait({
+        const result = yield* cancelTurnAndWait({
           cancel: Effect.void,
           promptFiber,
           graceMs: 10,

--- a/apps/server/src/provider/acp/TurnCancellation.ts
+++ b/apps/server/src/provider/acp/TurnCancellation.ts
@@ -1,20 +1,20 @@
-// FILE: DroidTurnCancellation.ts
+// FILE: TurnCancellation.ts
 // Purpose: Sends ACP turn cancellation, waits for the prompt response, then escalates if needed.
 // Layer: Provider ACP lifecycle coordination
 
 import { Cause, Effect, Exit, Fiber, Option } from "effect";
 
-export interface DroidTurnCancellationResult {
+export interface TurnCancellationResult {
   readonly cancelRequest: "sent" | "failed" | "timedOut";
   readonly cancelFailure?: string;
   readonly prompt: "notStarted" | "settled" | "timedOut";
 }
 
-export function cancelDroidTurnAndWait(input: {
+export function cancelTurnAndWait(input: {
   readonly cancel: Effect.Effect<void, unknown>;
   readonly promptFiber: Fiber.Fiber<void, never> | undefined;
   readonly graceMs: number;
-}): Effect.Effect<DroidTurnCancellationResult> {
+}): Effect.Effect<TurnCancellationResult> {
   return Effect.gen(function* () {
     const cancelExit = yield* input.cancel.pipe(Effect.timeoutOption(input.graceMs), Effect.exit);
     const cancelRequest = Exit.isFailure(cancelExit)


### PR DESCRIPTION
Prerequisite follow-up for #496. This isolates the ACP session-teardown and turn-cancellation helper extraction from the OMP feature implementation so it can be reviewed independently.

The cumulative OMP branch contains this same prerequisite commit; after this PR merges, #496 can be rebased to remove the duplicate prerequisite.

Validation: the server-focused test suite and TypeScript checks passed. The full repository test command still has the existing web localStorage failures reproduced on upstream main.