### PR TITLE
Fix OpenCode host policy re-injection after resume

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -12,7 +12,10 @@ import { Deferred, Effect, Exit, Fiber, Layer, Scope, Stream } from "effect";
 import { describe, it, expect, vi } from "vitest";
 
 import { ServerConfig } from "../../config.ts";
-import { SYNARA_HARNESS_POLICY_MARKER } from "../../agentGateway/harnessPolicy.ts";
+import {
+  SYNARA_HARNESS_POLICY_MARKER,
+  SYNARA_HARNESS_POLICY_VERSION,
+} from "../../agentGateway/harnessPolicy.ts";
 import {
   AgentGatewayCredentials,
   type AgentGatewayCredentialsShape,
@@ -267,6 +270,17 @@ function createMockOpenCodeRuntime(options?: {
   };
 }
 
+function makeOpenCodeAdapterTestLayer(runtime: OpenCodeRuntimeShape) {
+  return makeOpenCodeAdapterLive({ runtime }).pipe(
+    Layer.provideMerge(ServerConfig.layerTest(process.cwd(), { prefix: "opencode-adapter-test-" })),
+    Layer.provideMerge(NodeServices.layer),
+  );
+}
+
+function promptContainsHarnessPolicy(prompt: Record<string, unknown> | undefined): boolean {
+  return JSON.stringify(prompt).includes(SYNARA_HARNESS_POLICY_MARKER);
+}
+
 function makeGatewayCredentials(options?: {
   readonly cancelSessionTurnRequests?: (token: string, turnId: string) => Promise<void>;
 }) {
@@ -519,6 +533,188 @@ describe("normalizeOpenCodeTokenUsage", () => {
       maxTokens: 200,
       lastUsedTokens: 200,
     });
+  });
+});
+
+describe("OpenCode host policy delivery", () => {
+  const modelSelection = { provider: "opencode", model: "openai/gpt-5" } as const;
+
+  it("injects the host policy exactly once for a new native session", async () => {
+    const runtime = createMockOpenCodeRuntime();
+    const threadId = asThreadId("thread-host-policy-new-session");
+
+    const cursors = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId,
+          runtimeMode: "full-access",
+        });
+        const first = yield* adapter.sendTurn({
+          threadId,
+          input: "first turn",
+          attachments: [],
+          modelSelection,
+        });
+        const second = yield* adapter.sendTurn({
+          threadId,
+          input: "second turn",
+          attachments: [],
+          modelSelection,
+        });
+        return [first.resumeCursor, second.resumeCursor];
+      }).pipe(Effect.provide(makeOpenCodeAdapterTestLayer(runtime.runtime))),
+    );
+
+    expect(runtime.promptCalls.map(promptContainsHarnessPolicy)).toEqual([true, false]);
+    for (const cursor of cursors) {
+      expect(cursor).toMatchObject({
+        openCodeSessionId: "opencode-session-1",
+        harnessPolicyDelivery: {
+          sessionId: "opencode-session-1",
+          policyVersion: SYNARA_HARNESS_POLICY_VERSION,
+          gatewayControlAvailable: false,
+        },
+      });
+    }
+  });
+
+  it("does not re-inject the host policy when the same native session is restarted", async () => {
+    const runtime = createMockOpenCodeRuntime();
+    const threadId = asThreadId("thread-host-policy-same-session-restart");
+
+    const resumedSession = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId,
+          runtimeMode: "full-access",
+        });
+        const first = yield* adapter.sendTurn({
+          threadId,
+          input: "first turn",
+          attachments: [],
+          modelSelection,
+        });
+        const resumed = yield* adapter.startSession({
+          provider: "opencode",
+          threadId,
+          runtimeMode: "full-access",
+          resumeCursor: first.resumeCursor,
+        });
+        yield* adapter.sendTurn({
+          threadId,
+          input: "after restart",
+          attachments: [],
+          modelSelection,
+        });
+        return resumed;
+      }).pipe(Effect.provide(makeOpenCodeAdapterTestLayer(runtime.runtime))),
+    );
+
+    expect(runtime.promptCalls.map(promptContainsHarnessPolicy)).toEqual([true, false]);
+    expect(resumedSession.resumeCursor).toMatchObject({
+      openCodeSessionId: "opencode-session-1",
+      harnessPolicyDelivery: {
+        sessionId: "opencode-session-1",
+        policyVersion: SYNARA_HARNESS_POLICY_VERSION,
+        gatewayControlAvailable: false,
+      },
+    });
+  });
+
+  it("injects the host policy when the native session id changes", async () => {
+    const runtime = createMockOpenCodeRuntime();
+    const threadId = asThreadId("thread-host-policy-changed-session");
+
+    const secondCursor = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId,
+          runtimeMode: "full-access",
+        });
+        const first = yield* adapter.sendTurn({
+          threadId,
+          input: "first turn",
+          attachments: [],
+          modelSelection,
+        });
+        const firstCursor = first.resumeCursor as Record<string, unknown>;
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId,
+          runtimeMode: "full-access",
+          resumeCursor: {
+            ...firstCursor,
+            openCodeSessionId: "opencode-session-2",
+          },
+        });
+        const second = yield* adapter.sendTurn({
+          threadId,
+          input: "new native session",
+          attachments: [],
+          modelSelection,
+        });
+        return second.resumeCursor;
+      }).pipe(Effect.provide(makeOpenCodeAdapterTestLayer(runtime.runtime))),
+    );
+
+    expect(runtime.promptCalls.map(promptContainsHarnessPolicy)).toEqual([true, true]);
+    expect(secondCursor).toMatchObject({
+      openCodeSessionId: "opencode-session-2",
+      harnessPolicyDelivery: {
+        sessionId: "opencode-session-2",
+        policyVersion: SYNARA_HARNESS_POLICY_VERSION,
+        gatewayControlAvailable: false,
+      },
+    });
+  });
+
+  it("rehydrates host policy state after adapter teardown and recreation", async () => {
+    const runtime = createMockOpenCodeRuntime();
+    const threadId = asThreadId("thread-host-policy-adapter-recreation");
+
+    const resumeCursor = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId,
+          runtimeMode: "full-access",
+        });
+        const first = yield* adapter.sendTurn({
+          threadId,
+          input: "before teardown",
+          attachments: [],
+          modelSelection,
+        });
+        return first.resumeCursor;
+      }).pipe(Effect.provide(makeOpenCodeAdapterTestLayer(runtime.runtime))),
+    );
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId,
+          runtimeMode: "full-access",
+          resumeCursor,
+        });
+        yield* adapter.sendTurn({
+          threadId,
+          input: "after recreation",
+          attachments: [],
+          modelSelection,
+        });
+      }).pipe(Effect.provide(makeOpenCodeAdapterTestLayer(runtime.runtime))),
+    );
+
+    expect(runtime.promptCalls.map(promptContainsHarnessPolicy)).toEqual([true, false]);
   });
 });
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -625,6 +625,124 @@ describe("OpenCode host policy delivery", () => {
     });
   });
 
+  it("retries host policy delivery after the first prompt is rejected", async () => {
+    let promptAttempt = 0;
+    const runtime = createMockOpenCodeRuntime({
+      promptAsync: async () => {
+        promptAttempt += 1;
+        if (promptAttempt === 1) {
+          throw new Error("prompt rejected");
+        }
+        return { data: null };
+      },
+    });
+    const threadId = asThreadId("thread-host-policy-rejected-prompt");
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId,
+          runtimeMode: "full-access",
+        });
+        const firstExit = yield* Effect.exit(
+          adapter.sendTurn({
+            threadId,
+            input: "rejected turn",
+            attachments: [],
+            modelSelection,
+          }),
+        );
+        const [failedSession] = yield* adapter.listSessions();
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId,
+          runtimeMode: "full-access",
+          resumeCursor: failedSession?.resumeCursor,
+        });
+        const retry = yield* adapter.sendTurn({
+          threadId,
+          input: "retry turn",
+          attachments: [],
+          modelSelection,
+        });
+        return {
+          firstFailed: Exit.isFailure(firstExit),
+          failedCursor: failedSession?.resumeCursor,
+          retryCursor: retry.resumeCursor,
+        };
+      }).pipe(Effect.provide(makeOpenCodeAdapterTestLayer(runtime.runtime))),
+    );
+
+    expect(result.firstFailed).toBe(true);
+    expect(result.failedCursor).not.toHaveProperty("harnessPolicyDelivery");
+    expect(runtime.promptCalls.map(promptContainsHarnessPolicy)).toEqual([true, true]);
+    expect(result.retryCursor).toMatchObject({
+      harnessPolicyDelivery: {
+        sessionId: "opencode-session-1",
+        policyVersion: SYNARA_HARNESS_POLICY_VERSION,
+      },
+    });
+  });
+
+  it("re-injects the host policy when an in-memory restart has a stale policy version", async () => {
+    const runtime = createMockOpenCodeRuntime();
+    const threadId = asThreadId("thread-host-policy-stale-version-restart");
+
+    const secondCursor = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId,
+          runtimeMode: "full-access",
+        });
+        const first = yield* adapter.sendTurn({
+          threadId,
+          input: "first turn",
+          attachments: [],
+          modelSelection,
+        });
+        const firstCursor = first.resumeCursor as {
+          readonly openCodeSessionId: string;
+          readonly cwd: string;
+          readonly harnessPolicyDelivery: {
+            readonly sessionId: string;
+            readonly gatewayControlAvailable: boolean;
+          };
+        };
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId,
+          runtimeMode: "full-access",
+          resumeCursor: {
+            ...firstCursor,
+            harnessPolicyDelivery: {
+              ...firstCursor.harnessPolicyDelivery,
+              policyVersion: "stale-policy-version",
+            },
+          },
+        });
+        const second = yield* adapter.sendTurn({
+          threadId,
+          input: "after policy update",
+          attachments: [],
+          modelSelection,
+        });
+        return second.resumeCursor;
+      }).pipe(Effect.provide(makeOpenCodeAdapterTestLayer(runtime.runtime))),
+    );
+
+    expect(runtime.promptCalls.map(promptContainsHarnessPolicy)).toEqual([true, true]);
+    expect(secondCursor).toMatchObject({
+      harnessPolicyDelivery: {
+        sessionId: "opencode-session-1",
+        policyVersion: SYNARA_HARNESS_POLICY_VERSION,
+      },
+    });
+  });
+
   it("injects the host policy when the native session id changes", async () => {
     const runtime = createMockOpenCodeRuntime();
     const threadId = asThreadId("thread-host-policy-changed-session");

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -166,6 +166,7 @@ interface OpenCodeResumeCursor {
 
 interface OpenCodeSessionContext {
   harnessPolicyDelivered?: boolean;
+  pendingHarnessPolicyTurnId: TurnId | undefined;
   readonly gatewayControlAvailable: boolean;
   gatewaySessionLease?: AgentGatewaySessionLease;
   session: ProviderSession;
@@ -749,6 +750,9 @@ const clearActiveTurnState = Effect.fn("clearOpenCodeActiveTurnState")(function*
   if (options?.cancelGatewayTurn !== false) {
     yield* cancelAgentGatewayTurn(context.gatewaySessionLease, context.activeTurnId);
   }
+  if (context.pendingHarnessPolicyTurnId === context.activeTurnId) {
+    context.pendingHarnessPolicyTurnId = undefined;
+  }
   context.activeTurnId = undefined;
   context.activeTurnEventSerial = 0;
   context.activeTurnProviderActivitySerial = 0;
@@ -1002,6 +1006,22 @@ function buildOpenCodeResumeCursor(input: {
         }
       : {}),
   };
+}
+
+function markOpenCodeHarnessPolicyDelivered(context: OpenCodeSessionContext, turnId: TurnId): void {
+  if (context.pendingHarnessPolicyTurnId !== turnId) {
+    return;
+  }
+  context.pendingHarnessPolicyTurnId = undefined;
+  context.harnessPolicyDelivered = true;
+  updateProviderSession(context, {
+    resumeCursor: buildOpenCodeResumeCursor({
+      openCodeSessionId: context.openCodeSessionId,
+      cwd: context.directory,
+      harnessPolicyDelivered: true,
+      gatewayControlAvailable: context.gatewayControlAvailable,
+    }),
+  });
 }
 
 function openCodeRecord(value: unknown): Record<string, unknown> | undefined {
@@ -2081,6 +2101,9 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           context.client.session.prompt(input.promptInput),
         ).pipe(
           Effect.mapError(toAdapterRequestError),
+          Effect.tap(() =>
+            Effect.sync(() => markOpenCodeHarnessPolicyDelivered(context, input.turnId)),
+          ),
           Effect.flatMap((response) =>
             Effect.gen(function* () {
               if (yield* Ref.get(context.stopped)) {
@@ -2164,6 +2187,9 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           context.client.session.promptAsync(input.promptInput),
         ).pipe(
           Effect.mapError(toAdapterRequestError),
+          Effect.tap(() =>
+            Effect.sync(() => markOpenCodeHarnessPolicyDelivered(context, input.turnId)),
+          ),
           Effect.as(null),
           Effect.catch((requestError) =>
             Effect.gen(function* () {
@@ -2344,6 +2370,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           // User-message echoes should not disable prompt recovery; track provider-side
           // activity separately for the "accepted but nothing started" watchdog.
           if (isOpenCodeTurnProviderActivityEvent(context, event)) {
+            markOpenCodeHarnessPolicyDelivered(context, turnId);
             markOpenCodeTurnProviderActivity(context, turnId);
           }
         }
@@ -3756,13 +3783,10 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
                 // capability require a fresh, truthful host-policy delivery.
                 const harnessPolicyDelivered =
                   resumedSessionId === started.openCodeSessionId &&
-                  (isMatchingHarnessPolicyDelivery(persistedHarnessPolicyDelivery, {
+                  isMatchingHarnessPolicyDelivery(persistedHarnessPolicyDelivery, {
                     sessionId: started.openCodeSessionId,
                     gatewayControlAvailable: started.gatewayControlAvailable,
-                  }) ||
-                    (existing?.openCodeSessionId === started.openCodeSessionId &&
-                      existing.harnessPolicyDelivered === true &&
-                      existing.gatewayControlAvailable === started.gatewayControlAvailable));
+                  });
                 if (options?.beforeSessionInstall) {
                   yield* options.beforeSessionInstall;
                 }
@@ -3800,6 +3824,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
 
                 const context: OpenCodeSessionContext = {
                   ...(harnessPolicyDelivered ? { harnessPolicyDelivered: true } : {}),
+                  pendingHarnessPolicyTurnId: undefined,
                   session,
                   gatewayControlAvailable: started.gatewayControlAvailable,
                   ...(started.gatewayControlAvailable && agentGatewaySessionLease
@@ -3937,10 +3962,13 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
             issue: `${adapterConfig.displayName} turns require text input or at least one attachment.`,
           });
         }
-        const harnessPolicy = takeSynaraHarnessPolicyForProviderSession(context, {
-          provider,
-          scopedGatewayConnectionAvailable: context.gatewayControlAvailable,
-        });
+        const harnessPolicy = takeSynaraHarnessPolicyForProviderSession(
+          { harnessPolicyDelivered: context.harnessPolicyDelivered },
+          {
+            provider,
+            scopedGatewayConnectionAvailable: context.gatewayControlAvailable,
+          },
+        );
         const providerText = [harnessPolicy, text].filter(Boolean).join("\n\n");
 
         const requestedAgent =
@@ -3956,6 +3984,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         yield* applyPermissionInteractionMode(context, interactionMode);
 
         context.activeTurnId = turnId;
+        context.pendingHarnessPolicyTurnId = harnessPolicy === null ? undefined : turnId;
         context.activeTurnEventSerial = 0;
         context.activeTurnProviderActivitySerial = 0;
         context.activeTurnCompletionActivitySerial = 0;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -36,7 +36,10 @@ import {
   ProviderAdapterSessionNotFoundError,
   ProviderAdapterValidationError,
 } from "../Errors.ts";
-import { takeSynaraHarnessPolicyForProviderSession } from "../../agentGateway/harnessPolicy.ts";
+import {
+  SYNARA_HARNESS_POLICY_VERSION,
+  takeSynaraHarnessPolicyForProviderSession,
+} from "../../agentGateway/harnessPolicy.ts";
 import { buildOpenCodeMcpServer, SYNARA_MCP_SERVER_NAME } from "../../agentGateway/mcpInjection.ts";
 import { AgentGatewayCredentials } from "../../agentGateway/Services/AgentGatewayCredentials.ts";
 import {
@@ -147,6 +150,18 @@ type OpenCodeSubscribedEvent =
 interface OpenCodeTurnSnapshot {
   readonly id: TurnId;
   readonly items: Array<unknown>;
+}
+
+interface OpenCodeHarnessPolicyDelivery {
+  readonly sessionId: string;
+  readonly policyVersion: string;
+  readonly gatewayControlAvailable: boolean;
+}
+
+interface OpenCodeResumeCursor {
+  readonly openCodeSessionId: string;
+  readonly cwd: string;
+  readonly harnessPolicyDelivery?: OpenCodeHarnessPolicyDelivery;
 }
 
 interface OpenCodeSessionContext {
@@ -921,6 +936,72 @@ function extractResumeCwd(resumeCursor: unknown): string | undefined {
     return resumeCursor.cwd.trim();
   }
   return undefined;
+}
+
+function extractHarnessPolicyDelivery(
+  resumeCursor: unknown,
+): OpenCodeHarnessPolicyDelivery | undefined {
+  if (
+    resumeCursor &&
+    typeof resumeCursor === "object" &&
+    "harnessPolicyDelivery" in resumeCursor &&
+    resumeCursor.harnessPolicyDelivery &&
+    typeof resumeCursor.harnessPolicyDelivery === "object"
+  ) {
+    const delivery = resumeCursor.harnessPolicyDelivery;
+    if (
+      "sessionId" in delivery &&
+      typeof delivery.sessionId === "string" &&
+      delivery.sessionId.trim().length > 0 &&
+      "policyVersion" in delivery &&
+      typeof delivery.policyVersion === "string" &&
+      delivery.policyVersion.trim().length > 0 &&
+      "gatewayControlAvailable" in delivery &&
+      typeof delivery.gatewayControlAvailable === "boolean"
+    ) {
+      return {
+        sessionId: delivery.sessionId.trim(),
+        policyVersion: delivery.policyVersion.trim(),
+        gatewayControlAvailable: delivery.gatewayControlAvailable,
+      };
+    }
+  }
+  return undefined;
+}
+
+function isMatchingHarnessPolicyDelivery(
+  delivery: OpenCodeHarnessPolicyDelivery | undefined,
+  input: {
+    readonly sessionId: string;
+    readonly gatewayControlAvailable: boolean;
+  },
+): boolean {
+  return (
+    delivery?.sessionId === input.sessionId &&
+    delivery.policyVersion === SYNARA_HARNESS_POLICY_VERSION &&
+    delivery.gatewayControlAvailable === input.gatewayControlAvailable
+  );
+}
+
+function buildOpenCodeResumeCursor(input: {
+  readonly openCodeSessionId: string;
+  readonly cwd: string;
+  readonly harnessPolicyDelivered?: boolean;
+  readonly gatewayControlAvailable: boolean;
+}): OpenCodeResumeCursor {
+  return {
+    openCodeSessionId: input.openCodeSessionId,
+    cwd: input.cwd,
+    ...(input.harnessPolicyDelivered
+      ? {
+          harnessPolicyDelivery: {
+            sessionId: input.openCodeSessionId,
+            policyVersion: SYNARA_HARNESS_POLICY_VERSION,
+            gatewayControlAvailable: input.gatewayControlAvailable,
+          },
+        }
+      : {}),
+  };
 }
 
 function openCodeRecord(value: unknown): Record<string, unknown> | undefined {
@@ -3528,13 +3609,14 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
             input.modelSelection?.provider === adapterConfig.provider
               ? input.modelSelection.options?.variant
               : undefined;
+          const resumedSessionId = extractResumeSessionId(input.resumeCursor);
+          const persistedHarnessPolicyDelivery = extractHarnessPolicyDelivery(input.resumeCursor);
           const existing = sessions.get(input.threadId);
           if (existing) {
             yield* stopOpenCodeContext(existing);
             sessions.delete(input.threadId);
           }
 
-          const resumedSessionId = extractResumeSessionId(input.resumeCursor);
           // OpenCode's MCP registry is process/directory scoped, not session
           // scoped. Issue a gateway token only for a managed server isolated to
           // this exact Synara thread.
@@ -3670,6 +3752,17 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
                 }
 
                 const started = startedExit.value;
+                // A session id alone is not enough: policy revisions or a changed gateway
+                // capability require a fresh, truthful host-policy delivery.
+                const harnessPolicyDelivered =
+                  resumedSessionId === started.openCodeSessionId &&
+                  (isMatchingHarnessPolicyDelivery(persistedHarnessPolicyDelivery, {
+                    sessionId: started.openCodeSessionId,
+                    gatewayControlAvailable: started.gatewayControlAvailable,
+                  }) ||
+                    (existing?.openCodeSessionId === started.openCodeSessionId &&
+                      existing.harnessPolicyDelivered === true &&
+                      existing.gatewayControlAvailable === started.gatewayControlAvailable));
                 if (options?.beforeSessionInstall) {
                   yield* options.beforeSessionInstall;
                 }
@@ -3695,12 +3788,18 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
                   cwd: directory,
                   ...(input.modelSelection ? { model: input.modelSelection.model } : {}),
                   threadId: input.threadId,
-                  resumeCursor: { openCodeSessionId: started.openCodeSessionId, cwd: directory },
+                  resumeCursor: buildOpenCodeResumeCursor({
+                    openCodeSessionId: started.openCodeSessionId,
+                    cwd: directory,
+                    harnessPolicyDelivered,
+                    gatewayControlAvailable: started.gatewayControlAvailable,
+                  }),
                   createdAt,
                   updatedAt: createdAt,
                 };
 
                 const context: OpenCodeSessionContext = {
+                  ...(harnessPolicyDelivered ? { harnessPolicyDelivered: true } : {}),
                   session,
                   gatewayControlAvailable: started.gatewayControlAvailable,
                   ...(started.gatewayControlAvailable && agentGatewaySessionLease
@@ -3881,6 +3980,12 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
             status: "running",
             activeTurnId: turnId,
             model: modelSelection?.model ?? context.session.model,
+            resumeCursor: buildOpenCodeResumeCursor({
+              openCodeSessionId: context.openCodeSessionId,
+              cwd: context.directory,
+              harnessPolicyDelivered: context.harnessPolicyDelivered,
+              gatewayControlAvailable: context.gatewayControlAvailable,
+            }),
           },
           { clearLastError: true },
         );
@@ -3953,7 +4058,12 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         return {
           threadId: input.threadId,
           turnId,
-          resumeCursor: { openCodeSessionId: context.openCodeSessionId, cwd: context.directory },
+          resumeCursor: buildOpenCodeResumeCursor({
+            openCodeSessionId: context.openCodeSessionId,
+            cwd: context.directory,
+            harnessPolicyDelivered: context.harnessPolicyDelivered,
+            gatewayControlAvailable: context.gatewayControlAvailable,
+          }),
         };
       });
 


### PR DESCRIPTION
## Summary

- persist OpenCode host-policy delivery metadata in the provider resume cursor
- restore delivery state only when the native session id, policy version, and gateway capability still match
- keep the live session cursor synchronized so runtime-event persistence cannot regress the marker
- cover new sessions, same-session restarts, changed native session ids, and adapter teardown/recreation

## Root cause

`harnessPolicyDelivered` lived only on the in-memory OpenCode provider context. Recreating that context during restart/resume reset the flag, so the next prompt re-injected `<synara_host_context>` into the same native OpenCode session.

## Verification

- `bun run --cwd apps/server test -- src/provider/Layers/OpenCodeAdapter.test.ts src/agentGateway/harnessPolicy.test.ts` (78 tests passed)
- `bunx oxfmt --check apps/server/src/provider/Layers/OpenCodeAdapter.ts apps/server/src/provider/Layers/OpenCodeAdapter.test.ts`
- `git diff --check`

Closes #510

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OpenCode prompt composition and persisted resume state; incorrect matching could skip needed policy updates or re-inject host context, but behavior is heavily covered by new tests.
> 
> **Overview**
> Fixes duplicate `<synara_host_context>` injection when OpenCode adapter context was recreated on resume/restart while the same native session kept running.
> 
> **Resume cursor** now carries `harnessPolicyDelivery` (native session id, `SYNARA_HARNESS_POLICY_VERSION`, gateway-control flag). On `startSession`, delivery is restored only when that metadata still matches the resumed session; stale versions, changed session ids, or gateway capability mismatches trigger a fresh injection.
> 
> **Turn lifecycle** tracks `pendingHarnessPolicyTurnId` and marks delivery complete only after a successful prompt or provider activity—failed prompts leave the cursor without delivery metadata so the next turn retries. The live `resumeCursor` is kept in sync during turns so persisted state cannot regress the marker.
> 
> Adds focused adapter tests for one-shot injection, restarts, rejected prompts, stale policy versions, session id changes, and adapter teardown/recreation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af348f7da0db0c490fff325ce072ddd30a9a9af0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->