### PR TITLE
Update sidebar branch label on mid-turn VCS changes

### DIFF
--- a/apps/server/src/orchestration/Layers/ThreadGitMetadataReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ThreadGitMetadataReactor.test.ts
@@ -201,6 +201,18 @@ describe("ThreadGitMetadataReactor", () => {
     payload: { state: "completed" },
   });
 
+  const vcsStateChangedEvent = (
+    threadId: ThreadId,
+    options?: { readonly cwd?: string; readonly eventId?: string },
+  ): ProviderRuntimeEvent => ({
+    type: "vcs.state.changed",
+    eventId: EventId.makeUnsafe(options?.eventId ?? `vcs-${threadId}`),
+    provider: "claudeAgent",
+    threadId,
+    createdAt: "2026-08-07T10:00:30.000Z",
+    payload: { kind: "commit", ...(options?.cwd !== undefined ? { cwd: options.cwd } : {}) },
+  });
+
   const runtimeErrorEvent = (threadId: ThreadId): ProviderRuntimeEvent => ({
     type: "runtime.error",
     eventId: EventId.makeUnsafe(`runtime-error-${threadId}`),
@@ -465,6 +477,121 @@ describe("ThreadGitMetadataReactor", () => {
     await harness.drain();
 
     expect(harness.commands).toEqual([]);
+  });
+
+  it("refreshes worktree thread metadata mid-turn on a VCS state change", async () => {
+    const threadId = ThreadId.makeUnsafe("vcs-worktree-thread");
+    const cwd = "/repo/.worktrees/vcs";
+    const harness = await createHarness({
+      threads: [
+        {
+          id: threadId,
+          projectId: ProjectId.makeUnsafe("project-1"),
+          envMode: "worktree",
+          worktreePath: cwd,
+          branch: "synara/stale-branch",
+          lastKnownPr: null,
+        },
+      ],
+      branchByCwd: { [cwd]: pullRequest.headBranch },
+    });
+
+    await harness.publish(startedEvent(threadId, TurnId.makeUnsafe("vcs-running-turn")));
+    await harness.publish(vcsStateChangedEvent(threadId, { cwd }));
+    await waitFor(() => harness.commands.length === 1);
+
+    expect(harness.commands[0]).toMatchObject({
+      type: "thread.meta.update",
+      threadId,
+      branch: pullRequest.headBranch,
+      lastKnownPr: pullRequest,
+      associatedWorktreeBranch: pullRequest.headBranch,
+    });
+  });
+
+  it("ignores VCS state changes reported for a different workspace", async () => {
+    const threadId = ThreadId.makeUnsafe("vcs-mismatch-thread");
+    const cwd = "/repo/.worktrees/vcs-mismatch";
+    const harness = await createHarness({
+      threads: [
+        {
+          id: threadId,
+          projectId: ProjectId.makeUnsafe("project-1"),
+          envMode: "worktree",
+          worktreePath: cwd,
+          branch: "synara/stale-branch",
+          lastKnownPr: null,
+        },
+      ],
+      branchByCwd: { [cwd]: pullRequest.headBranch },
+    });
+
+    await harness.publish(
+      vcsStateChangedEvent(threadId, { cwd: "/elsewhere", eventId: "vcs-elsewhere" }),
+    );
+    await harness.publish(vcsStateChangedEvent(threadId, { cwd }));
+    await waitFor(() => harness.commands.length === 1);
+
+    expect(harness.statusCwds).toEqual([cwd]);
+    expect(harness.commands[0]).toMatchObject({
+      type: "thread.meta.update",
+      threadId,
+      branch: pullRequest.headBranch,
+    });
+  });
+
+  it("only applies shared-checkout VCS changes for the sole active owning thread", async () => {
+    const firstThreadId = ThreadId.makeUnsafe("vcs-first-local-thread");
+    const secondThreadId = ThreadId.makeUnsafe("vcs-second-local-thread");
+    const sentinelThreadId = ThreadId.makeUnsafe("vcs-sentinel-worktree-thread");
+    const sentinelCwd = "/repo/.worktrees/vcs-sentinel";
+    const projectId = ProjectId.makeUnsafe("project-1");
+    const harness = await createHarness({
+      threads: [
+        ...[firstThreadId, secondThreadId].map((id) => ({
+          id,
+          projectId,
+          envMode: "local" as const,
+          worktreePath: null,
+          branch: "synara/stale-branch",
+          lastKnownPr: null,
+        })),
+        {
+          id: sentinelThreadId,
+          projectId,
+          envMode: "worktree" as const,
+          worktreePath: sentinelCwd,
+          branch: "synara/stale-sentinel",
+          lastKnownPr: null,
+        },
+      ],
+      branchByCwd: {
+        "/repo": pullRequest.headBranch,
+        [sentinelCwd]: pullRequest.headBranch,
+      },
+    });
+
+    await harness.publish(startedEvent(firstThreadId, TurnId.makeUnsafe("vcs-first-turn")));
+    await harness.publish(vcsStateChangedEvent(firstThreadId, { cwd: "/repo" }));
+    await waitFor(() => harness.commands.length === 1);
+    expect(harness.commands[0]).toMatchObject({
+      type: "thread.meta.update",
+      threadId: firstThreadId,
+      branch: pullRequest.headBranch,
+    });
+
+    await harness.publish(startedEvent(secondThreadId, TurnId.makeUnsafe("vcs-second-turn")));
+    await harness.publish(
+      vcsStateChangedEvent(secondThreadId, { cwd: "/repo", eventId: "vcs-ambiguous" }),
+    );
+    await harness.publish(completedEvent(sentinelThreadId, TurnId.makeUnsafe("vcs-sentinel-turn")));
+    await waitFor(() => harness.commands.length === 2);
+
+    expect(harness.statusCwds).toEqual(["/repo", sentinelCwd]);
+    expect(harness.commands[1]).toMatchObject({
+      type: "thread.meta.update",
+      threadId: sentinelThreadId,
+    });
   });
 
   it("releases ambiguous local turn ownership when the provider runtime exits", async () => {

--- a/apps/server/src/orchestration/Layers/ThreadGitMetadataReactor.ts
+++ b/apps/server/src/orchestration/Layers/ThreadGitMetadataReactor.ts
@@ -25,6 +25,7 @@ type TerminalEvent = Extract<
   ProviderRuntimeEvent,
   { type: "turn.completed" | "turn.aborted" | "session.exited" | "runtime.error" }
 >;
+type VcsStateChangedEvent = Extract<ProviderRuntimeEvent, { type: "vcs.state.changed" }>;
 
 interface ThreadWorkspaceContext {
   readonly threadId: ThreadId;
@@ -179,25 +180,54 @@ const make = Effect.gen(function* () {
         }
       }
 
-      const threadOption = yield* projectionSnapshotQuery.getThreadShellById(event.threadId);
-      const thread = Option.getOrUndefined(threadOption);
-      if (!thread) return;
-
-      const details = yield* gitCore.readBranchContext(context.cwd);
-      if (!details.isRepo) return;
-
-      const token = Symbol(event.eventId);
-      latestCaptureTokenByThread.set(event.threadId, token);
-      yield* worker.enqueue({
-        token,
-        threadId: event.threadId,
-        cwd: context.cwd,
-        expectedThreadBranch: thread.branch,
-        observedBranch: details.branch,
-        upstreamRef: details.upstreamRef,
-        hasDedicatedWorktree: context.hasDedicatedWorktree,
-      });
+      yield* enqueueMetadataCapture(event.threadId, context, event.eventId);
     }).pipe(Effect.ensuring(cleanup));
+  });
+
+  const enqueueMetadataCapture = Effect.fnUntraced(function* (
+    threadId: ThreadId,
+    context: ThreadWorkspaceContext,
+    eventId: string,
+  ) {
+    const threadOption = yield* projectionSnapshotQuery.getThreadShellById(threadId);
+    const thread = Option.getOrUndefined(threadOption);
+    if (!thread) return;
+
+    const details = yield* gitCore.readBranchContext(context.cwd);
+    if (!details.isRepo) return;
+
+    const token = Symbol(eventId);
+    latestCaptureTokenByThread.set(threadId, token);
+    yield* worker.enqueue({
+      token,
+      threadId,
+      cwd: context.cwd,
+      expectedThreadBranch: thread.branch,
+      observedBranch: details.branch,
+      upstreamRef: details.upstreamRef,
+      hasDedicatedWorktree: context.hasDedicatedWorktree,
+    });
+  });
+
+  // Mid-turn VCS transitions (commit/checkout/rebase) refresh the durable thread
+  // metadata immediately; long-running turns would otherwise leave the projected
+  // branch stale until the turn boundary reconciliation.
+  const captureVcsMetadata = Effect.fnUntraced(function* (event: VcsStateChangedEvent) {
+    const context = yield* resolveWorkspaceContext(event.threadId);
+    if (!context) return;
+    if (event.payload.cwd !== undefined && event.payload.cwd !== context.cwd) return;
+
+    if (!context.hasDedicatedWorktree) {
+      const threadKeys = activeKeysForThread(event.threadId);
+      if (threadKeys.length !== 1) return;
+      const activeKey = threadKeys[0]!;
+      const owners = activeTurnKeysByCwd.get(context.cwd);
+      if (ambiguousSharedTurnKeys.has(activeKey) || owners?.size !== 1 || !owners.has(activeKey)) {
+        return;
+      }
+    }
+
+    yield* enqueueMetadataCapture(event.threadId, context, event.eventId);
   });
 
   const lookupPullRequest = (
@@ -295,6 +325,7 @@ const make = Effect.gen(function* () {
     // and suppress reconciliation when the actual parent turn completes.
     if (event.providerRefs?.providerParentThreadId !== undefined) return Effect.void;
     if (event.type === "turn.started") return trackTurnStart(event);
+    if (event.type === "vcs.state.changed") return captureVcsMetadata(event);
     if (
       event.type === "turn.completed" ||
       event.type === "turn.aborted" ||

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -2490,6 +2490,59 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("projects vcs_state_changed system messages as vcs.state.changed events", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) => event.type === "vcs.state.changed" || event.type === "runtime.warning",
+        ),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+      });
+
+      harness.query.emit({
+        type: "system",
+        subtype: "vcs_state_changed",
+        kind: "commit",
+        cwd: "/repo/worktree",
+        session_id: "sdk-session-vcs",
+        uuid: "vcs-1",
+      } as unknown as SDKMessage);
+      // Sentinel unknown subtype closes the collection window; the VCS event
+      // arriving first proves it did not surface as an unhandled warning.
+      harness.query.emit({
+        type: "system",
+        subtype: "totally_unknown_subtype",
+        session_id: "sdk-session-vcs",
+        uuid: "vcs-sentinel",
+      } as unknown as SDKMessage);
+
+      const events = Array.from(yield* Fiber.join(eventsFiber));
+      assert.equal(events[0]?.type, "vcs.state.changed");
+      if (events[0]?.type === "vcs.state.changed") {
+        assert.deepEqual(events[0].payload, { kind: "commit", cwd: "/repo/worktree" });
+      }
+      assert.equal(events[1]?.type, "runtime.warning");
+      if (events[1]?.type === "runtime.warning") {
+        assert.equal(
+          events[1].payload.message,
+          "Unhandled Claude system message subtype 'totally_unknown_subtype'.",
+        );
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("still announces a task backgrounded via task_updated before the snapshot", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -777,6 +777,34 @@ function readClaudeModelRefusalFallback(message: unknown): ClaudeModelRefusalFal
   };
 }
 
+// VCS state transitions (commit, checkout, rebase) stream as an untyped system
+// message; match structurally so SDK type drift stays inert.
+interface ClaudeVcsStateChange {
+  readonly kind?: string;
+  readonly cwd?: string;
+}
+
+function readClaudeVcsStateChange(message: unknown): ClaudeVcsStateChange | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const record = message as {
+    type?: unknown;
+    subtype?: unknown;
+    kind?: unknown;
+    cwd?: unknown;
+  };
+  if (record.type !== "system" || record.subtype !== "vcs_state_changed") {
+    return undefined;
+  }
+  const kind = readNonEmptyString(record.kind);
+  const cwd = readNonEmptyString(record.cwd);
+  return {
+    ...(kind !== undefined ? { kind } : {}),
+    ...(cwd !== undefined ? { cwd } : {}),
+  };
+}
+
 const DEFAULT_WORKFLOW_RUNTIME_POLL_INTERVAL_MS = 2_000;
 // Synthetic description for poller-emitted task.progress events; consumers key
 // off payload.workflowAgents, not this text.
@@ -3979,6 +4007,18 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               toModel: refusalFallback.fallbackModel,
               reason: refusalFallback.content ?? "Model safeguards rerouted this request.",
             },
+          });
+          return;
+        }
+
+        // VCS transitions let the thread git metadata reactor refresh the durable
+        // branch/PR projection mid-turn instead of waiting for the turn boundary.
+        const vcsStateChange = readClaudeVcsStateChange(message);
+        if (vcsStateChange) {
+          yield* offerRuntimeEvent(context, {
+            ...base,
+            type: "vcs.state.changed",
+            payload: vcsStateChange,
           });
           return;
         }

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -201,6 +201,7 @@ const ProviderRuntimeEventType = Schema.Literals([
   "config.warning",
   "deprecation.notice",
   "files.persisted",
+  "vcs.state.changed",
   "runtime.warning",
   "runtime.error",
 ]);
@@ -253,6 +254,7 @@ const ModelReroutedType = Schema.Literal("model.rerouted");
 const ConfigWarningType = Schema.Literal("config.warning");
 const DeprecationNoticeType = Schema.Literal("deprecation.notice");
 const FilesPersistedType = Schema.Literal("files.persisted");
+const VcsStateChangedType = Schema.Literal("vcs.state.changed");
 const RuntimeWarningType = Schema.Literal("runtime.warning");
 const RuntimeErrorType = Schema.Literal("runtime.error");
 
@@ -715,6 +717,12 @@ const FilesPersistedPayload = Schema.Struct({
 });
 export type FilesPersistedPayload = typeof FilesPersistedPayload.Type;
 
+const VcsStateChangedPayload = Schema.Struct({
+  kind: Schema.optional(TrimmedNonEmptyStringSchema),
+  cwd: Schema.optional(TrimmedNonEmptyStringSchema),
+});
+export type VcsStateChangedPayload = typeof VcsStateChangedPayload.Type;
+
 const RuntimeWarningPayload = Schema.Struct({
   message: TrimmedNonEmptyStringSchema,
   detail: Schema.optional(Schema.Unknown),
@@ -1074,6 +1082,13 @@ const ProviderRuntimeFilesPersistedEvent = Schema.Struct({
 });
 export type ProviderRuntimeFilesPersistedEvent = typeof ProviderRuntimeFilesPersistedEvent.Type;
 
+const ProviderRuntimeVcsStateChangedEvent = Schema.Struct({
+  ...ProviderRuntimeEventBase.fields,
+  type: VcsStateChangedType,
+  payload: VcsStateChangedPayload,
+});
+export type ProviderRuntimeVcsStateChangedEvent = typeof ProviderRuntimeVcsStateChangedEvent.Type;
+
 const ProviderRuntimeWarningEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
   type: RuntimeWarningType,
@@ -1136,6 +1151,7 @@ export const ProviderRuntimeEventV2 = Schema.Union([
   ProviderRuntimeConfigWarningEvent,
   ProviderRuntimeDeprecationNoticeEvent,
   ProviderRuntimeFilesPersistedEvent,
+  ProviderRuntimeVcsStateChangedEvent,
   ProviderRuntimeWarningEvent,
   ProviderRuntimeErrorEvent,
 ]);


### PR DESCRIPTION
## Problem

The sidebar thread row shows the branch from the persisted `projection_threads.branch` field, which is only reconciled by `ThreadGitMetadataReactor` at turn boundaries (`turn.completed` / `turn.aborted` / `session.exited` / `runtime.error`, added in #579). When an agent switches branches mid-turn — e.g. commits and creates `fix/…` during a long-running turn — the row keeps showing the original `synara/…` worktree branch until the turn ends, even though the right panel (live `git status` query) shows the correct one.

Meanwhile the Claude runtime announces every commit/checkout/rebase with a `vcs_state_changed` system message (payload: `kind`, `cwd`), which Synara dropped as *"Unhandled Claude system message subtype 'vcs_state_changed'."* — visible as runtime-warning noise in the chat.

## Fix

- **contracts**: add a `vcs.state.changed` provider runtime event with `{ kind?, cwd? }` payload.
- **ClaudeAdapter**: structurally match the `vcs_state_changed` system message (same pattern as the refusal-fallback reader, since the pinned SDK types don't include this subtype) and emit `vcs.state.changed` instead of the unhandled-subtype warning.
- **ThreadGitMetadataReactor**: react to `vcs.state.changed` mid-turn with the same branch/PR reconciliation used at turn boundaries. Guards: skip when the event `cwd` doesn't match the thread's workspace, and for shared (non-worktree) checkouts only apply when the thread is the sole unambiguous owner of the cwd. The capture logic is extracted into a shared helper so the terminal and mid-turn paths stay identical.

No web changes needed: the client already invalidates git queries on `thread.meta-updated` events that touch branch fields, so the sidebar chip updates as soon as the projection does.

## Verification

- New tests: mid-turn worktree refresh, cwd-mismatch skip, shared-checkout ambiguity skip (reactor) and the adapter mapping (emits `vcs.state.changed`, no runtime warning).
- `bun fmt`, `bun lint`, `bun typecheck` pass; reactor (11) and ClaudeAdapter (143) test files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration/git projection reconciliation on a new event path; incorrect attribution on shared checkouts could update the wrong thread, though ambiguity guards mirror existing terminal logic.
> 
> **Overview**
> Adds a **`vcs.state.changed`** provider runtime event and wires Claude’s `vcs_state_changed` system messages into it (optional `kind` / `cwd`), replacing the previous unhandled-subtype **runtime.warning** noise.
> 
> **`ThreadGitMetadataReactor`** now reconciles branch/PR metadata on that event **during an active turn**, using the same capture path as turn-boundary events via a shared **`enqueueMetadataCapture`** helper. Mid-turn updates are gated: ignore mismatched **`cwd`**, and for shared (non-worktree) checkouts only run when the thread is the sole unambiguous owner of the workspace.
> 
> Tests cover adapter mapping and reactor behavior (worktree refresh, cwd mismatch, shared-checkout ambiguity).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0de25646856009182f79085674c2f6fb61102dff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->