### PR TITLE
Float the composer over a translucent frosted transcript

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -524,6 +524,7 @@ import {
   dispatchThreadMarkerRemove,
 } from "../threadMarkers";
 import { getComposerProviderState } from "./chat/composerProviderRegistry";
+import { composerTranscriptBottomInsetPx, useComposerOverlayHeight } from "./chat/composerOverlay";
 import {
   COMPOSER_COMMAND_MENU_FLOATING_WRAPPER_CLASS_NAME,
   COMPOSER_INPUT_SHELL_CLASS_NAME,
@@ -1201,6 +1202,11 @@ export default function ChatView({
     (store) => store.setModelSelectionAndSticky,
   );
   const timestampFormat = settings.timestampFormat;
+  // The composer floats over the transcript; its measured height becomes the
+  // transcript's bottom content inset (see composerOverlay.ts).
+  const { overlayRef: composerOverlayRef, overlayHeightPx: composerOverlayHeightPx } =
+    useComposerOverlayHeight();
+  const composerTranscriptInsetPx = composerTranscriptBottomInsetPx(composerOverlayHeightPx);
   const navigate = useNavigate();
   const { handleNewThread } = useHandleNewThread();
   const { handleNewChat } = useHandleNewChat();
@@ -5403,58 +5409,38 @@ export default function ChatView({
     };
   }, [activeThread?.id, composerFooterHasWideActions, isInactiveSplitPane]);
 
+  // A composer that grows (attachments, approval cards, queued turns) eats into the
+  // transcript's bottom content inset, which would push the tail behind the frosted
+  // surface. Re-stick a transcript that was already parked at the end.
+  //
+  // This is driven by the *committed* inset rather than by a ResizeObserver on the
+  // composer: the inset lands a render after the measurement, so a scroll scheduled
+  // from the observer would race the padding it is supposed to compensate for. Here
+  // the new padding is already in the DOM, so the pre-resize viewport is simply the
+  // current one with the inset delta backed out.
+  const previousComposerTranscriptInsetRef = useRef(composerTranscriptInsetPx);
   useLayoutEffect(() => {
-    if (isInactiveSplitPane || typeof ResizeObserver === "undefined") return;
-    const composerForm = composerFormRef.current;
-    if (!composerForm) return;
+    const previousInsetPx = previousComposerTranscriptInsetRef.current;
+    previousComposerTranscriptInsetRef.current = composerTranscriptInsetPx;
+    const insetDeltaPx = composerTranscriptInsetPx - previousInsetPx;
+    if (isInactiveSplitPane || Math.abs(insetDeltaPx) < 0.5) return;
 
-    let previousHeight = composerForm.getBoundingClientRect().height;
-    let pendingScrollTimeout: number | null = null;
-    const observer = new ResizeObserver((entries) => {
-      const [entry] = entries;
-      if (!entry) return;
-
-      const nextHeight = entry.contentRect.height;
-      const heightDelta = nextHeight - previousHeight;
-      previousHeight = nextHeight;
-      if (Math.abs(heightDelta) < 0.5) return;
-
-      const scrollContainer = legendListRef.current?.getScrollableNode?.();
-      // A composer resize can make LegendList report `isAtEnd: false` after the viewport
-      // has already changed. Reconstruct the pre-resize viewport so only an existing
-      // tail stick is preserved; a user who was already scrolled away stays there.
-      const wasNearEndBeforeResize =
-        scrollContainer instanceof HTMLElement &&
-        isScrollContainerNearBottom({
-          scrollTop: scrollContainer.scrollTop,
-          clientHeight: scrollContainer.clientHeight + heightDelta,
-          scrollHeight: scrollContainer.scrollHeight,
-        });
-      if (!wasNearEndBeforeResize) return;
-
-      if (pendingScrollTimeout !== null) {
-        window.clearTimeout(pendingScrollTimeout);
-      }
-      pendingScrollTimeout = window.setTimeout(() => {
-        pendingScrollTimeout = null;
-        scrollToEnd(false);
-      }, 0);
+    const scrollContainer = legendListRef.current?.getScrollableNode?.();
+    if (!(scrollContainer instanceof HTMLElement)) return;
+    const wasNearEndBeforeResize = isScrollContainerNearBottom({
+      scrollTop: scrollContainer.scrollTop,
+      clientHeight: scrollContainer.clientHeight,
+      scrollHeight: scrollContainer.scrollHeight - insetDeltaPx,
     });
+    if (!wasNearEndBeforeResize) return;
 
-    observer.observe(composerForm);
-    return () => {
-      observer.disconnect();
-      if (pendingScrollTimeout !== null) {
-        window.clearTimeout(pendingScrollTimeout);
-      }
-    };
-  }, [
-    activeThread?.id,
-    isInactiveSplitPane,
-    scrollToEnd,
-    secondaryChromeReady,
-    shouldRenderChatPaneContent,
-  ]);
+    // Compensate by the exact inset delta rather than asking the list to scroll to its
+    // end: LegendList re-measures the padded viewport on its own schedule, so an
+    // end-scroll issued in this commit would aim at the pre-padding content height and
+    // land a composer-growth short of the tail.
+    programmaticScrollUntilRef.current = performance.now() + 200;
+    scrollContainer.scrollTop += insetDeltaPx;
+  }, [composerTranscriptInsetPx, isInactiveSplitPane]);
 
   useEffect(() => {
     isAtEndRef.current = true;
@@ -11969,45 +11955,55 @@ export default function ChatView({
                         ? ENVIRONMENT_DOCKED_CONTENT_INSET_PX
                         : undefined
                     }
+                    contentInsetBottomPx={composerTranscriptInsetPx}
                   />
                 </div>
 
-                <div
-                  className={cn(
-                    "relative z-10 -mt-5 w-full shrink-0 overflow-visible pt-0 sm:pt-0",
-                    ENVIRONMENT_CONTENT_INSET_MOTION_CLASS,
-                    CHAT_COLUMN_GUTTER_CLASS_NAME,
-                    // A trailing BranchToolbar only renders for legacy git threads; otherwise the
-                    // composer is the last element, so give it a comfortable bottom margin.
-                    isGitRepo && !environmentEnabled ? "pb-0.5" : "pb-3 sm:pb-4",
-                  )}
-                  // Match the transcript's right inset so the composer stays aligned with chat
-                  // content (and clear of the docked Environment overlay).
-                  style={
-                    environmentAppliesContentInset
-                      ? { paddingRight: ENVIRONMENT_DOCKED_CONTENT_INSET_PX }
-                      : undefined
-                  }
-                >
-                  {composerSection}
-                </div>
-                {secondaryChromeReady &&
-                ((isGitRepo && !environmentEnabled) || relocateComposerLeadingControls) ? (
-                  <div className={CHAT_COLUMN_GUTTER_CLASS_NAME}>
-                    <div className={COMPOSER_COLUMN_FRAME_CLASS_NAME}>
-                      <div className="flex w-full items-center gap-1">
-                        {relocateComposerLeadingControls ? (
-                          <div className="flex shrink-0 items-center gap-1 pl-1">
-                            {renderComposerLeadingControls({ iconOnly: true })}
-                          </div>
-                        ) : null}
-                        {isGitRepo && !environmentEnabled ? (
-                          <BranchToolbar {...branchToolbarProps} className="min-w-0 flex-1" />
-                        ) : null}
+                {/* Trailing block below the transcript: the composer floats on top of it
+                    (`bottom-full`), so the transcript's scroll viewport — and therefore every
+                    row scrolling behind the frosted composer — is clipped at the composer's
+                    bottom edge. Nothing ever shows through this gutter or the BranchToolbar row. */}
+                <div className="relative z-10 w-full shrink-0">
+                  <div
+                    ref={composerOverlayRef}
+                    className={cn(
+                      "pointer-events-none absolute inset-x-0 bottom-full w-full overflow-visible",
+                      ENVIRONMENT_CONTENT_INSET_MOTION_CLASS,
+                      CHAT_COLUMN_GUTTER_CLASS_NAME,
+                    )}
+                    // Match the transcript's right inset so the composer stays aligned with chat
+                    // content (and clear of the docked Environment overlay).
+                    style={
+                      environmentAppliesContentInset
+                        ? { paddingRight: ENVIRONMENT_DOCKED_CONTENT_INSET_PX }
+                        : undefined
+                    }
+                  >
+                    <div className="pointer-events-auto">{composerSection}</div>
+                  </div>
+                  {/* A trailing BranchToolbar only renders for legacy git threads; otherwise the
+                      composer is the last element, so give it a comfortable bottom margin. */}
+                  <div
+                    className={cn(isGitRepo && !environmentEnabled ? "pt-0.5" : "pt-3 sm:pt-4")}
+                  />
+                  {secondaryChromeReady &&
+                  ((isGitRepo && !environmentEnabled) || relocateComposerLeadingControls) ? (
+                    <div className={CHAT_COLUMN_GUTTER_CLASS_NAME}>
+                      <div className={COMPOSER_COLUMN_FRAME_CLASS_NAME}>
+                        <div className="flex w-full items-center gap-1">
+                          {relocateComposerLeadingControls ? (
+                            <div className="flex shrink-0 items-center gap-1 pl-1">
+                              {renderComposerLeadingControls({ iconOnly: true })}
+                            </div>
+                          ) : null}
+                          {isGitRepo && !environmentEnabled ? (
+                            <BranchToolbar {...branchToolbarProps} className="min-w-0 flex-1" />
+                          ) : null}
+                        </div>
                       </div>
                     </div>
-                  </div>
-                ) : null}
+                  ) : null}
+                </div>
               </div>
             ) : null}
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5418,11 +5418,20 @@ export default function ChatView({
   // from the observer would race the padding it is supposed to compensate for. Here
   // the new padding is already in the DOM, so the pre-resize viewport is simply the
   // current one with the inset delta backed out.
-  const previousComposerTranscriptInsetRef = useRef(composerTranscriptInsetPx);
+  const previousComposerTranscriptInsetRef = useRef({
+    threadId: activeThread?.id ?? null,
+    insetPx: composerTranscriptInsetPx,
+  });
   useLayoutEffect(() => {
-    const previousInsetPx = previousComposerTranscriptInsetRef.current;
-    previousComposerTranscriptInsetRef.current = composerTranscriptInsetPx;
-    const insetDeltaPx = composerTranscriptInsetPx - previousInsetPx;
+    const threadId = activeThread?.id ?? null;
+    const previous = previousComposerTranscriptInsetRef.current;
+    previousComposerTranscriptInsetRef.current = {
+      threadId,
+      insetPx: composerTranscriptInsetPx,
+    };
+    if (previous.threadId !== threadId) return;
+
+    const insetDeltaPx = composerTranscriptInsetPx - previous.insetPx;
     if (isInactiveSplitPane || Math.abs(insetDeltaPx) < 0.5) return;
 
     const scrollContainer = legendListRef.current?.getScrollableNode?.();
@@ -5440,7 +5449,7 @@ export default function ChatView({
     // land a composer-growth short of the tail.
     programmaticScrollUntilRef.current = performance.now() + 200;
     scrollContainer.scrollTop += insetDeltaPx;
-  }, [composerTranscriptInsetPx, isInactiveSplitPane]);
+  }, [activeThread?.id, composerTranscriptInsetPx, isInactiveSplitPane]);
 
   useEffect(() => {
     isAtEndRef.current = true;

--- a/apps/web/src/components/chat/ChatTranscriptPane.tsx
+++ b/apps/web/src/components/chat/ChatTranscriptPane.tsx
@@ -26,6 +26,7 @@ import { DISCLOSURE_CONTENT_MOTION_CLASS } from "~/lib/disclosureMotion";
 import { type ExpandedImagePreview } from "./ExpandedImagePreview";
 import { ChatEmptyStateHero } from "./ChatEmptyStateHero";
 import { MessagesTimeline, type MessagesTimelineController } from "./MessagesTimeline";
+import { composerOverlayAffordanceBottomPx } from "./composerOverlay";
 import { MessageTrail } from "./MessageTrail";
 import { createActiveTrailStore, deriveMessageTrailItems } from "./messageTrail.logic";
 import { AgentActivityDetailView } from "./AgentActivityDetailView";
@@ -38,6 +39,7 @@ interface ChatTranscriptPaneProps {
   activeTurnStartedAt: string | null;
   agentActivityDetail?: AgentActivityDetail | null;
   contentInsetRightPx?: ComponentProps<typeof MessagesTimeline>["contentInsetRightPx"];
+  contentInsetBottomPx?: ComponentProps<typeof MessagesTimeline>["contentInsetBottomPx"];
   chatFontSizePx: number;
   emptyStateContent?: ReactNode;
   emptyStateProjectName: string | undefined;
@@ -106,6 +108,7 @@ export function ChatTranscriptPane({
   activeTurnStartedAt,
   agentActivityDetail,
   contentInsetRightPx,
+  contentInsetBottomPx,
   chatFontSizePx,
   emptyStateContent,
   emptyStateProjectName,
@@ -162,9 +165,17 @@ export function ChatTranscriptPane({
   worktreeSetupPendingAction,
   onResolveWorktreeSetup,
 }: ChatTranscriptPaneProps) {
-  const scrollButtonFrameStyle: CSSProperties | undefined = contentInsetRightPx
-    ? { paddingRight: contentInsetRightPx }
-    : undefined;
+  // The composer floats over the transcript's bottom edge, so the scroll-to-bottom
+  // affordance rides above it on the same inset the transcript content uses.
+  const scrollButtonFrameStyle: CSSProperties | undefined =
+    contentInsetRightPx || contentInsetBottomPx
+      ? {
+          ...(contentInsetRightPx ? { paddingRight: contentInsetRightPx } : {}),
+          ...(contentInsetBottomPx
+            ? { bottom: composerOverlayAffordanceBottomPx(contentInsetBottomPx) }
+            : {}),
+        }
+      : undefined;
 
   // Left-edge navigation trail: one tick per sent message. Current + visible
   // highlights are pushed up from MessagesTimeline as the viewport scrolls. They
@@ -254,6 +265,7 @@ export function ChatTranscriptPane({
             timestampFormat={timestampFormat}
             workspaceRoot={workspaceRoot}
             contentInsetRightPx={contentInsetRightPx}
+            contentInsetBottomPx={contentInsetBottomPx}
             {...(onOpenAgentActivity ? { onOpenAgentActivity } : {})}
             emptyStateContent={
               emptyStateContent === undefined ? (

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -485,6 +485,12 @@ interface MessagesTimelineProps {
    * far right; only the content is inset.
    */
   contentInsetRightPx?: number | undefined;
+  /**
+   * Bottom padding (px) applied to the scroll viewport so transcript rows clear the
+   * floating composer. Passed through `style` (not a class) on purpose: LegendList reads
+   * style padding, so it can account for the inset in its own end-space math.
+   */
+  contentInsetBottomPx?: number | undefined;
 }
 
 export const MessagesTimeline = memo(function MessagesTimeline({
@@ -544,6 +550,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   workspaceRoot,
   emptyStateContent,
   contentInsetRightPx,
+  contentInsetBottomPx,
 }: MessagesTimelineProps) {
   // Prop defaults are resolved in the body rather than in the destructuring pattern:
   // an `AssignmentPattern` in the parameter list makes React Compiler bail out on the
@@ -583,9 +590,18 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   // Inset rows from the right (overriding the gutter's right padding) without moving the
   // scroll viewport, so the scrollbar stays pinned to the far right while content clears
   // any right-edge overlay. Kept stable so LegendList isn't re-rendered on unrelated updates.
+  // The bottom inset clears the floating composer the transcript scrolls under; it is
+  // padding on the scroll viewport (not a taller footer) so the list's own footer-layout
+  // and initial-scroll machinery is never resized from outside.
   const listScrollStyle = useMemo(
-    () => (contentInsetRightPx ? { paddingRight: contentInsetRightPx } : undefined),
-    [contentInsetRightPx],
+    () =>
+      contentInsetRightPx || contentInsetBottomPx
+        ? {
+            ...(contentInsetRightPx ? { paddingRight: contentInsetRightPx } : {}),
+            ...(contentInsetBottomPx ? { paddingBottom: contentInsetBottomPx } : {}),
+          }
+        : undefined,
+    [contentInsetBottomPx, contentInsetRightPx],
   );
   const appTypographyScale = useMemo(
     () => getAppTypographyScale(normalizedChatFontSizePx),
@@ -751,10 +767,16 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       return;
     }
     const style = getComputedStyle(node);
-    const inset =
-      (Number.parseFloat(style.paddingTop) || 0) + (Number.parseFloat(style.paddingBottom) || 0);
+    // Only the *class-based* padding belongs here. The composer inset is applied through
+    // `style.paddingBottom`, which the list already reads and reserves for itself —
+    // counting it twice would push the anchored message a composer-height off the top.
+    const bottomPadding = Math.max(
+      0,
+      (Number.parseFloat(style.paddingBottom) || 0) - (contentInsetBottomPx ?? 0),
+    );
+    const inset = (Number.parseFloat(style.paddingTop) || 0) + bottomPadding;
     setAnchorVerticalInsetPx((current) => (Math.abs(current - inset) > 0.5 ? inset : current));
-  }, [resolvedListRef, tailAnchorMessageId]);
+  }, [contentInsetBottomPx, resolvedListRef, tailAnchorMessageId]);
   const anchoredEndSpace = useMemo(
     () =>
       tailAnchorRowIndex < 0
@@ -2272,8 +2294,12 @@ export const MessagesTimeline = memo(function MessagesTimeline({
         // edge so streamed content dissolves toward the composer. It is scroll-aware
         // via `animation-timeline: scroll()`, so the fade clears at the live edge and a
         // pinned or non-scrollable transcript stays crisp (no permanent shadow).
+        // With the floating composer the viewport bottom sits *behind* the frosted
+        // surface, so the fade would erase exactly the content the glass should reveal —
+        // the composer's own material is the dissolve there instead.
         className={cn(
-          "scroll-fade-b h-full overflow-x-hidden overscroll-y-contain py-3 [scrollbar-gutter:stable] sm:py-4",
+          "h-full overflow-x-hidden overscroll-y-contain py-3 [scrollbar-gutter:stable] sm:py-4",
+          contentInsetBottomPx ? null : "scroll-fade-b",
           ENVIRONMENT_CONTENT_INSET_MOTION_CLASS,
           CHAT_COLUMN_GUTTER_CLASS_NAME,
         )}

--- a/apps/web/src/components/chat/composerOverlay.ts
+++ b/apps/web/src/components/chat/composerOverlay.ts
@@ -1,0 +1,78 @@
+// FILE: composerOverlay.ts
+// Purpose: Geometry for the floating composer — the transcript scrolls *under* the
+//   frosted composer, so its measured height becomes the transcript's bottom content inset.
+// Layer: Chat composer layout helper
+// Exports: useComposerOverlayHeight (measure), composerTranscriptBottomInsetPx (derive inset)
+//
+// The composer is absolutely positioned at `bottom-full` of the in-flow block that
+// carries the trailing gutter (and the git BranchToolbar), so the transcript's scroll
+// viewport ends exactly at the composer's BOTTOM edge: content dissolves behind the
+// glass and is clipped there, never appearing in the padding strip below it.
+
+import { useCallback, useRef, useState } from "react";
+
+/**
+ * How far transcript content tucks under the composer's top edge at rest.
+ * Mirrors the `-mt-5` overlap the in-flow composer used to have, so the resting
+ * gap between the last row and the composer is unchanged — but now those 20px are
+ * real content sliding behind the glass instead of a solid backing.
+ */
+export const COMPOSER_OVERLAY_TUCK_PX = 20;
+
+/**
+ * Bottom content inset for the transcript given the measured composer overlay height.
+ * Keep this the single conversion: the pane and the timeline must agree on it exactly,
+ * or rows either hide behind the composer or float above a gap.
+ */
+export function composerTranscriptBottomInsetPx(overlayHeightPx: number): number {
+  return Math.max(0, Math.round(overlayHeightPx) - COMPOSER_OVERLAY_TUCK_PX);
+}
+
+/** Gap between the composer's top edge and floating transcript affordances. */
+const COMPOSER_OVERLAY_AFFORDANCE_GAP_PX = 8;
+
+/**
+ * Bottom offset for affordances that must float clear of the composer (the
+ * scroll-to-bottom arrow). Derived from the same inset so it tracks composer growth.
+ */
+export function composerOverlayAffordanceBottomPx(bottomInsetPx: number): number {
+  return bottomInsetPx + COMPOSER_OVERLAY_TUCK_PX + COMPOSER_OVERLAY_AFFORDANCE_GAP_PX;
+}
+
+/**
+ * Measures the composer overlay's border box. Rounded to whole pixels and only
+ * committed on change, so a resize that settles on the same height never re-renders
+ * the transcript (the composer resizes on every wrap of typed text).
+ */
+export function useComposerOverlayHeight(): {
+  overlayRef: (node: HTMLElement | null) => void;
+  overlayHeightPx: number;
+} {
+  const [overlayHeightPx, setOverlayHeightPx] = useState(0);
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const overlayRef = useCallback((node: HTMLElement | null) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    if (!node) {
+      setOverlayHeightPx(0);
+      return;
+    }
+    const commit = (height: number) => {
+      const next = Math.round(height);
+      setOverlayHeightPx((current) => (current === next ? current : next));
+    };
+    commit(node.getBoundingClientRect().height);
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) {
+        commit(entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height);
+      }
+    });
+    observer.observe(node);
+    observerRef.current = observer;
+  }, []);
+  return { overlayRef, overlayHeightPx };
+}

--- a/apps/web/src/components/chat/composerPickerStyles.ts
+++ b/apps/web/src/components/chat/composerPickerStyles.ts
@@ -119,13 +119,14 @@ export const COMPOSER_COLUMN_FRAME_CLASS_NAME = CHAT_COLUMN_FRAME_CLASS_NAME;
  */
 export const COMPOSER_STACKED_HEADER_FRAME_CLASS_NAME = "mx-auto -mb-px w-11/12 min-w-0";
 
-/** Opaque base behind the composer shell: the composer overlaps the scrolling
- *  transcript (`-mt-5`), so without a solid backing the frosted surface would let
- *  transcript text bleed through its top edge. Match the chat surface to stay seamless.
+/** Shell around the composer surface. Deliberately has NO background: the composer
+ *  floats over the scrolling transcript (see `composerOverlay.ts`) and its frosted
+ *  material is meant to reveal and blur the content passing behind it — an opaque
+ *  backing here would be the only thing its `backdrop-filter` ever sampled.
  *  `relative z-[1]` keeps the full input outline above the inset stacked rail
  *  (`-mb-px`), so the top border is never covered by live-changes / task / queue chrome. */
 export const COMPOSER_INPUT_SHELL_CLASS_NAME =
-  "group relative z-[1] chat-composer-shell bg-[var(--color-background-surface)] transition-colors duration-200";
+  "group relative z-[1] chat-composer-shell transition-colors duration-200";
 
 /** Defined composer border: the heaviest border token nudged a bit darker with foreground. */
 export const COMPOSER_SURFACE_BORDER_CLASS_NAME =

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2546,17 +2546,56 @@ diffs-container {
   border-top-right-radius: 0;
 }
 
-/* Stacked rail above the composer input: the composer's own surface color at
-   half opacity, so the rail reads as a lighter continuation of the input shell
-   rather than a differently-colored block. */
+/* Composer glass — the same material as the floating menus/pickers
+   (`APP_TRANSLUCENT_POPUP_SURFACE_BASE_CLASS_NAME`), applied to the composer's own
+   surface color instead of the popover token so the fill keeps its familiar tint.
+
+   The blur lives on a `::before` at `z-index: -1` rather than on the element itself,
+   exactly like the popup primitive: `backdrop-filter` on the element would make it a
+   containing block and clip the composer's anchored pickers (which rely on
+   `overflow-visible`). Painted behind the element's own translucent fill, the layer
+   frosts the transcript scrolling underneath (see composerOverlay.ts).
+
+   `--composer-glass-opacity` keeps every composer-family surface on one knob. */
+:root {
+  --composer-glass-opacity: 72%;
+  --composer-glass-filter: blur(40px) saturate(150%);
+}
+
+.chat-composer-surface,
 .chat-composer-stacked-top {
-  background: color-mix(in srgb, var(--composer-surface) 50%, transparent);
+  position: relative;
+}
+
+.chat-composer-surface::before,
+.chat-composer-stacked-top::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  pointer-events: none;
+  backdrop-filter: var(--composer-glass-filter);
+  -webkit-backdrop-filter: var(--composer-glass-filter);
+}
+
+/* Stacked rail above the composer input: the composer's own surface color at
+   half the glass opacity, so the rail reads as a lighter continuation of the input
+   shell rather than a differently-colored block. */
+.chat-composer-stacked-top {
+  background: color-mix(
+    in srgb,
+    var(--composer-surface) calc(var(--composer-glass-opacity) / 2),
+    transparent
+  );
 }
 
 .chat-composer-surface {
-  background: var(--composer-surface);
-  backdrop-filter: var(--app-composer-backdrop-filter, none);
-  -webkit-backdrop-filter: var(--app-composer-backdrop-filter, none);
+  background: color-mix(
+    in srgb,
+    var(--composer-surface) var(--composer-glass-opacity),
+    transparent
+  );
 }
 
 /* Recessed track: a hairline border + faint inner shadow read the base as a sunken

--- a/apps/web/src/theme/theme.logic.ts
+++ b/apps/web/src/theme/theme.logic.ts
@@ -734,10 +734,12 @@ export function buildThemeCssVariables(
         : readCodexVariable("--color-background-surface-under"),
     "--app-composer-focus-border": composerFocusBorder,
     // Frosted blur only when the shell is translucent (macOS). On an opaque
-    // shell these promote the surface to a GPU layer that Chromium rasterizes at
+    // shell this promotes the surface to a GPU layer that Chromium rasterizes at
     // the wrong scale on fractional DPI (Windows), so text reads blurry until a
-    // repaint. Keep them "none" off macOS.
-    "--app-composer-backdrop-filter": material === "translucent" ? "blur(16px)" : "none",
+    // repaint. Keep it "none" off macOS.
+    // NOTE: this gates window-vibrancy frosting only. The composer's own glass
+    // (`.chat-composer-surface`, index.css) frosts page content, not the window
+    // material, so — like the floating menus — it stays on across platforms.
     "--app-composer-picker-backdrop-filter": material === "translucent" ? "blur(32px)" : "none",
     "--app-composer-picker-surface": composerPickerMenuSurface,
     "--app-chat-code-surface": chatCodeSurface,


### PR DESCRIPTION
## What Changed

- Floated the composer over the transcript with a translucent frosted glass surface.
- Added measured composer-height bottom insets so transcript content and scroll controls remain visible.
- Preserved scroll position when the composer grows or shrinks.
- Updated composer styling and theme logic to support the shared glass treatment.

## Why

The composer previously occupied an opaque block below the transcript. This change lets transcript content continue beneath the composer while keeping the latest messages, scroll affordances, and expanding composer states correctly positioned.

## UI Changes

The composer and stacked composer controls now use a translucent, blurred surface over the transcript. No screenshots or video included.

## Verification

- Not run; no verification commands were provided.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core chat layout, LegendList padding/anchor math, and scroll stickiness—regression risk for split panes, environment insets, and composer resize edge cases, but no auth or data changes.
> 
> **Overview**
> The chat composer now **floats above the transcript** on a translucent frosted surface instead of sitting in an opaque block below it. Transcript rows scroll underneath the glass; a new `composerOverlay` helper measures overlay height and drives a shared **bottom content inset** on the scroll viewport so the tail stays readable and the scroll-to-bottom control sits above the composer.
> 
> **Scroll behavior** when the composer grows (attachments, approvals, queue) was reworked: the old `ResizeObserver` + `scrollToEnd` path is replaced by a layout effect keyed on the **committed inset delta**, which nudges `scrollTop` directly when the user was already pinned to the bottom—avoiding races with LegendList’s padding updates.
> 
> **Styling**: composer shell backgrounds were removed so `backdrop-filter` can sample transcript content; glass is applied via `::before` on composer surfaces in CSS (with platform notes in theme logic). The transcript bottom **scroll-fade** is disabled when the floating inset is active so content isn’t erased behind the glass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd15c65fbef3a24095855a34066721efcc8fb9d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->