### PR TITLE
Discover installed Claude plugin skills

### DIFF
--- a/apps/server/src/provider/claudePluginSkills.ts
+++ b/apps/server/src/provider/claudePluginSkills.ts
@@ -92,9 +92,18 @@ function namespaceForPlugin(pluginId: string): string | null {
   return namespace.length > 0 ? namespace : null;
 }
 
-function pathIsWithin(parentPath: string, childPath: string): boolean {
-  const relative = nodePath.relative(parentPath, childPath);
-  return relative === "" || (!relative.startsWith(`..${nodePath.sep}`) && relative !== "..");
+type PathContainmentApi = Pick<typeof nodePath, "isAbsolute" | "relative" | "sep">;
+
+export function pathIsWithin(
+  parentPath: string,
+  childPath: string,
+  pathApi: PathContainmentApi = nodePath,
+): boolean {
+  const relative = pathApi.relative(parentPath, childPath);
+  return (
+    relative === "" ||
+    (!pathApi.isAbsolute(relative) && !relative.startsWith(`..${pathApi.sep}`) && relative !== "..")
+  );
 }
 
 async function canonicalPath(path: string): Promise<string | null> {

--- a/apps/server/src/provider/claudePluginSkills.ts
+++ b/apps/server/src/provider/claudePluginSkills.ts
@@ -1,0 +1,186 @@
+// FILE: claudePluginSkills.ts
+// Purpose: Resolve active Claude Code plugin skill roots from Claude's installed
+//          plugin registry without scanning orphaned cache versions.
+// Layer: Server provider discovery helper
+// Exports: discoverClaudePluginSkillRoots
+
+import * as fs from "node:fs/promises";
+import * as nodePath from "node:path";
+
+export interface ClaudePluginSkillRoot {
+  readonly path: string;
+  readonly scope: "claude";
+  readonly namespace: string;
+  readonly followSymlinks: false;
+}
+
+interface ClaudePluginInstall {
+  readonly installPath: string;
+  readonly scope: "user" | "project" | "local" | "managed";
+  readonly projectPath?: string;
+}
+
+interface ClaudeInstalledPlugin {
+  readonly pluginId: string;
+  readonly install: ClaudePluginInstall;
+}
+
+const CLAUDE_SCOPE_PRECEDENCE = {
+  managed: 0,
+  local: 1,
+  project: 2,
+  user: 3,
+} as const satisfies Record<ClaudePluginInstall["scope"], number>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseInstall(value: unknown): ClaudePluginInstall | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const installPath = value.installPath;
+  const scope = value.scope;
+  if (
+    typeof installPath !== "string" ||
+    installPath.trim().length === 0 ||
+    !nodePath.isAbsolute(installPath) ||
+    (scope !== "user" && scope !== "project" && scope !== "local" && scope !== "managed")
+  ) {
+    return null;
+  }
+  const projectPath = value.projectPath;
+  return {
+    installPath,
+    scope,
+    ...(typeof projectPath === "string" && projectPath.trim().length > 0 ? { projectPath } : {}),
+  };
+}
+
+function parseInstalledPlugins(value: unknown): ClaudeInstalledPlugin[] {
+  if (!isRecord(value) || !isRecord(value.plugins)) {
+    return [];
+  }
+  return Object.entries(value.plugins)
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .flatMap(([rawPluginId, rawInstalls]) => {
+      const pluginId = rawPluginId.trim();
+      if (pluginId.length === 0 || !pluginId.includes("@") || !Array.isArray(rawInstalls)) {
+        return [];
+      }
+      return rawInstalls
+        .map(parseInstall)
+        .filter((install): install is ClaudePluginInstall => install !== null)
+        .toSorted(
+          (left, right) =>
+            CLAUDE_SCOPE_PRECEDENCE[left.scope] - CLAUDE_SCOPE_PRECEDENCE[right.scope] ||
+            [left.projectPath ?? "", left.installPath]
+              .join("\u0000")
+              .localeCompare([right.projectPath ?? "", right.installPath].join("\u0000")),
+        )
+        .map((install) => ({ pluginId, install }));
+    });
+}
+
+function namespaceForPlugin(pluginId: string): string | null {
+  const separatorIndex = pluginId.indexOf("@");
+  if (separatorIndex <= 0) {
+    return null;
+  }
+  const namespace = pluginId.slice(0, separatorIndex).trim();
+  return namespace.length > 0 ? namespace : null;
+}
+
+function pathIsWithin(parentPath: string, childPath: string): boolean {
+  const relative = nodePath.relative(parentPath, childPath);
+  return relative === "" || (!relative.startsWith(`..${nodePath.sep}`) && relative !== "..");
+}
+
+async function canonicalPath(path: string): Promise<string | null> {
+  try {
+    return await fs.realpath(path);
+  } catch {
+    return null;
+  }
+}
+
+async function installAppliesToCwd(
+  install: ClaudePluginInstall,
+  cwd: string | null,
+): Promise<boolean> {
+  if (install.scope === "user" || install.scope === "managed") {
+    return true;
+  }
+  if (!cwd || !install.projectPath || !nodePath.isAbsolute(install.projectPath)) {
+    return false;
+  }
+  const [canonicalProjectPath, canonicalCwd] = await Promise.all([
+    canonicalPath(install.projectPath),
+    canonicalPath(cwd),
+  ]);
+  if (!canonicalProjectPath || !canonicalCwd) {
+    return false;
+  }
+  return pathIsWithin(canonicalProjectPath, canonicalCwd);
+}
+
+/**
+ * Claude keeps old plugin versions in its cache temporarily. The installed
+ * registry is therefore the source of truth; only its current install paths are
+ * considered, and those paths must resolve inside Claude's plugin cache.
+ */
+export async function discoverClaudePluginSkillRoots(input: {
+  readonly homeDir: string;
+  readonly cwd?: string | null;
+}): Promise<ClaudePluginSkillRoot[]> {
+  const claudePluginsDir = nodePath.join(input.homeDir, ".claude", "plugins");
+  const [manifestRaw, canonicalCacheRoot] = await Promise.all([
+    fs
+      .readFile(nodePath.join(claudePluginsDir, "installed_plugins.json"), "utf8")
+      .catch(() => null),
+    canonicalPath(nodePath.join(claudePluginsDir, "cache")),
+  ]);
+  if (!manifestRaw || !canonicalCacheRoot) {
+    return [];
+  }
+
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(manifestRaw);
+  } catch {
+    return [];
+  }
+
+  const roots: ClaudePluginSkillRoot[] = [];
+  const seen = new Set<string>();
+  const cwd = input.cwd?.trim() || null;
+  for (const { pluginId, install } of parseInstalledPlugins(manifest)) {
+    const namespace = namespaceForPlugin(pluginId);
+    if (!namespace || !(await installAppliesToCwd(install, cwd))) {
+      continue;
+    }
+    const canonicalInstallPath = await canonicalPath(install.installPath);
+    if (!canonicalInstallPath || !pathIsWithin(canonicalCacheRoot, canonicalInstallPath)) {
+      continue;
+    }
+    const skillsPath = await canonicalPath(nodePath.join(canonicalInstallPath, "skills"));
+    if (!skillsPath || !pathIsWithin(canonicalInstallPath, skillsPath)) {
+      continue;
+    }
+    try {
+      if (!(await fs.stat(skillsPath)).isDirectory()) {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+    const key = `${pluginId}\u0000${canonicalInstallPath}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    roots.push({ path: skillsPath, scope: "claude", namespace, followSymlinks: false });
+  }
+  return roots;
+}

--- a/apps/server/src/provider/claudePluginSkills.ts
+++ b/apps/server/src/provider/claudePluginSkills.ts
@@ -154,12 +154,20 @@ export async function discoverClaudePluginSkillRoots(input: {
 
   const roots: ClaudePluginSkillRoot[] = [];
   const seen = new Set<string>();
+  const selectedPluginIds = new Set<string>();
   const cwd = input.cwd?.trim() || null;
   for (const { pluginId, install } of parseInstalledPlugins(manifest)) {
+    if (selectedPluginIds.has(pluginId)) {
+      continue;
+    }
     const namespace = namespaceForPlugin(pluginId);
     if (!namespace || !(await installAppliesToCwd(install, cwd))) {
       continue;
     }
+    // Claude resolves one effective installation per plugin ID. Once the
+    // highest-precedence applicable scope is selected, a lower-precedence copy
+    // must not contribute additional skills even if the selected path is broken.
+    selectedPluginIds.add(pluginId);
     const canonicalInstallPath = await canonicalPath(install.installPath);
     if (!canonicalInstallPath || !pathIsWithin(canonicalCacheRoot, canonicalInstallPath)) {
       continue;

--- a/apps/server/src/provider/skillsCatalog.test.ts
+++ b/apps/server/src/provider/skillsCatalog.test.ts
@@ -4,7 +4,7 @@
 // Layer: Server provider tests
 
 import { mkdtempSync, rmSync } from "node:fs";
-import { mkdir, symlink, writeFile } from "node:fs/promises";
+import { mkdir, realpath, symlink, writeFile } from "node:fs/promises";
 import { access } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -36,6 +36,18 @@ description: ${description}
 # ${name}
 `,
   );
+}
+
+function claudePluginInstallPath(marketplace: string, plugin: string, version: string): string {
+  return path.join(homeDir, ".claude", "plugins", "cache", marketplace, plugin, version);
+}
+
+async function writeClaudePluginManifest(
+  plugins: Record<string, ReadonlyArray<Record<string, unknown>> | unknown>,
+): Promise<void> {
+  const manifestPath = path.join(homeDir, ".claude", "plugins", "installed_plugins.json");
+  await mkdir(path.dirname(manifestPath), { recursive: true });
+  await writeFile(manifestPath, JSON.stringify({ version: 2, plugins }, null, 2));
 }
 
 beforeEach(() => {
@@ -107,6 +119,154 @@ describe("discoverSkillsCatalog", () => {
     expect(byName.get("kilo-only")?.scope).toBe("kilo");
     expect(byName.get("opencode-only")?.scope).toBe("opencode");
     expect(byName.get("pi-only")?.scope).toBe("pi");
+  });
+
+  it("discovers only the registered Claude plugin version for Grok with its native namespace", async () => {
+    const currentInstallPath = claudePluginInstallPath("skill-forge", "workflow-kit", "1.21.0");
+    const staleInstallPath = claudePluginInstallPath("skill-forge", "workflow-kit", "1.20.0");
+    await writeSkill(
+      path.join(currentInstallPath, "skills", "feature-delivery"),
+      "feature-delivery",
+      "Deliver a feature",
+    );
+    await writeSkill(
+      path.join(staleInstallPath, "skills", "stale-only"),
+      "stale-only",
+      "Old cache entry",
+    );
+    await writeClaudePluginManifest({
+      "workflow-kit@skill-forge": [
+        {
+          scope: "user",
+          installPath: currentInstallPath,
+          version: "1.21.0",
+        },
+      ],
+    });
+
+    const skills = await discoverSkillsCatalog({
+      homeDir,
+      synaraBaseDir,
+      provider: "grok",
+    });
+
+    expect(skills.find((skill) => skill.name === "workflow-kit:feature-delivery")).toMatchObject({
+      scope: "claude",
+      path: await realpath(path.join(currentInstallPath, "skills", "feature-delivery", "SKILL.md")),
+    });
+    expect(skills.some((skill) => skill.name.includes("stale-only"))).toBe(false);
+  });
+
+  it("dedupes duplicate Claude plugin registrations deterministically", async () => {
+    const installPath = claudePluginInstallPath("skill-forge", "workflow-kit", "1.21.0");
+    await writeSkill(
+      path.join(installPath, "skills", "feature-delivery"),
+      "feature-delivery",
+      "Deliver a feature",
+    );
+    const install = { scope: "user", installPath, version: "1.21.0" };
+    await writeClaudePluginManifest({
+      "workflow-kit@skill-forge": [install, install],
+    });
+
+    const skills = await discoverSkillsCatalog({
+      homeDir,
+      synaraBaseDir,
+      includeDuplicateOrigins: true,
+    });
+
+    expect(skills.filter((skill) => skill.name === "workflow-kit:feature-delivery")).toHaveLength(
+      1,
+    );
+  });
+
+  it("uses deterministic plugin-id precedence when namespaces and skill names collide", async () => {
+    const alphaInstallPath = claudePluginInstallPath("alpha", "workflow-kit", "1.0.0");
+    const zetaInstallPath = claudePluginInstallPath("zeta", "workflow-kit", "1.0.0");
+    await Promise.all([
+      writeSkill(
+        path.join(alphaInstallPath, "skills", "feature-delivery"),
+        "feature-delivery",
+        "Alpha copy",
+      ),
+      writeSkill(
+        path.join(zetaInstallPath, "skills", "feature-delivery"),
+        "feature-delivery",
+        "Zeta copy",
+      ),
+    ]);
+    await writeClaudePluginManifest({
+      "workflow-kit@zeta": [{ scope: "user", installPath: zetaInstallPath }],
+      "workflow-kit@alpha": [{ scope: "user", installPath: alphaInstallPath }],
+    });
+
+    const skills = await discoverSkillsCatalog({ homeDir, synaraBaseDir });
+    const featureDelivery = skills.find((skill) => skill.name === "workflow-kit:feature-delivery");
+
+    expect(featureDelivery?.description).toBe("Alpha copy");
+    expect(featureDelivery?.path).toContain(path.join("cache", "alpha", "workflow-kit"));
+  });
+
+  it("includes user and matching project Claude plugins but excludes other projects", async () => {
+    const cwd = path.join(root, "repo", "packages", "web");
+    const otherProject = path.join(root, "other-repo");
+    await Promise.all([mkdir(cwd, { recursive: true }), mkdir(otherProject, { recursive: true })]);
+    const userInstallPath = claudePluginInstallPath("plugins", "user-tools", "1.0.0");
+    const projectInstallPath = claudePluginInstallPath("plugins", "project-tools", "1.0.0");
+    const otherInstallPath = claudePluginInstallPath("plugins", "other-tools", "1.0.0");
+    await Promise.all([
+      writeSkill(path.join(userInstallPath, "skills", "user-skill"), "user-skill", "User"),
+      writeSkill(
+        path.join(projectInstallPath, "skills", "project-skill"),
+        "project-skill",
+        "Project",
+      ),
+      writeSkill(path.join(otherInstallPath, "skills", "other-skill"), "other-skill", "Other"),
+    ]);
+    await writeClaudePluginManifest({
+      "user-tools@plugins": [{ scope: "user", installPath: userInstallPath }],
+      "project-tools@plugins": [
+        { scope: "project", projectPath: path.join(root, "repo"), installPath: projectInstallPath },
+      ],
+      "other-tools@plugins": [
+        { scope: "project", projectPath: otherProject, installPath: otherInstallPath },
+      ],
+    });
+
+    const skills = await discoverSkillsCatalog({ cwd, homeDir, synaraBaseDir });
+    expect(skills.map((skill) => skill.name)).toEqual(
+      expect.arrayContaining(["user-tools:user-skill", "project-tools:project-skill"]),
+    );
+    expect(skills.some((skill) => skill.name === "other-tools:other-skill")).toBe(false);
+  });
+
+  it("ignores malformed registrations and install paths outside Claude's plugin cache", async () => {
+    const validInstallPath = claudePluginInstallPath("plugins", "valid", "1.0.0");
+    const outsideInstallPath = path.join(root, "outside-plugin");
+    await writeSkill(path.join(validInstallPath, "skills", "valid-skill"), "valid-skill", "Valid");
+    await writeSkill(
+      path.join(outsideInstallPath, "skills", "outside-skill"),
+      "outside-skill",
+      "Outside",
+    );
+    await symlink(
+      path.join(outsideInstallPath, "skills", "outside-skill"),
+      path.join(validInstallPath, "skills", "linked-outside"),
+      "dir",
+    );
+    await writeClaudePluginManifest({
+      "valid@plugins": [{ scope: "user", installPath: validInstallPath }],
+      "outside@plugins": [{ scope: "user", installPath: outsideInstallPath }],
+      "relative@plugins": [{ scope: "user", installPath: "relative/plugin" }],
+      "missing@plugins": [{ scope: "user", installPath: path.join(validInstallPath, "missing") }],
+      malformed: [{ scope: "user", installPath: validInstallPath }],
+      "wrong-shape@plugins": { scope: "user", installPath: validInstallPath },
+    });
+
+    const skills = await discoverSkillsCatalog({ homeDir, synaraBaseDir });
+    expect(skills.map((skill) => skill.name)).toContain("valid:valid-skill");
+    expect(skills.some((skill) => skill.name.includes("outside-skill"))).toBe(false);
+    expect(skills.filter((skill) => skill.name === "valid:valid-skill")).toHaveLength(1);
   });
 
   it("follows symlinked skill directories from provider homes", async () => {

--- a/apps/server/src/provider/skillsCatalog.test.ts
+++ b/apps/server/src/provider/skillsCatalog.test.ts
@@ -240,6 +240,35 @@ describe("discoverSkillsCatalog", () => {
     expect(skills.some((skill) => skill.name === "other-tools:other-skill")).toBe(false);
   });
 
+  it("uses one highest-precedence applicable install per Claude plugin ID", async () => {
+    const cwd = path.join(root, "repo", "packages", "web");
+    await mkdir(cwd, { recursive: true });
+    const userInstallPath = claudePluginInstallPath("plugins", "workflow-kit", "1.0.0");
+    const projectInstallPath = claudePluginInstallPath("plugins", "workflow-kit", "2.0.0");
+    await Promise.all([
+      writeSkill(path.join(userInstallPath, "skills", "user-only"), "user-only", "User copy only"),
+      writeSkill(
+        path.join(projectInstallPath, "skills", "project-only"),
+        "project-only",
+        "Project copy only",
+      ),
+    ]);
+    await writeClaudePluginManifest({
+      "workflow-kit@plugins": [
+        { scope: "user", installPath: userInstallPath },
+        {
+          scope: "project",
+          projectPath: path.join(root, "repo"),
+          installPath: projectInstallPath,
+        },
+      ],
+    });
+
+    const skills = await discoverSkillsCatalog({ cwd, homeDir, synaraBaseDir });
+    expect(skills.map((skill) => skill.name)).toContain("workflow-kit:project-only");
+    expect(skills.map((skill) => skill.name)).not.toContain("workflow-kit:user-only");
+  });
+
   it("ignores malformed registrations and install paths outside Claude's plugin cache", async () => {
     const validInstallPath = claudePluginInstallPath("plugins", "valid", "1.0.0");
     const outsideInstallPath = path.join(root, "outside-plugin");

--- a/apps/server/src/provider/skillsCatalog.test.ts
+++ b/apps/server/src/provider/skillsCatalog.test.ts
@@ -19,6 +19,7 @@ import {
   mergeSkillsIntoCatalog,
   parseSkillFrontmatter,
 } from "./skillsCatalog.ts";
+import { pathIsWithin } from "./claudePluginSkills.ts";
 
 let root: string;
 let homeDir: string;
@@ -77,6 +78,15 @@ disable-model-invocation: true
       description: "Review recent code changes",
       "disable-model-invocation": true,
     });
+  });
+});
+
+describe("pathIsWithin", () => {
+  it("rejects Windows paths on another drive while preserving same-drive containment", () => {
+    expect(pathIsWithin("C:\\plugins", "C:\\plugins", path.win32)).toBe(true);
+    expect(pathIsWithin("C:\\plugins", "C:\\plugins\\workflow-kit", path.win32)).toBe(true);
+    expect(pathIsWithin("C:\\plugins", "C:\\other", path.win32)).toBe(false);
+    expect(pathIsWithin("C:\\plugins", "D:\\plugins\\workflow-kit", path.win32)).toBe(false);
   });
 });
 

--- a/apps/server/src/provider/skillsCatalog.ts
+++ b/apps/server/src/provider/skillsCatalog.ts
@@ -12,6 +12,7 @@ import * as fs from "node:fs/promises";
 import * as nodePath from "node:path";
 
 import type { ProviderKind, ProviderSkillDescriptor } from "@synara/contracts";
+import { discoverClaudePluginSkillRoots } from "./claudePluginSkills.ts";
 
 type FrontmatterValue = string | boolean;
 
@@ -19,6 +20,10 @@ export interface SkillRoot {
   readonly path: string;
   readonly scope: string;
   readonly includeMarkdownFiles?: boolean;
+  /** Prefix used by plugin-provided skills whose native invocation is namespaced. */
+  readonly namespace?: string;
+  /** Provider-owned plugin caches should not traverse linked content outside the install. */
+  readonly followSymlinks?: boolean;
 }
 
 // ── Frontmatter parsing ──────────────────────────────────────────────
@@ -123,11 +128,12 @@ async function readdirOrEmpty(path: string): Promise<import("node:fs").Dirent[]>
 async function isWalkableSkillDirectory(
   parentPath: string,
   dirent: import("node:fs").Dirent,
+  followSymlinks: boolean,
 ): Promise<boolean> {
   if (dirent.isDirectory()) {
     return true;
   }
-  if (!dirent.isSymbolicLink()) {
+  if (!followSymlinks || !dirent.isSymbolicLink()) {
     return false;
   }
   try {
@@ -163,12 +169,16 @@ async function isReadableMarkdownFile(
 
 export async function collectSkillMarkdownPaths(
   rootPath: string,
-  options?: { readonly includeMarkdownFiles?: boolean },
+  options?: {
+    readonly includeMarkdownFiles?: boolean;
+    readonly followSymlinks?: boolean;
+  },
 ): Promise<string[]> {
   async function visit(dir: string, depth: number): Promise<string[]> {
     const skillPath = nodePath.join(dir, "SKILL.md");
     try {
-      const stat = await fs.stat(skillPath);
+      const stat =
+        options?.followSymlinks === false ? await fs.lstat(skillPath) : await fs.stat(skillPath);
       if (stat.isFile()) {
         return [skillPath];
       }
@@ -199,7 +209,11 @@ export async function collectSkillMarkdownPaths(
       await Promise.all(
         dirents.map(async (dirent) => ({
           name: dirent.name,
-          isDirectory: await isWalkableSkillDirectory(dir, dirent),
+          isDirectory: await isWalkableSkillDirectory(
+            dir,
+            dirent,
+            options?.followSymlinks !== false,
+          ),
         })),
       )
     )
@@ -218,6 +232,7 @@ export async function collectSkillMarkdownPaths(
 export async function readSkillDescriptor(input: {
   readonly skillPath: string;
   readonly scope: string;
+  readonly namespace?: string;
 }): Promise<ProviderSkillDescriptor | null> {
   let raw: string;
   try {
@@ -232,7 +247,11 @@ export async function readSkillDescriptor(input: {
     skillFilename.toLowerCase() === "skill.md"
       ? nodePath.basename(nodePath.dirname(input.skillPath))
       : nodePath.basename(input.skillPath, nodePath.extname(input.skillPath));
-  const name = readStringField(frontmatter, ["name"]) ?? fallbackName;
+  const unqualifiedName = readStringField(frontmatter, ["name"]) ?? fallbackName;
+  const name =
+    input.namespace && !unqualifiedName.includes(":")
+      ? `${input.namespace}:${unqualifiedName}`
+      : unqualifiedName;
   const description = readStringField(frontmatter, ["description"]);
   const displayName = readStringField(frontmatter, ["display-name", "displayName", "title"]);
   const shortDescription = readStringField(frontmatter, [
@@ -271,10 +290,21 @@ async function collectSkillDescriptorsFromRoots(
     roots.map(async (root) => {
       const skillPaths = await collectSkillMarkdownPaths(
         root.path,
-        root.includeMarkdownFiles ? { includeMarkdownFiles: true } : undefined,
+        root.includeMarkdownFiles || root.followSymlinks === false
+          ? {
+              ...(root.includeMarkdownFiles ? { includeMarkdownFiles: true } : {}),
+              ...(root.followSymlinks === false ? { followSymlinks: false } : {}),
+            }
+          : undefined,
       );
       const descriptors = await Promise.all(
-        skillPaths.map((skillPath) => readSkillDescriptor({ skillPath, scope: root.scope })),
+        skillPaths.map((skillPath) =>
+          readSkillDescriptor({
+            skillPath,
+            scope: root.scope,
+            ...(root.namespace ? { namespace: root.namespace } : {}),
+          }),
+        ),
       );
       return descriptors.filter((skill) => skill !== null);
     }),
@@ -563,9 +593,16 @@ export async function discoverSkillsCatalog(
 
   const scan = (async () => {
     await ensureSynaraSkillsDir(input.synaraBaseDir);
+    const roots = [
+      ...skillsCatalogRoots(input),
+      ...(await discoverClaudePluginSkillRoots({
+        homeDir: input.homeDir,
+        ...(input.cwd ? { cwd: input.cwd } : {}),
+      })),
+    ];
     const skills = input.includeDuplicateOrigins
-      ? await collectSkillDescriptorsFromRoots(skillsCatalogRoots(input))
-      : await collectSkillsFromRoots(skillsCatalogRoots(input));
+      ? await collectSkillDescriptorsFromRoots(roots)
+      : await collectSkillsFromRoots(roots);
 
     skillsCatalogCache.delete(cacheKey);
     skillsCatalogCache.set(cacheKey, { at: Date.now(), skills });

--- a/apps/web/src/lib/providerDiscovery.test.ts
+++ b/apps/web/src/lib/providerDiscovery.test.ts
@@ -88,4 +88,22 @@ describe("rankProviderDiscoveryItems", () => {
 
     expect(ranked.map((skill) => skill.name)).toEqual(["check-code"]);
   });
+
+  it("finds namespaced Claude plugin skills by their unqualified skill name", () => {
+    const ranked = rankProviderDiscoveryItems(
+      [
+        makeSkill({
+          name: "workflow-kit:feature-delivery",
+          description: "Deliver a feature from planning through review.",
+          path: "/Users/tester/.claude/plugins/cache/skill-forge/workflow-kit/1.21.0/skills/feature-delivery/SKILL.md",
+          scope: "claude",
+        }),
+        makeSkill({ name: "check-code" }),
+      ],
+      "feature-delivery",
+      buildSkillSearchFields,
+    );
+
+    expect(ranked.map((skill) => skill.name)).toEqual(["workflow-kit:feature-delivery"]);
+  });
 });


### PR DESCRIPTION
## Summary

- discover Claude Code plugin skills from `~/.claude/plugins/installed_plugins.json`
- include only registered install paths under Claude's plugin cache, excluding orphaned cache versions and linked/outside content
- respect user, managed, project, and local installation scopes, including project-path matching
- expose plugin skills with Claude's canonical namespace (for example `workflow-kit:feature-delivery`) to every provider using Synara's unified catalog
- preserve deterministic precedence and keep unqualified autocomplete searches working

## Root cause

Synara scanned standalone `~/.claude/skills` directories but never read Claude Code's installed plugin registry. Plugin skills stored under `~/.claude/plugins/cache` were therefore invisible even though Claude/Grok tooling could discover them. Scanning the cache directly would also expose stale versions retained after updates, so this change treats the installed registry as the source of truth.

## Validation

- `bunx vitest run apps/server/src/provider/skillsCatalog.test.ts apps/web/src/lib/providerDiscovery.test.ts` (23 tests passed)
- targeted `oxfmt --check` on all changed files
- `git diff --check`
- two clean same-worktree Codex review passes

Full workspace formatting, lint, and typecheck are left to CI per the repository's local verification policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cross-provider skill discovery and filesystem path validation; mistakes could hide skills or leak paths, but installs are constrained to the cache with symlink traversal disabled.
> 
> **Overview**
> Synara’s unified skills catalog now picks up **Claude Code plugin skills** by reading `~/.claude/plugins/installed_plugins.json`, instead of only scanning `~/.claude/skills`. Only **registered install paths under the plugin cache** are used, so stale cache versions and arbitrary paths are not indexed.
> 
> A new **`discoverClaudePluginSkillRoots`** helper applies **managed / local / project / user** scope (project installs match `cwd` via canonical path containment), picks **one winning install per plugin ID** by scope precedence, and exposes each plugin’s **`skills`** directory with **`namespace:skill`** names (e.g. `workflow-kit:feature-delivery`). Plugin roots scan with **`followSymlinks: false`** and **`lstat`** on `SKILL.md` so symlinks cannot pull in content outside the install.
> 
> **`discoverSkillsCatalog`** merges these roots with existing provider roots; **`readSkillDescriptor`** applies the namespace prefix when needed. The web discovery test confirms **unqualified search** still matches namespaced plugin skills.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8883d2084e2a9fb131a6352546ab38efdde8969. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->