### PR TITLE
Add a setting for PR diff colors

### DIFF
--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -209,6 +209,7 @@ export const AppSettingsSchema = Schema.Struct({
   confirmThreadArchive: Schema.Boolean.pipe(withDefaults(() => false)),
   confirmTerminalTabClose: Schema.Boolean.pipe(withDefaults(() => true)),
   diffWordWrap: Schema.Boolean.pipe(withDefaults(() => false)),
+  showPullRequestDiffColors: Schema.Boolean.pipe(withDefaults(() => true)),
   // Local-only UI preferences for hiding sidebar surfaces a user doesn't want.
   // `showChatsSection` controls the standalone "Chats" list in the sidebar footer
   // (rootless chats not tied to a project). `showStudioSection` controls the

--- a/apps/web/src/components/chat/environment/EnvironmentPanel.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentPanel.tsx
@@ -404,6 +404,7 @@ export function EnvironmentPanel({
           activeThreadId={activeThreadId}
           projectId={activeProjectId}
           configuredRepositories={githubRepositories}
+          showDiffColors={settings.showPullRequestDiffColors}
           onOpenUrl={onOpenGithubRepository}
           onClose={onClose}
         />

--- a/apps/web/src/components/chat/environment/EnvironmentPullRequestSection.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentPullRequestSection.tsx
@@ -198,6 +198,7 @@ export function EnvironmentPullRequestSection({
   activeThreadId,
   projectId,
   configuredRepositories,
+  showDiffColors: showDiffColorsProp,
   onOpenUrl,
   onClose,
 }: {
@@ -207,10 +208,12 @@ export function EnvironmentPullRequestSection({
   activeThreadId: ThreadId | null;
   projectId: ProjectId | null;
   configuredRepositories: ReadonlyArray<{ readonly nameWithOwner: string }>;
+  showDiffColors?: boolean;
   /** Open non-PR URLs in the in-app browser panel. */
   onOpenUrl: (url: string) => void;
   onClose: () => void;
 }) {
+  const showDiffColors = showDiffColorsProp ?? true;
   const openPane = useRightDockStore((store) => store.openPane);
   // Shares the cached git status the git block already fetches — no extra RPC.
   const { data: gitStatus } = useQuery(gitStatusQueryOptions(gitCwd));
@@ -325,7 +328,7 @@ export function EnvironmentPullRequestSection({
               <PullRequestDiffStat
                 additions={diffStat.additions}
                 deletions={diffStat.deletions}
-                tone="diff"
+                tone={showDiffColors ? "diff" : "muted"}
               />
               {diffStat.filesLabel ? (
                 <span className="truncate text-muted-foreground">{diffStat.filesLabel}</span>

--- a/apps/web/src/components/pullRequest/PullRequestList.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestList.tsx
@@ -19,6 +19,7 @@ export const PullRequestList = function PullRequestList({
   selectedRepo,
   selectedNumber,
   showProjectTitle: showProjectTitleProp,
+  showDiffColors: showDiffColorsProp,
   onSelect,
   onTogglePinned,
 }: {
@@ -28,15 +29,18 @@ export const PullRequestList = function PullRequestList({
   selectedRepo: string | undefined;
   selectedNumber: number | undefined;
   showProjectTitle?: boolean;
+  showDiffColors?: boolean;
   onSelect: (entry: PullRequestListEntry) => void;
   onTogglePinned: (entry: PullRequestListEntry) => void;
 }) {
   const showProjectTitle = showProjectTitleProp ?? false;
+  const showDiffColors = showDiffColorsProp ?? true;
   const renderEntry = (entry: PullRequestListEntry) => (
     <PullRequestRow
       key={pullRequestListEntryKey(entry)}
       entry={entry}
       showProjectTitle={showProjectTitle}
+      showDiffColors={showDiffColors}
       selected={
         selectedProjectId === entry.projectId &&
         selectedRepo === entry.repository &&

--- a/apps/web/src/components/pullRequest/PullRequestRow.browser.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.browser.tsx
@@ -225,6 +225,25 @@ describe("PullRequestRow pin control", () => {
     expect(page.getByRole("button", { name: "Pin pull request #42" })).toBeVisible();
   });
 
+  it("renders neutral diff statistics when colors are disabled", async () => {
+    await render(
+      <PullRequestRow
+        entry={makeEntry(false)}
+        selected={false}
+        showDiffColors={false}
+        onClick={vi.fn()}
+        onTogglePinned={vi.fn()}
+      />,
+    );
+
+    expect(page.getByText("+2", { exact: true }).element().className).not.toContain(
+      "color-decoration-added",
+    );
+    expect(page.getByText("-1", { exact: true }).element().className).not.toContain(
+      "color-decoration-deleted",
+    );
+  });
+
   it("restores focus by remote identity when aggregate project context changes", async () => {
     const entry = makeEntry(false);
     await render(

--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -46,6 +46,7 @@ export const PullRequestRow = function PullRequestRow({
   entry,
   selected,
   showProjectTitle: showProjectTitleProp,
+  showDiffColors: showDiffColorsProp,
   onClick,
   onTogglePinned,
 }: {
@@ -53,10 +54,12 @@ export const PullRequestRow = function PullRequestRow({
   selected: boolean;
   /** All-projects view: identifies the preferred local context used when opening the remote PR. */
   showProjectTitle?: boolean;
+  showDiffColors?: boolean;
   onClick: (entry: PullRequestListEntry) => void;
   onTogglePinned: (entry: PullRequestListEntry) => void;
 }) {
   const showProjectTitle = showProjectTitleProp ?? false;
+  const showDiffColors = showDiffColorsProp ?? true;
   const isPinned = entry.isPinned === true;
   const projectContexts = pullRequestListProjectContexts(entry);
   const projectLabel =
@@ -141,7 +144,7 @@ export const PullRequestRow = function PullRequestRow({
           <PullRequestDiffStat
             additions={entry.additions}
             deletions={entry.deletions}
-            tone="diff"
+            tone={showDiffColors ? "diff" : "muted"}
           />
         </span>
       </button>

--- a/apps/web/src/routes/_chat.pull-requests.index.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.index.tsx
@@ -77,6 +77,7 @@ import {
 } from "~/rightDockStore.logic";
 import { useStore } from "~/store";
 import { PR_FINE_TEXT_CLASS_NAME } from "~/components/pullRequest/pullRequestText";
+import { useAppSettings } from "~/appSettings";
 
 export interface PullRequestsSearch {
   involvement: PullRequestInvolvement;
@@ -146,6 +147,7 @@ const STATE_TABS: ReadonlyArray<{ value: PullRequestState; label: string }> = [
 ];
 
 function PullRequestsRouteView() {
+  const { settings } = useAppSettings();
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
   const trafficLightGutter = useDesktopTopBarTrafficLightGutterClassName();
@@ -496,6 +498,7 @@ function PullRequestsRouteView() {
                 <PullRequestList
                   entries={entries}
                   grouped={grouped}
+                  showDiffColors={settings.showPullRequestDiffColors}
                   selectedProjectId={search.selectedProjectId}
                   selectedRepo={search.selectedRepo}
                   selectedNumber={search.number}

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -268,6 +268,9 @@ function SettingsRouteView() {
       ? ["Provider update checks"]
       : []),
     ...(settings.diffWordWrap !== defaults.diffWordWrap ? ["Diff line wrapping"] : []),
+    ...(settings.showPullRequestDiffColors !== defaults.showPullRequestDiffColors
+      ? ["Pull request diff colors"]
+      : []),
     ...(settings.confirmThreadDelete !== defaults.confirmThreadDelete
       ? ["Delete confirmation"]
       : []),
@@ -954,6 +957,14 @@ function SettingsRouteView() {
       </SettingsSection>
 
       <SettingsSection title="Review">
+        {renderBooleanSettingRow({
+          settingKey: "showPullRequestDiffColors",
+          title: "Pull request diff colors",
+          description: "Show additions in green and deletions in red in pull request summaries.",
+          resetLabel: "pull request diff colors",
+          ariaLabel: "Show pull request diff colors",
+        })}
+
         {renderBooleanSettingRow({
           settingKey: "diffWordWrap",
           title: "Diff line wrapping",


### PR DESCRIPTION
Adds a simple Review setting to show or hide the red/green diff statistics introduced by #544. Enabled by default.\n\nFocused checks:\n- appSettings tests (61 passed)\n- PR row and Environment PR browser tests (13 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local UI preference only; no API or auth changes, with a small prop-plumbing footprint and a browser regression test.
> 
> **Overview**
> Adds a **Review** setting, **Pull request diff colors** (on by default), so users can hide green/red on PR addition/deletion counts and show neutral styling instead.
> 
> The preference is stored as `showPullRequestDiffColors` in app settings and is passed into the pull requests list, each `PullRequestRow`, and the Environment panel PR diff row. Those surfaces switch `PullRequestDiffStat` between `tone="diff"` and `tone="muted"`. Settings includes the toggle and counts it in **Restore defaults**; a browser test asserts disabled colors omit the decoration classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79c53d8ada01f9947a1022cf89bdbf31167c21ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->