### PR TITLE
feat(web): add OMP catalog and thinking picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added a compensating checkpoint-revert saga that captures the pre-revert worktree in a managed rescue ref and restores it if provider conversation rollback fails.
 - Added deterministic, retryable revert completion and user-visible failure activities that identify retained rescue refs when manual recovery may be needed.
 - Added bounded provider-command attempts and urgent lifecycle control so one unresponsive adapter or per-thread lock cannot stall every task.
+- Added Oh My Pi (OMP) as an ACP provider, with model discovery via `omp models --json`, per-model reasoning efforts (including `max`), eager catalog pre-warming at startup, and OMP thread/session normalization.
 
 ### Changed
 
@@ -32,6 +33,7 @@
 - Fixed failed stop controls producing no visible explanation in the composer or keyboard shortcut path.
 - Fixed visible thread details being evicted or losing a refresh race and temporarily rendering as an empty conversation.
 - Fixed profile-stat cleanup purging soft-deleted threads without evidence of a manual delete, and retention sweeping archived or newly created fork and handoff threads because of inherited message timestamps.
+- Fixed OMP threads being mislabeled as Codex when the session-provider normalizer fell through to the Codex default instead of preserving the OMP provider.
 
 ### Verification
 

--- a/apps/server/integration/orchestrationEngine.integration.test.ts
+++ b/apps/server/integration/orchestrationEngine.integration.test.ts
@@ -122,8 +122,8 @@ const seedProjectAndThread = (harness: OrchestrationIntegrationHarness) =>
   Effect.gen(function* () {
     const createdAt = nowIso();
     const provider = harness.adapterHarness?.provider ?? "codex";
-    if (provider === "pi") {
-      throw new Error("Pi integration tests require an explicit model selection.");
+    if (provider === "pi" || provider === "omp") {
+      throw new Error("Pi/OMP integration tests require an explicit model selection.");
     }
     const defaultModel = DEFAULT_MODEL_BY_PROVIDER[provider];
 

--- a/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
@@ -806,6 +806,7 @@ function makeHarnessLayer(
     "kilo",
     "opencode",
     "pi",
+    "omp",
   ];
   let providerStatuses =
     options.providerStatuses ??

--- a/apps/server/src/agentGateway/harnessPolicy.ts
+++ b/apps/server/src/agentGateway/harnessPolicy.ts
@@ -75,6 +75,7 @@ const PROVIDERS_WITH_THREAD_SCOPED_SYNARA_MCP = new Set<ProviderKind>([
   "opencode",
   "kilo",
   "pi",
+  "omp",
 ]);
 
 export function providerHasSynaraGatewayControl(input: {

--- a/apps/server/src/agentGateway/targetResolver.test.ts
+++ b/apps/server/src/agentGateway/targetResolver.test.ts
@@ -307,6 +307,13 @@ describe("agent gateway target resolver", () => {
           rejectedValue: "invented",
         },
         {
+          provider: "omp",
+          descriptor: makeEffortDescriptor("omp-model", "max"),
+          optionKey: "thinkingLevel",
+          acceptedValue: "max",
+          rejectedValue: "invented",
+        },
+        {
           provider: "antigravity",
           descriptor: makeEffortDescriptor("antigravity-model", "low"),
           optionKey: "reasoningEffort",
@@ -386,6 +393,47 @@ describe("agent gateway target resolver", () => {
           assert.equal(rejected.code, "model_option_unavailable");
         }
       }
+    }),
+  );
+  it.effect("accepts OMP's max thinking level via the global routing rule on a bare model", () =>
+    Effect.gen(function* () {
+      // A bare descriptor (no supportedReasoningEfforts, no optionDescriptors) forces
+      // validateEffortOption's global fallback (rule.allowedValues) — the only path that
+      // consults OMP_THINKING_LEVEL_OPTIONS, the set that distinguishes omp from pi by
+      // adding "max". The sibling table test advertises per-model efforts and so never
+      // reaches this fallback; without this case, reverting the omp arm to
+      // PI_THINKING_LEVEL_OPTIONS would leave the suite green.
+      const descriptor: ProviderModelDescriptor = { slug: "omp-bare", name: "omp-bare" };
+      const providerDiscovery = {
+        listModels: () => Effect.succeed({ source: "test", models: [descriptor] }),
+      } as unknown as ProviderDiscoveryServiceShape;
+
+      const accepted = yield* resolveAgentGatewayTarget({
+        target: {
+          provider: "omp",
+          model: "omp-bare",
+          options: { thinkingLevel: "max" },
+        } as unknown as ModelSelection,
+        discovery: providerDiscovery,
+      });
+      assert.deepEqual(accepted, {
+        provider: "omp",
+        model: "omp-bare",
+        options: { thinkingLevel: "max" },
+      });
+
+      const rejected = yield* resolveAgentGatewayTarget({
+        target: {
+          provider: "omp",
+          model: "omp-bare",
+          options: { thinkingLevel: "invented" },
+        } as unknown as ModelSelection,
+        discovery: providerDiscovery,
+      }).pipe(
+        Effect.map(() => ({ code: "unexpected-success" })),
+        Effect.catch((error) => Effect.succeed(error)),
+      );
+      assert.equal(rejected.code, "model_option_unavailable");
     }),
   );
 

--- a/apps/server/src/agentGateway/targetResolver.ts
+++ b/apps/server/src/agentGateway/targetResolver.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_MODEL_BY_PROVIDER,
   DROID_REASONING_EFFORT_OPTIONS,
   GROK_REASONING_EFFORT_OPTIONS,
+  OMP_THINKING_LEVEL_OPTIONS,
   PI_THINKING_LEVEL_OPTIONS,
   type ModelSelection,
   type ProviderKind,
@@ -212,6 +213,10 @@ const PROVIDER_TARGET_OPTION_RULES = {
     primaryOptionKey: "thinkingLevel",
     options: { thinkingLevel: providerOptionRule("string", PI_THINKING_LEVEL_OPTIONS) },
   }),
+  omp: defineProviderOptionConfig<"omp">({
+    primaryOptionKey: "thinkingLevel",
+    options: { thinkingLevel: providerOptionRule("string", OMP_THINKING_LEVEL_OPTIONS) },
+  }),
   antigravity: defineProviderOptionConfig<"antigravity">({
     primaryOptionKey: "reasoningEffort",
     options: { reasoningEffort: providerOptionRule("string", [], "model-discovery") },
@@ -239,7 +244,7 @@ const PROVIDER_TARGET_OPTION_RULES = {
 } as const satisfies Record<ProviderKind, ProviderTargetOptionConfig>;
 
 function providerDefaultModel(provider: ProviderKind): string | null {
-  return provider === "pi" ? null : DEFAULT_MODEL_BY_PROVIDER[provider];
+  return provider === "pi" || provider === "omp" ? null : DEFAULT_MODEL_BY_PROVIDER[provider];
 }
 
 export function loadAgentGatewayProviderCatalog(input: {

--- a/apps/server/src/agentGateway/toolInput.ts
+++ b/apps/server/src/agentGateway/toolInput.ts
@@ -19,6 +19,7 @@ export const PROVIDER_KINDS: ReadonlyArray<ProviderKind> = [
   "kilo",
   "opencode",
   "pi",
+  "omp",
 ];
 
 export const MODEL_SELECTION_INPUT_SCHEMA = {
@@ -133,9 +134,9 @@ export function buildModelSelection(
 ): ModelSelection {
   const effectiveModel =
     model ??
-    (provider === "pi"
+    (provider === "pi" || provider === "omp"
       ? undefined
-      : DEFAULT_MODEL_BY_PROVIDER[provider as Exclude<ProviderKind, "pi">]);
+      : DEFAULT_MODEL_BY_PROVIDER[provider as Exclude<ProviderKind, "pi" | "omp">]);
   if (!effectiveModel) {
     throw new ToolInputError(
       `Provider "${provider}" has no default model; pass an explicit "model" argument.`,

--- a/apps/server/src/persistence/modelSelectionCompatibility.ts
+++ b/apps/server/src/persistence/modelSelectionCompatibility.ts
@@ -14,7 +14,8 @@ type ModelProviderKind =
   | "droid"
   | "kilo"
   | "opencode"
-  | "pi";
+  | "pi"
+  | "omp";
 
 const NON_DROID_MODEL_SLUGS = new Set(
   Object.entries(MODEL_OPTIONS_BY_PROVIDER).flatMap(([provider, models]) =>
@@ -50,6 +51,13 @@ function inferProviderFromLabel(label: string): ModelProviderKind | undefined {
   const lowerLabel = label.toLowerCase();
   if (/(^|[^a-z0-9])pi([^a-z0-9]|$)/u.test(lowerLabel)) {
     return "pi";
+  }
+  if (
+    /(^|[^a-z0-9])omp([^a-z0-9]|$)/u.test(lowerLabel) ||
+    lowerLabel.includes("oh-my-pi") ||
+    lowerLabel.includes("oh my pi")
+  ) {
+    return "omp";
   }
   if (lowerLabel.includes("opencode")) {
     return "opencode";
@@ -91,7 +99,8 @@ function inferLegacyModelProvider(provider: unknown, model: string): ModelProvid
     provider === "droid" ||
     provider === "kilo" ||
     provider === "opencode" ||
-    provider === "pi"
+    provider === "pi" ||
+    provider === "omp"
   ) {
     return provider;
   }

--- a/apps/server/src/profileStats.ts
+++ b/apps/server/src/profileStats.ts
@@ -34,6 +34,7 @@ const PROVIDER_KINDS = new Set<ProviderKind>([
   "kilo",
   "opencode",
   "pi",
+  "omp",
 ]);
 
 type HeatmapCell = ProfileStats["activity"]["heatmap"][number];

--- a/apps/server/src/provider/Layers/DroidAdapter.ts
+++ b/apps/server/src/provider/Layers/DroidAdapter.ts
@@ -111,8 +111,8 @@ import {
   makeDroidAcpRuntime,
   type DroidAcpRuntimeSettings,
 } from "../acp/DroidAcpSupport.ts";
-import { makeDroidSessionTeardownGate } from "../acp/DroidSessionTeardownGate.ts";
-import { cancelDroidTurnAndWait } from "../acp/DroidTurnCancellation.ts";
+import { makeSessionTeardownGate } from "../acp/SessionTeardownGate.ts";
+import { cancelTurnAndWait } from "../acp/TurnCancellation.ts";
 import {
   elicitationQuestionsFromRequest,
   elicitationResponseFromAnswers,
@@ -392,7 +392,7 @@ export function makeDroidAdapter(
       options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
 
     const sessions = new Map<ThreadId, DroidSessionContext>();
-    const sessionTeardownGate = makeDroidSessionTeardownGate();
+    const sessionTeardownGate = makeSessionTeardownGate();
     const modelDiscoveryCache = new Map<
       string,
       { readonly expiresAt: number; readonly result: ProviderListModelsResult }
@@ -642,7 +642,7 @@ export function makeDroidAdapter(
       promptFiber: Fiber.Fiber<void, never> | undefined,
     ) =>
       Effect.gen(function* () {
-        const result = yield* cancelDroidTurnAndWait({
+        const result = yield* cancelTurnAndWait({
           cancel: ctx.acp.cancel,
           promptFiber,
           graceMs: DROID_CANCEL_GRACE_MS,

--- a/apps/server/src/provider/Layers/OmpAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OmpAdapter.test.ts
@@ -1,0 +1,114 @@
+import { TurnId } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+import { SYNARA_HARNESS_POLICY_MARKER } from "../../agentGateway/harnessPolicy.ts";
+
+import {
+  classifyOmpPromptTurnCompletion,
+  isOmpNestedTaskToolCall,
+  isRenderableOmpAssistantDelta,
+  resolveOmpSessionCwd,
+  scopeOmpRuntimeItemIdForTurn,
+  scopeOmpToolCallStateForTurn,
+  shouldIgnoreOmpInterrupt,
+  takeOmpSynaraHarnessPolicyTextPart,
+} from "./OmpAdapter.ts";
+
+describe("OMP Synara harness policy", () => {
+  it("delivers private scoped host context once", () => {
+    const state: { harnessPolicyDelivered?: boolean } = {};
+    expect(takeOmpSynaraHarnessPolicyTextPart(state, true)?.text).toContain(
+      SYNARA_HARNESS_POLICY_MARKER,
+    );
+    expect(takeOmpSynaraHarnessPolicyTextPart(state, true)).toBeNull();
+  });
+});
+
+const serverConfig = {
+  cwd: "/server/cwd",
+  homeDir: "/home/test",
+} as Parameters<typeof resolveOmpSessionCwd>[1];
+
+describe("resolveOmpSessionCwd", () => {
+  it("prefers an explicit cwd over the active thread session cwd", () => {
+    expect(resolveOmpSessionCwd("/explicit", serverConfig, "/thread")).toBe("/explicit");
+  });
+
+  it("uses the active thread session cwd before the server fallback", () => {
+    expect(resolveOmpSessionCwd(undefined, serverConfig, "/thread")).toBe("/thread");
+  });
+});
+
+describe("OmpAdapter runtime event scoping", () => {
+  it("makes reused ACP assistant segment ids unique per turn", () => {
+    const providerItemId = "assistant:omp-session:segment:5";
+
+    expect(scopeOmpRuntimeItemIdForTurn(TurnId.makeUnsafe("turn-a"), providerItemId)).toBe(
+      "omp:turn-a:assistant:omp-session:segment:5",
+    );
+    expect(scopeOmpRuntimeItemIdForTurn(TurnId.makeUnsafe("turn-b"), providerItemId)).toBe(
+      "omp:turn-b:assistant:omp-session:segment:5",
+    );
+  });
+
+  it("preserves the provider tool id while scoping the runtime item id", () => {
+    const scoped = scopeOmpToolCallStateForTurn(TurnId.makeUnsafe("turn-a"), {
+      toolCallId: "call-1",
+      kind: "execute",
+      status: "completed",
+      title: "Ran command",
+      data: {
+        toolCallId: "call-1",
+      },
+    });
+
+    expect(scoped.toolCallId).toBe("omp:turn-a:call-1");
+    expect(scoped.data).toMatchObject({
+      toolCallId: "call-1",
+      providerToolCallId: "call-1",
+    });
+  });
+
+  it("only treats visible assistant text as renderable OMP content", () => {
+    expect(
+      isRenderableOmpAssistantDelta({
+        streamKind: "assistant_text",
+        text: "done",
+      }),
+    ).toBe(true);
+    expect(
+      isRenderableOmpAssistantDelta({
+        streamKind: "assistant_text",
+        text: "   ",
+      }),
+    ).toBe(false);
+  });
+
+  it("recognizes nested Task rows whose child progress is hidden from parent ACP", () => {
+    expect(
+      isOmpNestedTaskToolCall({
+        toolCallId: "task-1",
+        title: "Task",
+        status: "pending",
+        data: { rawInput: { subagent_type: "worker" } },
+      }),
+    ).toBe(true);
+    expect(
+      isOmpNestedTaskToolCall({
+        toolCallId: "read-1",
+        title: "Read",
+        status: "pending",
+        data: {},
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores a delayed stop when its turn is no longer active", () => {
+    const oldTurnId = TurnId.makeUnsafe("turn-a");
+    const newTurnId = TurnId.makeUnsafe("turn-b");
+
+    expect(shouldIgnoreOmpInterrupt(oldTurnId, newTurnId)).toBe(true);
+    expect(shouldIgnoreOmpInterrupt(oldTurnId, undefined)).toBe(true);
+    expect(shouldIgnoreOmpInterrupt(newTurnId, newTurnId)).toBe(false);
+    expect(shouldIgnoreOmpInterrupt(undefined, newTurnId)).toBe(false);
+  });
+});

--- a/apps/server/src/provider/Layers/OmpAdapter.ts
+++ b/apps/server/src/provider/Layers/OmpAdapter.ts
@@ -404,7 +404,11 @@ export function makeOmpAdapter(
     const collectDiscoveryStreamAsString = <E>(
       stream: Stream.Stream<Uint8Array, E>,
     ): Effect.Effect<string, E> =>
-      Stream.runFold(stream, () => "", (acc, chunk) => acc + new TextDecoder().decode(chunk));
+      Stream.runFold(
+        stream,
+        () => "",
+        (acc, chunk) => acc + new TextDecoder().decode(chunk),
+      );
 
     // OMP publishes its full multi-provider catalog via `omp models --json` in a
     // single subprocess call; each model carries its own `thinking` efforts
@@ -445,8 +449,7 @@ export function makeOmpAdapter(
           return yield* new ProviderAdapterRequestError({
             provider: PROVIDER,
             method: "model/list",
-            detail:
-              stderr.trim() || `'${executable} models --json' exited with code ${exitCode}.`,
+            detail: stderr.trim() || `'${executable} models --json' exited with code ${exitCode}.`,
           });
         }
         const models = parseOmpCliModelList(stdout);
@@ -1938,8 +1941,7 @@ export function makeOmpAdapter(
             inputBinaryPath: input.binaryPath ?? null,
             ompSettingsBinaryPath: ompSettings.binaryPath ?? null,
           });
-          const binaryPath =
-            input.binaryPath?.trim() || ompSettings.binaryPath?.trim() || "omp";
+          const binaryPath = input.binaryPath?.trim() || ompSettings.binaryPath?.trim() || "omp";
           const cacheKey = binaryPath;
           const cached = modelDiscoveryCache.get(cacheKey);
           if (cached && cached.expiresAt > Date.now()) {

--- a/apps/server/src/provider/Layers/OmpAdapter.ts
+++ b/apps/server/src/provider/Layers/OmpAdapter.ts
@@ -1,0 +1,2123 @@
+/**
+ * OmpAdapterLive - Oh My Pi (OMP) CLI (`omp acp`) via ACP.
+ *
+ * @module OmpAdapterLive
+ */
+import {
+  ApprovalRequestId,
+  EventId,
+  type ProviderComposerCapabilities,
+  type ProviderApprovalDecision,
+  type ProviderInteractionMode,
+  type ProviderListCommandsResult,
+  type ProviderListModelsResult,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  type ProviderUserInputAnswers,
+  RuntimeItemId,
+  RuntimeRequestId,
+  RuntimeTaskId,
+  ThreadId,
+  TurnId,
+} from "@synara/contracts";
+import {
+  Cause,
+  DateTime,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  FileSystem,
+  Layer,
+  Option,
+  PubSub,
+  Random,
+  Semaphore,
+  Scope,
+  Stream,
+} from "effect";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import type * as Acp from "@agentclientprotocol/sdk";
+import { prepareWindowsSafeProcess } from "@synara/shared/windowsProcess";
+import { buildProviderChildEnvironment } from "../../providerChildEnvironment.ts";
+
+import { buildAcpSynaraMcpServers } from "../../agentGateway/mcpInjection.ts";
+import {
+  type SynaraHarnessPolicyDeliveryState,
+  takeSynaraHarnessPolicyTextPartForProviderSession,
+} from "../../agentGateway/harnessPolicy.ts";
+import { AgentGatewayCredentials } from "../../agentGateway/Services/AgentGatewayCredentials.ts";
+import { PROVIDER_ADAPTER_RUNTIME_EVENT_BUFFER_CAPACITY } from "../Services/ProviderAdapter.ts";
+import {
+  acquireAgentGatewaySessionLease,
+  startAgentGatewaySessionLeaseExitWatcher,
+  type AgentGatewaySessionLease,
+} from "../../agentGateway/sessionLease.ts";
+import { ServerConfig, type ServerConfigShape } from "../../config.ts";
+import { appendFileAttachmentsPromptBlock } from "../attachmentProjection.ts";
+import { loadProviderPromptImageBlocks } from "../promptAttachments.ts";
+import { appendProviderReferencesPromptBlock } from "../promptReferenceProjection.ts";
+import {
+  ProviderAdapterRequestError,
+  ProviderAdapterProcessError,
+  ProviderAdapterSessionClosedError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+} from "../Errors.ts";
+import {
+  classifyAcpPromptTurnCompletion,
+  mapAcpToAdapterError,
+  readAcpFailedToolDetail,
+  resolveAcpPermissionPolicy,
+  selectAcpPermissionOptionId,
+} from "../acp/AcpAdapterSupport.ts";
+import {
+  acceptAcpPlanUpdate,
+  clearAcpActiveTurn,
+  finalizeAcpActiveTurnCost,
+  makeAcpThreadLock,
+  recordAcpSessionCost,
+  resolveAcpSessionCwd,
+  resolveAcpTurnInteractionMode,
+  scopeAcpRuntimeItemIdForTurn,
+  scopeAcpToolCallStateForTurn,
+  settleAcpPendingApprovalsAsCancelled,
+  settleAcpPendingUserInputsAsEmptyAnswers,
+  withAcpPlanModePrompt,
+} from "../acp/AcpAdapterSessionSupport.ts";
+import { type AcpSessionRuntimeShape } from "../acp/AcpSessionRuntime.ts";
+import {
+  makeAcpAssistantItemEvent,
+  makeAcpContentDeltaEvent,
+  makeAcpPlanUpdatedEvent,
+  makeAcpRequestOpenedEvent,
+  makeAcpRequestResolvedEvent,
+  makeAcpTokenUsageEvent,
+  makeAcpToolCallEvent,
+  stampAcpRuntimeEventLifecycleGeneration,
+} from "../acp/AcpCoreRuntimeEvents.ts";
+import { type AcpToolCallState, parsePermissionRequest } from "../acp/AcpRuntimeModel.ts";
+import { makeAcpDebugLoggers, makeAcpNativeLoggers } from "../acp/AcpNativeLogging.ts";
+import {
+  forkAcpTurnIdleWatchdog,
+  resolveAcpTurnIdleTimeoutMs,
+} from "../acp/AcpTurnIdleWatchdog.ts";
+import {
+  applyOmpAcpInteractionMode,
+  applyOmpAcpModelSelection,
+  makeOmpAcpRuntime,
+  parseOmpCliModelList,
+  resolveOmpCliBinaryPath,
+  type OmpAcpRuntimeSettings,
+} from "../acp/OmpAcpSupport.ts";
+import { makeSessionTeardownGate } from "../acp/SessionTeardownGate.ts";
+import { cancelTurnAndWait } from "../acp/TurnCancellation.ts";
+import {
+  elicitationQuestionsFromRequest,
+  elicitationResponseFromAnswers,
+  isFormElicitationRequest,
+} from "../acp/AcpElicitationSupport.ts";
+import { OmpAdapter, type OmpAdapterShape } from "../Services/OmpAdapter.ts";
+import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+import { createLogger } from "../../logger.ts";
+
+const PROVIDER = "omp" as const;
+const log = createLogger(PROVIDER);
+
+export const takeOmpSynaraHarnessPolicyTextPart = (
+  state: SynaraHarnessPolicyDeliveryState,
+  scopedGatewayConnectionAvailable: boolean,
+) =>
+  takeSynaraHarnessPolicyTextPartForProviderSession(state, {
+    provider: PROVIDER,
+    scopedGatewayConnectionAvailable,
+  });
+const OMP_RESUME_VERSION = 1 as const;
+const OMP_ACP_TRANSPORT_DEBUG_MARKER = "omp-acp-meta-stripper-v2";
+const OMP_ACP_LOG_PAYLOAD_LIMIT = 4_000;
+const OMP_ACP_DEBUG_ENV = "SYNARA_OMP_ACP_DEBUG";
+const OMP_RESUME_REPLAY_QUIET_MS = 350;
+// Bounds how long startSession blocks on the replay settling; the background
+// settle loop keeps suppression alive past this until the hard timeout.
+const OMP_RESUME_REPLAY_MAX_WAIT_MS = 3_000;
+const OMP_RESUME_REPLAY_HARD_TIMEOUT_MS = 30_000;
+const OMP_TURN_SETTLE_DRAIN_MAX_WAIT_MS = 1_000;
+const OMP_TURN_SETTLE_DRAIN_POLL_MS = 25;
+// Backstop for an alive-but-silent omp child: if a turn produces no ACP
+// activity for this long, force-fail it instead of showing "Working" forever.
+// Generous by design so legitimate long, quiet tool runs are not killed;
+// override with SYNARA_OMP_TURN_IDLE_TIMEOUT_MS when a workload needs longer.
+const OMP_TURN_IDLE_TIMEOUT_MS = resolveAcpTurnIdleTimeoutMs({
+  envVar: "SYNARA_OMP_TURN_IDLE_TIMEOUT_MS",
+  defaultMs: 600_000,
+});
+const OMP_TURN_WATCHDOG_INTERVAL_MS = 15_000;
+const OMP_NESTED_TASK_IDLE_TIMEOUT_MS = 60 * 60_000;
+const OMP_CANCEL_GRACE_MS = 5_000;
+const OMP_ACP_REQUEST_TIMEOUT_MS = 30_000;
+const OMP_MODEL_DISCOVERY_CACHE_MS = 5 * 60_000;
+const OMP_MODEL_DISCOVERY_TIMEOUT_MS = 30_000;
+const OMP_DISCOVERY_CACHE_MAX_ENTRIES = 16;
+const OMP_PLAN_MODE_PROMPT_PREFIX = [
+  "Synara OMP plan mode is active.",
+  "Do not implement or mutate files in this turn.",
+  "Do not ask follow-up questions or wait for confirmation; if scope is ambiguous, choose a reasonable default and state the assumption in the plan.",
+  "When ready, create the final implementation plan.",
+].join("\n");
+
+function ompAcpTimeoutError(method: string): ProviderAdapterRequestError {
+  return new ProviderAdapterRequestError({
+    provider: PROVIDER,
+    method,
+    detail: `Omp ACP did not respond to ${method} within ${OMP_ACP_REQUEST_TIMEOUT_MS / 1000}s.`,
+  });
+}
+
+function isOmpAcpDebugEnabled(): boolean {
+  return process.env[OMP_ACP_DEBUG_ENV] === "1";
+}
+
+export interface OmpAdapterLiveOptions {
+  readonly nativeEventLogPath?: string;
+  readonly nativeEventLogger?: EventNdjsonLogger;
+}
+
+interface PendingApproval {
+  readonly decision: Deferred.Deferred<ProviderApprovalDecision>;
+  readonly kind: string | "unknown";
+}
+
+interface PendingUserInput {
+  readonly answers: Deferred.Deferred<ProviderUserInputAnswers>;
+}
+
+interface OmpSessionContext {
+  harnessPolicyDelivered?: boolean;
+  readonly gatewaySessionLease?: AgentGatewaySessionLease;
+  readonly threadId: ThreadId;
+  readonly lifecycleGeneration?: string;
+  session: ProviderSession;
+  readonly scope: Scope.Closeable;
+  readonly acp: AcpSessionRuntimeShape;
+  notificationFiber: Fiber.Fiber<void, never> | undefined;
+  readonly pendingApprovals: Map<ApprovalRequestId, PendingApproval>;
+  readonly pendingUserInputs: Map<ApprovalRequestId, PendingUserInput>;
+  readonly turns: Array<{ id: TurnId; items: Array<unknown> }>;
+  lastPlanFingerprint: string | undefined;
+  activeInteractionMode: ProviderInteractionMode | undefined;
+  activeTurnId: TurnId | undefined;
+  activeTurnHadAssistantContent: boolean;
+  readonly activeAssistantItemsWithContent: Set<string>;
+  activeTurnFailedToolDetail: string | undefined;
+  activePromptFiber: Fiber.Fiber<void, never> | undefined;
+  // Epoch-ms of the last inbound ACP activity for the active turn; drives the
+  // idle-progress watchdog that force-fails a silently hung turn.
+  lastTurnActivityAt: number | undefined;
+  // Provider tool-call ids seen during the most recent turn, mapped to that
+  // turn. A backlogged consumer can process a queued ToolCallUpdated after the
+  // prompt response cleared activeTurnId; this keeps the event attributed to
+  // its originating turn instead of dropping it as an orphan. Cleared when the
+  // next turn dispatches.
+  readonly turnToolCallIds: Map<string, TurnId>;
+  // Omp executes `Task` subagents outside the parent ACP event stream. Track
+  // their parent tool rows so the watchdog can use a longer, still-finite cap.
+  readonly activeNestedTaskToolCallIds: Set<string>;
+  readonly nestedTaskLifecycleByToolCallId: Map<string, "active" | "completed">;
+  resumeReplayReady: Deferred.Deferred<void> | undefined;
+  resumeReplayLastSuppressedAt: number | undefined;
+  // Pending until startSession has applied the requested model/effort config.
+  // The session is registered in `sessions` before the config RPCs run (so
+  // replay keeps draining), which means sendTurn can route to it mid-startup;
+  // turns await this gate so the first prompt never runs with provider
+  // defaults. Resolved by stopSessionInternal too, like resumeReplayReady, so
+  // a failed startup never strands waiters.
+  sessionConfigReady: Deferred.Deferred<void> | undefined;
+  // Resolves only after the ACP scope and its child process have fully closed.
+  // Recovery awaits this gate before starting a replacement session.
+  readonly teardownComplete: Deferred.Deferred<void>;
+  latestSessionCostUsd: number | undefined;
+  // Count of ACP session/update events fully handled by the notification
+  // consumer. Compared against acp.sessionUpdatesEnqueuedCount to detect when
+  // events received before a prompt response have all been processed —
+  // in-flight handlers and stream chunk buffering included.
+  sessionUpdatesProcessed: number;
+  // True while sendTurn is between its entry check and prompt dispatch; lets
+  // interruptTurn flag a turn that has no prompt fiber to interrupt yet.
+  turnStarting: boolean;
+  // Set by interruptTurn when the turn is still starting; the prompt dispatch
+  // guard honors it so a cancelled turn is never prompted.
+  pendingTurnInterrupted: boolean;
+  stopped: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function scopeOmpRuntimeItemIdForTurn(turnId: TurnId, itemId: string): string {
+  return scopeAcpRuntimeItemIdForTurn(PROVIDER, turnId, itemId);
+}
+
+// Omp can close a stale assistant segment before any visible text arrives.
+export function isRenderableOmpAssistantDelta(input: {
+  readonly streamKind?: string | undefined;
+  readonly text: string;
+}): boolean {
+  return input.streamKind !== "reasoning_text" && input.text.trim().length > 0;
+}
+
+export function classifyOmpPromptTurnCompletion(input: {
+  readonly stopReason: string | null | undefined;
+  readonly failedToolDetail?: string | undefined;
+}): { readonly state: "completed" | "cancelled" | "failed"; readonly errorMessage?: string } {
+  return classifyAcpPromptTurnCompletion({
+    stopReason: input.stopReason,
+    ...(input.failedToolDetail !== undefined ? { failedToolDetail: input.failedToolDetail } : {}),
+  });
+}
+
+// Identifies OMP's parent `Task` tool row; child-session progress is not
+// forwarded over ACP, so this marker is the only reliable liveness signal.
+export function isOmpNestedTaskToolCall(toolCall: AcpToolCallState): boolean {
+  if (toolCall.title?.trim().toLowerCase() === "task") {
+    return true;
+  }
+  const rawInput = toolCall.data.rawInput;
+  return (
+    typeof rawInput === "object" &&
+    rawInput !== null &&
+    "subagent_type" in rawInput &&
+    typeof rawInput.subagent_type === "string"
+  );
+}
+
+// A turn-specific stop is valid only while that exact turn is active. During
+// startup no caller can know the new provider turn id yet, so a supplied id is stale.
+export function shouldIgnoreOmpInterrupt(
+  requestedTurnId: TurnId | undefined,
+  activeTurnId: TurnId | undefined,
+): boolean {
+  return requestedTurnId !== undefined && requestedTurnId !== activeTurnId;
+}
+
+// Omp may reuse ACP item ids across resumed history; DP runtime ids must stay turn-local.
+export function scopeOmpToolCallStateForTurn(
+  turnId: TurnId,
+  toolCall: AcpToolCallState,
+): AcpToolCallState {
+  return scopeAcpToolCallStateForTurn(PROVIDER, turnId, toolCall);
+}
+
+function parseOmpResume(raw: unknown): { sessionId: string } | undefined {
+  if (!isRecord(raw)) return undefined;
+  if (raw.schemaVersion !== OMP_RESUME_VERSION) return undefined;
+  if (typeof raw.sessionId !== "string" || !raw.sessionId.trim()) return undefined;
+  return { sessionId: raw.sessionId.trim() };
+}
+
+export function resolveOmpSessionCwd(
+  inputCwd: string | undefined,
+  serverConfig: ServerConfigShape,
+  sessionCwd?: string,
+): string | undefined {
+  return resolveAcpSessionCwd({
+    inputCwd,
+    sessionCwd,
+    serverCwd: serverConfig.cwd,
+    homeDir: serverConfig.homeDir,
+  });
+}
+
+function setOmpDiscoveryCacheEntry<T>(cache: Map<string, T>, key: string, value: T): void {
+  cache.delete(key);
+  cache.set(key, value);
+  while (cache.size > OMP_DISCOVERY_CACHE_MAX_ENTRIES) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey === undefined) break;
+    cache.delete(oldestKey);
+  }
+}
+
+export function makeOmpAdapter(
+  ompSettings: OmpAcpRuntimeSettings,
+  options?: OmpAdapterLiveOptions,
+) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const serverConfig = yield* Effect.service(ServerConfig);
+    const agentGatewayCredentials = Option.getOrUndefined(
+      yield* Effect.serviceOption(AgentGatewayCredentials),
+    );
+    const nativeEventLogger =
+      options?.nativeEventLogger ??
+      (options?.nativeEventLogPath !== undefined
+        ? yield* makeEventNdjsonLogger(options.nativeEventLogPath, { stream: "native" })
+        : undefined);
+    const managedNativeEventLogger =
+      options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
+
+    const sessions = new Map<ThreadId, OmpSessionContext>();
+    const sessionTeardownGate = makeSessionTeardownGate();
+    const modelDiscoveryCache = new Map<
+      string,
+      { readonly expiresAt: number; readonly result: ProviderListModelsResult }
+    >();
+    const commandDiscoveryCache = new Map<
+      string,
+      { readonly expiresAt: number; readonly result: ProviderListCommandsResult }
+    >();
+    const withThreadLock = yield* makeAcpThreadLock();
+    const discoveryLock = yield* Semaphore.make(1);
+    const runtimeEventPubSub = yield* PubSub.bounded<ProviderRuntimeEvent>(
+      PROVIDER_ADAPTER_RUNTIME_EVENT_BUFFER_CAPACITY,
+    );
+
+    const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+    const nextEventId = Effect.map(Random.nextUUIDv4, (id) => EventId.makeUnsafe(id));
+    const makeEventStamp = () => Effect.all({ eventId: nextEventId, createdAt: nowIso });
+
+    const offerRuntimeEvent = (
+      lifecycleGeneration: string | undefined,
+      event: ProviderRuntimeEvent,
+    ) =>
+      PubSub.publish(
+        runtimeEventPubSub,
+        stampAcpRuntimeEventLifecycleGeneration(event, lifecycleGeneration),
+      ).pipe(Effect.asVoid);
+
+    // Discovery sessions are disposable and never enter the live session directory.
+    const makeOmpDiscoveryRuntime = (input: {
+      readonly binaryPath?: string;
+      readonly cwd: string;
+      readonly clientName: string;
+    }) =>
+      makeOmpAcpRuntime({
+        ompSettings: {
+          ...(ompSettings.binaryPath ? { binaryPath: ompSettings.binaryPath } : {}),
+          ...(input.binaryPath ? { binaryPath: input.binaryPath } : {}),
+        },
+        childProcessSpawner,
+        cwd: input.cwd,
+        clientInfo: { name: input.clientName, version: "0.0.0" },
+      });
+    const collectDiscoveryStreamAsString = <E>(
+      stream: Stream.Stream<Uint8Array, E>,
+    ): Effect.Effect<string, E> =>
+      Stream.runFold(stream, () => "", (acc, chunk) => acc + new TextDecoder().decode(chunk));
+
+    // OMP publishes its full multi-provider catalog via `omp models --json` in a
+    // single subprocess call; each model carries its own `thinking` efforts
+    // inline. This is O(1) round-trips and scales to OMP's 300+ model catalogs.
+    // The ACP model option exposes only slug/name and would need one
+    // session/set_config_option round-trip per model to read per-model thinking.
+    const runOmpCliModelList = (binaryPath: string) =>
+      Effect.gen(function* () {
+        const executable = resolveOmpCliBinaryPath(binaryPath);
+        log.info("model/list cli start", { binaryPath, executable });
+        const env = buildProviderChildEnvironment({ provider: "omp" });
+        const prepared = prepareWindowsSafeProcess(executable, ["models", "--json"], {
+          env,
+        });
+        const command = ChildProcess.make(prepared.command, prepared.args, {
+          shell: prepared.shell,
+          ...(prepared.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
+          env,
+          stdin: "ignore",
+        });
+        const child = yield* childProcessSpawner.spawn(command);
+        const [stdout, stderr, exitCode] = yield* Effect.all(
+          [
+            collectDiscoveryStreamAsString(child.stdout),
+            collectDiscoveryStreamAsString(child.stderr),
+            child.exitCode.pipe(Effect.map(Number)),
+          ],
+          { concurrency: "unbounded" },
+        );
+        log.info("model/list cli spawned", {
+          exitCode,
+          stdoutBytes: stdout.length,
+          stdoutHead: stdout.slice(0, 240),
+          stderr,
+        });
+        if (exitCode !== 0) {
+          log.warn("model/list cli non-zero exit", { exitCode, stderr });
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "model/list",
+            detail:
+              stderr.trim() || `'${executable} models --json' exited with code ${exitCode}.`,
+          });
+        }
+        const models = parseOmpCliModelList(stdout);
+        log.info("model/list cli parsed", { parsedCount: models.length });
+        if (models.length === 0) {
+          log.warn("model/list cli returned zero models", {
+            stdoutHead: stdout.slice(0, 500),
+          });
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "model/list",
+            detail:
+              "OMP model discovery returned no models. Run `omp` to authenticate so ~/.omp credentials exist.",
+          });
+        }
+        return { models, source: "omp-cli", cached: false } satisfies ProviderListModelsResult;
+      }).pipe(Effect.scoped);
+
+    const logNative = (threadId: ThreadId, method: string, payload: unknown) =>
+      Effect.gen(function* () {
+        if (!nativeEventLogger) return;
+        const observedAt = new Date().toISOString();
+        yield* nativeEventLogger.write(
+          {
+            observedAt,
+            event: {
+              id: crypto.randomUUID(),
+              kind: "notification",
+              provider: PROVIDER,
+              createdAt: observedAt,
+              method,
+              threadId,
+              payload,
+            },
+          },
+          threadId,
+        );
+      });
+
+    const emitPlanUpdate = (
+      ctx: OmpSessionContext,
+      payload: {
+        readonly explanation?: string | null;
+        readonly plan: ReadonlyArray<{
+          readonly step: string;
+          readonly status: "pending" | "inProgress" | "completed";
+        }>;
+      },
+      rawPayload: unknown,
+    ) =>
+      Effect.gen(function* () {
+        if (!acceptAcpPlanUpdate(ctx, payload)) return;
+        yield* offerRuntimeEvent(
+          ctx.lifecycleGeneration,
+          makeAcpPlanUpdatedEvent({
+            stamp: yield* makeEventStamp(),
+            provider: PROVIDER,
+            threadId: ctx.threadId,
+            turnId: ctx.activeTurnId,
+            payload,
+            source: "acp.jsonrpc",
+            method: "session/update",
+            rawPayload,
+          }),
+        );
+      });
+
+    const emitNestedTaskLifecycle = (
+      ctx: OmpSessionContext,
+      toolCall: AcpToolCallState,
+      turnId: TurnId,
+    ) =>
+      Effect.gen(function* () {
+        if (!isOmpNestedTaskToolCall(toolCall)) {
+          return;
+        }
+        const previous = ctx.nestedTaskLifecycleByToolCallId.get(toolCall.toolCallId);
+        const terminal = toolCall.status === "completed" || toolCall.status === "failed";
+        if (terminal) {
+          ctx.activeNestedTaskToolCallIds.delete(toolCall.toolCallId);
+          if (previous === "completed") {
+            return;
+          }
+          ctx.nestedTaskLifecycleByToolCallId.set(toolCall.toolCallId, "completed");
+          yield* offerRuntimeEvent(ctx.lifecycleGeneration, {
+            type: "task.completed",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: ctx.threadId,
+            turnId,
+            payload: {
+              taskId: RuntimeTaskId.makeUnsafe(toolCall.toolCallId),
+              status: toolCall.status === "failed" ? "failed" : "completed",
+              ...(toolCall.detail ? { summary: toolCall.detail } : {}),
+            },
+          });
+          return;
+        }
+
+        ctx.activeNestedTaskToolCallIds.add(toolCall.toolCallId);
+        if (previous !== undefined) {
+          return;
+        }
+        ctx.nestedTaskLifecycleByToolCallId.set(toolCall.toolCallId, "active");
+        const rawInput = toolCall.data.rawInput;
+        const description =
+          typeof rawInput === "object" &&
+          rawInput !== null &&
+          "description" in rawInput &&
+          typeof rawInput.description === "string"
+            ? rawInput.description
+            : toolCall.detail;
+        yield* offerRuntimeEvent(ctx.lifecycleGeneration, {
+          type: "task.started",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: ctx.threadId,
+          turnId,
+          payload: {
+            taskId: RuntimeTaskId.makeUnsafe(toolCall.toolCallId),
+            taskType: "subagent",
+            ...(description ? { description } : {}),
+          },
+        });
+      });
+
+    const requireSession = (
+      threadId: ThreadId,
+    ): Effect.Effect<OmpSessionContext, ProviderAdapterSessionNotFoundError> => {
+      const ctx = sessions.get(threadId);
+      if (!ctx || ctx.stopped) {
+        return Effect.fail(
+          new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }),
+        );
+      }
+      return Effect.succeed(ctx);
+    };
+
+    const stopSessionInternal = (
+      ctx: OmpSessionContext,
+      options?: {
+        readonly exitKind?: "graceful" | "error";
+        readonly reason?: string;
+        readonly awaitTermination?: boolean;
+      },
+    ) =>
+      Effect.uninterruptibleMask((restore) =>
+        Effect.gen(function* () {
+          if (!ctx.stopped) {
+            ctx.stopped = true;
+            ctx.gatewaySessionLease?.release();
+            sessionTeardownGate.track(ctx.threadId, ctx.teardownComplete);
+            sessions.delete(ctx.threadId);
+            yield* settleAcpPendingApprovalsAsCancelled(ctx.pendingApprovals);
+            yield* settleAcpPendingUserInputsAsEmptyAnswers(ctx.pendingUserInputs);
+            if (ctx.sessionConfigReady !== undefined) {
+              yield* Deferred.succeed(ctx.sessionConfigReady, undefined);
+              ctx.sessionConfigReady = undefined;
+            }
+            if (ctx.resumeReplayReady !== undefined) {
+              yield* Deferred.succeed(ctx.resumeReplayReady, undefined);
+              ctx.resumeReplayReady = undefined;
+              ctx.resumeReplayLastSuppressedAt = undefined;
+            }
+            if (ctx.notificationFiber) {
+              yield* Fiber.interrupt(ctx.notificationFiber);
+            }
+
+            const completeTeardown = sessionTeardownGate.complete(
+              ctx.threadId,
+              ctx.teardownComplete,
+            );
+            const teardown = Effect.gen(function* () {
+              yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
+              yield* offerRuntimeEvent(ctx.lifecycleGeneration, {
+                type: "session.exited",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: ctx.threadId,
+                payload: {
+                  exitKind: options?.exitKind ?? "graceful",
+                  ...(options?.reason ? { reason: options.reason } : {}),
+                },
+              });
+            }).pipe(Effect.ensuring(completeTeardown));
+
+            // Scope.close interrupts prompt/watchdog fibers owned by this scope.
+            // A daemon performs the close so those fibers can initiate teardown
+            // without waiting on their own termination.
+            yield* teardown.pipe(Effect.forkDetach, Effect.asVoid);
+          }
+
+          if (options?.awaitTermination !== false) {
+            yield* restore(Deferred.await(ctx.teardownComplete));
+          }
+        }),
+      );
+
+    const noteSuppressedOmpRuntimeEvent = (
+      ctx: OmpSessionContext,
+      eventTag: string,
+      reason: "resume-replay" | "orphan-turn-event",
+    ) =>
+      Effect.gen(function* () {
+        if (reason === "resume-replay") {
+          ctx.resumeReplayLastSuppressedAt = Date.now();
+        }
+        if (!isOmpAcpDebugEnabled()) {
+          return;
+        }
+        yield* Effect.logInfo("omp.acp.runtime_event_suppressed", {
+          threadId: ctx.threadId,
+          turnId: ctx.activeTurnId,
+          eventTag,
+          reason,
+        });
+      });
+
+    const cancelOmpPromptWithGrace = (
+      ctx: OmpSessionContext,
+      promptFiber: Fiber.Fiber<void, never> | undefined,
+    ) =>
+      Effect.gen(function* () {
+        const result = yield* cancelTurnAndWait({
+          cancel: ctx.acp.cancel,
+          promptFiber,
+          graceMs: OMP_CANCEL_GRACE_MS,
+        });
+        if (result.cancelRequest !== "sent" || result.prompt === "timedOut") {
+          yield* Effect.logWarning("omp.acp.cancel_escalated", {
+            threadId: ctx.threadId,
+            turnId: ctx.activeTurnId,
+            cancelRequest: result.cancelRequest,
+            prompt: result.prompt,
+            ...(result.cancelFailure ? { reason: result.cancelFailure } : {}),
+          });
+        }
+        return result;
+      });
+
+    const activeTurnIdForOmpRuntimeEvent = (ctx: OmpSessionContext, eventTag: string) =>
+      Effect.gen(function* () {
+        if (ctx.resumeReplayReady !== undefined) {
+          yield* noteSuppressedOmpRuntimeEvent(ctx, eventTag, "resume-replay");
+          return undefined;
+        }
+        if (ctx.activeTurnId === undefined) {
+          yield* noteSuppressedOmpRuntimeEvent(ctx, eventTag, "orphan-turn-event");
+          return undefined;
+        }
+        return ctx.activeTurnId;
+      });
+
+    // Holds the active-turn window open until session/update events that were
+    // already enqueued when the prompt response resolved have been fully
+    // handled by the notification consumer, so they settle with their turn
+    // attribution (and recorded failed-tool detail) intact. Snapshotting the
+    // runtime's enqueued count and waiting for the adapter's processed count
+    // to catch up is immune to stream chunk buffering and in-flight handlers,
+    // unlike a queue-size probe. Returns immediately when the consumer kept
+    // up; bounded so a chatty stream cannot stall settlement past the cap.
+    const waitForOmpQueuedTurnEventsDrained = (ctx: OmpSessionContext) =>
+      Effect.gen(function* () {
+        const target = yield* ctx.acp.sessionUpdatesEnqueuedCount;
+        const startedAt = Date.now();
+        while (
+          ctx.sessionUpdatesProcessed < target &&
+          Date.now() - startedAt < OMP_TURN_SETTLE_DRAIN_MAX_WAIT_MS
+        ) {
+          yield* Effect.sleep(OMP_TURN_SETTLE_DRAIN_POLL_MS);
+        }
+      });
+
+    // On session/load, Omp can replay old ACP updates after the session is "ready".
+    // Keep suppression active until that stream actually goes quiet — clearing it
+    // on a fixed timeout lets late historical deltas leak into the first turn as
+    // its content. The hard cap only guards against a replay that never settles.
+    const settleOmpResumeReplayWhenQuiet = (ctx: OmpSessionContext) =>
+      Effect.gen(function* () {
+        const ready = ctx.resumeReplayReady;
+        if (ready === undefined) {
+          return;
+        }
+        const startedAt = Date.now();
+        ctx.resumeReplayLastSuppressedAt = startedAt;
+        while (ctx.resumeReplayReady !== undefined) {
+          const now = Date.now();
+          const lastSuppressedAt = ctx.resumeReplayLastSuppressedAt ?? startedAt;
+          const quietForMs = now - lastSuppressedAt;
+          const elapsedMs = now - startedAt;
+          if (
+            quietForMs >= OMP_RESUME_REPLAY_QUIET_MS ||
+            elapsedMs >= OMP_RESUME_REPLAY_HARD_TIMEOUT_MS
+          ) {
+            const timedOut = elapsedMs >= OMP_RESUME_REPLAY_HARD_TIMEOUT_MS;
+            ctx.resumeReplayReady = undefined;
+            ctx.resumeReplayLastSuppressedAt = undefined;
+            if (timedOut) {
+              yield* Effect.logWarning("omp.acp.resume_replay_quiet_wait_timeout", {
+                threadId: ctx.threadId,
+                elapsedMs,
+              });
+            }
+            yield* Deferred.succeed(ready, undefined);
+            return;
+          }
+          yield* Effect.sleep(Math.min(OMP_RESUME_REPLAY_QUIET_MS - quietForMs, 50));
+        }
+        yield* Deferred.succeed(ready, undefined);
+      });
+
+    const startSession: OmpAdapterShape["startSession"] = (input) =>
+      withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          if (input.provider !== undefined && input.provider !== PROVIDER) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+            });
+          }
+          yield* sessionTeardownGate.awaitPending(input.threadId);
+          const cwd = resolveOmpSessionCwd(input.cwd, serverConfig);
+          if (cwd === undefined) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: "cwd is required and no server cwd fallback is available.",
+            });
+          }
+
+          const ompModelSelection =
+            input.modelSelection?.provider === PROVIDER ? input.modelSelection : undefined;
+          const existing = sessions.get(input.threadId);
+          if (existing && !existing.stopped) {
+            yield* stopSessionInternal(existing);
+          }
+
+          const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
+          const pendingUserInputs = new Map<ApprovalRequestId, PendingUserInput>();
+          const sessionScope = yield* Scope.make("sequential");
+          let sessionScopeTransferred = false;
+          const gatewaySessionLease = acquireAgentGatewaySessionLease(
+            agentGatewayCredentials,
+            input.threadId,
+            PROVIDER,
+          );
+          yield* Effect.addFinalizer(() =>
+            sessionScopeTransferred ? Effect.void : Scope.close(sessionScope, Exit.void),
+          );
+          yield* Effect.addFinalizer(() =>
+            sessionScopeTransferred || !gatewaySessionLease
+              ? Effect.void
+              : Effect.sync(gatewaySessionLease.release),
+          );
+          let ctx!: OmpSessionContext;
+
+          const resumeSessionId = parseOmpResume(input.resumeCursor)?.sessionId;
+          const acpNativeLoggers = makeAcpNativeLoggers({
+            nativeEventLogger,
+            provider: PROVIDER,
+            threadId: input.threadId,
+          });
+          const acpRuntimeLoggers = makeAcpDebugLoggers({
+            base: acpNativeLoggers,
+            enabled: isOmpAcpDebugEnabled(),
+            provider: PROVIDER,
+            marker: OMP_ACP_TRANSPORT_DEBUG_MARKER,
+            payloadLimit: OMP_ACP_LOG_PAYLOAD_LIMIT,
+            shouldMirrorIncomingRaw: () => false,
+          });
+          const providerOmpOptions = input.providerOptions?.omp;
+          const effectiveOmpSettings: OmpAcpRuntimeSettings = {
+            ...(ompSettings.binaryPath !== undefined ? { binaryPath: ompSettings.binaryPath } : {}),
+            ...(providerOmpOptions?.binaryPath !== undefined
+              ? { binaryPath: providerOmpOptions.binaryPath }
+              : {}),
+          };
+
+          yield* Effect.logInfo("omp.acp.start", {
+            marker: OMP_ACP_TRANSPORT_DEBUG_MARKER,
+            debugEnv: OMP_ACP_DEBUG_ENV,
+            threadId: input.threadId,
+            cwd,
+            resume: resumeSessionId !== undefined,
+            binaryPath: effectiveOmpSettings.binaryPath ?? "omp",
+          });
+
+          const acp = yield* makeOmpAcpRuntime({
+            ompSettings: effectiveOmpSettings,
+            childProcessSpawner,
+            cwd,
+            ...(resumeSessionId ? { resumeSessionId } : {}),
+            clientCapabilities: { elicitation: { form: {} } },
+            clientInfo: { name: "Synara", version: "0.0.0" },
+            ...(agentGatewayCredentials
+              ? {
+                  buildMcpServers: (initializeResult: Acp.InitializeResponse) =>
+                    buildAcpSynaraMcpServers({
+                      connection: gatewaySessionLease!.connection,
+                      initializeResult,
+                      stdioProxy: agentGatewayCredentials.stdioProxy,
+                    }),
+                }
+              : {}),
+            ...acpRuntimeLoggers,
+          }).pipe(
+            Effect.provideService(Scope.Scope, sessionScope),
+            Effect.mapError((cause) =>
+              mapAcpToAdapterError(PROVIDER, input.threadId, "session/start", cause),
+            ),
+          );
+          yield* startAgentGatewaySessionLeaseExitWatcher(gatewaySessionLease, acp.awaitExit);
+
+          const started = yield* Effect.gen(function* () {
+            yield* acp.handleRequestPermission((params) =>
+              Effect.gen(function* () {
+                yield* logNative(input.threadId, "session/request_permission", params);
+                const policyOutcome = resolveAcpPermissionPolicy({
+                  runtimeMode: input.runtimeMode,
+                  interactionMode: ctx?.activeInteractionMode,
+                  options: params.options,
+                });
+                if (policyOutcome !== undefined) {
+                  if (policyOutcome.outcome === "selected") {
+                    if (isOmpAcpDebugEnabled()) {
+                      yield* Effect.logInfo("omp.acp.permission_policy_applied", {
+                        threadId: input.threadId,
+                        turnId: ctx?.activeTurnId,
+                        interactionMode: ctx?.activeInteractionMode,
+                        optionId: policyOutcome.optionId,
+                        options: params.options.map((option) => ({
+                          kind: option.kind,
+                          optionId: option.optionId,
+                        })),
+                        toolKind: params.toolCall.kind,
+                        toolTitle: params.toolCall.title,
+                      });
+                    }
+                    return {
+                      outcome: {
+                        outcome: "selected" as const,
+                        optionId: policyOutcome.optionId,
+                      },
+                    };
+                  }
+                  return { outcome: { outcome: "cancelled" as const } };
+                }
+                const permissionRequest = parsePermissionRequest(params);
+                const requestId = ApprovalRequestId.makeUnsafe(crypto.randomUUID());
+                const runtimeRequestId = RuntimeRequestId.makeUnsafe(requestId);
+                const decision = yield* Deferred.make<ProviderApprovalDecision>();
+                pendingApprovals.set(requestId, { decision, kind: permissionRequest.kind });
+                yield* offerRuntimeEvent(
+                  input.lifecycleGeneration,
+                  makeAcpRequestOpenedEvent({
+                    stamp: yield* makeEventStamp(),
+                    provider: PROVIDER,
+                    threadId: input.threadId,
+                    turnId: ctx?.activeTurnId,
+                    requestId: runtimeRequestId,
+                    permissionRequest,
+                    detail: permissionRequest.detail ?? JSON.stringify(params).slice(0, 2000),
+                    args: params,
+                    source: "acp.jsonrpc",
+                    method: "session/request_permission",
+                    rawPayload: params,
+                  }),
+                );
+                const resolved = yield* Deferred.await(decision);
+                pendingApprovals.delete(requestId);
+                yield* offerRuntimeEvent(
+                  input.lifecycleGeneration,
+                  makeAcpRequestResolvedEvent({
+                    stamp: yield* makeEventStamp(),
+                    provider: PROVIDER,
+                    threadId: input.threadId,
+                    turnId: ctx?.activeTurnId,
+                    requestId: runtimeRequestId,
+                    permissionRequest,
+                    decision: resolved,
+                  }),
+                );
+                return {
+                  outcome:
+                    resolved === "cancel"
+                      ? ({ outcome: "cancelled" } as const)
+                      : (() => {
+                          const selectedOptionId = selectAcpPermissionOptionId(
+                            resolved,
+                            params.options,
+                          );
+                          return selectedOptionId === undefined
+                            ? ({ outcome: "cancelled" } as const)
+                            : ({
+                                outcome: "selected" as const,
+                                optionId: selectedOptionId,
+                              } as const);
+                        })(),
+                };
+              }),
+            );
+            yield* acp.handleElicitation((params) =>
+              Effect.gen(function* () {
+                yield* logNative(input.threadId, "session/elicitation", params);
+                if (!isFormElicitationRequest(params)) {
+                  return { action: "decline" as const };
+                }
+                const questions = elicitationQuestionsFromRequest(params);
+                if (questions.length === 0) {
+                  return { action: "decline" as const };
+                }
+                const requestId = ApprovalRequestId.makeUnsafe(crypto.randomUUID());
+                const runtimeRequestId = RuntimeRequestId.makeUnsafe(requestId);
+                const answers = yield* Deferred.make<ProviderUserInputAnswers>();
+                pendingUserInputs.set(requestId, { answers });
+                yield* offerRuntimeEvent(input.lifecycleGeneration, {
+                  type: "user-input.requested",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  turnId: ctx?.activeTurnId,
+                  requestId: runtimeRequestId,
+                  payload: { questions },
+                  raw: {
+                    source: "acp.jsonrpc",
+                    method: "session/elicitation",
+                    payload: params,
+                  },
+                });
+                const resolved = yield* Deferred.await(answers);
+                pendingUserInputs.delete(requestId);
+                yield* offerRuntimeEvent(input.lifecycleGeneration, {
+                  type: "user-input.resolved",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  turnId: ctx?.activeTurnId,
+                  requestId: runtimeRequestId,
+                  payload: { answers: resolved },
+                });
+                return elicitationResponseFromAnswers(params, resolved);
+              }),
+            );
+            const startedOption = yield* acp
+              .start()
+              .pipe(Effect.timeoutOption(OMP_ACP_REQUEST_TIMEOUT_MS));
+            return yield* Option.match(startedOption, {
+              onNone: () => Effect.fail(ompAcpTimeoutError("session/start")),
+              onSome: Effect.succeed,
+            });
+          }).pipe(
+            Effect.mapError((error) =>
+              error instanceof ProviderAdapterRequestError
+                ? error
+                : mapAcpToAdapterError(PROVIDER, input.threadId, "session/start", error),
+            ),
+          );
+
+          if (resumeSessionId !== undefined && started.sessionSetupMethod === "new") {
+            return yield* new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "session/resume",
+              detail:
+                "Omp could not resume the requested native session. Synara refused the fresh fallback to avoid silently losing conversation context.",
+            });
+          }
+
+          // `session/resume` does not replay history; only legacy `session/load`
+          // needs the replay-suppression gate below.
+          const resumeReplayReady =
+            started.sessionSetupMethod === "load" ? yield* Deferred.make<void>() : undefined;
+          const sessionConfigReady = yield* Deferred.make<void>();
+          const teardownComplete = yield* Deferred.make<void>();
+          const now = yield* nowIso;
+          const session: ProviderSession = {
+            provider: PROVIDER,
+            status: "ready",
+            runtimeMode: input.runtimeMode,
+            cwd,
+            model: ompModelSelection?.model,
+            threadId: input.threadId,
+            resumeCursor: {
+              schemaVersion: OMP_RESUME_VERSION,
+              sessionId: started.sessionId,
+            },
+            createdAt: now,
+            updatedAt: now,
+          };
+
+          ctx = {
+            threadId: input.threadId,
+            ...(gatewaySessionLease ? { gatewaySessionLease } : {}),
+            ...(input.lifecycleGeneration !== undefined
+              ? { lifecycleGeneration: input.lifecycleGeneration }
+              : {}),
+            session,
+            scope: sessionScope,
+            acp,
+            notificationFiber: undefined,
+            pendingApprovals,
+            pendingUserInputs,
+            turns: [],
+            lastPlanFingerprint: undefined,
+            activeInteractionMode: undefined,
+            activeTurnId: undefined,
+            activeTurnHadAssistantContent: false,
+            activeAssistantItemsWithContent: new Set(),
+            activeTurnFailedToolDetail: undefined,
+            activePromptFiber: undefined,
+            lastTurnActivityAt: undefined,
+            turnToolCallIds: new Map(),
+            activeNestedTaskToolCallIds: new Set(),
+            nestedTaskLifecycleByToolCallId: new Map(),
+            resumeReplayReady,
+            resumeReplayLastSuppressedAt: resumeReplayReady !== undefined ? Date.now() : undefined,
+            sessionConfigReady,
+            teardownComplete,
+            latestSessionCostUsd: undefined,
+            sessionUpdatesProcessed: 0,
+            turnStarting: false,
+            pendingTurnInterrupted: false,
+            stopped: false,
+          };
+
+          const notificationFiber = yield* Stream.runDrain(
+            Stream.mapEffect(acp.getEvents(), (event) =>
+              Effect.gen(function* () {
+                // Any inbound ACP event proves the child is alive and making
+                // progress; reset the idle-progress watchdog clock.
+                ctx.lastTurnActivityAt = Date.now();
+                switch (event._tag) {
+                  case "ModeChanged":
+                    return;
+                  case "AssistantItemStarted":
+                    {
+                      const activeTurnId = yield* activeTurnIdForOmpRuntimeEvent(ctx, event._tag);
+                      if (activeTurnId === undefined) {
+                        return;
+                      }
+                      // Content deltas open the visible message; empty starts only add noise.
+                    }
+                    return;
+                  case "AssistantItemCompleted":
+                    {
+                      const activeTurnId = yield* activeTurnIdForOmpRuntimeEvent(ctx, event._tag);
+                      if (activeTurnId === undefined) {
+                        return;
+                      }
+                      const scopedItemId = scopeOmpRuntimeItemIdForTurn(activeTurnId, event.itemId);
+                      if (!ctx.activeAssistantItemsWithContent.has(scopedItemId)) {
+                        if (isOmpAcpDebugEnabled()) {
+                          yield* Effect.logInfo("omp.acp.empty_assistant_item_suppressed", {
+                            threadId: ctx.threadId,
+                            turnId: activeTurnId,
+                            itemId: scopedItemId,
+                          });
+                        }
+                        return;
+                      }
+                      ctx.activeAssistantItemsWithContent.delete(scopedItemId);
+                      yield* offerRuntimeEvent(
+                        input.lifecycleGeneration,
+                        makeAcpAssistantItemEvent({
+                          stamp: yield* makeEventStamp(),
+                          provider: PROVIDER,
+                          threadId: ctx.threadId,
+                          turnId: activeTurnId,
+                          itemId: scopedItemId,
+                          lifecycle: "item.completed",
+                        }),
+                      );
+                    }
+                    return;
+                  case "PlanUpdated":
+                    {
+                      const activeTurnId = yield* activeTurnIdForOmpRuntimeEvent(ctx, event._tag);
+                      if (activeTurnId === undefined) {
+                        return;
+                      }
+                      yield* logNative(ctx.threadId, "session/update", event.rawPayload);
+                      yield* emitPlanUpdate(ctx, event.payload, event.rawPayload);
+                    }
+                    return;
+                  case "ToolCallUpdated":
+                    {
+                      // A queued update for a tool call the just-settled turn
+                      // already rendered belongs to that turn; emit it with the
+                      // originating turn id so the existing tool row resolves in
+                      // place instead of being dropped as an orphan. Resume
+                      // replay stays suppressed like every other event.
+                      const lateTurnId =
+                        ctx.resumeReplayReady === undefined && ctx.activeTurnId === undefined
+                          ? ctx.turnToolCallIds.get(event.toolCall.toolCallId)
+                          : undefined;
+                      if (lateTurnId !== undefined) {
+                        yield* logNative(ctx.threadId, "session/update", event.rawPayload);
+                        yield* emitNestedTaskLifecycle(ctx, event.toolCall, lateTurnId);
+                        yield* offerRuntimeEvent(
+                          input.lifecycleGeneration,
+                          makeAcpToolCallEvent({
+                            stamp: yield* makeEventStamp(),
+                            provider: PROVIDER,
+                            threadId: ctx.threadId,
+                            turnId: lateTurnId,
+                            toolCall: scopeOmpToolCallStateForTurn(lateTurnId, event.toolCall),
+                            rawPayload: event.rawPayload,
+                          }),
+                        );
+                        return;
+                      }
+                      const activeTurnId = yield* activeTurnIdForOmpRuntimeEvent(ctx, event._tag);
+                      if (activeTurnId === undefined) {
+                        return;
+                      }
+                      ctx.turnToolCallIds.set(event.toolCall.toolCallId, activeTurnId);
+                      yield* logNative(ctx.threadId, "session/update", event.rawPayload);
+                      yield* emitNestedTaskLifecycle(ctx, event.toolCall, activeTurnId);
+                      const failedToolDetail = readAcpFailedToolDetail(event.toolCall);
+                      if (failedToolDetail !== undefined) {
+                        ctx.activeTurnFailedToolDetail = failedToolDetail;
+                      }
+                      yield* offerRuntimeEvent(
+                        input.lifecycleGeneration,
+                        makeAcpToolCallEvent({
+                          stamp: yield* makeEventStamp(),
+                          provider: PROVIDER,
+                          threadId: ctx.threadId,
+                          turnId: activeTurnId,
+                          toolCall: scopeOmpToolCallStateForTurn(activeTurnId, event.toolCall),
+                          rawPayload: event.rawPayload,
+                        }),
+                      );
+                    }
+                    return;
+                  case "ContentDelta":
+                    {
+                      const activeTurnId = yield* activeTurnIdForOmpRuntimeEvent(ctx, event._tag);
+                      if (activeTurnId === undefined) {
+                        return;
+                      }
+                      yield* logNative(ctx.threadId, "session/update", event.rawPayload);
+                      const scopedItemId = event.itemId
+                        ? scopeOmpRuntimeItemIdForTurn(activeTurnId, event.itemId)
+                        : undefined;
+                      if (isRenderableOmpAssistantDelta(event)) {
+                        ctx.activeTurnHadAssistantContent = true;
+                        if (scopedItemId !== undefined) {
+                          ctx.activeAssistantItemsWithContent.add(scopedItemId);
+                        }
+                      }
+                      yield* offerRuntimeEvent(
+                        input.lifecycleGeneration,
+                        makeAcpContentDeltaEvent({
+                          stamp: yield* makeEventStamp(),
+                          provider: PROVIDER,
+                          threadId: ctx.threadId,
+                          turnId: activeTurnId,
+                          ...(scopedItemId ? { itemId: scopedItemId } : {}),
+                          text: event.text,
+                          ...(event.streamKind ? { streamKind: event.streamKind } : {}),
+                          rawPayload: event.rawPayload,
+                        }),
+                      );
+                    }
+                    return;
+                  case "UsageUpdated":
+                    {
+                      const activeTurnId = yield* activeTurnIdForOmpRuntimeEvent(ctx, event._tag);
+                      if (activeTurnId === undefined) {
+                        return;
+                      }
+                      yield* logNative(ctx.threadId, "session/update", event.rawPayload);
+                      recordAcpSessionCost(ctx, event.cost);
+                      yield* offerRuntimeEvent(
+                        input.lifecycleGeneration,
+                        makeAcpTokenUsageEvent({
+                          stamp: yield* makeEventStamp(),
+                          provider: PROVIDER,
+                          threadId: ctx.threadId,
+                          turnId: activeTurnId,
+                          usage: event.usage,
+                          rawPayload: event.rawPayload,
+                        }),
+                      );
+                    }
+                    return;
+                }
+              }).pipe(
+                // Bump the processed count only after the handler fully ran, so
+                // waitForOmpQueuedTurnEventsDrained cannot observe an event as
+                // consumed while its state updates are still being applied.
+                Effect.ensuring(
+                  Effect.sync(() => {
+                    ctx.sessionUpdatesProcessed += 1;
+                  }),
+                ),
+              ),
+            ),
+          ).pipe(Effect.forkChild);
+
+          ctx.notificationFiber = notificationFiber;
+          sessions.set(input.threadId, ctx);
+          sessionScopeTransferred = true;
+
+          // Config RPCs run after the consumer fork so replay emitted while they
+          // are in flight keeps draining. The session is already registered and
+          // the start-scope finalizer no longer owns the session scope, so any
+          // failure OR interruption of the remaining startup steps must tear the
+          // session down explicitly instead of leaking a live child.
+          yield* Effect.gen(function* () {
+            if (ompModelSelection?.model) {
+              yield* applyOmpAcpModelSelection({
+                runtime: acp,
+                model: ompModelSelection.model,
+                thinkingLevel: ompModelSelection.options?.thinkingLevel,
+                mapError: ({ cause, method }) =>
+                  mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
+              });
+            }
+            // The requested model/effort are applied; turns gated on this
+            // deferred can now prompt without inheriting provider defaults.
+            yield* Deferred.succeed(sessionConfigReady, undefined);
+            ctx.sessionConfigReady = undefined;
+
+            if (resumeReplayReady !== undefined) {
+              // Settle the replay in the background: suppression stays active until
+              // the stream is genuinely quiet, while startup only blocks briefly so
+              // a long replay cannot hold session startup hostage. sendTurn awaits
+              // the deferred, so the first turn stays gated until the replay has
+              // actually finished.
+              yield* settleOmpResumeReplayWhenQuiet(ctx).pipe(Effect.forkIn(ctx.scope));
+              yield* Deferred.await(resumeReplayReady).pipe(
+                Effect.timeoutOption(OMP_RESUME_REPLAY_MAX_WAIT_MS),
+              );
+            }
+
+            yield* offerRuntimeEvent(input.lifecycleGeneration, {
+              type: "session.started",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              payload: { resume: started.initializeResult },
+            });
+            yield* offerRuntimeEvent(input.lifecycleGeneration, {
+              type: "session.state.changed",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              payload: { state: "ready", reason: "Omp ACP session ready" },
+            });
+            yield* offerRuntimeEvent(input.lifecycleGeneration, {
+              type: "thread.started",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              payload: { providerThreadId: started.sessionId },
+            });
+          }).pipe(
+            Effect.timeoutOption(OMP_ACP_REQUEST_TIMEOUT_MS),
+            Effect.flatMap(
+              Option.match({
+                onNone: () => Effect.fail(ompAcpTimeoutError("session/set_config_option")),
+                onSome: Effect.succeed,
+              }),
+            ),
+            Effect.onExit((exit) =>
+              Exit.isSuccess(exit) ? Effect.void : Effect.ignore(stopSessionInternal(ctx)),
+            ),
+          );
+
+          return session;
+        }).pipe(Effect.scoped),
+      );
+
+    // Idle-progress watchdog escape hatch: force-fail a turn whose omp child
+    // is alive but has gone completely silent. Mirrors the prompt-fiber
+    // onFailure branch and stays idempotent via clearAcpActiveTurn, so it is a
+    // no-op if the turn settled normally first (whichever fires first wins).
+    const failOmpTurnAsTimedOut = (ctx: OmpSessionContext, turnId: TurnId, idleMs: number) =>
+      Effect.gen(function* () {
+        const promptFiber = ctx.activePromptFiber;
+        if (!clearAcpActiveTurn(ctx, turnId)) {
+          return;
+        }
+        const completedCost = finalizeAcpActiveTurnCost(ctx);
+        const idleSeconds = Math.round(idleMs / 1000);
+        const detail = `Omp stopped responding (no activity for ${idleSeconds}s); the turn was timed out.`;
+        ctx.turns.push({ id: turnId, items: [{ prompt: turnId, timedOut: true, idleMs }] });
+        ctx.session = {
+          ...ctx.session,
+          status: "error",
+          updatedAt: yield* nowIso,
+          lastError: detail,
+        };
+        yield* Effect.logWarning("omp.acp.turn_idle_timeout", {
+          threadId: ctx.threadId,
+          turnId,
+          idleMs,
+        });
+        yield* offerRuntimeEvent(ctx.lifecycleGeneration, {
+          type: "turn.completed",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: ctx.threadId,
+          turnId,
+          payload: {
+            state: "failed",
+            stopReason: null,
+            errorMessage: detail,
+            ...completedCost,
+          },
+        });
+        // Let Omp flush final ACP updates and settle session/prompt before
+        // escalating to process teardown for a silent nested worker.
+        yield* cancelOmpPromptWithGrace(ctx, promptFiber);
+        yield* stopSessionInternal(ctx, {
+          exitKind: "error",
+          reason: detail,
+          awaitTermination: false,
+        });
+      });
+
+    const sendTurn: OmpAdapterShape["sendTurn"] = (input) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(input.threadId);
+        // A second sendTurn entering while another turn is still starting would
+        // clear that turn's pendingTurnInterrupted flag (letting a cancelled
+        // turn dispatch anyway) and race two ACP prompts; reject it instead.
+        if (ctx.turnStarting) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "sendTurn",
+            issue: "Another Omp turn is still starting for this thread.",
+          });
+        }
+        ctx.turnStarting = true;
+        ctx.pendingTurnInterrupted = false;
+        return yield* startOmpTurn(ctx, input).pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              ctx.turnStarting = false;
+            }),
+          ),
+        );
+      });
+
+    const startOmpTurn = (
+      ctx: OmpSessionContext,
+      input: Parameters<OmpAdapterShape["sendTurn"]>[0],
+    ) =>
+      Effect.gen(function* () {
+        // Startup registers the session before its config RPCs settle; a turn
+        // routed in during that window must not prompt with provider defaults.
+        if (ctx.sessionConfigReady !== undefined) {
+          yield* Deferred.await(ctx.sessionConfigReady);
+        }
+        if (ctx.resumeReplayReady !== undefined) {
+          yield* Deferred.await(ctx.resumeReplayReady);
+        }
+        // The gates above are resolved by stopSessionInternal too (a failed or
+        // stopped startup must not strand waiters); a turn that was blocked on
+        // them must fail here instead of emitting lifecycle events for a dead
+        // session.
+        if (ctx.stopped) {
+          return yield* new ProviderAdapterSessionNotFoundError({
+            provider: PROVIDER,
+            threadId: input.threadId,
+          });
+        }
+        const turnId = TurnId.makeUnsafe(crypto.randomUUID());
+        const turnModelSelection =
+          input.modelSelection?.provider === PROVIDER ? input.modelSelection : undefined;
+        const model = turnModelSelection?.model ?? ctx.session.model;
+        const interactionMode = resolveAcpTurnInteractionMode(input.interactionMode);
+        // Selection changes normally arrive via a session restart, but a turn
+        // can still carry an explicit selection; re-assert it over ACP (the
+        // shared runtime skips the RPC when the value already matches).
+        yield* Effect.gen(function* () {
+          if (model !== undefined) {
+            yield* applyOmpAcpModelSelection({
+              runtime: ctx.acp,
+              model,
+              thinkingLevel: turnModelSelection?.options?.thinkingLevel,
+              mapError: ({ cause, method }) =>
+                mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
+            });
+          }
+          yield* applyOmpAcpInteractionMode({
+            runtime: ctx.acp,
+            interactionMode,
+            runtimeMode: ctx.session.runtimeMode,
+            mapError: ({ cause, method }) =>
+              mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
+          });
+        }).pipe(
+          Effect.timeoutOption(OMP_ACP_REQUEST_TIMEOUT_MS),
+          Effect.flatMap(
+            Option.match({
+              onNone: () => Effect.fail(ompAcpTimeoutError("session/set_config_option")),
+              onSome: Effect.succeed,
+            }),
+          ),
+          Effect.onError((cause) =>
+            stopSessionInternal(ctx, {
+              exitKind: "error",
+              reason: Cause.pretty(cause),
+            }),
+          ),
+        );
+        const promptParts: Array<Acp.ContentBlock> = [];
+        const promptText = appendFileAttachmentsPromptBlock({
+          text: appendProviderReferencesPromptBlock({
+            text: input.input?.trim()
+              ? withAcpPlanModePrompt({
+                  text: input.input.trim(),
+                  interactionMode,
+                  promptPrefix: OMP_PLAN_MODE_PROMPT_PREFIX,
+                })
+              : undefined,
+            mentions: input.mentions,
+          }),
+          attachments: input.attachments,
+          attachmentsDir: serverConfig.attachmentsDir,
+          include: "all-files",
+        });
+        if (promptText) {
+          promptParts.push({
+            type: "text",
+            text: promptText,
+          });
+        }
+        promptParts.push(
+          ...(yield* loadProviderPromptImageBlocks({
+            attachments: input.attachments,
+            attachmentsDir: serverConfig.attachmentsDir,
+            provider: PROVIDER,
+            method: "session/prompt",
+            readFile: fileSystem.readFile,
+          })),
+        );
+
+        if (promptParts.length === 0) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "sendTurn",
+            issue: "Turn requires non-empty text or attachments.",
+          });
+        }
+        const harnessPolicy = takeOmpSynaraHarnessPolicyTextPart(
+          ctx,
+          agentGatewayCredentials !== undefined,
+        );
+        if (harnessPolicy) {
+          promptParts.unshift(harnessPolicy);
+        }
+
+        // A stop can land while the replay gate or attachment reads above were
+        // in flight; opening the turn now would publish turn.started (and a
+        // phantom cancelled completion) for a session that already exited.
+        if (ctx.stopped) {
+          return yield* new ProviderAdapterSessionNotFoundError({
+            provider: PROVIDER,
+            threadId: input.threadId,
+          });
+        }
+        ctx.activeTurnId = turnId;
+        ctx.activeTurnHadAssistantContent = false;
+        ctx.activeAssistantItemsWithContent.clear();
+        ctx.activeTurnFailedToolDetail = undefined;
+        // Late-event attribution only matters between turns; once a new turn
+        // dispatches, stragglers from older turns are stale enough to drop.
+        ctx.turnToolCallIds.clear();
+        ctx.activeNestedTaskToolCallIds.clear();
+        ctx.nestedTaskLifecycleByToolCallId.clear();
+        ctx.activeInteractionMode = interactionMode;
+        ctx.lastPlanFingerprint = undefined;
+        ctx.lastTurnActivityAt = Date.now();
+        const { lastError: _lastError, ...sessionWithoutLastError } = ctx.session;
+        ctx.session = {
+          ...sessionWithoutLastError,
+          status: "running",
+          activeTurnId: turnId,
+          updatedAt: yield* nowIso,
+        };
+
+        yield* offerRuntimeEvent(ctx.lifecycleGeneration, {
+          type: "turn.started",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: input.threadId,
+          turnId,
+          payload: { ...(model ? { model } : {}) },
+        });
+
+        const runPrompt = Effect.suspend(() =>
+          // interruptTurn during the pre-prompt waits (resume replay, attachment
+          // reads) or between turn.started publishing and this fiber being
+          // registered sets pendingTurnInterrupted; honor it (and a concurrent
+          // stop) here so a cancelled turn is never prompted. Self-interrupting
+          // routes through the onInterrupt branch below, which completes the
+          // turn as cancelled rather than as a provider failure.
+          ctx.pendingTurnInterrupted || ctx.stopped
+            ? Effect.interrupt
+            : ctx.acp.prompt({ prompt: promptParts }),
+        ).pipe(
+          Effect.mapError((error) =>
+            mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
+          ),
+          Effect.matchEffect({
+            onFailure: (error) =>
+              Effect.gen(function* () {
+                yield* waitForOmpQueuedTurnEventsDrained(ctx);
+                if (!clearAcpActiveTurn(ctx, turnId)) {
+                  return;
+                }
+                const completedCost = finalizeAcpActiveTurnCost(ctx);
+                ctx.turns.push({ id: turnId, items: [{ prompt: promptParts, error }] });
+                const detail = error.message;
+                ctx.session = {
+                  ...ctx.session,
+                  status: "error",
+                  updatedAt: yield* nowIso,
+                  ...(model ? { model } : {}),
+                  lastError: detail,
+                };
+                yield* offerRuntimeEvent(ctx.lifecycleGeneration, {
+                  type: "turn.completed",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  turnId,
+                  payload: {
+                    state: "failed",
+                    stopReason: null,
+                    errorMessage: detail,
+                    ...completedCost,
+                  },
+                });
+                // Transport/prompt failures make the ACP child unusable. Remove
+                // it from routing immediately so ProviderService can recover on
+                // the next send instead of reusing a dead session forever.
+                yield* stopSessionInternal(ctx, {
+                  exitKind: "error",
+                  reason: detail,
+                  awaitTermination: false,
+                });
+              }),
+            onSuccess: (result) =>
+              Effect.gen(function* () {
+                // Drain BEFORE snapshotting turn state: queued events may still
+                // set activeTurnFailedToolDetail or assistant-content flags.
+                yield* waitForOmpQueuedTurnEventsDrained(ctx);
+                const hadAssistantContent = ctx.activeTurnHadAssistantContent;
+                const failedToolDetail = ctx.activeTurnFailedToolDetail;
+                if (!clearAcpActiveTurn(ctx, turnId)) {
+                  return;
+                }
+                const completedCost = finalizeAcpActiveTurnCost(ctx);
+                ctx.turns.push({ id: turnId, items: [{ prompt: promptParts, result }] });
+                const { lastError: _lastError, ...sessionWithoutLastError } = ctx.session;
+                ctx.session = {
+                  ...sessionWithoutLastError,
+                  status: "ready",
+                  updatedAt: yield* nowIso,
+                  ...(model ? { model } : {}),
+                };
+                if (!hadAssistantContent && result.stopReason !== "cancelled") {
+                  yield* Effect.logWarning("omp.acp.turn_completed_without_content", {
+                    threadId: input.threadId,
+                    turnId,
+                    stopReason: result.stopReason ?? null,
+                    hasUsage: result.usage !== undefined,
+                  });
+                }
+                const completion = classifyOmpPromptTurnCompletion({
+                  stopReason: result.stopReason,
+                  ...(failedToolDetail !== undefined ? { failedToolDetail } : {}),
+                });
+                yield* offerRuntimeEvent(ctx.lifecycleGeneration, {
+                  type: "turn.completed",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  turnId,
+                  payload: {
+                    state: completion.state,
+                    stopReason: result.stopReason ?? null,
+                    ...(completion.errorMessage !== undefined
+                      ? { errorMessage: completion.errorMessage }
+                      : {}),
+                    ...(result.usage ? { usage: result.usage } : {}),
+                    ...completedCost,
+                  },
+                });
+              }),
+          }),
+          Effect.onInterrupt(() =>
+            Effect.gen(function* () {
+              if (!clearAcpActiveTurn(ctx, turnId)) {
+                return;
+              }
+              const completedCost = finalizeAcpActiveTurnCost(ctx);
+              ctx.turns.push({ id: turnId, items: [{ prompt: promptParts, interrupted: true }] });
+              const { lastError: _lastError, ...sessionWithoutLastError } = ctx.session;
+              ctx.session = {
+                ...sessionWithoutLastError,
+                status: "ready",
+                updatedAt: yield* nowIso,
+                ...(model ? { model } : {}),
+              };
+              yield* offerRuntimeEvent(ctx.lifecycleGeneration, {
+                type: "turn.completed",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                turnId,
+                payload: {
+                  state: "cancelled",
+                  stopReason: "cancelled",
+                  ...completedCost,
+                },
+              });
+            }),
+          ),
+          Effect.ignoreCause({ log: true }),
+          Effect.forkIn(ctx.scope),
+        );
+        ctx.activePromptFiber = yield* runPrompt;
+
+        // Backstop the forked prompt: if the child goes silent, fail the turn
+        // instead of leaving it "Working" forever. Self-terminates when the
+        // turn settles; pauses while a human approval is pending.
+        yield* forkAcpTurnIdleWatchdog({
+          idleTimeoutMs: OMP_TURN_IDLE_TIMEOUT_MS,
+          currentIdleTimeoutMs: () =>
+            ctx.activeNestedTaskToolCallIds.size > 0
+              ? OMP_NESTED_TASK_IDLE_TIMEOUT_MS
+              : OMP_TURN_IDLE_TIMEOUT_MS,
+          checkIntervalMs: OMP_TURN_WATCHDOG_INTERVAL_MS,
+          scope: ctx.scope,
+          isTurnActive: () => ctx.activeTurnId === turnId && !ctx.stopped,
+          isAwaitingHuman: () => ctx.pendingApprovals.size > 0 || ctx.pendingUserInputs.size > 0,
+          lastActivityAt: () => ctx.lastTurnActivityAt ?? Date.now(),
+          touchActivity: () => {
+            ctx.lastTurnActivityAt = Date.now();
+          },
+          onIdleTimeout: (idleMs) => failOmpTurnAsTimedOut(ctx, turnId, idleMs),
+        });
+
+        return {
+          threadId: input.threadId,
+          turnId,
+          ...(ctx.session.resumeCursor !== undefined
+            ? { resumeCursor: ctx.session.resumeCursor }
+            : {}),
+        };
+      });
+
+    const interruptTurn: OmpAdapterShape["interruptTurn"] = (threadId, turnId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        if (shouldIgnoreOmpInterrupt(turnId, ctx.activeTurnId)) {
+          yield* Effect.logWarning("omp.acp.stale_interrupt_ignored", {
+            threadId,
+            requestedTurnId: turnId,
+            activeTurnId: ctx.activeTurnId,
+          });
+          return;
+        }
+        if (!ctx.turnStarting && ctx.activeTurnId === undefined) {
+          return;
+        }
+        // A turn that is still starting has no prompt fiber to interrupt yet
+        // (it may be gated on resume replay); flag it so startOmpTurn aborts
+        // before prompting instead of running the cancelled turn anyway.
+        if (ctx.turnStarting && ctx.activePromptFiber === undefined) {
+          ctx.pendingTurnInterrupted = true;
+        }
+        yield* settleAcpPendingApprovalsAsCancelled(ctx.pendingApprovals);
+        yield* settleAcpPendingUserInputsAsEmptyAnswers(ctx.pendingUserInputs);
+        const activePromptFiber = ctx.activePromptFiber;
+        yield* cancelOmpPromptWithGrace(ctx, activePromptFiber);
+        // Closing the process group is intentional: OMP can acknowledge
+        // cancel before nested workers quiesce, so session reuse is unsafe.
+        yield* stopSessionInternal(ctx, {
+          exitKind: "graceful",
+          reason: "Omp turn cancelled; runtime closed to stop nested work.",
+        });
+      });
+
+    const respondToRequest: OmpAdapterShape["respondToRequest"] = (threadId, requestId, decision) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        const pending = ctx.pendingApprovals.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session/request_permission",
+            detail: `Unknown pending approval request: ${requestId}`,
+          });
+        }
+        yield* Deferred.succeed(pending.decision, decision);
+      });
+
+    const respondToUserInput: OmpAdapterShape["respondToUserInput"] = (
+      threadId,
+      requestId,
+      answers,
+    ) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        const pending = ctx.pendingUserInputs.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session/elicitation",
+            detail: `Unknown pending user-input request: ${requestId}`,
+          });
+        }
+        yield* Deferred.succeed(pending.answers, answers);
+      });
+
+    const readThread: OmpAdapterShape["readThread"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        return { threadId, turns: ctx.turns };
+      });
+
+    const rollbackThread: OmpAdapterShape["rollbackThread"] = (threadId, numTurns) =>
+      Effect.gen(function* () {
+        yield* requireSession(threadId);
+        if (!Number.isInteger(numTurns) || numTurns < 1) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "rollbackThread",
+            issue: "numTurns must be an integer >= 1.",
+          });
+        }
+        return yield* new ProviderAdapterValidationError({
+          provider: PROVIDER,
+          operation: "rollbackThread",
+          issue:
+            "Omp does not expose a native rewind cursor; rollback must restart the session with retained transcript context.",
+        });
+      });
+
+    const forkThread: NonNullable<OmpAdapterShape["forkThread"]> = (input) =>
+      Effect.gen(function* () {
+        const sourceCwd = resolveOmpSessionCwd(input.sourceCwd ?? input.cwd, serverConfig);
+        const targetCwd = resolveOmpSessionCwd(input.cwd ?? input.sourceCwd, serverConfig);
+        if (!sourceCwd || !targetCwd) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "forkThread",
+            issue: "A source and target cwd are required to fork a Omp session.",
+          });
+        }
+
+        const forkRuntime = (runtime: AcpSessionRuntimeShape) =>
+          Effect.gen(function* () {
+            if (!(yield* runtime.supportsSessionFork)) {
+              return yield* new ProviderAdapterValidationError({
+                provider: PROVIDER,
+                operation: "forkThread",
+                issue:
+                  "This Omp ACP version does not advertise session/fork; Synara will rebuild the fork from its retained transcript.",
+              });
+            }
+            return yield* runtime.forkSession({ cwd: targetCwd, mcpServers: [] });
+          }).pipe(
+            Effect.timeoutOption(OMP_ACP_REQUEST_TIMEOUT_MS),
+            Effect.flatMap(
+              Option.match({
+                onNone: () => Effect.fail(ompAcpTimeoutError("session/fork")),
+                onSome: Effect.succeed,
+              }),
+            ),
+          );
+
+        const activeSource = sessions.get(input.sourceThreadId);
+        const forked = activeSource
+          ? yield* forkRuntime(activeSource.acp)
+          : yield* Effect.gen(function* () {
+              const sourceSessionId = parseOmpResume(input.sourceResumeCursor)?.sessionId;
+              if (!sourceSessionId) {
+                return yield* new ProviderAdapterValidationError({
+                  provider: PROVIDER,
+                  operation: "forkThread",
+                  issue: "The source Omp session has no resumable native cursor.",
+                });
+              }
+              const runtime = yield* makeOmpAcpRuntime({
+                ompSettings: {
+                  ...(ompSettings.binaryPath ? { binaryPath: ompSettings.binaryPath } : {}),
+                  ...(input.providerOptions?.omp?.binaryPath
+                    ? { binaryPath: input.providerOptions.omp.binaryPath }
+                    : {}),
+                },
+                childProcessSpawner,
+                cwd: sourceCwd,
+                resumeSessionId: sourceSessionId,
+                clientInfo: { name: "Synara Fork", version: "0.0.0" },
+              });
+              yield* runtime.start().pipe(
+                Effect.timeoutOption(OMP_ACP_REQUEST_TIMEOUT_MS),
+                Effect.flatMap(
+                  Option.match({
+                    onNone: () => Effect.fail(ompAcpTimeoutError("session/resume")),
+                    onSome: Effect.succeed,
+                  }),
+                ),
+              );
+              return yield* forkRuntime(runtime);
+            }).pipe(Effect.scoped);
+
+        const resumeCursor = {
+          schemaVersion: OMP_RESUME_VERSION,
+          sessionId: forked.sessionId,
+        };
+        yield* startSession({
+          threadId: input.threadId,
+          provider: PROVIDER,
+          cwd: targetCwd,
+          runtimeMode: input.runtimeMode,
+          resumeCursor,
+          ...(input.modelSelection ? { modelSelection: input.modelSelection } : {}),
+          ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
+        });
+        return { threadId: input.threadId, resumeCursor };
+      }).pipe(
+        Effect.mapError((cause) =>
+          cause instanceof ProviderAdapterRequestError ||
+          cause instanceof ProviderAdapterProcessError ||
+          cause instanceof ProviderAdapterSessionClosedError ||
+          cause instanceof ProviderAdapterSessionNotFoundError ||
+          cause instanceof ProviderAdapterValidationError
+            ? cause
+            : mapAcpToAdapterError(PROVIDER, input.sourceThreadId, "session/fork", cause),
+        ),
+      );
+
+    const stopSession: OmpAdapterShape["stopSession"] = (threadId) =>
+      withThreadLock(
+        threadId,
+        Effect.gen(function* () {
+          const ctx = sessions.get(threadId);
+          if (ctx !== undefined && !ctx.stopped) {
+            yield* stopSessionInternal(ctx);
+            return;
+          }
+          if (sessionTeardownGate.isPending(threadId)) {
+            yield* sessionTeardownGate.awaitPending(threadId);
+            return;
+          }
+          return;
+        }),
+      );
+
+    const listSessions: OmpAdapterShape["listSessions"] = () =>
+      Effect.sync(() => Array.from(sessions.values(), (ctx) => ({ ...ctx.session })));
+
+    const hasSession: OmpAdapterShape["hasSession"] = (threadId) =>
+      Effect.sync(() => {
+        const ctx = sessions.get(threadId);
+        return ctx !== undefined && !ctx.stopped;
+      });
+
+    const getComposerCapabilities: NonNullable<OmpAdapterShape["getComposerCapabilities"]> = () =>
+      Effect.succeed({
+        provider: PROVIDER,
+        supportsSkillMentions: false,
+        supportsSkillDiscovery: false,
+        supportsNativeSlashCommandDiscovery: true,
+        supportsPluginMentions: false,
+        supportsPluginDiscovery: false,
+        supportsRuntimeModelList: true,
+        // Omp's TUI has /compact, but ACP currently exposes no compaction RPC
+        // and treats that text as an ordinary model prompt.
+        supportsThreadCompaction: false,
+        supportsThreadImport: false,
+      } satisfies ProviderComposerCapabilities);
+
+    const listModels: NonNullable<OmpAdapterShape["listModels"]> = (input) =>
+      discoveryLock.withPermits(1)(
+        Effect.gen(function* () {
+          log.info("model/list enter", {
+            inputBinaryPath: input.binaryPath ?? null,
+            ompSettingsBinaryPath: ompSettings.binaryPath ?? null,
+          });
+          const binaryPath =
+            input.binaryPath?.trim() || ompSettings.binaryPath?.trim() || "omp";
+          const cacheKey = binaryPath;
+          const cached = modelDiscoveryCache.get(cacheKey);
+          if (cached && cached.expiresAt > Date.now()) {
+            log.info("model/list cache hit", {
+              cacheKey,
+              modelCount: cached.result.models.length,
+            });
+            return { ...cached.result, cached: true };
+          }
+          const result = yield* runOmpCliModelList(binaryPath).pipe(
+            Effect.timeoutOption(OMP_MODEL_DISCOVERY_TIMEOUT_MS),
+            Effect.flatMap(
+              Option.match({
+                onNone: () =>
+                  Effect.fail(
+                    new ProviderAdapterRequestError({
+                      provider: PROVIDER,
+                      method: "model/list",
+                      detail: "Timed out while discovering Omp models via CLI.",
+                    }),
+                  ),
+                onSome: (discovered) => Effect.succeed(discovered),
+              }),
+            ),
+            Effect.mapError((cause) =>
+              cause instanceof ProviderAdapterRequestError
+                ? cause
+                : new ProviderAdapterRequestError({
+                    provider: PROVIDER,
+                    method: "model/list",
+                    detail:
+                      cause instanceof Error && cause.message
+                        ? cause.message
+                        : "OMP model discovery failed unexpectedly.",
+                  }),
+            ),
+            Effect.tapError((cause) =>
+              Effect.sync(() => {
+                if (cause instanceof ProviderAdapterRequestError) {
+                  log.warn("model/list failed", {
+                    method: cause.method,
+                    detail: cause.detail,
+                  });
+                } else {
+                  log.warn("model/list failed", { detail: String(cause) });
+                }
+              }),
+            ),
+          );
+          log.info("model/list success", {
+            modelCount: result.models.length,
+            source: result.source,
+          });
+          setOmpDiscoveryCacheEntry(modelDiscoveryCache, cacheKey, {
+            expiresAt: Date.now() + OMP_MODEL_DISCOVERY_CACHE_MS,
+            result,
+          });
+          return result;
+        }),
+      );
+
+    const listCommands: NonNullable<OmpAdapterShape["listCommands"]> = (input) =>
+      discoveryLock.withPermits(1)(
+        Effect.gen(function* () {
+          const cwd = resolveOmpSessionCwd(input.cwd, serverConfig);
+          if (!cwd) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "listCommands",
+              issue: "cwd is required and no server cwd fallback is available.",
+            });
+          }
+          const cacheKey = `${input.binaryPath?.trim() || ompSettings.binaryPath?.trim() || "omp"}\u0000${cwd}`;
+          const cached = commandDiscoveryCache.get(cacheKey);
+          if (input.forceReload !== true && cached && cached.expiresAt > Date.now()) {
+            return { ...cached.result, cached: true };
+          }
+          const runtime = yield* makeOmpDiscoveryRuntime({
+            ...(input.binaryPath ? { binaryPath: input.binaryPath } : {}),
+            cwd,
+            clientName: "Synara Command Discovery",
+          });
+          yield* runtime.start();
+          let commands = yield* runtime.getAvailableCommands;
+          const startedAt = Date.now();
+          while (commands.length === 0 && Date.now() - startedAt < 500) {
+            yield* Effect.sleep(25);
+            commands = yield* runtime.getAvailableCommands;
+          }
+          const result = {
+            commands: commands.map((command) => ({
+              name: command.name,
+              ...(command.description ? { description: command.description } : {}),
+            })),
+            source: "omp-acp",
+            cached: false,
+          } satisfies ProviderListCommandsResult;
+          setOmpDiscoveryCacheEntry(commandDiscoveryCache, cacheKey, {
+            expiresAt: Date.now() + OMP_MODEL_DISCOVERY_CACHE_MS,
+            result,
+          });
+          return result;
+        }).pipe(
+          Effect.scoped,
+          Effect.mapError((cause) =>
+            cause instanceof ProviderAdapterValidationError
+              ? cause
+              : mapAcpToAdapterError(
+                  PROVIDER,
+                  ThreadId.makeUnsafe("omp-command-discovery"),
+                  "command/list",
+                  cause,
+                ),
+          ),
+          Effect.timeoutOption(OMP_MODEL_DISCOVERY_TIMEOUT_MS),
+          Effect.flatMap(
+            Option.match({
+              onNone: () =>
+                Effect.fail(
+                  new ProviderAdapterRequestError({
+                    provider: PROVIDER,
+                    method: "command/list",
+                    detail: "Timed out while discovering Omp commands over ACP.",
+                  }),
+                ),
+              onSome: (result) => Effect.succeed(result),
+            }),
+          ),
+        ),
+      );
+
+    const stopAll: OmpAdapterShape["stopAll"] = () =>
+      Effect.forEach(Array.from(sessions.values()), (ctx) => stopSessionInternal(ctx), {
+        discard: true,
+      });
+
+    yield* Effect.addFinalizer(() =>
+      Effect.forEach(Array.from(sessions.values()), (ctx) => stopSessionInternal(ctx), {
+        discard: true,
+      }).pipe(
+        Effect.tap(() => PubSub.shutdown(runtimeEventPubSub)),
+        Effect.tap(() => managedNativeEventLogger?.close() ?? Effect.void),
+      ),
+    );
+
+    const streamEvents = Stream.fromPubSub(runtimeEventPubSub);
+
+    return {
+      provider: PROVIDER,
+      capabilities: {
+        sessionModelSwitch: "restart-session",
+        conversationRollback: "restart-session",
+      },
+      startSession,
+      sendTurn,
+      interruptTurn,
+      readThread,
+      rollbackThread,
+      forkThread,
+      respondToRequest,
+      respondToUserInput,
+      stopSession,
+      listSessions,
+      getComposerCapabilities,
+      listCommands,
+      listModels,
+      hasSession,
+      stopAll,
+      streamEvents,
+    } satisfies OmpAdapterShape;
+  });
+}
+
+export const OmpAdapterLive = Layer.effect(OmpAdapter, makeOmpAdapter({}));
+
+export function makeOmpAdapterLive(
+  ompSettings: OmpAcpRuntimeSettings = {},
+  options?: OmpAdapterLiveOptions,
+) {
+  return Layer.effect(OmpAdapter, makeOmpAdapter(ompSettings, options));
+}

--- a/apps/server/src/provider/Layers/OmpAdapter.ts
+++ b/apps/server/src/provider/Layers/OmpAdapter.ts
@@ -1426,6 +1426,14 @@ export function makeOmpAdapter(
           input.modelSelection?.provider === PROVIDER ? input.modelSelection : undefined;
         const model = turnModelSelection?.model ?? ctx.session.model;
         const interactionMode = resolveAcpTurnInteractionMode(input.interactionMode);
+        const runtimeMode = ctx.session.runtimeMode;
+        if (runtimeMode === "auto") {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "sendTurn",
+            issue: "Auto runtime mode is available only to Codex and Claude.",
+          });
+        }
         // Selection changes normally arrive via a session restart, but a turn
         // can still carry an explicit selection; re-assert it over ACP (the
         // shared runtime skips the RPC when the value already matches).
@@ -1442,7 +1450,7 @@ export function makeOmpAdapter(
           yield* applyOmpAcpInteractionMode({
             runtime: ctx.acp,
             interactionMode,
-            runtimeMode: ctx.session.runtimeMode,
+            runtimeMode,
             mapError: ({ cause, method }) =>
               mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
           });

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
@@ -12,6 +12,7 @@ import { GrokAdapter, GrokAdapterShape } from "../Services/GrokAdapter.ts";
 import { KiloAdapter, KiloAdapterShape } from "../Services/KiloAdapter.ts";
 import { OpenCodeAdapter, OpenCodeAdapterShape } from "../Services/OpenCodeAdapter.ts";
 import { PiAdapter, PiAdapterShape } from "../Services/PiAdapter.ts";
+import { OmpAdapter, OmpAdapterShape } from "../Services/OmpAdapter.ts";
 import { AntigravityAdapter, AntigravityAdapterShape } from "../Services/AntigravityAdapter.ts";
 import { ProviderAdapterRegistry } from "../Services/ProviderAdapterRegistry.ts";
 import { ProviderAdapterRegistryLive } from "./ProviderAdapterRegistry.ts";
@@ -156,6 +157,22 @@ const fakePiAdapter: PiAdapterShape = {
   stopAll: vi.fn(),
   streamEvents: Stream.empty,
 };
+const fakeOmpAdapter: OmpAdapterShape = {
+  provider: "omp",
+  capabilities: { sessionModelSwitch: "in-session" },
+  startSession: vi.fn(),
+  sendTurn: vi.fn(),
+  interruptTurn: vi.fn(),
+  respondToRequest: vi.fn(),
+  respondToUserInput: vi.fn(),
+  stopSession: vi.fn(),
+  listSessions: vi.fn(),
+  hasSession: vi.fn(),
+  readThread: vi.fn(),
+  rollbackThread: vi.fn(),
+  stopAll: vi.fn(),
+  streamEvents: Stream.empty,
+};
 
 const fakeAntigravityAdapter: AntigravityAdapterShape = {
   provider: "antigravity",
@@ -188,6 +205,7 @@ const layer = it.layer(
         Layer.succeed(KiloAdapter, fakeKiloAdapter),
         Layer.succeed(OpenCodeAdapter, fakeOpenCodeAdapter),
         Layer.succeed(PiAdapter, fakePiAdapter),
+        Layer.succeed(OmpAdapter, fakeOmpAdapter),
       ),
     ),
     NodeServices.layer,
@@ -207,6 +225,7 @@ layer("ProviderAdapterRegistryLive", (it) => {
       const kilo = yield* registry.getByProvider("kilo");
       const opencode = yield* registry.getByProvider("opencode");
       const pi = yield* registry.getByProvider("pi");
+      const omp = yield* registry.getByProvider("omp");
       assert.equal(codex, fakeCodexAdapter);
       assert.equal(claude, fakeClaudeAdapter);
       assert.equal(cursor, fakeCursorAdapter);
@@ -216,6 +235,7 @@ layer("ProviderAdapterRegistryLive", (it) => {
       assert.equal(kilo, fakeKiloAdapter);
       assert.equal(opencode, fakeOpenCodeAdapter);
       assert.equal(pi, fakePiAdapter);
+      assert.equal(omp, fakeOmpAdapter);
 
       const providers = yield* registry.listProviders();
       assert.deepEqual(providers, [
@@ -227,6 +247,7 @@ layer("ProviderAdapterRegistryLive", (it) => {
         "droid",
         "kilo",
         "opencode",
+        "omp",
         "pi",
       ]);
     }),

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
@@ -23,6 +23,7 @@ import { GrokAdapter } from "../Services/GrokAdapter.ts";
 import { KiloAdapter } from "../Services/KiloAdapter.ts";
 import { OpenCodeAdapter } from "../Services/OpenCodeAdapter.ts";
 import { PiAdapter } from "../Services/PiAdapter.ts";
+import { OmpAdapter } from "../Services/OmpAdapter.ts";
 import { AntigravityAdapter } from "../Services/AntigravityAdapter.ts";
 
 export interface ProviderAdapterRegistryLiveOptions {
@@ -43,6 +44,7 @@ const makeProviderAdapterRegistry = (options?: ProviderAdapterRegistryLiveOption
             yield* DroidAdapter,
             yield* KiloAdapter,
             yield* OpenCodeAdapter,
+            yield* OmpAdapter,
             yield* PiAdapter,
           ];
     const byProvider = new Map(adapters.map((adapter) => [adapter.provider, adapter]));

--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -156,6 +156,7 @@ const allProvidersDisabledSettings = {
     kilo: { enabled: false },
     opencode: { enabled: false },
     pi: { enabled: false },
+    omp: { enabled: false },
   },
 } as const;
 
@@ -171,6 +172,7 @@ const allProvidersDisabledServerSettings = {
     kilo: { ...DEFAULT_SERVER_SETTINGS.providers.kilo, enabled: false },
     opencode: { ...DEFAULT_SERVER_SETTINGS.providers.opencode, enabled: false },
     pi: { ...DEFAULT_SERVER_SETTINGS.providers.pi, enabled: false },
+    omp: { ...DEFAULT_SERVER_SETTINGS.providers.omp, enabled: false },
   },
 } satisfies typeof DEFAULT_SERVER_SETTINGS;
 
@@ -378,7 +380,7 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
       );
       const codex = statuses.find((status) => status.provider === "codex");
 
-      assert.strictEqual(statuses.length, 9);
+      assert.strictEqual(statuses.length, 10);
       assert.strictEqual(codex?.available, false);
       assert.strictEqual(codex?.message, "Provider is disabled in Synara settings.");
     });
@@ -513,7 +515,7 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
         const providerHealth = yield* ProviderHealth;
         const statuses = yield* providerHealth.refresh;
 
-        assert.strictEqual(statuses.length, 9);
+        assert.strictEqual(statuses.length, 10);
         for (const status of statuses) {
           assert.strictEqual(status.available, false);
           assert.strictEqual(status.message, "Provider is disabled in Synara settings.");

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -119,6 +119,7 @@ const DROID_PROVIDER = "droid" as const;
 const KILO_PROVIDER = "kilo" as const;
 const OPENCODE_PROVIDER = "opencode" as const;
 const PI_PROVIDER = "pi" as const;
+const OMP_PROVIDER = "omp" as const;
 type ProviderStatuses = ReadonlyArray<ServerProviderStatus>;
 const DISABLED_PROVIDER_STATUS_MESSAGE = "Provider is disabled in Synara settings.";
 const MINIMUM_ANTIGRAVITY_CLI_VERSION = "1.0.12";
@@ -133,6 +134,7 @@ const PROVIDERS = [
   KILO_PROVIDER,
   OPENCODE_PROVIDER,
   PI_PROVIDER,
+  OMP_PROVIDER,
 ] as const satisfies ReadonlyArray<ProviderKind>;
 
 const providerChildKind = (provider: ProviderKind): ProviderChildKind =>
@@ -273,6 +275,13 @@ export const PACKAGE_MANAGED_PROVIDER_UPDATES: Partial<
       lockKey: "pi-native",
       strategy: "always",
     },
+  },
+  omp: {
+    provider: OMP_PROVIDER,
+    binaryName: "omp",
+    npmPackageName: null,
+    homebrew: null,
+    nativeUpdate: null,
   },
 };
 
@@ -821,6 +830,15 @@ function cursorModelsOutputHasNoModels(output: string): boolean {
 
 const runPiCommand = (args: ReadonlyArray<string>, executable = "pi") =>
   runProviderCommand(executable, args, providerCommandEnv(PI_PROVIDER)).pipe(
+    Effect.flatMap((result) =>
+      isWindowsShellCommandMissingResult({ code: result.code, stderr: result.stderr })
+        ? Effect.fail(new Error(`spawn ${executable} ENOENT`))
+        : Effect.succeed(result),
+    ),
+  );
+
+const runOmpCommand = (args: ReadonlyArray<string>, executable = "omp") =>
+  runProviderCommand(executable, args, providerCommandEnv(OMP_PROVIDER)).pipe(
     Effect.flatMap((result) =>
       isWindowsShellCommandMissingResult({ code: result.code, stderr: result.stderr })
         ? Effect.fail(new Error(`spawn ${executable} ENOENT`))
@@ -1606,6 +1624,74 @@ export const checkPiProviderStatus = (
     } satisfies ServerProviderStatus;
   });
 
+export const checkOmpProviderStatus = (
+  agentDir?: string,
+  binaryPath?: string,
+): Effect.Effect<ServerProviderStatus, never, ChildProcessSpawner.ChildProcessSpawner> =>
+  Effect.gen(function* () {
+    const checkedAt = new Date().toISOString();
+    const executable = nonEmptyTrimmed(binaryPath) ?? "omp";
+
+    const versionProbe = yield* probeProviderCliVersion(
+      runOmpCommand(["--version"], executable),
+      DEFAULT_TIMEOUT_MS,
+    );
+
+    if (versionProbe.outcome === "missing" || versionProbe.outcome === "failure") {
+      const error = versionProbe.cause;
+      return {
+        provider: OMP_PROVIDER,
+        status: "warning" as const,
+        available: true,
+        authStatus: "unknown" as const,
+        checkedAt,
+        message:
+          versionProbe.outcome === "missing"
+            ? "OMP CLI (`omp`) is not on PATH. Install it to use the OMP provider."
+            : `OMP CLI health check failed: ${error instanceof Error ? error.message : String(error)}.`,
+      } satisfies ServerProviderStatus;
+    }
+
+    if (versionProbe.outcome === "timeout") {
+      return {
+        provider: OMP_PROVIDER,
+        status: "warning" as const,
+        available: true,
+        authStatus: "unknown" as const,
+        checkedAt,
+        message: "OMP CLI health check timed out before Synara could verify the installed version.",
+      } satisfies ServerProviderStatus;
+    }
+
+    if (versionProbe.outcome === "nonzero") {
+      const version = versionProbe.result;
+      const detail = detailFromResult(version);
+      return {
+        provider: OMP_PROVIDER,
+        status: "warning" as const,
+        available: true,
+        authStatus: "unknown" as const,
+        checkedAt,
+        message: detail ? `OMP CLI health check failed. ${detail}` : "OMP CLI health check failed.",
+      } satisfies ServerProviderStatus;
+    }
+
+    const version = versionProbe.result;
+    const parsedVersion = parseGenericCliVersion(`${version.stdout}\n${version.stderr}`);
+    const configuredAgentDir = nonEmptyTrimmed(agentDir);
+    return {
+      provider: OMP_PROVIDER,
+      status: "ready" as const,
+      available: true,
+      authStatus: "unknown" as const,
+      version: parsedVersion,
+      checkedAt,
+      message: configuredAgentDir
+        ? `OMP CLI is installed. Synara will use the OMP agent dir ${configuredAgentDir}.`
+        : "OMP CLI is installed. Configure provider credentials inside the OMP app as needed.",
+    } satisfies ServerProviderStatus;
+  });
+
 // ── Antigravity CLI health check ──────────────────────────────────
 
 export const checkAntigravityProviderStatus = (
@@ -2182,6 +2268,8 @@ export function makeProviderHealthLive(options?: { readonly providerUpdateTimeou
             return settings.providers.opencode.binaryPath;
           case "pi":
             return settings.providers.pi.binaryPath;
+          case "omp":
+            return settings.providers.omp.binaryPath;
         }
       };
 
@@ -2393,6 +2481,14 @@ export function makeProviderHealthLive(options?: { readonly providerUpdateTimeou
                   checkPiProviderStatus(
                     settings.providers.pi.agentDir,
                     settings.providers.pi.binaryPath,
+                  ),
+                ),
+                checkProviderWhenEnabled(
+                  settings,
+                  OMP_PROVIDER,
+                  checkOmpProviderStatus(
+                    settings.providers.omp.agentDir,
+                    settings.providers.omp.binaryPath,
                   ),
                 ),
               ],

--- a/apps/server/src/provider/Services/OmpAdapter.ts
+++ b/apps/server/src/provider/Services/OmpAdapter.ts
@@ -1,0 +1,17 @@
+/**
+ * OmpAdapter - Oh My Pi (OMP) ACP implementation of the generic provider contract.
+ *
+ * @module OmpAdapter
+ */
+import { ServiceMap } from "effect";
+
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
+
+export interface OmpAdapterShape extends ProviderAdapterShape<ProviderAdapterError> {
+  readonly provider: "omp";
+}
+
+export class OmpAdapter extends ServiceMap.Service<OmpAdapter, OmpAdapterShape>()(
+  "synara/provider/Services/OmpAdapter",
+) {}

--- a/apps/server/src/provider/acp/AcpConfigOptions.ts
+++ b/apps/server/src/provider/acp/AcpConfigOptions.ts
@@ -1,0 +1,65 @@
+/**
+ * Provider-neutral ACP session-config interpretation, shared by the Droid and
+ * OMP ACP support modules.
+ *
+ * @module AcpConfigOptions
+ */
+import { type ProviderModelDescriptor } from "@synara/contracts";
+import type * as Acp from "@agentclientprotocol/sdk";
+
+export function availableAuthMethodIds(
+  initializeResult: Acp.InitializeResponse,
+): ReadonlySet<string> {
+  return new Set((initializeResult.authMethods ?? []).map((method) => method.id.trim()));
+}
+
+export function flattenConfigOptions(
+  options: Acp.SessionConfigSelectOptions,
+): ReadonlyArray<Acp.SessionConfigSelectOption> {
+  return options.flatMap((entry) => ("options" in entry ? entry.options : [entry]));
+}
+
+export function findSelectConfig(
+  options: ReadonlyArray<Acp.SessionConfigOption>,
+  input: { readonly id: string; readonly category: string },
+): Extract<Acp.SessionConfigOption, { readonly type: "select" }> | undefined {
+  return options.find(
+    (option): option is Extract<Acp.SessionConfigOption, { readonly type: "select" }> =>
+      option.type === "select" && (option.id === input.id || option.category === input.category),
+  );
+}
+
+export function buildAcpModelDescriptor(
+  model: Acp.SessionConfigSelectOption,
+  levelOption: Extract<Acp.SessionConfigOption, { readonly type: "select" }> | undefined,
+): ProviderModelDescriptor {
+  const efforts = levelOption ? flattenConfigOptions(levelOption.options) : [];
+  const optionDescriptors = levelOption
+    ? [
+        {
+          id: "reasoningEffort",
+          label: levelOption.name,
+          type: "select" as const,
+          options: efforts.map((effort) => ({
+            id: effort.value,
+            label: effort.name,
+            ...(effort.description ? { description: effort.description } : {}),
+          })),
+          ...(levelOption.currentValue ? { currentValue: levelOption.currentValue } : {}),
+        },
+      ]
+    : undefined;
+  return {
+    slug: model.value,
+    name: model.name,
+    ...(model.description ? { description: model.description } : {}),
+    supportedReasoningEfforts: efforts.map((effort) => ({
+      value: effort.value,
+      label: effort.name,
+      ...(effort.description ? { description: effort.description } : {}),
+    })),
+    ...(optionDescriptors ? { optionDescriptors } : {}),
+    supportsFastMode: false,
+    supportsThinkingToggle: false,
+  };
+}

--- a/apps/server/src/provider/acp/DroidAcpSupport.ts
+++ b/apps/server/src/provider/acp/DroidAcpSupport.ts
@@ -24,6 +24,12 @@ import {
   type AcpSessionRuntimeShape,
   type AcpSpawnInput,
 } from "./AcpSessionRuntime.ts";
+import {
+  availableAuthMethodIds,
+  buildAcpModelDescriptor,
+  findSelectConfig,
+  flattenConfigOptions,
+} from "./AcpConfigOptions.ts";
 
 export interface DroidAcpRuntimeSettings {
   readonly appendSystemPrompt?: string;
@@ -126,10 +132,6 @@ export function buildDroidAcpSpawnInput(
   };
 }
 
-function availableAuthMethodIds(initializeResult: Acp.InitializeResponse): ReadonlySet<string> {
-  return new Set((initializeResult.authMethods ?? []).map((method) => method.id.trim()));
-}
-
 export const resolveDroidAcpAuthMethodId = (
   initializeResult: Acp.InitializeResponse,
 ): Effect.Effect<string, AcpErrors.AcpError> =>
@@ -224,57 +226,6 @@ export function applyDroidAcpInteractionMode<E>(input: {
   );
 }
 
-export function flattenDroidConfigOptions(
-  options: Acp.SessionConfigSelectOptions,
-): ReadonlyArray<Acp.SessionConfigSelectOption> {
-  return options.flatMap((entry) => ("options" in entry ? entry.options : [entry]));
-}
-
-function findDroidSelectConfig(
-  options: ReadonlyArray<Acp.SessionConfigOption>,
-  input: { readonly id: string; readonly category: string },
-): Extract<Acp.SessionConfigOption, { readonly type: "select" }> | undefined {
-  return options.find(
-    (option): option is Extract<Acp.SessionConfigOption, { readonly type: "select" }> =>
-      option.type === "select" && (option.id === input.id || option.category === input.category),
-  );
-}
-
-function droidModelDescriptor(
-  model: Acp.SessionConfigSelectOption,
-  reasoning: Extract<Acp.SessionConfigOption, { readonly type: "select" }> | undefined,
-): ProviderModelDescriptor {
-  const efforts = reasoning ? flattenDroidConfigOptions(reasoning.options) : [];
-  const optionDescriptors = reasoning
-    ? [
-        {
-          id: "reasoningEffort",
-          label: reasoning.name,
-          type: "select" as const,
-          options: efforts.map((effort) => ({
-            id: effort.value,
-            label: effort.name,
-            ...(effort.description ? { description: effort.description } : {}),
-          })),
-          ...(reasoning.currentValue ? { currentValue: reasoning.currentValue } : {}),
-        },
-      ]
-    : undefined;
-  return {
-    slug: model.value,
-    name: model.name,
-    ...(model.description ? { description: model.description } : {}),
-    supportedReasoningEfforts: efforts.map((effort) => ({
-      value: effort.value,
-      label: effort.name,
-      ...(effort.description ? { description: effort.description } : {}),
-    })),
-    ...(optionDescriptors ? { optionDescriptors } : {}),
-    supportsFastMode: false,
-    supportsThinkingToggle: false,
-  };
-}
-
 /**
  * Reads the model catalog from ACP and reselects each model so Droid returns that
  * model's current reasoning choices. Discovery runs in a disposable session.
@@ -284,7 +235,7 @@ export function discoverDroidAcpModels(
 ): Effect.Effect<ProviderListModelsResult, AcpErrors.AcpError> {
   return Effect.gen(function* () {
     const initialOptions = yield* runtime.getConfigOptions;
-    const modelConfig = findDroidSelectConfig(initialOptions, {
+    const modelConfig = findSelectConfig(initialOptions, {
       id: DROID_MODEL_CONFIG_ID,
       category: "model",
     });
@@ -296,27 +247,27 @@ export function discoverDroidAcpModels(
     }
 
     const originalModel = modelConfig.currentValue;
-    const originalReasoning = findDroidSelectConfig(initialOptions, {
+    const originalReasoning = findSelectConfig(initialOptions, {
       id: DROID_REASONING_EFFORT_CONFIG_ID,
       category: "thought_level",
     })?.currentValue;
-    const models = flattenDroidConfigOptions(modelConfig.options);
+    const models = flattenConfigOptions(modelConfig.options);
     const descriptors = yield* Effect.forEach(
       models,
       (model) =>
         runtime.setConfigOption(modelConfig.id, model.value).pipe(
           Effect.andThen(runtime.getConfigOptions),
           Effect.map((updatedOptions) =>
-            droidModelDescriptor(
+            buildAcpModelDescriptor(
               model,
-              findDroidSelectConfig(updatedOptions, {
+              findSelectConfig(updatedOptions, {
                 id: DROID_REASONING_EFFORT_CONFIG_ID,
                 category: "thought_level",
               }),
             ),
           ),
           // A newly announced model should remain selectable even if its option probe fails.
-          Effect.catch(() => Effect.succeed(droidModelDescriptor(model, undefined))),
+          Effect.catch(() => Effect.succeed(buildAcpModelDescriptor(model, undefined))),
         ),
       { concurrency: 1 },
     );

--- a/apps/server/src/provider/acp/OmpAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/OmpAcpSupport.test.ts
@@ -1,0 +1,363 @@
+// FILE: OmpAcpSupport.test.ts
+// Purpose: Verifies OMP ACP spawn, auth, mode, model, and discovery behavior.
+// Layer: Provider ACP support tests
+
+import { Effect } from "effect";
+import * as AcpErrors from "./AcpErrors.ts";
+import type * as Acp from "@agentclientprotocol/sdk";
+import { describe, expect, it } from "vitest";
+
+import {
+  applyOmpAcpInteractionMode,
+  applyOmpAcpModelSelection,
+  buildOmpAcpSpawnInput,
+  parseOmpCliModelList,
+  resolveOmpAcpAuthMethodId,
+  resolveOmpCliBinaryPath,
+} from "./OmpAcpSupport.ts";
+
+function initializeWithAuthMethods(ids: ReadonlyArray<string>): Acp.InitializeResponse {
+  return {
+    protocolVersion: 1,
+    authMethods: ids.map((id) => ({ id, name: id })),
+  };
+}
+
+describe("resolveOmpCliBinaryPath", () => {
+  it("honors a configured binary path", () => {
+    expect(resolveOmpCliBinaryPath("/opt/homebrew/bin/omp")).toBe("/opt/homebrew/bin/omp");
+  });
+
+  it("resolves to the omp name when nothing is configured", () => {
+    // Either a PATH-resolved absolute path or the bare "omp" name; both end in omp.
+    expect(resolveOmpCliBinaryPath("")).toMatch(/omp$/);
+  });
+});
+
+describe("buildOmpAcpSpawnInput", () => {
+  it("builds the default OMP ACP command", () => {
+    const spawn = buildOmpAcpSpawnInput(undefined, "/tmp/project");
+    expect(spawn.args).toEqual(["acp"]);
+    expect(spawn.cwd).toBe("/tmp/project");
+    expect(spawn.command.length).toBeGreaterThan(0);
+    expect(spawn.env).toBeDefined();
+  });
+
+  it("honors a configured binary path without adding model flags", () => {
+    // omp reads model/thinking from session config options, never CLI flags.
+    const spawn = buildOmpAcpSpawnInput({ binaryPath: "/usr/local/bin/omp" }, "/tmp/project");
+    expect(spawn.command).toBe("/usr/local/bin/omp");
+    expect(spawn.args).toEqual(["acp"]);
+    expect(spawn.cwd).toBe("/tmp/project");
+    expect(spawn.env).toBeDefined();
+  });
+});
+
+describe("applyOmpAcpModelSelection", () => {
+  function recordingRuntime(failFor?: string) {
+    const calls: Array<{ configId: string; value: string | boolean }> = [];
+    return {
+      calls,
+      runtime: {
+        setConfigOption: (configId: string, value: string | boolean) => {
+          if (configId === failFor) {
+            return Effect.fail(
+              new AcpErrors.AcpRequestError({
+                code: -32602,
+                errorMessage: `Unknown config option: ${configId}`,
+              }),
+            );
+          }
+          calls.push({ configId, value });
+          return Effect.succeed({ configOptions: [] });
+        },
+      },
+    };
+  }
+
+  it("sets the model before the thinking level", async () => {
+    const { calls, runtime } = recordingRuntime();
+    await Effect.runPromise(
+      applyOmpAcpModelSelection({
+        runtime,
+        model: "anthropic/claude-sonnet-4",
+        thinkingLevel: "high",
+        mapError: ({ cause }) => cause,
+      }),
+    );
+    expect(calls).toEqual([
+      { configId: "model", value: "anthropic/claude-sonnet-4" },
+      { configId: "thinking", value: "high" },
+    ]);
+  });
+
+  it("skips the thinking RPC when no level is requested", async () => {
+    const { calls, runtime } = recordingRuntime();
+    await Effect.runPromise(
+      applyOmpAcpModelSelection({
+        runtime,
+        model: "anthropic/claude-sonnet-4",
+        mapError: ({ cause }) => cause,
+      }),
+    );
+    expect(calls).toEqual([{ configId: "model", value: "anthropic/claude-sonnet-4" }]);
+  });
+
+  it("maps set_config_option failures through mapError", async () => {
+    const { runtime } = recordingRuntime("model");
+    const error = await Effect.runPromise(
+      applyOmpAcpModelSelection({
+        runtime,
+        model: "anthropic/claude-sonnet-4",
+        mapError: ({ method }) => new Error(`failed:${method}`),
+      }).pipe(Effect.flip),
+    );
+    expect(error.message).toBe("failed:session/set_config_option");
+  });
+});
+
+describe("applyOmpAcpInteractionMode", () => {
+  function modeRuntime(advertisedModes: ReadonlyArray<string>) {
+    const calls: Array<{ configId: string; value: string | boolean }> = [];
+    const configOptions = (): ReadonlyArray<Acp.SessionConfigOption> => [
+      {
+        id: "mode",
+        name: "Mode",
+        category: "mode",
+        type: "select",
+        currentValue: "default",
+        options: advertisedModes.map((value) => ({ value, name: value })),
+      },
+    ];
+    return {
+      calls,
+      runtime: {
+        getConfigOptions: Effect.sync(configOptions),
+        setConfigOption: (configId: string, value: string | boolean) => {
+          calls.push({ configId, value });
+          return Effect.succeed({ configOptions: [] });
+        },
+      },
+    };
+  }
+
+  it("routes plan interaction mode to OMP plan when advertised", async () => {
+    const { calls, runtime } = modeRuntime(["default", "plan"]);
+    await Effect.runPromise(
+      applyOmpAcpInteractionMode({
+        runtime,
+        interactionMode: "plan",
+        mapError: ({ cause }) => cause,
+      }),
+    );
+    expect(calls).toEqual([{ configId: "mode", value: "plan" }]);
+  });
+
+  it("leaves OMP on default when plan is requested but not advertised", async () => {
+    const { calls, runtime } = modeRuntime(["default"]);
+    await Effect.runPromise(
+      applyOmpAcpInteractionMode({
+        runtime,
+        interactionMode: "plan",
+        mapError: ({ cause }) => cause,
+      }),
+    );
+    expect(calls).toEqual([]);
+  });
+
+  it("passes the default interaction mode through as default", async () => {
+    const { calls, runtime } = modeRuntime(["default", "plan"]);
+    await Effect.runPromise(
+      applyOmpAcpInteractionMode({
+        runtime,
+        interactionMode: "default",
+        runtimeMode: "full-access",
+        mapError: ({ cause }) => cause,
+      }),
+    );
+    expect(calls).toEqual([{ configId: "mode", value: "default" }]);
+  });
+
+  it("leaves OMP as-is when no mode option is advertised", async () => {
+    const calls: Array<{ configId: string; value: string | boolean }> = [];
+    const runtime = {
+      getConfigOptions: Effect.sync(
+        (): ReadonlyArray<Acp.SessionConfigOption> => [
+          {
+            id: "model",
+            name: "Model",
+            category: "model",
+            type: "select",
+            currentValue: "",
+            options: [{ value: "anthropic/claude-sonnet-4", name: "Claude Sonnet 4" }],
+          },
+        ],
+      ),
+      setConfigOption: (configId: string, value: string | boolean) => {
+        calls.push({ configId, value });
+        return Effect.succeed({ configOptions: [] });
+      },
+    };
+
+    await Effect.runPromise(
+      applyOmpAcpInteractionMode({
+        runtime,
+        interactionMode: "plan",
+        mapError: ({ cause }) => cause,
+      }),
+    );
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("parseOmpCliModelList", () => {
+  it("reads each model with per-model thinking efforts from the omp catalog", () => {
+    const stdout = JSON.stringify({
+      models: [
+        {
+          provider: "alibaba-token-plan",
+          id: "glm-5.2",
+          selector: "alibaba-token-plan/glm-5.2",
+          name: "GLM-5.2",
+          contextWindow: 1000000,
+          maxTokens: 131072,
+          reasoning: true,
+          thinking: ["minimal", "low", "medium", "high", "max"],
+          input: ["text"],
+        },
+        {
+          provider: "commandcode",
+          id: "MiniMaxAI/MiniMax-M2.5",
+          selector: "commandcode/MiniMaxAI/MiniMax-M2.5",
+          name: "MiniMax M2.5",
+          reasoning: false,
+          thinking: null,
+        },
+      ],
+    });
+    const models = parseOmpCliModelList(stdout);
+    expect(models).toHaveLength(2);
+    expect(models).toEqual([
+      expect.objectContaining({
+        slug: "alibaba-token-plan/glm-5.2",
+        name: "GLM-5.2",
+        upstreamProviderId: "alibaba-token-plan",
+        supportedReasoningEfforts: [
+          { value: "minimal", label: "Minimal" },
+          { value: "low", label: "Low" },
+          { value: "medium", label: "Medium" },
+          { value: "high", label: "High" },
+          { value: "max", label: "Max" },
+        ],
+      }),
+      expect.objectContaining({
+        slug: "commandcode/MiniMaxAI/MiniMax-M2.5",
+        name: "MiniMax M2.5",
+        upstreamProviderId: "commandcode",
+      }),
+    ]);
+    // A non-reasoning model (thinking: null) advertises no efforts.
+    expect(models[1]).not.toHaveProperty("supportedReasoningEfforts");
+  });
+
+  it("dedupes models that share a selector", () => {
+    const stdout = JSON.stringify({
+      models: [
+        { provider: "p", selector: "p/a", name: "A", thinking: ["high"] },
+        { provider: "p", selector: "p/a", name: "A duplicate", thinking: ["high"] },
+        { provider: "p", selector: "p/b", name: "B", thinking: null },
+      ],
+    });
+    const models = parseOmpCliModelList(stdout);
+    expect(models.map((m) => m.slug)).toEqual(["p/a", "p/b"]);
+  });
+
+  it("skips entries missing a selector or name and omits provider when absent", () => {
+    const stdout = JSON.stringify({
+      models: [
+        { provider: "p", selector: "p/ok", name: "OK" },
+        { provider: "p", selector: "", name: "No Selector" },
+        { provider: "p", selector: "p/no-name", name: "" },
+        { provider: "p", name: "No Selector Field" },
+        { selector: "p/no-provider", name: "No Provider" },
+      ],
+    });
+    const models = parseOmpCliModelList(stdout);
+    expect(models.map((m) => m.slug)).toEqual(["p/ok", "p/no-provider"]);
+    expect(models[1]).not.toHaveProperty("upstreamProviderId");
+  });
+
+  it("returns an empty list for malformed JSON", () => {
+    expect(parseOmpCliModelList("not json")).toEqual([]);
+  });
+
+  it("returns an empty list when no models are present", () => {
+    expect(parseOmpCliModelList(JSON.stringify({ models: [] }))).toEqual([]);
+    expect(parseOmpCliModelList(JSON.stringify({}))).toEqual([]);
+  });
+
+  it("also accepts a bare models array as the top-level value", () => {
+    const stdout = JSON.stringify([
+      { provider: "p", selector: "p/x", name: "X", thinking: ["low", "xhigh"] },
+    ]);
+    const models = parseOmpCliModelList(stdout);
+    expect(models).toEqual([
+      expect.objectContaining({
+        slug: "p/x",
+        name: "X",
+        supportedReasoningEfforts: [
+          { value: "low", label: "Low" },
+          { value: "xhigh", label: "XHigh" },
+        ],
+      }),
+    ]);
+  });
+
+  it("canonicalizes thinking efforts: trims, lowercases, and drops unknown levels and duplicates", () => {
+    const stdout = JSON.stringify({
+      models: [
+        {
+          provider: "p",
+          selector: "p/a",
+          name: "A",
+          thinking: ["High", "high", "turbo", "  MAX  ", "ultra"],
+        },
+      ],
+    });
+    const models = parseOmpCliModelList(stdout);
+    expect(models).toEqual([
+      expect.objectContaining({
+        slug: "p/a",
+        name: "A",
+        supportedReasoningEfforts: [
+          { value: "high", label: "High" },
+          { value: "max", label: "Max" },
+        ],
+      }),
+    ]);
+  });
+
+  it("advertises no efforts when every thinking value is outside the omp contract", () => {
+    const stdout = JSON.stringify({
+      models: [{ provider: "p", selector: "p/a", name: "A", thinking: ["turbo", "ultra"] }],
+    });
+    const models = parseOmpCliModelList(stdout);
+    expect(models[0]).not.toHaveProperty("supportedReasoningEfforts");
+  });
+});
+
+describe("resolveOmpAcpAuthMethodId", () => {
+  it("selects the agent auth method backed by local ~/.omp credentials", async () => {
+    const id = await Effect.runPromise(
+      resolveOmpAcpAuthMethodId(initializeWithAuthMethods(["agent"])),
+    );
+    expect(id).toBe("agent");
+  });
+
+  it("fails when the agent auth method is unavailable", async () => {
+    const error = await Effect.runPromise(
+      resolveOmpAcpAuthMethodId(initializeWithAuthMethods([])).pipe(Effect.flip),
+    );
+    expect(error).toBeInstanceOf(AcpErrors.AcpRequestError);
+  });
+});

--- a/apps/server/src/provider/acp/OmpAcpSupport.ts
+++ b/apps/server/src/provider/acp/OmpAcpSupport.ts
@@ -1,0 +1,294 @@
+/**
+ * OMP ACP support - builds the Oh My Pi `omp acp` command and resolves auth.
+ *
+ * @module OmpAcpSupport
+ */
+import { existsSync } from "node:fs";
+import * as nodePath from "node:path";
+
+import { type ProviderModelDescriptor, OMP_THINKING_LEVEL_OPTIONS } from "@synara/contracts";
+import { Effect, Layer, Scope, ServiceMap } from "effect";
+import * as AcpErrors from "./AcpErrors.ts";
+import type * as Acp from "@agentclientprotocol/sdk";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import { buildProviderChildEnvironment } from "../../providerChildEnvironment.ts";
+import {
+  AcpSessionRuntime,
+  type AcpSessionRuntimeOptions,
+  type AcpSessionRuntimeShape,
+  type AcpSpawnInput,
+} from "./AcpSessionRuntime.ts";
+import {
+  availableAuthMethodIds,
+  findSelectConfig,
+  flattenConfigOptions,
+} from "./AcpConfigOptions.ts";
+
+export interface OmpAcpRuntimeSettings {
+  readonly binaryPath?: string;
+}
+
+export interface OmpAcpRuntimeInput extends Omit<
+  AcpSessionRuntimeOptions,
+  "authMethodId" | "resolveAuthMethodId" | "spawn"
+> {
+  readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
+  readonly ompSettings: OmpAcpRuntimeSettings | null | undefined;
+}
+
+export interface OmpAcpModelSelectionErrorContext {
+  readonly cause: AcpErrors.AcpError;
+  readonly method: "session/set_config_option";
+}
+
+export interface OmpAcpModeSelectionErrorContext {
+  readonly cause: AcpErrors.AcpError;
+  readonly method: "session/set_config_option";
+}
+
+const OMP_MODEL_CONFIG_ID = "model";
+const OMP_THINKING_CONFIG_ID = "thinking";
+const OMP_MODE_CONFIG_ID = "mode";
+const OMP_DEFAULT_MODE_ID = "default";
+const OMP_PLAN_MODE_ID = "plan";
+
+const OMP_AGENT_AUTH_METHOD_ID = "agent";
+
+/** Honors a configured binary path first, then resolves `omp` from PATH. */
+export function resolveOmpCliBinaryPath(binaryPath?: string | null): string {
+  const configured = binaryPath?.trim();
+  if (configured) {
+    return configured;
+  }
+  const name = "omp";
+  const searchPath = process.env.PATH ?? "";
+  for (const directory of searchPath.split(nodePath.delimiter)) {
+    if (!directory.trim()) {
+      continue;
+    }
+    const candidate = nodePath.join(directory, name);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return name;
+}
+
+export function buildOmpAcpSpawnInput(
+  ompSettings: OmpAcpRuntimeSettings | null | undefined,
+  cwd: string,
+): AcpSpawnInput {
+  return {
+    command: resolveOmpCliBinaryPath(ompSettings?.binaryPath),
+    args: ["acp"],
+    cwd,
+    env: buildProviderChildEnvironment({ provider: "omp" }),
+  };
+}
+
+export const resolveOmpAcpAuthMethodId = (
+  initializeResult: Acp.InitializeResponse,
+): Effect.Effect<string, AcpErrors.AcpError> =>
+  Effect.gen(function* () {
+    const authMethodIds = availableAuthMethodIds(initializeResult);
+    if (authMethodIds.has(OMP_AGENT_AUTH_METHOD_ID)) {
+      return OMP_AGENT_AUTH_METHOD_ID;
+    }
+    return yield* new AcpErrors.AcpRequestError({
+      code: -32602,
+      errorMessage: "OMP ACP authentication is unavailable.",
+      data: {
+        authMethods: [...authMethodIds],
+        detail: "Run `omp` to authenticate locally so ~/.omp credentials exist.",
+      },
+    });
+  });
+
+export const makeOmpAcpRuntime = (
+  input: OmpAcpRuntimeInput,
+): Effect.Effect<AcpSessionRuntimeShape, AcpErrors.AcpError, Scope.Scope> =>
+  Effect.gen(function* () {
+    const acpContext = yield* Layer.build(
+      AcpSessionRuntime.layer({
+        ...input,
+        spawn: buildOmpAcpSpawnInput(input.ompSettings, input.cwd),
+        resolveAuthMethodId: resolveOmpAcpAuthMethodId,
+        authenticateMeta: { headless: true },
+      }).pipe(
+        Layer.provide(
+          Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, input.childProcessSpawner),
+        ),
+      ),
+    );
+    return ServiceMap.getUnsafe(acpContext, AcpSessionRuntime);
+  });
+
+/**
+ * Applies the requested model and thinking level over ACP. `omp acp` reads its
+ * model and thinking from session config options (not CLI flags), so
+ * `session/set_config_option` is the only mechanism that switches them. The
+ * model is applied first because it determines which thinking levels are valid.
+ * The shared runtime validates values against the advertised options and skips
+ * the RPC when the current value already matches.
+ */
+export function applyOmpAcpModelSelection<E>(input: {
+  readonly runtime: Pick<AcpSessionRuntimeShape, "setConfigOption">;
+  readonly model: string;
+  readonly thinkingLevel?: string | null | undefined;
+  readonly mapError: (context: OmpAcpModelSelectionErrorContext) => E;
+}): Effect.Effect<void, E> {
+  return Effect.gen(function* () {
+    const mapError = (cause: AcpErrors.AcpError) =>
+      input.mapError({ cause, method: "session/set_config_option" });
+    const model = input.model.trim();
+    if (model) {
+      yield* input.runtime
+        .setConfigOption(OMP_MODEL_CONFIG_ID, model)
+        .pipe(Effect.mapError(mapError));
+    }
+    const thinkingLevel = input.thinkingLevel?.trim();
+    if (thinkingLevel) {
+      yield* input.runtime
+        .setConfigOption(OMP_THINKING_CONFIG_ID, thinkingLevel)
+        .pipe(Effect.mapError(mapError));
+    }
+  });
+}
+
+/**
+ * Applies OMP's native mode config option before a prompt is dispatched. OMP
+ * advertises a `mode` select option (category "mode") with `default` always
+ * present and `plan` only when plan mode is enabled. Synara's `plan`
+ * interaction mode routes to OMP `"plan"`; everything else passes through as
+ * `default`. If the requested mode is not advertised (e.g. plan disabled), or
+ * OMP did not advertise a mode option, OMP is left on its current (default) mode.
+ */
+export function applyOmpAcpInteractionMode<E>(input: {
+  readonly runtime: Pick<AcpSessionRuntimeShape, "getConfigOptions" | "setConfigOption">;
+  readonly interactionMode?: "default" | "plan";
+  readonly runtimeMode?: "approval-required" | "full-access";
+  readonly mapError: (context: OmpAcpModeSelectionErrorContext) => E;
+}): Effect.Effect<void, E> {
+  const requestedModeId = input.interactionMode === "plan" ? OMP_PLAN_MODE_ID : OMP_DEFAULT_MODE_ID;
+  return Effect.gen(function* () {
+    const mapError = (cause: AcpErrors.AcpError) =>
+      input.mapError({ cause, method: "session/set_config_option" });
+    const options = yield* input.runtime.getConfigOptions;
+    const modeConfig = findSelectConfig(options, {
+      id: OMP_MODE_CONFIG_ID,
+      category: "mode",
+    });
+    // Unknown/unavailable requested mode, or no mode option advertised → leave OMP as-is.
+    if (!modeConfig) {
+      return;
+    }
+    const advertisedValues = new Set(
+      flattenConfigOptions(modeConfig.options).map((choice) => choice.value),
+    );
+    if (!advertisedValues.has(requestedModeId)) {
+      return;
+    }
+    yield* input.runtime
+      .setConfigOption(modeConfig.id, requestedModeId)
+      .pipe(Effect.mapError(mapError));
+  });
+}
+
+/**
+ * Parses the multi-provider model catalog emitted by `omp models --json`.
+ *
+ * OMP aggregates many upstream providers (alibaba, cursor, google, xai, …) and
+ * `omp models --json` returns every model in a single subprocess call, each with
+ * its own `thinking` effort list inline. Discovery is therefore O(1) round-trips
+ * and scales to OMP's full catalog. The in-band ACP model option exposes only
+ * slug/name; reading per-model thinking that way needs one
+ * `session/set_config_option` round-trip per model, which is unscalable for the
+ * 300+ model catalogs OMP routinely serves.
+ */
+const OMP_THINKING_LABELS: Readonly<Record<string, string>> = {
+  off: "Off",
+  auto: "Auto",
+  minimal: "Minimal",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  max: "Max",
+  xhigh: "XHigh",
+};
+
+const ompThinkingLabel = (value: string): string =>
+  OMP_THINKING_LABELS[value] ?? value.charAt(0).toUpperCase() + value.slice(1);
+const OMP_THINKING_LEVEL_SET: ReadonlySet<string> = new Set(OMP_THINKING_LEVEL_OPTIONS);
+
+function isStringRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readStringField(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  return typeof value === "string" ? value : "";
+}
+
+function readStringArrayField(record: Record<string, unknown>, key: string): ReadonlyArray<string> {
+  const value = record[key];
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string" && item.trim() !== "")
+    : [];
+}
+
+export function parseOmpCliModelList(stdout: string): ReadonlyArray<ProviderModelDescriptor> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return [];
+  }
+  let rawModels: ReadonlyArray<unknown>;
+  if (Array.isArray(parsed)) {
+    rawModels = parsed;
+  } else if (isStringRecord(parsed) && "models" in parsed && Array.isArray(parsed.models)) {
+    rawModels = parsed.models;
+  } else {
+    rawModels = [];
+  }
+  const seen = new Set<string>();
+  const models: ProviderModelDescriptor[] = [];
+  for (const entry of rawModels) {
+    if (!isStringRecord(entry)) {
+      continue;
+    }
+    const slug = readStringField(entry, "selector").trim();
+    const name = readStringField(entry, "name").trim();
+    if (!slug || !name || seen.has(slug)) {
+      continue;
+    }
+    seen.add(slug);
+    const upstreamProviderId = readStringField(entry, "provider").trim();
+    const thinking = readStringArrayField(entry, "thinking");
+    const seenEfforts = new Set<string>();
+    const efforts = thinking
+      .map((value) => value.trim().toLowerCase())
+      .filter((value): value is string => {
+        if (seenEfforts.has(value) || !OMP_THINKING_LEVEL_SET.has(value)) {
+          return false;
+        }
+        seenEfforts.add(value);
+        return true;
+      });
+    models.push({
+      slug,
+      name,
+      ...(upstreamProviderId ? { upstreamProviderId } : {}),
+      ...(efforts.length > 0
+        ? {
+            supportedReasoningEfforts: efforts.map((value) => ({
+              value,
+              label: ompThinkingLabel(value),
+            })),
+          }
+        : {}),
+    });
+  }
+  return models;
+}

--- a/apps/server/src/provider/acp/SessionTeardownGate.test.ts
+++ b/apps/server/src/provider/acp/SessionTeardownGate.test.ts
@@ -2,13 +2,13 @@ import { ThreadId } from "@synara/contracts";
 import { Deferred, Effect, Fiber } from "effect";
 import { describe, expect, it } from "vitest";
 
-import { makeDroidSessionTeardownGate } from "./DroidSessionTeardownGate.ts";
+import { makeSessionTeardownGate } from "./SessionTeardownGate.ts";
 
-describe("DroidSessionTeardownGate", () => {
+describe("SessionTeardownGate", () => {
   it("blocks replacement work until the tracked teardown completes", async () => {
     await Effect.runPromise(
       Effect.gen(function* () {
-        const gate = makeDroidSessionTeardownGate();
+        const gate = makeSessionTeardownGate();
         const threadId = ThreadId.makeUnsafe("thread-1");
         const completion = yield* Deferred.make<void>();
         let replacementStarted = false;
@@ -37,7 +37,7 @@ describe("DroidSessionTeardownGate", () => {
   it("does not let stale cleanup clear a newer teardown gate", async () => {
     await Effect.runPromise(
       Effect.gen(function* () {
-        const gate = makeDroidSessionTeardownGate();
+        const gate = makeSessionTeardownGate();
         const threadId = ThreadId.makeUnsafe("thread-1");
         const oldCompletion = yield* Deferred.make<void>();
         const newCompletion = yield* Deferred.make<void>();

--- a/apps/server/src/provider/acp/SessionTeardownGate.ts
+++ b/apps/server/src/provider/acp/SessionTeardownGate.ts
@@ -1,11 +1,11 @@
-// FILE: DroidSessionTeardownGate.ts
-// Purpose: Prevents a replacement Droid ACP runtime from starting before its predecessor exits.
+// FILE: SessionTeardownGate.ts
+// Purpose: Prevents a replacement ACP runtime from starting before its predecessor exits.
 // Layer: Provider ACP lifecycle coordination
 
 import type { ThreadId } from "@synara/contracts";
 import { Deferred, Effect } from "effect";
 
-export interface DroidSessionTeardownGate {
+export interface SessionTeardownGate {
   readonly track: (threadId: ThreadId, completion: Deferred.Deferred<void>) => void;
   readonly isPending: (threadId: ThreadId) => boolean;
   readonly awaitPending: (threadId: ThreadId) => Effect.Effect<void>;
@@ -15,7 +15,7 @@ export interface DroidSessionTeardownGate {
   ) => Effect.Effect<void>;
 }
 
-export function makeDroidSessionTeardownGate(): DroidSessionTeardownGate {
+export function makeSessionTeardownGate(): SessionTeardownGate {
   const pendingByThreadId = new Map<ThreadId, Deferred.Deferred<void>>();
 
   return {

--- a/apps/server/src/provider/acp/TurnCancellation.test.ts
+++ b/apps/server/src/provider/acp/TurnCancellation.test.ts
@@ -1,15 +1,15 @@
 import { Deferred, Effect, Fiber } from "effect";
 import { describe, expect, it } from "vitest";
 
-import { cancelDroidTurnAndWait } from "./DroidTurnCancellation.ts";
+import { cancelTurnAndWait } from "./TurnCancellation.ts";
 
-describe("cancelDroidTurnAndWait", () => {
-  it("keeps the prompt fiber alive until Droid settles it", async () => {
+describe("cancelTurnAndWait", () => {
+  it("keeps the prompt fiber alive until the provider settles it", async () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const promptComplete = yield* Deferred.make<void>();
         const promptFiber = yield* Deferred.await(promptComplete).pipe(Effect.forkChild);
-        const cancellationFiber = yield* cancelDroidTurnAndWait({
+        const cancellationFiber = yield* cancelTurnAndWait({
           cancel: Effect.void,
           promptFiber,
           graceMs: 5_000,
@@ -31,7 +31,7 @@ describe("cancelDroidTurnAndWait", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const promptFiber = yield* Effect.never.pipe(Effect.forkChild);
-        const result = yield* cancelDroidTurnAndWait({
+        const result = yield* cancelTurnAndWait({
           cancel: Effect.void,
           promptFiber,
           graceMs: 10,

--- a/apps/server/src/provider/acp/TurnCancellation.ts
+++ b/apps/server/src/provider/acp/TurnCancellation.ts
@@ -1,20 +1,20 @@
-// FILE: DroidTurnCancellation.ts
+// FILE: TurnCancellation.ts
 // Purpose: Sends ACP turn cancellation, waits for the prompt response, then escalates if needed.
 // Layer: Provider ACP lifecycle coordination
 
 import { Cause, Effect, Exit, Fiber, Option } from "effect";
 
-export interface DroidTurnCancellationResult {
+export interface TurnCancellationResult {
   readonly cancelRequest: "sent" | "failed" | "timedOut";
   readonly cancelFailure?: string;
   readonly prompt: "notStarted" | "settled" | "timedOut";
 }
 
-export function cancelDroidTurnAndWait(input: {
+export function cancelTurnAndWait(input: {
   readonly cancel: Effect.Effect<void, unknown>;
   readonly promptFiber: Fiber.Fiber<void, never> | undefined;
   readonly graceMs: number;
-}): Effect.Effect<DroidTurnCancellationResult> {
+}): Effect.Effect<TurnCancellationResult> {
   return Effect.gen(function* () {
     const cancelExit = yield* input.cancel.pipe(Effect.timeoutOption(input.graceMs), Effect.exit);
     const cancelRequest = Exit.isFailure(cancelExit)

--- a/apps/server/src/provider/providerStatusCache.ts
+++ b/apps/server/src/provider/providerStatusCache.ts
@@ -20,6 +20,7 @@ const PROVIDER_STATUS_CACHE_IDS = [
   "kilo",
   "opencode",
   "pi",
+  "omp",
 ] as const satisfies ReadonlyArray<ServerProviderStatus["provider"]>;
 
 const decodeProviderStatusCache = Schema.decodeUnknownEffect(

--- a/apps/server/src/provider/runtimeLayer.ts
+++ b/apps/server/src/provider/runtimeLayer.ts
@@ -17,6 +17,7 @@ import { makeDroidAdapterLive } from "./Layers/DroidAdapter";
 import { makeGrokAdapterLive } from "./Layers/GrokAdapter";
 import { makeKiloAdapterLive, makeOpenCodeAdapterLive } from "./Layers/OpenCodeAdapter";
 import { makePiAdapterLive } from "./Layers/PiAdapter";
+import { makeOmpAdapterLive } from "./Layers/OmpAdapter";
 import { ProviderAdapterRegistryLive } from "./Layers/ProviderAdapterRegistry";
 import { ProviderDiscoveryServiceLive } from "./Layers/ProviderDiscoveryService";
 import { makeDurableProviderServiceLive } from "./Layers/ProviderService";
@@ -83,6 +84,10 @@ export function makeServerProviderLayer(
     const piAdapterLayer = makePiAdapterLive(
       nativeEventLogger ? { nativeEventLogger } : undefined,
     ).pipe(Layer.provide(agentGatewayCredentialsLayer));
+    const ompAdapterLayer = makeOmpAdapterLive(
+      {},
+      nativeEventLogger ? { nativeEventLogger } : undefined,
+    ).pipe(Layer.provide(agentGatewayCredentialsLayer));
     const adapterRegistryLayer = ProviderAdapterRegistryLive.pipe(
       Layer.provide(codexAdapterLayer),
       Layer.provide(claudeAdapterLayer),
@@ -93,6 +98,7 @@ export function makeServerProviderLayer(
       Layer.provide(kiloAdapterLayer),
       Layer.provide(openCodeAdapterLayer),
       Layer.provide(piAdapterLayer),
+      Layer.provide(ompAdapterLayer),
       Layer.provideMerge(providerSessionDirectoryLayer),
     );
     const providerServiceLayer = makeDurableProviderServiceLive(

--- a/apps/server/src/provider/skillsCatalog.ts
+++ b/apps/server/src/provider/skillsCatalog.ts
@@ -329,6 +329,7 @@ const HOME_ORIGIN_ORDER = [
   "kilo",
   "opencode",
   "pi",
+  "omp",
   "agents",
 ] as const;
 export type SkillsCatalogOrigin = (typeof HOME_ORIGIN_ORDER)[number] | "project";
@@ -421,6 +422,10 @@ const SKILL_ORIGIN_ROOTS = {
     homeRoots: (input) => [nodePath.join(input.homeDir, ".pi", "agent", "skills")],
     projectRootNames: [".pi"],
   },
+  omp: {
+    homeRoots: (input) => [nodePath.join(input.homeDir, ".omp", "agent", "skills")],
+    projectRootNames: [".omp"],
+  },
   agents: {
     homeRoots: (input) => [nodePath.join(input.homeDir, ".agents", "skills")],
     projectRootNames: [".agents"],
@@ -437,6 +442,7 @@ const PROVIDER_SKILL_ORIGIN_PREFERENCES = {
   kilo: ["kilo", "agents", "claude"],
   opencode: ["opencode", "claude", "agents"],
   pi: ["pi", "agents"],
+  omp: ["omp", "agents"],
 } as const satisfies Partial<Record<ProviderKind, readonly SkillsHomeOrigin[]>>;
 
 function homeRootsForOrigin(
@@ -490,7 +496,7 @@ function rootsForOrderedOrigins(
     homeRootsForOrigin(origin, input).map((path) => ({
       path,
       scope: origin,
-      ...(origin === "pi" ? { includeMarkdownFiles: true } : {}),
+      ...(origin === "pi" || origin === "omp" ? { includeMarkdownFiles: true } : {}),
     })),
   );
   const homeRootPaths = new Set(homeRoots.map((root) => nodePath.resolve(root.path)));
@@ -517,7 +523,7 @@ function rootsForOrderedOrigins(
           projectRoots.push({
             path: rootPath,
             scope: "project",
-            ...(origin === "pi" ? { includeMarkdownFiles: true } : {}),
+            ...(origin === "pi" || origin === "omp" ? { includeMarkdownFiles: true } : {}),
           });
         }
       }

--- a/apps/server/src/providerChildEnvironment.ts
+++ b/apps/server/src/providerChildEnvironment.ts
@@ -12,7 +12,8 @@ export type ProviderChildKind =
   | "grok"
   | "kilo"
   | "opencode"
-  | "pi";
+  | "pi"
+  | "omp";
 
 const PROVIDER_CREDENTIAL_KEYS = new Set([
   "ANTHROPIC_API_KEY",
@@ -50,6 +51,7 @@ const PROVIDER_CREDENTIAL_GRANTS: Record<ProviderChildKind, "all" | ReadonlySet<
   kilo: "all",
   opencode: "all",
   pi: "all",
+  omp: "all",
 };
 
 const INHERITED_NATIVE_CAPABILITY_KEYS = new Set([

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -255,6 +255,7 @@ describe("resolveAppModelSelection", () => {
           kilo: [],
           opencode: [],
           pi: [],
+          omp: [],
         },
         "galapagos-alpha",
       ),
@@ -275,6 +276,7 @@ describe("resolveAppModelSelection", () => {
           kilo: [],
           opencode: [],
           pi: [],
+          omp: [],
         },
         "",
       ),
@@ -295,6 +297,7 @@ describe("resolveAppModelSelection", () => {
           kilo: [],
           opencode: [],
           pi: [],
+          omp: [],
         },
         "GPT-5.3 Codex",
       ),
@@ -315,6 +318,7 @@ describe("resolveAppModelSelection", () => {
           kilo: [],
           opencode: [],
           pi: [],
+          omp: [],
         },
         "sonnet",
       ),
@@ -335,6 +339,7 @@ describe("resolveAppModelSelection", () => {
           kilo: [],
           opencode: [],
           pi: [],
+          omp: [],
         },
         "custom/selected-model",
       ),
@@ -497,6 +502,8 @@ describe("getProviderStartOptions", () => {
         openCodeServerUrl: "",
         piAgentDir: "",
         piBinaryPath: "",
+        ompBinaryPath: "",
+        ompAgentDir: "",
       }),
     ).toEqual({
       claudeAgent: {
@@ -536,6 +543,8 @@ describe("getProviderStartOptions", () => {
         openCodeServerUrl: "",
         piAgentDir: "",
         piBinaryPath: "",
+        ompBinaryPath: "",
+        ompAgentDir: "",
       }),
     ).toBeUndefined();
   });
@@ -558,6 +567,8 @@ describe("getProviderStartOptions", () => {
         openCodeServerUrl: "",
         piAgentDir: "",
         piBinaryPath: "pi",
+        ompBinaryPath: "",
+        ompAgentDir: "",
       }),
     ).toBeUndefined();
   });
@@ -574,6 +585,7 @@ describe("provider-indexed custom model settings", () => {
     customKiloModels: ["kilo/kilo-auto/free"],
     customOpenCodeModels: ["openrouter/gpt-oss-120b"],
     customPiModels: ["anthropic/custom-pi"],
+    customOmpModels: [],
   } as const;
 
   it("exports one provider config per provider", () => {
@@ -587,6 +599,7 @@ describe("provider-indexed custom model settings", () => {
       "kilo",
       "opencode",
       "pi",
+      "omp",
     ]);
   });
 
@@ -605,6 +618,7 @@ describe("provider-indexed custom model settings", () => {
     expect(getCustomModelsForProvider(settings, "kilo")).toEqual(["kilo/kilo-auto/free"]);
     expect(getCustomModelsForProvider(settings, "opencode")).toEqual(["openrouter/gpt-oss-120b"]);
     expect(getCustomModelsForProvider(settings, "pi")).toEqual(["anthropic/custom-pi"]);
+    expect(getCustomModelsForProvider(settings, "omp")).toEqual([]);
   });
 
   it("reads default custom models for each provider", () => {
@@ -618,6 +632,7 @@ describe("provider-indexed custom model settings", () => {
       customKiloModels: ["kilo/default-auto"],
       customOpenCodeModels: ["openai/gpt-5"],
       customPiModels: ["anthropic/default-pi"],
+      customOmpModels: [],
     } as const;
 
     expect(getDefaultCustomModelsForProvider(defaults, "codex")).toEqual(["default/codex-model"]);
@@ -633,6 +648,7 @@ describe("provider-indexed custom model settings", () => {
     expect(getDefaultCustomModelsForProvider(defaults, "kilo")).toEqual(["kilo/default-auto"]);
     expect(getDefaultCustomModelsForProvider(defaults, "opencode")).toEqual(["openai/gpt-5"]);
     expect(getDefaultCustomModelsForProvider(defaults, "pi")).toEqual(["anthropic/default-pi"]);
+    expect(getDefaultCustomModelsForProvider(defaults, "omp")).toEqual([]);
   });
 
   it("patches custom models for codex", () => {
@@ -700,6 +716,7 @@ describe("provider-indexed custom model settings", () => {
       kilo: ["kilo/kilo-auto/free"],
       opencode: ["openrouter/gpt-oss-120b"],
       pi: ["anthropic/custom-pi"],
+      omp: [],
     });
   });
 
@@ -757,6 +774,7 @@ describe("provider-indexed custom model settings", () => {
         "anthropic/custom-pi",
         "anthropic/custom-pi",
       ],
+      customOmpModels: [],
     });
 
     expect(

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -116,7 +116,8 @@ type CustomModelSettingsKey =
   | "customDroidModels"
   | "customKiloModels"
   | "customOpenCodeModels"
-  | "customPiModels";
+  | "customPiModels"
+  | "customOmpModels";
 export type ProviderCustomModelConfig = {
   provider: ProviderKind;
   settingsKey: CustomModelSettingsKey;
@@ -137,6 +138,7 @@ const BUILT_IN_MODEL_SLUGS_BY_PROVIDER: Record<ProviderKind, ReadonlySet<string>
   kilo: new Set(getModelOptions("kilo").map((option) => option.slug)),
   opencode: new Set(getModelOptions("opencode").map((option) => option.slug)),
   pi: new Set(getModelOptions("pi").map((option) => option.slug)),
+  omp: new Set(getModelOptions("omp").map((option) => option.slug)),
 };
 
 const withDefaults =
@@ -163,6 +165,7 @@ const PersistedProviderKind = Schema.Literals([
   "kilo",
   "opencode",
   "pi",
+  "omp",
 ]).pipe(
   Schema.decodeTo(
     ProviderKind,
@@ -198,6 +201,8 @@ export const AppSettingsSchema = Schema.Struct({
   openCodeBinaryPath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
   piBinaryPath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
   piAgentDir: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
+  ompBinaryPath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
+  ompAgentDir: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
   openCodeServerUrl: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
   openCodeServerPassword: Schema.String.check(Schema.isMaxLength(4096)).pipe(
     withDefaults(() => ""),
@@ -262,6 +267,7 @@ export const AppSettingsSchema = Schema.Struct({
   customKiloModels: Schema.Array(Schema.String).pipe(withDefaults(() => [])),
   customOpenCodeModels: Schema.Array(Schema.String).pipe(withDefaults(() => [])),
   customPiModels: Schema.Array(Schema.String).pipe(withDefaults(() => [])),
+  customOmpModels: Schema.Array(Schema.String).pipe(withDefaults(() => [])),
   textGenerationProvider: PersistedProviderKind.pipe(withDefaults(() => "codex" as const)),
   textGenerationModel: Schema.optional(TrimmedNonEmptyString),
   uiFontFamily: Schema.String.check(Schema.isMaxLength(256)).pipe(withDefaults(() => "")),
@@ -399,6 +405,15 @@ const PROVIDER_CUSTOM_MODEL_CONFIG: Record<ProviderKind, ProviderCustomModelConf
     placeholder: "provider/model",
     example: "anthropic/claude-sonnet-4-5",
   },
+  omp: {
+    provider: "omp",
+    settingsKey: "customOmpModels",
+    defaultSettingsKey: "customOmpModels",
+    title: "Oh My Pi",
+    description: "Save additional Oh My Pi model slugs for the picker and provider runtime.",
+    placeholder: "provider/model",
+    example: "anthropic/claude-sonnet-4-5",
+  },
 };
 
 export const MODEL_PROVIDER_SETTINGS = Object.values(PROVIDER_CUSTOM_MODEL_CONFIG);
@@ -531,6 +546,7 @@ function normalizeAppSettings(settings: AppSettings): AppSettings {
       settings.openCodeBinaryPath,
     ),
     piBinaryPath: normalizeProviderBinaryPathOverride("pi", settings.piBinaryPath),
+    ompBinaryPath: normalizeProviderBinaryPathOverride("omp", settings.ompBinaryPath),
     uiDensity: normalizeUiDensityValue(settings.uiDensity),
     chatFontSizePx: normalizeChatFontSizePx(settings.chatFontSizePx),
     terminalFontSizePx: normalizeTerminalFontSizePx(settings.terminalFontSizePx),
@@ -547,6 +563,7 @@ function normalizeAppSettings(settings: AppSettings): AppSettings {
     customKiloModels: normalizeCustomModelSlugs(settings.customKiloModels, "kilo"),
     customOpenCodeModels: normalizeCustomModelSlugs(settings.customOpenCodeModels, "opencode"),
     customPiModels: normalizeCustomModelSlugs(settings.customPiModels, "pi"),
+    customOmpModels: normalizeCustomModelSlugs(settings.customOmpModels, "omp"),
     hiddenProviders: normalizeHiddenProviders(settings.hiddenProviders),
     providerOrder: normalizeProviderOrder(settings.providerOrder),
     hiddenModels: [],
@@ -575,6 +592,8 @@ function serverSettingsToAppSettings(settings: ServerSettingsView): Partial<AppS
     openCodeServerUrl: settings.providers.opencode.serverUrl,
     piAgentDir: settings.providers.pi.agentDir,
     piBinaryPath: settings.providers.pi.binaryPath,
+    ompAgentDir: settings.providers.omp.agentDir,
+    ompBinaryPath: settings.providers.omp.binaryPath,
     customCodexModels: settings.providers.codex.customModels,
     customClaudeModels: settings.providers.claudeAgent.customModels,
     customCursorModels: settings.providers.cursor.customModels,
@@ -584,6 +603,7 @@ function serverSettingsToAppSettings(settings: ServerSettingsView): Partial<AppS
     customKiloModels: settings.providers.kilo.customModels,
     customOpenCodeModels: settings.providers.opencode.customModels,
     customPiModels: settings.providers.pi.customModels,
+    customOmpModels: settings.providers.omp.customModels,
     textGenerationProvider: settings.textGenerationModelSelection.provider,
     textGenerationModel: settings.textGenerationModelSelection.model,
   };
@@ -613,7 +633,8 @@ function touchesProviderDiscoverySettings(patch: Partial<AppSettings>): boolean 
     hasOwn(patch, "openCodeExperimentalWebSockets") ||
     hasOwn(patch, "openCodeServerPassword") ||
     hasOwn(patch, "openCodeServerUrl") ||
-    hasOwn(patch, "piAgentDir")
+    hasOwn(patch, "piAgentDir") ||
+    hasOwn(patch, "ompAgentDir")
   );
 }
 
@@ -750,6 +771,17 @@ function appSettingsPatchToServerSettingsPatch(patch: Partial<AppSettings>): Ser
       ...(hasOwn(patch, "customPiModels") ? { customModels: patch.customPiModels ?? [] } : {}),
     };
   }
+  if (
+    hasOwn(patch, "ompAgentDir") ||
+    hasOwn(patch, "ompBinaryPath") ||
+    hasOwn(patch, "customOmpModels")
+  ) {
+    providers.omp = {
+      ...(hasOwn(patch, "ompAgentDir") ? { agentDir: patch.ompAgentDir ?? "" } : {}),
+      ...(hasOwn(patch, "ompBinaryPath") ? { binaryPath: patch.ompBinaryPath ?? "" } : {}),
+      ...(hasOwn(patch, "customOmpModels") ? { customModels: patch.customOmpModels ?? [] } : {}),
+    };
+  }
 
   if (Object.keys(providers).length > 0) {
     serverPatch.providers = providers;
@@ -787,6 +819,8 @@ function buildInitialServerSettingsMigrationPatch(settings: AppSettings): Server
     "openCodeServerUrl",
     "piAgentDir",
     "piBinaryPath",
+    "ompAgentDir",
+    "ompBinaryPath",
     "textGenerationModel",
     "textGenerationProvider",
   ] as const) {
@@ -814,6 +848,7 @@ function buildInitialServerSettingsMigrationPatch(settings: AppSettings): Server
     "customKiloModels",
     "customOpenCodeModels",
     "customPiModels",
+    "customOmpModels",
   ] as const) {
     if (normalizedSettings[key].length > 0) {
       patch[key] = normalizedSettings[key] as never;
@@ -863,6 +898,7 @@ export function getCustomModelsByProvider(
     kilo: getCustomModelsForProvider(settings, "kilo"),
     opencode: getCustomModelsForProvider(settings, "opencode"),
     pi: getCustomModelsForProvider(settings, "pi"),
+    omp: getCustomModelsForProvider(settings, "omp"),
   };
 }
 
@@ -1011,6 +1047,7 @@ export function getCustomModelOptionsByProvider(
     kilo: getAppModelOptions("kilo", customModelsByProvider.kilo),
     opencode: getAppModelOptions("opencode", customModelsByProvider.opencode),
     pi: getAppModelOptions("pi", customModelsByProvider.pi),
+    omp: getAppModelOptions("omp", customModelsByProvider.omp),
   };
 }
 
@@ -1032,6 +1069,8 @@ export function getProviderStartOptions(
     | "openCodeServerUrl"
     | "piAgentDir"
     | "piBinaryPath"
+    | "ompAgentDir"
+    | "ompBinaryPath"
   >,
 ): ProviderStartOptions | undefined {
   const claudeBinaryPath = normalizeProviderBinaryPathOverride(
@@ -1052,6 +1091,7 @@ export function getProviderStartOptions(
     settings.openCodeBinaryPath,
   );
   const piBinaryPath = normalizeProviderBinaryPathOverride("pi", settings.piBinaryPath);
+  const ompBinaryPath = normalizeProviderBinaryPathOverride("omp", settings.ompBinaryPath);
   const hasOpenCodeStartOptions = Boolean(
     openCodeBinaryPath || settings.openCodeExperimentalWebSockets || settings.openCodeServerUrl,
   );
@@ -1125,6 +1165,14 @@ export function getProviderStartOptions(
           },
         }
       : {}),
+    ...(ompBinaryPath || settings.ompAgentDir
+      ? {
+          omp: {
+            ...(ompBinaryPath ? { binaryPath: ompBinaryPath } : {}),
+            ...(settings.ompAgentDir ? { agentDir: settings.ompAgentDir } : {}),
+          },
+        }
+      : {}),
   };
 
   return Object.keys(providerOptions).length > 0 ? providerOptions : undefined;
@@ -1170,6 +1218,7 @@ export function getCustomBinaryPathForProvider(
     | "kiloBinaryPath"
     | "openCodeBinaryPath"
     | "piBinaryPath"
+    | "ompBinaryPath"
   >,
   provider: ProviderKind,
 ): string {
@@ -1192,6 +1241,8 @@ export function getCustomBinaryPathForProvider(
       return normalizeProviderBinaryPathOverride(provider, settings.openCodeBinaryPath);
     case "pi":
       return normalizeProviderBinaryPathOverride(provider, settings.piBinaryPath);
+    case "omp":
+      return normalizeProviderBinaryPathOverride(provider, settings.ompBinaryPath);
   }
 }
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -899,6 +899,8 @@ function getProviderStartOptionsCustomBinaryPath(
       return normalizeCustomBinaryPath(providerOptions?.cursor?.binaryPath);
     case "pi":
       return normalizeCustomBinaryPath(providerOptions?.pi?.binaryPath);
+    case "omp":
+      return normalizeCustomBinaryPath(providerOptions?.omp?.binaryPath);
   }
 }
 
@@ -2186,6 +2188,7 @@ export default function ChatView({
       kilo: resolveHint("kilo"),
       opencode: resolveHint("opencode"),
       pi: resolveHint("pi"),
+      omp: resolveHint("omp"),
     };
   }, [
     activeProject?.defaultModelSelection,
@@ -2264,7 +2267,10 @@ export default function ChatView({
   const selectedPromptEffort = composerProviderState.promptEffort;
   const selectedModelOptionsForDispatch = composerProviderState.modelOptionsForDispatch;
   const selectedModelSelection = useMemo<ModelSelection>(() => {
-    if (selectedProvider === "pi" && draftModelSelectionForSelectedProvider?.provider === "pi") {
+    if (
+      (selectedProvider === "pi" || selectedProvider === "omp") &&
+      draftModelSelectionForSelectedProvider?.provider === selectedProvider
+    ) {
       return buildModelSelection(
         selectedProvider,
         draftModelSelectionForSelectedProvider.model,
@@ -2308,7 +2314,8 @@ export default function ChatView({
     selectedProvider === "droid" ||
     selectedProvider === "kilo" ||
     selectedProvider === "opencode" ||
-    selectedProvider === "pi";
+    selectedProvider === "pi" ||
+    selectedProvider === "omp";
   const showComposerModelBootstrapSkeleton = shouldShowComposerModelBootstrapSkeleton({
     selectedProvider,
     selectedModel,

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -277,6 +277,24 @@ export const PiIcon: Icon = (props) => (
   </svg>
 );
 
+export const OmpIcon: Icon = (props) => {
+  const id = useId();
+  const gradientId = `${id}-omp-logo`;
+
+  return (
+    <svg {...props} viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id={gradientId} x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stopColor="#ed4abf" />
+          <stop offset=".5" stopColor="#9b4dff" />
+          <stop offset="1" stopColor="#5ad8e6" />
+        </linearGradient>
+      </defs>
+      <path fill={`url(#${gradientId})`} d="M14 16h36v8H40v32h-8V24h-6v22h-8V24h-4z" />
+    </svg>
+  );
+};
+
 export const OpenCodeIcon: Icon = (props) => (
   <svg {...props} viewBox="0 0 32 40" fill="none" xmlns="http://www.w3.org/2000/svg">
     <g clipPath="url(#opencode__clip0_1311_94969)">

--- a/apps/web/src/components/PluginLibrary.tsx
+++ b/apps/web/src/components/PluginLibrary.tsx
@@ -395,6 +395,7 @@ export function PluginLibrary() {
   const kiloCapabilitiesQuery = useQuery(providerComposerCapabilitiesQueryOptions("kilo"));
   const openCodeCapabilitiesQuery = useQuery(providerComposerCapabilitiesQueryOptions("opencode"));
   const piCapabilitiesQuery = useQuery(providerComposerCapabilitiesQueryOptions("pi"));
+  const ompCapabilitiesQuery = useQuery(providerComposerCapabilitiesQueryOptions("omp"));
 
   const providerCapabilities: Record<ProviderKind, ProviderCapabilities> = {
     codex: {
@@ -432,6 +433,10 @@ export function PluginLibrary() {
     pi: {
       plugins: supportsPluginDiscovery(piCapabilitiesQuery.data),
       skills: supportsSkillDiscovery(piCapabilitiesQuery.data),
+    },
+    omp: {
+      plugins: supportsPluginDiscovery(ompCapabilitiesQuery.data),
+      skills: supportsSkillDiscovery(ompCapabilitiesQuery.data),
     },
   };
 

--- a/apps/web/src/components/ProviderIcon.tsx
+++ b/apps/web/src/components/ProviderIcon.tsx
@@ -17,6 +17,7 @@ import {
   GrokIcon,
   type Icon,
   KiloIcon,
+  OmpIcon,
   OpenAI,
   OpenCodeIcon,
   PiIcon,
@@ -73,6 +74,7 @@ export const PROVIDER_ICON_COMPONENT_BY_PROVIDER: Record<ProviderKind, Icon> = {
   kilo: KiloIcon,
   opencode: OpenCodeProviderIcon,
   pi: PiIcon,
+  omp: OmpIcon,
 };
 
 export function providerIconToneClassName(

--- a/apps/web/src/components/chat/ComposerModelEffortPicker.browser.tsx
+++ b/apps/web/src/components/chat/ComposerModelEffortPicker.browser.tsx
@@ -27,6 +27,7 @@ describe("ComposerModelEffortPicker", () => {
           kilo: [],
           opencode: [],
           pi: [],
+          omp: [],
         }}
         hideStatusLabel
         onProviderModelChange={vi.fn()}

--- a/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -62,6 +62,7 @@ const MODEL_OPTIONS_BY_PROVIDER = {
       upstreamProviderName: "Anthropic",
     },
   ],
+  omp: [],
   antigravity: [
     {
       slug: "Gemini 3.5 Flash",

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -21,6 +21,7 @@ import {
 } from "../ui/menu";
 import { PROVIDER_ICON_COMPONENT_BY_PROVIDER } from "../ProviderIcon";
 import { cn } from "~/lib/utils";
+import { TriangleAlertIcon } from "~/lib/icons";
 import { PickerPanelShell } from "./PickerPanelShell";
 import { PickerTriggerButton } from "./PickerTriggerButton";
 import { ProviderModelOptionGroupList } from "./ProviderModelOptionGroupList";
@@ -110,7 +111,10 @@ function providerIconClassName(
   provider: ProviderKind | ProviderPickerKind,
   fallbackClassName: string,
 ): string {
-  return provider === "claudeAgent" || provider === "antigravity" || provider === "pi"
+  return provider === "claudeAgent" ||
+    provider === "antigravity" ||
+    provider === "pi" ||
+    provider === "omp"
     ? "text-foreground"
     : fallbackClassName;
 }
@@ -288,7 +292,8 @@ export const ProviderModelMenuItems = function ProviderModelMenuItems(
       (provider === "kilo" ||
         provider === "opencode" ||
         provider === "cursor" ||
-        provider === "pi") &&
+        provider === "pi" ||
+        provider === "omp") &&
       providerOptions.length >= SEARCHABLE_MODEL_PICKER_THRESHOLD;
     const normalizedModelSearchQuery = deferredModelSearchQuery.trim().toLowerCase();
     const filteredOptions =
@@ -325,6 +330,17 @@ export const ProviderModelMenuItems = function ProviderModelMenuItems(
             {...(onAfterSelection ? { onAfterSelection } : {})}
           />
         </MenuRadioGroup>
+      ) : provider === "omp" && normalizedModelSearchQuery.length === 0 ? (
+        <div
+          role="status"
+          aria-live="polite"
+          aria-label="Couldn’t load OMP models. Check that omp is installed and authenticated."
+          tabIndex={-1}
+          className="flex items-start gap-1.5 px-2 py-2 text-sm text-amber-600 dark:text-amber-300/90"
+        >
+          <TriangleAlertIcon className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+          <span>Couldn’t load OMP models — check that omp is installed and authenticated</span>
+        </div>
       ) : (
         <div className="px-2 py-2 text-muted-foreground text-sm">
           {provider === "pi" && normalizedModelSearchQuery.length === 0

--- a/apps/web/src/components/chat/TraitsPicker.browser.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.browser.tsx
@@ -49,6 +49,7 @@ function ClaudeTraitsPickerHarness(props: {
       kilo: [],
       opencode: [],
       pi: [],
+      omp: [],
     },
   });
   const handlePromptChange = (nextPrompt: string) => {
@@ -651,6 +652,7 @@ function OpenCodeTraitsPickerHarness(props: {
       kilo: [],
       opencode: [],
       pi: [],
+      omp: [],
     },
   });
   const handlePromptChange = (nextPrompt: string) => {

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -360,7 +360,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
       primarySelectDescriptorId ??
       (provider === "kilo" || provider === "opencode"
         ? "variant"
-        : provider === "pi"
+        : provider === "pi" || provider === "omp"
           ? "thinkingLevel"
           : provider === "claudeAgent"
             ? "effort"

--- a/apps/web/src/components/chat/composerProviderRegistry.tsx
+++ b/apps/web/src/components/chat/composerProviderRegistry.tsx
@@ -21,6 +21,7 @@ import {
   normalizeClaudeModelOptions,
   normalizeOpenCodeModelOptions,
   normalizePiModelOptions,
+  normalizeOmpModelOptions,
   resolveLabeledOptionValue,
   trimOrNull,
 } from "@synara/shared/model";
@@ -237,6 +238,12 @@ function getProviderStateFromCapabilities(
       normalizedOptions = normalizePiModelOptions(providerOptions);
       break;
     }
+    case "omp": {
+      const providerOptions = modelOptions?.omp;
+      rawEffort = trimOrNull(providerOptions?.thinkingLevel);
+      normalizedOptions = normalizeOmpModelOptions(providerOptions);
+      break;
+    }
   }
 
   const draftEffort = trimOrNull(rawEffort);
@@ -318,6 +325,11 @@ const composerProviderRegistry: Record<ProviderKind, ProviderRegistryEntry> = {
     getState: (input) => getProviderStateFromCapabilities(input),
     renderTraitsMenuContent: (input) => renderTraitsMenuContentForProvider("pi", input),
     renderTraitsPicker: (input) => renderTraitsPickerForProvider("pi", input),
+  },
+  omp: {
+    getState: (input) => getProviderStateFromCapabilities(input),
+    renderTraitsMenuContent: (input) => renderTraitsMenuContentForProvider("omp", input),
+    renderTraitsPicker: (input) => renderTraitsPickerForProvider("omp", input),
   },
 };
 

--- a/apps/web/src/components/chat/runtimeModelCapabilities.ts
+++ b/apps/web/src/components/chat/runtimeModelCapabilities.ts
@@ -103,7 +103,8 @@ export function getRuntimeAwareModelCapabilities(input: {
       input.provider !== "droid" &&
       input.provider !== "kilo" &&
       input.provider !== "opencode" &&
-      input.provider !== "pi") ||
+      input.provider !== "pi" &&
+      input.provider !== "omp") ||
     !runtimeEfforts ||
     runtimeEfforts.length === 0
   ) {

--- a/apps/web/src/components/settings/ProfileSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProfileSettingsPanel.tsx
@@ -347,6 +347,8 @@ function formatProviderLabel(provider: ProviderKind): string {
       return "OpenCode";
     case "pi":
       return "Pi";
+    case "omp":
+      return "Oh My Pi";
   }
 }
 

--- a/apps/web/src/components/settings/ProvidersSettingsPanel.test.ts
+++ b/apps/web/src/components/settings/ProvidersSettingsPanel.test.ts
@@ -72,6 +72,8 @@ describe("createProviderInstallResetPatch", () => {
         "kiloBinaryPath",
         "kiloServerPassword",
         "kiloServerUrl",
+        "ompAgentDir",
+        "ompBinaryPath",
         "openCodeBinaryPath",
         "openCodeExperimentalWebSockets",
         "openCodeServerPassword",

--- a/apps/web/src/components/settings/ProvidersSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProvidersSettingsPanel.tsx
@@ -79,7 +79,9 @@ type ProviderInstallTextKey =
   | "openCodeBinaryPath"
   | "openCodeServerUrl"
   | "piBinaryPath"
-  | "piAgentDir";
+  | "piAgentDir"
+  | "ompBinaryPath"
+  | "ompAgentDir";
 type ProviderInstallPasswordKey = "kiloServerPassword" | "openCodeServerPassword";
 type ProviderInstallPasswordConfiguredKey =
   | "kiloServerPasswordConfigured"
@@ -370,6 +372,35 @@ const PROVIDER_INSTALL_SETTINGS: readonly ProviderInstallSettings[] = [
         label: "Pi agent directory",
         placeholder: "Pi agent directory",
         description: "Optional custom Pi agent directory for auth, models, skills, and commands.",
+      },
+    ],
+  },
+  {
+    provider: "omp",
+    docs: [
+      { label: "Docs", href: "https://omp.sh/docs" },
+      { label: "Install", href: "https://omp.sh/docs/quickstart" },
+      { label: "Source", href: "https://github.com/can1357/oh-my-pi" },
+    ],
+    fields: [
+      {
+        kind: "text",
+        settingsKey: "ompBinaryPath",
+        label: "Oh My Pi binary path",
+        placeholder: "Oh My Pi binary path",
+        description: (
+          <>
+            Leave blank to use <code>omp</code> from your PATH.
+          </>
+        ),
+      },
+      {
+        kind: "text",
+        settingsKey: "ompAgentDir",
+        label: "Oh My Pi agent directory",
+        placeholder: "Oh My Pi agent directory",
+        description:
+          "Optional custom Oh My Pi agent directory for auth, models, skills, and commands.",
       },
     ],
   },

--- a/apps/web/src/components/settings/skillsSettingsModel.ts
+++ b/apps/web/src/components/settings/skillsSettingsModel.ts
@@ -47,6 +47,7 @@ export const ORIGIN_SECTION_ORDER = [
   "kilo",
   "opencode",
   "pi",
+  "omp",
   "agents",
   "project",
 ] as const;
@@ -72,6 +73,8 @@ export function skillOriginInfo(scope: string | undefined): SkillOriginInfo {
       return { label: PROVIDER_DISPLAY_NAMES.opencode, provider: "opencode" };
     case "pi":
       return { label: PROVIDER_DISPLAY_NAMES.pi, provider: "pi" };
+    case "omp":
+      return { label: PROVIDER_DISPLAY_NAMES.omp, provider: "omp" };
     case "agents":
       return { label: "Shared (.agents)", provider: null };
     case "project":

--- a/apps/web/src/composerDraftModels.ts
+++ b/apps/web/src/composerDraftModels.ts
@@ -37,6 +37,7 @@ export const COMPOSER_PROVIDER_KINDS = [
   "kilo",
   "opencode",
   "pi",
+  "omp",
 ] as const satisfies readonly ProviderKind[];
 
 const isProviderKind = Schema.is(ProviderKind);
@@ -209,6 +210,14 @@ export function makeModelSelection(
           ? { options: options as Extract<ModelSelection, { provider: "pi" }>["options"] }
           : {}),
       };
+    case "omp":
+      return {
+        provider,
+        model,
+        ...(options
+          ? { options: options as Extract<ModelSelection, { provider: "omp" }>["options"] }
+          : {}),
+      };
   }
 }
 
@@ -253,6 +262,10 @@ export function normalizeProviderModelOptions(
   const piCandidate =
     candidate?.pi && typeof candidate.pi === "object"
       ? (candidate.pi as Record<string, unknown>)
+      : null;
+  const ompCandidate =
+    candidate?.omp && typeof candidate.omp === "object"
+      ? (candidate.omp as Record<string, unknown>)
       : null;
 
   const codexReasoningEffort: CodexReasoningEffort | undefined =
@@ -389,6 +402,16 @@ export function normalizeProviderModelOptions(
       ? piCandidate.thinkingLevel
       : undefined;
   const pi = piThinkingLevel !== undefined ? { thinkingLevel: piThinkingLevel } : undefined;
+  const ompThinkingLevel: PiThinkingLevel | undefined =
+    ompCandidate?.thinkingLevel === "off" ||
+    ompCandidate?.thinkingLevel === "minimal" ||
+    ompCandidate?.thinkingLevel === "low" ||
+    ompCandidate?.thinkingLevel === "medium" ||
+    ompCandidate?.thinkingLevel === "high" ||
+    ompCandidate?.thinkingLevel === "xhigh"
+      ? ompCandidate.thinkingLevel
+      : undefined;
+  const omp = ompThinkingLevel !== undefined ? { thinkingLevel: ompThinkingLevel } : undefined;
   if (
     !codex &&
     !claude &&
@@ -398,7 +421,8 @@ export function normalizeProviderModelOptions(
     !droid &&
     !kilo &&
     !opencode &&
-    !pi
+    !pi &&
+    !omp
   ) {
     return null;
   }
@@ -412,6 +436,7 @@ export function normalizeProviderModelOptions(
     ...(kilo ? { kilo } : {}),
     ...(opencode ? { opencode } : {}),
     ...(pi ? { pi } : {}),
+    ...(omp ? { omp } : {}),
   };
 }
 
@@ -485,7 +510,9 @@ export function normalizeModelSelection(
                     ? modelOptions?.opencode
                     : provider === "pi"
                       ? modelOptions?.pi
-                      : undefined;
+                      : provider === "omp"
+                        ? modelOptions?.omp
+                        : undefined;
   const normalizedOptions =
     provider === "antigravity" && hasLegacyAntigravityEffort
       ? {
@@ -771,8 +798,11 @@ export function resolvePreferredComposerModelSelection(input: {
     (input.projectModelSelection?.provider === preferredProvider
       ? input.projectModelSelection
       : null) ?? {
-      provider: preferredProvider === "pi" ? "codex" : preferredProvider,
-      model: getDefaultModel(preferredProvider === "pi" ? "codex" : preferredProvider),
+      provider:
+        preferredProvider === "pi" || preferredProvider === "omp" ? "codex" : preferredProvider,
+      model: getDefaultModel(
+        preferredProvider === "pi" || preferredProvider === "omp" ? "codex" : preferredProvider,
+      ),
     }
   );
 }

--- a/apps/web/src/composerDraftStore.models.test.ts
+++ b/apps/web/src/composerDraftStore.models.test.ts
@@ -365,6 +365,7 @@ describe("composerDraftStore modelSelection", () => {
         kilo: [],
         opencode: [],
         pi: [],
+        omp: [],
       },
       availableModelOptionsByProvider: {
         opencode: [{ slug: "opencode/gpt-5-nano", name: "GPT-5 Nano" }],
@@ -393,6 +394,7 @@ describe("composerDraftStore modelSelection", () => {
         kilo: [],
         opencode: [],
         pi: [],
+        omp: [],
       },
       availableModelOptionsByProvider: {
         opencode: [
@@ -426,6 +428,7 @@ describe("composerDraftStore modelSelection", () => {
         kilo: [],
         opencode: [],
         pi: [],
+        omp: [],
       },
       availableModelOptionsByProvider: {
         opencode: [
@@ -459,6 +462,7 @@ describe("composerDraftStore modelSelection", () => {
         kilo: [],
         opencode: [],
         pi: [],
+        omp: [],
       },
       availableModelOptionsByProvider: {
         pi: [

--- a/apps/web/src/hooks/useProviderModelCatalog.test.tsx
+++ b/apps/web/src/hooks/useProviderModelCatalog.test.tsx
@@ -44,12 +44,14 @@ interface QueryResultLike {
   readonly isFetching: boolean;
   readonly isLoading: boolean;
   readonly isPlaceholderData: boolean;
+  readonly isError: boolean;
 }
 
 const EMPTY_QUERY: QueryResultLike = {
   isFetching: false,
   isLoading: false,
   isPlaceholderData: false,
+  isError: false,
 };
 const modelQueries = new Map<ProviderKind, QueryResultLike>();
 const agentQueries = new Map<ProviderKind, QueryResultLike>();
@@ -244,6 +246,75 @@ describe("useProviderModelCatalog", () => {
     expect(readModelQueryEnabled("antigravity")).toBe(false);
   });
 
+  it("reports OMP as loading during its initial model discovery", () => {
+    // OMP has no static model fallback and (unlike other providers) opts out of
+    // placeholderData, so its first `omp models` fetch reports a genuine
+    // `isLoading` pending state. The catalog must flag OMP as loading in that
+    // window so the picker renders the "Loading models" skeleton — not a false
+    // "No matches" — during the ~3s discovery.
+    modelQueries.set("omp", {
+      isFetching: true,
+      isLoading: true,
+      isPlaceholderData: false,
+      isError: false,
+    });
+
+    const catalog = readCatalogRenders({
+      selectedProvider: "omp",
+      discoveryEnabled: true,
+    }).at(-1);
+
+    expect(catalog?.loadingModelProviders.omp).toBe(true);
+  });
+
+  it("clears OMP loading once discovery resolves with models", () => {
+    modelQueries.set("omp", {
+      data: {
+        models: [{ slug: "anthropic/claude-sonnet-4", name: "Claude Sonnet 4" }],
+        source: "omp-cli",
+        cached: false,
+      },
+      isFetching: false,
+      isLoading: false,
+      isPlaceholderData: false,
+      isError: false,
+    });
+
+    const catalog = readCatalogRenders({
+      selectedProvider: "omp",
+      discoveryEnabled: true,
+    }).at(-1);
+
+    expect(catalog?.loadingModelProviders.omp).toBe(false);
+    expect(catalog?.modelOptionsByProvider.omp.map((m) => m.slug)).toEqual([
+      "anthropic/claude-sonnet-4",
+    ]);
+  });
+
+  it("clears OMP loading and options on terminal discovery failure", () => {
+    // OMP has no static model fallback. A terminal discovery failure (retries
+    // exhausted) must NOT park the picker on the skeleton (the documented
+    // isInitialModelDiscoveryPending contract: "a failed provider must not park
+    // the model control on a skeleton") NOR collapse to the hint-only static
+    // list (previously-selected model as the sole OMP entry). Instead loading
+    // clears and the options are emptied so the picker surfaces a load-failure
+    // message.
+    modelQueries.set("omp", {
+      isFetching: false,
+      isLoading: false,
+      isPlaceholderData: false,
+      isError: true,
+    });
+
+    const catalog = readCatalogRenders({
+      selectedProvider: "omp",
+      discoveryEnabled: true,
+    }).at(-1);
+
+    expect(catalog?.loadingModelProviders.omp).toBe(false);
+    expect(catalog?.modelOptionsByProvider.omp).toEqual([]);
+  });
+
   it("merges a settled runtime catalog with custom models without reporting loading", () => {
     modelQueries.set("cursor", {
       data: {
@@ -254,6 +325,7 @@ describe("useProviderModelCatalog", () => {
       isFetching: true,
       isLoading: false,
       isPlaceholderData: true,
+      isError: false,
     });
 
     const catalog = readCatalogRenders({

--- a/apps/web/src/hooks/useProviderModelCatalog.ts
+++ b/apps/web/src/hooks/useProviderModelCatalog.ts
@@ -114,6 +114,7 @@ export function useProviderModelCatalog(input: {
   const kiloModelDiscoveryEnabled = shouldDiscoverProvider("kilo");
   const openCodeModelDiscoveryEnabled = shouldDiscoverProvider("opencode");
   const piModelDiscoveryEnabled = shouldDiscoverProvider("pi");
+  const ompModelDiscoveryEnabled = shouldDiscoverProvider("omp");
 
   const claudeDynamicModelsQuery = useQuery(
     providerModelsQueryOptions({
@@ -184,6 +185,17 @@ export function useProviderModelCatalog(input: {
       agentDir: settings.piAgentDir || null,
       cwd: discoveryCwd,
       enabled: piModelDiscoveryEnabled,
+    }),
+  );
+  const ompDynamicModelsQuery = useQuery(
+    providerModelsQueryOptions({
+      provider: "omp",
+      binaryPath: settings.ompBinaryPath || null,
+      agentDir: settings.ompAgentDir || null,
+      cwd: discoveryCwd,
+      // Eager-warmed at app startup (ProviderModelDiscoveryWarmer in __root); this observer
+      // shares the warmed cwd-agnostic cache entry (React Query dedupes by query key).
+      enabled: ompModelDiscoveryEnabled,
     }),
   );
 
@@ -260,6 +272,23 @@ export function useProviderModelCatalog(input: {
     piModelDiscoveryEnabled &&
     !hasResolvedPiModelDiscovery &&
     isInitialModelDiscoveryPending(piDynamicModelsQuery);
+  const hasResolvedOmpModelDiscovery =
+    ompDynamicModelsQuery.data?.source === "omp-cli" &&
+    (ompDynamicModelsQuery.data.models.length ?? 0) > 0;
+  // OMP has no static model fallback. A terminal discovery failure (retries
+  // exhausted — isError true) must NOT park the picker on the loading skeleton:
+  // isInitialModelDiscoveryPending's contract is "a failed provider must not
+  // park the model control on a skeleton" (see providerDiscoveryReactQuery).
+  // Instead modelOptionsByProvider clears OMP's options on failure so the picker
+  // surfaces a load-failure message rather than the hint-only static list
+  // (previously-selected model shown as the sole OMP entry — the "collapsed to
+  // one model" symptom). Pending stays true only while the first fetch is
+  // outstanding or retrying; transient cold-start failures retry under the
+  // skeleton before this flag ever flips.
+  const ompDiscoveryFailed =
+    ompModelDiscoveryEnabled && !hasResolvedOmpModelDiscovery && ompDynamicModelsQuery.isError;
+  const ompModelDiscoveryPending =
+    ompModelDiscoveryEnabled && !hasResolvedOmpModelDiscovery && !ompDiscoveryFailed;
   const antigravityModelDiscoveryPending =
     antigravityModelDiscoveryEnabled &&
     !(
@@ -295,6 +324,7 @@ export function useProviderModelCatalog(input: {
         modelHintByProvider?.opencode,
       ),
       pi: getAppModelOptions("pi", customModelsByProvider.pi, modelHintByProvider?.pi),
+      omp: getAppModelOptions("omp", customModelsByProvider.omp, modelHintByProvider?.omp),
     };
     const result: Record<
       ProviderKind,
@@ -313,6 +343,7 @@ export function useProviderModelCatalog(input: {
       kilo: kiloDynamicModelsQuery.data,
       opencode: openCodeDynamicModelsQuery.data,
       pi: piDynamicModelsQuery.data,
+      omp: ompDynamicModelsQuery.data,
     };
     for (const provider of [
       "claudeAgent",
@@ -324,6 +355,7 @@ export function useProviderModelCatalog(input: {
       "kilo",
       "opencode",
       "pi",
+      "omp",
     ] as const) {
       const dynamicModels = dynamicSources[provider]?.models;
       if (dynamicModels && dynamicModels.length > 0) {
@@ -333,6 +365,12 @@ export function useProviderModelCatalog(input: {
           dynamicModels,
         });
       }
+    }
+    // Terminal OMP discovery failure: clear options so the picker surfaces a
+    // load-failure message instead of the hint-only static list (OMP has no
+    // built-in catalog to fall back to).
+    if (ompDiscoveryFailed) {
+      result.omp = [];
     }
     return result;
   }, [
@@ -348,6 +386,8 @@ export function useProviderModelCatalog(input: {
     modelHintByProvider,
     openCodeDynamicModelsQuery.data,
     piDynamicModelsQuery.data,
+    ompDynamicModelsQuery.data,
+    ompDiscoveryFailed,
   ]);
 
   const loadingModelProviders = useMemo<Partial<Record<ProviderKind, boolean>>>(
@@ -358,6 +398,7 @@ export function useProviderModelCatalog(input: {
       kilo: kiloModelDiscoveryPending,
       opencode: openCodeModelDiscoveryPending,
       pi: piModelDiscoveryPending,
+      omp: ompModelDiscoveryPending,
     }),
     [
       antigravityModelDiscoveryPending,
@@ -366,6 +407,7 @@ export function useProviderModelCatalog(input: {
       kiloModelDiscoveryPending,
       openCodeModelDiscoveryPending,
       piModelDiscoveryPending,
+      ompModelDiscoveryPending,
     ],
   );
 
@@ -382,6 +424,7 @@ export function useProviderModelCatalog(input: {
       kilo: kiloDynamicModelsQuery.data?.models ?? [],
       opencode: openCodeDynamicModelsQuery.data?.models ?? [],
       pi: piDynamicModelsQuery.data?.models ?? [],
+      omp: ompDynamicModelsQuery.data?.models ?? [],
     }),
     [
       antigravityModelsQuery.data?.models,
@@ -393,6 +436,7 @@ export function useProviderModelCatalog(input: {
       kiloDynamicModelsQuery.data?.models,
       openCodeDynamicModelsQuery.data?.models,
       piDynamicModelsQuery.data?.models,
+      ompDynamicModelsQuery.data?.models,
     ],
   );
 
@@ -443,7 +487,9 @@ export function useProviderModelCatalog(input: {
                   ? kiloDynamicModelsQuery
                   : selectedProvider === "opencode"
                     ? openCodeDynamicModelsQuery
-                    : piDynamicModelsQuery;
+                    : selectedProvider === "omp"
+                      ? ompDynamicModelsQuery
+                      : piDynamicModelsQuery;
   const selectedProviderModelsLoading =
     selectedProviderRuntimeModelDiscoveryPending ||
     (loadingModelProviders[selectedProvider] === undefined &&

--- a/apps/web/src/lib/composerSend.ts
+++ b/apps/web/src/lib/composerSend.ts
@@ -204,6 +204,7 @@ export function resolvePromptEffortFromModelSelection(
     case "droid":
       return modelSelection.options?.reasoningEffort ?? null;
     case "pi":
+    case "omp":
       return modelSelection.options?.thinkingLevel ?? null;
     case "kilo":
     case "opencode":

--- a/apps/web/src/lib/providerDiscoveryReactQuery.test.ts
+++ b/apps/web/src/lib/providerDiscoveryReactQuery.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   isInitialModelDiscoveryPending,
+  providerDiscoveryQueryKeys,
   providerModelsQueryOptions,
 } from "./providerDiscoveryReactQuery";
 import * as nativeApi from "../nativeApi";
@@ -79,6 +80,16 @@ describe("providerModelsQueryOptions", () => {
     expect(providerModelsQueryOptions({ provider: "droid" }).retry).toBe(0);
   });
 
+  it("does not mask OMP's initial fetch with a placeholder", () => {
+    // OMP has no static model fallback, so an empty placeholder would surface a
+    // false "No matches" during its ~3s `omp models` discovery. OMP opts out of
+    // placeholderData to report a genuine `isLoading` pending state; other
+    // providers keep the placeholder to suppress refetch flicker.
+    expect(providerModelsQueryOptions({ provider: "omp" }).placeholderData).toBeUndefined();
+    expect(providerModelsQueryOptions({ provider: "cursor" }).placeholderData).toBeDefined();
+    expect(providerModelsQueryOptions({ provider: "pi" }).placeholderData).toBeDefined();
+  });
+
   it("surfaces real errors instead of masking them as empty catalogs", async () => {
     mockListModels(vi.fn().mockRejectedValue(new Error("discovery exploded")));
     const options = providerModelsQueryOptions({ provider: "cursor", enabled: true });
@@ -118,5 +129,29 @@ describe("providerModelsQueryOptions", () => {
 
     const queryClient = new QueryClient();
     await expect(queryClient.fetchQuery(options)).resolves.toEqual(catalog);
+  });
+
+  it("keeps OMP's model query key cwd-agnostic (its catalog is global)", () => {
+    const options = providerModelsQueryOptions({
+      provider: "omp",
+      binaryPath: "/bin/omp",
+      agentDir: "/agent",
+      cwd: "/some/project",
+    });
+    // cwd is null for OMP so an app-startup warm lands on the composer's cache.
+    expect(options.queryKey).toEqual(
+      providerDiscoveryQueryKeys.models("omp", "/bin/omp", null, "/agent", null),
+    );
+  });
+
+  it("scopes non-OMP providers by cwd in their query key", () => {
+    const options = providerModelsQueryOptions({
+      provider: "kilo",
+      binaryPath: "/bin/kilo",
+      cwd: "/some/project",
+    });
+    expect(options.queryKey).toEqual(
+      providerDiscoveryQueryKeys.models("kilo", "/bin/kilo", null, null, "/some/project"),
+    );
   });
 });

--- a/apps/web/src/lib/providerDiscoveryReactQuery.ts
+++ b/apps/web/src/lib/providerDiscoveryReactQuery.ts
@@ -205,13 +205,19 @@ export function providerModelsQueryOptions(input: {
   cwd?: string | null;
   enabled?: boolean;
 }) {
+  // OMP's catalog is global (`omp models --json` is not project-scoped — the
+  // server caches it by binary path only), so cwd is intentionally excluded
+  // from its query key and request. This keeps a single cache entry shared
+  // across threads/projects and lets an app-startup warm land on the exact key
+  // the composer reads.
+  const cwd = input.provider === "omp" ? null : (input.cwd ?? null);
   return queryOptions({
     queryKey: providerDiscoveryQueryKeys.models(
       input.provider,
       input.binaryPath ?? null,
       input.apiEndpoint ?? null,
       input.agentDir ?? null,
-      input.cwd ?? null,
+      cwd,
     ),
     queryFn: async (): Promise<ProviderListModelsResult> => {
       const api = ensureNativeApi();
@@ -220,16 +226,29 @@ export function providerModelsQueryOptions(input: {
         ...(input.binaryPath ? { binaryPath: input.binaryPath } : {}),
         ...(input.apiEndpoint ? { apiEndpoint: input.apiEndpoint } : {}),
         ...(input.agentDir ? { agentDir: input.agentDir } : {}),
-        ...(input.cwd ? { cwd: input.cwd } : {}),
+        ...(cwd ? { cwd } : {}),
       });
     },
     enabled: input.enabled ?? true,
     // Cursor/droid failures are permanent for a session (missing CLI/auth): fail
     // fast so the picker settles to static options instead of spinning (#103).
+    // OMP retries like pi (not fail-fast): it has no static model fallback, so a
+    // transient `omp models` cold-start failure must retry under the loading
+    // skeleton rather than settling instantly to a false "No matches".
     retry: input.provider === "droid" || input.provider === "cursor" ? 0 : 3,
-    staleTime: input.provider === "droid" ? 5 * 60_000 : 60_000,
-    ...(input.provider === "droid" ? { refetchOnWindowFocus: false } : {}),
-    placeholderData: (previous) => previous ?? EMPTY_MODELS_RESULT,
+    staleTime: input.provider === "droid" || input.provider === "omp" ? 5 * 60_000 : 60_000,
+    ...(input.provider === "droid" || input.provider === "omp"
+      ? { refetchOnWindowFocus: false }
+      : {}),
+    // OMP has no static model fallback, so masking its first `omp models` fetch
+    // with an empty placeholder would surface a false "No matches" during the
+    // ~3s discovery. Omit placeholderData for OMP so React Query reports a
+    // genuine `isLoading` pending state and the catalog renders the loading
+    // skeleton instead. Other providers keep the placeholder to suppress
+    // refetch flicker against their static catalogs.
+    ...(input.provider !== "omp"
+      ? { placeholderData: (previous) => previous ?? EMPTY_MODELS_RESULT }
+      : {}),
   });
 }
 

--- a/apps/web/src/lib/providerModelPrefetch.test.ts
+++ b/apps/web/src/lib/providerModelPrefetch.test.ts
@@ -34,6 +34,8 @@ function makeSettings(
     openCodeBinaryPath: "",
     piBinaryPath: "",
     piAgentDir: "",
+    ompBinaryPath: "",
+    ompAgentDir: "",
     ...overrides,
   };
 }
@@ -160,6 +162,22 @@ describe("providerModelsPrefetchQueryOptions", () => {
     });
     expect(codexOptions.queryKey).toEqual(
       providerDiscoveryQueryKeys.models("codex", null, null, null, null),
+    );
+  });
+  it("matches ChatView cache key for OMP and keeps it cwd-agnostic", () => {
+    const settings = makeSettings({
+      ompBinaryPath: "/bin/omp",
+      ompAgentDir: "/tmp/omp-agent",
+    });
+    const ompOptions = providerModelsPrefetchQueryOptions({
+      provider: "omp",
+      settings,
+      cwd: "/tmp/project",
+    });
+    // OMP's catalog is global, so cwd is forced to null — the prefetch must land on the
+    // same cwd-agnostic key the composer reads and the startup warmer (ProviderModelDiscoveryWarmer) writes.
+    expect(ompOptions.queryKey).toEqual(
+      providerDiscoveryQueryKeys.models("omp", "/bin/omp", null, "/tmp/omp-agent", null),
     );
   });
 });

--- a/apps/web/src/lib/providerModelPrefetch.ts
+++ b/apps/web/src/lib/providerModelPrefetch.ts
@@ -29,6 +29,8 @@ export type ProviderModelPrefetchSettings = Pick<
   | "openCodeBinaryPath"
   | "piBinaryPath"
   | "piAgentDir"
+  | "ompBinaryPath"
+  | "ompAgentDir"
 >;
 
 export function resolveNewThreadModelPrefetchProvider(input: {
@@ -115,6 +117,13 @@ export function providerModelsPrefetchQueryOptions(input: {
         provider: "pi",
         binaryPath: settings.piBinaryPath || null,
         agentDir: settings.piAgentDir || null,
+        cwd,
+      });
+    case "omp":
+      return providerModelsQueryOptions({
+        provider: "omp",
+        binaryPath: settings.ompBinaryPath || null,
+        agentDir: settings.ompAgentDir || null,
         cwd,
       });
   }

--- a/apps/web/src/lib/threadHandoff.test.ts
+++ b/apps/web/src/lib/threadHandoff.test.ts
@@ -99,6 +99,7 @@ describe("threadHandoff", () => {
       "kilo",
       "opencode",
       "pi",
+      "omp",
     ] as const;
 
     for (const source of providers) {

--- a/apps/web/src/providerModelOptions.test.ts
+++ b/apps/web/src/providerModelOptions.test.ts
@@ -33,6 +33,33 @@ describe("Antigravity model options", () => {
     });
   });
 });
+describe("OMP model options", () => {
+  it("builds an OMP model selection carrying a max thinking level", () => {
+    expect(
+      buildModelSelection("omp", "anthropic/claude-sonnet-4", { thinkingLevel: "max" }),
+    ).toEqual({
+      provider: "omp",
+      model: "anthropic/claude-sonnet-4",
+      options: { thinkingLevel: "max" },
+    });
+  });
+
+  it("builds an OMP model selection without options when none are provided", () => {
+    expect(buildModelSelection("omp", "anthropic/claude-sonnet-4")).toEqual({
+      provider: "omp",
+      model: "anthropic/claude-sonnet-4",
+    });
+  });
+
+  it("strips the upstream provider prefix from OMP slugs in display names", () => {
+    // omp sits in the slug-prefix condition alongside pi/opencode/kilo, so the
+    // "anthropic/" prefix must be stripped; regressing omp out of that condition
+    // would leave the slash in the display name.
+    const name = formatProviderModelOptionName({ provider: "omp", slug: "anthropic/claude-sonnet-4" });
+    expect(name).not.toContain("/");
+    expect(name.length).toBeGreaterThan(0);
+  });
+});
 
 describe("Claude model selections", () => {
   it("preserves the discovered Auto capability with the selected model", () => {

--- a/apps/web/src/providerModelOptions.ts
+++ b/apps/web/src/providerModelOptions.ts
@@ -18,6 +18,8 @@ import type {
   GrokModelSelection,
   KiloModelSelection,
   ModelSelection,
+  OmpModelOptions,
+  OmpModelSelection,
   OpenCodeModelOptions,
   OpenCodeModelSelection,
   PiModelOptions,
@@ -53,7 +55,12 @@ export function formatProviderModelOptionName(input: {
     return trimmedSlug;
   }
 
-  if (input.provider === "kilo" || input.provider === "opencode" || input.provider === "pi") {
+  if (
+    input.provider === "kilo" ||
+    input.provider === "opencode" ||
+    input.provider === "pi" ||
+    input.provider === "omp"
+  ) {
     const modelIdentifier = trimmedSlug.includes("/")
       ? trimmedSlug.slice(trimmedSlug.lastIndexOf("/") + 1)
       : trimmedSlug;
@@ -360,6 +367,11 @@ export function buildModelSelection(
   options?: PiModelOptions | null | undefined,
 ): PiModelSelection;
 export function buildModelSelection(
+  provider: "omp",
+  model: string,
+  options?: OmpModelOptions | null | undefined,
+): OmpModelSelection;
+export function buildModelSelection(
   provider: ProviderKind,
   model: string,
   options?: ProviderOptions | null | undefined,
@@ -441,6 +453,14 @@ export function buildModelSelection(
             provider,
             model,
             options: options as PiModelOptions,
+          }
+        : { provider, model };
+    case "omp":
+      return options
+        ? {
+            provider,
+            model,
+            options: options as OmpModelOptions,
           }
         : { provider, model };
   }

--- a/apps/web/src/providerUpdates.test.ts
+++ b/apps/web/src/providerUpdates.test.ts
@@ -72,6 +72,7 @@ function serverSettings(overrides: Partial<ServerSettings["providers"]> = {}): S
         experimentalWebSockets: false,
       },
       pi: { ...provider, binaryPath: "pi", agentDir: "" },
+      omp: { ...provider, binaryPath: "omp", agentDir: "" },
       ...overrides,
     },
     skills: { disabled: [] },

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -108,6 +108,7 @@ import { useProviderStatusRefresh } from "../hooks/useProviderStatusRefresh";
 import { resolveSplitViewThreadIds, selectSplitView, useSplitViewStore } from "../splitViewStore";
 import { providerModelDiscoveryInvalidationFingerprint } from "../lib/providerDiscoveryInvalidation";
 import { providerDiscoveryQueryKeys } from "../lib/providerDiscoveryReactQuery";
+import { providerModelsPrefetchQueryOptions } from "../lib/providerModelPrefetch";
 import { useAppSettings } from "../appSettings";
 import {
   getVisibleProviderUpdateStatuses,
@@ -248,6 +249,7 @@ function RootRouteView() {
           <GitProgressToastPreviewDev />
           <EventRouter />
           <ProviderStatusRefreshCoordinator />
+          <ProviderModelDiscoveryWarmer />
           <GlobalShortcutsDialog />
           <GlobalFeedbackDialog />
           <GlobalWhatsNewSurface />
@@ -328,6 +330,26 @@ function ProviderStatusRefreshCoordinator() {
     intervalMs: PROVIDER_UPDATE_REFRESH_INTERVAL_MS,
   });
 
+  return null;
+}
+
+function ProviderModelDiscoveryWarmer() {
+  // OMP is the only provider with no static model fallback whose catalog also
+  // takes ~3s to fetch (`omp models --json` cold-start), so it is the lone
+  // provider that doesn't render instantly when the model picker opens. Warm it
+  // at app startup — ahead of the picker opening — so the catalog is ready by
+  // the time the user browses to OMP. React Query dedupes by query key, and
+  // OMP's key is cwd-agnostic, so this prefetch lands on the exact cache entry
+  // the composer reads on mount.
+  const { settings } = useAppSettings();
+  const queryClient = useQueryClient();
+  const ompHidden = settings.hiddenProviders.includes("omp");
+  useEffect(() => {
+    if (ompHidden) return;
+    void queryClient.prefetchQuery(
+      providerModelsPrefetchQueryOptions({ provider: "omp", settings, cwd: null }),
+    );
+  }, [queryClient, settings, ompHidden]);
   return null;
 }
 

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -870,6 +870,7 @@ describe("PROVIDER_OPTIONS", () => {
       { value: "kilo", label: "Kilo", available: true },
       { value: "opencode", label: "OpenCode", available: true },
       { value: "pi", label: "Pi", available: true },
+      { value: "omp", label: "Oh My Pi", available: true },
     ]);
     expect(claude).toEqual({
       value: "claudeAgent",

--- a/apps/web/src/storeNormalization.test.ts
+++ b/apps/web/src/storeNormalization.test.ts
@@ -1,11 +1,15 @@
 // FILE: storeNormalization.test.ts
-// Purpose: Pins the incremental activity accumulator to the `normalizeActivities` fold it replaces.
+// Purpose: pins the incremental activity accumulator to the `normalizeActivities` fold it
+// replaces, and locks the legacy session provider-name → ProviderKind mapping.
 
 import { describe, expect, it } from "vitest";
+
+import type { ProviderKind } from "@synara/contracts";
 
 import {
   createThreadActivityAccumulator,
   normalizeActivities,
+  toLegacyProvider,
   type ThreadActivityAccumulator,
 } from "./storeNormalization";
 import { makeActivity } from "./storeTestFixtures";
@@ -64,6 +68,19 @@ const richPayload = {
   detail: "echo hello",
   data: { item: { type: "commandExecution", command: "echo hello" } },
 };
+
+const KNOWN_PROVIDERS: ReadonlyArray<ProviderKind> = [
+  "codex",
+  "claudeAgent",
+  "cursor",
+  "antigravity",
+  "grok",
+  "droid",
+  "kilo",
+  "opencode",
+  "pi",
+  "omp",
+];
 
 describe("createThreadActivityAccumulator", () => {
   it("matches the normalizeActivities fold for appends, in-place merges and exact duplicates", () => {
@@ -171,5 +188,28 @@ describe("createThreadActivityAccumulator", () => {
 
     expect(previous).toEqual(snapshot);
     expect(accumulator.result()).not.toBe(previous);
+  });
+});
+
+describe("toLegacyProvider", () => {
+  it("maps each known provider name to itself", () => {
+    for (const provider of KNOWN_PROVIDERS) {
+      expect(toLegacyProvider(provider)).toBe(provider);
+    }
+  });
+
+  it("maps omp to omp (regression: omp threads were coerced to codex)", () => {
+    // The server stamps providerName "omp" for OMP threads; before the fix this
+    // fell through to "codex", mislabeling every OMP thread across the UI
+    // (ChatHeader, Sidebar, ChatView activeProvider, kanban, threadDisplay).
+    expect(toLegacyProvider("omp")).toBe("omp");
+  });
+
+  it("falls back to codex for an unknown provider name", () => {
+    expect(toLegacyProvider("unknown-provider")).toBe("codex");
+  });
+
+  it("falls back to codex for null", () => {
+    expect(toLegacyProvider(null)).toBe("codex");
   });
 });

--- a/apps/web/src/storeNormalization.ts
+++ b/apps/web/src/storeNormalization.ts
@@ -1802,7 +1802,7 @@ function toLegacySessionStatus(
   }
 }
 
-function toLegacyProvider(providerName: string | null): ProviderKind {
+export function toLegacyProvider(providerName: string | null): ProviderKind {
   if (
     providerName === "codex" ||
     providerName === "claudeAgent" ||
@@ -1812,7 +1812,8 @@ function toLegacyProvider(providerName: string | null): ProviderKind {
     providerName === "droid" ||
     providerName === "kilo" ||
     providerName === "opencode" ||
-    providerName === "pi"
+    providerName === "pi" ||
+    providerName === "omp"
   ) {
     return providerName;
   }

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -326,6 +326,7 @@ describe("wsNativeApi", () => {
             customModels: [],
           },
           pi: { enabled: true, binaryPath: "pi", agentDir: "", customModels: [] },
+          omp: { enabled: true, binaryPath: "omp", agentDir: "", customModels: [] },
         },
         skills: { disabled: [] },
       },

--- a/packages/contracts/src/agentMentions.ts
+++ b/packages/contracts/src/agentMentions.ts
@@ -220,6 +220,7 @@ export const AGENT_MENTION_ALIASES_BY_PROVIDER: Record<
   kilo: OPENCODE_AGENT_MENTION_ALIASES,
   opencode: OPENCODE_AGENT_MENTION_ALIASES,
   pi: {},
+  omp: {},
 } as const satisfies Record<ProviderKind, Record<string, AgentAliasDefinition>>;
 
 // Backward compatibility for legacy call sites that still expect a flat alias table.
@@ -238,6 +239,7 @@ const AGENT_MENTION_AUTOCOMPLETE_ALIASES_BY_PROVIDER: Record<ProviderKind, reado
   kilo: [],
   opencode: [],
   pi: [],
+  omp: [],
 };
 
 function mapAgentEntries(input: Record<string, AgentAliasDefinition>): ResolvedAgentAlias[] {

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -26,6 +26,16 @@ export const PI_THINKING_LEVEL_OPTIONS = [
   "xhigh",
 ] as const;
 export type PiThinkingLevel = (typeof PI_THINKING_LEVEL_OPTIONS)[number];
+export const OMP_THINKING_LEVEL_OPTIONS = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
+export type OmpThinkingLevel = (typeof OMP_THINKING_LEVEL_OPTIONS)[number];
 export const GROK_REASONING_EFFORT_OPTIONS = ["none", "low", "medium", "high"] as const;
 export type GrokReasoningEffort = (typeof GROK_REASONING_EFFORT_OPTIONS)[number];
 export const DROID_REASONING_EFFORT_OPTIONS = [
@@ -125,6 +135,10 @@ export const PiModelOptions = Schema.Struct({
   thinkingLevel: Schema.optional(Schema.Literals(PI_THINKING_LEVEL_OPTIONS)),
 });
 export type PiModelOptions = typeof PiModelOptions.Type;
+export const OmpModelOptions = Schema.Struct({
+  thinkingLevel: Schema.optional(Schema.Literals(OMP_THINKING_LEVEL_OPTIONS)),
+});
+export type OmpModelOptions = typeof OmpModelOptions.Type;
 
 export const CursorModelOptions = Schema.Struct({
   reasoningEffort: Schema.optional(TrimmedNonEmptyString),
@@ -154,6 +168,7 @@ export const ProviderModelOptions = Schema.Struct({
   kilo: Schema.optional(OpenCodeModelOptions),
   opencode: Schema.optional(OpenCodeModelOptions),
   pi: Schema.optional(PiModelOptions),
+  omp: Schema.optional(OmpModelOptions),
 });
 export type ProviderModelOptions = typeof ProviderModelOptions.Type;
 
@@ -1011,13 +1026,14 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
       capabilities: cursorCapabilities({ efforts: ["high", "max"] }),
     },
   ],
+  omp: [],
 } as const satisfies Record<ProviderKind, readonly ModelDefinition[]>;
 export type ModelOptionsByProvider = typeof MODEL_OPTIONS_BY_PROVIDER;
 
 type BuiltInModelSlug = (typeof MODEL_OPTIONS_BY_PROVIDER)[ProviderKind][number]["slug"];
 export type ModelSlug = BuiltInModelSlug | (string & {});
 
-export type ProviderWithDefaultModel = Exclude<ProviderKind, "pi">;
+export type ProviderWithDefaultModel = Exclude<ProviderKind, "pi" | "omp">;
 
 export const DEFAULT_MODEL_BY_PROVIDER: Record<ProviderWithDefaultModel, ModelSlug> = {
   codex: "gpt-5.5",
@@ -1162,6 +1178,7 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Record<ProviderKind, Record<string,
   kilo: {},
   opencode: {},
   pi: {},
+  omp: {},
 };
 
 // ── Agent mention aliases ─────────────────────────────────────────────
@@ -1198,4 +1215,5 @@ export const PROVIDER_DISPLAY_NAMES: Record<ProviderKind, string> = {
   kilo: "Kilo",
   opencode: "OpenCode",
   pi: "Pi",
+  omp: "Oh My Pi",
 };

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -7,6 +7,7 @@ import {
   DroidModelOptions,
   GrokModelOptions,
   OpenCodeModelOptions,
+  OmpModelOptions,
   PiModelOptions,
 } from "./model";
 import { ProviderMentionReference, ProviderSkillReference } from "./providerDiscovery";
@@ -63,6 +64,7 @@ export const ProviderKind = Schema.Literals([
   "kilo",
   "opencode",
   "pi",
+  "omp",
 ]);
 export type ProviderKind = typeof ProviderKind.Type;
 export const ProviderApprovalPolicy = Schema.Literals([
@@ -143,6 +145,12 @@ export const PiModelSelection = Schema.Struct({
   options: Schema.optional(PiModelOptions),
 });
 export type PiModelSelection = typeof PiModelSelection.Type;
+export const OmpModelSelection = Schema.Struct({
+  provider: Schema.Literal("omp"),
+  model: TrimmedNonEmptyString,
+  options: Schema.optional(OmpModelOptions),
+});
+export type OmpModelSelection = typeof OmpModelSelection.Type;
 
 export const ModelSelection = Schema.Union([
   CodexModelSelection,
@@ -154,6 +162,7 @@ export const ModelSelection = Schema.Union([
   KiloModelSelection,
   OpenCodeModelSelection,
   PiModelSelection,
+  OmpModelSelection,
 ]);
 export type ModelSelection = typeof ModelSelection.Type;
 
@@ -200,6 +209,10 @@ export const PiProviderStartOptions = Schema.Struct({
   binaryPath: Schema.optional(TrimmedNonEmptyString),
   agentDir: Schema.optional(TrimmedNonEmptyString),
 });
+export const OmpProviderStartOptions = Schema.Struct({
+  binaryPath: Schema.optional(TrimmedNonEmptyString),
+  agentDir: Schema.optional(TrimmedNonEmptyString),
+});
 
 export const ProviderStartOptions = Schema.Struct({
   codex: Schema.optional(CodexProviderStartOptions),
@@ -211,6 +224,7 @@ export const ProviderStartOptions = Schema.Struct({
   kilo: Schema.optional(KiloProviderStartOptions),
   opencode: Schema.optional(OpenCodeProviderStartOptions),
   pi: Schema.optional(PiProviderStartOptions),
+  omp: Schema.optional(OmpProviderStartOptions),
 });
 export type ProviderStartOptions = typeof ProviderStartOptions.Type;
 

--- a/packages/contracts/src/providerDiscovery.ts
+++ b/packages/contracts/src/providerDiscovery.ts
@@ -17,6 +17,7 @@ const ProviderDiscoveryKind = Schema.Literals([
   "kilo",
   "opencode",
   "pi",
+  "omp",
 ]);
 
 export const ProviderSkillInterface = Schema.Struct({

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -78,6 +78,12 @@ export const PiServerProviderSettings = Schema.Struct({
   agentDir: StringSetting.pipe(Schema.withDecodingDefault(() => "")),
 });
 export type PiServerProviderSettings = typeof PiServerProviderSettings.Type;
+export const OmpServerProviderSettings = Schema.Struct({
+  ...ProviderSettingsBase,
+  binaryPath: StringSetting.pipe(Schema.withDecodingDefault(() => "omp")),
+  agentDir: StringSetting.pipe(Schema.withDecodingDefault(() => "")),
+});
+export type OmpServerProviderSettings = typeof OmpServerProviderSettings.Type;
 
 const DisabledSkillNames = Schema.Array(Schema.String.check(Schema.isMaxLength(256))).pipe(
   Schema.withDecodingDefault(() => []),
@@ -111,6 +117,7 @@ export const ServerSettings = Schema.Struct({
     kilo: KiloServerProviderSettings.pipe(Schema.withDecodingDefault(() => ({}))),
     opencode: OpenCodeServerProviderSettings.pipe(Schema.withDecodingDefault(() => ({}))),
     pi: PiServerProviderSettings.pipe(Schema.withDecodingDefault(() => ({}))),
+    omp: OmpServerProviderSettings.pipe(Schema.withDecodingDefault(() => ({}))),
   }).pipe(Schema.withDecodingDefault(() => ({}))),
   skills: SkillsServerSettings.pipe(Schema.withDecodingDefault(() => ({}))),
 });
@@ -184,6 +191,13 @@ export const ServerSettingsPatch = Schema.Struct({
         }),
       ),
       pi: Schema.optionalKey(
+        Schema.Struct({
+          ...ProviderSettingsBasePatch,
+          binaryPath: Schema.optionalKey(StringSetting),
+          agentDir: Schema.optionalKey(StringSetting),
+        }),
+      ),
+      omp: Schema.optionalKey(
         Schema.Struct({
           ...ProviderSettingsBasePatch,
           binaryPath: Schema.optionalKey(StringSetting),

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -27,6 +27,8 @@ import {
   normalizeClaudeModelOptions,
   normalizeCodexModelOptions,
   normalizeGrokModelOptions,
+  normalizeOmpModelOptions,
+  normalizePiModelOptions,
   normalizeModelSlug,
   parseCursorCliReasoningEffort,
   resolveApiModelId,
@@ -903,6 +905,37 @@ describe("normalizeAntigravityModelOptions", () => {
         runtimeCapabilities,
       ),
     ).toEqual({ reasoningEffort: "high" });
+  });
+});
+describe("normalizePiModelOptions", () => {
+  it("accepts pi thinking levels and drops max (pi-specific) plus invalid values", () => {
+    expect(normalizePiModelOptions({ thinkingLevel: "off" })).toEqual({ thinkingLevel: "off" });
+    expect(normalizePiModelOptions({ thinkingLevel: "xhigh" })).toEqual({ thinkingLevel: "xhigh" });
+    // "max" is OMP-only; pi must drop it (this is the distinction the OMP routing relies on).
+    expect(normalizePiModelOptions({ thinkingLevel: "max" as never })).toBeUndefined();
+    expect(normalizePiModelOptions({ thinkingLevel: "bogus" as never })).toBeUndefined();
+    expect(normalizePiModelOptions({ thinkingLevel: "  " as never })).toBeUndefined();
+    expect(normalizePiModelOptions(null)).toBeUndefined();
+    expect(normalizePiModelOptions(undefined)).toBeUndefined();
+    expect(normalizePiModelOptions({})).toBeUndefined();
+  });
+});
+
+describe("normalizeOmpModelOptions", () => {
+  it("accepts OMP thinking levels including max and drops invalid values", () => {
+    expect(normalizeOmpModelOptions({ thinkingLevel: "max" })).toEqual({ thinkingLevel: "max" });
+    expect(normalizeOmpModelOptions({ thinkingLevel: "xhigh" })).toEqual({
+      thinkingLevel: "xhigh",
+    });
+    expect(normalizeOmpModelOptions({ thinkingLevel: "minimal" })).toEqual({
+      thinkingLevel: "minimal",
+    });
+    expect(normalizeOmpModelOptions({ thinkingLevel: "off" })).toEqual({ thinkingLevel: "off" });
+    expect(normalizeOmpModelOptions({ thinkingLevel: "bogus" as never })).toBeUndefined();
+    expect(normalizeOmpModelOptions({ thinkingLevel: "  " as never })).toBeUndefined();
+    expect(normalizeOmpModelOptions(null)).toBeUndefined();
+    expect(normalizeOmpModelOptions(undefined)).toBeUndefined();
+    expect(normalizeOmpModelOptions({})).toBeUndefined();
   });
 });
 

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -3,6 +3,7 @@ import {
   MODEL_CAPABILITIES_INDEX,
   MODEL_OPTIONS_BY_PROVIDER,
   MODEL_SLUG_ALIASES_BY_PROVIDER,
+  OMP_THINKING_LEVEL_OPTIONS,
   type AntigravityModelOptions,
   type ClaudeApiEffort,
   type ClaudeModelOptions,
@@ -18,6 +19,8 @@ import {
   type ProviderOptionSelection,
   type PiModelOptions,
   type PiThinkingLevel,
+  type OmpModelOptions,
+  type OmpThinkingLevel,
   type ProviderKind,
   type ProviderWithDefaultModel,
   CodexReasoningEffort,
@@ -34,6 +37,7 @@ const MODEL_SLUG_SET_BY_PROVIDER: Record<ProviderKind, ReadonlySet<ModelSlug>> =
   kilo: new Set(MODEL_OPTIONS_BY_PROVIDER.kilo.map((option) => option.slug)),
   opencode: new Set(MODEL_OPTIONS_BY_PROVIDER.opencode.map((option) => option.slug)),
   pi: new Set<ModelSlug>(),
+  omp: new Set<ModelSlug>(),
 };
 
 export interface SelectableModelOption {
@@ -49,6 +53,7 @@ const PI_THINKING_LEVEL_SET = new Set<PiThinkingLevel>([
   "high",
   "xhigh",
 ]);
+const OMP_THINKING_LEVEL_SET = new Set<OmpThinkingLevel>(OMP_THINKING_LEVEL_OPTIONS);
 export const EMPTY_MODEL_CAPABILITIES: ModelCapabilities = {
   reasoningEffortLevels: [],
   supportsFastMode: false,
@@ -61,7 +66,7 @@ export function getModelOptions(provider: ProviderKind = "codex") {
 }
 
 function hasDefaultModel(provider: ProviderKind): provider is ProviderWithDefaultModel {
-  return provider !== "pi";
+  return provider !== "pi" && provider !== "omp";
 }
 
 export function getDefaultModel(provider: "pi"): null;
@@ -284,7 +289,7 @@ function reasoningDescriptorId(provider: ProviderKind): string {
   if (provider === "kilo" || provider === "opencode") {
     return "variant";
   }
-  if (provider === "pi") {
+  if (provider === "pi" || provider === "omp") {
     return "thinkingLevel";
   }
   return "reasoningEffort";
@@ -495,7 +500,7 @@ export function resolveModelSlug(
   provider: ProviderKind = "codex",
 ): ModelSlug | null {
   const normalized = normalizeModelSlug(model, provider);
-  if (provider === "pi") {
+  if (provider === "pi" || provider === "omp") {
     return normalized;
   }
   if (!normalized) {
@@ -676,6 +681,14 @@ export function normalizePiModelOptions(
   const thinkingLevel = trimOrNull(modelOptions?.thinkingLevel);
   return thinkingLevel && PI_THINKING_LEVEL_SET.has(thinkingLevel as PiThinkingLevel)
     ? { thinkingLevel: thinkingLevel as PiThinkingLevel }
+    : undefined;
+}
+export function normalizeOmpModelOptions(
+  modelOptions: OmpModelOptions | null | undefined,
+): OmpModelOptions | undefined {
+  const thinkingLevel = trimOrNull(modelOptions?.thinkingLevel);
+  return thinkingLevel && OMP_THINKING_LEVEL_SET.has(thinkingLevel as OmpThinkingLevel)
+    ? { thinkingLevel: thinkingLevel as OmpThinkingLevel }
     : undefined;
 }
 

--- a/packages/shared/src/providerMetadata.ts
+++ b/packages/shared/src/providerMetadata.ts
@@ -57,6 +57,7 @@ export const PROVIDER_DESCRIPTORS = [
     usage: null,
   },
   { kind: "pi", displayName: PROVIDER_DISPLAY_NAMES.pi, available: true, usage: null },
+  { kind: "omp", displayName: PROVIDER_DISPLAY_NAMES.omp, available: true, usage: null },
 ] as const satisfies readonly ProviderDescriptor[];
 
 export const PROVIDER_DESCRIPTOR_BY_KIND = Object.fromEntries(

--- a/packages/shared/src/serverSettings.test.ts
+++ b/packages/shared/src/serverSettings.test.ts
@@ -51,6 +51,11 @@ describe("providerStartOptionsFromServerSettings", () => {
           binaryPath: "",
           agentDir: "",
         },
+        omp: {
+          ...DEFAULT_SERVER_SETTINGS.providers.omp,
+          binaryPath: "",
+          agentDir: "",
+        },
       },
     };
 
@@ -73,6 +78,7 @@ describe("providerStartOptionsFromServerSettings", () => {
     expect(providerOptions.kilo).toEqual({});
     expect(providerOptions.opencode).toEqual({ experimentalWebSockets: false });
     expect(providerOptions.pi).toEqual({});
+    expect(providerOptions.omp).toEqual({});
   });
 
   it("preserves configured launch settings", () => {

--- a/packages/shared/src/serverSettings.ts
+++ b/packages/shared/src/serverSettings.ts
@@ -28,6 +28,7 @@ export function applyServerSettingsPatch(
     selectionPatch.model ??
     (selectionPatch.provider &&
     selectionPatch.provider !== "pi" &&
+    selectionPatch.provider !== "omp" &&
     selectionPatch.provider !== current.textGenerationModelSelection.provider
       ? DEFAULT_MODEL_BY_PROVIDER[selectionPatch.provider]
       : current.textGenerationModelSelection.model);
@@ -83,6 +84,10 @@ export function providerStartOptionsFromServerSettings(
     pi: {
       ...(providers.pi.binaryPath ? { binaryPath: providers.pi.binaryPath } : {}),
       ...(providers.pi.agentDir ? { agentDir: providers.pi.agentDir } : {}),
+    },
+    omp: {
+      ...(providers.omp.binaryPath ? { binaryPath: providers.omp.binaryPath } : {}),
+      ...(providers.omp.agentDir ? { agentDir: providers.omp.agentDir } : {}),
     },
   };
 }


### PR DESCRIPTION
Follow-up to #496 and #497. This branch adds the OMP web model catalog, thinking-level picker, and branding. It intentionally excludes the separate model-role picker in #499.

This is a cumulative branch because the web changes depend on the server/provider work in #496 and the ACP lifecycle extraction in #497. After the prerequisite PRs merge, this PR should be rebased so GitHub shows only the web delta.

Validation: focused changed web tests passed. The full repository test command still has the existing web localStorage failures reproduced on upstream main.