### PR TITLE
Fix long-thread composer latency during live activity

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -27,6 +27,7 @@ import { RouterProvider, createMemoryHistory } from "@tanstack/react-router";
 import { HttpResponse, http, ws } from "msw";
 import { setupWorker } from "msw/browser";
 import { page, userEvent } from "vitest/browser";
+import { Profiler, type ProfilerOnRenderCallback } from "react";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 
@@ -57,6 +58,7 @@ import {
   sendEffectRpcChunk,
   sendEffectRpcExit,
 } from "../test/effectRpcWebSocketMock";
+import { makeDomainEvent } from "../storeTestFixtures";
 import { createBrowserTestServerConfig, createFullscreenTestHost } from "../test/browserHarness";
 import { useTemporaryThreadStore } from "../temporaryThreadStore";
 import { useTerminalStateStore } from "../terminalStateStore";
@@ -339,6 +341,48 @@ function createSnapshotForTargetUser(options: {
       },
     ],
     updatedAt: NOW_ISO,
+  };
+}
+
+function createIssue550Snapshot(options: {
+  messageCount: number;
+  activityCount: number;
+}): OrchestrationReadModel {
+  const snapshot = createSnapshotForTargetUser({
+    targetMessageId: "msg-user-issue-550" as MessageId,
+    targetText: "issue 550 baseline",
+  });
+  const messages = Array.from({ length: options.messageCount }, (_, index) =>
+    index % 2 === 0
+      ? createUserMessage({
+          id: MessageId.makeUnsafe(`msg-issue-550-user-${index}`),
+          text: `user message ${index}`,
+          offsetSeconds: index * 2,
+        })
+      : createAssistantMessage({
+          id: MessageId.makeUnsafe(`msg-issue-550-assistant-${index}`),
+          text: `assistant message ${index}`,
+          offsetSeconds: index * 2,
+        }),
+  );
+  const activities = Array.from({ length: options.activityCount }, (_, index) => ({
+    id: EventId.makeUnsafe(`activity-issue-550-${index}`),
+    createdAt: isoAt(options.messageCount * 2 + index),
+    kind: "tool.completed" as const,
+    summary: `tool ${index}`,
+    tone: "tool" as const,
+    turnId: null,
+    payload: {
+      itemType: "dynamic_tool_call",
+      toolName: `tool-${index}`,
+    },
+  }));
+
+  return {
+    ...snapshot,
+    threads: snapshot.threads.map((thread) =>
+      thread.id === THREAD_ID ? { ...thread, messages, activities } : thread,
+    ),
   };
 }
 
@@ -1883,6 +1927,7 @@ async function mountChatView(options: {
   snapshot: OrchestrationReadModel;
   configureFixture?: (fixture: TestFixture) => void;
   initialEntry?: string;
+  onRender?: ProfilerOnRenderCallback;
 }): Promise<MountedChatView> {
   fixture = buildFixture(options.snapshot);
   options.configureFixture?.(fixture);
@@ -1899,7 +1944,14 @@ async function mountChatView(options: {
     }),
   );
 
-  const screen = await render(<RouterProvider router={router} />, {
+  const content = options.onRender ? (
+    <Profiler id="issue-550-root" onRender={options.onRender}>
+      <RouterProvider router={router} />
+    </Profiler>
+  ) : (
+    <RouterProvider router={router} />
+  );
+  const screen = await render(content, {
     container: host,
   });
 
@@ -2038,6 +2090,98 @@ describe("ChatView timeline estimator parity (full app)", () => {
     await resetStudioProjectPrewarmStateForTests();
     resetRetainedThreadDetailSubscriptionsForTests();
     document.body.innerHTML = "";
+  });
+
+  it("keeps near-cap composer work bounded while live activities arrive", async () => {
+    const percentile = (samples: readonly number[], fraction: number): number => {
+      const ordered = [...samples].sort((left, right) => left - right);
+      return ordered[Math.min(ordered.length - 1, Math.floor(ordered.length * fraction))] ?? 0;
+    };
+    const cases = [
+      { name: "short", messageCount: 10, activityCount: 20 },
+      { name: "near-cap", messageCount: 81, activityCount: 1_609 },
+    ] as const;
+    const reports: Array<{
+      name: (typeof cases)[number]["name"];
+      inputP95Ms: number;
+      reactCommitTotalMs: number;
+    }> = [];
+
+    const warmup = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createIssue550Snapshot(cases[0]),
+    });
+    await warmup.cleanup();
+    useComposerDraftStore.setState({ draftsByThreadId: {} });
+
+    for (const benchmarkCase of cases) {
+      const commits: number[] = [];
+      const mounted = await mountChatView({
+        viewport: DEFAULT_VIEWPORT,
+        snapshot: createIssue550Snapshot(benchmarkCase),
+        onRender: (_id, phase, actualDuration) => {
+          if (phase === "update") commits.push(actualDuration);
+        },
+      });
+      try {
+        const editor = await waitForComposerEditor();
+        await userEvent.click(editor);
+        commits.length = 0;
+
+        const inputToPaintMs: number[] = [];
+        for (let index = 0; index < 12; index += 1) {
+          const startedAt = performance.now();
+          useStore.getState().applyOrchestrationEventsHotPath([
+            makeDomainEvent(
+              "thread.activity-appended",
+              {
+                threadId: THREAD_ID,
+                activity: {
+                  id: EventId.makeUnsafe(`activity-issue-550-live-${index}`),
+                  createdAt: isoAt(
+                    benchmarkCase.messageCount * 2 + benchmarkCase.activityCount + index,
+                  ),
+                  kind: "tool.completed",
+                  summary: `live tool ${index}`,
+                  tone: "tool",
+                  turnId: null,
+                  payload: {
+                    itemType: "dynamic_tool_call",
+                    toolName: `live-tool-${index}`,
+                  },
+                },
+              },
+              { sequence: benchmarkCase.activityCount + index + 1 },
+            ),
+          ]);
+          await userEvent.keyboard("x");
+          await nextFrame();
+          inputToPaintMs.push(performance.now() - startedAt);
+        }
+
+        expect(useComposerDraftStore.getState().draftsByThreadId[THREAD_ID]?.prompt).toBe(
+          "x".repeat(12),
+        );
+        expect(useStore.getState().activityIdsByThreadId?.[THREAD_ID]).toHaveLength(
+          benchmarkCase.activityCount + 12,
+        );
+        reports.push({
+          name: benchmarkCase.name,
+          inputP95Ms: percentile(inputToPaintMs, 0.95),
+          reactCommitTotalMs: commits.reduce((total, duration) => total + duration, 0),
+        });
+      } finally {
+        await mounted.cleanup();
+        useComposerDraftStore.setState({ draftsByThreadId: {} });
+      }
+    }
+
+    const short = reports.find((report) => report.name === "short")!;
+    const nearCap = reports.find((report) => report.name === "near-cap")!;
+    expect(
+      nearCap.reactCommitTotalMs,
+      `Issue #550 benchmark: ${JSON.stringify(reports)}`,
+    ).toBeLessThan(short.reactCommitTotalMs * 1.6);
   });
 
   it("dispatches a rapid access-mode reversal while the server projection is stale", async () => {

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -7,7 +7,7 @@ import {
   type ModelSlug,
   type RuntimeMode,
 } from "@synara/contracts";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   appendVoiceTranscriptToPrompt,
@@ -38,6 +38,7 @@ import {
   resolveActiveThreadTitle,
   resolveActiveTurnLiveDiffState,
   resolveCommittedProviderModel,
+  resolveComposerStripWorkLogEntries,
   resolveCycledModelSlug,
   resolveDefaultEnvironmentPanelOpen,
   resolveEnvironmentPanelOpen,
@@ -63,6 +64,29 @@ import {
   shouldRenderTerminalWorkspace,
   worktreeSetupHasError,
 } from "./ChatView.logic";
+
+describe("composer strip work-log derivation", () => {
+  it("reuses the active derivation unless a subagent view needs its parent source", () => {
+    const activeWorkLogEntries = [];
+    const deriveParentWorkLogEntries = vi.fn(() => []);
+
+    expect(
+      resolveComposerStripWorkLogEntries({
+        hasDistinctParentSource: false,
+        activeWorkLogEntries,
+        deriveParentWorkLogEntries,
+      }),
+    ).toBe(activeWorkLogEntries);
+    expect(deriveParentWorkLogEntries).not.toHaveBeenCalled();
+
+    resolveComposerStripWorkLogEntries({
+      hasDistinctParentSource: true,
+      activeWorkLogEntries,
+      deriveParentWorkLogEntries,
+    });
+    expect(deriveParentWorkLogEntries).toHaveBeenCalledOnce();
+  });
+});
 
 describe("thread artifact workspace root", () => {
   it("uses a materialized worktree for file previews", () => {

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -1559,6 +1559,16 @@ function resolveTimelineSubagentThread(input: {
   return undefined;
 }
 
+export function resolveComposerStripWorkLogEntries(input: {
+  hasDistinctParentSource: boolean;
+  activeWorkLogEntries: WorkLogEntry[];
+  deriveParentWorkLogEntries: () => WorkLogEntry[];
+}): WorkLogEntry[] {
+  return input.hasDistinctParentSource
+    ? input.deriveParentWorkLogEntries()
+    : input.activeWorkLogEntries;
+}
+
 export function enrichSubagentWorkEntries(
   workEntries: ReadonlyArray<WorkLogEntry>,
   threads: ReadonlyArray<Thread>,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -181,6 +181,7 @@ import {
   resolveActiveThreadTitle,
   resolveActiveTurnLiveDiffState,
   resolveCommittedProviderModel,
+  resolveComposerStripWorkLogEntries,
   resolveCycledModelSlug,
   resolveDefaultEnvironmentPanelOpen,
   resolveEnvironmentPanelOpen,
@@ -2499,18 +2500,27 @@ export default function ChatView({
       ? null
       : (activeLatestTurn?.turnId ?? null);
   // Composer-strip source: the strip needs the routed subagent entries the
-  // transcript drops, so it derives from the parent thread's own activities.
+  // transcript drops. A top-level thread has already derived that exact source
+  // above; reuse it so every live activity does not scan and normalize the full
+  // history twice. Subagent views still derive from their distinct parent source.
   const stripRawWorkLogEntries = useMemo(
     () =>
-      deriveWorkLogEntries(stripSourceActivities, stripSourceLatestTurnId ?? undefined, {
-        visibleTurnIds: stripVisibleTurnIds,
-        activeTurnId: stripLiveTurnId,
-        activeTurnStartedAt: stripSourceLatestTurnStartedAt,
-        latestTurnState: stripSourceLatestTurnState,
-        latestTurnCompletedAt: stripSourceLatestTurnCompletedAt,
+      resolveComposerStripWorkLogEntries({
+        hasDistinctParentSource: stripParentThread !== undefined,
+        activeWorkLogEntries: rawWorkLogEntries,
+        deriveParentWorkLogEntries: () =>
+          deriveWorkLogEntries(stripSourceActivities, stripSourceLatestTurnId ?? undefined, {
+            visibleTurnIds: stripVisibleTurnIds,
+            activeTurnId: stripLiveTurnId,
+            activeTurnStartedAt: stripSourceLatestTurnStartedAt,
+            latestTurnState: stripSourceLatestTurnState,
+            latestTurnCompletedAt: stripSourceLatestTurnCompletedAt,
+          }),
       }),
     [
+      rawWorkLogEntries,
       stripLiveTurnId,
+      stripParentThread,
       stripSourceActivities,
       stripSourceLatestTurnCompletedAt,
       stripSourceLatestTurnId,


### PR DESCRIPTION
Closes #550.

## Root cause

Profiling showed that direct composer input is nearly size-independent and does not write the main app store. The scaling regression appears when live activities arrive: every activity update derived the full work log twice for top-level threads—once for the transcript and again for the composer subagent strip—even though both consumers used the same activity source and derivation options.

The activity reducer itself remained sub-millisecond, so pagination or a broader composer rewrite was not justified by the evidence.

## What changed

- Reuse the transcript's already-derived work log for the top-level composer strip.
- Preserve the distinct parent-thread derivation used while viewing subagent threads.
- Add a deterministic unit guard proving the top-level path does not invoke the fallback derivation.
- Add a full-app Chromium regression scenario that types while live activities arrive in short and near-cap (81 messages / 1,609 activities) threads and bounds React commit scaling.

## Performance evidence

Measured in the same full-app Chromium harness, 12 live activity + keypress iterations per case:

| Near-cap metric | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Input-to-paint p95 | 134.1 ms | 99.9 ms | 25.5% |
| React update duration | 630.8 ms | 337.2 ms | 46.5% |
| Long-task duration | 896 ms | 378 ms | 57.8% |
| Warm thread hydration | 716.5 ms | 496.7 ms | 30.7% |

The preliminary short/medium/near-cap comparison also confirmed direct typing stayed nearly flat and caused zero main-store writes; the expensive path was live activity rendering/derivation.

## Verification

- `bun run --cwd apps/web test -- src/components/ChatView.logic.test.ts -t "composer strip work-log derivation"`
- `bun run --cwd apps/web test -- src/components/chatHotPath.compiler.test.ts -t "compiles ChatView.tsx"`
- `bun run --cwd apps/web test:browser -- src/components/ChatView.browser.tsx -t "keeps near-cap composer work bounded"`
- `./node_modules/.bin/oxfmt --check apps/web/src/components/ChatView.browser.tsx apps/web/src/components/ChatView.logic.test.ts apps/web/src/components/ChatView.logic.ts apps/web/src/components/ChatView.tsx`
- `git diff --check`

Per `AGENTS.md`, heavyweight workspace-wide `bun fmt`, `bun lint`, and `bun typecheck` were not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized rendering/derivation optimization in ChatView with behavior preserved for subagent routes and covered by unit and browser regression tests.
> 
> **Overview**
> Fixes **long-thread composer lag** when live activities stream in (#550) by **not deriving the work log twice** for the transcript and the composer subagent strip on top-level threads.
> 
> Adds **`resolveComposerStripWorkLogEntries`** so the strip **reuses** `rawWorkLogEntries` when there is no distinct parent-thread source; **subagent views** still run the full parent-thread `deriveWorkLogEntries` path. **`ChatView`** wires the strip through that helper instead of always re-deriving from activities.
> 
> **Tests:** a **unit guard** that the top-level path skips the fallback derivation, plus a **Chromium browser benchmark** (React `Profiler`, short vs near-cap activity load) that bounds how much React commit work grows while typing during live `thread.activity-appended` events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d0bd2907adf3005c31773debc5792328d21cb54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->