### PR TITLE
[codex] Fix Windows terminal activity polling

### DIFF
--- a/apps/server/src/terminal/Layers/Manager.test.ts
+++ b/apps/server/src/terminal/Layers/Manager.test.ts
@@ -24,6 +24,7 @@ import {
   type TerminalSubprocessActivity,
 } from "./Manager";
 import type { ProcessTreeKiller } from "../processTreeKiller";
+import type { ProcessChildrenSnapshotObserver } from "../windowsProcessSnapshot";
 import { Effect, Encoding } from "effect";
 
 class FakePtyProcess implements PtyProcess {
@@ -229,6 +230,7 @@ describe("TerminalManager", () => {
     options: {
       shellResolver?: () => string;
       subprocessChecker?: (terminalPid: number) => Promise<boolean | TerminalSubprocessActivity>;
+      processSnapshotObserver?: ProcessChildrenSnapshotObserver;
       processTreeKiller?: ProcessTreeKiller;
       subprocessPollIntervalMs?: number;
       processKillGraceMs?: number;
@@ -247,6 +249,9 @@ describe("TerminalManager", () => {
       historyLineLimit,
       shellResolver: options.shellResolver ?? (() => "/bin/bash"),
       ...(options.subprocessChecker ? { subprocessChecker: options.subprocessChecker } : {}),
+      ...(options.processSnapshotObserver
+        ? { processSnapshotObserver: options.processSnapshotObserver }
+        : {}),
       ...(options.processTreeKiller ? { processTreeKiller: options.processTreeKiller } : {}),
       ...(options.subprocessPollIntervalMs
         ? { subprocessPollIntervalMs: options.subprocessPollIntervalMs }
@@ -655,6 +660,108 @@ describe("TerminalManager", () => {
       1_200,
     );
 
+    manager.dispose();
+  });
+
+  it("applies one shared process snapshot to multiple terminals per poll cycle", async () => {
+    let captureCount = 0;
+    const observer: ProcessChildrenSnapshotObserver = {
+      capture: vi.fn(async () => {
+        captureCount += 1;
+        if (captureCount === 1) return new Map();
+        return new Map([
+          [9000, [{ pid: 9100, command: "node.exe serve.js" }]],
+          [9001, [{ pid: 9101, command: "node.exe build.js" }]],
+        ]);
+      }),
+      retryDelayMs: () => 0,
+      dispose: vi.fn(),
+    };
+    const { manager } = makeManager(5, {
+      processSnapshotObserver: observer,
+      subprocessPollIntervalMs: 100,
+    });
+    const events: TerminalEvent[] = [];
+    manager.on("event", (event) => {
+      events.push(event);
+    });
+
+    await manager.open(openInput({ terminalId: "default" }));
+    await waitFor(() => captureCount === 1);
+    await manager.open(openInput({ terminalId: "sidecar" }));
+    await manager.write({ threadId: "thread-1", terminalId: "sidecar", data: "echo active\r" });
+
+    await waitFor(
+      () =>
+        events.some(
+          (event) =>
+            event.type === "activity" &&
+            event.terminalId === "default" &&
+            event.hasRunningSubprocess,
+        ) &&
+        events.some(
+          (event) =>
+            event.type === "activity" &&
+            event.terminalId === "sidecar" &&
+            event.hasRunningSubprocess,
+        ),
+      1_200,
+    );
+
+    expect(observer.capture).toHaveBeenCalledTimes(2);
+    manager.dispose();
+  });
+
+  it("honors process snapshot retry backoff instead of probing at the terminal cadence", async () => {
+    let backoffMs = 0;
+    const observer: ProcessChildrenSnapshotObserver = {
+      capture: vi.fn(async () => {
+        backoffMs = 120;
+        return null;
+      }),
+      retryDelayMs: () => backoffMs,
+      dispose: vi.fn(),
+    };
+    const { manager } = makeManager(5, {
+      processSnapshotObserver: observer,
+      subprocessPollIntervalMs: 10,
+    });
+
+    await manager.open(openInput());
+    await waitFor(() => vi.mocked(observer.capture).mock.calls.length === 1);
+    await new Promise((resolve) => setTimeout(resolve, 70));
+    expect(observer.capture).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => vi.mocked(observer.capture).mock.calls.length === 2, 300);
+    manager.dispose();
+  });
+
+  it("preserves the last activity state while a shared snapshot is unavailable", async () => {
+    let captureCount = 0;
+    const observer: ProcessChildrenSnapshotObserver = {
+      capture: vi.fn(async () => {
+        captureCount += 1;
+        return captureCount === 1
+          ? new Map([[9000, [{ pid: 9100, command: "node.exe build.js" }]]])
+          : null;
+      }),
+      retryDelayMs: () => 0,
+      dispose: vi.fn(),
+    };
+    const { manager } = makeManager(5, {
+      processSnapshotObserver: observer,
+      subprocessPollIntervalMs: 20,
+    });
+    const activityEvents: TerminalEvent[] = [];
+    manager.on("event", (event) => {
+      if (event.type === "activity") activityEvents.push(event);
+    });
+
+    await manager.open(openInput());
+    await waitFor(() => captureCount >= 2);
+
+    expect(activityEvents).toHaveLength(1);
+    expect(activityEvents[0]).toMatchObject({ hasRunningSubprocess: true });
     manager.dispose();
   });
 

--- a/apps/server/src/terminal/Layers/Manager.ts
+++ b/apps/server/src/terminal/Layers/Manager.ts
@@ -69,6 +69,10 @@ import {
   inspectSubprocessActivity,
   type TerminalSubprocessActivity,
 } from "../subprocessActivity";
+import {
+  createWindowsProcessSnapshotObserver,
+  type ProcessChildrenSnapshotObserver,
+} from "../windowsProcessSnapshot";
 
 export type { TerminalSubprocessActivity } from "../subprocessActivity";
 
@@ -743,6 +747,7 @@ interface TerminalManagerOptions {
   ptyAdapter: PtyAdapterShape;
   shellResolver?: () => string;
   subprocessChecker?: TerminalSubprocessChecker;
+  processSnapshotObserver?: ProcessChildrenSnapshotObserver;
   processTreeKiller?: ProcessTreeKiller;
   subprocessPollIntervalMs?: number;
   processKillGraceMs?: number;
@@ -780,6 +785,7 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
   private readonly subprocessChecker: TerminalSubprocessChecker;
   private readonly processTreeKiller: ProcessTreeKiller;
   private readonly useDefaultSubprocessChecker: boolean;
+  private readonly processSnapshotObserver: ProcessChildrenSnapshotObserver | null;
   private readonly subprocessPollIntervalMs: number;
   private readonly processKillGraceMs: number;
   private readonly maxRetainedInactiveSessions: number;
@@ -809,6 +815,11 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
     // Only the built-in checker can share a single process snapshot across the
     // poll cycle; injected checkers (tests) keep the per-pid path.
     this.useDefaultSubprocessChecker = options.subprocessChecker === undefined;
+    this.processSnapshotObserver =
+      options.processSnapshotObserver ??
+      (this.useDefaultSubprocessChecker && process.platform === "win32"
+        ? createWindowsProcessSnapshotObserver()
+        : null);
     this.subprocessPollIntervalMs =
       options.subprocessPollIntervalMs ?? DEFAULT_SUBPROCESS_POLL_INTERVAL_MS;
     this.processKillGraceMs = options.processKillGraceMs ?? DEFAULT_PROCESS_KILL_GRACE_MS;
@@ -1200,6 +1211,7 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
 
   private disposeInternal(options: { keepEscalationTimers: boolean }): number {
     this.stopSubprocessPolling();
+    this.processSnapshotObserver?.dispose();
     const sessions = [...this.sessions.values()];
     this.sessions.clear();
     for (const session of sessions) {
@@ -2045,10 +2057,13 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
     for (const session of this.sessions.values()) {
       if (session.status !== "running" || session.pid === null) continue;
       if (session.hasRunningSubprocess || isProviderSessionBusy(session, now)) {
-        return base;
+        return Math.max(base, this.processSnapshotObserver?.retryDelayMs() ?? 0);
       }
     }
-    return base * SUBPROCESS_IDLE_POLL_MULTIPLIER;
+    return Math.max(
+      base * SUBPROCESS_IDLE_POLL_MULTIPLIER,
+      this.processSnapshotObserver?.retryDelayMs() ?? 0,
+    );
   }
 
   private async runSubprocessPollCycle(): Promise<void> {
@@ -2113,16 +2128,23 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
     }
 
     this.subprocessPollInFlight = true;
-    // Capture the whole process tree once per cycle (built-in POSIX checker
-    // only); every running terminal is then inspected against this shared
-    // snapshot instead of each spawning its own full-system `ps`.
-    const sharedChildrenMap =
-      this.useDefaultSubprocessChecker && process.platform !== "win32"
+    // Capture the whole process tree once per cycle. POSIX uses one `ps`; Windows
+    // uses one persistent observer process. Every running terminal is then
+    // inspected synchronously against the same immutable snapshot.
+    const sharedChildrenMap = this.processSnapshotObserver
+      ? await this.processSnapshotObserver.capture()
+      : this.useDefaultSubprocessChecker && process.platform !== "win32"
         ? await captureProcessChildrenMap()
         : null;
+    const sharedSnapshotUnavailable =
+      this.processSnapshotObserver !== null && sharedChildrenMap === null;
     try {
       await Promise.all(
         runningSessions.map(async (session) => {
+          // A failed Windows snapshot proves nothing. Preserve the last known
+          // activity state while the observer backs off instead of reporting a
+          // false idle transition or falling back to per-terminal processes.
+          if (sharedSnapshotUnavailable) return;
           const terminalPid = session.pid;
           let hasRunningSubprocess = false;
           let shouldClearDetectedCliKind = false;

--- a/apps/server/src/terminal/subprocessActivity.test.ts
+++ b/apps/server/src/terminal/subprocessActivity.test.ts
@@ -77,6 +77,24 @@ describe("inspectSubprocessActivity", () => {
     });
   });
 
+  it("preserves provider and shell semantics for Windows executable names", () => {
+    const map = buildChildrenMap([
+      {
+        ppid: 100,
+        pid: 200,
+        command: '"C:\\Program Files\\PowerShell\\7\\pwsh.exe" -NoLogo',
+      },
+      { ppid: 200, pid: 300, command: "C:\\tools\\codex.exe" },
+    ]);
+
+    expect(inspectSubprocessActivity(100, map)).toEqual({
+      cliKind: "codex",
+      hasNonProviderSubprocess: false,
+      hasProviderDescendant: true,
+      hasRunningSubprocess: true,
+    });
+  });
+
   it("inspects multiple terminals against one shared snapshot", () => {
     // A single captured snapshot must yield independent, correct results per
     // terminal — this is the property the per-cycle batching relies on.

--- a/apps/server/src/terminal/subprocessActivity.ts
+++ b/apps/server/src/terminal/subprocessActivity.ts
@@ -11,6 +11,7 @@ import {
 
 import { runProcess } from "../processRunner";
 import { parseProcessChildrenMap, type ProcessChildrenMap } from "./processTreeKiller";
+import { captureWindowsProcessChildrenMap } from "./windowsProcessSnapshot";
 
 const POSIX_SUBPROCESS_TREE_WALK_MAX_VISITED = 256;
 
@@ -21,48 +22,16 @@ export interface TerminalSubprocessActivity {
   hasNonProviderSubprocess: boolean;
 }
 
-async function checkWindowsSubprocessActivity(
-  terminalPid: number,
-): Promise<TerminalSubprocessActivity> {
-  const command = [
-    `$children = Get-CimInstance Win32_Process -Filter "ParentProcessId = ${terminalPid}" -ErrorAction SilentlyContinue`,
-    "if ($children) { exit 0 }",
-    "exit 1",
-  ].join("; ");
-  try {
-    const result = await runProcess(
-      "powershell.exe",
-      ["-NoProfile", "-NonInteractive", "-Command", command],
-      {
-        timeoutMs: 1_500,
-        allowNonZeroExit: true,
-        maxBufferBytes: 32_768,
-        outputMode: "truncate",
-      },
-    );
-    return {
-      cliKind: null,
-      hasNonProviderSubprocess: false,
-      hasProviderDescendant: false,
-      hasRunningSubprocess: result.code === 0,
-    };
-  } catch {
-    return {
-      cliKind: null,
-      hasNonProviderSubprocess: false,
-      hasProviderDescendant: false,
-      hasRunningSubprocess: false,
-    };
-  }
-}
-
 const SHELL_LIKE_PROCESS_NAMES = new Set([
   "bash",
+  "cmd",
   "dash",
   "fish",
   "ksh",
   "login",
   "nu",
+  "powershell",
+  "pwsh",
   "screen",
   "sh",
   "tcsh",
@@ -80,9 +49,25 @@ function emptySubprocessActivity(): TerminalSubprocessActivity {
   };
 }
 
+function processExecutableName(command: string): string {
+  const firstToken = /^\s*"([^"]+)"/.exec(command)?.[1] ?? command.trim().split(/\s+/g)[0] ?? "";
+  const normalizedPath = firstToken.replaceAll("\\", "/");
+  return path
+    .basename(normalizedPath)
+    .replace(/\.(?:cmd|com|exe)$/i, "")
+    .toLowerCase();
+}
+
 function isShellLikeProcessName(command: string): boolean {
-  const normalized = path.basename(command.trim().split(/\s+/g)[0] ?? "").toLowerCase();
-  return SHELL_LIKE_PROCESS_NAMES.has(normalized);
+  return SHELL_LIKE_PROCESS_NAMES.has(processExecutableName(command));
+}
+
+function deriveProcessCliKind(command: string): TerminalCliKind | null {
+  return (
+    deriveTerminalProcessIdentity(command)?.cliKind ??
+    deriveTerminalProcessIdentity(processExecutableName(command))?.cliKind ??
+    null
+  );
 }
 
 function includeChildActivity(
@@ -90,7 +75,7 @@ function includeChildActivity(
   command: string,
   nestedActivity: TerminalSubprocessActivity,
 ): TerminalSubprocessActivity {
-  const childCliKind = deriveTerminalProcessIdentity(command)?.cliKind ?? null;
+  const childCliKind = deriveProcessCliKind(command);
   const isShellLike = isShellLikeProcessName(command);
   return {
     cliKind: activity.cliKind ?? childCliKind ?? nestedActivity.cliKind,
@@ -245,7 +230,10 @@ export async function defaultSubprocessChecker(
     return emptySubprocessActivity();
   }
   if (process.platform === "win32") {
-    return checkWindowsSubprocessActivity(terminalPid);
+    const childrenByParentPid = await captureWindowsProcessChildrenMap();
+    return childrenByParentPid === null
+      ? emptySubprocessActivity()
+      : inspectSubprocessActivity(terminalPid, childrenByParentPid);
   }
   return checkPosixSubprocessActivity(terminalPid);
 }

--- a/apps/server/src/terminal/windowsProcessSnapshot.test.ts
+++ b/apps/server/src/terminal/windowsProcessSnapshot.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ProcessChildrenMap } from "./processTreeKiller";
+import {
+  createWindowsProcessSnapshotObserver,
+  parseWindowsProcessSnapshotLine,
+  type ProcessChildrenSnapshotWorker,
+} from "./windowsProcessSnapshot";
+
+function snapshot(
+  entries: Array<{ ppid: number; pid: number; command: string }>,
+): ProcessChildrenMap {
+  const childrenByParentPid: ProcessChildrenMap = new Map();
+  for (const entry of entries) {
+    const siblings = childrenByParentPid.get(entry.ppid) ?? [];
+    siblings.push({ pid: entry.pid, command: entry.command });
+    childrenByParentPid.set(entry.ppid, siblings);
+  }
+  return childrenByParentPid;
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Windows process snapshots", () => {
+  it("parses base64-delimited rows without corrupting Windows command lines", () => {
+    const command = '"C:\\Program Files\\PowerShell\\7\\pwsh.exe" -NoLogo';
+    const encoded = Buffer.from(command, "utf8").toString("base64");
+
+    expect(parseWindowsProcessSnapshotLine(`42\t7\t${encoded}`)).toEqual({
+      pid: 42,
+      ppid: 7,
+      command,
+    });
+    expect(parseWindowsProcessSnapshotLine(`bad\t7\t${encoded}`)).toBeNull();
+    expect(parseWindowsProcessSnapshotLine("42\t7\tnot-base64")).toBeNull();
+  });
+
+  it("coalesces concurrent terminal requests and reuses one worker across snapshots", async () => {
+    const firstCapture = deferred<ProcessChildrenMap>();
+    const firstSnapshot = snapshot([
+      { ppid: 100, pid: 101, command: "codex.exe" },
+      { ppid: 200, pid: 201, command: "node.exe build.js" },
+    ]);
+    const worker: ProcessChildrenSnapshotWorker = {
+      capture: vi
+        .fn<() => Promise<ProcessChildrenMap>>()
+        .mockImplementationOnce(() => firstCapture.promise)
+        .mockResolvedValue(firstSnapshot),
+      dispose: vi.fn(),
+    };
+    const createWorker = vi.fn(() => worker);
+    const observer = createWindowsProcessSnapshotObserver({ createWorker });
+
+    const terminalOne = observer.capture();
+    const terminalTwo = observer.capture();
+    const terminalThree = observer.capture();
+    await Promise.resolve();
+
+    expect(createWorker).toHaveBeenCalledTimes(1);
+    expect(worker.capture).toHaveBeenCalledTimes(1);
+
+    firstCapture.resolve(firstSnapshot);
+    await expect(Promise.all([terminalOne, terminalTwo, terminalThree])).resolves.toEqual([
+      firstSnapshot,
+      firstSnapshot,
+      firstSnapshot,
+    ]);
+
+    await expect(observer.capture()).resolves.toBe(firstSnapshot);
+    expect(createWorker).toHaveBeenCalledTimes(1);
+    expect(worker.capture).toHaveBeenCalledTimes(2);
+    observer.dispose();
+  });
+
+  it("times out a stalled worker and does not create another process during backoff", async () => {
+    vi.useFakeTimers();
+    let now = 1_000;
+    const stalledCapture = deferred<ProcessChildrenMap>();
+    const worker: ProcessChildrenSnapshotWorker = {
+      capture: vi.fn(() => stalledCapture.promise),
+      dispose: vi.fn(),
+    };
+    const createWorker = vi.fn(() => worker);
+    const observer = createWindowsProcessSnapshotObserver({
+      createWorker,
+      now: () => now,
+      probeTimeoutMs: 50,
+      retryBackoffBaseMs: 200,
+      retryBackoffMaxMs: 800,
+    });
+
+    const capture = observer.capture();
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expect(capture).resolves.toBeNull();
+    expect(worker.dispose).toHaveBeenCalledTimes(1);
+    expect(observer.retryDelayMs()).toBe(200);
+
+    await expect(observer.capture()).resolves.toBeNull();
+    expect(createWorker).toHaveBeenCalledTimes(1);
+
+    now += 199;
+    await expect(observer.capture()).resolves.toBeNull();
+    expect(createWorker).toHaveBeenCalledTimes(1);
+    observer.dispose();
+  });
+
+  it("backs off repeated failures and resets after a successful recovery", async () => {
+    let now = 5_000;
+    const recoveredSnapshot = snapshot([{ ppid: 300, pid: 301, command: "claude.exe" }]);
+    const failedWorker = (): ProcessChildrenSnapshotWorker => ({
+      capture: vi.fn().mockRejectedValue(new Error("WMI unavailable")),
+      dispose: vi.fn(),
+    });
+    const recoveredWorker: ProcessChildrenSnapshotWorker = {
+      capture: vi.fn().mockResolvedValue(recoveredSnapshot),
+      dispose: vi.fn(),
+    };
+    const workers = [failedWorker(), failedWorker(), recoveredWorker];
+    const createWorker = vi.fn(() => workers.shift() ?? recoveredWorker);
+    const observer = createWindowsProcessSnapshotObserver({
+      createWorker,
+      now: () => now,
+      retryBackoffBaseMs: 100,
+      retryBackoffMaxMs: 400,
+    });
+
+    await expect(observer.capture()).resolves.toBeNull();
+    expect(observer.retryDelayMs()).toBe(100);
+
+    now += 100;
+    await expect(observer.capture()).resolves.toBeNull();
+    expect(observer.retryDelayMs()).toBe(200);
+
+    now += 200;
+    await expect(observer.capture()).resolves.toBe(recoveredSnapshot);
+    expect(observer.retryDelayMs()).toBe(0);
+
+    await expect(observer.capture()).resolves.toBe(recoveredSnapshot);
+    expect(createWorker).toHaveBeenCalledTimes(3);
+    expect(recoveredWorker.capture).toHaveBeenCalledTimes(2);
+    observer.dispose();
+  });
+});

--- a/apps/server/src/terminal/windowsProcessSnapshot.ts
+++ b/apps/server/src/terminal/windowsProcessSnapshot.ts
@@ -1,0 +1,348 @@
+// FILE: windowsProcessSnapshot.ts
+// Purpose: Maintains one bounded Windows process-table observer shared by all terminals.
+// Layer: Terminal infrastructure
+
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import path from "node:path";
+
+import { resolveWindowsSystemRoot } from "@synara/shared/windowsProcess";
+
+import type { ProcessChildrenMap } from "./processTreeKiller";
+
+const DEFAULT_PROBE_TIMEOUT_MS = 3_000;
+const DEFAULT_RETRY_BACKOFF_BASE_MS = 2_000;
+const DEFAULT_RETRY_BACKOFF_MAX_MS = 30_000;
+const MAX_SNAPSHOT_OUTPUT_BYTES = 8 * 1024 * 1024;
+
+const SNAPSHOT_START_MARKER = "@snapshot";
+const SNAPSHOT_END_MARKER = "@end";
+const SNAPSHOT_ERROR_MARKER = "@error";
+
+// EncodedCommand leaves stdin available for the request loop. A single
+// PowerShell interpreter can therefore serve every process-table snapshot
+// instead of paying interpreter startup once per terminal and poll cycle.
+const WINDOWS_PROCESS_SNAPSHOT_SCRIPT = `
+$ErrorActionPreference = 'Stop'
+while (($request = [Console]::In.ReadLine()) -ne $null) {
+  try {
+    [Console]::Out.WriteLine('${SNAPSHOT_START_MARKER}')
+    Get-CimInstance Win32_Process -ErrorAction Stop | ForEach-Object {
+      $command = if ($_.CommandLine) { [string]$_.CommandLine } else { [string]$_.Name }
+      $encoded = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($command))
+      [Console]::Out.WriteLine(("{0}\t{1}\t{2}" -f $_.ProcessId, $_.ParentProcessId, $encoded))
+    }
+    [Console]::Out.WriteLine('${SNAPSHOT_END_MARKER}')
+    [Console]::Out.Flush()
+  } catch {
+    [Console]::Out.WriteLine('${SNAPSHOT_ERROR_MARKER}')
+    [Console]::Out.Flush()
+  }
+}
+`.trim();
+
+export interface ProcessChildrenSnapshotWorker {
+  capture(): Promise<ProcessChildrenMap>;
+  dispose(): void;
+}
+
+export interface ProcessChildrenSnapshotObserver {
+  capture(): Promise<ProcessChildrenMap | null>;
+  retryDelayMs(): number;
+  dispose(): void;
+}
+
+interface PendingSnapshot {
+  childrenByParentPid: ProcessChildrenMap;
+  outputBytes: number;
+  sawStartMarker: boolean;
+  resolve: (snapshot: ProcessChildrenMap) => void;
+  reject: (error: Error) => void;
+}
+
+interface PowerShellProcessSnapshotWorkerOptions {
+  spawnProcess?: () => ChildProcessWithoutNullStreams;
+}
+
+export interface WindowsProcessSnapshotObserverOptions {
+  createWorker?: () => ProcessChildrenSnapshotWorker;
+  now?: () => number;
+  probeTimeoutMs?: number;
+  retryBackoffBaseMs?: number;
+  retryBackoffMaxMs?: number;
+}
+
+function powershellExecutablePath(): string {
+  return path.win32.join(
+    resolveWindowsSystemRoot(),
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe",
+  );
+}
+
+function encodedPowerShellCommand(script: string): string {
+  return Buffer.from(script, "utf16le").toString("base64");
+}
+
+function spawnPowerShellSnapshotProcess(): ChildProcessWithoutNullStreams {
+  return spawn(
+    powershellExecutablePath(),
+    [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-EncodedCommand",
+      encodedPowerShellCommand(WINDOWS_PROCESS_SNAPSHOT_SCRIPT),
+    ],
+    {
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    },
+  );
+}
+
+function decodeSnapshotCommand(encodedCommand: string): string | null {
+  if (encodedCommand.length % 4 !== 0 || !/^[A-Za-z0-9+/]+={0,2}$/.test(encodedCommand)) {
+    return null;
+  }
+  try {
+    const command = Buffer.from(encodedCommand, "base64").toString("utf8").trim();
+    return command.length > 0 ? command : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Parses one base64-delimited worker row without trusting command-line contents as separators. */
+export function parseWindowsProcessSnapshotLine(
+  line: string,
+): { pid: number; ppid: number; command: string } | null {
+  const [pidRaw, ppidRaw, encodedCommand, ...extra] = line.split("\t");
+  if (extra.length > 0 || !encodedCommand) return null;
+  const pid = Number(pidRaw);
+  const ppid = Number(ppidRaw);
+  if (!Number.isInteger(pid) || pid <= 0 || !Number.isInteger(ppid) || ppid < 0) return null;
+  const command = decodeSnapshotCommand(encodedCommand);
+  return command === null ? null : { pid, ppid, command };
+}
+
+class PowerShellProcessSnapshotWorker implements ProcessChildrenSnapshotWorker {
+  private readonly child: ChildProcessWithoutNullStreams;
+  private stdoutCarry = "";
+  private pending: PendingSnapshot | null = null;
+  private terminalError: Error | null = null;
+  private disposed = false;
+
+  constructor(options: PowerShellProcessSnapshotWorkerOptions = {}) {
+    this.child = (options.spawnProcess ?? spawnPowerShellSnapshotProcess)();
+    this.child.stdout.setEncoding("utf8");
+    this.child.stdout.on("data", (chunk: string) => {
+      this.consumeStdout(chunk);
+    });
+    // Drain diagnostics so a noisy PowerShell host cannot block on a full pipe.
+    this.child.stderr.resume();
+    this.child.once("error", (error) => {
+      this.fail(new Error(`Windows process snapshot worker failed: ${error.message}`));
+    });
+    this.child.once("close", (code, signal) => {
+      this.fail(
+        new Error(
+          `Windows process snapshot worker exited (code=${code ?? "null"}, signal=${signal ?? "null"}).`,
+        ),
+      );
+    });
+  }
+
+  capture(): Promise<ProcessChildrenMap> {
+    if (this.disposed) {
+      return Promise.reject(
+        this.terminalError ?? new Error("Windows process snapshot worker closed."),
+      );
+    }
+    if (this.pending) {
+      return Promise.reject(new Error("Windows process snapshot worker is already capturing."));
+    }
+
+    return new Promise<ProcessChildrenMap>((resolve, reject) => {
+      this.pending = {
+        childrenByParentPid: new Map(),
+        outputBytes: 0,
+        sawStartMarker: false,
+        resolve,
+        reject,
+      };
+      this.child.stdin.write("snapshot\n", (error) => {
+        if (error) {
+          this.fail(new Error(`Failed to request Windows process snapshot: ${error.message}`));
+        }
+      });
+    });
+  }
+
+  dispose(): void {
+    this.fail(new Error("Windows process snapshot worker disposed."));
+  }
+
+  private consumeStdout(chunk: string): void {
+    this.stdoutCarry += chunk;
+    while (true) {
+      const newlineIndex = this.stdoutCarry.indexOf("\n");
+      if (newlineIndex < 0) break;
+      const line = this.stdoutCarry.slice(0, newlineIndex).replace(/\r$/, "");
+      this.stdoutCarry = this.stdoutCarry.slice(newlineIndex + 1);
+      this.consumeLine(line);
+    }
+  }
+
+  private consumeLine(line: string): void {
+    const pending = this.pending;
+    if (!pending) return;
+
+    pending.outputBytes += Buffer.byteLength(line, "utf8") + 1;
+    if (pending.outputBytes > MAX_SNAPSHOT_OUTPUT_BYTES) {
+      this.fail(new Error("Windows process snapshot exceeded its output limit."));
+      return;
+    }
+    if (line === SNAPSHOT_START_MARKER) {
+      pending.sawStartMarker = true;
+      pending.childrenByParentPid.clear();
+      return;
+    }
+    if (line === SNAPSHOT_ERROR_MARKER) {
+      this.fail(new Error("Windows process snapshot query failed."));
+      return;
+    }
+    if (line === SNAPSHOT_END_MARKER) {
+      if (!pending.sawStartMarker) {
+        this.fail(new Error("Windows process snapshot ended before it started."));
+        return;
+      }
+      this.pending = null;
+      pending.resolve(pending.childrenByParentPid);
+      return;
+    }
+    if (!pending.sawStartMarker) return;
+
+    const process = parseWindowsProcessSnapshotLine(line);
+    if (!process) {
+      this.fail(new Error("Windows process snapshot contained a malformed process row."));
+      return;
+    }
+    const siblings = pending.childrenByParentPid.get(process.ppid) ?? [];
+    siblings.push({ pid: process.pid, command: process.command });
+    pending.childrenByParentPid.set(process.ppid, siblings);
+  }
+
+  private fail(error: Error): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.terminalError = error;
+    const pending = this.pending;
+    this.pending = null;
+    pending?.reject(error);
+    this.child.stdin.destroy();
+    this.child.kill();
+  }
+}
+
+export function createPowerShellProcessSnapshotWorker(
+  options: PowerShellProcessSnapshotWorkerOptions = {},
+): ProcessChildrenSnapshotWorker {
+  return new PowerShellProcessSnapshotWorker(options);
+}
+
+function retryBackoffMs(failureCount: number, baseMs: number, maxMs: number): number {
+  return Math.min(maxMs, baseMs * 2 ** Math.max(0, failureCount - 1));
+}
+
+/**
+ * Owns the persistent worker, coalesces callers, and rate-limits restarts after
+ * timeout/failure. Returning null means the previous terminal activity state is
+ * unproven and should be preserved until a later successful snapshot.
+ */
+export function createWindowsProcessSnapshotObserver(
+  options: WindowsProcessSnapshotObserverOptions = {},
+): ProcessChildrenSnapshotObserver {
+  const createWorker = options.createWorker ?? createPowerShellProcessSnapshotWorker;
+  const now = options.now ?? Date.now;
+  const probeTimeoutMs = options.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+  const retryBackoffBaseMs = options.retryBackoffBaseMs ?? DEFAULT_RETRY_BACKOFF_BASE_MS;
+  const retryBackoffMaxMs = options.retryBackoffMaxMs ?? DEFAULT_RETRY_BACKOFF_MAX_MS;
+
+  let worker: ProcessChildrenSnapshotWorker | null = null;
+  let inFlight: Promise<ProcessChildrenMap | null> | null = null;
+  let consecutiveFailures = 0;
+  let nextAttemptAt = 0;
+  let disposed = false;
+
+  const captureWithTimeout = (
+    activeWorker: ProcessChildrenSnapshotWorker,
+  ): Promise<ProcessChildrenMap> =>
+    new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error(`Windows process snapshot timed out after ${probeTimeoutMs}ms.`));
+      }, probeTimeoutMs);
+      timeout.unref?.();
+      activeWorker.capture().then(
+        (snapshot) => {
+          clearTimeout(timeout);
+          resolve(snapshot);
+        },
+        (error: unknown) => {
+          clearTimeout(timeout);
+          reject(error);
+        },
+      );
+    });
+
+  return {
+    capture: () => {
+      if (disposed || now() < nextAttemptAt) return Promise.resolve(null);
+      if (inFlight) return inFlight;
+
+      const attempt = Promise.resolve()
+        .then(() => {
+          worker ??= createWorker();
+          return captureWithTimeout(worker);
+        })
+        .then(
+          (snapshot) => {
+            consecutiveFailures = 0;
+            nextAttemptAt = 0;
+            return snapshot;
+          },
+          () => {
+            worker?.dispose();
+            worker = null;
+            consecutiveFailures += 1;
+            nextAttemptAt =
+              now() + retryBackoffMs(consecutiveFailures, retryBackoffBaseMs, retryBackoffMaxMs);
+            return null;
+          },
+        )
+        .finally(() => {
+          if (inFlight === attempt) inFlight = null;
+        });
+      inFlight = attempt;
+      return attempt;
+    },
+    retryDelayMs: () => Math.max(0, nextAttemptAt - now()),
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      worker?.dispose();
+      worker = null;
+    },
+  };
+}
+
+/** One-shot fallback for direct checker calls; the manager uses the shared observer. */
+export async function captureWindowsProcessChildrenMap(): Promise<ProcessChildrenMap | null> {
+  const observer = createWindowsProcessSnapshotObserver();
+  try {
+    return await observer.capture();
+  } finally {
+    observer.dispose();
+  }
+}


### PR DESCRIPTION
## Summary

Closes #514.

Windows terminal activity polling previously launched a fresh `powershell.exe` process for every running terminal on every poll. Each process ran its own `Get-CimInstance` query, and the general process runner also resolved PowerShell through `where.exe` on every launch. Slow WMI calls then timed out through a `taskkill` process tree, so process creation scaled with terminal count precisely while active sessions were polling every second. This congested the backend until otherwise healthy terminal WebSocket upgrades exceeded their open timeout.

This change replaces the per-terminal probe with one manager-owned Windows process snapshot observer. It starts PowerShell from the explicit Windows system path, keeps that one interpreter alive, captures one process table per poll cycle, and applies the resulting children map synchronously to every terminal. macOS and Linux retain their existing shared `ps` snapshot and fallback behavior.

The observer bounds each WMI snapshot to three seconds. A slow, failed, malformed, or oversized snapshot terminates the single worker and applies exponential restart backoff from two seconds up to thirty seconds. While a snapshot is unavailable, the manager preserves the last known terminal activity state instead of emitting a false idle transition or falling back to per-terminal process creation. A successful snapshot resets the backoff and reuses the recovered worker for later polls.

Windows executable-name normalization now recognizes shell processes and provider executables such as `pwsh.exe` and `codex.exe`, preserving the existing foreground/provider activity semantics when inspecting the shared Windows tree.

## Verification

- `bun run test src/terminal/windowsProcessSnapshot.test.ts src/terminal/subprocessActivity.test.ts src/terminal/Layers/Manager.test.ts` — 65 tests passed
- Focused `oxfmt --check` on the six changed files — passed
- Focused `oxlint` on the six changed files — zero errors (six pre-existing warnings in `Manager.ts`)
- `git diff --check` — passed

Regression coverage includes multiple terminals sharing one snapshot, concurrent request coalescing, bounded worker creation and reuse, slow-probe timeout, repeated-failure backoff, recovery/reset, Windows command parsing, and preservation of last-known activity during snapshot failure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core terminal subprocess/activity detection on Windows and introduces a persistent PowerShell worker; incorrect snapshot handling could misreport busy/idle state, though failed snapshots intentionally preserve prior activity.
> 
> **Overview**
> Replaces **per-terminal PowerShell parent-process probes** on Windows with a **single manager-owned process snapshot** used for every running terminal each poll cycle, addressing backend overload when many terminals polled activity every second.
> 
> Adds `windowsProcessSnapshot`: one long-lived `powershell.exe` (system path, no per-launch `where.exe`) runs `Get-CimInstance Win32_Process` on demand, returns a shared children map with base64-encoded command lines, and applies **timeouts, exponential backoff, and request coalescing**. `TerminalManager` wires this observer on win32, **skips activity updates when a snapshot is unavailable** (keeps last-known state), and **respects observer retry delay** in poll scheduling. Disposes the observer on manager teardown.
> 
> **`subprocessActivity`** drops the old per-PID WMI PowerShell check; Windows uses the shared snapshot path and **`inspectSubprocessActivity`** with improved **`.exe` / quoted-path** parsing plus shell names (`pwsh`, `cmd`, `powershell`). POSIX shared `ps` behavior is unchanged.
> 
> New unit tests cover shared multi-terminal snapshots, backoff, stale activity preservation, snapshot parsing/worker lifecycle, and Windows provider detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75d7a1c17f8b72e030fd18b2ec8a7843f8f2f5a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->