### PR TITLE
Fix stale browser test expectations

### DIFF
--- a/apps/desktop/src/browserManager.test.ts
+++ b/apps/desktop/src/browserManager.test.ts
@@ -184,7 +184,7 @@ describe("DesktopBrowserManager repeated workflow characterization", () => {
       tabs: [{ id: tabId, status: "suspended", isLoading: false }],
     });
     expect(() => manager.getVisibleAutomationRuntime({ threadId: THREAD_ID, tabId })).toThrow(
-      /has not attached yet/i,
+      /not ready yet/i,
     );
 
     // A duplicate terminal signal for the same physical guest must not publish

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -503,7 +503,10 @@ describe("ClaudeAdapterLive", () => {
         return assert.fail("Expected Claude preset system prompt.");
       }
       assert.include(systemPrompt.append ?? "", "Use the browser_* tools autonomously");
-      assert.include(systemPrompt.append ?? "", "exact Electron WebView the user sees");
+      assert.include(
+        systemPrompt.append ?? "",
+        "exact thread-scoped Electron page Synara surfaces to the user",
+      );
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/web/src/components/BrowserPanel.annotations.browser.tsx
+++ b/apps/web/src/components/BrowserPanel.annotations.browser.tsx
@@ -146,10 +146,11 @@ afterEach(() => {
 });
 
 describe("BrowserPanel annotations", () => {
-  it("resolves hex and color-mix theme variables before sending them to the guest", () => {
+  it("resolves theme colors from the opaque overlay surface token", () => {
     const root = document.createElement("div");
     root.classList.add("dark");
     root.style.setProperty("--color-text-accent", "#123456");
+    root.style.setProperty("--color-background-control-opaque", "#234567");
     root.style.setProperty(
       "--composer-surface",
       "color-mix(in srgb, rgb(0 0 0) 25%, rgb(255 255 255))",
@@ -160,9 +161,9 @@ describe("BrowserPanel annotations", () => {
     expect(theme).toMatchObject({
       mode: "dark",
       accent: "rgb(18, 52, 86)",
+      surface: "rgb(35, 69, 103)",
     });
-    expect(theme.surface).toMatch(/^(?:rgba?\(|color\(srgb)/);
-    expect(theme.surface).not.toBe("rgb(27, 27, 29)");
+    expect(theme.surface).not.toMatch(/(?:var|color-mix)\(/);
     root.remove();
   });
 


### PR DESCRIPTION
## Summary

- update the legacy `browserManager` characterization test to match the current runtime-not-ready state
- update the Claude harness integration test to protect the current thread-scoped Electron browser semantics
- update the browser annotation test to validate the opaque overlay surface token introduced on `main`
- keep all repairs test-only; production behavior is unchanged

## Root cause

Recent provider-agnostic browser work intentionally generalized Synara's browser from a renderer-only WebView to a thread-scoped Electron page, changed the runtime-not-ready wording, and switched annotation overlays from the translucent composer surface to the opaque control surface. Production code and newer tests reflect those semantics, but three older assertions retained the previous wording/token assumptions. Clean `origin/main` CI therefore failed deterministically in sequence as each stale assertion was repaired.

This is a prerequisite/base-CI repair for unrelated functional PRs.

## Validation

- `bun run --cwd apps/desktop test src/browserManager.test.ts` — 9/9 passed
- `bun run --cwd apps/server test src/provider/Layers/ClaudeAdapter.test.ts -t "injects the canonical Synara browser MCP into an Opus 4.8 session"` — passed
- `bun run --cwd apps/web test:browser:stable src/components/BrowserPanel.annotations.browser.tsx` — 6/6 passed
- `git diff --check` — passed
- two same-worktree review passes per repair: semantic/history check and full branch diff-scope check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Assertions and fixture CSS only; production browser manager, harness policy, and annotation theme logic are unchanged.
> 
> **Overview**
> Updates **test-only** expectations so CI matches production copy and theme behavior after the thread-scoped browser generalization—no runtime changes.
> 
> **Desktop `browserManager`:** After a guest crash, `getVisibleAutomationRuntime` is expected to throw **`/not ready yet/i`** instead of the old “has not attached yet” wording (aligned with `DesktopBrowserManager` and newer automation tests).
> 
> **Server Claude adapter:** The Opus harness integration test now asserts the injected preset prompt mentions the **thread-scoped Electron page** Synara surfaces to the user, not the legacy “exact Electron WebView” phrase (aligned with `renderSynaraHarnessPolicy`).
> 
> **Web browser annotations:** The theme characterization test expects **`browserAnnotationTheme`** to resolve **`surface`** from `--color-background-control-opaque` and to reject unresolved `var()` / `color-mix()` in the surface color sent to the guest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f6aa12ca71dcf6e3155c661926ba0d5eccb1b23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->