### PR TITLE
Make Create PR run the full commit-push-PR flow

### DIFF
--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -85,6 +85,7 @@ const NON_REPOSITORY_STATUS_DETAILS = Object.freeze({
   branch: null,
   upstreamRef: null,
   upstreamBranch: null,
+  configuredPrBaseBranch: null,
   hasWorkingTreeChanges: false,
   workingTree: { files: [], insertions: 0, deletions: 0 },
   hasUpstream: false,
@@ -1371,6 +1372,19 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
           );
         }
 
+        const configuredPrBaseBranch = branch
+          ? yield* runGitStdout(
+              "GitCore.statusDetails.configuredPrBaseBranch",
+              cwd,
+              ["config", "--get", `branch.${branch}.gh-merge-base`],
+              true,
+            ).pipe(
+              Effect.map((stdout) => stdout.trim()),
+              Effect.map((trimmed) => (trimmed.length > 0 ? trimmed : null)),
+              Effect.catch(() => Effect.succeed(null)),
+            )
+          : null;
+
         if (!upstreamRef && branch) {
           aheadCount = yield* computeAheadCountAgainstBase(cwd, branch).pipe(
             Effect.catch(() => Effect.succeed(0)),
@@ -1411,6 +1425,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
             branch,
             upstreamRef,
             upstreamBranch,
+            configuredPrBaseBranch,
             hasWorkingTreeChanges,
             workingTree: moveAwareWorkingTree,
             hasUpstream: upstreamRef !== null,
@@ -1472,6 +1487,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
           branch,
           upstreamRef,
           upstreamBranch,
+          configuredPrBaseBranch,
           hasWorkingTreeChanges,
           workingTree: {
             files,

--- a/apps/server/src/git/Layers/GitHubCli.ts
+++ b/apps/server/src/git/Layers/GitHubCli.ts
@@ -1423,6 +1423,7 @@ const makeGitHubCli = Effect.sync(() => {
           input.title,
           "--body-file",
           input.bodyFile,
+          ...(input.draft === true ? ["--draft"] : []),
         ],
       }).pipe(Effect.asVoid),
     getDefaultBranch: (input) =>

--- a/apps/server/src/git/Layers/GitManager.test.ts
+++ b/apps/server/src/git/Layers/GitManager.test.ts
@@ -304,6 +304,10 @@ function runStackedAction(
     commitMessage?: string;
     featureBranch?: boolean;
     filePaths?: readonly string[];
+    prTitle?: string;
+    prBody?: string;
+    prDraft?: boolean;
+    allowDirtyWorkingTree?: boolean;
   },
   options?: Parameters<GitManagerShape["runStackedAction"]>[1],
 ) {
@@ -1293,6 +1297,163 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
             call.includes("pr create --base main --head feature/create-pr-only"),
           ),
         ).toBe(true);
+      }),
+    30_000,
+  );
+
+  it.effect(
+    "uses provided PR title, body, and draft flag without generating content",
+    () =>
+      Effect.gen(function* () {
+        const repoDir = yield* makeTempDir("synara-git-manager-");
+        yield* initRepo(repoDir);
+        yield* runGit(repoDir, ["checkout", "-b", "feature/custom-pr-content"]);
+        const remoteDir = yield* createBareRemote();
+        yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+        fs.writeFileSync(path.join(repoDir, "custom-pr.txt"), "custom pr\n");
+        yield* runGit(repoDir, ["add", "custom-pr.txt"]);
+        yield* runGit(repoDir, ["commit", "-m", "Custom PR content"]);
+
+        let generateCalls = 0;
+        const { manager, ghCalls } = yield* makeManager({
+          textGeneration: {
+            generatePrContent: () => {
+              generateCalls += 1;
+              return Effect.succeed({ title: "Generated title", body: "Generated body" });
+            },
+          },
+          ghScenario: {
+            prListSequence: [
+              "[]",
+              "[]",
+              "[]",
+              JSON.stringify([
+                {
+                  number: 91,
+                  title: "Custom PR title",
+                  url: "https://github.com/example-org/sample-repo/pull/91",
+                  baseRefName: "main",
+                  headRefName: "feature/custom-pr-content",
+                },
+              ]),
+            ],
+          },
+        });
+        const result = yield* runStackedAction(manager, {
+          cwd: repoDir,
+          action: "create_pr",
+          prTitle: "Custom PR title",
+          prBody: "Custom PR body.",
+          prDraft: true,
+        });
+
+        expect(result.pr.status).toBe("created");
+        expect(result.pr.title).toBe("Custom PR title");
+        expect(generateCalls).toBe(0);
+        const createCall = ghCalls.find((call) => call.startsWith("pr create "));
+        expect(createCall).toContain(
+          "pr create --base main --head feature/custom-pr-content --title Custom PR title",
+        );
+        expect(createCall).toContain("--draft");
+      }),
+    30_000,
+  );
+
+  it.effect(
+    "rejects create_pr with uncommitted changes unless the caller opts out of the guard",
+    () =>
+      Effect.gen(function* () {
+        const repoDir = yield* makeTempDir("synara-git-manager-");
+        yield* initRepo(repoDir);
+        yield* runGit(repoDir, ["checkout", "-b", "feature/dirty-create-pr"]);
+        const remoteDir = yield* createBareRemote();
+        yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+        fs.writeFileSync(path.join(repoDir, "committed.txt"), "committed\n");
+        yield* runGit(repoDir, ["add", "committed.txt"]);
+        yield* runGit(repoDir, ["commit", "-m", "Committed work"]);
+        fs.writeFileSync(path.join(repoDir, "uncommitted.txt"), "left out\n");
+
+        const { manager, ghCalls } = yield* makeManager({
+          ghScenario: {
+            prListSequence: [
+              "[]",
+              "[]",
+              "[]",
+              JSON.stringify([
+                {
+                  number: 92,
+                  title: "Committed work",
+                  url: "https://github.com/example-org/sample-repo/pull/92",
+                  baseRefName: "main",
+                  headRefName: "feature/dirty-create-pr",
+                },
+              ]),
+            ],
+          },
+        });
+        const guardedError = yield* runStackedAction(manager, {
+          cwd: repoDir,
+          action: "create_pr",
+        }).pipe(
+          Effect.flip,
+          Effect.map((error) => error.message),
+        );
+        expect(guardedError).toContain("Commit local changes before creating a PR.");
+        expect(ghCalls.some((call) => call.startsWith("pr create "))).toBe(false);
+
+        const result = yield* runStackedAction(manager, {
+          cwd: repoDir,
+          action: "create_pr",
+          allowDirtyWorkingTree: true,
+        });
+
+        expect(result.commit.status).toBe("skipped_not_requested");
+        expect(result.push.status).toBe("pushed");
+        expect(result.pr.status).toBe("created");
+        const status = yield* runGit(repoDir, ["status", "--porcelain"]).pipe(
+          Effect.map((gitResult) => gitResult.stdout),
+        );
+        expect(status).toContain("uncommitted.txt");
+      }),
+    30_000,
+  );
+
+  it.effect(
+    "rejects push with uncommitted changes unless the caller opts out of the guard",
+    () =>
+      Effect.gen(function* () {
+        const repoDir = yield* makeTempDir("synara-git-manager-");
+        yield* initRepo(repoDir);
+        yield* runGit(repoDir, ["checkout", "-b", "feature/dirty-push"]);
+        const remoteDir = yield* createBareRemote();
+        yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+        fs.writeFileSync(path.join(repoDir, "committed.txt"), "committed\n");
+        yield* runGit(repoDir, ["add", "committed.txt"]);
+        yield* runGit(repoDir, ["commit", "-m", "Committed work"]);
+        fs.writeFileSync(path.join(repoDir, "uncommitted.txt"), "left out\n");
+
+        const { manager } = yield* makeManager();
+        const guardedError = yield* runStackedAction(manager, {
+          cwd: repoDir,
+          action: "push",
+        }).pipe(
+          Effect.flip,
+          Effect.map((error) => error.message),
+        );
+        expect(guardedError).toContain("Commit or stash local changes before pushing.");
+
+        const result = yield* runStackedAction(manager, {
+          cwd: repoDir,
+          action: "push",
+          allowDirtyWorkingTree: true,
+        });
+
+        expect(result.commit.status).toBe("skipped_not_requested");
+        expect(result.push.status).toBe("pushed");
+        const status = yield* runGit(repoDir, ["status", "--porcelain"]).pipe(
+          Effect.map((gitResult) => gitResult.stdout),
+        );
+        expect(status).toContain("uncommitted.txt");
       }),
     30_000,
   );

--- a/apps/server/src/git/Layers/GitManager.test.ts
+++ b/apps/server/src/git/Layers/GitManager.test.ts
@@ -430,6 +430,24 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
+  it.effect("status exposes the configured PR merge base", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("synara-git-manager-");
+      yield* initRepo(repoDir);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/configured-pr-base"]);
+      yield* runGit(repoDir, [
+        "config",
+        "branch.feature/configured-pr-base.gh-merge-base",
+        "release",
+      ]);
+
+      const { manager } = yield* makeManager();
+      const status = yield* manager.status({ cwd: repoDir });
+
+      expect(status.configuredPrBaseBranch).toBe("release");
+    }),
+  );
+
   it.effect("resolves a captured branch PR after the checkout has moved elsewhere", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("synara-git-manager-");

--- a/apps/server/src/git/Layers/GitManager.ts
+++ b/apps/server/src/git/Layers/GitManager.ts
@@ -1388,11 +1388,6 @@ export const makeGitManager = Effect.gen(function* () {
   const status: GitManagerShape["status"] = Effect.fnUntraced(function* (input) {
     const details = yield* gitCore.statusDetails(input.cwd);
 
-    const configuredPrBaseBranch =
-      details.branch === null
-        ? null
-        : yield* gitCore.readConfigValue(input.cwd, `branch.${details.branch}.gh-merge-base`);
-
     const pr =
       details.branch !== null
         ? yield* pullRequestForBranch({
@@ -1408,7 +1403,7 @@ export const makeGitManager = Effect.gen(function* () {
       workingTree: details.workingTree,
       hasUpstream: details.hasUpstream,
       upstreamBranch: details.upstreamBranch,
-      configuredPrBaseBranch,
+      configuredPrBaseBranch: details.configuredPrBaseBranch,
       aheadCount: details.aheadCount,
       behindCount: details.behindCount,
       pr,

--- a/apps/server/src/git/Layers/GitManager.ts
+++ b/apps/server/src/git/Layers/GitManager.ts
@@ -1388,6 +1388,11 @@ export const makeGitManager = Effect.gen(function* () {
   const status: GitManagerShape["status"] = Effect.fnUntraced(function* (input) {
     const details = yield* gitCore.statusDetails(input.cwd);
 
+    const configuredPrBaseBranch =
+      details.branch === null
+        ? null
+        : yield* gitCore.readConfigValue(input.cwd, `branch.${details.branch}.gh-merge-base`);
+
     const pr =
       details.branch !== null
         ? yield* pullRequestForBranch({
@@ -1403,6 +1408,7 @@ export const makeGitManager = Effect.gen(function* () {
       workingTree: details.workingTree,
       hasUpstream: details.hasUpstream,
       upstreamBranch: details.upstreamBranch,
+      configuredPrBaseBranch,
       aheadCount: details.aheadCount,
       behindCount: details.behindCount,
       pr,

--- a/apps/server/src/git/Layers/GitManager.ts
+++ b/apps/server/src/git/Layers/GitManager.ts
@@ -1235,6 +1235,11 @@ export const makeGitManager = Effect.gen(function* () {
     cwd: string,
     fallbackBranch: string | null,
     textGenerationParams?: GitTextGenerationParams,
+    prOptions?: {
+      readonly title?: string | undefined;
+      readonly body?: string | undefined;
+      readonly draft?: boolean | undefined;
+    },
   ) =>
     Effect.gen(function* () {
       const details = yield* gitCore.statusDetails(cwd);
@@ -1276,38 +1281,45 @@ export const makeGitManager = Effect.gen(function* () {
           `Cannot create a pull request from '${headContext.headBranch}' into itself. Create or switch to a feature branch and retry.`,
         );
       }
-      const rangeContext = yield* gitCore.readRangeContext(cwd, baseBranch);
-      const originRemoteUrl = headContext.isCrossRepository
-        ? yield* readConfigValueNullable(cwd, "remote.origin.url")
-        : null;
-      const targetRemoteName = headContext.isCrossRepository
-        ? originRemoteUrl
-          ? "origin"
-          : null
-        : headContext.remoteName;
-      const remoteBaseRef = targetRemoteName
-        ? `refs/remotes/${targetRemoteName}/${baseBranch}`
-        : null;
-      const useRemoteBaseRef = remoteBaseRef !== null && (yield* gitRefExists(cwd, remoteBaseRef));
-      const prTemplateTreeish = useRemoteBaseRef ? remoteBaseRef : baseBranch;
-      const prTemplate = Option.getOrUndefined(
-        yield* detectPrTemplate(cwd, prTemplateTreeish, gitCore.execute),
-      );
+      let prTitle = prOptions?.title;
+      let prBody = prOptions?.body;
+      if (prTitle === undefined || prBody === undefined) {
+        const rangeContext = yield* gitCore.readRangeContext(cwd, baseBranch);
+        const originRemoteUrl = headContext.isCrossRepository
+          ? yield* readConfigValueNullable(cwd, "remote.origin.url")
+          : null;
+        const targetRemoteName = headContext.isCrossRepository
+          ? originRemoteUrl
+            ? "origin"
+            : null
+          : headContext.remoteName;
+        const remoteBaseRef = targetRemoteName
+          ? `refs/remotes/${targetRemoteName}/${baseBranch}`
+          : null;
+        const useRemoteBaseRef =
+          remoteBaseRef !== null && (yield* gitRefExists(cwd, remoteBaseRef));
+        const prTemplateTreeish = useRemoteBaseRef ? remoteBaseRef : baseBranch;
+        const prTemplate = Option.getOrUndefined(
+          yield* detectPrTemplate(cwd, prTemplateTreeish, gitCore.execute),
+        );
 
-      const generated = yield* textGeneration.generatePrContent({
-        cwd,
-        baseBranch,
-        headBranch: headContext.headBranch,
-        commitSummary: limitContext(rangeContext.commitSummary, 20_000),
-        diffSummary: limitContext(rangeContext.diffSummary, 20_000),
-        diffPatch: limitContext(rangeContext.diffPatch, 60_000),
-        ...(prTemplate !== undefined ? { prTemplate } : {}),
-        ...buildGitTextGenerationCallInput(textGenerationParams ?? {}),
-      });
+        const generated = yield* textGeneration.generatePrContent({
+          cwd,
+          baseBranch,
+          headBranch: headContext.headBranch,
+          commitSummary: limitContext(rangeContext.commitSummary, 20_000),
+          diffSummary: limitContext(rangeContext.diffSummary, 20_000),
+          diffPatch: limitContext(rangeContext.diffPatch, 60_000),
+          ...(prTemplate !== undefined ? { prTemplate } : {}),
+          ...buildGitTextGenerationCallInput(textGenerationParams ?? {}),
+        });
+        prTitle ??= generated.title;
+        prBody ??= generated.body;
+      }
 
       const bodyFile = path.join(tempDir, `synara-pr-body-${process.pid}-${randomUUID()}.md`);
       yield* fileSystem
-        .writeFileString(bodyFile, generated.body)
+        .writeFileString(bodyFile, prBody)
         .pipe(
           Effect.mapError((cause) =>
             gitManagerError("runPrStep", "Failed to write pull request body temp file.", cause),
@@ -1318,8 +1330,9 @@ export const makeGitManager = Effect.gen(function* () {
           cwd,
           baseBranch,
           headSelector: headContext.preferredHeadSelector,
-          title: generated.title,
+          title: prTitle,
           bodyFile,
+          ...(prOptions?.draft !== undefined ? { draft: prOptions.draft } : {}),
         })
         .pipe(
           Effect.as(null),
@@ -1348,7 +1361,7 @@ export const makeGitManager = Effect.gen(function* () {
           status: "created" as const,
           baseBranch,
           headBranch: headContext.headBranch,
-          title: generated.title,
+          title: prTitle,
         };
       }
 
@@ -2614,13 +2627,21 @@ The local stash entry was kept for recovery.`,
           phases,
         });
 
-        if (input.action === "push" && initialStatus.hasWorkingTreeChanges) {
+        if (
+          input.action === "push" &&
+          initialStatus.hasWorkingTreeChanges &&
+          !input.allowDirtyWorkingTree
+        ) {
           return yield* gitManagerError(
             "runStackedAction",
             "Commit or stash local changes before pushing.",
           );
         }
-        if (input.action === "create_pr" && initialStatus.hasWorkingTreeChanges) {
+        if (
+          input.action === "create_pr" &&
+          initialStatus.hasWorkingTreeChanges &&
+          !input.allowDirtyWorkingTree
+        ) {
           return yield* gitManagerError(
             "runStackedAction",
             "Commit local changes before creating a PR.",
@@ -2719,7 +2740,11 @@ The local stash entry was kept for recovery.`,
                 Effect.flatMap(() =>
                   Effect.gen(function* () {
                     currentPhase = "pr";
-                    return yield* runPrStep(input.cwd, currentBranch, textGenerationParams);
+                    return yield* runPrStep(input.cwd, currentBranch, textGenerationParams, {
+                      title: input.prTitle,
+                      body: input.prBody,
+                      draft: input.prDraft,
+                    });
                   }),
                 ),
               )

--- a/apps/server/src/git/Layers/GitStatusBroadcaster.test.ts
+++ b/apps/server/src/git/Layers/GitStatusBroadcaster.test.ts
@@ -126,6 +126,41 @@ describe("GitStatusBroadcasterLive", () => {
     );
   });
 
+  it("refreshes the configured PR base while reusing cached remote metadata", async () => {
+    const initialStatus = {
+      ...baseStatus,
+      configuredPrBaseBranch: "main",
+    };
+    const state = {
+      currentDetails: {
+        ...baseDetails,
+        configuredPrBaseBranch: "main",
+      },
+      currentStatus: initialStatus,
+      detailsCalls: 0,
+      statusCalls: 0,
+    };
+
+    await runBroadcasterTest(
+      state,
+      Effect.gen(function* () {
+        const broadcaster = yield* GitStatusBroadcaster;
+
+        const first = yield* broadcaster.getStatus({ cwd: "/repo" });
+        state.currentDetails = {
+          ...baseDetails,
+          configuredPrBaseBranch: "release",
+        };
+        const second = yield* broadcaster.getStatus({ cwd: "/repo" });
+
+        expect(first.configuredPrBaseBranch).toBe("main");
+        expect(second.configuredPrBaseBranch).toBe("release");
+        expect(state.statusCalls).toBe(1);
+        expect(state.detailsCalls).toBe(1);
+      }),
+    );
+  });
+
   it("refreshes full status when cached remote metadata expires", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);

--- a/apps/server/src/git/Services/GitHubCli.ts
+++ b/apps/server/src/git/Services/GitHubCli.ts
@@ -281,6 +281,7 @@ export interface GitHubCliShape {
     readonly headSelector: string;
     readonly title: string;
     readonly bodyFile: string;
+    readonly draft?: boolean;
   }) => Effect.Effect<void, GitHubCliError>;
 
   /**

--- a/apps/server/src/git/gitStatusCache.ts
+++ b/apps/server/src/git/gitStatusCache.ts
@@ -96,7 +96,7 @@ export function splitRemoteStatusDetails(
   return {
     hasUpstream: status.hasUpstream,
     upstreamBranch: status.upstreamBranch,
-    configuredPrBaseBranch: cachedRemote?.configuredPrBaseBranch,
+    configuredPrBaseBranch: status.configuredPrBaseBranch,
     aheadCount: status.aheadCount,
     behindCount: status.behindCount,
     pr: cachedRemote?.pr ?? null,

--- a/apps/server/src/git/gitStatusCache.ts
+++ b/apps/server/src/git/gitStatusCache.ts
@@ -82,6 +82,7 @@ export function splitRemoteStatus(status: GitStatusResult): GitStatusRemoteResul
   return {
     hasUpstream: status.hasUpstream,
     upstreamBranch: status.upstreamBranch,
+    configuredPrBaseBranch: status.configuredPrBaseBranch,
     aheadCount: status.aheadCount,
     behindCount: status.behindCount,
     pr: status.pr,
@@ -95,6 +96,7 @@ export function splitRemoteStatusDetails(
   return {
     hasUpstream: status.hasUpstream,
     upstreamBranch: status.upstreamBranch,
+    configuredPrBaseBranch: cachedRemote?.configuredPrBaseBranch,
     aheadCount: status.aheadCount,
     behindCount: status.behindCount,
     pr: cachedRemote?.pr ?? null,

--- a/apps/server/src/git/testing/fakeGitHubCli.ts
+++ b/apps/server/src/git/testing/fakeGitHubCli.ts
@@ -371,6 +371,7 @@ export function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
             input.title,
             "--body-file",
             input.bodyFile,
+            ...(input.draft === true ? ["--draft"] : []),
           ],
         }).pipe(Effect.asVoid),
       getDefaultBranch: (input) =>

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -9,6 +9,7 @@ import {
   resolveCreatePrActionAvailability,
   resolveCreatePrBrowserPreparation,
   resolveCreatePrDialogExecution,
+  resolveCreatePrDialogRuntimeStatus,
   resolveCreatePrDialogView,
   resolveCreatePrExecution,
   resolveDefaultCreateBranchName,
@@ -1316,6 +1317,46 @@ describe("resolveCreatePrDialogExecution", () => {
       kind: "unavailable",
       hint: "Branch is behind upstream. Pull before creating a PR.",
     });
+  });
+});
+
+describe("resolveCreatePrDialogRuntimeStatus", () => {
+  it("uses a newly dirty live tree instead of a clean post-push snapshot", () => {
+    const postPushStatus = status({ hasWorkingTreeChanges: false, aheadCount: 0 });
+    const liveStatus = status({
+      hasWorkingTreeChanges: true,
+      workingTree: {
+        files: [{ path: "new-edit.ts", insertions: 7, deletions: 2 }],
+        insertions: 7,
+        deletions: 2,
+      },
+    });
+
+    const resolved = resolveCreatePrDialogRuntimeStatus({
+      liveGitStatus: liveStatus,
+      statusOverride: postPushStatus,
+      isDefaultBranch: false,
+      isDefaultBranchOverride: false,
+    });
+
+    assert.strictEqual(resolved.gitStatus, liveStatus);
+    assert.isTrue(resolved.gitStatus?.hasWorkingTreeChanges);
+    assert.isNull(resolved.statusOverride);
+  });
+
+  it("keeps the post-push snapshot only while live status is unavailable", () => {
+    const postPushStatus = status({ hasUpstream: true, aheadCount: 0 });
+
+    const resolved = resolveCreatePrDialogRuntimeStatus({
+      liveGitStatus: null,
+      statusOverride: postPushStatus,
+      isDefaultBranch: true,
+      isDefaultBranchOverride: false,
+    });
+
+    assert.strictEqual(resolved.gitStatus, postPushStatus);
+    assert.strictEqual(resolved.statusOverride, postPushStatus);
+    assert.isFalse(resolved.isDefaultBranch);
   });
 });
 

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -7,6 +7,9 @@ import {
   requiresDefaultBranchConfirmation,
   resolveAutoFeatureBranchName,
   resolveCreatePrActionAvailability,
+  resolveCreatePrBrowserPreparation,
+  resolveCreatePrDialogExecution,
+  resolveCreatePrDialogView,
   resolveCreatePrExecution,
   resolveDefaultCreateBranchName,
   resolveDefaultBranchActionDialogCopy,
@@ -1259,6 +1262,178 @@ describe("resolveCreatePrExecution", () => {
       gitStatus: status({ hasWorkingTreeChanges: true }),
     });
     assert.deepEqual(execution, { kind: "unavailable", hint: "Git action in progress." });
+  });
+});
+
+describe("resolveCreatePrDialogExecution", () => {
+  const baseContext = {
+    isBusy: false,
+    isDefaultBranch: false,
+    hasOriginRemote: true,
+    defaultBranchName: "main",
+  };
+
+  it("keeps the full commit chain when local changes are included", () => {
+    const execution = resolveCreatePrDialogExecution(
+      { ...baseContext, gitStatus: status({ hasWorkingTreeChanges: true }) },
+      true,
+    );
+    assert.deepEqual(execution, { kind: "run_action", action: "commit_push_pr" });
+  });
+
+  it("evaluates a dirty tree as clean when local changes are excluded", () => {
+    const execution = resolveCreatePrDialogExecution(
+      { ...baseContext, gitStatus: status({ hasWorkingTreeChanges: true, aheadCount: 2 }) },
+      false,
+    );
+    assert.deepEqual(execution, { kind: "run_action", action: "create_pr" });
+  });
+
+  it("reports unavailability when excluding changes leaves nothing to include", () => {
+    const execution = resolveCreatePrDialogExecution(
+      {
+        ...baseContext,
+        gitStatus: status({
+          hasWorkingTreeChanges: true,
+          upstreamBranch: "main",
+          aheadCount: 0,
+        }),
+      },
+      false,
+    );
+    assert.deepEqual(execution, {
+      kind: "unavailable",
+      hint: "No branch changes to include in a PR.",
+    });
+  });
+
+  it("keeps blocking states (behind upstream) regardless of the toggle", () => {
+    const execution = resolveCreatePrDialogExecution(
+      { ...baseContext, gitStatus: status({ hasWorkingTreeChanges: true, behindCount: 1 }) },
+      false,
+    );
+    assert.deepEqual(execution, {
+      kind: "unavailable",
+      hint: "Branch is behind upstream. Pull before creating a PR.",
+    });
+  });
+});
+
+describe("resolveCreatePrDialogView", () => {
+  const baseContext = {
+    isBusy: false,
+    isDefaultBranch: false,
+    hasOriginRemote: true,
+    defaultBranchName: "main",
+  };
+
+  it("describes a published feature branch as an existing branch", () => {
+    const view = resolveCreatePrDialogView({ ...baseContext, gitStatus: status() });
+    assert.deepEqual(view, {
+      branchName: "feature/test",
+      baseBranchName: "main",
+      isNewBranch: false,
+      willCreateFeatureBranch: false,
+      showCommitToggle: false,
+      insertions: 0,
+      deletions: 0,
+    });
+  });
+
+  it("describes an unpublished branch as new and surfaces diff stats", () => {
+    const view = resolveCreatePrDialogView({
+      ...baseContext,
+      gitStatus: status({
+        hasWorkingTreeChanges: true,
+        hasUpstream: false,
+        upstreamBranch: null,
+        workingTree: {
+          files: [{ path: "a.ts", insertions: 400, deletions: 41 }],
+          insertions: 400,
+          deletions: 41,
+        },
+      }),
+    });
+    assert.isTrue(view.isNewBranch);
+    assert.isFalse(view.willCreateFeatureBranch);
+    assert.isTrue(view.showCommitToggle);
+    assert.equal(view.insertions, 400);
+    assert.equal(view.deletions, 41);
+  });
+
+  it("plans an auto-named feature branch on the default branch", () => {
+    const view = resolveCreatePrDialogView({
+      ...baseContext,
+      isDefaultBranch: true,
+      gitStatus: status({ branch: "main", upstreamBranch: "main", hasWorkingTreeChanges: true }),
+    });
+    assert.isTrue(view.isNewBranch);
+    assert.isTrue(view.willCreateFeatureBranch);
+  });
+
+  it("falls back to main without a resolved default branch name", () => {
+    const view = resolveCreatePrDialogView({
+      ...baseContext,
+      defaultBranchName: null,
+      gitStatus: null,
+    });
+    assert.equal(view.baseBranchName, "main");
+    assert.isNull(view.branchName);
+  });
+});
+
+describe("resolveCreatePrBrowserPreparation", () => {
+  const baseContext = {
+    isBusy: false,
+    isDefaultBranch: false,
+    hasOriginRemote: true,
+    defaultBranchName: "main",
+  };
+
+  it("commits and pushes (without creating the PR) when local changes are included", () => {
+    const preparation = resolveCreatePrBrowserPreparation(
+      { ...baseContext, gitStatus: status({ hasWorkingTreeChanges: true }) },
+      true,
+    );
+    assert.deepEqual(preparation, { kind: "run_action", action: "commit_push" });
+  });
+
+  it("pushes first when the branch is ahead of upstream", () => {
+    const preparation = resolveCreatePrBrowserPreparation(
+      { ...baseContext, gitStatus: status({ aheadCount: 2 }) },
+      true,
+    );
+    assert.deepEqual(preparation, { kind: "run_action", action: "push" });
+  });
+
+  it("pushes committed work only when local changes are excluded on an ahead branch", () => {
+    const preparation = resolveCreatePrBrowserPreparation(
+      { ...baseContext, gitStatus: status({ hasWorkingTreeChanges: true, aheadCount: 1 }) },
+      false,
+    );
+    assert.deepEqual(preparation, { kind: "run_action", action: "push" });
+  });
+
+  it("opens the compare page directly for a clean published branch", () => {
+    const preparation = resolveCreatePrBrowserPreparation(
+      { ...baseContext, gitStatus: status() },
+      true,
+    );
+    assert.deepEqual(preparation, { kind: "open_compare" });
+  });
+
+  it("passes through open-PR and unavailable outcomes", () => {
+    assert.deepEqual(
+      resolveCreatePrBrowserPreparation(
+        { ...baseContext, gitStatus: status({ pr: statusPr() }) },
+        true,
+      ),
+      { kind: "open_pr" },
+    );
+    assert.deepEqual(resolveCreatePrBrowserPreparation({ ...baseContext, gitStatus: null }, true), {
+      kind: "unavailable",
+      hint: "Git status is unavailable.",
+    });
   });
 });
 

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -7,6 +7,7 @@ import {
   requiresDefaultBranchConfirmation,
   resolveAutoFeatureBranchName,
   resolveCreatePrActionAvailability,
+  resolveCreatePrBaseBranch,
   resolveCreatePrBrowserPreparation,
   resolveCreatePrDialogExecution,
   resolveCreatePrDialogRuntimeStatus,
@@ -1397,6 +1398,30 @@ describe("resolveCreatePrDialogView", () => {
       insertions: 0,
       deletions: 0,
     });
+  });
+
+  it("uses a different tracked upstream as the PR base branch", () => {
+    const gitStatus = status({
+      branch: "feature/test",
+      hasUpstream: true,
+      upstreamBranch: "develop",
+    });
+
+    assert.equal(resolveCreatePrBaseBranch(gitStatus, "main"), "develop");
+    assert.equal(
+      resolveCreatePrDialogView({ ...baseContext, gitStatus }).baseBranchName,
+      "develop",
+    );
+  });
+
+  it("uses the default branch when the tracked upstream is the PR head", () => {
+    assert.equal(
+      resolveCreatePrBaseBranch(
+        status({ branch: "feature/test", upstreamBranch: "feature/test" }),
+        "main",
+      ),
+      "main",
+    );
   });
 
   it("describes an unpublished branch as new and surfaces diff stats", () => {

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -357,6 +357,30 @@ describe("when: branch is clean, up to date, and has no open PR", () => {
     });
   });
 
+  it("resolveCreatePrActionAvailability preserves the resolver's blocked reason", () => {
+    const availability = resolveCreatePrActionAvailability({
+      gitStatus: status({ aheadCount: 1, behindCount: 1 }),
+      defaultBranchName: "main",
+    });
+
+    assert.deepEqual(availability, {
+      canRun: false,
+      hint: "Branch has diverged from upstream. Rebase/merge first.",
+    });
+  });
+
+  it("resolveCreatePrActionAvailability explains why literal create_pr cannot run dirty", () => {
+    const availability = resolveCreatePrActionAvailability({
+      gitStatus: status({ hasWorkingTreeChanges: true }),
+      defaultBranchName: "main",
+    });
+
+    assert.deepEqual(availability, {
+      canRun: false,
+      hint: "Commit local changes before creating a PR.",
+    });
+  });
+
   it("buildMenuItems disables create PR when the branch tracks the default branch", () => {
     const items = buildMenuItems(
       status({
@@ -1411,6 +1435,21 @@ describe("resolveCreatePrDialogView", () => {
     assert.equal(
       resolveCreatePrDialogView({ ...baseContext, gitStatus }).baseBranchName,
       "develop",
+    );
+  });
+
+  it("prefers the configured PR merge base over the tracked upstream", () => {
+    const gitStatus = status({
+      branch: "feature/test",
+      hasUpstream: true,
+      upstreamBranch: "develop",
+      configuredPrBaseBranch: "release",
+    });
+
+    assert.equal(resolveCreatePrBaseBranch(gitStatus, "main"), "release");
+    assert.equal(
+      resolveCreatePrDialogView({ ...baseContext, gitStatus }).baseBranchName,
+      "release",
     );
   });
 

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -1335,6 +1335,7 @@ describe("resolveCreatePrDialogRuntimeStatus", () => {
     const resolved = resolveCreatePrDialogRuntimeStatus({
       liveGitStatus: liveStatus,
       statusOverride: postPushStatus,
+      statusOverrideSource: status(),
       isDefaultBranch: false,
       isDefaultBranchOverride: false,
     });
@@ -1344,12 +1345,14 @@ describe("resolveCreatePrDialogRuntimeStatus", () => {
     assert.isNull(resolved.statusOverride);
   });
 
-  it("keeps the post-push snapshot only while live status is unavailable", () => {
+  it("keeps the post-push snapshot while the cache still returns its source object", () => {
+    const stalePrePushStatus = status({ aheadCount: 2 });
     const postPushStatus = status({ hasUpstream: true, aheadCount: 0 });
 
     const resolved = resolveCreatePrDialogRuntimeStatus({
-      liveGitStatus: null,
+      liveGitStatus: stalePrePushStatus,
       statusOverride: postPushStatus,
+      statusOverrideSource: stalePrePushStatus,
       isDefaultBranch: true,
       isDefaultBranchOverride: false,
     });
@@ -1357,6 +1360,21 @@ describe("resolveCreatePrDialogRuntimeStatus", () => {
     assert.strictEqual(resolved.gitStatus, postPushStatus);
     assert.strictEqual(resolved.statusOverride, postPushStatus);
     assert.isFalse(resolved.isDefaultBranch);
+  });
+
+  it("keeps the post-push snapshot while live status is unavailable", () => {
+    const postPushStatus = status({ hasUpstream: true, aheadCount: 0 });
+
+    const resolved = resolveCreatePrDialogRuntimeStatus({
+      liveGitStatus: null,
+      statusOverride: postPushStatus,
+      statusOverrideSource: status({ aheadCount: 2 }),
+      isDefaultBranch: false,
+      isDefaultBranchOverride: false,
+    });
+
+    assert.strictEqual(resolved.gitStatus, postPushStatus);
+    assert.strictEqual(resolved.statusOverride, postPushStatus);
   });
 });
 

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -7,6 +7,7 @@ import {
   requiresDefaultBranchConfirmation,
   resolveAutoFeatureBranchName,
   resolveCreatePrActionAvailability,
+  resolveCreatePrExecution,
   resolveDefaultCreateBranchName,
   resolveDefaultBranchActionDialogCopy,
   resolveLiveThreadBranchUpdate,
@@ -596,7 +597,7 @@ describe("when: working tree has local changes", () => {
     });
   });
 
-  it("buildMenuItems enables commit and disables push and PR", () => {
+  it("buildMenuItems enables commit and create PR while push stays disabled", () => {
     const items = buildMenuItems(status({ hasWorkingTreeChanges: true }), false);
     assert.deepEqual(items, [
       {
@@ -626,7 +627,7 @@ describe("when: working tree has local changes", () => {
       {
         id: "pr",
         label: "Create PR",
-        disabled: true,
+        disabled: false,
         icon: "pr",
         kind: "open_dialog",
         dialogAction: "create_pr",
@@ -664,7 +665,7 @@ describe("when: on default branch without open PR", () => {
     });
   });
 
-  it("buildMenuItems enables commit-and-push row when local changes exist on default branch", () => {
+  it("buildMenuItems enables commit-and-push and create PR when local changes exist on default branch", () => {
     const items = buildMenuItems(
       status({ branch: "main", hasWorkingTreeChanges: true, aheadCount: 0, pr: null }),
       false,
@@ -691,7 +692,7 @@ describe("when: on default branch without open PR", () => {
       {
         id: "pr",
         label: "Create PR",
-        disabled: true,
+        disabled: false,
         icon: "pr",
         kind: "open_dialog",
         dialogAction: "create_pr",
@@ -1131,6 +1132,133 @@ describe("when: branch has no upstream configured", () => {
         dialogAction: "create_pr",
       },
     ]);
+  });
+});
+
+describe("resolveCreatePrExecution", () => {
+  const baseInput = {
+    isBusy: false,
+    isDefaultBranch: false,
+    hasOriginRemote: true,
+    defaultBranchName: "main",
+  };
+
+  it("runs the full commit+push+PR chain when the working tree is dirty", () => {
+    const execution = resolveCreatePrExecution({
+      ...baseInput,
+      gitStatus: status({ hasWorkingTreeChanges: true }),
+    });
+    assert.deepEqual(execution, { kind: "run_action", action: "commit_push_pr" });
+  });
+
+  it("runs the commit chain even when the dirty branch has no upstream yet", () => {
+    const execution = resolveCreatePrExecution({
+      ...baseInput,
+      gitStatus: status({ hasWorkingTreeChanges: true, hasUpstream: false, upstreamBranch: null }),
+    });
+    assert.deepEqual(execution, { kind: "run_action", action: "commit_push_pr" });
+  });
+
+  it("runs the commit chain on the default branch so the caller can confirm a feature branch", () => {
+    const execution = resolveCreatePrExecution({
+      ...baseInput,
+      isDefaultBranch: true,
+      gitStatus: status({ branch: "main", hasWorkingTreeChanges: true }),
+    });
+    assert.deepEqual(execution, { kind: "run_action", action: "commit_push_pr" });
+  });
+
+  it("runs push+PR when the branch is clean but ahead", () => {
+    const execution = resolveCreatePrExecution({
+      ...baseInput,
+      gitStatus: status({ aheadCount: 2 }),
+    });
+    assert.deepEqual(execution, { kind: "run_action", action: "create_pr" });
+  });
+
+  it("runs create PR for a clean published feature branch", () => {
+    const execution = resolveCreatePrExecution({
+      ...baseInput,
+      gitStatus: status({ aheadCount: 0 }),
+    });
+    assert.deepEqual(execution, { kind: "run_action", action: "create_pr" });
+  });
+
+  it("opens the existing PR instead of creating a new one", () => {
+    const execution = resolveCreatePrExecution({
+      ...baseInput,
+      gitStatus: status({ hasWorkingTreeChanges: true, pr: statusPr() }),
+    });
+    assert.deepEqual(execution, { kind: "open_pr" });
+  });
+
+  it("stays unavailable when the branch is behind upstream, even with local changes", () => {
+    const execution = resolveCreatePrExecution({
+      ...baseInput,
+      gitStatus: status({ hasWorkingTreeChanges: true, behindCount: 1 }),
+    });
+    assert.deepEqual(execution, {
+      kind: "unavailable",
+      hint: "Branch is behind upstream. Pull before creating a PR.",
+    });
+  });
+
+  it("stays unavailable when the branch has diverged from upstream", () => {
+    const execution = resolveCreatePrExecution({
+      ...baseInput,
+      gitStatus: status({ aheadCount: 2, behindCount: 1 }),
+    });
+    assert.deepEqual(execution, {
+      kind: "unavailable",
+      hint: "Branch has diverged from upstream. Rebase/merge first.",
+    });
+  });
+
+  it("stays unavailable without an origin remote", () => {
+    const execution = resolveCreatePrExecution({
+      ...baseInput,
+      hasOriginRemote: false,
+      gitStatus: status({ hasWorkingTreeChanges: true, hasUpstream: false, upstreamBranch: null }),
+    });
+    assert.deepEqual(execution, {
+      kind: "unavailable",
+      hint: 'Add an "origin" remote before creating a PR.',
+    });
+  });
+
+  it("stays unavailable on a detached HEAD", () => {
+    const execution = resolveCreatePrExecution({
+      ...baseInput,
+      gitStatus: status({ branch: null }),
+    });
+    assert.deepEqual(execution, {
+      kind: "unavailable",
+      hint: "Detached HEAD: checkout a branch before creating a PR.",
+    });
+  });
+
+  it("stays unavailable when a clean branch only tracks the default branch", () => {
+    const execution = resolveCreatePrExecution({
+      ...baseInput,
+      gitStatus: status({
+        branch: "synara/pi-cleanup",
+        upstreamBranch: "main",
+        aheadCount: 0,
+      }),
+    });
+    assert.deepEqual(execution, {
+      kind: "unavailable",
+      hint: "No branch changes to include in a PR.",
+    });
+  });
+
+  it("stays unavailable while a git action is running", () => {
+    const execution = resolveCreatePrExecution({
+      ...baseInput,
+      isBusy: true,
+      gitStatus: status({ hasWorkingTreeChanges: true }),
+    });
+    assert.deepEqual(execution, { kind: "unavailable", hint: "Git action in progress." });
   });
 });
 

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -188,6 +188,39 @@ export interface CreatePrDialogContext {
   defaultBranchName?: string | null | undefined;
 }
 
+export interface CreatePrDialogRuntimeStatus {
+  gitStatus: GitStatusResult | null;
+  isDefaultBranch: boolean;
+  statusOverride: GitStatusResult | null;
+}
+
+/**
+ * A post-push toast carries a synthetic status so its CTA can open even when
+ * the query cache still reflects the pre-push branch. Once live status is
+ * available, it must win: the working tree or branch may have changed while
+ * the dialog was open. The synthetic snapshot remains only as a temporary
+ * fallback while live status is unavailable.
+ */
+export function resolveCreatePrDialogRuntimeStatus(input: {
+  liveGitStatus: GitStatusResult | null;
+  statusOverride: GitStatusResult | null;
+  isDefaultBranch: boolean;
+  isDefaultBranchOverride: boolean | null;
+}): CreatePrDialogRuntimeStatus {
+  if (input.liveGitStatus) {
+    return {
+      gitStatus: input.liveGitStatus,
+      isDefaultBranch: input.isDefaultBranch,
+      statusOverride: null,
+    };
+  }
+  return {
+    gitStatus: input.statusOverride,
+    isDefaultBranch: input.isDefaultBranchOverride ?? input.isDefaultBranch,
+    statusOverride: input.statusOverride,
+  };
+}
+
 /**
  * Execution for the Create PR dialog, honoring the "Commit and push local
  * changes" toggle: with the toggle off a dirty tree is evaluated as if it were

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -196,18 +196,21 @@ export interface CreatePrDialogRuntimeStatus {
 
 /**
  * A post-push toast carries a synthetic status so its CTA can open even when
- * the query cache still reflects the pre-push branch. Once live status is
- * available, it must win: the working tree or branch may have changed while
- * the dialog was open. The synthetic snapshot remains only as a temporary
- * fallback while live status is unavailable.
+ * the query cache still reflects the pre-push branch. Preserve that exact
+ * stale object as a freshness marker: the synthetic snapshot wins while the
+ * cache still returns it, then a newly fetched live object takes over so later
+ * working-tree or branch changes are reflected by the dialog.
  */
 export function resolveCreatePrDialogRuntimeStatus(input: {
   liveGitStatus: GitStatusResult | null;
   statusOverride: GitStatusResult | null;
+  statusOverrideSource: GitStatusResult | null;
   isDefaultBranch: boolean;
   isDefaultBranchOverride: boolean | null;
 }): CreatePrDialogRuntimeStatus {
-  if (input.liveGitStatus) {
+  const liveStatusIsKnownStale =
+    input.liveGitStatus !== null && input.liveGitStatus === input.statusOverrideSource;
+  if (input.liveGitStatus && !liveStatusIsKnownStale) {
     return {
       gitStatus: input.liveGitStatus,
       isDefaultBranch: input.isDefaultBranch,

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -170,6 +170,17 @@ function extractTrackedBranchName(upstreamBranch: string | null | undefined): st
   return branchName.length > 0 ? branchName : null;
 }
 
+export function resolveCreatePrBaseBranch(
+  gitStatus: GitStatusResult | null,
+  defaultBranchName?: string | null,
+): string {
+  const trackedBranchName = extractTrackedBranchName(gitStatus?.upstreamBranch);
+  if (gitStatus?.hasUpstream && trackedBranchName && trackedBranchName !== gitStatus.branch) {
+    return trackedBranchName;
+  }
+  return defaultBranchName ?? "main";
+}
+
 function tracksDefaultUpstream(
   gitStatus: GitStatusResult,
   defaultBranchName?: string | null,
@@ -261,7 +272,7 @@ export function resolveCreatePrDialogView(context: CreatePrDialogContext): Creat
   const gitStatus = context.gitStatus;
   return {
     branchName: gitStatus?.branch ?? null,
-    baseBranchName: context.defaultBranchName ?? "main",
+    baseBranchName: resolveCreatePrBaseBranch(gitStatus, context.defaultBranchName),
     isNewBranch: context.isDefaultBranch || gitStatus?.hasUpstream !== true,
     willCreateFeatureBranch: context.isDefaultBranch,
     showCommitToggle: gitStatus?.hasWorkingTreeChanges === true,

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -174,6 +174,9 @@ export function resolveCreatePrBaseBranch(
   gitStatus: GitStatusResult | null,
   defaultBranchName?: string | null,
 ): string {
+  if (gitStatus?.configuredPrBaseBranch) {
+    return gitStatus.configuredPrBaseBranch;
+  }
   const trackedBranchName = extractTrackedBranchName(gitStatus?.upstreamBranch);
   if (gitStatus?.hasUpstream && trackedBranchName && trackedBranchName !== gitStatus.branch) {
     return trackedBranchName;
@@ -601,10 +604,21 @@ export function resolveCreatePrActionAvailability(input: {
     defaultBranchName: input.defaultBranchName,
   });
   const canRun = execution.kind === "run_action" && execution.action === "create_pr";
+  const hint = (() => {
+    if (canRun) return null;
+    if (execution.kind === "unavailable") return execution.hint;
+    if (execution.kind === "open_pr") {
+      return "A pull request is already open for this branch.";
+    }
+    if (execution.kind === "run_action" && execution.action === "commit_push_pr") {
+      return "Commit local changes before creating a PR.";
+    }
+    return CREATE_PR_UNAVAILABLE_HINT;
+  })();
 
   return {
     canRun,
-    hint: canRun ? null : CREATE_PR_UNAVAILABLE_HINT,
+    hint,
   };
 }
 

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -180,6 +180,86 @@ function tracksDefaultUpstream(
   return FALLBACK_DEFAULT_BRANCH_NAMES.has(trackedBranchName);
 }
 
+export interface CreatePrDialogContext {
+  gitStatus: GitStatusResult | null;
+  isBusy: boolean;
+  isDefaultBranch: boolean;
+  hasOriginRemote: boolean;
+  defaultBranchName?: string | null | undefined;
+}
+
+/**
+ * Execution for the Create PR dialog, honoring the "Commit and push local
+ * changes" toggle: with the toggle off a dirty tree is evaluated as if it were
+ * clean, so the dialog can offer a PR from already-committed work only (and
+ * correctly reports unavailability when nothing is committed).
+ */
+export function resolveCreatePrDialogExecution(
+  context: CreatePrDialogContext,
+  includeLocalChanges: boolean,
+): CreatePrExecution {
+  const { gitStatus } = context;
+  if (!gitStatus || includeLocalChanges || !gitStatus.hasWorkingTreeChanges) {
+    return resolveCreatePrExecution(context);
+  }
+  return resolveCreatePrExecution({
+    ...context,
+    gitStatus: { ...gitStatus, hasWorkingTreeChanges: false },
+  });
+}
+
+export interface CreatePrDialogView {
+  branchName: string | null;
+  baseBranchName: string;
+  // The PR head does not exist on the remote yet: either the current branch is
+  // unpublished or a feature branch will be created off the default branch.
+  isNewBranch: boolean;
+  // Submitting creates an auto-named feature branch first (default-branch flow).
+  willCreateFeatureBranch: boolean;
+  showCommitToggle: boolean;
+  insertions: number;
+  deletions: number;
+}
+
+export function resolveCreatePrDialogView(context: CreatePrDialogContext): CreatePrDialogView {
+  const gitStatus = context.gitStatus;
+  return {
+    branchName: gitStatus?.branch ?? null,
+    baseBranchName: context.defaultBranchName ?? "main",
+    isNewBranch: context.isDefaultBranch || gitStatus?.hasUpstream !== true,
+    willCreateFeatureBranch: context.isDefaultBranch,
+    showCommitToggle: gitStatus?.hasWorkingTreeChanges === true,
+    insertions: gitStatus?.workingTree.insertions ?? 0,
+    deletions: gitStatus?.workingTree.deletions ?? 0,
+  };
+}
+
+export type CreatePrBrowserPreparation =
+  | { kind: "run_action"; action: "commit_push" | "push" }
+  | { kind: "open_compare" }
+  | { kind: "open_pr" }
+  | { kind: "unavailable"; hint: string };
+
+/**
+ * "Open PR in browser" runs only the missing local steps (commit and/or push)
+ * and then opens the GitHub compare page, leaving PR authoring to the browser.
+ */
+export function resolveCreatePrBrowserPreparation(
+  context: CreatePrDialogContext,
+  includeLocalChanges: boolean,
+): CreatePrBrowserPreparation {
+  const execution = resolveCreatePrDialogExecution(context, includeLocalChanges);
+  if (execution.kind !== "run_action") return execution;
+  if (execution.action === "commit_push_pr") {
+    return { kind: "run_action", action: "commit_push" };
+  }
+  const gitStatus = context.gitStatus;
+  if (!gitStatus?.hasUpstream || gitStatus.aheadCount > 0) {
+    return { kind: "run_action", action: "push" };
+  }
+  return { kind: "open_compare" };
+}
+
 export function summarizeGitResult(result: GitRunStackedActionResult): {
   title: string;
   description?: string;

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -108,37 +108,60 @@ export function buildGitActionProgressStages(input: {
 const withDescription = (title: string, description: string | undefined) =>
   description ? { title, description } : { title };
 
-// Shared PR eligibility for explicit menu/CTA paths; the primary quick action ranks separately.
-function canRunCreatePrAction(input: {
+export type CreatePrExecution =
+  | { kind: "run_action"; action: "create_pr" | "commit_push_pr" }
+  | { kind: "open_pr" }
+  | { kind: "unavailable"; hint: string };
+
+/**
+ * Create PR is a "do everything" action: it resolves whichever stacked action
+ * completes the missing steps (commit → push/publish → PR) from the current git
+ * state. Behind/diverged branches stay blocked so a one-click action never has
+ * to auto-resolve merge conflicts; the default branch keeps its confirmation
+ * dialog (handled by the caller) before switching to a feature branch.
+ */
+export function resolveCreatePrExecution(input: {
   gitStatus: GitStatusResult | null;
   isBusy: boolean;
   isDefaultBranch: boolean;
   hasOriginRemote: boolean;
   defaultBranchName?: string | null | undefined;
-}): boolean {
+}): CreatePrExecution {
   const { gitStatus, isBusy, isDefaultBranch, hasOriginRemote, defaultBranchName } = input;
-  if (!gitStatus) return false;
+  if (isBusy) return { kind: "unavailable", hint: "Git action in progress." };
+  if (!gitStatus) return { kind: "unavailable", hint: "Git status is unavailable." };
+  if (gitStatus.pr?.state === "open") return { kind: "open_pr" };
+  if (gitStatus.branch === null) {
+    return { kind: "unavailable", hint: "Detached HEAD: checkout a branch before creating a PR." };
+  }
 
-  const hasBranch = gitStatus.branch !== null;
-  const hasChanges = gitStatus.hasWorkingTreeChanges;
-  const hasOpenPr = gitStatus.pr?.state === "open";
-  const isBehind = gitStatus.behindCount > 0;
-  const canPushWithoutUpstream = hasOriginRemote && !gitStatus.hasUpstream;
+  const isAhead = gitStatus.aheadCount > 0;
+  if (gitStatus.behindCount > 0) {
+    return {
+      kind: "unavailable",
+      hint: isAhead
+        ? "Branch has diverged from upstream. Rebase/merge first."
+        : "Branch is behind upstream. Pull before creating a PR.",
+    };
+  }
+  if (!gitStatus.hasUpstream && !hasOriginRemote) {
+    return { kind: "unavailable", hint: 'Add an "origin" remote before creating a PR.' };
+  }
+
+  if (gitStatus.hasWorkingTreeChanges) {
+    return { kind: "run_action", action: "commit_push_pr" };
+  }
+
   const canCreateCleanPublishedPr =
     !isDefaultBranch &&
     gitStatus.hasUpstream &&
     gitStatus.upstreamBranch !== null &&
     !tracksDefaultUpstream(gitStatus, defaultBranchName);
+  if (isAhead || canCreateCleanPublishedPr) {
+    return { kind: "run_action", action: "create_pr" };
+  }
 
-  return (
-    !isBusy &&
-    hasBranch &&
-    !hasChanges &&
-    !hasOpenPr &&
-    !isBehind &&
-    (canCreateCleanPublishedPr ||
-      (gitStatus.aheadCount > 0 && (gitStatus.hasUpstream || canPushWithoutUpstream)))
-  );
+  return { kind: "unavailable", hint: CREATE_PR_UNAVAILABLE_HINT };
 }
 
 function extractTrackedBranchName(upstreamBranch: string | null | undefined): string | null {
@@ -215,7 +238,7 @@ export function buildMenuItems(
     !isBehind &&
     (hasChanges || gitStatus.aheadCount > 0) &&
     (gitStatus.hasUpstream || canPushWithoutUpstream);
-  const canCreatePr = canRunCreatePrAction({
+  const prExecution = resolveCreatePrExecution({
     gitStatus,
     isBusy,
     isDefaultBranch,
@@ -264,7 +287,7 @@ export function buildMenuItems(
       : {
           id: "pr",
           label: "Create PR",
-          disabled: !canCreatePr,
+          disabled: prExecution.kind !== "run_action",
           icon: "pr",
           kind: "open_dialog",
           dialogAction: "create_pr",
@@ -431,19 +454,26 @@ export function resolveQuickAction(
   };
 }
 
+/**
+ * Availability of the literal `create_pr` stacked action (clean tree required).
+ * Guards stale dispatches from surfaces that resolved their action earlier
+ * (quick action, post-push toast CTA); the menu path resolves the full chain
+ * via resolveCreatePrExecution instead.
+ */
 export function resolveCreatePrActionAvailability(input: {
   gitStatus: GitStatusResult | null;
   isDefaultBranch?: boolean;
   hasOriginRemote?: boolean;
   defaultBranchName?: string | null | undefined;
 }): { canRun: boolean; hint: string | null } {
-  const canRun = canRunCreatePrAction({
+  const execution = resolveCreatePrExecution({
     gitStatus: input.gitStatus,
     isBusy: false,
     isDefaultBranch: input.isDefaultBranch ?? false,
     hasOriginRemote: input.hasOriginRemote ?? true,
     defaultBranchName: input.defaultBranchName,
   });
+  const canRun = execution.kind === "run_action" && execution.action === "create_pr";
 
   return {
     canRun,

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -39,6 +39,7 @@ import {
   resolveDefaultCreateBranchName,
   resolveDefaultBranchActionDialogCopy,
   resolveCreatePrActionAvailability,
+  resolveCreatePrDialogRuntimeStatus,
   resolveCreatePrExecution,
   resolveQuickAction,
   resolvePullActionAvailability,
@@ -1037,22 +1038,30 @@ export default function GitActionsControl({
     ],
   );
 
+  const createPrDialogRuntimeStatus = useMemo(
+    () =>
+      resolveCreatePrDialogRuntimeStatus({
+        liveGitStatus: gitStatusForActions,
+        statusOverride: createPrDialog?.statusOverride ?? null,
+        isDefaultBranch,
+        isDefaultBranchOverride: createPrDialog?.isDefaultBranchOverride ?? null,
+      }),
+    [createPrDialog, gitStatusForActions, isDefaultBranch],
+  );
+
   const handleCreatePrDialogSubmit = useCallback(
     (submission: GitCreatePrDialogSubmission) => {
-      const dialogState = createPrDialog;
       setCreatePrDialog(null);
-      const statusOverride = dialogState?.statusOverride ?? null;
-      const actionStatus = statusOverride ?? gitStatusForActions;
-      const actionIsDefaultBranch = dialogState?.isDefaultBranchOverride ?? isDefaultBranch;
+      const actionStatus = createPrDialogRuntimeStatus.gitStatus;
+      const actionIsDefaultBranch = createPrDialogRuntimeStatus.isDefaultBranch;
       const excludesDirtyChanges =
         !submission.includeLocalChanges && actionStatus?.hasWorkingTreeChanges === true;
       void runGitActionWithToast({
         action: submission.action,
-        ...(statusOverride ? { statusOverride } : {}),
-        ...(dialogState?.isDefaultBranchOverride !== null &&
-        dialogState?.isDefaultBranchOverride !== undefined
-          ? { isDefaultBranchOverride: dialogState.isDefaultBranchOverride }
+        ...(createPrDialogRuntimeStatus.statusOverride
+          ? { statusOverride: createPrDialogRuntimeStatus.statusOverride }
           : {}),
+        isDefaultBranchOverride: actionIsDefaultBranch,
         ...(actionIsDefaultBranch ? { featureBranch: true } : {}),
         skipDefaultBranchPrompt: true,
         ...(submission.title ? { prTitle: submission.title } : {}),
@@ -1061,16 +1070,14 @@ export default function GitActionsControl({
         ...(excludesDirtyChanges ? { allowDirtyWorkingTree: true } : {}),
       });
     },
-    [createPrDialog, gitStatusForActions, isDefaultBranch, runGitActionWithToast],
+    [createPrDialogRuntimeStatus, runGitActionWithToast],
   );
 
   const handleCreatePrDialogBrowser = useCallback(
     (request: GitCreatePrDialogBrowserRequest) => {
-      const dialogState = createPrDialog;
       setCreatePrDialog(null);
-      const statusOverride = dialogState?.statusOverride ?? null;
-      const actionStatus = statusOverride ?? gitStatusForActions;
-      const actionIsDefaultBranch = dialogState?.isDefaultBranchOverride ?? isDefaultBranch;
+      const actionStatus = createPrDialogRuntimeStatus.gitStatus;
+      const actionIsDefaultBranch = createPrDialogRuntimeStatus.isDefaultBranch;
       const preparation = request.preparation;
       if (preparation.kind === "open_pr") {
         void openExistingPr();
@@ -1093,11 +1100,10 @@ export default function GitActionsControl({
         !request.includeLocalChanges && actionStatus?.hasWorkingTreeChanges === true;
       void runGitActionWithToast({
         action: preparation.action,
-        ...(statusOverride ? { statusOverride } : {}),
-        ...(dialogState?.isDefaultBranchOverride !== null &&
-        dialogState?.isDefaultBranchOverride !== undefined
-          ? { isDefaultBranchOverride: dialogState.isDefaultBranchOverride }
+        ...(createPrDialogRuntimeStatus.statusOverride
+          ? { statusOverride: createPrDialogRuntimeStatus.statusOverride }
           : {}),
+        isDefaultBranchOverride: actionIsDefaultBranch,
         ...(actionIsDefaultBranch ? { featureBranch: true } : {}),
         skipDefaultBranchPrompt: true,
         ...(excludesDirtyChanges ? { allowDirtyWorkingTree: true } : {}),
@@ -1109,9 +1115,7 @@ export default function GitActionsControl({
       });
     },
     [
-      createPrDialog,
-      gitStatusForActions,
-      isDefaultBranch,
+      createPrDialogRuntimeStatus,
       openComparePage,
       openExistingPr,
       runGitActionWithToast,
@@ -1121,18 +1125,16 @@ export default function GitActionsControl({
 
   const createPrDialogContext = useMemo<CreatePrDialogContext>(
     () => ({
-      gitStatus: createPrDialog?.statusOverride ?? gitStatusForActions,
+      gitStatus: createPrDialogRuntimeStatus.gitStatus,
       isBusy: isGitActionRunning,
-      isDefaultBranch: createPrDialog?.isDefaultBranchOverride ?? isDefaultBranch,
+      isDefaultBranch: createPrDialogRuntimeStatus.isDefaultBranch,
       hasOriginRemote,
       defaultBranchName,
     }),
     [
-      createPrDialog,
+      createPrDialogRuntimeStatus,
       defaultBranchName,
-      gitStatusForActions,
       hasOriginRemote,
-      isDefaultBranch,
       isGitActionRunning,
     ],
   );

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -37,6 +37,7 @@ import {
   resolveDefaultCreateBranchName,
   resolveDefaultBranchActionDialogCopy,
   resolveCreatePrActionAvailability,
+  resolveCreatePrExecution,
   resolveQuickAction,
   resolvePullActionAvailability,
   shouldShowEnvironmentPanelPullRow,
@@ -178,11 +179,15 @@ function getMenuActionDisabledReason({
   gitStatus,
   isBusy,
   hasOriginRemote,
+  isDefaultBranch,
+  defaultBranchName,
 }: {
   item: GitActionMenuItem;
   gitStatus: GitStatusResult | null;
   isBusy: boolean;
   hasOriginRemote: boolean;
+  isDefaultBranch: boolean;
+  defaultBranchName: string | null;
 }): string | null {
   if (!item.disabled) return null;
   if (isBusy) return "Git action in progress.";
@@ -239,20 +244,15 @@ function getMenuActionDisabledReason({
   if (hasOpenPr) {
     return "View PR is currently unavailable.";
   }
-  if (!hasBranch) {
-    return "Detached HEAD: checkout a branch before creating a PR.";
-  }
-  if (hasChanges) {
-    return "Commit local changes before creating a PR.";
-  }
-  if (!gitStatus.hasUpstream && !hasOriginRemote) {
-    return 'Add an "origin" remote before creating a PR.';
-  }
-  if (!isAhead) {
-    return "No local commits to include in a PR.";
-  }
-  if (isBehind) {
-    return "Branch is behind upstream. Pull/rebase before creating a PR.";
+  const prExecution = resolveCreatePrExecution({
+    gitStatus,
+    isBusy,
+    isDefaultBranch,
+    hasOriginRemote,
+    defaultBranchName,
+  });
+  if (prExecution.kind === "unavailable") {
+    return prExecution.hint;
   }
   return "Create PR is currently unavailable.";
 }
@@ -1140,12 +1140,45 @@ export default function GitActionsControl({
         return;
       }
       if (item.dialogAction === "create_pr") {
-        void runGitActionWithToast({ action: "create_pr" });
+        // Create PR runs the whole missing chain: resolve which stacked action
+        // covers the current git state (commit_push_pr on a dirty tree,
+        // create_pr when clean but unpushed/unpublished).
+        const execution = resolveCreatePrExecution({
+          gitStatus: gitStatusForActions,
+          isBusy: isGitActionRunning,
+          isDefaultBranch,
+          hasOriginRemote,
+          defaultBranchName,
+        });
+        if (execution.kind === "open_pr") {
+          void openExistingPr();
+          return;
+        }
+        if (execution.kind === "run_action") {
+          void runGitActionWithToast({ action: execution.action });
+          return;
+        }
+        toastManager.add({
+          type: "info",
+          title: "Create PR unavailable",
+          description: execution.hint,
+          data: threadToastData,
+        });
         return;
       }
       openCommitDialog();
     },
-    [openCommitDialog, openExistingPr, runGitActionWithToast],
+    [
+      defaultBranchName,
+      gitStatusForActions,
+      hasOriginRemote,
+      isDefaultBranch,
+      isGitActionRunning,
+      openCommitDialog,
+      openExistingPr,
+      runGitActionWithToast,
+      threadToastData,
+    ],
   );
 
   useEffect(() => {
@@ -1181,6 +1214,8 @@ export default function GitActionsControl({
           gitStatus: gitStatusForActions,
           isBusy: isGitActionRunning,
           hasOriginRemote,
+          isDefaultBranch,
+          defaultBranchName,
         }),
         icon: "commit",
         onSelect: () => openDialogForMenuItem(commitMenuItem),
@@ -1197,6 +1232,8 @@ export default function GitActionsControl({
           gitStatus: gitStatusForActions,
           isBusy: isGitActionRunning,
           hasOriginRemote,
+          isDefaultBranch,
+          defaultBranchName,
         }),
         icon: "push",
         onSelect: () => openDialogForMenuItem(commitPushMenuItem),
@@ -1222,6 +1259,8 @@ export default function GitActionsControl({
           gitStatus: gitStatusForActions,
           isBusy: isGitActionRunning,
           hasOriginRemote,
+          isDefaultBranch,
+          defaultBranchName,
         }),
         icon: "push",
         onSelect: () => openDialogForMenuItem(pushMenuItem),
@@ -1238,6 +1277,8 @@ export default function GitActionsControl({
           gitStatus: gitStatusForActions,
           isBusy: isGitActionRunning,
           hasOriginRemote,
+          isDefaultBranch,
+          defaultBranchName,
         }),
         icon: "pr",
         onSelect: () => openDialogForMenuItem(prMenuItem),
@@ -1259,9 +1300,11 @@ export default function GitActionsControl({
 
     return items;
   }, [
+    defaultBranchName,
     gitActionMenuItems,
     gitStatusForActions,
     hasOriginRemote,
+    isDefaultBranch,
     isGitActionRunning,
     openCreateBranchDialog,
     openDialogForMenuItem,

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -169,6 +169,7 @@ interface RunGitActionWithToastInput {
 // against the live status".
 interface CreatePrDialogState {
   statusOverride: GitStatusResult | null;
+  statusOverrideSource: GitStatusResult | null;
   isDefaultBranchOverride: boolean | null;
 }
 
@@ -683,7 +684,11 @@ export default function GitActionsControl({
   // PR can be created, opens the existing PR when one is already open, and
   // explains unavailability otherwise.
   const openCreatePrDialog = useCallback(
-    (input?: { statusOverride?: GitStatusResult | null; isDefaultBranchOverride?: boolean }) => {
+    (input?: {
+      statusOverride?: GitStatusResult | null;
+      statusOverrideSource?: GitStatusResult | null;
+      isDefaultBranchOverride?: boolean;
+    }) => {
       const execution = resolveCreatePrExecution({
         gitStatus: input?.statusOverride ?? gitStatusForActions,
         isBusy: isGitActionRunning,
@@ -706,6 +711,7 @@ export default function GitActionsControl({
       }
       setCreatePrDialog({
         statusOverride: input?.statusOverride ?? null,
+        statusOverrideSource: input?.statusOverrideSource ?? null,
         isDefaultBranchOverride: input?.isDefaultBranchOverride ?? null,
       });
     },
@@ -1008,6 +1014,7 @@ export default function GitActionsControl({
                         closeResultToast();
                         openCreatePrDialog({
                           statusOverride: postPushStatus,
+                          statusOverrideSource: actionStatus,
                           isDefaultBranchOverride: actionIsDefaultBranch,
                         });
                       },
@@ -1043,6 +1050,7 @@ export default function GitActionsControl({
       resolveCreatePrDialogRuntimeStatus({
         liveGitStatus: gitStatusForActions,
         statusOverride: createPrDialog?.statusOverride ?? null,
+        statusOverrideSource: createPrDialog?.statusOverrideSource ?? null,
         isDefaultBranch,
         isDefaultBranchOverride: createPrDialog?.isDefaultBranchOverride ?? null,
       }),

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1131,12 +1131,7 @@ export default function GitActionsControl({
       hasOriginRemote,
       defaultBranchName,
     }),
-    [
-      createPrDialogRuntimeStatus,
-      defaultBranchName,
-      hasOriginRemote,
-      isGitActionRunning,
-    ],
+    [createPrDialogRuntimeStatus, defaultBranchName, hasOriginRemote, isGitActionRunning],
   );
 
   const continuePendingDefaultBranchAction = useCallback(() => {

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -961,12 +961,13 @@ export default function GitActionsControl({
           !prUrl &&
           result.push.status === "pushed" &&
           !actionIsDefaultBranch &&
-          resolveCreatePrActionAvailability({
+          resolveCreatePrExecution({
             gitStatus: postPushStatus,
+            isBusy: false,
             isDefaultBranch: actionIsDefaultBranch,
             hasOriginRemote,
             defaultBranchName,
-          }).canRun;
+          }).kind === "run_action";
         const closeResultToast = () => {
           toastManager.close(resolvedProgressToastId);
         };

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -39,6 +39,7 @@ import {
   resolveDefaultCreateBranchName,
   resolveDefaultBranchActionDialogCopy,
   resolveCreatePrActionAvailability,
+  resolveCreatePrBaseBranch,
   resolveCreatePrDialogRuntimeStatus,
   resolveCreatePrExecution,
   resolveQuickAction,
@@ -727,7 +728,7 @@ export default function GitActionsControl({
   );
 
   const openComparePage = useCallback(
-    async (headBranch: string | null) => {
+    async (headBranch: string | null, baseBranch: string) => {
       const api = readNativeApi();
       if (!api || !gitCwd || !headBranch) {
         toastManager.add({
@@ -749,7 +750,6 @@ export default function GitActionsControl({
           });
           return;
         }
-        const baseBranch = defaultBranchName ?? "main";
         await api.shell.openExternal(
           `${repoUrl}/compare/${encodeBranchForCompareUrl(baseBranch)}...${encodeBranchForCompareUrl(headBranch)}?expand=1`,
         );
@@ -762,7 +762,7 @@ export default function GitActionsControl({
         });
       }
     },
-    [defaultBranchName, gitCwd, threadToastData],
+    [gitCwd, threadToastData],
   );
 
   const runSyncWithRemote = useCallback(() => {
@@ -1102,7 +1102,10 @@ export default function GitActionsControl({
         return;
       }
       if (preparation.kind === "open_compare") {
-        void openComparePage(actionStatus?.branch ?? null);
+        void openComparePage(
+          actionStatus?.branch ?? null,
+          resolveCreatePrBaseBranch(actionStatus, defaultBranchName),
+        );
         return;
       }
       const excludesDirtyChanges =
@@ -1119,12 +1122,14 @@ export default function GitActionsControl({
         afterSuccess: (result) => {
           void openComparePage(
             result.push.branch ?? result.branch.name ?? actionStatus?.branch ?? null,
+            resolveCreatePrBaseBranch(actionStatus, defaultBranchName),
           );
         },
       });
     },
     [
       createPrDialogRuntimeStatus,
+      defaultBranchName,
       openComparePage,
       openExistingPr,
       runGitActionWithToast,

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -6,6 +6,7 @@
 import { DEFAULT_GIT_TEXT_GENERATION_MODEL } from "@synara/contracts";
 import type {
   GitActionProgressEvent,
+  GitRunStackedActionResult,
   GitStackedAction,
   GitStatusResult,
   ModelSelection,
@@ -27,6 +28,7 @@ import { GitHubIcon } from "./Icons";
 import {
   buildGitActionProgressStages,
   buildMenuItems,
+  type CreatePrDialogContext,
   type GitActionMenuItem,
   type GitActionIconName,
   type GitQuickAction,
@@ -44,6 +46,11 @@ import {
   shouldOfferCreateBranchPrompt,
   summarizeGitResult,
 } from "./GitActionsControl.logic";
+import {
+  GitCreatePrDialog,
+  type GitCreatePrDialogBrowserRequest,
+  type GitCreatePrDialogSubmission,
+} from "./GitCreatePrDialog";
 import { getProviderStartOptions, useAppSettings } from "~/appSettings";
 import { formatClockDuration } from "~/session-logic";
 import { Button } from "~/components/ui/button";
@@ -149,6 +156,19 @@ interface RunGitActionWithToastInput {
   isDefaultBranchOverride?: boolean;
   progressToastId?: GitActionToastId;
   filePaths?: string[];
+  prTitle?: string;
+  prBody?: string;
+  prDraft?: boolean;
+  allowDirtyWorkingTree?: boolean;
+  afterSuccess?: (result: GitRunStackedActionResult) => void;
+}
+
+// Overrides captured when the Create PR dialog opens from a surface with a
+// pre-resolved git status (e.g. the post-push toast CTA); null means "open
+// against the live status".
+interface CreatePrDialogState {
+  statusOverride: GitStatusResult | null;
+  isDefaultBranchOverride: boolean | null;
 }
 
 interface GitPickerMenuItem {
@@ -158,6 +178,11 @@ interface GitPickerMenuItem {
   disabledReason: string | null;
   icon: GitActionIconName | "sync" | "branch";
   onSelect: () => void;
+}
+
+// Keep "/" literal in branch names; GitHub compare URLs expect it unescaped.
+function encodeBranchForCompareUrl(branch: string): string {
+  return branch.split("/").map(encodeURIComponent).join("/");
 }
 
 function formatElapsedDescription(startedAtMs: number | null): string | undefined {
@@ -361,6 +386,7 @@ export default function GitActionsControl({
     useState<PendingDefaultBranchAction | null>(null);
   const [isCreateBranchDialogOpen, setIsCreateBranchDialogOpen] = useState(false);
   const [createBranchName, setCreateBranchName] = useState("");
+  const [createPrDialog, setCreatePrDialog] = useState<CreatePrDialogState | null>(null);
   const activeGitActionProgressRef = useRef<ActiveGitActionProgress | null>(null);
 
   const updateActiveProgressToast = useCallback(() => {
@@ -652,6 +678,86 @@ export default function GitActionsControl({
     });
   }, [gitStatusForActions, threadToastData]);
 
+  // Single entry point for every "Create PR" surface: opens the PR dialog when a
+  // PR can be created, opens the existing PR when one is already open, and
+  // explains unavailability otherwise.
+  const openCreatePrDialog = useCallback(
+    (input?: { statusOverride?: GitStatusResult | null; isDefaultBranchOverride?: boolean }) => {
+      const execution = resolveCreatePrExecution({
+        gitStatus: input?.statusOverride ?? gitStatusForActions,
+        isBusy: isGitActionRunning,
+        isDefaultBranch: input?.isDefaultBranchOverride ?? isDefaultBranch,
+        hasOriginRemote,
+        defaultBranchName,
+      });
+      if (execution.kind === "open_pr") {
+        void openExistingPr();
+        return;
+      }
+      if (execution.kind === "unavailable") {
+        toastManager.add({
+          type: "info",
+          title: "Create PR unavailable",
+          description: execution.hint,
+          data: threadToastData,
+        });
+        return;
+      }
+      setCreatePrDialog({
+        statusOverride: input?.statusOverride ?? null,
+        isDefaultBranchOverride: input?.isDefaultBranchOverride ?? null,
+      });
+    },
+    [
+      defaultBranchName,
+      gitStatusForActions,
+      hasOriginRemote,
+      isDefaultBranch,
+      isGitActionRunning,
+      openExistingPr,
+      threadToastData,
+    ],
+  );
+
+  const openComparePage = useCallback(
+    async (headBranch: string | null) => {
+      const api = readNativeApi();
+      if (!api || !gitCwd || !headBranch) {
+        toastManager.add({
+          type: "error",
+          title: "Unable to open compare page.",
+          data: threadToastData,
+        });
+        return;
+      }
+      try {
+        const repoResult = await api.git.githubRepository({ cwd: gitCwd });
+        const repoUrl = repoResult.repository?.url ?? null;
+        if (!repoUrl) {
+          toastManager.add({
+            type: "error",
+            title: "Unable to open compare page",
+            description: "No GitHub repository detected for this project.",
+            data: threadToastData,
+          });
+          return;
+        }
+        const baseBranch = defaultBranchName ?? "main";
+        await api.shell.openExternal(
+          `${repoUrl}/compare/${encodeBranchForCompareUrl(baseBranch)}...${encodeBranchForCompareUrl(headBranch)}?expand=1`,
+        );
+      } catch (error) {
+        toastManager.add({
+          type: "error",
+          title: "Unable to open compare page",
+          description: error instanceof Error ? error.message : "An error occurred.",
+          data: threadToastData,
+        });
+      }
+    },
+    [defaultBranchName, gitCwd, threadToastData],
+  );
+
   const runSyncWithRemote = useCallback(() => {
     const promise = pullMutation.mutateAsync();
     toastManager.promise(promise, {
@@ -685,6 +791,11 @@ export default function GitActionsControl({
       isDefaultBranchOverride,
       progressToastId,
       filePaths,
+      prTitle,
+      prBody,
+      prDraft,
+      allowDirtyWorkingTree,
+      afterSuccess,
     }: RunGitActionWithToastInput) {
       const forcePushOnlyProgress = forcePushOnlyProgressProp ?? false;
       const skipDefaultBranchPrompt = skipDefaultBranchPromptProp ?? false;
@@ -717,7 +828,7 @@ export default function GitActionsControl({
         });
         return;
       }
-      if (action === "create_pr" && !featureBranch) {
+      if (action === "create_pr" && !featureBranch && !allowDirtyWorkingTree) {
         const createPrAvailability = resolveCreatePrActionAvailability({
           gitStatus: actionStatus,
           isDefaultBranch: actionIsDefaultBranch,
@@ -782,6 +893,10 @@ export default function GitActionsControl({
         ...(commitMessage ? { commitMessage } : {}),
         ...(featureBranch ? { featureBranch } : {}),
         ...(filePaths ? { filePaths } : {}),
+        ...(prTitle ? { prTitle } : {}),
+        ...(prBody ? { prBody } : {}),
+        ...(prDraft ? { prDraft } : {}),
+        ...(allowDirtyWorkingTree ? { allowDirtyWorkingTree } : {}),
       });
 
       try {
@@ -890,8 +1005,7 @@ export default function GitActionsControl({
                       children: "Create PR",
                       onClick: () => {
                         closeResultToast();
-                        void runGitActionWithToast({
-                          action: "create_pr",
+                        openCreatePrDialog({
                           statusOverride: postPushStatus,
                           isDefaultBranchOverride: actionIsDefaultBranch,
                         });
@@ -900,6 +1014,7 @@ export default function GitActionsControl({
                   }
                 : {}),
         });
+        afterSuccess?.(result);
       } catch (err) {
         activeGitActionProgressRef.current = null;
         toastManager.update(resolvedProgressToastId, {
@@ -915,9 +1030,110 @@ export default function GitActionsControl({
       gitStatusForActions,
       hasOriginRemote,
       isDefaultBranch,
+      openCreatePrDialog,
       persistThreadPr,
       runImmediateGitActionMutation,
       threadToastData,
+    ],
+  );
+
+  const handleCreatePrDialogSubmit = useCallback(
+    (submission: GitCreatePrDialogSubmission) => {
+      const dialogState = createPrDialog;
+      setCreatePrDialog(null);
+      const statusOverride = dialogState?.statusOverride ?? null;
+      const actionStatus = statusOverride ?? gitStatusForActions;
+      const actionIsDefaultBranch = dialogState?.isDefaultBranchOverride ?? isDefaultBranch;
+      const excludesDirtyChanges =
+        !submission.includeLocalChanges && actionStatus?.hasWorkingTreeChanges === true;
+      void runGitActionWithToast({
+        action: submission.action,
+        ...(statusOverride ? { statusOverride } : {}),
+        ...(dialogState?.isDefaultBranchOverride !== null &&
+        dialogState?.isDefaultBranchOverride !== undefined
+          ? { isDefaultBranchOverride: dialogState.isDefaultBranchOverride }
+          : {}),
+        ...(actionIsDefaultBranch ? { featureBranch: true } : {}),
+        skipDefaultBranchPrompt: true,
+        ...(submission.title ? { prTitle: submission.title } : {}),
+        ...(submission.body ? { prBody: submission.body } : {}),
+        ...(submission.draft ? { prDraft: true } : {}),
+        ...(excludesDirtyChanges ? { allowDirtyWorkingTree: true } : {}),
+      });
+    },
+    [createPrDialog, gitStatusForActions, isDefaultBranch, runGitActionWithToast],
+  );
+
+  const handleCreatePrDialogBrowser = useCallback(
+    (request: GitCreatePrDialogBrowserRequest) => {
+      const dialogState = createPrDialog;
+      setCreatePrDialog(null);
+      const statusOverride = dialogState?.statusOverride ?? null;
+      const actionStatus = statusOverride ?? gitStatusForActions;
+      const actionIsDefaultBranch = dialogState?.isDefaultBranchOverride ?? isDefaultBranch;
+      const preparation = request.preparation;
+      if (preparation.kind === "open_pr") {
+        void openExistingPr();
+        return;
+      }
+      if (preparation.kind === "unavailable") {
+        toastManager.add({
+          type: "info",
+          title: "Create PR unavailable",
+          description: preparation.hint,
+          data: threadToastData,
+        });
+        return;
+      }
+      if (preparation.kind === "open_compare") {
+        void openComparePage(actionStatus?.branch ?? null);
+        return;
+      }
+      const excludesDirtyChanges =
+        !request.includeLocalChanges && actionStatus?.hasWorkingTreeChanges === true;
+      void runGitActionWithToast({
+        action: preparation.action,
+        ...(statusOverride ? { statusOverride } : {}),
+        ...(dialogState?.isDefaultBranchOverride !== null &&
+        dialogState?.isDefaultBranchOverride !== undefined
+          ? { isDefaultBranchOverride: dialogState.isDefaultBranchOverride }
+          : {}),
+        ...(actionIsDefaultBranch ? { featureBranch: true } : {}),
+        skipDefaultBranchPrompt: true,
+        ...(excludesDirtyChanges ? { allowDirtyWorkingTree: true } : {}),
+        afterSuccess: (result) => {
+          void openComparePage(
+            result.push.branch ?? result.branch.name ?? actionStatus?.branch ?? null,
+          );
+        },
+      });
+    },
+    [
+      createPrDialog,
+      gitStatusForActions,
+      isDefaultBranch,
+      openComparePage,
+      openExistingPr,
+      runGitActionWithToast,
+      threadToastData,
+    ],
+  );
+
+  const createPrDialogContext = useMemo<CreatePrDialogContext>(
+    () => ({
+      gitStatus: createPrDialog?.statusOverride ?? gitStatusForActions,
+      isBusy: isGitActionRunning,
+      isDefaultBranch: createPrDialog?.isDefaultBranchOverride ?? isDefaultBranch,
+      hasOriginRemote,
+      defaultBranchName,
+    }),
+    [
+      createPrDialog,
+      defaultBranchName,
+      gitStatusForActions,
+      hasOriginRemote,
+      isDefaultBranch,
+      isGitActionRunning,
     ],
   );
 
@@ -999,10 +1215,17 @@ export default function GitActionsControl({
       return;
     }
     if (quickAction.action) {
+      // PR-creating quick actions go through the Create PR dialog so the user
+      // can review title/description/draft before the chain runs.
+      if (quickAction.action === "create_pr" || quickAction.action === "commit_push_pr") {
+        openCreatePrDialog();
+        return;
+      }
       void runGitActionWithToast({ action: quickAction.action });
     }
   }, [
     openCreateBranchDialog,
+    openCreatePrDialog,
     openExistingPr,
     quickAction,
     runGitActionWithToast,
@@ -1140,45 +1363,12 @@ export default function GitActionsControl({
         return;
       }
       if (item.dialogAction === "create_pr") {
-        // Create PR runs the whole missing chain: resolve which stacked action
-        // covers the current git state (commit_push_pr on a dirty tree,
-        // create_pr when clean but unpushed/unpublished).
-        const execution = resolveCreatePrExecution({
-          gitStatus: gitStatusForActions,
-          isBusy: isGitActionRunning,
-          isDefaultBranch,
-          hasOriginRemote,
-          defaultBranchName,
-        });
-        if (execution.kind === "open_pr") {
-          void openExistingPr();
-          return;
-        }
-        if (execution.kind === "run_action") {
-          void runGitActionWithToast({ action: execution.action });
-          return;
-        }
-        toastManager.add({
-          type: "info",
-          title: "Create PR unavailable",
-          description: execution.hint,
-          data: threadToastData,
-        });
+        openCreatePrDialog();
         return;
       }
       openCommitDialog();
     },
-    [
-      defaultBranchName,
-      gitStatusForActions,
-      hasOriginRemote,
-      isDefaultBranch,
-      isGitActionRunning,
-      openCommitDialog,
-      openExistingPr,
-      runGitActionWithToast,
-      threadToastData,
-    ],
+    [openCommitDialog, openCreatePrDialog, openExistingPr, runGitActionWithToast],
   );
 
   useEffect(() => {
@@ -1421,6 +1611,16 @@ export default function GitActionsControl({
   // The git action dialogs are identical across surfaces; only the trigger differs.
   const gitActionDialogs = (
     <>
+      <GitCreatePrDialog
+        open={createPrDialog !== null}
+        onOpenChange={(open) => {
+          if (!open) setCreatePrDialog(null);
+        }}
+        context={createPrDialogContext}
+        onSubmit={handleCreatePrDialogSubmit}
+        onOpenInBrowser={handleCreatePrDialogBrowser}
+      />
+
       <Dialog
         open={isCommitDialogOpen}
         onOpenChange={(open) => {

--- a/apps/web/src/components/GitCreatePrDialog.tsx
+++ b/apps/web/src/components/GitCreatePrDialog.tsx
@@ -1,0 +1,209 @@
+// FILE: GitCreatePrDialog.tsx
+// Purpose: Render the Create PR dialog: branch summary, optional PR title/description,
+//          local-changes toggle with diff stats, and create/draft/browser actions.
+// Layer: Header action control
+// Depends on: GitActionsControl.logic resolvers and shared dialog/checkbox/kbd primitives.
+
+import { useEffect, useMemo, useState } from "react";
+import { Checkbox } from "~/components/ui/checkbox";
+import {
+  Dialog,
+  DialogDescription,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "~/components/ui/dialog";
+import { ShortcutKbd } from "~/components/ui/shortcut-kbd";
+import {
+  type CreatePrBrowserPreparation,
+  type CreatePrDialogContext,
+  resolveCreatePrBrowserPreparation,
+  resolveCreatePrDialogExecution,
+  resolveCreatePrDialogView,
+} from "./GitActionsControl.logic";
+import { cn, isMacPlatform } from "~/lib/utils";
+
+export interface GitCreatePrDialogSubmission {
+  action: "create_pr" | "commit_push_pr";
+  draft: boolean;
+  includeLocalChanges: boolean;
+  title: string | null;
+  body: string | null;
+}
+
+export interface GitCreatePrDialogBrowserRequest {
+  preparation: CreatePrBrowserPreparation;
+  includeLocalChanges: boolean;
+}
+
+interface GitCreatePrDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  context: CreatePrDialogContext;
+  onSubmit: (submission: GitCreatePrDialogSubmission) => void;
+  onOpenInBrowser: (request: GitCreatePrDialogBrowserRequest) => void;
+}
+
+function CreatePrActionRow({
+  highlighted,
+  disabled,
+  onClick,
+  label,
+  trailing,
+}: {
+  highlighted?: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  label: string;
+  trailing?: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-sm outline-none transition-colors",
+        "hover:bg-[var(--color-background-button-secondary-hover)] focus-visible:bg-[var(--color-background-button-secondary-hover)]",
+        highlighted && "bg-[var(--color-background-button-secondary-hover)]",
+        disabled && "pointer-events-none opacity-50",
+      )}
+    >
+      <span className="truncate">{label}</span>
+      {trailing}
+    </button>
+  );
+}
+
+export function GitCreatePrDialog({
+  open,
+  onOpenChange,
+  context,
+  onSubmit,
+  onOpenInBrowser,
+}: GitCreatePrDialogProps) {
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [includeLocalChanges, setIncludeLocalChanges] = useState(true);
+
+  useEffect(() => {
+    if (!open) return;
+    setTitle("");
+    setBody("");
+    setIncludeLocalChanges(true);
+  }, [open]);
+
+  const view = useMemo(() => resolveCreatePrDialogView(context), [context]);
+  const execution = useMemo(
+    () => resolveCreatePrDialogExecution(context, includeLocalChanges),
+    [context, includeLocalChanges],
+  );
+  const browserPreparation = useMemo(
+    () => resolveCreatePrBrowserPreparation(context, includeLocalChanges),
+    [context, includeLocalChanges],
+  );
+  const canCreate = execution.kind === "run_action";
+  const canOpenInBrowser = browserPreparation.kind !== "unavailable";
+  const unavailableHint = execution.kind === "unavailable" ? execution.hint : null;
+  const isMac = isMacPlatform(typeof navigator === "undefined" ? "" : navigator.platform);
+
+  const submit = (draft: boolean) => {
+    if (execution.kind !== "run_action") return;
+    onSubmit({
+      action: execution.action,
+      draft,
+      includeLocalChanges,
+      title: title.trim() || null,
+      body: body.trim() || null,
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPopup
+        className="max-w-md"
+        showCloseButton={false}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+            event.preventDefault();
+            submit(false);
+          }
+        }}
+      >
+        <DialogHeader className="gap-0.5">
+          <DialogTitle className="font-normal font-sans text-muted-foreground text-xs">
+            {view.isNewBranch ? "New branch" : "Branch"} → {view.baseBranchName}
+          </DialogTitle>
+          <DialogDescription
+            className={cn(
+              "truncate font-medium text-sm",
+              view.willCreateFeatureBranch
+                ? "text-muted-foreground italic"
+                : "text-[var(--color-text-foreground)]",
+            )}
+          >
+            {view.willCreateFeatureBranch
+              ? "Auto-named feature branch"
+              : (view.branchName ?? "(detached HEAD)")}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogPanel className="space-y-1 pt-2">
+          <input
+            autoFocus
+            aria-label="Pull request title"
+            className="w-full bg-transparent py-1 font-medium text-sm outline-none placeholder:text-muted-foreground/70"
+            maxLength={300}
+            placeholder="Title (leave empty to generate)"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+          />
+          <textarea
+            aria-label="Pull request description"
+            className="w-full resize-none bg-transparent py-1 text-sm outline-none placeholder:text-muted-foreground/70"
+            maxLength={60_000}
+            placeholder="Description (leave empty to generate)"
+            rows={2}
+            value={body}
+            onChange={(event) => setBody(event.target.value)}
+          />
+          {view.showCommitToggle && (
+            <label className="flex cursor-pointer items-center gap-2 py-1 text-sm">
+              <Checkbox
+                checked={includeLocalChanges}
+                onCheckedChange={(checked) => setIncludeLocalChanges(checked === true)}
+              />
+              <span className="flex-1">Commit and push local changes</span>
+              <span className="shrink-0 font-mono text-xs">
+                <span className="text-success">+{view.insertions}</span>{" "}
+                <span className="text-destructive">−{view.deletions}</span>
+              </span>
+            </label>
+          )}
+          {unavailableHint && <p className="py-1 text-warning text-xs">{unavailableHint}</p>}
+        </DialogPanel>
+        <div className="border-[color:var(--color-border)] border-t p-2">
+          <CreatePrActionRow
+            disabled={!canCreate}
+            label="Create draft PR"
+            onClick={() => submit(true)}
+          />
+          <CreatePrActionRow
+            highlighted
+            disabled={!canCreate}
+            label="Create PR"
+            trailing={<ShortcutKbd shortcutLabel={isMac ? "⌘↵" : "Ctrl+↵"} />}
+            onClick={() => submit(false)}
+          />
+          <CreatePrActionRow
+            disabled={!canOpenInBrowser}
+            label="Open PR in browser"
+            onClick={() =>
+              onOpenInBrowser({ preparation: browserPreparation, includeLocalChanges })
+            }
+          />
+        </div>
+      </DialogPopup>
+    </Dialog>
+  );
+}

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -355,6 +355,10 @@ export function gitRunStackedActionMutationOptions(input: {
       commitMessage?: string;
       featureBranch?: boolean;
       filePaths?: string[];
+      prTitle?: string;
+      prBody?: string;
+      prDraft?: boolean;
+      allowDirtyWorkingTree?: boolean;
     },
     Awaited<ReturnType<NativeApi["git"]["runStackedAction"]>>
   >({
@@ -362,7 +366,21 @@ export function gitRunStackedActionMutationOptions(input: {
     queryClient: input.queryClient,
     mutationKey: gitMutationKeys.runStackedAction(input.cwd),
     unavailableMessage: "Git action is unavailable.",
-    run: (api, cwd, { actionId, action, commitMessage, featureBranch, filePaths }) =>
+    run: (
+      api,
+      cwd,
+      {
+        actionId,
+        action,
+        commitMessage,
+        featureBranch,
+        filePaths,
+        prTitle,
+        prBody,
+        prDraft,
+        allowDirtyWorkingTree,
+      },
+    ) =>
       api.git.runStackedAction({
         actionId,
         cwd,
@@ -370,6 +388,10 @@ export function gitRunStackedActionMutationOptions(input: {
         ...(commitMessage ? { commitMessage } : {}),
         ...(featureBranch ? { featureBranch } : {}),
         ...(filePaths ? { filePaths } : {}),
+        ...(prTitle ? { prTitle } : {}),
+        ...(prBody ? { prBody } : {}),
+        ...(prDraft !== undefined ? { prDraft } : {}),
+        ...(allowDirtyWorkingTree ? { allowDirtyWorkingTree } : {}),
         ...(input.codexHomePath ? { codexHomePath: input.codexHomePath } : {}),
         ...(input.model ? { textGenerationModel: input.model } : {}),
         ...(input.modelSelection ? { textGenerationModelSelection: input.modelSelection } : {}),

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -342,6 +342,7 @@ export const GitStatusResult = Schema.Struct({
   }),
   hasUpstream: Schema.Boolean,
   upstreamBranch: TrimmedNonEmptyStringSchema.pipe(Schema.NullOr),
+  configuredPrBaseBranch: Schema.optional(TrimmedNonEmptyStringSchema.pipe(Schema.NullOr)),
   aheadCount: NonNegativeInt,
   behindCount: NonNegativeInt,
   pr: Schema.NullOr(GitStatusPr),
@@ -358,6 +359,7 @@ export type GitStatusLocalResult = typeof GitStatusLocalResult.Type;
 export const GitStatusRemoteResult = Schema.Struct({
   hasUpstream: Schema.Boolean,
   upstreamBranch: GitStatusResult.fields.upstreamBranch,
+  configuredPrBaseBranch: GitStatusResult.fields.configuredPrBaseBranch,
   aheadCount: NonNegativeInt,
   behindCount: NonNegativeInt,
   pr: Schema.NullOr(GitStatusPr),

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -168,6 +168,13 @@ export const GitRunStackedActionInput = Schema.Struct({
   action: GitStackedAction,
   commitMessage: Schema.optional(TrimmedNonEmptyStringSchema.check(Schema.isMaxLength(10_000))),
   featureBranch: Schema.optional(Schema.Boolean),
+  // PR content overrides for create_pr/commit_push_pr; missing fields are generated.
+  prTitle: Schema.optional(TrimmedNonEmptyStringSchema.check(Schema.isMaxLength(300))),
+  prBody: Schema.optional(TrimmedNonEmptyStringSchema.check(Schema.isMaxLength(60_000))),
+  prDraft: Schema.optional(Schema.Boolean),
+  // The user explicitly chose to leave working-tree changes out of a push/create_pr,
+  // so the dirty-tree safety guard must not reject the action.
+  allowDirtyWorkingTree: Schema.optional(Schema.Boolean),
   filePaths: Schema.optional(
     Schema.Array(TrimmedNonEmptyStringSchema).check(Schema.isMinLength(1)),
   ),


### PR DESCRIPTION
## What Changed

Expanded the Git actions Create PR path so it now resolves the full stack of required git steps instead of only allowing already-published branches.

- Dirty branches now route `Create PR` to `commit_push_pr`
- Clean, already-published branches still use `create_pr`
- Existing open PRs now open the PR instead of starting a new flow
- Branches behind or diverged from upstream stay blocked with a clear hint
- Menu enablement and disabled reasons now use the same execution resolver
- Added coverage for the new execution matrix

## Why

This makes the Create PR action behave like a one-click publish flow for the common case where a branch still needs a commit and push before a PR can exist. It also keeps the action predictable by rejecting unsafe upstream states and reusing one shared resolver across the UI.

## UI Changes

None.

## Verification

- Updated and expanded unit tests in `apps/web/src/components/GitActionsControl.logic.test.ts`
- Did not run the full workspace verification suite

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches git stacked actions, PR creation via GitHub CLI, and push/create guards; behavior changes are user-facing but covered by expanded unit/integration tests.
> 
> **Overview**
> **Create PR** is now a guided flow: menu and quick actions open **`GitCreatePrDialog`** (title, description, draft, optional “commit and push local changes”, and **Open PR in browser** via GitHub compare) instead of firing `create_pr` immediately.
> 
> The UI uses shared resolvers (`resolveCreatePrExecution`, dialog variants) so dirty trees route to **`commit_push_pr`**, clean published branches use **`create_pr`**, and blocked states (behind/diverged, no origin, etc.) share the same hints as menu disable reasons. **Create PR** can stay enabled with uncommitted work while literal `create_pr` still requires a clean tree unless the dialog excludes local changes (`allowDirtyWorkingTree`).
> 
> **Server/contracts:** `runStackedAction` accepts **`prTitle`**, **`prBody`**, **`prDraft`**, and **`allowDirtyWorkingTree`**; PR creation skips AI generation when title/body are provided; **`gh pr create --draft`** is passed when requested; push/`create_pr` reject dirty working trees unless opted out. Git status exposes **`configuredPrBaseBranch`** from `branch.*.gh-merge-base` (surfaced in the dialog base branch and status cache refresh tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9401bc140e0fee98d37484e0924b4ae07b0e68d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->