### PR TITLE
Fix stale provider update notifications

### DIFF
--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -642,6 +642,48 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
       ]);
     });
 
+    it("drops a cached update advisory when a transient timeout prevents verification", () => {
+      const previousWithUpdate = {
+        ...previousReadyOpenCode,
+        versionAdvisory: {
+          status: "behind_latest",
+          currentVersion: "1.15.13",
+          latestVersion: "1.16.0",
+          updateCommand: "npm install -g opencode-ai@latest",
+          canUpdate: true,
+          checkedAt: "2026-06-04T17:00:00.000Z",
+          message: "Update available.",
+        },
+      } satisfies ServerProviderStatus;
+
+      const [result] = stabilizeProviderStatusesAgainstTransientTimeouts(
+        [previousWithUpdate],
+        [
+          {
+            provider: "opencode",
+            status: "error",
+            available: false,
+            authStatus: "unknown",
+            checkedAt: "2026-06-04T17:01:00.000Z",
+            message:
+              "OpenCode CLI is installed but failed to run. Timed out while running command.",
+          },
+        ],
+      );
+
+      assert.strictEqual(result?.status, "ready");
+      assert.strictEqual(result?.available, true);
+      assert.deepStrictEqual(result?.versionAdvisory, {
+        status: "unknown",
+        currentVersion: "1.15.13",
+        latestVersion: null,
+        updateCommand: null,
+        canUpdate: false,
+        checkedAt: "2026-06-04T17:01:00.000Z",
+        message: null,
+      });
+    });
+
     it("does not hide non-timeout provider failures", () => {
       const unavailableStatus = {
         provider: "opencode",

--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -247,6 +247,46 @@ function withTempCodexHome(configContent?: string) {
 
 it.layer(NodeServices.layer)("ProviderHealth", (it) => {
   describe("provider update commands", () => {
+    it("delegates native Claude release-channel truth to Claude", () => {
+      const definition = PACKAGE_MANAGED_PROVIDER_UPDATES.claudeAgent;
+      assert.ok(definition);
+
+      const capabilities = resolvePackageManagedProviderMaintenance(definition, {
+        binaryPath: "claude",
+        realCommandPath: "/Users/test/.local/share/claude/versions/2.1.100/claude",
+      });
+
+      assert.strictEqual(capabilities.latestVersionSource, null);
+      assert.deepStrictEqual(capabilities.update, {
+        command: "claude update",
+        executable: "claude",
+        args: ["update"],
+        lockKey: "claude-native",
+      });
+    });
+
+    it("keeps Claude's latest Homebrew cask source and command aligned", () => {
+      const definition = PACKAGE_MANAGED_PROVIDER_UPDATES.claudeAgent;
+      assert.ok(definition);
+
+      const capabilities = resolvePackageManagedProviderMaintenance(definition, {
+        binaryPath: "/opt/homebrew/bin/claude",
+        realCommandPath: "/opt/homebrew/Caskroom/claude-code@latest/2.1.100/claude",
+      });
+
+      assert.deepStrictEqual(capabilities.latestVersionSource, {
+        kind: "homebrew",
+        name: "claude-code@latest",
+        homebrewKind: "cask",
+      });
+      assert.deepStrictEqual(capabilities.update, {
+        command: "brew upgrade --cask claude-code@latest",
+        executable: "brew",
+        args: ["upgrade", "--cask", "claude-code@latest"],
+        lockKey: "homebrew",
+      });
+    });
+
     it("registers Antigravity's native updater", () => {
       const definition = PACKAGE_MANAGED_PROVIDER_UPDATES.antigravity;
       assert.ok(definition);

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -1997,11 +1997,16 @@ export function stabilizeProviderStatusesAgainstTransientTimeouts(
     }
 
     // A single slow CLI probe should not make an already usable provider look broken.
-    return {
+    // The previous update advisory is network-backed evidence, though, so it must
+    // not survive a probe that could not confirm the installed version.
+    const stabilizedStatus = {
       ...previous,
       checkedAt: status.checkedAt,
       ...(status.updateState !== undefined ? { updateState: status.updateState } : {}),
     };
+    return previous.versionAdvisory
+      ? suppressProviderVersionAdvisory(stabilizedStatus)
+      : stabilizedStatus;
   });
 }
 

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -166,6 +166,10 @@ function isClaudeNativeCommandPath(commandPath: string): boolean {
   );
 }
 
+function isClaudeLatestHomebrewCommandPath(commandPath: string): boolean {
+  return normalizeCommandPath(commandPath).includes("/caskroom/claude-code@latest/");
+}
+
 function isOpenCodeNativeCommandPath(commandPath: string): boolean {
   const normalized = normalizeCommandPath(commandPath);
   return (
@@ -197,12 +201,25 @@ export const PACKAGE_MANAGED_PROVIDER_UPDATES: Partial<
     provider: CLAUDE_AGENT_PROVIDER,
     binaryName: "claude",
     npmPackageName: "@anthropic-ai/claude-code",
-    homebrew: { name: "claude-code", kind: "cask" },
+    homebrew: {
+      name: "claude-code",
+      kind: "cask",
+      variants: [
+        {
+          name: "claude-code@latest",
+          kind: "cask",
+          isCommandPath: isClaudeLatestHomebrewCommandPath,
+        },
+      ],
+    },
     nativeUpdate: {
       executable: "claude",
       args: () => ["update"],
       lockKey: "claude-native",
       strategy: "matching-path",
+      // Native Claude owns stable/latest channel selection. npm's latest tag cannot
+      // tell whether the installed CLI is current for the user's configured channel.
+      latestVersionSource: null,
       isCommandPath: isClaudeNativeCommandPath,
     },
   },

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -301,8 +301,7 @@ describe("providerMaintenance", () => {
 
     it("resolves explicit Homebrew symlinks before selecting a cask variant", async () => {
       const layer = FileSystem.layerNoop({
-        realPath: () =>
-          Effect.succeed("/opt/homebrew/Caskroom/claude-code@latest/2.1.100/claude"),
+        realPath: () => Effect.succeed("/opt/homebrew/Caskroom/claude-code@latest/2.1.100/claude"),
       });
 
       const capabilities = await Effect.runPromise(

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -39,6 +39,33 @@ const OPENCODE_DEFINITION = {
   },
 } as const satisfies PackageManagedProviderMaintenanceDefinition;
 
+const CLAUDE_DEFINITION = {
+  provider: "claudeAgent",
+  binaryName: "claude",
+  npmPackageName: "@anthropic-ai/claude-code",
+  homebrew: {
+    name: "claude-code",
+    kind: "cask",
+    variants: [
+      {
+        name: "claude-code@latest",
+        kind: "cask",
+        isCommandPath: (commandPath: string) =>
+          commandPath.toLowerCase().includes("/caskroom/claude-code@latest/"),
+      },
+    ],
+  },
+  nativeUpdate: {
+    executable: "claude",
+    args: () => ["update"],
+    lockKey: "claude-native",
+    strategy: "matching-path",
+    latestVersionSource: null,
+    isCommandPath: (commandPath: string) =>
+      commandPath.toLowerCase().includes("/.local/share/claude/"),
+  },
+} as const satisfies PackageManagedProviderMaintenanceDefinition;
+
 /** The trailing name of a probed path, whichever separator the host joined it with. */
 function fileNameOf(probedPath: string): string {
   return probedPath.slice(Math.max(probedPath.lastIndexOf("/"), probedPath.lastIndexOf("\\")) + 1);
@@ -118,6 +145,40 @@ describe("providerMaintenance", () => {
       lockKey: "homebrew",
     });
     assert.strictEqual(capabilities.packageName, null);
+  });
+
+  it("keeps native provider update truth with the provider when explicitly configured", () => {
+    const capabilities = resolvePackageManagedProviderMaintenance(CLAUDE_DEFINITION, {
+      binaryPath: "claude",
+      realCommandPath: "/Users/test/.local/share/claude/versions/2.1.100/claude",
+    });
+
+    assert.deepStrictEqual(capabilities.update, {
+      command: "claude update",
+      executable: "claude",
+      args: ["update"],
+      lockKey: "claude-native",
+    });
+    assert.strictEqual(capabilities.latestVersionSource, null);
+  });
+
+  it("resolves alternate Homebrew casks from the installed command path", () => {
+    const capabilities = resolvePackageManagedProviderMaintenance(CLAUDE_DEFINITION, {
+      binaryPath: "/opt/homebrew/bin/claude",
+      realCommandPath: "/opt/homebrew/Caskroom/claude-code@latest/2.1.100/claude",
+    });
+
+    assert.deepStrictEqual(capabilities.update, {
+      command: "brew upgrade --cask claude-code@latest",
+      executable: "brew",
+      args: ["upgrade", "--cask", "claude-code@latest"],
+      lockKey: "homebrew",
+    });
+    assert.deepStrictEqual(capabilities.latestVersionSource, {
+      kind: "homebrew",
+      name: "claude-code@latest",
+      homebrewKind: "cask",
+    });
   });
 
   it("uses provider-native update commands with detected install method", () => {
@@ -228,7 +289,7 @@ describe("providerMaintenance", () => {
       assert.ok(batIndex < cmdIndex);
     });
 
-    it("never touches the filesystem for a binary path that already names a location", async () => {
+    it("does not search PATH when a binary path already names a location", async () => {
       const { probed } = await runWithVirtualFileSystem(new Set(), {
         binaryPath: "/opt/homebrew/bin/codex",
         platform: "darwin",
@@ -236,6 +297,32 @@ describe("providerMaintenance", () => {
       });
 
       assert.deepStrictEqual(probed, []);
+    });
+
+    it("resolves explicit Homebrew symlinks before selecting a cask variant", async () => {
+      const layer = FileSystem.layerNoop({
+        realPath: () =>
+          Effect.succeed("/opt/homebrew/Caskroom/claude-code@latest/2.1.100/claude"),
+      });
+
+      const capabilities = await Effect.runPromise(
+        resolveProviderMaintenanceCapabilitiesEffect(CLAUDE_DEFINITION, {
+          binaryPath: "/opt/homebrew/bin/claude",
+          platform: "darwin",
+        }).pipe(Effect.provide(layer)),
+      );
+
+      assert.deepStrictEqual(capabilities.update, {
+        command: "brew upgrade --cask claude-code@latest",
+        executable: "brew",
+        args: ["upgrade", "--cask", "claude-code@latest"],
+        lockKey: "homebrew",
+      });
+      assert.deepStrictEqual(capabilities.latestVersionSource, {
+        kind: "homebrew",
+        name: "claude-code@latest",
+        homebrewKind: "cask",
+      });
     });
 
     it("probes nothing when the supplied environment carries no PATH", async () => {

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -452,14 +452,8 @@ function makeProviderMaintenanceForInstallSource(input: {
   /** Path that matched install-source detection, used to pin the install tree. */
   readonly commandPath?: string | null;
 }): ProviderMaintenanceCapabilities {
-  const {
-    definition,
-    installSource,
-    homebrewPackage,
-    executable,
-    pathPrepend,
-    commandPath,
-  } = input;
+  const { definition, installSource, homebrewPackage, executable, pathPrepend, commandPath } =
+    input;
   if (
     definition.nativeUpdate?.strategy === "always" &&
     !definition.nativeUpdate.excludedInstallSources?.includes(installSource)
@@ -621,9 +615,7 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
   if (hasPathSeparator(binaryPath)) {
     const realCommandPath =
       nonEmptyString(options?.realCommandPath) ??
-      (yield* fileSystem.realPath(binaryPath).pipe(
-        Effect.catch(() => Effect.succeed(binaryPath)),
-      ));
+      (yield* fileSystem.realPath(binaryPath).pipe(Effect.catch(() => Effect.succeed(binaryPath))));
     return resolvePackageManagedProviderMaintenance(definition, {
       ...options,
       binaryPath,

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -28,6 +28,12 @@ export interface ProviderLatestVersionSource {
   readonly homebrewKind?: "formula" | "cask";
 }
 
+export interface ProviderHomebrewPackageDefinition {
+  readonly name: string;
+  readonly kind: "formula" | "cask";
+  readonly isCommandPath?: (commandPath: string) => boolean;
+}
+
 export interface ProviderMaintenanceCapabilities {
   readonly provider: ProviderKind;
   readonly packageName: string | null;
@@ -56,16 +62,19 @@ export interface PackageManagedProviderMaintenanceDefinition {
   readonly provider: ProviderKind;
   readonly binaryName: string;
   readonly npmPackageName: string | null;
-  readonly homebrew: {
-    readonly name: string;
-    readonly kind: "formula" | "cask";
-  } | null;
+  readonly homebrew:
+    | (ProviderHomebrewPackageDefinition & {
+        readonly variants?: ReadonlyArray<ProviderHomebrewPackageDefinition>;
+      })
+    | null;
   readonly latestVersionSource?: ProviderLatestVersionSource | null;
   readonly nativeUpdate: {
     readonly executable: string;
     readonly args: (installSource: ProviderInstallSource) => ReadonlyArray<string>;
     readonly lockKey: string;
     readonly strategy: "always" | "matching-path";
+    /** Explicit source for native installs. Null delegates update truth to the provider CLI. */
+    readonly latestVersionSource?: ProviderLatestVersionSource | null;
     readonly excludedInstallSources?: ReadonlyArray<ProviderInstallSource>;
     readonly isCommandPath?: (commandPath: string) => boolean;
   } | null;
@@ -245,8 +254,11 @@ export function makeProviderMaintenanceCapabilities(input: {
     provider: input.provider,
     packageName: input.packageName,
     latestVersionSource:
-      input.latestVersionSource ??
-      (input.packageName ? { kind: "npm", name: input.packageName } : null),
+      input.latestVersionSource !== undefined
+        ? input.latestVersionSource
+        : input.packageName
+          ? { kind: "npm", name: input.packageName }
+          : null,
     update,
   };
 }
@@ -333,9 +345,10 @@ function makePnpmGlobalProviderMaintenanceCapabilities(
 
 function makeHomebrewProviderMaintenanceCapabilities(
   definition: PackageManagedProviderMaintenanceDefinition,
+  homebrewPackage: ProviderHomebrewPackageDefinition | null,
   pathPrepend?: string | null,
 ): ProviderMaintenanceCapabilities {
-  if (!definition.homebrew) {
+  if (!homebrewPackage) {
     return makeManualOnlyProviderMaintenanceCapabilities({
       provider: definition.provider,
       packageName: definition.npmPackageName,
@@ -345,12 +358,16 @@ function makeHomebrewProviderMaintenanceCapabilities(
   return makeProviderMaintenanceCapabilities({
     provider: definition.provider,
     packageName: null,
-    latestVersionSource: resolveLatestVersionSourceForInstallSource(definition, "homebrew"),
+    latestVersionSource: resolveLatestVersionSourceForInstallSource(
+      definition,
+      "homebrew",
+      homebrewPackage,
+    ),
     updateExecutable: "brew",
     updateArgs:
-      definition.homebrew.kind === "cask"
-        ? ["upgrade", "--cask", definition.homebrew.name]
-        : ["upgrade", definition.homebrew.name],
+      homebrewPackage.kind === "cask"
+        ? ["upgrade", "--cask", homebrewPackage.name]
+        : ["upgrade", homebrewPackage.name],
     updateLockKey: "homebrew",
     ...(pathPrepend === undefined ? {} : { updatePathPrepend: pathPrepend }),
   });
@@ -359,15 +376,23 @@ function makeHomebrewProviderMaintenanceCapabilities(
 function resolveLatestVersionSourceForInstallSource(
   definition: PackageManagedProviderMaintenanceDefinition,
   installSource: ProviderInstallSource,
+  homebrewPackage?: ProviderHomebrewPackageDefinition | null,
 ): ProviderLatestVersionSource | null {
   if (definition.latestVersionSource) {
     return definition.latestVersionSource;
   }
-  if (installSource === "homebrew" && definition.homebrew) {
+  if (
+    installSource === "native" &&
+    definition.nativeUpdate &&
+    definition.nativeUpdate.latestVersionSource !== undefined
+  ) {
+    return definition.nativeUpdate.latestVersionSource;
+  }
+  if (installSource === "homebrew" && homebrewPackage) {
     return {
       kind: "homebrew",
-      name: definition.homebrew.name,
-      homebrewKind: definition.homebrew.kind,
+      name: homebrewPackage.name,
+      homebrewKind: homebrewPackage.kind,
     };
   }
   return definition.npmPackageName ? { kind: "npm", name: definition.npmPackageName } : null;
@@ -421,12 +446,20 @@ function detectInstallSource(
 function makeProviderMaintenanceForInstallSource(input: {
   readonly definition: PackageManagedProviderMaintenanceDefinition;
   readonly installSource: ProviderInstallSource;
+  readonly homebrewPackage?: ProviderHomebrewPackageDefinition | null;
   readonly executable?: string | null;
   readonly pathPrepend?: string | null;
   /** Path that matched install-source detection, used to pin the install tree. */
   readonly commandPath?: string | null;
 }): ProviderMaintenanceCapabilities {
-  const { definition, installSource, executable, pathPrepend, commandPath } = input;
+  const {
+    definition,
+    installSource,
+    homebrewPackage,
+    executable,
+    pathPrepend,
+    commandPath,
+  } = input;
   if (
     definition.nativeUpdate?.strategy === "always" &&
     !definition.nativeUpdate.excludedInstallSources?.includes(installSource)
@@ -468,12 +501,27 @@ function makeProviderMaintenanceForInstallSource(input: {
     return makeNpmGlobalProviderMaintenanceCapabilities(definition, pathPrepend, commandPath);
   }
   if (installSource === "homebrew") {
-    return makeHomebrewProviderMaintenanceCapabilities(definition, pathPrepend);
+    return makeHomebrewProviderMaintenanceCapabilities(
+      definition,
+      homebrewPackage ?? definition.homebrew,
+      pathPrepend,
+    );
   }
   return makeManualOnlyProviderMaintenanceCapabilities({
     provider: definition.provider,
     packageName: definition.npmPackageName,
   });
+}
+
+function resolveHomebrewPackageForCommandPath(
+  definition: PackageManagedProviderMaintenanceDefinition,
+  commandPath: string,
+): ProviderHomebrewPackageDefinition | null {
+  const homebrew = definition.homebrew;
+  if (!homebrew) {
+    return null;
+  }
+  return homebrew.variants?.find((variant) => variant.isCommandPath?.(commandPath)) ?? homebrew;
 }
 
 function isBunGlobalCommandPath(commandPath: string): boolean {
@@ -535,6 +583,9 @@ export function resolvePackageManagedProviderMaintenance(
       return makeProviderMaintenanceForInstallSource({
         definition,
         installSource,
+        ...(installSource === "homebrew"
+          ? { homebrewPackage: resolveHomebrewPackageForCommandPath(definition, commandPath) }
+          : {}),
         executable: binaryPath,
         commandPath,
         ...(options?.commandDirectory === undefined
@@ -566,11 +617,20 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
   options?: ProviderMaintenanceCapabilityResolutionOptions,
 ) {
   const binaryPath = nonEmptyString(options?.binaryPath) ?? definition.binaryName;
+  const fileSystem = yield* FileSystem.FileSystem;
   if (hasPathSeparator(binaryPath)) {
-    return resolvePackageManagedProviderMaintenance(definition, options);
+    const realCommandPath =
+      nonEmptyString(options?.realCommandPath) ??
+      (yield* fileSystem.realPath(binaryPath).pipe(
+        Effect.catch(() => Effect.succeed(binaryPath)),
+      ));
+    return resolvePackageManagedProviderMaintenance(definition, {
+      ...options,
+      binaryPath,
+      realCommandPath,
+    });
   }
 
-  const fileSystem = yield* FileSystem.FileSystem;
   // Existence, not executability: this is locating an installation to report on, so an
   // extensionless Windows file still counts even though nothing could spawn it directly.
   //

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -3025,7 +3025,10 @@ describe("ChatView timeline estimator parity (full app)", () => {
       let approachDirection = 0;
       for (let index = 1; index < approach.length; index += 1) {
         const delta = approach[index]!.offset - approach[index - 1]!.offset;
-        if (Math.abs(delta) <= 0.5) continue;
+        // Chromium can report a one-pixel layout/compositor rounding shift before
+        // the anchor animation starts. Match the arrival tolerance so that noise
+        // does not count as an extra change of direction.
+        if (Math.abs(delta) <= 2) continue;
         const direction = Math.sign(delta);
         if (approachDirection !== 0 && direction !== approachDirection) approachReversals += 1;
         approachDirection = direction;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -190,7 +190,6 @@ import { SidebarRowHoverActions } from "./SidebarRowHoverActions";
 import { SidebarSectionToolbar } from "./SidebarSectionToolbar";
 import { SidebarGlyph, sidebarGlyphClass, SIDEBAR_TRAILING_ICON_CLASS } from "./sidebarGlyphs";
 import { SidebarStatusTrailingGlyph } from "./SidebarStatusTrailingGlyph";
-import { createSidebarThreadRowGestures } from "./sidebarThreadRowGestures";
 import { ThreadArchiveActionButton } from "./ThreadArchiveActionButton";
 import { ThreadPinToggleButton } from "./ThreadPinToggleButton";
 import {
@@ -4361,20 +4360,25 @@ export default function Sidebar() {
             )}
             onPointerDown={(event) => primeThreadActivation(event, thread.id)}
             onClick={() => activateThreadFromSidebarIntent(thread.id)}
+            onDoubleClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              openRenameThreadDialog(thread.id);
+            }}
+            onPointerUp={(event) => handleThreadRenamePointerUp(event, thread.id)}
             onKeyDown={(event) => {
               if (event.key === "Enter" || event.key === " ") {
                 event.preventDefault();
                 activateThreadFromSidebarIntent(thread.id);
               }
             }}
-            {...createSidebarThreadRowGestures({
-              threadId: thread.id,
-              onRename: openRenameThreadDialog,
-              onRenamePointerUp: handleThreadRenamePointerUp,
-              onContextMenu: (threadId, position) => {
-                void handleThreadContextMenu(threadId, position);
-              },
-            })}
+            onContextMenu={(event) => {
+              event.preventDefault();
+              void handleThreadContextMenu(thread.id, {
+                x: event.clientX,
+                y: event.clientY,
+              });
+            }}
           >
             <SidebarThreadRowContent
               thread={thread}
@@ -4540,28 +4544,36 @@ export default function Sidebar() {
                   handleThreadClick(event, thread.id, orderedProjectThreadIds);
                 }}
                 onPointerDown={(event) => primeThreadActivation(event, thread.id)}
+                onDoubleClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  openRenameThreadDialog(thread.id);
+                }}
+                onPointerUp={(event) => handleThreadRenamePointerUp(event, thread.id)}
                 onKeyDown={(event) => {
                   if (event.key !== "Enter" && event.key !== " ") return;
                   event.preventDefault();
                   activateThreadFromSidebarIntent(thread.id);
                 }}
-                {...createSidebarThreadRowGestures({
-                  threadId: thread.id,
-                  onRename: openRenameThreadDialog,
-                  onRenamePointerUp: handleThreadRenamePointerUp,
-                  onContextMenu: (threadId, position) => {
-                    // A right-click inside an active multi-selection acts on the whole
-                    // selection; anywhere else it drops the selection and targets the row.
-                    if (selectedThreadIds.size > 0 && selectedThreadIds.has(threadId)) {
-                      void handleMultiSelectContextMenu(position);
-                      return;
-                    }
-                    if (selectedThreadIds.size > 0) {
-                      clearSelection();
-                    }
-                    void handleThreadContextMenu(threadId, position);
-                  },
-                })}
+                onContextMenu={(event) => {
+                  event.preventDefault();
+                  // A right-click inside an active multi-selection acts on the whole
+                  // selection; anywhere else it drops the selection and targets the row.
+                  if (selectedThreadIds.size > 0 && selectedThreadIds.has(thread.id)) {
+                    void handleMultiSelectContextMenu({
+                      x: event.clientX,
+                      y: event.clientY,
+                    });
+                    return;
+                  }
+                  if (selectedThreadIds.size > 0) {
+                    clearSelection();
+                  }
+                  void handleThreadContextMenu(thread.id, {
+                    x: event.clientX,
+                    y: event.clientY,
+                  });
+                }}
               />
             }
           >

--- a/apps/web/src/hooks/useProviderAuthRefreshOnFocus.ts
+++ b/apps/web/src/hooks/useProviderAuthRefreshOnFocus.ts
@@ -9,10 +9,11 @@ import { useProviderStatusRefresh } from "./useProviderStatusRefresh";
 
 // Minimum gap between window-focus-triggered provider auth re-probes, so rapid
 // focus/visibility changes can't spawn redundant CLI probes on the server.
-const PROVIDER_AUTH_REFRESH_MIN_INTERVAL_MS = 15_000;
+export const PROVIDER_AUTH_REFRESH_MIN_INTERVAL_MS = 15_000;
 
-export function useProviderAuthRefreshOnFocus(): void {
+export function useProviderAuthRefreshOnFocus(options?: { readonly enabled?: boolean }): void {
   useProviderStatusRefresh({
+    enabled: options?.enabled,
     minIntervalMs: PROVIDER_AUTH_REFRESH_MIN_INTERVAL_MS,
     refreshOnFocus: true,
   });

--- a/apps/web/src/hooks/useProviderAuthRefreshOnFocus.ts
+++ b/apps/web/src/hooks/useProviderAuthRefreshOnFocus.ts
@@ -13,7 +13,7 @@ export const PROVIDER_AUTH_REFRESH_MIN_INTERVAL_MS = 15_000;
 
 export function useProviderAuthRefreshOnFocus(options?: { readonly enabled?: boolean }): void {
   useProviderStatusRefresh({
-    enabled: options?.enabled,
+    ...(options?.enabled !== undefined ? { enabled: options.enabled } : {}),
     minIntervalMs: PROVIDER_AUTH_REFRESH_MIN_INTERVAL_MS,
     refreshOnFocus: true,
   });

--- a/apps/web/src/hooks/useProviderStatusRefresh.test.ts
+++ b/apps/web/src/hooks/useProviderStatusRefresh.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  cleanup: undefined as (() => void) | undefined,
+  queryClient: {},
+  readNativeApi: vi.fn(),
+  reconcileServerProviderStatuses: vi.fn(async () => undefined),
+}));
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    useEffect: (effect: () => void | (() => void)) => {
+      mocks.cleanup = effect() ?? undefined;
+    },
+  };
+});
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => mocks.queryClient,
+}));
+
+vi.mock("../nativeApi", () => ({
+  readNativeApi: mocks.readNativeApi,
+}));
+
+vi.mock("../lib/serverReactQuery", () => ({
+  reconcileServerProviderStatuses: mocks.reconcileServerProviderStatuses,
+}));
+
+import { useProviderStatusRefresh } from "./useProviderStatusRefresh";
+
+function installBrowserGlobals(visibilityState: DocumentVisibilityState) {
+  const windowTarget = new EventTarget();
+  Object.assign(windowTarget, {
+    setTimeout: globalThis.setTimeout,
+    clearTimeout: globalThis.clearTimeout,
+    setInterval: globalThis.setInterval,
+    clearInterval: globalThis.clearInterval,
+  });
+  const documentTarget = new EventTarget();
+  Object.defineProperty(documentTarget, "visibilityState", {
+    configurable: true,
+    value: visibilityState,
+    writable: true,
+  });
+  vi.stubGlobal("window", windowTarget);
+  vi.stubGlobal("document", documentTarget);
+  return {
+    documentTarget,
+    setVisibilityState: (next: DocumentVisibilityState) => {
+      Object.defineProperty(documentTarget, "visibilityState", {
+        configurable: true,
+        value: next,
+        writable: true,
+      });
+    },
+    windowTarget,
+  };
+}
+
+describe("useProviderStatusRefresh", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.cleanup = undefined;
+    mocks.readNativeApi.mockReset();
+    mocks.reconcileServerProviderStatuses.mockClear();
+  });
+
+  afterEach(() => {
+    mocks.cleanup?.();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("still runs the startup refresh after an early focus attempt fails", async () => {
+    const { windowTarget } = installBrowserGlobals("visible");
+    const refreshProviders = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transport unavailable"))
+      .mockResolvedValueOnce({ providers: [] });
+    mocks.readNativeApi.mockReturnValue({ server: { refreshProviders } });
+    const onRefreshSuccess = vi.fn();
+
+    useProviderStatusRefresh({
+      initialDelayMs: 10_000,
+      minIntervalMs: 15_000,
+      refreshOnFocus: true,
+      onRefreshSuccess,
+    });
+
+    windowTarget.dispatchEvent(new Event("focus"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(refreshProviders).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(refreshProviders).toHaveBeenCalledTimes(2);
+    expect(onRefreshSuccess).toHaveBeenCalledOnce();
+  });
+
+  it("retries a hidden startup refresh when the document becomes visible", async () => {
+    const { documentTarget, setVisibilityState } = installBrowserGlobals("hidden");
+    const refreshProviders = vi.fn().mockResolvedValue({ providers: [] });
+    mocks.readNativeApi.mockReturnValue({ server: { refreshProviders } });
+    const onRefreshSuccess = vi.fn();
+
+    useProviderStatusRefresh({
+      initialDelayMs: 10_000,
+      minIntervalMs: 15_000,
+      refreshOnFocus: true,
+      onRefreshSuccess,
+    });
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(refreshProviders).not.toHaveBeenCalled();
+
+    setVisibilityState("visible");
+    documentTarget.dispatchEvent(new Event("visibilitychange"));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(refreshProviders).toHaveBeenCalledOnce();
+    expect(onRefreshSuccess).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/hooks/useProviderStatusRefresh.ts
+++ b/apps/web/src/hooks/useProviderStatusRefresh.ts
@@ -59,6 +59,7 @@ type ProviderStatusRefreshOptions = {
   readonly intervalMs?: number;
   readonly minIntervalMs?: number;
   readonly refreshOnFocus?: boolean;
+  readonly onRefreshSuccess?: () => void;
 };
 
 export function useProviderStatusRefresh(options: ProviderStatusRefreshOptions): void {
@@ -68,6 +69,7 @@ export function useProviderStatusRefresh(options: ProviderStatusRefreshOptions):
   const intervalMs = options.intervalMs;
   const minIntervalMs = options.minIntervalMs ?? 0;
   const refreshOnFocus = options.refreshOnFocus ?? false;
+  const onRefreshSuccess = options.onRefreshSuccess;
 
   useEffect(() => {
     if (!enabled || typeof window === "undefined" || typeof document === "undefined") {
@@ -91,11 +93,14 @@ export function useProviderStatusRefresh(options: ProviderStatusRefreshOptions):
       lastRefreshAtMs = nowMs;
       void api.server
         .refreshProviders()
-        .then((result) => {
+        .then(async (result) => {
           if (disposed) {
             return;
           }
-          return writeProviderStatusesToConfigCache(queryClient, result.providers);
+          await writeProviderStatusesToConfigCache(queryClient, result.providers);
+          if (!disposed) {
+            onRefreshSuccess?.();
+          }
         })
         .catch(() => undefined);
     };
@@ -127,5 +132,13 @@ export function useProviderStatusRefresh(options: ProviderStatusRefreshOptions):
         document.removeEventListener("visibilitychange", refreshProviderStatuses);
       }
     };
-  }, [enabled, initialDelayMs, intervalMs, minIntervalMs, queryClient, refreshOnFocus]);
+  }, [
+    enabled,
+    initialDelayMs,
+    intervalMs,
+    minIntervalMs,
+    onRefreshSuccess,
+    queryClient,
+    refreshOnFocus,
+  ]);
 }

--- a/apps/web/src/hooks/useProviderStatusRefresh.ts
+++ b/apps/web/src/hooks/useProviderStatusRefresh.ts
@@ -77,46 +77,82 @@ export function useProviderStatusRefresh(options: ProviderStatusRefreshOptions):
     }
 
     let disposed = false;
-    let lastRefreshAtMs = 0;
-    const refreshProviderStatuses = () => {
+    let hasSuccessfulRefresh = false;
+    let startupRefreshPending = false;
+    let lastRefreshAttemptAtMs = 0;
+    let refreshInFlight: Promise<boolean> | null = null;
+    const refreshProviderStatuses = (input?: {
+      readonly ignoreMinInterval?: boolean;
+    }): Promise<boolean> => {
       if (document.visibilityState !== "visible") {
-        return;
+        return Promise.resolve(false);
+      }
+      if (refreshInFlight) {
+        return refreshInFlight;
       }
       const nowMs = Date.now();
-      if (minIntervalMs > 0 && nowMs - lastRefreshAtMs < minIntervalMs) {
-        return;
+      if (
+        input?.ignoreMinInterval !== true &&
+        minIntervalMs > 0 &&
+        nowMs - lastRefreshAttemptAtMs < minIntervalMs
+      ) {
+        return Promise.resolve(false);
       }
       const api = readNativeApi();
       if (!api) {
-        return;
+        return Promise.resolve(false);
       }
-      lastRefreshAtMs = nowMs;
-      void api.server
+      lastRefreshAttemptAtMs = nowMs;
+      const refresh = api.server
         .refreshProviders()
         .then(async (result) => {
           if (disposed) {
-            return;
+            return false;
           }
           await writeProviderStatusesToConfigCache(queryClient, result.providers);
           if (!disposed) {
+            hasSuccessfulRefresh = true;
+            startupRefreshPending = false;
             onRefreshSuccess?.();
           }
+          return true;
         })
-        .catch(() => undefined);
+        .catch(() => false)
+        .finally(() => {
+          refreshInFlight = null;
+        });
+      refreshInFlight = refresh;
+      return refresh;
+    };
+
+    const runInitialRefresh = async () => {
+      const existingRefresh = refreshInFlight;
+      if (existingRefresh) {
+        await existingRefresh;
+      }
+      if (disposed || hasSuccessfulRefresh) {
+        return;
+      }
+      startupRefreshPending = true;
+      // A failed early focus refresh must not consume the throttle window and
+      // suppress the one scheduled startup attempt.
+      await refreshProviderStatuses({ ignoreMinInterval: true });
     };
 
     const initialRefreshId =
       typeof initialDelayMs === "number" && initialDelayMs >= 0
-        ? window.setTimeout(refreshProviderStatuses, initialDelayMs)
+        ? window.setTimeout(() => void runInitialRefresh(), initialDelayMs)
         : null;
     const refreshIntervalId =
       typeof intervalMs === "number" && intervalMs > 0
-        ? window.setInterval(refreshProviderStatuses, intervalMs)
+        ? window.setInterval(() => void refreshProviderStatuses(), intervalMs)
         : null;
+    const refreshOnVisible = () =>
+      void refreshProviderStatuses({ ignoreMinInterval: startupRefreshPending });
 
     if (refreshOnFocus) {
-      window.addEventListener("focus", refreshProviderStatuses);
-      document.addEventListener("visibilitychange", refreshProviderStatuses);
+      window.addEventListener("focus", refreshOnVisible);
+      document.addEventListener("visibilitychange", refreshOnVisible);
     }
 
     return () => {
@@ -128,8 +164,8 @@ export function useProviderStatusRefresh(options: ProviderStatusRefreshOptions):
         window.clearInterval(refreshIntervalId);
       }
       if (refreshOnFocus) {
-        window.removeEventListener("focus", refreshProviderStatuses);
-        document.removeEventListener("visibilitychange", refreshProviderStatuses);
+        window.removeEventListener("focus", refreshOnVisible);
+        document.removeEventListener("visibilitychange", refreshOnVisible);
       }
     };
   }, [

--- a/apps/web/src/providerUpdates.test.ts
+++ b/apps/web/src/providerUpdates.test.ts
@@ -7,6 +7,7 @@ import type { ProviderKind, ServerProviderStatus, ServerSettings } from "@synara
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  getNotifiableProviderUpdateStatuses,
   getVisibleProviderUpdateStatuses,
   isProviderLatestVersionKnowable,
   isProviderUpdateActive,
@@ -146,6 +147,46 @@ describe("getVisibleProviderUpdateStatuses", () => {
         oneClickOnly: true,
       }).map((provider) => provider.provider),
     ).toEqual(["codex"]);
+  });
+});
+
+describe("getNotifiableProviderUpdateStatuses", () => {
+  it("suppresses cached update advisories until a live version check completes", () => {
+    const providers = [providerStatus("claudeAgent")];
+    const settings = serverSettings();
+
+    expect(
+      getNotifiableProviderUpdateStatuses({
+        providers,
+        serverSettings: settings,
+        liveVersionCheckCompleted: false,
+      }),
+    ).toEqual([]);
+    expect(
+      getNotifiableProviderUpdateStatuses({
+        providers,
+        serverSettings: settings,
+        liveVersionCheckCompleted: true,
+      }).map((provider) => provider.provider),
+    ).toEqual(["claudeAgent"]);
+  });
+
+  it("keeps notifications limited to one-click updates after verification", () => {
+    const manualOnly = providerStatus("claudeAgent", {
+      versionAdvisory: {
+        ...providerStatus("claudeAgent").versionAdvisory!,
+        updateCommand: null,
+        canUpdate: false,
+      },
+    });
+
+    expect(
+      getNotifiableProviderUpdateStatuses({
+        providers: [manualOnly],
+        serverSettings: serverSettings(),
+        liveVersionCheckCompleted: true,
+      }),
+    ).toEqual([]);
   });
 });
 

--- a/apps/web/src/providerUpdates.ts
+++ b/apps/web/src/providerUpdates.ts
@@ -143,6 +143,15 @@ export function getVisibleProviderUpdateStatuses(
   );
 }
 
+export function getNotifiableProviderUpdateStatuses(
+  input: ProviderUpdateFilterInput & { readonly liveVersionCheckCompleted: boolean },
+): ServerProviderStatus[] {
+  if (!input.liveVersionCheckCompleted) {
+    return [];
+  }
+  return getVisibleProviderUpdateStatuses({ ...input, oneClickOnly: true });
+}
+
 export function providerUpdateNotificationKey(
   providers: ReadonlyArray<ServerProviderStatus>,
 ): string | null {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -319,8 +319,13 @@ function ProviderStatusRefreshCoordinator() {
   const { settings } = useAppSettings();
   const serverSettingsQuery = useQuery(serverSettingsQueryOptions());
   const [transportOpen, setTransportOpen] = useState(false);
+  const [liveVersionCheckCompleted, setLiveVersionCheckCompleted] = useState(false);
   const providerUpdateChecksEnabled =
     serverSettingsQuery.data !== undefined && settings.enableProviderUpdateChecks;
+  const providerUpdateRefreshEnabled = providerUpdateChecksEnabled && transportOpen;
+  const markLiveVersionCheckCompleted = useCallback(() => {
+    setLiveVersionCheckCompleted(true);
+  }, []);
 
   // The update coordinator includes the same focus/visibility refresh. Keep the
   // auth-only loop for the setting-off case so enabling update checks never
@@ -328,29 +333,29 @@ function ProviderStatusRefreshCoordinator() {
   useProviderAuthRefreshOnFocus({ enabled: !providerUpdateChecksEnabled });
   useEffect(
     () =>
-      addWsTransportStateListener((state) => setTransportOpen(state === "open"), {
-        replayCurrent: true,
-      }),
+      addWsTransportStateListener(
+        (state) => {
+          const open = state === "open";
+          setTransportOpen(open);
+          if (!open) {
+            setLiveVersionCheckCompleted(false);
+          }
+        },
+        { replayCurrent: true },
+      ),
     [],
   );
 
-  // Unmounting across transport interruptions clears the live-check gate. When
-  // the socket reopens, a fresh coordinator schedules a new provider refresh
-  // before persisted server advisories are allowed to produce notifications.
-  return providerUpdateChecksEnabled && transportOpen ? (
-    <ProviderUpdateRefreshCoordinator />
-  ) : null;
-}
-
-function ProviderUpdateRefreshCoordinator() {
-  const [liveVersionCheckCompleted, setLiveVersionCheckCompleted] = useState(false);
-  const markLiveVersionCheckCompleted = useCallback(() => {
-    setLiveVersionCheckCompleted(true);
-  }, []);
+  useEffect(() => {
+    if (!providerUpdateChecksEnabled) {
+      setLiveVersionCheckCompleted(false);
+    }
+  }, [providerUpdateChecksEnabled]);
 
   // Provider latest-version checks are slow/network-backed, so keep this cadence
   // coarse while still honoring the automatic update-check setting.
   useProviderStatusRefresh({
+    enabled: providerUpdateRefreshEnabled,
     initialDelayMs: PROVIDER_UPDATE_INITIAL_REFRESH_DELAY_MS,
     intervalMs: PROVIDER_UPDATE_REFRESH_INTERVAL_MS,
     minIntervalMs: PROVIDER_AUTH_REFRESH_MIN_INTERVAL_MS,
@@ -358,7 +363,13 @@ function ProviderUpdateRefreshCoordinator() {
     onRefreshSuccess: markLiveVersionCheckCompleted,
   });
 
-  return <ProviderUpdateNotifications liveVersionCheckCompleted={liveVersionCheckCompleted} />;
+  // Keep the notifier mounted while the transport is interrupted. Dropping the
+  // gate makes it close any active prompt before a reconnect can reuse cached data.
+  return (
+    <ProviderUpdateNotifications
+      liveVersionCheckCompleted={providerUpdateRefreshEnabled && liveVersionCheckCompleted}
+    />
+  );
 }
 
 // Extracted to module scope so its run-always cleanup can stay a try/finally: the

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -18,7 +18,7 @@ import {
   useParams,
   useRouterState,
 } from "@tanstack/react-router";
-import { useMemo, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { QueryClient, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Throttler } from "@tanstack/react-pacer";
 
@@ -110,7 +110,7 @@ import { providerModelDiscoveryInvalidationFingerprint } from "../lib/providerDi
 import { providerDiscoveryQueryKeys } from "../lib/providerDiscoveryReactQuery";
 import { useAppSettings } from "../appSettings";
 import {
-  getVisibleProviderUpdateStatuses,
+  getNotifiableProviderUpdateStatuses,
   isProviderUpdateActive,
   providerUpdateNotificationKey,
   PROVIDER_UPDATE_INITIAL_REFRESH_DELAY_MS,
@@ -254,7 +254,6 @@ function RootRouteView() {
           <TaskCompletionNotifications />
           <AppSnapWelcomeDialog />
           <AppSnapCoordinator />
-          <ProviderUpdateNotifications />
           <DesktopProjectBootstrap />
           <Outlet />
         </AnchoredToastProvider>
@@ -316,19 +315,42 @@ function GitProgressToastPreviewDev() {
 function ProviderStatusRefreshCoordinator() {
   const { settings } = useAppSettings();
   const serverSettingsQuery = useQuery(serverSettingsQueryOptions());
+  const [transportOpen, setTransportOpen] = useState(false);
   const providerUpdateChecksEnabled =
     serverSettingsQuery.data !== undefined && settings.enableProviderUpdateChecks;
 
   useProviderAuthRefreshOnFocus();
+  useEffect(
+    () =>
+      addWsTransportStateListener((state) => setTransportOpen(state === "open"), {
+        replayCurrent: true,
+      }),
+    [],
+  );
+
+  // Unmounting across transport interruptions clears the live-check gate. When
+  // the socket reopens, a fresh coordinator schedules a new provider refresh
+  // before persisted server advisories are allowed to produce notifications.
+  return providerUpdateChecksEnabled && transportOpen ? (
+    <ProviderUpdateRefreshCoordinator />
+  ) : null;
+}
+
+function ProviderUpdateRefreshCoordinator() {
+  const [liveVersionCheckCompleted, setLiveVersionCheckCompleted] = useState(false);
+  const markLiveVersionCheckCompleted = useCallback(() => {
+    setLiveVersionCheckCompleted(true);
+  }, []);
+
   // Provider latest-version checks are slow/network-backed, so keep this cadence
   // coarse while still honoring the automatic update-check setting.
   useProviderStatusRefresh({
-    enabled: providerUpdateChecksEnabled,
     initialDelayMs: PROVIDER_UPDATE_INITIAL_REFRESH_DELAY_MS,
     intervalMs: PROVIDER_UPDATE_REFRESH_INTERVAL_MS,
+    onRefreshSuccess: markLiveVersionCheckCompleted,
   });
 
-  return null;
+  return <ProviderUpdateNotifications liveVersionCheckCompleted={liveVersionCheckCompleted} />;
 }
 
 // Extracted to module scope so its run-always cleanup can stay a try/finally: the
@@ -492,7 +514,11 @@ async function runProviderUpdateAll(params: {
   });
 }
 
-function ProviderUpdateNotifications() {
+function ProviderUpdateNotifications({
+  liveVersionCheckCompleted,
+}: {
+  readonly liveVersionCheckCompleted: boolean;
+}) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { settings } = useAppSettings();
@@ -508,11 +534,11 @@ function ProviderUpdateNotifications() {
   const activeToastRef = useRef<ActiveProviderUpdateToast | null>(null);
   const isUpdatingAllRef = useRef(false);
   const progressToastDismissedRef = useRef(false);
-  const outdatedProviders = getVisibleProviderUpdateStatuses({
+  const outdatedProviders = getNotifiableProviderUpdateStatuses({
     providers: serverConfigQuery.data?.providers ?? [],
     hiddenProviders: settings.hiddenProviders,
     serverSettings: providerUpdateServerSettings,
-    oneClickOnly: true,
+    liveVersionCheckCompleted,
   });
   const oneClickProviders = outdatedProviders.filter(
     (provider) => !isProviderUpdateActive(provider),

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -103,7 +103,10 @@ import { useNativeFontSmoothing } from "../hooks/useNativeFontSmoothing";
 import { invalidateGitQueries, invalidateGitQueriesForCwds } from "../lib/gitReactQuery";
 import { hasLiveThreadsWithMissingProjects } from "../lib/desktopProjectRecovery";
 import { useDiffRouteSearch } from "../hooks/useDiffRouteSearch";
-import { useProviderAuthRefreshOnFocus } from "../hooks/useProviderAuthRefreshOnFocus";
+import {
+  PROVIDER_AUTH_REFRESH_MIN_INTERVAL_MS,
+  useProviderAuthRefreshOnFocus,
+} from "../hooks/useProviderAuthRefreshOnFocus";
 import { useProviderStatusRefresh } from "../hooks/useProviderStatusRefresh";
 import { resolveSplitViewThreadIds, selectSplitView, useSplitViewStore } from "../splitViewStore";
 import { providerModelDiscoveryInvalidationFingerprint } from "../lib/providerDiscoveryInvalidation";
@@ -319,7 +322,10 @@ function ProviderStatusRefreshCoordinator() {
   const providerUpdateChecksEnabled =
     serverSettingsQuery.data !== undefined && settings.enableProviderUpdateChecks;
 
-  useProviderAuthRefreshOnFocus();
+  // The update coordinator includes the same focus/visibility refresh. Keep the
+  // auth-only loop for the setting-off case so enabling update checks never
+  // launches duplicate provider probes on focus.
+  useProviderAuthRefreshOnFocus({ enabled: !providerUpdateChecksEnabled });
   useEffect(
     () =>
       addWsTransportStateListener((state) => setTransportOpen(state === "open"), {
@@ -347,6 +353,8 @@ function ProviderUpdateRefreshCoordinator() {
   useProviderStatusRefresh({
     initialDelayMs: PROVIDER_UPDATE_INITIAL_REFRESH_DELAY_MS,
     intervalMs: PROVIDER_UPDATE_REFRESH_INTERVAL_MS,
+    minIntervalMs: PROVIDER_AUTH_REFRESH_MIN_INTERVAL_MS,
+    refreshOnFocus: true,
     onRefreshSuccess: markLiveVersionCheckCompleted,
   });
 


### PR DESCRIPTION
## Summary

- suppress global provider-update toasts until a live provider refresh succeeds, and reset that verification across transport reconnects
- let native Claude own its stable/latest channel instead of comparing it with npm's latest tag
- resolve Claude's `claude-code@latest` Homebrew cask from the installed binary path so checks and updates use the same channel
- keep notifications limited to actionable, one-click updates while preserving manual update actions in settings
- coalesce provider refreshes and guarantee startup retries across hidden tabs, early focus failures, and reconnects

## Verification

- `bun run --cwd apps/server test src/provider/providerMaintenance.test.ts src/provider/Layers/ProviderHealth.test.ts` (110 tests)
- `bun run --cwd apps/web test src/hooks/useProviderStatusRefresh.test.ts src/providerUpdates.test.ts src/wsTransportEvents.test.ts` (20 tests)
- `bun run --cwd apps/web build`
- `bun run --cwd apps/server build`
- `git diff --check`
- Cursor Bugbot reviewed commit `e2e4eddfd` and found no new issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider version comparison, update commands, and global notification timing; behavior is covered by new tests but affects user-visible update prompts.
> 
> **Overview**
> **Provider update notifications** no longer fire from cached “behind latest” state until a successful live `refreshProviders` run, and that verification resets when the WebSocket transport drops. The root coordinator avoids duplicate focus probes when update checks are on, and keeps the notifier mounted across reconnects.
> 
> **Server-side maintenance** treats native Claude as owning its release channel (`latestVersionSource: null`, `claude update`) instead of npm’s latest tag, and picks the `claude-code@latest` Homebrew cask when the resolved binary path is under that caskroom. Explicit Homebrew symlinks are resolved via `realPath` before variant selection. After a **transient CLI probe timeout**, usable provider status is still stabilized, but any prior **version advisory is cleared** so stale update hints do not linger.
> 
> **Web refresh hook** coalesces in-flight refreshes, retries scheduled startup after early focus failures or hidden tabs, and exposes an optional `onRefreshSuccess` / `enabled` on the focus helper. Sidebar thread rows use inline rename/context handlers (dropping the gesture helper) so React Compiler bailouts on `Sidebar.tsx` can be removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 352c2fc2ab3bab545ecab15b1fa62cf718443a02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->