### PR TITLE
[codex] Fix Grok ACP auth and permission handling

### DIFF
--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -1090,6 +1090,7 @@ export function makeGrokAdapter(
             resume: resumeSessionId !== undefined,
             model: effectiveGrokSettings.model,
             reasoningEffort: effectiveGrokSettings.reasoningEffort,
+            alwaysApprove: input.runtimeMode === "full-access",
             binaryPath: effectiveGrokSettings.binaryPath ?? "grok",
           });
 
@@ -1097,6 +1098,7 @@ export function makeGrokAdapter(
             grokSettings: effectiveGrokSettings,
             childProcessSpawner,
             cwd,
+            runtimeMode: input.runtimeMode,
             ...(resumeSessionId ? { resumeSessionId } : {}),
             clientInfo: { name: "Synara", version: "0.0.0" },
             // Grok registers client hooks from session setup metadata, not

--- a/apps/server/src/provider/acp/AcpRuntimeModel.test.ts
+++ b/apps/server/src/provider/acp/AcpRuntimeModel.test.ts
@@ -164,6 +164,48 @@ describe("AcpRuntimeModel", () => {
     }
   });
 
+  it("preserves Grok prompt-policy denial text on failed shell tools", () => {
+    const pending = parseSessionUpdateEvent({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tool-denied",
+        kind: "execute",
+        status: "pending",
+        rawInput: { command: "git pull" },
+      },
+    } satisfies Acp.SessionNotification);
+    const failed = parseSessionUpdateEvent({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tool-denied",
+        status: "failed",
+        content: [
+          {
+            type: "content",
+            content: {
+              type: "text",
+              text: "denied by prompt policy (tool not pre-approved)",
+            },
+          },
+        ],
+      },
+    } satisfies Acp.SessionNotification);
+
+    const pendingEvent = pending.events[0];
+    const failedEvent = failed.events[0];
+    expect(pendingEvent?._tag).toBe("ToolCallUpdated");
+    expect(failedEvent?._tag).toBe("ToolCallUpdated");
+    if (pendingEvent?._tag === "ToolCallUpdated" && failedEvent?._tag === "ToolCallUpdated") {
+      expect(mergeToolCallState(pendingEvent.toolCall, failedEvent.toolCall)).toMatchObject({
+        status: "failed",
+        command: "git pull",
+        detail: "denied by prompt policy (tool not pre-approved)",
+      });
+    }
+  });
+
   it("derives useful tool details when Cursor sends empty rawInput placeholders", () => {
     const searchCompleted = parseSessionUpdateEvent({
       sessionId: "session-1",

--- a/apps/server/src/provider/acp/AcpRuntimeModel.ts
+++ b/apps/server/src/provider/acp/AcpRuntimeModel.ts
@@ -441,12 +441,19 @@ function makeToolCallState(
   }
   const kindSpecificTitleIsGeneric = isProviderGenericToolTitle(title, kind);
   const fallbackDetail =
-    command ??
-    locationDetail ??
-    structuredContent ??
-    outputDetail ??
-    (kindSpecificTitleIsGeneric ? undefined : normalizedTitle) ??
-    textContent;
+    status === "failed"
+      ? (textContent ??
+        outputDetail ??
+        command ??
+        locationDetail ??
+        structuredContent ??
+        (kindSpecificTitleIsGeneric ? undefined : normalizedTitle))
+      : (command ??
+        locationDetail ??
+        structuredContent ??
+        outputDetail ??
+        (kindSpecificTitleIsGeneric ? undefined : normalizedTitle) ??
+        textContent);
   const actionTitle = deriveGenericToolActionTitle(kind, status);
   const hasPresentationSeed =
     title !== undefined ||

--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -3,6 +3,7 @@ import * as AcpErrors from "./AcpErrors.ts";
 import type * as Acp from "@agentclientprotocol/sdk";
 import { afterEach, describe, expect, it } from "vitest";
 
+import { resolveAcpPermissionPolicy } from "./AcpAdapterSupport.ts";
 import {
   applyGrokAcpModelSelection,
   buildGrokAcpSpawnInput,
@@ -19,7 +20,7 @@ function initializeWithAuthMethods(ids: ReadonlyArray<string>): Acp.InitializeRe
 
 describe("buildGrokAcpSpawnInput", () => {
   it("builds the default Grok ACP command", () => {
-    expect(buildGrokAcpSpawnInput(undefined, "/tmp/project")).toMatchObject({
+    expect(buildGrokAcpSpawnInput(undefined, "/tmp/project", "approval-required")).toMatchObject({
       command: "grok",
       args: ["--permission-mode", "default", "agent", "--no-leader", "stdio"],
       cwd: "/tmp/project",
@@ -28,7 +29,11 @@ describe("buildGrokAcpSpawnInput", () => {
 
   it("uses the configured Grok binary path", () => {
     expect(
-      buildGrokAcpSpawnInput({ binaryPath: "/usr/local/bin/grok" }, "/tmp/project"),
+      buildGrokAcpSpawnInput(
+        { binaryPath: "/usr/local/bin/grok" },
+        "/tmp/project",
+        "approval-required",
+      ),
     ).toMatchObject({
       command: "/usr/local/bin/grok",
       args: ["--permission-mode", "default", "agent", "--no-leader", "stdio"],
@@ -44,6 +49,7 @@ describe("buildGrokAcpSpawnInput", () => {
         reasoningEffort: "high",
       },
       "/tmp/project",
+      "approval-required",
     );
 
     expect(spawn).toMatchObject({
@@ -62,6 +68,17 @@ describe("buildGrokAcpSpawnInput", () => {
       cwd: "/tmp/project",
     });
     expect(spawn.args).not.toContain("--always-approve");
+  });
+
+  it("uses Grok's process-scoped approval override only for Full Access", () => {
+    expect(buildGrokAcpSpawnInput(undefined, "/tmp/project", "full-access").args).toEqual([
+      "--permission-mode",
+      "default",
+      "agent",
+      "--no-leader",
+      "--always-approve",
+      "stdio",
+    ]);
   });
 });
 
@@ -114,7 +131,7 @@ describe("resolveGrokAcpAuthMethodId", () => {
     ).resolves.toBe("cached_token");
   });
 
-  it("fails clearly when Grok exposes no supported ACP auth method", async () => {
+  it("identifies an interactive-only advertisement as missing headless credentials", async () => {
     delete process.env.XAI_API_KEY;
     delete process.env.GROK_CODE_XAI_API_KEY;
 
@@ -123,7 +140,82 @@ describe("resolveGrokAcpAuthMethodId", () => {
     );
 
     expect(error).toBeInstanceOf(AcpErrors.AcpRequestError);
-    expect(error.message).toBe("Grok ACP authentication is unavailable.");
+    expect(error.message).toContain("not authenticated for headless ACP");
+    expect(error.message).toContain("browser_login");
+  });
+
+  it("explains when an advertised API-key method has no configured key", async () => {
+    delete process.env.XAI_API_KEY;
+    delete process.env.GROK_CODE_XAI_API_KEY;
+
+    const error = await Effect.runPromise(
+      resolveGrokAcpAuthMethodId(initializeWithAuthMethods(["xai.api_key"])).pipe(Effect.flip),
+    );
+
+    expect(error.message).toContain("XAI_API_KEY is not set");
+  });
+
+  it("distinguishes an API-key advertisement mismatch from missing credentials", async () => {
+    process.env.XAI_API_KEY = "xai-test-key";
+
+    const error = await Effect.runPromise(
+      resolveGrokAcpAuthMethodId(initializeWithAuthMethods(["grok.com"])).pipe(Effect.flip),
+    );
+
+    expect(error.message).toContain("did not advertise API-key authentication");
+    expect(error.message).toContain("grok.com");
+  });
+
+  it("reports unknown or empty auth advertisements as a compatibility mismatch", async () => {
+    delete process.env.XAI_API_KEY;
+    delete process.env.GROK_CODE_XAI_API_KEY;
+
+    const unknownError = await Effect.runPromise(
+      resolveGrokAcpAuthMethodId(initializeWithAuthMethods(["future_auth"])).pipe(Effect.flip),
+    );
+    const emptyError = await Effect.runPromise(
+      resolveGrokAcpAuthMethodId(initializeWithAuthMethods([])).pipe(Effect.flip),
+    );
+
+    expect(unknownError.message).toContain("advertised: future_auth");
+    expect(emptyError.message).toContain("advertised: none");
+  });
+});
+
+describe("Grok ACP permission policy", () => {
+  const options = [
+    { kind: "allow_once", optionId: "allow-once" },
+    { kind: "reject_once", optionId: "reject-once" },
+  ] as const;
+
+  it("surfaces approval-required requests to Synara", () => {
+    expect(
+      resolveAcpPermissionPolicy({
+        runtimeMode: "approval-required",
+        interactionMode: "default",
+        options,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("auto-allows Full Access requests with the provider's request-scoped option", () => {
+    expect(
+      resolveAcpPermissionPolicy({
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        options,
+      }),
+    ).toEqual({ outcome: "selected", optionId: "allow-once" });
+  });
+
+  it("keeps Plan mode fail-closed above Full Access", () => {
+    expect(
+      resolveAcpPermissionPolicy({
+        runtimeMode: "full-access",
+        interactionMode: "plan",
+        options,
+      }),
+    ).toEqual({ outcome: "selected", optionId: "reject-once" });
   });
 });
 

--- a/apps/server/src/provider/acp/GrokAcpSupport.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.ts
@@ -3,7 +3,7 @@
  *
  * @module GrokAcpSupport
  */
-import { type GrokModelOptions } from "@synara/contracts";
+import { type GrokModelOptions, type RuntimeMode } from "@synara/contracts";
 import { Effect, Layer, Scope, ServiceMap } from "effect";
 import * as AcpErrors from "./AcpErrors.ts";
 import type * as Acp from "@agentclientprotocol/sdk";
@@ -29,6 +29,7 @@ export interface GrokAcpRuntimeInput extends Omit<
 > {
   readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
   readonly grokSettings: GrokAcpRuntimeSettings | null | undefined;
+  readonly runtimeMode: RuntimeMode;
 }
 
 export interface GrokAcpModelSelectionErrorContext {
@@ -38,6 +39,7 @@ export interface GrokAcpModelSelectionErrorContext {
 
 const GROK_API_KEY_AUTH_METHOD_ID = "xai.api_key";
 const GROK_CACHED_TOKEN_AUTH_METHOD_ID = "cached_token";
+const GROK_INTERACTIVE_AUTH_METHOD_IDS = new Set(["browser_login", "grok.com"]);
 const GROK_API_KEY_ENV_KEYS = ["XAI_API_KEY", "GROK_CODE_XAI_API_KEY"] as const;
 const GROK_COMPACT_COMMAND_NAME = "compact";
 const GROK_COMPACT_PROMPT = "/compact";
@@ -89,11 +91,17 @@ export function runGrokAcpCompactionCommand(
 export function buildGrokAcpSpawnInput(
   grokSettings: GrokAcpRuntimeSettings | null | undefined,
   cwd: string,
+  runtimeMode: RuntimeMode,
 ): AcpSpawnInput {
-  // Keep the provider itself in request-based permission mode. Synara then
-  // auto-answers per turn, so Full Access cannot leak into a later Plan turn
-  // through a sticky Grok config or a process-wide always-approve setting.
+  // Keep Grok's request-based mode as the explicit baseline. Full Access also
+  // needs the process-scoped override because some Grok builds deny before
+  // emitting an ACP permission request. Runtime-mode changes restart the Grok
+  // process, while native Plan mode plus Synara's pre-tool hook still gate
+  // writes on Plan turns.
   const args = ["--permission-mode", "default", "agent", "--no-leader"];
+  if (runtimeMode === "full-access") {
+    args.push("--always-approve");
+  }
   const model = grokSettings?.model?.trim();
   if (model) {
     args.push("-m", model);
@@ -113,7 +121,15 @@ export function buildGrokAcpSpawnInput(
 }
 
 function availableAuthMethodIds(initializeResult: Acp.InitializeResponse): ReadonlySet<string> {
-  return new Set((initializeResult.authMethods ?? []).map((method) => method.id.trim()));
+  return new Set(
+    (initializeResult.authMethods ?? [])
+      .map((method) => method.id.trim())
+      .filter((methodId) => methodId.length > 0),
+  );
+}
+
+function describeAuthMethodIds(authMethodIds: ReadonlySet<string>): string {
+  return authMethodIds.size > 0 ? [...authMethodIds].join(", ") : "none";
 }
 
 export const resolveGrokAcpAuthMethodId = (
@@ -121,18 +137,46 @@ export const resolveGrokAcpAuthMethodId = (
 ): Effect.Effect<string, AcpErrors.AcpError> =>
   Effect.gen(function* () {
     const authMethodIds = availableAuthMethodIds(initializeResult);
-    if (hasGrokApiKeyEnv() && authMethodIds.has(GROK_API_KEY_AUTH_METHOD_ID)) {
+    const hasApiKey = hasGrokApiKeyEnv();
+    if (hasApiKey && authMethodIds.has(GROK_API_KEY_AUTH_METHOD_ID)) {
       return GROK_API_KEY_AUTH_METHOD_ID;
     }
     if (authMethodIds.has(GROK_CACHED_TOKEN_AUTH_METHOD_ID)) {
       return GROK_CACHED_TOKEN_AUTH_METHOD_ID;
     }
+    const advertised = describeAuthMethodIds(authMethodIds);
+    if (!hasApiKey && authMethodIds.has(GROK_API_KEY_AUTH_METHOD_ID)) {
+      return yield* new AcpErrors.AcpRequestError({
+        code: -32602,
+        errorMessage:
+          "Grok ACP requires API-key authentication, but XAI_API_KEY is not set. Set XAI_API_KEY and restart Synara, or run `grok login` to create a cached login.",
+        data: { authMethods: [...authMethodIds], reason: "credentials_missing" },
+      });
+    }
+    if (
+      !hasApiKey &&
+      authMethodIds.size > 0 &&
+      [...authMethodIds].every((methodId) => GROK_INTERACTIVE_AUTH_METHOD_IDS.has(methodId))
+    ) {
+      return yield* new AcpErrors.AcpRequestError({
+        code: -32602,
+        errorMessage: `Grok is not authenticated for headless ACP. Run \`grok login\` (or launch \`grok\`) and retry. Grok advertised only interactive auth methods: ${advertised}.`,
+        data: { authMethods: [...authMethodIds], reason: "credentials_missing" },
+      });
+    }
+    if (hasApiKey && !authMethodIds.has(GROK_API_KEY_AUTH_METHOD_ID)) {
+      return yield* new AcpErrors.AcpRequestError({
+        code: -32602,
+        errorMessage: `Grok did not advertise API-key authentication even though XAI_API_KEY is set (advertised: ${advertised}). Update Grok or check its login policy, then restart Synara.`,
+        data: { authMethods: [...authMethodIds], reason: "compatibility_mismatch" },
+      });
+    }
     return yield* new AcpErrors.AcpRequestError({
       code: -32602,
-      errorMessage: "Grok ACP authentication is unavailable.",
+      errorMessage: `Grok ACP advertised no supported headless authentication method (advertised: ${advertised}). Synara supports cached_token and xai.api_key; update Grok and retry.`,
       data: {
         authMethods: [...authMethodIds],
-        detail: "Run `grok` to authenticate locally, or set XAI_API_KEY.",
+        reason: "compatibility_mismatch",
       },
     });
   });
@@ -144,7 +188,7 @@ export const makeGrokAcpRuntime = (
     const acpContext = yield* Layer.build(
       AcpSessionRuntime.layer({
         ...input,
-        spawn: buildGrokAcpSpawnInput(input.grokSettings, input.cwd),
+        spawn: buildGrokAcpSpawnInput(input.grokSettings, input.cwd, input.runtimeMode),
         resolveAuthMethodId: resolveGrokAcpAuthMethodId,
         authenticateMeta: { headless: true },
       }).pipe(


### PR DESCRIPTION
Closes #546.
Closes #557.

## Problem

Grok ACP session startup collapsed every unsupported authentication advertisement into the same `authentication is unavailable` error. That made a genuinely unauthenticated Grok install indistinguishable from an API-key/auth-method compatibility mismatch and hid the advertised method ids needed to resolve the problem.

Grok permission handling also had a compatibility gap for builds that deny a command in their prompt policy before sending `session/request_permission`. Synara could correctly answer an ACP permission request, but Full Access no longer enabled Grok's process-scoped approval override, so an upstream pre-request denial could ignore the thread mode. Failed tool updates also preferred the command text over Grok's supplied denial reason, making the failure less actionable.

## Root cause and fix

- Keep authentication strict: select only an advertised `xai.api_key` when a Grok API key is configured, otherwise select an advertised `cached_token`. No authentication path is bypassed.
- Distinguish missing headless credentials from a Grok/Synara compatibility mismatch. Startup errors now name the advertised methods and tell the user whether to run `grok login`, set `XAI_API_KEY`, check login policy, or update Grok.
- Map the thread runtime mode directly into Grok startup. Approval Required keeps `--permission-mode default`; Full Access adds Grok's `--always-approve` compatibility override so affected builds cannot deny before the ACP request reaches Synara.
- Preserve safety boundaries: runtime-mode changes restart the Grok process, normal approval-required ACP requests still surface to Synara, and Plan mode remains fail-closed through Grok's native Plan state plus Synara's pre-tool hook and decline policy.
- Prefer provider-supplied failure content for failed ACP tools, so a denial such as `denied by prompt policy (tool not pre-approved)` is visible in the failed tool row and terminal turn error instead of being replaced by the attempted command.

## Reproduction evidence

Against locally installed Grok `0.2.118`, direct ACP initialization advertised `cached_token` and `grok.com` (and additionally `xai.api_key` when an API key was present). Cached-token authentication succeeded. In Approval Required behavior, a mutating `touch` command emitted `session/request_permission`; rejecting it produced a failed ACP tool update and a cancelled permission result. This confirms that current Grok can follow Synara's request flow, while the reported pre-approved-policy denial is a build/policy path that Synara can safely accommodate for Full Access but cannot synthesize into an approval after Grok has already denied it.

## Verification

- `bun run test src/provider/acp/GrokAcpSupport.test.ts src/provider/acp/AcpRuntimeModel.test.ts src/provider/acp/AcpAdapterSupport.test.ts src/provider/Layers/GrokAdapter.test.ts` — 4 files, 59 tests passed
- Focused `oxfmt --check` on all five changed files
- `git diff --check`

The regression tests cover cached-token and API-key selection, unauthenticated and compatibility-mismatch diagnostics, Approval Required, Full Access, Plan-mode precedence, Full Access startup flags, and preservation of Grok prompt-policy denial text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Grok child process flags and auth selection at session start; Full Access widens auto-approval for affected Grok builds, though Plan gating and approval-required ACP flow stay in place.
> 
> **Overview**
> Improves **Grok ACP** startup and how permission denials show up in the UI.
> 
> **Authentication** errors are split by situation instead of one generic “unavailable” message: missing `XAI_API_KEY` when Grok advertises API-key auth, interactive-only methods (`browser_login`, `grok.com`) without headless credentials, API key set but Grok didn’t advertise `xai.api_key`, and other unsupported advertisements (with listed method ids).
> 
> **Full Access** passes thread `runtimeMode` into Grok spawn: approval-required stays on `--permission-mode default` only; full-access adds **`--always-approve`** so builds that deny via prompt policy before `session/request_permission` still align with Full Access. `GrokAdapter` logs `alwaysApprove` and forwards `runtimeMode` to `makeGrokAcpRuntime`. Request-scoped auto-allow via `resolveAcpPermissionPolicy` is unchanged; Plan mode still rejects above Full Access.
> 
> **Failed ACP tools** prefer provider text (e.g. prompt-policy denials) over the shell command when building tool `detail`, with a regression test for merged failed execute tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd2aacf4249e19ec5c08f312dc228e2a822e9320. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->