### PR TITLE
fix: harden warm model discovery

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -141,11 +141,7 @@ import {
   pullRequestQueryKeys,
   pullRequestReviewRequestCountQueryOptions,
 } from "../lib/pullRequestReactQuery";
-import {
-  prefetchProviderModelsForNewThread,
-  resolveNewThreadModelPrefetchCwd,
-  resolveNewThreadModelPrefetchProvider,
-} from "../lib/providerModelPrefetch";
+import { prefetchModelsForNewThread } from "../lib/providerModelPrefetch";
 import { serverConfigQueryOptions, serverSettingsQueryOptions } from "../lib/serverReactQuery";
 import {
   onNativeApiServerCapabilitiesChange,
@@ -1406,7 +1402,7 @@ export default function Sidebar() {
     () => groupAutomationsByContinuedThread(automationListQuery.data?.definitions ?? []),
     [automationListQuery.data],
   );
-  const { settings: appSettings, updateSettings } = useAppSettings();
+  const { settings: appSettings, serverSettings, updateSettings } = useAppSettings();
   // Projects is always available; Studio and the standalone Chats footer can be hidden
   // independently from Settings.
   const chatsSectionVisible = appSettings.showChatsSection;
@@ -2637,30 +2633,20 @@ export default function Sidebar() {
       const draftComposer = draftThread
         ? (draftStore.draftsByThreadId[draftThread.threadId] ?? null)
         : null;
-      const provider = resolveNewThreadModelPrefetchProvider({
+      prefetchModelsForNewThread(queryClient, {
+        settings: appSettings,
+        serverSettings: serverSettings ?? null,
+        hiddenProviders: appSettings.hiddenProviders,
         draftActiveProvider: draftComposer?.activeProvider ?? null,
         stickyActiveProvider: draftStore.stickyActiveProvider,
         projectDefaultProvider: project.defaultModelSelection?.provider ?? null,
-        defaultProvider: appSettings.defaultProvider,
-      });
-      // Droid discovery spins a disposable ACP session per model — only warm it
-      // from explicit new-thread intent (hover/click), not idle project focus.
-      if (provider === "droid" && options?.includeDroid !== true) {
-        return;
-      }
-      const cwd = resolveNewThreadModelPrefetchCwd({
-        draftWorktreePath: draftThread?.worktreePath ?? null,
         projectCwd: project.cwd,
+        draftWorktreePath: draftThread?.worktreePath ?? null,
         serverCwd,
-      });
-
-      prefetchProviderModelsForNewThread(queryClient, {
-        provider,
-        settings: appSettings,
-        cwd,
+        includeDroid: options?.includeDroid === true,
       });
     },
-    [appSettings, projects, queryClient, serverCwd],
+    [appSettings, projects, queryClient, serverCwd, serverSettings],
   );
 
   const prefetchModelsForPrimaryNewThread = useCallback(() => {
@@ -4902,10 +4888,10 @@ export default function Sidebar() {
                 tooltipSide="top"
                 data-testid="new-thread-button"
                 onMouseEnter={() => {
-                  prefetchModelsForProjectNewThread(project.id, { includeDroid: true });
+                  prefetchModelsForProjectNewThread(project.id);
                 }}
                 onFocus={() => {
-                  prefetchModelsForProjectNewThread(project.id, { includeDroid: true });
+                  prefetchModelsForProjectNewThread(project.id);
                 }}
                 onClick={(event) => {
                   event.preventDefault();

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -142,7 +142,11 @@ import {
   pullRequestReviewRequestCountQueryOptions,
 } from "../lib/pullRequestReactQuery";
 import { prefetchModelsForNewThread } from "../lib/providerModelPrefetch";
-import { serverConfigQueryOptions, serverSettingsQueryOptions } from "../lib/serverReactQuery";
+import {
+  hasReconciledServerProviderStatuses,
+  serverConfigQueryOptions,
+  serverSettingsQueryOptions,
+} from "../lib/serverReactQuery";
 import {
   onNativeApiServerCapabilitiesChange,
   readNativeApi,
@@ -2643,17 +2647,28 @@ export default function Sidebar() {
         projectCwd: project.cwd,
         draftWorktreePath: draftThread?.worktreePath ?? null,
         serverCwd,
+        // Hover-time warm must resolve the same envMode the click will pass so the
+        // warmed cwd keys match the thread ChatView actually mounts (local mode
+        // clears the draft worktree; worktree mode keeps it).
+        envMode: resolveSidebarNewThreadEnvMode({
+          defaultEnvMode: appSettings.defaultThreadEnvMode,
+        }),
+        providerStatuses,
+        statusesReconciled: hasReconciledServerProviderStatuses(queryClient),
+        providerOrder: appSettings.providerOrder,
         includeDroid: options?.includeDroid === true,
       });
     },
-    [appSettings, projects, queryClient, serverCwd, serverSettings],
+    [appSettings, projects, providerStatuses, queryClient, serverCwd, serverSettings],
   );
 
   const prefetchModelsForPrimaryNewThread = useCallback(() => {
     if (!primaryNewThreadTarget) {
       return;
     }
-    prefetchModelsForProjectNewThread(primaryNewThreadTarget.projectId, { includeDroid: true });
+    // Idle hover/focus must not spin Droid's expensive per-model ACP discovery;
+    // only explicit new-thread intent (the click path below) warms Droid.
+    prefetchModelsForProjectNewThread(primaryNewThreadTarget.projectId);
   }, [prefetchModelsForProjectNewThread, primaryNewThreadTarget]);
 
   useEffect(() => {

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -5,7 +5,11 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { startTransition } from "react";
 import { useAppSettings } from "../appSettings";
 import { prefetchModelsForNewThread } from "../lib/providerModelPrefetch";
-import { serverConfigQueryOptions } from "../lib/serverReactQuery";
+import { useProviderStatusesForLocalConfig } from "../hooks/useProviderStatusesForLocalConfig";
+import {
+  hasReconciledServerProviderStatuses,
+  serverConfigQueryOptions,
+} from "../lib/serverReactQuery";
 import {
   type ComposerThreadDraftState,
   type DraftThreadState,
@@ -48,6 +52,8 @@ export function useHandleNewThread() {
   const queryClient = useQueryClient();
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
   const serverCwd = serverConfigQuery.data?.cwd ?? null;
+  const providerStatuses = useProviderStatusesForLocalConfig();
+  const providerStatusesReconciled = hasReconciledServerProviderStatuses(queryClient);
   const navigate = useNavigate();
   const router = useRouter();
   const { activeDraftThread, activeProjectId, activeThread, focusedThreadId, routeThreadId } =
@@ -82,7 +88,14 @@ export function useHandleNewThread() {
         projectDefaultProvider: project?.defaultModelSelection?.provider ?? null,
         projectCwd: project?.cwd ?? null,
         draftWorktreePath: draftThread?.worktreePath ?? null,
+        worktreePath: options?.worktreePath ?? null,
+        hasExplicitWorktreePath: options?.worktreePath !== undefined,
+        fresh: options?.fresh === true,
+        envMode: options?.envMode ?? null,
         serverCwd,
+        providerStatuses,
+        statusesReconciled: providerStatusesReconciled,
+        providerOrder: settings.providerOrder,
         includeDroid: true,
       });
     }

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -1,8 +1,11 @@
 import { type ProjectId, ThreadId } from "@synara/contracts";
 import { getDefaultModel } from "@synara/shared/model";
 import { useNavigate, useRouter } from "@tanstack/react-router";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { startTransition } from "react";
 import { useAppSettings } from "../appSettings";
+import { prefetchModelsForNewThread } from "../lib/providerModelPrefetch";
+import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 import {
   type ComposerThreadDraftState,
   type DraftThreadState,
@@ -41,7 +44,10 @@ export interface NewThreadNavigationOptions {
 
 export function useHandleNewThread() {
   const projects = useStore((store) => store.projects);
-  const { settings } = useAppSettings();
+  const { settings, serverSettings } = useAppSettings();
+  const queryClient = useQueryClient();
+  const serverConfigQuery = useQuery(serverConfigQueryOptions());
+  const serverCwd = serverConfigQuery.data?.cwd ?? null;
   const navigate = useNavigate();
   const router = useRouter();
   const { activeDraftThread, activeProjectId, activeThread, focusedThreadId, routeThreadId } =
@@ -58,6 +64,28 @@ export function useHandleNewThread() {
     navigation?: NewThreadNavigationOptions,
   ): Promise<ThreadId | null> => {
     const entryPoint = options?.entryPoint ?? "chat";
+    if (entryPoint === "chat") {
+      const draftStore = useComposerDraftStore.getState();
+      const draftThread = draftStore.getDraftThreadByProjectId(projectId, "chat");
+      const draftComposer = draftThread
+        ? (draftStore.draftsByThreadId[draftThread.threadId] ?? null)
+        : null;
+      const project = useStore.getState().projects.find((candidate) => candidate.id === projectId);
+
+      prefetchModelsForNewThread(queryClient, {
+        settings,
+        serverSettings: serverSettings ?? null,
+        hiddenProviders: settings.hiddenProviders,
+        providerOverride: options?.provider ?? null,
+        draftActiveProvider: draftComposer?.activeProvider ?? null,
+        stickyActiveProvider: draftStore.stickyActiveProvider,
+        projectDefaultProvider: project?.defaultModelSelection?.provider ?? null,
+        projectCwd: project?.cwd ?? null,
+        draftWorktreePath: draftThread?.worktreePath ?? null,
+        serverCwd,
+        includeDroid: true,
+      });
+    }
     const wantsTemporaryThread = options?.temporary === true;
     const applyProviderOverride = (threadId: ThreadId) => {
       if (!options?.provider) {

--- a/apps/web/src/lib/providerModelPrefetch.test.ts
+++ b/apps/web/src/lib/providerModelPrefetch.test.ts
@@ -4,12 +4,13 @@
 //          and gates Droid to explicit intent.
 // Layer: Web lib tests
 
-import { DEFAULT_SERVER_SETTINGS, type ProviderKind } from "@synara/contracts";
+import { DEFAULT_SERVER_SETTINGS } from "@synara/contracts";
 import { QueryClient } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   prefetchModelsForNewThread,
+  prefetchProviderModelsForNewThread,
   providerModelsPrefetchQueryOptions,
   resolveNewThreadModelPrefetchCwd,
   resolveNewThreadModelPrefetchProvider,
@@ -238,10 +239,9 @@ describe("prefetchModelsForNewThread", () => {
     const queryClient = new QueryClient();
     const prefetchQuery = vi.spyOn(queryClient, "prefetchQuery").mockResolvedValue(undefined);
 
-    const { prefetchProviderModelsForNewThread } = await import("./providerModelPrefetch");
     prefetchProviderModelsForNewThread(queryClient, {
       settings: makeSettings(),
-      providers: ["codex", "droid" as ProviderKind],
+      providers: ["codex", "droid"],
     });
 
     const modelKeys = prefetchQuery.mock.calls

--- a/apps/web/src/lib/providerModelPrefetch.test.ts
+++ b/apps/web/src/lib/providerModelPrefetch.test.ts
@@ -1,14 +1,15 @@
 // FILE: providerModelPrefetch.test.ts
-// Purpose: Verifies new-thread model prefetch resolves providers/cwds and hits
-//          the same React Query keys ChatView uses for listModels.
+// Purpose: Verifies new-thread model prefetch resolves providers/cwds, hits the
+//          same React Query keys ChatView uses, warms every visible provider,
+//          and gates Droid to explicit intent.
 // Layer: Web lib tests
 
-import type { ProviderKind } from "@synara/contracts";
+import { DEFAULT_SERVER_SETTINGS, type ProviderKind } from "@synara/contracts";
 import { QueryClient } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
-  prefetchProviderModelsForNewThread,
+  prefetchModelsForNewThread,
   providerModelsPrefetchQueryOptions,
   resolveNewThreadModelPrefetchCwd,
   resolveNewThreadModelPrefetchProvider,
@@ -25,6 +26,7 @@ function makeSettings(
 ): ProviderModelPrefetchSettings {
   return {
     defaultProvider: "codex",
+    claudeBinaryPath: "",
     cursorBinaryPath: "",
     cursorApiEndpoint: "",
     antigravityBinaryPath: "",
@@ -39,7 +41,17 @@ function makeSettings(
 }
 
 describe("resolveNewThreadModelPrefetchProvider", () => {
-  it("prefers draft, then sticky, then project default, then app default", () => {
+  it("prefers override, draft, sticky, project default, then app default", () => {
+    expect(
+      resolveNewThreadModelPrefetchProvider({
+        providerOverride: "grok",
+        draftActiveProvider: "cursor",
+        stickyActiveProvider: "pi",
+        projectDefaultProvider: "opencode",
+        defaultProvider: "codex",
+      }),
+    ).toBe("grok");
+
     expect(
       resolveNewThreadModelPrefetchProvider({
         draftActiveProvider: "cursor",
@@ -48,15 +60,6 @@ describe("resolveNewThreadModelPrefetchProvider", () => {
         defaultProvider: "codex",
       }),
     ).toBe("cursor");
-
-    expect(
-      resolveNewThreadModelPrefetchProvider({
-        draftActiveProvider: null,
-        stickyActiveProvider: "pi",
-        projectDefaultProvider: "opencode",
-        defaultProvider: "codex",
-      }),
-    ).toBe("pi");
 
     expect(
       resolveNewThreadModelPrefetchProvider({
@@ -105,6 +108,7 @@ describe("resolveNewThreadModelPrefetchCwd", () => {
 describe("providerModelsPrefetchQueryOptions", () => {
   it("matches ChatView cache keys for cwd-scoped and binary-scoped providers", () => {
     const settings = makeSettings({
+      claudeBinaryPath: "/bin/claude",
       cursorBinaryPath: "/bin/agent",
       cursorApiEndpoint: "https://api.example",
       antigravityBinaryPath: "/bin/antigravity",
@@ -113,97 +117,139 @@ describe("providerModelsPrefetchQueryOptions", () => {
       piAgentDir: "/tmp/pi-agent",
     });
 
-    const cursorOptions = providerModelsPrefetchQueryOptions({
-      provider: "cursor",
-      settings,
-    });
-    expect(cursorOptions.queryKey).toEqual(
+    expect(
+      providerModelsPrefetchQueryOptions({ provider: "claudeAgent", settings }).queryKey,
+    ).toEqual(providerDiscoveryQueryKeys.models("claudeAgent", "/bin/claude", null, null, null));
+
+    expect(providerModelsPrefetchQueryOptions({ provider: "cursor", settings }).queryKey).toEqual(
       providerDiscoveryQueryKeys.models("cursor", "/bin/agent", "https://api.example", null, null),
     );
 
-    const openCodeOptions = providerModelsPrefetchQueryOptions({
-      provider: "opencode",
-      settings,
-      cwd: "/tmp/project",
-    });
-    expect(openCodeOptions.queryKey).toEqual(
+    expect(
+      providerModelsPrefetchQueryOptions({ provider: "opencode", settings, cwd: "/tmp/project" })
+        .queryKey,
+    ).toEqual(
       providerDiscoveryQueryKeys.models("opencode", "/bin/opencode", null, null, "/tmp/project"),
     );
 
-    const piOptions = providerModelsPrefetchQueryOptions({
-      provider: "pi",
-      settings,
-      cwd: "/tmp/project",
-    });
-    expect(piOptions.queryKey).toEqual(
+    expect(
+      providerModelsPrefetchQueryOptions({ provider: "pi", settings, cwd: "/tmp/project" })
+        .queryKey,
+    ).toEqual(
       providerDiscoveryQueryKeys.models("pi", "/bin/pi", null, "/tmp/pi-agent", "/tmp/project"),
     );
 
-    const antigravityOptions = providerModelsPrefetchQueryOptions({
-      provider: "antigravity",
-      settings,
-      cwd: "/tmp/project",
-    });
-    expect(antigravityOptions.queryKey).toEqual(
-      providerDiscoveryQueryKeys.models(
-        "antigravity",
-        "/bin/antigravity",
-        null,
-        null,
-        "/tmp/project",
-      ),
-    );
-
-    const codexOptions = providerModelsPrefetchQueryOptions({
-      provider: "codex",
-      settings,
-    });
-    expect(codexOptions.queryKey).toEqual(
+    expect(providerModelsPrefetchQueryOptions({ provider: "codex", settings }).queryKey).toEqual(
       providerDiscoveryQueryKeys.models("codex", null, null, null, null),
     );
   });
 });
 
-describe("prefetchProviderModelsForNewThread", () => {
-  it("prefetches models and agents for the resolved provider", async () => {
+describe("prefetchModelsForNewThread", () => {
+  it("warms every provider except Droid, selected provider first", async () => {
     const queryClient = new QueryClient();
     const prefetchQuery = vi.spyOn(queryClient, "prefetchQuery").mockResolvedValue(undefined);
 
-    prefetchProviderModelsForNewThread(queryClient, {
-      provider: "kilo" satisfies ProviderKind,
-      settings: makeSettings({
-        kiloBinaryPath: "/bin/kilo",
-      }),
-      cwd: "/tmp/project",
+    prefetchModelsForNewThread(queryClient, {
+      settings: makeSettings(),
+      projectCwd: "/tmp/project",
+      projectDefaultProvider: "opencode",
     });
 
-    expect(prefetchQuery).toHaveBeenCalledTimes(3);
-    expect(prefetchQuery.mock.calls[0]?.[0].queryKey).toEqual(
-      providerDiscoveryQueryKeys.models("kilo", "/bin/kilo", null, null, "/tmp/project"),
+    const modelKeys = prefetchQuery.mock.calls
+      .map((call) => call[0].queryKey)
+      .filter((key) => key[0] === "provider-discovery" && key[1] === "models");
+    expect(modelKeys[0]).toEqual(
+      providerDiscoveryQueryKeys.models("opencode", null, null, null, "/tmp/project"),
     );
-    expect(prefetchQuery.mock.calls[1]?.[0].queryKey).toEqual(
-      providerDiscoveryQueryKeys.agents("kilo", "/bin/kilo", "/tmp/project"),
+    // Warm results stay fresh for 30 minutes, so repeated hovers do not re-probe.
+    expect(prefetchQuery.mock.calls[0]?.[0].staleTime).toBe(30 * 60_000);
+    expect(modelKeys).toHaveLength(8);
+    expect(modelKeys).not.toContainEqual(
+      providerDiscoveryQueryKeys.models("droid", null, null, null, "/tmp/project"),
     );
-    expect(prefetchQuery.mock.calls[2]?.[0].queryKey).toEqual(
-      providerDiscoveryQueryKeys.composerCapabilities("kilo"),
+    expect(modelKeys).toContainEqual(
+      providerDiscoveryQueryKeys.models("claudeAgent", null, null, null, null),
     );
   });
 
-  it("prefetches only models for providers without agent discovery", async () => {
+  it("skips hidden and disabled providers", async () => {
     const queryClient = new QueryClient();
     const prefetchQuery = vi.spyOn(queryClient, "prefetchQuery").mockResolvedValue(undefined);
 
-    prefetchProviderModelsForNewThread(queryClient, {
-      provider: "cursor",
-      settings: makeSettings({ cursorBinaryPath: "/bin/agent" }),
+    prefetchModelsForNewThread(queryClient, {
+      settings: makeSettings(),
+      serverSettings: {
+        ...DEFAULT_SERVER_SETTINGS,
+        providers: {
+          ...DEFAULT_SERVER_SETTINGS.providers,
+          cursor: { ...DEFAULT_SERVER_SETTINGS.providers.cursor, enabled: false },
+        },
+      },
+      hiddenProviders: ["pi"],
+      projectCwd: "/tmp/project",
     });
 
-    expect(prefetchQuery).toHaveBeenCalledTimes(2);
-    expect(prefetchQuery.mock.calls[0]?.[0].queryKey).toEqual(
-      providerDiscoveryQueryKeys.models("cursor", "/bin/agent", null, null, null),
+    const modelKeys = prefetchQuery.mock.calls
+      .map((call) => call[0].queryKey)
+      .filter((key) => key[0] === "provider-discovery" && key[1] === "models");
+    expect(modelKeys).toHaveLength(6);
+    expect(modelKeys).not.toContainEqual(
+      providerDiscoveryQueryKeys.models("cursor", null, null, null, "/tmp/project"),
     );
-    expect(prefetchQuery.mock.calls[1]?.[0].queryKey).toEqual(
-      providerDiscoveryQueryKeys.composerCapabilities("cursor"),
+    expect(modelKeys).not.toContainEqual(
+      providerDiscoveryQueryKeys.models("pi", null, null, null, "/tmp/project"),
+    );
+  });
+
+  it("warms Droid only on explicit intent with Droid selected", async () => {
+    const queryClient = new QueryClient();
+    const prefetchQuery = vi.spyOn(queryClient, "prefetchQuery").mockResolvedValue(undefined);
+
+    prefetchModelsForNewThread(queryClient, {
+      settings: makeSettings(),
+      providerOverride: "droid",
+      projectCwd: "/tmp/project",
+    });
+
+    const modelKeys = prefetchQuery.mock.calls
+      .map((call) => call[0].queryKey)
+      .filter((key) => key[0] === "provider-discovery" && key[1] === "models");
+    expect(modelKeys).not.toContainEqual(
+      providerDiscoveryQueryKeys.models("droid", null, null, null, "/tmp/project"),
+    );
+
+    prefetchModelsForNewThread(queryClient, {
+      settings: makeSettings(),
+      providerOverride: "droid",
+      projectCwd: "/tmp/project",
+      includeDroid: true,
+    });
+
+    const modelKeys2 = prefetchQuery.mock.calls
+      .map((call) => call[0].queryKey)
+      .filter((key) => key[0] === "provider-discovery" && key[1] === "models");
+    expect(modelKeys2).toContainEqual(
+      providerDiscoveryQueryKeys.models("droid", null, null, null, "/tmp/project"),
+    );
+  });
+
+  it("warms the explicit providers subset without Droid", async () => {
+    const queryClient = new QueryClient();
+    const prefetchQuery = vi.spyOn(queryClient, "prefetchQuery").mockResolvedValue(undefined);
+
+    const { prefetchProviderModelsForNewThread } = await import("./providerModelPrefetch");
+    prefetchProviderModelsForNewThread(queryClient, {
+      settings: makeSettings(),
+      providers: ["codex", "droid" as ProviderKind],
+    });
+
+    const modelKeys = prefetchQuery.mock.calls
+      .map((call) => call[0].queryKey)
+      .filter((key) => key[0] === "provider-discovery" && key[1] === "models");
+    expect(modelKeys).toHaveLength(1);
+    expect(modelKeys[0]).toEqual(
+      providerDiscoveryQueryKeys.models("codex", null, null, null, null),
     );
   });
 });

--- a/apps/web/src/lib/providerModelPrefetch.test.ts
+++ b/apps/web/src/lib/providerModelPrefetch.test.ts
@@ -5,10 +5,13 @@
 // Layer: Web lib tests
 
 import { DEFAULT_SERVER_SETTINGS } from "@synara/contracts";
+import type { ProviderKind, ServerProviderStatus } from "@synara/contracts";
 import { QueryClient } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  NEW_THREAD_MODEL_PREFETCH_PROVIDERS,
+  NEW_THREAD_MODEL_PREFETCH_STALE_TIME_MS,
   prefetchModelsForNewThread,
   prefetchProviderModelsForNewThread,
   providerModelsPrefetchQueryOptions,
@@ -39,6 +42,29 @@ function makeSettings(
     piAgentDir: "",
     ...overrides,
   };
+}
+
+function makeStatus(provider: ProviderKind, available: boolean): ServerProviderStatus {
+  return {
+    provider,
+    available,
+    status: available ? "ready" : "error",
+    authStatus: "authenticated",
+    checkedAt: "2026-08-13T10:00:00.000Z",
+    message: available ? undefined : `${provider} is not installed on this machine.`,
+  };
+}
+
+function availableStatuses(unavailable: ReadonlyArray<ProviderKind>): ServerProviderStatus[] {
+  return NEW_THREAD_MODEL_PREFETCH_PROVIDERS.map((provider) =>
+    makeStatus(provider, !unavailable.includes(provider)),
+  );
+}
+
+function modelKeysFromCalls(prefetchQuery: { mock: { calls: unknown[][] } }): unknown[][] {
+  return prefetchQuery.mock.calls
+    .map((call) => (call[0] as { queryKey?: unknown[] }).queryKey ?? [])
+    .filter((key) => key[0] === "provider-discovery" && key[1] === "models");
 }
 
 describe("resolveNewThreadModelPrefetchProvider", () => {
@@ -103,6 +129,43 @@ describe("resolveNewThreadModelPrefetchCwd", () => {
         serverCwd: "/tmp/server",
       }),
     ).toBe("/tmp/server");
+  });
+
+  it("mirrors buildDraftThreadContextPatch: explicit worktree > fresh > local > draft", () => {
+    const base = {
+      draftWorktreePath: "/draft-wt",
+      projectCwd: "/project",
+      serverCwd: "/server",
+    };
+    const cases: Array<{
+      input: Parameters<typeof resolveNewThreadModelPrefetchCwd>[0];
+      expected: string | null;
+    }> = [
+      {
+        input: { ...base, worktreePath: "/explicit", hasExplicitWorktreePath: true },
+        expected: "/explicit",
+      },
+      {
+        input: { ...base, worktreePath: null, hasExplicitWorktreePath: true },
+        expected: "/project",
+      },
+      { input: { ...base, fresh: true }, expected: "/project" },
+      { input: { ...base, envMode: "local" }, expected: "/project" },
+      { input: { ...base, envMode: "worktree" }, expected: "/draft-wt" },
+      {
+        input: {
+          ...base,
+          worktreePath: "/explicit",
+          hasExplicitWorktreePath: true,
+          fresh: true,
+          envMode: "local",
+        },
+        expected: "/explicit",
+      },
+    ];
+    for (const { input, expected } of cases) {
+      expect(resolveNewThreadModelPrefetchCwd(input)).toBe(expected);
+    }
   });
 });
 
@@ -251,5 +314,150 @@ describe("prefetchModelsForNewThread", () => {
     expect(modelKeys[0]).toEqual(
       providerDiscoveryQueryKeys.models("codex", null, null, null, null),
     );
+  });
+});
+
+describe("prefetchModelsForNewThread — new-thread options key parity", () => {
+  it("warms the prepared worktree cwd for the PR-handoff shape (worktreePath + fresh + local)", async () => {
+    // PullRequestDetailPanel passes { worktreePath, envMode, fresh: true }; the
+    // prepared worktree must win over the stored draft and envMode "local" clearing.
+    const queryClient = new QueryClient();
+    const prefetchQuery = vi.spyOn(queryClient, "prefetchQuery").mockResolvedValue(undefined);
+
+    prefetchModelsForNewThread(queryClient, {
+      settings: makeSettings({ openCodeBinaryPath: "/bin/opencode" }),
+      projectCwd: "/project",
+      draftWorktreePath: "/old-draft-wt",
+      worktreePath: "/prepared-wt",
+      hasExplicitWorktreePath: true,
+      fresh: true,
+      envMode: "local",
+    });
+
+    const modelKeys = modelKeysFromCalls(prefetchQuery);
+    expect(modelKeys).toContainEqual(
+      providerDiscoveryQueryKeys.models("opencode", "/bin/opencode", null, null, "/prepared-wt"),
+    );
+    expect(modelKeys).not.toContainEqual(
+      providerDiscoveryQueryKeys.models("opencode", "/bin/opencode", null, null, "/old-draft-wt"),
+    );
+  });
+});
+
+describe("prefetchModelsForNewThread — availability parity (#652)", () => {
+  it("skips confirmed-unavailable providers only when reconciled, and mirrors ChatView's preference", async () => {
+    const queryClient = new QueryClient();
+    const prefetchQuery = vi.spyOn(queryClient, "prefetchQuery").mockResolvedValue(undefined);
+
+    // Reconciled + confirmed-unavailable cursor → skipped (8 - 1 = 7).
+    prefetchModelsForNewThread(queryClient, {
+      settings: makeSettings(),
+      providerStatuses: availableStatuses(["cursor"]),
+      statusesReconciled: true,
+      projectCwd: "/tmp/project",
+    });
+    let modelKeys = modelKeysFromCalls(prefetchQuery);
+    expect(modelKeys).toHaveLength(7);
+    expect(modelKeys).not.toContainEqual(
+      providerDiscoveryQueryKeys.models("cursor", null, null, null, null),
+    );
+
+    // Unreconciled → safe default: warm everything (8), even confirmed-unavailable.
+    prefetchQuery.mockClear();
+    prefetchModelsForNewThread(queryClient, {
+      settings: makeSettings(),
+      providerStatuses: availableStatuses(["cursor"]),
+      statusesReconciled: false,
+      projectCwd: "/tmp/project",
+    });
+    modelKeys = modelKeysFromCalls(prefetchQuery);
+    expect(modelKeys).toHaveLength(8);
+
+    // Preferred provider unavailable → warm leads with ChatView's swap target (codex).
+    prefetchQuery.mockClear();
+    prefetchModelsForNewThread(queryClient, {
+      settings: makeSettings({ defaultProvider: "cursor" }),
+      providerStatuses: availableStatuses(["cursor"]),
+      statusesReconciled: true,
+      projectCwd: "/tmp/project",
+    });
+    modelKeys = modelKeysFromCalls(prefetchQuery);
+    expect(modelKeys[0]).toEqual(
+      providerDiscoveryQueryKeys.models("codex", null, null, null, null),
+    );
+
+    // Disabled beats selected (useProviderModelCatalog short-circuit parity).
+    prefetchQuery.mockClear();
+    prefetchModelsForNewThread(queryClient, {
+      settings: makeSettings(),
+      serverSettings: {
+        ...DEFAULT_SERVER_SETTINGS,
+        providers: {
+          ...DEFAULT_SERVER_SETTINGS.providers,
+          cursor: { ...DEFAULT_SERVER_SETTINGS.providers.cursor, enabled: false },
+        },
+      },
+      providerOverride: "cursor",
+      providerStatuses: availableStatuses([]),
+      statusesReconciled: true,
+      projectCwd: "/tmp/project",
+    });
+    modelKeys = modelKeysFromCalls(prefetchQuery);
+    expect(modelKeys).not.toContainEqual(
+      providerDiscoveryQueryKeys.models("cursor", null, null, null, null),
+    );
+
+    // Selected but unavailable → still warmed (ChatView discovers it on mount).
+    prefetchQuery.mockClear();
+    prefetchModelsForNewThread(queryClient, {
+      settings: makeSettings(),
+      providerOverride: "cursor",
+      providerStatuses: availableStatuses(NEW_THREAD_MODEL_PREFETCH_PROVIDERS),
+      statusesReconciled: true,
+      projectCwd: "/tmp/project",
+    });
+    modelKeys = modelKeysFromCalls(prefetchQuery);
+    expect(modelKeys).toHaveLength(1);
+  });
+});
+
+describe("prefetchModelsForNewThread — warm-option invariants", () => {
+  it("applies retry: 0 and 30-minute gcTime to every warm call; capabilities once per provider; droid capabilities only on explicit intent", async () => {
+    const queryClient = new QueryClient();
+    const prefetchQuery = vi.spyOn(queryClient, "prefetchQuery").mockResolvedValue(undefined);
+
+    prefetchModelsForNewThread(queryClient, {
+      settings: makeSettings(),
+      projectCwd: "/tmp/project",
+    });
+
+    const calls = prefetchQuery.mock.calls.map((call) => call[0]);
+    // 8 models + 8 capabilities + 4 agents (claudeAgent, codex, kilo, opencode).
+    expect(calls).toHaveLength(8 + 8 + 4);
+    for (const options of calls) {
+      expect(options.retry).toBe(0);
+      expect(options.gcTime).toBe(NEW_THREAD_MODEL_PREFETCH_STALE_TIME_MS);
+    }
+    const capabilityKeys = calls
+      .map((options) => options.queryKey)
+      .filter((key) => key[1] === "composer-capabilities");
+    expect(capabilityKeys).toHaveLength(NEW_THREAD_MODEL_PREFETCH_PROVIDERS.length);
+    expect(capabilityKeys).not.toContainEqual(
+      providerDiscoveryQueryKeys.composerCapabilities("droid"),
+    );
+
+    // Droid warms only on explicit intent, capabilities riding along exactly once.
+    prefetchQuery.mockClear();
+    prefetchModelsForNewThread(queryClient, {
+      settings: makeSettings({ droidBinaryPath: "/bin/droid" }),
+      providerOverride: "droid",
+      projectCwd: "/tmp/project",
+      includeDroid: true,
+    });
+    const droidKeys = prefetchQuery.mock.calls.map((call) => call[0].queryKey);
+    expect(droidKeys).toContainEqual(
+      providerDiscoveryQueryKeys.models("droid", "/bin/droid", null, null, "/tmp/project"),
+    );
+    expect(droidKeys).toContainEqual(providerDiscoveryQueryKeys.composerCapabilities("droid"));
   });
 });

--- a/apps/web/src/lib/providerModelPrefetch.ts
+++ b/apps/web/src/lib/providerModelPrefetch.ts
@@ -6,10 +6,12 @@
 // Layer: Web lib
 // Exports: resolve + prefetch helpers that mirror ChatView's listModels query keys.
 
-import type { ProviderKind, ServerSettings } from "@synara/contracts";
+import type { ProviderKind, ServerProviderStatus, ServerSettings } from "@synara/contracts";
 import type { QueryClient } from "@tanstack/react-query";
 
 import type { AppSettings } from "../appSettings";
+import type { DraftThreadEnvMode } from "../composerDraftDomain";
+import { findProviderStatus, resolveAvailableProviderPreference } from "./providerAvailability";
 import { resolveProviderDiscoveryCwd } from "./providerDiscovery";
 import {
   providerAgentsQueryOptions,
@@ -52,6 +54,8 @@ export const NEW_THREAD_MODEL_PREFETCH_PROVIDERS: ReadonlyArray<Exclude<Provider
 /** Warm results stay fresh for 30 minutes instead of the interactive 60s. */
 export const NEW_THREAD_MODEL_PREFETCH_STALE_TIME_MS = 30 * 60_000;
 
+const EMPTY_PROVIDER_STATUSES: readonly ServerProviderStatus[] = [];
+
 export function resolveNewThreadModelPrefetchProvider(input: {
   providerOverride?: ProviderKind | null | undefined;
   draftActiveProvider?: ProviderKind | null | undefined;
@@ -69,12 +73,34 @@ export function resolveNewThreadModelPrefetchProvider(input: {
 }
 
 export function resolveNewThreadModelPrefetchCwd(input: {
+  /** options.worktreePath from the new-thread call (only meaningful with hasExplicitWorktreePath). */
+  worktreePath?: string | null | undefined;
+  /** True when the caller passed options.worktreePath (even as null) — explicit intent always wins. */
+  hasExplicitWorktreePath?: boolean;
+  /** options.fresh — a forced-fresh thread never inherits the stored draft's worktree. */
+  fresh?: boolean;
+  /** options.envMode — "local" clears the draft worktree unless one is passed explicitly. */
+  envMode?: DraftThreadEnvMode | null;
   draftWorktreePath?: string | null | undefined;
   projectCwd?: string | null | undefined;
   serverCwd?: string | null | undefined;
 }): string | null {
+  // Mirrors the new thread's real worktree resolution:
+  // - buildDraftThreadContextPatch (threadBootstrap): explicit worktreePath wins,
+  //   envMode "local" without an explicit worktree clears it.
+  // - createFreshDraftThreadSeed: fresh seeds ignore the stored draft entirely.
+  let worktreePath: string | null;
+  if (input.hasExplicitWorktreePath === true) {
+    worktreePath = input.worktreePath ?? null;
+  } else if (input.fresh === true) {
+    worktreePath = null;
+  } else if (input.envMode === "local") {
+    worktreePath = null;
+  } else {
+    worktreePath = input.draftWorktreePath ?? null;
+  }
   return resolveProviderDiscoveryCwd({
-    activeThreadWorktreePath: input.draftWorktreePath ?? null,
+    activeThreadWorktreePath: worktreePath,
     activeProjectCwd: input.projectCwd ?? null,
     serverCwd: input.serverCwd ?? null,
   });
@@ -218,8 +244,11 @@ export function prefetchProviderModelsForNewThread(
 
     // Composer capabilities gate composer affordances on ChatView mount; the query
     // has staleTime Infinity, so this costs one IPC per provider per session.
+    // retry: 0 keeps a failing capabilities probe from multiplying per hover —
+    // ChatView's own mount query still retries by its defaults if it refetches.
     void queryClient.prefetchQuery({
       ...providerComposerCapabilitiesQueryOptions(provider),
+      retry: 0,
       gcTime: NEW_THREAD_MODEL_PREFETCH_STALE_TIME_MS,
     });
   }
@@ -250,13 +279,17 @@ export function prefetchDroidModelsForNewThread(
   });
   void queryClient.prefetchQuery({
     ...providerComposerCapabilitiesQueryOptions("droid"),
+    retry: 0,
     gcTime: NEW_THREAD_MODEL_PREFETCH_STALE_TIME_MS,
   });
 }
 
 /**
  * Warm every visible provider for the next new thread: the selected provider
- * first, hidden/disabled providers skipped, Droid only on explicit intent.
+ * first, hidden/disabled/confirmed-uninstalled providers skipped, Droid only on
+ * explicit intent. Provider availability mirrors the model picker on main
+ * (#652): the picker lists only `status.available` providers, so warming a
+ * provider that is confirmed absent would only produce failing spawns.
  */
 export function prefetchModelsForNewThread(
   queryClient: QueryClient,
@@ -264,6 +297,11 @@ export function prefetchModelsForNewThread(
     settings: ProviderModelPrefetchSettings;
     serverSettings?: ServerSettings | null;
     hiddenProviders?: ReadonlyArray<ProviderKind>;
+    /** Normalized provider health (custom binary paths applied), see useProviderStatusesForLocalConfig. */
+    providerStatuses?: readonly ServerProviderStatus[] | null;
+    /** True once the server config's provider statuses have been reconciled (#652). */
+    statusesReconciled?: boolean;
+    providerOrder?: readonly ProviderKind[];
     providerOverride?: ProviderKind | null;
     draftActiveProvider?: ProviderKind | null;
     stickyActiveProvider?: ProviderKind | null;
@@ -271,25 +309,72 @@ export function prefetchModelsForNewThread(
     projectCwd?: string | null;
     draftWorktreePath?: string | null;
     serverCwd?: string | null;
+    worktreePath?: string | null;
+    hasExplicitWorktreePath?: boolean;
+    fresh?: boolean;
+    envMode?: DraftThreadEnvMode | null;
     includeDroid?: boolean;
   },
 ): void {
-  const selectedProvider = resolveNewThreadModelPrefetchProvider({
+  const resolvedProvider = resolveNewThreadModelPrefetchProvider({
     providerOverride: input.providerOverride,
     draftActiveProvider: input.draftActiveProvider,
     stickyActiveProvider: input.stickyActiveProvider,
     projectDefaultProvider: input.projectDefaultProvider,
     defaultProvider: input.settings.defaultProvider,
   });
+  // ChatView resolves the new thread's provider with the same availability
+  // preference (resolveAvailableProviderPreference) once statuses are reconciled,
+  // so the warm-first provider is the one the composer will actually show.
+  const selectedProvider =
+    input.statusesReconciled === true
+      ? resolveAvailableProviderPreference({
+          preferredProvider: resolvedProvider,
+          statuses: input.providerStatuses ?? EMPTY_PROVIDER_STATUSES,
+          providerOrder: input.providerOrder ?? [],
+          hiddenProviders: input.hiddenProviders ?? [],
+        })
+      : resolvedProvider;
   const cwd = resolveNewThreadModelPrefetchCwd({
+    worktreePath: input.worktreePath ?? null,
+    hasExplicitWorktreePath: input.hasExplicitWorktreePath === true,
+    fresh: input.fresh === true,
+    envMode: input.envMode ?? null,
     draftWorktreePath: input.draftWorktreePath,
     projectCwd: input.projectCwd,
     serverCwd: input.serverCwd,
   });
   const hiddenProviderSet = new Set(input.hiddenProviders ?? []);
-  const isProviderWarmable = (provider: ProviderKind): boolean =>
-    !hiddenProviderSet.has(provider) &&
-    input.serverSettings?.providers[provider]?.enabled !== false;
+  const statusesReconciled = input.statusesReconciled === true;
+  const providerStatuses = input.providerStatuses ?? EMPTY_PROVIDER_STATUSES;
+  const isProviderWarmable = (provider: ProviderKind): boolean => {
+    // Mirrors useProviderModelCatalog.shouldDiscoverProvider exactly:
+    // the enabled flag short-circuits even the selected provider, then the
+    // selected provider always wins, then hidden providers are skipped.
+    if (input.serverSettings?.providers[provider]?.enabled === false) {
+      return false;
+    }
+    // ChatView's useProviderModelCatalog always discovers the selected provider
+    // (even hidden/unavailable — the picker preserves it as protected), so the
+    // warm must too, or mount re-runs discovery with the loading state this
+    // prefetch exists to remove.
+    if (provider === selectedProvider) {
+      return true;
+    }
+    if (hiddenProviderSet.has(provider)) {
+      return false;
+    }
+    // The picker only lists installed providers once statuses are reconciled.
+    // A confirmed-unavailable provider would only produce a failing spawn, so
+    // skip it; unresolved statuses stay warmable (safe default).
+    if (statusesReconciled) {
+      const status = findProviderStatus(providerStatuses, provider);
+      if (status !== null && status.available === false) {
+        return false;
+      }
+    }
+    return true;
+  };
   const providers = NEW_THREAD_MODEL_PREFETCH_PROVIDERS.filter(isProviderWarmable);
   const orderedProviders =
     selectedProvider === "droid" || !isProviderWarmable(selectedProvider)

--- a/apps/web/src/lib/providerModelPrefetch.ts
+++ b/apps/web/src/lib/providerModelPrefetch.ts
@@ -64,8 +64,7 @@ export function resolveNewThreadModelPrefetchProvider(input: {
     input.draftActiveProvider ??
     input.stickyActiveProvider ??
     input.projectDefaultProvider ??
-    input.defaultProvider ??
-    "codex"
+    input.defaultProvider
   );
 }
 

--- a/apps/web/src/lib/providerModelPrefetch.ts
+++ b/apps/web/src/lib/providerModelPrefetch.ts
@@ -6,7 +6,7 @@
 // Layer: Web lib
 // Exports: resolve + prefetch helpers that mirror ChatView's listModels query keys.
 
-import type { ProviderKind } from "@synara/contracts";
+import type { ProviderKind, ServerSettings } from "@synara/contracts";
 import type { QueryClient } from "@tanstack/react-query";
 
 import type { AppSettings } from "../appSettings";
@@ -20,6 +20,7 @@ import {
 export type ProviderModelPrefetchSettings = Pick<
   AppSettings,
   | "defaultProvider"
+  | "claudeBinaryPath"
   | "cursorBinaryPath"
   | "cursorApiEndpoint"
   | "antigravityBinaryPath"
@@ -31,13 +32,35 @@ export type ProviderModelPrefetchSettings = Pick<
   | "piAgentDir"
 >;
 
+/**
+ * Providers whose model catalogs are runtime-discovered (not static) and thus
+ * need warming before the picker can show anything beyond the static fallback.
+ * Droid is excluded: its discovery spins a disposable ACP session per model,
+ * so it warms only on explicit new-thread intent.
+ */
+export const NEW_THREAD_MODEL_PREFETCH_PROVIDERS: ReadonlyArray<Exclude<ProviderKind, "droid">> = [
+  "codex",
+  "claudeAgent",
+  "cursor",
+  "antigravity",
+  "grok",
+  "kilo",
+  "opencode",
+  "pi",
+];
+
+/** Warm results stay fresh for 30 minutes instead of the interactive 60s. */
+export const NEW_THREAD_MODEL_PREFETCH_STALE_TIME_MS = 30 * 60_000;
+
 export function resolveNewThreadModelPrefetchProvider(input: {
+  providerOverride?: ProviderKind | null | undefined;
   draftActiveProvider?: ProviderKind | null | undefined;
   stickyActiveProvider?: ProviderKind | null | undefined;
   projectDefaultProvider?: ProviderKind | null | undefined;
   defaultProvider: ProviderKind;
 }): ProviderKind {
   return (
+    input.providerOverride ??
     input.draftActiveProvider ??
     input.stickyActiveProvider ??
     input.projectDefaultProvider ??
@@ -72,7 +95,10 @@ export function providerModelsPrefetchQueryOptions(input: {
 
   switch (provider) {
     case "claudeAgent":
-      return providerModelsQueryOptions({ provider: "claudeAgent" });
+      return providerModelsQueryOptions({
+        provider: "claudeAgent",
+        binaryPath: settings.claudeBinaryPath || null,
+      });
     case "codex":
       return providerModelsQueryOptions({ provider: "codex" });
     case "cursor":
@@ -153,31 +179,131 @@ function providerAgentsPrefetchQueryOptions(input: {
 export function prefetchProviderModelsForNewThread(
   queryClient: QueryClient,
   input: {
-    provider: ProviderKind;
+    settings: ProviderModelPrefetchSettings;
+    cwd?: string | null;
+    providers?: ReadonlyArray<ProviderKind>;
+  },
+): void {
+  const cwd = input.cwd ?? null;
+  const providers = (input.providers ?? NEW_THREAD_MODEL_PREFETCH_PROVIDERS).filter(
+    (provider) => provider !== "droid",
+  );
+
+  for (const provider of providers) {
+    const modelsOptions = providerModelsPrefetchQueryOptions({
+      provider,
+      settings: input.settings,
+      cwd,
+    });
+    void queryClient.prefetchQuery({
+      ...modelsOptions,
+      retry: 0,
+      staleTime: NEW_THREAD_MODEL_PREFETCH_STALE_TIME_MS,
+      gcTime: NEW_THREAD_MODEL_PREFETCH_STALE_TIME_MS,
+    });
+
+    // Agent/mode lists ride along for providers that surface them next to models.
+    const agentsOptions = providerAgentsPrefetchQueryOptions({
+      provider,
+      settings: input.settings,
+      cwd,
+    });
+    if (agentsOptions) {
+      void queryClient.prefetchQuery({
+        ...agentsOptions,
+        retry: 0,
+        staleTime: NEW_THREAD_MODEL_PREFETCH_STALE_TIME_MS,
+        gcTime: NEW_THREAD_MODEL_PREFETCH_STALE_TIME_MS,
+      });
+    }
+
+    // Composer capabilities gate composer affordances on ChatView mount; the query
+    // has staleTime Infinity, so this costs one IPC per provider per session.
+    void queryClient.prefetchQuery({
+      ...providerComposerCapabilitiesQueryOptions(provider),
+      gcTime: NEW_THREAD_MODEL_PREFETCH_STALE_TIME_MS,
+    });
+  }
+}
+
+/**
+ * Warm Droid's model catalog on explicit new-thread intent only. Droid
+ * discovery spins a disposable ACP session per model (expensive), so it must
+ * never run from idle project focus.
+ */
+export function prefetchDroidModelsForNewThread(
+  queryClient: QueryClient,
+  input: {
     settings: ProviderModelPrefetchSettings;
     cwd?: string | null;
   },
 ): void {
   const cwd = input.cwd ?? null;
-  void queryClient.prefetchQuery(
-    providerModelsPrefetchQueryOptions({
-      provider: input.provider,
+  void queryClient.prefetchQuery({
+    ...providerModelsPrefetchQueryOptions({
+      provider: "droid",
       settings: input.settings,
       cwd,
     }),
-  );
+    retry: 0,
+    staleTime: NEW_THREAD_MODEL_PREFETCH_STALE_TIME_MS,
+    gcTime: NEW_THREAD_MODEL_PREFETCH_STALE_TIME_MS,
+  });
+  void queryClient.prefetchQuery({
+    ...providerComposerCapabilitiesQueryOptions("droid"),
+    gcTime: NEW_THREAD_MODEL_PREFETCH_STALE_TIME_MS,
+  });
+}
 
-  // Agent/mode lists ride along for providers that surface them next to models.
-  const agentsOptions = providerAgentsPrefetchQueryOptions({
-    provider: input.provider,
+/**
+ * Warm every visible provider for the next new thread: the selected provider
+ * first, hidden/disabled providers skipped, Droid only on explicit intent.
+ */
+export function prefetchModelsForNewThread(
+  queryClient: QueryClient,
+  input: {
+    settings: ProviderModelPrefetchSettings;
+    serverSettings?: ServerSettings | null;
+    hiddenProviders?: ReadonlyArray<ProviderKind>;
+    providerOverride?: ProviderKind | null;
+    draftActiveProvider?: ProviderKind | null;
+    stickyActiveProvider?: ProviderKind | null;
+    projectDefaultProvider?: ProviderKind | null;
+    projectCwd?: string | null;
+    draftWorktreePath?: string | null;
+    serverCwd?: string | null;
+    includeDroid?: boolean;
+  },
+): void {
+  const selectedProvider = resolveNewThreadModelPrefetchProvider({
+    providerOverride: input.providerOverride,
+    draftActiveProvider: input.draftActiveProvider,
+    stickyActiveProvider: input.stickyActiveProvider,
+    projectDefaultProvider: input.projectDefaultProvider,
+    defaultProvider: input.settings.defaultProvider,
+  });
+  const cwd = resolveNewThreadModelPrefetchCwd({
+    draftWorktreePath: input.draftWorktreePath,
+    projectCwd: input.projectCwd,
+    serverCwd: input.serverCwd,
+  });
+  const hiddenProviderSet = new Set(input.hiddenProviders ?? []);
+  const isProviderWarmable = (provider: ProviderKind): boolean =>
+    !hiddenProviderSet.has(provider) &&
+    input.serverSettings?.providers[provider]?.enabled !== false;
+  const providers = NEW_THREAD_MODEL_PREFETCH_PROVIDERS.filter(isProviderWarmable);
+  const orderedProviders =
+    selectedProvider === "droid" || !isProviderWarmable(selectedProvider)
+      ? providers
+      : [selectedProvider, ...providers.filter((provider) => provider !== selectedProvider)];
+
+  prefetchProviderModelsForNewThread(queryClient, {
     settings: input.settings,
     cwd,
+    providers: orderedProviders,
   });
-  if (agentsOptions) {
-    void queryClient.prefetchQuery(agentsOptions);
-  }
 
-  // Composer capabilities gate composer affordances on ChatView mount; the query
-  // has staleTime Infinity, so this costs one IPC per provider per session.
-  void queryClient.prefetchQuery(providerComposerCapabilitiesQueryOptions(input.provider));
+  if (input.includeDroid === true && selectedProvider === "droid" && isProviderWarmable("droid")) {
+    prefetchDroidModelsForNewThread(queryClient, { settings: input.settings, cwd });
+  }
 }


### PR DESCRIPTION
## Summary

The composer model picker only warms the selected provider's models before a new
thread mounts. Every other provider falls back to its static catalog until its
on-demand discovery completes — in practice minutes of fallback-only picker content.

This PR warms every visible provider's model catalog (plus agents and composer
capabilities) at all ordinary chat new-thread entry points, so the picker shows
the discovered catalogs immediately.

- All 8 runtime-discovered providers warmed (Codex, Claude, Cursor, Antigravity,
  Grok, Kilo, OpenCode, Pi).
- Selected provider warmed first; hidden and disabled providers skipped.
- Droid never warmed from idle focus or hover — only on explicit new-thread intent
  with Droid selected (its discovery spins a disposable ACP session per model).
- Warm results stay fresh for 30 minutes (`retry: 0`), so repeated hovers don't
  re-probe.
- Sidebar hover/focus/click and the shared `useHandleNewThread` entry point all
  route through `prefetchModelsForNewThread`.

### What changed since the previous head (`08f58c9b5`)

This branch is now rebased onto `main` (`d7e5b068`) and carries three
production-hardening fixes beyond the original head:

1. **Worktree-aware prefetch cwd (F1)** — `resolveNewThreadModelPrefetchCwd` now
   mirrors `buildDraftThreadContextPatch` semantics: an explicitly passed
   `options.worktreePath` wins; `fresh: true` ignores the stored draft's worktree;
   `envMode: "local"` without an explicit worktree clears it; otherwise the stored
   draft's worktree is inherited. The warm lands on the exact cwd the new thread
   will open with, so the picker never warms a stale cwd for worktree handoffs.
2. **Droid gating on hover/focus (F2)** — the primary new-thread hover/focus path
   no longer passes `includeDroid`; only the explicit click paths
   (Sidebar primary click, per-project new-thread button, `useHandleNewThread`)
   warm Droid, and only when Droid is the selected provider.
3. **Availability parity with #652** — the warm now skips confirmed-unavailable
   providers once server statuses are reconciled (unknown/unreconciled providers
   stay warm — safe default), and the selected provider is resolved with
   `resolveAvailableProviderPreference`, the same preference ChatView's picker
   uses. The prefetch therefore warms exactly the providers the picker will show.
   Bonus: composer-capabilities prefetch hardened with `retry: 0`, matching the
   models warm.

### Verification (all numbers from this branch's gate evidence)

- Format: `bun run fmt:check` clean — formatter fixed only the 4 PR files.
- Lint: 422 warnings (all upstream, audited), **0 errors**.
- Typecheck: 7/7 workspace tasks (30.7s uncached).
- Web suite: `@synara/web:test` 3m23s green.
- Server suite (`@synara/cli`): 9m5s green.
- Desktop suite: green on retry (first attempt hit a machine DNS flake in the
  Socket Firewall: `telemetry.vercel.com` ENOTFOUND — environment, not code).
- Forced prod web build: 6m10s (not a cache hit).
- Unit tests: `providerModelPrefetch.test.ts` **11 pass / 0 fail / 83 expects**
  — the author's original 7 tests kept verbatim plus consolidated coverage:
  a table-driven cwd-precedence parity test, one prefetch↔ChatView key-parity
  test for the PR-handoff shape, one availability-parity test (skip when
  reconciled, unreconciled safe default, preferred-provider swap, disabled
  beats selected, selected-unavailable still warmed), and one warm-invariant
  test (retry: 0, 30-min gcTime, bounded call math, droid capabilities only on
  explicit intent).
- Live E2E (canary Electron + prod bundles + fresh home, react-query cache + WS
  instrumentation): picker shows all 9 provider entries in **147 ms with 0
  skeletons** (target ~1s); cold single-provider warm settles in **57 ms**; hover
  with Droid selected creates **0 droid queries** while click creates droid
  models + capabilities; per-project cwd scoping verified (proj-a vs proj-b keys);
  re-hover inside the staleness window creates **0 new queries** (stale errors
  re-probe, fresh successes cache-hit).

## Notes

- Deliberately minimal: no bounded warm queue and no failure cooldown. If a spawn
  storm at cold start or repeated re-probing of broken providers is measured as a
  problem, add them back.
- The OpenCode stale-cwd recovery and the Droid health-check timeout from earlier
  iterations were split out (separate concerns, separate PRs).
