### PR TITLE
Make queued-turn promotion replay-safe

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -56,6 +56,7 @@ import {
 import { OrchestrationEventStoreLive } from "../../persistence/Layers/OrchestrationEventStore.ts";
 import { OrchestrationCommandReceiptRepositoryLive } from "../../persistence/Layers/OrchestrationCommandReceipts.ts";
 import { OrchestrationEventDeliveryRepositoryLive } from "../../persistence/Layers/OrchestrationEventDeliveries.ts";
+import { PersistenceSqlError } from "../../persistence/Errors.ts";
 import {
   OrchestrationEventDeliveryRepository,
   PROVIDER_COMMAND_REACTOR_CONSUMER,
@@ -942,6 +943,224 @@ describe("ProviderCommandReactor", () => {
     expect(delivery.pipe(Option.getOrThrow)).toMatchObject({
       state: "succeeded",
       attemptCount: 2,
+    });
+  });
+
+  it("REL-01B gate: retries a transient queued-promotion enqueue before advancing", async () => {
+    const harness = await createHarness({ startReactor: false });
+    const now = new Date().toISOString();
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const messageId = asMessageId("message-queued-enqueue-retry");
+    const commandId = CommandId.makeUnsafe("cmd-queued-enqueue-retry");
+    const messageEventId = asEventId("evt-message-queued-enqueue-retry");
+    const persisted = await harness.persistWithoutLivePublication([
+      {
+        eventId: messageEventId,
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: now,
+        commandId,
+        causationEventId: null,
+        correlationId: commandId,
+        metadata: {},
+        type: "thread.message-sent",
+        payload: {
+          threadId,
+          messageId,
+          role: "user",
+          text: "survive the first enqueue failure",
+          dispatchMode: "queue",
+          turnId: null,
+          streaming: false,
+          source: "native",
+          createdAt: now,
+          updatedAt: now,
+        },
+      },
+      {
+        eventId: asEventId("evt-turn-queued-enqueue-retry"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: now,
+        commandId,
+        causationEventId: messageEventId,
+        correlationId: commandId,
+        metadata: {},
+        type: "thread.turn-queued",
+        payload: {
+          threadId,
+          messageId,
+          dispatchMode: "queue",
+          runtimeMode: "approval-required",
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          createdAt: now,
+        },
+      },
+    ]);
+    const queuedEvent = persisted[1]!;
+
+    const repository = harness.queuedTurnPromotionRepository as {
+      enqueue: typeof harness.queuedTurnPromotionRepository.enqueue;
+    };
+    const enqueue = repository.enqueue;
+    let enqueueAttempts = 0;
+    repository.enqueue = (input) => {
+      enqueueAttempts += 1;
+      return enqueueAttempts === 1
+        ? Effect.fail(
+            new PersistenceSqlError({
+              operation: "QueuedTurnPromotion.enqueue",
+              detail: "injected transient enqueue failure",
+            }),
+          )
+        : enqueue(input);
+    };
+
+    await harness.startReactor();
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+    expect(enqueueAttempts).toBe(2);
+    expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({
+      threadId,
+      input: "survive the first enqueue failure",
+    });
+    const delivery = await Effect.runPromise(
+      harness.deliveryRepository.getDelivery({
+        consumerName: PROVIDER_COMMAND_REACTOR_CONSUMER,
+        eventSequence: queuedEvent.sequence,
+      }),
+    );
+    expect(delivery.pipe(Option.getOrThrow)).toMatchObject({
+      state: "succeeded",
+      attemptCount: 2,
+    });
+    const promotion = await Effect.runPromise(
+      harness.queuedTurnPromotionRepository.getBySequence(queuedEvent.sequence),
+    );
+    expect(promotion.pipe(Option.getOrThrow)).toMatchObject({
+      state: "promoted",
+      attemptCount: 1,
+    });
+  });
+
+  it("reconciles and drains a queued-turn delivery without restart or a terminal event", async () => {
+    const harness = await createHarness({ startReactor: false });
+    const now = new Date().toISOString();
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const messageId = asMessageId("message-queued-reconcile");
+    const commandId = CommandId.makeUnsafe("cmd-queued-reconcile");
+    const messageEventId = asEventId("evt-message-queued-reconcile");
+    const persisted = await harness.persistWithoutLivePublication([
+      {
+        eventId: messageEventId,
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: now,
+        commandId,
+        causationEventId: null,
+        correlationId: commandId,
+        metadata: {},
+        type: "thread.message-sent",
+        payload: {
+          threadId,
+          messageId,
+          role: "user",
+          text: "drain immediately after reconciliation",
+          dispatchMode: "queue",
+          turnId: null,
+          streaming: false,
+          source: "native",
+          createdAt: now,
+          updatedAt: now,
+        },
+      },
+      {
+        eventId: asEventId("evt-turn-queued-reconcile"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: now,
+        commandId,
+        causationEventId: messageEventId,
+        correlationId: commandId,
+        metadata: {},
+        type: "thread.turn-queued",
+        payload: {
+          threadId,
+          messageId,
+          dispatchMode: "queue",
+          runtimeMode: "approval-required",
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          createdAt: now,
+        },
+      },
+    ]);
+    const queuedEvent = persisted[1]!;
+
+    const repository = harness.queuedTurnPromotionRepository as {
+      enqueue: typeof harness.queuedTurnPromotionRepository.enqueue;
+    };
+    const enqueue = repository.enqueue;
+    let rejectEnqueue = true;
+    let enqueueAttempts = 0;
+    repository.enqueue = (input) => {
+      enqueueAttempts += 1;
+      return rejectEnqueue
+        ? Effect.fail(
+            new PersistenceSqlError({
+              operation: "QueuedTurnPromotion.enqueue",
+              detail: "injected persistent enqueue failure",
+            }),
+          )
+        : enqueue(input);
+    };
+
+    await harness.startReactor();
+
+    const blockedDelivery = await Effect.runPromise(
+      harness.deliveryRepository.getDelivery({
+        consumerName: PROVIDER_COMMAND_REACTOR_CONSUMER,
+        eventSequence: queuedEvent.sequence,
+      }),
+    );
+    expect(blockedDelivery.pipe(Option.getOrThrow)).toMatchObject({
+      state: "dead",
+      attemptCount: 3,
+    });
+    expect(enqueueAttempts).toBe(3);
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+
+    rejectEnqueue = false;
+    const reconciled = await Effect.runPromise(
+      harness.reactor.reconcileDelivery({
+        eventSequence: queuedEvent.sequence,
+        threadId,
+        expectedState: "dead",
+        outcome: "safe_retry",
+        reconciledBy: "test-operator",
+        note: "SQLite is writable again.",
+      }),
+    );
+
+    expect(reconciled).toMatchObject({
+      eventSequence: queuedEvent.sequence,
+      threadId,
+      outcome: "safe_retry",
+      state: "succeeded",
+    });
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect(enqueueAttempts).toBe(4);
+    expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({
+      threadId,
+      input: "drain immediately after reconciliation",
+    });
+    const promotion = await Effect.runPromise(
+      harness.queuedTurnPromotionRepository.getBySequence(queuedEvent.sequence),
+    );
+    expect(promotion.pipe(Option.getOrThrow)).toMatchObject({
+      state: "promoted",
+      attemptCount: 1,
     });
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1164,6 +1164,104 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
+  it("cancels a safely retried queued delivery after its thread was deleted", async () => {
+    const harness = await createHarness({ startReactor: false });
+    const now = new Date().toISOString();
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const messageId = asMessageId("message-queued-reconcile-deleted");
+    const commandId = CommandId.makeUnsafe("cmd-queued-reconcile-deleted");
+    const persisted = await harness.persistWithoutLivePublication([
+      {
+        eventId: asEventId("evt-turn-queued-reconcile-deleted"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: now,
+        commandId,
+        causationEventId: null,
+        correlationId: commandId,
+        metadata: {},
+        type: "thread.turn-queued",
+        payload: {
+          threadId,
+          messageId,
+          dispatchMode: "queue",
+          runtimeMode: "approval-required",
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          createdAt: now,
+        },
+      },
+    ]);
+    const queuedEvent = persisted[0]!;
+
+    const repository = harness.queuedTurnPromotionRepository as {
+      enqueue: typeof harness.queuedTurnPromotionRepository.enqueue;
+    };
+    const enqueue = repository.enqueue;
+    let rejectEnqueue = true;
+    let enqueueAttempts = 0;
+    repository.enqueue = (input) => {
+      enqueueAttempts += 1;
+      return rejectEnqueue
+        ? Effect.fail(
+            new PersistenceSqlError({
+              operation: "QueuedTurnPromotion.enqueue",
+              detail: "injected persistent enqueue failure",
+            }),
+          )
+        : enqueue(input);
+    };
+
+    await harness.startReactor();
+    const blockedDelivery = await Effect.runPromise(
+      harness.deliveryRepository.getDelivery({
+        consumerName: PROVIDER_COMMAND_REACTOR_CONSUMER,
+        eventSequence: queuedEvent.sequence,
+      }),
+    );
+    expect(blockedDelivery.pipe(Option.getOrThrow)).toMatchObject({
+      state: "dead",
+      attemptCount: 3,
+    });
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.delete",
+        commandId: CommandId.makeUnsafe("cmd-delete-before-queued-reconcile"),
+        threadId,
+      }),
+    );
+    await harness.drain();
+    expect((await readHarnessThread(harness, threadId))?.deletedAt).not.toBeNull();
+
+    rejectEnqueue = false;
+    const reconciled = await Effect.runPromise(
+      harness.reactor.reconcileDelivery({
+        eventSequence: queuedEvent.sequence,
+        threadId,
+        expectedState: "dead",
+        outcome: "safe_retry",
+        reconciledBy: "test-operator",
+        note: "Retry after thread deletion must not resurrect queued work.",
+      }),
+    );
+
+    expect(reconciled).toMatchObject({
+      eventSequence: queuedEvent.sequence,
+      threadId,
+      outcome: "safe_retry",
+      state: "succeeded",
+    });
+    expect(enqueueAttempts).toBe(4);
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+    const promotion = await Effect.runPromise(
+      harness.queuedTurnPromotionRepository.getBySequence(queuedEvent.sequence),
+    );
+    expect(promotion.pipe(Option.getOrThrow)).toMatchObject({
+      state: "cancelled",
+      attemptCount: 0,
+    });
+  });
+
   it("REL-01B gate: quarantines an expired external claim without replaying it", async () => {
     const harness = await createHarness({ startReactor: false });
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -2377,15 +2377,10 @@ const make = Effect.gen(function* () {
   const processTurnQueued = Effect.fnUntraced(function* (
     event: Extract<ProviderIntentEvent, { type: "thread.turn-queued" }>,
   ) {
+    // Keep the replay-safe claimed delivery limited to this idempotent durable
+    // write. The recovery drain can dispatch a later provider intent, so it
+    // runs only after this delivery has settled successfully.
     yield* enqueueQueuedTurnStart(event);
-    // Recovery drain: if the provider turn settled between the decider's
-    // (stale) running check and this enqueue, the terminal
-    // `turn.completed`/`turn.aborted` event has already been consumed and will
-    // never drain this queue — the message would be stuck forever. Re-check
-    // live provider state and promote immediately.
-    if (!(yield* hasLiveProviderTurn(event.payload.threadId))) {
-      yield* drainQueuedTurnsForThread(event.payload.threadId);
-    }
   });
 
   const readOrchestrationEventAtSequence = (eventSequence: number) =>
@@ -3526,6 +3521,40 @@ const make = Effect.gen(function* () {
       }),
     );
 
+  const recoverQueuedTurnAfterDeliverySafely = (
+    event: Extract<ProviderIntentEvent, { type: "thread.turn-queued" }>,
+  ) =>
+    Effect.gen(function* () {
+      const delivery = yield* deliveryRepository.getDelivery({
+        consumerName: PROVIDER_COMMAND_REACTOR_CONSUMER,
+        eventSequence: event.sequence,
+      });
+      if (Option.isNone(delivery) || delivery.value.state !== "succeeded") {
+        return;
+      }
+      // Recovery drain: if the provider turn settled between the decider's
+      // (stale) running check and the durable enqueue, its terminal runtime
+      // event has already been consumed and cannot drain this queue. Re-check
+      // live provider state after delivery settlement and promote immediately.
+      if (!(yield* hasLiveProviderTurn(event.payload.threadId))) {
+        yield* drainQueuedTurnsForThread(event.payload.threadId);
+      }
+    }).pipe(
+      Effect.catchCause((cause) => {
+        if (Cause.hasInterruptsOnly(cause)) {
+          return Effect.failCause(cause);
+        }
+        // The promotion row is already durable. Startup recovery or a later
+        // terminal provider event will retry the drain without replaying the
+        // settled enqueue delivery.
+        return Effect.logWarning("provider command reactor failed queued-turn recovery drain", {
+          eventSequence: event.sequence,
+          threadId: event.payload.threadId,
+          cause: Cause.pretty(cause),
+        });
+      }),
+    );
+
   // One attach-before-replay source owns every provider intent. The claimed
   // canary classes settle before cursor advancement. Remaining classes execute
   // serially in the same source but do not acquire delivery claims yet.
@@ -3848,6 +3877,19 @@ const make = Effect.gen(function* () {
       yield* requireCursorAdvance(event);
     });
 
+    // Every entry point that settles a claimed delivery must cross this
+    // boundary. In particular, operator-authorized safe retries bypass the
+    // ordered event stream, but a successfully retried queued-turn enqueue
+    // still needs its post-settlement recovery drain.
+    const processClaimedProviderIntentWithRecovery = Effect.fnUntraced(function* (
+      event: ProviderIntentEvent,
+    ) {
+      yield* processClaimedProviderIntent(event);
+      if (event.type === "thread.turn-queued") {
+        yield* recoverQueuedTurnAfterDeliverySafely(event);
+      }
+    });
+
     const processOrderedEvent = Effect.fnUntraced(function* (event: OrchestrationEvent) {
       if (event.sequence <= cursor) return;
       if (!isProviderIntentEvent(event)) {
@@ -3855,7 +3897,7 @@ const make = Effect.gen(function* () {
         return;
       }
       if (isClaimedProviderIntent(event)) {
-        yield* processClaimedProviderIntent(event);
+        yield* processClaimedProviderIntentWithRecovery(event);
         return;
       }
       yield* processUnclaimedProviderIntent(event);
@@ -3894,7 +3936,7 @@ const make = Effect.gen(function* () {
             return Effect.void;
           }
           return isClaimedProviderIntent(event)
-            ? processClaimedProviderIntent(event)
+            ? processClaimedProviderIntentWithRecovery(event)
             : processUnclaimedProviderIntent(event);
         },
       );
@@ -3913,7 +3955,7 @@ const make = Effect.gen(function* () {
           ),
         );
       }
-      yield* processClaimedProviderIntent(event);
+      yield* processClaimedProviderIntentWithRecovery(event);
       const delivery = yield* deliveryRepository.getDelivery({
         consumerName: PROVIDER_COMMAND_REACTOR_CONSUMER,
         eventSequence: input.eventSequence,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -2539,28 +2539,28 @@ const make = Effect.gen(function* () {
     yield* drainQueuedTurnsForSession(event.threadId);
   });
 
+  const recoverQueuedTurnPromotionsForThread = Effect.fnUntraced(function* (threadId: ThreadId) {
+    // `resolveThread` filters `deleted_at IS NULL`, so a soft-deleted (or fully
+    // missing) thread returns undefined. Cancel instead of dispatching into an
+    // absent thread, including when an operator retries an older dead delivery
+    // after the corresponding thread deletion has already been consumed.
+    const thread = yield* resolveThread(threadId);
+    if (!thread || thread.deletedAt !== null) {
+      yield* queuedTurnPromotions.cancelThread({
+        threadId,
+        updatedAt: new Date().toISOString(),
+      });
+      return;
+    }
+    if (yield* hasLiveProviderTurn(threadId)) {
+      return;
+    }
+    yield* drainQueuedTurnsForThread(threadId);
+  });
+
   const recoverQueuedTurnPromotions = Effect.gen(function* () {
     yield* Effect.forEach(yield* queuedTurnPromotions.listPendingThreadIds, (rawThreadId) =>
-      Effect.gen(function* () {
-        const threadId = ThreadId.makeUnsafe(rawThreadId);
-        // Resolve the projected thread first. `resolveThread` filters
-        // `deleted_at IS NULL`, so a soft-deleted (or fully missing) thread
-        // returns undefined; either way there is nothing to drain into, and the
-        // pending promotions must be cancelled rather than promoted (otherwise a
-        // deletion that raced startup would leave orphan turns to dispatch).
-        const thread = yield* resolveThread(threadId);
-        if (!thread || thread.deletedAt !== null) {
-          yield* queuedTurnPromotions.cancelThread({
-            threadId: rawThreadId,
-            updatedAt: new Date().toISOString(),
-          });
-          return;
-        }
-        if (yield* hasLiveProviderTurn(threadId)) {
-          return;
-        }
-        yield* drainQueuedTurnsForThread(threadId);
-      }),
+      recoverQueuedTurnPromotionsForThread(ThreadId.makeUnsafe(rawThreadId)),
     );
   });
 
@@ -3535,10 +3535,8 @@ const make = Effect.gen(function* () {
       // Recovery drain: if the provider turn settled between the decider's
       // (stale) running check and the durable enqueue, its terminal runtime
       // event has already been consumed and cannot drain this queue. Re-check
-      // live provider state after delivery settlement and promote immediately.
-      if (!(yield* hasLiveProviderTurn(event.payload.threadId))) {
-        yield* drainQueuedTurnsForThread(event.payload.threadId);
-      }
+      // the projected thread and live provider state after delivery settlement.
+      yield* recoverQueuedTurnPromotionsForThread(event.payload.threadId);
     }).pipe(
       Effect.catchCause((cause) => {
         if (Cause.hasInterruptsOnly(cause)) {

--- a/apps/server/src/orchestration/providerIntentClassification.ts
+++ b/apps/server/src/orchestration/providerIntentClassification.ts
@@ -51,7 +51,12 @@ export const isProviderIntentEvent = (event: OrchestrationEvent): event is Provi
   isProviderIntentEventType(event.type);
 
 export const isReplaySafeClaimedProviderIntent = (event: ProviderIntentEvent): boolean =>
-  event.type === "thread.created" || event.type === "thread.archived";
+  event.type === "thread.created" ||
+  event.type === "thread.archived" ||
+  // The claimed handler only performs the idempotent durable enqueue. Queue
+  // draining runs after the delivery settles, so replay never repeats provider
+  // dispatch as part of this claim.
+  event.type === "thread.turn-queued";
 
 export const isProviderSideEffectIntent = (event: ProviderIntentEvent): boolean =>
   event.type !== "thread.created" &&


### PR DESCRIPTION
## Summary

- claim the durable queued-turn enqueue before advancing its provider cursor
- retry transient persistence failures instead of losing the promotion
- run the recovery drain after every successful claimed settlement, including startup and operator reconciliation

## Verification

- focused ProviderCommandReactor queue, promotion, and reconciliation tests passed