### PR TITLE
Fix foreground task completion notifications

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1769,12 +1769,16 @@ function showDesktopNotification(input: {
   title: string;
   body?: string;
   silent?: boolean;
+  suppressWhenForeground?: boolean;
   threadId?: string;
 }): boolean {
   const title = typeof input.title === "string" ? input.title.trim() : "";
   const body = typeof input.body === "string" ? input.body.trim() : "";
   const threadId = typeof input.threadId === "string" ? input.threadId.trim() : "";
   if (title.length === 0 || !Notification.isSupported()) {
+    return false;
+  }
+  if (input.suppressWhenForeground === true && isMainWindowForeground(mainWindow)) {
     return false;
   }
 
@@ -3806,6 +3810,7 @@ function registerIpcHandlers(): void {
             title?: unknown;
             body?: unknown;
             silent?: unknown;
+            suppressWhenForeground?: unknown;
             threadId?: unknown;
           }
         | null
@@ -3815,6 +3820,7 @@ function registerIpcHandlers(): void {
         title: typeof input?.title === "string" ? input.title : "",
         body: typeof input?.body === "string" ? input.body : "",
         silent: input?.silent === true,
+        suppressWhenForeground: input?.suppressWhenForeground === true,
         ...(typeof input?.threadId === "string" ? { threadId: input.threadId } : {}),
       }),
   );

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -27,6 +27,7 @@ import {
 } from "./notificationSurface";
 import { useDiffRouteSearch } from "../../hooks/useDiffRouteSearch";
 import { selectSplitView, useSplitViewStore } from "../../splitViewStore";
+import { selectRightDockState, useRightDockStore } from "../../rightDockStore";
 import {
   resolveVisibleToastThreadIds,
   shouldRenderToastForVisibleThreads,
@@ -125,8 +126,11 @@ function useVisibleThreadIdsFromRoute(): ReadonlySet<ThreadId> {
   const splitView = useSplitViewStore(
     useMemo(() => selectSplitView(routeSearch.splitViewId ?? null), [routeSearch.splitViewId]),
   );
+  const rightDockState = useRightDockStore(
+    useMemo(() => selectRightDockState(activeThreadId), [activeThreadId]),
+  );
 
-  return resolveVisibleToastThreadIds({ activeThreadId, splitView });
+  return resolveVisibleToastThreadIds({ activeThreadId, splitView, rightDockState });
 }
 
 function ThreadToastVisibleAutoDismiss({

--- a/apps/web/src/components/ui/toastRouteVisibility.test.ts
+++ b/apps/web/src/components/ui/toastRouteVisibility.test.ts
@@ -10,6 +10,7 @@ import type { SplitView } from "../../splitViewStore";
 const PROJECT_ID = ProjectId.makeUnsafe("project-1");
 const THREAD_A = ThreadId.makeUnsafe("thread-a");
 const THREAD_B = ThreadId.makeUnsafe("thread-b");
+const THREAD_C = ThreadId.makeUnsafe("thread-c");
 
 function createSplitView(): SplitView {
   const firstLeaf = {
@@ -69,6 +70,87 @@ describe("resolveVisibleToastThreadIds", () => {
       resolveVisibleToastThreadIds({
         activeThreadId: THREAD_A,
         splitView: createSplitView(),
+      }),
+    ).toEqual(new Set([THREAD_A, THREAD_B]));
+  });
+
+  it("includes the active sidechat when its host dock is visible", () => {
+    expect(
+      resolveVisibleToastThreadIds({
+        activeThreadId: THREAD_A,
+        splitView: null,
+        rightDockState: {
+          open: true,
+          activePaneId: "sidechat-pane",
+          panes: [
+            {
+              id: "sidechat-pane",
+              kind: "sidechat",
+              threadId: THREAD_B,
+              diffTurnId: null,
+              diffFilePath: null,
+              filePath: null,
+              pullRequestProjectId: null,
+              pullRequestRepository: null,
+              pullRequestNumber: null,
+              pullRequestInitialTab: null,
+            },
+          ],
+        },
+      }),
+    ).toEqual(new Set([THREAD_A, THREAD_B]));
+  });
+
+  it("does not treat hidden or inactive sidechat panes as visible", () => {
+    expect(
+      resolveVisibleToastThreadIds({
+        activeThreadId: THREAD_A,
+        splitView: null,
+        rightDockState: {
+          open: false,
+          activePaneId: "sidechat-pane",
+          panes: [
+            {
+              id: "sidechat-pane",
+              kind: "sidechat",
+              threadId: THREAD_B,
+              diffTurnId: null,
+              diffFilePath: null,
+              filePath: null,
+              pullRequestProjectId: null,
+              pullRequestRepository: null,
+              pullRequestNumber: null,
+              pullRequestInitialTab: null,
+            },
+          ],
+        },
+      }),
+    ).toEqual(new Set([THREAD_A]));
+  });
+
+  it("ignores persisted dock state while the route is rendering a split", () => {
+    expect(
+      resolveVisibleToastThreadIds({
+        activeThreadId: THREAD_A,
+        splitView: createSplitView(),
+        rightDockState: {
+          open: true,
+          activePaneId: "sidechat-pane",
+          panes: [
+            {
+              id: "sidechat-pane",
+              kind: "sidechat",
+              threadId: THREAD_C,
+              diffTurnId: null,
+              diffFilePath: null,
+              filePath: null,
+              pullRequestProjectId: null,
+              pullRequestRepository: null,
+              pullRequestNumber: null,
+              pullRequestInitialTab: null,
+            },
+          ],
+        },
       }),
     ).toEqual(new Set([THREAD_A, THREAD_B]));
   });

--- a/apps/web/src/components/ui/toastRouteVisibility.ts
+++ b/apps/web/src/components/ui/toastRouteVisibility.ts
@@ -5,15 +5,29 @@
 
 import type { ThreadId } from "@synara/contracts";
 import { resolveSplitViewThreadIds, type SplitView } from "../../splitViewStore";
+import type { RightDockThreadState } from "../../rightDockStore.logic";
 
 export function resolveVisibleToastThreadIds(input: {
   activeThreadId: ThreadId | null;
   splitView: SplitView | null;
+  rightDockState?: RightDockThreadState | null;
 }): ReadonlySet<ThreadId> {
-  if (input.splitView) {
-    return new Set(resolveSplitViewThreadIds(input.splitView));
+  const visibleThreadIds = input.splitView
+    ? new Set(resolveSplitViewThreadIds(input.splitView))
+    : input.activeThreadId
+      ? new Set([input.activeThreadId])
+      : new Set<ThreadId>();
+
+  if (!input.splitView && input.rightDockState?.open) {
+    const activePane = input.rightDockState.panes.find(
+      (pane) => pane.id === input.rightDockState?.activePaneId,
+    );
+    if (activePane?.kind === "sidechat" && activePane.threadId) {
+      visibleThreadIds.add(activePane.threadId);
+    }
   }
-  return input.activeThreadId ? new Set([input.activeThreadId]) : new Set<ThreadId>();
+
+  return visibleThreadIds;
 }
 
 export function shouldRenderToastForVisibleThreads(input: {

--- a/apps/web/src/notifications/taskCompletion.logic.test.ts
+++ b/apps/web/src/notifications/taskCompletion.logic.test.ts
@@ -123,15 +123,15 @@ function buildCollectedTaskCompletionCopy(assistantText: string) {
 
 describe("shouldAttemptSystemTaskNotification", () => {
   it("only attempts enabled notifications while the window is in the background", () => {
-    expect(
-      shouldAttemptSystemTaskNotification({ enabled: true, isWindowForeground: false }),
-    ).toBe(true);
-    expect(
-      shouldAttemptSystemTaskNotification({ enabled: true, isWindowForeground: true }),
-    ).toBe(false);
-    expect(
-      shouldAttemptSystemTaskNotification({ enabled: false, isWindowForeground: false }),
-    ).toBe(false);
+    expect(shouldAttemptSystemTaskNotification({ enabled: true, isWindowForeground: false })).toBe(
+      true,
+    );
+    expect(shouldAttemptSystemTaskNotification({ enabled: true, isWindowForeground: true })).toBe(
+      false,
+    );
+    expect(shouldAttemptSystemTaskNotification({ enabled: false, isWindowForeground: false })).toBe(
+      false,
+    );
   });
 });
 

--- a/apps/web/src/notifications/taskCompletion.logic.test.ts
+++ b/apps/web/src/notifications/taskCompletion.logic.test.ts
@@ -15,6 +15,7 @@ import {
   collectInputNeededThreadCandidates,
   completedThreadNotificationKey,
   isNotificationRuntimeFreshTimestamp,
+  shouldAttemptSystemTaskNotification,
   shouldShowThreadNotificationToast,
 } from "./taskCompletion.logic";
 import type { Thread } from "../types";
@@ -119,6 +120,20 @@ function buildCollectedTaskCompletionCopy(assistantText: string) {
   }
   return buildTaskCompletionCopy(candidate);
 }
+
+describe("shouldAttemptSystemTaskNotification", () => {
+  it("only attempts enabled notifications while the window is in the background", () => {
+    expect(
+      shouldAttemptSystemTaskNotification({ enabled: true, isWindowForeground: false }),
+    ).toBe(true);
+    expect(
+      shouldAttemptSystemTaskNotification({ enabled: true, isWindowForeground: true }),
+    ).toBe(false);
+    expect(
+      shouldAttemptSystemTaskNotification({ enabled: false, isWindowForeground: false }),
+    ).toBe(false);
+  });
+});
 
 describe("collectCompletedThreadCandidates", () => {
   it("returns threads that moved from working to completed", () => {

--- a/apps/web/src/notifications/taskCompletion.logic.ts
+++ b/apps/web/src/notifications/taskCompletion.logic.ts
@@ -69,6 +69,13 @@ export function shouldShowThreadNotificationToast(input: {
   return !input.visibleThreadIds.has(input.threadId);
 }
 
+export function shouldAttemptSystemTaskNotification(input: {
+  enabled: boolean;
+  isWindowForeground: boolean;
+}): boolean {
+  return input.enabled && !input.isWindowForeground;
+}
+
 // Treat sidebar "working" states as the only notification-worthy starting point.
 function isRunningStatus(status: ThreadSessionStatus | null | undefined): boolean {
   return status === "running" || status === "connecting";

--- a/apps/web/src/notifications/taskCompletion.tsx
+++ b/apps/web/src/notifications/taskCompletion.tsx
@@ -100,7 +100,13 @@ async function showSystemThreadNotification(
     if (!supported) {
       return false;
     }
-    return window.desktopBridge.notifications.show({ title, body, silent: false, threadId });
+    return window.desktopBridge.notifications.show({
+      title,
+      body,
+      silent: false,
+      suppressWhenForeground: true,
+      threadId,
+    });
   }
 
   if (readBrowserNotificationPermissionState() !== "granted") {

--- a/apps/web/src/notifications/taskCompletion.tsx
+++ b/apps/web/src/notifications/taskCompletion.tsx
@@ -12,6 +12,7 @@ import { useAppSettings } from "../appSettings";
 import { isElectron } from "../env";
 import { useDiffRouteSearch } from "../hooks/useDiffRouteSearch";
 import { selectSplitView, useSplitViewStore } from "../splitViewStore";
+import { selectRightDockState, useRightDockStore } from "../rightDockStore";
 import { useStore } from "../store";
 import { createAllThreadsSelector } from "../storeSelectors";
 import { useTerminalStateStore } from "../terminalStateStore";
@@ -27,6 +28,7 @@ import {
   collectInputNeededThreadCandidates,
   collectTerminalAttentionCandidates,
   isNotificationRuntimeFreshTimestamp,
+  shouldAttemptSystemTaskNotification,
   shouldShowThreadNotificationToast,
 } from "./taskCompletion.logic";
 
@@ -153,11 +155,18 @@ export function TaskCompletionNotifications() {
   const splitView = useSplitViewStore(
     useMemo(() => selectSplitView(routeSearch.splitViewId ?? null), [routeSearch.splitViewId]),
   );
+  const rightDockState = useRightDockStore(
+    useMemo(() => selectRightDockState(activeThreadId), [activeThreadId]),
+  );
   const [allThreadsSelector] = useState(() => createAllThreadsSelector());
   const threads = useStore(allThreadsSelector);
   const threadsHydrated = useStore((store) => store.threadsHydrated);
   const terminalStateByThreadId = useTerminalStateStore((store) => store.terminalStateByThreadId);
-  const visibleThreadIds = resolveVisibleToastThreadIds({ activeThreadId, splitView });
+  const visibleThreadIds = resolveVisibleToastThreadIds({
+    activeThreadId,
+    splitView,
+    rightDockState,
+  });
   const previousThreadsRef = useRef<readonly Thread[]>([]);
   const previousTerminalStateRef = useRef(terminalStateByThreadId);
   // Lazy state init: evaluated once, keeping the impure Date.now() call out
@@ -235,9 +244,10 @@ export function TaskCompletionNotifications() {
       return;
     }
 
-    const shouldAttemptSystemNotification =
-      settings.enableSystemTaskCompletionNotifications &&
-      (window.desktopBridge ? true : !isWindowForeground());
+    const shouldAttemptSystemNotification = shouldAttemptSystemTaskNotification({
+      enabled: settings.enableSystemTaskCompletionNotifications,
+      isWindowForeground: isWindowForeground(),
+    });
 
     for (const completion of completions) {
       notifiedCompletionKeysRef.current.add(completedThreadNotificationKey(completion));

--- a/apps/web/src/rightDockStore.ts
+++ b/apps/web/src/rightDockStore.ts
@@ -129,8 +129,9 @@ export const useRightDockStore = create<RightDockStore>()(
   ),
 );
 
-export function selectRightDockState(threadId: ThreadId) {
+export function selectRightDockState(threadId: ThreadId | null) {
   // Keep the fallback snapshot stable so React does not observe phantom store
   // changes while mounting a thread that has no persisted dock state yet.
-  return (store: RightDockStore) => store.dockStateByThreadId[threadId] ?? DEFAULT_RIGHT_DOCK_STATE;
+  return (store: RightDockStore) =>
+    (threadId ? store.dockStateByThreadId[threadId] : undefined) ?? DEFAULT_RIGHT_DOCK_STATE;
 }

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -461,6 +461,7 @@ export interface DesktopNotificationInput {
   title: string;
   body?: string;
   silent?: boolean;
+  suppressWhenForeground?: boolean;
   threadId?: ThreadId;
 }
 

--- a/packages/shared/src/pendingInteractions.test.ts
+++ b/packages/shared/src/pendingInteractions.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   isPendingInteractionResponseClaimable,
   respondingInteractionReclaimCutoff,
-} from "./pendingInteractions.ts";
+} from "./pendingInteractions";
 
 describe("pending interaction response claims", () => {
   it.each(["pending", "retryable", "uncertain"] as const)(

--- a/packages/shared/src/pendingInteractions.ts
+++ b/packages/shared/src/pendingInteractions.ts
@@ -19,11 +19,7 @@ export function isPendingInteractionResponseClaimable(input: {
   readonly responseRequestedAt: string | null;
   readonly requestedAt: string;
 }): boolean {
-  if (
-    input.status === "pending" ||
-    input.status === "retryable" ||
-    input.status === "uncertain"
-  ) {
+  if (input.status === "pending" || input.status === "retryable" || input.status === "uncertain") {
     return true;
   }
   if (input.status !== "responding") {


### PR DESCRIPTION
## Summary
- suppress OS task-completion notifications whenever Synara is in the foreground, including Electron
- treat the active sidechat in the visible right dock as visible for toast suppression
- ignore a persisted right-dock selection while split view is active

## Root cause
Completion visibility was inferred from browser visibility alone and route matching did not account for the sidechat singleton dock or an active split view.

## Verification
- `bun run --cwd apps/web test src/notifications/taskCompletion.logic.test.ts src/components/ui/toastRouteVisibility.test.ts` — 64 tests passed
- `bun run --cwd apps/web build` — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Notification and toast-suppression behavior only; no auth, data, or persistence changes beyond existing dock selectors.
> 
> **Overview**
> Fixes **foreground task-completion notifications** and **toast visibility** when the main thread, split view, or right-dock sidechat is on screen.
> 
> **OS notifications** now run only when system task notifications are enabled **and** the window is in the background (`shouldAttemptSystemTaskNotification`), including Electron (previously desktop always attempted OS alerts). Electron passes **`suppressWhenForeground`** so the main process skips native notifications when the main window is focused.
> 
> **In-app toasts** treat an **open right dock** with an active **sidechat** pane as a visible thread (alongside split-view panes). **Persisted dock state is ignored while a split view is active** so a stale sidechat selection does not hide toasts for the split layout.
> 
> `selectRightDockState` accepts a **null** thread id for routes without an active thread. Contracts add **`suppressWhenForeground`** to `DesktopNotificationInput`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24f9a5e1d9390a111790107303762ed48309e932. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
