### PR TITLE
feat(server): bind provider runtimes to exact account targets

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1801,6 +1801,7 @@ const make = Effect.gen(function* () {
                 ? parentThread.modelSelection
                 : {
                     provider: parentThread.modelSelection.provider,
+                    profileId: parentThread.modelSelection.profileId,
                     model: identity.model,
                   }
               : undefined;

--- a/apps/server/src/persistence/Layers/ProviderSessionRuntime.ts
+++ b/apps/server/src/persistence/Layers/ProviderSessionRuntime.ts
@@ -39,6 +39,7 @@ const makeProviderSessionRuntimeRepository = Effect.gen(function* () {
         INSERT INTO provider_session_runtime (
           thread_id,
           provider_name,
+          provider_profile_id,
           adapter_key,
           runtime_mode,
           status,
@@ -50,6 +51,7 @@ const makeProviderSessionRuntimeRepository = Effect.gen(function* () {
         VALUES (
           ${runtime.threadId},
           ${runtime.providerName},
+          ${runtime.profileId},
           ${runtime.adapterKey},
           ${runtime.runtimeMode},
           ${runtime.status},
@@ -61,6 +63,7 @@ const makeProviderSessionRuntimeRepository = Effect.gen(function* () {
         ON CONFLICT (thread_id)
         DO UPDATE SET
           provider_name = excluded.provider_name,
+          provider_profile_id = excluded.provider_profile_id,
           adapter_key = excluded.adapter_key,
           runtime_mode = excluded.runtime_mode,
           status = excluded.status,
@@ -79,6 +82,7 @@ const makeProviderSessionRuntimeRepository = Effect.gen(function* () {
         SELECT
           thread_id AS "threadId",
           provider_name AS "providerName",
+          provider_profile_id AS "profileId",
           adapter_key AS "adapterKey",
           runtime_mode AS "runtimeMode",
           status,
@@ -99,6 +103,7 @@ const makeProviderSessionRuntimeRepository = Effect.gen(function* () {
         SELECT
           thread_id AS "threadId",
           provider_name AS "providerName",
+          provider_profile_id AS "profileId",
           adapter_key AS "adapterKey",
           runtime_mode AS "runtimeMode",
           status,

--- a/apps/server/src/persistence/Migrations.test.ts
+++ b/apps/server/src/persistence/Migrations.test.ts
@@ -291,10 +291,11 @@ managedAttachmentsLegacyLayer("managed attachment migration after private migrat
         [87, "DropUnusedOrchestrationEventIndexes"],
         [88, "ProjectionThreadsSettledAt"],
         [89, "RecoverRetentionHiddenThreads"],
+        [90, "ProviderProfilesFoundation"],
       ]);
 
       const tracker = yield* trackerRows(sql);
-      assert.deepStrictEqual(tracker.slice(-36), [
+      assert.deepStrictEqual(tracker.slice(-37), [
         { migration_id: 54, name: "DurableProviderCommandDelivery" },
         { migration_id: 55, name: "ManagedAttachments" },
         { migration_id: 56, name: "CommandReceiptFingerprints" },
@@ -331,6 +332,7 @@ managedAttachmentsLegacyLayer("managed attachment migration after private migrat
         { migration_id: 87, name: "DropUnusedOrchestrationEventIndexes" },
         { migration_id: 88, name: "ProjectionThreadsSettledAt" },
         { migration_id: 89, name: "RecoverRetentionHiddenThreads" },
+        { migration_id: 90, name: "ProviderProfilesFoundation" },
       ]);
       const preserved = yield* sql<{ readonly count: number }>`
         SELECT COUNT(*) AS count FROM orchestration_consumer_state
@@ -412,6 +414,7 @@ agentGatewayRetentionLegacyLayer(
           [87, "DropUnusedOrchestrationEventIndexes"],
           [88, "ProjectionThreadsSettledAt"],
           [89, "RecoverRetentionHiddenThreads"],
+          [90, "ProviderProfilesFoundation"],
         ]);
 
         const columns = yield* sql<{ readonly name: string }>`
@@ -496,11 +499,12 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
         [87, "DropUnusedOrchestrationEventIndexes"],
         [88, "ProjectionThreadsSettledAt"],
         [89, "RecoverRetentionHiddenThreads"],
+        [90, "ProviderProfilesFoundation"],
       ]);
 
       const tracker = yield* trackerRows(sql);
       assert.deepStrictEqual(
-        tracker.slice(-20).map((row) => [row.migration_id, row.name]),
+        tracker.slice(-21).map((row) => [row.migration_id, row.name]),
         [
           [70, "AgentGatewayOperations"],
           [71, "ProjectionThreadsGatewayProvenance"],
@@ -522,6 +526,7 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
           [87, "DropUnusedOrchestrationEventIndexes"],
           [88, "ProjectionThreadsSettledAt"],
           [89, "RecoverRetentionHiddenThreads"],
+          [90, "ProviderProfilesFoundation"],
         ],
       );
 
@@ -601,11 +606,12 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
         [87, "DropUnusedOrchestrationEventIndexes"],
         [88, "ProjectionThreadsSettledAt"],
         [89, "RecoverRetentionHiddenThreads"],
+        [90, "ProviderProfilesFoundation"],
       ]);
 
       const tracker = yield* trackerRows(sql);
       assert.deepStrictEqual(
-        tracker.slice(-16).map((row) => [row.migration_id, row.name]),
+        tracker.slice(-17).map((row) => [row.migration_id, row.name]),
         [
           [74, "ExternalMcpIntegrations"],
           [75, "ExternalMcpActiveCapacity"],
@@ -623,6 +629,7 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
           [87, "DropUnusedOrchestrationEventIndexes"],
           [88, "ProjectionThreadsSettledAt"],
           [89, "RecoverRetentionHiddenThreads"],
+          [90, "ProviderProfilesFoundation"],
         ],
       );
       const preservedSpaces = yield* sql<{ readonly spaceId: string }>`

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -105,6 +105,7 @@ import Migration0086 from "./Migrations/086_NormalizeStudioThreadWorkspaces.ts";
 import Migration0087 from "./Migrations/087_DropUnusedOrchestrationEventIndexes.ts";
 import Migration0088 from "./Migrations/088_ProjectionThreadsSettledAt.ts";
 import Migration0089 from "./Migrations/089_RecoverRetentionHiddenThreads.ts";
+import Migration0090 from "./Migrations/090_ProviderProfilesFoundation.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -209,6 +210,7 @@ export const migrationEntries = [
   [87, "DropUnusedOrchestrationEventIndexes", Migration0087],
   [88, "ProjectionThreadsSettledAt", Migration0088],
   [89, "RecoverRetentionHiddenThreads", Migration0089],
+  [90, "ProviderProfilesFoundation", Migration0090],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/090_ProviderProfilesFoundation.test.ts
+++ b/apps/server/src/persistence/Migrations/090_ProviderProfilesFoundation.test.ts
@@ -1,0 +1,45 @@
+import { assert, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+layer("090_ProviderProfilesFoundation", (it) => {
+  it.effect("backfills the default profile on existing provider bindings", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations({ toMigrationInclusive: 89 });
+
+      yield* sql`
+        INSERT INTO provider_session_runtime (
+          thread_id,
+          provider_name,
+          adapter_key,
+          runtime_mode,
+          status,
+          lifecycle_generation,
+          last_seen_at
+        ) VALUES (
+          'thread-legacy-profile',
+          'codex',
+          'codex',
+          'full-access',
+          'stopped',
+          'legacy-profile-generation',
+          '2026-08-10T00:00:00.000Z'
+        )
+      `;
+      assert.deepStrictEqual(yield* runMigrations(), [[90, "ProviderProfilesFoundation"]]);
+
+      const runtimeRows = yield* sql<{ readonly profileId: string }>`
+        SELECT provider_profile_id AS "profileId"
+        FROM provider_session_runtime
+        WHERE thread_id = 'thread-legacy-profile'
+      `;
+      assert.deepStrictEqual(runtimeRows, [{ profileId: "default" }]);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/090_ProviderProfilesFoundation.ts
+++ b/apps/server/src/persistence/Migrations/090_ProviderProfilesFoundation.ts
@@ -1,0 +1,15 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { columnExists } from "./schemaHelpers.ts";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  if (!(yield* columnExists(sql, "provider_session_runtime", "provider_profile_id"))) {
+    yield* sql`
+      ALTER TABLE provider_session_runtime
+      ADD COLUMN provider_profile_id TEXT NOT NULL DEFAULT 'default'
+    `;
+  }
+});

--- a/apps/server/src/persistence/Services/ProviderSessionRuntime.ts
+++ b/apps/server/src/persistence/Services/ProviderSessionRuntime.ts
@@ -7,6 +7,7 @@
  */
 import {
   IsoDateTime,
+  ProviderProfileId,
   ProviderSessionRuntimeStatus,
   RuntimeMode,
   ThreadId,
@@ -19,6 +20,7 @@ import type { ProviderSessionRuntimeRepositoryError } from "../Errors.ts";
 export const ProviderSessionRuntime = Schema.Struct({
   threadId: ThreadId,
   providerName: Schema.String,
+  profileId: ProviderProfileId,
   adapterKey: Schema.String,
   runtimeMode: RuntimeMode,
   status: ProviderSessionRuntimeStatus,

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -5,6 +5,7 @@ import {
   ApprovalRequestId,
   EventId,
   ProviderItemId,
+  ProviderProfileId,
   type ProviderApprovalDecision,
   type ProviderEvent,
   type ProviderSession,
@@ -33,6 +34,7 @@ const asThreadId = (value: string): ThreadId => ThreadId.makeUnsafe(value);
 const asTurnId = (value: string): TurnId => TurnId.makeUnsafe(value);
 const asEventId = (value: string): EventId => EventId.makeUnsafe(value);
 const asItemId = (value: string): ProviderItemId => ProviderItemId.makeUnsafe(value);
+const asProfileId = (value: string): ProviderProfileId => ProviderProfileId.makeUnsafe(value);
 
 class FakeCodexManager extends CodexAppServerManager {
   public startSessionImpl = vi.fn(
@@ -465,6 +467,30 @@ const lifecycleLayer = it.layer(
 );
 
 lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
+  it.effect("propagates provider profile identity to canonical runtime events", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+
+      lifecycleManager.emit("event", {
+        id: asEventId("evt-profile-runtime"),
+        kind: "session",
+        provider: "codex",
+        profileId: asProfileId("work"),
+        threadId: asThreadId("thread-1"),
+        createdAt: new Date().toISOString(),
+        method: "session/closed",
+        message: "Session stopped",
+      } satisfies ProviderEvent);
+
+      const firstEvent = yield* Fiber.join(firstEventFiber);
+      assert.equal(firstEvent._tag, "Some");
+      if (firstEvent._tag === "Some") {
+        assert.equal(firstEvent.value.profileId, "work");
+      }
+    }),
+  );
+
   it.effect("normalizes whitespace in configuration warnings at the provider boundary", () =>
     Effect.gen(function* () {
       const adapter = yield* CodexAdapter;

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -792,6 +792,7 @@ function runtimeEventBase(
   return {
     eventId: event.id,
     provider: event.provider,
+    ...(event.profileId !== undefined ? { profileId: event.profileId } : {}),
     threadId: canonicalThreadId,
     createdAt: event.createdAt,
     ...(event.lifecycleGeneration !== undefined

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   EventId,
   type ProviderKind,
   type ProviderComposerCapabilities,
@@ -3837,7 +3838,13 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         const context = ensureAdapterSessionContext(input.threadId);
         const modelSelection =
           input.modelSelection ??
-          (context.session.model ? { provider, model: context.session.model } : undefined);
+          (context.session.model
+            ? {
+                provider,
+                profileId: context.session.profileId ?? DEFAULT_PROVIDER_PROFILE_ID,
+                model: context.session.model,
+              }
+            : undefined);
         const parsedModel = parseOpenCodeModelSlug(modelSelection?.model);
         if (!parsedModel) {
           return yield* new ProviderAdapterValidationError({

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -9,6 +9,8 @@ import path from "node:path";
 
 import type {
   ProviderApprovalDecision,
+  ProviderForkThreadInput,
+  ProviderForkThreadResult,
   ProviderRuntimeEvent,
   ProviderSendTurnInput,
   ProviderSession,
@@ -17,10 +19,11 @@ import type {
   ProviderTurnStartResult,
 } from "@synara/contracts";
 import {
-  DEFAULT_PROVIDER_PROFILE_ID,
   ApprovalRequestId,
+  DEFAULT_PROVIDER_PROFILE_ID,
   EventId,
   type ProviderKind,
+  ProviderProfileId,
   ProviderSessionStartInput,
   ThreadId,
   TurnId,
@@ -74,6 +77,7 @@ const asRequestId = (value: string): ApprovalRequestId => ApprovalRequestId.make
 const asEventId = (value: string): EventId => EventId.makeUnsafe(value);
 const asThreadId = (value: string): ThreadId => ThreadId.makeUnsafe(value);
 const asTurnId = (value: string): TurnId => TurnId.makeUnsafe(value);
+const asProfileId = (value: string): ProviderProfileId => ProviderProfileId.makeUnsafe(value);
 
 type LegacyProviderRuntimeEvent = {
   readonly type: string;
@@ -165,6 +169,30 @@ function makeFakeCodexAdapter(
         turnId: TurnId.makeUnsafe(`turn-${String(input.threadId)}`),
       });
     },
+  );
+
+  const forkThread = vi.fn(
+    (
+      input: ProviderForkThreadInput,
+    ): Effect.Effect<ProviderForkThreadResult, ProviderAdapterError> =>
+      Effect.sync(() => {
+        const now = new Date().toISOString();
+        sessions.set(input.threadId, {
+          provider,
+          profileId: input.profileId ?? DEFAULT_PROVIDER_PROFILE_ID,
+          status: "ready",
+          runtimeMode: input.runtimeMode,
+          threadId: input.threadId,
+          resumeCursor: { opaque: `fork-${String(input.threadId)}` },
+          cwd: input.cwd ?? process.cwd(),
+          createdAt: now,
+          updatedAt: now,
+        });
+        return {
+          threadId: input.threadId,
+          resumeCursor: { opaque: `fork-${String(input.threadId)}` },
+        };
+      }),
   );
 
   const steerTurn = vi.fn(
@@ -270,6 +298,7 @@ function makeFakeCodexAdapter(
         : {}),
     },
     startSession,
+    forkThread,
     sendTurn,
     steerTurn,
     startReview,
@@ -315,6 +344,7 @@ function makeFakeCodexAdapter(
     waitForRuntimeSubscribers,
     updateSession,
     startSession,
+    forkThread,
     sendTurn,
     steerTurn,
     startReview,
@@ -432,6 +462,30 @@ function makeProviderServiceLayer(
 }
 
 const routing = makeProviderServiceLayer();
+const profileRouting = makeProviderServiceLayer({
+  resolveProviderProfile: ({ target }) => Effect.succeed(target),
+});
+const profileAdmissionJournal: ProviderRuntimeEvent[] = [];
+let profileAdmissionPersistenceGate:
+  | {
+      readonly eventId: EventId;
+      readonly entered: Deferred.Deferred<void>;
+      readonly release: Deferred.Deferred<void>;
+    }
+  | undefined;
+const profileEventAdmission = makeProviderServiceLayer({
+  resolveProviderProfile: ({ target }) => Effect.succeed(target),
+  persistRuntimeEvent: (event) =>
+    Effect.gen(function* () {
+      const gate = profileAdmissionPersistenceGate;
+      if (gate !== undefined && gate.eventId === event.eventId) {
+        yield* Deferred.succeed(gate.entered, undefined);
+        yield* Deferred.await(gate.release);
+      }
+      profileAdmissionJournal.push(event);
+      return { sequence: profileAdmissionJournal.length, event };
+    }),
+});
 const rotationRetryPersistAttempts = new Map<string, number>();
 const ROTATION_RETRY_FAILURE_EVENT_ID = "terminal-rotation-settlement-retry";
 const rotationRetry = makeProviderServiceLayer({
@@ -591,6 +645,97 @@ it.effect(
 );
 
 it.effect(
+  "ProviderServiceLive preserves persisted profiles when stopAll sees ambiguous live targets",
+  () =>
+    Effect.gen(function* () {
+      const tempDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "synara-provider-service-stopall-profile-"),
+      );
+      const dbPath = path.join(tempDir, "orchestration.sqlite");
+      const persistenceLayer = makeSqlitePersistenceLive(dbPath);
+      const runtimeRepositoryLayer = ProviderSessionRuntimeRepositoryLive.pipe(
+        Layer.provide(persistenceLayer),
+      );
+      const directoryLayer = ProviderSessionDirectoryLive.pipe(
+        Layer.provide(runtimeRepositoryLayer),
+      );
+      const codex = makeFakeCodexAdapter();
+      const registry: typeof ProviderAdapterRegistry.Service = {
+        getByProvider: (provider) =>
+          provider === "codex"
+            ? Effect.succeed(codex.adapter)
+            : Effect.fail(new ProviderUnsupportedError({ provider })),
+        listProviders: () => Effect.succeed(["codex"]),
+      };
+      const providerLayer = makeProviderServiceLive({
+        resolveProviderProfile: ({ target }) => Effect.succeed(target),
+      }).pipe(
+        Layer.provide(Layer.succeed(ProviderAdapterRegistry, registry)),
+        Layer.provide(directoryLayer),
+      );
+
+      const startedSessions = yield* Effect.gen(function* () {
+        const provider = yield* ProviderService;
+        const legacyThreadId = asThreadId("thread-stopall-profile-legacy");
+        const mismatchedThreadId = asThreadId("thread-stopall-profile-mismatch");
+        const legacySession = yield* provider.startSession(legacyThreadId, {
+          provider: "codex",
+          profileId: asProfileId("work"),
+          threadId: legacyThreadId,
+          runtimeMode: "full-access",
+        });
+        const mismatchedSession = yield* provider.startSession(mismatchedThreadId, {
+          provider: "codex",
+          profileId: asProfileId("work"),
+          threadId: mismatchedThreadId,
+          runtimeMode: "full-access",
+        });
+
+        codex.updateSession(legacyThreadId, (existing) => {
+          const { profileId: _profileId, ...legacySessionWithoutProfile } = existing;
+          return {
+            ...legacySessionWithoutProfile,
+            resumeCursor: { opaque: "legacy-adapter-cursor" },
+          };
+        });
+        codex.updateSession(mismatchedThreadId, (existing) => ({
+          ...existing,
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          resumeCursor: { opaque: "mismatched-adapter-cursor" },
+        }));
+
+        const observedSessions = yield* provider.listSessions();
+        const observedLegacySession = observedSessions.find(
+          (session) => session.threadId === legacyThreadId,
+        );
+        const observedMismatchedSession = observedSessions.find(
+          (session) => session.threadId === mismatchedThreadId,
+        );
+        assert.equal(observedLegacySession?.profileId, undefined);
+        assert.equal(observedMismatchedSession?.profileId, DEFAULT_PROVIDER_PROFILE_ID);
+
+        return [legacySession, mismatchedSession] as const;
+      }).pipe(Effect.provide(providerLayer));
+
+      for (const session of startedSessions) {
+        const persisted = yield* Effect.gen(function* () {
+          const repository = yield* ProviderSessionRuntimeRepository;
+          return yield* repository.getByThreadId({ threadId: session.threadId });
+        }).pipe(Effect.provide(runtimeRepositoryLayer));
+
+        assert.equal(Option.isSome(persisted), true);
+        if (Option.isSome(persisted)) {
+          assert.equal(persisted.value.profileId, "work");
+          assert.equal(persisted.value.status, "stopped");
+          assert.deepEqual(persisted.value.resumeCursor, session.resumeCursor);
+        }
+      }
+
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.effect(
   "ProviderServiceLive restores rollback routing after restart using persisted thread mapping",
   () =>
     Effect.gen(function* () {
@@ -704,6 +849,63 @@ it.effect(
 );
 
 routing.layer("ProviderServiceLive routing", (it) => {
+  it.effect("rejects non-default profiles before launching an adapter", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const threadId = asThreadId("thread-unsupported-profile");
+      const startCallCount = routing.codex.startSession.mock.calls.length;
+
+      const result = yield* Effect.result(
+        provider.startSession(threadId, {
+          provider: "codex",
+          profileId: asProfileId("work"),
+          threadId,
+          runtimeMode: "full-access",
+        }),
+      );
+
+      assertFailure(
+        result,
+        new ProviderValidationError({
+          operation: "ProviderService.startSession",
+          issue: "Provider profile 'work' is not configured for provider 'codex'.",
+        }),
+      );
+      assert.equal(routing.codex.startSession.mock.calls.length, startCallCount);
+    }),
+  );
+
+  it.effect("rejects persisted non-default profiles before recovery", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-unsupported-profile-recovery");
+      yield* directory.upsert({
+        threadId,
+        provider: "codex",
+        profileId: asProfileId("work"),
+        runtimeMode: "full-access",
+        status: "stopped",
+        resumeCursor: { opaque: "work-profile-cursor" },
+      });
+      const startCallCount = routing.codex.startSession.mock.calls.length;
+
+      const result = yield* Effect.result(
+        provider.sendTurn({ threadId, input: "do not recover", attachments: [] }),
+      );
+
+      assertFailure(
+        result,
+        new ProviderValidationError({
+          operation: "ProviderService.sendTurn",
+          issue: "Provider profile 'work' is not configured for provider 'codex'.",
+        }),
+      );
+      assert.equal(routing.codex.startSession.mock.calls.length, startCallCount);
+      yield* directory.remove(threadId);
+    }),
+  );
+
   it.effect("fork source overrides explicit and persisted resume cursors", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService;
@@ -1928,9 +2130,67 @@ routing.layer("ProviderServiceLive routing", (it) => {
     }),
   );
 
+  it.effect("normalizes legacy persisted model selection during rollback recovery", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-legacy-model-selection-recovery");
+      const providerOptions = {
+        claudeAgent: {
+          binaryPath: "/usr/local/bin/claude",
+          permissionMode: "acceptEdits",
+        },
+      };
+
+      const initial = yield* provider.startSession(threadId, {
+        provider: "claudeAgent",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
+        threadId,
+        cwd: "/tmp/project-legacy-model-selection",
+        runtimeMode: "full-access",
+      });
+      const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      assert.notEqual(binding, undefined);
+      yield* directory.upsert({
+        threadId,
+        provider: "claudeAgent",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
+        runtimePayload: {
+          ...asRuntimePayloadRecord(binding?.runtimePayload),
+          // Raw legacy persistence fixture: old rows predate profileId.
+          modelSelection: {
+            provider: "claudeAgent",
+            model: "claude-opus-4-6",
+            options: { effort: "max" },
+          },
+          providerOptions,
+        },
+      });
+      yield* routing.claude.stopSession(threadId);
+      routing.claude.startSession.mockClear();
+      routing.claude.rollbackThread.mockClear();
+
+      yield* provider.rollbackConversation({ threadId, numTurns: 1 });
+
+      assert.equal(routing.claude.startSession.mock.calls.length, 1);
+      const resumedStartInput = routing.claude.startSession.mock.calls[0]?.[0];
+      assert.deepEqual(resumedStartInput?.modelSelection, {
+        provider: "claudeAgent",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
+        model: "claude-opus-4-6",
+        options: { effort: "max" },
+      });
+      assert.deepEqual(resumedStartInput?.providerOptions, providerOptions);
+      assert.deepEqual(resumedStartInput?.resumeCursor, initial.resumeCursor);
+      assert.equal(routing.claude.rollbackThread.mock.calls.length, 1);
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
   it.effect("routes explicit claudeAgent provider session starts to the claude adapter", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService;
+      routing.claude.startSession.mockClear();
 
       const session = yield* provider.startSession(asThreadId("thread-claude"), {
         provider: "claudeAgent",
@@ -2129,8 +2389,9 @@ routing.layer("ProviderServiceLive routing", (it) => {
         input: "hello",
         attachments: [],
         modelSelection: {
-          provider: "opencode",
-          model: "opencode/minimax-m2.5-free",
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          model: "gpt-5-codex",
         },
       });
       yield* sleep(50);
@@ -2163,9 +2424,9 @@ routing.layer("ProviderServiceLive routing", (it) => {
           assert.equal(runtimePayload.activeTurnId, null);
           assert.equal(runtimePayload.lastRuntimeEvent, "turn.completed");
           assert.deepEqual(runtimePayload.modelSelection, {
-            provider: "opencode",
+            provider: "codex",
             profileId: DEFAULT_PROVIDER_PROFILE_ID,
-            model: "opencode/minimax-m2.5-free",
+            model: "gpt-5-codex",
           });
         }
       }
@@ -2187,9 +2448,9 @@ routing.layer("ProviderServiceLive routing", (it) => {
         model: "gpt-5.1-codex-mini",
       };
       const newerModelSelection = {
-        provider: "opencode" as const,
+        provider: "codex" as const,
         profileId: DEFAULT_PROVIDER_PROFILE_ID,
-        model: "opencode/minimax-m2.5-free",
+        model: "gpt-5.2-codex",
       };
       let olderDispatchStarted = false;
       let releaseOlderDispatch: ((result: ProviderTurnStartResult) => void) | undefined;
@@ -2500,9 +2761,9 @@ routing.layer("ProviderServiceLive routing", (it) => {
       const turnId = asTurnId("turn-steer-persistence");
       const resumeCursor = { cursor: "steer-resume" };
       const modelSelection = {
-        provider: "opencode" as const,
+        provider: "codex" as const,
         profileId: DEFAULT_PROVIDER_PROFILE_ID,
-        model: "opencode/minimax-m2.5-free",
+        model: "gpt-5.2-codex",
       };
 
       yield* provider.startSession(threadId, {
@@ -2546,9 +2807,9 @@ routing.layer("ProviderServiceLive routing", (it) => {
         model: "gpt-5-codex",
       };
       const staleSteerModelSelection = {
-        provider: "opencode" as const,
+        provider: "codex" as const,
         profileId: DEFAULT_PROVIDER_PROFILE_ID,
-        model: "opencode/minimax-m2.5-free",
+        model: "gpt-5.1-codex-mini",
       };
       let steerStarted = false;
       let releaseSteer: ((result: ProviderTurnStartResult) => void) | undefined;
@@ -3037,6 +3298,87 @@ routing.layer("ProviderServiceLive routing", (it) => {
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
+  it.effect("clears a resume cursor without deadlocking a concurrent runtime event", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-clear-resume-runtime-event-race");
+      const eventId = asEventId("runtime-clear-resume-runtime-event-race");
+      const clearWriteEntered = yield* Deferred.make<void>();
+      const releaseClearWrite = yield* Deferred.make<void>();
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* routing.codex.waitForRuntimeSubscribers();
+      const originalUpsert = directory.upsert;
+      let clearWriteGated = false;
+      const upsertSpy = vi.spyOn(directory, "upsert").mockImplementation((input) => {
+        if (
+          !clearWriteGated &&
+          input.threadId === threadId &&
+          input.resumeCursor === null
+        ) {
+          clearWriteGated = true;
+          return Deferred.succeed(clearWriteEntered, undefined).pipe(
+            Effect.andThen(Deferred.await(releaseClearWrite)),
+            Effect.andThen(originalUpsert(input)),
+          );
+        }
+        return originalUpsert(input);
+      });
+
+      return yield* Effect.gen(function* () {
+        assert.equal(typeof provider.clearSessionResumeCursor, "function");
+        if (!provider.clearSessionResumeCursor) {
+          return assert.fail("Expected clearSessionResumeCursor");
+        }
+        const clearFiber = yield* provider
+          .clearSessionResumeCursor({ threadId })
+          .pipe(Effect.forkChild);
+        yield* Deferred.await(clearWriteEntered);
+
+        const observedEvent = yield* provider.streamEvents.pipe(
+          Stream.filter((event) => event.eventId === eventId),
+          Stream.runHead,
+          Effect.forkChild,
+        );
+        yield* sleep(10);
+        routing.codex.emit({
+          type: "session.state.changed",
+          eventId,
+          provider: "codex",
+          createdAt: "2026-08-10T00:00:00.000Z",
+          threadId,
+          payload: { state: "ready" },
+        });
+        yield* sleep(25);
+        yield* Deferred.succeed(releaseClearWrite, undefined);
+
+        assert.equal(
+          Option.isSome(yield* Fiber.join(clearFiber).pipe(Effect.timeoutOption("1 second"))),
+          true,
+        );
+        const observed = yield* Fiber.join(observedEvent).pipe(
+          Effect.timeoutOption("1 second"),
+        );
+        assert.equal(Option.isSome(observed), true);
+        const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+        assert.equal(binding?.resumeCursor, null);
+        assert.equal(yield* routing.codex.hasSession(threadId), false);
+      }).pipe(
+        Effect.ensuring(Deferred.succeed(releaseClearWrite, undefined).pipe(Effect.asVoid)),
+        Effect.ensuring(
+          Effect.sync(() => {
+            upsertSpy.mockRestore();
+          }),
+        ),
+      );
+    }),
+  );
+
   it.effect("stops the live runtime while preserving resume cursor and provider options", () =>
     Effect.gen(function* () {
       const tempDir = fs.mkdtempSync(
@@ -3128,6 +3470,1680 @@ routing.layer("ProviderServiceLive routing", (it) => {
 
       fs.rmSync(tempDir, { recursive: true, force: true });
     }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("rejects a non-default live session that has no persisted binding", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const threadId = asThreadId("thread-unbound-work-profile");
+      const sendCallCount = routing.codex.sendTurn.mock.calls.length;
+
+      yield* routing.codex.adapter.startSession({
+        provider: "codex",
+        profileId: asProfileId("work"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const result = yield* Effect.result(
+        provider.sendTurn({ threadId, input: "do not route this", attachments: [] }),
+      );
+      assertFailure(
+        result,
+        new ProviderValidationError({
+          operation: "ProviderService.sendTurn",
+          issue: "Provider profile 'work' is not configured for provider 'codex'.",
+        }),
+      );
+      assert.equal(routing.codex.sendTurn.mock.calls.length, sendCallCount);
+
+      yield* routing.codex.stopSession(threadId);
+    }),
+  );
+
+  it.effect("retires an adapter session that reports the wrong target", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const threadId = asThreadId("thread-adapter-target-mismatch");
+      const stopCallCount = routing.codex.stopSession.mock.calls.length;
+      const startImplementation = routing.codex.startSession.getMockImplementation();
+      if (!startImplementation) assert.fail("Expected fake start implementation");
+      routing.codex.startSession.mockImplementationOnce((input) =>
+        startImplementation(input).pipe(
+          Effect.map((session) => {
+            const mismatched = { ...session, profileId: asProfileId("work") };
+            routing.codex.updateSession(threadId, () => mismatched);
+            return mismatched;
+          }),
+        ),
+      );
+
+      const result = yield* Effect.result(
+        provider.startSession(threadId, {
+          provider: "codex",
+          threadId,
+          runtimeMode: "full-access",
+        }),
+      );
+      assertFailure(
+        result,
+        new ProviderValidationError({
+          operation: "ProviderService.startSession",
+          issue: "Adapter target mismatch: expected 'codex/default', received 'codex/work'.",
+        }),
+      );
+      assert.equal(routing.codex.stopSession.mock.calls.length, stopCallCount + 1);
+      assert.equal(yield* routing.codex.hasSession(threadId), false);
+    }),
+  );
+
+  it.effect("allows cleanup of a persisted profile that is no longer configured", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-unconfigured-profile-cleanup");
+
+      yield* routing.codex.adapter.startSession({
+        provider: "codex",
+        profileId: asProfileId("work"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* directory.upsert({
+        threadId,
+        provider: "codex",
+        profileId: asProfileId("work"),
+        status: "running",
+      });
+
+      yield* provider.stopSession({ threadId });
+
+      assert.equal(yield* routing.codex.hasSession(threadId), false);
+      assert.equal(Option.isNone(yield* directory.getBinding(threadId)), true);
+    }),
+  );
+});
+
+profileRouting.layer("ProviderServiceLive profile routing", (it) => {
+  it.effect("preserves a profile cursor when runtime stop sees another profile", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-stop-mismatch");
+      const workCursor = { opaque: "work-profile-stop-cursor" };
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        profileId: asProfileId("work"),
+        threadId,
+        resumeCursor: workCursor,
+        runtimeMode: "full-access",
+      });
+      profileRouting.codex.updateSession(threadId, (session) => ({
+        ...session,
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
+        resumeCursor: { opaque: "default-profile-stop-cursor" },
+      }));
+
+      assert.equal(typeof provider.stopRuntimeSession, "function");
+      if (!provider.stopRuntimeSession) assert.fail("Expected stopRuntimeSession");
+      yield* provider.stopRuntimeSession({ threadId });
+
+      const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      assert.equal(binding?.profileId, "work");
+      assert.deepEqual(binding?.resumeCursor, workCursor);
+      assert.equal(binding?.status, "stopped");
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
+  it.effect("persists the exact live-session target when the first turn creates the binding", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-live-work-profile-first-binding");
+      const turnId = asTurnId("turn-live-work-profile-first-binding");
+      const liveCursor = { opaque: "work-profile-live-cursor" };
+      const turnCursor = { opaque: "work-profile-turn-cursor" };
+      const modelSelection = {
+        provider: "codex" as const,
+        profileId: asProfileId("work"),
+        model: "gpt-5.6-codex",
+      };
+
+      yield* profileRouting.codex.adapter.startSession({
+        provider: "codex",
+        profileId: asProfileId("work"),
+        threadId,
+        resumeCursor: liveCursor,
+        runtimeMode: "full-access",
+      });
+      profileRouting.codex.sendTurn.mockImplementationOnce(() =>
+        Effect.succeed({ threadId, turnId, resumeCursor: turnCursor }),
+      );
+      assert.equal(Option.isNone(yield* directory.getBinding(threadId)), true);
+
+      yield* provider.sendTurn({
+        threadId,
+        input: "preserve the live work target",
+        modelSelection,
+      });
+
+      const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      assert.equal(binding?.provider, "codex");
+      assert.equal(binding?.profileId, "work");
+      assert.deepEqual(binding?.resumeCursor, turnCursor);
+      assert.deepEqual(
+        asRuntimePayloadRecord(binding?.runtimePayload).modelSelection,
+        modelSelection,
+      );
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
+  it.effect("accepts generation-less runtime events for the legacy default profile", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-default-profile-legacy-event");
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* profileRouting.codex.waitForRuntimeSubscribers();
+      const observed = yield* provider.streamEvents.pipe(
+        Stream.filter(
+          (event) => event.eventId === asEventId("runtime-default-profile-generationless"),
+        ),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* sleep(10);
+      profileRouting.codex.emit({
+        type: "session.state.changed",
+        eventId: asEventId("runtime-default-profile-generationless"),
+        provider: "codex",
+        createdAt: "2026-08-10T00:00:03.000Z",
+        threadId,
+        payload: { state: "error", reason: "legacy default runtime" },
+      });
+      assert.equal(Option.isSome(yield* Fiber.join(observed)), true);
+
+      const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      assert.equal(binding?.profileId, DEFAULT_PROVIDER_PROFILE_ID);
+      assert.equal(binding?.status, "error");
+      assert.equal(
+        asRuntimePayloadRecord(binding?.runtimePayload).lastError,
+        "legacy default runtime",
+      );
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
+  it.effect("replaces same-provider profiles without reusing continuation state", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-replacement");
+      const defaultCursor = { opaque: "default-profile-cursor" };
+      const defaultOptions = { codex: { homePath: "/tmp/default-profile" } };
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        resumeCursor: defaultCursor,
+        providerOptions: defaultOptions,
+        runtimeMode: "full-access",
+      });
+      const startCallCount = profileRouting.codex.startSession.mock.calls.length;
+      const stopCallCount = profileRouting.codex.stopSession.mock.calls.length;
+
+      const replacement = yield* provider.startSession(threadId, {
+        provider: "codex",
+        profileId: asProfileId("work"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const replacementCall = profileRouting.codex.startSession.mock.calls[startCallCount]?.[0];
+      const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      assert.equal(replacement.profileId, "work");
+      assert.equal(replacementCall?.profileId, "work");
+      assert.equal(replacementCall?.resumeCursor, undefined);
+      assert.equal(replacementCall?.providerOptions, undefined);
+      assert.equal(binding?.profileId, "work");
+      assert.equal(profileRouting.codex.stopSession.mock.calls.length, stopCallCount + 1);
+      assert.ok(
+        (profileRouting.codex.stopSession.mock.invocationCallOrder.at(-1) ?? 0) <
+          (profileRouting.codex.startSession.mock.invocationCallOrder.at(-1) ?? 0),
+      );
+
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
+  it.effect("retires a partially spawned runtime when explicit start fails", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-explicit-partial-start-failure");
+      const startFailure = new ProviderAdapterSessionNotFoundError({
+        provider: "codex",
+        threadId,
+      });
+      const startImplementation = profileRouting.codex.startSession.getMockImplementation();
+      if (!startImplementation) assert.fail("Expected adapter start implementation");
+      profileRouting.codex.startSession.mockImplementationOnce((input) =>
+        startImplementation(input).pipe(Effect.andThen(Effect.fail(startFailure))),
+      );
+      const stopCallCount = profileRouting.codex.stopSession.mock.calls.length;
+
+      const result = yield* Effect.result(
+        provider.startSession(threadId, {
+          provider: "codex",
+          profileId: asProfileId("work"),
+          threadId,
+          runtimeMode: "full-access",
+        }),
+      );
+
+      assertFailure(result, startFailure);
+      assert.equal(profileRouting.codex.stopSession.mock.calls.length, stopCallCount + 1);
+      assert.equal(yield* profileRouting.codex.hasSession(threadId), false);
+      assert.equal(Option.isNone(yield* directory.getBinding(threadId)), true);
+    }),
+  );
+
+  it.effect("retires an active same-target replacement when its binding commit fails", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-active-same-target-commit-failure");
+      const workProfile = asProfileId("work");
+      const persistenceFailure = new ProviderSessionDirectoryPersistenceError({
+        operation: "test.active-same-target-replacement",
+        detail: "injected active replacement binding failure",
+      });
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        profileId: workProfile,
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const originalBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      const originalUpsert = directory.upsert;
+      const upsertSpy = vi.spyOn(directory, "upsert").mockImplementation((input) =>
+        input.threadId === threadId &&
+        asRuntimePayloadRecord(input.runtimePayload)
+          .agentGatewayCredentialRotationRequired === false
+          ? Effect.fail(persistenceFailure)
+          : originalUpsert(input),
+      );
+      const stopCallCount = profileRouting.codex.stopSession.mock.calls.length;
+
+      const result = yield* Effect.result(
+        provider
+          .startSession(threadId, {
+            provider: "codex",
+            profileId: workProfile,
+            threadId,
+            runtimeMode: "full-access",
+          })
+          .pipe(
+            Effect.ensuring(
+              Effect.sync(() => {
+                upsertSpy.mockRestore();
+              }),
+            ),
+          ),
+      );
+
+      assertFailure(result, persistenceFailure);
+      assert.equal(profileRouting.codex.stopSession.mock.calls.length, stopCallCount + 1);
+      assert.equal(yield* profileRouting.codex.hasSession(threadId), false);
+      assert.deepEqual(
+        Option.getOrUndefined(yield* directory.getBinding(threadId)),
+        originalBinding,
+      );
+
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
+  it.effect("atomically preserves the old binding when replacement persistence fails", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-replacement-persistence-failure");
+      const workProfile = asProfileId("work");
+      const originalCursor = { opaque: "work-profile-inactive-cursor" };
+      const persistenceFailure = new ProviderSessionDirectoryPersistenceError({
+        operation: "test.profile-replacement",
+        detail: "injected replacement binding failure",
+      });
+
+      yield* directory.upsert({
+        threadId,
+        provider: "codex",
+        profileId: workProfile,
+        lifecycleGeneration: "work-profile-generation",
+        status: "stopped",
+        resumeCursor: originalCursor,
+        runtimePayload: { preserved: "work-profile-runtime" },
+      });
+      const originalBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      assert.equal(yield* profileRouting.codex.hasSession(threadId), false);
+      const startCallCount = profileRouting.codex.startSession.mock.calls.length;
+      const stopCallCount = profileRouting.codex.stopSession.mock.calls.length;
+      const originalUpsert = directory.upsert;
+      let atomicCommitRejected = false;
+      const upsertSpy = vi.spyOn(directory, "upsert").mockImplementation((input) => {
+        if (
+          input.threadId === threadId &&
+          asRuntimePayloadRecord(input.runtimePayload)
+            .agentGatewayCredentialRotationRequired === false
+        ) {
+          atomicCommitRejected = true;
+          return Effect.fail(persistenceFailure);
+        }
+        return originalUpsert(input);
+      });
+
+      const result = yield* Effect.result(
+        provider
+          .startSession(threadId, {
+            provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
+            threadId,
+            runtimeMode: "full-access",
+          })
+          .pipe(
+            Effect.ensuring(
+              Effect.sync(() => {
+                upsertSpy.mockRestore();
+              }),
+            ),
+          ),
+      );
+
+      assertFailure(result, persistenceFailure);
+      assert.equal(atomicCommitRejected, true);
+      assert.equal(profileRouting.codex.startSession.mock.calls.length, startCallCount + 1);
+      assert.equal(profileRouting.codex.stopSession.mock.calls.length, stopCallCount + 1);
+      assert.equal(yield* profileRouting.codex.hasSession(threadId), false);
+      const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      assert.deepEqual(binding, originalBinding);
+
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
+  it.effect("blocks recovery until a failed replacement retirement is retried explicitly", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-replacement-retirement-failure");
+      const workProfile = asProfileId("work");
+      const persistenceFailure = new ProviderSessionDirectoryPersistenceError({
+        operation: "test.profile-replacement",
+        detail: "injected replacement binding failure",
+      });
+      const cleanupFailure = new ProviderAdapterSessionNotFoundError({
+        provider: "codex",
+        threadId,
+      });
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        profileId: workProfile,
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const originalBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      const defaultStop = profileRouting.codex.stopSession.getMockImplementation();
+      if (defaultStop === undefined) {
+        return assert.fail("Expected default stop implementation");
+      }
+      profileRouting.codex.stopSession
+        .mockImplementationOnce(defaultStop)
+        .mockImplementationOnce(() => Effect.fail(cleanupFailure));
+      const upsertSpy = vi
+        .spyOn(directory, "upsert")
+        .mockImplementationOnce(() => Effect.fail(persistenceFailure));
+      const startCallCount = profileRouting.codex.startSession.mock.calls.length;
+
+      const replacementResult = yield* Effect.result(
+        provider
+          .startSession(threadId, {
+            provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
+            threadId,
+            runtimeMode: "full-access",
+          })
+          .pipe(
+            Effect.ensuring(
+              Effect.sync(() => {
+                upsertSpy.mockRestore();
+              }),
+            ),
+          ),
+      );
+      assertFailure(replacementResult, persistenceFailure);
+      assert.equal(profileRouting.codex.startSession.mock.calls.length, startCallCount + 1);
+      assert.equal(yield* profileRouting.codex.hasSession(threadId), true);
+      assert.equal(
+        (yield* profileRouting.codex.listSessions()).find(
+          (session) => session.threadId === threadId,
+        )?.profileId,
+        DEFAULT_PROVIDER_PROFILE_ID,
+      );
+      const bindingAfterFailure = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      assert.equal(bindingAfterFailure?.profileId, workProfile);
+      assert.equal(
+        bindingAfterFailure?.lifecycleGeneration,
+        originalBinding?.lifecycleGeneration,
+      );
+
+      const blockedStart = yield* provider
+        .startSession(threadId, {
+          provider: "codex",
+          profileId: workProfile,
+          threadId,
+          runtimeMode: "full-access",
+        })
+        .pipe(Effect.flip);
+      assert.match(blockedStart.message, /could not be retired safely/);
+      assert.equal(profileRouting.codex.startSession.mock.calls.length, startCallCount + 1);
+
+      const sendCallCount = profileRouting.codex.sendTurn.mock.calls.length;
+      const blockedSend = yield* provider
+        .sendTurn({ threadId, input: "must remain fenced", attachments: [] })
+        .pipe(Effect.flip);
+      assert.match(blockedSend.message, /could not be retired safely/);
+      assert.equal(profileRouting.codex.sendTurn.mock.calls.length, sendCallCount);
+
+      yield* provider.stopSession({ threadId });
+      assert.equal(yield* profileRouting.codex.hasSession(threadId), false);
+      assert.equal(Option.isNone(yield* directory.getBinding(threadId)), true);
+    }),
+  );
+
+  it.effect("rechecks retirement poison after queued lifecycle work acquires the lock", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-retirement-poison-lock-race");
+      const workProfile = asProfileId("work");
+      const persistenceFailure = new ProviderSessionDirectoryPersistenceError({
+        operation: "test.retirement-poison-race",
+        detail: "injected replacement binding failure",
+      });
+      const cleanupFailure = new ProviderAdapterSessionNotFoundError({
+        provider: "codex",
+        threadId,
+      });
+      const cleanupEntered = yield* Deferred.make<void>();
+      const releaseCleanup = yield* Deferred.make<void>();
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        profileId: workProfile,
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const originalBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      const originalUpsert = directory.upsert;
+      const upsertSpy = vi.spyOn(directory, "upsert").mockImplementation((input) =>
+        input.threadId === threadId &&
+        asRuntimePayloadRecord(input.runtimePayload)
+          .agentGatewayCredentialRotationRequired === false
+          ? Effect.fail(persistenceFailure)
+          : originalUpsert(input),
+      );
+      profileRouting.codex.stopSession.mockImplementationOnce(() =>
+        Deferred.succeed(cleanupEntered, undefined).pipe(
+          Effect.andThen(Deferred.await(releaseCleanup)),
+          Effect.andThen(Effect.fail(cleanupFailure)),
+        ),
+      );
+
+      return yield* Effect.gen(function* () {
+        const startCallCount = profileRouting.codex.startSession.mock.calls.length;
+        const sendCallCount = profileRouting.codex.sendTurn.mock.calls.length;
+        const failingReplacement = yield* provider
+          .startSession(threadId, {
+            provider: "codex",
+            profileId: workProfile,
+            threadId,
+            runtimeMode: "full-access",
+          })
+          .pipe(Effect.result, Effect.forkChild);
+        yield* Deferred.await(cleanupEntered);
+
+        const queuedStart = yield* provider
+          .startSession(threadId, {
+            provider: "codex",
+            profileId: workProfile,
+            threadId,
+            runtimeMode: "full-access",
+          })
+          .pipe(Effect.result, Effect.forkChild);
+        const queuedSend = yield* provider
+          .sendTurn({ threadId, input: "must wait for retirement", attachments: [] })
+          .pipe(Effect.result, Effect.forkChild);
+        yield* sleep(25);
+
+        assert.equal(profileRouting.codex.startSession.mock.calls.length, startCallCount + 1);
+        assert.equal(profileRouting.codex.sendTurn.mock.calls.length, sendCallCount);
+        yield* Deferred.succeed(releaseCleanup, undefined);
+
+        assertFailure(yield* Fiber.join(failingReplacement), persistenceFailure);
+        const blockedStart = yield* Fiber.join(queuedStart);
+        const blockedSend = yield* Fiber.join(queuedSend);
+        assert.equal(blockedStart._tag, "Failure");
+        assert.equal(blockedSend._tag, "Failure");
+        if (blockedStart._tag === "Failure") {
+          assert.match(blockedStart.failure.message, /could not be retired safely/);
+        }
+        if (blockedSend._tag === "Failure") {
+          assert.match(blockedSend.failure.message, /could not be retired safely/);
+        }
+        assert.equal(profileRouting.codex.startSession.mock.calls.length, startCallCount + 1);
+        assert.equal(profileRouting.codex.sendTurn.mock.calls.length, sendCallCount);
+        assert.deepEqual(
+          Option.getOrUndefined(yield* directory.getBinding(threadId)),
+          originalBinding,
+        );
+
+        yield* provider.stopSession({ threadId });
+        assert.equal(yield* profileRouting.codex.hasSession(threadId), false);
+        assert.equal(Option.isNone(yield* directory.getBinding(threadId)), true);
+      }).pipe(
+        Effect.ensuring(Deferred.succeed(releaseCleanup, undefined).pipe(Effect.asVoid)),
+        Effect.ensuring(
+          Effect.sync(() => {
+            upsertSpy.mockRestore();
+          }),
+        ),
+      );
+    }),
+  );
+
+  it.effect("restores the exact previous profile when replacement fails", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-rollback");
+      const workCursor = { opaque: "work-profile-cursor" };
+      const workOptions = { codex: { homePath: "/tmp/work-profile" } };
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        profileId: asProfileId("work"),
+        threadId,
+        resumeCursor: workCursor,
+        providerOptions: workOptions,
+        runtimeMode: "full-access",
+      });
+      const originalBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      const replacementFailure = new ProviderAdapterSessionNotFoundError({
+        provider: "codex",
+        threadId,
+      });
+      profileRouting.codex.startSession.mockImplementationOnce(() =>
+        Effect.fail(replacementFailure),
+      );
+
+      const result = yield* Effect.result(
+        provider.startSession(threadId, {
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          threadId,
+          runtimeMode: "full-access",
+        }),
+      );
+      assertFailure(result, replacementFailure);
+
+      const restoredBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      const restoredSession = (yield* profileRouting.codex.listSessions()).find(
+        (session) => session.threadId === threadId,
+      );
+      const restoreCall = profileRouting.codex.startSession.mock.calls.at(-1)?.[0];
+      assert.equal(restoredBinding?.profileId, "work");
+      assert.equal(
+        restoredBinding?.lifecycleGeneration,
+        originalBinding?.lifecycleGeneration,
+      );
+      assert.equal(restoredSession?.profileId, "work");
+      assert.equal(restoreCall?.profileId, "work");
+      assert.deepEqual(restoreCall?.resumeCursor, workCursor);
+      assert.deepEqual(restoreCall?.providerOptions, workOptions);
+
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
+  it.effect("retires a partially spawned restoration without masking replacement failure", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-restoration-start-timeout");
+      const workProfile = asProfileId("work");
+      const replacementFailure = new ProviderAdapterSessionNotFoundError({
+        provider: "codex",
+        threadId,
+      });
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        profileId: workProfile,
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const originalBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      const startImplementation = profileRouting.codex.startSession.getMockImplementation();
+      if (!startImplementation) assert.fail("Expected adapter start implementation");
+      profileRouting.codex.startSession
+        .mockImplementationOnce(() => Effect.fail(replacementFailure))
+        .mockImplementationOnce((input) =>
+          startImplementation(input).pipe(Effect.andThen(Effect.never)),
+        );
+
+      const replacement = yield* provider
+        .startSession(threadId, {
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          threadId,
+          runtimeMode: "full-access",
+        })
+        .pipe(Effect.result, Effect.forkChild);
+      yield* waitUntilEffect(
+        () => profileRouting.codex.hasSession(threadId),
+        500,
+        10,
+        "partially spawned previous-profile restoration",
+      );
+      yield* TestClock.adjust("60 seconds");
+
+      assertFailure(yield* Fiber.join(replacement), replacementFailure);
+      assert.equal(yield* profileRouting.codex.hasSession(threadId), false);
+      assert.deepEqual(
+        Option.getOrUndefined(yield* directory.getBinding(threadId)),
+        originalBinding,
+      );
+
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
+  it.effect("recovers only the exact persisted profile", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const threadId = asThreadId("thread-profile-recovery");
+      const initial = yield* provider.startSession(threadId, {
+        provider: "codex",
+        profileId: asProfileId("work"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      assert.equal(typeof provider.stopRuntimeSession, "function");
+      if (!provider.stopRuntimeSession) assert.fail("Expected stopRuntimeSession");
+      yield* provider.stopRuntimeSession({ threadId });
+      const startCallCount = profileRouting.codex.startSession.mock.calls.length;
+
+      yield* provider.sendTurn({ threadId, input: "recover work profile", attachments: [] });
+
+      const recoveryCall = profileRouting.codex.startSession.mock.calls[startCallCount]?.[0];
+      assert.equal(recoveryCall?.profileId, "work");
+      assert.deepEqual(recoveryCall?.resumeCursor, initial.resumeCursor);
+
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
+  it.effect("retires a partially spawned runtime when recovery start fails", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-recovery-partial-start-failure");
+      const workProfile = asProfileId("work");
+      const startFailure = new ProviderAdapterSessionNotFoundError({
+        provider: "codex",
+        threadId,
+      });
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        profileId: workProfile,
+        threadId,
+        runtimeMode: "full-access",
+      });
+      assert.equal(typeof provider.stopRuntimeSession, "function");
+      if (!provider.stopRuntimeSession) assert.fail("Expected stopRuntimeSession");
+      yield* provider.stopRuntimeSession({ threadId });
+      const originalBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      const startImplementation = profileRouting.codex.startSession.getMockImplementation();
+      if (!startImplementation) assert.fail("Expected adapter start implementation");
+      profileRouting.codex.startSession.mockImplementationOnce((input) =>
+        startImplementation(input).pipe(Effect.andThen(Effect.fail(startFailure))),
+      );
+      const startCallCount = profileRouting.codex.startSession.mock.calls.length;
+      const stopCallCount = profileRouting.codex.stopSession.mock.calls.length;
+
+      const result = yield* Effect.result(
+        provider.sendTurn({ threadId, input: "reject partial recovery", attachments: [] }),
+      );
+
+      assertFailure(result, startFailure);
+      assert.equal(profileRouting.codex.startSession.mock.calls.length, startCallCount + 1);
+      assert.equal(profileRouting.codex.stopSession.mock.calls.length, stopCallCount + 1);
+      assert.equal(yield* profileRouting.codex.hasSession(threadId), false);
+      assert.deepEqual(
+        Option.getOrUndefined(yield* directory.getBinding(threadId)),
+        originalBinding,
+      );
+
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
+  it.effect("times out and retires a partially spawned recovery runtime", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-recovery-start-timeout");
+      const workProfile = asProfileId("work");
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        profileId: workProfile,
+        threadId,
+        runtimeMode: "full-access",
+      });
+      assert.equal(typeof provider.stopRuntimeSession, "function");
+      if (!provider.stopRuntimeSession) assert.fail("Expected stopRuntimeSession");
+      yield* provider.stopRuntimeSession({ threadId });
+      const originalBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      const startImplementation = profileRouting.codex.startSession.getMockImplementation();
+      if (!startImplementation) assert.fail("Expected adapter start implementation");
+      profileRouting.codex.startSession.mockImplementationOnce((input) =>
+        startImplementation(input).pipe(Effect.andThen(Effect.never)),
+      );
+      const startCallCount = profileRouting.codex.startSession.mock.calls.length;
+      const stopCallCount = profileRouting.codex.stopSession.mock.calls.length;
+
+      const recoveryFiber = yield* provider
+        .sendTurn({ threadId, input: "timeout partial recovery", attachments: [] })
+        .pipe(Effect.result, Effect.forkChild);
+      yield* waitUntilEffect(
+        () => profileRouting.codex.hasSession(threadId),
+        500,
+        10,
+        "partially spawned recovery runtime",
+      );
+      yield* TestClock.adjust("60 seconds");
+      const result = yield* Fiber.join(recoveryFiber);
+
+      assertFailure(
+        result,
+        new ProviderValidationError({
+          operation: "ProviderService.sendTurn",
+          issue:
+            "Provider 'codex' did not finish recovering within 60000ms for thread 'thread-profile-recovery-start-timeout'.",
+        }),
+      );
+      assert.equal(profileRouting.codex.startSession.mock.calls.length, startCallCount + 1);
+      assert.equal(profileRouting.codex.stopSession.mock.calls.length, stopCallCount + 1);
+      assert.equal(yield* profileRouting.codex.hasSession(threadId), false);
+      assert.deepEqual(
+        Option.getOrUndefined(yield* directory.getBinding(threadId)),
+        originalBinding,
+      );
+
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
+  it.effect("retires a recovered runtime that reports the wrong target", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-recovery-returned-target-mismatch");
+      const workProfile = asProfileId("work");
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        profileId: workProfile,
+        threadId,
+        runtimeMode: "full-access",
+      });
+      assert.equal(typeof provider.stopRuntimeSession, "function");
+      if (!provider.stopRuntimeSession) assert.fail("Expected stopRuntimeSession");
+      yield* provider.stopRuntimeSession({ threadId });
+      const originalBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      const startImplementation = profileRouting.codex.startSession.getMockImplementation();
+      if (!startImplementation) assert.fail("Expected adapter start implementation");
+      profileRouting.codex.startSession.mockImplementationOnce((input) =>
+        startImplementation(input).pipe(
+          Effect.map((session) => {
+            const mismatched = {
+              ...session,
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
+            };
+            profileRouting.codex.updateSession(threadId, () => mismatched);
+            return mismatched;
+          }),
+        ),
+      );
+      const startCallCount = profileRouting.codex.startSession.mock.calls.length;
+      const stopCallCount = profileRouting.codex.stopSession.mock.calls.length;
+      const sendCallCount = profileRouting.codex.sendTurn.mock.calls.length;
+
+      const result = yield* Effect.result(
+        provider.sendTurn({ threadId, input: "reject the mismatched recovery", attachments: [] }),
+      );
+
+      assertFailure(
+        result,
+        new ProviderValidationError({
+          operation: "ProviderService.sendTurn",
+          issue: "Adapter target mismatch: expected 'codex/work', received 'codex/default'.",
+        }),
+      );
+      assert.equal(profileRouting.codex.startSession.mock.calls.length, startCallCount + 1);
+      assert.equal(profileRouting.codex.stopSession.mock.calls.length, stopCallCount + 1);
+      assert.equal(profileRouting.codex.sendTurn.mock.calls.length, sendCallCount);
+      assert.equal(yield* profileRouting.codex.hasSession(threadId), false);
+      assert.deepEqual(
+        Option.getOrUndefined(yield* directory.getBinding(threadId)),
+        originalBinding,
+      );
+
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
+  it.effect("atomically preserves the old binding when recovery persistence fails", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-recovery-persistence-failure");
+      const workProfile = asProfileId("work");
+      const persistenceFailure = new ProviderSessionDirectoryPersistenceError({
+        operation: "test.profile-recovery",
+        detail: "injected recovery binding failure",
+      });
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        profileId: workProfile,
+        threadId,
+        runtimeMode: "full-access",
+      });
+      assert.equal(typeof provider.stopRuntimeSession, "function");
+      if (!provider.stopRuntimeSession) assert.fail("Expected stopRuntimeSession");
+      yield* provider.stopRuntimeSession({ threadId });
+      yield* directory.upsert({
+        threadId,
+        provider: "codex",
+        profileId: workProfile,
+        runtimePayload: { agentGatewayCredentialRotationRequired: true },
+      });
+      const originalBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      const originalUpsert = directory.upsert;
+      let atomicCommitRejected = false;
+      const upsertSpy = vi.spyOn(directory, "upsert").mockImplementation((input) => {
+        if (
+          input.threadId === threadId &&
+          asRuntimePayloadRecord(input.runtimePayload)
+            .agentGatewayCredentialRotationRequired === false
+        ) {
+          atomicCommitRejected = true;
+          return Effect.fail(persistenceFailure);
+        }
+        return originalUpsert(input);
+      });
+      const startCallCount = profileRouting.codex.startSession.mock.calls.length;
+      const stopCallCount = profileRouting.codex.stopSession.mock.calls.length;
+      const sendCallCount = profileRouting.codex.sendTurn.mock.calls.length;
+
+      const result = yield* Effect.result(
+        provider
+          .sendTurn({ threadId, input: "reject the failed recovery commit", attachments: [] })
+          .pipe(
+            Effect.ensuring(
+              Effect.sync(() => {
+                upsertSpy.mockRestore();
+              }),
+            ),
+          ),
+      );
+
+      assertFailure(result, persistenceFailure);
+      assert.equal(atomicCommitRejected, true);
+      assert.equal(profileRouting.codex.startSession.mock.calls.length, startCallCount + 1);
+      assert.equal(profileRouting.codex.stopSession.mock.calls.length, stopCallCount + 1);
+      assert.equal(profileRouting.codex.sendTurn.mock.calls.length, sendCallCount);
+      assert.equal(yield* profileRouting.codex.hasSession(threadId), false);
+      assert.deepEqual(
+        Option.getOrUndefined(yield* directory.getBinding(threadId)),
+        originalBinding,
+      );
+
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
+  it.effect("fences future work when failed recovery cleanup cannot retire the runtime", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-recovery-cleanup-failure");
+      const workProfile = asProfileId("work");
+      const cleanupFailure = new ProviderAdapterSessionNotFoundError({
+        provider: "codex",
+        threadId,
+      });
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        profileId: workProfile,
+        threadId,
+        runtimeMode: "full-access",
+      });
+      assert.equal(typeof provider.stopRuntimeSession, "function");
+      if (!provider.stopRuntimeSession) assert.fail("Expected stopRuntimeSession");
+      yield* provider.stopRuntimeSession({ threadId });
+      const originalBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      const startImplementation = profileRouting.codex.startSession.getMockImplementation();
+      if (!startImplementation) assert.fail("Expected adapter start implementation");
+      profileRouting.codex.startSession.mockImplementationOnce((input) =>
+        startImplementation(input).pipe(
+          Effect.map((session) => {
+            const mismatched = {
+              ...session,
+              profileId: DEFAULT_PROVIDER_PROFILE_ID,
+            };
+            profileRouting.codex.updateSession(threadId, () => mismatched);
+            return mismatched;
+          }),
+        ),
+      );
+      profileRouting.codex.stopSession.mockImplementationOnce(() => Effect.fail(cleanupFailure));
+      const startCallCount = profileRouting.codex.startSession.mock.calls.length;
+      const sendCallCount = profileRouting.codex.sendTurn.mock.calls.length;
+
+      const recoveryResult = yield* Effect.result(
+        provider.sendTurn({ threadId, input: "poison failed recovery", attachments: [] }),
+      );
+      assertFailure(
+        recoveryResult,
+        new ProviderValidationError({
+          operation: "ProviderService.sendTurn",
+          issue: "Adapter target mismatch: expected 'codex/work', received 'codex/default'.",
+        }),
+      );
+      assert.equal(yield* profileRouting.codex.hasSession(threadId), true);
+      assert.deepEqual(
+        Option.getOrUndefined(yield* directory.getBinding(threadId)),
+        originalBinding,
+      );
+
+      const blockedSend = yield* provider
+        .sendTurn({ threadId, input: "must remain fenced", attachments: [] })
+        .pipe(Effect.flip);
+      assert.match(blockedSend.message, /could not be retired safely/);
+      const blockedStart = yield* provider
+        .startSession(threadId, {
+          provider: "codex",
+          profileId: workProfile,
+          threadId,
+          runtimeMode: "full-access",
+        })
+        .pipe(Effect.flip);
+      assert.match(blockedStart.message, /could not be retired safely/);
+      assert.equal(profileRouting.codex.startSession.mock.calls.length, startCallCount + 1);
+      assert.equal(profileRouting.codex.sendTurn.mock.calls.length, sendCallCount);
+
+      yield* provider.stopSession({ threadId });
+      assert.equal(yield* profileRouting.codex.hasSession(threadId), false);
+      assert.equal(Option.isNone(yield* directory.getBinding(threadId)), true);
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        profileId: workProfile,
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
+  it.effect("refuses to adopt an active session from another profile", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const threadId = asThreadId("thread-profile-recovery-mismatch");
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        profileId: asProfileId("work"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      profileRouting.codex.updateSession(threadId, (session) => ({
+        ...session,
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
+      }));
+      const sendCallCount = profileRouting.codex.sendTurn.mock.calls.length;
+
+      const result = yield* Effect.result(
+        provider.sendTurn({ threadId, input: "must not cross profiles", attachments: [] }),
+      );
+      assertFailure(
+        result,
+        new ProviderValidationError({
+          operation: "ProviderService.sendTurn",
+          issue:
+            "Cannot recover thread 'thread-profile-recovery-mismatch' because its active provider target does not match 'codex/work'.",
+        }),
+      );
+      assert.equal(profileRouting.codex.sendTurn.mock.calls.length, sendCallCount);
+
+      profileRouting.codex.updateSession(threadId, (session) => ({
+        ...session,
+        profileId: asProfileId("work"),
+      }));
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
+  it.effect("allows native forks only within the exact source profile", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const sourceThreadId = asThreadId("thread-profile-fork-source");
+      const targetThreadId = asThreadId("thread-profile-fork-target");
+      const rejectedThreadId = asThreadId("thread-profile-fork-rejected");
+
+      yield* provider.startSession(sourceThreadId, {
+        provider: "codex",
+        profileId: asProfileId("work"),
+        threadId: sourceThreadId,
+        runtimeMode: "full-access",
+      });
+      const forkCallCount = profileRouting.codex.forkThread.mock.calls.length;
+      if (!provider.forkThread) assert.fail("Expected forkThread");
+
+      const forked = yield* provider.forkThread({
+        sourceThreadId,
+        threadId: targetThreadId,
+        profileId: asProfileId("work"),
+        runtimeMode: "full-access",
+      });
+      const rejected = yield* provider.forkThread({
+        sourceThreadId,
+        threadId: rejectedThreadId,
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
+        runtimeMode: "full-access",
+      });
+
+      const targetBinding = Option.getOrUndefined(yield* directory.getBinding(targetThreadId));
+      assert.equal(forked?.threadId, targetThreadId);
+      assert.equal(targetBinding?.profileId, "work");
+      assert.equal(rejected, null);
+      assert.equal(profileRouting.codex.forkThread.mock.calls.length, forkCallCount + 1);
+
+      yield* provider.stopSession({ threadId: targetThreadId });
+      yield* provider.stopSession({ threadId: sourceThreadId });
+    }),
+  );
+
+  it.effect("rejects send and steer selections from another profile", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const threadId = asThreadId("thread-profile-turn-mismatch");
+      const modelSelection = {
+        provider: "codex" as const,
+        profileId: asProfileId("work"),
+        model: "gpt-5-codex",
+      };
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const sendCallCount = profileRouting.codex.sendTurn.mock.calls.length;
+      const steerCallCount = profileRouting.codex.steerTurn.mock.calls.length;
+
+      const sendResult = yield* Effect.result(
+        provider.sendTurn({
+          threadId,
+          input: "wrong account",
+          attachments: [],
+          modelSelection,
+        }),
+      );
+      const steerResult = yield* Effect.result(
+        provider.steerTurn({
+          threadId,
+          input: "wrong account",
+          attachments: [],
+          modelSelection,
+        }),
+      );
+      const expected = (operation: string) =>
+        new ProviderValidationError({
+          operation,
+          issue: "Model selection target does not match 'codex/default'.",
+        });
+      assertFailure(sendResult, expected("ProviderService.sendTurn"));
+      assertFailure(steerResult, expected("ProviderService.steerTurn"));
+      assert.equal(profileRouting.codex.sendTurn.mock.calls.length, sendCallCount);
+      assert.equal(profileRouting.codex.steerTurn.mock.calls.length, steerCallCount);
+
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+});
+
+profileEventAdmission.layer("ProviderServiceLive runtime event target admission", (it) => {
+  it.effect("rejects generation-less work-profile events without a binding", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-unbound-generationless-event");
+      const workProfile = asProfileId("work");
+      const observedEvents = yield* Ref.make<ProviderRuntimeEvent[]>([]);
+      profileAdmissionJournal.length = 0;
+
+      yield* profileEventAdmission.codex.adapter.startSession({
+        provider: "codex",
+        profileId: workProfile,
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* profileEventAdmission.codex.waitForRuntimeSubscribers();
+      assert.equal(Option.isNone(yield* directory.getBinding(threadId)), true);
+
+      const consumer = yield* provider.streamEvents.pipe(
+        Stream.runForEach((event) =>
+          Ref.update(observedEvents, (current) => [...current, event]),
+        ),
+        Effect.forkChild,
+      );
+      yield* sleep(10);
+
+      return yield* Effect.gen(function* () {
+        profileEventAdmission.codex.emit({
+          type: "session.state.changed",
+          eventId: asEventId("runtime-profile-unbound-generationless-event"),
+          provider: "codex",
+          profileId: workProfile,
+          createdAt: "2026-08-10T00:00:00.000Z",
+          threadId,
+          payload: { state: "error", reason: "unbound work runtime" },
+        });
+        yield* sleep(25);
+
+        assert.deepEqual(profileAdmissionJournal, []);
+        assert.deepEqual(yield* Ref.get(observedEvents), []);
+        assert.equal(Option.isNone(yield* directory.getBinding(threadId)), true);
+      }).pipe(
+        Effect.ensuring(Fiber.interrupt(consumer)),
+        Effect.ensuring(profileEventAdmission.codex.adapter.stopSession(threadId)),
+      );
+    }),
+  );
+
+  it.effect("keeps stale targets out of the journal, ingestion stream, and turn bookkeeping", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-event-admission");
+      const workProfile = asProfileId("work");
+      const validTurnId = asTurnId("turn-profile-event-admission");
+      profileAdmissionJournal.length = 0;
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        profileId: workProfile,
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const initialBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      const lifecycleGeneration = initialBinding?.lifecycleGeneration;
+      assert.equal(typeof lifecycleGeneration, "string");
+      if (lifecycleGeneration === undefined) assert.fail("Expected lifecycle generation");
+      yield* profileEventAdmission.codex.waitForRuntimeSubscribers();
+
+      // ProviderRuntimeIngestion consumes this exact stream. A stale event that
+      // appears here can cross-contaminate projections even if binding writes reject it.
+      const ingestionVisibleEvents: ProviderRuntimeEvent[] = [];
+      const ingestionConsumer = yield* provider.streamEvents.pipe(
+        Stream.take(2),
+        Stream.runForEach((event) =>
+          Effect.sync(() => {
+            ingestionVisibleEvents.push(event);
+          }),
+        ),
+        Effect.forkChild,
+      );
+      yield* sleep(10);
+
+      const rejectedEvents: ReadonlyArray<LegacyProviderRuntimeEvent> = [
+        {
+          type: "session.state.changed",
+          eventId: asEventId("runtime-provider-mismatch"),
+          provider: "claudeAgent",
+          profileId: workProfile,
+          lifecycleGeneration,
+          createdAt: "2026-08-10T00:00:00.000Z",
+          threadId,
+          payload: { state: "error", reason: "wrong provider" },
+        },
+        {
+          type: "turn.started",
+          eventId: asEventId("runtime-profile-mismatched-turn-started"),
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          lifecycleGeneration,
+          createdAt: "2026-08-10T00:00:01.000Z",
+          threadId,
+          turnId: asTurnId("turn-profile-mismatch-stale"),
+          payload: {},
+        },
+        {
+          type: "session.state.changed",
+          eventId: asEventId("runtime-work-generation-missing"),
+          provider: "codex",
+          profileId: workProfile,
+          createdAt: "2026-08-10T00:00:02.000Z",
+          threadId,
+          payload: { state: "error", reason: "generation missing" },
+        },
+        {
+          type: "session.state.changed",
+          eventId: asEventId("runtime-late-default-generationless"),
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          createdAt: "2026-08-10T00:00:03.000Z",
+          threadId,
+          payload: { state: "error", reason: "late default runtime" },
+        },
+        {
+          type: "session.state.changed",
+          eventId: asEventId("runtime-generation-mismatch"),
+          provider: "codex",
+          profileId: workProfile,
+          lifecycleGeneration: `${lifecycleGeneration}-stale`,
+          createdAt: "2026-08-10T00:00:04.000Z",
+          threadId,
+          payload: { state: "error", reason: "stale generation" },
+        },
+      ];
+      for (const event of rejectedEvents) {
+        profileEventAdmission.codex.emit(event);
+      }
+      profileEventAdmission.codex.emit({
+        type: "turn.started",
+        eventId: asEventId("runtime-profile-valid-turn-started"),
+        provider: "codex",
+        profileId: workProfile,
+        lifecycleGeneration,
+        createdAt: "2026-08-10T00:00:05.000Z",
+        threadId,
+        turnId: validTurnId,
+        payload: {},
+      });
+      profileEventAdmission.codex.emit({
+        type: "turn.completed",
+        eventId: asEventId("runtime-profile-valid-turn-completed"),
+        provider: "codex",
+        profileId: workProfile,
+        lifecycleGeneration,
+        createdAt: "2026-08-10T00:00:06.000Z",
+        threadId,
+        payload: { state: "completed" },
+      });
+
+      yield* Fiber.join(ingestionConsumer);
+      const acceptedEventIds = [
+        asEventId("runtime-profile-valid-turn-started"),
+        asEventId("runtime-profile-valid-turn-completed"),
+      ];
+      assert.deepEqual(
+        ingestionVisibleEvents.map((event) => event.eventId),
+        acceptedEventIds,
+      );
+      assert.deepEqual(
+        profileAdmissionJournal.map((event) => event.eventId),
+        acceptedEventIds,
+      );
+
+      const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      const runtimePayload = asRuntimePayloadRecord(binding?.runtimePayload);
+      assert.equal(binding?.profileId, workProfile);
+      assert.equal(binding?.status, "stopped");
+      assert.equal(runtimePayload.activeTurnId, null);
+      assert.equal(runtimePayload.lastRuntimeEvent, "turn.completed");
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
+  it.effect("serializes event admission through journal and publish with target replacement", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-event-admission-replacement-race");
+      const workProfile = asProfileId("work");
+      const eventId = asEventId("runtime-profile-event-admission-replacement-race");
+      const persistenceEntered = yield* Deferred.make<void>();
+      const releasePersistence = yield* Deferred.make<void>();
+      profileAdmissionJournal.length = 0;
+      profileAdmissionPersistenceGate = {
+        eventId,
+        entered: persistenceEntered,
+        release: releasePersistence,
+      };
+
+      return yield* Effect.gen(function* () {
+        yield* provider.startSession(threadId, {
+          provider: "codex",
+          profileId: workProfile,
+          threadId,
+          runtimeMode: "full-access",
+        });
+        const initialBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+        const lifecycleGeneration = initialBinding?.lifecycleGeneration;
+        assert.equal(typeof lifecycleGeneration, "string");
+        if (lifecycleGeneration === undefined) assert.fail("Expected lifecycle generation");
+        yield* profileEventAdmission.codex.waitForRuntimeSubscribers();
+
+        const observed = yield* provider.streamEvents.pipe(
+          Stream.filter((event) => event.eventId === eventId),
+          Stream.runHead,
+          Effect.forkChild,
+        );
+        yield* sleep(10);
+        profileEventAdmission.codex.emit({
+          type: "session.state.changed",
+          eventId,
+          provider: "codex",
+          profileId: workProfile,
+          lifecycleGeneration,
+          createdAt: "2026-08-10T00:00:07.000Z",
+          threadId,
+          payload: { state: "ready" },
+        });
+        yield* Deferred.await(persistenceEntered);
+
+        const startsBeforeReplacement =
+          profileEventAdmission.codex.startSession.mock.calls.length;
+        const stopsBeforeReplacement = profileEventAdmission.codex.stopSession.mock.calls.length;
+        const replacement = yield* provider
+          .startSession(threadId, {
+            provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
+            threadId,
+            runtimeMode: "full-access",
+          })
+          .pipe(Effect.forkChild);
+        yield* sleep(25);
+
+        // Once admission accepts an owner, replacement must wait until that
+        // event is durable and published. Otherwise the old profile can become
+        // stale between the ownership check and journal insertion.
+        assert.equal(
+          profileEventAdmission.codex.startSession.mock.calls.length,
+          startsBeforeReplacement,
+        );
+        assert.equal(
+          profileEventAdmission.codex.stopSession.mock.calls.length,
+          stopsBeforeReplacement,
+        );
+        assert.deepEqual(profileAdmissionJournal, []);
+        assert.equal(
+          Option.getOrUndefined(yield* directory.getBinding(threadId))?.profileId,
+          workProfile,
+        );
+
+        yield* Deferred.succeed(releasePersistence, undefined);
+        const observedEvent = yield* Fiber.join(observed);
+        assert.equal(Option.getOrUndefined(observedEvent)?.eventId, eventId);
+        assert.equal(Option.getOrUndefined(observedEvent)?.profileId, workProfile);
+        yield* Fiber.join(replacement);
+
+        assert.deepEqual(
+          profileAdmissionJournal.map((event) => event.eventId),
+          [eventId],
+        );
+        assert.equal(
+          Option.getOrUndefined(yield* directory.getBinding(threadId))?.profileId,
+          DEFAULT_PROVIDER_PROFILE_ID,
+        );
+        yield* provider.stopSession({ threadId });
+      }).pipe(
+        Effect.ensuring(
+          Deferred.succeed(releasePersistence, undefined).pipe(
+            Effect.andThen(
+              Effect.sync(() => {
+                if (profileAdmissionPersistenceGate?.eventId === eventId) {
+                  profileAdmissionPersistenceGate = undefined;
+                }
+              }),
+            ),
+            Effect.asVoid,
+          ),
+        ),
+      );
+    }),
+  );
+
+  it.effect("admits the new generation's startup event before replacement binding upsert", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-startup-event-transition");
+      const workProfile = asProfileId("work");
+      const startupEventId = asEventId("runtime-profile-startup-event-transition");
+      const staleEventId = asEventId("runtime-profile-stale-event-transition");
+      const wrongProfileEventId = asEventId("runtime-profile-wrong-target-after-transition");
+      const replacementStarted = yield* Deferred.make<string>();
+      const releaseReplacement = yield* Deferred.make<void>();
+      profileAdmissionJournal.length = 0;
+
+      return yield* Effect.gen(function* () {
+        yield* provider.startSession(threadId, {
+          provider: "codex",
+          profileId: workProfile,
+          threadId,
+          runtimeMode: "full-access",
+        });
+        const initialBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+        const initialGeneration = initialBinding?.lifecycleGeneration;
+        assert.equal(typeof initialGeneration, "string");
+        if (initialGeneration === undefined) assert.fail("Expected lifecycle generation");
+        yield* profileEventAdmission.codex.waitForRuntimeSubscribers();
+
+        const defaultStart = profileEventAdmission.codex.startSession.getMockImplementation();
+        if (defaultStart === undefined) assert.fail("Expected adapter start implementation");
+        profileEventAdmission.codex.startSession.mockImplementationOnce((input) =>
+          Effect.gen(function* () {
+            assert.equal(typeof input.lifecycleGeneration, "string");
+            if (input.lifecycleGeneration === undefined) {
+              return yield* Effect.die("Expected replacement lifecycle generation");
+            }
+            yield* Deferred.succeed(replacementStarted, input.lifecycleGeneration);
+            yield* Deferred.await(releaseReplacement);
+            return yield* defaultStart(input);
+          }),
+        );
+        const replacement = yield* provider
+          .startSession(threadId, {
+            provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
+            threadId,
+            runtimeMode: "full-access",
+          })
+          .pipe(Effect.forkChild);
+        const replacementGeneration = yield* Deferred.await(replacementStarted);
+        assert.equal(
+          Option.getOrUndefined(yield* directory.getBinding(threadId))?.profileId,
+          workProfile,
+        );
+
+        const observed = yield* provider.streamEvents.pipe(
+          Stream.filter((event) => event.eventId === startupEventId),
+          Stream.runHead,
+          Effect.forkChild,
+        );
+        yield* sleep(10);
+        profileEventAdmission.codex.emit({
+          type: "session.state.changed",
+          eventId: staleEventId,
+          provider: "codex",
+          profileId: workProfile,
+          lifecycleGeneration: initialGeneration,
+          createdAt: "2026-08-10T00:00:08.000Z",
+          threadId,
+          payload: { state: "error", reason: "stale replaced runtime" },
+        });
+        profileEventAdmission.codex.emit({
+          type: "session.started",
+          eventId: startupEventId,
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          lifecycleGeneration: replacementGeneration,
+          createdAt: "2026-08-10T00:00:09.000Z",
+          threadId,
+          payload: {},
+        });
+
+        assert.equal(Option.getOrUndefined(yield* Fiber.join(observed))?.eventId, startupEventId);
+        assert.deepEqual(
+          profileAdmissionJournal.map((event) => event.eventId),
+          [startupEventId],
+        );
+        const transitionBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+        assert.equal(transitionBinding?.status, "running");
+        assert.equal(
+          asRuntimePayloadRecord(transitionBinding?.runtimePayload).lastRuntimeEvent,
+          "session.started",
+        );
+        yield* Deferred.succeed(releaseReplacement, undefined);
+        yield* Fiber.join(replacement);
+        assert.equal(
+          Option.getOrUndefined(yield* directory.getBinding(threadId))?.profileId,
+          DEFAULT_PROVIDER_PROFILE_ID,
+        );
+
+        profileEventAdmission.codex.emit({
+          type: "session.state.changed",
+          eventId: wrongProfileEventId,
+          provider: "codex",
+          profileId: workProfile,
+          lifecycleGeneration: replacementGeneration,
+          createdAt: "2026-08-10T00:00:10.000Z",
+          threadId,
+          payload: { state: "error", reason: "wrong profile on current generation" },
+        });
+        yield* sleep(25);
+        assert.deepEqual(
+          profileAdmissionJournal.map((event) => event.eventId),
+          [startupEventId],
+        );
+        assert.notEqual(
+          Option.getOrUndefined(yield* directory.getBinding(threadId))?.status,
+          "error",
+        );
+        yield* provider.stopSession({ threadId });
+      }).pipe(
+        Effect.ensuring(Deferred.succeed(releaseReplacement, undefined).pipe(Effect.asVoid)),
+      );
+    }),
+  );
+
+  it.effect("admits restored-generation startup events before rollback binding upsert", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-profile-restore-startup-event-transition");
+      const workProfile = asProfileId("work");
+      const restoredEventId = asEventId("runtime-profile-restored-startup-event-transition");
+      profileAdmissionJournal.length = 0;
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        profileId: workProfile,
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const initialBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      const initialGeneration = initialBinding?.lifecycleGeneration;
+      assert.equal(typeof initialGeneration, "string");
+      if (initialGeneration === undefined) assert.fail("Expected lifecycle generation");
+      yield* profileEventAdmission.codex.waitForRuntimeSubscribers();
+
+      const defaultCodexStart = profileEventAdmission.codex.startSession.getMockImplementation();
+      if (defaultCodexStart === undefined) assert.fail("Expected adapter start implementation");
+      profileEventAdmission.codex.startSession.mockImplementationOnce((input) =>
+        Effect.gen(function* () {
+          profileEventAdmission.codex.emit({
+            type: "session.started",
+            eventId: restoredEventId,
+            provider: "codex",
+            profileId: workProfile,
+            lifecycleGeneration: initialGeneration,
+            createdAt: "2026-08-10T00:00:11.000Z",
+            threadId,
+            payload: {},
+          });
+          yield* waitUntil(
+            () => profileAdmissionJournal.some((event) => event.eventId === restoredEventId),
+            500,
+            10,
+            "restored-generation startup event admission",
+          );
+          return yield* defaultCodexStart(input);
+        }),
+      );
+      const replacementFailure = new ProviderAdapterSessionNotFoundError({
+        provider: "claudeAgent",
+        threadId,
+      });
+      profileEventAdmission.claude.startSession.mockImplementationOnce(() =>
+        Effect.fail(replacementFailure),
+      );
+      const observed = yield* provider.streamEvents.pipe(
+        Stream.filter((event) => event.eventId === restoredEventId),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      yield* sleep(10);
+
+      const replacement = yield* Effect.result(
+        provider.startSession(threadId, {
+          provider: "claudeAgent",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          threadId,
+          runtimeMode: "full-access",
+        }),
+      );
+
+      assertFailure(replacement, replacementFailure);
+      assert.equal(Option.getOrUndefined(yield* Fiber.join(observed))?.eventId, restoredEventId);
+      assert.deepEqual(
+        profileAdmissionJournal.map((event) => event.eventId),
+        [restoredEventId],
+      );
+      const restoredBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      assert.equal(restoredBinding?.profileId, workProfile);
+      assert.equal(restoredBinding?.lifecycleGeneration, initialGeneration);
+      yield* provider.stopSession({ threadId });
+    }),
   );
 });
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -10,6 +10,7 @@
  * @module ProviderServiceLive
  */
 import {
+  DEFAULT_PROVIDER_PROFILE_ID,
   EventId,
   ProviderCompactThreadInput,
   ProviderForkThreadInput,
@@ -31,6 +32,7 @@ import {
   TurnId,
   type ProviderRuntimeEvent,
   type ProviderSession,
+  type ProviderTarget,
 } from "@synara/contracts";
 import {
   providerSupportsAutoRuntimeMode,
@@ -52,8 +54,14 @@ import {
   Stream,
 } from "effect";
 import { nonEmptyTrimmed } from "@synara/shared/text";
+import {
+  providerTargetFromModelSelection,
+  providerTargetFromSource,
+  providerTargetsEqual,
+} from "@synara/shared/providerTarget";
 
-import { ProviderValidationError } from "../Errors.ts";
+import { ProviderValidationError, type ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
 import { ProviderAdapterRegistry } from "../Services/ProviderAdapterRegistry.ts";
 import { ProviderService, type ProviderServiceShape } from "../Services/ProviderService.ts";
 import {
@@ -82,6 +90,10 @@ import {
   AGENT_GATEWAY_CREDENTIAL_ROTATION_REQUIRED,
   AGENT_GATEWAY_TURN_AUTHORITY_RETIRED,
 } from "../../agentGateway/sessionLease.ts";
+import {
+  resolveDefaultProviderProfile,
+  type ResolveProviderProfile,
+} from "../providerProfileResolver.ts";
 
 export interface ProviderServiceLiveOptions {
   readonly canonicalEventLogPath?: string;
@@ -101,6 +113,8 @@ export interface ProviderServiceLiveOptions {
   /** Test override for supervised event retry timing. */
   readonly runtimeEventRetryBaseDelayMs?: number;
   readonly runtimeEventRetryMaxDelayMs?: number;
+  /** Test/embedding override. Production accepts only the server-owned default profile. */
+  readonly resolveProviderProfile?: ResolveProviderProfile;
 }
 
 const DEFAULT_PROVIDER_RUNTIME_IDLE_STOP_MS = 10 * 60 * 1000;
@@ -212,21 +226,109 @@ const decodeInputOrValidationError = <S extends Schema.Top>(input: {
     ),
   );
 
+function providerTargetLabel(target: ProviderTarget): string {
+  return `${target.provider}/${target.profileId}`;
+}
+
+function sessionStartTarget(
+  input: ProviderSessionStartInput,
+): Effect.Effect<ProviderTarget, ProviderValidationError> {
+  const selectionTarget = input.modelSelection
+    ? providerTargetFromModelSelection(input.modelSelection)
+    : undefined;
+  const target = providerTargetFromSource({
+    provider: input.provider ?? selectionTarget?.provider ?? "codex",
+    profileId: input.profileId ?? selectionTarget?.profileId,
+  });
+
+  return selectionTarget && !providerTargetsEqual(target, selectionTarget)
+    ? Effect.fail(
+        toValidationError(
+          "ProviderService.startSession",
+          `Session target '${providerTargetLabel(target)}' does not match model selection target '${providerTargetLabel(selectionTarget)}'.`,
+        ),
+      )
+    : Effect.succeed(target);
+}
+
+function forkTarget(
+  input: ProviderForkThreadInput,
+  sourceTarget: ProviderTarget,
+): Effect.Effect<ProviderTarget, ProviderValidationError> {
+  const selectionTarget = input.modelSelection
+    ? providerTargetFromModelSelection(input.modelSelection)
+    : undefined;
+  const target =
+    selectionTarget ??
+    providerTargetFromSource({
+      provider: sourceTarget.provider,
+      profileId: input.profileId ?? sourceTarget.profileId,
+    });
+
+  return input.profileId !== undefined && input.profileId !== target.profileId
+    ? Effect.fail(
+        toValidationError(
+          "ProviderService.forkThread",
+          `Fork profile '${input.profileId}' does not match model selection target '${providerTargetLabel(target)}'.`,
+        ),
+      )
+    : Effect.succeed(target);
+}
+
+function modelSelectionForTarget(input: {
+  readonly operation: string;
+  readonly modelSelection: ModelSelection | undefined;
+  readonly target: ProviderTarget;
+}): Effect.Effect<ModelSelection | undefined, ProviderValidationError> {
+  if (
+    input.modelSelection &&
+    !providerTargetsEqual(providerTargetFromModelSelection(input.modelSelection), input.target)
+  ) {
+    return Effect.fail(
+      toValidationError(
+        input.operation,
+        `Model selection target does not match '${providerTargetLabel(input.target)}'.`,
+      ),
+    );
+  }
+  return Effect.succeed(input.modelSelection);
+}
+
+function sessionWithExpectedTarget(input: {
+  readonly operation: string;
+  readonly session: ProviderSession;
+  readonly target: ProviderTarget;
+}): Effect.Effect<ProviderSession, ProviderValidationError> {
+  const actualTarget = providerTargetFromSource(input.session);
+  if (!providerTargetsEqual(actualTarget, input.target)) {
+    return Effect.fail(
+      toValidationError(
+        input.operation,
+        `Adapter target mismatch: expected '${providerTargetLabel(input.target)}', received '${providerTargetLabel(actualTarget)}'.`,
+      ),
+    );
+  }
+  return Effect.succeed({ ...input.session, profileId: input.target.profileId });
+}
+
 function toRuntimeStatus(session: ProviderSession): "starting" | "running" | "stopped" | "error" {
   if (session.status === "connecting") return "starting";
   if (session.status === "closed") return "stopped";
   return session.status === "error" ? "error" : "running";
 }
 
+interface SessionBindingExtra {
+  readonly modelSelection?: unknown;
+  readonly providerOptions?: unknown;
+  readonly lastRuntimeEvent?: string;
+  readonly lastRuntimeEventAt?: string;
+  readonly lifecycleGeneration?: string;
+  readonly agentGatewayCredentialRotationRequired?: boolean;
+}
+
 function toRuntimePayloadFromSession(
   session: ProviderSession,
-  extra?: {
-    readonly modelSelection?: unknown;
-    readonly providerOptions?: unknown;
-    readonly lastRuntimeEvent?: string;
-    readonly lastRuntimeEventAt?: string;
-    readonly lifecycleGeneration?: string;
-  },
+  extra?: SessionBindingExtra,
 ): Record<string, unknown> {
   return {
     cwd: session.cwd ?? null,
@@ -245,6 +347,12 @@ function toRuntimePayloadFromSession(
     ...(extra?.lifecycleGeneration !== undefined
       ? { lifecycleGeneration: extra.lifecycleGeneration }
       : {}),
+    ...(extra?.agentGatewayCredentialRotationRequired !== undefined
+      ? {
+          [AGENT_GATEWAY_CREDENTIAL_ROTATION_REQUIRED]:
+            extra.agentGatewayCredentialRotationRequired,
+        }
+      : {}),
   };
 }
 
@@ -252,7 +360,7 @@ function readPersistedModelSelection(
   runtimePayload: ProviderRuntimeBinding["runtimePayload"],
 ): ModelSelection | undefined {
   const raw = runtimePayloadRecord(runtimePayload).modelSelection;
-  return Schema.is(ModelSelection)(raw) ? raw : undefined;
+  return Option.getOrUndefined(Schema.decodeUnknownOption(ModelSelection)(raw));
 }
 
 function readPersistedProviderOptions(
@@ -279,6 +387,56 @@ function runtimePayloadRecord(value: unknown): Record<string, unknown> {
 
 function runtimeEventRetiredGatewayTurnAuthority(event: ProviderRuntimeEvent): boolean {
   return runtimePayloadRecord(event.raw?.payload)[AGENT_GATEWAY_TURN_AUTHORITY_RETIRED] === true;
+}
+
+function runtimeEventOwnsBinding(
+  event: ProviderRuntimeEvent,
+  binding: ProviderRuntimeBinding,
+): boolean {
+  if (binding.provider !== event.provider) return false;
+  if (event.profileId !== undefined && binding.profileId !== event.profileId) return false;
+  if (
+    event.lifecycleGeneration === undefined &&
+    binding.profileId !== DEFAULT_PROVIDER_PROFILE_ID
+  ) {
+    return false;
+  }
+  return (
+    event.lifecycleGeneration === undefined ||
+    binding.lifecycleGeneration === event.lifecycleGeneration
+  );
+}
+
+function runtimeEventOwnsAdmission(
+  event: ProviderRuntimeEvent,
+  binding: ProviderRuntimeBinding,
+  currentGeneration: string | undefined,
+): boolean {
+  if (event.lifecycleGeneration === undefined) {
+    return runtimeEventOwnsBinding(event, binding);
+  }
+  if (event.lifecycleGeneration !== currentGeneration) {
+    return false;
+  }
+  // A lifecycle run publishes its new generation before the replacement
+  // adapter can emit startup events and before the new binding is durable.
+  // During that narrow transition the generation is the ownership proof.
+  if (binding.lifecycleGeneration !== currentGeneration) {
+    return true;
+  }
+  return providerTargetsEqual(
+    providerTargetFromSource(event),
+    providerTargetFromSource(binding),
+  );
+}
+
+function runtimeEventOwnsUnboundAdmission(event: ProviderRuntimeEvent): boolean {
+  if (event.lifecycleGeneration !== undefined) {
+    return true;
+  }
+  return (
+    event.profileId === undefined || event.profileId === DEFAULT_PROVIDER_PROFILE_ID
+  );
 }
 
 function runtimeActiveTurnId(value: unknown): string | undefined {
@@ -364,6 +522,8 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
 
     const registry = yield* ProviderAdapterRegistry;
     const directory = yield* ProviderSessionDirectory;
+    const resolveProviderProfile =
+      options?.resolveProviderProfile ?? resolveDefaultProviderProfile;
     const lifecycle = makeProviderLifecycleCoordinator();
     for (const binding of yield* directory.listBindings()) {
       if (binding.lifecycleGeneration !== undefined) {
@@ -390,6 +550,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     const runtimeIdleGenerations = new Map<ThreadId, symbol>();
     const runtimeIdleStopsInFlight = new Map<ThreadId, Promise<void>>();
     const providerInterruptionFences = new Map<ThreadId, ProviderInterruptionFence>();
+    const failedUncommittedSessionRetirements = new Map<
+      ThreadId,
+      { readonly target: ProviderTarget; readonly failure: string }
+    >();
     const targetedChildInterruptTombstones = new Map<string, TargetedChildInterruptTombstone>();
     const runtimeIdleStopMs = Math.max(
       0,
@@ -535,6 +699,87 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         );
       });
 
+    const ensureUncommittedSessionRetirementSettled = (
+      threadId: ThreadId,
+      operation: string,
+    ): Effect.Effect<void, ProviderValidationError> => {
+      const failedRetirement = failedUncommittedSessionRetirements.get(threadId);
+      return failedRetirement === undefined
+        ? Effect.void
+        : Effect.fail(
+            toValidationError(
+              operation,
+              `Cannot continue thread '${threadId}' because uncommitted provider target ` +
+                `'${providerTargetLabel(failedRetirement.target)}' could not be retired safely: ` +
+                `${failedRetirement.failure}. Stop the provider session before retrying.`,
+            ),
+          );
+    };
+
+    const retireUncommittedSession = (input: {
+      readonly adapter: ProviderAdapterShape<ProviderAdapterError>;
+      readonly target: ProviderTarget;
+      readonly threadId: ThreadId;
+      readonly operation: string;
+    }): Effect.Effect<boolean> =>
+      input.adapter.stopSession(input.threadId).pipe(
+        Effect.timeoutOption(PROVIDER_STOP_SESSION_TIMEOUT),
+        Effect.flatMap(
+          Option.match({
+            onNone: () => {
+              const failure = `cleanup exceeded ${Duration.toMillis(
+                PROVIDER_STOP_SESSION_TIMEOUT,
+              )}ms`;
+              return Effect.sync(() => {
+                failedUncommittedSessionRetirements.set(input.threadId, {
+                  target: input.target,
+                  failure,
+                });
+              }).pipe(
+                Effect.andThen(
+                  Effect.logWarning(
+                    "provider session cleanup exceeded its deadline after an uncommitted start",
+                    {
+                      threadId: input.threadId,
+                      provider: input.target.provider,
+                      profileId: input.target.profileId,
+                      operation: input.operation,
+                      timeoutMs: Duration.toMillis(PROVIDER_STOP_SESSION_TIMEOUT),
+                    },
+                  ),
+                ),
+                Effect.as(false),
+              );
+            },
+            onSome: () =>
+              Effect.sync(() => {
+                failedUncommittedSessionRetirements.delete(input.threadId);
+                return true;
+              }),
+          }),
+        ),
+        Effect.catchCause((cause) => {
+          const failure = Cause.pretty(cause);
+          return Effect.sync(() => {
+            failedUncommittedSessionRetirements.set(input.threadId, {
+              target: input.target,
+              failure,
+            });
+          }).pipe(
+            Effect.andThen(
+              Effect.logWarning("failed to retire an uncommitted provider session", {
+                threadId: input.threadId,
+                provider: input.target.provider,
+                profileId: input.target.profileId,
+                operation: input.operation,
+                cause: failure,
+              }),
+            ),
+            Effect.as(false),
+          );
+        }),
+      );
+
     const acquireProviderInterruptionFence = (
       threadId: ThreadId,
     ): Effect.Effect<ProviderInterruptionFence, ProviderValidationError> =>
@@ -585,16 +830,30 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                   ),
                 )
               : Effect.void,
-          ),
+            ),
         );
+        const waitForUncommittedSessionRetirement =
+          ensureUncommittedSessionRetirementSettled(
+            threadId,
+            "ProviderService.turnDispatch",
+          );
         const existingIdleStop = runtimeIdleStopsInFlight.get(threadId);
         const displacedIdleStop = existingIdleStop !== undefined || runtimeIdleTimers.has(threadId);
         const waitForExistingIdleStop =
           existingIdleStop !== undefined ? Effect.promise(() => existingIdleStop) : Effect.void;
         return waitForInterruptionFence.pipe(
+          Effect.andThen(waitForUncommittedSessionRetirement),
           Effect.andThen(waitForExistingIdleStop),
           Effect.tap(() => Effect.sync(() => clearRuntimeIdleTimer(threadId))),
           Effect.flatMap(() => waitForRuntimeIdleStop(threadId)),
+          Effect.flatMap(() =>
+            lifecycle.runCurrent(threadId, () =>
+              ensureUncommittedSessionRetirementSettled(
+                threadId,
+                "ProviderService.turnDispatch",
+              ),
+            ),
+          ),
           Effect.flatMap(() => effect),
           Effect.onExit((exit) =>
             Exit.isSuccess(exit)
@@ -687,17 +946,12 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     const upsertSessionBinding = (
       session: ProviderSession,
       threadId: ThreadId,
-      extra?: {
-        readonly lifecycleGeneration?: string;
-        readonly modelSelection?: unknown;
-        readonly providerOptions?: unknown;
-        readonly lastRuntimeEvent?: string;
-        readonly lastRuntimeEventAt?: string;
-      },
+      extra?: SessionBindingExtra,
     ) =>
       directory.upsert({
         threadId,
         provider: session.provider,
+        profileId: providerTargetFromSource(session).profileId,
         runtimeMode: session.runtimeMode,
         status: toRuntimeStatus(session),
         ...(extra?.lifecycleGeneration !== undefined
@@ -716,6 +970,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         ? directory.upsert({
             threadId,
             provider: session.provider,
+            profileId: providerTargetFromSource(session).profileId,
             runtimeMode: session.runtimeMode,
             status: "stopped",
             ...(session.resumeCursor !== undefined ? { resumeCursor: session.resumeCursor } : {}),
@@ -727,11 +982,11 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               activeTurnId: null,
             },
           })
-        : directory.getProvider(threadId).pipe(
-            Effect.flatMap((provider) =>
+        : directory.getTarget(threadId).pipe(
+            Effect.flatMap((target) =>
               directory.upsert({
                 threadId,
-                provider,
+                ...target,
                 status: "stopped",
                 runtimePayload: {
                   activeTurnId: null,
@@ -756,7 +1011,15 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         const adapter = yield* registry.getByProvider(binding.provider);
         const sessions = yield* adapter.listSessions();
         const activeSession = sessions.find((session) => session.threadId === event.threadId);
-        return activeSession?.resumeCursor ?? binding.resumeCursor;
+        const compatibleActiveSession =
+          activeSession !== undefined &&
+          providerTargetsEqual(
+            providerTargetFromSource(activeSession),
+            providerTargetFromSource(binding),
+          )
+            ? activeSession
+            : undefined;
+        return compatibleActiveSession?.resumeCursor ?? binding.resumeCursor;
       }).pipe(
         Effect.catchCause((cause) =>
           Effect.logWarning("provider.session.resume_cursor_refresh_failed", {
@@ -810,7 +1073,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
 
     interface StartedTurnPersistenceInput {
       readonly threadId: ThreadId;
-      readonly provider: ProviderRuntimeBinding["provider"];
+      readonly target: ProviderTarget;
       readonly turnId: string;
       readonly generation: number;
       readonly resumeCursor?: unknown;
@@ -920,7 +1183,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             }
             yield* directory.upsert({
               threadId: input.threadId,
-              provider: input.provider,
+              ...input.target,
               status: "stopped",
               ...(input.resumeCursor !== undefined ? { resumeCursor: input.resumeCursor } : {}),
               ...(input.modelSelection !== undefined
@@ -937,7 +1200,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           clearRuntimeIdleTimer(input.threadId);
           yield* directory.upsert({
             threadId: input.threadId,
-            provider: input.provider,
+            ...input.target,
             status: "running",
             ...(input.resumeCursor !== undefined ? { resumeCursor: input.resumeCursor } : {}),
             runtimePayload: {
@@ -1002,6 +1265,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
 
     const updateSessionBindingFromRuntimeEvent = (
       event: ProviderRuntimeEvent,
+      currentGeneration: string | undefined,
     ): Effect.Effect<void> => {
       // Subagent-scoped events carry the parent thread id with the child
       // identity in providerRefs. Their turn/session lifecycle belongs to the
@@ -1028,131 +1292,126 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           return Effect.sync(() => reconcileRuntimeIdleTimer(event));
       }
 
-      return withBindingWriteLock(
-        event.threadId,
-        Effect.gen(function* () {
-          if (event.type === "turn.started" && event.turnId !== undefined) {
-            getDispatchState(event.threadId).outstandingTurnIds.add(String(event.turnId));
-          }
-          if (
-            (event.type === "turn.completed" || event.type === "turn.aborted") &&
-            event.turnId !== undefined &&
-            (dispatchStateByThread.get(event.threadId)?.inFlightGenerations.size ?? 0) > 0
-          ) {
-            recordRecentlyCompletedTurn(event.threadId, String(event.turnId));
-          }
-          const binding = Option.getOrUndefined(yield* directory.getBinding(event.threadId));
-          if (!binding) {
-            reconcileRuntimeIdleTimer(event);
-            return;
-          }
-          if (binding.provider !== event.provider) {
-            return;
-          }
-          if (
-            event.lifecycleGeneration !== undefined &&
-            binding.lifecycleGeneration !== event.lifecycleGeneration
-          ) {
-            return;
-          }
+      return Effect.gen(function* () {
+        const binding = Option.getOrUndefined(yield* directory.getBinding(event.threadId));
+        if (
+          binding !== undefined &&
+          !runtimeEventOwnsAdmission(event, binding, currentGeneration)
+        ) {
+          return;
+        }
+        if (event.type === "turn.started" && event.turnId !== undefined) {
+          getDispatchState(event.threadId).outstandingTurnIds.add(String(event.turnId));
+        }
+        if (
+          (event.type === "turn.completed" || event.type === "turn.aborted") &&
+          event.turnId !== undefined &&
+          (dispatchStateByThread.get(event.threadId)?.inFlightGenerations.size ?? 0) > 0
+        ) {
+          recordRecentlyCompletedTurn(event.threadId, String(event.turnId));
+        }
+        if (binding === undefined) {
+          reconcileRuntimeIdleTimer(event);
+          return;
+        }
 
-          const currentActiveTurnId = runtimeActiveTurnId(binding.runtimePayload);
-          if (
-            event.type === "turn.started" &&
-            !isStartedTurnApplicable({
-              activeTurnId: currentActiveTurnId,
-              eventTurnId: event.turnId === undefined ? undefined : String(event.turnId),
-            })
-          ) {
-            return;
-          }
-          if (event.type === "turn.completed" || event.type === "turn.aborted") {
-            const applicability = classifyTerminalTurnApplicability({
-              activeTurnId: currentActiveTurnId,
-              eventTurnId: event.turnId === undefined ? undefined : String(event.turnId),
-              hasAmbiguousTurns: hasAmbiguousTerminalTurn(event.threadId),
-            });
-            if (!applicability.applicable) {
-              if (event.turnId !== undefined) {
-                dispatchStateByThread
-                  .get(event.threadId)
-                  ?.outstandingTurnIds.delete(String(event.turnId));
-                cleanupDispatchState(event.threadId);
-              }
-              if (applicability.reason === "ambiguous-missing-turn-id") {
-                yield* Effect.logWarning("provider.session.ambiguous_terminal_event_ignored", {
-                  threadId: event.threadId,
-                  eventType: event.type,
-                });
-              }
-              return;
-            }
-            if (event.turnId === undefined && applicability.resolvedTurnId !== undefined) {
-              recordRecentlyCompletedTurn(event.threadId, applicability.resolvedTurnId);
-            }
-            if (applicability.resolvedTurnId !== undefined) {
+        const currentActiveTurnId = runtimeActiveTurnId(binding.runtimePayload);
+        if (
+          event.type === "turn.started" &&
+          !isStartedTurnApplicable({
+            activeTurnId: currentActiveTurnId,
+            eventTurnId: event.turnId === undefined ? undefined : String(event.turnId),
+          })
+        ) {
+          return;
+        }
+        if (event.type === "turn.completed" || event.type === "turn.aborted") {
+          const applicability = classifyTerminalTurnApplicability({
+            activeTurnId: currentActiveTurnId,
+            eventTurnId: event.turnId === undefined ? undefined : String(event.turnId),
+            hasAmbiguousTurns: hasAmbiguousTerminalTurn(event.threadId),
+          });
+          if (!applicability.applicable) {
+            if (event.turnId !== undefined) {
               dispatchStateByThread
                 .get(event.threadId)
-                ?.outstandingTurnIds.delete(applicability.resolvedTurnId);
+                ?.outstandingTurnIds.delete(String(event.turnId));
               cleanupDispatchState(event.threadId);
             }
-          }
-          const activeTurnId =
-            event.type === "turn.started"
-              ? (event.turnId ?? null)
-              : event.type === "thread.state.changed" && event.payload.state === "compacted"
-                ? (event.turnId ?? currentActiveTurnId)
-                : event.type === "turn.completed" ||
-                    event.type === "turn.aborted" ||
-                    (event.type === "thread.state.changed" &&
-                      (event.payload.state === "archived" ||
-                        event.payload.state === "closed" ||
-                        event.payload.state === "error")) ||
-                    event.type === "session.exited" ||
-                    event.type === "runtime.error" ||
-                    (event.type === "session.state.changed" &&
-                      (event.payload.state === "ready" ||
-                        event.payload.state === "stopped" ||
-                        event.payload.state === "error"))
-                  ? null
-                  : currentActiveTurnId;
-          const lastError = runtimeLastErrorForEvent(event);
-          const resumeCursor = yield* refreshResumeCursorFromActiveSession(event, binding);
-
-          yield* directory.upsert({
-            threadId: event.threadId,
-            provider: binding.provider,
-            ...(binding.adapterKey !== undefined ? { adapterKey: binding.adapterKey } : {}),
-            ...(binding.runtimeMode !== undefined ? { runtimeMode: binding.runtimeMode } : {}),
-            status: runtimeStatusForEvent(event, activeTurnId),
-            ...(resumeCursor !== undefined ? { resumeCursor } : {}),
-            runtimePayload: {
-              activeTurnId,
-              lastRuntimeEvent: event.type,
-              lastRuntimeEventAt: event.createdAt,
-              ...(lastError !== undefined ? { lastError } : {}),
-              ...(runtimeEventRetiredGatewayTurnAuthority(event)
-                ? { [AGENT_GATEWAY_CREDENTIAL_ROTATION_REQUIRED]: true }
-                : {}),
-            },
-          });
-          if (event.type === "session.exited") {
-            const dispatchState = dispatchStateByThread.get(event.threadId);
-            if (dispatchState) {
-              // Invalidate adapter calls that were already in flight when the
-              // session exited, then retain only the generations needed for
-              // their eventual settlement/cleanup.
-              dispatchState.latestGeneration = dispatchState.nextGeneration + 1;
-              dispatchState.nextGeneration = dispatchState.latestGeneration;
-              dispatchState.outstandingTurnIds.clear();
-              dispatchState.successfulResults.clear();
+            if (applicability.reason === "ambiguous-missing-turn-id") {
+              yield* Effect.logWarning("provider.session.ambiguous_terminal_event_ignored", {
+                threadId: event.threadId,
+                eventType: event.type,
+              });
             }
-            recentlyCompletedTurnsByThread.delete(event.threadId);
+            return;
+          }
+          if (event.turnId === undefined && applicability.resolvedTurnId !== undefined) {
+            recordRecentlyCompletedTurn(event.threadId, applicability.resolvedTurnId);
+          }
+          if (applicability.resolvedTurnId !== undefined) {
+            dispatchStateByThread
+              .get(event.threadId)
+              ?.outstandingTurnIds.delete(applicability.resolvedTurnId);
             cleanupDispatchState(event.threadId);
           }
-          reconcileRuntimeIdleTimer(event);
-        }),
-      ).pipe(
+        }
+        const activeTurnId =
+          event.type === "turn.started"
+            ? (event.turnId ?? null)
+            : event.type === "thread.state.changed" && event.payload.state === "compacted"
+              ? (event.turnId ?? currentActiveTurnId)
+              : event.type === "turn.completed" ||
+                  event.type === "turn.aborted" ||
+                  (event.type === "thread.state.changed" &&
+                    (event.payload.state === "archived" ||
+                      event.payload.state === "closed" ||
+                      event.payload.state === "error")) ||
+                  event.type === "session.exited" ||
+                  event.type === "runtime.error" ||
+                  (event.type === "session.state.changed" &&
+                    (event.payload.state === "ready" ||
+                      event.payload.state === "stopped" ||
+                      event.payload.state === "error"))
+                ? null
+                : currentActiveTurnId;
+        const lastError = runtimeLastErrorForEvent(event);
+        const resumeCursor = yield* refreshResumeCursorFromActiveSession(event, binding);
+
+        yield* directory.upsert({
+          threadId: event.threadId,
+          provider: binding.provider,
+          profileId: binding.profileId,
+          ...(binding.adapterKey !== undefined ? { adapterKey: binding.adapterKey } : {}),
+          ...(binding.runtimeMode !== undefined ? { runtimeMode: binding.runtimeMode } : {}),
+          status: runtimeStatusForEvent(event, activeTurnId),
+          ...(resumeCursor !== undefined ? { resumeCursor } : {}),
+          runtimePayload: {
+            activeTurnId,
+            lastRuntimeEvent: event.type,
+            lastRuntimeEventAt: event.createdAt,
+            ...(lastError !== undefined ? { lastError } : {}),
+            ...(runtimeEventRetiredGatewayTurnAuthority(event)
+              ? { [AGENT_GATEWAY_CREDENTIAL_ROTATION_REQUIRED]: true }
+              : {}),
+          },
+        });
+        if (event.type === "session.exited") {
+          const dispatchState = dispatchStateByThread.get(event.threadId);
+          if (dispatchState) {
+            // Invalidate adapter calls that were already in flight when the
+            // session exited, then retain only the generations needed for
+            // their eventual settlement/cleanup.
+            dispatchState.latestGeneration = dispatchState.nextGeneration + 1;
+            dispatchState.nextGeneration = dispatchState.latestGeneration;
+            dispatchState.outstandingTurnIds.clear();
+            dispatchState.successfulResults.clear();
+          }
+          recentlyCompletedTurnsByThread.delete(event.threadId);
+          cleanupDispatchState(event.threadId);
+        }
+        reconcileRuntimeIdleTimer(event);
+      }).pipe(
         Effect.catchCause((cause) =>
           Effect.logWarning("provider.session.runtime_binding_update_failed", {
             threadId: event.threadId,
@@ -1171,39 +1430,73 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     let scheduleRetiredGatewaySessionRecovery = (
       _event: ProviderRuntimeEvent,
     ): Effect.Effect<void> => Effect.void;
+    const processAdmittedRuntimeEvent = (
+      event: ProviderRuntimeEvent,
+      currentGeneration: string | undefined,
+    ): Effect.Effect<void, unknown> =>
+      // Journal before mutating lifecycle/task state. If durable persistence
+      // fails, the supervised pump retries while ownership is still current.
+      persistCanonicalRuntimeEvent(event).pipe(
+        Effect.flatMap((persisted) =>
+          Effect.sync(() => {
+            if (event.type === "turn.started") {
+              reconcileRuntimeIdleTimer(event);
+            }
+          }).pipe(
+            Effect.andThen(updateSessionBindingFromRuntimeEvent(event, currentGeneration)),
+            Effect.andThen(publishRuntimeEvent(event, persisted)),
+            Effect.andThen(scheduleRetiredGatewaySessionRecovery(event)),
+          ),
+        ),
+      );
     const processRuntimeEvent = (event: ProviderRuntimeEvent): Effect.Effect<void, unknown> =>
       Effect.uninterruptible(
-        Effect.suspend(() => {
+        lifecycle.runStable(event.threadId, (currentGeneration) => {
           if (
             event.lifecycleGeneration !== undefined &&
-            lifecycle.currentGeneration(event.threadId) !== event.lifecycleGeneration
+            currentGeneration !== event.lifecycleGeneration
           ) {
-            // Warn, not debug: a persistent mismatch silently discards every
-            // runtime event for the thread — the provider runs, the UI shows
-            // nothing, and the runtime reconciler later settles the turn as
-            // interrupted. This log line is the only way to see it happening.
             return Effect.logWarning("provider.session.stale_generation_event_ignored", {
               threadId: event.threadId,
               provider: event.provider,
               eventType: event.type,
               eventLifecycleGeneration: event.lifecycleGeneration,
-              currentLifecycleGeneration: lifecycle.currentGeneration(event.threadId),
+              currentLifecycleGeneration: currentGeneration,
             });
           }
-          const canonicalEvent = event;
-          // Journal before mutating lifecycle/task state. If durable persistence
-          // fails, the supervised pump retries the same event while its source
-          // generation is still current and no recovery waiter has been released.
-          return persistCanonicalRuntimeEvent(canonicalEvent).pipe(
-            Effect.flatMap((persisted) =>
-              Effect.sync(() => {
-                if (canonicalEvent.type === "turn.started") {
-                  reconcileRuntimeIdleTimer(canonicalEvent);
-                }
-              }).pipe(
-                Effect.andThen(updateSessionBindingFromRuntimeEvent(canonicalEvent)),
-                Effect.andThen(publishRuntimeEvent(canonicalEvent, persisted)),
-                Effect.andThen(scheduleRetiredGatewaySessionRecovery(canonicalEvent)),
+          return withBindingWriteLock(
+            event.threadId,
+            directory.getBinding(event.threadId).pipe(
+              Effect.flatMap(
+                Option.match({
+                  // Startup and live-session fallback events can arrive before the
+                  // first binding write. Preserve that established admission path.
+                  onNone: () =>
+                    runtimeEventOwnsUnboundAdmission(event)
+                      ? processAdmittedRuntimeEvent(event, currentGeneration)
+                      : Effect.logWarning("provider.session.stale_target_event_ignored", {
+                          threadId: event.threadId,
+                          eventType: event.type,
+                          eventProvider: event.provider,
+                          eventProfileId: event.profileId,
+                          eventLifecycleGeneration: event.lifecycleGeneration,
+                        }),
+                  // The binding lock and stable generation jointly keep target
+                  // replacement outside admission, journal, and publication.
+                  onSome: (binding) =>
+                    runtimeEventOwnsAdmission(event, binding, currentGeneration)
+                      ? processAdmittedRuntimeEvent(event, currentGeneration)
+                      : Effect.logWarning("provider.session.stale_target_event_ignored", {
+                          threadId: event.threadId,
+                          eventType: event.type,
+                          eventProvider: event.provider,
+                          eventProfileId: event.profileId,
+                          eventLifecycleGeneration: event.lifecycleGeneration,
+                          bindingProvider: binding.provider,
+                          bindingProfileId: binding.profileId,
+                          bindingLifecycleGeneration: binding.lifecycleGeneration,
+                        }),
+                }),
               ),
             ),
           );
@@ -1216,6 +1509,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     }) =>
       Effect.gen(function* () {
         const threadId = input.binding.threadId;
+        yield* ensureUncommittedSessionRetirementSettled(threadId, input.operation);
         const getCurrentBinding = () =>
           directory.getBinding(threadId).pipe(
             Effect.flatMap(
@@ -1238,7 +1532,12 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         // could wait forever.
         yield* lifecycle.runCurrent(threadId, () =>
           Effect.gen(function* () {
+            yield* ensureUncommittedSessionRetirementSettled(threadId, input.operation);
             let binding = yield* getCurrentBinding();
+            let target = yield* resolveProviderProfile({
+              operation: input.operation,
+              target: providerTargetFromSource(binding),
+            });
             const requiresCredentialRotation =
               runtimePayloadRecord(binding.runtimePayload)[
                 AGENT_GATEWAY_CREDENTIAL_ROTATION_REQUIRED
@@ -1247,7 +1546,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               return;
             }
 
-            let adapter = yield* registry.getByProvider(binding.provider);
+            let adapter = yield* registry.getByProvider(target.provider);
             if (!(yield* adapter.hasSession(threadId))) {
               return;
             }
@@ -1257,6 +1556,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             // The drain may have waited for a while. Re-read all durable
             // routing state before stopping anything.
             binding = yield* getCurrentBinding();
+            target = yield* resolveProviderProfile({
+              operation: input.operation,
+              target: providerTargetFromSource(binding),
+            });
             if (
               runtimePayloadRecord(binding.runtimePayload)[
                 AGENT_GATEWAY_CREDENTIAL_ROTATION_REQUIRED
@@ -1264,7 +1567,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             ) {
               return;
             }
-            adapter = yield* registry.getByProvider(binding.provider);
+            adapter = yield* registry.getByProvider(target.provider);
             if (!(yield* adapter.hasSession(threadId))) {
               return;
             }
@@ -1272,12 +1575,22 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             const activeSession = (yield* adapter.listSessions()).find(
               (session) => session.threadId === threadId,
             );
+            if (
+              !activeSession ||
+              !providerTargetsEqual(providerTargetFromSource(activeSession), target)
+            ) {
+              return yield* toValidationError(
+                input.operation,
+                `Cannot recover thread '${threadId}' because its active provider target does not match '${providerTargetLabel(target)}'.`,
+              );
+            }
             if (activeSession?.resumeCursor !== undefined) {
               yield* withBindingWriteLock(
                 threadId,
                 directory.upsert({
                   threadId,
                   provider: binding.provider,
+                  profileId: binding.profileId,
                   resumeCursor: activeSession.resumeCursor,
                 }),
               );
@@ -1288,25 +1601,38 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
 
         return yield* lifecycle.run(threadId, (lease) =>
           Effect.gen(function* () {
+            yield* ensureUncommittedSessionRetirementSettled(threadId, input.operation);
             const binding = yield* getCurrentBinding();
-            const adapter = yield* registry.getByProvider(binding.provider);
+            const target = yield* resolveProviderProfile({
+              operation: input.operation,
+              target: providerTargetFromSource(binding),
+            });
+            const adapter = yield* registry.getByProvider(target.provider);
             const hasPersistedResumeCursor = hasResumeCursor(binding.resumeCursor);
             const requiresCredentialRotation =
               runtimePayloadRecord(binding.runtimePayload)[
                 AGENT_GATEWAY_CREDENTIAL_ROTATION_REQUIRED
               ] === true;
             const hasActiveSession = yield* adapter.hasSession(threadId);
+            const activeSession = hasActiveSession
+              ? (yield* adapter.listSessions()).find((session) => session.threadId === threadId)
+              : undefined;
+            const activeSessionMatchesTarget =
+              activeSession !== undefined &&
+              providerTargetsEqual(providerTargetFromSource(activeSession), target);
 
             // A concurrent recovery may have won between the drain and restart
             // phases. Adopt its fresh runtime instead of replacing it again.
-            if (hasActiveSession && !requiresCredentialRotation) {
-              const existing = (yield* adapter.listSessions()).find(
-                (session) => session.threadId === threadId,
+            if (activeSessionMatchesTarget && !requiresCredentialRotation) {
+              yield* lease.adopt(binding.lifecycleGeneration ?? "legacy");
+              return adapter;
+            }
+
+            if (hasActiveSession && !activeSessionMatchesTarget) {
+              return yield* toValidationError(
+                input.operation,
+                `Cannot recover thread '${threadId}' because its active provider target does not match '${providerTargetLabel(target)}'.`,
               );
-              if (existing) {
-                lease.adopt(binding.lifecycleGeneration ?? "legacy");
-                return adapter;
-              }
             }
 
             if (hasActiveSession && requiresCredentialRotation) {
@@ -1324,51 +1650,83 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             }
 
             const persistedCwd = readPersistedCwd(binding.runtimePayload);
-            const persistedModelSelection = readPersistedModelSelection(binding.runtimePayload);
+            const persistedModelSelection = yield* modelSelectionForTarget({
+              operation: input.operation,
+              modelSelection: readPersistedModelSelection(binding.runtimePayload),
+              target,
+            });
             const persistedProviderOptions = readPersistedProviderOptions(binding.runtimePayload);
             yield* validateAutoRuntimeMode(
               input.operation,
-              binding.provider,
+              target.provider,
               binding.runtimeMode ?? "full-access",
             );
 
-            const resumed = yield* adapter.startSession({
-              threadId,
-              provider: binding.provider,
-              lifecycleGeneration: lease.generation,
-              ...(persistedCwd ? { cwd: persistedCwd } : {}),
-              ...(persistedModelSelection ? { modelSelection: persistedModelSelection } : {}),
-              ...(persistedProviderOptions ? { providerOptions: persistedProviderOptions } : {}),
-              ...(hasPersistedResumeCursor ? { resumeCursor: binding.resumeCursor } : {}),
-              runtimeMode: binding.runtimeMode ?? "full-access",
-            });
-            if (resumed.provider !== adapter.provider) {
-              return yield* toValidationError(
-                input.operation,
-                `Adapter/provider mismatch while recovering thread '${threadId}'. Expected '${adapter.provider}', received '${resumed.provider}'.`,
-              );
-            }
+            let recoveryStartAttempted = false;
+            const resumeAndCommit = Effect.gen(function* () {
+              recoveryStartAttempted = true;
+              const started = yield* adapter
+                .startSession({
+                  threadId,
+                  provider: target.provider,
+                  profileId: target.profileId,
+                  lifecycleGeneration: lease.generation,
+                  ...(persistedCwd ? { cwd: persistedCwd } : {}),
+                  ...(persistedModelSelection ? { modelSelection: persistedModelSelection } : {}),
+                  ...(persistedProviderOptions
+                    ? { providerOptions: persistedProviderOptions }
+                    : {}),
+                  ...(hasPersistedResumeCursor ? { resumeCursor: binding.resumeCursor } : {}),
+                  runtimeMode: binding.runtimeMode ?? "full-access",
+                })
+                .pipe(Effect.timeoutOption(PROVIDER_START_SESSION_TIMEOUT));
+              if (Option.isNone(started)) {
+                yield* Effect.logError("provider session recovery exceeded its deadline", {
+                  threadId,
+                  provider: target.provider,
+                  profileId: target.profileId,
+                  operation: input.operation,
+                  timeoutMs: Duration.toMillis(PROVIDER_START_SESSION_TIMEOUT),
+                });
+                return yield* toValidationError(
+                  input.operation,
+                  `Provider '${target.provider}' did not finish recovering within ${Duration.toMillis(
+                    PROVIDER_START_SESSION_TIMEOUT,
+                  )}ms for thread '${threadId}'.`,
+                );
+              }
+              const resumed = started.value;
+              const resumedSession = yield* sessionWithExpectedTarget({
+                operation: input.operation,
+                session: resumed,
+                target,
+              });
 
-            yield* withBindingWriteLock(
-              threadId,
-              upsertSessionBinding(resumed, threadId, {
-                lifecycleGeneration: lease.generation,
-              }).pipe(
-                Effect.andThen(
-                  requiresCredentialRotation
-                    ? directory.upsert({
-                        threadId,
-                        provider: binding.provider,
-                        runtimePayload: {
-                          [AGENT_GATEWAY_CREDENTIAL_ROTATION_REQUIRED]: false,
-                        },
-                      })
-                    : Effect.void,
-                ),
+              yield* withBindingWriteLock(
+                threadId,
+                upsertSessionBinding(resumedSession, threadId, {
+                  lifecycleGeneration: lease.generation,
+                  ...(requiresCredentialRotation
+                    ? { agentGatewayCredentialRotationRequired: false }
+                    : {}),
+                }),
+              );
+              lease.commit();
+              return adapter;
+            });
+
+            return yield* resumeAndCommit.pipe(
+              Effect.onExit((exit) =>
+                Exit.isFailure(exit) && recoveryStartAttempted
+                  ? retireUncommittedSession({
+                      adapter,
+                      target,
+                      threadId,
+                      operation: input.operation,
+                    }).pipe(Effect.asVoid)
+                  : Effect.void,
               ),
             );
-            lease.commit();
-            return adapter;
           }),
         );
       });
@@ -1472,8 +1830,18 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           // the provider binding, but the adapter already owns a live session.
           const liveAdapter = yield* findLiveSessionAdapter(input.threadId);
           if (liveAdapter) {
+            const liveSession = (yield* liveAdapter.listSessions()).find(
+              (session) => session.threadId === input.threadId,
+            );
+            const target = yield* resolveProviderProfile({
+              operation: input.operation,
+              target: liveSession
+                ? providerTargetFromSource(liveSession)
+                : providerTargetFromSource({ provider: liveAdapter.provider }),
+            });
             return {
               adapter: liveAdapter,
+              target,
               isActive: true,
               lifecycleGeneration: lifecycle.currentGeneration(input.threadId),
             } as const;
@@ -1483,24 +1851,47 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             `Cannot route thread '${input.threadId}' because no persisted provider binding exists.`,
           );
         }
-        const adapter = yield* registry.getByProvider(binding.provider);
+        const target = yield* resolveProviderProfile({
+          operation: input.operation,
+          target: providerTargetFromSource(binding),
+        });
+        const adapter = yield* registry.getByProvider(target.provider);
 
         const hasActiveSession = yield* adapter.hasSession(input.threadId);
+        const activeSession = hasActiveSession
+          ? (yield* adapter.listSessions()).find((session) => session.threadId === input.threadId)
+          : undefined;
+        const activeSessionMatchesTarget =
+          activeSession !== undefined &&
+          providerTargetsEqual(providerTargetFromSource(activeSession), target);
         const requiresCredentialRotation =
           runtimePayloadRecord(binding.runtimePayload)[
             AGENT_GATEWAY_CREDENTIAL_ROTATION_REQUIRED
           ] === true;
-        if (hasActiveSession && (!input.allowRecovery || !requiresCredentialRotation)) {
+        if (
+          hasActiveSession &&
+          activeSessionMatchesTarget &&
+          (!input.allowRecovery || !requiresCredentialRotation)
+        ) {
           return {
             adapter,
+            target,
             isActive: true,
             lifecycleGeneration: binding.lifecycleGeneration,
           } as const;
         }
 
+        if (hasActiveSession && !activeSessionMatchesTarget && !input.allowRecovery) {
+          return yield* toValidationError(
+            input.operation,
+            `Cannot route thread '${input.threadId}' because its active provider target does not match '${providerTargetLabel(target)}'.`,
+          );
+        }
+
         if (!input.allowRecovery) {
           return {
             adapter,
+            target,
             isActive: false,
             lifecycleGeneration: binding.lifecycleGeneration,
           } as const;
@@ -1508,6 +1899,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
 
         return {
           adapter: yield* recoverSessionForThread({ binding, operation: input.operation }),
+          target,
           isActive: true,
           lifecycleGeneration: lifecycle.currentGeneration(input.threadId),
         } as const;
@@ -1521,18 +1913,31 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           payload: rawInput,
         });
 
+        const target = yield* sessionStartTarget(parsed).pipe(
+          Effect.flatMap((requestedTarget) =>
+            resolveProviderProfile({
+              operation: "ProviderService.startSession",
+              target: requestedTarget,
+            }),
+          ),
+        );
         const input = {
           ...parsed,
           threadId,
-          provider: parsed.provider ?? "codex",
+          provider: target.provider,
+          profileId: target.profileId,
         };
         yield* validateAutoRuntimeMode(
           "ProviderService.startSession",
           input.provider,
           input.runtimeMode,
         );
-        // An explicit start is the recovery authority for a failed retirement,
-        // but it must never interleave with one still in progress. Capture the
+        yield* ensureUncommittedSessionRetirementSettled(
+          threadId,
+          "ProviderService.startSession",
+        );
+        // An explicit start is the recovery authority for a settled interruption
+        // fence, but it must never interleave with one still in progress. Capture the
         // exact settled fence so this replacement cannot delete a newer fence
         // that was published while provider startup was running.
         const replacementFence = yield* waitForCurrentInterruptionFence(threadId);
@@ -1540,24 +1945,38 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         yield* waitForRuntimeIdleStop(threadId);
         return yield* lifecycle.run(threadId, (lease) =>
           Effect.gen(function* () {
+            yield* ensureUncommittedSessionRetirementSettled(
+              threadId,
+              "ProviderService.startSession",
+            );
             const persistedBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+            const persistedTarget = persistedBinding
+              ? providerTargetFromSource(persistedBinding)
+              : undefined;
+            const compatiblePersistedBinding =
+              persistedBinding &&
+              persistedTarget &&
+              providerTargetsEqual(target, persistedTarget)
+                ? persistedBinding
+                : undefined;
             const effectiveResumeCursor =
               input.forkSourceResumeCursor !== undefined
                 ? undefined
                 : (input.resumeCursor ??
-                  (persistedBinding?.provider === input.provider
-                    ? persistedBinding.resumeCursor
-                    : undefined));
+                  compatiblePersistedBinding?.resumeCursor);
             const adapterStartInput = { ...input };
             delete adapterStartInput.resumeCursor;
             const effectiveProviderOptions =
               input.providerOptions ??
-              (persistedBinding?.provider === input.provider
-                ? readPersistedProviderOptions(persistedBinding.runtimePayload)
+              (compatiblePersistedBinding
+                ? readPersistedProviderOptions(compatiblePersistedBinding.runtimePayload)
                 : undefined);
-            const adapter = yield* registry.getByProvider(input.provider);
-            let replacementStarted = false;
+            const adapter = yield* registry.getByProvider(target.provider);
+            let replacementStartAttempted = false;
+            let replacementCleanupRequired = false;
+            let replacementCleanupSucceeded = false;
             const startAndPersistReplacement = Effect.gen(function* () {
+              replacementStartAttempted = true;
               // A provider start that never returns holds this thread's
               // lifecycle lock and the caller's command slot forever. Bound it,
               // retire whatever the adapter may have half-spawned, and fail
@@ -1580,16 +1999,6 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                   provider: input.provider,
                   timeoutMs: Duration.toMillis(PROVIDER_START_SESSION_TIMEOUT),
                 });
-                yield* adapter.stopSession(threadId).pipe(
-                  Effect.timeoutOption(PROVIDER_STOP_SESSION_TIMEOUT),
-                  Effect.catchCause((cause) =>
-                    Effect.logWarning("failed to retire a timed-out provider session start", {
-                      threadId,
-                      provider: input.provider,
-                      cause: Cause.pretty(cause),
-                    }),
-                  ),
-                );
                 return yield* toValidationError(
                   "ProviderService.startSession",
                   `Provider '${input.provider}' did not finish starting within ${Duration.toMillis(
@@ -1597,15 +2006,12 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                   )}ms for thread '${threadId}'.`,
                 );
               }
-              const session = started.value;
-              replacementStarted = true;
-
-              if (session.provider !== adapter.provider) {
-                return yield* toValidationError(
-                  "ProviderService.startSession",
-                  `Adapter/provider mismatch: requested '${adapter.provider}', received '${session.provider}'.`,
-                );
-              }
+              const startedSession = started.value;
+              const session = yield* sessionWithExpectedTarget({
+                operation: "ProviderService.startSession",
+                session: startedSession,
+                target,
+              });
 
               yield* withBindingWriteLock(
                 threadId,
@@ -1613,17 +2019,8 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                   modelSelection: input.modelSelection,
                   providerOptions: effectiveProviderOptions,
                   lifecycleGeneration: lease.generation,
-                }).pipe(
-                  Effect.andThen(
-                    directory.upsert({
-                      threadId,
-                      provider: session.provider,
-                      runtimePayload: {
-                        [AGENT_GATEWAY_CREDENTIAL_ROTATION_REQUIRED]: false,
-                      },
-                    }),
-                  ),
-                ),
+                  agentGatewayCredentialRotationRequired: false,
+                }),
               );
               lease.commit();
               if (
@@ -1634,21 +2031,44 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               }
 
               return session;
-            });
+            }).pipe(
+              Effect.onExit((exit) => {
+                replacementCleanupRequired =
+                  Exit.isFailure(exit) && replacementStartAttempted;
+                return replacementCleanupRequired
+                  ? retireUncommittedSession({
+                      adapter,
+                      target,
+                      threadId,
+                      operation: "ProviderService.startSession",
+                    }).pipe(
+                      Effect.tap((cleanupSucceeded) =>
+                        Effect.sync(() => {
+                          replacementCleanupSucceeded = cleanupSucceeded;
+                        }),
+                      ),
+                      Effect.asVoid,
+                    )
+                  : Effect.void;
+              }),
+            );
 
-            if (!persistedBinding || persistedBinding.provider === input.provider) {
+            if (!persistedBinding || compatiblePersistedBinding) {
               return yield* startAndPersistReplacement;
             }
 
-            const previousAdapter = yield* registry.getByProvider(persistedBinding.provider);
+            const previousTarget = providerTargetFromSource(persistedBinding);
+            const previousAdapter = yield* registry.getByProvider(previousTarget.provider);
             if (!(yield* previousAdapter.hasSession(threadId))) {
               return yield* startAndPersistReplacement;
             }
 
             const previousGeneration = persistedBinding.lifecycleGeneration ?? "legacy";
-            const previousModelSelection = readPersistedModelSelection(
-              persistedBinding.runtimePayload,
-            );
+            const previousModelSelection = yield* modelSelectionForTarget({
+              operation: "ProviderService.startSession",
+              modelSelection: readPersistedModelSelection(persistedBinding.runtimePayload),
+              target: previousTarget,
+            });
             const previousProviderOptions = readPersistedProviderOptions(
               persistedBinding.runtimePayload,
             );
@@ -1661,46 +2081,92 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                   ? Effect.void
                   : Effect.gen(function* () {
                       // A provider switch is stop-first so one thread is never dual-owned.
-                      // If anything after the stop fails, retire a partially started
-                      // replacement before restoring the exact previous generation.
-                      if (replacementStarted) {
-                        yield* adapter.stopSession(threadId);
+                      // The replacement effect retires any runtime it created
+                      // before this rollback restores the exact previous generation.
+                      if (replacementCleanupRequired && !replacementCleanupSucceeded) {
+                        yield* Effect.logError(
+                          "skipping previous provider restoration because replacement cleanup failed",
+                          {
+                            threadId,
+                            previousProvider: previousTarget.provider,
+                            replacementProvider: target.provider,
+                          },
+                        );
+                        return;
                       }
-                      const restored = yield* previousAdapter.startSession({
-                        threadId,
-                        provider: persistedBinding.provider,
-                        lifecycleGeneration: previousGeneration,
-                        runtimeMode: persistedBinding.runtimeMode ?? "full-access",
-                        ...(previousCwd !== undefined ? { cwd: previousCwd } : {}),
-                        ...(previousModelSelection !== undefined
-                          ? { modelSelection: previousModelSelection }
-                          : {}),
-                        ...(previousProviderOptions !== undefined
-                          ? { providerOptions: previousProviderOptions }
-                          : {}),
-                        ...(persistedBinding.resumeCursor !== undefined
-                          ? { resumeCursor: persistedBinding.resumeCursor }
-                          : {}),
-                      });
-                      if (restored.provider !== previousAdapter.provider) {
-                        return yield* toValidationError(
-                          "ProviderService.startSession",
-                          `Adapter/provider mismatch while restoring '${previousAdapter.provider}': received '${restored.provider}'.`,
+                      // Publish the restored generation before starting the
+                      // previous runtime: adapters can emit startup events
+                      // before startSession returns and before binding upsert.
+                      yield* lease.adopt(previousGeneration);
+                      let restorationStartAttempted = false;
+                      const restorePreviousSession = Effect.gen(function* () {
+                        restorationStartAttempted = true;
+                        const started = yield* previousAdapter
+                          .startSession({
+                            threadId,
+                            provider: previousTarget.provider,
+                            profileId: previousTarget.profileId,
+                            lifecycleGeneration: previousGeneration,
+                            runtimeMode: persistedBinding.runtimeMode ?? "full-access",
+                            ...(previousCwd !== undefined ? { cwd: previousCwd } : {}),
+                            ...(previousModelSelection !== undefined
+                              ? { modelSelection: previousModelSelection }
+                              : {}),
+                            ...(previousProviderOptions !== undefined
+                              ? { providerOptions: previousProviderOptions }
+                              : {}),
+                            ...(persistedBinding.resumeCursor !== undefined
+                              ? { resumeCursor: persistedBinding.resumeCursor }
+                              : {}),
+                          })
+                          .pipe(Effect.timeoutOption(PROVIDER_START_SESSION_TIMEOUT));
+                        if (Option.isNone(started)) {
+                          return yield* toValidationError(
+                            "ProviderService.startSession",
+                            `Provider '${previousTarget.provider}' did not finish restoring within ${Duration.toMillis(
+                              PROVIDER_START_SESSION_TIMEOUT,
+                            )}ms for thread '${threadId}'.`,
+                          );
+                        }
+                        const restoredSession = yield* sessionWithExpectedTarget({
+                          operation: "ProviderService.startSession",
+                          session: started.value,
+                          target: previousTarget,
+                        });
+                        yield* withBindingWriteLock(
+                          threadId,
+                          upsertSessionBinding(restoredSession, threadId, {
+                            lifecycleGeneration: previousGeneration,
+                            modelSelection: previousModelSelection,
+                            providerOptions: previousProviderOptions,
+                          }),
+                        );
+                      }).pipe(
+                        Effect.onExit((restoreExit) =>
+                          Exit.isFailure(restoreExit) && restorationStartAttempted
+                            ? retireUncommittedSession({
+                                adapter: previousAdapter,
+                                target: previousTarget,
+                                threadId,
+                                operation: "ProviderService.startSession:restorePrevious",
+                              }).pipe(Effect.asVoid)
+                            : Effect.void,
+                        ),
+                      );
+                      const restoration = yield* Effect.exit(restorePreviousSession);
+                      if (Exit.isFailure(restoration)) {
+                        yield* Effect.logError(
+                          "failed to restore the previous provider after replacement failure",
+                          {
+                            threadId,
+                            previousProvider: previousTarget.provider,
+                            previousProfileId: previousTarget.profileId,
+                            replacementProvider: target.provider,
+                            replacementProfileId: target.profileId,
+                            cause: Cause.pretty(restoration.cause),
+                          },
                         );
                       }
-                      yield* withBindingWriteLock(
-                        threadId,
-                        upsertSessionBinding(restored, threadId, {
-                          lifecycleGeneration: previousGeneration,
-                          modelSelection: previousModelSelection,
-                          providerOptions: previousProviderOptions,
-                        }),
-                      );
-                      // The restored runtime stamps its events with the exact
-                      // generation persisted above, so the coordinator must end
-                      // the run owning that generation and not the abandoned
-                      // replacement's.
-                      lease.adopt(previousGeneration);
                     }),
               ),
             );
@@ -1727,24 +2193,26 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           return null;
         }
 
+        const sourceTarget = yield* resolveProviderProfile({
+          operation: "ProviderService.forkThread",
+          target: providerTargetFromSource(sourceBinding),
+        });
+        const target = yield* forkTarget(input, sourceTarget);
+        if (!providerTargetsEqual(sourceTarget, target)) {
+          return null;
+        }
+
         const effectiveProviderOptions =
           input.providerOptions ?? readPersistedProviderOptions(sourceBinding.runtimePayload);
         const sourceCwd = readPersistedCwd(sourceBinding.runtimePayload);
         yield* validateAutoRuntimeMode(
           "ProviderService.forkThread",
-          sourceBinding.provider,
+          sourceTarget.provider,
           input.runtimeMode,
         );
 
-        const adapter = yield* registry.getByProvider(sourceBinding.provider);
+        const adapter = yield* registry.getByProvider(sourceTarget.provider);
         if (!adapter.forkThread) {
-          return null;
-        }
-
-        if (
-          input.modelSelection !== undefined &&
-          input.modelSelection.provider !== adapter.provider
-        ) {
           return null;
         }
 
@@ -1753,6 +2221,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             ...input,
             threadId: input.threadId,
             sourceThreadId: input.sourceThreadId,
+            profileId: target.profileId,
             ...(effectiveProviderOptions !== undefined
               ? { providerOptions: effectiveProviderOptions }
               : {}),
@@ -1778,6 +2247,15 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         const forkedSession = (yield* adapter.listSessions()).find(
           (session) => session.threadId === input.threadId,
         );
+        const targetSession = forkedSession
+          ? yield* sessionWithExpectedTarget({
+              operation: "ProviderService.forkThread",
+              session: forkedSession,
+              target,
+            }).pipe(
+              Effect.tapError(() => adapter.stopSession(input.threadId).pipe(Effect.ignore)),
+            )
+          : undefined;
         // Register the fork under a committed lifecycle generation. Writing the
         // binding outside the coordinator lands it on the directory's "legacy"
         // default while the coordinator has no entry for the thread at all, and
@@ -1786,8 +2264,8 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         // silently discarding the thread's runtime events.
         yield* lifecycle.run(input.threadId, (lease) =>
           Effect.gen(function* () {
-            if (forkedSession) {
-              yield* upsertSessionBinding(forkedSession, input.threadId, {
+            if (targetSession) {
+              yield* upsertSessionBinding(targetSession, input.threadId, {
                 lifecycleGeneration: lease.generation,
                 ...(input.modelSelection !== undefined
                   ? { modelSelection: input.modelSelection }
@@ -1801,7 +2279,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             } else {
               yield* directory.upsert({
                 threadId: input.threadId,
-                provider: adapter.provider,
+                ...target,
                 runtimeMode: input.runtimeMode,
                 status: "stopped",
                 lifecycleGeneration: lease.generation,
@@ -1853,10 +2331,15 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               operation: "ProviderService.sendTurn",
               allowRecovery: true,
             });
+            yield* modelSelectionForTarget({
+              operation: "ProviderService.sendTurn",
+              modelSelection: input.modelSelection,
+              target: routed.target,
+            });
             const turn = yield* routed.adapter.sendTurn(input);
             const persistenceInput: StartedTurnPersistenceInput = {
               threadId: input.threadId,
-              provider: routed.adapter.provider,
+              target: routed.target,
               turnId: String(turn.turnId),
               generation,
               ...(turn.resumeCursor !== undefined ? { resumeCursor: turn.resumeCursor } : {}),
@@ -1906,6 +2389,11 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               operation: "ProviderService.steerTurn",
               allowRecovery: true,
             });
+            yield* modelSelectionForTarget({
+              operation: "ProviderService.steerTurn",
+              modelSelection: input.modelSelection,
+              target: routed.target,
+            });
             if (
               !routed.adapter.steerTurn ||
               routed.adapter.capabilities.supportsTurnSteering !== true
@@ -1918,7 +2406,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             const turn = yield* routed.adapter.steerTurn(input);
             const persistenceInput: StartedTurnPersistenceInput = {
               threadId: input.threadId,
-              provider: routed.adapter.provider,
+              target: routed.target,
               turnId: String(turn.turnId),
               generation,
               ...(turn.resumeCursor !== undefined ? { resumeCursor: turn.resumeCursor } : {}),
@@ -1959,7 +2447,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             const turn = yield* routed.adapter.startReview(input);
             const persistenceInput: StartedTurnPersistenceInput = {
               threadId: input.threadId,
-              provider: routed.adapter.provider,
+              target: routed.target,
               turnId: String(turn.turnId),
               generation,
               ...(turn.resumeCursor !== undefined ? { resumeCursor: turn.resumeCursor } : {}),
@@ -2322,19 +2810,25 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         clearRuntimeIdleTimer(input.threadId);
         return yield* lifecycle.run(input.threadId, (lease) =>
           Effect.gen(function* () {
-            const routed = yield* resolveRoutableSession({
-              threadId: input.threadId,
-              operation: "ProviderService.stopSession",
-              allowRecovery: false,
-            }).pipe(
-              Effect.catchTag("ProviderValidationError", (error) =>
-                error.issue.includes("no persisted provider binding exists")
-                  ? Effect.succeed(null)
-                  : Effect.fail(error),
-              ),
+            const failedSessionRetirement = failedUncommittedSessionRetirements.get(
+              input.threadId,
             );
-            if (routed === null) {
+            let retiredUncommittedAdapter:
+              | ProviderAdapterShape<ProviderAdapterError>
+              | undefined;
+            if (failedSessionRetirement !== undefined) {
+              retiredUncommittedAdapter = yield* registry.getByProvider(
+                failedSessionRetirement.target.provider,
+              );
+              yield* retiredUncommittedAdapter.stopSession(input.threadId);
+            }
+            const binding = Option.getOrUndefined(yield* directory.getBinding(input.threadId));
+            const adapter = binding
+              ? yield* registry.getByProvider(binding.provider)
+              : yield* findLiveSessionAdapter(input.threadId);
+            if (adapter === null) {
               clearLiveRuntimeTasks(input.threadId);
+              failedUncommittedSessionRetirements.delete(input.threadId);
               lease.retire();
               retireRuntimeIdleGeneration(input.threadId);
               return;
@@ -2342,11 +2836,14 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             // Adapter stop is an idempotent cleanup barrier. Even when the
             // routable session is inactive, the adapter may retain ownership
             // from a teardown whose exit proof previously failed.
-            yield* routed.adapter.stopSession(input.threadId);
+            if (adapter !== retiredUncommittedAdapter) {
+              yield* adapter.stopSession(input.threadId);
+            }
             clearLiveRuntimeTasks(input.threadId);
             yield* waitForRuntimeIdleStop(input.threadId);
             yield* withBindingWriteLock(input.threadId, directory.remove(input.threadId));
             providerInterruptionFences.delete(input.threadId);
+            failedUncommittedSessionRetirements.delete(input.threadId);
             lease.retire();
             retireRuntimeIdleGeneration(input.threadId);
           }),
@@ -2393,7 +2890,13 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               const activeSession = activeSessions.find(
                 (session) => session.threadId === input.threadId,
               );
-              if (activeSession?.resumeCursor !== undefined) {
+              const activeSessionMatchesBinding =
+                activeSession !== undefined &&
+                providerTargetsEqual(
+                  providerTargetFromSource(activeSession),
+                  providerTargetFromSource(binding),
+                );
+              if (activeSessionMatchesBinding && activeSession.resumeCursor !== undefined) {
                 resumeCursor = activeSession.resumeCursor;
               }
               yield* adapter.stopSession(input.threadId);
@@ -2407,6 +2910,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               directory.upsert({
                 threadId: input.threadId,
                 provider: binding.provider,
+                profileId: binding.profileId,
                 ...(binding.adapterKey !== undefined ? { adapterKey: binding.adapterKey } : {}),
                 ...(binding.runtimeMode !== undefined ? { runtimeMode: binding.runtimeMode } : {}),
                 status: "stopped",
@@ -2514,46 +3018,49 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         // Share the runtime-event binding lock so a delayed session.exited
         // update cannot restore the stale cursor after this explicit clear.
         yield* lifecycle.run(input.threadId, (lease) =>
-          withBindingWriteLock(
-            input.threadId,
-            Effect.gen(function* () {
-              const binding = Option.getOrUndefined(yield* directory.getBinding(input.threadId));
-              if (!binding) {
-                return undefined;
-              }
-              const adapter = yield* registry.getByProvider(binding.provider);
-              const hasActiveSession = yield* adapter.hasSession(input.threadId);
-              const preserveActive = hasActiveSession && input.preserveActiveRuntime === true;
-              if (hasActiveSession && !preserveActive) {
-                yield* adapter.stopSession(input.threadId);
-              }
-              if (!preserveActive) {
-                clearLiveRuntimeTasks(input.threadId);
-              }
-              // A preserved runtime keeps stamping its events with the
-              // generation it was started under, so clearing the cursor must
-              // not re-label the thread with a generation that runtime will
-              // never emit.
-              const effectiveGeneration = preserveActive
-                ? (binding.lifecycleGeneration ?? lease.generation)
-                : lease.generation;
-              yield* directory.upsert({
-                threadId: input.threadId,
-                provider: binding.provider,
-                ...(binding.adapterKey !== undefined ? { adapterKey: binding.adapterKey } : {}),
-                ...(binding.runtimeMode !== undefined ? { runtimeMode: binding.runtimeMode } : {}),
-                status: preserveActive ? (binding.status ?? "running") : "stopped",
-                lifecycleGeneration: effectiveGeneration,
-                resumeCursor: null,
-                runtimePayload: {
-                  ...runtimePayloadRecord(binding.runtimePayload),
-                  ...(preserveActive ? {} : { activeTurnId: null }),
+          lease.withStableGeneration((adoptGeneration) =>
+            withBindingWriteLock(
+              input.threadId,
+              Effect.gen(function* () {
+                const binding = Option.getOrUndefined(yield* directory.getBinding(input.threadId));
+                if (!binding) {
+                  return undefined;
+                }
+                const adapter = yield* registry.getByProvider(binding.provider);
+                const hasActiveSession = yield* adapter.hasSession(input.threadId);
+                const preserveActive = hasActiveSession && input.preserveActiveRuntime === true;
+                if (hasActiveSession && !preserveActive) {
+                  yield* adapter.stopSession(input.threadId);
+                }
+                if (!preserveActive) {
+                  clearLiveRuntimeTasks(input.threadId);
+                }
+                // A preserved runtime keeps stamping its events with the
+                // generation it was started under, so clearing the cursor must
+                // not re-label the thread with a generation that runtime will
+                // never emit.
+                const effectiveGeneration = preserveActive
+                  ? (binding.lifecycleGeneration ?? lease.generation)
+                  : lease.generation;
+                yield* directory.upsert({
+                  threadId: input.threadId,
+                  provider: binding.provider,
+                  profileId: binding.profileId,
+                  ...(binding.adapterKey !== undefined ? { adapterKey: binding.adapterKey } : {}),
+                  ...(binding.runtimeMode !== undefined ? { runtimeMode: binding.runtimeMode } : {}),
+                  status: preserveActive ? (binding.status ?? "running") : "stopped",
                   lifecycleGeneration: effectiveGeneration,
-                },
-              });
-              lease.adopt(effectiveGeneration);
-              return binding.provider;
-            }),
+                  resumeCursor: null,
+                  runtimePayload: {
+                    ...runtimePayloadRecord(binding.runtimePayload),
+                    ...(preserveActive ? {} : { activeTurnId: null }),
+                    lifecycleGeneration: effectiveGeneration,
+                  },
+                });
+                adoptGeneration(effectiveGeneration);
+                return binding.provider;
+              }),
+            ),
           ),
         );
         yield* waitForRuntimeIdleStop(input.threadId);
@@ -2593,7 +3100,14 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           const overrides: {
             resumeCursor?: ProviderSession["resumeCursor"];
             runtimeMode?: ProviderSession["runtimeMode"];
+            profileId?: ProviderSession["profileId"];
           } = {};
+          if (
+            session.profileId === undefined &&
+            binding.profileId === DEFAULT_PROVIDER_PROFILE_ID
+          ) {
+            overrides.profileId = binding.profileId;
+          }
           if (session.resumeCursor === undefined && binding.resumeCursor !== undefined) {
             overrides.resumeCursor = binding.resumeCursor;
           }
@@ -2694,16 +3208,31 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     const runStopAll = () =>
       Effect.gen(function* () {
         const stoppedAt = new Date().toISOString();
-        const threadIds = yield* directory.listThreadIds();
+        const bindings = yield* directory.listBindings();
+        const bindingByThreadId = new Map(
+          bindings.map((binding) => [binding.threadId, binding] as const),
+        );
         const activeSessionByThreadId = new Map(
           (yield* Effect.forEach(adapters, (adapter) => adapter.listSessions()))
             .flatMap((sessions) => sessions)
             .map((session) => [session.threadId, session] as const),
         );
         yield* Effect.forEach(
-          new Set([...threadIds, ...activeSessionByThreadId.keys()]),
-          (threadId) =>
-            markThreadStopped(threadId, stoppedAt, activeSessionByThreadId.get(threadId)),
+          new Set([...bindingByThreadId.keys(), ...activeSessionByThreadId.keys()]),
+          (threadId) => {
+            const binding = bindingByThreadId.get(threadId);
+            const activeSession = activeSessionByThreadId.get(threadId);
+            const compatibleSession =
+              binding && activeSession
+                ? providerTargetsEqual(
+                    providerTargetFromSource(binding),
+                    providerTargetFromSource(activeSession),
+                  )
+                  ? activeSession
+                  : undefined
+                : activeSession;
+            return markThreadStopped(threadId, stoppedAt, compatibleSession);
+          },
         );
         yield* Effect.forEach(adapters, (adapter) => adapter.stopAll());
       });

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.test.ts
@@ -5,10 +5,11 @@ import path from "node:path";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import {
   DEFAULT_PROVIDER_PROFILE_ID,
+  ProviderProfileId,
   ThreadId,
 } from "@synara/contracts";
 import { it, assert } from "@effect/vitest";
-import { assertFailure, assertSome } from "@effect/vitest/utils";
+import { assertFailure } from "@effect/vitest/utils";
 import { Effect, Layer, Option } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
@@ -27,14 +28,14 @@ function makeDirectoryLayer<E, R>(persistenceLayer: Layer.Layer<SqlClient.SqlCli
     Layer.provide(persistenceLayer),
   );
   return Layer.mergeAll(
+    persistenceLayer,
     runtimeRepositoryLayer,
     ProviderSessionDirectoryLive.pipe(Layer.provide(runtimeRepositoryLayer)),
-    NodeServices.layer,
-  );
+  ).pipe(Layer.provideMerge(NodeServices.layer));
 }
 
 it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryLive", (it) => {
-  it("upserts, reads, and removes thread bindings", () =>
+  it.effect("upserts, reads, and removes thread bindings", () =>
     Effect.gen(function* () {
       const directory = yield* ProviderSessionDirectory;
       const runtimeRepository = yield* ProviderSessionRuntimeRepository;
@@ -48,13 +49,16 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
 
       const provider = yield* directory.getProvider(initialThreadId);
       assert.equal(provider, "codex");
-      const resolvedBinding = yield* directory.getBinding(initialThreadId);
-      assertSome(resolvedBinding, {
-        threadId: initialThreadId,
+      assert.deepEqual(yield* directory.getTarget(initialThreadId), {
         provider: "codex",
+        profileId: "default",
       });
+      const resolvedBinding = yield* directory.getBinding(initialThreadId);
+      assert.equal(Option.isSome(resolvedBinding), true);
       if (Option.isSome(resolvedBinding)) {
         assert.equal(resolvedBinding.value.threadId, initialThreadId);
+        assert.equal(resolvedBinding.value.provider, "codex");
+        assert.equal(resolvedBinding.value.profileId, DEFAULT_PROVIDER_PROFILE_ID);
       }
 
       const nextThreadId = ThreadId.makeUnsafe("thread-2");
@@ -78,8 +82,9 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
       }
 
       const threadIds = yield* directory.listThreadIds();
-      assert.deepEqual(threadIds, [nextThreadId]);
+      assert.deepEqual(threadIds, [initialThreadId, nextThreadId]);
 
+      yield* directory.remove(initialThreadId);
       yield* directory.remove(nextThreadId);
       const missingProvider = yield* directory.getProvider(nextThreadId).pipe(Effect.result);
       assertFailure(
@@ -91,7 +96,64 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
       );
     }));
 
-  it("persists runtime fields and merges payload updates", () =>
+  it.effect("preserves an explicit profile across partial binding updates", () =>
+    Effect.gen(function* () {
+      const directory = yield* ProviderSessionDirectory;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+      const threadId = ThreadId.makeUnsafe("thread-work-profile");
+      const profileId = ProviderProfileId.makeUnsafe("work");
+
+      yield* directory.upsert({
+        provider: "codex",
+        profileId,
+        threadId,
+        resumeCursor: { threadId: "provider-work-thread" },
+      });
+      yield* directory.upsert({
+        provider: "codex",
+        threadId,
+        status: "running",
+      });
+
+      assert.deepEqual(yield* directory.getTarget(threadId), {
+        provider: "codex",
+        profileId: "work",
+      });
+      const runtime = yield* runtimeRepository.getByThreadId({ threadId });
+      assert.equal(Option.isSome(runtime), true);
+      if (Option.isSome(runtime)) {
+        assert.equal(runtime.value.profileId, profileId);
+        assert.deepEqual(runtime.value.resumeCursor, { threadId: "provider-work-thread" });
+      }
+    }));
+
+  it.effect("clears incompatible runtime state when the profile changes", () =>
+    Effect.gen(function* () {
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = ThreadId.makeUnsafe("thread-profile-change");
+
+      yield* directory.upsert({
+        provider: "codex",
+        threadId,
+        resumeCursor: { threadId: "provider-personal-thread" },
+        runtimePayload: { model: "gpt-5.6-codex" },
+      });
+      yield* directory.upsert({
+        provider: "codex",
+        profileId: ProviderProfileId.makeUnsafe("work"),
+        threadId,
+      });
+
+      const binding = yield* directory.getBinding(threadId);
+      assert.equal(Option.isSome(binding), true);
+      if (Option.isSome(binding)) {
+        assert.equal(binding.value.profileId, "work");
+        assert.equal(binding.value.resumeCursor, null);
+        assert.equal(binding.value.runtimePayload, null);
+      }
+    }));
+
+  it.effect("persists runtime fields and merges payload updates", () =>
     Effect.gen(function* () {
       const directory = yield* ProviderSessionDirectory;
       const runtimeRepository = yield* ProviderSessionRuntimeRepository;
@@ -136,7 +198,9 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
       }
     }));
 
-  it("resets adapterKey to the new provider when provider changes without an explicit adapter key", () =>
+  it.effect(
+    "resets adapterKey to the new provider when provider changes without an explicit adapter key",
+    () =>
     Effect.gen(function* () {
       const directory = yield* ProviderSessionDirectory;
       const runtimeRepository = yield* ProviderSessionRuntimeRepository;
@@ -166,9 +230,10 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
         assert.equal(runtime.value.providerName, "codex");
         assert.equal(runtime.value.adapterKey, "codex");
       }
-    }));
+    }),
+  );
 
-  it("rehydrates persisted mappings across layer restart", () =>
+  it.effect("rehydrates persisted mappings across layer restart", () =>
     Effect.gen(function* () {
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "synara-provider-directory-"));
       const dbPath = path.join(tempDir, "orchestration.sqlite");
@@ -191,12 +256,11 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
         assert.equal(provider, "codex");
 
         const resolvedBinding = yield* directory.getBinding(threadId);
-        assertSome(resolvedBinding, {
-          threadId,
-          provider: "codex",
-        });
+        assert.equal(Option.isSome(resolvedBinding), true);
         if (Option.isSome(resolvedBinding)) {
           assert.equal(resolvedBinding.value.threadId, threadId);
+          assert.equal(resolvedBinding.value.provider, "codex");
+          assert.equal(resolvedBinding.value.profileId, DEFAULT_PROVIDER_PROFILE_ID);
         }
 
         const legacyTableRows = yield* sql<{ readonly name: string }>`
@@ -210,7 +274,7 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
       fs.rmSync(tempDir, { recursive: true, force: true });
     }));
 
-  it("rehydrates persisted OpenCode bindings across layer restart", () =>
+  it.effect("rehydrates persisted OpenCode bindings across layer restart", () =>
     Effect.gen(function* () {
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "synara-provider-directory-opencode-"));
       const dbPath = path.join(tempDir, "orchestration.sqlite");
@@ -233,16 +297,18 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
         assert.equal(provider, "opencode");
 
         const resolvedBinding = yield* directory.getBinding(threadId);
-        assertSome(resolvedBinding, {
-          threadId,
-          provider: "opencode",
-        });
+        assert.equal(Option.isSome(resolvedBinding), true);
+        if (Option.isSome(resolvedBinding)) {
+          assert.equal(resolvedBinding.value.threadId, threadId);
+          assert.equal(resolvedBinding.value.provider, "opencode");
+          assert.equal(resolvedBinding.value.profileId, DEFAULT_PROVIDER_PROFILE_ID);
+        }
       }).pipe(Effect.provide(directoryLayer));
 
       fs.rmSync(tempDir, { recursive: true, force: true });
     }));
 
-  it("skips legacy bindings with unknown provider names when listing all bindings", () =>
+  it.effect("skips legacy bindings with unknown provider names when listing all bindings", () =>
     Effect.gen(function* () {
       const directory = yield* ProviderSessionDirectory;
       const runtimeRepository = yield* ProviderSessionRuntimeRepository;
@@ -252,8 +318,9 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
 
       yield* runtimeRepository.upsert({
         threadId: legacyThreadId,
-        providerName: "kilo",
-        adapterKey: "kilo",
+        providerName: "legacyUnknownProvider",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
+        adapterKey: "legacyUnknownProvider",
         runtimeMode: "full-access",
         status: "running",
         lifecycleGeneration: "legacy-test-kilo",
@@ -267,9 +334,7 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
       });
 
       const bindings = yield* directory.listBindings();
-      assert.deepEqual(
-        bindings.map((binding) => binding.threadId),
-        [codexThreadId],
-      );
+      assert.equal(bindings.some((binding) => binding.threadId === legacyThreadId), false);
+      assert.equal(bindings.some((binding) => binding.threadId === codexThreadId), true);
     }));
 });

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
@@ -1,4 +1,9 @@
-import { ProviderKind, type ThreadId } from "@synara/contracts";
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  ProviderKind,
+  type ProviderTarget,
+  type ThreadId,
+} from "@synara/contracts";
 import { Effect, Layer, Option, Schema } from "effect";
 
 import { ProviderSessionRuntimeRepository } from "../../persistence/Services/ProviderSessionRuntime.ts";
@@ -65,6 +70,7 @@ const makeProviderSessionDirectory = Effect.gen(function* () {
                 Option.some({
                   threadId: value.threadId,
                   provider,
+                  profileId: value.profileId,
                   adapterKey: value.adapterKey,
                   runtimeMode: value.runtimeMode,
                   status: value.status,
@@ -94,16 +100,23 @@ const makeProviderSessionDirectory = Effect.gen(function* () {
     }
 
     const now = new Date().toISOString();
-    const providerChanged =
-      existingRuntime !== undefined && existingRuntime.providerName !== binding.provider;
-    const compatibleRuntime = providerChanged ? undefined : existingRuntime;
+    const profileId =
+      binding.profileId ??
+      (existingRuntime?.providerName === binding.provider
+        ? existingRuntime.profileId
+        : DEFAULT_PROVIDER_PROFILE_ID);
+    const targetChanged =
+      existingRuntime !== undefined &&
+      (existingRuntime.providerName !== binding.provider || existingRuntime.profileId !== profileId);
+    const compatibleRuntime = targetChanged ? undefined : existingRuntime;
     yield* repository
       .upsert({
         threadId: resolvedThreadId,
         providerName: binding.provider,
+        profileId,
         adapterKey:
           binding.adapterKey ??
-          (providerChanged ? binding.provider : (existingRuntime?.adapterKey ?? binding.provider)),
+          (targetChanged ? binding.provider : (existingRuntime?.adapterKey ?? binding.provider)),
         runtimeMode: binding.runtimeMode ?? existingRuntime?.runtimeMode ?? "full-access",
         status: binding.status ?? compatibleRuntime?.status ?? "running",
         lifecycleGeneration:
@@ -137,6 +150,23 @@ const makeProviderSessionDirectory = Effect.gen(function* () {
       ),
     );
 
+  const getTarget: ProviderSessionDirectoryShape["getTarget"] = (threadId) =>
+    getBinding(threadId).pipe(
+      Effect.flatMap((binding) =>
+        Option.match(binding, {
+          onSome: ({ provider, profileId }) =>
+            Effect.succeed({ provider, profileId } satisfies ProviderTarget),
+          onNone: () =>
+            Effect.fail(
+              new ProviderSessionDirectoryPersistenceError({
+                operation: "ProviderSessionDirectory.getTarget",
+                detail: `No persisted provider binding found for thread '${threadId}'.`,
+              }),
+            ),
+        }),
+      ),
+    );
+
   const remove: ProviderSessionDirectoryShape["remove"] = (threadId) =>
     repository
       .deleteByThreadId({ threadId })
@@ -160,6 +190,7 @@ const makeProviderSessionDirectory = Effect.gen(function* () {
               Option.some({
                 threadId: row.threadId,
                 provider,
+                profileId: row.profileId,
                 adapterKey: row.adapterKey,
                 runtimeMode: row.runtimeMode,
                 status: row.status,
@@ -185,6 +216,7 @@ const makeProviderSessionDirectory = Effect.gen(function* () {
   return {
     upsert,
     getProvider,
+    getTarget,
     getBinding,
     remove,
     listThreadIds,

--- a/apps/server/src/provider/Services/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Services/ProviderSessionDirectory.ts
@@ -1,5 +1,7 @@
 import type {
   ProviderKind,
+  ProviderProfileId,
+  ProviderTarget,
   ProviderSessionRuntimeStatus,
   RuntimeMode,
   ThreadId,
@@ -15,6 +17,7 @@ import type {
 export interface ProviderRuntimeBinding {
   readonly threadId: ThreadId;
   readonly provider: ProviderKind;
+  readonly profileId: ProviderProfileId;
   readonly adapterKey?: string;
   readonly status?: ProviderSessionRuntimeStatus;
   readonly lifecycleGeneration?: string;
@@ -24,6 +27,10 @@ export interface ProviderRuntimeBinding {
   readonly runtimeMode?: RuntimeMode;
 }
 
+export type ProviderRuntimeBindingUpdate = Omit<ProviderRuntimeBinding, "profileId"> & {
+  readonly profileId?: ProviderProfileId;
+};
+
 export type ProviderSessionDirectoryReadError = ProviderSessionDirectoryPersistenceError;
 
 export type ProviderSessionDirectoryWriteError =
@@ -32,12 +39,16 @@ export type ProviderSessionDirectoryWriteError =
 
 export interface ProviderSessionDirectoryShape {
   readonly upsert: (
-    binding: ProviderRuntimeBinding,
+    binding: ProviderRuntimeBindingUpdate,
   ) => Effect.Effect<void, ProviderSessionDirectoryWriteError>;
 
   readonly getProvider: (
     threadId: ThreadId,
   ) => Effect.Effect<ProviderKind, ProviderSessionDirectoryReadError>;
+
+  readonly getTarget: (
+    threadId: ThreadId,
+  ) => Effect.Effect<ProviderTarget, ProviderSessionDirectoryReadError>;
 
   readonly getBinding: (
     threadId: ThreadId,

--- a/apps/server/src/provider/providerLifecycleCoordinator.test.ts
+++ b/apps/server/src/provider/providerLifecycleCoordinator.test.ts
@@ -68,6 +68,33 @@ describe("makeProviderLifecycleCoordinator", () => {
     );
   });
 
+  it("clears a provisional generation when interrupted at publication", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const published = yield* Deferred.make<string>();
+        let operationEntered = false;
+        const coordinator = makeProviderLifecycleCoordinator({
+          onGenerationPublished: ({ generation }) =>
+            Deferred.succeed(published, generation).pipe(Effect.andThen(Effect.never)),
+        });
+        const fiber = yield* coordinator
+          .run(threadId, () =>
+            Effect.sync(() => {
+              operationEntered = true;
+            }),
+          )
+          .pipe(Effect.forkChild);
+
+        const generation = yield* Deferred.await(published);
+        expect(coordinator.currentGeneration(threadId)).toBe(generation);
+        yield* Fiber.interrupt(fiber);
+
+        expect(operationEntered).toBe(false);
+        expect(coordinator.currentGeneration(threadId)).toBeUndefined();
+      }),
+    );
+  });
+
   it("restores the previous generation when a run fails before taking ownership", async () => {
     await Effect.runPromise(
       Effect.gen(function* () {
@@ -118,8 +145,8 @@ describe("makeProviderLifecycleCoordinator", () => {
       Effect.gen(function* () {
         const coordinator = makeProviderLifecycleCoordinator();
         yield* coordinator.run(threadId, (lease) =>
-          Effect.sync(() => {
-            lease.adopt("legacy");
+          Effect.gen(function* () {
+            yield* lease.adopt("legacy");
             expect(lease.isCurrent()).toBe(true);
           }),
         );
@@ -180,6 +207,48 @@ describe("makeProviderLifecycleCoordinator", () => {
 
         expect(order).toEqual(["first", "second"]);
         expect(coordinator.currentGeneration(threadId)).toBe(secondGeneration);
+      }),
+    );
+  });
+
+  it("keeps generation mutation outside a stable admission without blocking current work", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const coordinator = makeProviderLifecycleCoordinator();
+        const live = yield* coordinator.run(threadId, (lease) =>
+          Effect.sync(() => {
+            lease.commit();
+            return lease.generation;
+          }),
+        );
+        const stableEntered = yield* Deferred.make<void>();
+        const releaseStable = yield* Deferred.make<void>();
+        const stable = yield* coordinator
+          .runStable(threadId, (generation) =>
+            Deferred.succeed(stableEntered, undefined).pipe(
+              Effect.andThen(Deferred.await(releaseStable)),
+              Effect.as(generation),
+            ),
+          )
+          .pipe(Effect.forkChild);
+
+        yield* Deferred.await(stableEntered);
+        expect(yield* coordinator.runCurrent(threadId, Effect.succeed)).toBe(live);
+        const replacement = yield* coordinator
+          .run(threadId, (lease) =>
+            Effect.sync(() => {
+              lease.commit();
+              return lease.generation;
+            }),
+          )
+          .pipe(Effect.forkChild);
+        yield* Effect.sleep("10 millis");
+        expect(coordinator.currentGeneration(threadId)).toBe(live);
+
+        yield* Deferred.succeed(releaseStable, undefined);
+        expect(yield* Fiber.join(stable)).toBe(live);
+        const replacementGeneration = yield* Fiber.join(replacement);
+        expect(coordinator.currentGeneration(threadId)).toBe(replacementGeneration);
       }),
     );
   });

--- a/apps/server/src/provider/providerLifecycleCoordinator.ts
+++ b/apps/server/src/provider/providerLifecycleCoordinator.ts
@@ -4,6 +4,8 @@ import type { ThreadId } from "@synara/contracts";
 import { Duration, Effect, Option } from "effect";
 import * as Semaphore from "effect/Semaphore";
 
+import { makeKeyedLock } from "./keyedLock.ts";
+
 export interface ProviderLifecycleLease {
   readonly generation: string;
   readonly isCurrent: () => boolean;
@@ -18,7 +20,15 @@ export interface ProviderLifecycleLease {
    */
   readonly commit: () => void;
   /** Takes lasting ownership of an existing generation instead of this run's. */
-  readonly adopt: (generation: string) => void;
+  readonly adopt: (generation: string) => Effect.Effect<void>;
+  /**
+   * Holds generation ownership stable while coordinating another per-thread
+   * write. The callback adopts without reacquiring the stability fence, which
+   * preserves the global stability -> binding lock order.
+   */
+  readonly withStableGeneration: <A, E, R>(
+    operation: (adopt: (generation: string) => void) => Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E, R>;
   /** Takes lasting ownership of "this thread has no provider generation". */
   readonly retire: () => void;
 }
@@ -29,6 +39,14 @@ export interface ProviderLifecycleCoordinator {
     operation: (lease: ProviderLifecycleLease) => Effect.Effect<A, E, R>,
   ) => Effect.Effect<A, E, R>;
   readonly runCurrent: <A, E, R>(
+    threadId: ThreadId,
+    operation: (generation: string | undefined) => Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E, R>;
+  /**
+   * Holds the thread's generation stable for the full operation without
+   * excluding current-generation control work.
+   */
+  readonly runStable: <A, E, R>(
     threadId: ThreadId,
     operation: (generation: string | undefined) => Effect.Effect<A, E, R>,
   ) => Effect.Effect<A, E, R>;
@@ -51,10 +69,20 @@ export interface ProviderLifecycleCoordinator {
 const URGENT_LOCK_WAIT = Duration.seconds(5);
 const URGENT_LOCK_POLL = Duration.millis(25);
 
+interface ProviderLifecycleCoordinatorOptions {
+  readonly onGenerationPublished?: (input: {
+    readonly threadId: ThreadId;
+    readonly generation: string;
+  }) => Effect.Effect<void>;
+}
+
 /** Serializes provider lifecycle mutations per thread and gives each mutation a unique epoch. */
-export function makeProviderLifecycleCoordinator(): ProviderLifecycleCoordinator {
+export function makeProviderLifecycleCoordinator(
+  options?: ProviderLifecycleCoordinatorOptions,
+): ProviderLifecycleCoordinator {
   const locks = new Map<ThreadId, { readonly semaphore: Semaphore.Semaphore; users: number }>();
   const currentGenerations = new Map<ThreadId, string>();
+  const generationStabilityLock = makeKeyedLock<ThreadId>();
 
   type LockEntry = { readonly semaphore: Semaphore.Semaphore; users: number };
 
@@ -116,65 +144,129 @@ export function makeProviderLifecycleCoordinator(): ProviderLifecycleCoordinator
       return attempt.pipe(Effect.ensuring(releaseEntry(threadId, entry)));
     });
 
-  const run: ProviderLifecycleCoordinator["run"] = (threadId, operation) =>
-    withThreadLock(
+  type FinalOwnership =
+    | { readonly _tag: "generation"; readonly generation: string }
+    | { readonly _tag: "retired" };
+  interface PublishedGeneration {
+    readonly generation: string;
+    readonly previousGeneration: string | undefined;
+    ownedGeneration: string;
+    finalOwnership: FinalOwnership | undefined;
+  }
+
+  const publishGeneration = (threadId: ThreadId): Effect.Effect<PublishedGeneration> =>
+    generationStabilityLock.withLock(
       threadId,
-      Effect.suspend(() => {
+      Effect.sync(() => {
         const generation = randomUUID();
         const previousGeneration = currentGenerations.get(threadId);
         currentGenerations.set(threadId, generation);
-        let ownedGeneration: string = generation;
-        // Ownership is opt-in. The eagerly published generation is rewound on
-        // exit unless the run explicitly committed/adopted/retired, so a run
-        // that ends without changing anything — a successful no-op early
-        // return, a failure, an interrupt before the provider was touched —
-        // leaves the still-live session's generation exactly as it found it.
-        // The inverse default is unsafe: an uncommitted generation nobody else
-        // knows about silently invalidates every runtime event and every
-        // generation-checked control call for that thread, forever.
-        let owned = false;
-        const isCurrent = () => currentGenerations.get(threadId) === ownedGeneration;
-        return operation({
+        return {
           generation,
-          isCurrent,
-          commit: () => {
-            if (isCurrent()) owned = true;
-          },
-          adopt: (adoptedGeneration) => {
-            if (isCurrent()) {
-              ownedGeneration = adoptedGeneration;
-              currentGenerations.set(threadId, adoptedGeneration);
-              owned = true;
-            }
-          },
-          retire: () => {
-            if (isCurrent()) {
-              currentGenerations.delete(threadId);
-              owned = true;
-            }
-          },
-        }).pipe(
-          Effect.onExit(() =>
-            // `isCurrent` also guards against clobbering a newer owner: only
-            // rewind while this run's generation is still the published one.
-            owned || !isCurrent()
-              ? Effect.void
-              : Effect.sync(() => {
-                  if (previousGeneration === undefined) {
-                    currentGenerations.delete(threadId);
-                  } else {
-                    currentGenerations.set(threadId, previousGeneration);
-                  }
-                }),
-          ),
-        );
+          previousGeneration,
+          ownedGeneration: generation,
+          finalOwnership: undefined,
+        };
       }),
+    );
+
+  const settleGeneration = (
+    threadId: ThreadId,
+    published: PublishedGeneration,
+  ): Effect.Effect<void> =>
+    // Lock ordering is lifecycle -> generation stability. `runStable` never
+    // takes the lifecycle lock, so event ingestion cannot form a cycle with
+    // control work that waits for runtime task settlement.
+    generationStabilityLock.withLock(
+      threadId,
+      Effect.sync(() => {
+        if (currentGenerations.get(threadId) !== published.ownedGeneration) return;
+        if (published.finalOwnership?._tag === "generation") {
+          currentGenerations.set(threadId, published.finalOwnership.generation);
+        } else if (published.finalOwnership?._tag === "retired") {
+          currentGenerations.delete(threadId);
+        } else if (published.previousGeneration === undefined) {
+          currentGenerations.delete(threadId);
+        } else {
+          currentGenerations.set(threadId, published.previousGeneration);
+        }
+      }),
+    );
+
+  const usePublishedGeneration = <A, E, R>(
+    threadId: ThreadId,
+    published: PublishedGeneration,
+    operation: (lease: ProviderLifecycleLease) => Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E, R> => {
+    const isCurrent = () =>
+      currentGenerations.get(threadId) === published.ownedGeneration;
+    const adoptCurrentGeneration = (adoptedGeneration: string) => {
+      if (!isCurrent()) return;
+      currentGenerations.set(threadId, adoptedGeneration);
+      published.ownedGeneration = adoptedGeneration;
+      published.finalOwnership = {
+        _tag: "generation",
+        generation: adoptedGeneration,
+      };
+    };
+    const withStableGeneration: ProviderLifecycleLease["withStableGeneration"] =
+      (stableOperation) =>
+        generationStabilityLock.withLock(
+          threadId,
+          Effect.suspend(() => stableOperation(adoptCurrentGeneration)),
+        );
+    const lease: ProviderLifecycleLease = {
+      generation: published.generation,
+      isCurrent,
+      commit: () => {
+        if (isCurrent()) {
+          published.finalOwnership = {
+            _tag: "generation",
+            generation: published.generation,
+          };
+        }
+      },
+      adopt: (adoptedGeneration) =>
+        withStableGeneration((adopt) =>
+          Effect.sync(() => {
+            adopt(adoptedGeneration);
+          }),
+        ),
+      withStableGeneration,
+      retire: () => {
+        if (isCurrent()) {
+          published.finalOwnership = { _tag: "retired" };
+        }
+      },
+    };
+    const publicationHook = options?.onGenerationPublished
+      ? options.onGenerationPublished({
+          threadId,
+          generation: published.generation,
+        })
+      : Effect.void;
+    return publicationHook.pipe(Effect.andThen(Effect.suspend(() => operation(lease))));
+  };
+
+  const run: ProviderLifecycleCoordinator["run"] = (threadId, operation) =>
+    withThreadLock(
+      threadId,
+      Effect.acquireUseRelease(
+        publishGeneration(threadId),
+        (published) => usePublishedGeneration(threadId, published, operation),
+        (published) => settleGeneration(threadId, published),
+      ),
     );
 
   return {
     run,
     runCurrent: (threadId, operation) =>
       withThreadLock(
+        threadId,
+        Effect.suspend(() => operation(currentGenerations.get(threadId))),
+      ),
+    runStable: (threadId, operation) =>
+      generationStabilityLock.withLock(
         threadId,
         Effect.suspend(() => operation(currentGenerations.get(threadId))),
       ),

--- a/apps/server/src/provider/providerProfileResolver.ts
+++ b/apps/server/src/provider/providerProfileResolver.ts
@@ -1,0 +1,26 @@
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  type ProviderTarget,
+} from "@synara/contracts";
+import { Effect } from "effect";
+
+import { ProviderValidationError } from "./Errors.ts";
+
+export interface ProviderProfileResolutionInput {
+  readonly operation: string;
+  readonly target: ProviderTarget;
+}
+
+export type ResolveProviderProfile = (
+  input: ProviderProfileResolutionInput,
+) => Effect.Effect<ProviderTarget, ProviderValidationError>;
+
+export const resolveDefaultProviderProfile: ResolveProviderProfile = ({ operation, target }) =>
+  target.profileId === DEFAULT_PROVIDER_PROFILE_ID
+    ? Effect.succeed(target)
+    : Effect.fail(
+        new ProviderValidationError({
+          operation,
+          issue: `Provider profile '${target.profileId}' is not configured for provider '${target.provider}'.`,
+        }),
+      );

--- a/apps/server/src/provider/providerRuntimeReconciliation.test.ts
+++ b/apps/server/src/provider/providerRuntimeReconciliation.test.ts
@@ -1,8 +1,9 @@
 import {
-  DEFAULT_PROVIDER_PROFILE_ID,
   CommandId,
+  DEFAULT_PROVIDER_PROFILE_ID,
   OrchestrationCommand,
   ProjectId,
+  ProviderProfileId,
   ThreadId,
   TurnId,
   type OrchestrationSession,
@@ -82,10 +83,12 @@ function threadShell(overrides: Partial<OrchestrationThreadShell> = {}): Orchest
 function binding(
   activeTurnId: string | null = OLD_TURN_ID,
   provider: ProviderRuntimeBinding["provider"] = "codex",
+  profileId: ProviderRuntimeBinding["profileId"] = DEFAULT_PROVIDER_PROFILE_ID,
 ): ProviderRuntimeBinding {
   return {
     threadId: THREAD_ID,
     provider,
+    profileId,
     status: activeTurnId === null ? "stopped" : "running",
     lastSeenAt: "2026-07-23T20:00:00.000Z",
     runtimePayload: { activeTurnId },
@@ -96,10 +99,12 @@ function liveSession(input: {
   readonly status: ProviderSession["status"];
   readonly activeTurnId?: TurnId;
   readonly provider?: ProviderSession["provider"];
+  readonly profileId?: ProviderSession["profileId"];
   readonly lastError?: string;
 }): ProviderSession {
   return {
     provider: input.provider ?? "codex",
+    profileId: input.profileId ?? DEFAULT_PROVIDER_PROFILE_ID,
     status: input.status,
     runtimeMode: "full-access",
     threadId: THREAD_ID,
@@ -207,6 +212,40 @@ describe("planProviderRuntimeReconciliation", () => {
         action: "align-running-turn",
         projectedTurnId: OLD_TURN_ID,
         runtimeTurnId: LIVE_TURN_ID,
+      }),
+    ]);
+  });
+
+  it("does not align a projection to a live session from another profile", () => {
+    const workProfile = ProviderProfileId.makeUnsafe("work");
+    const plans = planProviderRuntimeReconciliation({
+      threads: [
+        threadShell({
+          modelSelection: {
+            provider: "codex",
+            profileId: workProfile,
+            model: "gpt-5.6",
+          },
+        }),
+      ],
+      bindings: [binding(LIVE_TURN_ID, "codex", workProfile)],
+      liveSessions: [
+        liveSession({
+          status: "running",
+          activeTurnId: LIVE_TURN_ID,
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+        }),
+      ],
+      pumpHealth: [],
+      nowMs: NOW,
+      staleAfterMs: 10_000,
+    });
+
+    expect(plans).toEqual([
+      expect.objectContaining({
+        action: "settle-interrupted",
+        projectedTurnId: OLD_TURN_ID,
+        runtimeTurnId: null,
       }),
     ]);
   });

--- a/apps/server/src/provider/providerRuntimeReconciliation.ts
+++ b/apps/server/src/provider/providerRuntimeReconciliation.ts
@@ -14,6 +14,11 @@ import {
   type ProviderSession,
   type ThreadId,
 } from "@synara/contracts";
+import {
+  providerTargetFromModelSelection,
+  providerTargetFromSource,
+  providerTargetsEqual,
+} from "@synara/shared/providerTarget";
 import { nonEmptyTrimmed } from "@synara/shared/text";
 
 import type { ProviderRuntimeEventPumpHealth } from "./Services/ProviderService.ts";
@@ -205,9 +210,12 @@ export function planProviderRuntimeReconciliation(input: {
     input.maxTurnAgeMs ?? RUNTIME_RECONCILIATION_MAX_TURN_AGE_MS,
   );
   const bindingByThreadId = new Map(input.bindings.map((binding) => [binding.threadId, binding]));
-  const liveSessionByThreadId = new Map(
-    input.liveSessions.map((session) => [session.threadId, session]),
-  );
+  const liveSessionsByThreadId = new Map<ThreadId, ProviderSession[]>();
+  for (const session of input.liveSessions) {
+    const sessions = liveSessionsByThreadId.get(session.threadId) ?? [];
+    sessions.push(session);
+    liveSessionsByThreadId.set(session.threadId, sessions);
+  }
   const healthByProvider = new Map(input.pumpHealth.map((health) => [health.provider, health]));
   const plans: ProviderRuntimeReconciliationPlan[] = [];
 
@@ -216,7 +224,14 @@ export function planProviderRuntimeReconciliation(input: {
     if (lifecycleAgeMs < staleAfterMs) continue;
 
     const binding = bindingByThreadId.get(thread.id);
-    const liveSession = liveSessionByThreadId.get(thread.id);
+    const expectedTarget = binding
+      ? providerTargetFromSource(binding)
+      : providerTargetFromModelSelection(thread.modelSelection);
+    const liveSession = liveSessionsByThreadId
+      .get(thread.id)
+      ?.find((session) =>
+        providerTargetsEqual(providerTargetFromSource(session), expectedTarget),
+      );
     // The binding row can be gone entirely (a stop that removed it, a crashed
     // start) - which is precisely the thread most likely to be stuck with
     // nothing left that could ever settle it - so fall back to the thread's own


### PR DESCRIPTION
## Summary

Binds live provider runtimes to the complete provider target rather than only the provider kind:

- adds migration 090 with a backward-compatible `default` profile
- persists profile identity in runtime bindings
- makes session replacement, recovery, forks, cursors, and reconciliation target-aware
- serializes lifecycle replacement by generation
- rejects stale or cross-target runtime events before persistence and publication
- propagates profile identity through Codex and OpenCode adapter events
- introduces the default-only server profile resolver

The lifecycle coordinator and ProviderService changes stay together because event admission, generation publication, replacement, and rollback share one ownership boundary.

## Stack

Depends on #619.  
Base: `codex/provider-profiles-01-identity` at `1800df5c7`  
Head: `fb1bc977d`

> **Release gate:** Foundation PR 2 of 3. PRs 1–3 are coupled, must merge in order, and must all land before release. Do not ship a partial foundation.

## Replacement for #254

This rebuilds the runtime portion of #254 against the current ProviderService, persistence, and event-ingestion architecture. Copying the old implementation would bypass today's lifecycle-generation and runtime-ownership safeguards.

#254 remains open as historical design and failure-case context; this PR does not close it.

## Safety and compatibility

- Migration 090 is additive and backfills existing runtime rows with `provider_profile_id = 'default'`.
- Legacy default-profile runtime events remain compatible.
- Non-default, generationless, stale, or mismatched events fail closed.
- Target replacement stops the previous runtime before adopting the next one.
- Failed replacement restores the exact previous target and compatible runtime state.
- Persisted target identity remains intact even when its profile cannot currently be resolved.

## Validation

- `bun run --cwd apps/server test`: 326 files passed, 3 skipped; 3,746 tests passed, 16 skipped.
- Slice and stack-top diff checks passed.

`bun fmt`, `bun lint`, and `bun typecheck` were not run because repository policy requires explicit user permission; permission is pending.
