### PR TITLE
Fix transient Grok session storage startup

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -21,6 +21,7 @@ const emitUpstreamAssistantMessageIds =
 const emitReasoningThenToolCall = process.env.SYNARA_ACP_EMIT_REASONING_THEN_TOOL_CALL === "1";
 const emitGenericToolPlaceholders = process.env.SYNARA_ACP_EMIT_GENERIC_TOOL_PLACEHOLDERS === "1";
 const emitAskQuestion = process.env.SYNARA_ACP_EMIT_ASK_QUESTION === "1";
+const failSessionNewOnce = process.env.SYNARA_ACP_FAIL_SESSION_NEW_ONCE === "1";
 const failSetConfigOption = process.env.SYNARA_ACP_FAIL_SET_CONFIG_OPTION === "1";
 const exitOnSetConfigOption = process.env.SYNARA_ACP_EXIT_ON_SET_CONFIG_OPTION === "1";
 const promptResponseText = process.env.SYNARA_ACP_PROMPT_RESPONSE_TEXT;
@@ -37,6 +38,7 @@ let parameterizedModelPicker = false;
 let currentReasoning = "medium";
 let currentContext = "272k";
 let currentFast = false;
+let sessionNewAttempts = 0;
 const cancelledSessions = new Set<string>();
 
 function logExit(reason: string): void {
@@ -288,6 +290,13 @@ app.onRequest(OfficialAcp.methods.agent.initialize, ({ params: request }) =>
 app.onRequest(OfficialAcp.methods.agent.authenticate, () => ({}));
 
 app.onRequest(OfficialAcp.methods.agent.session.new, ({ client: context }) => {
+  sessionNewAttempts += 1;
+  if (failSessionNewOnce && sessionNewAttempts === 1) {
+    throw new OfficialAcp.RequestError(-32603, "Path not found.", {
+      code: "FS_NOT_FOUND",
+      detail: "No such file or directory (os error 2)",
+    });
+  }
   const client = makeClient(context);
   return runEffect(
     Effect.gen(function* () {

--- a/apps/server/src/provider/acp/AcpAdapterSupport.test.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSupport.test.ts
@@ -187,4 +187,23 @@ describe("AcpAdapterSupport", () => {
     expect(error.message).toContain('402 {"title":"Payment Required"}');
     expect(error.message).not.toContain("Internal error: Agent error");
   });
+
+  it("preserves filesystem detail from ACP persistence errors", () => {
+    const error = mapAcpToAdapterError(
+      "grok",
+      "thread-1" as never,
+      "session/start",
+      new AcpErrors.AcpRequestError({
+        code: -32603,
+        errorMessage: "Path not found.",
+        data: {
+          code: "FS_NOT_FOUND",
+          detail: "No such file or directory (os error 2)",
+        },
+      }),
+    );
+
+    expect(error.message).toContain("Path not found.");
+    expect(error.message).toContain("No such file or directory (os error 2)");
+  });
 });

--- a/apps/server/src/provider/acp/AcpAdapterSupport.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSupport.ts
@@ -34,19 +34,23 @@ export function canonicalItemTypeFromAcpToolKind(kind: string | undefined): Tool
 
 function acpRequestErrorDetail(error: AcpErrors.AcpRequestError): string {
   const message = error.message.trim();
+  const data =
+    typeof error.data === "object" && error.data !== null
+      ? (error.data as Record<string, unknown>)
+      : undefined;
+  const rawDataDetail = data?.detail ?? data?.details;
   const dataDetail =
     typeof error.data === "string"
       ? error.data.trim()
-      : typeof error.data === "object" && error.data !== null
-        ? (() => {
-            const data = error.data as Record<string, unknown>;
-            const detail = data.detail ?? data.details;
-            return typeof detail === "string" ? detail.trim() : "";
-          })()
+      : typeof rawDataDetail === "string"
+        ? rawDataDetail.trim()
         : "";
 
   if (dataDetail && /^(?:internal error(?:: agent error)?|agent error)$/iu.test(message)) {
     return dataDetail;
+  }
+  if (dataDetail && typeof data?.code === "string" && data.code.startsWith("FS_")) {
+    return message ? `${message} ${dataDetail}` : dataDetail;
   }
   return message || dataDetail || "ACP request failed.";
 }

--- a/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
+++ b/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
@@ -108,6 +108,55 @@ describe("AcpSessionRuntime", () => {
     );
   });
 
+  it.effect("retries one matching fresh session setup failure", () => {
+    const requestEvents: Array<AcpSessionRequestLogEvent> = [];
+    return Effect.gen(function* () {
+      const runtime = yield* AcpSessionRuntime;
+      const started = yield* runtime.start();
+
+      expect(started.sessionId).toBe("mock-session-1");
+      expect(
+        requestEvents.filter(
+          (event) => event.method === "session/new" && event.status === "started",
+        ),
+      ).toHaveLength(2);
+      expect(
+        requestEvents.filter(
+          (event) => event.method === "initialize" && event.status === "started",
+        ),
+      ).toHaveLength(1);
+    }).pipe(
+      Effect.provide(
+        AcpSessionRuntime.layer({
+          spawn: {
+            command: bunExe,
+            args: [mockAgentPath],
+            env: {
+              VITEST: "true",
+              SYNARA_ACP_FAIL_SESSION_NEW_ONCE: "1",
+            },
+          },
+          cwd: process.cwd(),
+          clientInfo: { name: "synara-test", version: "0.0.0" },
+          authMethodId: "test",
+          freshSessionRetry: {
+            shouldRetry: (error) =>
+              error._tag === "AcpRequestError" &&
+              typeof error.data === "object" &&
+              error.data !== null &&
+              (error.data as { readonly code?: unknown }).code === "FS_NOT_FOUND",
+          },
+          requestLogger: (event) =>
+            Effect.sync(() => {
+              requestEvents.push(event);
+            }),
+        }),
+      ),
+      Effect.scoped,
+      Effect.provide(NodeServices.layer),
+    );
+  });
+
   it.effect("loads a resumed session and still prompts normally", () =>
     Effect.gen(function* () {
       const runtime = yield* AcpSessionRuntime;

--- a/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
@@ -8,9 +8,11 @@ import {
   awaitAcpChildExit,
   decodeSetSessionConfigOptionResponse,
   makeAcpIncomingFrameGuard,
+  runAcpFreshSessionSetup,
   sessionConfigOptionsFromSetup,
   teardownAcpChildProcess,
 } from "./AcpSessionRuntime.ts";
+import * as AcpErrors from "./AcpErrors.ts";
 
 describe("makeAcpIncomingFrameGuard", () => {
   const encode = (value: string) => new TextEncoder().encode(value);
@@ -102,6 +104,52 @@ describe("awaitAcpChildExit", () => {
 
     expect(successfulCompleted).toBe(true);
     expect(failedCompleted).toBe(true);
+  });
+});
+
+describe("runAcpFreshSessionSetup", () => {
+  it("retries one matching fresh-session failure and then succeeds", async () => {
+    const retryable = new AcpErrors.AcpRequestError({
+      code: -32603,
+      errorMessage: "Path not found.",
+      data: { code: "FS_NOT_FOUND" },
+    });
+    let attempts = 0;
+    const setup = Effect.suspend(() => {
+      attempts += 1;
+      return attempts === 1 ? Effect.fail(retryable) : Effect.succeed("session-ready");
+    });
+
+    await expect(
+      Effect.runPromise(
+        runAcpFreshSessionSetup(setup, {
+          shouldRetry: (error) => error === retryable,
+        }),
+      ),
+    ).resolves.toBe("session-ready");
+    expect(attempts).toBe(2);
+  });
+
+  it("does not retry a non-matching failure", async () => {
+    const terminal = new AcpErrors.AcpRequestError({
+      code: -32603,
+      errorMessage: "Permission denied.",
+      data: { code: "FS_PERMISSION_DENIED" },
+    });
+    let attempts = 0;
+    const setup = Effect.suspend(() => {
+      attempts += 1;
+      return Effect.fail(terminal);
+    });
+
+    await expect(
+      Effect.runPromise(
+        runAcpFreshSessionSetup(setup, {
+          shouldRetry: () => false,
+        }),
+      ),
+    ).rejects.toThrow("Permission denied.");
+    expect(attempts).toBe(1);
   });
 });
 

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -173,6 +173,34 @@ export interface AcpSpawnInput {
   readonly env?: NodeJS.ProcessEnv;
 }
 
+export interface AcpFreshSessionRetryPolicy {
+  readonly shouldRetry: (error: AcpErrors.AcpError) => boolean;
+  readonly delayMs?: number;
+}
+
+/**
+ * Retries one fresh `session/new` request when the provider reports a failure
+ * that is known to occur before a session exists. Resume/load requests must not
+ * use this path because repeating them can make delivery ambiguous.
+ */
+export function runAcpFreshSessionSetup<A>(
+  setup: Effect.Effect<A, AcpErrors.AcpError>,
+  retryPolicy: AcpFreshSessionRetryPolicy | undefined,
+): Effect.Effect<A, AcpErrors.AcpError> {
+  if (retryPolicy === undefined) {
+    return setup;
+  }
+  return setup.pipe(
+    Effect.catch((error) => {
+      if (!retryPolicy.shouldRetry(error)) {
+        return Effect.fail(error);
+      }
+      const delayMs = retryPolicy.delayMs ?? 0;
+      return delayMs > 0 ? Effect.sleep(delayMs).pipe(Effect.andThen(setup)) : setup;
+    }),
+  );
+}
+
 export interface AcpSessionRuntimeOptions {
   readonly spawn: AcpSpawnInput;
   readonly cwd: string;
@@ -195,6 +223,8 @@ export interface AcpSessionRuntimeOptions {
    */
   readonly buildMcpServers?: (initializeResult: Acp.InitializeResponse) => Array<Acp.McpServer>;
   readonly authenticateMeta?: Record<string, unknown>;
+  /** Optional one-time retry for a fresh session/new failure. Never applies to resume/load. */
+  readonly freshSessionRetry?: AcpFreshSessionRetryPolicy;
   /** Overrides for {@link DEFAULT_ACP_SESSION_STARTUP_TIMEOUTS}. */
   readonly startupTimeouts?: Partial<AcpSessionStartupTimeouts>;
   readonly requestLogger?: (event: AcpSessionRequestLogEvent) => Effect.Effect<void, never>;
@@ -1144,7 +1174,10 @@ const makeAcpSessionRuntime = (
         const created = yield* withStartupTimeout(
           "session/new",
           startupTimeouts.sessionSetupMs,
-          runLoggedRequest("session/new", createPayload, acp.agent.createSession(createPayload)),
+          runAcpFreshSessionSetup(
+            runLoggedRequest("session/new", createPayload, acp.agent.createSession(createPayload)),
+            options.freshSessionRetry,
+          ),
         );
         sessionId = created.sessionId;
         sessionSetupResult = created;

--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -7,6 +7,7 @@ import { resolveAcpPermissionPolicy } from "./AcpAdapterSupport.ts";
 import {
   applyGrokAcpModelSelection,
   buildGrokAcpSpawnInput,
+  isGrokSessionStoragePathNotFoundError,
   resolveGrokAcpAuthMethodId,
   runGrokAcpCompactionCommand,
 } from "./GrokAcpSupport.ts";
@@ -79,6 +80,40 @@ describe("buildGrokAcpSpawnInput", () => {
       "--always-approve",
       "stdio",
     ]);
+  });
+});
+
+describe("isGrokSessionStoragePathNotFoundError", () => {
+  it("matches Grok's stable persistence code", () => {
+    expect(
+      isGrokSessionStoragePathNotFoundError(
+        new AcpErrors.AcpRequestError({
+          code: -32603,
+          errorMessage: "Path not found.",
+          data: { code: "FS_NOT_FOUND", detail: "No such file or directory (os error 2)" },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not retry other ACP or filesystem failures", () => {
+    expect(
+      isGrokSessionStoragePathNotFoundError(
+        new AcpErrors.AcpRequestError({
+          code: -32603,
+          errorMessage: "Permission denied.",
+          data: { code: "FS_PERMISSION_DENIED" },
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isGrokSessionStoragePathNotFoundError(
+        new AcpErrors.AcpTransportError({
+          detail: "connection closed",
+          cause: new Error("connection closed"),
+        }),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/apps/server/src/provider/acp/GrokAcpSupport.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.ts
@@ -25,7 +25,7 @@ export interface GrokAcpRuntimeSettings {
 
 export interface GrokAcpRuntimeInput extends Omit<
   AcpSessionRuntimeOptions,
-  "authMethodId" | "resolveAuthMethodId" | "spawn"
+  "authMethodId" | "freshSessionRetry" | "resolveAuthMethodId" | "spawn"
 > {
   readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
   readonly grokSettings: GrokAcpRuntimeSettings | null | undefined;
@@ -43,6 +43,15 @@ const GROK_INTERACTIVE_AUTH_METHOD_IDS = new Set(["browser_login", "grok.com"]);
 const GROK_API_KEY_ENV_KEYS = ["XAI_API_KEY", "GROK_CODE_XAI_API_KEY"] as const;
 const GROK_COMPACT_COMMAND_NAME = "compact";
 const GROK_COMPACT_PROMPT = "/compact";
+const GROK_SESSION_STORAGE_NOT_FOUND_CODE = "FS_NOT_FOUND";
+const GROK_SESSION_STORAGE_RETRY_DELAY_MS = 100;
+
+export function isGrokSessionStoragePathNotFoundError(error: AcpErrors.AcpError): boolean {
+  if (error._tag !== "AcpRequestError" || typeof error.data !== "object" || error.data === null) {
+    return false;
+  }
+  return (error.data as { readonly code?: unknown }).code === GROK_SESSION_STORAGE_NOT_FOUND_CODE;
+}
 
 export function getGrokApiKeyEnv(env: NodeJS.ProcessEnv = process.env): string | undefined {
   for (const key of GROK_API_KEY_ENV_KEYS) {
@@ -191,6 +200,10 @@ export const makeGrokAcpRuntime = (
         spawn: buildGrokAcpSpawnInput(input.grokSettings, input.cwd, input.runtimeMode),
         resolveAuthMethodId: resolveGrokAcpAuthMethodId,
         authenticateMeta: { headless: true },
+        freshSessionRetry: {
+          shouldRetry: isGrokSessionStoragePathNotFoundError,
+          delayMs: GROK_SESSION_STORAGE_RETRY_DELAY_MS,
+        },
       }).pipe(
         Layer.provide(
           Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, input.childProcessSpawner),


### PR DESCRIPTION
## Summary

- retry a fresh Grok `session/new` once when Grok reports its stable `FS_NOT_FOUND` persistence error
- keep resume/load requests non-retryable to avoid ambiguous session delivery
- preserve Grok filesystem details when the retry still fails
- add focused unit and subprocess integration coverage

## Root cause

Grok 1.0.0 can return `FS_NOT_FOUND` while initializing local session persistence before a provider session exists. Synara previously failed the start immediately and discarded the low-level `data.detail`, leaving only `Path not found.`

## User impact

Transient Grok persistence initialization failures now recover automatically. Persistent failures remain visible with the underlying filesystem detail so they can be diagnosed.

## Verification

- `bun run --cwd apps/server test -- src/provider/acp/AcpAdapterSupport.test.ts src/provider/acp/AcpSessionRuntime.test.ts src/provider/acp/GrokAcpSupport.test.ts src/provider/acp/AcpJsonRpcConnection.test.ts`
- 4 test files passed, 62 tests passed
- `git diff --check`

Repository-wide `bun fmt`, `bun lint`, and `bun typecheck` were not run because project instructions require an explicit user request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session startup behavior for Grok only, with bounded one retry on fresh sessions; resume/load paths are explicitly excluded to limit ambiguity risk.
> 
> **Overview**
> Adds a **one-time retry** for fresh `session/new` when Grok reports `FS_NOT_FOUND` during local session persistence setup, so transient startup races recover instead of failing immediately.
> 
> `runAcpFreshSessionSetup` wraps only the new-session path; **resume/load stay non-retryable** to avoid ambiguous duplicate sessions. Grok’s runtime wires this with `isGrokSessionStoragePathNotFoundError` and a 100ms delay.
> 
> When errors still surface, **`mapAcpToAdapterError`** now keeps filesystem `data.detail` for `FS_*` codes (not just generic internal errors), so failures show both “Path not found.” and the OS detail.
> 
> The mock ACP agent can fail `session/new` once via `SYNARA_ACP_FAIL_SESSION_NEW_ONCE`; unit and subprocess tests cover retry policy, error mapping, and end-to-end recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32a9dd1833a8963f821971d279b9ba6d199da093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->