### PR TITLE
Guard timeline rows against painted overlap during streaming

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.rowOverlap.browser.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.rowOverlap.browser.tsx
@@ -1,0 +1,400 @@
+// FILE: MessagesTimeline.rowOverlap.browser.tsx
+// Purpose: Browser regression for virtualized row overlap — while a turn
+//          streams (tool calls landing one by one, narration growing, groups
+//          collapsing behind summaries, disclosures animating), LegendList's
+//          absolutely-positioned row containers must never draw on top of each
+//          other for more than a transient frame.
+// Layer: Vitest browser tests
+
+import "../../index.css";
+
+import { MessageId } from "@synara/contracts";
+import { type LegendListRef } from "@legendapp/list/react";
+import { useRef, useState } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { MessagesTimeline } from "./MessagesTimeline";
+import type { TimelineEntry } from "../../session-logic";
+
+const VIEWPORT_HEIGHT_PX = 480;
+// Entry transforms (`chat-message-send-enter`) and sub-pixel rounding shift a
+// row's rect by a few pixels without any layout fault; only deeper intrusions
+// count as overlap.
+const OVERLAP_SLACK_PX = 4;
+// A stale measurement that self-corrects on the next layout pass is the
+// virtualizer working as designed. The user-visible bug is overlap that
+// persists across frames.
+const MAX_TOLERATED_OVERLAP_STREAK_FRAMES = 4;
+
+function messageEntry(
+  id: string,
+  role: "user" | "assistant",
+  text: string,
+  streaming = false,
+): TimelineEntry {
+  return {
+    id: `entry-${id}`,
+    kind: "message",
+    createdAt: "2026-03-17T19:12:28.000Z",
+    message: {
+      id: MessageId.makeUnsafe(id),
+      role,
+      text,
+      createdAt: "2026-03-17T19:12:28.000Z",
+      streaming,
+    },
+  };
+}
+
+function commandEntry(
+  id: string,
+  command: string,
+  toolStatus: "running" | "completed",
+): TimelineEntry {
+  return {
+    id: `entry-${id}`,
+    kind: "work",
+    createdAt: "2026-03-17T19:12:28.000Z",
+    entry: {
+      id,
+      createdAt: "2026-03-17T19:12:28.000Z",
+      label: "Ran command",
+      tone: "tool",
+      itemType: "command_execution",
+      toolStatus,
+      command,
+    },
+  };
+}
+
+function thinkingEntry(id: string, label: string): TimelineEntry {
+  return {
+    id: `entry-${id}`,
+    kind: "work",
+    createdAt: "2026-03-17T19:12:28.000Z",
+    entry: {
+      id,
+      createdAt: "2026-03-17T19:12:28.000Z",
+      label,
+      tone: "thinking",
+    },
+  };
+}
+
+function seedEntries(): TimelineEntry[] {
+  const entries: TimelineEntry[] = [];
+  for (let index = 0; index < 6; index += 1) {
+    entries.push(messageEntry(`seed-user-${index}`, "user", `Earlier question ${index}.`));
+    entries.push(
+      messageEntry(
+        `seed-assistant-${index}`,
+        "assistant",
+        `Earlier answer ${index}. ${"Some settled response text. ".repeat(6)}`,
+      ),
+    );
+  }
+  return entries;
+}
+
+interface HarnessHandle {
+  listRef: React.RefObject<LegendListRef | null>;
+  send: (messageId: string) => void;
+  clearAnchor: () => void;
+  update: (mutate: (current: TimelineEntry[]) => TimelineEntry[]) => void;
+  setFollowLiveOutput: (follow: boolean) => void;
+}
+
+function RowOverlapTimeline({ handleRef }: { handleRef: { current: HarnessHandle | null } }) {
+  const listRef = useRef<LegendListRef | null>(null);
+  const [entries, setEntries] = useState<TimelineEntry[]>(seedEntries);
+  const [tailAnchorMessageId, setTailAnchorMessageId] = useState<MessageId | null>(null);
+  const [followLiveOutput, setFollowLiveOutput] = useState(false);
+
+  handleRef.current = {
+    listRef,
+    send: (messageId: string) => {
+      setEntries((current) => [
+        ...current,
+        messageEntry(messageId, "user", "Freshly sent question."),
+      ]);
+      setTailAnchorMessageId(MessageId.makeUnsafe(messageId));
+    },
+    clearAnchor: () => {
+      setTailAnchorMessageId(null);
+    },
+    update: (mutate) => {
+      setEntries((current) => mutate([...current]));
+    },
+    setFollowLiveOutput,
+  };
+
+  return (
+    <div style={{ height: VIEWPORT_HEIGHT_PX, width: "100%" }}>
+      <MessagesTimeline
+        hasMessages
+        isWorking
+        activeTurnInProgress
+        activeTurnStartedAt="2026-03-17T19:12:29.000Z"
+        listRef={listRef}
+        tailAnchorMessageId={tailAnchorMessageId}
+        followLiveOutput={followLiveOutput}
+        timelineEntries={entries}
+        turnDiffSummaryByAssistantMessageId={new Map()}
+        nowIso="2026-03-17T19:12:30.000Z"
+        expandedWorkGroups={{}}
+        onToggleWorkGroup={() => {}}
+        onOpenTurnDiff={() => {}}
+        revertTurnCountByUserMessageId={new Map()}
+        onRevertUserMessage={() => {}}
+        isRevertingCheckpoint={false}
+        onImageExpand={() => {}}
+        markdownCwd={undefined}
+        resolvedTheme="dark"
+        timestampFormat="locale"
+        workspaceRoot={undefined}
+      />
+    </div>
+  );
+}
+
+function createTimelineHost(): HTMLDivElement {
+  const host = document.createElement("div");
+  host.style.cssText = `display:block;width:600px;height:${VIEWPORT_HEIGHT_PX}px;overflow:hidden;`;
+  document.body.append(host);
+  return host;
+}
+
+type OverlapSample = {
+  frame: number;
+  overlapPx: number;
+  pair: string;
+};
+
+/**
+ * Measures every timeline row's border box and returns the deepest intrusion of
+ * one row into the next (sorted by top). Rows are absolutely positioned by
+ * LegendList, so any intrusion beyond the slack means the container `top`s were
+ * computed from stale sizes.
+ */
+function deepestRowOverlap(): { overlapPx: number; pair: string } {
+  const rows = [...document.querySelectorAll<HTMLElement>("[data-timeline-row-kind]")]
+    .map((row) => ({ row, rect: row.getBoundingClientRect() }))
+    .filter(({ rect }) => rect.height > 0)
+    .sort((left, right) => left.rect.top - right.rect.top);
+
+  let overlapPx = 0;
+  let pair = "";
+  for (let index = 1; index < rows.length; index += 1) {
+    const previous = rows[index - 1]!;
+    const current = rows[index]!;
+    const intrusion = previous.rect.bottom - current.rect.top;
+    if (intrusion > overlapPx) {
+      overlapPx = intrusion;
+      pair = `${previous.row.dataset["timelineRowKind"]} -> ${current.row.dataset["timelineRowKind"]}`;
+    }
+  }
+  return { overlapPx, pair };
+}
+
+function findSummaryTrigger(): HTMLButtonElement | null {
+  return (
+    [...document.querySelectorAll<HTMLButtonElement>("button[aria-expanded]")].find((button) =>
+      (button.textContent ?? "").includes("commands"),
+    ) ?? null
+  );
+}
+
+async function nextFrame(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    window.requestAnimationFrame(() => resolve());
+  });
+}
+
+const STREAM_COMMANDS = [
+  "bun run lint",
+  "bun run typecheck",
+  "rg -n providerManager apps/server/src",
+  "bun run test -- storeEventReducer",
+  "git diff --stat",
+  "node scripts/check.mjs",
+  "git status --porcelain",
+  "bun run build",
+];
+
+describe("MessagesTimeline row overlap under streaming", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("keeps virtualized rows from overlapping while tool calls stream, groups collapse, and disclosures animate", async () => {
+    const handleRef: { current: HarnessHandle | null } = { current: null };
+    const host = createTimelineHost();
+    const screen = await render(<RowOverlapTimeline handleRef={handleRef} />, {
+      container: host,
+    });
+
+    try {
+      const handle = () => {
+        if (!handleRef.current) throw new Error("harness not mounted");
+        return handleRef.current;
+      };
+
+      await expect.poll(() => handle().listRef.current?.getScrollableNode?.() != null).toBe(true);
+      for (let frame = 0; frame < 3; frame += 1) {
+        await nextFrame();
+      }
+      void handle().listRef.current?.scrollToEnd?.({ animated: false });
+      await nextFrame();
+
+      // A real turn: anchored send, then narration + tool calls streaming in.
+      // The user is reading rather than following the live tail, so once the
+      // anchor releases the list runs with maintainVisibleContentPosition on —
+      // the mode where anchor-locked size updates defer position recalcs.
+      handle().send("overlap-sent-message");
+      handle().setFollowLiveOutput(false);
+
+      let narrationText = "";
+      let secondNarrationText = "";
+      let commandCount = 0;
+      const overlapSamples: OverlapSample[] = [];
+      let overlapStreakFrames = 0;
+      let worstOverlapStreakFrames = 0;
+
+      // Painted-state sampler. Rendered frames are only observable between the
+      // frame's ResizeObserver phase and its paint: rAF-time sampling would see
+      // React's between-frames commit (row already grown) without the same
+      // frame's pre-paint corrections, a state that never reaches the screen.
+      // A ResizeObserver created after the timeline mounted is delivered after
+      // the timeline's own observers, and resizing the probe every rAF forces
+      // it to fire every frame — so its callback sees exactly what this frame
+      // paints.
+      const probe = document.createElement("div");
+      probe.style.cssText = "position:fixed;left:-9999px;top:0;width:1px;height:1px;";
+      document.body.append(probe);
+      let sampleFrame = -1;
+      const samplerObserver = new ResizeObserver(() => {
+        if (sampleFrame < 0) {
+          return;
+        }
+        const { overlapPx, pair } = deepestRowOverlap();
+        if (overlapPx > OVERLAP_SLACK_PX) {
+          overlapSamples.push({ frame: sampleFrame, overlapPx, pair });
+          overlapStreakFrames += 1;
+          worstOverlapStreakFrames = Math.max(worstOverlapStreakFrames, overlapStreakFrames);
+        } else {
+          overlapStreakFrames = 0;
+        }
+      });
+      samplerObserver.observe(probe);
+
+      const applyStreamStep = (frame: number) => {
+        handle().update((current) => {
+          // Rebuild the live turn's entries from scratch each step, the way the
+          // store re-derives the timeline from projected events.
+          const next = current.filter(
+            (entry) =>
+              !entry.id.startsWith("entry-narration-") && !entry.id.startsWith("entry-stream-"),
+          );
+          // Narration text grows on a token cadence.
+          if (frame % 3 === 0 && frame < 90) {
+            narrationText += "Streaming narration text that keeps growing. ";
+          }
+          if (frame >= 90 && frame % 3 === 0 && frame < 150) {
+            secondNarrationText += "Second narration block after the tools ran. ";
+          }
+          // Tool calls land one at a time; the previous one completes as the
+          // next starts.
+          if (frame % 8 === 4 && commandCount < STREAM_COMMANDS.length && frame < 90) {
+            commandCount += 1;
+          }
+          const commands = STREAM_COMMANDS.slice(0, commandCount).map((command, index) =>
+            commandEntry(
+              `stream-command-${index}`,
+              command,
+              index === commandCount - 1 && frame < 90 ? "running" : "completed",
+            ),
+          );
+          const rebuilt = [...next];
+          if (narrationText.length > 0) {
+            rebuilt.push(messageEntry("narration-1", "assistant", narrationText, frame < 90));
+          }
+          const boundaryIndex = rebuilt.length;
+          rebuilt.push(...commands);
+          // Mid-turn a thinking boundary splits the run, collapsing the settled
+          // commands behind a "Ran N commands" summary (the structural remap
+          // that swings two row heights in one commit).
+          if (frame >= 56 && commandCount > 2) {
+            rebuilt.splice(
+              boundaryIndex + commandCount - 1,
+              0,
+              thinkingEntry("stream-think", "Weighing the next verification step"),
+            );
+          }
+          if (secondNarrationText.length > 0) {
+            rebuilt.push(
+              messageEntry("narration-2", "assistant", secondNarrationText, frame < 150),
+            );
+          }
+          return rebuilt;
+        });
+      };
+
+      for (let frame = 0; frame < 170; frame += 1) {
+        applyStreamStep(frame);
+        // Mid-stream the tail anchor releases (the real hand-off once the
+        // response grows past the reserve), turning maintainVisibleContentPosition
+        // back on while data keeps changing — the mode where LegendList's
+        // anchor lock defers size-driven position recalcs past the paint.
+        if (frame === 40) {
+          handle().clearAnchor();
+        }
+        // The reader has scrolled to the live tail; the frame-100 disclosure
+        // now animates above the viewport, so MVCP keeps compensating scroll
+        // while sizes change — the anchor-locked mode that defers recalcs.
+        if (frame === 95) {
+          void handle().listRef.current?.scrollToEnd?.({ animated: false });
+        }
+        // Toggle a summary disclosure while content still streams, so the
+        // 220ms height animation overlaps live growth.
+        if (frame === 100) {
+          findSummaryTrigger()?.click();
+        }
+        if (frame === 120) {
+          findSummaryTrigger()?.click();
+        }
+        // Alternate the probe's size so the sampler observer fires during this
+        // frame's pre-paint ResizeObserver phase and records the painted state.
+        sampleFrame = frame;
+        probe.style.height = `${1 + (frame % 2)}px`;
+        await nextFrame();
+      }
+      sampleFrame = -1;
+      samplerObserver.disconnect();
+      probe.remove();
+
+      // Let everything settle: stream over, animations done.
+      handle().setFollowLiveOutput(false);
+      for (let frame = 0; frame < 30; frame += 1) {
+        await nextFrame();
+      }
+      const settled = deepestRowOverlap();
+
+      const report = overlapSamples
+        .map((sample) => `frame ${sample.frame}: ${sample.overlapPx.toFixed(1)}px (${sample.pair})`)
+        .join("\n");
+
+      expect(
+        worstOverlapStreakFrames,
+        `rows overlapped for ${worstOverlapStreakFrames} consecutive frames:\n${report}`,
+      ).toBeLessThanOrEqual(MAX_TOLERATED_OVERLAP_STREAK_FRAMES);
+      expect(
+        settled.overlapPx,
+        `rows still overlap after settling: ${settled.overlapPx.toFixed(1)}px (${settled.pair})`,
+      ).toBeLessThanOrEqual(1);
+    } finally {
+      await screen.unmount();
+      host.remove();
+    }
+  });
+});

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -105,6 +105,7 @@ import {
 import { summarizeToolCallGroup } from "./toolCallGroup.logic";
 import { ToolCallGroupSummaryRow } from "./ToolCallGroupSummaryRow";
 import { useTailAnchorScroll } from "./useTailAnchorScroll";
+import { useTimelineRowOverlapGuard } from "./useTimelineRowOverlapGuard";
 import {
   deriveDisplayedUserMessageState,
   type ParsedTerminalContextEntry,
@@ -688,6 +689,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     ),
     [],
   );
+  const observeTimelineRow = useTimelineRowOverlapGuard();
   useTailAnchorScroll({
     listRef: resolvedListRef,
     timelineRootRef,
@@ -1109,6 +1111,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
 
   const renderRowContent = (row: MessagesTimelineRow) => (
     <div
+      ref={observeTimelineRow}
       className={cn(
         CHAT_COLUMN_FRAME_CLASS_NAME,
         "px-1 transition-colors duration-500",

--- a/apps/web/src/components/chat/useTimelineRowOverlapGuard.browser.tsx
+++ b/apps/web/src/components/chat/useTimelineRowOverlapGuard.browser.tsx
@@ -1,0 +1,125 @@
+// FILE: useTimelineRowOverlapGuard.browser.tsx
+// Purpose: Direct browser regression for the pre-paint overlap guard. The
+//          timeline-level test can't discriminate the guard's effect when the
+//          virtualizer self-corrects before paint, so this harness recreates
+//          the failure state the guard exists for: absolutely positioned
+//          containers whose `top`s were computed from stale row heights (the
+//          virtualizer's write-back deferred past the paint). The guard must
+//          push the stale containers down within the same frame — and must
+//          never pull a container up when a row shrinks.
+// Layer: Vitest browser tests
+
+import { useRef, useState } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { useTimelineRowOverlapGuard } from "./useTimelineRowOverlapGuard";
+
+const INITIAL_ROW_HEIGHT_PX = 40;
+
+interface HarnessHandle {
+  setRowHeight: (index: number, heightPx: number) => void;
+}
+
+/**
+ * Three rows in absolutely positioned containers, tops laid out for the
+ * initial heights. Row heights change via state; container tops deliberately
+ * stay stale — the guard is the only thing allowed to move them.
+ */
+function StaleContainers({ handleRef }: { handleRef: { current: HarnessHandle | null } }) {
+  const observeRow = useTimelineRowOverlapGuard();
+  const [rowHeights, setRowHeights] = useState([
+    INITIAL_ROW_HEIGHT_PX,
+    INITIAL_ROW_HEIGHT_PX,
+    INITIAL_ROW_HEIGHT_PX,
+  ]);
+
+  handleRef.current = {
+    setRowHeight: (index, heightPx) => {
+      setRowHeights((current) => current.map((height, at) => (at === index ? heightPx : height)));
+    },
+  };
+
+  return (
+    <div style={{ position: "relative", height: 400, width: 300 }}>
+      {rowHeights.map((height, index) => (
+        <div
+          key={index}
+          data-overlap-container={index}
+          style={{
+            position: "absolute",
+            top: index * INITIAL_ROW_HEIGHT_PX,
+            left: 0,
+            right: 0,
+          }}
+        >
+          <div ref={observeRow} style={{ height }} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function containerTop(index: number): number {
+  const container = document.querySelector<HTMLElement>(`[data-overlap-container="${index}"]`);
+  if (!container) throw new Error(`container ${index} not mounted`);
+  return Number.parseFloat(container.style.top);
+}
+
+async function nextFrame(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    window.requestAnimationFrame(() => resolve());
+  });
+}
+
+describe("useTimelineRowOverlapGuard", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("pushes stale containers down in the frame a row grows", async () => {
+    const handleRef: { current: HarnessHandle | null } = { current: null };
+    const screen = await render(<StaleContainers handleRef={handleRef} />);
+
+    try {
+      await expect.poll(() => handleRef.current != null).toBe(true);
+      // Let the observer's initial delivery settle before mutating.
+      await nextFrame();
+      await nextFrame();
+
+      handleRef.current!.setRowHeight(0, 100);
+      // The ResizeObserver fires pre-paint in the frame the growth lays out;
+      // two frames later its corrections are unambiguously visible.
+      await nextFrame();
+      await nextFrame();
+
+      // Rows below the grown row cascade down to sit flush under it.
+      expect(containerTop(1)).toBeCloseTo(100, 0);
+      expect(containerTop(2)).toBeCloseTo(140, 0);
+    } finally {
+      await screen.unmount();
+    }
+  });
+
+  it("leaves a gap alone when a row shrinks", async () => {
+    const handleRef: { current: HarnessHandle | null } = { current: null };
+    const screen = await render(<StaleContainers handleRef={handleRef} />);
+
+    try {
+      await expect.poll(() => handleRef.current != null).toBe(true);
+      await nextFrame();
+      await nextFrame();
+
+      handleRef.current!.setRowHeight(0, 10);
+      await nextFrame();
+      await nextFrame();
+
+      // Pulling rows up is the virtualizer's call (it defers shrink handling
+      // deliberately); the guard must not move anything.
+      expect(containerTop(1)).toBe(INITIAL_ROW_HEIGHT_PX);
+      expect(containerTop(2)).toBe(INITIAL_ROW_HEIGHT_PX * 2);
+    } finally {
+      await screen.unmount();
+    }
+  });
+});

--- a/apps/web/src/components/chat/useTimelineRowOverlapGuard.ts
+++ b/apps/web/src/components/chat/useTimelineRowOverlapGuard.ts
@@ -1,0 +1,122 @@
+// FILE: useTimelineRowOverlapGuard.ts
+// Purpose: Pre-paint correction for LegendList's one-frame row overlap. The
+//          list positions each row's container absolutely from its size model,
+//          but on web the model→DOM write goes through a default-priority React
+//          update that flushes in a macrotask — after the frame in which a row
+//          changed height has already painted. Every frame where a row grows
+//          (streaming text, tool calls landing, the 220ms disclosure animation)
+//          therefore paints with the rows below still at stale offsets, drawn
+//          on top of the grown row. This hook closes that window: a
+//          ResizeObserver fires in the same frame as the height change but
+//          before paint, and pushes the stale containers down with direct
+//          style writes. LegendList's own commit lands next frame with the
+//          same cumulative positions, so the manual writes are transient and
+//          never fight the list's model.
+// Layer: React hooks (chat timeline)
+
+import { useCallback, useEffect, useRef } from "react";
+
+// LegendList parks recycled containers at top: -10000000; anything that far up
+// is not part of the visible layout.
+const OUT_OF_VIEW_THRESHOLD_PX = -100_000;
+// Sub-pixel rounding between the list's integer size model and border-box
+// measurement; intrusions this small are not visible.
+const OVERLAP_EPSILON_PX = 1;
+// A row's positioned container is expected within a few wrappers; walking to
+// the document root would mean the row is not inside a LegendList container.
+const MAX_CONTAINER_ANCESTOR_DEPTH = 8;
+
+/**
+ * Finds the LegendList container that positions this row: the nearest ancestor
+ * with an inline `position: absolute` and an inline `top`. That shape is the
+ * virtualizer's core placement contract, not a private detail.
+ */
+function resolvePositionedContainer(row: HTMLElement): HTMLElement | null {
+  let candidate = row.parentElement;
+  for (let depth = 0; candidate && depth < MAX_CONTAINER_ANCESTOR_DEPTH; depth += 1) {
+    if (candidate.style.position === "absolute" && candidate.style.top !== "") {
+      return candidate;
+    }
+    candidate = candidate.parentElement;
+  }
+  return null;
+}
+
+/**
+ * Observes timeline row elements and, whenever any row's size changes, pushes
+ * the containers below a grown row down so no two rows paint on top of each
+ * other. Only ever moves containers down: a transient gap (a row shrank and
+ * the rows below catch up next frame) is invisible, while pulling rows up
+ * would fight the list's deliberate deferred-shrink handling.
+ *
+ * Returns a ref callback to attach to every timeline row wrapper.
+ */
+export function useTimelineRowOverlapGuard(): (element: HTMLElement | null) => (() => void) | void {
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const observedRowsRef = useRef(new Set<HTMLElement>());
+
+  const closeOverlaps = useCallback(() => {
+    const containers = new Set<HTMLElement>();
+    for (const row of observedRowsRef.current) {
+      if (!row.isConnected) {
+        continue;
+      }
+      const container = resolvePositionedContainer(row);
+      if (container) {
+        containers.add(container);
+      }
+    }
+
+    const placed: { container: HTMLElement; top: number; height: number }[] = [];
+    for (const container of containers) {
+      const top = Number.parseFloat(container.style.top);
+      if (!Number.isFinite(top) || top < OUT_OF_VIEW_THRESHOLD_PX) {
+        continue;
+      }
+      const height = container.getBoundingClientRect().height;
+      if (height <= 0) {
+        continue;
+      }
+      placed.push({ container, top, height });
+    }
+    placed.sort((left, right) => left.top - right.top);
+
+    for (let index = 1; index < placed.length; index += 1) {
+      const previous = placed[index - 1]!;
+      const current = placed[index]!;
+      const minTop = previous.top + previous.height;
+      if (current.top < minTop - OVERLAP_EPSILON_PX) {
+        current.top = minTop;
+        current.container.style.top = `${minTop}px`;
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const observedRows = observedRowsRef.current;
+    return () => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+      observedRows.clear();
+    };
+  }, []);
+
+  return useCallback(
+    (element: HTMLElement | null) => {
+      if (!element) {
+        return;
+      }
+      // ResizeObserver callbacks run after layout but before paint, so the
+      // correction below lands in the same frame as the size change.
+      observerRef.current ??= new ResizeObserver(closeOverlaps);
+      const observer = observerRef.current;
+      observer.observe(element);
+      observedRowsRef.current.add(element);
+      return () => {
+        observer.unobserve(element);
+        observedRowsRef.current.delete(element);
+      };
+    },
+    [closeOverlaps],
+  );
+}


### PR DESCRIPTION
## Problem

User report: while a turn streams tool calls, timeline rows can draw on top of each other (rare; first report).

LegendList positions every row container absolutely (`top`) from its measured-size model. Investigation of `@legendapp/list` 3.3.3 internals found the write-back paths that can land **after** the frame that changed a row's height has already painted:

- With `maintainVisibleContentPosition` data-mode on (our timeline whenever no tail anchor is held and the user isn't following live output) and the MVCP **anchor lock** active, size-driven recalcs are deferred to the *next* frame's rAF (`runOrScheduleMVCPRecalculate` → `queuedMVCPRecalculate`) — a full painted frame with stale offsets, sustained across a 220ms disclosure animation because heights change every frame.
- Store→DOM writes go through `useSyncExternalStore`; under production load the flush can slip past the paint.

Any such frame paints the rows below a growing row at stale offsets — exactly "tool calls overlapping over each other".

## Fix

`useTimelineRowOverlapGuard`: a ResizeObserver on every timeline row. RO callbacks run post-layout but pre-paint, in the same frame as the height change, so the guard cascades direct `style.top` push-downs on the stale containers before the user can see them. Properties that keep it safe:

- **Idempotent with the list's model** — LegendList's own commit lands next with the same cumulative positions; corrections are transient.
- **Push-down only** — a gap after a shrink is invisible and deliberately deferred by the list; the guard never pulls rows up.
- **No-op when the list self-corrects** (verified: zero corrections in the healthy pipeline), and only runs on size-change frames.

## Verification

- `useTimelineRowOverlapGuard.browser.tsx` recreates the failure state directly (absolutely positioned containers with stale `top`s) and asserts the guard pushes followers flush within a frame, and leaves shrink gaps alone.
- `MessagesTimeline.rowOverlap.browser.tsx` drives a realistic streaming turn (anchored send → anchor release → tool calls landing, narration growing, thinking boundary splitting a group, disclosure toggles mid-stream) and asserts **painted** frames stay overlap-free. Sampling uses a probe-driven ResizeObserver created after the timeline's observers — rAF-time sampling shows mid-frame transients up to ~33px that never paint, so this is the only honest sampling point.

Caveat, for transparency: headless Chromium corrects everything pre-paint even without the guard (React flushes the store updates on SyncLane in a microtask), so the timeline-level test alone can't discriminate the guard — that's what the direct guard test is for. The deferred `queuedMVCPRecalculate` path crosses a paint by construction; it needs production-like anchor-lock conditions I could not stage in the harness.

- `bun fmt` / `bun lint` / `bun typecheck` pass; full web suite (3592 tests) and all chat browser tests pass.

Sibling PR (same user report, markdown half): #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live chat transcript layout during streaming by mutating virtualizer row positions, though corrections are push-down-only and intended to be transient until LegendList reconciles.
> 
> **Overview**
> Fixes rare **stacked/overlapping chat rows** while a turn streams (growing narration, tool calls, group collapses, disclosure animations) when LegendList’s absolutely positioned row `top` values can lag one painted frame behind measured heights.
> 
> Adds **`useTimelineRowOverlapGuard`**: a `ResizeObserver` on each timeline row that, pre-paint, finds LegendList’s positioned row containers and **only pushes lower rows down** via direct `style.top` writes when a row grows—never pulling rows up on shrink. **`MessagesTimeline`** attaches the hook’s ref callback to every row wrapper.
> 
> **Browser regressions:** a focused harness proves push-down vs shrink no-op behavior, and a long **`MessagesTimeline`** simulation asserts painted frames stay overlap-free (probe-driven sampling) and layout settles cleanly after streaming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2217ea0115bcb9ec1079be6e1dd764f6580ae411. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->