### PR TITLE
Fix thread branch and PR recognition

### DIFF
--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -61,6 +61,7 @@ import {
 } from "../src/orchestration/Services/OrchestrationEngine.ts";
 import { OrchestrationReactor } from "../src/orchestration/Services/OrchestrationReactor.ts";
 import { ProjectionSnapshotQuery } from "../src/orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ThreadGitMetadataReactor } from "../src/orchestration/Services/ThreadGitMetadataReactor.ts";
 import {
   RuntimeReceiptBus,
   type OrchestrationRuntimeReceipt,
@@ -326,11 +327,16 @@ export const makeOrchestrationIntegrationHarness = (
     const checkpointReactorLayer = CheckpointReactorLive.pipe(
       Layer.provideMerge(runtimeServicesLayer),
     );
+    const threadGitMetadataReactorLayer = Layer.succeed(ThreadGitMetadataReactor, {
+      start: Effect.void,
+      drain: Effect.void,
+    });
     const orchestrationReactorLayer = OrchestrationReactorLive.pipe(
       Layer.provideMerge(runtimeIngestionLayer),
       Layer.provideMerge(providerCommandReactorLayer),
       Layer.provideMerge(checkpointReactorLayer),
       Layer.provideMerge(studioOutputReactorLayer),
+      Layer.provideMerge(threadGitMetadataReactorLayer),
     );
     const layer = orchestrationReactorLayer.pipe(
       Layer.provide(persistenceLayer),

--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -1793,6 +1793,38 @@ it.layer(TestLayer)("git integration", (it) => {
       }),
     );
 
+    it.effect("reads branch identity without requiring full status details", () =>
+      Effect.gen(function* () {
+        const remote = yield* makeTmpDir();
+        const tmp = yield* makeTmpDir();
+        const nonRepo = yield* makeTmpDir();
+        yield* git(remote, ["init", "--bare"]);
+        yield* initRepoWithCommit(tmp);
+        yield* git(tmp, ["remote", "add", "origin", remote]);
+        yield* git(tmp, ["checkout", "-b", "feature/branch-context"]);
+        yield* git(tmp, ["push", "-u", "origin", "feature/branch-context"]);
+        const core = yield* GitCore;
+
+        expect(yield* core.readBranchContext(tmp)).toEqual({
+          isRepo: true,
+          branch: "feature/branch-context",
+          upstreamRef: "origin/feature/branch-context",
+        });
+
+        yield* git(tmp, ["checkout", "--detach"]);
+        expect(yield* core.readBranchContext(tmp)).toEqual({
+          isRepo: true,
+          branch: null,
+          upstreamRef: null,
+        });
+        expect(yield* core.readBranchContext(nonRepo)).toEqual({
+          isRepo: false,
+          branch: null,
+          upstreamRef: null,
+        });
+      }),
+    );
+
     it.effect("preserves adversarial filenames in status details", () =>
       Effect.gen(function* () {
         if (process.platform === "win32") return;

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -1486,6 +1486,46 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
 
     const statusDetails: GitCoreShape["statusDetails"] = (cwd) => readStatusDetails(cwd, true);
 
+    const readBranchContext: GitCoreShape["readBranchContext"] = (cwd) =>
+      Effect.gen(function* () {
+        const branchOperation = "GitCore.readBranchContext.branch";
+        const branchArgs = ["symbolic-ref", "--quiet", "--short", "HEAD"] as const;
+        const branchResult = yield* executeGit(branchOperation, cwd, branchArgs, {
+          allowNonZeroExit: true,
+          timeoutMs: 5_000,
+          maxOutputBytes: 4_096,
+        }).pipe(Effect.catchIf(isMissingGitCwdError, () => Effect.succeed(null)));
+        if (branchResult === null || branchResult.code === 128) {
+          return { isRepo: false, branch: null, upstreamRef: null };
+        }
+        if (branchResult.code !== 0 && branchResult.code !== 1) {
+          return yield* createGitCommandError(
+            branchOperation,
+            cwd,
+            branchArgs,
+            branchResult.stderr.trim() ||
+              `${commandLabel(branchArgs)} failed: code=${branchResult.code}`,
+          );
+        }
+
+        const branch = branchResult.code === 0 ? branchResult.stdout.trim() || null : null;
+        if (branch === null) {
+          return { isRepo: true, branch: null, upstreamRef: null };
+        }
+
+        const upstreamResult = yield* executeGit(
+          "GitCore.readBranchContext.upstream",
+          cwd,
+          ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+          { allowNonZeroExit: true, timeoutMs: 5_000, maxOutputBytes: 4_096 },
+        );
+        return {
+          isRepo: true,
+          branch,
+          upstreamRef: upstreamResult.code === 0 ? upstreamResult.stdout.trim() || null : null,
+        };
+      });
+
     const status: GitCoreShape["status"] = (input) =>
       Effect.gen(function* () {
         const details = yield* readStatusDetails(input.cwd, false);
@@ -3227,6 +3267,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
       execute,
       status,
       statusDetails,
+      readBranchContext,
       readWorkingTreePatch,
       readUnstagedPatch,
       readStagedPatch,

--- a/apps/server/src/git/Layers/GitManager.test.ts
+++ b/apps/server/src/git/Layers/GitManager.test.ts
@@ -426,6 +426,46 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
+  it.effect("resolves a captured branch PR after the checkout has moved elsewhere", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("synara-git-manager-");
+      yield* initRepo(repoDir);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/captured-pr"]);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "feature/captured-pr"]);
+      yield* runGit(repoDir, ["checkout", "main"]);
+
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          prListByHeadSelector: {
+            "feature/captured-pr": JSON.stringify([
+              {
+                number: 574,
+                title: "Captured branch PR",
+                url: "https://github.com/example-org/sample-repo/pull/574",
+                baseRefName: "main",
+                headRefName: "feature/captured-pr",
+                state: "OPEN",
+              },
+            ]),
+          },
+        },
+      });
+
+      const resolved = yield* manager.pullRequestForBranch({
+        cwd: repoDir,
+        branch: "feature/captured-pr",
+        upstreamRef: "origin/feature/captured-pr",
+      });
+
+      expect(resolved).toMatchObject({ number: 574, headBranch: "feature/captured-pr" });
+      expect(ghCalls.some((call) => call.includes("pr list --head feature/captured-pr"))).toBe(
+        true,
+      );
+    }),
+  );
+
   it.effect(
     "status detects cross-repo PRs from the upstream remote URL owner",
     () =>

--- a/apps/server/src/git/Layers/GitManager.ts
+++ b/apps/server/src/git/Layers/GitManager.ts
@@ -1362,19 +1362,26 @@ export const makeGitManager = Effect.gen(function* () {
       };
     });
 
+  const pullRequestForBranch: GitManagerShape["pullRequestForBranch"] = Effect.fnUntraced(
+    function* (input) {
+      const latest = yield* findLatestPr(input.cwd, {
+        branch: input.branch,
+        upstreamRef: input.upstreamRef,
+      });
+      return latest ? toResolvedPullRequest(latest) : null;
+    },
+  );
+
   const status: GitManagerShape["status"] = Effect.fnUntraced(function* (input) {
     const details = yield* gitCore.statusDetails(input.cwd);
 
     const pr =
       details.branch !== null
-        ? yield* findLatestPr(input.cwd, {
+        ? yield* pullRequestForBranch({
+            cwd: input.cwd,
             branch: details.branch,
             upstreamRef: details.upstreamRef,
-          }).pipe(
-            // Status and PR-resolution surfaces share one mapper so their shapes cannot drift.
-            Effect.map((latest) => (latest ? toResolvedPullRequest(latest) : null)),
-            Effect.catch(() => Effect.succeed(null)),
-          )
+          }).pipe(Effect.catch(() => Effect.succeed(null)))
         : null;
 
     return {
@@ -2748,6 +2755,7 @@ The local stash entry was kept for recovery.`,
 
   return {
     status,
+    pullRequestForBranch,
     readWorkingTreeDiff,
     readWorkingTreeDiffStats,
     summarizeDiff,

--- a/apps/server/src/git/Layers/GitStatusBroadcaster.test.ts
+++ b/apps/server/src/git/Layers/GitStatusBroadcaster.test.ts
@@ -53,6 +53,8 @@ function makeTestLayer(state: {
         state.statusCalls += 1;
         return state.currentStatus;
       }),
+    pullRequestForBranch: () =>
+      Effect.die("pullRequestForBranch should not be called in this test"),
     readWorkingTreeDiff: () => Effect.die("readWorkingTreeDiff should not be called in this test"),
     readWorkingTreeDiffStats: () =>
       Effect.die("readWorkingTreeDiffStats should not be called in this test"),

--- a/apps/server/src/git/Services/GitCore.ts
+++ b/apps/server/src/git/Services/GitCore.ts
@@ -56,6 +56,12 @@ export interface GitStatusDetails extends Omit<GitStatusResult, "pr"> {
   upstreamRef: string | null;
 }
 
+export interface GitBranchContext {
+  readonly isRepo: boolean;
+  readonly branch: string | null;
+  readonly upstreamRef: string | null;
+}
+
 export interface GitPreparedCommitContext {
   stagedSummary: string;
   stagedPatch: string;
@@ -203,6 +209,11 @@ export interface GitCoreShape {
    * Read detailed working tree / branch status for a repository.
    */
   readonly statusDetails: (cwd: string) => Effect.Effect<GitStatusDetails, GitCommandError>;
+
+  /** Read only branch identity, without diff stats or remote refresh work. */
+  readonly readBranchContext: (
+    cwd: string,
+  ) => Effect.Effect<GitBranchContext, GitCommandError>;
 
   /**
    * Read a unified patch for the current working tree, including untracked files.

--- a/apps/server/src/git/Services/GitCore.ts
+++ b/apps/server/src/git/Services/GitCore.ts
@@ -211,9 +211,7 @@ export interface GitCoreShape {
   readonly statusDetails: (cwd: string) => Effect.Effect<GitStatusDetails, GitCommandError>;
 
   /** Read only branch identity, without diff stats or remote refresh work. */
-  readonly readBranchContext: (
-    cwd: string,
-  ) => Effect.Effect<GitBranchContext, GitCommandError>;
+  readonly readBranchContext: (cwd: string) => Effect.Effect<GitBranchContext, GitCommandError>;
 
   /**
    * Read a unified patch for the current working tree, including untracked files.

--- a/apps/server/src/git/Services/GitManager.ts
+++ b/apps/server/src/git/Services/GitManager.ts
@@ -15,6 +15,7 @@ import {
   GitPullRequestRefInput,
   GitPullRequestSnapshotInput,
   GitPullRequestSnapshotResult,
+  GitResolvedPullRequest,
   GitReadWorkingTreeDiffInput,
   GitReadWorkingTreeDiffResult,
   GitWorkingTreeDiffStatsResult,
@@ -49,6 +50,17 @@ export interface GitManagerShape {
   readonly status: (
     input: GitStatusInput,
   ) => Effect.Effect<GitStatusResult, GitManagerServiceError>;
+
+  /**
+   * Resolve the most relevant pull request for an already-captured branch.
+   * Unlike status(), lookup failures remain typed failures so callers can distinguish
+   * “no PR exists” from “GitHub is temporarily unavailable”.
+   */
+  readonly pullRequestForBranch: (input: {
+    readonly cwd: string;
+    readonly branch: string;
+    readonly upstreamRef: string | null;
+  }) => Effect.Effect<GitResolvedPullRequest | null, GitManagerServiceError>;
 
   /**
    * Read a unified patch for the current repository working tree.

--- a/apps/server/src/orchestration/Layers/OrchestrationReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationReactor.test.ts
@@ -5,6 +5,7 @@ import { CheckpointReactor } from "../Services/CheckpointReactor.ts";
 import { ProviderCommandReactor } from "../Services/ProviderCommandReactor.ts";
 import { ProviderRuntimeIngestionService } from "../Services/ProviderRuntimeIngestion.ts";
 import { StudioOutputReactor } from "../Services/StudioOutputReactor.ts";
+import { ThreadGitMetadataReactor } from "../Services/ThreadGitMetadataReactor.ts";
 import { OrchestrationReactor } from "../Services/OrchestrationReactor.ts";
 import { makeOrchestrationReactor } from "./OrchestrationReactor.ts";
 
@@ -76,6 +77,17 @@ describe("OrchestrationReactor", () => {
             drain: Effect.void,
           }),
         ),
+        Layer.provideMerge(
+          Layer.succeed(ThreadGitMetadataReactor, {
+            start: Effect.acquireRelease(
+              Effect.sync(() => {
+                started.push("thread-git-metadata-reactor");
+              }),
+              () => Effect.sync(() => stopped.push("thread-git-metadata-reactor")),
+            ),
+            drain: Effect.void,
+          }),
+        ),
       ),
     );
 
@@ -87,6 +99,7 @@ describe("OrchestrationReactor", () => {
     expect(started).toEqual([
       "studio-output-reactor",
       "checkpoint-reactor",
+      "thread-git-metadata-reactor",
       "provider-runtime-ingestion",
       "provider-command-reactor",
     ]);
@@ -96,6 +109,7 @@ describe("OrchestrationReactor", () => {
     expect(stopped).toEqual([
       "provider-command-reactor",
       "provider-runtime-ingestion",
+      "thread-git-metadata-reactor",
       "checkpoint-reactor",
       "studio-output-reactor",
     ]);

--- a/apps/server/src/orchestration/Layers/OrchestrationReactor.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationReactor.ts
@@ -8,20 +8,23 @@ import { CheckpointReactor } from "../Services/CheckpointReactor.ts";
 import { ProviderCommandReactor } from "../Services/ProviderCommandReactor.ts";
 import { ProviderRuntimeIngestionService } from "../Services/ProviderRuntimeIngestion.ts";
 import { StudioOutputReactor } from "../Services/StudioOutputReactor.ts";
+import { ThreadGitMetadataReactor } from "../Services/ThreadGitMetadataReactor.ts";
 
 export const makeOrchestrationReactor = Effect.gen(function* () {
   const providerRuntimeIngestion = yield* ProviderRuntimeIngestionService;
   const providerCommandReactor = yield* ProviderCommandReactor;
   const checkpointReactor = yield* CheckpointReactor;
   const studioOutputReactor = yield* StudioOutputReactor;
+  const threadGitMetadataReactor = yield* ThreadGitMetadataReactor;
 
   const start: OrchestrationReactorShape["start"] = Effect.gen(function* () {
     yield* studioOutputReactor.start;
     yield* checkpointReactor.start;
+    yield* threadGitMetadataReactor.start;
     yield* providerRuntimeIngestion.start;
     // Install every runtime observer before provider command dispatch can
     // begin. Reverse-order finalization then drains provider commands first,
-    // runtime ingestion second, checkpoints third, and Studio output last.
+    // runtime ingestion second, Git metadata third, checkpoints fourth, and Studio output last.
     yield* providerCommandReactor.start;
   });
 

--- a/apps/server/src/orchestration/Layers/ThreadGitMetadataReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ThreadGitMetadataReactor.test.ts
@@ -272,6 +272,48 @@ describe("ThreadGitMetadataReactor", () => {
     });
   });
 
+  it("ignores native subagent lifecycle events while attributing the shared parent turn", async () => {
+    const threadId = ThreadId.makeUnsafe("local-parent-thread");
+    const parentTurnId = TurnId.makeUnsafe("local-parent-turn");
+    const childTurnId = TurnId.makeUnsafe("local-child-turn");
+    const childProviderRefs = {
+      providerThreadId: "child-provider-thread",
+      providerParentThreadId: "parent-provider-thread",
+    } as const;
+    const harness = await createHarness({
+      threads: [
+        {
+          id: threadId,
+          projectId: ProjectId.makeUnsafe("project-1"),
+          envMode: "local",
+          worktreePath: null,
+          branch: "synara/stale-branch",
+          lastKnownPr: null,
+        },
+      ],
+      branchByCwd: { "/repo": pullRequest.headBranch },
+    });
+
+    await harness.publish(startedEvent(threadId, parentTurnId));
+    await harness.publish({
+      ...startedEvent(threadId, childTurnId),
+      providerRefs: childProviderRefs,
+    });
+    await harness.publish({
+      ...completedEvent(threadId, childTurnId),
+      providerRefs: childProviderRefs,
+    });
+    await harness.publish(completedEvent(threadId, parentTurnId));
+    await waitFor(() => harness.commands.length === 1);
+
+    expect(harness.commands[0]).toMatchObject({
+      type: "thread.meta.update",
+      threadId,
+      branch: pullRequest.headBranch,
+      lastKnownPr: pullRequest,
+    });
+  });
+
   it("does not claim a shared local checkout without an observed owning turn", async () => {
     const localThreadId = ThreadId.makeUnsafe("unowned-local-thread");
     const worktreeThreadId = ThreadId.makeUnsafe("worktree-flush-thread");
@@ -307,6 +349,59 @@ describe("ThreadGitMetadataReactor", () => {
     expect(harness.commands[0]).toMatchObject({
       type: "thread.meta.update",
       threadId: worktreeThreadId,
+    });
+  });
+
+  it("does not let a stale explicit terminal event consume the active shared turn", async () => {
+    const localThreadId = ThreadId.makeUnsafe("active-local-thread");
+    const sentinelThreadId = ThreadId.makeUnsafe("sentinel-worktree-thread");
+    const activeTurnId = TurnId.makeUnsafe("active-local-turn");
+    const sentinelCwd = "/repo/.worktrees/sentinel";
+    const projectId = ProjectId.makeUnsafe("project-1");
+    const harness = await createHarness({
+      threads: [
+        {
+          id: localThreadId,
+          projectId,
+          envMode: "local",
+          worktreePath: null,
+          branch: "synara/stale-branch",
+          lastKnownPr: null,
+        },
+        {
+          id: sentinelThreadId,
+          projectId,
+          envMode: "worktree",
+          worktreePath: sentinelCwd,
+          branch: "synara/stale-sentinel",
+          lastKnownPr: null,
+        },
+      ],
+      branchByCwd: {
+        "/repo": pullRequest.headBranch,
+        [sentinelCwd]: pullRequest.headBranch,
+      },
+    });
+
+    await harness.publish(startedEvent(localThreadId, activeTurnId));
+    await harness.publish(completedEvent(localThreadId, TurnId.makeUnsafe("stale-local-turn")));
+    await harness.publish(
+      completedEvent(sentinelThreadId, TurnId.makeUnsafe("sentinel-worktree-turn")),
+    );
+    await waitFor(() => harness.commands.length === 1);
+
+    expect(harness.commands[0]).toMatchObject({
+      type: "thread.meta.update",
+      threadId: sentinelThreadId,
+    });
+    expect(harness.statusCwds).toEqual([sentinelCwd]);
+
+    await harness.publish(completedEvent(localThreadId, activeTurnId));
+    await waitFor(() => harness.commands.length === 2);
+    expect(harness.commands[1]).toMatchObject({
+      type: "thread.meta.update",
+      threadId: localThreadId,
+      branch: pullRequest.headBranch,
     });
   });
 

--- a/apps/server/src/orchestration/Layers/ThreadGitMetadataReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ThreadGitMetadataReactor.test.ts
@@ -1,0 +1,404 @@
+import {
+  EventId,
+  ProjectId,
+  ThreadId,
+  TurnId,
+  type OrchestrationCommand,
+  type OrchestrationThreadPullRequest,
+  type ProviderRuntimeEvent,
+} from "@synara/contracts";
+import { Effect, Exit, Layer, ManagedRuntime, Option, PubSub, Scope, Stream } from "effect";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { GitManagerError } from "../../git/Errors.ts";
+import { GitCore, type GitCoreShape, type GitStatusDetails } from "../../git/Services/GitCore.ts";
+import { GitManager, type GitManagerShape } from "../../git/Services/GitManager.ts";
+import {
+  ProviderService,
+  type ProviderServiceShape,
+} from "../../provider/Services/ProviderService.ts";
+import {
+  OrchestrationEngineService,
+  type OrchestrationEngineShape,
+} from "../Services/OrchestrationEngine.ts";
+import {
+  ProjectionSnapshotQuery,
+  type ProjectionSnapshotQueryShape,
+} from "../Services/ProjectionSnapshotQuery.ts";
+import { ThreadGitMetadataReactor } from "../Services/ThreadGitMetadataReactor.ts";
+import { ThreadGitMetadataReactorLive } from "./ThreadGitMetadataReactor.ts";
+
+interface MutableThreadShell {
+  readonly id: ThreadId;
+  readonly projectId: ProjectId;
+  readonly envMode: "local" | "worktree";
+  readonly worktreePath: string | null;
+  branch: string | null;
+  lastKnownPr: OrchestrationThreadPullRequest | null;
+  associatedWorktreePath?: string | null;
+  associatedWorktreeBranch?: string | null;
+  associatedWorktreeRef?: string | null;
+}
+
+const pullRequest: OrchestrationThreadPullRequest = {
+  number: 574,
+  title: "Cache provider usage",
+  url: "https://github.com/Emanuele-web04/synara/pull/574",
+  baseBranch: "main",
+  headBranch: "feat/provider-usage-snapshot-cache",
+  state: "open",
+};
+
+const statusDetails = (branch: string): GitStatusDetails => ({
+  isRepo: true,
+  hasOriginRemote: true,
+  isDefaultBranch: false,
+  branch,
+  upstreamRef: `origin/${branch}`,
+  upstreamBranch: branch,
+  hasWorkingTreeChanges: false,
+  workingTree: { files: [], insertions: 0, deletions: 0 },
+  hasUpstream: true,
+  aheadCount: 0,
+  behindCount: 0,
+});
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error("Timed out waiting for thread Git metadata reconciliation.");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+describe("ThreadGitMetadataReactor", () => {
+  let runtime: ManagedRuntime.ManagedRuntime<ThreadGitMetadataReactor, unknown> | null = null;
+  let scope: Scope.Closeable | null = null;
+
+  afterEach(async () => {
+    if (scope) await Effect.runPromise(Scope.close(scope, Exit.void));
+    scope = null;
+    if (runtime) await runtime.dispose();
+    runtime = null;
+  });
+
+  const createHarness = async (input: {
+    readonly threads: MutableThreadShell[];
+    readonly branchByCwd: Readonly<Record<string, string>>;
+    readonly pullRequestLookupFails?: boolean;
+  }) => {
+    const runtimeEvents = Effect.runSync(PubSub.unbounded<ProviderRuntimeEvent>());
+    const commands: OrchestrationCommand[] = [];
+    const pullRequestLookups: string[] = [];
+    const statusCwds: string[] = [];
+    const threads = new Map(input.threads.map((thread) => [thread.id, thread]));
+    const projectId = input.threads[0]!.projectId;
+
+    const providerService = {
+      streamEvents: Stream.fromPubSub(runtimeEvents),
+    } as unknown as ProviderServiceShape;
+    const projectionSnapshotQuery = {
+      getThreadShellById: (threadId: ThreadId) =>
+        Effect.succeed(Option.fromNullishOr(threads.get(threadId) as never)),
+      getProjectShellById: () =>
+        Effect.succeed(
+          Option.some({
+            id: projectId,
+            kind: "project",
+            workspaceRoot: "/repo",
+          } as never),
+        ),
+    } as unknown as ProjectionSnapshotQueryShape;
+    const gitCore = {
+      readBranchContext: (cwd: string) =>
+        Effect.sync(() => {
+          statusCwds.push(cwd);
+          return statusDetails(input.branchByCwd[cwd]!);
+        }),
+    } as unknown as GitCoreShape;
+    const gitManager = {
+      pullRequestForBranch: ({ branch }: { branch: string }) =>
+        Effect.gen(function* () {
+          pullRequestLookups.push(branch);
+          if (input.pullRequestLookupFails) {
+            return yield* new GitManagerError({
+              operation: "pullRequestForBranch",
+              detail: "GitHub unavailable",
+            });
+          }
+          return branch === pullRequest.headBranch ? pullRequest : null;
+        }),
+    } as unknown as GitManagerShape;
+    const orchestrationEngine = {
+      dispatch: (command: OrchestrationCommand) =>
+        Effect.sync(() => {
+          commands.push(command);
+          if (command.type === "thread.meta.update") {
+            const thread = threads.get(command.threadId);
+            if (thread) {
+              if (command.branch !== undefined) thread.branch = command.branch;
+              if (command.lastKnownPr !== undefined) thread.lastKnownPr = command.lastKnownPr;
+              if (command.associatedWorktreePath !== undefined) {
+                thread.associatedWorktreePath = command.associatedWorktreePath;
+              }
+              if (command.associatedWorktreeBranch !== undefined) {
+                thread.associatedWorktreeBranch = command.associatedWorktreeBranch;
+              }
+              if (command.associatedWorktreeRef !== undefined) {
+                thread.associatedWorktreeRef = command.associatedWorktreeRef;
+              }
+            }
+          }
+          return { sequence: commands.length };
+        }),
+    } as unknown as OrchestrationEngineShape;
+
+    const layer = ThreadGitMetadataReactorLive.pipe(
+      Layer.provideMerge(Layer.succeed(ProviderService, providerService)),
+      Layer.provideMerge(Layer.succeed(ProjectionSnapshotQuery, projectionSnapshotQuery)),
+      Layer.provideMerge(Layer.succeed(GitCore, gitCore)),
+      Layer.provideMerge(Layer.succeed(GitManager, gitManager)),
+      Layer.provideMerge(Layer.succeed(OrchestrationEngineService, orchestrationEngine)),
+    );
+    const managedRuntime = ManagedRuntime.make(layer);
+    runtime = managedRuntime;
+    const reactor = await managedRuntime.runPromise(Effect.service(ThreadGitMetadataReactor));
+    scope = await Effect.runPromise(Scope.make("sequential"));
+    await Effect.runPromise(reactor.start.pipe(Scope.provide(scope)));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const publish = (event: ProviderRuntimeEvent) =>
+      Effect.runPromise(PubSub.publish(runtimeEvents, event).pipe(Effect.asVoid));
+
+    return {
+      commands,
+      pullRequestLookups,
+      statusCwds,
+      publish,
+      drain: () => managedRuntime.runPromise(reactor.drain),
+    };
+  };
+
+  const startedEvent = (threadId: ThreadId, turnId: TurnId): ProviderRuntimeEvent => ({
+    type: "turn.started",
+    eventId: EventId.makeUnsafe(`started-${turnId}`),
+    provider: "codex",
+    threadId,
+    turnId,
+    createdAt: "2026-08-07T10:00:00.000Z",
+    payload: {},
+  });
+
+  const completedEvent = (threadId: ThreadId, turnId: TurnId): ProviderRuntimeEvent => ({
+    type: "turn.completed",
+    eventId: EventId.makeUnsafe(`completed-${turnId}`),
+    provider: "codex",
+    threadId,
+    turnId,
+    createdAt: "2026-08-07T10:01:00.000Z",
+    payload: { state: "completed" },
+  });
+
+  const runtimeErrorEvent = (threadId: ThreadId): ProviderRuntimeEvent => ({
+    type: "runtime.error",
+    eventId: EventId.makeUnsafe(`runtime-error-${threadId}`),
+    provider: "codex",
+    threadId,
+    createdAt: "2026-08-07T10:01:00.000Z",
+    payload: { message: "Provider stopped" },
+  });
+
+  it("persists the actual worktree branch and PR even when branch metadata is stale", async () => {
+    const threadId = ThreadId.makeUnsafe("worktree-thread");
+    const turnId = TurnId.makeUnsafe("worktree-turn");
+    const harness = await createHarness({
+      threads: [
+        {
+          id: threadId,
+          projectId: ProjectId.makeUnsafe("project-1"),
+          envMode: "worktree",
+          worktreePath: "/repo/.worktrees/thread",
+          branch: "synara/stale-branch",
+          lastKnownPr: null,
+        },
+      ],
+      branchByCwd: { "/repo/.worktrees/thread": pullRequest.headBranch },
+    });
+
+    await harness.publish(completedEvent(threadId, turnId));
+    await waitFor(() => harness.statusCwds.length === 1);
+    await waitFor(() => harness.commands.length === 1);
+
+    expect(harness.commands[0]).toMatchObject({
+      type: "thread.meta.update",
+      threadId,
+      branch: pullRequest.headBranch,
+      lastKnownPr: pullRequest,
+      associatedWorktreePath: "/repo/.worktrees/thread",
+      associatedWorktreeBranch: pullRequest.headBranch,
+      associatedWorktreeRef: pullRequest.headBranch,
+    });
+    expect(harness.pullRequestLookups).toEqual([pullRequest.headBranch]);
+  });
+
+  it("attributes a shared local branch only to the thread that owned the turn", async () => {
+    const threadId = ThreadId.makeUnsafe("local-thread");
+    const turnId = TurnId.makeUnsafe("local-turn");
+    const harness = await createHarness({
+      threads: [
+        {
+          id: threadId,
+          projectId: ProjectId.makeUnsafe("project-1"),
+          envMode: "local",
+          worktreePath: null,
+          branch: "synara/stale-branch",
+          lastKnownPr: null,
+        },
+      ],
+      branchByCwd: { "/repo": pullRequest.headBranch },
+    });
+
+    await harness.publish(startedEvent(threadId, turnId));
+    await harness.publish(completedEvent(threadId, turnId));
+    await waitFor(() => harness.commands.length === 1);
+
+    expect(harness.commands[0]).toMatchObject({
+      type: "thread.meta.update",
+      threadId,
+      branch: pullRequest.headBranch,
+      lastKnownPr: pullRequest,
+    });
+  });
+
+  it("does not claim a shared local checkout without an observed owning turn", async () => {
+    const localThreadId = ThreadId.makeUnsafe("unowned-local-thread");
+    const worktreeThreadId = ThreadId.makeUnsafe("worktree-flush-thread");
+    const harness = await createHarness({
+      threads: [
+        {
+          id: localThreadId,
+          projectId: ProjectId.makeUnsafe("project-1"),
+          envMode: "local",
+          worktreePath: null,
+          branch: "synara/local-stale",
+          lastKnownPr: null,
+        },
+        {
+          id: worktreeThreadId,
+          projectId: ProjectId.makeUnsafe("project-1"),
+          envMode: "worktree",
+          worktreePath: "/repo/.worktrees/flush",
+          branch: "synara/worktree-stale",
+          lastKnownPr: null,
+        },
+      ],
+      branchByCwd: {
+        "/repo": pullRequest.headBranch,
+        "/repo/.worktrees/flush": pullRequest.headBranch,
+      },
+    });
+
+    await harness.publish(completedEvent(localThreadId, TurnId.makeUnsafe("unowned-turn")));
+    await harness.publish(completedEvent(worktreeThreadId, TurnId.makeUnsafe("flush-turn")));
+    await waitFor(() => harness.commands.length === 1);
+
+    expect(harness.commands[0]).toMatchObject({
+      type: "thread.meta.update",
+      threadId: worktreeThreadId,
+    });
+  });
+
+  it("skips overlapping shared turns and resumes on the next exclusive owner", async () => {
+    const firstThreadId = ThreadId.makeUnsafe("first-local-thread");
+    const secondThreadId = ThreadId.makeUnsafe("second-local-thread");
+    const thirdThreadId = ThreadId.makeUnsafe("third-local-thread");
+    const firstTurnId = TurnId.makeUnsafe("first-local-turn");
+    const secondTurnId = TurnId.makeUnsafe("second-local-turn");
+    const projectId = ProjectId.makeUnsafe("project-1");
+    const harness = await createHarness({
+      threads: [firstThreadId, secondThreadId, thirdThreadId].map((id) => ({
+        id,
+        projectId,
+        envMode: "local" as const,
+        worktreePath: null,
+        branch: "synara/stale-branch",
+        lastKnownPr: null,
+      })),
+      branchByCwd: { "/repo": pullRequest.headBranch },
+    });
+
+    await harness.publish(startedEvent(firstThreadId, firstTurnId));
+    await harness.publish(startedEvent(secondThreadId, secondTurnId));
+    await harness.publish(completedEvent(firstThreadId, firstTurnId));
+    await harness.publish(completedEvent(secondThreadId, secondTurnId));
+    const thirdTurnId = TurnId.makeUnsafe("third-local-turn");
+    await harness.publish(startedEvent(thirdThreadId, thirdTurnId));
+    await harness.publish(completedEvent(thirdThreadId, thirdTurnId));
+    await waitFor(() => harness.commands.length === 1);
+
+    expect(harness.commands[0]).toMatchObject({
+      type: "thread.meta.update",
+      threadId: thirdThreadId,
+    });
+  });
+
+  it("preserves matching durable metadata when GitHub is temporarily unavailable", async () => {
+    const threadId = ThreadId.makeUnsafe("worktree-offline-thread");
+    const cwd = "/repo/.worktrees/offline";
+    const harness = await createHarness({
+      threads: [
+        {
+          id: threadId,
+          projectId: ProjectId.makeUnsafe("project-1"),
+          envMode: "worktree",
+          worktreePath: cwd,
+          branch: pullRequest.headBranch,
+          lastKnownPr: pullRequest,
+          associatedWorktreePath: cwd,
+          associatedWorktreeBranch: pullRequest.headBranch,
+          associatedWorktreeRef: pullRequest.headBranch,
+        },
+      ],
+      branchByCwd: { [cwd]: pullRequest.headBranch },
+      pullRequestLookupFails: true,
+    });
+
+    await harness.publish(completedEvent(threadId, TurnId.makeUnsafe("offline-turn")));
+    await waitFor(() => harness.pullRequestLookups.length === 1);
+    await harness.drain();
+
+    expect(harness.commands).toEqual([]);
+  });
+
+  it("releases ambiguous local turn ownership when the provider runtime exits", async () => {
+    const staleThreadId = ThreadId.makeUnsafe("stale-local-thread");
+    const nextThreadId = ThreadId.makeUnsafe("next-local-thread");
+    const projectId = ProjectId.makeUnsafe("project-1");
+    const harness = await createHarness({
+      threads: [staleThreadId, nextThreadId].map((id) => ({
+        id,
+        projectId,
+        envMode: "local" as const,
+        worktreePath: null,
+        branch: "synara/stale-branch",
+        lastKnownPr: null,
+      })),
+      branchByCwd: { "/repo": pullRequest.headBranch },
+    });
+
+    await harness.publish(startedEvent(staleThreadId, TurnId.makeUnsafe("stale-turn-1")));
+    await harness.publish(startedEvent(staleThreadId, TurnId.makeUnsafe("stale-turn-2")));
+    await harness.publish(runtimeErrorEvent(staleThreadId));
+    await harness.publish(startedEvent(nextThreadId, TurnId.makeUnsafe("next-turn")));
+    await harness.publish(completedEvent(nextThreadId, TurnId.makeUnsafe("next-turn")));
+    await waitFor(() => harness.commands.length === 1);
+
+    expect(harness.commands[0]).toMatchObject({
+      type: "thread.meta.update",
+      threadId: nextThreadId,
+      branch: pullRequest.headBranch,
+    });
+  });
+});

--- a/apps/server/src/orchestration/Layers/ThreadGitMetadataReactor.ts
+++ b/apps/server/src/orchestration/Layers/ThreadGitMetadataReactor.ts
@@ -5,6 +5,7 @@ import { Cause, Effect, Layer, Option, Stream } from "effect";
 import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
 import { GitCore } from "../../git/Services/GitCore.ts";
 import { GitManager } from "../../git/Services/GitManager.ts";
+import type { ProjectionRepositoryError } from "../../persistence/Errors.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
@@ -60,7 +61,7 @@ const make = Effect.gen(function* () {
 
   const resolveWorkspaceContext = Effect.fnUntraced(function* (
     threadId: ThreadId,
-  ): Effect.fn.Return<ThreadWorkspaceContext | null> {
+  ): Effect.fn.Return<ThreadWorkspaceContext | null, ProjectionRepositoryError> {
     const threadOption = yield* projectionSnapshotQuery.getThreadShellById(threadId);
     const thread = Option.getOrUndefined(threadOption);
     if (!thread) return null;

--- a/apps/server/src/orchestration/Layers/ThreadGitMetadataReactor.ts
+++ b/apps/server/src/orchestration/Layers/ThreadGitMetadataReactor.ts
@@ -123,6 +123,10 @@ const make = Effect.gen(function* () {
     if (explicitKey) {
       const context = activeContextByTurnKey.get(explicitKey);
       if (context) return { context, activeKey: explicitKey };
+      const fallbackContext = yield* resolveWorkspaceContext(event.threadId);
+      return fallbackContext?.hasDedicatedWorktree
+        ? { context: fallbackContext, activeKey: null }
+        : null;
     }
 
     const threadKeys = activeKeysForThread(event.threadId);
@@ -286,6 +290,10 @@ const make = Effect.gen(function* () {
   });
 
   const processProviderEvent = (event: ProviderRuntimeEvent) => {
+    // Native subagent lifecycle events carry the parent Synara thread id and the child identity
+    // in providerRefs. Treating them as parent turns would make shared-root ownership ambiguous
+    // and suppress reconciliation when the actual parent turn completes.
+    if (event.providerRefs?.providerParentThreadId !== undefined) return Effect.void;
     if (event.type === "turn.started") return trackTurnStart(event);
     if (
       event.type === "turn.completed" ||

--- a/apps/server/src/orchestration/Layers/ThreadGitMetadataReactor.ts
+++ b/apps/server/src/orchestration/Layers/ThreadGitMetadataReactor.ts
@@ -1,8 +1,4 @@
-import {
-  CommandId,
-  type ProviderRuntimeEvent,
-  type ThreadId,
-} from "@synara/contracts";
+import { CommandId, type ProviderRuntimeEvent, type ThreadId } from "@synara/contracts";
 import { makeDrainableWorker, startDrainableWorkerProducers } from "@synara/shared/DrainableWorker";
 import { Cause, Effect, Layer, Option, Stream } from "effect";
 
@@ -122,8 +118,7 @@ const make = Effect.gen(function* () {
   });
 
   const resolveTerminalContext = Effect.fnUntraced(function* (event: TerminalEvent) {
-    const explicitKey =
-      event.turnId === undefined ? null : turnKey(event.threadId, event.turnId);
+    const explicitKey = event.turnId === undefined ? null : turnKey(event.threadId, event.turnId);
     if (explicitKey) {
       const context = activeContextByTurnKey.get(explicitKey);
       if (context) return { context, activeKey: explicitKey };
@@ -213,9 +208,7 @@ const make = Effect.gen(function* () {
         upstreamRef: captured.upstreamRef,
       })
       .pipe(
-        Effect.map(
-          (pullRequest): ThreadPullRequestLookup => ({ status: "resolved", pullRequest }),
-        ),
+        Effect.map((pullRequest): ThreadPullRequestLookup => ({ status: "resolved", pullRequest })),
         Effect.catch((error) =>
           Effect.logDebug("thread git metadata PR lookup unavailable", {
             threadId: captured.threadId,

--- a/apps/server/src/orchestration/Layers/ThreadGitMetadataReactor.ts
+++ b/apps/server/src/orchestration/Layers/ThreadGitMetadataReactor.ts
@@ -1,0 +1,334 @@
+import {
+  CommandId,
+  type ProviderRuntimeEvent,
+  type ThreadId,
+} from "@synara/contracts";
+import { makeDrainableWorker, startDrainableWorkerProducers } from "@synara/shared/DrainableWorker";
+import { Cause, Effect, Layer, Option, Stream } from "effect";
+
+import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
+import { GitCore } from "../../git/Services/GitCore.ts";
+import { GitManager } from "../../git/Services/GitManager.ts";
+import { ProviderService } from "../../provider/Services/ProviderService.ts";
+import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
+import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
+import {
+  ThreadGitMetadataReactor,
+  type ThreadGitMetadataReactorShape,
+} from "../Services/ThreadGitMetadataReactor.ts";
+import {
+  deriveThreadGitMetadataPatch,
+  type ThreadPullRequestLookup,
+} from "../threadGitMetadata.ts";
+
+const THREAD_GIT_METADATA_REACTOR_CAPACITY = 128;
+
+type StartedEvent = Extract<ProviderRuntimeEvent, { type: "turn.started" }>;
+type TerminalEvent = Extract<
+  ProviderRuntimeEvent,
+  { type: "turn.completed" | "turn.aborted" | "session.exited" | "runtime.error" }
+>;
+
+interface ThreadWorkspaceContext {
+  readonly threadId: ThreadId;
+  readonly cwd: string;
+  readonly hasDedicatedWorktree: boolean;
+}
+
+interface CapturedThreadGitMetadata {
+  readonly token: symbol;
+  readonly threadId: ThreadId;
+  readonly cwd: string;
+  readonly expectedThreadBranch: string | null;
+  readonly observedBranch: string | null;
+  readonly upstreamRef: string | null;
+  readonly hasDedicatedWorktree: boolean;
+}
+
+const turnKey = (threadId: ThreadId, turnId: string) => `${threadId}\0${turnId}`;
+
+const serverCommandId = (): CommandId =>
+  CommandId.makeUnsafe(`server:thread-git-metadata:${crypto.randomUUID()}`);
+
+const make = Effect.gen(function* () {
+  const orchestrationEngine = yield* OrchestrationEngineService;
+  const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
+  const providerService = yield* ProviderService;
+  const gitCore = yield* GitCore;
+  const gitManager = yield* GitManager;
+
+  const activeContextByTurnKey = new Map<string, ThreadWorkspaceContext>();
+  const activeTurnKeysByCwd = new Map<string, Set<string>>();
+  const ambiguousSharedTurnKeys = new Set<string>();
+  const latestCaptureTokenByThread = new Map<ThreadId, symbol>();
+
+  const resolveWorkspaceContext = Effect.fnUntraced(function* (
+    threadId: ThreadId,
+  ): Effect.fn.Return<ThreadWorkspaceContext | null> {
+    const threadOption = yield* projectionSnapshotQuery.getThreadShellById(threadId);
+    const thread = Option.getOrUndefined(threadOption);
+    if (!thread) return null;
+
+    const projectOption = yield* projectionSnapshotQuery.getProjectShellById(thread.projectId);
+    const project = Option.getOrUndefined(projectOption);
+    if (!project) return null;
+
+    const cwd = resolveThreadWorkspaceCwd({ thread, projects: [project] });
+    if (!cwd) return null;
+
+    return {
+      threadId,
+      cwd,
+      hasDedicatedWorktree: thread.worktreePath !== null,
+    };
+  });
+
+  const addActiveContext = (key: string, context: ThreadWorkspaceContext) => {
+    activeContextByTurnKey.set(key, context);
+    const keys = activeTurnKeysByCwd.get(context.cwd) ?? new Set<string>();
+    if (!context.hasDedicatedWorktree) {
+      const otherKeys = [...keys].filter((candidate) => candidate !== key);
+      if (otherKeys.length > 0) {
+        ambiguousSharedTurnKeys.add(key);
+        for (const otherKey of otherKeys) ambiguousSharedTurnKeys.add(otherKey);
+      }
+    }
+    keys.add(key);
+    activeTurnKeysByCwd.set(context.cwd, keys);
+  };
+
+  const removeActiveContext = (key: string) => {
+    const context = activeContextByTurnKey.get(key);
+    activeContextByTurnKey.delete(key);
+    ambiguousSharedTurnKeys.delete(key);
+    if (!context) return;
+    const keys = activeTurnKeysByCwd.get(context.cwd);
+    keys?.delete(key);
+    if (keys?.size === 0) {
+      activeTurnKeysByCwd.delete(context.cwd);
+    }
+  };
+
+  const activeKeysForThread = (threadId: ThreadId): string[] =>
+    [...activeContextByTurnKey.entries()]
+      .filter(([, context]) => context.threadId === threadId)
+      .map(([key]) => key);
+
+  const trackTurnStart = Effect.fnUntraced(function* (event: StartedEvent) {
+    if (event.turnId === undefined) return;
+    const context = yield* resolveWorkspaceContext(event.threadId);
+    if (!context) return;
+    addActiveContext(turnKey(event.threadId, event.turnId), context);
+  });
+
+  const resolveTerminalContext = Effect.fnUntraced(function* (event: TerminalEvent) {
+    const explicitKey =
+      event.turnId === undefined ? null : turnKey(event.threadId, event.turnId);
+    if (explicitKey) {
+      const context = activeContextByTurnKey.get(explicitKey);
+      if (context) return { context, activeKey: explicitKey };
+    }
+
+    const threadKeys = activeKeysForThread(event.threadId);
+    if (threadKeys.length === 1) {
+      const activeKey = threadKeys[0]!;
+      const context = activeContextByTurnKey.get(activeKey);
+      if (context) return { context, activeKey };
+    }
+
+    const context = yield* resolveWorkspaceContext(event.threadId);
+    return context?.hasDedicatedWorktree ? { context, activeKey: null } : null;
+  });
+
+  const captureTerminalMetadata = Effect.fnUntraced(function* (event: TerminalEvent) {
+    const resolved = yield* resolveTerminalContext(event);
+    if (!resolved) {
+      if (event.type === "session.exited" || event.type === "runtime.error") {
+        for (const key of activeKeysForThread(event.threadId)) removeActiveContext(key);
+      }
+      return;
+    }
+    const { context, activeKey } = resolved;
+
+    const cleanup = Effect.sync(() => {
+      if (activeKey) removeActiveContext(activeKey);
+      if (event.type === "session.exited" || event.type === "runtime.error") {
+        for (const key of activeKeysForThread(event.threadId)) removeActiveContext(key);
+      }
+    });
+
+    yield* Effect.gen(function* () {
+      const currentContext = yield* resolveWorkspaceContext(event.threadId);
+      if (
+        !currentContext ||
+        currentContext.cwd !== context.cwd ||
+        currentContext.hasDedicatedWorktree !== context.hasDedicatedWorktree
+      ) {
+        return;
+      }
+
+      if (!context.hasDedicatedWorktree) {
+        const owners = activeTurnKeysByCwd.get(context.cwd);
+        if (
+          !activeKey ||
+          ambiguousSharedTurnKeys.has(activeKey) ||
+          owners?.size !== 1 ||
+          !owners.has(activeKey)
+        ) {
+          return;
+        }
+      }
+
+      const threadOption = yield* projectionSnapshotQuery.getThreadShellById(event.threadId);
+      const thread = Option.getOrUndefined(threadOption);
+      if (!thread) return;
+
+      const details = yield* gitCore.readBranchContext(context.cwd);
+      if (!details.isRepo) return;
+
+      const token = Symbol(event.eventId);
+      latestCaptureTokenByThread.set(event.threadId, token);
+      yield* worker.enqueue({
+        token,
+        threadId: event.threadId,
+        cwd: context.cwd,
+        expectedThreadBranch: thread.branch,
+        observedBranch: details.branch,
+        upstreamRef: details.upstreamRef,
+        hasDedicatedWorktree: context.hasDedicatedWorktree,
+      });
+    }).pipe(Effect.ensuring(cleanup));
+  });
+
+  const lookupPullRequest = (
+    captured: CapturedThreadGitMetadata,
+  ): Effect.Effect<ThreadPullRequestLookup> => {
+    if (captured.observedBranch === null) {
+      return Effect.succeed({ status: "resolved", pullRequest: null });
+    }
+    return gitManager
+      .pullRequestForBranch({
+        cwd: captured.cwd,
+        branch: captured.observedBranch,
+        upstreamRef: captured.upstreamRef,
+      })
+      .pipe(
+        Effect.map(
+          (pullRequest): ThreadPullRequestLookup => ({ status: "resolved", pullRequest }),
+        ),
+        Effect.catch((error) =>
+          Effect.logDebug("thread git metadata PR lookup unavailable", {
+            threadId: captured.threadId,
+            branch: captured.observedBranch,
+            error: error.message,
+          }).pipe(Effect.as({ status: "unavailable" } as const)),
+        ),
+      );
+  };
+
+  const processCapturedMetadata = Effect.fnUntraced(function* (
+    captured: CapturedThreadGitMetadata,
+  ) {
+    if (latestCaptureTokenByThread.get(captured.threadId) !== captured.token) return;
+    const pullRequestLookup = yield* lookupPullRequest(captured);
+    if (latestCaptureTokenByThread.get(captured.threadId) !== captured.token) return;
+
+    const threadOption = yield* projectionSnapshotQuery.getThreadShellById(captured.threadId);
+    const thread = Option.getOrUndefined(threadOption);
+    if (!thread) return;
+    if (latestCaptureTokenByThread.get(captured.threadId) !== captured.token) return;
+    if (
+      thread.branch !== captured.expectedThreadBranch &&
+      thread.branch !== captured.observedBranch
+    ) {
+      return;
+    }
+
+    const patch = deriveThreadGitMetadataPatch({
+      currentBranch: thread.branch,
+      currentPullRequest: thread.lastKnownPr ?? null,
+      observedBranch: captured.observedBranch,
+      pullRequestLookup,
+      ...(captured.hasDedicatedWorktree
+        ? {
+            dedicatedWorktree: {
+              cwd: captured.cwd,
+              currentPath: thread.associatedWorktreePath ?? null,
+              currentBranch: thread.associatedWorktreeBranch ?? null,
+            },
+          }
+        : {}),
+    });
+    if (!patch) return;
+
+    yield* orchestrationEngine.dispatch({
+      type: "thread.meta.update",
+      commandId: serverCommandId(),
+      threadId: captured.threadId,
+      ...patch,
+    });
+  });
+
+  const processCapturedMetadataSafely = (captured: CapturedThreadGitMetadata) =>
+    processCapturedMetadata(captured).pipe(
+      Effect.catchCause((cause) => {
+        if (Cause.hasInterruptsOnly(cause)) return Effect.failCause(cause);
+        return Effect.logWarning("thread git metadata reconciliation failed", {
+          threadId: captured.threadId,
+          cause: Cause.pretty(cause),
+        });
+      }),
+      Effect.ensuring(
+        Effect.sync(() => {
+          if (latestCaptureTokenByThread.get(captured.threadId) === captured.token) {
+            latestCaptureTokenByThread.delete(captured.threadId);
+          }
+        }),
+      ),
+    );
+
+  const worker = yield* makeDrainableWorker(processCapturedMetadataSafely, {
+    capacity: THREAD_GIT_METADATA_REACTOR_CAPACITY,
+  });
+
+  const processProviderEvent = (event: ProviderRuntimeEvent) => {
+    if (event.type === "turn.started") return trackTurnStart(event);
+    if (
+      event.type === "turn.completed" ||
+      event.type === "turn.aborted" ||
+      event.type === "session.exited" ||
+      event.type === "runtime.error"
+    ) {
+      return captureTerminalMetadata(event);
+    }
+    return Effect.void;
+  };
+
+  const processProviderEventSafely = (event: ProviderRuntimeEvent) =>
+    processProviderEvent(event).pipe(
+      Effect.catchCause((cause) => {
+        if (Cause.hasInterruptsOnly(cause)) return Effect.failCause(cause);
+        return Effect.logWarning("thread git metadata reactor failed to observe provider event", {
+          eventType: event.type,
+          threadId: event.threadId,
+          cause: Cause.pretty(cause),
+        });
+      }),
+    );
+
+  const start: ThreadGitMetadataReactorShape["start"] = startDrainableWorkerProducers(
+    worker,
+    Effect.gen(function* () {
+      yield* Effect.forkScoped(
+        Stream.runForEach(providerService.streamEvents, processProviderEventSafely),
+      );
+    }),
+  );
+
+  return {
+    start,
+    drain: worker.drain,
+  } satisfies ThreadGitMetadataReactorShape;
+});
+
+export const ThreadGitMetadataReactorLive = Layer.effect(ThreadGitMetadataReactor, make);

--- a/apps/server/src/orchestration/Services/ThreadGitMetadataReactor.ts
+++ b/apps/server/src/orchestration/Services/ThreadGitMetadataReactor.ts
@@ -1,0 +1,15 @@
+import { ServiceMap } from "effect";
+import type { Effect, Scope } from "effect";
+
+export interface ThreadGitMetadataReactorShape {
+  /** Starts the provider-turn observer that persists branch and PR metadata. */
+  readonly start: Effect.Effect<void, never, Scope.Scope>;
+
+  /** Resolves when every captured turn boundary has been reconciled. */
+  readonly drain: Effect.Effect<void>;
+}
+
+export class ThreadGitMetadataReactor extends ServiceMap.Service<
+  ThreadGitMetadataReactor,
+  ThreadGitMetadataReactorShape
+>()("synara/orchestration/Services/ThreadGitMetadataReactor") {}

--- a/apps/server/src/orchestration/threadGitMetadata.test.ts
+++ b/apps/server/src/orchestration/threadGitMetadata.test.ts
@@ -1,0 +1,119 @@
+import type { OrchestrationThreadPullRequest } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+
+import { deriveThreadGitMetadataPatch } from "./threadGitMetadata.ts";
+
+const pullRequest: OrchestrationThreadPullRequest = {
+  number: 574,
+  title: "Cache provider usage",
+  url: "https://github.com/Emanuele-web04/synara/pull/574",
+  baseBranch: "main",
+  headBranch: "feat/provider-usage-snapshot-cache",
+  state: "open",
+  isDraft: false,
+  mergeability: "unknown",
+  additions: 10,
+  deletions: 2,
+  changedFiles: 3,
+};
+
+describe("deriveThreadGitMetadataPatch", () => {
+  it("adopts the observed branch and its pull request", () => {
+    expect(
+      deriveThreadGitMetadataPatch({
+        currentBranch: "synara/old-branch",
+        currentPullRequest: null,
+        observedBranch: "feat/provider-usage-snapshot-cache",
+        pullRequestLookup: { status: "resolved", pullRequest },
+      }),
+    ).toEqual({
+      branch: "feat/provider-usage-snapshot-cache",
+      lastKnownPr: pullRequest,
+    });
+  });
+
+  it("clears a previous PR when the current branch has no PR", () => {
+    expect(
+      deriveThreadGitMetadataPatch({
+        currentBranch: pullRequest.headBranch,
+        currentPullRequest: pullRequest,
+        observedBranch: pullRequest.headBranch,
+        pullRequestLookup: { status: "resolved", pullRequest: null },
+      }),
+    ).toEqual({ lastKnownPr: null });
+  });
+
+  it("preserves a durable PR when GitHub is unavailable on the unchanged branch", () => {
+    expect(
+      deriveThreadGitMetadataPatch({
+        currentBranch: pullRequest.headBranch,
+        currentPullRequest: pullRequest,
+        observedBranch: pullRequest.headBranch,
+        pullRequestLookup: { status: "unavailable" },
+      }),
+    ).toBeNull();
+  });
+
+  it("clears a stale PR when the branch changes while GitHub is unavailable", () => {
+    expect(
+      deriveThreadGitMetadataPatch({
+        currentBranch: pullRequest.headBranch,
+        currentPullRequest: pullRequest,
+        observedBranch: "feat/next-change",
+        pullRequestLookup: { status: "unavailable" },
+      }),
+    ).toEqual({ branch: "feat/next-change", lastKnownPr: null });
+  });
+
+  it("clears branch and PR for detached HEAD", () => {
+    expect(
+      deriveThreadGitMetadataPatch({
+        currentBranch: pullRequest.headBranch,
+        currentPullRequest: pullRequest,
+        observedBranch: null,
+        pullRequestLookup: { status: "resolved", pullRequest: null },
+      }),
+    ).toEqual({ branch: null, lastKnownPr: null });
+  });
+
+  it("does not regress a semantic branch to a temporary worktree branch", () => {
+    expect(
+      deriveThreadGitMetadataPatch({
+        currentBranch: pullRequest.headBranch,
+        currentPullRequest: pullRequest,
+        observedBranch: "synara/deadbeef",
+        pullRequestLookup: { status: "resolved", pullRequest: null },
+      }),
+    ).toBeNull();
+  });
+
+  it("does not emit an event when persisted metadata already matches", () => {
+    expect(
+      deriveThreadGitMetadataPatch({
+        currentBranch: pullRequest.headBranch,
+        currentPullRequest: pullRequest,
+        observedBranch: pullRequest.headBranch,
+        pullRequestLookup: { status: "resolved", pullRequest: { ...pullRequest } },
+      }),
+    ).toBeNull();
+  });
+
+  it("repairs stale associated worktree identity without changing matching branch metadata", () => {
+    expect(
+      deriveThreadGitMetadataPatch({
+        currentBranch: pullRequest.headBranch,
+        currentPullRequest: pullRequest,
+        observedBranch: pullRequest.headBranch,
+        pullRequestLookup: { status: "resolved", pullRequest },
+        dedicatedWorktree: {
+          cwd: "/repo/.worktrees/thread",
+          currentPath: "/repo/.worktrees/thread",
+          currentBranch: "synara/stale-branch",
+        },
+      }),
+    ).toEqual({
+      associatedWorktreeBranch: pullRequest.headBranch,
+      associatedWorktreeRef: pullRequest.headBranch,
+    });
+  });
+});

--- a/apps/server/src/orchestration/threadGitMetadata.ts
+++ b/apps/server/src/orchestration/threadGitMetadata.ts
@@ -1,0 +1,106 @@
+import type { OrchestrationThreadPullRequest } from "@synara/contracts";
+import { resolveThreadBranchRegressionGuard } from "@synara/shared/git";
+
+export type ThreadPullRequestLookup =
+  | {
+      readonly status: "resolved";
+      readonly pullRequest: OrchestrationThreadPullRequest | null;
+    }
+  | { readonly status: "unavailable" };
+
+export interface ThreadGitMetadataPatch {
+  readonly branch?: string | null;
+  readonly lastKnownPr?: OrchestrationThreadPullRequest | null;
+  readonly associatedWorktreePath?: string | null;
+  readonly associatedWorktreeBranch?: string | null;
+  readonly associatedWorktreeRef?: string | null;
+}
+
+function pullRequestsEqual(
+  left: OrchestrationThreadPullRequest | null,
+  right: OrchestrationThreadPullRequest | null,
+): boolean {
+  if (left === right) return true;
+  if (left === null || right === null) return false;
+  return (
+    left.number === right.number &&
+    left.title === right.title &&
+    left.url === right.url &&
+    left.baseBranch === right.baseBranch &&
+    left.headBranch === right.headBranch &&
+    left.state === right.state &&
+    (left.isDraft ?? false) === (right.isDraft ?? false) &&
+    (left.mergeability ?? "unknown") === (right.mergeability ?? "unknown") &&
+    (left.additions ?? null) === (right.additions ?? null) &&
+    (left.deletions ?? null) === (right.deletions ?? null) &&
+    (left.changedFiles ?? null) === (right.changedFiles ?? null)
+  );
+}
+
+/**
+ * Derives the durable thread metadata observed at a provider-turn boundary.
+ *
+ * A successful lookup may intentionally clear a prior PR when the current branch has none.
+ * A transient lookup failure preserves a PR on an unchanged branch, but clears it when the
+ * branch itself changed so the sidebar never labels the new branch with the previous branch's PR.
+ */
+export function deriveThreadGitMetadataPatch(input: {
+  readonly currentBranch: string | null;
+  readonly currentPullRequest: OrchestrationThreadPullRequest | null;
+  readonly observedBranch: string | null;
+  readonly pullRequestLookup: ThreadPullRequestLookup;
+  readonly dedicatedWorktree?: {
+    readonly cwd: string;
+    readonly currentPath: string | null;
+    readonly currentBranch: string | null;
+  };
+}): ThreadGitMetadataPatch | null {
+  const guardedBranch = resolveThreadBranchRegressionGuard({
+    currentBranch: input.currentBranch,
+    nextBranch: input.observedBranch,
+  });
+  if (guardedBranch !== input.observedBranch) {
+    return null;
+  }
+
+  const branchChanged = input.currentBranch !== input.observedBranch;
+  let nextPullRequest = input.currentPullRequest;
+
+  if (input.observedBranch === null) {
+    nextPullRequest = null;
+  } else if (input.pullRequestLookup.status === "resolved") {
+    nextPullRequest = input.pullRequestLookup.pullRequest;
+  } else if (branchChanged) {
+    nextPullRequest = null;
+  }
+
+  const pullRequestChanged = !pullRequestsEqual(input.currentPullRequest, nextPullRequest);
+  const dedicatedWorktree = input.dedicatedWorktree;
+  const associatedPathChanged =
+    dedicatedWorktree !== undefined && dedicatedWorktree.currentPath !== dedicatedWorktree.cwd;
+  const associatedBranchChanged =
+    input.observedBranch !== null &&
+    dedicatedWorktree !== undefined &&
+    dedicatedWorktree.currentBranch !== input.observedBranch;
+  const associatedWorktreePatch =
+    dedicatedWorktree !== undefined && (associatedPathChanged || associatedBranchChanged)
+      ? {
+          ...(associatedPathChanged ? { associatedWorktreePath: dedicatedWorktree.cwd } : {}),
+          ...(associatedBranchChanged
+            ? {
+                associatedWorktreeBranch: input.observedBranch,
+                associatedWorktreeRef: input.observedBranch,
+              }
+            : {}),
+        }
+      : null;
+  if (!branchChanged && !pullRequestChanged && associatedWorktreePatch === null) {
+    return null;
+  }
+
+  return {
+    ...(branchChanged ? { branch: input.observedBranch } : {}),
+    ...(pullRequestChanged ? { lastKnownPr: nextPullRequest } : {}),
+    ...(associatedWorktreePatch ?? {}),
+  };
+}

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -13,6 +13,7 @@ import { CheckpointStoreLive } from "./checkpointing/Layers/CheckpointStore";
 import { CheckpointReactorLive } from "./orchestration/Layers/CheckpointReactor";
 import { OrchestrationReactorLive } from "./orchestration/Layers/OrchestrationReactor";
 import { StudioOutputReactorLive } from "./orchestration/Layers/StudioOutputReactor";
+import { ThreadGitMetadataReactorLive } from "./orchestration/Layers/ThreadGitMetadataReactor";
 import { ProviderCommandReactorLive } from "./orchestration/Layers/ProviderCommandReactor";
 import { ProviderRuntimeIngestionLive } from "./orchestration/Layers/ProviderRuntimeIngestion";
 import { RuntimeReceiptBusLive } from "./orchestration/Layers/RuntimeReceiptBus";
@@ -86,6 +87,10 @@ export function makeServerRuntimeServicesLayer(
   const studioOutputReactorLayer = StudioOutputReactorLive.pipe(
     Layer.provideMerge(runtimeServicesLayer),
   );
+  const threadGitMetadataReactorLayer = ThreadGitMetadataReactorLive.pipe(
+    Layer.provideMerge(runtimeServicesLayer),
+    Layer.provideMerge(GitLayerLive),
+  );
   const providerCommandReactorLayer = ProviderCommandReactorLive.pipe(
     Layer.provideMerge(runtimeServicesLayer),
     Layer.provideMerge(OrchestrationEventDeliveryRepositoryLive),
@@ -106,6 +111,7 @@ export function makeServerRuntimeServicesLayer(
     Layer.provideMerge(providerCommandReactorLayer),
     Layer.provideMerge(checkpointReactorLayer),
     Layer.provideMerge(studioOutputReactorLayer),
+    Layer.provideMerge(threadGitMetadataReactorLayer),
   );
   const threadDeletionReactorLayer = ThreadDeletionReactorLive.pipe(
     Layer.provideMerge(profileStatsArchiveLayer),
@@ -202,6 +208,7 @@ export function makeServerRuntimeServicesLayer(
     pullRequestServiceLayer,
     orchestrationReactorLayer,
     providerCommandReactorLayer,
+    threadGitMetadataReactorLayer,
     threadDeletionReactorLayer,
     devServerManagerLayer,
     GitLayerLive,

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -36,6 +36,8 @@ import {
   runExclusiveProjectAddition,
   runProjectProvisionWithCancellationRecovery,
   resolvePullRequestReviewBadge,
+  resolveSidebarThreadPullRequest,
+  resolveThreadDisplayBranch,
   resolveSidebarThreadListPaging,
   resolveProjectEmptyState,
   resolveSettingsBackTarget,
@@ -48,6 +50,7 @@ import {
   isUrgentThreadStatusPill,
   type ThreadStatusPill,
   shouldShowDebugFeatureFlagsMenu,
+  shouldUseLivePullRequestForSidebarThread,
   shouldPrunePinnedThreads,
   shouldClearThreadSelectionOnMouseDown,
   sortProjectsForSidebar,
@@ -119,6 +122,115 @@ describe("pullRequestRepositoryConfigFingerprint", () => {
     expect(
       pullRequestRepositoryConfigFingerprint([{ ...first, name: "Renamed" }, second]),
     ).not.toBe(baseline);
+  });
+});
+
+describe("shouldUseLivePullRequestForSidebarThread", () => {
+  it("trusts the checked-out branch for a dedicated worktree when persisted metadata is stale", () => {
+    expect(
+      shouldUseLivePullRequestForSidebarThread({
+        threadBranch: "synara/original-branch",
+        liveBranch: "feat/agent-created-branch",
+        hasDedicatedWorktree: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("still requires a branch match for a shared project root", () => {
+    expect(
+      shouldUseLivePullRequestForSidebarThread({
+        threadBranch: "feature/another-thread",
+        liveBranch: "feat/agent-created-branch",
+        hasDedicatedWorktree: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldUseLivePullRequestForSidebarThread({
+        threadBranch: "feat/agent-created-branch",
+        liveBranch: "feat/agent-created-branch",
+        hasDedicatedWorktree: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not use live PR data for a detached worktree", () => {
+    expect(
+      shouldUseLivePullRequestForSidebarThread({
+        threadBranch: "synara/original-branch",
+        liveBranch: null,
+        hasDedicatedWorktree: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveSidebarThreadPullRequest", () => {
+  it("keeps persisted PR metadata when the worktree is no longer available", () => {
+    const persisted = { number: 574, headBranch: "feat/provider-usage-snapshot-cache" };
+    expect(
+      resolveSidebarThreadPullRequest({
+        threadBranch: "feat/provider-usage-snapshot-cache",
+        liveBranch: null,
+        hasLiveStatus: false,
+        hasDedicatedWorktree: false,
+        livePullRequest: null,
+        persistedPullRequest: persisted,
+      }),
+    ).toBe(persisted);
+  });
+
+  it("prefers live metadata for the worktree's current branch", () => {
+    const live = { number: 575, headBranch: "feat/current-branch" };
+    expect(
+      resolveSidebarThreadPullRequest({
+        threadBranch: "synara/stale-branch",
+        liveBranch: "feat/current-branch",
+        hasLiveStatus: true,
+        hasDedicatedWorktree: true,
+        livePullRequest: live,
+        persistedPullRequest: { number: 574, headBranch: "synara/stale-branch" },
+      }),
+    ).toBe(live);
+  });
+
+  it("keeps persisted metadata during a transient lookup failure on the same branch", () => {
+    const persisted = { number: 574, headBranch: "feat/current-branch" };
+    expect(
+      resolveSidebarThreadPullRequest({
+        threadBranch: "feat/current-branch",
+        liveBranch: "feat/current-branch",
+        hasLiveStatus: true,
+        hasDedicatedWorktree: true,
+        livePullRequest: null,
+        persistedPullRequest: persisted,
+      }),
+    ).toBe(persisted);
+  });
+
+  it("does not attach a persisted PR from another branch to the current worktree branch", () => {
+    expect(
+      resolveSidebarThreadPullRequest({
+        threadBranch: "feat/previous-branch",
+        liveBranch: "feat/current-branch",
+        hasLiveStatus: true,
+        hasDedicatedWorktree: true,
+        livePullRequest: null,
+        persistedPullRequest: { number: 574, headBranch: "feat/previous-branch" },
+      }),
+    ).toBeNull();
+  });
+
+  it("hides a persisted PR when an active dedicated worktree is detached", () => {
+    expect(
+      resolveSidebarThreadPullRequest({
+        threadBranch: "feat/previous-branch",
+        liveBranch: null,
+        hasLiveStatus: true,
+        hasDedicatedWorktree: true,
+        livePullRequest: null,
+        persistedPullRequest: { number: 574, headBranch: "feat/previous-branch" },
+      }),
+    ).toBeNull();
   });
 });
 
@@ -249,6 +361,41 @@ describe("resolveThreadHoverCardMetadata", () => {
       branch: "main",
       worktreeName: null,
     });
+  });
+
+  it("shows the current branch instead of a stale associated worktree branch", () => {
+    const thread = makeSidebarThreadSummary({
+      envMode: "worktree",
+      branch: "feat/current-branch",
+      worktreePath: "/repo/.worktrees/thread",
+      associatedWorktreeBranch: "synara/stale-branch",
+    });
+
+    expect(resolveThreadDisplayBranch(thread)).toBe("feat/current-branch");
+    expect(
+      resolveThreadHoverCardMetadata({
+        thread,
+        project: {
+          kind: "project",
+          name: "synara",
+          folderName: "synara",
+          cwd: "/repo",
+        },
+      }).branch,
+    ).toBe("feat/current-branch");
+  });
+
+  it("does not label a detached active worktree with its historical branch", () => {
+    expect(
+      resolveThreadDisplayBranch(
+        makeSidebarThreadSummary({
+          envMode: "worktree",
+          branch: null,
+          worktreePath: "/repo/.worktrees/thread",
+          associatedWorktreeBranch: "feat/previous-branch",
+        }),
+      ),
+    ).toBeNull();
   });
 
   it("labels project-less chat containers as Synara instead of the slug folder", () => {

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -207,6 +207,20 @@ describe("resolveSidebarThreadPullRequest", () => {
     ).toBe(persisted);
   });
 
+  it("uses the live worktree branch to validate persisted metadata while thread branch metadata catches up", () => {
+    const persisted = { number: 574, headBranch: "feat/current-branch" };
+    expect(
+      resolveSidebarThreadPullRequest({
+        threadBranch: null,
+        liveBranch: "feat/current-branch",
+        hasLiveStatus: true,
+        hasDedicatedWorktree: true,
+        livePullRequest: null,
+        persistedPullRequest: persisted,
+      }),
+    ).toBe(persisted);
+  });
+
   it("does not attach a persisted PR from another branch to the current worktree branch", () => {
     expect(
       resolveSidebarThreadPullRequest({

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -221,6 +221,20 @@ describe("resolveSidebarThreadPullRequest", () => {
     ).toBe(persisted);
   });
 
+  it("uses the live worktree branch to validate persisted metadata when the thread branch is stale", () => {
+    const persisted = { number: 574, headBranch: "feat/current-branch" };
+    expect(
+      resolveSidebarThreadPullRequest({
+        threadBranch: "feat/previous-branch",
+        liveBranch: "feat/current-branch",
+        hasLiveStatus: true,
+        hasDedicatedWorktree: true,
+        livePullRequest: null,
+        persistedPullRequest: persisted,
+      }),
+    ).toBe(persisted);
+  });
+
   it("does not attach a persisted PR from another branch to the current worktree branch", () => {
     expect(
       resolveSidebarThreadPullRequest({

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -102,6 +102,55 @@ export function pullRequestRepositoryConfigFingerprint(
   );
 }
 
+/**
+ * Shared project roots can serve several threads, so their live Git status only belongs to a
+ * thread when the checked-out branch matches the persisted thread branch. A materialized
+ * worktree is thread-scoped, though, and coding agents may checkout or create a new branch
+ * without going through Synara's branch picker. In that case the worktree's checked-out branch
+ * is authoritative even when the persisted branch metadata is stale.
+ */
+export function shouldUseLivePullRequestForSidebarThread(input: {
+  readonly threadBranch: string | null;
+  readonly liveBranch: string | null;
+  readonly hasDedicatedWorktree: boolean;
+}): boolean {
+  if (input.liveBranch === null) {
+    return false;
+  }
+  if (input.hasDedicatedWorktree) {
+    return true;
+  }
+  return input.threadBranch !== null && input.threadBranch === input.liveBranch;
+}
+
+export function resolveSidebarThreadPullRequest<T extends { readonly headBranch: string }>(input: {
+  readonly threadBranch: string | null;
+  readonly liveBranch: string | null;
+  readonly hasLiveStatus: boolean;
+  readonly hasDedicatedWorktree: boolean;
+  readonly livePullRequest: T | null;
+  readonly persistedPullRequest: T | null;
+}): T | null {
+  const persistedPullRequest =
+    input.threadBranch !== null &&
+    input.persistedPullRequest?.headBranch === input.threadBranch
+      ? input.persistedPullRequest
+      : null;
+  if (!input.hasLiveStatus) {
+    return persistedPullRequest;
+  }
+  if (input.liveBranch === null && input.hasDedicatedWorktree) {
+    return null;
+  }
+  if (!shouldUseLivePullRequestForSidebarThread(input)) {
+    return persistedPullRequest;
+  }
+  if (input.livePullRequest !== null) {
+    return input.livePullRequest;
+  }
+  return persistedPullRequest?.headBranch === input.liveBranch ? persistedPullRequest : null;
+}
+
 type SidebarProject = {
   id: string;
   name: string;
@@ -162,6 +211,25 @@ export type SidebarThreadHoverMetadata = {
   worktreeName: string | null;
 };
 
+/** Prefer the branch captured from the active workspace. The associated worktree branch is a
+ * durable handoff/recovery identity and can legitimately lag after an agent checks out a branch. */
+export function resolveThreadDisplayBranch(
+  thread: Pick<
+    SidebarThreadSummary,
+    "envMode" | "branch" | "worktreePath" | "associatedWorktreeBranch"
+  >,
+): string | null {
+  const currentBranch = nonEmptyDisplayValue(thread.branch);
+  if (currentBranch !== null) return currentBranch;
+
+  const isActiveWorktree =
+    resolveThreadEnvironmentMode({
+      envMode: thread.envMode,
+      worktreePath: thread.worktreePath,
+    }) === "worktree";
+  return isActiveWorktree ? null : nonEmptyDisplayValue(thread.associatedWorktreeBranch);
+}
+
 export function resolveThreadHoverCardMetadata(input: {
   thread: Pick<
     SidebarThreadSummary,
@@ -185,9 +253,7 @@ export function resolveThreadHoverCardMetadata(input: {
     sourceProjectName: isWorktree
       ? differentDisplayValue(input.project?.folderName, projectName)
       : null,
-    branch:
-      nonEmptyDisplayValue(input.thread.associatedWorktreeBranch) ??
-      nonEmptyDisplayValue(input.thread.branch),
+    branch: resolveThreadDisplayBranch(input.thread),
     worktreeName: worktreePath ? formatWorktreePathForDisplay(worktreePath) : null,
   };
 }

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -132,8 +132,7 @@ export function resolveSidebarThreadPullRequest<T extends { readonly headBranch:
   readonly persistedPullRequest: T | null;
 }): T | null {
   const persistedPullRequest =
-    input.threadBranch !== null &&
-    input.persistedPullRequest?.headBranch === input.threadBranch
+    input.threadBranch !== null && input.persistedPullRequest?.headBranch === input.threadBranch
       ? input.persistedPullRequest
       : null;
   if (!input.hasLiveStatus) {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -131,9 +131,12 @@ export function resolveSidebarThreadPullRequest<T extends { readonly headBranch:
   readonly livePullRequest: T | null;
   readonly persistedPullRequest: T | null;
 }): T | null {
+  const persistedValidationBranch =
+    input.hasLiveStatus && input.hasDedicatedWorktree ? input.liveBranch : input.threadBranch;
   const persistedPullRequest =
     input.persistedPullRequest !== null &&
-    (input.threadBranch === null || input.persistedPullRequest.headBranch === input.threadBranch)
+    (persistedValidationBranch === null ||
+      input.persistedPullRequest.headBranch === persistedValidationBranch)
       ? input.persistedPullRequest
       : null;
   if (!input.hasLiveStatus) {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -132,7 +132,8 @@ export function resolveSidebarThreadPullRequest<T extends { readonly headBranch:
   readonly persistedPullRequest: T | null;
 }): T | null {
   const persistedPullRequest =
-    input.threadBranch !== null && input.persistedPullRequest?.headBranch === input.threadBranch
+    input.persistedPullRequest !== null &&
+    (input.threadBranch === null || input.persistedPullRequest.headBranch === input.threadBranch)
       ? input.persistedPullRequest
       : null;
   if (!input.hasLiveStatus) {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -4135,7 +4135,8 @@ export default function Sidebar() {
     for (let index = 0; index < threadGitStatusCwds.length; index += 1) {
       const cwd = threadGitStatusCwds[index];
       if (!cwd) continue;
-      const status = threadGitStatusQueries[index]?.data;
+      const statusQuery = threadGitStatusQueries[index];
+      const status = statusQuery?.isSuccess ? statusQuery.data : undefined;
       if (status) {
         statusByCwd.set(cwd, status);
       }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -305,6 +305,7 @@ import {
   runExclusiveProjectAddition,
   runProjectProvisionWithCancellationRecovery,
   resolvePullRequestReviewBadge,
+  resolveSidebarThreadPullRequest,
   resolveSidebarThreadListPaging,
   DEBUG_FEATURE_FLAGS_MENU_STORAGE_KEY,
   resolveProjectEmptyState,
@@ -4081,6 +4082,7 @@ export default function Sidebar() {
         threadId: thread.id,
         branch: thread.branch,
         lastKnownPr: thread.lastKnownPr ?? null,
+        hasDedicatedWorktree: thread.worktreePath !== null,
         cwd: resolveThreadWorkspaceCwd({
           projectCwd: projectCwdById.get(thread.projectId) ?? null,
           envMode: thread.envMode,
@@ -4093,7 +4095,7 @@ export default function Sidebar() {
     () => [
       ...new Set(
         threadGitTargets
-          .filter((target) => target.branch !== null)
+          .filter((target) => target.branch !== null || target.hasDedicatedWorktree)
           .map((target) => target.cwd)
           .filter((cwd): cwd is string => cwd !== null),
       ),
@@ -4156,10 +4158,20 @@ export default function Sidebar() {
     const map = new Map<ThreadId, ThreadPr>();
     for (const target of threadGitTargets) {
       const status = target.cwd ? statusByCwd.get(target.cwd) : undefined;
-      const branchMatches =
-        target.branch !== null && status?.branch !== null && status?.branch === target.branch;
-      const livePr = branchMatches ? (status?.pr ?? null) : null;
-      map.set(target.threadId, livePr ?? storedPrByThreadId.get(target.threadId) ?? null);
+      const persistedPr =
+        storedPrByThreadId.get(target.threadId) ??
+        (target.lastKnownPr ? toThreadPr(target.lastKnownPr) : null);
+      map.set(
+        target.threadId,
+        resolveSidebarThreadPullRequest({
+          threadBranch: target.branch,
+          liveBranch: status?.branch ?? null,
+          hasLiveStatus: status !== undefined,
+          hasDedicatedWorktree: target.hasDedicatedWorktree,
+          livePullRequest: status?.pr ?? null,
+          persistedPullRequest: persistedPr,
+        }),
+      );
     }
     return map;
   }, [

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -4135,8 +4135,9 @@ export default function Sidebar() {
     for (let index = 0; index < threadGitStatusCwds.length; index += 1) {
       const cwd = threadGitStatusCwds[index];
       if (!cwd) continue;
-      const statusQuery = threadGitStatusQueries[index];
-      const status = statusQuery?.isSuccess ? statusQuery.data : undefined;
+      // Keep the last successful snapshot during a failed background refetch. React Query
+      // retains that data, and it is still a better branch authority than stale thread metadata.
+      const status = threadGitStatusQueries[index]?.data;
       if (status) {
         statusByCwd.set(cwd, status);
       }

--- a/apps/web/src/components/SidebarActivityView.tsx
+++ b/apps/web/src/components/SidebarActivityView.tsx
@@ -43,6 +43,7 @@ import { PrStateChip } from "./pullRequest/PrStateChip";
 import {
   createSidebarThreadHoverAnchorId,
   resolveSidebarThreadListPaging,
+  resolveThreadDisplayBranch,
   resolveThreadProjectLabel,
   resolveThreadStatusTrailingIndicator,
   type ThreadStatusPill,
@@ -131,7 +132,7 @@ function ActivityThreadRow({
   renderHoverCard: (anchorId: string) => ReactNode;
 }) {
   const provider = thread.session?.provider ?? thread.modelSelection.provider;
-  const branch = thread.associatedWorktreeBranch?.trim() || thread.branch?.trim() || null;
+  const branch = resolveThreadDisplayBranch(thread);
   const isWorktree =
     resolveThreadEnvironmentMode({
       envMode: thread.envMode,


### PR DESCRIPTION
## Summary

- Treat a dedicated worktree's checked-out branch as authoritative for sidebar PR recognition, even when persisted thread metadata is stale.
- Persist the real branch, associated worktree identity, and linked PR at provider turn boundaries.
- Attribute shared local checkouts only to an exclusively owning provider turn; overlapping turns are deliberately skipped as ambiguous.
- Preserve durable PR metadata during transient GitHub failures, clear it after a confirmed branch/PR change, and never reuse a PR from another branch.
- Display the current thread branch ahead of historical worktree association metadata, including correct detached-HEAD behavior.

## Root cause

Thread `bc246baa-a2ee-4c4b-ac61-e3c766f750f1` persisted `synara/fix-instabilit-usage-provider` with no `last_known_pr_json`, while its dedicated worktree was actually on `feat/provider-usage-snapshot-cache`, the head of PR #574. The sidebar required the persisted branch to match live Git status before accepting the live PR, so it discarded the correct result.

The persisted branch could drift because provider-driven checkouts and PR creation were not reconciled back into thread metadata. Shared project roots also made a naive global Git-status sync unsafe because several threads can point to the same checkout.

## Implementation

- Add a lightweight Git branch-context read that avoids full diff/status and remote refresh work at every turn boundary.
- Add a captured-branch PR lookup that still works if the checkout moves before the background GitHub request completes and preserves the distinction between “no PR” and “GitHub unavailable”.
- Add a drainable orchestration reactor that:
  - tracks `turn.started` ownership;
  - captures branch/upstream state on completed, aborted, exited, or errored turns;
  - treats worktrees as thread-scoped;
  - requires exclusive ownership for shared local checkouts;
  - discards stale asynchronous results;
  - persists branch, PR, and worktree association through `thread.meta.update`.
- Harden sidebar selection and branch presentation with pure, tested helpers.

## Verification

- Server focused/integration suite: 183 passed, 1 pre-existing skip.
- Web sidebar logic suite: 117 passed.
- `git diff --check` passed before commit.

Per repository instructions, `bun fmt`, `bun lint`, and `bun typecheck` were not run because they were not explicitly requested in this conversation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration reactor startup order and durable thread metadata with nuanced shared-checkout attribution; mistakes could mis-label threads or skip updates, but behavior is heavily unit/integration tested.
> 
> **Overview**
> Fixes sidebar threads showing the wrong branch or missing PRs when agents check out or create branches outside Synara’s branch picker, especially on dedicated worktrees.
> 
> **Server:** Adds `GitCore.readBranchContext` and `GitManager.pullRequestForBranch` for lightweight branch/PR resolution without full status work. A new **`ThreadGitMetadataReactor`** listens to provider turn lifecycle events, captures workspace branch state at turn boundaries, and dispatches `thread.meta.update` with branch, `lastKnownPr`, and worktree association. Shared project roots only update when a single thread exclusively owns the active turn; overlapping local turns are skipped. `deriveThreadGitMetadataPatch` handles GitHub outages (keep PR on same branch, clear on branch change) and blocks regressing to temporary `synara/*` worktree branches.
> 
> **Web:** Sidebar PR badges and branch labels use new helpers so dedicated worktrees trust live checkout over stale persisted metadata, while shared roots still require branch match; persisted PRs are not shown for the wrong branch or detached worktrees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f060d2ca515e7ff4be78db7af77083f072a38c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->