### PR TITLE
Fix stale git refresh coalescing and stuck merged-PR badges

### DIFF
--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -528,15 +528,18 @@ export function BranchToolbarBranchSelector({
     const api = readNativeApi();
     if (!dialog || !api || isDroppingStash) return;
     setIsDroppingStash(true);
-    runBranchAction(async () => {
-      try {
-        if (!dialog.info) return;
-        await api.git.stashDrop({ cwd: dialog.cwd, stashRef: dialog.info.stashRef });
-        setStashDiscardDialog(null);
-      } finally {
-        setIsDroppingStash(false);
-      }
-    });
+    runBranchAction(
+      async () => {
+        try {
+          if (!dialog.info) return;
+          await api.git.stashDrop({ cwd: dialog.cwd, stashRef: dialog.info.stashRef });
+          setStashDiscardDialog(null);
+        } finally {
+          setIsDroppingStash(false);
+        }
+      },
+      { refreshCwds: [dialog.cwd] },
+    );
   }, [isDroppingStash, runBranchAction, stashDiscardDialog]);
 
   const selectBranch = (branch: GitBranch) => {

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -26,6 +26,7 @@ import {
   gitQueryKeys,
   gitStatusQueryOptions,
   invalidateGitQueries,
+  invalidateGitQueriesForCwds,
 } from "../lib/gitReactQuery";
 import { readNativeApi } from "../nativeApi";
 import { parsePullRequestReference } from "../pullRequestReference";
@@ -184,7 +185,7 @@ function handleCheckoutError(
 ): void {
   const retryStashAndCheckout = async (): Promise<void> => {
     await input.api.git.stashAndCheckout({ cwd: input.cwd, branch: input.branch });
-    await invalidateGitQueries(input.queryClient);
+    await invalidateGitQueriesForCwds(input.queryClient, [input.cwd]);
     input.onSuccess();
   };
 
@@ -262,7 +263,7 @@ function handleCheckoutError(
                 return;
               }
               if (isStashConflictError(stashError)) {
-                await invalidateGitQueries(input.queryClient);
+                await invalidateGitQueriesForCwds(input.queryClient, [input.cwd]);
                 input.onSuccess();
                 addBranchRecoveryToast({
                   type: "warning",
@@ -469,10 +470,18 @@ export function BranchToolbarBranchSelector({
     onSetThreadWorkspace,
   ]);
 
-  const runBranchAction = (action: () => Promise<void>) => {
+  const runBranchAction = (
+    action: () => Promise<void>,
+    options?: { readonly refreshCwds?: readonly string[] },
+  ) => {
     startBranchActionTransition(async () => {
       await action().catch(() => undefined);
-      await invalidateGitQueries(queryClient).catch(() => undefined);
+      // Only the acted-on checkout gates re-enabling the selector; the remaining cached
+      // repos (checked-out markers in sibling worktrees) refresh in the background so a
+      // slow unrelated worktree cannot hold the selector disabled.
+      const awaitedCwds = options?.refreshCwds ?? (branchCwd ? [branchCwd] : []);
+      await invalidateGitQueriesForCwds(queryClient, awaitedCwds).catch(() => undefined);
+      void invalidateGitQueries(queryClient, { excludeCwds: awaitedCwds }).catch(() => undefined);
     });
   };
 
@@ -564,45 +573,47 @@ export function BranchToolbarBranchSelector({
     setIsBranchMenuOpen(false);
     onComposerFocusRequest?.();
 
-    runBranchAction(async () => {
-      setOptimisticBranch(selectedBranchName);
-      try {
-        await api.git.checkout({ cwd: selectionTarget.checkoutCwd, branch: branch.name });
-        await invalidateGitQueries(queryClient);
-      } catch (error) {
-        handleCheckoutError(error, {
-          api,
-          branch: branch.name,
-          cwd: selectionTarget.checkoutCwd,
-          fallbackTitle: "Failed to checkout branch.",
-          onSuccess: () => {
-            setOptimisticBranch(selectedBranchName);
-            onSetThreadWorkspace({
-              branch: selectedBranchName,
-              worktreePath: selectionTarget.nextWorktreePath,
-            });
-          },
-          queryClient,
-          runBranchAction,
-          onRequestDiscardStash: openStashDiscardDialog,
-        });
-        return;
-      }
-
-      let nextBranchName = selectedBranchName;
-      if (branch.isRemote) {
-        const status = await api.git.status({ cwd: branchCwd }).catch(() => null);
-        if (status?.branch) {
-          nextBranchName = status.branch;
+    runBranchAction(
+      async () => {
+        setOptimisticBranch(selectedBranchName);
+        try {
+          await api.git.checkout({ cwd: selectionTarget.checkoutCwd, branch: branch.name });
+        } catch (error) {
+          handleCheckoutError(error, {
+            api,
+            branch: branch.name,
+            cwd: selectionTarget.checkoutCwd,
+            fallbackTitle: "Failed to checkout branch.",
+            onSuccess: () => {
+              setOptimisticBranch(selectedBranchName);
+              onSetThreadWorkspace({
+                branch: selectedBranchName,
+                worktreePath: selectionTarget.nextWorktreePath,
+              });
+            },
+            queryClient,
+            runBranchAction,
+            onRequestDiscardStash: openStashDiscardDialog,
+          });
+          return;
         }
-      }
 
-      setOptimisticBranch(nextBranchName);
-      onSetThreadWorkspace({
-        branch: nextBranchName,
-        worktreePath: selectionTarget.nextWorktreePath,
-      });
-    });
+        let nextBranchName = selectedBranchName;
+        if (branch.isRemote) {
+          const status = await api.git.status({ cwd: branchCwd }).catch(() => null);
+          if (status?.branch) {
+            nextBranchName = status.branch;
+          }
+        }
+
+        setOptimisticBranch(nextBranchName);
+        onSetThreadWorkspace({
+          branch: nextBranchName,
+          worktreePath: selectionTarget.nextWorktreePath,
+        });
+      },
+      { refreshCwds: [selectionTarget.checkoutCwd] },
+    );
   };
 
   const createBranch = (rawName: string) => {

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -5,7 +5,7 @@
 // menu-item-style affordance inside a ComboboxPopup, not a generic action.
 import type { GitBranch, GitStashInfoResult, GitStatusResult, NativeApi } from "@synara/contracts";
 import { pluralize } from "@synara/shared/text";
-import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { ChevronDownIcon, PlusIcon } from "~/lib/icons";
 import { CentralIcon } from "~/lib/central-icons";
@@ -25,8 +25,7 @@ import {
   gitBranchesQueryOptions,
   gitQueryKeys,
   gitStatusQueryOptions,
-  invalidateGitQueries,
-  invalidateGitQueriesForCwds,
+  refreshGitQueriesScoped,
 } from "../lib/gitReactQuery";
 import { readNativeApi } from "../nativeApi";
 import { parsePullRequestReference } from "../pullRequestReference";
@@ -178,14 +177,19 @@ function handleCheckoutError(
     cwd: string;
     fallbackTitle: string;
     onSuccess: () => void;
-    queryClient: QueryClient;
-    runBranchAction: (action: () => Promise<void>) => void;
+    runBranchAction: (
+      action: () => Promise<void>,
+      options?: { readonly refreshCwds?: readonly string[] },
+    ) => void;
     onRequestDiscardStash: (input: { cwd: string }) => void;
   },
 ): void {
+  // Recovery always acts on input.cwd, which can differ from the selector's own checkout
+  // (e.g. "Stash & Switch" from a dedicated worktree back to the project root), so every
+  // retry passes it as the awaited refresh scope instead of relying on the default.
+  const retryRefreshOptions = { refreshCwds: [input.cwd] } as const;
   const retryStashAndCheckout = async (): Promise<void> => {
     await input.api.git.stashAndCheckout({ cwd: input.cwd, branch: input.branch });
-    await invalidateGitQueriesForCwds(input.queryClient, [input.cwd]);
     input.onSuccess();
   };
 
@@ -210,7 +214,7 @@ function handleCheckoutError(
             } catch (retryError) {
               handleCheckoutError(retryError, input);
             }
-          });
+          }, retryRefreshOptions);
         },
       },
     });
@@ -232,7 +236,7 @@ function handleCheckoutError(
             } catch (retryError) {
               handleCheckoutError(retryError, input);
             }
-          });
+          }, retryRefreshOptions);
         },
       },
     });
@@ -263,7 +267,6 @@ function handleCheckoutError(
                 return;
               }
               if (isStashConflictError(stashError)) {
-                await invalidateGitQueriesForCwds(input.queryClient, [input.cwd]);
                 input.onSuccess();
                 addBranchRecoveryToast({
                   type: "warning",
@@ -300,7 +303,7 @@ function handleCheckoutError(
                 data: { copyText: toBranchActionErrorMessage(stashError) },
               });
             }
-          });
+          }, retryRefreshOptions);
         },
       },
     });
@@ -480,8 +483,7 @@ export function BranchToolbarBranchSelector({
       // repos (checked-out markers in sibling worktrees) refresh in the background so a
       // slow unrelated worktree cannot hold the selector disabled.
       const awaitedCwds = options?.refreshCwds ?? (branchCwd ? [branchCwd] : []);
-      await invalidateGitQueriesForCwds(queryClient, awaitedCwds).catch(() => undefined);
-      void invalidateGitQueries(queryClient, { excludeCwds: awaitedCwds }).catch(() => undefined);
+      await refreshGitQueriesScoped(queryClient, awaitedCwds).catch(() => undefined);
     });
   };
 
@@ -591,7 +593,6 @@ export function BranchToolbarBranchSelector({
                 worktreePath: selectionTarget.nextWorktreePath,
               });
             },
-            queryClient,
             runBranchAction,
             onRequestDiscardStash: openStashDiscardDialog,
           });
@@ -646,7 +647,6 @@ export function BranchToolbarBranchSelector({
               setBranchQuery("");
               setCreateBranchName("");
             },
-            queryClient,
             runBranchAction,
             onRequestDiscardStash: openStashDiscardDialog,
           });

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -165,8 +165,24 @@ describe("shouldUseLivePullRequestForSidebarThread", () => {
 });
 
 describe("resolveSidebarThreadPullRequest", () => {
+  type TestPr = {
+    readonly number: number;
+    readonly headBranch: string;
+    readonly state: "open" | "closed" | "merged";
+  };
+  const openPr = (number: number, headBranch: string): TestPr => ({
+    number,
+    headBranch,
+    state: "open",
+  });
+  const mergedPr = (number: number, headBranch: string): TestPr => ({
+    number,
+    headBranch,
+    state: "merged",
+  });
+
   it("keeps persisted PR metadata when the worktree is no longer available", () => {
-    const persisted = { number: 574, headBranch: "feat/provider-usage-snapshot-cache" };
+    const persisted = openPr(574, "feat/provider-usage-snapshot-cache");
     expect(
       resolveSidebarThreadPullRequest({
         threadBranch: "feat/provider-usage-snapshot-cache",
@@ -180,7 +196,7 @@ describe("resolveSidebarThreadPullRequest", () => {
   });
 
   it("prefers live metadata for the worktree's current branch", () => {
-    const live = { number: 575, headBranch: "feat/current-branch" };
+    const live = openPr(575, "feat/current-branch");
     expect(
       resolveSidebarThreadPullRequest({
         threadBranch: "synara/stale-branch",
@@ -188,13 +204,13 @@ describe("resolveSidebarThreadPullRequest", () => {
         hasLiveStatus: true,
         hasDedicatedWorktree: true,
         livePullRequest: live,
-        persistedPullRequest: { number: 574, headBranch: "synara/stale-branch" },
+        persistedPullRequest: openPr(574, "synara/stale-branch"),
       }),
     ).toBe(live);
   });
 
   it("keeps persisted metadata during a transient lookup failure on the same branch", () => {
-    const persisted = { number: 574, headBranch: "feat/current-branch" };
+    const persisted = openPr(574, "feat/current-branch");
     expect(
       resolveSidebarThreadPullRequest({
         threadBranch: "feat/current-branch",
@@ -208,7 +224,7 @@ describe("resolveSidebarThreadPullRequest", () => {
   });
 
   it("uses the live worktree branch to validate persisted metadata while thread branch metadata catches up", () => {
-    const persisted = { number: 574, headBranch: "feat/current-branch" };
+    const persisted = openPr(574, "feat/current-branch");
     expect(
       resolveSidebarThreadPullRequest({
         threadBranch: null,
@@ -222,7 +238,7 @@ describe("resolveSidebarThreadPullRequest", () => {
   });
 
   it("uses the live worktree branch to validate persisted metadata when the thread branch is stale", () => {
-    const persisted = { number: 574, headBranch: "feat/current-branch" };
+    const persisted = openPr(574, "feat/current-branch");
     expect(
       resolveSidebarThreadPullRequest({
         threadBranch: "feat/previous-branch",
@@ -235,7 +251,7 @@ describe("resolveSidebarThreadPullRequest", () => {
     ).toBe(persisted);
   });
 
-  it("does not attach a persisted PR from another branch to the current worktree branch", () => {
+  it("does not attach an open persisted PR from another branch to the current worktree branch", () => {
     expect(
       resolveSidebarThreadPullRequest({
         threadBranch: "feat/previous-branch",
@@ -243,12 +259,54 @@ describe("resolveSidebarThreadPullRequest", () => {
         hasLiveStatus: true,
         hasDedicatedWorktree: true,
         livePullRequest: null,
-        persistedPullRequest: { number: 574, headBranch: "feat/previous-branch" },
+        persistedPullRequest: openPr(574, "feat/previous-branch"),
       }),
     ).toBeNull();
   });
 
-  it("hides a persisted PR when an active dedicated worktree is detached", () => {
+  it("keeps a merged persisted PR visible after the worktree switches to another branch", () => {
+    const merged = mergedPr(574, "feat/previous-branch");
+    expect(
+      resolveSidebarThreadPullRequest({
+        threadBranch: "feat/previous-branch",
+        liveBranch: "main",
+        hasLiveStatus: true,
+        hasDedicatedWorktree: true,
+        livePullRequest: null,
+        persistedPullRequest: merged,
+      }),
+    ).toBe(merged);
+  });
+
+  it("keeps a merged persisted PR visible on a shared checkout that moved to another branch", () => {
+    const merged = mergedPr(574, "feat/previous-branch");
+    expect(
+      resolveSidebarThreadPullRequest({
+        threadBranch: "main",
+        liveBranch: "main",
+        hasLiveStatus: true,
+        hasDedicatedWorktree: false,
+        livePullRequest: null,
+        persistedPullRequest: merged,
+      }),
+    ).toBe(merged);
+  });
+
+  it("prefers a live PR for the current branch over a merged persisted PR", () => {
+    const live = openPr(600, "feat/current-branch");
+    expect(
+      resolveSidebarThreadPullRequest({
+        threadBranch: "feat/current-branch",
+        liveBranch: "feat/current-branch",
+        hasLiveStatus: true,
+        hasDedicatedWorktree: true,
+        livePullRequest: live,
+        persistedPullRequest: mergedPr(574, "feat/previous-branch"),
+      }),
+    ).toBe(live);
+  });
+
+  it("hides an open persisted PR when an active dedicated worktree is detached", () => {
     expect(
       resolveSidebarThreadPullRequest({
         threadBranch: "feat/previous-branch",
@@ -256,9 +314,23 @@ describe("resolveSidebarThreadPullRequest", () => {
         hasLiveStatus: true,
         hasDedicatedWorktree: true,
         livePullRequest: null,
-        persistedPullRequest: { number: 574, headBranch: "feat/previous-branch" },
+        persistedPullRequest: openPr(574, "feat/previous-branch"),
       }),
     ).toBeNull();
+  });
+
+  it("keeps a merged persisted PR when an active dedicated worktree is detached", () => {
+    const merged = mergedPr(574, "feat/previous-branch");
+    expect(
+      resolveSidebarThreadPullRequest({
+        threadBranch: "feat/previous-branch",
+        liveBranch: null,
+        hasLiveStatus: true,
+        hasDedicatedWorktree: true,
+        livePullRequest: null,
+        persistedPullRequest: merged,
+      }),
+    ).toBe(merged);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -123,7 +123,9 @@ export function shouldUseLivePullRequestForSidebarThread(input: {
   return input.threadBranch !== null && input.threadBranch === input.liveBranch;
 }
 
-export function resolveSidebarThreadPullRequest<T extends { readonly headBranch: string }>(input: {
+export function resolveSidebarThreadPullRequest<
+  T extends { readonly headBranch: string; readonly state: "open" | "closed" | "merged" },
+>(input: {
   readonly threadBranch: string | null;
   readonly liveBranch: string | null;
   readonly hasLiveStatus: boolean;
@@ -131,6 +133,14 @@ export function resolveSidebarThreadPullRequest<T extends { readonly headBranch:
   readonly livePullRequest: T | null;
   readonly persistedPullRequest: T | null;
 }): T | null {
+  // A settled (merged/closed) PR is the thread's outcome, not a claim about the current
+  // checkout, so it stays visible after the checkout moves on — e.g. switching back to
+  // main after merging must flip the badge to "merged", not drop it and let stale
+  // metadata elsewhere keep it "open".
+  const settledPersistedPullRequest =
+    input.persistedPullRequest !== null && input.persistedPullRequest.state !== "open"
+      ? input.persistedPullRequest
+      : null;
   const persistedValidationBranch =
     input.hasLiveStatus && input.hasDedicatedWorktree ? input.liveBranch : input.threadBranch;
   const persistedPullRequest =
@@ -138,12 +148,12 @@ export function resolveSidebarThreadPullRequest<T extends { readonly headBranch:
     (persistedValidationBranch === null ||
       input.persistedPullRequest.headBranch === persistedValidationBranch)
       ? input.persistedPullRequest
-      : null;
+      : settledPersistedPullRequest;
   if (!input.hasLiveStatus) {
     return persistedPullRequest;
   }
   if (input.liveBranch === null && input.hasDedicatedWorktree) {
-    return null;
+    return settledPersistedPullRequest;
   }
   if (!shouldUseLivePullRequestForSidebarThread(input)) {
     return persistedPullRequest;
@@ -151,7 +161,9 @@ export function resolveSidebarThreadPullRequest<T extends { readonly headBranch:
   if (input.livePullRequest !== null) {
     return input.livePullRequest;
   }
-  return persistedPullRequest?.headBranch === input.liveBranch ? persistedPullRequest : null;
+  return persistedPullRequest !== null && persistedPullRequest.headBranch === input.liveBranch
+    ? persistedPullRequest
+    : settledPersistedPullRequest;
 }
 
 type SidebarProject = {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -85,7 +85,6 @@ import {
   SpaceId,
   type ProviderKind,
   ThreadId,
-  type GitStatusResult,
   type ResolvedKeybindingsConfig,
   WS_GITHUB_PROJECT_PROVISIONING_CAPABILITY,
 } from "@synara/contracts";
@@ -127,7 +126,7 @@ import {
   createSidebarTreeThreadsSelector,
 } from "../storeSelectors";
 import { derivePendingApprovals, derivePendingUserInputs } from "../session-logic";
-import { gitResolvePullRequestQueryOptions, gitStatusQueryOptions } from "../lib/gitReactQuery";
+import { useThreadPullRequests, type ThreadPullRequest } from "../hooks/useThreadPullRequests";
 import {
   providerComposerCapabilitiesQueryOptions,
   supportsThreadImport,
@@ -305,7 +304,6 @@ import {
   runExclusiveProjectAddition,
   runProjectProvisionWithCancellationRecovery,
   resolvePullRequestReviewBadge,
-  resolveSidebarThreadPullRequest,
   resolveSidebarThreadListPaging,
   DEBUG_FEATURE_FLAGS_MENU_STORAGE_KEY,
   resolveProjectEmptyState,
@@ -708,41 +706,7 @@ interface PrStatusIndicator {
   url: string;
 }
 
-type ThreadPr = GitStatusResult["pr"];
-
-// Also accepts persisted `lastKnownPr` entries, whose draft/mergeability/diff fields are
-// optional because older rows predate them.
-function toThreadPr(
-  pr:
-    | NonNullable<ThreadPr>
-    | {
-        number: number;
-        title: string;
-        url: string;
-        baseBranch: string;
-        headBranch: string;
-        state: "open" | "closed" | "merged";
-        isDraft?: boolean | undefined;
-        mergeability?: "mergeable" | "conflicting" | "unknown" | undefined;
-        additions?: number | null | undefined;
-        deletions?: number | null | undefined;
-        changedFiles?: number | null | undefined;
-      },
-): ThreadPr {
-  return {
-    number: pr.number,
-    title: pr.title,
-    url: pr.url,
-    baseBranch: pr.baseBranch,
-    headBranch: pr.headBranch,
-    state: pr.state,
-    isDraft: pr.isDraft ?? false,
-    mergeability: pr.mergeability ?? "unknown",
-    additions: pr.additions ?? null,
-    deletions: pr.deletions ?? null,
-    changedFiles: pr.changedFiles ?? null,
-  };
-}
+type ThreadPr = ThreadPullRequest;
 
 function terminalStatusFromThreadState(input: {
   runningTerminalIds: string[];
@@ -4071,113 +4035,10 @@ export default function Sidebar() {
     [sidebarTreeThreads, visibleSidebarThreadIdSet],
   );
   // PR badges only render on visible rows, so keep git/PR query setup off hidden project history.
-  const threadGitTargets = useMemo(
-    () =>
-      visibleSidebarThreads.map((thread) => ({
-        threadId: thread.id,
-        branch: thread.branch,
-        lastKnownPr: thread.lastKnownPr ?? null,
-        hasDedicatedWorktree: thread.worktreePath !== null,
-        cwd: resolveThreadWorkspaceCwd({
-          projectCwd: projectCwdById.get(thread.projectId) ?? null,
-          envMode: thread.envMode,
-          worktreePath: thread.worktreePath,
-        }),
-      })),
-    [projectCwdById, visibleSidebarThreads],
-  );
-  const threadGitStatusCwds = useMemo(
-    () => [
-      ...new Set(
-        threadGitTargets
-          .filter((target) => target.branch !== null || target.hasDedicatedWorktree)
-          .map((target) => target.cwd)
-          .filter((cwd): cwd is string => cwd !== null),
-      ),
-    ],
-    [threadGitTargets],
-  );
-  const threadGitStatusQueries = useQueries({
-    queries: threadGitStatusCwds.map((cwd) => ({
-      ...gitStatusQueryOptions(cwd),
-      staleTime: 30_000,
-      refetchInterval: 60_000,
-    })),
+  const prByThreadId = useThreadPullRequests({
+    threads: visibleSidebarThreads,
+    projectCwdById,
   });
-  const threadStoredPrTargets = useMemo(
-    () =>
-      threadGitTargets.flatMap((target) =>
-        target.cwd !== null &&
-        target.lastKnownPr !== null &&
-        target.lastKnownPr.url.trim().length > 0
-          ? [{ ...target, cwd: target.cwd, lastKnownPr: target.lastKnownPr }]
-          : [],
-      ),
-    [threadGitTargets],
-  );
-  const threadStoredPrQueries = useQueries({
-    queries: threadStoredPrTargets.map((target) => ({
-      ...gitResolvePullRequestQueryOptions({
-        cwd: target.cwd,
-        reference: target.lastKnownPr.url,
-      }),
-      staleTime: 30_000,
-      refetchInterval: 60_000,
-    })),
-  });
-  const prByThreadId = useMemo(() => {
-    const statusByCwd = new Map<string, GitStatusResult>();
-    for (let index = 0; index < threadGitStatusCwds.length; index += 1) {
-      const cwd = threadGitStatusCwds[index];
-      if (!cwd) continue;
-      // Keep the last successful snapshot during a failed background refetch. React Query
-      // retains that data, and it is still a better branch authority than stale thread metadata.
-      const status = threadGitStatusQueries[index]?.data;
-      if (status) {
-        statusByCwd.set(cwd, status);
-      }
-    }
-
-    const storedPrByThreadId = new Map<ThreadId, ThreadPr>();
-    for (let index = 0; index < threadStoredPrTargets.length; index += 1) {
-      const target = threadStoredPrTargets[index];
-      if (!target) {
-        continue;
-      }
-      const result = threadStoredPrQueries[index]?.data?.pullRequest ?? null;
-      if (result) {
-        storedPrByThreadId.set(target.threadId, toThreadPr(result));
-        continue;
-      }
-      storedPrByThreadId.set(target.threadId, toThreadPr(target.lastKnownPr));
-    }
-
-    const map = new Map<ThreadId, ThreadPr>();
-    for (const target of threadGitTargets) {
-      const status = target.cwd ? statusByCwd.get(target.cwd) : undefined;
-      const persistedPr =
-        storedPrByThreadId.get(target.threadId) ??
-        (target.lastKnownPr ? toThreadPr(target.lastKnownPr) : null);
-      map.set(
-        target.threadId,
-        resolveSidebarThreadPullRequest({
-          threadBranch: target.branch,
-          liveBranch: status?.branch ?? null,
-          hasLiveStatus: status !== undefined,
-          hasDedicatedWorktree: target.hasDedicatedWorktree,
-          livePullRequest: status?.pr ?? null,
-          persistedPullRequest: persistedPr,
-        }),
-      );
-    }
-    return map;
-  }, [
-    threadGitStatusCwds,
-    threadGitStatusQueries,
-    threadGitTargets,
-    threadStoredPrQueries,
-    threadStoredPrTargets,
-  ]);
   const isManualProjectSorting = appSettings.sidebarProjectSortOrder === "manual";
   const threadJumpCommandByThreadId = useMemo(() => {
     const mapping = new Map<ThreadId, NonNullable<ReturnType<typeof threadJumpCommandForIndex>>>();

--- a/apps/web/src/components/SidebarActivityView.tsx
+++ b/apps/web/src/components/SidebarActivityView.tsx
@@ -35,6 +35,7 @@ import {
   SIDEBAR_SECTION_LABEL_CLASS_NAME,
   sidebarHoverRevealHideClassName,
 } from "../sidebarRowStyles";
+import { resolveThreadPullRequestFallback } from "../hooks/useThreadPullRequests";
 import type { Project, SidebarThreadSummary } from "../types";
 import { ComposerPickerMenuPopup } from "./chat/ComposerPickerMenuPopup";
 import { FolderClosed } from "./FolderClosed";
@@ -702,10 +703,15 @@ export function SidebarActivityView({
       isPinned={pinnedThreadIdSet.has(thread.id)}
       pr={
         // An explicit null from the resolver means the persisted PR was ruled out (e.g. the
-        // checkout moved on); falling back to lastKnownPr would resurrect that stale badge.
+        // checkout moved on); falling back to raw lastKnownPr would resurrect that stale
+        // badge. Rows not yet covered (revealed by paging a paint before the parent's map
+        // catches up) get the same resolution without live status instead.
         prByThreadId.has(thread.id)
           ? (prByThreadId.get(thread.id) ?? null)
-          : (thread.lastKnownPr ?? null)
+          : resolveThreadPullRequestFallback({
+              branch: thread.branch,
+              lastKnownPr: thread.lastKnownPr ?? null,
+            })
       }
       status={resolveThreadStatus(thread)}
       onOpen={() => onOpenThread(thread.id)}

--- a/apps/web/src/components/SidebarActivityView.tsx
+++ b/apps/web/src/components/SidebarActivityView.tsx
@@ -700,7 +700,13 @@ export function SidebarActivityView({
       isActive={activeThreadId === thread.id}
       isSettled={isSettled}
       isPinned={pinnedThreadIdSet.has(thread.id)}
-      pr={prByThreadId.get(thread.id) ?? thread.lastKnownPr ?? null}
+      pr={
+        // An explicit null from the resolver means the persisted PR was ruled out (e.g. the
+        // checkout moved on); falling back to lastKnownPr would resurrect that stale badge.
+        prByThreadId.has(thread.id)
+          ? (prByThreadId.get(thread.id) ?? null)
+          : (thread.lastKnownPr ?? null)
+      }
       status={resolveThreadStatus(thread)}
       onOpen={() => onOpenThread(thread.id)}
       onSetSettled={(settled) => {

--- a/apps/web/src/components/kanban/KanbanCardView.tsx
+++ b/apps/web/src/components/kanban/KanbanCardView.tsx
@@ -4,8 +4,13 @@
 // Layer: UI component (pure; drag wiring lives in KanbanColumn)
 // Exports: KanbanCardView
 
+import type { ThreadId } from "@synara/contracts";
 import { GoRepoForked } from "react-icons/go";
 
+import {
+  resolveThreadPullRequestFallback,
+  type ThreadPullRequest,
+} from "~/hooks/useThreadPullRequests";
 import { PrStateChip } from "../pullRequest/PrStateChip";
 import { resolveThreadStatusPill } from "../Sidebar.logic";
 import { ThreadStatusPillChip } from "../ThreadStatusPillChip";
@@ -26,11 +31,15 @@ import { RAISED_SURFACE_CHROME_CLASS_NAME } from "../chat/composerPickerStyles";
 import { KanbanStatusIcon } from "./KanbanStatusIcon";
 import { KANBAN_COLUMN_LABELS, kanbanThreadCardId, type KanbanCard } from "./kanban.logic";
 
+/** Resolved PR badge per thread from the board root's useThreadPullRequests call. */
+export type KanbanCardPrLookup = ReadonlyMap<ThreadId, ThreadPullRequest>;
+
 export interface KanbanCardViewProps {
   card: KanbanCard;
   onOpen?: (card: KanbanCard) => void;
   /** Right-click handler — opens the sidebar-style thread/draft context menu. */
   onContextMenu?: (card: KanbanCard, event: React.MouseEvent) => void;
+  prByThreadId: KanbanCardPrLookup;
   /** Rendered inside the DragOverlay — lifted styling, no interactions. */
   isOverlay?: boolean;
   /** The in-column original while its overlay clone is being dragged. */
@@ -84,6 +93,7 @@ function KanbanCardViewComponent({
   card,
   onOpen,
   onContextMenu,
+  prByThreadId,
   isOverlay: isOverlayProp,
   isDragSource: isDragSourceProp,
   nowMs,
@@ -102,7 +112,17 @@ function KanbanCardViewComponent({
     envMode: card.envMode,
     worktreePath: card.worktreePath,
   }).worktreeBadgeLabel;
-  const pr = card.thread?.lastKnownPr ?? null;
+  // An explicit null from the resolver means the persisted PR was ruled out (e.g. the
+  // checkout moved on); rows the board root has not resolved yet get the same validation
+  // without live status instead of the raw — possibly stale — persisted badge.
+  const pr = card.thread
+    ? prByThreadId.has(card.threadId)
+      ? (prByThreadId.get(card.threadId) ?? null)
+      : resolveThreadPullRequestFallback({
+          branch: card.thread.branch,
+          lastKnownPr: card.thread.lastKnownPr ?? null,
+        })
+    : null;
   const activeWorkElapsed =
     card.activeWorkStartedAt && nowMs
       ? formatElapsed(card.activeWorkStartedAt, new Date(nowMs).toISOString())

--- a/apps/web/src/components/kanban/KanbanColumn.tsx
+++ b/apps/web/src/components/kanban/KanbanColumn.tsx
@@ -12,7 +12,7 @@ import { memo, useMemo, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { PlusIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
-import { KanbanCardView } from "./KanbanCardView";
+import { KanbanCardView, type KanbanCardPrLookup } from "./KanbanCardView";
 import { KanbanStatusIcon } from "./KanbanStatusIcon";
 import {
   KANBAN_COLUMN_LABELS,
@@ -45,11 +45,13 @@ function SortableKanbanCard({
   card,
   onOpen,
   onContextMenu,
+  prByThreadId,
   nowMs,
 }: {
   card: KanbanCard;
   onOpen: (card: KanbanCard) => void;
   onContextMenu?: ((card: KanbanCard, event: React.MouseEvent) => void) | undefined;
+  prByThreadId: KanbanCardPrLookup;
   nowMs?: number;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -68,6 +70,7 @@ function SortableKanbanCard({
         card={card}
         onOpen={onOpen}
         {...(onContextMenu ? { onContextMenu } : {})}
+        prByThreadId={prByThreadId}
         isDragSource={isDragging}
         {...(nowMs !== undefined ? { nowMs } : {})}
       />
@@ -85,6 +88,7 @@ function KanbanColumnComponent({
   droppable: droppableProp,
   activeCard: activeCardProp,
   onNewCard,
+  prByThreadId,
   nowMs,
 }: {
   projectId: ProjectId;
@@ -101,6 +105,7 @@ function KanbanColumnComponent({
   activeCard?: KanbanCard | null;
   /** Renders a + button in the column header (Draft column's new-task entry point). */
   onNewCard?: (() => void) | undefined;
+  prByThreadId: KanbanCardPrLookup;
   /** Shared board clock for live elapsed labels. */
   nowMs?: number;
 }) {
@@ -133,6 +138,7 @@ function KanbanColumnComponent({
         card={card}
         onOpen={onOpenCard}
         onContextMenu={onCardContextMenu}
+        prByThreadId={prByThreadId}
         {...(nowMs !== undefined ? { nowMs } : {})}
       />
     ) : (
@@ -141,6 +147,7 @@ function KanbanColumnComponent({
           card={card}
           onOpen={onOpenCard}
           {...(onCardContextMenu ? { onContextMenu: onCardContextMenu } : {})}
+          prByThreadId={prByThreadId}
           {...(nowMs !== undefined ? { nowMs } : {})}
         />
       </li>

--- a/apps/web/src/components/kanban/KanbanOverview.tsx
+++ b/apps/web/src/components/kanban/KanbanOverview.tsx
@@ -8,15 +8,13 @@ import type { ProjectId } from "@synara/contracts";
 import { Button } from "~/components/ui/button";
 import { ChevronRightIcon, PlusIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
-import { KanbanCardView } from "./KanbanCardView";
+import { KanbanCardView, type KanbanCardPrLookup } from "./KanbanCardView";
 import {
-  flattenProjectBoardForOverview,
+  overviewVisibleKanbanCards,
   type KanbanBoard,
   type KanbanCard,
   type KanbanProjectBoard,
 } from "./kanban.logic";
-
-const OVERVIEW_RENDER_CAP = 20;
 
 const OverviewProjectColumn = function OverviewProjectColumn({
   projectBoard,
@@ -24,6 +22,7 @@ const OverviewProjectColumn = function OverviewProjectColumn({
   onOpenCard,
   onCardContextMenu,
   onNewTask,
+  prByThreadId,
   nowMs,
 }: {
   projectBoard: KanbanProjectBoard;
@@ -31,12 +30,10 @@ const OverviewProjectColumn = function OverviewProjectColumn({
   onOpenCard: (card: KanbanCard) => void;
   onCardContextMenu?: ((card: KanbanCard, event: React.MouseEvent) => void) | undefined;
   onNewTask: (projectId: ProjectId) => void;
+  prByThreadId: KanbanCardPrLookup;
   nowMs?: number;
 }) {
-  const cards = flattenProjectBoardForOverview(projectBoard);
-  const visibleCards =
-    cards.length > OVERVIEW_RENDER_CAP ? cards.slice(0, OVERVIEW_RENDER_CAP) : cards;
-  const hiddenCount = cards.length - visibleCards.length;
+  const { visibleCards, hiddenCount } = overviewVisibleKanbanCards(projectBoard);
 
   return (
     <section className="flex w-72 shrink-0 flex-col">
@@ -72,6 +69,7 @@ const OverviewProjectColumn = function OverviewProjectColumn({
             <KanbanCardView
               card={card}
               onOpen={onOpenCard}
+              prByThreadId={prByThreadId}
               {...(onCardContextMenu ? { onContextMenu: onCardContextMenu } : {})}
               {...(nowMs !== undefined ? { nowMs } : {})}
             />
@@ -99,6 +97,7 @@ export function KanbanOverview({
   onOpenCard,
   onCardContextMenu,
   onNewTask,
+  prByThreadId,
   nowMs,
 }: {
   board: KanbanBoard;
@@ -106,6 +105,7 @@ export function KanbanOverview({
   onOpenCard: (card: KanbanCard) => void;
   onCardContextMenu?: ((card: KanbanCard, event: React.MouseEvent) => void) | undefined;
   onNewTask: (projectId: ProjectId) => void;
+  prByThreadId: KanbanCardPrLookup;
   nowMs?: number;
 }) {
   // Projects without any cards are pure noise on the overview; their boards stay
@@ -135,6 +135,7 @@ export function KanbanOverview({
           onOpenCard={onOpenCard}
           onCardContextMenu={onCardContextMenu}
           onNewTask={onNewTask}
+          prByThreadId={prByThreadId}
           {...(nowMs !== undefined ? { nowMs } : {})}
         />
       ))}

--- a/apps/web/src/components/kanban/KanbanProjectBoardView.tsx
+++ b/apps/web/src/components/kanban/KanbanProjectBoardView.tsx
@@ -28,7 +28,7 @@ import { useProviderStatusesForLocalConfig } from "~/hooks/useProviderStatusesFo
 import { useRefreshProviderStatusesNow } from "~/hooks/useProviderStatusRefresh";
 import { resolveProviderSendAvailabilityWithRefresh } from "~/lib/providerAvailability";
 import { dispatchKanbanDraftCard } from "../../lib/kanbanDispatch";
-import { KanbanCardView } from "./KanbanCardView";
+import { KanbanCardView, type KanbanCardPrLookup } from "./KanbanCardView";
 import { KanbanColumn, parseKanbanColumnDropId } from "./KanbanColumn";
 import {
   reorderDraftCardIds,
@@ -60,12 +60,14 @@ export function KanbanProjectBoardView({
   onOpenCard,
   onCardContextMenu,
   onNewTask,
+  prByThreadId,
   nowMs,
 }: {
   board: KanbanProjectBoard;
   onOpenCard: (card: KanbanCard) => void;
   onCardContextMenu?: ((card: KanbanCard, event: React.MouseEvent) => void) | undefined;
   onNewTask: () => void;
+  prByThreadId: KanbanCardPrLookup;
   nowMs?: number;
 }) {
   const { settings } = useAppSettings();
@@ -235,6 +237,7 @@ export function KanbanProjectBoardView({
           droppable
           activeCard={activeCard}
           onNewCard={onNewTask}
+          prByThreadId={prByThreadId}
           {...(nowMs !== undefined ? { nowMs } : {})}
         />
         <KanbanColumn
@@ -245,6 +248,7 @@ export function KanbanProjectBoardView({
           onCardContextMenu={onCardContextMenu}
           droppable
           activeCard={activeCard}
+          prByThreadId={prByThreadId}
           {...(nowMs !== undefined ? { nowMs } : {})}
         />
         <KanbanColumn
@@ -255,12 +259,18 @@ export function KanbanProjectBoardView({
           onCardContextMenu={onCardContextMenu}
           droppable
           activeCard={activeCard}
+          prByThreadId={prByThreadId}
           {...(nowMs !== undefined ? { nowMs } : {})}
         />
       </div>
       <DragOverlay dropAnimation={null}>
         {activeCard ? (
-          <KanbanCardView card={activeCard} isOverlay {...(nowMs !== undefined ? { nowMs } : {})} />
+          <KanbanCardView
+            card={activeCard}
+            isOverlay
+            prByThreadId={prByThreadId}
+            {...(nowMs !== undefined ? { nowMs } : {})}
+          />
         ) : null}
       </DragOverlay>
     </DndContext>

--- a/apps/web/src/components/kanban/KanbanView.tsx
+++ b/apps/web/src/components/kanban/KanbanView.tsx
@@ -6,7 +6,7 @@
 
 import type { ProjectId } from "@synara/contracts";
 import { useNavigate } from "@tanstack/react-router";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { SidebarHeaderNavigationControls } from "~/components/SidebarHeaderNavigationControls";
 import { Button } from "~/components/ui/button";
@@ -18,6 +18,7 @@ import {
   useDesktopTopBarWindowControlsGutterClassName,
 } from "~/hooks/useDesktopTopBarGutter";
 import { useNowMs } from "~/hooks/useNowMs";
+import { useThreadPullRequests } from "~/hooks/useThreadPullRequests";
 import { splitShortcutLabel } from "~/keybindings";
 import { ArrowLeftIcon, PlusIcon } from "~/lib/icons";
 import { cn, isMacPlatform } from "~/lib/utils";
@@ -53,7 +54,7 @@ import { KanbanOverview } from "./KanbanOverview";
 import { KanbanProjectBoardView } from "./KanbanProjectBoardView";
 import { useKanbanBoard } from "./useKanbanBoard";
 import { useKanbanCardContextMenu } from "./useKanbanCardContextMenu";
-import type { KanbanCard } from "./kanban.logic";
+import { overviewVisibleKanbanCards, type KanbanCard } from "./kanban.logic";
 
 export default function KanbanView({ projectId }: { projectId: string | null }) {
   const navigate = useNavigate();
@@ -71,6 +72,25 @@ export default function KanbanView({ projectId }: { projectId: string | null }) 
     project.inProgress.some((card) => card.activeWorkStartedAt !== null),
   );
   const nowMs = useNowMs(hasActiveCardWork);
+
+  // PR badges resolve like the sidebar's: live git status per checkout validates the
+  // persisted PR instead of trusting stale lastKnownPr metadata. Scoped to the cards the
+  // current surface renders (one board, or each overview column's capped list).
+  const allProjects = useStore((state) => state.projects);
+  const projectCwdById = useMemo(
+    () => new Map(allProjects.map((project) => [project.id, project.cwd] as const)),
+    [allProjects],
+  );
+  const renderedCardThreads = useMemo(() => {
+    const cards = projectBoard
+      ? [...projectBoard.inProgress, ...projectBoard.draft, ...projectBoard.done]
+      : board.projects.flatMap((candidate) => overviewVisibleKanbanCards(candidate).visibleCards);
+    return cards.flatMap((card) => (card.thread ? [card.thread] : []));
+  }, [board.projects, projectBoard]);
+  const prByThreadId = useThreadPullRequests({
+    threads: renderedCardThreads,
+    projectCwdById,
+  });
 
   const [newTaskDialog, setNewTaskDialog] = useState<{
     key: number;
@@ -221,6 +241,7 @@ export default function KanbanView({ projectId }: { projectId: string | null }) 
               onOpenCard={handleOpenCard}
               onCardContextMenu={onCardContextMenu}
               onNewTask={handleNewDraftInProjectBoard}
+              prByThreadId={prByThreadId}
               nowMs={nowMs}
             />
           ) : (
@@ -230,6 +251,7 @@ export default function KanbanView({ projectId }: { projectId: string | null }) 
               onOpenCard={handleOpenCard}
               onCardContextMenu={onCardContextMenu}
               onNewTask={handleNewTask}
+              prByThreadId={prByThreadId}
               nowMs={nowMs}
             />
           )}

--- a/apps/web/src/components/kanban/kanban.logic.test.ts
+++ b/apps/web/src/components/kanban/kanban.logic.test.ts
@@ -13,12 +13,14 @@ import {
   kanbanDraftCardId,
   kanbanThreadCardId,
   orderDraftCards,
+  overviewVisibleKanbanCards,
   reorderDraftCardIds,
   resolveDraftDropAction,
   resolveOptimisticDispatchOutcome,
   type BuildKanbanBoardInput,
   type KanbanCard,
   type KanbanOptimisticDispatchSnapshot,
+  type KanbanProjectBoard,
 } from "./kanban.logic";
 
 function makeLatestTurn(
@@ -939,37 +941,67 @@ describe("resolveDraftDropAction", () => {
 });
 
 describe("flattenProjectBoardForOverview", () => {
-  it("orders cards In Progress, then Draft, then Done", () => {
-    const card = (cardId: string, column: KanbanCard["column"]): KanbanCard => ({
-      cardId,
-      threadId: ThreadId.makeUnsafe(cardId),
-      projectId: ProjectId.makeUnsafe("project-1"),
-      column,
-      title: cardId,
-      provider: null,
-      isTerminal: false,
-      branch: null,
-      envMode: null,
-      worktreePath: null,
-      thread: null,
-      draftPrompt: "",
-      draftHasAttachments: false,
-      sortTimestamp: 0,
-      timestamp: null,
-      activeWorkStartedAt: null,
-      isOptimisticDispatch: false,
-    });
-
-    const flattened = flattenProjectBoardForOverview({
+  const card = (cardId: string, column: KanbanCard["column"]): KanbanCard => ({
+    cardId,
+    threadId: ThreadId.makeUnsafe(cardId),
+    projectId: ProjectId.makeUnsafe("project-1"),
+    column,
+    title: cardId,
+    provider: null,
+    isTerminal: false,
+    branch: null,
+    envMode: null,
+    worktreePath: null,
+    thread: null,
+    draftPrompt: "",
+    draftHasAttachments: false,
+    sortTimestamp: 0,
+    timestamp: null,
+    activeWorkStartedAt: null,
+    isOptimisticDispatch: false,
+  });
+  const board = (columns: Partial<Pick<KanbanProjectBoard, "draft" | "inProgress" | "done">>) => {
+    const draft = columns.draft ?? [];
+    const inProgress = columns.inProgress ?? [];
+    const done = columns.done ?? [];
+    return {
       projectId: ProjectId.makeUnsafe("project-1"),
       projectName: "Synara",
-      projectKind: "project",
-      draft: [card("d", "draft")],
-      inProgress: [card("w", "inProgress")],
-      done: [card("x", "done")],
-      totalCount: 3,
-    });
+      projectKind: "project" as const,
+      draft,
+      inProgress,
+      done,
+      totalCount: draft.length + inProgress.length + done.length,
+    };
+  };
+
+  it("orders cards In Progress, then Draft, then Done", () => {
+    const flattened = flattenProjectBoardForOverview(
+      board({
+        draft: [card("d", "draft")],
+        inProgress: [card("w", "inProgress")],
+        done: [card("x", "done")],
+      }),
+    );
 
     expect(flattened.map((entry) => entry.cardId)).toEqual(["w", "d", "x"]);
+  });
+
+  it("caps the overview's visible cards and reports the folded remainder", () => {
+    const done = Array.from({ length: 25 }, (_, index) => card(`done-${index}`, "done"));
+    const { visibleCards, hiddenCount } = overviewVisibleKanbanCards(board({ done }));
+
+    expect(visibleCards).toHaveLength(20);
+    expect(hiddenCount).toBe(5);
+    expect(visibleCards.at(-1)?.cardId).toBe("done-19");
+  });
+
+  it("shows every card when the overview cap is not reached", () => {
+    const { visibleCards, hiddenCount } = overviewVisibleKanbanCards(
+      board({ inProgress: [card("w", "inProgress")] }),
+    );
+
+    expect(visibleCards.map((entry) => entry.cardId)).toEqual(["w"]);
+    expect(hiddenCount).toBe(0);
   });
 });

--- a/apps/web/src/components/kanban/kanban.logic.ts
+++ b/apps/web/src/components/kanban/kanban.logic.ts
@@ -662,6 +662,23 @@ export function flattenProjectBoardForOverview(board: KanbanProjectBoard): Kanba
   return [...board.inProgress, ...board.draft, ...board.done];
 }
 
+const OVERVIEW_RENDER_CAP = 20;
+
+/**
+ * The capped card list an overview project column actually renders, plus the count folded
+ * behind its "Show more" affordance. Shared with the board root so per-card data (PR
+ * badges) is fetched for exactly the rendered set.
+ */
+export function overviewVisibleKanbanCards(board: KanbanProjectBoard): {
+  visibleCards: KanbanCard[];
+  hiddenCount: number;
+} {
+  const cards = flattenProjectBoardForOverview(board);
+  const visibleCards =
+    cards.length > OVERVIEW_RENDER_CAP ? cards.slice(0, OVERVIEW_RENDER_CAP) : cards;
+  return { visibleCards, hiddenCount: cards.length - visibleCards.length };
+}
+
 export type KanbanDraftOpenThreadReason = "not-draft" | "empty" | "worktree-pending";
 export type KanbanDraftDropAction = "dispatch" | "open-thread";
 

--- a/apps/web/src/hooks/useThreadPullRequests.ts
+++ b/apps/web/src/hooks/useThreadPullRequests.ts
@@ -1,0 +1,203 @@
+// FILE: useThreadPullRequests.ts
+// Purpose: Shared PR-badge source for thread rows (sidebar tree, activity view, kanban
+//          cards). Polls live git status per checkout plus the stored PR reference per
+//          thread, then resolves which PR each thread row should surface.
+// Layer: UI state hook (resolution rules live in Sidebar.logic.ts)
+// Exports: useThreadPullRequests, resolveThreadPullRequestFallback, toThreadPullRequest
+
+import type {
+  GitStatusResult,
+  OrchestrationThreadPullRequest,
+  ProjectId,
+  ThreadId,
+} from "@synara/contracts";
+import { resolveThreadWorkspaceCwd } from "@synara/shared/threadEnvironment";
+import { useQueries } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import { resolveSidebarThreadPullRequest } from "../components/Sidebar.logic";
+import { gitResolvePullRequestQueryOptions, gitStatusQueryOptions } from "../lib/gitReactQuery";
+import type { SidebarThreadSummary } from "../types";
+
+export type ThreadPullRequest = GitStatusResult["pr"];
+
+export type ThreadPullRequestSource = Pick<
+  SidebarThreadSummary,
+  "id" | "projectId" | "branch" | "envMode" | "worktreePath" | "lastKnownPr"
+>;
+
+const THREAD_PR_STALE_TIME_MS = 30_000;
+const THREAD_PR_REFETCH_INTERVAL_MS = 60_000;
+
+// Also accepts persisted `lastKnownPr` entries, whose draft/mergeability/diff fields are
+// optional because older rows predate them.
+export function toThreadPullRequest(
+  pr:
+    | NonNullable<ThreadPullRequest>
+    | {
+        number: number;
+        title: string;
+        url: string;
+        baseBranch: string;
+        headBranch: string;
+        state: "open" | "closed" | "merged";
+        isDraft?: boolean | undefined;
+        mergeability?: "mergeable" | "conflicting" | "unknown" | undefined;
+        additions?: number | null | undefined;
+        deletions?: number | null | undefined;
+        changedFiles?: number | null | undefined;
+      },
+): ThreadPullRequest {
+  return {
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+    baseBranch: pr.baseBranch,
+    headBranch: pr.headBranch,
+    state: pr.state,
+    isDraft: pr.isDraft ?? false,
+    mergeability: pr.mergeability ?? "unknown",
+    additions: pr.additions ?? null,
+    deletions: pr.deletions ?? null,
+    changedFiles: pr.changedFiles ?? null,
+  };
+}
+
+/**
+ * Resolution for a thread row without live git-status coverage: rows revealed before the
+ * shared hook picks them up (activity paging reveals a row a paint earlier) or rendered
+ * where no checkout is resolvable. Runs the same persisted-PR validation as the live
+ * path, so a stale "open" badge the resolver already ruled out cannot reappear here.
+ */
+export function resolveThreadPullRequestFallback(input: {
+  readonly branch: string | null;
+  readonly lastKnownPr: OrchestrationThreadPullRequest | null | undefined;
+}): ThreadPullRequest {
+  return resolveSidebarThreadPullRequest({
+    threadBranch: input.branch,
+    liveBranch: null,
+    hasLiveStatus: false,
+    hasDedicatedWorktree: false,
+    livePullRequest: null,
+    persistedPullRequest: input.lastKnownPr ? toThreadPullRequest(input.lastKnownPr) : null,
+  });
+}
+
+/**
+ * Resolves the PR badge for each given thread. Callers pass only the rows they render:
+ * every distinct checkout behind them gets a polled git-status query and every stored PR
+ * reference a polled lookup, so hidden history must stay out of the input.
+ */
+export function useThreadPullRequests(input: {
+  readonly threads: readonly ThreadPullRequestSource[];
+  readonly projectCwdById: ReadonlyMap<ProjectId, string>;
+}): ReadonlyMap<ThreadId, ThreadPullRequest> {
+  const { threads, projectCwdById } = input;
+  const threadGitTargets = useMemo(
+    () =>
+      threads.map((thread) => ({
+        threadId: thread.id,
+        branch: thread.branch,
+        lastKnownPr: thread.lastKnownPr ?? null,
+        hasDedicatedWorktree: thread.worktreePath !== null,
+        cwd: resolveThreadWorkspaceCwd({
+          projectCwd: projectCwdById.get(thread.projectId) ?? null,
+          envMode: thread.envMode,
+          worktreePath: thread.worktreePath,
+        }),
+      })),
+    [projectCwdById, threads],
+  );
+  const threadGitStatusCwds = useMemo(
+    () => [
+      ...new Set(
+        threadGitTargets
+          .filter((target) => target.branch !== null || target.hasDedicatedWorktree)
+          .map((target) => target.cwd)
+          .filter((cwd): cwd is string => cwd !== null),
+      ),
+    ],
+    [threadGitTargets],
+  );
+  const threadGitStatusQueries = useQueries({
+    queries: threadGitStatusCwds.map((cwd) => ({
+      ...gitStatusQueryOptions(cwd),
+      staleTime: THREAD_PR_STALE_TIME_MS,
+      refetchInterval: THREAD_PR_REFETCH_INTERVAL_MS,
+    })),
+  });
+  const threadStoredPrTargets = useMemo(
+    () =>
+      threadGitTargets.flatMap((target) =>
+        target.cwd !== null &&
+        target.lastKnownPr !== null &&
+        target.lastKnownPr.url.trim().length > 0
+          ? [{ ...target, cwd: target.cwd, lastKnownPr: target.lastKnownPr }]
+          : [],
+      ),
+    [threadGitTargets],
+  );
+  const threadStoredPrQueries = useQueries({
+    queries: threadStoredPrTargets.map((target) => ({
+      ...gitResolvePullRequestQueryOptions({
+        cwd: target.cwd,
+        reference: target.lastKnownPr.url,
+      }),
+      staleTime: THREAD_PR_STALE_TIME_MS,
+      refetchInterval: THREAD_PR_REFETCH_INTERVAL_MS,
+    })),
+  });
+  return useMemo(() => {
+    const statusByCwd = new Map<string, GitStatusResult>();
+    for (let index = 0; index < threadGitStatusCwds.length; index += 1) {
+      const cwd = threadGitStatusCwds[index];
+      if (!cwd) continue;
+      // Keep the last successful snapshot during a failed background refetch. React Query
+      // retains that data, and it is still a better branch authority than stale thread metadata.
+      const status = threadGitStatusQueries[index]?.data;
+      if (status) {
+        statusByCwd.set(cwd, status);
+      }
+    }
+
+    const storedPrByThreadId = new Map<ThreadId, ThreadPullRequest>();
+    for (let index = 0; index < threadStoredPrTargets.length; index += 1) {
+      const target = threadStoredPrTargets[index];
+      if (!target) {
+        continue;
+      }
+      const result = threadStoredPrQueries[index]?.data?.pullRequest ?? null;
+      if (result) {
+        storedPrByThreadId.set(target.threadId, toThreadPullRequest(result));
+        continue;
+      }
+      storedPrByThreadId.set(target.threadId, toThreadPullRequest(target.lastKnownPr));
+    }
+
+    const map = new Map<ThreadId, ThreadPullRequest>();
+    for (const target of threadGitTargets) {
+      const status = target.cwd ? statusByCwd.get(target.cwd) : undefined;
+      const persistedPr =
+        storedPrByThreadId.get(target.threadId) ??
+        (target.lastKnownPr ? toThreadPullRequest(target.lastKnownPr) : null);
+      map.set(
+        target.threadId,
+        resolveSidebarThreadPullRequest({
+          threadBranch: target.branch,
+          liveBranch: status?.branch ?? null,
+          hasLiveStatus: status !== undefined,
+          hasDedicatedWorktree: target.hasDedicatedWorktree,
+          livePullRequest: status?.pr ?? null,
+          persistedPullRequest: persistedPr,
+        }),
+      );
+    }
+    return map;
+  }, [
+    threadGitStatusCwds,
+    threadGitStatusQueries,
+    threadGitTargets,
+    threadStoredPrQueries,
+    threadStoredPrTargets,
+  ]);
+}

--- a/apps/web/src/lib/gitReactQuery.test.ts
+++ b/apps/web/src/lib/gitReactQuery.test.ts
@@ -208,6 +208,45 @@ describe("git query invalidation", () => {
     unsubscribe();
   });
 
+  it("starts a fresh refresh when the existing one has already begun its reads", async () => {
+    const queryClient = new QueryClient();
+    const cwd = "/repo/post-mutation";
+    const statusKey = gitQueryKeys.status(cwd);
+    let branch = "main";
+    let statusCalls = 0;
+    const firstStatusGate = deferredVoid();
+    queryClient.setQueryData(statusKey, { branch });
+    const observer = new QueryObserver(queryClient, {
+      queryKey: statusKey,
+      queryFn: async () => {
+        statusCalls += 1;
+        const observed = branch;
+        if (statusCalls === 1) {
+          await firstStatusGate.promise;
+        }
+        return { branch: observed };
+      },
+      staleTime: Number.POSITIVE_INFINITY,
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+
+    const first = refreshGitActionAvailability(queryClient, cwd);
+    await vi.waitFor(() => expect(statusCalls).toBe(1));
+
+    // A mutation (e.g. checkout or pull) settles while the first refresh is mid-read:
+    // its in-flight fetch observed the pre-mutation repository, so the follow-up refresh
+    // must issue new reads instead of joining it.
+    branch = "feature";
+    const second = refreshGitActionAvailability(queryClient, cwd);
+    expect(second).not.toBe(first);
+
+    firstStatusGate.resolve();
+    await Promise.all([first, second]);
+    expect(statusCalls).toBe(2);
+    expect(queryClient.getQueryData(statusKey)).toEqual({ branch: "feature" });
+    unsubscribe();
+  });
+
   it("serializes active expensive Git detail reads after status", async () => {
     const queryClient = new QueryClient();
     const cwd = "/repo/serialized";

--- a/apps/web/src/lib/gitReactQuery.test.ts
+++ b/apps/web/src/lib/gitReactQuery.test.ts
@@ -247,6 +247,43 @@ describe("git query invalidation", () => {
     unsubscribe();
   });
 
+  it("cancels a cold query's initial fetch instead of adopting its pre-mutation result", async () => {
+    const queryClient = new QueryClient();
+    const cwd = "/repo/cold-cache";
+    const statusKey = gitQueryKeys.status(cwd);
+    let branch = "main";
+    let statusCalls = 0;
+    const firstStatusGate = deferredVoid();
+    // No initial cache data: the observer's mount fetch is the query's first ever fetch,
+    // which refetchQueries' cancelRefetch alone would join instead of cancelling.
+    const observer = new QueryObserver(queryClient, {
+      queryKey: statusKey,
+      queryFn: async () => {
+        statusCalls += 1;
+        const observed = branch;
+        if (statusCalls === 1) {
+          await firstStatusGate.promise;
+        }
+        return { branch: observed };
+      },
+      retry: false,
+      staleTime: Number.POSITIVE_INFINITY,
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+    await vi.waitFor(() => expect(statusCalls).toBe(1));
+
+    // A mutation settles while the initial fetch is still reading pre-mutation state.
+    branch = "feature";
+    await refreshGitActionAvailability(queryClient, cwd);
+
+    expect(statusCalls).toBe(2);
+    expect(queryClient.getQueryData(statusKey)).toEqual({ branch: "feature" });
+    firstStatusGate.resolve();
+    await Promise.resolve();
+    expect(queryClient.getQueryData(statusKey)).toEqual({ branch: "feature" });
+    unsubscribe();
+  });
+
   it("serializes active expensive Git detail reads after status", async () => {
     const queryClient = new QueryClient();
     const cwd = "/repo/serialized";

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -110,6 +110,9 @@ type GitRefreshDepth = "availability" | "active-details";
 interface ActiveGitRefresh {
   depth: GitRefreshDepth;
   started: boolean;
+  /** Resolves after the availability phase (repository/status/branches). */
+  availability: Promise<void>;
+  /** Resolves after the full refresh, including active detail reads when requested. */
   promise: Promise<void>;
 }
 
@@ -150,6 +153,24 @@ function trackGitRefresh(
   return entry.promise;
 }
 
+/**
+ * Refetches the matching active queries from scratch. A fetch already in flight may have
+ * read the repository before whatever change triggered this refresh (e.g. a checkout or
+ * pull that just settled), so reusing it would mark stale data fresh. It is cancelled
+ * explicitly first because refetchQueries' cancelRefetch only cancels fetches on queries
+ * that already hold data — a cold query's initial fetch would otherwise be joined.
+ */
+async function refetchFreshGitQueries(
+  queryClient: QueryClient,
+  queryKey: readonly unknown[],
+): Promise<void> {
+  await queryClient.cancelQueries({ queryKey, exact: true, fetchStatus: "fetching" });
+  await queryClient.refetchQueries(
+    { queryKey, exact: true, type: "active" },
+    { cancelRefetch: true },
+  );
+}
+
 async function refreshGitAvailability(queryClient: QueryClient, cwd: string): Promise<void> {
   await Promise.all([
     queryClient.invalidateQueries({
@@ -168,22 +189,10 @@ async function refreshGitAvailability(queryClient: QueryClient, cwd: string): Pr
       refetchType: "none",
     }),
   ]);
-  // cancelRefetch: a fetch already in flight may have read the repository before whatever
-  // change triggered this refresh (e.g. a checkout or pull that just settled); reusing it
-  // would mark stale data fresh, so cancel and restart instead.
   await Promise.all([
-    queryClient.refetchQueries(
-      { queryKey: gitQueryKeys.githubRepository(cwd), exact: true, type: "active" },
-      { cancelRefetch: true },
-    ),
-    queryClient.refetchQueries(
-      { queryKey: gitQueryKeys.status(cwd), exact: true, type: "active" },
-      { cancelRefetch: true },
-    ),
-    queryClient.refetchQueries(
-      { queryKey: gitQueryKeys.branches(cwd), exact: true, type: "active" },
-      { cancelRefetch: true },
-    ),
+    refetchFreshGitQueries(queryClient, gitQueryKeys.githubRepository(cwd)),
+    refetchFreshGitQueries(queryClient, gitQueryKeys.status(cwd)),
+    refetchFreshGitQueries(queryClient, gitQueryKeys.branches(cwd)),
   ]);
 }
 
@@ -220,12 +229,7 @@ async function refreshActiveGitDetails(queryClient: QueryClient, cwd: string): P
     }),
   ]);
   for (const query of activeGitDetailQueries(queryClient, cwd)) {
-    await enqueueGitRefresh(queryClient, () =>
-      queryClient.refetchQueries(
-        { queryKey: query.queryKey, exact: true, type: "active" },
-        { cancelRefetch: true },
-      ),
-    );
+    await enqueueGitRefresh(queryClient, () => refetchFreshGitQueries(queryClient, query.queryKey));
   }
 }
 
@@ -247,22 +251,30 @@ export function refreshGitQueriesForCwd(
   const existing = activeGitRefreshes.get(queryClient)?.get(cwd);
   if (existing && !existing.started) {
     if (depth === "active-details") existing.depth = "active-details";
-    return existing.promise;
+    return depth === "availability" ? existing.availability : existing.promise;
   }
 
-  const entry: ActiveGitRefresh = { depth, started: false, promise: Promise.resolve() };
-  const availability = enqueueGitRefresh(queryClient, () => {
+  const entry: ActiveGitRefresh = {
+    depth,
+    started: false,
+    availability: Promise.resolve(),
+    promise: Promise.resolve(),
+  };
+  entry.availability = enqueueGitRefresh(queryClient, () => {
     entry.started = true;
     return refreshGitAvailability(queryClient, cwd);
   });
   // Read entry.depth only after availability settles so a pre-start upgrade to
   // "active-details" is honored even when the original request was availability-only.
-  entry.promise = availability.then(() =>
+  entry.promise = entry.availability.then(() =>
     entry.depth === "active-details" ? refreshActiveGitDetails(queryClient, cwd) : undefined,
   );
-  return trackGitRefresh(queryClient, cwd, entry);
+  trackGitRefresh(queryClient, cwd, entry);
+  return depth === "availability" ? entry.availability : entry.promise;
 }
 
+/** Resolves once repository/status/branches are fresh, even when the underlying refresh
+ * was upgraded to also re-read active details after the availability phase. */
 export function refreshGitActionAvailability(queryClient: QueryClient, cwd: string): Promise<void> {
   return refreshGitQueriesForCwd(queryClient, cwd, "availability");
 }
@@ -306,6 +318,22 @@ export function invalidateGitQueries(
 export function invalidateGitQueriesForCwds(queryClient: QueryClient, cwds: Iterable<string>) {
   const uniqueCwds = [...new Set([...cwds].filter((cwd) => cwd.length > 0))];
   return Promise.all(uniqueCwds.map((cwd) => refreshGitQueriesForCwd(queryClient, cwd)));
+}
+
+/**
+ * Refreshes the given checkouts and resolves once they are fresh; every other cached
+ * repository refreshes in the background. For callers gating UI on a refresh (e.g. a
+ * branch action transition) so one slow unrelated worktree cannot hold the UI busy.
+ * The awaited checkouts are queued first so background work cannot delay them.
+ */
+export function refreshGitQueriesScoped(
+  queryClient: QueryClient,
+  cwds: Iterable<string>,
+): Promise<void> {
+  const awaitedCwds = [...new Set([...cwds].filter((cwd) => cwd.length > 0))];
+  const scoped = invalidateGitQueriesForCwds(queryClient, awaitedCwds);
+  void invalidateGitQueries(queryClient, { excludeCwds: awaitedCwds }).catch(() => undefined);
+  return scoped.then(() => undefined);
 }
 
 export function gitStatusQueryOptions(cwd: string | null, enabled = true) {

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -108,9 +108,9 @@ export const gitMutationKeys = {
 type GitRefreshDepth = "availability" | "active-details";
 
 interface ActiveGitRefresh {
-  readonly depth: GitRefreshDepth;
-  readonly promise: Promise<void>;
-  availabilityPromise: Promise<void> | undefined;
+  depth: GitRefreshDepth;
+  started: boolean;
+  promise: Promise<void>;
 }
 
 const activeGitRefreshes = new WeakMap<QueryClient, Map<string, ActiveGitRefresh>>();
@@ -135,40 +135,19 @@ function enqueueGitRefresh(queryClient: QueryClient, refresh: () => Promise<void
 function trackGitRefresh(
   queryClient: QueryClient,
   cwd: string,
-  depth: GitRefreshDepth,
-  promise: Promise<void>,
-  availabilityPromise?: Promise<void>,
+  entry: ActiveGitRefresh,
 ): Promise<void> {
   let refreshes = activeGitRefreshes.get(queryClient);
   if (!refreshes) {
     refreshes = new Map();
     activeGitRefreshes.set(queryClient, refreshes);
   }
-  const entry: ActiveGitRefresh = { depth, promise, availabilityPromise };
   refreshes.set(cwd, entry);
-  if (availabilityPromise) {
-    void availabilityPromise.then(
-      () => {
-        if (entry.availabilityPromise === availabilityPromise) {
-          entry.availabilityPromise = undefined;
-        }
-      },
-      () => {
-        if (entry.availabilityPromise === availabilityPromise) {
-          entry.availabilityPromise = undefined;
-        }
-      },
-    );
-  }
-  void promise.then(
-    () => {
-      if (refreshes?.get(cwd) === entry) refreshes.delete(cwd);
-    },
-    () => {
-      if (refreshes?.get(cwd) === entry) refreshes.delete(cwd);
-    },
-  );
-  return promise;
+  const cleanup = () => {
+    if (refreshes.get(cwd) === entry) refreshes.delete(cwd);
+  };
+  void entry.promise.then(cleanup, cleanup);
+  return entry.promise;
 }
 
 async function refreshGitAvailability(queryClient: QueryClient, cwd: string): Promise<void> {
@@ -189,18 +168,21 @@ async function refreshGitAvailability(queryClient: QueryClient, cwd: string): Pr
       refetchType: "none",
     }),
   ]);
+  // cancelRefetch: a fetch already in flight may have read the repository before whatever
+  // change triggered this refresh (e.g. a checkout or pull that just settled); reusing it
+  // would mark stale data fresh, so cancel and restart instead.
   await Promise.all([
     queryClient.refetchQueries(
       { queryKey: gitQueryKeys.githubRepository(cwd), exact: true, type: "active" },
-      { cancelRefetch: false },
+      { cancelRefetch: true },
     ),
     queryClient.refetchQueries(
       { queryKey: gitQueryKeys.status(cwd), exact: true, type: "active" },
-      { cancelRefetch: false },
+      { cancelRefetch: true },
     ),
     queryClient.refetchQueries(
       { queryKey: gitQueryKeys.branches(cwd), exact: true, type: "active" },
-      { cancelRefetch: false },
+      { cancelRefetch: true },
     ),
   ]);
 }
@@ -241,7 +223,7 @@ async function refreshActiveGitDetails(queryClient: QueryClient, cwd: string): P
     await enqueueGitRefresh(queryClient, () =>
       queryClient.refetchQueries(
         { queryKey: query.queryKey, exact: true, type: "active" },
-        { cancelRefetch: false },
+        { cancelRefetch: true },
       ),
     );
   }
@@ -251,6 +233,11 @@ async function refreshActiveGitDetails(queryClient: QueryClient, cwd: string): P
  * Coalesces refreshes by repository and serializes their expensive reads across the client.
  * Availability is refreshed first; active diff/PR details follow one at a time so Git UI work
  * cannot consume both expensive-read leases or fan out across every visible worktree.
+ *
+ * A refresh only joins an existing one while that refresh is still queued: once its reads
+ * have begun they may predate whatever change triggered this request (a checkout or pull
+ * that just settled), so joining would return without ever observing the new repository
+ * state. In that case a fresh refresh is queued behind the running one instead.
  */
 export function refreshGitQueriesForCwd(
   queryClient: QueryClient,
@@ -258,41 +245,22 @@ export function refreshGitQueriesForCwd(
   depth: GitRefreshDepth = "active-details",
 ): Promise<void> {
   const existing = activeGitRefreshes.get(queryClient)?.get(cwd);
-  if (existing) {
-    if (depth === "availability") {
-      if (existing.availabilityPromise) return existing.availabilityPromise;
-      if (existing.depth === "availability") return existing.promise;
-
-      const availability = enqueueGitRefresh(queryClient, () =>
-        refreshGitAvailability(queryClient, cwd),
-      );
-      const extended = existing.promise.finally(() => availability);
-      trackGitRefresh(queryClient, cwd, "active-details", extended, availability);
-      return availability;
-    }
-    if (existing.depth === "active-details") {
-      return existing.promise;
-    }
-    const upgraded = existing.promise
-      .catch(() => undefined)
-      .then(() => refreshActiveGitDetails(queryClient, cwd));
-    return trackGitRefresh(
-      queryClient,
-      cwd,
-      "active-details",
-      upgraded,
-      existing.availabilityPromise,
-    );
+  if (existing && !existing.started) {
+    if (depth === "active-details") existing.depth = "active-details";
+    return existing.promise;
   }
 
-  const availability = enqueueGitRefresh(queryClient, () =>
-    refreshGitAvailability(queryClient, cwd),
+  const entry: ActiveGitRefresh = { depth, started: false, promise: Promise.resolve() };
+  const availability = enqueueGitRefresh(queryClient, () => {
+    entry.started = true;
+    return refreshGitAvailability(queryClient, cwd);
+  });
+  // Read entry.depth only after availability settles so a pre-start upgrade to
+  // "active-details" is honored even when the original request was availability-only.
+  entry.promise = availability.then(() =>
+    entry.depth === "active-details" ? refreshActiveGitDetails(queryClient, cwd) : undefined,
   );
-  const refresh =
-    depth === "active-details"
-      ? availability.then(() => refreshActiveGitDetails(queryClient, cwd))
-      : availability;
-  return trackGitRefresh(queryClient, cwd, depth, refresh, availability);
+  return trackGitRefresh(queryClient, cwd, entry);
 }
 
 export function refreshGitActionAvailability(queryClient: QueryClient, cwd: string): Promise<void> {
@@ -320,9 +288,17 @@ function cachedGitCwds(queryClient: QueryClient): string[] {
   return [...new Set(cwds)];
 }
 
-export function invalidateGitQueries(queryClient: QueryClient) {
+// excludeCwds lets a caller that already refreshed (and awaited) specific checkouts fan the
+// rest out in the background without queueing duplicate refreshes for the awaited ones.
+export function invalidateGitQueries(
+  queryClient: QueryClient,
+  options?: { readonly excludeCwds?: Iterable<string> },
+) {
+  const excludedCwds = new Set(options?.excludeCwds ?? []);
   return Promise.all(
-    cachedGitCwds(queryClient).map((cwd) => refreshGitQueriesForCwd(queryClient, cwd)),
+    cachedGitCwds(queryClient)
+      .filter((cwd) => !excludedCwds.has(cwd))
+      .map((cwd) => refreshGitQueriesForCwd(queryClient, cwd)),
   );
 }
 


### PR DESCRIPTION
## Problems

Three regressions surfaced after the PR-detection work (#587/#590/#591):

1. **Switching branch from the environment panel made the selector "unavailable" until a page reload.**
2. **After pulling, the toolbar stayed stuck on "Pull".**
3. **A merged PR attached to another branch kept showing the green open icon instead of the indigo merged one.**

## Root causes

**1 & 2 — post-mutation refreshes were coalesced into pre-mutation reads.** #591 serializes git refreshes per repo and coalesces concurrent requests. But a refresh requested *after* a checkout/pull settled would join a refresh already in flight whose fetches began *before* the mutation, so no new reads were issued. Combined with `cancelRefetch: false` (a pre-mutation in-flight fetch could satisfy the post-mutation refetch and clear the invalidation), the stale snapshot was marked fresh for up to the 300s poll interval. After a checkout this left the branch list and git status disagreeing about the current branch, which `GitActionsControl` treats as out-of-sync (`gitStatusForActions = null` → every row "unavailable"); its one-shot self-heal joined the same stale in-flight refresh and never re-fired. After a pull, `status.behind` never refreshed, so the Pull promotion never cleared.

**3 — the sidebar resolver dropped settled PRs, and the activity view resurrected stale metadata.** `resolveSidebarThreadPullRequest` validates the persisted PR against the current branch, so after switching to main the merged PR (head branch elsewhere) resolved to `null` — and `SidebarActivityView` then fell back to `thread.lastKnownPr`, whose persisted state is still `"open"` (thread metadata only updates on provider turn events). Fresh merged data from the 60s `resolvePullRequest` poll was arriving but being discarded.

## Fixes

- `gitReactQuery.ts`: a refresh only joins an existing one while it is still **queued**; once its reads have begun, a fresh refresh is queued behind it. Refetches use `cancelRefetch: true` so an in-flight pre-mutation fetch can't satisfy a post-mutation refresh. Serialization/coalescing of bursts is preserved (at most one running + one queued refresh per repo).
- `BranchToolbarBranchSelector.tsx`: branch actions await only the acted-on checkout's refresh and fan the remaining cached repos out in the background (`invalidateGitQueries` gained `excludeCwds`), so a slow unrelated worktree can't hold the selector disabled. Also removes a double full refresh after checkout.
- `Sidebar.logic.ts`: a settled (merged/closed) persisted PR is the thread's outcome, not a claim about the current checkout — it now survives branch validation, so the badge flips to indigo instead of disappearing. A live open PR for the current branch still wins.
- `SidebarActivityView.tsx`: an explicit `null` from the resolver is respected; `lastKnownPr` is only used when the thread wasn't resolved at all.

## Tests

- New regression test: a refresh requested while an existing one has begun its reads issues fresh fetches and lands post-mutation data.
- New resolver tests: merged persisted PR stays visible after the worktree/shared checkout moves to another branch (and when a dedicated worktree is detached); live PR still outranks it.
- `bun fmt`, `bun lint`, `bun typecheck`, and the full `bun run test` suite pass.

## Notes

Kanban cards still read `thread.lastKnownPr` directly and can show a stale state until thread metadata updates on the next turn — left as a follow-up since it lacks the sidebar's live-status context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches git refresh serialization and PR resolution across sidebar, kanban, and branch actions; regressions could affect toolbar availability or badge accuracy, but behavior is heavily covered by new tests.
> 
> **Overview**
> Fixes post-mutation git UI getting stuck (branch selector unavailable, Pull toolbar) and sidebar/kanban PR badges showing stale **open** state after merge or branch moves.
> 
> **Git React Query** only coalesces refreshes while a refresh is still **queued**; once reads have started, a new refresh is queued so post-checkout/pull work is not satisfied by pre-mutation fetches. Refetches go through `refetchFreshGitQueries` (cancel in-flight fetches, then `cancelRefetch: true`). **`refreshGitQueriesScoped`** awaits freshness for specific checkouts and refreshes other cached repos in the background; the branch toolbar uses it (and optional `refreshCwds` on recovery paths) instead of blocking on a full `invalidateGitQueries`, and drops redundant post-checkout invalidation.
> 
> **PR badges:** `resolveSidebarThreadPullRequest` keeps **merged/closed** persisted PRs visible when the checkout no longer matches the PR head branch; live open PRs for the current branch still win. Inline sidebar PR logic moves to **`useThreadPullRequests`**; **Kanban** and **SidebarActivityView** consume the same resolver/fallback so explicit `null` is not replaced by raw `lastKnownPr`. Overview kanban caps are centralized in **`overviewVisibleKanbanCards`** so PR polling matches rendered cards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e980cec65b953ac5ca3e26dd8f993149ef8f0aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->