### PR TITLE
refactor(server): keep Antigravity cancel settlement minimal

### DIFF
--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -6,8 +6,8 @@ import path from "node:path";
 import { PassThrough } from "node:stream";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { type ProviderRuntimeEvent, ThreadId } from "@synara/contracts";
-import { Effect, Fiber, Layer, Stream } from "effect";
+import { ThreadId } from "@synara/contracts";
+import { Effect, Layer } from "effect";
 import { describe, expect, it } from "vitest";
 
 import { ServerConfig } from "../../config";
@@ -43,59 +43,6 @@ function runCaptureCommand(command: string, input: string, env: NodeJS.ProcessEn
     encoding: "utf8",
     timeout: 5_000,
   });
-}
-
-type ControllableAntigravityChild = ChildProcess & {
-  readonly stdout: PassThrough;
-  readonly stderr: PassThrough;
-};
-
-function makeControllableAntigravityChild(): ControllableAntigravityChild {
-  const child = new EventEmitter() as ControllableAntigravityChild;
-  Object.assign(child, {
-    stdout: new PassThrough(),
-    stderr: new PassThrough(),
-    killed: false,
-    exitCode: null as number | null,
-    signalCode: null as NodeJS.Signals | null,
-    kill: () => true,
-  });
-  return child;
-}
-
-function closeControllableAntigravityChild(
-  child: ControllableAntigravityChild,
-  code: number | null,
-  signal: NodeJS.Signals | null,
-): void {
-  Object.assign(child, { exitCode: code, signalCode: signal });
-  child.emit("exit", code, signal);
-  child.emit("close", code, signal);
-}
-
-function makeGatewayCredentials(onRevoke: (token: string) => void): AgentGatewayCredentialsShape {
-  let tokenSequence = 0;
-  return {
-    mcpEndpointUrl: "http://127.0.0.1:3773/mcp",
-    setListeningPort: () => undefined,
-    issueSessionToken: () => `test-session-${String(++tokenSequence)}`,
-    verifySessionToken: () => null,
-    verifySession: () => null,
-    issueStdioBootstrapToken: (token) => `bootstrap-${token}`,
-    exchangeStdioBootstrapToken: () => null,
-    bindWriteAuthority: () => null,
-    verifyWriteAuthority: () => false,
-    registerInFlightRequest: () => () => undefined,
-    cancelInFlightRequests: () => ({ count: 0, settled: Promise.resolve() }),
-    cancelSessionTurnRequests: () => Promise.resolve(),
-    retireSessionTurn: () => Promise.resolve(),
-    revokeSessionToken: onRevoke,
-    connectionForThread: () => ({
-      url: "http://127.0.0.1:3773/mcp",
-      bearerToken: `test-session-${String(++tokenSequence)}`,
-    }),
-    stdioProxy: { command: process.execPath, args: ["proxy.mjs"] },
-  };
 }
 
 describe("Antigravity CLI model translation", () => {
@@ -675,21 +622,35 @@ describe("Antigravity CLI integration helpers", () => {
 });
 
 describe("Antigravity turn settle on cancel (#465)", () => {
-  it("keeps an unproven process active and blocks a successor", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-interrupt-hung-"));
-    let teardownShouldFail = true;
-    const child = makeControllableAntigravityChild();
-    const spawnProcess = ((
+  const makeSpawnProcess = (children: ChildProcess[]) =>
+    ((
       _command: string,
       _args: readonly string[],
       _options: { readonly env?: NodeJS.ProcessEnv },
-    ) => child) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
-    const teardownProcessTree: NonNullable<
-      AntigravityAdapterDependencies["teardownProcessTree"]
-    > = async () => {
-      if (teardownShouldFail) throw new Error("process exit remains unproven");
-      return { escalated: false, signalErrors: [] };
-    };
+    ) => {
+      const child = new EventEmitter() as ChildProcess;
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      Object.assign(child, {
+        stdout,
+        stderr,
+        killed: false,
+        exitCode: null as number | null,
+        signalCode: null as NodeJS.Signals | null,
+        kill: () => true,
+      });
+      children.push(child);
+      return child;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+
+  const failTeardown = async () => {
+    throw new Error("process exit could not be proven");
+  };
+
+  it("unlocks Cancel without letting a late close settle the follow-up", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-interrupt-hung-"));
+    const children: ChildProcess[] = [];
+    const spawnProcess = makeSpawnProcess(children);
 
     try {
       await Effect.runPromise(
@@ -715,712 +676,35 @@ describe("Antigravity turn settle on cancel (#465)", () => {
           yield* adapter.interruptTurn(threadId, turn.turnId);
 
           const after = (yield* adapter.listSessions()).find((s) => s.threadId === threadId);
-          expect(after?.status).toBe("running");
-          expect(after?.activeTurnId).toBe(turn.turnId);
-          yield* adapter.sendTurn({ threadId, input: "must remain blocked", attachments: [] }).pipe(
-            Effect.flip,
-            Effect.tap((error) =>
-              Effect.sync(() => expect(error.message).toContain("already active")),
-            ),
+          expect(after?.status).toBe("ready");
+          expect(after?.activeTurnId).toBeUndefined();
+
+          const followUp = yield* adapter.sendTurn({
+            threadId,
+            input: "follow-up",
+            attachments: [],
+          });
+          children[0]?.emit("close", 0, null);
+          yield* Effect.sleep("25 millis");
+
+          const afterLateClose = (yield* adapter.listSessions()).find(
+            (session) => session.threadId === threadId,
           );
-          teardownShouldFail = false;
+          expect(afterLateClose?.status).toBe("running");
+          expect(afterLateClose?.activeTurnId).toBe(followUp.turnId);
+
+          children[1]?.emit("close", 0, null);
+          yield* Effect.sleep("25 millis");
           yield* adapter.stopSession(threadId);
         }).pipe(
           Effect.provide(
             makeAntigravityAdapterLive({
               ensurePlugin: async () => undefined,
               spawnProcess,
-              teardownProcessTree,
+              teardownProcessTree: failTeardown,
             }).pipe(
               Layer.provideMerge(
                 ServerConfig.layerTest(root, { prefix: "antigravity-interrupt-hung-" }),
-              ),
-              Layer.provideMerge(NodeServices.layer),
-            ),
-          ),
-        ),
-      );
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("drains final output before settling a successfully interrupted process", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-close-drain-"));
-    const child = makeControllableAntigravityChild();
-    let resolveTreeExit!: (result: { escalated: boolean; signalErrors: Error[] }) => void;
-    const treeExit = new Promise<{ escalated: boolean; signalErrors: Error[] }>((resolve) => {
-      resolveTreeExit = resolve;
-    });
-    const spawnProcess = (() => child) as NonNullable<
-      AntigravityAdapterDependencies["spawnProcess"]
-    >;
-    const teardownProcessTree: NonNullable<
-      AntigravityAdapterDependencies["teardownProcessTree"]
-    > = async () => {
-      setTimeout(() => {
-        child.stdout.end("final output before close\n");
-        child.stderr.end();
-        closeControllableAntigravityChild(child, null, "SIGTERM");
-      }, 10);
-      setTimeout(() => resolveTreeExit({ escalated: false, signalErrors: [] }), 30);
-      return treeExit;
-    };
-
-    try {
-      await Effect.runPromise(
-        Effect.gen(function* () {
-          const adapter = yield* AntigravityAdapter;
-          const runtimeEventsFiber = yield* Stream.runCollect(
-            Stream.take(adapter.streamEvents, 7),
-          ).pipe(Effect.forkChild);
-          const threadId = ThreadId.makeUnsafe("thread-antigravity-close-drain");
-          yield* adapter.startSession({
-            provider: "antigravity",
-            threadId,
-            runtimeMode: "full-access",
-            cwd: root,
-            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
-          });
-          const turn = yield* adapter.sendTurn({
-            threadId,
-            input: "cancel after output",
-            attachments: [],
-          });
-          yield* adapter.interruptTurn(threadId, turn.turnId);
-
-          const runtimeEvents = Array.from(
-            yield* Fiber.join(runtimeEventsFiber).pipe(Effect.timeout("5 seconds")),
-          );
-          expect(
-            runtimeEvents
-              .filter((event) => event.type === "content.delta")
-              .map((event) => event.payload.delta),
-          ).toEqual(["final output before close"]);
-          const completed = runtimeEvents.find((event) => event.type === "turn.completed");
-          expect(completed?.turnId).toBe(turn.turnId);
-          expect(completed?.payload).toMatchObject({
-            state: "interrupted",
-            stopReason: "interrupted",
-          });
-          yield* adapter.stopSession(threadId);
-        }).pipe(
-          Effect.provide(
-            makeAntigravityAdapterLive({
-              ensurePlugin: async () => undefined,
-              spawnProcess,
-              teardownProcessTree,
-              closeDrainTimeoutMs: 100,
-            }).pipe(
-              Layer.provideMerge(
-                ServerConfig.layerTest(root, { prefix: "antigravity-close-drain-" }),
-              ),
-              Layer.provideMerge(NodeServices.layer),
-            ),
-          ),
-        ),
-      );
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("keeps interrupt ownership when root closes before tree-exit proof fails", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-interrupt-proof-"));
-    const child = makeControllableAntigravityChild();
-    const spawnProcess = (() => child) as NonNullable<
-      AntigravityAdapterDependencies["spawnProcess"]
-    >;
-    const teardownProcessTree: NonNullable<
-      AntigravityAdapterDependencies["teardownProcessTree"]
-    > = async () => {
-      setTimeout(() => {
-        child.stdout.end("output before failed proof\n");
-        child.stderr.end();
-        closeControllableAntigravityChild(child, null, "SIGTERM");
-      }, 10);
-      await new Promise((_, reject) =>
-        setTimeout(() => reject(new Error("interrupt descendants remain alive")), 30),
-      );
-      return { escalated: false, signalErrors: [] };
-    };
-
-    try {
-      await Effect.runPromise(
-        Effect.gen(function* () {
-          const adapter = yield* AntigravityAdapter;
-          const threadId = ThreadId.makeUnsafe("thread-antigravity-interrupt-proof");
-          yield* adapter.startSession({
-            provider: "antigravity",
-            threadId,
-            runtimeMode: "full-access",
-            cwd: root,
-            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
-          });
-          const turn = yield* adapter.sendTurn({
-            threadId,
-            input: "cancel with surviving descendants",
-            attachments: [],
-          });
-          yield* adapter.interruptTurn(threadId, turn.turnId);
-
-          const afterFailedProof = (yield* adapter.listSessions()).find(
-            (session) => session.threadId === threadId,
-          );
-          expect(afterFailedProof?.status).toBe("running");
-          expect(afterFailedProof?.activeTurnId).toBe(turn.turnId);
-          yield* adapter.sendTurn({ threadId, input: "must remain blocked", attachments: [] }).pipe(
-            Effect.flip,
-            Effect.tap((error) =>
-              Effect.sync(() => expect(error.message).toContain("already active")),
-            ),
-          );
-        }).pipe(
-          Effect.provide(
-            makeAntigravityAdapterLive({
-              ensurePlugin: async () => undefined,
-              spawnProcess,
-              teardownProcessTree,
-              closeDrainTimeoutMs: 100,
-            }).pipe(
-              Layer.provideMerge(
-                ServerConfig.layerTest(root, { prefix: "antigravity-interrupt-proof-" }),
-              ),
-              Layer.provideMerge(NodeServices.layer),
-            ),
-          ),
-        ),
-      );
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("classifies a Stop-hook teardown as model completion", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-model-stop-"));
-    const child = makeControllableAntigravityChild();
-    let eventFile = "";
-    let teardownStarted = false;
-    let resolveTreeExit!: (result: { escalated: boolean; signalErrors: Error[] }) => void;
-    const treeExit = new Promise<{ escalated: boolean; signalErrors: Error[] }>((resolve) => {
-      resolveTreeExit = resolve;
-    });
-    const spawnProcess = ((
-      _command: string,
-      _args: readonly string[],
-      options: { readonly env?: NodeJS.ProcessEnv },
-    ) => {
-      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS ?? "";
-      return child;
-    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
-    const teardownProcessTree: NonNullable<
-      AntigravityAdapterDependencies["teardownProcessTree"]
-    > = async () => {
-      teardownStarted = true;
-      return treeExit;
-    };
-
-    try {
-      await Effect.runPromise(
-        Effect.gen(function* () {
-          const adapter = yield* AntigravityAdapter;
-          const runtimeEventsFiber = yield* Stream.runCollect(
-            Stream.take(adapter.streamEvents, 7),
-          ).pipe(Effect.forkChild);
-          const threadId = ThreadId.makeUnsafe("thread-antigravity-model-stop");
-          yield* adapter.startSession({
-            provider: "antigravity",
-            threadId,
-            runtimeMode: "full-access",
-            cwd: root,
-            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
-          });
-          const turn = yield* adapter.sendTurn({
-            threadId,
-            input: "finish normally",
-            attachments: [],
-          });
-          yield* Effect.promise(() => fs.appendFile(eventFile, "stop\t{}\n"));
-          for (let attempt = 0; attempt < 20 && !teardownStarted; attempt += 1) {
-            yield* Effect.sleep(10);
-          }
-          expect(teardownStarted).toBe(true);
-          child.stdout.end("completed response\n");
-          child.stderr.end();
-          closeControllableAntigravityChild(child, null, "SIGTERM");
-          yield* Effect.sleep(20);
-
-          const beforeTreeExitProof = (yield* adapter.listSessions()).find(
-            (session) => session.threadId === threadId,
-          );
-          expect(beforeTreeExitProof?.status).toBe("running");
-          expect(beforeTreeExitProof?.activeTurnId).toBe(turn.turnId);
-          resolveTreeExit({ escalated: false, signalErrors: [] });
-
-          const runtimeEvents = Array.from(
-            yield* Fiber.join(runtimeEventsFiber).pipe(Effect.timeout("5 seconds")),
-          );
-          const completed = runtimeEvents.find((event) => event.type === "turn.completed");
-          expect(completed?.turnId).toBe(turn.turnId);
-          expect(completed?.payload).toMatchObject({
-            state: "completed",
-            stopReason: "model_stop",
-          });
-          yield* adapter.stopSession(threadId);
-        }).pipe(
-          Effect.provide(
-            makeAntigravityAdapterLive({
-              ensurePlugin: async () => undefined,
-              spawnProcess,
-              teardownProcessTree,
-              closeDrainTimeoutMs: 100,
-              stopNaturalExitGraceMs: 10,
-            }).pipe(
-              Layer.provideMerge(
-                ServerConfig.layerTest(root, { prefix: "antigravity-model-stop-" }),
-              ),
-              Layer.provideMerge(NodeServices.layer),
-            ),
-          ),
-        ),
-      );
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("retains ownership when Stop teardown cannot prove descendant exit", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-stop-unproven-"));
-    const child = makeControllableAntigravityChild();
-    let eventFile = "";
-    let teardownCalls = 0;
-    let rejectTreeExit!: (cause: unknown) => void;
-    const treeExit = new Promise<never>((_resolve, reject) => {
-      rejectTreeExit = reject;
-    });
-    const spawnProcess = ((
-      _command: string,
-      _args: readonly string[],
-      options: { readonly env?: NodeJS.ProcessEnv },
-    ) => {
-      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS ?? "";
-      return child;
-    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
-    const teardownProcessTree: NonNullable<
-      AntigravityAdapterDependencies["teardownProcessTree"]
-    > = async () => {
-      teardownCalls += 1;
-      if (teardownCalls === 1) return treeExit;
-      return { escalated: false, signalErrors: [] };
-    };
-
-    try {
-      await Effect.runPromise(
-        Effect.gen(function* () {
-          const adapter = yield* AntigravityAdapter;
-          const threadId = ThreadId.makeUnsafe("thread-antigravity-stop-unproven");
-          yield* adapter.startSession({
-            provider: "antigravity",
-            threadId,
-            runtimeMode: "full-access",
-            cwd: root,
-            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
-          });
-          const turn = yield* adapter.sendTurn({
-            threadId,
-            input: "finish with surviving descendants",
-            attachments: [],
-          });
-          yield* Effect.promise(() => fs.appendFile(eventFile, "stop\t{}\n"));
-          for (let attempt = 0; attempt < 20 && teardownCalls === 0; attempt += 1) {
-            yield* Effect.sleep(10);
-          }
-          expect(teardownCalls).toBe(1);
-          child.stdout.end("root response\n");
-          child.stderr.end();
-          closeControllableAntigravityChild(child, null, "SIGTERM");
-          rejectTreeExit(new Error("descendant exit remains unproven"));
-          yield* Effect.sleep(20);
-
-          const afterFailedProof = (yield* adapter.listSessions()).find(
-            (session) => session.threadId === threadId,
-          );
-          expect(afterFailedProof?.status).toBe("running");
-          expect(afterFailedProof?.activeTurnId).toBe(turn.turnId);
-          yield* adapter.sendTurn({ threadId, input: "must remain blocked", attachments: [] }).pipe(
-            Effect.flip,
-            Effect.tap((error) =>
-              Effect.sync(() => expect(error.message).toContain("already active")),
-            ),
-          );
-          yield* adapter.stopSession(threadId).pipe(
-            Effect.flip,
-            Effect.tap((error) =>
-              Effect.sync(() =>
-                expect(error.message).toContain("descendant exit remains unproven"),
-              ),
-            ),
-          );
-          expect(teardownCalls).toBe(1);
-        }).pipe(
-          Effect.provide(
-            makeAntigravityAdapterLive({
-              ensurePlugin: async () => undefined,
-              spawnProcess,
-              teardownProcessTree,
-              closeDrainTimeoutMs: 100,
-              stopNaturalExitGraceMs: 10,
-            }).pipe(
-              Layer.provideMerge(
-                ServerConfig.layerTest(root, { prefix: "antigravity-stop-unproven-" }),
-              ),
-              Layer.provideMerge(NodeServices.layer),
-            ),
-          ),
-        ),
-      );
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("does not start teardown from a Stop hook discovered after root close", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-short-close-"));
-    const child = makeControllableAntigravityChild();
-    let eventFile = "";
-    let teardownCalls = 0;
-    const spawnProcess = ((
-      _command: string,
-      _args: readonly string[],
-      options: { readonly env?: NodeJS.ProcessEnv },
-    ) => {
-      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS ?? "";
-      return child;
-    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
-    const teardownProcessTree: NonNullable<
-      AntigravityAdapterDependencies["teardownProcessTree"]
-    > = async () => {
-      teardownCalls += 1;
-      return { escalated: false, signalErrors: [] };
-    };
-
-    try {
-      await Effect.runPromise(
-        Effect.gen(function* () {
-          const adapter = yield* AntigravityAdapter;
-          const runtimeEventsFiber = yield* Stream.runCollect(
-            Stream.take(adapter.streamEvents, 7),
-          ).pipe(Effect.forkChild);
-          const threadId = ThreadId.makeUnsafe("thread-antigravity-short-close");
-          yield* adapter.startSession({
-            provider: "antigravity",
-            threadId,
-            runtimeMode: "full-access",
-            cwd: root,
-            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
-          });
-          const turn = yield* adapter.sendTurn({
-            threadId,
-            input: "short successful turn",
-            attachments: [],
-          });
-          yield* Effect.promise(() => fs.appendFile(eventFile, "stop\t{}\n"));
-          yield* Effect.sleep(20);
-          expect(teardownCalls).toBe(0);
-          child.stdout.end("short response\n");
-          child.stderr.end();
-          closeControllableAntigravityChild(child, 0, null);
-
-          const runtimeEvents = Array.from(
-            yield* Fiber.join(runtimeEventsFiber).pipe(Effect.timeout("5 seconds")),
-          );
-          expect(teardownCalls).toBe(0);
-          const completed = runtimeEvents.find((event) => event.type === "turn.completed");
-          expect(completed?.turnId).toBe(turn.turnId);
-          expect(completed?.payload).toMatchObject({
-            state: "completed",
-            stopReason: "model_stop",
-          });
-          yield* adapter.stopSession(threadId);
-        }).pipe(
-          Effect.provide(
-            makeAntigravityAdapterLive({
-              ensurePlugin: async () => undefined,
-              spawnProcess,
-              teardownProcessTree,
-              stopNaturalExitGraceMs: 100,
-            }).pipe(
-              Layer.provideMerge(
-                ServerConfig.layerTest(root, { prefix: "antigravity-short-close-" }),
-              ),
-              Layer.provideMerge(NodeServices.layer),
-            ),
-          ),
-        ),
-      );
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("cleans turn resources before Stop close-drain timeout settlement", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-stop-timeout-"));
-    const child = makeControllableAntigravityChild();
-    const revokedTokens: string[] = [];
-    const credentials = makeGatewayCredentials((token) => revokedTokens.push(token));
-    let eventFile = "";
-    const spawnProcess = ((
-      _command: string,
-      _args: readonly string[],
-      options: { readonly env?: NodeJS.ProcessEnv },
-    ) => {
-      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS ?? "";
-      return child;
-    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
-    const teardownProcessTree: NonNullable<
-      AntigravityAdapterDependencies["teardownProcessTree"]
-    > = async () => ({ escalated: false, signalErrors: [] });
-
-    try {
-      await Effect.runPromise(
-        Effect.gen(function* () {
-          const adapter = yield* AntigravityAdapter;
-          const threadId = ThreadId.makeUnsafe("thread-antigravity-stop-timeout");
-          yield* adapter.startSession({
-            provider: "antigravity",
-            threadId,
-            runtimeMode: "full-access",
-            cwd: root,
-            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
-          });
-          yield* adapter.sendTurn({
-            threadId,
-            input: "stop without close",
-            attachments: [],
-          });
-          const runDir = path.dirname(eventFile);
-          yield* Effect.promise(() => fs.appendFile(eventFile, "stop\t{}\n"));
-          for (let attempt = 0; attempt < 50; attempt += 1) {
-            const session = (yield* adapter.listSessions()).find(
-              (candidate) => candidate.threadId === threadId,
-            );
-            if (session?.status === "ready") break;
-            yield* Effect.sleep(10);
-          }
-
-          const settled = (yield* adapter.listSessions()).find(
-            (session) => session.threadId === threadId,
-          );
-          expect(settled?.status).toBe("ready");
-          expect(revokedTokens).toEqual(["test-session-1"]);
-          yield* Effect.promise(() =>
-            fs.stat(runDir).then(
-              () => expect.fail("expected the completed turn run directory to be removed"),
-              (error: NodeJS.ErrnoException) => expect(error.code).toBe("ENOENT"),
-            ),
-          );
-          yield* adapter.stopSession(threadId);
-        }).pipe(
-          Effect.provide(
-            makeAntigravityAdapterLive({
-              ensurePlugin: async () => undefined,
-              spawnProcess,
-              teardownProcessTree,
-              closeDrainTimeoutMs: 25,
-              stopNaturalExitGraceMs: 10,
-            }).pipe(
-              Layer.provide(Layer.succeed(AgentGatewayCredentials, credentials)),
-              Layer.provideMerge(
-                ServerConfig.layerTest(root, { prefix: "antigravity-stop-timeout-" }),
-              ),
-              Layer.provideMerge(NodeServices.layer),
-            ),
-          ),
-        ),
-      );
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("does not settle a detached Stop timeout after session removal", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-stop-session-"));
-    const child = makeControllableAntigravityChild();
-    let eventFile = "";
-    let teardownCalls = 0;
-    const spawnProcess = ((
-      _command: string,
-      _args: readonly string[],
-      options: { readonly env?: NodeJS.ProcessEnv },
-    ) => {
-      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS ?? "";
-      return child;
-    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
-    const teardownProcessTree: NonNullable<
-      AntigravityAdapterDependencies["teardownProcessTree"]
-    > = async () => {
-      teardownCalls += 1;
-      return { escalated: false, signalErrors: [] };
-    };
-
-    try {
-      await Effect.runPromise(
-        Effect.gen(function* () {
-          const adapter = yield* AntigravityAdapter;
-          const runtimeEvents: ProviderRuntimeEvent[] = [];
-          const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
-            Effect.sync(() => runtimeEvents.push(event)),
-          ).pipe(Effect.forkChild);
-          const threadId = ThreadId.makeUnsafe("thread-antigravity-stop-session");
-          yield* adapter.startSession({
-            provider: "antigravity",
-            threadId,
-            runtimeMode: "full-access",
-            cwd: root,
-            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
-          });
-          yield* adapter.sendTurn({
-            threadId,
-            input: "stop session during timeout",
-            attachments: [],
-          });
-          yield* Effect.promise(() => fs.appendFile(eventFile, "stop\t{}\n"));
-          for (let attempt = 0; attempt < 30 && teardownCalls === 0; attempt += 1) {
-            yield* Effect.sleep(10);
-          }
-          expect(teardownCalls).toBe(1);
-          yield* adapter.stopSession(threadId);
-          yield* Effect.sleep(150);
-          yield* Fiber.interrupt(runtimeEventsFiber);
-
-          expect(runtimeEvents.map((event) => event.type)).toEqual([
-            "session.started",
-            "thread.started",
-            "turn.started",
-            "session.exited",
-          ]);
-          expect(runtimeEvents.some((event) => event.type === "turn.completed")).toBe(false);
-        }).pipe(
-          Effect.provide(
-            makeAntigravityAdapterLive({
-              ensurePlugin: async () => undefined,
-              spawnProcess,
-              teardownProcessTree,
-              closeDrainTimeoutMs: 100,
-              stopNaturalExitGraceMs: 10,
-            }).pipe(
-              Layer.provideMerge(
-                ServerConfig.layerTest(root, { prefix: "antigravity-stop-session-" }),
-              ),
-              Layer.provideMerge(NodeServices.layer),
-            ),
-          ),
-        ),
-      );
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("does not let a stale child contaminate or settle the follow-up turn", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-stale-child-"));
-    const children: ControllableAntigravityChild[] = [];
-    const eventFiles: string[] = [];
-    const spawnProcess = ((
-      _command: string,
-      _args: readonly string[],
-      options: { readonly env?: NodeJS.ProcessEnv },
-    ) => {
-      const child = makeControllableAntigravityChild();
-      children.push(child);
-      eventFiles.push(options.env?.SYNARA_ANTIGRAVITY_EVENTS ?? "");
-      return child;
-    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
-    const teardownProcessTree: NonNullable<
-      AntigravityAdapterDependencies["teardownProcessTree"]
-    > = async () => ({ escalated: false, signalErrors: [] });
-
-    try {
-      await Effect.runPromise(
-        Effect.gen(function* () {
-          const adapter = yield* AntigravityAdapter;
-          const runtimeEventsFiber = yield* Stream.runCollect(
-            Stream.take(adapter.streamEvents, 9),
-          ).pipe(Effect.forkChild);
-          const threadId = ThreadId.makeUnsafe("thread-antigravity-stale-child");
-          yield* adapter.startSession({
-            provider: "antigravity",
-            threadId,
-            runtimeMode: "full-access",
-            cwd: root,
-            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
-          });
-
-          const firstTurn = yield* adapter.sendTurn({
-            threadId,
-            input: "first turn",
-            attachments: [],
-          });
-          yield* adapter.interruptTurn(threadId, firstTurn.turnId);
-
-          const secondTurn = yield* adapter.sendTurn({
-            threadId,
-            input: "follow-up turn",
-            attachments: [],
-          });
-          const firstChild = children[0]!;
-          const secondChild = children[1]!;
-          yield* Effect.promise(() =>
-            fs.stat(path.dirname(eventFiles[0]!)).then(
-              () => expect.fail("expected the interrupted turn run directory to be removed"),
-              (error: NodeJS.ErrnoException) => expect(error.code).toBe("ENOENT"),
-            ),
-          );
-          firstChild.stdout.write("stale first-turn output\n");
-          closeControllableAntigravityChild(firstChild, 0, null);
-          yield* Effect.sleep(100);
-
-          const afterStaleClose = (yield* adapter.listSessions()).find(
-            (session) => session.threadId === threadId,
-          );
-          expect(afterStaleClose?.status).toBe("running");
-          expect(afterStaleClose?.activeTurnId).toBe(secondTurn.turnId);
-
-          secondChild.stdout.end("fresh follow-up output\n");
-          secondChild.stderr.end();
-          closeControllableAntigravityChild(secondChild, 0, null);
-
-          const runtimeEvents = Array.from(
-            yield* Fiber.join(runtimeEventsFiber).pipe(Effect.timeout("5 seconds")),
-          );
-          const completed = runtimeEvents.filter((event) => event.type === "turn.completed");
-          expect(
-            completed.map((event) => ({ turnId: event.turnId, state: event.payload.state })),
-          ).toEqual([
-            { turnId: firstTurn.turnId, state: "interrupted" },
-            { turnId: secondTurn.turnId, state: "completed" },
-          ]);
-          expect(
-            runtimeEvents
-              .filter((event) => event.type === "content.delta")
-              .map((event) => event.payload.delta),
-          ).toEqual(["fresh follow-up output"]);
-          expect(
-            runtimeEvents.some(
-              (event) => event.providerRefs?.providerThreadId === "stale-conversation",
-            ),
-          ).toBe(false);
-          yield* adapter.stopSession(threadId);
-        }).pipe(
-          Effect.provide(
-            makeAntigravityAdapterLive({
-              ensurePlugin: async () => undefined,
-              spawnProcess,
-              teardownProcessTree,
-              closeDrainTimeoutMs: 25,
-            }).pipe(
-              Layer.provideMerge(
-                ServerConfig.layerTest(root, { prefix: "antigravity-stale-child-" }),
               ),
               Layer.provideMerge(NodeServices.layer),
             ),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -67,8 +67,6 @@ const PROVIDER = "antigravity" as const;
 const DEFAULT_MODEL = "Gemini 3.5 Flash";
 const PRINT_TIMEOUT = "30m";
 const POLL_INTERVAL_MS = 75;
-const CLOSE_DRAIN_TIMEOUT_MS = 1_000;
-const STOP_NATURAL_EXIT_GRACE_MS = 150;
 const MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
 const PLUGIN_INSTALL_TIMEOUT_MS = 30_000;
 const HELPER_OUTPUT_MAX_CHARS = 128 * 1024;
@@ -99,17 +97,6 @@ type StoredTurn = {
   readonly items: unknown[];
 };
 
-type AntigravityTreeExitProof = {
-  readonly turnId: TurnId;
-  readonly child: ChildProcess;
-  result?: AntigravityTreeExitResult;
-  readonly promise: Promise<AntigravityTreeExitResult>;
-};
-
-type AntigravityTreeExitResult =
-  | { readonly proven: true }
-  | { readonly proven: false; readonly cause: unknown };
-
 type AntigravitySessionContext = {
   session: ProviderSession;
   gatewaySessionLease?: AgentGatewaySessionLease;
@@ -119,16 +106,6 @@ type AntigravitySessionContext = {
   readonly turns: StoredTurn[];
   activeTurnId?: TurnId | undefined;
   activeProcess?: ChildProcess | undefined;
-  activePollTimer?: NodeJS.Timeout | undefined;
-  activeCloseDrain?: {
-    readonly turnId: TurnId;
-    readonly child: ChildProcess;
-    readonly promise: Promise<void>;
-    readonly releaseGateway: () => Promise<void>;
-    readonly cleanupRunDir: () => Promise<void>;
-    readonly cleanup: () => Promise<void>;
-  };
-  activeTreeExitProof?: AntigravityTreeExitProof;
   activePrompt?: string | undefined;
   eventFile?: string | undefined;
   transcriptPath?: string | undefined;
@@ -141,7 +118,6 @@ type AntigravitySessionContext = {
   processedSteps: Set<number>;
   pendingTools: PendingTool[];
   sawAssistant: boolean;
-  modelStopObserved: boolean;
   interrupted: boolean;
   stopped: boolean;
   /** Guards against double turn.completed (process close + interrupt/stop). */
@@ -150,23 +126,6 @@ type AntigravitySessionContext = {
 
 function messageFromCause(cause: unknown, fallback: string): string {
   return cause instanceof Error && cause.message.trim() ? cause.message : fallback;
-}
-
-function waitForCloseDrain(closeDrain: Promise<void>, timeoutMs: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    let settled = false;
-    const finish = (drained: boolean) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve(drained);
-    };
-    const timer = setTimeout(() => finish(false), timeoutMs);
-    closeDrain.then(
-      () => finish(true),
-      () => finish(true),
-    );
-  });
 }
 
 function trim(value: string | null | undefined): string | undefined {
@@ -610,8 +569,6 @@ type AntigravityChildProcess = ChildProcess & {
 export interface AntigravityAdapterDependencies {
   readonly ensurePlugin?: typeof ensureCapturePlugin;
   readonly teardownProcessTree?: typeof teardownChildProcessTree;
-  readonly closeDrainTimeoutMs?: number;
-  readonly stopNaturalExitGraceMs?: number;
   readonly spawnProcess?: (
     command: string,
     args: readonly string[],
@@ -622,6 +579,7 @@ export interface AntigravityAdapterDependencies {
 const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {}) =>
   Effect.gen(function* () {
     const serverConfig = yield* ServerConfig;
+    const teardownProcessTree = dependencies.teardownProcessTree ?? teardownChildProcessTree;
     const agentGatewayCredentials = Option.getOrUndefined(
       yield* Effect.serviceOption(AgentGatewayCredentials),
     );
@@ -630,10 +588,6 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
     );
     const sessions = new Map<ThreadId, AntigravitySessionContext>();
     const defaultEffortByModel = new Map(Object.entries(DEFAULT_EFFORT_BY_MODEL));
-    const teardownProcessTree = dependencies.teardownProcessTree ?? teardownChildProcessTree;
-    const closeDrainTimeoutMs = dependencies.closeDrainTimeoutMs ?? CLOSE_DRAIN_TIMEOUT_MS;
-    const stopNaturalExitGraceMs =
-      dependencies.stopNaturalExitGraceMs ?? STOP_NATURAL_EXIT_GRACE_MS;
 
     const eventIngress = yield* makeBoundedCallbackIngress<ProviderRuntimeEvent, never, never>(
       (event) => Queue.offer(eventQueue, event).pipe(Effect.asVoid),
@@ -684,16 +638,6 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         : Effect.fail(new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }));
     };
 
-    const ownsTurnProcess = (
-      threadId: ThreadId,
-      context: AntigravitySessionContext,
-      turnId: TurnId,
-      child: ChildProcess,
-    ): boolean =>
-      sessions.get(threadId) === context &&
-      context.activeTurnId === turnId &&
-      context.activeProcess === child;
-
     const releaseTurnGatewayLease = (
       context: AntigravitySessionContext,
       lease: AgentGatewaySessionLease | undefined = context.gatewaySessionLease,
@@ -702,56 +646,13 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       if (context.gatewaySessionLease === lease) delete context.gatewaySessionLease;
     };
 
-    const stopActivePoll = (context: AntigravitySessionContext): void => {
-      if (context.activePollTimer) clearInterval(context.activePollTimer);
-      delete context.activePollTimer;
-    };
-
-    const startTreeExitProof = (
-      context: AntigravitySessionContext,
-      turnId: TurnId,
-      child: ChildProcess,
-    ): AntigravityTreeExitProof => {
-      const existing = context.activeTreeExitProof;
-      if (
-        existing?.turnId === turnId &&
-        existing.child === child &&
-        (existing.result?.proven !== false || child.exitCode !== null || child.signalCode !== null)
-      ) {
-        return existing;
-      }
-      if (child.exitCode !== null || child.signalCode !== null) {
-        const result = {
-          proven: false,
-          cause: new Error("Cannot establish process-tree exit proof after the root has closed."),
-        } as const;
-        const proof = { turnId, child, result, promise: Promise.resolve(result) };
-        context.activeTreeExitProof = proof;
-        return proof;
-      }
-      let proof!: AntigravityTreeExitProof;
-      const promise = Promise.resolve()
-        .then(() => teardownProcessTree(child))
-        .then(
-          () => ({ proven: true }) as const,
-          (cause: unknown) => ({ proven: false, cause }) as const,
-        )
-        .then((result) => {
-          proof.result = result;
-          return result;
-        });
-      proof = { turnId, child, promise };
-      context.activeTreeExitProof = proof;
-      return proof;
-    };
-
     const teardownActiveProcess = (
       context: AntigravitySessionContext,
       method: string,
     ): Effect.Effect<void, ProviderAdapterRequestError> => {
       const child = context.activeProcess;
       if (!child) return Effect.void;
-      const runTeardown = Effect.tryPromise({
+      return Effect.tryPromise({
         try: () => teardownProcessTree(child),
         catch: (cause) =>
           new ProviderAdapterRequestError({
@@ -761,45 +662,6 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
             cause,
           }),
       }).pipe(Effect.asVoid);
-      const existingProof = context.activeTreeExitProof;
-      if (
-        existingProof !== undefined &&
-        existingProof.turnId === context.activeTurnId &&
-        existingProof.child === child
-      ) {
-        return Effect.promise(() => existingProof.promise).pipe(
-          Effect.flatMap((result) => {
-            if (result.proven) return Effect.void;
-            if (child.exitCode === null && child.signalCode === null) {
-              if (context.activeTreeExitProof === existingProof) {
-                delete context.activeTreeExitProof;
-              }
-              return runTeardown;
-            }
-            return Effect.fail(
-              new ProviderAdapterRequestError({
-                provider: PROVIDER,
-                method,
-                detail: messageFromCause(
-                  result.cause,
-                  "The Antigravity process tree did not prove exit.",
-                ),
-                cause: result.cause,
-              }),
-            );
-          }),
-        );
-      }
-      if (child.exitCode !== null || child.signalCode !== null) {
-        return Effect.fail(
-          new ProviderAdapterRequestError({
-            provider: PROVIDER,
-            method,
-            detail: "Cannot safely capture the Antigravity process tree after its root closed.",
-          }),
-        );
-      }
-      return runTeardown;
     };
 
     /**
@@ -810,28 +672,17 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
     const settleActiveTurn = (
       context: AntigravitySessionContext,
       input: {
-        readonly turnId: TurnId;
-        readonly child?: ChildProcess;
         readonly state: "completed" | "interrupted" | "failed";
         readonly stopReason: "model_stop" | "interrupted" | "error";
         readonly errorMessage?: string;
         readonly raw?: ReturnType<typeof raw>;
       },
     ): boolean => {
-      if (
-        context.stopped ||
-        sessions.get(context.session.threadId) !== context ||
-        context.turnTerminalEmitted ||
-        context.activeTurnId !== input.turnId ||
-        (input.child !== undefined && context.activeProcess !== input.child)
-      ) {
+      if (context.turnTerminalEmitted || context.activeTurnId === undefined) {
         return false;
       }
       const completionBase = base(context);
       context.turnTerminalEmitted = true;
-      stopActivePoll(context);
-      delete context.activeCloseDrain;
-      delete context.activeTreeExitProof;
       delete context.activeProcess;
       delete context.activeTurnId;
       const {
@@ -974,23 +825,21 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       }
     };
 
-    const readTranscript = async (
-      context: AntigravitySessionContext,
-      isCurrentTurnProcess: () => boolean,
-    ) => {
-      if (!isCurrentTurnProcess() || !context.transcriptPath) return;
-      const transcriptPath = context.transcriptPath;
-      const isInitialRead = context.processedTranscriptPath !== transcriptPath;
-      const processedTranscriptBytes = isInitialRead ? 0 : context.processedTranscriptBytes;
+    const readTranscript = async (context: AntigravitySessionContext) => {
+      if (!context.transcriptPath) return;
+      const isInitialRead = context.processedTranscriptPath !== context.transcriptPath;
+      if (isInitialRead) context.processedTranscriptBytes = 0;
       let batch: Awaited<ReturnType<typeof readCompleteAntigravityLines>>;
       try {
-        batch = await readCompleteAntigravityLines(transcriptPath, processedTranscriptBytes);
+        batch = await readCompleteAntigravityLines(
+          context.transcriptPath,
+          context.processedTranscriptBytes,
+        );
       } catch {
         return;
       }
-      if (!isCurrentTurnProcess() || context.transcriptPath !== transcriptPath) return;
       context.processedTranscriptBytes = batch.nextOffset;
-      context.processedTranscriptPath = transcriptPath;
+      context.processedTranscriptPath = context.transcriptPath;
       const steps = batch.lines.flatMap((line) => {
         try {
           return [JSON.parse(line) as TranscriptStep];
@@ -1025,20 +874,15 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       }
     };
 
-    const pollHookFile = async (
-      context: AntigravitySessionContext,
-      isCurrentTurnProcess: () => boolean,
-    ) => {
-      if (!isCurrentTurnProcess() || context.stopped || !context.eventFile) return;
-      const eventFile = context.eventFile;
-      const processedHookBytes = context.processedHookBytes;
+    const pollHookFile = async (context: AntigravitySessionContext) => {
+      if (context.stopped) return;
+      if (!context.eventFile) return;
       let batch: Awaited<ReturnType<typeof readCompleteAntigravityLines>>;
       try {
-        batch = await readCompleteAntigravityLines(eventFile, processedHookBytes);
+        batch = await readCompleteAntigravityLines(context.eventFile, context.processedHookBytes);
       } catch {
         return;
       }
-      if (!isCurrentTurnProcess() || context.eventFile !== eventFile) return;
       context.processedHookBytes = batch.nextOffset;
       for (const line of batch.lines) {
         const tab = line.indexOf("\t");
@@ -1078,57 +922,18 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         }
         // Agent finished: if the print process lingers, tear it down so the
         // close handler (or interrupt fallback) can settle the turn (#465).
-        if (eventName === "stop") context.modelStopObserved = true;
-        if (
-          eventName === "stop" &&
-          context.activeTurnId &&
-          context.activeProcess &&
-          !context.turnTerminalEmitted
-        ) {
-          const turnId = context.activeTurnId;
+        if (eventName === "stop" && context.activeProcess && !context.turnTerminalEmitted) {
           const child = context.activeProcess;
-          const closeDrain = context.activeCloseDrain;
-          // Once close/exit has fired the PID can be reused and descendants may
-          // already be reparented. Never start a new signal/capture pass then;
-          // only a proof begun while the owned root was live can gate settlement.
-          if (child.exitCode !== null || child.signalCode !== null) continue;
-          void (async () => {
-            if (closeDrain) {
-              const closedNaturally = await waitForCloseDrain(
-                closeDrain.promise,
-                stopNaturalExitGraceMs,
-              );
-              if (closedNaturally) return;
+          void teardownProcessTree(child).catch(() => {
+            try {
+              child.kill("SIGKILL");
+            } catch {
+              // Process may already be gone.
             }
-            if (
-              !isCurrentTurnProcess() ||
-              context.stopped ||
-              child.exitCode !== null ||
-              child.signalCode !== null
-            ) {
-              return;
-            }
-            const treeExitProof = startTreeExitProof(context, turnId, child);
-            const result = await treeExitProof.promise;
-            if (!result.proven || !isCurrentTurnProcess() || context.stopped) return;
-            if (!closeDrain || closeDrain.turnId !== turnId || closeDrain.child !== child) return;
-            const drained = await waitForCloseDrain(closeDrain.promise, closeDrainTimeoutMs);
-            if (!drained) {
-              if (!isCurrentTurnProcess() || context.stopped) return;
-              await closeDrain.cleanup();
-              if (!isCurrentTurnProcess() || context.stopped) return;
-              settleActiveTurn(context, {
-                turnId,
-                child,
-                state: "completed",
-                stopReason: "model_stop",
-                raw: raw("stop-close-drain-timeout", { timeoutMs: closeDrainTimeoutMs }),
-              });
-            }
-          })();
+          });
         }
       }
-      await readTranscript(context, isCurrentTurnProcess);
+      await readTranscript(context);
     };
 
     const startSession: AntigravityAdapterShape["startSession"] = (input) =>
@@ -1158,17 +963,11 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         });
         const existing = sessions.get(input.threadId);
         if (existing) {
-          const activeResources = existing.activeCloseDrain;
           existing.stopped = true;
           existing.interrupted = true;
-          stopActivePoll(existing);
           yield* cancelAgentGatewayTurn(existing.gatewaySessionLease, existing.activeTurnId);
           yield* teardownActiveProcess(existing, "session/restart");
-          if (activeResources) {
-            yield* Effect.promise(() => activeResources.cleanup());
-          } else {
-            releaseTurnGatewayLease(existing);
-          }
+          releaseTurnGatewayLease(existing);
         }
         const now = new Date().toISOString();
         const conversationId = resumeConversationId(input.resumeCursor);
@@ -1203,7 +1002,6 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           processedSteps: new Set(),
           pendingTools: [],
           sawAssistant: false,
-          modelStopObserved: false,
           interrupted: false,
           stopped: false,
           turnTerminalEmitted: false,
@@ -1323,7 +1121,6 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         yield* Effect.promise(() => markExistingTranscriptStepsProcessed(context));
         context.pendingTools = [];
         context.sawAssistant = false;
-        context.modelStopObserved = false;
         context.interrupted = false;
         context.turnTerminalEmitted = false;
         context.turns.push({ id: turnId, items: [] });
@@ -1383,49 +1180,22 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           });
         }
         context.activeProcess = child;
-        const isCurrentTurnProcess = () =>
-          !context.stopped && ownsTurnProcess(input.threadId, context, turnId, child);
-        let resolveCloseDrain!: () => void;
-        const closeDrain = new Promise<void>((resolve) => {
-          resolveCloseDrain = resolve;
-        });
-        let releaseGatewayPromise: Promise<void> | undefined;
-        const releaseGateway = () =>
-          (releaseGatewayPromise ??= Effect.runPromise(
-            cancelAgentGatewayTurn(gatewaySessionLease, turnId),
-          ).then(() => releaseTurnGatewayLease(context, gatewaySessionLease)));
-        let cleanupRunDirPromise: Promise<void> | undefined;
-        const cleanupRunDir = () =>
-          (cleanupRunDirPromise ??= fs
-            .rm(runDir, { recursive: true, force: true })
-            .catch(() => undefined));
-        const cleanup = async () => {
-          await releaseGateway();
-          await cleanupRunDir();
-        };
-        context.activeCloseDrain = {
-          turnId,
-          child,
-          promise: closeDrain,
-          releaseGateway,
-          cleanupRunDir,
-          cleanup,
-        };
+        const ownsTurn = () =>
+          sessions.get(input.threadId) === context &&
+          context.activeProcess === child &&
+          context.activeTurnId === turnId;
         let stdout = "";
         let stderr = "";
         child.stdout.setEncoding("utf8");
         child.stderr.setEncoding("utf8");
         child.stdout.on("data", (chunk) => (stdout += chunk));
         child.stderr.on("data", (chunk) => (stderr += chunk));
-        const timer = setInterval(
-          () => void pollHookFile(context, isCurrentTurnProcess),
-          POLL_INTERVAL_MS,
-        );
-        context.activePollTimer = timer;
+        const timer = setInterval(() => {
+          if (ownsTurn()) void pollHookFile(context);
+        }, POLL_INTERVAL_MS);
         child.once("error", (cause) => {
           clearInterval(timer);
-          if (context.activePollTimer === timer) delete context.activePollTimer;
-          if (!isCurrentTurnProcess()) return;
+          if (!ownsTurn()) return;
           offer({
             ...base(context, { includeTurn: false }),
             type: "runtime.error",
@@ -1438,68 +1208,69 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         });
         child.once("close", (code, signal) => {
           clearInterval(timer);
-          if (context.activePollTimer === timer) delete context.activePollTimer;
           void (async () => {
-            try {
-              // Each `agy -p` invocation owns a fresh gateway session. Revoke it as
-              // soon as that process exits, even when this callback is stale.
-              await releaseGateway();
-              if (!isCurrentTurnProcess()) return;
-              // Drain only this process generation. A forced interrupt may already
-              // have made a successor turn active while this close was pending.
-              await pollHookFile(context, isCurrentTurnProcess).catch(() => undefined);
-              if (!isCurrentTurnProcess()) return;
-              if (!context.sawAssistant && stdout.trim()) {
-                emitTextItem(
-                  context,
-                  {
-                    step_index: Number.MAX_SAFE_INTEGER,
-                    type: "PRINT_OUTPUT",
-                    content: stdout.trim(),
-                  },
-                  "assistant_message",
-                  "assistant_text",
-                );
-              }
-              const treeExitProof = context.activeTreeExitProof;
-              if (treeExitProof?.turnId === turnId && treeExitProof.child === child) {
-                const result = await treeExitProof.promise;
-                if (!isCurrentTurnProcess() || !result.proven) return;
-              }
-              const interrupted =
-                !context.modelStopObserved && (context.interrupted || signal !== null);
-              const failed = !context.modelStopObserved && !interrupted && (code ?? 1) !== 0;
-              if (failed && stderr.trim()) {
-                offer({
-                  ...base(context, { includeTurn: false }),
-                  type: "runtime.error",
-                  payload: { message: stderr.trim(), class: "provider_error" },
-                  raw: raw("stderr", { code, stderr }),
-                } satisfies ProviderRuntimeEvent);
-              }
-              settleActiveTurn(context, {
-                turnId,
-                child,
-                state: interrupted ? "interrupted" : failed ? "failed" : "completed",
-                stopReason: interrupted ? "interrupted" : failed ? "error" : "model_stop",
-                ...(failed
-                  ? {
-                      errorMessage:
-                        stderr.trim() || `Antigravity CLI exited with code ${code ?? 1}.`,
-                    }
-                  : {}),
-                raw: raw("process-exit", { code, signal, stdout, stderr }),
-              });
-            } finally {
-              if (
-                context.activeCloseDrain?.turnId === turnId &&
-                context.activeCloseDrain.child === child
-              ) {
-                delete context.activeCloseDrain;
-              }
-              await cleanupRunDir();
-              resolveCloseDrain();
+            if (!ownsTurn()) {
+              releaseTurnGatewayLease(context, gatewaySessionLease);
+              await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
+              return;
             }
+            // Another path may already have settled (interrupt / stop-hook kill).
+            // Still drain hooks/stdout before deciding, but never double-complete.
+            const completedTurnId = turnId;
+            await Effect.runPromise(cancelAgentGatewayTurn(gatewaySessionLease, completedTurnId));
+            if (!ownsTurn()) {
+              releaseTurnGatewayLease(context, gatewaySessionLease);
+              await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
+              return;
+            }
+            // Each `agy -p` invocation owns a fresh gateway session. Revoke it as
+            // soon as that process exits, before post-processing or a later turn
+            // can begin, so an unconsumed bootstrap from this turn cannot cross
+            // into the next turn's authority.
+            releaseTurnGatewayLease(context, gatewaySessionLease);
+            await pollHookFile(context).catch(() => undefined);
+            if (!ownsTurn()) {
+              await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
+              return;
+            }
+            if (!context.sawAssistant && stdout.trim()) {
+              emitTextItem(
+                context,
+                {
+                  step_index: Number.MAX_SAFE_INTEGER,
+                  type: "PRINT_OUTPUT",
+                  content: stdout.trim(),
+                },
+                "assistant_message",
+                "assistant_text",
+              );
+            }
+            if (context.turnTerminalEmitted) {
+              if (context.activeProcess === child) delete context.activeProcess;
+              await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
+              return;
+            }
+            const interrupted = context.interrupted || signal !== null;
+            const failed = !interrupted && (code ?? 1) !== 0;
+            if (failed && stderr.trim()) {
+              offer({
+                ...base(context, { includeTurn: false }),
+                type: "runtime.error",
+                payload: { message: stderr.trim(), class: "provider_error" },
+                raw: raw("stderr", { code, stderr }),
+              } satisfies ProviderRuntimeEvent);
+            }
+            settleActiveTurn(context, {
+              state: interrupted ? "interrupted" : failed ? "failed" : "completed",
+              stopReason: interrupted ? "interrupted" : failed ? "error" : "model_stop",
+              ...(failed
+                ? {
+                    errorMessage: stderr.trim() || `Antigravity CLI exited with code ${code ?? 1}.`,
+                  }
+                : {}),
+              raw: raw("process-exit", { code, signal, stdout, stderr }),
+            });
+            await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
           })();
         });
         return {
@@ -1521,64 +1292,46 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           return;
         }
         const activeTurnId = turnId ?? context.activeTurnId;
-        if (activeTurnId === undefined) return;
-        const activeProcess = context.activeProcess;
-        const activeCloseDrain = context.activeCloseDrain;
         yield* withAgentGatewayTurnCancellation(
           context.gatewaySessionLease,
           activeTurnId,
           Effect.gen(function* () {
             context.interrupted = true;
-            if (!activeProcess) {
+            const hadProcess = context.activeProcess !== undefined;
+            if (hadProcess) {
+              // Prefer process close for settlement so stdout/hooks still drain.
+              // If teardown cannot prove exit, force-settle so Cancel never no-ops (#465).
+              yield* teardownActiveProcess(context, "turn/interrupt").pipe(
+                Effect.catch((error) =>
+                  Effect.gen(function* () {
+                    const detail =
+                      error instanceof ProviderAdapterRequestError
+                        ? error.detail
+                        : messageFromCause(error, "interrupt teardown failed");
+                    yield* Effect.logWarning("antigravity.interrupt_teardown_failed", {
+                      threadId,
+                      detail,
+                    });
+                    settleActiveTurn(context, {
+                      state: "interrupted",
+                      stopReason: "interrupted",
+                      raw: raw("interrupt-teardown-failed", { detail }),
+                    });
+                  }),
+                ),
+              );
+            }
+            // Process already gone (or never attached) but turn still open — Cancel
+            // must still unlock the composer.
+            if (!context.turnTerminalEmitted && context.activeTurnId !== undefined) {
               settleActiveTurn(context, {
-                turnId: activeTurnId,
                 state: "interrupted",
                 stopReason: "interrupted",
-                raw: raw("interrupt-without-process", {}),
+                raw: raw("interrupt-without-process", {
+                  hadProcess,
+                }),
               });
-              return;
             }
-            const treeExitProof = startTreeExitProof(context, activeTurnId, activeProcess);
-            const treeExitResult = yield* Effect.promise(() => treeExitProof.promise);
-            // A failed teardown is not exit proof. Retain the child handle and
-            // active turn so no successor can overlap a potentially live process.
-            if (!treeExitResult.proven) {
-              yield* Effect.logWarning("antigravity.interrupt_teardown_failed", {
-                threadId,
-                detail: messageFromCause(treeExitResult.cause, "interrupt teardown failed"),
-              });
-              return;
-            }
-            const drained =
-              activeCloseDrain?.turnId === activeTurnId && activeCloseDrain.child === activeProcess
-                ? yield* Effect.promise(() =>
-                    waitForCloseDrain(activeCloseDrain.promise, closeDrainTimeoutMs),
-                  )
-                : false;
-            if (drained) return;
-            if (
-              context.stopped ||
-              !ownsTurnProcess(threadId, context, activeTurnId, activeProcess)
-            ) {
-              return;
-            }
-            if (activeCloseDrain) {
-              yield* Effect.promise(() => activeCloseDrain.cleanup());
-            }
-            if (
-              context.stopped ||
-              !ownsTurnProcess(threadId, context, activeTurnId, activeProcess)
-            ) {
-              return;
-            }
-            const modelStopped = context.modelStopObserved;
-            settleActiveTurn(context, {
-              turnId: activeTurnId,
-              child: activeProcess,
-              state: modelStopped ? "completed" : "interrupted",
-              stopReason: modelStopped ? "model_stop" : "interrupted",
-              raw: raw("interrupt-close-drain-timeout", { timeoutMs: closeDrainTimeoutMs }),
-            });
           }),
         );
       });
@@ -1596,17 +1349,11 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       Effect.gen(function* () {
         const context = sessions.get(threadId);
         if (!context) return;
-        const activeResources = context.activeCloseDrain;
         context.stopped = true;
         context.interrupted = true;
-        stopActivePoll(context);
         yield* cancelAgentGatewayTurn(context.gatewaySessionLease, context.activeTurnId);
         yield* teardownActiveProcess(context, "session/stop");
-        if (activeResources) {
-          yield* Effect.promise(() => activeResources.cleanup());
-        } else {
-          releaseTurnGatewayLease(context);
-        }
+        releaseTurnGatewayLease(context);
         sessions.delete(threadId);
         offer({
           ...base(context, { includeTurn: false }),


### PR DESCRIPTION
Reduces the merged #542 implementation back to Dilip's original change plus the minimal stale-turn ownership guard. Removes 1,135 lines of lifecycle machinery while preserving Cancel settlement and preventing a late close from settling a follow-up. Focused Antigravity adapter tests: 20/20.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Antigravity turn interrupt, process close, and stop-hook behavior where incorrect settlement could leave the UI stuck or corrupt follow-up turns; scope is large but behavior is narrowed and covered by focused tests.
> 
> **Overview**
> **Strips the Antigravity adapter’s turn-lifecycle machinery** (close-drain timeouts, process-tree exit proofs, `activeCloseDrain`, `modelStopObserved`, and related test-only dependency knobs) in favor of a smaller cancel/settle path for #465.
> 
> **Cancel (`interruptTurn`)** now force-settles the turn when teardown cannot prove process exit, so the session returns to `ready` instead of staying blocked on a hung process. **Process `close`** uses an `ownsTurn()` guard so a late close from a prior turn cleans up gateway/run dir only and cannot complete or disturb a follow-up turn.
> 
> **Stop hooks** only trigger a simple teardown/kill on the lingering CLI process; settlement stays on the normal close/interrupt path. **Tests** drop the large matrix of lifecycle scenarios and keep one focused case: cancel unlocks the composer even when teardown fails, and a stale child close does not settle the next turn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a47eadc93407bc88f8e8b0d7cdcfb240289691c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->