### PR TITLE
Fix AskUserQuestion response recovery at full context

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -8283,6 +8283,158 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
+  it("keeps full-context AskUserQuestion rejection retryable across session recovery", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+    harness.respondToUserInput.mockImplementation(() =>
+      Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: "claudeAgent",
+          method: "item/tool/respondToUserInput",
+          detail:
+            "API Error: 400 input_length and max_tokens exceed context limit; prompt is too long.",
+        }),
+      ),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-set-full-context"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "running",
+          providerName: "claudeAgent",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.activity.append",
+        commandId: CommandId.makeUnsafe("cmd-user-input-requested-full-context"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        activity: {
+          id: EventId.makeUnsafe("activity-user-input-requested-full-context"),
+          tone: "info",
+          kind: "user-input.requested",
+          summary: "User input requested",
+          payload: {
+            requestId: "user-input-request-full-context",
+            questions: [],
+          },
+          turnId: null,
+          createdAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.user-input.respond",
+        commandId: CommandId.makeUnsafe("cmd-user-input-respond-full-context"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        requestId: asApprovalRequestId("user-input-request-full-context"),
+        answers: { continue: "Yes" },
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(
+      async () =>
+        (await readHarnessThread(harness))?.activities.some(
+          (activity) => activity.kind === "provider.user-input.respond.failed",
+        ) === true,
+    );
+    const failureActivity = (await readHarnessThread(harness))?.activities.find(
+      (activity) => activity.kind === "provider.user-input.respond.failed",
+    );
+    expect(failureActivity?.payload).toMatchObject({
+      requestId: "user-input-request-full-context",
+      responseCommandId: "cmd-user-input-respond-full-context",
+      settlementStatus: "retryable",
+      detail: expect.stringContaining("context limit"),
+    });
+    const failedResponse = await Effect.runPromise(
+      harness.pendingInteractionRepository.getByIdentity({
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        interactionKind: "userInput",
+        requestId: asApprovalRequestId("user-input-request-full-context"),
+      }),
+    );
+    expect(Option.getOrUndefined(failedResponse)).toMatchObject({
+      status: "retryable",
+      responseCommandId: "cmd-user-input-respond-full-context",
+    });
+
+    const stoppedAt = new Date(Date.now() + 1).toISOString();
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-stopped-full-context"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "stopped",
+          providerName: "claudeAgent",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: stoppedAt,
+        },
+        createdAt: stoppedAt,
+      }),
+    );
+
+    const recoveredAt = new Date(Date.now() + 2).toISOString();
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-recovered-full-context"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "running",
+          providerName: "claudeAgent",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: recoveredAt,
+        },
+        createdAt: recoveredAt,
+      }),
+    );
+    harness.respondToUserInput.mockImplementation(() => Effect.void);
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.user-input.respond",
+        commandId: CommandId.makeUnsafe("cmd-user-input-retry-full-context"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        requestId: asApprovalRequestId("user-input-request-full-context"),
+        answers: { continue: "Yes" },
+        createdAt: recoveredAt,
+      }),
+    );
+
+    await waitFor(() => harness.respondToUserInput.mock.calls.length === 2);
+    const retriedResponse = await Effect.runPromise(
+      harness.pendingInteractionRepository.getByIdentity({
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        interactionKind: "userInput",
+        requestId: asApprovalRequestId("user-input-request-full-context"),
+      }),
+    );
+    expect(Option.getOrUndefined(retriedResponse)).toMatchObject({
+      status: "responding",
+      responseCommandId: "cmd-user-input-retry-full-context",
+    });
+  });
+
   it("surfaces unclaimable user-input responses instead of dropping them silently", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -365,6 +365,25 @@ function isUnknownPendingUserInputRequestError(cause: Cause.Cause<ProviderServic
   return Cause.pretty(cause).toLowerCase().includes("unknown pending user-input request");
 }
 
+function isClaudeContextWindowUserInputRejection(error: ProviderServiceError): boolean {
+  if (
+    error._tag !== "ProviderAdapterRequestError" ||
+    error.provider !== "claudeAgent" ||
+    error.method !== "item/tool/respondToUserInput"
+  ) {
+    return false;
+  }
+  const detail = error.detail.toLowerCase();
+  return (
+    detail.includes("context window") ||
+    detail.includes("context limit") ||
+    detail.includes("context length") ||
+    detail.includes("context_length_exceeded") ||
+    detail.includes("prompt is too long") ||
+    detail.includes("input_length and max_tokens")
+  );
+}
+
 function interactionFailureSettlementStatus(
   cause: Cause.Cause<ProviderServiceError>,
   isUnknownPendingRequest: boolean,
@@ -373,8 +392,9 @@ function interactionFailureSettlementStatus(
     onNone: () => "uncertain" as const,
     onSome: (error) => {
       if (
-        error._tag === "ProviderAdapterRequestError" &&
-        error.method === "permission.reply.acknowledge"
+        (error._tag === "ProviderAdapterRequestError" &&
+          error.method === "permission.reply.acknowledge") ||
+        isClaudeContextWindowUserInputRejection(error)
       ) {
         return "retryable" as const;
       }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -39,6 +39,7 @@ import {
   RuntimeMode,
 } from "@synara/contracts";
 import { automationRequiresTargetThread } from "@synara/shared/automationMode";
+import { respondingInteractionReclaimAt } from "@synara/shared/pendingInteractions";
 import { providerSupportsNativeTurnSteering } from "@synara/shared/providerMetadata";
 import { getModelCapabilities, normalizeModelSlug } from "@synara/shared/model";
 import {
@@ -2590,17 +2591,51 @@ export default function ChatView({
       threadActivities,
     ],
   );
+  const nextUserInputResponseReclaimAt = useMemo(() => {
+    let earliest: string | null = null;
+    for (const interaction of activeThread?.pendingInteractions ?? []) {
+      if (
+        interaction.interactionKind !== "userInput" ||
+        interaction.status !== "responding"
+      ) {
+        continue;
+      }
+      if (interaction.responseRequestedAt === null) {
+        return new Date(0).toISOString();
+      }
+      const reclaimAt = respondingInteractionReclaimAt(interaction.responseRequestedAt);
+      if (earliest === null || reclaimAt < earliest) {
+        earliest = reclaimAt;
+      }
+    }
+    return earliest;
+  }, [activeThread?.pendingInteractions]);
+  const [userInputResponseClaimReferenceAt, setUserInputResponseClaimReferenceAt] = useState(() =>
+    new Date().toISOString(),
+  );
+  useEffect(() => {
+    if (nextUserInputResponseReclaimAt === null) {
+      return;
+    }
+    const delayMs = Math.max(0, Date.parse(nextUserInputResponseReclaimAt) - Date.now());
+    const timeoutId = window.setTimeout(() => {
+      setUserInputResponseClaimReferenceAt(new Date().toISOString());
+    }, delayMs);
+    return () => window.clearTimeout(timeoutId);
+  }, [nextUserInputResponseReclaimAt]);
   const pendingUserInputs = useMemo(
     () =>
       derivePendingUserInputs(threadActivities, activeThread?.pendingInteractions, {
         authoritativeHasPending: activeThread?.hasPendingUserInput,
         latestTurnId: activeThread?.latestTurn?.turnId,
+        responseClaimReferenceAt: userInputResponseClaimReferenceAt,
       }),
     [
       activeThread?.hasPendingUserInput,
       activeThread?.latestTurn?.turnId,
       activeThread?.pendingInteractions,
       threadActivities,
+      userInputResponseClaimReferenceAt,
     ],
   );
   const activePendingUserInput = pendingUserInputs[0] ?? null;

--- a/apps/web/src/pendingInteractionDerivation.test.ts
+++ b/apps/web/src/pendingInteractionDerivation.test.ts
@@ -13,6 +13,7 @@ import { makeActivity } from "./storeTestFixtures";
 function makePendingInteraction(
   interactionKind: OrchestrationPendingInteraction["interactionKind"],
   status: OrchestrationPendingInteraction["status"],
+  overrides: Partial<OrchestrationPendingInteraction> = {},
 ): OrchestrationPendingInteraction {
   return {
     interactionKind,
@@ -26,6 +27,7 @@ function makePendingInteraction(
     responseRequestedAt: null,
     createdAt: "2026-02-23T00:00:01.000Z",
     resolvedAt: null,
+    ...overrides,
   };
 }
 
@@ -389,6 +391,65 @@ describe("derivePendingUserInputs", () => {
         authoritativeHasPending: false,
         latestTurnId: undefined,
       }),
+    ).toHaveLength(1);
+  });
+
+  it("restores retry access after rehydrating uncertain and orphaned user-input responses", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "user-input-retry-recovery",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        tone: "info",
+        payload: {
+          requestId: "req-settlement",
+          lifecycleGeneration: "generation-settlement",
+          questions: [
+            {
+              id: "continue",
+              header: "Continue",
+              question: "Continue after context recovery?",
+              options: [{ label: "Yes", description: "Retry the response" }],
+            },
+          ],
+        },
+      }),
+    ];
+    const options = {
+      authoritativeHasPending: false,
+      latestTurnId: undefined,
+      responseClaimReferenceAt: "2026-02-23T00:01:00.000Z",
+    };
+
+    expect(
+      derivePendingUserInputs(
+        activities,
+        [makePendingInteraction("userInput", "uncertain")],
+        options,
+      ),
+    ).toHaveLength(1);
+    expect(
+      derivePendingUserInputs(
+        activities,
+        [
+          makePendingInteraction("userInput", "responding", {
+            responseRequestedAt: "2026-02-23T00:00:45.000Z",
+          }),
+        ],
+        options,
+      ),
+    ).toHaveLength(0);
+    expect(
+      derivePendingUserInputs(
+        activities,
+        [
+          makePendingInteraction("userInput", "responding", {
+            responseRequestedAt: "2026-02-23T00:00:30.000Z",
+          }),
+        ],
+        options,
+      ),
     ).toHaveLength(1);
   });
 

--- a/apps/web/src/pendingInteractionDerivation.ts
+++ b/apps/web/src/pendingInteractionDerivation.ts
@@ -5,6 +5,7 @@ import {
   type TurnId,
   type UserInputQuestion,
 } from "@synara/contracts";
+import { isPendingInteractionResponseClaimable } from "@synara/shared/pendingInteractions";
 import {
   approvalRequestKindFromRequestType,
   pendingRequestInstanceKey,
@@ -39,6 +40,11 @@ export interface PendingInteractionDerivationOptions {
   // unresolved older request so a background prompt can outlive later turns.
   readonly authoritativeHasPending: boolean | undefined;
   readonly latestTurnId: TurnId | undefined;
+  // The active composer supplies a wall-clock reference so durable failures
+  // and orphaned response claims become actionable under the same atomic
+  // reclaim policy enforced by persistence. Historical/sidebar derivations
+  // can omit it to remain time-independent.
+  readonly responseClaimReferenceAt?: string;
 }
 
 interface PendingInteractionReplay<T extends { requestId: ApprovalRequestId }> {
@@ -92,6 +98,7 @@ function retainActionableSettlements<T extends { requestId: ApprovalRequestId }>
   openByInstance: Map<string, T>,
   settlements: ReadonlyArray<OrchestrationPendingInteraction> | undefined,
   interactionKind: PendingInteractionKind,
+  responseClaimReferenceAt: string | undefined,
 ): void {
   if (settlements === undefined) {
     return;
@@ -101,7 +108,14 @@ function retainActionableSettlements<T extends { requestId: ApprovalRequestId }>
       .filter(
         (settlement) =>
           settlement.interactionKind === interactionKind &&
-          (settlement.status === "pending" || settlement.status === "retryable"),
+          (settlement.status === "pending" ||
+            settlement.status === "retryable" ||
+            (responseClaimReferenceAt !== undefined &&
+              isPendingInteractionResponseClaimable({
+                status: settlement.status,
+                responseRequestedAt: settlement.responseRequestedAt,
+                requestedAt: responseClaimReferenceAt,
+              }))),
       )
       .map((settlement) =>
         pendingRequestInstanceKey(
@@ -181,7 +195,12 @@ function replayPendingInteractions<T extends { requestId: ApprovalRequestId; cre
     }
   }
 
-  retainActionableSettlements(openByInstance, settlements, replay.interactionKind);
+  retainActionableSettlements(
+    openByInstance,
+    settlements,
+    replay.interactionKind,
+    options?.responseClaimReferenceAt,
+  );
   if (isAggregateFallback && options.authoritativeHasPending === true) {
     const actionableLatestTurnKeys = [...openByInstance.keys()].filter((key) =>
       latestTurnRequestedKeys.has(key),

--- a/packages/shared/src/pendingInteractions.test.ts
+++ b/packages/shared/src/pendingInteractions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   isPendingInteractionResponseClaimable,
+  respondingInteractionReclaimAt,
   respondingInteractionReclaimCutoff,
 } from "./pendingInteractions";
 
@@ -22,6 +23,9 @@ describe("pending interaction response claims", () => {
   it("only reclaims responding interactions after the grace period", () => {
     expect(respondingInteractionReclaimCutoff("2026-07-14T12:31:00.000Z")).toBe(
       "2026-07-14T12:30:30.000Z",
+    );
+    expect(respondingInteractionReclaimAt("2026-07-14T12:30:30.000Z")).toBe(
+      "2026-07-14T12:31:00.000Z",
     );
     expect(
       isPendingInteractionResponseClaimable({

--- a/packages/shared/src/pendingInteractions.ts
+++ b/packages/shared/src/pendingInteractions.ts
@@ -14,6 +14,13 @@ export function respondingInteractionReclaimCutoff(requestedAt: string): string 
     : new Date(requestedAtMs - RESPONDING_INTERACTION_RECLAIM_GRACE_MS).toISOString();
 }
 
+export function respondingInteractionReclaimAt(responseRequestedAt: string): string {
+  const responseRequestedAtMs = Date.parse(responseRequestedAt);
+  return Number.isNaN(responseRequestedAtMs)
+    ? responseRequestedAt
+    : new Date(responseRequestedAtMs + RESPONDING_INTERACTION_RECLAIM_GRACE_MS).toISOString();
+}
+
 export function isPendingInteractionResponseClaimable(input: {
   readonly status: OrchestrationPendingInteraction["status"];
   readonly responseRequestedAt: string | null;


### PR DESCRIPTION
## Summary

- keep explicit Claude/GLM-compatible full-context AskUserQuestion submission rejections retryable while preserving uncertain handling for stale IDs and lost acknowledgements
- restore failed or orphaned durable user-input prompts in the active composer using the same 30-second atomic reclaim policy as persistence
- schedule a one-shot composer refresh at the reclaim boundary so a response left in `responding` becomes actionable without another server event
- preserve ClaudeAdapter's exactly-once settlement behavior

## Verification

- `bun run --cwd apps/server test src/orchestration/Layers/ProviderCommandReactor.test.ts -t "keeps full-context AskUserQuestion rejection retryable across session recovery"`
- `bun run --cwd apps/web test src/pendingInteractionDerivation.test.ts`
- `bun run --cwd packages/shared test src/pendingInteractions.test.ts`
- `bun run --cwd apps/server test src/provider/Layers/ClaudeAdapter.test.ts -t "settles unanswered AskUserQuestion exactly once before terminal turn state"`
- `git diff --check`

Closes #545

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user-input settlement and pending-interaction UX in orchestration; behavior is well covered by new tests but affects when users can retry prompts after failures.
> 
> **Overview**
> Fixes **AskUserQuestion** recovery when Claude rejects a user-input response because the prompt exceeds the context window, and when durable settlements leave the UI stuck after session stop/recovery.
> 
> **Server:** Claude `respondToUserInput` failures whose detail matches context-window/limit patterns are classified as **retryable** (alongside permission ack failures), so the pending interaction stays retryable and can be resubmitted after session recovery.
> 
> **Web + shared:** The active composer passes a wall-clock `responseClaimReferenceAt` into `derivePendingUserInputs`, using the same 30s reclaim rules as persistence (`uncertain` settlements and `responding` claims past grace). `respondingInteractionReclaimAt` schedules a one-shot timer in `ChatView` so prompts become actionable at the reclaim boundary without waiting for another server event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09c77499d8f35b2cf0dbad5542016edabce27fed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->