### PR TITLE
Repair malformed GFM table delimiter rows before rendering

### DIFF
--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -136,6 +136,33 @@ describe("ChatMarkdown", () => {
     expect(markup).not.toContain('class="katex"');
   });
 
+  it("renders a table whose delimiter row is missing cells", async () => {
+    // Models regularly emit a delimiter row with fewer cells than the header;
+    // GFM rejects the whole block on the mismatch and the table degrades into
+    // one run-on paragraph of pipes. The repair pass pads the delimiter row.
+    const markup = await renderMarkdown(
+      [
+        "Studio vs. normal mode:",
+        "",
+        "| | Normal mode | Studio |",
+        "|---|---|",
+        "| Purpose | Focused, interactive work | Long-running, agent-led work |",
+      ].join("\n"),
+    );
+
+    expect(markup).toContain("<table>");
+    expect(markup).toContain("<th>Studio</th>");
+    expect(markup).toContain("<td>Purpose</td>");
+    expect(markup).not.toContain("|---|");
+  });
+
+  it("keeps pipe-and-dash lines inside code fences out of table repair", async () => {
+    const markup = await renderMarkdown(["```", "| a | b |", "|---|", "```"].join("\n"));
+
+    expect(markup).not.toContain("<table>");
+    expect(markup).toContain("|---|");
+  });
+
   it("renders exact thread marker ranges without changing markdown structure", async () => {
     const marker: ThreadMarker = {
       id: ThreadMarkerId.makeUnsafe("marker-1"),

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -33,6 +33,7 @@ import { dedentCode, parseCodeFenceInfo, type CodeFenceInfo } from "../lib/codeF
 import { getFileIconName, pathLooksLikeKnownFile } from "../file-icons";
 import { CentralIcon } from "~/lib/central-icons";
 import { isLocalImageMarkdownSrc } from "../lib/localImageUrls";
+import { repairMarkdownTableDelimiters } from "../lib/markdownTableRepair";
 import { useTheme } from "../hooks/useTheme";
 import { useSmoothStreamedText } from "../hooks/useSmoothStreamedText";
 import { openWorkspaceFileReference, useWorkspaceFileOpener } from "../lib/workspaceFileOpener";
@@ -1039,8 +1040,13 @@ function ChatMarkdown({
   const smoothedText = useSmoothStreamedText(text, isStreaming);
   // The dollar rewrite exists to disambiguate math from currency; the user
   // variant has no math, so its text must stay byte-for-byte what was typed.
+  // Table repair runs first and can change text length, so the thread-marker
+  // plugin below must resolve offsets against the same repaired text.
   const normalizedText = useMemo(
-    () => (isUserVariant ? smoothedText : protectLiteralMarkdownDollars(smoothedText)),
+    () =>
+      isUserVariant
+        ? smoothedText
+        : protectLiteralMarkdownDollars(repairMarkdownTableDelimiters(smoothedText)),
     [isUserVariant, smoothedText],
   );
   // While streaming, let React deprioritize and coalesce the markdown re-parse so a
@@ -1049,9 +1055,15 @@ function ChatMarkdown({
   // completed messages render the exact current text immediately (no visual change).
   const deferredNormalizedText = useDeferredValue(normalizedText);
   const renderedText = isStreaming ? deferredNormalizedText : normalizedText;
+  // Marker offsets are applied against mdast positions, which come from the
+  // repaired text — validate them against the same string. A marker recorded
+  // after a repaired delimiter row fails its `selectedText` check and is
+  // dropped instead of highlighting a shifted range.
   const threadMarkerRemarkPlugin = useMemo(
     () =>
-      markers && markers.length > 0 ? createThreadMarkerRemarkPlugin({ text, markers }) : null,
+      markers && markers.length > 0
+        ? createThreadMarkerRemarkPlugin({ text: repairMarkdownTableDelimiters(text), markers })
+        : null,
     [markers, text],
   );
   const composerChipsRemarkPlugin = useMemo(

--- a/apps/web/src/lib/markdownTableRepair.test.ts
+++ b/apps/web/src/lib/markdownTableRepair.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { repairMarkdownTableDelimiters } from "./markdownTableRepair";
+
+describe("repairMarkdownTableDelimiters", () => {
+  it("pads a delimiter row that has fewer cells than the header", () => {
+    const source = [
+      "Studio vs. normal mode:",
+      "",
+      "| | Normal mode (regular tasks/chats) | Studio |",
+      "|---|---|",
+      "| Purpose | Focused, interactive work | Long-running, agent-led work |",
+    ].join("\n");
+
+    expect(repairMarkdownTableDelimiters(source)).toBe(
+      [
+        "Studio vs. normal mode:",
+        "",
+        "| | Normal mode (regular tasks/chats) | Studio |",
+        "| --- | --- | --- |",
+        "| Purpose | Focused, interactive work | Long-running, agent-led work |",
+      ].join("\n"),
+    );
+  });
+
+  it("drops delimiter cells beyond the header cell count", () => {
+    const source = ["| a | b |", "|:--|---|--:|", "| 1 | 2 |"].join("\n");
+
+    expect(repairMarkdownTableDelimiters(source)).toBe(
+      ["| a | b |", "| :-- | --- |", "| 1 | 2 |"].join("\n"),
+    );
+  });
+
+  it("keeps the kept cells' alignment markers when padding", () => {
+    const source = ["| a | b | c |", "|:--|--:|"].join("\n");
+
+    expect(repairMarkdownTableDelimiters(source)).toBe(
+      ["| a | b | c |", "| :-- | --: | --- |"].join("\n"),
+    );
+  });
+
+  it("returns the input string unchanged when every table is well-formed", () => {
+    const source = ["| a | b |", "| --- | --- |", "| 1 | 2 |"].join("\n");
+
+    expect(repairMarkdownTableDelimiters(source)).toBe(source);
+  });
+
+  it("ignores pipe-and-dash lines inside fenced code blocks", () => {
+    const source = ["```", "| a | b |", "|---|", "```"].join("\n");
+
+    expect(repairMarkdownTableDelimiters(source)).toBe(source);
+  });
+
+  it("repairs a table that follows a closed fence", () => {
+    const source = ["```ts", "const x = 1;", "```", "", "| a | b |", "|---|"].join("\n");
+
+    expect(repairMarkdownTableDelimiters(source)).toBe(
+      ["```ts", "const x = 1;", "```", "", "| a | b |", "| --- | --- |"].join("\n"),
+    );
+  });
+
+  it("ignores indented code blocks", () => {
+    const source = ["Example:", "", "    | a | b |", "    |---|"].join("\n");
+
+    expect(repairMarkdownTableDelimiters(source)).toBe(source);
+  });
+
+  it("ignores blockquoted headers", () => {
+    const source = ["> | a | b |", "|---|"].join("\n");
+
+    expect(repairMarkdownTableDelimiters(source)).toBe(source);
+  });
+
+  it("does not treat a dashed body row of an ongoing table as a delimiter", () => {
+    const source = ["| a | b |", "| --- | --- |", "| 1 | 2 |", "| --- |"].join("\n");
+
+    expect(repairMarkdownTableDelimiters(source)).toBe(source);
+  });
+
+  it("does not pair two delimiter-shaped rows as header and delimiter", () => {
+    const source = ["|---|---|", "|---|"].join("\n");
+
+    expect(repairMarkdownTableDelimiters(source)).toBe(source);
+  });
+
+  it("does not count escaped pipes as cell boundaries", () => {
+    const source = ["| a \\| b | c |", "|---|"].join("\n");
+
+    expect(repairMarkdownTableDelimiters(source)).toBe(
+      ["| a \\| b | c |", "| --- | --- |"].join("\n"),
+    );
+  });
+
+  it("leaves text without any table candidates untouched", () => {
+    const source = "plain prose - with a dash | and a pipe";
+
+    expect(repairMarkdownTableDelimiters(source)).toBe(source);
+  });
+});

--- a/apps/web/src/lib/markdownTableRepair.ts
+++ b/apps/web/src/lib/markdownTableRepair.ts
@@ -1,0 +1,154 @@
+// GFM rejects an entire table when the delimiter row's cell count differs from
+// the header row's, so the block falls back to a paragraph — and there soft line
+// breaks render as spaces, collapsing the table into one run-on wall of pipes.
+// Models emit this malformation regularly (e.g. a three-column header over a
+// `|---|---|` delimiter), so before rendering we repair the delimiter row to the
+// header's cell count: pad missing cells with `---`, drop extras. Only the
+// delimiter row is ever rewritten; header and body rows stay byte-for-byte.
+
+const DELIMITER_CELL_REGEX = /^:?-+:?$/;
+const CODE_FENCE_REGEX = /^ {0,3}(`{3,}|~{3,})(.*)$/;
+
+type FenceState = { readonly marker: string; readonly length: number };
+
+function matchCodeFence(line: string): (FenceState & { readonly info: string }) | null {
+  const match = CODE_FENCE_REGEX.exec(line);
+  if (!match) {
+    return null;
+  }
+  const delimiter = match[1] ?? "";
+  return {
+    marker: delimiter[0] ?? "`",
+    length: delimiter.length,
+    info: (match[2] ?? "").trim(),
+  };
+}
+
+function leadingIndentWidth(line: string): number {
+  let width = 0;
+  for (const char of line) {
+    if (char === " ") {
+      width += 1;
+    } else if (char === "\t") {
+      width += 4;
+    } else {
+      break;
+    }
+  }
+  return width;
+}
+
+// Splits a table row into cells the way GFM does: any unescaped pipe divides
+// cells (even inside inline code — GFM requires `\|` there too), and the
+// leading/trailing pipes do not delimit extra empty cells.
+function splitRowCells(line: string): string[] | null {
+  const trimmed = line.trim();
+  if (!trimmed.includes("|")) {
+    return null;
+  }
+  const cells: string[] = [];
+  let current = "";
+  for (let index = 0; index < trimmed.length; index += 1) {
+    const char = trimmed[index];
+    if (char === "\\" && trimmed[index + 1] === "|") {
+      current += "\\|";
+      index += 1;
+      continue;
+    }
+    if (char === "|") {
+      cells.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  cells.push(current);
+  if (trimmed.startsWith("|")) {
+    cells.shift();
+  }
+  if (cells.length > 1 && cells[cells.length - 1] === "") {
+    cells.pop();
+  }
+  return cells.length > 0 ? cells : null;
+}
+
+function parseDelimiterCells(line: string): string[] | null {
+  const cells = splitRowCells(line);
+  if (!cells) {
+    return null;
+  }
+  const trimmedCells = cells.map((cell) => cell.trim());
+  return trimmedCells.every((cell) => DELIMITER_CELL_REGEX.test(cell)) ? trimmedCells : null;
+}
+
+export function repairMarkdownTableDelimiters(value: string): string {
+  if (!value.includes("|") || !value.includes("-")) {
+    return value;
+  }
+
+  const lines = value.split("\n");
+  let repaired = false;
+  let fence: FenceState | null = null;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    const fenceMatch = matchCodeFence(line);
+    if (fence) {
+      // A closing fence uses the same marker, at least the opening length, and
+      // carries no info string.
+      if (
+        fenceMatch &&
+        fenceMatch.marker === fence.marker &&
+        fenceMatch.length >= fence.length &&
+        fenceMatch.info === ""
+      ) {
+        fence = null;
+      }
+      continue;
+    }
+    if (fenceMatch) {
+      fence = { marker: fenceMatch.marker, length: fenceMatch.length };
+      continue;
+    }
+
+    if (index === 0 || leadingIndentWidth(line) >= 4) {
+      continue;
+    }
+    const delimiterCells = parseDelimiterCells(line);
+    if (!delimiterCells) {
+      continue;
+    }
+
+    const header = lines[index - 1] ?? "";
+    // Indented code, blockquotes, and delimiter-shaped headers are not the
+    // header row of a table this delimiter belongs to.
+    if (leadingIndentWidth(header) >= 4 || header.trimStart().startsWith(">")) {
+      continue;
+    }
+    const headerCells = splitRowCells(header);
+    if (
+      !headerCells ||
+      headerCells.every((cell) => DELIMITER_CELL_REGEX.test(cell.trim())) ||
+      headerCells.length === delimiterCells.length
+    ) {
+      continue;
+    }
+    // Only the first row of a block can be a table header: a pipe-delimited
+    // line above means `header` is a body row of an ongoing table (or part of
+    // a pipe-heavy paragraph) and this dashed line is content, not a delimiter.
+    const preceding = index >= 2 ? (lines[index - 2] ?? "") : "";
+    if (preceding.trim() !== "" && preceding.includes("|")) {
+      continue;
+    }
+
+    const rebuiltCells = delimiterCells.slice(0, headerCells.length);
+    while (rebuiltCells.length < headerCells.length) {
+      rebuiltCells.push("---");
+    }
+    const indent = line.slice(0, line.length - line.trimStart().length);
+    lines[index] = `${indent}| ${rebuiltCells.join(" | ")} |`;
+    repaired = true;
+  }
+
+  return repaired ? lines.join("\n") : value;
+}


### PR DESCRIPTION
## Problem

A user reported assistant markdown tables rendering as a run-on wall of pipe characters (screenshot showed a gpt-5.6-sol answer). Root cause: the model emitted a table with a 3-cell header over a 2-cell delimiter row (`|---|---|`). GFM requires those counts to match — on mismatch remark-gfm rejects the whole block and renders it as a paragraph, where soft line breaks become spaces, so every row flows into one line.

The rendering pipeline itself was verified innocent: no stage trims or collapses newlines.

## Fix

New `repairMarkdownTableDelimiters` pass in `apps/web/src/lib/markdownTableRepair.ts`, applied in `ChatMarkdown` before dollar protection:

- Pads a short delimiter row with `---` cells / drops extra cells to match the header's cell count. Only the delimiter row is ever rewritten.
- Mirrors GFM cell splitting (unescaped pipes split, `\|` doesn't).
- Skips fenced code blocks, indented code, blockquotes, delimiter-shaped headers, and dashed body rows inside an ongoing table.
- The thread-marker plugin now resolves offsets against the same repaired text, so a marker recorded after a repaired row fails its `selectedText` check and drops instead of highlighting a shifted range.

## Tests

- Unit tests for the repair pass (12 cases: padding, truncation, alignment preservation, fences, indented code, blockquotes, ongoing-table body rows, escaped pipes).
- ChatMarkdown render tests: the reported malformed table now renders a real `<table>`; pipe-and-dash lines inside code fences stay untouched.
- `bun fmt`, `bun lint`, `bun typecheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized markdown preprocessing in chat rendering with conservative guards and broad test coverage; no auth, data, or API changes.
> 
> **Overview**
> Fixes assistant markdown tables that collapse into a run-on line of pipes when the model emits a **delimiter row with a different cell count than the header** (GFM rejects the whole block).
> 
> Adds a **`repairMarkdownTableDelimiters`** pre-parse pass that pads or trims delimiter cells to match the header, skips fenced/indented code and other false positives, and wires it into **`ChatMarkdown`** (before dollar protection) for assistant messages only. **Thread markers** now validate offsets against the same repaired string so highlights after a fixed delimiter row drop instead of shifting.
> 
> Unit and **`ChatMarkdown`** render tests cover the reported malformed table case and fence safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0c0ded7cef54c5d3062dd8e41bec1be49f11c93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->