### PR TITLE
fix(providers): settle Antigravity turns on cancel and clean stop

### DIFF
--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -73,6 +73,31 @@ function closeControllableAntigravityChild(
   child.emit("close", code, signal);
 }
 
+function makeGatewayCredentials(onRevoke: (token: string) => void): AgentGatewayCredentialsShape {
+  let tokenSequence = 0;
+  return {
+    mcpEndpointUrl: "http://127.0.0.1:3773/mcp",
+    setListeningPort: () => undefined,
+    issueSessionToken: () => `test-session-${String(++tokenSequence)}`,
+    verifySessionToken: () => null,
+    verifySession: () => null,
+    issueStdioBootstrapToken: (token) => `bootstrap-${token}`,
+    exchangeStdioBootstrapToken: () => null,
+    bindWriteAuthority: () => null,
+    verifyWriteAuthority: () => false,
+    registerInFlightRequest: () => () => undefined,
+    cancelInFlightRequests: () => ({ count: 0, settled: Promise.resolve() }),
+    cancelSessionTurnRequests: () => Promise.resolve(),
+    retireSessionTurn: () => Promise.resolve(),
+    revokeSessionToken: onRevoke,
+    connectionForThread: () => ({
+      url: "http://127.0.0.1:3773/mcp",
+      bearerToken: `test-session-${String(++tokenSequence)}`,
+    }),
+    stdioProxy: { command: process.execPath, args: ["proxy.mjs"] },
+  };
+}
+
 describe("Antigravity CLI model translation", () => {
   it("collapses CLI model/effort labels into base models with effort ladders", () => {
     expect(
@@ -723,6 +748,10 @@ describe("Antigravity turn settle on cancel (#465)", () => {
   it("drains final output before settling a successfully interrupted process", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-close-drain-"));
     const child = makeControllableAntigravityChild();
+    let resolveTreeExit!: (result: { escalated: boolean; signalErrors: Error[] }) => void;
+    const treeExit = new Promise<{ escalated: boolean; signalErrors: Error[] }>((resolve) => {
+      resolveTreeExit = resolve;
+    });
     const spawnProcess = (() => child) as NonNullable<
       AntigravityAdapterDependencies["spawnProcess"]
     >;
@@ -734,7 +763,8 @@ describe("Antigravity turn settle on cancel (#465)", () => {
         child.stderr.end();
         closeControllableAntigravityChild(child, null, "SIGTERM");
       }, 10);
-      return { escalated: false, signalErrors: [] };
+      setTimeout(() => resolveTreeExit({ escalated: false, signalErrors: [] }), 30);
+      return treeExit;
     };
 
     try {
@@ -784,6 +814,77 @@ describe("Antigravity turn settle on cancel (#465)", () => {
             }).pipe(
               Layer.provideMerge(
                 ServerConfig.layerTest(root, { prefix: "antigravity-close-drain-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps interrupt ownership when root closes before tree-exit proof fails", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-interrupt-proof-"));
+    const child = makeControllableAntigravityChild();
+    const spawnProcess = (() => child) as NonNullable<
+      AntigravityAdapterDependencies["spawnProcess"]
+    >;
+    const teardownProcessTree: NonNullable<
+      AntigravityAdapterDependencies["teardownProcessTree"]
+    > = async () => {
+      setTimeout(() => {
+        child.stdout.end("output before failed proof\n");
+        child.stderr.end();
+        closeControllableAntigravityChild(child, null, "SIGTERM");
+      }, 10);
+      await new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("interrupt descendants remain alive")), 30),
+      );
+      return { escalated: false, signalErrors: [] };
+    };
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-interrupt-proof");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+          const turn = yield* adapter.sendTurn({
+            threadId,
+            input: "cancel with surviving descendants",
+            attachments: [],
+          });
+          yield* adapter.interruptTurn(threadId, turn.turnId);
+
+          const afterFailedProof = (yield* adapter.listSessions()).find(
+            (session) => session.threadId === threadId,
+          );
+          expect(afterFailedProof?.status).toBe("running");
+          expect(afterFailedProof?.activeTurnId).toBe(turn.turnId);
+          yield* adapter.sendTurn({ threadId, input: "must remain blocked", attachments: [] }).pipe(
+            Effect.flip,
+            Effect.tap((error) =>
+              Effect.sync(() => expect(error.message).toContain("already active")),
+            ),
+          );
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+              teardownProcessTree,
+              closeDrainTimeoutMs: 100,
+            }).pipe(
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-interrupt-proof-" }),
               ),
               Layer.provideMerge(NodeServices.layer),
             ),
@@ -951,8 +1052,15 @@ describe("Antigravity turn settle on cancel (#465)", () => {
               Effect.sync(() => expect(error.message).toContain("already active")),
             ),
           );
-          yield* adapter.stopSession(threadId);
-          expect(teardownCalls).toBe(2);
+          yield* adapter.stopSession(threadId).pipe(
+            Effect.flip,
+            Effect.tap((error) =>
+              Effect.sync(() =>
+                expect(error.message).toContain("descendant exit remains unproven"),
+              ),
+            ),
+          );
+          expect(teardownCalls).toBe(1);
         }).pipe(
           Effect.provide(
             makeAntigravityAdapterLive({
@@ -963,6 +1071,161 @@ describe("Antigravity turn settle on cancel (#465)", () => {
             }).pipe(
               Layer.provideMerge(
                 ServerConfig.layerTest(root, { prefix: "antigravity-stop-unproven-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not start teardown from a Stop hook discovered after root close", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-short-close-"));
+    const child = makeControllableAntigravityChild();
+    let eventFile = "";
+    let teardownCalls = 0;
+    const spawnProcess = ((
+      _command: string,
+      _args: readonly string[],
+      options: { readonly env?: NodeJS.ProcessEnv },
+    ) => {
+      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS ?? "";
+      return child;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+    const teardownProcessTree: NonNullable<
+      AntigravityAdapterDependencies["teardownProcessTree"]
+    > = async () => {
+      teardownCalls += 1;
+      return { escalated: false, signalErrors: [] };
+    };
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const runtimeEventsFiber = yield* Stream.runCollect(
+            Stream.take(adapter.streamEvents, 7),
+          ).pipe(Effect.forkChild);
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-short-close");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+          const turn = yield* adapter.sendTurn({
+            threadId,
+            input: "short successful turn",
+            attachments: [],
+          });
+          yield* Effect.promise(() => fs.appendFile(eventFile, "stop\t{}\n"));
+          child.stdout.end("short response\n");
+          child.stderr.end();
+          closeControllableAntigravityChild(child, 0, null);
+
+          const runtimeEvents = Array.from(
+            yield* Fiber.join(runtimeEventsFiber).pipe(Effect.timeout("5 seconds")),
+          );
+          expect(teardownCalls).toBe(0);
+          const completed = runtimeEvents.find((event) => event.type === "turn.completed");
+          expect(completed?.turnId).toBe(turn.turnId);
+          expect(completed?.payload).toMatchObject({
+            state: "completed",
+            stopReason: "model_stop",
+          });
+          yield* adapter.stopSession(threadId);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+              teardownProcessTree,
+            }).pipe(
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-short-close-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("cleans turn resources before Stop close-drain timeout settlement", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-stop-timeout-"));
+    const child = makeControllableAntigravityChild();
+    const revokedTokens: string[] = [];
+    const credentials = makeGatewayCredentials((token) => revokedTokens.push(token));
+    let eventFile = "";
+    const spawnProcess = ((
+      _command: string,
+      _args: readonly string[],
+      options: { readonly env?: NodeJS.ProcessEnv },
+    ) => {
+      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS ?? "";
+      return child;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+    const teardownProcessTree: NonNullable<
+      AntigravityAdapterDependencies["teardownProcessTree"]
+    > = async () => ({ escalated: false, signalErrors: [] });
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-stop-timeout");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+          yield* adapter.sendTurn({
+            threadId,
+            input: "stop without close",
+            attachments: [],
+          });
+          const runDir = path.dirname(eventFile);
+          yield* Effect.promise(() => fs.appendFile(eventFile, "stop\t{}\n"));
+          for (let attempt = 0; attempt < 50; attempt += 1) {
+            const session = (yield* adapter.listSessions()).find(
+              (candidate) => candidate.threadId === threadId,
+            );
+            if (session?.status === "ready") break;
+            yield* Effect.sleep(10);
+          }
+
+          const settled = (yield* adapter.listSessions()).find(
+            (session) => session.threadId === threadId,
+          );
+          expect(settled?.status).toBe("ready");
+          expect(revokedTokens).toEqual(["test-session-1"]);
+          yield* Effect.promise(() =>
+            fs.stat(runDir).then(
+              () => expect.fail("expected the completed turn run directory to be removed"),
+              (error: NodeJS.ErrnoException) => expect(error.code).toBe("ENOENT"),
+            ),
+          );
+          yield* adapter.stopSession(threadId);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+              teardownProcessTree,
+              closeDrainTimeoutMs: 25,
+            }).pipe(
+              Layer.provide(Layer.succeed(AgentGatewayCredentials, credentials)),
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-stop-timeout-" }),
               ),
               Layer.provideMerge(NodeServices.layer),
             ),
@@ -1023,9 +1286,9 @@ describe("Antigravity turn settle on cancel (#465)", () => {
           const firstChild = children[0]!;
           const secondChild = children[1]!;
           yield* Effect.promise(() =>
-            fs.appendFile(
-              eventFiles[0]!,
-              `pre-invocation\t${JSON.stringify({ conversationId: "stale-conversation" })}\n`,
+            fs.stat(path.dirname(eventFiles[0]!)).then(
+              () => expect.fail("expected the interrupted turn run directory to be removed"),
+              (error: NodeJS.ErrnoException) => expect(error.code).toBe("ENOENT"),
             ),
           );
           firstChild.stdout.write("stale first-turn output\n");

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { PassThrough } from "node:stream";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { ThreadId } from "@synara/contracts";
+import { type ProviderRuntimeEvent, ThreadId } from "@synara/contracts";
 import { Effect, Fiber, Layer, Stream } from "effect";
 import { describe, expect, it } from "vitest";
 
@@ -974,6 +974,7 @@ describe("Antigravity turn settle on cancel (#465)", () => {
               spawnProcess,
               teardownProcessTree,
               closeDrainTimeoutMs: 100,
+              stopNaturalExitGraceMs: 10,
             }).pipe(
               Layer.provideMerge(
                 ServerConfig.layerTest(root, { prefix: "antigravity-model-stop-" }),
@@ -1068,6 +1069,7 @@ describe("Antigravity turn settle on cancel (#465)", () => {
               spawnProcess,
               teardownProcessTree,
               closeDrainTimeoutMs: 100,
+              stopNaturalExitGraceMs: 10,
             }).pipe(
               Layer.provideMerge(
                 ServerConfig.layerTest(root, { prefix: "antigravity-stop-unproven-" }),
@@ -1123,6 +1125,8 @@ describe("Antigravity turn settle on cancel (#465)", () => {
             attachments: [],
           });
           yield* Effect.promise(() => fs.appendFile(eventFile, "stop\t{}\n"));
+          yield* Effect.sleep(20);
+          expect(teardownCalls).toBe(0);
           child.stdout.end("short response\n");
           child.stderr.end();
           closeControllableAntigravityChild(child, 0, null);
@@ -1144,6 +1148,7 @@ describe("Antigravity turn settle on cancel (#465)", () => {
               ensurePlugin: async () => undefined,
               spawnProcess,
               teardownProcessTree,
+              stopNaturalExitGraceMs: 100,
             }).pipe(
               Layer.provideMerge(
                 ServerConfig.layerTest(root, { prefix: "antigravity-short-close-" }),
@@ -1222,10 +1227,90 @@ describe("Antigravity turn settle on cancel (#465)", () => {
               spawnProcess,
               teardownProcessTree,
               closeDrainTimeoutMs: 25,
+              stopNaturalExitGraceMs: 10,
             }).pipe(
               Layer.provide(Layer.succeed(AgentGatewayCredentials, credentials)),
               Layer.provideMerge(
                 ServerConfig.layerTest(root, { prefix: "antigravity-stop-timeout-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not settle a detached Stop timeout after session removal", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-stop-session-"));
+    const child = makeControllableAntigravityChild();
+    let eventFile = "";
+    let teardownCalls = 0;
+    const spawnProcess = ((
+      _command: string,
+      _args: readonly string[],
+      options: { readonly env?: NodeJS.ProcessEnv },
+    ) => {
+      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS ?? "";
+      return child;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+    const teardownProcessTree: NonNullable<
+      AntigravityAdapterDependencies["teardownProcessTree"]
+    > = async () => {
+      teardownCalls += 1;
+      return { escalated: false, signalErrors: [] };
+    };
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const runtimeEvents: ProviderRuntimeEvent[] = [];
+          const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+            Effect.sync(() => runtimeEvents.push(event)),
+          ).pipe(Effect.forkChild);
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-stop-session");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+          yield* adapter.sendTurn({
+            threadId,
+            input: "stop session during timeout",
+            attachments: [],
+          });
+          yield* Effect.promise(() => fs.appendFile(eventFile, "stop\t{}\n"));
+          for (let attempt = 0; attempt < 30 && teardownCalls === 0; attempt += 1) {
+            yield* Effect.sleep(10);
+          }
+          expect(teardownCalls).toBe(1);
+          yield* adapter.stopSession(threadId);
+          yield* Effect.sleep(150);
+          yield* Fiber.interrupt(runtimeEventsFiber);
+
+          expect(runtimeEvents.map((event) => event.type)).toEqual([
+            "session.started",
+            "thread.started",
+            "turn.started",
+            "session.exited",
+          ]);
+          expect(runtimeEvents.some((event) => event.type === "turn.completed")).toBe(false);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+              teardownProcessTree,
+              closeDrainTimeoutMs: 100,
+              stopNaturalExitGraceMs: 10,
+            }).pipe(
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-stop-session-" }),
               ),
               Layer.provideMerge(NodeServices.layer),
             ),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -7,7 +7,7 @@ import { PassThrough } from "node:stream";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { ThreadId } from "@synara/contracts";
-import { Effect, Layer } from "effect";
+import { Effect, Fiber, Layer, Stream } from "effect";
 import { describe, expect, it } from "vitest";
 
 import { ServerConfig } from "../../config";
@@ -43,6 +43,25 @@ function runCaptureCommand(command: string, input: string, env: NodeJS.ProcessEn
     encoding: "utf8",
     timeout: 5_000,
   });
+}
+
+type ControllableAntigravityChild = ChildProcess & {
+  readonly stdout: PassThrough;
+  readonly stderr: PassThrough;
+};
+
+function makeControllableAntigravityChild(pid: number): ControllableAntigravityChild {
+  const child = new EventEmitter() as ControllableAntigravityChild;
+  Object.assign(child, {
+    pid,
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    killed: false,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    kill: () => true,
+  });
+  return child;
 }
 
 describe("Antigravity CLI model translation", () => {
@@ -631,19 +650,7 @@ describe("Antigravity turn settle on cancel (#465)", () => {
       _args: readonly string[],
       _options: { readonly env?: NodeJS.ProcessEnv },
     ) => {
-      const child = new EventEmitter() as ChildProcess;
-      const stdout = new PassThrough();
-      const stderr = new PassThrough();
-      Object.assign(child, {
-        pid: 42_002,
-        stdout,
-        stderr,
-        killed: false,
-        exitCode: null as number | null,
-        signalCode: null as NodeJS.Signals | null,
-        kill: () => true,
-      });
-      return child;
+      return makeControllableAntigravityChild(42_002);
     }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
 
     try {
@@ -681,6 +688,111 @@ describe("Antigravity turn settle on cancel (#465)", () => {
             }).pipe(
               Layer.provideMerge(
                 ServerConfig.layerTest(root, { prefix: "antigravity-interrupt-hung-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not let a stale child contaminate or settle the follow-up turn", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-stale-child-"));
+    const children: ControllableAntigravityChild[] = [];
+    const eventFiles: string[] = [];
+    const spawnProcess = ((
+      _command: string,
+      _args: readonly string[],
+      options: { readonly env?: NodeJS.ProcessEnv },
+    ) => {
+      const child = makeControllableAntigravityChild(43_000 + children.length);
+      children.push(child);
+      eventFiles.push(options.env?.SYNARA_ANTIGRAVITY_EVENTS ?? "");
+      return child;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const runtimeEventsFiber = yield* Stream.runCollect(
+            Stream.take(adapter.streamEvents, 9),
+          ).pipe(Effect.forkChild);
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-stale-child");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+
+          const firstTurn = yield* adapter.sendTurn({
+            threadId,
+            input: "first turn",
+            attachments: [],
+          });
+          yield* adapter.interruptTurn(threadId, firstTurn.turnId);
+
+          const secondTurn = yield* adapter.sendTurn({
+            threadId,
+            input: "follow-up turn",
+            attachments: [],
+          });
+          const firstChild = children[0]!;
+          const secondChild = children[1]!;
+          yield* Effect.promise(() =>
+            fs.appendFile(
+              eventFiles[0]!,
+              `pre-invocation\t${JSON.stringify({ conversationId: "stale-conversation" })}\n`,
+            ),
+          );
+          firstChild.stdout.write("stale first-turn output\n");
+          firstChild.emit("close", 0, null);
+          yield* Effect.sleep(100);
+
+          const afterStaleClose = (yield* adapter.listSessions()).find(
+            (session) => session.threadId === threadId,
+          );
+          expect(afterStaleClose?.status).toBe("running");
+          expect(afterStaleClose?.activeTurnId).toBe(secondTurn.turnId);
+
+          secondChild.stdout.end("fresh follow-up output\n");
+          secondChild.stderr.end();
+          secondChild.emit("close", 0, null);
+
+          const runtimeEvents = Array.from(
+            yield* Fiber.join(runtimeEventsFiber).pipe(Effect.timeout("5 seconds")),
+          );
+          const completed = runtimeEvents.filter((event) => event.type === "turn.completed");
+          expect(
+            completed.map((event) => ({ turnId: event.turnId, state: event.payload.state })),
+          ).toEqual([
+            { turnId: firstTurn.turnId, state: "interrupted" },
+            { turnId: secondTurn.turnId, state: "completed" },
+          ]);
+          expect(
+            runtimeEvents
+              .filter((event) => event.type === "content.delta")
+              .map((event) => event.payload.delta),
+          ).toEqual(["fresh follow-up output"]);
+          expect(
+            runtimeEvents.some(
+              (event) => event.providerRefs?.providerThreadId === "stale-conversation",
+            ),
+          ).toBe(false);
+          yield* adapter.stopSession(threadId);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+            }).pipe(
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-stale-child-" }),
               ),
               Layer.provideMerge(NodeServices.layer),
             ),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -595,4 +595,100 @@ describe("Antigravity CLI integration helpers", () => {
       }),
     ).rejects.toThrow("Antigravity helper timed out after 50ms");
   });
+
+  // #465: an active Stop hook must not emit a non-standard decision that can
+  // hang the print process after the assistant reply is already visible.
+  it("answers stop hooks with a neutral allow-exit payload", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-stop-hook-"));
+    const scriptPath = path.join(directory, "capture.cjs");
+    const eventPath = path.join(directory, "events.ndjson");
+    try {
+      await fs.writeFile(scriptPath, hookScriptSource(), { mode: 0o700 });
+      const result = spawnSync(process.execPath, [scriptPath, "stop"], {
+        env: { ...process.env, SYNARA_ANTIGRAVITY_EVENTS: eventPath },
+        input: JSON.stringify({ stop: true }),
+        encoding: "utf8",
+        timeout: 5_000,
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(result.stdout.trim()).toBe("{}");
+      expect(result.stdout).not.toContain('"decision":"stop"');
+      expect(await fs.readFile(eventPath, "utf8")).toContain("stop\t");
+    } finally {
+      await fs.rm(directory, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("Antigravity turn settle on cancel (#465)", () => {
+  it("unlocks a running turn when Cancel cannot prove process exit", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-interrupt-hung-"));
+    // Fake pid that does not exist so supervised teardown cannot prove exit.
+    // Cancel must still force-settle the turn (#465).
+    const spawnProcess = ((
+      _command: string,
+      _args: readonly string[],
+      _options: { readonly env?: NodeJS.ProcessEnv },
+    ) => {
+      const child = new EventEmitter() as ChildProcess;
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      Object.assign(child, {
+        pid: 42_002,
+        stdout,
+        stderr,
+        killed: false,
+        exitCode: null as number | null,
+        signalCode: null as NodeJS.Signals | null,
+        kill: () => true,
+      });
+      return child;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-interrupt-hung");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+          const turn = yield* adapter.sendTurn({
+            threadId,
+            input: "stuck working",
+            attachments: [],
+          });
+          const before = (yield* adapter.listSessions()).find((s) => s.threadId === threadId);
+          expect(before?.status).toBe("running");
+          expect(before?.activeTurnId).toBe(turn.turnId);
+
+          yield* adapter.interruptTurn(threadId, turn.turnId);
+
+          const after = (yield* adapter.listSessions()).find((s) => s.threadId === threadId);
+          expect(after?.status).toBe("ready");
+          expect(after?.activeTurnId).toBeUndefined();
+          yield* adapter.stopSession(threadId);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+            }).pipe(
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-interrupt-hung-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -50,10 +50,9 @@ type ControllableAntigravityChild = ChildProcess & {
   readonly stderr: PassThrough;
 };
 
-function makeControllableAntigravityChild(pid: number): ControllableAntigravityChild {
+function makeControllableAntigravityChild(): ControllableAntigravityChild {
   const child = new EventEmitter() as ControllableAntigravityChild;
   Object.assign(child, {
-    pid,
     stdout: new PassThrough(),
     stderr: new PassThrough(),
     killed: false,
@@ -62,6 +61,16 @@ function makeControllableAntigravityChild(pid: number): ControllableAntigravityC
     kill: () => true,
   });
   return child;
+}
+
+function closeControllableAntigravityChild(
+  child: ControllableAntigravityChild,
+  code: number | null,
+  signal: NodeJS.Signals | null,
+): void {
+  Object.assign(child, { exitCode: code, signalCode: signal });
+  child.emit("exit", code, signal);
+  child.emit("close", code, signal);
 }
 
 describe("Antigravity CLI model translation", () => {
@@ -641,17 +650,21 @@ describe("Antigravity CLI integration helpers", () => {
 });
 
 describe("Antigravity turn settle on cancel (#465)", () => {
-  it("unlocks a running turn when Cancel cannot prove process exit", async () => {
+  it("keeps an unproven process active and blocks a successor", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-interrupt-hung-"));
-    // Fake pid that does not exist so supervised teardown cannot prove exit.
-    // Cancel must still force-settle the turn (#465).
+    let teardownShouldFail = true;
+    const child = makeControllableAntigravityChild();
     const spawnProcess = ((
       _command: string,
       _args: readonly string[],
       _options: { readonly env?: NodeJS.ProcessEnv },
-    ) => {
-      return makeControllableAntigravityChild(42_002);
-    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+    ) => child) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+    const teardownProcessTree: NonNullable<
+      AntigravityAdapterDependencies["teardownProcessTree"]
+    > = async () => {
+      if (teardownShouldFail) throw new Error("process exit remains unproven");
+      return { escalated: false, signalErrors: [] };
+    };
 
     try {
       await Effect.runPromise(
@@ -677,17 +690,176 @@ describe("Antigravity turn settle on cancel (#465)", () => {
           yield* adapter.interruptTurn(threadId, turn.turnId);
 
           const after = (yield* adapter.listSessions()).find((s) => s.threadId === threadId);
-          expect(after?.status).toBe("ready");
-          expect(after?.activeTurnId).toBeUndefined();
+          expect(after?.status).toBe("running");
+          expect(after?.activeTurnId).toBe(turn.turnId);
+          yield* adapter.sendTurn({ threadId, input: "must remain blocked", attachments: [] }).pipe(
+            Effect.flip,
+            Effect.tap((error) =>
+              Effect.sync(() => expect(error.message).toContain("already active")),
+            ),
+          );
+          teardownShouldFail = false;
           yield* adapter.stopSession(threadId);
         }).pipe(
           Effect.provide(
             makeAntigravityAdapterLive({
               ensurePlugin: async () => undefined,
               spawnProcess,
+              teardownProcessTree,
             }).pipe(
               Layer.provideMerge(
                 ServerConfig.layerTest(root, { prefix: "antigravity-interrupt-hung-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("drains final output before settling a successfully interrupted process", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-close-drain-"));
+    const child = makeControllableAntigravityChild();
+    const spawnProcess = (() => child) as NonNullable<
+      AntigravityAdapterDependencies["spawnProcess"]
+    >;
+    const teardownProcessTree: NonNullable<
+      AntigravityAdapterDependencies["teardownProcessTree"]
+    > = async () => {
+      setTimeout(() => {
+        child.stdout.end("final output before close\n");
+        child.stderr.end();
+        closeControllableAntigravityChild(child, null, "SIGTERM");
+      }, 10);
+      return { escalated: false, signalErrors: [] };
+    };
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const runtimeEventsFiber = yield* Stream.runCollect(
+            Stream.take(adapter.streamEvents, 7),
+          ).pipe(Effect.forkChild);
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-close-drain");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+          const turn = yield* adapter.sendTurn({
+            threadId,
+            input: "cancel after output",
+            attachments: [],
+          });
+          yield* adapter.interruptTurn(threadId, turn.turnId);
+
+          const runtimeEvents = Array.from(
+            yield* Fiber.join(runtimeEventsFiber).pipe(Effect.timeout("5 seconds")),
+          );
+          expect(
+            runtimeEvents
+              .filter((event) => event.type === "content.delta")
+              .map((event) => event.payload.delta),
+          ).toEqual(["final output before close"]);
+          const completed = runtimeEvents.find((event) => event.type === "turn.completed");
+          expect(completed?.turnId).toBe(turn.turnId);
+          expect(completed?.payload).toMatchObject({
+            state: "interrupted",
+            stopReason: "interrupted",
+          });
+          yield* adapter.stopSession(threadId);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+              teardownProcessTree,
+              closeDrainTimeoutMs: 100,
+            }).pipe(
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-close-drain-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("classifies a Stop-hook teardown as model completion", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-model-stop-"));
+    const child = makeControllableAntigravityChild();
+    let eventFile = "";
+    const spawnProcess = ((
+      _command: string,
+      _args: readonly string[],
+      options: { readonly env?: NodeJS.ProcessEnv },
+    ) => {
+      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS ?? "";
+      return child;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+    const teardownProcessTree: NonNullable<
+      AntigravityAdapterDependencies["teardownProcessTree"]
+    > = async () => {
+      setTimeout(() => {
+        child.stdout.end("completed response\n");
+        child.stderr.end();
+        closeControllableAntigravityChild(child, null, "SIGTERM");
+      }, 10);
+      return { escalated: false, signalErrors: [] };
+    };
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const runtimeEventsFiber = yield* Stream.runCollect(
+            Stream.take(adapter.streamEvents, 7),
+          ).pipe(Effect.forkChild);
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-model-stop");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+          const turn = yield* adapter.sendTurn({
+            threadId,
+            input: "finish normally",
+            attachments: [],
+          });
+          yield* Effect.promise(() => fs.appendFile(eventFile, "stop\t{}\n"));
+
+          const runtimeEvents = Array.from(
+            yield* Fiber.join(runtimeEventsFiber).pipe(Effect.timeout("5 seconds")),
+          );
+          const completed = runtimeEvents.find((event) => event.type === "turn.completed");
+          expect(completed?.turnId).toBe(turn.turnId);
+          expect(completed?.payload).toMatchObject({
+            state: "completed",
+            stopReason: "model_stop",
+          });
+          yield* adapter.stopSession(threadId);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+              teardownProcessTree,
+              closeDrainTimeoutMs: 100,
+            }).pipe(
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-model-stop-" }),
               ),
               Layer.provideMerge(NodeServices.layer),
             ),
@@ -708,11 +880,14 @@ describe("Antigravity turn settle on cancel (#465)", () => {
       _args: readonly string[],
       options: { readonly env?: NodeJS.ProcessEnv },
     ) => {
-      const child = makeControllableAntigravityChild(43_000 + children.length);
+      const child = makeControllableAntigravityChild();
       children.push(child);
       eventFiles.push(options.env?.SYNARA_ANTIGRAVITY_EVENTS ?? "");
       return child;
     }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+    const teardownProcessTree: NonNullable<
+      AntigravityAdapterDependencies["teardownProcessTree"]
+    > = async () => ({ escalated: false, signalErrors: [] });
 
     try {
       await Effect.runPromise(
@@ -751,7 +926,7 @@ describe("Antigravity turn settle on cancel (#465)", () => {
             ),
           );
           firstChild.stdout.write("stale first-turn output\n");
-          firstChild.emit("close", 0, null);
+          closeControllableAntigravityChild(firstChild, 0, null);
           yield* Effect.sleep(100);
 
           const afterStaleClose = (yield* adapter.listSessions()).find(
@@ -762,7 +937,7 @@ describe("Antigravity turn settle on cancel (#465)", () => {
 
           secondChild.stdout.end("fresh follow-up output\n");
           secondChild.stderr.end();
-          secondChild.emit("close", 0, null);
+          closeControllableAntigravityChild(secondChild, 0, null);
 
           const runtimeEvents = Array.from(
             yield* Fiber.join(runtimeEventsFiber).pipe(Effect.timeout("5 seconds")),
@@ -790,6 +965,8 @@ describe("Antigravity turn settle on cancel (#465)", () => {
             makeAntigravityAdapterLive({
               ensurePlugin: async () => undefined,
               spawnProcess,
+              teardownProcessTree,
+              closeDrainTimeoutMs: 25,
             }).pipe(
               Layer.provideMerge(
                 ServerConfig.layerTest(root, { prefix: "antigravity-stale-child-" }),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -799,6 +799,11 @@ describe("Antigravity turn settle on cancel (#465)", () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-model-stop-"));
     const child = makeControllableAntigravityChild();
     let eventFile = "";
+    let teardownStarted = false;
+    let resolveTreeExit!: (result: { escalated: boolean; signalErrors: Error[] }) => void;
+    const treeExit = new Promise<{ escalated: boolean; signalErrors: Error[] }>((resolve) => {
+      resolveTreeExit = resolve;
+    });
     const spawnProcess = ((
       _command: string,
       _args: readonly string[],
@@ -810,12 +815,8 @@ describe("Antigravity turn settle on cancel (#465)", () => {
     const teardownProcessTree: NonNullable<
       AntigravityAdapterDependencies["teardownProcessTree"]
     > = async () => {
-      setTimeout(() => {
-        child.stdout.end("completed response\n");
-        child.stderr.end();
-        closeControllableAntigravityChild(child, null, "SIGTERM");
-      }, 10);
-      return { escalated: false, signalErrors: [] };
+      teardownStarted = true;
+      return treeExit;
     };
 
     try {
@@ -839,6 +840,21 @@ describe("Antigravity turn settle on cancel (#465)", () => {
             attachments: [],
           });
           yield* Effect.promise(() => fs.appendFile(eventFile, "stop\t{}\n"));
+          for (let attempt = 0; attempt < 20 && !teardownStarted; attempt += 1) {
+            yield* Effect.sleep(10);
+          }
+          expect(teardownStarted).toBe(true);
+          child.stdout.end("completed response\n");
+          child.stderr.end();
+          closeControllableAntigravityChild(child, null, "SIGTERM");
+          yield* Effect.sleep(20);
+
+          const beforeTreeExitProof = (yield* adapter.listSessions()).find(
+            (session) => session.threadId === threadId,
+          );
+          expect(beforeTreeExitProof?.status).toBe("running");
+          expect(beforeTreeExitProof?.activeTurnId).toBe(turn.turnId);
+          resolveTreeExit({ escalated: false, signalErrors: [] });
 
           const runtimeEvents = Array.from(
             yield* Fiber.join(runtimeEventsFiber).pipe(Effect.timeout("5 seconds")),
@@ -860,6 +876,93 @@ describe("Antigravity turn settle on cancel (#465)", () => {
             }).pipe(
               Layer.provideMerge(
                 ServerConfig.layerTest(root, { prefix: "antigravity-model-stop-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("retains ownership when Stop teardown cannot prove descendant exit", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-stop-unproven-"));
+    const child = makeControllableAntigravityChild();
+    let eventFile = "";
+    let teardownCalls = 0;
+    let rejectTreeExit!: (cause: unknown) => void;
+    const treeExit = new Promise<never>((_resolve, reject) => {
+      rejectTreeExit = reject;
+    });
+    const spawnProcess = ((
+      _command: string,
+      _args: readonly string[],
+      options: { readonly env?: NodeJS.ProcessEnv },
+    ) => {
+      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS ?? "";
+      return child;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+    const teardownProcessTree: NonNullable<
+      AntigravityAdapterDependencies["teardownProcessTree"]
+    > = async () => {
+      teardownCalls += 1;
+      if (teardownCalls === 1) return treeExit;
+      return { escalated: false, signalErrors: [] };
+    };
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-stop-unproven");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+          const turn = yield* adapter.sendTurn({
+            threadId,
+            input: "finish with surviving descendants",
+            attachments: [],
+          });
+          yield* Effect.promise(() => fs.appendFile(eventFile, "stop\t{}\n"));
+          for (let attempt = 0; attempt < 20 && teardownCalls === 0; attempt += 1) {
+            yield* Effect.sleep(10);
+          }
+          expect(teardownCalls).toBe(1);
+          child.stdout.end("root response\n");
+          child.stderr.end();
+          closeControllableAntigravityChild(child, null, "SIGTERM");
+          rejectTreeExit(new Error("descendant exit remains unproven"));
+          yield* Effect.sleep(20);
+
+          const afterFailedProof = (yield* adapter.listSessions()).find(
+            (session) => session.threadId === threadId,
+          );
+          expect(afterFailedProof?.status).toBe("running");
+          expect(afterFailedProof?.activeTurnId).toBe(turn.turnId);
+          yield* adapter.sendTurn({ threadId, input: "must remain blocked", attachments: [] }).pipe(
+            Effect.flip,
+            Effect.tap((error) =>
+              Effect.sync(() => expect(error.message).toContain("already active")),
+            ),
+          );
+          yield* adapter.stopSession(threadId);
+          expect(teardownCalls).toBe(2);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+              teardownProcessTree,
+              closeDrainTimeoutMs: 100,
+            }).pipe(
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-stop-unproven-" }),
               ),
               Layer.provideMerge(NodeServices.layer),
             ),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -67,6 +67,7 @@ const PROVIDER = "antigravity" as const;
 const DEFAULT_MODEL = "Gemini 3.5 Flash";
 const PRINT_TIMEOUT = "30m";
 const POLL_INTERVAL_MS = 75;
+const CLOSE_DRAIN_TIMEOUT_MS = 1_000;
 const MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
 const PLUGIN_INSTALL_TIMEOUT_MS = 30_000;
 const HELPER_OUTPUT_MAX_CHARS = 128 * 1024;
@@ -107,6 +108,11 @@ type AntigravitySessionContext = {
   activeTurnId?: TurnId | undefined;
   activeProcess?: ChildProcess | undefined;
   activePollTimer?: NodeJS.Timeout | undefined;
+  activeCloseDrain?: {
+    readonly turnId: TurnId;
+    readonly child: ChildProcess;
+    readonly promise: Promise<void>;
+  };
   activePrompt?: string | undefined;
   eventFile?: string | undefined;
   transcriptPath?: string | undefined;
@@ -119,6 +125,7 @@ type AntigravitySessionContext = {
   processedSteps: Set<number>;
   pendingTools: PendingTool[];
   sawAssistant: boolean;
+  modelStopObserved: boolean;
   interrupted: boolean;
   stopped: boolean;
   /** Guards against double turn.completed (process close + interrupt/stop). */
@@ -127,6 +134,23 @@ type AntigravitySessionContext = {
 
 function messageFromCause(cause: unknown, fallback: string): string {
   return cause instanceof Error && cause.message.trim() ? cause.message : fallback;
+}
+
+function waitForCloseDrain(closeDrain: Promise<void>, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (drained: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(drained);
+    };
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    closeDrain.then(
+      () => finish(true),
+      () => finish(true),
+    );
+  });
 }
 
 function trim(value: string | null | undefined): string | undefined {
@@ -569,6 +593,8 @@ type AntigravityChildProcess = ChildProcess & {
 
 export interface AntigravityAdapterDependencies {
   readonly ensurePlugin?: typeof ensureCapturePlugin;
+  readonly teardownProcessTree?: typeof teardownChildProcessTree;
+  readonly closeDrainTimeoutMs?: number;
   readonly spawnProcess?: (
     command: string,
     args: readonly string[],
@@ -587,6 +613,8 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
     );
     const sessions = new Map<ThreadId, AntigravitySessionContext>();
     const defaultEffortByModel = new Map(Object.entries(DEFAULT_EFFORT_BY_MODEL));
+    const teardownProcessTree = dependencies.teardownProcessTree ?? teardownChildProcessTree;
+    const closeDrainTimeoutMs = dependencies.closeDrainTimeoutMs ?? CLOSE_DRAIN_TIMEOUT_MS;
 
     const eventIngress = yield* makeBoundedCallbackIngress<ProviderRuntimeEvent, never, never>(
       (event) => Queue.offer(eventQueue, event).pipe(Effect.asVoid),
@@ -662,7 +690,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       const child = context.activeProcess;
       if (!child) return Effect.void;
       return Effect.tryPromise({
-        try: () => teardownChildProcessTree(child),
+        try: () => teardownProcessTree(child),
         catch: (cause) =>
           new ProviderAdapterRequestError({
             provider: PROVIDER,
@@ -700,6 +728,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       context.turnTerminalEmitted = true;
       if (context.activePollTimer) clearInterval(context.activePollTimer);
       delete context.activePollTimer;
+      delete context.activeCloseDrain;
       delete context.activeProcess;
       delete context.activeTurnId;
       const {
@@ -946,15 +975,40 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         }
         // Agent finished: if the print process lingers, tear it down so the
         // close handler (or interrupt fallback) can settle the turn (#465).
-        if (eventName === "stop" && context.activeProcess && !context.turnTerminalEmitted) {
+        if (eventName === "stop") context.modelStopObserved = true;
+        if (
+          eventName === "stop" &&
+          context.activeTurnId &&
+          context.activeProcess &&
+          !context.turnTerminalEmitted
+        ) {
+          const turnId = context.activeTurnId;
           const child = context.activeProcess;
-          void teardownChildProcessTree(child).catch(() => {
-            try {
-              child.kill("SIGKILL");
-            } catch {
-              // Process may already be gone.
-            }
-          });
+          const closeDrain = context.activeCloseDrain;
+          if (child.exitCode === null && child.signalCode === null) {
+            void teardownProcessTree(child)
+              .then(async () => {
+                if (!closeDrain || closeDrain.turnId !== turnId || closeDrain.child !== child)
+                  return;
+                const drained = await waitForCloseDrain(closeDrain.promise, closeDrainTimeoutMs);
+                if (!drained) {
+                  settleActiveTurn(context, {
+                    turnId,
+                    child,
+                    state: "completed",
+                    stopReason: "model_stop",
+                    raw: raw("stop-close-drain-timeout", { timeoutMs: closeDrainTimeoutMs }),
+                  });
+                }
+              })
+              .catch(() => {
+                try {
+                  child.kill("SIGKILL");
+                } catch {
+                  // Process may already be gone. Keep tracking it until close proves exit.
+                }
+              });
+          }
         }
       }
       await readTranscript(context, isCurrentTurnProcess);
@@ -1026,6 +1080,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           processedSteps: new Set(),
           pendingTools: [],
           sawAssistant: false,
+          modelStopObserved: false,
           interrupted: false,
           stopped: false,
           turnTerminalEmitted: false,
@@ -1145,6 +1200,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         yield* Effect.promise(() => markExistingTranscriptStepsProcessed(context));
         context.pendingTools = [];
         context.sawAssistant = false;
+        context.modelStopObserved = false;
         context.interrupted = false;
         context.turnTerminalEmitted = false;
         context.turns.push({ id: turnId, items: [] });
@@ -1205,6 +1261,11 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         }
         context.activeProcess = child;
         const isCurrentTurnProcess = () => ownsTurnProcess(input.threadId, context, turnId, child);
+        let resolveCloseDrain!: () => void;
+        const closeDrain = new Promise<void>((resolve) => {
+          resolveCloseDrain = resolve;
+        });
+        context.activeCloseDrain = { turnId, child, promise: closeDrain };
         let stdout = "";
         let stderr = "";
         child.stdout.setEncoding("utf8");
@@ -1234,56 +1295,57 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           clearInterval(timer);
           if (context.activePollTimer === timer) delete context.activePollTimer;
           void (async () => {
-            await Effect.runPromise(cancelAgentGatewayTurn(gatewaySessionLease, turnId));
-            // Each `agy -p` invocation owns a fresh gateway session. Revoke it as
-            // soon as that process exits, even when this callback is stale.
-            releaseTurnGatewayLease(context, gatewaySessionLease);
-            if (!isCurrentTurnProcess()) {
+            try {
+              await Effect.runPromise(cancelAgentGatewayTurn(gatewaySessionLease, turnId));
+              // Each `agy -p` invocation owns a fresh gateway session. Revoke it as
+              // soon as that process exits, even when this callback is stale.
+              releaseTurnGatewayLease(context, gatewaySessionLease);
+              if (!isCurrentTurnProcess()) return;
+              // Drain only this process generation. A forced interrupt may already
+              // have made a successor turn active while this close was pending.
+              await pollHookFile(context, isCurrentTurnProcess).catch(() => undefined);
+              if (!isCurrentTurnProcess()) return;
+              if (!context.sawAssistant && stdout.trim()) {
+                emitTextItem(
+                  context,
+                  {
+                    step_index: Number.MAX_SAFE_INTEGER,
+                    type: "PRINT_OUTPUT",
+                    content: stdout.trim(),
+                  },
+                  "assistant_message",
+                  "assistant_text",
+                );
+              }
+              const interrupted =
+                !context.modelStopObserved && (context.interrupted || signal !== null);
+              const failed = !context.modelStopObserved && !interrupted && (code ?? 1) !== 0;
+              if (failed && stderr.trim()) {
+                offer({
+                  ...base(context, { includeTurn: false }),
+                  type: "runtime.error",
+                  payload: { message: stderr.trim(), class: "provider_error" },
+                  raw: raw("stderr", { code, stderr }),
+                } satisfies ProviderRuntimeEvent);
+              }
+              settleActiveTurn(context, {
+                turnId,
+                child,
+                state: interrupted ? "interrupted" : failed ? "failed" : "completed",
+                stopReason: interrupted ? "interrupted" : failed ? "error" : "model_stop",
+                ...(failed
+                  ? {
+                      errorMessage:
+                        stderr.trim() || `Antigravity CLI exited with code ${code ?? 1}.`,
+                    }
+                  : {}),
+                raw: raw("process-exit", { code, signal, stdout, stderr }),
+              });
+            } finally {
+              if (context.activeCloseDrain?.child === child) delete context.activeCloseDrain;
               await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
-              return;
+              resolveCloseDrain();
             }
-            // Drain only this process generation. A forced interrupt may already
-            // have made a successor turn active while this close was pending.
-            await pollHookFile(context, isCurrentTurnProcess).catch(() => undefined);
-            if (!isCurrentTurnProcess()) {
-              await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
-              return;
-            }
-            if (!context.sawAssistant && stdout.trim()) {
-              emitTextItem(
-                context,
-                {
-                  step_index: Number.MAX_SAFE_INTEGER,
-                  type: "PRINT_OUTPUT",
-                  content: stdout.trim(),
-                },
-                "assistant_message",
-                "assistant_text",
-              );
-            }
-            const interrupted = context.interrupted || signal !== null;
-            const failed = !interrupted && (code ?? 1) !== 0;
-            if (failed && stderr.trim()) {
-              offer({
-                ...base(context, { includeTurn: false }),
-                type: "runtime.error",
-                payload: { message: stderr.trim(), class: "provider_error" },
-                raw: raw("stderr", { code, stderr }),
-              } satisfies ProviderRuntimeEvent);
-            }
-            settleActiveTurn(context, {
-              turnId,
-              child,
-              state: interrupted ? "interrupted" : failed ? "failed" : "completed",
-              stopReason: interrupted ? "interrupted" : failed ? "error" : "model_stop",
-              ...(failed
-                ? {
-                    errorMessage: stderr.trim() || `Antigravity CLI exited with code ${code ?? 1}.`,
-                  }
-                : {}),
-              raw: raw("process-exit", { code, signal, stdout, stderr }),
-            });
-            await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
           })();
         });
         return {
@@ -1307,50 +1369,52 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         const activeTurnId = turnId ?? context.activeTurnId;
         if (activeTurnId === undefined) return;
         const activeProcess = context.activeProcess;
+        const activeCloseDrain = context.activeCloseDrain;
         yield* withAgentGatewayTurnCancellation(
           context.gatewaySessionLease,
           activeTurnId,
           Effect.gen(function* () {
             context.interrupted = true;
-            const hadProcess = context.activeProcess !== undefined;
-            if (hadProcess) {
-              // Prefer process close for settlement so stdout/hooks still drain.
-              // If teardown cannot prove exit, force-settle so Cancel never no-ops (#465).
-              yield* teardownActiveProcess(context, "turn/interrupt").pipe(
-                Effect.catch((error) =>
-                  Effect.gen(function* () {
-                    const detail =
-                      error instanceof ProviderAdapterRequestError
-                        ? error.detail
-                        : messageFromCause(error, "interrupt teardown failed");
-                    yield* Effect.logWarning("antigravity.interrupt_teardown_failed", {
-                      threadId,
-                      detail,
-                    });
-                    settleActiveTurn(context, {
-                      turnId: activeTurnId,
-                      ...(activeProcess ? { child: activeProcess } : {}),
-                      state: "interrupted",
-                      stopReason: "interrupted",
-                      raw: raw("interrupt-teardown-failed", { detail }),
-                    });
-                  }),
-                ),
-              );
-            }
-            // Process already gone (or never attached) but turn still open — Cancel
-            // must still unlock the composer.
-            if (!context.turnTerminalEmitted) {
+            if (!activeProcess) {
               settleActiveTurn(context, {
                 turnId: activeTurnId,
-                ...(activeProcess ? { child: activeProcess } : {}),
                 state: "interrupted",
                 stopReason: "interrupted",
-                raw: raw("interrupt-without-process", {
-                  hadProcess,
-                }),
+                raw: raw("interrupt-without-process", {}),
               });
+              return;
             }
+            const teardownSucceeded = yield* teardownActiveProcess(context, "turn/interrupt").pipe(
+              Effect.as(true),
+              Effect.catch((error) => {
+                const detail =
+                  error instanceof ProviderAdapterRequestError
+                    ? error.detail
+                    : messageFromCause(error, "interrupt teardown failed");
+                return Effect.logWarning("antigravity.interrupt_teardown_failed", {
+                  threadId,
+                  detail,
+                }).pipe(Effect.as(false));
+              }),
+            );
+            // A failed teardown is not exit proof. Retain the child handle and
+            // active turn so no successor can overlap a potentially live process.
+            if (!teardownSucceeded) return;
+            const drained =
+              activeCloseDrain?.turnId === activeTurnId && activeCloseDrain.child === activeProcess
+                ? yield* Effect.promise(() =>
+                    waitForCloseDrain(activeCloseDrain.promise, closeDrainTimeoutMs),
+                  )
+                : false;
+            if (drained) return;
+            const modelStopped = context.modelStopObserved;
+            settleActiveTurn(context, {
+              turnId: activeTurnId,
+              child: activeProcess,
+              state: modelStopped ? "completed" : "interrupted",
+              stopReason: modelStopped ? "model_stop" : "interrupted",
+              raw: raw("interrupt-close-drain-timeout", { timeoutMs: closeDrainTimeoutMs }),
+            });
           }),
         );
       });

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -106,6 +106,7 @@ type AntigravitySessionContext = {
   readonly turns: StoredTurn[];
   activeTurnId?: TurnId | undefined;
   activeProcess?: ChildProcess | undefined;
+  activePollTimer?: NodeJS.Timeout | undefined;
   activePrompt?: string | undefined;
   eventFile?: string | undefined;
   transcriptPath?: string | undefined;
@@ -636,6 +637,16 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         : Effect.fail(new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }));
     };
 
+    const ownsTurnProcess = (
+      threadId: ThreadId,
+      context: AntigravitySessionContext,
+      turnId: TurnId,
+      child: ChildProcess,
+    ): boolean =>
+      sessions.get(threadId) === context &&
+      context.activeTurnId === turnId &&
+      context.activeProcess === child;
+
     const releaseTurnGatewayLease = (
       context: AntigravitySessionContext,
       lease: AgentGatewaySessionLease | undefined = context.gatewaySessionLease,
@@ -670,17 +681,25 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
     const settleActiveTurn = (
       context: AntigravitySessionContext,
       input: {
+        readonly turnId: TurnId;
+        readonly child?: ChildProcess;
         readonly state: "completed" | "interrupted" | "failed";
         readonly stopReason: "model_stop" | "interrupted" | "error";
         readonly errorMessage?: string;
         readonly raw?: ReturnType<typeof raw>;
       },
     ): boolean => {
-      if (context.turnTerminalEmitted || context.activeTurnId === undefined) {
+      if (
+        context.turnTerminalEmitted ||
+        context.activeTurnId !== input.turnId ||
+        (input.child !== undefined && context.activeProcess !== input.child)
+      ) {
         return false;
       }
       const completionBase = base(context);
       context.turnTerminalEmitted = true;
+      if (context.activePollTimer) clearInterval(context.activePollTimer);
+      delete context.activePollTimer;
       delete context.activeProcess;
       delete context.activeTurnId;
       const {
@@ -823,21 +842,23 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       }
     };
 
-    const readTranscript = async (context: AntigravitySessionContext) => {
-      if (!context.transcriptPath) return;
-      const isInitialRead = context.processedTranscriptPath !== context.transcriptPath;
-      if (isInitialRead) context.processedTranscriptBytes = 0;
+    const readTranscript = async (
+      context: AntigravitySessionContext,
+      isCurrentTurnProcess: () => boolean,
+    ) => {
+      if (!isCurrentTurnProcess() || !context.transcriptPath) return;
+      const transcriptPath = context.transcriptPath;
+      const isInitialRead = context.processedTranscriptPath !== transcriptPath;
+      const processedTranscriptBytes = isInitialRead ? 0 : context.processedTranscriptBytes;
       let batch: Awaited<ReturnType<typeof readCompleteAntigravityLines>>;
       try {
-        batch = await readCompleteAntigravityLines(
-          context.transcriptPath,
-          context.processedTranscriptBytes,
-        );
+        batch = await readCompleteAntigravityLines(transcriptPath, processedTranscriptBytes);
       } catch {
         return;
       }
+      if (!isCurrentTurnProcess() || context.transcriptPath !== transcriptPath) return;
       context.processedTranscriptBytes = batch.nextOffset;
-      context.processedTranscriptPath = context.transcriptPath;
+      context.processedTranscriptPath = transcriptPath;
       const steps = batch.lines.flatMap((line) => {
         try {
           return [JSON.parse(line) as TranscriptStep];
@@ -872,15 +893,20 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       }
     };
 
-    const pollHookFile = async (context: AntigravitySessionContext) => {
-      if (context.stopped) return;
-      if (!context.eventFile) return;
+    const pollHookFile = async (
+      context: AntigravitySessionContext,
+      isCurrentTurnProcess: () => boolean,
+    ) => {
+      if (!isCurrentTurnProcess() || context.stopped || !context.eventFile) return;
+      const eventFile = context.eventFile;
+      const processedHookBytes = context.processedHookBytes;
       let batch: Awaited<ReturnType<typeof readCompleteAntigravityLines>>;
       try {
-        batch = await readCompleteAntigravityLines(context.eventFile, context.processedHookBytes);
+        batch = await readCompleteAntigravityLines(eventFile, processedHookBytes);
       } catch {
         return;
       }
+      if (!isCurrentTurnProcess() || context.eventFile !== eventFile) return;
       context.processedHookBytes = batch.nextOffset;
       for (const line of batch.lines) {
         const tab = line.indexOf("\t");
@@ -931,7 +957,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           });
         }
       }
-      await readTranscript(context);
+      await readTranscript(context, isCurrentTurnProcess);
     };
 
     const startSession: AntigravityAdapterShape["startSession"] = (input) =>
@@ -1178,16 +1204,23 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           });
         }
         context.activeProcess = child;
+        const isCurrentTurnProcess = () =>
+          ownsTurnProcess(input.threadId, context, turnId, child);
         let stdout = "";
         let stderr = "";
         child.stdout.setEncoding("utf8");
         child.stderr.setEncoding("utf8");
         child.stdout.on("data", (chunk) => (stdout += chunk));
         child.stderr.on("data", (chunk) => (stderr += chunk));
-        const timer = setInterval(() => void pollHookFile(context), POLL_INTERVAL_MS);
+        const timer = setInterval(
+          () => void pollHookFile(context, isCurrentTurnProcess),
+          POLL_INTERVAL_MS,
+        );
+        context.activePollTimer = timer;
         child.once("error", (cause) => {
           clearInterval(timer);
-          if (sessions.get(input.threadId) !== context || context.activeProcess !== child) return;
+          if (context.activePollTimer === timer) delete context.activePollTimer;
+          if (!isCurrentTurnProcess()) return;
           offer({
             ...base(context, { includeTurn: false }),
             type: "runtime.error",
@@ -1200,22 +1233,23 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         });
         child.once("close", (code, signal) => {
           clearInterval(timer);
+          if (context.activePollTimer === timer) delete context.activePollTimer;
           void (async () => {
-            if (sessions.get(input.threadId) !== context) {
-              releaseTurnGatewayLease(context, gatewaySessionLease);
+            await Effect.runPromise(cancelAgentGatewayTurn(gatewaySessionLease, turnId));
+            // Each `agy -p` invocation owns a fresh gateway session. Revoke it as
+            // soon as that process exits, even when this callback is stale.
+            releaseTurnGatewayLease(context, gatewaySessionLease);
+            if (!isCurrentTurnProcess()) {
               await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
               return;
             }
-            // Another path may already have settled (interrupt / stop-hook kill).
-            // Still drain hooks/stdout before deciding, but never double-complete.
-            const completedTurnId = context.activeTurnId;
-            await Effect.runPromise(cancelAgentGatewayTurn(gatewaySessionLease, completedTurnId));
-            // Each `agy -p` invocation owns a fresh gateway session. Revoke it as
-            // soon as that process exits, before post-processing or a later turn
-            // can begin, so an unconsumed bootstrap from this turn cannot cross
-            // into the next turn's authority.
-            releaseTurnGatewayLease(context, gatewaySessionLease);
-            await pollHookFile(context).catch(() => undefined);
+            // Drain only this process generation. A forced interrupt may already
+            // have made a successor turn active while this close was pending.
+            await pollHookFile(context, isCurrentTurnProcess).catch(() => undefined);
+            if (!isCurrentTurnProcess()) {
+              await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
+              return;
+            }
             if (!context.sawAssistant && stdout.trim()) {
               emitTextItem(
                 context,
@@ -1228,11 +1262,6 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
                 "assistant_text",
               );
             }
-            if (context.turnTerminalEmitted) {
-              if (context.activeProcess === child) delete context.activeProcess;
-              await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
-              return;
-            }
             const interrupted = context.interrupted || signal !== null;
             const failed = !interrupted && (code ?? 1) !== 0;
             if (failed && stderr.trim()) {
@@ -1244,6 +1273,8 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
               } satisfies ProviderRuntimeEvent);
             }
             settleActiveTurn(context, {
+              turnId,
+              child,
               state: interrupted ? "interrupted" : failed ? "failed" : "completed",
               stopReason: interrupted ? "interrupted" : failed ? "error" : "model_stop",
               ...(failed
@@ -1275,6 +1306,8 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           return;
         }
         const activeTurnId = turnId ?? context.activeTurnId;
+        if (activeTurnId === undefined) return;
+        const activeProcess = context.activeProcess;
         yield* withAgentGatewayTurnCancellation(
           context.gatewaySessionLease,
           activeTurnId,
@@ -1296,6 +1329,8 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
                       detail,
                     });
                     settleActiveTurn(context, {
+                      turnId: activeTurnId,
+                      ...(activeProcess ? { child: activeProcess } : {}),
                       state: "interrupted",
                       stopReason: "interrupted",
                       raw: raw("interrupt-teardown-failed", { detail }),
@@ -1306,8 +1341,10 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
             }
             // Process already gone (or never attached) but turn still open — Cancel
             // must still unlock the composer.
-            if (!context.turnTerminalEmitted && context.activeTurnId !== undefined) {
+            if (!context.turnTerminalEmitted) {
               settleActiveTurn(context, {
+                turnId: activeTurnId,
+                ...(activeProcess ? { child: activeProcess } : {}),
                 state: "interrupted",
                 stopReason: "interrupted",
                 raw: raw("interrupt-without-process", {

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -101,10 +101,13 @@ type StoredTurn = {
 type AntigravityTreeExitProof = {
   readonly turnId: TurnId;
   readonly child: ChildProcess;
-  readonly promise: Promise<
-    { readonly proven: true } | { readonly proven: false; readonly cause: unknown }
-  >;
+  result?: AntigravityTreeExitResult;
+  readonly promise: Promise<AntigravityTreeExitResult>;
 };
+
+type AntigravityTreeExitResult =
+  | { readonly proven: true }
+  | { readonly proven: false; readonly cause: unknown };
 
 type AntigravitySessionContext = {
   session: ProviderSession;
@@ -120,6 +123,9 @@ type AntigravitySessionContext = {
     readonly turnId: TurnId;
     readonly child: ChildProcess;
     readonly promise: Promise<void>;
+    readonly releaseGateway: () => Promise<void>;
+    readonly cleanupRunDir: () => Promise<void>;
+    readonly cleanup: () => Promise<void>;
   };
   activeTreeExitProof?: AntigravityTreeExitProof;
   activePrompt?: string | undefined;
@@ -698,14 +704,34 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       child: ChildProcess,
     ): AntigravityTreeExitProof => {
       const existing = context.activeTreeExitProof;
-      if (existing?.turnId === turnId && existing.child === child) return existing;
+      if (
+        existing?.turnId === turnId &&
+        existing.child === child &&
+        (existing.result?.proven !== false || child.exitCode !== null || child.signalCode !== null)
+      ) {
+        return existing;
+      }
+      if (child.exitCode !== null || child.signalCode !== null) {
+        const result = {
+          proven: false,
+          cause: new Error("Cannot establish process-tree exit proof after the root has closed."),
+        } as const;
+        const proof = { turnId, child, result, promise: Promise.resolve(result) };
+        context.activeTreeExitProof = proof;
+        return proof;
+      }
+      let proof!: AntigravityTreeExitProof;
       const promise = Promise.resolve()
         .then(() => teardownProcessTree(child))
         .then(
           () => ({ proven: true }) as const,
           (cause: unknown) => ({ proven: false, cause }) as const,
-        );
-      const proof = { turnId, child, promise } satisfies AntigravityTreeExitProof;
+        )
+        .then((result) => {
+          proof.result = result;
+          return result;
+        });
+      proof = { turnId, child, promise };
       context.activeTreeExitProof = proof;
       return proof;
     };
@@ -716,7 +742,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
     ): Effect.Effect<void, ProviderAdapterRequestError> => {
       const child = context.activeProcess;
       if (!child) return Effect.void;
-      return Effect.tryPromise({
+      const runTeardown = Effect.tryPromise({
         try: () => teardownProcessTree(child),
         catch: (cause) =>
           new ProviderAdapterRequestError({
@@ -726,6 +752,41 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
             cause,
           }),
       }).pipe(Effect.asVoid);
+      const existingProof = context.activeTreeExitProof;
+      if (existingProof?.turnId === context.activeTurnId && existingProof.child === child) {
+        return Effect.promise(() => existingProof.promise).pipe(
+          Effect.flatMap((result) => {
+            if (result.proven) return Effect.void;
+            if (child.exitCode === null && child.signalCode === null) {
+              if (context.activeTreeExitProof === existingProof) {
+                delete context.activeTreeExitProof;
+              }
+              return runTeardown;
+            }
+            return Effect.fail(
+              new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method,
+                detail: messageFromCause(
+                  result.cause,
+                  "The Antigravity process tree did not prove exit.",
+                ),
+                cause: result.cause,
+              }),
+            );
+          }),
+        );
+      }
+      if (child.exitCode !== null || child.signalCode !== null) {
+        return Effect.fail(
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method,
+            detail: "Cannot safely capture the Antigravity process tree after its root closed.",
+          }),
+        );
+      }
+      return runTeardown;
     };
 
     /**
@@ -1013,12 +1074,17 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           const turnId = context.activeTurnId;
           const child = context.activeProcess;
           const closeDrain = context.activeCloseDrain;
+          // Once close/exit has fired the PID can be reused and descendants may
+          // already be reparented. Never start a new signal/capture pass then;
+          // only a proof begun while the owned root was live can gate settlement.
+          if (child.exitCode !== null || child.signalCode !== null) continue;
           const treeExitProof = startTreeExitProof(context, turnId, child);
           void treeExitProof.promise.then(async (result) => {
             if (!result.proven) return;
             if (!closeDrain || closeDrain.turnId !== turnId || closeDrain.child !== child) return;
             const drained = await waitForCloseDrain(closeDrain.promise, closeDrainTimeoutMs);
             if (!drained) {
+              await closeDrain.cleanup();
               settleActiveTurn(context, {
                 turnId,
                 child,
@@ -1284,7 +1350,28 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         const closeDrain = new Promise<void>((resolve) => {
           resolveCloseDrain = resolve;
         });
-        context.activeCloseDrain = { turnId, child, promise: closeDrain };
+        let releaseGatewayPromise: Promise<void> | undefined;
+        const releaseGateway = () =>
+          (releaseGatewayPromise ??= Effect.runPromise(
+            cancelAgentGatewayTurn(gatewaySessionLease, turnId),
+          ).then(() => releaseTurnGatewayLease(context, gatewaySessionLease)));
+        let cleanupRunDirPromise: Promise<void> | undefined;
+        const cleanupRunDir = () =>
+          (cleanupRunDirPromise ??= fs
+            .rm(runDir, { recursive: true, force: true })
+            .catch(() => undefined));
+        const cleanup = async () => {
+          await releaseGateway();
+          await cleanupRunDir();
+        };
+        context.activeCloseDrain = {
+          turnId,
+          child,
+          promise: closeDrain,
+          releaseGateway,
+          cleanupRunDir,
+          cleanup,
+        };
         let stdout = "";
         let stderr = "";
         child.stdout.setEncoding("utf8");
@@ -1315,10 +1402,9 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           if (context.activePollTimer === timer) delete context.activePollTimer;
           void (async () => {
             try {
-              await Effect.runPromise(cancelAgentGatewayTurn(gatewaySessionLease, turnId));
               // Each `agy -p` invocation owns a fresh gateway session. Revoke it as
               // soon as that process exits, even when this callback is stale.
-              releaseTurnGatewayLease(context, gatewaySessionLease);
+              await releaseGateway();
               if (!isCurrentTurnProcess()) return;
               // Drain only this process generation. A forced interrupt may already
               // have made a successor turn active while this close was pending.
@@ -1336,9 +1422,8 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
                   "assistant_text",
                 );
               }
-              if (context.modelStopObserved) {
-                const treeExitProof = context.activeTreeExitProof;
-                if (treeExitProof?.turnId !== turnId || treeExitProof.child !== child) return;
+              const treeExitProof = context.activeTreeExitProof;
+              if (treeExitProof?.turnId === turnId && treeExitProof.child === child) {
                 const result = await treeExitProof.promise;
                 if (!isCurrentTurnProcess() || !result.proven) return;
               }
@@ -1368,7 +1453,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
               });
             } finally {
               if (context.activeCloseDrain?.child === child) delete context.activeCloseDrain;
-              await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
+              await cleanupRunDir();
               resolveCloseDrain();
             }
           })();
@@ -1409,22 +1494,17 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
               });
               return;
             }
-            const teardownSucceeded = yield* teardownActiveProcess(context, "turn/interrupt").pipe(
-              Effect.as(true),
-              Effect.catch((error) => {
-                const detail =
-                  error instanceof ProviderAdapterRequestError
-                    ? error.detail
-                    : messageFromCause(error, "interrupt teardown failed");
-                return Effect.logWarning("antigravity.interrupt_teardown_failed", {
-                  threadId,
-                  detail,
-                }).pipe(Effect.as(false));
-              }),
-            );
+            const treeExitProof = startTreeExitProof(context, activeTurnId, activeProcess);
+            const treeExitResult = yield* Effect.promise(() => treeExitProof.promise);
             // A failed teardown is not exit proof. Retain the child handle and
             // active turn so no successor can overlap a potentially live process.
-            if (!teardownSucceeded) return;
+            if (!treeExitResult.proven) {
+              yield* Effect.logWarning("antigravity.interrupt_teardown_failed", {
+                threadId,
+                detail: messageFromCause(treeExitResult.cause, "interrupt teardown failed"),
+              });
+              return;
+            }
             const drained =
               activeCloseDrain?.turnId === activeTurnId && activeCloseDrain.child === activeProcess
                 ? yield* Effect.promise(() =>
@@ -1432,6 +1512,9 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
                   )
                 : false;
             if (drained) return;
+            if (activeCloseDrain) {
+              yield* Effect.promise(() => activeCloseDrain.cleanup());
+            }
             const modelStopped = context.modelStopObserved;
             settleActiveTurn(context, {
               turnId: activeTurnId,

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -1248,8 +1248,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
               stopReason: interrupted ? "interrupted" : failed ? "error" : "model_stop",
               ...(failed
                 ? {
-                    errorMessage:
-                      stderr.trim() || `Antigravity CLI exited with code ${code ?? 1}.`,
+                    errorMessage: stderr.trim() || `Antigravity CLI exited with code ${code ?? 1}.`,
                   }
                 : {}),
               raw: raw("process-exit", { code, signal, stdout, stderr }),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -1204,8 +1204,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           });
         }
         context.activeProcess = child;
-        const isCurrentTurnProcess = () =>
-          ownsTurnProcess(input.threadId, context, turnId, child);
+        const isCurrentTurnProcess = () => ownsTurnProcess(input.threadId, context, turnId, child);
         let stdout = "";
         let stderr = "";
         child.stdout.setEncoding("utf8");

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -68,6 +68,7 @@ const DEFAULT_MODEL = "Gemini 3.5 Flash";
 const PRINT_TIMEOUT = "30m";
 const POLL_INTERVAL_MS = 75;
 const CLOSE_DRAIN_TIMEOUT_MS = 1_000;
+const STOP_NATURAL_EXIT_GRACE_MS = 150;
 const MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
 const PLUGIN_INSTALL_TIMEOUT_MS = 30_000;
 const HELPER_OUTPUT_MAX_CHARS = 128 * 1024;
@@ -610,6 +611,7 @@ export interface AntigravityAdapterDependencies {
   readonly ensurePlugin?: typeof ensureCapturePlugin;
   readonly teardownProcessTree?: typeof teardownChildProcessTree;
   readonly closeDrainTimeoutMs?: number;
+  readonly stopNaturalExitGraceMs?: number;
   readonly spawnProcess?: (
     command: string,
     args: readonly string[],
@@ -630,6 +632,8 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
     const defaultEffortByModel = new Map(Object.entries(DEFAULT_EFFORT_BY_MODEL));
     const teardownProcessTree = dependencies.teardownProcessTree ?? teardownChildProcessTree;
     const closeDrainTimeoutMs = dependencies.closeDrainTimeoutMs ?? CLOSE_DRAIN_TIMEOUT_MS;
+    const stopNaturalExitGraceMs =
+      dependencies.stopNaturalExitGraceMs ?? STOP_NATURAL_EXIT_GRACE_MS;
 
     const eventIngress = yield* makeBoundedCallbackIngress<ProviderRuntimeEvent, never, never>(
       (event) => Queue.offer(eventQueue, event).pipe(Effect.asVoid),
@@ -696,6 +700,11 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
     ): void => {
       lease?.release();
       if (context.gatewaySessionLease === lease) delete context.gatewaySessionLease;
+    };
+
+    const stopActivePoll = (context: AntigravitySessionContext): void => {
+      if (context.activePollTimer) clearInterval(context.activePollTimer);
+      delete context.activePollTimer;
     };
 
     const startTreeExitProof = (
@@ -810,6 +819,8 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       },
     ): boolean => {
       if (
+        context.stopped ||
+        sessions.get(context.session.threadId) !== context ||
         context.turnTerminalEmitted ||
         context.activeTurnId !== input.turnId ||
         (input.child !== undefined && context.activeProcess !== input.child)
@@ -818,8 +829,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       }
       const completionBase = base(context);
       context.turnTerminalEmitted = true;
-      if (context.activePollTimer) clearInterval(context.activePollTimer);
-      delete context.activePollTimer;
+      stopActivePoll(context);
       delete context.activeCloseDrain;
       delete context.activeTreeExitProof;
       delete context.activeProcess;
@@ -1082,13 +1092,31 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           // already be reparented. Never start a new signal/capture pass then;
           // only a proof begun while the owned root was live can gate settlement.
           if (child.exitCode !== null || child.signalCode !== null) continue;
-          const treeExitProof = startTreeExitProof(context, turnId, child);
-          void treeExitProof.promise.then(async (result) => {
-            if (!result.proven) return;
+          void (async () => {
+            if (closeDrain) {
+              const closedNaturally = await waitForCloseDrain(
+                closeDrain.promise,
+                stopNaturalExitGraceMs,
+              );
+              if (closedNaturally) return;
+            }
+            if (
+              !isCurrentTurnProcess() ||
+              context.stopped ||
+              child.exitCode !== null ||
+              child.signalCode !== null
+            ) {
+              return;
+            }
+            const treeExitProof = startTreeExitProof(context, turnId, child);
+            const result = await treeExitProof.promise;
+            if (!result.proven || !isCurrentTurnProcess() || context.stopped) return;
             if (!closeDrain || closeDrain.turnId !== turnId || closeDrain.child !== child) return;
             const drained = await waitForCloseDrain(closeDrain.promise, closeDrainTimeoutMs);
             if (!drained) {
+              if (!isCurrentTurnProcess() || context.stopped) return;
               await closeDrain.cleanup();
+              if (!isCurrentTurnProcess() || context.stopped) return;
               settleActiveTurn(context, {
                 turnId,
                 child,
@@ -1097,7 +1125,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
                 raw: raw("stop-close-drain-timeout", { timeoutMs: closeDrainTimeoutMs }),
               });
             }
-          });
+          })();
         }
       }
       await readTranscript(context, isCurrentTurnProcess);
@@ -1130,11 +1158,17 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         });
         const existing = sessions.get(input.threadId);
         if (existing) {
+          const activeResources = existing.activeCloseDrain;
           existing.stopped = true;
           existing.interrupted = true;
+          stopActivePoll(existing);
           yield* cancelAgentGatewayTurn(existing.gatewaySessionLease, existing.activeTurnId);
           yield* teardownActiveProcess(existing, "session/restart");
-          releaseTurnGatewayLease(existing);
+          if (activeResources) {
+            yield* Effect.promise(() => activeResources.cleanup());
+          } else {
+            releaseTurnGatewayLease(existing);
+          }
         }
         const now = new Date().toISOString();
         const conversationId = resumeConversationId(input.resumeCursor);
@@ -1349,7 +1383,8 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           });
         }
         context.activeProcess = child;
-        const isCurrentTurnProcess = () => ownsTurnProcess(input.threadId, context, turnId, child);
+        const isCurrentTurnProcess = () =>
+          !context.stopped && ownsTurnProcess(input.threadId, context, turnId, child);
         let resolveCloseDrain!: () => void;
         const closeDrain = new Promise<void>((resolve) => {
           resolveCloseDrain = resolve;
@@ -1456,7 +1491,12 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
                 raw: raw("process-exit", { code, signal, stdout, stderr }),
               });
             } finally {
-              if (context.activeCloseDrain?.child === child) delete context.activeCloseDrain;
+              if (
+                context.activeCloseDrain?.turnId === turnId &&
+                context.activeCloseDrain.child === child
+              ) {
+                delete context.activeCloseDrain;
+              }
               await cleanupRunDir();
               resolveCloseDrain();
             }
@@ -1516,8 +1556,20 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
                   )
                 : false;
             if (drained) return;
+            if (
+              context.stopped ||
+              !ownsTurnProcess(threadId, context, activeTurnId, activeProcess)
+            ) {
+              return;
+            }
             if (activeCloseDrain) {
               yield* Effect.promise(() => activeCloseDrain.cleanup());
+            }
+            if (
+              context.stopped ||
+              !ownsTurnProcess(threadId, context, activeTurnId, activeProcess)
+            ) {
+              return;
             }
             const modelStopped = context.modelStopObserved;
             settleActiveTurn(context, {
@@ -1544,11 +1596,17 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       Effect.gen(function* () {
         const context = sessions.get(threadId);
         if (!context) return;
+        const activeResources = context.activeCloseDrain;
         context.stopped = true;
         context.interrupted = true;
+        stopActivePoll(context);
         yield* cancelAgentGatewayTurn(context.gatewaySessionLease, context.activeTurnId);
         yield* teardownActiveProcess(context, "session/stop");
-        releaseTurnGatewayLease(context);
+        if (activeResources) {
+          yield* Effect.promise(() => activeResources.cleanup());
+        } else {
+          releaseTurnGatewayLease(context);
+        }
         sessions.delete(threadId);
         offer({
           ...base(context, { includeTurn: false }),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -98,6 +98,14 @@ type StoredTurn = {
   readonly items: unknown[];
 };
 
+type AntigravityTreeExitProof = {
+  readonly turnId: TurnId;
+  readonly child: ChildProcess;
+  readonly promise: Promise<
+    { readonly proven: true } | { readonly proven: false; readonly cause: unknown }
+  >;
+};
+
 type AntigravitySessionContext = {
   session: ProviderSession;
   gatewaySessionLease?: AgentGatewaySessionLease;
@@ -113,6 +121,7 @@ type AntigravitySessionContext = {
     readonly child: ChildProcess;
     readonly promise: Promise<void>;
   };
+  activeTreeExitProof?: AntigravityTreeExitProof;
   activePrompt?: string | undefined;
   eventFile?: string | undefined;
   transcriptPath?: string | undefined;
@@ -683,6 +692,24 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       if (context.gatewaySessionLease === lease) delete context.gatewaySessionLease;
     };
 
+    const startTreeExitProof = (
+      context: AntigravitySessionContext,
+      turnId: TurnId,
+      child: ChildProcess,
+    ): AntigravityTreeExitProof => {
+      const existing = context.activeTreeExitProof;
+      if (existing?.turnId === turnId && existing.child === child) return existing;
+      const promise = Promise.resolve()
+        .then(() => teardownProcessTree(child))
+        .then(
+          () => ({ proven: true }) as const,
+          (cause: unknown) => ({ proven: false, cause }) as const,
+        );
+      const proof = { turnId, child, promise } satisfies AntigravityTreeExitProof;
+      context.activeTreeExitProof = proof;
+      return proof;
+    };
+
     const teardownActiveProcess = (
       context: AntigravitySessionContext,
       method: string,
@@ -729,6 +756,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       if (context.activePollTimer) clearInterval(context.activePollTimer);
       delete context.activePollTimer;
       delete context.activeCloseDrain;
+      delete context.activeTreeExitProof;
       delete context.activeProcess;
       delete context.activeTurnId;
       const {
@@ -985,30 +1013,21 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           const turnId = context.activeTurnId;
           const child = context.activeProcess;
           const closeDrain = context.activeCloseDrain;
-          if (child.exitCode === null && child.signalCode === null) {
-            void teardownProcessTree(child)
-              .then(async () => {
-                if (!closeDrain || closeDrain.turnId !== turnId || closeDrain.child !== child)
-                  return;
-                const drained = await waitForCloseDrain(closeDrain.promise, closeDrainTimeoutMs);
-                if (!drained) {
-                  settleActiveTurn(context, {
-                    turnId,
-                    child,
-                    state: "completed",
-                    stopReason: "model_stop",
-                    raw: raw("stop-close-drain-timeout", { timeoutMs: closeDrainTimeoutMs }),
-                  });
-                }
-              })
-              .catch(() => {
-                try {
-                  child.kill("SIGKILL");
-                } catch {
-                  // Process may already be gone. Keep tracking it until close proves exit.
-                }
+          const treeExitProof = startTreeExitProof(context, turnId, child);
+          void treeExitProof.promise.then(async (result) => {
+            if (!result.proven) return;
+            if (!closeDrain || closeDrain.turnId !== turnId || closeDrain.child !== child) return;
+            const drained = await waitForCloseDrain(closeDrain.promise, closeDrainTimeoutMs);
+            if (!drained) {
+              settleActiveTurn(context, {
+                turnId,
+                child,
+                state: "completed",
+                stopReason: "model_stop",
+                raw: raw("stop-close-drain-timeout", { timeoutMs: closeDrainTimeoutMs }),
               });
-          }
+            }
+          });
         }
       }
       await readTranscript(context, isCurrentTurnProcess);
@@ -1316,6 +1335,12 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
                   "assistant_message",
                   "assistant_text",
                 );
+              }
+              if (context.modelStopObserved) {
+                const treeExitProof = context.activeTreeExitProof;
+                if (treeExitProof?.turnId !== turnId || treeExitProof.child !== child) return;
+                const result = await treeExitProof.promise;
+                if (!isCurrentTurnProcess() || !result.proven) return;
               }
               const interrupted =
                 !context.modelStopObserved && (context.interrupted || signal !== null);

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -753,7 +753,11 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           }),
       }).pipe(Effect.asVoid);
       const existingProof = context.activeTreeExitProof;
-      if (existingProof?.turnId === context.activeTurnId && existingProof.child === child) {
+      if (
+        existingProof !== undefined &&
+        existingProof.turnId === context.activeTurnId &&
+        existingProof.child === child
+      ) {
         return Effect.promise(() => existingProof.promise).pipe(
           Effect.flatMap((result) => {
             if (result.proven) return Effect.void;

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -120,6 +120,8 @@ type AntigravitySessionContext = {
   sawAssistant: boolean;
   interrupted: boolean;
   stopped: boolean;
+  /** Guards against double turn.completed (process close + interrupt/stop). */
+  turnTerminalEmitted: boolean;
 };
 
 function messageFromCause(cause: unknown, fallback: string): string {
@@ -167,6 +169,12 @@ function shellQuote(value: string, platform: NodeJS.Platform = process.platform)
  * "ask" preserves the permission flow the user would have without the hook.
  * `{}` stays correct for the other hook points, including Stop, where an
  * inactive hook must not force a decision over Antigravity's default.
+ *
+ * Active Stop hooks must also stay neutral (`{}`). Returning
+ * `{"decision":"stop"}` is not a valid Antigravity/Claude stop decision
+ * (only `"block"` is recognized to prevent exit) and can leave the print
+ * process hung after the assistant has already finished, so the UI stays
+ * "Working" and Cancel has nothing left to kill (#465).
  */
 function inactiveHookOutput(event: string): string {
   return event === "pre-tool" ? '{"decision":"ask"}' : "{}";
@@ -204,9 +212,10 @@ process.stdin.on("end", () => {
   if (event === "pre-tool") {
     const decision = process.env.SYNARA_ANTIGRAVITY_HOOK_DECISION === "allow" ? "allow" : "ask";
     process.stdout.write(JSON.stringify({ decision }) + "\\n");
-  } else if (event === "stop") {
-    process.stdout.write('{"decision":"stop"}\\n');
   } else {
+    // Stop and other non-tool hooks: empty object allows the agent to exit.
+    // Do not emit decision:"stop" — it is not a recognized stop decision and
+    // can hang the print process after the reply is already visible (#465).
     process.stdout.write("{}\\n");
   }
 });
@@ -653,6 +662,58 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       }).pipe(Effect.asVoid);
     };
 
+    /**
+     * Emit a single terminal turn.completed for the active turn and mark the
+     * session idle. Idempotent so process-close, interrupt, and stop-hook
+     * paths can all call it without double-settling (#465).
+     */
+    const settleActiveTurn = (
+      context: AntigravitySessionContext,
+      input: {
+        readonly state: "completed" | "interrupted" | "failed";
+        readonly stopReason: "model_stop" | "interrupted" | "error";
+        readonly errorMessage?: string;
+        readonly raw?: ReturnType<typeof raw>;
+      },
+    ): boolean => {
+      if (context.turnTerminalEmitted || context.activeTurnId === undefined) {
+        return false;
+      }
+      const completionBase = base(context);
+      context.turnTerminalEmitted = true;
+      delete context.activeProcess;
+      delete context.activeTurnId;
+      const {
+        activeTurnId: _activeTurnId,
+        lastError: _lastError,
+        ...inactiveSession
+      } = context.session;
+      const failed = input.state === "failed";
+      context.session = {
+        ...inactiveSession,
+        status: failed ? "error" : "ready",
+        ...(context.conversationId ? { resumeCursor: context.conversationId } : {}),
+        updatedAt: new Date().toISOString(),
+        ...(failed && input.errorMessage ? { lastError: input.errorMessage } : {}),
+      };
+      offer({
+        ...completionBase,
+        type: "turn.completed",
+        payload:
+          input.state === "interrupted"
+            ? { state: "interrupted", stopReason: "interrupted" }
+            : input.state === "failed"
+              ? {
+                  state: "failed",
+                  stopReason: "error",
+                  errorMessage: input.errorMessage ?? "Antigravity turn failed.",
+                }
+              : { state: "completed", stopReason: "model_stop" },
+        ...(input.raw ? { raw: input.raw } : {}),
+      } satisfies ProviderRuntimeEvent);
+      return true;
+    };
+
     const currentTurn = (context: AntigravitySessionContext): StoredTurn | undefined =>
       context.activeTurnId
         ? context.turns.find((turn) => turn.id === context.activeTurnId)
@@ -857,6 +918,18 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
             raw: raw(eventName, payload),
           } satisfies ProviderRuntimeEvent);
         }
+        // Agent finished: if the print process lingers, tear it down so the
+        // close handler (or interrupt fallback) can settle the turn (#465).
+        if (eventName === "stop" && context.activeProcess && !context.turnTerminalEmitted) {
+          const child = context.activeProcess;
+          void teardownChildProcessTree(child).catch(() => {
+            try {
+              child.kill("SIGKILL");
+            } catch {
+              // Process may already be gone.
+            }
+          });
+        }
       }
       await readTranscript(context);
     };
@@ -929,6 +1002,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           sawAssistant: false,
           interrupted: false,
           stopped: false,
+          turnTerminalEmitted: false,
         };
         sessions.set(input.threadId, context);
         offer({
@@ -1046,6 +1120,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         context.pendingTools = [];
         context.sawAssistant = false;
         context.interrupted = false;
+        context.turnTerminalEmitted = false;
         context.turns.push({ id: turnId, items: [] });
         context.session = {
           ...context.session,
@@ -1126,12 +1201,13 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         child.once("close", (code, signal) => {
           clearInterval(timer);
           void (async () => {
-            if (sessions.get(input.threadId) !== context || context.activeProcess !== child) {
+            if (sessions.get(input.threadId) !== context) {
               releaseTurnGatewayLease(context, gatewaySessionLease);
               await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
               return;
             }
-            const completionBase = base(context);
+            // Another path may already have settled (interrupt / stop-hook kill).
+            // Still drain hooks/stdout before deciding, but never double-complete.
             const completedTurnId = context.activeTurnId;
             await Effect.runPromise(cancelAgentGatewayTurn(gatewaySessionLease, completedTurnId));
             // Each `agy -p` invocation owns a fresh gateway session. Revoke it as
@@ -1152,6 +1228,11 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
                 "assistant_text",
               );
             }
+            if (context.turnTerminalEmitted) {
+              if (context.activeProcess === child) delete context.activeProcess;
+              await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
+              return;
+            }
             const interrupted = context.interrupted || signal !== null;
             const failed = !interrupted && (code ?? 1) !== 0;
             if (failed && stderr.trim()) {
@@ -1162,37 +1243,17 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
                 raw: raw("stderr", { code, stderr }),
               } satisfies ProviderRuntimeEvent);
             }
-            delete context.activeProcess;
-            delete context.activeTurnId;
-            const {
-              activeTurnId: _activeTurnId,
-              lastError: _lastError,
-              ...inactiveSession
-            } = context.session;
-            context.session = {
-              ...inactiveSession,
-              status: failed ? "error" : "ready",
-              ...(context.conversationId ? { resumeCursor: context.conversationId } : {}),
-              updatedAt: new Date().toISOString(),
+            settleActiveTurn(context, {
+              state: interrupted ? "interrupted" : failed ? "failed" : "completed",
+              stopReason: interrupted ? "interrupted" : failed ? "error" : "model_stop",
               ...(failed
-                ? { lastError: stderr.trim() || `Antigravity CLI exited with code ${code ?? 1}.` }
+                ? {
+                    errorMessage:
+                      stderr.trim() || `Antigravity CLI exited with code ${code ?? 1}.`,
+                  }
                 : {}),
-            };
-            offer({
-              ...completionBase,
-              type: "turn.completed",
-              payload: interrupted
-                ? { state: "interrupted", stopReason: "interrupted" }
-                : failed
-                  ? {
-                      state: "failed",
-                      stopReason: "error",
-                      errorMessage:
-                        stderr.trim() || `Antigravity CLI exited with code ${code ?? 1}.`,
-                    }
-                  : { state: "completed", stopReason: "model_stop" },
               raw: raw("process-exit", { code, signal, stdout, stderr }),
-            } satisfies ProviderRuntimeEvent);
+            });
             await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
           })();
         });
@@ -1220,7 +1281,41 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           activeTurnId,
           Effect.gen(function* () {
             context.interrupted = true;
-            yield* teardownActiveProcess(context, "turn/interrupt");
+            const hadProcess = context.activeProcess !== undefined;
+            if (hadProcess) {
+              // Prefer process close for settlement so stdout/hooks still drain.
+              // If teardown cannot prove exit, force-settle so Cancel never no-ops (#465).
+              yield* teardownActiveProcess(context, "turn/interrupt").pipe(
+                Effect.catch((error) =>
+                  Effect.gen(function* () {
+                    const detail =
+                      error instanceof ProviderAdapterRequestError
+                        ? error.detail
+                        : messageFromCause(error, "interrupt teardown failed");
+                    yield* Effect.logWarning("antigravity.interrupt_teardown_failed", {
+                      threadId,
+                      detail,
+                    });
+                    settleActiveTurn(context, {
+                      state: "interrupted",
+                      stopReason: "interrupted",
+                      raw: raw("interrupt-teardown-failed", { detail }),
+                    });
+                  }),
+                ),
+              );
+            }
+            // Process already gone (or never attached) but turn still open — Cancel
+            // must still unlock the composer.
+            if (!context.turnTerminalEmitted && context.activeTurnId !== undefined) {
+              settleActiveTurn(context, {
+                state: "interrupted",
+                stopReason: "interrupted",
+                raw: raw("interrupt-without-process", {
+                  hadProcess,
+                }),
+              });
+            }
           }),
         );
       });


### PR DESCRIPTION
## Summary

Closes **#465**.

Antigravity threads could stay **Working** after a full assistant reply, with **Cancel** doing nothing and follow-ups blocked.

### Root causes
1. Capture **Stop** hook answered with `{"decision":"stop"}` (not a valid stop decision; only `"block"` prevents exit) → print process could hang after the reply was already visible.
2. `interruptTurn` only tore down a live process; if teardown could not prove exit, **no `turn.completed`** was emitted, so `activeTurnId` stayed set.

### Fix
- Stop hooks return neutral `{}` (allow exit)
- Idempotent `settleActiveTurn` shared by process-close and interrupt
- Cancel force-settles when teardown fails / process already gone
- Stop hook event tears down a lingering print process

## Evidence (tests only — no synthetic UI screenshots)

```text
$ cd apps/server && bun run test -- src/provider/Layers/AntigravityAdapter.test.ts
✓ 20 tests passed
  including stop-hook neutral payload + Cancel force-settle when exit unproven
```

## Test plan
- [x] AntigravityAdapter unit tests (20/20)
- [ ] Manual with `agy`: turn completes → Idle; Cancel unlocks composer