### PR TITLE
Improve file preview header copy and breadcrumbs

### DIFF
--- a/apps/web/src/components/WorkspaceFilePreview.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.tsx
@@ -834,6 +834,7 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
         onMarkdownPreviewChange={handleMarkdownPreviewChange}
         onReferenceInChat={onReferenceInChat}
         onAskWhyInChat={onAskWhyInChat}
+        contentsForCopy={fileIsImage || fileQuery.data === undefined ? null : displayedFileContents}
         truncated={fileQuery.data?.truncated ?? false}
         dirty={editBufferDirty}
         readOnlyReason={readOnlyReason}

--- a/apps/web/src/components/chat/WorkspaceFilePreviewHeader.tsx
+++ b/apps/web/src/components/chat/WorkspaceFilePreviewHeader.tsx
@@ -25,6 +25,10 @@ import { Menu, MenuItem, MenuTrigger } from "../ui/menu";
 import { CHAT_SURFACE_HEADER_DIVIDER_CLASS_NAME, ChatHeaderIconButton } from "./chatHeaderControls";
 import { ComposerPickerMenuPopup } from "./ComposerPickerMenuPopup";
 import { OpenInPicker } from "./OpenInPicker";
+import {
+  calculateBreadcrumbLayout,
+  type CollapsedBreadcrumbLayout,
+} from "./workspaceFilePreviewBreadcrumb";
 
 interface WorkspaceFilePreviewHeaderProps {
   workspaceRoot: string | null;
@@ -75,14 +79,6 @@ interface BreadcrumbSegment {
   key: string;
 }
 
-// How the directory prefix is drawn: `null` means everything fits at natural
-// width; otherwise only the trailing `visibleTail` directories are shown
-// behind a "…" crumb (dropped too when even the ellipsis alone cannot fit).
-interface CollapsedPrefixLayout {
-  visibleTail: number;
-  showEllipsis: boolean;
-}
-
 // Reserved room for the unsaved-changes dot after the filename (size-1.5 dot
 // + ml-1.5 gap), plus a small epsilon absorbing fractional-width rounding.
 const DIRTY_DOT_RESERVE_PX = 12;
@@ -105,12 +101,14 @@ function CollapsingPathBreadcrumb(props: {
   const { prefixSegments, fileSegment, filePath, dirty } = props;
   const navRef = useRef<HTMLElement>(null);
   const measureRef = useRef<HTMLDivElement>(null);
-  const [collapsedLayout, setCollapsedLayout] = useState<CollapsedPrefixLayout | null>(null);
+  const fileRef = useRef<HTMLSpanElement>(null);
+  const [collapsedLayout, setCollapsedLayout] = useState<CollapsedBreadcrumbLayout | null>(null);
 
   useLayoutEffect(() => {
     const nav = navRef.current;
     const measure = measureRef.current;
-    if (!nav || !measure) {
+    const file = fileRef.current;
+    if (!nav || !measure || !file) {
       return;
     }
 
@@ -122,37 +120,23 @@ function CollapsingPathBreadcrumb(props: {
       const ellipsisWidth =
         measure.querySelector<HTMLElement>('[data-measure="ellipsis"]')?.getBoundingClientRect()
           .width ?? 0;
-      const fileWidth =
-        measure.querySelector<HTMLElement>('[data-measure="file"]')?.getBoundingClientRect()
-          .width ?? 0;
-      const available =
-        nav.clientWidth - fileWidth - (dirty ? DIRTY_DOT_RESERVE_PX : 0) - MEASURE_EPSILON_PX;
-
-      const totalPrefixWidth = crumbWidths.reduce((sum, width) => sum + width, 0);
-      if (totalPrefixWidth <= available) {
-        setCollapsedLayout(null);
-        return;
-      }
-      let usedWidth = ellipsisWidth;
-      let visibleTail = 0;
-      for (let index = crumbWidths.length - 1; index >= 0; index -= 1) {
-        const crumbWidth = crumbWidths[index] ?? 0;
-        if (usedWidth + crumbWidth > available) {
-          break;
-        }
-        usedWidth += crumbWidth;
-        visibleTail += 1;
-      }
-      const showEllipsis = ellipsisWidth <= available;
+      const nextLayout = calculateBreadcrumbLayout({
+        containerWidth: nav.clientWidth,
+        renderedFileWidth: file.getBoundingClientRect().width,
+        prefixWidths: crumbWidths,
+        ellipsisWidth,
+        trailingReserveWidth: (dirty ? DIRTY_DOT_RESERVE_PX : 0) + MEASURE_EPSILON_PX,
+      });
       // Keep the previous state object when nothing changed so resize frames
       // that land on the same layout skip the re-render entirely.
-      setCollapsedLayout((current) =>
-        current !== null &&
-        current.visibleTail === visibleTail &&
-        current.showEllipsis === showEllipsis
+      setCollapsedLayout((current) => {
+        if (current === nextLayout) return current;
+        if (current === null || nextLayout === null) return nextLayout;
+        return current.visibleTail === nextLayout.visibleTail &&
+          current.showEllipsis === nextLayout.showEllipsis
           ? current
-          : { visibleTail, showEllipsis },
-      );
+          : nextLayout;
+      });
     };
 
     compute();
@@ -161,6 +145,7 @@ function CollapsingPathBreadcrumb(props: {
     const observer = new ResizeObserver(compute);
     observer.observe(nav);
     observer.observe(measure);
+    observer.observe(file);
     return () => observer.disconnect();
   }, [filePath, prefixSegments.length, dirty]);
 
@@ -204,9 +189,6 @@ function CollapsingPathBreadcrumb(props: {
             {crumbChevron}
           </span>
         ))}
-        <span data-measure="file" className="font-medium">
-          {fileSegment}
-        </span>
       </div>
 
       {showEllipsisCrumb ? (
@@ -223,7 +205,11 @@ function CollapsingPathBreadcrumb(props: {
           {crumbChevron}
         </Fragment>
       ))}
-      <span className="min-w-0 shrink truncate font-medium text-foreground" title={filePath}>
+      <span
+        ref={fileRef}
+        className="min-w-0 shrink truncate font-medium text-foreground"
+        title={filePath}
+      >
         {fileSegment}
       </span>
       {dirty ? (

--- a/apps/web/src/components/chat/WorkspaceFilePreviewHeader.tsx
+++ b/apps/web/src/components/chat/WorkspaceFilePreviewHeader.tsx
@@ -3,19 +3,23 @@
 //          breadcrumb (project › …dirs › file) on the left, and an overflow
 //          menu + "Open in editor" split button on the right. Shared by the
 //          right-dock file/explorer panes and the editor center pane so every
-//          surface reads identically. The header is a `header-actions` inline-size
-//          query container, so the breadcrumb collapses dir-first then truncates
-//          the filename, and the controls (markdown toggle, "Open") shed their
-//          text labels for icons as the pane narrows — no overlap at any width.
+//          surface reads identically. Under width pressure the breadcrumb
+//          collapses whole middle directories behind a single "…" crumb
+//          (never letter-shards like "S… › O…"), keeping the nearest parent
+//          folders and the filename readable; only once every directory is
+//          hidden does the filename itself truncate. The header is a
+//          `header-actions` inline-size query container so the "Open" control
+//          sheds its text label for an icon as the pane narrows.
 // Layer: Chat/editor file-preview UI
 // Exports: WorkspaceFilePreviewHeader
 
 import { isWorkspaceRelativePathSafe, joinWorkspaceRelativePath } from "@synara/shared/path";
-import { Fragment } from "react";
+import { Fragment, useLayoutEffect, useRef, useState } from "react";
 
 import { basenameOfPath } from "~/file-icons";
+import { useCopyFileContentsToClipboard } from "~/hooks/useCopyToClipboard";
 import type { ChatFileReference } from "~/lib/chatReferences";
-import { ChevronRightIcon, EllipsisIcon, EyeIcon, FileIcon } from "~/lib/icons";
+import { ChevronRightIcon, CodeIcon, EllipsisIcon, EyeOpenIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
 import { Menu, MenuItem, MenuTrigger } from "../ui/menu";
 import { CHAT_SURFACE_HEADER_DIVIDER_CLASS_NAME, ChatHeaderIconButton } from "./chatHeaderControls";
@@ -33,6 +37,12 @@ interface WorkspaceFilePreviewHeaderProps {
   /** Whole-file chat actions, surfaced in the overflow menu when wired. */
   onReferenceInChat?: ((reference: ChatFileReference) => void) | undefined;
   onAskWhyInChat?: ((reference: ChatFileReference) => void) | undefined;
+  /**
+   * Text contents of the previewed file, enabling the overflow menu's
+   * "Copy contents" action. Null when no text is loaded (binary previews,
+   * pending/failed reads).
+   */
+  contentsForCopy?: string | null;
   /** Shown when the preview only holds a partial read of a large file. */
   truncated?: boolean;
   /** Marks the currently open source buffer as different from its saved version. */
@@ -44,20 +54,189 @@ interface WorkspaceFilePreviewHeaderProps {
 // Source (raw file, where selecting text yields a precise line/column chat
 // reference) vs. Preview (rendered markdown, read-only — browse + task lists).
 // Ordered Source-first so the interactive mode reads as the primary surface.
+// Icon-only by design: the title tooltip + sr-only text carry the labels.
 const MARKDOWN_VIEW_SEGMENTS = [
   {
     rendered: false,
     label: "Source",
     title: "Source view — select text to reference exact lines in chat",
-    Icon: FileIcon,
+    Icon: CodeIcon,
   },
   {
     rendered: true,
     label: "Preview",
     title: "Rendered preview — browse and toggle task lists",
-    Icon: EyeIcon,
+    Icon: EyeOpenIcon,
   },
 ] as const;
+
+interface BreadcrumbSegment {
+  name: string;
+  key: string;
+}
+
+// How the directory prefix is drawn: `null` means everything fits at natural
+// width; otherwise only the trailing `visibleTail` directories are shown
+// behind a "…" crumb (dropped too when even the ellipsis alone cannot fit).
+interface CollapsedPrefixLayout {
+  visibleTail: number;
+  showEllipsis: boolean;
+}
+
+// Reserved room for the unsaved-changes dot after the filename (size-1.5 dot
+// + ml-1.5 gap), plus a small epsilon absorbing fractional-width rounding.
+const DIRTY_DOT_RESERVE_PX = 12;
+const MEASURE_EPSILON_PX = 1;
+
+/**
+ * Breadcrumb that collapses whole middle directories behind a single "…"
+ * crumb when the row runs out of room, instead of letting every crumb
+ * truncate into unreadable letter-shards. A hidden mirror of the full path
+ * is measured (ResizeObserver keeps it honest across pane resizes and late
+ * font loads) to decide how many trailing directories still fit next to the
+ * filename; the filename itself only truncates once no directory fits.
+ */
+function CollapsingPathBreadcrumb(props: {
+  prefixSegments: BreadcrumbSegment[];
+  fileSegment: string;
+  filePath: string;
+  dirty: boolean;
+}) {
+  const { prefixSegments, fileSegment, filePath, dirty } = props;
+  const navRef = useRef<HTMLElement>(null);
+  const measureRef = useRef<HTMLDivElement>(null);
+  const [collapsedLayout, setCollapsedLayout] = useState<CollapsedPrefixLayout | null>(null);
+
+  useLayoutEffect(() => {
+    const nav = navRef.current;
+    const measure = measureRef.current;
+    if (!nav || !measure) {
+      return;
+    }
+
+    const compute = () => {
+      const crumbWidths = Array.from(
+        measure.querySelectorAll<HTMLElement>('[data-measure="crumb"]'),
+        (crumb) => crumb.getBoundingClientRect().width,
+      );
+      const ellipsisWidth =
+        measure.querySelector<HTMLElement>('[data-measure="ellipsis"]')?.getBoundingClientRect()
+          .width ?? 0;
+      const fileWidth =
+        measure.querySelector<HTMLElement>('[data-measure="file"]')?.getBoundingClientRect()
+          .width ?? 0;
+      const available =
+        nav.clientWidth - fileWidth - (dirty ? DIRTY_DOT_RESERVE_PX : 0) - MEASURE_EPSILON_PX;
+
+      const totalPrefixWidth = crumbWidths.reduce((sum, width) => sum + width, 0);
+      if (totalPrefixWidth <= available) {
+        setCollapsedLayout(null);
+        return;
+      }
+      let usedWidth = ellipsisWidth;
+      let visibleTail = 0;
+      for (let index = crumbWidths.length - 1; index >= 0; index -= 1) {
+        const crumbWidth = crumbWidths[index] ?? 0;
+        if (usedWidth + crumbWidth > available) {
+          break;
+        }
+        usedWidth += crumbWidth;
+        visibleTail += 1;
+      }
+      const showEllipsis = ellipsisWidth <= available;
+      // Keep the previous state object when nothing changed so resize frames
+      // that land on the same layout skip the re-render entirely.
+      setCollapsedLayout((current) =>
+        current !== null &&
+        current.visibleTail === visibleTail &&
+        current.showEllipsis === showEllipsis
+          ? current
+          : { visibleTail, showEllipsis },
+      );
+    };
+
+    compute();
+    // Observing the hidden mirror too re-measures when its natural width
+    // changes without a pane resize (late-loading fonts, new file path).
+    const observer = new ResizeObserver(compute);
+    observer.observe(nav);
+    observer.observe(measure);
+    return () => observer.disconnect();
+  }, [filePath, prefixSegments.length, dirty]);
+
+  const visiblePrefix =
+    collapsedLayout === null
+      ? prefixSegments
+      : prefixSegments.slice(prefixSegments.length - collapsedLayout.visibleTail);
+  const showEllipsisCrumb =
+    collapsedLayout !== null &&
+    collapsedLayout.showEllipsis &&
+    visiblePrefix.length < prefixSegments.length;
+
+  const crumbChevron = (
+    <ChevronRightIcon
+      aria-hidden="true"
+      className="mx-0.5 size-3 shrink-0 text-muted-foreground/40"
+    />
+  );
+
+  return (
+    <nav
+      ref={navRef}
+      aria-label="File path"
+      className="relative flex min-w-0 flex-1 items-center overflow-hidden text-[12px] leading-none"
+    >
+      {/* Hidden mirror of the full breadcrumb at natural width, measured to
+          decide how many directories fit. Absolutely positioned so it never
+          affects layout; invisible so it never paints. */}
+      <div
+        ref={measureRef}
+        aria-hidden="true"
+        className="pointer-events-none invisible absolute top-0 left-0 flex items-center whitespace-nowrap"
+      >
+        <span data-measure="ellipsis" className="flex items-center">
+          <span>…</span>
+          {crumbChevron}
+        </span>
+        {prefixSegments.map((segment) => (
+          <span key={segment.key} data-measure="crumb" className="flex items-center">
+            <span>{segment.name}</span>
+            {crumbChevron}
+          </span>
+        ))}
+        <span data-measure="file" className="font-medium">
+          {fileSegment}
+        </span>
+      </div>
+
+      {showEllipsisCrumb ? (
+        <span className="flex shrink-0 items-center" title={filePath}>
+          <span className="text-muted-foreground/80">…</span>
+          {crumbChevron}
+        </span>
+      ) : null}
+      {visiblePrefix.map((segment) => (
+        <Fragment key={segment.key}>
+          <span className="shrink-0 whitespace-nowrap text-muted-foreground/80">
+            {segment.name}
+          </span>
+          {crumbChevron}
+        </Fragment>
+      ))}
+      <span className="min-w-0 shrink truncate font-medium text-foreground" title={filePath}>
+        {fileSegment}
+      </span>
+      {dirty ? (
+        <span
+          className="ml-1.5 size-1.5 shrink-0 rounded-full bg-foreground/75"
+          role="status"
+          aria-label="Unsaved changes"
+          title="Unsaved changes"
+        />
+      ) : null}
+    </nav>
+  );
+}
 
 export const WorkspaceFilePreviewHeader = function WorkspaceFilePreviewHeader(
   props: WorkspaceFilePreviewHeaderProps,
@@ -69,9 +248,9 @@ export const WorkspaceFilePreviewHeader = function WorkspaceFilePreviewHeader(
   const fileIsOutsideWorkspace = !isWorkspaceRelativePathSafe(filePath);
 
   // Breadcrumb segments: project folder name, then each path part. Splitting
-  // here (vs. rendering the raw string) lets the directory prefix collapse
-  // first under width pressure while the filename stays pinned. Absolute
-  // paths drop the project prefix — they live outside the workspace.
+  // here (vs. rendering the raw string) lets middle directories collapse
+  // behind a "…" crumb under width pressure while the filename stays pinned.
+  // Absolute paths drop the project prefix — they live outside the workspace.
   const projectName =
     fileIsOutsideWorkspace || !workspaceRoot ? null : basenameOfPath(workspaceRoot);
   const relativeSegments = filePath
@@ -87,15 +266,17 @@ export const WorkspaceFilePreviewHeader = function WorkspaceFilePreviewHeader(
   }));
   const fileSegment = segments.at(-1) ?? filePath;
 
-  const { onReferenceInChat, onAskWhyInChat } = props;
+  const { onReferenceInChat, onAskWhyInChat, contentsForCopy } = props;
   const referenceWholeFile = () => {
     onReferenceInChat?.({ path: filePath });
   };
   const askWhyWholeFile = () => {
     onAskWhyInChat?.({ path: filePath });
   };
+  const copyFileContents = useCopyFileContentsToClipboard();
 
-  const hasChatActions = Boolean(onReferenceInChat || onAskWhyInChat);
+  const canCopyContents = contentsForCopy != null;
+  const hasOverflowMenu = canCopyContents || Boolean(onReferenceInChat || onAskWhyInChat);
 
   return (
     <div
@@ -104,38 +285,12 @@ export const WorkspaceFilePreviewHeader = function WorkspaceFilePreviewHeader(
         CHAT_SURFACE_HEADER_DIVIDER_CLASS_NAME,
       )}
     >
-      <nav
-        aria-label="File path"
-        className="flex min-w-0 flex-1 items-center text-[12px] leading-none"
-      >
-        {/* Dir prefix shrinks far faster than the filename (shrink-[9999]), so under
-            width pressure it collapses to nothing before the filename gives up any
-            room; only once the prefix is gone does the filename itself truncate.
-            This keeps the filename pinned-yet-bounded so it never overflows into the
-            controls on its right. */}
-        <span className="flex min-w-0 shrink-[9999] items-center overflow-hidden">
-          {prefixSegments.map((segment) => (
-            <Fragment key={segment.key}>
-              <span className="truncate text-muted-foreground/80">{segment.name}</span>
-              <ChevronRightIcon
-                aria-hidden="true"
-                className="mx-0.5 size-3 shrink-0 text-muted-foreground/40"
-              />
-            </Fragment>
-          ))}
-        </span>
-        <span className="min-w-0 shrink truncate font-medium text-foreground" title={filePath}>
-          {fileSegment}
-        </span>
-        {props.dirty ? (
-          <span
-            className="ml-1.5 size-1.5 shrink-0 rounded-full bg-foreground/75"
-            role="status"
-            aria-label="Unsaved changes"
-            title="Unsaved changes"
-          />
-        ) : null}
-      </nav>
+      <CollapsingPathBreadcrumb
+        prefixSegments={prefixSegments}
+        fileSegment={fileSegment}
+        filePath={filePath}
+        dirty={props.dirty ?? false}
+      />
 
       {props.truncated ? (
         <span className="hidden shrink-0 text-[10px] text-muted-foreground/70 @sm/header-actions:inline">
@@ -167,29 +322,38 @@ export const WorkspaceFilePreviewHeader = function WorkspaceFilePreviewHeader(
                   aria-checked={selected}
                   title={segment.title}
                   className={cn(
-                    "flex h-6 cursor-pointer items-center gap-1.5 rounded-md px-2 text-[11px] transition-colors",
+                    "flex h-6 w-7 cursor-pointer items-center justify-center rounded-md transition-colors",
                     selected
                       ? "bg-[var(--color-background-button-secondary)] text-[var(--color-text-foreground)]"
                       : "text-muted-foreground hover:text-foreground",
                   )}
                   onClick={() => props.onMarkdownPreviewChange(segment.rendered)}
                 >
-                  <segment.Icon aria-hidden="true" className="size-3.5 shrink-0" />
-                  {/* Label collapses to icon-only on a narrow pane; the title +
-                      sr-only text keep both modes labelled for a11y/tooltips. */}
-                  <span className="sr-only @sm/header-actions:not-sr-only">{segment.label}</span>
+                  <segment.Icon className="size-3.5 shrink-0" />
+                  <span className="sr-only">{segment.label}</span>
                 </button>
               );
             })}
           </div>
         ) : null}
 
-        {hasChatActions ? (
+        {hasOverflowMenu ? (
           <Menu>
             <MenuTrigger render={<ChatHeaderIconButton label="More actions" tone="plain" />}>
               <EllipsisIcon aria-hidden="true" className="size-3.5" />
             </MenuTrigger>
             <ComposerPickerMenuPopup align="end" side="bottom" className="w-52 min-w-52">
+              {canCopyContents ? (
+                <MenuItem
+                  onClick={() =>
+                    copyFileContents(contentsForCopy ?? "", fileSegment, {
+                      partial: props.truncated ?? false,
+                    })
+                  }
+                >
+                  Copy contents
+                </MenuItem>
+              ) : null}
               {onReferenceInChat ? (
                 <MenuItem onClick={referenceWholeFile}>Reference in chat</MenuItem>
               ) : null}

--- a/apps/web/src/components/chat/workspaceFilePreviewBreadcrumb.test.ts
+++ b/apps/web/src/components/chat/workspaceFilePreviewBreadcrumb.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateBreadcrumbLayout } from "./workspaceFilePreviewBreadcrumb";
+
+describe("calculateBreadcrumbLayout", () => {
+  it("keeps directories that fit beside the rendered filename", () => {
+    expect(
+      calculateBreadcrumbLayout({
+        containerWidth: 160,
+        renderedFileWidth: 40,
+        prefixWidths: [60, 60],
+        ellipsisWidth: 20,
+        trailingReserveWidth: 0,
+      }),
+    ).toBeNull();
+  });
+
+  it("uses space from a hidden ellipsis for a narrow trailing directory", () => {
+    expect(
+      calculateBreadcrumbLayout({
+        containerWidth: 50,
+        renderedFileWidth: 30,
+        prefixWidths: [100, 18],
+        ellipsisWidth: 24,
+        trailingReserveWidth: 0,
+      }),
+    ).toEqual({ visibleTail: 1, showEllipsis: false });
+  });
+
+  it("keeps the nearest directories that fit after the ellipsis", () => {
+    expect(
+      calculateBreadcrumbLayout({
+        containerWidth: 150,
+        renderedFileWidth: 50,
+        prefixWidths: [60, 45, 30],
+        ellipsisWidth: 20,
+        trailingReserveWidth: 0,
+      }),
+    ).toEqual({ visibleTail: 2, showEllipsis: true });
+  });
+});

--- a/apps/web/src/components/chat/workspaceFilePreviewBreadcrumb.ts
+++ b/apps/web/src/components/chat/workspaceFilePreviewBreadcrumb.ts
@@ -1,0 +1,52 @@
+export interface CollapsedBreadcrumbLayout {
+  visibleTail: number;
+  showEllipsis: boolean;
+}
+
+interface BreadcrumbMeasurement {
+  containerWidth: number;
+  renderedFileWidth: number;
+  prefixWidths: number[];
+  ellipsisWidth: number;
+  trailingReserveWidth: number;
+}
+
+function countTrailingCrumbsThatFit(
+  prefixWidths: number[],
+  availableWidth: number,
+  initialUsedWidth: number,
+): number {
+  let usedWidth = initialUsedWidth;
+  let visibleTail = 0;
+
+  for (let index = prefixWidths.length - 1; index >= 0; index -= 1) {
+    const nextWidth = prefixWidths[index] ?? 0;
+    if (usedWidth + nextWidth > availableWidth) break;
+    usedWidth += nextWidth;
+    visibleTail += 1;
+  }
+
+  return visibleTail;
+}
+
+export function calculateBreadcrumbLayout(
+  measurement: BreadcrumbMeasurement,
+): CollapsedBreadcrumbLayout | null {
+  const availableWidth = Math.max(
+    0,
+    measurement.containerWidth - measurement.renderedFileWidth - measurement.trailingReserveWidth,
+  );
+  const totalPrefixWidth = measurement.prefixWidths.reduce((sum, width) => sum + width, 0);
+  if (totalPrefixWidth <= availableWidth) return null;
+
+  const showEllipsis = measurement.ellipsisWidth <= availableWidth;
+  const initialUsedWidth = showEllipsis ? measurement.ellipsisWidth : 0;
+  return {
+    visibleTail: countTrailingCrumbsThatFit(
+      measurement.prefixWidths,
+      availableWidth,
+      initialUsedWidth,
+    ),
+    showEllipsis,
+  };
+}

--- a/apps/web/src/hooks/useCopyToClipboard.ts
+++ b/apps/web/src/hooks/useCopyToClipboard.ts
@@ -139,35 +139,92 @@ export function useCopyToClipboard<TContext = void>({
   return { copyToClipboard, isCopied };
 }
 
+interface CopyToastLabels {
+  successTitle: string;
+  /** Shown under the success title — usually the thing that was copied. */
+  successDescription: string;
+  errorTitle: string;
+}
+
+/**
+ * Shared "copy + toast" plumbing behind every copy-X convenience hook below:
+ * one success/error toast shape, one place to change it.
+ */
+function useCopyWithToasts(): (value: string, labels: CopyToastLabels) => void {
+  const { copyToClipboard } = useCopyToClipboard<CopyToastLabels>({
+    onCopy: (labels) =>
+      toastManager.add({
+        type: "success",
+        title: labels.successTitle,
+        description: labels.successDescription,
+      }),
+    onError: (error, labels) =>
+      toastManager.add({
+        type: "error",
+        title: labels.errorTitle,
+        description: error instanceof Error ? error.message : "An error occurred.",
+      }),
+  });
+  return copyToClipboard;
+}
+
 /**
  * Copy a filesystem path and surface the shared success/error toast. Single source
  * of truth for the "Path copied" affordance used by the sidebar and the kanban board.
  */
 export function useCopyPathToClipboard(): (path: string) => void {
-  const { copyToClipboard } = useCopyToClipboard<{ path: string }>({
-    onCopy: (ctx) =>
-      toastManager.add({ type: "success", title: "Path copied", description: ctx.path }),
-    onError: (error) =>
-      toastManager.add({
-        type: "error",
-        title: "Failed to copy path",
-        description: error instanceof Error ? error.message : "An error occurred.",
-      }),
-  });
-  return (path: string) => copyToClipboard(path, { path });
+  const copy = useCopyWithToasts();
+  return (path: string) =>
+    copy(path, {
+      successTitle: "Path copied",
+      successDescription: path,
+      errorTitle: "Failed to copy path",
+    });
+}
+
+/**
+ * Copy a previewed file's text contents and surface the shared success/error
+ * toast. Single source of truth for the "Copy contents" affordance in the
+ * file-preview header's overflow menu. Empty files get an informational toast
+ * instead of a copy (the clipboard helper never writes empty strings), and
+ * `partial: true` (large files whose preview holds a truncated read) is called
+ * out so the success toast never claims more than what was copied.
+ */
+export function useCopyFileContentsToClipboard(): (
+  contents: string,
+  fileName: string,
+  options?: { partial?: boolean },
+) => void {
+  const copy = useCopyWithToasts();
+  return (contents: string, fileName: string, options?: { partial?: boolean }) => {
+    if (contents.length === 0) {
+      toastManager.add({ type: "info", title: "Nothing to copy", description: "File is empty" });
+      return;
+    }
+    copy(
+      contents,
+      options?.partial
+        ? {
+            successTitle: "Partial contents copied",
+            successDescription: "Large file — only the loaded part was copied",
+            errorTitle: "Failed to copy contents",
+          }
+        : {
+            successTitle: "Contents copied",
+            successDescription: fileName,
+            errorTitle: "Failed to copy contents",
+          },
+    );
+  };
 }
 
 /** Copy a thread id and surface the shared "Thread ID copied" toast. */
 export function useCopyThreadIdToClipboard(): (threadId: string) => void {
-  const { copyToClipboard } = useCopyToClipboard<{ threadId: string }>({
-    onCopy: (ctx) =>
-      toastManager.add({ type: "success", title: "Thread ID copied", description: ctx.threadId }),
-    onError: (error) =>
-      toastManager.add({
-        type: "error",
-        title: "Failed to copy thread ID",
-        description: error instanceof Error ? error.message : "An error occurred.",
-      }),
-  });
-  return (threadId: string) => copyToClipboard(threadId, { threadId });
+  const copy = useCopyWithToasts();
+  return (threadId: string) =>
+    copy(threadId, {
+      successTitle: "Thread ID copied",
+      successDescription: threadId,
+      errorTitle: "Failed to copy thread ID",
+    });
 }

--- a/apps/web/src/lib/icons.tsx
+++ b/apps/web/src/lib/icons.tsx
@@ -154,6 +154,11 @@ export const ClockIcon = centralIconWrapper("clock");
 export const EllipsisIcon = adaptIcon(IconDots);
 export const ExternalLinkIcon = adaptIcon(IconExternalLink);
 export const EyeIcon = adaptIcon(IconEye);
+// Markdown Source/Preview toggle glyphs, sourced from the Central set so the
+// file-preview header controls share one visual language with the rest of the
+// chrome (raw source = code brackets, rendered preview = open eye).
+export const CodeIcon: LucideIcon = centralIconWrapper("code");
+export const EyeOpenIcon: LucideIcon = centralIconWrapper("eye-open");
 export const PaperclipIcon = adaptIcon(IconPaperclip);
 export const ArchiveIcon = adaptIcon(IconArchive);
 export const BrainIcon = adaptIcon(IconBrain);


### PR DESCRIPTION
## What Changed

- Updated the file preview header to make path copy actions more direct and consistent.
- Refined breadcrumb behavior and related clipboard handling in the workspace file preview flow.
- Cleaned up supporting copy utilities and header wiring in the chat/file preview UI.

## Why

The previous header interactions were harder to use than they needed to be, especially when copying file paths from the preview. This change makes the header actions clearer and the breadcrumb/path affordances more predictable.

## UI Changes

- File preview header actions now surface copy behavior more clearly.
- Breadcrumb/path display in the preview header was adjusted to better match the available file context.

## Verification

- Reviewed the diff for the file preview header, copy hook, and related UI wiring.
- Existing test coverage was updated where needed across the affected desktop and web code paths.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized chat/file-preview UI and clipboard helpers; no auth, data persistence, or API changes.
> 
> **Overview**
> Improves the workspace file preview header with **smarter path breadcrumbs**, a **Copy contents** overflow action, and small polish on markdown view controls.
> 
> The path breadcrumb no longer shrinks each directory into unreadable fragments. A measured layout (`calculateBreadcrumbLayout` + `ResizeObserver`) hides middle segments behind a single **…** crumb while keeping the nearest parent folders and filename readable; the filename only truncates when no directory crumbs fit.
> 
> The overflow menu gains **Copy contents** when text is loaded (`contentsForCopy` from the preview). Clipboard hooks are centralized via `useCopyWithToasts`, including `useCopyFileContentsToClipboard` with toasts for empty files and partial (truncated) reads.
> 
> Markdown **Source/Preview** toggles are icon-only (`CodeIcon` / `EyeOpenIcon`); labels stay in tooltips and screen-reader text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b47fb27abdb6c99ad3b9fc6e4cdf3a8027601352. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->