### PR TITLE
feat(server): add managed Codex profile registry

### DIFF
--- a/apps/server/src/provider/Layers/ProviderProfileRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderProfileRegistry.test.ts
@@ -1,0 +1,480 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { DEFAULT_PROVIDER_PROFILE_ID, type CodexProviderTarget } from "@synara/contracts";
+import { Effect, Layer } from "effect";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ServerConfig } from "../../config";
+import { ServerSettingsService } from "../../serverSettings";
+import {
+  ProviderProfileRegistry,
+  ProviderProfileRegistryError,
+} from "../Services/ProviderProfileRegistry";
+import { ProviderProfileRegistryLive } from "./ProviderProfileRegistry";
+
+const temporaryRoots: string[] = [];
+
+function makeBaseDir(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "synara-provider-profiles-test-"));
+  temporaryRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function makeLayer(
+  baseDir: string,
+  codexSettings: {
+    readonly enabled?: boolean;
+    readonly binaryPath?: string;
+    readonly homePath?: string;
+  } = {},
+) {
+  const configLayer = ServerConfig.layerTest(process.cwd(), baseDir).pipe(
+    Layer.provide(NodeServices.layer),
+  );
+  const settingsLayer = ServerSettingsService.layerTest({
+    providers: { codex: { enabled: true, ...codexSettings } },
+  });
+  const dependencies = Layer.merge(configLayer, settingsLayer);
+  return Layer.merge(
+    dependencies,
+    ProviderProfileRegistryLive.pipe(Layer.provide(dependencies)),
+  );
+}
+
+function runWithRegistry<A, E>(
+  baseDir: string,
+  effect: Effect.Effect<A, E, ProviderProfileRegistry | ServerConfig>,
+  codexSettings: {
+    readonly enabled?: boolean;
+    readonly binaryPath?: string;
+    readonly homePath?: string;
+  } = {},
+) {
+  return Effect.runPromise(
+    effect.pipe(Effect.provide(makeLayer(baseDir, codexSettings)), Effect.scoped),
+  );
+}
+
+function storedProfile(profileId: string, storageKey: string) {
+  return {
+    profileId,
+    storageKey,
+    displayName: profileId,
+    enabled: false,
+    createdAt: "2026-08-10T00:00:00.000Z",
+    updatedAt: "2026-08-10T00:00:00.000Z",
+    tombstonedAt: null,
+  };
+}
+
+describe("ProviderProfileRegistryLive", () => {
+  it("lists the implicit legacy default without persisting it", async () => {
+    const baseDir = makeBaseDir();
+
+    const result = await runWithRegistry(
+      baseDir,
+      Effect.gen(function* () {
+        const registry = yield* ProviderProfileRegistry;
+        const config = yield* ServerConfig;
+        return {
+          snapshot: yield* registry.list({ provider: "codex" }),
+          indexPath: path.join(config.stateDir, "provider-profiles", "index.json"),
+          resolution: yield* registry.resolveForRuntime({
+            provider: "codex",
+            profileId: DEFAULT_PROVIDER_PROFILE_ID,
+          }),
+        };
+      }),
+      { binaryPath: "/opt/codex", homePath: "/source/codex-home" },
+    );
+
+    expect(result.snapshot).toEqual({
+      providerEnabled: true,
+      profiles: [
+        {
+          target: { provider: "codex", profileId: "default" },
+          displayName: "Default",
+          enabled: true,
+          lifecycle: "active",
+          storageKind: "legacy-default",
+        },
+      ],
+    });
+    expect(fs.existsSync(result.indexPath)).toBe(false);
+    expect(result.resolution.launchContext).toEqual({
+      target: { provider: "codex", profileId: "default" },
+      binaryPath: "/opt/codex",
+      settingsRevision: 0,
+      registryRevision: 0,
+      home: { strategy: "legacy-overlay", sourceHomePath: "/source/codex-home" },
+    });
+    expect(Object.isFrozen(result.resolution.launchContext)).toBe(true);
+    expect(Object.isFrozen(result.resolution.launchContext.home)).toBe(true);
+  });
+
+  it("creates an isolated disabled profile and resolves separate managed homes after enable", async () => {
+    const baseDir = makeBaseDir();
+    const sourceHome = path.join(baseDir, "source-codex-home");
+    fs.mkdirSync(sourceHome, { recursive: true });
+    fs.writeFileSync(path.join(sourceHome, "auth.json"), "source-secret", { mode: 0o600 });
+    fs.writeFileSync(path.join(sourceHome, "config.toml"), "model = \"source\"\n", {
+      mode: 0o600,
+    });
+
+    const result = await runWithRegistry(
+      baseDir,
+      Effect.gen(function* () {
+        const registry = yield* ProviderProfileRegistry;
+        const created = yield* registry.create({ provider: "codex", displayName: "Work" });
+        const managed = created.profiles[1]!;
+        const managementResolution = yield* registry.resolveForManagement(managed.target);
+        if (managementResolution.launchContext.home.strategy !== "managed-direct") {
+          throw new Error("Expected a managed Codex launch context");
+        }
+        fs.writeFileSync(
+          path.join(managementResolution.launchContext.home.codexHomePath, "config.toml"),
+          "model = \"managed\"\n",
+          { mode: 0o600 },
+        );
+        fs.rmSync(managementResolution.launchContext.home.codexSqliteHomePath, {
+          recursive: true,
+          force: true,
+        });
+        const disabledError = yield* registry.resolveForRuntime(managed.target).pipe(Effect.flip);
+        const disabledRuntimeCreatedStorage = fs.existsSync(
+          managementResolution.launchContext.home.codexSqliteHomePath,
+        );
+        const enabled = yield* registry.setEnabled({ target: managed.target, enabled: true });
+        const runtimeResolution = yield* registry.resolveForRuntime(managed.target);
+        return {
+          created,
+          managementResolution,
+          disabledError,
+          disabledRuntimeCreatedStorage,
+          enabled,
+          runtimeResolution,
+        };
+      }),
+      { binaryPath: "/opt/codex", homePath: sourceHome },
+    );
+
+    expect(result.created.profiles[1]).toMatchObject({
+      displayName: "Work",
+      enabled: false,
+      lifecycle: "active",
+      storageKind: "managed",
+    });
+    expect(result.disabledError.code).toBe("PROVIDER_PROFILE_DISABLED");
+    expect(result.disabledRuntimeCreatedStorage).toBe(false);
+    expect(result.enabled.profiles[1]?.enabled).toBe(true);
+
+    const persistedRegistry = JSON.parse(
+      fs.readFileSync(path.join(baseDir, "userdata", "provider-profiles", "index.json"), "utf8"),
+    ) as { profiles: Array<{ profileId: string; storageKey: string }> };
+    const persistedProfile = persistedRegistry.profiles[0]!;
+    expect(persistedProfile.profileId).toBe(result.created.profiles[1]!.target.profileId);
+    expect(persistedProfile.profileId).not.toBe(
+      `codex_${persistedProfile.storageKey.replaceAll("-", "")}`,
+    );
+    expect(JSON.stringify(result.created)).not.toContain(persistedProfile.storageKey);
+
+    expect(result.managementResolution.summary.enabled).toBe(false);
+    expect(result.managementResolution.launchContext.registryRevision).toBe(1);
+    expect(result.runtimeResolution.launchContext.registryRevision).toBe(2);
+    expect(result.managementResolution.launchContext.home).toEqual(
+      result.runtimeResolution.launchContext.home,
+    );
+    const launchContext = result.runtimeResolution.launchContext;
+    expect(launchContext.home.strategy).toBe("managed-direct");
+    if (launchContext.home.strategy !== "managed-direct") {
+      throw new Error("Expected a managed Codex launch context");
+    }
+    expect(launchContext.home.codexHomePath).not.toBe(sourceHome);
+    expect(launchContext.home.codexSqliteHomePath).not.toBe(launchContext.home.codexHomePath);
+    expect(fs.readdirSync(launchContext.home.codexHomePath)).toEqual(["config.toml"]);
+    expect(
+      fs.readFileSync(path.join(launchContext.home.codexHomePath, "config.toml"), "utf8"),
+    ).toBe('model = "managed"\n');
+    expect(fs.readdirSync(launchContext.home.codexSqliteHomePath)).toEqual([]);
+    expect(fs.readFileSync(path.join(sourceHome, "auth.json"), "utf8")).toBe("source-secret");
+    expect(fs.existsSync(path.join(launchContext.home.codexHomePath, "auth.json"))).toBe(false);
+    expect(Object.isFrozen(launchContext)).toBe(true);
+    expect(Object.isFrozen(launchContext.target)).toBe(true);
+
+    if (process.platform !== "win32") {
+      const profileRoot = path.dirname(launchContext.home.codexHomePath);
+      const codexProfilesRoot = path.dirname(profileRoot);
+      const profilesRoot = path.dirname(codexProfilesRoot);
+      for (const directoryPath of [
+        profilesRoot,
+        codexProfilesRoot,
+        profileRoot,
+        launchContext.home.codexHomePath,
+        launchContext.home.codexSqliteHomePath,
+      ]) {
+        expect(fs.statSync(directoryPath).mode & 0o777).toBe(0o700);
+      }
+      expect(
+        fs.statSync(path.join(launchContext.home.codexHomePath, "config.toml")).mode & 0o777,
+      ).toBe(0o600);
+      expect(fs.statSync(path.join(profilesRoot, "index.json")).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("persists rename, enable, and terminal tombstones across service instances", async () => {
+    const baseDir = makeBaseDir();
+    let profileId = "";
+
+    await runWithRegistry(
+      baseDir,
+      Effect.gen(function* () {
+        const registry = yield* ProviderProfileRegistry;
+        const created = yield* registry.create({ provider: "codex", displayName: "Work" });
+        const target = created.profiles[1]!.target;
+        profileId = target.profileId;
+        const conflict = yield* registry
+          .create({ provider: "codex", displayName: "work" })
+          .pipe(Effect.flip);
+        expect(conflict.code).toBe("PROVIDER_PROFILE_NAME_CONFLICT");
+        expect((yield* registry.list({ provider: "codex" })).profiles).toHaveLength(2);
+        yield* registry.rename({ target, displayName: "Client" });
+        yield* registry.setEnabled({ target, enabled: true });
+        const activeResolution = yield* registry.resolveForManagement(target);
+        if (activeResolution.launchContext.home.strategy !== "managed-direct") {
+          throw new Error("Expected a managed Codex launch context");
+        }
+        const retainedProfileRoot = path.dirname(activeResolution.launchContext.home.codexHomePath);
+        const tombstoned = yield* registry.tombstone({ target });
+        const indexPath = path.join(baseDir, "userdata", "provider-profiles", "index.json");
+        const persistedTombstone = fs.readFileSync(indexPath, "utf8");
+        const repeated = yield* registry.tombstone({ target });
+        expect(repeated).toEqual(tombstoned);
+        expect(fs.readFileSync(indexPath, "utf8")).toBe(persistedTombstone);
+        expect(fs.existsSync(retainedProfileRoot)).toBe(true);
+        const managementError = yield* registry.resolveForManagement(target).pipe(Effect.flip);
+        expect(managementError.code).toBe("PROVIDER_PROFILE_TOMBSTONED");
+      }),
+    );
+
+    const persistedIndexPath = path.join(
+      baseDir,
+      "userdata",
+      "provider-profiles",
+      "index.json",
+    );
+    if (process.platform !== "win32") fs.chmodSync(persistedIndexPath, 0o644);
+
+    const reloaded = await runWithRegistry(
+      baseDir,
+      Effect.gen(function* () {
+        const registry = yield* ProviderProfileRegistry;
+        return yield* registry.list({ provider: "codex" });
+      }),
+    );
+
+    expect(reloaded.profiles[1]).toEqual({
+      target: { provider: "codex", profileId },
+      displayName: "Client",
+      enabled: false,
+      lifecycle: "tombstoned",
+      storageKind: "managed",
+    });
+    if (process.platform !== "win32") {
+      expect(fs.statSync(persistedIndexPath).mode & 0o777).toBe(0o600);
+    }
+
+    const replacement = await runWithRegistry(
+      baseDir,
+      Effect.gen(function* () {
+        const registry = yield* ProviderProfileRegistry;
+        return yield* registry.create({ provider: "codex", displayName: "Client" });
+      }),
+    );
+    expect(replacement.profiles[2]!.target.profileId).not.toBe(profileId);
+  });
+
+  it("keeps the global Codex switch separate from each profile's administrative switch", async () => {
+    const baseDir = makeBaseDir();
+    let target: CodexProviderTarget | undefined;
+
+    await runWithRegistry(
+      baseDir,
+      Effect.gen(function* () {
+        const registry = yield* ProviderProfileRegistry;
+        const created = yield* registry.create({ provider: "codex", displayName: "Work" });
+        const createdTarget = created.profiles[1]!.target;
+        target = createdTarget;
+        yield* registry.setEnabled({ target: createdTarget, enabled: true });
+      }),
+    );
+
+    const result = await runWithRegistry(
+      baseDir,
+      Effect.gen(function* () {
+        const registry = yield* ProviderProfileRegistry;
+        const snapshot = yield* registry.list({ provider: "codex" });
+        const managementResolution = yield* registry.resolveForManagement(target!);
+        const runtimeError = yield* registry.resolveForRuntime(target!).pipe(Effect.flip);
+        return { snapshot, managementResolution, runtimeError };
+      }),
+      { enabled: false },
+    );
+
+    expect(result.snapshot.providerEnabled).toBe(false);
+    expect(result.snapshot.profiles.map((profile) => profile.enabled)).toEqual([true, true]);
+    expect(result.managementResolution.providerEnabled).toBe(false);
+    expect(result.runtimeError.code).toBe("PROVIDER_PROFILE_DISABLED");
+  });
+
+  it("rejects default mutation and corrupt registries without exposing private paths", async () => {
+    const baseDir = makeBaseDir();
+    const defaultTarget = { provider: "codex" as const, profileId: DEFAULT_PROVIDER_PROFILE_ID };
+
+    const defaultMutations = await runWithRegistry(
+      baseDir,
+      Effect.gen(function* () {
+        const registry = yield* ProviderProfileRegistry;
+        return yield* Effect.all([
+          registry.rename({ target: defaultTarget, displayName: "Changed" }).pipe(Effect.flip),
+          registry.setEnabled({ target: defaultTarget, enabled: false }).pipe(Effect.flip),
+          registry.tombstone({ target: defaultTarget }).pipe(Effect.flip),
+        ]);
+      }),
+    );
+    expect(defaultMutations.map((error) => error.code)).toEqual([
+      "PROVIDER_PROFILE_DEFAULT_IMMUTABLE",
+      "PROVIDER_PROFILE_DEFAULT_IMMUTABLE",
+      "PROVIDER_PROFILE_DEFAULT_IMMUTABLE",
+    ]);
+
+    const indexPath = path.join(baseDir, "userdata", "provider-profiles", "index.json");
+    fs.mkdirSync(path.dirname(indexPath), { recursive: true });
+    fs.writeFileSync(indexPath, '{"version":999,"revision":0,"profiles":[]}', { mode: 0o600 });
+
+    const corruptResult = await runWithRegistry(
+      baseDir,
+      Effect.gen(function* () {
+        const registry = yield* ProviderProfileRegistry;
+        return yield* registry.list({ provider: "codex" });
+      }).pipe(Effect.flip),
+    );
+    expect(corruptResult).toBeInstanceOf(ProviderProfileRegistryError);
+    expect(corruptResult.code).toBe("PROVIDER_PROFILE_REGISTRY_INVALID");
+    expect(corruptResult.message).not.toContain(baseDir);
+    expect(fs.readFileSync(indexPath, "utf8")).toContain('"version":999');
+  });
+
+  it.each([
+    [
+      "duplicate profile ids",
+      [
+        storedProfile("codex_one", "11111111-1111-4111-8111-111111111111"),
+        storedProfile("codex_one", "22222222-2222-4222-8222-222222222222"),
+      ],
+    ],
+    [
+      "duplicate storage keys",
+      [
+        storedProfile("codex_one", "11111111-1111-4111-8111-111111111111"),
+        storedProfile("codex_two", "11111111-1111-4111-8111-111111111111"),
+      ],
+    ],
+    [
+      "duplicate active display names",
+      [
+        {
+          ...storedProfile("codex_one", "11111111-1111-4111-8111-111111111111"),
+          displayName: "Work",
+        },
+        {
+          ...storedProfile("codex_two", "22222222-2222-4222-8222-222222222222"),
+          displayName: "work",
+        },
+      ],
+    ],
+    [
+      "an enabled tombstone",
+      [
+        {
+          ...storedProfile("codex_one", "11111111-1111-4111-8111-111111111111"),
+          enabled: true,
+          tombstonedAt: "2026-08-10T01:00:00.000Z",
+        },
+      ],
+    ],
+    [
+      "an active profile named Default",
+      [
+        {
+          ...storedProfile("codex_one", "11111111-1111-4111-8111-111111111111"),
+          displayName: "DEFAULT",
+        },
+      ],
+    ],
+    ["an unsafe storage key", [storedProfile("codex_one", "../../legacy-codex-home")]],
+  ])("fails closed on %s without rewriting the registry", async (_label, profiles) => {
+    const baseDir = makeBaseDir();
+    const indexPath = path.join(baseDir, "userdata", "provider-profiles", "index.json");
+    fs.mkdirSync(path.dirname(indexPath), { recursive: true, mode: 0o700 });
+    const invalidContents = `${JSON.stringify({ version: 1, revision: 7, profiles }, null, 2)}\n`;
+    fs.writeFileSync(indexPath, invalidContents, { mode: 0o600 });
+
+    const error = await runWithRegistry(
+      baseDir,
+      Effect.gen(function* () {
+        const registry = yield* ProviderProfileRegistry;
+        return yield* registry.list({ provider: "codex" });
+      }).pipe(Effect.flip),
+    );
+
+    expect(error.code).toBe("PROVIDER_PROFILE_REGISTRY_INVALID");
+    expect(fs.readFileSync(indexPath, "utf8")).toBe(invalidContents);
+  });
+
+  it("leaves an inert private orphan instead of publishing a profile when index persistence fails", async () => {
+    const baseDir = makeBaseDir();
+    const profilesRoot = path.join(baseDir, "userdata", "provider-profiles");
+    const indexPath = path.join(profilesRoot, "index.json");
+
+    const result = await runWithRegistry(
+      baseDir,
+      Effect.gen(function* () {
+        const registry = yield* ProviderProfileRegistry;
+        yield* registry.list({ provider: "codex" });
+        yield* Effect.sync(() => fs.mkdirSync(indexPath, { recursive: true, mode: 0o700 }));
+        const error = yield* registry
+          .create({ provider: "codex", displayName: "Work" })
+          .pipe(Effect.flip);
+        const snapshot = yield* registry.list({ provider: "codex" });
+        return { error, snapshot };
+      }),
+    );
+
+    expect(result.error.code).toBe("PROVIDER_PROFILE_STORAGE_ERROR");
+    expect(result.error.message).not.toContain(baseDir);
+    expect(result.snapshot.profiles.map((profile) => profile.target.profileId)).toEqual([
+      "default",
+    ]);
+    expect(fs.statSync(indexPath).isDirectory()).toBe(true);
+    const storageKeys = fs.readdirSync(path.join(profilesRoot, "codex"));
+    expect(storageKeys).toHaveLength(1);
+    const orphanRoot = path.join(profilesRoot, "codex", storageKeys[0]!);
+    expect(fs.readdirSync(path.join(orphanRoot, "home"))).toEqual(["config.toml"]);
+    expect(fs.readdirSync(path.join(orphanRoot, "sqlite"))).toEqual([]);
+    expect(fs.readdirSync(profilesRoot).sort()).toEqual(["codex", "index.json"]);
+
+    if (process.platform !== "win32") {
+      expect(fs.statSync(orphanRoot).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(path.join(orphanRoot, "home", "config.toml")).mode & 0o777).toBe(0o600);
+    }
+  });
+});

--- a/apps/server/src/provider/Layers/ProviderProfileRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderProfileRegistry.ts
@@ -1,0 +1,591 @@
+import { randomUUID } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import * as fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  DEFAULT_PROVIDER_PROFILE_ID,
+  NonNegativeInt,
+  ProviderProfileDisplayName,
+  ProviderProfileId,
+  type CodexProviderProfileSummary,
+  type CodexServerProviderSettings,
+  type CodexProviderTarget,
+  type ProviderProfilesSnapshot,
+} from "@synara/contracts";
+import { Effect, Layer, Ref, Schema } from "effect";
+import * as Semaphore from "effect/Semaphore";
+
+import { writeFileStringAtomically } from "../../atomicWrite";
+import { ServerConfig } from "../../config";
+import {
+  PRIVATE_FILE_MODE,
+  supportsPosixPermissions,
+} from "../../privatePathPermissions";
+import { ServerSettingsService } from "../../serverSettings";
+import {
+  materializeCodexManagedProfileHome,
+  isCodexProfileStorageKey,
+} from "../codexManagedProfileHome";
+import {
+  makeLegacyCodexLaunchContext,
+  makeManagedCodexLaunchContext,
+} from "../codexProviderLaunchContext";
+import {
+  ProviderProfileRegistry,
+  ProviderProfileRegistryError,
+  type ProviderProfileRegistryErrorCode,
+  type ProviderProfileRegistryShape,
+} from "../Services/ProviderProfileRegistry";
+
+const REGISTRY_VERSION = 1;
+const DEFAULT_PROFILE_DISPLAY_NAME = "Default";
+
+const StorageKey = Schema.String.check(Schema.isPattern(/^[0-9a-f-]{36}$/u));
+
+const StoredCodexProfile = Schema.Struct({
+  profileId: ProviderProfileId,
+  storageKey: StorageKey,
+  displayName: ProviderProfileDisplayName,
+  enabled: Schema.Boolean,
+  createdAt: Schema.String,
+  updatedAt: Schema.String,
+  tombstonedAt: Schema.NullOr(Schema.String),
+});
+type StoredCodexProfile = typeof StoredCodexProfile.Type;
+
+const StoredProviderProfileRegistry = Schema.Struct({
+  version: Schema.Literal(REGISTRY_VERSION),
+  revision: NonNegativeInt,
+  profiles: Schema.Array(StoredCodexProfile),
+});
+type StoredProviderProfileRegistry = typeof StoredProviderProfileRegistry.Type;
+
+type ActiveProfileInspection = Readonly<{
+  state: StoredProviderProfileRegistry;
+  target: CodexProviderTarget;
+  settingsRevision: number;
+  codexSettings: CodexServerProviderSettings;
+  providerEnabled: boolean;
+  profile: StoredCodexProfile | null;
+  summary: CodexProviderProfileSummary;
+}>;
+
+function registryError(
+  code: ProviderProfileRegistryErrorCode,
+  message: string,
+  cause?: unknown,
+): ProviderProfileRegistryError {
+  return new ProviderProfileRegistryError({
+    code,
+    message,
+    ...(cause === undefined ? {} : { cause }),
+  });
+}
+
+function registryAttempt<A>(operation: () => A): Effect.Effect<A, ProviderProfileRegistryError> {
+  return Effect.try({
+    try: operation,
+    catch: (cause) =>
+      cause instanceof ProviderProfileRegistryError
+        ? cause
+        : registryError(
+            "PROVIDER_PROFILE_REGISTRY_INVALID",
+            "The Codex provider profile registry is invalid.",
+            cause,
+          ),
+  });
+}
+
+function assertValidRegistry(state: StoredProviderProfileRegistry): StoredProviderProfileRegistry {
+  const profileIds = new Set<string>();
+  const storageKeys = new Set<string>();
+  const activeDisplayNames = new Set([normalizedDisplayName(DEFAULT_PROFILE_DISPLAY_NAME)]);
+  for (const profile of state.profiles) {
+    const normalizedName = normalizedDisplayName(profile.displayName);
+    if (
+      profile.profileId === DEFAULT_PROVIDER_PROFILE_ID ||
+      profileIds.has(profile.profileId) ||
+      storageKeys.has(profile.storageKey) ||
+      !isCodexProfileStorageKey(profile.storageKey) ||
+      (profile.tombstonedAt !== null && profile.enabled) ||
+      (profile.tombstonedAt === null && activeDisplayNames.has(normalizedName))
+    ) {
+      throw registryError(
+        "PROVIDER_PROFILE_REGISTRY_INVALID",
+        "The Codex provider profile registry is invalid.",
+      );
+    }
+    profileIds.add(profile.profileId);
+    storageKeys.add(profile.storageKey);
+    if (profile.tombstonedAt === null) activeDisplayNames.add(normalizedName);
+  }
+  return state;
+}
+
+function managedSummary(profile: StoredCodexProfile): CodexProviderProfileSummary {
+  return {
+    target: { provider: "codex", profileId: profile.profileId },
+    displayName: profile.displayName,
+    enabled: profile.enabled,
+    lifecycle: profile.tombstonedAt === null ? "active" : "tombstoned",
+    storageKind: "managed",
+  };
+}
+
+function findProfile(
+  state: StoredProviderProfileRegistry,
+  target: CodexProviderTarget,
+): StoredCodexProfile {
+  const profile = state.profiles.find((candidate) => candidate.profileId === target.profileId);
+  if (!profile) {
+    throw registryError(
+      "PROVIDER_PROFILE_NOT_FOUND",
+      `Codex provider profile '${target.profileId}' was not found.`,
+    );
+  }
+  return profile;
+}
+
+function assertManagedTarget(target: CodexProviderTarget): void {
+  if (target.profileId === DEFAULT_PROVIDER_PROFILE_ID) {
+    throw registryError(
+      "PROVIDER_PROFILE_DEFAULT_IMMUTABLE",
+      "The default Codex profile is managed by the existing provider settings.",
+    );
+  }
+}
+
+function assertActive(profile: StoredCodexProfile): void {
+  if (profile.tombstonedAt !== null) {
+    throw registryError(
+      "PROVIDER_PROFILE_TOMBSTONED",
+      `Codex provider profile '${profile.profileId}' has been removed.`,
+    );
+  }
+}
+
+function normalizedDisplayName(displayName: string): string {
+  return displayName.toLowerCase();
+}
+
+function assertDisplayNameAvailable(
+  state: StoredProviderProfileRegistry,
+  displayName: string,
+  exceptProfileId?: string,
+): void {
+  const normalized = normalizedDisplayName(displayName);
+  const conflictsWithDefault = normalized === normalizedDisplayName(DEFAULT_PROFILE_DISPLAY_NAME);
+  const conflictsWithManaged = state.profiles.some(
+    (profile) =>
+      profile.profileId !== exceptProfileId &&
+      profile.tombstonedAt === null &&
+      normalizedDisplayName(profile.displayName) === normalized,
+  );
+  if (conflictsWithDefault || conflictsWithManaged) {
+    throw registryError(
+      "PROVIDER_PROFILE_NAME_CONFLICT",
+      `An active Codex provider profile already uses the name '${displayName}'.`,
+    );
+  }
+}
+
+function makeIdentifiers(state: StoredProviderProfileRegistry): {
+  readonly profileId: ProviderProfileId;
+  readonly storageKey: string;
+} {
+  while (true) {
+    const profileKey = randomUUID();
+    const storageKey = randomUUID();
+    const profileId = ProviderProfileId.makeUnsafe(`codex_${profileKey.replaceAll("-", "")}`);
+    if (
+      !state.profiles.some(
+        (profile) => profile.profileId === profileId || profile.storageKey === storageKey,
+      )
+    ) {
+      return { profileId, storageKey };
+    }
+  }
+}
+
+export const makeProviderProfileRegistry = Effect.gen(function* () {
+  const config = yield* ServerConfig;
+  const serverSettings = yield* ServerSettingsService;
+  const lock = yield* Semaphore.make(1);
+  const stateRef = yield* Ref.make<StoredProviderProfileRegistry | null>(null);
+  const profilesRoot = path.join(config.stateDir, "provider-profiles");
+  const indexPath = path.join(profilesRoot, "index.json");
+
+  const readRegistry = Effect.tryPromise({
+    try: async () => {
+      let handle: fs.FileHandle | undefined;
+      try {
+        const noFollowFlag = supportsPosixPermissions() ? fsConstants.O_NOFOLLOW : 0;
+        handle = await fs.open(indexPath, fsConstants.O_RDONLY | noFollowFlag);
+        const stat = await handle.stat();
+        if (!stat.isFile()) throw new Error("Provider profile registry is not a regular file.");
+        if (supportsPosixPermissions()) await handle.chmod(PRIVATE_FILE_MODE);
+        return await handle.readFile("utf8");
+      } catch (cause) {
+        if ((cause as NodeJS.ErrnoException).code === "ENOENT") return null;
+        throw cause;
+      } finally {
+        await handle?.close();
+      }
+    },
+    catch: (cause) =>
+      registryError(
+        "PROVIDER_PROFILE_STORAGE_ERROR",
+        "Could not read the Codex provider profile registry.",
+        cause,
+      ),
+  }).pipe(
+    Effect.flatMap((contents) => {
+      if (contents === null) {
+        return Effect.succeed<StoredProviderProfileRegistry>({
+          version: REGISTRY_VERSION,
+          revision: 0,
+          profiles: [],
+        });
+      }
+      return Effect.try({
+        try: () => JSON.parse(contents) as unknown,
+        catch: (cause) =>
+          registryError(
+            "PROVIDER_PROFILE_REGISTRY_INVALID",
+            "The Codex provider profile registry is invalid.",
+            cause,
+          ),
+      }).pipe(
+        Effect.flatMap(Schema.decodeUnknownEffect(StoredProviderProfileRegistry)),
+        Effect.mapError((cause) =>
+          cause instanceof ProviderProfileRegistryError
+            ? cause
+            : registryError(
+                "PROVIDER_PROFILE_REGISTRY_INVALID",
+                "The Codex provider profile registry is invalid.",
+                cause,
+              ),
+        ),
+        Effect.flatMap((state) =>
+          Effect.try({
+            try: () => assertValidRegistry(state),
+            catch: (cause) =>
+              cause instanceof ProviderProfileRegistryError
+                ? cause
+                : registryError(
+                    "PROVIDER_PROFILE_REGISTRY_INVALID",
+                    "The Codex provider profile registry is invalid.",
+                    cause,
+                  ),
+          }),
+        ),
+      );
+    }),
+  );
+
+  const loadState = Ref.get(stateRef).pipe(
+    Effect.flatMap((cached) =>
+      cached === null
+        ? readRegistry.pipe(Effect.tap((loaded) => Ref.set(stateRef, loaded)))
+        : Effect.succeed(cached),
+    ),
+  );
+
+  const persist = (state: StoredProviderProfileRegistry) =>
+    Effect.uninterruptible(
+      writeFileStringAtomically({
+        filePath: indexPath,
+        contents: `${JSON.stringify(state, null, 2)}\n`,
+      }).pipe(
+        Effect.mapError((cause) =>
+          registryError(
+            "PROVIDER_PROFILE_STORAGE_ERROR",
+            "Could not save the Codex provider profile registry.",
+            cause,
+          ),
+        ),
+        // The in-memory publication and disk rename are one transaction. An
+        // interrupt between them would let a later mutation overwrite a state
+        // that was already durably committed.
+        Effect.andThen(Ref.set(stateRef, state)),
+      ),
+    );
+
+  const getSettingsSnapshot = serverSettings.getSnapshot.pipe(
+    Effect.mapError((cause) =>
+      registryError(
+        "PROVIDER_PROFILE_STORAGE_ERROR",
+        "Could not read the Codex provider settings.",
+        cause,
+      ),
+    ),
+  );
+
+  const snapshot = (state: StoredProviderProfileRegistry) =>
+    getSettingsSnapshot.pipe(
+      Effect.map(
+        ({ settings }): ProviderProfilesSnapshot => ({
+          providerEnabled: settings.providers.codex.enabled,
+          profiles: [
+            {
+              target: { provider: "codex", profileId: DEFAULT_PROVIDER_PROFILE_ID },
+              displayName: DEFAULT_PROFILE_DISPLAY_NAME,
+              enabled: true,
+              lifecycle: "active",
+              storageKind: "legacy-default",
+            },
+            ...state.profiles.map(managedSummary),
+          ],
+        }),
+      ),
+    );
+
+  const list: ProviderProfileRegistryShape["list"] = () =>
+    lock.withPermits(1)(loadState.pipe(Effect.flatMap(snapshot)));
+
+  const create: ProviderProfileRegistryShape["create"] = (input) =>
+    lock.withPermits(1)(
+      Effect.gen(function* () {
+        const state = yield* loadState;
+        yield* registryAttempt(() => assertDisplayNameAvailable(state, input.displayName));
+        const { profileId, storageKey } = makeIdentifiers(state);
+        // Prepare storage before publishing the record. If the later atomic
+        // index write fails, the unique directory is an inert orphan; the
+        // inverse ordering could publish an executable profile whose home was
+        // never made private. We deliberately do not delete here because a
+        // failed durability boundary must not trigger recursive cleanup.
+        yield* Effect.try({
+          try: () => materializeCodexManagedProfileHome({ profilesRoot, storageKey }),
+          catch: (cause) =>
+            registryError(
+              "PROVIDER_PROFILE_STORAGE_ERROR",
+              "Could not prepare private storage for the Codex provider profile.",
+              cause,
+            ),
+        });
+        const timestamp = new Date().toISOString();
+        const nextState: StoredProviderProfileRegistry = {
+          ...state,
+          revision: state.revision + 1,
+          profiles: [
+            ...state.profiles,
+            {
+              profileId,
+              storageKey,
+              displayName: input.displayName,
+              enabled: false,
+              createdAt: timestamp,
+              updatedAt: timestamp,
+              tombstonedAt: null,
+            },
+          ],
+        };
+        yield* persist(nextState);
+        return yield* snapshot(nextState);
+      }),
+    );
+
+  const rename: ProviderProfileRegistryShape["rename"] = (input) =>
+    lock.withPermits(1)(
+      Effect.gen(function* () {
+        yield* registryAttempt(() => assertManagedTarget(input.target));
+        const state = yield* loadState;
+        const profile = yield* registryAttempt(() => findProfile(state, input.target));
+        yield* registryAttempt(() => assertActive(profile));
+        if (profile.displayName === input.displayName) return yield* snapshot(state);
+        yield* registryAttempt(() =>
+          assertDisplayNameAvailable(state, input.displayName, profile.profileId),
+        );
+        const nextState: StoredProviderProfileRegistry = {
+          ...state,
+          revision: state.revision + 1,
+          profiles: state.profiles.map((candidate) =>
+            candidate.profileId === profile.profileId
+              ? {
+                  ...candidate,
+                  displayName: input.displayName,
+                  updatedAt: new Date().toISOString(),
+                }
+              : candidate,
+          ),
+        };
+        yield* persist(nextState);
+        return yield* snapshot(nextState);
+      }),
+    );
+
+  const setEnabled: ProviderProfileRegistryShape["setEnabled"] = (input) =>
+    lock.withPermits(1)(
+      Effect.gen(function* () {
+        yield* registryAttempt(() => assertManagedTarget(input.target));
+        const state = yield* loadState;
+        const profile = yield* registryAttempt(() => findProfile(state, input.target));
+        yield* registryAttempt(() => assertActive(profile));
+        if (profile.enabled === input.enabled) return yield* snapshot(state);
+        const nextState: StoredProviderProfileRegistry = {
+          ...state,
+          revision: state.revision + 1,
+          profiles: state.profiles.map((candidate) =>
+            candidate.profileId === profile.profileId
+              ? { ...candidate, enabled: input.enabled, updatedAt: new Date().toISOString() }
+              : candidate,
+          ),
+        };
+        yield* persist(nextState);
+        return yield* snapshot(nextState);
+      }),
+    );
+
+  const tombstone: ProviderProfileRegistryShape["tombstone"] = (input) =>
+    lock.withPermits(1)(
+      Effect.gen(function* () {
+        yield* registryAttempt(() => assertManagedTarget(input.target));
+        const state = yield* loadState;
+        const profile = yield* registryAttempt(() => findProfile(state, input.target));
+        if (profile.tombstonedAt !== null) return yield* snapshot(state);
+        const timestamp = new Date().toISOString();
+        const nextState: StoredProviderProfileRegistry = {
+          ...state,
+          revision: state.revision + 1,
+          profiles: state.profiles.map((candidate) =>
+            candidate.profileId === profile.profileId
+              ? {
+                  ...candidate,
+                  enabled: false,
+                  updatedAt: timestamp,
+                  tombstonedAt: timestamp,
+                }
+              : candidate,
+          ),
+        };
+        yield* persist(nextState);
+        return yield* snapshot(nextState);
+      }),
+    );
+
+  const inspectActiveProfile = (
+    state: StoredProviderProfileRegistry,
+    target: CodexProviderTarget,
+  ): Effect.Effect<ActiveProfileInspection, ProviderProfileRegistryError> =>
+    Effect.gen(function* () {
+      const { revision: settingsRevision, settings } = yield* getSettingsSnapshot;
+      const providerEnabled = settings.providers.codex.enabled;
+      if (target.profileId === DEFAULT_PROVIDER_PROFILE_ID) {
+        return {
+          state,
+          target,
+          settingsRevision,
+          codexSettings: settings.providers.codex,
+          providerEnabled,
+          profile: null,
+          summary: {
+            target,
+            displayName: DEFAULT_PROFILE_DISPLAY_NAME,
+            enabled: true,
+            lifecycle: "active",
+            storageKind: "legacy-default",
+          } satisfies CodexProviderProfileSummary,
+        } as const;
+      }
+
+      const profile = yield* registryAttempt(() => findProfile(state, target));
+      yield* registryAttempt(() => assertActive(profile));
+      return {
+        state,
+        target,
+        settingsRevision,
+        codexSettings: settings.providers.codex,
+        providerEnabled,
+        profile,
+        summary: managedSummary(profile),
+      } as const;
+    });
+
+  const materializeResolvedProfile = Effect.fnUntraced(function* (
+    inspection: ActiveProfileInspection,
+  ) {
+    if (inspection.profile === null) {
+      return {
+        summary: inspection.summary,
+        providerEnabled: inspection.providerEnabled,
+        launchContext: makeLegacyCodexLaunchContext({
+          target: inspection.target,
+          binaryPath: inspection.codexSettings.binaryPath,
+          sourceHomePath: inspection.codexSettings.homePath.trim() || null,
+          settingsRevision: inspection.settingsRevision,
+          registryRevision: inspection.state.revision,
+        }),
+      };
+    }
+
+    const home = yield* Effect.try({
+      try: () =>
+        materializeCodexManagedProfileHome({
+          profilesRoot,
+          storageKey: inspection.profile.storageKey,
+        }),
+      catch: (cause) =>
+        registryError(
+          "PROVIDER_PROFILE_STORAGE_ERROR",
+          "Could not prepare private storage for the Codex provider profile.",
+          cause,
+        ),
+    });
+    return {
+      summary: inspection.summary,
+      providerEnabled: inspection.providerEnabled,
+      launchContext: makeManagedCodexLaunchContext({
+        target: inspection.target,
+        binaryPath: inspection.codexSettings.binaryPath,
+        settingsRevision: inspection.settingsRevision,
+        registryRevision: inspection.state.revision,
+        ...home,
+      }),
+    };
+  });
+
+  const resolveForManagement: ProviderProfileRegistryShape["resolveForManagement"] = (target) =>
+    lock.withPermits(1)(
+      loadState.pipe(
+        Effect.flatMap((state) => inspectActiveProfile(state, target)),
+        Effect.flatMap(materializeResolvedProfile),
+      ),
+    );
+
+  const resolveForRuntime: ProviderProfileRegistryShape["resolveForRuntime"] = (target) =>
+    lock.withPermits(1)(
+      Effect.gen(function* () {
+        const state = yield* loadState;
+        const inspection = yield* inspectActiveProfile(state, target);
+        if (!inspection.providerEnabled) {
+          return yield* registryError(
+            "PROVIDER_PROFILE_DISABLED",
+            "The Codex provider is disabled in Synara settings.",
+          );
+        }
+        if (!inspection.summary.enabled) {
+          return yield* registryError(
+            "PROVIDER_PROFILE_DISABLED",
+            `Codex provider profile '${inspection.target.profileId}' is disabled.`,
+          );
+        }
+        return yield* materializeResolvedProfile(inspection);
+      }),
+    );
+
+  return {
+    list,
+    create,
+    rename,
+    setEnabled,
+    tombstone,
+    resolveForManagement,
+    resolveForRuntime,
+  } satisfies ProviderProfileRegistryShape;
+});
+
+export const ProviderProfileRegistryLive = Layer.effect(
+  ProviderProfileRegistry,
+  makeProviderProfileRegistry,
+);

--- a/apps/server/src/provider/Services/ProviderProfileRegistry.ts
+++ b/apps/server/src/provider/Services/ProviderProfileRegistry.ts
@@ -1,0 +1,68 @@
+import type {
+  CodexProviderProfileSummary,
+  CodexProviderTarget,
+  ProviderProfilesCreateInput,
+  ProviderProfilesListInput,
+  ProviderProfilesRenameInput,
+  ProviderProfilesSetEnabledInput,
+  ProviderProfilesSnapshot,
+  ProviderProfilesTombstoneInput,
+} from "@synara/contracts";
+import { Data, ServiceMap } from "effect";
+import type { Effect } from "effect";
+
+import type { CodexProviderLaunchContext } from "../codexProviderLaunchContext";
+
+export type ProviderProfileRegistryErrorCode =
+  | "PROVIDER_PROFILE_DEFAULT_IMMUTABLE"
+  | "PROVIDER_PROFILE_DISABLED"
+  | "PROVIDER_PROFILE_NAME_CONFLICT"
+  | "PROVIDER_PROFILE_NOT_FOUND"
+  | "PROVIDER_PROFILE_REGISTRY_INVALID"
+  | "PROVIDER_PROFILE_STORAGE_ERROR"
+  | "PROVIDER_PROFILE_TOMBSTONED";
+
+export class ProviderProfileRegistryError extends Data.TaggedError(
+  "ProviderProfileRegistryError",
+)<{
+  readonly code: ProviderProfileRegistryErrorCode;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+export interface ResolvedCodexProviderProfile {
+  readonly summary: CodexProviderProfileSummary;
+  readonly providerEnabled: boolean;
+  readonly launchContext: CodexProviderLaunchContext;
+}
+
+export interface ProviderProfileRegistryShape {
+  readonly list: (
+    input: ProviderProfilesListInput,
+  ) => Effect.Effect<ProviderProfilesSnapshot, ProviderProfileRegistryError>;
+  readonly create: (
+    input: ProviderProfilesCreateInput,
+  ) => Effect.Effect<ProviderProfilesSnapshot, ProviderProfileRegistryError>;
+  readonly rename: (
+    input: ProviderProfilesRenameInput,
+  ) => Effect.Effect<ProviderProfilesSnapshot, ProviderProfileRegistryError>;
+  readonly setEnabled: (
+    input: ProviderProfilesSetEnabledInput,
+  ) => Effect.Effect<ProviderProfilesSnapshot, ProviderProfileRegistryError>;
+  readonly tombstone: (
+    input: ProviderProfilesTombstoneInput,
+  ) => Effect.Effect<ProviderProfilesSnapshot, ProviderProfileRegistryError>;
+  /** Resolves active profile storage for login and other control-plane work. */
+  readonly resolveForManagement: (
+    target: CodexProviderTarget,
+  ) => Effect.Effect<ResolvedCodexProviderProfile, ProviderProfileRegistryError>;
+  /** Resolves a profile only when both global and per-profile execution switches permit it. */
+  readonly resolveForRuntime: (
+    target: CodexProviderTarget,
+  ) => Effect.Effect<ResolvedCodexProviderProfile, ProviderProfileRegistryError>;
+}
+
+export class ProviderProfileRegistry extends ServiceMap.Service<
+  ProviderProfileRegistry,
+  ProviderProfileRegistryShape
+>()("synara/provider/Services/ProviderProfileRegistry") {}

--- a/apps/server/src/provider/codexManagedProfileHome.ts
+++ b/apps/server/src/provider/codexManagedProfileHome.ts
@@ -1,0 +1,52 @@
+import path from "node:path";
+
+import {
+  ensurePrivateDirectorySync,
+  ensurePrivateFileSync,
+} from "../privatePathPermissions";
+
+const STORAGE_KEY_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+
+export interface CodexManagedProfileHome {
+  readonly codexHomePath: string;
+  readonly codexSqliteHomePath: string;
+}
+
+export function isCodexProfileStorageKey(value: string): boolean {
+  return STORAGE_KEY_PATTERN.test(value);
+}
+
+/**
+ * Materializes an empty, server-owned Codex home. This function intentionally
+ * has no source-home input: managed profiles never inspect, link, or copy a
+ * user's legacy Codex state.
+ */
+export function materializeCodexManagedProfileHome(input: {
+  readonly profilesRoot: string;
+  readonly storageKey: string;
+  readonly platform?: NodeJS.Platform;
+}): Readonly<CodexManagedProfileHome> {
+  if (!isCodexProfileStorageKey(input.storageKey)) {
+    throw new Error("Invalid managed Codex profile storage key.");
+  }
+
+  const platform = input.platform ?? process.platform;
+  const codexProfilesRoot = path.join(input.profilesRoot, "codex");
+  const profileRoot = path.join(codexProfilesRoot, input.storageKey);
+  const codexHomePath = path.join(profileRoot, "home");
+  const codexSqliteHomePath = path.join(profileRoot, "sqlite");
+
+  for (const directoryPath of [
+    input.profilesRoot,
+    codexProfilesRoot,
+    profileRoot,
+    codexHomePath,
+    codexSqliteHomePath,
+  ]) {
+    ensurePrivateDirectorySync(directoryPath, platform);
+  }
+  ensurePrivateFileSync(path.join(codexHomePath, "config.toml"), { platform });
+
+  return Object.freeze({ codexHomePath, codexSqliteHomePath });
+}

--- a/apps/server/src/provider/codexProviderLaunchContext.ts
+++ b/apps/server/src/provider/codexProviderLaunchContext.ts
@@ -1,0 +1,72 @@
+import type { CodexProviderTarget } from "@synara/contracts";
+
+interface CodexLaunchContextBase {
+  readonly target: Readonly<CodexProviderTarget>;
+  readonly binaryPath: string;
+  readonly settingsRevision: number;
+  readonly registryRevision: number;
+}
+
+export interface LegacyCodexLaunchContext extends CodexLaunchContextBase {
+  readonly home: Readonly<{
+    readonly strategy: "legacy-overlay";
+    readonly sourceHomePath: string | null;
+  }>;
+}
+
+export interface ManagedCodexLaunchContext extends CodexLaunchContextBase {
+  readonly home: Readonly<{
+    readonly strategy: "managed-direct";
+    readonly codexHomePath: string;
+    readonly codexSqliteHomePath: string;
+  }>;
+}
+
+export type CodexProviderLaunchContext = Readonly<
+  LegacyCodexLaunchContext | ManagedCodexLaunchContext
+>;
+
+interface LaunchContextCommonInput {
+  readonly target: CodexProviderTarget;
+  readonly binaryPath: string;
+  readonly settingsRevision: number;
+  readonly registryRevision: number;
+}
+
+function freezeTarget(target: CodexProviderTarget): Readonly<CodexProviderTarget> {
+  return Object.freeze({ ...target });
+}
+
+export function makeLegacyCodexLaunchContext(
+  input: LaunchContextCommonInput & { readonly sourceHomePath: string | null },
+): LegacyCodexLaunchContext {
+  return Object.freeze({
+    target: freezeTarget(input.target),
+    binaryPath: input.binaryPath,
+    settingsRevision: input.settingsRevision,
+    registryRevision: input.registryRevision,
+    home: Object.freeze({
+      strategy: "legacy-overlay" as const,
+      sourceHomePath: input.sourceHomePath,
+    }),
+  });
+}
+
+export function makeManagedCodexLaunchContext(
+  input: LaunchContextCommonInput & {
+    readonly codexHomePath: string;
+    readonly codexSqliteHomePath: string;
+  },
+): ManagedCodexLaunchContext {
+  return Object.freeze({
+    target: freezeTarget(input.target),
+    binaryPath: input.binaryPath,
+    settingsRevision: input.settingsRevision,
+    registryRevision: input.registryRevision,
+    home: Object.freeze({
+      strategy: "managed-direct" as const,
+      codexHomePath: input.codexHomePath,
+      codexSqliteHomePath: input.codexSqliteHomePath,
+    }),
+  });
+}

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -54,6 +54,7 @@ import { ThreadDiagnosticsQueryLive } from "./diagnostics/Layers/ThreadDiagnosti
 import { ManagedAttachmentCleanupLive } from "./managedAttachmentCleanup";
 import { PullRequestServiceLive } from "./pullRequests/Layers/PullRequestService";
 import { ProviderHealthLive } from "./provider/Layers/ProviderHealth";
+import { ProviderProfileRegistryLive } from "./provider/Layers/ProviderProfileRegistry";
 import { makeServerProviderLayer } from "./provider/runtimeLayer";
 
 export { makeServerProviderLayer } from "./provider/runtimeLayer";
@@ -79,6 +80,9 @@ export function makeServerRuntimeServicesLayer(
   const agentGatewayCredentialsLayer =
     options.agentGatewayCredentialsLayer ?? AgentGatewayCredentialsWithSecretsLive;
   const providerHealthLayer = ProviderHealthLive.pipe(Layer.provideMerge(ServerSettingsLive));
+  const providerProfileRegistryLayer = ProviderProfileRegistryLive.pipe(
+    Layer.provideMerge(ServerSettingsLive),
+  );
   const checkpointStoreLayer = CheckpointStoreLive.pipe(Layer.provide(GitCoreLive));
 
   const checkpointDiffQueryLayer = CheckpointDiffQueryLive.pipe(
@@ -225,6 +229,7 @@ export function makeServerRuntimeServicesLayer(
     externalMcpServiceLayer,
     externalMcpGatewayLayer,
     providerHealthLayer,
+    providerProfileRegistryLayer,
     ProjectPullRequestPinsLive,
     pullRequestServiceLayer,
     orchestrationReactorLayer,

--- a/apps/server/src/wsRpc.auth.test.ts
+++ b/apps/server/src/wsRpc.auth.test.ts
@@ -6,12 +6,38 @@ import { AuthError } from "./auth/Services/ServerAuth";
 import {
   authenticateRpcWebSocketUpgrade,
   authorizeDeviceFrameWebSocketUpgrade,
+  canAccessProviderProfiles,
   canManageExternalMcp,
+  toProviderProfileWsRpcError,
 } from "./wsRpc";
+import { ProviderProfileRegistryError } from "./provider/Services/ProviderProfileRegistry";
 
 it("reserves external MCP management for owner sessions", () => {
   assert.isTrue(canManageExternalMcp("owner"));
   assert.isFalse(canManageExternalMcp("client"));
+});
+
+it("allows clients to list provider profiles but reserves every mutation for owners", () => {
+  assert.isTrue(canAccessProviderProfiles("client", "list"));
+  for (const operation of ["create", "rename", "setEnabled", "tombstone"] as const) {
+    assert.isTrue(canAccessProviderProfiles("owner", operation));
+    assert.isFalse(canAccessProviderProfiles("client", operation));
+  }
+});
+
+it("redacts registry error causes before they cross RPC", () => {
+  const privatePath = "/private/state/provider-profiles/index.json";
+  const rpcError = toProviderProfileWsRpcError(
+    new ProviderProfileRegistryError({
+      code: "PROVIDER_PROFILE_STORAGE_ERROR",
+      message: "Could not save the Codex provider profile registry.",
+      cause: new Error(`EACCES: ${privatePath}`),
+    }),
+  );
+
+  assert.equal(rpcError.code, "PROVIDER_PROFILE_STORAGE_ERROR");
+  assert.equal(rpcError.cause, undefined);
+  assert.isFalse(JSON.stringify(rpcError).includes(privatePath));
 });
 
 it.effect("rejects an unauthorized websocket upgrade on a non-loopback bind", () =>

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -99,6 +99,10 @@ import { discoverSkillsCatalog, synaraSkillsDir } from "./provider/skillsCatalog
 import { recoverUnregisteredGitHubCheckout } from "./project/githubProjectRegistration";
 import { ProviderAdapterRegistry } from "./provider/Services/ProviderAdapterRegistry";
 import { ProviderHealth } from "./provider/Services/ProviderHealth";
+import {
+  ProviderProfileRegistry,
+  ProviderProfileRegistryError,
+} from "./provider/Services/ProviderProfileRegistry";
 import { ProviderService } from "./provider/Services/ProviderService";
 import { listProviderUsage } from "./providerUsage";
 import { getProviderUsageSnapshot } from "./providerUsageSnapshot";
@@ -157,6 +161,32 @@ import {
 
 export function canManageExternalMcp(role: "owner" | "client"): boolean {
   return role === "owner";
+}
+
+export type ProviderProfileRpcOperation =
+  | "list"
+  | "create"
+  | "rename"
+  | "setEnabled"
+  | "tombstone";
+
+export function canAccessProviderProfiles(
+  role: "owner" | "client",
+  operation: ProviderProfileRpcOperation,
+): boolean {
+  return operation === "list" || role === "owner";
+}
+
+export function toProviderProfileWsRpcError(
+  cause: ProviderProfileRegistryError | WsRpcError,
+): WsRpcError {
+  return cause instanceof WsRpcError
+    ? cause
+    : new WsRpcError({
+        message: cause.message,
+        code: cause.code,
+        retryable: false,
+      });
 }
 
 const MAX_DIAGNOSTIC_CHILD_PROCESSES = 80;
@@ -335,6 +365,7 @@ const makeWsRpcHandlersLayer = () =>
       const providerAdapterRegistry = yield* ProviderAdapterRegistry;
       const providerDiscoveryService = yield* ProviderDiscoveryService;
       const providerHealth = yield* ProviderHealth;
+      const providerProfiles = yield* ProviderProfileRegistry;
       const providerService = yield* ProviderService;
       const lifecycleEvents = yield* ServerLifecycleEvents;
       const runtimeStartup = yield* ServerRuntimeStartup;
@@ -794,6 +825,11 @@ const makeWsRpcHandlersLayer = () =>
       const rpcEffect = <A, E, R>(effect: Effect.Effect<A, E, R>, fallbackMessage: string) =>
         effect.pipe(Effect.mapError((cause) => toWsRpcError(cause, fallbackMessage)));
 
+      const providerProfileRpcEffect = <A, R>(
+        effect: Effect.Effect<A, ProviderProfileRegistryError | WsRpcError, R>,
+      ) =>
+        effect.pipe(Effect.mapError(toProviderProfileWsRpcError));
+
       const toProjectProvisionRpcError = (cause: unknown) =>
         cause instanceof GitHubProjectProvisioningError
           ? new WsRpcError({
@@ -832,6 +868,16 @@ const makeWsRpcHandlersLayer = () =>
           );
         }
       });
+
+      const requireProviderProfileAccess = (operation: ProviderProfileRpcOperation) =>
+        Effect.gen(function* () {
+          if (canAccessProviderProfiles(yield* CurrentWsSessionRole, operation)) return;
+          return yield* new WsRpcError({
+            message: "Owner authorization is required to manage provider profiles.",
+            code: "PROVIDER_PROFILE_OWNER_REQUIRED",
+            retryable: false,
+          });
+        });
 
       return AdmittedWsFeatureRpcGroup.of({
         [ORCHESTRATION_WS_METHODS.dispatchCommand]: (command) =>
@@ -1595,6 +1641,36 @@ const makeWsRpcHandlersLayer = () =>
             "Failed to refresh providers",
           ),
         [WS_METHODS.serverUpdateProvider]: (input) => providerHealth.updateProvider(input),
+        [WS_METHODS.providerProfilesList]: (input) =>
+          providerProfileRpcEffect(
+            requireProviderProfileAccess("list").pipe(
+              Effect.andThen(providerProfiles.list(input)),
+            ),
+          ),
+        [WS_METHODS.providerProfilesCreate]: (input) =>
+          providerProfileRpcEffect(
+            requireProviderProfileAccess("create").pipe(
+              Effect.andThen(providerProfiles.create(input)),
+            ),
+          ),
+        [WS_METHODS.providerProfilesRename]: (input) =>
+          providerProfileRpcEffect(
+            requireProviderProfileAccess("rename").pipe(
+              Effect.andThen(providerProfiles.rename(input)),
+            ),
+          ),
+        [WS_METHODS.providerProfilesSetEnabled]: (input) =>
+          providerProfileRpcEffect(
+            requireProviderProfileAccess("setEnabled").pipe(
+              Effect.andThen(providerProfiles.setEnabled(input)),
+            ),
+          ),
+        [WS_METHODS.providerProfilesTombstone]: (input) =>
+          providerProfileRpcEffect(
+            requireProviderProfileAccess("tombstone").pipe(
+              Effect.andThen(providerProfiles.tombstone(input)),
+            ),
+          ),
         [WS_METHODS.serverListExternalMcpIntegrations]: () =>
           rpcEffect(
             requireOwner.pipe(Effect.andThen(externalMcp.listIntegrations())),

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -652,6 +652,26 @@ describe("wsNativeApi", () => {
     expect(requestMock).toHaveBeenCalledWith(WS_METHODS.serverGetEnvironment);
   });
 
+  it("forwards provider profile registry requests without adding internal fields", async () => {
+    const { createWsNativeApi } = await import("./wsNativeApi");
+    const api = createWsNativeApi();
+    const target = { provider: "codex" as const, profileId: "codex_work" as const };
+
+    await api.providerProfiles.list({ provider: "codex" });
+    await api.providerProfiles.create({ provider: "codex", displayName: "Work" });
+    await api.providerProfiles.rename({ target, displayName: "Client" });
+    await api.providerProfiles.setEnabled({ target, enabled: true });
+    await api.providerProfiles.tombstone({ target });
+
+    expect(requestMock.mock.calls).toEqual([
+      [WS_METHODS.providerProfilesList, { provider: "codex" }],
+      [WS_METHODS.providerProfilesCreate, { provider: "codex", displayName: "Work" }],
+      [WS_METHODS.providerProfilesRename, { target, displayName: "Client" }],
+      [WS_METHODS.providerProfilesSetEnabled, { target, enabled: true }],
+      [WS_METHODS.providerProfilesTombstone, { target }],
+    ]);
+  });
+
   it("uses websocket RPC for external MCP management in packaged and browser builds", async () => {
     requestMock
       .mockResolvedValueOnce([])

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -721,6 +721,13 @@ export function createWsNativeApi(): NativeApi {
       },
       upsertKeybinding: (input) => transport.request(WS_METHODS.serverUpsertKeybinding, input),
     },
+    providerProfiles: {
+      list: (input) => transport.request(WS_METHODS.providerProfilesList, input),
+      create: (input) => transport.request(WS_METHODS.providerProfilesCreate, input),
+      rename: (input) => transport.request(WS_METHODS.providerProfilesRename, input),
+      setEnabled: (input) => transport.request(WS_METHODS.providerProfilesSetEnabled, input),
+      tombstone: (input) => transport.request(WS_METHODS.providerProfilesTombstone, input),
+    },
     stats: {
       getProfileStats: (input) => transport.request(WS_METHODS.statsGetProfileStats, input),
       getProfileTokenStats: (input) =>

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -15,6 +15,7 @@ export * from "./ipc";
 export * from "./terminal";
 export * from "./provider";
 export * from "./providerProfile";
+export * from "./providerProfileManagement";
 export * from "./providerDiscovery";
 export * from "./providerRuntime";
 export * from "./model";

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -22,6 +22,14 @@ import type {
   ExternalMcpRevokeIntegrationInput,
 } from "./externalMcp";
 import type {
+  ProviderProfilesCreateInput,
+  ProviderProfilesListInput,
+  ProviderProfilesRenameInput,
+  ProviderProfilesSetEnabledInput,
+  ProviderProfilesSnapshot,
+  ProviderProfilesTombstoneInput,
+} from "./providerProfileManagement";
+import type {
   AutomationCancelRunInput,
   AutomationCancelRunResult,
   AutomationArchiveRunInput,
@@ -765,6 +773,13 @@ export interface NativeApi {
       input: ServerVoiceTranscriptionInput,
     ) => Promise<ServerVoiceTranscriptionResult>;
     upsertKeybinding: (input: ServerUpsertKeybindingInput) => Promise<ServerUpsertKeybindingResult>;
+  };
+  providerProfiles: {
+    list: (input: ProviderProfilesListInput) => Promise<ProviderProfilesSnapshot>;
+    create: (input: ProviderProfilesCreateInput) => Promise<ProviderProfilesSnapshot>;
+    rename: (input: ProviderProfilesRenameInput) => Promise<ProviderProfilesSnapshot>;
+    setEnabled: (input: ProviderProfilesSetEnabledInput) => Promise<ProviderProfilesSnapshot>;
+    tombstone: (input: ProviderProfilesTombstoneInput) => Promise<ProviderProfilesSnapshot>;
   };
   stats: {
     getProfileStats: (input: StatsGetProfileStatsInput) => Promise<StatsGetProfileStatsResult>;

--- a/packages/contracts/src/providerProfileManagement.test.ts
+++ b/packages/contracts/src/providerProfileManagement.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+
+import { it } from "@effect/vitest";
+import { Effect, Schema } from "effect";
+
+import {
+  CodexProviderProfileSummary,
+  ProviderProfilesCreateInput,
+  ProviderProfilesSetEnabledInput,
+} from "./providerProfileManagement";
+
+it.effect("decodes redacted Codex profile summaries", () =>
+  Effect.gen(function* () {
+    const summary = yield* Schema.decodeUnknownEffect(CodexProviderProfileSummary)({
+      target: { provider: "codex", profileId: "codex_work" },
+      displayName: "Work",
+      enabled: false,
+      lifecycle: "active",
+      storageKind: "managed",
+      storageKey: "must-not-cross-the-contract",
+      codexHomePath: "/private/profile/home",
+    });
+
+    assert.deepEqual(summary, {
+      target: { provider: "codex", profileId: "codex_work" },
+      displayName: "Work",
+      enabled: false,
+      lifecycle: "active",
+      storageKind: "managed",
+    });
+  }),
+);
+
+it("accepts bounded managed-profile mutations and rejects unsafe targets", () => {
+  assert.equal(
+    Schema.is(ProviderProfilesCreateInput)({ provider: "codex", displayName: "Personal" }),
+    true,
+  );
+  assert.equal(
+    Schema.is(ProviderProfilesCreateInput)({ provider: "codex", displayName: " ".repeat(81) }),
+    false,
+  );
+  assert.equal(
+    Schema.is(ProviderProfilesSetEnabledInput)({
+      target: { provider: "codex", profileId: "../other" },
+      enabled: true,
+    }),
+    false,
+  );
+  assert.equal(
+    Schema.is(ProviderProfilesSetEnabledInput)({
+      target: { provider: "claudeAgent", profileId: "work" },
+      enabled: true,
+    }),
+    false,
+  );
+});

--- a/packages/contracts/src/providerProfileManagement.ts
+++ b/packages/contracts/src/providerProfileManagement.ts
@@ -1,0 +1,70 @@
+import { Schema } from "effect";
+
+import { TrimmedNonEmptyString } from "./baseSchemas";
+import { ProviderProfileId } from "./providerProfile";
+
+const PROVIDER_PROFILE_DISPLAY_NAME_MAX_LENGTH = 80;
+
+export const ProviderProfileDisplayName = TrimmedNonEmptyString.check(
+  Schema.isMaxLength(PROVIDER_PROFILE_DISPLAY_NAME_MAX_LENGTH),
+);
+export type ProviderProfileDisplayName = typeof ProviderProfileDisplayName.Type;
+
+export const CodexProviderTarget = Schema.Struct({
+  provider: Schema.Literal("codex"),
+  profileId: ProviderProfileId,
+});
+export type CodexProviderTarget = typeof CodexProviderTarget.Type;
+
+export const CodexProviderProfileLifecycle = Schema.Literals(["active", "tombstoned"]);
+export type CodexProviderProfileLifecycle = typeof CodexProviderProfileLifecycle.Type;
+
+export const CodexProviderProfileStorageKind = Schema.Literals(["legacy-default", "managed"]);
+export type CodexProviderProfileStorageKind = typeof CodexProviderProfileStorageKind.Type;
+
+/** Browser-safe profile metadata. Internal storage keys and filesystem paths never cross RPC. */
+export const CodexProviderProfileSummary = Schema.Struct({
+  target: CodexProviderTarget,
+  displayName: ProviderProfileDisplayName,
+  // Administrative profile switch. Effective availability also requires the
+  // snapshot's providerEnabled flag and an active lifecycle.
+  enabled: Schema.Boolean,
+  lifecycle: CodexProviderProfileLifecycle,
+  storageKind: CodexProviderProfileStorageKind,
+});
+export type CodexProviderProfileSummary = typeof CodexProviderProfileSummary.Type;
+
+export const ProviderProfilesSnapshot = Schema.Struct({
+  // Global Codex switch from server settings, kept separate from each profile switch.
+  providerEnabled: Schema.Boolean,
+  profiles: Schema.Array(CodexProviderProfileSummary),
+});
+export type ProviderProfilesSnapshot = typeof ProviderProfilesSnapshot.Type;
+
+export const ProviderProfilesListInput = Schema.Struct({
+  provider: Schema.Literal("codex"),
+});
+export type ProviderProfilesListInput = typeof ProviderProfilesListInput.Type;
+
+export const ProviderProfilesCreateInput = Schema.Struct({
+  provider: Schema.Literal("codex"),
+  displayName: ProviderProfileDisplayName,
+});
+export type ProviderProfilesCreateInput = typeof ProviderProfilesCreateInput.Type;
+
+export const ProviderProfilesRenameInput = Schema.Struct({
+  target: CodexProviderTarget,
+  displayName: ProviderProfileDisplayName,
+});
+export type ProviderProfilesRenameInput = typeof ProviderProfilesRenameInput.Type;
+
+export const ProviderProfilesSetEnabledInput = Schema.Struct({
+  target: CodexProviderTarget,
+  enabled: Schema.Boolean,
+});
+export type ProviderProfilesSetEnabledInput = typeof ProviderProfilesSetEnabledInput.Type;
+
+export const ProviderProfilesTombstoneInput = Schema.Struct({
+  target: CodexProviderTarget,
+});
+export type ProviderProfilesTombstoneInput = typeof ProviderProfilesTombstoneInput.Type;

--- a/packages/contracts/src/rpc.test.ts
+++ b/packages/contracts/src/rpc.test.ts
@@ -8,6 +8,8 @@ import {
   WsFeatureRpcGroup,
   WsProjectsDiscoverScriptsRpc,
   WsProjectsProvisionFromGitHubRpc,
+  WsProviderProfilesCreateRpc,
+  WsProviderProfilesListRpc,
   WsPullRequestsReviewRequestCountRpc,
   WsRpcError,
   WsRpcGroup,
@@ -41,6 +43,13 @@ describe("WS RPC contracts", () => {
     expect(WsAutomationCreateRpc).toBeDefined();
     expect(WsAutomationGetMemoryRpc).toBeDefined();
     expect(WsAutomationResolveProposalRpc).toBeDefined();
+  });
+
+  it("exports the provider profile registry RPCs", () => {
+    expect(WsProviderProfilesListRpc).toBeDefined();
+    expect(WsProviderProfilesCreateRpc).toBeDefined();
+    expect(WsFeatureRpcGroup.requests.has("providerProfiles.list")).toBe(true);
+    expect(WsFeatureRpcGroup.requests.has("providerProfiles.tombstone")).toBe(true);
   });
 
   it("exports the count-only pull request review RPC", () => {

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -138,6 +138,14 @@ import {
 } from "./orchestration";
 import { ProviderCompactThreadInput } from "./provider";
 import {
+  ProviderProfilesCreateInput,
+  ProviderProfilesListInput,
+  ProviderProfilesRenameInput,
+  ProviderProfilesSetEnabledInput,
+  ProviderProfilesSnapshot,
+  ProviderProfilesTombstoneInput,
+} from "./providerProfileManagement";
+import {
   ProviderGetComposerCapabilitiesInput,
   ProviderComposerCapabilities,
   ProviderListAgentsInput,
@@ -916,6 +924,36 @@ export const WsServerUpdateProviderRpc = Rpc.make(WS_METHODS.serverUpdateProvide
   error: ServerProviderUpdateError,
 });
 
+export const WsProviderProfilesListRpc = Rpc.make(WS_METHODS.providerProfilesList, {
+  payload: ProviderProfilesListInput,
+  success: ProviderProfilesSnapshot,
+  error: WsRpcError,
+});
+
+export const WsProviderProfilesCreateRpc = Rpc.make(WS_METHODS.providerProfilesCreate, {
+  payload: ProviderProfilesCreateInput,
+  success: ProviderProfilesSnapshot,
+  error: WsRpcError,
+});
+
+export const WsProviderProfilesRenameRpc = Rpc.make(WS_METHODS.providerProfilesRename, {
+  payload: ProviderProfilesRenameInput,
+  success: ProviderProfilesSnapshot,
+  error: WsRpcError,
+});
+
+export const WsProviderProfilesSetEnabledRpc = Rpc.make(WS_METHODS.providerProfilesSetEnabled, {
+  payload: ProviderProfilesSetEnabledInput,
+  success: ProviderProfilesSnapshot,
+  error: WsRpcError,
+});
+
+export const WsProviderProfilesTombstoneRpc = Rpc.make(WS_METHODS.providerProfilesTombstone, {
+  payload: ProviderProfilesTombstoneInput,
+  success: ProviderProfilesSnapshot,
+  error: WsRpcError,
+});
+
 export const WsServerListExternalMcpIntegrationsRpc = Rpc.make(
   WS_METHODS.serverListExternalMcpIntegrations,
   {
@@ -1271,6 +1309,11 @@ export const WsFeatureRpcGroup = RpcGroup.make(
   WsServerUpdateSettingsRpc,
   WsServerRefreshProvidersRpc,
   WsServerUpdateProviderRpc,
+  WsProviderProfilesListRpc,
+  WsProviderProfilesCreateRpc,
+  WsProviderProfilesRenameRpc,
+  WsProviderProfilesSetEnabledRpc,
+  WsProviderProfilesTombstoneRpc,
   WsServerListExternalMcpIntegrationsRpc,
   WsServerCreateExternalMcpIntegrationRpc,
   WsServerRevokeExternalMcpIntegrationRpc,

--- a/packages/contracts/src/ws.test.ts
+++ b/packages/contracts/src/ws.test.ts
@@ -114,6 +114,30 @@ it.effect("accepts automation create requests", () =>
   }),
 );
 
+it.effect("accepts bounded provider profile registry requests", () =>
+  Effect.gen(function* () {
+    const create = yield* decode(WebSocketRequest, {
+      id: "req-provider-profile-create-1",
+      body: {
+        _tag: WS_METHODS.providerProfilesCreate,
+        provider: "codex",
+        displayName: "Work",
+      },
+    });
+    const enable = yield* decode(WebSocketRequest, {
+      id: "req-provider-profile-enable-1",
+      body: {
+        _tag: WS_METHODS.providerProfilesSetEnabled,
+        target: { provider: "codex", profileId: "codex_work" },
+        enabled: true,
+      },
+    });
+
+    assert.strictEqual(create.body._tag, WS_METHODS.providerProfilesCreate);
+    assert.strictEqual(enable.body._tag, WS_METHODS.providerProfilesSetEnabled);
+  }),
+);
+
 it.effect("accepts automation proposal resolution requests", () =>
   Effect.gen(function* () {
     const parsed = yield* decode(WebSocketRequest, {

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -140,6 +140,13 @@ import {
 } from "./providerDiscovery";
 import { ProviderCompactThreadInput } from "./provider";
 import {
+  ProviderProfilesCreateInput,
+  ProviderProfilesListInput,
+  ProviderProfilesRenameInput,
+  ProviderProfilesSetEnabledInput,
+  ProviderProfilesTombstoneInput,
+} from "./providerProfileManagement";
+import {
   PullRequestActionInput,
   PullRequestCommentInput,
   PullRequestDetailInput,
@@ -256,6 +263,13 @@ export const WS_METHODS = {
   subscribeServerConfig: "server.subscribeConfig",
   subscribeServerProviderStatuses: "server.subscribeProviderStatuses",
   subscribeServerSettings: "server.subscribeSettings",
+
+  // Server-owned provider profile registry
+  providerProfilesList: "providerProfiles.list",
+  providerProfilesCreate: "providerProfiles.create",
+  providerProfilesRename: "providerProfiles.rename",
+  providerProfilesSetEnabled: "providerProfiles.setEnabled",
+  providerProfilesTombstone: "providerProfiles.tombstone",
 
   // Streaming subscriptions
   subscribeTerminalEvents: "terminal.subscribeEvents",
@@ -456,6 +470,13 @@ const WebSocketRequestBody = Schema.Union([
   tagRequestBody(WS_METHODS.serverGenerateThreadRecap, ServerGenerateThreadRecapInput),
   tagRequestBody(WS_METHODS.serverGenerateAutomationIntent, ServerGenerateAutomationIntentInput),
   tagRequestBody(WS_METHODS.serverUpsertKeybinding, KeybindingRule),
+
+  // Server-owned provider profile registry
+  tagRequestBody(WS_METHODS.providerProfilesList, ProviderProfilesListInput),
+  tagRequestBody(WS_METHODS.providerProfilesCreate, ProviderProfilesCreateInput),
+  tagRequestBody(WS_METHODS.providerProfilesRename, ProviderProfilesRenameInput),
+  tagRequestBody(WS_METHODS.providerProfilesSetEnabled, ProviderProfilesSetEnabledInput),
+  tagRequestBody(WS_METHODS.providerProfilesTombstone, ProviderProfilesTombstoneInput),
 
   // Provider discovery
   tagRequestBody(WS_METHODS.providerGetComposerCapabilities, ProviderGetComposerCapabilitiesInput),


### PR DESCRIPTION
## Summary

Adds a server-owned managed Codex account registry and the private launch-context boundary needed for true account isolation:

- persists opaque managed-profile records outside browser-writable settings
- gives every managed profile independent private `CODEX_HOME` and `CODEX_SQLITE_HOME` directories
- keeps public profile IDs independent from private storage keys
- preserves the existing `default` account as the legacy-overlay path
- exposes redacted list/create/rename/enable/tombstone RPCs
- allows authenticated clients to list accounts while reserving every mutation for owners
- separates management resolution from runtime admission so the next PR can support create → login → enable safely

Managed profiles are created disabled. This PR deliberately does **not** route Codex runtimes or discovery through them yet; the Stage 1 default-only resolver remains the execution backstop until the next stack entry lands.

## Stack

Base: PR #622 / `codex/provider-profiles-04-web-guards` at `c72e49577`  
Head: `7de98afce`

This is the first managed-account implementation PR after the four-PR provider-target foundation and must merge after PR #622.

## Replacement for #254

This continues the fresh replacement stack for #254. The old PR remains useful as requirements and failure-case history, but its shared-home and lifecycle assumptions do not fit Synara's current runtime ownership model. This implementation preserves the idea of first-class accounts while rebuilding storage and authorization around today's server boundaries.

## Safety and compatibility

- Existing default-account behavior is unchanged.
- Managed homes never inspect, copy, or symlink legacy Codex auth, sessions, caches, or configuration.
- Registry directories are `0700`; the index and generated config are `0600`.
- Public RPC data contains no filesystem paths, storage keys, secrets, or raw causes.
- Corrupt, semantically invalid, symlinked, or newer-version registries fail closed and are not overwritten.
- Disk commit and in-memory publication form one uninterruptible transaction.
- Tombstones are terminal, idempotent, disabled, and retain private storage.
- Global Codex enablement is separate from each account's administrative enablement.
- An index-write failure may leave one inert private orphan directory, but never publishes an executable account and does not trigger risky recursive cleanup.

## Validation

- Full server suite: 328 files passed, 3 skipped; 3,788 tests passed, 16 skipped.
- Full contracts suite: 20 files; 210/210 tests passed.
- Full web node suite: 304 files; 3,817/3,817 tests passed.
- Focused server registry/layer/WebSocket coverage: 46/46 passed.
- Independent adversarial exact-head review: no remaining P0/P1/P2 findings.
- `git diff --check`: passed.

`bun fmt`, `bun lint`, and `bun typecheck` remain unrun because repository policy requires explicit user permission. The existing stack's GitHub CI currently stops at the formatter gate for the same reason; permission is pending.
