### PR TITLE
Stabilize and simplify side chats

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -361,6 +361,7 @@ import {
   ComposerPickerMenuSubPopup,
 } from "./chat/ComposerPickerMenuPopup";
 import { selectSplitView, useSplitViewStore } from "../splitViewStore";
+import { useRightDockStore } from "../rightDockStore";
 import { THREAD_DRAG_MIME } from "./chat-drop-overlay/ChatPaneDropOverlay";
 import { useTemporaryThreadStore } from "../temporaryThreadStore";
 import { useThreadActivationController } from "../hooks/useThreadActivationController";
@@ -1500,6 +1501,7 @@ export default function Sidebar() {
   }, []);
   const createSplitViewFromDrop = useSplitViewStore((store) => store.createFromDrop);
   const setSplitFocusedPane = useSplitViewStore((store) => store.setFocusedPane);
+  const openRightDockPane = useRightDockStore((store) => store.openPane);
   // Query defaults are applied after destructuring: a default inside the destructuring
   // pattern makes React Compiler bail out on the whole Sidebar component.
   const keybindingsQuery = useQuery({
@@ -3216,13 +3218,10 @@ export default function Sidebar() {
     clearSelection,
     navigate,
     openChatThreadPage,
-    openSidechatSplit: ({ sourceThreadId, ownerProjectId, sidechatThreadId }) =>
-      createSplitViewFromDrop({
-        sourceThreadId,
-        ownerProjectId,
-        droppedThreadId: sidechatThreadId,
-        direction: "horizontal",
-        side: "second",
+    openSidechatDock: ({ sourceThreadId, sidechatThreadId }) =>
+      openRightDockPane(sourceThreadId, {
+        kind: "sidechat",
+        threadId: sidechatThreadId,
       }),
     openTerminalThreadPage,
     prewarmThreadDetailForIntent,

--- a/apps/web/src/components/chat/SingleChatSurface.tsx
+++ b/apps/web/src/components/chat/SingleChatSurface.tsx
@@ -12,6 +12,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 
 import { useAppSettings } from "../../appSettings";
@@ -43,6 +44,12 @@ import { canComposerHandlePanelWidth } from "../../lib/panelResize";
 import { projectListDirectoriesQueryOptions } from "../../lib/projectReactQuery";
 import { getSidechatCreator } from "../../lib/sidechatCreatorRegistry";
 import {
+  clearSidechatPaneRetention,
+  getSidechatPaneRetentionVersion,
+  sidechatPaneRetentionRemainingMs,
+  subscribeSidechatPaneRetention,
+} from "../../lib/sidechatCreation";
+import {
   prefetchWorkspaceFile,
   resolveDockFileOpenTarget,
   resolveWorkspaceFileOpenTarget,
@@ -52,6 +59,7 @@ import {
 import { selectRightDockState, useRightDockStore } from "../../rightDockStore";
 import {
   resolveActivePane,
+  findMissingSidechatPaneIds,
   type RightDockPane,
   type RightDockPaneKind,
 } from "../../rightDockStore.logic";
@@ -220,6 +228,7 @@ export function SingleChatSurface(props: {
   });
   const availableDockPaneKinds = dockLauncherItems.map(({ kind }) => kind);
   const projects = useStore((store) => store.projects);
+  const threadsHydrated = useStore((store) => store.threadsHydrated);
   const { settings: appSettings } = useAppSettings();
   const { handleNewThread } = useHandleNewThread();
   const queryClient = useQueryClient();
@@ -565,6 +574,62 @@ export function SingleChatSurface(props: {
   // selector, which re-emits on every streaming token of any thread and would
   // otherwise re-render the entire chat surface + right dock + active pane.
   const threadSummaries = useStore(useMemo(() => createSidebarThreadSummariesSelector(), []));
+  const sidechatPaneRetentionVersion = useSyncExternalStore(
+    subscribeSidechatPaneRetention,
+    getSidechatPaneRetentionVersion,
+    getSidechatPaneRetentionVersion,
+  );
+  useEffect(() => {
+    if (!threadsHydrated) {
+      return;
+    }
+    const existingThreadIds = new Set(threadSummaries.map((thread) => thread.id));
+    for (const pane of dockState.panes) {
+      if (pane.kind === "sidechat" && pane.threadId && existingThreadIds.has(pane.threadId)) {
+        clearSidechatPaneRetention(pane.threadId);
+      }
+    }
+    const missingPaneIds = findMissingSidechatPaneIds(dockState, existingThreadIds);
+    if (missingPaneIds.length === 0) {
+      return;
+    }
+
+    const timerIds: number[] = [];
+    for (const paneId of missingPaneIds) {
+      const pane = dockState.panes.find((candidate) => candidate.id === paneId);
+      const remainingGraceMs = pane?.threadId ? sidechatPaneRetentionRemainingMs(pane.threadId) : 0;
+      if (remainingGraceMs === null) {
+        continue;
+      }
+      if (remainingGraceMs <= 0) {
+        if (pane?.threadId) {
+          clearSidechatPaneRetention(pane.threadId);
+        }
+        closePane(props.threadId, paneId);
+        continue;
+      }
+      timerIds.push(
+        window.setTimeout(() => {
+          if (pane?.threadId) {
+            clearSidechatPaneRetention(pane.threadId);
+          }
+          closePane(props.threadId, paneId);
+        }, remainingGraceMs),
+      );
+    }
+    return () => {
+      for (const timerId of timerIds) {
+        window.clearTimeout(timerId);
+      }
+    };
+  }, [
+    closePane,
+    dockState,
+    props.threadId,
+    sidechatPaneRetentionVersion,
+    threadSummaries,
+    threadsHydrated,
+  ]);
   const editorProjectOptions = projects.flatMap((project) =>
     project.kind === "project" ? [{ id: project.id, name: project.name }] : [],
   );
@@ -608,7 +673,6 @@ export function SingleChatSurface(props: {
       });
     });
   };
-  const hasSidechatPane = dockState.panes.some((pane) => pane.kind === "sidechat");
   const hasNamedFilePane = dockState.panes.some(
     (pane) => pane.kind === "file" && pane.filePath !== null,
   );
@@ -616,15 +680,10 @@ export function SingleChatSurface(props: {
     (pane) => pane.kind === "pullRequest" && pane.pullRequestNumber !== null,
   );
   let paneLabelOverrides: Record<string, string | undefined> | undefined;
-  if (hasSidechatPane || hasNamedFilePane || hasNumberedPullRequestPane) {
-    const titleByThreadId = hasSidechatPane
-      ? new Map(threadSummaries.map((summary) => [summary.id, summary.title]))
-      : null;
+  if (hasNamedFilePane || hasNumberedPullRequestPane) {
     const overrides: Record<string, string | undefined> = {};
     for (const pane of dockState.panes) {
-      if (pane.kind === "sidechat" && pane.threadId) {
-        overrides[pane.id] = titleByThreadId?.get(pane.threadId) || "Side";
-      } else if (pane.kind === "file" && pane.filePath) {
+      if (pane.kind === "file" && pane.filePath) {
         overrides[pane.id] = basenameOfPath(pane.filePath);
       } else if (pane.kind === "pullRequest" && pane.pullRequestNumber !== null) {
         overrides[pane.id] = pullRequestPaneTabLabel(pane.pullRequestNumber);
@@ -774,6 +833,9 @@ export function SingleChatSurface(props: {
       case "sidechat":
         if (!pane.threadId) {
           return <RightDockPanePlaceholder kind="sidechat" />;
+        }
+        if (!threadSummaries.some((thread) => thread.id === pane.threadId)) {
+          return <PanelStateMessage>Loading side chat...</PanelStateMessage>;
         }
         if (context.runtimeMode === "preview") {
           return null;

--- a/apps/web/src/components/chat/rightDockPaneMeta.test.ts
+++ b/apps/web/src/components/chat/rightDockPaneMeta.test.ts
@@ -38,7 +38,7 @@ describe("resolveRightDockLauncherItems", () => {
       ["terminal", "Terminal"],
       ["browser", "Browser"],
       ["explorer", "Files"],
-      ["sidechat", "Side chat"],
+      ["sidechat", "Side chats"],
     ]);
   });
 

--- a/apps/web/src/components/chat/rightDockPaneMeta.tsx
+++ b/apps/web/src/components/chat/rightDockPaneMeta.tsx
@@ -40,7 +40,7 @@ export const RIGHT_DOCK_PANE_META: Record<RightDockPaneKind, RightDockPaneMeta> 
   explorer: { label: "Explorer", Icon: FoldersIcon },
   file: { label: "File", Icon: FileIcon },
   terminal: { label: "Terminal", Icon: TerminalIcon },
-  sidechat: { label: "Side", Icon: MessageCircleIcon },
+  sidechat: { label: "Side chats", Icon: MessageCircleIcon },
   git: { label: "Git", Icon: GitCommitIcon },
   pullRequest: { label: "Pull request", Icon: GitPullRequestIcon },
 };
@@ -84,7 +84,7 @@ const RIGHT_DOCK_LAUNCHER_ORDER: readonly RightDockPaneKind[] = [
 const RIGHT_DOCK_LAUNCHER_LABELS: Partial<Record<RightDockPaneKind, string>> = {
   diff: "Review",
   explorer: "Files",
-  sidechat: "Side chat",
+  sidechat: "Side chats",
   git: "Source control",
 };
 

--- a/apps/web/src/hooks/useComposerSlashCommands.ts
+++ b/apps/web/src/hooks/useComposerSlashCommands.ts
@@ -8,9 +8,8 @@ import {
   type RuntimeMode,
   type ThreadId,
 } from "@synara/contracts";
-import { buildPromptThreadTitleFallback } from "@synara/shared/chatThreads";
 import { deriveAssociatedWorktreeMetadata } from "@synara/shared/threadWorkspace";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { newCommandId, newMessageId, newThreadId } from "../lib/utils";
 import { readNativeApi } from "../nativeApi";
 import type { Project, Thread } from "../types";
@@ -37,6 +36,12 @@ import { registerSidechatCreator } from "../lib/sidechatCreatorRegistry";
 import { downloadUrlAsBlob } from "../lib/browserDownload";
 import { resolveWsHttpUrl } from "../lib/wsHttpUrl";
 import { useFeedbackDialogStore } from "../feedbackDialogStore";
+import {
+  createOrJoinSidechat,
+  createSidechatThread,
+  sendSidechatPrompt,
+  type SidechatCreationFlight,
+} from "../lib/sidechatCreation";
 
 type ComposerSnapshot = {
   value: string;
@@ -303,95 +308,87 @@ export function useComposerSlashCommands(input: {
     ],
   );
 
+  const sidechatCreationBySourceThreadIdRef = useRef(new Map<ThreadId, SidechatCreationFlight>());
   const createSidechatFromSlashCommand = useCallback(
-    async (inputOptions?: { initialPrompt?: string }) => {
+    (inputOptions?: { initialPrompt?: string }): Promise<true> => {
       const api = readNativeApi();
-      if (!api || !activeProject || !activeThread || !isServerThread || !canOfferSideCommand) {
+      if (
+        !api ||
+        !activeProject ||
+        !activeThread ||
+        !isServerThread ||
+        activeThread.sidechatSourceThreadId
+      ) {
         toastManager.add({
           type: "warning",
           title: "Side is unavailable",
           description: "Open a server-backed main thread before starting Side.",
         });
-        return true;
+        return Promise.resolve(true);
       }
 
-      const importedMessages = buildThreadHandoffImportedMessages(activeThread);
-      const nextThreadId = newThreadId();
-      const createdAt = new Date().toISOString();
-      const initialPrompt = inputOptions?.initialPrompt?.trim() ?? "";
-      const titleSeed =
-        initialPrompt.length > 0
-          ? buildPromptThreadTitleFallback(initialPrompt)
-          : activeThread.title;
-
-      await api.orchestration.dispatchCommand({
-        type: "thread.fork.create",
-        commandId: newCommandId(),
-        threadId: nextThreadId,
+      return createOrJoinSidechat({
+        inFlightBySourceThreadId: sidechatCreationBySourceThreadIdRef.current,
         sourceThreadId: activeThread.id,
-        sidechatSourceThreadId: activeThread.id,
-        projectId: activeProject.id,
-        title: `Sidechat: ${titleSeed}`,
-        modelSelection: selectedModelSelection,
-        runtimeMode: "approval-required",
-        interactionMode: "default",
-        envMode: activeThread.envMode ?? (activeThread.worktreePath ? "worktree" : "local"),
-        branch: activeThread.branch,
-        worktreePath: activeThread.worktreePath,
-        workingDirectory: activeThread.workingDirectory ?? null,
-        associatedWorktreePath: activeThread.associatedWorktreePath ?? null,
-        associatedWorktreeBranch: activeThread.associatedWorktreeBranch ?? null,
-        associatedWorktreeRef: activeThread.associatedWorktreeRef ?? null,
-        importedMessages: [...importedMessages],
-        createdAt,
+        initialPrompt: inputOptions?.initialPrompt,
+        startCreation: (initialPrompt) =>
+          createSidechatThread({
+            api,
+            project: activeProject,
+            sourceThread: activeThread,
+            selectedModelSelection,
+            initialPrompt,
+            openSidechat: (sidechatThreadId) => {
+              useRightDockStore.getState().openPane(activeThread.id, {
+                kind: "sidechat",
+                threadId: sidechatThreadId,
+              });
+            },
+            syncServerShellSnapshot,
+          }),
+        sendQueuedPrompt: (sidechatThreadId, prompt) =>
+          sendSidechatPrompt({
+            api,
+            threadId: sidechatThreadId,
+            selectedModelSelection,
+            prompt,
+          }),
+        onCreationResult: (result) => {
+          if (result.promptError) {
+            toastManager.add({
+              type: "warning",
+              title: "Side chat started without the prompt",
+              description: "The side chat is open. Send the prompt again when it finishes loading.",
+            });
+          } else if (result.snapshotError) {
+            toastManager.add({
+              type: "warning",
+              title: "Side chat is still syncing",
+              description:
+                "The fork succeeded and will appear as soon as the thread list refreshes.",
+            });
+          }
+        },
+        onQueuedPromptError: () => {
+          toastManager.add({
+            type: "warning",
+            title: "Side chat prompt was not sent",
+            description: "The side chat is open. Send the prompt again when it finishes loading.",
+          });
+        },
       });
-
-      if (initialPrompt.length > 0) {
-        await api.orchestration.dispatchCommand({
-          type: "thread.turn.start",
-          commandId: newCommandId(),
-          threadId: nextThreadId,
-          message: {
-            messageId: newMessageId(),
-            role: "user",
-            text: initialPrompt,
-            attachments: [],
-          },
-          modelSelection: selectedModelSelection,
-          runtimeMode: "approval-required",
-          interactionMode: "default",
-          createdAt: new Date().toISOString(),
-        });
-      }
-
-      const snapshot = await api.orchestration.getShellSnapshot();
-      syncServerShellSnapshot(snapshot);
-      // Side chats now live as a tab in the host thread's right dock instead of a
-      // split-view pane, so the user stays on the main conversation.
-      useRightDockStore.getState().openPane(activeThread.id, {
-        kind: "sidechat",
-        threadId: nextThreadId,
-      });
-      return true;
     },
-    [
-      activeProject,
-      activeThread,
-      canOfferSideCommand,
-      isServerThread,
-      selectedModelSelection,
-      syncServerShellSnapshot,
-    ],
+    [activeProject, activeThread, isServerThread, selectedModelSelection, syncServerShellSnapshot],
   );
 
-  // Publish the host thread's sidechat creator so the right-dock "+" button can start
-  // a sidechat using the exact same flow (and model selection) as typing /side.
+  // Publish a stable host capability. Composer drafts, attachments, and modes only
+  // affect whether `/side` is offered; they must not make the dock action disappear.
   useEffect(() => {
-    if (!canOfferSideCommand) {
+    if (!activeProject || !activeThread || !isServerThread || activeThread.sidechatSourceThreadId) {
       return;
     }
     return registerSidechatCreator(threadId, createSidechatFromSlashCommand);
-  }, [canOfferSideCommand, createSidechatFromSlashCommand, threadId]);
+  }, [activeProject, activeThread, createSidechatFromSlashCommand, isServerThread, threadId]);
 
   const runCodexReviewStart = useCallback(
     async (target: "changes" | "base-branch") => {
@@ -755,6 +752,14 @@ export function useComposerSlashCommands(input: {
         return true;
       }
       if (slashInvocation.command === "side") {
+        if (!canOfferSideCommand) {
+          toastManager.add({
+            type: "warning",
+            title: "Side is unavailable",
+            description: "Remove composer attachments or context before using /side.",
+          });
+          return true;
+        }
         try {
           editorActions.clearComposerSlashDraft();
           await createSidechatFromSlashCommand({ initialPrompt: slashInvocation.args });
@@ -772,6 +777,7 @@ export function useComposerSlashCommands(input: {
     },
     [
       availableBuiltInSlashCommands,
+      canOfferSideCommand,
       checkClaudeFastSlashCommandAvailability,
       compactProviderThread,
       createForkThreadFromSlashCommand,

--- a/apps/web/src/hooks/useThreadActivationController.test.ts
+++ b/apps/web/src/hooks/useThreadActivationController.test.ts
@@ -52,7 +52,7 @@ function makeControllerInput(
   navigate: ReturnType<typeof vi.fn>;
   clearSelection: ReturnType<typeof vi.fn>;
   openChatThreadPage: ReturnType<typeof vi.fn>;
-  openSidechatSplit: ReturnType<typeof vi.fn>;
+  openSidechatDock: ReturnType<typeof vi.fn>;
   openTerminalThreadPage: ReturnType<typeof vi.fn>;
   prewarmThreadDetailForIntent: ReturnType<typeof vi.fn>;
   rememberLastThreadRouteNow: ReturnType<typeof vi.fn>;
@@ -65,7 +65,7 @@ function makeControllerInput(
     clearSelection: vi.fn(),
     navigate: vi.fn(),
     openChatThreadPage: vi.fn(),
-    openSidechatSplit: vi.fn(() => "split-sidechat"),
+    openSidechatDock: vi.fn(),
     openTerminalThreadPage: vi.fn(),
     prewarmThreadDetailForIntent: vi.fn(),
     rememberLastThreadRouteNow: vi.fn(),
@@ -87,7 +87,7 @@ function makeControllerInput(
     navigate: ReturnType<typeof vi.fn>;
     clearSelection: ReturnType<typeof vi.fn>;
     openChatThreadPage: ReturnType<typeof vi.fn>;
-    openSidechatSplit: ReturnType<typeof vi.fn>;
+    openSidechatDock: ReturnType<typeof vi.fn>;
     openTerminalThreadPage: ReturnType<typeof vi.fn>;
     prewarmThreadDetailForIntent: ReturnType<typeof vi.fn>;
     rememberLastThreadRouteNow: ReturnType<typeof vi.fn>;
@@ -275,7 +275,7 @@ describe("activateThreadFromSidebarIntent", () => {
     expect(getFirstNavigateArgs(input).params).toEqual({ threadId: THREAD_C });
   });
 
-  it("opens sidechat rows beside their source thread when no persisted split exists", () => {
+  it("opens sidechat rows in their source thread's dock", () => {
     const input = makeControllerInput({
       routeThreadId: THREAD_A,
       sidebarThreadSummaryById: {
@@ -286,23 +286,22 @@ describe("activateThreadFromSidebarIntent", () => {
 
     activateThreadFromSidebarIntent(input, THREAD_B);
 
-    expect(input.openSidechatSplit).toHaveBeenCalledWith({
+    expect(input.openSidechatDock).toHaveBeenCalledWith({
       sourceThreadId: THREAD_A,
-      ownerProjectId: PROJECT_ID,
       sidechatThreadId: THREAD_B,
     });
-    expect(input.openChatThreadPage).not.toHaveBeenCalled();
+    expect(input.openChatThreadPage).toHaveBeenCalledWith(THREAD_A);
     expect(input.rememberLastThreadRouteNow).toHaveBeenCalledWith({
-      threadId: THREAD_B,
-      splitViewId: "split-sidechat",
+      threadId: THREAD_A,
     });
+    expect(getFirstNavigateArgs(input).params).toEqual({ threadId: THREAD_A });
     expect(getFirstNavigateArgs(input).search({ keep: true })).toEqual({
       keep: true,
-      splitViewId: "split-sidechat",
+      splitViewId: undefined,
     });
   });
 
-  it("opens the active single sidechat as a split when clicked again", () => {
+  it("reopens the active sidechat in the same dock destination when clicked again", () => {
     const input = makeControllerInput({
       routeThreadId: THREAD_B,
       sidebarThreadSummaryById: {
@@ -313,11 +312,68 @@ describe("activateThreadFromSidebarIntent", () => {
 
     activateThreadFromSidebarIntent(input, THREAD_B);
 
-    expect(input.openSidechatSplit).toHaveBeenCalledWith({
+    expect(input.openSidechatDock).toHaveBeenCalledWith({
       sourceThreadId: THREAD_A,
-      ownerProjectId: PROJECT_ID,
       sidechatThreadId: THREAD_B,
     });
     expect(input.navigate).toHaveBeenCalledOnce();
+  });
+
+  it("uses the dock even when the sidechat belonged to a persisted split", () => {
+    const splitView = makeSplitViewFixture({
+      id: "legacy-sidechat-split",
+      sourceThreadId: THREAD_A,
+      firstThreadId: THREAD_A,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+    const input = makeControllerInput({
+      activeSplitView: splitView,
+      routeSplitViewId: splitView.id,
+      sidebarThreadSummaryById: {
+        [THREAD_A]: { id: THREAD_A, projectId: PROJECT_ID, sidechatSourceThreadId: null },
+        [THREAD_B]: { id: THREAD_B, projectId: PROJECT_ID, sidechatSourceThreadId: THREAD_A },
+      },
+      splitViewsById: { [splitView.id]: splitView },
+    });
+
+    activateThreadFromSidebarIntent(input, THREAD_B);
+
+    expect(input.openSidechatDock).toHaveBeenCalledWith({
+      sourceThreadId: THREAD_A,
+      sidechatThreadId: THREAD_B,
+    });
+    expect(input.setSplitFocusedPane).not.toHaveBeenCalled();
+    expect(getFirstNavigateArgs(input).search({ splitViewId: splitView.id })).toEqual({
+      splitViewId: undefined,
+    });
+  });
+
+  it("does not restore a legacy sidechat split when opening its source thread", () => {
+    const splitView = makeSplitViewFixture({
+      id: "legacy-sidechat-split",
+      sourceThreadId: THREAD_A,
+      firstThreadId: THREAD_A,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+    const input = makeControllerInput({
+      activeSplitView: splitView,
+      routeThreadId: THREAD_A,
+      routeSplitViewId: splitView.id,
+      sidebarThreadSummaryById: {
+        [THREAD_A]: { id: THREAD_A, projectId: PROJECT_ID, sidechatSourceThreadId: null },
+        [THREAD_B]: { id: THREAD_B, projectId: PROJECT_ID, sidechatSourceThreadId: THREAD_A },
+      },
+      splitViewsById: { [splitView.id]: splitView },
+    });
+
+    activateThreadFromSidebarIntent(input, THREAD_A);
+
+    expect(input.openChatThreadPage).toHaveBeenCalledWith(THREAD_A);
+    expect(input.setSplitFocusedPane).not.toHaveBeenCalled();
+    expect(getFirstNavigateArgs(input).search({ splitViewId: splitView.id })).toEqual({
+      splitViewId: undefined,
+    });
   });
 });

--- a/apps/web/src/hooks/useThreadActivationController.ts
+++ b/apps/web/src/hooks/useThreadActivationController.ts
@@ -3,9 +3,14 @@
 // Exports: useThreadActivationController
 
 import type { useNavigate } from "@tanstack/react-router";
-import type { ProjectId, ThreadId } from "@synara/contracts";
+import type { ThreadId } from "@synara/contracts";
 import type { LastThreadRoute } from "../chatRouteRestore";
-import { type PaneId, type SplitView, type SplitViewId } from "../splitViewStore";
+import {
+  resolveSplitViewThreadIds,
+  type PaneId,
+  type SplitView,
+  type SplitViewId,
+} from "../splitViewStore";
 import { selectThreadTerminalState } from "../terminalStateStore";
 import type { SidebarThreadSummary } from "../types";
 import {
@@ -25,11 +30,7 @@ export type ThreadActivationControllerInput = {
   clearSelection: () => void;
   navigate: Navigate;
   openChatThreadPage: (threadId: ThreadId) => void;
-  openSidechatSplit: (input: {
-    sidechatThreadId: ThreadId;
-    sourceThreadId: ThreadId;
-    ownerProjectId: ProjectId;
-  }) => SplitViewId;
+  openSidechatDock: (input: { sidechatThreadId: ThreadId; sourceThreadId: ThreadId }) => void;
   openTerminalThreadPage: (threadId: ThreadId) => void;
   prewarmThreadDetailForIntent: (threadId: ThreadId) => void;
   rememberLastThreadRouteNow: (nextLastThreadRoute: LastThreadRoute) => void;
@@ -65,29 +66,42 @@ export function activateThreadFromSidebarIntent(
     splitViewsById,
   } = input;
 
+  const targetThread = sidebarThreadSummaryById[threadId];
+  const sidechatDockActivation = resolveSidechatDockActivation(input, {
+    threadId,
+    targetThread,
+  });
+  if (sidechatDockActivation) {
+    activateSidechatDock(input, sidechatDockActivation);
+    return;
+  }
+
   // Active split wins first; otherwise every persisted split block can restore deterministically.
-  const preferredSplit = resolvePreferredSplitForCommand({
+  const preferredSplitCandidate = resolvePreferredSplitForCommand({
     activeSplitView,
     splitViewsById,
     threadId,
   });
-  const targetThread = sidebarThreadSummaryById[threadId];
+  const preferredSplitView = preferredSplitCandidate
+    ? (splitViewsById[preferredSplitCandidate.splitViewId] ??
+      (activeSplitView?.id === preferredSplitCandidate.splitViewId ? activeSplitView : null))
+    : null;
+  const preferredSplit =
+    preferredSplitCandidate &&
+    preferredSplitView &&
+    resolveSplitViewThreadIds(preferredSplitView).some(
+      (paneThreadId) => sidebarThreadSummaryById[paneThreadId]?.sidechatSourceThreadId,
+    )
+      ? null
+      : preferredSplitCandidate;
   const activation = resolveThreadCommandActivation({
     threadId,
     threadExists: targetThread !== undefined,
-    activeSidebarThreadId: routeThreadId,
+    activeSidebarThreadId:
+      routeSplitViewId && preferredSplitCandidate && !preferredSplit ? null : routeThreadId,
     preferredSplitViewId: preferredSplit?.splitViewId ?? null,
     splitPaneId: preferredSplit?.paneId ?? null,
   });
-
-  const sidechatSplitActivation = resolveSidechatSplitActivation(input, {
-    threadId,
-    targetThread,
-  });
-  if (sidechatSplitActivation && activation.kind !== "split") {
-    activateSidechatSplit(input, sidechatSplitActivation);
-    return;
-  }
 
   if (activation.kind === "ignore") {
     return;
@@ -123,59 +137,57 @@ export function activateThreadFromSidebarIntent(
   });
 }
 
-function resolveSidechatSplitActivation(
+function resolveSidechatDockActivation(
   input: ThreadActivationControllerInput,
   options: {
     threadId: ThreadId;
     targetThread: SidebarThreadActivationSummary | undefined;
   },
-): { threadId: ThreadId; sourceThreadId: ThreadId; ownerProjectId: ProjectId } | null {
+): { threadId: ThreadId; sourceThreadId: ThreadId } | null {
   if (!options.targetThread?.sidechatSourceThreadId) {
     return null;
   }
   const sourceThread = input.sidebarThreadSummaryById[options.targetThread.sidechatSourceThreadId];
-  if (!sourceThread || input.routeSplitViewId) {
+  if (!sourceThread) {
     return null;
   }
   return {
     threadId: options.threadId,
     sourceThreadId: options.targetThread.sidechatSourceThreadId,
-    ownerProjectId: sourceThread.projectId,
   };
 }
 
-// Sidechat rows reopen as source-left + sidechat-right when no split route is active.
-function activateSidechatSplit(
+// Sidechat rows always target the source thread's dock, matching where sidechats
+// are created and avoiding a second, conflicting split-view navigation model.
+function activateSidechatDock(
   input: ThreadActivationControllerInput,
   activation: {
     threadId: ThreadId;
     sourceThreadId: ThreadId;
-    ownerProjectId: ProjectId;
   },
 ): void {
   input.prewarmThreadDetailForIntent(activation.sourceThreadId);
   input.prewarmThreadDetailForIntent(activation.threadId);
-  input.setOptimisticActiveThreadId(activation.threadId);
+  input.setOptimisticActiveThreadId(activation.sourceThreadId);
   if (input.selectedThreadCount > 0) {
     input.clearSelection();
   }
   input.setSelectionAnchor(activation.threadId);
 
-  const splitViewId = input.openSidechatSplit({
+  input.openChatThreadPage(activation.sourceThreadId);
+  input.openSidechatDock({
     sourceThreadId: activation.sourceThreadId,
-    ownerProjectId: activation.ownerProjectId,
     sidechatThreadId: activation.threadId,
   });
   input.rememberLastThreadRouteNow({
-    threadId: activation.threadId,
-    splitViewId,
+    threadId: activation.sourceThreadId,
   });
   void input.navigate({
     to: "/$threadId",
-    params: { threadId: activation.threadId },
+    params: { threadId: activation.sourceThreadId },
     search: (previous) => ({
       ...previous,
-      splitViewId,
+      splitViewId: undefined,
     }),
   });
 }
@@ -219,7 +231,7 @@ export function useThreadActivationController(input: ThreadActivationControllerI
     clearSelection,
     navigate,
     openChatThreadPage,
-    openSidechatSplit,
+    openSidechatDock,
     openTerminalThreadPage,
     prewarmThreadDetailForIntent,
     rememberLastThreadRouteNow,
@@ -241,7 +253,7 @@ export function useThreadActivationController(input: ThreadActivationControllerI
         clearSelection,
         navigate,
         openChatThreadPage,
-        openSidechatSplit,
+        openSidechatDock,
         openTerminalThreadPage,
         prewarmThreadDetailForIntent,
         rememberLastThreadRouteNow,

--- a/apps/web/src/lib/sidechatCreation.test.ts
+++ b/apps/web/src/lib/sidechatCreation.test.ts
@@ -1,0 +1,345 @@
+import type { NativeApi, OrchestrationShellSnapshot } from "@synara/contracts";
+import { ProjectId, ThreadId } from "@synara/contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Project, Thread } from "../types";
+import {
+  clearSidechatPaneRetention,
+  createOrJoinSidechat,
+  createSidechatThread,
+  getSidechatPaneRetentionVersion,
+  sidechatPaneRetentionRemainingMs,
+  subscribeSidechatPaneRetention,
+  type SidechatCreationFlight,
+  type SidechatCreationResult,
+} from "./sidechatCreation";
+
+vi.mock("./utils", () => ({
+  newCommandId: () => "command-1",
+  newMessageId: () => "message-1",
+  newThreadId: () => "sidechat-thread",
+}));
+
+const sourceThread = {
+  id: ThreadId.makeUnsafe("source-thread"),
+  projectId: ProjectId.makeUnsafe("project-1"),
+  title: "Source thread",
+  envMode: "local",
+  branch: "main",
+  worktreePath: null,
+  workingDirectory: "/repo",
+  associatedWorktreePath: null,
+  associatedWorktreeBranch: null,
+  associatedWorktreeRef: null,
+  messages: [],
+} as unknown as Thread;
+
+const project = {
+  id: ProjectId.makeUnsafe("project-1"),
+  name: "Project",
+  cwd: "/repo",
+} as Project;
+
+const selectedModelSelection = { provider: "codex", model: "gpt-5.6" } as const;
+
+function makeApi(input?: {
+  dispatchCommand?: ReturnType<typeof vi.fn>;
+  getShellSnapshot?: ReturnType<typeof vi.fn>;
+}): NativeApi {
+  return {
+    orchestration: {
+      dispatchCommand: input?.dispatchCommand ?? vi.fn().mockResolvedValue(undefined),
+      getShellSnapshot:
+        input?.getShellSnapshot ?? vi.fn().mockResolvedValue({} as OrchestrationShellSnapshot),
+    },
+  } as unknown as NativeApi;
+}
+
+describe("createSidechatThread", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearSidechatPaneRetention(ThreadId.makeUnsafe("sidechat-thread"));
+  });
+
+  it("opens the fork before waiting for the shell snapshot", async () => {
+    const openSidechat = vi.fn();
+    const getShellSnapshot = vi.fn().mockImplementation(async () => {
+      expect(openSidechat).toHaveBeenCalledWith(ThreadId.makeUnsafe("sidechat-thread"));
+      return {} as OrchestrationShellSnapshot;
+    });
+    const syncServerShellSnapshot = vi.fn();
+
+    const result = await createSidechatThread({
+      api: makeApi({ getShellSnapshot }),
+      project,
+      sourceThread,
+      selectedModelSelection,
+      openSidechat,
+      syncServerShellSnapshot,
+    });
+
+    expect(result).toEqual({
+      threadId: ThreadId.makeUnsafe("sidechat-thread"),
+      promptError: null,
+      snapshotError: null,
+    });
+    expect(syncServerShellSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it("starts snapshot synchronization before dispatching the optional prompt", async () => {
+    const dispatchCommand = vi.fn().mockResolvedValue(undefined);
+    const getShellSnapshot = vi.fn().mockImplementation(async () => {
+      expect(dispatchCommand).toHaveBeenCalledTimes(1);
+      return {} as OrchestrationShellSnapshot;
+    });
+
+    await createSidechatThread({
+      api: makeApi({ dispatchCommand, getShellSnapshot }),
+      project,
+      sourceThread,
+      selectedModelSelection,
+      initialPrompt: "Investigate this",
+      openSidechat: vi.fn(),
+      syncServerShellSnapshot: vi.fn(),
+    });
+
+    expect(dispatchCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it("retains the pane without a deadline while snapshot synchronization is in flight", async () => {
+    let resolveSnapshot: ((snapshot: OrchestrationShellSnapshot) => void) | undefined;
+    const getShellSnapshot = vi.fn().mockImplementation(
+      () =>
+        new Promise<OrchestrationShellSnapshot>((resolve) => {
+          resolveSnapshot = resolve;
+        }),
+    );
+    const creation = createSidechatThread({
+      api: makeApi({ getShellSnapshot }),
+      project,
+      sourceThread,
+      selectedModelSelection,
+      openSidechat: vi.fn(),
+      syncServerShellSnapshot: vi.fn(),
+    });
+
+    await vi.waitFor(() => expect(getShellSnapshot).toHaveBeenCalledOnce());
+    expect(sidechatPaneRetentionRemainingMs(ThreadId.makeUnsafe("sidechat-thread"))).toBeNull();
+
+    resolveSnapshot?.({} as OrchestrationShellSnapshot);
+    await creation;
+  });
+
+  it("notifies the pane cleanup subscriber when snapshot synchronization finishes", async () => {
+    let resolveSnapshot: ((snapshot: OrchestrationShellSnapshot) => void) | undefined;
+    const getShellSnapshot = vi.fn().mockImplementation(
+      () =>
+        new Promise<OrchestrationShellSnapshot>((resolve) => {
+          resolveSnapshot = resolve;
+        }),
+    );
+    const onRetentionChange = vi.fn();
+    const initialVersion = getSidechatPaneRetentionVersion();
+    const unsubscribe = subscribeSidechatPaneRetention(onRetentionChange);
+    const creation = createSidechatThread({
+      api: makeApi({ getShellSnapshot }),
+      project,
+      sourceThread,
+      selectedModelSelection,
+      openSidechat: vi.fn(),
+      syncServerShellSnapshot: vi.fn(),
+    });
+
+    await vi.waitFor(() => expect(getShellSnapshot).toHaveBeenCalledOnce());
+    expect(onRetentionChange).toHaveBeenCalledTimes(1);
+    expect(getSidechatPaneRetentionVersion()).toBe(initialVersion + 1);
+
+    resolveSnapshot?.({} as OrchestrationShellSnapshot);
+    await creation;
+    expect(onRetentionChange).toHaveBeenCalledTimes(2);
+    expect(getSidechatPaneRetentionVersion()).toBe(initialVersion + 2);
+    unsubscribe();
+  });
+
+  it("keeps the created sidechat open when its initial prompt fails", async () => {
+    const promptError = new Error("turn failed");
+    const dispatchCommand = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(promptError);
+    const openSidechat = vi.fn();
+
+    const result = await createSidechatThread({
+      api: makeApi({ dispatchCommand }),
+      project,
+      sourceThread,
+      selectedModelSelection,
+      initialPrompt: "Investigate this",
+      openSidechat,
+      syncServerShellSnapshot: vi.fn(),
+    });
+
+    expect(result.promptError).toBe(promptError);
+    expect(openSidechat).toHaveBeenCalledOnce();
+  });
+
+  it("retains a grace period when snapshot synchronization fails", async () => {
+    const snapshotError = new Error("snapshot failed");
+    const result = await createSidechatThread({
+      api: makeApi({ getShellSnapshot: vi.fn().mockRejectedValue(snapshotError) }),
+      project,
+      sourceThread,
+      selectedModelSelection,
+      openSidechat: vi.fn(),
+      syncServerShellSnapshot: vi.fn(),
+    });
+
+    expect(result.snapshotError).toBe(snapshotError);
+    expect(sidechatPaneRetentionRemainingMs(result.threadId)).toBeGreaterThan(0);
+  });
+
+  it("does not open a pane when the fork itself fails", async () => {
+    const openSidechat = vi.fn();
+
+    await expect(
+      createSidechatThread({
+        api: makeApi({ dispatchCommand: vi.fn().mockRejectedValue(new Error("fork failed")) }),
+        project,
+        sourceThread,
+        selectedModelSelection,
+        openSidechat,
+        syncServerShellSnapshot: vi.fn(),
+      }),
+    ).rejects.toThrow("fork failed");
+    expect(openSidechat).not.toHaveBeenCalled();
+  });
+});
+
+describe("sidechat pane retention", () => {
+  it("gives a restored missing pane one grace window before pruning", () => {
+    const threadId = ThreadId.makeUnsafe("restored-sidechat");
+    clearSidechatPaneRetention(threadId);
+
+    expect(sidechatPaneRetentionRemainingMs(threadId, 1_000)).toBe(15_000);
+    expect(sidechatPaneRetentionRemainingMs(threadId, 15_999)).toBe(1);
+    expect(sidechatPaneRetentionRemainingMs(threadId, 16_000)).toBe(0);
+  });
+});
+
+describe("createOrJoinSidechat", () => {
+  const result = {
+    threadId: ThreadId.makeUnsafe("created-sidechat"),
+    promptError: null,
+    snapshotError: null,
+  } satisfies SidechatCreationResult;
+
+  function run(input: {
+    flights: Map<ThreadId, SidechatCreationFlight>;
+    sourceThreadId: ThreadId;
+    initialPrompt?: string | undefined;
+    startCreation: (initialPrompt?: string | undefined) => Promise<SidechatCreationResult>;
+    sendQueuedPrompt: (threadId: ThreadId, prompt: string) => Promise<void>;
+  }): Promise<true> {
+    return createOrJoinSidechat({
+      inFlightBySourceThreadId: input.flights,
+      sourceThreadId: input.sourceThreadId,
+      initialPrompt: input.initialPrompt,
+      startCreation: input.startCreation,
+      sendQueuedPrompt: input.sendQueuedPrompt,
+      onCreationResult: vi.fn(),
+      onQueuedPromptError: vi.fn(),
+    });
+  }
+
+  it("queues a later prompt onto the in-flight sidechat instead of dropping it", async () => {
+    let resolveCreation: ((value: SidechatCreationResult) => void) | undefined;
+    const startCreation = vi.fn(
+      () =>
+        new Promise<SidechatCreationResult>((resolve) => {
+          resolveCreation = resolve;
+        }),
+    );
+    const sendQueuedPrompt = vi.fn().mockResolvedValue(undefined);
+    const flights = new Map<ThreadId, SidechatCreationFlight>();
+    const sourceThreadId = ThreadId.makeUnsafe("source-a");
+
+    const first = run({ flights, sourceThreadId, startCreation, sendQueuedPrompt });
+    const second = run({
+      flights,
+      sourceThreadId,
+      initialPrompt: "Do not lose this",
+      startCreation,
+      sendQueuedPrompt,
+    });
+
+    expect(startCreation).toHaveBeenCalledOnce();
+    resolveCreation?.(result);
+    await Promise.all([first, second]);
+    expect(sendQueuedPrompt).toHaveBeenCalledWith(result.threadId, "Do not lose this");
+  });
+
+  it("does not queue the initial prompt twice when the same action is repeated", async () => {
+    let resolveCreation: ((value: SidechatCreationResult) => void) | undefined;
+    const startCreation = vi.fn(
+      () =>
+        new Promise<SidechatCreationResult>((resolve) => {
+          resolveCreation = resolve;
+        }),
+    );
+    const sendQueuedPrompt = vi.fn().mockResolvedValue(undefined);
+    const flights = new Map<ThreadId, SidechatCreationFlight>();
+    const sourceThreadId = ThreadId.makeUnsafe("source-a");
+
+    const first = run({
+      flights,
+      sourceThreadId,
+      initialPrompt: "Only once",
+      startCreation,
+      sendQueuedPrompt,
+    });
+    const duplicate = run({
+      flights,
+      sourceThreadId,
+      initialPrompt: "Only once",
+      startCreation,
+      sendQueuedPrompt,
+    });
+
+    expect(startCreation).toHaveBeenCalledWith("Only once");
+    resolveCreation?.(result);
+    await Promise.all([first, duplicate]);
+    expect(startCreation).toHaveBeenCalledOnce();
+    expect(sendQueuedPrompt).not.toHaveBeenCalled();
+  });
+
+  it("allows different host threads to create sidechats concurrently", async () => {
+    const flights = new Map<ThreadId, SidechatCreationFlight>();
+    const startFirst = vi.fn().mockResolvedValue(result);
+    const startSecond = vi.fn().mockResolvedValue({
+      ...result,
+      threadId: ThreadId.makeUnsafe("other-sidechat"),
+    });
+
+    await Promise.all([
+      run({
+        flights,
+        sourceThreadId: ThreadId.makeUnsafe("source-a"),
+        startCreation: startFirst,
+        sendQueuedPrompt: vi
+          .fn<(threadId: ThreadId, prompt: string) => Promise<void>>()
+          .mockResolvedValue(undefined),
+      }),
+      run({
+        flights,
+        sourceThreadId: ThreadId.makeUnsafe("source-b"),
+        startCreation: startSecond,
+        sendQueuedPrompt: vi
+          .fn<(threadId: ThreadId, prompt: string) => Promise<void>>()
+          .mockResolvedValue(undefined),
+      }),
+    ]);
+
+    expect(startFirst).toHaveBeenCalledOnce();
+    expect(startSecond).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/lib/sidechatCreation.ts
+++ b/apps/web/src/lib/sidechatCreation.ts
@@ -1,0 +1,289 @@
+// FILE: sidechatCreation.ts
+// Purpose: Own the sidechat fork/start/snapshot lifecycle independently of composer state.
+// Layer: Chat orchestration
+
+import type {
+  ModelSelection,
+  NativeApi,
+  OrchestrationShellSnapshot,
+  ThreadId,
+} from "@synara/contracts";
+import { buildPromptThreadTitleFallback } from "@synara/shared/chatThreads";
+
+import { newCommandId, newMessageId, newThreadId } from "./utils";
+import { buildThreadHandoffImportedMessages } from "./threadHandoff";
+import type { Project, Thread } from "../types";
+
+const SIDECHAT_MISSING_GRACE_MS = 15_000;
+type SidechatPaneRetention = { kind: "syncing" } | { kind: "grace"; untilMs: number };
+const sidechatPaneRetentionByThreadId = new Map<ThreadId, SidechatPaneRetention>();
+const sidechatPaneRetentionListeners = new Set<() => void>();
+let sidechatPaneRetentionVersion = 0;
+
+function emitSidechatPaneRetentionChange(): void {
+  sidechatPaneRetentionVersion += 1;
+  for (const listener of sidechatPaneRetentionListeners) {
+    listener();
+  }
+}
+
+function setSidechatPaneRetention(threadId: ThreadId, retention: SidechatPaneRetention): void {
+  sidechatPaneRetentionByThreadId.set(threadId, retention);
+  emitSidechatPaneRetentionChange();
+}
+
+export function subscribeSidechatPaneRetention(listener: () => void): () => void {
+  sidechatPaneRetentionListeners.add(listener);
+  return () => sidechatPaneRetentionListeners.delete(listener);
+}
+
+export function getSidechatPaneRetentionVersion(): number {
+  return sidechatPaneRetentionVersion;
+}
+
+export interface SidechatCreationResult {
+  threadId: ThreadId;
+  promptError: unknown | null;
+  snapshotError: unknown | null;
+}
+
+export interface SidechatCreationFlight {
+  readonly creation: Promise<SidechatCreationResult>;
+  readonly completion: Promise<true>;
+  readonly submittedPrompts: Set<string>;
+  promptTail: Promise<void>;
+  creationSettled: boolean;
+}
+
+function scheduleSidechatFlightCleanup(
+  inFlightBySourceThreadId: Map<ThreadId, SidechatCreationFlight>,
+  sourceThreadId: ThreadId,
+  flight: SidechatCreationFlight,
+): void {
+  const observedTail = flight.promptTail;
+  void observedTail.then(
+    () => {
+      if (
+        flight.creationSettled &&
+        flight.promptTail === observedTail &&
+        inFlightBySourceThreadId.get(sourceThreadId) === flight
+      ) {
+        inFlightBySourceThreadId.delete(sourceThreadId);
+      }
+    },
+    () => {
+      if (
+        flight.creationSettled &&
+        flight.promptTail === observedTail &&
+        inFlightBySourceThreadId.get(sourceThreadId) === flight
+      ) {
+        inFlightBySourceThreadId.delete(sourceThreadId);
+      }
+    },
+  );
+}
+
+export function createOrJoinSidechat(input: {
+  inFlightBySourceThreadId: Map<ThreadId, SidechatCreationFlight>;
+  sourceThreadId: ThreadId;
+  initialPrompt?: string | undefined;
+  startCreation: (initialPrompt?: string) => Promise<SidechatCreationResult>;
+  sendQueuedPrompt: (threadId: ThreadId, prompt: string) => Promise<void>;
+  onCreationResult: (result: SidechatCreationResult) => void;
+  onQueuedPromptError: (error: unknown) => void;
+}): Promise<true> {
+  const prompt = input.initialPrompt?.trim() ?? "";
+  const existing = input.inFlightBySourceThreadId.get(input.sourceThreadId);
+  if (existing) {
+    if (prompt.length === 0) {
+      return existing.completion;
+    }
+    if (existing.submittedPrompts.has(prompt)) {
+      return Promise.all([existing.completion, existing.promptTail]).then(() => true as const);
+    }
+    existing.submittedPrompts.add(prompt);
+    existing.promptTail = existing.promptTail.then(async () => {
+      const result = await existing.creation;
+      try {
+        await input.sendQueuedPrompt(result.threadId, prompt);
+      } catch (error) {
+        input.onQueuedPromptError(error);
+      }
+    });
+    if (existing.creationSettled) {
+      scheduleSidechatFlightCleanup(input.inFlightBySourceThreadId, input.sourceThreadId, existing);
+    }
+    return existing.promptTail.then(() => true as const);
+  }
+
+  const creation = input.startCreation(prompt.length > 0 ? prompt : undefined);
+  const completion = creation.then((result) => {
+    input.onCreationResult(result);
+    return true as const;
+  });
+  const flight: SidechatCreationFlight = {
+    creation,
+    completion,
+    submittedPrompts: new Set(prompt.length > 0 ? [prompt] : []),
+    promptTail: Promise.resolve(),
+    creationSettled: false,
+  };
+  input.inFlightBySourceThreadId.set(input.sourceThreadId, flight);
+  void flight.completion.then(
+    () => {
+      flight.creationSettled = true;
+      scheduleSidechatFlightCleanup(input.inFlightBySourceThreadId, input.sourceThreadId, flight);
+    },
+    () => {
+      flight.creationSettled = true;
+      scheduleSidechatFlightCleanup(input.inFlightBySourceThreadId, input.sourceThreadId, flight);
+    },
+  );
+  return flight.completion;
+}
+
+// Null means the successful fork is still synchronizing and must not be pruned.
+// Missing restored panes receive one bounded recheck window before removal.
+export function sidechatPaneRetentionRemainingMs(
+  threadId: ThreadId,
+  nowMs = Date.now(),
+): number | null {
+  let retention = sidechatPaneRetentionByThreadId.get(threadId);
+  if (!retention) {
+    retention = { kind: "grace", untilMs: nowMs + SIDECHAT_MISSING_GRACE_MS };
+    setSidechatPaneRetention(threadId, retention);
+  }
+  if (retention.kind === "syncing") {
+    return null;
+  }
+  const remainingMs = retention.untilMs - nowMs;
+  if (remainingMs <= 0) {
+    clearSidechatPaneRetention(threadId);
+    return 0;
+  }
+  return remainingMs;
+}
+
+function markSidechatSyncing(threadId: ThreadId): void {
+  setSidechatPaneRetention(threadId, { kind: "syncing" });
+}
+
+function markSidechatSyncFailed(threadId: ThreadId): void {
+  setSidechatPaneRetention(threadId, {
+    kind: "grace",
+    untilMs: Date.now() + SIDECHAT_MISSING_GRACE_MS,
+  });
+}
+
+export function clearSidechatPaneRetention(threadId: ThreadId): void {
+  if (sidechatPaneRetentionByThreadId.delete(threadId)) {
+    emitSidechatPaneRetentionChange();
+  }
+}
+
+export async function sendSidechatPrompt(input: {
+  api: NativeApi;
+  threadId: ThreadId;
+  selectedModelSelection: ModelSelection;
+  prompt: string;
+}): Promise<void> {
+  const prompt = input.prompt.trim();
+  if (prompt.length === 0) {
+    return;
+  }
+  await input.api.orchestration.dispatchCommand({
+    type: "thread.turn.start",
+    commandId: newCommandId(),
+    threadId: input.threadId,
+    message: {
+      messageId: newMessageId(),
+      role: "user",
+      text: prompt,
+      attachments: [],
+    },
+    modelSelection: input.selectedModelSelection,
+    runtimeMode: "approval-required",
+    interactionMode: "default",
+    createdAt: new Date().toISOString(),
+  });
+}
+
+export async function createSidechatThread(input: {
+  api: NativeApi;
+  project: Project;
+  sourceThread: Thread;
+  selectedModelSelection: ModelSelection;
+  initialPrompt?: string | undefined;
+  openSidechat: (threadId: ThreadId) => void;
+  syncServerShellSnapshot: (snapshot: OrchestrationShellSnapshot) => void;
+}): Promise<SidechatCreationResult> {
+  const nextThreadId = newThreadId();
+  const createdAt = new Date().toISOString();
+  const initialPrompt = input.initialPrompt?.trim() ?? "";
+  const titleSeed =
+    initialPrompt.length > 0
+      ? buildPromptThreadTitleFallback(initialPrompt)
+      : input.sourceThread.title;
+
+  await input.api.orchestration.dispatchCommand({
+    type: "thread.fork.create",
+    commandId: newCommandId(),
+    threadId: nextThreadId,
+    sourceThreadId: input.sourceThread.id,
+    sidechatSourceThreadId: input.sourceThread.id,
+    projectId: input.project.id,
+    title: `Sidechat: ${titleSeed}`,
+    modelSelection: input.selectedModelSelection,
+    runtimeMode: "approval-required",
+    interactionMode: "default",
+    envMode: input.sourceThread.envMode ?? (input.sourceThread.worktreePath ? "worktree" : "local"),
+    branch: input.sourceThread.branch,
+    worktreePath: input.sourceThread.worktreePath,
+    workingDirectory: input.sourceThread.workingDirectory ?? null,
+    associatedWorktreePath: input.sourceThread.associatedWorktreePath ?? null,
+    associatedWorktreeBranch: input.sourceThread.associatedWorktreeBranch ?? null,
+    associatedWorktreeRef: input.sourceThread.associatedWorktreeRef ?? null,
+    importedMessages: [...buildThreadHandoffImportedMessages(input.sourceThread)],
+    createdAt,
+  });
+
+  // The fork now exists. Expose it immediately so a slow snapshot refresh cannot
+  // leave a successful creation invisible and tempt the user into creating duplicates.
+  markSidechatSyncing(nextThreadId);
+  input.openSidechat(nextThreadId);
+
+  // Start snapshot synchronization before an optional prompt. A slow/queued turn
+  // must never prevent the successful fork from reaching the shell projection.
+  const snapshotPromise = (async (): Promise<unknown | null> => {
+    try {
+      const snapshot = await input.api.orchestration.getShellSnapshot();
+      input.syncServerShellSnapshot(snapshot);
+      return null;
+    } catch (error) {
+      return error;
+    }
+  })();
+
+  const promptPromise = (async (): Promise<unknown | null> => {
+    try {
+      await sendSidechatPrompt({
+        api: input.api,
+        threadId: nextThreadId,
+        selectedModelSelection: input.selectedModelSelection,
+        prompt: initialPrompt,
+      });
+      return null;
+    } catch (error) {
+      return error;
+    }
+  })();
+
+  const [snapshotError, promptError] = await Promise.all([snapshotPromise, promptPromise]);
+  if (snapshotError) {
+    markSidechatSyncFailed(nextThreadId);
+  } else {
+    clearSidechatPaneRetention(nextThreadId);
+  }
+
+  return { threadId: nextThreadId, promptError, snapshotError };
+}

--- a/apps/web/src/rightDockStore.logic.test.ts
+++ b/apps/web/src/rightDockStore.logic.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
+import { ThreadId } from "@synara/contracts";
 
 import {
   RIGHT_DOCK_PANE_KINDS,
   SINGLETON_PANE_KINDS,
   closePaneInState,
   createDefaultRightDockState,
+  findMissingSidechatPaneIds,
   isRightDockPaneKind,
   openPaneInState,
   sanitizeRightDockStateByThreadId,
@@ -29,7 +31,7 @@ describe("RIGHT_DOCK_PANE_KINDS (single source of truth)", () => {
 
   it("derives singletons as every kind except the multi-instance ones", () => {
     for (const kind of RIGHT_DOCK_PANE_KINDS) {
-      expect(SINGLETON_PANE_KINDS.has(kind)).toBe(kind !== "sidechat" && kind !== "file");
+      expect(SINGLETON_PANE_KINDS.has(kind)).toBe(kind !== "file");
     }
   });
 });
@@ -154,6 +156,54 @@ describe("sanitizeRightDockThreadState", () => {
       panes: [],
       activePaneId: null,
     });
+  });
+
+  it("migrates multiple persisted sidechat tabs into one active destination", () => {
+    const state = sanitizeRightDockThreadState({
+      open: true,
+      activePaneId: "side-b",
+      panes: [
+        { id: "side-a", kind: "sidechat", threadId: "thread-a" },
+        { id: "side-b", kind: "sidechat", threadId: "thread-b" },
+      ],
+    });
+
+    expect(state.panes).toHaveLength(1);
+    expect(state.panes[0]?.id).toBe("side-b");
+    expect(state.panes[0]?.threadId).toBe("thread-b");
+    expect(state.activePaneId).toBe("side-b");
+  });
+});
+
+describe("sidechat pane", () => {
+  it("reuses the singleton destination and switches its embedded thread", () => {
+    const first = openPaneInState(createDefaultRightDockState(), {
+      paneId: "side-pane",
+      kind: "sidechat",
+      threadId: ThreadId.makeUnsafe("thread-a"),
+    });
+    const switched = openPaneInState(first, {
+      paneId: "ignored",
+      kind: "sidechat",
+      threadId: ThreadId.makeUnsafe("thread-b"),
+    });
+
+    expect(switched.panes).toHaveLength(1);
+    expect(switched.activePaneId).toBe("side-pane");
+    expect(switched.panes[0]?.threadId).toBe("thread-b");
+  });
+
+  it("finds sidechat panes whose backing thread no longer exists", () => {
+    const state = openPaneInState(createDefaultRightDockState(), {
+      paneId: "side-pane",
+      kind: "sidechat",
+      threadId: ThreadId.makeUnsafe("missing-thread"),
+    });
+
+    expect(findMissingSidechatPaneIds(state, new Set())).toEqual(["side-pane"]);
+    expect(
+      findMissingSidechatPaneIds(state, new Set([ThreadId.makeUnsafe("missing-thread")])),
+    ).toEqual([]);
   });
 });
 

--- a/apps/web/src/rightDockStore.logic.ts
+++ b/apps/web/src/rightDockStore.logic.ts
@@ -47,9 +47,9 @@ export interface RightDockThreadState {
   activePaneId: string | null;
 }
 
-// Kinds that allow multiple concurrent panes per host thread: sidechat opens
-// one pane per embedded thread, file opens one tab per previewed file.
-const MULTI_INSTANCE_PANE_KINDS: ReadonlySet<RightDockPaneKind> = new Set(["sidechat", "file"]);
+// File previews are the only multi-instance dock kind. Side chats share one
+// destination and switch the embedded thread inside it.
+const MULTI_INSTANCE_PANE_KINDS: ReadonlySet<RightDockPaneKind> = new Set(["file"]);
 
 // Kinds that can only ever have one instance per host thread, derived as
 // "every kind that is not multi-instance" so the two sets can never drift.
@@ -118,15 +118,29 @@ export function sanitizeRightDockThreadState(value: unknown): RightDockThreadSta
     return createDefaultRightDockState();
   }
   const candidate = value;
-  const panes = Array.isArray(candidate.panes)
+  const sanitizedPanes = Array.isArray(candidate.panes)
     ? candidate.panes
         .map(sanitizePersistedPane)
         .filter((pane): pane is RightDockPane => pane !== null)
     : [];
+  const persistedActivePaneId =
+    typeof candidate.activePaneId === "string" ? candidate.activePaneId : null;
+  const keptSingletonPaneIdByKind = new Map<RightDockPaneKind, string>();
+  for (const pane of sanitizedPanes) {
+    if (
+      isSingletonPaneKind(pane.kind) &&
+      (pane.id === persistedActivePaneId || !keptSingletonPaneIdByKind.has(pane.kind))
+    ) {
+      keptSingletonPaneIdByKind.set(pane.kind, pane.id);
+    }
+  }
+  const panes = sanitizedPanes.filter(
+    (pane) =>
+      !isSingletonPaneKind(pane.kind) || keptSingletonPaneIdByKind.get(pane.kind) === pane.id,
+  );
   const activePaneId =
-    typeof candidate.activePaneId === "string" &&
-    panes.some((pane) => pane.id === candidate.activePaneId)
-      ? candidate.activePaneId
+    persistedActivePaneId && panes.some((pane) => pane.id === persistedActivePaneId)
+      ? persistedActivePaneId
       : (panes[0]?.id ?? null);
   return {
     open: candidate.open === true,
@@ -175,6 +189,9 @@ function createPane(input: OpenPaneInput): RightDockPane {
 // overwrite content metadata when the caller explicitly targets new content,
 // so a bare re-open/toggle keeps the pane focused on what it currently shows.
 function singletonPaneReopenPatch(input: OpenPaneInput): Partial<RightDockPane> | null {
+  if (input.kind === "sidechat" && input.threadId !== undefined) {
+    return { threadId: input.threadId ?? null };
+  }
   if (
     input.kind === "diff" &&
     (input.diffTurnId !== undefined || input.diffFilePath !== undefined)
@@ -198,20 +215,12 @@ function singletonPaneReopenPatch(input: OpenPaneInput): Partial<RightDockPane> 
   return null;
 }
 
-// Multi-instance kinds reuse an existing pane only when it already shows the
-// requested content: sidechat panes match on the embedded thread, file panes
-// on the previewed file (so re-clicking an open file focuses its tab instead
-// of duplicating it, and a bare open reuses an existing empty file pane).
+// Multi-instance file panes reuse an existing pane when it already shows the
+// requested path, so re-clicking a file focuses its tab instead of duplicating it.
 function findMatchingMultiInstancePane(
   state: RightDockThreadState,
   input: OpenPaneInput,
 ): RightDockPane | undefined {
-  if (input.kind === "sidechat") {
-    if (!input.threadId) {
-      return undefined;
-    }
-    return state.panes.find((pane) => pane.kind === "sidechat" && pane.threadId === input.threadId);
-  }
   if (input.kind === "file") {
     const filePath = input.filePath ?? null;
     return state.panes.find((pane) => pane.kind === "file" && pane.filePath === filePath);
@@ -377,4 +386,15 @@ export function resolveActivePane(state: RightDockThreadState): RightDockPane | 
     return null;
   }
   return state.panes.find((pane) => pane.id === state.activePaneId) ?? null;
+}
+
+export function findMissingSidechatPaneIds(
+  state: RightDockThreadState,
+  existingThreadIds: ReadonlySet<ThreadId>,
+): readonly string[] {
+  return state.panes.flatMap((pane) =>
+    pane.kind === "sidechat" && pane.threadId && !existingThreadIds.has(pane.threadId)
+      ? [pane.id]
+      : [],
+  );
 }


### PR DESCRIPTION
## Summary
- open the sidechat pane immediately after forking and deduplicate in-flight creation
- preserve partial-success states when the prompt or snapshot fails
- register sidechat creation independently from transient composer draft state
- replace per-conversation right-dock tabs with a single `Side chats` dock
- sanitize persisted duplicates and prune stale thread references
- route sidebar sidechat activation to the host dock and stop restoring legacy sidechat splits

## Root cause
Sidechat creation, composer registration, split restoration, and dock persistence were coupled across transient UI states. That allowed duplicate requests, stale selections, and navigation loops.

## Verification
- focused sidechat tests — 45 tests passed
- `bun run --cwd apps/web build` — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches thread activation, split-view restoration, and dock persistence—user-visible navigation—but behavior is covered by new unit tests and is mostly UX/orchestration rather than auth or data integrity.
> 
> **Overview**
> Side chats move from **split-view panes** and **multiple dock tabs** to a **single “Side chats” dock** on the host thread, with creation and navigation decoupled from transient composer state.
> 
> **Creation** is centralized in `sidechatCreation.ts`: the dock opens **immediately after fork**, in-flight work is **deduplicated** per host thread (queued prompts join the same flight), and snapshot sync runs **in parallel** with the optional initial turn so a slow prompt cannot block the shell from showing the new thread. Partial failures surface toasts instead of tearing down the pane; **retention/grace timers** keep panes during sync or until the thread list catches up, then prune stale references.
> 
> **Sidebar activation** navigates to the **source thread**, opens the side chat in the right dock, and **clears `splitViewId`**—including **ignoring legacy splits** that paired a main thread with a side chat. **Persisted state** collapses duplicate sidechat tabs to one singleton that **switches embedded `threadId`** on reopen.
> 
> Labels change to **“Side chats”**; `/side` still respects composer attachment rules while the dock **+** action stays registered whenever the host thread can create a side chat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd2c1c131b173ec8a2ea953665027243a126bf6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->