### PR TITLE
fix(web): prevent deferred chat mount loader from hanging

### DIFF
--- a/apps/web/src/components/chat/ChatThreadSurfacePrimitives.tsx
+++ b/apps/web/src/components/chat/ChatThreadSurfacePrimitives.tsx
@@ -14,6 +14,7 @@ import type { SplitViewPanePanelState } from "../../splitViewStore";
 import { CHAT_BACKGROUND_CLASS_NAME } from "./composerPickerStyles";
 import { Spinner } from "../ui/spinner";
 import { cn } from "~/lib/utils";
+import { scheduleDeferredChatMount } from "./deferredChatMount";
 
 const DiffPanel = lazy(() => import("../DiffPanel"));
 export const LazyBrowserPanel = lazy(() => import("../BrowserPanel"));
@@ -134,16 +135,11 @@ export function DeferredChatView(props: {
     }
     // readyMountKey is keyed by mountKey, so a changed mountKey already makes
     // canMountChatView false (loader) without an eager reset here; the double
-    // rAF then stamps the new key once the paint has settled.
-    let firstFrame = 0;
-    let secondFrame = 0;
-    firstFrame = window.requestAnimationFrame(() => {
-      secondFrame = window.requestAnimationFrame(() => setReadyMountKey(mountKey));
-    });
-    return () => {
-      window.cancelAnimationFrame(firstFrame);
-      window.cancelAnimationFrame(secondFrame);
-    };
+    // rAF then stamps the new key once the paint has settled. Chromium can
+    // suppress animation frames while an Electron window is starting or being
+    // background-throttled, so keep a bounded fallback: a deferred draft must
+    // never remain on the mount loader forever just because frames did not run.
+    return scheduleDeferredChatMount(window, () => setReadyMountKey(mountKey));
   }, [mountKey, props.deferMount]);
 
   useEffect(() => {

--- a/apps/web/src/components/chat/deferredChatMount.test.ts
+++ b/apps/web/src/components/chat/deferredChatMount.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DEFERRED_CHAT_MOUNT_FALLBACK_MS,
+  type DeferredChatMountScheduler,
+  scheduleDeferredChatMount,
+} from "./deferredChatMount";
+
+function createScheduler() {
+  const frameCallbacks = new Map<number, FrameRequestCallback>();
+  const timeoutCallbacks = new Map<number, () => void>();
+  const timeoutDelays = new Map<number, number>();
+  let nextHandle = 1;
+
+  const scheduler: DeferredChatMountScheduler = {
+    requestAnimationFrame(callback) {
+      const handle = nextHandle++;
+      frameCallbacks.set(handle, callback);
+      return handle;
+    },
+    cancelAnimationFrame(handle) {
+      frameCallbacks.delete(handle);
+    },
+    setTimeout(callback, delayMs) {
+      const handle = nextHandle++;
+      timeoutCallbacks.set(handle, callback);
+      timeoutDelays.set(handle, delayMs);
+      return handle;
+    },
+    clearTimeout(handle) {
+      timeoutCallbacks.delete(handle);
+      timeoutDelays.delete(handle);
+    },
+  };
+
+  return { scheduler, frameCallbacks, timeoutCallbacks, timeoutDelays };
+}
+
+describe("scheduleDeferredChatMount", () => {
+  it("falls back after the bounded delay when animation frames do not run", () => {
+    const state = createScheduler();
+    const onReady = vi.fn();
+
+    scheduleDeferredChatMount(state.scheduler, onReady);
+
+    expect([...state.timeoutDelays.values()]).toEqual([DEFERRED_CHAT_MOUNT_FALLBACK_MS]);
+    [...state.timeoutCallbacks.values()][0]?.();
+    expect(onReady).toHaveBeenCalledOnce();
+  });
+
+  it("mounts after two animation frames and cancels the fallback", () => {
+    const state = createScheduler();
+    const onReady = vi.fn();
+
+    scheduleDeferredChatMount(state.scheduler, onReady);
+
+    const firstFrame = [...state.frameCallbacks.entries()][0];
+    expect(firstFrame).toBeDefined();
+    state.frameCallbacks.delete(firstFrame![0]);
+    firstFrame![1](0);
+
+    const secondFrame = [...state.frameCallbacks.entries()][0];
+    expect(secondFrame).toBeDefined();
+    state.frameCallbacks.delete(secondFrame![0]);
+    secondFrame![1](16);
+
+    expect(onReady).toHaveBeenCalledOnce();
+    expect(state.timeoutCallbacks.size).toBe(0);
+  });
+
+  it("prevents pending frame and timer callbacks from committing after cleanup", () => {
+    const state = createScheduler();
+    const onReady = vi.fn();
+
+    const cleanup = scheduleDeferredChatMount(state.scheduler, onReady);
+    const pendingTimeout = [...state.timeoutCallbacks.values()][0];
+    const pendingFrame = [...state.frameCallbacks.values()][0];
+
+    cleanup();
+    pendingTimeout?.();
+    pendingFrame?.(0);
+
+    expect(onReady).not.toHaveBeenCalled();
+    expect(state.timeoutCallbacks.size).toBe(0);
+    expect(state.frameCallbacks.size).toBe(0);
+  });
+});

--- a/apps/web/src/components/chat/deferredChatMount.ts
+++ b/apps/web/src/components/chat/deferredChatMount.ts
@@ -1,0 +1,52 @@
+// FILE: deferredChatMount.ts
+// Purpose: Schedules deferred chat mounting with a bounded fallback when Chromium
+//          suppresses animation frames during Electron startup/background throttling.
+// Layer: Chat surface lifecycle helper
+
+export const DEFERRED_CHAT_MOUNT_FALLBACK_MS = 500;
+
+export interface DeferredChatMountScheduler {
+  requestAnimationFrame(callback: FrameRequestCallback): number;
+  cancelAnimationFrame(handle: number): void;
+  setTimeout(callback: () => void, delayMs: number): number;
+  clearTimeout(handle: number): void;
+}
+
+/**
+ * Wait for two paints before mounting a heavy chat surface, but never leave the
+ * loader visible forever when Chromium pauses animation frames. Returns a cleanup
+ * function that prevents either path from committing after the caller unmounts.
+ */
+export function scheduleDeferredChatMount(
+  scheduler: DeferredChatMountScheduler,
+  onReady: () => void,
+): () => void {
+  let firstFrame = 0;
+  let secondFrame = 0;
+  let fallbackTimer = 0;
+  let settled = false;
+
+  const markReady = () => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    scheduler.clearTimeout(fallbackTimer);
+    onReady();
+  };
+
+  fallbackTimer = scheduler.setTimeout(markReady, DEFERRED_CHAT_MOUNT_FALLBACK_MS);
+  firstFrame = scheduler.requestAnimationFrame(() => {
+    if (settled) {
+      return;
+    }
+    secondFrame = scheduler.requestAnimationFrame(markReady);
+  });
+
+  return () => {
+    settled = true;
+    scheduler.clearTimeout(fallbackTimer);
+    scheduler.cancelAnimationFrame(firstFrame);
+    scheduler.cancelAnimationFrame(secondFrame);
+  };
+}


### PR DESCRIPTION
## Why

`DeferredChatView` waits for two animation frames before mounting the heavy chat surface. During Electron startup, or while its window is background-throttled, Chromium can suppress those frames. When that happens, `readyMountKey` remains unset, `ChatView` never mounts, and Synara stays on the centered loading logo indefinitely.

This can affect packaged Electron releases as well as development because the deferred-mount path is not guarded by `import.meta.env.DEV`. It is separate from the development-only HMR provider error observed while repeatedly rolling back UI files.

## What changed

- keep the normal two-frame mount path for the common case
- add a bounded 500 ms fallback so missing animation frames cannot leave the loader visible forever
- centralize scheduling and cleanup in `deferredChatMount.ts`
- prevent pending frame or timer callbacks from committing after unmount or a thread change

## Testing

- fallback mounts when animation frames never run
- normal double-frame progression mounts once and cancels the fallback
- cleanup prevents stale frame and timer callbacks from mounting
- `bun run test -- src/components/chat/deferredChatMount.test.ts`