### PR TITLE
Fix OpenCode and Antigravity provider issues on Windows

### DIFF
--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -99,9 +99,54 @@ GPT-OSS 120B (Medium)
     ]);
   });
 
+  it("collapses tab-separated slug/label rows from newer agy models output", () => {
+    expect(
+      parseAntigravityModelLines(`
+gemini-3.6-flash-high\tGemini 3.6 Flash (High)
+gemini-3.6-flash-medium\tGemini 3.6 Flash (Medium)
+gemini-3.6-flash-low\tGemini 3.6 Flash (Low)
+gemini-3.1-pro-high\tGemini 3.1 Pro (High)
+gemini-3.1-pro-low\tGemini 3.1 Pro (Low)
+claude-sonnet-4-6\tClaude Sonnet 4.6 (Thinking)
+`),
+    ).toEqual([
+      {
+        slug: "Gemini 3.6 Flash",
+        name: "Gemini 3.6 Flash",
+        supportedReasoningEfforts: [
+          { value: "low", label: "Low" },
+          { value: "medium", label: "Medium" },
+          { value: "high", label: "High" },
+        ],
+        defaultReasoningEffort: "medium",
+      },
+      {
+        slug: "Gemini 3.1 Pro",
+        name: "Gemini 3.1 Pro",
+        supportedReasoningEfforts: [
+          { value: "low", label: "Low" },
+          { value: "high", label: "High" },
+        ],
+        defaultReasoningEffort: "low",
+      },
+      {
+        slug: "Claude Sonnet 4.6",
+        name: "Claude Sonnet 4.6",
+        supportedReasoningEfforts: [{ value: "thinking", label: "Thinking" }],
+        defaultReasoningEffort: "thinking",
+      },
+    ]);
+  });
+
   it("rebuilds the exact CLI model label only at dispatch", () => {
     expect(parseAntigravityCliModelLabel("Gemini 3.5 Flash (High)")).toEqual({
       model: "Gemini 3.5 Flash",
+      effort: "high",
+    });
+    expect(
+      parseAntigravityCliModelLabel("gemini-3.6-flash-high\tGemini 3.6 Flash (High)"),
+    ).toEqual({
+      model: "Gemini 3.6 Flash",
       effort: "high",
     });
     expect(resolveAntigravityCliModelLabel("Gemini 3.5 Flash")).toBe("Gemini 3.5 Flash (Medium)");
@@ -111,6 +156,9 @@ GPT-OSS 120B (Medium)
     expect(resolveAntigravityCliModelLabel("Gemini 3.5 Flash (Low)")).toBe(
       "Gemini 3.5 Flash (Low)",
     );
+    expect(
+      resolveAntigravityCliModelLabel("gemini-3.6-flash-high\tGemini 3.6 Flash (High)"),
+    ).toBe("Gemini 3.6 Flash (High)");
   });
 
   it("accepts bullet-prefixed model output", () => {

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -442,6 +442,7 @@ export function buildAntigravityTurnPrompt(
 }
 
 const DEFAULT_EFFORT_BY_MODEL: Readonly<Record<string, string>> = {
+  "Gemini 3.6 Flash": "medium",
   "Gemini 3.5 Flash": "medium",
   "Gemini 3.1 Pro": "low",
   "Claude Sonnet 4.6": "thinking",
@@ -462,11 +463,18 @@ function effortLabel(value: string): string {
 export function parseAntigravityCliModelLabel(
   value: string,
 ): { model: string; effort?: string } | null {
-  const trimmed = value
-    .replace(/\x1b\[[0-9;]*m/g, "")
-    .trim()
-    .replace(/^(?:[*•-]\s+)+/u, "");
+  const stripped = value.replace(/\x1b\[[0-9;]*m/g, "").trim();
+  if (!stripped) return null;
+
+  // Newer `agy models` rows are `slug<TAB>Display Name (Effort)`. Older builds
+  // printed only the display label. Prefer the display column when present so
+  // Synara never treats `slug\tName` as a single model id at dispatch.
+  const tabIndex = stripped.indexOf("\t");
+  const labelColumn =
+    tabIndex >= 0 ? stripped.slice(tabIndex + 1).trim() : stripped.replace(/^(?:[*•-]\s+)+/u, "");
+  const trimmed = labelColumn.replace(/^(?:[*•-]\s+)+/u, "").trim();
   if (!trimmed) return null;
+
   const match = trimmed.match(/^(.*?)\s+\(([^()]+)\)$/u);
   if (!match?.[1] || !match[2]) return { model: trimmed };
   return {
@@ -527,11 +535,13 @@ export function resolveAntigravityCliModelLabel(
 ): string {
   const parsed = parseAntigravityCliModelLabel(model);
   if (!parsed) return model;
-  if (parsed.effort) return model.trim();
   const effort =
+    parsed.effort ??
     options?.reasoningEffort?.trim().toLowerCase() ??
     discoveredDefaultEffort?.trim().toLowerCase() ??
     DEFAULT_EFFORT_BY_MODEL[parsed.model];
+  // Always rebuild the CLI display label. Returning the raw input would preserve
+  // corrupted `slug\tName (Effort)` rows from older discovery parsing.
   return effort ? `${parsed.model} (${effortLabel(effort)})` : parsed.model;
 }
 

--- a/apps/server/src/provider/OpenCodeDiscovery.test.ts
+++ b/apps/server/src/provider/OpenCodeDiscovery.test.ts
@@ -25,6 +25,7 @@ function makeProvider(input: {
   name: string;
   source?: Provider["source"];
   env?: ReadonlyArray<string>;
+  options?: Record<string, unknown>;
   models?: Record<string, TestModelInput>;
 }): Provider {
   return {
@@ -32,7 +33,7 @@ function makeProvider(input: {
     name: input.name,
     source: input.source ?? "api",
     env: input.env ? [...input.env] : [],
-    options: {},
+    options: input.options ?? {},
     models: Object.fromEntries(
       Object.entries(input.models ?? {}).map(([modelId, model]) => [
         modelId,
@@ -196,6 +197,34 @@ describe("resolvePreferredOpenCodeModelProviders", () => {
     });
 
     expect(providers.map((provider) => provider.id)).toEqual(["opencode"]);
+  });
+
+  it("keeps connected config providers with inline apiKey even without auth.json credentials", () => {
+    const providers = resolvePreferredOpenCodeModelProviders({
+      inventory: {
+        providerList: {
+          connected: ["fastapicloud", "opencode"],
+          all: [
+            makeProvider({
+              id: "fastapicloud",
+              name: "FastAPI Cloud AI",
+              source: "config",
+              options: { baseURL: "https://example.invalid/v1", apiKey: "test-key" },
+            }),
+            makeProvider({
+              id: "opencode",
+              name: "OpenCode Zen",
+              source: "custom",
+              env: ["OPENCODE_API_KEY"],
+            }),
+          ],
+        },
+        consoleState: null,
+      },
+      credentialProviderIDs: ["unrelated"],
+    });
+
+    expect(providers.map((provider) => provider.id)).toEqual(["fastapicloud", "opencode"]);
   });
 
   it("falls back to non-environment connected providers when no stronger OpenCode signals exist", () => {

--- a/apps/server/src/provider/OpenCodeDiscovery.ts
+++ b/apps/server/src/provider/OpenCodeDiscovery.ts
@@ -80,6 +80,16 @@ function isOpenCodeManagedProvider(provider: OpenCodeInventoryProvider) {
   );
 }
 
+// Custom providers declared in opencode.jsonc carry their credential inline
+// (`options.apiKey`) instead of through auth.json, so they never appear in
+// credentialProviderIDs even though `connected` already proves they are usable.
+function hasInlineConfiguredApiKey(provider: OpenCodeInventoryProvider): boolean {
+  return (
+    trimNonEmptyString(provider.options?.apiKey) !== undefined ||
+    trimNonEmptyString(provider.options?.api_key) !== undefined
+  );
+}
+
 export function resolvePreferredOpenCodeModelProviders(input: {
   readonly inventory: OpenCodeModelInventory;
   readonly credentialProviderIDs?: ReadonlyArray<string>;
@@ -94,8 +104,8 @@ export function resolvePreferredOpenCodeModelProviders(input: {
   }
 
   const credentialProviders = new Set(input.credentialProviderIDs ?? []);
-  const authenticatedConnectedProviders = connectedProviders.filter((provider) =>
-    credentialProviders.has(provider.id),
+  const authenticatedConnectedProviders = connectedProviders.filter(
+    (provider) => credentialProviders.has(provider.id) || hasInlineConfiguredApiKey(provider),
   );
 
   const consoleManagedProviders = new Set(inventory.consoleState?.consoleManagedProviders ?? []);

--- a/apps/server/src/provider/opencodeRuntime.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.test.ts
@@ -7,7 +7,8 @@ import { Duration, Effect, Exit, Fiber, Layer, Scope, Sink, Stream } from "effec
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { TestClock } from "effect/testing";
 import type { ChatAttachment } from "@synara/contracts";
-import { describe, expect, it } from "vitest";
+import { resolveWindowsComSpec } from "@synara/shared/windowsProcess";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   buildOpenCodePermissionRules,
@@ -68,10 +69,17 @@ function mockOpenCodeServerHandle(input: {
   });
 }
 
-function mockOpenCodeServerSpawnerLayer(input: { stdout: string; stderr: string }) {
+function mockOpenCodeServerSpawnerLayer(input: {
+  stdout: string;
+  stderr: string;
+  spawnedCommands?: Array<ChildProcess.StandardCommand>;
+}) {
   return Layer.succeed(
     ChildProcessSpawner.ChildProcessSpawner,
-    ChildProcessSpawner.make(() => Effect.succeed(mockOpenCodeServerHandle(input))),
+    ChildProcessSpawner.make((command) => {
+      if (command._tag === "StandardCommand") input.spawnedCommands?.push(command);
+      return Effect.succeed(mockOpenCodeServerHandle(input));
+    }),
   );
 }
 
@@ -223,6 +231,62 @@ describe("buildOpenCodeServerProcessEnv", () => {
 });
 
 describe("OpenCodeRuntime startup diagnostics", () => {
+  it("wraps Windows .cmd server shims before spawning", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const spawnedCommands: Array<ChildProcess.StandardCommand> = [];
+
+    try {
+      const server = await Effect.runPromise(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const runtime = yield* OpenCodeRuntime;
+            return yield* runtime.startOpenCodeServerProcess({
+              binaryPath: "C:\\Users\\Test User\\AppData\\Roaming\\npm\\opencode.cmd",
+              hostname: "127.0.0.1",
+              port: 58_123,
+            });
+          }),
+        ).pipe(
+          Effect.provide(
+            makeOpenCodeRuntimeLive({
+              teardownProcessTree: async () => ({
+                escalated: false,
+                signalErrors: [],
+              }),
+            }).pipe(
+              Layer.provide(
+                mockOpenCodeServerSpawnerLayer({
+                  stdout: "opencode server listening on http://127.0.0.1:58123\n",
+                  stderr: "",
+                  spawnedCommands,
+                }),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(server.url).toBe("http://127.0.0.1:58123");
+      expect(spawnedCommands).toHaveLength(1);
+      expect(spawnedCommands[0]).toMatchObject({
+        command: resolveWindowsComSpec(),
+        args: [
+          "/d",
+          "/s",
+          "/v:off",
+          "/c",
+          'call "C:\\Users\\Test User\\AppData\\Roaming\\npm\\opencode.cmd" "serve" "--hostname" "127.0.0.1" "--port" "58123"',
+        ],
+        options: {
+          shell: false,
+          windowsVerbatimArguments: true,
+        },
+      });
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
   it("includes command and partial process output when server startup times out", async () => {
     const error = await Effect.runPromise(
       Effect.scoped(

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -967,16 +967,25 @@ const makeOpenCodeRuntime = (options?: OpenCodeRuntimeLiveOptions) =>
           ));
         const timeoutMs = input.timeoutMs ?? DEFAULT_OPENCODE_SERVER_TIMEOUT_MS;
         const args = ["serve", "--hostname", hostname, "--port", String(port)];
+        const childEnv = buildOpenCodeServerProcessEnv({
+          cliSpec,
+          ...(input.experimentalWebSockets !== undefined
+            ? { experimentalWebSockets: input.experimentalWebSockets }
+            : {}),
+        });
+        // Match runOpenCodeCommand: bare npm/pi-node shims like `opencode.cmd` need
+        // Windows-safe resolution before Effect/Node spawn can launch them.
+        const prepared = prepareWindowsSafeProcess(input.binaryPath, args, {
+          cwd: input.cwd,
+          env: childEnv,
+        });
 
         const child = yield* spawner
           .spawn(
-            ChildProcess.make(input.binaryPath, args, {
-              env: buildOpenCodeServerProcessEnv({
-                cliSpec,
-                ...(input.experimentalWebSockets !== undefined
-                  ? { experimentalWebSockets: input.experimentalWebSockets }
-                  : {}),
-              }),
+            ChildProcess.make(prepared.command, prepared.args, {
+              shell: prepared.shell,
+              ...(prepared.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
+              env: childEnv,
               ...(input.cwd ? { cwd: input.cwd } : {}),
               detached: false,
               killSignal: "SIGKILL",


### PR DESCRIPTION
## Summary

- **OpenCode spawn on Windows**: `startOpenCodeServerProcess` spawned the binary directly, but on Windows `opencode` is an npm/pi-node `.cmd` shim that Node's `spawn` cannot execute directly (ENOENT). It now goes through `prepareWindowsSafeProcess`, matching what `runOpenCodeCommand` already did.
- **Antigravity model parsing**: newer `agy models` output is tab-separated (`slug<TAB>Name (Effort)`). The parser now uses the display column and `resolveAntigravityCliModelLabel` always rebuilds the label, fixing duplicated/corrupted model names in the picker and `invalid model selection` errors when starting a chat.
- **OpenCode model discovery**: custom providers configured in `opencode.json` carry their `apiKey` inline in provider options instead of `auth.json`, so they never appeared in `credentialProviderIDs` and their models were dropped from the picker whenever another preferred provider existed. Connected providers with an inline `apiKey` now count as authenticated.

## Test plan

- [x] Unit tests added/updated: `opencodeRuntime.test.ts`, `AntigravityAdapter.test.ts`, `OpenCodeDiscovery.test.ts`
- [x] `bun fmt`, `bun lint`, `bun typecheck` (@synara/server) pass
- [x] Manual verification on Windows 11: OpenCode session starts, custom provider models (configured with inline `apiKey`) appear in the picker, Antigravity models render correctly and chats start