### PR TITLE
Restore automatic branch creation and attachment for worktree threads

### DIFF
--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -51,6 +51,7 @@ import { OrchestrationProjectionPipelineLive } from "../src/orchestration/Layers
 import { OrchestrationProjectionSnapshotQueryLive } from "../src/orchestration/Layers/ProjectionSnapshotQuery.ts";
 import { RuntimeReceiptBusLive } from "../src/orchestration/Layers/RuntimeReceiptBus.ts";
 import { OrchestrationReactorLive } from "../src/orchestration/Layers/OrchestrationReactor.ts";
+import { AgentGatewayOperationRepositoryLive } from "../src/agentGateway/Layers/AgentGatewayOperationRepository.ts";
 import { ProviderCommandReactorLive } from "../src/orchestration/Layers/ProviderCommandReactor.ts";
 import { ProviderRuntimeIngestionLive } from "../src/orchestration/Layers/ProviderRuntimeIngestion.ts";
 import { TurnCheckpointCoordinatorLive } from "../src/orchestration/Layers/TurnCheckpointCoordinator.ts";
@@ -320,6 +321,7 @@ export const makeOrchestrationIntegrationHarness = (
       Layer.provideMerge(gitCoreLayer),
       Layer.provideMerge(textGenerationLayer),
       Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(AgentGatewayOperationRepositoryLive),
     );
     const checkpointReactorLayer = CheckpointReactorLive.pipe(
       Layer.provideMerge(runtimeServicesLayer),

--- a/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
@@ -22,6 +22,7 @@ import {
   ThreadId,
   TurnId,
 } from "@synara/contracts";
+import { isTemporaryWorktreeBranch } from "@synara/shared/git";
 import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
 
@@ -681,7 +682,7 @@ function makeHarnessLayer(
           },
         };
       }),
-    createDetachedWorktree: (input: { ref: string; path?: string }) =>
+    createDetachedWorktree: (input: { ref: string; path?: string; newBranch?: string }) =>
       Effect.gen(function* () {
         worktreeCreates.push(input);
         if (options.pauseAfterWorktreeCreate) {
@@ -692,7 +693,7 @@ function makeHarnessLayer(
           worktree: {
             path: input.path ?? "/tmp/worktrees/generated/synara",
             ref: input.ref,
-            branch: null,
+            branch: input.newBranch ?? null,
           },
         };
       }),
@@ -2033,13 +2034,15 @@ describe("AgentGateway", () => {
       });
       assert.isFalse(isToolError(response.result), toolErrorText(response.result));
       const payload = toolResultJson(response.result);
-      assert.isNull(payload.branch);
+      assert.isString(payload.branch);
+      assert.isTrue(isTemporaryWorktreeBranch(payload.branch as string));
+      assert.equal(payload.branch, harness.worktreeCreates[0]?.newBranch);
       assert.equal(payload.worktreePath, harness.worktreeCreates[0]?.path);
       assert.equal(harness.worktreeCreates[0]?.ref, "0123456789abcdef0123456789abcdef01234567");
       const create = harness.dispatched[0]!;
       if (create.type === "thread.create") {
         assert.equal(create.envMode, "worktree");
-        assert.isNull(create.branch);
+        assert.equal(create.branch, payload.branch);
         assert.equal(create.associatedWorktreeRef, "0123456789abcdef0123456789abcdef01234567");
       }
     }).pipe(Effect.provide(gatewayLayer));
@@ -2098,7 +2101,9 @@ describe("AgentGateway", () => {
       assert.deepEqual(harness.fetchedPullRequests, [425]);
       assert.deepEqual(harness.fetchedPullRequestRepositories, ["example/repo"]);
       assert.equal(harness.worktreeCreates[0]?.ref, "fedcba9876543210fedcba9876543210fedcba98");
-      assert.equal(harness.worktreeCreates[0]?.newBranch, undefined);
+      // The worktree is born on a temporary synara/* branch, but no branch is
+      // ever created for the pull request itself.
+      assert.isTrue(isTemporaryWorktreeBranch(harness.worktreeCreates[0]?.newBranch ?? ""));
     }).pipe(Effect.provide(gatewayLayer));
   });
 
@@ -2699,7 +2704,10 @@ describe("AgentGateway", () => {
       );
       assert.equal(harness.worktreeCreates.length, 1);
       assert.equal(harness.worktreeRemoves.length, 1);
-      assert.equal(harness.branchDeletes.length, 0);
+      assert.deepEqual(
+        harness.branchDeletes.map(({ branch }) => branch),
+        [harness.worktreeCreates[0]?.newBranch],
+      );
     }).pipe(Effect.provide(gatewayLayer));
   });
 
@@ -3120,7 +3128,10 @@ describe("AgentGateway", () => {
         );
         assert.equal(harness.worktreeCreates.length, 1);
         assert.equal(harness.worktreeRemoves.length, 1);
-        assert.equal(harness.branchDeletes.length, 0);
+        assert.deepEqual(
+          harness.branchDeletes.map(({ branch }) => branch),
+          [harness.worktreeCreates[0]?.newBranch],
+        );
         assert.equal(harness.dispatched.length, 0);
         assert.equal(harness.getOperationStatus("turn-parent-active"), "failed");
       }).pipe(Effect.provide(gatewayLayer));
@@ -3243,7 +3254,10 @@ describe("AgentGateway", () => {
       assert.isTrue(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause));
       assert.equal(harness.worktreeCreates.length, 1);
       assert.equal(harness.worktreeRemoves.length, 1);
-      assert.equal(harness.branchDeletes.length, 0);
+      assert.deepEqual(
+        harness.branchDeletes.map(({ branch }) => branch),
+        [harness.worktreeCreates[0]?.newBranch],
+      );
       assert.equal(
         harness.dispatched.filter((command) => command.type === "thread.create").length,
         0,
@@ -3465,7 +3479,10 @@ describe("AgentGateway", () => {
       );
       assert.equal(harness.worktreeCreates.length, 2);
       assert.equal(harness.worktreeRemoves.length, 2);
-      assert.equal(harness.branchDeletes.length, 0);
+      assert.deepEqual(
+        harness.branchDeletes.map(({ branch }) => branch).toSorted(),
+        harness.worktreeCreates.map(({ newBranch }) => newBranch).toSorted(),
+      );
     }).pipe(Effect.provide(gatewayLayer));
   });
 

--- a/apps/server/src/agentGateway/Layers/AgentGateway.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.ts
@@ -217,7 +217,7 @@ export const makeAgentGateway = Effect.gen(function* () {
     definition: {
       name: "synara_create_threads",
       description:
-        "Create an exact batch of 1–20 standalone Synara threads. Worktree threads use a detached HEAD at baseRef (or the selected checkout's HEAD) and copy local checkout changes plus .worktreeinclude files when the ref is that checkout's HEAD. Validation/preflight failures create nothing and may be corrected with the same requestId; durable retries replay the exact operation.",
+        "Create an exact batch of 1–20 standalone Synara threads. Worktree threads start on a Synara-managed temporary branch pinned at baseRef (or the selected checkout's HEAD) and copy local checkout changes plus .worktreeinclude files when the ref is that checkout's HEAD; on the first turn Synara may rename the branch after the prompt and publish it. Validation/preflight failures create nothing and may be corrected with the same requestId; durable retries replay the exact operation.",
       inputSchema: {
         type: "object",
         properties: {
@@ -243,7 +243,7 @@ export const makeAgentGateway = Effect.gen(function* () {
                 baseRef: {
                   type: "string",
                   description:
-                    "Local Git revision, #PR, or GitHub pull-request URL for a detached worktree. Defaults to the selected checkout's HEAD.",
+                    "Local Git revision, #PR, or GitHub pull-request URL the worktree is pinned at. Defaults to the selected checkout's HEAD.",
                 },
                 runtimeMode: {
                   type: "string",
@@ -281,7 +281,7 @@ export const makeAgentGateway = Effect.gen(function* () {
     definition: {
       name: "synara_create_thread",
       description:
-        "Create exactly one standalone Synara thread. Worktree threads start at a detached HEAD. For two or more threads use one synara_create_threads call instead.",
+        "Create exactly one standalone Synara thread. Worktree threads start on a Synara-managed temporary branch pinned at baseRef; on the first turn Synara may rename the branch after the prompt and publish it. For two or more threads use one synara_create_threads call instead.",
       inputSchema: {
         type: "object",
         properties: {
@@ -302,7 +302,7 @@ export const makeAgentGateway = Effect.gen(function* () {
           baseRef: {
             type: "string",
             description:
-              "Local Git revision, #PR, or GitHub pull-request URL for a detached worktree. Defaults to the selected checkout's HEAD.",
+              "Local Git revision, #PR, or GitHub pull-request URL the worktree is pinned at. Defaults to the selected checkout's HEAD.",
           },
           runtimeMode: {
             type: "string",

--- a/apps/server/src/agentGateway/creationCoordinator.ts
+++ b/apps/server/src/agentGateway/creationCoordinator.ts
@@ -458,7 +458,7 @@ export const makeCreateThreadsHandler = Effect.fn(function* (
       if (deprecatedBranchName) {
         return yield* Effect.fail(
           new ToolInputError(
-            '"branchName" is no longer supported for managed worktrees. Synara creates a detached HEAD; create a branch inside the new thread when the work is ready.',
+            '"branchName" is no longer supported for managed worktrees. Synara creates a managed temporary branch and renames it after the first prompt; create additional branches inside the new thread if needed.',
           ),
         );
       }
@@ -724,10 +724,15 @@ export const makeCreateThreadsHandler = Effect.fn(function* (
                           Effect.flatMap(() =>
                             worktree.branch === null
                               ? Effect.void
-                              : git.deleteBranch({
+                              : // The branch is this operation's own deterministic
+                                // synara/* name and its worktree was just force-removed.
+                                // A non-forced delete would fail whenever the pinned
+                                // ref is not merged into the root HEAD (e.g. PR heads),
+                                // stranding the name and blocking exact-plan retries.
+                                git.deleteBranch({
                                   cwd: worktree.cwd,
                                   branch: worktree.branch,
-                                  force: false,
+                                  force: true,
                                 }),
                           ),
                         )

--- a/apps/server/src/agentGateway/creationCoordinator.ts
+++ b/apps/server/src/agentGateway/creationCoordinator.ts
@@ -16,6 +16,7 @@ import {
   type SynaraCreateThreadsResult,
 } from "@synara/contracts";
 import { buildPromptThreadTitleFallback } from "@synara/shared/chatThreads";
+import { WORKTREE_BRANCH_PREFIX } from "@synara/shared/git";
 import { parseGitHubRepositoryNameWithOwnerFromPullRequestUrl } from "@synara/shared/githubRepository";
 import { runtimeModeEscalatesPrivilege } from "@synara/shared/runtimeMode";
 import { Cause, Effect, Option, Semaphore } from "effect";
@@ -620,7 +621,13 @@ export const makeCreateThreadsHandler = Effect.fn(function* (
             projectScripts: project.scripts,
             worktreeRef,
             copyChangesFrom,
-            newBranch: null,
+            // Deterministic like the planned path: an exact-plan retry must
+            // resolve to the same branch, and recovery reclaims it by name.
+            // The 8-hex-digit token keeps it a temporary synara/* branch.
+            newBranch:
+              environment === "worktree"
+                ? `${WORKTREE_BRANCH_PREFIX}/${stableGatewayDigest({ operationId, index, resource: "worktree-branch" }, 8)}`
+                : null,
             plannedWorktreePath,
             ownershipPreflightPassed: true,
             ids: makeAgentCreationIds(operationId, index),
@@ -991,6 +998,7 @@ export const makeCreateThreadsHandler = Effect.fn(function* (
                           cwd: entry.workspaceRoot,
                           ref: entry.worktreeRef!,
                           path: entry.plannedWorktreePath,
+                          ...(entry.newBranch ? { newBranch: entry.newBranch } : {}),
                           ...(entry.copyChangesFrom
                             ? { copyChangesFrom: entry.copyChangesFrom }
                             : {}),

--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -17,6 +17,7 @@ import {
   type OrchestrationProjectShell,
   type OrchestrationThreadShell,
 } from "@synara/contracts";
+import { isTemporaryWorktreeBranch } from "@synara/shared/git";
 import { Duration, Effect, Layer, Option, Stream } from "effect";
 import { TestClock } from "effect/testing";
 
@@ -489,7 +490,7 @@ const gitCore = {
         worktree: {
           path: "/tmp/automation-worktree",
           ref: "0123456789abcdef0123456789abcdef01234567",
-          branch: null,
+          branch: input.newBranch ?? null,
         },
       };
     }),
@@ -953,8 +954,10 @@ layer("AutomationService", (it) => {
       }
       assert.strictEqual(threadCreate.envMode, "worktree");
       assert.strictEqual(threadCreate.worktreePath, "/tmp/automation-worktree");
-      assert.strictEqual(threadCreate.branch, null);
-      assert.strictEqual(threadCreate.associatedWorktreeBranch, null);
+      assert.ok(createdWorktree.newBranch);
+      assert.ok(isTemporaryWorktreeBranch(createdWorktree.newBranch));
+      assert.strictEqual(threadCreate.branch, createdWorktree.newBranch);
+      assert.strictEqual(threadCreate.associatedWorktreeBranch, createdWorktree.newBranch);
       assert.strictEqual(
         threadCreate.associatedWorktreeRef,
         "0123456789abcdef0123456789abcdef01234567",
@@ -979,6 +982,7 @@ layer("AutomationService", (it) => {
           cwd: project.workspaceRoot,
           path: "/tmp/automation-worktree",
           force: true,
+          reclaimTemporaryBranch: true,
         },
       ]);
 
@@ -1034,6 +1038,7 @@ layer("AutomationService", (it) => {
           cwd: project.workspaceRoot,
           path: "/tmp/automation-worktree",
           force: true,
+          reclaimTemporaryBranch: true,
         },
       ]);
       assert.strictEqual(

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -31,6 +31,7 @@ import {
   automationOwnsItsThread,
   automationRequiresTargetThread,
 } from "@synara/shared/automationMode";
+import { buildTemporaryWorktreeBranchName } from "@synara/shared/git";
 import { providerStartOptionsFromServerSettings } from "@synara/shared/serverSettings";
 import { autoRuntimeModeSelectionIssue } from "@synara/shared/runtimeMode";
 import { Cause, Effect, Layer, Option, PubSub, Queue, Stream } from "effect";
@@ -632,6 +633,7 @@ export const AutomationServiceLive = Layer.effect(
           cwd: input.project.workspaceRoot,
           path,
           force: true,
+          reclaimTemporaryBranch: true,
         })
         .pipe(
           Effect.catch((error) =>
@@ -855,16 +857,17 @@ export const AutomationServiceLive = Layer.effect(
                   ref: "HEAD",
                   path: null,
                   copyChangesFrom: project.workspaceRoot,
+                  newBranch: buildTemporaryWorktreeBranchName(),
                 })
                 .pipe(
                   Effect.mapError(toServiceError("Failed to create automation worktree.")),
                   Effect.map(
                     (result): ThreadEnvironment => ({
                       envMode: "worktree",
-                      branch: null,
+                      branch: result.worktree.branch,
                       worktreePath: result.worktree.path,
                       associatedWorktreePath: result.worktree.path,
-                      associatedWorktreeBranch: null,
+                      associatedWorktreeBranch: result.worktree.branch,
                       associatedWorktreeRef: result.worktree.ref,
                     }),
                   ),

--- a/apps/server/src/externalMcp/Layers/ExternalMcpGateway.e2e.test.ts
+++ b/apps/server/src/externalMcp/Layers/ExternalMcpGateway.e2e.test.ts
@@ -240,14 +240,18 @@ describe("external MCP gateway stdio flow", () => {
           stdout: "0123456789abcdef0123456789abcdef01234567\n",
           stderr: "",
         }),
-      createDetachedWorktree: (input: { readonly path?: string; readonly ref: string }) =>
+      createDetachedWorktree: (input: {
+        readonly path?: string;
+        readonly ref: string;
+        readonly newBranch?: string;
+      }) =>
         Effect.sync(() => {
           worktreeCreates.push(input);
           return {
             worktree: {
               path: input.path ?? path.join(worktreesDir, "generated"),
               ref: input.ref,
-              branch: null,
+              branch: input.newBranch ?? null,
             },
           };
         }),

--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -1262,6 +1262,63 @@ it.layer(TestLayer)("git integration", (it) => {
       }),
     );
 
+    it.effect("creates a branch-backed managed worktree when newBranch is provided", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const core = yield* GitCore;
+        const expectedHead = yield* git(tmp, ["rev-parse", "HEAD"]);
+        const wtPath = path.join(tmp, "wt-branch-backed");
+        const result = yield* core.createDetachedWorktree({
+          cwd: tmp,
+          ref: "HEAD",
+          path: wtPath,
+          newBranch: "synara/abcd1234",
+        });
+
+        expect(result.worktree).toEqual({
+          path: wtPath,
+          ref: expectedHead,
+          branch: "synara/abcd1234",
+        });
+        expect(yield* git(wtPath, ["symbolic-ref", "--short", "HEAD"])).toBe("synara/abcd1234");
+        expect(yield* git(tmp, ["rev-parse", "refs/heads/synara/abcd1234"])).toBe(expectedHead);
+
+        yield* core.removeWorktree({
+          cwd: tmp,
+          path: wtPath,
+          force: true,
+          reclaimTemporaryBranch: true,
+        });
+        const remainingBranches = yield* git(tmp, ["branch", "--list", "synara/abcd1234"]);
+        expect(remainingBranches).toBe("");
+      }),
+    );
+
+    it.effect("removeWorktree reclamation never deletes user-named branches", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const core = yield* GitCore;
+        const wtPath = path.join(tmp, "wt-user-branch");
+        yield* core.createDetachedWorktree({
+          cwd: tmp,
+          ref: "HEAD",
+          path: wtPath,
+          newBranch: "feature/user-owned",
+        });
+
+        yield* core.removeWorktree({
+          cwd: tmp,
+          path: wtPath,
+          force: true,
+          reclaimTemporaryBranch: true,
+        });
+        const remainingBranches = yield* git(tmp, ["branch", "--list", "feature/user-owned"]);
+        expect(remainingBranches).toContain("feature/user-owned");
+      }),
+    );
+
     it.effect("atomically replaces an incomplete worktree snapshot", () =>
       Effect.gen(function* () {
         const tmp = yield* makeTmpDir();

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -26,6 +26,7 @@ import { createReadStream } from "node:fs";
 import * as nodeFs from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as nodePath from "node:path";
+import { isTemporaryWorktreeBranch } from "@synara/shared/git";
 import { parseGitHubRepositoryNameWithOwnerFromRemoteUrl } from "@synara/shared/githubRepository";
 import { decodeJsonResult } from "@synara/shared/schemaJson";
 
@@ -2585,13 +2586,16 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
             ),
           ));
 
-        yield* executeGit("GitCore.createDetachedWorktree", input.cwd, [
-          "worktree",
-          "add",
-          "--detach",
-          worktreePath,
-          resolvedRef,
-        ]);
+        // Branch-backed managed worktrees still pin to the resolved commit, so
+        // ownership proofs and pruning behave exactly like the detached form.
+        const newBranch = input.newBranch ?? null;
+        yield* executeGit(
+          "GitCore.createDetachedWorktree",
+          input.cwd,
+          newBranch
+            ? ["worktree", "add", "-b", newBranch, worktreePath, resolvedRef]
+            : ["worktree", "add", "--detach", worktreePath, resolvedRef],
+        );
 
         if (input.copyChangesFrom) {
           yield* copyCheckoutChanges(input.copyChangesFrom, worktreePath).pipe(
@@ -2601,7 +2605,19 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
                 input.cwd,
                 ["worktree", "remove", "--force", worktreePath],
                 { allowNonZeroExit: true },
-              ).pipe(Effect.ignore),
+              ).pipe(
+                Effect.andThen(
+                  newBranch
+                    ? executeGit(
+                        "GitCore.createDetachedWorktree.rollbackBranch",
+                        input.cwd,
+                        ["branch", "-D", newBranch],
+                        { allowNonZeroExit: true },
+                      )
+                    : Effect.void,
+                ),
+                Effect.ignore,
+              ),
             ),
           );
         }
@@ -2610,7 +2626,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
           worktree: {
             path: worktreePath,
             ref: resolvedRef,
-            branch: null,
+            branch: newBranch,
           },
         };
       });
@@ -2701,6 +2717,25 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
 
     const removeWorktree: GitCoreShape["removeWorktree"] = (input) =>
       Effect.gen(function* () {
+        // Resolve the branch before removal: afterwards the worktree checkout
+        // is gone and can no longer answer. Only temporary synara/* branches
+        // qualify for reclamation; detached HEADs and user-named branches
+        // resolve to null.
+        const temporaryBranch = input.reclaimTemporaryBranch
+          ? yield* executeGit(
+              "GitCore.removeWorktree.readBranch",
+              input.path,
+              ["symbolic-ref", "--quiet", "--short", "HEAD"],
+              { allowNonZeroExit: true, timeoutMs: 5_000 },
+            ).pipe(
+              Effect.map((result) => {
+                if (result.code !== 0) return null;
+                const branch = result.stdout.trim();
+                return branch.length > 0 && isTemporaryWorktreeBranch(branch) ? branch : null;
+              }),
+              Effect.catch(() => Effect.succeed(null)),
+            )
+          : null;
         const args = ["worktree", "remove"];
         if (input.force) {
           args.push("--force");
@@ -2720,6 +2755,27 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
             ),
           ),
         );
+        if (temporaryBranch !== null) {
+          // Temporary branches hold unmerged thread commits by design, so this
+          // is a forced delete. The removal itself already succeeded; a branch
+          // cleanup failure must not surface as a failed removal.
+          yield* executeGit(
+            "GitCore.removeWorktree.reclaimBranch",
+            input.cwd,
+            ["branch", "-D", "--", temporaryBranch],
+            { allowNonZeroExit: true, timeoutMs: 10_000 },
+          ).pipe(
+            Effect.catch((error) =>
+              Effect.logWarning("worktree removal could not reclaim its temporary branch", {
+                cwd: input.cwd,
+                path: input.path,
+                branch: temporaryBranch,
+                error: error instanceof Error ? error.message : String(error),
+              }),
+            ),
+            Effect.asVoid,
+          );
+        }
       });
 
     const deleteBranch: GitCoreShape["deleteBranch"] = (input) =>

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -2717,10 +2717,10 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
 
     const removeWorktree: GitCoreShape["removeWorktree"] = (input) =>
       Effect.gen(function* () {
-        // Resolve the branch before removal: afterwards the worktree checkout
-        // is gone and can no longer answer. Only temporary synara/* branches
-        // qualify for reclamation; detached HEADs and user-named branches
-        // resolve to null.
+        // Resolve the branch and its HEAD before removal: afterwards the
+        // worktree checkout is gone and can no longer answer. Only temporary
+        // synara/* branches qualify for reclamation; detached HEADs and
+        // user-named branches resolve to null.
         const temporaryBranch = input.reclaimTemporaryBranch
           ? yield* executeGit(
               "GitCore.removeWorktree.readBranch",
@@ -2728,10 +2728,18 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
               ["symbolic-ref", "--quiet", "--short", "HEAD"],
               { allowNonZeroExit: true, timeoutMs: 5_000 },
             ).pipe(
-              Effect.map((result) => {
-                if (result.code !== 0) return null;
+              Effect.flatMap((result) => {
+                if (result.code !== 0) return Effect.succeed(null);
                 const branch = result.stdout.trim();
-                return branch.length > 0 && isTemporaryWorktreeBranch(branch) ? branch : null;
+                if (branch.length === 0 || !isTemporaryWorktreeBranch(branch)) {
+                  return Effect.succeed(null);
+                }
+                return executeGit(
+                  "GitCore.removeWorktree.readBranchHead",
+                  input.path,
+                  ["rev-parse", "--verify", `refs/heads/${branch}`],
+                  { timeoutMs: 5_000 },
+                ).pipe(Effect.map((head) => ({ branch, head: head.stdout.trim() })));
               }),
               Effect.catch(() => Effect.succeed(null)),
             )
@@ -2756,20 +2764,23 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
           ),
         );
         if (temporaryBranch !== null) {
-          // Temporary branches hold unmerged thread commits by design, so this
-          // is a forced delete. The removal itself already succeeded; a branch
-          // cleanup failure must not surface as a failed removal.
+          // Compare-and-delete against the HEAD observed above: if a concurrent
+          // Git process repointed the ref since then, its commits survive. The
+          // removal itself already succeeded; a branch cleanup failure must not
+          // surface as a failed removal, but it must be logged — a stranded
+          // deterministic branch blocks later reuse of its name.
           yield* executeGit(
             "GitCore.removeWorktree.reclaimBranch",
             input.cwd,
-            ["branch", "-D", "--", temporaryBranch],
-            { allowNonZeroExit: true, timeoutMs: 10_000 },
+            ["update-ref", "-d", `refs/heads/${temporaryBranch.branch}`, temporaryBranch.head],
+            { timeoutMs: 10_000 },
           ).pipe(
             Effect.catch((error) =>
               Effect.logWarning("worktree removal could not reclaim its temporary branch", {
                 cwd: input.cwd,
                 path: input.path,
-                branch: temporaryBranch,
+                branch: temporaryBranch.branch,
+                expectedHead: temporaryBranch.head,
                 error: error instanceof Error ? error.message : String(error),
               }),
             ),

--- a/apps/server/src/managedWorktrees.ts
+++ b/apps/server/src/managedWorktrees.ts
@@ -218,6 +218,7 @@ export function pruneArchivedManagedWorktrees(input: {
                   cwd: entry.workspaceRoot,
                   path: entry.path,
                   force: true,
+                  reclaimTemporaryBranch: true,
                 }),
               ),
               Effect.tap(() => Effect.sync(() => removedPaths.add(entry.path))),

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -42,6 +42,7 @@ import {
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { AgentGatewayOperationRepositoryLive } from "../../agentGateway/Layers/AgentGatewayOperationRepository.ts";
 import { deriveServerPaths, ServerConfig } from "../../config.ts";
 import { TextGenerationError } from "../../git/Errors.ts";
 import {
@@ -520,6 +521,7 @@ describe("ProviderCommandReactor", () => {
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),
       Layer.provideMerge(OrchestrationEventDeliveryRepositoryLive),
+      Layer.provideMerge(AgentGatewayOperationRepositoryLive),
       Layer.provideMerge(SqlitePersistenceMemory),
     );
     const runtime = ManagedRuntime.make(layer);

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -43,6 +43,7 @@ import * as SqlClient from "effect/unstable/sql/SqlClient";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AgentGatewayOperationRepositoryLive } from "../../agentGateway/Layers/AgentGatewayOperationRepository.ts";
+import { AgentGatewayOperationRepository } from "../../agentGateway/Services/AgentGatewayOperationRepository.ts";
 import { deriveServerPaths, ServerConfig } from "../../config.ts";
 import { TextGenerationError } from "../../git/Errors.ts";
 import {
@@ -204,6 +205,7 @@ describe("ProviderCommandReactor", () => {
     readonly startReactor?: boolean;
     readonly interruptTurn?: ProviderServiceShape["interruptTurn"];
     readonly commandEventTimeout?: Duration.Duration;
+    readonly gatewayOperationId?: string;
   }) {
     const now = new Date().toISOString();
     const baseDir = input?.baseDir ?? fs.mkdtempSync(path.join(os.tmpdir(), "synara-reactor-"));
@@ -558,6 +560,9 @@ describe("ProviderCommandReactor", () => {
     const pendingInteractionRepository = await runtime.runPromise(
       Effect.service(ProjectionPendingInteractionRepository),
     );
+    const gatewayOperations = await runtime.runPromise(
+      Effect.service(AgentGatewayOperationRepository),
+    );
     scope = await Effect.runPromise(Scope.make("sequential"));
     let reactorStarted = false;
     const startReactor = async () => {
@@ -593,6 +598,13 @@ describe("ProviderCommandReactor", () => {
         runtimeMode: "approval-required",
         branch: null,
         worktreePath: null,
+        ...(input?.gatewayOperationId
+          ? {
+              creationSource: "synara_mcp" as const,
+              gatewayOperationId: input.gatewayOperationId,
+              gatewayOperationIndex: 0,
+            }
+          : {}),
         createdAt: now,
       }),
     );
@@ -684,6 +696,30 @@ describe("ProviderCommandReactor", () => {
       startReactor,
       deliveryRepository,
       pendingInteractionRepository,
+      reserveGatewayOperation: (operationId: string) =>
+        runtime.runPromise(
+          gatewayOperations.reserve({
+            operationId,
+            callerThreadId: "caller-thread",
+            callerTurnId: "caller-turn",
+            operationKind: "create_threads",
+            requestId: `request-${operationId}`,
+            fingerprint: `fingerprint-${operationId}`,
+            requestedCount: 1,
+            planJson: "[]",
+            now,
+          }),
+        ),
+      markGatewayOperationDispatching: (operationId: string) =>
+        runtime.runPromise(gatewayOperations.markDispatching({ operationId, now })),
+      completeGatewayOperation: (operationId: string) =>
+        runtime.runPromise(
+          gatewayOperations.complete({
+            operationId,
+            resultJson: "{}",
+            now: new Date().toISOString(),
+          }),
+        ),
       persistWithoutLivePublication: async (
         events: ReadonlyArray<Omit<OrchestrationEvent, "sequence">>,
       ) => {
@@ -4376,6 +4412,97 @@ describe("ProviderCommandReactor", () => {
       associatedWorktreeBranch: "synara/app-startup-crash",
       associatedWorktreeRef: "synara/app-startup-crash",
     });
+  });
+
+  it("waits for gateway operation completion before renaming its temporary branch", async () => {
+    const operationId = "gateway-operation-worktree-rename";
+    const harness = await createHarness({ gatewayOperationId: operationId });
+    const now = new Date().toISOString();
+    harness.generateBranchName.mockImplementation(() =>
+      Effect.succeed({ branch: "gateway-worktree-rename" }),
+    );
+    await harness.reserveGatewayOperation(operationId);
+    await harness.markGatewayOperationDispatching(operationId);
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-gateway-worktree-bootstrap"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        envMode: "worktree",
+        branch: "synara/cb661f0d",
+        worktreePath: "/tmp/provider-project/.worktrees/cb661f0d",
+        associatedWorktreePath: "/tmp/provider-project/.worktrees/cb661f0d",
+        associatedWorktreeBranch: "synara/cb661f0d",
+        associatedWorktreeRef: "synara/cb661f0d",
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-gateway-turn-start-worktree-rename"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-gateway-worktree-rename"),
+          role: "user",
+          text: "Rename this gateway worktree",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.generateBranchName.mock.calls.length === 1);
+    expect(harness.renameBranch).not.toHaveBeenCalled();
+
+    await harness.completeGatewayOperation(operationId);
+    await waitFor(() => harness.renameBranch.mock.calls.length === 1);
+    await waitFor(() => harness.publishBranch.mock.calls.length === 1);
+  });
+
+  it("does not rename a gateway branch when the operation record is missing", async () => {
+    const harness = await createHarness({ gatewayOperationId: "missing-gateway-operation" });
+    const now = new Date().toISOString();
+    harness.generateBranchName.mockImplementation(() =>
+      Effect.succeed({ branch: "must-not-be-used" }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-missing-gateway-worktree-bootstrap"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        envMode: "worktree",
+        branch: "synara/cb661f0d",
+        worktreePath: "/tmp/provider-project/.worktrees/cb661f0d",
+        associatedWorktreePath: "/tmp/provider-project/.worktrees/cb661f0d",
+        associatedWorktreeBranch: "synara/cb661f0d",
+        associatedWorktreeRef: "synara/cb661f0d",
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-missing-gateway-turn-start-worktree-rename"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-missing-gateway-worktree-rename"),
+          role: "user",
+          text: "Do not rename this worktree",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.generateBranchName.mock.calls.length === 1);
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(harness.renameBranch).not.toHaveBeenCalled();
+    expect(harness.publishBranch).not.toHaveBeenCalled();
   });
 
   it("falls back to prompt-based worktree branch names when the provider cannot generate one", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -65,6 +65,7 @@ import {
   resolveThreadWorkspaceCwd,
 } from "../../checkpointing/Utils.ts";
 import { CheckpointStore } from "../../checkpointing/Services/CheckpointStore.ts";
+import { AgentGatewayOperationRepository } from "../../agentGateway/Services/AgentGatewayOperationRepository.ts";
 import { GitCore } from "../../git/Services/GitCore.ts";
 import {
   ProviderAdapterRequestError,
@@ -107,6 +108,7 @@ import {
   listImportedForkMessages,
   listPriorTranscriptMessages,
 } from "../handoff.ts";
+import type { OrchestrationDispatchError } from "../Errors.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
 import {
@@ -463,6 +465,7 @@ const make = Effect.gen(function* () {
   const checkpointStore = yield* CheckpointStore;
   const studioOutputReactor = yield* StudioOutputReactor;
   const git = yield* GitCore;
+  const gatewayOperations = yield* AgentGatewayOperationRepository;
   const textGeneration = yield* TextGeneration;
   const serverSettings = yield* ServerSettingsService;
   const managedAttachments = yield* ManagedAttachmentRepository;
@@ -1829,9 +1832,38 @@ const make = Effect.gen(function* () {
     readonly cwd: string;
     readonly oldBranch: string;
     readonly targetBranch: string;
+    readonly gatewayOperationId: string | null;
   }) {
     if (input.targetBranch === input.oldBranch) {
       return;
+    }
+
+    // Gateway-created threads: the creating operation's durable ownership
+    // proof records the temporary branch name. Renaming before the operation
+    // reaches a terminal state would make live compensation and startup
+    // recovery reject the worktree as tampered ("worktree branch changed"),
+    // stranding it. Check right before mutating so the window between the LLM
+    // name generation and the rename stays covered; skipping is safe — the
+    // thread simply keeps its temporary name.
+    if (input.gatewayOperationId !== null) {
+      const operation = yield* gatewayOperations.getById(input.gatewayOperationId).pipe(
+        // An unreadable record proves nothing; skip the rename rather than
+        // risk invalidating a proof that may still be needed.
+        Effect.catch(() => Effect.succeed(null)),
+      );
+      if (operation !== null && operation.status !== "completed") {
+        yield* Effect.logInfo(
+          "provider command reactor skipped worktree branch rename: creating gateway operation is not complete",
+          {
+            threadId: input.threadId,
+            cwd: input.cwd,
+            oldBranch: input.oldBranch,
+            gatewayOperationId: input.gatewayOperationId,
+            operationStatus: operation.status,
+          },
+        );
+        return;
+      }
     }
 
     const renamed = yield* git.withMutation(
@@ -1916,6 +1948,7 @@ const make = Effect.gen(function* () {
         cwd,
         oldBranch,
         targetBranch,
+        gatewayOperationId: thread.gatewayOperationId ?? null,
       }).pipe(
         Effect.catchCause((cause) =>
           Effect.logWarning(
@@ -1957,6 +1990,7 @@ const make = Effect.gen(function* () {
           cwd,
           oldBranch,
           targetBranch,
+          gatewayOperationId: thread.gatewayOperationId ?? null,
         });
       }),
       Effect.catchCause((cause) =>
@@ -2679,7 +2713,7 @@ const make = Effect.gen(function* () {
       readonly detail: string;
       readonly settlementStatus: "retryable" | "uncertain";
     },
-  ) =>
+  ): Effect.Effect<void, OrchestrationDispatchError> =>
     event.commandId === null
       ? Effect.void
       : appendProviderFailureActivity({

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -299,6 +299,7 @@ const PROVIDER_COMMAND_SAFE_RETRY_DELAY = Duration.millis(50);
 const PROVIDER_COMMAND_INTERRUPT_TIMEOUT = Duration.seconds(10);
 const PROVIDER_COMMAND_STOP_TIMEOUT = Duration.seconds(15);
 const PROVIDER_COMMAND_EVENT_TIMEOUT = Duration.seconds(120);
+const GATEWAY_OPERATION_COMPLETION_WAIT_TIMEOUT = Duration.seconds(120);
 const PROVIDER_INPUT_SAFETY_MARGIN_CHARS = 1_000;
 const THREAD_MENTION_CONTEXT_SUFFIX_PREFIX_CHARS = 2;
 const DEFAULT_RUNTIME_MODE: RuntimeMode = "full-access";
@@ -468,6 +469,41 @@ const make = Effect.gen(function* () {
   const gatewayOperations = yield* AgentGatewayOperationRepository;
   const textGeneration = yield* TextGeneration;
   const serverSettings = yield* ServerSettingsService;
+
+  const waitForGatewayOperationCompletion = Effect.fnUntraced(function* (operationId: string) {
+    const completed = yield* Effect.gen(function* () {
+      while (true) {
+        const operation = yield* gatewayOperations
+          .getById(operationId)
+          .pipe(
+            Effect.catch((error) =>
+              Effect.logWarning(
+                "provider command reactor could not read creating gateway operation; skipping worktree branch rename",
+                { operationId, error: error instanceof Error ? error.message : String(error) },
+              ).pipe(Effect.as(null)),
+            ),
+          );
+        if (operation === null) {
+          return false;
+        }
+        if (operation.status === "completed") {
+          return true;
+        }
+        if (operation.status === "failed" || operation.status === "compensating") {
+          return false;
+        }
+        yield* Effect.sleep(Duration.millis(100));
+      }
+    }).pipe(Effect.timeoutOption(GATEWAY_OPERATION_COMPLETION_WAIT_TIMEOUT));
+    if (Option.isNone(completed)) {
+      yield* Effect.logWarning(
+        "provider command reactor timed out waiting for creating gateway operation; skipping worktree branch rename",
+        { operationId },
+      );
+      return false;
+    }
+    return completed.value;
+  });
   const managedAttachments = yield* ManagedAttachmentRepository;
   const serverConfig = yield* ServerConfig;
   const handledTurnStartKeys = yield* Cache.make<string, true>({
@@ -1842,26 +1878,12 @@ const make = Effect.gen(function* () {
     // proof records the temporary branch name. Renaming before the operation
     // reaches a terminal state would make live compensation and startup
     // recovery reject the worktree as tampered ("worktree branch changed"),
-    // stranding it. Check right before mutating so the window between the LLM
-    // name generation and the rename stays covered; skipping is safe — the
-    // thread simply keeps its temporary name.
+    // stranding it. Wait for durable completion rather than dropping the
+    // first-turn rename; failed, compensating, missing, or unreadable
+    // operations never authorize the mutation.
     if (input.gatewayOperationId !== null) {
-      const operation = yield* gatewayOperations.getById(input.gatewayOperationId).pipe(
-        // An unreadable record proves nothing; skip the rename rather than
-        // risk invalidating a proof that may still be needed.
-        Effect.catch(() => Effect.succeed(null)),
-      );
-      if (operation !== null && operation.status !== "completed") {
-        yield* Effect.logInfo(
-          "provider command reactor skipped worktree branch rename: creating gateway operation is not complete",
-          {
-            threadId: input.threadId,
-            cwd: input.cwd,
-            oldBranch: input.oldBranch,
-            gatewayOperationId: input.gatewayOperationId,
-            operationStatus: operation.status,
-          },
-        );
+      const completed = yield* waitForGatewayOperationCompletion(input.gatewayOperationId);
+      if (!completed) {
         return;
       }
     }

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -93,6 +93,7 @@ export function makeServerRuntimeServicesLayer(
     Layer.provideMerge(GitCoreLive),
     Layer.provideMerge(TextGenerationLayerLive),
     Layer.provideMerge(ServerSettingsLive),
+    Layer.provideMerge(AgentGatewayOperationRepositoryLive),
   );
   const checkpointReactorLayer = CheckpointReactorLive.pipe(
     Layer.provideMerge(runtimeServicesLayer),

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -1180,7 +1180,7 @@ function resolveWsRpc(body: WsRequestEnvelope["body"]): unknown {
       worktree: {
         path: "/repo/.codex/worktrees/generated/synara",
         ref: "0123456789abcdef0123456789abcdef01234567",
-        branch: null,
+        branch: typeof body.newBranch === "string" ? body.newBranch : null,
       },
     };
   }
@@ -5911,6 +5911,9 @@ describe("ChatView timeline estimator parity (full app)", () => {
               request.copyChangesFrom === "/repo/project",
           );
           expect(createWorktreeRequest).toBeTruthy();
+          const temporaryBranch = createWorktreeRequest?.newBranch;
+          expect(typeof temporaryBranch).toBe("string");
+          expect(temporaryBranch).toMatch(/^synara\/[0-9a-f]{8}$/);
 
           const createThreadRequest = wsRequests.find(
             (request) =>
@@ -5925,10 +5928,10 @@ describe("ChatView timeline estimator parity (full app)", () => {
           expect(createThreadRequest).toBeTruthy();
           expect(createThreadRequest?.command).toMatchObject({
             envMode: "worktree",
-            branch: null,
+            branch: temporaryBranch,
             worktreePath: "/repo/.codex/worktrees/generated/synara",
             associatedWorktreePath: "/repo/.codex/worktrees/generated/synara",
-            associatedWorktreeBranch: null,
+            associatedWorktreeBranch: temporaryBranch,
             associatedWorktreeRef: "0123456789abcdef0123456789abcdef01234567",
           });
         },

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -77,6 +77,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Debouncer, useDebouncedValue } from "@tanstack/react-pacer";
 import { useNavigate } from "@tanstack/react-router";
 import { type LegendListRef } from "@legendapp/list/react";
+import { buildTemporaryWorktreeBranchName } from "@synara/shared/git";
 import {
   GIT_WORKING_TREE_DIFF_LIVE_REFETCH_INTERVAL_MS,
   gitCreateDetachedWorktreeMutationOptions,
@@ -7870,6 +7871,7 @@ export default function ChatView({
         const result = await createWorktreeMutation.mutateAsync({
           cwd: targetProjectCwdForSend,
           ref: baseBranchForWorktree,
+          newBranch: buildTemporaryWorktreeBranchName(),
           ...(baseBranchForWorktree === activeRootBranch
             ? { copyChangesFrom: targetProjectCwdForSend }
             : {}),
@@ -7883,7 +7885,7 @@ export default function ChatView({
         createdWorktreeForSendPath = result.worktree.path;
         const nextAssociatedWorktree = {
           associatedWorktreePath: result.worktree.path,
-          associatedWorktreeBranch: null,
+          associatedWorktreeBranch: result.worktree.branch,
           associatedWorktreeRef: result.worktree.ref,
         };
         nextAssociatedWorktreePath = nextAssociatedWorktree.associatedWorktreePath;
@@ -8107,6 +8109,7 @@ export default function ChatView({
             cwd: targetProjectCwdForSend,
             path: createdWorktreeForSendPath,
             force: true,
+            reclaimTemporaryBranch: true,
           })
           .then(
             () => true,

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -419,11 +419,13 @@ export function gitCreateDetachedWorktreeMutationOptions(input: { queryClient: Q
       ref,
       path,
       copyChangesFrom,
+      newBranch,
     }: {
       cwd: string;
       ref: string;
       path?: string | null;
       copyChangesFrom?: string;
+      newBranch?: string;
     }) => {
       const api = ensureNativeApi();
       if (!cwd) throw new Error("Git worktree creation is unavailable.");
@@ -432,6 +434,7 @@ export function gitCreateDetachedWorktreeMutationOptions(input: { queryClient: Q
         ref,
         path: path ?? null,
         ...(copyChangesFrom ? { copyChangesFrom } : {}),
+        ...(newBranch ? { newBranch } : {}),
       });
     },
     mutationKey: ["git", "mutation", "create-detached-worktree"] as const,
@@ -446,7 +449,9 @@ export function gitRemoveWorktreeMutationOptions(input: { queryClient: QueryClie
     mutationFn: async ({ cwd, path, force }: { cwd: string; path: string; force?: boolean }) => {
       const api = ensureNativeApi();
       if (!cwd) throw new Error("Git worktree removal is unavailable.");
-      return api.git.removeWorktree({ cwd, path, force });
+      // Every UI removal retires a thread-scoped managed worktree, so its
+      // temporary synara/* branch (if any) is reclaimed with it.
+      return api.git.removeWorktree({ cwd, path, force, reclaimTemporaryBranch: true });
     },
     mutationKey: ["git", "mutation", "remove-worktree"] as const,
     onSettled: async () => {

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -198,6 +198,9 @@ export const GitCreateDetachedWorktreeInput = Schema.Struct({
   ref: TrimmedNonEmptyStringSchema,
   path: Schema.NullOr(TrimmedNonEmptyStringSchema),
   copyChangesFrom: Schema.optional(TrimmedNonEmptyStringSchema),
+  // When set, the worktree is created on this new branch (pinned at `ref`)
+  // instead of a detached HEAD, so threads get a branch attached from birth.
+  newBranch: Schema.optional(TrimmedNonEmptyStringSchema),
 });
 export type GitCreateDetachedWorktreeInput = typeof GitCreateDetachedWorktreeInput.Type;
 
@@ -240,6 +243,11 @@ export const GitRemoveWorktreeInput = Schema.Struct({
   cwd: TrimmedNonEmptyStringSchema,
   path: TrimmedNonEmptyStringSchema,
   force: Schema.optional(Schema.Boolean),
+  // Managed worktrees are born on temporary synara/* branches. When set, a
+  // removal also deletes that branch so retiring the worktree cannot strand it;
+  // user-named branches are never touched. Handoff flows leave this unset
+  // because they re-home the branch into the root checkout instead.
+  reclaimTemporaryBranch: Schema.optional(Schema.Boolean),
 });
 export type GitRemoveWorktreeInput = typeof GitRemoveWorktreeInput.Type;
 


### PR DESCRIPTION
## Problem

Since the managed-worktrees rework (`a7d2a142`), worktrees are created with `git worktree add --detach` and threads no longer get a branch created and attached automatically. `buildTemporaryWorktreeBranchName` became dead code, and worktree threads were born with `branch: null` everywhere (web first-send, agent gateway, automations).

## Approach

Restore the old behavior on top of the new architecture rather than reverting it — worktrees stay ref-pinned, ownership-proofed, and prunable, but are now born on a temporary `synara/<8-hex>` branch.

- **Contracts**: `GitCreateDetachedWorktreeInput.newBranch` (optional) and `GitRemoveWorktreeInput.reclaimTemporaryBranch` (optional).
- **GitCore**: `createDetachedWorktree` uses `worktree add -b <branch> <path> <ref>` when `newBranch` is set; the `copyChangesFrom` failure rollback also deletes the branch. `removeWorktree` with `reclaimTemporaryBranch` reads the worktree's branch before removal and deletes it afterward **only if it matches the temporary `synara/*` pattern** — user-named branches are never touched (branch deletion failure is warn-only, never fails the removal).
- **Web first-send** (`ChatView.tsx`): passes `buildTemporaryWorktreeBranchName()` and attaches the resulting branch to the thread (`branch` + `associatedWorktreeBranch`), as before the regression.
- **Agent gateway** (`creationCoordinator.ts`): the branch name is derived at plan-preparation time from the operation digest (`stableGatewayDigest`), keeping plans deterministic so exact-plan retries, plan-vs-created verification, ownership proofs, and startup recovery all agree on the branch. Existing compensation paths were already branch-aware.
- **Automations** (`AutomationService.ts`): automation-created worktree threads get the same temporary branch and attachment.
- **Reclamation sites**: UI worktree removals, ChatView send-failure rollback, automation cleanup, and retention pruning all pass `reclaimTemporaryBranch: true`, so retiring a worktree can no longer strand its branch. Handoff-to-local deliberately does **not** reclaim, since it re-homes the branch into the root checkout.

## Testing

- New real-git integration tests in `GitCore.test.ts`: branch-backed creation + branch reclamation on removal, and a guard that user-named branches survive removal with the flag set.
- Updated harness fakes and assertions in `AgentGateway.test.ts`, `AutomationService.test.ts`, `ExternalMcpGateway.e2e.test.ts`, and `ChatView.browser.tsx` to cover the branch now flowing through creation, thread attachment, and compensation (compensation tests now assert the temp branch is deleted).
- Full server suite (3277 passed), web unit suite (3543 passed), stable ChatView browser suite (74 passed) all green; `bun fmt`, `bun lint`, `bun typecheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Git worktree/branch lifecycle, thread creation across gateway/web/automation, and timing-sensitive first-turn rename tied to gateway operation state; mistakes could strand branches or break ownership/compensation, but scope is bounded by the temporary `synara/*` pattern and extensive test updates.
> 
> **Overview**
> Restores **automatic branch attachment** for managed worktree threads: instead of detached HEAD with `branch: null`, creation paths now use optional `newBranch` on `createDetachedWorktree` (`git worktree add -b …`) and thread metadata carries that branch from birth.
> 
> **Git contracts & GitCore:** `GitCreateDetachedWorktreeInput.newBranch` and `GitRemoveWorktreeInput.reclaimTemporaryBranch`. Removal with reclamation deletes only branches matching the temporary `synara/*` pattern (compare-and-delete by observed HEAD; failures are warn-only). Rollback on failed `copyChangesFrom` also drops the new branch.
> 
> **Call sites:** Web first-send (`ChatView`), agent gateway creation (`creationCoordinator` uses a digest-stable `synara/<8-hex>` per operation index), and automation worktrees all pass temporary branch names and set `associatedWorktreeBranch`. Cleanup paths (send failure, automation, managed retention, UI `removeWorktree`) pass `reclaimTemporaryBranch: true`. Gateway tool docs and deprecated `branchName` messaging are updated.
> 
> **Provider reactor:** For threads with `gatewayOperationId`, first-turn worktree rename/publish **waits** (poll + timeout) for the creating gateway operation to reach `completed` so compensation/recovery still sees the original branch name; missing/failed operations skip rename. `AgentGatewayOperationRepositoryLive` is wired into provider command reactor layers for this.
> 
> Tests and harnesses are updated to assert temp branches flow through creation, thread attachment, and compensation (branch delete on cleanup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 955024357bca07dd6ad5619403d74dde2c57b723. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->