### PR TITLE
Fix terminal cleanup after natural exit

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1945,6 +1945,7 @@ export default function ChatView({
     openNewFullWidthTerminal,
     activateTerminal,
     closeTerminal,
+    handleTerminalSessionExited,
     closeActiveWorkspaceView,
   } = useChatTerminalController({
     threadId,
@@ -4403,6 +4404,7 @@ export default function ChatView({
       workspaceCloseShortcutLabel: closeWorkspaceShortcutLabel ?? undefined,
       onActiveTerminalChange: activateTerminal,
       onCloseTerminal: closeTerminal,
+      onTerminalSessionExited: handleTerminalSessionExited,
       onCloseTerminalGroup: (groupId: string) => {
         if (!activeThreadId) return;
         storeCloseTerminalGroup(activeThreadId, groupId);
@@ -4439,6 +4441,7 @@ export default function ChatView({
       activateTerminal,
       addTerminalContextToDraft,
       closeTerminal,
+      handleTerminalSessionExited,
       closeTerminalShortcutLabel,
       closeWorkspaceShortcutLabel,
       createNewTerminal,

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -488,6 +488,7 @@ interface ThreadTerminalDrawerProps {
   workspaceCloseShortcutLabel?: string | undefined;
   onActiveTerminalChange: (terminalId: string) => void;
   onCloseTerminal: (terminalId: string) => void;
+  onTerminalSessionExited: (terminalId: string) => void;
   onCloseTerminalGroup: (groupId: string) => void;
   onHeightChange: (height: number) => void;
   onResizeTerminalSplit: (groupId: string, splitId: string, weights: number[]) => void;
@@ -534,6 +535,7 @@ export default function ThreadTerminalDrawer({
   workspaceCloseShortcutLabel,
   onActiveTerminalChange,
   onCloseTerminal,
+  onTerminalSessionExited,
   onCloseTerminalGroup,
   onHeightChange,
   onResizeTerminalSplit,
@@ -747,7 +749,7 @@ export default function ThreadTerminalDrawer({
                   terminalCliKind={terminalVisualIdentityById.get(terminalId)?.cliKind ?? null}
                   cwd={cwd}
                   {...(runtimeEnv ? { runtimeEnv } : {})}
-                  onSessionExited={() => onCloseTerminal(terminalId)}
+                  onSessionExited={() => onTerminalSessionExited(terminalId)}
                   onTerminalMetadataChange={onTerminalMetadataChange}
                   onTerminalActivityChange={onTerminalActivityChange}
                   onAddTerminalContext={onAddTerminalContext}

--- a/apps/web/src/components/chat/DockTerminalPane.tsx
+++ b/apps/web/src/components/chat/DockTerminalPane.tsx
@@ -114,6 +114,7 @@ export function DockTerminalPane(props: {
       onMoveTerminalToGroup={terminal.moveTerminalToNewGroup}
       onActiveTerminalChange={terminal.activateTerminal}
       onCloseTerminal={terminal.closeTerminal}
+      onTerminalSessionExited={terminal.handleTerminalSessionExited}
       onCloseTerminalGroup={terminal.closeTerminalGroup}
       onHeightChange={terminal.setTerminalHeight}
       onResizeTerminalSplit={terminal.resizeTerminalSplit}

--- a/apps/web/src/components/chat/useChatTerminalController.test.ts
+++ b/apps/web/src/components/chat/useChatTerminalController.test.ts
@@ -251,4 +251,29 @@ describe("useChatTerminalController", () => {
     expect(onDeletePlaceholderThread).toHaveBeenCalledWith(THREAD_ID);
     expect(result.terminalFocusRequestId).toBe(1);
   });
+
+  it("finalizes a naturally exited terminal without confirmation or placeholder deletion", () => {
+    terminalHarness.terminalState = {
+      ...terminalHarness.makeTerminalState(["terminal-1"]),
+      runningTerminalIds: ["terminal-1"],
+    };
+    terminalLogic.shouldAutoDelete.mockReturnValue(true);
+    let result = render();
+
+    result.handleTerminalSessionExited("terminal-1");
+    result = render();
+
+    expect(nativeApi.confirm).not.toHaveBeenCalled();
+    expect(terminalLogic.shouldAutoDelete).not.toHaveBeenCalled();
+    expect(terminalSession.disposeAndClose).toHaveBeenCalledWith({
+      api: expect.any(Object),
+      threadId: THREAD_ID,
+      terminalId: "terminal-1",
+      clearHistoryBeforeClose: true,
+      processAlreadyExited: true,
+    });
+    expect(terminalHarness.actions.closeTerminal).toHaveBeenCalledWith(THREAD_ID, "terminal-1");
+    expect(onDeletePlaceholderThread).not.toHaveBeenCalled();
+    expect(result.terminalFocusRequestId).toBe(1);
+  });
 });

--- a/apps/web/src/components/chat/useChatTerminalController.ts
+++ b/apps/web/src/components/chat/useChatTerminalController.ts
@@ -297,6 +297,22 @@ export function useChatTerminalController({
       terminalState.terminalTitleOverridesById,
     ],
   );
+  const handleTerminalSessionExited = useCallback(
+    (terminalId: string) => {
+      if (!activeThreadId) return;
+      const isFinalTerminal = terminalState.terminalIds.length <= 1;
+      disposeAndCloseTerminalSession({
+        api: readNativeApi(),
+        threadId: activeThreadId,
+        terminalId,
+        clearHistoryBeforeClose: isFinalTerminal,
+        processAlreadyExited: true,
+      });
+      closeTerminalInStore(activeThreadId, terminalId);
+      requestTerminalFocus();
+    },
+    [activeThreadId, closeTerminalInStore, requestTerminalFocus, terminalState.terminalIds.length],
+  );
   const closeActiveWorkspaceView = useCallback(() => {
     if (!activeThreadId || !terminalWorkspaceOpen) return;
     if (terminalState.workspaceLayout === "both" && terminalState.workspaceActiveTab === "chat") {
@@ -355,6 +371,7 @@ export function useChatTerminalController({
     openNewFullWidthTerminal,
     activateTerminal,
     closeTerminal,
+    handleTerminalSessionExited,
     closeActiveWorkspaceView,
   };
 }

--- a/apps/web/src/components/terminal/terminalRuntime.ts
+++ b/apps/web/src/components/terminal/terminalRuntime.ts
@@ -1056,6 +1056,11 @@ export function createRuntimeEntry(config: TerminalRuntimeConfig): TerminalRunti
 
       if (event.type === "exited") {
         flushPendingWrites(entry);
+        setRuntimeStatus(entry, "exited");
+        entry.callbacks.onTerminalActivityChange(entry.terminalId, {
+          hasRunningSubprocess: false,
+          agentState: null,
+        });
         const details = [
           typeof event.exitCode === "number" ? `code ${event.exitCode}` : null,
           typeof event.exitSignal === "number" ? `signal ${event.exitSignal}` : null,

--- a/apps/web/src/components/terminal/terminalRuntimeTypes.ts
+++ b/apps/web/src/components/terminal/terminalRuntimeTypes.ts
@@ -48,7 +48,7 @@ export interface TerminalPendingWrite {
   queuedAt: number;
 }
 
-export type TerminalRuntimeStatus = "connecting" | "replaying" | "ready" | "error";
+export type TerminalRuntimeStatus = "connecting" | "replaying" | "ready" | "exited" | "error";
 
 export interface TerminalRuntimeEntry {
   runtimeKey: string;

--- a/apps/web/src/components/terminal/terminalSession.ts
+++ b/apps/web/src/components/terminal/terminalSession.ts
@@ -37,11 +37,16 @@ export function disposeAndCloseTerminalSession(input: {
   threadId: string;
   terminalId: string;
   clearHistoryBeforeClose?: boolean;
+  processAlreadyExited?: boolean;
 }): void {
   const { api, threadId, terminalId } = input;
 
-  const fallbackExitWrite = () =>
-    api?.terminal.write({ threadId, terminalId, data: "exit\n" }).catch(() => undefined);
+  const fallbackExitWrite = () => {
+    if (input.processAlreadyExited) {
+      return Promise.resolve();
+    }
+    return api?.terminal.write({ threadId, terminalId, data: "exit\n" }).catch(() => undefined);
+  };
 
   // Local disposal stays ordered before the server close, as it was when the
   // registry was imported statically.

--- a/apps/web/src/hooks/useTerminalSurfaceController.ts
+++ b/apps/web/src/hooks/useTerminalSurfaceController.ts
@@ -103,6 +103,17 @@ export function useTerminalSurfaceController(threadId: ThreadId) {
     bumpFocusRequest();
   };
 
+  const handleTerminalSessionExited = (terminalId: string) => {
+    disposeAndCloseTerminalSession({
+      api: readNativeApi(),
+      threadId,
+      terminalId,
+      processAlreadyExited: true,
+    });
+    closeTerminalStore(threadId, terminalId);
+    bumpFocusRequest();
+  };
+
   const closeTerminalGroup = (groupId: string) => closeTerminalGroupStore(threadId, groupId);
 
   const setTerminalHeight = (height: number) => setTerminalHeightStore(threadId, height);
@@ -128,6 +139,7 @@ export function useTerminalSurfaceController(threadId: ThreadId) {
     moveTerminalToNewGroup,
     activateTerminal,
     closeTerminal,
+    handleTerminalSessionExited,
     closeTerminalGroup,
     setTerminalHeight,
     resizeTerminalSplit,


### PR DESCRIPTION
## Summary
- model terminal sessions that have exited separately from running sessions
- clear terminal activity and close only the exited tab when `exit` completes
- avoid manual-close confirmation and placeholder deletion for natural exits
- skip sending a second fallback `exit` command to an already exited session

## Root cause
Natural process exit flowed through the same UI path as a user-requested destructive close, leaving stale state and causing confirmation/cleanup races.

## Verification
- focused terminal tests — 164 tests passed
- `bun run --cwd apps/web build` — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal lifecycle and store cleanup across chat and dock surfaces; behavior change is intentional but could affect edge cases around last-tab close and thread placeholders.
> 
> **Overview**
> **Fixes terminal cleanup when a process exits on its own** by routing `onSessionExited` through a new `handleTerminalSessionExited` handler instead of the user-initiated `closeTerminal` path.
> 
> That handler disposes the session with `processAlreadyExited: true`, removes the tab from the store, and refocuses—**without** the close-confirmation dialog, auto-delete placeholder-thread logic, or sending a fallback `exit` command to an already-dead session. The same callback is plumbed through chat terminal controllers, `ThreadTerminalDrawer`, and dock panes.
> 
> On the runtime side, an **`exited`** status is recorded when the backend reports exit, and terminal activity is cleared before the UI teardown runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf7b208562a525fbafd59380f58698bebb42b6ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->