### PR TITLE
Fix stale human interaction lifecycle

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -9460,6 +9460,104 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
     );
   });
 
+  it.effect("settles unanswered AskUserQuestion exactly once before terminal turn state", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+      });
+      yield* Stream.take(adapter.streamEvents, 3).pipe(Stream.runDrain);
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "ask a question",
+        attachments: [],
+      });
+      yield* Stream.take(adapter.streamEvents, 1).pipe(Stream.runDrain);
+
+      const createInput = harness.getLastCreateQueryInput();
+      const canUseTool = createInput?.options.canUseTool;
+      if (!canUseTool) {
+        assert.fail("Expected canUseTool to be defined");
+        return;
+      }
+
+      const permissionPromise = canUseTool(
+        "AskUserQuestion",
+        {
+          questions: [
+            {
+              question: "Continue?",
+              header: "Continue",
+              options: [{ label: "Yes", description: "Proceed" }],
+              multiSelect: false,
+            },
+          ],
+        },
+        {
+          signal: new AbortController().signal,
+          toolUseID: "tool-ask-terminal",
+          requestId: "request-tool-ask-terminal",
+        },
+      );
+
+      const requestedEvent = yield* Stream.runHead(adapter.streamEvents);
+      if (requestedEvent._tag !== "Some" || requestedEvent.value.type !== "user-input.requested") {
+        assert.fail("Expected user-input.requested event");
+        return;
+      }
+      const requestId = requestedEvent.value.requestId;
+
+      const terminalLifecycleFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "user-input.resolved" || event.type === "turn.completed",
+      ).pipe(Stream.take(2), Stream.runCollect, Effect.forkChild);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-user-input-terminal",
+        uuid: "result-user-input-terminal",
+      } as unknown as SDKMessage);
+
+      const terminalLifecycle = Array.from(yield* Fiber.join(terminalLifecycleFiber));
+      assert.deepEqual(
+        terminalLifecycle.map((event) => event.type),
+        ["user-input.resolved", "turn.completed"],
+      );
+      const resolvedEvent = terminalLifecycle[0];
+      if (resolvedEvent?.type !== "user-input.resolved") {
+        assert.fail("Expected user-input.resolved before turn.completed");
+        return;
+      }
+      assert.equal(resolvedEvent.requestId, requestId);
+      assert.deepEqual(resolvedEvent.payload.answers, {});
+      assert.equal(resolvedEvent.turnId, terminalLifecycle[1]?.turnId);
+
+      const permissionResult = yield* Effect.promise(() => permissionPromise);
+      assert.deepEqual(permissionResult, {
+        behavior: "deny",
+        message: "User cancelled tool execution.",
+      } satisfies PermissionResult);
+
+      const lateResponse = yield* Effect.exit(
+        adapter.respondToUserInput(session.threadId, ApprovalRequestId.makeUnsafe(requestId), {
+          Continue: "Yes",
+        }),
+      );
+      assert.equal(Exit.isFailure(lateResponse), true);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("writes provider-native observability records when enabled", () => {
     const nativeEvents: Array<{
       event?: {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -9501,6 +9501,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         {
           signal: new AbortController().signal,
           toolUseID: "tool-ask-terminal",
+          agentID: "foreground-agent-terminal",
           requestId: "request-tool-ask-terminal",
         },
       );
@@ -9552,6 +9553,236 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         }),
       );
       assert.equal(Exit.isFailure(lateResponse), true);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect(
+    "keeps background-agent questions actionable after the foreground turn completes",
+    () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+
+        const session = yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: "claudeAgent",
+          runtimeMode: "full-access",
+        });
+        yield* Stream.take(adapter.streamEvents, 3).pipe(Stream.runDrain);
+
+        yield* adapter.sendTurn({
+          threadId: session.threadId,
+          input: "start a background task",
+          attachments: [],
+        });
+        yield* Stream.take(adapter.streamEvents, 1).pipe(Stream.runDrain);
+
+        harness.query.emit({
+          type: "system",
+          subtype: "task_updated",
+          task_id: "background-agent-1",
+          patch: { is_backgrounded: true },
+          session_id: "sdk-session-background-question",
+          uuid: "task-updated-background-question",
+        } as unknown as SDKMessage);
+        yield* Stream.take(adapter.streamEvents, 1).pipe(Stream.runDrain);
+
+        const canUseTool = harness.getLastCreateQueryInput()?.options.canUseTool;
+        if (!canUseTool) {
+          assert.fail("Expected canUseTool to be defined");
+          return;
+        }
+
+        const permissionPromise = canUseTool(
+          "AskUserQuestion",
+          {
+            questions: [
+              {
+                question: "Which environment?",
+                header: "Environment",
+                options: [{ label: "Staging", description: "Use staging" }],
+                multiSelect: false,
+              },
+            ],
+          },
+          {
+            signal: new AbortController().signal,
+            toolUseID: "tool-background-question",
+            agentID: "background-agent-1",
+            requestId: "request-background-question",
+          },
+        );
+
+        const requestedEvent = yield* Stream.runHead(adapter.streamEvents);
+        if (
+          requestedEvent._tag !== "Some" ||
+          requestedEvent.value.type !== "user-input.requested"
+        ) {
+          assert.fail("Expected user-input.requested event");
+          return;
+        }
+
+        const completedEventFiber = yield* Stream.filter(
+          adapter.streamEvents,
+          (event) => event.type === "turn.completed",
+        ).pipe(Stream.runHead, Effect.forkChild);
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          errors: [],
+          session_id: "sdk-session-background-question",
+          uuid: "result-background-question",
+        } as unknown as SDKMessage);
+
+        const completedEvent = yield* Fiber.join(completedEventFiber);
+        assert.equal(completedEvent._tag, "Some");
+        assert.equal(completedEvent._tag === "Some" && completedEvent.value.type, "turn.completed");
+
+        yield* adapter.respondToUserInput(
+          session.threadId,
+          ApprovalRequestId.makeUnsafe(requestedEvent.value.requestId!),
+          { Environment: "Staging" },
+        );
+        const resolvedEvent = yield* Stream.runHead(adapter.streamEvents);
+        assert.equal(resolvedEvent._tag, "Some");
+        assert.equal(
+          resolvedEvent._tag === "Some" && resolvedEvent.value.type,
+          "user-input.resolved",
+        );
+
+        const permissionResult = yield* Effect.promise(() => permissionPromise);
+        assert.equal((permissionResult as PermissionResult).behavior, "allow");
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
+  it.effect("accepts exactly one of two concurrent user-input responses", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+      });
+      yield* Stream.take(adapter.streamEvents, 3).pipe(Stream.runDrain);
+
+      const canUseTool = harness.getLastCreateQueryInput()?.options.canUseTool;
+      if (!canUseTool) {
+        assert.fail("Expected canUseTool to be defined");
+        return;
+      }
+      const permissionPromise = canUseTool(
+        "AskUserQuestion",
+        {
+          questions: [
+            {
+              question: "Choose a mode",
+              header: "Mode",
+              options: [
+                { label: "Safe", description: "Use safe mode" },
+                { label: "Fast", description: "Use fast mode" },
+              ],
+              multiSelect: false,
+            },
+          ],
+        },
+        {
+          signal: new AbortController().signal,
+          toolUseID: "tool-racing-question",
+          requestId: "request-racing-question",
+        },
+      );
+      const requestedEvent = yield* Stream.runHead(adapter.streamEvents);
+      if (requestedEvent._tag !== "Some" || requestedEvent.value.type !== "user-input.requested") {
+        assert.fail("Expected user-input.requested event");
+        return;
+      }
+      const requestId = ApprovalRequestId.makeUnsafe(requestedEvent.value.requestId!);
+
+      const responses = yield* Effect.all(
+        [
+          Effect.exit(adapter.respondToUserInput(session.threadId, requestId, { Mode: "Safe" })),
+          Effect.exit(adapter.respondToUserInput(session.threadId, requestId, { Mode: "Fast" })),
+        ],
+        { concurrency: "unbounded" },
+      );
+      assert.equal(responses.filter(Exit.isSuccess).length, 1);
+      assert.equal(responses.filter(Exit.isFailure).length, 1);
+
+      const resolvedEvent = yield* Stream.runHead(adapter.streamEvents);
+      assert.equal(resolvedEvent._tag, "Some");
+      assert.equal(
+        resolvedEvent._tag === "Some" && resolvedEvent.value.type,
+        "user-input.resolved",
+      );
+      const permissionResult = yield* Effect.promise(() => permissionPromise);
+      assert.equal((permissionResult as PermissionResult).behavior, "allow");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("accepts exactly one of two concurrent approval decisions", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "approval-required",
+      });
+      yield* Stream.take(adapter.streamEvents, 3).pipe(Stream.runDrain);
+
+      const canUseTool = harness.getLastCreateQueryInput()?.options.canUseTool;
+      if (!canUseTool) {
+        assert.fail("Expected canUseTool to be defined");
+        return;
+      }
+      const permissionPromise = canUseTool(
+        "Bash",
+        { command: "pwd" },
+        {
+          signal: new AbortController().signal,
+          toolUseID: "tool-racing-approval",
+          requestId: "request-racing-approval",
+        },
+      );
+      const requestedEvent = yield* Stream.runHead(adapter.streamEvents);
+      if (requestedEvent._tag !== "Some" || requestedEvent.value.type !== "request.opened") {
+        assert.fail("Expected request.opened event");
+        return;
+      }
+      const requestId = ApprovalRequestId.makeUnsafe(requestedEvent.value.requestId!);
+
+      const responses = yield* Effect.all(
+        [
+          Effect.exit(adapter.respondToRequest(session.threadId, requestId, "accept")),
+          Effect.exit(adapter.respondToRequest(session.threadId, requestId, "decline")),
+        ],
+        { concurrency: "unbounded" },
+      );
+      assert.equal(responses.filter(Exit.isSuccess).length, 1);
+      assert.equal(responses.filter(Exit.isFailure).length, 1);
+
+      const resolvedEvent = yield* Stream.runHead(adapter.streamEvents);
+      if (resolvedEvent._tag !== "Some" || resolvedEvent.value.type !== "request.resolved") {
+        assert.fail("Expected request.resolved event");
+        return;
+      }
+      const permissionResult = yield* Effect.promise(() => permissionPromise);
+      assert.equal(
+        (permissionResult as PermissionResult).behavior,
+        resolvedEvent.value.payload.decision === "accept" ? "allow" : "deny",
+      );
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -9511,7 +9511,12 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         assert.fail("Expected user-input.requested event");
         return;
       }
-      const requestId = requestedEvent.value.requestId;
+      const rawRequestId = requestedEvent.value.requestId;
+      if (!rawRequestId) {
+        assert.fail("Expected user-input request id");
+        return;
+      }
+      const requestId = ApprovalRequestId.makeUnsafe(rawRequestId);
 
       const terminalLifecycleFiber = yield* Stream.filter(
         adapter.streamEvents,
@@ -9556,7 +9561,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
       } satisfies PermissionResult);
 
       const lateResponse = yield* Effect.exit(
-        adapter.respondToUserInput(session.threadId, ApprovalRequestId.makeUnsafe(requestId), {
+        adapter.respondToUserInput(session.threadId, requestId, {
           Continue: "Yes",
         }),
       );

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -9550,7 +9550,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         assert.fail("Expected user-input.resolved before turn.completed");
         return;
       }
-      assert.equal(resolvedEvent.requestId, requestId);
+      assert.equal(resolvedEvent.requestId, rawRequestId);
       assert.deepEqual(resolvedEvent.payload.answers, {});
       assert.equal(resolvedEvent.turnId, terminalLifecycle[1]?.turnId);
 

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -9519,6 +9519,14 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
       ).pipe(Stream.take(2), Stream.runCollect, Effect.forkChild);
 
       harness.query.emit({
+        type: "system",
+        subtype: "task_updated",
+        task_id: "foreground-agent-terminal",
+        patch: { status: "completed" },
+        session_id: "sdk-session-user-input-terminal",
+        uuid: "task-updated-user-input-terminal",
+      } as unknown as SDKMessage);
+      harness.query.emit({
         type: "result",
         subtype: "success",
         is_error: false,
@@ -9560,7 +9568,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
   });
 
   it.effect(
-    "keeps background-agent questions actionable after the foreground turn completes",
+    "keeps background-agent questions actionable when the background marker arrives late",
     () => {
       const harness = makeHarness();
       return Effect.gen(function* () {
@@ -9578,16 +9586,6 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
           input: "start a background task",
           attachments: [],
         });
-        yield* Stream.take(adapter.streamEvents, 1).pipe(Stream.runDrain);
-
-        harness.query.emit({
-          type: "system",
-          subtype: "task_updated",
-          task_id: "background-agent-1",
-          patch: { is_backgrounded: true },
-          session_id: "sdk-session-background-question",
-          uuid: "task-updated-background-question",
-        } as unknown as SDKMessage);
         yield* Stream.take(adapter.streamEvents, 1).pipe(Stream.runDrain);
 
         const canUseTool = harness.getLastCreateQueryInput()?.options.canUseTool;
@@ -9641,6 +9639,21 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         const completedEvent = yield* Fiber.join(completedEventFiber);
         assert.equal(completedEvent._tag, "Some");
         assert.equal(completedEvent._tag === "Some" && completedEvent.value.type, "turn.completed");
+
+        harness.query.emit({
+          type: "system",
+          subtype: "task_updated",
+          task_id: "background-agent-1",
+          patch: { is_backgrounded: true },
+          session_id: "sdk-session-background-question",
+          uuid: "task-updated-background-question",
+        } as unknown as SDKMessage);
+        const backgroundedEvent = yield* Stream.runHead(adapter.streamEvents);
+        assert.equal(backgroundedEvent._tag, "Some");
+        assert.equal(
+          backgroundedEvent._tag === "Some" && backgroundedEvent.value.type,
+          "task.updated",
+        );
 
         yield* adapter.respondToUserInput(
           session.threadId,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -383,6 +383,10 @@ interface ClaudeSessionContext {
   // Live background-task ids. background_tasks_changed replaces the set while
   // task_updated patches close the ordering window around individual tasks.
   readonly knownBackgroundTaskIds: Set<string>;
+  // Task ids with provider-terminal evidence. Agent-scoped human interactions
+  // are cancelled only on this evidence (or whole-session stop), never merely
+  // because their parent foreground turn completed.
+  readonly terminalTaskIds: Set<string>;
   // Final status per tool-use id whose task already settled (terminal
   // task_updated or task_notification). Late messages still tagged with them
   // must not resurrect a scoped run: the synthetic turn that would start on
@@ -2576,7 +2580,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
     ): boolean =>
       scope.type === "session" ||
       (pending.turnId === scope.turnId &&
-        (pending.agentId === undefined || !context.knownBackgroundTaskIds.has(pending.agentId)));
+        (pending.agentId === undefined || context.terminalTaskIds.has(pending.agentId)));
 
     const settlePendingHumanInteractions = (
       context: ClaudeSessionContext,
@@ -2600,6 +2604,26 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         }
       });
 
+    const settlePendingHumanInteractionsForAgent = (
+      context: ClaudeSessionContext,
+      agentId: string,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        for (const [requestId, pending] of context.pendingApprovals) {
+          if (pending.agentId === agentId) {
+            yield* settlePendingApproval(context, requestId, pending, "cancel");
+          }
+        }
+        for (const [requestId, pending] of context.pendingUserInputs) {
+          if (pending.agentId === agentId) {
+            yield* settlePendingUserInput(context, requestId, pending, {
+              answers: {},
+              cancelled: true,
+            });
+          }
+        }
+      });
+
     const completeTurn = (
       context: ClaudeSessionContext,
       status: ProviderRuntimeTurnStatus,
@@ -2607,9 +2631,10 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
       result?: SDKResultMessage,
     ): Effect.Effect<void> =>
       Effect.gen(function* () {
-        // A terminal foreground turn cannot retain its own provider callbacks
-        // once the UI can no longer answer them. Background-agent callbacks
-        // remain actionable until they settle or the whole session stops.
+        // A terminal foreground turn cannot retain its root callbacks once the
+        // UI can no longer answer them. Agent callbacks remain actionable until
+        // their own task has provider-terminal evidence or the session stops;
+        // background membership messages may race the callback itself.
         if (context.turnState) {
           yield* settlePendingHumanInteractions(context, {
             type: "foregroundTurn",
@@ -2916,6 +2941,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           pendingSubagentSteers: new Map(),
           pendingSubagentStops: new Set(),
           knownBackgroundTaskIds: new Set(),
+          terminalTaskIds: new Set(),
           settledSubagentToolUseIds: new Map(),
           liveWorkflowTaskIds: new Set(),
           knownWorkflowTaskIds: new Set(),
@@ -3825,6 +3851,10 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           }
           const isTerminalStatus =
             status === "completed" || status === "failed" || status === "killed";
+          if (isTerminalStatus) {
+            context.terminalTaskIds.add(message.task_id);
+            yield* settlePendingHumanInteractionsForAgent(context, message.task_id);
+          }
           if (isTerminalStatus || isBackgrounded === false) {
             context.knownBackgroundTaskIds.delete(message.task_id);
           } else if (isBackgrounded === true) {
@@ -4029,6 +4059,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             });
             return;
           case "task_started": {
+            context.terminalTaskIds.delete(message.task_id);
             // Subagent tasks get a run entry so later task_progress/notification and
             // stopTask can be keyed by the Task tool_use_id ingestion routes on.
             if (
@@ -4140,6 +4171,8 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           }
           case "task_notification": {
             yield* emitTaskUsageSnapshot(context, message);
+            context.terminalTaskIds.add(message.task_id);
+            yield* settlePendingHumanInteractionsForAgent(context, message.task_id);
             context.knownBackgroundTaskIds.delete(message.task_id);
             const workflowTaskId = context.workflowTaskIdByMemberTaskId.get(message.task_id);
             // Settled workflows: the output file's workflowProgress carries the
@@ -4718,6 +4751,15 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             });
 
             pendingUserInputs.set(requestId, pendingInput);
+            if (
+              callbackOptions.agentID !== undefined &&
+              context.terminalTaskIds.has(callbackOptions.agentID)
+            ) {
+              yield* settlePendingUserInput(context, requestId, pendingInput, {
+                answers: {},
+                cancelled: true,
+              });
+            }
 
             // Handle abort (e.g. turn interrupted while waiting for user input).
             const onAbort = () => {
@@ -4911,6 +4953,12 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               });
 
               pendingApprovals.set(requestId, pendingApproval);
+              if (
+                callbackOptions.agentID !== undefined &&
+                context.terminalTaskIds.has(callbackOptions.agentID)
+              ) {
+                yield* settlePendingApproval(context, requestId, pendingApproval, "cancel");
+              }
 
               const onAbort = () => {
                 Effect.runFork(
@@ -5258,6 +5306,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             pendingSubagentSteers,
             pendingSubagentStops,
             knownBackgroundTaskIds: new Set(),
+            terminalTaskIds: new Set(),
             settledSubagentToolUseIds: new Map(),
             liveWorkflowTaskIds: new Set(),
             knownWorkflowTaskIds: new Set(),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -229,11 +229,24 @@ interface PendingApproval {
   readonly detail?: string;
   readonly suggestions?: ReadonlyArray<PermissionUpdate>;
   readonly decision: Deferred.Deferred<ProviderApprovalDecision>;
+  readonly settled: Deferred.Deferred<void>;
+  readonly turnId?: TurnId;
+  readonly providerItemId?: string;
+  settlementStarted: boolean;
+}
+
+interface PendingUserInputResult {
+  readonly answers: ProviderUserInputAnswers;
+  readonly cancelled: boolean;
 }
 
 interface PendingUserInput {
   readonly questions: ReadonlyArray<UserInputQuestion>;
-  readonly answers: Deferred.Deferred<ProviderUserInputAnswers>;
+  readonly result: Deferred.Deferred<PendingUserInputResult>;
+  readonly settled: Deferred.Deferred<void>;
+  readonly turnId?: TurnId;
+  readonly providerItemId?: string;
+  settlementStarted: boolean;
 }
 
 function coerceClaudeAnswerValue(value: unknown): string {
@@ -2450,6 +2463,119 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         });
       });
 
+    const settlePendingApproval = (
+      context: ClaudeSessionContext,
+      requestId: ApprovalRequestId,
+      pending: PendingApproval,
+      decision: ProviderApprovalDecision,
+    ): Effect.Effect<void> =>
+      Effect.uninterruptible(
+        Effect.gen(function* () {
+          const ownsSettlement = yield* Effect.sync(() => {
+            if (context.pendingApprovals.get(requestId) !== pending) {
+              return false;
+            }
+            if (pending.settlementStarted) {
+              return false;
+            }
+            pending.settlementStarted = true;
+            return true;
+          });
+          if (!ownsSettlement) {
+            yield* Deferred.await(pending.settled);
+            return;
+          }
+
+          const stamp = yield* makeEventStamp();
+          yield* offerRuntimeEvent(context, {
+            type: "request.resolved",
+            eventId: stamp.eventId,
+            provider: PROVIDER,
+            createdAt: stamp.createdAt,
+            threadId: context.session.threadId,
+            ...(pending.turnId ? { turnId: pending.turnId } : {}),
+            requestId: asRuntimeRequestId(requestId),
+            payload: {
+              requestType: pending.requestType,
+              decision,
+            },
+            providerRefs: nativeProviderRefs(context, {
+              providerItemId: pending.providerItemId,
+            }),
+            raw: {
+              source: "claude.sdk.permission",
+              method: "canUseTool/decision",
+              payload: { decision },
+            },
+          });
+          context.pendingApprovals.delete(requestId);
+          yield* Deferred.succeed(pending.decision, decision);
+          yield* Deferred.succeed(pending.settled, undefined);
+        }),
+      );
+
+    const settlePendingUserInput = (
+      context: ClaudeSessionContext,
+      requestId: ApprovalRequestId,
+      pending: PendingUserInput,
+      result: PendingUserInputResult,
+    ): Effect.Effect<void> =>
+      Effect.uninterruptible(
+        Effect.gen(function* () {
+          const ownsSettlement = yield* Effect.sync(() => {
+            if (context.pendingUserInputs.get(requestId) !== pending) {
+              return false;
+            }
+            if (pending.settlementStarted) {
+              return false;
+            }
+            pending.settlementStarted = true;
+            return true;
+          });
+          if (!ownsSettlement) {
+            yield* Deferred.await(pending.settled);
+            return;
+          }
+
+          const answers = remapAnswersToClaudeQuestionText(pending.questions, result.answers);
+          const stamp = yield* makeEventStamp();
+          yield* offerRuntimeEvent(context, {
+            type: "user-input.resolved",
+            eventId: stamp.eventId,
+            provider: PROVIDER,
+            createdAt: stamp.createdAt,
+            threadId: context.session.threadId,
+            ...(pending.turnId ? { turnId: pending.turnId } : {}),
+            requestId: asRuntimeRequestId(requestId),
+            payload: { answers },
+            providerRefs: nativeProviderRefs(context, {
+              providerItemId: pending.providerItemId,
+            }),
+            raw: {
+              source: "claude.sdk.permission",
+              method: "canUseTool/AskUserQuestion/resolved",
+              payload: { answers, cancelled: result.cancelled },
+            },
+          });
+          context.pendingUserInputs.delete(requestId);
+          yield* Deferred.succeed(pending.result, result);
+          yield* Deferred.succeed(pending.settled, undefined);
+        }),
+      );
+
+    const settlePendingHumanInteractions = (context: ClaudeSessionContext): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        for (const [requestId, pending] of context.pendingApprovals) {
+          yield* settlePendingApproval(context, requestId, pending, "cancel");
+        }
+        for (const [requestId, pending] of context.pendingUserInputs) {
+          yield* settlePendingUserInput(context, requestId, pending, {
+            answers: {},
+            cancelled: true,
+          });
+        }
+      });
+
     const completeTurn = (
       context: ClaudeSessionContext,
       status: ProviderRuntimeTurnStatus,
@@ -2457,6 +2583,11 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
       result?: SDKResultMessage,
     ): Effect.Effect<void> =>
       Effect.gen(function* () {
+        // A terminal turn cannot retain provider callbacks that the UI can no
+        // longer answer. Settle them before the terminal event so activity
+        // replay and durable pending state observe one ordered lifecycle.
+        yield* settlePendingHumanInteractions(context);
+
         const liveContextUsage = yield* readClaudeContextUsage(context);
         const resultContextWindow = maxClaudeContextWindowFromModelUsage(result?.modelUsage);
         const liveRawContextWindow = positiveFiniteNumber(liveContextUsage?.rawMaxTokens);
@@ -4319,25 +4450,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         yield* cancelAgentGatewayTurn(context.gatewaySessionLease, context.turnState?.turnId);
         context.gatewaySessionLease?.release();
 
-        for (const [requestId, pending] of context.pendingApprovals) {
-          yield* Deferred.succeed(pending.decision, "cancel");
-          const stamp = yield* makeEventStamp();
-          yield* offerRuntimeEvent(context, {
-            type: "request.resolved",
-            eventId: stamp.eventId,
-            provider: PROVIDER,
-            createdAt: stamp.createdAt,
-            threadId: context.session.threadId,
-            ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
-            requestId: asRuntimeRequestId(requestId),
-            payload: {
-              requestType: pending.requestType,
-              decision: "cancel",
-            },
-            providerRefs: nativeProviderRefs(context),
-          });
-        }
-        context.pendingApprovals.clear();
+        yield* settlePendingHumanInteractions(context);
 
         for (const run of context.subagentRuns.values()) {
           if (run.context.turnState) {
@@ -4529,11 +4642,15 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               }),
             );
 
-            const answersDeferred = yield* Deferred.make<ProviderUserInputAnswers>();
-            let aborted = false;
+            const resultDeferred = yield* Deferred.make<PendingUserInputResult>();
+            const settledDeferred = yield* Deferred.make<void>();
             const pendingInput: PendingUserInput = {
               questions,
-              answers: answersDeferred,
+              result: resultDeferred,
+              settled: settledDeferred,
+              ...(context.turnState ? { turnId: context.turnState.turnId } : {}),
+              ...(callbackOptions.toolUseID ? { providerItemId: callbackOptions.toolUseID } : {}),
+              settlementStarted: false,
             };
 
             // Emit user-input.requested so the UI can present the questions.
@@ -4561,50 +4678,25 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
 
             // Handle abort (e.g. turn interrupted while waiting for user input).
             const onAbort = () => {
-              if (!pendingUserInputs.has(requestId)) {
-                return;
-              }
-              aborted = true;
-              pendingUserInputs.delete(requestId);
-              Effect.runFork(Deferred.succeed(answersDeferred, {} as ProviderUserInputAnswers));
+              Effect.runFork(
+                settlePendingUserInput(context, requestId, pendingInput, {
+                  answers: {},
+                  cancelled: true,
+                }),
+              );
             };
             callbackOptions.signal.addEventListener("abort", onAbort, { once: true });
 
             // Block until the user provides answers.
-            const answers = remapAnswersToClaudeQuestionText(
-              questions,
-              yield* Deferred.await(answersDeferred).pipe(
-                Effect.ensuring(
-                  Effect.sync(() => {
-                    callbackOptions.signal.removeEventListener("abort", onAbort);
-                  }),
-                ),
+            const result = yield* Deferred.await(resultDeferred).pipe(
+              Effect.ensuring(
+                Effect.sync(() => {
+                  callbackOptions.signal.removeEventListener("abort", onAbort);
+                }),
               ),
             );
-            pendingUserInputs.delete(requestId);
 
-            // Emit user-input.resolved so the UI knows the interaction completed.
-            const resolvedStamp = yield* makeEventStamp();
-            yield* offerRuntimeEvent(context, {
-              type: "user-input.resolved",
-              eventId: resolvedStamp.eventId,
-              provider: PROVIDER,
-              createdAt: resolvedStamp.createdAt,
-              threadId: context.session.threadId,
-              ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
-              requestId: asRuntimeRequestId(requestId),
-              payload: { answers },
-              providerRefs: nativeProviderRefs(context, {
-                providerItemId: callbackOptions.toolUseID,
-              }),
-              raw: {
-                source: "claude.sdk.permission",
-                method: "canUseTool/AskUserQuestion/resolved",
-                payload: { answers },
-              },
-            });
-
-            if (aborted) {
+            if (result.cancelled) {
               return {
                 behavior: "deny",
                 message: "User cancelled tool execution.",
@@ -4617,7 +4709,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               behavior: "allow",
               updatedInput: {
                 questions: toolInput.questions,
-                answers,
+                answers: remapAnswersToClaudeQuestionText(questions, result.answers),
               },
             } satisfies PermissionResult;
           });
@@ -4719,10 +4811,15 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               const requestType = classifyRequestType(toolName);
               const detail = summarizeToolRequest(toolName, toolInput);
               const decisionDeferred = yield* Deferred.make<ProviderApprovalDecision>();
+              const settledDeferred = yield* Deferred.make<void>();
               const pendingApproval: PendingApproval = {
                 requestType,
                 detail,
                 decision: decisionDeferred,
+                settled: settledDeferred,
+                ...(context.turnState ? { turnId: context.turnState.turnId } : {}),
+                ...(callbackOptions.toolUseID ? { providerItemId: callbackOptions.toolUseID } : {}),
+                settlementStarted: false,
                 ...(callbackOptions.suggestions && callbackOptions.suggestions.length > 0
                   ? { suggestions: callbackOptions.suggestions }
                   : {}),
@@ -4767,11 +4864,9 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               pendingApprovals.set(requestId, pendingApproval);
 
               const onAbort = () => {
-                if (!pendingApprovals.has(requestId)) {
-                  return;
-                }
-                pendingApprovals.delete(requestId);
-                Effect.runFork(Deferred.succeed(decisionDeferred, "cancel"));
+                Effect.runFork(
+                  settlePendingApproval(context, requestId, pendingApproval, "cancel"),
+                );
               };
 
               callbackOptions.signal.addEventListener("abort", onAbort, {
@@ -4785,34 +4880,6 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
                   }),
                 ),
               );
-              pendingApprovals.delete(requestId);
-
-              const resolvedStamp = yield* makeEventStamp();
-              yield* offerRuntimeEvent(context, {
-                type: "request.resolved",
-                eventId: resolvedStamp.eventId,
-                provider: PROVIDER,
-                createdAt: resolvedStamp.createdAt,
-                threadId: context.session.threadId,
-                ...(context.turnState
-                  ? { turnId: asCanonicalTurnId(context.turnState.turnId) }
-                  : {}),
-                requestId: asRuntimeRequestId(requestId),
-                payload: {
-                  requestType,
-                  decision,
-                },
-                providerRefs: nativeProviderRefs(context, {
-                  providerItemId: callbackOptions.toolUseID,
-                }),
-                raw: {
-                  source: "claude.sdk.permission",
-                  method: "canUseTool/decision",
-                  payload: {
-                    decision,
-                  },
-                },
-              });
 
               if (decision === "accept" || decision === "acceptForSession") {
                 if (decision === "acceptForSession" && runtimeMode !== "auto") {
@@ -5734,8 +5801,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           });
         }
 
-        context.pendingApprovals.delete(requestId);
-        yield* Deferred.succeed(pending.decision, decision);
+        yield* settlePendingApproval(context, requestId, pending, decision);
       });
 
     const respondToUserInput: ClaudeAdapterShape["respondToUserInput"] = (
@@ -5754,8 +5820,10 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           });
         }
 
-        context.pendingUserInputs.delete(requestId);
-        yield* Deferred.succeed(pending.answers, answers);
+        yield* settlePendingUserInput(context, requestId, pending, {
+          answers,
+          cancelled: false,
+        });
       });
 
     const stopSession: ClaudeAdapterShape["stopSession"] = (threadId) =>

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -229,9 +229,10 @@ interface PendingApproval {
   readonly detail?: string;
   readonly suggestions?: ReadonlyArray<PermissionUpdate>;
   readonly decision: Deferred.Deferred<ProviderApprovalDecision>;
-  readonly settled: Deferred.Deferred<void>;
+  readonly settled: Deferred.Deferred<ProviderApprovalDecision>;
   readonly turnId?: TurnId;
   readonly providerItemId?: string;
+  readonly agentId?: string;
   settlementStarted: boolean;
 }
 
@@ -243,9 +244,10 @@ interface PendingUserInputResult {
 interface PendingUserInput {
   readonly questions: ReadonlyArray<UserInputQuestion>;
   readonly result: Deferred.Deferred<PendingUserInputResult>;
-  readonly settled: Deferred.Deferred<void>;
+  readonly settled: Deferred.Deferred<PendingUserInputResult>;
   readonly turnId?: TurnId;
   readonly providerItemId?: string;
+  readonly agentId?: string;
   settlementStarted: boolean;
 }
 
@@ -378,8 +380,8 @@ interface ClaudeSessionContext {
   // Stop requests that arrived before task_started mapped the tool_use_id to an
   // SDK task id; fired via query.stopTask the moment the mapping lands.
   readonly pendingSubagentStops: Set<string>;
-  // Last background-task ids from background_tasks_changed (REPLACE
-  // semantics); diffed so only newly backgrounded work gets announced.
+  // Live background-task ids. background_tasks_changed replaces the set while
+  // task_updated patches close the ordering window around individual tasks.
   readonly knownBackgroundTaskIds: Set<string>;
   // Final status per tool-use id whose task already settled (terminal
   // task_updated or task_notification). Late messages still tagged with them
@@ -2468,7 +2470,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
       requestId: ApprovalRequestId,
       pending: PendingApproval,
       decision: ProviderApprovalDecision,
-    ): Effect.Effect<void> =>
+    ): Effect.Effect<ProviderApprovalDecision> =>
       Effect.uninterruptible(
         Effect.gen(function* () {
           const ownsSettlement = yield* Effect.sync(() => {
@@ -2482,8 +2484,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             return true;
           });
           if (!ownsSettlement) {
-            yield* Deferred.await(pending.settled);
-            return;
+            return yield* Deferred.await(pending.settled);
           }
 
           const stamp = yield* makeEventStamp();
@@ -2510,7 +2511,8 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           });
           context.pendingApprovals.delete(requestId);
           yield* Deferred.succeed(pending.decision, decision);
-          yield* Deferred.succeed(pending.settled, undefined);
+          yield* Deferred.succeed(pending.settled, decision);
+          return decision;
         }),
       );
 
@@ -2519,7 +2521,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
       requestId: ApprovalRequestId,
       pending: PendingUserInput,
       result: PendingUserInputResult,
-    ): Effect.Effect<void> =>
+    ): Effect.Effect<PendingUserInputResult> =>
       Effect.uninterruptible(
         Effect.gen(function* () {
           const ownsSettlement = yield* Effect.sync(() => {
@@ -2533,8 +2535,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             return true;
           });
           if (!ownsSettlement) {
-            yield* Deferred.await(pending.settled);
-            return;
+            return yield* Deferred.await(pending.settled);
           }
 
           const answers = remapAnswersToClaudeQuestionText(pending.questions, result.answers);
@@ -2559,16 +2560,39 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           });
           context.pendingUserInputs.delete(requestId);
           yield* Deferred.succeed(pending.result, result);
-          yield* Deferred.succeed(pending.settled, undefined);
+          yield* Deferred.succeed(pending.settled, result);
+          return result;
         }),
       );
 
-    const settlePendingHumanInteractions = (context: ClaudeSessionContext): Effect.Effect<void> =>
+    type PendingInteractionSettlementScope =
+      | { readonly type: "session" }
+      | { readonly type: "foregroundTurn"; readonly turnId: TurnId };
+
+    const pendingBelongsToSettlementScope = (
+      context: ClaudeSessionContext,
+      pending: Pick<PendingApproval, "agentId" | "turnId">,
+      scope: PendingInteractionSettlementScope,
+    ): boolean =>
+      scope.type === "session" ||
+      (pending.turnId === scope.turnId &&
+        (pending.agentId === undefined || !context.knownBackgroundTaskIds.has(pending.agentId)));
+
+    const settlePendingHumanInteractions = (
+      context: ClaudeSessionContext,
+      scope: PendingInteractionSettlementScope,
+    ): Effect.Effect<void> =>
       Effect.gen(function* () {
         for (const [requestId, pending] of context.pendingApprovals) {
+          if (!pendingBelongsToSettlementScope(context, pending, scope)) {
+            continue;
+          }
           yield* settlePendingApproval(context, requestId, pending, "cancel");
         }
         for (const [requestId, pending] of context.pendingUserInputs) {
+          if (!pendingBelongsToSettlementScope(context, pending, scope)) {
+            continue;
+          }
           yield* settlePendingUserInput(context, requestId, pending, {
             answers: {},
             cancelled: true,
@@ -2583,10 +2607,15 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
       result?: SDKResultMessage,
     ): Effect.Effect<void> =>
       Effect.gen(function* () {
-        // A terminal turn cannot retain provider callbacks that the UI can no
-        // longer answer. Settle them before the terminal event so activity
-        // replay and durable pending state observe one ordered lifecycle.
-        yield* settlePendingHumanInteractions(context);
+        // A terminal foreground turn cannot retain its own provider callbacks
+        // once the UI can no longer answer them. Background-agent callbacks
+        // remain actionable until they settle or the whole session stops.
+        if (context.turnState) {
+          yield* settlePendingHumanInteractions(context, {
+            type: "foregroundTurn",
+            turnId: context.turnState.turnId,
+          });
+        }
 
         const liveContextUsage = yield* readClaudeContextUsage(context);
         const resultContextWindow = maxClaudeContextWindowFromModelUsage(result?.modelUsage);
@@ -3796,6 +3825,11 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           }
           const isTerminalStatus =
             status === "completed" || status === "failed" || status === "killed";
+          if (isTerminalStatus || isBackgrounded === false) {
+            context.knownBackgroundTaskIds.delete(message.task_id);
+          } else if (isBackgrounded === true) {
+            context.knownBackgroundTaskIds.add(message.task_id);
+          }
           const isSettledRuntimeStatus = isTerminalStatus || status === "paused";
           if (isSettledRuntimeStatus && context.liveWorkflowTaskIds.has(message.task_id)) {
             context.liveWorkflowTaskIds.delete(message.task_id);
@@ -4106,6 +4140,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           }
           case "task_notification": {
             yield* emitTaskUsageSnapshot(context, message);
+            context.knownBackgroundTaskIds.delete(message.task_id);
             const workflowTaskId = context.workflowTaskIdByMemberTaskId.get(message.task_id);
             // Settled workflows: the output file's workflowProgress carries the
             // final per-agent states/models the live stream never surfaced.
@@ -4450,7 +4485,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         yield* cancelAgentGatewayTurn(context.gatewaySessionLease, context.turnState?.turnId);
         context.gatewaySessionLease?.release();
 
-        yield* settlePendingHumanInteractions(context);
+        yield* settlePendingHumanInteractions(context, { type: "session" });
 
         for (const run of context.subagentRuns.values()) {
           if (run.context.turnState) {
@@ -4620,10 +4655,13 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         const handleAskUserQuestion = (
           context: ClaudeSessionContext,
           toolInput: Record<string, unknown>,
-          callbackOptions: { readonly signal: AbortSignal; readonly toolUseID?: string },
+          callbackOptions: Parameters<CanUseTool>[2],
         ) =>
           Effect.gen(function* () {
             const requestId = ApprovalRequestId.makeUnsafe(yield* Random.nextUUIDv4);
+            const interactionTurnId =
+              context.turnState?.turnId ??
+              (callbackOptions.agentID !== undefined ? context.lastTurnId : undefined);
 
             // Parse questions from the SDK's AskUserQuestion input.
             const rawQuestions = Array.isArray(toolInput.questions) ? toolInput.questions : [];
@@ -4643,13 +4681,16 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             );
 
             const resultDeferred = yield* Deferred.make<PendingUserInputResult>();
-            const settledDeferred = yield* Deferred.make<void>();
+            const settledDeferred = yield* Deferred.make<PendingUserInputResult>();
             const pendingInput: PendingUserInput = {
               questions,
               result: resultDeferred,
               settled: settledDeferred,
-              ...(context.turnState ? { turnId: context.turnState.turnId } : {}),
+              ...(interactionTurnId !== undefined ? { turnId: interactionTurnId } : {}),
               ...(callbackOptions.toolUseID ? { providerItemId: callbackOptions.toolUseID } : {}),
+              ...(callbackOptions.agentID !== undefined
+                ? { agentId: callbackOptions.agentID }
+                : {}),
               settlementStarted: false,
             };
 
@@ -4661,7 +4702,9 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               provider: PROVIDER,
               createdAt: requestedStamp.createdAt,
               threadId: context.session.threadId,
-              ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+              ...(interactionTurnId !== undefined
+                ? { turnId: asCanonicalTurnId(interactionTurnId) }
+                : {}),
               requestId: asRuntimeRequestId(requestId),
               payload: { questions },
               providerRefs: nativeProviderRefs(context, {
@@ -4810,15 +4853,21 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               const requestId = ApprovalRequestId.makeUnsafe(yield* Random.nextUUIDv4);
               const requestType = classifyRequestType(toolName);
               const detail = summarizeToolRequest(toolName, toolInput);
+              const interactionTurnId =
+                context.turnState?.turnId ??
+                (callbackOptions.agentID !== undefined ? context.lastTurnId : undefined);
               const decisionDeferred = yield* Deferred.make<ProviderApprovalDecision>();
-              const settledDeferred = yield* Deferred.make<void>();
+              const settledDeferred = yield* Deferred.make<ProviderApprovalDecision>();
               const pendingApproval: PendingApproval = {
                 requestType,
                 detail,
                 decision: decisionDeferred,
                 settled: settledDeferred,
-                ...(context.turnState ? { turnId: context.turnState.turnId } : {}),
+                ...(interactionTurnId !== undefined ? { turnId: interactionTurnId } : {}),
                 ...(callbackOptions.toolUseID ? { providerItemId: callbackOptions.toolUseID } : {}),
+                ...(callbackOptions.agentID !== undefined
+                  ? { agentId: callbackOptions.agentID }
+                  : {}),
                 settlementStarted: false,
                 ...(callbackOptions.suggestions && callbackOptions.suggestions.length > 0
                   ? { suggestions: callbackOptions.suggestions }
@@ -4832,8 +4881,8 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
                 provider: PROVIDER,
                 createdAt: requestedStamp.createdAt,
                 threadId: context.session.threadId,
-                ...(context.turnState
-                  ? { turnId: asCanonicalTurnId(context.turnState.turnId) }
+                ...(interactionTurnId !== undefined
+                  ? { turnId: asCanonicalTurnId(interactionTurnId) }
                   : {}),
                 requestId: asRuntimeRequestId(requestId),
                 payload: {
@@ -5801,7 +5850,14 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           });
         }
 
-        yield* settlePendingApproval(context, requestId, pending, decision);
+        const settledDecision = yield* settlePendingApproval(context, requestId, pending, decision);
+        if (settledDecision !== decision) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "item/requestApproval/decision",
+            detail: `Approval request ${requestId} was already resolved as ${settledDecision}.`,
+          });
+        }
       });
 
     const respondToUserInput: ClaudeAdapterShape["respondToUserInput"] = (
@@ -5820,10 +5876,23 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           });
         }
 
-        yield* settlePendingUserInput(context, requestId, pending, {
+        const submittedResult: PendingUserInputResult = {
           answers,
           cancelled: false,
-        });
+        };
+        const settledResult = yield* settlePendingUserInput(
+          context,
+          requestId,
+          pending,
+          submittedResult,
+        );
+        if (settledResult !== submittedResult) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "item/tool/respondToUserInput",
+            detail: `User-input request ${requestId} was already resolved.`,
+          });
+        }
       });
 
     const stopSession: ClaudeAdapterShape["stopSession"] = (threadId) =>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2568,12 +2568,18 @@ export default function ChatView({
     return () => window.clearTimeout(settle);
   }, [agentActivityTimelineState.detailById, openAgentActivityId]);
   const pendingApprovals = useMemo(
-    () => derivePendingApprovals(threadActivities, activeThread?.pendingInteractions),
-    [activeThread?.pendingInteractions, threadActivities],
+    () =>
+      derivePendingApprovals(threadActivities, activeThread?.pendingInteractions, {
+        authoritativeHasPending: activeThread?.hasPendingApprovals,
+      }),
+    [activeThread?.hasPendingApprovals, activeThread?.pendingInteractions, threadActivities],
   );
   const pendingUserInputs = useMemo(
-    () => derivePendingUserInputs(threadActivities, activeThread?.pendingInteractions),
-    [activeThread?.pendingInteractions, threadActivities],
+    () =>
+      derivePendingUserInputs(threadActivities, activeThread?.pendingInteractions, {
+        authoritativeHasPending: activeThread?.hasPendingUserInput,
+      }),
+    [activeThread?.hasPendingUserInput, activeThread?.pendingInteractions, threadActivities],
   );
   const activePendingUserInput = pendingUserInputs[0] ?? null;
   const activePendingUserInputKey = activePendingUserInput

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2571,15 +2571,27 @@ export default function ChatView({
     () =>
       derivePendingApprovals(threadActivities, activeThread?.pendingInteractions, {
         authoritativeHasPending: activeThread?.hasPendingApprovals,
+        latestTurn: activeThread?.latestTurn,
       }),
-    [activeThread?.hasPendingApprovals, activeThread?.pendingInteractions, threadActivities],
+    [
+      activeThread?.hasPendingApprovals,
+      activeThread?.latestTurn,
+      activeThread?.pendingInteractions,
+      threadActivities,
+    ],
   );
   const pendingUserInputs = useMemo(
     () =>
       derivePendingUserInputs(threadActivities, activeThread?.pendingInteractions, {
         authoritativeHasPending: activeThread?.hasPendingUserInput,
+        latestTurn: activeThread?.latestTurn,
       }),
-    [activeThread?.hasPendingUserInput, activeThread?.pendingInteractions, threadActivities],
+    [
+      activeThread?.hasPendingUserInput,
+      activeThread?.latestTurn,
+      activeThread?.pendingInteractions,
+      threadActivities,
+    ],
   );
   const activePendingUserInput = pendingUserInputs[0] ?? null;
   const activePendingUserInputKey = activePendingUserInput

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2571,11 +2571,11 @@ export default function ChatView({
     () =>
       derivePendingApprovals(threadActivities, activeThread?.pendingInteractions, {
         authoritativeHasPending: activeThread?.hasPendingApprovals,
-        latestTurn: activeThread?.latestTurn,
+        latestTurnId: activeThread?.latestTurn?.turnId,
       }),
     [
       activeThread?.hasPendingApprovals,
-      activeThread?.latestTurn,
+      activeThread?.latestTurn?.turnId,
       activeThread?.pendingInteractions,
       threadActivities,
     ],
@@ -2584,11 +2584,11 @@ export default function ChatView({
     () =>
       derivePendingUserInputs(threadActivities, activeThread?.pendingInteractions, {
         authoritativeHasPending: activeThread?.hasPendingUserInput,
-        latestTurn: activeThread?.latestTurn,
+        latestTurnId: activeThread?.latestTurn?.turnId,
       }),
     [
       activeThread?.hasPendingUserInput,
-      activeThread?.latestTurn,
+      activeThread?.latestTurn?.turnId,
       activeThread?.pendingInteractions,
       threadActivities,
     ],

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2850,10 +2850,14 @@ export default function Sidebar() {
       const isPinned = pinnedThreadIdSet.has(threadId);
       const hasPendingApprovals =
         threadSummary?.hasPendingApprovals ??
-        derivePendingApprovals(thread.activities, thread.pendingInteractions).length > 0;
+        derivePendingApprovals(thread.activities, thread.pendingInteractions, {
+          authoritativeHasPending: thread.hasPendingApprovals,
+        }).length > 0;
       const hasPendingUserInput =
         threadSummary?.hasPendingUserInput ??
-        derivePendingUserInputs(thread.activities, thread.pendingInteractions).length > 0;
+        derivePendingUserInputs(thread.activities, thread.pendingInteractions, {
+          authoritativeHasPending: thread.hasPendingUserInput,
+        }).length > 0;
       const canHandoff = canCreateThreadHandoff({
         thread,
         hasPendingApprovals,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2852,13 +2852,13 @@ export default function Sidebar() {
         threadSummary?.hasPendingApprovals ??
         derivePendingApprovals(thread.activities, thread.pendingInteractions, {
           authoritativeHasPending: thread.hasPendingApprovals,
-          latestTurn: thread.latestTurn,
+          latestTurnId: thread.latestTurn?.turnId,
         }).length > 0;
       const hasPendingUserInput =
         threadSummary?.hasPendingUserInput ??
         derivePendingUserInputs(thread.activities, thread.pendingInteractions, {
           authoritativeHasPending: thread.hasPendingUserInput,
-          latestTurn: thread.latestTurn,
+          latestTurnId: thread.latestTurn?.turnId,
         }).length > 0;
       const canHandoff = canCreateThreadHandoff({
         thread,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2852,11 +2852,13 @@ export default function Sidebar() {
         threadSummary?.hasPendingApprovals ??
         derivePendingApprovals(thread.activities, thread.pendingInteractions, {
           authoritativeHasPending: thread.hasPendingApprovals,
+          latestTurn: thread.latestTurn,
         }).length > 0;
       const hasPendingUserInput =
         threadSummary?.hasPendingUserInput ??
         derivePendingUserInputs(thread.activities, thread.pendingInteractions, {
           authoritativeHasPending: thread.hasPendingUserInput,
+          latestTurn: thread.latestTurn,
         }).length > 0;
       const canHandoff = canCreateThreadHandoff({
         thread,

--- a/apps/web/src/notifications/taskCompletion.logic.test.ts
+++ b/apps/web/src/notifications/taskCompletion.logic.test.ts
@@ -760,9 +760,10 @@ describe("buildTaskCompletionCopy", () => {
 
 describe("collectInputNeededThreadCandidates", () => {
   it("returns threads with newly opened approval requests", () => {
-    const previous = [makeThread({ activities: [] })];
+    const previous = [makeThread({ activities: [], hasPendingApprovals: false })];
     const next = [
       makeThread({
+        hasPendingApprovals: true,
         activities: [
           {
             id: EventId.makeUnsafe("activity-approval-1"),
@@ -794,9 +795,10 @@ describe("collectInputNeededThreadCandidates", () => {
   });
 
   it("returns threads with newly opened user-input requests", () => {
-    const previous = [makeThread({ activities: [] })];
+    const previous = [makeThread({ activities: [], hasPendingUserInput: false })];
     const next = [
       makeThread({
+        hasPendingUserInput: true,
         activities: [
           {
             id: EventId.makeUnsafe("activity-user-input-1"),
@@ -854,8 +856,37 @@ describe("collectInputNeededThreadCandidates", () => {
 
     expect(
       collectInputNeededThreadCandidates(
-        [makeThread({ activities })],
-        [makeThread({ activities })],
+        [makeThread({ activities, hasPendingApprovals: true })],
+        [makeThread({ activities, hasPendingApprovals: true })],
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not notify for a historical request when only the aggregate flag revives", () => {
+    const historicalActivity = {
+      id: EventId.makeUnsafe("activity-stale-user-input"),
+      tone: "info" as const,
+      kind: "user-input.requested",
+      summary: "User input requested",
+      payload: {
+        requestId: "stale-user-input-request",
+        questions: [
+          {
+            id: "question-stale",
+            header: "Question",
+            question: "Continue?",
+            options: [{ label: "Yes", description: "Continue" }],
+          },
+        ],
+      },
+      turnId: TurnId.makeUnsafe("turn-old"),
+      createdAt: "2026-04-05T09:00:00.000Z",
+    };
+
+    expect(
+      collectInputNeededThreadCandidates(
+        [makeThread({ activities: [historicalActivity], hasPendingUserInput: false })],
+        [makeThread({ activities: [historicalActivity], hasPendingUserInput: true })],
       ),
     ).toEqual([]);
   });

--- a/apps/web/src/notifications/taskCompletion.logic.test.ts
+++ b/apps/web/src/notifications/taskCompletion.logic.test.ts
@@ -6,6 +6,7 @@ import {
   ProjectId,
   ThreadId,
   TurnId,
+  type OrchestrationPendingInteraction,
 } from "@synara/contracts";
 import {
   buildInputNeededCopy,
@@ -52,6 +53,26 @@ function makeThread(overrides: Partial<Thread>): Thread {
     turnDiffSummaries: [],
     activities: [],
     ...overrides,
+  };
+}
+
+function makeInteraction(
+  interactionKind: OrchestrationPendingInteraction["interactionKind"],
+  requestId: string,
+  status: OrchestrationPendingInteraction["status"],
+): OrchestrationPendingInteraction {
+  return {
+    interactionKind,
+    requestId: ApprovalRequestId.makeUnsafe(requestId),
+    threadId: ThreadId.makeUnsafe("thread-1"),
+    turnId: TurnId.makeUnsafe("turn-1"),
+    lifecycleGeneration: "generation-1",
+    status,
+    decision: null,
+    responseCommandId: null,
+    responseRequestedAt: null,
+    createdAt: "2026-04-05T10:00:04.000Z",
+    resolvedAt: null,
   };
 }
 
@@ -889,6 +910,79 @@ describe("collectInputNeededThreadCandidates", () => {
         [makeThread({ activities: [historicalActivity], hasPendingUserInput: true })],
       ),
     ).toEqual([]);
+  });
+
+  it("notifies when a detailed approval becomes retryable", () => {
+    const activity = {
+      id: EventId.makeUnsafe("activity-retryable-approval"),
+      tone: "approval" as const,
+      kind: "approval.requested",
+      summary: "Command approval requested",
+      payload: {
+        requestId: "retryable-approval",
+        lifecycleGeneration: "generation-1",
+        requestKind: "command",
+      },
+      turnId: TurnId.makeUnsafe("turn-1"),
+      createdAt: "2026-04-05T10:00:04.000Z",
+    };
+
+    expect(
+      collectInputNeededThreadCandidates(
+        [
+          makeThread({
+            activities: [activity],
+            pendingInteractions: [makeInteraction("approval", "retryable-approval", "responding")],
+          }),
+        ],
+        [
+          makeThread({
+            activities: [activity],
+            pendingInteractions: [makeInteraction("approval", "retryable-approval", "retryable")],
+          }),
+        ],
+      ).map((candidate) => candidate.requestId),
+    ).toEqual([ApprovalRequestId.makeUnsafe("retryable-approval")]);
+  });
+
+  it("notifies when detailed user input becomes retryable", () => {
+    const activity = {
+      id: EventId.makeUnsafe("activity-retryable-input"),
+      tone: "info" as const,
+      kind: "user-input.requested",
+      summary: "User input requested",
+      payload: {
+        requestId: "retryable-input",
+        lifecycleGeneration: "generation-1",
+        questions: [
+          {
+            id: "question-retryable",
+            header: "Question",
+            question: "Try again?",
+            options: [{ label: "Yes", description: "Retry" }],
+          },
+        ],
+      },
+      turnId: TurnId.makeUnsafe("turn-1"),
+      createdAt: "2026-04-05T10:00:04.000Z",
+    };
+
+    expect(
+      collectInputNeededThreadCandidates(
+        [
+          makeThread({
+            activities: [activity],
+            pendingInteractions: [makeInteraction("userInput", "retryable-input", "responding")],
+          }),
+        ],
+        [
+          makeThread({
+            activities: [activity],
+            pendingInteractions: [makeInteraction("userInput", "retryable-input", "retryable")],
+          }),
+        ],
+      ).map((candidate) => candidate.requestId),
+    ).toEqual([ApprovalRequestId.makeUnsafe("retryable-input")]);
   });
 });
 

--- a/apps/web/src/notifications/taskCompletion.logic.ts
+++ b/apps/web/src/notifications/taskCompletion.logic.ts
@@ -697,9 +697,10 @@ export function collectThreadAttentionCandidates(
     })) {
       if (
         previousApprovalIds.has(approval.requestId) ||
-        previousApprovalActivityKeys.has(
-          pendingRequestInstanceKey(approval.requestId, approval.lifecycleGeneration),
-        )
+        (thread.pendingInteractions === undefined &&
+          previousApprovalActivityKeys.has(
+            pendingRequestInstanceKey(approval.requestId, approval.lifecycleGeneration),
+          ))
       ) {
         continue;
       }
@@ -720,9 +721,10 @@ export function collectThreadAttentionCandidates(
     })) {
       if (
         previousUserInputIds.has(request.requestId) ||
-        previousUserInputActivityKeys.has(
-          pendingRequestInstanceKey(request.requestId, request.lifecycleGeneration),
-        )
+        (thread.pendingInteractions === undefined &&
+          previousUserInputActivityKeys.has(
+            pendingRequestInstanceKey(request.requestId, request.lifecycleGeneration),
+          ))
       ) {
         continue;
       }

--- a/apps/web/src/notifications/taskCompletion.logic.ts
+++ b/apps/web/src/notifications/taskCompletion.logic.ts
@@ -8,6 +8,7 @@ import {
   type TerminalCliKind,
   type TerminalVisualState,
 } from "@synara/shared/terminalThreads";
+import { pendingRequestInstanceKey } from "@synara/shared/threadSummary";
 import type { Thread, ThreadSession } from "../types";
 import {
   derivePendingApprovals,
@@ -633,6 +634,28 @@ function approvalSummary(
   }
 }
 
+function requestedActivityInstanceKeys(
+  activities: Thread["activities"],
+  kind: "approval.requested" | "user-input.requested",
+): Set<string> {
+  return new Set(
+    activities.flatMap((activity) => {
+      if (activity.kind !== kind || !activity.payload) return [];
+      const payload = activity.payload as Record<string, unknown>;
+      return typeof payload.requestId === "string"
+        ? [
+            pendingRequestInstanceKey(
+              payload.requestId,
+              typeof payload.lifecycleGeneration === "string"
+                ? payload.lifecycleGeneration
+                : undefined,
+            ),
+          ]
+        : [];
+    }),
+  );
+}
+
 // Compare consecutive activity snapshots and emit only fresh input-needed transitions.
 export function collectThreadAttentionCandidates(
   previousThreads: readonly Thread[],
@@ -659,12 +682,25 @@ export function collectThreadAttentionCandidates(
         latestTurn: previousThread.latestTurn,
       }).map((request) => request.requestId),
     );
+    const previousApprovalActivityKeys = requestedActivityInstanceKeys(
+      previousThread.activities,
+      "approval.requested",
+    );
+    const previousUserInputActivityKeys = requestedActivityInstanceKeys(
+      previousThread.activities,
+      "user-input.requested",
+    );
 
     for (const approval of derivePendingApprovals(thread.activities, thread.pendingInteractions, {
       authoritativeHasPending: thread.hasPendingApprovals,
       latestTurn: thread.latestTurn,
     })) {
-      if (previousApprovalIds.has(approval.requestId)) {
+      if (
+        previousApprovalIds.has(approval.requestId) ||
+        previousApprovalActivityKeys.has(
+          pendingRequestInstanceKey(approval.requestId, approval.lifecycleGeneration),
+        )
+      ) {
         continue;
       }
       candidates.push({
@@ -682,7 +718,12 @@ export function collectThreadAttentionCandidates(
       authoritativeHasPending: thread.hasPendingUserInput,
       latestTurn: thread.latestTurn,
     })) {
-      if (previousUserInputIds.has(request.requestId)) {
+      if (
+        previousUserInputIds.has(request.requestId) ||
+        previousUserInputActivityKeys.has(
+          pendingRequestInstanceKey(request.requestId, request.lifecycleGeneration),
+        )
+      ) {
         continue;
       }
       candidates.push({

--- a/apps/web/src/notifications/taskCompletion.logic.ts
+++ b/apps/web/src/notifications/taskCompletion.logic.ts
@@ -673,13 +673,13 @@ export function collectThreadAttentionCandidates(
     const previousApprovalIds = new Set(
       derivePendingApprovals(previousThread.activities, previousThread.pendingInteractions, {
         authoritativeHasPending: previousThread.hasPendingApprovals,
-        latestTurn: previousThread.latestTurn,
+        latestTurnId: previousThread.latestTurn?.turnId,
       }).map((approval) => approval.requestId),
     );
     const previousUserInputIds = new Set(
       derivePendingUserInputs(previousThread.activities, previousThread.pendingInteractions, {
         authoritativeHasPending: previousThread.hasPendingUserInput,
-        latestTurn: previousThread.latestTurn,
+        latestTurnId: previousThread.latestTurn?.turnId,
       }).map((request) => request.requestId),
     );
     const previousApprovalActivityKeys = requestedActivityInstanceKeys(
@@ -693,7 +693,7 @@ export function collectThreadAttentionCandidates(
 
     for (const approval of derivePendingApprovals(thread.activities, thread.pendingInteractions, {
       authoritativeHasPending: thread.hasPendingApprovals,
-      latestTurn: thread.latestTurn,
+      latestTurnId: thread.latestTurn?.turnId,
     })) {
       if (
         previousApprovalIds.has(approval.requestId) ||
@@ -716,7 +716,7 @@ export function collectThreadAttentionCandidates(
 
     for (const request of derivePendingUserInputs(thread.activities, thread.pendingInteractions, {
       authoritativeHasPending: thread.hasPendingUserInput,
-      latestTurn: thread.latestTurn,
+      latestTurnId: thread.latestTurn?.turnId,
     })) {
       if (
         previousUserInputIds.has(request.requestId) ||

--- a/apps/web/src/notifications/taskCompletion.logic.ts
+++ b/apps/web/src/notifications/taskCompletion.logic.ts
@@ -648,17 +648,19 @@ export function collectThreadAttentionCandidates(
     }
 
     const previousApprovalIds = new Set(
-      derivePendingApprovals(previousThread.activities, previousThread.pendingInteractions).map(
-        (approval) => approval.requestId,
-      ),
+      derivePendingApprovals(previousThread.activities, previousThread.pendingInteractions, {
+        authoritativeHasPending: previousThread.hasPendingApprovals,
+      }).map((approval) => approval.requestId),
     );
     const previousUserInputIds = new Set(
-      derivePendingUserInputs(previousThread.activities, previousThread.pendingInteractions).map(
-        (request) => request.requestId,
-      ),
+      derivePendingUserInputs(previousThread.activities, previousThread.pendingInteractions, {
+        authoritativeHasPending: previousThread.hasPendingUserInput,
+      }).map((request) => request.requestId),
     );
 
-    for (const approval of derivePendingApprovals(thread.activities, thread.pendingInteractions)) {
+    for (const approval of derivePendingApprovals(thread.activities, thread.pendingInteractions, {
+      authoritativeHasPending: thread.hasPendingApprovals,
+    })) {
       if (previousApprovalIds.has(approval.requestId)) {
         continue;
       }
@@ -673,7 +675,9 @@ export function collectThreadAttentionCandidates(
       });
     }
 
-    for (const request of derivePendingUserInputs(thread.activities, thread.pendingInteractions)) {
+    for (const request of derivePendingUserInputs(thread.activities, thread.pendingInteractions, {
+      authoritativeHasPending: thread.hasPendingUserInput,
+    })) {
       if (previousUserInputIds.has(request.requestId)) {
         continue;
       }

--- a/apps/web/src/notifications/taskCompletion.logic.ts
+++ b/apps/web/src/notifications/taskCompletion.logic.ts
@@ -650,16 +650,19 @@ export function collectThreadAttentionCandidates(
     const previousApprovalIds = new Set(
       derivePendingApprovals(previousThread.activities, previousThread.pendingInteractions, {
         authoritativeHasPending: previousThread.hasPendingApprovals,
+        latestTurn: previousThread.latestTurn,
       }).map((approval) => approval.requestId),
     );
     const previousUserInputIds = new Set(
       derivePendingUserInputs(previousThread.activities, previousThread.pendingInteractions, {
         authoritativeHasPending: previousThread.hasPendingUserInput,
+        latestTurn: previousThread.latestTurn,
       }).map((request) => request.requestId),
     );
 
     for (const approval of derivePendingApprovals(thread.activities, thread.pendingInteractions, {
       authoritativeHasPending: thread.hasPendingApprovals,
+      latestTurn: thread.latestTurn,
     })) {
       if (previousApprovalIds.has(approval.requestId)) {
         continue;
@@ -677,6 +680,7 @@ export function collectThreadAttentionCandidates(
 
     for (const request of derivePendingUserInputs(thread.activities, thread.pendingInteractions, {
       authoritativeHasPending: thread.hasPendingUserInput,
+      latestTurn: thread.latestTurn,
     })) {
       if (previousUserInputIds.has(request.requestId)) {
         continue;

--- a/apps/web/src/pendingInteractionDerivation.test.ts
+++ b/apps/web/src/pendingInteractionDerivation.test.ts
@@ -1,6 +1,8 @@
 import {
   ApprovalRequestId,
   ThreadId,
+  TurnId,
+  type OrchestrationLatestTurn,
   type OrchestrationPendingInteraction,
   type OrchestrationThreadActivity,
 } from "@synara/contracts";
@@ -8,6 +10,20 @@ import { describe, expect, it } from "vitest";
 
 import { derivePendingApprovals, derivePendingUserInputs } from "./pendingInteractionDerivation";
 import { makeActivity } from "./storeTestFixtures";
+
+function makeLatestTurn(
+  turnId: string,
+  state: OrchestrationLatestTurn["state"] = "running",
+): OrchestrationLatestTurn {
+  return {
+    turnId: TurnId.makeUnsafe(turnId),
+    state,
+    requestedAt: "2026-02-23T00:00:00.000Z",
+    startedAt: "2026-02-23T00:00:00.000Z",
+    completedAt: state === "running" ? null : "2026-02-23T00:00:03.000Z",
+    assistantMessageId: null,
+  };
+}
 
 function makePendingInteraction(
   interactionKind: OrchestrationPendingInteraction["interactionKind"],
@@ -57,15 +73,17 @@ describe("derivePendingApprovals", () => {
     expect(
       derivePendingApprovals(activities, [makePendingInteraction("approval", "pending")], {
         authoritativeHasPending: false,
+        latestTurn: null,
       }),
     ).toHaveLength(1);
   });
 
-  it("does not resurrect historical approvals when the authoritative flag is false", () => {
+  it("does not resurrect historical approvals when aggregate state flips false to true", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
         id: "approval-legacy-stale",
         createdAt: "2026-02-23T00:00:01.000Z",
+        turnId: "turn-old",
         kind: "approval.requested",
         summary: "Command approval requested",
         tone: "approval",
@@ -75,13 +93,52 @@ describe("derivePendingApprovals", () => {
         },
       }),
     ];
+    const options = {
+      authoritativeHasPending: false,
+      latestTurn: makeLatestTurn("turn-current"),
+    };
 
+    expect(derivePendingApprovals(activities, undefined, options)).toEqual([]);
     expect(
-      derivePendingApprovals(activities, undefined, { authoritativeHasPending: false }),
+      derivePendingApprovals(activities, undefined, {
+        ...options,
+        authoritativeHasPending: undefined,
+      }),
     ).toEqual([]);
     expect(
-      derivePendingApprovals(activities, undefined, { authoritativeHasPending: true }),
-    ).toHaveLength(1);
+      derivePendingApprovals(activities, undefined, {
+        ...options,
+        authoritativeHasPending: true,
+      }),
+    ).toEqual([]);
+
+    const freshActivities = [
+      ...activities,
+      makeActivity({
+        id: "approval-current",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        turnId: "turn-current",
+        kind: "approval.requested",
+        summary: "Command approval requested",
+        tone: "approval",
+        payload: {
+          requestId: "req-current",
+          requestKind: "command",
+        },
+      }),
+    ];
+    expect(
+      derivePendingApprovals(freshActivities, undefined, {
+        ...options,
+        authoritativeHasPending: true,
+      }).map((pending) => pending.requestId),
+    ).toEqual(["req-current"]);
+    expect(
+      derivePendingApprovals(freshActivities, undefined, {
+        ...options,
+        authoritativeHasPending: undefined,
+      }).map((pending) => pending.requestId),
+    ).toEqual(["req-current"]);
   });
 
   it("tracks open approvals and removes resolved ones", () => {
@@ -333,15 +390,17 @@ describe("derivePendingUserInputs", () => {
     expect(
       derivePendingUserInputs(activities, [makePendingInteraction("userInput", "pending")], {
         authoritativeHasPending: false,
+        latestTurn: null,
       }),
     ).toHaveLength(1);
   });
 
-  it("does not resurrect historical questions when the authoritative flag is false", () => {
+  it("does not resurrect historical questions when aggregate state flips false to true", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
         id: "user-input-legacy-stale",
         createdAt: "2026-02-23T00:00:01.000Z",
+        turnId: "turn-old",
         kind: "user-input.requested",
         summary: "User input requested",
         tone: "info",
@@ -358,13 +417,133 @@ describe("derivePendingUserInputs", () => {
         },
       }),
     ];
+    const options = {
+      authoritativeHasPending: false,
+      latestTurn: makeLatestTurn("turn-current"),
+    };
 
+    expect(derivePendingUserInputs(activities, undefined, options)).toEqual([]);
     expect(
-      derivePendingUserInputs(activities, undefined, { authoritativeHasPending: false }),
+      derivePendingUserInputs(activities, undefined, {
+        ...options,
+        authoritativeHasPending: undefined,
+      }),
     ).toEqual([]);
     expect(
-      derivePendingUserInputs(activities, undefined, { authoritativeHasPending: true }),
-    ).toHaveLength(1);
+      derivePendingUserInputs(activities, undefined, {
+        ...options,
+        authoritativeHasPending: true,
+      }),
+    ).toEqual([]);
+
+    const freshActivities = [
+      ...activities,
+      makeActivity({
+        id: "user-input-current",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        turnId: "turn-current",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        tone: "info",
+        payload: {
+          requestId: "req-user-input-current",
+          questions: [
+            {
+              id: "mode",
+              header: "Mode",
+              question: "Which mode?",
+              options: [{ label: "safe", description: "Use safe mode" }],
+            },
+          ],
+        },
+      }),
+    ];
+    expect(
+      derivePendingUserInputs(freshActivities, undefined, {
+        ...options,
+        authoritativeHasPending: true,
+      }).map((pending) => pending.requestId),
+    ).toEqual(["req-user-input-current"]);
+    expect(
+      derivePendingUserInputs(freshActivities, undefined, {
+        ...options,
+        authoritativeHasPending: undefined,
+      }).map((pending) => pending.requestId),
+    ).toEqual(["req-user-input-current"]);
+  });
+
+  it("keeps a latest-turn background question visible after that turn completes", () => {
+    const activities = [
+      makeActivity({
+        id: "user-input-background",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        turnId: "turn-completed",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        tone: "info",
+        payload: {
+          requestId: "req-user-input-background",
+          questions: [
+            {
+              id: "environment",
+              header: "Environment",
+              question: "Which environment?",
+              options: [{ label: "staging", description: "Use staging" }],
+            },
+          ],
+        },
+      }),
+    ];
+
+    expect(
+      derivePendingUserInputs(activities, undefined, {
+        authoritativeHasPending: true,
+        latestTurn: makeLatestTurn("turn-completed", "completed"),
+      }).map((pending) => pending.requestId),
+    ).toEqual(["req-user-input-background"]);
+  });
+
+  it("clears a latest-turn question with a thread-scoped stale response failure", () => {
+    const activities = [
+      makeActivity({
+        id: "user-input-current-stale",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        turnId: "turn-current",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        tone: "info",
+        payload: {
+          requestId: "req-user-input-current-stale",
+          questions: [
+            {
+              id: "environment",
+              header: "Environment",
+              question: "Which environment?",
+              options: [{ label: "staging", description: "Use staging" }],
+            },
+          ],
+        },
+      }),
+      makeActivity({
+        id: "user-input-current-stale-failure",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        turnId: null,
+        kind: "provider.user-input.respond.failed",
+        summary: "Provider user input response failed",
+        tone: "error",
+        payload: {
+          requestId: "req-user-input-current-stale",
+          detail: "Unknown pending user-input request: req-user-input-current-stale",
+        },
+      }),
+    ];
+
+    expect(
+      derivePendingUserInputs(activities, undefined, {
+        authoritativeHasPending: true,
+        latestTurn: makeLatestTurn("turn-current"),
+      }),
+    ).toEqual([]);
   });
 
   it("tracks open structured prompts and removes resolved ones", () => {

--- a/apps/web/src/pendingInteractionDerivation.test.ts
+++ b/apps/web/src/pendingInteractionDerivation.test.ts
@@ -78,7 +78,7 @@ describe("derivePendingApprovals", () => {
     ).toHaveLength(1);
   });
 
-  it("does not resurrect historical approvals when aggregate state flips false to true", () => {
+  it("bounds aggregate-only approval replay to the newest turn with requests", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
         id: "approval-legacy-stale",
@@ -109,8 +109,8 @@ describe("derivePendingApprovals", () => {
       derivePendingApprovals(activities, undefined, {
         ...options,
         authoritativeHasPending: true,
-      }),
-    ).toEqual([]);
+      }).map((pending) => pending.requestId),
+    ).toEqual(["req-legacy-stale"]);
 
     const freshActivities = [
       ...activities,
@@ -126,19 +126,31 @@ describe("derivePendingApprovals", () => {
           requestKind: "command",
         },
       }),
+      makeActivity({
+        id: "approval-current-concurrent",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        turnId: "turn-current",
+        kind: "approval.requested",
+        summary: "Command approval requested",
+        tone: "approval",
+        payload: {
+          requestId: "req-current-concurrent",
+          requestKind: "command",
+        },
+      }),
     ];
     expect(
       derivePendingApprovals(freshActivities, undefined, {
         ...options,
         authoritativeHasPending: true,
       }).map((pending) => pending.requestId),
-    ).toEqual(["req-current"]);
+    ).toEqual(["req-current", "req-current-concurrent"]);
     expect(
       derivePendingApprovals(freshActivities, undefined, {
         ...options,
         authoritativeHasPending: undefined,
       }).map((pending) => pending.requestId),
-    ).toEqual(["req-current"]);
+    ).toEqual(["req-current", "req-current-concurrent"]);
   });
 
   it("tracks open approvals and removes resolved ones", () => {
@@ -395,7 +407,7 @@ describe("derivePendingUserInputs", () => {
     ).toHaveLength(1);
   });
 
-  it("does not resurrect historical questions when aggregate state flips false to true", () => {
+  it("uses explicit aggregate input as evidence for the newest unresolved question", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
         id: "user-input-legacy-stale",
@@ -433,8 +445,8 @@ describe("derivePendingUserInputs", () => {
       derivePendingUserInputs(activities, undefined, {
         ...options,
         authoritativeHasPending: true,
-      }),
-    ).toEqual([]);
+      }).map((pending) => pending.requestId),
+    ).toEqual(["req-user-input-legacy-stale"]);
 
     const freshActivities = [
       ...activities,
@@ -472,7 +484,7 @@ describe("derivePendingUserInputs", () => {
     ).toEqual(["req-user-input-current"]);
   });
 
-  it("keeps a latest-turn background question visible after that turn completes", () => {
+  it("keeps the newest unresolved background question visible across later turns", () => {
     const activities = [
       makeActivity({
         id: "user-input-background",
@@ -498,7 +510,7 @@ describe("derivePendingUserInputs", () => {
     expect(
       derivePendingUserInputs(activities, undefined, {
         authoritativeHasPending: true,
-        latestTurn: makeLatestTurn("turn-completed", "completed"),
+        latestTurn: makeLatestTurn("turn-newer"),
       }).map((pending) => pending.requestId),
     ).toEqual(["req-user-input-background"]);
   });
@@ -527,7 +539,6 @@ describe("derivePendingUserInputs", () => {
       makeActivity({
         id: "user-input-current-stale-failure",
         createdAt: "2026-02-23T00:00:02.000Z",
-        turnId: null,
         kind: "provider.user-input.respond.failed",
         summary: "Provider user input response failed",
         tone: "error",

--- a/apps/web/src/pendingInteractionDerivation.test.ts
+++ b/apps/web/src/pendingInteractionDerivation.test.ts
@@ -54,6 +54,34 @@ describe("derivePendingApprovals", () => {
     expect(
       derivePendingApprovals(activities, [makePendingInteraction("approval", "retryable")]),
     ).toHaveLength(1);
+    expect(
+      derivePendingApprovals(activities, [makePendingInteraction("approval", "pending")], {
+        authoritativeHasPending: false,
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("does not resurrect historical approvals when the authoritative flag is false", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "approval-legacy-stale",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "approval.requested",
+        summary: "Command approval requested",
+        tone: "approval",
+        payload: {
+          requestId: "req-legacy-stale",
+          requestKind: "command",
+        },
+      }),
+    ];
+
+    expect(
+      derivePendingApprovals(activities, undefined, { authoritativeHasPending: false }),
+    ).toEqual([]);
+    expect(
+      derivePendingApprovals(activities, undefined, { authoritativeHasPending: true }),
+    ).toHaveLength(1);
   });
 
   it("tracks open approvals and removes resolved ones", () => {
@@ -301,6 +329,41 @@ describe("derivePendingUserInputs", () => {
     ).toEqual([]);
     expect(
       derivePendingUserInputs(activities, [makePendingInteraction("userInput", "pending")]),
+    ).toHaveLength(1);
+    expect(
+      derivePendingUserInputs(activities, [makePendingInteraction("userInput", "pending")], {
+        authoritativeHasPending: false,
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("does not resurrect historical questions when the authoritative flag is false", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "user-input-legacy-stale",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        tone: "info",
+        payload: {
+          requestId: "req-user-input-legacy-stale",
+          questions: [
+            {
+              id: "mode",
+              header: "Mode",
+              question: "Which mode?",
+              options: [{ label: "safe", description: "Use safe mode" }],
+            },
+          ],
+        },
+      }),
+    ];
+
+    expect(
+      derivePendingUserInputs(activities, undefined, { authoritativeHasPending: false }),
+    ).toEqual([]);
+    expect(
+      derivePendingUserInputs(activities, undefined, { authoritativeHasPending: true }),
     ).toHaveLength(1);
   });
 

--- a/apps/web/src/pendingInteractionDerivation.test.ts
+++ b/apps/web/src/pendingInteractionDerivation.test.ts
@@ -2,7 +2,6 @@ import {
   ApprovalRequestId,
   ThreadId,
   TurnId,
-  type OrchestrationLatestTurn,
   type OrchestrationPendingInteraction,
   type OrchestrationThreadActivity,
 } from "@synara/contracts";
@@ -10,20 +9,6 @@ import { describe, expect, it } from "vitest";
 
 import { derivePendingApprovals, derivePendingUserInputs } from "./pendingInteractionDerivation";
 import { makeActivity } from "./storeTestFixtures";
-
-function makeLatestTurn(
-  turnId: string,
-  state: OrchestrationLatestTurn["state"] = "running",
-): OrchestrationLatestTurn {
-  return {
-    turnId: TurnId.makeUnsafe(turnId),
-    state,
-    requestedAt: "2026-02-23T00:00:00.000Z",
-    startedAt: "2026-02-23T00:00:00.000Z",
-    completedAt: state === "running" ? null : "2026-02-23T00:00:03.000Z",
-    assistantMessageId: null,
-  };
-}
 
 function makePendingInteraction(
   interactionKind: OrchestrationPendingInteraction["interactionKind"],
@@ -73,7 +58,7 @@ describe("derivePendingApprovals", () => {
     expect(
       derivePendingApprovals(activities, [makePendingInteraction("approval", "pending")], {
         authoritativeHasPending: false,
-        latestTurn: null,
+        latestTurnId: undefined,
       }),
     ).toHaveLength(1);
   });
@@ -95,7 +80,7 @@ describe("derivePendingApprovals", () => {
     ];
     const options = {
       authoritativeHasPending: false,
-      latestTurn: makeLatestTurn("turn-current"),
+      latestTurnId: TurnId.makeUnsafe("turn-current"),
     };
 
     expect(derivePendingApprovals(activities, undefined, options)).toEqual([]);
@@ -402,7 +387,7 @@ describe("derivePendingUserInputs", () => {
     expect(
       derivePendingUserInputs(activities, [makePendingInteraction("userInput", "pending")], {
         authoritativeHasPending: false,
-        latestTurn: null,
+        latestTurnId: undefined,
       }),
     ).toHaveLength(1);
   });
@@ -431,7 +416,7 @@ describe("derivePendingUserInputs", () => {
     ];
     const options = {
       authoritativeHasPending: false,
-      latestTurn: makeLatestTurn("turn-current"),
+      latestTurnId: TurnId.makeUnsafe("turn-current"),
     };
 
     expect(derivePendingUserInputs(activities, undefined, options)).toEqual([]);
@@ -510,7 +495,7 @@ describe("derivePendingUserInputs", () => {
     expect(
       derivePendingUserInputs(activities, undefined, {
         authoritativeHasPending: true,
-        latestTurn: makeLatestTurn("turn-newer"),
+        latestTurnId: TurnId.makeUnsafe("turn-newer"),
       }).map((pending) => pending.requestId),
     ).toEqual(["req-user-input-background"]);
   });
@@ -552,7 +537,7 @@ describe("derivePendingUserInputs", () => {
     expect(
       derivePendingUserInputs(activities, undefined, {
         authoritativeHasPending: true,
-        latestTurn: makeLatestTurn("turn-current"),
+        latestTurnId: TurnId.makeUnsafe("turn-current"),
       }),
     ).toEqual([]);
   });

--- a/apps/web/src/pendingInteractionDerivation.ts
+++ b/apps/web/src/pendingInteractionDerivation.ts
@@ -1,8 +1,8 @@
 import {
   ApprovalRequestId,
-  type OrchestrationLatestTurn,
   type OrchestrationPendingInteraction,
   type OrchestrationThreadActivity,
+  type TurnId,
   type UserInputQuestion,
 } from "@synara/contracts";
 import {
@@ -38,7 +38,7 @@ export interface PendingInteractionDerivationOptions {
   // trusts only latest-turn requests; true additionally retains the newest
   // unresolved older request so a background prompt can outlive later turns.
   readonly authoritativeHasPending: boolean | undefined;
-  readonly latestTurn: OrchestrationLatestTurn | null | undefined;
+  readonly latestTurnId: TurnId | undefined;
 }
 
 interface PendingInteractionReplay<T extends { requestId: ApprovalRequestId }> {
@@ -125,7 +125,7 @@ function replayPendingInteractions<T extends { requestId: ApprovalRequestId; cre
 ): T[] {
   const openByInstance = new Map<string, T>();
   const isAggregateFallback = settlements === undefined && options !== undefined;
-  const fallbackLatestTurnId = isAggregateFallback ? options.latestTurn?.turnId : undefined;
+  const fallbackLatestTurnId = isAggregateFallback ? options.latestTurnId : undefined;
   const latestTurnRequestedKeys = new Set<string>();
   const replayActivities =
     !isAggregateFallback || options.authoritativeHasPending !== false ? activities : [];

--- a/apps/web/src/pendingInteractionDerivation.ts
+++ b/apps/web/src/pendingInteractionDerivation.ts
@@ -34,8 +34,9 @@ type PendingInteractionKind = OrchestrationPendingInteraction["interactionKind"]
 
 export interface PendingInteractionDerivationOptions {
   // Aggregate flags cannot identify a pending request. When detailed
-  // settlements are missing, replay only the latest turn's activity. The turn
-  // may be terminal because background-agent interactions can outlive it.
+  // settlements are missing, an explicit false clears everything. Undefined
+  // trusts only latest-turn requests; true additionally retains the newest
+  // unresolved older request so a background prompt can outlive later turns.
   readonly authoritativeHasPending: boolean | undefined;
   readonly latestTurn: OrchestrationLatestTurn | null | undefined;
 }
@@ -123,16 +124,11 @@ function replayPendingInteractions<T extends { requestId: ApprovalRequestId; cre
   options?: PendingInteractionDerivationOptions,
 ): T[] {
   const openByInstance = new Map<string, T>();
-  const fallbackLatestTurnId =
-    settlements === undefined && options !== undefined && options.authoritativeHasPending !== false
-      ? options.latestTurn?.turnId
-      : undefined;
+  const isAggregateFallback = settlements === undefined && options !== undefined;
+  const fallbackLatestTurnId = isAggregateFallback ? options.latestTurn?.turnId : undefined;
+  const latestTurnRequestedKeys = new Set<string>();
   const replayActivities =
-    settlements !== undefined || options === undefined
-      ? activities
-      : fallbackLatestTurnId !== undefined
-        ? activities
-        : [];
+    !isAggregateFallback || options.authoritativeHasPending !== false ? activities : [];
 
   for (const activity of orderedActivities(replayActivities)) {
     const payload = activityPayload(activity);
@@ -146,10 +142,12 @@ function replayPendingInteractions<T extends { requestId: ApprovalRequestId; cre
 
     const lifecycleGeneration = activityLifecycleGeneration(payload);
     if (activity.kind === replay.requestedActivityKind) {
-      // Limit only request creation to the latest turn. Resolution/failure
-      // activities are thread-scoped and may intentionally carry no turn id;
-      // they still have to close a latest-turn request during fallback replay.
-      if (fallbackLatestTurnId !== undefined && activity.turnId !== fallbackLatestTurnId) {
+      const isLatestTurnRequest =
+        fallbackLatestTurnId !== undefined && activity.turnId === fallbackLatestTurnId;
+      // While aggregate state is absent, only a request tied to the latest turn
+      // is fresh enough to trust. An explicit true is stronger evidence: replay
+      // all request lifecycles, then bound the ambiguous result below.
+      if (isAggregateFallback && options.authoritativeHasPending !== true && !isLatestTurnRequest) {
         continue;
       }
       const pending = replay.parseRequested({
@@ -160,6 +158,11 @@ function replayPendingInteractions<T extends { requestId: ApprovalRequestId; cre
       });
       if (pending) {
         replacePendingInteraction(openByInstance, pending, lifecycleGeneration);
+        if (isLatestTurnRequest) {
+          latestTurnRequestedKeys.add(
+            pendingRequestInstanceKey(pending.requestId, lifecycleGeneration),
+          );
+        }
       }
       continue;
     }
@@ -179,6 +182,34 @@ function replayPendingInteractions<T extends { requestId: ApprovalRequestId; cre
   }
 
   retainActionableSettlements(openByInstance, settlements, replay.interactionKind);
+  if (isAggregateFallback && options.authoritativeHasPending === true) {
+    const actionableLatestTurnKeys = [...openByInstance.keys()].filter((key) =>
+      latestTurnRequestedKeys.has(key),
+    );
+    if (actionableLatestTurnKeys.length > 0) {
+      const retainedKeys = new Set(actionableLatestTurnKeys);
+      for (const key of openByInstance.keys()) {
+        if (!retainedKeys.has(key)) {
+          openByInstance.delete(key);
+        }
+      }
+    } else if (openByInstance.size > 1) {
+      // A boolean shell cannot express concurrent older interactions. Keep the
+      // newest unresolved lifecycle as the safest actionable fallback; current
+      // servers provide detailed settlements and preserve all concurrency.
+      const newest = [...openByInstance.entries()]
+        .toSorted(([, left], [, right]) =>
+          left.createdAt === right.createdAt
+            ? left.requestId.localeCompare(right.requestId)
+            : left.createdAt.localeCompare(right.createdAt),
+        )
+        .at(-1);
+      openByInstance.clear();
+      if (newest) {
+        openByInstance.set(newest[0], newest[1]);
+      }
+    }
+  }
   return [...openByInstance.values()].toSorted((left, right) =>
     left.createdAt.localeCompare(right.createdAt),
   );

--- a/apps/web/src/pendingInteractionDerivation.ts
+++ b/apps/web/src/pendingInteractionDerivation.ts
@@ -1,5 +1,6 @@
 import {
   ApprovalRequestId,
+  type OrchestrationLatestTurn,
   type OrchestrationPendingInteraction,
   type OrchestrationThreadActivity,
   type UserInputQuestion,
@@ -32,10 +33,11 @@ export interface PendingUserInput {
 type PendingInteractionKind = OrchestrationPendingInteraction["interactionKind"];
 
 export interface PendingInteractionDerivationOptions {
-  // Snapshot shells can outlive their optional interaction detail. Trust an
-  // explicit false only when no detailed settlements are available; a fresh
-  // activity event creates detail atomically and must remain actionable.
-  readonly authoritativeHasPending?: boolean;
+  // Aggregate flags cannot identify a pending request. When detailed
+  // settlements are missing, replay only the latest turn's activity. The turn
+  // may be terminal because background-agent interactions can outlive it.
+  readonly authoritativeHasPending: boolean | undefined;
+  readonly latestTurn: OrchestrationLatestTurn | null | undefined;
 }
 
 interface PendingInteractionReplay<T extends { requestId: ApprovalRequestId }> {
@@ -89,12 +91,8 @@ function retainActionableSettlements<T extends { requestId: ApprovalRequestId }>
   openByInstance: Map<string, T>,
   settlements: ReadonlyArray<OrchestrationPendingInteraction> | undefined,
   interactionKind: PendingInteractionKind,
-  options: PendingInteractionDerivationOptions | undefined,
 ): void {
   if (settlements === undefined) {
-    if (options?.authoritativeHasPending === false) {
-      openByInstance.clear();
-    }
     return;
   }
   const actionableKeys = new Set(
@@ -125,8 +123,18 @@ function replayPendingInteractions<T extends { requestId: ApprovalRequestId; cre
   options?: PendingInteractionDerivationOptions,
 ): T[] {
   const openByInstance = new Map<string, T>();
+  const fallbackLatestTurnId =
+    settlements === undefined && options !== undefined && options.authoritativeHasPending !== false
+      ? options.latestTurn?.turnId
+      : undefined;
+  const replayActivities =
+    settlements !== undefined || options === undefined
+      ? activities
+      : fallbackLatestTurnId !== undefined
+        ? activities
+        : [];
 
-  for (const activity of orderedActivities(activities)) {
+  for (const activity of orderedActivities(replayActivities)) {
     const payload = activityPayload(activity);
     const requestId =
       typeof payload?.requestId === "string"
@@ -138,6 +146,12 @@ function replayPendingInteractions<T extends { requestId: ApprovalRequestId; cre
 
     const lifecycleGeneration = activityLifecycleGeneration(payload);
     if (activity.kind === replay.requestedActivityKind) {
+      // Limit only request creation to the latest turn. Resolution/failure
+      // activities are thread-scoped and may intentionally carry no turn id;
+      // they still have to close a latest-turn request during fallback replay.
+      if (fallbackLatestTurnId !== undefined && activity.turnId !== fallbackLatestTurnId) {
+        continue;
+      }
       const pending = replay.parseRequested({
         activity,
         payload,
@@ -164,7 +178,7 @@ function replayPendingInteractions<T extends { requestId: ApprovalRequestId; cre
     }
   }
 
-  retainActionableSettlements(openByInstance, settlements, replay.interactionKind, options);
+  retainActionableSettlements(openByInstance, settlements, replay.interactionKind);
   return [...openByInstance.values()].toSorted((left, right) =>
     left.createdAt.localeCompare(right.createdAt),
   );

--- a/apps/web/src/pendingInteractionDerivation.ts
+++ b/apps/web/src/pendingInteractionDerivation.ts
@@ -31,6 +31,13 @@ export interface PendingUserInput {
 
 type PendingInteractionKind = OrchestrationPendingInteraction["interactionKind"];
 
+export interface PendingInteractionDerivationOptions {
+  // Snapshot shells can outlive their optional interaction detail. Trust an
+  // explicit false only when no detailed settlements are available; a fresh
+  // activity event creates detail atomically and must remain actionable.
+  readonly authoritativeHasPending?: boolean;
+}
+
 interface PendingInteractionReplay<T extends { requestId: ApprovalRequestId }> {
   interactionKind: PendingInteractionKind;
   requestedActivityKind: string;
@@ -82,8 +89,12 @@ function retainActionableSettlements<T extends { requestId: ApprovalRequestId }>
   openByInstance: Map<string, T>,
   settlements: ReadonlyArray<OrchestrationPendingInteraction> | undefined,
   interactionKind: PendingInteractionKind,
+  options: PendingInteractionDerivationOptions | undefined,
 ): void {
   if (settlements === undefined) {
+    if (options?.authoritativeHasPending === false) {
+      openByInstance.clear();
+    }
     return;
   }
   const actionableKeys = new Set(
@@ -111,6 +122,7 @@ function replayPendingInteractions<T extends { requestId: ApprovalRequestId; cre
   activities: ReadonlyArray<OrchestrationThreadActivity>,
   settlements: ReadonlyArray<OrchestrationPendingInteraction> | undefined,
   replay: PendingInteractionReplay<T>,
+  options?: PendingInteractionDerivationOptions,
 ): T[] {
   const openByInstance = new Map<string, T>();
 
@@ -152,7 +164,7 @@ function replayPendingInteractions<T extends { requestId: ApprovalRequestId; cre
     }
   }
 
-  retainActionableSettlements(openByInstance, settlements, replay.interactionKind);
+  retainActionableSettlements(openByInstance, settlements, replay.interactionKind, options);
   return [...openByInstance.values()].toSorted((left, right) =>
     left.createdAt.localeCompare(right.createdAt),
   );
@@ -208,67 +220,79 @@ function parseUserInputQuestions(
 export function derivePendingApprovals(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
   settlements?: ReadonlyArray<OrchestrationPendingInteraction>,
+  options?: PendingInteractionDerivationOptions,
 ): PendingApproval[] {
-  return replayPendingInteractions(activities, settlements, {
-    interactionKind: "approval",
-    requestedActivityKind: "approval.requested",
-    resolvedActivityKind: "approval.resolved",
-    responseFailedActivityKind: "provider.approval.respond.failed",
-    parseRequested: ({ activity, payload, requestId, lifecycleGeneration }) => {
-      const requestKind =
-        payload?.requestKind === "command" ||
-        payload?.requestKind === "file-read" ||
-        payload?.requestKind === "file-change" ||
-        payload?.requestKind === "permissions"
-          ? payload.requestKind
-          : approvalRequestKindFromRequestType(payload?.requestType);
-      if (!requestKind) {
-        return null;
-      }
-      const detail = typeof payload?.detail === "string" ? payload.detail : undefined;
-      const permissionProfile =
-        payload?.permissionProfile !== null &&
-        typeof payload?.permissionProfile === "object" &&
-        !Array.isArray(payload.permissionProfile)
-          ? (payload.permissionProfile as Record<string, unknown>)
-          : undefined;
-      const sessionApprovalAvailable =
-        typeof payload?.sessionApprovalAvailable === "boolean"
-          ? payload.sessionApprovalAvailable
-          : undefined;
-      return {
-        requestId,
-        ...(lifecycleGeneration !== undefined ? { lifecycleGeneration } : {}),
-        requestKind,
-        createdAt: activity.createdAt,
-        ...(detail ? { detail } : {}),
-        ...(permissionProfile ? { permissionProfile } : {}),
-        ...(sessionApprovalAvailable !== undefined ? { sessionApprovalAvailable } : {}),
-      };
+  return replayPendingInteractions(
+    activities,
+    settlements,
+    {
+      interactionKind: "approval",
+      requestedActivityKind: "approval.requested",
+      resolvedActivityKind: "approval.resolved",
+      responseFailedActivityKind: "provider.approval.respond.failed",
+      parseRequested: ({ activity, payload, requestId, lifecycleGeneration }) => {
+        const requestKind =
+          payload?.requestKind === "command" ||
+          payload?.requestKind === "file-read" ||
+          payload?.requestKind === "file-change" ||
+          payload?.requestKind === "permissions"
+            ? payload.requestKind
+            : approvalRequestKindFromRequestType(payload?.requestType);
+        if (!requestKind) {
+          return null;
+        }
+        const detail = typeof payload?.detail === "string" ? payload.detail : undefined;
+        const permissionProfile =
+          payload?.permissionProfile !== null &&
+          typeof payload?.permissionProfile === "object" &&
+          !Array.isArray(payload.permissionProfile)
+            ? (payload.permissionProfile as Record<string, unknown>)
+            : undefined;
+        const sessionApprovalAvailable =
+          typeof payload?.sessionApprovalAvailable === "boolean"
+            ? payload.sessionApprovalAvailable
+            : undefined;
+        return {
+          requestId,
+          ...(lifecycleGeneration !== undefined ? { lifecycleGeneration } : {}),
+          requestKind,
+          createdAt: activity.createdAt,
+          ...(detail ? { detail } : {}),
+          ...(permissionProfile ? { permissionProfile } : {}),
+          ...(sessionApprovalAvailable !== undefined ? { sessionApprovalAvailable } : {}),
+        };
+      },
     },
-  });
+    options,
+  );
 }
 
 export function derivePendingUserInputs(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
   settlements?: ReadonlyArray<OrchestrationPendingInteraction>,
+  options?: PendingInteractionDerivationOptions,
 ): PendingUserInput[] {
-  return replayPendingInteractions(activities, settlements, {
-    interactionKind: "userInput",
-    requestedActivityKind: "user-input.requested",
-    resolvedActivityKind: "user-input.resolved",
-    responseFailedActivityKind: "provider.user-input.respond.failed",
-    parseRequested: ({ activity, payload, requestId, lifecycleGeneration }) => {
-      const questions = parseUserInputQuestions(payload);
-      if (!questions) {
-        return null;
-      }
-      return {
-        requestId,
-        ...(lifecycleGeneration !== undefined ? { lifecycleGeneration } : {}),
-        createdAt: activity.createdAt,
-        questions,
-      };
+  return replayPendingInteractions(
+    activities,
+    settlements,
+    {
+      interactionKind: "userInput",
+      requestedActivityKind: "user-input.requested",
+      resolvedActivityKind: "user-input.resolved",
+      responseFailedActivityKind: "provider.user-input.respond.failed",
+      parseRequested: ({ activity, payload, requestId, lifecycleGeneration }) => {
+        const questions = parseUserInputQuestions(payload);
+        if (!questions) {
+          return null;
+        }
+        return {
+          requestId,
+          ...(lifecycleGeneration !== undefined ? { lifecycleGeneration } : {}),
+          createdAt: activity.createdAt,
+          questions,
+        };
+      },
     },
-  });
+    options,
+  );
 }


### PR DESCRIPTION
## Summary

- settle outstanding Claude approvals and `AskUserQuestion` callbacks before a turn reaches terminal state
- serialize response, abort, stop, and terminal settlement so each request resolves exactly once and no Deferred remains blocked
- suppress historical pending cards when an authoritative thread summary says no interaction is pending and detailed settlement state is unavailable
- keep fresh detailed pending interactions actionable even if a shell summary update is momentarily behind

## Root cause

Claude turn completion cleared the live turn without canonically closing provider callbacks that were still waiting for a human. Separately, the web client could reconstruct a historical `user-input.requested` activity when detailed settlement state was absent, even when the thread summary explicitly reported `hasPendingUserInput: false`.

Together those paths left an old question visible and selectable after the provider had already completed the turn, while submission could no longer reach a live callback.

## Verification

- `bun run --cwd apps/server test src/provider/Layers/ClaudeAdapter.test.ts -t "keeps Auto reviewer-gated|classifies Agent tools|AskUserQuestion"` — 6 passed
- `bun run --cwd apps/web test src/notifications/taskCompletion.logic.test.ts src/pendingInteractionDerivation.test.ts` — 63 passed
- focused `oxfmt --check` on all changed files
- `git diff --check`

The complete Claude adapter test file currently reports 136/137 passing. The one failure is an existing browser-harness wording assertion (`exact Electron WebView the user sees`), reproduced unchanged on `main`; this PR does not modify that path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Claude permission/user-input lifecycle and client derivation of pending state; race and ordering bugs could still affect approvals or background agents, but behavior is heavily covered by new adapter and derivation tests.
> 
> **Overview**
> Fixes **stale or stuck human-in-the-loop** flows where approvals and `AskUserQuestion` callbacks could outlive a finished turn or be shown again from old activity logs.
> 
> **Server (`ClaudeAdapter`)** introduces centralized **settlement** for pending approvals and user input: each request resolves exactly once (concurrent accept/decline or duplicate responses lose with an error), emits `request.resolved` / `user-input.resolved` from one path, and unblocks SDK `canUseTool` promises. **Foreground turn completion** now auto-cancels only that turn’s *foreground* callbacks; **background/agent** prompts stay open until the agent task is terminal (`terminalTaskIds` from `task_updated` / `task_notification`) or the session stops. Late `task_updated` background markers no longer strand questions. Session stop reuses the same settlement helper instead of ad-hoc map clearing.
> 
> **Web** passes `authoritativeHasPending` and `latestTurnId` into `derivePendingApprovals` / `derivePendingUserInputs` (Chat, sidebar, notifications). When detailed `pendingInteractions` are missing, an explicit `hasPending*: false` clears ghosts; `true` can keep the newest unresolved background question across later turns. Input-needed notifications ignore aggregate-flag-only revivals of historical requests but still fire when detailed interactions become **retryable**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2a28c300a7533a5b7f5d9b84ec5cfcfc4577265. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->