### PR TITLE
Fix send spinner sticking on lost thread stream acknowledgements

### DIFF
--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -147,6 +147,13 @@ export function canManageExternalMcp(role: "owner" | "client"): boolean {
 const MAX_DIAGNOSTIC_CHILD_PROCESSES = 80;
 const MAX_DIAGNOSTIC_ARGS_CHARS = 500;
 
+// Bounded window a thread subscription waits for the projector to commit the
+// thread's detail read model before failing with THREAD_SNAPSHOT_NOT_FOUND.
+// Covers subscribe-vs-projection races on freshly created threads; a thread
+// that truly does not exist still fails, just this much later.
+const THREAD_DETAIL_SNAPSHOT_BOOTSTRAP_TIMEOUT_MS = 5_000;
+const THREAD_DETAIL_SNAPSHOT_BOOTSTRAP_POLL_MS = 100;
+
 class WsRequestAdmissionMiddleware extends RpcMiddleware.Service<WsRequestAdmissionMiddleware>()(
   "synara/WsRequestAdmissionMiddleware",
   { error: WsRpcError, requiredForClient: false },
@@ -431,6 +438,25 @@ const makeWsRpcHandlersLayer = () =>
               }),
             ),
           );
+
+      // A thread subscription can race the projector: the client subscribes the
+      // moment a create/turn RPC resolves, while the detail read model commits
+      // asynchronously behind the journal. Failing straight away with
+      // THREAD_SNAPSHOT_NOT_FOUND tears the stream down for a thread the server
+      // is actively running. Waiting here is safe because the cursor-safe
+      // stream attaches its live tap before evaluating the snapshot effect, so
+      // no event that commits during the wait is lost.
+      const loadThreadDetailSnapshotWithBootstrapWait = (threadId: ThreadId) =>
+        Effect.gen(function* () {
+          const deadline = Date.now() + THREAD_DETAIL_SNAPSHOT_BOOTSTRAP_TIMEOUT_MS;
+          while (true) {
+            const detail = yield* projectionReadModelQuery.getThreadDetailSnapshotById(threadId);
+            if (Option.isSome(detail) || Date.now() >= deadline) {
+              return detail;
+            }
+            yield* Effect.sleep(THREAD_DETAIL_SNAPSHOT_BOOTSTRAP_POLL_MS);
+          }
+        });
 
       const isGlobalGitHubCliError = (error: unknown): error is GitHubCliError =>
         error instanceof GitHubCliError &&
@@ -979,7 +1005,7 @@ const makeWsRpcHandlersLayer = () =>
                   ),
                 ),
               ),
-              snapshot: projectionReadModelQuery.getThreadDetailSnapshotById(input.threadId).pipe(
+              snapshot: loadThreadDetailSnapshotWithBootstrapWait(input.threadId).pipe(
                 Effect.flatMap(
                   Option.match({
                     onNone: () =>

--- a/apps/server/src/wsStreamAdmission.test.ts
+++ b/apps/server/src/wsStreamAdmission.test.ts
@@ -18,20 +18,27 @@ describe("WsStreamAdmission", () => {
             Effect.andThen(Deferred.succeed(rejectionRecorded, undefined)),
           ),
       });
-      const lease = yield* admission.acquire(1, { key: "thread.stream:1", threadId: "thread-1" });
-      const duplicate = yield* admission
-        .acquire(1, { key: "thread.stream:1", threadId: "thread-1" })
+      const leases = yield* Effect.forEach(
+        Array.from({ length: MAX_THREAD_STREAMS_PER_RPC_CLIENT }, (_, index) => index),
+        (index) =>
+          admission.acquire(1, {
+            key: `orchestration.thread:thread-${index}`,
+            threadId: `thread-${index}`,
+          }),
+      );
+      const overflow = yield* admission
+        .acquire(1, { key: "orchestration.thread:overflow", threadId: "overflow" })
         .pipe(Effect.exit);
       yield* Deferred.await(rejectionRecorded);
-      expect(duplicate._tag).toBe("Failure");
+      expect(overflow._tag).toBe("Failure");
       expect(recorded).toEqual([
         expect.objectContaining({
-          threadId: "thread-1",
-          reason: "duplicate",
-          errorCode: "STREAM_DUPLICATE_SUBSCRIPTION",
+          threadId: "overflow",
+          reason: "thread-capacity",
+          errorCode: "THREAD_STREAM_CAPACITY_EXCEEDED",
         }),
       ]);
-      yield* admission.release(lease);
+      yield* Effect.forEach(leases, admission.release, { discard: true });
     }).pipe(Effect.runPromise);
   });
 
@@ -41,18 +48,21 @@ describe("WsStreamAdmission", () => {
       const admission = yield* makeWsStreamAdmission({
         recordRejection: () => Deferred.await(persistenceGate),
       });
-      const lease = yield* admission.acquire(1, { key: "server.settings" });
+      const leases = yield* Effect.forEach(
+        Array.from({ length: MAX_STREAMS_PER_RPC_CLIENT }, (_, index) => index),
+        (index) => admission.acquire(1, { key: `stream:${index}` }),
+      );
 
       const outcome = yield* Effect.raceFirst(
         admission
-          .acquire(1, { key: "server.settings" })
+          .acquire(1, { key: "stream:overflow" })
           .pipe(Effect.exit, Effect.as("rejected" as const)),
         Effect.sleep(100).pipe(Effect.as("timed-out" as const)),
       );
 
       expect(outcome).toBe("rejected");
       yield* Deferred.succeed(persistenceGate, undefined);
-      yield* admission.release(lease);
+      yield* Effect.forEach(leases, admission.release, { discard: true });
     }).pipe(Effect.runPromise);
   });
 
@@ -75,11 +85,18 @@ describe("WsStreamAdmission", () => {
 
       yield* Deferred.await(started);
       expect(yield* admission.snapshot).toMatchObject({ active: 1, releasedTotal: 0 });
-      const duplicate = yield* Stream.runDrain(
-        admission.guard(1, { key: "server.settings" }, source),
-      ).pipe(Effect.exit);
-      expect(duplicate._tag).toBe("Failure");
+      // A same-key resubscribe takes the lease over; the takeover's own
+      // release is the only one counted because the evicted lease is already
+      // gone from the ledger when the interrupted stream finalizes.
+      yield* Stream.runDrain(admission.guard(1, { key: "server.settings" }, Stream.empty));
       expect(yield* Ref.get(subscriptions)).toBe(1);
+      expect(yield* admission.snapshot).toMatchObject({
+        clients: 0,
+        active: 0,
+        admittedTotal: 2,
+        replacedDuplicateTotal: 1,
+        releasedTotal: 1,
+      });
       yield* Fiber.interrupt(fiber);
       expect(yield* admission.snapshot).toMatchObject({
         clients: 0,
@@ -115,28 +132,32 @@ describe("WsStreamAdmission", () => {
     }).pipe(Effect.runPromise);
   });
 
-  it("rejects duplicate subscriptions only within the owning RPC client", async () => {
+  it("lets a same-key resubscribe take over the lease only within the owning RPC client", async () => {
     await Effect.gen(function* () {
       const admission = yield* makeWsStreamAdmission();
       const first = yield* admission.acquire(1, { key: "server.settings" });
-      const duplicate = yield* admission.acquire(1, { key: "server.settings" }).pipe(Effect.flip);
+      const takeover = yield* admission.acquire(1, { key: "server.settings" });
       const otherClient = yield* admission.acquire(2, { key: "server.settings" });
 
-      expect(duplicate.code).toBe("STREAM_DUPLICATE_SUBSCRIPTION");
-      expect(duplicate.retryable).toBe(false);
+      expect(takeover.leaseId).not.toBe(first.leaseId);
       expect(yield* admission.snapshot).toMatchObject({
         clients: 2,
         active: 2,
-        rejectedDuplicateTotal: 1,
+        admittedTotal: 3,
+        replacedDuplicateTotal: 1,
       });
 
+      // The evicted lease's release must be a no-op: its stream finalizes
+      // later and must not decrement the takeover's live lease.
       yield* admission.release(first);
-      yield* admission.release(first);
+      expect(yield* admission.snapshot).toMatchObject({ active: 2, releasedTotal: 0 });
+
+      yield* admission.release(takeover);
       yield* admission.release(otherClient);
       expect(yield* admission.snapshot).toMatchObject({
         clients: 0,
         active: 0,
-        admittedTotal: 2,
+        admittedTotal: 3,
         releasedTotal: 2,
       });
     }).pipe(Effect.runPromise);

--- a/apps/server/src/wsStreamAdmission.test.ts
+++ b/apps/server/src/wsStreamAdmission.test.ts
@@ -66,7 +66,7 @@ describe("WsStreamAdmission", () => {
     }).pipe(Effect.runPromise);
   });
 
-  it("holds a stream lease through interruption and releases it after finalization", async () => {
+  it("tears down the evicted stream on a same-key takeover and counts a single release", async () => {
     await Effect.gen(function* () {
       const admission = yield* makeWsStreamAdmission();
       const started = yield* Deferred.make<void>();
@@ -85,11 +85,14 @@ describe("WsStreamAdmission", () => {
 
       yield* Deferred.await(started);
       expect(yield* admission.snapshot).toMatchObject({ active: 1, releasedTotal: 0 });
-      // A same-key resubscribe takes the lease over; the takeover's own
-      // release is the only one counted because the evicted lease is already
-      // gone from the ledger when the interrupted stream finalizes.
+      // A same-key resubscribe takes the lease over and tears the evicted
+      // stream down through its eviction latch — the fiber draining it
+      // completes without manual interruption. The takeover's own release is
+      // the only one counted because the evicted lease is already gone from
+      // the ledger when the evicted stream finalizes.
       yield* Stream.runDrain(admission.guard(1, { key: "server.settings" }, Stream.empty));
       expect(yield* Ref.get(subscriptions)).toBe(1);
+      yield* Fiber.join(fiber);
       expect(yield* admission.snapshot).toMatchObject({
         clients: 0,
         active: 0,
@@ -97,10 +100,51 @@ describe("WsStreamAdmission", () => {
         replacedDuplicateTotal: 1,
         releasedTotal: 1,
       });
-      yield* Fiber.interrupt(fiber);
+    }).pipe(Effect.runPromise);
+  });
+
+  it("bounds live taps under repeated same-key resubscribes", async () => {
+    await Effect.gen(function* () {
+      const admission = yield* makeWsStreamAdmission();
+      // Forks a guarded never-ending stream and waits until it is admitted, so
+      // successive resubscribes evict in a deterministic order.
+      const forkGuardedNever = () =>
+        Effect.gen(function* () {
+          const admitted = yield* Deferred.make<void>();
+          const source = Stream.concat(
+            Stream.fromEffect(Deferred.succeed(admitted, undefined)),
+            Stream.never,
+          );
+          const fiber = yield* Effect.forkChild(
+            Stream.runDrain(
+              admission.guard(1, { key: "orchestration.thread:t", threadId: "t" }, source),
+            ),
+          );
+          yield* Deferred.await(admitted);
+          return fiber;
+        });
+      const first = yield* forkGuardedNever();
+      const second = yield* forkGuardedNever();
+      // Each takeover must terminate its predecessor: joining the evicted
+      // fibers completes without manual interruption, and capacity accounting
+      // never sees more than the single live lease.
+      yield* Fiber.join(first);
+      const third = yield* forkGuardedNever();
+      yield* Fiber.join(second);
+      expect(yield* admission.snapshot).toMatchObject({
+        active: 1,
+        admittedTotal: 3,
+        replacedDuplicateTotal: 2,
+      });
+      yield* Stream.runDrain(
+        admission.guard(1, { key: "orchestration.thread:t", threadId: "t" }, Stream.empty),
+      );
+      yield* Fiber.join(third);
       expect(yield* admission.snapshot).toMatchObject({
         clients: 0,
         active: 0,
+        admittedTotal: 4,
+        replacedDuplicateTotal: 3,
         releasedTotal: 1,
       });
     }).pipe(Effect.runPromise);

--- a/apps/server/src/wsStreamAdmission.ts
+++ b/apps/server/src/wsStreamAdmission.ts
@@ -25,7 +25,7 @@ interface AdmissionLedger {
   readonly clients: ReadonlyMap<number, ClientLedger>;
   readonly admittedTotal: number;
   readonly releasedTotal: number;
-  readonly rejectedDuplicateTotal: number;
+  readonly replacedDuplicateTotal: number;
   readonly rejectedCapacityTotal: number;
 }
 
@@ -34,16 +34,16 @@ export interface WsStreamAdmissionSnapshot {
   readonly active: number;
   readonly admittedTotal: number;
   readonly releasedTotal: number;
-  readonly rejectedDuplicateTotal: number;
+  readonly replacedDuplicateTotal: number;
   readonly rejectedCapacityTotal: number;
 }
 
 type AdmissionOutcome =
-  | { readonly _tag: "Admitted"; readonly lease: WsStreamLease }
+  | { readonly _tag: "Admitted"; readonly lease: WsStreamLease; readonly replacedCount: number }
   | {
       readonly _tag: "Rejected";
       readonly error: WsRpcError;
-      readonly reason: "duplicate" | "stream-capacity" | "thread-capacity";
+      readonly reason: "stream-capacity" | "thread-capacity";
       readonly active: number;
       readonly activeThreads: number;
     };
@@ -52,7 +52,7 @@ const initialLedger = (): AdmissionLedger => ({
   clients: new Map(),
   admittedTotal: 0,
   releasedTotal: 0,
-  rejectedDuplicateTotal: 0,
+  replacedDuplicateTotal: 0,
   rejectedCapacityTotal: 0,
 });
 
@@ -68,7 +68,7 @@ export const makeWsStreamAdmission = (
   options: {
     readonly recordRejection?: (input: {
       readonly threadId?: string;
-      readonly reason: "duplicate" | "stream-capacity" | "thread-capacity";
+      readonly reason: "stream-capacity" | "thread-capacity";
       readonly errorCode: string;
       readonly active: number;
       readonly activeThreads: number;
@@ -81,28 +81,18 @@ export const makeWsStreamAdmission = (
     const acquire = (clientId: number, subscription: WsStreamSubscription) =>
       Ref.modify(ledgerRef, (ledger): readonly [AdmissionOutcome, AdmissionLedger] => {
         const client = ledger.clients.get(clientId) ?? { leases: new Map() };
-        const leases = client.leases;
-        const active = leases.size;
-        const activeThreads = activeThreadCount(leases);
-        const duplicate = Array.from(leases.values()).some(
-          (lease) => lease.key === subscription.key,
+        // Last subscription wins: a resubscribe for the same key evicts the
+        // prior lease instead of being rejected. Release timing of the old
+        // stream depends on async scope finalization (unsubscribeThread is a
+        // no-op), so rejecting duplicates made every fast resubscribe race the
+        // old stream's teardown. The evicted stream's own eventual release is a
+        // safe no-op because its leaseId is no longer in the ledger.
+        const retainedLeases = new Map(
+          Array.from(client.leases).filter(([, lease]) => lease.key !== subscription.key),
         );
-        if (duplicate) {
-          return [
-            {
-              _tag: "Rejected",
-              reason: "duplicate",
-              active,
-              activeThreads,
-              error: new WsRpcError({
-                message: "Duplicate streaming RPC subscription.",
-                code: "STREAM_DUPLICATE_SUBSCRIPTION",
-                retryable: false,
-              }),
-            },
-            { ...ledger, rejectedDuplicateTotal: ledger.rejectedDuplicateTotal + 1 },
-          ];
-        }
+        const replacedCount = client.leases.size - retainedLeases.size;
+        const active = retainedLeases.size;
+        const activeThreads = activeThreadCount(retainedLeases);
         if (active >= MAX_STREAMS_PER_RPC_CLIENT) {
           return [
             {
@@ -146,18 +136,34 @@ export const makeWsStreamAdmission = (
           clientId,
           leaseId: Crypto.randomUUID(),
         };
-        const nextLeases = new Map(leases);
+        const nextLeases = new Map(retainedLeases);
         nextLeases.set(lease.leaseId, lease);
         const nextClients = new Map(ledger.clients);
         nextClients.set(clientId, { leases: nextLeases });
         return [
-          { _tag: "Admitted", lease },
-          { ...ledger, clients: nextClients, admittedTotal: ledger.admittedTotal + 1 },
+          { _tag: "Admitted", lease, replacedCount },
+          {
+            ...ledger,
+            clients: nextClients,
+            admittedTotal: ledger.admittedTotal + 1,
+            replacedDuplicateTotal: ledger.replacedDuplicateTotal + replacedCount,
+          },
         ];
       }).pipe(
         Effect.flatMap((outcome) =>
           outcome._tag === "Admitted"
-            ? Effect.succeed(outcome.lease)
+            ? Effect.gen(function* () {
+                if (outcome.replacedCount > 0) {
+                  yield* Effect.logWarning("Streaming RPC subscription replaced prior lease.").pipe(
+                    Effect.annotateLogs({
+                      key: subscription.key,
+                      replacedCount: outcome.replacedCount,
+                      requestedThreadId: subscription.threadId ?? null,
+                    }),
+                  );
+                }
+                return outcome.lease;
+              })
             : Effect.gen(function* () {
                 yield* Effect.logWarning("Rejected streaming RPC admission.").pipe(
                   Effect.annotateLogs({
@@ -223,7 +229,7 @@ export const makeWsStreamAdmission = (
           ),
           admittedTotal: ledger.admittedTotal,
           releasedTotal: ledger.releasedTotal,
-          rejectedDuplicateTotal: ledger.rejectedDuplicateTotal,
+          replacedDuplicateTotal: ledger.replacedDuplicateTotal,
           rejectedCapacityTotal: ledger.rejectedCapacityTotal,
         }),
       ),

--- a/apps/server/src/wsStreamAdmission.ts
+++ b/apps/server/src/wsStreamAdmission.ts
@@ -1,7 +1,7 @@
 import * as Crypto from "node:crypto";
 
 import { WS_STREAM_LIMITS, WsRpcError } from "@synara/contracts";
-import { Effect, Ref, Stream } from "effect";
+import { Deferred, Effect, Ref, Stream } from "effect";
 
 export const MAX_STREAMS_PER_RPC_CLIENT = WS_STREAM_LIMITS.totalPerClient;
 export const MAX_THREAD_STREAMS_PER_RPC_CLIENT = WS_STREAM_LIMITS.threadPerClient;
@@ -15,6 +15,11 @@ export interface WsStreamSubscription {
 export interface WsStreamLease extends WsStreamSubscription {
   readonly clientId: number;
   readonly leaseId: string;
+  // Resolves when a same-key resubscribe evicts this lease. Guarded streams
+  // interrupt on it: removing the lease from the ledger alone would leave the
+  // evicted stream's live tap running until its scope happens to finalize,
+  // letting a resubscribing client hold more live streams than the caps allow.
+  readonly evicted: Deferred.Deferred<void>;
 }
 
 interface ClientLedger {
@@ -39,7 +44,11 @@ export interface WsStreamAdmissionSnapshot {
 }
 
 type AdmissionOutcome =
-  | { readonly _tag: "Admitted"; readonly lease: WsStreamLease; readonly replacedCount: number }
+  | {
+      readonly _tag: "Admitted";
+      readonly lease: WsStreamLease;
+      readonly evictedLeases: readonly WsStreamLease[];
+    }
   | {
       readonly _tag: "Rejected";
       readonly error: WsRpcError;
@@ -79,120 +88,132 @@ export const makeWsStreamAdmission = (
     const ledgerRef = yield* Ref.make<AdmissionLedger>(initialLedger());
 
     const acquire = (clientId: number, subscription: WsStreamSubscription) =>
-      Ref.modify(ledgerRef, (ledger): readonly [AdmissionOutcome, AdmissionLedger] => {
-        const client = ledger.clients.get(clientId) ?? { leases: new Map() };
-        // Last subscription wins: a resubscribe for the same key evicts the
-        // prior lease instead of being rejected. Release timing of the old
-        // stream depends on async scope finalization (unsubscribeThread is a
-        // no-op), so rejecting duplicates made every fast resubscribe race the
-        // old stream's teardown. The evicted stream's own eventual release is a
-        // safe no-op because its leaseId is no longer in the ledger.
-        const retainedLeases = new Map(
-          Array.from(client.leases).filter(([, lease]) => lease.key !== subscription.key),
-        );
-        const replacedCount = client.leases.size - retainedLeases.size;
-        const active = retainedLeases.size;
-        const activeThreads = activeThreadCount(retainedLeases);
-        if (active >= MAX_STREAMS_PER_RPC_CLIENT) {
-          return [
-            {
-              _tag: "Rejected",
-              reason: "stream-capacity",
-              active,
-              activeThreads,
-              error: new WsRpcError({
-                message: "Streaming RPC capacity exceeded.",
-                code: "STREAM_CAPACITY_EXCEEDED",
-                retryable: true,
-                retryAfterMs: STREAM_CAPACITY_RETRY_AFTER_MS,
-              }),
-            },
-            { ...ledger, rejectedCapacityTotal: ledger.rejectedCapacityTotal + 1 },
-          ];
-        }
-        if (
-          subscription.threadId !== undefined &&
-          activeThreads >= MAX_THREAD_STREAMS_PER_RPC_CLIENT
-        ) {
-          return [
-            {
-              _tag: "Rejected",
-              reason: "thread-capacity",
-              active,
-              activeThreads,
-              error: new WsRpcError({
-                message: "Thread streaming RPC capacity exceeded.",
-                code: "THREAD_STREAM_CAPACITY_EXCEEDED",
-                retryable: true,
-                retryAfterMs: STREAM_CAPACITY_RETRY_AFTER_MS,
-              }),
-            },
-            { ...ledger, rejectedCapacityTotal: ledger.rejectedCapacityTotal + 1 },
-          ];
-        }
-
-        const lease: WsStreamLease = {
-          ...subscription,
-          clientId,
-          leaseId: Crypto.randomUUID(),
-        };
-        const nextLeases = new Map(retainedLeases);
-        nextLeases.set(lease.leaseId, lease);
-        const nextClients = new Map(ledger.clients);
-        nextClients.set(clientId, { leases: nextLeases });
-        return [
-          { _tag: "Admitted", lease, replacedCount },
-          {
-            ...ledger,
-            clients: nextClients,
-            admittedTotal: ledger.admittedTotal + 1,
-            replacedDuplicateTotal: ledger.replacedDuplicateTotal + replacedCount,
-          },
-        ];
-      }).pipe(
-        Effect.flatMap((outcome) =>
-          outcome._tag === "Admitted"
-            ? Effect.gen(function* () {
-                if (outcome.replacedCount > 0) {
-                  yield* Effect.logWarning("Streaming RPC subscription replaced prior lease.").pipe(
-                    Effect.annotateLogs({
-                      key: subscription.key,
-                      replacedCount: outcome.replacedCount,
-                      requestedThreadId: subscription.threadId ?? null,
-                    }),
-                  );
-                }
-                return outcome.lease;
-              })
-            : Effect.gen(function* () {
-                yield* Effect.logWarning("Rejected streaming RPC admission.").pipe(
-                  Effect.annotateLogs({
-                    reason: outcome.reason,
-                    active: outcome.active,
-                    activeThreads: outcome.activeThreads,
-                    streamLimit: MAX_STREAMS_PER_RPC_CLIENT,
-                    threadLimit: MAX_THREAD_STREAMS_PER_RPC_CLIENT,
-                    requestedThreadId: subscription.threadId ?? null,
+      Effect.gen(function* () {
+        const evicted = yield* Deferred.make<void>();
+        const outcome = yield* Ref.modify(
+          ledgerRef,
+          (ledger): readonly [AdmissionOutcome, AdmissionLedger] => {
+            const client = ledger.clients.get(clientId) ?? { leases: new Map() };
+            // Last subscription wins: a resubscribe for the same key evicts the
+            // prior lease instead of being rejected. Release timing of the old
+            // stream depends on async scope finalization (unsubscribeThread is a
+            // no-op), so rejecting duplicates made every fast resubscribe race
+            // the old stream's teardown. The evicted stream is torn down through
+            // its eviction latch below, and its own eventual release is a safe
+            // no-op because its leaseId is no longer in the ledger.
+            const retainedLeases = new Map<string, WsStreamLease>();
+            const evictedLeases: WsStreamLease[] = [];
+            for (const [leaseId, lease] of client.leases) {
+              if (lease.key === subscription.key) evictedLeases.push(lease);
+              else retainedLeases.set(leaseId, lease);
+            }
+            const active = retainedLeases.size;
+            const activeThreads = activeThreadCount(retainedLeases);
+            if (active >= MAX_STREAMS_PER_RPC_CLIENT) {
+              return [
+                {
+                  _tag: "Rejected",
+                  reason: "stream-capacity",
+                  active,
+                  activeThreads,
+                  error: new WsRpcError({
+                    message: "Streaming RPC capacity exceeded.",
+                    code: "STREAM_CAPACITY_EXCEEDED",
+                    retryable: true,
+                    retryAfterMs: STREAM_CAPACITY_RETRY_AFTER_MS,
                   }),
-                );
-                if (options.recordRejection) {
-                  const recordRejection = options.recordRejection;
-                  yield* Effect.sync(() => {
-                    Effect.runFork(
-                      recordRejection({
-                        ...(subscription.threadId ? { threadId: subscription.threadId } : {}),
-                        reason: outcome.reason,
-                        errorCode: outcome.error.code ?? "STREAM_ADMISSION_REJECTED",
-                        active: outcome.active,
-                        activeThreads: outcome.activeThreads,
-                      }),
-                    );
-                  });
-                }
-                return yield* Effect.fail(outcome.error);
+                },
+                { ...ledger, rejectedCapacityTotal: ledger.rejectedCapacityTotal + 1 },
+              ];
+            }
+            if (
+              subscription.threadId !== undefined &&
+              activeThreads >= MAX_THREAD_STREAMS_PER_RPC_CLIENT
+            ) {
+              return [
+                {
+                  _tag: "Rejected",
+                  reason: "thread-capacity",
+                  active,
+                  activeThreads,
+                  error: new WsRpcError({
+                    message: "Thread streaming RPC capacity exceeded.",
+                    code: "THREAD_STREAM_CAPACITY_EXCEEDED",
+                    retryable: true,
+                    retryAfterMs: STREAM_CAPACITY_RETRY_AFTER_MS,
+                  }),
+                },
+                { ...ledger, rejectedCapacityTotal: ledger.rejectedCapacityTotal + 1 },
+              ];
+            }
+
+            const lease: WsStreamLease = {
+              ...subscription,
+              clientId,
+              leaseId: Crypto.randomUUID(),
+              evicted,
+            };
+            const nextLeases = new Map(retainedLeases);
+            nextLeases.set(lease.leaseId, lease);
+            const nextClients = new Map(ledger.clients);
+            nextClients.set(clientId, { leases: nextLeases });
+            return [
+              { _tag: "Admitted", lease, evictedLeases },
+              {
+                ...ledger,
+                clients: nextClients,
+                admittedTotal: ledger.admittedTotal + 1,
+                replacedDuplicateTotal: ledger.replacedDuplicateTotal + evictedLeases.length,
+              },
+            ];
+          },
+        );
+        if (outcome._tag === "Admitted") {
+          if (outcome.evictedLeases.length > 0) {
+            yield* Effect.logWarning("Streaming RPC subscription replaced prior lease.").pipe(
+              Effect.annotateLogs({
+                key: subscription.key,
+                replacedCount: outcome.evictedLeases.length,
+                requestedThreadId: subscription.threadId ?? null,
               }),
-        ),
-      );
+            );
+            // Tear the replaced streams down now: capacity accounting already
+            // dropped them, so letting them keep streaming would break the
+            // invariant that the ledger bounds live taps.
+            yield* Effect.forEach(
+              outcome.evictedLeases,
+              (evictedLease) => Deferred.succeed(evictedLease.evicted, undefined),
+              { discard: true },
+            );
+          }
+          return outcome.lease;
+        }
+        yield* Effect.logWarning("Rejected streaming RPC admission.").pipe(
+          Effect.annotateLogs({
+            reason: outcome.reason,
+            active: outcome.active,
+            activeThreads: outcome.activeThreads,
+            streamLimit: MAX_STREAMS_PER_RPC_CLIENT,
+            threadLimit: MAX_THREAD_STREAMS_PER_RPC_CLIENT,
+            requestedThreadId: subscription.threadId ?? null,
+          }),
+        );
+        if (options.recordRejection) {
+          const recordRejection = options.recordRejection;
+          yield* Effect.sync(() => {
+            Effect.runFork(
+              recordRejection({
+                ...(subscription.threadId ? { threadId: subscription.threadId } : {}),
+                reason: outcome.reason,
+                errorCode: outcome.error.code ?? "STREAM_ADMISSION_REJECTED",
+                active: outcome.active,
+                activeThreads: outcome.activeThreads,
+              }),
+            );
+          });
+        }
+        return yield* Effect.fail(outcome.error);
+      });
 
     const release = (lease: WsStreamLease) =>
       Ref.update(ledgerRef, (ledger) => {
@@ -216,7 +237,12 @@ export const makeWsStreamAdmission = (
       stream: Stream.Stream<A, E, R>,
     ): Stream.Stream<A, E | WsRpcError, R> =>
       Stream.unwrap(
-        Effect.acquireRelease(acquire(clientId, subscription), release).pipe(Effect.as(stream)),
+        Effect.acquireRelease(acquire(clientId, subscription), release).pipe(
+          // Eviction ends the stream gracefully (interruptWhen completes it on
+          // latch success); scope finalization then runs the lease's release,
+          // which is a no-op because the takeover already removed it.
+          Effect.map((lease) => stream.pipe(Stream.interruptWhen(Deferred.await(lease.evicted)))),
+        ),
       );
 
     const snapshot = Ref.get(ledgerRef).pipe(

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -995,6 +995,14 @@ export function worktreeSetupHasError(snapshot: WorktreeSetupSnapshot | null): b
   return snapshot?.steps.some((step) => step.status === "error") ?? false;
 }
 
+// Once the turn RPC has resolved the server provably owns the turn; the
+// dispatch marker then only waits for the thread stream to echo the change
+// (session running / message echo / turn change). A dead or stalled stream
+// would otherwise leave the composer spinner stuck forever, so the marker is
+// force-cleared after this bound and the catch-up watchdog re-syncs the real
+// thread state.
+export const LOCAL_DISPATCH_ACK_TIMEOUT_MS = 10_000;
+
 export interface LocalDispatchSnapshot {
   startedAt: string;
   worktreeSetup: WorktreeSetupSnapshot | null;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5844,27 +5844,6 @@ export default function ChatView({
     [],
   );
 
-  // Mirror the outstanding dispatch into the cross-component pending-turn
-  // signal: the EventRouter catch-up watchdog re-syncs threads it believes are
-  // busy, and a lost running transition leaves that belief stale. This signal
-  // makes the watchdog re-check a thread the composer just wrote to even while
-  // the store still reports it idle.
-  //
-  // Mark-only on purpose. The composer clears `localDispatch` on its own
-  // acknowledgement signals (message echo, ack fallback, takeover reset),
-  // all of which can fire off a stream that then stalls before the running
-  // transition — exactly the loss the marker exists to repair. So the marker
-  // must outlive `localDispatch`: the watchdog retires it once the projection
-  // confirms the thread busy, dispatch failures clear it at the dispatch
-  // site, and the age cap bounds any stray.
-  const pendingDispatchStartedAt = localDispatch?.startedAt ?? null;
-  useEffect(() => {
-    if (activeThreadId === null || pendingDispatchStartedAt === null) {
-      return;
-    }
-    markPendingTurnDispatch(activeThreadId);
-  }, [activeThreadId, pendingDispatchStartedAt]);
-
   // Fallback cleanup for a failed worktree setup: clears the dispatch after the
   // error hold unless a newer dispatch already replaced it.
   const scheduleFailedWorktreeSetupDispatchReset = useCallback(() => {
@@ -9106,9 +9085,7 @@ export default function ChatView({
       })
       .then(() => {
         // The turn RPC resolved for a thread this view never made active, so
-        // the dispatch-mirror effect cannot arm the watchdog marker for it —
-        // arm it here so a lost running transition on the new thread still
-        // forces catch-up after navigation subscribes it.
+        // arm the watchdog marker with that exact thread id before navigation.
         markPendingTurnDispatch(nextThreadId);
         return api.orchestration.getShellSnapshot();
       })
@@ -9131,6 +9108,7 @@ export default function ChatView({
           .then(() => true)
           .catch(() => false);
         if (deletedOnServer) {
+          clearPendingTurnDispatch(nextThreadId);
           void reconcileDeletedThreadFromClient({
             threadId: nextThreadId,
             removeDeletedThreadFromClientState:

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -552,6 +552,7 @@ import {
   failWorktreeSetupSnapshot,
   filterSidechatTranscriptMessages,
   hasServerAcknowledgedLocalDispatch,
+  LOCAL_DISPATCH_ACK_TIMEOUT_MS,
   resolveNextLocalDispatchSnapshot,
   resolveThreadArtifactWorkspaceRoot,
   WORKTREE_SETUP_ERROR_HOLD_MS,
@@ -568,6 +569,7 @@ import {
   revokeBlobPreviewUrl,
   revokeUserMessagePreviewUrls,
 } from "./ChatView.logic";
+import { clearPendingTurnDispatch, markPendingTurnDispatch } from "../pendingTurnDispatch";
 import { useLocalStorage } from "~/hooks/useLocalStorage";
 import { useComposerSlashCommands } from "../hooks/useComposerSlashCommands";
 import { useFeatureFlags } from "../featureFlags";
@@ -5761,6 +5763,58 @@ export default function ChatView({
     setLocalDispatch(null);
   }, []);
 
+  // The dispatch marker normally clears when the thread stream echoes the sent
+  // turn. Once the turn RPC has resolved the server owns the turn, so a stream
+  // that never echoes (dead subscription, lost event) must not lock the
+  // composer forever: this fallback force-clears the marker after a bound. The
+  // startedAt match keeps a stale timer from clearing a newer dispatch.
+  const localDispatchStartedAtRef = useRef<string | null>(null);
+  useEffect(() => {
+    localDispatchStartedAtRef.current = localDispatch?.startedAt ?? null;
+  }, [localDispatch]);
+  const localDispatchAckFallbackTimeoutRef = useRef<number | null>(null);
+  const armLocalDispatchAckFallback = useCallback(() => {
+    const armedStartedAt = localDispatchStartedAtRef.current;
+    if (armedStartedAt === null) {
+      return;
+    }
+    if (localDispatchAckFallbackTimeoutRef.current !== null) {
+      window.clearTimeout(localDispatchAckFallbackTimeoutRef.current);
+    }
+    localDispatchAckFallbackTimeoutRef.current = window.setTimeout(() => {
+      localDispatchAckFallbackTimeoutRef.current = null;
+      setLocalDispatch((current) =>
+        current &&
+        current.startedAt === armedStartedAt &&
+        !worktreeSetupHasError(current.worktreeSetup)
+          ? null
+          : current,
+      );
+    }, LOCAL_DISPATCH_ACK_TIMEOUT_MS);
+  }, []);
+  useEffect(
+    () => () => {
+      if (localDispatchAckFallbackTimeoutRef.current !== null) {
+        window.clearTimeout(localDispatchAckFallbackTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  // Mirror the outstanding dispatch into the cross-component pending-turn
+  // signal: the EventRouter catch-up watchdog re-syncs threads it believes are
+  // busy, and a lost running transition leaves that belief stale. This signal
+  // makes the watchdog re-check a thread the composer just wrote to even while
+  // the store still reports it idle.
+  const pendingDispatchStartedAt = localDispatch?.startedAt ?? null;
+  useEffect(() => {
+    if (activeThreadId === null || pendingDispatchStartedAt === null) {
+      return;
+    }
+    markPendingTurnDispatch(activeThreadId);
+    return () => clearPendingTurnDispatch(activeThreadId);
+  }, [activeThreadId, pendingDispatchStartedAt]);
+
   // Fallback cleanup for a failed worktree setup: clears the dispatch after the
   // error hold unless a newer dispatch already replaced it.
   const scheduleFailedWorktreeSetupDispatchReset = useCallback(() => {
@@ -8018,11 +8072,14 @@ export default function ChatView({
         });
       }
 
-      beginLocalDispatch(
-        baseBranchForWorktree
+      // Carry the expected message id so a snapshot rebuilt after an interim
+      // reset (thread switch, ack effect) keeps the message-echo ack signal.
+      beginLocalDispatch({
+        expectedUserMessageId: messageIdForSend,
+        ...(baseBranchForWorktree
           ? { worktreeSetupStepId: "start-session", setupScriptName: worktreeSetupScriptName }
-          : undefined,
-      );
+          : {}),
+      });
       const stagedTurnAttachments = await turnAttachmentsPromise;
       rememberCustomBinaryPathForDispatch({
         threadId: threadIdForSend,
@@ -8057,6 +8114,7 @@ export default function ChatView({
         }),
       );
       turnStartSucceeded = true;
+      armLocalDispatchAckFallback();
       // Steers on providers without native mid-turn steering interrupt the live
       // turn before re-dispatching; hold queued auto-dispatch through that gap
       // so it can't race the steer. The live session provider decides the
@@ -8583,6 +8641,7 @@ export default function ChatView({
 
     try {
       await dispatchPlanFollowUpTurn();
+      armLocalDispatchAckFallback();
       sendInFlightRef.current = false;
       return true;
     } catch (err) {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5795,13 +5795,25 @@ export default function ChatView({
   // turn. Once the turn RPC has resolved the server owns the turn, so a stream
   // that never echoes (dead subscription, lost event) must not lock the
   // composer forever: this fallback force-clears the marker after a bound. The
-  // startedAt match keeps a stale timer from clearing a newer dispatch.
+  // startedAt match keeps a stale timer from clearing a newer dispatch, and an
+  // already-acknowledged dispatch is left alone — the send spinner has
+  // released, and the awaiting-turn bridge legitimately keeps `localDispatch`
+  // alive until takeover or its own fail-open bound.
   const localDispatchStartedAtRef = useRef<string | null>(null);
   useEffect(() => {
     localDispatchStartedAtRef.current = localDispatch?.startedAt ?? null;
   }, [localDispatch]);
+  const serverAcknowledgedLocalDispatchRef = useRef(serverAcknowledgedLocalDispatch);
+  useEffect(() => {
+    serverAcknowledgedLocalDispatchRef.current = serverAcknowledgedLocalDispatch;
+  }, [serverAcknowledgedLocalDispatch]);
   const localDispatchAckFallbackTimeoutRef = useRef<number | null>(null);
-  const armLocalDispatchAckFallback = useCallback(() => {
+  const armLocalDispatchAckFallback = useCallback((threadIdForSend: ThreadId) => {
+    // The turn RPC has resolved, so the server provably owns a turn. Re-arm
+    // the cross-component watchdog marker here: pre-dispatch work (worktree
+    // creation, attachment uploads) can outlive the marker's age cap, and this
+    // is the moment its clock should restart.
+    markPendingTurnDispatch(threadIdForSend);
     const armedStartedAt = localDispatchStartedAtRef.current;
     if (armedStartedAt === null) {
       return;
@@ -5811,6 +5823,9 @@ export default function ChatView({
     }
     localDispatchAckFallbackTimeoutRef.current = window.setTimeout(() => {
       localDispatchAckFallbackTimeoutRef.current = null;
+      if (serverAcknowledgedLocalDispatchRef.current) {
+        return;
+      }
       setLocalDispatch((current) =>
         current &&
         current.startedAt === armedStartedAt &&
@@ -5834,13 +5849,20 @@ export default function ChatView({
   // busy, and a lost running transition leaves that belief stale. This signal
   // makes the watchdog re-check a thread the composer just wrote to even while
   // the store still reports it idle.
+  //
+  // Mark-only on purpose. The composer clears `localDispatch` on its own
+  // acknowledgement signals (message echo, ack fallback, takeover reset),
+  // all of which can fire off a stream that then stalls before the running
+  // transition — exactly the loss the marker exists to repair. So the marker
+  // must outlive `localDispatch`: the watchdog retires it once the projection
+  // confirms the thread busy, dispatch failures clear it at the dispatch
+  // site, and the age cap bounds any stray.
   const pendingDispatchStartedAt = localDispatch?.startedAt ?? null;
   useEffect(() => {
     if (activeThreadId === null || pendingDispatchStartedAt === null) {
       return;
     }
     markPendingTurnDispatch(activeThreadId);
-    return () => clearPendingTurnDispatch(activeThreadId);
   }, [activeThreadId, pendingDispatchStartedAt]);
 
   // Fallback cleanup for a failed worktree setup: clears the dispatch after the
@@ -8163,7 +8185,7 @@ export default function ChatView({
         }),
       );
       turnStartSucceeded = true;
-      armLocalDispatchAckFallback();
+      armLocalDispatchAckFallback(threadIdForSend);
       // Steers on providers without native mid-turn steering interrupt the live
       // turn before re-dispatching; hold queued auto-dispatch through that gap
       // so it can't race the steer. The live session provider decides the
@@ -8198,6 +8220,11 @@ export default function ChatView({
       // Surface the failure on whichever setup step was active (no-op for
       // sends without a worktree setup in flight).
       failLocalDispatchWorktreeSetup();
+      if (!turnStartSucceeded) {
+        // The turn RPC never resolved, so no server turn exists for the
+        // watchdog to recover — drop the marker armed when the dispatch began.
+        clearPendingTurnDispatch(threadIdForSend);
+      }
       if (createdServerThreadForLocalDraft && !turnStartSucceeded) {
         // This rollback cleans up a retryable draft promotion; do not tombstone the draft id.
         await api.orchestration
@@ -8690,7 +8717,7 @@ export default function ChatView({
 
     try {
       await dispatchPlanFollowUpTurn();
-      armLocalDispatchAckFallback();
+      armLocalDispatchAckFallback(threadIdForSend);
       sendInFlightRef.current = false;
       return true;
     } catch (err) {
@@ -8702,6 +8729,9 @@ export default function ChatView({
         err instanceof Error ? err.message : "Failed to send plan follow-up.",
       );
       sendInFlightRef.current = false;
+      // The turn RPC failed, so no server turn exists for the watchdog to
+      // recover — drop the marker armed when the dispatch began.
+      clearPendingTurnDispatch(threadIdForSend);
       resetLocalDispatch();
       return false;
     }
@@ -9074,7 +9104,14 @@ export default function ChatView({
           createdAt,
         });
       })
-      .then(() => api.orchestration.getShellSnapshot())
+      .then(() => {
+        // The turn RPC resolved for a thread this view never made active, so
+        // the dispatch-mirror effect cannot arm the watchdog marker for it —
+        // arm it here so a lost running transition on the new thread still
+        // forces catch-up after navigation subscribes it.
+        markPendingTurnDispatch(nextThreadId);
+        return api.orchestration.getShellSnapshot();
+      })
       .then((snapshot) => {
         syncServerShellSnapshot(snapshot);
         // Signal that the plan sidebar should open on the new thread.

--- a/apps/web/src/components/chat/ChatTranscriptPane.tsx
+++ b/apps/web/src/components/chat/ChatTranscriptPane.tsx
@@ -199,7 +199,7 @@ export function ChatTranscriptPane({
             key={activeThreadId}
             hasMessages={hasMessages}
             isWorking={isWorking}
-            workingLabel={workingLabel}
+            {...(workingLabel ? { workingLabel } : {})}
             worktreeSetup={worktreeSetup}
             activeTurnId={activeTurnId ?? null}
             activeTurnInProgress={activeTurnInProgress}

--- a/apps/web/src/pendingTurnDispatch.ts
+++ b/apps/web/src/pendingTurnDispatch.ts
@@ -18,9 +18,8 @@ import type { ThreadId } from "@synara/contracts";
 // can fire off a stream that then stalls before the running transition:
 // - armed when the composer begins a dispatch, and re-armed when the turn RPC
 //   resolves (pre-dispatch work like worktree setup can outlive the age cap);
-// - cleared by the watchdog once the store reports the thread busy (the
-//   projection has confirmed the turn, store-derived signals take over), or
-//   at the dispatch site when the turn RPC fails (no server turn exists);
+// - cleared at the dispatch site when the turn RPC fails or rollback confirms
+//   that no server turn remains;
 // - otherwise expired by the age cap below.
 const pendingDispatchArmedAtByThreadId = new Map<ThreadId, number>();
 

--- a/apps/web/src/pendingTurnDispatch.ts
+++ b/apps/web/src/pendingTurnDispatch.ts
@@ -10,13 +10,23 @@ import type { ThreadId } from "@synara/contracts";
 // The catch-up watchdog otherwise re-syncs only threads the store already
 // believes are busy. A lost `thread.session-set(running)` event corrupts
 // exactly that belief, so the watchdog needs a signal that does not come from
-// the store: "the composer dispatched a turn here and has seen no echo yet".
+// the store: "the composer dispatched a turn here that the projection has not
+// yet confirmed".
+//
+// Lifecycle — deliberately independent of the composer's own dispatch state,
+// which clears on UI-level acknowledgement (message echo, ack fallback) that
+// can fire off a stream that then stalls before the running transition:
+// - armed when the composer begins a dispatch, and re-armed when the turn RPC
+//   resolves (pre-dispatch work like worktree setup can outlive the age cap);
+// - cleared by the watchdog once the store reports the thread busy (the
+//   projection has confirmed the turn, store-derived signals take over), or
+//   at the dispatch site when the turn RPC fails (no server turn exists);
+// - otherwise expired by the age cap below.
 const pendingDispatchArmedAtByThreadId = new Map<ThreadId, number>();
 
-// Upper bound on how long a pending dispatch keeps forcing catch-up work. The
-// composer's own ack fallback clears its marker well before this; the age cap
-// only guards against a marker leaking (e.g. the owning view unmounted without
-// cleanup) turning into a permanent poll.
+// Upper bound on how long a pending dispatch keeps forcing catch-up work.
+// Covers both leaked markers and a dispatched turn that settles before the
+// watchdog ever observes a busy state (nothing else clears that marker).
 export const PENDING_TURN_DISPATCH_MAX_AGE_MS = 30_000;
 
 export function markPendingTurnDispatch(threadId: ThreadId): void {

--- a/apps/web/src/pendingTurnDispatch.ts
+++ b/apps/web/src/pendingTurnDispatch.ts
@@ -1,0 +1,44 @@
+// FILE: pendingTurnDispatch.ts
+// Purpose: Cross-component signal that a thread has a composer turn dispatch
+//          the thread event stream has not yet acknowledged.
+// Layer: Web subscription utility
+// Exports: mark/clear/has helpers consumed by ChatView and the EventRouter
+//          catch-up watchdog.
+
+import type { ThreadId } from "@synara/contracts";
+
+// The catch-up watchdog otherwise re-syncs only threads the store already
+// believes are busy. A lost `thread.session-set(running)` event corrupts
+// exactly that belief, so the watchdog needs a signal that does not come from
+// the store: "the composer dispatched a turn here and has seen no echo yet".
+const pendingDispatchArmedAtByThreadId = new Map<ThreadId, number>();
+
+// Upper bound on how long a pending dispatch keeps forcing catch-up work. The
+// composer's own ack fallback clears its marker well before this; the age cap
+// only guards against a marker leaking (e.g. the owning view unmounted without
+// cleanup) turning into a permanent poll.
+export const PENDING_TURN_DISPATCH_MAX_AGE_MS = 30_000;
+
+export function markPendingTurnDispatch(threadId: ThreadId): void {
+  pendingDispatchArmedAtByThreadId.set(threadId, Date.now());
+}
+
+export function clearPendingTurnDispatch(threadId: ThreadId): void {
+  pendingDispatchArmedAtByThreadId.delete(threadId);
+}
+
+export function hasPendingTurnDispatch(threadId: ThreadId): boolean {
+  const armedAt = pendingDispatchArmedAtByThreadId.get(threadId);
+  if (armedAt === undefined) {
+    return false;
+  }
+  if (Date.now() - armedAt > PENDING_TURN_DISPATCH_MAX_AGE_MS) {
+    pendingDispatchArmedAtByThreadId.delete(threadId);
+    return false;
+  }
+  return true;
+}
+
+export function resetPendingTurnDispatchesForTests(): void {
+  pendingDispatchArmedAtByThreadId.clear();
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -92,6 +92,7 @@ import {
   getThreadDetailResumeCursor,
   setThreadDetailResumeCursor,
 } from "../threadDetailResumeCursors";
+import { hasPendingTurnDispatch } from "../pendingTurnDispatch";
 import { canApplyThreadSnapshot, selectOrphanedThreadDetailIds } from "./-threadDetailOwnership";
 import { getThreadFromState, getThreadsFromState } from "../threadDerivation";
 import { useAppDensity } from "../hooks/useAppDensity";
@@ -950,7 +951,15 @@ function isThreadDetailEventForThread(event: OrchestrationEvent, threadId: Threa
   );
 }
 
+// Both catch-up predicates also honor the composer's pending-dispatch signal:
+// the store-derived checks describe what the client already believes, and the
+// exact failure being repaired is a lost `thread.session-set(running)` event
+// that leaves that belief stale. A turn dispatched with no observed echo must
+// force re-sync regardless of what the store says.
 function shouldPollThreadDetailCatchup(threadId: ThreadId): boolean {
+  if (hasPendingTurnDispatch(threadId)) {
+    return true;
+  }
   const thread = getThreadFromState(useStore.getState(), threadId);
   return (
     thread?.session?.orchestrationStatus === "running" || thread?.latestTurn?.state === "running"
@@ -958,6 +967,9 @@ function shouldPollThreadDetailCatchup(threadId: ThreadId): boolean {
 }
 
 function shouldReconcileThreadProjection(threadId: ThreadId): boolean {
+  if (hasPendingTurnDispatch(threadId)) {
+    return true;
+  }
   const thread = getThreadFromState(useStore.getState(), threadId);
   return (
     thread?.session?.orchestrationStatus === "starting" ||
@@ -1144,6 +1156,29 @@ function EventRouter() {
       );
     };
 
+    // Single choke point for handing a thread detail event to the reducer.
+    // The reducer silently ignores detail events for a thread the store no
+    // longer holds (pruned by a shell full sync, evicted, deleted), and domain
+    // events never create thread records, so advancing the fence and resume
+    // cursor first would vouch for events that never landed — a later cursor
+    // resume would then skip them forever. When the thread is missing, drop
+    // the resume bookkeeping and re-snapshot through the projection instead.
+    const applyFencedThreadEvent = (threadId: ThreadId, event: OrchestrationEvent): boolean => {
+      if (!getThreadFromState(useStore.getState(), threadId)) {
+        threadSnapshotSequenceById.delete(threadId);
+        pendingThreadEventsById.delete(threadId);
+        clearThreadDetailResumeCursor(threadId);
+        if (subscribedThreadIds.has(threadId)) {
+          void reconcileThreadProjection(threadId).catch(() => undefined);
+        }
+        return false;
+      }
+      threadSnapshotSequenceById.set(threadId, event.sequence);
+      advanceThreadDetailResumeCursor(threadId, event.sequence);
+      queueDomainEvent(event);
+      return true;
+    };
+
     const flushThreadBuffer = (threadId: ThreadId, snapshotSequence: number) => {
       const pendingEvents = pendingThreadEventsById.get(threadId) ?? [];
       pendingThreadEventsById.delete(threadId);
@@ -1151,9 +1186,9 @@ function EventRouter() {
       for (const event of pendingEvents.toSorted((left, right) => left.sequence - right.sequence)) {
         if (event.sequence > latestThreadSequence) {
           latestThreadSequence = event.sequence;
-          threadSnapshotSequenceById.set(threadId, latestThreadSequence);
-          advanceThreadDetailResumeCursor(threadId, latestThreadSequence);
-          queueDomainEvent(event);
+          if (!applyFencedThreadEvent(threadId, event)) {
+            return;
+          }
         }
       }
     };
@@ -1497,9 +1532,9 @@ function EventRouter() {
             if (event.sequence <= latestThreadSequence) {
               continue;
             }
-            threadSnapshotSequenceById.set(threadId, event.sequence);
-            advanceThreadDetailResumeCursor(threadId, event.sequence);
-            queueDomainEvent(event);
+            if (!applyFencedThreadEvent(threadId, event)) {
+              break;
+            }
           }
         })
         .finally(() => {
@@ -1718,13 +1753,13 @@ function EventRouter() {
       if (item.event.sequence <= latestThreadSequence) {
         return;
       }
-      threadSnapshotSequenceById.set(threadId, item.event.sequence);
-      advanceThreadDetailResumeCursor(threadId, item.event.sequence);
+      if (!applyFencedThreadEvent(threadId, item.event)) {
+        return;
+      }
       nextThreadProjectionReconcileAtById.set(
         threadId,
         Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
       );
-      queueDomainEvent(item.event);
     });
     const unsubThreadStreamFailure = onThreadStreamFailure((failure) => {
       const threadId = ThreadId.makeUnsafe(failure.threadId);

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -92,7 +92,7 @@ import {
   getThreadDetailResumeCursor,
   setThreadDetailResumeCursor,
 } from "../threadDetailResumeCursors";
-import { clearPendingTurnDispatch, hasPendingTurnDispatch } from "../pendingTurnDispatch";
+import { hasPendingTurnDispatch } from "../pendingTurnDispatch";
 import { canApplyThreadSnapshot, selectOrphanedThreadDetailIds } from "./-threadDetailOwnership";
 import { getThreadFromState, getThreadsFromState } from "../threadDerivation";
 import { useAppDensity } from "../hooks/useAppDensity";
@@ -957,38 +957,29 @@ function isThreadDetailEventForThread(event: OrchestrationEvent, threadId: Threa
 // that leaves that belief stale. A turn dispatched with no observed echo must
 // force re-sync regardless of what the store says.
 //
-// The watchdog also owns retiring that signal. The composer clears its own
-// dispatch state on UI-level acknowledgement (a user-message echo can arrive
-// on a stream that then stalls before the running transition), which is too
-// early — the marker must hold until the projection itself confirms the
-// thread busy, and these predicates are where that confirmation is observed.
-// Once the store reports busy the store-derived checks take over seamlessly.
-// A turn that settles before any busy state is ever observed leaves the
-// marker to the age cap, which bounds the redundant catch-up polls.
+// A store-derived busy state may belong to an earlier queued turn, so it cannot
+// safely retire the marker for the new dispatch. The marker therefore remains
+// independent until its age cap expires or the dispatch site proves that no
+// server turn remains.
 function shouldPollThreadDetailCatchup(threadId: ThreadId): boolean {
   const thread = getThreadFromState(useStore.getState(), threadId);
-  if (
+  return (
     thread?.session?.orchestrationStatus === "running" ||
-    thread?.latestTurn?.state === "running"
-  ) {
-    clearPendingTurnDispatch(threadId);
-    return true;
-  }
-  return hasPendingTurnDispatch(threadId);
+    thread?.latestTurn?.state === "running" ||
+    hasPendingTurnDispatch(threadId)
+  );
 }
 
 function shouldReconcileThreadProjection(threadId: ThreadId): boolean {
   const thread = getThreadFromState(useStore.getState(), threadId);
-  if (
+  return (
     thread?.session?.orchestrationStatus === "starting" ||
     thread?.session?.orchestrationStatus === "running" ||
     thread?.latestTurn?.state === "running" ||
-    thread?.messages.some((message) => message.role === "assistant" && message.streaming) === true
-  ) {
-    clearPendingTurnDispatch(threadId);
-    return true;
-  }
-  return hasPendingTurnDispatch(threadId);
+    thread?.messages.some((message) => message.role === "assistant" && message.streaming) ===
+      true ||
+    hasPendingTurnDispatch(threadId)
+  );
 }
 
 function isTerminalThreadSessionStatus(status: string): boolean {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -92,7 +92,7 @@ import {
   getThreadDetailResumeCursor,
   setThreadDetailResumeCursor,
 } from "../threadDetailResumeCursors";
-import { hasPendingTurnDispatch } from "../pendingTurnDispatch";
+import { clearPendingTurnDispatch, hasPendingTurnDispatch } from "../pendingTurnDispatch";
 import { canApplyThreadSnapshot, selectOrphanedThreadDetailIds } from "./-threadDetailOwnership";
 import { getThreadFromState, getThreadsFromState } from "../threadDerivation";
 import { useAppDensity } from "../hooks/useAppDensity";
@@ -956,27 +956,39 @@ function isThreadDetailEventForThread(event: OrchestrationEvent, threadId: Threa
 // exact failure being repaired is a lost `thread.session-set(running)` event
 // that leaves that belief stale. A turn dispatched with no observed echo must
 // force re-sync regardless of what the store says.
+//
+// The watchdog also owns retiring that signal. The composer clears its own
+// dispatch state on UI-level acknowledgement (a user-message echo can arrive
+// on a stream that then stalls before the running transition), which is too
+// early — the marker must hold until the projection itself confirms the
+// thread busy, and these predicates are where that confirmation is observed.
+// Once the store reports busy the store-derived checks take over seamlessly.
+// A turn that settles before any busy state is ever observed leaves the
+// marker to the age cap, which bounds the redundant catch-up polls.
 function shouldPollThreadDetailCatchup(threadId: ThreadId): boolean {
-  if (hasPendingTurnDispatch(threadId)) {
+  const thread = getThreadFromState(useStore.getState(), threadId);
+  if (
+    thread?.session?.orchestrationStatus === "running" ||
+    thread?.latestTurn?.state === "running"
+  ) {
+    clearPendingTurnDispatch(threadId);
     return true;
   }
-  const thread = getThreadFromState(useStore.getState(), threadId);
-  return (
-    thread?.session?.orchestrationStatus === "running" || thread?.latestTurn?.state === "running"
-  );
+  return hasPendingTurnDispatch(threadId);
 }
 
 function shouldReconcileThreadProjection(threadId: ThreadId): boolean {
-  if (hasPendingTurnDispatch(threadId)) {
-    return true;
-  }
   const thread = getThreadFromState(useStore.getState(), threadId);
-  return (
+  if (
     thread?.session?.orchestrationStatus === "starting" ||
     thread?.session?.orchestrationStatus === "running" ||
     thread?.latestTurn?.state === "running" ||
     thread?.messages.some((message) => message.role === "assistant" && message.streaming) === true
-  );
+  ) {
+    clearPendingTurnDispatch(threadId);
+    return true;
+  }
+  return hasPendingTurnDispatch(threadId);
 }
 
 function isTerminalThreadSessionStatus(status: string): boolean {

--- a/apps/web/src/storeProjection.test.ts
+++ b/apps/web/src/storeProjection.test.ts
@@ -1635,13 +1635,14 @@ describe("thread detail sync state", () => {
     expect(removed.threadDetailSyncById?.[threadId]).toBeUndefined();
   });
 
-  it("keeps applied detail authoritative over a late stream failure", () => {
+  it("downgrades a synced thread when its stream dies, without touching applied detail", () => {
     const synced = syncServerThreadDetailHotPath(makeState(makeThread()), makeReadModelThread({}));
 
     const afterFailure = markThreadDetailSyncFailedInClientState(synced, threadId);
 
-    expect(afterFailure).toBe(synced);
-    expect(afterFailure.threadDetailSyncById?.[threadId]).toBe("synced");
+    expect(afterFailure.threadDetailSyncById?.[threadId]).toBe("failed");
+    expect(afterFailure.messageByThreadId).toBe(synced.messageByThreadId);
+    expect(afterFailure.threadShellById).toBe(synced.threadShellById);
   });
 
   it("records a failure for an unsynced thread and clears it only from the failed state", () => {

--- a/apps/web/src/storeProjection.ts
+++ b/apps/web/src/storeProjection.ts
@@ -650,10 +650,11 @@ export function markThreadDetailSyncFailedInClientState(
   state: AppState,
   threadId: ThreadId,
 ): AppState {
-  // Applied detail outranks a late stream failure: keep rendering the data we have.
-  if (state.threadDetailSyncById?.[threadId] === "synced") {
-    return state;
-  }
+  // A "synced" thread downgrades too: the caller reports a terminally dead
+  // stream, and keeping "synced" would let the client treat frozen cached
+  // detail as live. Cached timeline entries keep rendering regardless
+  // (resolveThreadDetailHydration treats a populated timeline as ready), so
+  // the downgrade only surfaces the failure, it never blanks applied detail.
   return writeThreadDetailSyncState(state, threadId, "failed");
 }
 

--- a/apps/web/src/wsTransport.ts
+++ b/apps/web/src/wsTransport.ts
@@ -574,6 +574,12 @@ export class WsTransport {
   private readonly streamCompletionRetryTimers = new Map<string, number>();
   private readonly activeThreadStreamInputs = new Map<string, unknown>();
   private shellSubscribed = false;
+  // Whether the active shell stream has already delivered its snapshot item.
+  // An explicit subscribeShell while this is true must restart the stream (the
+  // caller reset its fence and needs a new snapshot); while false, the pending
+  // snapshot of the just-started stream will satisfy the caller, so the call
+  // is absorbed (bootstrap coalescing).
+  private shellSnapshotDelivered = false;
   private readonly threadSubscriptions = new Map<string, unknown>();
   private compatibility: WsBootstrapNegotiateResult | null = null;
   private compatibilityIssue: WsCompatibilityError | null = null;
@@ -625,7 +631,7 @@ export class WsTransport {
         this.shellSubscribed = true;
         this.resetStreamCapacityRetry("orchestration.shell");
         this.resetStreamCompletionRetry("orchestration.shell");
-        this.startShellStream(client);
+        await this.startShellStream(client, this.shellSnapshotDelivered);
         return undefined as T;
       }
       if (method === ORCHESTRATION_WS_METHODS.subscribeThread) {
@@ -1131,7 +1137,7 @@ export class WsTransport {
       this.startChannelStream(channel as WsPushChannel);
     }
     if (this.shellSubscribed) {
-      this.startShellStream(client);
+      void this.startShellStream(client);
     }
     // Refreshing only overwrites existing keys, so iterating the live key set
     // is safe here.
@@ -1304,20 +1310,38 @@ export class WsTransport {
     );
   }
 
-  private startShellStream(client: RpcClientInstance): void {
+  private async startShellStream(client: RpcClientInstance, forceRestart = false): Promise<void> {
     if (this.disposed || !this.shellSubscribed) return;
+    if (forceRestart) {
+      // An explicit resubscribe expects a fresh snapshot: the caller has reset
+      // its shell fence and buffers events until one arrives. A surviving
+      // stream whose snapshot was already delivered would dedupe the start and
+      // leave the caller buffering forever.
+      const sessionVersion = this.sessionVersion;
+      await this.stopStream("orchestration.shell", { resetCapacityRetry: false });
+      if (this.disposed || this.sessionVersion !== sessionVersion || !this.shellSubscribed) {
+        return;
+      }
+    }
     const restartShell = () => {
       if (!this.shellSubscribed) return;
       void this.getClient()
         .then((nextClient) => this.startShellStream(nextClient))
         .catch((error) => console.warn("WebSocket RPC shell stream failed to restart", error));
     };
+    if (!this.streamCleanups.has("orchestration.shell")) {
+      this.shellSnapshotDelivered = false;
+    }
     this.startStream(
       client,
       "orchestration.shell",
       client[ORCHESTRATION_WS_METHODS.subscribeShell]({}),
-      (event: OrchestrationShellStreamItem) =>
-        this.emit(ORCHESTRATION_WS_CHANNELS.shellEvent, event),
+      (event: OrchestrationShellStreamItem) => {
+        if (event.kind === "snapshot") {
+          this.shellSnapshotDelivered = true;
+        }
+        this.emit(ORCHESTRATION_WS_CHANNELS.shellEvent, event);
+      },
       restartShell,
     );
   }


### PR DESCRIPTION
## Problem

Sending a message sometimes left the UI stuck on the loading spinner inside the send button — never advancing to thinking/working — while the turn ran fine server-side; only a page reload revealed the answer. Root cause: the spinner's "acknowledged" signal was inferred purely from store changes delivered over a per-thread subscription stream, and that stream could silently die with no repair path:

- A subscribe racing the projector on a freshly created thread failed with non-retryable `THREAD_SNAPSHOT_NOT_FOUND`.
- A fast resubscribe racing the old stream's async lease release died with `STREAM_DUPLICATE_SUBSCRIPTION` (`unsubscribeThread` is a server no-op, so release timing depends on stream scope finalization).
- The resume cursor advanced before the reducer applied events, permanently vouching for events the store silently dropped.
- The catch-up watchdog only re-synced threads the store already believed were busy — exactly the belief a lost `thread.session-set(running)` corrupts.

## Fixes

**1. Bounded spinner (`ChatView.tsx`, `ChatView.logic.ts`)** — once the turn RPC resolves the server provably owns the turn, so a 10s fallback force-clears the dispatch marker if the stream never echoes. Healthy sends are unchanged; the spinner can no longer stick forever.

**2. Pending-dispatch watchdog signal (`pendingTurnDispatch.ts`, `__root.tsx`)** — the composer marks a store-independent "dispatched, no echo yet" signal per thread; the catch-up watchdog and projection reconcile honor it and re-sync via authoritative RPC snapshot, bypassing the dead stream. This is what actually fetches the missing turn instead of just unsticking the button.

**3. Server stream admission (`wsRpc.ts`, `wsStreamAdmission.ts`)** — `subscribeThread` waits up to 5s (100ms polls) for the projector to commit a new thread's detail read model before failing; safe because the cursor-safe stream attaches its live tap before evaluating the snapshot effect. Duplicate admission switched to last-subscription-wins takeover: a same-key resubscribe evicts the prior lease, and the evicted lease's late release is a no-op. `replacedDuplicateTotal` replaces `rejectedDuplicateTotal` in the ledger.

**4. Client stream hygiene (`__root.tsx`, `wsTransport.ts`, `storeProjection.ts`)** — new `applyFencedThreadEvent` choke point advances fence/cursor only when the store actually holds the thread (otherwise drops the bookkeeping and re-snapshots); explicit `subscribeShell` force-restarts a stream whose snapshot was already consumed (while still absorbing the bootstrap welcome-coalescing double-call whose snapshot is in flight); a terminally dead thread stream downgrades the thread's `"synced"` detail state — never blanking rendered detail, since hydration treats a populated timeline as ready.

## Verification

- `bun fmt`, `bun lint` (0 errors; all warnings pre-existing), `bun typecheck` — all pass.
- `wsStreamAdmission.test.ts` 6/6 (three tests rewritten for takeover semantics), `wsTransport.test.ts` 36/36, `storeProjection.test.ts` + `ChatView.logic.test.ts` + `threadDetailResumeCursors.test.ts` 241/241 (one storeProjection test updated for the sync-state downgrade).
- Browser: `EventRouter.browser.tsx` 14/14; `ChatView.browser.tsx` 77/77 non-geometry tests (the 8 failing `[geometry:linux]` tests are Linux-font-metric tests excluded from macOS runs by the stable config, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live WebSocket stream admission, thread subscription bootstrap, and event-router cursor semantics—areas where races can drop or duplicate events—but changes are bounded with timeouts and tests for takeover/eviction behavior.
> 
> **Overview**
> Fixes the case where a turn succeeds server-side but the UI keeps the send spinner because thread detail never arrives over a broken or racing WebSocket subscription.
> 
> **Server:** `subscribeThread` **polls up to 5s** for the projector to commit a new thread’s detail snapshot before `THREAD_SNAPSHOT_NOT_FOUND`. Stream admission switches from rejecting duplicate same-key subscriptions to **last-subscription-wins**: evicted leases get an `evicted` latch that **interrupts** the old guarded stream so caps stay honest (`replacedDuplicateTotal` replaces duplicate rejections).
> 
> **Web client:** After the turn RPC resolves, a **10s fallback** clears `localDispatch` if the stream never echoes; **`pendingTurnDispatch`** (30s cap) drives catch-up/reconcile when the store doesn’t yet show “busy.” **`applyFencedThreadEvent`** only advances resume cursor/fence when the thread still exists in the store. Terminally failed streams **downgrade** `"synced"` to `"failed"` without wiping cached timeline. **`subscribeShell`** force-restarts when a snapshot was already delivered so explicit resubscribes aren’t stuck buffering forever.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fa7fa82ec1c11c472e96d1b00ad3c50e9ea747d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->