### PR TITLE
fix: autofocus project picker search on open

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -5479,6 +5479,46 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("focuses and keyboard-selects from the new-thread project picker", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: withOpenProjectPickerFixtures(
+        createSnapshotForTargetUser({
+          targetMessageId: "msg-user-project-picker-keyboard-test" as MessageId,
+          targetText: "project picker keyboard test",
+        }),
+      ),
+    });
+
+    try {
+      await page.getByLabelText("Create new thread in Project").click();
+      const newThreadPath = await waitForURL(
+        mounted.router,
+        (path) => UUID_ROUTE_RE.test(path),
+        "Route should have changed to a new draft thread UUID.",
+      );
+      const newThreadId = newThreadPath.slice(1) as ThreadId;
+
+      await page.getByTestId("project-picker-trigger").click();
+      const searchInput = page.getByPlaceholder("Search projects");
+      await vi.waitFor(() => {
+        expect(document.activeElement).toBe(searchInput.element());
+      });
+
+      await searchInput.fill("oth");
+      await userEvent.keyboard("{ArrowDown}{Enter}");
+
+      await vi.waitFor(() => {
+        expect(useComposerDraftStore.getState().getDraftThread(newThreadId)).toMatchObject({
+          projectId: OTHER_PROJECT_ID,
+        });
+      });
+      expect(mounted.router.state.location.pathname).toBe(newThreadPath);
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("coalesces repeated Studio new-chat clicks and stays in Studio after navigation settles", async () => {
     useComposerDraftStore.setState({
       draftThreadsByThreadId: {

--- a/apps/web/src/components/chat/PickerPanelShell.tsx
+++ b/apps/web/src/components/chat/PickerPanelShell.tsx
@@ -28,6 +28,7 @@ export function PickerPanelShell(props: {
   searchPlaceholder?: string;
   query?: string;
   onQueryChange?: (query: string) => void;
+  searchInput?: ReactNode;
   stopSearchKeyPropagation?: boolean;
   autoFocusSearch?: boolean;
   children: ReactNode;
@@ -40,6 +41,7 @@ export function PickerPanelShell(props: {
     searchPlaceholder: searchPlaceholderProp,
     query: queryProp,
     onQueryChange,
+    searchInput,
     stopSearchKeyPropagation: stopSearchKeyPropagationProp,
     autoFocusSearch: autoFocusSearchProp,
     children,
@@ -78,7 +80,7 @@ export function PickerPanelShell(props: {
         bleedParentPadding ? cn("-m-1 overflow-clip", COMPOSER_PICKER_RADIUS_CLASS_NAME) : null,
       )}
     >
-      {onQueryChange ? (
+      {onQueryChange || searchInput ? (
         <div
           className={cn(
             bleedParentPadding
@@ -86,28 +88,30 @@ export function PickerPanelShell(props: {
               : "sticky top-0 z-20 shrink-0 border-b border-border bg-[var(--composer-surface)] p-1",
           )}
         >
-          <Input
-            className={cn(
-              "rounded-md border-border/60 shadow-none before:hidden has-focus-visible:border-neutral-500/15 has-focus-visible:ring-0 [&_input]:font-sans",
-              bleedParentPadding ? COMPOSER_PICKER_SEARCH_INPUT_CLASS_NAME : "bg-background",
-            )}
-            nativeInput
-            ref={searchInputRef}
-            size="sm"
-            type="search"
-            placeholder={searchPlaceholder}
-            value={query}
-            onChange={(event) => onQueryChange(event.target.value)}
-            onKeyDownCapture={
-              stopSearchKeyPropagation
-                ? (event) => {
-                    if (!MENU_NAVIGATION_KEYS.has(event.key)) {
-                      event.stopPropagation();
+          {searchInput ?? (
+            <Input
+              className={cn(
+                "rounded-md border-border/60 shadow-none before:hidden has-focus-visible:border-neutral-500/15 has-focus-visible:ring-0 [&_input]:font-sans",
+                bleedParentPadding ? COMPOSER_PICKER_SEARCH_INPUT_CLASS_NAME : "bg-background",
+              )}
+              nativeInput
+              ref={searchInputRef}
+              size="sm"
+              type="search"
+              placeholder={searchPlaceholder}
+              value={query}
+              onChange={(event) => onQueryChange?.(event.target.value)}
+              onKeyDownCapture={
+                stopSearchKeyPropagation
+                  ? (event) => {
+                      if (!MENU_NAVIGATION_KEYS.has(event.key)) {
+                        event.stopPropagation();
+                      }
                     }
-                  }
-                : undefined
-            }
-          />
+                  : undefined
+              }
+            />
+          )}
         </div>
       ) : null}
       <div

--- a/apps/web/src/components/chat/ProjectPicker.tsx
+++ b/apps/web/src/components/chat/ProjectPicker.tsx
@@ -27,12 +27,12 @@ import { ELEVATED_HOVER_SURFACE_CLASS_NAME } from "~/surfaceStyles";
 import { FolderClosed } from "../FolderClosed";
 import { SpaceIcon } from "../SpaceIcon";
 import { PickerTriggerButton } from "./PickerTriggerButton";
-import { PickerPanelShell } from "./PickerPanelShell";
 import {
   Combobox,
   ComboboxEmpty,
   ComboboxGroup,
   ComboboxGroupLabel,
+  ComboboxInput,
   ComboboxItem,
   ComboboxList,
   ComboboxPopup,
@@ -617,101 +617,106 @@ export const ProjectPicker = memo(function ProjectPicker({
           ) : null}
         </div>
       )}
-      <ComboboxPopup align={align} side={side} className="p-0">
-        <PickerPanelShell
-          searchPlaceholder={searchPlaceholder}
-          query={query}
-          onQueryChange={setQuery}
-          footer={
-            <>
-              <button
-                type="button"
-                className={cn(
-                  PICKER_FOOTER_ACTION_CLASS_NAME,
-                  "disabled:cursor-not-allowed disabled:opacity-60",
-                )}
-                onClick={() => void handleAddNewProject()}
-                disabled={isPicking}
-              >
-                <PlusIcon className="size-3.5 shrink-0 text-muted-foreground/70" />
-                <span className="truncate">
-                  {isPicking ? loadingAddProjectLabel : addProjectLabel}
-                </span>
-              </button>
-              {shouldShowResetToHome ? (
-                <button
-                  type="button"
-                  className={PICKER_FOOTER_ACTION_CLASS_NAME}
-                  onClick={handleResetToHome}
+      <ComboboxPopup align={align} side={side} className="w-72 p-0">
+        {/* ComboboxInput (not a plain Input) so Base UI autofocuses it on open and
+            Arrow/Enter keep driving list highlight + selection while typing to filter. */}
+        <div className="sticky top-0 z-20 shrink-0 border-b border-border bg-[var(--composer-surface)] p-1">
+          <ComboboxInput
+            className="rounded-md border-border/60 bg-background shadow-none before:hidden has-focus-visible:border-neutral-500/15 has-focus-visible:ring-0 [&_input]:font-sans"
+            inputClassName="ring-0"
+            placeholder={searchPlaceholder}
+            showTrigger={false}
+            size="sm"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+        </div>
+        <ComboboxEmpty>
+          {isLoadingDirectories
+            ? "Loading folders…"
+            : activeFolderOptions.length === 0 && localFolderOptions.length === 0
+              ? "No folders found"
+              : "No matches"}
+        </ComboboxEmpty>
+        <ComboboxList className="max-h-64">
+          {filteredActiveFolderGroups.map((group, groupIndex) => {
+            const precedingOptionCount = filteredActiveFolderGroups
+              .slice(0, groupIndex)
+              .reduce((count, candidate) => count + candidate.items.length, 0);
+            return (
+              <Fragment key={group.key}>
+                {groupIndex > 0 ? <ComboboxSeparator /> : null}
+                <ComboboxGroup>
+                  <ComboboxGroupLabel className="flex items-center gap-1.5">
+                    <SpaceIcon icon={group.icon} className="size-3 shrink-0" />
+                    <span className="min-w-0 truncate">{group.label}</span>
+                  </ComboboxGroupLabel>
+                  {group.items.map((folder, index) =>
+                    renderActiveFolderOption(folder, precedingOptionCount + index),
+                  )}
+                </ComboboxGroup>
+              </Fragment>
+            );
+          })}
+          {filteredActiveFolderOptions.length > 0 && filteredLocalFolderOptions.length > 0 ? (
+            <ComboboxSeparator />
+          ) : null}
+          {filteredLocalFolderOptions.length > 0 ? (
+            <ComboboxGroup>
+              <ComboboxGroupLabel>{localFoldersGroupLabel}</ComboboxGroupLabel>
+              {filteredLocalFolderOptions.map(({ absolutePath, entry }, index) => (
+                <ComboboxItem
+                  hideIndicator={absolutePath !== selectedWorkspaceRoot}
+                  key={absolutePath}
+                  index={filteredActiveFolderOptions.length + index}
+                  value={absolutePath}
+                  onClick={() => {
+                    onSelectWorkspaceRoot?.(absolutePath);
+                    setOpen(false);
+                  }}
+                  className={cn(
+                    absolutePath === selectedWorkspaceRoot &&
+                      "bg-[var(--color-background-elevated-secondary)] text-[var(--color-text-foreground)]",
+                  )}
                 >
-                  <XIcon className="size-3.5 shrink-0 text-muted-foreground/70" />
-                  <span className="truncate">{resetActionLabel}</span>
-                </button>
-              ) : null}
-              {errorMessage ? (
-                <div className="px-2 pb-1 text-destructive text-xs">{errorMessage}</div>
-              ) : null}
-            </>
-          }
-        >
-          <ComboboxEmpty>
-            {isLoadingDirectories
-              ? "Loading folders…"
-              : activeFolderOptions.length === 0 && localFolderOptions.length === 0
-                ? "No folders found"
-                : "No matches"}
-          </ComboboxEmpty>
-          <ComboboxList className="max-h-64">
-            {filteredActiveFolderGroups.map((group, groupIndex) => {
-              const precedingOptionCount = filteredActiveFolderGroups
-                .slice(0, groupIndex)
-                .reduce((count, candidate) => count + candidate.items.length, 0);
-              return (
-                <Fragment key={group.key}>
-                  {groupIndex > 0 ? <ComboboxSeparator /> : null}
-                  <ComboboxGroup>
-                    <ComboboxGroupLabel className="flex items-center gap-1.5">
-                      <SpaceIcon icon={group.icon} className="size-3 shrink-0" />
-                      <span className="min-w-0 truncate">{group.label}</span>
-                    </ComboboxGroupLabel>
-                    {group.items.map((folder, index) =>
-                      renderActiveFolderOption(folder, precedingOptionCount + index),
-                    )}
-                  </ComboboxGroup>
-                </Fragment>
-              );
-            })}
-            {filteredActiveFolderOptions.length > 0 && filteredLocalFolderOptions.length > 0 ? (
-              <ComboboxSeparator />
-            ) : null}
-            {filteredLocalFolderOptions.length > 0 ? (
-              <ComboboxGroup>
-                <ComboboxGroupLabel>{localFoldersGroupLabel}</ComboboxGroupLabel>
-                {filteredLocalFolderOptions.map(({ absolutePath, entry }, index) => (
-                  <ComboboxItem
-                    hideIndicator={absolutePath !== selectedWorkspaceRoot}
-                    key={absolutePath}
-                    index={filteredActiveFolderOptions.length + index}
-                    value={absolutePath}
-                    onClick={() => {
-                      onSelectWorkspaceRoot?.(absolutePath);
-                      setOpen(false);
-                    }}
-                    className={cn(
-                      absolutePath === selectedWorkspaceRoot &&
-                        "bg-[var(--color-background-elevated-secondary)] text-[var(--color-text-foreground)]",
-                    )}
-                  >
-                    <div className="flex min-w-0 items-center gap-2">
-                      <FolderClosed className="size-3.5 shrink-0 text-muted-foreground/70" />
-                      <span className="truncate">{entry.name}</span>
-                    </div>
-                  </ComboboxItem>
-                ))}
-              </ComboboxGroup>
-            ) : null}
-          </ComboboxList>
-        </PickerPanelShell>
+                  <div className="flex min-w-0 items-center gap-2">
+                    <FolderClosed className="size-3.5 shrink-0 text-muted-foreground/70" />
+                    <span className="truncate">{entry.name}</span>
+                  </div>
+                </ComboboxItem>
+              ))}
+            </ComboboxGroup>
+          ) : null}
+        </ComboboxList>
+        <div className="border-t p-1">
+          <button
+            type="button"
+            className={cn(
+              PICKER_FOOTER_ACTION_CLASS_NAME,
+              "disabled:cursor-not-allowed disabled:opacity-60",
+            )}
+            onClick={() => void handleAddNewProject()}
+            disabled={isPicking}
+          >
+            <PlusIcon className="size-3.5 shrink-0 text-muted-foreground/70" />
+            <span className="truncate">
+              {isPicking ? loadingAddProjectLabel : addProjectLabel}
+            </span>
+          </button>
+          {shouldShowResetToHome ? (
+            <button
+              type="button"
+              className={PICKER_FOOTER_ACTION_CLASS_NAME}
+              onClick={handleResetToHome}
+            >
+              <XIcon className="size-3.5 shrink-0 text-muted-foreground/70" />
+              <span className="truncate">{resetActionLabel}</span>
+            </button>
+          ) : null}
+          {errorMessage ? (
+            <div className="px-2 pb-1 text-destructive text-xs">{errorMessage}</div>
+          ) : null}
+        </div>
       </ComboboxPopup>
     </Combobox>
   );

--- a/apps/web/src/components/chat/ProjectPicker.tsx
+++ b/apps/web/src/components/chat/ProjectPicker.tsx
@@ -699,9 +699,7 @@ export const ProjectPicker = memo(function ProjectPicker({
             disabled={isPicking}
           >
             <PlusIcon className="size-3.5 shrink-0 text-muted-foreground/70" />
-            <span className="truncate">
-              {isPicking ? loadingAddProjectLabel : addProjectLabel}
-            </span>
+            <span className="truncate">{isPicking ? loadingAddProjectLabel : addProjectLabel}</span>
           </button>
           {shouldShowResetToHome ? (
             <button

--- a/apps/web/src/components/chat/ProjectPicker.tsx
+++ b/apps/web/src/components/chat/ProjectPicker.tsx
@@ -26,6 +26,7 @@ import { cn } from "~/lib/utils";
 import { ELEVATED_HOVER_SURFACE_CLASS_NAME } from "~/surfaceStyles";
 import { FolderClosed } from "../FolderClosed";
 import { SpaceIcon } from "../SpaceIcon";
+import { PickerPanelShell } from "./PickerPanelShell";
 import { PickerTriggerButton } from "./PickerTriggerButton";
 import {
   Combobox,
@@ -617,104 +618,109 @@ export const ProjectPicker = memo(function ProjectPicker({
           ) : null}
         </div>
       )}
-      <ComboboxPopup align={align} side={side} className="w-72 p-0">
-        {/* ComboboxInput (not a plain Input) so Base UI autofocuses it on open and
-            Arrow/Enter keep driving list highlight + selection while typing to filter. */}
-        <div className="sticky top-0 z-20 shrink-0 border-b border-border bg-[var(--composer-surface)] p-1">
-          <ComboboxInput
-            className="rounded-md border-border/60 bg-background shadow-none before:hidden has-focus-visible:border-neutral-500/15 has-focus-visible:ring-0 [&_input]:font-sans"
-            inputClassName="ring-0"
-            placeholder={searchPlaceholder}
-            showTrigger={false}
-            size="sm"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-          />
-        </div>
-        <ComboboxEmpty>
-          {isLoadingDirectories
-            ? "Loading folders…"
-            : activeFolderOptions.length === 0 && localFolderOptions.length === 0
-              ? "No folders found"
-              : "No matches"}
-        </ComboboxEmpty>
-        <ComboboxList className="max-h-64">
-          {filteredActiveFolderGroups.map((group, groupIndex) => {
-            const precedingOptionCount = filteredActiveFolderGroups
-              .slice(0, groupIndex)
-              .reduce((count, candidate) => count + candidate.items.length, 0);
-            return (
-              <Fragment key={group.key}>
-                {groupIndex > 0 ? <ComboboxSeparator /> : null}
-                <ComboboxGroup>
-                  <ComboboxGroupLabel className="flex items-center gap-1.5">
-                    <SpaceIcon icon={group.icon} className="size-3 shrink-0" />
-                    <span className="min-w-0 truncate">{group.label}</span>
-                  </ComboboxGroupLabel>
-                  {group.items.map((folder, index) =>
-                    renderActiveFolderOption(folder, precedingOptionCount + index),
-                  )}
-                </ComboboxGroup>
-              </Fragment>
-            );
-          })}
-          {filteredActiveFolderOptions.length > 0 && filteredLocalFolderOptions.length > 0 ? (
-            <ComboboxSeparator />
-          ) : null}
-          {filteredLocalFolderOptions.length > 0 ? (
-            <ComboboxGroup>
-              <ComboboxGroupLabel>{localFoldersGroupLabel}</ComboboxGroupLabel>
-              {filteredLocalFolderOptions.map(({ absolutePath, entry }, index) => (
-                <ComboboxItem
-                  hideIndicator={absolutePath !== selectedWorkspaceRoot}
-                  key={absolutePath}
-                  index={filteredActiveFolderOptions.length + index}
-                  value={absolutePath}
-                  onClick={() => {
-                    onSelectWorkspaceRoot?.(absolutePath);
-                    setOpen(false);
-                  }}
-                  className={cn(
-                    absolutePath === selectedWorkspaceRoot &&
-                      "bg-[var(--color-background-elevated-secondary)] text-[var(--color-text-foreground)]",
-                  )}
+      <ComboboxPopup align={align} side={side} className="p-0">
+        <PickerPanelShell
+          searchInput={
+            <ComboboxInput
+              className="rounded-md border-border/60 bg-background shadow-none before:hidden has-focus-visible:border-neutral-500/15 has-focus-visible:ring-0 [&_input]:font-sans"
+              inputClassName="ring-0"
+              placeholder={searchPlaceholder}
+              showTrigger={false}
+              size="sm"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+          }
+          footer={
+            <>
+              <button
+                type="button"
+                className={cn(
+                  PICKER_FOOTER_ACTION_CLASS_NAME,
+                  "disabled:cursor-not-allowed disabled:opacity-60",
+                )}
+                onClick={() => void handleAddNewProject()}
+                disabled={isPicking}
+              >
+                <PlusIcon className="size-3.5 shrink-0 text-muted-foreground/70" />
+                <span className="truncate">
+                  {isPicking ? loadingAddProjectLabel : addProjectLabel}
+                </span>
+              </button>
+              {shouldShowResetToHome ? (
+                <button
+                  type="button"
+                  className={PICKER_FOOTER_ACTION_CLASS_NAME}
+                  onClick={handleResetToHome}
                 >
-                  <div className="flex min-w-0 items-center gap-2">
-                    <FolderClosed className="size-3.5 shrink-0 text-muted-foreground/70" />
-                    <span className="truncate">{entry.name}</span>
-                  </div>
-                </ComboboxItem>
-              ))}
-            </ComboboxGroup>
-          ) : null}
-        </ComboboxList>
-        <div className="border-t p-1">
-          <button
-            type="button"
-            className={cn(
-              PICKER_FOOTER_ACTION_CLASS_NAME,
-              "disabled:cursor-not-allowed disabled:opacity-60",
-            )}
-            onClick={() => void handleAddNewProject()}
-            disabled={isPicking}
-          >
-            <PlusIcon className="size-3.5 shrink-0 text-muted-foreground/70" />
-            <span className="truncate">{isPicking ? loadingAddProjectLabel : addProjectLabel}</span>
-          </button>
-          {shouldShowResetToHome ? (
-            <button
-              type="button"
-              className={PICKER_FOOTER_ACTION_CLASS_NAME}
-              onClick={handleResetToHome}
-            >
-              <XIcon className="size-3.5 shrink-0 text-muted-foreground/70" />
-              <span className="truncate">{resetActionLabel}</span>
-            </button>
-          ) : null}
-          {errorMessage ? (
-            <div className="px-2 pb-1 text-destructive text-xs">{errorMessage}</div>
-          ) : null}
-        </div>
+                  <XIcon className="size-3.5 shrink-0 text-muted-foreground/70" />
+                  <span className="truncate">{resetActionLabel}</span>
+                </button>
+              ) : null}
+              {errorMessage ? (
+                <div className="px-2 pb-1 text-destructive text-xs">{errorMessage}</div>
+              ) : null}
+            </>
+          }
+        >
+          <ComboboxEmpty>
+            {isLoadingDirectories
+              ? "Loading folders…"
+              : activeFolderOptions.length === 0 && localFolderOptions.length === 0
+                ? "No folders found"
+                : "No matches"}
+          </ComboboxEmpty>
+          <ComboboxList className="max-h-64">
+            {filteredActiveFolderGroups.map((group, groupIndex) => {
+              const precedingOptionCount = filteredActiveFolderGroups
+                .slice(0, groupIndex)
+                .reduce((count, candidate) => count + candidate.items.length, 0);
+              return (
+                <Fragment key={group.key}>
+                  {groupIndex > 0 ? <ComboboxSeparator /> : null}
+                  <ComboboxGroup>
+                    <ComboboxGroupLabel className="flex items-center gap-1.5">
+                      <SpaceIcon icon={group.icon} className="size-3 shrink-0" />
+                      <span className="min-w-0 truncate">{group.label}</span>
+                    </ComboboxGroupLabel>
+                    {group.items.map((folder, index) =>
+                      renderActiveFolderOption(folder, precedingOptionCount + index),
+                    )}
+                  </ComboboxGroup>
+                </Fragment>
+              );
+            })}
+            {filteredActiveFolderOptions.length > 0 && filteredLocalFolderOptions.length > 0 ? (
+              <ComboboxSeparator />
+            ) : null}
+            {filteredLocalFolderOptions.length > 0 ? (
+              <ComboboxGroup>
+                <ComboboxGroupLabel>{localFoldersGroupLabel}</ComboboxGroupLabel>
+                {filteredLocalFolderOptions.map(({ absolutePath, entry }, index) => (
+                  <ComboboxItem
+                    hideIndicator={absolutePath !== selectedWorkspaceRoot}
+                    key={absolutePath}
+                    index={filteredActiveFolderOptions.length + index}
+                    value={absolutePath}
+                    onClick={() => {
+                      onSelectWorkspaceRoot?.(absolutePath);
+                      setOpen(false);
+                    }}
+                    className={cn(
+                      absolutePath === selectedWorkspaceRoot &&
+                        "bg-[var(--color-background-elevated-secondary)] text-[var(--color-text-foreground)]",
+                    )}
+                  >
+                    <div className="flex min-w-0 items-center gap-2">
+                      <FolderClosed className="size-3.5 shrink-0 text-muted-foreground/70" />
+                      <span className="truncate">{entry.name}</span>
+                    </div>
+                  </ComboboxItem>
+                ))}
+              </ComboboxGroup>
+            ) : null}
+          </ComboboxList>
+        </PickerPanelShell>
       </ComboboxPopup>
     </Combobox>
   );


### PR DESCRIPTION
## What Changed

- Opening the new-thread project picker now focuses the **Search projects** field immediately so you can type to filter without an extra click.
- Switched the popup search from a plain input (`PickerPanelShell`) to `ComboboxInput`, matching the branch picker pattern so Base UI owns focus and keyboard handling.

## Why

The project picker already had a search box, but focus stayed on the trigger after open. A plain input inside the Combobox popup also broke arrow-key list navigation while typing. Using `ComboboxInput` in the popup fixes both: autofocus on open, and Arrow/Enter still highlight and select projects.

## UI Changes

Interaction-only (no visual redesign): open the project selector on a new thread — the search field should be focused; typing filters; arrow keys move the highlight; Enter selects.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes