### PR TITLE
fix(server): reject unavailable provider profiles before side effects

### DIFF
--- a/apps/server/src/agentGateway/targetResolver.test.ts
+++ b/apps/server/src/agentGateway/targetResolver.test.ts
@@ -1,6 +1,7 @@
 import { assert, describe, it } from "@effect/vitest";
 import {
   DEFAULT_PROVIDER_PROFILE_ID,
+  ProviderProfileId,
   type ModelSelection,
   type ProviderKind,
   type ProviderModelDescriptor,
@@ -58,6 +59,31 @@ function makeVariantDescriptor(slug: string): ProviderModelDescriptor {
 }
 
 describe("agent gateway target resolver", () => {
+  it.effect("rejects a non-default profile before provider discovery", () =>
+    Effect.gen(function* () {
+      let discoveryCalls = 0;
+      const guardedDiscovery = {
+        listModels: () => {
+          discoveryCalls += 1;
+          return Effect.succeed({ source: "test", models: [] });
+        },
+      } as unknown as ProviderDiscoveryServiceShape;
+
+      const error = yield* resolveAgentGatewayTarget({
+        target: {
+          provider: "codex",
+          profileId: ProviderProfileId.makeUnsafe("work"),
+          model: "gpt-5.6-terra",
+        },
+        discovery: guardedDiscovery,
+      }).pipe(Effect.flip);
+
+      assert.equal(error.code, "provider_unavailable");
+      assert.match(error.message, /profile 'work' is not configured/);
+      assert.equal(discoveryCalls, 0);
+    }),
+  );
+
   it.effect("builds examples from the exact model restrictions and preserves option types", () =>
     Effect.gen(function* () {
       const codexCatalog = {

--- a/apps/server/src/agentGateway/targetResolver.ts
+++ b/apps/server/src/agentGateway/targetResolver.ts
@@ -12,8 +12,10 @@ import {
   type ServerProviderAuthStatus,
 } from "@synara/contracts";
 import { Effect } from "effect";
+import { providerTargetFromModelSelection } from "@synara/shared/providerTarget";
 
 import type { ProviderDiscoveryServiceShape } from "../provider/Services/ProviderDiscoveryService.ts";
+import { resolveDefaultProviderProfile } from "../provider/providerProfileResolver.ts";
 
 export type AgentGatewayTargetErrorCode =
   | "provider_unavailable"
@@ -610,6 +612,19 @@ export function resolveAgentGatewayTarget(input: {
   readonly cwd?: string;
 }): Effect.Effect<ModelSelection, AgentGatewayTargetError> {
   return Effect.gen(function* () {
+    const target = providerTargetFromModelSelection(input.target);
+    yield* resolveDefaultProviderProfile({
+      operation: "AgentGateway.resolveTarget",
+      target,
+    }).pipe(
+      Effect.mapError(
+        (cause) =>
+          new AgentGatewayTargetError("provider_unavailable", cause.issue, {
+            provider: target.provider,
+            profileId: target.profileId,
+          }),
+      ),
+    );
     const catalog = yield* loadAgentGatewayProviderCatalog({
       provider: input.target.provider,
       discovery: input.discovery,

--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_AUTOMATION_STOP_CONFIDENCE_THRESHOLD,
   DEFAULT_PROVIDER_PROFILE_ID,
   MessageId,
+  ProviderProfileId,
   ProjectId,
   ThreadId,
   TurnId,
@@ -1222,6 +1223,74 @@ layer("AutomationService", (it) => {
         dispatchedCommands.filter((command) => command.type === "thread.create").length,
         0,
       );
+      const listed = yield* service.list({ projectId });
+      assert.strictEqual(
+        listed.runs.find((run) => run.automationId === automationId)?.status,
+        "failed",
+      );
+    }),
+  );
+
+  it.effect("rejects a non-default profile before creating a fresh automation thread", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const repository = yield* AutomationRepository;
+      const automationId = AutomationId.makeUnsafe("automation-profile-fresh");
+      yield* repository.createDefinition({
+        id: automationId,
+        input: {
+          ...createInput("worktree"),
+          modelSelection: {
+            provider: "codex",
+            profileId: ProviderProfileId.makeUnsafe("work"),
+            model: "gpt-5-codex",
+          },
+        },
+        now,
+      });
+
+      const error = yield* service.runNow({ automationId }).pipe(Effect.flip);
+
+      assert.match(error.message, /profile 'work' is not configured/);
+      assert.strictEqual(dispatchedCommands.length, 0);
+      assert.strictEqual(createdWorktrees.length, 0);
+      const listed = yield* service.list({ projectId });
+      assert.strictEqual(
+        listed.runs.find((run) => run.automationId === automationId)?.status,
+        "failed",
+      );
+    }),
+  );
+
+  it.effect("rejects a non-default profile before continuing an automation thread", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const repository = yield* AutomationRepository;
+      const automationId = AutomationId.makeUnsafe("automation-profile-continuation");
+      const targetThreadId = ThreadId.makeUnsafe("automation-profile-target");
+      threadShell = Option.some(makeThreadShell({ id: targetThreadId }));
+      yield* repository.createDefinition({
+        id: automationId,
+        input: {
+          ...createInput("local"),
+          mode: "heartbeat",
+          targetThreadId,
+          modelSelection: {
+            provider: "codex",
+            profileId: ProviderProfileId.makeUnsafe("work"),
+            model: "gpt-5-codex",
+          },
+        },
+        now,
+      });
+
+      const error = yield* service.runNow({ automationId }).pipe(Effect.flip);
+
+      assert.match(error.message, /profile 'work' is not configured/);
+      assert.strictEqual(dispatchedCommands.length, 0);
+      assert.strictEqual(createdWorktrees.length, 0);
       const listed = yield* service.list({ projectId });
       assert.strictEqual(
         listed.runs.find((run) => run.automationId === automationId)?.status,

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -33,6 +33,7 @@ import {
 } from "@synara/shared/automationMode";
 import { buildTemporaryWorktreeBranchName } from "@synara/shared/git";
 import { providerStartOptionsFromServerSettings } from "@synara/shared/serverSettings";
+import { providerTargetFromModelSelection } from "@synara/shared/providerTarget";
 import { autoRuntimeModeSelectionIssue } from "@synara/shared/runtimeMode";
 import { Cause, Effect, Layer, Option, PubSub, Queue, Stream } from "effect";
 
@@ -47,6 +48,7 @@ import { ProjectionTurnRepository } from "../../persistence/Services/ProjectionT
 import { runWorktreeSetupScript } from "../../worktreeSetup.ts";
 import type { ProjectionTurn } from "../../persistence/Services/ProjectionTurns.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
+import { resolveDefaultProviderProfile } from "../../provider/providerProfileResolver.ts";
 import { AutomationServiceError } from "../Errors.ts";
 import { AutomationService, type AutomationServiceShape } from "../Services/AutomationService.ts";
 import { buildAutomationProposalActivity } from "../proposalActivity.ts";
@@ -797,6 +799,24 @@ export const AutomationServiceLive = Layer.effect(
         : Effect.fail(new AutomationServiceError({ message: issue }));
     };
 
+    const validateProviderProfile = (
+      modelSelection: AutomationDefinition["modelSelection"],
+      operation: string,
+    ) =>
+      resolveDefaultProviderProfile({
+        operation,
+        target: providerTargetFromModelSelection(modelSelection),
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new AutomationServiceError({
+              message: cause.issue,
+              cause,
+            }),
+        ),
+        Effect.asVoid,
+      );
+
     // Run-path backstop for the fast-interval policy. validateSchedulePolicy enforces this at
     // create/update; this guards the run path it never covers. Effect.try converts a throwing
     // schedule (invalid cron/timezone in a persisted row) into a typed error so the dispatch
@@ -939,6 +959,10 @@ export const AutomationServiceLive = Layer.effect(
       now: string,
     ): Effect.Effect<AutomationRunNowResult, AutomationServiceError> => {
       return Effect.gen(function* () {
+        yield* validateProviderProfile(
+          definition.modelSelection,
+          "AutomationService.dispatchRun",
+        );
         const plannedIds = deriveAutomationRunIds(run.id);
         // Read the thread from the definition rather than the run: a dedicated automation can
         // claim its thread after this run was planned, and continuing it beats creating a second.
@@ -2377,6 +2401,7 @@ export const AutomationServiceLive = Layer.effect(
           modelSelection: input.modelSelection,
           runtimeMode: input.runtimeMode ?? "approval-required",
         });
+        yield* validateProviderProfile(input.modelSelection, "AutomationService.create");
         yield* validateHeartbeatTarget({
           mode: input.mode ?? "standalone",
           projectId: input.projectId,
@@ -2433,6 +2458,7 @@ export const AutomationServiceLive = Layer.effect(
           acknowledgedRisks: updated.acknowledgedRisks,
         });
         yield* validateAutoRuntimeMode(updated);
+        yield* validateProviderProfile(updated.modelSelection, "AutomationService.update");
         yield* validateHeartbeatTarget(updated);
         const saved = yield* automationRepository
           .saveDefinition(updated)

--- a/apps/server/src/git/Layers/ProviderTextGeneration.test.ts
+++ b/apps/server/src/git/Layers/ProviderTextGeneration.test.ts
@@ -1,5 +1,5 @@
-import { DEFAULT_PROVIDER_PROFILE_ID } from "@synara/contracts";
 import { Effect, Layer } from "effect";
+import { DEFAULT_PROVIDER_PROFILE_ID, ProviderProfileId } from "@synara/contracts";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -335,5 +335,75 @@ describe("ProviderTextGenerationLive", () => {
     );
     expect(codex.evaluateAutomationCompletion).not.toHaveBeenCalled();
     expect(opencode.evaluateAutomationCompletion).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-default profiles before any text-generation implementation runs", async () => {
+    const { layer, codex, cursor, kilo, opencode } = makeProviderTextGenerationTestLayer();
+    const modelSelection = {
+      provider: "codex" as const,
+      profileId: ProviderProfileId.makeUnsafe("work"),
+      model: "gpt-5.4-mini",
+    };
+
+    const failures = await Effect.runPromise(
+      Effect.gen(function* () {
+        const textGeneration = yield* TextGeneration;
+        const calls = [
+          textGeneration.generateCommitMessage({
+            cwd: "/repo",
+            branch: "main",
+            stagedSummary: "summary",
+            stagedPatch: "patch",
+            modelSelection,
+          }),
+          textGeneration.generatePrContent({
+            cwd: "/repo",
+            baseBranch: "main",
+            headBranch: "feature",
+            commitSummary: "summary",
+            diffSummary: "diff",
+            diffPatch: "patch",
+            modelSelection,
+          }),
+          textGeneration.generateDiffSummary({ cwd: "/repo", patch: "patch", modelSelection }),
+          textGeneration.generateBranchName({ cwd: "/repo", message: "message", modelSelection }),
+          textGeneration.generateThreadTitle({ cwd: "/repo", message: "message", modelSelection }),
+          textGeneration.generateThreadRecap({
+            cwd: "/repo",
+            newMaterial: "material",
+            modelSelection,
+          }),
+          textGeneration.generateAutomationIntent({
+            cwd: "/repo",
+            message: "message",
+            nowIso: "2026-08-10T00:00:00.000Z",
+            modelSelection,
+          }),
+          textGeneration.evaluateAutomationCompletion({
+            cwd: "/repo",
+            automationName: "Watch PR",
+            automationPrompt: "Check it",
+            stopWhen: "done",
+            runUserMessage: "Check it",
+            runAssistantText: "Still working",
+            modelSelection,
+          }),
+        ] as const;
+        return yield* Effect.forEach(calls, (call) => Effect.flip(call));
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(failures).toHaveLength(8);
+    expect(failures.every((failure) => failure.detail.includes("not configured"))).toBe(true);
+    for (const implementation of [codex, cursor, kilo, opencode]) {
+      expect(implementation.generateCommitMessage).not.toHaveBeenCalled();
+      expect(implementation.generatePrContent).not.toHaveBeenCalled();
+      expect(implementation.generateDiffSummary).not.toHaveBeenCalled();
+      expect(implementation.generateBranchName).not.toHaveBeenCalled();
+      expect(implementation.generateThreadTitle).not.toHaveBeenCalled();
+      expect(implementation.generateThreadRecap).not.toHaveBeenCalled();
+      expect(implementation.generateAutomationIntent).not.toHaveBeenCalled();
+      expect(implementation.evaluateAutomationCompletion).not.toHaveBeenCalled();
+    }
   });
 });

--- a/apps/server/src/git/Layers/ProviderTextGeneration.ts
+++ b/apps/server/src/git/Layers/ProviderTextGeneration.ts
@@ -1,12 +1,17 @@
 import { Effect, Layer } from "effect";
+import type { ModelSelection } from "@synara/contracts";
+import { providerTargetFromModelSelection } from "@synara/shared/providerTarget";
 
 import { parseOpenCodeModelSlug } from "../../provider/opencodeRuntime.ts";
+import { resolveDefaultProviderProfile } from "../../provider/providerProfileResolver.ts";
+import { TextGenerationError } from "../Errors.ts";
 import {
   CodexTextGeneration,
   CursorTextGeneration,
   KiloTextGeneration,
   OpenCodeTextGeneration,
   type TextGenerationShape,
+  type TextGenerationOperation,
   TextGeneration,
 } from "../Services/TextGeneration.ts";
 
@@ -34,17 +39,66 @@ const makeProviderTextGeneration = Effect.gen(function* () {
       : codexTextGeneration;
   };
 
+  const withImplementation = <A>(
+    operation: TextGenerationOperation,
+    input: { readonly modelSelection?: ModelSelection },
+    run: (implementation: TextGenerationShape) => Effect.Effect<A, TextGenerationError>,
+  ): Effect.Effect<A, TextGenerationError> => {
+    const validateProfile = input.modelSelection
+      ? resolveDefaultProviderProfile({
+          operation: `TextGeneration.${operation}`,
+          target: providerTargetFromModelSelection(input.modelSelection),
+        }).pipe(
+          Effect.mapError(
+            (cause) =>
+              new TextGenerationError({
+                operation,
+                detail: cause.issue,
+                cause,
+              }),
+          ),
+          Effect.asVoid,
+        )
+      : Effect.void;
+
+    return validateProfile.pipe(
+      Effect.flatMap(() => run(resolveImplementation(input))),
+    );
+  };
+
   return {
-    generateCommitMessage: (input) => resolveImplementation(input).generateCommitMessage(input),
-    generatePrContent: (input) => resolveImplementation(input).generatePrContent(input),
-    generateDiffSummary: (input) => resolveImplementation(input).generateDiffSummary(input),
-    generateBranchName: (input) => resolveImplementation(input).generateBranchName(input),
-    generateThreadTitle: (input) => resolveImplementation(input).generateThreadTitle(input),
-    generateThreadRecap: (input) => resolveImplementation(input).generateThreadRecap(input),
+    generateCommitMessage: (input) =>
+      withImplementation("generateCommitMessage", input, (implementation) =>
+        implementation.generateCommitMessage(input),
+      ),
+    generatePrContent: (input) =>
+      withImplementation("generatePrContent", input, (implementation) =>
+        implementation.generatePrContent(input),
+      ),
+    generateDiffSummary: (input) =>
+      withImplementation("generateDiffSummary", input, (implementation) =>
+        implementation.generateDiffSummary(input),
+      ),
+    generateBranchName: (input) =>
+      withImplementation("generateBranchName", input, (implementation) =>
+        implementation.generateBranchName(input),
+      ),
+    generateThreadTitle: (input) =>
+      withImplementation("generateThreadTitle", input, (implementation) =>
+        implementation.generateThreadTitle(input),
+      ),
+    generateThreadRecap: (input) =>
+      withImplementation("generateThreadRecap", input, (implementation) =>
+        implementation.generateThreadRecap(input),
+      ),
     generateAutomationIntent: (input) =>
-      resolveImplementation(input).generateAutomationIntent(input),
+      withImplementation("generateAutomationIntent", input, (implementation) =>
+        implementation.generateAutomationIntent(input),
+      ),
     evaluateAutomationCompletion: (input) =>
-      resolveImplementation(input).evaluateAutomationCompletion(input),
+      withImplementation("evaluateAutomationCompletion", input, (implementation) =>
+        implementation.evaluateAutomationCompletion(input),
+      ),
   } satisfies TextGenerationShape;
 });
 

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -1,10 +1,11 @@
 import {
-  DEFAULT_PROVIDER_PROFILE_ID,
   CheckpointRef,
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
+  DEFAULT_PROVIDER_PROFILE_ID,
   MessageId,
   ProjectId,
+  ProviderProfileId,
   ThreadId,
   TurnId,
   type OrchestrationCommand,
@@ -1197,6 +1198,186 @@ describe("OrchestrationEngine", () => {
       ),
     ).rejects.toThrow("Thread 'thread-missing' does not exist");
 
+    await system.dispose();
+  });
+
+  it("hydrates message history before deciding a provider target change", async () => {
+    const system = await createOrchestrationSystem();
+    const { engine } = system;
+    const createdAt = now();
+    const projectId = asProjectId("project-target-lock");
+    const threadId = ThreadId.makeUnsafe("thread-target-lock");
+
+    await system.run(
+      engine.dispatch({
+        type: "project.create",
+        commandId: CommandId.makeUnsafe("cmd-target-lock-project"),
+        projectId,
+        title: "Target lock",
+        workspaceRoot: "/tmp/target-lock",
+        defaultModelSelection: null,
+        createdAt,
+      }),
+    );
+    await system.run(
+      engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.makeUnsafe("cmd-target-lock-thread"),
+        threadId,
+        projectId,
+        title: "Target lock",
+        modelSelection: {
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          model: "gpt-5.6-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        branch: null,
+        worktreePath: null,
+        createdAt,
+      }),
+    );
+    await system.run(
+      engine.dispatch({
+        type: "thread.messages.import",
+        commandId: CommandId.makeUnsafe("cmd-target-lock-import"),
+        threadId,
+        messages: [
+          {
+            messageId: MessageId.makeUnsafe("message-target-lock"),
+            role: "user",
+            text: "Existing work",
+            createdAt,
+            updatedAt: createdAt,
+          },
+        ],
+        createdAt,
+      }),
+    );
+    const commandModel = await system.run(engine.refreshCommandReadModel());
+    expect(commandModel.threads.find((thread) => thread.id === threadId)).toMatchObject({
+      latestTurn: null,
+      messages: [],
+      session: null,
+    });
+
+    await expect(
+      system.run(
+        engine.dispatch({
+          type: "thread.meta.update",
+          commandId: CommandId.makeUnsafe("cmd-target-lock-update"),
+          threadId,
+          modelSelection: {
+            provider: "codex",
+            profileId: ProviderProfileId.makeUnsafe("work"),
+            model: "gpt-5.6-codex",
+          },
+        }),
+      ),
+    ).rejects.toThrow("already has work on provider target 'codex/default'");
+
+    const readModel = await system.run(engine.getReadModel());
+    expect(readModel.threads.find((thread) => thread.id === threadId)?.modelSelection).toMatchObject({
+      provider: "codex",
+      profileId: "default",
+    });
+    await system.dispose();
+  });
+
+  it("rejects a cross-profile turn before appending its message after command-model refresh", async () => {
+    const system = await createOrchestrationSystem();
+    const { engine } = system;
+    const createdAt = now();
+    const projectId = asProjectId("project-turn-target-lock");
+    const threadId = ThreadId.makeUnsafe("thread-turn-target-lock");
+
+    await system.run(
+      engine.dispatch({
+        type: "project.create",
+        commandId: CommandId.makeUnsafe("cmd-turn-target-lock-project"),
+        projectId,
+        title: "Turn target lock",
+        workspaceRoot: "/tmp/turn-target-lock",
+        defaultModelSelection: null,
+        createdAt,
+      }),
+    );
+    await system.run(
+      engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.makeUnsafe("cmd-turn-target-lock-thread"),
+        threadId,
+        projectId,
+        title: "Turn target lock",
+        modelSelection: {
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          model: "gpt-5.6-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        branch: null,
+        worktreePath: null,
+        createdAt,
+      }),
+    );
+    await system.run(
+      engine.dispatch({
+        type: "thread.messages.import",
+        commandId: CommandId.makeUnsafe("cmd-turn-target-lock-import"),
+        threadId,
+        messages: [
+          {
+            messageId: MessageId.makeUnsafe("message-turn-target-lock-existing"),
+            role: "user",
+            text: "Existing work",
+            createdAt,
+            updatedAt: createdAt,
+          },
+        ],
+        createdAt,
+      }),
+    );
+    const commandModel = await system.run(engine.refreshCommandReadModel());
+    expect(commandModel.threads.find((thread) => thread.id === threadId)).toMatchObject({
+      latestTurn: null,
+      messages: [],
+      session: null,
+    });
+    const sequenceBeforeRejectedTurn = (await system.run(engine.getReadModel())).snapshotSequence;
+
+    await expect(
+      system.run(
+        engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.makeUnsafe("cmd-turn-target-lock-start"),
+          threadId,
+          message: {
+            messageId: MessageId.makeUnsafe("message-turn-target-lock-rejected"),
+            role: "user",
+            text: "Wrong account",
+            attachments: [],
+          },
+          modelSelection: {
+            provider: "codex",
+            profileId: ProviderProfileId.makeUnsafe("work"),
+            model: "gpt-5.6-codex",
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt,
+        }),
+      ),
+    ).rejects.toThrow("already has work on provider target 'codex/default'");
+
+    const readModel = await system.run(engine.getReadModel());
+    const thread = readModel.threads.find((entry) => entry.id === threadId);
+    expect(readModel.snapshotSequence).toBe(sequenceBeforeRejectedTurn);
+    expect(thread?.modelSelection).toMatchObject({
+      provider: "codex",
+      profileId: "default",
+    });
     await system.dispose();
   });
 

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -8,6 +8,10 @@ import type {
 } from "@synara/contracts";
 import { OrchestrationCommand, ORCHESTRATION_WS_METHODS } from "@synara/contracts";
 import {
+  providerTargetFromModelSelection,
+  providerTargetsEqual,
+} from "@synara/shared/providerTarget";
+import {
   Cause,
   Deferred,
   Effect,
@@ -450,13 +454,45 @@ const makeOrchestrationEngine = Effect.gen(function* () {
       case "thread.fork.create":
         return loadThreadDetailForDecider(command, commandReadModel, command.sourceThreadId);
       case "thread.turn.start":
-        return command.sourceProposedPlan
-          ? loadThreadDetailForDecider(
-              command,
-              commandReadModel,
-              command.sourceProposedPlan.threadId,
-            )
+        return Effect.gen(function* () {
+          const readModel = command.sourceProposedPlan
+            ? yield* loadThreadDetailForDecider(
+                command,
+                commandReadModel,
+                command.sourceProposedPlan.threadId,
+              )
+            : commandReadModel;
+          if (command.modelSelection === undefined) {
+            return readModel;
+          }
+          const thread = readModel.threads.find((entry) => entry.id === command.threadId);
+          const targetChanged =
+            thread !== undefined &&
+            !providerTargetsEqual(
+              providerTargetFromModelSelection(thread.modelSelection),
+              providerTargetFromModelSelection(command.modelSelection),
+            );
+          if (
+            !targetChanged ||
+            command.sourceProposedPlan?.threadId === command.threadId
+          ) {
+            return readModel;
+          }
+          return yield* loadThreadDetailForDecider(command, readModel, command.threadId);
+        });
+      case "thread.meta.update": {
+        if (command.modelSelection === undefined) {
+          return Effect.succeed(commandReadModel);
+        }
+        const thread = commandReadModel.threads.find((entry) => entry.id === command.threadId);
+        return thread !== undefined &&
+          !providerTargetsEqual(
+            providerTargetFromModelSelection(thread.modelSelection),
+            providerTargetFromModelSelection(command.modelSelection),
+          )
+          ? loadThreadDetailForDecider(command, commandReadModel, command.threadId)
           : Effect.succeed(commandReadModel);
+      }
       case "thread.conversation.rollback":
       case "thread.message.edit-and-resend":
       case "thread.message.assistant.complete":

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -70,7 +70,11 @@ import {
 import { applySpaceMetadataProjection } from "../spaceMetadataProjection.ts";
 import { resolveStableMessageTurnId } from "../messageTurnId.ts";
 import { settleTurnStateFromSession } from "../turnLifecycle.ts";
-import { deriveTurnStartModelSelection, deriveTurnStartSession } from "../turnStartSession.ts";
+import {
+  canAdoptFirstTurnTarget,
+  deriveTurnStartModelSelection,
+  deriveTurnStartSession,
+} from "../turnStartSession.ts";
 import {
   attachmentRelativePath,
   parseAttachmentIdFromRelativePath,
@@ -799,14 +803,15 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
               threadId: event.payload.threadId,
             }),
           ]);
-          const canAdoptFirstTurnProvider =
-            existingRow.value.latestTurnId === null &&
-            Option.isNone(session) &&
-            messages.length <= 1;
+          const canAdoptRequestedTarget = canAdoptFirstTurnTarget({
+            hasLatestTurn: existingRow.value.latestTurnId !== null,
+            hasSession: Option.isSome(session),
+            messageCount: messages.length,
+          });
           const projectedModelSelection = deriveTurnStartModelSelection({
             currentModelSelection: existingRow.value.modelSelection,
             requestedModelSelection: event.payload.modelSelection,
-            canAdoptRequestedProvider: canAdoptFirstTurnProvider,
+            canAdoptRequestedTarget,
           });
           // Automation-dispatched turns run with the automation's modes but must not
           // repaint the thread's persisted modes: on a heartbeat target thread the

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -16,15 +16,16 @@ import type {
   ProviderSession,
 } from "@synara/contracts";
 import {
-  DEFAULT_PROVIDER_PROFILE_ID,
   ApprovalRequestId,
   type ChatAttachment,
   CommandId,
   DEFAULT_GIT_TEXT_GENERATION_MODEL,
   DEFAULT_PROVIDER_INTERACTION_MODE,
+  DEFAULT_PROVIDER_PROFILE_ID,
   EventId,
   MessageId,
   PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
+  ProviderProfileId,
   ProjectId,
   ThreadId,
   TurnId,
@@ -7345,7 +7346,7 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
-  it("rejects provider changes after a thread is already bound to a session provider", async () => {
+  it("rejects provider changes at the command boundary after a thread has work", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();
 
@@ -7369,20 +7370,65 @@ describe("ProviderCommandReactor", () => {
     await waitFor(() => harness.startSession.mock.calls.length === 1);
     await waitFor(() => harness.sendTurn.mock.calls.length === 1);
 
+    await expect(
+      Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.makeUnsafe("cmd-turn-start-provider-switch-2"),
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          message: {
+            messageId: asMessageId("user-message-provider-switch-2"),
+            role: "user",
+            text: "second",
+            attachments: [],
+          },
+          modelSelection: {
+            provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
+            model: "claude-opus-4-6",
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt: now,
+        }),
+      ),
+    ).rejects.toThrow(
+      "already has work on provider target 'codex/default'. Create a new thread or explicit handoff to use 'claudeAgent/default'",
+    );
+    await harness.drain();
+
+    expect(harness.startSession.mock.calls.length).toBe(1);
+    expect(harness.sendTurn.mock.calls.length).toBe(1);
+    expect(harness.stopSession.mock.calls.length).toBe(0);
+
+    const thread = await readHarnessThread(harness);
+    expect(thread?.session?.threadId).toBe("thread-1");
+    expect(thread?.session?.providerName).toBe("codex");
+    expect(thread?.session?.runtimeMode).toBe("approval-required");
+    expect(thread?.messages.some((message) => message.id === "user-message-provider-switch-2")).toBe(
+      false,
+    );
+  });
+
+  it("rejects a fresh non-default profile before session and text-generation side effects", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
     await Effect.runPromise(
       harness.engine.dispatch({
         type: "thread.turn.start",
-        commandId: CommandId.makeUnsafe("cmd-turn-start-provider-switch-2"),
+        commandId: CommandId.makeUnsafe("cmd-turn-start-profile-fresh"),
         threadId: ThreadId.makeUnsafe("thread-1"),
         message: {
-          messageId: asMessageId("user-message-provider-switch-2"),
+          messageId: asMessageId("user-message-profile-fresh"),
           role: "user",
-          text: "second",
+          text: "start with the work account",
           attachments: [],
         },
         modelSelection: {
-          provider: "claudeAgent",
-          model: "claude-opus-4-6",
+          provider: "codex",
+          profileId: ProviderProfileId.makeUnsafe("work"),
+          model: "gpt-5.6-codex",
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "approval-required",
@@ -7398,21 +7444,397 @@ describe("ProviderCommandReactor", () => {
       );
     });
 
+    expect(harness.startSession).not.toHaveBeenCalled();
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+    expect(harness.generateBranchName).not.toHaveBeenCalled();
+    expect(harness.generateThreadTitle).not.toHaveBeenCalled();
+
+    const thread = await readHarnessThread(harness);
+    expect(
+      thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
+    ).toMatchObject({
+      payload: {
+        detail: expect.stringContaining("profile 'work' is not configured"),
+      },
+    });
+  });
+
+  it("rejects a work-profile edit before destructive replay side effects", async () => {
+    const workSelection: ModelSelection = {
+      provider: "codex",
+      profileId: ProviderProfileId.makeUnsafe("work"),
+      model: "gpt-5.6-codex",
+    };
+    const harness = await createHarness({ threadModelSelection: workSelection });
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const messageId = asMessageId("user-message-work-profile-edit");
+    const turnId = asTurnId("turn-work-profile-edit");
+    const now = new Date().toISOString();
+
+    await seedRollbackTarget(harness, { messageId, turnId, createdAt: now });
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.makeUnsafe("cmd-work-profile-edit-diff-complete"),
+        threadId,
+        turnId,
+        completedAt: now,
+        checkpointRef: checkpointRefForThreadTurn(threadId, 1),
+        status: "ready",
+        files: [],
+        assistantMessageId: asMessageId("assistant-user-message-work-profile-edit"),
+        checkpointTurnCount: 1,
+        createdAt: now,
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-work-profile-edit-session-running"),
+        threadId,
+        session: {
+          threadId,
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: turnId,
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+    await harness.drain();
+
+    const queuedPromotions = harness.queuedTurnPromotionRepository as {
+      cancelMessage: typeof harness.queuedTurnPromotionRepository.cancelMessage;
+      cancelThread: typeof harness.queuedTurnPromotionRepository.cancelThread;
+    };
+    const cancelMessage = vi.fn(queuedPromotions.cancelMessage);
+    const cancelThread = vi.fn(queuedPromotions.cancelThread);
+    queuedPromotions.cancelMessage = cancelMessage;
+    queuedPromotions.cancelThread = cancelThread;
+    const replayCommands: OrchestrationCommand[] = [];
+    harness.interceptEngineDispatch((command) => {
+      if (
+        command.type === "thread.conversation.rollback.complete" ||
+        command.type === "thread.turn.start"
+      ) {
+        replayCommands.push(command);
+      }
+      return undefined;
+    });
+    harness.isGitRepository.mockImplementation(() => Effect.succeed(true));
+    harness.stopRuntimeSession.mockClear();
+    harness.stopSession.mockClear();
+    harness.clearSessionResumeCursor.mockClear();
+    harness.rollbackConversation.mockClear();
+    harness.restoreCheckpoint.mockClear();
+    harness.sendTurn.mockClear();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.message.edit-and-resend",
+        commandId: CommandId.makeUnsafe("cmd-work-profile-edit-and-resend"),
+        threadId,
+        messageId,
+        text: "edited prompt",
+        runtimeMode: "approval-required",
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(async () => (await readHarnessThread(harness))?.session?.status === "error");
+    await harness.drain();
+
+    expect(harness.stopRuntimeSession).not.toHaveBeenCalled();
+    expect(harness.stopSession).not.toHaveBeenCalled();
+    expect(harness.clearSessionResumeCursor).not.toHaveBeenCalled();
+    expect(harness.rollbackConversation).not.toHaveBeenCalled();
+    expect(cancelMessage).not.toHaveBeenCalled();
+    expect(cancelThread).not.toHaveBeenCalled();
+    expect(harness.isGitRepository).not.toHaveBeenCalled();
+    expect(harness.restoreCheckpoint).not.toHaveBeenCalled();
+    expect(replayCommands).toEqual([]);
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+
+    const thread = await readHarnessThread(harness);
+    expect(thread?.session?.lastError).toContain("profile 'work' is not configured");
+    expect(
+      thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
+    ).toMatchObject({
+      payload: {
+        detail: expect.stringContaining("profile 'work' is not configured"),
+      },
+    });
+  });
+
+  it("rejects a replayed cross-provider edit before destructive replay side effects", async () => {
+    const harness = await createHarness({ startReactor: false });
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const messageId = asMessageId("user-message-replayed-cross-provider-edit");
+    const turnId = asTurnId("turn-replayed-cross-provider-edit");
+    const now = new Date().toISOString();
+
+    await seedRollbackTarget(harness, { messageId, turnId, createdAt: now });
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-replayed-cross-provider-session-running"),
+        threadId,
+        session: {
+          threadId,
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: turnId,
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+
+    const queuedPromotions = harness.queuedTurnPromotionRepository as {
+      cancelMessage: typeof harness.queuedTurnPromotionRepository.cancelMessage;
+      cancelThread: typeof harness.queuedTurnPromotionRepository.cancelThread;
+    };
+    const cancelMessage = vi.fn(queuedPromotions.cancelMessage);
+    const cancelThread = vi.fn(queuedPromotions.cancelThread);
+    queuedPromotions.cancelMessage = cancelMessage;
+    queuedPromotions.cancelThread = cancelThread;
+    const replayCommands: OrchestrationCommand[] = [];
+    harness.interceptEngineDispatch((command) => {
+      if (
+        command.type === "thread.conversation.rollback.complete" ||
+        command.type === "thread.turn.start"
+      ) {
+        replayCommands.push(command);
+      }
+      return undefined;
+    });
+    harness.isGitRepository.mockImplementation(() => Effect.succeed(true));
+
+    await harness.persistWithoutLivePublication([
+      {
+        eventId: asEventId("evt-replayed-cross-provider-edit"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: now,
+        commandId: CommandId.makeUnsafe("cmd-replayed-cross-provider-edit"),
+        causationEventId: null,
+        correlationId: CommandId.makeUnsafe("cmd-replayed-cross-provider-edit"),
+        metadata: {},
+        type: "thread.message-edit-resend-requested",
+        payload: {
+          threadId,
+          messageId,
+          text: "edited prompt",
+          rollbackTurnCount: 1,
+          removedTurnIds: [turnId],
+          modelSelection: {
+            provider: "claudeAgent",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
+            model: "claude-opus-4-6",
+          },
+          runtimeMode: "approval-required",
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          createdAt: now,
+        },
+      },
+    ]);
+
+    harness.stopRuntimeSession.mockClear();
+    harness.stopSession.mockClear();
+    harness.clearSessionResumeCursor.mockClear();
+    harness.rollbackConversation.mockClear();
+    harness.restoreCheckpoint.mockClear();
+    harness.sendTurn.mockClear();
+    await harness.startReactor();
+
+    await waitFor(async () => (await readHarnessThread(harness))?.session?.status === "error");
+    await harness.drain();
+
+    expect(harness.stopRuntimeSession).not.toHaveBeenCalled();
+    expect(harness.stopSession).not.toHaveBeenCalled();
+    expect(harness.clearSessionResumeCursor).not.toHaveBeenCalled();
+    expect(harness.rollbackConversation).not.toHaveBeenCalled();
+    expect(cancelMessage).not.toHaveBeenCalled();
+    expect(cancelThread).not.toHaveBeenCalled();
+    expect(harness.isGitRepository).not.toHaveBeenCalled();
+    expect(harness.restoreCheckpoint).not.toHaveBeenCalled();
+    expect(replayCommands).toEqual([]);
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+
+    const thread = await readHarnessThread(harness);
+    expect(thread?.session?.lastError).toContain(
+      "bound to 'codex/default' and cannot switch to 'claudeAgent/default'",
+    );
+  });
+
+  it("does not queue behind or dispatch through a live default session for a work profile", async () => {
+    const workSelection: ModelSelection = {
+      provider: "codex",
+      profileId: ProviderProfileId.makeUnsafe("work"),
+      model: "gpt-5.6-codex",
+    };
+    const harness = await createHarness({ threadModelSelection: workSelection });
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const now = new Date().toISOString();
+
+    await harness.drain();
+    const defaultSession = await Effect.runPromise(
+      harness.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "approval-required",
+        modelSelection: {
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          model: "gpt-5.6-codex",
+        },
+      }),
+    );
+    const defaultTurnId = asTurnId("turn-live-default-for-work");
+    harness.setRuntimeSessionTurnState({
+      threadId,
+      status: "running",
+      activeTurnId: defaultTurnId,
+    });
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-live-default-session-set"),
+        threadId,
+        session: {
+          threadId,
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: defaultTurnId,
+          lastError: null,
+          updatedAt: defaultSession.updatedAt,
+        },
+        createdAt: defaultSession.updatedAt,
+      }),
+    );
+    await harness.drain();
+    harness.startSession.mockClear();
+    harness.sendTurn.mockClear();
+    harness.startSession.mockImplementationOnce(() =>
+      Effect.fail(
+        new ProviderValidationError({
+          provider: "codex",
+          operation: "ProviderService.startSession",
+          issue: "Provider profile 'work' is not configured for provider 'codex'.",
+        }),
+      ),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-work-with-live-default"),
+        threadId,
+        message: {
+          messageId: asMessageId("user-message-work-with-live-default"),
+          role: "user",
+          text: "use the work account",
+          attachments: [],
+        },
+        modelSelection: workSelection,
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(async () => {
+      const thread = await readHarnessThread(harness);
+      return (
+        thread?.activities.some((activity) => activity.kind === "provider.turn.start.failed") ??
+        false
+      );
+    });
+
+    const liveSessions = await Effect.runPromise(harness.listSessions());
+    expect(liveSessions).toHaveLength(1);
+    expect(liveSessions[0]).toMatchObject({ provider: "codex", threadId });
+    expect(liveSessions[0]).not.toHaveProperty("profileId");
+    expect(harness.startSession).toHaveBeenCalledOnce();
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+    expect(harness.stopSession).not.toHaveBeenCalled();
+
+    const thread = await readHarnessThread(harness);
+    expect(
+      thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
+    ).toMatchObject({
+      payload: {
+        detail: expect.stringContaining("profile 'work' is not configured"),
+      },
+    });
+  });
+
+  it("rejects profile changes at the command boundary after a thread has work", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-profile-switch-1"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-profile-switch-1"),
+          role: "user",
+          text: "first",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+    await expect(
+      Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.makeUnsafe("cmd-turn-start-profile-switch-2"),
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          message: {
+            messageId: asMessageId("user-message-profile-switch-2"),
+            role: "user",
+            text: "second",
+            attachments: [],
+          },
+          modelSelection: {
+            provider: "codex",
+            profileId: ProviderProfileId.makeUnsafe("work"),
+            model: "gpt-5.6-codex",
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt: now,
+        }),
+      ),
+    ).rejects.toThrow(
+      "already has work on provider target 'codex/default'. Create a new thread or explicit handoff to use 'codex/work'",
+    );
+    await harness.drain();
+
     expect(harness.startSession.mock.calls.length).toBe(1);
     expect(harness.sendTurn.mock.calls.length).toBe(1);
     expect(harness.stopSession.mock.calls.length).toBe(0);
 
     const thread = await readHarnessThread(harness);
-    expect(thread?.session?.threadId).toBe("thread-1");
-    expect(thread?.session?.providerName).toBe("codex");
-    expect(thread?.session?.runtimeMode).toBe("approval-required");
-    expect(
-      thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
-    ).toMatchObject({
-      payload: {
-        detail: expect.stringContaining("cannot switch to 'claudeAgent'"),
-      },
-    });
+    expect(thread?.messages.some((message) => message.id === "user-message-profile-switch-2")).toBe(
+      false,
+    );
   });
 
   it("does not stop the active session when restart fails before rebind", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -53,6 +53,11 @@ import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@synara/share
 import { claudeSelectionRequiresRestart } from "@synara/shared/model";
 import { providerSupportsNativeTurnSteering } from "@synara/shared/providerMetadata";
 import {
+  providerTargetFromModelSelection,
+  providerTargetFromSource,
+  providerTargetsEqual,
+} from "@synara/shared/providerTarget";
+import {
   formatProviderDeliveryBlockDetail,
   PROVIDER_DELIVERY_BLOCK_SUMMARY,
 } from "@synara/shared/providerDeliveryBlock";
@@ -86,6 +91,7 @@ import {
 import { resolveTextGenerationInputForSelection } from "../../git/textGenerationSelection.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { resolveProviderDispatchAttachments } from "../../provider/providerAttachmentPaths.ts";
+import { resolveDefaultProviderProfile } from "../../provider/providerProfileResolver.ts";
 import { OrchestrationEventDeliveryRepositoryLive } from "../../persistence/Layers/OrchestrationEventDeliveries.ts";
 import { ProjectionPendingInteractionRepositoryLive } from "../../persistence/Layers/ProjectionPendingInteractions.ts";
 import { QueuedTurnPromotionRepositoryLive } from "../../persistence/Layers/QueuedTurnPromotions.ts";
@@ -786,6 +792,28 @@ const make = Effect.gen(function* () {
     });
   });
 
+  const surfaceProviderProfileTurnStartFailure = Effect.fnUntraced(function* (input: {
+    readonly threadId: ThreadId;
+    readonly runtimeMode?: RuntimeMode;
+    readonly detail: string;
+    readonly createdAt: string;
+  }) {
+    yield* appendProviderFailureActivity({
+      threadId: input.threadId,
+      kind: "provider.turn.start.failed",
+      summary: "Provider turn start failed",
+      detail: input.detail,
+      turnId: null,
+      createdAt: input.createdAt,
+    });
+    yield* setThreadSessionError({
+      threadId: input.threadId,
+      runtimeMode: input.runtimeMode,
+      detail: input.detail,
+      createdAt: input.createdAt,
+    });
+  });
+
   /**
    * Finalizes a turn the provider will never settle on its own. `Stop` is only
    * trustworthy if every dead-end branch clears the projected active turn:
@@ -872,10 +900,22 @@ const make = Effect.gen(function* () {
   // would always miss and drain queued child messages into a live turn.
   const resolveLiveProviderTurnId = Effect.fnUntraced(function* (threadId: ThreadId) {
     const providerThread = yield* resolveProviderSessionThread(threadId);
+    if (!providerThread) {
+      return undefined;
+    }
     const sessionThreadId = providerThread?.id ?? threadId;
+    const expectedTarget = providerTargetFromModelSelection(providerThread.modelSelection);
     const session = yield* providerService
       .listSessions()
-      .pipe(Effect.map((sessions) => sessions.find((entry) => entry.threadId === sessionThreadId)));
+      .pipe(
+        Effect.map((sessions) =>
+          sessions.find(
+            (entry) =>
+              entry.threadId === sessionThreadId &&
+              providerTargetsEqual(providerTargetFromSource(entry), expectedTarget),
+          ),
+        ),
+      );
     return session?.status === "running" ? session.activeTurnId : undefined;
   });
   const hasLiveProviderTurn = (threadId: ThreadId) =>
@@ -1111,18 +1151,22 @@ const make = Effect.gen(function* () {
       ? thread.session.providerName
       : undefined;
     const requestedModelSelection = options?.modelSelection;
-    const threadProvider: ProviderKind = currentProvider ?? thread.modelSelection.provider;
+    const persistedTarget = providerTargetFromModelSelection(thread.modelSelection);
+    const threadTarget = persistedTarget;
     if (
       requestedModelSelection !== undefined &&
-      requestedModelSelection.provider !== threadProvider
+      !providerTargetsEqual(providerTargetFromModelSelection(requestedModelSelection), threadTarget)
     ) {
+      const requestedTarget = providerTargetFromModelSelection(requestedModelSelection);
       return yield* new ProviderAdapterValidationError({
-        provider: threadProvider,
+        provider: threadTarget.provider,
         operation: "thread.turn.start",
-        issue: `Thread '${threadId}' is bound to provider '${threadProvider}' and cannot switch to '${requestedModelSelection.provider}'.`,
+        issue:
+          `Thread '${threadId}' is bound to '${threadTarget.provider}/${threadTarget.profileId}' ` +
+          `and cannot switch to '${requestedTarget.provider}/${requestedTarget.profileId}'.`,
       });
     }
-    const preferredProvider: ProviderKind = currentProvider ?? threadProvider;
+    const preferredProvider: ProviderKind = threadTarget.provider;
     const desiredModelSelection = requestedModelSelection ?? thread.modelSelection;
     const settingsSnapshot = yield* serverSettings.getSnapshot;
     if (!settingsSnapshot.settings.providers[preferredProvider].enabled) {
@@ -1142,7 +1186,7 @@ const make = Effect.gen(function* () {
     });
     if (workspaceState === "worktree-pending") {
       return yield* new ProviderAdapterValidationError({
-        provider: threadProvider,
+        provider: threadTarget.provider,
         operation: "thread.turn.start",
         issue: `Thread '${threadId}' targets a worktree that has not been created yet.`,
       });
@@ -1195,9 +1239,10 @@ const make = Effect.gen(function* () {
     if (reusableSession) {
       const existingSessionThreadId = thread.id;
       const runtimeModeChanged = desiredRuntimeMode !== thread.session?.runtimeMode;
-      const providerChanged =
-        requestedModelSelection !== undefined &&
-        requestedModelSelection.provider !== currentProvider;
+      const activeTarget = providerTargetFromSource(activeSessionBeforeEnsure);
+      const desiredTarget = providerTargetFromModelSelection(desiredModelSelection);
+      const targetChanged = !providerTargetsEqual(activeTarget, desiredTarget);
+      const providerChanged = activeTarget.provider !== desiredTarget.provider;
       const sessionModelSwitch =
         currentProvider === undefined
           ? "in-session"
@@ -1226,7 +1271,7 @@ const make = Effect.gen(function* () {
 
       if (
         !runtimeModeChanged &&
-        !providerChanged &&
+        !targetChanged &&
         !shouldRestartForModelChange &&
         !shouldRestartForModelSelectionChange
       ) {
@@ -1237,7 +1282,7 @@ const make = Effect.gen(function* () {
       }
 
       const resumeCursor =
-        providerChanged || shouldRestartForModelChange || runtimeModeChanged
+        targetChanged || shouldRestartForModelChange || runtimeModeChanged
           ? undefined
           : (activeSessionBeforeEnsure?.resumeCursor ?? undefined);
       yield* Effect.logInfo("provider command reactor restarting provider session", {
@@ -1248,6 +1293,7 @@ const make = Effect.gen(function* () {
         currentRuntimeMode: thread.session?.runtimeMode,
         desiredRuntimeMode,
         runtimeModeChanged,
+        targetChanged,
         providerChanged,
         modelChanged,
         shouldRestartForModelChange,
@@ -2205,6 +2251,28 @@ const make = Effect.gen(function* () {
         return;
       }
 
+      if (thread.latestTurn === null) {
+        const requestedTarget = providerTargetFromModelSelection(
+          event.payload.modelSelection ?? thread.modelSelection,
+        );
+        const profileIssue = yield* resolveDefaultProviderProfile({
+          operation: "ProviderCommandReactor.turnStart",
+          target: requestedTarget,
+        }).pipe(
+          Effect.as<string | null>(null),
+          Effect.catch((cause) => Effect.succeed(cause.issue)),
+        );
+        if (profileIssue !== null) {
+          yield* surfaceProviderProfileTurnStartFailure({
+            threadId: event.payload.threadId,
+            detail: profileIssue,
+            runtimeMode: event.payload.runtimeMode,
+            createdAt: event.payload.createdAt,
+          });
+          return;
+        }
+      }
+
       // The decider routes turn starts from the projected session, which can lag
       // the runtime: a message dispatched right as another turn begins (e.g. the
       // gap between a steer interrupt and the steered turn's start) would race a
@@ -3114,6 +3182,40 @@ const make = Effect.gen(function* () {
     event: Extract<ProviderIntentEvent, { type: "thread.message-edit-resend-requested" }>,
   ) {
     const thread = yield* resolveThread(event.payload.threadId);
+    if (thread) {
+      const requestedTarget = providerTargetFromModelSelection(
+        event.payload.modelSelection ?? thread.modelSelection,
+      );
+      const threadTarget = providerTargetFromModelSelection(thread.modelSelection);
+      if (!providerTargetsEqual(requestedTarget, threadTarget)) {
+        yield* surfaceProviderProfileTurnStartFailure({
+          threadId: event.payload.threadId,
+          runtimeMode: event.payload.runtimeMode,
+          detail:
+            `Thread '${event.payload.threadId}' is bound to ` +
+            `'${threadTarget.provider}/${threadTarget.profileId}' and cannot switch to ` +
+            `'${requestedTarget.provider}/${requestedTarget.profileId}'.`,
+          createdAt: event.payload.createdAt,
+        });
+        return;
+      }
+      const profileIssue = yield* resolveDefaultProviderProfile({
+        operation: "ProviderCommandReactor.messageEditResend",
+        target: requestedTarget,
+      }).pipe(
+        Effect.as<string | null>(null),
+        Effect.catch((cause) => Effect.succeed(cause.issue)),
+      );
+      if (profileIssue !== null) {
+        yield* surfaceProviderProfileTurnStartFailure({
+          threadId: event.payload.threadId,
+          runtimeMode: event.payload.runtimeMode,
+          detail: profileIssue,
+          createdAt: event.payload.createdAt,
+        });
+        return;
+      }
+    }
     const providerThread = yield* resolveProviderSessionThread(event.payload.threadId);
     const activeTurnId =
       providerThread?.session?.status === "running"

--- a/apps/server/src/orchestration/decider.providerTarget.test.ts
+++ b/apps/server/src/orchestration/decider.providerTarget.test.ts
@@ -1,0 +1,324 @@
+import {
+  CommandId,
+  DEFAULT_PROVIDER_INTERACTION_MODE,
+  DEFAULT_PROVIDER_PROFILE_ID,
+  MessageId,
+  ProjectId,
+  ProviderProfileId,
+  ThreadId,
+  TurnId,
+  type ModelSelection,
+  type OrchestrationReadModel,
+} from "@synara/contracts";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { decideOrchestrationCommand } from "./decider.ts";
+
+const NOW = "2026-08-10T00:00:00.000Z";
+const THREAD_ID = ThreadId.makeUnsafe("thread-provider-target");
+
+function makeReadModel(input?: {
+  readonly modelSelection?: ModelSelection;
+  readonly established?: boolean;
+  readonly hasMessage?: boolean;
+  readonly hasSession?: boolean;
+  readonly creationSource?: "provider_native";
+}): OrchestrationReadModel {
+  const established = input?.established ?? false;
+  return {
+    snapshotSequence: 1,
+    updatedAt: NOW,
+    spaces: [],
+    projects: [],
+    threads: [
+      {
+        id: THREAD_ID,
+        projectId: ProjectId.makeUnsafe("project-provider-target"),
+        title: "Provider target",
+        modelSelection: input?.modelSelection ?? {
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          model: "gpt-5.6-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "full-access",
+        branch: null,
+        worktreePath: null,
+        createdAt: NOW,
+        updatedAt: NOW,
+        latestTurn: established
+          ? {
+              turnId: TurnId.makeUnsafe("turn-provider-target"),
+              state: "completed",
+              requestedAt: NOW,
+              startedAt: NOW,
+              completedAt: NOW,
+              assistantMessageId: null,
+            }
+          : null,
+        ...(input?.creationSource !== undefined
+          ? { creationSource: input.creationSource }
+          : {}),
+        handoff: null,
+        messages: input?.hasMessage
+          ? [
+              {
+                id: MessageId.makeUnsafe("message-provider-target"),
+                role: "user",
+                text: "Existing work",
+                turnId: null,
+                streaming: false,
+                source: "native",
+                createdAt: NOW,
+                updatedAt: NOW,
+              },
+            ]
+          : [],
+        session: input?.hasSession
+          ? {
+              threadId: THREAD_ID,
+              status: "ready",
+              providerName: "codex",
+              runtimeMode: "full-access",
+              activeTurnId: null,
+              lastError: null,
+              updatedAt: NOW,
+            }
+          : null,
+        activities: [],
+        proposedPlans: [],
+        checkpoints: [],
+        deletedAt: null,
+      },
+    ],
+  };
+}
+
+function updateModelSelection(modelSelection: ModelSelection) {
+  return decideOrchestrationCommand({
+    command: {
+      type: "thread.meta.update",
+      commandId: CommandId.makeUnsafe("cmd-update-provider-target"),
+      threadId: THREAD_ID,
+      modelSelection,
+    },
+    readModel: makeReadModel(),
+  });
+}
+
+describe("thread provider target invariants", () => {
+  it("allows an empty thread to adopt its first provider profile", async () => {
+    const result = await Effect.runPromise(
+      updateModelSelection({
+        provider: "codex",
+        profileId: ProviderProfileId.makeUnsafe("work"),
+        model: "gpt-5.6-codex",
+      }),
+    );
+
+    const event = Array.isArray(result) ? result[0] : result;
+    expect(event?.type).toBe("thread.meta-updated");
+    if (event?.type !== "thread.meta-updated") return;
+    expect(event.payload.modelSelection).toMatchObject({
+      provider: "codex",
+      profileId: "work",
+    });
+  });
+
+  it("rejects changing provider profiles after the first turn", async () => {
+    await expect(
+      Effect.runPromise(
+        decideOrchestrationCommand({
+          command: {
+            type: "thread.meta.update",
+            commandId: CommandId.makeUnsafe("cmd-replace-provider-target"),
+            threadId: THREAD_ID,
+            modelSelection: {
+              provider: "codex",
+              profileId: ProviderProfileId.makeUnsafe("work"),
+              model: "gpt-5.6-codex",
+            },
+          },
+          readModel: makeReadModel({ established: true }),
+        }),
+      ),
+    ).rejects.toThrow(
+      "Create a new thread or explicit handoff to use 'codex/work'.",
+    );
+  });
+
+  it("rejects target changes once a message has been recorded", async () => {
+    await expect(
+      Effect.runPromise(
+        decideOrchestrationCommand({
+          command: {
+            type: "thread.meta.update",
+            commandId: CommandId.makeUnsafe("cmd-replace-message-target"),
+            threadId: THREAD_ID,
+            modelSelection: {
+              provider: "codex",
+              profileId: ProviderProfileId.makeUnsafe("work"),
+              model: "gpt-5.6-codex",
+            },
+          },
+          readModel: makeReadModel({ hasMessage: true }),
+        }),
+      ),
+    ).rejects.toThrow("already has work on provider target 'codex/default'");
+  });
+
+  it("rejects target changes once a provider session has been recorded", async () => {
+    await expect(
+      Effect.runPromise(
+        decideOrchestrationCommand({
+          command: {
+            type: "thread.meta.update",
+            commandId: CommandId.makeUnsafe("cmd-replace-session-target"),
+            threadId: THREAD_ID,
+            modelSelection: {
+              provider: "codex",
+              profileId: ProviderProfileId.makeUnsafe("work"),
+              model: "gpt-5.6-codex",
+            },
+          },
+          readModel: makeReadModel({ hasSession: true }),
+        }),
+      ),
+    ).rejects.toThrow("already has work on provider target 'codex/default'");
+  });
+
+  it("allows the first turn on an empty thread to adopt its provider profile", async () => {
+    const result = await Effect.runPromise(
+      decideOrchestrationCommand({
+        command: {
+          type: "thread.turn.start",
+          commandId: CommandId.makeUnsafe("cmd-first-turn-provider-target"),
+          threadId: THREAD_ID,
+          message: {
+            messageId: MessageId.makeUnsafe("message-first-turn-provider-target"),
+            role: "user",
+            text: "First work",
+            attachments: [],
+          },
+          modelSelection: {
+            provider: "codex",
+            profileId: ProviderProfileId.makeUnsafe("work"),
+            model: "gpt-5.6-codex",
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "full-access",
+          createdAt: NOW,
+        },
+        readModel: makeReadModel(),
+      }),
+    );
+
+    const events = Array.isArray(result) ? result : [result];
+    expect(events.map((event) => event.type)).toEqual([
+      "thread.message-sent",
+      "thread.turn-start-requested",
+    ]);
+  });
+
+  it("rejects a turn through another provider profile before recording its message", async () => {
+    await expect(
+      Effect.runPromise(
+        decideOrchestrationCommand({
+          command: {
+            type: "thread.turn.start",
+            commandId: CommandId.makeUnsafe("cmd-retarget-turn-start"),
+            threadId: THREAD_ID,
+            message: {
+              messageId: MessageId.makeUnsafe("message-retarget-turn-start"),
+              role: "user",
+              text: "Wrong account",
+              attachments: [],
+            },
+            modelSelection: {
+              provider: "codex",
+              profileId: ProviderProfileId.makeUnsafe("work"),
+              model: "gpt-5.6-codex",
+            },
+            interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+            runtimeMode: "full-access",
+            createdAt: NOW,
+          },
+          readModel: makeReadModel({ hasMessage: true }),
+        }),
+      ),
+    ).rejects.toThrow("already has work on provider target 'codex/default'");
+  });
+
+  it("rejects retargeting an empty provider-native thread", async () => {
+    await expect(
+      Effect.runPromise(
+        decideOrchestrationCommand({
+          command: {
+            type: "thread.meta.update",
+            commandId: CommandId.makeUnsafe("cmd-replace-provider-native-target"),
+            threadId: THREAD_ID,
+            modelSelection: {
+              provider: "codex",
+              profileId: ProviderProfileId.makeUnsafe("work"),
+              model: "gpt-5.6-codex",
+            },
+          },
+          readModel: makeReadModel({ creationSource: "provider_native" }),
+        }),
+      ),
+    ).rejects.toThrow("already has work on provider target 'codex/default'");
+  });
+
+  it("rejects edit-and-resend through another provider profile before rollback", async () => {
+    await expect(
+      Effect.runPromise(
+        decideOrchestrationCommand({
+          command: {
+            type: "thread.message.edit-and-resend",
+            commandId: CommandId.makeUnsafe("cmd-retarget-edit-resend"),
+            threadId: THREAD_ID,
+            messageId: MessageId.makeUnsafe("message-provider-target"),
+            text: "Edited work",
+            modelSelection: {
+              provider: "codex",
+              profileId: ProviderProfileId.makeUnsafe("work"),
+              model: "gpt-5.6-codex",
+            },
+            interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+            runtimeMode: "full-access",
+            createdAt: NOW,
+          },
+          readModel: makeReadModel({ hasMessage: true }),
+        }),
+      ),
+    ).rejects.toThrow("already has work on provider target 'codex/default'");
+  });
+
+  it("allows model edits that keep an established provider target", async () => {
+    const result = await Effect.runPromise(
+      decideOrchestrationCommand({
+        command: {
+          type: "thread.meta.update",
+          commandId: CommandId.makeUnsafe("cmd-update-model"),
+          threadId: THREAD_ID,
+          modelSelection: {
+            provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
+            model: "gpt-5.5-codex",
+          },
+        },
+        readModel: makeReadModel({ established: true }),
+      }),
+    );
+
+    const event = Array.isArray(result) ? result[0] : result;
+    expect(event?.type).toBe("thread.meta-updated");
+    if (event?.type !== "thread.meta-updated") return;
+    expect(event.payload.modelSelection).toMatchObject({
+      provider: "codex",
+      profileId: "default",
+      model: "gpt-5.5-codex",
+    });
+  });
+});

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -25,6 +25,10 @@ import { collectSubagentDescendants } from "@synara/shared/threadHierarchy";
 import { autoRuntimeModeSelectionIssue } from "@synara/shared/runtimeMode";
 import { providerSupportsNativeTurnSteering } from "@synara/shared/providerMetadata";
 import {
+  providerTargetFromModelSelection,
+  providerTargetsEqual,
+} from "@synara/shared/providerTarget";
+import {
   collectTailTurnIds,
   resolveTailUserMessageEditTarget,
 } from "@synara/shared/conversationEdit";
@@ -82,6 +86,45 @@ function validateAutoRuntimeMode(
           detail: issue,
         }),
       );
+}
+
+type ThreadTargetSelectionCommand =
+  | Extract<OrchestrationCommand, { type: "thread.meta.update" }>
+  | Extract<OrchestrationCommand, { type: "thread.turn.start" }>
+  | Extract<OrchestrationCommand, { type: "thread.message.edit-and-resend" }>;
+
+function validateThreadTargetSelection(
+  command: ThreadTargetSelectionCommand,
+  thread: OrchestrationThread,
+) {
+  if (command.modelSelection === undefined) {
+    return Effect.void;
+  }
+
+  const currentTarget = providerTargetFromModelSelection(thread.modelSelection);
+  const requestedTarget = providerTargetFromModelSelection(command.modelSelection);
+  const canAdoptInitialTarget =
+    (command.type === "thread.meta.update" || command.type === "thread.turn.start") &&
+    thread.creationSource !== "provider_native" &&
+    thread.latestTurn === null &&
+    thread.session === null &&
+    thread.messages.length === 0;
+  if (
+    providerTargetsEqual(currentTarget, requestedTarget) ||
+    canAdoptInitialTarget
+  ) {
+    return Effect.void;
+  }
+
+  return Effect.fail(
+    new OrchestrationCommandInvariantError({
+      commandType: command.type,
+      detail:
+        `Thread '${thread.id}' already has work on provider target ` +
+        `'${currentTarget.provider}/${currentTarget.profileId}'. Create a new thread or explicit ` +
+        `handoff to use '${requestedTarget.provider}/${requestedTarget.profileId}'.`,
+    }),
+  );
 }
 
 const defaultMetadata: Omit<OrchestrationEvent, "sequence" | "type" | "payload"> = {
@@ -1220,6 +1263,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         threadId: command.threadId,
       });
+      yield* validateThreadTargetSelection(command, thread);
       const project = readModel.projects.find((candidate) => candidate.id === thread.projectId);
       // Provider-native threads: see thread.create — the selection mirrors the
       // provider's own subagent, so the Auto-mode capability check doesn't apply.
@@ -1569,6 +1613,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         threadId: command.threadId,
       });
+      yield* validateThreadTargetSelection(command, targetThread);
       if (threadHasCheckpointRevertInProgress(targetThread)) {
         return yield* new OrchestrationCommandInvariantError({
           commandType: command.type,
@@ -1980,6 +2025,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         threadId: command.threadId,
       });
+      yield* validateThreadTargetSelection(command, thread);
       if (threadHasCheckpointRevertInProgress(thread)) {
         return yield* new OrchestrationCommandInvariantError({
           commandType: command.type,

--- a/apps/server/src/orchestration/importThreadRoute.test.ts
+++ b/apps/server/src/orchestration/importThreadRoute.test.ts
@@ -4,6 +4,7 @@ import {
   type OrchestrationCommand,
   type OrchestrationThread,
   ProjectId,
+  ProviderProfileId,
   type ProviderSession,
   ThreadId,
 } from "@synara/contracts";
@@ -21,16 +22,18 @@ const threadId = ThreadId.makeUnsafe("thread-import");
 const projectId = ProjectId.makeUnsafe("project-import");
 const importedAt = "2026-08-09T12:00:00.000Z";
 
-function makeCodexThread(): OrchestrationThread {
+function makeCodexThread(
+  modelSelection: OrchestrationThread["modelSelection"] = {
+    provider: "codex",
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
+    model: "gpt-5.5",
+  },
+): OrchestrationThread {
   return {
     id: threadId,
     projectId,
     title: "Imported thread",
-    modelSelection: {
-      provider: "codex",
-      profileId: DEFAULT_PROVIDER_PROFILE_ID,
-      model: "gpt-5.5",
-    },
+    modelSelection,
     runtimeMode: "full-access",
     interactionMode: "default",
     envMode: "local",
@@ -138,5 +141,69 @@ it.effect("imports Codex history through a provider-owned fork", () =>
     ]);
     assert.deepEqual(readThread.mock.calls, [[threadId]]);
     assert.equal(dispatchedCommands.at(-1)?.type, "thread.session.set");
+  }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.effect("rejects a non-default profile before import side effects", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const dispatch = vi.fn(() => Effect.succeed({ sequence: 1 }));
+    const getProjectShellById = vi.fn(() => Effect.succeed(Option.none()));
+    const readExternalThread = vi.fn(() => Effect.succeed(null));
+    const readThread = vi.fn(() =>
+      Effect.succeed({
+        threadId: "provider-thread",
+        turns: [],
+      }),
+    );
+    const getByProvider = vi.fn(() =>
+      Effect.succeed({
+        readExternalThread,
+        readThread,
+      } as never),
+    );
+    const startSession = vi.fn(() => Effect.succeed({} as never));
+    const stopSession = vi.fn(() => Effect.void);
+
+    const handler = makeImportThreadHandler({
+      fileSystem,
+      path,
+      platform: process.platform,
+      orchestrationEngine: {
+        dispatch,
+      } as unknown as OrchestrationEngineShape,
+      projectionSnapshotQuery: {
+        getThreadDetailById: () =>
+          Effect.succeed(
+            Option.some(
+              makeCodexThread({
+                provider: "codex",
+                profileId: ProviderProfileId.makeUnsafe("work"),
+                model: "gpt-5.5",
+              }),
+            ),
+          ),
+        getProjectShellById,
+      } as unknown as ProjectionSnapshotQueryShape,
+      providerAdapterRegistry: {
+        getByProvider,
+      } as unknown as ProviderAdapterRegistryShape,
+      providerService: {
+        startSession,
+        stopSession,
+      } as unknown as ProviderServiceShape,
+    });
+
+    const error = yield* handler({ threadId, externalId: "external-thread" }).pipe(Effect.flip);
+
+    assert.match(error.message, /profile 'work' is not configured/);
+    assert.equal(getProjectShellById.mock.calls.length, 0);
+    assert.equal(getByProvider.mock.calls.length, 0);
+    assert.equal(readExternalThread.mock.calls.length, 0);
+    assert.equal(readThread.mock.calls.length, 0);
+    assert.equal(dispatch.mock.calls.length, 0);
+    assert.equal(startSession.mock.calls.length, 0);
+    assert.equal(stopSession.mock.calls.length, 0);
   }).pipe(Effect.provide(NodeServices.layer)),
 );

--- a/apps/server/src/orchestration/importThreadRoute.ts
+++ b/apps/server/src/orchestration/importThreadRoute.ts
@@ -10,6 +10,7 @@ import {
   type ThreadHandoffImportedMessage,
   type ThreadId,
 } from "@synara/contracts";
+import { providerTargetFromModelSelection } from "@synara/shared/providerTarget";
 import {
   deriveAssociatedWorktreeMetadata,
   workspaceRootsEqual,
@@ -23,6 +24,7 @@ import type { OrchestrationEngineShape } from "./Services/OrchestrationEngine";
 import type { ProjectionSnapshotQueryShape } from "./Services/ProjectionSnapshotQuery";
 import type { ProviderAdapterRegistryShape } from "../provider/Services/ProviderAdapterRegistry";
 import type { ProviderServiceShape } from "../provider/Services/ProviderService";
+import { resolveDefaultProviderProfile } from "../provider/providerProfileResolver.ts";
 import { parseManagedWorktreeWorkspaceRoot } from "../workspace/managedWorktree";
 import {
   mapClaudeSessionMessages,
@@ -351,6 +353,11 @@ export function makeImportThreadHandler(options: ImportThreadHandlerOptions) {
         importMessagesError(`Thread '${body.threadId}' already has an active provider session.`),
       );
     }
+
+    yield* resolveDefaultProviderProfile({
+      operation: "Orchestration.importThread",
+      target: providerTargetFromModelSelection(thread.modelSelection),
+    }).pipe(Effect.mapError((cause) => importMessagesError(cause.issue)));
 
     const projectOption = yield* options.projectionSnapshotQuery.getProjectShellById(
       thread.projectId,

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -54,7 +54,11 @@ import {
 } from "./Schemas.ts";
 import { resolveStableMessageTurnId } from "./messageTurnId.ts";
 import { settleTurnStateFromSession } from "./turnLifecycle.ts";
-import { deriveTurnStartModelSelection, deriveTurnStartSession } from "./turnStartSession.ts";
+import {
+  canAdoptFirstTurnTarget,
+  deriveTurnStartModelSelection,
+  deriveTurnStartSession,
+} from "./turnStartSession.ts";
 
 type ThreadPatch = Partial<Omit<OrchestrationThread, "id" | "projectId">>;
 const MAX_THREAD_MESSAGES = 2_000;
@@ -864,12 +868,15 @@ export function projectEvent(
           if (!thread) {
             return nextBase;
           }
-          const canAdoptFirstTurnProvider =
-            thread.latestTurn === null && thread.session === null && thread.messages.length <= 1;
+          const canAdoptRequestedTarget = canAdoptFirstTurnTarget({
+            hasLatestTurn: thread.latestTurn !== null,
+            hasSession: thread.session !== null,
+            messageCount: thread.messages.length,
+          });
           const projectedModelSelection = deriveTurnStartModelSelection({
             currentModelSelection: thread.modelSelection,
             requestedModelSelection: payload.modelSelection,
-            canAdoptRequestedProvider: canAdoptFirstTurnProvider,
+            canAdoptRequestedTarget,
           });
           const modelSelectionPatch =
             projectedModelSelection !== thread.modelSelection

--- a/apps/server/src/orchestration/turnStartSession.test.ts
+++ b/apps/server/src/orchestration/turnStartSession.test.ts
@@ -1,11 +1,16 @@
 import {
   DEFAULT_PROVIDER_PROFILE_ID,
+  ProviderProfileId,
   ThreadId,
   type OrchestrationSession,
 } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
-import { deriveTurnStartModelSelection, deriveTurnStartSession } from "./turnStartSession.ts";
+import {
+  canAdoptFirstTurnTarget,
+  deriveTurnStartModelSelection,
+  deriveTurnStartSession,
+} from "./turnStartSession.ts";
 
 const THREAD_ID = ThreadId.makeUnsafe("thread-turn-start-session");
 const REQUESTED_AT = "2026-07-21T00:00:00.000Z";
@@ -33,6 +38,16 @@ function derive(currentSession: OrchestrationSession | null) {
 }
 
 describe("deriveTurnStartSession", () => {
+  it.each([
+    [{ hasLatestTurn: false, hasSession: false, messageCount: 0 }, true],
+    [{ hasLatestTurn: false, hasSession: false, messageCount: 1 }, true],
+    [{ hasLatestTurn: true, hasSession: false, messageCount: 0 }, false],
+    [{ hasLatestTurn: false, hasSession: true, messageCount: 0 }, false],
+    [{ hasLatestTurn: false, hasSession: false, messageCount: 2 }, false],
+  ] as const)("resolves whether first-turn target adoption is safe", (input, expected) => {
+    expect(canAdoptFirstTurnTarget(input)).toBe(expected);
+  });
+
   it("keeps an established provider when a later turn requests another provider", () => {
     expect(
       deriveTurnStartModelSelection({
@@ -46,7 +61,7 @@ describe("deriveTurnStartSession", () => {
           profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "openai/gpt-5",
         },
-        canAdoptRequestedProvider: false,
+        canAdoptRequestedTarget: false,
       }),
     ).toEqual({
       provider: "codex",
@@ -68,13 +83,49 @@ describe("deriveTurnStartSession", () => {
           profileId: DEFAULT_PROVIDER_PROFILE_ID,
           model: "openai/gpt-5",
         },
-        canAdoptRequestedProvider: true,
+        canAdoptRequestedTarget: true,
       }),
     ).toEqual({
       provider: "pi",
       profileId: DEFAULT_PROVIDER_PROFILE_ID,
       model: "openai/gpt-5",
     });
+  });
+
+  it("keeps an established profile when a later turn requests another profile", () => {
+    expect(
+      deriveTurnStartModelSelection({
+        currentModelSelection: {
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          model: "gpt-5-codex",
+        },
+        requestedModelSelection: {
+          provider: "codex",
+          profileId: ProviderProfileId.makeUnsafe("work"),
+          model: "gpt-5-codex",
+        },
+        canAdoptRequestedTarget: false,
+      }),
+    ).toMatchObject({ provider: "codex", profileId: "default" });
+  });
+
+  it("allows an empty thread to adopt its first requested profile", () => {
+    expect(
+      deriveTurnStartModelSelection({
+        currentModelSelection: {
+          provider: "codex",
+          profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          model: "gpt-5-codex",
+        },
+        requestedModelSelection: {
+          provider: "codex",
+          profileId: ProviderProfileId.makeUnsafe("work"),
+          model: "gpt-5-codex",
+        },
+        canAdoptRequestedTarget: true,
+      }),
+    ).toMatchObject({ provider: "codex", profileId: "work" });
   });
 
   it("creates a starting session when no session exists", () => {

--- a/apps/server/src/orchestration/turnStartSession.ts
+++ b/apps/server/src/orchestration/turnStartSession.ts
@@ -4,16 +4,31 @@ import type {
   RuntimeMode,
   ThreadId,
 } from "@synara/contracts";
+import {
+  providerTargetFromModelSelection,
+  providerTargetsEqual,
+} from "@synara/shared/providerTarget";
+
+export function canAdoptFirstTurnTarget(input: {
+  readonly hasLatestTurn: boolean;
+  readonly hasSession: boolean;
+  readonly messageCount: number;
+}): boolean {
+  return !input.hasLatestTurn && !input.hasSession && input.messageCount <= 1;
+}
 
 export function deriveTurnStartModelSelection(input: {
   readonly currentModelSelection: ModelSelection;
   readonly requestedModelSelection: ModelSelection | undefined;
-  readonly canAdoptRequestedProvider: boolean;
+  readonly canAdoptRequestedTarget: boolean;
 }): ModelSelection {
   const requestedModelSelection = input.requestedModelSelection;
   return requestedModelSelection !== undefined &&
-    (requestedModelSelection.provider === input.currentModelSelection.provider ||
-      input.canAdoptRequestedProvider)
+    (providerTargetsEqual(
+      providerTargetFromModelSelection(requestedModelSelection),
+      providerTargetFromModelSelection(input.currentModelSelection),
+    ) ||
+      input.canAdoptRequestedTarget)
     ? requestedModelSelection
     : input.currentModelSelection;
 }


### PR DESCRIPTION
## Summary

Applies complete provider-target invariants across server workflows:

- rejects unavailable profiles in Agent Gateway, automations, text generation, imports, and turn dispatch
- validates the target before session, generation, rollback, or persistence side effects
- lets an empty thread adopt its first requested target
- locks provider and profile after the thread has work
- keeps command-model and projection behavior consistent
- adds focused decider coverage for provider/profile replacement invariants

## Stack

Depends on #620 (and #619).  
Base: `codex/provider-profiles-02-runtime` at `fb1bc977d`  
Head: `cc4e1f543`

> **Release gate:** Foundation PR 3 of 3. PRs 1–3 are coupled, must merge in order, and must all land before release. Do not ship a partial foundation.

## Replacement for #254

This implements the guard behavior explored by #254 using Synara's current orchestration engine, decider, projection pipeline, and provider-command reactor.

The old PR remains useful as a requirements archive, but its implementation no longer fits these boundaries. This PR deliberately does not close #254.

## Safety and compatibility

- The existing `default` profile continues through the established paths.
- Unsupported profiles return explicit errors instead of silently falling back to another account.
- Rejected target changes occur before destructive replay, runtime startup, text generation, or message append.
- Established threads preserve their persisted target; switching accounts requires a new thread or explicit handoff.

## Validation

- The server subtree at `cc4e1f543` matches immutable snapshot `56af6f089`.
- Full server suite on that snapshot: 327 files passed, 3 skipped; 3,774 tests passed, 16 skipped.
- Slice and stack-top diff checks passed.

`bun fmt`, `bun lint`, and `bun typecheck` were not run because repository policy requires explicit user permission; permission is pending.
