### PR TITLE
fix: expose Pi thinking level max

### DIFF
--- a/apps/server/src/provider/Layers/PiAdapter.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.test.ts
@@ -451,13 +451,16 @@ describe("getPiSupportedThinkingOptions", () => {
     expect(getPiSupportedThinkingOptions(makePiModel({ reasoning: false }))).toEqual([]);
   });
 
-  it("advertises xhigh only when the concrete Pi model supports it", () => {
-    const withoutXHigh = getPiSupportedThinkingOptions(makePiModel({ reasoning: true }));
+  it("advertises xhigh and max only when the concrete Pi model supports them", () => {
+    const withoutExtended = getPiSupportedThinkingOptions(makePiModel({ reasoning: true }));
     const withXHigh = getPiSupportedThinkingOptions(
       makePiModel({ reasoning: true, thinkingLevelMap: { xhigh: "xhigh" } }),
     );
+    const withMax = getPiSupportedThinkingOptions(
+      makePiModel({ reasoning: true, thinkingLevelMap: { max: "max" } }),
+    );
 
-    expect(withoutXHigh.map((option) => option.value)).toEqual([
+    expect(withoutExtended.map((option) => option.value)).toEqual([
       "off",
       "minimal",
       "low",
@@ -471,6 +474,14 @@ describe("getPiSupportedThinkingOptions", () => {
       "medium",
       "high",
       "xhigh",
+    ]);
+    expect(withMax.map((option) => option.value)).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "max",
     ]);
   });
 
@@ -489,6 +500,25 @@ describe("getPiSupportedThinkingOptions", () => {
     );
 
     expect(options.map((option) => option.value)).toEqual(["minimal", "low", "medium", "high"]);
+  });
+
+  it("preserves kimi-k3 style ladders that expose low, high, and max", () => {
+    const options = getPiSupportedThinkingOptions(
+      makePiModel({
+        reasoning: true,
+        thinkingLevelMap: {
+          off: null,
+          minimal: null,
+          low: "low",
+          medium: null,
+          high: "high",
+          xhigh: null,
+          max: "max",
+        },
+      }),
+    );
+
+    expect(options.map((option) => option.value)).toEqual(["low", "high", "max"]);
   });
 });
 

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -102,7 +102,8 @@ const PI_THINKING_OPTIONS: ReadonlyArray<{
   { value: "low", label: "Low", description: "Faster reasoning" },
   { value: "medium", label: "Medium", description: "Balanced reasoning", isDefault: true },
   { value: "high", label: "High", description: "Deeper reasoning" },
-  { value: "xhigh", label: "Extra High", description: "Maximum reasoning" },
+  { value: "xhigh", label: "Extra High", description: "Extra-high reasoning" },
+  { value: "max", label: "Max", description: "Maximum reasoning" },
 ];
 const PI_DEFAULT_SUPPORTED_THINKING_LEVELS = new Set<ThinkingLevel>([
   "off",
@@ -496,7 +497,8 @@ function isPiThinkingLevel(value: string | null | undefined): value is ThinkingL
     value === "low" ||
     value === "medium" ||
     value === "high" ||
-    value === "xhigh"
+    value === "xhigh" ||
+    value === "max"
   );
 }
 

--- a/apps/server/src/serverLayers.device.test.ts
+++ b/apps/server/src/serverLayers.device.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { Effect, Layer, ServiceMap } from "effect";
 
+import { ThreadId } from "@synara/contracts";
+
 import { DeviceManager } from "./device/DeviceManager";
 import { FakeDeviceBackend } from "./device/FakeDeviceBackend";
 import { DeviceService } from "./device/Services/DeviceService";
@@ -14,7 +16,7 @@ class ThreadDeletionDeviceProbe extends ServiceMap.Service<
 
 describe("thread deletion reactor device-service wiring", () => {
   it("feeds the same DeviceService instance into lifecycle cleanup", async () => {
-    const threadId = "thread-delete-layer-wiring";
+    const threadId = ThreadId.makeUnsafe("thread-delete-layer-wiring");
     const backend = new FakeDeviceBackend();
     const manager = new DeviceManager({ backend });
     await backend.boot("FAKE-0001");

--- a/apps/web/src/components/chat/composerProviderRegistry.test.tsx
+++ b/apps/web/src/components/chat/composerProviderRegistry.test.tsx
@@ -763,6 +763,52 @@ describe("getComposerProviderState", () => {
     });
   });
 
+  it("keeps Pi max thinking selections when discovery advertises max", () => {
+    const runtimeModel: ProviderModelDescriptor = {
+      slug: "moonshotai/kimi-k3",
+      name: "Kimi K3",
+      upstreamProviderId: "moonshotai",
+      upstreamProviderName: "Moonshot AI",
+      supportedReasoningEfforts: [
+        { value: "low", label: "Low" },
+        { value: "high", label: "High" },
+        { value: "max", label: "Max" },
+      ],
+      defaultReasoningEffort: "high",
+    };
+    const selection = getComposerTraitSelection(
+      "pi",
+      "moonshotai/kimi-k3",
+      "",
+      { thinkingLevel: "max" },
+      runtimeModel,
+    );
+    const state = getComposerProviderState({
+      provider: "pi",
+      model: "moonshotai/kimi-k3",
+      runtimeModel,
+      prompt: "",
+      modelOptions: {
+        pi: {
+          thinkingLevel: "max",
+        },
+      },
+    });
+
+    expect(selection.effort).toBe("max");
+    expect(selection.primarySelectDescriptor).toMatchObject({
+      id: "thinkingLevel",
+      currentValue: "max",
+    });
+    expect(state).toEqual({
+      provider: "pi",
+      promptEffort: "max",
+      modelOptionsForDispatch: {
+        thinkingLevel: "max",
+      },
+    });
+  });
+
   it("does not render a traits picker for OpenCode models without exposed controls", () => {
     const threadId = ThreadId.makeUnsafe("thread-opencode-traits-hidden");
 

--- a/apps/web/src/components/chat/runtimeModelCapabilities.ts
+++ b/apps/web/src/components/chat/runtimeModelCapabilities.ts
@@ -31,6 +31,8 @@ function runtimeEffortLabel(value: string): string {
       return "High";
     case "xhigh":
       return "Extra High";
+    case "max":
+      return "Max";
     default:
       return value
         .split(/[-_\s]+/u)

--- a/apps/web/src/composerDraftModels.ts
+++ b/apps/web/src/composerDraftModels.ts
@@ -385,7 +385,8 @@ export function normalizeProviderModelOptions(
     piCandidate?.thinkingLevel === "low" ||
     piCandidate?.thinkingLevel === "medium" ||
     piCandidate?.thinkingLevel === "high" ||
-    piCandidate?.thinkingLevel === "xhigh"
+    piCandidate?.thinkingLevel === "xhigh" ||
+    piCandidate?.thinkingLevel === "max"
       ? piCandidate.thinkingLevel
       : undefined;
   const pi = piThinkingLevel !== undefined ? { thinkingLevel: piThinkingLevel } : undefined;

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -24,6 +24,7 @@ export const PI_THINKING_LEVEL_OPTIONS = [
   "medium",
   "high",
   "xhigh",
+  "max",
 ] as const;
 export type PiThinkingLevel = (typeof PI_THINKING_LEVEL_OPTIONS)[number];
 export const GROK_REASONING_EFFORT_OPTIONS = ["none", "low", "medium", "high"] as const;

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -28,6 +28,7 @@ import {
   normalizeCodexModelOptions,
   normalizeGrokModelOptions,
   normalizeModelSlug,
+  normalizePiModelOptions,
   parseCursorCliReasoningEffort,
   resolveApiModelId,
   resolveSelectableModel,
@@ -866,6 +867,15 @@ describe("normalizeGrokModelOptions", () => {
     expect(normalizeGrokModelOptions("grok-4.5", { reasoningEffort: "high" })).toEqual({
       reasoningEffort: "high",
     });
+  });
+});
+
+describe("normalizePiModelOptions", () => {
+  it("keeps supported Pi thinking levels including max", () => {
+    expect(normalizePiModelOptions({ thinkingLevel: "high" })).toEqual({ thinkingLevel: "high" });
+    expect(normalizePiModelOptions({ thinkingLevel: "max" })).toEqual({ thinkingLevel: "max" });
+    expect(normalizePiModelOptions({ thinkingLevel: "ultra" as never })).toBeUndefined();
+    expect(normalizePiModelOptions({})).toBeUndefined();
   });
 });
 

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -48,6 +48,7 @@ const PI_THINKING_LEVEL_SET = new Set<PiThinkingLevel>([
   "medium",
   "high",
   "xhigh",
+  "max",
 ]);
 export const EMPTY_MODEL_CAPABILITIES: ModelCapabilities = {
   reasoningEffortLevels: [],


### PR DESCRIPTION
﻿## Summary
- Fix missing Pi thinking level `max` end-to-end (contracts/shared/PiAdapter/UI). Pi SDK models such as `kimi-k3` already advertise `max`, but Synara's whitelist stopped at `xhigh`, so the picker dropped it.
- Unblock typecheck inherited from `main` after #529: device deletion wiring test now passes a branded `ThreadId` into `detachThreadDevice`.

## Test plan
- [ ] Open Synara (Dev), select provider **Pi**
- [ ] Select **kimi-k3** and verify thinking/effort options include **low / high / max**
- [ ] Spot-check another Pi reasoning model still shows its expected thinking levels
- [ ] CI typecheck passes
