### PR TITLE
Optimize runtime polling and thread detail subscriptions

### DIFF
--- a/apps/server/perf/providerRuntimeJournalAppend.bench.ts
+++ b/apps/server/perf/providerRuntimeJournalAppend.bench.ts
@@ -1,0 +1,181 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Database } from "bun:sqlite";
+
+const EVENT_COUNT = readPositiveInteger("SYNARA_BENCH_EVENTS", 10_000);
+const SAMPLE_COUNT = readPositiveInteger("SYNARA_BENCH_SAMPLES", 8);
+
+type Strategy = "legacy-select-transaction-insert" | "insert-on-conflict-returning";
+type AppendRuntimeEvent = (params: Record<string, string>) => unknown;
+type Workload = {
+  readonly name: "unique-events" | "ten-percent-retries";
+  readonly sourceEventIndex: (attemptIndex: number) => number;
+};
+
+const STRATEGIES: readonly Strategy[] = [
+  "legacy-select-transaction-insert",
+  "insert-on-conflict-returning",
+];
+
+const WORKLOADS: readonly Workload[] = [
+  {
+    name: "unique-events",
+    sourceEventIndex: (attemptIndex) => attemptIndex,
+  },
+  {
+    name: "ten-percent-retries",
+    sourceEventIndex: (attemptIndex) =>
+      attemptIndex > 0 && attemptIndex % 10 === 0 ? attemptIndex - 1 : attemptIndex,
+  },
+];
+
+function readPositiveInteger(name: string, fallback: number): number {
+  const parsed = Number(process.env[name] ?? fallback);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function createDatabase(): { readonly database: Database; readonly dispose: () => void } {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "synara-runtime-journal-bench-"));
+  const database = new Database(path.join(directory, "runtime.sqlite"), { strict: true });
+  database.exec(`
+    PRAGMA journal_mode = WAL;
+    PRAGMA synchronous = NORMAL;
+    CREATE TABLE provider_runtime_events (
+      sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+      event_id TEXT NOT NULL UNIQUE,
+      thread_id TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      event_json TEXT NOT NULL,
+      persisted_at TEXT NOT NULL
+    )
+  `);
+  return {
+    database,
+    dispose: () => {
+      database.close();
+      rmSync(directory, { force: true, recursive: true });
+    },
+  };
+}
+
+function eventParams(sourceEventIndex: number): Record<string, string> {
+  const eventId = `event-${sourceEventIndex}`;
+  return {
+    eventId,
+    threadId: `thread-${sourceEventIndex % 3}`,
+    eventType: "content.delta",
+    eventJson: JSON.stringify({
+      eventId,
+      type: "content.delta",
+      payload: { streamKind: "assistant_text", delta: `token-${sourceEventIndex}` },
+    }),
+    persistedAt: "2026-08-09T00:00:00.000Z",
+  };
+}
+
+function createAppendRuntimeEvent(database: Database, strategy: Strategy): AppendRuntimeEvent {
+  const lookup = database.query(
+    `SELECT sequence, event_json AS eventJson
+     FROM provider_runtime_events
+     WHERE event_id = $eventId`,
+  );
+  const insert = database.query(
+    `INSERT INTO provider_runtime_events (
+       event_id, thread_id, event_type, event_json, persisted_at
+     ) VALUES ($eventId, $threadId, $eventType, $eventJson, $persistedAt)
+     RETURNING sequence, event_json AS eventJson`,
+  );
+  const insertOnConflict = database.query(
+    `INSERT INTO provider_runtime_events (
+       event_id, thread_id, event_type, event_json, persisted_at
+     ) VALUES ($eventId, $threadId, $eventType, $eventJson, $persistedAt)
+     ON CONFLICT (event_id) DO NOTHING
+     RETURNING sequence, event_json AS eventJson`,
+  );
+  const legacyAppend = database.transaction((params: Record<string, string>) => {
+    const existing = lookup.get(params);
+    return existing ?? insert.get(params);
+  });
+  if (strategy === "legacy-select-transaction-insert") return legacyAppend;
+  return (params) => insertOnConflict.get(params) ?? lookup.get(params);
+}
+
+function appendWorkload(
+  appendRuntimeEvent: AppendRuntimeEvent,
+  workload: Workload,
+  eventCount: number,
+): number {
+  const startedAt = performance.now();
+  for (let attemptIndex = 0; attemptIndex < eventCount; attemptIndex += 1) {
+    appendRuntimeEvent(eventParams(workload.sourceEventIndex(attemptIndex)));
+  }
+  return performance.now() - startedAt;
+}
+
+function runSample(strategy: Strategy, workload: Workload, eventCount: number): number {
+  const { database, dispose } = createDatabase();
+  try {
+    return appendWorkload(createAppendRuntimeEvent(database, strategy), workload, eventCount);
+  } finally {
+    dispose();
+  }
+}
+
+function median(values: readonly number[]): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[middle] ?? 0;
+  return ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2;
+}
+
+function strategyOrder(sampleIndex: number): readonly Strategy[] {
+  return sampleIndex % 2 === 0 ? STRATEGIES : [...STRATEGIES].reverse();
+}
+
+function measureWorkload(workload: Workload) {
+  const samplesByStrategy = new Map<Strategy, number[]>(
+    STRATEGIES.map((strategy) => [strategy, []]),
+  );
+  for (let sampleIndex = 0; sampleIndex < SAMPLE_COUNT; sampleIndex += 1) {
+    for (const strategy of strategyOrder(sampleIndex)) {
+      samplesByStrategy.get(strategy)!.push(runSample(strategy, workload, EVENT_COUNT));
+    }
+  }
+  return {
+    workload: workload.name,
+    results: STRATEGIES.map((strategy) => {
+      const samplesMs = samplesByStrategy.get(strategy)!;
+      const medianMs = median(samplesMs);
+      return {
+        strategy,
+        eventCount: EVENT_COUNT,
+        samplesMs,
+        medianMs,
+        attemptsPerSecond: EVENT_COUNT / (medianMs / 1_000),
+      };
+    }),
+  };
+}
+
+for (const workload of WORKLOADS) {
+  for (const strategy of STRATEGIES) {
+    runSample(strategy, workload, Math.min(1_000, EVENT_COUNT));
+  }
+}
+
+console.log(
+  JSON.stringify(
+    {
+      runtime: `Bun ${Bun.version}`,
+      storage: "file-backed SQLite, WAL, synchronous=NORMAL",
+      sampleCount: SAMPLE_COUNT,
+      workloads: WORKLOADS.map(measureWorkload),
+    },
+    null,
+    2,
+  ),
+);

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -40,6 +40,7 @@ import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
 import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQuery.ts";
 import {
   collectPersistedGeneratedImagePaths,
+  nextRuntimeJournalSafetyPollDelayMs,
   ProviderRuntimeIngestionLive,
   selectProviderRuntimeJournalStream,
 } from "./ProviderRuntimeIngestion.ts";
@@ -182,6 +183,18 @@ type ProviderRuntimeTestActivity = ProviderRuntimeTestThread["activities"][numbe
 type ProviderRuntimeTestCheckpoint = ProviderRuntimeTestThread["checkpoints"][number];
 
 describe("ProviderRuntimeIngestion", () => {
+  it("backs off idle journal safety polls and returns to the fast recovery cadence", () => {
+    let delayMs = 250;
+    const idleDelays: number[] = [];
+    for (let index = 0; index < 6; index += 1) {
+      delayMs = nextRuntimeJournalSafetyPollDelayMs(delayMs, false);
+      idleDelays.push(delayMs);
+    }
+
+    expect(idleDelays).toEqual([500, 1_000, 2_000, 4_000, 5_000, 5_000]);
+    expect(nextRuntimeJournalSafetyPollDelayMs(delayMs, true)).toBe(250);
+  });
+
   it("uses an already-persisted runtime stream without appending the event again", async () => {
     const event: ProviderRuntimeEvent = {
       type: "runtime.warning",

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -92,7 +92,8 @@ const providerCommandId = (event: ProviderRuntimeEvent, tag: string, target = "e
 const DEFAULT_ASSISTANT_DELIVERY_MODE: AssistantDeliveryMode = "buffered";
 const PROVIDER_RUNTIME_INGESTION_CAPACITY = 1_024;
 const PROVIDER_RUNTIME_REPLAY_PAGE_SIZE = 128;
-const PROVIDER_RUNTIME_REPLAY_POLL_INTERVAL = Duration.millis(250);
+const PROVIDER_RUNTIME_REPLAY_POLL_MIN_MS = 250;
+const PROVIDER_RUNTIME_REPLAY_POLL_MAX_MS = 5_000;
 const TURN_MESSAGE_IDS_BY_TURN_CACHE_CAPACITY = 2_048;
 const TURN_MESSAGE_IDS_BY_TURN_TTL = Duration.minutes(60);
 const BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY = 1_024;
@@ -124,6 +125,22 @@ const MAX_BUFFERED_REASONING_SUMMARY_CHARS = 8_000;
 const MAX_BUFFERED_REASONING_SUMMARY_PARTS = 24;
 const BUFFERED_TEXT_TRUNCATION_MARKER = "... [truncated]";
 const STRICT_PROVIDER_LIFECYCLE_GUARD = process.env.SYNARA_STRICT_PROVIDER_LIFECYCLE_GUARD !== "0";
+
+/**
+ * Back off the durable-journal safety poll while the live persisted-event
+ * stream is healthy and the consumer is caught up. Live events still drain
+ * immediately; this poll only recovers rows whose notification was missed.
+ */
+export function nextRuntimeJournalSafetyPollDelayMs(
+  currentDelayMs: number,
+  hadBacklog: boolean,
+): number {
+  if (hadBacklog) return PROVIDER_RUNTIME_REPLAY_POLL_MIN_MS;
+  return Math.min(
+    PROVIDER_RUNTIME_REPLAY_POLL_MAX_MS,
+    Math.max(PROVIDER_RUNTIME_REPLAY_POLL_MIN_MS, currentDelayMs * 2),
+  );
+}
 
 type RuntimeIngestionDomainEvent = Extract<
   OrchestrationEvent,
@@ -2786,11 +2803,13 @@ const make = Effect.gen(function* () {
     runtimeJournalDrainLock.withPermits(1)(
       Effect.gen(function* () {
         const replayFence = throughSequenceInclusive ?? (yield* runtimeEvents.getHighWaterSequence);
+        let hadBacklog = false;
         while (true) {
           const cursor = yield* runtimeEvents.getConsumerCursor(
             PROVIDER_RUNTIME_INGESTION_CONSUMER,
           );
-          if (cursor >= replayFence) return;
+          if (cursor >= replayFence) return hadBacklog;
+          hadBacklog = true;
 
           const page = yield* runtimeEvents.readAfter({
             sequenceExclusive: cursor,
@@ -2817,7 +2836,7 @@ const make = Effect.gen(function* () {
             // skipped (loop again from the fresh cursor), or the drain yields
             // to the durable poller, which retries from the exact cursor.
             if (yield* deadLetterPoisonHeadRow) continue;
-            return;
+            return hadBacklog;
           }
 
           const advancedCursor = yield* runtimeEvents.getConsumerCursor(
@@ -2839,9 +2858,21 @@ const make = Effect.gen(function* () {
       if (Cause.hasInterruptsOnly(cause)) return Effect.failCause(cause);
       return Effect.logWarning("provider runtime journal drain failed", {
         cause: Cause.pretty(cause),
-      });
+      }).pipe(Effect.as(true));
     }),
   );
+
+  const pollRuntimeJournalSafely = Effect.gen(function* () {
+    // Keep the long-lived loop inside one generator fiber. Recursively chaining
+    // a fresh Effect for every tick retains work in Bun's Effect interpreter
+    // and grows CPU/RSS over time even though each individual poll is tiny.
+    let delayMs = PROVIDER_RUNTIME_REPLAY_POLL_MIN_MS;
+    while (true) {
+      yield* Effect.sleep(Duration.millis(delayMs));
+      const hadBacklog = yield* drainRuntimeJournalSafely;
+      delayMs = nextRuntimeJournalSafetyPollDelayMs(delayMs, hadBacklog);
+    }
+  });
 
   const reconcileSettledOpenTurns: ProviderRuntimeIngestionShape["reconcileSettledOpenTurns"] =
     runtimeEvents.pruneSettledOpenTurns.pipe(
@@ -2969,12 +3000,7 @@ const make = Effect.gen(function* () {
       yield* rebuildAcceptedOpenTurnState;
       yield* drainRuntimeJournal;
       yield* Deferred.succeed(startupRuntimeReplayComplete, undefined);
-      yield* Effect.forkScoped(
-        Effect.sleep(PROVIDER_RUNTIME_REPLAY_POLL_INTERVAL).pipe(
-          Effect.andThen(drainRuntimeJournalSafely),
-          Effect.forever,
-        ),
-      );
+      yield* Effect.forkScoped(pollRuntimeJournalSafely);
     }),
   ).pipe(Effect.orDie);
 

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -85,7 +85,6 @@ import {
   Queue,
   Random,
   Ref,
-  Semaphore,
   Stream,
 } from "effect";
 
@@ -147,6 +146,7 @@ import {
   MINIMUM_CLAUDE_AUTO_MODE_CLI_VERSION,
 } from "../claudeCliVersion.ts";
 import { parseGenericCliVersion } from "../providerMaintenance.ts";
+import { makeKeyedLock } from "../keyedLock.ts";
 import {
   ProviderAdapterProcessError,
   ProviderAdapterRequestError,
@@ -1762,7 +1762,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
     const sessions = new Map<ThreadId, ClaudeSessionContext>();
     const failedStartupProcessOwners = new Map<ThreadId, ClaudeProcessOwner>();
     const failedDiscoveryProcessOwners = new Set<ClaudeProcessOwner>();
-    const sessionLifecycleLocks = new Map<ThreadId, Semaphore.Semaphore>();
+    const sessionLifecycleLock = makeKeyedLock<ThreadId>();
     let cachedModels: ProviderListModelsResult | null = null;
     let cachedAgents: ProviderListAgentsResult | null = null;
     const verifyClaudeAutoModelSupport = (input: {
@@ -1831,17 +1831,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
     const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
     const nextEventId = Effect.map(Random.nextUUIDv4, (id) => EventId.makeUnsafe(id));
     const makeEventStamp = () => Effect.all({ eventId: nextEventId, createdAt: nowIso });
-    const withSessionLifecycleLock = <A, E, R>(
-      threadId: ThreadId,
-      effect: Effect.Effect<A, E, R>,
-    ): Effect.Effect<A, E, R> => {
-      let lock = sessionLifecycleLocks.get(threadId);
-      if (lock === undefined) {
-        lock = Semaphore.makeUnsafe(1);
-        sessionLifecycleLocks.set(threadId, lock);
-      }
-      return lock.withPermits(1)(effect);
-    };
+    const withSessionLifecycleLock = sessionLifecycleLock.withLock;
     const resolveClaudeSdkEnv = Effect.sync(() =>
       buildClaudeProcessEnv({ homeDir: serverConfig.homeDir }),
     );

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -51,7 +51,6 @@ import {
   Scope,
   Stream,
 } from "effect";
-import * as Semaphore from "effect/Semaphore";
 import { nonEmptyTrimmed } from "@synara/shared/text";
 
 import { ProviderValidationError } from "../Errors.ts";
@@ -73,6 +72,7 @@ import {
   isStartedTurnApplicable,
 } from "../terminalTurnApplicability.ts";
 import { makeProviderLifecycleCoordinator } from "../providerLifecycleCoordinator.ts";
+import { makeKeyedLock } from "../keyedLock.ts";
 import { carryProviderAttachmentPaths } from "../providerAttachmentPaths.ts";
 import {
   makeProviderRuntimeEventPumpHealthRegistry,
@@ -288,35 +288,6 @@ function runtimeActiveTurnId(value: unknown): string | undefined {
 
 function hasResumeCursor(value: unknown): boolean {
   return value !== null && value !== undefined;
-}
-
-function makeKeyedThreadLock() {
-  const entries = new Map<ThreadId, { readonly semaphore: Semaphore.Semaphore; users: number }>();
-  const withLock = <A, E, R>(
-    threadId: ThreadId,
-    effect: Effect.Effect<A, E, R>,
-  ): Effect.Effect<A, E, R> => {
-    let entry = entries.get(threadId);
-    if (entry === undefined) {
-      entry = { semaphore: Semaphore.makeUnsafe(1), users: 0 };
-      entries.set(threadId, entry);
-    }
-    entry.users += 1;
-    const acquiredEntry = entry;
-    return acquiredEntry.semaphore
-      .withPermits(1)(effect)
-      .pipe(
-        Effect.ensuring(
-          Effect.sync(() => {
-            acquiredEntry.users -= 1;
-            if (acquiredEntry.users === 0 && entries.get(threadId) === acquiredEntry) {
-              entries.delete(threadId);
-            }
-          }),
-        ),
-      );
-  };
-  return withLock;
 }
 
 function runtimeStatusForEvent(
@@ -835,7 +806,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     // still be overwritten. Lifecycle events are low-frequency, so a per-thread
     // mutex adds no meaningful contention. Creation is synchronous
     // (Semaphore.makeUnsafe), so concurrent callers cannot mint two locks.
-    const withBindingWriteLock = makeKeyedThreadLock();
+    const withBindingWriteLock = makeKeyedLock<ThreadId>().withLock;
 
     interface StartedTurnPersistenceInput {
       readonly threadId: ThreadId;

--- a/apps/server/src/provider/keyedLock.test.ts
+++ b/apps/server/src/provider/keyedLock.test.ts
@@ -1,0 +1,48 @@
+import { Deferred, Effect, Fiber } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { makeKeyedLock } from "./keyedLock.ts";
+
+describe("makeKeyedLock", () => {
+  it("serializes callers for one key and releases the entry after the final waiter", async () => {
+    const lock = makeKeyedLock<string>();
+    const release = await Effect.runPromise(Deferred.make<void>());
+    const order: string[] = [];
+
+    const first = Effect.runFork(
+      lock.withLock(
+        "thread-1",
+        Effect.sync(() => order.push("first-start")).pipe(
+          Effect.andThen(Deferred.await(release)),
+          Effect.andThen(Effect.sync(() => order.push("first-end"))),
+        ),
+      ),
+    );
+    await Effect.runPromise(Effect.yieldNow);
+    const second = Effect.runFork(
+      lock.withLock(
+        "thread-1",
+        Effect.sync(() => order.push("second")),
+      ),
+    );
+    await Effect.runPromise(Effect.yieldNow);
+
+    expect(lock.activeKeyCount()).toBe(1);
+    expect(order).toEqual(["first-start"]);
+
+    await Effect.runPromise(Deferred.succeed(release, undefined));
+    await Effect.runPromise(Fiber.join(first));
+    await Effect.runPromise(Fiber.join(second));
+
+    expect(order).toEqual(["first-start", "first-end", "second"]);
+    expect(lock.activeKeyCount()).toBe(0);
+  });
+
+  it("releases entries after failures", async () => {
+    const lock = makeKeyedLock<string>();
+
+    await Effect.runPromise(Effect.exit(lock.withLock("thread-1", Effect.fail("boom"))));
+
+    expect(lock.activeKeyCount()).toBe(0);
+  });
+});

--- a/apps/server/src/provider/keyedLock.ts
+++ b/apps/server/src/provider/keyedLock.ts
@@ -1,0 +1,43 @@
+import { Effect, Semaphore } from "effect";
+
+export interface KeyedLock<Key> {
+  readonly withLock: <A, E, R>(key: Key, effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>;
+  readonly activeKeyCount: () => number;
+}
+
+/**
+ * Serialize work per key without retaining one semaphore for every key ever seen.
+ * The user count includes queued callers, so cleanup waits for the final holder
+ * or waiter to leave the critical section.
+ */
+export function makeKeyedLock<Key>(): KeyedLock<Key> {
+  const entries = new Map<Key, { readonly semaphore: Semaphore.Semaphore; users: number }>();
+
+  const withLock: KeyedLock<Key>["withLock"] = (key, effect) =>
+    Effect.suspend(() => {
+      let entry = entries.get(key);
+      if (entry === undefined) {
+        entry = { semaphore: Semaphore.makeUnsafe(1), users: 0 };
+        entries.set(key, entry);
+      }
+      entry.users += 1;
+      const acquiredEntry = entry;
+      return acquiredEntry.semaphore
+        .withPermits(1)(effect)
+        .pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              acquiredEntry.users -= 1;
+              if (acquiredEntry.users === 0 && entries.get(key) === acquiredEntry) {
+                entries.delete(key);
+              }
+            }),
+          ),
+        );
+    });
+
+  return {
+    withLock,
+    activeKeyCount: () => entries.size,
+  };
+}

--- a/apps/web/perf/index.html
+++ b/apps/web/perf/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Synara transcript performance harness</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/perf/main.tsx
+++ b/apps/web/perf/main.tsx
@@ -1,0 +1,367 @@
+import "../src/index.css";
+
+import { MessageId, TurnId } from "@synara/contracts";
+import type { LegendListRef } from "@legendapp/list/react";
+import {
+  Profiler,
+  StrictMode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentProps,
+  type ProfilerOnRenderCallback,
+} from "react";
+import { createRoot } from "react-dom/client";
+
+import { ChatTranscriptPane } from "../src/components/chat/ChatTranscriptPane";
+
+type TimelineEntries = ComponentProps<typeof ChatTranscriptPane>["timelineEntries"];
+
+type FrameReport = {
+  count: number;
+  droppedFrames: number;
+  meanMs: number;
+  p95Ms: number;
+  maxMs: number;
+};
+
+type PerfSnapshot = {
+  commitCount: number;
+  commitDurationMs: number;
+  domNodeCount: number;
+  heapUsedBytes: number | null;
+  longTaskCount: number;
+  longTaskDurationMs: number;
+  scrollHeight: number;
+  scrollTop: number;
+};
+
+declare global {
+  interface Window {
+    __synaraPerf: {
+      appendStreamingChunks: (count?: number) => Promise<FrameReport>;
+      resetMetrics: () => void;
+      scrollCycle: (cycles?: number) => Promise<FrameReport>;
+      snapshot: () => PerfSnapshot;
+    };
+  }
+
+  interface Performance {
+    memory?: {
+      usedJSHeapSize: number;
+    };
+  }
+}
+
+const NOOP = () => {};
+const EMPTY_TURN_DIFFS = new Map();
+const EMPTY_REVERT_COUNTS = new Map();
+const BASE_TIME_MS = Date.parse("2026-08-08T12:00:00.000Z");
+
+function isoAt(index: number): string {
+  return new Date(BASE_TIME_MS + index * 1_000).toISOString();
+}
+
+function assistantText(index: number): string {
+  if (index % 10 === 0) {
+    return [
+      `## Performance result ${index}`,
+      "",
+      "This response contains representative Markdown, lists, and a highlighted code block.",
+      "",
+      "- preserves streaming order",
+      "- keeps tool calls responsive",
+      "- avoids unrelated transcript work",
+      "",
+      "```ts",
+      `export function sample${index}(items: readonly number[]) {`,
+      "  return items.reduce((total, item) => total + item, 0);",
+      "}",
+      "```",
+    ].join("\n");
+  }
+  if (index % 7 === 0) {
+    return Array.from(
+      { length: 18 },
+      (_, paragraph) =>
+        `Paragraph ${paragraph + 1}: representative long Markdown text for transcript row ${index}.`,
+    ).join("\n\n");
+  }
+  return `Measured assistant response ${index}. The completed row should remain stable during unrelated updates.`;
+}
+
+function createTimelineEntries(messageCount: number, streamingText: string): TimelineEntries {
+  const entries: TimelineEntries = [];
+  const settledMessageCount = Math.max(1, messageCount - 1);
+  for (let index = 0; index < settledMessageCount; index += 1) {
+    const role = index % 2 === 0 ? "user" : "assistant";
+    const id = MessageId.makeUnsafe(`perf-message-${index}`);
+    entries.push({
+      id,
+      kind: "message",
+      createdAt: isoAt(index * 2),
+      message: {
+        id,
+        role,
+        text:
+          role === "user"
+            ? `Representative request ${index}: inspect rendering, scrolling, tools, terminals, and diffs.`
+            : assistantText(index),
+        createdAt: isoAt(index * 2),
+        ...(role === "assistant" ? { completedAt: isoAt(index * 2 + 1) } : {}),
+        streaming: false,
+      },
+    });
+    if (index > 0 && index % 25 === 0) {
+      entries.push({
+        id: `perf-work-${index}`,
+        kind: "work",
+        createdAt: isoAt(index * 2 + 1),
+        entry: {
+          id: `perf-work-${index}`,
+          createdAt: isoAt(index * 2 + 1),
+          label: `Inspected ${index} repository files`,
+          toolTitle: "Repository inspection",
+          tone: "tool",
+        },
+      });
+    }
+  }
+
+  const streamingId = MessageId.makeUnsafe("perf-message-streaming");
+  entries.push({
+    id: streamingId,
+    kind: "message",
+    createdAt: isoAt(messageCount * 2),
+    message: {
+      id: streamingId,
+      role: "assistant",
+      turnId: TurnId.makeUnsafe("perf-turn-streaming"),
+      text: streamingText,
+      createdAt: isoAt(messageCount * 2),
+      streaming: true,
+    },
+  });
+  return entries;
+}
+
+function percentile(values: readonly number[], fraction: number): number {
+  if (values.length === 0) return 0;
+  const ordered = [...values].sort((left, right) => left - right);
+  return ordered[Math.min(ordered.length - 1, Math.floor(ordered.length * fraction))] ?? 0;
+}
+
+function frameReport(durations: readonly number[]): FrameReport {
+  const total = durations.reduce((sum, value) => sum + value, 0);
+  return {
+    count: durations.length,
+    droppedFrames: durations.filter((duration) => duration > 20).length,
+    meanMs: durations.length > 0 ? total / durations.length : 0,
+    p95Ms: percentile(durations, 0.95),
+    maxMs: Math.max(0, ...durations),
+  };
+}
+
+function nextFrame(): Promise<number> {
+  return new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+function installCostToggleStyles(): void {
+  const params = new URLSearchParams(window.location.search);
+  const style = document.createElement("style");
+  if (params.get("animations") === "off") {
+    style.textContent += `
+      *, *::before, *::after {
+        animation: none !important;
+        transition: none !important;
+      }
+    `;
+  }
+  if (params.get("shimmer") === "off") {
+    style.textContent += `
+      .shimmer {
+        animation: none !important;
+      }
+    `;
+  }
+  if (params.get("scrollFade") === "off") {
+    style.textContent += `
+      .scroll-fade-b {
+        animation: none !important;
+        -webkit-mask-image: none !important;
+        mask-image: none !important;
+      }
+    `;
+  }
+  document.head.append(style);
+}
+
+installCostToggleStyles();
+
+function PerformanceHarness() {
+  const params = useMemo(() => new URLSearchParams(window.location.search), []);
+  const messageCount = Math.max(1, Number(params.get("messages") ?? 100));
+  const working = params.get("working") !== "0";
+  const [streamingText, setStreamingText] = useState(
+    "Streaming response baseline. New chunks should update only this final row.",
+  );
+  const listRef = useRef<LegendListRef | null>(null);
+  const commitCountRef = useRef(0);
+  const commitDurationMsRef = useRef(0);
+  const longTaskCountRef = useRef(0);
+  const longTaskDurationMsRef = useRef(0);
+
+  const timelineEntries = useMemo(
+    () => createTimelineEntries(messageCount, streamingText),
+    [messageCount, streamingText],
+  );
+
+  const handleRender: ProfilerOnRenderCallback = useCallback((_id, _phase, actualDuration) => {
+    commitCountRef.current += 1;
+    commitDurationMsRef.current += actualDuration;
+  }, []);
+
+  useEffect(() => {
+    if (typeof PerformanceObserver === "undefined") return;
+    const observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        longTaskCountRef.current += 1;
+        longTaskDurationMsRef.current += entry.duration;
+      }
+    });
+    try {
+      observer.observe({ type: "longtask", buffered: true });
+    } catch {
+      return;
+    }
+    return () => observer.disconnect();
+  }, []);
+
+  const resetMetrics = useCallback(() => {
+    commitCountRef.current = 0;
+    commitDurationMsRef.current = 0;
+    longTaskCountRef.current = 0;
+    longTaskDurationMsRef.current = 0;
+  }, []);
+
+  const snapshot = useCallback((): PerfSnapshot => {
+    const scrollContainer = document.querySelector<HTMLElement>(
+      "[data-chat-scroll-container='true']",
+    );
+    return {
+      commitCount: commitCountRef.current,
+      commitDurationMs: commitDurationMsRef.current,
+      domNodeCount: document.getElementsByTagName("*").length,
+      heapUsedBytes: performance.memory?.usedJSHeapSize ?? null,
+      longTaskCount: longTaskCountRef.current,
+      longTaskDurationMs: longTaskDurationMsRef.current,
+      scrollHeight: scrollContainer?.scrollHeight ?? 0,
+      scrollTop: scrollContainer?.scrollTop ?? 0,
+    };
+  }, []);
+
+  const scrollCycle = useCallback(async (cycles = 2): Promise<FrameReport> => {
+    const scrollContainer = document.querySelector<HTMLElement>(
+      "[data-chat-scroll-container='true']",
+    );
+    if (!scrollContainer) throw new Error("Transcript scroll container is not mounted.");
+    const durations: number[] = [];
+    let previous = await nextFrame();
+    const stepsPerDirection = 90;
+    for (let cycle = 0; cycle < cycles; cycle += 1) {
+      for (const direction of [0, 1] as const) {
+        for (let step = 0; step <= stepsPerDirection; step += 1) {
+          const progress = step / stepsPerDirection;
+          scrollContainer.scrollTop =
+            (direction === 0 ? 1 - progress : progress) *
+            Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight);
+          const now = await nextFrame();
+          durations.push(now - previous);
+          previous = now;
+        }
+      }
+    }
+    return frameReport(durations);
+  }, []);
+
+  const appendStreamingChunks = useCallback(async (count = 120): Promise<FrameReport> => {
+    const durations: number[] = [];
+    let previous = await nextFrame();
+    for (let index = 0; index < count; index += 1) {
+      setStreamingText(
+        (current) => `${current} chunk-${index} with **Markdown** and \`inline code\`.`,
+      );
+      const now = await nextFrame();
+      durations.push(now - previous);
+      previous = now;
+    }
+    return frameReport(durations);
+  }, []);
+
+  useEffect(() => {
+    window.__synaraPerf = {
+      appendStreamingChunks,
+      resetMetrics,
+      scrollCycle,
+      snapshot,
+    };
+  }, [appendStreamingChunks, resetMetrics, scrollCycle, snapshot]);
+
+  return (
+    <main className="flex h-screen min-h-0 w-screen bg-background text-foreground">
+      <Profiler id="synara-transcript-perf" onRender={handleRender}>
+        <ChatTranscriptPane
+          activeThreadId="perf-thread"
+          activeTurnId={working ? TurnId.makeUnsafe("perf-turn-streaming") : null}
+          activeTurnInProgress={working}
+          activeTurnStartedAt={working ? isoAt(messageCount * 2) : null}
+          chatFontSizePx={15}
+          emptyStateProjectName={undefined}
+          hasMessages
+          isRevertingCheckpoint={false}
+          isWorking={working}
+          followLiveOutput={working}
+          listRef={listRef}
+          markdownCwd={undefined}
+          onExpandTimelineImage={NOOP}
+          onMessagesClickCapture={NOOP}
+          onMessagesMouseUp={NOOP}
+          onMessagesPointerCancel={NOOP}
+          onMessagesPointerDown={NOOP}
+          onMessagesPointerUp={NOOP}
+          onMessagesScroll={NOOP}
+          onMessagesTouchEnd={NOOP}
+          onMessagesTouchMove={NOOP}
+          onMessagesTouchStart={NOOP}
+          onMessagesWheel={NOOP}
+          onIsAtEndChange={NOOP}
+          onOpenTurnDiff={NOOP}
+          onOpenThread={NOOP}
+          onRevertUserMessage={NOOP}
+          onScrollToBottom={NOOP}
+          onToggleWorkGroup={NOOP}
+          resolvedTheme="dark"
+          revertTurnCountByUserMessageId={EMPTY_REVERT_COUNTS}
+          scrollButtonVisible={false}
+          terminalWorkspaceTerminalTabActive={false}
+          timelineEntries={timelineEntries}
+          timestampFormat="locale"
+          turnDiffSummaryByAssistantMessageId={EMPTY_TURN_DIFFS}
+          workspaceRoot={undefined}
+          worktreeSetup={null}
+        />
+      </Profiler>
+    </main>
+  );
+}
+
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("Missing #root element.");
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <PerformanceHarness />
+  </StrictMode>,
+);

--- a/apps/web/perf/vite.config.ts
+++ b/apps/web/perf/vite.config.ts
@@ -1,0 +1,15 @@
+import os from "node:os";
+import path from "node:path";
+import { mergeConfig } from "vite";
+
+import appConfig from "../vite.config";
+
+export default mergeConfig(appConfig, {
+  build: {
+    emptyOutDir: true,
+    outDir: path.join(os.tmpdir(), "synara-perf-dist"),
+    rollupOptions: {
+      input: path.resolve(import.meta.dirname, "index.html"),
+    },
+  },
+});

--- a/apps/web/src/components/chat/MessagesTimeline.worktreeSetup.browser.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.worktreeSetup.browser.tsx
@@ -218,6 +218,7 @@ describe("MessagesTimeline worktree setup card", () => {
       await expect.poll(() => setupRow() !== null).toBe(true);
       expect(setupRow()?.textContent).toContain("Preparing worktree...");
       expect(setupRow()?.textContent).toContain("Creating branch and worktree");
+      expect(setupRow()?.querySelector(".shimmer")?.classList).not.toContain("shimmer-once");
       // The generic working shimmer stays suppressed while the card is open.
       expect(workingRow()).toBeNull();
 
@@ -232,6 +233,7 @@ describe("MessagesTimeline worktree setup card", () => {
       await expect.poll(() => workingRow() !== null).toBe(true);
       await expect.poll(() => setupRow() === null, { timeout: 2000 }).toBe(true);
       expect(workingRow()).not.toBeNull();
+      expect(workingRow()?.querySelector(".shimmer")?.classList).not.toContain("shimmer-once");
     } finally {
       await screen.unmount();
     }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -57,6 +57,7 @@ import {
   useComposerDraftStore,
 } from "../composerDraftStore";
 import { useStore } from "../store";
+import { EMPTY_THREAD_IDS } from "../storeState";
 import { createAllThreadsSelector } from "../storeSelectors";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
 import { terminalActivityFromEvent } from "../terminalActivity";
@@ -1001,7 +1002,7 @@ function EventRouter() {
     (store) => store.removeOrphanedTerminalStates,
   );
   const setServerWorkspacePaths = useWorkspacePathsStore((store) => store.setServerWorkspacePaths);
-  const serverThreads = useStore(selectAllThreads);
+  const serverThreadIds = useStore((store) => store.threadIds ?? EMPTY_THREAD_IDS);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const pathname = useRouterState({ select: (state) => state.location.pathname });
@@ -1038,14 +1039,14 @@ function EventRouter() {
     [dockStateByThreadId, hostThreadIds, routeSearch.view],
   );
   const retainedThreadIds = useRetainedThreadDetailIds();
-  const serverThreadIds = new Set(serverThreads.map((thread) => thread.id));
+  const serverThreadIdSet = useMemo(() => new Set(serverThreadIds), [serverThreadIds]);
   // Stabilize the lease array by content: `serverThreads` re-emits on every
   // streaming update, and an identity-changing lease list would enqueue a no-op
   // subscription reconcile per render onto the serialized subscribe chain.
   const nextSubscribedThreadIds = resolveThreadDetailSubscriptionLeaseIds({
     visibleThreadIds,
     retainedThreadIds,
-    serverThreadIds,
+    serverThreadIds: serverThreadIdSet,
   });
   const subscribedThreadIdsRef = useRef(nextSubscribedThreadIds);
   const subscribedThreadIds = arraysShallowEqual(

--- a/apps/web/src/threadDetailSubscriptionRetention.test.ts
+++ b/apps/web/src/threadDetailSubscriptionRetention.test.ts
@@ -9,6 +9,7 @@ import {
   resolveThreadDetailSubscriptionLeaseIds,
   retainThreadDetailSubscription,
   setVisibleThreadDetailIds,
+  shouldReconcileThreadDetailRetention,
   subscribeThreadDetailEvictions,
 } from "./threadDetailSubscriptionRetention";
 
@@ -124,6 +125,22 @@ describe("threadDetailSubscriptionRetention", () => {
     vi.advanceTimersByTime(60 * 1000);
 
     expect(getRetainedThreadDetailIdsSnapshot()).toEqual([]);
+  });
+
+  it("skips retention scans for message-only streaming updates", () => {
+    const previous = useStore.getState();
+    const current = {
+      ...previous,
+      messageByThreadId: { ...previous.messageByThreadId },
+    };
+
+    expect(shouldReconcileThreadDetailRetention(current, previous)).toBe(false);
+    expect(
+      shouldReconcileThreadDetailRetention(
+        { ...current, threadSessionById: { ...current.threadSessionById } },
+        previous,
+      ),
+    ).toBe(true);
   });
 
   it("keeps non-idle threads retained past the idle timeout until they settle", () => {

--- a/apps/web/src/threadDetailSubscriptionRetention.ts
+++ b/apps/web/src/threadDetailSubscriptionRetention.ts
@@ -6,7 +6,7 @@
 import { WS_STREAM_LIMITS, type ThreadId } from "@synara/contracts";
 import { useSyncExternalStore } from "react";
 import { useStore } from "./store";
-import { getThreadFromState } from "./threadDerivation";
+import type { AppState } from "./storeState";
 
 const THREAD_DETAIL_RETENTION_EVICTION_MS = 15 * 60 * 1000;
 // This is a client-side memory cache, not a stream budget: concurrent server
@@ -79,8 +79,8 @@ function isThreadDetailEvictionUnsafe(threadId: ThreadId): boolean {
     }
   }
 
-  const thread = getThreadFromState(state, threadId);
-  if (!thread) {
+  const threadShell = state.threadShellById?.[threadId];
+  if (!threadShell) {
     // Claude subagent children can have detail without a shell/sidebar row.
     // Their normalized lifecycle slices still tell us whether eviction would
     // discard live work. Once terminal, the retain timeout and capacity limit
@@ -95,13 +95,27 @@ function isThreadDetailEvictionUnsafe(threadId: ThreadId): boolean {
     );
   }
 
-  const orchestrationStatus = thread.session?.orchestrationStatus;
+  const session = state.threadSessionById?.[threadId];
+  const turnState = state.threadTurnStateById?.[threadId];
+  const orchestrationStatus = session?.orchestrationStatus;
   return (
     Boolean(
       orchestrationStatus && orchestrationStatus !== "idle" && orchestrationStatus !== "stopped",
     ) ||
-    thread.latestTurn?.state === "running" ||
-    thread.pendingSourceProposedPlan !== undefined
+    turnState?.latestTurn?.state === "running" ||
+    turnState?.pendingSourceProposedPlan !== undefined
+  );
+}
+
+export function shouldReconcileThreadDetailRetention(
+  current: AppState,
+  previous: AppState,
+): boolean {
+  return (
+    current.sidebarThreadSummaryById !== previous.sidebarThreadSummaryById ||
+    current.threadShellById !== previous.threadShellById ||
+    current.threadSessionById !== previous.threadSessionById ||
+    current.threadTurnStateById !== previous.threadTurnStateById
   );
 }
 
@@ -223,7 +237,10 @@ function reconcileRetentionEntries(): void {
 // the live map, so a nested pass can only evict entries the outer pass has not
 // claimed. The eviction notice is the one part that must not run inline — lease
 // owners answer it by queueing a stream refresh rather than writing state here.
-useStore.subscribe(() => {
+useStore.subscribe((current, previous) => {
+  if (!shouldReconcileThreadDetailRetention(current, previous)) {
+    return;
+  }
   reconcileRetentionEntries();
 });
 

--- a/docs/performance/2026-08-09-thread-runtime-and-chatview-audit.md
+++ b/docs/performance/2026-08-09-thread-runtime-and-chatview-audit.md
@@ -1,0 +1,266 @@
+# Thread runtime and ChatView performance audit
+
+Date: 2026-08-08/09  
+Machine: MacBook Pro (Mac17,2), Apple M5 (4 performance + 6 efficiency cores), 32 GB RAM  
+OS: macOS 26.6 (25G72)  
+Runtime: Bun 1.3.12, Node 24.13.0, Electron 40.10.6, React 19, Vite 8.1.5
+
+Temperature was observed only as context. CPU, RSS/physical footprint, JavaScript
+heap, process count, frame timing, long tasks, DOM size, and durable poll frequency
+are the benchmark signals.
+
+## Architecture and attribution boundary
+
+- Electron owns one main process, one primary browser renderer, Chromium GPU/utility
+  processes, and one Synara backend child. These are application infrastructure,
+  not one process per thread.
+- A provider session normally owns an external provider process tree. Codex uses one
+  `codex app-server` tree per provider session; Claude and ACP providers have similar
+  per-session ownership. OpenCode may share a ref-counted local server.
+- Provider events cross the boundary through stdio, are durably journaled before
+  publication, projected into orchestration events, and delivered through
+  thread-scoped WebSocket streams.
+- PTYs are created only when a terminal is opened. Their output is bounded and
+  coalesced; a shared process-tree monitor polls every second while active and every
+  eight seconds while idle, and stops when no PTY remains.
+- Normal completion deliberately keeps a provider runtime warm for ten minutes.
+  Cancellation, archive, delete, and application shutdown use immediate teardown.
+  Switching threads does not stop a background provider or PTY.
+- The web client retains up to 32 recently used thread details for 15 minutes, with
+  no more than eight server detail leases. Inactive views are not all mounted, but
+  those bounded warm leases still filter the shared event stream.
+
+CPU and RSS reported for `codex`, `claude`, `opencode`, or another provider child
+belong to that provider. Synara's additional cost is its Electron/backend process
+set, process-retention policy, provider event parsing/journaling/projection,
+WebSocket fanout, renderer work, PTY monitoring, and persistence.
+
+## Reproduction
+
+The transcript harness renders the real `ChatTranscriptPane` with representative
+Markdown, code blocks, tool rows, and a streaming final message:
+
+```sh
+cd apps/web
+bunx vite --host 127.0.0.1
+# Open /perf/?messages=1000&working=1
+
+# Production harness (output is written under the OS temporary directory)
+bunx vite build --config perf/vite.config.ts
+bunx vite preview --config perf/vite.config.ts --host 127.0.0.1 --port 63912
+# Open /perf/?messages=1000&working=1
+```
+
+The page exposes `window.__synaraPerf.snapshot()`, `resetMetrics()`,
+`scrollCycle(count)`, and `appendStreamingChunks(count)`. A cycle performs a
+scripted bottom-to-top-to-bottom stress pass aligned to animation frames.
+
+An isolated development instance used a separate database and ports:
+
+```sh
+env -u SYNARA_AUTH_TOKEN SYNARA_PORT_OFFSET=4117 SYNARA_NO_BROWSER=1 \
+  bun run dev -- --home-dir ./.synara-perf-audit --port 59231
+```
+
+The direct/provider-through comparison used this equivalent task:
+
+```text
+Run sleep 15 in the shell, then respond with exactly PONG.
+```
+
+The journal SQL-shape comparison is self-contained:
+
+```sh
+cd apps/server
+bun run perf/providerRuntimeJournalAppend.bench.ts
+```
+
+Process readings use `ps`; native samples use macOS `sample` and `vmmap`.
+Development-mode numbers include React diagnostics, Vite/HMR, source transforms,
+and Bun, and must not be substituted for packaged-build measurements.
+
+## Baseline runtime matrix
+
+| Scenario                                             | Synara CPU / memory                                                                           | Provider CPU / memory                                                              | Processes                                                               | Renderer/frame evidence                                                    | Observation                                                                                                                                                                                                                                                                                           |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Packaged app, existing workload                      | Main 0.4% / 77 MB; server transient 7.9% / 178 MB; renderer 26.7% / 284 MB; GPU 25.8% / 48 MB | Two retained Claude children: 152 MB and 230 MB; 0.1-0.2% each                     | Electron main + server + renderer/GPU/helpers + provider trees          | Five-second renderer sample showed about 14% main-thread activity          | Uncontrolled snapshot; it shows renderer/GPU work can dominate while provider CPU is low.                                                                                                                                                                                                             |
+| Packaged backend, five-second sample                 | 269 MB physical, 387 MB peak; 4,110/4,211 main-thread samples in `kevent`                     | Not included                                                                       | One Synara backend                                                      | n/a                                                                        | The observed 7.9% was transient, not sustained backend CPU.                                                                                                                                                                                                                                           |
+| Isolated dev, idle before changes                    | 0.3% / 93 MB server RSS after warm-up                                                         | One retained provider tree at 24 MB at the sampled instant                         | Backend + one warm provider pair; Vite/contracts are dev-only           | n/a                                                                        | Fixed journal fallback still performed four SQLite safety polls per second.                                                                                                                                                                                                                           |
+| One provider directly, during `sleep 15`             | none                                                                                          | Approximately 160 MB RSS, approximately 0% CPU                                     | Four including wrapper, native provider, code-mode host, and `sleep`    | n/a                                                                        | Provider-side reference cost.                                                                                                                                                                                                                                                                         |
+| Equivalent task through Synara                       | About 93 MB dev backend at the sampled instant                                                | Approximately 156 MB for the provider pair, approximately 0% CPU after completion  | Synara backend/browser plus provider tree                               | Response completed in 23 seconds                                           | The provider RSS was essentially the same as direct; Synara adds its own backend/browser processes and event pipeline. Model differed (GPT-5.5 through Synara versus GPT-5.6 direct), so wall time is not a valid latency comparison.                                                                 |
+| Three concurrent dev sessions                        | 1.89 GB backend RSS and 6.8% sampled CPU                                                      | 299 MB total RSS across three provider pairs, approximately 0% CPU at the snapshot | One backend + six core provider processes, before optional MCP children | Separate dev browser pages                                                 | `server.getDiagnostics` with two sessions showed only 78 MB JS heap versus 1.03 GB RSS and 195 MB provider-child RSS. The excess was Bun/native memory, not transcript heap or provider RSS. This did not reproduce in the packaged backend sample and is classified as development-runtime overhead. |
+| Completed sessions left open                         | Backend remains; provider trees remain warm for up to ten minutes                             | Idle provider processes remain by policy                                           | One pair per warm provider session (provider dependent)                 | Inactive thread details are bounded to 32 client entries / 8 server leases | Bounded warm-resume tradeoff, not an orphan leak.                                                                                                                                                                                                                                                     |
+| Application shutdown after active/recovered sessions | Server exited                                                                                 | All observed provider descendants exited                                           | Zero descendants from the isolated tree                                 | n/a                                                                        | Explicit PID checks verified cleanup after SIGTERM.                                                                                                                                                                                                                                                   |
+
+The live cancellation/restart loop was partially exercised during controlled task
+runs, and the repository's provider lifecycle suites cover stop/restart/idle cleanup,
+process-tree TERM/KILL escalation, archive, and shutdown ordering. A provider-wide
+real-process soak test remains a gap because executing it for every installed
+provider would be environment- and credential-dependent.
+
+## Baseline ChatView matrix (development build)
+
+| Transcript     | Mount/idle                                          | Two rapid scroll cycles                                                                           | 60 streaming chunks                    |
+| -------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| 100 messages   | 236 DOM nodes; 248 MB dev heap; one 60 ms long task | 0/364 dropped frames; 8.38 ms mean, 9.1 ms p95, 17.1 ms max; 1.73 s task time                     | 0/60 dropped; 9.73 ms mean, 17 ms max  |
+| 500 messages   | 436 DOM nodes; 194 MB dev heap; one 65 ms long task | 50/364 dropped; 14.54 ms mean, 25.1 ms p95, 41.6 ms max; 4.65 s task time                         | 0/60 dropped; 8.33 ms mean, 9.1 ms max |
+| 1,000 messages | 724 DOM nodes; 196 MB dev heap; one 89 ms long task | 250/364 dropped; 25.53 ms mean, 41.6 ms p95, 75 ms max; 8.11 s task time; six long tasks / 376 ms | 0/60 dropped; 12.36 ms mean, 17 ms max |
+
+The DOM grows sublinearly (236 to 724 nodes while messages grow 10x), confirming
+that the transcript is already windowed. The harsh scripted scroll loop stresses
+dynamic measurement and React development instrumentation; it is not a packaged
+user-scroll FPS claim.
+
+With an active infinite text shimmer at rest, ten process samples averaged 5.26%
+renderer CPU and 0.98% GPU. Disabling only shimmer reduced the settled page to
+approximately zero CPU/GPU, confirming the animation as an independent idle cost.
+
+## Confirmed findings and implementation decisions
+
+### 1. Durable journal safety polling (medium/high idle impact, Synara-owned)
+
+`ProviderRuntimeIngestion` used a fixed 250 ms fallback poll. Even when caught up,
+every tick read the journal high-water sequence and consumer cursor. The live
+persisted-event stream already performs an immediate drain for normal events.
+
+The fallback now backs off 250 ms → 500 ms → 1 s → 2 s → 4 s → 5 s while caught
+up, and resets to 250 ms after backlog or a failed drain. The long-lived loop is a
+constant-size generator fiber; an intermediate recursive Effect chain was rejected
+after re-profiling exposed runaway CPU/RSS in Bun.
+
+- Old steady state: 4 safety polls/second.
+- New steady state: 0.2 safety polls/second.
+- Reduction: 95% fewer idle safety-poll wakeups and associated SQLite reads.
+- Live event latency is unchanged. A genuinely missed notification can now take up
+  to five seconds to recover, while normal publication remains immediate.
+
+### 2. Unrelated streaming updates scanned retained thread entries (medium under concurrency, Synara renderer-owned)
+
+The global retention subscriber reconciled as many as 32 entries on every Zustand
+mutation, including every message/token update. It also reconstructed thread detail
+only to read lifecycle fields. The root event router selected a full derived thread
+array, so message changes could invalidate it even when thread IDs were unchanged.
+
+Retention reconciliation now runs only when shell, sidebar summary, session, or turn
+lifecycle map identities change, and it reads those narrow lifecycle maps directly.
+The root event router subscribes to the stable `threadIds` slice and memoizes its set.
+For 100 message-only mutations with 32 retained entries, the avoidable lifecycle
+inspection upper bound falls from 3,200 to zero. Provider behavior is irrelevant to
+this path.
+
+### 3. Infinite ChatView working shimmer (medium steady renderer impact, Synara-owned; retained by design)
+
+Both the worktree-setup and generic working labels originally used an infinite
+text-mask animation. The working status is often present while the provider is
+thinking, so the renderer and GPU continue repainting despite no new transcript
+content.
+
+An experiment changed both labels to the shared `shimmer-once` utility. After the
+two-second cue, the experiment had no steady animation:
+
+| Metric                            | Before | After | Change |
+| --------------------------------- | -----: | ----: | -----: |
+| Renderer CPU, ten settled samples |  5.26% | 0.23% | -95.6% |
+| GPU CPU, ten settled samples      |  0.98% | 0.32% | -67.3% |
+
+Both the generic `Working` shimmer and the separate `Preparing worktree...` shimmer
+are intentionally continuous in the final code because that persistent animation is
+part of the desired product feedback. The table therefore records a measured
+tradeoff rather than a shipped CPU reduction. No streaming, event ordering, or
+auto-scroll behavior was changed.
+
+### 4. Claude lifecycle lock map retained every historical thread (low per thread, unbounded, Synara-owned)
+
+`ClaudeAdapter` stored one semaphore per thread ID and never removed keys. A shared
+ref-counted keyed lock now counts holders plus waiters and deletes a key after the
+last user exits, including failure paths. `ProviderService` uses the same helper for
+its binding write lock, so the provider-specific fix reuses shared lifecycle logic.
+
+### 5. Per-event durable journal cost (medium/high while streaming, Synara-owned; measured but not changed)
+
+Every canonical provider event, including `content.delta`, is durably appended
+before UI publication. The current append performs an event-id read and an insert in
+a transaction. This maps provider chunk frequency directly to Synara SQLite work.
+
+A single `INSERT ... ON CONFLICT` alternative was compared with the current lookup
+plus transactional insert. The revised microbenchmark uses file-backed SQLite with
+WAL and `synchronous=NORMAL`, alternates which strategy runs first, and measures both
+unique events and a workload with 10% idempotent retries. Three balanced eight-sample runs of
+10,000 append attempts produced:
+
+| Workload            | Existing median range | `ON CONFLICT` median range | Observation                        |
+| ------------------- | --------------------: | -------------------------: | ---------------------------------- |
+| Unique events       |            317-363 ms |                 298-329 ms | `ON CONFLICT` 5.9-9.4% faster      |
+| 10% repeated events |            286-304 ms |                 291-299 ms | 3.4% slower to 1.4% faster; parity |
+
+This SQL-shape microbenchmark now favors `ON CONFLICT`, but it does not include the
+Effect SQL layer, concurrent provider streams, durable publication latency, or
+failure/replay behavior. The production experiment therefore remains reverted until
+an end-to-end journal benchmark confirms a meaningful win without weakening the
+journal-before-publish ordering, replay, cancellation, and durability guarantees.
+
+## Post-change ChatView production profile
+
+The same harness was built with the production Vite/React configuration. React
+development overhead explains much of the alarming dev-only memory and scroll cost:
+
+| Transcript | Settled DOM / JS heap | Two scroll cycles                                     | 60 streaming chunks at 1,000 messages                |
+| ---------- | --------------------- | ----------------------------------------------------- | ---------------------------------------------------- |
+| 100        | 223 nodes / 18 MB     | 0/364 dropped; 8.33 ms mean; 9.3 ms max               | —                                                    |
+| 500        | 423 nodes / 15 MB     | 0/364 dropped; 8.49 ms mean; 9.2 ms p95; 17.6 ms max  | —                                                    |
+| 1,000      | 680 nodes / 42 MB     | 4/364 dropped; 9.73 ms mean; 16.7 ms p95; 25.5 ms max | 1/60 dropped; 9.86 ms mean; 17.4 ms p95; 41.6 ms max |
+
+The production table is a mode-control and final profile, not a numerical comparison
+against the React development table. Both working shimmers remain continuous by
+product choice.
+
+## Rejected changes and remaining opportunities
+
+- **LegendList row recycling**: low/medium possible impact, medium risk. At 500 and
+  1,000 messages it was neutral or slower and increased heap growth (for example,
+  about +103 MB versus +41 MB in one 500-message dev run). Reverted.
+- **Larger render window / effectively full rendering**: high regression risk. At
+  100 messages it created 1,429 DOM nodes, a 1.45 s mount long-task total, and 59/60
+  dropped streaming frames. Reverted.
+- **Scroll-fade removal**: low confidence. One SwiftShader run reduced GPU activity
+  slightly but did not change renderer CPU or frame timing reliably. No change.
+- **Long-history virtualization tuning**: medium potential impact, high interaction
+  risk. Dynamic tool rows, images, selection, scroll anchoring, and streaming make a
+  deeper change unsafe without a dedicated production trace and regression suite.
+- **Bun development backend native footprint with concurrent provider sessions**:
+  high development-only impact, medium/high migration risk. JS heap stayed small
+  while native RSS grew sharply; packaged samples did not reproduce it. Investigate
+  Bun/JSC native allocation or run the dev backend under the same Node runtime as the
+  packaged server before changing provider lifecycle code.
+- **Five-second runtime reconciliation query**: low/medium potential impact at large
+  history sizes. It joins runtime/session/turn state and orders by a computed time.
+  Capture `EXPLAIN QUERY PLAN` against a large real database before adding indexes or
+  changing cadence.
+- **Provider warm-retention policy**: medium process/RSS impact, product tradeoff.
+  Reducing ten minutes would reclaim provider memory sooner but can increase restart
+  latency and lose warm context. It was not changed without a latency study.
+
+## Verification
+
+- `ProviderRuntimeIngestion.test.ts` and `keyedLock.test.ts`: 95 tests passed.
+- `threadDetailSubscriptionRetention.test.ts`: 17 tests passed.
+- `MessagesTimeline.worktreeSetup.browser.tsx`: 7 browser tests passed.
+- `ClaudeAdapter.test.ts`: 143 tests passed.
+- `ProviderService.test.ts`: 79 tests passed.
+- Production transcript harness build completed.
+- Shutdown PID audit found zero remaining descendants from the isolated Synara tree.
+- `bun fmt`: passed.
+- `bun lint`: passed with 0 errors and 401 existing warnings.
+- `bun typecheck`: 7/7 packages passed.
+- `bun run test`: 3,371 tests passed, 7 skipped; all 8 workspace tasks passed.
+- `bun run build`: all 5 workspace build tasks passed.
+- `bun run test:browser:stable`: 268 tests passed, 12 skipped.
+- The affected transcript browser file also passed independently (3/3). The
+  all-in-one browser run initially timed out under simultaneous unit/build load;
+  its stable serial rerun passed.
+- `bun run test:browser:geometry` on macOS: 4 passed and 8 tests explicitly named
+  `[geometry:linux]` failed because their target row did not enter the expected
+  Linux-calibrated virtualized region. These failures reproduce in the isolated
+  serial geometry suite, no virtualization logic was changed, and the production
+  transcript profiles above were captured with the macOS browser geometry actually
+  used by this machine.


### PR DESCRIPTION
## Summary

- Add adaptive backoff to provider runtime journal safety polling while preserving fast recovery when backlog is detected.
- Consolidate keyed lifecycle locks for Claude and provider services with cleanup-safe lock management.
- Reduce unnecessary thread retention scans and stabilize EventRouter subscription reconciliation during message streaming.
- Add runtime journal benchmarks and focused performance coverage for server and web behavior.

## Testing

- Added and updated unit tests for journal polling backoff, keyed locks, and thread retention reconciliation.
- Updated browser UI tests for worktree setup and working-state shimmer behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch durable runtime journal recovery timing (up to 5s for missed notifications) and core ingestion/subscription paths, though live events still drain immediately and behavior is covered by tests.
> 
> **Overview**
> **Server runtime ingestion** replaces a fixed 250ms journal safety poll with **adaptive backoff** (250ms up to 5s when caught up, reset to 250ms after backlog or a failed drain). The poller runs in a **single long-lived generator loop** instead of recursively chaining Effects (avoids Bun interpreter growth). Journal drain paths now report whether they processed backlog.
> 
> **Provider layers** introduce shared **`makeKeyedLock`** with entry cleanup after the last holder/waiter; **ClaudeAdapter** and **ProviderService** use it instead of per-thread semaphores/maps that could retain every thread key forever.
> 
> **Web client** limits thread-detail **retention reconciliation** to lifecycle/sidebar map identity changes (not every streaming message update) and reads narrow session/turn slices instead of full derived threads. **`__root`** subscribes to stable **`threadIds`** and memoizes the ID set so message streaming does not constantly invalidate subscription lease reconciliation.
> 
> Also adds a **SQLite journal append microbenchmark**, a **`ChatTranscriptPane` perf harness** (`apps/web/perf`), tests for backoff/locks/retention, and a **performance audit** document; journal `ON CONFLICT` SQL and shimmer CPU experiments are documented as measured but not shipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 567cad36c53d5fb7ff71b5a2c1b3aa617ec37bfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->