### PR TITLE
feat(providers): introduce profile-aware provider targets

### DIFF
--- a/apps/server/integration/orchestrationEngine.integration.test.ts
+++ b/apps/server/integration/orchestrationEngine.integration.test.ts
@@ -5,6 +5,7 @@ import {
   ApprovalRequestId,
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
+  DEFAULT_PROVIDER_PROFILE_ID,
   DEFAULT_MODEL_BY_PROVIDER,
   EventId,
   MessageId,
@@ -135,6 +136,7 @@ const seedProjectAndThread = (harness: OrchestrationIntegrationHarness) =>
       workspaceRoot: harness.workspaceDir,
       defaultModelSelection: {
         provider,
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: defaultModel,
       },
       createdAt,
@@ -148,6 +150,7 @@ const seedProjectAndThread = (harness: OrchestrationIntegrationHarness) =>
       title: "Integration Thread",
       modelSelection: {
         provider,
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: defaultModel,
       },
       interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -284,6 +287,7 @@ it.live.skipIf(!process.env.CODEX_BINARY_PATH)(
           workspaceRoot: harness.workspaceDir,
           defaultModelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5.3-codex",
           },
           createdAt,
@@ -297,6 +301,7 @@ it.live.skipIf(!process.env.CODEX_BINARY_PATH)(
           title: "Integration Thread",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5.3-codex",
           },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -962,6 +967,7 @@ it.live("starts a claudeAgent session on first turn when provider is requested",
           text: "Use Claude",
           modelSelection: {
             provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "claude-sonnet-4-6",
           },
         });
@@ -1021,6 +1027,7 @@ itLiveUnlessCi(
             text: "Before restart",
             modelSelection: {
               provider: "claudeAgent",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: "claude-sonnet-4-6",
             },
           });
@@ -1139,6 +1146,7 @@ it.live("forwards claudeAgent approval responses to the provider session", () =>
           text: "Need approval",
           modelSelection: {
             provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "claude-sonnet-4-6",
           },
         });
@@ -1220,6 +1228,7 @@ it.live("forwards thread.turn.interrupt to claudeAgent provider sessions", () =>
           text: "Start long turn",
           modelSelection: {
             provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "claude-sonnet-4-6",
           },
         });
@@ -1293,6 +1302,7 @@ itLiveUnlessCi("reverts claudeAgent turns and rolls back provider conversation s
           text: "First Claude edit",
           modelSelection: {
             provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "claude-sonnet-4-6",
           },
         });

--- a/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
@@ -15,6 +15,7 @@ import type {
 import {
   AutomationId,
   DEFAULT_AUTOMATION_STOP_CONFIDENCE_THRESHOLD,
+  DEFAULT_PROVIDER_PROFILE_ID,
   EventId,
   MessageId,
   ModelSelection,
@@ -88,7 +89,7 @@ function makeThreadShell(
     id: ThreadId.makeUnsafe(id),
     projectId: PROJECT_ID,
     title: `Thread ${id}`,
-    modelSelection: { provider: "codex", model: "gpt-5.5" },
+    modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.5" },
     runtimeMode: "approval-required",
     interactionMode: "default",
     envMode: "local",
@@ -195,7 +196,7 @@ function makeAutomationDefinition(
     schedule: { type: "interval", everySeconds: 300 },
     enabled: true,
     nextRunAt: NOW,
-    modelSelection: { provider: "codex", model: "gpt-5.5" },
+    modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.5" },
     runtimeMode: "approval-required",
     interactionMode: "default",
     worktreeMode: "local",
@@ -1642,7 +1643,11 @@ describe("AgentGateway", () => {
       for (const construction of Object.values(targetConstruction)) {
         const exampleTarget = construction.exampleTarget;
         if (exampleTarget === null || exampleTarget === undefined) continue;
-        assert.deepEqual(Schema.decodeUnknownSync(ModelSelection)(exampleTarget), exampleTarget);
+        assert.equal("profileId" in exampleTarget, false);
+        assert.equal(
+          Schema.decodeUnknownSync(ModelSelection)(exampleTarget).profileId,
+          DEFAULT_PROVIDER_PROFILE_ID,
+        );
       }
 
       const serialized = JSON.stringify(payload);
@@ -1716,7 +1721,7 @@ describe("AgentGateway", () => {
         }),
         makeThreadShell("thread-other", {
           title: "Unrelated task",
-          modelSelection: { provider: "claudeAgent", model: "opus-4.8" },
+          modelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "opus-4.8" },
           updatedAt: "2026-02-01T10:00:00.000Z",
         }),
       ];
@@ -3087,6 +3092,7 @@ describe("AgentGateway", () => {
       if (create?.type === "thread.create") {
         assert.deepEqual(create.modelSelection, {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.6-terra",
           options: { reasoningEffort: "low" },
         });
@@ -3829,10 +3835,11 @@ describe("AgentGateway", () => {
             index === 0
               ? {
                   provider: "codex",
+                  profileId: DEFAULT_PROVIDER_PROFILE_ID,
                   model: "gpt-5.6-terra",
                   options: { reasoningEffort: "low" },
                 }
-              : { provider: "claudeAgent", model: "claude-sonnet-5" },
+              : { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "claude-sonnet-5" },
           latestTurn: {
             turnId: runId,
             state: "completed",
@@ -3909,10 +3916,15 @@ describe("AgentGateway", () => {
         [
           {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5.6-terra",
             options: { reasoningEffort: "low" },
           },
-          { provider: "claudeAgent", model: "claude-sonnet-5" },
+          {
+            provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
+            model: "claude-sonnet-5",
+          },
         ],
       );
     }).pipe(Effect.provide(gatewayLayer));

--- a/apps/server/src/agentGateway/creationCoordinator.ts
+++ b/apps/server/src/agentGateway/creationCoordinator.ts
@@ -38,6 +38,7 @@ import type {
 import { resolveExternalMcpRuntimePolicy } from "../externalMcp/runtimePolicy.ts";
 import {
   canonicalJson,
+  fingerprintGatewayCreateThreadsInput,
   gatewayIsoNow,
   makeAgentCreationIds,
   stableGatewayDigest,
@@ -333,7 +334,7 @@ export const makeCreateThreadsHandler = Effect.fn(function* (
         ...(callerTurnId ? { callerTurnId } : {}),
         requestId: input.requestId,
       })}`;
-      const fingerprint = stableGatewayDigest(input, 64);
+      const fingerprint = fingerprintGatewayCreateThreadsInput(input);
       const externalOperationRepository =
         context.kind === "external-client" ? externalMcpRepository : undefined;
       if (context.kind === "external-client" && externalOperationRepository === undefined) {

--- a/apps/server/src/agentGateway/creationUtils.test.ts
+++ b/apps/server/src/agentGateway/creationUtils.test.ts
@@ -1,0 +1,54 @@
+import { SynaraCreateThreadsInput } from "@synara/contracts";
+import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { fingerprintGatewayCreateThreadsInput } from "./creationUtils.ts";
+
+const decodeCreateInput = Schema.decodeUnknownSync(SynaraCreateThreadsInput);
+
+describe("fingerprintGatewayCreateThreadsInput", () => {
+  it("preserves the legacy default-profile fingerprint without erasing explicit profiles", () => {
+    const legacyInput = {
+      requestId: "legacy-profile-retry",
+      threads: [
+        {
+          prompt: "Do the work",
+          target: {
+            provider: "codex",
+            model: "gpt-5.5",
+            options: { reasoningEffort: "high" },
+          },
+        },
+      ],
+    } as const;
+    const explicitDefaultInput = {
+      ...legacyInput,
+      threads: [
+        {
+          ...legacyInput.threads[0],
+          target: { ...legacyInput.threads[0].target, profileId: "default" },
+        },
+      ],
+    } as const;
+    const workInput = {
+      ...legacyInput,
+      threads: [
+        {
+          ...legacyInput.threads[0],
+          target: { ...legacyInput.threads[0].target, profileId: "work" },
+        },
+      ],
+    } as const;
+
+    const legacyFingerprint = fingerprintGatewayCreateThreadsInput(decodeCreateInput(legacyInput));
+    expect(legacyFingerprint).toBe(
+      "dd350426be22577bedac4d86f8c2b49af3b562c0898844f1063abfd8e6098a06",
+    );
+    expect(fingerprintGatewayCreateThreadsInput(decodeCreateInput(explicitDefaultInput))).toBe(
+      legacyFingerprint,
+    );
+    expect(fingerprintGatewayCreateThreadsInput(decodeCreateInput(workInput))).not.toBe(
+      legacyFingerprint,
+    );
+  });
+});

--- a/apps/server/src/agentGateway/creationUtils.ts
+++ b/apps/server/src/agentGateway/creationUtils.ts
@@ -1,6 +1,12 @@
 import { createHash } from "node:crypto";
 
-import { CommandId, MessageId, ThreadId } from "@synara/contracts";
+import {
+  CommandId,
+  DEFAULT_PROVIDER_PROFILE_ID,
+  MessageId,
+  ThreadId,
+  type SynaraCreateThreadsInput,
+} from "@synara/contracts";
 
 export function slugifyAgentTask(value: string): string {
   return (
@@ -29,6 +35,23 @@ export function canonicalJson(value: unknown): string {
 
 export function stableGatewayDigest(value: unknown, length = 32): string {
   return createHash("sha256").update(canonicalJson(value)).digest("hex").slice(0, length);
+}
+
+/** Preserves pre-profile hashes for retries of already-reserved create operations. */
+export function fingerprintGatewayCreateThreadsInput(input: SynaraCreateThreadsInput): string {
+  return stableGatewayDigest(
+    {
+      ...input,
+      threads: input.threads.map(({ target, ...thread }) => {
+        if (target.profileId !== DEFAULT_PROVIDER_PROFILE_ID) {
+          return { ...thread, target };
+        }
+        const { profileId: _profileId, ...legacyTarget } = target;
+        return { ...thread, target: legacyTarget };
+      }),
+    },
+    64,
+  );
 }
 
 export function makeAgentCreationIds(operationId: string, index: number) {

--- a/apps/server/src/agentGateway/mcpTransport.test.ts
+++ b/apps/server/src/agentGateway/mcpTransport.test.ts
@@ -1,5 +1,11 @@
 import { assert, describe, it } from "@effect/vitest";
-import { ProjectId, ThreadId, TurnId, type OrchestrationThreadShell } from "@synara/contracts";
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  ProjectId,
+  ThreadId,
+  TurnId,
+  type OrchestrationThreadShell,
+} from "@synara/contracts";
 import { Deferred, Effect, Fiber, Option } from "effect";
 
 import type { ProjectionSnapshotQueryShape } from "../orchestration/Services/ProjectionSnapshotQuery.ts";
@@ -19,7 +25,11 @@ function makeThread(threadId: string): OrchestrationThreadShell {
     id: ThreadId.makeUnsafe(threadId),
     projectId: ProjectId.makeUnsafe("project-mcp-cancellation"),
     title: threadId,
-    modelSelection: { provider: "codex", model: "gpt-5.6-sol" },
+    modelSelection: {
+      provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
+      model: "gpt-5.6-sol",
+    },
     runtimeMode: "full-access",
     interactionMode: "default",
     envMode: "local",

--- a/apps/server/src/agentGateway/targetResolver.test.ts
+++ b/apps/server/src/agentGateway/targetResolver.test.ts
@@ -1,5 +1,10 @@
 import { assert, describe, it } from "@effect/vitest";
-import type { ModelSelection, ProviderKind, ProviderModelDescriptor } from "@synara/contracts";
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  type ModelSelection,
+  type ProviderKind,
+  type ProviderModelDescriptor,
+} from "@synara/contracts";
 import { Effect } from "effect";
 
 import type { ProviderDiscoveryServiceShape } from "../provider/Services/ProviderDiscoveryService.ts";
@@ -79,10 +84,16 @@ describe("agent gateway target resolver", () => {
       });
       assert.deepEqual(
         yield* resolveAgentGatewayTarget({
-          target: codexGuidance.exampleTarget!,
+          target: {
+            ...codexGuidance.exampleTarget!,
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          },
           discovery,
         }),
-        codexGuidance.exampleTarget,
+        {
+          ...codexGuidance.exampleTarget,
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+        },
       );
 
       const antigravityGuidance = agentGatewayTargetOptionGuidance({
@@ -155,7 +166,7 @@ describe("agent gateway target resolver", () => {
   it.effect("rejects a guessed model slug before creation", () =>
     Effect.gen(function* () {
       const result = yield* resolveAgentGatewayTarget({
-        target: { provider: "codex", model: "gpt-5.6-terra-low" },
+        target: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.6-terra-low" },
         discovery,
       }).pipe(
         Effect.map(() => ({ code: "unexpected-success" })),
@@ -170,6 +181,7 @@ describe("agent gateway target resolver", () => {
       const result = yield* resolveAgentGatewayTarget({
         target: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.6-terra",
           options: { reasoningEffort: "ultra" },
         },
@@ -432,7 +444,7 @@ describe("agent gateway target resolver", () => {
           listModels: () => Effect.succeed({ source: "test", models: [unavailableDescriptor] }),
         } as unknown as ProviderDiscoveryServiceShape;
         const result = yield* resolveAgentGatewayTarget({
-          target: { provider: "cursor", model: descriptor.slug, options },
+          target: { provider: "cursor", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: descriptor.slug, options },
           discovery: unavailableDiscovery,
         }).pipe(
           Effect.map(() => ({ code: "unexpected-success" })),
@@ -529,7 +541,7 @@ describe("agent gateway target resolver", () => {
         },
       } as unknown as ProviderDiscoveryServiceShape;
       const result = yield* resolveAgentGatewayTarget({
-        target: { provider: "codex", model: "gpt-5.5" },
+        target: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.5" },
         discovery: trackedDiscovery,
         availability: { enabled: false },
       }).pipe(
@@ -544,7 +556,7 @@ describe("agent gateway target resolver", () => {
   it.effect("rejects a known unavailable or unauthenticated provider", () =>
     Effect.gen(function* () {
       const result = yield* resolveAgentGatewayTarget({
-        target: { provider: "codex", model: "gpt-5.5" },
+        target: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.5" },
         discovery,
         availability: {
           enabled: true,
@@ -579,7 +591,7 @@ describe("agent gateway target resolver", () => {
       );
 
       const customResult = yield* resolveAgentGatewayTarget({
-        target: { provider: "codex", model: "gpt-5.6-terra" },
+        target: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.6-terra" },
         discovery: unavailableDiscovery,
         availability: { enabled: true, available: true, authStatus: "authenticated" },
       }).pipe(
@@ -591,6 +603,7 @@ describe("agent gateway target resolver", () => {
       const invalidOption = yield* resolveAgentGatewayTarget({
         target: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.5",
           options: { reasoningEffort: "invented" },
         },

--- a/apps/server/src/agentGateway/toolInput.ts
+++ b/apps/server/src/agentGateway/toolInput.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_MODEL_BY_PROVIDER,
+  DEFAULT_PROVIDER_PROFILE_ID,
   SynaraCreateThreadsInput,
   SynaraWaitForThreadsInput,
   type ModelSelection,
@@ -141,7 +142,11 @@ export function buildModelSelection(
       `Provider "${provider}" has no default model; pass an explicit "model" argument.`,
     );
   }
-  return { provider, model: effectiveModel } as ModelSelection;
+  return {
+    provider,
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
+    model: effectiveModel,
+  } as ModelSelection;
 }
 
 export function decodeCreateThreadsInput(value: unknown) {

--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -5,6 +5,7 @@ import {
   AutomationRunId,
   CommandId,
   DEFAULT_AUTOMATION_STOP_CONFIDENCE_THRESHOLD,
+  DEFAULT_PROVIDER_PROFILE_ID,
   MessageId,
   ProjectId,
   ThreadId,
@@ -47,6 +48,7 @@ const project: OrchestrationProjectShell = {
   workspaceRoot: "/tmp/automation-project",
   defaultModelSelection: {
     provider: "codex",
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
     model: "gpt-5-codex",
   },
   scripts: [],
@@ -332,6 +334,7 @@ const createInput = (
   schedule: { type: "manual" },
   modelSelection: {
     provider: "codex",
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
     model: "gpt-5-codex",
   },
   worktreeMode,
@@ -1902,7 +1905,7 @@ layer("AutomationService", (it) => {
         scheduledFor: "2000-01-01T00:00:00.000Z",
         permissionSnapshot: {
           provider: "codex",
-          modelSelection: { provider: "codex", model: "gpt-5-codex" },
+          modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
           runtimeMode: "approval-required",
           interactionMode: "default",
           worktreeMode: "local",
@@ -1967,7 +1970,7 @@ layer("AutomationService", (it) => {
         scheduledFor: "2000-01-01T00:00:00.000Z",
         permissionSnapshot: {
           provider: "codex",
-          modelSelection: { provider: "codex", model: "gpt-5-codex" },
+          modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
           runtimeMode: "approval-required",
           interactionMode: "default",
           worktreeMode: "local",
@@ -2973,6 +2976,7 @@ layer("AutomationService", (it) => {
         targetThreadId,
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-8",
         },
         completionPolicy: aiCompletionPolicy("the PR is ready"),
@@ -2995,6 +2999,7 @@ layer("AutomationService", (it) => {
 
       assert.deepStrictEqual(completionEvaluationInputs.at(-1)?.modelSelection, {
         provider: "cursor",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "composer-2",
       });
     }),
@@ -4755,7 +4760,7 @@ layer("AutomationService", (it) => {
         scheduledFor: "2026-06-16T10:00:00.000Z",
         permissionSnapshot: {
           provider: "codex",
-          modelSelection: { provider: "codex", model: "gpt-5-codex" },
+          modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
           runtimeMode: "approval-required",
           interactionMode: "default",
           worktreeMode: "local",
@@ -4813,7 +4818,7 @@ layer("AutomationService", (it) => {
             scheduledFor: now,
             permissionSnapshot: {
               provider: "codex",
-              modelSelection: { provider: "codex", model: "gpt-5-codex" },
+              modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
               runtimeMode: "approval-required",
               interactionMode: "default",
               worktreeMode: "local",
@@ -4863,7 +4868,7 @@ layer("AutomationService", (it) => {
         scheduledFor: "2026-06-16T10:00:00.000Z",
         permissionSnapshot: {
           provider: "codex",
-          modelSelection: { provider: "codex", model: "gpt-5-codex" },
+          modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
           runtimeMode: "approval-required",
           interactionMode: "default",
           worktreeMode: "local",
@@ -5008,7 +5013,7 @@ layer("AutomationService", (it) => {
           scheduledFor,
           permissionSnapshot: {
             provider: "codex",
-            modelSelection: { provider: "codex", model: "gpt-5-codex" },
+            modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
             runtimeMode: "approval-required",
             interactionMode: "default",
             worktreeMode: "local",

--- a/apps/server/src/automation/runEnvelope.test.ts
+++ b/apps/server/src/automation/runEnvelope.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   AutomationId,
   AutomationRunId,
   ProjectId,
@@ -35,7 +36,7 @@ function run(overrides: Partial<AutomationRun> = {}): AutomationRun {
     scheduledFor: "2026-07-23T09:00:00.000Z",
     permissionSnapshot: {
       provider: "codex",
-      modelSelection: { provider: "codex", model: "gpt-5-codex" },
+      modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
       runtimeMode: "approval-required",
       interactionMode: "default",
       worktreeMode: "local",

--- a/apps/server/src/git/Layers/CursorTextGeneration.test.ts
+++ b/apps/server/src/git/Layers/CursorTextGeneration.test.ts
@@ -11,6 +11,7 @@ import { expect } from "vitest";
 import { TextGenerationError } from "../Errors.ts";
 import { TextGeneration } from "../Services/TextGeneration.ts";
 import { CursorTextGenerationLive } from "./CursorTextGeneration.ts";
+import { DEFAULT_PROVIDER_PROFILE_ID } from "@synara/contracts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const mockAgentPath = path.join(__dirname, "../../../scripts/acp-mock-agent.ts");
@@ -106,6 +107,7 @@ it.layer(CursorTextGenerationTestLayer)("CursorTextGenerationLive", (it) => {
               "diff --git a/apps/server/src/git/Layers/CursorTextGeneration.ts b/apps/server/src/git/Layers/CursorTextGeneration.ts",
             modelSelection: {
               provider: "cursor",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: "gpt-5.4",
               options: {
                 reasoningEffort: "xhigh",
@@ -189,6 +191,7 @@ it.layer(CursorTextGenerationTestLayer)("CursorTextGenerationLive", (it) => {
             stagedPatch: "diff --git a/README.md b/README.md",
             modelSelection: {
               provider: "cursor",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: "composer-2",
             },
             providerOptions: {
@@ -220,6 +223,7 @@ it.layer(CursorTextGenerationTestLayer)("CursorTextGenerationLive", (it) => {
             patch: "diff --git a/file.ts b/file.ts",
             modelSelection: {
               provider: "cursor",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: "composer-2",
             },
             providerOptions: {
@@ -248,6 +252,7 @@ it.layer(CursorTextGenerationTestLayer)("CursorTextGenerationLive", (it) => {
             message: "Improve sidebar thread row spacing and hover states.",
             modelSelection: {
               provider: "cursor",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: "composer-2",
             },
             providerOptions: {
@@ -276,6 +281,7 @@ it.layer(CursorTextGenerationTestLayer)("CursorTextGenerationLive", (it) => {
             message: "Fix the websocket reconnect backoff.",
             modelSelection: {
               provider: "cursor",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: "composer-2",
             },
             providerOptions: {
@@ -306,6 +312,7 @@ it.layer(CursorTextGenerationTestLayer)("CursorTextGenerationLive", (it) => {
               message: "Fix the websocket reconnect backoff.",
               modelSelection: {
                 provider: "cursor",
+                profileId: DEFAULT_PROVIDER_PROFILE_ID,
                 model: "composer-2",
               },
               providerOptions: {
@@ -352,6 +359,7 @@ it.layer(CursorTextGenerationTestLayer)("CursorTextGenerationLive", (it) => {
             message: "Fix the reconnect spinner after a resumed session.",
             modelSelection: {
               provider: "cursor",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: "composer-2",
             },
             providerOptions: {

--- a/apps/server/src/git/Layers/OpenCodeTextGeneration.test.ts
+++ b/apps/server/src/git/Layers/OpenCodeTextGeneration.test.ts
@@ -5,6 +5,7 @@
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
+import { DEFAULT_PROVIDER_PROFILE_ID } from "@synara/contracts";
 import { Duration, Effect, Fiber, Layer } from "effect";
 import { TestClock } from "effect/testing";
 import { beforeEach, expect } from "vitest";
@@ -142,6 +143,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
 
 const DEFAULT_TEST_MODEL_SELECTION = {
   provider: "opencode" as const,
+  profileId: DEFAULT_PROVIDER_PROFILE_ID,
   model: "openai/gpt-5",
 };
 
@@ -398,6 +400,7 @@ it.layer(OpenCodeTextGenerationTestLayer)("OpenCodeTextGenerationServiceLive", (
         message: "which model are you",
         modelSelection: {
           provider: "opencode",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "opencode/big-pickle",
           options: {
             agent: "build",

--- a/apps/server/src/git/Layers/OpenCodeTextGeneration.ts
+++ b/apps/server/src/git/Layers/OpenCodeTextGeneration.ts
@@ -6,12 +6,13 @@
 import { Effect, Exit, Fiber, Layer, Schema, Scope } from "effect";
 import * as Semaphore from "effect/Semaphore";
 
-import type {
-  ChatAttachment,
-  KiloModelSelection,
-  OpenCodeModelSelection,
-  OpenCodeModelOptions,
-  ProviderStartOptions,
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  type ChatAttachment,
+  type KiloModelSelection,
+  type OpenCodeModelSelection,
+  type OpenCodeModelOptions,
+  type ProviderStartOptions,
 } from "@synara/contracts";
 import { sanitizeGeneratedThreadTitle } from "@synara/shared/chatThreads";
 import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@synara/shared/git";
@@ -146,6 +147,7 @@ function resolveOpenCodeCompatibleModelSelection(
 
   return {
     provider: "opencode",
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
     model,
   };
 }

--- a/apps/server/src/git/Layers/ProviderTextGeneration.test.ts
+++ b/apps/server/src/git/Layers/ProviderTextGeneration.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PROVIDER_PROFILE_ID } from "@synara/contracts";
 import { Effect, Layer } from "effect";
 import { describe, expect, it, vi } from "vitest";
 
@@ -157,6 +158,7 @@ describe("ProviderTextGenerationLive", () => {
           patch: "diff --git a/file.ts b/file.ts",
           modelSelection: {
             provider: "kilo",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "kilo/kilo-auto/free",
           },
         });
@@ -179,6 +181,7 @@ describe("ProviderTextGenerationLive", () => {
           message: "Plan the deployment work",
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5",
             options: {
               agent: "plan",
@@ -200,6 +203,7 @@ describe("ProviderTextGenerationLive", () => {
       expect.objectContaining({
         modelSelection: {
           provider: "opencode",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "openai/gpt-5",
           options: {
             agent: "plan",
@@ -229,6 +233,7 @@ describe("ProviderTextGenerationLive", () => {
           message: "Plan the Cursor integration work",
           modelSelection: {
             provider: "cursor",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "composer-2",
             options: {
               reasoningEffort: "high",
@@ -250,6 +255,7 @@ describe("ProviderTextGenerationLive", () => {
       expect.objectContaining({
         modelSelection: {
           provider: "cursor",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "composer-2",
           options: {
             reasoningEffort: "high",
@@ -281,6 +287,7 @@ describe("ProviderTextGenerationLive", () => {
           nowIso: "2026-06-19T10:00:00.000Z",
           modelSelection: {
             provider: "cursor",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "composer-2",
           },
         });
@@ -313,6 +320,7 @@ describe("ProviderTextGenerationLive", () => {
           runAssistantText: "Still working.",
           modelSelection: {
             provider: "cursor",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "composer-2",
           },
         });

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -10,6 +10,7 @@ import type {
   ProviderSession,
 } from "@synara/contracts";
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   CheckpointRef,
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -396,6 +397,7 @@ describe("CheckpointReactor", () => {
         workspaceRoot: options?.projectWorkspaceRoot ?? cwd,
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         createdAt,
@@ -410,6 +412,7 @@ describe("CheckpointReactor", () => {
         title: "Thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -1874,7 +1877,7 @@ describe("CheckpointReactor", () => {
         threadId: childThreadId,
         projectId: asProjectId("project-1"),
         title: "Child revert",
-        modelSelection: { provider: "codex", model: "gpt-5-codex" },
+        modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "approval-required",
         parentThreadId: ThreadId.makeUnsafe("thread-1"),

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   CheckpointRef,
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -161,6 +162,7 @@ describe("OrchestrationEngine", () => {
         title: "Engine quiesce thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -289,6 +291,7 @@ describe("OrchestrationEngine", () => {
         workspaceRoot: "/tmp/project-1",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         createdAt,
@@ -303,6 +306,7 @@ describe("OrchestrationEngine", () => {
         title: "Thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -378,7 +382,7 @@ describe("OrchestrationEngine", () => {
         projectId: asProjectId("project-managed-attachment"),
         title: "Managed attachment project",
         workspaceRoot: "/tmp/project-managed-attachment",
-        defaultModelSelection: { provider: "codex", model: "gpt-5-codex" },
+        defaultModelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
         createdAt,
       }),
     );
@@ -389,7 +393,7 @@ describe("OrchestrationEngine", () => {
         threadId,
         projectId: asProjectId("project-managed-attachment"),
         title: "Managed attachment thread",
-        modelSelection: { provider: "codex", model: "gpt-5-codex" },
+        modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "approval-required",
         branch: null,
@@ -510,6 +514,7 @@ describe("OrchestrationEngine", () => {
         workspaceRoot: "/tmp/project-replay",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         createdAt,
@@ -524,6 +529,7 @@ describe("OrchestrationEngine", () => {
         title: "replay",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -568,6 +574,7 @@ describe("OrchestrationEngine", () => {
         workspaceRoot: "/tmp/project-stream",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         createdAt,
@@ -592,6 +599,7 @@ describe("OrchestrationEngine", () => {
           title: "domain-stream",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -629,6 +637,7 @@ describe("OrchestrationEngine", () => {
         workspaceRoot: "/tmp/project-turn-diff",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         createdAt,
@@ -643,6 +652,7 @@ describe("OrchestrationEngine", () => {
         title: "Turn diff thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -747,12 +757,12 @@ describe("OrchestrationEngine", () => {
         workspaceRoot: "/tmp/project-flaky",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         createdAt,
       }),
     );
-
     await expect(
       runtime.runPromise(
         engine.dispatch({
@@ -763,6 +773,7 @@ describe("OrchestrationEngine", () => {
           title: "flaky-fail",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -783,6 +794,7 @@ describe("OrchestrationEngine", () => {
         title: "flaky-ok",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -846,6 +858,7 @@ describe("OrchestrationEngine", () => {
         workspaceRoot: "/tmp/project-atomic",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         createdAt,
@@ -860,6 +873,7 @@ describe("OrchestrationEngine", () => {
         title: "atomic",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -993,6 +1007,7 @@ describe("OrchestrationEngine", () => {
           workspaceRoot: "/tmp/project-defect-1",
           defaultModelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           createdAt,
@@ -1010,6 +1025,7 @@ describe("OrchestrationEngine", () => {
           workspaceRoot: "/tmp/project-defect-2",
           defaultModelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           createdAt,
@@ -1111,6 +1127,7 @@ describe("OrchestrationEngine", () => {
         workspaceRoot: "/tmp/project-sync",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         createdAt,
@@ -1125,6 +1142,7 @@ describe("OrchestrationEngine", () => {
         title: "sync-before",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -1246,6 +1264,7 @@ describe("OrchestrationEngine", () => {
         workspaceRoot: "/tmp/project-deferred-recovery",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         createdAt,
@@ -1260,6 +1279,7 @@ describe("OrchestrationEngine", () => {
         title: "deferred-recovery",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -1363,6 +1383,7 @@ describe("OrchestrationEngine", () => {
         workspaceRoot: "/tmp/readd-project",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         createdAt,
@@ -1379,6 +1400,7 @@ describe("OrchestrationEngine", () => {
           workspaceRoot: "/tmp/readd-project",
           defaultModelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           createdAt,
@@ -1411,6 +1433,7 @@ describe("OrchestrationEngine", () => {
         workspaceRoot: "/tmp/active-project",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         createdAt,
@@ -1425,6 +1448,7 @@ describe("OrchestrationEngine", () => {
         title: "active",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -1445,6 +1469,7 @@ describe("OrchestrationEngine", () => {
           workspaceRoot: "/tmp/active-project",
           defaultModelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           createdAt,
@@ -1673,6 +1698,7 @@ describe("OrchestrationEngine", () => {
         workspaceRoot: "/tmp/project-duplicate",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         createdAt,
@@ -1688,6 +1714,7 @@ describe("OrchestrationEngine", () => {
         title: "duplicate",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -1708,6 +1735,7 @@ describe("OrchestrationEngine", () => {
           title: "duplicate",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -3,6 +3,7 @@ import {
   CheckpointRef,
   CommandId,
   CorrelationId,
+  DEFAULT_PROVIDER_PROFILE_ID,
   EventId,
   MessageId,
   ProjectId,
@@ -136,6 +137,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
           title: "Thread 1",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           runtimeMode: "full-access",
@@ -258,6 +260,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
           title: "Thread",
           modelSelection: {
             provider: "pi",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.1",
           },
           runtimeMode: "full-access",
@@ -283,6 +286,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
           messageId: MessageId.makeUnsafe("message-turn-settings"),
           modelSelection: {
             provider: "pi",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.5",
           },
           runtimeMode: "approval-required",
@@ -311,6 +315,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
       assert.equal(rows.length, 1);
       assert.deepEqual(JSON.parse(rows[0]!.modelSelectionJson), {
         provider: "pi",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "openai/gpt-5.5",
       });
       assert.equal(rows[0]!.runtimeMode, "approval-required");
@@ -410,7 +415,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
         payload: {
           threadId: ThreadId.makeUnsafe("thread-turn-settings"),
           messageId: MessageId.makeUnsafe("message-turn-settings-cross-provider"),
-          modelSelection: { provider: "codex", model: "gpt-5-codex" },
+          modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
           runtimeMode: "full-access",
           interactionMode: "default",
           createdAt: crossProviderRequestedAt,
@@ -432,6 +437,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
       `;
       assert.deepEqual(JSON.parse(providerRows[0]!.modelSelectionJson), {
         provider: "pi",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "openai/gpt-5.5",
       });
       assert.equal(providerRows[0]!.providerName, "pi");
@@ -522,7 +528,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
           threadId,
           projectId: ProjectId.makeUnsafe("project-retained-error"),
           title: "Retained error thread",
-          modelSelection: { provider: "codex", model: "gpt-5.6-sol" },
+          modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.6-sol" },
           runtimeMode: "full-access",
           branch: null,
           worktreePath: null,
@@ -543,7 +549,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
         payload: {
           threadId,
           messageId: MessageId.makeUnsafe("message-retained-error"),
-          modelSelection: { provider: "codex", model: "gpt-5.6-sol" },
+          modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.6-sol" },
           runtimeMode: "full-access",
           interactionMode: "default",
           dispatchMode: "queue",
@@ -1056,6 +1062,7 @@ it.effect("fast-forwards lagging hot projector cursors before restart replay", (
           title: "Bootstrap fast-forward thread",
           modelSelection: {
             provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "claude-sonnet-4-5-20250929",
           },
           runtimeMode: "full-access",
@@ -1413,6 +1420,7 @@ it.layer(
           title: "Approvals Thread",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           runtimeMode: "full-access",
@@ -1548,6 +1556,7 @@ it.layer(
           title: "Streaming Shell Thread",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           runtimeMode: "full-access",
@@ -1650,6 +1659,7 @@ it.layer(
           title: "User Input Thread",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           runtimeMode: "full-access",
@@ -1967,6 +1977,7 @@ it.layer(
           title: "Stale Reconcile Thread",
           modelSelection: {
             provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "claude-sonnet-5",
           },
           runtimeMode: "full-access",
@@ -2183,6 +2194,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
             title: "Thread Clear Attachments",
             modelSelection: {
               provider: "codex",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: "gpt-5-codex",
             },
             runtimeMode: "full-access",
@@ -2311,6 +2323,7 @@ it.layer(
           title: "Thread Overwrite",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           runtimeMode: "full-access",
@@ -2456,6 +2469,7 @@ it.layer(
           title: "Thread Rollback",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           runtimeMode: "full-access",
@@ -2575,7 +2589,7 @@ it.layer(
           threadId,
           projectId,
           title: "Stream Append Thread",
-          modelSelection: { provider: "codex", model: "gpt-5-codex" },
+          modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
           runtimeMode: "full-access",
           branch: null,
           worktreePath: null,
@@ -2775,7 +2789,7 @@ it.layer(
           threadId,
           projectId,
           title: "Stream Restart Thread",
-          modelSelection: { provider: "codex", model: "gpt-5-codex" },
+          modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
           runtimeMode: "full-access",
           branch: null,
           worktreePath: null,
@@ -2943,6 +2957,7 @@ it.layer(
           title: "Thread Revert Files",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           runtimeMode: "full-access",
@@ -3219,6 +3234,7 @@ it.layer(
           title: "Thread Delete Files",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           runtimeMode: "full-access",
@@ -3377,6 +3393,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
           title: "Thread A",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           runtimeMode: "full-access",
@@ -3504,6 +3521,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
           title: "Thread Empty",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           runtimeMode: "full-access",
@@ -3641,6 +3659,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
             title: "Thread Conflict",
             modelSelection: {
               provider: "codex",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: "gpt-5-codex",
             },
             runtimeMode: "full-access",
@@ -3783,6 +3802,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
           title: "Thread Revert",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           runtimeMode: "full-access",
@@ -4110,6 +4130,7 @@ engineLayer("OrchestrationProjectionPipeline via engine dispatch", (it) => {
         workspaceRoot: "/tmp/project-live",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         createdAt,
@@ -4177,6 +4198,7 @@ engineLayer("OrchestrationProjectionPipeline via engine dispatch", (it) => {
         workspaceRoot: "/tmp/project-scripts",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         createdAt,
@@ -4198,6 +4220,7 @@ engineLayer("OrchestrationProjectionPipeline via engine dispatch", (it) => {
         isPinned: true,
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5",
         },
       });
@@ -4218,7 +4241,11 @@ engineLayer("OrchestrationProjectionPipeline via engine dispatch", (it) => {
         {
           scriptsJson:
             '[{"id":"script-1","name":"Build","command":"bun run build","icon":"build","runOnWorktreeCreate":false}]',
-          defaultModelSelection: '{"provider":"codex","model":"gpt-5"}',
+          defaultModelSelection: JSON.stringify({
+            provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
+            model: "gpt-5",
+          }),
           isPinned: 1,
         },
       ]);
@@ -4239,7 +4266,7 @@ engineLayer("OrchestrationProjectionPipeline via engine dispatch", (it) => {
         projectId,
         title: "Routed telemetry",
         workspaceRoot: "/tmp/project-routed-telemetry",
-        defaultModelSelection: { provider: "codex", model: "gpt-5-codex" },
+        defaultModelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
         createdAt,
       });
       yield* engine.dispatch({
@@ -4248,7 +4275,7 @@ engineLayer("OrchestrationProjectionPipeline via engine dispatch", (it) => {
         threadId,
         projectId,
         title: "Routed telemetry",
-        modelSelection: { provider: "codex", model: "gpt-5-codex" },
+        modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
         interactionMode: "default",
         runtimeMode: "full-access",
         branch: null,

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -2,6 +2,7 @@ import {
   ApprovalRequestId,
   CheckpointRef,
   CommandId,
+  DEFAULT_PROVIDER_PROFILE_ID,
   EventId,
   MessageId,
   ProjectId,
@@ -343,6 +344,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           workspaceRoot: "/tmp/project-1",
           defaultModelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           scripts: [
@@ -367,6 +369,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           title: "Thread 1",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           interactionMode: "default",
@@ -1147,11 +1150,13 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
 
       const expectedProjectSelection = {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "imported-project-model",
         options: { reasoningEffort: "medium" },
       } as const;
       const expectedThreadSelection = {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "gpt-5.5",
         options: { reasoningEffort: "medium" },
       } as const;
@@ -1667,6 +1672,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           title: "Shell Thread",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           interactionMode: "default",

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -16,6 +16,7 @@ import type {
   ProviderSession,
 } from "@synara/contracts";
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   ApprovalRequestId,
   type ChatAttachment,
   CommandId,
@@ -223,6 +224,7 @@ describe("ProviderCommandReactor", () => {
     );
     const modelSelection = input?.threadModelSelection ?? {
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5-codex",
     };
     const startSession = vi.fn((_: unknown, input: unknown) => {
@@ -1365,6 +1367,7 @@ describe("ProviderCommandReactor", () => {
         title: "Unrelated thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -2119,6 +2122,7 @@ describe("ProviderCommandReactor", () => {
         title: "Sidechat: Thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         runtimeMode: "approval-required",
@@ -2218,6 +2222,7 @@ describe("ProviderCommandReactor", () => {
         title: "Native Droid sidechat",
         modelSelection: {
           provider: "droid",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-4-6",
         },
         runtimeMode: "approval-required",
@@ -2346,6 +2351,7 @@ describe("ProviderCommandReactor", () => {
         title: "Review sidechat",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         runtimeMode: "approval-required",
@@ -2440,6 +2446,7 @@ describe("ProviderCommandReactor", () => {
         title: "Restarted Droid sidechat",
         modelSelection: {
           provider: "droid",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-4-6",
         },
         runtimeMode: "approval-required",
@@ -2500,6 +2507,7 @@ describe("ProviderCommandReactor", () => {
         reviewTarget: { type: "uncommittedChanges" },
         modelSelection: {
           provider: "droid",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
         },
         runtimeMode: "approval-required",
@@ -2549,6 +2557,7 @@ describe("ProviderCommandReactor", () => {
         title: "Droid fork",
         modelSelection: {
           provider: "droid",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-4-6",
         },
         runtimeMode: "approval-required",
@@ -2643,6 +2652,7 @@ describe("ProviderCommandReactor", () => {
         title: "Empty Droid fork",
         modelSelection: {
           provider: "droid",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-4-6",
         },
         runtimeMode: "approval-required",
@@ -2722,6 +2732,7 @@ describe("ProviderCommandReactor", () => {
         title: "Retry Droid fork",
         modelSelection: {
           provider: "droid",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-4-6",
         },
         runtimeMode: "approval-required",
@@ -2799,6 +2810,7 @@ describe("ProviderCommandReactor", () => {
     const harness = await createHarness({
       threadModelSelection: {
         provider: "droid",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "claude-sonnet-4-6",
       },
     });
@@ -2819,6 +2831,7 @@ describe("ProviderCommandReactor", () => {
         title: "Droid async bootstrap failure",
         modelSelection: {
           provider: "droid",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-4-6",
         },
         runtimeMode: "approval-required",
@@ -3168,7 +3181,7 @@ describe("ProviderCommandReactor", () => {
 
   it("restarts Droid edits and bootstraps only the retained transcript", async () => {
     const harness = await createHarness({
-      threadModelSelection: { provider: "droid", model: "claude-opus-4-8" },
+      threadModelSelection: { provider: "droid", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "claude-opus-4-8" },
       conversationRollback: "restart-session",
     });
     const now = new Date().toISOString();
@@ -3697,7 +3710,7 @@ describe("ProviderCommandReactor", () => {
         threadId: ThreadId.makeUnsafe("subagent:thread-1:tool-steer-1"),
         projectId: asProjectId("project-1"),
         title: "Subagent",
-        modelSelection: { provider: "claudeAgent", model: "claude-sonnet-4-5" },
+        modelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "claude-sonnet-4-5" },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "approval-required",
         parentThreadId: ThreadId.makeUnsafe("thread-1"),
@@ -4155,7 +4168,7 @@ describe("ProviderCommandReactor", () => {
 
   it("clears stale Claude resume state and retries the turn with transcript context", async () => {
     const harness = await createHarness({
-      threadModelSelection: { provider: "claudeAgent", model: "claude-opus-4-8" },
+      threadModelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "claude-opus-4-8" },
     });
     const now = new Date().toISOString();
     const staleResumeFailure = () =>
@@ -4209,7 +4222,7 @@ describe("ProviderCommandReactor", () => {
           text: "nice but bring it on the left.",
           attachments: [],
         },
-        modelSelection: { provider: "claudeAgent", model: "claude-opus-4-8" },
+        modelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "claude-opus-4-8" },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "approval-required",
         createdAt: now,
@@ -4243,7 +4256,7 @@ describe("ProviderCommandReactor", () => {
 
   it("retries a stale Claude resume natively before paying the transcript bootstrap", async () => {
     const harness = await createHarness({
-      threadModelSelection: { provider: "claudeAgent", model: "claude-opus-4-8" },
+      threadModelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "claude-opus-4-8" },
     });
     const now = new Date().toISOString();
     harness.sendTurn.mockImplementationOnce(() =>
@@ -4268,7 +4281,7 @@ describe("ProviderCommandReactor", () => {
           text: "keep going.",
           attachments: [],
         },
-        modelSelection: { provider: "claudeAgent", model: "claude-opus-4-8" },
+        modelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "claude-opus-4-8" },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "approval-required",
         createdAt: now,
@@ -4291,7 +4304,7 @@ describe("ProviderCommandReactor", () => {
 
   it("skips the native resume retry when background tasks keep the runtime alive", async () => {
     const harness = await createHarness({
-      threadModelSelection: { provider: "claudeAgent", model: "claude-opus-4-8" },
+      threadModelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "claude-opus-4-8" },
     });
     const now = new Date().toISOString();
     harness.hasLiveRuntimeTasks.mockImplementation(() => Effect.succeed(true));
@@ -4317,7 +4330,7 @@ describe("ProviderCommandReactor", () => {
           text: "keep going.",
           attachments: [],
         },
-        modelSelection: { provider: "claudeAgent", model: "claude-opus-4-8" },
+        modelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "claude-opus-4-8" },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "approval-required",
         createdAt: now,
@@ -4479,6 +4492,7 @@ describe("ProviderCommandReactor", () => {
         workspaceRoot: "/Users/tester",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         createdAt: now,
@@ -4494,6 +4508,7 @@ describe("ProviderCommandReactor", () => {
         title: "Home thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -4577,6 +4592,7 @@ describe("ProviderCommandReactor", () => {
     const harness = await createHarness({
       threadModelSelection: {
         provider: "antigravity",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "Gemini 3.5 Flash",
       },
     });
@@ -4609,6 +4625,7 @@ describe("ProviderCommandReactor", () => {
         },
         modelSelection: {
           provider: "antigravity",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "Gemini 3.5 Flash",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -4633,6 +4650,7 @@ describe("ProviderCommandReactor", () => {
     const harness = await createHarness({
       threadModelSelection: {
         provider: "antigravity",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "Gemini 3.5 Flash",
       },
     });
@@ -4660,6 +4678,7 @@ describe("ProviderCommandReactor", () => {
         },
         modelSelection: {
           provider: "antigravity",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "Gemini 3.5 Flash",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -4841,6 +4860,7 @@ describe("ProviderCommandReactor", () => {
     const harness = await createHarness({
       threadModelSelection: {
         provider: "antigravity",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "Gemini 3.5 Flash",
       },
     });
@@ -4876,6 +4896,7 @@ describe("ProviderCommandReactor", () => {
         },
         modelSelection: {
           provider: "antigravity",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "Gemini 3.5 Flash",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -4906,10 +4927,12 @@ describe("ProviderCommandReactor", () => {
     const harness = await createHarness({
       threadModelSelection: {
         provider: "antigravity",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "Gemini 3.5 Flash",
       },
       gitWritingModelSelection: {
         provider: "claudeAgent",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "claude-opus-4-8",
       },
     });
@@ -4942,6 +4965,7 @@ describe("ProviderCommandReactor", () => {
         },
         modelSelection: {
           provider: "antigravity",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "Gemini 3.5 Flash",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -4967,6 +4991,7 @@ describe("ProviderCommandReactor", () => {
     const harness = await createHarness({
       threadModelSelection: {
         provider: "opencode",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "openai/gpt-5",
         options: {
           agent: "plan",
@@ -5003,6 +5028,7 @@ describe("ProviderCommandReactor", () => {
         },
         modelSelection: {
           provider: "opencode",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "openai/gpt-5",
           options: {
             agent: "plan",
@@ -5657,7 +5683,7 @@ describe("ProviderCommandReactor", () => {
         projectId: asProjectId("project-1"),
         parentThreadId: ThreadId.makeUnsafe("thread-1"),
         title: "Child",
-        modelSelection: { provider: "codex", model: "gpt-5-codex" },
+        modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "approval-required",
         branch: null,
@@ -5729,7 +5755,7 @@ describe("ProviderCommandReactor", () => {
         projectId: asProjectId("project-1"),
         parentThreadId: ThreadId.makeUnsafe("thread-1"),
         title: "Queued child",
-        modelSelection: { provider: "codex", model: "gpt-5-codex" },
+        modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "approval-required",
         branch: null,
@@ -5820,7 +5846,7 @@ describe("ProviderCommandReactor", () => {
           projectId: asProjectId("project-1"),
           parentThreadId: ThreadId.makeUnsafe("thread-1"),
           title: childId,
-          modelSelection: { provider: "codex", model: "gpt-5-codex" },
+          modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
           runtimeMode: "approval-required",
           branch: null,
@@ -5904,7 +5930,7 @@ describe("ProviderCommandReactor", () => {
         projectId: asProjectId("project-1"),
         parentThreadId: ThreadId.makeUnsafe("thread-1"),
         title: "Queued child",
-        modelSelection: { provider: "codex", model: "gpt-5-codex" },
+        modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "approval-required",
         branch: null,
@@ -6240,6 +6266,7 @@ describe("ProviderCommandReactor", () => {
     const harness = await createHarness({
       threadModelSelection: {
         provider: "claudeAgent",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "claude-opus-4-6",
       },
     });
@@ -6304,6 +6331,7 @@ describe("ProviderCommandReactor", () => {
     const harness = await createHarness({
       threadModelSelection: {
         provider: "cursor",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "composer-1",
       },
     });
@@ -6397,6 +6425,7 @@ describe("ProviderCommandReactor", () => {
         },
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.3-codex",
           options: {
             reasoningEffort: "high",
@@ -6436,7 +6465,7 @@ describe("ProviderCommandReactor", () => {
 
   it("forwards claude effort options through session start and turn send", async () => {
     const harness = await createHarness({
-      threadModelSelection: { provider: "claudeAgent", model: "claude-sonnet-4-6" },
+      threadModelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "claude-sonnet-4-6" },
     });
     const now = new Date().toISOString();
 
@@ -6453,6 +6482,7 @@ describe("ProviderCommandReactor", () => {
         },
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-4-6",
           options: {
             effort: "max",
@@ -6489,7 +6519,7 @@ describe("ProviderCommandReactor", () => {
 
   it("forwards codex effort options through session start and turn send", async () => {
     const harness = await createHarness({
-      threadModelSelection: { provider: "codex", model: "gpt-5-codex" },
+      threadModelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
     });
     const now = new Date().toISOString();
 
@@ -6506,6 +6536,7 @@ describe("ProviderCommandReactor", () => {
         },
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
           options: {
             reasoningEffort: "high",
@@ -6542,7 +6573,7 @@ describe("ProviderCommandReactor", () => {
 
   it("restarts an idle Claude session only for spawn-fixed model selection changes", async () => {
     const harness = await createHarness({
-      threadModelSelection: { provider: "claudeAgent", model: "claude-opus-4-7" },
+      threadModelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "claude-opus-4-7" },
     });
     const now = new Date().toISOString();
 
@@ -6583,6 +6614,7 @@ describe("ProviderCommandReactor", () => {
         threadId: ThreadId.makeUnsafe("thread-1"),
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-7",
           options: {
             contextWindow: "1m",
@@ -6599,6 +6631,7 @@ describe("ProviderCommandReactor", () => {
         threadId: ThreadId.makeUnsafe("thread-1"),
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-7",
           options: {
             effort: "max",
@@ -6622,6 +6655,7 @@ describe("ProviderCommandReactor", () => {
   it("restarts a directly started Claude session when spawn-fixed options change", async () => {
     const initialSelection: ModelSelection = {
       provider: "claudeAgent",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "claude-opus-4-7",
     };
     const harness = await createHarness({ threadModelSelection: initialSelection });
@@ -6664,6 +6698,7 @@ describe("ProviderCommandReactor", () => {
         threadId,
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-7",
           options: { effort: "max" },
         },
@@ -6682,7 +6717,7 @@ describe("ProviderCommandReactor", () => {
 
   it("keeps the applied Claude spawn profile while metadata changes mid-turn", async () => {
     const harness = await createHarness({
-      threadModelSelection: { provider: "claudeAgent", model: "claude-opus-4-7" },
+      threadModelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "claude-opus-4-7" },
     });
     const threadId = ThreadId.makeUnsafe("thread-1");
     const turnId = asTurnId("turn-active-selection-change");
@@ -6733,6 +6768,7 @@ describe("ProviderCommandReactor", () => {
         threadId,
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-7",
           options: { effort: "max" },
         },
@@ -6769,6 +6805,7 @@ describe("ProviderCommandReactor", () => {
         threadId,
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-7",
           options: { effort: "max", contextWindow: "1m" },
         },
@@ -6789,6 +6826,7 @@ describe("ProviderCommandReactor", () => {
     const harness = await createHarness({
       threadModelSelection: {
         provider: "droid",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "claude-sonnet-4-6",
         options: { reasoningEffort: "medium" },
       },
@@ -6822,6 +6860,7 @@ describe("ProviderCommandReactor", () => {
         threadId: ThreadId.makeUnsafe("thread-1"),
         modelSelection: {
           provider: "droid",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-4-6",
           options: { reasoningEffort: "medium" },
         },
@@ -6837,6 +6876,7 @@ describe("ProviderCommandReactor", () => {
         threadId: ThreadId.makeUnsafe("thread-1"),
         modelSelection: {
           provider: "droid",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-4-6",
           options: { reasoningEffort: "high" },
         },
@@ -6856,7 +6896,7 @@ describe("ProviderCommandReactor", () => {
 
   it("forwards claude fast mode options through session start and turn send", async () => {
     const harness = await createHarness({
-      threadModelSelection: { provider: "claudeAgent", model: "claude-opus-4-6" },
+      threadModelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "claude-opus-4-6" },
     });
     const now = new Date().toISOString();
 
@@ -6873,6 +6913,7 @@ describe("ProviderCommandReactor", () => {
         },
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
           options: {
             fastMode: true,
@@ -6947,7 +6988,7 @@ describe("ProviderCommandReactor", () => {
 
   it("adopts the requested provider on a first turn before binding a session", async () => {
     const harness = await createHarness({
-      threadModelSelection: { provider: "codex", model: "gpt-5-codex" },
+      threadModelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
     });
     const now = new Date().toISOString();
 
@@ -6964,6 +7005,7 @@ describe("ProviderCommandReactor", () => {
         },
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -6991,6 +7033,7 @@ describe("ProviderCommandReactor", () => {
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"));
     expect(thread?.modelSelection).toEqual({
       provider: "claudeAgent",
+      profileId: "default",
       model: "claude-opus-4-6",
     });
     expect(thread?.session?.providerName).toBe("claudeAgent");
@@ -7098,7 +7141,7 @@ describe("ProviderCommandReactor", () => {
 
   it("restarts claude sessions when claude effort changes", async () => {
     const harness = await createHarness({
-      threadModelSelection: { provider: "claudeAgent", model: "claude-sonnet-4-6" },
+      threadModelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "claude-sonnet-4-6" },
     });
     const now = new Date().toISOString();
 
@@ -7115,6 +7158,7 @@ describe("ProviderCommandReactor", () => {
         },
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-4-6",
           options: {
             effort: "medium",
@@ -7142,6 +7186,7 @@ describe("ProviderCommandReactor", () => {
         },
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-4-6",
           options: {
             effort: "max",
@@ -7257,7 +7302,7 @@ describe("ProviderCommandReactor", () => {
 
   it("does not inject derived model options when restarting claude on runtime mode changes", async () => {
     const harness = await createHarness({
-      threadModelSelection: { provider: "claudeAgent", model: "claude-opus-4-6" },
+      threadModelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "claude-opus-4-6" },
     });
     const now = new Date().toISOString();
 
@@ -7615,6 +7660,7 @@ describe("ProviderCommandReactor", () => {
         title: "Halley [explorer]",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -7692,6 +7738,7 @@ describe("ProviderCommandReactor", () => {
         title: "Halley [explorer]",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -7750,6 +7797,7 @@ describe("ProviderCommandReactor", () => {
         title: "Agent",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -7830,7 +7878,7 @@ describe("ProviderCommandReactor", () => {
         threadId: ThreadId.makeUnsafe("subagent:thread-1:child-provider-steer"),
         projectId: asProjectId("project-1"),
         title: "Synthetic child",
-        modelSelection: { provider: "codex", model: "gpt-5-codex" },
+        modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "approval-required",
         branch: null,
@@ -9032,6 +9080,7 @@ describe("ProviderCommandReactor", () => {
         title: "Stopped Droid sidechat",
         modelSelection: {
           provider: "droid",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-4-6",
         },
         runtimeMode: "approval-required",
@@ -9147,6 +9196,7 @@ describe("ProviderCommandReactor", () => {
         title: "Agent",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -10,6 +10,7 @@ import type {
   ProviderSession,
 } from "@synara/contracts";
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   ApprovalRequestId,
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -302,6 +303,7 @@ describe("ProviderRuntimeIngestion", () => {
         workspaceRoot,
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         createdAt,
@@ -316,6 +318,7 @@ describe("ProviderRuntimeIngestion", () => {
         title: "Thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -594,6 +597,7 @@ describe("ProviderRuntimeIngestion", () => {
         title: "Late thread",
         modelSelection: {
           provider: "cursor",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "cursor-default",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -2578,6 +2582,7 @@ describe("ProviderRuntimeIngestion", () => {
         title: "Plan Source",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: "plan",
@@ -2613,6 +2618,7 @@ describe("ProviderRuntimeIngestion", () => {
         title: "Plan Target",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -2765,6 +2771,7 @@ describe("ProviderRuntimeIngestion", () => {
         title: "Plan Source",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: "plan",
@@ -2918,6 +2925,7 @@ describe("ProviderRuntimeIngestion", () => {
         title: "Plan Source",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: "plan",
@@ -2953,6 +2961,7 @@ describe("ProviderRuntimeIngestion", () => {
         title: "Plan Target",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -3620,7 +3629,7 @@ describe("ProviderRuntimeIngestion", () => {
         threadId: secondThreadId,
         projectId: asProjectId("project-1"),
         title: "Buffered Thread",
-        modelSelection: { provider: "codex", model: "gpt-5-codex" },
+        modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "approval-required",
         branch: null,
@@ -6658,7 +6667,7 @@ describe("ProviderRuntimeIngestion", () => {
           threadId: asThreadId("thread-1"),
           projectId: asProjectId("project-1"),
           title: "Duplicate",
-          modelSelection: { provider: "codex", model: "gpt-5-codex" },
+          modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
           runtimeMode: "approval-required",
           branch: null,

--- a/apps/server/src/orchestration/Layers/pinnedMessagesRoundTrip.test.ts
+++ b/apps/server/src/orchestration/Layers/pinnedMessagesRoundTrip.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   MessageId,
@@ -61,7 +62,7 @@ describe("pinned messages round-trip", () => {
           projectId,
           title: "Pins project",
           workspaceRoot: "/tmp/project-pins",
-          defaultModelSelection: { provider: "codex", model: "gpt-5-codex" },
+          defaultModelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
           createdAt,
         }),
       );
@@ -72,7 +73,7 @@ describe("pinned messages round-trip", () => {
           threadId,
           projectId,
           title: "Pins thread",
-          modelSelection: { provider: "codex", model: "gpt-5-codex" },
+          modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
           runtimeMode: "approval-required",
           branch: null,
@@ -165,7 +166,7 @@ describe("pinned messages round-trip", () => {
           projectId,
           title: "Markers project",
           workspaceRoot: "/tmp/project-markers",
-          defaultModelSelection: { provider: "codex", model: "gpt-5-codex" },
+          defaultModelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
           createdAt,
         }),
       );
@@ -176,7 +177,7 @@ describe("pinned messages round-trip", () => {
           threadId,
           projectId,
           title: "Markers thread",
-          modelSelection: { provider: "codex", model: "gpt-5-codex" },
+          modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
           runtimeMode: "approval-required",
           branch: null,

--- a/apps/server/src/orchestration/commandFingerprint.test.ts
+++ b/apps/server/src/orchestration/commandFingerprint.test.ts
@@ -1,7 +1,10 @@
 import {
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
+  DEFAULT_PROVIDER_PROFILE_ID,
+  EventId,
   MessageId,
+  ProviderProfileId,
   ThreadId,
   type OrchestrationCommand,
 } from "@synara/contracts";
@@ -68,6 +71,54 @@ describe("fingerprintOrchestrationCommand", () => {
 
     expect(fingerprintOrchestrationCommand(withAttachments("generated-a", "one.png"))).toEqual(
       fingerprintOrchestrationCommand(withAttachments("generated-b", "spoofed.png")),
+    );
+  });
+
+  it("preserves v1 fingerprints for legacy default-profile retries", () => {
+    const legacyCompatible = fingerprintOrchestrationCommand(
+      turnCommand({
+        modelSelection: {
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          model: "gpt-5.6-sol",
+        },
+      }),
+    );
+    const workProfile = fingerprintOrchestrationCommand(
+      turnCommand({
+        modelSelection: {
+          provider: "codex",
+          profileId: ProviderProfileId.makeUnsafe("work"),
+          model: "gpt-5.6-sol",
+        },
+      }),
+    );
+
+    expect(legacyCompatible.value).toBe(
+      "f5e81d743fcb1a2a90a68d6b3d52ba8bc2fc7c17b47b250607a6f0f7d9521bda",
+    );
+    expect(workProfile.value).not.toBe(legacyCompatible.value);
+  });
+
+  it("keeps arbitrary activity profileId payloads fingerprint-significant", () => {
+    const activityCommand = (payload: Record<string, unknown>): OrchestrationCommand => ({
+      type: "thread.activity.append",
+      commandId: CommandId.makeUnsafe("command-activity-profile"),
+      threadId: ThreadId.makeUnsafe("thread-a"),
+      activity: {
+        id: EventId.makeUnsafe("activity-profile"),
+        tone: "info",
+        kind: "profile.observed",
+        summary: "Profile observed",
+        payload,
+        turnId: null,
+        createdAt: "2026-07-14T00:00:00.000Z",
+      },
+      createdAt: "2026-07-14T00:00:00.000Z",
+    });
+
+    expect(fingerprintOrchestrationCommand(activityCommand({ profileId: "default" })).value).not.toBe(
+      fingerprintOrchestrationCommand(activityCommand({})).value,
     );
   });
 });

--- a/apps/server/src/orchestration/commandFingerprint.ts
+++ b/apps/server/src/orchestration/commandFingerprint.ts
@@ -1,6 +1,10 @@
 import * as Crypto from "node:crypto";
 
-import { OrchestrationCommand, type OrchestrationCommand as Command } from "@synara/contracts";
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  OrchestrationCommand,
+  type OrchestrationCommand as Command,
+} from "@synara/contracts";
 import { Schema } from "effect";
 
 export const ORCHESTRATION_COMMAND_FINGERPRINT_VERSION = 1;
@@ -26,14 +30,32 @@ function canonicalizeJson(value: unknown): unknown {
   return value;
 }
 
+// Fingerprint v1 predates provider profiles. Only schema-owned model-selection
+// fields omit the reserved default; arbitrary JSON payloads remain untouched.
+function preserveV1ModelSelectionFingerprint(intent: Record<string, unknown>) {
+  const compatibleIntent = { ...intent };
+  for (const key of ["modelSelection", "defaultModelSelection"] as const) {
+    const selection = compatibleIntent[key];
+    if (
+      selection !== null &&
+      typeof selection === "object" &&
+      (selection as Record<string, unknown>).profileId === DEFAULT_PROVIDER_PROFILE_ID
+    ) {
+      const { profileId: _profileId, ...legacySelection } = selection as Record<string, unknown>;
+      compatibleIntent[key] = legacySelection;
+    }
+  }
+  return compatibleIntent;
+}
+
 function commandIntent(command: Command): Record<string, unknown> {
   const decoded = Schema.decodeUnknownSync(OrchestrationCommand)(command);
   const { commandId: _commandId, ...intent } = decoded;
   if (intent.type !== "thread.turn.start") {
-    return intent;
+    return preserveV1ModelSelectionFingerprint(intent);
   }
 
-  return {
+  return preserveV1ModelSelectionFingerprint({
     ...intent,
     message: {
       ...intent.message,
@@ -53,7 +75,7 @@ function commandIntent(command: Command): Record<string, unknown> {
         }
       }),
     },
-  };
+  });
 }
 
 export function fingerprintOrchestrationCommand(command: Command): OrchestrationCommandFingerprint {

--- a/apps/server/src/orchestration/commandInvariants.test.ts
+++ b/apps/server/src/orchestration/commandInvariants.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   MessageId,
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -34,6 +35,7 @@ const readModel: OrchestrationReadModel = {
       workspaceRoot: "/tmp/project-a",
       defaultModelSelection: {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "gpt-5-codex",
       },
       scripts: [],
@@ -47,6 +49,7 @@ const readModel: OrchestrationReadModel = {
       workspaceRoot: "/tmp/project-b",
       defaultModelSelection: {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "gpt-5-codex",
       },
       scripts: [],
@@ -62,6 +65,7 @@ const readModel: OrchestrationReadModel = {
       title: "Thread A",
       modelSelection: {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "gpt-5-codex",
       },
       interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -85,6 +89,7 @@ const readModel: OrchestrationReadModel = {
       title: "Thread B",
       modelSelection: {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "gpt-5-codex",
       },
       interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -108,6 +113,7 @@ const readModel: OrchestrationReadModel = {
       title: "Archived Thread",
       modelSelection: {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "gpt-5-codex",
       },
       interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -132,6 +138,7 @@ const readModel: OrchestrationReadModel = {
       title: "Deleted Thread",
       modelSelection: {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "gpt-5-codex",
       },
       interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -221,6 +228,7 @@ describe("commandInvariants", () => {
           title: "new",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -245,6 +253,7 @@ describe("commandInvariants", () => {
             title: "dup",
             modelSelection: {
               provider: "codex",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: "gpt-5-codex",
             },
             interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,

--- a/apps/server/src/orchestration/decider.archive.test.ts
+++ b/apps/server/src/orchestration/decider.archive.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   ProjectId,
@@ -30,6 +31,7 @@ function makeThread(input: {
     title: `Thread ${input.id}`,
     modelSelection: {
       provider: "claudeAgent",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "claude-opus-4-6",
       supportsAutoMode: true,
     },

--- a/apps/server/src/orchestration/decider.checkpointRevert.test.ts
+++ b/apps/server/src/orchestration/decider.checkpointRevert.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   EventId,
@@ -41,6 +42,7 @@ function makeReadModel(input: {
         title: "Checkpoint revert",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,

--- a/apps/server/src/orchestration/decider.projectScripts.test.ts
+++ b/apps/server/src/orchestration/decider.projectScripts.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   EventId,
@@ -185,6 +186,7 @@ describe("decider project scripts", () => {
           title: "Saved chat",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -375,6 +377,7 @@ describe("decider project scripts", () => {
           title: "Thread",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -402,6 +405,7 @@ describe("decider project scripts", () => {
           },
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5.3-codex",
             options: {
               reasoningEffort: "high",
@@ -486,6 +490,7 @@ describe("decider project scripts", () => {
           title: "Thread",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -569,6 +574,7 @@ describe("decider project scripts", () => {
           title: "Thread",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -652,6 +658,7 @@ describe("decider project scripts", () => {
           title: "Handoff",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -707,6 +714,7 @@ describe("decider project scripts", () => {
             title: "Handoff Copy",
             modelSelection: {
               provider: "claudeAgent",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: "sonnet",
             },
             interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -774,6 +782,7 @@ describe("decider project scripts", () => {
           title: "Handoff",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -853,6 +862,7 @@ describe("decider project scripts", () => {
           title: "Handoff Copy",
           modelSelection: {
             provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "sonnet",
           },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,

--- a/apps/server/src/orchestration/decider.runtimeMode.test.ts
+++ b/apps/server/src/orchestration/decider.runtimeMode.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   EventId,
@@ -32,6 +33,7 @@ function makeReadModel(
         title: "Claude Auto",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
           supportsAutoMode,
         },
@@ -95,6 +97,7 @@ describe("decider Auto model compatibility", () => {
             threadId: THREAD_ID,
             modelSelection: {
               provider: "claudeAgent",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: "claude-haiku-4-5",
               supportsAutoMode: false,
             },
@@ -131,6 +134,7 @@ describe("decider Auto model compatibility", () => {
           threadId: THREAD_ID,
           modelSelection: {
             provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "claude-fable-5",
             supportsAutoMode: true,
           },
@@ -156,6 +160,7 @@ describe("decider Auto model compatibility", () => {
             title: "User Auto thread",
             modelSelection: {
               provider: "claudeAgent",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: "claude-fable-5",
             },
             interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -188,6 +193,7 @@ describe("decider Auto model compatibility", () => {
           title: "Subagent",
           modelSelection: {
             provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "claude-fable-5",
           },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -218,6 +224,7 @@ describe("decider Auto model compatibility", () => {
           threadId: THREAD_ID,
           modelSelection: {
             provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "claude-fable-5",
           },
         },

--- a/apps/server/src/orchestration/decider.settle.test.ts
+++ b/apps/server/src/orchestration/decider.settle.test.ts
@@ -3,6 +3,7 @@
 //          settledAt from the isSettled intent and the projector applies it.
 
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   EventId,
@@ -61,7 +62,7 @@ async function createThreadReadModel(now: string) {
         threadId: THREAD_ID,
         projectId: PROJECT_ID,
         title: "Thread",
-        modelSelection: { provider: "codex", model: "gpt-5-codex" },
+        modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "full-access",
         envMode: "local",

--- a/apps/server/src/orchestration/decider.worktreeMetadata.test.ts
+++ b/apps/server/src/orchestration/decider.worktreeMetadata.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   ApprovalRequestId,
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -68,6 +69,7 @@ async function createWorktreeThreadReadModel(now: string, kind: "project" | "stu
         title: "Worktree thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -107,6 +109,7 @@ describe("decider worktree metadata", () => {
           title: "Studio thread",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -252,6 +255,7 @@ describe("decider worktree metadata", () => {
           title: "Worktree thread",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
@@ -293,6 +297,7 @@ describe("decider worktree metadata", () => {
           title: "Forked thread",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,

--- a/apps/server/src/orchestration/importThreadRoute.test.ts
+++ b/apps/server/src/orchestration/importThreadRoute.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   type OrchestrationCommand,
   type OrchestrationThread,
   ProjectId,
@@ -25,7 +26,11 @@ function makeCodexThread(): OrchestrationThread {
     id: threadId,
     projectId,
     title: "Imported thread",
-    modelSelection: { provider: "codex", model: "gpt-5.5" },
+    modelSelection: {
+      provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
+      model: "gpt-5.5",
+    },
     runtimeMode: "full-access",
     interactionMode: "default",
     envMode: "local",
@@ -122,7 +127,11 @@ it.effect("imports Codex history through a provider-owned fork", () =>
       {
         threadId,
         provider: "codex",
-        modelSelection: { provider: "codex", model: "gpt-5.5" },
+        modelSelection: {
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          model: "gpt-5.5",
+        },
         forkSourceResumeCursor: { threadId: externalId },
         runtimeMode: "full-access",
       },

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -1,5 +1,6 @@
 import {
   CommandId,
+  DEFAULT_PROVIDER_PROFILE_ID,
   EventId,
   ProjectId,
   SpaceId,
@@ -160,6 +161,7 @@ describe("orchestration projector", () => {
         title: "demo",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         runtimeMode: "full-access",
@@ -261,6 +263,7 @@ describe("orchestration projector", () => {
 
     expect(next.threads[0]?.modelSelection).toEqual({
       provider: "pi",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "openai/gpt-5.5",
     });
     expect(next.threads[0]?.runtimeMode).toBe("approval-required");
@@ -337,6 +340,7 @@ describe("orchestration projector", () => {
 
     expect(next.threads[0]?.modelSelection).toEqual({
       provider: "opencode",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "openai/gpt-5",
     });
     expect(next.threads[0]?.session).toMatchObject({

--- a/apps/server/src/orchestration/turnStartSession.test.ts
+++ b/apps/server/src/orchestration/turnStartSession.test.ts
@@ -1,4 +1,8 @@
-import { ThreadId, type OrchestrationSession } from "@synara/contracts";
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  ThreadId,
+  type OrchestrationSession,
+} from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
 import { deriveTurnStartModelSelection, deriveTurnStartSession } from "./turnStartSession.ts";
@@ -32,21 +36,45 @@ describe("deriveTurnStartSession", () => {
   it("keeps an established provider when a later turn requests another provider", () => {
     expect(
       deriveTurnStartModelSelection({
-        currentModelSelection: { provider: "codex", model: "gpt-5-codex" },
-        requestedModelSelection: { provider: "pi", model: "openai/gpt-5" },
+        currentModelSelection: {
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          model: "gpt-5-codex",
+        },
+        requestedModelSelection: {
+          provider: "pi",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          model: "openai/gpt-5",
+        },
         canAdoptRequestedProvider: false,
       }),
-    ).toEqual({ provider: "codex", model: "gpt-5-codex" });
+    ).toEqual({
+      provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
+      model: "gpt-5-codex",
+    });
   });
 
   it("allows an empty thread to adopt its first requested provider", () => {
     expect(
       deriveTurnStartModelSelection({
-        currentModelSelection: { provider: "codex", model: "gpt-5-codex" },
-        requestedModelSelection: { provider: "pi", model: "openai/gpt-5" },
+        currentModelSelection: {
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          model: "gpt-5-codex",
+        },
+        requestedModelSelection: {
+          provider: "pi",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          model: "openai/gpt-5",
+        },
         canAdoptRequestedProvider: true,
       }),
-    ).toEqual({ provider: "pi", model: "openai/gpt-5" });
+    ).toEqual({
+      provider: "pi",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
+      model: "openai/gpt-5",
+    });
   });
 
   it("creates a starting session when no session exists", () => {

--- a/apps/server/src/persistence/Layers/AutomationRepository.test.ts
+++ b/apps/server/src/persistence/Layers/AutomationRepository.test.ts
@@ -1,5 +1,6 @@
 import { assert, it } from "@effect/vitest";
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   AutomationId,
   AutomationRunId,
   CommandId,
@@ -27,6 +28,7 @@ const createInput = {
   schedule: { type: "manual" },
   modelSelection: {
     provider: "codex",
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
     model: "gpt-5-codex",
   },
 } satisfies AutomationCreateInput;

--- a/apps/server/src/persistence/Layers/OrchestrationEventStore.test.ts
+++ b/apps/server/src/persistence/Layers/OrchestrationEventStore.test.ts
@@ -1,4 +1,10 @@
-import { CommandId, EventId, ProjectId, ThreadId } from "@synara/contracts";
+import {
+  CommandId,
+  DEFAULT_PROVIDER_PROFILE_ID,
+  EventId,
+  ProjectId,
+  ThreadId,
+} from "@synara/contracts";
 import { assert, it } from "@effect/vitest";
 import { Effect, Layer, Schema, Stream } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
@@ -334,6 +340,7 @@ layer("OrchestrationEventStore", (it) => {
           : null,
         {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "imported-project-model",
         },
       );
@@ -341,6 +348,7 @@ layer("OrchestrationEventStore", (it) => {
         threadCreated?.type === "thread.created" ? threadCreated.payload.modelSelection : null,
         {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.5",
           options: {
             reasoningEffort: "medium",
@@ -353,6 +361,7 @@ layer("OrchestrationEventStore", (it) => {
           : null,
         {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.5",
           options: {
             reasoningEffort: "medium",

--- a/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
@@ -1,4 +1,10 @@
-import { ProjectId, SpaceId, ThreadId, TurnId } from "@synara/contracts";
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  ProjectId,
+  SpaceId,
+  ThreadId,
+  TurnId,
+} from "@synara/contracts";
 import { assert, it } from "@effect/vitest";
 import { Effect, Layer, Option } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
@@ -90,6 +96,7 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
         workspaceRoot: "/tmp/project-null-options",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.4",
         },
         scripts: [],
@@ -116,6 +123,7 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
         row.defaultModelSelection,
         JSON.stringify({
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.4",
         }),
       );
@@ -125,6 +133,7 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
       });
       assert.deepStrictEqual(Option.getOrNull(persisted)?.defaultModelSelection, {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "gpt-5.4",
       });
     }),
@@ -141,6 +150,7 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
         title: "Null options thread",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
         },
         runtimeMode: "full-access",
@@ -183,6 +193,7 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
         row.modelSelection,
         JSON.stringify({
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
         }),
       );
@@ -192,6 +203,7 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
       });
       assert.deepStrictEqual(Option.getOrNull(persisted)?.modelSelection, {
         provider: "claudeAgent",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "claude-opus-4-6",
       });
     }),

--- a/apps/server/src/persistence/Migrations/035_NormalizeLegacyModelSelectionOptions.test.ts
+++ b/apps/server/src/persistence/Migrations/035_NormalizeLegacyModelSelectionOptions.test.ts
@@ -2,7 +2,7 @@
 // Purpose: Verifies legacy array-shaped modelSelection options are repaired before strict decode.
 // Layer: Persistence migration test
 
-import { ModelSelection } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, ModelSelection } from "@synara/contracts";
 import { assert, it } from "@effect/vitest";
 import { Effect, Layer, Schema } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
@@ -381,31 +381,37 @@ layer("035_NormalizeLegacyModelSelectionOptions", (it) => {
 
       assert.deepStrictEqual(decodeModelSelection(projectSelection), {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "gpt-5.5",
         options: { reasoningEffort: "medium" },
       });
       assert.deepStrictEqual(decodeModelSelection(threadSelections.get("claude-opus-4-6")), {
         provider: "claudeAgent",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "claude-opus-4-6",
         options: { effort: "high", fastMode: true },
       });
       assert.deepStrictEqual(decodeModelSelection(threadSelections.get("openai/gpt-5.4")), {
         provider: "opencode",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "openai/gpt-5.4",
         options: { agent: "plan", variant: "fast" },
       });
       assert.deepStrictEqual(decodeModelSelection(threadSelections.get("gpt-5.4")), {
         provider: "cursor",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "gpt-5.4",
         options: { reasoningEffort: "high" },
       });
       assert.deepStrictEqual(decodeModelSelection(projectEventPayload.defaultModelSelection), {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "gpt-5.5",
         options: { reasoningEffort: "low" },
       });
       assert.deepStrictEqual(decodeModelSelection(threadEventPayload.modelSelection), {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "gpt-5.5",
         options: { reasoningEffort: "xhigh" },
       });
@@ -413,6 +419,7 @@ layer("035_NormalizeLegacyModelSelectionOptions", (it) => {
         decodeModelSelection(JSON.parse(pagedProjectRows[0]!.modelSelection) as unknown),
         {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.5",
           options: { reasoningEffort: "high" },
         },
@@ -421,6 +428,7 @@ layer("035_NormalizeLegacyModelSelectionOptions", (it) => {
         decodeModelSelection(JSON.parse(pagedThreadRows[0]!.modelSelection) as unknown),
         {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.5",
           options: { reasoningEffort: "high" },
         },
@@ -430,6 +438,7 @@ layer("035_NormalizeLegacyModelSelectionOptions", (it) => {
       };
       assert.deepStrictEqual(decodeModelSelection(pagedEventPayload.modelSelection), {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "gpt-5.5",
         options: { reasoningEffort: "high" },
       });

--- a/apps/server/src/persistence/modelSelectionCompatibility.test.ts
+++ b/apps/server/src/persistence/modelSelectionCompatibility.test.ts
@@ -3,13 +3,16 @@
 // Layer: Persistence compatibility tests
 // Depends on: modelSelectionCompatibility.
 
+import { DEFAULT_PROVIDER_PROFILE_ID, ModelSelection } from "@synara/contracts";
 import { assert, it } from "@effect/vitest";
+import { Schema } from "effect";
 
 import { normalizePersistedModelSelection } from "./modelSelectionCompatibility.ts";
 
 it("preserves canonical Pi model selections", () => {
   assert.deepEqual(normalizePersistedModelSelection({ provider: "pi", model: "openai/gpt-5.5" }), {
     provider: "pi",
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
     model: "openai/gpt-5.5",
   });
 });
@@ -22,6 +25,7 @@ it("migrates combined Antigravity model and effort labels", () => {
     }),
     {
       provider: "antigravity",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "Gemini 3.5 Flash",
       options: { reasoningEffort: "high" },
     },
@@ -36,6 +40,7 @@ it("infers Antigravity from persisted instance labels", () => {
     }),
     {
       provider: "antigravity",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "Claude Sonnet 4.6",
       options: { reasoningEffort: "thinking" },
     },
@@ -50,6 +55,7 @@ it("prefers an explicit Antigravity instance over a model vendor in its label", 
     }),
     {
       provider: "antigravity",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "Claude Sonnet 4.6",
       options: { reasoningEffort: "thinking" },
     },
@@ -64,6 +70,7 @@ it("migrates known Gemini models without discarding the saved selection", () => 
     }),
     {
       provider: "antigravity",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "Gemini 3.1 Pro",
     },
   );
@@ -77,6 +84,7 @@ it("preserves unknown Gemini models as custom Antigravity selections", () => {
     }),
     {
       provider: "antigravity",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gemini-custom-preview",
     },
   );
@@ -90,6 +98,7 @@ it("infers Pi from persisted instance labels", () => {
     }),
     {
       provider: "pi",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "openai/gpt-5.5",
     },
   );
@@ -98,6 +107,7 @@ it("infers Pi from persisted instance labels", () => {
 it("infers Droid only for Factory-exclusive provider-less model slugs", () => {
   assert.deepEqual(normalizePersistedModelSelection({ model: "minimax-m3" }), {
     provider: "droid",
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
     model: "minimax-m3",
   });
 });
@@ -105,6 +115,32 @@ it("infers Droid only for Factory-exclusive provider-less model slugs", () => {
 it("does not steal ambiguous provider-less Claude slugs from Claude Agent", () => {
   assert.deepEqual(normalizePersistedModelSelection({ model: "claude-opus-4-8" }), {
     provider: "claudeAgent",
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
     model: "claude-opus-4-8",
   });
+});
+
+it("preserves explicit provider profile routing", () => {
+  assert.deepEqual(
+    normalizePersistedModelSelection({
+      provider: "codex",
+      profileId: "work",
+      model: "gpt-5.6-codex",
+    }),
+    {
+      provider: "codex",
+      profileId: "work",
+      model: "gpt-5.6-codex",
+    },
+  );
+});
+
+it("does not replace an invalid explicit profile with the default", () => {
+  const normalized = normalizePersistedModelSelection({
+    provider: "codex",
+    profileId: "../work",
+    model: "gpt-5.6-codex",
+  });
+
+  assert.equal(Schema.decodeUnknownExit(ModelSelection)(normalized)._tag, "Failure");
 });

--- a/apps/server/src/persistence/modelSelectionCompatibility.ts
+++ b/apps/server/src/persistence/modelSelectionCompatibility.ts
@@ -3,7 +3,7 @@
 // Layer: Persistence compatibility helper
 // Exports: normalizeLegacyModelSelection, normalizePersistedModelSelection
 
-import { MODEL_OPTIONS_BY_PROVIDER } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, MODEL_OPTIONS_BY_PROVIDER } from "@synara/contracts";
 
 type ModelProviderKind =
   | "codex"
@@ -174,6 +174,7 @@ function migrateLegacyGeminiModel(model: string): string {
 
 export function normalizeLegacyModelSelection(input: {
   readonly provider: unknown;
+  readonly profileId?: unknown;
   readonly model: string;
   readonly options: unknown;
 }): Record<string, unknown> {
@@ -196,8 +197,11 @@ export function normalizeLegacyModelSelection(input: {
           reasoningEffort: antigravityModel.reasoningEffort,
         }
       : normalizedOptions;
+  const profileId =
+    input.profileId === undefined ? DEFAULT_PROVIDER_PROFILE_ID : input.profileId;
   return {
     provider,
+    profileId,
     model: antigravityModel?.model ?? input.model,
     ...(options === undefined ? {} : { options }),
   };
@@ -217,6 +221,7 @@ export function normalizePersistedModelSelection(input: unknown): unknown {
   // option rows as [{ id, value }]; Synara stores canonical provider/options objects.
   return normalizeLegacyModelSelection({
     provider: input.provider ?? input.instanceId,
+    profileId: input.profileId,
     model,
     options: input.options,
   });

--- a/apps/server/src/project/githubProjectProvisioning.test.ts
+++ b/apps/server/src/project/githubProjectProvisioning.test.ts
@@ -1,5 +1,5 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { CommandId, ProjectId, type GitHubProjectProvisionInput } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, CommandId, ProjectId, type GitHubProjectProvisionInput } from "@synara/contracts";
 import { Deferred, Effect, Fiber, FileSystem, Path, PlatformError } from "effect";
 import { describe, expect, it } from "vitest";
 
@@ -20,7 +20,7 @@ function makeInput(destinationParent: string): GitHubProjectProvisionInput {
     commandId: CommandId.makeUnsafe("command-1"),
     projectId: ProjectId.makeUnsafe("project-1"),
     newProjectSpaceId: null,
-    defaultModelSelection: { provider: "codex", model: "gpt-5" },
+    defaultModelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5" },
     createdAt: "2026-08-04T00:00:00.000Z",
   };
 }

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -14,6 +14,7 @@ import type {
   SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   ApprovalRequestId,
   ProviderItemId,
   ProviderRuntimeEvent,
@@ -479,6 +480,7 @@ describe("ClaudeAdapterLive", () => {
         runtimeMode: "full-access",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-8",
         },
       });
@@ -643,6 +645,7 @@ describe("ClaudeAdapterLive", () => {
         provider: "claudeAgent",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
           options: {
             effort: "max",
@@ -668,6 +671,7 @@ describe("ClaudeAdapterLive", () => {
         provider: "claudeAgent",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
           options: {
             autoCompactWindow: "1m",
@@ -695,6 +699,7 @@ describe("ClaudeAdapterLive", () => {
         provider: "claudeAgent",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-7",
           options: {
             effort: "xhigh",
@@ -721,6 +726,7 @@ describe("ClaudeAdapterLive", () => {
         provider: "claudeAgent",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-5",
           options: {
             effort: "xhigh",
@@ -752,6 +758,7 @@ describe("ClaudeAdapterLive", () => {
             provider: "claudeAgent",
             modelSelection: {
               provider: "claudeAgent",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: "claude-sonnet-5",
               options: { effort },
             },
@@ -783,6 +790,7 @@ describe("ClaudeAdapterLive", () => {
         provider: "claudeAgent",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-5",
           options: {
             effort: "ultracode",
@@ -815,6 +823,7 @@ describe("ClaudeAdapterLive", () => {
         provider: "claudeAgent",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-4-6",
           options: {
             effort: "max",
@@ -840,6 +849,7 @@ describe("ClaudeAdapterLive", () => {
         provider: "claudeAgent",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-haiku-4-5",
           options: {
             effort: "high",
@@ -865,6 +875,7 @@ describe("ClaudeAdapterLive", () => {
         provider: "claudeAgent",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-haiku-4-5",
           options: {
             thinking: false,
@@ -893,6 +904,7 @@ describe("ClaudeAdapterLive", () => {
         provider: "claudeAgent",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-4-6",
           options: {
             thinking: false,
@@ -921,6 +933,7 @@ describe("ClaudeAdapterLive", () => {
         provider: "claudeAgent",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
           options: {
             fastMode: true,
@@ -950,6 +963,7 @@ describe("ClaudeAdapterLive", () => {
         provider: "claudeAgent",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-4-6",
           options: {
             fastMode: true,
@@ -978,6 +992,7 @@ describe("ClaudeAdapterLive", () => {
         provider: "claudeAgent",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-4-6",
           options: {
             effort: "ultrathink",
@@ -992,6 +1007,7 @@ describe("ClaudeAdapterLive", () => {
         attachments: [],
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-4-6",
           options: {
             effort: "ultrathink",
@@ -1393,6 +1409,7 @@ describe("ClaudeAdapterLive", () => {
         provider: "claudeAgent",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-sonnet-4-5",
         },
         runtimeMode: "full-access",
@@ -7584,6 +7601,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         input: "hello",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
         },
         attachments: [],
@@ -7634,6 +7652,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         runtimeMode: "auto",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
         },
       });
@@ -7644,6 +7663,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
           input: "switch to Haiku",
           modelSelection: {
             provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "claude-haiku-4-5",
           },
           attachments: [],
@@ -7658,6 +7678,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         input: "switch to Fable",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-fable-5",
         },
         attachments: [],
@@ -7684,6 +7705,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         input: "hello",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
           options: {
             autoCompactWindow: "1m",
@@ -7715,6 +7737,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         runtimeMode: "full-access",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
           options: { autoCompactWindow: "1m" },
         },
@@ -7724,6 +7747,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         input: "use the default auto-compact budget",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
         },
         attachments: [],
@@ -7733,6 +7757,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         input: "switch to a discovered model",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude/custom-opus",
         },
         attachments: [],
@@ -7766,6 +7791,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         runtimeMode: "full-access",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-haiku-4-5",
           options: { thinking: false },
         },
@@ -7779,6 +7805,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         input: "hello",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-haiku-4-5",
           options: { thinking: true },
         },
@@ -7792,6 +7819,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         input: "continue",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-haiku-4-5",
           options: { thinking: true },
         },
@@ -7815,6 +7843,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         runtimeMode: "full-access",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-8",
           options: { effort: "high" },
         },
@@ -7826,6 +7855,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         input: "hello",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-8",
           options: { effort: "ultracode", fastMode: true },
         },
@@ -7841,6 +7871,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         input: "continue",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-8",
           options: { effort: "ultracode", fastMode: true },
         },
@@ -7856,6 +7887,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         input: "wrap up",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-8",
         },
         attachments: [],
@@ -7949,6 +7981,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         runtimeMode: "full-access",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-8",
         },
       });
@@ -7957,6 +7990,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         input: "hello",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-8",
         },
         attachments: [],
@@ -8015,6 +8049,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         runtimeMode: "full-access",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-8",
           options: { autoCompactWindow: "1m" },
         },
@@ -8047,6 +8082,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         runtimeMode: "full-access",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-fable-5",
         },
       });
@@ -8056,6 +8092,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         input: "hello",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-fable-5",
         },
         attachments: [],
@@ -8103,6 +8140,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         input: "continue",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-fable-5",
         },
         attachments: [],
@@ -8129,6 +8167,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         runtimeMode: "full-access",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-fable-5",
           options: { autoCompactWindow: "1m" },
         },
@@ -8158,6 +8197,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         runtimeMode: "full-access",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-fable-5",
           options: { autoCompactWindow: "1m" },
         },
@@ -8176,6 +8216,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         input: "continue after resume",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-fable-5",
           options: { autoCompactWindow: "1m" },
         },
@@ -8196,7 +8237,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         threadId: THREAD_ID,
         provider: "claudeAgent",
         runtimeMode: "full-access",
-        modelSelection: { provider: "claudeAgent", model: "claude-opus-4-8" },
+        modelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "claude-opus-4-8" },
       });
       const firstQuery = harness.queries[0];
       assert.ok(firstQuery);
@@ -8208,6 +8249,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
           runtimeMode: "full-access",
           modelSelection: {
             provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "claude-opus-4-8",
             options: { effort: "max" },
           },
@@ -8245,6 +8287,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
           runtimeMode: "full-access",
           modelSelection: {
             provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "claude-opus-4-8",
             options: { effort: "max" },
           },
@@ -8351,6 +8394,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
           runtimeMode: "auto",
           modelSelection: {
             provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "claude-haiku-4-5",
           },
         }),
@@ -8400,6 +8444,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
           runtimeMode: "auto",
           modelSelection: {
             provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "claude-sonnet-5",
           },
         }),
@@ -8440,6 +8485,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
           runtimeMode: "auto",
           modelSelection: {
             provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "claude-sonnet-5",
           },
         }),
@@ -8566,6 +8612,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         runtimeMode: "full-access",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
           options: { autoCompactWindow: "1m" },
         },
@@ -8627,6 +8674,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         input: "hello",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
           options: {
             autoCompactWindow: "1m",
@@ -8685,6 +8733,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         input: "hello",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
           options: {
             autoCompactWindow: "1m",
@@ -8782,7 +8831,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         threadId: THREAD_ID,
         provider: "claudeAgent",
         runtimeMode: "full-access",
-        modelSelection: { provider: "claudeAgent", model: "claude-sonnet-5" },
+        modelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "claude-sonnet-5" },
       });
       harness.query.emit({
         type: "result",

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import path from "node:path";
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   ApprovalRequestId,
   EventId,
   ProviderItemId,
@@ -209,6 +210,7 @@ validationLayer("CodexAdapterLive validation", (it) => {
         lifecycleGeneration: "generation-start-a",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.3-codex",
           options: {
             reasoningEffort: "high",
@@ -302,6 +304,7 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
           input: "hello",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5.3-codex",
             options: {
               reasoningEffort: "high",

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1,4 +1,4 @@
-import { ApprovalRequestId, ThreadId, TurnId } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, ApprovalRequestId, ThreadId, TurnId } from "@synara/contracts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import type {
   Agent,
@@ -1127,7 +1127,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
             threadId,
             input: "coordinate work",
             attachments: [],
-            modelSelection: { provider: "opencode", model: "openai/gpt-5" },
+            modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5" },
           });
         }
         yield* adapter.stopSession(firstThread);
@@ -1195,14 +1195,14 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           threadId: firstThread,
           input: "coordinate first",
           attachments: [],
-          modelSelection: { provider: "opencode", model: "openai/gpt-5" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5" },
         });
         const secondTurn = yield* adapter
           .sendTurn({
             threadId: secondThread,
             input: "coordinate second",
             attachments: [],
-            modelSelection: { provider: "opencode", model: "openai/gpt-5" },
+            modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5" },
           })
           .pipe(Effect.forkChild);
         yield* Effect.sleep(20);
@@ -1325,7 +1325,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
             threadId,
             input: "first attempt",
             attachments: [],
-            modelSelection: { provider: "opencode", model: "openai/gpt-5" },
+            modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5" },
           })
           .pipe(Effect.exit);
         expect(Exit.isFailure(failed)).toBe(false);
@@ -1335,7 +1335,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           threadId,
           input: "second attempt",
           attachments: [],
-          modelSelection: { provider: "opencode", model: "openai/gpt-5" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5" },
         });
         expect(runtime.promptCalls).toHaveLength(2);
         yield* adapter.interruptTurn(threadId);
@@ -1378,7 +1378,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           threadId,
           input: "coordinate work",
           attachments: [],
-          modelSelection: { provider: "opencode", model: "openai/gpt-5" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5" },
         });
       }).pipe(
         Effect.provide(
@@ -1454,7 +1454,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           threadId,
           input: "perform a long-running task",
           attachments: [],
-          modelSelection: { provider: "kilo", model: "openai/gpt-5" },
+          modelSelection: { provider: "kilo", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5" },
         });
         yield* adapter.stopSession(threadId);
       }).pipe(
@@ -1500,14 +1500,14 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           threadId: firstThread,
           input: "coordinate first",
           attachments: [],
-          modelSelection: { provider: "kilo", model: "openai/gpt-5" },
+          modelSelection: { provider: "kilo", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5" },
         });
         const secondTurn = yield* adapter
           .sendTurn({
             threadId: secondThread,
             input: "coordinate second",
             attachments: [],
-            modelSelection: { provider: "kilo", model: "openai/gpt-5" },
+            modelSelection: { provider: "kilo", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5" },
           })
           .pipe(Effect.forkChild);
         yield* Effect.sleep(20);
@@ -1780,7 +1780,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           input: "Implement the change",
           attachments: [],
           interactionMode: "default",
-          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5.4" },
         });
       }).pipe(
         Effect.provide(
@@ -2009,6 +2009,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           runtimeMode: "full-access",
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "opencode/big-pickle",
             options: {
               agent: "build",
@@ -2062,6 +2063,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
             options: {
               variant: "high",
@@ -2152,7 +2154,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           threadId,
           input: "wait in the visible browser",
           attachments: [],
-          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5.4" },
         });
 
         const interruptFiber = yield* adapter
@@ -2221,6 +2223,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -2357,6 +2360,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -2496,6 +2500,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -2584,6 +2589,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -2631,6 +2637,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           ],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -2679,6 +2686,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -2719,6 +2727,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
             options: {
               agent: "plan",
@@ -2762,6 +2771,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
             options: {
               agent: "reviewer",
@@ -2818,6 +2828,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -2914,6 +2925,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -2995,6 +3007,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -3052,6 +3065,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -3120,6 +3134,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -3205,6 +3220,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -3279,6 +3295,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -3373,7 +3390,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           input: "Plan the change",
           attachments: [],
           interactionMode: "plan",
-          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5.4" },
         });
         yield* adapter.interruptTurn(threadId);
         yield* adapter.sendTurn({
@@ -3381,7 +3398,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           input: "Implement the change",
           attachments: [],
           interactionMode: "default",
-          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5.4" },
         });
       }).pipe(
         Effect.provide(
@@ -3431,7 +3448,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           threadId,
           input: "Delegate a read-only check",
           attachments: [],
-          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5.4" },
         });
         eventQueue.push({
           type: "permission.asked",
@@ -3623,7 +3640,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           threadId,
           input: "Run a command",
           attachments: [],
-          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5.4" },
         });
         eventQueue.push({
           type: "permission.asked",
@@ -3692,6 +3709,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -3813,6 +3831,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -3961,6 +3980,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -4040,7 +4060,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           threadId,
           input: "Search the web",
           attachments: [],
-          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5.4" },
         });
 
         const openedFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(
@@ -4214,7 +4234,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           threadId,
           input: "Inspect status",
           attachments: [],
-          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5.4" },
         });
         const openedFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(
           Effect.forkChild,
@@ -4314,7 +4334,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           threadId,
           input: "Inspect status",
           attachments: [],
-          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5.4" },
         });
         eventQueue.push({ type: "permission.asked", properties: permission });
         yield* Fiber.join(openedFiber);
@@ -4399,7 +4419,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           threadId,
           input: "Inspect status",
           attachments: [],
-          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5.4" },
         });
         const openedFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(
           Effect.forkChild,
@@ -4497,7 +4517,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           threadId,
           input: "Search docs",
           attachments: [],
-          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5.4" },
         });
         const openedFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(
           Effect.forkChild,
@@ -4576,6 +4596,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -4679,6 +4700,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -4809,6 +4831,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -4905,6 +4928,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
             attachments: [],
             modelSelection: {
               provider: "opencode",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: "opencode/claude-opus-4-7",
             },
           })
@@ -4966,6 +4990,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
             attachments: [],
             modelSelection: {
               provider: "opencode",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: "opencode/claude-opus-4-7",
             },
           }),
@@ -5036,6 +5061,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           attachments: [],
           modelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         });
@@ -5134,7 +5160,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           threadId,
           input: "hello",
           attachments: [],
-          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5.4" },
         });
 
         messageSnapshot = [
@@ -5265,7 +5291,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           threadId,
           input: "hello",
           attachments: [],
-          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5.4" },
         });
 
         eventQueue.push({
@@ -5360,7 +5386,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           input: "plan this",
           interactionMode: "plan",
           attachments: [],
-          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5.4" },
         });
 
         eventQueue.push({
@@ -5484,7 +5510,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           input: "plan this",
           interactionMode: "plan",
           attachments: [],
-          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5.4" },
         });
 
         const finalInfo = {
@@ -5625,7 +5651,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           threadId,
           input: "first",
           attachments: [],
-          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5.4" },
         });
         eventQueue.push({
           type: "session.idle",
@@ -5650,7 +5676,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           threadId,
           input: "second",
           attachments: [],
-          modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+          modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5.4" },
         });
 
         yield* Effect.sync(() => {

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -17,6 +17,7 @@ import type {
   ProviderTurnStartResult,
 } from "@synara/contracts";
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   ApprovalRequestId,
   EventId,
   type ProviderKind,
@@ -132,6 +133,7 @@ function makeFakeCodexAdapter(
         const now = new Date().toISOString();
         const session: ProviderSession = {
           provider,
+          profileId: input.profileId ?? DEFAULT_PROVIDER_PROFILE_ID,
           status: "ready",
           runtimeMode: input.runtimeMode,
           threadId: input.threadId,
@@ -1999,6 +2001,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
         cwd: "/tmp/project-claude-send-turn",
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
           options: {
             effort: "max",
@@ -2032,6 +2035,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
         assert.equal(startPayload.cwd, "/tmp/project-claude-send-turn");
         assert.deepEqual(startPayload.modelSelection, {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
           options: {
             effort: "max",
@@ -2160,6 +2164,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
           assert.equal(runtimePayload.lastRuntimeEvent, "turn.completed");
           assert.deepEqual(runtimePayload.modelSelection, {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "opencode/minimax-m2.5-free",
           });
         }
@@ -2176,9 +2181,14 @@ routing.layer("ProviderServiceLive routing", (it) => {
       const newerTurnId = asTurnId("turn-overlapping-newer");
       const olderResumeCursor = { cursor: "older-resume" };
       const newerResumeCursor = { cursor: "newer-resume" };
-      const olderModelSelection = { provider: "codex" as const, model: "gpt-5.1-codex-mini" };
+      const olderModelSelection = {
+        provider: "codex" as const,
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
+        model: "gpt-5.1-codex-mini",
+      };
       const newerModelSelection = {
         provider: "opencode" as const,
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "opencode/minimax-m2.5-free",
       };
       let olderDispatchStarted = false;
@@ -2305,7 +2315,11 @@ routing.layer("ProviderServiceLive routing", (it) => {
       const threadId = asThreadId("thread-promote-older-success");
       const olderTurnId = asTurnId("turn-promoted-older");
       const olderCursor = { cursor: "promoted-older" };
-      const olderModelSelection = { provider: "codex" as const, model: "gpt-5-codex" };
+      const olderModelSelection = {
+        provider: "codex" as const,
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
+        model: "gpt-5-codex",
+      };
       const newerFailure = new ProviderAdapterSessionNotFoundError({
         provider: "codex",
         threadId,
@@ -2487,6 +2501,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
       const resumeCursor = { cursor: "steer-resume" };
       const modelSelection = {
         provider: "opencode" as const,
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "opencode/minimax-m2.5-free",
       };
 
@@ -2525,9 +2540,14 @@ routing.layer("ProviderServiceLive routing", (it) => {
       const reviewTurnId = asTurnId("turn-newer-review");
       const staleSteerCursor = { cursor: "stale-steer-resume" };
       const reviewCursor = { cursor: "newer-review-resume" };
-      const initialModelSelection = { provider: "codex" as const, model: "gpt-5-codex" };
+      const initialModelSelection = {
+        provider: "codex" as const,
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
+        model: "gpt-5-codex",
+      };
       const staleSteerModelSelection = {
         provider: "opencode" as const,
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "opencode/minimax-m2.5-free",
       };
       let steerStarted = false;

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.test.ts
@@ -3,7 +3,10 @@ import os from "node:os";
 import path from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { ThreadId } from "@synara/contracts";
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  ThreadId,
+} from "@synara/contracts";
 import { it, assert } from "@effect/vitest";
 import { assertFailure, assertSome } from "@effect/vitest/utils";
 import { Effect, Layer, Option } from "effect";
@@ -142,6 +145,7 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
       yield* runtimeRepository.upsert({
         threadId,
         providerName: "claudeAgent",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         adapterKey: "claudeAgent",
         runtimeMode: "full-access",
         status: "running",

--- a/apps/server/src/provider/providerRuntimeReconciliation.test.ts
+++ b/apps/server/src/provider/providerRuntimeReconciliation.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   CommandId,
   OrchestrationCommand,
   ProjectId,
@@ -27,7 +28,11 @@ function threadShell(overrides: Partial<OrchestrationThreadShell> = {}): Orchest
     id: THREAD_ID,
     projectId: ProjectId.makeUnsafe("project-reconcile"),
     title: "Runtime reconciliation",
-    modelSelection: { provider: "codex", model: "gpt-5.6" },
+    modelSelection: {
+      provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
+      model: "gpt-5.6",
+    },
     runtimeMode: "full-access",
     interactionMode: "default",
     branch: null,
@@ -131,7 +136,7 @@ describe("planProviderRuntimeReconciliation", () => {
       planProviderRuntimeReconciliation({
         threads: [
           threadShell({
-            modelSelection: { provider: "claudeAgent", model: "claude-opus-4-8" },
+            modelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "claude-opus-4-8" },
             session: {
               ...threadShell().session!,
               providerName: "claudeAgent",

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -7,6 +7,7 @@
  */
 import {
   DEFAULT_MODEL_BY_PROVIDER,
+  DEFAULT_PROVIDER_PROFILE_ID,
   DEFAULT_SERVER_SETTINGS,
   type ModelSelection,
   type ProviderWithDefaultModel,
@@ -151,6 +152,7 @@ function resolveTextGenerationProvider(settings: ServerSettings): ServerSettings
     ...settings,
     textGenerationModelSelection: {
       provider: fallback,
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: DEFAULT_MODEL_BY_PROVIDER[fallback],
     } as ModelSelection,
   };

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -3,11 +3,13 @@
 // Layer: Web settings tests
 // Exports: Vitest suites for appSettings.ts
 
+import { ProviderProfileId } from "@synara/contracts";
 import { Schema } from "effect";
 import { describe, expect, it } from "vitest";
 
 import {
   AppSettingsSchema,
+  appSettingsPatchToServerSettingsPatch,
   CUSTOM_MODEL_EDITOR_PROVIDER_SETTINGS,
   DEFAULT_CHAT_FONT_SIZE_PX,
   DEFAULT_FOLLOW_UP_BEHAVIOR,
@@ -233,10 +235,44 @@ describe("isGitTextGenerationSettingsDirty", () => {
     expect(isGitTextGenerationSettingsDirty(defaults, defaults)).toBe(false);
     expect(
       isGitTextGenerationSettingsDirty(
+        { ...defaults, textGenerationProfileId: ProviderProfileId.makeUnsafe("work") },
+        defaults,
+      ),
+    ).toBe(true);
+    expect(
+      isGitTextGenerationSettingsDirty(
         { ...defaults, textGenerationProvider: "opencode", textGenerationModel: "custom/model" },
         defaults,
       ),
     ).toBe(true);
+  });
+});
+
+describe("appSettingsPatchToServerSettingsPatch", () => {
+  it("preserves the current provider and model for a profile-only patch", () => {
+    expect(
+      appSettingsPatchToServerSettingsPatch({
+        textGenerationProfileId: ProviderProfileId.makeUnsafe("work"),
+      }),
+    ).toEqual({
+      textGenerationModelSelection: {
+        profileId: ProviderProfileId.makeUnsafe("work"),
+      },
+    });
+  });
+
+  it("does not attach a default profile to model-only patches", () => {
+    expect(
+      appSettingsPatchToServerSettingsPatch({
+        textGenerationProvider: "opencode",
+        textGenerationModel: "openai/gpt-5",
+      }),
+    ).toEqual({
+      textGenerationModelSelection: {
+        provider: "opencode",
+        model: "openai/gpt-5",
+      },
+    });
   });
 });
 

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -10,10 +10,12 @@ import {
   type AssistantDeliveryMode,
   DesktopAppIcon,
   DEFAULT_GIT_TEXT_GENERATION_MODEL,
+  DEFAULT_PROVIDER_PROFILE_ID,
   DEFAULT_SERVER_SETTINGS,
   DEFAULT_SERVER_SETTINGS_VIEW,
   TrimmedNonEmptyString,
   ProviderKind,
+  ProviderProfileId,
   type ProviderStartOptions,
   type ServerSettingsView,
   type ServerSettingsPatch,
@@ -265,6 +267,9 @@ export const AppSettingsSchema = Schema.Struct({
   customOpenCodeModels: Schema.Array(Schema.String).pipe(withDefaults(() => [])),
   customPiModels: Schema.Array(Schema.String).pipe(withDefaults(() => [])),
   textGenerationProvider: PersistedProviderKind.pipe(withDefaults(() => "codex" as const)),
+  textGenerationProfileId: ProviderProfileId.pipe(
+    withDefaults(() => DEFAULT_PROVIDER_PROFILE_ID),
+  ),
   textGenerationModel: Schema.optional(TrimmedNonEmptyString),
   uiFontFamily: Schema.String.check(Schema.isMaxLength(256)).pipe(withDefaults(() => "")),
   defaultProvider: PersistedProviderKind.pipe(withDefaults(() => "codex" as const)),
@@ -302,6 +307,7 @@ export function isGitTextGenerationSettingsDirty(
 ): boolean {
   return (
     (settings.textGenerationProvider ?? "codex") !== (defaults.textGenerationProvider ?? "codex") ||
+    settings.textGenerationProfileId !== defaults.textGenerationProfileId ||
     (settings.textGenerationModel ?? DEFAULT_GIT_TEXT_GENERATION_MODEL) !==
       (defaults.textGenerationModel ?? DEFAULT_GIT_TEXT_GENERATION_MODEL)
   );
@@ -587,6 +593,7 @@ function serverSettingsToAppSettings(settings: ServerSettingsView): Partial<AppS
     customOpenCodeModels: settings.providers.opencode.customModels,
     customPiModels: settings.providers.pi.customModels,
     textGenerationProvider: settings.textGenerationModelSelection.provider,
+    textGenerationProfileId: settings.textGenerationModelSelection.profileId,
     textGenerationModel: settings.textGenerationModelSelection.model,
   };
 }
@@ -619,7 +626,9 @@ function touchesProviderDiscoverySettings(patch: Partial<AppSettings>): boolean 
   );
 }
 
-function appSettingsPatchToServerSettingsPatch(patch: Partial<AppSettings>): ServerSettingsPatch {
+export function appSettingsPatchToServerSettingsPatch(
+  patch: Partial<AppSettings>,
+): ServerSettingsPatch {
   const providers: MutableServerSettingsProvidersPatch = {};
   const serverPatch: MutableServerSettingsPatch = {};
 
@@ -632,16 +641,26 @@ function appSettingsPatchToServerSettingsPatch(patch: Partial<AppSettings>): Ser
   if (patch.defaultThreadEnvMode === "local" || patch.defaultThreadEnvMode === "worktree") {
     serverPatch.defaultThreadEnvMode = patch.defaultThreadEnvMode;
   }
-  if (hasOwn(patch, "textGenerationModel") || hasOwn(patch, "textGenerationProvider")) {
-    const model = patch.textGenerationModel ?? DEFAULT_GIT_TEXT_GENERATION_MODEL;
+  if (
+    hasOwn(patch, "textGenerationModel") ||
+    hasOwn(patch, "textGenerationProvider") ||
+    hasOwn(patch, "textGenerationProfileId")
+  ) {
     serverPatch.textGenerationModelSelection = {
-      provider: resolveTextGenerationProvider({
-        ...(patch.textGenerationProvider !== undefined
-          ? { provider: patch.textGenerationProvider }
-          : {}),
-        model,
-      }),
-      model,
+      ...(hasOwn(patch, "textGenerationModel") || hasOwn(patch, "textGenerationProvider")
+        ? {
+            provider: resolveTextGenerationProvider({
+              ...(patch.textGenerationProvider !== undefined
+                ? { provider: patch.textGenerationProvider }
+                : {}),
+              model: patch.textGenerationModel ?? DEFAULT_GIT_TEXT_GENERATION_MODEL,
+            }),
+            model: patch.textGenerationModel ?? DEFAULT_GIT_TEXT_GENERATION_MODEL,
+          }
+        : {}),
+      ...(hasOwn(patch, "textGenerationProfileId")
+        ? { profileId: patch.textGenerationProfileId }
+        : {}),
     };
   }
 
@@ -790,6 +809,7 @@ function buildInitialServerSettingsMigrationPatch(settings: AppSettings): Server
     "piAgentDir",
     "piBinaryPath",
     "textGenerationModel",
+    "textGenerationProfileId",
     "textGenerationProvider",
   ] as const) {
     if (normalizedSettings[key] !== defaults[key]) {

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -2,6 +2,7 @@
 import "../index.css";
 
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   AutomationId,
   type AutomationCreateInput,
   type AutomationDefinition,
@@ -310,6 +311,7 @@ function createSnapshotForTargetUser(options: {
         workspaceRoot: "/repo/project",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5",
         },
         scripts: [],
@@ -325,6 +327,7 @@ function createSnapshotForTargetUser(options: {
         title: THREAD_TITLE,
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5",
         },
         interactionMode: "default",
@@ -525,6 +528,7 @@ function addThreadToSnapshot(
         title: "New thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5",
         },
         interactionMode: "default",
@@ -617,6 +621,7 @@ function withOpenProjectPickerFixtures(snapshot: OrchestrationReadModel): Orches
         workspaceRoot: "/repo/other",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5",
         },
         scripts: [],
@@ -640,6 +645,7 @@ function withHomeChatProject(snapshot: OrchestrationReadModel): OrchestrationRea
         workspaceRoot: "/Users/tester",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5",
         },
         scripts: [],
@@ -673,6 +679,7 @@ function withStudioProject(snapshot: OrchestrationReadModel): OrchestrationReadM
         workspaceRoot: "/Users/tester/Documents/Synara/Studio",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5",
         },
         scripts: [],
@@ -1144,6 +1151,7 @@ function recordProjectCreateCommand(command: unknown): boolean {
               ? (command.defaultModelSelection as OrchestrationReadModel["projects"][number]["defaultModelSelection"])
               : {
                   provider: "codex" as const,
+                  profileId: DEFAULT_PROVIDER_PROFILE_ID,
                   model: "gpt-5",
                 },
           scripts: [],
@@ -3867,6 +3875,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
     });
     useComposerDraftStore.getState().setModelSelection(THREAD_ID, {
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5.4",
       options: {
         reasoningEffort: "low",
@@ -4972,6 +4981,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
         selectedPromptEffort: null,
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5",
         },
         runtimeMode: "full-access",
@@ -4998,6 +5008,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
         selectedPromptEffort: null,
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5",
         },
         runtimeMode: "full-access",
@@ -5091,6 +5102,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
         selectedPromptEffort: null,
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5",
         },
         runtimeMode: "full-access",
@@ -5175,6 +5187,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
         selectedPromptEffort: null,
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5",
         },
         runtimeMode: "full-access",
@@ -6213,6 +6226,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
       stickyModelSelectionByProvider: {
         codex: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.3-codex",
           options: {
             reasoningEffort: "medium",
@@ -6678,6 +6692,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
       stickyModelSelectionByProvider: {
         claudeAgent: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
           options: {
             effort: "max",
@@ -6760,6 +6775,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
       stickyModelSelectionByProvider: {
         codex: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.3-codex",
           options: {
             reasoningEffort: "medium",
@@ -6806,6 +6822,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
 
       useComposerDraftStore.getState().setModelSelection(threadId, {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "gpt-5.4",
         options: {
           reasoningEffort: "low",
@@ -6996,6 +7013,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
           modelSelectionByProvider: {
             claudeAgent: {
               provider: "claudeAgent",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: "claude-opus-4-6",
               options: {
                 effort: "max",

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   CheckpointRef,
   EventId,
   MessageId,
@@ -1306,6 +1307,7 @@ describe("shouldShowComposerModelBootstrapSkeleton", () => {
         selectedModel: "openai/gpt-5-codex",
         persistedModelSelection: {
           provider: "opencode",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "openai/gpt-5.4",
         },
         draftModelSelection: null,
@@ -1321,6 +1323,7 @@ describe("shouldShowComposerModelBootstrapSkeleton", () => {
         selectedModel: "openai/gpt-5.4",
         persistedModelSelection: {
           provider: "opencode",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "openai/gpt-5.4",
         },
         draftModelSelection: null,
@@ -1337,6 +1340,7 @@ describe("shouldShowComposerModelBootstrapSkeleton", () => {
         selectedModel: "auto",
         persistedModelSelection: {
           provider: "cursor",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "auto",
         },
         draftModelSelection: null,
@@ -1353,10 +1357,12 @@ describe("shouldShowComposerModelBootstrapSkeleton", () => {
         selectedModel: "opencode/minimax-m2.5-free",
         persistedModelSelection: {
           provider: "opencode",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "openai/gpt-5.4",
         },
         draftModelSelection: {
           provider: "opencode",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "opencode/minimax-m2.5-free",
         },
         providerModelsLoading: true,
@@ -1371,6 +1377,7 @@ describe("shouldShowComposerModelBootstrapSkeleton", () => {
         selectedModel: "gpt-5.4",
         persistedModelSelection: {
           provider: "opencode",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "openai/gpt-5.4",
         },
         draftModelSelection: null,
@@ -2558,10 +2565,12 @@ describe("createRuntimeModePersistenceQueue", () => {
 describe("persistModelSelectionBeforeRuntimeMode", () => {
   const previousModel = {
     provider: "droid",
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
     model: "claude-opus-4-8",
   } as const;
   const autoCapableModel = {
     provider: "codex",
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
     model: "gpt-5.6-sol",
   } as const;
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3,6 +3,7 @@ import {
   type AutomationSchedule,
   type ApprovalRequestId,
   DEFAULT_MODEL_BY_PROVIDER,
+  DEFAULT_PROVIDER_PROFILE_ID,
   EventId,
   MessageId,
   type ModelSelection,
@@ -1809,6 +1810,7 @@ export default function ChatView({
             draftThread,
             fallbackDraftProject?.defaultModelSelection ?? {
               provider: "codex",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: DEFAULT_MODEL_BY_PROVIDER.codex,
             },
             localDraftError,

--- a/apps/web/src/components/DiffPanel.logic.test.ts
+++ b/apps/web/src/components/DiffPanel.logic.test.ts
@@ -1,4 +1,4 @@
-import { ProjectId, ThreadId, TurnId } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, ProjectId, ThreadId, TurnId } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
 import type { DraftThreadState } from "../composerDraftStore";
@@ -34,7 +34,7 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     codexThreadId: null,
     projectId: PROJECT_ID,
     title: "Thread 1",
-    modelSelection: { provider: "codex", model: "gpt-5.4-mini" },
+    modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.4-mini" },
     runtimeMode: "full-access",
     interactionMode: "default",
     session: null,
@@ -84,7 +84,7 @@ describe("resolveDiffPanelThread", () => {
         threadId: THREAD_ID,
         serverThread,
         draftThread: makeDraftThread({ branch: "feature/draft" }),
-        fallbackModelSelection: { provider: "codex", model: "gpt-5.4-mini" },
+        fallbackModelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.4-mini" },
       }),
     ).toBe(serverThread);
   });
@@ -98,7 +98,7 @@ describe("resolveDiffPanelThread", () => {
         worktreePath: "/tmp/worktree",
         envMode: "worktree",
       }),
-      fallbackModelSelection: { provider: "codex", model: "gpt-5.4-mini" },
+      fallbackModelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.4-mini" },
     });
 
     expect(resolved).toMatchObject({

--- a/apps/web/src/components/DiffPanel.logic.ts
+++ b/apps/web/src/components/DiffPanel.logic.ts
@@ -5,6 +5,7 @@
 
 import {
   DEFAULT_MODEL_BY_PROVIDER,
+  DEFAULT_PROVIDER_PROFILE_ID,
   type ModelSelection,
   type ThreadId,
   type TurnId,
@@ -61,6 +62,7 @@ export function resolveDiffPanelThread(input: {
     input.draftThread,
     input.fallbackModelSelection ?? {
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: DEFAULT_MODEL_BY_PROVIDER.codex,
     },
     null,

--- a/apps/web/src/components/EventRouter.browser.tsx
+++ b/apps/web/src/components/EventRouter.browser.tsx
@@ -1,6 +1,7 @@
 import "../index.css";
 
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   EventId,
   MessageId,
   DEVICE_WS_METHODS,
@@ -111,6 +112,7 @@ function createSnapshot(overrides?: Partial<OrchestrationReadModel["threads"][nu
         workspaceRoot: "/repo/project",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5",
         },
         scripts: [],
@@ -126,6 +128,7 @@ function createSnapshot(overrides?: Partial<OrchestrationReadModel["threads"][nu
         title: "Root test thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5",
         },
         interactionMode: "default",

--- a/apps/web/src/components/KeybindingsToast.browser.tsx
+++ b/apps/web/src/components/KeybindingsToast.browser.tsx
@@ -1,6 +1,7 @@
 import "../index.css";
 
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   DEVICE_WS_METHODS,
   ORCHESTRATION_WS_METHODS,
   type MessageId,
@@ -63,6 +64,7 @@ function createMinimalSnapshot(): OrchestrationReadModel {
         workspaceRoot: "/repo/project",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5",
         },
         scripts: [],
@@ -78,6 +80,7 @@ function createMinimalSnapshot(): OrchestrationReadModel {
         title: "Test thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5",
         },
         interactionMode: "default",

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -56,7 +56,7 @@ import {
   sortProjectsForSidebar,
   sortThreadsForSidebar,
 } from "./Sidebar.logic";
-import { ProjectId, ThreadId } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, ProjectId, ThreadId } from "@synara/contracts";
 import {
   DEFAULT_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,
@@ -923,6 +923,7 @@ describe("pin helpers", () => {
       title: id,
       modelSelection: {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "gpt-5-codex",
       },
       runtimeMode: DEFAULT_RUNTIME_MODE,
@@ -1847,6 +1848,7 @@ function makeProject(overrides: Partial<Project> = {}): Project {
     cwd: "/tmp/project",
     defaultModelSelection: {
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5.4",
       ...defaultModelSelection,
     },
@@ -1867,6 +1869,7 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     title: "Thread",
     modelSelection: {
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5.4",
       ...overrides?.modelSelection,
     },
@@ -1896,6 +1899,7 @@ function makeSidebarThreadSummary(
     title: "Thread",
     modelSelection: {
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5.4",
     },
     interactionMode: DEFAULT_INTERACTION_MODE,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -77,6 +77,7 @@ import { CSS } from "@dnd-kit/utilities";
 import {
   type AutomationDefinition,
   type AutomationListResult,
+  DEFAULT_PROVIDER_PROFILE_ID,
   MAX_PINNED_PROJECTS,
   type DesktopUpdateState,
   type OrchestrationShellSnapshot,
@@ -2692,6 +2693,7 @@ export default function Sidebar() {
           : providerDefaultModel
             ? {
                 provider,
+                profileId: DEFAULT_PROVIDER_PROFILE_ID,
                 model: providerDefaultModel,
               }
             : null;
@@ -3337,6 +3339,7 @@ export default function Sidebar() {
                     newProjectSpaceId: value.spaceId,
                     defaultModelSelection: {
                       provider: "codex",
+                      profileId: DEFAULT_PROVIDER_PROFILE_ID,
                       model: getDefaultModel("codex"),
                     },
                     createdAt: new Date().toISOString(),

--- a/apps/web/src/components/SidebarActivityView.browser.tsx
+++ b/apps/web/src/components/SidebarActivityView.browser.tsx
@@ -4,7 +4,7 @@
 
 import "../index.css";
 
-import { ProjectId, ThreadId, type OrchestrationThreadPullRequest } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, ProjectId, ThreadId, type OrchestrationThreadPullRequest } from "@synara/contracts";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { page, userEvent } from "vitest/browser";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -41,7 +41,7 @@ function makeThread(
     id: ThreadId.makeUnsafe(`activity-thread-${index}`),
     projectId: PROJECT_A,
     title: `Activity thread ${index}`,
-    modelSelection: { provider: "codex", model: "gpt-5" },
+    modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5" },
     interactionMode: "default",
     branch: null,
     worktreePath: null,

--- a/apps/web/src/components/SidebarActivityView.logic.test.ts
+++ b/apps/web/src/components/SidebarActivityView.logic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { ProjectId, ThreadId } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, ProjectId, ThreadId } from "@synara/contracts";
 
 import type { SidebarThreadSummary, ThreadSession } from "../types";
 import { formatRelativeTime } from "~/lib/relativeTime";
@@ -56,7 +56,7 @@ function makeThread(input: {
     id: ThreadId.makeUnsafe(input.id),
     projectId: input.projectId ?? PROJECT_ID,
     title: `Thread ${input.id}`,
-    modelSelection: { provider: "codex", model: "gpt-5" },
+    modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5" },
     interactionMode: "default",
     branch: null,
     worktreePath: null,

--- a/apps/web/src/components/SidebarThreadRowContent.browser.tsx
+++ b/apps/web/src/components/SidebarThreadRowContent.browser.tsx
@@ -4,7 +4,7 @@
 
 import "../index.css";
 
-import { ProjectId, ThreadId } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, ProjectId, ThreadId } from "@synara/contracts";
 import { afterEach, describe, expect, it } from "vitest";
 import { render } from "vitest-browser-react";
 
@@ -16,7 +16,7 @@ function makeThread(overrides: Partial<SidebarThreadSummary> = {}): SidebarThrea
     id: ThreadId.makeUnsafe("thread-row-content"),
     projectId: ProjectId.makeUnsafe("project-row-content"),
     title: "Shared thread row",
-    modelSelection: { provider: "codex", model: "gpt-5.4" },
+    modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.4" },
     interactionMode: DEFAULT_INTERACTION_MODE,
     branch: null,
     worktreePath: null,

--- a/apps/web/src/components/chat/ComposerSubagentStrip.logic.test.ts
+++ b/apps/web/src/components/chat/ComposerSubagentStrip.logic.test.ts
@@ -4,7 +4,7 @@
 // Layer: Web chat composer tests
 // Depends on: deriveComposerSubagentStripItems
 
-import { EventId, ThreadId, TurnId, type OrchestrationThreadActivity } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, EventId, ThreadId, TurnId, type OrchestrationThreadActivity } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -426,7 +426,7 @@ describe("deriveComposerSubagentStripItems", () => {
         codexThreadId: null,
         projectId: "project-1" as Thread["projectId"],
         title: "Subagent task",
-        modelSelection: { provider: "claudeAgent", model: "sonnet" },
+        modelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "sonnet" },
         runtimeMode: "full-access",
         interactionMode: "default",
         session: {
@@ -559,7 +559,7 @@ describe("deriveComposerSubagentStripItems", () => {
       codexThreadId: null,
       projectId: "project-1" as Thread["projectId"],
       title: "Subagent task",
-      modelSelection: { provider: "claudeAgent", model: "sonnet" },
+      modelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "sonnet" },
       runtimeMode: "full-access",
       interactionMode: "default",
       session: {

--- a/apps/web/src/components/chat/TraitsPicker.browser.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.browser.tsx
@@ -6,6 +6,7 @@ import {
   CodexModelOptions,
   type CursorModelOptions,
   DEFAULT_MODEL_BY_PROVIDER,
+  DEFAULT_PROVIDER_PROFILE_ID,
   type OpenCodeModelOptions,
   type ProviderModelDescriptor,
   ProjectId,
@@ -103,6 +104,7 @@ async function mountClaudePicker(props?: {
         : {
             claudeAgent: {
               provider: "claudeAgent",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model,
               ...(claudeOptions && Object.keys(claudeOptions).length > 0
                 ? { options: claudeOptions }
@@ -125,6 +127,7 @@ async function mountClaudePicker(props?: {
     props?.fallbackModelOptions !== undefined
       ? ({
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model,
           options: props.fallbackModelOptions ?? undefined,
         } satisfies ModelSelection)
@@ -351,6 +354,7 @@ async function mountCodexPicker(props: { model?: string; options?: CodexModelOpt
       modelSelectionByProvider: {
         codex: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model,
           ...(props.options ? { options: props.options } : {}),
         },
@@ -696,6 +700,7 @@ async function mountOpenCodePicker(props?: {
       modelSelectionByProvider: {
         opencode: {
           provider: "opencode",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model,
           ...(props?.options ? { options: props.options } : {}),
         },
@@ -715,6 +720,7 @@ async function mountOpenCodePicker(props?: {
   document.body.append(host);
   const fallbackModelSelection: ModelSelection = {
     provider: "opencode",
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
     model,
     ...(props?.fallbackModelOptions ? { options: props.fallbackModelOptions } : {}),
   };

--- a/apps/web/src/components/chat/environment/EnvironmentAutomationsSection.browser.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentAutomationsSection.browser.tsx
@@ -4,7 +4,7 @@
 
 import "../../../index.css";
 
-import { AutomationId, ProjectId, ThreadId, type AutomationDefinition } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, AutomationId, ProjectId, ThreadId, type AutomationDefinition } from "@synara/contracts";
 import { page } from "vitest/browser";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
@@ -20,7 +20,7 @@ const baseAutomation = (overrides: Partial<AutomationDefinition> = {}): Automati
   schedule: { type: "interval", everySeconds: 180 },
   enabled: true,
   nextRunAt: "2026-06-21T15:00:00.000Z",
-  modelSelection: { provider: "codex", model: "gpt-5-codex" },
+  modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
   runtimeMode: "approval-required",
   interactionMode: "default",
   worktreeMode: "worktree",

--- a/apps/web/src/components/kanban/kanban.logic.test.ts
+++ b/apps/web/src/components/kanban/kanban.logic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { ProjectId, ThreadId } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, ProjectId, ThreadId } from "@synara/contracts";
 import { DEFAULT_INTERACTION_MODE } from "../../types";
 import type { SidebarThreadSummary, ThreadSession } from "../../types";
 import {
@@ -57,6 +57,7 @@ function makeSidebarThreadSummary(
     title: "Thread",
     modelSelection: {
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5.4",
     },
     interactionMode: DEFAULT_INTERACTION_MODE,

--- a/apps/web/src/components/kanban/useKanbanTaskScratchDraft.ts
+++ b/apps/web/src/components/kanban/useKanbanTaskScratchDraft.ts
@@ -3,7 +3,11 @@
 // Layer: Kanban UI hook
 // Exports: useKanbanTaskScratchDraft
 
-import type { ModelSlug, ProviderKind } from "@synara/contracts";
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  type ModelSlug,
+  type ProviderKind,
+} from "@synara/contracts";
 import { getDefaultModel } from "@synara/shared/model";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -21,7 +25,7 @@ import {
   useComposerDraftStore,
   useComposerThreadDraft,
 } from "../../composerDraftStore";
-import { buildModelSelection } from "../../providerModelOptions";
+import { buildModelSelectionForTarget } from "../../providerModelOptions";
 import { toastManager } from "../ui/toast";
 
 export function useKanbanTaskScratchDraft(input: { readonly defaultProvider: ProviderKind }) {
@@ -58,6 +62,8 @@ export function useKanbanTaskScratchDraft(input: { readonly defaultProvider: Pro
   const draftModelSelection =
     scratchDraft.modelSelectionByProvider[selectedProvider] ??
     stickyModelSelectionByProvider[selectedProvider];
+  const selectedProfileId =
+    draftModelSelection?.profileId ?? DEFAULT_PROVIDER_PROFILE_ID;
   const selectedModel: ModelSlug | null =
     draftModelSelection?.model ?? getDefaultModel(selectedProvider);
   const selectedProviderModelOptions = draftModelSelection?.options;
@@ -108,7 +114,17 @@ export function useKanbanTaskScratchDraft(input: { readonly defaultProvider: Pro
     supportsAutoMode?: boolean,
   ) => {
     const store = useComposerDraftStore.getState();
-    const nextSelection = buildModelSelection(provider, model, undefined, supportsAutoMode);
+    const currentSelection =
+      store.draftsByThreadId[scratchThreadId]?.modelSelectionByProvider[provider] ??
+      store.stickyModelSelectionByProvider[provider];
+    const nextSelection = buildModelSelectionForTarget({
+      target: {
+        provider,
+        profileId: currentSelection?.profileId ?? DEFAULT_PROVIDER_PROFILE_ID,
+      },
+      model,
+      supportsAutoMode,
+    });
     // Mirrors the composer: update the scratch draft and persist the sticky selection.
     store.setModelSelectionAndSticky(scratchThreadId, nextSelection);
   };
@@ -176,6 +192,7 @@ export function useKanbanTaskScratchDraft(input: { readonly defaultProvider: Pro
     pendingImageCount,
     waitForPendingImages,
     selectedProvider,
+    selectedProfileId,
     selectedModel,
     selectedModelSupportsAutoMode,
     selectedProviderModelOptions,

--- a/apps/web/src/composerDraftActions.ts
+++ b/apps/web/src/composerDraftActions.ts
@@ -77,7 +77,6 @@ import {
   composerImageConsumesAttachmentSlot,
   effectiveComposerAttachmentCount,
 } from "./lib/composerAttachmentCapacity";
-import { buildModelSelection } from "./providerModelOptions";
 import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE } from "./types";
 
 function removeDraftThreadIfUnmapped(input: {
@@ -528,7 +527,10 @@ export const createComposerDraftStoreState =
           if (selection) {
             const current = nextMap[provider as ProviderKind];
             nextMap[provider as ProviderKind] =
-              current && current.model !== selection.model ? current : selection;
+              current &&
+              (current.model !== selection.model || current.profileId !== selection.profileId)
+                ? current
+                : selection;
           }
         }
         if (
@@ -843,14 +845,16 @@ export const createComposerDraftStoreState =
               model,
               opts,
               current?.provider === "claudeAgent" ? current.supportsAutoMode : undefined,
+              current?.profileId,
             );
           } else if (current?.options) {
             // Remove options but keep the selection
-            nextMap[provider] = buildModelSelection(
+            nextMap[provider] = makeModelSelection(
               provider,
               current.model,
               undefined,
               current.provider === "claudeAgent" ? current.supportsAutoMode : undefined,
+              current.profileId,
             );
           }
         }
@@ -907,15 +911,17 @@ export const createComposerDraftStoreState =
             currentForProvider?.provider === "claudeAgent"
               ? currentForProvider.supportsAutoMode
               : undefined,
+            currentForProvider?.profileId,
           );
         } else if (currentForProvider?.options) {
-          nextMap[normalizedProvider] = buildModelSelection(
+          nextMap[normalizedProvider] = makeModelSelection(
             normalizedProvider,
             currentForProvider.model,
             undefined,
             currentForProvider.provider === "claudeAgent"
               ? currentForProvider.supportsAutoMode
               : undefined,
+            currentForProvider.profileId,
           );
         }
 
@@ -938,14 +944,16 @@ export const createComposerDraftStoreState =
                 stickyBase.model,
                 providerOpts,
                 stickyBase.provider === "claudeAgent" ? stickyBase.supportsAutoMode : undefined,
+                stickyBase.profileId,
               ),
             );
           } else if (stickyBase.options) {
-            nextStickyMap[normalizedProvider] = buildModelSelection(
+            nextStickyMap[normalizedProvider] = makeModelSelection(
               normalizedProvider,
               stickyBase.model,
               undefined,
               stickyBase.provider === "claudeAgent" ? stickyBase.supportsAutoMode : undefined,
+              stickyBase.profileId,
             );
           }
           nextStickyActiveProvider = base.activeProvider ?? normalizedProvider;

--- a/apps/web/src/composerDraftModels.test.ts
+++ b/apps/web/src/composerDraftModels.test.ts
@@ -1,0 +1,60 @@
+import { DEFAULT_PROVIDER_PROFILE_ID, ProviderProfileId } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeModelSelection,
+  reconcileProviderScopedModelSelection,
+} from "./composerDraftModels";
+
+describe("normalizeModelSelection", () => {
+  it("defaults legacy selections to the default provider profile", () => {
+    expect(normalizeModelSelection({ provider: "codex", model: "gpt-5.6-codex" })).toEqual({
+      provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
+      model: "gpt-5.6-codex",
+    });
+  });
+
+  it("preserves an explicit provider profile", () => {
+    expect(
+      normalizeModelSelection({
+        provider: "codex",
+        profileId: "work",
+        model: "gpt-5.6-codex",
+      }),
+    ).toEqual({
+      provider: "codex",
+      profileId: "work",
+      model: "gpt-5.6-codex",
+    });
+  });
+
+  it("rejects an explicit invalid provider profile instead of falling back", () => {
+    expect(
+      normalizeModelSelection({
+        provider: "codex",
+        profileId: "../work",
+        model: "gpt-5.6-codex",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("reconcileProviderScopedModelSelection", () => {
+  it("does not carry model options across provider profiles", () => {
+    const requested = {
+      provider: "codex" as const,
+      profileId: ProviderProfileId.makeUnsafe("work"),
+      model: "gpt-5.6-codex",
+    };
+
+    expect(
+      reconcileProviderScopedModelSelection(requested, {
+        provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
+        model: "gpt-5.6-codex",
+        options: { reasoningEffort: "high" },
+      }),
+    ).toEqual(requested);
+  });
+});

--- a/apps/web/src/composerDraftModels.ts
+++ b/apps/web/src/composerDraftModels.ts
@@ -3,8 +3,10 @@
 // Exports: Model state helpers used by persistence, actions, and the public facade.
 
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   GROK_REASONING_EFFORT_OPTIONS,
   ProviderKind,
+  ProviderProfileId,
   type ClaudeCodeEffort,
   type CodexReasoningEffort,
   type CursorModelOptions,
@@ -14,6 +16,7 @@ import {
   type ModelSlug,
   type PiThinkingLevel,
   type ProviderModelOptions,
+  type ProviderTarget,
 } from "@synara/contracts";
 import * as Schema from "effect/Schema";
 
@@ -23,6 +26,10 @@ import {
   resolveModelSlugForProvider,
   resolveSelectableModel,
 } from "@synara/shared/model";
+import {
+  providerTargetFromModelSelection,
+  providerTargetsEqual,
+} from "@synara/shared/providerTarget";
 import { resolveAppModelSelection } from "./appSettings";
 import type { ComposerThreadDraftState } from "./composerDraftDomain";
 import { classifyProviderReasoningEffortSupport } from "./lib/codexReasoningEffort";
@@ -40,6 +47,7 @@ export const COMPOSER_PROVIDER_KINDS = [
 ] as const satisfies readonly ProviderKind[];
 
 const isProviderKind = Schema.is(ProviderKind);
+const isProviderProfileId = Schema.is(ProviderProfileId);
 
 const GROK_REASONING_EFFORT_SET = new Set<string>(GROK_REASONING_EFFORT_OPTIONS);
 
@@ -80,6 +88,7 @@ function deriveEffectiveComposerModelOptions(input: {
     | undefined;
   threadModelSelection: ModelSelection | null | undefined;
   projectModelSelection: ModelSelection | null | undefined;
+  selectedTarget?: ProviderTarget;
 }): ProviderModelOptions | null {
   const baseOptions = mergeProviderModelOptionsFromSelections(
     input.projectModelSelection,
@@ -97,6 +106,12 @@ function deriveEffectiveComposerModelOptions(input: {
     [ProviderKind, ModelSelection | undefined]
   >) {
     if (!selection) continue;
+    if (
+      input.selectedTarget?.provider === provider &&
+      !providerTargetsEqual(providerTargetFromModelSelection(selection), input.selectedTarget)
+    ) {
+      continue;
+    }
     if (selection.options) {
       result[provider] = selection.options;
     } else {
@@ -111,6 +126,15 @@ export function normalizeProviderKind(value: unknown): ProviderKind | null {
     return "antigravity";
   }
   return isProviderKind(value) ? value : null;
+}
+
+function normalizeModelSelectionProfileId(
+  candidate: Record<string, unknown> | null,
+): ProviderProfileId | null {
+  if (!candidate || !Object.hasOwn(candidate, "profileId")) {
+    return DEFAULT_PROVIDER_PROFILE_ID;
+  }
+  return isProviderProfileId(candidate.profileId) ? candidate.profileId : null;
 }
 
 function trimStringOrUndefined(value: unknown): string | undefined {
@@ -130,11 +154,31 @@ export function makeModelSelection(
   model: string,
   options?: ProviderModelOptions[ProviderKind],
   supportsAutoMode?: boolean,
+  profileId: ProviderProfileId = DEFAULT_PROVIDER_PROFILE_ID,
 ): ModelSelection {
+  return makeProfiledModelSelection({
+    target: { provider, profileId },
+    model,
+    options,
+    supportsAutoMode,
+  });
+}
+
+interface ProfiledModelSelectionInput {
+  readonly target: ProviderTarget;
+  readonly model: string;
+  readonly options?: ProviderModelOptions[ProviderKind] | undefined;
+  readonly supportsAutoMode?: boolean | undefined;
+}
+
+function makeProfiledModelSelection(input: ProfiledModelSelectionInput): ModelSelection {
+  const { provider, profileId } = input.target;
+  const { model, options, supportsAutoMode } = input;
   switch (provider) {
     case "antigravity":
       return {
         provider,
+        profileId,
         model,
         ...(options
           ? {
@@ -145,6 +189,7 @@ export function makeModelSelection(
     case "codex":
       return {
         provider,
+        profileId,
         model,
         ...(options
           ? { options: options as Extract<ModelSelection, { provider: "codex" }>["options"] }
@@ -153,6 +198,7 @@ export function makeModelSelection(
     case "claudeAgent":
       return {
         provider,
+        profileId,
         model,
         ...(options
           ? {
@@ -164,6 +210,7 @@ export function makeModelSelection(
     case "cursor":
       return {
         provider,
+        profileId,
         model,
         ...(options
           ? { options: options as Extract<ModelSelection, { provider: "cursor" }>["options"] }
@@ -172,6 +219,7 @@ export function makeModelSelection(
     case "grok":
       return {
         provider,
+        profileId,
         model,
         ...(options
           ? { options: options as Extract<ModelSelection, { provider: "grok" }>["options"] }
@@ -180,6 +228,7 @@ export function makeModelSelection(
     case "droid":
       return {
         provider,
+        profileId,
         model,
         ...(options
           ? { options: options as Extract<ModelSelection, { provider: "droid" }>["options"] }
@@ -188,6 +237,7 @@ export function makeModelSelection(
     case "kilo":
       return {
         provider,
+        profileId,
         model,
         ...(options
           ? { options: options as Extract<ModelSelection, { provider: "kilo" }>["options"] }
@@ -196,6 +246,7 @@ export function makeModelSelection(
     case "opencode":
       return {
         provider,
+        profileId,
         model,
         ...(options
           ? { options: options as Extract<ModelSelection, { provider: "opencode" }>["options"] }
@@ -204,6 +255,7 @@ export function makeModelSelection(
     case "pi":
       return {
         provider,
+        profileId,
         model,
         ...(options
           ? { options: options as Extract<ModelSelection, { provider: "pi" }>["options"] }
@@ -432,6 +484,10 @@ export function normalizeModelSelection(
   if (provider === null) {
     return null;
   }
+  const profileId = normalizeModelSelectionProfileId(candidate);
+  if (profileId === null) {
+    return null;
+  }
   const rawModel = candidate?.model ?? legacy?.model;
   if (typeof rawModel !== "string") {
     return null;
@@ -493,34 +549,43 @@ export function normalizeModelSelection(
           reasoningEffort: modelOptions?.antigravity?.reasoningEffort ?? antigravityLegacyEffort,
         }
       : options;
-  return makeModelSelection(
-    provider,
+  return makeProfiledModelSelection({
+    target: { provider, profileId },
     model,
-    normalizedOptions,
-    provider === "claudeAgent" && typeof candidate?.supportsAutoMode === "boolean"
-      ? candidate.supportsAutoMode
-      : undefined,
-  );
+    options: normalizedOptions,
+    supportsAutoMode:
+      provider === "claudeAgent" && typeof candidate?.supportsAutoMode === "boolean"
+        ? candidate.supportsAutoMode
+        : undefined,
+  });
 }
 
 export function reconcileProviderScopedModelSelection(
   requested: ModelSelection,
   current: ModelSelection | null | undefined,
 ): ModelSelection {
-  if (requested.options !== undefined || current?.provider !== requested.provider) {
+  if (
+    !current ||
+    requested.options !== undefined ||
+    !providerTargetsEqual(
+      providerTargetFromModelSelection(requested),
+      providerTargetFromModelSelection(current),
+    )
+  ) {
     return requested;
   }
   if (current.model === requested.model) {
     const currentSupportsAutoMode =
       current.provider === "claudeAgent" ? current.supportsAutoMode : undefined;
-    return makeModelSelection(
-      requested.provider,
-      requested.model,
-      current.options,
-      requested.provider === "claudeAgent"
-        ? (requested.supportsAutoMode ?? currentSupportsAutoMode)
-        : undefined,
-    );
+    return makeProfiledModelSelection({
+      target: providerTargetFromModelSelection(requested),
+      model: requested.model,
+      options: current.options,
+      supportsAutoMode:
+        requested.provider === "claudeAgent"
+          ? (requested.supportsAutoMode ?? currentSupportsAutoMode)
+          : undefined,
+    });
   }
   if (
     current.provider !== "codex" &&
@@ -552,12 +617,13 @@ export function reconcileProviderScopedModelSelection(
       preservedOptions = Object.keys(remainingOptions).length > 0 ? remainingOptions : undefined;
     }
   }
-  return makeModelSelection(
-    requested.provider,
-    requested.model,
-    preservedOptions,
-    requested.provider === "claudeAgent" ? requested.supportsAutoMode : undefined,
-  );
+  return makeProfiledModelSelection({
+    target: providerTargetFromModelSelection(requested),
+    model: requested.model,
+    options: preservedOptions,
+    supportsAutoMode:
+      requested.provider === "claudeAgent" ? requested.supportsAutoMode : undefined,
+  });
 }
 
 export function stripNonStickyModelOptions(selection: ModelSelection): ModelSelection {
@@ -572,12 +638,12 @@ export function stripNonStickyModelOptions(selection: ModelSelection): ModelSele
     autoCompactWindow: _autoCompactWindow,
     ...rest
   } = selection.options;
-  return makeModelSelection(
-    selection.provider,
-    selection.model,
-    Object.keys(rest).length > 0 ? rest : undefined,
-    selection.supportsAutoMode,
-  );
+  return makeProfiledModelSelection({
+    target: providerTargetFromModelSelection(selection),
+    model: selection.model,
+    options: Object.keys(rest).length > 0 ? rest : undefined,
+    supportsAutoMode: selection.supportsAutoMode,
+  });
 }
 
 export function sanitizeStickyModelSelectionMap(
@@ -601,12 +667,13 @@ export function legacySyncModelSelectionOptions(
     return null;
   }
   const options = modelOptions?.[modelSelection.provider];
-  return makeModelSelection(
-    modelSelection.provider,
-    modelSelection.model,
+  return makeProfiledModelSelection({
+    target: providerTargetFromModelSelection(modelSelection),
+    model: modelSelection.model,
     options,
-    modelSelection.provider === "claudeAgent" ? modelSelection.supportsAutoMode : undefined,
-  );
+    supportsAutoMode:
+      modelSelection.provider === "claudeAgent" ? modelSelection.supportsAutoMode : undefined,
+  });
 }
 
 export function legacyMergeModelSelectionIntoProviderModelOptions(
@@ -674,6 +741,7 @@ export function deriveEffectiveComposerModelState(input: {
   selectedProvider: ProviderKind;
   threadModelSelection: ModelSelection | null | undefined;
   projectModelSelection: ModelSelection | null | undefined;
+  selectedTarget?: ProviderTarget;
   customModelsByProvider: Record<ProviderKind, readonly string[]>;
   availableModelOptionsByProvider?: Partial<
     Record<ProviderKind, ReadonlyArray<{ slug: string; name: string }>>
@@ -706,7 +774,13 @@ export function deriveEffectiveComposerModelState(input: {
       ? (normalizeModelSlug(input.projectModelSelection.model, input.selectedProvider) ??
         input.projectModelSelection.model)
       : null;
-  const activeSelection = input.draft?.modelSelectionByProvider?.[input.selectedProvider];
+  const draftSelection = input.draft?.modelSelectionByProvider?.[input.selectedProvider];
+  const activeSelection =
+    draftSelection &&
+    (!input.selectedTarget ||
+      providerTargetsEqual(providerTargetFromModelSelection(draftSelection), input.selectedTarget))
+      ? draftSelection
+      : undefined;
   const selectedDraftModel = activeSelection?.model
     ? resolveAppModelSelection(
         input.selectedProvider,
@@ -773,6 +847,7 @@ export function resolvePreferredComposerModelSelection(input: {
       ? input.projectModelSelection
       : null) ?? {
       provider: preferredProvider === "pi" ? "codex" : preferredProvider,
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: getDefaultModel(preferredProvider === "pi" ? "codex" : preferredProvider),
     }
   );

--- a/apps/web/src/composerDraftPersistence.ts
+++ b/apps/web/src/composerDraftPersistence.ts
@@ -678,6 +678,24 @@ function normalizePersistedQueuedTurns(
   return normalizedTurns.length > 0 ? normalizedTurns : undefined;
 }
 
+function normalizeModelSelectionByProviderMap(
+  value: unknown,
+): Partial<Record<ProviderKind, ModelSelection>> {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+
+  const normalized: Partial<Record<ProviderKind, ModelSelection>> = {};
+  for (const [rawProvider, rawSelection] of Object.entries(value)) {
+    const provider = normalizeProviderKind(rawProvider);
+    const selection = normalizeModelSelection(rawSelection);
+    if (provider !== null && selection?.provider === provider) {
+      normalized[provider] = selection;
+    }
+  }
+  return normalized;
+}
+
 function normalizeDraftThreadEnvMode(
   value: unknown,
   fallbackWorktreePath: string | null,
@@ -890,9 +908,9 @@ function normalizePersistedDraftsByThreadId(
       typeof draftCandidate.modelSelectionByProvider === "object"
     ) {
       // v3 format
-      modelSelectionByProvider = draftCandidate.modelSelectionByProvider as Partial<
-        Record<ProviderKind, ModelSelection>
-      >;
+      modelSelectionByProvider = normalizeModelSelectionByProviderMap(
+        draftCandidate.modelSelectionByProvider,
+      );
       activeProvider = normalizeProviderKind(draftCandidate.activeProvider);
     } else {
       // v2 or legacy format: migrate
@@ -1276,10 +1294,9 @@ export function normalizeCurrentPersistedComposerDraftStoreState(
     normalizedPersistedState.stickyModelSelectionByProvider &&
     typeof normalizedPersistedState.stickyModelSelectionByProvider === "object"
   ) {
-    stickyModelSelectionByProvider =
-      normalizedPersistedState.stickyModelSelectionByProvider as Partial<
-        Record<ProviderKind, ModelSelection>
-      >;
+    stickyModelSelectionByProvider = normalizeModelSelectionByProviderMap(
+      normalizedPersistedState.stickyModelSelectionByProvider,
+    );
     stickyActiveProvider = normalizeProviderKind(normalizedPersistedState.stickyActiveProvider);
   } else {
     // Legacy migration path

--- a/apps/web/src/composerDraftStore.models.test.ts
+++ b/apps/web/src/composerDraftStore.models.test.ts
@@ -1,4 +1,9 @@
-import { ThreadId, type ModelSelection } from "@synara/contracts";
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  ProviderProfileId,
+  ThreadId,
+  type ModelSelection,
+} from "@synara/contracts";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   deriveEffectiveComposerModelState,
@@ -649,6 +654,7 @@ describe("composerDraftStore sticky composer settings", () => {
     const threadId = ThreadId.makeUnsafe("thread-claude-auto-capability");
     const selection: ModelSelection = {
       provider: "claudeAgent",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "claude-haiku-4-5",
       supportsAutoMode: false,
     };
@@ -711,12 +717,14 @@ describe("composerDraftStore sticky composer settings", () => {
     const threadId = ThreadId.makeUnsafe("thread-claude-auto-model-switch");
     store.setModelSelection(threadId, {
       provider: "claudeAgent",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "claude-haiku-4-5",
       supportsAutoMode: false,
     });
 
     store.setModelSelection(threadId, {
       provider: "claudeAgent",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "claude-sonnet-5",
     });
 
@@ -725,6 +733,7 @@ describe("composerDraftStore sticky composer settings", () => {
         .claudeAgent,
     ).toEqual({
       provider: "claudeAgent",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "claude-sonnet-5",
     });
   });
@@ -797,6 +806,27 @@ describe("composerDraftStore sticky composer settings", () => {
     });
     store.setStickyModelSelection(
       modelSelection("codex", "gpt-5.6-sol", { reasoningEffort: "ultra" }),
+    );
+    store.setModelSelection(threadId, currentSelection);
+
+    store.applyStickyState(threadId);
+
+    expect(
+      useComposerDraftStore.getState().draftsByThreadId[threadId]?.modelSelectionByProvider.codex,
+    ).toEqual(currentSelection);
+  });
+
+  it("does not overwrite an existing profile with sticky state from another profile", () => {
+    const store = useComposerDraftStore.getState();
+    const threadId = ThreadId.makeUnsafe("thread-sticky-profile-scope");
+    const currentSelection: ModelSelection = {
+      provider: "codex",
+      profileId: ProviderProfileId.makeUnsafe("work"),
+      model: "gpt-5.4",
+      options: { reasoningEffort: "xhigh" },
+    };
+    store.setStickyModelSelection(
+      modelSelection("codex", "gpt-5.4", { reasoningEffort: "medium" }),
     );
     store.setModelSelection(threadId, currentSelection);
 

--- a/apps/web/src/composerDraftStore.persistence.test.ts
+++ b/apps/web/src/composerDraftStore.persistence.test.ts
@@ -1,4 +1,9 @@
-import { OrchestrationProposedPlanId, ProjectId, ThreadId } from "@synara/contracts";
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  OrchestrationProposedPlanId,
+  ProjectId,
+  ThreadId,
+} from "@synara/contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { partializeComposerDraftStoreState, useComposerDraftStore } from "./composerDraftStore";
 import { normalizeCurrentPersistedComposerDraftStoreState } from "./composerDraftPersistence";
@@ -117,6 +122,52 @@ describe("composerDraftStore persisted-state hydration", () => {
 
     expect(hydrated.draftsByThreadId[threadId]?.runtimeMode).toBe("auto");
     expect(hydrated.draftThreadsByThreadId[threadId]?.runtimeMode).toBe("auto");
+  });
+
+  it("normalizes current-format provider selections without losing explicit profiles", () => {
+    const threadId = ThreadId.makeUnsafe("thread-provider-profile-hydration");
+
+    const hydrated = normalizeCurrentPersistedComposerDraftStoreState({
+      draftsByThreadId: {
+        [threadId]: {
+          prompt: "Continue this draft",
+          attachments: [],
+          modelSelectionByProvider: {
+            codex: { provider: "codex", model: "gpt-5.6-sol" },
+            claudeAgent: {
+              provider: "claudeAgent",
+              profileId: "work",
+              model: "opus-4.8",
+            },
+            cursor: { provider: "codex", model: "mismatched-key" },
+          },
+          activeProvider: "codex",
+        },
+      },
+      draftThreadsByThreadId: {},
+      projectDraftThreadIdByProjectId: {},
+      stickyModelSelectionByProvider: {
+        codex: { provider: "codex", model: "gpt-5.6-sol" },
+        claudeAgent: {
+          provider: "claudeAgent",
+          profileId: "work",
+          model: "opus-4.8",
+        },
+      },
+      stickyActiveProvider: "codex",
+    });
+
+    expect(hydrated.draftsByThreadId[threadId]?.modelSelectionByProvider.codex?.profileId).toBe(
+      DEFAULT_PROVIDER_PROFILE_ID,
+    );
+    expect(
+      hydrated.draftsByThreadId[threadId]?.modelSelectionByProvider.claudeAgent?.profileId,
+    ).toBe("work");
+    expect(hydrated.draftsByThreadId[threadId]?.modelSelectionByProvider.cursor).toBeUndefined();
+    expect(hydrated.stickyModelSelectionByProvider.codex?.profileId).toBe(
+      DEFAULT_PROVIDER_PROFILE_ID,
+    );
+    expect(hydrated.stickyModelSelectionByProvider.claudeAgent?.profileId).toBe("work");
   });
 });
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -2,7 +2,12 @@
 // Purpose: Public Zustand facade for composer drafts, model choices, attachments, and persistence.
 // Exports: Stable composer draft API, hooks, and promotion helpers.
 
-import { type ModelSelection, type ProviderKind, type ThreadId } from "@synara/contracts";
+import {
+  type ModelSelection,
+  type ProviderKind,
+  type ProviderTarget,
+  type ThreadId,
+} from "@synara/contracts";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
@@ -122,6 +127,7 @@ export function useEffectiveComposerModelState(input: {
   selectedProvider: ProviderKind;
   threadModelSelection: ModelSelection | null | undefined;
   projectModelSelection: ModelSelection | null | undefined;
+  selectedTarget?: ProviderTarget;
   customModelsByProvider: Record<ProviderKind, readonly string[]>;
   availableModelOptionsByProvider?: Partial<
     Record<ProviderKind, ReadonlyArray<{ slug: string; name: string }>>
@@ -133,6 +139,7 @@ export function useEffectiveComposerModelState(input: {
     selectedProvider: input.selectedProvider,
     threadModelSelection: input.threadModelSelection,
     projectModelSelection: input.projectModelSelection,
+    ...(input.selectedTarget !== undefined ? { selectedTarget: input.selectedTarget } : {}),
     customModelsByProvider: input.customModelsByProvider,
     ...(input.availableModelOptionsByProvider !== undefined
       ? { availableModelOptionsByProvider: input.availableModelOptionsByProvider }

--- a/apps/web/src/composerDraftStoreTestFixtures.ts
+++ b/apps/web/src/composerDraftStoreTestFixtures.ts
@@ -1,4 +1,9 @@
-import { ThreadId, type ModelSelection, type ProviderModelOptions } from "@synara/contracts";
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  ThreadId,
+  type ModelSelection,
+  type ProviderModelOptions,
+} from "@synara/contracts";
 import {
   useComposerDraftStore,
   type ComposerFileAttachment,
@@ -116,6 +121,7 @@ export function makeQueuedTurn(id: string): QueuedComposerTurn {
     selectedPromptEffort: null,
     modelSelection: {
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5",
     },
     runtimeMode: "full-access",
@@ -146,6 +152,7 @@ export function makeQueuedChatTurn(
     selectedPromptEffort: null,
     modelSelection: {
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5",
     },
     sourceProposedPlan: {
@@ -175,6 +182,7 @@ export function modelSelection(
 ): ModelSelection {
   return {
     provider,
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
     model,
     ...(options ? { options } : {}),
   } as ModelSelection;

--- a/apps/web/src/focusedChatContext.test.ts
+++ b/apps/web/src/focusedChatContext.test.ts
@@ -1,4 +1,4 @@
-import { ProjectId, ThreadId, TurnId } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, ProjectId, ThreadId, TurnId } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
 import { type DraftThreadState } from "./composerDraftStore";
@@ -19,7 +19,7 @@ function makeProject(): Project {
     folderName: "project",
     localName: null,
     cwd: "/tmp/project",
-    defaultModelSelection: { provider: "codex", model: "gpt-5.4-mini" },
+    defaultModelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.4-mini" },
     expanded: true,
     spaceId: null,
     scripts: [],
@@ -32,7 +32,7 @@ function makeThread(threadId: ThreadId, overrides: Partial<Thread> = {}): Thread
     codexThreadId: null,
     projectId: PROJECT_ID,
     title: `Thread ${threadId}`,
-    modelSelection: { provider: "codex", model: "gpt-5.4-mini" },
+    modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.4-mini" },
     runtimeMode: "full-access",
     interactionMode: "default",
     session: null,

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -1,4 +1,4 @@
-import { type ProjectId, ThreadId } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, type ProjectId, ThreadId } from "@synara/contracts";
 import { getDefaultModel } from "@synara/shared/model";
 import { useNavigate, useRouter } from "@tanstack/react-router";
 import { startTransition } from "react";
@@ -69,6 +69,7 @@ export function useHandleNewThread() {
       }
       setModelSelection(threadId, {
         provider: options.provider,
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: defaultModel,
       });
     };

--- a/apps/web/src/hooks/useSidebarThreadActions.test.ts
+++ b/apps/web/src/hooks/useSidebarThreadActions.test.ts
@@ -2,7 +2,7 @@
 // Purpose: Characterizes Sidebar pin races, archive serialization/undo, and batch deletion.
 // Layer: Web hook tests
 
-import { ProjectId, ThreadId } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, ProjectId, ThreadId } from "@synara/contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const reactHarness = vi.hoisted(() => {
@@ -207,7 +207,7 @@ function makeThread(id: ThreadId, overrides: Partial<SidebarThreadSummary> = {})
     id,
     projectId: PROJECT_ID,
     title: String(id),
-    modelSelection: { provider: "codex", model: "gpt-5.6" },
+    modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.6" },
     interactionMode: "default",
     branch: null,
     worktreePath: null,

--- a/apps/web/src/lib/automationForm.ts
+++ b/apps/web/src/lib/automationForm.ts
@@ -6,6 +6,7 @@
 import {
   DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS,
   DEFAULT_AUTOMATION_MINIMUM_INTERVAL_SECONDS,
+  DEFAULT_PROVIDER_PROFILE_ID,
 } from "@synara/contracts";
 import type {
   AutomationCreateInput,
@@ -39,6 +40,7 @@ import {
 
 export const defaultModelSelection: ModelSelection = {
   provider: "codex",
+  profileId: DEFAULT_PROVIDER_PROFILE_ID,
   model: "gpt-5-codex",
 };
 
@@ -533,16 +535,21 @@ function modelSelectionsMatch(left: ModelSelection, right: ModelSelection): bool
   const rightOptions = "options" in right ? right.options : undefined;
   return (
     left.provider === right.provider &&
+    left.profileId === right.profileId &&
     left.model === right.model &&
     JSON.stringify(leftOptions ?? null) === JSON.stringify(rightOptions ?? null)
   );
 }
 
 function modelIdentityMatches(left: ModelSelection, right: ModelSelection): boolean {
-  return left.provider === right.provider && left.model === right.model;
+  return (
+    left.provider === right.provider &&
+    left.profileId === right.profileId &&
+    left.model === right.model
+  );
 }
 
-// Automation edits keep saved provider start options unless the provider/model identity changes.
+// Automation edits keep saved provider start options unless the complete target or model changes.
 export function providerOptionsForAutomationModelSelection(
   definition: Pick<AutomationDefinition, "modelSelection" | "providerOptions">,
   nextModelSelection: ModelSelection,

--- a/apps/web/src/lib/chatFirstSend.ts
+++ b/apps/web/src/lib/chatFirstSend.ts
@@ -1,4 +1,8 @@
-import { DEFAULT_MODEL_BY_PROVIDER, type ModelSelection } from "@synara/contracts";
+import {
+  DEFAULT_MODEL_BY_PROVIDER,
+  DEFAULT_PROVIDER_PROFILE_ID,
+  type ModelSelection,
+} from "@synara/contracts";
 import { workspaceRootsEqual } from "@synara/shared/threadWorkspace";
 
 import type { Project } from "../types";
@@ -104,6 +108,7 @@ export function resolveFirstSendTarget(input: {
         createWorkspaceRootIfMissing: true,
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: DEFAULT_MODEL_BY_PROVIDER.codex,
         },
       },
@@ -130,6 +135,7 @@ export function resolveFirstSendTarget(input: {
       createWorkspaceRootIfMissing: false,
       defaultModelSelection: {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: DEFAULT_MODEL_BY_PROVIDER.codex,
       },
     },

--- a/apps/web/src/lib/composerAutomation.test.ts
+++ b/apps/web/src/lib/composerAutomation.test.ts
@@ -3,7 +3,12 @@
 // Layer: Web lib test
 // Depends on: composerAutomation resolver and automation form helpers.
 
-import type { ModelSelection, ProjectId, ThreadId } from "@synara/contracts";
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  type ModelSelection,
+  type ProjectId,
+  type ThreadId,
+} from "@synara/contracts";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -16,6 +21,7 @@ const PROJECT_ID = "project-composer-automation" as ProjectId;
 const THREAD_ID = "thread-composer-automation" as ThreadId;
 const MODEL_SELECTION: ModelSelection = {
   provider: "codex",
+  profileId: DEFAULT_PROVIDER_PROFILE_ID,
   model: "gpt-5",
 };
 const NOW_ISO = "2026-06-22T08:00:00.000Z";

--- a/apps/web/src/lib/desktopProjectRecovery.test.ts
+++ b/apps/web/src/lib/desktopProjectRecovery.test.ts
@@ -2,6 +2,7 @@
 // Purpose: Verifies desktop startup detects snapshots where threads outlive visible project rows.
 
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   ProjectId,
   ThreadId,
   type OrchestrationReadModel,
@@ -21,6 +22,7 @@ function makeProject(
     workspaceRoot: "/tmp/project",
     defaultModelSelection: {
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5.3-codex",
     },
     scripts: [],
@@ -40,6 +42,7 @@ function makeThread(
     title: "Thread",
     modelSelection: {
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5.3-codex",
     },
     runtimeMode: "approval-required",

--- a/apps/web/src/lib/projectCreation.test.ts
+++ b/apps/web/src/lib/projectCreation.test.ts
@@ -4,6 +4,7 @@
 // Depends on: projectCreation helper plus mocked NativeApi orchestration calls.
 
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   type NativeApi,
   type OrchestrationShellSnapshot,
   type ProjectId,
@@ -25,6 +26,7 @@ function makeProject(id: string, workspaceRoot = WORKSPACE_ROOT) {
     workspaceRoot,
     defaultModelSelection: {
       provider: "codex" as const,
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5",
     },
     scripts: [],

--- a/apps/web/src/lib/projectCreation.ts
+++ b/apps/web/src/lib/projectCreation.ts
@@ -4,6 +4,7 @@
 // Exports: createOrRecoverProjectFromPath
 
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   type NativeApi,
   type OrchestrationShellSnapshot,
   type ProjectId,
@@ -70,6 +71,7 @@ export async function createOrRecoverProjectFromPath(input: {
       createWorkspaceRootIfMissing: input.createIfMissing === true,
       defaultModelSelection: {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: getDefaultModel("codex"),
       },
       // A project created while a space is active belongs to that space — filing it

--- a/apps/web/src/lib/sidechatCreation.test.ts
+++ b/apps/web/src/lib/sidechatCreation.test.ts
@@ -1,5 +1,5 @@
 import type { NativeApi, OrchestrationShellSnapshot } from "@synara/contracts";
-import { ProjectId, ThreadId } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, ProjectId, ThreadId } from "@synara/contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Project, Thread } from "../types";
@@ -40,7 +40,11 @@ const project = {
   cwd: "/repo",
 } as Project;
 
-const selectedModelSelection = { provider: "codex", model: "gpt-5.6" } as const;
+const selectedModelSelection = {
+  provider: "codex",
+  profileId: DEFAULT_PROVIDER_PROFILE_ID,
+  model: "gpt-5.6",
+} as const;
 
 function makeApi(input?: {
   dispatchCommand?: ReturnType<typeof vi.fn>;

--- a/apps/web/src/lib/spaceNavigation.test.ts
+++ b/apps/web/src/lib/spaceNavigation.test.ts
@@ -1,4 +1,4 @@
-import { ProjectId, SpaceId, ThreadId } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, ProjectId, SpaceId, ThreadId } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
 import { resolveChatIndexRestoreRoute } from "../routes/-chatIndexRoute.logic";
@@ -41,7 +41,7 @@ function thread(input: { id: string; projectId: string }): SidebarThreadSummary 
     id: ThreadId.makeUnsafe(input.id),
     projectId: ProjectId.makeUnsafe(input.projectId),
     title: input.id,
-    modelSelection: { provider: "codex", model: "gpt-5" },
+    modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5" },
     interactionMode: "default",
     branch: null,
     worktreePath: null,

--- a/apps/web/src/lib/threadBootstrap.test.ts
+++ b/apps/web/src/lib/threadBootstrap.test.ts
@@ -1,4 +1,9 @@
-import { ProjectId, type ModelSelection, ThreadId } from "@synara/contracts";
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  ProjectId,
+  type ModelSelection,
+  ThreadId,
+} from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 import { type ComposerThreadDraftState, type DraftThreadState } from "../composerDraftStore";
 import {
@@ -23,6 +28,7 @@ function modelSelection(
 ): ModelSelection {
   return {
     provider,
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
     model,
     ...(options ? { options } : {}),
   } as ModelSelection;

--- a/apps/web/src/lib/threadCreatePromotion.test.ts
+++ b/apps/web/src/lib/threadCreatePromotion.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   CommandId,
   ProjectId,
   ThreadId,
@@ -41,6 +42,7 @@ function makeThreadCreateCommand(threadId = "thread-promote") {
     title: "Promoted thread",
     modelSelection: {
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5",
     },
     runtimeMode: "full-access",
@@ -114,6 +116,7 @@ describe("threadCreatePromotion", () => {
           title: "Promoted thread",
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5",
           },
           runtimeMode: "full-access",

--- a/apps/web/src/lib/threadHandoff.test.ts
+++ b/apps/web/src/lib/threadHandoff.test.ts
@@ -1,7 +1,9 @@
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   DEFAULT_SERVER_SETTINGS_VIEW,
   EventId,
   MessageId,
+  ProviderProfileId,
   type ModelSelection,
   type OrchestrationThreadActivity,
   type ProviderKind,
@@ -155,6 +157,7 @@ describe("threadHandoff", () => {
   it("prefers sticky model selection for the chosen handoff target", () => {
     const stickySelection = {
       provider: "antigravity",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "Gemini 3.5 Flash",
     } satisfies ModelSelection;
 
@@ -163,12 +166,14 @@ describe("threadHandoff", () => {
         sourceThread: {
           modelSelection: {
             provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "claude-sonnet-4-6",
           },
         },
         targetProvider: "antigravity",
         projectDefaultModelSelection: {
           provider: "antigravity",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "Claude Sonnet 4.6",
         },
         stickyModelSelectionByProvider: {
@@ -178,12 +183,38 @@ describe("threadHandoff", () => {
     ).toEqual(stickySelection);
   });
 
+  it("preserves a sticky non-default target so handoff dispatch can fail closed", () => {
+    const workProfileId = ProviderProfileId.makeUnsafe("work");
+
+    expect(
+      resolveThreadHandoffModelSelection({
+        sourceThread: {
+          modelSelection: {
+            provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
+            model: "claude-sonnet-4-6",
+          },
+        },
+        targetProvider: "codex",
+        projectDefaultModelSelection: null,
+        stickyModelSelectionByProvider: {
+          codex: {
+            provider: "codex",
+            profileId: workProfileId,
+            model: "gpt-5.6-sol",
+          },
+        },
+      }),
+    ).toMatchObject({ profileId: workProfileId });
+  });
+
   it("falls back to the resolved provider default model when no sticky or project default exists", () => {
     expect(
       resolveThreadHandoffModelSelection({
         sourceThread: {
           modelSelection: {
             provider: "antigravity",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "Gemini 3.5 Flash",
           },
         },
@@ -193,6 +224,7 @@ describe("threadHandoff", () => {
       }),
     ).toEqual({
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5.5",
     });
   });

--- a/apps/web/src/lib/threadHandoff.ts
+++ b/apps/web/src/lib/threadHandoff.ts
@@ -4,6 +4,7 @@
 // Exports: target-provider, title, transcript, and model-selection helpers.
 
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   EventId,
   MessageId,
   type OrchestrationThreadActivity,
@@ -203,6 +204,7 @@ export function resolveThreadHandoffModelSelection(input: {
   }
   return {
     provider: input.targetProvider,
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
     model: defaultModel,
   };
 }

--- a/apps/web/src/lib/threadModelSummary.test.ts
+++ b/apps/web/src/lib/threadModelSummary.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PROVIDER_PROFILE_ID } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
 import { resolveThreadModelSummary } from "./threadModelSummary";
@@ -11,6 +12,7 @@ describe("resolveThreadModelSummary", () => {
   it("summarizes a codex selection with its reasoning effort", () => {
     const summary = resolveThreadModelSummary({
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5.5",
       options: { reasoningEffort: "high" },
     });
@@ -23,11 +25,13 @@ describe("resolveThreadModelSummary", () => {
   it("falls back to the model's default effort when none is stored", () => {
     const withEffort = resolveThreadModelSummary({
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5.5",
       options: { reasoningEffort: "low" },
     });
     const withoutOptions = resolveThreadModelSummary({
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5.5",
     });
 
@@ -39,6 +43,7 @@ describe("resolveThreadModelSummary", () => {
   it("summarizes a claude selection", () => {
     const summary = resolveThreadModelSummary({
       provider: "claudeAgent",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "claude-sonnet-5",
       options: { effort: "high" },
     });

--- a/apps/web/src/lib/threadRecap.test.ts
+++ b/apps/web/src/lib/threadRecap.test.ts
@@ -2,6 +2,7 @@
 // Purpose: Verify compact recap inputs only advance on real transcript messages.
 // Layer: Unit test
 
+import { DEFAULT_PROVIDER_PROFILE_ID } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
 import type { MessageId, ThreadId } from "@synara/contracts";
@@ -59,7 +60,7 @@ function thread(overrides: Partial<Thread> = {}): Thread {
     codexThreadId: null,
     projectId: "project-1" as Thread["projectId"],
     title: "Environment panel",
-    modelSelection: { provider: "codex", model: "gpt-5.4-mini" },
+    modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.4-mini" },
     runtimeMode: "full-access",
     interactionMode: "default",
     session: null,

--- a/apps/web/src/lib/threadRename.test.ts
+++ b/apps/web/src/lib/threadRename.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PROVIDER_PROFILE_ID } from "@synara/contracts";
 import { describe, expect, it, vi } from "vitest";
 
 const dispatchCommand = vi.fn<(command: unknown) => Promise<void>>();
@@ -42,6 +43,7 @@ describe("dispatchThreadRename", () => {
         projectId: "project-chat" as never,
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5",
         },
         runtimeMode: "full-access",

--- a/apps/web/src/notifications/taskCompletion.logic.test.ts
+++ b/apps/web/src/notifications/taskCompletion.logic.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   ApprovalRequestId,
   EventId,
   MessageId,
@@ -26,7 +27,7 @@ function makeThread(overrides: Partial<Thread>): Thread {
     codexThreadId: null,
     projectId: "project-1" as ProjectId,
     title: "Polish notifications",
-    modelSelection: { provider: "codex", model: "gpt-5.4-mini" },
+    modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.4-mini" },
     runtimeMode: "full-access",
     interactionMode: "default",
     session: {

--- a/apps/web/src/providerModelOptions.test.ts
+++ b/apps/web/src/providerModelOptions.test.ts
@@ -3,10 +3,12 @@
 // Layer: Web unit tests
 // Depends on: providerModelOptions shared formatting helpers.
 
+import { DEFAULT_PROVIDER_PROFILE_ID, ProviderProfileId } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
 import {
   buildModelSelection,
+  buildModelSelectionForTarget,
   buildNextProviderOptions,
   buildProviderOptionPatch,
   formatProviderModelOptionName,
@@ -29,6 +31,7 @@ describe("Antigravity model options", () => {
     expect(options).toEqual({ reasoningEffort: "high" });
     expect(buildModelSelection("antigravity", "Gemini 3.5 Flash", options)).toEqual({
       provider: "antigravity",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "Gemini 3.5 Flash",
       options: { reasoningEffort: "high" },
     });
@@ -39,8 +42,54 @@ describe("Claude model selections", () => {
   it("preserves the discovered Auto capability with the selected model", () => {
     expect(buildModelSelection("claudeAgent", "claude-haiku-4-5", undefined, false)).toEqual({
       provider: "claudeAgent",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "claude-haiku-4-5",
       supportsAutoMode: false,
+    });
+  });
+
+  it("builds selections for an explicit provider profile", () => {
+    expect(
+      buildModelSelectionForTarget({
+        target: {
+          provider: "claudeAgent",
+          profileId: ProviderProfileId.makeUnsafe("work"),
+        },
+        model: "claude-haiku-4-5",
+        supportsAutoMode: true,
+      }),
+    ).toEqual({
+      provider: "claudeAgent",
+      profileId: "work",
+      model: "claude-haiku-4-5",
+      supportsAutoMode: true,
+    });
+  });
+
+  it("keeps an existing non-default target when rebuilding an edited selection", () => {
+    const existingSelection = buildModelSelectionForTarget({
+      target: {
+        provider: "claudeAgent",
+        profileId: ProviderProfileId.makeUnsafe("work"),
+      },
+      model: "claude-haiku-4-5",
+      options: { effort: "high" },
+    });
+
+    expect(
+      buildModelSelectionForTarget({
+        target: {
+          provider: existingSelection.provider,
+          profileId: existingSelection.profileId,
+        },
+        model: "claude-sonnet-5",
+        options: { effort: "max" },
+      }),
+    ).toEqual({
+      provider: "claudeAgent",
+      profileId: ProviderProfileId.makeUnsafe("work"),
+      model: "claude-sonnet-5",
+      options: { effort: "max" },
     });
   });
 });

--- a/apps/web/src/providerModelOptions.ts
+++ b/apps/web/src/providerModelOptions.ts
@@ -4,6 +4,7 @@ import {
   normalizeModelSlug,
 } from "@synara/shared/model";
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   PROVIDER_DISPLAY_NAMES,
   type AntigravityModelOptions,
   type AntigravityModelSelection,
@@ -25,6 +26,7 @@ import {
   type PiModelSelection,
   type ProviderKind,
   type ProviderModelOptions,
+  type ProviderTarget,
 } from "@synara/contracts";
 import { normalizeCursorModelVariantBaseId } from "./cursorModelVariants";
 
@@ -403,21 +405,24 @@ export function buildModelSelection(
       return options
         ? {
             provider,
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model,
             options: options as AntigravityModelOptions,
           }
-        : { provider, model };
+        : { provider, profileId: DEFAULT_PROVIDER_PROFILE_ID, model };
     case "codex":
       return options
         ? {
             provider,
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model,
             options: options as CodexModelOptions,
           }
-        : { provider, model };
+        : { provider, profileId: DEFAULT_PROVIDER_PROFILE_ID, model };
     case "claudeAgent":
       return {
         provider,
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model,
         ...(options ? { options: options as ClaudeModelOptions } : {}),
         ...(typeof supportsAutoMode === "boolean" ? { supportsAutoMode } : {}),
@@ -426,49 +431,72 @@ export function buildModelSelection(
       return options
         ? {
             provider,
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model,
             options: options as CursorModelOptions,
           }
-        : { provider, model };
+        : { provider, profileId: DEFAULT_PROVIDER_PROFILE_ID, model };
     case "grok":
       return options
         ? {
             provider,
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model,
             options: options as GrokModelOptions,
           }
-        : { provider, model };
+        : { provider, profileId: DEFAULT_PROVIDER_PROFILE_ID, model };
     case "droid":
       return options
         ? {
             provider,
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model,
             options: options as DroidModelOptions,
           }
-        : { provider, model };
+        : { provider, profileId: DEFAULT_PROVIDER_PROFILE_ID, model };
     case "kilo":
       return options
         ? {
             provider,
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model,
             options: options as OpenCodeModelOptions,
           }
-        : { provider, model };
+        : { provider, profileId: DEFAULT_PROVIDER_PROFILE_ID, model };
     case "opencode":
       return options
         ? {
             provider,
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model,
             options: options as OpenCodeModelOptions,
           }
-        : { provider, model };
+        : { provider, profileId: DEFAULT_PROVIDER_PROFILE_ID, model };
     case "pi":
       return options
         ? {
             provider,
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model,
             options: options as PiModelOptions,
           }
-        : { provider, model };
+        : { provider, profileId: DEFAULT_PROVIDER_PROFILE_ID, model };
   }
+}
+
+export function buildModelSelectionForTarget(input: {
+  target: ProviderTarget;
+  model: string;
+  options?: ProviderOptions | null | undefined;
+  supportsAutoMode?: boolean | undefined;
+}): ModelSelection {
+  return {
+    ...buildModelSelection(
+      input.target.provider,
+      input.model,
+      input.options,
+      input.supportsAutoMode,
+    ),
+    profileId: input.target.profileId,
+  };
 }

--- a/apps/web/src/providerUpdates.test.ts
+++ b/apps/web/src/providerUpdates.test.ts
@@ -3,6 +3,7 @@
 // Layer: Web utility tests
 // Exports: Vitest suites for providerUpdates.ts
 
+import { DEFAULT_PROVIDER_PROFILE_ID } from "@synara/contracts";
 import type { ProviderKind, ServerProviderStatus, ServerSettings } from "@synara/contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -58,7 +59,7 @@ function serverSettings(overrides: Partial<ServerSettings["providers"]> = {}): S
     enableProviderUpdateChecks: true,
     defaultThreadEnvMode: "local",
     addProjectBaseDirectory: "",
-    textGenerationModelSelection: { provider: "codex", model: "gpt-5.4-mini" },
+    textGenerationModelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.4-mini" },
     providers: {
       codex: { ...provider, binaryPath: "codex", homePath: "" },
       claudeAgent: { ...provider, binaryPath: "claude", launchArgs: "" },

--- a/apps/web/src/recentViews.logic.test.ts
+++ b/apps/web/src/recentViews.logic.test.ts
@@ -3,7 +3,7 @@
 // Layer: UI state logic test
 
 import { describe, expect, it } from "vitest";
-import { ProjectId, ThreadId } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, ProjectId, ThreadId } from "@synara/contracts";
 import type { ResolvedTerminalVisualIdentity } from "@synara/shared/terminalThreads";
 import {
   buildRecentViewDisplayEntries,
@@ -138,7 +138,7 @@ describe("recent view MRU logic", () => {
       id: terminalThreadId,
       projectId: project.id,
       title: "Dev server",
-      modelSelection: { provider: "codex", model: "gpt-5" },
+      modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5" },
     } as SidebarThreadSummary;
 
     const entries = buildRecentViewDisplayEntries({

--- a/apps/web/src/routes/-automations.shared.test.tsx
+++ b/apps/web/src/routes/-automations.shared.test.tsx
@@ -4,6 +4,7 @@
 // Depends on: -automations.shared exported helper functions.
 
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   AutomationId,
   AutomationRunId,
   CommandId,
@@ -127,7 +128,7 @@ const baseRun: AutomationRun = {
   },
   permissionSnapshot: {
     provider: "codex",
-    modelSelection: { provider: "codex", model: "gpt-5-codex" },
+    modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
     runtimeMode: "approval-required",
     interactionMode: "default",
     worktreeMode: "auto",
@@ -147,7 +148,7 @@ const baseDefinition: AutomationDefinition = {
   schedule: { type: "interval", everySeconds: 3600 },
   enabled: true,
   nextRunAt: "2026-06-19T11:00:00.000Z",
-  modelSelection: { provider: "codex", model: "gpt-5-codex" },
+  modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
   runtimeMode: "approval-required",
   interactionMode: "default",
   worktreeMode: "auto",
@@ -458,40 +459,66 @@ describe("automation shared route helpers", () => {
     const projects = [
       {
         id: projectId("project-old"),
-        defaultModelSelection: { provider: "codex", model: "gpt-5-codex" },
+        defaultModelSelection: {
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          model: "gpt-5-codex",
+        },
       },
       {
         id: projectId("project-new"),
-        defaultModelSelection: { provider: "claudeAgent", model: "sonnet" },
+        defaultModelSelection: {
+          provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          model: "sonnet",
+        },
       },
     ] as Parameters<typeof modelSelectionForProjectChange>[0];
 
     expect(
       modelSelectionForProjectChange(projects, "project-old", "project-new", {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "gpt-5-codex",
       }),
-    ).toEqual({ provider: "claudeAgent", model: "sonnet" });
+    ).toEqual({
+      provider: "claudeAgent",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
+      model: "sonnet",
+    });
   });
 
   it("preserves an explicitly chosen model when switching projects", () => {
     const projects = [
       {
         id: projectId("project-old"),
-        defaultModelSelection: { provider: "codex", model: "gpt-5-codex" },
+        defaultModelSelection: {
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          model: "gpt-5-codex",
+        },
       },
       {
         id: projectId("project-new"),
-        defaultModelSelection: { provider: "claudeAgent", model: "sonnet" },
+        defaultModelSelection: {
+          provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          model: "sonnet",
+        },
       },
     ] as Parameters<typeof modelSelectionForProjectChange>[0];
 
     expect(
       modelSelectionForProjectChange(projects, "project-old", "project-new", {
         provider: "cursor",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "cursor-default",
       }),
-    ).toEqual({ provider: "cursor", model: "cursor-default" });
+    ).toEqual({
+      provider: "cursor",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
+      model: "cursor-default",
+    });
   });
 
   it("preserves timezone when changing weekly day and time", () => {
@@ -613,7 +640,7 @@ describe("automation shared route helpers", () => {
       opencode: { binaryPath: "/new/opencode", serverUrl: "http://new.example" },
     };
     const definition = definitionWith({
-      modelSelection: { provider: "opencode", model: "openai/gpt-5" },
+      modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5" },
       providerOptions: savedProviderOptions,
     });
     const form = formFromDefinition(definition, "project-1");
@@ -631,10 +658,18 @@ describe("automation shared route helpers", () => {
       cursor: { binaryPath: "/current/cursor", apiEndpoint: "http://cursor.example" },
     };
     const definition = definitionWith({
-      modelSelection: { provider: "opencode", model: "openai/gpt-5" },
+      modelSelection: {
+        provider: "opencode",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
+        model: "openai/gpt-5",
+      },
       providerOptions: savedProviderOptions,
     });
-    const nextModelSelection = { provider: "cursor" as const, model: "composer-2" };
+    const nextModelSelection = {
+      provider: "cursor" as const,
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
+      model: "composer-2",
+    };
 
     expect(
       providerOptionsForAutomationModelSelection(
@@ -655,6 +690,7 @@ describe("automation shared route helpers", () => {
     const definition = definitionWith({
       modelSelection: {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "gpt-5-codex",
         options: { reasoningEffort: "medium" },
       },
@@ -666,6 +702,7 @@ describe("automation shared route helpers", () => {
         definition,
         {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
           options: { reasoningEffort: "high" },
         },
@@ -676,7 +713,11 @@ describe("automation shared route helpers", () => {
 
   it("clears stale provider options when an automation edit changes models without current options", () => {
     const definition = definitionWith({
-      modelSelection: { provider: "opencode", model: "openai/gpt-5" },
+      modelSelection: {
+        provider: "opencode",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
+        model: "openai/gpt-5",
+      },
       providerOptions: {
         opencode: { binaryPath: "/old/opencode", serverUrl: "http://old.example" },
       },
@@ -685,6 +726,7 @@ describe("automation shared route helpers", () => {
     expect(
       providerOptionsForAutomationModelSelection(definition, {
         provider: "cursor",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "composer-2",
       }),
     ).toEqual({});

--- a/apps/web/src/routes/-rootEventInvalidation.test.ts
+++ b/apps/web/src/routes/-rootEventInvalidation.test.ts
@@ -3,7 +3,7 @@
 // Layer: Route utility unit tests
 // Depends on: rootEventInvalidation predicates and Vitest assertions.
 
-import { ProjectId, ThreadId, type OrchestrationEvent } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, ProjectId, ThreadId, type OrchestrationEvent } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -161,7 +161,7 @@ function makeThread(overrides: Partial<Thread>): Thread {
     codexThreadId: null,
     projectId: ProjectId.makeUnsafe("project"),
     title: "Thread",
-    modelSelection: { provider: "codex", model: "gpt-5.4-mini" },
+    modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.4-mini" },
     runtimeMode: "full-access",
     interactionMode: "default",
     session: null,

--- a/apps/web/src/storeEventReducer.test.ts
+++ b/apps/web/src/storeEventReducer.test.ts
@@ -2,6 +2,7 @@
 // Purpose: Exercises orchestration domain-event reduction and batching.
 
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   ApprovalRequestId,
   CheckpointRef,
   CommandId,
@@ -262,6 +263,7 @@ describe("store event reducer", () => {
             workspaceRoot: "/tmp/live-project",
             defaultModelSelection: {
               provider: "codex",
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
               model: "gpt-5-codex",
             },
             scripts: [],
@@ -1972,6 +1974,7 @@ describe("store event reducer", () => {
         title: "Stale archived thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.3-codex",
         },
         runtimeMode: DEFAULT_RUNTIME_MODE,

--- a/apps/web/src/storeProjection.test.ts
+++ b/apps/web/src/storeProjection.test.ts
@@ -2,6 +2,7 @@
 // Purpose: Exercises snapshot normalization and normalized projection ownership.
 
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   EventId,
   MessageId,
   ProjectId,
@@ -197,6 +198,7 @@ describe("store projection", () => {
         title: "Stale project thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.3-codex",
         },
         runtimeMode: DEFAULT_RUNTIME_MODE,
@@ -403,6 +405,7 @@ describe("store projection", () => {
         title: "Thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.3-codex",
         },
         runtimeMode: DEFAULT_RUNTIME_MODE,
@@ -509,6 +512,7 @@ describe("store projection", () => {
         title: "Thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.3-codex",
         },
         runtimeMode: DEFAULT_RUNTIME_MODE,
@@ -677,6 +681,7 @@ describe("store projection", () => {
       makeReadModelThread({
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-6",
         },
       }),
@@ -693,6 +698,7 @@ describe("store projection", () => {
       makeReadModelThread({
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "sonnet",
         },
         session: {
@@ -718,6 +724,7 @@ describe("store projection", () => {
       makeReadModelThread({
         modelSelection: {
           provider: "opencode",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "openrouter/gpt-oss-120b:free",
         },
         session: {
@@ -744,6 +751,7 @@ describe("store projection", () => {
       makeReadModelThread({
         modelSelection: {
           provider: "pi",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "anthropic/claude-sonnet-4-5",
         },
         session: {
@@ -770,6 +778,7 @@ describe("store projection", () => {
       makeReadModelThread({
         modelSelection: {
           provider: "opencode",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "openai/gpt-5.4",
         },
       }),
@@ -788,6 +797,7 @@ describe("store projection", () => {
         makeReadModelProject({
           defaultModelSelection: {
             provider: "opencode",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "openai/gpt-5.4",
           },
         }),
@@ -822,6 +832,7 @@ describe("store projection", () => {
         id: threadId,
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-7",
         },
         session: {
@@ -868,6 +879,7 @@ describe("store projection", () => {
         id: threadId,
         modelSelection: {
           provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "claude-opus-4-7",
         },
         latestTurn: {
@@ -974,6 +986,7 @@ describe("store projection", () => {
         id: threadId,
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         session: {
@@ -1021,6 +1034,7 @@ describe("store projection", () => {
         id: threadId,
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         latestTurn: {
@@ -1084,6 +1098,7 @@ describe("store projection", () => {
         id: threadId,
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         session: {
@@ -1123,6 +1138,7 @@ describe("store projection", () => {
         id: threadId,
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         latestTurn: {
@@ -1167,6 +1183,7 @@ describe("store projection", () => {
         id: threadId,
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         session: {
@@ -1205,6 +1222,7 @@ describe("store projection", () => {
         id: threadId,
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5-codex",
         },
         latestTurn: {
@@ -1504,6 +1522,7 @@ describe("store projection", () => {
         title: "Stale resurrected thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.3-codex",
         },
         runtimeMode: DEFAULT_RUNTIME_MODE,
@@ -1553,6 +1572,7 @@ describe("store projection", () => {
         title: "Rehydrated shell removed thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.3-codex",
         },
         runtimeMode: DEFAULT_RUNTIME_MODE,
@@ -1585,6 +1605,7 @@ describe("store projection", () => {
         makeReadModelProject({
           defaultModelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           updatedAt: "2026-02-27T00:00:00.000Z",
@@ -1594,6 +1615,7 @@ describe("store projection", () => {
         makeReadModelThread({
           modelSelection: {
             provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
             model: "gpt-5-codex",
           },
           createdAt: "2026-02-13T00:00:00.000Z",
@@ -1694,7 +1716,7 @@ describe("deletion tombstone retirement", () => {
         id: deletedThreadId,
         projectId,
         title,
-        modelSelection: { provider: "codex", model: "gpt-5.3-codex" },
+        modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.3-codex" },
         runtimeMode: DEFAULT_RUNTIME_MODE,
         interactionMode: DEFAULT_INTERACTION_MODE,
         envMode: "local",
@@ -1901,7 +1923,7 @@ describe("deletion tombstone retirement", () => {
       id: deletedThreadId,
       projectId,
       title: "Base",
-      modelSelection: { provider: "codex", model: "gpt-5.3-codex" },
+      modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.3-codex" },
       runtimeMode: DEFAULT_RUNTIME_MODE,
       interactionMode: DEFAULT_INTERACTION_MODE,
       envMode: "local",
@@ -2009,6 +2031,7 @@ describe("deletion tombstone retirement", () => {
         title: "Thread",
         modelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.3-codex",
         },
         runtimeMode: DEFAULT_RUNTIME_MODE,

--- a/apps/web/src/storeSelectors.test.ts
+++ b/apps/web/src/storeSelectors.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PROVIDER_PROFILE_ID } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
 import type { MessageId, ProjectId, ThreadId } from "@synara/contracts";
@@ -26,7 +27,7 @@ const summaryA = {
   id: threadIdA,
   projectId,
   title: "A",
-  modelSelection: { provider: "codex", model: "gpt-5-codex" },
+  modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
   session: null,
   createdAt: "2026-01-01T00:00:00.000Z",
   latestUserMessageAt: null,

--- a/apps/web/src/storeTestFixtures.ts
+++ b/apps/web/src/storeTestFixtures.ts
@@ -3,6 +3,7 @@
 // Exports: Minimal normalized-state and orchestration payload fixtures.
 
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   EventId,
   ProjectId,
   ThreadId,
@@ -25,6 +26,7 @@ export function makeThread(overrides: Partial<Thread> = {}): Thread {
     title: "Thread",
     modelSelection: {
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5-codex",
     },
     runtimeMode: DEFAULT_RUNTIME_MODE,
@@ -158,6 +160,7 @@ export function makeProject(
     cwd: "/tmp/project",
     defaultModelSelection: {
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5-codex",
     },
     expanded: true,
@@ -174,6 +177,7 @@ export function makeReadModelThread(overrides: Partial<OrchestrationReadModel["t
     title: "Thread",
     modelSelection: {
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5.3-codex",
     },
     runtimeMode: DEFAULT_RUNTIME_MODE,
@@ -212,6 +216,7 @@ export function makeReadModel(
         workspaceRoot: "/tmp/project",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.3-codex",
         },
         createdAt: "2026-02-27T00:00:00.000Z",
@@ -237,6 +242,7 @@ export function makeShellSnapshot(thread: OrchestrationShellSnapshot["threads"][
         workspaceRoot: "/tmp/project",
         defaultModelSelection: {
           provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "gpt-5.3-codex",
         },
         createdAt: "2026-02-27T00:00:00.000Z",
@@ -259,6 +265,7 @@ export function makeReadModelProject(
     workspaceRoot: "/tmp/project",
     defaultModelSelection: {
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5.3-codex",
     },
     createdAt: "2026-02-27T00:00:00.000Z",

--- a/apps/web/src/threadDetailSubscriptionRetention.test.ts
+++ b/apps/web/src/threadDetailSubscriptionRetention.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ThreadId, TurnId, WS_STREAM_LIMITS } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, ThreadId, TurnId, WS_STREAM_LIMITS } from "@synara/contracts";
 import { useStore } from "./store";
 import {
   MAX_CACHED_THREAD_DETAIL_SUBSCRIPTIONS,
@@ -24,7 +24,7 @@ describe("threadDetailSubscriptionRetention", () => {
           id: threadId,
           projectId: "project-1" as never,
           title: "Idle thread",
-          modelSelection: { provider: "codex", model: "gpt-5.4" },
+          modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.4" },
           interactionMode: "default",
           envMode: "local",
           branch: null,
@@ -155,7 +155,7 @@ describe("threadDetailSubscriptionRetention", () => {
           id: threadId,
           projectId: "project-1" as never,
           title: "Busy thread",
-          modelSelection: { provider: "codex", model: "gpt-5.4" },
+          modelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.4" },
           interactionMode: "default",
           envMode: "local",
           branch: null,

--- a/apps/web/src/worktreeCleanup.test.ts
+++ b/apps/web/src/worktreeCleanup.test.ts
@@ -1,4 +1,4 @@
-import { ProjectId, ThreadId } from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID, ProjectId, ThreadId } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
 import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type Thread } from "./types";
@@ -12,6 +12,7 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     title: "Thread",
     modelSelection: {
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5.3-codex",
     },
     runtimeMode: DEFAULT_RUNTIME_MODE,

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -4,6 +4,7 @@
 // Depends on: wsTransport mock plus contracts channel constants.
 
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   ApprovalRequestId,
   AutomationId,
   AutomationRunId,
@@ -302,7 +303,11 @@ describe("wsNativeApi", () => {
         enableProviderUpdateChecks: true,
         defaultThreadEnvMode: "local",
         addProjectBaseDirectory: "",
-        textGenerationModelSelection: { provider: "codex", model: "gpt-5.4-mini" },
+        textGenerationModelSelection: {
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          model: "gpt-5.4-mini",
+        },
         providers: {
           codex: { enabled: true, binaryPath: "codex", homePath: "", customModels: [] },
           claudeAgent: { enabled: true, binaryPath: "claude", launchArgs: "", customModels: [] },
@@ -502,6 +507,7 @@ describe("wsNativeApi", () => {
       workspaceRoot: "/tmp/project",
       defaultModelSelection: {
         provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "gpt-5-codex",
       },
       createdAt: "2026-02-24T00:00:00.000Z",
@@ -791,7 +797,11 @@ describe("wsNativeApi", () => {
       commandId: CommandId.makeUnsafe("command-1"),
       projectId: ProjectId.makeUnsafe("project-1"),
       newProjectSpaceId: null,
-      defaultModelSelection: { provider: "codex" as const, model: "gpt-5" },
+      defaultModelSelection: {
+        provider: "codex" as const,
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
+        model: "gpt-5",
+      },
       createdAt: "2026-08-04T00:00:00.000Z",
     };
     const result = {

--- a/docs/provider-profiles.md
+++ b/docs/provider-profiles.md
@@ -1,0 +1,73 @@
+# Provider profiles
+
+Provider profiles let one provider implementation, such as Codex, run with more than one
+server-owned account configuration. The profile identity is part of thread routing; credentials
+and launch configuration are not.
+
+## Identity model
+
+Synara keeps these concepts separate:
+
+- `ProviderKind` selects the adapter implementation, for example `codex` or `claudeAgent`.
+- `ProviderProfileId` selects one named server-owned configuration for that provider.
+- `ProviderTarget` is the complete routing identity: `{ provider, profileId }`.
+- A continuation namespace identifies the provider-native thread store. It is not automatically
+  the same thing as an authentication profile.
+- A runtime lease owns the right to write to one provider-native continuation. It is a runtime
+  concern, not a persisted profile identifier.
+
+Legacy data that has no profile identifier belongs to the reserved `default` profile.
+
+## Sources of truth
+
+- A thread's persisted model selection records its intended provider target.
+- `provider_session_runtime` records the exact target needed for runtime recovery.
+- A server-owned profile registry resolves a target into launch configuration and credentials.
+- Browser requests may select a target, but they never supply or override profile credentials.
+
+Do not add another independently writable target field to a projection. Derived views may expose
+the target, but they must be rebuilt from the thread model selection or runtime binding.
+
+## Routing invariants
+
+1. Resume cursors, provider options, active runtimes, and native forks are reusable only when the
+   complete provider target matches.
+2. A change of provider or profile is a target replacement. The old runtime stops before the new
+   runtime starts, so two accounts never own the same continuation concurrently.
+3. If replacement fails, recovery restores the exact old target and its compatible runtime state.
+4. A thread may adopt its first target before work begins. After its first turn, changing profiles
+   creates a new thread or an explicit history handoff; it does not mutate the established thread.
+5. Missing, disabled, or invalid profiles fail closed. They never fall back to `default`.
+6. Profile removal must not erase the persisted target. Keeping the unresolved identity makes the
+   failure explainable and allows recovery if the profile returns.
+7. Authentication identity and continuation storage remain separate. Sharing a continuation store
+   is an explicit provider policy, never a side effect of copying an entire home directory.
+
+## Delivery stages
+
+### 1. Routing foundation
+
+- Add typed profile and target identities with legacy `default` compatibility.
+- Preserve target identity through model selections, settings, projections, and runtime bindings.
+- Make session start, recovery, fork, and first-turn locking compare complete targets.
+- Keep executable profiles restricted to `default` until server-owned profile resolution exists.
+
+### 2. Isolated runtime profiles
+
+- Add the typed, redacted server profile registry.
+- Resolve immutable launch contexts on the server.
+- Isolate Codex authentication and cache state without cloning or symlinking a broad home tree.
+- Route discovery, health, text generation, automations, Agent Gateway, images, and recovery by
+  complete target.
+- Add per-continuation runtime leases and deterministic stop-then-start handoff.
+
+### 3. Product experience
+
+- Add profile management and a separate account picker.
+- Explain missing or disabled profiles without silently changing the thread.
+- Offer an explicit "Continue with another account" flow that creates a new thread or handoff.
+- Verify concurrent accounts, restart recovery, profile removal, authentication rotation, and
+  active-writer conflicts end to end.
+
+The old multi-account pull request remains useful as a requirements and failure-case archive. Its
+implementation is not a base for these stages.

--- a/packages/contracts/src/agentGateway.test.ts
+++ b/packages/contracts/src/agentGateway.test.ts
@@ -9,6 +9,7 @@ import {
   SynaraWaitForThreadsInput,
   SynaraWaitForThreadsResult,
 } from "./agentGateway";
+import { DEFAULT_PROVIDER_PROFILE_ID } from "./providerProfile";
 
 const decodeCreate = Schema.decodeUnknownSync(SynaraCreateThreadsInput);
 const decodeWait = Schema.decodeUnknownSync(SynaraWaitForThreadsInput);
@@ -17,6 +18,7 @@ const thread = {
   prompt: "Explain this repository",
   target: {
     provider: "codex",
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
     model: "gpt-5.6-terra",
     options: { reasoningEffort: "low" },
   },

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -14,6 +14,7 @@ export * from "./browserAnnotations";
 export * from "./ipc";
 export * from "./terminal";
 export * from "./provider";
+export * from "./providerProfile";
 export * from "./providerDiscovery";
 export * from "./providerRuntime";
 export * from "./model";

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -21,6 +21,7 @@ import {
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
   ProviderStartOptions,
+  ProviderTarget,
   ProjectCreateCommand,
   THREAD_NOTES_MAX_CHARS,
   THREAD_MARKER_LABEL_MAX_CHARS,
@@ -31,6 +32,7 @@ import {
   ThreadTurnStartRequestedPayload,
   RuntimeMode,
 } from "./orchestration";
+import { DEFAULT_PROVIDER_PROFILE_ID } from "./providerProfile";
 
 const decodeTurnDiffInput = Schema.decodeUnknownEffect(OrchestrationGetTurnDiffInput);
 const decodeFullThreadDiffInput = Schema.decodeUnknownEffect(OrchestrationGetFullThreadDiffInput);
@@ -56,6 +58,7 @@ const decodeThreadCreatedPayload = Schema.decodeUnknownEffect(ThreadCreatedPaylo
 const decodeThreadMetaUpdatedPayload = Schema.decodeUnknownEffect(ThreadMetaUpdatedPayload);
 const decodeModelSelection = Schema.decodeUnknownEffect(ModelSelection);
 const decodeProviderStartOptions = Schema.decodeUnknownEffect(ProviderStartOptions);
+const decodeProviderTarget = Schema.decodeUnknownEffect(ProviderTarget);
 const decodeClientOrchestrationCommand = Schema.decodeUnknownEffect(ClientOrchestrationCommand);
 const decodeOrchestrationCommand = Schema.decodeUnknownEffect(OrchestrationCommand);
 const decodeOrchestrationEvent = Schema.decodeUnknownEffect(OrchestrationEvent);
@@ -176,7 +179,7 @@ it.effect("preserves thread activity payloads through the RPC JSON codec", () =>
   }),
 );
 
-it.effect("preserves Pi model selections when decoding model selections", () =>
+it.effect("defaults legacy model selections to the default provider profile", () =>
   Effect.gen(function* () {
     const parsed = yield* decodeModelSelection({
       provider: "pi",
@@ -185,8 +188,48 @@ it.effect("preserves Pi model selections when decoding model selections", () =>
 
     assert.deepStrictEqual(parsed, {
       provider: "pi",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "openai/gpt-5.5",
     });
+  }),
+);
+
+it.effect("defaults legacy provider targets to the default profile", () =>
+  Effect.gen(function* () {
+    assert.deepStrictEqual(yield* decodeProviderTarget({ provider: "codex" }), {
+      provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
+    });
+  }),
+);
+
+it.effect("preserves explicit provider profile routing on model selections", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeModelSelection({
+      provider: "codex",
+      profileId: "work",
+      model: "gpt-5.6-codex",
+    });
+
+    assert.deepStrictEqual(parsed, {
+      provider: "codex",
+      profileId: "work",
+      model: "gpt-5.6-codex",
+    });
+  }),
+);
+
+it.effect("rejects an invalid explicit model-selection profile", () =>
+  Effect.gen(function* () {
+    const result = yield* Effect.exit(
+      decodeModelSelection({
+        provider: "codex",
+        profileId: "../work",
+        model: "gpt-5.6-codex",
+      }),
+    );
+
+    assert.equal(result._tag, "Failure");
   }),
 );
 
@@ -200,6 +243,7 @@ it.effect("preserves Antigravity effort options separately from the model", () =
 
     assert.deepStrictEqual(parsed, {
       provider: "antigravity",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "Gemini 3.5 Flash",
       options: { reasoningEffort: "high" },
     });
@@ -218,6 +262,7 @@ it.effect("preserves Pi model selections through the JSON codec", () =>
 
     assert.deepStrictEqual(parsed, {
       provider: "pi",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "openai/gpt-5.5",
     });
   }),
@@ -344,6 +389,7 @@ it.effect("trims branded ids and command string fields at decode boundaries", ()
     assert.strictEqual(parsed.workspaceRoot, "/tmp/workspace");
     assert.deepStrictEqual(parsed.defaultModelSelection, {
       provider: "codex",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "gpt-5.2",
     });
   }),

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -10,6 +10,7 @@ import {
   PiModelOptions,
 } from "./model";
 import { ProviderMentionReference, ProviderSkillReference } from "./providerDiscovery";
+import { DEFAULT_PROVIDER_PROFILE_ID, ProviderProfileId } from "./providerProfile";
 import { ProjectKind } from "./project";
 import {
   ApprovalRequestId,
@@ -65,6 +66,14 @@ export const ProviderKind = Schema.Literals([
   "pi",
 ]);
 export type ProviderKind = typeof ProviderKind.Type;
+const ProviderProfileIdWithDefault = ProviderProfileId.pipe(
+  Schema.withDecodingDefault(() => DEFAULT_PROVIDER_PROFILE_ID),
+);
+export const ProviderTarget = Schema.Struct({
+  provider: ProviderKind,
+  profileId: ProviderProfileIdWithDefault,
+});
+export type ProviderTarget = typeof ProviderTarget.Type;
 export const ProviderApprovalPolicy = Schema.Literals([
   "untrusted",
   "on-failure",
@@ -82,6 +91,7 @@ export const DEFAULT_PROVIDER_KIND: ProviderKind = "codex";
 
 export const CodexModelSelection = Schema.Struct({
   provider: Schema.Literal("codex"),
+  profileId: ProviderProfileIdWithDefault,
   model: TrimmedNonEmptyString,
   options: Schema.optional(CodexModelOptions),
 });
@@ -89,6 +99,7 @@ export type CodexModelSelection = typeof CodexModelSelection.Type;
 
 export const ClaudeModelSelection = Schema.Struct({
   provider: Schema.Literal("claudeAgent"),
+  profileId: ProviderProfileIdWithDefault,
   model: TrimmedNonEmptyString,
   options: Schema.optional(ClaudeModelOptions),
   supportsAutoMode: Schema.optional(Schema.Boolean),
@@ -97,6 +108,7 @@ export type ClaudeModelSelection = typeof ClaudeModelSelection.Type;
 
 export const CursorModelSelection = Schema.Struct({
   provider: Schema.Literal("cursor"),
+  profileId: ProviderProfileIdWithDefault,
   model: TrimmedNonEmptyString,
   options: Schema.optional(CursorModelOptions),
 });
@@ -104,6 +116,7 @@ export type CursorModelSelection = typeof CursorModelSelection.Type;
 
 export const AntigravityModelSelection = Schema.Struct({
   provider: Schema.Literal("antigravity"),
+  profileId: ProviderProfileIdWithDefault,
   model: TrimmedNonEmptyString,
   options: Schema.optional(AntigravityModelOptions),
 });
@@ -111,6 +124,7 @@ export type AntigravityModelSelection = typeof AntigravityModelSelection.Type;
 
 export const GrokModelSelection = Schema.Struct({
   provider: Schema.Literal("grok"),
+  profileId: ProviderProfileIdWithDefault,
   model: TrimmedNonEmptyString,
   options: Schema.optional(GrokModelOptions),
 });
@@ -118,6 +132,7 @@ export type GrokModelSelection = typeof GrokModelSelection.Type;
 
 export const DroidModelSelection = Schema.Struct({
   provider: Schema.Literal("droid"),
+  profileId: ProviderProfileIdWithDefault,
   model: TrimmedNonEmptyString,
   options: Schema.optional(DroidModelOptions),
 });
@@ -125,6 +140,7 @@ export type DroidModelSelection = typeof DroidModelSelection.Type;
 
 export const OpenCodeModelSelection = Schema.Struct({
   provider: Schema.Literal("opencode"),
+  profileId: ProviderProfileIdWithDefault,
   model: TrimmedNonEmptyString,
   options: Schema.optional(OpenCodeModelOptions),
 });
@@ -132,6 +148,7 @@ export type OpenCodeModelSelection = typeof OpenCodeModelSelection.Type;
 
 export const KiloModelSelection = Schema.Struct({
   provider: Schema.Literal("kilo"),
+  profileId: ProviderProfileIdWithDefault,
   model: TrimmedNonEmptyString,
   options: Schema.optional(OpenCodeModelOptions),
 });
@@ -139,6 +156,7 @@ export type KiloModelSelection = typeof KiloModelSelection.Type;
 
 export const PiModelSelection = Schema.Struct({
   provider: Schema.Literal("pi"),
+  profileId: ProviderProfileIdWithDefault,
   model: TrimmedNonEmptyString,
   options: Schema.optional(PiModelOptions),
 });

--- a/packages/contracts/src/provider.test.ts
+++ b/packages/contracts/src/provider.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { Schema } from "effect";
 
-import { ProviderSendTurnInput, ProviderSessionStartInput } from "./provider";
+import {
+  ProviderEvent,
+  ProviderSendTurnInput,
+  ProviderSession,
+  ProviderSessionStartInput,
+} from "./provider";
 
 const decodeProviderSessionStartInput = Schema.decodeUnknownSync(ProviderSessionStartInput);
 const decodeProviderSendTurnInput = Schema.decodeUnknownSync(ProviderSendTurnInput);
@@ -85,6 +90,41 @@ describe("ProviderSessionStartInput", () => {
     expect(parsed.providerOptions?.claudeAgent?.permissionMode).toBe("plan");
     expect(parsed.providerOptions?.claudeAgent?.maxThinkingTokens).toBe(12_000);
     expect(parsed.runtimeMode).toBe("full-access");
+  });
+
+  it("carries explicit profile identity through start and session payloads", () => {
+    const start = decodeProviderSessionStartInput({
+      threadId: "thread-profile",
+      provider: "codex",
+      profileId: "work",
+      runtimeMode: "full-access",
+    });
+    const session = Schema.decodeUnknownSync(ProviderSession)({
+      provider: "codex",
+      profileId: "work",
+      status: "ready",
+      runtimeMode: "full-access",
+      threadId: "thread-profile",
+      createdAt: "2026-08-10T00:00:00.000Z",
+      updatedAt: "2026-08-10T00:00:00.000Z",
+    });
+
+    expect(start.profileId).toBe("work");
+    expect(session.profileId).toBe("work");
+  });
+
+  it("keeps profile identity observable on native provider events", () => {
+    const event = Schema.decodeUnknownSync(ProviderEvent)({
+      id: "event-profile",
+      kind: "session",
+      provider: "codex",
+      profileId: "work",
+      threadId: "thread-profile",
+      createdAt: "2026-08-10T00:00:00.000Z",
+      method: "session.started",
+    });
+
+    expect(event.profileId).toBe("work");
   });
 });
 

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -25,6 +25,7 @@ import {
   RuntimeMode,
 } from "./orchestration";
 import { ProviderMentionReference, ProviderSkillReference } from "./providerDiscovery";
+import { ProviderProfileId } from "./providerProfile";
 
 const ProviderSessionStatus = Schema.Literals([
   "connecting",
@@ -36,6 +37,7 @@ const ProviderSessionStatus = Schema.Literals([
 
 export const ProviderSession = Schema.Struct({
   provider: ProviderKind,
+  profileId: Schema.optional(ProviderProfileId),
   status: ProviderSessionStatus,
   runtimeMode: RuntimeMode,
   cwd: Schema.optional(TrimmedNonEmptyString),
@@ -52,6 +54,7 @@ export type ProviderSession = typeof ProviderSession.Type;
 export const ProviderSessionStartInput = Schema.Struct({
   threadId: ThreadId,
   provider: Schema.optional(ProviderKind),
+  profileId: Schema.optional(ProviderProfileId),
   lifecycleGeneration: Schema.optional(TrimmedNonEmptyString),
   cwd: Schema.optional(TrimmedNonEmptyString),
   modelSelection: Schema.optional(ModelSelection),
@@ -84,6 +87,7 @@ export type ProviderSteerTurnInput = typeof ProviderSteerTurnInput.Type;
 export const ProviderForkThreadInput = Schema.Struct({
   sourceThreadId: ThreadId,
   threadId: ThreadId,
+  profileId: Schema.optional(ProviderProfileId),
   sourceResumeCursor: Schema.optional(Schema.Unknown),
   sourceCwd: Schema.optional(TrimmedNonEmptyString),
   cwd: Schema.optional(TrimmedNonEmptyString),
@@ -177,6 +181,7 @@ export const ProviderEvent = Schema.Struct({
   id: EventId,
   kind: ProviderEventKind,
   provider: ProviderKind,
+  profileId: Schema.optional(ProviderProfileId),
   threadId: ThreadId,
   createdAt: IsoDateTime,
   method: TrimmedNonEmptyString,

--- a/packages/contracts/src/providerProfile.test.ts
+++ b/packages/contracts/src/providerProfile.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+
+import { it } from "@effect/vitest";
+import { Effect, Schema } from "effect";
+
+import { DEFAULT_PROVIDER_PROFILE_ID, ProviderProfileId } from "./providerProfile";
+
+const decodeProviderProfileId = Schema.decodeUnknownEffect(ProviderProfileId);
+
+it.effect("decodes stable provider profile slugs", () =>
+  Effect.gen(function* () {
+    assert.equal(yield* decodeProviderProfileId("work_account"), "work_account");
+    assert.equal(DEFAULT_PROVIDER_PROFILE_ID, "default");
+  }),
+);
+
+it("rejects provider profile ids that are unsafe as routing keys", () => {
+  assert.equal(Schema.is(ProviderProfileId)("../work"), false);
+  assert.equal(Schema.is(ProviderProfileId)("Work Account"), false);
+  assert.equal(Schema.is(ProviderProfileId)(""), false);
+});

--- a/packages/contracts/src/providerProfile.ts
+++ b/packages/contracts/src/providerProfile.ts
@@ -1,0 +1,14 @@
+import { Schema } from "effect";
+
+import { TrimmedNonEmptyString } from "./baseSchemas";
+
+const PROVIDER_PROFILE_ID_MAX_LENGTH = 64;
+const PROVIDER_PROFILE_ID_PATTERN = /^[a-z][a-z0-9_-]*$/u;
+
+export const ProviderProfileId = TrimmedNonEmptyString.check(
+  Schema.isMaxLength(PROVIDER_PROFILE_ID_MAX_LENGTH),
+  Schema.isPattern(PROVIDER_PROFILE_ID_PATTERN),
+).pipe(Schema.brand("ProviderProfileId"));
+export type ProviderProfileId = typeof ProviderProfileId.Type;
+
+export const DEFAULT_PROVIDER_PROFILE_ID = ProviderProfileId.makeUnsafe("default");

--- a/packages/contracts/src/providerRuntime.test.ts
+++ b/packages/contracts/src/providerRuntime.test.ts
@@ -11,6 +11,29 @@ describe("ProviderRuntimeEvent", () => {
     expect(eventType).toBe("turn.steered");
   });
 
+  it("decodes optional provider profile identity", () => {
+    const profiled = decodeRuntimeEvent({
+      type: "session.started",
+      eventId: "event-profiled-runtime",
+      provider: "codex",
+      profileId: "work",
+      createdAt: "2026-08-10T00:00:00.000Z",
+      threadId: "thread-profiled-runtime",
+      payload: {},
+    });
+    const legacy = decodeRuntimeEvent({
+      type: "session.started",
+      eventId: "event-legacy-runtime",
+      provider: "codex",
+      createdAt: "2026-08-10T00:00:01.000Z",
+      threadId: "thread-legacy-runtime",
+      payload: {},
+    });
+
+    expect(profiled.profileId).toBe("work");
+    expect(legacy.profileId).toBeUndefined();
+  });
+
   it("decodes turn.tasks.updated for task-list rendering", () => {
     const parsed = decodeRuntimeEvent({
       type: "turn.tasks.updated",

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -13,6 +13,7 @@ import {
   TurnId,
 } from "./baseSchemas";
 import { ProviderKind } from "./orchestration";
+import { ProviderProfileId } from "./providerProfile";
 
 const TrimmedNonEmptyStringSchema = TrimmedNonEmptyString;
 const UnknownRecordSchema = Schema.Record(Schema.String, Schema.Unknown);
@@ -261,6 +262,7 @@ const RuntimeErrorType = Schema.Literal("runtime.error");
 const ProviderRuntimeEventBase = Schema.Struct({
   eventId: EventId,
   provider: ProviderKind,
+  profileId: Schema.optional(ProviderProfileId),
   threadId: ThreadId,
   createdAt: IsoDateTime,
   turnId: Schema.optional(TurnId),

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -2,6 +2,7 @@ import { Schema } from "effect";
 import { TrimmedString } from "./baseSchemas";
 import { DEFAULT_GIT_TEXT_GENERATION_MODEL } from "./model";
 import { ModelSelection, ProviderKind, ThreadEnvironmentMode } from "./orchestration";
+import { DEFAULT_PROVIDER_PROFILE_ID, ProviderProfileId } from "./providerProfile";
 
 const StringSetting = TrimmedString.check(Schema.isMaxLength(4096));
 const CustomModels = Schema.Array(Schema.String.check(Schema.isMaxLength(256))).pipe(
@@ -98,6 +99,7 @@ export const ServerSettings = Schema.Struct({
   textGenerationModelSelection: ModelSelection.pipe(
     Schema.withDecodingDefault(() => ({
       provider: "codex" as const,
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: DEFAULT_GIT_TEXT_GENERATION_MODEL,
     })),
   ),
@@ -129,6 +131,7 @@ export const DEFAULT_SERVER_SETTINGS_VIEW: ServerSettingsView = Schema.decodeSyn
 
 const ModelSelectionPatch = Schema.Struct({
   provider: Schema.optionalKey(ProviderKind),
+  profileId: Schema.optionalKey(ProviderProfileId),
   model: Schema.optionalKey(Schema.String.check(Schema.isMaxLength(256))),
   options: Schema.optionalKey(Schema.Unknown),
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -228,6 +228,10 @@
       "types": "./src/providerMetadata.ts",
       "import": "./src/providerMetadata.ts"
     },
+    "./providerTarget": {
+      "types": "./src/providerTarget.ts",
+      "import": "./src/providerTarget.ts"
+    },
     "./formatBytes": {
       "types": "./src/formatBytes.ts",
       "import": "./src/formatBytes.ts"

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   CLAUDE_API_EFFORT_OPTIONS,
   CLAUDE_CODE_MODE_OPTIONS,
   CLAUDE_PROMPT_MODE_OPTIONS,
@@ -645,6 +646,7 @@ describe("resolveApiModelId", () => {
     expect(
       resolveApiModelId({
         provider: "claudeAgent",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "claude-opus-4-6",
         options: { autoCompactWindow: "1m" },
       }),
@@ -652,6 +654,7 @@ describe("resolveApiModelId", () => {
     expect(
       resolveApiModelId({
         provider: "claudeAgent",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "claude-sonnet-5",
         options: { autoCompactWindow: "1m" },
       }),
@@ -662,6 +665,7 @@ describe("resolveApiModelId", () => {
     expect(
       resolveApiModelId({
         provider: "claudeAgent",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
         model: "claude-opus-4-6",
         options: { contextWindow: "200k" },
       }),
@@ -682,6 +686,7 @@ describe("claudeSelectionRequiresRestart", () => {
   ) =>
     ({
       provider: "claudeAgent",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model,
       ...(options ? { options } : {}),
     }) as Parameters<typeof claudeSelectionRequiresRestart>[1];
@@ -689,8 +694,8 @@ describe("claudeSelectionRequiresRestart", () => {
   it("never restarts for non-Claude selections", () => {
     expect(
       claudeSelectionRequiresRestart(
-        { provider: "codex", model: "gpt-5.5" },
-        { provider: "codex", model: "gpt-5.4" },
+        { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.5" },
+        { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5.4" },
       ),
     ).toBe(false);
   });

--- a/packages/shared/src/providerTarget.test.ts
+++ b/packages/shared/src/providerTarget.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+
+import { ProviderProfileId } from "@synara/contracts";
+import { it } from "@effect/vitest";
+
+import {
+  defaultProviderTarget,
+  providerTargetFromModelSelection,
+  providerTargetFromSource,
+  providerTargetsEqual,
+} from "./providerTarget";
+
+it("resolves legacy provider sources to the default provider profile", () => {
+  assert.deepEqual(
+    providerTargetFromSource({
+      provider: "codex",
+    }),
+    {
+      provider: "codex",
+      profileId: "default",
+    },
+  );
+});
+
+it("preserves explicit provider profile routing", () => {
+  const target = providerTargetFromModelSelection({
+    provider: "codex",
+    profileId: ProviderProfileId.makeUnsafe("work"),
+    model: "gpt-5.6-codex",
+  });
+
+  assert.deepEqual(target, {
+    provider: "codex",
+    profileId: "work",
+  });
+  assert.equal(providerTargetsEqual(target, defaultProviderTarget("codex")), false);
+  assert.equal(providerTargetsEqual(target, { ...target }), true);
+});

--- a/packages/shared/src/providerTarget.ts
+++ b/packages/shared/src/providerTarget.ts
@@ -1,0 +1,36 @@
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  type ModelSelection,
+  type ProviderKind,
+  type ProviderProfileId,
+  type ProviderTarget,
+} from "@synara/contracts";
+
+interface ProviderTargetSource {
+  readonly provider: ProviderKind;
+  readonly profileId?: ProviderProfileId | undefined;
+}
+
+export function defaultProviderTarget(provider: ProviderKind): ProviderTarget {
+  return {
+    provider,
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
+  };
+}
+
+export function providerTargetFromModelSelection(
+  modelSelection: ModelSelection,
+): ProviderTarget {
+  return providerTargetFromSource(modelSelection);
+}
+
+export function providerTargetFromSource(source: ProviderTargetSource): ProviderTarget {
+  return {
+    provider: source.provider,
+    profileId: source.profileId ?? DEFAULT_PROVIDER_PROFILE_ID,
+  };
+}
+
+export function providerTargetsEqual(left: ProviderTarget, right: ProviderTarget): boolean {
+  return left.provider === right.provider && left.profileId === right.profileId;
+}

--- a/packages/shared/src/serverSettings.test.ts
+++ b/packages/shared/src/serverSettings.test.ts
@@ -1,9 +1,84 @@
-import { DEFAULT_SERVER_SETTINGS, ProviderSessionStartInput } from "@synara/contracts";
+import {
+  DEFAULT_MODEL_BY_PROVIDER,
+  DEFAULT_PROVIDER_PROFILE_ID,
+  DEFAULT_SERVER_SETTINGS,
+  ProviderProfileId,
+  ProviderSessionStartInput,
+} from "@synara/contracts";
 import { Schema } from "effect";
 import { describe, expect, it } from "vitest";
-import { providerStartOptionsFromServerSettings } from "./serverSettings";
+import { applyServerSettingsPatch, providerStartOptionsFromServerSettings } from "./serverSettings";
 
 const decodeProviderSessionStartInput = Schema.decodeUnknownSync(ProviderSessionStartInput);
+
+describe("applyServerSettingsPatch", () => {
+  const workProfileId = ProviderProfileId.makeUnsafe("work");
+  const settingsWithWorkProfile = {
+    ...DEFAULT_SERVER_SETTINGS,
+    textGenerationModelSelection: {
+      provider: "codex" as const,
+      profileId: workProfileId,
+      model: "gpt-5.6-codex",
+      options: { reasoningEffort: "high" as const },
+    },
+  };
+
+  it("preserves the profile when the model changes", () => {
+    const next = applyServerSettingsPatch(settingsWithWorkProfile, {
+      textGenerationModelSelection: {
+        provider: "codex",
+        model: "gpt-5.5",
+      },
+    });
+
+    expect(next.textGenerationModelSelection).toEqual({
+      provider: "codex",
+      profileId: workProfileId,
+      model: "gpt-5.5",
+    });
+  });
+
+  it("resets the profile when the provider changes without an explicit profile", () => {
+    const next = applyServerSettingsPatch(settingsWithWorkProfile, {
+      textGenerationModelSelection: { provider: "claudeAgent" },
+    });
+
+    expect(next.textGenerationModelSelection).toEqual({
+      provider: "claudeAgent",
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
+      model: DEFAULT_MODEL_BY_PROVIDER.claudeAgent,
+    });
+  });
+
+  it("changes profiles without carrying model options between accounts", () => {
+    const personalProfileId = ProviderProfileId.makeUnsafe("personal");
+    const next = applyServerSettingsPatch(settingsWithWorkProfile, {
+      textGenerationModelSelection: { profileId: personalProfileId },
+    });
+
+    expect(next.textGenerationModelSelection).toEqual({
+      provider: "codex",
+      profileId: personalProfileId,
+      model: "gpt-5.6-codex",
+    });
+  });
+
+  it("preserves an explicit profile when changing providers", () => {
+    const claudeWorkProfileId = ProviderProfileId.makeUnsafe("claude_work");
+    const next = applyServerSettingsPatch(settingsWithWorkProfile, {
+      textGenerationModelSelection: {
+        provider: "claudeAgent",
+        profileId: claudeWorkProfileId,
+      },
+    });
+
+    expect(next.textGenerationModelSelection).toEqual({
+      provider: "claudeAgent",
+      profileId: claudeWorkProfileId,
+      model: DEFAULT_MODEL_BY_PROVIDER.claudeAgent,
+    });
+  });
+});
 
 describe("providerStartOptionsFromServerSettings", () => {
   it("omits blank launch settings from provider session input", () => {

--- a/packages/shared/src/serverSettings.ts
+++ b/packages/shared/src/serverSettings.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_MODEL_BY_PROVIDER,
+  DEFAULT_PROVIDER_PROFILE_ID,
   type ModelSelection,
   type ProviderStartOptions,
   type ServerSettings,
@@ -10,7 +11,17 @@ import { deepMerge, type DeepPartial } from "./Struct";
 function shouldReplaceTextGenerationModelSelection(
   patch: ServerSettingsPatch["textGenerationModelSelection"] | undefined,
 ): boolean {
-  return Boolean(patch && (patch.provider !== undefined || patch.model !== undefined));
+  return Boolean(
+    patch &&
+      (patch.provider !== undefined || patch.profileId !== undefined || patch.model !== undefined),
+  );
+}
+
+function changesTextGenerationProvider(
+  current: ModelSelection,
+  patch: NonNullable<ServerSettingsPatch["textGenerationModelSelection"]>,
+): boolean {
+  return patch.provider !== undefined && patch.provider !== current.provider;
 }
 
 export function applyServerSettingsPatch(
@@ -24,12 +35,19 @@ export function applyServerSettingsPatch(
   }
 
   const provider = selectionPatch.provider ?? current.textGenerationModelSelection.provider;
+  const providerChanged = changesTextGenerationProvider(
+    current.textGenerationModelSelection,
+    selectionPatch,
+  );
+  const profileId =
+    selectionPatch.profileId ??
+    (providerChanged
+      ? DEFAULT_PROVIDER_PROFILE_ID
+      : current.textGenerationModelSelection.profileId);
   const model =
     selectionPatch.model ??
-    (selectionPatch.provider &&
-    selectionPatch.provider !== "pi" &&
-    selectionPatch.provider !== current.textGenerationModelSelection.provider
-      ? DEFAULT_MODEL_BY_PROVIDER[selectionPatch.provider]
+    (providerChanged && provider !== "pi"
+      ? DEFAULT_MODEL_BY_PROVIDER[provider]
       : current.textGenerationModelSelection.model);
   const options = shouldReplaceTextGenerationModelSelection(selectionPatch)
     ? selectionPatch.options
@@ -39,6 +57,7 @@ export function applyServerSettingsPatch(
     ...next,
     textGenerationModelSelection: {
       provider,
+      profileId,
       model,
       ...(options !== undefined ? { options } : {}),
     } as ModelSelection,


### PR DESCRIPTION
## Summary

Introduces the provider-profile identity foundation:

- adds `ProviderProfileId` and complete `{ provider, profileId }` targets
- carries profile identity through model selections, settings, drafts, contracts, projections, and runtime schemas
- treats legacy data without a profile as the reserved `default` profile
- documents the routing invariants and staged delivery plan

This is identity and compatibility work only. Executable profiles remain restricted to `default` until server-owned profile configuration is implemented.

## Stack

Base: `main` at `2a032f8d5`  
Head: `1800df5c7`

> **Release gate:** Foundation PR 1 of 3. PRs 1–3 are coupled, must merge in order, and must all land before release. Do not ship a partial foundation.

## Replacement for #254

This is a fresh replacement for the implementation approach in #254. Synara's provider runtime, orchestration, persistence, and composer architecture have changed substantially since that PR, so rebasing its code would preserve obsolete ownership assumptions.

The requirements and failure cases from #254 remain useful historical context. This PR deliberately does not close #254.

## Safety and compatibility

- Missing legacy profile identifiers decode as `default`.
- Existing provider-only settings remain associated with the default profile.
- Only profile identifiers cross contracts; credentials and launch configuration remain server-owned.
- Most of the broad file surface is mechanical default-profile propagation and compatibility coverage.

## Validation

- `bun run --cwd apps/server test`: 325 files passed, 3 skipped; 3,706 tests passed, 16 skipped.
- Contracts: 206/206 passed.
- Shared: 538 passed, 1 skipped.
- Web node suite: 299 files passed; 3,798/3,798 tests passed.
- Slice and stack-top diff checks passed.

`bun fmt`, `bun lint`, and `bun typecheck` were not run because repository policy requires explicit user permission; permission is pending.
