### PR TITLE
Use red/green colors for PR list diff stats

### DIFF
--- a/apps/web/src/components/chat/environment/EnvironmentPullRequestSection.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentPullRequestSection.tsx
@@ -322,9 +322,11 @@ export function EnvironmentPullRequestSection({
           icon={<DiffIcon className={ENVIRONMENT_ROW_ICON_CLASS_NAME} aria-hidden />}
           label={
             <span className="flex min-w-0 items-center gap-1.5">
-              {/* Muted like every other pull request diff stat, not the green/red used by
-                  working-tree diffs — PR change counts read as ambient metadata. */}
-              <PullRequestDiffStat additions={diffStat.additions} deletions={diffStat.deletions} />
+              <PullRequestDiffStat
+                additions={diffStat.additions}
+                deletions={diffStat.deletions}
+                tone="diff"
+              />
               {diffStat.filesLabel ? (
                 <span className="truncate text-muted-foreground">{diffStat.filesLabel}</span>
               ) : null}

--- a/apps/web/src/components/pullRequest/PullRequestDiffStat.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDiffStat.tsx
@@ -1,8 +1,7 @@
 // FILE: PullRequestDiffStat.tsx
 // Purpose: The "+N -M" additions/deletions counter shown wherever the pull request feature
-//          summarizes a change size. Muted by default (list rows, environment row) where the
-//          counts are ambient metadata; the "diff" tone applies the working-tree diff colors
-//          inside the detail view, where the change size is the point. Tabular-nums keeps
+//          summarizes a change size. The "diff" tone applies the working-tree green/red
+//          decoration colors; "muted" keeps ambient metadata quiet. Tabular-nums keeps
 //          counts column-aligned.
 // Layer: Pull request presentation
 // Exports: PullRequestDiffStat

--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -138,7 +138,11 @@ export const PullRequestRow = function PullRequestRow({
           )}
         >
           <span>{formatRelativeTime(entry.updatedAt)}</span>
-          <PullRequestDiffStat additions={entry.additions} deletions={entry.deletions} />
+          <PullRequestDiffStat
+            additions={entry.additions}
+            deletions={entry.deletions}
+            tone="diff"
+          />
         </span>
       </button>
       <Tooltip>


### PR DESCRIPTION
## What Changed

Pull request list rows and the Environment panel PR change counts now use the existing `tone="diff"` styling on `PullRequestDiffStat`, so additions render green and deletions red (same decoration tokens as detail views and working-tree stats).

## Why

Those `+/−` counts were muted like timestamps, which made change size harder to scan. The colored tone already existed for the detail summary and code tabs; the list and Environment rows just were not using it.

## UI Changes

- Before: PR list / Environment `+N -M` used quiet muted ink

<img width="1168" height="1348" alt="CleanShot 2026-08-06 at 07 39 06" src="https://github.com/user-attachments/assets/0c18f10c-87b7-4b19-a1d6-dc6c8a61e4dd" />

- After: `+N` uses `--color-decoration-added`, `-M` uses `--color-decoration-deleted`

<img width="837" height="1192" alt="image" src="https://github.com/user-attachments/assets/b157fb87-dda8-4f78-aac8-13dd1dae863c" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

