### PR TITLE
Show Loading before a turn starts

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -11615,6 +11615,7 @@ export default function ChatView({
                     agentActivityDetail={openAgentActivityDetail}
                     hasMessages={timelineEntries.length > 0}
                     isWorking={isWorking}
+                    workingLabel={isAwaitingTurnStart ? "Loading" : "Thinking"}
                     worktreeSetup={activeWorktreeSetup}
                     activeTurnInProgress={activeTurnInProgress}
                     activeTurnStartedAt={activeWorkStartedAt}

--- a/apps/web/src/components/chat/ChatTranscriptPane.tsx
+++ b/apps/web/src/components/chat/ChatTranscriptPane.tsx
@@ -46,6 +46,7 @@ interface ChatTranscriptPaneProps {
   isRevertingCheckpoint: boolean;
   isTemporaryThread?: boolean;
   isWorking: boolean;
+  workingLabel?: ComponentProps<typeof MessagesTimeline>["workingLabel"];
   followLiveOutput: boolean;
   listRef: RefObject<LegendListRef | null>;
   timelineControllerRef?: RefObject<MessagesTimelineController | null>;
@@ -109,6 +110,7 @@ export function ChatTranscriptPane({
   isRevertingCheckpoint,
   isTemporaryThread,
   isWorking,
+  workingLabel,
   followLiveOutput,
   listRef,
   timelineControllerRef,
@@ -197,6 +199,7 @@ export function ChatTranscriptPane({
             key={activeThreadId}
             hasMessages={hasMessages}
             isWorking={isWorking}
+            workingLabel={workingLabel}
             worktreeSetup={worktreeSetup}
             activeTurnId={activeTurnId ?? null}
             activeTurnInProgress={activeTurnInProgress}

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1739,13 +1739,14 @@ describe("MessagesTimeline", () => {
     expect(markup).not.toContain("Reasoning trace Inspecting");
   });
 
-  it("keeps Thinking when a new local send has no server turn id yet", async () => {
+  it("shows Loading when a new local send has no server turn id yet", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const previousTurnId = TurnId.makeUnsafe("turn-previous");
     const markup = renderToStaticMarkup(
       <MessagesTimeline
         hasMessages
         isWorking
+        workingLabel="Loading"
         activeTurnInProgress
         activeTurnId={null}
         activeTurnStartedAt={null}
@@ -1817,7 +1818,7 @@ describe("MessagesTimeline", () => {
       />,
     );
 
-    expect(markup).toContain(">Thinking<");
+    expect(markup).toContain(">Loading<");
   });
 
   it("attaches trailing tool rows to the last assistant reply after completion", async () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -361,6 +361,7 @@ function WorktreeSetupCard({ steps }: { steps: ReadonlyArray<WorktreeSetupStep> 
 interface MessagesTimelineProps {
   hasMessages: boolean;
   isWorking: boolean;
+  workingLabel?: "Loading" | "Thinking";
   activeTurnInProgress: boolean;
   activeTurnStartedAt: string | null;
   /** Transient "New worktree" setup progress; rendered as an ephemeral step card at the tail. */
@@ -449,6 +450,7 @@ interface MessagesTimelineProps {
 export const MessagesTimeline = memo(function MessagesTimeline({
   hasMessages,
   isWorking,
+  workingLabel = "Thinking",
   activeTurnInProgress,
   activeTurnStartedAt,
   worktreeSetup: worktreeSetupProp,
@@ -2145,7 +2147,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
           className="shimmer pt-0.5 text-muted-foreground/70 font-system-ui"
           style={{ fontSize: `${appTypographyScale.chatPx}px` }}
         >
-          Thinking
+          {workingLabel}
         </div>
       )}
 


### PR DESCRIPTION
Follow-up to #524. Shows **Loading** while a local dispatch is waiting for the provider turn to start, then keeps **Thinking** for the active turn.\n\nFocused checks: 52 MessagesTimeline and ChatTranscriptPane tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UX change in the chat working row; no auth, data, or API behavior changes.
> 
> **Overview**
> The chat transcript **working** shimmer no longer always says **Thinking**. While a local send is in flight but the server/provider turn has not started yet (`isAwaitingTurnStart`), the label is **Loading**; once the turn is active, it stays **Thinking**.
> 
> A new optional `workingLabel` prop is threaded from `ChatView` through `ChatTranscriptPane` into `MessagesTimeline` (default **Thinking**). The timeline test for “no server turn id yet” now expects **Loading** when that prop is passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a10276a9724e7c72ed257cbb5ece1d42fd7f5e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->