### PR TITLE
Improve Mic mode performance and reliability

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -2305,6 +2305,76 @@ describe("CodexAppServerManager discovery", () => {
     });
   });
 
+  it("uses discovery for voice auth while the requested thread is still connecting", async () => {
+    const manager = new CodexAppServerManager();
+    const connectingContext = {
+      session: {
+        provider: "codex",
+        status: "connecting",
+        threadId: "thread_connecting",
+        runtimeMode: "full-access",
+        cwd: "/repo",
+      },
+      child: {
+        exitCode: null,
+        signalCode: null,
+        killed: false,
+        stdin: new PassThrough(),
+      },
+      stopping: false,
+    };
+    const discoveryContext = { discovery: true };
+    (
+      manager as unknown as {
+        sessions: Map<string, unknown>;
+      }
+    ).sessions.set("thread_connecting", connectingContext);
+    const resolveContextForDiscovery = vi
+      .spyOn(
+        manager as unknown as {
+          resolveContextForDiscovery: (threadId?: string, cwd?: string) => Promise<unknown>;
+        },
+        "resolveContextForDiscovery",
+      )
+      .mockResolvedValue(discoveryContext);
+    const sendRequest = vi
+      .spyOn(
+        manager as unknown as {
+          sendRequest: (...args: unknown[]) => Promise<unknown>;
+        },
+        "sendRequest",
+      )
+      .mockResolvedValue({ authMethod: "chatgpt", authToken: "voice-token" });
+
+    const loadVoiceTranscriptionAuth = (
+      manager as unknown as {
+        loadVoiceTranscriptionAuth: (input: {
+          cwd: string;
+          threadId: string;
+          refreshToken: boolean;
+        }) => Promise<unknown>;
+      }
+    ).loadVoiceTranscriptionAuth.bind(manager);
+
+    await expect(
+      loadVoiceTranscriptionAuth({
+        cwd: "/repo",
+        threadId: "thread_connecting",
+        refreshToken: false,
+      }),
+    ).resolves.toEqual({ authMethod: "chatgpt", token: "voice-token" });
+    expect(resolveContextForDiscovery).toHaveBeenCalledWith(undefined, "/repo");
+    expect(sendRequest).toHaveBeenCalledWith(discoveryContext, "getAuthStatus", {
+      includeToken: true,
+      refreshToken: false,
+    });
+    expect(sendRequest).not.toHaveBeenCalledWith(
+      connectingContext,
+      "getAuthStatus",
+      expect.anything(),
+    );
+  });
+
   it("retries skills/list with cwd when a runtime rejects cwds", async () => {
     const manager = new CodexAppServerManager();
     const context = {

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -2218,6 +2218,11 @@ describe("CodexAppServerManager discovery", () => {
         getOrCreateDiscoverySession: (cwd: string) => Promise<unknown>;
       }
     ).getOrCreateDiscoverySession("/repo");
+    (
+      manager as unknown as {
+        discoverySessions: Map<string, unknown>;
+      }
+    ).discoverySessions.set("/repo", { status: "connecting" });
     const stopping = manager.stopAll();
     await Promise.resolve();
     expect(stopDiscoverySession).not.toHaveBeenCalled();
@@ -2228,6 +2233,7 @@ describe("CodexAppServerManager discovery", () => {
       undefined,
     ]);
     expect(stopDiscoverySession).toHaveBeenCalledWith("/repo");
+    expect(stopDiscoverySession).toHaveBeenCalledTimes(1);
   });
 
   it("reuses a live thread for voice auth even when the project cwd is a worktree", async () => {

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -2163,6 +2163,142 @@ describe("CodexAppServerManager discovery", () => {
     expect(getOrCreateDiscoverySession).toHaveBeenCalledWith(process.cwd());
   });
 
+  it("reuses one in-flight discovery startup for concurrent callers", async () => {
+    const manager = new CodexAppServerManager();
+    const context = { discovery: true };
+    let resolveStartup!: (value: unknown) => void;
+    const startup = new Promise<unknown>((resolve) => {
+      resolveStartup = resolve;
+    });
+    const createDiscoverySession = vi
+      .spyOn(
+        manager as unknown as {
+          createDiscoverySession: (cwd: string) => Promise<unknown>;
+        },
+        "createDiscoverySession",
+      )
+      .mockReturnValue(startup);
+    const getOrCreateDiscoverySession = (
+      manager as unknown as {
+        getOrCreateDiscoverySession: (cwd: string) => Promise<unknown>;
+      }
+    ).getOrCreateDiscoverySession.bind(manager);
+
+    const first = getOrCreateDiscoverySession("/repo");
+    const second = getOrCreateDiscoverySession("/repo");
+
+    expect(createDiscoverySession).toHaveBeenCalledTimes(1);
+    resolveStartup(context);
+    await expect(Promise.all([first, second])).resolves.toEqual([context, context]);
+  });
+
+  it("waits for an in-flight discovery startup before stopAll completes", async () => {
+    const manager = new CodexAppServerManager();
+    let resolveStartup!: (value: unknown) => void;
+    const startup = new Promise<unknown>((resolve) => {
+      resolveStartup = resolve;
+    });
+    vi.spyOn(
+      manager as unknown as {
+        createDiscoverySession: (cwd: string) => Promise<unknown>;
+      },
+      "createDiscoverySession",
+    ).mockReturnValue(startup);
+    const stopDiscoverySession = vi
+      .spyOn(
+        manager as unknown as {
+          stopDiscoverySession: (cwd: string) => Promise<void>;
+        },
+        "stopDiscoverySession",
+      )
+      .mockResolvedValue(undefined);
+
+    const pendingStartup = (
+      manager as unknown as {
+        getOrCreateDiscoverySession: (cwd: string) => Promise<unknown>;
+      }
+    ).getOrCreateDiscoverySession("/repo");
+    const stopping = manager.stopAll();
+    await Promise.resolve();
+    expect(stopDiscoverySession).not.toHaveBeenCalled();
+
+    resolveStartup({ discovery: true });
+    await expect(Promise.all([pendingStartup, stopping])).resolves.toEqual([
+      { discovery: true },
+      undefined,
+    ]);
+    expect(stopDiscoverySession).toHaveBeenCalledWith("/repo");
+  });
+
+  it("reuses a live thread for voice auth even when the project cwd is a worktree", async () => {
+    const manager = new CodexAppServerManager();
+    const context = {
+      session: {
+        provider: "codex",
+        status: "ready",
+        threadId: "thread_voice",
+        runtimeMode: "full-access",
+        cwd: "/provider/repo",
+      },
+      child: {
+        exitCode: null,
+        signalCode: null,
+        killed: false,
+        stdin: new PassThrough(),
+      },
+      stopping: false,
+    };
+    (
+      manager as unknown as {
+        sessions: Map<string, unknown>;
+      }
+    ).sessions.set("thread_voice", context);
+    const resolveContextForDiscovery = vi.spyOn(
+      manager as unknown as {
+        resolveContextForDiscovery: (threadId?: string, cwd?: string) => Promise<unknown>;
+      },
+      "resolveContextForDiscovery",
+    );
+    const sendRequest = vi
+      .spyOn(
+        manager as unknown as {
+          sendRequest: (...args: unknown[]) => Promise<unknown>;
+        },
+        "sendRequest",
+      )
+      .mockResolvedValue({ authMethod: "chatgpt", authToken: "voice-token" });
+
+    const resolveVoiceTranscriptionAuth = (
+      manager as unknown as {
+        resolveVoiceTranscriptionAuth: (input: {
+          cwd: string;
+          threadId: string;
+          refreshToken: boolean;
+        }) => Promise<unknown>;
+      }
+    ).resolveVoiceTranscriptionAuth.bind(manager);
+    await expect(
+      resolveVoiceTranscriptionAuth({
+        cwd: "/worktrees/repo-2",
+        threadId: "thread_voice",
+        refreshToken: false,
+      }),
+    ).resolves.toEqual({ authMethod: "chatgpt", token: "voice-token" });
+    await expect(
+      resolveVoiceTranscriptionAuth({
+        cwd: "/worktrees/repo-3",
+        threadId: "thread_voice",
+        refreshToken: false,
+      }),
+    ).resolves.toEqual({ authMethod: "chatgpt", token: "voice-token" });
+    expect(resolveContextForDiscovery).not.toHaveBeenCalled();
+    expect(sendRequest).toHaveBeenCalledTimes(1);
+    expect(sendRequest).toHaveBeenCalledWith(context, "getAuthStatus", {
+      includeToken: true,
+      refreshToken: false,
+    });
+  });
+
   it("retries skills/list with cwd when a runtime rejects cwds", async () => {
     const manager = new CodexAppServerManager();
     const context = {

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -2443,8 +2443,8 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
   }): Promise<{ readonly ready: true }> {
     void prewarmChatGptVoiceTranscriptionConnection().catch(() => undefined);
     await this.resolveVoiceTranscriptionAuth({
-      cwd: input.cwd,
-      ...(input.threadId ? { threadId: input.threadId } : {}),
+      ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
+      ...(input.threadId !== undefined ? { threadId: input.threadId } : {}),
       refreshToken: false,
     });
     return { ready: true };

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -891,10 +891,7 @@ function setRecentCacheEntry<K, V>(
 export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEvents> {
   private readonly sessions = new Map<ThreadId, CodexSessionContext>();
   private readonly discoverySessions = new Map<string, CodexSessionContext>();
-  private readonly discoverySessionStartups = new Map<
-    string,
-    Promise<CodexSessionContext>
-  >();
+  private readonly discoverySessionStartups = new Map<string, Promise<CodexSessionContext>>();
   private readonly discoverySessionIdleTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private voiceAuthCache:
     | {

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -2491,6 +2491,13 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     );
   }
 
+  private isContextInitializedAndRoutable(context: CodexSessionContext): boolean {
+    return (
+      this.isContextRoutable(context) &&
+      (context.session.status === "ready" || context.session.status === "running")
+    );
+  }
+
   private async resolveContextForDiscovery(
     threadId?: string,
     cwd?: string,
@@ -2500,7 +2507,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     if (normalizedThreadId) {
       try {
         const session = this.requireSession(ThreadId.makeUnsafe(normalizedThreadId));
-        if (!normalizedCwd || session.session.cwd === normalizedCwd) {
+        if (
+          this.isContextInitializedAndRoutable(session) &&
+          (!normalizedCwd || session.session.cwd === normalizedCwd)
+        ) {
           return session;
         }
       } catch {
@@ -2511,14 +2521,17 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     }
     if (normalizedCwd) {
       for (const activeSession of this.sessions.values()) {
-        if (this.isContextRoutable(activeSession) && activeSession.session.cwd === normalizedCwd) {
+        if (
+          this.isContextInitializedAndRoutable(activeSession) &&
+          activeSession.session.cwd === normalizedCwd
+        ) {
           return activeSession;
         }
       }
       return this.getOrCreateDiscoverySession(normalizedCwd);
     }
     const firstActive = Array.from(this.sessions.values()).find((context) =>
-      this.isContextRoutable(context),
+      this.isContextInitializedAndRoutable(context),
     );
     if (firstActive) {
       return firstActive;
@@ -2563,7 +2576,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     const normalizedThreadId = input.threadId?.trim();
     if (normalizedThreadId) {
       try {
-        context = this.requireSession(ThreadId.makeUnsafe(normalizedThreadId));
+        const candidate = this.requireSession(ThreadId.makeUnsafe(normalizedThreadId));
+        if (this.isContextInitializedAndRoutable(candidate)) {
+          context = candidate;
+        }
       } catch {
         // A draft or closed thread can still use a cwd-scoped discovery session.
       }

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -2277,9 +2277,6 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       ...Array.from(this.sessions.keys(), (threadId) => this.stopSession(threadId)),
       ...Array.from(discoveryKeys, async (key) => {
         const startup = this.discoverySessionStartups.get(key);
-        if (this.discoverySessions.has(key)) {
-          await this.stopDiscoverySession(key);
-        }
         await startup?.catch(() => undefined);
         await this.stopDiscoverySession(key);
       }),

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -34,6 +34,7 @@ import {
   type ServerVoiceTranscriptionResult,
   type UserInputQuestion,
 } from "@synara/contracts";
+import { prewarmChatGptVoiceTranscriptionConnection } from "@synara/shared/chatGptVoiceTranscription";
 import { getModelSelectionBooleanOptionValue, normalizeModelSlug } from "@synara/shared/model";
 import { decodeSubagentReceiverThreadIds } from "@synara/shared/subagents";
 import { prepareWindowsSafeProcess } from "@synara/shared/windowsProcess";
@@ -316,6 +317,7 @@ const CODEX_DEFAULT_MODEL = "gpt-5.5";
 const CODEX_SPARK_MODEL = "gpt-5.3-codex-spark";
 const CODEX_SPARK_DISABLED_PLAN_TYPES = new Set<CodexPlanType>(["free", "go", "plus"]);
 const CODEX_DISCOVERY_SESSION_IDLE_MS = 10 * 60 * 1000;
+const CODEX_VOICE_AUTH_CACHE_TTL_MS = 60_000;
 const CODEX_PENDING_SETTLE_DEADLINE_MS = 2_000;
 
 // Bounds the best-effort answers written to parked server requests: a child that
@@ -889,7 +891,17 @@ function setRecentCacheEntry<K, V>(
 export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEvents> {
   private readonly sessions = new Map<ThreadId, CodexSessionContext>();
   private readonly discoverySessions = new Map<string, CodexSessionContext>();
+  private readonly discoverySessionStartups = new Map<
+    string,
+    Promise<CodexSessionContext>
+  >();
   private readonly discoverySessionIdleTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private voiceAuthCache:
+    | {
+        readonly loadedAt: number;
+        readonly promise: Promise<CodexVoiceTranscriptionAuthContext>;
+      }
+    | undefined;
   private readonly skillsCache = new Map<string, ProviderListSkillsResult>();
   private readonly pluginsCache = new Map<string, ProviderListPluginsResult>();
   private readonly pluginDetailCache = new Map<string, ProviderReadPluginResult>();
@@ -2260,9 +2272,20 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
   }
 
   async stopAll(): Promise<void> {
+    const discoveryKeys = new Set([
+      ...this.discoverySessions.keys(),
+      ...this.discoverySessionStartups.keys(),
+    ]);
     const results = await Promise.allSettled([
       ...Array.from(this.sessions.keys(), (threadId) => this.stopSession(threadId)),
-      ...Array.from(this.discoverySessions.keys(), (key) => this.stopDiscoverySession(key)),
+      ...Array.from(discoveryKeys, async (key) => {
+        const startup = this.discoverySessionStartups.get(key);
+        if (this.discoverySessions.has(key)) {
+          await this.stopDiscoverySession(key);
+        }
+        await startup?.catch(() => undefined);
+        await this.stopDiscoverySession(key);
+      }),
     ]);
     const failures = results.flatMap((result) =>
       result.status === "rejected" ? [result.reason] : [],
@@ -2417,6 +2440,19 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     });
   }
 
+  async prewarmVoice(input: {
+    readonly cwd?: string;
+    readonly threadId?: string;
+  }): Promise<{ readonly ready: true }> {
+    void prewarmChatGptVoiceTranscriptionConnection().catch(() => undefined);
+    await this.resolveVoiceTranscriptionAuth({
+      cwd: input.cwd,
+      ...(input.threadId ? { threadId: input.threadId } : {}),
+      refreshToken: false,
+    });
+    return { ready: true };
+  }
+
   getComposerCapabilities(): ProviderComposerCapabilities {
     return {
       provider: "codex",
@@ -2501,14 +2537,53 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     readonly threadId?: string;
     readonly refreshToken: boolean;
   }): Promise<CodexVoiceTranscriptionAuthContext> {
-    // Voice transcription should always resolve auth from a fresh discovery context
-    // instead of reusing a possibly stale thread-bound session token.
-    const context = await this.getOrCreateDiscoverySession(input.cwd?.trim() || process.cwd());
+    const cached = this.voiceAuthCache;
+    if (
+      !input.refreshToken &&
+      cached &&
+      Date.now() - cached.loadedAt < CODEX_VOICE_AUTH_CACHE_TTL_MS
+    ) {
+      return cached.promise;
+    }
+
+    const promise = this.loadVoiceTranscriptionAuth(input);
+    this.voiceAuthCache = { loadedAt: Date.now(), promise };
+    try {
+      return await promise;
+    } catch (error) {
+      if (this.voiceAuthCache?.promise === promise) {
+        this.voiceAuthCache = undefined;
+      }
+      throw error;
+    }
+  }
+
+  private async loadVoiceTranscriptionAuth(input: {
+    readonly cwd?: string;
+    readonly threadId?: string;
+    readonly refreshToken: boolean;
+  }): Promise<CodexVoiceTranscriptionAuthContext> {
+    // Auth is account-scoped, so a live thread session remains reusable even when
+    // a worktree project reports a different cwd from the provider session.
+    let context: CodexSessionContext | undefined;
+    const normalizedThreadId = input.threadId?.trim();
+    if (normalizedThreadId) {
+      try {
+        context = this.requireSession(ThreadId.makeUnsafe(normalizedThreadId));
+      } catch {
+        // A draft or closed thread can still use a cwd-scoped discovery session.
+      }
+    }
+    const authContext = context ?? (await this.resolveContextForDiscovery(undefined, input.cwd));
     const readAuthStatus = async (refreshToken: boolean) => {
-      const response = await this.sendRequest<Record<string, unknown>>(context, "getAuthStatus", {
-        includeToken: true,
-        refreshToken,
-      });
+      const response = await this.sendRequest<Record<string, unknown>>(
+        authContext,
+        "getAuthStatus",
+        {
+          includeToken: true,
+          refreshToken,
+        },
+      );
       const authMethod = this.readString(response, "authMethod");
       return {
         authMethod,
@@ -2536,11 +2611,34 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
 
   private async getOrCreateDiscoverySession(cwd: string): Promise<CodexSessionContext> {
     const normalizedCwd = cwd.trim() || process.cwd();
+    const startup = this.discoverySessionStartups.get(normalizedCwd);
+    if (startup) {
+      return startup;
+    }
     const existing = this.discoverySessions.get(normalizedCwd);
-    if (existing && !existing.stopping && !existing.child.killed) {
+    if (
+      existing &&
+      existing.session.status === "ready" &&
+      !existing.stopping &&
+      !existing.child.killed
+    ) {
       this.scheduleDiscoverySessionIdleStop(normalizedCwd);
       return existing;
     }
+
+    const nextStartup = this.createDiscoverySession(normalizedCwd);
+    this.discoverySessionStartups.set(normalizedCwd, nextStartup);
+    try {
+      return await nextStartup;
+    } finally {
+      if (this.discoverySessionStartups.get(normalizedCwd) === nextStartup) {
+        this.discoverySessionStartups.delete(normalizedCwd);
+      }
+    }
+  }
+
+  private async createDiscoverySession(normalizedCwd: string): Promise<CodexSessionContext> {
+    const existing = this.discoverySessions.get(normalizedCwd);
     if (existing) {
       await this.stopDiscoverySession(normalizedCwd);
     }

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -67,6 +67,7 @@ import {
   normalizeCorsOrigin,
   shouldRejectAuthMutationOrigin,
 } from "./trustedOrigins";
+import { voiceUploadAdmissionGate } from "./voiceUploadAdmission";
 
 const PROJECT_FAVICON_CACHE_CONTROL = "public, max-age=3600";
 const SITE_FAVICON_CACHE_CONTROL_SUCCESS = "public, max-age=86400"; // 24 h
@@ -962,25 +963,34 @@ const binaryUploadEffectHandler = Effect.gen(function* () {
         { status: 400, headers: corsHeaders },
       );
     }
-    const bytes = yield* readEffectBinary(request, SERVER_VOICE_TRANSCRIPTION_MAX_AUDIO_BYTES);
-    const registry = yield* ProviderAdapterRegistry;
-    const adapter = yield* registry.getByProvider(provider as never);
-    if (!adapter.transcribeVoice) {
+    const releaseUpload = voiceUploadAdmissionGate.tryAcquire();
+    if (!releaseUpload) {
       return HttpServerResponse.jsonUnsafe(
-        { error: `Voice transcription is unavailable for provider '${provider}'.` },
-        { status: 400, headers: corsHeaders },
+        { error: "Too many voice uploads are already in progress. Try again shortly." },
+        { status: 429, headers: corsHeaders },
       );
     }
-    const result = yield* adapter.transcribeVoice({
-      provider: provider as never,
-      cwd,
-      ...(threadId ? { threadId: ThreadId.makeUnsafe(threadId) } : {}),
-      mimeType,
-      sampleRateHz,
-      durationMs,
-      audioBase64: Buffer.from(bytes).toString("base64"),
-    });
-    return HttpServerResponse.jsonUnsafe(result, { status: 200, headers: corsHeaders });
+    return yield* Effect.gen(function* () {
+      const bytes = yield* readEffectBinary(request, SERVER_VOICE_TRANSCRIPTION_MAX_AUDIO_BYTES);
+      const registry = yield* ProviderAdapterRegistry;
+      const adapter = yield* registry.getByProvider(provider as never);
+      if (!adapter.transcribeVoice) {
+        return HttpServerResponse.jsonUnsafe(
+          { error: `Voice transcription is unavailable for provider '${provider}'.` },
+          { status: 400, headers: corsHeaders },
+        );
+      }
+      const result = yield* adapter.transcribeVoice({
+        provider: provider as never,
+        cwd,
+        ...(threadId ? { threadId: ThreadId.makeUnsafe(threadId) } : {}),
+        mimeType,
+        sampleRateHz,
+        durationMs,
+        audioBase64: Buffer.from(bytes).toString("base64"),
+      });
+      return HttpServerResponse.jsonUnsafe(result, { status: 200, headers: corsHeaders });
+    }).pipe(Effect.ensuring(Effect.sync(releaseUpload)));
   }
 
   return HttpServerResponse.text("Not Found", { status: 404, headers: corsHeaders });

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -67,7 +67,10 @@ import {
   normalizeCorsOrigin,
   shouldRejectAuthMutationOrigin,
 } from "./trustedOrigins";
-import { voiceUploadAdmissionGate } from "./voiceUploadAdmission";
+import {
+  VOICE_UPLOAD_CAPACITY_ERROR_MESSAGE,
+  voiceUploadAdmissionGate,
+} from "./voiceUploadAdmission";
 
 const PROJECT_FAVICON_CACHE_CONTROL = "public, max-age=3600";
 const SITE_FAVICON_CACHE_CONTROL_SUCCESS = "public, max-age=86400"; // 24 h
@@ -966,7 +969,7 @@ const binaryUploadEffectHandler = Effect.gen(function* () {
     const releaseUpload = voiceUploadAdmissionGate.tryAcquire();
     if (!releaseUpload) {
       return HttpServerResponse.jsonUnsafe(
-        { error: "Too many voice uploads are already in progress. Try again shortly." },
+        { error: VOICE_UPLOAD_CAPACITY_ERROR_MESSAGE },
         { status: 429, headers: corsHeaders },
       );
     }

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -2141,6 +2141,18 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
           }),
       }).pipe(Effect.map((result) => result satisfies ServerVoiceTranscriptionResult));
 
+    const prewarmVoice: NonNullable<CodexAdapterShape["prewarmVoice"]> = (input) =>
+      Effect.tryPromise({
+        try: () => manager.prewarmVoice(input),
+        catch: (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "voice/prewarm",
+            detail: toMessage(cause, "voice/prewarm failed"),
+            cause,
+          }),
+      });
+
     yield* Effect.acquireRelease(
       Effect.gen(function* () {
         const writeNativeEvent = (event: ProviderEvent) =>
@@ -2255,6 +2267,7 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
       listPlugins,
       readPlugin,
       listModels,
+      prewarmVoice,
       transcribeVoice,
       streamEvents: Stream.fromQueue(runtimeEventQueue),
     } satisfies CodexAdapterShape;

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -2143,7 +2143,11 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
 
     const prewarmVoice: NonNullable<CodexAdapterShape["prewarmVoice"]> = (input) =>
       Effect.tryPromise({
-        try: () => manager.prewarmVoice(input),
+        try: () =>
+          manager.prewarmVoice({
+            cwd: input.cwd,
+            ...(input.threadId !== undefined ? { threadId: input.threadId } : {}),
+          }),
         catch: (cause) =>
           new ProviderAdapterRequestError({
             provider: PROVIDER,

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -33,6 +33,8 @@ import type {
   ProviderSteerTurnInput,
   ProviderSession,
   ProviderSessionStartInput,
+  ServerVoicePrewarmInput,
+  ServerVoicePrewarmResult,
   ServerVoiceTranscriptionInput,
   ServerVoiceTranscriptionResult,
   ThreadId,
@@ -288,6 +290,13 @@ export interface ProviderAdapterShape<TError> {
   readonly listAgents?: (
     input: ProviderListAgentsInput,
   ) => Effect.Effect<ProviderListAgentsResult, TError>;
+
+  /**
+   * Warm provider state needed by voice transcription when supported.
+   */
+  readonly prewarmVoice?: (
+    input: ServerVoicePrewarmInput,
+  ) => Effect.Effect<ServerVoicePrewarmResult, TError>;
 
   /**
    * Transcribe one captured voice clip into plain text when supported.

--- a/apps/server/src/voiceUploadAdmission.test.ts
+++ b/apps/server/src/voiceUploadAdmission.test.ts
@@ -1,9 +1,13 @@
 // FILE: voiceUploadAdmission.test.ts
 // Purpose: Verifies bounded, leak-free admission for buffered voice uploads.
 
+import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
 
-import { VoiceUploadAdmissionGate } from "./voiceUploadAdmission";
+import {
+  VOICE_UPLOAD_CAPACITY_ERROR_MESSAGE,
+  VoiceUploadAdmissionGate,
+} from "./voiceUploadAdmission";
 
 describe("VoiceUploadAdmissionGate", () => {
   it("rejects excess uploads until an active lease is released", () => {
@@ -28,5 +32,17 @@ describe("VoiceUploadAdmissionGate", () => {
 
     expect(gate.tryAcquire()).toBeTypeOf("function");
     expect(gate.tryAcquire()).toBeNull();
+  });
+
+  it("guards fallback transports with the shared capacity and releases after use", async () => {
+    const gate = new VoiceUploadAdmissionGate(1);
+    const release = gate.tryAcquire();
+
+    await expect(Effect.runPromise(gate.run(Effect.succeed("blocked")))).rejects.toThrow(
+      VOICE_UPLOAD_CAPACITY_ERROR_MESSAGE,
+    );
+    release?.();
+    await expect(Effect.runPromise(gate.run(Effect.succeed("accepted")))).resolves.toBe("accepted");
+    expect(gate.tryAcquire()).toBeTypeOf("function");
   });
 });

--- a/apps/server/src/voiceUploadAdmission.test.ts
+++ b/apps/server/src/voiceUploadAdmission.test.ts
@@ -1,0 +1,32 @@
+// FILE: voiceUploadAdmission.test.ts
+// Purpose: Verifies bounded, leak-free admission for buffered voice uploads.
+
+import { describe, expect, it } from "vitest";
+
+import { VoiceUploadAdmissionGate } from "./voiceUploadAdmission";
+
+describe("VoiceUploadAdmissionGate", () => {
+  it("rejects excess uploads until an active lease is released", () => {
+    const gate = new VoiceUploadAdmissionGate(2);
+    const releaseFirst = gate.tryAcquire();
+    const releaseSecond = gate.tryAcquire();
+
+    expect(releaseFirst).toBeTypeOf("function");
+    expect(releaseSecond).toBeTypeOf("function");
+    expect(gate.tryAcquire()).toBeNull();
+
+    releaseFirst?.();
+    expect(gate.tryAcquire()).toBeTypeOf("function");
+  });
+
+  it("makes lease release idempotent", () => {
+    const gate = new VoiceUploadAdmissionGate(1);
+    const release = gate.tryAcquire();
+
+    release?.();
+    release?.();
+
+    expect(gate.tryAcquire()).toBeTypeOf("function");
+    expect(gate.tryAcquire()).toBeNull();
+  });
+});

--- a/apps/server/src/voiceUploadAdmission.ts
+++ b/apps/server/src/voiceUploadAdmission.ts
@@ -1,0 +1,35 @@
+// FILE: voiceUploadAdmission.ts
+// Purpose: Bounds voice uploads before request bodies are buffered in server memory.
+// Layer: Server transport utility
+// Exports: VoiceUploadAdmissionGate, voiceUploadAdmissionGate
+
+const MAX_CONCURRENT_VOICE_UPLOADS = 2;
+
+export class VoiceUploadAdmissionGate {
+  private active = 0;
+
+  constructor(private readonly maxConcurrent: number) {
+    if (!Number.isSafeInteger(maxConcurrent) || maxConcurrent < 1) {
+      throw new Error("Voice upload concurrency must be a positive integer.");
+    }
+  }
+
+  tryAcquire(): (() => void) | null {
+    if (this.active >= this.maxConcurrent) {
+      return null;
+    }
+    this.active += 1;
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      this.active -= 1;
+    };
+  }
+}
+
+export const voiceUploadAdmissionGate = new VoiceUploadAdmissionGate(
+  MAX_CONCURRENT_VOICE_UPLOADS,
+);

--- a/apps/server/src/voiceUploadAdmission.ts
+++ b/apps/server/src/voiceUploadAdmission.ts
@@ -3,7 +3,11 @@
 // Layer: Server transport utility
 // Exports: VoiceUploadAdmissionGate, voiceUploadAdmissionGate
 
+import { Effect } from "effect";
+
 const MAX_CONCURRENT_VOICE_UPLOADS = 2;
+export const VOICE_UPLOAD_CAPACITY_ERROR_MESSAGE =
+  "Too many voice uploads are already in progress. Try again shortly.";
 
 export class VoiceUploadAdmissionGate {
   private active = 0;
@@ -27,6 +31,21 @@ export class VoiceUploadAdmissionGate {
       released = true;
       this.active -= 1;
     };
+  }
+
+  run<A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E | Error, R> {
+    const acquire = Effect.sync(() => this.tryAcquire()).pipe(
+      Effect.flatMap((release) =>
+        release
+          ? Effect.succeed(release)
+          : Effect.fail(new Error(VOICE_UPLOAD_CAPACITY_ERROR_MESSAGE)),
+      ),
+    );
+    return Effect.acquireUseRelease(
+      acquire,
+      () => effect,
+      (release) => Effect.sync(release),
+    );
   }
 }
 

--- a/apps/server/src/voiceUploadAdmission.ts
+++ b/apps/server/src/voiceUploadAdmission.ts
@@ -30,6 +30,4 @@ export class VoiceUploadAdmissionGate {
   }
 }
 
-export const voiceUploadAdmissionGate = new VoiceUploadAdmissionGate(
-  MAX_CONCURRENT_VOICE_UPLOADS,
-);
+export const voiceUploadAdmissionGate = new VoiceUploadAdmissionGate(MAX_CONCURRENT_VOICE_UPLOADS);

--- a/apps/server/src/wsRequestAdmission.test.ts
+++ b/apps/server/src/wsRequestAdmission.test.ts
@@ -12,6 +12,7 @@ describe("WsRequestAdmission", () => {
     );
     expect(classifyWsRequest(ORCHESTRATION_WS_METHODS.getTurnDiff)).toBe("expensive-read");
     expect(classifyWsRequest(ORCHESTRATION_WS_METHODS.repairState)).toBe("expensive-read");
+    expect(classifyWsRequest(WS_METHODS.serverPrewarmVoice)).toBe("expensive-read");
     expect(classifyWsRequest(WS_METHODS.terminalAckOutput)).toBe("control");
   });
 

--- a/apps/server/src/wsRequestAdmission.ts
+++ b/apps/server/src/wsRequestAdmission.ts
@@ -45,6 +45,7 @@ const EXPENSIVE_READ_METHODS = new Set<string>([
   WS_METHODS.serverGetProviderUsageSnapshot,
   WS_METHODS.serverListProviderUsage,
   WS_METHODS.serverGetDiagnostics,
+  WS_METHODS.serverPrewarmVoice,
   WS_METHODS.serverGenerateThreadRecap,
   WS_METHODS.serverGenerateAutomationIntent,
   WS_METHODS.serverTranscribeVoice,

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -1438,6 +1438,23 @@ const makeWsRpcHandlersLayer = () =>
             }),
             "Failed to load server diagnostics",
           ),
+        [WS_METHODS.serverPrewarmVoice]: (input) =>
+          rpcEffect(
+            providerAdapterRegistry
+              .getByProvider(input.provider)
+              .pipe(
+                Effect.flatMap((adapter) =>
+                  adapter.prewarmVoice
+                    ? adapter.prewarmVoice(input)
+                    : Effect.fail(
+                        new Error(
+                          `Voice transcription is unavailable for provider '${input.provider}'.`,
+                        ),
+                      ),
+                ),
+              ),
+            "Voice transcription prewarm failed",
+          ),
         [WS_METHODS.serverTranscribeVoice]: (input) =>
           rpcEffect(
             providerAdapterRegistry

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -106,6 +106,7 @@ import {
 } from "./wsStreamAdmission";
 import { ThreadDiagnosticsQuery } from "./diagnostics/Services/ThreadDiagnosticsQuery";
 import { makeWsRequestAdmission } from "./wsRequestAdmission";
+import { voiceUploadAdmissionGate } from "./voiceUploadAdmission";
 import {
   CurrentWsSessionRole,
   provideWsConnectionSession,
@@ -1457,19 +1458,21 @@ const makeWsRpcHandlersLayer = () =>
           ),
         [WS_METHODS.serverTranscribeVoice]: (input) =>
           rpcEffect(
-            providerAdapterRegistry
-              .getByProvider(input.provider)
-              .pipe(
-                Effect.flatMap((adapter) =>
-                  adapter.transcribeVoice
-                    ? adapter.transcribeVoice(input)
-                    : Effect.fail(
-                        new Error(
-                          `Voice transcription is unavailable for provider '${input.provider}'.`,
+            voiceUploadAdmissionGate.run(
+              providerAdapterRegistry
+                .getByProvider(input.provider)
+                .pipe(
+                  Effect.flatMap((adapter) =>
+                    adapter.transcribeVoice
+                      ? adapter.transcribeVoice(input)
+                      : Effect.fail(
+                          new Error(
+                            `Voice transcription is unavailable for provider '${input.provider}'.`,
+                          ),
                         ),
-                      ),
+                  ),
                 ),
-              ),
+            ),
             "Voice transcription failed",
           ),
         [WS_METHODS.serverGenerateThreadRecap]: (input) =>

--- a/apps/web/scripts/voice-processing-benchmark.ts
+++ b/apps/web/scripts/voice-processing-benchmark.ts
@@ -1,0 +1,199 @@
+// Reproducible Mic post-processing benchmark. Run with:
+// bun apps/web/scripts/voice-processing-benchmark.ts
+
+import { encodeVoiceRecordingWav } from "../src/lib/voiceRecorderEncoding";
+
+const TARGET_SAMPLE_RATE = 24_000;
+const LEGACY_INPUT_SAMPLE_RATE = 48_000;
+const WARMUP_COUNT = 5;
+const SAMPLE_COUNT = 25;
+
+interface BenchmarkStats {
+  readonly meanMs: number;
+  readonly medianMs: number;
+  readonly p95Ms: number;
+  readonly minMs: number;
+  readonly maxMs: number;
+  readonly stddevMs: number;
+}
+
+function makeChunks(
+  durationSeconds: number,
+  inputSampleRateHz: number,
+  chunkSize: number,
+): Float32Array[] {
+  const total = durationSeconds * inputSampleRateHz;
+  const chunks: Float32Array[] = [];
+  for (let offset = 0; offset < total; offset += chunkSize) {
+    const length = Math.min(chunkSize, total - offset);
+    const chunk = new Float32Array(length);
+    for (let index = 0; index < length; index += 1) {
+      chunk[index] =
+        Math.sin(((offset + index) * Math.PI * 2 * 220) / inputSampleRateHz) * 0.5;
+    }
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+function legacyEncode(chunks: readonly Float32Array[], inputSampleRateHz: number): ArrayBuffer {
+  return legacyEncodeWav(
+    legacyResample(legacyMerge(chunks), inputSampleRateHz, TARGET_SAMPLE_RATE),
+  );
+}
+
+function legacyMerge(chunks: readonly Float32Array[]): Float32Array {
+  const inputSampleCount = chunks.reduce((total, chunk) => total + chunk.length, 0);
+  const merged = new Float32Array(inputSampleCount);
+  let mergedOffset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, mergedOffset);
+    mergedOffset += chunk.length;
+  }
+  return merged;
+}
+
+function legacyResample(
+  samples: Float32Array,
+  inputSampleRateHz: number,
+  outputSampleRateHz: number,
+): Float32Array {
+  if (inputSampleRateHz === outputSampleRateHz) return samples.slice();
+  const ratio = inputSampleRateHz / outputSampleRateHz;
+  const resampled = new Float32Array(Math.max(1, Math.round(samples.length / ratio)));
+  for (let index = 0; index < resampled.length; index += 1) {
+    const sourceIndex = index * ratio;
+    const leftIndex = Math.floor(sourceIndex);
+    const rightIndex = Math.min(samples.length - 1, leftIndex + 1);
+    const leftValue = samples[leftIndex] ?? 0;
+    const rightValue = samples[rightIndex] ?? leftValue;
+    resampled[index] = leftValue + (rightValue - leftValue) * (sourceIndex - leftIndex);
+  }
+  return resampled;
+}
+
+function legacyEncodeWav(samples: Float32Array): ArrayBuffer {
+  const view = new DataView(new ArrayBuffer(44 + samples.length * 2));
+  writeWavHeader(view, samples.length);
+  let wavOffset = 44;
+  for (const sample of samples) {
+    const clamped = Math.max(-1, Math.min(1, sample));
+    const pcm = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff;
+    view.setInt16(wavOffset, Math.round(pcm), true);
+    wavOffset += 2;
+  }
+  return view.buffer;
+}
+
+function writeWavHeader(view: DataView, sampleCount: number): void {
+  writeAscii(view, 0, "RIFF");
+  view.setUint32(4, 36 + sampleCount * 2, true);
+  writeAscii(view, 8, "WAVE");
+  writeAscii(view, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, TARGET_SAMPLE_RATE, true);
+  view.setUint32(28, TARGET_SAMPLE_RATE * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeAscii(view, 36, "data");
+  view.setUint32(40, sampleCount * 2, true);
+}
+
+function writeAscii(view: DataView, offset: number, value: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    view.setUint8(offset + index, value.charCodeAt(index));
+  }
+}
+
+function summarize(values: readonly number[]): BenchmarkStats {
+  const sorted = [...values].sort((left, right) => left - right);
+  const mean = values.reduce((total, value) => total + value, 0) / values.length;
+  const variance =
+    values.reduce((total, value) => total + (value - mean) ** 2, 0) / values.length;
+  return {
+    meanMs: mean,
+    medianMs: percentile(sorted, 0.5),
+    p95Ms: percentile(sorted, 0.95),
+    minMs: sorted[0] ?? 0,
+    maxMs: sorted.at(-1) ?? 0,
+    stddevMs: Math.sqrt(variance),
+  };
+}
+
+function percentile(sorted: readonly number[], value: number): number {
+  return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * value) - 1)] ?? 0;
+}
+
+function measure(
+  implementation: string,
+  durationSeconds: number,
+  inputSampleRateHz: number,
+  chunkSize: number,
+  run: (chunks: readonly Float32Array[]) => ArrayBuffer,
+  temporaryBytes: number,
+): void {
+  const chunks = makeChunks(durationSeconds, inputSampleRateHz, chunkSize);
+  let checksum = 0;
+  for (let index = 0; index < WARMUP_COUNT; index += 1) {
+    checksum ^= run(chunks).byteLength;
+  }
+  const durations: number[] = [];
+  for (let index = 0; index < SAMPLE_COUNT; index += 1) {
+    Bun.gc(true);
+    const startedAt = performance.now();
+    checksum ^= run(chunks).byteLength;
+    durations.push(performance.now() - startedAt);
+  }
+  const capturedChunkBytes = durationSeconds * inputSampleRateHz * 4;
+  console.log(
+    JSON.stringify({
+      implementation,
+      durationSeconds,
+      inputSampleRateHz,
+      targetSampleRateHz: TARGET_SAMPLE_RATE,
+      warmups: WARMUP_COUNT,
+      samples: SAMPLE_COUNT,
+      temporaryBytes,
+      capturedChunkBytes,
+      totalAudioArrayBytes: capturedChunkBytes + temporaryBytes,
+      ...summarize(durations),
+      checksum,
+    }),
+  );
+}
+
+for (const durationSeconds of [30, 120]) {
+  const outputBytes = 44 + durationSeconds * TARGET_SAMPLE_RATE * 2;
+  const legacyInputSamples = durationSeconds * LEGACY_INPUT_SAMPLE_RATE;
+  const legacyResampledBytes = durationSeconds * TARGET_SAMPLE_RATE * 4;
+  measure(
+    "legacy-48khz",
+    durationSeconds,
+    LEGACY_INPUT_SAMPLE_RATE,
+    4_096,
+    (chunks) => legacyEncode(chunks, LEGACY_INPUT_SAMPLE_RATE),
+    legacyInputSamples * 4 + legacyResampledBytes + outputBytes,
+  );
+  measure(
+    "optimized-fallback-48khz",
+    durationSeconds,
+    LEGACY_INPUT_SAMPLE_RATE,
+    4_096,
+    (chunks) =>
+      encodeVoiceRecordingWav(chunks, LEGACY_INPUT_SAMPLE_RATE, TARGET_SAMPLE_RATE)?.bytes ??
+      new ArrayBuffer(0),
+    outputBytes,
+  );
+  measure(
+    "optimized-target-24khz",
+    durationSeconds,
+    TARGET_SAMPLE_RATE,
+    2_048,
+    (chunks) =>
+      encodeVoiceRecordingWav(chunks, TARGET_SAMPLE_RATE, TARGET_SAMPLE_RATE)?.bytes ??
+      new ArrayBuffer(0),
+    outputBytes,
+  );
+}

--- a/apps/web/scripts/voice-processing-benchmark.ts
+++ b/apps/web/scripts/voice-processing-benchmark.ts
@@ -28,8 +28,7 @@ function makeChunks(
     const length = Math.min(chunkSize, total - offset);
     const chunk = new Float32Array(length);
     for (let index = 0; index < length; index += 1) {
-      chunk[index] =
-        Math.sin(((offset + index) * Math.PI * 2 * 220) / inputSampleRateHz) * 0.5;
+      chunk[index] = Math.sin(((offset + index) * Math.PI * 2 * 220) / inputSampleRateHz) * 0.5;
     }
     chunks.push(chunk);
   }
@@ -110,8 +109,7 @@ function writeAscii(view: DataView, offset: number, value: string): void {
 function summarize(values: readonly number[]): BenchmarkStats {
   const sorted = [...values].sort((left, right) => left - right);
   const mean = values.reduce((total, value) => total + value, 0) / values.length;
-  const variance =
-    values.reduce((total, value) => total + (value - mean) ** 2, 0) / values.length;
+  const variance = values.reduce((total, value) => total + (value - mean) ** 2, 0) / values.length;
   return {
     meanMs: mean,
     medianMs: percentile(sorted, 0.5),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -11053,14 +11053,8 @@ export default function ChatView({
                           isTranscribing={isVoiceTranscribing}
                           durationLabel={voiceRecordingDurationLabel}
                           waveformLevels={voiceWaveformLevels}
-                          onCancel={() => {
-                            if (isVoiceRecording) {
-                              void submitComposerVoiceRecording();
-                              return;
-                            }
-                            cancelComposerVoiceRecording();
-                          }}
-                          onSubmit={() => {
+                          onDiscard={cancelComposerVoiceRecording}
+                          onStop={() => {
                             void submitComposerVoiceRecording();
                           }}
                         />

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -159,7 +159,7 @@ import {
 } from "../lib/automationDraft";
 import { dispatchThreadRename } from "../lib/threadRename";
 import { useHandleNewChat } from "../hooks/useHandleNewChat";
-import { useComposerDropzone } from "../hooks/useComposerDropzone";
+import { splitComposerDropzoneFiles, useComposerDropzone } from "../hooks/useComposerDropzone";
 import { useComposerImageIntake } from "../hooks/useComposerImageIntake";
 import { useDiffRouteSearch } from "../hooks/useDiffRouteSearch";
 import {
@@ -6356,6 +6356,19 @@ export default function ChatView({
     [activeThreadId, addComposerFilesToDraft, pendingUserInputs.length, setThreadError],
   );
 
+  const addComposerAttachments = useCallback(
+    (files: readonly File[]) => {
+      const { imageFiles, genericFiles } = splitComposerDropzoneFiles(files);
+      if (imageFiles.length > 0) {
+        addComposerImages(imageFiles);
+      }
+      if (genericFiles.length > 0) {
+        addComposerFiles(genericFiles);
+      }
+    },
+    [addComposerFiles, addComposerImages],
+  );
+
   const removeComposerFile = (fileId: string) => {
     discardPromptHistoryNavigationForComposerMutation();
     removeComposerDraftFile(threadId, fileId);
@@ -10438,7 +10451,7 @@ export default function ChatView({
         interactionMode={interactionMode}
         supportsFastMode={composerTraitSelection.caps.supportsFastMode}
         fastModeEnabled={composerTraitSelection.fastModeEnabled}
-        onAddPhotos={addComposerImages}
+        onAddAttachments={addComposerAttachments}
         onToggleFastMode={toggleFastMode}
         onSetPlanMode={setPlanMode}
       />

--- a/apps/web/src/components/chat/ComposerExtrasMenu.browser.tsx
+++ b/apps/web/src/components/chat/ComposerExtrasMenu.browser.tsx
@@ -1,5 +1,5 @@
 // FILE: ComposerExtrasMenu.browser.tsx
-// Purpose: Verifies the composer `+` menu exposes image-only uploads and quick mode toggles.
+// Purpose: Verifies the composer `+` menu exposes generic file uploads and quick mode toggles.
 // Layer: Browser UI test
 // Depends on: vitest browser rendering helpers and the ComposerExtrasMenu component.
 
@@ -16,7 +16,7 @@ async function mountMenu(props?: {
   interactionMode?: "default" | "plan";
   supportsFastMode?: boolean;
 }) {
-  const onAddPhotos = vi.fn();
+  const onAddAttachments = vi.fn();
   const onToggleFastMode = vi.fn();
   const onSetPlanMode = vi.fn();
   const host = document.createElement("div");
@@ -26,7 +26,7 @@ async function mountMenu(props?: {
       interactionMode={props?.interactionMode ?? "default"}
       supportsFastMode={props?.supportsFastMode ?? true}
       fastModeEnabled={props?.fastModeEnabled ?? false}
-      onAddPhotos={onAddPhotos}
+      onAddAttachments={onAddAttachments}
       onToggleFastMode={onToggleFastMode}
       onSetPlanMode={onSetPlanMode}
     />,
@@ -41,7 +41,7 @@ async function mountMenu(props?: {
   return {
     [Symbol.asyncDispose]: cleanup,
     cleanup,
-    onAddPhotos,
+    onAddAttachments,
     onToggleFastMode,
     onSetPlanMode,
   };
@@ -52,23 +52,27 @@ describe("ComposerExtrasMenu", () => {
     document.body.innerHTML = "";
   });
 
-  it("uses an image-only file picker and forwards selected images", async () => {
+  it("uses an unrestricted file picker and forwards every selected file", async () => {
     await using menu = await mountMenu();
 
-    const input = document.querySelector<HTMLInputElement>("[data-testid='composer-photo-input']");
+    const input = document.querySelector<HTMLInputElement>("[data-testid='composer-file-input']");
     expect(input).not.toBeNull();
-    expect(input?.accept).toBe("image/*");
+    expect(input?.hasAttribute("accept")).toBe(false);
 
     const files = new DataTransfer();
     files.items.add(new File(["photo"], "photo.png", { type: "image/png" }));
+    files.items.add(new File(["document"], "document.pdf", { type: "application/pdf" }));
     Object.defineProperty(input, "files", {
       configurable: true,
       value: files.files,
     });
     input?.dispatchEvent(new Event("change", { bubbles: true }));
 
-    expect(menu.onAddPhotos).toHaveBeenCalledTimes(1);
-    expect(menu.onAddPhotos.mock.calls[0]?.[0]?.[0]?.name).toBe("photo.png");
+    expect(menu.onAddAttachments).toHaveBeenCalledTimes(1);
+    expect(menu.onAddAttachments.mock.calls[0]?.[0]?.map((file: File) => file.name)).toEqual([
+      "photo.png",
+      "document.pdf",
+    ]);
   });
 
   it("shows the attachment action in the menu", async () => {
@@ -78,7 +82,7 @@ describe("ComposerExtrasMenu", () => {
 
     await vi.waitFor(() => {
       const text = document.body.textContent ?? "";
-      expect(text).toContain("Add image");
+      expect(text).toContain("Add files");
       expect(text).toContain("Plan mode");
       expect(text).toContain("Fast");
       expect(text).not.toContain("Plugins");

--- a/apps/web/src/components/chat/ComposerExtrasMenu.tsx
+++ b/apps/web/src/components/chat/ComposerExtrasMenu.tsx
@@ -26,18 +26,18 @@ export const ComposerExtrasMenu = function ComposerExtrasMenu(props: {
   interactionMode: ProviderInteractionMode;
   supportsFastMode: boolean;
   fastModeEnabled: boolean;
-  onAddPhotos: (files: File[]) => void;
+  onAddAttachments: (files: File[]) => void;
   onToggleFastMode: () => void;
   onSetPlanMode: (enabled: boolean) => void;
 }) {
   const inputId = useId();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
-  // Reset the hidden input so selecting the same image twice still emits a change event.
+  // Reset the hidden input so selecting the same file twice still emits a change event.
   const handleFileInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files ?? []);
     if (files.length > 0) {
-      props.onAddPhotos(files);
+      props.onAddAttachments(files);
     }
     event.target.value = "";
   };
@@ -47,9 +47,8 @@ export const ComposerExtrasMenu = function ComposerExtrasMenu(props: {
       <input
         id={inputId}
         ref={fileInputRef}
-        data-testid="composer-photo-input"
+        data-testid="composer-file-input"
         type="file"
-        accept="image/*"
         multiple
         className="sr-only"
         onChange={handleFileInputChange}
@@ -65,7 +64,7 @@ export const ComposerExtrasMenu = function ComposerExtrasMenu(props: {
             />
           }
         >
-          <PlusIcon aria-hidden="true" className="size-4" />
+          <PlusIcon aria-hidden="true" className="size-4 text-white" />
         </MenuTrigger>
         <ComposerPickerMenuPopup align="start">
           <MenuItem
@@ -74,7 +73,7 @@ export const ComposerExtrasMenu = function ComposerExtrasMenu(props: {
             }}
           >
             <PaperclipIcon className="size-4 shrink-0" />
-            Add image
+            Add files
           </MenuItem>
 
           <MenuSeparator />

--- a/apps/web/src/components/chat/ComposerVoiceButton.tsx
+++ b/apps/web/src/components/chat/ComposerVoiceButton.tsx
@@ -30,9 +30,9 @@ export const ComposerVoiceButton = function ComposerVoiceButton(props: {
       onClick={props.onClick}
     >
       {props.isTranscribing ? (
-        <Loader2Icon aria-hidden="true" className="size-4 animate-spin" />
+        <Loader2Icon aria-hidden="true" className="size-4 animate-spin text-white" />
       ) : (
-        <MicIcon aria-hidden="true" className="size-4" />
+        <MicIcon aria-hidden="true" className="size-4 text-white" />
       )}
     </Button>
   );

--- a/apps/web/src/components/chat/ComposerVoiceRecorderBar.browser.tsx
+++ b/apps/web/src/components/chat/ComposerVoiceRecorderBar.browser.tsx
@@ -17,16 +17,16 @@ describe("ComposerVoiceRecorderBar", () => {
   });
 
   it("uses the send treatment for stop while keeping cancel separate", async () => {
-    const onCancel = vi.fn();
-    const onSubmit = vi.fn();
+    const onDiscard = vi.fn();
+    const onStop = vi.fn();
     const screen = await render(
       <ComposerVoiceRecorderBar
         durationLabel="0:03"
         isRecording
         isTranscribing={false}
         waveformLevels={[0.2, 0.6, 0.4]}
-        onCancel={onCancel}
-        onSubmit={onSubmit}
+        onDiscard={onDiscard}
+        onStop={onStop}
       />,
     );
 
@@ -39,11 +39,12 @@ describe("ComposerVoiceRecorderBar", () => {
     expect(document.querySelector('button[aria-label="Send voice note"]')).toBeNull();
 
     await page.getByRole("button", { name: "Stop voice recording" }).click();
-    expect(onSubmit).toHaveBeenCalledTimes(1);
-    expect(onCancel).not.toHaveBeenCalled();
+    expect(onStop).toHaveBeenCalledTimes(1);
+    expect(onDiscard).not.toHaveBeenCalled();
 
     await page.getByRole("button", { name: "Cancel voice recording" }).click();
-    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+    expect(onStop).toHaveBeenCalledTimes(1);
 
     await screen.unmount();
   });

--- a/apps/web/src/components/chat/ComposerVoiceRecorderBar.browser.tsx
+++ b/apps/web/src/components/chat/ComposerVoiceRecorderBar.browser.tsx
@@ -1,0 +1,50 @@
+// FILE: ComposerVoiceRecorderBar.browser.tsx
+// Purpose: Verifies voice recording exposes cancel plus a send-styled primary stop action.
+// Layer: Browser UI test
+// Depends on: vitest browser rendering and ComposerVoiceRecorderBar.
+
+import "../../index.css";
+
+import { page } from "vitest/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { ComposerVoiceRecorderBar } from "./ComposerVoiceRecorderBar";
+
+describe("ComposerVoiceRecorderBar", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("uses the send treatment for stop while keeping cancel separate", async () => {
+    const onCancel = vi.fn();
+    const onSubmit = vi.fn();
+    const screen = await render(
+      <ComposerVoiceRecorderBar
+        durationLabel="0:03"
+        isRecording
+        isTranscribing={false}
+        waveformLevels={[0.2, 0.6, 0.4]}
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const stopButton = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Stop voice recording"]',
+    );
+    expect(stopButton).not.toBeNull();
+    expect(stopButton?.className).toContain("bg-[var(--color-text-foreground)]");
+    expect(stopButton?.className).toContain("text-[var(--color-background-surface)]");
+    expect(document.querySelector('button[aria-label="Send voice note"]')).toBeNull();
+
+    await page.getByRole("button", { name: "Stop voice recording" }).click();
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+
+    await page.getByRole("button", { name: "Cancel voice recording" }).click();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    await screen.unmount();
+  });
+});

--- a/apps/web/src/components/chat/ComposerVoiceRecorderBar.tsx
+++ b/apps/web/src/components/chat/ComposerVoiceRecorderBar.tsx
@@ -15,8 +15,8 @@ interface ComposerVoiceRecorderBarProps {
   isRecording: boolean;
   isTranscribing: boolean;
   waveformLevels: readonly number[];
-  onCancel: () => void;
-  onSubmit: () => void;
+  onDiscard: () => void;
+  onStop: () => void;
 }
 
 const BAR_WIDTH_PX = 2;
@@ -92,7 +92,7 @@ export function ComposerVoiceRecorderBar(props: ComposerVoiceRecorderBarProps) {
         className="flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-full bg-zinc-200/80 text-zinc-700 transition-colors hover:bg-zinc-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white/10 dark:text-zinc-100 dark:hover:bg-white/15 sm:h-7 sm:w-7"
         aria-label={props.isTranscribing ? "Transcribing voice note" : "Cancel voice recording"}
         disabled={props.disabled || props.isTranscribing}
-        onClick={props.onCancel}
+        onClick={props.onDiscard}
       >
         {props.isTranscribing ? (
           <Loader2Icon aria-hidden="true" className="size-3 animate-spin" />
@@ -108,7 +108,7 @@ export function ComposerVoiceRecorderBar(props: ComposerVoiceRecorderBarProps) {
         className="size-7 rounded-full sm:size-7"
         aria-label={props.isTranscribing ? "Transcribing voice note" : "Stop voice recording"}
         disabled={props.disabled || props.isTranscribing}
-        onClick={props.onSubmit}
+        onClick={props.onStop}
       >
         {props.isTranscribing ? (
           <Loader2Icon aria-hidden="true" className="size-3 animate-spin" />

--- a/apps/web/src/components/chat/ComposerVoiceRecorderBar.tsx
+++ b/apps/web/src/components/chat/ComposerVoiceRecorderBar.tsx
@@ -4,11 +4,10 @@
 // Depends on: live waveform samples and caller-owned record/cancel/send actions.
 
 import { useEffect, useRef, useState } from "react";
-import { FiArrowUp } from "react-icons/fi";
-import { IoStopSharp } from "react-icons/io5";
 
-import { Loader2Icon } from "~/lib/icons";
+import { Loader2Icon, XIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
+import { Button } from "../ui/button";
 
 interface ComposerVoiceRecorderBarProps {
   disabled?: boolean;
@@ -91,30 +90,32 @@ export function ComposerVoiceRecorderBar(props: ComposerVoiceRecorderBarProps) {
       <button
         type="button"
         className="flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-full bg-zinc-200/80 text-zinc-700 transition-colors hover:bg-zinc-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white/10 dark:text-zinc-100 dark:hover:bg-white/15 sm:h-7 sm:w-7"
-        aria-label={props.isTranscribing ? "Transcribing voice note" : "Cancel voice note"}
+        aria-label={props.isTranscribing ? "Transcribing voice note" : "Cancel voice recording"}
         disabled={props.disabled || props.isTranscribing}
         onClick={props.onCancel}
       >
         {props.isTranscribing ? (
           <Loader2Icon aria-hidden="true" className="size-3 animate-spin" />
         ) : (
-          <IoStopSharp aria-hidden="true" className="size-[11px]" />
+          <XIcon aria-hidden="true" className="size-3.5" />
         )}
       </button>
 
-      <button
+      <Button
         type="button"
-        className="flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-full bg-foreground text-background transition-transform duration-150 hover:scale-105 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:scale-100 sm:h-7 sm:w-7"
-        aria-label={props.isTranscribing ? "Transcribing voice note" : "Send voice note"}
+        variant="prominent"
+        size="icon-xs"
+        className="size-7 rounded-full sm:size-7"
+        aria-label={props.isTranscribing ? "Transcribing voice note" : "Stop voice recording"}
         disabled={props.disabled || props.isTranscribing}
         onClick={props.onSubmit}
       >
         {props.isTranscribing ? (
           <Loader2Icon aria-hidden="true" className="size-3 animate-spin" />
         ) : (
-          <FiArrowUp aria-hidden="true" className="size-[13px]" strokeWidth={2.25} />
+          <span aria-hidden="true" className="block size-2 rounded-[1px] bg-current" />
         )}
-      </button>
+      </Button>
     </div>
   );
 }

--- a/apps/web/src/components/chat/useComposerVoiceController.test.ts
+++ b/apps/web/src/components/chat/useComposerVoiceController.test.ts
@@ -9,6 +9,7 @@ const reactHarness = vi.hoisted(() => {
   interface HookSlot {
     value?: unknown;
     deps?: readonly unknown[];
+    cleanup?: () => void;
   }
 
   let slots: HookSlot[] = [];
@@ -29,8 +30,14 @@ const reactHarness = vi.hoisted(() => {
     if (depsEqual(slot.deps, deps)) {
       return;
     }
+    slot.cleanup?.();
     slot.deps = deps;
-    effect();
+    const cleanup = effect();
+    if (cleanup) {
+      slot.cleanup = cleanup;
+    } else {
+      delete slot.cleanup;
+    }
   };
 
   return {
@@ -40,6 +47,11 @@ const reactHarness = vi.hoisted(() => {
     reset() {
       slots = [];
       cursor = 0;
+    },
+    unmount() {
+      for (const slot of slots.toReversed()) {
+        slot.cleanup?.();
+      }
     },
     useEffect: runEffect,
     useLayoutEffect: runEffect,
@@ -70,6 +82,7 @@ const recorder = vi.hoisted(() => ({
 }));
 
 const nativeApi = vi.hoisted(() => ({
+  prewarmVoice: vi.fn(),
   transcribeVoice: vi.fn(),
   available: true,
 }));
@@ -89,6 +102,8 @@ vi.mock("react", () => ({
 
 vi.mock("../../lib/voiceRecorder", () => ({
   formatVoiceRecordingDuration: () => "0:00",
+  isVoiceRecordingCancelledError: (error: unknown) =>
+    error instanceof Error && error.name === "VoiceRecordingCancelledError",
   useVoiceRecorder: () => ({
     isRecording: recorder.isRecording,
     durationMs: 0,
@@ -104,6 +119,7 @@ vi.mock("../../nativeApi", () => ({
     nativeApi.available
       ? {
           server: {
+            prewarmVoice: nativeApi.prewarmVoice,
             transcribeVoice: nativeApi.transcribeVoice,
           },
         }
@@ -172,6 +188,7 @@ describe("useComposerVoiceController", () => {
     recorder.startRecording.mockReset().mockResolvedValue(undefined);
     recorder.stopRecording.mockReset().mockResolvedValue(AUDIO_PAYLOAD);
     recorder.cancelRecording.mockReset().mockResolvedValue(undefined);
+    nativeApi.prewarmVoice.mockReset().mockResolvedValue({ ready: true });
     nativeApi.transcribeVoice.mockReset().mockResolvedValue({ text: "transcribed once" });
     nativeApi.available = true;
     voiceAvailability.canStartVoiceNotes = true;
@@ -199,6 +216,19 @@ describe("useComposerVoiceController", () => {
     expect(options.onTranscriptReady).toHaveBeenCalledWith("transcribed once");
   });
 
+  it("prewarms persistent voice state after recording starts", async () => {
+    recorder.isRecording = false;
+    render();
+
+    await result.startComposerVoiceRecording();
+
+    expect(nativeApi.prewarmVoice).toHaveBeenCalledWith({
+      provider: "codex",
+      cwd: PROJECT.cwd,
+      threadId: THREAD_A,
+    });
+  });
+
   it.each(["thread", "provider", "cancel"] as const)(
     "ignores a stale transcription after %s changes",
     async (staleCause) => {
@@ -218,10 +248,54 @@ describe("useComposerVoiceController", () => {
 
       transcription.resolve({ text: "stale" });
       await submission;
+      render();
 
       expect(options.onTranscriptReady).not.toHaveBeenCalled();
+      expect(result.isVoiceTranscribing).toBe(false);
     },
   );
+
+  it("does not surface recorder startup cancellation as an error", async () => {
+    recorder.isRecording = false;
+    recorder.startRecording.mockRejectedValueOnce(
+      Object.assign(new Error("Voice recording was cancelled."), {
+        name: "VoiceRecordingCancelledError",
+      }),
+    );
+    render();
+
+    await result.startComposerVoiceRecording();
+
+    expect(toast.add).not.toHaveBeenCalled();
+    expect(nativeApi.prewarmVoice).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a genuine browser AbortError from microphone startup", async () => {
+    recorder.isRecording = false;
+    recorder.startRecording.mockRejectedValueOnce(
+      new DOMException("The microphone could not start.", "AbortError"),
+    );
+    render();
+
+    await result.startComposerVoiceRecording();
+
+    expect(toast.add).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Could not start recording" }),
+    );
+  });
+
+  it("invalidates an in-flight transcript when the composer unmounts", async () => {
+    const transcription = deferred<{ text: string }>();
+    nativeApi.transcribeVoice.mockReturnValueOnce(transcription.promise);
+
+    const submission = result.submitComposerVoiceRecording();
+    await vi.waitFor(() => expect(nativeApi.transcribeVoice).toHaveBeenCalledTimes(1));
+    reactHarness.unmount();
+    transcription.resolve({ text: "stale after unmount" });
+    await submission;
+
+    expect(options.onTranscriptReady).not.toHaveBeenCalled();
+  });
 
   it("blocks submit and cancel until the configured action-arm delay elapses", async () => {
     let now = 1_000;

--- a/apps/web/src/components/chat/useComposerVoiceController.test.ts
+++ b/apps/web/src/components/chat/useComposerVoiceController.test.ts
@@ -216,6 +216,15 @@ describe("useComposerVoiceController", () => {
     expect(options.onTranscriptReady).toHaveBeenCalledWith("transcribed once");
   });
 
+  it("discards the active recording without stopping or transcribing it", () => {
+    result.cancelComposerVoiceRecording();
+
+    expect(recorder.cancelRecording).toHaveBeenCalledTimes(1);
+    expect(recorder.stopRecording).not.toHaveBeenCalled();
+    expect(nativeApi.transcribeVoice).not.toHaveBeenCalled();
+    expect(options.onTranscriptReady).not.toHaveBeenCalled();
+  });
+
   it("prewarms persistent voice state after recording starts", async () => {
     recorder.isRecording = false;
     render();

--- a/apps/web/src/components/chat/useComposerVoiceController.ts
+++ b/apps/web/src/components/chat/useComposerVoiceController.ts
@@ -7,7 +7,11 @@ import { type ProviderKind, type ServerProviderStatus, type ThreadId } from "@sy
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import type { Project } from "../../types";
-import { formatVoiceRecordingDuration, useVoiceRecorder } from "../../lib/voiceRecorder";
+import {
+  formatVoiceRecordingDuration,
+  isVoiceRecordingCancelledError,
+  useVoiceRecorder,
+} from "../../lib/voiceRecorder";
 import { readNativeApi } from "../../nativeApi";
 import type { RefreshProviderStatusesNow } from "../../hooks/useProviderStatusRefresh";
 import { toastManager } from "../ui/toast";
@@ -125,7 +129,15 @@ export function useComposerVoiceController(
         setIsVoiceTranscribing(false);
       }
     });
-  }, [cancelVoiceRecording, threadId]);
+  }, [cancelVoiceRecording, selectedProvider, threadId]);
+
+  useEffect(
+    () => () => {
+      voiceTranscriptionRequestIdRef.current += 1;
+      voiceRecordingStartedAtRef.current = null;
+    },
+    [],
+  );
 
   useEffect(() => {
     if (canStartVoiceNotes || !isVoiceRecording) {
@@ -196,7 +208,18 @@ export function useComposerVoiceController(
     try {
       await startVoiceRecording();
       voiceRecordingStartedAtRef.current = performance.now();
+      const api = readNativeApi();
+      void api?.server
+        .prewarmVoice?.({
+          provider: "codex",
+          cwd: activeProject.cwd,
+          ...(activeThreadId ? { threadId: activeThreadId } : {}),
+        })
+        .catch(() => undefined);
     } catch (error) {
+      if (isVoiceRecordingCancelledError(error)) {
+        return;
+      }
       toastManager.add({
         type: "error",
         title: "Could not start recording",

--- a/apps/web/src/components/kanban/KanbanNewTaskDialog.tsx
+++ b/apps/web/src/components/kanban/KanbanNewTaskDialog.tsx
@@ -566,8 +566,8 @@ export function KanbanNewTaskDialog({
                 isRecording={voice.isVoiceRecording}
                 isTranscribing={voice.isVoiceTranscribing}
                 waveformLevels={voice.voiceWaveformLevels}
-                onCancel={voice.cancelComposerVoiceRecording}
-                onSubmit={() => void voice.submitComposerVoiceRecording()}
+                onDiscard={voice.cancelComposerVoiceRecording}
+                onStop={() => void voice.submitComposerVoiceRecording()}
               />
             ) : (
               <div className="flex w-full items-center justify-between gap-2">

--- a/apps/web/src/lib/voiceRecorder.browser.tsx
+++ b/apps/web/src/lib/voiceRecorder.browser.tsx
@@ -1,0 +1,53 @@
+// FILE: voiceRecorder.browser.tsx
+// Purpose: Verifies microphone startup cancellation against real React/browser scheduling.
+// Layer: Web browser test
+// Depends on: vitest browser hooks and mocked browser media/Web Audio primitives.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "vitest-browser-react";
+
+import { isVoiceRecordingCancelledError, useVoiceRecorder } from "./voiceRecorder";
+
+describe("useVoiceRecorder", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not activate recording after cancellation during AudioContext resume", async () => {
+    let resolveResume!: () => void;
+    const resume = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveResume = resolve;
+        }),
+    );
+    const close = vi.fn(async () => undefined);
+
+    class DeferredAudioContext {
+      readonly resume = resume;
+      readonly close = close;
+    }
+
+    const stopTrack = vi.fn();
+    const stream = {
+      getTracks: () => [{ stop: stopTrack }],
+    } as unknown as MediaStream;
+    vi.spyOn(navigator.mediaDevices, "getUserMedia").mockResolvedValue(stream);
+    vi.stubGlobal("AudioContext", DeferredAudioContext);
+
+    const hook = await renderHook(() => useVoiceRecorder());
+    const starting = hook.result.current.startRecording();
+    await vi.waitFor(() => expect(resume).toHaveBeenCalledTimes(1));
+
+    await hook.result.current.cancelRecording();
+    resolveResume();
+
+    await expect(starting).rejects.toSatisfy(isVoiceRecordingCancelledError);
+    expect(hook.result.current.isRecording).toBe(false);
+    expect(stopTrack).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
+
+    await hook.unmount();
+  });
+});

--- a/apps/web/src/lib/voiceRecorder.ts
+++ b/apps/web/src/lib/voiceRecorder.ts
@@ -201,6 +201,9 @@ export function useVoiceRecorder() {
       processorNode.connect(silentGainNode);
       silentGainNode.connect(audioContext.destination);
 
+      // Publish the runtime only while this startup still owns the current
+      // generation. This keeps future async setup additions cancellation-safe.
+      assertStartIsCurrent();
       runtimeRef.current = runtime;
       isStartingRef.current = false;
       waveformLevelsRef.current = [];

--- a/apps/web/src/lib/voiceRecorder.ts
+++ b/apps/web/src/lib/voiceRecorder.ts
@@ -1,13 +1,15 @@
 // FILE: voiceRecorder.ts
 // Purpose: Captures microphone audio in the browser and normalizes it to Remodex-style WAV clips.
 // Layer: Client utility hook
-// Exports: useVoiceRecorder, formatVoiceRecordingDuration
-// Depends on: browser media devices, Web Audio API, and FileReader for base64 encoding.
+// Exports: useVoiceRecorder, formatVoiceRecordingDuration, isVoiceRecordingCancelledError
+// Depends on: browser media devices, Web Audio API, the streaming WAV encoder, and FileReader.
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { encodeVoiceRecordingWav } from "./voiceRecorderEncoding";
 
 const TARGET_SAMPLE_RATE = 24_000;
-const BUFFER_SIZE = 4_096;
+const BUFFER_SIZE = 2_048;
 
 export interface VoiceRecordingPayload {
   readonly audioBase64: string;
@@ -29,6 +31,16 @@ interface RecorderRuntime {
 
 const MAX_WAVEFORM_SAMPLES = 160;
 
+class VoiceRecordingCancelledError extends Error {
+  override readonly name = "VoiceRecordingCancelledError";
+}
+
+export function isVoiceRecordingCancelledError(
+  error: unknown,
+): boolean {
+  return error instanceof VoiceRecordingCancelledError;
+}
+
 export function formatVoiceRecordingDuration(durationMs: number): string {
   const totalSeconds = Math.max(0, Math.floor(durationMs / 1_000));
   const minutes = Math.floor(totalSeconds / 60);
@@ -38,6 +50,8 @@ export function formatVoiceRecordingDuration(durationMs: number): string {
 
 export function useVoiceRecorder() {
   const runtimeRef = useRef<RecorderRuntime | null>(null);
+  const startGenerationRef = useRef(0);
+  const isStartingRef = useRef(false);
   const timerRef = useRef<number | null>(null);
   const waveformLevelsRef = useRef<number[]>([]);
   const waveformLastEmitAtRef = useRef(0);
@@ -45,14 +59,16 @@ export function useVoiceRecorder() {
   const [durationMs, setDurationMs] = useState(0);
   const [waveformLevels, setWaveformLevels] = useState<number[]>([]);
 
-  const clearTimer = () => {
+  const clearTimer = useCallback(() => {
     if (timerRef.current !== null) {
       window.clearInterval(timerRef.current);
       timerRef.current = null;
     }
-  };
+  }, []);
 
-  const teardownRuntime = async () => {
+  const teardownRuntime = useCallback(async () => {
+    startGenerationRef.current += 1;
+    isStartingRef.current = false;
     const runtime = runtimeRef.current;
     runtimeRef.current = null;
     clearTimer();
@@ -79,15 +95,24 @@ export function useVoiceRecorder() {
       sampleRateHz,
       durationMs: duration,
     };
-  };
+  }, [clearTimer]);
 
-  const startRecording = async () => {
-    if (runtimeRef.current) {
+  const startRecording = useCallback(async () => {
+    if (runtimeRef.current || isStartingRef.current) {
       throw new Error("Voice recording is already running.");
     }
     if (!navigator.mediaDevices?.getUserMedia) {
       throw new Error("Microphone recording is unavailable in this browser.");
     }
+
+    const startGeneration = startGenerationRef.current + 1;
+    startGenerationRef.current = startGeneration;
+    isStartingRef.current = true;
+    const assertStartIsCurrent = () => {
+      if (startGenerationRef.current !== startGeneration) {
+        throw new VoiceRecordingCancelledError("Voice recording was cancelled.");
+      }
+    };
 
     let stream: MediaStream | null = null;
     let audioContext: AudioContext | null = null;
@@ -101,13 +126,20 @@ export function useVoiceRecorder() {
           channelCount: 1,
           echoCancellation: true,
           noiseSuppression: true,
+          sampleRate: { ideal: TARGET_SAMPLE_RATE },
         },
       });
-      audioContext = new AudioContext();
+      assertStartIsCurrent();
+      audioContext = createVoiceAudioContext();
       await audioContext.resume();
+      assertStartIsCurrent();
 
       sourceNode = audioContext.createMediaStreamSource(stream);
-      processorNode = audioContext.createScriptProcessor(BUFFER_SIZE, 1, 1);
+      processorNode = audioContext.createScriptProcessor(
+        resolveVoiceProcessorBufferSize(audioContext.sampleRate),
+        1,
+        1,
+      );
       silentGainNode = audioContext.createGain();
       silentGainNode.gain.value = 0;
 
@@ -128,17 +160,28 @@ export function useVoiceRecorder() {
         const frameCount = inputBuffer.length;
         const monoSamples = new Float32Array(frameCount);
 
-        for (let channelIndex = 0; channelIndex < channelCount; channelIndex += 1) {
-          const channelData = inputBuffer.getChannelData(channelIndex);
+        let sumOfSquares = 0;
+        if (channelCount === 1) {
+          const channelData = inputBuffer.getChannelData(0);
           for (let sampleIndex = 0; sampleIndex < frameCount; sampleIndex += 1) {
-            monoSamples[sampleIndex] =
-              (monoSamples[sampleIndex] ?? 0) + (channelData[sampleIndex] ?? 0);
+            const sample = channelData[sampleIndex] ?? 0;
+            monoSamples[sampleIndex] = sample;
+            sumOfSquares += sample * sample;
           }
-        }
-
-        const normalizer = channelCount > 0 ? channelCount : 1;
-        for (let sampleIndex = 0; sampleIndex < frameCount; sampleIndex += 1) {
-          monoSamples[sampleIndex] = (monoSamples[sampleIndex] ?? 0) / normalizer;
+        } else {
+          for (let channelIndex = 0; channelIndex < channelCount; channelIndex += 1) {
+            const channelData = inputBuffer.getChannelData(channelIndex);
+            for (let sampleIndex = 0; sampleIndex < frameCount; sampleIndex += 1) {
+              monoSamples[sampleIndex] =
+                (monoSamples[sampleIndex] ?? 0) + (channelData[sampleIndex] ?? 0);
+            }
+          }
+          const normalizer = channelCount > 0 ? channelCount : 1;
+          for (let sampleIndex = 0; sampleIndex < frameCount; sampleIndex += 1) {
+            const sample = (monoSamples[sampleIndex] ?? 0) / normalizer;
+            monoSamples[sampleIndex] = sample;
+            sumOfSquares += sample * sample;
+          }
         }
 
         runtime.chunks.push(monoSamples);
@@ -146,8 +189,7 @@ export function useVoiceRecorder() {
         const rmsLevel = Math.min(
           1,
           Math.sqrt(
-            monoSamples.reduce((sum, sample) => sum + sample * sample, 0) /
-              Math.max(1, monoSamples.length),
+            sumOfSquares / Math.max(1, monoSamples.length),
           ) * 3.2,
         );
         const now = performance.now();
@@ -164,6 +206,7 @@ export function useVoiceRecorder() {
       silentGainNode.connect(audioContext.destination);
 
       runtimeRef.current = runtime;
+      isStartingRef.current = false;
       waveformLevelsRef.current = [];
       waveformLastEmitAtRef.current = 0;
       setWaveformLevels([]);
@@ -182,51 +225,45 @@ export function useVoiceRecorder() {
       silentGainNode?.disconnect();
       stream?.getTracks().forEach((track) => track.stop());
       await audioContext?.close().catch(() => undefined);
+      if (startGenerationRef.current === startGeneration) {
+        isStartingRef.current = false;
+      }
       throw error;
     }
-  };
+  }, []);
 
-  const stopRecording = async (): Promise<VoiceRecordingPayload | null> => {
+  const stopRecording = useCallback(async (): Promise<VoiceRecordingPayload | null> => {
     const recorded = await teardownRuntime();
     if (!recorded) {
       return null;
     }
 
-    const mergedSamples = mergeFloat32Chunks(recorded.chunks);
-    if (mergedSamples.length === 0) {
-      return null;
-    }
-
-    const resampledSamples = resampleLinear(
-      mergedSamples,
+    const encoded = encodeVoiceRecordingWav(
+      recorded.chunks,
       recorded.sampleRateHz,
       TARGET_SAMPLE_RATE,
     );
-    if (resampledSamples.length === 0) {
+    if (!encoded) {
       return null;
     }
 
-    const wavBytes = encodeMono16BitWav(resampledSamples, TARGET_SAMPLE_RATE);
-    const audioBase64 = await blobToBase64(new Blob([wavBytes], { type: "audio/wav" }));
+    const audioBase64 = await blobToBase64(new Blob([encoded.bytes], { type: "audio/wav" }));
 
     const payload: VoiceRecordingPayload = {
       audioBase64,
       mimeType: "audio/wav",
       sampleRateHz: TARGET_SAMPLE_RATE,
-      durationMs: Math.max(
-        1,
-        Math.round((resampledSamples.length / TARGET_SAMPLE_RATE) * 1_000) || recorded.durationMs,
-      ),
+      durationMs: encoded.durationMs || recorded.durationMs,
     };
     return payload;
-  };
+  }, [teardownRuntime]);
 
-  const cancelRecording = async () => {
+  const cancelRecording = useCallback(async () => {
     await teardownRuntime();
     waveformLevelsRef.current = [];
     waveformLastEmitAtRef.current = 0;
     setWaveformLevels([]);
-  };
+  }, [teardownRuntime]);
 
   useEffect(
     () => () => {
@@ -245,81 +282,16 @@ export function useVoiceRecorder() {
   };
 }
 
-function mergeFloat32Chunks(chunks: readonly Float32Array[]): Float32Array {
-  let totalLength = 0;
-  for (const chunk of chunks) {
-    totalLength += chunk.length;
+function createVoiceAudioContext(): AudioContext {
+  try {
+    return new AudioContext({ latencyHint: "interactive", sampleRate: TARGET_SAMPLE_RATE });
+  } catch {
+    return new AudioContext({ latencyHint: "interactive" });
   }
-  const merged = new Float32Array(totalLength);
-  let offset = 0;
-  for (const chunk of chunks) {
-    merged.set(chunk, offset);
-    offset += chunk.length;
-  }
-  return merged;
 }
 
-function resampleLinear(
-  samples: Float32Array,
-  inputSampleRateHz: number,
-  outputSampleRateHz: number,
-): Float32Array {
-  if (!Number.isFinite(inputSampleRateHz) || inputSampleRateHz <= 0) {
-    return new Float32Array(0);
-  }
-  if (inputSampleRateHz === outputSampleRateHz) {
-    return samples.slice();
-  }
-
-  const ratio = inputSampleRateHz / outputSampleRateHz;
-  const outputLength = Math.max(1, Math.round(samples.length / ratio));
-  const output = new Float32Array(outputLength);
-
-  for (let index = 0; index < outputLength; index += 1) {
-    const sourceIndex = index * ratio;
-    const leftIndex = Math.floor(sourceIndex);
-    const rightIndex = Math.min(samples.length - 1, leftIndex + 1);
-    const interpolationWeight = sourceIndex - leftIndex;
-    const leftValue = samples[leftIndex] ?? 0;
-    const rightValue = samples[rightIndex] ?? leftValue;
-    output[index] = leftValue + (rightValue - leftValue) * interpolationWeight;
-  }
-
-  return output;
-}
-
-function encodeMono16BitWav(samples: Float32Array, sampleRateHz: number): ArrayBuffer {
-  const dataView = new DataView(new ArrayBuffer(44 + samples.length * 2));
-
-  writeAscii(dataView, 0, "RIFF");
-  dataView.setUint32(4, 36 + samples.length * 2, true);
-  writeAscii(dataView, 8, "WAVE");
-  writeAscii(dataView, 12, "fmt ");
-  dataView.setUint32(16, 16, true);
-  dataView.setUint16(20, 1, true);
-  dataView.setUint16(22, 1, true);
-  dataView.setUint32(24, sampleRateHz, true);
-  dataView.setUint32(28, sampleRateHz * 2, true);
-  dataView.setUint16(32, 2, true);
-  dataView.setUint16(34, 16, true);
-  writeAscii(dataView, 36, "data");
-  dataView.setUint32(40, samples.length * 2, true);
-
-  let offset = 44;
-  for (const sample of samples) {
-    const clamped = Math.max(-1, Math.min(1, sample));
-    const pcm = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff;
-    dataView.setInt16(offset, Math.round(pcm), true);
-    offset += 2;
-  }
-
-  return dataView.buffer;
-}
-
-function writeAscii(view: DataView, offset: number, value: string): void {
-  for (let index = 0; index < value.length; index += 1) {
-    view.setUint8(offset + index, value.charCodeAt(index));
-  }
+function resolveVoiceProcessorBufferSize(sampleRateHz: number): number {
+  return sampleRateHz > TARGET_SAMPLE_RATE * 1.5 ? BUFFER_SIZE * 2 : BUFFER_SIZE;
 }
 
 async function blobToBase64(blob: Blob): Promise<string> {

--- a/apps/web/src/lib/voiceRecorder.ts
+++ b/apps/web/src/lib/voiceRecorder.ts
@@ -35,9 +35,7 @@ class VoiceRecordingCancelledError extends Error {
   override readonly name = "VoiceRecordingCancelledError";
 }
 
-export function isVoiceRecordingCancelledError(
-  error: unknown,
-): boolean {
+export function isVoiceRecordingCancelledError(error: unknown): boolean {
   return error instanceof VoiceRecordingCancelledError;
 }
 
@@ -188,9 +186,7 @@ export function useVoiceRecorder() {
 
         const rmsLevel = Math.min(
           1,
-          Math.sqrt(
-            sumOfSquares / Math.max(1, monoSamples.length),
-          ) * 3.2,
+          Math.sqrt(sumOfSquares / Math.max(1, monoSamples.length)) * 3.2,
         );
         const now = performance.now();
         if (now - waveformLastEmitAtRef.current >= 45) {

--- a/apps/web/src/lib/voiceRecorderEncoding.test.ts
+++ b/apps/web/src/lib/voiceRecorderEncoding.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import { encodeVoiceRecordingWav } from "./voiceRecorderEncoding";
+
+describe("encodeVoiceRecordingWav", () => {
+  it.each([48_000, 44_100, 24_000, 16_000])(
+    "matches the legacy encoder across chunk boundaries at %i Hz",
+    (inputSampleRateHz) => {
+      const samples = Float32Array.from(
+        { length: 10_003 },
+        (_, index) => Math.sin((index * Math.PI * 2) / 97) * 0.8,
+      );
+      const chunks = [samples.slice(0, 1), samples.slice(1, 4_098), samples.slice(4_098)];
+
+      const encoded = encodeVoiceRecordingWav(chunks, inputSampleRateHz, 24_000);
+
+      expect(encoded).not.toBeNull();
+      expect(new Uint8Array(encoded?.bytes ?? new ArrayBuffer(0))).toEqual(
+        new Uint8Array(legacyEncode(chunks, inputSampleRateHz, 24_000)),
+      );
+    },
+  );
+
+  it("returns normalized duration and WAV metadata", () => {
+    const encoded = encodeVoiceRecordingWav([new Float32Array(48_000)], 48_000, 24_000);
+    const view = new DataView(encoded?.bytes ?? new ArrayBuffer(0));
+
+    expect(encoded).toMatchObject({ durationMs: 1_000, sampleCount: 24_000 });
+    expect(view.getUint32(24, true)).toBe(24_000);
+    expect(view.getUint16(22, true)).toBe(1);
+    expect(view.getUint16(34, true)).toBe(16);
+    expect(view.getUint32(40, true)).toBe(48_000);
+  });
+
+  it("rejects empty audio and invalid sample rates", () => {
+    expect(encodeVoiceRecordingWav([], 48_000, 24_000)).toBeNull();
+    expect(encodeVoiceRecordingWav([new Float32Array([0.5])], 0, 24_000)).toBeNull();
+    expect(encodeVoiceRecordingWav([new Float32Array([0.5])], 48_000, Number.NaN)).toBeNull();
+  });
+});
+
+function legacyEncode(
+  chunks: readonly Float32Array[],
+  inputSampleRateHz: number,
+  outputSampleRateHz: number,
+): ArrayBuffer {
+  const merged = new Float32Array(chunks.reduce((total, chunk) => total + chunk.length, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  const ratio = inputSampleRateHz / outputSampleRateHz;
+  const outputLength = Math.max(1, Math.round(merged.length / ratio));
+  const output = new Float32Array(outputLength);
+  for (let index = 0; index < outputLength; index += 1) {
+    const sourceIndex = index * ratio;
+    const leftIndex = Math.floor(sourceIndex);
+    const rightIndex = Math.min(merged.length - 1, leftIndex + 1);
+    const leftValue = merged[leftIndex] ?? 0;
+    const rightValue = merged[rightIndex] ?? leftValue;
+    output[index] = leftValue + (rightValue - leftValue) * (sourceIndex - leftIndex);
+  }
+
+  const view = new DataView(new ArrayBuffer(44 + output.length * 2));
+  writeAscii(view, 0, "RIFF");
+  view.setUint32(4, 36 + output.length * 2, true);
+  writeAscii(view, 8, "WAVE");
+  writeAscii(view, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, outputSampleRateHz, true);
+  view.setUint32(28, outputSampleRateHz * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeAscii(view, 36, "data");
+  view.setUint32(40, output.length * 2, true);
+  let wavOffset = 44;
+  for (const sample of output) {
+    const clamped = Math.max(-1, Math.min(1, sample));
+    const pcm = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff;
+    view.setInt16(wavOffset, Math.round(pcm), true);
+    wavOffset += 2;
+  }
+  return view.buffer;
+}
+
+function writeAscii(view: DataView, offset: number, value: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    view.setUint8(offset + index, value.charCodeAt(index));
+  }
+}

--- a/apps/web/src/lib/voiceRecorderEncoding.ts
+++ b/apps/web/src/lib/voiceRecorderEncoding.ts
@@ -1,0 +1,135 @@
+// FILE: voiceRecorderEncoding.ts
+// Purpose: Converts chunked browser microphone samples directly into normalized mono WAV bytes.
+// Layer: Client audio utility
+// Exports: encodeVoiceRecordingWav
+
+export interface EncodedVoiceRecordingWav {
+  readonly bytes: ArrayBuffer;
+  readonly durationMs: number;
+  readonly sampleCount: number;
+}
+
+const IS_LITTLE_ENDIAN = new Uint8Array(Uint16Array.of(1).buffer)[0] === 1;
+
+export function encodeVoiceRecordingWav(
+  chunks: readonly Float32Array[],
+  inputSampleRateHz: number,
+  outputSampleRateHz: number,
+): EncodedVoiceRecordingWav | null {
+  if (
+    !Number.isFinite(inputSampleRateHz) ||
+    inputSampleRateHz <= 0 ||
+    !Number.isFinite(outputSampleRateHz) ||
+    outputSampleRateHz <= 0
+  ) {
+    return null;
+  }
+
+  let inputSampleCount = 0;
+  for (const chunk of chunks) {
+    inputSampleCount += chunk.length;
+  }
+  if (inputSampleCount === 0) {
+    return null;
+  }
+
+  const inputSamplesPerOutputSample = inputSampleRateHz / outputSampleRateHz;
+  const outputSampleCount = Math.max(
+    1,
+    Math.round(inputSampleCount / inputSamplesPerOutputSample),
+  );
+  const dataView = new DataView(new ArrayBuffer(44 + outputSampleCount * 2));
+  writeWavHeader(dataView, outputSampleCount, outputSampleRateHz);
+  const pcmSamples = IS_LITTLE_ENDIAN
+    ? new Int16Array(dataView.buffer, 44, outputSampleCount)
+    : null;
+
+  let wavOffset = 44;
+  let outputIndex = 0;
+  if (inputSampleRateHz === outputSampleRateHz) {
+    for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex += 1) {
+      const chunk = chunks[chunkIndex];
+      if (!chunk) continue;
+      for (let sampleIndex = 0; sampleIndex < chunk.length; sampleIndex += 1) {
+        const sample = chunk[sampleIndex] ?? 0;
+        const clamped = Math.max(-1, Math.min(1, sample));
+        const pcm = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff;
+        if (pcmSamples) {
+          pcmSamples[outputIndex] = Math.round(pcm);
+        } else {
+          dataView.setInt16(wavOffset, Math.round(pcm), true);
+        }
+        outputIndex += 1;
+        wavOffset += 2;
+      }
+    }
+  } else {
+    let chunkIndex = 0;
+    let chunkStart = 0;
+    let chunk = chunks[0];
+    const integerStride = Number.isInteger(inputSamplesPerOutputSample);
+    for (let index = 0; index < outputSampleCount; index += 1) {
+      const sourceIndex = index * inputSamplesPerOutputSample;
+      const leftIndex = Math.floor(sourceIndex);
+      while (
+        chunk &&
+        leftIndex >= chunkStart + chunk.length &&
+        chunkIndex < chunks.length - 1
+      ) {
+        chunkStart += chunk.length;
+        chunkIndex += 1;
+        chunk = chunks[chunkIndex];
+      }
+      const localIndex = leftIndex - chunkStart;
+      const leftValue = chunk?.[localIndex] ?? 0;
+      let sample = leftValue;
+      if (!integerStride) {
+        const rightValue =
+          leftIndex >= inputSampleCount - 1
+            ? leftValue
+            : (chunk?.[localIndex + 1] ?? chunks[chunkIndex + 1]?.[0] ?? leftValue);
+        // The legacy pipeline materialized interpolation into Float32Array before
+        // PCM conversion. Preserve that rounding so clips stay byte-for-byte identical.
+        sample = Math.fround(
+          leftValue + (rightValue - leftValue) * (sourceIndex - leftIndex),
+        );
+      }
+      const clamped = Math.max(-1, Math.min(1, sample));
+      const pcm = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff;
+      if (pcmSamples) {
+        pcmSamples[index] = Math.round(pcm);
+      } else {
+        dataView.setInt16(wavOffset, Math.round(pcm), true);
+      }
+      wavOffset += 2;
+    }
+  }
+
+  return {
+    bytes: dataView.buffer,
+    durationMs: Math.max(1, Math.round((outputSampleCount / outputSampleRateHz) * 1_000)),
+    sampleCount: outputSampleCount,
+  };
+}
+
+function writeWavHeader(view: DataView, sampleCount: number, sampleRateHz: number): void {
+  writeAscii(view, 0, "RIFF");
+  view.setUint32(4, 36 + sampleCount * 2, true);
+  writeAscii(view, 8, "WAVE");
+  writeAscii(view, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRateHz, true);
+  view.setUint32(28, sampleRateHz * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeAscii(view, 36, "data");
+  view.setUint32(40, sampleCount * 2, true);
+}
+
+function writeAscii(view: DataView, offset: number, value: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    view.setUint8(offset + index, value.charCodeAt(index));
+  }
+}

--- a/apps/web/src/lib/voiceRecorderEncoding.ts
+++ b/apps/web/src/lib/voiceRecorderEncoding.ts
@@ -34,10 +34,7 @@ export function encodeVoiceRecordingWav(
   }
 
   const inputSamplesPerOutputSample = inputSampleRateHz / outputSampleRateHz;
-  const outputSampleCount = Math.max(
-    1,
-    Math.round(inputSampleCount / inputSamplesPerOutputSample),
-  );
+  const outputSampleCount = Math.max(1, Math.round(inputSampleCount / inputSamplesPerOutputSample));
   const dataView = new DataView(new ArrayBuffer(44 + outputSampleCount * 2));
   writeWavHeader(dataView, outputSampleCount, outputSampleRateHz);
   const pcmSamples = IS_LITTLE_ENDIAN
@@ -71,11 +68,7 @@ export function encodeVoiceRecordingWav(
     for (let index = 0; index < outputSampleCount; index += 1) {
       const sourceIndex = index * inputSamplesPerOutputSample;
       const leftIndex = Math.floor(sourceIndex);
-      while (
-        chunk &&
-        leftIndex >= chunkStart + chunk.length &&
-        chunkIndex < chunks.length - 1
-      ) {
+      while (chunk && leftIndex >= chunkStart + chunk.length && chunkIndex < chunks.length - 1) {
         chunkStart += chunk.length;
         chunkIndex += 1;
         chunk = chunks[chunkIndex];
@@ -90,9 +83,7 @@ export function encodeVoiceRecordingWav(
             : (chunk?.[localIndex + 1] ?? chunks[chunkIndex + 1]?.[0] ?? leftValue);
         // The legacy pipeline materialized interpolation into Float32Array before
         // PCM conversion. Preserve that rounding so clips stay byte-for-byte identical.
-        sample = Math.fround(
-          leftValue + (rightValue - leftValue) * (sourceIndex - leftIndex),
-        );
+        sample = Math.fround(leftValue + (rightValue - leftValue) * (sourceIndex - leftIndex));
       }
       const clamped = Math.max(-1, Math.min(1, sample));
       const pcm = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff;

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -960,18 +960,26 @@ describe("wsNativeApi", () => {
     );
   });
 
-  it("uses the desktop voice bridge when available", async () => {
+  it("uses the bounded server upload even when the desktop bridge is available", async () => {
     const transcribeVoice = vi.fn().mockResolvedValue({ text: "hello" });
     Object.defineProperty(getWindowForTest(), "desktopBridge", {
       configurable: true,
       writable: true,
       value: {
+        getWsUrl: () => "ws://127.0.0.1:3773/ws?token=desktop-secret",
         server: {
           transcribeVoice,
         },
       },
     });
 
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ text: "hello" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
     const { createWsNativeApi } = await import("./wsNativeApi");
     const api = createWsNativeApi();
     await api.server.transcribeVoice({
@@ -983,18 +991,27 @@ describe("wsNativeApi", () => {
       durationMs: 1000,
     });
 
-    expect(transcribeVoice).toHaveBeenCalledWith({
-      provider: "codex",
-      cwd: "/repo",
-      audioBase64: "UklGRgAAAAAAAAAAAAAAAAAAAAA=",
-      mimeType: "audio/wav",
-      sampleRateHz: 24_000,
-      durationMs: 1000,
-    });
+    expect(transcribeVoice).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/api/voice/transcribe?"),
+      expect.objectContaining({ method: "POST" }),
+    );
     expect(requestMock).not.toHaveBeenCalledWith(
       WS_METHODS.serverTranscribeVoice,
       expect.anything(),
     );
+  });
+
+  it("prewarms voice state through the persistent server transport", async () => {
+    const { createWsNativeApi } = await import("./wsNativeApi");
+    const api = createWsNativeApi();
+
+    await api.server.prewarmVoice?.({ provider: "codex", cwd: "/repo" });
+
+    expect(requestMock).toHaveBeenCalledWith(WS_METHODS.serverPrewarmVoice, {
+      provider: "codex",
+      cwd: "/repo",
+    });
   });
 
   it("uses the bounded HTTP upload instead of WebSocket RPC for browser voice", async () => {
@@ -1031,5 +1048,36 @@ describe("wsNativeApi", () => {
       WS_METHODS.serverTranscribeVoice,
       expect.anything(),
     );
+  });
+
+  it("falls back to WebSocket voice RPC when an older server has no upload route", async () => {
+    Object.defineProperty(getWindowForTest(), "desktopBridge", {
+      configurable: true,
+      writable: true,
+      value: { getWsUrl: () => "ws://127.0.0.1:3773/ws?token=desktop-secret" },
+    });
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response("Not Found", { status: 404 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    requestMock.mockResolvedValueOnce({ text: "legacy transport" });
+
+    const { createWsNativeApi } = await import("./wsNativeApi");
+    const api = createWsNativeApi();
+    const input = {
+      provider: "codex" as const,
+      cwd: "/repo",
+      audioBase64: "AQID",
+      mimeType: "audio/wav",
+      sampleRateHz: 24_000,
+      durationMs: 1000,
+    };
+
+    await expect(api.server.transcribeVoice(input)).resolves.toEqual({
+      text: "legacy transport",
+    });
+    expect(requestMock).toHaveBeenCalledWith(WS_METHODS.serverTranscribeVoice, input, {
+      timeoutMs: null,
+    });
   });
 });

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -1056,9 +1056,9 @@ describe("wsNativeApi", () => {
       writable: true,
       value: { getWsUrl: () => "ws://127.0.0.1:3773/ws?token=desktop-secret" },
     });
-    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response("Not Found", { status: 404 }),
-    );
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response("Not Found", { status: 404 }));
     vi.stubGlobal("fetch", fetchMock);
     requestMock.mockResolvedValueOnce({ text: "legacy transport" });
 

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -228,6 +228,9 @@ async function requestVoiceTranscriptionUpload(
     | ServerVoiceTranscriptionResult
     | { readonly error?: unknown }
     | null;
+  if (response.status === 404 || response.status === 405) {
+    throw new VoiceUploadRouteUnavailableError();
+  }
   if (!response.ok || !payload || !("text" in payload)) {
     const message =
       payload && "error" in payload && typeof payload.error === "string"
@@ -237,6 +240,8 @@ async function requestVoiceTranscriptionUpload(
   }
   return payload;
 }
+
+class VoiceUploadRouteUnavailableError extends Error {}
 
 function createFallbackTab(url = "about:blank") {
   return {
@@ -647,11 +652,16 @@ export function createWsNativeApi(): NativeApi {
         transport.request(WS_METHODS.serverGenerateAutomationIntent, input, {
           timeoutMs: null,
         }),
-      transcribeVoice: (input) => {
-        if (window.desktopBridge?.server?.transcribeVoice) {
-          return window.desktopBridge.server.transcribeVoice(input);
+      prewarmVoice: (input) => transport.request(WS_METHODS.serverPrewarmVoice, input),
+      transcribeVoice: async (input) => {
+        try {
+          return await requestVoiceTranscriptionUpload(input);
+        } catch (error) {
+          if (!(error instanceof VoiceUploadRouteUnavailableError)) {
+            throw error;
+          }
+          return transport.request(WS_METHODS.serverTranscribeVoice, input, { timeoutMs: null });
         }
-        return requestVoiceTranscriptionUpload(input);
       },
       upsertKeybinding: (input) => transport.request(WS_METHODS.serverUpsertKeybinding, input),
     },

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -144,6 +144,8 @@ import type {
   ServerUpdateSettingsResult,
   ServerUpsertKeybindingInput,
   ServerUpsertKeybindingResult,
+  ServerVoicePrewarmInput,
+  ServerVoicePrewarmResult,
   ServerVoiceTranscriptionInput,
   ServerVoiceTranscriptionResult,
 } from "./server";
@@ -697,6 +699,7 @@ export interface NativeApi {
     generateAutomationIntent: (
       input: ServerGenerateAutomationIntentInput,
     ) => Promise<ServerGenerateAutomationIntentResult>;
+    prewarmVoice?: (input: ServerVoicePrewarmInput) => Promise<ServerVoicePrewarmResult>;
     transcribeVoice: (
       input: ServerVoiceTranscriptionInput,
     ) => Promise<ServerVoiceTranscriptionResult>;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -167,6 +167,8 @@ import {
   ServerUpdateSettingsInput,
   ServerUpdateSettingsResult,
   ServerUpsertKeybindingResult,
+  ServerVoicePrewarmInput,
+  ServerVoicePrewarmResult,
   ServerVoiceTranscriptionInput,
   ServerVoiceTranscriptionResult,
 } from "./server";
@@ -795,6 +797,12 @@ export const WsServerGetDiagnosticsRpc = Rpc.make(WS_METHODS.serverGetDiagnostic
   error: WsRpcError,
 });
 
+export const WsServerPrewarmVoiceRpc = Rpc.make(WS_METHODS.serverPrewarmVoice, {
+  payload: ServerVoicePrewarmInput,
+  success: ServerVoicePrewarmResult,
+  error: WsRpcError,
+});
+
 export const WsServerTranscribeVoiceRpc = Rpc.make(WS_METHODS.serverTranscribeVoice, {
   payload: ServerVoiceTranscriptionInput,
   success: ServerVoiceTranscriptionResult,
@@ -1067,6 +1075,7 @@ export const WsFeatureRpcGroup = RpcGroup.make(
   WsStatsGetProfileStatsRpc,
   WsStatsGetProfileTokenStatsRpc,
   WsServerGetDiagnosticsRpc,
+  WsServerPrewarmVoiceRpc,
   WsServerTranscribeVoiceRpc,
   WsServerGenerateThreadRecapRpc,
   WsServerGenerateAutomationIntentRpc,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -257,6 +257,18 @@ export const ServerDiagnosticsResult = Schema.Struct({
 });
 export type ServerDiagnosticsResult = typeof ServerDiagnosticsResult.Type;
 
+export const ServerVoicePrewarmInput = Schema.Struct({
+  provider: ProviderKind,
+  cwd: TrimmedNonEmptyString,
+  threadId: Schema.optional(ThreadId),
+});
+export type ServerVoicePrewarmInput = typeof ServerVoicePrewarmInput.Type;
+
+export const ServerVoicePrewarmResult = Schema.Struct({
+  ready: Schema.Boolean,
+});
+export type ServerVoicePrewarmResult = typeof ServerVoicePrewarmResult.Type;
+
 export const ServerVoiceTranscriptionInput = Schema.Struct({
   provider: ProviderKind,
   cwd: TrimmedNonEmptyString,

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -98,6 +98,7 @@ import {
   ServerProviderStatusesUpdatedPayload,
   ServerSettingsUpdatedPayload,
   ServerStopLocalServerInput,
+  ServerVoicePrewarmInput,
   ServerVoiceTranscriptionInput,
 } from "./server";
 import { StatsGetProfileStatsInput, StatsGetProfileTokenStatsInput } from "./stats";
@@ -214,6 +215,7 @@ export const WS_METHODS = {
   statsGetProfileStats: "stats.getProfileStats",
   statsGetProfileTokenStats: "stats.getProfileTokenStats",
   serverGetDiagnostics: "server.getDiagnostics",
+  serverPrewarmVoice: "server.prewarmVoice",
   serverTranscribeVoice: "server.transcribeVoice",
   serverGenerateThreadRecap: "server.generateThreadRecap",
   serverGenerateAutomationIntent: "server.generateAutomationIntent",
@@ -388,6 +390,7 @@ const WebSocketRequestBody = Schema.Union([
   tagRequestBody(WS_METHODS.statsGetProfileStats, StatsGetProfileStatsInput),
   tagRequestBody(WS_METHODS.statsGetProfileTokenStats, StatsGetProfileTokenStatsInput),
   tagRequestBody(WS_METHODS.serverGetDiagnostics, Schema.Struct({})),
+  tagRequestBody(WS_METHODS.serverPrewarmVoice, ServerVoicePrewarmInput),
   tagRequestBody(WS_METHODS.serverTranscribeVoice, ServerVoiceTranscriptionInput),
   tagRequestBody(WS_METHODS.serverGenerateThreadRecap, ServerGenerateThreadRecapInput),
   tagRequestBody(WS_METHODS.serverGenerateAutomationIntent, ServerGenerateAutomationIntentInput),

--- a/packages/shared/src/chatGptVoiceTranscription.test.ts
+++ b/packages/shared/src/chatGptVoiceTranscription.test.ts
@@ -1,0 +1,69 @@
+// FILE: chatGptVoiceTranscription.test.ts
+// Purpose: Verifies the voice transport warms the provider connection safely.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CHATGPT_VOICE_TRANSCRIPTION_URL,
+  prewarmChatGptVoiceTranscriptionConnection,
+  requestChatGptVoiceTranscription,
+} from "./chatGptVoiceTranscription";
+import { outboundHttp } from "./outboundHttp";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("prewarmChatGptVoiceTranscriptionConnection", () => {
+  it("opens the ChatGPT HTTPS origin with a bounded HEAD request", async () => {
+    const request = vi.spyOn(outboundHttp, "request").mockResolvedValue({
+      status: 200,
+      headers: new Headers(),
+      body: new Uint8Array(),
+      url: "https://chatgpt.com/",
+    });
+
+    await prewarmChatGptVoiceTranscriptionConnection();
+
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: new URL("/", CHATGPT_VOICE_TRANSCRIPTION_URL),
+        method: "HEAD",
+        headers: {
+          "User-Agent": expect.stringContaining("Mozilla/5.0"),
+        },
+        policy: expect.objectContaining({
+          service: "chatgpt-voice-transcription",
+          timeoutMs: 10_000,
+          maxResponseBytes: 64 * 1024,
+          maxConcurrent: 2,
+        }),
+      }),
+    );
+  });
+
+  it("uses the accepted browser identity for transcription uploads", async () => {
+    const request = vi.spyOn(outboundHttp, "request").mockResolvedValue({
+      status: 200,
+      headers: new Headers(),
+      body: new Uint8Array(),
+      url: CHATGPT_VOICE_TRANSCRIPTION_URL,
+    });
+
+    await requestChatGptVoiceTranscription({
+      audio: Uint8Array.from([1, 2, 3]),
+      mimeType: "audio/wav",
+      token: "test-token",
+    });
+
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-token",
+          "User-Agent": expect.stringContaining("Mozilla/5.0"),
+        }),
+      }),
+    );
+  });
+});

--- a/packages/shared/src/chatGptVoiceTranscription.ts
+++ b/packages/shared/src/chatGptVoiceTranscription.ts
@@ -10,6 +10,34 @@ export const CHATGPT_VOICE_TRANSCRIPTION_URL = "https://chatgpt.com/backend-api/
 
 const MAX_MULTIPART_BYTES = SERVER_VOICE_TRANSCRIPTION_MAX_AUDIO_BYTES + 64 * 1024;
 const MAX_RESPONSE_BYTES = 1024 * 1024;
+const DEFAULT_VOICE_UPLOAD_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 " +
+  "(KHTML, like Gecko) Version/17.4 Safari/605.1.15";
+const VOICE_UPLOAD_USER_AGENT = resolveVoiceUploadUserAgent();
+
+function resolveVoiceUploadUserAgent(): string {
+  const override = process.env.SYNARA_VOICE_UPLOAD_USER_AGENT?.trim();
+  return override && !/[\r\n]/u.test(override) ? override : DEFAULT_VOICE_UPLOAD_USER_AGENT;
+}
+
+export async function prewarmChatGptVoiceTranscriptionConnection(): Promise<void> {
+  await outboundHttp.request({
+    policy: {
+      service: "chatgpt-voice-transcription",
+      allowedOrigins: [new URL(CHATGPT_VOICE_TRANSCRIPTION_URL).origin],
+      timeoutMs: 10_000,
+      maxRequestBytes: 1,
+      maxResponseBytes: 64 * 1024,
+      maxRedirects: 0,
+      maxConcurrent: 2,
+      maxQueued: 4,
+      requirePublicAddress: true,
+    },
+    url: new URL("/", CHATGPT_VOICE_TRANSCRIPTION_URL),
+    method: "HEAD",
+    headers: { "User-Agent": VOICE_UPLOAD_USER_AGENT },
+  });
+}
 
 export function requestChatGptVoiceTranscription(input: {
   readonly audio: Uint8Array;
@@ -47,6 +75,7 @@ export function requestChatGptVoiceTranscription(input: {
     headers: {
       Authorization: `Bearer ${input.token}`,
       "Content-Type": multipart.contentType,
+      "User-Agent": VOICE_UPLOAD_USER_AGENT,
     },
     body: multipart.body,
     ...(input.signal ? { signal: input.signal } : {}),

--- a/packages/shared/src/outboundHttp.ts
+++ b/packages/shared/src/outboundHttp.ts
@@ -56,7 +56,7 @@ export interface OutboundHttpPolicy {
 export interface OutboundHttpRequest {
   readonly policy: OutboundHttpPolicy;
   readonly url: string | URL;
-  readonly method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  readonly method?: "GET" | "HEAD" | "POST" | "PUT" | "PATCH" | "DELETE";
   readonly headers?: ConstructorParameters<typeof Headers>[0];
   readonly body?: string | Uint8Array;
   readonly signal?: AbortSignal;


### PR DESCRIPTION
## What changed

- encode captured microphone chunks directly into normalized PCM16 WAV output
- request 24 kHz capture with an optimized 48 kHz fallback
- reuse persistent Codex sessions, cache voice auth briefly, and prewarm the ChatGPT TLS connection
- move desktop voice uploads onto the bounded server HTTP route with an older-server WebSocket fallback
- bound concurrent voice uploads before buffering
- fix recorder startup/cancellation, provider-switch, unmount, worktree auth, and discovery-startup races
- add focused tests and a reproducible voice processing benchmark

## Why

Mic mode performed multiple full-buffer merge, resample, and WAV encoding passes, and the desktop path created a fresh Codex app-server for each transcription. That produced avoidable CPU, allocations, and startup latency compared with Remodex.

## Measured impact

For a 120-second clip:

- processing median: 130.98 ms → 3.34 ms at requested 24 kHz
- 48 kHz fallback median: 130.98 ms → 5.32 ms
- audio-array memory: 63.36 MB → 17.28 MB
- temporary allocations: 40.32 MB → 5.76 MB
- auth/session preparation median: 591.49 ms → 2.29 ms through a persistent session

## Validation

- full repository test suite
- focused Mic/server/transport suites: 198 passed, 2 skipped
- production web build
- production server build
- `git diff --check`
- paired benchmark: `bun apps/web/scripts/voice-processing-benchmark.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth/session routing, concurrent upload admission, and large client audio pipeline changes; behavior is well-tested but affects transcription latency and server memory under load.
> 
> **Overview**
> **Mic mode** is reworked end-to-end for lower latency and fewer allocations: capture targets 24 kHz, chunks encode straight to PCM16 WAV via `encodeVoiceRecordingWav` (no merge-then-resample pass), and startup/cancel/unmount races are handled with `VoiceRecordingCancelledError` and request invalidation.
> 
> **Server and transport:** New `server.prewarmVoice` warms ChatGPT TLS and resolves Codex voice auth (60s cache, reuse ready thread sessions including worktrees, deduped discovery startups, `stopAll` waits on in-flight discovery). Voice uploads are capped at **two** concurrent bodies before buffering (HTTP **429** / WS gate); desktop and browser prefer the bounded HTTP upload route with WebSocket fallback on 404/405.
> 
> **Composer UX:** Voice bar separates **cancel** (X) vs **stop** (send-style); extras menu is **Add files** (any type, routed to images vs generic attachments); prewarm runs after recording starts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d1fb52634adfd4e54a8a69f88b2caa26177753e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->