### PR TITLE
Fix handoff provider eligibility

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -96,7 +96,11 @@ import {
   supportsThreadCompaction,
 } from "~/lib/providerDiscoveryReactQuery";
 import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
-import { serverConfigQueryOptions, serverQueryKeys } from "~/lib/serverReactQuery";
+import {
+  serverConfigQueryOptions,
+  serverQueryKeys,
+  serverSettingsQueryOptions,
+} from "~/lib/serverReactQuery";
 import { useRefreshProviderStatusesNow } from "~/hooks/useProviderStatusRefresh";
 import { SINGLE_CHAT_PANE_SCOPE_ID } from "~/lib/chatPaneScope";
 import {
@@ -111,7 +115,6 @@ import {
 import { getLocalFolderBrowseRootPath, isLocalFolderMentionQuery } from "~/lib/localFolderMentions";
 import {
   findProviderStatus,
-  isProviderUsable,
   normalizeCustomBinaryPath,
   normalizeProviderStatusForLocalConfig,
   resolveProviderSendAvailabilityWithRefresh,
@@ -2177,6 +2180,7 @@ export default function ChatView({
   const featureFlags = useFeatureFlags();
   const showDebugTaskBanner = import.meta.env.DEV && featureFlags["show-debug-task-banner"];
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
+  const serverSettingsQuery = useQuery(serverSettingsQueryOptions());
   const composerModelHintByProvider = useMemo<Record<ProviderKind, string | null>>(() => {
     const threadModelSelection = activeThread?.modelSelection ?? null;
     const projectModelSelection = activeProject?.defaultModelSelection ?? null;
@@ -3873,11 +3877,13 @@ export default function ChatView({
   const handoffTargetProviders = useMemo(
     () =>
       activeThread
-        ? resolveAvailableHandoffTargetProviders(activeThread.modelSelection.provider).filter(
-            (provider) => isProviderUsable(findProviderStatus(providerStatuses, provider)),
-          )
+        ? resolveAvailableHandoffTargetProviders({
+            sourceProvider: activeThread.modelSelection.provider,
+            providerSettings: serverSettingsQuery.data?.providers,
+            providerStatuses,
+          })
         : [],
-    [activeThread, providerStatuses],
+    [activeThread, providerStatuses, serverSettingsQuery.data?.providers],
   );
   const handoffActionLabel = activeThread ? "Hand off thread" : "Create handoff thread";
   const activeProviderStatus = useMemo(

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -87,7 +87,6 @@ import {
   ThreadId,
   type GitStatusResult,
   type ResolvedKeybindingsConfig,
-  type ServerProviderStatus,
   WS_GITHUB_PROJECT_PROVISIONING_CAPABILITY,
 } from "@synara/contracts";
 import { isGenericChatThreadTitle } from "@synara/shared/chatThreads";
@@ -217,6 +216,7 @@ import {
 import { useHandleNewChat } from "../hooks/useHandleNewChat";
 import { useHandleNewStudioChat } from "../hooks/useHandleNewStudioChat";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
+import { useProviderStatusesForLocalConfig } from "../hooks/useProviderStatusesForLocalConfig";
 import { useThreadHandoff } from "../hooks/useThreadHandoff";
 import { useFeedbackDialogStore } from "../feedbackDialogStore";
 import { openExternalLink } from "~/lib/linkChips";
@@ -423,7 +423,6 @@ const CollapseAllIcon = createCentralIconComponent("minimize-45");
 const SortFilterIcon = createCentralIconComponent("filter-2");
 
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
-const EMPTY_PROVIDER_STATUSES: readonly ServerProviderStatus[] = [];
 const subscribeGitHubProvisioningCapability = (listener: () => void) =>
   onNativeApiServerCapabilitiesChange(listener);
 const readGitHubProvisioningCapability = () =>
@@ -1558,11 +1557,7 @@ export default function Sidebar() {
     select: (config) => config.cwd ?? null,
   });
   const serverCwd = serverCwdQuery.data ?? null;
-  const providerStatusesQuery = useQuery({
-    ...serverConfigQueryOptions(),
-    select: (config) => config.providers,
-  });
-  const providerStatuses = providerStatusesQuery.data ?? EMPTY_PROVIDER_STATUSES;
+  const providerStatuses = useProviderStatusesForLocalConfig();
   const serverSettingsQuery = useQuery(serverSettingsQueryOptions());
   // Declared next to `keybindings` (rather than further down) because the project-row render
   // helpers above read these labels. A const declared after the closure that captures it

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -87,6 +87,7 @@ import {
   ThreadId,
   type GitStatusResult,
   type ResolvedKeybindingsConfig,
+  type ServerProviderStatus,
   WS_GITHUB_PROJECT_PROVISIONING_CAPABILITY,
 } from "@synara/contracts";
 import { isGenericChatThreadTitle } from "@synara/shared/chatThreads";
@@ -146,7 +147,7 @@ import {
   resolveNewThreadModelPrefetchCwd,
   resolveNewThreadModelPrefetchProvider,
 } from "../lib/providerModelPrefetch";
-import { serverConfigQueryOptions } from "../lib/serverReactQuery";
+import { serverConfigQueryOptions, serverSettingsQueryOptions } from "../lib/serverReactQuery";
 import {
   onNativeApiServerCapabilitiesChange,
   readNativeApi,
@@ -422,6 +423,7 @@ const CollapseAllIcon = createCentralIconComponent("minimize-45");
 const SortFilterIcon = createCentralIconComponent("filter-2");
 
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
+const EMPTY_PROVIDER_STATUSES: readonly ServerProviderStatus[] = [];
 const subscribeGitHubProvisioningCapability = (listener: () => void) =>
   onNativeApiServerCapabilitiesChange(listener);
 const readGitHubProvisioningCapability = () =>
@@ -1556,6 +1558,12 @@ export default function Sidebar() {
     select: (config) => config.cwd ?? null,
   });
   const serverCwd = serverCwdQuery.data ?? null;
+  const providerStatusesQuery = useQuery({
+    ...serverConfigQueryOptions(),
+    select: (config) => config.providers,
+  });
+  const providerStatuses = providerStatusesQuery.data ?? EMPTY_PROVIDER_STATUSES;
+  const serverSettingsQuery = useQuery(serverSettingsQueryOptions());
   // Declared next to `keybindings` (rather than further down) because the project-row render
   // helpers above read these labels. A const declared after the closure that captures it
   // widens its inferred mutable range and makes React Compiler drop the memoization of every
@@ -2939,7 +2947,11 @@ export default function Sidebar() {
       });
       const threadStatus = threadSummary ? resolveThreadStatusForSidebar(threadSummary) : null;
       const handoffTargets = canHandoff
-        ? resolveAvailableHandoffTargetProviders(thread.modelSelection.provider)
+        ? resolveAvailableHandoffTargetProviders({
+            sourceProvider: thread.modelSelection.provider,
+            providerSettings: serverSettingsQuery.data?.providers,
+            providerStatuses,
+          })
         : [];
       const handoffItems = handoffTargets.map((provider, index) => ({
         id: `handoff:${provider}`,
@@ -3132,7 +3144,9 @@ export default function Sidebar() {
       openRenameThreadDialog,
       pinnedThreadIdSet,
       projectCwdById,
+      providerStatuses,
       resolveThreadStatusForSidebar,
+      serverSettingsQuery.data?.providers,
       sidebarThreadSummaryById,
       toggleThreadPinned,
     ],

--- a/apps/web/src/hooks/useThreadHandoff.ts
+++ b/apps/web/src/hooks/useThreadHandoff.ts
@@ -3,6 +3,7 @@
 // Layer: Web hook
 // Exports: useThreadHandoff
 
+import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { type ProviderKind } from "@synara/contracts";
 import { useComposerDraftStore } from "../composerDraftStore";
@@ -12,11 +13,12 @@ import {
   buildThreadHandoffImportedActivities,
   buildThreadHandoffImportedMessages,
   canCreateThreadHandoff,
-  resolveAvailableHandoffTargetProviders,
+  isEligibleHandoffTargetProvider,
   resolveThreadHandoffModelSelection,
   resolveThreadHandoffTitle,
 } from "../lib/threadHandoff";
 import { resolveProviderSendAvailabilityWithRefresh } from "../lib/providerAvailability";
+import { serverSettingsQueryOptions } from "../lib/serverReactQuery";
 import { newCommandId, newThreadId } from "../lib/utils";
 import { readNativeApi } from "../nativeApi";
 import { useStore } from "../store";
@@ -28,6 +30,7 @@ export function useThreadHandoff() {
   const syncServerShellSnapshot = useStore((store) => store.syncServerShellSnapshot);
   const providerStatuses = useProviderStatusesForLocalConfig();
   const refreshProviderStatuses = useRefreshProviderStatusesNow();
+  const serverSettingsQuery = useQuery(serverSettingsQueryOptions());
 
   const createThreadHandoff = async (
     thread: Thread,
@@ -46,20 +49,24 @@ export function useThreadHandoff() {
     if (!canCreateThreadHandoff({ thread })) {
       throw new Error("This thread cannot be handed off yet.");
     }
-    if (
-      !resolveAvailableHandoffTargetProviders(thread.modelSelection.provider).includes(
-        targetProvider,
-      )
-    ) {
-      throw new Error("This handoff target is not available for the current thread.");
-    }
     const targetAvailability = await resolveProviderSendAvailabilityWithRefresh({
       provider: targetProvider,
       statuses: providerStatuses,
       refreshStatuses: () => refreshProviderStatuses({ silent: true }),
     });
-    if (!targetAvailability.usable) {
-      throw new Error(targetAvailability.unavailableReason);
+    if (
+      !isEligibleHandoffTargetProvider({
+        sourceProvider: thread.modelSelection.provider,
+        targetProvider,
+        targetProviderEnabled: serverSettingsQuery.data?.providers[targetProvider].enabled,
+        targetProviderStatus: targetAvailability.status,
+      })
+    ) {
+      throw new Error(
+        targetAvailability.usable
+          ? "This handoff target is not available for the current thread."
+          : targetAvailability.unavailableReason,
+      );
     }
 
     const nextThreadId = newThreadId();

--- a/apps/web/src/lib/threadHandoff.test.ts
+++ b/apps/web/src/lib/threadHandoff.test.ts
@@ -1,8 +1,11 @@
 import {
+  DEFAULT_SERVER_SETTINGS_VIEW,
   EventId,
   MessageId,
   type ModelSelection,
   type OrchestrationThreadActivity,
+  type ProviderKind,
+  type ServerProviderStatus,
 } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 import {
@@ -88,24 +91,58 @@ describe("threadHandoff", () => {
     expect(imported.map(({ kind }) => kind)).toEqual(["context-window.updated"]);
   });
 
-  it("lists all supported handoff targets except the active provider", () => {
-    const providers = [
-      "codex",
-      "claudeAgent",
-      "cursor",
-      "antigravity",
-      "grok",
-      "droid",
-      "kilo",
-      "opencode",
-      "pi",
-    ] as const;
+  it("excludes disabled, missing, unavailable, and unauthenticated handoff targets", () => {
+    const readyStatus = (
+      provider: ProviderKind,
+      overrides: Partial<ServerProviderStatus> = {},
+    ): ServerProviderStatus => ({
+      provider,
+      status: "ready",
+      available: true,
+      authStatus: "authenticated",
+      checkedAt: "2026-08-07T12:00:00.000Z",
+      ...overrides,
+    });
+    const providerSettings = {
+      ...DEFAULT_SERVER_SETTINGS_VIEW.providers,
+      antigravity: {
+        ...DEFAULT_SERVER_SETTINGS_VIEW.providers.antigravity,
+        enabled: false,
+      },
+    };
 
-    for (const source of providers) {
-      expect(resolveAvailableHandoffTargetProviders(source)).toEqual(
-        providers.filter((provider) => provider !== source),
-      );
-    }
+    expect(
+      resolveAvailableHandoffTargetProviders({
+        sourceProvider: "codex",
+        providerSettings,
+        providerStatuses: [
+          readyStatus("codex"),
+          readyStatus("claudeAgent"),
+          readyStatus("cursor", { available: false, status: "error" }),
+          readyStatus("antigravity"),
+          readyStatus("grok", { authStatus: "unauthenticated" }),
+          readyStatus("kilo", { authStatus: "unknown" }),
+        ],
+      }),
+    ).toEqual(["claudeAgent", "kilo"]);
+  });
+
+  it("does not expose targets before enabled-provider settings are available", () => {
+    expect(
+      resolveAvailableHandoffTargetProviders({
+        sourceProvider: "codex",
+        providerSettings: undefined,
+        providerStatuses: [
+          {
+            provider: "claudeAgent",
+            status: "ready",
+            available: true,
+            authStatus: "authenticated",
+            checkedAt: "2026-08-07T12:00:00.000Z",
+          },
+        ],
+      }),
+    ).toEqual([]);
   });
 
   it("preserves the source thread title for the created handoff thread", () => {

--- a/apps/web/src/lib/threadHandoff.ts
+++ b/apps/web/src/lib/threadHandoff.ts
@@ -10,6 +10,8 @@ import {
   PROVIDER_DISPLAY_NAMES,
   type ModelSelection,
   type ProviderKind,
+  type ServerProviderStatus,
+  type ServerSettingsView,
   type ThreadHandoffImportedMessage,
 } from "@synara/contracts";
 import { getDefaultModel } from "@synara/shared/model";
@@ -17,6 +19,7 @@ import { type Thread } from "../types";
 import { DEFAULT_PROVIDER_ORDER } from "../providerOrdering";
 import { stripEmbeddedAssistantSelections } from "./assistantSelections";
 import { extractTrailingBrowserAnnotations } from "./browserAnnotations";
+import { findProviderStatus, isProviderUsable } from "./providerAvailability";
 import { randomUUID } from "./utils";
 
 const IMPORTABLE_THREAD_ACTIVITY_KINDS = new Set([
@@ -39,10 +42,33 @@ function isImportableThreadActivity(
   return IMPORTABLE_THREAD_ACTIVITY_KINDS.has(activity.kind);
 }
 
-export function resolveAvailableHandoffTargetProviders(
-  sourceProvider: ProviderKind,
-): ReadonlyArray<ProviderKind> {
-  return DEFAULT_PROVIDER_ORDER.filter((provider) => provider !== sourceProvider);
+export function isEligibleHandoffTargetProvider(input: {
+  readonly sourceProvider: ProviderKind;
+  readonly targetProvider: ProviderKind;
+  readonly targetProviderEnabled: boolean | null | undefined;
+  readonly targetProviderStatus: ServerProviderStatus | null | undefined;
+}): boolean {
+  return (
+    input.targetProvider !== input.sourceProvider &&
+    input.targetProviderEnabled === true &&
+    input.targetProviderStatus?.provider === input.targetProvider &&
+    isProviderUsable(input.targetProviderStatus)
+  );
+}
+
+export function resolveAvailableHandoffTargetProviders(input: {
+  readonly sourceProvider: ProviderKind;
+  readonly providerSettings: ServerSettingsView["providers"] | null | undefined;
+  readonly providerStatuses: readonly ServerProviderStatus[];
+}): ReadonlyArray<ProviderKind> {
+  return DEFAULT_PROVIDER_ORDER.filter((targetProvider) =>
+    isEligibleHandoffTargetProvider({
+      sourceProvider: input.sourceProvider,
+      targetProvider,
+      targetProviderEnabled: input.providerSettings?.[targetProvider].enabled,
+      targetProviderStatus: findProviderStatus(input.providerStatuses, targetProvider),
+    }),
+  );
 }
 
 export function resolveThreadHandoffBadgeLabel(thread: Pick<Thread, "handoff">): string | null {


### PR DESCRIPTION
## Summary

- centralize provider handoff eligibility around explicit enablement plus current install/availability and authentication status
- reuse the same policy in the chat header, sidebar context menu, and execution guard
- keep handoff targets empty while provider settings/status are missing instead of exposing the full provider list
- add regression coverage for disabled, missing, unavailable, unauthenticated, and healthy targets

## Root cause

`resolveAvailableHandoffTargetProviders` only removed the active provider from the global provider order. ChatView added its own status filter, but Sidebar and the execution pre-check still consumed the unfiltered result. Status alone was also insufficient because local custom-binary normalization can temporarily make a disabled provider look usable.

## Verification

- `bun run --cwd apps/web test src/lib/threadHandoff.test.ts src/lib/providerAvailability.test.ts` (20 passed)
- `bun run --cwd apps/web test src/components/chatHotPath.compiler.test.ts -t 'compiles (ChatView|Sidebar)'` (2 passed)
- `git diff --check`

Closes #559

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible handoff menus and the create-handoff guard; behavior is more restrictive but aligned across UI and execution, with regression tests.
> 
> **Overview**
> **Thread handoff** no longer lists every provider except the current one. `resolveAvailableHandoffTargetProviders` now takes **server provider settings** and **live statuses**, and only returns targets that are **explicitly enabled**, **not the source provider**, and **usable** (available + authenticated per `isProviderUsable`). If settings are still loading, the list stays **empty** instead of showing the full catalog.
> 
> A shared **`isEligibleHandoffTargetProvider`** helper drives the same rules in **ChatView** (header handoff UI), **Sidebar** (context-menu targets), and **`useThreadHandoff`** (pre-dispatch guard), replacing ad-hoc status-only filtering in chat and unfiltered lists elsewhere.
> 
> Tests in `threadHandoff.test.ts` now cover disabled, unavailable, unauthenticated, and missing-settings cases instead of asserting “all providers minus source.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcbfe0e5a817a8256a0c6cf02ceff9cf9aa78970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->