### PR TITLE
Fix slow startup and late event handling

### DIFF
--- a/apps/desktop/src/backendReadiness.test.ts
+++ b/apps/desktop/src/backendReadiness.test.ts
@@ -103,6 +103,31 @@ describe("waitForHttpReady", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps observing a live backend beyond sixty seconds when no deadline is configured", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(0);
+      const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () =>
+        Date.now() >= 130_000
+          ? new Response(null, { status: 200 })
+          : new Response(null, { status: 503 }),
+      );
+
+      const readiness = waitForHttpReady("http://127.0.0.1:3773", {
+        fetchImpl,
+        timeoutMs: null,
+        intervalMs: 1_000,
+      });
+
+      await vi.advanceTimersByTimeAsync(130_000);
+
+      await expect(readiness).resolves.toBeUndefined();
+      expect(fetchImpl).toHaveBeenCalledTimes(131);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("aborts an in-flight readiness wait", async () => {
     const controller = new AbortController();
     const fetchImpl = vi.fn<typeof fetch>().mockImplementation(

--- a/apps/desktop/src/backendReadiness.test.ts
+++ b/apps/desktop/src/backendReadiness.test.ts
@@ -107,11 +107,13 @@ describe("waitForHttpReady", () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(0);
-      const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () =>
-        Date.now() >= 130_000
-          ? new Response(null, { status: 200 })
-          : new Response(null, { status: 503 }),
-      );
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockImplementation(async () =>
+          Date.now() >= 130_000
+            ? new Response(null, { status: 200 })
+            : new Response(null, { status: 503 }),
+        );
 
       const readiness = waitForHttpReady("http://127.0.0.1:3773", {
         fetchImpl,

--- a/apps/desktop/src/backendReadiness.ts
+++ b/apps/desktop/src/backendReadiness.ts
@@ -62,8 +62,7 @@ export async function waitForHttpReady(
 ): Promise<void> {
   const fetchImpl = options?.fetchImpl ?? fetch;
   const signal = options?.signal;
-  const timeoutMs =
-    options?.timeoutMs === undefined ? DEFAULT_TIMEOUT_MS : options.timeoutMs;
+  const timeoutMs = options?.timeoutMs === undefined ? DEFAULT_TIMEOUT_MS : options.timeoutMs;
   const intervalMs = options?.intervalMs ?? DEFAULT_INTERVAL_MS;
   const requestTimeoutMs = options?.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   const readinessPath = options?.path ?? "/";

--- a/apps/desktop/src/backendReadiness.ts
+++ b/apps/desktop/src/backendReadiness.ts
@@ -4,7 +4,7 @@
 // Exports: waitForHttpReady, isBackendReadinessAborted, BackendReadinessAbortedError
 
 export interface WaitForHttpReadyOptions {
-  readonly timeoutMs?: number;
+  readonly timeoutMs?: number | null;
   readonly intervalMs?: number;
   readonly requestTimeoutMs?: number;
   readonly fetchImpl?: typeof fetch;
@@ -62,12 +62,13 @@ export async function waitForHttpReady(
 ): Promise<void> {
   const fetchImpl = options?.fetchImpl ?? fetch;
   const signal = options?.signal;
-  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const timeoutMs =
+    options?.timeoutMs === undefined ? DEFAULT_TIMEOUT_MS : options.timeoutMs;
   const intervalMs = options?.intervalMs ?? DEFAULT_INTERVAL_MS;
   const requestTimeoutMs = options?.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   const readinessPath = options?.path ?? "/";
   const isReady = options?.isReady ?? ((response: Response) => response.ok);
-  const deadline = Date.now() + timeoutMs;
+  const deadline = timeoutMs === null ? null : Date.now() + timeoutMs;
 
   for (;;) {
     if (signal?.aborted) {
@@ -104,7 +105,7 @@ export async function waitForHttpReady(
       signal?.removeEventListener("abort", abortRequest);
     }
 
-    if (Date.now() >= deadline) {
+    if (deadline !== null && Date.now() >= deadline) {
       throw new Error(`Timed out waiting for backend readiness at ${baseUrl}.`);
     }
 

--- a/apps/desktop/src/backendStartupReadiness.test.ts
+++ b/apps/desktop/src/backendStartupReadiness.test.ts
@@ -40,13 +40,45 @@ describe("waitForBackendStartupReady", () => {
 
   it("rejects when the listening promise fails before http is ready", async () => {
     const error = new Error("backend exited");
+    const cancelHttpWait = vi.fn();
 
     await expect(
       waitForBackendStartupReady({
         listeningPromise: Promise.reject(error),
         waitForHttpReady: () => new Promise<void>(() => {}),
-        cancelHttpWait: vi.fn(),
+        cancelHttpWait,
       }),
     ).rejects.toThrow("backend exited");
+
+    expect(cancelHttpWait).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cancel http after http readiness already won", async () => {
+    let resolveHttpReady!: () => void;
+    let rejectListening!: (error: Error) => void;
+    const listeningPromise = new Promise<void>((_resolve, reject) => {
+      rejectListening = reject;
+    });
+    const waitForHttpReady = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveHttpReady = resolve;
+        }),
+    );
+    const cancelHttpWait = vi.fn();
+
+    const resultPromise = waitForBackendStartupReady({
+      listeningPromise,
+      waitForHttpReady,
+      cancelHttpWait,
+    });
+
+    resolveHttpReady();
+    await expect(resultPromise).resolves.toBe("http");
+
+    rejectListening(new Error("late backend exit"));
+    await Promise.resolve();
+
+    expect(cancelHttpWait).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/backendStartupReadiness.ts
+++ b/apps/desktop/src/backendStartupReadiness.ts
@@ -41,7 +41,13 @@ export async function waitForBackendStartupReady(
 
     listeningPromise.then(
       () => settleResolve("listening"),
-      (error) => settleReject(error),
+      (error) => {
+        if (settled) {
+          return;
+        }
+        options.cancelHttpWait();
+        settleReject(error);
+      },
     );
     httpReadyPromise.then(
       () => settleResolve("http"),

--- a/apps/desktop/src/initialBackendWindowOpen.test.ts
+++ b/apps/desktop/src/initialBackendWindowOpen.test.ts
@@ -81,7 +81,7 @@ describe("openInitialBackendWindow", () => {
     expect(options.setReadinessInFlight).not.toHaveBeenCalled();
   });
 
-  it("skips startup work when a window already exists", () => {
+  it("keeps observing readiness when a packaged window already exists", () => {
     const options = createOptions({
       hasExistingWindow: vi.fn(() => true),
     });
@@ -89,6 +89,7 @@ describe("openInitialBackendWindow", () => {
     openInitialBackendWindow(options);
 
     expect(options.createWindow).not.toHaveBeenCalled();
-    expect(options.waitForBackendWindowReady).not.toHaveBeenCalled();
+    expect(options.waitForBackendWindowReady).toHaveBeenCalledTimes(1);
+    expect(options.setReadinessInFlight).toHaveBeenCalledWith(expect.any(Promise));
   });
 });

--- a/apps/desktop/src/initialBackendWindowOpen.ts
+++ b/apps/desktop/src/initialBackendWindowOpen.ts
@@ -20,14 +20,16 @@ export interface InitialBackendWindowOpenOptions {
 }
 
 export function openInitialBackendWindow(options: InitialBackendWindowOpenOptions): void {
-  if (options.isDevelopment || options.baseUrl.length === 0 || options.hasExistingWindow()) {
+  if (options.isDevelopment || options.baseUrl.length === 0) {
     return;
   }
 
-  // The packaged renderer is served from local files, so surface the window
-  // while the backend finishes startup instead of leaving macOS menu-bar-only.
-  options.createWindow();
-  options.writeLog("bootstrap main window created");
+  if (!options.hasExistingWindow()) {
+    // The packaged renderer is served from local files, so surface the window
+    // while the backend finishes startup instead of leaving macOS menu-bar-only.
+    options.createWindow();
+    options.writeLog("bootstrap main window created");
+  }
 
   if (options.getReadinessInFlight() !== null) {
     return;
@@ -45,7 +47,7 @@ export function openInitialBackendWindow(options: InitialBackendWindowOpenOption
       options.writeLog(
         `bootstrap backend readiness warning message=${options.formatErrorMessage(error)}`,
       );
-      options.warn("[desktop] backend readiness check timed out during packaged bootstrap", error);
+      options.warn("[desktop] backend readiness observation ended before startup completed", error);
     })
     .finally(() => {
       if (options.getReadinessInFlight() === nextOpen) {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -596,7 +596,11 @@ async function waitForBackendWindowReady(baseUrl: string): Promise<"listening" |
     waitForHttpReady: () =>
       waitForBackendHttpReady(baseUrl, {
         path: "/health",
-        timeoutMs: 60_000,
+        // The child supervisor, not elapsed wall time, owns the terminal
+        // condition. Large projection catch-up can legitimately outlive a
+        // minute; this observer is cancelled when that child exits or the app
+        // shuts down.
+        timeoutMs: null,
         isReady: async (response) => {
           if (!response.ok) {
             return false;
@@ -3233,6 +3237,10 @@ async function restartBackendAfterCrash(
   }
 
   cancelBackendReadinessWait();
+  // The aborted observer settles on a later microtask. Clear its identity now
+  // so the replacement child always gets a fresh readiness observation even
+  // when the renderer window survived the crash.
+  backendInitialWindowOpenInFlight = null;
   try {
     await reserveBackendEndpoint("backend restart");
   } catch (error) {

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -22,6 +22,7 @@ import {
 } from "../../persistence/Layers/Sqlite.ts";
 import {
   OrchestrationEventStore,
+  type OrchestrationEventReplayFilter,
   type OrchestrationEventStoreShape,
 } from "../../persistence/Services/OrchestrationEventStore.ts";
 import { ManagedAttachmentRepository } from "../../persistence/Services/ManagedAttachments.ts";
@@ -47,16 +48,25 @@ const makeProjectionPipelinePrefixedTestLayer = (prefix: string) =>
     Layer.provideMerge(NodeServices.layer),
   );
 
-const makeObservedEventStoreLayer = (readCursors: Array<number>) =>
+const makeObservedEventStoreLayer = (
+  readCursors: Array<number>,
+  readFilters: Array<OrchestrationEventReplayFilter> = [],
+) =>
   Layer.effect(
     OrchestrationEventStore,
     Effect.gen(function* () {
       const eventStore = yield* OrchestrationEventStore;
       return {
         ...eventStore,
-        readFromSequence(sequenceExclusive, limit, throughSequenceInclusive) {
+        readFromSequence(sequenceExclusive, limit, throughSequenceInclusive, filter) {
           readCursors.push(sequenceExclusive);
-          return eventStore.readFromSequence(sequenceExclusive, limit, throughSequenceInclusive);
+          if (filter) readFilters.push(filter);
+          return eventStore.readFromSequence(
+            sequenceExclusive,
+            limit,
+            throughSequenceInclusive,
+            filter,
+          );
         },
       } satisfies OrchestrationEventStoreShape;
     }),
@@ -997,8 +1007,9 @@ it.effect("fast-forwards lagging hot projector cursors before restart replay", (
       Layer.provideMerge(persistenceLayer),
     );
     const readCursors: Array<number> = [];
+    const readFilters: Array<OrchestrationEventReplayFilter> = [];
     const secondProjectionLayer = OrchestrationProjectionPipelineLive.pipe(
-      Layer.provideMerge(makeObservedEventStoreLayer(readCursors)),
+      Layer.provideMerge(makeObservedEventStoreLayer(readCursors, readFilters)),
       Layer.provideMerge(persistenceLayer),
     );
     const projectId = ProjectId.makeUnsafe("project-bootstrap-fast-forward");
@@ -1104,6 +1115,15 @@ it.effect("fast-forwards lagging hot projector cursors before restart replay", (
 
     assert.equal(readCursors.length, projectorStates.length);
     assert.deepEqual([...new Set(readCursors)], [latestSequence]);
+    assert.equal(readFilters.length, projectorStates.length);
+    assert.isTrue(readFilters.every((filter) => filter.includeBoundaryEvent === true));
+    assert.isTrue(
+      readFilters.some(
+        (filter) =>
+          filter.eventTypes.includes("thread.activity-appended") &&
+          filter.activityKinds?.includes("approval.requested") === true,
+      ),
+    );
     for (const row of projectorStates) {
       assert.equal(row.lastAppliedSequence, latestSequence);
     }
@@ -1202,7 +1222,7 @@ it.effect("drains 2,501 file-backed events to a captured high-water fence", () =
         const eventStore = yield* OrchestrationEventStore;
         return {
           ...eventStore,
-          readFromSequence(sequenceExclusive, limit, throughSequenceInclusive) {
+          readFromSequence(sequenceExclusive, limit, throughSequenceInclusive, filter) {
             return Stream.unwrap(
               Effect.gen(function* () {
                 if (!appendedAfterFence) {
@@ -1228,6 +1248,7 @@ it.effect("drains 2,501 file-backed events to a captured high-water fence", () =
                   sequenceExclusive,
                   limit,
                   throughSequenceInclusive,
+                  filter,
                 );
               }),
             );

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -78,8 +78,10 @@ import {
   toSafeThreadAttachmentSegment,
 } from "../../attachmentStore.ts";
 import {
+  DEFERRED_THREAD_SHELL_SUMMARY_EVENT_TYPES,
   shouldApplyDeferredThreadShellSummary,
   shouldApplyThreadsProjection,
+  THREAD_PROJECTION_EVENT_TYPES,
 } from "../threadShellEvents.ts";
 
 export const ORCHESTRATION_PROJECTOR_NAMES = {
@@ -105,6 +107,10 @@ interface ProjectorDefinition {
   readonly name: ProjectorName;
   readonly phase: "hot" | "deferred";
   readonly shouldApply?: (event: OrchestrationEvent) => boolean;
+  readonly replayFilter: {
+    readonly eventTypes: ReadonlyArray<OrchestrationEvent["type"]>;
+    readonly activityKinds?: ReadonlyArray<string>;
+  };
   readonly apply: (
     event: OrchestrationEvent,
     attachmentSideEffects: AttachmentSideEffects,
@@ -167,12 +173,32 @@ const THREAD_ACTIVITY_PROJECTION_EVENT_TYPES = new Set<OrchestrationEvent["type"
   "thread.conversation-rolled-back",
 ]);
 
+const THREAD_SESSION_PROJECTION_EVENT_TYPES = new Set<OrchestrationEvent["type"]>([
+  "thread.turn-start-requested",
+  "thread.session-set",
+]);
+
 const THREAD_TURN_PROJECTION_EVENT_TYPES = new Set<OrchestrationEvent["type"]>([
   "thread.turn-start-requested",
   "thread.session-set",
   "thread.turn-diff-completed",
   "thread.reverted",
   "thread.conversation-rolled-back",
+]);
+
+const PENDING_INTERACTION_ACTIVITY_KINDS = new Set([
+  "approval.requested",
+  "approval.resolved",
+  "provider.approval.respond.failed",
+  "user-input.requested",
+  "user-input.resolved",
+  "provider.user-input.respond.failed",
+]);
+
+const PENDING_INTERACTION_EVENT_TYPES = new Set<OrchestrationEvent["type"]>([
+  "thread.activity-appended",
+  "thread.approval-response-requested",
+  "thread.user-input-response-requested",
 ]);
 
 function shouldApplyThreadTurnsProjection(event: OrchestrationEvent): boolean {
@@ -189,12 +215,7 @@ function shouldApplyPendingInteractionsProjection(event: OrchestrationEvent): bo
     event.type === "thread.approval-response-requested" ||
     event.type === "thread.user-input-response-requested" ||
     (event.type === "thread.activity-appended" &&
-      (event.payload.activity.kind === "approval.requested" ||
-        event.payload.activity.kind === "approval.resolved" ||
-        event.payload.activity.kind === "provider.approval.respond.failed" ||
-        event.payload.activity.kind === "user-input.requested" ||
-        event.payload.activity.kind === "user-input.resolved" ||
-        event.payload.activity.kind === "provider.user-input.respond.failed"))
+      PENDING_INTERACTION_ACTIVITY_KINDS.has(event.payload.activity.kind))
   );
 }
 
@@ -1809,61 +1830,75 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
       name: ORCHESTRATION_PROJECTOR_NAMES.projects,
       phase: "hot",
       shouldApply: (event) => PROJECT_EVENT_TYPES.has(event.type),
+      replayFilter: { eventTypes: [...PROJECT_EVENT_TYPES] },
       apply: applyProjectsProjection,
     },
     {
       name: ORCHESTRATION_PROJECTOR_NAMES.threadMessages,
       phase: "hot",
       shouldApply: (event) => THREAD_MESSAGE_PROJECTION_EVENT_TYPES.has(event.type),
+      replayFilter: { eventTypes: [...THREAD_MESSAGE_PROJECTION_EVENT_TYPES] },
       apply: applyThreadMessagesProjection,
     },
     {
       name: ORCHESTRATION_PROJECTOR_NAMES.threadProposedPlans,
       phase: "hot",
       shouldApply: (event) => THREAD_PROPOSED_PLAN_PROJECTION_EVENT_TYPES.has(event.type),
+      replayFilter: { eventTypes: [...THREAD_PROPOSED_PLAN_PROJECTION_EVENT_TYPES] },
       apply: applyThreadProposedPlansProjection,
     },
     {
       name: ORCHESTRATION_PROJECTOR_NAMES.threadActivities,
       phase: "hot",
       shouldApply: (event) => THREAD_ACTIVITY_PROJECTION_EVENT_TYPES.has(event.type),
+      replayFilter: { eventTypes: [...THREAD_ACTIVITY_PROJECTION_EVENT_TYPES] },
       apply: applyThreadActivitiesProjection,
     },
     {
       name: ORCHESTRATION_PROJECTOR_NAMES.threads,
       phase: "hot",
       shouldApply: shouldApplyThreadsProjection,
+      replayFilter: { eventTypes: [...THREAD_PROJECTION_EVENT_TYPES] },
       apply: applyThreadsProjection,
     },
     {
       name: ORCHESTRATION_PROJECTOR_NAMES.threadSessions,
       phase: "hot",
-      shouldApply: (event) =>
-        event.type === "thread.turn-start-requested" || event.type === "thread.session-set",
+      shouldApply: (event) => THREAD_SESSION_PROJECTION_EVENT_TYPES.has(event.type),
+      replayFilter: { eventTypes: [...THREAD_SESSION_PROJECTION_EVENT_TYPES] },
       apply: applyThreadSessionsProjection,
     },
     {
       name: ORCHESTRATION_PROJECTOR_NAMES.threadTurns,
       phase: "hot",
       shouldApply: shouldApplyThreadTurnsProjection,
+      replayFilter: {
+        eventTypes: [...THREAD_TURN_PROJECTION_EVENT_TYPES, "thread.message-sent"],
+      },
       apply: applyThreadTurnsProjection,
     },
     {
       name: ORCHESTRATION_PROJECTOR_NAMES.checkpoints,
       phase: "hot",
       shouldApply: () => false,
+      replayFilter: { eventTypes: [] },
       apply: applyCheckpointsProjection,
     },
     {
       name: ORCHESTRATION_PROJECTOR_NAMES.pendingInteractions,
       phase: "hot",
       shouldApply: shouldApplyPendingInteractionsProjection,
+      replayFilter: {
+        eventTypes: [...PENDING_INTERACTION_EVENT_TYPES],
+        activityKinds: [...PENDING_INTERACTION_ACTIVITY_KINDS],
+      },
       apply: applyPendingInteractionsProjection,
     },
     {
       name: ORCHESTRATION_PROJECTOR_NAMES.threadShellSummaries,
       phase: "deferred",
       shouldApply: shouldApplyDeferredThreadShellSummary,
+      replayFilter: { eventTypes: [...DEFERRED_THREAD_SHELL_SUMMARY_EVENT_TYPES] },
       apply: applyThreadShellSummariesProjection,
     },
   ];
@@ -2102,6 +2137,10 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
                 Option.isSome(stateRow) ? stateRow.value.lastAppliedSequence : 0,
                 Number.MAX_SAFE_INTEGER,
                 highWaterSequence,
+                {
+                  ...projector.replayFilter,
+                  includeBoundaryEvent: true,
+                },
               ),
               (event) => {
                 if (!(projector.shouldApply?.(event) ?? true)) {

--- a/apps/server/src/orchestration/threadShellEvents.ts
+++ b/apps/server/src/orchestration/threadShellEvents.ts
@@ -38,9 +38,7 @@ const OTHER_THREAD_SHELL_EVENT_TYPES = new Set<OrchestrationEvent["type"]>([
   "thread.turn-diff-completed",
 ]);
 
-export const DEFERRED_THREAD_SHELL_SUMMARY_EVENT_TYPES = new Set<
-  OrchestrationEvent["type"]
->([
+export const DEFERRED_THREAD_SHELL_SUMMARY_EVENT_TYPES = new Set<OrchestrationEvent["type"]>([
   "thread.message-sent",
   "thread.proposed-plan-upserted",
   "thread.reverted",

--- a/apps/server/src/orchestration/threadShellEvents.ts
+++ b/apps/server/src/orchestration/threadShellEvents.ts
@@ -9,7 +9,7 @@ const THREAD_SHELL_SUMMARY_ACTIVITY_KINDS = new Set([
   "provider.user-input.respond.failed",
 ]);
 
-const THREAD_PROJECTION_EVENT_TYPES = new Set<OrchestrationEvent["type"]>([
+export const THREAD_PROJECTION_EVENT_TYPES = new Set<OrchestrationEvent["type"]>([
   "thread.created",
   "thread.meta-updated",
   "thread.pinned-message-added",
@@ -32,6 +32,17 @@ const OTHER_THREAD_SHELL_EVENT_TYPES = new Set<OrchestrationEvent["type"]>([
   "thread.proposed-plan-upserted",
   "thread.approval-response-requested",
   "thread.user-input-response-requested",
+  "thread.reverted",
+  "thread.conversation-rolled-back",
+  "thread.session-set",
+  "thread.turn-diff-completed",
+]);
+
+export const DEFERRED_THREAD_SHELL_SUMMARY_EVENT_TYPES = new Set<
+  OrchestrationEvent["type"]
+>([
+  "thread.message-sent",
+  "thread.proposed-plan-upserted",
   "thread.reverted",
   "thread.conversation-rolled-back",
   "thread.session-set",
@@ -69,14 +80,10 @@ export function shouldRefreshThreadShellSummary(event: OrchestrationEvent): bool
  * them out of the deferred projector avoids rescanning activity history.
  */
 export function shouldApplyDeferredThreadShellSummary(event: OrchestrationEvent): boolean {
-  if (!shouldRefreshThreadShellSummary(event)) {
+  if (!DEFERRED_THREAD_SHELL_SUMMARY_EVENT_TYPES.has(event.type)) {
     return false;
   }
-  return (
-    event.type !== "thread.activity-appended" &&
-    event.type !== "thread.approval-response-requested" &&
-    event.type !== "thread.user-input-response-requested"
-  );
+  return event.type !== "thread.message-sent" || event.payload.role === "user";
 }
 
 /** True only when an event can change the persisted thread shell sent to sidebar clients. */

--- a/apps/server/src/persistence/Layers/OrchestrationEventStore.test.ts
+++ b/apps/server/src/persistence/Layers/OrchestrationEventStore.test.ts
@@ -165,6 +165,52 @@ layer("OrchestrationEventStore", (it) => {
     }),
   );
 
+  it.effect("filters sparse projector replay before decoding unrelated activity payloads", () =>
+    Effect.gen(function* () {
+      const eventStore = yield* OrchestrationEventStore;
+      const now = "2026-08-09T00:00:00.000Z";
+      const threadId = ThreadId.makeUnsafe("thread-filtered-replay");
+      const appendActivity = (eventId: string, kind: string) =>
+        eventStore.append({
+          type: "thread.activity-appended",
+          eventId: EventId.makeUnsafe(eventId),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: now,
+          commandId: null,
+          causationEventId: null,
+          correlationId: null,
+          metadata: {},
+          payload: {
+            threadId,
+            activity: {
+              id: EventId.makeUnsafe(`${eventId}-activity`),
+              tone: "info",
+              kind,
+              summary: kind,
+              payload: {},
+              turnId: null,
+              createdAt: now,
+            },
+          },
+        } as Parameters<typeof eventStore.append>[0]);
+
+      yield* appendActivity("evt-filtered-replay-noise", "context-window.updated");
+      const relevant = yield* appendActivity("evt-filtered-replay-relevant", "approval.requested");
+      const replayed = yield* Stream.runCollect(
+        eventStore.readFromSequence(0, Number.MAX_SAFE_INTEGER, relevant.sequence, {
+          eventTypes: ["thread.activity-appended"],
+          activityKinds: ["approval.requested"],
+        }),
+      ).pipe(Effect.map((events) => Array.from(events)));
+
+      assert.deepEqual(
+        replayed.map((event) => event.eventId),
+        [relevant.eventId],
+      );
+    }),
+  );
+
   it.effect("normalizes imported Synara model-selection shapes during replay", () =>
     Effect.gen(function* () {
       const eventStore = yield* OrchestrationEventStore;

--- a/apps/server/src/persistence/Layers/OrchestrationEventStore.ts
+++ b/apps/server/src/persistence/Layers/OrchestrationEventStore.ts
@@ -13,7 +13,7 @@ import {
 } from "@synara/contracts";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as SqlSchema from "effect/unstable/sql/SqlSchema";
-import { Effect, Layer, Schema, Stream } from "effect";
+import { Effect, Layer, Option, Schema, Stream } from "effect";
 
 import {
   PersistenceDecodeError,
@@ -67,6 +67,10 @@ const ReadFromSequenceRequestSchema = Schema.Struct({
   sequenceExclusive: NonNegativeInt,
   throughSequenceInclusive: NonNegativeInt,
   limit: Schema.Number,
+  filterEnabled: Schema.Boolean,
+  includeBoundaryEvent: Schema.Boolean,
+  eventTypes: Schema.Array(Schema.String),
+  activityKinds: Schema.Array(Schema.String),
 });
 const ReadThreadFromSequenceRequestSchema = Schema.Struct({
   threadId: Schema.String,
@@ -396,8 +400,28 @@ const makeEventStore = Effect.gen(function* () {
   const readEventRowsFromSequence = SqlSchema.findAll({
     Request: ReadFromSequenceRequestSchema,
     Result: RawPersistedEventRowSchema,
-    execute: (request) =>
-      sql`
+    execute: (request) => {
+      const activityKindFilter =
+        request.activityKinds.length === 0
+          ? sql``
+          : sql`
+              AND (
+                event_type <> 'thread.activity-appended'
+                OR json_extract(payload_json, '$.activity.kind') IN ${sql.in(request.activityKinds)}
+              )
+            `;
+      const filteredEventPredicate =
+        request.eventTypes.length === 0
+          ? sql`0`
+          : sql`(event_type IN ${sql.in(request.eventTypes)} ${activityKindFilter})`;
+      const replayFilter = !request.filterEnabled
+        ? sql``
+        : request.includeBoundaryEvent
+          ? sql`AND (sequence = ${request.throughSequenceInclusive} OR ${filteredEventPredicate})`
+          : sql`
+              AND ${filteredEventPredicate}
+            `;
+      return sql`
         SELECT
           sequence,
           event_id AS "eventId",
@@ -413,9 +437,11 @@ const makeEventStore = Effect.gen(function* () {
         FROM orchestration_events
         WHERE sequence > ${request.sequenceExclusive}
           AND sequence <= ${request.throughSequenceInclusive}
+          ${replayFilter}
         ORDER BY sequence ASC
         LIMIT ${request.limit}
-      `,
+      `;
+    },
   });
 
   const readThreadEventRowsFromSequence = SqlSchema.findAll({
@@ -533,25 +559,61 @@ const makeEventStore = Effect.gen(function* () {
       ),
     );
 
+  interface EventPageState {
+    readonly cursor: number;
+    readonly remaining: number;
+  }
+
+  const makeEventStream = (input: {
+    readonly sequenceExclusive: number;
+    readonly limit: number;
+    readonly readPage: (
+      cursor: number,
+      pageSize: number,
+    ) => Effect.Effect<ReadonlyArray<OrchestrationEvent>, OrchestrationEventStoreError>;
+  }) =>
+    Stream.paginate<EventPageState, OrchestrationEvent, OrchestrationEventStoreError>(
+      { cursor: input.sequenceExclusive, remaining: input.limit },
+      ({ cursor, remaining }) => {
+        const pageSize = Math.min(remaining, READ_PAGE_SIZE);
+        return input.readPage(cursor, pageSize).pipe(
+          Effect.map((events) => {
+            const nextRemaining = remaining - events.length;
+            const lastEvent = events[events.length - 1];
+            const nextState =
+              lastEvent !== undefined && events.length === pageSize && nextRemaining > 0
+                ? Option.some({ cursor: lastEvent.sequence, remaining: nextRemaining })
+                : Option.none<EventPageState>();
+            return [events, nextState] as const;
+          }),
+        );
+      },
+    );
+
   const readFromSequence: OrchestrationEventStoreShape["readFromSequence"] = (
     sequenceExclusive,
     limit = DEFAULT_READ_FROM_SEQUENCE_LIMIT,
     throughSequenceInclusive = Number.MAX_SAFE_INTEGER,
+    filter,
   ) => {
     const normalizedLimit = Math.max(0, Math.floor(limit));
     const normalizedThroughSequence = Math.max(0, Math.floor(throughSequenceInclusive));
     if (normalizedLimit === 0 || normalizedThroughSequence <= sequenceExclusive) {
       return Stream.empty;
     }
-    const readPage = (
-      cursor: number,
-      remaining: number,
-    ): Stream.Stream<OrchestrationEvent, OrchestrationEventStoreError> =>
-      Stream.fromEffect(
+
+    return makeEventStream({
+      sequenceExclusive,
+      limit: normalizedLimit,
+      readPage: (cursor, pageSize) =>
         readEventRowsFromSequence({
           sequenceExclusive: cursor,
           throughSequenceInclusive: normalizedThroughSequence,
-          limit: Math.min(remaining, READ_PAGE_SIZE),
+          limit: pageSize,
+          filterEnabled: filter !== undefined,
+          includeBoundaryEvent: filter?.includeBoundaryEvent === true,
+          eventTypes: [...(filter?.eventTypes ?? [])],
+          activityKinds: [...(filter?.activityKinds ?? [])],
         }).pipe(
           Effect.mapError(
             toPersistenceSqlOrDecodeError(
@@ -564,24 +626,8 @@ const makeEventStore = Effect.gen(function* () {
               decodePersistedEventRow("OrchestrationEventStore.readFromSequence:rowToEvent", row),
             ),
           ),
-        ),
-      ).pipe(
-        Stream.flatMap((events) => {
-          if (events.length === 0) {
-            return Stream.empty;
-          }
-          const nextRemaining = remaining - events.length;
-          if (nextRemaining <= 0) {
-            return Stream.fromIterable(events);
-          }
-          return Stream.concat(
-            Stream.fromIterable(events),
-            readPage(events[events.length - 1]!.sequence, nextRemaining),
-          );
-        }),
-      );
-
-    return readPage(sequenceExclusive, normalizedLimit);
+      ),
+    });
   };
 
   const readThreadEventsFromSequence: OrchestrationEventStoreShape["readThreadEventsFromSequence"] =
@@ -597,16 +643,15 @@ const makeEventStore = Effect.gen(function* () {
       if (normalizedLimit === 0 || normalizedThroughSequence <= sequenceExclusive) {
         return Stream.empty;
       }
-      const readPage = (
-        cursor: number,
-        remaining: number,
-      ): Stream.Stream<OrchestrationEvent, OrchestrationEventStoreError> =>
-        Stream.fromEffect(
+      return makeEventStream({
+        sequenceExclusive,
+        limit: normalizedLimit,
+        readPage: (cursor, pageSize) =>
           readThreadEventRowsFromSequence({
             threadId,
             sequenceExclusive: cursor,
             throughSequenceInclusive: normalizedThroughSequence,
-            limit: Math.min(remaining, READ_PAGE_SIZE),
+            limit: pageSize,
             eventTypes: [...eventTypes],
           }).pipe(
             Effect.mapError(
@@ -624,19 +669,7 @@ const makeEventStore = Effect.gen(function* () {
               ),
             ),
           ),
-        ).pipe(
-          Stream.flatMap((events) => {
-            if (events.length === 0) return Stream.empty;
-            const nextRemaining = remaining - events.length;
-            if (nextRemaining <= 0) return Stream.fromIterable(events);
-            return Stream.concat(
-              Stream.fromIterable(events),
-              readPage(events[events.length - 1]!.sequence, nextRemaining),
-            );
-          }),
-        );
-
-      return readPage(sequenceExclusive, normalizedLimit);
+      });
     };
 
   const getHighWaterSequence: OrchestrationEventStoreShape["getHighWaterSequence"] = () =>

--- a/apps/server/src/persistence/Layers/OrchestrationEventStore.ts
+++ b/apps/server/src/persistence/Layers/OrchestrationEventStore.ts
@@ -626,7 +626,7 @@ const makeEventStore = Effect.gen(function* () {
               decodePersistedEventRow("OrchestrationEventStore.readFromSequence:rowToEvent", row),
             ),
           ),
-      ),
+        ),
     });
   };
 

--- a/apps/server/src/persistence/Services/OrchestrationEventStore.ts
+++ b/apps/server/src/persistence/Services/OrchestrationEventStore.ts
@@ -15,6 +15,12 @@ import type { Effect, Stream } from "effect";
 
 import type { OrchestrationEventStoreError } from "../Errors.ts";
 
+export interface OrchestrationEventReplayFilter {
+  readonly eventTypes: ReadonlyArray<OrchestrationEvent["type"]>;
+  readonly activityKinds?: ReadonlyArray<string>;
+  readonly includeBoundaryEvent?: boolean;
+}
+
 /**
  * OrchestrationEventStoreShape - Service API for orchestration event persistence.
  */
@@ -71,6 +77,7 @@ export interface OrchestrationEventStoreShape {
     sequenceExclusive: number,
     limit?: number,
     throughSequenceInclusive?: number,
+    filter?: OrchestrationEventReplayFilter,
   ) => Stream.Stream<OrchestrationEvent, OrchestrationEventStoreError>;
 
   /**

--- a/apps/web/src/wsTransport.test.ts
+++ b/apps/web/src/wsTransport.test.ts
@@ -21,6 +21,7 @@ import {
 import {
   shouldKeepServerLifecycleStream,
   getUnexpectedStreamCompletionRetryDelayMs,
+  getReconnectRetryDelayMs,
   getStreamCapacityRetryDelayMs,
   getStreamDuplicateRetryDelayMs,
   getStreamFailureCode,
@@ -137,10 +138,13 @@ interface WsTransportInternals {
   readonly streamCompletionRetryTimers: Map<string, number>;
   readonly activeThreadStreamInputs: Map<string, unknown>;
   readonly threadSubscriptions: Map<string, unknown>;
+  shellSubscribed: boolean;
   readonly threadStreamFailureListeners: Set<(failure: WsThreadStreamFailure) => void>;
   disposed: boolean;
   sessionVersion: number;
   reconnect(): Promise<unknown>;
+  openReconnectSession(): Promise<unknown>;
+  getClient(): Promise<unknown>;
   startStream<T>(
     client: unknown,
     key: string,
@@ -703,6 +707,170 @@ describe("WsTransport", () => {
     await transport.request(ORCHESTRATION_WS_METHODS.subscribeThread, { threadId });
 
     expect(startThreadStream).toHaveBeenCalledWith(client, threadId, input, true);
+  });
+
+  it("retains shell and thread subscription intent while the initial connection is unavailable", async () => {
+    vi.useFakeTimers();
+    try {
+      const { transport, internals } = makeBareTransport();
+      const threadId = "thread-slow-start";
+      Object.assign(internals, {
+        shellSubscribed: false,
+        getClient: vi.fn(() => new Promise(() => {})),
+      });
+
+      const shellRequest = transport
+        .request(ORCHESTRATION_WS_METHODS.subscribeShell, {}, { timeoutMs: 25 })
+        .catch((error: unknown) => error);
+      const threadRequest = transport
+        .request(ORCHESTRATION_WS_METHODS.subscribeThread, { threadId }, { timeoutMs: 25 })
+        .catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(25);
+
+      await expect(shellRequest).resolves.toMatchObject({ code: "WS_REQUEST_TIMEOUT" });
+      await expect(threadRequest).resolves.toMatchObject({ code: "WS_REQUEST_TIMEOUT" });
+      expect(internals.shellSubscribed).toBe(true);
+      expect(internals.threadSubscriptions.get(threadId)).toEqual({ threadId });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not restart an automatically restored shell stream for the initial subscriber", async () => {
+    const { transport, internals } = makeBareTransport();
+    const client = {};
+    let resolveClient!: (client: unknown) => void;
+    const startShellStream = vi.fn(async () => undefined);
+    Object.assign(internals, {
+      shellSubscribed: false,
+      shellSnapshotDelivered: false,
+      getClient: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveClient = resolve;
+          }),
+      ),
+      startShellStream,
+    });
+
+    const subscription = transport.request(ORCHESTRATION_WS_METHODS.subscribeShell, {});
+    // Recovery restored the desired stream and delivered its snapshot before
+    // the original request resumed.
+    Object.assign(internals, { shellSnapshotDelivered: true });
+    resolveClient(client);
+    await subscription;
+
+    expect(startShellStream).toHaveBeenCalledWith(client, false);
+  });
+
+  it("uses bounded exponential reconnect backoff", () => {
+    expect(getReconnectRetryDelayMs(0)).toBe(500);
+    expect(getReconnectRetryDelayMs(1)).toBe(1_000);
+    expect(getReconnectRetryDelayMs(3)).toBe(4_000);
+    expect(getReconnectRetryDelayMs(4)).toBe(5_000);
+    expect(getReconnectRetryDelayMs(100)).toBe(5_000);
+  });
+
+  it("joins an active reconnect instead of returning the detached prior client", async () => {
+    const transport = Object.create(WsTransport.prototype) as WsTransport;
+    const internals = transport as unknown as WsTransportInternals;
+    const recoveredClient = { generation: "recovered" };
+    Object.assign(internals, {
+      reconnectPromise: Promise.resolve(recoveredClient),
+      clientPromise: Promise.resolve({ generation: "stale" }),
+    });
+
+    await expect(internals.getClient()).resolves.toBe(recoveredClient);
+  });
+
+  it("keeps reconnecting and restores shell and thread subscriptions after recovery", async () => {
+    vi.useFakeTimers();
+    bindWindowTimersToCurrentGlobals();
+    try {
+      const transport = Object.create(WsTransport.prototype) as WsTransport;
+      const internals = transport as unknown as WsTransportInternals;
+      const threadId = "thread-reconnect";
+      const input = { threadId };
+      const client = { connected: true };
+      const createSession = vi
+        .fn()
+        .mockImplementationOnce(() => ({
+          clientPromise: Promise.reject(new Error("starting-1")),
+        }))
+        .mockImplementationOnce(() => ({
+          clientPromise: Promise.reject(new Error("starting-2")),
+        }))
+        .mockImplementationOnce(() => ({ clientPromise: Promise.resolve(client) }));
+      const startChannelStream = vi.fn();
+      const startShellStream = vi.fn(async () => undefined);
+      const startThreadStream = vi.fn(async () => undefined);
+      Object.assign(internals, {
+        disposed: false,
+        state: "closed",
+        stateListeners: new Set(),
+        reconnectFailures: 0,
+        lifetime: new AbortController(),
+        listeners: new Map([[WS_CHANNELS.serverWelcome, new Set([vi.fn()])]]),
+        shellSubscribed: true,
+        threadSubscriptions: new Map([[threadId, input]]),
+        runtime: null,
+        clientScope: null,
+        createSession,
+        takeCurrentRuntime: () => null,
+        closeRuntime: vi.fn(async () => undefined),
+        startChannelStream,
+        startShellStream,
+        refreshThreadSubscriptionInput: () => input,
+        startThreadStream,
+      });
+
+      const recovery = internals.openReconnectSession();
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      await expect(recovery).resolves.toBe(client);
+      expect(createSession).toHaveBeenCalledTimes(3);
+      expect(startChannelStream).toHaveBeenCalledOnce();
+      expect(startShellStream).toHaveBeenCalledOnce();
+      expect(startThreadStream).toHaveBeenCalledOnce();
+      expect(startThreadStream).toHaveBeenCalledWith(client, threadId, input);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels a pending reconnect delay during transport shutdown", async () => {
+    vi.useFakeTimers();
+    bindWindowTimersToCurrentGlobals();
+    try {
+      const transport = Object.create(WsTransport.prototype) as WsTransport;
+      const internals = transport as unknown as WsTransportInternals & {
+        disposed: boolean;
+        lifetime: AbortController;
+      };
+      const lifetime = new AbortController();
+      const createSession = vi.fn();
+      Object.assign(internals, {
+        disposed: false,
+        state: "closed",
+        stateListeners: new Set(),
+        reconnectFailures: 0,
+        lifetime,
+        createSession,
+      });
+
+      const recovery = internals.openReconnectSession();
+      internals.disposed = true;
+      lifetime.abort(new Error("Transport disposed"));
+
+      await expect(recovery).rejects.toThrow("Transport disposed");
+      expect(createSession).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("latches terminal compatibility guidance for late UI subscribers", () => {

--- a/apps/web/src/wsTransport.ts
+++ b/apps/web/src/wsTransport.ts
@@ -163,6 +163,33 @@ const makeRpcClient = RpcClient.make(WsFeatureRpcGroup);
 const makeBootstrapRpcClient = RpcClient.make(WsBootstrapRpcGroup);
 const REQUEST_TIMEOUT_MS = 60_000;
 const FEATURE_CONNECTION_PROBE_TIMEOUT_MS = 10_000;
+const INITIAL_RECONNECT_RETRY_MS = 500;
+const MAX_RECONNECT_RETRY_MS = 5_000;
+
+/** Keeps outages gentle on the backend while still recovering promptly. */
+export function getReconnectRetryDelayMs(attempt: number): number {
+  const exponent = Math.max(0, Math.min(Math.trunc(attempt), 16));
+  return Math.min(INITIAL_RECONNECT_RETRY_MS * 2 ** exponent, MAX_RECONNECT_RETRY_MS);
+}
+
+function delayWithAbort(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.reject(signal.reason);
+  return new Promise<void>((resolve, reject) => {
+    const timeoutId = window.setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      cleanup();
+      reject(signal.reason);
+    };
+    const cleanup = () => {
+      window.clearTimeout(timeoutId);
+      signal.removeEventListener("abort", onAbort);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
 
 function resolveRpcUrl(rawUrl: string, path: string): string {
   const url = new URL(rawUrl);
@@ -591,6 +618,14 @@ export class WsTransport {
   constructor(url?: string) {
     this.explicitUrl = url ?? null;
     this.clientPromise = this.createSession().clientPromise;
+    void this.clientPromise.catch((error) => {
+      if (this.disposed || isTerminalCompatibilityFailure(error)) return;
+      void this.reconnect().catch((reconnectError) => {
+        if (!this.disposed && !isTerminalCompatibilityFailure(reconnectError)) {
+          console.warn("WebSocket reconnect loop stopped unexpectedly", reconnectError);
+        }
+      });
+    });
   }
 
   async request<T = unknown>(
@@ -618,20 +653,13 @@ export class WsTransport {
         return undefined as T;
       }
 
-      const client = await awaitWithAbort(this.getClient(), abortScope.signal);
-
-      if (method === WS_METHODS.gitRunStackedAction) {
-        return (await this.runGitActionStream(client, params, abortScope.signal)) as T;
-      }
-      if (method === WS_METHODS.projectsProvisionFromGitHub) {
-        return (await this.runProjectProvisionStream(client, params, abortScope.signal)) as T;
-      }
-
       if (method === ORCHESTRATION_WS_METHODS.subscribeShell) {
+        const wasSubscribed = this.shellSubscribed;
         this.shellSubscribed = true;
         this.resetStreamCapacityRetry("orchestration.shell");
         this.resetStreamCompletionRetry("orchestration.shell");
-        await this.startShellStream(client, this.shellSnapshotDelivered);
+        const client = await awaitWithAbort(this.getClient(), abortScope.signal);
+        await this.startShellStream(client, wasSubscribed && this.shellSnapshotDelivered);
         return undefined as T;
       }
       if (method === ORCHESTRATION_WS_METHODS.subscribeThread) {
@@ -641,10 +669,21 @@ export class WsTransport {
         // Preserve the stored input identity across explicit refreshes so stale
         // restart callbacks cannot supersede the newly requested stream.
         const existingInput = this.threadSubscriptions.get(threadId);
+        const wasSubscribed = existingInput !== undefined;
         const input = threadStreamInputsEqual(existingInput, params) ? existingInput : params;
         this.threadSubscriptions.set(threadId, input);
-        await this.startThreadStream(client, threadId, input as never, true);
+        const client = await awaitWithAbort(this.getClient(), abortScope.signal);
+        await this.startThreadStream(client, threadId, input as never, wasSubscribed);
         return undefined as T;
+      }
+
+      const client = await awaitWithAbort(this.getClient(), abortScope.signal);
+
+      if (method === WS_METHODS.gitRunStackedAction) {
+        return (await this.runGitActionStream(client, params, abortScope.signal)) as T;
+      }
+      if (method === WS_METHODS.projectsProvisionFromGitHub) {
+        return (await this.runProjectProvisionStream(client, params, abortScope.signal)) as T;
       }
 
       const rpcInput =
@@ -791,7 +830,7 @@ export class WsTransport {
     this.disposed = true;
     // Abort before anything else: a pending negotiate must fail now rather
     // than resolve later and build a runtime this teardown will not see.
-    this.lifetime.abort();
+    this.lifetime.abort(new Error("Transport disposed"));
     this.setState("disposed");
     this.resetAllStreamCapacityRetries();
     this.resetAllStreamCompletionRetries();
@@ -803,13 +842,8 @@ export class WsTransport {
     // handled before closing the runtime so test/browser teardown stays quiet.
     void this.clientPromise.catch(() => undefined);
     void this.reconnectPromise?.catch(() => undefined);
-    const runtime = this.runtime;
-    const clientScope = this.clientScope;
-    if (!runtime) return;
-    if (clientScope) {
-      await runtime.runPromise(Scope.close(clientScope, Exit.void)).catch(() => undefined);
-    }
-    await runtime.dispose().catch(() => undefined);
+    const resources = this.takeCurrentRuntime();
+    if (resources) await this.closeRuntime(resources);
   }
 
   /**
@@ -943,6 +977,10 @@ export class WsTransport {
   }
 
   private async getClient(): Promise<RpcClientInstance> {
+    // Once recovery starts, the last fulfilled client belongs to a runtime
+    // that reconnect() has detached. New work must join the shared recovery
+    // promise instead of briefly reusing that stale socket.
+    if (this.reconnectPromise) return this.reconnectPromise;
     try {
       return await this.clientPromise;
     } catch (error) {
@@ -962,13 +1000,34 @@ export class WsTransport {
     return runtime;
   }
 
+  private takeCurrentRuntime(): {
+    readonly runtime: ManagedRuntime.ManagedRuntime<RpcClient.Protocol, never>;
+    readonly clientScope: Scope.Closeable | null;
+  } | null {
+    const runtime = this.runtime;
+    if (!runtime) return null;
+    const clientScope = this.clientScope;
+    this.runtime = null;
+    this.clientScope = null;
+    return { runtime, clientScope };
+  }
+
+  private async closeRuntime(resources: {
+    readonly runtime: ManagedRuntime.ManagedRuntime<RpcClient.Protocol, never>;
+    readonly clientScope: Scope.Closeable | null;
+  }): Promise<void> {
+    if (resources.clientScope) {
+      await resources.runtime
+        .runPromise(Scope.close(resources.clientScope, Exit.void))
+        .catch(() => undefined);
+    }
+    await resources.runtime.dispose().catch(() => undefined);
+  }
+
   private reconnect(): Promise<RpcClientInstance> {
     if (this.reconnectPromise) return this.reconnectPromise;
 
-    const oldRuntime = this.runtime;
-    const oldClientScope = this.clientScope;
-    this.runtime = null;
-    this.clientScope = null;
+    const oldResources = this.takeCurrentRuntime();
     this.resetAllStreamCapacityRetries();
     this.resetAllStreamCompletionRetries();
     for (const cleanup of this.streamCleanups.values()) cleanup();
@@ -977,15 +1036,7 @@ export class WsTransport {
 
     this.setState("connecting");
 
-    if (oldRuntime) {
-      void (
-        oldClientScope
-          ? oldRuntime.runPromise(Scope.close(oldClientScope, Exit.void)).catch(() => undefined)
-          : Promise.resolve()
-      ).finally(() => {
-        void oldRuntime.dispose().catch(() => undefined);
-      });
-    }
+    if (oldResources) void this.closeRuntime(oldResources);
 
     this.reconnectPromise = this.openReconnectSession().finally(() => {
       this.reconnectPromise = null;
@@ -1121,32 +1172,41 @@ export class WsTransport {
   }
 
   private async openReconnectSession(): Promise<RpcClientInstance> {
-    const delayMs = Math.min(500 * 2 ** this.reconnectFailures, 5_000);
-    this.reconnectFailures += 1;
-    await new Promise((resolve) => window.setTimeout(resolve, delayMs));
-    if (this.disposed) {
-      throw new Error("Transport disposed");
-    }
+    for (;;) {
+      if (this.disposed) throw new Error("Transport disposed");
+      this.setState("connecting");
+      const delayMs = getReconnectRetryDelayMs(this.reconnectFailures);
+      this.reconnectFailures += 1;
+      await delayWithAbort(delayMs, this.lifetime.signal);
 
-    const session = this.createSession();
-    this.clientPromise = session.clientPromise;
-
-    const client = await session.clientPromise;
-    this.reconnectFailures = 0;
-    for (const channel of this.listeners.keys()) {
-      this.startChannelStream(channel as WsPushChannel);
+      const session = this.createSession();
+      this.clientPromise = session.clientPromise;
+      try {
+        const client = await session.clientPromise;
+        for (const channel of this.listeners.keys()) {
+          this.startChannelStream(channel as WsPushChannel);
+        }
+        if (this.shellSubscribed) {
+          await this.startShellStream(client);
+        }
+        // Refreshing only overwrites existing keys, so iterating the live key
+        // set is safe here. Each stream starts at most once for this session.
+        for (const threadId of this.threadSubscriptions.keys()) {
+          const input = this.refreshThreadSubscriptionInput(threadId);
+          if (input === undefined) continue;
+          await this.startThreadStream(client, threadId, input);
+        }
+        this.reconnectFailures = 0;
+        return client;
+      } catch (error) {
+        const failedResources = this.takeCurrentRuntime();
+        if (failedResources) await this.closeRuntime(failedResources);
+        if (this.disposed) throw new Error("Transport disposed");
+        if (isTerminalCompatibilityFailure(error)) throw error;
+        // The backend may still be starting. Continue with bounded backoff;
+        // the transport lifetime aborts this loop immediately on disposal.
+      }
     }
-    if (this.shellSubscribed) {
-      void this.startShellStream(client);
-    }
-    // Refreshing only overwrites existing keys, so iterating the live key set
-    // is safe here.
-    for (const threadId of this.threadSubscriptions.keys()) {
-      const input = this.refreshThreadSubscriptionInput(threadId);
-      if (input === undefined) continue;
-      await this.startThreadStream(client, threadId, input);
-    }
-    return client;
   }
 
   private emit<C extends WsPushChannel>(channel: C, data: WsPushMessage<C>["data"]): void {


### PR DESCRIPTION
## Summary

- Improve desktop backend readiness and initial window opening.
- Tighten orchestration projection and event-store handling for thread shell events.
- Improve WebSocket transport behavior during startup and late events.
- Add focused regression coverage across desktop, server, and web layers.

## Testing

- Added and updated focused unit tests for backend readiness, window opening, projection pipelines, event persistence, and WebSocket transport.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration projection replay semantics and event-store filtering (correctness during catch-up), plus desktop startup and WS lifecycle; well-covered by new tests but spans critical startup paths.
> 
> **Overview**
> Addresses **slow packaged startup** and **late events** by letting desktop observe backend health until the child process exits (no 60s cap), continuing readiness when a window already exists, and resetting in-flight observation on backend restart.
> 
> On the server, **lagging projector catch-up** now replays only each projector’s relevant event types (and activity kinds) via SQL filtering on `readFromSequence`, with boundary-sequence handling—reducing decode work during fast-forward. Deferred thread shell summary replay is narrowed to an explicit event-type set.
> 
> The **web WebSocket transport** auto-starts reconnect on failed initial connect, uses bounded exponential backoff (abortable on dispose), preserves shell/thread subscription intent while the socket is down, avoids reusing a detached client during recovery, and restores streams after reconnect without double-starting for first-time subscribers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b94a3ca96f79d7a295eb1ebf399ada48f2f93108. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->