### PR TITLE
fix(server): throttle failed git upstream refreshes

### DIFF
--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -8,19 +8,7 @@ import path from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
-import {
-  Duration,
-  Effect,
-  Exit,
-  FileSystem,
-  Layer,
-  Logger,
-  PlatformError,
-  Schema,
-  Scope,
-  Stream,
-} from "effect";
-import { TestClock } from "effect/testing";
+import { Effect, Exit, FileSystem, Layer, PlatformError, Schema, Scope, Stream } from "effect";
 import { describe, expect, vi } from "vitest";
 
 import { collectGitOutput, GitCoreLive, makeGitCore } from "./GitCore.ts";
@@ -2330,57 +2318,6 @@ it.layer(TestLayer)("git integration", (it) => {
           expect(details.behindCount).toBe(1);
         }),
     );
-
-    it.effect("logs a failed status upstream refresh only once per retry window", () => {
-      const messages: string[] = [];
-      const logger = Logger.make(({ message }) => {
-        messages.push(String(message));
-      });
-
-      return Effect.gen(function* () {
-        const remote = yield* makeTmpDir();
-        const source = yield* makeTmpDir();
-        yield* git(remote, ["init", "--bare"]);
-        const { initialBranch } = yield* initRepoWithCommit(source);
-        yield* git(source, ["remote", "add", "origin", remote]);
-        yield* git(source, ["push", "-u", "origin", initialBranch]);
-
-        const realGitCore = yield* GitCore;
-        let fetchAttempts = 0;
-        const core = yield* makeIsolatedGitCore((input) => {
-          if (input.args[0] === "fetch") {
-            fetchAttempts += 1;
-            return Effect.fail(
-              new GitCommandError({
-                operation: "git.test.statusRefreshFailure",
-                command: `git ${input.args.join(" ")}`,
-                cwd: input.cwd,
-                detail: "simulated fetch timeout",
-              }),
-            );
-          }
-          return realGitCore.execute(input);
-        });
-
-        yield* core.statusDetails(source);
-        yield* core.statusDetails(source);
-        yield* core.statusDetails(source);
-
-        const refreshFailureLogs = () =>
-          messages.filter((message) => message.includes("Git status upstream refresh failed"));
-        expect(fetchAttempts).toBe(1);
-        expect(refreshFailureLogs()).toHaveLength(1);
-
-        yield* TestClock.adjust(Duration.seconds(31));
-        yield* core.statusDetails(source);
-
-        expect(fetchAttempts).toBe(2);
-        expect(refreshFailureLogs()).toHaveLength(2);
-      }).pipe(
-        Effect.provide(Logger.layer([logger], { mergeWithExisting: false })),
-        Effect.provide(TestClock.layer()),
-      );
-    });
 
     it.effect("returns UI status before its background upstream refresh completes", () =>
       Effect.gen(function* () {

--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -8,7 +8,19 @@ import path from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
-import { Effect, Exit, FileSystem, Layer, PlatformError, Schema, Scope, Stream } from "effect";
+import {
+  Duration,
+  Effect,
+  Exit,
+  FileSystem,
+  Layer,
+  Logger,
+  PlatformError,
+  Schema,
+  Scope,
+  Stream,
+} from "effect";
+import { TestClock } from "effect/testing";
 import { describe, expect, vi } from "vitest";
 
 import { collectGitOutput, GitCoreLive, makeGitCore } from "./GitCore.ts";
@@ -2318,6 +2330,57 @@ it.layer(TestLayer)("git integration", (it) => {
           expect(details.behindCount).toBe(1);
         }),
     );
+
+    it.effect("logs a failed status upstream refresh only once per retry window", () => {
+      const messages: string[] = [];
+      const logger = Logger.make(({ message }) => {
+        messages.push(String(message));
+      });
+
+      return Effect.gen(function* () {
+        const remote = yield* makeTmpDir();
+        const source = yield* makeTmpDir();
+        yield* git(remote, ["init", "--bare"]);
+        const { initialBranch } = yield* initRepoWithCommit(source);
+        yield* git(source, ["remote", "add", "origin", remote]);
+        yield* git(source, ["push", "-u", "origin", initialBranch]);
+
+        const realGitCore = yield* GitCore;
+        let fetchAttempts = 0;
+        const core = yield* makeIsolatedGitCore((input) => {
+          if (input.args[0] === "fetch") {
+            fetchAttempts += 1;
+            return Effect.fail(
+              new GitCommandError({
+                operation: "git.test.statusRefreshFailure",
+                command: `git ${input.args.join(" ")}`,
+                cwd: input.cwd,
+                detail: "simulated fetch timeout",
+              }),
+            );
+          }
+          return realGitCore.execute(input);
+        });
+
+        yield* core.statusDetails(source);
+        yield* core.statusDetails(source);
+        yield* core.statusDetails(source);
+
+        const refreshFailureLogs = () =>
+          messages.filter((message) => message.includes("Git status upstream refresh failed"));
+        expect(fetchAttempts).toBe(1);
+        expect(refreshFailureLogs()).toHaveLength(1);
+
+        yield* TestClock.adjust(Duration.seconds(31));
+        yield* core.statusDetails(source);
+
+        expect(fetchAttempts).toBe(2);
+        expect(refreshFailureLogs()).toHaveLength(2);
+      }).pipe(
+        Effect.provide(Logger.layer([logger], { mergeWithExisting: false })),
+        Effect.provide(TestClock.layer()),
+      );
+    });
 
     it.effect("returns UI status before its background upstream refresh completes", () =>
       Effect.gen(function* () {

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -58,12 +58,13 @@ const STATUS_UPSTREAM_REFRESH_FAILURE_INTERVAL = Duration.seconds(30);
 // latency). Align with the success refresh interval.
 const STATUS_UPSTREAM_REFRESH_TIMEOUT = Duration.seconds(15);
 const STATUS_UPSTREAM_REFRESH_CACHE_CAPACITY = 2_048;
+type StatusUpstreamRefreshResult = "refreshed" | "failed";
 
 /** Pure policy for status-upstream refresh cache TTL (#515). Exported for tests. */
 export function statusUpstreamRefreshCacheTimeToLive(
-  exit: Exit.Exit<unknown, unknown>,
+  exit: Exit.Exit<StatusUpstreamRefreshResult, unknown>,
 ): Duration.Duration {
-  return Exit.isSuccess(exit)
+  return Exit.isSuccess(exit) && exit.value === "refreshed"
     ? STATUS_UPSTREAM_REFRESH_INTERVAL
     : STATUS_UPSTREAM_REFRESH_FAILURE_INTERVAL;
 }
@@ -1015,16 +1016,23 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
     const statusUpstreamRefreshCache = yield* Cache.makeWith({
       capacity: STATUS_UPSTREAM_REFRESH_CACHE_CAPACITY,
       lookup: (cacheKey: StatusUpstreamRefreshCacheKey) =>
-        Effect.gen(function* () {
-          yield* fetchUpstreamRefForStatus(cacheKey.cwd, {
-            upstreamRef: cacheKey.upstreamRef,
-            remoteName: cacheKey.remoteName,
-            upstreamBranch: cacheKey.upstreamBranch,
-          });
-          return true as const;
-        }),
+        fetchUpstreamRefForStatus(cacheKey.cwd, {
+          upstreamRef: cacheKey.upstreamRef,
+          remoteName: cacheKey.remoteName,
+          upstreamBranch: cacheKey.upstreamBranch,
+        }).pipe(
+          Effect.as("refreshed" as const),
+          Effect.catch((cause) =>
+            Effect.logWarning("Git status upstream refresh failed; retry is temporarily paused", {
+              cause,
+              cwd: cacheKey.cwd,
+              remoteName: cacheKey.remoteName,
+              upstreamBranch: cacheKey.upstreamBranch,
+            }).pipe(Effect.as("failed" as const)),
+          ),
+        ),
       // Keep successful refreshes warm; also cache failures so unreachable
-      // remotes do not re-fetch on every git.status (#515).
+      // remotes neither re-fetch nor re-log on every git.status (#515).
       timeToLive: statusUpstreamRefreshCacheTimeToLive,
     });
 

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -62,7 +62,7 @@ type StatusUpstreamRefreshResult = "refreshed" | "failed";
 
 /** Pure policy for status-upstream refresh cache TTL (#515). Exported for tests. */
 export function statusUpstreamRefreshCacheTimeToLive(
-  exit: Exit.Exit<StatusUpstreamRefreshResult, unknown>,
+  exit: Exit.Exit<StatusUpstreamRefreshResult, never>,
 ): Duration.Duration {
   return Exit.isSuccess(exit) && exit.value === "refreshed"
     ? STATUS_UPSTREAM_REFRESH_INTERVAL

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -1007,7 +1007,6 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
         cwd,
         ["fetch", "--quiet", "--no-tags", upstream.remoteName, refspec],
         {
-          allowNonZeroExit: true,
           timeoutMs: Duration.toMillis(STATUS_UPSTREAM_REFRESH_TIMEOUT),
         },
       ).pipe(Effect.asVoid);

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -48,9 +48,25 @@ import { ServerConfig } from "../../config.ts";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
+// Successful upstream refreshes stay warm for 15s. Failures used to use
+// Duration.zero, which re-ran `git fetch` on every git.status and created a
+// permanent fetch storm for unreachable remotes (#515). Cache failures too,
+// with a longer TTL so a dead remote settles into occasional retries.
 const STATUS_UPSTREAM_REFRESH_INTERVAL = Duration.seconds(15);
-const STATUS_UPSTREAM_REFRESH_TIMEOUT = Duration.seconds(5);
+const STATUS_UPSTREAM_REFRESH_FAILURE_INTERVAL = Duration.seconds(30);
+// 5s was below realistic authenticated-fetch cost on Windows (credential helper
+// latency). Align with the success refresh interval.
+const STATUS_UPSTREAM_REFRESH_TIMEOUT = Duration.seconds(15);
 const STATUS_UPSTREAM_REFRESH_CACHE_CAPACITY = 2_048;
+
+/** Pure policy for status-upstream refresh cache TTL (#515). Exported for tests. */
+export function statusUpstreamRefreshCacheTimeToLive(
+  exit: Exit.Exit<unknown, unknown>,
+): Duration.Duration {
+  return Exit.isSuccess(exit)
+    ? STATUS_UPSTREAM_REFRESH_INTERVAL
+    : STATUS_UPSTREAM_REFRESH_FAILURE_INTERVAL;
+}
 const DEFAULT_BASE_BRANCH_CANDIDATES = ["main", "master"] as const;
 const EMPTY_TREE_OBJECT_ID = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
 const WORKING_TREE_DIFF_TIMEOUT_MS = 15_000;
@@ -1007,9 +1023,9 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
           });
           return true as const;
         }),
-      // Keep successful refreshes warm; drop failures immediately so next request can retry.
-      timeToLive: (exit) =>
-        Exit.isSuccess(exit) ? STATUS_UPSTREAM_REFRESH_INTERVAL : Duration.zero,
+      // Keep successful refreshes warm; also cache failures so unreachable
+      // remotes do not re-fetch on every git.status (#515).
+      timeToLive: statusUpstreamRefreshCacheTimeToLive,
     });
 
     const refreshStatusUpstreamIfStale = (cwd: string): Effect.Effect<void, GitCommandError> =>

--- a/apps/server/src/git/Layers/gitUpstreamRefreshPolicy.test.ts
+++ b/apps/server/src/git/Layers/gitUpstreamRefreshPolicy.test.ts
@@ -1,0 +1,25 @@
+import { Duration, Exit } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { statusUpstreamRefreshCacheTimeToLive } from "./GitCore.ts";
+
+describe("statusUpstreamRefreshCacheTimeToLive (#515)", () => {
+  it("keeps successful upstream refreshes warm for 15 seconds", () => {
+    expect(Duration.toMillis(statusUpstreamRefreshCacheTimeToLive(Exit.void))).toBe(15_000);
+  });
+
+  it("caches failures for 30 seconds instead of Duration.zero", () => {
+    const failed = Exit.fail(new Error("git fetch timed out"));
+    // A zero TTL re-ran fetch on every git.status for unreachable remotes.
+    expect(Duration.toMillis(statusUpstreamRefreshCacheTimeToLive(failed))).toBe(30_000);
+    expect(Duration.toMillis(statusUpstreamRefreshCacheTimeToLive(failed))).toBeGreaterThan(0);
+  });
+
+  it("throttles failures at least as long as successes", () => {
+    const successMs = Duration.toMillis(statusUpstreamRefreshCacheTimeToLive(Exit.void));
+    const failureMs = Duration.toMillis(
+      statusUpstreamRefreshCacheTimeToLive(Exit.fail("unreachable")),
+    );
+    expect(failureMs).toBeGreaterThanOrEqual(successMs);
+  });
+});

--- a/apps/server/src/git/Layers/gitUpstreamRefreshPolicy.test.ts
+++ b/apps/server/src/git/Layers/gitUpstreamRefreshPolicy.test.ts
@@ -5,20 +5,24 @@ import { statusUpstreamRefreshCacheTimeToLive } from "./GitCore.ts";
 
 describe("statusUpstreamRefreshCacheTimeToLive (#515)", () => {
   it("keeps successful upstream refreshes warm for 15 seconds", () => {
-    expect(Duration.toMillis(statusUpstreamRefreshCacheTimeToLive(Exit.void))).toBe(15_000);
+    expect(Duration.toMillis(statusUpstreamRefreshCacheTimeToLive(Exit.succeed("refreshed")))).toBe(
+      15_000,
+    );
   });
 
-  it("caches failures for 30 seconds instead of Duration.zero", () => {
-    const failed = Exit.fail(new Error("git fetch timed out"));
+  it("caches handled failures for 30 seconds instead of Duration.zero", () => {
+    const failed = Exit.succeed("failed" as const);
     // A zero TTL re-ran fetch on every git.status for unreachable remotes.
     expect(Duration.toMillis(statusUpstreamRefreshCacheTimeToLive(failed))).toBe(30_000);
     expect(Duration.toMillis(statusUpstreamRefreshCacheTimeToLive(failed))).toBeGreaterThan(0);
   });
 
   it("throttles failures at least as long as successes", () => {
-    const successMs = Duration.toMillis(statusUpstreamRefreshCacheTimeToLive(Exit.void));
+    const successMs = Duration.toMillis(
+      statusUpstreamRefreshCacheTimeToLive(Exit.succeed("refreshed")),
+    );
     const failureMs = Duration.toMillis(
-      statusUpstreamRefreshCacheTimeToLive(Exit.fail("unreachable")),
+      statusUpstreamRefreshCacheTimeToLive(Exit.succeed("failed")),
     );
     expect(failureMs).toBeGreaterThanOrEqual(successMs);
   });


### PR DESCRIPTION
## Summary

Closes **#515**.

When a project's upstream remote is unreachable (or `git fetch` exceeds the timeout), Synara re-ran `git fetch` on **every** `git.status` call because the status-upstream cache used `Duration.zero` TTL on the failure path. Combined with a tight 5s timeout, that produced a permanent fetch storm in the server log.

### Fix
- Cache **failed** upstream refreshes for **30s** (successes stay at 15s)
- Raise status-upstream fetch timeout from **5s → 15s** (Windows credential-helper latency)
- Export pure TTL policy helper for unit coverage

## Evidence (tests only — no synthetic UI screenshots)

```text
$ cd apps/server && bun run test -- src/git/Layers/gitUpstreamRefreshPolicy.test.ts
✓ statusUpstreamRefreshCacheTimeToLive (#515) (3)
```

| Case | Result |
|------|--------|
| Success TTL | 15_000 ms |
| Failure TTL | 30_000 ms (was effectively 0) |
| Failure ≥ success throttle | pass |

## Test plan
- [x] Unit policy tests above
- [ ] Manual: open project with dead upstream → server log should not spam fetch timeouts every few seconds