### PR TITLE
Match Studio sidebar title size to Synara

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1292,12 +1292,7 @@ export function SidebarSurfacePicker({
           />
         }
       >
-        <span
-          className={cn(
-            "font-display min-w-0 truncate text-foreground",
-            activeView === "threads" ? "text-[17px]" : "text-[15px]",
-          )}
-        >
+        <span className="font-display min-w-0 truncate text-[17px] text-foreground">
           {activeCopy.title}
         </span>
         <DisclosureChevron open className="text-muted-foreground/70" />


### PR DESCRIPTION
## Summary

The sidebar surface picker sized its trigger label conditionally: 17px when the active surface was Synara, 15px when it was Studio. Switching surfaces made the title visibly shrink.

Both surfaces now render at 17px.

## Changes

- `apps/web/src/components/Sidebar.tsx`: drop the `activeView === "threads"` size branch in `SidebarSurfacePicker`; the label is a plain `text-[17px]` span.

## Verification

`bun fmt`, `bun lint`, `bun typecheck` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single styling change in the sidebar picker with no logic, data, or auth impact.
> 
> **Overview**
> Fixes a visible **size jump** when switching sidebar surfaces: the surface picker trigger used **17px** for Synara (`threads`) and **15px** for Studio, so the title looked smaller on Studio.
> 
> **`SidebarSurfacePicker`** in `Sidebar.tsx` now applies a fixed **`text-[17px]`** on the trigger label and removes the `activeView === "threads"` branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aa5dad54ffbcfc3ed8589e1e8c666769409941e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->