### PR TITLE
Fix OpenCode permission reply acknowledgement

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -7909,6 +7909,102 @@ describe("ProviderCommandReactor", () => {
     expect(resolvedActivity).toBeUndefined();
   });
 
+  it("keeps OpenCode permission acknowledgement failures retryable", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+    harness.respondToRequest.mockImplementation(() =>
+      Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: "opencode",
+          method: "permission.reply.acknowledge",
+          detail: "OpenCode still reports permission approval-request-ack as pending.",
+        }),
+      ),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-set-for-approval-ack-error"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "running",
+          providerName: "opencode",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.activity.append",
+        commandId: CommandId.makeUnsafe("cmd-approval-ack-requested"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        activity: {
+          id: EventId.makeUnsafe("activity-approval-ack-requested"),
+          tone: "approval",
+          kind: "approval.requested",
+          summary: "Permission approval requested",
+          payload: {
+            requestId: "approval-request-ack",
+            requestKind: "permissions",
+          },
+          turnId: null,
+          createdAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.approval.respond",
+        commandId: CommandId.makeUnsafe("cmd-approval-ack-respond"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        requestId: asApprovalRequestId("approval-request-ack"),
+        decision: "accept",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(
+      async () =>
+        (await readHarnessThread(harness))?.activities.some(
+          (activity) => activity.kind === "provider.approval.respond.failed",
+        ) === true,
+    );
+
+    const thread = await readHarnessThread(harness);
+    const failureActivity = thread?.activities.find(
+      (activity) => activity.kind === "provider.approval.respond.failed",
+    );
+    expect(failureActivity?.payload).toMatchObject({
+      requestId: "approval-request-ack",
+      responseCommandId: "cmd-approval-ack-respond",
+      settlementStatus: "retryable",
+      detail: expect.stringContaining("permission.reply.acknowledge"),
+    });
+
+    const retryableApproval = await Effect.runPromise(
+      harness.pendingInteractionRepository.getByIdentity({
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        interactionKind: "approval",
+        requestId: asApprovalRequestId("approval-request-ack"),
+      }),
+    );
+    expect(Option.getOrUndefined(retryableApproval)).toMatchObject({
+      status: "retryable",
+      responseCommandId: "cmd-approval-ack-respond",
+      decision: "accept",
+      resolvedAt: null,
+    });
+  });
+
   it("surfaces stale provider user-input failures without faking user-input resolution", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -368,12 +368,19 @@ function interactionFailureSettlementStatus(
 ): "retryable" | "uncertain" {
   return Option.match(Cause.findErrorOption(cause), {
     onNone: () => "uncertain" as const,
-    onSome: (error) =>
-      isUnknownPendingRequest ||
-      error._tag === "ProviderAdapterRequestError" ||
-      error._tag === "ProviderAdapterProcessError"
+    onSome: (error) => {
+      if (
+        error._tag === "ProviderAdapterRequestError" &&
+        error.method === "permission.reply.acknowledge"
+      ) {
+        return "retryable" as const;
+      }
+      return isUnknownPendingRequest ||
+        error._tag === "ProviderAdapterRequestError" ||
+        error._tag === "ProviderAdapterProcessError"
         ? ("uncertain" as const)
-        : ("retryable" as const),
+        : ("retryable" as const);
+    },
   });
 }
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -3859,11 +3859,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           .pipe(Effect.forkChild);
         yield* Effect.promise(() => listStarted);
         const conflictingResponse = yield* adapter
-          .respondToRequest(
-            threadId,
-            ApprovalRequestId.makeUnsafe(permission.id),
-            "decline",
-          )
+          .respondToRequest(threadId, ApprovalRequestId.makeUnsafe(permission.id), "decline")
           .pipe(Effect.result);
         eventQueue.push({
           type: "permission.replied",
@@ -3905,9 +3901,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
       type: "request.resolved",
       payload: { decision: "acceptForSession" },
     });
-    expect(runtime.permissionReplyCalls).toEqual([
-      { requestID: permission.id, reply: "always" },
-    ]);
+    expect(runtime.permissionReplyCalls).toEqual([{ requestID: permission.id, reply: "always" }]);
   });
 
   it("fails acknowledgement without consuming a permission that the runtime still lists", async () => {
@@ -3961,11 +3955,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
         yield* Fiber.join(openedFiber);
 
         const firstResponse = yield* adapter
-          .respondToRequest(
-            threadId,
-            ApprovalRequestId.makeUnsafe(permission.id),
-            "accept",
-          )
+          .respondToRequest(threadId, ApprovalRequestId.makeUnsafe(permission.id), "accept")
           .pipe(Effect.result);
         keepPending = false;
         const resolvedFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 1)).pipe(
@@ -4063,11 +4053,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
         yield* Fiber.join(openedFiber);
 
         const firstResponse = yield* adapter
-          .respondToRequest(
-            threadId,
-            ApprovalRequestId.makeUnsafe(permission.id),
-            "accept",
-          )
+          .respondToRequest(threadId, ApprovalRequestId.makeUnsafe(permission.id), "accept")
           .pipe(Effect.result);
         listFails = false;
         const resolvedFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 1)).pipe(

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -3904,6 +3904,84 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
     expect(runtime.permissionReplyCalls).toEqual([{ requestID: permission.id, reply: "always" }]);
   });
 
+  it("does not block session teardown when permission resolution backpressure is interrupted", async () => {
+    const eventQueue = createSubscribedEventQueue();
+    const permission = {
+      id: "permission-backpressure-1",
+      sessionID: "opencode-session-1",
+      permission: "bash",
+      patterns: ["git status"],
+      metadata: {},
+      always: [],
+    } satisfies PermissionRequest;
+    const runtime = createMockOpenCodeRuntime();
+    const client = runtime.runtime.createOpenCodeSdkClient({
+      baseUrl: "http://127.0.0.1:4099",
+      directory: process.cwd(),
+    }) as unknown as {
+      event: { subscribe: () => Promise<{ stream: AsyncIterable<unknown> }> };
+    };
+    client.event.subscribe = async () => ({ stream: eventQueue.stream });
+
+    const exit = await Effect.runPromiseExit(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const threadId = asThreadId("thread-human-permission-backpressure");
+        const openedFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(
+          Effect.forkChild,
+        );
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId,
+          runtimeMode: "approval-required",
+        });
+        yield* adapter.sendTurn({
+          threadId,
+          input: "Inspect status",
+          attachments: [],
+          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+        });
+        eventQueue.push({ type: "permission.asked", properties: permission });
+        yield* Fiber.join(openedFiber);
+
+        // Fill the one-slot runtime event queue, then let permission.replied block on the next
+        // offer. Layer teardown must still interrupt the session event pump.
+        eventQueue.push({
+          type: "session.next.text.delta",
+          properties: {
+            timestamp: 1,
+            sessionID: permission.sessionID,
+            delta: "queued",
+          },
+        });
+        eventQueue.push({
+          type: "permission.replied",
+          properties: {
+            sessionID: permission.sessionID,
+            requestID: permission.id,
+            reply: "once",
+          },
+        });
+        yield* Effect.sleep(25);
+      }).pipe(
+        Effect.provide(
+          makeOpenCodeAdapterLive({
+            runtime: runtime.runtime,
+            runtimeEventBufferCapacity: 1,
+          }).pipe(
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-adapter-test-" }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
+        Effect.timeout("1 second"),
+      ),
+    );
+
+    expect(exit).toMatchObject({ _tag: "Success" });
+  });
+
   it("fails acknowledgement without consuming a permission that the runtime still lists", async () => {
     const eventQueue = createSubscribedEventQueue();
     let replySubmitted = false;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -3715,6 +3715,20 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
             reply: "once",
           },
         });
+        // Reconnect replay can repeat both the reply and the original ask. The settled request id
+        // remains guarded for the lifetime of the adapter session, so neither becomes a second UI
+        // interaction.
+        eventQueue.push({
+          type: "permission.asked",
+          properties: {
+            id: "permission-human-1",
+            sessionID: "opencode-session-1",
+            permission: "websearch",
+            patterns: ["Synara handoff"],
+            metadata: {},
+            always: [],
+          },
+        });
         eventQueue.push({
           type: "session.next.text.delta",
           properties: {

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1,4 +1,4 @@
-import { ThreadId, TurnId } from "@synara/contracts";
+import { ApprovalRequestId, ThreadId, TurnId } from "@synara/contracts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import type {
   Agent,
@@ -3646,6 +3646,463 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
       },
     });
     expect(runtime.permissionReplyCalls).toEqual([]);
+  });
+
+  it("confirms a human permission reply from permission.list and continues the same turn", async () => {
+    const eventQueue = createSubscribedEventQueue();
+    let replySubmitted = false;
+    const runtime = createMockOpenCodeRuntime({
+      permissionReply: async () => {
+        replySubmitted = true;
+        return { data: null };
+      },
+      permissionList: async () => ({ data: [] }),
+    });
+    const client = runtime.runtime.createOpenCodeSdkClient({
+      baseUrl: "http://127.0.0.1:4099",
+      directory: process.cwd(),
+    }) as unknown as {
+      event: { subscribe: () => Promise<{ stream: AsyncIterable<unknown> }> };
+    };
+    client.event.subscribe = async () => ({ stream: eventQueue.stream });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const threadId = asThreadId("thread-human-permission-ack");
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId,
+          runtimeMode: "approval-required",
+        });
+        yield* adapter.sendTurn({
+          threadId,
+          input: "Search the web",
+          attachments: [],
+          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+        });
+
+        const openedFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(
+          Effect.forkChild,
+        );
+        eventQueue.push({
+          type: "permission.asked",
+          properties: {
+            id: "permission-human-1",
+            sessionID: "opencode-session-1",
+            permission: "websearch",
+            patterns: ["Synara handoff"],
+            metadata: {},
+            always: [],
+          },
+        });
+        const opened = Array.from(yield* Fiber.join(openedFiber));
+
+        const continuedFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(
+          Effect.forkChild,
+        );
+        yield* adapter.respondToRequest(
+          threadId,
+          ApprovalRequestId.makeUnsafe("permission-human-1"),
+          "accept",
+        );
+        // The runtime echo may arrive after permission.list already confirmed the reply.
+        eventQueue.push({
+          type: "permission.replied",
+          properties: {
+            sessionID: "opencode-session-1",
+            requestID: "permission-human-1",
+            reply: "once",
+          },
+        });
+        eventQueue.push({
+          type: "session.next.text.delta",
+          properties: {
+            timestamp: 1,
+            sessionID: "opencode-session-1",
+            delta: "Search complete",
+          },
+        });
+        eventQueue.push({
+          type: "session.next.text.ended",
+          properties: {
+            timestamp: 2,
+            sessionID: "opencode-session-1",
+            text: "Search complete",
+          },
+        });
+        eventQueue.push({
+          type: "session.next.step.ended",
+          properties: {
+            timestamp: 3,
+            sessionID: "opencode-session-1",
+            finish: "stop",
+            cost: 0,
+            tokens: {
+              input: 0,
+              output: 0,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+          },
+        });
+        const continued = Array.from(yield* Fiber.join(continuedFiber));
+        eventQueue.close();
+        return [...opened, ...continued];
+      }).pipe(
+        Effect.provide(
+          makeOpenCodeAdapterLive({
+            runtime: runtime.runtime,
+            permissionReplyAckDelaysMs: [],
+          }).pipe(
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-adapter-test-" }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
+      ),
+    );
+
+    expect(replySubmitted).toBe(true);
+    expect(result.map((event) => event.type)).toEqual([
+      "session.started",
+      "thread.started",
+      "turn.started",
+      "request.opened",
+      "request.resolved",
+      "content.delta",
+      "item.completed",
+      "turn.completed",
+    ]);
+    expect(result.filter((event) => event.type === "request.resolved")).toHaveLength(1);
+    expect(result[4]).toMatchObject({
+      type: "request.resolved",
+      payload: { decision: "accept" },
+    });
+    expect(runtime.permissionReplyCalls).toEqual([
+      { requestID: "permission-human-1", reply: "once" },
+    ]);
+  });
+
+  it("settles a human permission exactly once when the SSE reply races acknowledgement", async () => {
+    const eventQueue = createSubscribedEventQueue();
+    let replySubmitted = false;
+    let markListStarted: (() => void) | undefined;
+    let releaseList: (() => void) | undefined;
+    const listStarted = new Promise<void>((resolve) => {
+      markListStarted = resolve;
+    });
+    const listGate = new Promise<void>((resolve) => {
+      releaseList = resolve;
+    });
+    const permission = {
+      id: "permission-race-1",
+      sessionID: "opencode-session-1",
+      permission: "bash",
+      patterns: ["git status"],
+      metadata: {},
+      always: [],
+    } satisfies PermissionRequest;
+    const runtime = createMockOpenCodeRuntime({
+      permissionReply: async () => {
+        replySubmitted = true;
+        return { data: null };
+      },
+      permissionList: async () => {
+        if (!replySubmitted) {
+          return { data: [] };
+        }
+        markListStarted?.();
+        await listGate;
+        return { data: [permission] };
+      },
+    });
+    const client = runtime.runtime.createOpenCodeSdkClient({
+      baseUrl: "http://127.0.0.1:4099",
+      directory: process.cwd(),
+    }) as unknown as {
+      event: { subscribe: () => Promise<{ stream: AsyncIterable<unknown> }> };
+    };
+    client.event.subscribe = async () => ({ stream: eventQueue.stream });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const threadId = asThreadId("thread-human-permission-race");
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId,
+          runtimeMode: "approval-required",
+        });
+        yield* adapter.sendTurn({
+          threadId,
+          input: "Inspect status",
+          attachments: [],
+          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+        });
+        const openedFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(
+          Effect.forkChild,
+        );
+        eventQueue.push({ type: "permission.asked", properties: permission });
+        yield* Fiber.join(openedFiber);
+
+        const resolvedFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 1)).pipe(
+          Effect.forkChild,
+        );
+        const responseFiber = yield* adapter
+          .respondToRequest(
+            threadId,
+            ApprovalRequestId.makeUnsafe(permission.id),
+            "acceptForSession",
+          )
+          .pipe(Effect.forkChild);
+        yield* Effect.promise(() => listStarted);
+        const conflictingResponse = yield* adapter
+          .respondToRequest(
+            threadId,
+            ApprovalRequestId.makeUnsafe(permission.id),
+            "decline",
+          )
+          .pipe(Effect.result);
+        eventQueue.push({
+          type: "permission.replied",
+          properties: {
+            sessionID: permission.sessionID,
+            requestID: permission.id,
+            reply: "always",
+          },
+        });
+        const resolved = Array.from(yield* Fiber.join(resolvedFiber));
+        releaseList?.();
+        yield* Fiber.join(responseFiber);
+        eventQueue.close();
+        return { conflictingResponse, resolved };
+      }).pipe(
+        Effect.provide(
+          makeOpenCodeAdapterLive({
+            runtime: runtime.runtime,
+            permissionReplyAckDelaysMs: [],
+          }).pipe(
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-adapter-test-" }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
+      ),
+    );
+
+    expect(result.conflictingResponse).toMatchObject({
+      _tag: "Failure",
+      failure: {
+        _tag: "ProviderAdapterRequestError",
+        method: "permission.reply",
+      },
+    });
+    expect(result.resolved).toHaveLength(1);
+    expect(result.resolved[0]).toMatchObject({
+      type: "request.resolved",
+      payload: { decision: "acceptForSession" },
+    });
+    expect(runtime.permissionReplyCalls).toEqual([
+      { requestID: permission.id, reply: "always" },
+    ]);
+  });
+
+  it("fails acknowledgement without consuming a permission that the runtime still lists", async () => {
+    const eventQueue = createSubscribedEventQueue();
+    let replySubmitted = false;
+    let keepPending = true;
+    const permission = {
+      id: "permission-still-pending-1",
+      sessionID: "opencode-session-1",
+      permission: "bash",
+      patterns: ["git status"],
+      metadata: {},
+      always: [],
+    } satisfies PermissionRequest;
+    const runtime = createMockOpenCodeRuntime({
+      permissionReply: async () => {
+        replySubmitted = true;
+        return { data: null };
+      },
+      permissionList: async () => ({
+        data: replySubmitted && keepPending ? [permission] : [],
+      }),
+    });
+    const client = runtime.runtime.createOpenCodeSdkClient({
+      baseUrl: "http://127.0.0.1:4099",
+      directory: process.cwd(),
+    }) as unknown as {
+      event: { subscribe: () => Promise<{ stream: AsyncIterable<unknown> }> };
+    };
+    client.event.subscribe = async () => ({ stream: eventQueue.stream });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const threadId = asThreadId("thread-human-permission-still-pending");
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId,
+          runtimeMode: "approval-required",
+        });
+        yield* adapter.sendTurn({
+          threadId,
+          input: "Inspect status",
+          attachments: [],
+          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+        });
+        const openedFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(
+          Effect.forkChild,
+        );
+        eventQueue.push({ type: "permission.asked", properties: permission });
+        yield* Fiber.join(openedFiber);
+
+        const firstResponse = yield* adapter
+          .respondToRequest(
+            threadId,
+            ApprovalRequestId.makeUnsafe(permission.id),
+            "accept",
+          )
+          .pipe(Effect.result);
+        keepPending = false;
+        const resolvedFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 1)).pipe(
+          Effect.forkChild,
+        );
+        yield* adapter.respondToRequest(
+          threadId,
+          ApprovalRequestId.makeUnsafe(permission.id),
+          "accept",
+        );
+        const resolved = Array.from(yield* Fiber.join(resolvedFiber));
+        eventQueue.close();
+        return { firstResponse, resolved };
+      }).pipe(
+        Effect.provide(
+          makeOpenCodeAdapterLive({
+            runtime: runtime.runtime,
+            permissionReplyAckDelaysMs: [],
+          }).pipe(
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-adapter-test-" }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
+      ),
+    );
+
+    expect(result.firstResponse._tag).toBe("Failure");
+    if (result.firstResponse._tag === "Failure") {
+      expect(result.firstResponse.failure).toMatchObject({
+        _tag: "ProviderAdapterRequestError",
+        method: "permission.reply.acknowledge",
+      });
+    }
+    expect(result.resolved).toHaveLength(1);
+    expect(result.resolved[0]?.type).toBe("request.resolved");
+    expect(runtime.permissionReplyCalls).toEqual([
+      { requestID: permission.id, reply: "once" },
+      { requestID: permission.id, reply: "once" },
+    ]);
+  });
+
+  it("keeps a permission actionable when acknowledgement listing fails", async () => {
+    const eventQueue = createSubscribedEventQueue();
+    let replySubmitted = false;
+    let listFails = true;
+    const permission = {
+      id: "permission-list-failure-1",
+      sessionID: "opencode-session-1",
+      permission: "websearch",
+      patterns: ["Synara"],
+      metadata: {},
+      always: [],
+    } satisfies PermissionRequest;
+    const runtime = createMockOpenCodeRuntime({
+      permissionReply: async () => {
+        replySubmitted = true;
+        return { data: null };
+      },
+      permissionList: async () => {
+        if (replySubmitted && listFails) {
+          throw new Error("permission.list unavailable");
+        }
+        return { data: [] };
+      },
+    });
+    const client = runtime.runtime.createOpenCodeSdkClient({
+      baseUrl: "http://127.0.0.1:4099",
+      directory: process.cwd(),
+    }) as unknown as {
+      event: { subscribe: () => Promise<{ stream: AsyncIterable<unknown> }> };
+    };
+    client.event.subscribe = async () => ({ stream: eventQueue.stream });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const threadId = asThreadId("thread-human-permission-list-failure");
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId,
+          runtimeMode: "approval-required",
+        });
+        yield* adapter.sendTurn({
+          threadId,
+          input: "Search docs",
+          attachments: [],
+          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+        });
+        const openedFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(
+          Effect.forkChild,
+        );
+        eventQueue.push({ type: "permission.asked", properties: permission });
+        yield* Fiber.join(openedFiber);
+
+        const firstResponse = yield* adapter
+          .respondToRequest(
+            threadId,
+            ApprovalRequestId.makeUnsafe(permission.id),
+            "accept",
+          )
+          .pipe(Effect.result);
+        listFails = false;
+        const resolvedFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 1)).pipe(
+          Effect.forkChild,
+        );
+        yield* adapter.respondToRequest(
+          threadId,
+          ApprovalRequestId.makeUnsafe(permission.id),
+          "accept",
+        );
+        yield* Fiber.join(resolvedFiber);
+        eventQueue.close();
+        return firstResponse;
+      }).pipe(
+        Effect.provide(
+          makeOpenCodeAdapterLive({
+            runtime: runtime.runtime,
+            permissionReplyAckDelaysMs: [],
+          }).pipe(
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-adapter-test-" }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
+      ),
+    );
+
+    expect(result._tag).toBe("Failure");
+    if (result._tag === "Failure") {
+      expect(result.failure).toMatchObject({
+        _tag: "ProviderAdapterRequestError",
+        method: "permission.reply.acknowledge",
+      });
+    }
   });
 
   it("keeps newer OpenCode tool-call steps attached to the active turn", async () => {

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -161,6 +161,7 @@ interface OpenCodeSessionContext {
   readonly openCodeSessionId: string;
   readonly pendingPermissions: Map<string, PermissionRequest>;
   readonly replyingPermissions: Map<string, "once" | "always" | "reject">;
+  readonly settlingPermissions: Map<string, Deferred.Deferred<boolean>>;
   /** Permission request ids resolved by Synara policy and never surfaced to the UI. */
   readonly policyResolvedPermissionIds: Set<string>;
   /** Human replies settled from permission.list while their permission.replied echo is pending. */
@@ -247,6 +248,7 @@ export interface OpenCodeAdapterLiveOptions {
   readonly promptAcceptedRecoveryDelaysMs?: ReadonlyArray<number>;
   readonly promptSubmissionInlineWaitMs?: number;
   readonly permissionReplyAckDelaysMs?: ReadonlyArray<number>;
+  readonly runtimeEventBufferCapacity?: number;
   readonly prematureIdleCompletionGraceMs?: number;
   readonly beforeSessionInstall?: Effect.Effect<void>;
   readonly resolveServerPassword?: (
@@ -1221,7 +1223,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
       const managedNativeEventLogger =
         options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
       const runtimeEvents = yield* Queue.bounded<ProviderRuntimeEvent>(
-        PROVIDER_ADAPTER_RUNTIME_EVENT_BUFFER_CAPACITY,
+        options?.runtimeEventBufferCapacity ?? PROVIDER_ADAPTER_RUNTIME_EVENT_BUFFER_CAPACITY,
       );
       const sessions = new Map<ThreadId, OpenCodeSessionContext>();
 
@@ -2161,38 +2163,77 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           readonly suppressLateRuntimeEvents: boolean;
         },
       ) {
-        return yield* Effect.uninterruptible(
-          Effect.gen(function* () {
-            const request = yield* Effect.sync(() => {
-              const pending = context.pendingPermissions.get(input.requestId);
-              if (!pending) {
-                return undefined;
-              }
-              context.pendingPermissions.delete(input.requestId);
-              if (input.suppressLateRuntimeEvents) {
-                context.locallyResolvedPermissionIds.add(input.requestId);
-              }
-              return pending;
-            });
+        while (true) {
+          const settlement = yield* Deferred.make<boolean>();
+          const claim = yield* Effect.sync(() => {
+            const request = context.pendingPermissions.get(input.requestId);
             if (!request) {
+              return { _tag: "missing" } as const;
+            }
+            const existing = context.settlingPermissions.get(input.requestId);
+            if (existing) {
+              return { _tag: "waiting", settlement: existing } as const;
+            }
+            context.settlingPermissions.set(input.requestId, settlement);
+            return { _tag: "claimed", request } as const;
+          });
+
+          if (claim._tag === "missing") {
+            return false;
+          }
+          if (claim._tag === "waiting") {
+            const settled = yield* Deferred.await(claim.settlement);
+            if (settled) {
+              if (!input.suppressLateRuntimeEvents) {
+                context.locallyResolvedPermissionIds.delete(input.requestId);
+              }
               return false;
             }
-            yield* emit(context, {
-              ...buildEventBase({
-                threadId: context.session.threadId,
-                turnId: context.activeTurnId,
-                requestId: input.requestId,
-                raw: input.raw,
-              }),
-              type: "request.resolved",
-              payload: {
-                requestType: mapPermissionToRequestType(request.permission),
-                decision: mapPermissionDecision(input.reply),
-              },
-            });
-            return true;
-          }),
-        );
+            continue;
+          }
+
+          return yield* Effect.uninterruptibleMask((restore) =>
+            Effect.gen(function* () {
+              const emitted = yield* restore(
+                emit(context, {
+                  ...buildEventBase({
+                    threadId: context.session.threadId,
+                    turnId: context.activeTurnId,
+                    requestId: input.requestId,
+                    raw: input.raw,
+                  }),
+                  type: "request.resolved",
+                  payload: {
+                    requestType: mapPermissionToRequestType(claim.request.permission),
+                    decision: mapPermissionDecision(input.reply),
+                  },
+                }),
+              ).pipe(Effect.exit);
+
+              if (Exit.isFailure(emitted)) {
+                yield* Effect.sync(() => {
+                  if (context.settlingPermissions.get(input.requestId) === settlement) {
+                    context.settlingPermissions.delete(input.requestId);
+                  }
+                });
+                yield* Deferred.succeed(settlement, false);
+                return yield* Effect.failCause(emitted.cause);
+              }
+
+              yield* Effect.sync(() => {
+                if (context.settlingPermissions.get(input.requestId) === settlement) {
+                  context.settlingPermissions.delete(input.requestId);
+                  context.pendingPermissions.delete(input.requestId);
+                  if (input.suppressLateRuntimeEvents) {
+                    context.locallyResolvedPermissionIds.add(input.requestId);
+                  }
+                }
+              });
+              yield* Deferred.succeed(settlement, true);
+              return true;
+            }),
+          );
+        }
       });
 
       const handleSubscribedEvent = Effect.fn("handleSubscribedEvent")(function* (
@@ -3679,6 +3720,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
                   openCodeSessionId: started.openCodeSessionId,
                   pendingPermissions: new Map(),
                   replyingPermissions: new Map(),
+                  settlingPermissions: new Map(),
                   policyResolvedPermissionIds: new Set(),
                   locallyResolvedPermissionIds: new Set(),
                   pendingQuestions: new Map(),

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -3982,81 +3982,81 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         },
       );
 
-      const acknowledgeHumanPermissionReply = Effect.fn(
-        "acknowledgeHumanPermissionReply",
-      )(function* (
-        context: OpenCodeSessionContext,
-        input: {
-          readonly requestId: string;
-          readonly reply: "once" | "always" | "reject";
-        },
-      ) {
-        let lastListError: unknown;
-        const attemptCount = permissionReplyAckDelaysMs.length + 1;
+      const acknowledgeHumanPermissionReply = Effect.fn("acknowledgeHumanPermissionReply")(
+        function* (
+          context: OpenCodeSessionContext,
+          input: {
+            readonly requestId: string;
+            readonly reply: "once" | "always" | "reject";
+          },
+        ) {
+          let lastListError: unknown;
+          const attemptCount = permissionReplyAckDelaysMs.length + 1;
 
-        for (let attempt = 0; attempt < attemptCount; attempt += 1) {
-          if (!context.pendingPermissions.has(input.requestId)) {
-            // The subscription processed permission.replied while the reply was in flight.
-            return;
-          }
-          if (attempt > 0) {
-            const delayMs = permissionReplyAckDelaysMs[attempt - 1];
-            if (delayMs !== undefined) {
-              yield* Effect.sleep(delayMs);
+          for (let attempt = 0; attempt < attemptCount; attempt += 1) {
+            if (!context.pendingPermissions.has(input.requestId)) {
+              // The subscription processed permission.replied while the reply was in flight.
+              return;
             }
+            if (attempt > 0) {
+              const delayMs = permissionReplyAckDelaysMs[attempt - 1];
+              if (delayMs !== undefined) {
+                yield* Effect.sleep(delayMs);
+              }
+              if (!context.pendingPermissions.has(input.requestId)) {
+                return;
+              }
+            }
+
+            const listExit = yield* Effect.exit(
+              runOpenCodeSdk("permission.list", () => context.client.permission.list()),
+            );
+            if (Exit.isFailure(listExit)) {
+              lastListError = Cause.squash(listExit.cause);
+              continue;
+            }
+            lastListError = undefined;
             if (!context.pendingPermissions.has(input.requestId)) {
               return;
             }
-          }
+            const stillPending = (listExit.value.data ?? []).some(
+              (request) => request.id === input.requestId,
+            );
+            if (stillPending) {
+              continue;
+            }
 
-          const listExit = yield* Effect.exit(
-            runOpenCodeSdk("permission.list", () => context.client.permission.list()),
-          );
-          if (Exit.isFailure(listExit)) {
-            lastListError = Cause.squash(listExit.cause);
-            continue;
-          }
-          lastListError = undefined;
-          if (!context.pendingPermissions.has(input.requestId)) {
+            yield* settlePendingHumanPermission(context, {
+              requestId: input.requestId,
+              reply: input.reply,
+              raw: {
+                type: "permission.reply.acknowledged",
+                properties: {
+                  sessionID: context.openCodeSessionId,
+                  requestID: input.requestId,
+                  reply: input.reply,
+                },
+              },
+              suppressLateRuntimeEvents: true,
+            });
             return;
           }
-          const stillPending = (listExit.value.data ?? []).some(
-            (request) => request.id === input.requestId,
-          );
-          if (stillPending) {
-            continue;
+
+          if (!context.pendingPermissions.has(input.requestId)) {
+            // The final permission.list result was stale and the subscription won the race.
+            return;
           }
 
-          yield* settlePendingHumanPermission(context, {
-            requestId: input.requestId,
-            reply: input.reply,
-            raw: {
-              type: "permission.reply.acknowledged",
-              properties: {
-                sessionID: context.openCodeSessionId,
-                requestID: input.requestId,
-                reply: input.reply,
-              },
-            },
-            suppressLateRuntimeEvents: true,
+          return yield* new ProviderAdapterRequestError({
+            provider,
+            method: "permission.reply.acknowledge",
+            detail: lastListError
+              ? `${adapterConfig.displayName} could not verify that permission ${input.requestId} was resolved: ${openCodeRuntimeErrorDetail(lastListError)}`
+              : `${adapterConfig.displayName} still reports permission ${input.requestId} as pending after ${String(attemptCount)} acknowledgement attempts.`,
+            ...(lastListError !== undefined ? { cause: lastListError } : {}),
           });
-          return;
-        }
-
-        if (!context.pendingPermissions.has(input.requestId)) {
-          // The final permission.list result was stale and the subscription won the race.
-          return;
-        }
-
-        return yield* new ProviderAdapterRequestError({
-          provider,
-          method: "permission.reply.acknowledge",
-          detail: lastListError
-            ? `${adapterConfig.displayName} could not verify that permission ${input.requestId} was resolved: ${openCodeRuntimeErrorDetail(lastListError)}`
-            : `${adapterConfig.displayName} still reports permission ${input.requestId} as pending after ${String(attemptCount)} acknowledgement attempts.`,
-          ...(lastListError !== undefined ? { cause: lastListError } : {}),
-        });
-      });
+        },
+      );
 
       const respondToRequest: OpenCodeAdapterShape["respondToRequest"] = Effect.fn(
         "respondToRequest",

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -2184,9 +2184,6 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           if (claim._tag === "waiting") {
             const settled = yield* Deferred.await(claim.settlement);
             if (settled) {
-              if (!input.suppressLateRuntimeEvents) {
-                context.locallyResolvedPermissionIds.delete(input.requestId);
-              }
               return false;
             }
             continue;
@@ -2581,11 +2578,11 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           }
 
           case "permission.replied": {
-            if (context.policyResolvedPermissionIds.delete(event.properties.requestID)) {
+            if (context.policyResolvedPermissionIds.has(event.properties.requestID)) {
               // Synara policy resolved this request; nothing was surfaced to the UI.
               break;
             }
-            if (context.locallyResolvedPermissionIds.delete(event.properties.requestID)) {
+            if (context.locallyResolvedPermissionIds.has(event.properties.requestID)) {
               // permission.list already confirmed this reply and projected the resolution.
               break;
             }

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -134,6 +134,7 @@ const OPENCODE_PROMPT_ACCEPTED_ACTIVITY_TIMEOUT_MS = 60_000;
 const OPENCODE_PROMPT_ACCEPTED_RECOVERY_DELAYS_MS = [2_000, 5_000, 10_000, 20_000] as const;
 const OPENCODE_PROMPT_SUBMISSION_INLINE_WAIT_MS = 500;
 const OPENCODE_EVENT_RECONNECT_DELAYS_MS = [250, 1_000, 2_500, 5_000] as const;
+const OPENCODE_PERMISSION_REPLY_ACK_DELAYS_MS = [50, 150, 300, 500] as const;
 const OPENCODE_MAX_RELATED_SESSIONS = 256;
 
 type OpenCodeSubscribedEvent =
@@ -159,8 +160,11 @@ interface OpenCodeSessionContext {
   readonly directory: string;
   readonly openCodeSessionId: string;
   readonly pendingPermissions: Map<string, PermissionRequest>;
+  readonly replyingPermissions: Map<string, "once" | "always" | "reject">;
   /** Permission request ids resolved by Synara policy and never surfaced to the UI. */
   readonly policyResolvedPermissionIds: Set<string>;
+  /** Human replies settled from permission.list while their permission.replied echo is pending. */
+  readonly locallyResolvedPermissionIds: Set<string>;
   readonly pendingQuestions: Map<string, QuestionRequest>;
   readonly pendingTextDeltasByPartId: Map<string, string>;
   readonly messageRoleById: Map<string, "user" | "assistant">;
@@ -242,6 +246,7 @@ export interface OpenCodeAdapterLiveOptions {
   readonly promptAcceptedActivityTimeoutMs?: number;
   readonly promptAcceptedRecoveryDelaysMs?: ReadonlyArray<number>;
   readonly promptSubmissionInlineWaitMs?: number;
+  readonly permissionReplyAckDelaysMs?: ReadonlyArray<number>;
   readonly prematureIdleCompletionGraceMs?: number;
   readonly beforeSessionInstall?: Effect.Effect<void>;
   readonly resolveServerPassword?: (
@@ -740,11 +745,11 @@ const clearActiveTurnState = Effect.fn("clearOpenCodeActiveTurnState")(function*
   context.activeVariant = undefined;
   context.latestTurnCostUsd = undefined;
   context.relatedSessionIds.clear();
-  // Deliberately NOT cleared here: a permission policy-resolved at the tail of a turn can
-  // have its permission.replied echo arrive after turn teardown, and dropping the id first
-  // would misclassify that echo as a real resolution (orphaned "Approval resolved" in the
-  // UI). Ids are unique per request so stale entries are inert; the set is freed with the
-  // session context when the session is removed.
+  // Deliberately NOT cleared here: a permission resolved by policy or permission.list at the
+  // tail of a turn can have its permission.replied echo arrive after turn teardown. Dropping
+  // the id first would misclassify that echo as a real resolution (an orphaned "Approval
+  // resolved" in the UI). Ids are unique per request so stale entries are inert; the sets are
+  // freed with the session context when the session is removed.
 });
 
 function markOpenCodeTurnProviderActivity(
@@ -1201,6 +1206,10 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         ) ?? OPENCODE_PROMPT_ACCEPTED_RECOVERY_DELAYS_MS;
       const promptSubmissionInlineWaitMs =
         options?.promptSubmissionInlineWaitMs ?? OPENCODE_PROMPT_SUBMISSION_INLINE_WAIT_MS;
+      const permissionReplyAckDelaysMs =
+        options?.permissionReplyAckDelaysMs?.filter(
+          (delayMs) => Number.isFinite(delayMs) && delayMs > 0,
+        ) ?? OPENCODE_PERMISSION_REPLY_ACK_DELAYS_MS;
       const prematureIdleCompletionGraceMs = options?.prematureIdleCompletionGraceMs ?? 10_000;
       const nativeEventLogger =
         options?.nativeEventLogger ??
@@ -2143,6 +2152,49 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         }
       });
 
+      const settlePendingHumanPermission = Effect.fn("settlePendingHumanPermission")(function* (
+        context: OpenCodeSessionContext,
+        input: {
+          readonly requestId: string;
+          readonly reply: "once" | "always" | "reject";
+          readonly raw: unknown;
+          readonly suppressLateRuntimeEvents: boolean;
+        },
+      ) {
+        return yield* Effect.uninterruptible(
+          Effect.gen(function* () {
+            const request = yield* Effect.sync(() => {
+              const pending = context.pendingPermissions.get(input.requestId);
+              if (!pending) {
+                return undefined;
+              }
+              context.pendingPermissions.delete(input.requestId);
+              if (input.suppressLateRuntimeEvents) {
+                context.locallyResolvedPermissionIds.add(input.requestId);
+              }
+              return pending;
+            });
+            if (!request) {
+              return false;
+            }
+            yield* emit(context, {
+              ...buildEventBase({
+                threadId: context.session.threadId,
+                turnId: context.activeTurnId,
+                requestId: input.requestId,
+                raw: input.raw,
+              }),
+              type: "request.resolved",
+              payload: {
+                requestType: mapPermissionToRequestType(request.permission),
+                decision: mapPermissionDecision(input.reply),
+              },
+            });
+            return true;
+          }),
+        );
+      });
+
       const handleSubscribedEvent = Effect.fn("handleSubscribedEvent")(function* (
         context: OpenCodeSessionContext,
         event: OpenCodeSubscribedEvent,
@@ -2409,7 +2461,8 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           case "permission.asked": {
             if (
               context.pendingPermissions.has(event.properties.id) ||
-              context.policyResolvedPermissionIds.has(event.properties.id)
+              context.policyResolvedPermissionIds.has(event.properties.id) ||
+              context.locallyResolvedPermissionIds.has(event.properties.id)
             ) {
               break;
             }
@@ -2491,20 +2544,15 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
               // Synara policy resolved this request; nothing was surfaced to the UI.
               break;
             }
-            const request = context.pendingPermissions.get(event.properties.requestID);
-            context.pendingPermissions.delete(event.properties.requestID);
-            yield* emit(context, {
-              ...buildEventBase({
-                threadId: context.session.threadId,
-                turnId,
-                requestId: event.properties.requestID,
-                raw: event,
-              }),
-              type: "request.resolved",
-              payload: {
-                requestType: request ? mapPermissionToRequestType(request.permission) : "unknown",
-                decision: mapPermissionDecision(event.properties.reply),
-              },
+            if (context.locallyResolvedPermissionIds.delete(event.properties.requestID)) {
+              // permission.list already confirmed this reply and projected the resolution.
+              break;
+            }
+            yield* settlePendingHumanPermission(context, {
+              requestId: event.properties.requestID,
+              reply: event.properties.reply,
+              raw: event,
+              suppressLateRuntimeEvents: false,
             });
             break;
           }
@@ -3630,7 +3678,9 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
                   directory,
                   openCodeSessionId: started.openCodeSessionId,
                   pendingPermissions: new Map(),
+                  replyingPermissions: new Map(),
                   policyResolvedPermissionIds: new Set(),
+                  locallyResolvedPermissionIds: new Set(),
                   pendingQuestions: new Map(),
                   pendingTextDeltasByPartId: new Map(),
                   partById: new Map(),
@@ -3932,10 +3982,87 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         },
       );
 
+      const acknowledgeHumanPermissionReply = Effect.fn(
+        "acknowledgeHumanPermissionReply",
+      )(function* (
+        context: OpenCodeSessionContext,
+        input: {
+          readonly requestId: string;
+          readonly reply: "once" | "always" | "reject";
+        },
+      ) {
+        let lastListError: unknown;
+        const attemptCount = permissionReplyAckDelaysMs.length + 1;
+
+        for (let attempt = 0; attempt < attemptCount; attempt += 1) {
+          if (!context.pendingPermissions.has(input.requestId)) {
+            // The subscription processed permission.replied while the reply was in flight.
+            return;
+          }
+          if (attempt > 0) {
+            const delayMs = permissionReplyAckDelaysMs[attempt - 1];
+            if (delayMs !== undefined) {
+              yield* Effect.sleep(delayMs);
+            }
+            if (!context.pendingPermissions.has(input.requestId)) {
+              return;
+            }
+          }
+
+          const listExit = yield* Effect.exit(
+            runOpenCodeSdk("permission.list", () => context.client.permission.list()),
+          );
+          if (Exit.isFailure(listExit)) {
+            lastListError = Cause.squash(listExit.cause);
+            continue;
+          }
+          lastListError = undefined;
+          if (!context.pendingPermissions.has(input.requestId)) {
+            return;
+          }
+          const stillPending = (listExit.value.data ?? []).some(
+            (request) => request.id === input.requestId,
+          );
+          if (stillPending) {
+            continue;
+          }
+
+          yield* settlePendingHumanPermission(context, {
+            requestId: input.requestId,
+            reply: input.reply,
+            raw: {
+              type: "permission.reply.acknowledged",
+              properties: {
+                sessionID: context.openCodeSessionId,
+                requestID: input.requestId,
+                reply: input.reply,
+              },
+            },
+            suppressLateRuntimeEvents: true,
+          });
+          return;
+        }
+
+        if (!context.pendingPermissions.has(input.requestId)) {
+          // The final permission.list result was stale and the subscription won the race.
+          return;
+        }
+
+        return yield* new ProviderAdapterRequestError({
+          provider,
+          method: "permission.reply.acknowledge",
+          detail: lastListError
+            ? `${adapterConfig.displayName} could not verify that permission ${input.requestId} was resolved: ${openCodeRuntimeErrorDetail(lastListError)}`
+            : `${adapterConfig.displayName} still reports permission ${input.requestId} as pending after ${String(attemptCount)} acknowledgement attempts.`,
+          ...(lastListError !== undefined ? { cause: lastListError } : {}),
+        });
+      });
+
       const respondToRequest: OpenCodeAdapterShape["respondToRequest"] = Effect.fn(
         "respondToRequest",
       )(function* (threadId, requestId, decision) {
         const context = ensureAdapterSessionContext(threadId);
+        const reply = toOpenCodePermissionReply(decision);
         if (!context.pendingPermissions.has(requestId)) {
           return yield* new ProviderAdapterRequestError({
             provider,
@@ -3943,13 +4070,33 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
             detail: `Unknown pending permission request: ${requestId}`,
           });
         }
+        const responseInFlight = context.replyingPermissions.get(requestId);
+        if (responseInFlight !== undefined) {
+          return yield* new ProviderAdapterRequestError({
+            provider,
+            method: "permission.reply",
+            detail: `Permission request ${requestId} already has a ${responseInFlight} response in flight.`,
+          });
+        }
+        context.replyingPermissions.set(requestId, reply);
 
-        yield* runOpenCodeSdk("permission.reply", () =>
-          context.client.permission.reply({
-            requestID: requestId,
-            reply: toOpenCodePermissionReply(decision),
-          }),
-        ).pipe(Effect.mapError(toAdapterRequestError));
+        yield* Effect.gen(function* () {
+          yield* runOpenCodeSdk("permission.reply", () =>
+            context.client.permission.reply({
+              requestID: requestId,
+              reply,
+            }),
+          ).pipe(Effect.mapError(toAdapterRequestError));
+          yield* acknowledgeHumanPermissionReply(context, { requestId, reply });
+        }).pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              if (context.replyingPermissions.get(requestId) === reply) {
+                context.replyingPermissions.delete(requestId);
+              }
+            }),
+          ),
+        );
       });
 
       const respondToUserInput: OpenCodeAdapterShape["respondToUserInput"] = Effect.fn(


### PR DESCRIPTION
## Summary
- verify human OpenCode permission replies against permission.list before reporting success
- synthesize one durable resolution when the runtime drops the request but the SSE echo is missing
- keep replies actionable when acknowledgement fails and handle SSE/concurrent-response races idempotently

## Stack
This PR is intentionally based on codex/fix-stale-human-interactions / PR #522. Merge #522 first, then retarget this PR to main before merging.

## Verification
- bun run --cwd apps/server test -- src/provider/Layers/OpenCodeAdapter.test.ts (68/68)
- git diff --check 9abbdb564..HEAD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches human approval settlement and when successes/failures are reported; mis-handling could block turns or mark approvals resolved prematurely, though the design fails closed on ack failure and adds retry paths.
> 
> **Overview**
> Human OpenCode permission approvals are no longer treated as successful right after `permission.reply`. The adapter **polls `permission.list`** (with backoff) until the request disappears, then emits a single durable `request.resolved`; if the runtime still lists it pending, it fails with `permission.reply.acknowledge` instead of silently succeeding.
> 
> Settlement is **deduplicated** across SSE `permission.replied`, list-based acknowledgement, and reconnect replays: in-flight replies are serialized, concurrent duplicate responses are rejected, and ids settled via list are tracked so late echoes do not double-resolve in the UI.
> 
> **ProviderCommandReactor** treats `permission.reply.acknowledge` failures as **retryable** (not uncertain), so the pending approval stays actionable for another user attempt when verification fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0782a7c66fb5c0ff9e5671ef55b59c90ce7e83d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->