### PR TITLE
[codex] Fix image overlay browser layering

### DIFF
--- a/apps/web/src/components/BrowserPanel.tsx
+++ b/apps/web/src/components/BrowserPanel.tsx
@@ -46,7 +46,7 @@ import { CentralIcon } from "~/lib/central-icons";
 import { readNativeApi } from "~/nativeApi";
 import type { DockPaneRuntimeMode } from "~/lib/dockPaneActivation";
 import { readDesktopZoomFactor, subscribeDesktopZoomFactor } from "~/lib/desktopZoom";
-import { PANEL_RESIZE_OVERLAY_SYNC_EVENT } from "~/lib/panelResize";
+import { NATIVE_SURFACE_OCCLUSION_SYNC_EVENT } from "~/lib/nativeSurfaceOcclusion";
 import { serverLocalServersQueryOptions } from "~/lib/serverReactQuery";
 import { cn, isMacPlatform } from "~/lib/utils";
 
@@ -1170,7 +1170,7 @@ export function BrowserPanel({
     // measured rect and would otherwise strand the native view at the old scale.
     const unsubscribeZoom = subscribeDesktopZoomFactor(scheduleSyncBounds);
     window.addEventListener("resize", scheduleSyncBounds);
-    window.addEventListener(PANEL_RESIZE_OVERLAY_SYNC_EVENT, scheduleSyncBounds);
+    window.addEventListener(NATIVE_SURFACE_OCCLUSION_SYNC_EVENT, scheduleSyncBounds);
     document.addEventListener("transitionrun", handleTransitionBounds, true);
     document.addEventListener("transitionend", handleTransitionBounds, true);
     document.addEventListener("transitioncancel", handleTransitionBounds, true);
@@ -1180,7 +1180,7 @@ export function BrowserPanel({
       observer.disconnect();
       unsubscribeZoom();
       window.removeEventListener("resize", scheduleSyncBounds);
-      window.removeEventListener(PANEL_RESIZE_OVERLAY_SYNC_EVENT, scheduleSyncBounds);
+      window.removeEventListener(NATIVE_SURFACE_OCCLUSION_SYNC_EVENT, scheduleSyncBounds);
       document.removeEventListener("transitionrun", handleTransitionBounds, true);
       document.removeEventListener("transitionend", handleTransitionBounds, true);
       document.removeEventListener("transitioncancel", handleTransitionBounds, true);

--- a/apps/web/src/components/chat/ExpandedImageOverlay.browser.tsx
+++ b/apps/web/src/components/chat/ExpandedImageOverlay.browser.tsx
@@ -4,6 +4,7 @@ import { page } from "vitest/browser";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 
+import { NATIVE_SURFACE_OCCLUSION_SYNC_EVENT } from "~/lib/nativeSurfaceOcclusion";
 import { ExpandedImageOverlay } from "./ExpandedImageOverlay";
 
 describe("ExpandedImageOverlay", () => {
@@ -57,6 +58,38 @@ describe("ExpandedImageOverlay", () => {
       expect(onNavigate).toHaveBeenNthCalledWith(2, 1);
       expect(onClose).toHaveBeenCalledOnce();
     } finally {
+      await screen.unmount();
+    }
+  });
+
+  it("signals native surfaces when the overlay opens and closes", async () => {
+    const onOcclusionChange = vi.fn();
+    window.addEventListener(NATIVE_SURFACE_OCCLUSION_SYNC_EVENT, onOcclusionChange);
+    const screen = await render(
+      <ExpandedImageOverlay expandedImage={null} onClose={vi.fn()} onNavigate={vi.fn()} />,
+    );
+
+    try {
+      expect(onOcclusionChange).not.toHaveBeenCalled();
+
+      await screen.rerender(
+        <ExpandedImageOverlay
+          expandedImage={{
+            images: [{ src: "data:image/png;base64,preview", name: "Preview image" }],
+            index: 0,
+          }}
+          onClose={vi.fn()}
+          onNavigate={vi.fn()}
+        />,
+      );
+      expect(onOcclusionChange).toHaveBeenCalledTimes(1);
+
+      await screen.rerender(
+        <ExpandedImageOverlay expandedImage={null} onClose={vi.fn()} onNavigate={vi.fn()} />,
+      );
+      expect(onOcclusionChange).toHaveBeenCalledTimes(2);
+    } finally {
+      window.removeEventListener(NATIVE_SURFACE_OCCLUSION_SYNC_EVENT, onOcclusionChange);
       await screen.unmount();
     }
   });

--- a/apps/web/src/components/chat/ExpandedImageOverlay.tsx
+++ b/apps/web/src/components/chat/ExpandedImageOverlay.tsx
@@ -3,8 +3,11 @@
 // Layer: Chat and composer UI component
 // Exports: ExpandedImageOverlay
 
+import { useLayoutEffect } from "react";
+
 import { Button } from "~/components/ui/button";
 import { ChevronLeftIcon, ChevronRightIcon, XIcon } from "~/lib/icons";
+import { notifyNativeSurfaceOcclusionChange } from "~/lib/nativeSurfaceOcclusion";
 import type { ExpandedImagePreview } from "./ExpandedImagePreview";
 
 interface ExpandedImageOverlayProps {
@@ -19,6 +22,17 @@ export function ExpandedImageOverlay({
   onNavigate,
 }: ExpandedImageOverlayProps) {
   const expandedImageItem = expandedImage ? expandedImage.images[expandedImage.index] : null;
+  const open = expandedImageItem !== null;
+
+  useLayoutEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    notifyNativeSurfaceOcclusionChange();
+    return notifyNativeSurfaceOcclusionChange;
+  }, [open]);
+
   if (!expandedImage || !expandedImageItem) {
     return null;
   }

--- a/apps/web/src/lib/nativeSurfaceOcclusion.ts
+++ b/apps/web/src/lib/nativeSurfaceOcclusion.ts
@@ -1,0 +1,15 @@
+// FILE: nativeSurfaceOcclusion.ts
+// Purpose: Notify native Electron surfaces when a DOM overlay starts or stops obscuring them.
+// Layer: Web cross-surface coordination
+
+// Electron WebContentsViews render above the DOM regardless of CSS z-index. DOM overlays
+// broadcast this event so BrowserPanel can hide or restore its native surface after the
+// overlay has been committed.
+export const NATIVE_SURFACE_OCCLUSION_SYNC_EVENT = "synara:native-surface-occlusion-sync";
+
+export function notifyNativeSurfaceOcclusionChange(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.dispatchEvent(new Event(NATIVE_SURFACE_OCCLUSION_SYNC_EVENT));
+}

--- a/apps/web/src/lib/panelResize.ts
+++ b/apps/web/src/lib/panelResize.ts
@@ -1,13 +1,14 @@
 // FILE: panelResize.ts
 // Purpose: Pure DOM helpers for chat/split panel resizing — the drag overlay that
 //          keeps pointer events in the React layer over Electron <webview>s, the
-//          cross-surface "overlay changed" sync event, and the composer width
-//          feasibility probe. Extracted from the chat route so the route file holds
+//          cross-surface occlusion notification, and the composer width feasibility
+//          probe. Extracted from the chat route so the route file holds
 //          orchestration, not low-level DOM measurement.
 // Layer: Web panel layout utilities
 
 import { SINGLE_CHAT_PANE_SCOPE_ID } from "./chatPaneScope";
 import { findNearestMeasurableAncestor } from "./domLayout";
+import { notifyNativeSurfaceOcclusionChange } from "./nativeSurfaceOcclusion";
 
 // Minimum width (px) the composer's left controls cluster needs before it overflows.
 // Kept intentionally lean: this is only a soft buffer, since canComposerHandlePanelWidth
@@ -15,11 +16,6 @@ import { findNearestMeasurableAncestor } from "./domLayout";
 // lets the right dock and split panes resize across a much wider range before the probe
 // stops the drag, while the overflow checks still prevent the composer from clipping.
 const COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX = 160;
-
-// Broadcast when the resize overlay is added/removed so embedded surfaces (e.g.
-// BrowserPanel's native webview) can re-sync their bounds. Shared so the event
-// name has a single source of truth across the chat route and BrowserPanel.
-export const PANEL_RESIZE_OVERLAY_SYNC_EVENT = "synara:panel-resize-overlay-sync";
 
 // Probe whether the composer can render at `nextWidth` without overflowing its
 // viewport or violating its minimum control width. Applies the width, measures,
@@ -94,11 +90,11 @@ export function createPanelResizeOverlay(): HTMLDivElement {
   overlay.style.cursor = "col-resize";
   overlay.style.background = "transparent";
   document.body.append(overlay);
-  window.dispatchEvent(new Event(PANEL_RESIZE_OVERLAY_SYNC_EVENT));
+  notifyNativeSurfaceOcclusionChange();
   return overlay;
 }
 
 export function removePanelResizeOverlay(overlay: HTMLDivElement): void {
   overlay.remove();
-  window.dispatchEvent(new Event(PANEL_RESIZE_OVERLAY_SYNC_EVENT));
+  notifyNativeSurfaceOcclusionChange();
 }


### PR DESCRIPTION
## Summary

Fix the expanded image preview so it fully overlays Synara's in-app browser content instead of leaving the website painted above the dimmed preview.

## Problem

When the browser panel was open and a user expanded an image attached to or sent with a prompt, the React image overlay appeared but the Electron browser surface remained in front of it. This made the preview look partially broken and left browser content interactive-looking above a modal surface.

## Root cause

Electron browser surfaces render above the DOM independently of CSS z-index. Synara already detects obscuring dialogs and hides the browser surface, but that detection was only re-run for resize and transition signals. The expanded image viewer opens and closes without a transition, so the browser surface never received a bounds/visibility resync.

## Fix

- Add a shared native-surface occlusion event for DOM overlays.
- Emit the event when the expanded image overlay opens and closes.
- Make `BrowserPanel` resync its surface visibility when that event fires.
- Reuse the same event for the panel-resize overlay instead of keeping a resize-specific event contract.
- Add regression coverage for the image overlay's open/close notifications.

## Verification

- `bun run --cwd apps/web test:browser src/components/BrowserPanel.annotations.browser.tsx src/components/chat/ExpandedImageOverlay.browser.tsx`
  - 2 test files passed
  - 9 tests passed
- `git diff --check`

The repository's full `bun fmt`, `bun lint`, and `bun typecheck` checks were not run because project instructions require an explicit request for those heavyweight checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop UI layering coordination only; no auth, data, or API changes beyond event wiring and a targeted browser test.
> 
> **Overview**
> Fixes the expanded image preview appearing **under** the in-app Electron browser by triggering a native-surface visibility resync when overlays mount and unmount.
> 
> Introduces **`nativeSurfaceOcclusion.ts`** with `NATIVE_SURFACE_OCCLUSION_SYNC_EVENT` and `notifyNativeSurfaceOcclusionChange()`. **`ExpandedImageOverlay`** fires that notification on open (via `useLayoutEffect`) and again on close (effect cleanup). **`BrowserPanel`** listens for the shared event instead of the old resize-only signal so it re-runs bounds/occlusion logic when any overlay changes. **`panelResize`** create/remove overlay helpers now call the same notifier, replacing **`PANEL_RESIZE_OVERLAY_SYNC_EVENT`**. Adds a browser test that the image overlay emits the event on open and close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 608ce8d8c6a8bb55230914b00d9f921a7eb64b59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->