### PR TITLE
[codex] Retry transient Kilo credential startup failures

### DIFF
--- a/apps/server/src/provider/opencodeRuntime.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.test.ts
@@ -12,6 +12,8 @@ import { describe, expect, it } from "vitest";
 import {
   buildOpenCodePermissionRules,
   buildOpenCodeServerProcessEnv,
+  KILO_CLI_SPEC,
+  KILO_CREDENTIAL_STARTUP_RETRY_DELAYS_MS,
   OpenCodeRuntime,
   OpenCodeRuntimeError,
   makeOpenCodeRuntimeLive,
@@ -311,6 +313,119 @@ describe("OpenCodeRuntime startup diagnostics", () => {
 });
 
 describe("OpenCodeRuntime local server pool", () => {
+  it("retries transient Kilo credential-store startup failures", async () => {
+    let spawnCount = 0;
+    let teardownCount = 0;
+    const spawnerLayer = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make(() => {
+        spawnCount += 1;
+        if (spawnCount < 3) {
+          return Effect.succeed(
+            mockOpenCodeServerHandle({
+              stdout: "",
+              stderr:
+                '\u001b[91mError: Unexpected error Failed query: update "credential" set "value" = ?\n',
+              pid: spawnCount,
+              exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(1)),
+            }),
+          );
+        }
+        return Effect.succeed(
+          mockOpenCodeServerHandle({
+            stdout: "kilo server listening on http://127.0.0.1:59002\n",
+            stderr: "",
+            pid: spawnCount,
+          }),
+        );
+      }),
+    );
+    const layer = Layer.merge(
+      makeOpenCodeRuntimeLive({
+        netService: {
+          canListenOnHost: () => Effect.succeed(true),
+          isPortAvailableOnLoopback: () => Effect.succeed(true),
+          reserveLoopbackPort: () => Effect.succeed(59_000),
+          findAvailablePort: () => Effect.succeed(59_000),
+        },
+        teardownProcessTree: async () => {
+          teardownCount += 1;
+          return { escalated: false, signalErrors: [] };
+        },
+      }).pipe(Layer.provide(spawnerLayer)),
+      TestClock.layer(),
+    );
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const runtime = yield* OpenCodeRuntime;
+          const serverScope = yield* Scope.make();
+          const connectionFiber = yield* runtime
+            .connectToOpenCodeServer({
+              binaryPath: "kilo",
+              cliSpec: KILO_CLI_SPEC,
+              poolIsolationKey: "synara-kilo-thread",
+            })
+            .pipe(Effect.provideService(Scope.Scope, serverScope), Effect.forkChild);
+
+          for (const delayMs of KILO_CREDENTIAL_STARTUP_RETRY_DELAYS_MS) {
+            yield* Effect.yieldNow;
+            yield* TestClock.adjust(Duration.millis(delayMs));
+          }
+
+          const connection = yield* Fiber.join(connectionFiber);
+          expect(connection.url).toBe("http://127.0.0.1:59002");
+          expect(spawnCount).toBe(3);
+          expect(teardownCount).toBe(2);
+
+          yield* Scope.close(serverScope, Exit.void);
+          expect(teardownCount).toBe(3);
+        }),
+      ).pipe(Effect.provide(layer)),
+    );
+  });
+
+  it("does not retry unrelated Kilo startup failures", async () => {
+    let spawnCount = 0;
+    const spawnerLayer = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make(() => {
+        spawnCount += 1;
+        return Effect.succeed(
+          mockOpenCodeServerHandle({
+            stdout: "",
+            stderr: "Error: invalid Kilo configuration\n",
+            exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(1)),
+          }),
+        );
+      }),
+    );
+    const layer = makeOpenCodeRuntimeLive({
+      netService: {
+        canListenOnHost: () => Effect.succeed(true),
+        isPortAvailableOnLoopback: () => Effect.succeed(true),
+        reserveLoopbackPort: () => Effect.succeed(59_000),
+        findAvailablePort: () => Effect.succeed(59_000),
+      },
+      teardownProcessTree: async () => ({ escalated: false, signalErrors: [] }),
+    }).pipe(Layer.provide(spawnerLayer));
+
+    const error = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const runtime = yield* OpenCodeRuntime;
+          return yield* runtime
+            .connectToOpenCodeServer({ binaryPath: "kilo", cliSpec: KILO_CLI_SPEC })
+            .pipe(Effect.flip);
+        }),
+      ).pipe(Effect.provide(layer)),
+    );
+
+    expect(spawnCount).toBe(1);
+    expect(error.detail).toContain("invalid Kilo configuration");
+  });
+
   it("keeps server scope closure pending until process-tree exit is proven", async () => {
     let proveExit: (() => void) | undefined;
     const exitProof = new Promise<void>((resolve) => {

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -50,6 +50,7 @@ import { isWindowsShellCommandMissingResult } from "../shell-command-detection.t
 const DEFAULT_OPENCODE_SERVER_TIMEOUT_MS = 20_000;
 const DEFAULT_HOSTNAME = "127.0.0.1";
 export const OPENCODE_LOCAL_SERVER_IDLE_TTL_MS = 5 * 60_000;
+export const KILO_CREDENTIAL_STARTUP_RETRY_DELAYS_MS = [500, 1_500] as const;
 const OPENCODE_STARTUP_OUTPUT_MAX_CHARS = 4_000;
 const REDACTED_STARTUP_SECRET = "[redacted]";
 const STARTUP_OUTPUT_AUTHORIZATION_PATTERN =
@@ -329,6 +330,25 @@ function pooledOpenCodeServerKey(input: {
       serverAuthUsername: cliSpec.serverAuthUsername,
     },
   });
+}
+
+function isRetryableKiloCredentialStartupFailure(
+  cliSpec: OpenCodeCompatibleCliSpec,
+  cause: unknown,
+): boolean {
+  if (cliSpec.dataDirectoryName !== KILO_CLI_SPEC.dataDirectoryName) {
+    return false;
+  }
+
+  const detail = openCodeRuntimeErrorDetail(cause).toLowerCase();
+  return (
+    detail.includes('failed query: update "credential" set') ||
+    detail.includes("failed query: update 'credential' set") ||
+    detail.includes("failed query: update `credential` set") ||
+    detail.includes("sqlite_busy") ||
+    detail.includes("database is busy") ||
+    detail.includes("database is locked")
+  );
 }
 
 export function parseOpenCodeModelSlug(
@@ -1217,24 +1237,50 @@ const makeOpenCodeRuntime = (options?: OpenCodeRuntimeLiveOptions) =>
           // Start lazily on first real use, then keep warm only while recent sessions need it.
           return yield* Effect.uninterruptibleMask((restore) =>
             Effect.gen(function* () {
-              const serverScope = yield* Scope.make();
-              const startedExit = yield* Effect.exit(
-                restore(
-                  startOpenCodeServerProcess(input).pipe(
-                    Effect.provideService(Scope.Scope, serverScope),
-                  ),
-                ),
-              );
+              const cliSpec = input.cliSpec ?? OPENCODE_CLI_SPEC;
+              let retryIndex = 0;
+              let started: { server: OpenCodeServerProcess; scope: Scope.Closeable } | undefined;
 
-              if (Exit.isFailure(startedExit)) {
+              while (!started) {
+                const serverScope = yield* Scope.make();
+                const startedExit = yield* Effect.exit(
+                  restore(
+                    startOpenCodeServerProcess(input).pipe(
+                      Effect.provideService(Scope.Scope, serverScope),
+                    ),
+                  ),
+                );
+
+                if (Exit.isSuccess(startedExit)) {
+                  started = { server: startedExit.value, scope: serverScope };
+                  break;
+                }
+
                 yield* Scope.close(serverScope, Exit.void).pipe(Effect.ignore);
-                return yield* Effect.failCause(startedExit.cause);
+                const retryDelayMs = KILO_CREDENTIAL_STARTUP_RETRY_DELAYS_MS[retryIndex];
+                const failure = Cause.squash(startedExit.cause);
+                if (
+                  retryDelayMs === undefined ||
+                  !isRetryableKiloCredentialStartupFailure(cliSpec, failure)
+                ) {
+                  return yield* Effect.failCause(startedExit.cause);
+                }
+
+                retryIndex += 1;
+                yield* Effect.logWarning(
+                  "Kilo credential reconciliation failed during startup; retrying",
+                  {
+                    attempt: retryIndex + 1,
+                    delayMs: retryDelayMs,
+                  },
+                );
+                yield* restore(Effect.sleep(retryDelayMs));
               }
 
               const pooledServer: PooledOpenCodeServer = {
                 key,
-                server: startedExit.value,
-                scope: serverScope,
+                server: started.server,
+                scope: started.scope,
                 closeOnRelease: input.poolIsolationKey !== undefined,
                 refCount: 1,
                 idleCloseFiber: null,


### PR DESCRIPTION
## Problem

On Windows, a managed Kilo server can exit before its ready message with an error such as `Failed query: update "credential" set`. Users then have to create the same thread several times until a later Kilo process starts successfully.

## Root cause

Synara gives managed threads isolated Kilo server processes because Kilo's MCP configuration is process scoped, but those processes still use Kilo's shared credential database. Kilo reconciles legacy credentials during server startup, so a transient SQLite or credential-update conflict can terminate a process before it begins listening. Synara previously treated that first process exit as a permanent session-start failure.

## Fix

Managed startup now recognizes only Kilo credential-update and SQLite busy/locked failure signatures. It closes the failed process scope, waits 500 ms and then 1.5 seconds, and makes at most two additional attempts. If the error is unrelated, or all three attempts fail, Synara returns the original detailed startup error unchanged. OpenCode startup behavior is unaffected.

## Validation

- `bun run --cwd apps/server test src/provider/opencodeRuntime.test.ts`
- 24 runtime tests passed.
- Added coverage for the exact ANSI-decorated `update "credential" set` failure followed by success on the third process.
- Added coverage proving unrelated Kilo configuration failures are not retried.
- The recovery test also verifies that every failed process scope is torn down before the next attempt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes managed process startup and pooling in a critical provider path; scope is limited to Kilo-specific error matching and bounded retries.
> 
> **Overview**
> **Managed Kilo server startup** no longer fails permanently on transient credential-store / SQLite contention during pool acquisition.
> 
> When a pooled Kilo process exits before the ready line with signatures such as `update "credential" set`, `sqlite_busy`, or database locked/busy, the runtime **closes that process scope**, waits **500 ms** then **1.5 s** (`KILO_CREDENTIAL_STARTUP_RETRY_DELAYS_MS`), and retries up to **two** more times (three spawns total). Unrelated Kilo errors and **OpenCode** startup are unchanged—no retries. Warnings are logged on each retry.
> 
> Tests cover success on the third spawn after ANSI-decorated credential-update failures (with teardown between attempts) and a single spawn when configuration is invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44d4ac003328d1c3f1ec779fd0ff4bec93e6afb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->