### PR TITLE
fix(shared): keep the outbound error listener attached

### DIFF
--- a/packages/shared/src/outboundHttp.test.ts
+++ b/packages/shared/src/outboundHttp.test.ts
@@ -1,7 +1,7 @@
 import { createServer, type Server } from "node:net";
 import { describe, expect, it } from "vitest";
 
-import { outboundHttp } from "./outboundHttp.ts";
+import { outboundHttp } from "./outboundHttp";
 
 /**
  * A port nothing is listening on, so every connection attempt is refused.

--- a/packages/shared/src/outboundHttp.test.ts
+++ b/packages/shared/src/outboundHttp.test.ts
@@ -1,0 +1,72 @@
+import { createServer, type Server } from "node:net";
+import { describe, expect, it } from "vitest";
+
+import { outboundHttp } from "./outboundHttp.ts";
+
+/**
+ * A port nothing is listening on, so every connection attempt is refused.
+ *
+ * HTTPS because the outbound policy rejects plain HTTP destinations outright,
+ * which would fail the request before it ever reaches a socket.
+ *
+ * Taken by opening a server and closing it, which is more reliable than picking
+ * a number and hoping: the OS will not hand the same port out again while this
+ * process holds the reference.
+ */
+async function refusedPort(): Promise<number> {
+  const server: Server = createServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address !== null ? address.port : 0;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return port;
+}
+
+const policyFor = (port: number) => ({
+  service: "test",
+  allowedOrigins: [`https://127.0.0.1:${port}`],
+  timeoutMs: 5_000,
+  maxRequestBytes: 0,
+  maxResponseBytes: 64 * 1024,
+  maxRedirects: 0,
+  maxConcurrent: 2,
+  maxQueued: 4,
+  requirePublicAddress: false,
+});
+
+/**
+ * These cover the observable contract: a refused connection rejects, and the
+ * client is still usable afterwards.
+ *
+ * The specific regression behind the `on`/`once` change is not reproducible
+ * here. It needs a host whose addresses all refuse so Happy Eyeballs emits
+ * `error` more than once, and the client pins DNS to a single address, so a
+ * request from this suite can only ever emit once. It was reproduced by hand
+ * against a real multi-address host: the request rejected correctly, execution
+ * continued, and the process then died on the second emit.
+ */
+describe("outbound requests that cannot connect", () => {
+  it("rejects rather than hanging", async () => {
+    const port = await refusedPort();
+
+    await expect(
+      outboundHttp.request({
+        policy: policyFor(port),
+        url: `https://127.0.0.1:${port}/favicon.ico`,
+        headers: { Accept: "image/*" },
+      }),
+    ).rejects.toThrow(/Outbound request failed/u);
+  });
+
+  it("stays usable for the next caller after a connection failure", async () => {
+    const port = await refusedPort();
+
+    await expect(
+      outboundHttp.request({
+        policy: policyFor(port),
+        url: `https://127.0.0.1:${port}/again.ico`,
+        headers: { Accept: "image/*" },
+      }),
+    ).rejects.toThrow(/Outbound request failed/u);
+  });
+});

--- a/packages/shared/src/outboundHttp.ts
+++ b/packages/shared/src/outboundHttp.ts
@@ -408,12 +408,20 @@ async function requestHop(input: {
             url: input.url.href,
           });
         });
-        response.once("error", (cause) => {
+        // `on`, not `once`: a stream can emit `error` more than once, and a
+        // second emit with no listener attached is fatal to the process.
+        response.on("error", (cause) => {
           settle(new OutboundHttpError("request", "Outbound response failed.", cause));
         });
       },
     );
-    request.once("error", (cause) => {
+    // Also `on` rather than `once`. Happy Eyeballs tries each resolved address
+    // in turn, so a host that refuses all of them emits `error` once per
+    // attempt. `once` detaches after the first, `settle` correctly ignores the
+    // rest as duplicates, and those later emits then reach a request with no
+    // error listener. Node treats an unhandled `error` event as fatal, so the
+    // whole server exits: a failed favicon fetch could take the process down.
+    request.on("error", (cause) => {
       if (input.signal.aborted) {
         settle(abortedError(input.signal.reason));
       } else {


### PR DESCRIPTION
A failed outbound HTTP request can kill the server process.

Reproduced against the favicon URL `siteFaviconCache` uses. The ordering is the tell:

```
start
caught: OutboundHttpError: Outbound request failed.   <- handled
STILL ALIVE                                            <- execution continued
error: connect ECONNREFUSED www.google.com:443         <- then the process died
```

The error was caught and the code moved on, then a *second* error arrived and took the process down.

## Cause

Both listeners in `requestHop` were registered with `once`:

```ts
request.once("error", (cause) => { ... settle(...) })
```

Happy Eyeballs tries each resolved address in turn, so a host whose addresses all refuse emits `error` once per attempt. The first emit settles the promise and `once` detaches the listener. `settle` correctly ignores the later emits as duplicates, but nothing is listening for them any more, and Node treats an unhandled `error` event as fatal.

Anyone on flaky DNS or behind a captive portal can lose their session to a favicon fetch. It is not favicon-specific: it applies to every caller of `outboundHttp`, which is why the fix is in the client rather than in `siteFaviconCache`.

## Fix

Both listeners now use `on`, so they stay attached for the life of the request. `settle` already guarded against double resolution, so the extra emits are absorbed rather than duplicated. Two lines, plus comments explaining why `once` is wrong here.

## Testing

The regression is not reproducible in a unit test, and I would rather say so than ship a test that passes either way. It needs a host whose addresses all refuse so more than one `error` is emitted, and the client pins DNS to a single address, so a request from a test can only ever emit once. I tried a loopback port and confirmed it passes with and without the fix.

The added tests cover the observable contract instead: a refused connection rejects, and the client is still usable afterwards. The crash itself was verified by hand, before and after, with the script above.

`bun lint` is clean and the shared suite passes 507 tests.