### PR TITLE
Make Explorer files editable and saveable

### DIFF
--- a/apps/server/src/workspace/Layers/WorkspaceFileSystem.test.ts
+++ b/apps/server/src/workspace/Layers/WorkspaceFileSystem.test.ts
@@ -57,11 +57,14 @@ it.layer(TestLayer)("WorkspaceFileSystemLive", (it) => {
           relativePath: "src/app.ts",
         });
 
-        expect(result).toEqual({
+        expect(result).toMatchObject({
           relativePath: "src/app.ts",
           contents: "export const value = 1;\n",
           truncated: false,
+          encoding: "utf8",
+          lineEnding: "lf",
         });
+        expect(result.version).toMatch(/^sha256:[0-9a-f]{64}$/);
       }),
     );
 
@@ -81,7 +84,27 @@ it.layer(TestLayer)("WorkspaceFileSystemLive", (it) => {
           relativePath: "large.txt",
           contents: "abc",
           truncated: true,
+          version: null,
+          encoding: null,
+          lineEnding: null,
         });
+      }),
+    );
+
+    it.effect("refuses binary files instead of exposing them as editable text", () =>
+      Effect.gen(function* () {
+        const workspaceFileSystem = yield* WorkspaceFileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir;
+        yield* Effect.promise(() =>
+          NodeFs.writeFile(path.join(cwd, "binary.dat"), Buffer.from([0x01, 0x00, 0x02])),
+        );
+
+        const error = yield* workspaceFileSystem
+          .readFile({ cwd, relativePath: "binary.dat" })
+          .pipe(Effect.flip);
+
+        expect(error.message).toContain("File appears to be binary");
       }),
     );
 
@@ -105,11 +128,14 @@ it.layer(TestLayer)("WorkspaceFileSystemLive", (it) => {
             previewGrant: grant.grant,
           });
 
-          expect(result).toEqual({
+          expect(result).toMatchObject({
             relativePath: absolutePath,
             contents: "local file\n",
             truncated: false,
+            encoding: "utf8",
+            lineEnding: "lf",
           });
+          expect(result.version).toMatch(/^sha256:[0-9a-f]{64}$/);
         }),
     );
 
@@ -150,11 +176,14 @@ it.layer(TestLayer)("WorkspaceFileSystemLive", (it) => {
           relativePath: "chatReferences.test.ts",
         });
 
-        expect(result).toEqual({
+        expect(result).toMatchObject({
           relativePath: "apps/web/src/lib/chatReferences.test.ts",
           contents: "export const v = 1;\n",
           truncated: false,
+          encoding: "utf8",
+          lineEnding: "lf",
         });
+        expect(result.version).toMatch(/^sha256:[0-9a-f]{64}$/);
       }),
     );
 
@@ -260,8 +289,131 @@ it.layer(TestLayer)("WorkspaceFileSystemLive", (it) => {
           .readFileString(path.join(cwd, "plans/effect-rpc.md"))
           .pipe(Effect.orDie);
 
-        expect(result).toEqual({ relativePath: "plans/effect-rpc.md" });
+        expect(result.relativePath).toBe("plans/effect-rpc.md");
+        expect(result.version).toMatch(/^sha256:[0-9a-f]{64}$/);
         expect(saved).toBe("# Plan\n");
+      }),
+    );
+
+    it.effect("safely saves the loaded version while preserving UTF-8 BOM and CRLF", () =>
+      Effect.gen(function* () {
+        const workspaceFileSystem = yield* WorkspaceFileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir;
+        const absolutePath = path.join(cwd, "notes.txt");
+        yield* Effect.promise(() =>
+          NodeFs.writeFile(
+            absolutePath,
+            Buffer.from([0xef, 0xbb, 0xbf, ...Buffer.from("one\r\ntwo\r\n")]),
+          ),
+        );
+
+        const loaded = yield* workspaceFileSystem.readFile({ cwd, relativePath: "notes.txt" });
+        expect(loaded).toMatchObject({
+          contents: "one\ntwo\n",
+          encoding: "utf8-bom",
+          lineEnding: "crlf",
+          truncated: false,
+        });
+
+        const saved = yield* workspaceFileSystem.writeFile({
+          cwd,
+          relativePath: loaded.relativePath,
+          contents: "one edited\ntwo\n",
+          expectedVersion: loaded.version!,
+          encoding: loaded.encoding!,
+          lineEnding: loaded.lineEnding!,
+        });
+        const savedBytes = yield* Effect.promise(() => NodeFs.readFile(absolutePath));
+
+        expect(saved.version).toMatch(/^sha256:[0-9a-f]{64}$/);
+        expect(saved.version).not.toBe(loaded.version);
+        expect(savedBytes.subarray(0, 3)).toEqual(Buffer.from([0xef, 0xbb, 0xbf]));
+        expect(savedBytes.subarray(3).toString("utf8")).toBe("one edited\r\ntwo\r\n");
+      }),
+    );
+
+    it.effect("refuses a guarded save when the file changed after loading", () =>
+      Effect.gen(function* () {
+        const workspaceFileSystem = yield* WorkspaceFileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir;
+        const absolutePath = path.join(cwd, "shared.txt");
+        yield* writeTextFile(cwd, "shared.txt", "loaded\n");
+        const loaded = yield* workspaceFileSystem.readFile({ cwd, relativePath: "shared.txt" });
+        yield* Effect.promise(() => NodeFs.writeFile(absolutePath, "agent!\n"));
+
+        const error = yield* workspaceFileSystem
+          .writeFile({
+            cwd,
+            relativePath: loaded.relativePath,
+            contents: "manual edit\n",
+            expectedVersion: loaded.version!,
+            encoding: loaded.encoding!,
+            lineEnding: loaded.lineEnding!,
+          })
+          .pipe(Effect.flip);
+
+        expect(error._tag).toBe("WorkspaceFileConflictError");
+        expect(error.message).toContain("changed on disk");
+        expect(yield* Effect.promise(() => NodeFs.readFile(absolutePath, "utf8"))).toBe(
+          "agent!\n",
+        );
+      }),
+    );
+
+    it.effect("refuses a guarded save when the loaded file was deleted", () =>
+      Effect.gen(function* () {
+        const workspaceFileSystem = yield* WorkspaceFileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir;
+        const absolutePath = path.join(cwd, "removed.txt");
+        yield* writeTextFile(cwd, "removed.txt", "loaded\n");
+        const loaded = yield* workspaceFileSystem.readFile({ cwd, relativePath: "removed.txt" });
+        yield* Effect.promise(() => NodeFs.unlink(absolutePath));
+
+        const error = yield* workspaceFileSystem
+          .writeFile({
+            cwd,
+            relativePath: loaded.relativePath,
+            contents: "manual edit\n",
+            expectedVersion: loaded.version!,
+            encoding: loaded.encoding!,
+            lineEnding: loaded.lineEnding!,
+          })
+          .pipe(Effect.flip);
+
+        expect(error._tag).toBe("WorkspaceFileDeletedError");
+        expect(error.message).toContain("removed from disk");
+        expect(yield* Effect.promise(() => NodeFs.stat(absolutePath).catch(() => null))).toBeNull();
+      }),
+    );
+
+    it.effect("surfaces permission failures from guarded saves", () =>
+      Effect.gen(function* () {
+        if (process.platform === "win32") return;
+
+        const workspaceFileSystem = yield* WorkspaceFileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir;
+        const absolutePath = path.join(cwd, "read-only.txt");
+        yield* writeTextFile(cwd, "read-only.txt", "loaded\n");
+        const loaded = yield* workspaceFileSystem.readFile({ cwd, relativePath: "read-only.txt" });
+        yield* Effect.promise(() => NodeFs.chmod(absolutePath, 0o444));
+
+        const error = yield* workspaceFileSystem
+          .writeFile({
+            cwd,
+            relativePath: loaded.relativePath,
+            contents: "manual edit\n",
+            expectedVersion: loaded.version!,
+            encoding: loaded.encoding!,
+            lineEnding: loaded.lineEnding!,
+          })
+          .pipe(Effect.flip);
+
+        expect(error.message).toContain("workspaceFileSystem.writeFile failed");
+        expect(yield* Effect.promise(() => NodeFs.readFile(absolutePath, "utf8"))).toBe("loaded\n");
       }),
     );
 
@@ -297,7 +449,14 @@ it.layer(TestLayer)("WorkspaceFileSystemLive", (it) => {
         const fileSystem = yield* FileSystem.FileSystem;
 
         const error = yield* workspaceFileSystem
-          .writeFile({ cwd, relativePath: "../escape.md", contents: "# nope\n" })
+          .writeFile({
+            cwd,
+            relativePath: "../escape.md",
+            contents: "# nope\n",
+            expectedVersion: `sha256:${"0".repeat(64)}`,
+            encoding: "utf8",
+            lineEnding: "lf",
+          })
           .pipe(Effect.flip);
 
         expect(error.message).toContain(
@@ -387,7 +546,8 @@ it.layer(TestLayer)("WorkspaceFileSystemLive", (it) => {
           NodeFs.readFile(path.join(cwd, "actual/new/deep/file.txt"), "utf8"),
         );
 
-        expect(result).toEqual({ relativePath: "linked-inside/new/deep/file.txt" });
+        expect(result.relativePath).toBe("linked-inside/new/deep/file.txt");
+        expect(result.version).toMatch(/^sha256:[0-9a-f]{64}$/);
         expect(saved).toBe("allowed\n");
       }),
     );

--- a/apps/server/src/workspace/Layers/WorkspaceFileSystem.ts
+++ b/apps/server/src/workspace/Layers/WorkspaceFileSystem.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from "node:crypto";
-import { constants as NodeFsConstants } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { constants as NodeFsConstants, type BigIntStats } from "node:fs";
 import * as NodeFs from "node:fs/promises";
 import * as NodePath from "node:path";
 
@@ -8,6 +8,8 @@ import { Effect, Layer, Path } from "effect";
 
 import { resolveLocalPreviewGrantRealPath } from "../../localImageFiles";
 import {
+  WorkspaceFileConflictError,
+  WorkspaceFileDeletedError,
   WorkspaceFileSystem,
   WorkspaceFileSystemError,
   type WorkspaceFileSystemShape,
@@ -22,6 +24,43 @@ import {
 } from "../realPathContainment";
 
 const DEFAULT_READ_FILE_MAX_BYTES = 1_000_000;
+const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf]);
+
+function fileVersion(bytes: Uint8Array): string {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function detectLineEnding(contents: string): "lf" | "crlf" | "cr" | "mixed" {
+  const crlfCount = contents.match(/\r\n/g)?.length ?? 0;
+  const lfCount = contents.match(/(?<!\r)\n/g)?.length ?? 0;
+  const crCount = contents.match(/\r(?!\n)/g)?.length ?? 0;
+  const styles = Number(crlfCount > 0) + Number(lfCount > 0) + Number(crCount > 0);
+  if (styles > 1) return "mixed";
+  if (crlfCount > 0) return "crlf";
+  if (crCount > 0) return "cr";
+  return "lf";
+}
+
+function normalizeLineEndings(contents: string): string {
+  return contents.replaceAll("\r\n", "\n").replaceAll("\r", "\n");
+}
+
+function encodeWorkspaceText(
+  contents: string,
+  encoding: "utf8" | "utf8-bom",
+  lineEnding: "lf" | "crlf" | "cr",
+): Buffer {
+  const normalizedContents = normalizeLineEndings(contents);
+  const encodedContents = Buffer.from(
+    lineEnding === "lf"
+      ? normalizedContents
+      : normalizedContents.replaceAll("\n", lineEnding === "crlf" ? "\r\n" : "\r"),
+    "utf8",
+  );
+  return encoding === "utf8-bom"
+    ? Buffer.concat([UTF8_BOM, encodedContents])
+    : encodedContents;
+}
 
 function isBinaryLike(bytes: Uint8Array): boolean {
   return bytes.includes(0);
@@ -31,16 +70,69 @@ function isFileNotFoundError(cause: unknown): boolean {
   return (cause as NodeJS.ErrnoException | null)?.code === "ENOENT";
 }
 
-async function writeFileStringAtomically(
+function sameFileState(left: BigIntStats, right: BigIntStats): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+async function readCurrentFileVersion(
   workspaceRoot: string,
   filePath: string,
-  contents: string,
+): Promise<{ readonly version: string; readonly stat: BigIntStats }> {
+  const handle = await NodeFs.open(filePath, "r").catch((cause: unknown) => {
+    if (isFileNotFoundError(cause)) {
+      throw new WorkspaceFileDeletedError({ cwd: workspaceRoot, relativePath: filePath });
+    }
+    throw cause;
+  });
+  try {
+    const beforeReadStat = await handle.stat({ bigint: true });
+    const buffer = Buffer.alloc(DEFAULT_READ_FILE_MAX_BYTES + 1);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    const afterReadStat = await handle.stat({ bigint: true });
+    const pathStat = await NodeFs.stat(filePath, { bigint: true }).catch((cause: unknown) => {
+      if (isFileNotFoundError(cause)) {
+        throw new WorkspaceFileDeletedError({ cwd: workspaceRoot, relativePath: filePath });
+      }
+      throw cause;
+    });
+    if (
+      !afterReadStat.isFile() ||
+      bytesRead > DEFAULT_READ_FILE_MAX_BYTES ||
+      afterReadStat.size !== BigInt(bytesRead) ||
+      !sameFileState(beforeReadStat, afterReadStat) ||
+      !sameFileState(afterReadStat, pathStat)
+    ) {
+      throw new WorkspaceFileConflictError({ cwd: workspaceRoot, relativePath: filePath });
+    }
+    return { version: fileVersion(buffer.subarray(0, bytesRead)), stat: afterReadStat };
+  } finally {
+    await handle.close();
+  }
+}
+
+async function writeFileAtomically(
+  workspaceRoot: string,
+  filePath: string,
+  contents: Uint8Array,
+  expectedVersion?: string,
 ): Promise<void> {
   const realRoot = await NodeFs.realpath(workspaceRoot);
   const targetStat = await NodeFs.stat(filePath).catch((cause: unknown) => {
     if (isFileNotFoundError(cause)) return null;
     throw cause;
   });
+  if (expectedVersion !== undefined && targetStat === null) {
+    throw new WorkspaceFileDeletedError({ cwd: workspaceRoot, relativePath: filePath });
+  }
+  if (expectedVersion !== undefined) {
+    await NodeFs.access(filePath, NodeFsConstants.W_OK);
+  }
   const mode = targetStat === null ? 0o666 : targetStat.mode & 0o777;
   const temporaryPath = NodePath.join(
     NodePath.dirname(filePath),
@@ -83,7 +175,7 @@ async function writeFileStringAtomically(
       // bits through the already-validated descriptor before it is renamed.
       await handle.chmod(mode);
     }
-    await handle.writeFile(contents, "utf8");
+    await handle.writeFile(contents);
     await handle.sync();
     await handle.close();
     handle = undefined;
@@ -104,6 +196,23 @@ async function writeFileStringAtomically(
       temporaryPathStatBeforeRename.ino !== temporaryIdentity.ino
     ) {
       throw new Error("Write target parent escaped the workspace root.");
+    }
+    if (expectedVersion !== undefined) {
+      const current = await readCurrentFileVersion(workspaceRoot, filePath);
+      if (current.version !== expectedVersion) {
+        throw new WorkspaceFileConflictError({ cwd: workspaceRoot, relativePath: filePath });
+      }
+      const finalTargetStat = await NodeFs.stat(filePath, { bigint: true }).catch(
+        (cause: unknown) => {
+          if (isFileNotFoundError(cause)) {
+            throw new WorkspaceFileDeletedError({ cwd: workspaceRoot, relativePath: filePath });
+          }
+          throw cause;
+        },
+      );
+      if (!sameFileState(current.stat, finalTargetStat)) {
+        throw new WorkspaceFileConflictError({ cwd: workspaceRoot, relativePath: filePath });
+      }
     }
     await NodeFs.rename(temporaryPath, filePath);
   } catch (cause) {
@@ -317,10 +426,40 @@ export const makeWorkspaceFileSystem = Effect.gen(function* () {
         });
       }
 
+      if (fileSize > bytes.length) {
+        return {
+          relativePath: target.relativePath,
+          contents: bytes.toString("utf8"),
+          truncated: true,
+          version: null,
+          encoding: null,
+          lineEnding: null,
+        };
+      }
+
+      const hasUtf8Bom = bytes.length >= UTF8_BOM.length && bytes.subarray(0, 3).equals(UTF8_BOM);
+      const textBytes = hasUtf8Bom ? bytes.subarray(UTF8_BOM.length) : bytes;
+      let decodedContents: string;
+      try {
+        decodedContents = new TextDecoder("utf-8", { fatal: true }).decode(textBytes);
+      } catch (cause) {
+        return yield* new WorkspaceFileSystemError({
+          cwd: input.cwd,
+          relativePath: input.relativePath,
+          operation: "workspaceFileSystem.readFile",
+          detail: "File encoding is not supported for text editing.",
+          cause,
+        });
+      }
+      const lineEnding = detectLineEnding(decodedContents);
+
       return {
         relativePath: target.relativePath,
-        contents: bytes.toString("utf8"),
-        truncated: fileSize > bytes.length,
+        contents: normalizeLineEndings(decodedContents),
+        truncated: false,
+        version: fileVersion(bytes),
+        encoding: hasUtf8Bom ? "utf8-bom" : "utf8",
+        lineEnding,
       };
     },
   );
@@ -333,12 +472,51 @@ export const makeWorkspaceFileSystem = Effect.gen(function* () {
       relativePath: input.relativePath,
     });
 
+    const guardedWrite = input.expectedVersion !== undefined;
+    if (
+      guardedWrite &&
+      (input.encoding === undefined ||
+        input.lineEnding === undefined ||
+        input.lineEnding === "mixed")
+    ) {
+      return yield* new WorkspaceFileSystemError({
+        cwd: input.cwd,
+        relativePath: input.relativePath,
+        operation: "workspaceFileSystem.writeFile",
+        detail: "Guarded text saves require a supported encoding and consistent line endings.",
+      });
+    }
+    const bytes = guardedWrite
+      ? encodeWorkspaceText(
+          input.contents,
+          input.encoding as "utf8" | "utf8-bom",
+          input.lineEnding as "lf" | "crlf" | "cr",
+        )
+      : Buffer.from(input.contents, "utf8");
+    if (guardedWrite && bytes.length > DEFAULT_READ_FILE_MAX_BYTES) {
+      return yield* new WorkspaceFileSystemError({
+        cwd: input.cwd,
+        relativePath: input.relativePath,
+        operation: "workspaceFileSystem.writeFile",
+        detail: "The edited file is too large to save from Explorer.",
+      });
+    }
+
     yield* Effect.tryPromise({
       try: async () => {
-        const initialRealTarget = await prepareRealPathForWriteWithinRoot(
-          input.cwd,
-          target.absolutePath,
-        );
+        const initialRealTarget = guardedWrite
+          ? await resolveRealPathWithinRoot(input.cwd, target.absolutePath).catch(
+              (cause: unknown) => {
+                if (isFileNotFoundError(cause)) {
+                  throw new WorkspaceFileDeletedError({
+                    cwd: input.cwd,
+                    relativePath: input.relativePath,
+                  });
+                }
+                throw cause;
+              },
+            )
+          : await prepareRealPathForWriteWithinRoot(input.cwd, target.absolutePath);
         if (initialRealTarget === null) {
           return "outside" as const;
         }
@@ -353,17 +531,24 @@ export const makeWorkspaceFileSystem = Effect.gen(function* () {
           return "outside" as const;
         }
 
-        await writeFileStringAtomically(input.cwd, finalRealTarget, input.contents);
+        await writeFileAtomically(input.cwd, finalRealTarget, bytes, input.expectedVersion);
         return "written" as const;
       },
-      catch: (cause) =>
-        new WorkspaceFileSystemError({
+      catch: (cause) => {
+        if (
+          cause instanceof WorkspaceFileConflictError ||
+          cause instanceof WorkspaceFileDeletedError
+        ) {
+          return cause;
+        }
+        return new WorkspaceFileSystemError({
           cwd: input.cwd,
           relativePath: input.relativePath,
           operation: "workspaceFileSystem.writeFile",
           detail: cause instanceof Error ? cause.message : String(cause),
           cause,
-        }),
+        });
+      },
     }).pipe(
       Effect.flatMap((result) =>
         result === "outside"
@@ -377,7 +562,7 @@ export const makeWorkspaceFileSystem = Effect.gen(function* () {
       ),
     );
     yield* workspaceEntries.invalidate(input.cwd);
-    return { relativePath: target.relativePath };
+    return { relativePath: target.relativePath, version: fileVersion(bytes) };
   });
 
   return { readFile, writeFile } satisfies WorkspaceFileSystemShape;

--- a/apps/server/src/workspace/Services/WorkspaceFileSystem.ts
+++ b/apps/server/src/workspace/Services/WorkspaceFileSystem.ts
@@ -23,6 +23,30 @@ export class WorkspaceFileSystemError extends Schema.TaggedErrorClass<WorkspaceF
   }
 }
 
+export class WorkspaceFileConflictError extends Schema.TaggedErrorClass<WorkspaceFileConflictError>()(
+  "WorkspaceFileConflictError",
+  {
+    cwd: Schema.String,
+    relativePath: Schema.String,
+  },
+) {
+  override get message(): string {
+    return "This file changed on disk after it was opened. Reload it before saving to avoid overwriting those changes.";
+  }
+}
+
+export class WorkspaceFileDeletedError extends Schema.TaggedErrorClass<WorkspaceFileDeletedError>()(
+  "WorkspaceFileDeletedError",
+  {
+    cwd: Schema.String,
+    relativePath: Schema.String,
+  },
+) {
+  override get message(): string {
+    return "This file was removed from disk after it was opened. Reload the Explorer before saving.";
+  }
+}
+
 export interface WorkspaceFileSystemShape {
   readonly readFile: (
     input: ProjectReadFileInput,
@@ -34,7 +58,10 @@ export interface WorkspaceFileSystemShape {
     input: ProjectWriteFileInput,
   ) => Effect.Effect<
     ProjectWriteFileResult,
-    WorkspaceFileSystemError | WorkspacePathOutsideRootError
+    | WorkspaceFileConflictError
+    | WorkspaceFileDeletedError
+    | WorkspaceFileSystemError
+    | WorkspacePathOutsideRootError
   >;
 }
 

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -103,7 +103,11 @@ import { TerminalManager } from "./terminal/Services/Manager";
 import { TerminalThreadTitleTracker } from "./terminal/terminalThreadTitleTracker";
 import { resolveOutOfRootFileReference } from "./workspace/outOfRootFileReference";
 import { WorkspaceEntries } from "./workspace/Services/WorkspaceEntries";
-import { WorkspaceFileSystem } from "./workspace/Services/WorkspaceFileSystem";
+import {
+  WorkspaceFileConflictError,
+  WorkspaceFileDeletedError,
+  WorkspaceFileSystem,
+} from "./workspace/Services/WorkspaceFileSystem";
 import {
   MAX_STREAMS_PER_RPC_CLIENT,
   MAX_THREAD_STREAMS_PER_RPC_CLIENT,
@@ -1100,7 +1104,23 @@ const makeWsRpcHandlersLayer = () =>
             "Failed to create local file preview grant",
           ),
         [WS_METHODS.projectsWriteFile]: (input) =>
-          rpcEffect(workspaceFileSystem.writeFile(input), "Failed to write workspace file"),
+          workspaceFileSystem.writeFile(input).pipe(
+            Effect.mapError((cause) =>
+              cause instanceof WorkspaceFileConflictError
+                ? new WsRpcError({
+                    message: cause.message,
+                    code: "WORKSPACE_FILE_CONFLICT",
+                    retryable: false,
+                  })
+                : cause instanceof WorkspaceFileDeletedError
+                  ? new WsRpcError({
+                      message: cause.message,
+                      code: "WORKSPACE_FILE_DELETED",
+                      retryable: false,
+                    })
+                  : toWsRpcError(cause, "Failed to write workspace file"),
+            ),
+          ),
         [WS_METHODS.projectsRunDevServer]: (input) =>
           rpcEffect(devServerManager.run(input), "Failed to start dev server"),
         [WS_METHODS.projectsStopDevServer]: (input) =>

--- a/apps/web/src/components/EditorWorkspaceView.tsx
+++ b/apps/web/src/components/EditorWorkspaceView.tsx
@@ -629,6 +629,7 @@ export function EditorWorkspaceView(props: EditorWorkspaceViewProps) {
                 <WorkspaceFilePreview
                   workspaceRoot={props.workspaceRoot}
                   filePath={props.selectedFilePath}
+                  editable
                   onReferenceInChat={props.onReferenceInChat}
                   onAskWhyInChat={props.onAskWhyInChat}
                   onCommentInChat={props.onCommentInChat}

--- a/apps/web/src/components/WorkspaceFilePreview.editing.browser.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.editing.browser.tsx
@@ -131,6 +131,59 @@ it("keeps the buffer dirty and shows guarded write failures", async () => {
   }
 });
 
+it("keeps markdown task previews and guarded versions in sync after an editor save", async () => {
+  const markdownPath = "README.md";
+  const taskVersion = `sha256:${"3".repeat(64)}`;
+  let completeTaskWrite: ((result: { relativePath: string; version: string }) => void) | null = null;
+  const pendingTaskWrite = new Promise<{ relativePath: string; version: string }>((resolve) => {
+    completeTaskWrite = resolve;
+  });
+  const readFile = vi.fn().mockResolvedValue(
+    loadedFile({
+      relativePath: markdownPath,
+      contents: "- [ ] task\n",
+    }),
+  );
+  const writeFile = vi
+    .fn()
+    .mockResolvedValueOnce({ relativePath: markdownPath, version: SAVED_VERSION })
+    .mockReturnValueOnce(pendingTaskWrite);
+  const restoreNativeApi = installNativeApi({
+    projects: { readFile, writeFile },
+  } as unknown as NativeApi);
+
+  try {
+    await render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <WorkspaceFilePreview workspaceRoot={WORKSPACE_ROOT} filePath={markdownPath} editable />
+      </QueryClientProvider>,
+    );
+
+    const editor = page.getByRole("textbox", { name: `Edit ${markdownPath}` });
+    await editor.fill("- [ ] updated task\n");
+    pressKeyboardSave(editor.element());
+    await vi.waitFor(() => expect(writeFile).toHaveBeenCalledTimes(1));
+    await page.getByRole("radio", { name: "Preview" }).click();
+
+    const checkbox = page.getByRole("checkbox");
+    await checkbox.click();
+    await expect.element(checkbox).toBeChecked();
+    await vi.waitFor(() =>
+      expect(writeFile).toHaveBeenNthCalledWith(2, {
+        cwd: WORKSPACE_ROOT,
+        relativePath: markdownPath,
+        contents: "- [x] updated task\n",
+        expectedVersion: SAVED_VERSION,
+        encoding: "utf8",
+        lineEnding: "lf",
+      }),
+    );
+    completeTaskWrite?.({ relativePath: markdownPath, version: taskVersion });
+  } finally {
+    restoreNativeApi();
+  }
+});
+
 it("keeps oversized and mixed-line-ending files read-only", async () => {
   const readFile = vi
     .fn()

--- a/apps/web/src/components/WorkspaceFilePreview.editing.browser.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.editing.browser.tsx
@@ -1,0 +1,170 @@
+// FILE: WorkspaceFilePreview.editing.browser.tsx
+// Purpose: Browser regressions for guarded Explorer editing and save-state UX.
+// Layer: Focused component integration tests
+
+import "../index.css";
+
+import type { NativeApi, ProjectReadFileResult } from "@synara/contracts";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { page } from "vitest/browser";
+import { afterEach, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { WorkspaceFilePreview } from "./WorkspaceFilePreview";
+
+const WORKSPACE_ROOT = "/Users/tester/project";
+const FILE_PATH = "src/app.ts";
+const LOADED_VERSION = `sha256:${"1".repeat(64)}`;
+const SAVED_VERSION = `sha256:${"2".repeat(64)}`;
+
+function installNativeApi(api: NativeApi): () => void {
+  const previousDescriptor = Object.getOwnPropertyDescriptor(window, "nativeApi");
+  Object.defineProperty(window, "nativeApi", {
+    configurable: true,
+    value: api,
+  });
+  return () => {
+    if (previousDescriptor) {
+      Object.defineProperty(window, "nativeApi", previousDescriptor);
+    } else {
+      Reflect.deleteProperty(window, "nativeApi");
+    }
+  };
+}
+
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function loadedFile(overrides: Partial<ProjectReadFileResult> = {}): ProjectReadFileResult {
+  return {
+    relativePath: FILE_PATH,
+    contents: "export const value = 1;\n",
+    truncated: false,
+    version: LOADED_VERSION,
+    encoding: "utf8",
+    lineEnding: "lf",
+    ...overrides,
+  };
+}
+
+function pressKeyboardSave(element: HTMLElement): void {
+  element.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key: "s",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+it("tracks dirty state and saves the loaded version with Ctrl+S", async () => {
+  const readFile = vi.fn().mockResolvedValue(loadedFile());
+  const writeFile = vi.fn().mockResolvedValue({ relativePath: FILE_PATH, version: SAVED_VERSION });
+  const restoreNativeApi = installNativeApi({
+    projects: { readFile, writeFile },
+  } as unknown as NativeApi);
+
+  try {
+    await render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <WorkspaceFilePreview workspaceRoot={WORKSPACE_ROOT} filePath={FILE_PATH} editable />
+      </QueryClientProvider>,
+    );
+
+    const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
+    await expect.element(editor).toHaveValue("export const value = 1;\n");
+    await editor.fill("export const value = 2;\n");
+    await expect.element(page.getByRole("status", { name: "Unsaved changes" })).toBeVisible();
+
+    pressKeyboardSave(editor.element());
+
+    await vi.waitFor(() =>
+      expect(writeFile).toHaveBeenCalledWith({
+        cwd: WORKSPACE_ROOT,
+        relativePath: FILE_PATH,
+        contents: "export const value = 2;\n",
+        expectedVersion: LOADED_VERSION,
+        encoding: "utf8",
+        lineEnding: "lf",
+      }),
+    );
+    await vi.waitFor(() =>
+      expect(document.querySelector('[aria-label="Unsaved changes"]')).toBeNull(),
+    );
+  } finally {
+    restoreNativeApi();
+  }
+});
+
+it("keeps the buffer dirty and shows guarded write failures", async () => {
+  const conflictMessage =
+    "This file changed on disk after it was opened. Reload it before saving to avoid overwriting those changes.";
+  const readFile = vi.fn().mockResolvedValue(loadedFile());
+  const writeFile = vi.fn().mockRejectedValue(new Error(conflictMessage));
+  const restoreNativeApi = installNativeApi({
+    projects: { readFile, writeFile },
+  } as unknown as NativeApi);
+
+  try {
+    await render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <WorkspaceFilePreview workspaceRoot={WORKSPACE_ROOT} filePath={FILE_PATH} editable />
+      </QueryClientProvider>,
+    );
+
+    const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
+    await editor.fill("manual edit\n");
+    pressKeyboardSave(editor.element());
+
+    await expect.element(page.getByRole("alert")).toHaveTextContent(conflictMessage);
+    await expect.element(page.getByRole("status", { name: "Unsaved changes" })).toBeVisible();
+    await expect.element(editor).toHaveValue("manual edit\n");
+    expect(writeFile).toHaveBeenCalledTimes(1);
+  } finally {
+    restoreNativeApi();
+  }
+});
+
+it("keeps oversized and mixed-line-ending files read-only", async () => {
+  const readFile = vi
+    .fn()
+    .mockResolvedValueOnce(
+      loadedFile({ truncated: true, version: null, encoding: null, lineEnding: null }),
+    )
+    .mockResolvedValueOnce(loadedFile({ lineEnding: "mixed" }));
+  const restoreNativeApi = installNativeApi({
+    projects: { readFile },
+  } as unknown as NativeApi);
+  const queryClient = makeQueryClient();
+
+  try {
+    const screen = await render(
+      <QueryClientProvider client={queryClient}>
+        <WorkspaceFilePreview workspaceRoot={WORKSPACE_ROOT} filePath={FILE_PATH} editable />
+      </QueryClientProvider>,
+    );
+    await vi.waitFor(() => expect(document.body.textContent).toContain("Shown partially"));
+    expect(document.querySelector("textarea")).toBeNull();
+
+    await screen.rerender(
+      <QueryClientProvider client={queryClient}>
+        <WorkspaceFilePreview
+          workspaceRoot={WORKSPACE_ROOT}
+          filePath="src/mixed.ts"
+          editable
+        />
+      </QueryClientProvider>,
+    );
+    await vi.waitFor(() => expect(readFile).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(document.body.textContent).toContain("Read-only"));
+    expect(document.querySelector("textarea")).toBeNull();
+  } finally {
+    restoreNativeApi();
+  }
+});

--- a/apps/web/src/components/WorkspaceFilePreview.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.tsx
@@ -343,7 +343,9 @@ function resolveFileEditBuffer(
     return makeFileEditBuffer(document);
   }
   const dirty = current.contents !== current.savedContents;
-  return !dirty && current.version !== document.version ? makeFileEditBuffer(document) : current;
+  const sourceChanged =
+    current.version !== document.version || current.savedContents !== document.contents;
+  return !dirty && sourceChanged ? makeFileEditBuffer(document) : current;
 }
 
 function readFileSaveError(error: unknown): string {
@@ -572,6 +574,11 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
         encoding: activeEditBuffer.encoding,
         lineEnding: activeEditBuffer.lineEnding,
       });
+      const options = projectReadFileQueryOptions({ cwd: workspaceRoot, relativePath: filePath });
+      queryClient.setQueryData<ProjectReadFileResult>(options.queryKey, (current) =>
+        current ? { ...current, contents: contentsToSave, version: result.version } : current,
+      );
+      taskFileDiskVersionRef.current.set(`${workspaceRoot}\0${filePath}`, result.version);
       setEditBuffer((current) =>
         current?.key === documentKey
           ? {
@@ -581,12 +588,6 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
               saving: false,
               error: null,
             }
-          : current,
-      );
-      const options = projectReadFileQueryOptions({ cwd: workspaceRoot, relativePath: filePath });
-      queryClient.setQueryData<ProjectReadFileResult>(options.queryKey, (current) =>
-        current
-          ? { ...current, contents: contentsToSave, version: result.version }
           : current,
       );
     } catch (error) {

--- a/apps/web/src/components/WorkspaceFilePreview.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.tsx
@@ -5,6 +5,11 @@
 // Layer: Web chat presentation component
 // Exports: WorkspaceFilePreview, isMarkdownPreviewablePath
 
+import type {
+  ProjectFileEncoding,
+  ProjectFileLineEnding,
+  ProjectReadFileResult,
+} from "@synara/contracts";
 import {
   isSupportedLocalImagePath,
   isSupportedLocalPdfPath,
@@ -295,11 +300,56 @@ export interface WorkspaceFilePreviewProps {
    * lets the user flip either way.
    */
   markdownPreviewDefault?: boolean;
+  /** Enables guarded editing for complete, supported files inside the workspace. */
+  editable?: boolean;
   /** Shown when no file is selected yet. */
   emptyState?: ReactNode;
   onReferenceInChat?: ((reference: ChatFileReference) => void) | undefined;
   onAskWhyInChat?: ((reference: ChatFileReference) => void) | undefined;
   onCommentInChat?: ((comment: FileCommentSelection) => void) | undefined;
+}
+
+type EditableLineEnding = Exclude<ProjectFileLineEnding, "mixed">;
+
+interface EditableFileDocument {
+  key: string;
+  relativePath: string;
+  contents: string;
+  version: string;
+  encoding: ProjectFileEncoding;
+  lineEnding: EditableLineEnding;
+}
+
+interface FileEditBuffer extends EditableFileDocument {
+  savedContents: string;
+  saving: boolean;
+  error: string | null;
+}
+
+function makeFileEditBuffer(document: EditableFileDocument): FileEditBuffer {
+  return {
+    ...document,
+    savedContents: document.contents,
+    saving: false,
+    error: null,
+  };
+}
+
+function resolveFileEditBuffer(
+  current: FileEditBuffer | null,
+  document: EditableFileDocument,
+): FileEditBuffer {
+  if (current?.key !== document.key) {
+    return makeFileEditBuffer(document);
+  }
+  const dirty = current.contents !== current.savedContents;
+  return !dirty && current.version !== document.version ? makeFileEditBuffer(document) : current;
+}
+
+function readFileSaveError(error: unknown): string {
+  return error instanceof Error && error.message.length > 0
+    ? error.message
+    : "Could not save this file.";
 }
 
 export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
@@ -308,6 +358,8 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
   const contentsRef = useRef<HTMLDivElement>(null);
   const taskWriteQueueRef = useRef<Promise<void>>(Promise.resolve());
   const latestTaskWriteVersionRef = useRef({ next: 0, byFile: new Map<string, number>() });
+  const taskFileDiskVersionRef = useRef(new Map<string, string>());
+  const [editBuffer, setEditBuffer] = useState<FileEditBuffer | null>(null);
   const {
     filePath: requestedFilePath,
     onAskWhyInChat,
@@ -433,7 +485,136 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
 
   const fileContents = fileQuery.data?.contents ?? "";
   const showMarkdownPreview = fileIsMarkdown && markdownPreviewEnabled;
-  const lineCount = fileContents.length === 0 ? 0 : fileContents.split("\n").length;
+  const editableDocument: EditableFileDocument | null =
+    props.editable &&
+    workspaceRoot !== null &&
+    filePath !== null &&
+    fileIsWorkspaceRelative &&
+    fileQuery.data !== undefined &&
+    !fileQuery.data.truncated &&
+    fileQuery.data.version !== null &&
+    fileQuery.data.encoding !== null &&
+    fileQuery.data.lineEnding !== null &&
+    fileQuery.data.lineEnding !== "mixed"
+      ? {
+          key: `${workspaceRoot}\0${fileQuery.data.relativePath}`,
+          relativePath: fileQuery.data.relativePath,
+          contents: fileQuery.data.contents,
+          version: fileQuery.data.version,
+          encoding: fileQuery.data.encoding,
+          lineEnding: fileQuery.data.lineEnding,
+        }
+      : null;
+  const activeEditBuffer = editableDocument
+    ? resolveFileEditBuffer(editBuffer, editableDocument)
+    : null;
+  const editBufferDirty =
+    activeEditBuffer !== null && activeEditBuffer.contents !== activeEditBuffer.savedContents;
+  const displayedFileContents = activeEditBuffer?.contents ?? fileContents;
+  const lineCount =
+    displayedFileContents.length === 0 ? 0 : displayedFileContents.split("\n").length;
+  const readOnlyReason =
+    !props.editable || showMarkdownPreview || fileQuery.data === undefined
+      ? null
+      : !fileIsWorkspaceRelative
+        ? "Only files inside the project can be edited."
+        : fileQuery.data.truncated
+          ? "Large files are read-only."
+          : fileQuery.data.lineEnding === "mixed"
+            ? "Files with mixed line endings are read-only to preserve their exact format."
+            : fileQuery.data.version === null || fileQuery.data.encoding === null
+              ? "This file format is read-only."
+              : null;
+
+  const handleEditBufferChange = (contents: string) => {
+    if (!editableDocument) return;
+    setEditBuffer((current) => ({
+      ...resolveFileEditBuffer(current, editableDocument),
+      contents,
+      error: null,
+    }));
+  };
+
+  const handleEditBufferSave = async () => {
+    if (
+      !workspaceRoot ||
+      !editableDocument ||
+      !activeEditBuffer ||
+      !editBufferDirty ||
+      activeEditBuffer.saving
+    ) {
+      return;
+    }
+    const api = readNativeApi();
+    if (!api) {
+      setEditBuffer((current) => ({
+        ...resolveFileEditBuffer(current, editableDocument),
+        error: "File saving is unavailable.",
+      }));
+      return;
+    }
+
+    const documentKey = activeEditBuffer.key;
+    const contentsToSave = activeEditBuffer.contents;
+    const expectedVersion = activeEditBuffer.version;
+    setEditBuffer((current) => ({
+      ...resolveFileEditBuffer(current, editableDocument),
+      saving: true,
+      error: null,
+    }));
+
+    try {
+      const result = await api.projects.writeFile({
+        cwd: workspaceRoot,
+        relativePath: activeEditBuffer.relativePath,
+        contents: contentsToSave,
+        expectedVersion,
+        encoding: activeEditBuffer.encoding,
+        lineEnding: activeEditBuffer.lineEnding,
+      });
+      setEditBuffer((current) =>
+        current?.key === documentKey
+          ? {
+              ...current,
+              savedContents: contentsToSave,
+              version: result.version,
+              saving: false,
+              error: null,
+            }
+          : current,
+      );
+      const options = projectReadFileQueryOptions({ cwd: workspaceRoot, relativePath: filePath });
+      queryClient.setQueryData<ProjectReadFileResult>(options.queryKey, (current) =>
+        current
+          ? { ...current, contents: contentsToSave, version: result.version }
+          : current,
+      );
+    } catch (error) {
+      setEditBuffer((current) =>
+        current?.key === documentKey
+          ? { ...current, saving: false, error: readFileSaveError(error) }
+          : current,
+      );
+    }
+  };
+
+  const handleEditBufferReload = () => {
+    if (!editableDocument || !filePath) return;
+    const documentKey = editableDocument.key;
+    const options = projectReadFileQueryOptions({ cwd: workspaceRoot, relativePath: filePath });
+    void queryClient
+      .invalidateQueries({ queryKey: options.queryKey })
+      .then(() => {
+        setEditBuffer((current) => (current?.key === documentKey ? null : current));
+      })
+      .catch((error: unknown) => {
+        setEditBuffer((current) =>
+          current?.key === documentKey
+            ? { ...current, error: readFileSaveError(error) }
+            : current,
+        );
+      });
+  };
   // Highlight -> floating "Add to chat" -> reference that points at exactly what
   // was selected, mirroring the transcript flow. This is offered only in the
   // source view, where the DOM mirrors the file's lines/columns 1:1 so a
@@ -451,7 +632,7 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
     }
   };
   const previewSelectionAction = useCodeSelectionAction({
-    enabled: Boolean(onReferenceInChat && filePath) && !showMarkdownPreview,
+    enabled: Boolean(onReferenceInChat && filePath) && !showMarkdownPreview && !editableDocument,
     readSelection: readPreviewSelection,
     onCommit: commitPreviewSelection,
   });
@@ -459,7 +640,8 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
   // the source view, where the DOM mirrors the file's lines 1:1 so the hovered
   // `.line` resolves to an exact line number (the rendered-markdown view
   // restructures the source and cannot map a row back to a file line).
-  const lineCommentingEnabled = Boolean(onCommentInChat && filePath) && !showMarkdownPreview;
+  const lineCommentingEnabled =
+    Boolean(onCommentInChat && filePath) && !showMarkdownPreview && !editableDocument;
   const lineCommenting = useFileLineCommenting({
     enabled: lineCommentingEnabled,
     resetKey: filePath,
@@ -499,7 +681,14 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
     }
     const options = projectReadFileQueryOptions({ cwd: workspaceRoot, relativePath: filePath });
     const current = queryClient.getQueryData(options.queryKey);
-    if (!current || current.truncated) {
+    if (
+      !current ||
+      current.truncated ||
+      current.version === null ||
+      current.encoding === null ||
+      current.lineEnding === null ||
+      current.lineEnding === "mixed"
+    ) {
       return;
     }
     const nextContents = toggleMarkdownTaskMarker(current.contents, sourceLine, checked);
@@ -521,23 +710,34 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
     // Writes carry the full file contents, so serialize them: a slower earlier
     // checkbox write must never land after a newer toggle and erase it.
     const fileKey = `${workspaceRoot}\0${filePath}`;
+    if (!taskFileDiskVersionRef.current.has(fileKey)) {
+      taskFileDiskVersionRef.current.set(fileKey, current.version);
+    }
     const writeVersion = latestTaskWriteVersionRef.current.next + 1;
     latestTaskWriteVersionRef.current.next = writeVersion;
     latestTaskWriteVersionRef.current.byFile.set(fileKey, writeVersion);
     taskWriteQueueRef.current = taskWriteQueueRef.current
       .catch(() => undefined)
-      .then(() =>
-        api.projects.writeFile({
+      .then(async () => {
+        const result = await api.projects.writeFile({
           cwd: workspaceRoot,
           relativePath: writeRelativePath,
           contents: nextContents,
-        }),
-      )
+          expectedVersion: taskFileDiskVersionRef.current.get(fileKey) ?? current.version,
+          encoding: current.encoding,
+          lineEnding: current.lineEnding,
+        });
+        taskFileDiskVersionRef.current.set(fileKey, result.version);
+        queryClient.setQueryData<ProjectReadFileResult>(options.queryKey, (cached) =>
+          cached ? { ...cached, version: result.version } : cached,
+        );
+      })
       .then(() => undefined)
       .catch(() => {
         if (latestTaskWriteVersionRef.current.byFile.get(fileKey) !== writeVersion) {
           return;
         }
+        taskFileDiskVersionRef.current.delete(fileKey);
         void queryClient.invalidateQueries({ queryKey: options.queryKey });
       });
     void taskWriteQueueRef.current;
@@ -551,7 +751,12 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
     props.workspaceRoot !== null &&
     fileIsWorkspaceRelative &&
     fileQuery.data !== undefined &&
-    !fileQuery.data.truncated;
+    !fileQuery.data.truncated &&
+    fileQuery.data.version !== null &&
+    fileQuery.data.encoding !== null &&
+    fileQuery.data.lineEnding !== null &&
+    fileQuery.data.lineEnding !== "mixed" &&
+    !editBufferDirty;
 
   if (!props.workspaceRoot && !fileIsLocalAbsolute && !fileIsScratchBinaryPreview) {
     return (
@@ -623,7 +828,24 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
         onReferenceInChat={onReferenceInChat}
         onAskWhyInChat={onAskWhyInChat}
         truncated={fileQuery.data?.truncated ?? false}
+        dirty={editBufferDirty}
+        readOnlyReason={readOnlyReason}
       />
+      {activeEditBuffer?.error ? (
+        <div
+          role="alert"
+          className="flex shrink-0 items-center gap-3 border-b border-destructive/25 bg-destructive/5 px-3 py-2 text-[11px] text-destructive"
+        >
+          <span className="min-w-0 flex-1">{activeEditBuffer.error}</span>
+          <button
+            type="button"
+            className="shrink-0 rounded-md px-2 py-1 font-medium text-foreground/80 hover:bg-foreground/8"
+            onClick={handleEditBufferReload}
+          >
+            Reload from disk
+          </button>
+        </div>
+      ) : null}
       {locatingOutOfRootFile ? (
         <FilePreviewLoadingState />
       ) : fileIsImage ? (
@@ -651,6 +873,24 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
             {fileQuery.error instanceof Error ? fileQuery.error.message : "Could not read file."}
           </p>
         </PanelStateMessage>
+      ) : activeEditBuffer && editableDocument && !showMarkdownPreview ? (
+        <textarea
+          className="editor-file-editor"
+          aria-label={`Edit ${filePath}`}
+          aria-busy={activeEditBuffer.saving}
+          aria-invalid={activeEditBuffer.error ? "true" : undefined}
+          value={activeEditBuffer.contents}
+          spellCheck={false}
+          autoCapitalize="off"
+          autoCorrect="off"
+          onChange={(event) => handleEditBufferChange(event.currentTarget.value)}
+          onKeyDown={(event) => {
+            if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
+              event.preventDefault();
+              void handleEditBufferSave();
+            }
+          }}
+        />
       ) : (
         <div
           ref={contentsRef}
@@ -666,7 +906,7 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
           {showMarkdownPreview ? (
             <div className="editor-markdown-preview">
               <ChatMarkdown
-                text={fileContents}
+                text={displayedFileContents}
                 cwd={markdownPreviewCwd(props.workspaceRoot, filePath)}
                 isStreaming={false}
                 className="editor-markdown-preview__body text-sm leading-relaxed"

--- a/apps/web/src/components/chat/DockExplorerPane.tsx
+++ b/apps/web/src/components/chat/DockExplorerPane.tsx
@@ -65,6 +65,7 @@ export const DockExplorerPane = function DockExplorerPane(props: {
         <WorkspaceFilePreview
           workspaceRoot={props.workspaceRoot}
           filePath={selectedFilePath}
+          editable
           emptyState={
             <PanelStateMessage density="compact" fill="flex">
               <p>Select a file from the tree to view it.</p>

--- a/apps/web/src/components/chat/WorkspaceFilePreviewHeader.tsx
+++ b/apps/web/src/components/chat/WorkspaceFilePreviewHeader.tsx
@@ -35,6 +35,10 @@ interface WorkspaceFilePreviewHeaderProps {
   onAskWhyInChat?: ((reference: ChatFileReference) => void) | undefined;
   /** Shown when the preview only holds a partial read of a large file. */
   truncated?: boolean;
+  /** Marks the currently open source buffer as different from its saved version. */
+  dirty?: boolean;
+  /** Short reason the current source cannot be edited safely. */
+  readOnlyReason?: string | null;
 }
 
 // Source (raw file, where selecting text yields a precise line/column chat
@@ -123,11 +127,26 @@ export const WorkspaceFilePreviewHeader = function WorkspaceFilePreviewHeader(
         <span className="min-w-0 shrink truncate font-medium text-foreground" title={filePath}>
           {fileSegment}
         </span>
+        {props.dirty ? (
+          <span
+            className="ml-1.5 size-1.5 shrink-0 rounded-full bg-foreground/75"
+            role="status"
+            aria-label="Unsaved changes"
+            title="Unsaved changes"
+          />
+        ) : null}
       </nav>
 
       {props.truncated ? (
         <span className="hidden shrink-0 text-[10px] text-muted-foreground/70 @sm/header-actions:inline">
           Shown partially
+        </span>
+      ) : props.readOnlyReason ? (
+        <span
+          className="hidden max-w-32 shrink-0 truncate text-[10px] text-muted-foreground/70 @sm/header-actions:inline"
+          title={props.readOnlyReason}
+        >
+          Read-only
         </span>
       ) : null}
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1122,6 +1122,28 @@ label:has(> select#reasoning-effort) select {
   font-family: inherit !important;
 }
 
+.editor-file-editor {
+  min-height: 0;
+  flex: 1;
+  resize: none;
+  overflow: auto;
+  border: 0;
+  border-radius: 0;
+  outline: none;
+  background: transparent;
+  padding: 1rem;
+  color: color-mix(in srgb, var(--foreground) 88%, transparent);
+  font-family: var(--font-chat-code-family);
+  font-size: var(--app-font-size-chat-code, 12px);
+  line-height: 1.65;
+  tab-size: 2;
+  white-space: pre;
+}
+
+.editor-file-editor:focus-visible {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ring) 45%, transparent);
+}
+
 /* Line-number gutter for the read-only file preview. Rendered via CSS counters
    on the per-line spans (Shiki and the plain fallback both emit .line), so the
    numbers stay out of text selection, clipboard copies, and the selection

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -541,7 +541,10 @@ describe("wsNativeApi", () => {
   });
 
   it("forwards workspace file writes to the websocket project method", async () => {
-    requestMock.mockResolvedValue({ relativePath: "plan.md" });
+    requestMock.mockResolvedValue({
+      relativePath: "plan.md",
+      version: `sha256:${"1".repeat(64)}`,
+    });
     const { createWsNativeApi } = await import("./wsNativeApi");
 
     const api = createWsNativeApi();
@@ -563,6 +566,9 @@ describe("wsNativeApi", () => {
       relativePath: "src/app.ts",
       contents: "export {};\n",
       truncated: false,
+      version: `sha256:${"1".repeat(64)}`,
+      encoding: "utf8",
+      lineEnding: "lf",
     });
     const { createWsNativeApi } = await import("./wsNativeApi");
 

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -16,6 +16,12 @@ const PROJECT_DIRECTORY_LIST_MAX_DEPTH = 32;
 const PROJECT_SCRIPT_DISCOVERY_MAX_DEPTH = 3;
 const ProjectEntryKind = Schema.Literals(["file", "directory"]);
 
+export const ProjectFileEncoding = Schema.Literals(["utf8", "utf8-bom"]);
+export type ProjectFileEncoding = typeof ProjectFileEncoding.Type;
+
+export const ProjectFileLineEnding = Schema.Literals(["lf", "crlf", "cr", "mixed"]);
+export type ProjectFileLineEnding = typeof ProjectFileLineEnding.Type;
+
 export const ProjectKind = Schema.Literals(["project", "chat", "studio"]);
 export type ProjectKind = typeof ProjectKind.Type;
 
@@ -128,11 +134,15 @@ export const ProjectWriteFileInput = Schema.Struct({
   cwd: TrimmedNonEmptyString,
   relativePath: TrimmedNonEmptyString.check(Schema.isMaxLength(PROJECT_FILE_PATH_MAX_LENGTH)),
   contents: Schema.String.check(Schema.isMaxLength(PROJECT_READ_FILE_MAX_BYTES)),
+  expectedVersion: Schema.optional(TrimmedNonEmptyString.check(Schema.isMaxLength(128))),
+  encoding: Schema.optional(ProjectFileEncoding),
+  lineEnding: Schema.optional(ProjectFileLineEnding),
 });
 export type ProjectWriteFileInput = typeof ProjectWriteFileInput.Type;
 
 export const ProjectWriteFileResult = Schema.Struct({
   relativePath: TrimmedNonEmptyString,
+  version: TrimmedNonEmptyString,
 });
 export type ProjectWriteFileResult = typeof ProjectWriteFileResult.Type;
 
@@ -150,6 +160,9 @@ export const ProjectReadFileResult = Schema.Struct({
   relativePath: TrimmedNonEmptyString,
   contents: Schema.String,
   truncated: Schema.Boolean,
+  version: Schema.NullOr(TrimmedNonEmptyString),
+  encoding: Schema.NullOr(ProjectFileEncoding),
+  lineEnding: Schema.NullOr(ProjectFileLineEnding),
 });
 export type ProjectReadFileResult = typeof ProjectReadFileResult.Type;
 


### PR DESCRIPTION
## Summary

- make complete text files opened from Explorer editable in place
- save with Cmd/Ctrl+S and show unsaved state plus visible write failures
- guard saves with the raw-byte version loaded from disk so concurrent agent or terminal edits are not overwritten
- preserve UTF-8 BOM and consistent LF/CRLF/CR line endings; keep binary, oversized, mixed-line-ending, and out-of-root files read-only

## Root cause

The shared preview rendered source as read-only markup. Its existing whole-file write RPC performed an unconditional atomic replacement, so it had no safe compare-before-write contract for an editor buffer.

## Verification

- `bun run --cwd apps/server test src/workspace/Layers/WorkspaceFileSystem.test.ts src/wsRpc.auth.test.ts src/wsRpc.connectionLifecycle.test.ts` (54 tests)
- `bun run --cwd apps/web test src/wsNativeApi.test.ts src/components/EditorWorkspaceView.test.tsx` (49 tests)
- `VITEST_BROWSER_API_PORT=51147 bun run --cwd apps/web test:browser src/components/WorkspaceFilePreview.editing.browser.tsx src/components/WorkspaceFilePreview.relocation.browser.tsx` (6 tests)
- `git diff --check`

Closes #517

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace file read/write semantics and on-disk write paths with compare-before-write logic; incorrect versioning could block saves or allow overwrites, though behavior is heavily covered by server and browser tests.
> 
> **Overview**
> Adds **in-place editing** for complete workspace text files in Explorer and the editor file view, with **Cmd/Ctrl+S**, an unsaved indicator, and save error UI including **reload from disk**.
> 
> The project read/write contract now carries a **SHA-256 content version** plus **encoding** (`utf8` / `utf8-bom`) and **line ending** metadata. **Guarded saves** send `expectedVersion` (and encoding/line ending) so the server can reject writes when the file changed or was deleted on disk; WebSocket maps those to `WORKSPACE_FILE_CONFLICT` / `WORKSPACE_FILE_DELETED`. Saves **preserve BOM and LF/CRLF/CR**; truncated, binary, mixed line endings, and out-of-root files stay **read-only**. Markdown preview task toggles use the same guarded write path and track disk versions after editor saves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ceb3bde1bf693e4ba64cfba1b2c7f2bd257b248. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->