### PR TITLE
Persist stacked/split diff layout

### DIFF
--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -860,6 +860,13 @@ describe("AppSettingsSchema", () => {
     ).toBe(true);
   });
 
+  it("defaults diff render mode to split and preserves an explicit stacked preference", () => {
+    const decode = Schema.decodeSync(Schema.fromJsonString(AppSettingsSchema));
+
+    expect(decode("{}").diffRenderMode).toBe("split");
+    expect(decode(JSON.stringify({ diffRenderMode: "stacked" })).diffRenderMode).toBe("stacked");
+  });
+
   it("fills decoding defaults for persisted settings that predate newer keys", () => {
     const decode = Schema.decodeSync(Schema.fromJsonString(AppSettingsSchema));
 

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -89,6 +89,9 @@ export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "update
 export const FollowUpBehavior = Schema.Literals(["queue", "steer"]);
 export type FollowUpBehavior = typeof FollowUpBehavior.Type;
 export const DEFAULT_FOLLOW_UP_BEHAVIOR: FollowUpBehavior = "queue";
+export const DiffRenderMode = Schema.Literals(["stacked", "split"]);
+export type DiffRenderMode = typeof DiffRenderMode.Type;
+export const DEFAULT_DIFF_RENDER_MODE: DiffRenderMode = "split";
 
 export const UiDensity = Schema.Literals(UI_DENSITY_MODES);
 export type UiDensity = typeof UiDensity.Type;
@@ -208,6 +211,9 @@ export const AppSettingsSchema = Schema.Struct({
   confirmThreadDelete: Schema.Boolean.pipe(withDefaults(() => true)),
   confirmThreadArchive: Schema.Boolean.pipe(withDefaults(() => false)),
   confirmTerminalTabClose: Schema.Boolean.pipe(withDefaults(() => true)),
+  // Local-only review default for stacked vs split diffs. In-panel toggles are
+  // stored per thread separately and do not overwrite this settings value.
+  diffRenderMode: DiffRenderMode.pipe(withDefaults(() => DEFAULT_DIFF_RENDER_MODE)),
   diffWordWrap: Schema.Boolean.pipe(withDefaults(() => false)),
   // Local-only UI preferences for hiding sidebar surfaces a user doesn't want.
   // `showChatsSection` controls the standalone "Chats" list in the sidebar footer

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -43,6 +43,7 @@ import { createProjectSelector } from "../storeSelectors";
 import { inferCheckpointTurnCountByTurnId } from "../session-logic";
 import { type TimestampFormat, useAppSettings } from "../appSettings";
 import { useComposerDraftStore } from "../composerDraftStore";
+import { useDiffRenderModeStore } from "../diffRenderModeStore";
 import { DOCK_HEADER_ICON_BUTTON_CLASS, type DiffRenderMode } from "./chat/chatHeaderControls";
 import {
   areAllRenderableFilesCollapsed,
@@ -383,7 +384,6 @@ export default function DiffPanel({
   const navigate = useNavigate();
   const { resolvedTheme } = useTheme();
   const { settings } = useAppSettings();
-  const [diffRenderMode, setDiffRenderMode] = useState<DiffRenderMode>("split");
   const [diffWordWrap, setDiffWordWrap] = useState(settings.diffWordWrap);
   const [diffIgnoreWhitespace, setDiffIgnoreWhitespace] = useState(true);
   const [scopePickerOpen, setScopePickerOpen] = useState(false);
@@ -436,6 +436,20 @@ export default function DiffPanel({
     [diffQueriesEnabled, scopePickerOpen],
   );
   const activeThreadId = controlledThreadId ?? routeThreadId;
+  // Per-thread panel override; Settings.diffRenderMode is only the fallback default.
+  const diffRenderMode = useDiffRenderModeStore((store) =>
+    store.getModeForThread(activeThreadId, settings.diffRenderMode),
+  );
+  const setModeForThread = useDiffRenderModeStore((store) => store.setModeForThread);
+  const setDiffRenderMode = useCallback(
+    (mode: DiffRenderMode) => {
+      if (!activeThreadId) {
+        return;
+      }
+      setModeForThread(activeThreadId, mode);
+    },
+    [activeThreadId, setModeForThread],
+  );
   const serverThreadCatalog = useStore(
     useMemo(() => createDiffPanelThreadCatalogSelector(activeThreadId), [activeThreadId]),
   );
@@ -1090,6 +1104,7 @@ export default function DiffPanel({
       selectRepoScope,
       selectTurn,
       selectedTurnId,
+      setDiffRenderMode,
       settings.timestampFormat,
       toggleCollapseAll,
     ],
@@ -1197,6 +1212,7 @@ export default function DiffPanel({
       selectTurn,
       selectedFilePath,
       selectedTurnId,
+      setDiffRenderMode,
       settings.timestampFormat,
       showDiffToolbar,
       toggleCollapseAll,

--- a/apps/web/src/components/SettingsSidebarNav.test.tsx
+++ b/apps/web/src/components/SettingsSidebarNav.test.tsx
@@ -30,6 +30,11 @@ describe("rankSettingsSearchEntries", () => {
     expect(results.some((entry) => entry.id === "behavior:diff-line-wrapping")).toBe(true);
   });
 
+  it("indexes the stacked and split diff layout preference", () => {
+    const results = rankSettingsSearchEntries("stacked", 12);
+    expect(results.some((entry) => entry.id === "behavior:diff-layout")).toBe(true);
+  });
+
   it("indexes the follow-up Queue and Steer preference", () => {
     const results = rankSettingsSearchEntries("steer", 12);
     expect(results.some((entry) => entry.id === "behavior:follow-up-behavior")).toBe(true);

--- a/apps/web/src/diffRenderModeStore.test.ts
+++ b/apps/web/src/diffRenderModeStore.test.ts
@@ -1,0 +1,51 @@
+// FILE: diffRenderModeStore.test.ts
+// Purpose: Pins per-thread diff layout persistence separate from the Settings default.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useDiffRenderModeStore } from "./diffRenderModeStore";
+
+const ORIGINAL_LOCAL_STORAGE = globalThis.localStorage;
+
+function createMemoryStorage(): Storage {
+  const storage = new Map<string, string>();
+  return {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+    clear: () => {
+      storage.clear();
+    },
+    key: (index: number) => [...storage.keys()][index] ?? null,
+    get length() {
+      return storage.size;
+    },
+  } as Storage;
+}
+
+describe("useDiffRenderModeStore", () => {
+  beforeEach(() => {
+    globalThis.localStorage = createMemoryStorage();
+    useDiffRenderModeStore.setState({ modeByThreadId: {} });
+  });
+
+  afterEach(() => {
+    globalThis.localStorage = ORIGINAL_LOCAL_STORAGE;
+  });
+
+  it("falls back to the settings default when a thread has no override", () => {
+    expect(useDiffRenderModeStore.getState().getModeForThread("thread-a", "split")).toBe("split");
+    expect(useDiffRenderModeStore.getState().getModeForThread(null, "stacked")).toBe("stacked");
+  });
+
+  it("remembers a per-thread override without affecting other threads", () => {
+    useDiffRenderModeStore.getState().setModeForThread("thread-a", "stacked");
+
+    expect(useDiffRenderModeStore.getState().getModeForThread("thread-a", "split")).toBe("stacked");
+    expect(useDiffRenderModeStore.getState().getModeForThread("thread-b", "split")).toBe("split");
+  });
+});

--- a/apps/web/src/diffRenderModeStore.ts
+++ b/apps/web/src/diffRenderModeStore.ts
@@ -1,0 +1,70 @@
+// FILE: diffRenderModeStore.ts
+// Purpose: Persists per-thread stacked/split diff layout choices separately from the
+//          Settings default, so in-panel toggles survive thread switches without
+//          overwriting the configurable default.
+// Layer: Web UI state store
+// Exports: per-thread diff render mode store helpers
+
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+import type { DiffRenderMode } from "./appSettings";
+import { sanitizeStringKeyedRecord } from "./persistedRecord";
+
+const DIFF_RENDER_MODE_STORAGE_KEY = "synara:diff-render-mode-by-thread:v1";
+
+function isDiffRenderMode(value: unknown): value is DiffRenderMode {
+  return value === "stacked" || value === "split";
+}
+
+interface DiffRenderModeStore {
+  modeByThreadId: Record<string, DiffRenderMode>;
+  getModeForThread: (threadId: string | null, fallback: DiffRenderMode) => DiffRenderMode;
+  setModeForThread: (threadId: string, mode: DiffRenderMode) => void;
+}
+
+export const useDiffRenderModeStore = create<DiffRenderModeStore>()(
+  persist(
+    (set, get) => ({
+      modeByThreadId: {},
+      getModeForThread: (threadId, fallback) => {
+        if (!threadId) {
+          return fallback;
+        }
+        return get().modeByThreadId[threadId] ?? fallback;
+      },
+      setModeForThread: (threadId, mode) =>
+        set((state) => ({
+          modeByThreadId: {
+            ...state.modeByThreadId,
+            [threadId]: mode,
+          },
+        })),
+    }),
+    {
+      name: DIFF_RENDER_MODE_STORAGE_KEY,
+      // Resolve storage through globalThis on each call so tests can replace
+      // localStorage after this module has already been evaluated.
+      storage: createJSONStorage(() => ({
+        getItem: (name) => globalThis.localStorage.getItem(name),
+        setItem: (name, value) => {
+          globalThis.localStorage.setItem(name, value);
+        },
+        removeItem: (name) => {
+          globalThis.localStorage.removeItem(name);
+        },
+      })),
+      partialize: (state) => ({ modeByThreadId: state.modeByThreadId }),
+      merge: (persisted, current) => {
+        const persistedModes = (persisted as { modeByThreadId?: unknown } | undefined)
+          ?.modeByThreadId;
+        return {
+          ...current,
+          modeByThreadId: sanitizeStringKeyedRecord(persistedModes, (value) =>
+            isDiffRenderMode(value) ? value : null,
+          ),
+        };
+      },
+    },
+  ),
+);

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -11,6 +11,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import {
   type AppSettings,
+  type DiffRenderMode,
   type FollowUpBehavior,
   DEFAULT_UI_DENSITY,
   type UiDensity,
@@ -164,6 +165,11 @@ const FOLLOW_UP_BEHAVIOR_OPTIONS = [
   { value: "steer", label: "Steer" },
 ] as const satisfies ReadonlyArray<{ value: FollowUpBehavior; label: string }>;
 
+const DIFF_RENDER_MODE_OPTIONS = [
+  { value: "stacked", label: "Stacked" },
+  { value: "split", label: "Split" },
+] as const satisfies ReadonlyArray<{ value: DiffRenderMode; label: string }>;
+
 // ── Settings UI primitives ────────────────────────────────────────────────
 
 // Shared settings controls live in ~/components/settings/SettingControls.
@@ -267,6 +273,7 @@ function SettingsRouteView() {
     ...(settings.enableProviderUpdateChecks !== defaults.enableProviderUpdateChecks
       ? ["Provider update checks"]
       : []),
+    ...(settings.diffRenderMode !== defaults.diffRenderMode ? ["Diff layout"] : []),
     ...(settings.diffWordWrap !== defaults.diffWordWrap ? ["Diff line wrapping"] : []),
     ...(settings.confirmThreadDelete !== defaults.confirmThreadDelete
       ? ["Delete confirmation"]
@@ -954,6 +961,31 @@ function SettingsRouteView() {
       </SettingsSection>
 
       <SettingsSection title="Review">
+        <SettingsRow
+          title="Diff layout"
+          description="Default stacked or split layout for threads that have not chosen one in the review panel. In-panel changes are remembered per thread and do not update this default."
+          resetAction={
+            settings.diffRenderMode !== defaults.diffRenderMode ? (
+              <SettingResetButton
+                label="diff layout"
+                onClick={() =>
+                  updateSettings({
+                    diffRenderMode: defaults.diffRenderMode,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <SettingsSegmentedControl
+              value={settings.diffRenderMode}
+              onValueChange={(value) => updateSettings({ diffRenderMode: value })}
+              ariaLabel="Diff layout"
+              options={DIFF_RENDER_MODE_OPTIONS}
+            />
+          }
+        />
+
         {renderBooleanSettingRow({
           settingKey: "diffWordWrap",
           title: "Diff line wrapping",

--- a/apps/web/src/settingsSearchIndex.ts
+++ b/apps/web/src/settingsSearchIndex.ts
@@ -259,6 +259,13 @@ export const SETTINGS_SEARCH_ENTRIES: readonly SettingsSearchEntry[] = [
     keywords: "Show token-by-token output while a response is in progress. streaming",
   },
   {
+    id: "behavior:diff-layout",
+    section: "behavior",
+    title: "Diff layout",
+    keywords:
+      "Default stacked or split layout for threads. review panel side by side unified per thread",
+  },
+  {
     id: "behavior:diff-line-wrapping",
     section: "behavior",
     title: "Diff line wrapping",


### PR DESCRIPTION
## Summary
- Persists in-panel Stacked/Split choice **per thread** in local storage so it survives navigation without overwriting the Settings default.
- Adds a Settings → Behavior → Review **Diff layout** default (`stacked` / `split`, default split).
- New threads fall back to the Settings default until the panel is toggled.