### PR TITLE
fix(web): distinguish favourite model providers

### DIFF
--- a/apps/web/src/components/chat/ProviderModelOptionGroupList.tsx
+++ b/apps/web/src/components/chat/ProviderModelOptionGroupList.tsx
@@ -73,7 +73,7 @@ function ProviderModelRadioItem(
     <MenuRadioItem
       key={`${provider}:${modelOption.slug}`}
       value={modelOption.slug}
-      aria-label={accessibleModelName}
+      {...(provenanceLabel ? { "aria-label": accessibleModelName } : {})}
       preserveChildLayout={preserveChildLayout}
       className={costMultiplierLabel ? "grid-cols-[minmax(0,1fr)_auto]" : undefined}
       trailing={

--- a/apps/web/src/components/chat/ProviderModelOptionGroupList.tsx
+++ b/apps/web/src/components/chat/ProviderModelOptionGroupList.tsx
@@ -11,6 +11,7 @@ import {
   resolveModelGroupDefaultOpen,
   shouldUseCollapsibleModelGroups,
   providerModelCostMultiplierLabel,
+  providerModelOptionProvenanceLabel,
   type ProviderModelOption,
   type ProviderModelOptionGroup,
 } from "../../providerModelOptions";
@@ -43,6 +44,7 @@ function ProviderModelRadioItem(
     modelOption: ProviderModelOption;
     favoriteProvider: FavoriteModelProvider | null;
     isFavorite: boolean;
+    showProvenance: boolean;
     onToggleFavorite: (provider: FavoriteModelProvider, slug: string) => void;
     onAfterSelection?: () => void;
   }>,
@@ -52,6 +54,7 @@ function ProviderModelRadioItem(
     modelOption,
     favoriteProvider,
     isFavorite,
+    showProvenance,
     onToggleFavorite,
     onAfterSelection,
   } = props;
@@ -59,11 +62,18 @@ function ProviderModelRadioItem(
   const costMultiplierLabel =
     provider === "droid" ? providerModelCostMultiplierLabel(modelOption.description) : null;
   const preserveChildLayout = supportsFavorites || costMultiplierLabel !== null;
+  const provenanceLabel = showProvenance
+    ? providerModelOptionProvenanceLabel({ provider, option: modelOption })
+    : null;
+  const accessibleModelName = provenanceLabel
+    ? `${modelOption.name} — ${provenanceLabel}`
+    : modelOption.name;
 
   return (
     <MenuRadioItem
       key={`${provider}:${modelOption.slug}`}
       value={modelOption.slug}
+      aria-label={accessibleModelName}
       preserveChildLayout={preserveChildLayout}
       className={costMultiplierLabel ? "grid-cols-[minmax(0,1fr)_auto]" : undefined}
       trailing={
@@ -72,8 +82,8 @@ function ProviderModelRadioItem(
             type="button"
             aria-label={
               isFavorite
-                ? `Remove ${modelOption.name} from favourites`
-                : `Add ${modelOption.name} to favourites`
+                ? `Remove ${accessibleModelName} from favourites`
+                : `Add ${accessibleModelName} to favourites`
             }
             className={cn(
               "inline-flex size-5 shrink-0 items-center justify-center text-muted-foreground/50 transition-colors hover:bg-[color-mix(in_srgb,var(--foreground)_5%,transparent)] hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/60",
@@ -112,11 +122,19 @@ function ProviderModelRadioItem(
       {preserveChildLayout ? (
         <span
           className={cn(
-            "block min-w-0 truncate",
+            "flex min-w-0 flex-col",
             supportsFavorites && COMPOSER_PICKER_MODEL_ROW_LABEL_INDENT_CLASS_NAME,
           )}
         >
-          {modelOption.name}
+          <span className="block min-w-0 truncate">{modelOption.name}</span>
+          {provenanceLabel ? (
+            <span
+              aria-hidden="true"
+              className="block min-w-0 truncate text-[10px] leading-tight text-muted-foreground/60"
+            >
+              {provenanceLabel}
+            </span>
+          ) : null}
         </span>
       ) : (
         modelOption.name
@@ -171,6 +189,7 @@ export function ProviderModelOptionGroupList(props: ProviderModelOptionGroupList
             modelOption={modelOption}
             favoriteProvider={props.favoriteProvider}
             isFavorite={props.favoriteModelSlugSet?.has(modelOption.slug) ?? false}
+            showProvenance={group.key === "__favorites__"}
             onToggleFavorite={props.onToggleFavorite}
             {...(props.onAfterSelection ? { onAfterSelection: props.onAfterSelection } : {})}
           />

--- a/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -5,6 +5,7 @@ import { render } from "vitest-browser-react";
 
 import { ProviderModelPicker } from "./ProviderModelPicker";
 import type { ProviderModelOption } from "../../providerModelOptions";
+import { FAVORITE_MODEL_STORAGE_KEYS } from "../../lib/modelFavorites";
 
 const MODEL_OPTIONS_BY_PROVIDER = {
   claudeAgent: [
@@ -89,6 +90,21 @@ const OPENCODE_FAVORITE_SORT_MODELS = [
     name: "GPT Favorite Sort",
     upstreamProviderId: "openai",
     upstreamProviderName: "OpenAI",
+  },
+] satisfies ReadonlyArray<ProviderModelOption & { slug: ModelSlug }>;
+
+const OPENCODE_DUPLICATE_NAME_MODELS = [
+  {
+    slug: "deepseek/deepseek-v4-flash" as ModelSlug,
+    name: "DeepSeek V4 Flash",
+    upstreamProviderId: "deepseek",
+    upstreamProviderName: "DeepSeek",
+  },
+  {
+    slug: "opencode-go/deepseek-v4-flash" as ModelSlug,
+    name: "DeepSeek V4 Flash",
+    upstreamProviderId: "opencode-go",
+    upstreamProviderName: "OpenCode Go",
   },
 ] satisfies ReadonlyArray<ProviderModelOption & { slug: ModelSlug }>;
 
@@ -380,13 +396,61 @@ describe("ProviderModelPicker", () => {
         expect(text.indexOf("GPT Favorite Sort")).toBeLessThan(text.indexOf("Anthropic"));
       });
       await expect
-        .element(page.getByRole("menuitemradio", { name: "GPT Favorite Sort" }))
+        .element(page.getByRole("menuitemradio", { name: "GPT Favorite Sort — OpenAI" }))
         .toBeInTheDocument();
       expect(
         Array.from(document.querySelectorAll('[role="menuitemradio"]')).filter((element) =>
           element.textContent?.includes("GPT Favorite Sort"),
         ),
       ).toHaveLength(1);
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("distinguishes same-name favourite models by their upstream provider", async () => {
+    localStorage.setItem(
+      FAVORITE_MODEL_STORAGE_KEYS.opencode,
+      JSON.stringify(OPENCODE_DUPLICATE_NAME_MODELS.map((model) => model.slug)),
+    );
+    const mounted = await mountPicker({
+      provider: "opencode",
+      model: OPENCODE_DUPLICATE_NAME_MODELS[0]!.slug,
+      lockedProvider: "opencode",
+      modelOptionsByProvider: {
+        ...MODEL_OPTIONS_BY_PROVIDER,
+        opencode: OPENCODE_DUPLICATE_NAME_MODELS,
+      },
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await expect
+        .element(page.getByRole("menuitemradio", { name: "DeepSeek V4 Flash — DeepSeek" }))
+        .toBeInTheDocument();
+      await expect
+        .element(page.getByRole("menuitemradio", { name: "DeepSeek V4 Flash — OpenCode Go" }))
+        .toBeInTheDocument();
+      await expect
+        .element(
+          page.getByRole("button", {
+            name: "Remove DeepSeek V4 Flash — DeepSeek from favourites",
+          }),
+        )
+        .toBeInTheDocument();
+      await expect
+        .element(
+          page.getByRole("button", {
+            name: "Remove DeepSeek V4 Flash — OpenCode Go from favourites",
+          }),
+        )
+        .toBeInTheDocument();
+      expect(
+        Array.from(document.querySelectorAll('[role="menuitemradio"]')).map(
+          (element) => element.textContent,
+        ),
+      ).toEqual(["DeepSeek V4 FlashDeepSeek", "DeepSeek V4 FlashOpenCode Go"]);
     } finally {
       await mounted.cleanup();
     }
@@ -454,7 +518,7 @@ describe("ProviderModelPicker", () => {
         expect(text.indexOf("GPT Cursor Favorite Sort")).toBeLessThan(text.indexOf("Anthropic"));
       });
       await expect
-        .element(page.getByRole("menuitemradio", { name: "GPT Cursor Favorite Sort" }))
+        .element(page.getByRole("menuitemradio", { name: "GPT Cursor Favorite Sort — OpenAI" }))
         .toBeInTheDocument();
       expect(
         Array.from(document.querySelectorAll('[role="menuitemradio"]')).filter((element) =>
@@ -494,7 +558,7 @@ describe("ProviderModelPicker", () => {
         expect(text.indexOf("GPT Pi Favorite Sort")).toBeLessThan(text.indexOf("Anthropic"));
       });
       await expect
-        .element(page.getByRole("menuitemradio", { name: "GPT Pi Favorite Sort" }))
+        .element(page.getByRole("menuitemradio", { name: "GPT Pi Favorite Sort — OpenAI" }))
         .toBeInTheDocument();
       expect(
         Array.from(document.querySelectorAll('[role="menuitemradio"]')).filter((element) =>

--- a/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -270,6 +270,13 @@ describe("ProviderModelPicker", () => {
       expect(pricedRow?.textContent).toContain("0.4×");
       expect(pricedRow?.querySelector('[title="0.4x Factory token rate"]')).not.toBeNull();
       expect(byokRow?.textContent).not.toContain("×");
+      await expect
+        .element(
+          page.getByRole("menuitemradio", {
+            name: "GPT-5.6 Luna 0.4x Factory token rate",
+          }),
+        )
+        .toBeInTheDocument();
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/providerModelOptions.test.ts
+++ b/apps/web/src/providerModelOptions.test.ts
@@ -14,6 +14,7 @@ import {
   groupProviderModelOptionsWithFavorites,
   mergeDynamicModelOptions,
   providerModelCostMultiplierLabel,
+  providerModelOptionProvenanceLabel,
   resolveModelGroupDefaultOpen,
   shouldUseCollapsibleModelGroups,
   type ProviderModelOption,
@@ -203,6 +204,40 @@ describe("providerModelCostMultiplierLabel", () => {
   it("ignores descriptions that do not begin with a multiplier", () => {
     expect(providerModelCostMultiplierLabel("Launch Pricing")).toBeNull();
     expect(providerModelCostMultiplierLabel()).toBeNull();
+  });
+});
+
+describe("providerModelOptionProvenanceLabel", () => {
+  it("prefers the discovered upstream provider name", () => {
+    expect(
+      providerModelOptionProvenanceLabel({
+        provider: "opencode",
+        option: {
+          slug: "opencode-go/deepseek-v4-flash",
+          name: "DeepSeek V4 Flash",
+          upstreamProviderId: "opencode-go",
+          upstreamProviderName: "OpenCode Go",
+        },
+      }),
+    ).toBe("OpenCode Go");
+  });
+
+  it("falls back to a humanized slug provider, then the Synara provider", () => {
+    expect(
+      providerModelOptionProvenanceLabel({
+        provider: "opencode",
+        option: {
+          slug: "local-runtime/deepseek-v4-flash",
+          name: "DeepSeek V4 Flash",
+        },
+      }),
+    ).toBe("Local Runtime");
+    expect(
+      providerModelOptionProvenanceLabel({
+        provider: "cursor",
+        option: { slug: "auto", name: "Auto" },
+      }),
+    ).toBe("Cursor");
   });
 });
 

--- a/apps/web/src/providerModelOptions.ts
+++ b/apps/web/src/providerModelOptions.ts
@@ -3,27 +3,28 @@ import {
   humanizeModelSlug,
   normalizeModelSlug,
 } from "@synara/shared/model";
-import type {
-  AntigravityModelOptions,
-  AntigravityModelSelection,
-  ClaudeModelOptions,
-  ClaudeModelSelection,
-  CodexModelOptions,
-  CodexModelSelection,
-  CursorModelOptions,
-  CursorModelSelection,
-  DroidModelOptions,
-  DroidModelSelection,
-  GrokModelOptions,
-  GrokModelSelection,
-  KiloModelSelection,
-  ModelSelection,
-  OpenCodeModelOptions,
-  OpenCodeModelSelection,
-  PiModelOptions,
-  PiModelSelection,
-  ProviderKind,
-  ProviderModelOptions,
+import {
+  PROVIDER_DISPLAY_NAMES,
+  type AntigravityModelOptions,
+  type AntigravityModelSelection,
+  type ClaudeModelOptions,
+  type ClaudeModelSelection,
+  type CodexModelOptions,
+  type CodexModelSelection,
+  type CursorModelOptions,
+  type CursorModelSelection,
+  type DroidModelOptions,
+  type DroidModelSelection,
+  type GrokModelOptions,
+  type GrokModelSelection,
+  type KiloModelSelection,
+  type ModelSelection,
+  type OpenCodeModelOptions,
+  type OpenCodeModelSelection,
+  type PiModelOptions,
+  type PiModelSelection,
+  type ProviderKind,
+  type ProviderModelOptions,
 } from "@synara/contracts";
 import { normalizeCursorModelVariantBaseId } from "./cursorModelVariants";
 
@@ -41,6 +42,32 @@ export interface ProviderModelOptionGroup {
   key: string;
   label: string | null;
   options: ProviderModelOption[];
+}
+
+/**
+ * Returns the provider provenance shown when a model is detached from its
+ * normal upstream-provider group (for example, inside Favourites).
+ */
+export function providerModelOptionProvenanceLabel(input: {
+  provider: ProviderKind;
+  option: ProviderModelOption;
+}): string {
+  const upstreamProviderName = input.option.upstreamProviderName?.trim();
+  if (upstreamProviderName) {
+    return upstreamProviderName;
+  }
+
+  const upstreamProviderId = input.option.upstreamProviderId?.trim();
+  if (upstreamProviderId) {
+    return humanizeModelSlug(upstreamProviderId);
+  }
+
+  const slugProvider = input.option.slug.split("/", 1)[0]?.trim();
+  if (input.option.slug.includes("/") && slugProvider) {
+    return humanizeModelSlug(slugProvider);
+  }
+
+  return PROVIDER_DISPLAY_NAMES[input.provider];
 }
 
 export function formatProviderModelOptionName(input: {


### PR DESCRIPTION
## Summary
- show the upstream provider as a compact secondary label for models in Favourites
- provide deterministic provenance fallbacks when discovery metadata is incomplete
- give same-name favourite rows and star actions distinct accessible labels

## Verification
- bun run --cwd apps/web test src/providerModelOptions.test.ts
- bun run --cwd apps/web test:browser src/components/chat/ProviderModelPicker.browser.tsx
- git diff --check

Note: full fmt, lint, and typecheck were not run because repository instructions prohibit them unless explicitly requested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to the composer model picker and a small display helper; no auth, persistence, or model-selection logic changes.
> 
> **Overview**
> **Favourites** in the model picker now show a compact **upstream provider** line under the model name so same-named models (e.g. two “DeepSeek V4 Flash” entries) are easy to tell apart when they’re not grouped by provider.
> 
> Adds `providerModelOptionProvenanceLabel` with a fixed fallback chain: discovered upstream name → humanized upstream id → slug prefix → Synara provider display name. Provenance is only enabled for the `__favorites__` group; regular upstream-grouped lists are unchanged.
> 
> **Accessibility:** favourite rows and star buttons use `aria-label` values like `Model — Provider`, and the secondary provenance text is `aria-hidden` so screen readers get one clear name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fcaeca80b70162965decf7c88aec9f5993b98ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->