### PR TITLE
Scope orchestration replay and avoid duplicate runtime event persistence

### DIFF
--- a/apps/server/scripts/orchestration-thread-replay-benchmark.ts
+++ b/apps/server/scripts/orchestration-thread-replay-benchmark.ts
@@ -164,13 +164,9 @@ async function run(): Promise<void> {
           summary: {
             wallMs: summary(samples.map((sample) => sample.wallMs)),
             cpuTotalMs: summary(samples.map((sample) => sample.cpuTotalMs)),
-            maxObservedRssBytes: summary(
-              samples.map((sample) => sample.maxObservedRssBytes),
-            ),
+            maxObservedRssBytes: summary(samples.map((sample) => sample.maxObservedRssBytes)),
             rssGrowthBytes: summary(samples.map((sample) => sample.rssGrowthBytes)),
-            encodedResponseBytes: summary(
-              samples.map((sample) => sample.encodedResponseBytes),
-            ),
+            encodedResponseBytes: summary(samples.map((sample) => sample.encodedResponseBytes)),
             decodedEvents: summary(samples.map((sample) => sample.decodedEvents)),
           },
           samples,

--- a/apps/server/scripts/orchestration-thread-replay-benchmark.ts
+++ b/apps/server/scripts/orchestration-thread-replay-benchmark.ts
@@ -1,0 +1,187 @@
+import { performance } from "node:perf_hooks";
+
+import { EventId, ThreadId, type OrchestrationEvent } from "@synara/contracts";
+import { THREAD_DETAIL_EVENT_TYPES } from "@synara/shared/threadDetailEvents";
+import { Effect, Layer, ManagedRuntime, Stream } from "effect";
+
+import { OrchestrationEventStoreLive } from "../src/persistence/Layers/OrchestrationEventStore.ts";
+import { SqlitePersistenceMemory } from "../src/persistence/Layers/Sqlite.ts";
+import { OrchestrationEventStore } from "../src/persistence/Services/OrchestrationEventStore.ts";
+
+type BenchmarkMode = "global" | "scoped";
+
+interface Sample {
+  readonly wallMs: number;
+  readonly cpuTotalMs: number;
+  readonly maxObservedRssBytes: number;
+  readonly rssGrowthBytes: number;
+  readonly encodedResponseBytes: number;
+  readonly decodedEvents: number;
+}
+
+function argument(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  return process.argv.find((value) => value.startsWith(prefix))?.slice(prefix.length);
+}
+
+function positiveInteger(name: string, fallback: number): number {
+  const raw = argument(name);
+  if (raw === undefined) return fallback;
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`--${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function modeArgument(): BenchmarkMode {
+  const mode = argument("mode") ?? "scoped";
+  if (mode !== "global" && mode !== "scoped") {
+    throw new Error("--mode must be global or scoped");
+  }
+  return mode;
+}
+
+function forceGc(): void {
+  if (typeof Bun.gc === "function") Bun.gc(true);
+}
+
+function percentile(sorted: ReadonlyArray<number>, fraction: number): number {
+  return sorted[Math.max(0, Math.ceil(sorted.length * fraction) - 1)] ?? 0;
+}
+
+function summary(values: ReadonlyArray<number>) {
+  const sorted = [...values].sort((left, right) => left - right);
+  return {
+    mean: values.reduce((total, value) => total + value, 0) / Math.max(1, values.length),
+    p50: percentile(sorted, 0.5),
+    p95: percentile(sorted, 0.95),
+    min: sorted[0] ?? 0,
+    max: sorted.at(-1) ?? 0,
+  };
+}
+
+async function run(): Promise<void> {
+  const mode = modeArgument();
+  const eventCount = positiveInteger("events", 8_000);
+  const catchupEventCount = Math.min(positiveInteger("catchup-events", 400), eventCount);
+  const threadCount = positiveInteger("threads", 4);
+  const catchupBurstsPerSample = positiveInteger("bursts", 40);
+  const warmups = positiveInteger("warmups", 1);
+  const sampleCount = positiveInteger("samples", 7);
+  const runtime = ManagedRuntime.make(
+    OrchestrationEventStoreLive.pipe(Layer.provide(SqlitePersistenceMemory)),
+  );
+
+  try {
+    const eventStore = await runtime.runPromise(Effect.service(OrchestrationEventStore));
+    const collectEvents = (
+      stream: Stream.Stream<OrchestrationEvent, unknown>,
+    ): Promise<ReadonlyArray<OrchestrationEvent>> =>
+      runtime.runPromise(
+        Stream.runCollect(stream).pipe(Effect.map((events) => Array.from(events))),
+      );
+    const threadIds = Array.from({ length: threadCount }, (_, index) =>
+      ThreadId.makeUnsafe(`benchmark-thread-${index}`),
+    );
+    const occurredAt = "2026-08-07T00:00:00.000Z";
+    for (let index = 0; index < eventCount; index += 1) {
+      const threadId = threadIds[index % threadCount]!;
+      await runtime.runPromise(
+        eventStore.append({
+          type: "thread.unarchived",
+          eventId: EventId.makeUnsafe(`benchmark-thread-event-${index}`),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt,
+          commandId: null,
+          causationEventId: null,
+          correlationId: null,
+          metadata: {},
+          payload: { threadId, updatedAt: occurredAt },
+        }),
+      );
+    }
+
+    const fromSequenceExclusive = eventCount - catchupEventCount;
+    const runSample = async (): Promise<Sample> => {
+      forceGc();
+      const rssBeforeBytes = process.memoryUsage().rss;
+      let maxObservedRssBytes = rssBeforeBytes;
+      let encodedResponseBytes = 0;
+      let decodedEvents = 0;
+      const cpuBefore = process.cpuUsage();
+      const startedAt = performance.now();
+      for (let burst = 0; burst < catchupBurstsPerSample; burst += 1) {
+        for (const threadId of threadIds) {
+          const events = await collectEvents(
+            mode === "global"
+              ? eventStore.readFromSequence(fromSequenceExclusive)
+              : eventStore.readThreadEventsFromSequence(
+                  threadId,
+                  fromSequenceExclusive,
+                  undefined,
+                  undefined,
+                  THREAD_DETAIL_EVENT_TYPES,
+                ),
+          );
+          decodedEvents += events.length;
+          encodedResponseBytes += Buffer.byteLength(JSON.stringify(events));
+        }
+        maxObservedRssBytes = Math.max(maxObservedRssBytes, process.memoryUsage().rss);
+      }
+      const cpu = process.cpuUsage(cpuBefore);
+      return {
+        wallMs: performance.now() - startedAt,
+        cpuTotalMs: (cpu.user + cpu.system) / 1_000,
+        maxObservedRssBytes,
+        rssGrowthBytes: Math.max(0, maxObservedRssBytes - rssBeforeBytes),
+        encodedResponseBytes,
+        decodedEvents,
+      };
+    };
+
+    for (let index = 0; index < warmups; index += 1) await runSample();
+    const samples: Sample[] = [];
+    for (let index = 0; index < sampleCount; index += 1) samples.push(await runSample());
+
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          createdAt: new Date().toISOString(),
+          environment: { bun: Bun.version, platform: process.platform, arch: process.arch },
+          workload: {
+            mode,
+            eventCount,
+            catchupEventCount,
+            threadCount,
+            catchupBurstsPerSample,
+            warmups,
+            samples: sampleCount,
+            persistence: "SQLite in-memory with production migrations and event decoding",
+            responseWork: "JSON encode every visible thread response in repeated catch-up bursts",
+          },
+          summary: {
+            wallMs: summary(samples.map((sample) => sample.wallMs)),
+            cpuTotalMs: summary(samples.map((sample) => sample.cpuTotalMs)),
+            maxObservedRssBytes: summary(
+              samples.map((sample) => sample.maxObservedRssBytes),
+            ),
+            rssGrowthBytes: summary(samples.map((sample) => sample.rssGrowthBytes)),
+            encodedResponseBytes: summary(
+              samples.map((sample) => sample.encodedResponseBytes),
+            ),
+            decodedEvents: summary(samples.map((sample) => sample.decodedEvents)),
+          },
+          samples,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  } finally {
+    await runtime.dispose();
+  }
+}
+
+await run();

--- a/apps/server/scripts/provider-runtime-journal-benchmark.ts
+++ b/apps/server/scripts/provider-runtime-journal-benchmark.ts
@@ -1,0 +1,177 @@
+import { performance } from "node:perf_hooks";
+
+import { EventId, ThreadId, TurnId, type ProviderRuntimeEvent } from "@synara/contracts";
+import { Effect, Layer, ManagedRuntime } from "effect";
+
+import { ProviderRuntimeEventRepositoryLive } from "../src/persistence/Layers/ProviderRuntimeEvents.ts";
+import { SqlitePersistenceMemory } from "../src/persistence/Layers/Sqlite.ts";
+import { ProviderRuntimeEventRepository } from "../src/persistence/Services/ProviderRuntimeEvents.ts";
+
+type BenchmarkMode = "once" | "duplicate";
+
+interface Sample {
+  readonly wallMs: number;
+  readonly cpuUserMs: number;
+  readonly cpuSystemMs: number;
+  readonly cpuTotalMs: number;
+  readonly rssBeforeBytes: number;
+  readonly rssAfterBytes: number;
+  readonly maxObservedRssBytes: number;
+  readonly heapUsedBeforeBytes: number;
+  readonly heapUsedAfterBytes: number;
+}
+
+function argument(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  return process.argv.find((value) => value.startsWith(prefix))?.slice(prefix.length);
+}
+
+function positiveInteger(name: string, fallback: number): number {
+  const raw = argument(name);
+  if (raw === undefined) return fallback;
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`--${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function modeArgument(): BenchmarkMode {
+  const mode = argument("mode") ?? "once";
+  if (mode !== "once" && mode !== "duplicate") {
+    throw new Error("--mode must be once or duplicate");
+  }
+  return mode;
+}
+
+function forceGc(): void {
+  if (typeof Bun.gc === "function") Bun.gc(true);
+}
+
+function percentile(sorted: ReadonlyArray<number>, fraction: number): number {
+  return sorted[Math.max(0, Math.ceil(sorted.length * fraction) - 1)] ?? 0;
+}
+
+function summary(values: ReadonlyArray<number>) {
+  const sorted = [...values].sort((left, right) => left - right);
+  const mean = values.reduce((total, value) => total + value, 0) / Math.max(1, values.length);
+  return {
+    mean,
+    p50: percentile(sorted, 0.5),
+    p95: percentile(sorted, 0.95),
+    min: sorted[0] ?? 0,
+    max: sorted.at(-1) ?? 0,
+  };
+}
+
+function runtimeEvent(index: number, threadCount: number): ProviderRuntimeEvent {
+  const threadIndex = index % threadCount;
+  return {
+    type: "content.delta",
+    eventId: EventId.makeUnsafe(`benchmark-event-${index}`),
+    provider: "codex",
+    createdAt: "2026-08-07T00:00:00.000Z",
+    threadId: ThreadId.makeUnsafe(`benchmark-thread-${threadIndex}`),
+    turnId: TurnId.makeUnsafe(`benchmark-turn-${threadIndex}`),
+    payload: {
+      streamKind: "assistant_text",
+      delta: `provider-neutral streamed text ${index.toString().padStart(8, "0")}\n`,
+    },
+  };
+}
+
+async function runSample(input: {
+  readonly mode: BenchmarkMode;
+  readonly eventCount: number;
+  readonly threadCount: number;
+}): Promise<Sample> {
+  const runtime = ManagedRuntime.make(
+    ProviderRuntimeEventRepositoryLive.pipe(Layer.provide(SqlitePersistenceMemory)),
+  );
+  try {
+    const repository = await runtime.runPromise(Effect.service(ProviderRuntimeEventRepository));
+    forceGc();
+    const before = process.memoryUsage();
+    let maxObservedRssBytes = before.rss;
+    const cpuBefore = process.cpuUsage();
+    const startedAt = performance.now();
+
+    for (let index = 0; index < input.eventCount; index += 1) {
+      const event = runtimeEvent(index, input.threadCount);
+      await runtime.runPromise(repository.append(event));
+      if (input.mode === "duplicate") {
+        await runtime.runPromise(repository.append(event));
+      }
+      if ((index & 127) === 0) {
+        maxObservedRssBytes = Math.max(maxObservedRssBytes, process.memoryUsage().rss);
+      }
+    }
+
+    const wallMs = performance.now() - startedAt;
+    const cpu = process.cpuUsage(cpuBefore);
+    const after = process.memoryUsage();
+    maxObservedRssBytes = Math.max(maxObservedRssBytes, after.rss);
+    return {
+      wallMs,
+      cpuUserMs: cpu.user / 1_000,
+      cpuSystemMs: cpu.system / 1_000,
+      cpuTotalMs: (cpu.user + cpu.system) / 1_000,
+      rssBeforeBytes: before.rss,
+      rssAfterBytes: after.rss,
+      maxObservedRssBytes,
+      heapUsedBeforeBytes: before.heapUsed,
+      heapUsedAfterBytes: after.heapUsed,
+    };
+  } finally {
+    await runtime.dispose();
+  }
+}
+
+async function run(): Promise<void> {
+  const mode = modeArgument();
+  const eventCount = positiveInteger("events", 2_000);
+  const threadCount = positiveInteger("threads", 4);
+  const warmups = positiveInteger("warmups", 1);
+  const sampleCount = positiveInteger("samples", 5);
+
+  for (let index = 0; index < warmups; index += 1) {
+    await runSample({ mode, eventCount, threadCount });
+  }
+
+  const samples: Sample[] = [];
+  for (let index = 0; index < sampleCount; index += 1) {
+    samples.push(await runSample({ mode, eventCount, threadCount }));
+  }
+
+  const wall = summary(samples.map((sample) => sample.wallMs));
+  const cpu = summary(samples.map((sample) => sample.cpuTotalMs));
+  const maxRss = summary(samples.map((sample) => sample.maxObservedRssBytes));
+  const result = {
+    createdAt: new Date().toISOString(),
+    environment: {
+      bun: Bun.version,
+      platform: process.platform,
+      arch: process.arch,
+    },
+    workload: {
+      mode,
+      eventCount,
+      threadCount,
+      warmups,
+      samples: sampleCount,
+      payload: "provider-neutral assistant text delta",
+      persistence: "SQLite in-memory with production migrations and repository",
+    },
+    summary: {
+      wallMs: wall,
+      cpuTotalMs: cpu,
+      maxObservedRssBytes: maxRss,
+      eventsPerWallSecondAtP50: wall.p50 === 0 ? 0 : (eventCount * 1_000) / wall.p50,
+      eventsPerCpuSecondAtP50: cpu.p50 === 0 ? 0 : (eventCount * 1_000) / cpu.p50,
+    },
+    samples,
+  };
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+await run();

--- a/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
@@ -495,6 +495,24 @@ function makeHarnessLayer(
           .toSorted((left, right) => right.sequence - left.sequence)
           .slice(0, input.limit),
       ),
+    readThreadEventsFromSequence: (
+      threadId: string,
+      sequenceExclusive: number,
+      limit = 1_000,
+      throughSequenceInclusive = Number.MAX_SAFE_INTEGER,
+      eventTypes?: ReadonlyArray<string>,
+    ) =>
+      Stream.fromIterable(
+        (options.diagnosticEvents ?? [])
+          .filter(
+            (event) =>
+              event.aggregateId === threadId &&
+              event.sequence > sequenceExclusive &&
+              event.sequence <= throughSequenceInclusive &&
+              (eventTypes === undefined || eventTypes.includes(event.type)),
+          )
+          .slice(0, limit),
+      ),
     readFromSequence: () => Stream.empty,
     readAll: () => Stream.empty,
   });

--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -350,6 +350,8 @@ const orchestrationEngine = {
   }),
   readEvents: () => Stream.empty,
   readEventsThrough: () => Stream.empty,
+  readThreadEvents: () => Stream.empty,
+  readThreadEventsThrough: () => Stream.empty,
   getEventHighWaterSequence: Effect.succeed(0),
   subscribeDomainEvents: Effect.succeed(Stream.empty),
   getReadModel: () =>

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -56,7 +56,10 @@ const asMessageId = (value: string): MessageId => MessageId.makeUnsafe(value);
 
 const makeThreadEventReadMethods = (
   events: ReadonlyArray<OrchestrationEvent>,
-): Pick<OrchestrationEventStoreShape, "getThreadHighWaterSequence" | "readThreadEvents"> => ({
+): Pick<
+  OrchestrationEventStoreShape,
+  "getThreadHighWaterSequence" | "readThreadEvents" | "readThreadEventsFromSequence"
+> => ({
   getThreadHighWaterSequence: (threadId) =>
     Effect.succeed(
       events
@@ -76,6 +79,25 @@ const makeThreadEventReadMethods = (
         )
         .toSorted((left, right) => right.sequence - left.sequence)
         .slice(0, input.limit),
+    ),
+  readThreadEventsFromSequence: (
+    threadId,
+    sequenceExclusive,
+    limit = 1_000,
+    throughSequenceInclusive = Number.MAX_SAFE_INTEGER,
+    eventTypes,
+  ) =>
+    Stream.fromIterable(
+      events
+        .filter(
+          (event) =>
+            event.aggregateKind === "thread" &&
+            event.aggregateId === threadId &&
+            event.sequence > sequenceExclusive &&
+            event.sequence <= throughSequenceInclusive &&
+            (eventTypes === undefined || eventTypes.includes(event.type)),
+        )
+        .slice(0, limit),
     ),
 });
 const asTurnId = (value: string): TurnId => TurnId.makeUnsafe(value);

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -1097,6 +1097,31 @@ const makeOrchestrationEngine = Effect.gen(function* () {
       Number.MAX_SAFE_INTEGER,
       throughSequenceInclusive,
     );
+  const readThreadEvents: OrchestrationEngineShape["readThreadEvents"] = (
+    threadId,
+    fromSequenceExclusive,
+    eventTypes,
+  ) =>
+    eventStore.readThreadEventsFromSequence(
+      threadId,
+      fromSequenceExclusive,
+      undefined,
+      undefined,
+      eventTypes,
+    );
+  const readThreadEventsThrough: OrchestrationEngineShape["readThreadEventsThrough"] = (
+    threadId,
+    fromSequenceExclusive,
+    throughSequenceInclusive,
+    eventTypes,
+  ) =>
+    eventStore.readThreadEventsFromSequence(
+      threadId,
+      fromSequenceExclusive,
+      Number.MAX_SAFE_INTEGER,
+      throughSequenceInclusive,
+      eventTypes,
+    );
   const getEventHighWaterSequence = eventStore.getHighWaterSequence();
   const subscribeDomainEvents: OrchestrationEngineShape["subscribeDomainEvents"] = PubSub.subscribe(
     eventPubSub,
@@ -1338,6 +1363,8 @@ const makeOrchestrationEngine = Effect.gen(function* () {
     refreshCommandReadModel,
     readEvents,
     readEventsThrough,
+    readThreadEvents,
+    readThreadEventsThrough,
     getEventHighWaterSequence,
     subscribeDomainEvents,
     dispatch,

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -41,6 +41,7 @@ import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQu
 import {
   collectPersistedGeneratedImagePaths,
   ProviderRuntimeIngestionLive,
+  selectProviderRuntimeJournalStream,
 } from "./ProviderRuntimeIngestion.ts";
 import {
   OrchestrationEngineService,
@@ -181,6 +182,36 @@ type ProviderRuntimeTestActivity = ProviderRuntimeTestThread["activities"][numbe
 type ProviderRuntimeTestCheckpoint = ProviderRuntimeTestThread["checkpoints"][number];
 
 describe("ProviderRuntimeIngestion", () => {
+  it("uses an already-persisted runtime stream without appending the event again", async () => {
+    const event: ProviderRuntimeEvent = {
+      type: "runtime.warning",
+      eventId: asEventId("evt-already-persisted-stream"),
+      provider: "codex",
+      createdAt: "2026-08-07T00:00:00.000Z",
+      threadId: asThreadId("thread-1"),
+      payload: { message: "already durable" },
+    };
+    const persisted = { sequence: 42, event };
+    let appendCalls = 0;
+
+    const selected = await Effect.runPromise(
+      Stream.runCollect(
+        selectProviderRuntimeJournalStream({
+          streamEvents: Stream.succeed(event),
+          streamPersistedEvents: Stream.succeed(persisted),
+          append: (candidate) =>
+            Effect.sync(() => {
+              appendCalls += 1;
+              return { sequence: 43, event: candidate };
+            }),
+        }),
+      ).pipe(Effect.map((events) => Array.from(events))),
+    );
+
+    expect(selected).toEqual([persisted]);
+    expect(appendCalls).toBe(0);
+  });
+
   let runtime: ManagedRuntime.ManagedRuntime<
     OrchestrationEngineService | ProviderRuntimeIngestionService | ProviderRuntimeEventRepository,
     unknown

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -52,6 +52,7 @@ import { OrchestrationCommandReceiptRepository } from "../../persistence/Service
 import {
   PROVIDER_RUNTIME_INGESTION_CONSUMER,
   ProviderRuntimeEventRepository,
+  type PersistedProviderRuntimeEvent,
 } from "../../persistence/Services/ProviderRuntimeEvents.ts";
 import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
 import { isGitRepository } from "../../git/isRepo.ts";
@@ -544,6 +545,36 @@ const takeCached = <Key, Value>(cache: Cache.Cache<Key, Value>, key: Key) =>
   Cache.getOption(cache, key).pipe(
     Effect.flatMap((value) => Cache.invalidate(cache, key).pipe(Effect.as(value))),
   );
+
+export function selectProviderRuntimeJournalStream(input: {
+  readonly streamEvents: Stream.Stream<ProviderRuntimeEvent>;
+  readonly streamPersistedEvents?: Stream.Stream<PersistedProviderRuntimeEvent>;
+  readonly append: (
+    event: ProviderRuntimeEvent,
+  ) => Effect.Effect<PersistedProviderRuntimeEvent, unknown>;
+}) {
+  return (
+    input.streamPersistedEvents ??
+    input.streamEvents.pipe(
+      Stream.mapEffect((event) =>
+        input.append(event).pipe(
+          Effect.catchCause((cause) =>
+            Cause.hasInterruptsOnly(cause)
+              ? Effect.failCause(cause)
+              : Effect.logWarning("provider runtime event journal ingestion failed", {
+                  eventId: event.eventId,
+                  eventType: event.type,
+                  cause: Cause.pretty(cause),
+                }).pipe(Effect.as(undefined)),
+          ),
+        ),
+      ),
+      Stream.filter(
+        (persisted): persisted is NonNullable<typeof persisted> => persisted !== undefined,
+      ),
+    )
+  );
+}
 
 const make = Effect.gen(function* () {
   const orchestrationEngine = yield* OrchestrationEngineService;
@@ -2893,20 +2924,22 @@ const make = Effect.gen(function* () {
   const start: ProviderRuntimeIngestionShape["start"] = startDrainableWorkerProducers(
     worker,
     Effect.gen(function* () {
+      const streamPersistedEvents = providerService.streamPersistedEvents;
+      const persistedRuntimeEvents = selectProviderRuntimeJournalStream({
+        streamEvents: providerService.streamEvents,
+        ...(streamPersistedEvents === undefined ? {} : { streamPersistedEvents }),
+        append: (event) => runtimeEvents.append(event),
+      });
       yield* Effect.forkScoped(
-        Stream.runForEach(providerService.streamEvents, (event) =>
-          runtimeEvents.append(event).pipe(
-            Effect.flatMap((persisted) =>
-              Deferred.await(startupRuntimeReplayComplete).pipe(
-                Effect.andThen(drainRuntimeJournalThrough(persisted.sequence)),
-              ),
-            ),
+        Stream.runForEach(persistedRuntimeEvents, (persisted) =>
+          Deferred.await(startupRuntimeReplayComplete).pipe(
+            Effect.andThen(drainRuntimeJournalThrough(persisted.sequence)),
             Effect.catchCause((cause) =>
               Cause.hasInterruptsOnly(cause)
                 ? Effect.failCause(cause)
                 : Effect.logWarning("provider runtime event journal ingestion failed", {
-                    eventId: event.eventId,
-                    eventType: event.type,
+                    eventId: persisted.event.eventId,
+                    eventType: persisted.event.type,
                     cause: Cause.pretty(cause),
                   }),
             ),

--- a/apps/server/src/orchestration/Services/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Services/OrchestrationEngine.ts
@@ -68,6 +68,21 @@ export interface OrchestrationEngineShape {
     throughSequenceInclusive: number,
   ) => Stream.Stream<OrchestrationEvent, OrchestrationEventStoreError, never>;
 
+  /** Replay one thread's persisted events from an exclusive global cursor. */
+  readonly readThreadEvents: (
+    threadId: string,
+    fromSequenceExclusive: number,
+    eventTypes?: ReadonlyArray<string>,
+  ) => Stream.Stream<OrchestrationEvent, OrchestrationEventStoreError, never>;
+
+  /** Read one thread's inclusive high-water-fenced event range. */
+  readonly readThreadEventsThrough: (
+    threadId: string,
+    fromSequenceExclusive: number,
+    throughSequenceInclusive: number,
+    eventTypes?: ReadonlyArray<string>,
+  ) => Stream.Stream<OrchestrationEvent, OrchestrationEventStoreError, never>;
+
   /** Capture the durable orchestration event-log high-water sequence. */
   readonly getEventHighWaterSequence: Effect.Effect<number, OrchestrationEventStoreError>;
 

--- a/apps/server/src/persistence/Layers/OrchestrationEventStore.test.ts
+++ b/apps/server/src/persistence/Layers/OrchestrationEventStore.test.ts
@@ -100,13 +100,9 @@ layer("OrchestrationEventStore", (it) => {
         [sameThreadNonDetail.sequence, second.sequence],
       );
       const detailCatchup = yield* Stream.runCollect(
-        eventStore.readThreadEventsFromSequence(
-          threadId,
-          first.sequence,
-          1,
-          second.sequence,
-          ["thread.unarchived"],
-        ),
+        eventStore.readThreadEventsFromSequence(threadId, first.sequence, 1, second.sequence, [
+          "thread.unarchived",
+        ]),
       ).pipe(Effect.map((events) => Array.from(events)));
       assert.deepEqual(
         detailCatchup.map((event) => event.sequence),

--- a/apps/server/src/persistence/Layers/OrchestrationEventStore.test.ts
+++ b/apps/server/src/persistence/Layers/OrchestrationEventStore.test.ts
@@ -30,6 +30,34 @@ layer("OrchestrationEventStore", (it) => {
         metadata: {},
         payload: { threadId, archivedAt: now, updatedAt: now },
       });
+      yield* eventStore.append({
+        type: "thread.archived",
+        eventId: EventId.makeUnsafe("evt-thread-diagnostic-unrelated"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.makeUnsafe("thread-diagnostic-unrelated"),
+        occurredAt: now,
+        commandId: null,
+        causationEventId: null,
+        correlationId: null,
+        metadata: {},
+        payload: {
+          threadId: ThreadId.makeUnsafe("thread-diagnostic-unrelated"),
+          archivedAt: now,
+          updatedAt: now,
+        },
+      });
+      const sameThreadNonDetail = yield* eventStore.append({
+        type: "thread.deleted",
+        eventId: EventId.makeUnsafe("evt-thread-diagnostic-non-detail"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: now,
+        commandId: null,
+        causationEventId: null,
+        correlationId: null,
+        metadata: {},
+        payload: { threadId, deletedAt: now },
+      });
       const second = yield* eventStore.append({
         type: "thread.unarchived",
         eventId: EventId.makeUnsafe("evt-thread-diagnostic-second"),
@@ -63,6 +91,26 @@ layer("OrchestrationEventStore", (it) => {
       assert.deepEqual(
         older.map((event) => event.sequence),
         [first.sequence],
+      );
+      const catchup = yield* Stream.runCollect(
+        eventStore.readThreadEventsFromSequence(threadId, first.sequence, 10, second.sequence),
+      ).pipe(Effect.map((events) => Array.from(events)));
+      assert.deepEqual(
+        catchup.map((event) => event.sequence),
+        [sameThreadNonDetail.sequence, second.sequence],
+      );
+      const detailCatchup = yield* Stream.runCollect(
+        eventStore.readThreadEventsFromSequence(
+          threadId,
+          first.sequence,
+          1,
+          second.sequence,
+          ["thread.unarchived"],
+        ),
+      ).pipe(Effect.map((events) => Array.from(events)));
+      assert.deepEqual(
+        detailCatchup.map((event) => event.sequence),
+        [second.sequence],
       );
     }),
   );

--- a/apps/server/src/persistence/Layers/OrchestrationEventStore.ts
+++ b/apps/server/src/persistence/Layers/OrchestrationEventStore.ts
@@ -68,6 +68,13 @@ const ReadFromSequenceRequestSchema = Schema.Struct({
   throughSequenceInclusive: NonNegativeInt,
   limit: Schema.Number,
 });
+const ReadThreadFromSequenceRequestSchema = Schema.Struct({
+  threadId: Schema.String,
+  sequenceExclusive: NonNegativeInt,
+  throughSequenceInclusive: NonNegativeInt,
+  limit: Schema.Number,
+  eventTypes: Schema.Array(Schema.String),
+});
 const ReadThreadEventsRequestSchema = Schema.Struct({
   threadId: Schema.String,
   throughSequenceInclusive: NonNegativeInt,
@@ -411,6 +418,39 @@ const makeEventStore = Effect.gen(function* () {
       `,
   });
 
+  const readThreadEventRowsFromSequence = SqlSchema.findAll({
+    Request: ReadThreadFromSequenceRequestSchema,
+    Result: RawPersistedEventRowSchema,
+    execute: (request) => {
+      const typeFilter =
+        request.eventTypes.length === 0
+          ? sql``
+          : sql`AND event_type IN ${sql.in(request.eventTypes)}`;
+      return sql`
+        SELECT
+          sequence,
+          event_id AS "eventId",
+          event_type AS "type",
+          aggregate_kind AS "aggregateKind",
+          stream_id AS "aggregateId",
+          occurred_at AS "occurredAt",
+          command_id AS "commandId",
+          causation_event_id AS "causationEventId",
+          correlation_id AS "correlationId",
+          payload_json AS "payloadJson",
+          metadata_json AS "metadataJson"
+        FROM orchestration_events
+        WHERE aggregate_kind = 'thread'
+          AND stream_id = ${request.threadId}
+          AND sequence > ${request.sequenceExclusive}
+          AND sequence <= ${request.throughSequenceInclusive}
+          ${typeFilter}
+        ORDER BY sequence ASC
+        LIMIT ${request.limit}
+      `;
+    },
+  });
+
   const readHighWaterSequenceRow = SqlSchema.findOne({
     Request: Schema.Void,
     Result: HighWaterSequenceRowSchema,
@@ -544,6 +584,61 @@ const makeEventStore = Effect.gen(function* () {
     return readPage(sequenceExclusive, normalizedLimit);
   };
 
+  const readThreadEventsFromSequence: OrchestrationEventStoreShape["readThreadEventsFromSequence"] =
+    (
+      threadId,
+      sequenceExclusive,
+      limit = DEFAULT_READ_FROM_SEQUENCE_LIMIT,
+      throughSequenceInclusive = Number.MAX_SAFE_INTEGER,
+      eventTypes = [],
+    ) => {
+      const normalizedLimit = Math.max(0, Math.floor(limit));
+      const normalizedThroughSequence = Math.max(0, Math.floor(throughSequenceInclusive));
+      if (normalizedLimit === 0 || normalizedThroughSequence <= sequenceExclusive) {
+        return Stream.empty;
+      }
+      const readPage = (
+        cursor: number,
+        remaining: number,
+      ): Stream.Stream<OrchestrationEvent, OrchestrationEventStoreError> =>
+        Stream.fromEffect(
+          readThreadEventRowsFromSequence({
+            threadId,
+            sequenceExclusive: cursor,
+            throughSequenceInclusive: normalizedThroughSequence,
+            limit: Math.min(remaining, READ_PAGE_SIZE),
+            eventTypes: [...eventTypes],
+          }).pipe(
+            Effect.mapError(
+              toPersistenceSqlOrDecodeError(
+                "OrchestrationEventStore.readThreadEventsFromSequence:query",
+                "OrchestrationEventStore.readThreadEventsFromSequence:decodeRows",
+              ),
+            ),
+            Effect.flatMap((rows) =>
+              Effect.forEach(rows, (row) =>
+                decodePersistedEventRow(
+                  "OrchestrationEventStore.readThreadEventsFromSequence:rowToEvent",
+                  row,
+                ),
+              ),
+            ),
+          ),
+        ).pipe(
+          Stream.flatMap((events) => {
+            if (events.length === 0) return Stream.empty;
+            const nextRemaining = remaining - events.length;
+            if (nextRemaining <= 0) return Stream.fromIterable(events);
+            return Stream.concat(
+              Stream.fromIterable(events),
+              readPage(events[events.length - 1]!.sequence, nextRemaining),
+            );
+          }),
+        );
+
+      return readPage(sequenceExclusive, normalizedLimit);
+    };
+
   const getHighWaterSequence: OrchestrationEventStoreShape["getHighWaterSequence"] = () =>
     readHighWaterSequenceRow(undefined).pipe(
       Effect.mapError(
@@ -600,6 +695,7 @@ const makeEventStore = Effect.gen(function* () {
     getHighWaterSequence,
     getThreadHighWaterSequence,
     readThreadEvents,
+    readThreadEventsFromSequence,
     readFromSequence,
     readAll: () => readFromSequence(0, Number.MAX_SAFE_INTEGER),
   } satisfies OrchestrationEventStoreShape;

--- a/apps/server/src/persistence/Services/OrchestrationEventStore.ts
+++ b/apps/server/src/persistence/Services/OrchestrationEventStore.ts
@@ -48,6 +48,15 @@ export interface OrchestrationEventStoreShape {
     readonly eventTypes?: ReadonlyArray<string>;
   }) => Effect.Effect<ReadonlyArray<OrchestrationEvent>, OrchestrationEventStoreError>;
 
+  /** Replay one thread's events after an exclusive global sequence cursor. */
+  readonly readThreadEventsFromSequence: (
+    threadId: string,
+    sequenceExclusive: number,
+    limit?: number,
+    throughSequenceInclusive?: number,
+    eventTypes?: ReadonlyArray<string>,
+  ) => Stream.Stream<OrchestrationEvent, OrchestrationEventStoreError>;
+
   /**
    * Replay events after the provided sequence.
    *

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -4719,6 +4719,9 @@ persistedFanout.layer("ProviderServiceLive durable fanout", (it) => {
       yield* Fiber.interrupt(persistedEventFiber);
       assert.notEqual(canonicalEvent, undefined);
       assert.notEqual(persistedEvent, undefined);
+      if (canonicalEvent === undefined || persistedEvent === undefined) {
+        assert.fail("Expected both canonical and persisted runtime events");
+      }
       assert.equal(canonicalEvent.eventId, completedEvent.eventId);
       assert.equal(persistedEvent.event.eventId, completedEvent.eventId);
       assert.equal(persistedEvent.sequence > 0, true);

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -441,7 +441,7 @@ const rotationRetry = makeProviderServiceLayer({
       if (eventId === ROTATION_RETRY_FAILURE_EVENT_ID && attempts === 1) {
         return Effect.fail(new Error("injected transient runtime persistence failure"));
       }
-      return Effect.void;
+      return Effect.succeed({ sequence: attempts, event });
     }),
   runtimeEventRetryBaseDelayMs: 1,
   runtimeEventRetryMaxDelayMs: 1,
@@ -4664,6 +4664,64 @@ fanout.layer("ProviderServiceLive fanout", (it) => {
       const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
       const runtimePayload = asRuntimePayloadRecord(binding?.runtimePayload);
       assert.equal(runtimePayload.activeTurnId, null);
+    }),
+  );
+});
+
+let persistedFanoutSequence = 0;
+const persistedFanout = makeProviderServiceLayer({
+  persistRuntimeEvent: (event) =>
+    Effect.sync(() => ({
+      sequence: ++persistedFanoutSequence,
+      event,
+    })),
+});
+persistedFanout.layer("ProviderServiceLive durable fanout", (it) => {
+  it.effect("reuses the durable journal result without changing the canonical event stream", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const threadId = asThreadId("thread-persisted-fanout");
+      const session = yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      assert.notEqual(provider.streamPersistedEvents, undefined);
+
+      const canonicalEvents = yield* Ref.make<Array<ProviderRuntimeEvent>>([]);
+      const persistedEvents = yield* Ref.make<
+        Array<{ readonly sequence: number; readonly event: ProviderRuntimeEvent }>
+      >([]);
+      const canonicalEventFiber = yield* Stream.runForEach(provider.streamEvents, (event) =>
+        Ref.update(canonicalEvents, (current) => [...current, event]),
+      ).pipe(Effect.forkChild);
+      const persistedEventFiber = yield* Stream.runForEach(
+        provider.streamPersistedEvents!,
+        (event) => Ref.update(persistedEvents, (current) => [...current, event]),
+      ).pipe(Effect.forkChild);
+      yield* sleep(50);
+
+      const completedEvent: LegacyProviderRuntimeEvent = {
+        type: "turn.completed",
+        eventId: asEventId("evt-persisted-fanout"),
+        provider: "codex",
+        createdAt: new Date().toISOString(),
+        threadId: session.threadId,
+        turnId: asTurnId("turn-persisted-fanout"),
+        status: "completed",
+      };
+      persistedFanout.codex.emit(completedEvent);
+      yield* sleep(100);
+
+      const canonicalEvent = (yield* Ref.get(canonicalEvents))[0];
+      const persistedEvent = (yield* Ref.get(persistedEvents))[0];
+      yield* Fiber.interrupt(canonicalEventFiber);
+      yield* Fiber.interrupt(persistedEventFiber);
+      assert.notEqual(canonicalEvent, undefined);
+      assert.notEqual(persistedEvent, undefined);
+      assert.equal(canonicalEvent.eventId, completedEvent.eventId);
+      assert.equal(persistedEvent.event.eventId, completedEvent.eventId);
+      assert.equal(persistedEvent.sequence > 0, true);
     }),
   );
 });

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -689,16 +689,20 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
 
     const persistCanonicalRuntimeEvent = (
       event: ProviderRuntimeEvent,
-    ): Effect.Effect<PersistedProviderRuntimeEvent | undefined, unknown> =>
-      Effect.uninterruptible(
-        (options?.persistRuntimeEvent
+    ): Effect.Effect<PersistedProviderRuntimeEvent | undefined, unknown> => {
+      const persistence: Effect.Effect<PersistedProviderRuntimeEvent | undefined, unknown> =
+        options?.persistRuntimeEvent
           ? options.persistRuntimeEvent(event)
-          : Effect.succeed(undefined)).pipe(
+          : Effect.succeed(undefined);
+
+      return Effect.uninterruptible(
+        persistence.pipe(
           Effect.tap(() =>
             canonicalEventLogger ? canonicalEventLogger.write(event, null) : Effect.void,
           ),
         ),
       );
+    };
 
     const publishRuntimeEvent = (
       event: ProviderRuntimeEvent,

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -64,7 +64,10 @@ import {
 } from "../Services/ProviderSessionDirectory.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
 import { PersistenceDecodeError } from "../../persistence/Errors.ts";
-import { ProviderRuntimeEventRepository } from "../../persistence/Services/ProviderRuntimeEvents.ts";
+import {
+  ProviderRuntimeEventRepository,
+  type PersistedProviderRuntimeEvent,
+} from "../../persistence/Services/ProviderRuntimeEvents.ts";
 import {
   classifyTerminalTurnApplicability,
   isStartedTurnApplicable,
@@ -87,7 +90,9 @@ export interface ProviderServiceLiveOptions {
   /** Test/embedding override for the lossless runtime-event fan-out budget. */
   readonly runtimeEventBufferCapacity?: number;
   /** Production journal hook. The event must be durable before this effect returns. */
-  readonly persistRuntimeEvent?: (event: ProviderRuntimeEvent) => Effect.Effect<void, unknown>;
+  readonly persistRuntimeEvent?: (
+    event: ProviderRuntimeEvent,
+  ) => Effect.Effect<PersistedProviderRuntimeEvent, unknown>;
   /** Durable fallback for events that can never be accepted by the canonical journal. */
   readonly quarantineRuntimeEvent?: (
     event: ProviderRuntimeEvent,
@@ -398,7 +403,11 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
       1,
       Math.floor(options?.runtimeEventBufferCapacity ?? PROVIDER_RUNTIME_EVENT_BUFFER_CAPACITY),
     );
-    const runtimeEventPubSub = yield* PubSub.bounded<ProviderRuntimeEvent>(
+    type PublishedRuntimeEvent = {
+      readonly event: ProviderRuntimeEvent;
+      readonly persisted?: PersistedProviderRuntimeEvent;
+    };
+    const runtimeEventPubSub = yield* PubSub.bounded<PublishedRuntimeEvent>(
       runtimeEventBufferCapacity,
     );
     const runtimeEventProducerScope = yield* Scope.make("sequential");
@@ -680,18 +689,25 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
 
     const persistCanonicalRuntimeEvent = (
       event: ProviderRuntimeEvent,
-    ): Effect.Effect<void, unknown> =>
+    ): Effect.Effect<PersistedProviderRuntimeEvent | undefined, unknown> =>
       Effect.uninterruptible(
-        (options?.persistRuntimeEvent ? options.persistRuntimeEvent(event) : Effect.void).pipe(
-          Effect.andThen(
+        (options?.persistRuntimeEvent
+          ? options.persistRuntimeEvent(event)
+          : Effect.succeed(undefined)).pipe(
+          Effect.tap(() =>
             canonicalEventLogger ? canonicalEventLogger.write(event, null) : Effect.void,
           ),
-          Effect.asVoid,
         ),
       );
 
-    const publishRuntimeEvent = (event: ProviderRuntimeEvent): Effect.Effect<void> =>
-      PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
+    const publishRuntimeEvent = (
+      event: ProviderRuntimeEvent,
+      persisted: PersistedProviderRuntimeEvent | undefined,
+    ): Effect.Effect<void> =>
+      PubSub.publish(runtimeEventPubSub, {
+        event,
+        ...(persisted === undefined ? {} : { persisted }),
+      }).pipe(Effect.asVoid);
 
     const upsertSessionBinding = (
       session: ProviderSession,
@@ -1204,16 +1220,17 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           // fails, the supervised pump retries the same event while its source
           // generation is still current and no recovery waiter has been released.
           return persistCanonicalRuntimeEvent(canonicalEvent).pipe(
-            Effect.andThen(
+            Effect.flatMap((persisted) =>
               Effect.sync(() => {
                 if (canonicalEvent.type === "turn.started") {
                   reconcileRuntimeIdleTimer(canonicalEvent);
                 }
-              }),
+              }).pipe(
+                Effect.andThen(updateSessionBindingFromRuntimeEvent(canonicalEvent)),
+                Effect.andThen(publishRuntimeEvent(canonicalEvent, persisted)),
+                Effect.andThen(scheduleRetiredGatewaySessionRecovery(canonicalEvent)),
+              ),
             ),
-            Effect.andThen(updateSessionBindingFromRuntimeEvent(canonicalEvent)),
-            Effect.andThen(publishRuntimeEvent(canonicalEvent)),
-            Effect.andThen(scheduleRetiredGatewaySessionRecovery(canonicalEvent)),
           );
         }),
       );
@@ -2788,8 +2805,26 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
       // consumers (ProviderRuntimeIngestion, CheckpointReactor, etc.) each
       // independently receive all runtime events.
       get streamEvents(): ProviderServiceShape["streamEvents"] {
-        return Stream.fromPubSub(runtimeEventPubSub);
+        return Stream.fromPubSub(runtimeEventPubSub).pipe(Stream.map(({ event }) => event));
       },
+      ...(options?.persistRuntimeEvent === undefined
+        ? {}
+        : {
+            get streamPersistedEvents(): NonNullable<
+              ProviderServiceShape["streamPersistedEvents"]
+            > {
+              return Stream.fromPubSub(runtimeEventPubSub).pipe(
+                Stream.filter(
+                  (
+                    published,
+                  ): published is PublishedRuntimeEvent & {
+                    readonly persisted: PersistedProviderRuntimeEvent;
+                  } => published.persisted !== undefined,
+                ),
+                Stream.map(({ persisted }) => persisted),
+              );
+            },
+          }),
     } satisfies ProviderServiceShape;
   });
 
@@ -2807,7 +2842,7 @@ export function makeDurableProviderServiceLive(options?: ProviderServiceLiveOpti
       const runtimeEvents = yield* ProviderRuntimeEventRepository;
       return yield* makeProviderService({
         ...options,
-        persistRuntimeEvent: (event) => runtimeEvents.append(event).pipe(Effect.asVoid),
+        persistRuntimeEvent: (event) => runtimeEvents.append(event),
         quarantineRuntimeEvent: (event, cause) =>
           runtimeEvents
             .append({

--- a/apps/server/src/provider/Services/ProviderService.ts
+++ b/apps/server/src/provider/Services/ProviderService.ts
@@ -35,6 +35,7 @@ import { ServiceMap } from "effect";
 import type { Effect, Stream } from "effect";
 
 import type { ProviderServiceError } from "../Errors.ts";
+import type { PersistedProviderRuntimeEvent } from "../../persistence/Services/ProviderRuntimeEvents.ts";
 import type { ProviderAdapterCapabilities } from "./ProviderAdapter.ts";
 
 export type ProviderRuntimeEventPumpStatus = "starting" | "healthy" | "recovering" | "degraded";
@@ -218,6 +219,15 @@ export interface ProviderServiceShape {
    * Fan-out is owned by ProviderService (not by a standalone event-bus service).
    */
   readonly streamEvents: Stream.Stream<ProviderRuntimeEvent>;
+
+  /**
+   * Canonical runtime events paired with their already-durable journal sequence.
+   *
+   * Durable production services expose this stream so the ingestion worker can
+   * drain through the accepted row without appending the same event again.
+   * Lightweight/test services may omit it and retain the append-on-ingest path.
+   */
+  readonly streamPersistedEvents?: Stream.Stream<PersistedProviderRuntimeEvent>;
 }
 
 /**

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -48,6 +48,10 @@ import { resolveThreadWorkspaceCwd } from "./checkpointing/Utils";
 import { ServerConfig, type ServerConfigShape } from "./config";
 import { realpathNearestExisting } from "./realpathNearestExisting";
 import { workspaceRootsEqual } from "@synara/shared/threadWorkspace";
+import {
+  isThreadDetailEventFor,
+  THREAD_DETAIL_EVENT_TYPES,
+} from "@synara/shared/threadDetailEvents";
 import { listStudioThreadOutputs } from "./studioOutputs";
 import {
   ensureStudioWorkspaceInstructionsFiles,
@@ -288,31 +292,6 @@ function isShellRelevantEvent(event: OrchestrationEvent): boolean {
     event.type === "project.deleted" ||
     event.type === "thread.deleted" ||
     (event.aggregateKind === "thread" && shouldPublishThreadShellForEvent(event))
-  );
-}
-
-function isThreadDetailEventFor(threadId: ThreadId, event: OrchestrationEvent): boolean {
-  return (
-    event.aggregateKind === "thread" &&
-    event.aggregateId === threadId &&
-    (event.type === "thread.message-sent" ||
-      event.type === "thread.proposed-plan-upserted" ||
-      event.type === "thread.activity-appended" ||
-      event.type === "thread.turn-diff-completed" ||
-      event.type === "thread.reverted" ||
-      event.type === "thread.conversation-rolled-back" ||
-      event.type === "thread.session-set" ||
-      event.type === "thread.meta-updated" ||
-      event.type === "thread.pinned-message-added" ||
-      event.type === "thread.pinned-message-removed" ||
-      event.type === "thread.pinned-message-done-set" ||
-      event.type === "thread.pinned-message-label-set" ||
-      event.type === "thread.marker-added" ||
-      event.type === "thread.marker-removed" ||
-      event.type === "thread.marker-done-set" ||
-      event.type === "thread.marker-label-set" ||
-      event.type === "thread.archived" ||
-      event.type === "thread.unarchived")
   );
 }
 
@@ -875,18 +854,24 @@ const makeWsRpcHandlersLayer = () =>
             checkpointDiffQuery.getFullThreadDiff(input),
             "Failed to load full thread diff",
           ),
-        [ORCHESTRATION_WS_METHODS.replayEvents]: (input) =>
-          rpcEffect(
-            Stream.runCollect(
-              orchestrationEngine.readEvents(
-                clamp(input.fromSequenceExclusive, {
-                  maximum: Number.MAX_SAFE_INTEGER,
-                  minimum: 0,
-                }),
-              ),
-            ).pipe(Effect.map((events) => Array.from(events))),
+        [ORCHESTRATION_WS_METHODS.replayEvents]: (input) => {
+          const fromSequenceExclusive = clamp(input.fromSequenceExclusive, {
+            maximum: Number.MAX_SAFE_INTEGER,
+            minimum: 0,
+          });
+          const replay =
+            input.threadId === undefined
+              ? orchestrationEngine.readEvents(fromSequenceExclusive)
+              : orchestrationEngine.readThreadEvents(
+                  input.threadId,
+                  fromSequenceExclusive,
+                  THREAD_DETAIL_EVENT_TYPES,
+                );
+          return rpcEffect(
+            Stream.runCollect(replay).pipe(Effect.map((events) => Array.from(events))),
             "Failed to replay orchestration events",
-          ),
+          );
+        },
         [ORCHESTRATION_WS_METHODS.listProviderDeliveryBlockers]: (input) =>
           rpcEffect(
             providerCommandReactor.listBlockingDeliveries({
@@ -996,7 +981,7 @@ const makeWsRpcHandlersLayer = () =>
                 Effect.map((stream) =>
                   bufferLiveUiStream(
                     stream.pipe(
-                      Stream.filter((event) => isThreadDetailEventFor(input.threadId, event)),
+                      Stream.filter((event) => isThreadDetailEventFor(event, input.threadId)),
                     ),
                     {
                       label: "orchestration.thread-detail",
@@ -1028,9 +1013,14 @@ const makeWsRpcHandlersLayer = () =>
               getHighWaterSequence: getOrchestrationHighWaterSequence,
               replay: (fromSequenceExclusive, throughSequenceInclusive) =>
                 orchestrationEngine
-                  .readEventsThrough(fromSequenceExclusive, throughSequenceInclusive)
+                  .readThreadEventsThrough(
+                    input.threadId,
+                    fromSequenceExclusive,
+                    throughSequenceInclusive,
+                    THREAD_DETAIL_EVENT_TYPES,
+                  )
                   .pipe(
-                    Stream.filter((event) => isThreadDetailEventFor(input.threadId, event)),
+                    Stream.filter((event) => isThreadDetailEventFor(event, input.threadId)),
                     Stream.mapError((cause) =>
                       toWsRpcError(cause, "Failed to replay thread events"),
                     ),

--- a/apps/web/src/components/chat/environment/environmentPullRequest.logic.ts
+++ b/apps/web/src/components/chat/environment/environmentPullRequest.logic.ts
@@ -115,8 +115,7 @@ export interface PullRequestCommentDisplay {
 
 const COMMENT_TITLE_MAX_LENGTH = 120;
 const COMMENT_SNIPPET_MAX_LENGTH = 160;
-const DESCRIPTION_METADATA_MARKER_PATTERN =
-  /<!--\s*DESCRIPTION\s+(?:START|END)\s*-->/gi;
+const DESCRIPTION_METADATA_MARKER_PATTERN = /<!--\s*DESCRIPTION\s+(?:START|END)\s*-->/gi;
 
 function truncate(text: string, maxLength: number): string {
   return text.length > maxLength ? `${text.slice(0, maxLength - 1).trimEnd()}…` : text;

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -10,6 +10,7 @@ import {
   type WsCompatibilityError,
 } from "@synara/contracts";
 import { defaultTerminalTitleForCliKind } from "@synara/shared/terminalThreads";
+import { isThreadDetailEventFor } from "@synara/shared/threadDetailEvents";
 import {
   Outlet,
   createRootRouteWithContext,
@@ -926,29 +927,7 @@ function shouldFlushDomainEventImmediately(
 }
 
 function isThreadDetailEventForThread(event: OrchestrationEvent, threadId: ThreadId): boolean {
-  if (event.aggregateKind !== "thread" || event.aggregateId !== threadId) {
-    return false;
-  }
-  return (
-    event.type === "thread.message-sent" ||
-    event.type === "thread.proposed-plan-upserted" ||
-    event.type === "thread.activity-appended" ||
-    event.type === "thread.turn-diff-completed" ||
-    event.type === "thread.reverted" ||
-    event.type === "thread.conversation-rolled-back" ||
-    event.type === "thread.session-set" ||
-    event.type === "thread.meta-updated" ||
-    event.type === "thread.pinned-message-added" ||
-    event.type === "thread.pinned-message-removed" ||
-    event.type === "thread.pinned-message-done-set" ||
-    event.type === "thread.pinned-message-label-set" ||
-    event.type === "thread.marker-added" ||
-    event.type === "thread.marker-removed" ||
-    event.type === "thread.marker-done-set" ||
-    event.type === "thread.marker-label-set" ||
-    event.type === "thread.archived" ||
-    event.type === "thread.unarchived"
-  );
+  return isThreadDetailEventFor(event, threadId);
 }
 
 // Both catch-up predicates also honor the composer's pending-dispatch signal:
@@ -1523,7 +1502,7 @@ function EventRouter() {
       // Promise chain keeps the run-always cleanup (finally) and lets a replay
       // rejection propagate to callers exactly as the try/finally did.
       await api.orchestration
-        .replayEvents(fromSequence)
+        .replayEvents(fromSequence, threadId)
         .then((replayedEvents) => {
           for (const event of replayedEvents
             .filter((candidate) => isThreadDetailEventForThread(candidate, threadId))

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -827,6 +827,19 @@ describe("wsNativeApi", () => {
     });
   });
 
+  it("scopes orchestration replay requests to the visible thread when provided", async () => {
+    requestMock.mockResolvedValue([]);
+    const { createWsNativeApi } = await import("./wsNativeApi");
+    const api = createWsNativeApi();
+
+    await api.orchestration.replayEvents(41, ThreadId.makeUnsafe("thread-1"));
+
+    expect(requestMock).toHaveBeenCalledWith(ORCHESTRATION_WS_METHODS.replayEvents, {
+      fromSequenceExclusive: 41,
+      threadId: "thread-1",
+    });
+  });
+
   it("forwards provider delivery inspection and reconciliation", async () => {
     requestMock.mockResolvedValue([]);
     const { createWsNativeApi } = await import("./wsNativeApi");

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -737,9 +737,10 @@ export function createWsNativeApi(): NativeApi {
       getTurnDiff: (input) => transport.request(ORCHESTRATION_WS_METHODS.getTurnDiff, input),
       getFullThreadDiff: (input) =>
         transport.request(ORCHESTRATION_WS_METHODS.getFullThreadDiff, input),
-      replayEvents: (fromSequenceExclusive) =>
+      replayEvents: (fromSequenceExclusive, threadId) =>
         transport.request(ORCHESTRATION_WS_METHODS.replayEvents, {
           fromSequenceExclusive,
+          ...(threadId === undefined ? {} : { threadId }),
         }),
       listProviderDeliveryBlockers: (input = {}) =>
         transport.request(ORCHESTRATION_WS_METHODS.listProviderDeliveryBlockers, input),

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -757,7 +757,10 @@ export interface NativeApi {
     getFullThreadDiff: (
       input: OrchestrationGetFullThreadDiffInput,
     ) => Promise<OrchestrationGetFullThreadDiffResult>;
-    replayEvents: (fromSequenceExclusive: number) => Promise<OrchestrationEvent[]>;
+    replayEvents: (
+      fromSequenceExclusive: number,
+      threadId?: ThreadId,
+    ) => Promise<OrchestrationEvent[]>;
     listProviderDeliveryBlockers: (
       input?: OrchestrationListProviderDeliveryBlockersInput,
     ) => Promise<OrchestrationListProviderDeliveryBlockersResult>;

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -2371,6 +2371,7 @@ export type OrchestrationGetFullThreadDiffResult = typeof OrchestrationGetFullTh
 
 export const OrchestrationReplayEventsInput = Schema.Struct({
   fromSequenceExclusive: NonNegativeInt,
+  threadId: Schema.optional(ThreadId),
 });
 export type OrchestrationReplayEventsInput = typeof OrchestrationReplayEventsInput.Type;
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -120,6 +120,10 @@
       "types": "./src/threadEnvironment.ts",
       "import": "./src/threadEnvironment.ts"
     },
+    "./threadDetailEvents": {
+      "types": "./src/threadDetailEvents.ts",
+      "import": "./src/threadDetailEvents.ts"
+    },
     "./threadSummary": {
       "types": "./src/threadSummary.ts",
       "import": "./src/threadSummary.ts"

--- a/packages/shared/src/threadDetailEvents.test.ts
+++ b/packages/shared/src/threadDetailEvents.test.ts
@@ -1,0 +1,25 @@
+import { ThreadId, type OrchestrationEvent } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+
+import { isThreadDetailEventFor, THREAD_DETAIL_EVENT_TYPES } from "./threadDetailEvents";
+
+describe("thread detail events", () => {
+  it("keeps replay filtering and routing on one event-type definition", () => {
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const detailEvent = {
+      aggregateKind: "thread",
+      aggregateId: threadId,
+      type: "thread.unarchived",
+    } as OrchestrationEvent;
+    const shellOnlyEvent = {
+      aggregateKind: "thread",
+      aggregateId: threadId,
+      type: "thread.deleted",
+    } as OrchestrationEvent;
+
+    expect(THREAD_DETAIL_EVENT_TYPES).toContain(detailEvent.type);
+    expect(isThreadDetailEventFor(detailEvent, threadId)).toBe(true);
+    expect(isThreadDetailEventFor(shellOnlyEvent, threadId)).toBe(false);
+    expect(isThreadDetailEventFor(detailEvent, ThreadId.makeUnsafe("thread-2"))).toBe(false);
+  });
+});

--- a/packages/shared/src/threadDetailEvents.ts
+++ b/packages/shared/src/threadDetailEvents.ts
@@ -21,14 +21,9 @@ export const THREAD_DETAIL_EVENT_TYPES = [
   "thread.unarchived",
 ] as const satisfies ReadonlyArray<OrchestrationEvent["type"]>;
 
-const THREAD_DETAIL_EVENT_TYPE_SET = new Set<OrchestrationEvent["type"]>(
-  THREAD_DETAIL_EVENT_TYPES,
-);
+const THREAD_DETAIL_EVENT_TYPE_SET = new Set<OrchestrationEvent["type"]>(THREAD_DETAIL_EVENT_TYPES);
 
-export function isThreadDetailEventFor(
-  event: OrchestrationEvent,
-  threadId: ThreadId,
-): boolean {
+export function isThreadDetailEventFor(event: OrchestrationEvent, threadId: ThreadId): boolean {
   return (
     event.aggregateKind === "thread" &&
     event.aggregateId === threadId &&

--- a/packages/shared/src/threadDetailEvents.ts
+++ b/packages/shared/src/threadDetailEvents.ts
@@ -1,0 +1,37 @@
+import type { OrchestrationEvent, ThreadId } from "@synara/contracts";
+
+export const THREAD_DETAIL_EVENT_TYPES = [
+  "thread.message-sent",
+  "thread.proposed-plan-upserted",
+  "thread.activity-appended",
+  "thread.turn-diff-completed",
+  "thread.reverted",
+  "thread.conversation-rolled-back",
+  "thread.session-set",
+  "thread.meta-updated",
+  "thread.pinned-message-added",
+  "thread.pinned-message-removed",
+  "thread.pinned-message-done-set",
+  "thread.pinned-message-label-set",
+  "thread.marker-added",
+  "thread.marker-removed",
+  "thread.marker-done-set",
+  "thread.marker-label-set",
+  "thread.archived",
+  "thread.unarchived",
+] as const satisfies ReadonlyArray<OrchestrationEvent["type"]>;
+
+const THREAD_DETAIL_EVENT_TYPE_SET = new Set<OrchestrationEvent["type"]>(
+  THREAD_DETAIL_EVENT_TYPES,
+);
+
+export function isThreadDetailEventFor(
+  event: OrchestrationEvent,
+  threadId: ThreadId,
+): boolean {
+  return (
+    event.aggregateKind === "thread" &&
+    event.aggregateId === threadId &&
+    THREAD_DETAIL_EVENT_TYPE_SET.has(event.type)
+  );
+}


### PR DESCRIPTION
## Summary
- Add thread-scoped, high-water-fenced orchestration event replay with event-type filtering
- Reuse provider runtime events that are already persisted to avoid duplicate journal entries
- Centralize thread-detail event selection and update WebSocket replay requests
- Add coverage for durable fan-out, replay filtering, and thread-scoped API requests

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration replay paths, WebSocket thread sync, and provider runtime persistence/ingestion coupling; incorrect scoping or double-append bugs could affect client state or journal integrity, though behavior is heavily tested.
> 
> **Overview**
> **Thread catch-up** no longer replays the full global orchestration log when a `threadId` is provided. The event store and engine gain **forward thread replay** (`readThreadEventsFromSequence` / `readThreadEvents` / `readThreadEventsThrough`) with optional **high-water fences** and **event-type filters**. WebSocket `replayEvents`, thread subscription catch-up, and the web client now pass `threadId` and use **`THREAD_DETAIL_EVENT_TYPES`** from `@synara/shared/threadDetailEvents` instead of duplicated inline predicates.
> 
> **Provider runtime ingestion** can consume **`streamPersistedEvents`** from `ProviderService` after the canonical pump has journaled each event, via **`selectProviderRuntimeJournalStream`**, so the ingestion worker drains by sequence **without appending the same row again**. Durable `ProviderService` publishes persisted payloads on the pub-sub alongside canonical events.
> 
> Adds **benchmark scripts** for thread replay vs global replay and provider runtime journal append modes, plus tests for store replay, durable fan-out, and scoped replay API calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbaa2b5edcf9231b75e98a80814e35e6697da904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->