### PR TITLE
Stream worktree setup progress and simplify keybinding handling

### DIFF
--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -1329,6 +1329,36 @@ it.layer(TestLayer)("git integration", (it) => {
       }),
     );
 
+    it.effect("does not report branch creation before preliminary validation", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const core = yield* GitCore;
+        const phases: string[] = [];
+
+        const result = yield* Effect.exit(
+          core.createDetachedWorktree(
+            {
+              cwd: tmp,
+              ref: "refs/heads/missing",
+              path: path.join(tmp, "wt-invalid-ref"),
+              newBranch: "synara/notstarted",
+            },
+            {
+              onPhase: (phase) =>
+                Effect.sync(() => {
+                  phases.push(phase);
+                }),
+            },
+          ),
+        );
+
+        expect(Exit.isFailure(result)).toBe(true);
+        expect(phases).toEqual([]);
+        expect(yield* git(tmp, ["branch", "--list", "synara/notstarted"])).toBe("");
+      }),
+    );
+
     it.effect("deletes the pre-created branch when worktree add fails", () =>
       Effect.gen(function* () {
         const tmp = yield* makeTmpDir();

--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -1295,6 +1295,64 @@ it.layer(TestLayer)("git integration", (it) => {
       }),
     );
 
+    it.effect("reports setup phases at the real command boundaries", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        yield* writeTextFile(path.join(tmp, "notes.txt"), "untracked note\n");
+        const core = yield* GitCore;
+        const wtPath = path.join(tmp, "wt-phase-events");
+        const phases: string[] = [];
+        yield* core.createDetachedWorktree(
+          {
+            cwd: tmp,
+            ref: "HEAD",
+            path: wtPath,
+            newBranch: "synara/ph123456",
+            copyChangesFrom: tmp,
+          },
+          {
+            onPhase: (phase) =>
+              Effect.sync(() => {
+                phases.push(phase);
+              }),
+          },
+        );
+
+        expect(phases).toEqual(["branch", "worktree", "copy-changes"]);
+        yield* core.removeWorktree({
+          cwd: tmp,
+          path: wtPath,
+          force: true,
+          reclaimTemporaryBranch: true,
+        });
+      }),
+    );
+
+    it.effect("deletes the pre-created branch when worktree add fails", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const core = yield* GitCore;
+        const wtPath = path.join(tmp, "wt-rollback-branch");
+        // A plain file at the target path makes `git worktree add` fail after
+        // the branch has already been created.
+        yield* writeTextFile(wtPath, "occupied\n");
+
+        const result = yield* Effect.exit(
+          core.createDetachedWorktree({
+            cwd: tmp,
+            ref: "HEAD",
+            path: wtPath,
+            newBranch: "synara/rollback1",
+          }),
+        );
+
+        expect(Exit.isFailure(result)).toBe(true);
+        expect(yield* git(tmp, ["branch", "--list", "synara/rollback1"])).toBe("");
+      }),
+    );
+
     it.effect("removeWorktree reclamation never deletes user-named branches", () =>
       Effect.gen(function* () {
         const tmp = yield* makeTmpDir();

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -2628,8 +2628,13 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
         return { verified: true, reason: null };
       });
 
-    const createDetachedWorktree: GitCoreShape["createDetachedWorktree"] = (input) =>
+    const createDetachedWorktree: GitCoreShape["createDetachedWorktree"] = (input, options) =>
       Effect.gen(function* () {
+        const onPhase = options?.onPhase ?? (() => Effect.void);
+        const newBranch = input.newBranch ?? null;
+        if (newBranch) {
+          yield* onPhase("branch");
+        }
         const refResult = yield* executeGit(
           "GitCore.createDetachedWorktree.resolveRef",
           input.cwd,
@@ -2667,16 +2672,38 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
 
         // Branch-backed managed worktrees still pin to the resolved commit, so
         // ownership proofs and pruning behave exactly like the detached form.
-        const newBranch = input.newBranch ?? null;
-        yield* executeGit(
+        // The branch is created before the (slow) checkout so progress phases
+        // reflect the real boundary between the two.
+        if (newBranch) {
+          yield* executeGit("GitCore.createDetachedWorktree.createBranch", input.cwd, [
+            "branch",
+            newBranch,
+            resolvedRef,
+          ]);
+        }
+        yield* onPhase("worktree");
+        const addWorktree = executeGit(
           "GitCore.createDetachedWorktree",
           input.cwd,
           newBranch
-            ? ["worktree", "add", "-b", newBranch, worktreePath, resolvedRef]
+            ? ["worktree", "add", worktreePath, newBranch]
             : ["worktree", "add", "--detach", worktreePath, resolvedRef],
         );
+        yield* newBranch
+          ? addWorktree.pipe(
+              Effect.onError(() =>
+                executeGit(
+                  "GitCore.createDetachedWorktree.rollbackBranch",
+                  input.cwd,
+                  ["branch", "-D", newBranch],
+                  { allowNonZeroExit: true },
+                ).pipe(Effect.ignore),
+              ),
+            )
+          : addWorktree;
 
         if (input.copyChangesFrom) {
+          yield* onPhase("copy-changes");
           yield* copyCheckoutChanges(input.copyChangesFrom, worktreePath).pipe(
             Effect.onError(() =>
               executeGit(

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -2632,9 +2632,6 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
       Effect.gen(function* () {
         const onPhase = options?.onPhase ?? (() => Effect.void);
         const newBranch = input.newBranch ?? null;
-        if (newBranch) {
-          yield* onPhase("branch");
-        }
         const refResult = yield* executeGit(
           "GitCore.createDetachedWorktree.resolveRef",
           input.cwd,
@@ -2675,6 +2672,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
         // The branch is created before the (slow) checkout so progress phases
         // reflect the real boundary between the two.
         if (newBranch) {
+          yield* onPhase("branch");
           yield* executeGit("GitCore.createDetachedWorktree.createBranch", input.cwd, [
             "branch",
             newBranch,

--- a/apps/server/src/git/Services/GitCore.ts
+++ b/apps/server/src/git/Services/GitCore.ts
@@ -12,6 +12,7 @@ import type {
   GitCheckoutInput,
   GitCreateBranchInput,
   GitCreateDetachedWorktreeInput,
+  GitWorktreeSetupPhase,
   GitCreateDetachedWorktreeResult,
   GitCreateWorktreeInput,
   GitCreateWorktreeResult,
@@ -315,10 +316,14 @@ export interface GitCoreShape {
   ) => Effect.Effect<void, GitCommandError>;
 
   /**
-   * Create a detached worktree from a branch or ref.
+   * Create a detached worktree from a branch or ref. `onPhase` fires as each
+   * setup phase (branch → worktree → copy-changes) begins, for progress UIs.
    */
   readonly createDetachedWorktree: (
     input: GitCreateDetachedWorktreeInput,
+    options?: {
+      readonly onPhase?: (phase: GitWorktreeSetupPhase) => Effect.Effect<void>;
+    },
   ) => Effect.Effect<GitCreateDetachedWorktreeResult, GitCommandError>;
 
   /**

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -17,6 +17,7 @@ import {
   PullRequestsUnavailableError,
   type GitActionProgressEvent,
   type GitHubProjectProvisionProgressEvent,
+  type GitWorktreeSetupProgressEvent,
   type OrchestrationCommand,
   type OrchestrationEvent,
   type ProjectDevServerEvent,
@@ -1381,12 +1382,33 @@ const makeWsRpcHandlersLayer = () =>
             "Failed to create worktree",
           ),
         [WS_METHODS.gitCreateDetachedWorktree]: (input) =>
-          rpcEffect(
-            refreshGitStatusAfter(
-              input.cwd,
-              git.withMutation(input.cwd, git.createDetachedWorktree(input)),
-            ),
-            "Failed to create detached worktree",
+          bufferLiveUiStream(
+            Stream.callback<GitWorktreeSetupProgressEvent, WsRpcError>((queue) => {
+              const progressId = input.progressId ?? null;
+              return refreshGitStatusAfter(
+                input.cwd,
+                git.withMutation(
+                  input.cwd,
+                  git.createDetachedWorktree(input, {
+                    onPhase: (phase) =>
+                      Queue.offer(queue, { kind: "phase_started", progressId, phase }).pipe(
+                        Effect.asVoid,
+                      ),
+                  }),
+                ),
+              ).pipe(
+                Effect.matchCauseEffect({
+                  onFailure: (cause) =>
+                    Queue.fail(queue, toWsRpcError(cause, "Failed to create detached worktree")),
+                  onSuccess: (result) =>
+                    Queue.offer(queue, { kind: "completed", progressId, result }).pipe(
+                      Effect.andThen(Queue.end(queue)),
+                      Effect.asVoid,
+                    ),
+                }),
+              );
+            }),
+            { label: "git.create-detached-worktree" },
           ),
         [WS_METHODS.gitRemoveWorktree]: (input) =>
           rpcEffect(

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -4,6 +4,7 @@ import {
   MessageId,
   ThreadId,
   TurnId,
+  type GitWorktreeSetupProgressEvent,
   type ModelSlug,
   type RuntimeMode,
 } from "@synara/contracts";
@@ -55,6 +56,7 @@ import {
   resolveRuntimeModeAfterApprovalDecision,
   resolveThreadDetailHydration,
   resolveThreadArtifactWorkspaceRoot,
+  runWorktreeCreationFlow,
   QUEUED_STEER_GATE_TIMEOUT_MS,
   sanitizeVoiceErrorMessage,
   buildExpiredTerminalContextToastCopy,
@@ -1717,23 +1719,49 @@ describe("shouldStartActiveTurnLayoutGrace", () => {
 describe("worktree setup snapshots", () => {
   it("marks earlier steps done, the active step active, and later steps pending", () => {
     expect(createWorktreeSetupSnapshot("prepare-thread").steps).toEqual([
-      { id: "create-worktree", label: "Creating branch and worktree", status: "done" },
+      { id: "create-branch", label: "Creating branch", status: "done" },
+      { id: "create-worktree", label: "Creating worktree", status: "done" },
       { id: "prepare-thread", label: "Linking thread workspace", status: "active" },
       { id: "start-session", label: "Starting session", status: "pending" },
     ]);
   });
 
   it("starts with every step pending except the first when setup begins", () => {
-    expect(createWorktreeSetupSnapshot("create-worktree").steps.map((step) => step.status)).toEqual(
-      ["active", "pending", "pending"],
-    );
+    expect(createWorktreeSetupSnapshot("create-branch").steps.map((step) => step.status)).toEqual([
+      "active",
+      "pending",
+      "pending",
+      "pending",
+    ]);
   });
 
   it("ends with every step done except the last when the session starts", () => {
     expect(createWorktreeSetupSnapshot("start-session").steps.map((step) => step.status)).toEqual([
       "done",
       "done",
+      "done",
       "active",
+    ]);
+  });
+
+  it("inserts the copy step when the worktree copies local changes", () => {
+    expect(createWorktreeSetupSnapshot("copy-changes").steps).toEqual([
+      { id: "create-branch", label: "Creating branch", status: "done" },
+      { id: "create-worktree", label: "Creating worktree", status: "done" },
+      { id: "copy-changes", label: "Copying local changes", status: "active" },
+      { id: "prepare-thread", label: "Linking thread workspace", status: "pending" },
+      { id: "start-session", label: "Starting session", status: "pending" },
+    ]);
+    expect(
+      createWorktreeSetupSnapshot("create-branch", { copyLocalChanges: true }).steps.map(
+        (step) => step.id,
+      ),
+    ).toEqual([
+      "create-branch",
+      "create-worktree",
+      "copy-changes",
+      "prepare-thread",
+      "start-session",
     ]);
   });
 
@@ -1741,7 +1769,8 @@ describe("worktree setup snapshots", () => {
     expect(
       createWorktreeSetupSnapshot("run-setup-action", { setupScriptName: "Setup" }).steps,
     ).toEqual([
-      { id: "create-worktree", label: "Creating branch and worktree", status: "done" },
+      { id: "create-branch", label: "Creating branch", status: "done" },
+      { id: "create-worktree", label: "Creating worktree", status: "done" },
       { id: "prepare-thread", label: "Linking thread workspace", status: "done" },
       { id: "run-setup-action", label: "Running setup action: Setup", status: "active" },
       { id: "start-session", label: "Starting session", status: "pending" },
@@ -1753,7 +1782,7 @@ describe("worktree setup snapshots", () => {
       createWorktreeSetupSnapshot("start-session", { setupScriptName: "Setup" }).steps.map(
         (step) => step.status,
       ),
-    ).toEqual(["done", "done", "done", "active"]);
+    ).toEqual(["done", "done", "done", "done", "active"]);
   });
 
   it("preserves setup action metadata while advancing local worktree setup", () => {
@@ -1769,7 +1798,8 @@ describe("worktree setup snapshots", () => {
     });
 
     expect(next.worktreeSetup?.steps).toEqual([
-      { id: "create-worktree", label: "Creating branch and worktree", status: "done" },
+      { id: "create-branch", label: "Creating branch", status: "done" },
+      { id: "create-worktree", label: "Creating worktree", status: "done" },
       { id: "prepare-thread", label: "Linking thread workspace", status: "done" },
       { id: "run-setup-action", label: "Running setup action: Setup", status: "active" },
       { id: "start-session", label: "Starting session", status: "pending" },
@@ -1778,7 +1808,7 @@ describe("worktree setup snapshots", () => {
 
   it("fails only the active step and leaves the rest untouched", () => {
     const failed = failWorktreeSetupSnapshot(createWorktreeSetupSnapshot("prepare-thread"));
-    expect(failed.steps.map((step) => step.status)).toEqual(["done", "error", "pending"]);
+    expect(failed.steps.map((step) => step.status)).toEqual(["done", "done", "error", "pending"]);
     expect(worktreeSetupHasError(failed)).toBe(true);
   });
 
@@ -1879,10 +1909,125 @@ describe("worktree setup snapshots", () => {
 
     expect(next).not.toBe(current);
     expect(next.worktreeSetup?.steps.map((step) => step.status)).toEqual([
+      "done",
       "active",
       "pending",
       "pending",
     ]);
+  });
+});
+
+describe("runWorktreeCreationFlow", () => {
+  interface FlowHarness {
+    emit: (event: GitWorktreeSetupProgressEvent) => void;
+    resolution: ReturnType<typeof createWorktreeSetupResolution>;
+    steps: string[];
+    removedPaths: string[];
+    unsubscribeCount: () => number;
+    settleCreation: (worktreePath: string) => void;
+    rejectCreation: (error: unknown) => void;
+    flow: ReturnType<typeof runWorktreeCreationFlow<{ worktree: { path: string } }>>;
+  }
+
+  function startFlowHarness(): FlowHarness {
+    const listeners: Array<(event: GitWorktreeSetupProgressEvent) => void> = [];
+    let unsubscribes = 0;
+    let settle!: (result: { worktree: { path: string } }) => void;
+    let reject!: (error: unknown) => void;
+    const resolution = createWorktreeSetupResolution();
+    const steps: string[] = [];
+    const removedPaths: string[] = [];
+    const flow = runWorktreeCreationFlow({
+      progressId: "progress-1",
+      subscribeToProgress: (listener) => {
+        listeners.push(listener);
+        return () => {
+          unsubscribes += 1;
+        };
+      },
+      startCreation: () =>
+        new Promise<{ worktree: { path: string } }>((resolveCreation, rejectCreation) => {
+          settle = resolveCreation;
+          reject = rejectCreation;
+        }),
+      resolution,
+      onCreationStep: (stepId) => steps.push(stepId),
+      removeWorktree: (worktreePath) => {
+        removedPaths.push(worktreePath);
+        return Promise.resolve();
+      },
+    });
+    return {
+      emit: (event) => {
+        for (const listener of listeners) {
+          listener(event);
+        }
+      },
+      resolution,
+      steps,
+      removedPaths,
+      unsubscribeCount: () => unsubscribes,
+      settleCreation: (worktreePath) => settle({ worktree: { path: worktreePath } }),
+      rejectCreation: (error) => reject(error),
+      flow,
+    };
+  }
+
+  it("advances steps only for this creation's phase-started events", async () => {
+    const harness = startFlowHarness();
+
+    harness.emit({ progressId: "progress-1", kind: "phase_started", phase: "branch" });
+    harness.emit({ progressId: "progress-other", kind: "phase_started", phase: "worktree" });
+    harness.emit({
+      progressId: "progress-1",
+      kind: "completed",
+      result: { worktree: { path: "/wt", ref: "abc123", branch: "synara/x" } },
+    });
+    harness.emit({ progressId: "progress-1", kind: "phase_started", phase: "copy-changes" });
+
+    expect(harness.steps).toEqual(["create-branch", "copy-changes"]);
+
+    harness.settleCreation("/wt");
+    await expect(harness.flow).resolves.toEqual({
+      outcome: "created",
+      result: { worktree: { path: "/wt" } },
+    });
+    expect(harness.removedPaths).toEqual([]);
+    expect(harness.unsubscribeCount()).toBe(1);
+  });
+
+  it("stops advancing steps once the setup card is resolved", async () => {
+    const harness = startFlowHarness();
+
+    harness.emit({ progressId: "progress-1", kind: "phase_started", phase: "branch" });
+    harness.resolution.resolve("cancel");
+    harness.emit({ progressId: "progress-1", kind: "phase_started", phase: "worktree" });
+
+    expect(harness.steps).toEqual(["create-branch"]);
+    await expect(harness.flow).resolves.toEqual({ outcome: "resolved" });
+  });
+
+  it("tears down the worktree once creation lands after a resolution won the race", async () => {
+    const harness = startFlowHarness();
+
+    harness.resolution.resolve("work-locally");
+    await expect(harness.flow).resolves.toEqual({ outcome: "resolved" });
+    expect(harness.unsubscribeCount()).toBe(1);
+    expect(harness.removedPaths).toEqual([]);
+
+    harness.settleCreation("/late-worktree");
+    await Promise.resolve();
+    expect(harness.removedPaths).toEqual(["/late-worktree"]);
+  });
+
+  it("unsubscribes and rethrows when creation fails", async () => {
+    const harness = startFlowHarness();
+
+    harness.rejectCreation(new Error("worktree add failed"));
+
+    await expect(harness.flow).rejects.toThrow("worktree add failed");
+    expect(harness.unsubscribeCount()).toBe(1);
+    expect(harness.removedPaths).toEqual([]);
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -1,6 +1,8 @@
 import {
   ProjectId,
   ThreadId,
+  type GitWorktreeSetupPhase,
+  type GitWorktreeSetupProgressEvent,
   type ModelSelection,
   type ModelSlug,
   type ProviderApprovalDecision,
@@ -923,19 +925,30 @@ export interface PullRequestDialogState {
   key: number;
 }
 
-// Ordered client-side phases of the "New worktree" first-send setup. The
-// labels surface verbatim in the transcript's transient setup row.
-export const WORKTREE_SETUP_STEP_DEFINITIONS: ReadonlyArray<{
-  id: WorktreeSetupStepId;
-  label: string;
-}> = [
-  { id: "create-worktree", label: "Creating branch and worktree" },
-  { id: "prepare-thread", label: "Linking thread workspace" },
-  { id: "start-session", label: "Starting session" },
-];
+// Labels for the "New worktree" first-send setup steps, surfaced verbatim in
+// the transcript's transient setup row. Single source — the ordered step list
+// is assembled in `worktreeSetupStepDefinitions`.
+const WORKTREE_SETUP_STEP_LABELS: Record<WorktreeSetupStepId, string> = {
+  "create-branch": "Creating branch",
+  "create-worktree": "Creating worktree",
+  "copy-changes": "Copying local changes",
+  "prepare-thread": "Linking thread workspace",
+  "run-setup-action": "Running setup action",
+  "start-session": "Starting session",
+};
+
+// Creation phases mirror the server's real worktree setup progress events, so
+// each row completes on an actual boundary instead of one row spinning through
+// all of them.
+export const WORKTREE_SETUP_STEP_ID_BY_PHASE: Record<GitWorktreeSetupPhase, WorktreeSetupStepId> = {
+  branch: "create-branch",
+  worktree: "create-worktree",
+  "copy-changes": "copy-changes",
+};
 
 export interface WorktreeSetupSnapshotOptions {
   setupScriptName?: string | null;
+  copyLocalChanges?: boolean;
 }
 
 export interface WorktreeSetupDispatchOptions extends WorktreeSetupSnapshotOptions {
@@ -949,18 +962,23 @@ function worktreeSetupStepDefinitions(
 ): ReadonlyArray<{ id: WorktreeSetupStepId; label: string }> {
   const setupScriptName = options?.setupScriptName?.trim();
   const includeSetupStep = activeStepId === "run-setup-action" || Boolean(setupScriptName);
-  if (!includeSetupStep) {
-    return WORKTREE_SETUP_STEP_DEFINITIONS;
+  const includeCopyStep = activeStepId === "copy-changes" || Boolean(options?.copyLocalChanges);
+  const stepIds: WorktreeSetupStepId[] = ["create-branch", "create-worktree"];
+  if (includeCopyStep) {
+    stepIds.push("copy-changes");
   }
-  return [
-    { id: "create-worktree", label: "Creating branch and worktree" },
-    { id: "prepare-thread", label: "Linking thread workspace" },
-    {
-      id: "run-setup-action",
-      label: setupScriptName ? `Running setup action: ${setupScriptName}` : "Running setup action",
-    },
-    { id: "start-session", label: "Starting session" },
-  ];
+  stepIds.push("prepare-thread");
+  if (includeSetupStep) {
+    stepIds.push("run-setup-action");
+  }
+  stepIds.push("start-session");
+  return stepIds.map((id) => ({
+    id,
+    label:
+      id === "run-setup-action" && setupScriptName
+        ? `${WORKTREE_SETUP_STEP_LABELS[id]}: ${setupScriptName}`
+        : WORKTREE_SETUP_STEP_LABELS[id],
+  }));
 }
 
 // How long a failed setup step stays visible before the row is dismissed, so
@@ -1040,6 +1058,58 @@ export function createWorktreeSetupResolution(): WorktreeSetupResolution {
       settle(next);
     },
   };
+}
+
+export interface WorktreeCreationFlowDeps<Result extends { worktree: { path: string } }> {
+  /** Correlates streamed progress events with this creation request. */
+  progressId: string;
+  subscribeToProgress: (listener: (event: GitWorktreeSetupProgressEvent) => void) => () => void;
+  startCreation: () => Promise<Result>;
+  resolution: WorktreeSetupResolution;
+  /** Advances the setup card to the step matching a streamed creation phase. */
+  onCreationStep: (stepId: WorktreeSetupStepId) => void;
+  removeWorktree: (worktreePath: string) => Promise<unknown>;
+}
+
+export type WorktreeCreationFlowOutcome<Result> =
+  | { outcome: "resolved" }
+  | { outcome: "created"; result: Result };
+
+/**
+ * Runs one worktree creation while the setup card is showing: subscribes to
+ * the server's streamed setup phases, races the creation against the card's
+ * "Cancel" / "Work locally" resolution, and — when the user resolves first —
+ * tears the (possibly still materializing) worktree down once the creation
+ * lands so a resolved send leaves no stray checkout.
+ */
+export async function runWorktreeCreationFlow<Result extends { worktree: { path: string } }>(
+  deps: WorktreeCreationFlowDeps<Result>,
+): Promise<WorktreeCreationFlowOutcome<Result>> {
+  const unsubscribe = deps.subscribeToProgress((event) => {
+    if (
+      event.progressId !== deps.progressId ||
+      event.kind !== "phase_started" ||
+      deps.resolution.action !== null
+    ) {
+      return;
+    }
+    deps.onCreationStep(WORKTREE_SETUP_STEP_ID_BY_PHASE[event.phase]);
+  });
+  try {
+    const creation = deps.startCreation();
+    // `git worktree add` is the longest step; let the card's buttons win the
+    // wait instead of only taking effect once the creation finishes.
+    await Promise.race([creation, deps.resolution.promise]);
+    if (deps.resolution.action !== null) {
+      void creation
+        .then((result) => deps.removeWorktree(result.worktree.path))
+        .catch(() => undefined);
+      return { outcome: "resolved" };
+    }
+    return { outcome: "created", result: await creation };
+  } finally {
+    unsubscribe();
+  }
 }
 
 // Once the turn RPC has resolved the server provably owns the turn; the

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -571,6 +571,7 @@ import {
   worktreeSetupHasError,
   WorktreeSetupCancelledError,
   createWorktreeSetupResolution,
+  runWorktreeCreationFlow,
   LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
   LastInvokedScriptByProjectSchema,
   type LocalDispatchSnapshot,
@@ -7909,6 +7910,10 @@ export default function ChatView({
       ? setupProjectScript(targetProjectScriptsForSend)
       : null;
     const worktreeSetupScriptName = setupScriptForWorktree?.name ?? null;
+    // Branching off the checkout's current branch also carries its uncommitted
+    // changes into the worktree, which the setup card surfaces as its own step.
+    const worktreeCopiesLocalChanges =
+      Boolean(baseBranchForWorktree) && baseBranchForWorktree === activeRootBranch;
     const messageIdForSend = newMessageId();
     const worktreeSetupResolution = baseBranchForWorktree ? createWorktreeSetupResolution() : null;
     worktreeSetupResolutionRef.current = worktreeSetupResolution;
@@ -7920,7 +7925,11 @@ export default function ChatView({
     beginLocalDispatch({
       expectedUserMessageId: messageIdForSend,
       ...(baseBranchForWorktree
-        ? { worktreeSetupStepId: "create-worktree", setupScriptName: worktreeSetupScriptName }
+        ? {
+            worktreeSetupStepId: "create-branch" as const,
+            setupScriptName: worktreeSetupScriptName,
+            copyLocalChanges: worktreeCopiesLocalChanges,
+          }
         : {}),
     });
 
@@ -8133,36 +8142,44 @@ export default function ChatView({
 
       // On first message: lock in branch + create worktree if needed.
       if (baseBranchForWorktree && worktreeSetupResolution) {
-        const creation = createWorktreeMutation.mutateAsync({
-          cwd: targetProjectCwdForSend,
-          ref: baseBranchForWorktree,
-          newBranch: buildTemporaryWorktreeBranchName(),
-          ...(baseBranchForWorktree === activeRootBranch
-            ? { copyChangesFrom: targetProjectCwdForSend }
-            : {}),
+        // The server streams each real setup phase (branch → worktree → copy
+        // changes); advance the card's rows from those events instead of
+        // letting one row spin through the whole creation.
+        const worktreeProgressId = randomUUID();
+        const creationFlow = await runWorktreeCreationFlow({
+          progressId: worktreeProgressId,
+          subscribeToProgress: (listener) => api.git.onWorktreeSetupProgress(listener),
+          startCreation: () =>
+            createWorktreeMutation.mutateAsync({
+              cwd: targetProjectCwdForSend,
+              ref: baseBranchForWorktree,
+              newBranch: buildTemporaryWorktreeBranchName(),
+              progressId: worktreeProgressId,
+              ...(worktreeCopiesLocalChanges ? { copyChangesFrom: targetProjectCwdForSend } : {}),
+            }),
+          resolution: worktreeSetupResolution,
+          onCreationStep: (stepId) =>
+            beginLocalDispatch({
+              worktreeSetupStepId: stepId,
+              setupScriptName: worktreeSetupScriptName,
+              copyLocalChanges: worktreeCopiesLocalChanges,
+            }),
+          removeWorktree: (worktreePath) =>
+            api.git.removeWorktree({
+              cwd: targetProjectCwdForSend,
+              path: worktreePath,
+              force: true,
+              reclaimTemporaryBranch: true,
+            }),
         });
-        // `git worktree add` is the longest step; let the card's buttons win
-        // the wait instead of only taking effect once it finishes.
-        await Promise.race([creation, worktreeSetupResolution.promise]);
-        if (worktreeSetupResolution.action !== null) {
-          // The worktree may still be materializing — tear it down whenever
-          // the creation lands so a resolved send leaves no stray checkout.
-          void creation
-            .then((result) =>
-              api.git.removeWorktree({
-                cwd: targetProjectCwdForSend,
-                path: result.worktree.path,
-                force: true,
-                reclaimTemporaryBranch: true,
-              }),
-            )
-            .catch(() => undefined);
+        if (creationFlow.outcome === "resolved") {
           await consumeWorktreeSetupResolution();
         } else {
-          const result = await creation;
+          const result = creationFlow.result;
           beginLocalDispatch({
             worktreeSetupStepId: "prepare-thread",
             setupScriptName: worktreeSetupScriptName,
+            copyLocalChanges: worktreeCopiesLocalChanges,
           });
           nextThreadBranch = result.worktree.branch;
           nextThreadWorktreePath = result.worktree.path;
@@ -8276,6 +8293,7 @@ export default function ChatView({
           beginLocalDispatch({
             worktreeSetupStepId: "run-setup-action",
             setupScriptName: setupScript.name,
+            copyLocalChanges: worktreeCopiesLocalChanges,
           });
           const setupScriptOptions: Parameters<typeof runProjectScript>[1] = {
             worktreePath: nextThreadWorktreePath,
@@ -8328,7 +8346,11 @@ export default function ChatView({
       beginLocalDispatch({
         expectedUserMessageId: messageIdForSend,
         ...(baseBranchForWorktree && !switchedToLocalCheckout
-          ? { worktreeSetupStepId: "start-session", setupScriptName: worktreeSetupScriptName }
+          ? {
+              worktreeSetupStepId: "start-session" as const,
+              setupScriptName: worktreeSetupScriptName,
+              copyLocalChanges: worktreeCopiesLocalChanges,
+            }
           : {}),
       });
       rememberCustomBinaryPathForDispatch({

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -301,7 +301,7 @@ describe("computeStableMessagesTimelineRows", () => {
       kind: "worktree-setup",
       id: "worktree-setup-row",
       open,
-      steps: [{ id: "create-worktree", label: "Creating branch and worktree", status }],
+      steps: [{ id: "create-worktree", label: "Creating worktree", status }],
     });
 
     const first = computeStableMessagesTimelineRows([makeRow("active", true)], emptyStableRows());
@@ -1266,7 +1266,8 @@ describe("deriveMessagesTimelineRows", () => {
 
   const worktreeSetupSnapshot = (): WorktreeSetupSnapshot => ({
     steps: [
-      { id: "create-worktree", label: "Creating branch and worktree", status: "done" },
+      { id: "create-branch", label: "Creating branch", status: "done" },
+      { id: "create-worktree", label: "Creating worktree", status: "done" },
       { id: "prepare-thread", label: "Linking thread workspace", status: "active" },
       { id: "start-session", label: "Starting session", status: "pending" },
     ],

--- a/apps/web/src/components/chat/MessagesTimeline.worktreeSetup.browser.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.worktreeSetup.browser.tsx
@@ -37,7 +37,7 @@ function userEntry(id: string, text: string): TimelineEntries[number] {
 function setupSnapshot(statuses: [WorktreeSetupStepStatus, WorktreeSetupStepStatus]) {
   return {
     steps: [
-      { id: "create-worktree", label: "Creating branch and worktree", status: statuses[0] },
+      { id: "create-branch", label: "Creating branch", status: statuses[0] },
       { id: "prepare-thread", label: "Linking thread workspace", status: statuses[1] },
     ],
   } satisfies WorktreeSetupSnapshot;
@@ -46,7 +46,8 @@ function setupSnapshot(statuses: [WorktreeSetupStepStatus, WorktreeSetupStepStat
 function setupActionSnapshot() {
   return {
     steps: [
-      { id: "create-worktree", label: "Creating branch and worktree", status: "done" },
+      { id: "create-branch", label: "Creating branch", status: "done" },
+      { id: "create-worktree", label: "Creating worktree", status: "done" },
       { id: "prepare-thread", label: "Linking thread workspace", status: "done" },
       { id: "run-setup-action", label: "Running setup action: Setup", status: "active" },
       { id: "start-session", label: "Starting session", status: "pending" },
@@ -157,7 +158,8 @@ function FailedSetupWithoutMessagesTimeline() {
 function startingSessionSnapshot() {
   return {
     steps: [
-      { id: "create-worktree", label: "Creating branch and worktree", status: "done" },
+      { id: "create-branch", label: "Creating branch", status: "done" },
+      { id: "create-worktree", label: "Creating worktree", status: "done" },
       { id: "prepare-thread", label: "Linking thread workspace", status: "done" },
       { id: "start-session", label: "Starting session", status: "active" },
     ],
@@ -217,7 +219,7 @@ describe("MessagesTimeline worktree setup card", () => {
     try {
       await expect.poll(() => setupRow() !== null).toBe(true);
       expect(setupRow()?.textContent).toContain("Preparing worktree...");
-      expect(setupRow()?.textContent).toContain("Creating branch and worktree");
+      expect(setupRow()?.textContent).toContain("Creating branch");
       expect(setupRow()?.querySelector(".shimmer")?.classList).not.toContain("shimmer-once");
       // The generic working shimmer stays suppressed while the card is open.
       expect(workingRow()).toBeNull();
@@ -243,7 +245,7 @@ describe("MessagesTimeline worktree setup card", () => {
     const screen = await render(<FailedSetupWithoutMessagesTimeline />);
 
     try {
-      await expect.poll(() => setupRow()?.textContent).toContain("Creating branch and worktree");
+      await expect.poll(() => setupRow()?.textContent).toContain("Creating branch");
       expect(setupRow()?.textContent).toContain("failed");
       expect(document.body.textContent).not.toContain("Send a message to start the conversation.");
     } finally {

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -695,12 +695,14 @@ export function gitCreateDetachedWorktreeMutationOptions(input: { queryClient: Q
       path,
       copyChangesFrom,
       newBranch,
+      progressId,
     }: {
       cwd: string;
       ref: string;
       path?: string | null;
       copyChangesFrom?: string;
       newBranch?: string;
+      progressId?: string;
     }) => {
       const api = ensureNativeApi();
       if (!cwd) throw new Error("Git worktree creation is unavailable.");
@@ -710,6 +712,7 @@ export function gitCreateDetachedWorktreeMutationOptions(input: { queryClient: Q
         path: path ?? null,
         ...(copyChangesFrom ? { copyChangesFrom } : {}),
         ...(newBranch ? { newBranch } : {}),
+        ...(progressId ? { progressId } : {}),
       });
     },
     mutationKey: ["git", "mutation", "create-detached-worktree"] as const,

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -147,10 +147,12 @@ export interface TurnDiffSummary {
 }
 
 // Ephemeral client-side progress of the "New worktree" first-send setup
-// sequence (create worktree → link thread → start session). Rendered as a
-// transient transcript row; never persisted.
+// sequence (create branch → create worktree → copy changes → link thread →
+// start session). Rendered as a transient transcript row; never persisted.
 export type WorktreeSetupStepId =
+  | "create-branch"
   | "create-worktree"
+  | "copy-changes"
   | "prepare-thread"
   | "run-setup-action"
   | "start-session";

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -348,12 +348,14 @@ describe("wsNativeApi", () => {
     const onTerminalEvent = vi.fn();
     const onDomainEvent = vi.fn();
     const onActionProgress = vi.fn();
+    const onWorktreeSetupProgress = vi.fn();
 
     api.terminal.onEvent(onTerminalEvent);
     expect(channelListeners.has(ORCHESTRATION_WS_CHANNELS.domainEvent)).toBe(false);
     const unsubscribeDomainEvent = api.orchestration.onDomainEvent(onDomainEvent);
     expect(channelListeners.get(ORCHESTRATION_WS_CHANNELS.domainEvent)?.size).toBe(1);
     api.git.onActionProgress(onActionProgress);
+    api.git.onWorktreeSetupProgress(onWorktreeSetupProgress);
 
     const terminalEvent = {
       threadId: "thread-1",
@@ -395,6 +397,11 @@ describe("wsNativeApi", () => {
       phase: "commit",
       label: "Committing...",
     });
+    emitPush(WS_CHANNELS.gitWorktreeSetupProgress, {
+      progressId: "progress-1",
+      kind: "phase_started",
+      phase: "worktree",
+    });
 
     expect(onTerminalEvent).toHaveBeenCalledTimes(1);
     expect(onTerminalEvent).toHaveBeenCalledWith(terminalEvent);
@@ -410,6 +417,12 @@ describe("wsNativeApi", () => {
       kind: "phase_started",
       phase: "commit",
       label: "Committing...",
+    });
+    expect(onWorktreeSetupProgress).toHaveBeenCalledTimes(1);
+    expect(onWorktreeSetupProgress).toHaveBeenCalledWith({
+      progressId: "progress-1",
+      kind: "phase_started",
+      phase: "worktree",
     });
   });
 

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -24,6 +24,7 @@ import {
   type ThreadId,
   type ThreadBrowserState,
   type GitActionProgressEvent,
+  type GitWorktreeSetupProgressEvent,
   type GitHubProjectProvisionProgressEvent,
   type OrchestrationEvent,
   type OrchestrationShellStreamItem,
@@ -129,6 +130,7 @@ const serverProviderStatusesUpdatedListeners =
 const serverMaintenanceUpdatedListeners = createListenerRegistry<ServerLifecycleStreamEvent>();
 const serverSettingsUpdatedListeners = createListenerRegistry<ServerSettingsUpdatedPayload>();
 const gitActionProgressListeners = createListenerRegistry<GitActionProgressEvent>();
+const gitWorktreeSetupProgressListeners = createListenerRegistry<GitWorktreeSetupProgressEvent>();
 const projectProvisionProgressListeners =
   createListenerRegistry<GitHubProjectProvisionProgressEvent>();
 
@@ -165,6 +167,7 @@ function clearWsNativeApiListeners(): void {
   serverMaintenanceUpdatedListeners.clear();
   serverSettingsUpdatedListeners.clear();
   gitActionProgressListeners.clear();
+  gitWorktreeSetupProgressListeners.clear();
   projectProvisionProgressListeners.clear();
   terminalEventListeners.clear();
   projectDevServerEventListeners.clear();
@@ -447,6 +450,9 @@ export function createWsNativeApi(): NativeApi {
   transport.subscribe(WS_CHANNELS.gitActionProgress, (message) => {
     gitActionProgressListeners.emit(message.data);
   });
+  transport.subscribe(WS_CHANNELS.gitWorktreeSetupProgress, (message) => {
+    gitWorktreeSetupProgressListeners.emit(message.data);
+  });
   transport.subscribe(WS_CHANNELS.projectProvisionProgress, (message) => {
     projectProvisionProgressListeners.emit(message.data);
   });
@@ -573,8 +579,12 @@ export function createWsNativeApi(): NativeApi {
         }),
       listBranches: (input) => transport.request(WS_METHODS.gitListBranches, input),
       createWorktree: (input) => transport.request(WS_METHODS.gitCreateWorktree, input),
+      // Worktree materialization scales with checkout size; progress events
+      // keep the UI honest while the stream runs, so no fixed timeout.
       createDetachedWorktree: (input) =>
-        transport.request(WS_METHODS.gitCreateDetachedWorktree, input),
+        transport.request(WS_METHODS.gitCreateDetachedWorktree, input, {
+          timeoutMs: null,
+        }),
       removeWorktree: (input) => transport.request(WS_METHODS.gitRemoveWorktree, input),
       createBranch: (input) => transport.request(WS_METHODS.gitCreateBranch, input),
       checkout: (input) => transport.request(WS_METHODS.gitCheckout, input),
@@ -591,6 +601,7 @@ export function createWsNativeApi(): NativeApi {
       preparePullRequestThread: (input) =>
         transport.request(WS_METHODS.gitPreparePullRequestThread, input),
       onActionProgress: gitActionProgressListeners.subscribe,
+      onWorktreeSetupProgress: gitWorktreeSetupProgressListeners.subscribe,
     },
     pullRequests: {
       list: (input) => transport.request(WS_METHODS.pullRequestsList, input),

--- a/apps/web/src/wsTransport.test.ts
+++ b/apps/web/src/wsTransport.test.ts
@@ -305,6 +305,50 @@ describe("WsTransport", () => {
     expect(emit).toHaveBeenNthCalledWith(2, WS_CHANNELS.projectProvisionProgress, completed);
   });
 
+  it("returns the completed worktree setup result and emits each progress event", async () => {
+    const phase = {
+      progressId: "progress-1",
+      kind: "phase_started" as const,
+      phase: "worktree" as const,
+    };
+    const completed = {
+      progressId: "progress-1",
+      kind: "completed" as const,
+      result: {
+        worktree: {
+          path: "/repo/.codex/worktrees/generated/synara",
+          ref: "0123456789abcdef0123456789abcdef01234567",
+          branch: "synara/abcd1234",
+        },
+      },
+    };
+    const emit = vi.fn();
+    const transport = Object.create(WsTransport.prototype) as WsTransport;
+    Object.assign(transport, {
+      emit,
+      getClientRuntime: () => ({ runPromise: Effect.runPromise }),
+    });
+    const runWorktreeSetupStream = (
+      transport as unknown as {
+        runWorktreeSetupStream: (
+          client: Record<string, () => Stream.Stream<typeof phase | typeof completed>>,
+          params: unknown,
+        ) => Promise<typeof completed.result>;
+      }
+    ).runWorktreeSetupStream.bind(transport);
+
+    await expect(
+      runWorktreeSetupStream(
+        {
+          [WS_METHODS.gitCreateDetachedWorktree]: () => Stream.make(phase, completed),
+        },
+        { cwd: "/repo", ref: "main" },
+      ),
+    ).resolves.toEqual(completed.result);
+    expect(emit).toHaveBeenNthCalledWith(1, WS_CHANNELS.gitWorktreeSetupProgress, phase);
+    expect(emit).toHaveBeenNthCalledWith(2, WS_CHANNELS.gitWorktreeSetupProgress, completed);
+  });
+
   it("does not reconnect the socket for typed stream-admission failures", () => {
     expect(
       shouldReconnectAfterStreamFailure(

--- a/apps/web/src/wsTransport.ts
+++ b/apps/web/src/wsTransport.ts
@@ -24,7 +24,9 @@ import {
   WsFeatureRpcGroup,
   type AutomationStreamEvent,
   type GitActionProgressEvent,
+  type GitCreateDetachedWorktreeResult,
   type GitRunStackedActionResult,
+  type GitWorktreeSetupProgressEvent,
   type GitHubProjectProvisionProgressEvent,
   type GitHubProjectProvisionResult,
   type OrchestrationEvent,
@@ -681,6 +683,9 @@ export class WsTransport {
 
       if (method === WS_METHODS.gitRunStackedAction) {
         return (await this.runGitActionStream(client, params, abortScope.signal)) as T;
+      }
+      if (method === WS_METHODS.gitCreateDetachedWorktree) {
+        return (await this.runWorktreeSetupStream(client, params, abortScope.signal)) as T;
       }
       if (method === WS_METHODS.projectsProvisionFromGitHub) {
         return (await this.runProjectProvisionStream(client, params, abortScope.signal)) as T;
@@ -1635,6 +1640,28 @@ export class WsTransport {
       signal ? { signal } : undefined,
     );
     if (!result) throw new Error("Git action stream completed without a final result.");
+    return result;
+  }
+
+  private async runWorktreeSetupStream(
+    client: RpcClientInstance,
+    params: unknown,
+    signal?: AbortSignal,
+  ): Promise<GitCreateDetachedWorktreeResult> {
+    let result: GitCreateDetachedWorktreeResult | null = null;
+    await this.getClientRuntime(client).runPromise(
+      Stream.runForEach(client[WS_METHODS.gitCreateDetachedWorktree](params as never), (event) =>
+        Effect.sync(() => {
+          const progressEvent = event as GitWorktreeSetupProgressEvent;
+          this.emit(WS_CHANNELS.gitWorktreeSetupProgress, progressEvent);
+          if (progressEvent.kind === "completed") {
+            result = progressEvent.result;
+          }
+        }),
+      ),
+      signal ? { signal } : undefined,
+    );
+    if (!result) throw new Error("Worktree creation completed without a final result.");
     return result;
   }
 

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -208,6 +208,9 @@ export const GitCreateDetachedWorktreeInput = Schema.Struct({
   // When set, the worktree is created on this new branch (pinned at `ref`)
   // instead of a detached HEAD, so threads get a branch attached from birth.
   newBranch: Schema.optional(TrimmedNonEmptyStringSchema),
+  // Caller-chosen correlation id echoed on every setup progress event, so
+  // concurrent creations can be told apart by progress subscribers.
+  progressId: Schema.optional(TrimmedNonEmptyStringSchema),
 });
 export type GitCreateDetachedWorktreeInput = typeof GitCreateDetachedWorktreeInput.Type;
 
@@ -441,6 +444,32 @@ export const GitCreateDetachedWorktreeResult = Schema.Struct({
   worktree: GitDetachedWorktree,
 });
 export type GitCreateDetachedWorktreeResult = typeof GitCreateDetachedWorktreeResult.Type;
+
+// Real phases of detached-worktree creation, in execution order: create the
+// branch, materialize the checkout, then copy local changes (when requested).
+export const GitWorktreeSetupPhase = Schema.Literals(["branch", "worktree", "copy-changes"]);
+export type GitWorktreeSetupPhase = typeof GitWorktreeSetupPhase.Type;
+
+const GitWorktreeSetupProgressBase = Schema.Struct({
+  progressId: Schema.NullOr(TrimmedNonEmptyStringSchema),
+});
+
+const GitWorktreeSetupPhaseStartedEvent = Schema.Struct({
+  ...GitWorktreeSetupProgressBase.fields,
+  kind: Schema.Literal("phase_started"),
+  phase: GitWorktreeSetupPhase,
+});
+const GitWorktreeSetupCompletedEvent = Schema.Struct({
+  ...GitWorktreeSetupProgressBase.fields,
+  kind: Schema.Literal("completed"),
+  result: GitCreateDetachedWorktreeResult,
+});
+
+export const GitWorktreeSetupProgressEvent = Schema.Union([
+  GitWorktreeSetupPhaseStartedEvent,
+  GitWorktreeSetupCompletedEvent,
+]);
+export type GitWorktreeSetupProgressEvent = typeof GitWorktreeSetupProgressEvent.Type;
 
 export const GitStashInfoResult = Schema.Struct({
   cwd: TrimmedNonEmptyStringSchema,

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -42,6 +42,7 @@ import type {
 import type {
   GitCheckoutInput,
   GitActionProgressEvent,
+  GitWorktreeSetupProgressEvent,
   GitCreateBranchInput,
   GitCreateDetachedWorktreeInput,
   GitCreateDetachedWorktreeResult,
@@ -653,6 +654,9 @@ export interface NativeApi {
     summarizeDiff: (input: GitSummarizeDiffInput) => Promise<GitSummarizeDiffResult>;
     runStackedAction: (input: GitRunStackedActionInput) => Promise<GitRunStackedActionResult>;
     onActionProgress: (callback: (event: GitActionProgressEvent) => void) => () => void;
+    onWorktreeSetupProgress: (
+      callback: (event: GitWorktreeSetupProgressEvent) => void,
+    ) => () => void;
   };
   pullRequests: {
     list: (input: PullRequestsListInput) => Promise<PullRequestsListResult>;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -41,7 +41,6 @@ import {
   GitActionProgressEvent,
   GitCreateBranchInput,
   GitCreateDetachedWorktreeInput,
-  GitCreateDetachedWorktreeResult,
   GitCreateWorktreeInput,
   GitCreateWorktreeResult,
   GitHubRepositoryInput,
@@ -76,6 +75,7 @@ import {
   GitSummarizeDiffInput,
   GitSummarizeDiffResult,
   GitUnstageFilesInput,
+  GitWorktreeSetupProgressEvent,
   GitUnstageFilesResult,
 } from "./git";
 import {
@@ -575,10 +575,13 @@ export const WsGitCreateWorktreeRpc = Rpc.make(WS_METHODS.gitCreateWorktree, {
   error: WsRpcError,
 });
 
+// Streams setup phases (branch → worktree → copy-changes) so the UI can show
+// real progress; the terminal `completed` event carries the created worktree.
 export const WsGitCreateDetachedWorktreeRpc = Rpc.make(WS_METHODS.gitCreateDetachedWorktree, {
   payload: GitCreateDetachedWorktreeInput,
-  success: GitCreateDetachedWorktreeResult,
+  success: GitWorktreeSetupProgressEvent,
   error: WsRpcError,
+  stream: true,
 });
 
 export const WsGitRemoveWorktreeRpc = Rpc.make(WS_METHODS.gitRemoveWorktree, {

--- a/packages/contracts/src/ws.test.ts
+++ b/packages/contracts/src/ws.test.ts
@@ -198,6 +198,27 @@ it.effect("accepts git.actionProgress push envelopes", () =>
   }),
 );
 
+it.effect("accepts git.worktreeSetupProgress push envelopes", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decode(WsResponse, {
+      type: "push",
+      sequence: 5,
+      channel: WS_CHANNELS.gitWorktreeSetupProgress,
+      data: {
+        progressId: "progress-1",
+        kind: "phase_started",
+        phase: "branch",
+      },
+    });
+
+    if (!("type" in parsed) || parsed.type !== "push") {
+      assert.fail("expected websocket response to decode as a push envelope");
+    }
+
+    assert.strictEqual(parsed.channel, WS_CHANNELS.gitWorktreeSetupProgress);
+  }),
+);
+
 it.effect("accepts automation.event push envelopes", () =>
   Effect.gen(function* () {
     const parsed = yield* decode(WsResponse, {

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -59,6 +59,7 @@ import {
   GitStatusInput,
   GitSummarizeDiffInput,
   GitUnstageFilesInput,
+  GitWorktreeSetupProgressEvent,
 } from "./git";
 import {
   TerminalAckOutputInput,
@@ -266,6 +267,7 @@ export const WS_METHODS = {
 export const WS_CHANNELS = {
   automationEvent: "automation.event",
   gitActionProgress: "git.actionProgress",
+  gitWorktreeSetupProgress: "git.worktreeSetupProgress",
   projectProvisionProgress: "project.provisionProgress",
   terminalEvent: "terminal.event",
   projectDevServerEvent: "project.devServerEvent",
@@ -473,6 +475,7 @@ export interface WsPushPayloadByChannel {
   readonly [WS_CHANNELS.serverSettingsUpdated]: typeof ServerSettingsUpdatedPayload.Type;
   readonly [WS_CHANNELS.automationEvent]: typeof AutomationStreamEvent.Type;
   readonly [WS_CHANNELS.gitActionProgress]: typeof GitActionProgressEvent.Type;
+  readonly [WS_CHANNELS.gitWorktreeSetupProgress]: typeof GitWorktreeSetupProgressEvent.Type;
   readonly [WS_CHANNELS.projectProvisionProgress]: typeof GitHubProjectProvisionProgressEvent.Type;
   readonly [WS_CHANNELS.terminalEvent]: typeof TerminalEvent.Type;
   readonly [WS_CHANNELS.projectDevServerEvent]: typeof ProjectDevServerEvent.Type;
@@ -520,6 +523,10 @@ export const WsPushGitActionProgress = makeWsPushSchema(
   WS_CHANNELS.gitActionProgress,
   GitActionProgressEvent,
 );
+export const WsPushGitWorktreeSetupProgress = makeWsPushSchema(
+  WS_CHANNELS.gitWorktreeSetupProgress,
+  GitWorktreeSetupProgressEvent,
+);
 export const WsPushProjectProvisionProgress = makeWsPushSchema(
   WS_CHANNELS.projectProvisionProgress,
   GitHubProjectProvisionProgressEvent,
@@ -544,6 +551,7 @@ export const WsPushOrchestrationThreadEvent = makeWsPushSchema(
 
 export const WsPushChannelSchema = Schema.Literals([
   WS_CHANNELS.gitActionProgress,
+  WS_CHANNELS.gitWorktreeSetupProgress,
   WS_CHANNELS.projectProvisionProgress,
   WS_CHANNELS.serverWelcome,
   WS_CHANNELS.serverMaintenanceUpdated,
@@ -567,6 +575,7 @@ export const WsPush = Schema.Union([
   WsPushServerSettingsUpdated,
   WsPushAutomationEvent,
   WsPushGitActionProgress,
+  WsPushGitWorktreeSetupProgress,
   WsPushProjectProvisionProgress,
   WsPushTerminalEvent,
   WsPushProjectDevServerEvent,

--- a/packages/contracts/src/wsCompatibility.ts
+++ b/packages/contracts/src/wsCompatibility.ts
@@ -42,6 +42,11 @@ export const WS_CLIENT_REQUIRED_CAPABILITIES = [
   "orchestration.cursor-safe-streams",
   "orchestration.thread-detail-snapshot",
   "rpc.typed-errors",
+  // git.createDetachedWorktree is a streaming RPC on this client; an older
+  // server would answer it unary and the worktree-setup card would never
+  // advance, so require the capability and fail negotiation with a clear
+  // "update-server" instead.
+  "git.worktree-setup-progress",
 ] as const;
 
 export const WS_SERVER_CAPABILITIES = [


### PR DESCRIPTION
## What Changed

- Split detached worktree creation into explicit `branch`, `worktree`, and `copy-changes` phases and streamed those phases over WS RPC.
- Updated the chat/worktree setup UI to show the new step boundaries and handle late-resolution cleanup correctly.
- Simplified keybinding upserts to replace by command only, and removed the extra commit-and-push defaults.
- Tightened a few provider/runtime parsing paths and trimmed stale special-case logic and tests.

## Why

- Worktree creation was previously a single opaque step, which made progress UI less accurate and harder to recover cleanly when races occurred.
- Streaming the real command boundaries gives the UI better feedback and makes failure handling more predictable.
- The keybinding and provider cleanup removes brittle special cases that were adding complexity without enough value.

## UI Changes

- Worktree setup now shows separate branch, worktree, and copy steps instead of one combined creation step.
- The setup card can now reflect progress more precisely during long-running worktree creation.

## Verification

- Updated and expanded unit tests for Git worktree setup, worktree progress flow, keybinding behavior, and WS transport/API wiring.
- Covered rollback behavior when worktree creation fails after branch creation.
- Covered UI snapshot transitions for the new multi-phase setup flow.

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Git worktree/branch orchestration and a breaking WS RPC shape for detached worktree creation; rollout depends on the new capability gate, but rollback and tests reduce leftover-branch risk.
> 
> **Overview**
> **Detached worktree creation** is split into real Git boundaries—**branch**, **worktree**, and optional **copy-changes**—with an optional `onPhase` callback on `createDetachedWorktree`. Branch creation runs before `git worktree add` (using a pre-created branch instead of `worktree add -b`), and a failed worktree add rolls back the temporary branch.
> 
> **`git.createDetachedWorktree`** is now a **streaming WS RPC** (`GitWorktreeSetupProgressEvent` on `git.worktreeSetupProgress`), with optional `progressId` for correlation. Clients must negotiate **`git.worktree-setup-progress`** or fail connect with a clear upgrade path.
> 
> The **New worktree** setup card shows separate steps (branch / worktree / copy changes) driven by streamed phases via **`runWorktreeCreationFlow`**, which races user Cancel / Work locally against creation and removes a late-created worktree if the user resolved first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e99d1b5f33e8921a4edbd4149cce27b127c4349b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->