### PR TITLE
fix: exempt reviewed T3 attribution lines from brand:check

### DIFF
--- a/scripts/check-brand-identity.test.ts
+++ b/scripts/check-brand-identity.test.ts
@@ -27,7 +27,7 @@ describe("brand identity guard", () => {
     ).toEqual([]);
   });
 
-  it("rejects retired identity in legal notices", () => {
+  it("allows the reviewed legal attribution lines only in their approved files", () => {
     const notice = `Copyright (c) 2026 ${characters(84, 51)} ${characters(
       84,
       111,
@@ -35,9 +35,28 @@ describe("brand identity guard", () => {
       108,
       115,
     )} Inc.`;
-    expect(findBrandIdentityViolations([{ path: "LICENSE", contents: notice }])).toHaveLength(1);
+    expect(findBrandIdentityViolations([{ path: "LICENSE", contents: notice }])).toEqual([]);
     expect(
       findBrandIdentityViolations([{ path: "docs/license-copy.md", contents: notice }]),
+    ).toHaveLength(1);
+  });
+
+  it("rejects edited variants of an approved attribution line", () => {
+    const editedNotice = `Copyright (c) 2027 ${characters(84, 51)} ${characters(
+      84,
+      111,
+      111,
+      108,
+      115,
+    )} Inc.`;
+    expect(findBrandIdentityViolations([{ path: "LICENSE", contents: editedNotice }])).toHaveLength(
+      1,
+    );
+  });
+
+  it("rejects retired identity elsewhere in an approved file", () => {
+    expect(
+      findBrandIdentityViolations([{ path: "LICENSE", contents: `made by ${firstName}` }]),
     ).toHaveLength(1);
   });
 

--- a/scripts/check-brand-identity.ts
+++ b/scripts/check-brand-identity.ts
@@ -42,6 +42,22 @@ const forbiddenPatterns = [
   new RegExp(escapeRegExp(incorrectBundleDomain), "i"),
 ] as const;
 
+// Legally required attribution keeps the retired identity, but only as the
+// exact lines reviewed here. Any other occurrence — or any edit to these
+// lines — still fails, so loosening the attribution requires updating this
+// allowlist in the same change.
+const retiredCompanyDisplayName = `${characters(84, 51)} ${characters(84, 111, 111, 108, 115)} Inc.`;
+const retiredFirstDisplayName = `${characters(84, 51)}${characters(67, 111, 100, 101)}`;
+const approvedAttributionLines = new Map<string, ReadonlySet<string>>([
+  ["LICENSE", new Set([`Copyright (c) 2026 ${retiredCompanyDisplayName}`])],
+  [
+    "README.md",
+    new Set([
+      `Synara began as a clone of [${retiredFirstDisplayName}](https://github.com/pingdotgg/${retiredFirstName}), but it has since become a substantially different product with its own branding, packaging, release system, provider orchestration, desktop app behavior, and product direction.`,
+    ]),
+  ],
+]);
+
 // Raster images cannot be searched for embedded text. Keep the user-facing
 // screenshots behind reviewed digests so changing either one requires another
 // explicit visual identity audit instead of silently bypassing this guard.
@@ -78,14 +94,17 @@ function containsForbiddenIdentity(value: string): boolean {
 
 export function findBrandIdentityViolations(
   files: readonly BrandIdentityFile[],
+  approvedLines: ReadonlyMap<string, ReadonlySet<string>> = approvedAttributionLines,
 ): BrandIdentityViolation[] {
   const violations: BrandIdentityViolation[] = [];
   for (const file of files) {
     if (containsForbiddenIdentity(file.path)) {
       violations.push({ path: file.path, line: null, text: file.path });
     }
+    const approvedForFile = approvedLines.get(file.path);
     for (const [index, line] of file.contents.split(/\r?\n/).entries()) {
       if (!containsForbiddenIdentity(line)) continue;
+      if (approvedForFile?.has(line.trim())) continue;
       violations.push({ path: file.path, line: index + 1, text: line.trim() });
     }
   }


### PR DESCRIPTION
Fixes #512.

`bun run brand:check` fails on main because LICENSE:3 (the T3 Tools Inc. copyright line) and the README Origins sentence deliberately restore the legally required T3 attribution, while `scripts/check-brand-identity.ts` forbids exactly those strings. Since brand:check runs early in CI, the unit and browser suites never run on any PR.

The attribution is legally required and has to stay, so this takes option 1 from the issue: an exact-line allowlist.

## Changes

- `scripts/check-brand-identity.ts`: add `approvedAttributionLines`, a per-file map of reviewed lines. A line containing the retired identity passes only if it appears verbatim (trimmed) in its approved file. The two entries are the LICENSE copyright line and the README Origins sentence. Any edit to those lines, or the retired identity anywhere else (including elsewhere in LICENSE or README), still fails, so changing the attribution requires updating the allowlist in the same PR.
- `scripts/check-brand-identity.test.ts`: the old "rejects retired identity in legal notices" test asserted the opposite of the new behavior. Replaced with three tests: the approved notice passes in LICENSE but fails in other files, an edited variant of the notice fails, and other retired-identity text inside an approved file fails.

## Verification

- `bun run brand:check` passes on this branch
- `bunx vitest run scripts/check-brand-identity.test.ts`: 6/6 pass
- `bun fmt`, `bun lint`, `bun typecheck` all pass