### PR TITLE
fix(web): fail closed for unavailable provider account targets

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -20,6 +20,7 @@ import {
   type WsWelcomePayload,
   WS_METHODS,
   OrchestrationSessionStatus,
+  ProviderProfileId,
 } from "@synara/contracts";
 import {
   ATTACHMENT_CANCEL_ROUTE_PATH,
@@ -985,6 +986,26 @@ function createSnapshotWithSettledPlanAwaitingFollowUp(): OrchestrationReadModel
               },
             ],
             updatedAt: isoAt(1_005),
+          }
+        : thread,
+    ),
+  };
+}
+
+function createSnapshotWithUnsupportedProfilePlan(): OrchestrationReadModel {
+  const snapshot = createSnapshotWithSettledPlanAwaitingFollowUp();
+  const profileId = ProviderProfileId.makeUnsafe("work");
+
+  return {
+    ...snapshot,
+    threads: snapshot.threads.map((thread) =>
+      thread.id === THREAD_ID
+        ? {
+            ...thread,
+            modelSelection: {
+              ...thread.modelSelection,
+              profileId,
+            },
           }
         : thread,
     ),
@@ -5144,6 +5165,56 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("rejects an unsupported queued plan follow-up before optimistic or durable dispatch", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-unsupported-queued-plan" as MessageId,
+        targetText: "unsupported queued plan target",
+        sessionStatus: "ready",
+      }),
+    });
+
+    try {
+      const initialMessageIds = useStore.getState().messageIdsByThreadId[THREAD_ID] ?? [];
+      useComposerDraftStore.getState().enqueueQueuedTurn(THREAD_ID, {
+        id: "queued-plan-unsupported-profile",
+        kind: "plan-follow-up",
+        createdAt: NOW_ISO,
+        previewText: "Implement the queued plan",
+        text: "Implement the queued plan",
+        interactionMode: "default",
+        selectedProvider: "codex",
+        selectedModel: "gpt-5",
+        selectedPromptEffort: null,
+        modelSelection: {
+          provider: "codex",
+          profileId: ProviderProfileId.makeUnsafe("work"),
+          model: "gpt-5",
+        },
+        runtimeMode: "full-access",
+      });
+
+      await vi.waitFor(() => {
+        expect(useStore.getState().threadShellById[THREAD_ID]?.error).toBe(
+          "Provider profile 'work' is not configured for provider 'codex'.",
+        );
+      });
+
+      expect(useStore.getState().messageIdsByThreadId[THREAD_ID]).toEqual(initialMessageIds);
+      expect(
+        wsRequests.filter(
+          (request) => request._tag === ORCHESTRATION_WS_METHODS.dispatchCommand,
+        ),
+      ).toHaveLength(0);
+      expect(
+        useComposerDraftStore.getState().draftsByThreadId[THREAD_ID]?.queuedTurns,
+      ).toHaveLength(1);
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("auto-dispatches a queued chat turn as a chat message even while a plan follow-up is pending", async () => {
     const restoreNativeApi = installDeterministicSendNativeApi();
     const queuedPrompt = "queued chat turn that must stay a chat message";
@@ -7171,6 +7242,35 @@ describe("ChatView timeline estimator parity (full app)", () => {
         .element(page.getByTitle("Plan mode — click to return to normal build mode"))
         .toBeInTheDocument();
       await expect.element(page.getByLabelText("Show plan details sidebar")).toBeInTheDocument();
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("rejects implementing a plan in a new thread before creation for an unsupported profile", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotWithUnsupportedProfilePlan(),
+    });
+
+    try {
+      await waitForServerConfigToApply();
+      await page.getByLabelText("Implementation actions").click();
+      await page.getByText("Implement in a new thread").click();
+
+      await vi.waitFor(() => {
+        expect(document.body.textContent).toContain("Implementation is unavailable");
+      });
+      expect(
+        wsRequests.filter(
+          (request) =>
+            request._tag === ORCHESTRATION_WS_METHODS.dispatchCommand &&
+            typeof request.command === "object" &&
+            request.command !== null &&
+            "type" in request.command &&
+            request.command.type === "thread.create",
+        ),
+      ).toHaveLength(0);
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1,17 +1,21 @@
 import {
-  DEFAULT_PROVIDER_PROFILE_ID,
   CheckpointRef,
+  DEFAULT_PROVIDER_PROFILE_ID,
   EventId,
   MessageId,
+  ProviderProfileId,
   ThreadId,
   TurnId,
   type GitWorktreeSetupProgressEvent,
   type ModelSlug,
+  type ProviderComposerCapabilities,
   type RuntimeMode,
 } from "@synara/contracts";
 import { describe, expect, it, vi } from "vitest";
 
 import type { WorkLogEntry } from "../session-logic";
+import { deriveEffectiveComposerModelState } from "../composerDraftModels";
+import { supportsThreadCompaction } from "../lib/providerDiscoveryReactQuery";
 
 import {
   appendVoiceTranscriptToPrompt,
@@ -40,7 +44,9 @@ import {
   hasLiveTurnTakenOver,
   hasServerAcknowledgedLocalDispatch,
   isVoiceAuthExpiredMessage,
+  isProviderDiscoveryPending,
   LOCAL_DISPATCH_TURN_TAKEOVER_TIMEOUT_MS,
+  modelSelectionsEqual,
   resolveActiveThreadTitle,
   resolveActiveTurnLiveDiffState,
   resolveCommittedProviderModel,
@@ -70,7 +76,52 @@ import {
   shouldStartActiveTurnLayoutGrace,
   shouldRenderTerminalWorkspace,
   worktreeSetupHasError,
+  visibleProviderDiscoveryData,
 } from "./ChatView.logic";
+
+describe("provider-profile discovery presentation", () => {
+  it("masks cached capabilities, commands, skills, plugins, compaction, and loading", () => {
+    const capabilities = {
+      provider: "codex",
+      supportsSkillMentions: true,
+      supportsSkillDiscovery: true,
+      supportsNativeSlashCommandDiscovery: true,
+      supportsPluginMentions: true,
+      supportsPluginDiscovery: true,
+      supportsRuntimeModelList: true,
+      supportsThreadCompaction: true,
+    } satisfies ProviderComposerCapabilities;
+    const commands = [{ name: "cached-command" }];
+    const skills = [{ name: "cached-skill" }];
+    const plugins = [{ name: "cached-plugin" }];
+
+    expect(visibleProviderDiscoveryData(false, capabilities)).toBeUndefined();
+    expect(visibleProviderDiscoveryData(false, commands)).toBeUndefined();
+    expect(visibleProviderDiscoveryData(false, skills)).toBeUndefined();
+    expect(visibleProviderDiscoveryData(false, plugins)).toBeUndefined();
+    expect(
+      supportsThreadCompaction(visibleProviderDiscoveryData(false, capabilities)),
+    ).toBe(false);
+    expect(
+      isProviderDiscoveryPending(false, {
+        isLoading: true,
+        isFetching: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("preserves executable-target discovery data and pending state", () => {
+    const cached = { value: "cached" };
+    expect(visibleProviderDiscoveryData(true, cached)).toBe(cached);
+    expect(
+      isProviderDiscoveryPending(
+        true,
+        { isLoading: false, isFetching: false },
+        { isLoading: false, isFetching: true },
+      ),
+    ).toBe(true);
+  });
+});
 
 describe("composer strip work-log derivation", () => {
   it("reuses the active derivation unless a subagent view needs its parent source", () => {
@@ -340,6 +391,64 @@ describe("composer menu selection", () => {
         items,
       }),
     ).toBeNull();
+  });
+});
+
+describe("composer provider target", () => {
+  const threadModelSelection = {
+    provider: "codex" as const,
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
+    model: "gpt-5.6-sol",
+  };
+  const workProfileId = ProviderProfileId.makeUnsafe("work");
+
+  it("ignores another profile's stale draft model and options for a locked thread", () => {
+    const canonicalSelection = {
+      ...threadModelSelection,
+      options: { reasoningEffort: "high" as const },
+    };
+    const state = deriveEffectiveComposerModelState({
+      draft: {
+        activeProvider: "codex",
+        modelSelectionByProvider: {
+          codex: {
+            provider: "codex",
+            profileId: workProfileId,
+            model: "gpt-5.4",
+            options: { reasoningEffort: "low" },
+          },
+        },
+      },
+      selectedProvider: "codex",
+      selectedTarget: {
+        provider: "codex",
+        profileId: DEFAULT_PROVIDER_PROFILE_ID,
+      },
+      threadModelSelection: canonicalSelection,
+      projectModelSelection: null,
+      customModelsByProvider: {
+        codex: [],
+        claudeAgent: [],
+        cursor: [],
+        antigravity: [],
+        grok: [],
+        droid: [],
+        kilo: [],
+        opencode: [],
+        pi: [],
+      },
+      availableModelOptionsByProvider: {
+        codex: [
+          { slug: "gpt-5.4", name: "GPT-5.4" },
+          { slug: threadModelSelection.model, name: "GPT-5.6 Sol" },
+        ],
+      },
+    });
+
+    expect(state).toEqual({
+      selectedModel: threadModelSelection.model,
+      modelOptions: { codex: canonicalSelection.options },
+    });
   });
 });
 
@@ -2632,6 +2741,22 @@ describe("persistModelSelectionBeforeRuntimeMode", () => {
     });
 
     expect(calls).toEqual(["runtime", "model"]);
+  });
+});
+
+describe("modelSelectionsEqual", () => {
+  it("treats a provider-profile-only change as a different selection", () => {
+    const defaultProfileSelection = {
+      provider: "codex" as const,
+      profileId: DEFAULT_PROVIDER_PROFILE_ID,
+      model: "gpt-5.6-sol",
+    };
+    const workProfileSelection = {
+      ...defaultProfileSelection,
+      profileId: ProviderProfileId.makeUnsafe("work"),
+    };
+
+    expect(modelSelectionsEqual(defaultProfileSelection, workProfileSelection)).toBe(false);
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -55,6 +55,20 @@ export const PROMPT_HISTORY_MAX_ENTRIES = 100;
 export const LastInvokedScriptByProjectSchema = Schema.Record(ProjectId, Schema.String);
 export const DismissedProviderHealthBannersSchema = Schema.Array(Schema.String);
 
+export function visibleProviderDiscoveryData<T>(
+  targetExecutable: boolean,
+  cachedData: T | undefined,
+): T | undefined {
+  return targetExecutable ? cachedData : undefined;
+}
+
+export function isProviderDiscoveryPending(
+  targetExecutable: boolean,
+  ...queries: ReadonlyArray<{ readonly isLoading: boolean; readonly isFetching: boolean }>
+): boolean {
+  return targetExecutable && queries.some((query) => query.isLoading || query.isFetching);
+}
+
 export interface PendingFileUndo {
   readonly threadId: ThreadIdType;
   // A changes card can merge several turns; one Undo reverts all of them, so the
@@ -194,6 +208,7 @@ export function createRuntimeModePersistenceQueue(
 export function modelSelectionsEqual(left: ModelSelection, right: ModelSelection): boolean {
   return (
     left.provider === right.provider &&
+    left.profileId === right.profileId &&
     left.model === right.model &&
     JSON.stringify(left.options ?? null) === JSON.stringify(right.options ?? null) &&
     (left.provider !== "claudeAgent" ||

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -586,6 +586,7 @@ import {
   type QueuedSteerGate,
   resolveQueuedSteerGateTransition,
   shouldRenderProviderHealthBanner,
+  isProviderDiscoveryPending,
   resolveRuntimeModeAfterApprovalDecision,
   revokeBlobPreviewUrl,
   revokeUserMessagePreviewUrls,
@@ -600,11 +601,15 @@ import {
   resolveAvailableHandoffTargetProviders,
   resolveThreadHandoffBadgeLabel,
 } from "../lib/threadHandoff";
+import { unsupportedProviderProfileIssue } from "../lib/providerProfileAvailability";
 import {
   resolveDiffEnvironmentState,
   resolveThreadEnvironmentMode,
 } from "../lib/threadEnvironment";
-import { buildModelSelection, buildNextProviderOptions } from "../providerModelOptions";
+import {
+  buildModelSelectionForTarget,
+  buildNextProviderOptions,
+} from "../providerModelOptions";
 import {
   isDuplicateProjectCreateError,
   waitForRecoverableProjectForDuplicateCreate,
@@ -2197,21 +2202,42 @@ export default function ChatView({
     markThreadVisited,
   ]);
 
-  const sessionProvider = activeThread?.session?.provider ?? null;
   const selectedProviderByThreadId = composerDraft.activeProvider ?? null;
-  const threadProvider =
-    activeThread?.modelSelection.provider ?? activeProject?.defaultModelSelection?.provider ?? null;
   const hasThreadStarted = Boolean(
     activeThread &&
     (activeThread.latestTurn !== null ||
       activeThread.messages.length > 0 ||
       activeThread.session !== null),
   );
+  const threadModelSelection = activeThread?.modelSelection ?? null;
+  const projectModelSelection = activeProject?.defaultModelSelection ?? null;
   const lockedProvider: ProviderKind | null = hasThreadStarted
-    ? (sessionProvider ?? threadProvider ?? selectedProviderByThreadId ?? null)
+    ? (threadModelSelection?.provider ?? null)
     : null;
   const selectedProvider: ProviderKind =
-    lockedProvider ?? selectedProviderByThreadId ?? threadProvider ?? settings.defaultProvider;
+    lockedProvider ??
+    selectedProviderByThreadId ??
+    threadModelSelection?.provider ??
+    projectModelSelection?.provider ??
+    settings.defaultProvider;
+  const draftModelSelectionCandidate =
+    composerDraft.modelSelectionByProvider[selectedProvider] ?? null;
+  const selectedProfileId =
+    hasThreadStarted && threadModelSelection?.provider === selectedProvider
+      ? threadModelSelection.profileId
+      : draftModelSelectionCandidate?.provider === selectedProvider
+        ? draftModelSelectionCandidate.profileId
+        : threadModelSelection?.provider === selectedProvider
+          ? threadModelSelection.profileId
+          : projectModelSelection?.provider === selectedProvider
+            ? projectModelSelection.profileId
+            : DEFAULT_PROVIDER_PROFILE_ID;
+  const draftModelSelectionForSelectedProvider =
+    draftModelSelectionCandidate?.provider === selectedProvider &&
+    draftModelSelectionCandidate.profileId === selectedProfileId
+      ? draftModelSelectionCandidate
+      : null;
+  const selectedTargetExecutable = selectedProfileId === DEFAULT_PROVIDER_PROFILE_ID;
   const previousSelectedProviderRef = useRef<{
     threadId: ThreadId;
     provider: ProviderKind;
@@ -2225,10 +2251,19 @@ export default function ChatView({
     const projectModelSelection = activeProject?.defaultModelSelection ?? null;
     const draftSelections = composerDraft.modelSelectionByProvider;
 
-    const resolveHint = (provider: ProviderKind): string | null =>
-      draftSelections[provider]?.model ??
-      (threadModelSelection?.provider === provider ? threadModelSelection.model : null) ??
-      (projectModelSelection?.provider === provider ? projectModelSelection.model : null);
+    const resolveHint = (provider: ProviderKind): string | null => {
+      const draftSelection = draftSelections[provider];
+      const draftModel =
+        draftSelection?.provider === provider &&
+        (provider !== selectedProvider || draftSelection.profileId === selectedProfileId)
+          ? draftSelection.model
+          : null;
+      return (
+        draftModel ??
+        (threadModelSelection?.provider === provider ? threadModelSelection.model : null) ??
+        (projectModelSelection?.provider === provider ? projectModelSelection.model : null)
+      );
+    };
 
     return {
       codex: resolveHint("codex"),
@@ -2245,6 +2280,8 @@ export default function ChatView({
     activeProject?.defaultModelSelection,
     activeThread?.modelSelection,
     composerDraft.modelSelectionByProvider,
+    selectedProfileId,
+    selectedProvider,
   ]);
   const providerModelDiscoveryCwd = resolveProviderDiscoveryCwd({
     activeThreadWorktreePath: resolvedThreadWorktreePath,
@@ -2261,6 +2298,7 @@ export default function ChatView({
     selectedProviderRuntimeModelDiscoveryPending,
   } = useProviderModelCatalog({
     selectedProvider,
+    targetExecutable: selectedTargetExecutable,
     discoveryEnabled: isModelPickerOpen,
     cwd: providerModelDiscoveryCwd,
     modelHintByProvider: composerModelHintByProvider,
@@ -2271,11 +2309,10 @@ export default function ChatView({
     selectedProvider,
     threadModelSelection: activeThread?.modelSelection,
     projectModelSelection: activeProject?.defaultModelSelection,
+    selectedTarget: { provider: selectedProvider, profileId: selectedProfileId },
     customModelsByProvider,
     availableModelOptionsByProvider: modelOptionsByProvider,
   });
-  const draftModelSelectionForSelectedProvider =
-    composerDraft.modelSelectionByProvider[selectedProvider] ?? null;
   const persistedClaudeSupportsAutoMode =
     selectedProvider === "claudeAgent"
       ? draftModelSelectionForSelectedProvider?.provider === "claudeAgent" &&
@@ -2319,22 +2356,24 @@ export default function ChatView({
   const selectedModelOptionsForDispatch = composerProviderState.modelOptionsForDispatch;
   const selectedModelSelection = useMemo<ModelSelection>(() => {
     if (selectedProvider === "pi" && draftModelSelectionForSelectedProvider?.provider === "pi") {
-      return buildModelSelection(
-        selectedProvider,
-        draftModelSelectionForSelectedProvider.model,
-        selectedModelOptionsForDispatch ?? draftModelSelectionForSelectedProvider.options,
-      );
+      return buildModelSelectionForTarget({
+        target: { provider: selectedProvider, profileId: selectedProfileId },
+        model: draftModelSelectionForSelectedProvider.model,
+        options: selectedModelOptionsForDispatch ?? draftModelSelectionForSelectedProvider.options,
+      });
     }
-    return buildModelSelection(
-      selectedProvider,
-      selectedModel,
-      selectedModelOptionsForDispatch,
-      selectedProvider === "claudeAgent" ? selectedRuntimeModel?.supportsAutoMode : undefined,
-    );
+    return buildModelSelectionForTarget({
+      target: { provider: selectedProvider, profileId: selectedProfileId },
+      model: selectedModel,
+      options: selectedModelOptionsForDispatch,
+      supportsAutoMode:
+        selectedProvider === "claudeAgent" ? selectedRuntimeModel?.supportsAutoMode : undefined,
+    });
   }, [
     draftModelSelectionForSelectedProvider,
     selectedModel,
     selectedModelOptionsForDispatch,
+    selectedProfileId,
     selectedProvider,
     selectedRuntimeModel,
   ]);
@@ -2350,11 +2389,7 @@ export default function ChatView({
       : (normalizeModelSlug(selectedModelForPicker, selectedProvider) ?? selectedModelForPicker);
   }, [modelOptionsByProvider, selectedModelForPicker, selectedProvider]);
   const persistedComposerModelSelection =
-    sessionProvider && activeThread?.modelSelection.provider !== sessionProvider
-      ? activeProject?.defaultModelSelection?.provider === selectedProvider
-        ? activeProject.defaultModelSelection
-        : null
-      : (activeThread?.modelSelection ?? activeProject?.defaultModelSelection ?? null);
+    activeThread?.modelSelection ?? activeProject?.defaultModelSelection ?? null;
   const providerModelsLoading = selectedProviderModelsLoading;
   const selectedProviderRequiresRuntimeModels =
     selectedProvider === "cursor" ||
@@ -3602,8 +3637,11 @@ export default function ChatView({
   const effectiveMentionQuery = mentionTriggerQuery.length > 0 ? debouncedPathQuery : "";
   const composerSkillCwd = providerModelDiscoveryCwd;
   const providerComposerCapabilitiesQuery = useQuery(
-    providerComposerCapabilitiesQueryOptions(selectedProvider),
+    providerComposerCapabilitiesQueryOptions(selectedProvider, selectedTargetExecutable),
   );
+  const providerComposerCapabilities = selectedTargetExecutable
+    ? providerComposerCapabilitiesQuery.data
+    : undefined;
   const providerCommandsQuery = useQuery(
     providerCommandsQueryOptions({
       provider: selectedProvider,
@@ -3627,13 +3665,14 @@ export default function ChatView({
           : undefined,
       agentDir: selectedProvider === "pi" ? settings.piAgentDir || null : null,
       enabled:
+        selectedTargetExecutable &&
         (composerTriggerKind === "slash-command" || composerTriggerKind === "slash-model") &&
-        supportsNativeSlashCommandDiscovery(providerComposerCapabilitiesQuery.data) &&
+        supportsNativeSlashCommandDiscovery(providerComposerCapabilities) &&
         composerSkillCwd !== null,
     }),
   );
   const canDiscoverProviderSkills =
-    selectedProvider === "pi" || supportsSkillDiscovery(providerComposerCapabilitiesQuery.data);
+    selectedProvider === "pi" || supportsSkillDiscovery(providerComposerCapabilities);
   const providerSkillsQuery = useQuery(
     providerSkillsQueryOptions({
       provider: selectedProvider,
@@ -3641,6 +3680,7 @@ export default function ChatView({
       threadId,
       agentDir: selectedProvider === "pi" ? settings.piAgentDir || null : null,
       enabled:
+        selectedTargetExecutable &&
         (isSkillTrigger || composerTriggerKind === "slash-command" || selectedProvider === "pi") &&
         canDiscoverProviderSkills &&
         composerSkillCwd !== null,
@@ -3652,7 +3692,8 @@ export default function ChatView({
       cwd: composerSkillCwd,
       threadId,
       enabled:
-        supportsPluginDiscovery(providerComposerCapabilitiesQuery.data) &&
+        selectedTargetExecutable &&
+        supportsPluginDiscovery(providerComposerCapabilities) &&
         composerSkillCwd !== null,
     }),
   );
@@ -3677,19 +3718,22 @@ export default function ChatView({
   // Keep plugin suggestions referentially stable so prompt-sync effects do not loop on rerender.
   const providerPlugins = useMemo(
     () =>
-      providerPluginsQuery.data?.marketplaces.flatMap((marketplace) =>
-        marketplace.plugins.map((plugin) => ({
-          plugin,
-          mention: {
-            name: plugin.name,
-            path: `plugin://${plugin.name}@${marketplace.name}`,
-          } satisfies ProviderMentionReference,
-        })),
-      ) ?? EMPTY_COMPOSER_PLUGIN_SUGGESTIONS,
-    [providerPluginsQuery.data],
+      selectedTargetExecutable
+        ? (providerPluginsQuery.data?.marketplaces.flatMap((marketplace) =>
+            marketplace.plugins.map((plugin) => ({
+              plugin,
+              mention: {
+                name: plugin.name,
+                path: `plugin://${plugin.name}@${marketplace.name}`,
+              } satisfies ProviderMentionReference,
+            })),
+          ) ?? EMPTY_COMPOSER_PLUGIN_SUGGESTIONS)
+        : EMPTY_COMPOSER_PLUGIN_SUGGESTIONS,
+    [providerPluginsQuery.data, selectedTargetExecutable],
   );
-  const providerNativeCommands =
-    providerCommandsQuery.data?.commands ?? EMPTY_PROVIDER_NATIVE_COMMANDS;
+  const providerNativeCommands = selectedTargetExecutable
+    ? (providerCommandsQuery.data?.commands ?? EMPTY_PROVIDER_NATIVE_COMMANDS)
+    : EMPTY_PROVIDER_NATIVE_COMMANDS;
   const providerNativeCommandNames = useMemo(
     () => providerNativeCommands.map((command) => command.name),
     [providerNativeCommands],
@@ -3712,7 +3756,9 @@ export default function ChatView({
     () => providerSupportsTextNativeReviewCommand(selectedProvider, providerNativeCommands),
     [providerNativeCommands, selectedProvider],
   );
-  const providerSkills = providerSkillsQuery.data?.skills ?? EMPTY_PROVIDER_SKILLS;
+  const providerSkills = selectedTargetExecutable
+    ? (providerSkillsQuery.data?.skills ?? EMPTY_PROVIDER_SKILLS)
+    : EMPTY_PROVIDER_SKILLS;
   const selectedModelCaps = useMemo(
     () => getModelCapabilities(selectedProvider, selectedModel),
     [selectedModel, selectedProvider],
@@ -3775,7 +3821,7 @@ export default function ChatView({
     searchableModelOptions,
     supportsFastSlashCommand,
     canOfferCompactCommand:
-      supportsThreadCompaction(providerComposerCapabilitiesQuery.data) &&
+      supportsThreadCompaction(providerComposerCapabilities) &&
       isServerThread &&
       activeThread?.session !== null &&
       activeThread?.session?.status !== "closed",
@@ -6194,12 +6240,16 @@ export default function ChatView({
         model: resolvedModel,
         runtimeModels: runtimeModelsByProvider[provider],
       });
-      const nextModelSelection = buildModelSelection(
-        provider,
-        resolvedModel,
-        undefined,
-        provider === "claudeAgent" ? runtimeModel?.supportsAutoMode : undefined,
-      );
+      const nextModelSelection = buildModelSelectionForTarget({
+        target: {
+          provider,
+          profileId:
+            provider === selectedProvider ? selectedProfileId : DEFAULT_PROVIDER_PROFILE_ID,
+        },
+        model: resolvedModel,
+        supportsAutoMode:
+          provider === "claudeAgent" ? runtimeModel?.supportsAutoMode : undefined,
+      });
       const providerStatus = findProviderStatus(providerStatuses, provider);
       const nextRuntimeMode =
         runtimeMode === "auto" &&
@@ -6238,6 +6288,8 @@ export default function ChatView({
       runtimeMode,
       runtimeModelsByProvider,
       scheduleComposerFocus,
+      selectedProfileId,
+      selectedProvider,
       setComposerDraftModelSelectionAndSticky,
       setComposerDraftProviderModelOptions,
     ],
@@ -7369,6 +7421,11 @@ export default function ChatView({
     const selectedPromptEffortForSend =
       queuedChatTurn?.selectedPromptEffort ?? selectedPromptEffort;
     const selectedModelSelectionForSend = queuedChatTurn?.modelSelection ?? selectedModelSelection;
+    const profileIssue = unsupportedProviderProfileIssue(selectedModelSelectionForSend);
+    if (profileIssue !== null) {
+      setStoreThreadError(activeThread.id, profileIssue);
+      return false;
+    }
     const providerOptionsForDispatchForSend =
       queuedChatTurn?.providerOptionsForDispatch ?? providerOptionsForDispatch;
     const runtimeModeForSend = queuedChatTurn?.runtimeMode ?? runtimeMode;
@@ -8279,17 +8336,22 @@ export default function ChatView({
         }
       }
 
-      const threadCreateModelSelection: ModelSelection = buildModelSelection(
-        selectedModelSelectionForSend.provider,
-        selectedModelSelectionForSend.model ||
+      const threadCreateModelSelection: ModelSelection = buildModelSelectionForTarget({
+        target: {
+          provider: selectedModelSelectionForSend.provider,
+          profileId: selectedModelSelectionForSend.profileId,
+        },
+        model:
+          selectedModelSelectionForSend.model ||
           selectedModelForSend ||
           targetProjectDefaultModelSelectionForSend?.model ||
           DEFAULT_MODEL_BY_PROVIDER.codex,
-        selectedModelSelectionForSend.options,
-        selectedModelSelectionForSend.provider === "claudeAgent"
-          ? selectedModelSelectionForSend.supportsAutoMode
-          : undefined,
-      );
+        options: selectedModelSelectionForSend.options,
+        supportsAutoMode:
+          selectedModelSelectionForSend.provider === "claudeAgent"
+            ? selectedModelSelectionForSend.supportsAutoMode
+            : undefined,
+      });
 
       if (isLocalDraftThread) {
         const inheritedProjectInstructions =
@@ -8883,6 +8945,13 @@ export default function ChatView({
       return false;
     }
 
+    const modelSelectionForPlanDispatch = queuedTurn?.modelSelection ?? selectedModelSelection;
+    const profileIssue = unsupportedProviderProfileIssue(modelSelectionForPlanDispatch);
+    if (profileIssue) {
+      setThreadError(activeThread.id, profileIssue);
+      return false;
+    }
+
     const threadIdForSend = activeThread.id;
     const messageIdForSend = newMessageId();
     const messageCreatedAt = new Date().toISOString();
@@ -8918,7 +8987,7 @@ export default function ChatView({
       await persistThreadSettingsForNextTurn({
         threadId: threadIdForSend,
         createdAt: messageCreatedAt,
-        modelSelection: queuedTurn?.modelSelection ?? selectedModelSelection,
+        modelSelection: modelSelectionForPlanDispatch,
         runtimeMode: queuedTurn?.runtimeMode ?? runtimeMode,
         interactionMode: nextInteractionMode,
       });
@@ -8929,7 +8998,6 @@ export default function ChatView({
 
       const providerOptionsForPlanDispatch =
         queuedTurn?.providerOptionsForDispatch ?? providerOptionsForDispatch;
-      const modelSelectionForPlanDispatch = queuedTurn?.modelSelection ?? selectedModelSelection;
       const sourceProposedPlan =
         nextInteractionMode === "default"
           ? buildSourceProposedPlanReference({
@@ -9038,6 +9106,12 @@ export default function ChatView({
       }
       if (isSendBusy || isConnecting || sendInFlightRef.current) {
         setThreadError(activeThread.id, "Wait for the current send to start before editing.");
+        return false;
+      }
+
+      const profileIssue = unsupportedProviderProfileIssue(selectedModelSelection);
+      if (profileIssue) {
+        setThreadError(activeThread.id, profileIssue);
         return false;
       }
 
@@ -9307,6 +9381,16 @@ export default function ChatView({
       isConnecting ||
       sendInFlightRef.current
     ) {
+      return;
+    }
+
+    const profileIssue = unsupportedProviderProfileIssue(selectedModelSelection);
+    if (profileIssue) {
+      toastManager.add({
+        type: "warning",
+        title: "Implementation is unavailable",
+        description: profileIssue,
+      });
       return;
     }
 
@@ -10161,7 +10245,7 @@ export default function ChatView({
     isServerThread,
     supportsFastSlashCommand,
     canOfferCompactCommand:
-      supportsThreadCompaction(providerComposerCapabilitiesQuery.data) &&
+      supportsThreadCompaction(providerComposerCapabilities) &&
       isServerThread &&
       activeThread?.session !== null &&
       activeThread?.session?.status !== "closed",
@@ -10171,6 +10255,7 @@ export default function ChatView({
     fastModeEnabled,
     providerNativeCommands,
     providerCommandDiscoveryCwd: composerSkillCwd,
+    targetExecutable: selectedTargetExecutable,
     selectedProvider,
     currentProviderModelOptions,
     selectedModelSelection,
@@ -10367,18 +10452,19 @@ export default function ChatView({
       ((mentionTriggerQuery.length > 0 && composerPathQueryDebouncer.state.isPending) ||
         workspaceEntriesQuery.isLoading ||
         workspaceEntriesQuery.isFetching ||
-        providerPluginsQuery.isLoading ||
-        providerPluginsQuery.isFetching)) ||
+        isProviderDiscoveryPending(selectedTargetExecutable, providerPluginsQuery))) ||
     (composerTriggerKind === "slash-command" &&
-      (providerCommandsQuery.isLoading ||
-        providerCommandsQuery.isFetching ||
-        providerSkillsQuery.isLoading ||
-        providerSkillsQuery.isFetching)) ||
+      isProviderDiscoveryPending(
+        selectedTargetExecutable,
+        providerCommandsQuery,
+        providerSkillsQuery,
+      )) ||
     (composerTriggerKind === "skill" &&
-      (providerComposerCapabilitiesQuery.isLoading ||
-        providerComposerCapabilitiesQuery.isFetching ||
-        providerSkillsQuery.isLoading ||
-        providerSkillsQuery.isFetching));
+      isProviderDiscoveryPending(
+        selectedTargetExecutable,
+        providerComposerCapabilitiesQuery,
+        providerSkillsQuery,
+      ));
 
   const onPromptChange = useCallback(
     (

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -370,9 +370,14 @@ export default function GitActionsControl({
   const gitTextGenerationModelSelection = useMemo(
     (): ModelSelection => ({
       provider: settings.textGenerationProvider ?? "codex",
+      profileId: settings.textGenerationProfileId,
       model: settings.textGenerationModel ?? DEFAULT_GIT_TEXT_GENERATION_MODEL,
     }),
-    [settings.textGenerationModel, settings.textGenerationProvider],
+    [
+      settings.textGenerationModel,
+      settings.textGenerationProfileId,
+      settings.textGenerationProvider,
+    ],
   );
   const activeThread = useStore(
     useMemo(() => createThreadSelector(activeThreadId), [activeThreadId]),

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -144,7 +144,7 @@ import {
 import {
   prefetchProviderModelsForNewThread,
   resolveNewThreadModelPrefetchCwd,
-  resolveNewThreadModelPrefetchProvider,
+  resolveNewThreadModelPrefetchTarget,
 } from "../lib/providerModelPrefetch";
 import { serverConfigQueryOptions, serverSettingsQueryOptions } from "../lib/serverReactQuery";
 import {
@@ -2602,12 +2602,15 @@ export default function Sidebar() {
       const draftComposer = draftThread
         ? (draftStore.draftsByThreadId[draftThread.threadId] ?? null)
         : null;
-      const provider = resolveNewThreadModelPrefetchProvider({
+      const prefetchTarget = resolveNewThreadModelPrefetchTarget({
         draftActiveProvider: draftComposer?.activeProvider ?? null,
         stickyActiveProvider: draftStore.stickyActiveProvider,
-        projectDefaultProvider: project.defaultModelSelection?.provider ?? null,
+        projectDefaultModelSelection: project.defaultModelSelection,
         defaultProvider: appSettings.defaultProvider,
+        draftModelSelectionByProvider: draftComposer?.modelSelectionByProvider,
+        stickyModelSelectionByProvider: draftStore.stickyModelSelectionByProvider,
       });
+      const provider = prefetchTarget.provider;
       // Droid discovery spins a disposable ACP session per model — only warm it
       // from explicit new-thread intent (hover/click), not idle project focus.
       if (provider === "droid" && options?.includeDroid !== true) {
@@ -2621,6 +2624,7 @@ export default function Sidebar() {
 
       prefetchProviderModelsForNewThread(queryClient, {
         provider,
+        targetExecutable: prefetchTarget.targetExecutable,
         settings: appSettings,
         cwd,
       });

--- a/apps/web/src/components/kanban/KanbanNewTaskDialog.tsx
+++ b/apps/web/src/components/kanban/KanbanNewTaskDialog.tsx
@@ -8,11 +8,12 @@
 // Layer: Kanban UI component
 // Exports: KanbanNewTaskDialog
 
-import type {
-  ProjectId,
-  ProviderInteractionMode,
-  ProviderKind,
-  RuntimeMode,
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  type ProjectId,
+  type ProviderInteractionMode,
+  type ProviderKind,
+  type RuntimeMode,
 } from "@synara/contracts";
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -146,6 +147,7 @@ export function KanbanNewTaskDialog({
     pendingImageCount,
     waitForPendingImages,
     selectedProvider,
+    selectedProfileId,
     selectedModel,
     selectedModelSupportsAutoMode,
     selectedProviderModelOptions,
@@ -204,6 +206,7 @@ export function KanbanNewTaskDialog({
     selectedRuntimeAgents,
   } = useProviderModelCatalog({
     selectedProvider,
+    targetExecutable: selectedProfileId === DEFAULT_PROVIDER_PROFILE_ID,
     // Keep discovery warm whenever either picker can open so cursor/codex effort
     // and fast-mode controls are populated, not just the model list.
     discoveryEnabled: isModelPickerOpen || isTraitsPickerOpen,
@@ -311,6 +314,7 @@ export function KanbanNewTaskDialog({
     composerMentions,
     scratchThreadId,
     selectedProvider,
+    targetExecutable: selectedProfileId === DEFAULT_PROVIDER_PROFILE_ID,
     modelOptionsByProvider,
     selectedRuntimeAgents,
     selectedProjectCwd: selectedProject?.cwd ?? null,

--- a/apps/web/src/components/kanban/useKanbanTaskComposerDiscovery.test.tsx
+++ b/apps/web/src/components/kanban/useKanbanTaskComposerDiscovery.test.tsx
@@ -1,0 +1,188 @@
+// FILE: useKanbanTaskComposerDiscovery.test.tsx
+// Purpose: Verifies account-target guards mask provider discovery caches in the kanban composer.
+// Layer: Kanban UI hook tests
+
+import type { ProviderKind, ThreadId } from "@synara/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useKanbanTaskComposerDiscovery } from "./useKanbanTaskComposerDiscovery";
+
+const mocks = vi.hoisted(() => ({
+  buildSearchableModelOptions: vi.fn(),
+  useComposerCommandMenuItems: vi.fn(),
+  useDebouncedValue: vi.fn(),
+  useQuery: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return { ...actual, useQuery: mocks.useQuery };
+});
+
+vi.mock("@tanstack/react-pacer", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-pacer")>();
+  return { ...actual, useDebouncedValue: mocks.useDebouncedValue };
+});
+
+vi.mock("~/hooks/useComposerCommandMenuItems", () => ({
+  buildSearchableModelOptions: mocks.buildSearchableModelOptions,
+  useComposerCommandMenuItems: mocks.useComposerCommandMenuItems,
+}));
+
+interface QueryOptionsLike {
+  readonly queryKey: readonly unknown[];
+}
+
+const PROVIDERS: readonly ProviderKind[] = [
+  "codex",
+  "claudeAgent",
+  "cursor",
+  "antigravity",
+  "grok",
+  "droid",
+  "kilo",
+  "opencode",
+  "pi",
+];
+const MODEL_OPTIONS_BY_PROVIDER = Object.fromEntries(
+  PROVIDERS.map((provider) => [
+    provider,
+    provider === "codex" ? [{ slug: "static-model", name: "Static model" }] : [],
+  ]),
+) as Parameters<typeof useKanbanTaskComposerDiscovery>[0]["modelOptionsByProvider"];
+const WORKSPACE_ENTRY = { kind: "file", name: "local.ts", path: "src/local.ts" };
+const SEARCHABLE_STATIC_MODEL = {
+  provider: "codex",
+  providerLabel: "Codex",
+  slug: "static-model",
+  name: "Static model",
+  searchSlug: "static-model",
+  searchName: "static model",
+  searchProvider: "codex",
+  searchUpstreamProvider: "",
+};
+
+beforeEach(() => {
+  mocks.buildSearchableModelOptions.mockReset().mockReturnValue([SEARCHABLE_STATIC_MODEL]);
+  mocks.useComposerCommandMenuItems.mockReset().mockReturnValue([]);
+  mocks.useDebouncedValue
+    .mockReset()
+    .mockImplementation((value: string) => [value, { state: { isPending: false } }]);
+  mocks.useQuery.mockReset().mockImplementation((options: QueryOptionsLike) => {
+    const resource = options.queryKey[1];
+    if (resource === "composer-capabilities") {
+      return {
+        data: {
+          provider: "codex",
+          supportsSkillMentions: true,
+          supportsSkillDiscovery: true,
+          supportsNativeSlashCommandDiscovery: true,
+          supportsPluginMentions: true,
+          supportsPluginDiscovery: true,
+          supportsRuntimeModelList: true,
+          supportsThreadCompaction: true,
+        },
+        isLoading: true,
+        isFetching: true,
+      };
+    }
+    if (resource === "commands") {
+      return {
+        data: {
+          commands: [{ name: "cached-command", description: "From the default account" }],
+          source: "cache",
+          cached: true,
+        },
+        isLoading: true,
+        isFetching: true,
+      };
+    }
+    if (resource === "skills") {
+      return {
+        data: {
+          skills: [
+            {
+              name: "cached-skill",
+              path: "/default-account/cached-skill",
+              description: "From the default account",
+            },
+          ],
+          source: "cache",
+          cached: true,
+        },
+        isLoading: true,
+        isFetching: true,
+      };
+    }
+    if (resource === "plugins") {
+      return {
+        data: {
+          marketplaces: [
+            {
+              name: "cached-marketplace",
+              path: "/default-account/marketplace",
+              plugins: [{ name: "cached-plugin", description: "From the default account" }],
+            },
+          ],
+          marketplaceLoadErrors: [],
+          remoteSyncError: null,
+          featuredPluginIds: [],
+          source: "cache",
+          cached: true,
+        },
+        isLoading: true,
+        isFetching: true,
+      };
+    }
+    if (resource === "search-entries") {
+      return {
+        data: { entries: [WORKSPACE_ENTRY], truncated: false },
+        isLoading: false,
+        isFetching: false,
+      };
+    }
+    throw new Error(`Unexpected query resource: ${String(resource)}`);
+  });
+});
+
+describe("useKanbanTaskComposerDiscovery", () => {
+  it("masks cached provider discovery while preserving local workspace and static models", () => {
+    let result: ReturnType<typeof useKanbanTaskComposerDiscovery> | undefined;
+
+    function Probe() {
+      result = useKanbanTaskComposerDiscovery({
+        composerTrigger: { kind: "mention", query: "local", rangeStart: 0, rangeEnd: 6 },
+        selectedProvider: "codex",
+        targetExecutable: false,
+        modelOptionsByProvider: MODEL_OPTIONS_BY_PROVIDER,
+        selectedRuntimeAgents: [],
+        selectedProjectCwd: "/workspace",
+        serverCwd: "/workspace",
+        serverHomeDir: "/home/tester",
+        scratchThreadId: "scratch-thread" as ThreadId,
+        providerOptionsForDispatch: undefined,
+        hiddenProviders: [],
+        providerOrder: PROVIDERS,
+        piAgentDir: null,
+      });
+      return null;
+    }
+
+    renderToStaticMarkup(<Probe />);
+
+    const menuInput = mocks.useComposerCommandMenuItems.mock.calls.at(-1)?.[0] as {
+      providerPlugins: readonly unknown[];
+      providerNativeCommands: readonly unknown[];
+      providerSkills: readonly unknown[];
+      workspaceEntries: readonly unknown[];
+      searchableModelOptions: readonly unknown[];
+    };
+    expect(menuInput.providerPlugins).toEqual([]);
+    expect(menuInput.providerNativeCommands).toEqual([]);
+    expect(menuInput.providerSkills).toEqual([]);
+    expect(menuInput.workspaceEntries).toEqual([WORKSPACE_ENTRY]);
+    expect(menuInput.searchableModelOptions).toEqual([SEARCHABLE_STATIC_MODEL]);
+    expect(result?.isComposerMenuLoading).toBe(false);
+  });
+});

--- a/apps/web/src/components/kanban/useKanbanTaskComposerDiscovery.ts
+++ b/apps/web/src/components/kanban/useKanbanTaskComposerDiscovery.ts
@@ -54,6 +54,7 @@ const KANBAN_SUPPORTED_APP_SLASH_COMMANDS = new Set(["clear", "default", "plan"]
 interface UseKanbanTaskComposerDiscoveryInput {
   readonly composerTrigger: ComposerTrigger | null;
   readonly selectedProvider: ProviderKind;
+  readonly targetExecutable: boolean;
   readonly modelOptionsByProvider: Record<
     ProviderKind,
     ReadonlyArray<ProviderModelOption & { isCustom?: boolean }>
@@ -79,6 +80,7 @@ export function useKanbanTaskComposerDiscovery(input: UseKanbanTaskComposerDisco
   const {
     composerTrigger,
     selectedProvider,
+    targetExecutable,
     modelOptionsByProvider,
     selectedRuntimeAgents,
     selectedProjectCwd,
@@ -115,8 +117,11 @@ export function useKanbanTaskComposerDiscovery(input: UseKanbanTaskComposerDisco
   });
 
   const providerComposerCapabilitiesQuery = useQuery(
-    providerComposerCapabilitiesQueryOptions(selectedProvider),
+    providerComposerCapabilitiesQueryOptions(selectedProvider, targetExecutable),
   );
+  const providerComposerCapabilities = targetExecutable
+    ? providerComposerCapabilitiesQuery.data
+    : undefined;
   const providerCommandsQuery = useQuery(
     providerCommandsQueryOptions({
       provider: selectedProvider,
@@ -140,13 +145,14 @@ export function useKanbanTaskComposerDiscovery(input: UseKanbanTaskComposerDisco
           : undefined,
       agentDir: selectedProvider === "pi" ? piAgentDir : null,
       enabled:
+        targetExecutable &&
         (composerTriggerKind === "slash-command" || composerTriggerKind === "slash-model") &&
-        supportsNativeSlashCommandDiscovery(providerComposerCapabilitiesQuery.data) &&
+        supportsNativeSlashCommandDiscovery(providerComposerCapabilities) &&
         composerSkillCwd !== null,
     }),
   );
   const canDiscoverProviderSkills =
-    selectedProvider === "pi" || supportsSkillDiscovery(providerComposerCapabilitiesQuery.data);
+    selectedProvider === "pi" || supportsSkillDiscovery(providerComposerCapabilities);
   const providerSkillsQuery = useQuery(
     providerSkillsQueryOptions({
       provider: selectedProvider,
@@ -154,6 +160,7 @@ export function useKanbanTaskComposerDiscovery(input: UseKanbanTaskComposerDisco
       threadId: scratchThreadId,
       agentDir: selectedProvider === "pi" ? piAgentDir : null,
       enabled:
+        targetExecutable &&
         (isSkillTrigger || composerTriggerKind === "slash-command" || selectedProvider === "pi") &&
         canDiscoverProviderSkills &&
         composerSkillCwd !== null,
@@ -165,7 +172,8 @@ export function useKanbanTaskComposerDiscovery(input: UseKanbanTaskComposerDisco
       cwd: composerSkillCwd,
       threadId: scratchThreadId,
       enabled:
-        supportsPluginDiscovery(providerComposerCapabilitiesQuery.data) &&
+        targetExecutable &&
+        supportsPluginDiscovery(providerComposerCapabilities) &&
         composerSkillCwd !== null,
     }),
   );
@@ -179,19 +187,23 @@ export function useKanbanTaskComposerDiscovery(input: UseKanbanTaskComposerDisco
   );
 
   const workspaceEntries = workspaceEntriesQuery.data?.entries ?? EMPTY_PROJECT_ENTRIES;
-  const providerPlugins =
-    providerPluginsQuery.data?.marketplaces.flatMap((marketplace) =>
-      marketplace.plugins.map((plugin) => ({
-        plugin,
-        mention: {
-          name: plugin.name,
-          path: `plugin://${plugin.name}@${marketplace.name}`,
-        } satisfies ProviderMentionReference,
-      })),
-    ) ?? EMPTY_COMPOSER_PLUGIN_SUGGESTIONS;
-  const providerNativeCommands =
-    providerCommandsQuery.data?.commands ?? EMPTY_PROVIDER_NATIVE_COMMANDS;
-  const providerSkills = providerSkillsQuery.data?.skills ?? EMPTY_PROVIDER_SKILLS;
+  const providerPlugins = targetExecutable
+    ? (providerPluginsQuery.data?.marketplaces.flatMap((marketplace) =>
+        marketplace.plugins.map((plugin) => ({
+          plugin,
+          mention: {
+            name: plugin.name,
+            path: `plugin://${plugin.name}@${marketplace.name}`,
+          } satisfies ProviderMentionReference,
+        })),
+      ) ?? EMPTY_COMPOSER_PLUGIN_SUGGESTIONS)
+    : EMPTY_COMPOSER_PLUGIN_SUGGESTIONS;
+  const providerNativeCommands = targetExecutable
+    ? (providerCommandsQuery.data?.commands ?? EMPTY_PROVIDER_NATIVE_COMMANDS)
+    : EMPTY_PROVIDER_NATIVE_COMMANDS;
+  const providerSkills = targetExecutable
+    ? (providerSkillsQuery.data?.skills ?? EMPTY_PROVIDER_SKILLS)
+    : EMPTY_PROVIDER_SKILLS;
   const searchableModelOptions = buildSearchableModelOptions({
     providerOptions: AVAILABLE_PROVIDER_OPTIONS,
     modelOptionsByProvider,
@@ -230,14 +242,16 @@ export function useKanbanTaskComposerDiscovery(input: UseKanbanTaskComposerDisco
       ((mentionTriggerQuery.length > 0 && composerPathQueryDebouncer.state.isPending) ||
         workspaceEntriesQuery.isLoading ||
         workspaceEntriesQuery.isFetching ||
-        providerPluginsQuery.isLoading ||
-        providerPluginsQuery.isFetching)) ||
+        (targetExecutable &&
+          (providerPluginsQuery.isLoading || providerPluginsQuery.isFetching)))) ||
     (composerTriggerKind === "slash-command" &&
+      targetExecutable &&
       (providerCommandsQuery.isLoading ||
         providerCommandsQuery.isFetching ||
         providerSkillsQuery.isLoading ||
         providerSkillsQuery.isFetching)) ||
     (composerTriggerKind === "skill" &&
+      targetExecutable &&
       (providerComposerCapabilitiesQuery.isLoading ||
         providerComposerCapabilitiesQuery.isFetching ||
         providerSkillsQuery.isLoading ||

--- a/apps/web/src/components/kanban/useKanbanTaskComposerMenu.ts
+++ b/apps/web/src/components/kanban/useKanbanTaskComposerMenu.ts
@@ -46,6 +46,7 @@ interface UseKanbanTaskComposerMenuInput {
   readonly composerMentions: readonly ProviderMentionReference[];
   readonly scratchThreadId: ThreadId;
   readonly selectedProvider: ProviderKind;
+  readonly targetExecutable: boolean;
   readonly modelOptionsByProvider: Record<
     ProviderKind,
     ReadonlyArray<ProviderModelOption & { isCustom?: boolean }>
@@ -75,6 +76,7 @@ export function useKanbanTaskComposerMenu(input: UseKanbanTaskComposerMenuInput)
     composerMentions,
     scratchThreadId,
     selectedProvider,
+    targetExecutable,
     modelOptionsByProvider,
     selectedRuntimeAgents,
     selectedProjectCwd,
@@ -111,6 +113,7 @@ export function useKanbanTaskComposerMenu(input: UseKanbanTaskComposerMenuInput)
   } = useKanbanTaskComposerDiscovery({
     composerTrigger,
     selectedProvider,
+    targetExecutable,
     modelOptionsByProvider,
     selectedRuntimeAgents,
     selectedProjectCwd,

--- a/apps/web/src/components/kanban/useKanbanTaskSubmit.test.ts
+++ b/apps/web/src/components/kanban/useKanbanTaskSubmit.test.ts
@@ -1,0 +1,138 @@
+// FILE: useKanbanTaskSubmit.test.ts
+// Purpose: Verifies provider-profile safety at the Kanban task send boundary.
+// Layer: Web Kanban hook tests
+
+import {
+  ProjectId,
+  ProviderProfileId,
+  ThreadId,
+  type ModelSlug,
+} from "@synara/contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  draftsByThreadId: {} as Record<string, unknown>,
+  navigate: vi.fn(),
+  toast: vi.fn(),
+  refreshStatuses: vi.fn(),
+  waitForPendingImages: vi.fn(),
+  createDraft: vi.fn(),
+  createAndSend: vi.fn(),
+  resolveAvailability: vi.fn(),
+}));
+
+vi.mock("react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react")>()),
+  useRef: <T>(value: T) => ({ current: value }),
+  useState: <T>(value: T) => [value, vi.fn()] as const,
+}));
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => harness.navigate }));
+vi.mock("~/components/ui/toast", () => ({ toastManager: { add: harness.toast } }));
+vi.mock("~/composerDraftStore", () => {
+  const useComposerDraftStore = {
+    getState: () => ({ draftsByThreadId: harness.draftsByThreadId }),
+  };
+  return { useComposerDraftStore };
+});
+vi.mock("~/hooks/useProviderStatusRefresh", () => ({
+  useRefreshProviderStatusesNow: () => harness.refreshStatuses,
+}));
+vi.mock("~/lib/kanbanTaskCreate", () => ({
+  createKanbanDraftTask: harness.createDraft,
+  createAndSendKanbanTask: harness.createAndSend,
+}));
+vi.mock("~/lib/providerAvailability", () => ({
+  resolveProviderSendAvailabilityWithRefresh: harness.resolveAvailability,
+}));
+
+import { useKanbanTaskSubmit } from "./useKanbanTaskSubmit";
+
+const PROJECT_ID = ProjectId.makeUnsafe("project-kanban-profile");
+const SCRATCH_THREAD_ID = ThreadId.makeUnsafe("thread-kanban-profile");
+const MODEL = "gpt-5.6-sol" as ModelSlug;
+const WORK_PROFILE_ID = ProviderProfileId.makeUnsafe("work");
+
+function renderSubmit(sendAsDraft: boolean) {
+  return useKanbanTaskSubmit({
+    selectedProjectId: PROJECT_ID,
+    hasSendableContent: true,
+    selectedProvider: "codex",
+    selectedModel: MODEL,
+    selectedModelSupportsAutoMode: undefined,
+    taskPreview: "Profile-aware task",
+    trimmedPrompt: "Profile-aware task",
+    scratchThreadId: SCRATCH_THREAD_ID,
+    runtimeMode: "approval-required",
+    interactionMode: "default",
+    envMode: "local",
+    sendAsDraft,
+    defaultProvider: "codex",
+    assistantDeliveryMode: "streaming",
+    providerOptionsForDispatch: undefined,
+    providerStatuses: [],
+    isPreparingImages: false,
+    waitForPendingImages: harness.waitForPendingImages,
+    onOpenChange: vi.fn(),
+  });
+}
+
+beforeEach(() => {
+  harness.draftsByThreadId = {
+    [SCRATCH_THREAD_ID]: {
+      modelSelectionByProvider: {
+        codex: {
+          provider: "codex",
+          profileId: WORK_PROFILE_ID,
+          model: MODEL,
+        },
+      },
+    },
+  };
+  for (const mock of [
+    harness.navigate,
+    harness.toast,
+    harness.refreshStatuses,
+    harness.waitForPendingImages,
+    harness.createDraft,
+    harness.createAndSend,
+    harness.resolveAvailability,
+  ]) {
+    mock.mockReset();
+  }
+  harness.waitForPendingImages.mockResolvedValue(undefined);
+  harness.resolveAvailability.mockResolvedValue({ usable: true });
+});
+
+describe("useKanbanTaskSubmit provider profiles", () => {
+  it("rejects an unavailable profile before images, discovery, or task creation", async () => {
+    await renderSubmit(false).handleCreate();
+
+    expect(harness.toast).toHaveBeenCalledWith({
+      type: "error",
+      title: "Provider profile 'work' is not configured for provider 'codex'.",
+    });
+    expect(harness.waitForPendingImages).not.toHaveBeenCalled();
+    expect(harness.resolveAvailability).not.toHaveBeenCalled();
+    expect(harness.refreshStatuses).not.toHaveBeenCalled();
+    expect(harness.createDraft).not.toHaveBeenCalled();
+    expect(harness.createAndSend).not.toHaveBeenCalled();
+    expect(harness.navigate).not.toHaveBeenCalled();
+  });
+
+  it("preserves a non-default profile when saving a draft without dispatching", async () => {
+    await renderSubmit(true).handleCreate();
+
+    expect(harness.waitForPendingImages).toHaveBeenCalledOnce();
+    expect(harness.createDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelSelection: expect.objectContaining({
+          provider: "codex",
+          profileId: WORK_PROFILE_ID,
+          model: MODEL,
+        }),
+      }),
+    );
+    expect(harness.resolveAvailability).not.toHaveBeenCalled();
+    expect(harness.createAndSend).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/kanban/useKanbanTaskSubmit.ts
+++ b/apps/web/src/components/kanban/useKanbanTaskSubmit.ts
@@ -3,16 +3,17 @@
 // Layer: Kanban UI hook
 // Exports: useKanbanTaskSubmit
 
-import type {
-  AssistantDeliveryMode,
-  ModelSlug,
-  ProjectId,
-  ProviderInteractionMode,
-  ProviderKind,
-  ProviderStartOptions,
-  RuntimeMode,
-  ServerProviderStatus,
-  ThreadId,
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  type AssistantDeliveryMode,
+  type ModelSlug,
+  type ProjectId,
+  type ProviderInteractionMode,
+  type ProviderKind,
+  type ProviderStartOptions,
+  type RuntimeMode,
+  type ServerProviderStatus,
+  type ThreadId,
 } from "@synara/contracts";
 import { useNavigate } from "@tanstack/react-router";
 import { useRef, useState } from "react";
@@ -23,7 +24,8 @@ import { useComposerDraftStore } from "~/composerDraftStore";
 import { useRefreshProviderStatusesNow } from "~/hooks/useProviderStatusRefresh";
 import { createAndSendKanbanTask, createKanbanDraftTask } from "~/lib/kanbanTaskCreate";
 import { resolveProviderSendAvailabilityWithRefresh } from "~/lib/providerAvailability";
-import { buildModelSelection } from "~/providerModelOptions";
+import { unsupportedProviderProfileIssue } from "~/lib/providerProfileAvailability";
+import { buildModelSelectionForTarget } from "~/providerModelOptions";
 import { truncateKanbanTaskPreview } from "./KanbanNewTaskDialog.logic";
 
 interface UseKanbanTaskSubmitInput {
@@ -96,24 +98,44 @@ export function useKanbanTaskSubmit(input: UseKanbanTaskSubmitInput) {
     }
 
     isCreatingRef.current = true;
-    await waitForPendingImages();
-    const truncatedPrompt = truncateKanbanTaskPreview(taskPreview);
     // The scratch draft carries the full selection (model + reasoning effort +
     // speed) set through the picker; fall back to a bare selection otherwise.
     const scratchState = useComposerDraftStore.getState().draftsByThreadId[scratchThreadId];
     const storedModelSelection = scratchState?.modelSelectionByProvider[selectedProvider];
+    const profileId = storedModelSelection?.profileId ?? DEFAULT_PROVIDER_PROFILE_ID;
+    if (!sendAsDraft) {
+      const profileIssue = unsupportedProviderProfileIssue({
+        provider: selectedProvider,
+        profileId,
+      });
+      if (profileIssue !== null) {
+        toastManager.add({
+          type: "error",
+          title: profileIssue,
+        });
+        isCreatingRef.current = false;
+        return;
+      }
+    }
+
+    await waitForPendingImages();
+    const truncatedPrompt = truncateKanbanTaskPreview(taskPreview);
     const storedModelSupportsAutoMode =
       storedModelSelection?.provider === "claudeAgent"
         ? storedModelSelection.supportsAutoMode
         : undefined;
-    const modelSelection = buildModelSelection(
-      selectedProvider,
-      selectedModel,
-      storedModelSelection?.options,
-      selectedProvider === "claudeAgent"
-        ? (selectedModelSupportsAutoMode ?? storedModelSupportsAutoMode)
-        : undefined,
-    );
+    const modelSelection = buildModelSelectionForTarget({
+      target: {
+        provider: selectedProvider,
+        profileId,
+      },
+      model: selectedModel,
+      options: storedModelSelection?.options,
+      supportsAutoMode:
+        selectedProvider === "claudeAgent"
+          ? (selectedModelSupportsAutoMode ?? storedModelSupportsAutoMode)
+          : undefined,
+    });
     const taskInput = {
       projectId: selectedProjectId,
       prompt: trimmedPrompt,

--- a/apps/web/src/components/settings/ModelsSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ModelsSettingsPanel.tsx
@@ -4,6 +4,7 @@
 
 import {
   DEFAULT_GIT_TEXT_GENERATION_MODEL,
+  DEFAULT_PROVIDER_PROFILE_ID,
   PROVIDER_DISPLAY_NAMES,
   type ProviderKind,
 } from "@synara/contracts";
@@ -103,6 +104,7 @@ export function ModelsSettingsPanel({
     customKiloModels,
     customOpenCodeModels,
     textGenerationModel,
+    textGenerationProfileId,
     textGenerationProvider,
   } = settings;
   const currentGitTextGenerationProvider = textGenerationProvider ?? "codex";
@@ -118,6 +120,7 @@ export function ModelsSettingsPanel({
   });
   const { modelOptionsByProvider: gitWritingCatalogOptionsByProvider } = useProviderModelCatalog({
     selectedProvider: currentGitTextGenerationProvider,
+    targetExecutable: textGenerationProfileId === DEFAULT_PROVIDER_PROFILE_ID,
     discoveryEnabled: active,
     cwd: providerModelDiscoveryCwd,
     modelHintByProvider: gitWritingModelHintByProvider,
@@ -268,6 +271,7 @@ export function ModelsSettingsPanel({
                 onClick={() =>
                   updateSettings({
                     textGenerationProvider: defaults.textGenerationProvider,
+                    textGenerationProfileId: defaults.textGenerationProfileId,
                     textGenerationModel: defaults.textGenerationModel,
                   })
                 }

--- a/apps/web/src/hooks/useComposerSlashCommands.test.tsx
+++ b/apps/web/src/hooks/useComposerSlashCommands.test.tsx
@@ -1,0 +1,153 @@
+// FILE: useComposerSlashCommands.test.tsx
+// Purpose: Locks provider-profile guards around imperative composer slash-command discovery.
+// Layer: Web hook tests
+
+import { ProviderProfileId, ThreadId, type ModelSlug } from "@synara/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Project, Thread } from "../types";
+
+const mocks = vi.hoisted(() => ({
+  clearComposerSlashDraft: vi.fn(),
+  dispatchCommand: vi.fn(),
+  listCommands: vi.fn(),
+  toast: vi.fn(),
+}));
+
+vi.mock("../nativeApi", () => ({
+  readNativeApi: () => ({
+    provider: {
+      listCommands: mocks.listCommands,
+    },
+    orchestration: {
+      dispatchCommand: mocks.dispatchCommand,
+    },
+  }),
+}));
+
+vi.mock("../components/ui/toast", () => ({
+  toastManager: {
+    add: mocks.toast,
+  },
+}));
+
+vi.mock("../feedbackDialogStore", () => ({
+  useFeedbackDialogStore: (selector: (state: { openDialog: () => void }) => unknown) =>
+    selector({ openDialog: vi.fn() }),
+}));
+
+vi.mock("../rightDockStore", () => ({
+  useRightDockStore: {
+    getState: () => ({ openPane: vi.fn() }),
+  },
+}));
+
+import { useComposerSlashCommands } from "./useComposerSlashCommands";
+
+function renderSlashCommandsHook(
+  overrides: Partial<Parameters<typeof useComposerSlashCommands>[0]> = {},
+) {
+  let result: ReturnType<typeof useComposerSlashCommands> | undefined;
+
+  function Probe() {
+    result = useComposerSlashCommands({
+      activeProject: undefined,
+      activeThread: undefined,
+      activeRootBranch: null,
+      isServerThread: false,
+      supportsFastSlashCommand: false,
+      canOfferCompactCommand: false,
+      canOfferSideCommand: false,
+      canOfferExportCommand: false,
+      supportsTextNativeReviewCommand: false,
+      fastModeEnabled: false,
+      providerNativeCommands: [],
+      providerCommandDiscoveryCwd: "/repo",
+      targetExecutable: false,
+      selectedProvider: "claudeAgent",
+      currentProviderModelOptions: undefined,
+      selectedModelSelection: {
+        provider: "claudeAgent",
+        profileId: ProviderProfileId.makeUnsafe("work"),
+        model: "claude-opus-4-1" as ModelSlug,
+      },
+      environmentMode: "local",
+      runtimeMode: "approval-required",
+      interactionMode: "default",
+      threadId: ThreadId.makeUnsafe("thread-slash-profile"),
+      syncServerShellSnapshot: vi.fn(),
+      navigateToThread: vi.fn(),
+      handleClearConversation: vi.fn(),
+      handleInteractionModeChange: vi.fn(),
+      openForkTargetPicker: vi.fn(),
+      openReviewTargetPicker: vi.fn(),
+      setComposerDraftProviderModelOptions: vi.fn(),
+      editorActions: {
+        resolveActiveComposerTrigger: () => ({
+          snapshot: { value: "/fast", cursor: 5, expandedCursor: 5 },
+          trigger: null,
+        }),
+        applyPromptReplacement: vi.fn(),
+        clearComposerSlashDraft: mocks.clearComposerSlashDraft,
+        setComposerPromptValue: vi.fn(),
+        scheduleComposerFocus: vi.fn(),
+        setComposerHighlightedItemId: vi.fn(),
+      },
+      ...overrides,
+    });
+    return null;
+  }
+
+  renderToStaticMarkup(<Probe />);
+  if (!result) {
+    throw new Error("Slash-command hook did not render.");
+  }
+  return result;
+}
+
+beforeEach(() => {
+  mocks.clearComposerSlashDraft.mockReset();
+  mocks.dispatchCommand.mockReset();
+  mocks.listCommands.mockReset();
+  mocks.toast.mockReset();
+});
+
+describe("useComposerSlashCommands provider profile guard", () => {
+  it("rejects Claude /fast discovery for an unsupported profile before force reload", async () => {
+    const hook = renderSlashCommandsHook();
+
+    await expect(hook.handleStandaloneSlashCommand("/fast")).resolves.toBe(true);
+
+    expect(mocks.clearComposerSlashDraft).toHaveBeenCalledTimes(1);
+    expect(mocks.listCommands).not.toHaveBeenCalled();
+    expect(mocks.toast).toHaveBeenCalledWith({
+      type: "warning",
+      title: "Fast mode is unavailable",
+      description:
+        "Provider profile 'work' is not configured for provider 'claudeAgent'.",
+    });
+  });
+
+  it("rejects a native review before creating a thread for an unsupported profile", async () => {
+    const hook = renderSlashCommandsHook({
+      activeProject: { id: "project-review" } as unknown as Project,
+      activeThread: { title: "Review source" } as unknown as Thread,
+      isServerThread: true,
+      selectedProvider: "codex",
+      selectedModelSelection: {
+        provider: "codex",
+        profileId: ProviderProfileId.makeUnsafe("work"),
+        model: "gpt-5" as ModelSlug,
+      },
+    });
+
+    await expect(hook.handleReviewTargetSelection("changes")).resolves.toBeUndefined();
+
+    expect(mocks.dispatchCommand).not.toHaveBeenCalled();
+    expect(mocks.toast).toHaveBeenCalledWith({
+      type: "warning",
+      title: "Review is unavailable",
+      description: "Provider profile 'work' is not configured for provider 'codex'.",
+    });
+  });
+});

--- a/apps/web/src/hooks/useComposerSlashCommands.ts
+++ b/apps/web/src/hooks/useComposerSlashCommands.ts
@@ -42,6 +42,7 @@ import {
   sendSidechatPrompt,
   type SidechatCreationFlight,
 } from "../lib/sidechatCreation";
+import { unsupportedProviderProfileIssue } from "../lib/providerProfileAvailability";
 
 type ComposerSnapshot = {
   value: string;
@@ -68,6 +69,7 @@ export function useComposerSlashCommands(input: {
   fastModeEnabled: boolean;
   providerNativeCommands: readonly ProviderNativeCommandDescriptor[];
   providerCommandDiscoveryCwd: string | null;
+  targetExecutable: boolean;
   selectedProvider: ProviderKind;
   currentProviderModelOptions: ProviderModelOptions[ProviderKind] | undefined;
   selectedModelSelection: ModelSelection;
@@ -119,6 +121,7 @@ export function useComposerSlashCommands(input: {
     fastModeEnabled,
     providerNativeCommands,
     providerCommandDiscoveryCwd,
+    targetExecutable,
     selectedProvider,
     currentProviderModelOptions,
     selectedModelSelection,
@@ -411,6 +414,16 @@ export function useComposerSlashCommands(input: {
         return false;
       }
 
+      const profileIssue = unsupportedProviderProfileIssue(selectedModelSelection);
+      if (profileIssue) {
+        toastManager.add({
+          type: "warning",
+          title: "Review is unavailable",
+          description: profileIssue,
+        });
+        return false;
+      }
+
       const messageText =
         target === "base-branch" && activeRootBranch
           ? `Review against base branch ${activeRootBranch}`
@@ -531,6 +544,18 @@ export function useComposerSlashCommands(input: {
   );
 
   const checkClaudeFastSlashCommandAvailability = useCallback(async (): Promise<boolean> => {
+    if (!targetExecutable) {
+      editorActions.clearComposerSlashDraft();
+      toastManager.add({
+        type: "warning",
+        title: "Fast mode is unavailable",
+        description:
+          unsupportedProviderProfileIssue(selectedModelSelection) ??
+          "The selected provider profile is unavailable.",
+      });
+      return false;
+    }
+
     const api = readNativeApi();
     if (!api || !providerCommandDiscoveryCwd) {
       editorActions.clearComposerSlashDraft();
@@ -575,7 +600,13 @@ export function useComposerSlashCommands(input: {
       description: "Claude did not expose /fast for this account or environment.",
     });
     return false;
-  }, [editorActions, providerCommandDiscoveryCwd, threadId]);
+  }, [
+    editorActions,
+    providerCommandDiscoveryCwd,
+    selectedModelSelection,
+    targetExecutable,
+    threadId,
+  ]);
 
   const runExportSlashCommand = useCallback(() => {
     // Re-validate at call time (mirrors /compact): menu selections and stale

--- a/apps/web/src/hooks/useProviderModelCatalog.test.tsx
+++ b/apps/web/src/hooks/useProviderModelCatalog.test.tsx
@@ -133,6 +133,7 @@ describe("useProviderModelCatalog", () => {
   it("keeps aggregate identities stable when inputs and query data are unchanged", () => {
     const [first, second] = readCatalogRenders({
       selectedProvider: "cursor",
+      targetExecutable: true,
       discoveryEnabled: true,
       modelHintByProvider: MODEL_HINTS,
     });
@@ -146,18 +147,91 @@ describe("useProviderModelCatalog", () => {
   });
 
   it("discovers core agents only when selected unless eager-core is requested", () => {
-    readCatalogRenders({ selectedProvider: "cursor", discoveryEnabled: false });
+    readCatalogRenders({
+      selectedProvider: "cursor",
+      targetExecutable: true,
+      discoveryEnabled: false,
+    });
     expect(readAgentQueryEnabled("claudeAgent")).toBe(false);
     expect(readAgentQueryEnabled("codex")).toBe(false);
 
     mocks.useQuery.mockClear();
     readCatalogRenders({
       selectedProvider: "cursor",
+      targetExecutable: true,
       discoveryEnabled: false,
       agentDiscoveryPolicy: "eager-core",
     });
     expect(readAgentQueryEnabled("claudeAgent")).toBe(true);
     expect(readAgentQueryEnabled("codex")).toBe(true);
+  });
+
+  it("suppresses all provider discovery for an unsupported account target", () => {
+    readCatalogRenders({
+      selectedProvider: "codex",
+      targetExecutable: false,
+      discoveryEnabled: true,
+      agentDiscoveryPolicy: "eager-core",
+    });
+
+    for (const provider of [
+      "codex",
+      "claudeAgent",
+      "cursor",
+      "antigravity",
+      "grok",
+      "droid",
+      "kilo",
+      "opencode",
+      "pi",
+    ] as const) {
+      expect(readModelQueryEnabled(provider)).toBe(false);
+    }
+    expect(readAgentQueryEnabled("codex")).toBe(false);
+    expect(readAgentQueryEnabled("claudeAgent")).toBe(false);
+    expect(readAgentQueryEnabled("kilo")).toBe(false);
+    expect(readAgentQueryEnabled("opencode")).toBe(false);
+  });
+
+  it("does not expose cached default-account discovery for an unsupported target", () => {
+    modelQueries.set("codex", {
+      data: {
+        models: [
+          { slug: "cached-selected-model", name: "Cached selected model" },
+          { slug: "cached-default-only", name: "Cached default only" },
+        ],
+        source: "codex.app-server",
+        cached: true,
+      },
+      isFetching: false,
+      isLoading: false,
+      isPlaceholderData: false,
+    });
+    agentQueries.set("codex", {
+      data: {
+        agents: [{ name: "cached-default-agent", displayName: "Cached default agent" }],
+        cached: true,
+      },
+      isFetching: false,
+      isLoading: false,
+      isPlaceholderData: false,
+    });
+
+    const catalog = readCatalogRenders({
+      selectedProvider: "codex",
+      targetExecutable: false,
+      discoveryEnabled: true,
+      modelHintByProvider: { codex: "cached-selected-model" },
+      agentDiscoveryPolicy: "eager-core",
+    }).at(-1);
+
+    expect(catalog?.modelOptionsByProvider.codex.map((model) => model.slug)).not.toContain(
+      "cached-default-only",
+    );
+    expect(catalog?.runtimeModelsByProvider.codex).toEqual([]);
+    expect(catalog?.selectedRuntimeModel).toBeUndefined();
+    expect(catalog?.selectedRuntimeAgents).toEqual([]);
+    expect(catalog?.selectedProviderModelsLoading).toBe(false);
   });
 
   it("does not prefetch providers hidden from picker surfaces", () => {
@@ -166,7 +240,11 @@ describe("useProviderModelCatalog", () => {
       serverSettings: DEFAULT_SERVER_SETTINGS,
     });
 
-    readCatalogRenders({ selectedProvider: "codex", discoveryEnabled: true });
+    readCatalogRenders({
+      selectedProvider: "codex",
+      targetExecutable: true,
+      discoveryEnabled: true,
+    });
 
     expect(readModelQueryEnabled("codex")).toBe(true);
     expect(readModelQueryEnabled("cursor")).toBe(false);
@@ -179,7 +257,11 @@ describe("useProviderModelCatalog", () => {
       serverSettings: DEFAULT_SERVER_SETTINGS,
     });
 
-    readCatalogRenders({ selectedProvider: "cursor", discoveryEnabled: false });
+    readCatalogRenders({
+      selectedProvider: "cursor",
+      targetExecutable: true,
+      discoveryEnabled: false,
+    });
 
     expect(readModelQueryEnabled("cursor")).toBe(true);
   });
@@ -199,7 +281,11 @@ describe("useProviderModelCatalog", () => {
       },
     });
 
-    readCatalogRenders({ selectedProvider: "cursor", discoveryEnabled: true });
+    readCatalogRenders({
+      selectedProvider: "cursor",
+      targetExecutable: true,
+      discoveryEnabled: true,
+    });
 
     expect(readModelQueryEnabled("cursor")).toBe(false);
   });
@@ -210,7 +296,11 @@ describe("useProviderModelCatalog", () => {
     // closed here would blank every provider's model list, selected one included.
     mocks.useAppSettings.mockReturnValue({ settings: SETTINGS, serverSettings: undefined });
 
-    readCatalogRenders({ selectedProvider: "claudeAgent", discoveryEnabled: true });
+    readCatalogRenders({
+      selectedProvider: "claudeAgent",
+      targetExecutable: true,
+      discoveryEnabled: true,
+    });
 
     expect(readModelQueryEnabled("claudeAgent")).toBe(true);
     expect(readModelQueryEnabled("codex")).toBe(true);
@@ -225,7 +315,11 @@ describe("useProviderModelCatalog", () => {
       serverSettings: { ...DEFAULT_SERVER_SETTINGS, providers: providersWithoutCursor },
     });
 
-    readCatalogRenders({ selectedProvider: "cursor", discoveryEnabled: false });
+    readCatalogRenders({
+      selectedProvider: "cursor",
+      targetExecutable: true,
+      discoveryEnabled: false,
+    });
 
     expect(readModelQueryEnabled("cursor")).toBe(true);
   });
@@ -233,6 +327,7 @@ describe("useProviderModelCatalog", () => {
   it("restricts non-picker prefetch to the requested providers", () => {
     readCatalogRenders({
       selectedProvider: "codex",
+      targetExecutable: true,
       discoveryEnabled: true,
       prefetchProviders: ["codex", "kilo", "opencode"],
     });
@@ -258,6 +353,7 @@ describe("useProviderModelCatalog", () => {
 
     const catalog = readCatalogRenders({
       selectedProvider: "cursor",
+      targetExecutable: true,
       discoveryEnabled: true,
       modelHintByProvider: MODEL_HINTS,
     }).at(-1);

--- a/apps/web/src/hooks/useProviderModelCatalog.ts
+++ b/apps/web/src/hooks/useProviderModelCatalog.ts
@@ -51,6 +51,8 @@ const EMPTY_PROVIDER_AGENTS: ReadonlyArray<ProviderAgentDescriptor> = [];
 
 export function useProviderModelCatalog(input: {
   selectedProvider: ProviderKind;
+  /** False when the selected account target cannot be executed safely. */
+  targetExecutable: boolean;
   /**
    * Enables discovery for the on-demand providers (cursor/grok/droid/kilo/opencode/pi)
    * even when they are not selected — pass the picker's open state so their lists
@@ -70,6 +72,7 @@ export function useProviderModelCatalog(input: {
   agentDiscoveryPolicy?: "selected" | "eager-core";
 }): ProviderModelCatalog {
   const { selectedProvider, discoveryEnabled, modelHintByProvider } = input;
+  const targetExecutable = input.targetExecutable === true;
   const agentDiscoveryPolicy = input.agentDiscoveryPolicy ?? "selected";
   const discoveryCwd = input.cwd ?? null;
   const { settings, serverSettings } = useAppSettings();
@@ -87,6 +90,9 @@ export function useProviderModelCatalog(input: {
     provider: ProviderKind,
     prefetchRequested = discoveryEnabled,
   ): boolean => {
+    if (!targetExecutable) {
+      return false;
+    }
     // The enabled flag is a short-circuit, not a precondition. `serverSettings` is
     // undefined while the settings query is in flight and stays undefined if it
     // fails — and it never refetches on its own (`staleTime: Infinity`). Treating
@@ -301,18 +307,18 @@ export function useProviderModelCatalog(input: {
       ReadonlyArray<ProviderModelOption & { isCustom?: boolean }>
     > = { ...staticOptions };
     const dynamicSources: Record<ProviderKind, typeof claudeDynamicModelsQuery.data> = {
-      claudeAgent: claudeDynamicModelsQuery.data,
-      codex: codexDynamicModelsQuery.data,
+      claudeAgent: targetExecutable ? claudeDynamicModelsQuery.data : undefined,
+      codex: targetExecutable ? codexDynamicModelsQuery.data : undefined,
       cursor:
-        cursorDynamicModelsQuery.data === undefined
+        !targetExecutable || cursorDynamicModelsQuery.data === undefined
           ? undefined
           : { ...cursorDynamicModelsQuery.data, models: cursorRuntimeModels },
-      antigravity: antigravityModelsQuery.data,
-      grok: grokDynamicModelsQuery.data,
-      droid: droidDynamicModelsQuery.data,
-      kilo: kiloDynamicModelsQuery.data,
-      opencode: openCodeDynamicModelsQuery.data,
-      pi: piDynamicModelsQuery.data,
+      antigravity: targetExecutable ? antigravityModelsQuery.data : undefined,
+      grok: targetExecutable ? grokDynamicModelsQuery.data : undefined,
+      droid: targetExecutable ? droidDynamicModelsQuery.data : undefined,
+      kilo: targetExecutable ? kiloDynamicModelsQuery.data : undefined,
+      opencode: targetExecutable ? openCodeDynamicModelsQuery.data : undefined,
+      pi: targetExecutable ? piDynamicModelsQuery.data : undefined,
     };
     for (const provider of [
       "claudeAgent",
@@ -348,6 +354,7 @@ export function useProviderModelCatalog(input: {
     modelHintByProvider,
     openCodeDynamicModelsQuery.data,
     piDynamicModelsQuery.data,
+    targetExecutable,
   ]);
 
   const loadingModelProviders = useMemo<Partial<Record<ProviderKind, boolean>>>(
@@ -372,17 +379,30 @@ export function useProviderModelCatalog(input: {
   const runtimeModelsByProvider = useMemo<
     Record<ProviderKind, ReadonlyArray<ProviderModelDescriptor>>
   >(
-    () => ({
-      claudeAgent: claudeDynamicModelsQuery.data?.models ?? [],
-      codex: codexDynamicModelsQuery.data?.models ?? [],
-      cursor: cursorRuntimeModels,
-      antigravity: antigravityModelsQuery.data?.models ?? [],
-      grok: grokDynamicModelsQuery.data?.models ?? [],
-      droid: droidDynamicModelsQuery.data?.models ?? [],
-      kilo: kiloDynamicModelsQuery.data?.models ?? [],
-      opencode: openCodeDynamicModelsQuery.data?.models ?? [],
-      pi: piDynamicModelsQuery.data?.models ?? [],
-    }),
+    () =>
+      targetExecutable
+        ? {
+            claudeAgent: claudeDynamicModelsQuery.data?.models ?? [],
+            codex: codexDynamicModelsQuery.data?.models ?? [],
+            cursor: cursorRuntimeModels,
+            antigravity: antigravityModelsQuery.data?.models ?? [],
+            grok: grokDynamicModelsQuery.data?.models ?? [],
+            droid: droidDynamicModelsQuery.data?.models ?? [],
+            kilo: kiloDynamicModelsQuery.data?.models ?? [],
+            opencode: openCodeDynamicModelsQuery.data?.models ?? [],
+            pi: piDynamicModelsQuery.data?.models ?? [],
+          }
+        : {
+            claudeAgent: [],
+            codex: [],
+            cursor: [],
+            antigravity: [],
+            grok: [],
+            droid: [],
+            kilo: [],
+            opencode: [],
+            pi: [],
+          },
     [
       antigravityModelsQuery.data?.models,
       claudeDynamicModelsQuery.data?.models,
@@ -393,6 +413,7 @@ export function useProviderModelCatalog(input: {
       kiloDynamicModelsQuery.data?.models,
       openCodeDynamicModelsQuery.data?.models,
       piDynamicModelsQuery.data?.models,
+      targetExecutable,
     ],
   );
 
@@ -406,8 +427,9 @@ export function useProviderModelCatalog(input: {
     [modelHintByProvider, runtimeModelsByProvider, selectedProvider],
   );
 
-  const selectedDynamicAgents =
-    selectedProvider === "claudeAgent"
+  const selectedDynamicAgents = !targetExecutable
+    ? EMPTY_PROVIDER_AGENTS
+    : selectedProvider === "claudeAgent"
       ? (claudeDynamicAgentsQuery.data?.agents ?? EMPTY_PROVIDER_AGENTS)
       : selectedProvider === "kilo"
         ? (kiloDynamicAgentsQuery.data?.agents ?? EMPTY_PROVIDER_AGENTS)
@@ -445,11 +467,12 @@ export function useProviderModelCatalog(input: {
                     ? openCodeDynamicModelsQuery
                     : piDynamicModelsQuery;
   const selectedProviderModelsLoading =
-    selectedProviderRuntimeModelDiscoveryPending ||
-    (loadingModelProviders[selectedProvider] === undefined &&
-      (selectedProviderModelsQuery.isLoading ||
-        (selectedProviderModelsQuery.isFetching &&
-          selectedProviderModelsQuery.data === undefined)));
+    targetExecutable &&
+    (selectedProviderRuntimeModelDiscoveryPending ||
+      (loadingModelProviders[selectedProvider] === undefined &&
+        (selectedProviderModelsQuery.isLoading ||
+          (selectedProviderModelsQuery.isFetching &&
+            selectedProviderModelsQuery.data === undefined))));
 
   return useMemo(
     () => ({

--- a/apps/web/src/hooks/useThreadHandoff.test.ts
+++ b/apps/web/src/hooks/useThreadHandoff.test.ts
@@ -1,0 +1,130 @@
+// FILE: useThreadHandoff.test.ts
+// Purpose: Verifies handoff target guards run before provider or orchestration side effects.
+// Layer: Web hook tests
+
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  MessageId,
+  ProjectId,
+  ThreadId,
+  type ModelSlug,
+} from "@synara/contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  copyTransferableComposerState: vi.fn(),
+  dispatchCommand: vi.fn(),
+  getShellSnapshot: vi.fn(),
+  navigate: vi.fn(),
+  refreshProviderStatuses: vi.fn(),
+  syncServerShellSnapshot: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: undefined }),
+}));
+
+vi.mock("../lib/serverReactQuery", () => ({
+  serverSettingsQueryOptions: () => ({}),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock("../composerDraftStore", () => {
+  const useComposerDraftStore = Object.assign(() => undefined, {
+    getState: () => ({
+      copyTransferableComposerState: mocks.copyTransferableComposerState,
+      stickyModelSelectionByProvider: {
+        claudeAgent: {
+          provider: "claudeAgent",
+          profileId: "work",
+          model: "claude-opus-4-1",
+        },
+      },
+    }),
+  });
+  return { useComposerDraftStore };
+});
+
+vi.mock("./useProviderStatusesForLocalConfig", () => ({
+  useProviderStatusesForLocalConfig: () => [],
+}));
+
+vi.mock("./useProviderStatusRefresh", () => ({
+  useRefreshProviderStatusesNow: () => mocks.refreshProviderStatuses,
+}));
+
+vi.mock("../nativeApi", () => ({
+  readNativeApi: () => ({
+    orchestration: {
+      dispatchCommand: mocks.dispatchCommand,
+      getShellSnapshot: mocks.getShellSnapshot,
+    },
+  }),
+}));
+
+const PROJECT_ID = ProjectId.makeUnsafe("project-handoff-profile");
+const THREAD_ID = ThreadId.makeUnsafe("thread-handoff-profile");
+
+vi.mock("../store", () => ({
+  useStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      projects: [
+        {
+          id: "project-handoff-profile",
+          defaultModelSelection: null,
+        },
+      ],
+      syncServerShellSnapshot: mocks.syncServerShellSnapshot,
+    }),
+}));
+
+import { useThreadHandoff } from "./useThreadHandoff";
+import type { Thread } from "../types";
+
+const SOURCE_THREAD = {
+  id: THREAD_ID,
+  projectId: PROJECT_ID,
+  modelSelection: {
+    provider: "codex",
+    profileId: DEFAULT_PROVIDER_PROFILE_ID,
+    model: "gpt-5.6-sol" as ModelSlug,
+  },
+  session: null,
+  handoff: null,
+  messages: [
+    {
+      id: MessageId.makeUnsafe("message-handoff-profile"),
+      role: "user",
+      text: "Continue this work",
+      source: "native",
+      streaming: false,
+      createdAt: "2026-08-10T12:00:00.000Z",
+    },
+  ],
+} as unknown as Thread;
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) {
+    mock.mockReset();
+  }
+});
+
+describe("useThreadHandoff provider profile guard", () => {
+  it("rejects an unsupported target before refresh, dispatch, copy, snapshot, or navigation", async () => {
+    const { createThreadHandoff } = useThreadHandoff();
+
+    await expect(createThreadHandoff(SOURCE_THREAD, "claudeAgent")).rejects.toThrow(
+      "Provider profile 'work' is not configured for provider 'claudeAgent'.",
+    );
+
+    expect(mocks.refreshProviderStatuses).not.toHaveBeenCalled();
+    expect(mocks.dispatchCommand).not.toHaveBeenCalled();
+    expect(mocks.copyTransferableComposerState).not.toHaveBeenCalled();
+    expect(mocks.getShellSnapshot).not.toHaveBeenCalled();
+    expect(mocks.syncServerShellSnapshot).not.toHaveBeenCalled();
+    expect(mocks.navigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/useThreadHandoff.ts
+++ b/apps/web/src/hooks/useThreadHandoff.ts
@@ -18,6 +18,7 @@ import {
   resolveThreadHandoffTitle,
 } from "../lib/threadHandoff";
 import { resolveProviderSendAvailabilityWithRefresh } from "../lib/providerAvailability";
+import { unsupportedProviderProfileIssue } from "../lib/providerProfileAvailability";
 import { serverSettingsQueryOptions } from "../lib/serverReactQuery";
 import { newCommandId, newThreadId } from "../lib/utils";
 import { readNativeApi } from "../nativeApi";
@@ -49,6 +50,19 @@ export function useThreadHandoff() {
     if (!canCreateThreadHandoff({ thread })) {
       throw new Error("This thread cannot be handed off yet.");
     }
+    const { copyTransferableComposerState, stickyModelSelectionByProvider } =
+      useComposerDraftStore.getState();
+    const modelSelection = resolveThreadHandoffModelSelection({
+      sourceThread: thread,
+      targetProvider,
+      projectDefaultModelSelection: project.defaultModelSelection,
+      stickyModelSelectionByProvider,
+    });
+    const profileIssue = unsupportedProviderProfileIssue(modelSelection);
+    if (profileIssue !== null) {
+      throw new Error(profileIssue);
+    }
+
     const targetAvailability = await resolveProviderSendAvailabilityWithRefresh({
       provider: targetProvider,
       statuses: providerStatuses,
@@ -73,8 +87,6 @@ export function useThreadHandoff() {
     const createdAt = new Date().toISOString();
     const importedMessages = buildThreadHandoffImportedMessages(thread);
     const importedActivities = buildThreadHandoffImportedActivities(thread);
-    const { copyTransferableComposerState, stickyModelSelectionByProvider } =
-      useComposerDraftStore.getState();
 
     await api.orchestration.dispatchCommand({
       type: "thread.handoff.create",
@@ -83,12 +95,7 @@ export function useThreadHandoff() {
       sourceThreadId: thread.id,
       projectId: thread.projectId,
       title: resolveThreadHandoffTitle(thread),
-      modelSelection: resolveThreadHandoffModelSelection({
-        sourceThread: thread,
-        targetProvider,
-        projectDefaultModelSelection: project.defaultModelSelection,
-        stickyModelSelectionByProvider,
-      }),
+      modelSelection,
       runtimeMode: thread.runtimeMode,
       interactionMode: thread.interactionMode,
       envMode: thread.envMode ?? (thread.worktreePath ? "worktree" : "local"),

--- a/apps/web/src/lib/kanbanDispatch.test.ts
+++ b/apps/web/src/lib/kanbanDispatch.test.ts
@@ -1,0 +1,99 @@
+// FILE: kanbanDispatch.test.ts
+// Purpose: Verifies Kanban draft dispatch rejects unavailable provider profiles before side effects.
+// Layer: Web orchestration helper tests
+
+import { ProjectId, ProviderProfileId, ThreadId } from "@synara/contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  resolveModelSelection: vi.fn(),
+  dispatchCommand: vi.fn(),
+  stageAttachments: vi.fn(),
+  markOptimisticDispatch: vi.fn(),
+  clearOptimisticDispatch: vi.fn(),
+  promoteThreadCreate: vi.fn(),
+  getDraftThread: vi.fn(),
+}));
+
+vi.mock("../components/kanban/kanban.logic", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../components/kanban/kanban.logic")>()),
+  buildKanbanComposerDraftSnapshot: () => ({ prompt: "Use the work account", hasAttachments: false }),
+}));
+vi.mock("../composerDraftStore", () => ({
+  resolvePreferredComposerModelSelection: harness.resolveModelSelection,
+  useComposerDraftStore: {
+    getState: () => ({
+      draftsByThreadId: { "thread-kanban-work": { prompt: "Use the work account" } },
+      getDraftThread: harness.getDraftThread,
+      clearComposerContent: vi.fn(),
+    }),
+  },
+}));
+vi.mock("../kanbanUiStore", () => ({
+  useKanbanUiStore: {
+    getState: () => ({
+      markOptimisticDispatch: harness.markOptimisticDispatch,
+      clearOptimisticDispatch: harness.clearOptimisticDispatch,
+    }),
+  },
+}));
+vi.mock("../nativeApi", () => ({
+  readNativeApi: () => ({ orchestration: { dispatchCommand: harness.dispatchCommand } }),
+}));
+vi.mock("../store", () => ({
+  useStore: { getState: () => ({ projects: [] }) },
+}));
+vi.mock("./composerSend", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./composerSend")>()),
+  stageUploadComposerAttachments: harness.stageAttachments,
+}));
+vi.mock("./threadCreatePromotion", () => ({
+  promoteThreadCreate: harness.promoteThreadCreate,
+}));
+
+import { dispatchKanbanDraftThread } from "./kanbanDispatch";
+
+const THREAD_ID = ThreadId.makeUnsafe("thread-kanban-work");
+const PROJECT_ID = ProjectId.makeUnsafe("project-kanban-work");
+
+beforeEach(() => {
+  for (const mock of [
+    harness.resolveModelSelection,
+    harness.dispatchCommand,
+    harness.stageAttachments,
+    harness.markOptimisticDispatch,
+    harness.clearOptimisticDispatch,
+    harness.promoteThreadCreate,
+    harness.getDraftThread,
+  ]) {
+    mock.mockReset();
+  }
+  harness.resolveModelSelection.mockReturnValue({
+    provider: "codex",
+    profileId: ProviderProfileId.makeUnsafe("work"),
+    model: "gpt-5.6-sol",
+  });
+});
+
+describe("dispatchKanbanDraftThread provider profiles", () => {
+  it("rejects a saved non-default draft before staging or durable UI mutations", async () => {
+    await expect(
+      dispatchKanbanDraftThread({
+        threadId: THREAD_ID,
+        projectId: PROJECT_ID,
+        thread: null,
+        defaultProvider: "codex",
+        assistantDeliveryMode: "streaming",
+      }),
+    ).resolves.toEqual({
+      kind: "error",
+      message: "Provider profile 'work' is not configured for provider 'codex'.",
+    });
+
+    expect(harness.stageAttachments).not.toHaveBeenCalled();
+    expect(harness.markOptimisticDispatch).not.toHaveBeenCalled();
+    expect(harness.promoteThreadCreate).not.toHaveBeenCalled();
+    expect(harness.dispatchCommand).not.toHaveBeenCalled();
+    expect(harness.getDraftThread).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/kanbanDispatch.ts
+++ b/apps/web/src/lib/kanbanDispatch.ts
@@ -53,6 +53,7 @@ import {
 } from "./terminalContext";
 import { resolveTerminalThreadCreationState } from "./threadBootstrap";
 import { promoteThreadCreate } from "./threadCreatePromotion";
+import { unsupportedProviderProfileIssue } from "./providerProfileAvailability";
 import { newCommandId, newMessageId } from "./utils";
 
 export type KanbanDraftDispatchResult =
@@ -151,6 +152,10 @@ async function dispatchKanbanDraftThreadOnce(
     projectModelSelection: project?.defaultModelSelection ?? null,
     defaultProvider: input.defaultProvider,
   });
+  const profileIssue = unsupportedProviderProfileIssue(modelSelection);
+  if (profileIssue !== null) {
+    return { kind: "error", message: profileIssue };
+  }
   const draftThread = composerStore.getDraftThread(threadId);
   // Worktree creation is owned by the full chat composer path. Kanban stays a
   // control surface and opens chat when a draft still needs that preflight.

--- a/apps/web/src/lib/providerDiscoveryReactQuery.ts
+++ b/apps/web/src/lib/providerDiscoveryReactQuery.ts
@@ -82,13 +82,17 @@ export const providerDiscoveryQueryKeys = {
     [...providerDiscoveryQueryKeys.agentsForProvider(provider), binaryPath, cwd] as const,
 };
 
-export function providerComposerCapabilitiesQueryOptions(provider: ProviderKind) {
+export function providerComposerCapabilitiesQueryOptions(
+  provider: ProviderKind,
+  enabled = true,
+) {
   return queryOptions({
     queryKey: providerDiscoveryQueryKeys.composerCapabilities(provider),
     queryFn: async () => {
       const api = ensureNativeApi();
       return api.provider.getComposerCapabilities({ provider });
     },
+    enabled,
     staleTime: Infinity,
   });
 }

--- a/apps/web/src/lib/providerModelPrefetch.test.ts
+++ b/apps/web/src/lib/providerModelPrefetch.test.ts
@@ -3,7 +3,12 @@
 //          the same React Query keys ChatView uses for listModels.
 // Layer: Web lib tests
 
-import type { ProviderKind } from "@synara/contracts";
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  ProviderProfileId,
+  type ModelSlug,
+  type ProviderKind,
+} from "@synara/contracts";
 import { QueryClient } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -12,6 +17,7 @@ import {
   providerModelsPrefetchQueryOptions,
   resolveNewThreadModelPrefetchCwd,
   resolveNewThreadModelPrefetchProvider,
+  resolveNewThreadModelPrefetchTarget,
   type ProviderModelPrefetchSettings,
 } from "./providerModelPrefetch";
 import { providerDiscoveryQueryKeys } from "./providerDiscoveryReactQuery";
@@ -72,6 +78,92 @@ describe("resolveNewThreadModelPrefetchProvider", () => {
         defaultProvider: "claudeAgent",
       }),
     ).toBe("claudeAgent");
+  });
+});
+
+describe("resolveNewThreadModelPrefetchTarget", () => {
+  const projectSelection = {
+    provider: "codex",
+    profileId: ProviderProfileId.makeUnsafe("project"),
+    model: "project-model" as ModelSlug,
+  } as const;
+  const stickySelection = {
+    provider: "codex",
+    profileId: ProviderProfileId.makeUnsafe("sticky"),
+    model: "sticky-model" as ModelSlug,
+  } as const;
+  const draftSelection = {
+    provider: "codex",
+    profileId: ProviderProfileId.makeUnsafe("draft"),
+    model: "draft-model" as ModelSlug,
+  } as const;
+
+  it("resolves the selected provider profile with draft, sticky, then project precedence", () => {
+    const common = {
+      draftActiveProvider: "codex" as const,
+      stickyActiveProvider: "codex" as const,
+      projectDefaultModelSelection: projectSelection,
+      defaultProvider: "claudeAgent" as const,
+    };
+
+    expect(
+      resolveNewThreadModelPrefetchTarget({
+        ...common,
+        draftModelSelectionByProvider: { codex: draftSelection },
+        stickyModelSelectionByProvider: { codex: stickySelection },
+      }),
+    ).toEqual({
+      provider: "codex",
+      modelSelection: draftSelection,
+      targetExecutable: false,
+    });
+    expect(
+      resolveNewThreadModelPrefetchTarget({
+        ...common,
+        stickyModelSelectionByProvider: { codex: stickySelection },
+      }).modelSelection,
+    ).toEqual(stickySelection);
+    expect(resolveNewThreadModelPrefetchTarget(common).modelSelection).toEqual(projectSelection);
+  });
+
+  it("feeds an unsupported resolved profile into the prefetch fail-closed gate", () => {
+    const queryClient = new QueryClient();
+    const prefetchQuery = vi.spyOn(queryClient, "prefetchQuery").mockResolvedValue(undefined);
+    const target = resolveNewThreadModelPrefetchTarget({
+      draftActiveProvider: "codex",
+      defaultProvider: "claudeAgent",
+      draftModelSelectionByProvider: { codex: draftSelection },
+    });
+
+    prefetchProviderModelsForNewThread(queryClient, {
+      provider: target.provider,
+      targetExecutable: target.targetExecutable,
+      settings: makeSettings(),
+      cwd: "/repo",
+    });
+
+    expect(prefetchQuery).not.toHaveBeenCalled();
+  });
+
+  it("treats a missing or default selection as executable", () => {
+    expect(
+      resolveNewThreadModelPrefetchTarget({
+        defaultProvider: "codex",
+      }).targetExecutable,
+    ).toBe(true);
+    expect(
+      resolveNewThreadModelPrefetchTarget({
+        draftActiveProvider: "codex",
+        defaultProvider: "claudeAgent",
+        draftModelSelectionByProvider: {
+          codex: {
+            provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
+            model: "gpt-5.6-sol" as ModelSlug,
+          },
+        },
+      }).targetExecutable,
+    ).toBe(true);
   });
 });
 
@@ -171,6 +263,7 @@ describe("prefetchProviderModelsForNewThread", () => {
 
     prefetchProviderModelsForNewThread(queryClient, {
       provider: "kilo" satisfies ProviderKind,
+      targetExecutable: true,
       settings: makeSettings({
         kiloBinaryPath: "/bin/kilo",
       }),
@@ -195,6 +288,7 @@ describe("prefetchProviderModelsForNewThread", () => {
 
     prefetchProviderModelsForNewThread(queryClient, {
       provider: "cursor",
+      targetExecutable: true,
       settings: makeSettings({ cursorBinaryPath: "/bin/agent" }),
     });
 
@@ -205,5 +299,18 @@ describe("prefetchProviderModelsForNewThread", () => {
     expect(prefetchQuery.mock.calls[1]?.[0].queryKey).toEqual(
       providerDiscoveryQueryKeys.composerCapabilities("cursor"),
     );
+  });
+
+  it("does not prefetch through the default account for an unavailable target", () => {
+    const queryClient = new QueryClient();
+    const prefetchQuery = vi.spyOn(queryClient, "prefetchQuery").mockResolvedValue(undefined);
+
+    prefetchProviderModelsForNewThread(queryClient, {
+      provider: "codex",
+      targetExecutable: false,
+      settings: makeSettings(),
+    });
+
+    expect(prefetchQuery).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/providerModelPrefetch.ts
+++ b/apps/web/src/lib/providerModelPrefetch.ts
@@ -6,7 +6,11 @@
 // Layer: Web lib
 // Exports: resolve + prefetch helpers that mirror ChatView's listModels query keys.
 
-import type { ProviderKind } from "@synara/contracts";
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  type ModelSelection,
+  type ProviderKind,
+} from "@synara/contracts";
 import type { QueryClient } from "@tanstack/react-query";
 
 import type { AppSettings } from "../appSettings";
@@ -44,6 +48,42 @@ export function resolveNewThreadModelPrefetchProvider(input: {
     input.defaultProvider ??
     "codex"
   );
+}
+
+export function resolveNewThreadModelPrefetchTarget(input: {
+  draftActiveProvider?: ProviderKind | null | undefined;
+  stickyActiveProvider?: ProviderKind | null | undefined;
+  projectDefaultModelSelection?: ModelSelection | null | undefined;
+  defaultProvider: ProviderKind;
+  draftModelSelectionByProvider?: Partial<Record<ProviderKind, ModelSelection>> | undefined;
+  stickyModelSelectionByProvider?: Partial<Record<ProviderKind, ModelSelection>> | undefined;
+}): {
+  readonly provider: ProviderKind;
+  readonly modelSelection: ModelSelection | null;
+  readonly targetExecutable: boolean;
+} {
+  const provider = resolveNewThreadModelPrefetchProvider({
+    draftActiveProvider: input.draftActiveProvider,
+    stickyActiveProvider: input.stickyActiveProvider,
+    projectDefaultProvider: input.projectDefaultModelSelection?.provider ?? null,
+    defaultProvider: input.defaultProvider,
+  });
+  const draftSelection = input.draftModelSelectionByProvider?.[provider];
+  const stickySelection = input.stickyModelSelectionByProvider?.[provider];
+  const modelSelection =
+    (draftSelection?.provider === provider ? draftSelection : null) ??
+    (stickySelection?.provider === provider ? stickySelection : null) ??
+    (input.projectDefaultModelSelection?.provider === provider
+      ? input.projectDefaultModelSelection
+      : null);
+
+  return {
+    provider,
+    modelSelection,
+    targetExecutable:
+      (modelSelection?.profileId ?? DEFAULT_PROVIDER_PROFILE_ID) ===
+      DEFAULT_PROVIDER_PROFILE_ID,
+  };
 }
 
 export function resolveNewThreadModelPrefetchCwd(input: {
@@ -154,10 +194,14 @@ export function prefetchProviderModelsForNewThread(
   queryClient: QueryClient,
   input: {
     provider: ProviderKind;
+    targetExecutable: boolean;
     settings: ProviderModelPrefetchSettings;
     cwd?: string | null;
   },
 ): void {
+  if (!input.targetExecutable) {
+    return;
+  }
   const cwd = input.cwd ?? null;
   void queryClient.prefetchQuery(
     providerModelsPrefetchQueryOptions({

--- a/apps/web/src/lib/providerProfileAvailability.ts
+++ b/apps/web/src/lib/providerProfileAvailability.ts
@@ -1,0 +1,10 @@
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  type ProviderTarget,
+} from "@synara/contracts";
+
+export function unsupportedProviderProfileIssue(target: ProviderTarget): string | null {
+  return target.profileId === DEFAULT_PROVIDER_PROFILE_ID
+    ? null
+    : `Provider profile '${target.profileId}' is not configured for provider '${target.provider}'.`;
+}

--- a/apps/web/src/routes/-automations.shared.test.tsx
+++ b/apps/web/src/routes/-automations.shared.test.tsx
@@ -10,6 +10,7 @@ import {
   CommandId,
   MessageId,
   ProjectId,
+  ProviderProfileId,
   ThreadId,
   DEFAULT_AUTOMATION_STOP_CONFIDENCE_THRESHOLD,
   type AutomationDefinition,
@@ -459,19 +460,11 @@ describe("automation shared route helpers", () => {
     const projects = [
       {
         id: projectId("project-old"),
-        defaultModelSelection: {
-          provider: "codex",
-          profileId: DEFAULT_PROVIDER_PROFILE_ID,
-          model: "gpt-5-codex",
-        },
+        defaultModelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
       },
       {
         id: projectId("project-new"),
-        defaultModelSelection: {
-          provider: "claudeAgent",
-          profileId: DEFAULT_PROVIDER_PROFILE_ID,
-          model: "sonnet",
-        },
+        defaultModelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "sonnet" },
       },
     ] as Parameters<typeof modelSelectionForProjectChange>[0];
 
@@ -492,19 +485,11 @@ describe("automation shared route helpers", () => {
     const projects = [
       {
         id: projectId("project-old"),
-        defaultModelSelection: {
-          provider: "codex",
-          profileId: DEFAULT_PROVIDER_PROFILE_ID,
-          model: "gpt-5-codex",
-        },
+        defaultModelSelection: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "gpt-5-codex" },
       },
       {
         id: projectId("project-new"),
-        defaultModelSelection: {
-          provider: "claudeAgent",
-          profileId: DEFAULT_PROVIDER_PROFILE_ID,
-          model: "sonnet",
-        },
+        defaultModelSelection: { provider: "claudeAgent", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "sonnet" },
       },
     ] as Parameters<typeof modelSelectionForProjectChange>[0];
 
@@ -658,11 +643,7 @@ describe("automation shared route helpers", () => {
       cursor: { binaryPath: "/current/cursor", apiEndpoint: "http://cursor.example" },
     };
     const definition = definitionWith({
-      modelSelection: {
-        provider: "opencode",
-        profileId: DEFAULT_PROVIDER_PROFILE_ID,
-        model: "openai/gpt-5",
-      },
+      modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5" },
       providerOptions: savedProviderOptions,
     });
     const nextModelSelection = {
@@ -711,13 +692,38 @@ describe("automation shared route helpers", () => {
     ).toEqual(savedProviderOptions);
   });
 
-  it("clears stale provider options when an automation edit changes models without current options", () => {
+  it("does not reuse saved provider options across profiles of the same provider and model", () => {
+    const savedProviderOptions: ProviderStartOptions = {
+      codex: { binaryPath: "/old/codex", homePath: "/old/home" },
+    };
+    const currentProviderOptions: ProviderStartOptions = {
+      codex: { binaryPath: "/new/codex", homePath: "/new/home" },
+    };
     const definition = definitionWith({
       modelSelection: {
-        provider: "opencode",
-        profileId: DEFAULT_PROVIDER_PROFILE_ID,
-        model: "openai/gpt-5",
+        provider: "codex",
+        profileId: ProviderProfileId.makeUnsafe("personal"),
+        model: "gpt-5-codex",
       },
+      providerOptions: savedProviderOptions,
+    });
+
+    expect(
+      providerOptionsForAutomationModelSelection(
+        definition,
+        {
+          provider: "codex",
+          profileId: ProviderProfileId.makeUnsafe("work"),
+          model: "gpt-5-codex",
+        },
+        currentProviderOptions,
+      ),
+    ).toEqual(currentProviderOptions);
+  });
+
+  it("clears stale provider options when an automation edit changes models without current options", () => {
+    const definition = definitionWith({
+      modelSelection: { provider: "opencode", profileId: DEFAULT_PROVIDER_PROFILE_ID, model: "openai/gpt-5" },
       providerOptions: {
         opencode: { binaryPath: "/old/opencode", serverUrl: "http://old.example" },
       },

--- a/apps/web/src/routes/-automations.shared.tsx
+++ b/apps/web/src/routes/-automations.shared.tsx
@@ -100,7 +100,8 @@ import { findProviderStatus } from "~/lib/providerAvailability";
 import { cn } from "~/lib/utils";
 import { serverConfigQueryOptions } from "~/lib/serverReactQuery";
 import { ensureNativeApi } from "~/nativeApi";
-import { buildModelSelection } from "~/providerModelOptions";
+import { DEFAULT_PROVIDER_PROFILE_ID } from "@synara/contracts";
+import { buildModelSelectionForTarget } from "~/providerModelOptions";
 import { useProviderModelCatalog } from "~/hooks/useProviderModelCatalog";
 import { useProviderStatusesForLocalConfig } from "~/hooks/useProviderStatusesForLocalConfig";
 import { useStore } from "~/store";
@@ -863,6 +864,7 @@ export function AutomationModelPicker({
     selectedRuntimeModel,
   } = useProviderModelCatalog({
     selectedProvider: value.provider,
+    targetExecutable: value.profileId === DEFAULT_PROVIDER_PROFILE_ID,
     discoveryEnabled: open,
     cwd: providerModelDiscoveryCwd,
     modelHintByProvider,
@@ -904,7 +906,19 @@ export function AutomationModelPicker({
           model,
           runtimeModels: runtimeModelsByProvider[provider],
         });
-        onChange(buildModelSelection(provider, model, undefined, runtimeModel?.supportsAutoMode));
+        onChange(
+          buildModelSelectionForTarget({
+            target: {
+              provider,
+              profileId:
+                provider === value.provider
+                  ? value.profileId
+                  : DEFAULT_PROVIDER_PROFILE_ID,
+            },
+            model,
+            supportsAutoMode: runtimeModel?.supportsAutoMode,
+          }),
+        );
       }}
     />
   );

--- a/apps/web/src/routes/_chat.automations.$automationId.tsx
+++ b/apps/web/src/routes/_chat.automations.$automationId.tsx
@@ -50,7 +50,7 @@ import {
 import { CentralIcon } from "~/lib/central-icons";
 import { cn } from "~/lib/utils";
 import {
-  buildModelSelection,
+  buildModelSelectionForTarget,
   buildNextProviderOptions,
   buildProviderOptionPatch,
   type ProviderOptions,
@@ -1023,12 +1023,18 @@ function ModelOptionRows({
       optionPatch,
     );
     onChange(
-      buildModelSelection(
-        provider,
+      buildModelSelectionForTarget({
+        target: {
+          provider,
+          profileId: modelSelection.profileId,
+        },
         model,
-        nextOptions,
-        modelSelection.provider === "claudeAgent" ? modelSelection.supportsAutoMode : undefined,
-      ),
+        options: nextOptions,
+        supportsAutoMode:
+          modelSelection.provider === "claudeAgent"
+            ? modelSelection.supportsAutoMode
+            : undefined,
+      }),
     );
   };
 


### PR DESCRIPTION
## Summary

Extends the provider-target guard into web entry points:

- keys discovery, model catalogs, and prefetching by complete provider target
- preserves the thread's locked provider/profile selection
- blocks unavailable profiles in chat, automations, Kanban, slash commands, handoff, and related submit paths
- prevents stale drafts or cached options from another profile being reused
- shows an unavailable target instead of silently falling back to `default`

## Stack

Depends on #621, #620, and #619.  
Base: `codex/provider-profiles-03-server-guards` at `cc4e1f543`  
Head: `c72e49577`

This PR depends on the complete coupled foundation in PRs 1–3 and must merge after them.

## Replacement for #254

This rebuilds the product-facing safeguards from #254 around the current composer, discovery, automation, and Kanban architecture. Reusing the old UI code would miss several modern send paths and cache boundaries.

#254 remains open as historical design and UX context; this PR does not close it.

## Safety and compatibility

- Existing default-profile flows remain unchanged.
- Persisted unavailable targets are preserved and explained rather than rewritten.
- Actions fail closed before dispatch, preventing accidental execution through a different account.
- Discovery and option caches cannot leak between profiles of the same provider.

## Validation

- The tree at `c72e49577` exactly matches immutable snapshot `56af6f089`.
- Web node suite: 304 files passed; 3,816/3,816 tests passed.
- Contracts: 206/206 passed.
- Shared: 538 passed, 1 skipped.
- Targeted provider-profile browser tests and compiler hot path: 12/12 passed.
- Slice and stack-top diff checks passed.

The full browser suite is **not** reported as green: it also produced 8 unchanged virtualization-geometry assertion failures and one flaky render-count failure.

`bun fmt`, `bun lint`, and `bun typecheck` were not run because repository policy requires explicit user permission; permission is pending.
