### PR TITLE
Support Codex thread forks for imported history

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -28,11 +28,13 @@ import {
 } from "./codexProcessEnv";
 import {
   buildCodexInitializeParams,
+  buildCodexThreadOpenRequest,
   CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS,
   CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS,
   __codexCliVersionGateTesting,
   CodexAppServerManager,
   classifyCodexStderrLine,
+  formatCodexThreadResumeError,
   isRecoverableThreadResumeError,
   normalizeCodexModelSlug,
   readCodexAccountSnapshot,
@@ -1383,6 +1385,84 @@ describe("isRecoverableThreadResumeError", () => {
         new Error("thread/resume failed: timed out waiting for server"),
       ),
     ).toBe(false);
+  });
+});
+
+describe("buildCodexThreadOpenRequest", () => {
+  const sessionOverrides = {
+    model: null,
+    cwd: "/tmp/project",
+    approvalPolicy: "never" as const,
+    approvalsReviewer: "user" as const,
+    sandbox: "danger-full-access" as const,
+  };
+
+  it("forks an external thread into a new provider-owned thread", () => {
+    expect(
+      buildCodexThreadOpenRequest({
+        forkSourceThreadId: "external-thread",
+        sessionOverrides,
+      }),
+    ).toEqual({
+      method: "thread/fork",
+      params: {
+        ...sessionOverrides,
+        threadId: "external-thread",
+      },
+    });
+  });
+
+  it("resumes an existing provider thread without start-only options", () => {
+    expect(
+      buildCodexThreadOpenRequest({
+        resumeThreadId: "existing-thread",
+        sessionOverrides,
+      }),
+    ).toEqual({
+      method: "thread/resume",
+      params: {
+        ...sessionOverrides,
+        threadId: "existing-thread",
+      },
+    });
+  });
+
+  it("starts a fresh thread with raw events disabled", () => {
+    expect(buildCodexThreadOpenRequest({ sessionOverrides })).toEqual({
+      method: "thread/start",
+      params: {
+        ...sessionOverrides,
+        experimentalRawEvents: false,
+      },
+    });
+  });
+
+  it("rejects conflicting resume and fork sources", () => {
+    expect(() =>
+      buildCodexThreadOpenRequest({
+        forkSourceThreadId: "fork-source",
+        resumeThreadId: "resume-source",
+        sessionOverrides,
+      }),
+    ).toThrow("cannot resume and fork at the same time");
+  });
+});
+
+describe("formatCodexThreadResumeError", () => {
+  it("explains how to resolve an active writer conflict", () => {
+    const formatted = formatCodexThreadResumeError(
+      new Error("thread/resume failed: thread external-thread already has an active writer"),
+      "external-thread",
+    );
+
+    expect(formatted.message).toBe(
+      "Codex thread external-thread is open in another Codex client. Close that client before continuing the original thread, or import it as a copy instead.",
+    );
+  });
+
+  it("preserves unrelated resume errors", () => {
+    const original = new Error("thread/resume failed: permission denied");
+    expect(formatCodexThreadResumeError(original, "external-thread")).toBe(original);
   });
 });
 

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -272,6 +272,7 @@ export interface CodexAppServerStartSessionInput {
   readonly model?: string;
   readonly serviceTier?: string;
   readonly resumeCursor?: unknown;
+  readonly forkSourceResumeCursor?: unknown;
   readonly providerOptions?: ProviderSessionStartInput["providerOptions"];
   readonly runtimeMode: RuntimeMode;
 }
@@ -598,6 +599,51 @@ function mapCodexRuntimeMode(runtimeMode: RuntimeMode): {
   }
 }
 
+interface CodexThreadSessionOverrides {
+  readonly model: string | null;
+  readonly serviceTier?: string;
+  readonly cwd: string;
+  readonly approvalPolicy: CodexApprovalPolicy;
+  readonly approvalsReviewer: CodexApprovalsReviewer;
+  readonly sandbox: CodexSandboxMode;
+}
+
+type CodexThreadOpenRequest =
+  | {
+      readonly method: "thread/start";
+      readonly params: CodexThreadSessionOverrides & { readonly experimentalRawEvents: false };
+    }
+  | {
+      readonly method: "thread/resume" | "thread/fork";
+      readonly params: CodexThreadSessionOverrides & { readonly threadId: string };
+    };
+
+export function buildCodexThreadOpenRequest(input: {
+  readonly forkSourceThreadId?: string;
+  readonly resumeThreadId?: string;
+  readonly sessionOverrides: CodexThreadSessionOverrides;
+}): CodexThreadOpenRequest {
+  if (input.forkSourceThreadId && input.resumeThreadId) {
+    throw new Error("A Codex session cannot resume and fork at the same time.");
+  }
+  if (input.forkSourceThreadId) {
+    return {
+      method: "thread/fork",
+      params: { ...input.sessionOverrides, threadId: input.forkSourceThreadId },
+    };
+  }
+  if (input.resumeThreadId) {
+    return {
+      method: "thread/resume",
+      params: { ...input.sessionOverrides, threadId: input.resumeThreadId },
+    };
+  }
+  return {
+    method: "thread/start",
+    params: { ...input.sessionOverrides, experimentalRawEvents: false },
+  };
+}
+
 // turn/start uses sandboxPolicy objects, so keep this separate from thread/start.
 function mapCodexRuntimeModeToTurnOverrides(runtimeMode: RuntimeMode): {
   readonly approvalPolicy: CodexApprovalPolicy;
@@ -854,6 +900,18 @@ export function isRecoverableThreadResumeError(error: unknown): boolean {
   return RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS.some((snippet) => message.includes(snippet));
 }
 
+export function formatCodexThreadResumeError(error: unknown, providerThreadId: string): Error {
+  const originalError = error instanceof Error ? error : new Error(String(error));
+  if (!originalError.message.toLowerCase().includes("already has an active writer")) {
+    return originalError;
+  }
+
+  return new Error(
+    `Codex thread ${providerThreadId} is open in another Codex client. Close that client before continuing the original thread, or import it as a copy instead.`,
+    { cause: originalError },
+  );
+}
+
 export interface CodexAppServerManagerEvents {
   event: [event: ProviderEvent];
 }
@@ -1078,70 +1136,89 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         ...mapCodexRuntimeMode(input.runtimeMode ?? "full-access"),
       };
 
-      const threadStartParams = {
-        ...sessionOverrides,
-        experimentalRawEvents: false,
-      };
       const resumeThreadId = readResumeThreadId(input);
+      const forkSourceThreadId = readResumeCursorThreadId(input.forkSourceResumeCursor);
+      const threadOpenRequest = buildCodexThreadOpenRequest({
+        ...(forkSourceThreadId ? { forkSourceThreadId } : {}),
+        ...(resumeThreadId ? { resumeThreadId } : {}),
+        sessionOverrides,
+      });
       this.emitLifecycleEvent(
         context,
         "session/threadOpenRequested",
-        resumeThreadId
-          ? `Attempting to resume thread ${resumeThreadId}.`
-          : "Starting a new Codex thread.",
+        threadOpenRequest.method === "thread/fork"
+          ? `Forking Codex thread ${forkSourceThreadId}.`
+          : threadOpenRequest.method === "thread/resume"
+            ? `Attempting to resume thread ${resumeThreadId}.`
+            : "Starting a new Codex thread.",
       );
       await Effect.logInfo("codex app-server opening thread", {
         threadId,
+        threadOpenMethod: threadOpenRequest.method,
         requestedRuntimeMode: input.runtimeMode,
         requestedModel: normalizedModel ?? null,
         requestedCwd: resolvedCwd,
         resumeThreadId: resumeThreadId ?? null,
+        forkSourceThreadId: forkSourceThreadId ?? null,
       }).pipe(this.runPromise);
 
-      let threadOpenMethod: "thread/start" | "thread/resume" = "thread/start";
+      let threadOpenMethod = threadOpenRequest.method;
       let threadOpenResponse: unknown;
-      if (resumeThreadId) {
-        try {
-          threadOpenMethod = "thread/resume";
-          threadOpenResponse = await this.sendRequest(context, "thread/resume", {
-            ...sessionOverrides,
-            threadId: resumeThreadId,
-          });
-        } catch (error) {
-          if (!isRecoverableThreadResumeError(error)) {
-            this.emitErrorEvent(
-              context,
-              "session/threadResumeFailed",
-              error instanceof Error ? error.message : "Codex thread resume failed.",
-            );
-            await Effect.logWarning("codex app-server thread resume failed", {
-              threadId,
-              requestedRuntimeMode: input.runtimeMode,
-              resumeThreadId,
-              recoverable: false,
-              cause: error instanceof Error ? error.message : String(error),
-            }).pipe(this.runPromise);
-            throw error;
-          }
-
-          threadOpenMethod = "thread/start";
-          this.emitLifecycleEvent(
+      try {
+        threadOpenResponse = await this.sendRequest(
+          context,
+          threadOpenRequest.method,
+          threadOpenRequest.params,
+        );
+      } catch (error) {
+        const recoverableResumeFailure =
+          threadOpenRequest.method === "thread/resume" && isRecoverableThreadResumeError(error);
+        if (!recoverableResumeFailure) {
+          const threadOpenError =
+            threadOpenRequest.method === "thread/resume" && resumeThreadId
+              ? formatCodexThreadResumeError(error, resumeThreadId)
+              : error instanceof Error
+                ? error
+                : new Error(String(error));
+          this.emitErrorEvent(
             context,
-            "session/threadResumeFallback",
-            `Could not resume thread ${resumeThreadId}; started a new thread instead.`,
+            threadOpenRequest.method === "thread/fork"
+              ? "session/threadForkFailed"
+              : threadOpenRequest.method === "thread/resume"
+                ? "session/threadResumeFailed"
+                : "session/threadStartFailed",
+            threadOpenError.message,
           );
-          await Effect.logWarning("codex app-server thread resume fell back to fresh start", {
+          await Effect.logWarning(`codex app-server ${threadOpenRequest.method} failed`, {
             threadId,
             requestedRuntimeMode: input.runtimeMode,
-            resumeThreadId,
-            recoverable: true,
-            cause: error instanceof Error ? error.message : String(error),
+            resumeThreadId: resumeThreadId ?? null,
+            forkSourceThreadId: forkSourceThreadId ?? null,
+            recoverable: false,
+            cause: threadOpenError.message,
           }).pipe(this.runPromise);
-          threadOpenResponse = await this.sendRequest(context, "thread/start", threadStartParams);
+          throw threadOpenError;
         }
-      } else {
+
         threadOpenMethod = "thread/start";
-        threadOpenResponse = await this.sendRequest(context, "thread/start", threadStartParams);
+        this.emitLifecycleEvent(
+          context,
+          "session/threadResumeFallback",
+          `Could not resume thread ${resumeThreadId}; started a new thread instead.`,
+        );
+        await Effect.logWarning("codex app-server thread resume fell back to fresh start", {
+          threadId,
+          requestedRuntimeMode: input.runtimeMode,
+          resumeThreadId,
+          recoverable: true,
+          cause: error instanceof Error ? error.message : String(error),
+        }).pipe(this.runPromise);
+        const fallbackRequest = buildCodexThreadOpenRequest({ sessionOverrides });
+        threadOpenResponse = await this.sendRequest(
+          context,
+          fallbackRequest.method,
+          fallbackRequest.params,
+        );
       }
 
       const threadOpenRecord = this.readObject(threadOpenResponse);
@@ -1166,6 +1243,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         threadId,
         threadOpenMethod,
         requestedResumeThreadId: resumeThreadId ?? null,
+        requestedForkSourceThreadId: forkSourceThreadId ?? null,
         resolvedThreadId: providerThreadId,
         requestedRuntimeMode: input.runtimeMode,
       }).pipe(this.runPromise);

--- a/apps/server/src/orchestration/importThreadRoute.test.ts
+++ b/apps/server/src/orchestration/importThreadRoute.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import {
+  type OrchestrationCommand,
+  type OrchestrationThread,
+  ProjectId,
+  type ProviderSession,
+  ThreadId,
+} from "@synara/contracts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { it, vi } from "@effect/vitest";
+import { Effect, FileSystem, Option, Path } from "effect";
+
+import type { ProviderAdapterRegistryShape } from "../provider/Services/ProviderAdapterRegistry";
+import type { ProviderServiceShape } from "../provider/Services/ProviderService";
+import type { OrchestrationEngineShape } from "./Services/OrchestrationEngine";
+import type { ProjectionSnapshotQueryShape } from "./Services/ProjectionSnapshotQuery";
+import { makeImportThreadHandler } from "./importThreadRoute";
+
+const threadId = ThreadId.makeUnsafe("thread-import");
+const projectId = ProjectId.makeUnsafe("project-import");
+const importedAt = "2026-08-09T12:00:00.000Z";
+
+function makeCodexThread(): OrchestrationThread {
+  return {
+    id: threadId,
+    projectId,
+    title: "Imported thread",
+    modelSelection: { provider: "codex", model: "gpt-5.5" },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    envMode: "local",
+    branch: null,
+    worktreePath: null,
+    workingDirectory: null,
+    associatedWorktreePath: null,
+    associatedWorktreeBranch: null,
+    associatedWorktreeRef: null,
+    createBranchFlowCompleted: false,
+    isPinned: false,
+    parentThreadId: null,
+    creationSource: null,
+    sourceThreadId: null,
+    sourceTurnId: null,
+    gatewayOperationId: null,
+    gatewayOperationIndex: null,
+    subagentAgentId: null,
+    subagentNickname: null,
+    subagentRole: null,
+    forkSourceThreadId: null,
+    sidechatSourceThreadId: null,
+    lastKnownPr: null,
+    latestTurn: null,
+    createdAt: importedAt,
+    updatedAt: importedAt,
+    archivedAt: null,
+    settledAt: null,
+    deletedAt: null,
+    handoff: null,
+    messages: [],
+    proposedPlans: [],
+    activities: [],
+    checkpoints: [],
+    session: null,
+  };
+}
+
+it.effect("imports Codex history through a provider-owned fork", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const externalId = "019fbe83-572e-7092-a84e-5ba7285ca2c5";
+    const dispatchedCommands: OrchestrationCommand[] = [];
+    const session: ProviderSession = {
+      provider: "codex",
+      status: "ready",
+      runtimeMode: "full-access",
+      threadId,
+      resumeCursor: { threadId: "forked-codex-thread" },
+      createdAt: importedAt,
+      updatedAt: importedAt,
+    };
+    const startSession = vi.fn(() => Effect.succeed(session));
+    const readThread = vi.fn(() =>
+      Effect.succeed({
+        threadId: "forked-codex-thread",
+        turns: [],
+      }),
+    );
+
+    const handler = makeImportThreadHandler({
+      fileSystem,
+      path,
+      platform: process.platform,
+      orchestrationEngine: {
+        dispatch: (command: OrchestrationCommand) =>
+          Effect.sync(() => {
+            dispatchedCommands.push(command);
+            return { sequence: dispatchedCommands.length };
+          }),
+      } as unknown as OrchestrationEngineShape,
+      projectionSnapshotQuery: {
+        getThreadDetailById: () => Effect.succeed(Option.some(makeCodexThread())),
+        getProjectShellById: () => Effect.succeed(Option.none()),
+      } as unknown as ProjectionSnapshotQueryShape,
+      providerAdapterRegistry: {
+        getByProvider: () =>
+          Effect.succeed({
+            readThread,
+          } as never),
+      } as unknown as ProviderAdapterRegistryShape,
+      providerService: {
+        startSession,
+        stopSession: () => Effect.void,
+      } as unknown as ProviderServiceShape,
+    });
+
+    const result = yield* handler({ threadId, externalId });
+
+    assert.deepEqual(result, { threadId });
+    assert.deepEqual(startSession.mock.calls[0], [
+      threadId,
+      {
+        threadId,
+        provider: "codex",
+        modelSelection: { provider: "codex", model: "gpt-5.5" },
+        forkSourceResumeCursor: { threadId: externalId },
+        runtimeMode: "full-access",
+      },
+    ]);
+    assert.deepEqual(readThread.mock.calls, [[threadId]]);
+    assert.equal(dispatchedCommands.at(-1)?.type, "thread.session.set");
+  }).pipe(Effect.provide(NodeServices.layer)),
+);

--- a/apps/server/src/orchestration/importThreadRoute.ts
+++ b/apps/server/src/orchestration/importThreadRoute.ts
@@ -400,6 +400,10 @@ export function makeImportThreadHandler(options: ImportThreadHandlerOptions) {
       });
     }
 
+    const importResumeCursor = providerResumeCursorForImport(
+      thread.modelSelection.provider,
+      externalId,
+    );
     const session = yield* options.providerService.startSession(thread.id, {
       threadId: thread.id,
       provider: thread.modelSelection.provider,
@@ -407,7 +411,9 @@ export function makeImportThreadHandler(options: ImportThreadHandlerOptions) {
         ? { cwd: importedProviderContext?.runtimeCwd ?? cwd }
         : {}),
       modelSelection: thread.modelSelection,
-      resumeCursor: providerResumeCursorForImport(thread.modelSelection.provider, externalId),
+      ...(thread.modelSelection.provider === "codex"
+        ? { forkSourceResumeCursor: importResumeCursor }
+        : { resumeCursor: importResumeCursor }),
       runtimeMode: thread.runtimeMode,
     });
 

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -229,6 +229,27 @@ validationLayer("CodexAdapterLive validation", (it) => {
       });
     }),
   );
+  it.effect("forwards an external fork cursor when starting a session", () =>
+    Effect.gen(function* () {
+      validationManager.startSessionImpl.mockClear();
+      const adapter = yield* CodexAdapter;
+      const forkSourceResumeCursor = { threadId: "external-codex-thread" };
+
+      yield* adapter.startSession({
+        provider: "codex",
+        threadId: asThreadId("thread-import"),
+        forkSourceResumeCursor,
+        runtimeMode: "full-access",
+      });
+
+      assert.deepStrictEqual(validationManager.startSessionImpl.mock.calls[0]?.[0], {
+        provider: "codex",
+        threadId: asThreadId("thread-import"),
+        forkSourceResumeCursor,
+        runtimeMode: "full-access",
+      });
+    }),
+  );
 });
 
 const sessionErrorManager = new FakeCodexManager();

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1856,6 +1856,9 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
           : {}),
         ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
         ...(input.resumeCursor !== undefined ? { resumeCursor: input.resumeCursor } : {}),
+        ...(input.forkSourceResumeCursor !== undefined
+          ? { forkSourceResumeCursor: input.forkSourceResumeCursor }
+          : {}),
         ...(input.providerOptions !== undefined ? { providerOptions: input.providerOptions } : {}),
         runtimeMode: input.runtimeMode,
         ...codexModelSelectionOverrides(input.modelSelection),

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -702,7 +702,7 @@ it.effect(
 );
 
 routing.layer("ProviderServiceLive routing", (it) => {
-  it.effect("does not resume a persisted thread when an external fork is requested", () =>
+  it.effect("fork source overrides explicit and persisted resume cursors", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService;
       const threadId = asThreadId("thread-external-fork");
@@ -720,6 +720,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
         provider: "codex",
         threadId,
         forkSourceResumeCursor,
+        resumeCursor: { threadId: "explicit-thread" },
         runtimeMode: "full-access",
       });
 

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -702,6 +702,35 @@ it.effect(
 );
 
 routing.layer("ProviderServiceLive routing", (it) => {
+  it.effect("does not resume a persisted thread when an external fork is requested", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const threadId = asThreadId("thread-external-fork");
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        resumeCursor: { threadId: "persisted-thread" },
+        runtimeMode: "full-access",
+      });
+      routing.codex.startSession.mockClear();
+
+      const forkSourceResumeCursor = { threadId: "external-thread" };
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        forkSourceResumeCursor,
+        runtimeMode: "full-access",
+      });
+
+      const startInput = routing.codex.startSession.mock.calls[0]?.[0];
+      assert.deepEqual(startInput?.forkSourceResumeCursor, forkSourceResumeCursor);
+      assert.equal(startInput?.resumeCursor, undefined);
+
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
   it.effect("runs the idempotent adapter cleanup barrier for an inactive binding", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService;

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -1542,10 +1542,12 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           Effect.gen(function* () {
             const persistedBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
             const effectiveResumeCursor =
-              input.resumeCursor ??
-              (persistedBinding?.provider === input.provider
-                ? persistedBinding.resumeCursor
-                : undefined);
+              input.forkSourceResumeCursor !== undefined
+                ? undefined
+                : (input.resumeCursor ??
+                  (persistedBinding?.provider === input.provider
+                    ? persistedBinding.resumeCursor
+                    : undefined));
             const effectiveProviderOptions =
               input.providerOptions ??
               (persistedBinding?.provider === input.provider

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -1548,6 +1548,8 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                   (persistedBinding?.provider === input.provider
                     ? persistedBinding.resumeCursor
                     : undefined));
+            const adapterStartInput = { ...input };
+            delete adapterStartInput.resumeCursor;
             const effectiveProviderOptions =
               input.providerOptions ??
               (persistedBinding?.provider === input.provider
@@ -1562,7 +1564,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               // with text the caller can surface as a session error.
               const started = yield* adapter
                 .startSession({
-                  ...input,
+                  ...adapterStartInput,
                   lifecycleGeneration: lease.generation,
                   ...(effectiveProviderOptions !== undefined
                     ? { providerOptions: effectiveProviderOptions }

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -56,6 +56,7 @@ export const ProviderSessionStartInput = Schema.Struct({
   cwd: Schema.optional(TrimmedNonEmptyString),
   modelSelection: Schema.optional(ModelSelection),
   resumeCursor: Schema.optional(Schema.Unknown),
+  forkSourceResumeCursor: Schema.optional(Schema.Unknown),
   approvalPolicy: Schema.optional(ProviderApprovalPolicy),
   sandboxMode: Schema.optional(ProviderSandboxMode),
   providerOptions: Schema.optional(ProviderStartOptions),


### PR DESCRIPTION
## What Changed

- Added Codex thread fork support for imported history so imported Codex threads start as provider-owned forks instead of attempting a direct resume.
- Plumbed `forkSourceResumeCursor` through the provider contract, provider service, and Codex adapter.
- Updated Codex session startup to choose between `thread/start`, `thread/resume`, and `thread/fork` with clearer lifecycle/error handling.
- Added tests covering fork request construction, import flow routing, and provider/session forwarding.

## Why

Imported Codex history could not be restored safely through a normal resume path when the source thread already belonged to another client. Forking preserves the imported history while avoiding active-writer conflicts and keeps provider-owned sessions isolated.

## UI Changes

- None.

## Verification

- Added and updated unit tests for Codex session startup, import routing, adapter forwarding, and provider service behavior.
- No full workspace checks were run.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex session open semantics and provider start input on the import path; mistakes could break imports or normal resume, though behavior is covered by new unit tests.
> 
> **Overview**
> **Imported Codex threads** now open via **`thread/fork`** on the external thread ID instead of **`thread/resume`**, so Synara gets a provider-owned session and avoids “active writer” conflicts when the source thread is still open elsewhere.
> 
> The change adds optional **`forkSourceResumeCursor`** on provider session start (contract → **`ProviderService`** → Codex adapter → app-server manager). When that field is set, persisted/explicit **`resumeCursor`** is not applied; **`buildCodexThreadOpenRequest`** picks **`thread/start`**, **`thread/resume`**, or **`thread/fork`**. Resume failures that mention an active writer are surfaced with **`formatCodexThreadResumeError`** (close the other client or import as a copy). Import routing passes **`forkSourceResumeCursor`** for Codex and keeps **`resumeCursor`** for other providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c42374c8dff000cc24db1e8048067725379ec103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->