### PR TITLE
DO NOT MERGE: fix(server): brand thread id in device lifecycle test

### DIFF
--- a/apps/server/src/serverLayers.device.test.ts
+++ b/apps/server/src/serverLayers.device.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { Effect, Layer, ServiceMap } from "effect";
 
+import { ThreadId } from "@synara/contracts";
 import { DeviceManager } from "./device/DeviceManager";
 import { FakeDeviceBackend } from "./device/FakeDeviceBackend";
 import { DeviceService } from "./device/Services/DeviceService";
@@ -14,7 +15,7 @@ class ThreadDeletionDeviceProbe extends ServiceMap.Service<
 
 describe("thread deletion reactor device-service wiring", () => {
   it("feeds the same DeviceService instance into lifecycle cleanup", async () => {
-    const threadId = "thread-delete-layer-wiring";
+    const threadId = ThreadId.makeUnsafe("thread-delete-layer-wiring");
     const backend = new FakeDeviceBackend();
     const manager = new DeviceManager({ backend });
     await backend.boot("FAKE-0001");


### PR DESCRIPTION
Fixes a typecheck regression on main introduced by #529 (feat(device): iOS Simulator pane).

The new test file `apps/server/src/serverLayers.device.test.ts` passes a plain `string` to `detachThreadDevice(threadId: ThreadId)`, where `ThreadId` is a branded string from `@synara/contracts`. Upstream main 467d2f218 fails `bun run typecheck` at `serverLayers.device.test.ts(28,35)` with `TS2345: Argument of type 'string' is not assignable to parameter of type 'string & Brand<"ThreadId">'`.

This is a one-line, behavior-neutral fix: construct the test thread id with `ThreadId.makeUnsafe(...)`, matching the established pattern used across `apps/server` (e.g. `externalMcp/waitForTask.ts`, `http.ts`). No runtime behavior changes.

## Verification

- `bun run typecheck` passes across all 7 workspace packages (7/7 tasks).
- The only change is the brand on the test-local string.

Please merge upstream so PRs rebased on 467d2f218 stop failing typecheck through no fault of their own.