### PR TITLE
Polish PR dialog and project picker

### DIFF
--- a/apps/web/src/components/GitCreatePrDialog.tsx
+++ b/apps/web/src/components/GitCreatePrDialog.tsx
@@ -14,7 +14,7 @@ import {
   DialogPopup,
   DialogTitle,
 } from "~/components/ui/dialog";
-import { ShortcutKbd } from "~/components/ui/shortcut-kbd";
+import { Kbd } from "~/components/ui/kbd";
 import {
   type CreatePrBrowserPreparation,
   type CreatePrDialogContext,
@@ -22,6 +22,7 @@ import {
   resolveCreatePrDialogExecution,
   resolveCreatePrDialogView,
 } from "./GitActionsControl.logic";
+import { ArrowUpRightIcon, GitPullRequestDraftIcon, GitPullRequestIcon } from "~/lib/icons";
 import { cn, isMacPlatform } from "~/lib/utils";
 
 export interface GitCreatePrDialogSubmission {
@@ -49,12 +50,14 @@ function CreatePrActionRow({
   highlighted,
   disabled,
   onClick,
+  icon,
   label,
   trailing,
 }: {
   highlighted?: boolean;
   disabled?: boolean;
   onClick: () => void;
+  icon: React.ReactNode;
   label: string;
   trailing?: React.ReactNode;
 }) {
@@ -64,13 +67,14 @@ function CreatePrActionRow({
       disabled={disabled}
       onClick={onClick}
       className={cn(
-        "flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-sm outline-none transition-colors",
+        "flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-sm outline-none transition-colors",
         "hover:bg-[var(--color-background-button-secondary-hover)] focus-visible:bg-[var(--color-background-button-secondary-hover)]",
         highlighted && "bg-[var(--color-background-button-secondary-hover)]",
         disabled && "pointer-events-none opacity-50",
       )}
     >
-      <span className="truncate">{label}</span>
+      <span className="shrink-0 text-muted-foreground [&_svg]:size-4">{icon}</span>
+      <span className="flex-1 truncate">{label}</span>
       {trailing}
     </button>
   );
@@ -152,7 +156,7 @@ export function GitCreatePrDialog({
           <input
             autoFocus
             aria-label="Pull request title"
-            className="w-full bg-transparent py-1 font-medium text-sm outline-none placeholder:text-muted-foreground/70"
+            className="w-full bg-transparent py-1 font-system-ui text-sm outline-none placeholder:text-muted-foreground/70"
             maxLength={300}
             placeholder="Title (leave empty to generate)"
             value={title}
@@ -160,7 +164,7 @@ export function GitCreatePrDialog({
           />
           <textarea
             aria-label="Pull request description"
-            className="w-full resize-none bg-transparent py-1 text-sm outline-none placeholder:text-muted-foreground/70"
+            className="w-full resize-none bg-transparent py-1 font-system-ui text-sm outline-none placeholder:text-muted-foreground/70"
             maxLength={60_000}
             placeholder="Description (leave empty to generate)"
             rows={2}
@@ -185,18 +189,21 @@ export function GitCreatePrDialog({
         <div className="border-[color:var(--color-border)] border-t p-2">
           <CreatePrActionRow
             disabled={!canCreate}
+            icon={<GitPullRequestDraftIcon />}
             label="Create draft PR"
             onClick={() => submit(true)}
           />
           <CreatePrActionRow
             highlighted
             disabled={!canCreate}
+            icon={<GitPullRequestIcon />}
             label="Create PR"
-            trailing={<ShortcutKbd shortcutLabel={isMac ? "⌘↵" : "Ctrl+↵"} />}
+            trailing={<Kbd>{isMac ? "⌘↵" : "Ctrl ↵"}</Kbd>}
             onClick={() => submit(false)}
           />
           <CreatePrActionRow
             disabled={!canOpenInBrowser}
+            icon={<ArrowUpRightIcon />}
             label="Open PR in browser"
             onClick={() =>
               onOpenInBrowser({ preparation: browserPreparation, includeLocalChanges })


### PR DESCRIPTION
## What Changed

- Refined the PR creation dialog action rows with icons, tighter spacing, and clearer keyboard affordances.
- Switched the PR title and description fields to the system UI font for better visual consistency.
- Simplified the picker panel shell to own its search input directly instead of accepting a custom search element.
- Updated the project picker to use the shared shell search field.
- Removed an obsolete keyboard-focus test tied to the old project picker behavior.

## Why

- The PR dialog actions needed clearer visual hierarchy and a more polished affordance for the three available actions.
- The picker shell was carrying extra flexibility that was no longer needed, which made the component harder to reason about.
- Consolidating the search UI into the shell reduces duplication and keeps picker behavior more predictable.

## UI Changes

- PR dialog action rows now include icons and a denser layout.
- The primary PR action now shows a keyboard hint in the shared `Kbd` style.
- Project picker search is rendered by the shared shell input rather than a custom combobox input.

## Verification

- Not run (not requested).

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes in the PR dialog; no changes to submit, browser-open, or git action logic.
> 
> **Overview**
> **Polishes the Create PR dialog** with clearer action rows and typography aligned to the rest of the app.
> 
> `CreatePrActionRow` now takes a leading **icon** and uses tighter padding (`px-2.5 py-1.5`, `gap-2.5`). Draft PR, Create PR, and Open in browser each show **draft**, **PR**, and **external-link** icons. The primary **Create PR** shortcut hint switches from `ShortcutKbd` to the shared **`Kbd`** component (Windows label becomes `Ctrl ↵` instead of `Ctrl+↵`).
> 
> PR **title** and **description** inputs drop `font-medium` on the title field and use **`font-system-ui`** on both fields for consistency with other UI chrome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aacfa6016f5cb7e67cab1b5aa6da83c65e976012. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->