### PR TITLE
[codex] Use async submission for Kilo turns

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -93,6 +93,7 @@ function createMockOpenCodeRuntime(options?: {
   const forkCalls: Array<{ sessionID: string }> = [];
   const permissionReplyCalls: Array<Record<string, unknown>> = [];
   const promptCalls: Array<Record<string, unknown>> = [];
+  const promptCallKinds: Array<"async" | "sync"> = [];
   const mcpAddCalls: Array<Record<string, unknown>> = [];
   let eventSubscribeCallCount = 0;
   const emptySubscription = {
@@ -125,6 +126,7 @@ function createMockOpenCodeRuntime(options?: {
       },
       promptAsync: async (promptInput: Record<string, unknown>) => {
         promptCalls.push(promptInput);
+        promptCallKinds.push("async");
         if (options?.promptAsync) {
           return options.promptAsync(promptInput);
         }
@@ -132,6 +134,7 @@ function createMockOpenCodeRuntime(options?: {
       },
       prompt: async (promptInput: Record<string, unknown>) => {
         promptCalls.push(promptInput);
+        promptCallKinds.push("sync");
         if (options?.prompt) {
           return options.prompt(promptInput);
         }
@@ -262,6 +265,7 @@ function createMockOpenCodeRuntime(options?: {
     forkCalls,
     permissionReplyCalls,
     promptCalls,
+    promptCallKinds,
     mcpAddCalls,
     get eventSubscribeCallCount() {
       return eventSubscribeCallCount;
@@ -1427,6 +1431,49 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
       headers: { Authorization: "Bearer gateway-token-1" },
     });
     expect(gateway.revoked).toEqual(["gateway-token-1"]);
+  });
+
+  it("submits Kilo turns through the asynchronous prompt endpoint", async () => {
+    const runtime = createMockOpenCodeRuntime({
+      prompt: async () => {
+        throw new Error("Kilo's blocking prompt endpoint must not be used");
+      },
+    });
+    const threadId = asThreadId("thread-kilo-async-prompt");
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* KiloAdapter;
+        yield* adapter.startSession({
+          provider: "kilo",
+          threadId,
+          runtimeMode: "full-access",
+          cwd: "/repo",
+        });
+        yield* adapter.sendTurn({
+          threadId,
+          input: "perform a long-running task",
+          attachments: [],
+          modelSelection: { provider: "kilo", model: "openai/gpt-5" },
+        });
+        yield* adapter.stopSession(threadId);
+      }).pipe(
+        Effect.provide(
+          makeKiloAdapterLive({ runtime: runtime.runtime }).pipe(
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), { prefix: "kilo-adapter-test-" }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
+      ),
+    );
+
+    expect(runtime.promptCallKinds).toEqual(["async"]);
+    expect(runtime.promptCalls[0]).toMatchObject({
+      sessionID: "opencode-session-1",
+      messageID: expect.stringMatching(/^msg_/),
+    });
   });
 
   it("keeps shared external Kilo servers identity-only and never installs a token", async () => {

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -2086,95 +2086,6 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         );
       });
 
-      const submitOpenCodePrompt = Effect.fn("submitOpenCodePrompt")(function* (
-        context: OpenCodeSessionContext,
-        input: {
-          readonly turnId: TurnId;
-          readonly promptInput: Parameters<OpencodeClient["session"]["prompt"]>[0];
-        },
-      ) {
-        const settled = yield* Deferred.make<ProviderAdapterRequestError | null, never>();
-
-        // Keep the documented prompt request off the command path; SSE streams live
-        // updates, and the final HTTP response lets us recover if events are missed.
-        yield* runOpenCodeSdk("session.prompt", () =>
-          context.client.session.prompt(input.promptInput),
-        ).pipe(
-          Effect.mapError(toAdapterRequestError),
-          Effect.tap(() =>
-            Effect.sync(() => markOpenCodeHarnessPolicyDelivered(context, input.turnId)),
-          ),
-          Effect.flatMap((response) =>
-            Effect.gen(function* () {
-              if (yield* Ref.get(context.stopped)) {
-                return null;
-              }
-              if (context.activeTurnId !== input.turnId) {
-                return null;
-              }
-              const assistantEntry =
-                response.data && response.data.info.role === "assistant"
-                  ? ({
-                      info: response.data.info,
-                      parts: response.data.parts,
-                    } satisfies OpenCodeMessageSnapshot)
-                  : null;
-              if (assistantEntry && isOpenCodeCompletedAssistantMessage(assistantEntry)) {
-                yield* recoverOpenCodeTurnFromAssistantMessage(context, {
-                  turnId: input.turnId,
-                  assistantEntry,
-                  raw: {
-                    source: "synara.opencode.prompt.response",
-                    message: assistantEntry,
-                  },
-                });
-              }
-              return null;
-            }),
-          ),
-          Effect.catch((requestError) =>
-            Effect.gen(function* () {
-              if (yield* Ref.get(context.stopped)) {
-                return requestError;
-              }
-              if (
-                context.activeTurnId !== input.turnId ||
-                context.activeTurnProviderActivitySerial > 0
-              ) {
-                return requestError;
-              }
-              yield* clearActiveTurnState(context);
-              updateProviderSession(
-                context,
-                {
-                  status: "ready",
-                  model: context.session.model,
-                  lastError: requestError.detail,
-                },
-                { clearActiveTurnId: true },
-              );
-              yield* emit(context, {
-                ...buildEventBase({ threadId: context.session.threadId, turnId: input.turnId }),
-                type: "turn.aborted",
-                payload: {
-                  reason: requestError.detail,
-                },
-              });
-              return requestError;
-            }),
-          ),
-          Effect.flatMap((result) => Deferred.succeed(settled, result)),
-          Effect.forkIn(context.sessionScope),
-        );
-
-        const quickResult = yield* Deferred.await(settled).pipe(
-          Effect.timeoutOption(promptSubmissionInlineWaitMs),
-        );
-        if (quickResult._tag === "Some" && quickResult.value) {
-          return yield* quickResult.value;
-        }
-      });
-
       const submitOpenCodePromptAsync = Effect.fn("submitOpenCodePromptAsync")(function* (
         context: OpenCodeSessionContext,
         input: {
@@ -4039,7 +3950,10 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
             providerActivitySerial,
             excludedMessageIds: recoveryBaselineMessageIds,
           });
-          yield* submitOpenCodePrompt(context, {
+          // Kilo's own editor client uses promptAsync so execution is owned by the
+          // server rather than by one long-lived HTTP request. Keep Synara's event
+          // and message-snapshot recovery as the authoritative completion paths.
+          yield* submitOpenCodePromptAsync(context, {
             turnId,
             promptInput: {
               sessionID: context.openCodeSessionId,
@@ -4047,7 +3961,6 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
               model: parsedModel,
               ...(context.activeAgent ? { agent: context.activeAgent } : {}),
               ...(context.activeVariant ? { variant: context.activeVariant } : {}),
-              noReply: false,
               parts: [
                 ...(providerText ? [{ type: "text" as const, text: providerText }] : []),
                 ...fileParts,


### PR DESCRIPTION
## Problem

Long-running Kilo turns could be marked idle before Synara received an assistant response. A follow-up such as “proceed” could then reach a Kilo session that had not reliably accepted or persisted the original prompt, leaving the model without the expected context.

## Root cause

Synara submitted Kilo turns through the blocking `session.prompt` endpoint and kept that HTTP request alive for the full agent run. Kilo's own VS Code client uses `session.promptAsync`, which transfers execution ownership to the Kilo server immediately and observes progress through events. Synara already has event-stream and message-snapshot recovery for final responses, so the blocking response was redundant and made long runs dependent on the lifetime and ordering of one request.

## Fix

Kilo now uses `session.promptAsync`, matching Kilo's editor integration. The existing prompt-acceptance watchdog and busy-session message snapshot polling remain in place, and Synara continues to generate a stable Kilo message ID for recovery and event correlation. The now-unused blocking prompt submission path has been removed.

## Validation

- `bun run --cwd apps/server test src/provider/Layers/OpenCodeAdapter.test.ts`
- 76 adapter tests passed.
- Added a regression test that records the SDK endpoint used for a Kilo turn and fails if the blocking endpoint is selected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Kilo turns are submitted and removes blocking-prompt recovery; misbehavior could affect long-running Kilo sessions, though scope is limited to the Kilo branch and async submission matches the provider’s intended integration.
> 
> **Overview**
> **Kilo turns now use `session.promptAsync` instead of blocking `session.prompt`**, aligning with Kilo’s editor client so the server owns execution rather than holding one HTTP request open for the full agent run.
> 
> Completion still relies on the existing SSE event stream and message-snapshot recovery (prompt-acceptance watchdog and busy-session polling are unchanged). Kilo submissions keep a stable `messageID` (`msg_*`) for correlation; `noReply` is no longer sent on that path.
> 
> The unused blocking **`submitOpenCodePrompt`** helper (inline wait, prompt HTTP response recovery, and related error handling) is removed. A regression test asserts Kilo never calls the sync `prompt` endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3644252c9799c875e1cd62eee51eba0bd339dff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->