### PR TITLE
[codex] Fix terminal add to chat routing

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -370,6 +370,7 @@ import {
   type TerminalContextDraft,
   type TerminalContextSelection,
 } from "../lib/terminalContext";
+import { registerTerminalContextComposerTarget } from "../lib/terminalContextComposerRegistry";
 import {
   appendPastedTextsToPrompt,
   createPastedTextDraft,
@@ -4196,7 +4197,7 @@ export default function ChatView({
   });
   const addTerminalContextToDraft = useCallback(
     (selection: TerminalContextSelection) => {
-      if (!activeThread) {
+      if (!activeThreadId) {
         return;
       }
       discardPromptHistoryNavigationForComposerMutation();
@@ -4216,11 +4217,11 @@ export default function ChatView({
         insertion.cursor,
       );
       const inserted = insertComposerDraftTerminalContext(
-        activeThread.id,
+        activeThreadId,
         insertion.prompt,
         {
           id: randomUUID(),
-          threadId: activeThread.id,
+          threadId: activeThreadId,
           createdAt: new Date().toISOString(),
           ...selection,
         },
@@ -4237,13 +4238,31 @@ export default function ChatView({
       });
     },
     [
-      activeThread,
+      activeThreadId,
       composerCursor,
       composerTerminalContexts,
       discardPromptHistoryNavigationForComposerMutation,
       insertComposerDraftTerminalContext,
     ],
   );
+  // Terminal-only workspaces intentionally have no mounted composer. Do not
+  // publish a global-looking action with nowhere to insert the selection.
+  const canAddTerminalContextToChat = activeThread !== undefined && shouldRenderChatPaneContent;
+  // Keep the published capability stable while cursor and draft state change;
+  // dock terminals should not rerender for ordinary composer edits.
+  const addTerminalContextToDraftRef = useRef(addTerminalContextToDraft);
+  useLayoutEffect(() => {
+    addTerminalContextToDraftRef.current = addTerminalContextToDraft;
+  }, [addTerminalContextToDraft]);
+  const addRegisteredTerminalContextToDraft = useCallback((selection: TerminalContextSelection) => {
+    addTerminalContextToDraftRef.current(selection);
+  }, []);
+  useLayoutEffect(() => {
+    if (!canAddTerminalContextToChat) {
+      return;
+    }
+    return registerTerminalContextComposerTarget(paneScopeId, addRegisteredTerminalContextToDraft);
+  }, [addRegisteredTerminalContextToDraft, canAddTerminalContextToChat, paneScopeId]);
   // Collapse an oversized paste into an attachment card above the composer instead
   // of flooding the editor with raw text. The card holds the full content until the
   // user sends or clicks "Show in text field".
@@ -4392,7 +4411,7 @@ export default function ChatView({
         if (!activeThreadId) return;
         storeSetTerminalActivity(activeThreadId, terminalId, activity);
       },
-      onAddTerminalContext: addTerminalContextToDraft,
+      ...(canAddTerminalContextToChat ? { onAddTerminalContext: addTerminalContextToDraft } : {}),
     }),
     [
       activeProject?.cwd,
@@ -4432,6 +4451,7 @@ export default function ChatView({
       toggleRightDock,
       rightDockOpen,
       hasRightDockPanes,
+      canAddTerminalContextToChat,
     ],
   );
   const runProjectScript = useCallback(

--- a/apps/web/src/components/ThreadTerminalDrawer.test.ts
+++ b/apps/web/src/components/ThreadTerminalDrawer.test.ts
@@ -2,11 +2,19 @@ import { describe, expect, it } from "vitest";
 
 import {
   resolveTerminalSelectionActionPosition,
+  resolveTerminalSelectionContextMenuItems,
   shouldHandleTerminalSelectionMouseUp,
   terminalSelectionActionDelayForClickCount,
 } from "./terminal/terminalSelectionActions";
 
 describe("resolveTerminalSelectionActionPosition", () => {
+  it("only offers Add to chat when a composer target exists", () => {
+    expect(resolveTerminalSelectionContextMenuItems(false)).toEqual([]);
+    expect(resolveTerminalSelectionContextMenuItems(true)).toEqual([
+      { id: "add-to-chat", label: "Add to chat" },
+    ]);
+  });
+
   it("prefers the selection rect over the last pointer position", () => {
     expect(
       resolveTerminalSelectionActionPosition({

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -15,7 +15,7 @@ import {
 import { type ThreadId } from "@synara/contracts";
 import { type TerminalActivityState, type TerminalCliKind } from "@synara/shared/terminalThreads";
 import { Terminal } from "@xterm/xterm";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { type TerminalContextSelection } from "~/lib/terminalContext";
 import { readNativeApi } from "~/nativeApi";
 import {
@@ -32,6 +32,7 @@ import {
 import { resolveThreadTerminalLayout } from "./terminal/TerminalLayout";
 import {
   resolveTerminalSelectionActionPosition,
+  resolveTerminalSelectionContextMenuItems,
   shouldHandleTerminalSelectionMouseUp,
   terminalSelectionActionDelayForClickCount,
 } from "./terminal/terminalSelectionActions";
@@ -122,7 +123,7 @@ interface TerminalViewportProps {
     terminalId: string,
     activity: { hasRunningSubprocess: boolean; agentState: TerminalActivityState | null },
   ) => void;
-  onAddTerminalContext: (selection: TerminalContextSelection) => void;
+  onAddTerminalContext?: ((selection: TerminalContextSelection) => void) | undefined;
   focusRequestId: number;
   autoFocus: boolean;
   isVisible: boolean;
@@ -209,7 +210,7 @@ function TerminalViewport({
   const runtimeConfigRef = useRef(runtimeConfig);
   const runtimeViewStateRef = useRef(runtimeViewState);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     onAddTerminalContextRef.current = onAddTerminalContext;
   }, [onAddTerminalContext]);
 
@@ -355,6 +356,13 @@ function TerminalViewport({
     if (selectionActionOpenRef.current) {
       return;
     }
+    const contextMenuItems = resolveTerminalSelectionContextMenuItems(
+      onAddTerminalContextRef.current !== undefined,
+    );
+    if (contextMenuItems.length === 0) {
+      clearSelectionAction();
+      return;
+    }
     const nextAction = readSelectionAction();
     if (!nextAction) {
       clearSelectionAction();
@@ -367,12 +375,16 @@ function TerminalViewport({
     // Promise chain instead of async/try-finally: React Compiler does not yet
     // support try/finally, and it would skip optimizing this whole component.
     void api.contextMenu
-      .show([{ id: "add-to-chat", label: "Add to chat" }], nextAction.position)
+      .show(contextMenuItems, nextAction.position)
       .then((clicked) => {
         if (requestId !== selectionActionRequestIdRef.current || clicked !== "add-to-chat") {
           return;
         }
-        onAddTerminalContextRef.current(nextAction.selection);
+        const addTerminalContext = onAddTerminalContextRef.current;
+        if (!addTerminalContext) {
+          return;
+        }
+        addTerminalContext(nextAction.selection);
         terminalRef.current?.clearSelection();
         terminalRuntimeRegistry.focus(runtimeKey);
       })
@@ -487,7 +499,7 @@ interface ThreadTerminalDrawerProps {
     terminalId: string,
     activity: { hasRunningSubprocess: boolean; agentState: TerminalActivityState | null },
   ) => void;
-  onAddTerminalContext: (selection: TerminalContextSelection) => void;
+  onAddTerminalContext?: ((selection: TerminalContextSelection) => void) | undefined;
   onTogglePresentationMode?: (() => void) | undefined;
   onTogglePanel?: (() => void) | undefined;
   isPanelOpen?: boolean | undefined;

--- a/apps/web/src/components/chat/DockTerminalPane.tsx
+++ b/apps/web/src/components/chat/DockTerminalPane.tsx
@@ -10,10 +10,15 @@
 
 import { type ProjectId, type ThreadId } from "@synara/contracts";
 import { resolveThreadWorkspaceCwd } from "@synara/shared/threadEnvironment";
-import { useMemo, useEffect } from "react";
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
 
 import { useTerminalSurfaceController } from "~/hooks/useTerminalSurfaceController";
+import { SINGLE_CHAT_PANE_SCOPE_ID } from "~/lib/chatPaneScope";
 import { dockTerminalThreadId } from "~/lib/dockTerminalScope";
+import {
+  getTerminalContextComposerTarget,
+  subscribeTerminalContextComposerTarget,
+} from "~/lib/terminalContextComposerRegistry";
 import { projectScriptRuntimeEnv } from "~/projectScripts";
 import { useStore } from "~/store";
 import { createProjectSelector, createThreadWorkspaceMetadataSelector } from "~/storeSelectors";
@@ -50,6 +55,20 @@ export function DockTerminalPane(props: {
 
   const terminal = useTerminalSurfaceController(scopeId);
   const { terminalState, openTerminalThreadPage, bumpFocusRequest, newTerminalGroup } = terminal;
+  const subscribeToComposerTarget = useCallback(
+    (listener: () => void) =>
+      subscribeTerminalContextComposerTarget(SINGLE_CHAT_PANE_SCOPE_ID, listener),
+    [],
+  );
+  const readComposerTarget = useCallback(
+    () => getTerminalContextComposerTarget(SINGLE_CHAT_PANE_SCOPE_ID),
+    [],
+  );
+  const composerTarget = useSyncExternalStore(
+    subscribeToComposerTarget,
+    readComposerTarget,
+    readComposerTarget,
+  );
 
   // A dock terminal pane always shows a live terminal: ensure one is open on mount
   // and re-open if the user closes the last tab (normalize guarantees a default id).
@@ -100,7 +119,7 @@ export function DockTerminalPane(props: {
       onResizeTerminalSplit={terminal.resizeTerminalSplit}
       onTerminalMetadataChange={terminal.setTerminalMetadata}
       onTerminalActivityChange={terminal.setTerminalActivity}
-      onAddTerminalContext={() => {}}
+      onAddTerminalContext={composerTarget}
     />
   );
 }

--- a/apps/web/src/components/terminal/terminalSelectionActions.ts
+++ b/apps/web/src/components/terminal/terminalSelectionActions.ts
@@ -2,7 +2,15 @@
 // Purpose: Keep pure selection-action positioning helpers separate from the browser-heavy drawer.
 // Layer: Chat terminal workspace helpers
 
+import type { ContextMenuItem } from "@synara/contracts";
+
 const MULTI_CLICK_SELECTION_ACTION_DELAY_MS = 260;
+
+export function resolveTerminalSelectionContextMenuItems(
+  hasComposerTarget: boolean,
+): readonly ContextMenuItem<"add-to-chat">[] {
+  return hasComposerTarget ? [{ id: "add-to-chat", label: "Add to chat" }] : [];
+}
 
 export function resolveTerminalSelectionActionPosition(options: {
   bounds: { left: number; top: number; width: number; height: number };

--- a/apps/web/src/lib/terminalContextComposerRegistry.test.ts
+++ b/apps/web/src/lib/terminalContextComposerRegistry.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { TerminalContextSelection } from "./terminalContext";
+import {
+  getTerminalContextComposerTarget,
+  registerTerminalContextComposerTarget,
+  subscribeTerminalContextComposerTarget,
+} from "./terminalContextComposerRegistry";
+
+const selection: TerminalContextSelection = {
+  terminalId: "terminal-1",
+  terminalLabel: "Terminal 1",
+  lineStart: 2,
+  lineEnd: 3,
+  text: "first\nsecond",
+};
+
+describe("terminalContextComposerRegistry", () => {
+  it("publishes a composer target and removes it on cleanup", () => {
+    const target = vi.fn();
+    const cleanup = registerTerminalContextComposerTarget("pane-1", target);
+
+    getTerminalContextComposerTarget("pane-1")?.(selection);
+    expect(target).toHaveBeenCalledWith(selection);
+
+    cleanup();
+    expect(getTerminalContextComposerTarget("pane-1")).toBeUndefined();
+  });
+
+  it("does not let stale cleanup remove a replacement target", () => {
+    const firstTarget = vi.fn();
+    const secondTarget = vi.fn();
+    const cleanupFirst = registerTerminalContextComposerTarget("pane-2", firstTarget);
+    const cleanupSecond = registerTerminalContextComposerTarget("pane-2", secondTarget);
+
+    cleanupFirst();
+    expect(getTerminalContextComposerTarget("pane-2")).toBe(secondTarget);
+
+    cleanupSecond();
+    expect(getTerminalContextComposerTarget("pane-2")).toBeUndefined();
+  });
+
+  it("notifies subscribers when availability changes", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeTerminalContextComposerTarget("pane-3", listener);
+    const cleanup = registerTerminalContextComposerTarget("pane-3", vi.fn());
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    cleanup();
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    registerTerminalContextComposerTarget("pane-3", vi.fn())();
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/lib/terminalContextComposerRegistry.ts
+++ b/apps/web/src/lib/terminalContextComposerRegistry.ts
@@ -1,0 +1,56 @@
+// FILE: terminalContextComposerRegistry.ts
+// Purpose: Connect terminal selection actions to the composer that owns draft insertion.
+// Layer: Chat capability registry
+
+import type { TerminalContextSelection } from "./terminalContext";
+
+export type TerminalContextComposerTarget = (selection: TerminalContextSelection) => void;
+
+type RegistryListener = () => void;
+
+const targetsByPaneScopeId = new Map<string, TerminalContextComposerTarget>();
+const listenersByPaneScopeId = new Map<string, Set<RegistryListener>>();
+
+function notifyTargetChanged(paneScopeId: string): void {
+  const listeners = listenersByPaneScopeId.get(paneScopeId);
+  if (!listeners) return;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function registerTerminalContextComposerTarget(
+  paneScopeId: string,
+  target: TerminalContextComposerTarget,
+): () => void {
+  targetsByPaneScopeId.set(paneScopeId, target);
+  notifyTargetChanged(paneScopeId);
+  return () => {
+    if (targetsByPaneScopeId.get(paneScopeId) !== target) {
+      return;
+    }
+    targetsByPaneScopeId.delete(paneScopeId);
+    notifyTargetChanged(paneScopeId);
+  };
+}
+
+export function getTerminalContextComposerTarget(
+  paneScopeId: string,
+): TerminalContextComposerTarget | undefined {
+  return targetsByPaneScopeId.get(paneScopeId);
+}
+
+export function subscribeTerminalContextComposerTarget(
+  paneScopeId: string,
+  listener: RegistryListener,
+): () => void {
+  const listeners = listenersByPaneScopeId.get(paneScopeId) ?? new Set<RegistryListener>();
+  listeners.add(listener);
+  listenersByPaneScopeId.set(paneScopeId, listeners);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      listenersByPaneScopeId.delete(paneScopeId);
+    }
+  };
+}


### PR DESCRIPTION
## Issue

Selecting terminal output and choosing **Add to chat** did nothing in the right-dock terminal. The action could also appear on terminal-only surfaces where no chat composer was mounted to receive the selection.

## Root cause

The dock terminal supplied a no-op terminal-context callback. Separately, the terminal selection menu was built unconditionally, so it did not reflect whether a composer target actually existed.

## Fix

- Publish mounted chat composers through a pane-scoped terminal-context capability registry.
- Subscribe the right-dock terminal to the main chat composer and route selections through the existing draft insertion path.
- Keep the registered callback stable while using the latest cursor and draft state.
- Make the terminal callback optional and omit **Add to chat** whenever no composer target is available, including terminal-only workspaces and transient unmounts.
- Guard replacement and cleanup behavior so stale registrations cannot remove the current target.

## Verification

- `bun run --cwd apps/web test src/lib/terminalContextComposerRegistry.test.ts src/components/ThreadTerminalDrawer.test.ts` — 9 tests passed.
- Targeted formatting and lint checks passed for the changed files; `ChatView.tsx` retained only unrelated pre-existing warnings.
- Production web build completed successfully during implementation.
- `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI wiring and optional callbacks in chat/terminal surfaces; no auth, data, or API changes.
> 
> **Overview**
> Fixes **Add to chat** from terminal selections (especially the right-dock terminal) by wiring selections into the real chat composer instead of a no-op.
> 
> **ChatView** registers a pane-scoped composer target when a thread and chat pane are mounted, using a stable callback ref so dock terminals do not rerender on every composer edit. Registration is skipped on terminal-only workspaces with no composer.
> 
> A new **`terminalContextComposerRegistry`** maps `paneScopeId` to the insert-into-draft handler, with subscribe/notify for availability and cleanup that cannot remove a newer registration.
> 
> **DockTerminalPane** subscribes to the main chat pane scope and passes the resolved target into **ThreadTerminalDrawer**. **`onAddTerminalContext`** is optional; **`resolveTerminalSelectionContextMenuItems`** omits **Add to chat** when no target exists, and the selection menu is not shown in that case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d44b5d7905f13f48e4138f02e0e3c89df39e433e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->