### PR TITLE
Use the configured Git model for worktree branch naming

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -19,6 +19,7 @@ import {
   ApprovalRequestId,
   type ChatAttachment,
   CommandId,
+  DEFAULT_GIT_TEXT_GENERATION_MODEL,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   EventId,
   MessageId,
@@ -206,6 +207,7 @@ describe("ProviderCommandReactor", () => {
     readonly interruptTurn?: ProviderServiceShape["interruptTurn"];
     readonly commandEventTimeout?: Duration.Duration;
     readonly gatewayOperationId?: string;
+    readonly gitWritingModelSelection?: ModelSelection;
   }) {
     const now = new Date().toISOString();
     const baseDir = input?.baseDir ?? fs.mkdtempSync(path.join(os.tmpdir(), "synara-reactor-"));
@@ -519,7 +521,13 @@ describe("ProviderCommandReactor", () => {
           generateThreadTitle,
         } as unknown as TextGenerationShape),
       ),
-      Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(
+        ServerSettingsService.layerTest(
+          input?.gitWritingModelSelection
+            ? { textGenerationModelSelection: input.gitWritingModelSelection }
+            : {},
+        ),
+      ),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),
       Layer.provideMerge(OrchestrationEventDeliveryRepositoryLive),
@@ -4395,6 +4403,13 @@ describe("ProviderCommandReactor", () => {
     await waitFor(() => harness.renameBranch.mock.calls.length === 1);
     await waitFor(() => harness.publishBranch.mock.calls.length === 1);
 
+    expect(harness.generateBranchName.mock.calls[0]?.[0]).toMatchObject({
+      modelSelection: {
+        provider: "codex",
+        model: DEFAULT_GIT_TEXT_GENERATION_MODEL,
+      },
+    });
+
     await waitFor(async () => {
       const thread = await readHarnessThread(harness);
       return (
@@ -4505,9 +4520,17 @@ describe("ProviderCommandReactor", () => {
     expect(harness.publishBranch).not.toHaveBeenCalled();
   });
 
-  it("falls back to prompt-based worktree branch names when the provider cannot generate one", async () => {
-    const harness = await createHarness();
+  it("uses the configured Git-writing model when the chat provider cannot generate names", async () => {
+    const harness = await createHarness({
+      threadModelSelection: {
+        provider: "antigravity",
+        model: "Gemini 3.5 Flash",
+      },
+    });
     const now = new Date().toISOString();
+    harness.generateBranchName.mockImplementation(() =>
+      Effect.succeed({ branch: "provider-startup-timeouts" }),
+    );
 
     await Effect.runPromise(
       harness.engine.dispatch({
@@ -4544,17 +4567,84 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
+    await waitFor(() => harness.generateBranchName.mock.calls.length === 1);
     await waitFor(() => harness.renameBranch.mock.calls.length === 1);
-    expect(harness.generateBranchName).not.toHaveBeenCalled();
+    expect(harness.generateBranchName.mock.calls[0]?.[0]).toMatchObject({
+      modelSelection: {
+        provider: "codex",
+        model: DEFAULT_GIT_TEXT_GENERATION_MODEL,
+      },
+    });
     expect(harness.renameBranch.mock.calls[0]?.[0]).toMatchObject({
       oldBranch: "synara/cb661f0d",
-      newBranch: "synara/fix-provider-startup-timeouts",
+      newBranch: "synara/provider-startup-timeouts",
     });
 
     await waitFor(
       async () =>
-        (await readHarnessThread(harness))?.branch === "synara/fix-provider-startup-timeouts",
+        (await readHarnessThread(harness))?.branch === "synara/provider-startup-timeouts",
     );
+  });
+
+  it("keeps the temporary worktree branch when no Git-writing generator is available", async () => {
+    const harness = await createHarness({
+      threadModelSelection: {
+        provider: "antigravity",
+        model: "Gemini 3.5 Flash",
+      },
+      gitWritingModelSelection: {
+        provider: "claudeAgent",
+        model: "claude-opus-4-8",
+      },
+    });
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-thread-worktree-keep-temporary"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        envMode: "worktree",
+        branch: "synara/cb661f0d",
+        worktreePath: "/tmp/provider-project/.worktrees/cb661f0d",
+        associatedWorktreePath: "/tmp/provider-project/.worktrees/cb661f0d",
+        associatedWorktreeBranch: "synara/cb661f0d",
+        associatedWorktreeRef: "synara/cb661f0d",
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-worktree-keep-temporary"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-worktree-keep-temporary"),
+          role: "user",
+          text: "This entire message must never become the branch name",
+          attachments: [],
+        },
+        modelSelection: {
+          provider: "antigravity",
+          model: "Gemini 3.5 Flash",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect(harness.generateBranchName).not.toHaveBeenCalled();
+    expect(harness.renameBranch).not.toHaveBeenCalled();
+    expect(harness.publishBranch).not.toHaveBeenCalled();
+
+    const thread = await readHarnessThread(harness);
+    expect(thread).toMatchObject({
+      branch: "synara/cb661f0d",
+      associatedWorktreeBranch: "synara/cb661f0d",
+      associatedWorktreeRef: "synara/cb661f0d",
+    });
   });
 
   it("renames generic OpenCode first-turn thread titles using text generation", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -4581,8 +4581,7 @@ describe("ProviderCommandReactor", () => {
     });
 
     await waitFor(
-      async () =>
-        (await readHarnessThread(harness))?.branch === "synara/provider-startup-timeouts",
+      async () => (await readHarnessThread(harness))?.branch === "synara/provider-startup-timeouts",
     );
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -665,6 +665,14 @@ const make = Effect.gen(function* () {
     completePendingContextBootstrapAttempt(event.threadId, attempt, event);
   };
 
+  const resolveConfiguredTextGenerationInput = Effect.fnUntraced(function* () {
+    const settings = yield* serverSettings.getSettings;
+    return resolveTextGenerationInputForSelection(
+      settings.textGenerationModelSelection,
+      providerStartOptionsFromServerSettings(settings),
+    );
+  });
+
   const resolveThreadTextGenerationInput = Effect.fnUntraced(function* (input: {
     readonly threadId: ThreadId;
     readonly modelSelection?: ModelSelection;
@@ -687,11 +695,7 @@ const make = Effect.gen(function* () {
     }
 
     // Non-generating chat providers still get AI titles via the configured git-writing model.
-    const settings = yield* serverSettings.getSettings;
-    return resolveTextGenerationInputForSelection(
-      settings.textGenerationModelSelection,
-      providerOptions,
-    );
+    return yield* resolveConfiguredTextGenerationInput();
   });
 
   const appendProviderFailureActivity = (input: {
@@ -1960,8 +1964,6 @@ const make = Effect.gen(function* () {
     readonly messageId: string;
     readonly messageText: string;
     readonly attachments?: ReadonlyArray<ChatAttachment>;
-    readonly modelSelection?: ModelSelection;
-    readonly providerOptions?: ProviderStartOptions;
   }) {
     if (!input.branch || !input.worktreePath) {
       return;
@@ -1976,34 +1978,18 @@ const make = Effect.gen(function* () {
     const oldBranch = input.branch;
     const cwd = input.worktreePath;
     const attachments = input.attachments ?? [];
-    const textGenerationInput = yield* resolveThreadTextGenerationInput({
-      threadId: input.threadId,
-      ...(input.modelSelection ? { modelSelection: input.modelSelection } : {}),
-      ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
-    });
+    // Branch naming is a Git-writing concern, just like commit and PR text.
+    // Keep it on the dedicated configured model instead of coupling it to the
+    // conversation provider, which may not support structured text generation.
+    const textGenerationInput = yield* resolveConfiguredTextGenerationInput();
     if (!textGenerationInput) {
-      const targetBranch = buildGeneratedWorktreeBranchName(
-        input.messageText.trim() || attachmentTitleSeed(attachments[0]) || "",
-      );
-      yield* renameTemporaryWorktreeBranch({
-        threadId: input.threadId,
-        cwd,
-        oldBranch,
-        targetBranch,
-        gatewayOperationId: thread.gatewayOperationId ?? null,
-      }).pipe(
-        Effect.catchCause((cause) =>
-          Effect.logWarning(
-            "provider command reactor failed to apply fallback worktree branch name",
-            {
-              threadId: input.threadId,
-              cwd,
-              oldBranch,
-              targetBranch,
-              cause: Cause.pretty(cause),
-            },
-          ),
-        ),
+      yield* Effect.logDebug(
+        "provider command reactor has no Git-writing model for worktree branch naming; keeping temporary branch",
+        {
+          threadId: input.threadId,
+          cwd,
+          branch: oldBranch,
+        },
       );
       return;
     }
@@ -2019,7 +2005,7 @@ const make = Effect.gen(function* () {
     yield* textGeneration.generateBranchName(branchNameGenerationInput).pipe(
       Effect.catch((error) =>
         Effect.logWarning(
-          "provider command reactor failed to generate worktree branch name; skipping rename",
+          "provider command reactor failed to generate worktree branch name; keeping temporary branch",
           { threadId: input.threadId, cwd, oldBranch, reason: error.message },
         ),
       ),
@@ -2293,12 +2279,6 @@ const make = Effect.gen(function* () {
         messageId: message.id,
         messageText: message.text,
         ...(message.attachments !== undefined ? { attachments: resolvedAttachments } : {}),
-        ...(event.payload.modelSelection !== undefined
-          ? { modelSelection: event.payload.modelSelection }
-          : {}),
-        ...(event.payload.providerOptions !== undefined
-          ? { providerOptions: event.payload.providerOptions }
-          : {}),
       }).pipe(Effect.forkScoped);
       yield* maybeGenerateAndRenameThreadTitleForFirstTurn({
         threadId: event.payload.threadId,


### PR DESCRIPTION
## Summary

- Route worktree branch-name generation through the configured Git-writing model
- Keep temporary branches unchanged when no Git-writing generator is available
- Add unit coverage for default, configured, and unavailable model scenarios

## Testing

- Added and updated unit tests for ProviderCommandReactor branch naming behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-turn Git branch rename behavior for worktree threads; wrong model or missing generator affects branch names but not chat turns, with a safer no-rename fallback.
> 
> **Overview**
> **Worktree branch naming on the first turn** no longer follows the chat provider’s model. It always goes through the server’s **Git-writing** model (`textGenerationModelSelection`), aligned with commit/PR text generation via a shared `resolveConfiguredTextGenerationInput` helper.
> 
> When no Git-writing generator is configured or branch generation fails, the reactor **leaves the temporary `synara/…` branch** instead of deriving a name from the user message. Thread title generation still uses the thread provider with the existing configured fallback.
> 
> **Tests** assert the default Codex Git model is passed to `generateBranchName`, that Antigravity chat threads still rename via the Git model, and that a non-generating Git model selection keeps the temporary branch unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a33e65bb29221f95ecc185f7d4bdd0880d379206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->