### PR TITLE
Show live Anti-Gravity tool activity

### DIFF
--- a/apps/server/src/orchestration/providerRuntimeActivityProjection.test.ts
+++ b/apps/server/src/orchestration/providerRuntimeActivityProjection.test.ts
@@ -354,6 +354,67 @@ describe("provider runtime activity projection", () => {
     expect(providerActivityUpdateFingerprint(activity!)).toContain('"kind":"tool.updated"');
   });
 
+  it.each(["antigravity", "codex"] as const)(
+    "projects %s tool lifecycle events through the same canonical activities",
+    (provider) => {
+      const itemId = RuntimeItemId.makeUnsafe(`${provider}-tool-1`);
+      const data = { toolCallId: itemId, toolName: "run_command" };
+      const [started] = projectProviderRuntimeActivities(
+        runtimeEvent({
+          provider,
+          type: "item.started",
+          eventId: `${provider}-tool-started`,
+          turnId: TURN_ID,
+          itemId,
+          payload: {
+            itemType: "command_execution",
+            status: "inProgress",
+            title: "run_command",
+            data,
+          },
+        }),
+      );
+      const [completed] = projectProviderRuntimeActivities(
+        runtimeEvent({
+          provider,
+          type: "item.completed",
+          eventId: `${provider}-tool-completed`,
+          turnId: TURN_ID,
+          itemId,
+          payload: {
+            itemType: "command_execution",
+            status: "completed",
+            title: "run_command",
+            data,
+          },
+        }),
+      );
+
+      expect(started).toMatchObject({
+        kind: "tool.started",
+        summary: "run_command started",
+        payload: {
+          itemType: "command_execution",
+          status: "inProgress",
+          title: "run_command",
+          data,
+        },
+      });
+      expect(completed).toMatchObject({
+        kind: "tool.completed",
+        summary: "run_command",
+        payload: {
+          itemType: "command_execution",
+          status: "completed",
+          title: "run_command",
+          data,
+        },
+      });
+      expect(() => decodeActivityAppendCommand(started!)).not.toThrow();
+      expect(() => decodeActivityAppendCommand(completed!)).not.toThrow();
+    },
+  );
+
   it("maps canonical approvals and structured user input", () => {
     const approval = projectProviderRuntimeActivities(
       runtimeEvent({

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -7,7 +7,7 @@ import { PassThrough } from "node:stream";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { ThreadId } from "@synara/contracts";
-import { Effect, Layer } from "effect";
+import { Effect, Fiber, Layer, Stream } from "effect";
 import { describe, expect, it } from "vitest";
 
 import { ServerConfig } from "../../config";
@@ -504,7 +504,15 @@ describe("Antigravity CLI integration helpers", () => {
     try {
       await fs.writeFile(scriptPath, hookScriptSource(), { mode: 0o700 });
       const command = buildAntigravityCaptureCommand(process.execPath, scriptPath, "pre-tool");
-      const payload = JSON.stringify({ tool: "shell" });
+      const payload = JSON.stringify({
+        stepIdx: 12,
+        conversationId: "conversation-1",
+        transcriptPath: "/tmp/transcript.jsonl",
+        toolCall: {
+          name: "run_command",
+          args: { CommandLine: "echo super-secret-token" },
+        },
+      });
       const result = runCaptureCommand(command, payload, {
         SYNARA_ANTIGRAVITY_EVENTS: eventPath,
         SYNARA_ANTIGRAVITY_HOOK_DECISION: "allow",
@@ -513,7 +521,11 @@ describe("Antigravity CLI integration helpers", () => {
       expect(result.error).toBeUndefined();
       expect(result.status).toBe(0);
       expect(result.stdout.trim()).toBe('{"decision":"allow"}');
-      expect(await fs.readFile(eventPath, "utf8")).toBe(`pre-tool\t${payload}\n`);
+      const captured = await fs.readFile(eventPath, "utf8");
+      expect(captured).toBe(
+        'pre-tool\t{"conversationId":"conversation-1","transcriptPath":"/tmp/transcript.jsonl","stepIdx":12,"toolCall":{"name":"run_command"}}\n',
+      );
+      expect(captured).not.toContain("super-secret-token");
     } finally {
       await fs.rm(directory, { recursive: true, force: true });
     }
@@ -585,6 +597,138 @@ describe("Antigravity CLI integration helpers", () => {
       expect(second).toEqual({ lines: ['{"second":true}'], nextOffset: 31 });
     } finally {
       await fs.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("streams hook tool names and terminal states without arguments", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-tool-events-"));
+    let eventFile: string | undefined;
+    let child: ChildProcess | undefined;
+    const spawnProcess = ((
+      _command: string,
+      _args: readonly string[],
+      options: { readonly env?: NodeJS.ProcessEnv },
+    ) => {
+      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS;
+      const spawned = new EventEmitter() as ChildProcess;
+      Object.assign(spawned, {
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        killed: false,
+        kill: () => true,
+      });
+      child = spawned;
+      return spawned;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const toolEventsFiber = yield* adapter.streamEvents.pipe(
+            Stream.filter(
+              (event) => event.type === "item.started" || event.type === "item.completed",
+            ),
+            Stream.take(4),
+            Stream.runCollect,
+            Effect.forkChild,
+          );
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-tool-events");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+          const turn = yield* adapter.sendTurn({
+            threadId,
+            input: "exercise tools",
+            attachments: [],
+          });
+          expect(eventFile).toBeTruthy();
+          yield* Effect.promise(() =>
+            fs.appendFile(
+              eventFile!,
+              [
+                'pre-tool\t{"stepIdx":7,"toolCall":{"name":"run_command","args":{"token":"super-secret-token"}}}',
+                'post-tool\t{"stepIdx":7,"error":"super-secret-error"}',
+                'pre-tool\t{"stepIdx":8,"toolCall":{"name":"write_to_file","args":{"content":"super-secret-content"}}}',
+                'post-tool\t{"stepIdx":8,"error":""}',
+                "",
+              ].join("\n"),
+            ),
+          );
+
+          const events = Array.from(
+            yield* Fiber.join(toolEventsFiber).pipe(Effect.timeout("2 seconds")),
+          );
+          expect(events).toHaveLength(4);
+          expect(events.map((event) => event.type)).toEqual([
+            "item.started",
+            "item.completed",
+            "item.started",
+            "item.completed",
+          ]);
+          expect(events.map((event) => event.payload)).toEqual([
+            {
+              itemType: "command_execution",
+              status: "inProgress",
+              title: "run_command",
+              data: {
+                toolCallId: `antigravity-${turn.turnId}-tool-0`,
+                toolName: "run_command",
+              },
+            },
+            {
+              itemType: "command_execution",
+              status: "failed",
+              title: "run_command",
+              data: {
+                toolCallId: `antigravity-${turn.turnId}-tool-0`,
+                toolName: "run_command",
+              },
+            },
+            {
+              itemType: "file_change",
+              status: "inProgress",
+              title: "write_to_file",
+              data: {
+                toolCallId: `antigravity-${turn.turnId}-tool-1`,
+                toolName: "write_to_file",
+              },
+            },
+            {
+              itemType: "file_change",
+              status: "completed",
+              title: "write_to_file",
+              data: {
+                toolCallId: `antigravity-${turn.turnId}-tool-1`,
+                toolName: "write_to_file",
+              },
+            },
+          ]);
+          expect(JSON.stringify(events)).not.toContain("super-secret");
+
+          child?.emit("close", 0, null);
+          yield* Effect.sleep("25 millis");
+          yield* adapter.stopSession(threadId);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+            }).pipe(
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-tool-events-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
     }
   });
 

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -86,10 +86,10 @@ type TranscriptStep = {
 };
 
 type PendingTool = {
+  readonly stepIndex: number;
   readonly itemId: RuntimeItemId;
   readonly itemType: "command_execution" | "file_change" | "dynamic_tool_call" | "web_search";
   readonly name: string;
-  readonly args: unknown;
 };
 
 type StoredTurn = {
@@ -117,6 +117,7 @@ type AntigravitySessionContext = {
   processedTranscriptPath?: string | undefined;
   processedSteps: Set<number>;
   pendingTools: PendingTool[];
+  nextToolSequence: number;
   sawAssistant: boolean;
   interrupted: boolean;
   stopped: boolean;
@@ -208,7 +209,29 @@ process.stdin.on("end", () => {
     process.stdout.write((event === "pre-tool" ? '{"decision":"ask"}' : "{}") + "\\n");
     return;
   }
-  fs.appendFileSync(target, event + "\\t" + payload.trim() + "\\n");
+  let capturedPayload = payload.trim();
+  if (event === "pre-tool" || event === "post-tool") {
+    try {
+      const input = JSON.parse(capturedPayload);
+      const sanitized = {};
+      for (const key of ["conversationId", "transcriptPath", "modelName"]) {
+        if (typeof input[key] === "string" && input[key].trim()) sanitized[key] = input[key];
+      }
+      if (Number.isInteger(input.stepIdx) && input.stepIdx >= 0) sanitized.stepIdx = input.stepIdx;
+      if (event === "pre-tool") {
+        const name = input.toolCall && typeof input.toolCall.name === "string"
+          ? input.toolCall.name.trim()
+          : "";
+        if (name) sanitized.toolCall = { name };
+      } else {
+        sanitized.failed = typeof input.error === "string" && input.error.trim().length > 0;
+      }
+      capturedPayload = JSON.stringify(sanitized);
+    } catch {
+      capturedPayload = "{}";
+    }
+  }
+  fs.appendFileSync(target, event + "\\t" + capturedPayload + "\\n");
   if (event === "pre-tool") {
     const decision = process.env.SYNARA_ANTIGRAVITY_HOOK_DECISION === "allow" ? "allow" : "ask";
     process.stdout.write(JSON.stringify({ decision }) + "\\n");
@@ -529,21 +552,6 @@ function toolItemType(name: string): PendingTool["itemType"] {
   return "dynamic_tool_call";
 }
 
-function resultStreamKind(itemType: PendingTool["itemType"]) {
-  if (itemType === "command_execution") return "command_output" as const;
-  if (itemType === "file_change") return "file_change_output" as const;
-  return "unknown" as const;
-}
-
-function isToolResultStep(step: TranscriptStep): boolean {
-  return (
-    step.source === "MODEL" &&
-    step.type !== "PLANNER_RESPONSE" &&
-    step.type !== "CONVERSATION_HISTORY" &&
-    step.type !== "CHECKPOINT"
-  );
-}
-
 export function makeAntigravityRuntimeEventBase(input: {
   readonly threadId: ThreadId;
   readonly lifecycleGeneration?: string;
@@ -773,55 +781,10 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         const calls = Array.isArray(step.tool_calls) ? step.tool_calls : [];
         if (calls.length > 0) {
           emitTextItem(context, step, "reasoning", "reasoning_text");
-          for (const [index, call] of calls.entries()) {
-            const name = trim(call.name) ?? "tool";
-            const itemId = RuntimeItemId.makeUnsafe(
-              `antigravity-${context.activeTurnId ?? "turn"}-${stepIndex}-tool-${index}`,
-            );
-            const itemType = toolItemType(name);
-            const pending = { itemId, itemType, name, args: call.args ?? {} } satisfies PendingTool;
-            context.pendingTools.push(pending);
-            offer({
-              ...base(context, { itemId }),
-              type: "item.started",
-              payload: {
-                itemType,
-                status: "inProgress",
-                title: name,
-                data: { name, args: pending.args },
-              },
-              raw: raw("tool-call", call),
-            } satisfies ProviderRuntimeEvent);
-          }
         } else {
           emitTextItem(context, step, "assistant_message", "assistant_text");
         }
         return;
-      }
-
-      if (isToolResultStep(step)) {
-        const pending = context.pendingTools.shift();
-        if (!pending) return;
-        const content = typeof step.content === "string" ? step.content : "";
-        if (content) {
-          offer({
-            ...base(context, { itemId: pending.itemId }),
-            type: "content.delta",
-            payload: { streamKind: resultStreamKind(pending.itemType), delta: content },
-            raw: raw(step.type ?? "tool-result", step),
-          } satisfies ProviderRuntimeEvent);
-        }
-        offer({
-          ...base(context, { itemId: pending.itemId }),
-          type: "item.completed",
-          payload: {
-            itemType: pending.itemType,
-            status: step.status === "ERROR" ? "failed" : "completed",
-            title: pending.name,
-            data: { name: pending.name, args: pending.args, result: step },
-          },
-          raw: raw(step.type ?? "tool-result", step),
-        } satisfies ProviderRuntimeEvent);
       }
     };
 
@@ -920,6 +883,69 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
             raw: raw(eventName, payload),
           } satisfies ProviderRuntimeEvent);
         }
+        const stepIndex =
+          typeof payload.stepIdx === "number" &&
+          Number.isInteger(payload.stepIdx) &&
+          payload.stepIdx >= 0
+            ? payload.stepIdx
+            : undefined;
+        if (eventName === "pre-tool" && stepIndex !== undefined) {
+          const toolCall =
+            payload.toolCall && typeof payload.toolCall === "object"
+              ? (payload.toolCall as Record<string, unknown>)
+              : undefined;
+          const name = typeof toolCall?.name === "string" ? trim(toolCall.name) : undefined;
+          if (name) {
+            const itemId = RuntimeItemId.makeUnsafe(
+              `antigravity-${context.activeTurnId ?? "turn"}-tool-${context.nextToolSequence++}`,
+            );
+            const pending = {
+              stepIndex,
+              itemId,
+              itemType: toolItemType(name),
+              name,
+            } satisfies PendingTool;
+            context.pendingTools.push(pending);
+            offer({
+              ...base(context, { itemId }),
+              type: "item.started",
+              payload: {
+                itemType: pending.itemType,
+                status: "inProgress",
+                title: pending.name,
+                data: { toolCallId: pending.itemId, toolName: pending.name },
+              },
+              raw: raw("tool-lifecycle", { eventName, stepIdx: stepIndex, name }),
+            } satisfies ProviderRuntimeEvent);
+          }
+        } else if (eventName === "post-tool" && stepIndex !== undefined) {
+          const pendingIndex = context.pendingTools.findIndex(
+            (pending) => pending.stepIndex === stepIndex,
+          );
+          const pending =
+            pendingIndex >= 0 ? context.pendingTools.splice(pendingIndex, 1)[0] : undefined;
+          if (pending) {
+            const failed =
+              payload.failed === true ||
+              (typeof payload.error === "string" && payload.error.trim().length > 0);
+            offer({
+              ...base(context, { itemId: pending.itemId }),
+              type: "item.completed",
+              payload: {
+                itemType: pending.itemType,
+                status: failed ? "failed" : "completed",
+                title: pending.name,
+                data: { toolCallId: pending.itemId, toolName: pending.name },
+              },
+              raw: raw("tool-lifecycle", {
+                eventName,
+                stepIdx: stepIndex,
+                name: pending.name,
+                failed,
+              }),
+            } satisfies ProviderRuntimeEvent);
+          }
+        }
         // Agent finished: if the print process lingers, tear it down so the
         // close handler (or interrupt fallback) can settle the turn (#465).
         if (eventName === "stop" && context.activeProcess && !context.turnTerminalEmitted) {
@@ -1001,6 +1027,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           processedTranscriptBytes: 0,
           processedSteps: new Set(),
           pendingTools: [],
+          nextToolSequence: 0,
           sawAssistant: false,
           interrupted: false,
           stopped: false,
@@ -1120,6 +1147,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         context.processedSteps.clear();
         yield* Effect.promise(() => markExistingTranscriptStepsProcessed(context));
         context.pendingTools = [];
+        context.nextToolSequence = 0;
         context.sawAssistant = false;
         context.interrupted = false;
         context.turnTerminalEmitted = false;

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -7,7 +7,8 @@ import { CheckpointRef, MessageId, ThreadId, TurnId } from "@synara/contracts";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { formatShortTimestamp } from "../../timestampFormat";
-import type { WorkLogEntry } from "../../workLog";
+import { makeActivity } from "../../storeTestFixtures";
+import { deriveWorkLogEntries, type WorkLogEntry } from "../../workLog";
 import { COLLAPSED_USER_MESSAGE_MAX_CHARS } from "./userMessageCollapse";
 
 const TOOLTIP_TRIGGER_MARKER = 'data-base-ui-tooltip-trigger=""';
@@ -1737,6 +1738,78 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain(">Thinking<");
     expect(markup).toContain("Inspecting apps/web/src/store.ts");
     expect(markup).not.toContain("Reasoning trace Inspecting");
+  });
+
+  it.each([
+    {
+      provider: "Anti-Gravity",
+      expectedText: "Run_command",
+      activity: makeActivity({
+        id: "antigravity-live-tool",
+        createdAt: "2026-03-17T19:12:28.100Z",
+        turnId: "turn-provider-live-tool",
+        kind: "tool.started",
+        summary: "run_command started",
+        payload: {
+          itemType: "command_execution",
+          status: "inProgress",
+          title: "run_command",
+          data: {
+            toolCallId: "antigravity-tool-1",
+            toolName: "run_command",
+          },
+        },
+      }),
+    },
+    {
+      provider: "Codex",
+      expectedText: "Checking git status",
+      activity: makeActivity({
+        id: "codex-live-tool",
+        createdAt: "2026-03-17T19:12:28.100Z",
+        turnId: "turn-provider-live-tool",
+        kind: "tool.started",
+        summary: "Ran command started",
+        payload: {
+          itemType: "command_execution",
+          status: "inProgress",
+          title: "Ran command",
+          data: {
+            item: {
+              type: "commandExecution",
+              id: "codex-tool-1",
+              command: "/bin/zsh -lc 'git status --short'",
+              status: "inProgress",
+              commandActions: [{ type: "unknown", command: "git status --short" }],
+            },
+          },
+        },
+      }),
+    },
+  ])("renders $provider tool activity beside live Thinking", async ({ activity, expectedText }) => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const activeTurnId = TurnId.makeUnsafe("turn-provider-live-tool");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...makeTimelineBaseProps()}
+        isWorking
+        activeTurnInProgress
+        activeTurnId={activeTurnId}
+        activeTurnStartedAt="2026-03-17T19:12:28.000Z"
+        timelineEntries={deriveWorkLogEntries([activity], activeTurnId).map((entry) => ({
+          id: entry.id,
+          kind: "work" as const,
+          createdAt: entry.createdAt,
+          entry,
+        }))}
+      />,
+    );
+
+    expect(markup).toContain('data-timeline-row-kind="work"');
+    expect(markup).toContain('data-work-entry-display-text="true"');
+    expect(markup).toContain('data-live-activity-meta="true"');
+    expect(markup).toContain(">Thinking<");
+    expect(markup).toContain(expectedText);
   });
 
   it("shows Loading when a new local send has no server turn id yet", async () => {

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -1402,6 +1402,39 @@ describe("deriveWorkLogEntries", () => {
     expect(deriveWorkLogEntries(activities, undefined)).toEqual([]);
   });
 
+  it("keeps a named Anti-Gravity command visible before arguments are available", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "antigravity-command-start",
+        createdAt: "2026-05-08T21:00:00.000Z",
+        kind: "tool.started",
+        summary: "run_command started",
+        payload: {
+          itemType: "command_execution",
+          status: "inProgress",
+          title: "run_command",
+          data: {
+            toolCallId: "antigravity-tool-1",
+            toolName: "run_command",
+          },
+        },
+      }),
+    ];
+
+    expect(deriveWorkLogEntries(activities, undefined)).toMatchObject([
+      {
+        id: "antigravity-command-start",
+        itemType: "command_execution",
+        toolName: "run_command",
+        toolStatus: "running",
+        liveActivity: {
+          state: "running_tool",
+          startedAt: "2026-05-08T21:00:00.000Z",
+        },
+      },
+    ]);
+  });
+
   it("retains a filtered Codex command start timestamp after lifecycle correlation", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -515,7 +515,8 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
     activity.kind === "tool.started" &&
     itemType === "command_execution" &&
     !commandAction &&
-    !commandPreview.command
+    !commandPreview.command &&
+    !toolName
   ) {
     entry.suppressStandaloneCommandStart = true;
   }


### PR DESCRIPTION
Closes #547

## Summary

- project Anti-Gravity `PreToolUse` / `PostToolUse` hooks into the existing canonical tool lifecycle activity path
- retain only tool name, correlation id, and terminal state; strip tool arguments and error text before capture/projection
- keep named command starts visible in the shared bounded, collapsible Thinking/work surface without changing assistant streaming or auto-scroll behavior
- cover Anti-Gravity and Codex projection/rendering plus Anti-Gravity success/failure lifecycle behavior

## Verification

- `bun run --cwd apps/server test src/provider/Layers/AntigravityAdapter.test.ts src/orchestration/providerRuntimeActivityProjection.test.ts` (35 passed)
- `bun run --cwd apps/web test src/workLog.test.ts src/components/chat/MessagesTimeline.test.tsx` (145 passed)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Antigravity runtime event sourcing and what sensitive hook data is persisted or projected; behavior is covered by new adapter, projection, work-log, and timeline tests.
> 
> **Overview**
> Anti-Gravity **live tool activity** now comes from **PreToolUse / PostToolUse** hooks instead of inferring tools from transcript steps, so Antigravity and Codex share the same canonical `item.started` / `item.completed` → work-log path.
> 
> The capture hook **rewrites hook payloads before they are written**: it keeps correlation fields (`stepIdx`, conversation metadata) and the **tool name**, drops **arguments and error text** (post-tool only records a boolean failure), and the adapter emits runtime items with **`toolCallId` + `toolName` only**—no streamed tool output or result bodies from the transcript.
> 
> On the web, **command tool starts are no longer hidden** when only a tool name is known (no command preview yet), so named Anti-Gravity commands stay visible in the Thinking/work surface beside live activity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57d67d2ea7f53fb99ae04871c266e03af10029bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->