### PR TITLE
fix(opencode): normalize tool details before persistence

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -3830,7 +3830,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
                 input: {
                   pattern: "changelog",
                 },
-                output: "Found 18 matches",
+                output: "\nFound 18 matches\n",
                 time: {
                   start: 2,
                   end: 3,

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -3799,7 +3799,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
               callID: "task-call-1",
               state: {
                 status: "running",
-                title: "Find changelog implementation",
+                title: "\nFind changelog implementation\n",
                 input: {
                   description: "Find changelog implementation",
                   prompt: "Explore changelog files.",

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -2354,7 +2354,9 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
               rememberRelatedOpenCodeSession(context, part);
               const itemType = toToolLifecycleItemType(part.tool);
               const title =
-                part.state.status === "running" ? (part.state.title ?? part.tool) : part.tool;
+                part.state.status === "running"
+                  ? (normalizedToolDetail(part.state.title) ?? part.tool)
+                  : part.tool;
               const detail = detailFromToolPart(part);
               const payload = {
                 itemType,

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -637,14 +637,19 @@ function messageRoleForPart(
   return part.type === "tool" ? "assistant" : undefined;
 }
 
+function normalizedToolDetail(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
 function detailFromToolPart(part: Extract<Part, { type: "tool" }>): string | undefined {
   switch (part.state.status) {
     case "completed":
-      return part.state.output;
+      return normalizedToolDetail(part.state.output);
     case "error":
-      return part.state.error;
+      return normalizedToolDetail(part.state.error);
     case "running":
-      return part.state.title;
+      return normalizedToolDetail(part.state.title);
     default:
       return undefined;
   }


### PR DESCRIPTION
OpenCode tool titles, outputs, and errors can contain ordinary surrounding newlines, but the canonical ItemLifecyclePayload requires TrimmedNonEmptyString. This caused item.completed events to be quarantined before durable persistence. Normalize non-empty tool detail at the adapter boundary and add a regression fixture with newline-padded output. Focused verification: bun run --cwd apps/server test --run src/provider/Layers/OpenCodeAdapter.test.ts (64/64 passing). Browser reliability work is intentionally out of scope.

Follow-up review fix: running lifecycle titles are normalized as well, with a newline-padded running-title regression fixture.

CI note: the required Format step is failing on apps/web/src/lib/toolCallLabel.ts, which is unchanged by this PR. The latest main-branch CI run fails on the same pre-existing formatter issue; the two changed files pass scoped formatting.
