### PR TITLE
Serialize Git refreshes and improve capacity retry handling

### DIFF
--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -663,7 +663,8 @@ const makeWsRpcHandlersLayer = () =>
       const refreshGitStatusInBackground = (cwd: string) =>
         gitStatusBroadcaster.refreshStatus(cwd).pipe(
           Effect.catchCause(() => Effect.void),
-          Effect.forkDaemon,
+          Effect.forkDetach,
+          Effect.asVoid,
         );
 
       const pruneManagedWorktrees = pruneProjectedArchivedManagedWorktrees({

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -660,6 +660,12 @@ const makeWsRpcHandlersLayer = () =>
           ),
         );
 
+      const refreshGitStatusInBackground = (cwd: string) =>
+        gitStatusBroadcaster.refreshStatus(cwd).pipe(
+          Effect.catchCause(() => Effect.void),
+          Effect.forkDaemon,
+        );
+
       const pruneManagedWorktrees = pruneProjectedArchivedManagedWorktrees({
         homeDir: config.homeDir,
         worktreesDir: config.worktreesDir,
@@ -1316,20 +1322,21 @@ const makeWsRpcHandlersLayer = () =>
         [WS_METHODS.gitRunStackedAction]: (input) =>
           bufferLiveUiStream(
             Stream.callback<GitActionProgressEvent, WsRpcError>((queue) =>
-              refreshGitStatusAfter(
-                input.cwd,
-                gitManager.runStackedAction(input, {
+              gitManager
+                .runStackedAction(input, {
                   actionId: input.actionId,
                   progressReporter: {
                     publish: (event) => Queue.offer(queue, event).pipe(Effect.asVoid),
                   },
-                }),
-              ).pipe(
-                Effect.matchCauseEffect({
-                  onFailure: (cause) => Queue.fail(queue, toWsRpcError(cause, "Git action failed")),
-                  onSuccess: () => Queue.end(queue).pipe(Effect.asVoid),
-                }),
-              ),
+                })
+                .pipe(
+                  Effect.tap(() => refreshGitStatusInBackground(input.cwd)),
+                  Effect.matchCauseEffect({
+                    onFailure: (cause) =>
+                      Queue.fail(queue, toWsRpcError(cause, "Git action failed")),
+                    onSuccess: () => Queue.end(queue).pipe(Effect.asVoid),
+                  }),
+                ),
             ),
             { label: "git.stacked-action" },
           ),

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -393,9 +393,7 @@ export default function GitActionsControl({
     data: gitStatusData,
     error: gitStatusError,
     isFetching: isGitStatusFetching,
-  } = useQuery(
-    gitStatusQueryOptions(gitCwd, branchListReady && branchList?.isRepo === true),
-  );
+  } = useQuery(gitStatusQueryOptions(gitCwd, branchListReady && branchList?.isRepo === true));
   const gitStatus = gitStatusData ?? null;
   const isGitStatusRefreshDelayed = isGitExpensiveReadCapacityError(gitStatusError);
   const requestGitActionAvailabilityRefresh = useCallback(() => {

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -94,6 +94,8 @@ import {
   gitRunStackedActionMutationOptions,
   gitStatusQueryOptions,
   invalidateGitQueries,
+  isGitExpensiveReadCapacityError,
+  refreshGitActionAvailability,
 } from "~/lib/gitReactQuery";
 import { cn, newCommandId, randomUUID } from "~/lib/utils";
 import { resolvePathLinkTarget } from "~/terminal-links";
@@ -387,10 +389,19 @@ export default function GitActionsControl({
   const currentBranch = branchList?.branches.find((branch) => branch.current)?.name ?? null;
   // Only poll status after branch discovery confirms a repo — avoids non-repo
   // cwds feeding a permanent "Refreshing git status..." invalidation loop.
-  const { data: gitStatusData, error: gitStatusError } = useQuery(
+  const {
+    data: gitStatusData,
+    error: gitStatusError,
+    isFetching: isGitStatusFetching,
+  } = useQuery(
     gitStatusQueryOptions(gitCwd, branchListReady && branchList?.isRepo === true),
   );
   const gitStatus = gitStatusData ?? null;
+  const isGitStatusRefreshDelayed = isGitExpensiveReadCapacityError(gitStatusError);
+  const requestGitActionAvailabilityRefresh = useCallback(() => {
+    if (!gitCwd) return;
+    void refreshGitActionAvailability(queryClient, gitCwd).catch(() => undefined);
+  }, [gitCwd, queryClient]);
   const liveThreadBranchUpdate = useMemo(
     () =>
       resolveLiveThreadBranchUpdate({
@@ -403,8 +414,8 @@ export default function GitActionsControl({
 
   useEffect(() => {
     if (!isGitStatusOutOfSync) return;
-    void invalidateGitQueries(queryClient);
-  }, [isGitStatusOutOfSync, queryClient]);
+    requestGitActionAvailabilityRefresh();
+  }, [isGitStatusOutOfSync, requestGitActionAvailabilityRefresh]);
 
   const gitStatusForActions = isGitStatusOutOfSync ? null : gitStatus;
 
@@ -592,11 +603,8 @@ export default function GitActionsControl({
           progress.lastOutputLine = null;
           break;
         case "action_finished":
-          // Don't clear timestamps here — the HTTP response handler (line 496)
-          // sets activeGitActionProgressRef to null and shows the success toast.
-          // Clearing timestamps early causes the "Running for Xs" description
-          // to disappear before the success state renders, leaving a bare
-          // "Pushing..." toast in the gap between the WS event and HTTP response.
+          // The terminal stream response owns the final toast so success is rendered once.
+          // Its server-side status refresh is detached, keeping this event-to-response gap short.
           return;
         case "action_failed":
           // Same reasoning as action_finished — let the HTTP error handler
@@ -1369,7 +1377,12 @@ export default function GitActionsControl({
       {isGitStatusOutOfSync && (
         <p className="px-3 py-1.5 text-xs text-muted-foreground">Refreshing git status...</p>
       )}
-      {gitStatusError && (
+      {isGitStatusRefreshDelayed && !isGitStatusOutOfSync && (
+        <p className="px-3 py-1.5 text-xs text-muted-foreground">
+          {isGitStatusFetching ? "Refreshing git status..." : "Git status refresh delayed."}
+        </p>
+      )}
+      {gitStatusError && !isGitStatusRefreshDelayed && (
         <p className="px-3 py-1.5 text-xs text-destructive">{gitStatusError.message}</p>
       )}
     </>
@@ -1674,7 +1687,7 @@ export default function GitActionsControl({
     const panelGitActionsMenu = (
       <Menu
         onOpenChange={(open) => {
-          if (open) void invalidateGitQueries(queryClient);
+          if (open) requestGitActionAvailabilityRefresh();
         }}
       >
         <MenuTrigger
@@ -1824,7 +1837,7 @@ export default function GitActionsControl({
           <ChatHeaderSplitDivider />
           <Menu
             onOpenChange={(open) => {
-              if (open) void invalidateGitQueries(queryClient);
+              if (open) requestGitActionAvailabilityRefresh();
             }}
           >
             <MenuTrigger

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1381,7 +1381,9 @@ export default function GitActionsControl({
         </p>
       )}
       {gitStatusError && !isGitStatusRefreshDelayed && (
-        <p className="px-3 py-1.5 text-xs text-destructive">{gitStatusError.message}</p>
+        <p className="px-3 py-1.5 text-xs text-destructive">
+          {gitStatusError instanceof Error ? gitStatusError.message : "Git status refresh failed."}
+        </p>
       )}
     </>
   );

--- a/apps/web/src/lib/gitReactQuery.test.ts
+++ b/apps/web/src/lib/gitReactQuery.test.ts
@@ -1,15 +1,19 @@
-import { QueryClient } from "@tanstack/react-query";
-import { describe, expect, it } from "vitest";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
 import {
   GIT_WORKING_TREE_DIFF_LIVE_REFETCH_INTERVAL_MS,
   gitQueryKeys,
+  gitStatusQueryOptions,
   gitWorkingTreeDiffQueryOptions,
   invalidateGitQueries,
   invalidateGitQueriesForCwds,
+  isGitExpensiveReadCapacityError,
   gitMutationKeys,
   gitPreparePullRequestThreadMutationOptions,
   gitPullMutationOptions,
   gitRunStackedActionMutationOptions,
+  refreshGitActionAvailability,
+  refreshGitQueriesForCwd,
 } from "./gitReactQuery";
 
 describe("gitMutationKeys", () => {
@@ -49,6 +53,37 @@ describe("git mutation options", () => {
       queryClient,
     });
     expect(options.mutationKey).toEqual(gitMutationKeys.preparePullRequestThread("/repo/a"));
+  });
+
+  it("does not keep a completed stacked action pending while Git queries refresh", async () => {
+    const queryClient = new QueryClient();
+    const cwd = "/repo/non-blocking";
+    const statusKey = gitQueryKeys.status(cwd);
+    let statusCalls = 0;
+    let releaseStatus: (() => void) | null = null;
+    queryClient.setQueryData(statusKey, { branch: "main" });
+    const observer = new QueryObserver(queryClient, {
+      queryKey: statusKey,
+      queryFn: async () => {
+        statusCalls += 1;
+        await new Promise<void>((resolve) => {
+          releaseStatus = resolve;
+        });
+        return { branch: "main" };
+      },
+      staleTime: Number.POSITIVE_INFINITY,
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+    const options = gitRunStackedActionMutationOptions({ cwd, queryClient });
+
+    const callbackResult = (options.onSettled as (() => unknown) | undefined)?.();
+    expect(callbackResult).toBeUndefined();
+
+    const refresh = refreshGitQueriesForCwd(queryClient, cwd);
+    await vi.waitFor(() => expect(statusCalls).toBe(1));
+    releaseStatus?.();
+    await refresh;
+    unsubscribe();
   });
 });
 
@@ -107,6 +142,93 @@ describe("git query invalidation", () => {
     for (const key of cwdBKeys) {
       expect(queryClient.getQueryState(key)?.isInvalidated).toBe(false);
     }
+  });
+
+  it("coalesces simultaneous availability refreshes for the same cwd", async () => {
+    const queryClient = new QueryClient();
+    const cwd = "/repo/coalesced";
+    const statusKey = gitQueryKeys.status(cwd);
+    let statusCalls = 0;
+    let releaseStatus: (() => void) | null = null;
+    queryClient.setQueryData(statusKey, { branch: "main" });
+    const observer = new QueryObserver(queryClient, {
+      queryKey: statusKey,
+      queryFn: async () => {
+        statusCalls += 1;
+        await new Promise<void>((resolve) => {
+          releaseStatus = resolve;
+        });
+        return { branch: "main" };
+      },
+      staleTime: Number.POSITIVE_INFINITY,
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+
+    const first = refreshGitActionAvailability(queryClient, cwd);
+    const second = refreshGitActionAvailability(queryClient, cwd);
+
+    expect(second).toBe(first);
+    await vi.waitFor(() => expect(statusCalls).toBe(1));
+    releaseStatus?.();
+    await Promise.all([first, second]);
+    unsubscribe();
+  });
+
+  it("serializes active expensive Git detail reads after status", async () => {
+    const queryClient = new QueryClient();
+    const cwd = "/repo/serialized";
+    const calls: string[] = [];
+    let activeCalls = 0;
+    let maxActiveCalls = 0;
+    const observe = (queryKey: readonly unknown[], label: string) => {
+      queryClient.setQueryData(queryKey, {});
+      const observer = new QueryObserver(queryClient, {
+        queryKey,
+        queryFn: async () => {
+          calls.push(label);
+          activeCalls += 1;
+          maxActiveCalls = Math.max(maxActiveCalls, activeCalls);
+          await Promise.resolve();
+          activeCalls -= 1;
+          return {};
+        },
+        staleTime: Number.POSITIVE_INFINITY,
+      });
+      return observer.subscribe(() => undefined);
+    };
+    const unsubscribes = [
+      observe(gitQueryKeys.status(cwd), "status"),
+      observe(gitQueryKeys.workingTreeDiffStats(cwd, "unstaged"), "stats"),
+      observe(gitQueryKeys.workingTreeDiff(cwd, "unstaged"), "patch"),
+    ];
+
+    await refreshGitQueriesForCwd(queryClient, cwd);
+
+    expect(calls).toEqual(["status", "stats", "patch"]);
+    expect(maxActiveCalls).toBe(1);
+    for (const unsubscribe of unsubscribes) unsubscribe();
+  });
+});
+
+describe("git expensive-read capacity retry", () => {
+  const capacityError = {
+    code: "RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED",
+    retryable: true,
+    retryAfterMs: 375,
+  };
+
+  it("recognizes the typed capacity error and honors the server retry delay", () => {
+    expect(isGitExpensiveReadCapacityError(capacityError)).toBe(true);
+    expect(isGitExpensiveReadCapacityError(new Error("network"))).toBe(false);
+
+    const options = gitStatusQueryOptions("/repo");
+    expect(typeof options.retry).toBe("function");
+    expect(typeof options.retryDelay).toBe("function");
+    if (typeof options.retry !== "function" || typeof options.retryDelay !== "function") return;
+
+    expect(options.retry(0, capacityError)).toBe(true);
+    expect(options.retry(12, capacityError)).toBe(false);
+    expect(options.retryDelay(0, capacityError)).toBe(375);
   });
 });
 

--- a/apps/web/src/lib/gitReactQuery.test.ts
+++ b/apps/web/src/lib/gitReactQuery.test.ts
@@ -208,6 +208,47 @@ describe("git query invalidation", () => {
     expect(maxActiveCalls).toBe(1);
     for (const unsubscribe of unsubscribes) unsubscribe();
   });
+
+  it("prioritizes an availability refresh between active detail reads", async () => {
+    const queryClient = new QueryClient();
+    const cwd = "/repo/prioritized";
+    const calls: string[] = [];
+    let releaseStats: (() => void) | null = null;
+    const observe = (queryKey: readonly unknown[], label: string, waitForRelease = false) => {
+      queryClient.setQueryData(queryKey, {});
+      const observer = new QueryObserver(queryClient, {
+        queryKey,
+        queryFn: async () => {
+          calls.push(label);
+          if (waitForRelease) {
+            await new Promise<void>((resolve) => {
+              releaseStats = resolve;
+            });
+          }
+          return {};
+        },
+        staleTime: Number.POSITIVE_INFINITY,
+      });
+      return observer.subscribe(() => undefined);
+    };
+    const unsubscribes = [
+      observe(gitQueryKeys.status(cwd), "status"),
+      observe(gitQueryKeys.workingTreeDiffStats(cwd, "unstaged"), "stats", true),
+      observe(gitQueryKeys.workingTreeDiff(cwd, "unstaged"), "patch"),
+    ];
+
+    const detailsRefresh = refreshGitQueriesForCwd(queryClient, cwd);
+    await vi.waitFor(() => expect(calls).toEqual(["status", "stats"]));
+    const availabilityRefresh = refreshGitActionAvailability(queryClient, cwd);
+
+    releaseStats?.();
+    await availabilityRefresh;
+    expect(calls).toEqual(["status", "stats", "status"]);
+
+    await detailsRefresh;
+    expect(calls).toEqual(["status", "stats", "status", "patch"]);
+    for (const unsubscribe of unsubscribes) unsubscribe();
+  });
 });
 
 describe("git expensive-read capacity retry", () => {

--- a/apps/web/src/lib/gitReactQuery.test.ts
+++ b/apps/web/src/lib/gitReactQuery.test.ts
@@ -16,6 +16,14 @@ import {
   refreshGitQueriesForCwd,
 } from "./gitReactQuery";
 
+function deferredVoid() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe("gitMutationKeys", () => {
   it("scopes stacked action keys by cwd", () => {
     expect(gitMutationKeys.runStackedAction("/repo/a")).not.toEqual(
@@ -60,15 +68,13 @@ describe("git mutation options", () => {
     const cwd = "/repo/non-blocking";
     const statusKey = gitQueryKeys.status(cwd);
     let statusCalls = 0;
-    let releaseStatus: (() => void) | null = null;
+    const statusGate = deferredVoid();
     queryClient.setQueryData(statusKey, { branch: "main" });
     const observer = new QueryObserver(queryClient, {
       queryKey: statusKey,
       queryFn: async () => {
         statusCalls += 1;
-        await new Promise<void>((resolve) => {
-          releaseStatus = resolve;
-        });
+        await statusGate.promise;
         return { branch: "main" };
       },
       staleTime: Number.POSITIVE_INFINITY,
@@ -81,7 +87,7 @@ describe("git mutation options", () => {
 
     const refresh = refreshGitQueriesForCwd(queryClient, cwd);
     await vi.waitFor(() => expect(statusCalls).toBe(1));
-    releaseStatus?.();
+    statusGate.resolve();
     await refresh;
     unsubscribe();
   });
@@ -149,15 +155,13 @@ describe("git query invalidation", () => {
     const cwd = "/repo/coalesced";
     const statusKey = gitQueryKeys.status(cwd);
     let statusCalls = 0;
-    let releaseStatus: (() => void) | null = null;
+    const statusGate = deferredVoid();
     queryClient.setQueryData(statusKey, { branch: "main" });
     const observer = new QueryObserver(queryClient, {
       queryKey: statusKey,
       queryFn: async () => {
         statusCalls += 1;
-        await new Promise<void>((resolve) => {
-          releaseStatus = resolve;
-        });
+        await statusGate.promise;
         return { branch: "main" };
       },
       staleTime: Number.POSITIVE_INFINITY,
@@ -169,8 +173,38 @@ describe("git query invalidation", () => {
 
     expect(second).toBe(first);
     await vi.waitFor(() => expect(statusCalls).toBe(1));
-    releaseStatus?.();
+    statusGate.resolve();
     await Promise.all([first, second]);
+    unsubscribe();
+  });
+
+  it("keeps availability coalesced when a refresh is upgraded to include details", async () => {
+    const queryClient = new QueryClient();
+    const cwd = "/repo/upgraded";
+    const statusKey = gitQueryKeys.status(cwd);
+    let statusCalls = 0;
+    const statusGate = deferredVoid();
+    queryClient.setQueryData(statusKey, {});
+    const observer = new QueryObserver(queryClient, {
+      queryKey: statusKey,
+      queryFn: async () => {
+        statusCalls += 1;
+        await statusGate.promise;
+        return {};
+      },
+      staleTime: Number.POSITIVE_INFINITY,
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+
+    const availability = refreshGitActionAvailability(queryClient, cwd);
+    const details = refreshGitQueriesForCwd(queryClient, cwd);
+    const repeatedAvailability = refreshGitActionAvailability(queryClient, cwd);
+
+    expect(repeatedAvailability).toBe(availability);
+    await vi.waitFor(() => expect(statusCalls).toBe(1));
+    statusGate.resolve();
+    await Promise.all([availability, details, repeatedAvailability]);
+    expect(statusCalls).toBe(1);
     unsubscribe();
   });
 
@@ -213,7 +247,7 @@ describe("git query invalidation", () => {
     const queryClient = new QueryClient();
     const cwd = "/repo/prioritized";
     const calls: string[] = [];
-    let releaseStats: (() => void) | null = null;
+    const statsGate = deferredVoid();
     const observe = (queryKey: readonly unknown[], label: string, waitForRelease = false) => {
       queryClient.setQueryData(queryKey, {});
       const observer = new QueryObserver(queryClient, {
@@ -221,9 +255,7 @@ describe("git query invalidation", () => {
         queryFn: async () => {
           calls.push(label);
           if (waitForRelease) {
-            await new Promise<void>((resolve) => {
-              releaseStats = resolve;
-            });
+            await statsGate.promise;
           }
           return {};
         },
@@ -241,7 +273,7 @@ describe("git query invalidation", () => {
     await vi.waitFor(() => expect(calls).toEqual(["status", "stats"]));
     const availabilityRefresh = refreshGitActionAvailability(queryClient, cwd);
 
-    releaseStats?.();
+    statsGate.resolve();
     await availabilityRefresh;
     expect(calls).toEqual(["status", "stats", "status"]);
 

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -19,6 +19,41 @@ const GIT_BRANCHES_STALE_TIME_MS = 15_000;
 const GIT_BRANCHES_REFETCH_INTERVAL_MS = 300_000;
 const GIT_WORKING_TREE_DIFF_STALE_TIME_MS = 5_000;
 export const GIT_WORKING_TREE_DIFF_LIVE_REFETCH_INTERVAL_MS = 4_000;
+const RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED = "RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED";
+const GIT_CAPACITY_RETRY_LIMIT = 12;
+const DEFAULT_GIT_CAPACITY_RETRY_MS = 250;
+
+export function isGitExpensiveReadCapacityError(
+  error: unknown,
+): error is { readonly code: string; readonly retryAfterMs?: unknown } {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED
+  );
+}
+
+function shouldRetryGitExpensiveRead(failureCount: number, error: unknown): boolean {
+  return isGitExpensiveReadCapacityError(error)
+    ? failureCount < GIT_CAPACITY_RETRY_LIMIT
+    : failureCount < 3;
+}
+
+function gitExpensiveReadRetryDelay(attemptIndex: number, error: unknown): number {
+  if (isGitExpensiveReadCapacityError(error)) {
+    const retryAfterMs = "retryAfterMs" in error ? error.retryAfterMs : undefined;
+    return typeof retryAfterMs === "number" && retryAfterMs > 0
+      ? retryAfterMs
+      : DEFAULT_GIT_CAPACITY_RETRY_MS;
+  }
+  return Math.min(1_000 * 2 ** attemptIndex, 30_000);
+}
+
+const GIT_EXPENSIVE_READ_RETRY_OPTIONS = {
+  retry: shouldRetryGitExpensiveRead,
+  retryDelay: gitExpensiveReadRetryDelay,
+} as const;
 
 export const gitQueryKeys = {
   all: ["git"] as const,
@@ -70,28 +105,195 @@ export const gitMutationKeys = {
   unstageFiles: (cwd: string | null) => ["git", "mutation", "unstage-files", cwd] as const,
 };
 
-export function invalidateGitQueries(queryClient: QueryClient) {
-  return Promise.all([
-    queryClient.invalidateQueries({ queryKey: ["git", "github-repository"] as const }),
-    queryClient.invalidateQueries({ queryKey: gitQueryKeys.statuses }),
-    queryClient.invalidateQueries({ queryKey: ["git", "branches"] as const }),
-    queryClient.invalidateQueries({ queryKey: ["git", "working-tree-diff"] as const }),
-    queryClient.invalidateQueries({ queryKey: gitQueryKeys.pullRequests }),
+type GitRefreshDepth = "availability" | "active-details";
+
+interface ActiveGitRefresh {
+  readonly depth: GitRefreshDepth;
+  readonly promise: Promise<void>;
+}
+
+const activeGitRefreshes = new WeakMap<QueryClient, Map<string, ActiveGitRefresh>>();
+const gitRefreshQueueTails = new WeakMap<QueryClient, Promise<void>>();
+
+function enqueueGitRefresh(queryClient: QueryClient, refresh: () => Promise<void>): Promise<void> {
+  const previous = gitRefreshQueueTails.get(queryClient) ?? Promise.resolve();
+  const result = previous.catch(() => undefined).then(refresh);
+  const settled = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  gitRefreshQueueTails.set(queryClient, settled);
+  void settled.then(() => {
+    if (gitRefreshQueueTails.get(queryClient) === settled) {
+      gitRefreshQueueTails.delete(queryClient);
+    }
+  });
+  return result;
+}
+
+function trackGitRefresh(
+  queryClient: QueryClient,
+  cwd: string,
+  depth: GitRefreshDepth,
+  promise: Promise<void>,
+): Promise<void> {
+  let refreshes = activeGitRefreshes.get(queryClient);
+  if (!refreshes) {
+    refreshes = new Map();
+    activeGitRefreshes.set(queryClient, refreshes);
+  }
+  const entry = { depth, promise } satisfies ActiveGitRefresh;
+  refreshes.set(cwd, entry);
+  void promise.then(
+    () => {
+      if (refreshes?.get(cwd) === entry) refreshes.delete(cwd);
+    },
+    () => {
+      if (refreshes?.get(cwd) === entry) refreshes.delete(cwd);
+    },
+  );
+  return promise;
+}
+
+async function refreshGitAvailability(queryClient: QueryClient, cwd: string): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: gitQueryKeys.githubRepository(cwd),
+      exact: true,
+      refetchType: "none",
+    }),
+    queryClient.invalidateQueries({
+      queryKey: gitQueryKeys.status(cwd),
+      exact: true,
+      refetchType: "none",
+    }),
+    queryClient.invalidateQueries({
+      queryKey: gitQueryKeys.branches(cwd),
+      exact: true,
+      refetchType: "none",
+    }),
   ]);
+  await Promise.all([
+    queryClient.refetchQueries(
+      { queryKey: gitQueryKeys.githubRepository(cwd), exact: true, type: "active" },
+      { cancelRefetch: false },
+    ),
+    queryClient.refetchQueries(
+      { queryKey: gitQueryKeys.status(cwd), exact: true, type: "active" },
+      { cancelRefetch: false },
+    ),
+    queryClient.refetchQueries(
+      { queryKey: gitQueryKeys.branches(cwd), exact: true, type: "active" },
+      { cancelRefetch: false },
+    ),
+  ]);
+}
+
+function activeGitDetailQueries(queryClient: QueryClient, cwd: string) {
+  const queryCache = queryClient.getQueryCache();
+  const queries = [
+    ...queryCache.findAll({
+      queryKey: ["git", "working-tree-diff", cwd] as const,
+      type: "active",
+    }),
+    ...queryCache.findAll({ queryKey: gitQueryKeys.pullRequest(cwd), type: "active" }),
+  ];
+  const uniqueQueries = [...new Map(queries.map((query) => [query.queryHash, query])).values()];
+  return uniqueQueries.toSorted((left, right) => {
+    const leftIsStats = left.queryKey.at(-1) === "stats";
+    const rightIsStats = right.queryKey.at(-1) === "stats";
+    if (leftIsStats !== rightIsStats) return leftIsStats ? -1 : 1;
+    const leftIsPatch = left.queryKey[1] === "working-tree-diff" && !leftIsStats;
+    const rightIsPatch = right.queryKey[1] === "working-tree-diff" && !rightIsStats;
+    if (leftIsPatch !== rightIsPatch) return leftIsPatch ? 1 : -1;
+    return left.queryHash.localeCompare(right.queryHash);
+  });
+}
+
+async function refreshActiveGitDetails(queryClient: QueryClient, cwd: string): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: ["git", "working-tree-diff", cwd] as const,
+      refetchType: "none",
+    }),
+    queryClient.invalidateQueries({
+      queryKey: gitQueryKeys.pullRequest(cwd),
+      refetchType: "none",
+    }),
+  ]);
+  for (const query of activeGitDetailQueries(queryClient, cwd)) {
+    await queryClient.refetchQueries(
+      { queryKey: query.queryKey, exact: true, type: "active" },
+      { cancelRefetch: false },
+    );
+  }
+}
+
+/**
+ * Coalesces refreshes by repository and serializes their expensive reads across the client.
+ * Availability is refreshed first; active diff/PR details follow one at a time so Git UI work
+ * cannot consume both expensive-read leases or fan out across every visible worktree.
+ */
+export function refreshGitQueriesForCwd(
+  queryClient: QueryClient,
+  cwd: string,
+  depth: GitRefreshDepth = "active-details",
+): Promise<void> {
+  const existing = activeGitRefreshes.get(queryClient)?.get(cwd);
+  if (existing) {
+    if (existing.depth === "active-details" || depth === "availability") {
+      return existing.promise;
+    }
+    const upgraded = existing.promise
+      .catch(() => undefined)
+      .then(() => enqueueGitRefresh(queryClient, () => refreshActiveGitDetails(queryClient, cwd)));
+    return trackGitRefresh(queryClient, cwd, "active-details", upgraded);
+  }
+
+  const refresh = enqueueGitRefresh(queryClient, async () => {
+    await refreshGitAvailability(queryClient, cwd);
+    if (depth === "active-details") {
+      await refreshActiveGitDetails(queryClient, cwd);
+    }
+  });
+  return trackGitRefresh(queryClient, cwd, depth, refresh);
+}
+
+export function refreshGitActionAvailability(queryClient: QueryClient, cwd: string): Promise<void> {
+  return refreshGitQueriesForCwd(queryClient, cwd, "availability");
+}
+
+function cachedGitCwds(queryClient: QueryClient): string[] {
+  const cwdFamilies = new Set([
+    "github-repository",
+    "status",
+    "branches",
+    "working-tree-diff",
+    "pull-request",
+  ]);
+  const cwds = queryClient
+    .getQueryCache()
+    .findAll({ queryKey: gitQueryKeys.all })
+    .flatMap((query) => {
+      const family = query.queryKey[1];
+      const cwd = query.queryKey[2];
+      return typeof family === "string" && cwdFamilies.has(family) && typeof cwd === "string"
+        ? [cwd]
+        : [];
+    });
+  return [...new Set(cwds)];
+}
+
+export function invalidateGitQueries(queryClient: QueryClient) {
+  return Promise.all(
+    cachedGitCwds(queryClient).map((cwd) => refreshGitQueriesForCwd(queryClient, cwd)),
+  );
 }
 
 // Scope live file-change invalidations so unrelated project/worktree git caches stay warm.
 export function invalidateGitQueriesForCwds(queryClient: QueryClient, cwds: Iterable<string>) {
   const uniqueCwds = [...new Set([...cwds].filter((cwd) => cwd.length > 0))];
-  return Promise.all(
-    uniqueCwds.flatMap((cwd) => [
-      queryClient.invalidateQueries({ queryKey: gitQueryKeys.githubRepository(cwd) }),
-      queryClient.invalidateQueries({ queryKey: gitQueryKeys.status(cwd) }),
-      queryClient.invalidateQueries({ queryKey: gitQueryKeys.branches(cwd) }),
-      queryClient.invalidateQueries({ queryKey: ["git", "working-tree-diff", cwd] as const }),
-      queryClient.invalidateQueries({ queryKey: gitQueryKeys.pullRequest(cwd) }),
-    ]),
-  );
+  return Promise.all(uniqueCwds.map((cwd) => refreshGitQueriesForCwd(queryClient, cwd)));
 }
 
 export function gitStatusQueryOptions(cwd: string | null, enabled = true) {
@@ -107,6 +309,7 @@ export function gitStatusQueryOptions(cwd: string | null, enabled = true) {
     refetchOnWindowFocus: true,
     refetchOnReconnect: "always",
     refetchInterval: GIT_STATUS_REFETCH_INTERVAL_MS,
+    ...GIT_EXPENSIVE_READ_RETRY_OPTIONS,
   });
 }
 
@@ -192,6 +395,7 @@ export function gitPullRequestSnapshotQueryOptions(input: {
     refetchOnWindowFocus: (query) =>
       !query.state.data || query.state.data.pullRequest.state === "open",
     refetchOnReconnect: true,
+    ...GIT_EXPENSIVE_READ_RETRY_OPTIONS,
   });
 }
 
@@ -226,6 +430,7 @@ export function gitWorkingTreeDiffStatsQueryOptions(input: {
     ...(refetchInterval !== undefined ? { refetchInterval } : {}),
     refetchOnWindowFocus: true,
     refetchOnReconnect: true,
+    ...GIT_EXPENSIVE_READ_RETRY_OPTIONS,
   });
 }
 
@@ -251,6 +456,7 @@ export function gitWorkingTreeDiffQueryOptions(input: {
     ...(refetchInterval !== undefined ? { refetchInterval } : {}),
     refetchOnWindowFocus: true,
     refetchOnReconnect: true,
+    ...GIT_EXPENSIVE_READ_RETRY_OPTIONS,
   });
 }
 
@@ -269,6 +475,7 @@ function makeGitMutationOptions<TArgs, TResult>(config: {
   run: (api: NativeApi, cwd: string, args: TArgs) => Promise<TResult>;
   invalidate?: GitMutationInvalidation;
   invalidateOn?: GitMutationInvalidateOn;
+  awaitInvalidation?: boolean;
 }) {
   const invalidate = config.invalidate ?? "all";
   const invalidateOn = config.invalidateOn ?? "settled";
@@ -281,6 +488,12 @@ function makeGitMutationOptions<TArgs, TResult>(config: {
     }
     await invalidateGitQueries(config.queryClient);
   };
+  const handleInvalidation =
+    config.awaitInvalidation === false
+      ? () => {
+          void runInvalidation().catch(() => undefined);
+        }
+      : runInvalidation;
 
   return mutationOptions({
     mutationKey: config.mutationKey,
@@ -290,8 +503,8 @@ function makeGitMutationOptions<TArgs, TResult>(config: {
       return config.run(api, config.cwd, args);
     },
     ...(invalidateOn === "success"
-      ? { onSuccess: runInvalidation }
-      : { onSettled: runInvalidation }),
+      ? { onSuccess: handleInvalidation }
+      : { onSettled: handleInvalidation }),
   });
 }
 
@@ -362,6 +575,8 @@ export function gitRunStackedActionMutationOptions(input: {
     queryClient: input.queryClient,
     mutationKey: gitMutationKeys.runStackedAction(input.cwd),
     unavailableMessage: "Git action is unavailable.",
+    invalidate: "cwd",
+    awaitInvalidation: false,
     run: (api, cwd, { actionId, action, commitMessage, featureBranch, filePaths }) =>
       api.git.runStackedAction({
         actionId,
@@ -384,6 +599,8 @@ export function gitPullMutationOptions(input: { cwd: string | null; queryClient:
     queryClient: input.queryClient,
     mutationKey: gitMutationKeys.pull(input.cwd),
     unavailableMessage: "Git pull is unavailable.",
+    invalidate: "cwd",
+    awaitInvalidation: false,
     run: (api, cwd) => api.git.pull({ cwd }),
   });
 }

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -110,7 +110,7 @@ type GitRefreshDepth = "availability" | "active-details";
 interface ActiveGitRefresh {
   readonly depth: GitRefreshDepth;
   readonly promise: Promise<void>;
-  availabilityPromise?: Promise<void>;
+  availabilityPromise: Promise<void> | undefined;
 }
 
 const activeGitRefreshes = new WeakMap<QueryClient, Map<string, ActiveGitRefresh>>();
@@ -144,8 +144,7 @@ function trackGitRefresh(
     refreshes = new Map();
     activeGitRefreshes.set(queryClient, refreshes);
   }
-  const entry: ActiveGitRefresh = { depth, promise };
-  if (availabilityPromise) entry.availabilityPromise = availabilityPromise;
+  const entry: ActiveGitRefresh = { depth, promise, availabilityPromise };
   refreshes.set(cwd, entry);
   if (availabilityPromise) {
     void availabilityPromise.then(
@@ -277,7 +276,13 @@ export function refreshGitQueriesForCwd(
     const upgraded = existing.promise
       .catch(() => undefined)
       .then(() => refreshActiveGitDetails(queryClient, cwd));
-    return trackGitRefresh(queryClient, cwd, "active-details", upgraded);
+    return trackGitRefresh(
+      queryClient,
+      cwd,
+      "active-details",
+      upgraded,
+      existing.availabilityPromise,
+    );
   }
 
   const availability = enqueueGitRefresh(queryClient, () =>

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -110,6 +110,7 @@ type GitRefreshDepth = "availability" | "active-details";
 interface ActiveGitRefresh {
   readonly depth: GitRefreshDepth;
   readonly promise: Promise<void>;
+  availabilityPromise?: Promise<void>;
 }
 
 const activeGitRefreshes = new WeakMap<QueryClient, Map<string, ActiveGitRefresh>>();
@@ -136,14 +137,30 @@ function trackGitRefresh(
   cwd: string,
   depth: GitRefreshDepth,
   promise: Promise<void>,
+  availabilityPromise?: Promise<void>,
 ): Promise<void> {
   let refreshes = activeGitRefreshes.get(queryClient);
   if (!refreshes) {
     refreshes = new Map();
     activeGitRefreshes.set(queryClient, refreshes);
   }
-  const entry = { depth, promise } satisfies ActiveGitRefresh;
+  const entry: ActiveGitRefresh = { depth, promise };
+  if (availabilityPromise) entry.availabilityPromise = availabilityPromise;
   refreshes.set(cwd, entry);
+  if (availabilityPromise) {
+    void availabilityPromise.then(
+      () => {
+        if (entry.availabilityPromise === availabilityPromise) {
+          entry.availabilityPromise = undefined;
+        }
+      },
+      () => {
+        if (entry.availabilityPromise === availabilityPromise) {
+          entry.availabilityPromise = undefined;
+        }
+      },
+    );
+  }
   void promise.then(
     () => {
       if (refreshes?.get(cwd) === entry) refreshes.delete(cwd);
@@ -222,9 +239,11 @@ async function refreshActiveGitDetails(queryClient: QueryClient, cwd: string): P
     }),
   ]);
   for (const query of activeGitDetailQueries(queryClient, cwd)) {
-    await queryClient.refetchQueries(
-      { queryKey: query.queryKey, exact: true, type: "active" },
-      { cancelRefetch: false },
+    await enqueueGitRefresh(queryClient, () =>
+      queryClient.refetchQueries(
+        { queryKey: query.queryKey, exact: true, type: "active" },
+        { cancelRefetch: false },
+      ),
     );
   }
 }
@@ -241,22 +260,34 @@ export function refreshGitQueriesForCwd(
 ): Promise<void> {
   const existing = activeGitRefreshes.get(queryClient)?.get(cwd);
   if (existing) {
-    if (existing.depth === "active-details" || depth === "availability") {
+    if (depth === "availability") {
+      if (existing.availabilityPromise) return existing.availabilityPromise;
+      if (existing.depth === "availability") return existing.promise;
+
+      const availability = enqueueGitRefresh(queryClient, () =>
+        refreshGitAvailability(queryClient, cwd),
+      );
+      const extended = existing.promise.finally(() => availability);
+      trackGitRefresh(queryClient, cwd, "active-details", extended, availability);
+      return availability;
+    }
+    if (existing.depth === "active-details") {
       return existing.promise;
     }
     const upgraded = existing.promise
       .catch(() => undefined)
-      .then(() => enqueueGitRefresh(queryClient, () => refreshActiveGitDetails(queryClient, cwd)));
+      .then(() => refreshActiveGitDetails(queryClient, cwd));
     return trackGitRefresh(queryClient, cwd, "active-details", upgraded);
   }
 
-  const refresh = enqueueGitRefresh(queryClient, async () => {
-    await refreshGitAvailability(queryClient, cwd);
-    if (depth === "active-details") {
-      await refreshActiveGitDetails(queryClient, cwd);
-    }
-  });
-  return trackGitRefresh(queryClient, cwd, depth, refresh);
+  const availability = enqueueGitRefresh(queryClient, () =>
+    refreshGitAvailability(queryClient, cwd),
+  );
+  const refresh =
+    depth === "active-details"
+      ? availability.then(() => refreshActiveGitDetails(queryClient, cwd))
+      : availability;
+  return trackGitRefresh(queryClient, cwd, depth, refresh, availability);
 }
 
 export function refreshGitActionAvailability(queryClient: QueryClient, cwd: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Serialize Git availability and detail refreshes per repository to avoid overlapping expensive reads
- Refresh stacked-action Git status in the background so completed actions resolve promptly
- Add capacity-aware retries and clearer delayed-refresh messaging
- Add unit tests for refresh coalescing, serialization, non-blocking invalidation, and retry behavior

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Git UI refresh and mutation completion paths; behavior changes could leave stale action availability or race refreshes, but scope is client query orchestration plus a detached server status refresh rather than git mutation logic itself.
> 
> **Overview**
> Git React Query invalidation is replaced with **per-repo refresh orchestration** that coalesces overlapping work, refreshes status/branches first, then runs diff/PR detail refetches **one at a time** so expensive reads do not pile up across worktrees.
> 
> **Stacked git actions** no longer block on a synchronous status refresh on the server or on awaiting query invalidation in the client; status refresh is **forked in the background** after the action completes. Pull/stacked-action mutations fire cwd-scoped invalidation **without awaiting** it.
> 
> Git queries gain **capacity-aware retries** (`RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED` with server `retryAfterMs`). The git actions UI uses **availability-only** refresh when opening menus or when branch/status is out of sync, and shows a muted “delayed” message instead of a hard error when capacity is exceeded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3239ebe66eb0312713d3be0bb389e693882bf932. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->