### PR TITLE
Set a ten-second default timeout for toast notifications

### DIFF
--- a/apps/web/src/components/ui/toast.logic.test.ts
+++ b/apps/web/src/components/ui/toast.logic.test.ts
@@ -1,5 +1,15 @@
 import { assert, describe, it } from "vitest";
-import { buildVisibleToastLayout, shouldHideCollapsedToastContent } from "./toast.logic";
+import {
+  buildVisibleToastLayout,
+  DEFAULT_TOAST_TIMEOUT_MS,
+  shouldHideCollapsedToastContent,
+} from "./toast.logic";
+
+describe("DEFAULT_TOAST_TIMEOUT_MS", () => {
+  it("auto-dismisses standard toasts after ten seconds", () => {
+    assert.equal(DEFAULT_TOAST_TIMEOUT_MS, 10_000);
+  });
+});
 
 describe("shouldHideCollapsedToastContent", () => {
   it("keeps a single visible toast readable", () => {

--- a/apps/web/src/components/ui/toast.logic.ts
+++ b/apps/web/src/components/ui/toast.logic.ts
@@ -1,3 +1,5 @@
+export const DEFAULT_TOAST_TIMEOUT_MS = 10_000;
+
 export function shouldHideCollapsedToastContent(
   visibleToastIndex: number,
   visibleToastCount: number,

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -19,7 +19,11 @@ import { cn } from "~/lib/utils";
 import { Button, buttonVariants } from "~/components/ui/button";
 import { APP_TOOLTIP_SURFACE_CLASS_NAME } from "~/components/chat/composerPickerStyles";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
-import { buildVisibleToastLayout, shouldHideCollapsedToastContent } from "./toast.logic";
+import {
+  buildVisibleToastLayout,
+  DEFAULT_TOAST_TIMEOUT_MS,
+  shouldHideCollapsedToastContent,
+} from "./toast.logic";
 import {
   NOTIFICATION_ICON_CLASS_NAME,
   notificationSurfaceClassName,
@@ -498,10 +502,15 @@ function ToastSurface({
   );
 }
 
-function ToastProvider({ children, position: positionProp, ...props }: ToastProviderProps) {
+function ToastProvider({
+  children,
+  position: positionProp,
+  timeout = DEFAULT_TOAST_TIMEOUT_MS,
+  ...props
+}: ToastProviderProps) {
   const position = positionProp ?? "top-center";
   return (
-    <Toast.Provider toastManager={toastManager} {...props}>
+    <Toast.Provider timeout={timeout} toastManager={toastManager} {...props}>
       {children}
       <Toasts position={position} />
     </Toast.Provider>
@@ -672,9 +681,13 @@ function Toasts({ position: positionProp }: { position: ToastPosition }) {
   );
 }
 
-function AnchoredToastProvider({ children, ...props }: Toast.Provider.Props) {
+function AnchoredToastProvider({
+  children,
+  timeout = DEFAULT_TOAST_TIMEOUT_MS,
+  ...props
+}: Toast.Provider.Props) {
   return (
-    <Toast.Provider toastManager={anchoredToastManager} {...props}>
+    <Toast.Provider timeout={timeout} toastManager={anchoredToastManager} {...props}>
       {children}
       <AnchoredToasts />
     </Toast.Provider>


### PR DESCRIPTION
## Summary

- Set the default toast auto-dismiss timeout to 10 seconds.
- Apply the default to both standard and anchored toast providers.
- Add a unit test covering the timeout constant.

## Testing

- Unit test added for the default timeout value.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX default change on toast providers; timeout remains overridable and does not touch auth or data paths.
> 
> **Overview**
> Standard and anchored toast providers now **auto-dismiss after 10 seconds** by default via a shared `DEFAULT_TOAST_TIMEOUT_MS` constant in `toast.logic.ts`, passed through to Base UI’s `Toast.Provider` `timeout` prop. Callers can still override `timeout` on either provider.
> 
> A unit test locks the constant to `10_000` ms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08d98f52e92f5dd9157c3112502175ed332dc770. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->