### PR TITLE
Guard Expo and Metro server title probing

### DIFF
--- a/apps/server/src/localServerMonitor.test.ts
+++ b/apps/server/src/localServerMonitor.test.ts
@@ -32,6 +32,16 @@ async function withMockedFetch<T>(
   }
 }
 
+function buildServerForCommand(commandLine: string, port: number) {
+  const processInfo = new Map<number, LocalServerProcessInfo>([
+    [123, { ppid: 1, commandLine }],
+  ]);
+  return buildLocalServerProcesses(
+    parseLsofTcpListenOutput(["p123", "cnode", "PTCP", `n127.0.0.1:${port}`].join("\n")),
+    processInfo,
+  );
+}
+
 describe("localServerMonitor", () => {
   it("parses lsof listener records into local endpoints", () => {
     const listeners = parseLsofTcpListenOutput(
@@ -287,6 +297,53 @@ describe("localServerMonitor", () => {
 
     expect(enriched[0]?.displayName).toBe("Vite");
     expect(enriched[0]?.pageTitle).toBe("Acme Admin");
+  });
+
+  it.each([
+    ["Expo CLI", "node ./node_modules/@expo/cli/build/bin/cli start", "Expo"],
+    ["Expo through bunx", "bunx expo start", "Expo"],
+    ["standalone Metro", "node ./node_modules/metro/src/index.js", "Metro"],
+    ["React Native CLI", "react-native start", "Metro"],
+  ])("keeps %s visible without probing it", async (_case, commandLine, displayName) => {
+    const servers = buildServerForCommand(commandLine, 8081);
+    const fetchTitle = vi.fn(async () => "Unexpected browser title");
+
+    const enriched = await enrichLocalServerProcessesWithPageTitles(servers, fetchTitle);
+
+    expect(enriched[0]).toMatchObject({
+      displayName,
+      ports: [8081],
+    });
+    expect(fetchTitle).not.toHaveBeenCalled();
+  });
+
+  it("allows page-title probing when Expo is explicitly started for web", async () => {
+    const servers = buildServerForCommand(
+      "node ./node_modules/@expo/cli/build/bin/cli start --web",
+      8081,
+    );
+    const fetchTitle = vi.fn(async () => "Expo Web");
+
+    const enriched = await enrichLocalServerProcessesWithPageTitles(servers, fetchTitle);
+
+    expect(enriched[0]).toMatchObject({
+      displayName: "Expo",
+      pageTitle: "Expo Web",
+    });
+    expect(fetchTitle).toHaveBeenCalledOnce();
+  });
+
+  it("does not classify browser servers from project directory names", async () => {
+    const servers = buildServerForCommand(
+      "node /projects/expo-app/node_modules/vite/bin/vite.js",
+      5173,
+    );
+    const fetchTitle = vi.fn(async () => "Vite App");
+
+    const enriched = await enrichLocalServerProcessesWithPageTitles(servers, fetchTitle);
+
+    expect(enriched[0]).toMatchObject({ displayName: "Vite", pageTitle: "Vite App" });
+    expect(fetchTitle).toHaveBeenCalledOnce();
   });
 
   it("keeps page-title redirects on local/private hosts", async () => {

--- a/apps/server/src/localServerMonitor.test.ts
+++ b/apps/server/src/localServerMonitor.test.ts
@@ -33,9 +33,7 @@ async function withMockedFetch<T>(
 }
 
 function buildServerForCommand(commandLine: string, port: number) {
-  const processInfo = new Map<number, LocalServerProcessInfo>([
-    [123, { ppid: 1, commandLine }],
-  ]);
+  const processInfo = new Map<number, LocalServerProcessInfo>([[123, { ppid: 1, commandLine }]]);
   return buildLocalServerProcesses(
     parseLsofTcpListenOutput(["p123", "cnode", "PTCP", `n127.0.0.1:${port}`].join("\n")),
     processInfo,
@@ -330,6 +328,23 @@ describe("localServerMonitor", () => {
       displayName: "Expo",
       pageTitle: "Expo Web",
     });
+    expect(fetchTitle).toHaveBeenCalledOnce();
+  });
+
+  it("uses parent process arguments to recognize Expo web mode", async () => {
+    const processInfo = new Map<number, LocalServerProcessInfo>([
+      [123, { ppid: 456, commandLine: "node generic-listener.js" }],
+      [456, { ppid: 1, commandLine: "bunx expo start --web" }],
+    ]);
+    const servers = buildLocalServerProcesses(
+      parseLsofTcpListenOutput(["p123", "cnode", "PTCP", "n127.0.0.1:8081"].join("\n")),
+      processInfo,
+    );
+    const fetchTitle = vi.fn(async () => "Expo Web");
+
+    const enriched = await enrichLocalServerProcessesWithPageTitles(servers, fetchTitle);
+
+    expect(enriched[0]).toMatchObject({ displayName: "Expo", pageTitle: "Expo Web" });
     expect(fetchTitle).toHaveBeenCalledOnce();
   });
 

--- a/apps/server/src/localServerMonitor.ts
+++ b/apps/server/src/localServerMonitor.ts
@@ -121,6 +121,8 @@ const DEV_ARGS_PATTERN =
 
 const pageTitleCache = new Map<string, CachedPageTitle>();
 const pageTitleInFlight = new Map<string, Promise<string | null>>();
+// Preserve lineage-only command context without extending the public local-server contract.
+const pageTitleProbeArgs = new WeakMap<ServerLocalServerProcess, string>();
 
 function execFileText(command: string, args: readonly string[]): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -271,7 +273,10 @@ function tokenizeCommandLine(commandLine: string): string[] {
 }
 
 function commandTokenName(token: string): string {
-  return path.basename(token).replace(/\.[cm]?js$/i, "").toLowerCase();
+  return path
+    .basename(token)
+    .replace(/\.[cm]?js$/i, "")
+    .toLowerCase();
 }
 
 function normalizeCommandName(command: string, args: string): string {
@@ -696,10 +701,11 @@ function pageTitleCandidateUrls(server: ServerLocalServerProcess): string[] {
 }
 
 function allowsPageTitleProbe(server: ServerLocalServerProcess): boolean {
-  if (server.displayName === "Expo" || isExpoDevServerCommand(server.command, server.args)) {
-    return tokenizeCommandLine(server.args).includes("--web");
+  const detectionArgs = pageTitleProbeArgs.get(server) ?? server.args;
+  if (server.displayName === "Expo" || isExpoDevServerCommand(server.command, detectionArgs)) {
+    return tokenizeCommandLine(detectionArgs).includes("--web");
   }
-  return server.displayName !== "Metro" && !isMetroDevServerCommand(server.command, server.args);
+  return server.displayName !== "Metro" && !isMetroDevServerCommand(server.command, detectionArgs);
 }
 
 async function firstResolvedPageTitle(
@@ -811,7 +817,7 @@ function toServerProcess(
 
   const isStoppable = isProcessSignalable(pid);
   const cwd = resolveProcessCwd(pid, processInfoByPid, cwdByPid);
-  return {
+  const server: ServerLocalServerProcess = {
     id: `${pid}:${ports.join(",")}`,
     pid,
     ...(typeof processInfo?.ppid === "number" && processInfo.ppid > 0
@@ -826,6 +832,8 @@ function toServerProcess(
     isStoppable,
     ...(isStoppable ? {} : { stopDisabledReason: "Synara cannot signal this process." }),
   };
+  pageTitleProbeArgs.set(server, detectionArgs);
+  return server;
 }
 
 // Resolves the working directory for a listener, walking up the process lineage

--- a/apps/server/src/localServerMonitor.ts
+++ b/apps/server/src/localServerMonitor.ts
@@ -270,12 +270,38 @@ function tokenizeCommandLine(commandLine: string): string[] {
     .filter((token) => token.length > 0);
 }
 
+function commandTokenName(token: string): string {
+  return path.basename(token).replace(/\.[cm]?js$/i, "").toLowerCase();
+}
+
 function normalizeCommandName(command: string, args: string): string {
-  const firstToken = tokenizeCommandLine(args)[0] ?? command;
-  return path
-    .basename(firstToken || command)
-    .replace(/\.[cm]?js$/i, "")
-    .toLowerCase();
+  return commandTokenName(tokenizeCommandLine(args)[0] ?? command);
+}
+
+function processCommandTokens(command: string, args: string): string[] {
+  return tokenizeCommandLine(`${command} ${args}`);
+}
+
+function isExpoDevServerCommand(command: string, args: string): boolean {
+  return processCommandTokens(command, args).some((token) => {
+    const normalizedToken = token.replaceAll("\\", "/").toLowerCase();
+    return (
+      commandTokenName(token) === "expo" || normalizedToken.includes("/node_modules/@expo/cli/")
+    );
+  });
+}
+
+function isMetroDevServerCommand(command: string, args: string): boolean {
+  const tokens = processCommandTokens(command, args);
+  const tokenNames = tokens.map(commandTokenName);
+  const reactNativeIndex = tokenNames.indexOf("react-native");
+  return (
+    tokenNames.includes("metro") ||
+    tokens.some((token) =>
+      token.replaceAll("\\", "/").toLowerCase().includes("/node_modules/metro/"),
+    ) ||
+    (reactNativeIndex >= 0 && tokenNames.slice(reactNativeIndex + 1).includes("start"))
+  );
 }
 
 // Some dev tools let a generic child own the port while the parent has the useful command.
@@ -345,18 +371,21 @@ function devScriptNameFromArgs(args: string): string | null {
 
 function detectDevServerKindFromText(input: DevServerCandidateInput): string | null {
   const commandName = normalizeCommandName(input.command, input.args);
+  const text = normalizeProcessText(input.command, input.args);
+  if (isExpoDevServerCommand(input.command, input.args)) return "Expo";
+  if (isMetroDevServerCommand(input.command, input.args)) return "Metro";
+
   const directToolLabel = DEV_COMMAND_LABELS.get(commandName);
   if (directToolLabel) {
     if (commandName === "next" && !/\bnext\s+dev\b/i.test(input.args)) return null;
     return directToolLabel;
   }
-
-  const text = normalizeProcessText(input.command, input.args);
-  if (/(^|[\s/\\])vite(?:\.js|\.mjs|\.cjs)?(?:\s|$)/i.test(text)) return "Vite";
+  if (/(^|[\s/\\])vite(?:\.js|\.mjs|\.cjs)?(?:\s|$)/i.test(text)) {
+    return "Vite";
+  }
   if (/\bnext\s+dev\b/i.test(text)) return "Next.js";
   if (/\bnuxt\b/i.test(text)) return "Nuxt";
   if (/\bastro\b/i.test(text)) return "Astro";
-  if (/\bexpo\b/i.test(text)) return "Expo";
   if (/\bwebpack(?:-dev-server|\s+serve)\b/i.test(text)) return "Webpack";
   if (/\bparcel\b/i.test(text)) return "Parcel";
   if (/\buvicorn\b/i.test(text)) return "Uvicorn";
@@ -383,25 +412,6 @@ function detectDevServerKindFromText(input: DevServerCandidateInput): string | n
 
 export function isLikelyDevServerProcess(input: DevServerCandidateInput): boolean {
   return !isIgnoredLocalServerProcess(input) && detectDevServerKindFromText(input) !== null;
-}
-
-function formatDisplayName(command: string, args: string): string {
-  const textKind = detectDevServerKindFromText({ command, args, ports: [] });
-  if (textKind) return textKind;
-  const text = normalizeProcessText(command, args);
-  if (/\bvite\b/.test(text)) return "Vite";
-  if (/\bnext\b/.test(text)) return "Next.js";
-  if (/\bnuxt\b/.test(text)) return "Nuxt";
-  if (/\bastro\b/.test(text)) return "Astro";
-  if (/\bexpo\b/.test(text)) return "Expo";
-  if (/\bwebpack\b/.test(text)) return "Webpack";
-  if (/\bparcel\b/.test(text)) return "Parcel";
-  if (/\buvicorn\b/.test(text)) return "Uvicorn";
-  if (/\bflask\b/.test(text)) return "Flask";
-  if (/(?:manage\.py\s+runserver)|\bdjango\b/.test(text)) return "Django";
-  if (/(?:php\s+artisan\s+serve)|\blaravel\b/.test(text)) return "Laravel";
-  if (/\brails\b/.test(text)) return "Rails";
-  return path.basename(command).replace(/\.[cm]?js$/i, "") || command;
 }
 
 function addressUrl(address: Omit<ServerLocalServerAddress, "url">): string | null {
@@ -685,6 +695,13 @@ function pageTitleCandidateUrls(server: ServerLocalServerProcess): string[] {
   return localServerCandidateUrls(server.addresses);
 }
 
+function allowsPageTitleProbe(server: ServerLocalServerProcess): boolean {
+  if (server.displayName === "Expo" || isExpoDevServerCommand(server.command, server.args)) {
+    return tokenizeCommandLine(server.args).includes("--web");
+  }
+  return server.displayName !== "Metro" && !isMetroDevServerCommand(server.command, server.args);
+}
+
 async function firstResolvedPageTitle(
   urls: readonly string[],
   fetchTitle: (url: string) => Promise<string | null>,
@@ -721,6 +738,9 @@ export async function enrichLocalServerProcessesWithPageTitles(
   fetchTitle: (url: string) => Promise<string | null> = resolvePageTitleFromUrl,
 ): Promise<ServerLocalServerProcess[]> {
   return mapWithConcurrency(servers, PAGE_TITLE_FETCH_CONCURRENCY, async (server) => {
+    if (!allowsPageTitleProbe(server)) {
+      return server;
+    }
     const pageTitle = await firstResolvedPageTitle(pageTitleCandidateUrls(server), fetchTitle);
     return pageTitle ? { ...server, pageTitle } : server;
   });
@@ -780,7 +800,12 @@ function toServerProcess(
   const processInfo = processInfoByPid.get(pid);
   const args = processInfo?.commandLine ?? command;
   const detectionArgs = processLineageCommandLines(pid, processInfoByPid) ?? args;
-  if (!isLikelyDevServerProcess({ command, args: detectionArgs, ports })) {
+  const candidate = { command, args: detectionArgs, ports };
+  if (isIgnoredLocalServerProcess(candidate)) {
+    return null;
+  }
+  const displayName = detectDevServerKindFromText(candidate);
+  if (!displayName) {
     return null;
   }
 
@@ -793,7 +818,7 @@ function toServerProcess(
       ? { ppid: processInfo.ppid }
       : {}),
     command,
-    displayName: formatDisplayName(command, detectionArgs),
+    displayName,
     ...(cwd ? { cwd } : {}),
     args,
     ports,


### PR DESCRIPTION
## Summary

- Detect Expo and Metro servers from command tokens and package paths
- Keep React Native and Metro servers visible without browser title probes
- Only probe Expo page titles when started with `--web`
- Add regression coverage for command detection and project-name false positives

## Testing

- Added and ran focused unit tests for local server monitoring

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to local server labeling and optional localhost HTML fetches in the dev monitor; behavior is covered by new unit tests with no auth or data-path changes.
> 
> **Overview**
> Improves how **local dev servers** are labeled and when the monitor **fetches HTML page titles** for the UI.
> 
> **Detection:** Expo and Metro are identified from command tokens and package paths (`@expo/cli`, `metro`, `react-native start`) instead of loose `\bexpo\b` text, so paths like `expo-app/.../vite` stay **Vite**. Display names come directly from `detectDevServerKindFromText` (the old `formatDisplayName` fallback is removed).
> 
> **Page titles:** Metro and native Expo listeners are still listed but **skip HTTP title probes**. Expo only probes when `--web` is present, including when that flag lives on a **parent** process in the lineage. Lineage args are stored in a `WeakMap` so probe rules match detection without changing the public server shape.
> 
> **Tests:** New coverage for Expo/Metro skip-probe behavior, Expo `--web` probing, parent-lineage web mode, and the expo-in-path false positive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c7d1e4aed37ca132e6923ac61f61a5245f396bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->