### PR TITLE
feat(server): add isolated Codex account control

### DIFF
--- a/apps/server/src/codexAppServerInitialize.ts
+++ b/apps/server/src/codexAppServerInitialize.ts
@@ -1,0 +1,12 @@
+export function buildCodexInitializeParams() {
+  return {
+    clientInfo: {
+      name: "synara_desktop",
+      title: "Synara Desktop",
+      version: "0.1.0",
+    },
+    capabilities: {
+      experimentalApi: true,
+    },
+  } as const;
+}

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -57,6 +57,7 @@ import {
   type AgentGatewaySessionLease,
 } from "./agentGateway/sessionLease.ts";
 import { isNonFatalCodexErrorMessage } from "./codexErrorClassification.ts";
+import { buildCodexInitializeParams } from "./codexAppServerInitialize.ts";
 import { buildCodexProcessEnv } from "./codexProcessEnv.ts";
 import { assertCodexWorkingDirectoryExists } from "./codexWorkingDirectory.ts";
 import { executableIdentity, resolveExecutable } from "./executableLookup.ts";
@@ -738,18 +739,7 @@ export function normalizeCodexModelSlug(
   return normalized;
 }
 
-export function buildCodexInitializeParams() {
-  return {
-    clientInfo: {
-      name: "synara_desktop",
-      title: "Synara Desktop",
-      version: "0.1.0",
-    },
-    capabilities: {
-      experimentalApi: true,
-    },
-  } as const;
-}
+export { buildCodexInitializeParams } from "./codexAppServerInitialize.ts";
 
 function buildCodexCollaborationMode(input: {
   readonly interactionMode?: "default" | "plan";
@@ -1114,7 +1104,6 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       // with its own 20-second deadline.
       try {
         const accountReadResponse = await this.sendRequest(context, "account/read", {});
-        log.info("account/read response", { accountReadResponse });
         context.account = readCodexAccountSnapshot(accountReadResponse);
         log.info("subscription status", {
           type: context.account.type,

--- a/apps/server/src/provider/Layers/CodexAccountControl.test.ts
+++ b/apps/server/src/provider/Layers/CodexAccountControl.test.ts
@@ -1,0 +1,756 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { CodexProviderTarget, ProviderProfilesSnapshot } from "@synara/contracts";
+import { Effect } from "effect";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  CodexAccountProtocolClient,
+  CodexAccountProtocolNotification,
+} from "../codexAccountProtocolClient";
+import {
+  makeLegacyCodexLaunchContext,
+  makeManagedCodexLaunchContext,
+} from "../codexProviderLaunchContext";
+import type {
+  ProviderProfileRegistryShape,
+  ResolvedCodexProviderProfile,
+} from "../Services/ProviderProfileRegistry";
+import { makeAccountControlRuntime } from "./CodexAccountControl";
+
+const managedTarget = {
+  provider: "codex",
+  profileId: "codex_11111111111141118111111111111111",
+} as CodexProviderTarget;
+const defaultTarget = { provider: "codex", profileId: "default" } as CodexProviderTarget;
+const temporaryRoots: string[] = [];
+
+interface RequestCall {
+  readonly method: string;
+  readonly params: unknown;
+}
+
+class FakeAccountClient implements CodexAccountProtocolClient {
+  readonly requests: RequestCall[] = [];
+  closeCalls = 0;
+  closeFailuresRemaining = 0;
+  private readonly notificationListeners = new Set<
+    (notification: CodexAccountProtocolNotification) => void
+  >();
+  private readonly closeListeners = new Set<(error: Error) => void>();
+
+  constructor(
+    private readonly respond: (
+      method: string,
+      params: unknown,
+      client: FakeAccountClient,
+    ) => unknown | Promise<unknown>,
+  ) {}
+
+  request(method: string, params?: unknown): Promise<unknown> {
+    this.requests.push({ method, params });
+    return Promise.resolve(this.respond(method, params, this));
+  }
+
+  onNotification(
+    listener: (notification: CodexAccountProtocolNotification) => void,
+  ): () => void {
+    this.notificationListeners.add(listener);
+    return () => this.notificationListeners.delete(listener);
+  }
+
+  onUnexpectedClose(listener: (error: Error) => void): () => void {
+    this.closeListeners.add(listener);
+    return () => this.closeListeners.delete(listener);
+  }
+
+  emit(notification: CodexAccountProtocolNotification): void {
+    for (const listener of this.notificationListeners) listener(notification);
+  }
+
+  emitUnexpectedClose(error = new Error("account process closed unexpectedly")): void {
+    for (const listener of this.closeListeners) listener(error);
+  }
+
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+    if (this.closeFailuresRemaining > 0) {
+      this.closeFailuresRemaining -= 1;
+      throw new Error("process tree still alive");
+    }
+  }
+}
+
+interface RegistryHarness {
+  readonly registry: ProviderProfileRegistryShape;
+  readonly seal: ReturnType<typeof vi.fn>;
+  readonly tombstone: ReturnType<typeof vi.fn>;
+  readonly setEnabled: ReturnType<typeof vi.fn>;
+  readonly getBound: () => boolean;
+}
+
+function makeRegistry(input: {
+  readonly root: string;
+  readonly defaultOnly?: boolean;
+  readonly initiallyBound?: boolean;
+}): RegistryHarness {
+  let bound = input.initiallyBound ?? false;
+  let tombstoned = false;
+  const snapshot = (): ProviderProfilesSnapshot => ({
+    providerEnabled: true,
+    profiles: [
+      {
+        target: defaultTarget,
+        displayName: "Default",
+        enabled: true,
+        lifecycle: "active",
+        storageKind: "legacy-default",
+      },
+      ...(input.defaultOnly
+        ? []
+        : [
+            {
+              target: managedTarget,
+              displayName: "Work",
+              enabled: false,
+              lifecycle: tombstoned ? ("tombstoned" as const) : ("active" as const),
+              storageKind: "managed" as const,
+            },
+          ]),
+    ],
+  });
+  const resolution = (target: CodexProviderTarget): ResolvedCodexProviderProfile => {
+    if (target.profileId === "default") {
+      return {
+        providerEnabled: true,
+        summary: snapshot().profiles[0]!,
+        launchContext: makeLegacyCodexLaunchContext({
+          target,
+          binaryPath: "/usr/bin/codex",
+          settingsRevision: 1,
+          registryRevision: 0,
+          sourceHomePath: input.root,
+        }),
+      };
+    }
+    const profileRoot = path.join(input.root, "managed");
+    const codexHomePath = path.join(profileRoot, "home");
+    const codexSqliteHomePath = path.join(profileRoot, "sqlite");
+    fs.mkdirSync(codexHomePath, { recursive: true, mode: 0o700 });
+    fs.mkdirSync(codexSqliteHomePath, { recursive: true, mode: 0o700 });
+    return {
+      providerEnabled: true,
+      summary: snapshot().profiles[1]!,
+      launchContext: makeManagedCodexLaunchContext({
+        target,
+        binaryPath: "/usr/bin/codex",
+        settingsRevision: 1,
+        registryRevision: bound ? 2 : 1,
+        authenticationBoundAt: bound ? "2026-08-10T00:00:00.000Z" : null,
+        continuationNamespaceId: "11111111-1111-4111-8111-111111111111",
+        codexHomePath,
+        codexSqliteHomePath,
+      }),
+    };
+  };
+  const seal = vi.fn(() => {
+    bound = true;
+    return Effect.void;
+  });
+  const tombstone = vi.fn(() => {
+    tombstoned = true;
+    return Effect.succeed(snapshot());
+  });
+  const setEnabled = vi.fn(() => Effect.succeed(snapshot()));
+  return {
+    registry: {
+      list: () => Effect.succeed(snapshot()),
+      create: () => Effect.succeed(snapshot()),
+      rename: () => Effect.succeed(snapshot()),
+      setEnabled,
+      tombstone,
+      sealManagedAuthentication: seal,
+      resolveForManagement: (target) => Effect.succeed(resolution(target)),
+      resolveForRuntime: (target) => Effect.succeed(resolution(target)),
+    },
+    seal,
+    tombstone,
+    setEnabled,
+    getBound: () => bound,
+  };
+}
+
+function makeRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "synara-account-control-"));
+  temporaryRoots.push(root);
+  return root;
+}
+
+function signedOutResponse() {
+  return { account: null, requiresOpenaiAuth: true };
+}
+
+function chatGptResponse() {
+  return {
+    account: { type: "chatgpt", email: "owner@example.test", planType: "plus" },
+    requiresOpenaiAuth: true,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const root of temporaryRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("CodexAccountControl", () => {
+  it("keeps the legacy default account read-only", async () => {
+    const root = makeRoot();
+    const registry = makeRegistry({ root, defaultOnly: true });
+    const clients: FakeAccountClient[] = [];
+    const runtime = makeAccountControlRuntime({
+      registry: registry.registry,
+      cwd: root,
+      openClient: async () => {
+        const client = new FakeAccountClient((method) => {
+          if (method === "account/read") return signedOutResponse();
+          throw new Error(`unexpected method ${method}`);
+        });
+        clients.push(client);
+        return client;
+      },
+    });
+
+    await expect(
+      Effect.runPromise(runtime.service.readAccount({ target: defaultTarget })),
+    ).resolves.toMatchObject({ authentication: "signed-out", pendingLogin: null });
+    for (const operation of [
+      runtime.service.startLogin({ target: defaultTarget, method: "browser" }),
+      runtime.service.cancelLogin({ target: defaultTarget }),
+      runtime.service.logout({ target: defaultTarget }),
+      runtime.service.setEnabled({ target: defaultTarget, enabled: false }),
+      runtime.service.tombstone({ target: defaultTarget }),
+    ]) {
+      const error = await Effect.runPromise(operation.pipe(Effect.flip));
+      expect(error).toMatchObject({
+        code: "PROVIDER_ACCOUNT_TARGET_IMMUTABLE",
+        retryable: false,
+      });
+    }
+    expect(clients).toHaveLength(1);
+    expect(clients[0]?.requests).toEqual([
+      { method: "account/read", params: { refreshToken: false } },
+    ]);
+    await runtime.shutdown();
+  });
+
+  it("returns the same pending challenge only for the same login method", async () => {
+    const root = makeRoot();
+    const registry = makeRegistry({ root });
+    const client = new FakeAccountClient((method) => {
+      if (method === "account/read") return signedOutResponse();
+      if (method === "account/login/start") {
+        return {
+          type: "chatgptDeviceCode",
+          loginId: "login-1",
+          verificationUrl: "https://auth.example.test/device",
+          userCode: "ABCD-EFGH",
+        };
+      }
+      if (method === "account/login/cancel") return { status: "canceled" };
+      throw new Error(`unexpected method ${method}`);
+    });
+    const runtime = makeAccountControlRuntime({
+      registry: registry.registry,
+      cwd: root,
+      openClient: async () => client,
+      now: () => Date.parse("2026-08-10T00:00:00.000Z"),
+    });
+
+    const first = await Effect.runPromise(
+      runtime.service.startLogin({ target: managedTarget, method: "device-code" }),
+    );
+    const retry = await Effect.runPromise(
+      runtime.service.startLogin({ target: managedTarget, method: "device-code" }),
+    );
+    expect(retry).toEqual(first);
+    expect(client.requests.filter(({ method }) => method === "account/login/start")).toHaveLength(
+      1,
+    );
+
+    const conflict = await Effect.runPromise(
+      runtime.service
+        .startLogin({ target: managedTarget, method: "browser" })
+        .pipe(Effect.flip),
+    );
+    expect(conflict).toMatchObject({
+      code: "PROVIDER_ACCOUNT_LOGIN_METHOD_CONFLICT",
+      retryable: false,
+    });
+    await Effect.runPromise(runtime.service.cancelLogin({ target: managedTarget }));
+    expect(client.closeCalls).toBe(1);
+    await runtime.shutdown();
+  });
+
+  it("accepts a 0.144 completion without loginId and seals only after fresh ChatGPT proof", async () => {
+    const root = makeRoot();
+    const registry = makeRegistry({ root });
+    let signedIn = false;
+    let openCount = 0;
+    const clients: FakeAccountClient[] = [];
+    const syncManagedAuthState = vi.fn(() => {
+      expect(clients.every((client) => client.closeCalls === 1)).toBe(true);
+    });
+    const runtime = makeAccountControlRuntime({
+      registry: registry.registry,
+      cwd: root,
+      openClient: async (launchContext) => {
+        openCount += 1;
+        const client = new FakeAccountClient((method, _params, current) => {
+          if (method === "account/read") {
+            if (!signedIn) return signedOutResponse();
+            if (launchContext.home.strategy === "managed-direct") {
+              fs.writeFileSync(
+                path.join(launchContext.home.codexHomePath, "auth.json"),
+                "private",
+                { mode: 0o600 },
+              );
+            }
+            return chatGptResponse();
+          }
+          if (method === "account/login/start") {
+            signedIn = true;
+            queueMicrotask(() =>
+              current.emit({
+                method: "account/login/completed",
+                params: { success: true },
+              }),
+            );
+            return {
+              type: "chatgpt",
+              loginId: "browser-login",
+              authUrl: "https://auth.example.test/start",
+            };
+          }
+          throw new Error(`unexpected method ${method}`);
+        });
+        clients.push(client);
+        return client;
+      },
+      syncManagedAuthState,
+    });
+
+    await Effect.runPromise(
+      runtime.service.startLogin({ target: managedTarget, method: "browser" }),
+    );
+    await vi.waitFor(() => expect(registry.seal).toHaveBeenCalledOnce());
+
+    expect(registry.getBound()).toBe(true);
+    expect(openCount).toBe(2);
+    expect(clients.every((client) => client.closeCalls === 1)).toBe(true);
+    expect(syncManagedAuthState).toHaveBeenCalledOnce();
+    expect(syncManagedAuthState.mock.invocationCallOrder[0]).toBeLessThan(
+      registry.seal.mock.invocationCallOrder[0]!,
+    );
+    await runtime.shutdown();
+  });
+
+  it.each([
+    { account: { type: "apiKey" }, requiresOpenaiAuth: false },
+    {
+      account: { type: "amazonBedrock", usesCodexManagedCredentials: false },
+      requiresOpenaiAuth: true,
+    },
+    { account: { type: "chatgpt" }, requiresOpenaiAuth: true },
+  ])("refuses to seal unsupported $account.type authentication", async (response) => {
+    const root = makeRoot();
+    const registry = makeRegistry({ root });
+    const client = new FakeAccountClient((method) => {
+      if (method === "account/read") return response;
+      throw new Error(`unexpected method ${method}`);
+    });
+    const runtime = makeAccountControlRuntime({
+      registry: registry.registry,
+      cwd: root,
+      openClient: async () => client,
+    });
+
+    const error = await Effect.runPromise(
+      runtime.service.readAccount({ target: managedTarget }).pipe(Effect.flip),
+    );
+    expect(error).toMatchObject({
+      code: "PROVIDER_ACCOUNT_UNSUPPORTED_AUTHENTICATION",
+      retryable: false,
+    });
+    expect(registry.seal).not.toHaveBeenCalled();
+    expect(client.closeCalls).toBe(1);
+    await runtime.shutdown();
+  });
+
+  it.each([42, { requiresOpenaiAuth: true }])(
+    "does not tombstone after malformed account response %#",
+    async (response) => {
+      const root = makeRoot();
+      const registry = makeRegistry({ root, initiallyBound: true });
+      const client = new FakeAccountClient((method) => {
+        if (method === "account/read") return response;
+        if (method === "account/logout") return {};
+        throw new Error(`unexpected method ${method}`);
+      });
+      const runtime = makeAccountControlRuntime({
+        registry: registry.registry,
+        cwd: root,
+        openClient: async () => client,
+      });
+
+      const error = await Effect.runPromise(
+        runtime.service.tombstone({ target: managedTarget }).pipe(Effect.flip),
+      );
+      expect(error).toMatchObject({ code: "PROVIDER_ACCOUNT_PROTOCOL_INVALID" });
+      expect(client.closeCalls).toBe(1);
+      expect(registry.tombstone).not.toHaveBeenCalled();
+      await runtime.shutdown();
+    },
+  );
+
+  it("logs out and confirms signed-out state before terminally tombstoning", async () => {
+    const root = makeRoot();
+    const registry = makeRegistry({ root, initiallyBound: true });
+    let signedIn = true;
+    const syncManagedLoggedOutState = vi.fn(() => {
+      expect(client.closeCalls).toBe(1);
+    });
+    const client = new FakeAccountClient((method) => {
+      if (method === "account/read") return signedIn ? chatGptResponse() : signedOutResponse();
+      if (method === "account/logout") {
+        signedIn = false;
+        return {};
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const runtime = makeAccountControlRuntime({
+      registry: registry.registry,
+      cwd: root,
+      openClient: async () => client,
+      syncManagedLoggedOutState,
+    });
+
+    const result = await Effect.runPromise(runtime.service.logout({ target: managedTarget }));
+    expect(result.account.authentication).toBe("signed-out");
+    expect(client.requests).toEqual([
+      { method: "account/logout", params: undefined },
+      { method: "account/read", params: { refreshToken: false } },
+    ]);
+    expect(client.closeCalls).toBe(1);
+    expect(syncManagedLoggedOutState).toHaveBeenCalledOnce();
+    expect(syncManagedLoggedOutState.mock.invocationCallOrder[0]).toBeLessThan(
+      registry.tombstone.mock.invocationCallOrder[0]!,
+    );
+    expect(registry.tombstone).toHaveBeenCalledOnce();
+    const repeatedLogout = await Effect.runPromise(
+      runtime.service.logout({ target: managedTarget }),
+    );
+    expect(repeatedLogout.account).toMatchObject({
+      authentication: "signed-out",
+      authMode: null,
+      pendingLogin: null,
+    });
+    await Effect.runPromise(runtime.service.tombstone({ target: managedTarget }));
+    expect(client.closeCalls).toBe(1);
+    expect(registry.tombstone).toHaveBeenCalledOnce();
+    await runtime.shutdown();
+  });
+
+  it("tombstones a never-authenticated profile idempotently without account control", async () => {
+    const root = makeRoot();
+    const registry = makeRegistry({ root });
+    const client = new FakeAccountClient((method) => {
+      if (method === "account/read") return signedOutResponse();
+      throw new Error(`unexpected method ${method}`);
+    });
+    const openClient = vi.fn(async () => client);
+    const syncManagedLoggedOutState = vi.fn(() => {
+      expect(openClient).not.toHaveBeenCalled();
+    });
+    const runtime = makeAccountControlRuntime({
+      registry: registry.registry,
+      cwd: root,
+      openClient,
+      syncManagedLoggedOutState,
+    });
+
+    const first = await Effect.runPromise(
+      runtime.service.tombstone({ target: managedTarget }),
+    );
+    const repeated = await Effect.runPromise(
+      runtime.service.tombstone({ target: managedTarget }),
+    );
+
+    expect(repeated).toEqual(first);
+    expect(openClient).not.toHaveBeenCalled();
+    expect(client.closeCalls).toBe(0);
+    expect(syncManagedLoggedOutState).toHaveBeenCalledOnce();
+    expect(syncManagedLoggedOutState.mock.invocationCallOrder[0]).toBeLessThan(
+      registry.tombstone.mock.invocationCallOrder[0]!,
+    );
+    expect(registry.tombstone).toHaveBeenCalledOnce();
+    await runtime.shutdown();
+  });
+
+  it("revokes discovered authentication even when the initial read reports signed-out", async () => {
+    const root = makeRoot();
+    const registry = makeRegistry({ root });
+    const home = path.join(root, "managed", "home");
+    fs.mkdirSync(home, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(home, "auth.json"), "private", { mode: 0o600 });
+    let signedIn = false;
+    const client = new FakeAccountClient((method) => {
+      if (method === "account/read") return signedIn ? chatGptResponse() : signedOutResponse();
+      if (method === "account/logout") {
+        signedIn = false;
+        fs.rmSync(path.join(home, "auth.json"));
+        return {};
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const openClient = vi.fn(async () => client);
+    const runtime = makeAccountControlRuntime({
+      registry: registry.registry,
+      cwd: root,
+      openClient,
+    });
+
+    await Effect.runPromise(runtime.service.tombstone({ target: managedTarget }));
+
+    expect(openClient).toHaveBeenCalledOnce();
+    expect(client.requests.some(({ method }) => method === "account/logout")).toBe(true);
+    expect(registry.tombstone).toHaveBeenCalledOnce();
+    await runtime.shutdown();
+  });
+
+  it("does not seal when the credential durability boundary fails", async () => {
+    const root = makeRoot();
+    const registry = makeRegistry({ root });
+    const clients: FakeAccountClient[] = [];
+    const runtime = makeAccountControlRuntime({
+      registry: registry.registry,
+      cwd: root,
+      openClient: async (launchContext) => {
+        const client = new FakeAccountClient((method) => {
+          if (method !== "account/read") throw new Error(`unexpected method ${method}`);
+          if (launchContext.home.strategy === "managed-direct") {
+            fs.writeFileSync(
+              path.join(launchContext.home.codexHomePath, "auth.json"),
+              "private",
+              { mode: 0o600 },
+            );
+          }
+          return chatGptResponse();
+        });
+        clients.push(client);
+        return client;
+      },
+      syncManagedAuthState: () => {
+        throw Object.assign(new Error("credential fsync failed"), { code: "EIO" });
+      },
+    });
+
+    const error = await Effect.runPromise(
+      runtime.service.readAccount({ target: managedTarget }).pipe(Effect.flip),
+    );
+
+    expect(error).toMatchObject({
+      code: "PROVIDER_ACCOUNT_CONTROL_FAILED",
+      retryable: true,
+    });
+    expect(clients).toHaveLength(2);
+    expect(clients.every((client) => client.closeCalls === 1)).toBe(true);
+    expect(registry.seal).not.toHaveBeenCalled();
+    await runtime.shutdown();
+  });
+
+  it("does not tombstone when logged-out credential state cannot be made durable", async () => {
+    const root = makeRoot();
+    const registry = makeRegistry({ root, initiallyBound: true });
+    const client = new FakeAccountClient((method) => {
+      if (method === "account/read") return signedOutResponse();
+      if (method === "account/logout") return {};
+      throw new Error(`unexpected method ${method}`);
+    });
+    const runtime = makeAccountControlRuntime({
+      registry: registry.registry,
+      cwd: root,
+      openClient: async () => client,
+      syncManagedLoggedOutState: () => {
+        throw Object.assign(new Error("credential directory fsync failed"), { code: "EIO" });
+      },
+    });
+
+    const error = await Effect.runPromise(
+      runtime.service.tombstone({ target: managedTarget }).pipe(Effect.flip),
+    );
+
+    expect(error).toMatchObject({
+      code: "PROVIDER_ACCOUNT_CONTROL_FAILED",
+      retryable: true,
+    });
+    expect(client.closeCalls).toBe(1);
+    expect(client.requests.map(({ method }) => method)).toEqual([
+      "account/logout",
+      "account/read",
+    ]);
+    expect(registry.tombstone).not.toHaveBeenCalled();
+    await runtime.shutdown();
+  });
+
+  it("does not tombstone when an authentication file survives logout", async () => {
+    const root = makeRoot();
+    const registry = makeRegistry({ root, initiallyBound: true });
+    const home = path.join(root, "managed", "home");
+    fs.mkdirSync(home, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(home, "auth.json"), "private", { mode: 0o600 });
+    const client = new FakeAccountClient((method) => {
+      if (method === "account/logout") return {};
+      if (method === "account/read") return signedOutResponse();
+      throw new Error(`unexpected method ${method}`);
+    });
+    const runtime = makeAccountControlRuntime({
+      registry: registry.registry,
+      cwd: root,
+      openClient: async () => client,
+    });
+
+    const error = await Effect.runPromise(
+      runtime.service.tombstone({ target: managedTarget }).pipe(Effect.flip),
+    );
+
+    expect(error).toMatchObject({
+      code: "PROVIDER_ACCOUNT_CONTROL_FAILED",
+      retryable: true,
+    });
+    expect(client.closeCalls).toBe(1);
+    expect(registry.tombstone).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(home, "auth.json"))).toBe(true);
+    await runtime.shutdown();
+  });
+
+  it("closes a pending process after malformed cancel or account responses", async () => {
+    const root = makeRoot();
+    const registry = makeRegistry({ root });
+    const client = new FakeAccountClient((method) => {
+      if (method === "account/read") return signedOutResponse();
+      if (method === "account/login/start") {
+        return {
+          type: "chatgpt",
+          loginId: "login-1",
+          authUrl: "https://auth.example.test/start",
+        };
+      }
+      if (method === "account/login/cancel") return { status: "invalid" };
+      throw new Error(`unexpected method ${method}`);
+    });
+    const runtime = makeAccountControlRuntime({
+      registry: registry.registry,
+      cwd: root,
+      openClient: async () => client,
+    });
+    await Effect.runPromise(
+      runtime.service.startLogin({ target: managedTarget, method: "browser" }),
+    );
+
+    const error = await Effect.runPromise(
+      runtime.service.cancelLogin({ target: managedTarget }).pipe(Effect.flip),
+    );
+    expect(error).toMatchObject({ code: "PROVIDER_ACCOUNT_PROTOCOL_INVALID" });
+    expect(client.closeCalls).toBe(1);
+    await runtime.shutdown();
+  });
+
+  it("fences a target while an ephemeral process tree cannot be retired", async () => {
+    const root = makeRoot();
+    const registry = makeRegistry({ root });
+    const poisoned = new FakeAccountClient((method) => {
+      if (method === "account/read") return signedOutResponse();
+      throw new Error(`unexpected method ${method}`);
+    });
+    poisoned.closeFailuresRemaining = 3;
+    const replacement = new FakeAccountClient(() => signedOutResponse());
+    const openClient = vi
+      .fn<() => Promise<CodexAccountProtocolClient>>()
+      .mockResolvedValueOnce(poisoned)
+      .mockResolvedValue(replacement);
+    const runtime = makeAccountControlRuntime({
+      registry: registry.registry,
+      cwd: root,
+      openClient,
+    });
+
+    await expect(
+      Effect.runPromise(runtime.service.readAccount({ target: managedTarget })),
+    ).rejects.toMatchObject({ code: "PROVIDER_ACCOUNT_CONTROL_FAILED" });
+    await expect(
+      Effect.runPromise(runtime.service.readAccount({ target: managedTarget })),
+    ).rejects.toMatchObject({ code: "PROVIDER_ACCOUNT_CONTROL_FAILED" });
+    expect(openClient).toHaveBeenCalledOnce();
+
+    await runtime.shutdown();
+    expect(poisoned.closeCalls).toBe(4);
+  });
+
+  it("drops a stale login and retires its poisoned process before opening a replacement", async () => {
+    const root = makeRoot();
+    const registry = makeRegistry({ root });
+    const first = new FakeAccountClient((method) => {
+      if (method === "account/read") return signedOutResponse();
+      if (method === "account/login/start") {
+        return {
+          type: "chatgpt",
+          loginId: "login-1",
+          authUrl: "https://auth.example.test/first",
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    first.closeFailuresRemaining = 1;
+    const second = new FakeAccountClient((method) => {
+      if (method === "account/read") return signedOutResponse();
+      if (method === "account/login/start") {
+        return {
+          type: "chatgpt",
+          loginId: "login-2",
+          authUrl: "https://auth.example.test/second",
+        };
+      }
+      if (method === "account/login/cancel") return { status: "canceled" };
+      throw new Error(`unexpected method ${method}`);
+    });
+    const openClient = vi
+      .fn<() => Promise<CodexAccountProtocolClient>>()
+      .mockResolvedValueOnce(first)
+      .mockResolvedValue(second);
+    const runtime = makeAccountControlRuntime({
+      registry: registry.registry,
+      cwd: root,
+      openClient,
+    });
+
+    const original = await Effect.runPromise(
+      runtime.service.startLogin({ target: managedTarget, method: "browser" }),
+    );
+    first.emitUnexpectedClose();
+    await vi.waitFor(() => expect(first.closeCalls).toBe(1));
+
+    const replacement = await Effect.runPromise(
+      runtime.service.startLogin({ target: managedTarget, method: "browser" }),
+    );
+
+    expect(replacement.challenge).not.toEqual(original.challenge);
+    expect(first.closeCalls).toBe(2);
+    expect(openClient).toHaveBeenCalledTimes(2);
+    await Effect.runPromise(runtime.service.cancelLogin({ target: managedTarget }));
+    await runtime.shutdown();
+  });
+});

--- a/apps/server/src/provider/Layers/CodexAccountControl.ts
+++ b/apps/server/src/provider/Layers/CodexAccountControl.ts
@@ -1,0 +1,887 @@
+import type {
+  CodexProviderAccountAuthMode,
+  CodexProviderAccountStatus,
+  CodexProviderLoginChallenge,
+  CodexProviderLoginMethod,
+  CodexProviderTarget,
+  ProviderProfileLoginCancelResult,
+  ProviderProfileLoginStartResult,
+  ProviderProfileLogoutResult,
+  ProviderProfilesSnapshot,
+} from "@synara/contracts";
+import { DEFAULT_PROVIDER_PROFILE_ID } from "@synara/contracts";
+import { Effect, Layer } from "effect";
+
+import { ServerConfig } from "../../config";
+import type { CodexProviderLaunchContext } from "../codexProviderLaunchContext";
+import {
+  CodexAccountProtocolOpenError,
+  CodexAccountProtocolRequestError,
+  CodexAccountProtocolVersionError,
+  openCodexAccountProtocolClient,
+  type CodexAccountProtocolClient,
+  type CodexAccountProtocolNotification,
+} from "../codexAccountProtocolClient";
+import {
+  assertManagedCodexAuthFilePrivate,
+  inspectManagedCodexAuthFile,
+  syncManagedCodexAuthState,
+  syncManagedCodexLoggedOutState,
+} from "../codexManagedProfileHome";
+import {
+  CodexAccountControl,
+  CodexAccountControlError,
+  type CodexAccountControlErrorCode,
+  type CodexAccountControlShape,
+} from "../Services/CodexAccountControl";
+import {
+  ProviderProfileRegistry,
+  ProviderProfileRegistryError,
+  type ResolvedCodexProviderProfile,
+} from "../Services/ProviderProfileRegistry";
+
+const LOGIN_LIFETIME_MS = 15 * 60 * 1_000;
+const LOGIN_ID_MAX_LENGTH = 512;
+const LOGIN_URL_MAX_LENGTH = 4_096;
+const LOGIN_USER_CODE_MAX_LENGTH = 256;
+const ACCOUNT_EMAIL_MAX_LENGTH = 320;
+const ACCOUNT_PLAN_MAX_LENGTH = 80;
+
+interface LoginCompletion {
+  readonly success: boolean;
+}
+
+interface DecodedAccountStatus {
+  readonly status: CodexProviderAccountStatus;
+  readonly bindableChatGptShape: boolean;
+}
+
+interface ActiveLogin {
+  readonly target: CodexProviderTarget;
+  readonly loginId: string;
+  readonly method: CodexProviderLoginMethod;
+  readonly client: CodexAccountProtocolClient;
+  readonly resolution: ResolvedCodexProviderProfile;
+  readonly result: ProviderProfileLoginStartResult;
+  readonly expiresTimer: ReturnType<typeof setTimeout>;
+  readonly detachNotification: () => void;
+  readonly detachUnexpectedClose: () => void;
+  completion?: LoginCompletion;
+}
+
+type OpenAccountClient = (
+  launchContext: CodexProviderLaunchContext,
+  cwd: string,
+) => Promise<CodexAccountProtocolClient>;
+
+interface AccountControlRuntime {
+  readonly service: CodexAccountControlShape;
+  readonly shutdown: () => Promise<void>;
+}
+
+export const makeCodexAccountControl = Effect.gen(function* () {
+  const config = yield* ServerConfig;
+  const registry = yield* ProviderProfileRegistry;
+  return makeAccountControlRuntime({
+    registry,
+    cwd: config.homeDir,
+    openClient: (launchContext, cwd) =>
+      openCodexAccountProtocolClient({ launchContext, cwd }),
+  });
+});
+
+export function makeAccountControlRuntime(input: {
+  readonly registry: typeof ProviderProfileRegistry.Service;
+  readonly cwd: string;
+  readonly openClient: OpenAccountClient;
+  readonly now?: () => number;
+  readonly loginLifetimeMs?: number;
+  readonly syncManagedAuthState?: (codexHomePath: string) => void;
+  readonly syncManagedLoggedOutState?: (codexHomePath: string) => void;
+}): AccountControlRuntime {
+  const now = input.now ?? Date.now;
+  const loginLifetimeMs = input.loginLifetimeMs ?? LOGIN_LIFETIME_MS;
+  const syncManagedAuthState = input.syncManagedAuthState ?? syncManagedCodexAuthState;
+  const syncManagedLoggedOutState =
+    input.syncManagedLoggedOutState ?? syncManagedCodexLoggedOutState;
+  const activeLogins = new Map<string, ActiveLogin>();
+  const unretiredClients = new Map<
+    string,
+    { readonly target: CodexProviderTarget; readonly client: CodexAccountProtocolClient }
+  >();
+  const targetQueues = new Map<string, Promise<void>>();
+  let shuttingDown = false;
+  let shutdownPromise: Promise<void> | undefined;
+
+  const retireClient = async (
+    target: CodexProviderTarget,
+    client: CodexAccountProtocolClient,
+  ): Promise<void> => {
+    const key = targetKey(target);
+    try {
+      await client.close();
+    } catch (cause) {
+      unretiredClients.set(key, { target, client });
+      throw cause;
+    }
+    if (unretiredClients.get(key)?.client === client) unretiredClients.delete(key);
+  };
+
+  const retirePoisonedClient = async (target: CodexProviderTarget): Promise<void> => {
+    const unretired = unretiredClients.get(targetKey(target));
+    if (unretired) await retireClient(unretired.target, unretired.client);
+  };
+
+  const serialize = <A>(target: CodexProviderTarget, operation: () => Promise<A>): Promise<A> => {
+    if (shuttingDown) {
+      return Promise.reject(
+        controlError(
+          "PROVIDER_ACCOUNT_CONTROL_FAILED",
+          "Codex account control is shutting down.",
+          true,
+        ),
+      );
+    }
+    const key = targetKey(target);
+    const previous = targetQueues.get(key) ?? Promise.resolve();
+    const result = previous.catch(() => undefined).then(async () => {
+      await retirePoisonedClient(target);
+      return operation();
+    });
+    const barrier = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    targetQueues.set(key, barrier);
+    void barrier.finally(() => {
+      if (targetQueues.get(key) === barrier) targetQueues.delete(key);
+    });
+    return result;
+  };
+
+  const resolve = (target: CodexProviderTarget) =>
+    Effect.runPromise(input.registry.resolveForManagement(target));
+
+  const openTrackedClient = async (
+    target: CodexProviderTarget,
+    launchContext: CodexProviderLaunchContext,
+  ): Promise<CodexAccountProtocolClient> => {
+    try {
+      return await input.openClient(launchContext, input.cwd);
+    } catch (cause) {
+      if (cause instanceof CodexAccountProtocolOpenError) {
+        unretiredClients.set(targetKey(target), {
+          target,
+          client: cause.unretiredClient,
+        });
+      }
+      throw cause;
+    }
+  };
+
+  const withTrackedAccountClient = async <A>(
+    resolution: ResolvedCodexProviderProfile,
+    operation: (client: CodexAccountProtocolClient) => Promise<A>,
+  ): Promise<A> => {
+    const target = resolution.summary.target;
+    const client = await openTrackedClient(target, resolution.launchContext);
+    let result: A;
+    try {
+      result = await operation(client);
+    } catch (cause) {
+      await retireClient(target, client);
+      throw cause;
+    }
+    await retireClient(target, client);
+    return result;
+  };
+
+  const assertMutableTarget = (target: CodexProviderTarget): void => {
+    if (target.profileId === DEFAULT_PROVIDER_PROFILE_ID) {
+      throw controlError(
+        "PROVIDER_ACCOUNT_TARGET_IMMUTABLE",
+        "Synara does not mutate the legacy default Codex account.",
+        false,
+      );
+    }
+  };
+
+  const assertBindableAccount = (account: DecodedAccountStatus): void => {
+    if (
+      account.status.authentication !== "signed-in" ||
+      account.status.authMode !== "chatgpt" ||
+      account.status.requiresOpenaiAuth !== true ||
+      !account.bindableChatGptShape
+    ) {
+      throw controlError(
+        "PROVIDER_ACCOUNT_UNSUPPORTED_AUTHENTICATION",
+        "Managed Codex profiles require a ChatGPT account.",
+        false,
+      );
+    }
+  };
+
+  const verifyAndSealManagedAccount = async (
+    resolution: ResolvedCodexProviderProfile,
+    account: DecodedAccountStatus,
+  ): Promise<void> => {
+    if (resolution.launchContext.home.strategy !== "managed-direct") return;
+    if (account.status.authentication !== "signed-in") return;
+    assertBindableAccount(account);
+    if (resolution.launchContext.authenticationBoundAt !== null) return;
+    assertManagedCodexAuthFilePrivate(resolution.launchContext.home.codexHomePath);
+    const verified = await withTrackedAccountClient(
+      resolution,
+      async (client) =>
+        readAccountResponse(
+          resolution.summary.target,
+          await client.request("account/read", { refreshToken: false }),
+        ),
+    );
+    assertBindableAccount(verified);
+    assertManagedCodexAuthFilePrivate(resolution.launchContext.home.codexHomePath);
+    syncManagedAuthState(resolution.launchContext.home.codexHomePath);
+    await Effect.runPromise(
+      input.registry.sealManagedAuthentication(resolution.summary.target),
+    );
+  };
+
+  const closeActiveLogin = async (active: ActiveLogin): Promise<void> => {
+    try {
+      await retireClient(active.target, active.client);
+    } finally {
+      clearTimeout(active.expiresTimer);
+      active.detachNotification();
+      active.detachUnexpectedClose();
+      if (activeLogins.get(targetKey(active.target)) === active) {
+        activeLogins.delete(targetKey(active.target));
+      }
+    }
+  };
+
+  const settleCompletedLogin = async (
+    active: ActiveLogin,
+  ): Promise<CodexProviderAccountStatus | undefined> => {
+    if (!active.completion) return undefined;
+    if (!active.completion.success) {
+      await closeActiveLogin(active);
+      return undefined;
+    }
+    let account: DecodedAccountStatus;
+    try {
+      account = readAccountResponse(
+        active.target,
+        await active.client.request("account/read", { refreshToken: false }),
+      );
+    } finally {
+      await closeActiveLogin(active);
+    }
+    if (account.status.authentication !== "signed-in") {
+      throw controlError(
+        "PROVIDER_ACCOUNT_LOGIN_RESPONSE_INVALID",
+        "Codex reported a completed login without a signed-in account.",
+        false,
+      );
+    }
+    await verifyAndSealManagedAccount(active.resolution, account);
+    return account.status;
+  };
+
+  const scheduleCompletion = (active: ActiveLogin): void => {
+    void serialize(active.target, async () => {
+      if (activeLogins.get(targetKey(active.target)) !== active) return;
+      await settleCompletedLogin(active);
+    }).catch(() => undefined);
+  };
+
+  const cancelActiveLogin = async (
+    target: CodexProviderTarget,
+  ): Promise<ProviderProfileLoginCancelResult> => {
+    const active = activeLogins.get(targetKey(target));
+    if (!active) return { target, status: "not-pending" };
+    if (active.completion) {
+      await settleCompletedLogin(active);
+      return { target, status: "not-pending" };
+    }
+
+    let canceled = false;
+    let account: DecodedAccountStatus | undefined;
+    try {
+      const response = await active.client.request("account/login/cancel", {
+        loginId: active.loginId,
+      });
+      if (active.completion) {
+        await settleCompletedLogin(active);
+        return { target, status: "not-pending" };
+      }
+      canceled = readCancelResponse(response);
+      if (!canceled) {
+        account = readAccountResponse(
+          target,
+          await active.client.request("account/read", { refreshToken: false }),
+        );
+      }
+    } finally {
+      if (activeLogins.get(targetKey(target)) === active) {
+        await closeActiveLogin(active);
+      }
+    }
+    if (account) await verifyAndSealManagedAccount(active.resolution, account);
+    return { target, status: canceled ? "canceled" : "not-pending" };
+  };
+
+  const readAccount = (target: CodexProviderTarget) =>
+    serialize(target, async () => {
+      const active = activeLogins.get(targetKey(target));
+      if (active?.completion) {
+        const settled = await settleCompletedLogin(active);
+        if (settled) return settled;
+      }
+      const pending = activeLogins.get(targetKey(target));
+      if (pending) {
+        const account = readAccountResponse(
+          target,
+          await pending.client.request("account/read", { refreshToken: false }),
+          pending,
+        );
+        if (account.status.authentication === "signed-in") {
+          await closeActiveLogin(pending);
+          const settledAccount = {
+            ...account,
+            status: { ...account.status, pendingLogin: null },
+          } as const;
+          await verifyAndSealManagedAccount(pending.resolution, settledAccount);
+          return settledAccount.status;
+        }
+        return account.status;
+      }
+
+      const resolution = await resolve(target);
+      const account = await withTrackedAccountClient(
+        resolution,
+        async (client) =>
+          readAccountResponse(
+            target,
+            await client.request("account/read", { refreshToken: false }),
+          ),
+      );
+      await verifyAndSealManagedAccount(resolution, account);
+      return account.status;
+    });
+
+  const startLogin = (request: {
+    readonly target: CodexProviderTarget;
+    readonly method: CodexProviderLoginMethod;
+  }): Promise<ProviderProfileLoginStartResult> =>
+    serialize(request.target, async () => {
+      assertMutableTarget(request.target);
+      const existing = activeLogins.get(targetKey(request.target));
+      if (existing?.completion) await settleCompletedLogin(existing);
+      const pending = activeLogins.get(targetKey(request.target));
+      if (pending) {
+        if (pending.method === request.method) return pending.result;
+        throw controlError(
+          "PROVIDER_ACCOUNT_LOGIN_METHOD_CONFLICT",
+          "A different Codex account login method is already pending for this profile.",
+          false,
+        );
+      }
+
+      const resolution = await resolve(request.target);
+      if (
+        resolution.launchContext.home.strategy === "managed-direct" &&
+        resolution.launchContext.authenticationBoundAt !== null
+      ) {
+        throw controlError(
+          "PROVIDER_ACCOUNT_AUTHENTICATION_BOUND",
+          "This managed Codex profile is permanently bound to its original account.",
+          false,
+        );
+      }
+
+      const client = await openTrackedClient(request.target, resolution.launchContext);
+      let clientRetired = false;
+      let detachNotification = () => undefined;
+      let detachUnexpectedClose = () => undefined;
+      try {
+        const currentAccount = readAccountResponse(
+          request.target,
+          await client.request("account/read", { refreshToken: false }),
+        );
+        if (currentAccount.status.authentication === "signed-in") {
+          await retireClient(request.target, client);
+          clientRetired = true;
+          await verifyAndSealManagedAccount(resolution, currentAccount);
+          throw controlError(
+            "PROVIDER_ACCOUNT_ALREADY_SIGNED_IN",
+            "The Codex provider profile is already signed in.",
+            false,
+          );
+        }
+
+        const bufferedCompletions: CodexAccountProtocolNotification[] = [];
+        detachNotification = client.onNotification((notification) => {
+          if (
+            notification.method === "account/login/completed" &&
+            bufferedCompletions.length < 8
+          ) {
+            bufferedCompletions.push(notification);
+          }
+        });
+        const response = await client.request(
+          "account/login/start",
+          loginParams(request.method),
+        );
+        const started = readLoginStartResponse(request.method, response);
+        const expiresAtMs = now() + loginLifetimeMs;
+        let active: ActiveLogin;
+        const expiresTimer = setTimeout(() => {
+          void serialize(request.target, async () => {
+            if (activeLogins.get(targetKey(request.target)) !== active) return;
+            await cancelActiveLogin(request.target);
+          }).catch(() => undefined);
+        }, loginLifetimeMs);
+        expiresTimer.unref();
+
+        active = {
+          target: request.target,
+          loginId: started.loginId,
+          method: request.method,
+          client,
+          resolution,
+          result: {
+            target: request.target,
+            challenge: started.challenge,
+            expiresAt: new Date(expiresAtMs).toISOString(),
+          },
+          expiresTimer,
+          detachNotification,
+          detachUnexpectedClose: () => undefined,
+        };
+        detachNotification();
+        active.detachNotification = client.onNotification((notification) => {
+          const completion = readLoginCompletion(notification, active.loginId);
+          if (!completion || active.completion) return;
+          active.completion = completion;
+          scheduleCompletion(active);
+        });
+        detachUnexpectedClose = client.onUnexpectedClose(() => {
+          void serialize(request.target, async () => {
+            if (activeLogins.get(targetKey(request.target)) !== active) return;
+            await closeActiveLogin(active);
+          }).catch(() => undefined);
+        });
+        active.detachUnexpectedClose = detachUnexpectedClose;
+        activeLogins.set(targetKey(request.target), active);
+        const buffered = bufferedCompletions
+          .map((notification) => readLoginCompletion(notification, active.loginId))
+          .filter((completion): completion is LoginCompletion => completion !== undefined)
+          .at(-1);
+        if (buffered) {
+          active.completion = buffered;
+          scheduleCompletion(active);
+        }
+        return active.result;
+      } catch (cause) {
+        detachNotification();
+        detachUnexpectedClose();
+        if (!clientRetired) await retireClient(request.target, client);
+        throw cause;
+      }
+    });
+
+  const logoutResolvedProfile = async (
+    resolution: ResolvedCodexProviderProfile,
+  ): Promise<{
+    readonly account: CodexProviderAccountStatus;
+    readonly snapshot: ProviderProfilesSnapshot;
+  }> => {
+    const target = resolution.summary.target;
+    const account = await withTrackedAccountClient(
+      resolution,
+      async (client) => {
+        await client.request("account/logout");
+        const after = readAccountResponse(
+          target,
+          await client.request("account/read", { refreshToken: false }),
+        );
+        if (after.status.authentication !== "signed-out") {
+          throw controlError(
+            "PROVIDER_ACCOUNT_LOGOUT_UNCONFIRMED",
+            "Codex account logout could not be confirmed.",
+            true,
+          );
+        }
+        return after.status;
+      },
+    );
+    if (resolution.launchContext.home.strategy === "managed-direct") {
+      syncManagedLoggedOutState(resolution.launchContext.home.codexHomePath);
+    }
+    const snapshot = await Effect.runPromise(input.registry.tombstone({ target }));
+    return { account, snapshot };
+  };
+
+  const logoutAndTombstone = async (target: CodexProviderTarget) => {
+    assertMutableTarget(target);
+    await cancelActiveLogin(target);
+    return logoutResolvedProfile(await resolve(target));
+  };
+
+  const service: CodexAccountControlShape = {
+    readAccount: ({ target }) => accountEffect(() => readAccount(target)),
+    startLogin: (request) => accountEffect(() => startLogin(request)),
+    cancelLogin: ({ target }) =>
+      accountEffect(() =>
+        serialize(target, () => {
+          assertMutableTarget(target);
+          return cancelActiveLogin(target);
+        }),
+      ),
+    logout: ({ target }) =>
+      accountEffect(() =>
+        serialize(target, async (): Promise<ProviderProfileLogoutResult> => {
+          assertMutableTarget(target);
+          const existing = await Effect.runPromise(
+            input.registry.list({ provider: "codex" }),
+          );
+          if (
+            existing.profiles.some(
+              (profile) =>
+                profile.target.profileId === target.profileId &&
+                profile.lifecycle === "tombstoned",
+            )
+          ) {
+            return { target, account: signedOutAccount(target) };
+          }
+          const result = await logoutAndTombstone(target);
+          return { target, account: result.account };
+        }),
+      ),
+    setEnabled: (request) =>
+      accountEffect(() =>
+        serialize(request.target, async () => {
+          assertMutableTarget(request.target);
+          if (!request.enabled) await cancelActiveLogin(request.target);
+          return Effect.runPromise(input.registry.setEnabled(request));
+        }),
+      ),
+    tombstone: ({ target }) =>
+      accountEffect(() =>
+        serialize(target, async () => {
+          assertMutableTarget(target);
+          const existing = await Effect.runPromise(
+            input.registry.list({ provider: "codex" }),
+          );
+          if (
+            existing.profiles.some(
+              (profile) =>
+                profile.target.profileId === target.profileId &&
+                profile.lifecycle === "tombstoned",
+            )
+          ) {
+            return existing;
+          }
+          await cancelActiveLogin(target);
+          const resolution = await resolve(target);
+          if (
+            resolution.launchContext.home.strategy === "managed-direct" &&
+            resolution.launchContext.authenticationBoundAt === null &&
+            !inspectManagedCodexAuthFile(resolution.launchContext.home.codexHomePath)
+          ) {
+            syncManagedLoggedOutState(resolution.launchContext.home.codexHomePath);
+            return Effect.runPromise(input.registry.tombstone({ target }));
+          }
+          return (await logoutResolvedProfile(resolution)).snapshot;
+        }),
+      ),
+  };
+
+  const shutdown = async (): Promise<void> => {
+    if (shutdownPromise) return shutdownPromise;
+    shuttingDown = true;
+    shutdownPromise = (async () => {
+      await Promise.allSettled([...targetQueues.values()]);
+      const active = [...activeLogins.values()];
+      const poisoned = [...unretiredClients.values()];
+      const retirements = await Promise.allSettled([
+        ...active.map((login) => retryOnce(() => closeActiveLogin(login))),
+        ...poisoned.map(({ target, client }) =>
+          retryOnce(() => retireClient(target, client)),
+        ),
+      ]);
+      if (retirements.some((result) => result.status === "rejected")) {
+        throw new Error("One or more Codex account process trees could not be retired.");
+      }
+    })();
+    try {
+      await shutdownPromise;
+    } catch (cause) {
+      shutdownPromise = undefined;
+      throw cause;
+    }
+  };
+
+  return { service, shutdown };
+}
+
+export const CodexAccountControlLive = Layer.effect(
+  CodexAccountControl,
+  Effect.gen(function* () {
+    const runtime = yield* makeCodexAccountControl;
+    yield* Effect.addFinalizer(() => Effect.promise(runtime.shutdown));
+    return runtime.service;
+  }),
+);
+
+function accountEffect<A>(
+  operation: () => Promise<A>,
+): Effect.Effect<A, CodexAccountControlError | ProviderProfileRegistryError> {
+  return Effect.tryPromise({
+    try: operation,
+    catch: normalizeAccountControlError,
+  });
+}
+
+function normalizeAccountControlError(
+  cause: unknown,
+): CodexAccountControlError | ProviderProfileRegistryError {
+  if (cause instanceof CodexAccountControlError || cause instanceof ProviderProfileRegistryError) {
+    return cause;
+  }
+  if (cause instanceof CodexAccountProtocolVersionError) {
+    return controlError(
+      "PROVIDER_ACCOUNT_VERSION_UNSUPPORTED",
+      "Codex CLI v0.144.0 or newer is required for account control.",
+      false,
+      cause,
+    );
+  }
+  if (cause instanceof CodexAccountProtocolRequestError) {
+    if (cause.rpcCode === -32601) {
+      return controlError(
+        "PROVIDER_ACCOUNT_VERSION_UNSUPPORTED",
+        "The installed Codex CLI does not support account control.",
+        false,
+        cause,
+      );
+    }
+    const unsupportedLoginMethod =
+      cause.method === "account/login/start" &&
+      cause.rpcCode === -32602;
+    return unsupportedLoginMethod
+      ? controlError(
+          "PROVIDER_ACCOUNT_LOGIN_METHOD_UNAVAILABLE",
+          "This Codex CLI does not support the requested account login method.",
+          false,
+          cause,
+        )
+      : controlError(
+          "PROVIDER_ACCOUNT_CONTROL_FAILED",
+          "The Codex account operation failed.",
+          true,
+          cause,
+        );
+  }
+  return controlError(
+    "PROVIDER_ACCOUNT_CONTROL_FAILED",
+    "The Codex account operation failed.",
+    true,
+    cause,
+  );
+}
+
+function controlError(
+  code: CodexAccountControlErrorCode,
+  message: string,
+  retryable: boolean,
+  cause?: unknown,
+): CodexAccountControlError {
+  return new CodexAccountControlError({
+    code,
+    message,
+    retryable,
+    ...(cause === undefined ? {} : { cause }),
+  });
+}
+
+async function retryOnce(operation: () => Promise<void>): Promise<void> {
+  try {
+    await operation();
+  } catch {
+    await operation();
+  }
+}
+
+function readAccountResponse(
+  target: CodexProviderTarget,
+  response: unknown,
+  pending?: ActiveLogin,
+): DecodedAccountStatus {
+  const record = asRecord(response);
+  if (
+    !record ||
+    typeof record.requiresOpenaiAuth !== "boolean" ||
+    !("account" in record) ||
+    (record.account !== null && !asRecord(record.account))
+  ) {
+    throw controlError(
+      "PROVIDER_ACCOUNT_PROTOCOL_INVALID",
+      "Codex returned an invalid account status.",
+      false,
+    );
+  }
+  const account = record.account === null ? undefined : asRecord(record.account);
+  const authMode = readAuthMode(account?.type);
+  return {
+    status: {
+      target,
+      authentication: account ? "signed-in" : "signed-out",
+      requiresOpenaiAuth: record.requiresOpenaiAuth,
+      authMode,
+      email: boundedOptionalString(account?.email, ACCOUNT_EMAIL_MAX_LENGTH),
+      planType: boundedOptionalString(account?.planType, ACCOUNT_PLAN_MAX_LENGTH),
+      pendingLogin: pending
+        ? { method: pending.method, expiresAt: pending.result.expiresAt }
+        : null,
+    },
+    bindableChatGptShape: hasBindableChatGptShape(account),
+  };
+}
+
+function hasBindableChatGptShape(
+  account: Record<string, unknown> | undefined,
+): boolean {
+  if (!account || account.type !== "chatgpt") return false;
+  const hasEmail = Object.prototype.hasOwnProperty.call(account, "email");
+  const email = account.email;
+  const validEmail = email === null || boundedRequiredString(email, ACCOUNT_EMAIL_MAX_LENGTH);
+  const hasPlanType = Object.prototype.hasOwnProperty.call(account, "planType");
+  return Boolean(
+    hasEmail &&
+      validEmail &&
+      hasPlanType &&
+      boundedRequiredString(account.planType, ACCOUNT_PLAN_MAX_LENGTH),
+  );
+}
+
+function signedOutAccount(target: CodexProviderTarget): CodexProviderAccountStatus {
+  return {
+    target,
+    authentication: "signed-out",
+    requiresOpenaiAuth: true,
+    authMode: null,
+    email: null,
+    planType: null,
+    pendingLogin: null,
+  };
+}
+
+function readAuthMode(type: unknown): CodexProviderAccountAuthMode | null {
+  if (type === "apiKey") return "api-key";
+  if (type === "chatgpt") return "chatgpt";
+  if (type === "amazonBedrock") return "amazon-bedrock";
+  return typeof type === "string" ? "other" : null;
+}
+
+function loginParams(method: CodexProviderLoginMethod): unknown {
+  return method === "browser" ? { type: "chatgpt" } : { type: "chatgptDeviceCode" };
+}
+
+function readLoginStartResponse(
+  method: CodexProviderLoginMethod,
+  response: unknown,
+): { readonly loginId: string; readonly challenge: CodexProviderLoginChallenge } {
+  const record = asRecord(response);
+  const loginId = boundedRequiredString(record?.loginId, LOGIN_ID_MAX_LENGTH);
+  if (!record || !loginId) throw invalidLoginStartResponse();
+  if (method === "browser") {
+    const authUrl = readHttpUrl(record.authUrl);
+    if (record.type !== "chatgpt" || !authUrl) throw invalidLoginStartResponse();
+    return { loginId, challenge: { method, authUrl } };
+  }
+  const verificationUrl = readHttpUrl(record.verificationUrl);
+  const userCode = boundedRequiredString(record.userCode, LOGIN_USER_CODE_MAX_LENGTH);
+  if (record.type !== "chatgptDeviceCode" || !verificationUrl || !userCode) {
+    throw invalidLoginStartResponse();
+  }
+  return { loginId, challenge: { method, verificationUrl, userCode } };
+}
+
+function invalidLoginStartResponse(): CodexAccountControlError {
+  return controlError(
+    "PROVIDER_ACCOUNT_LOGIN_RESPONSE_INVALID",
+    "Codex returned an invalid account login challenge.",
+    false,
+  );
+}
+
+function readLoginCompletion(
+  notification: CodexAccountProtocolNotification,
+  expectedLoginId?: string,
+): LoginCompletion | undefined {
+  if (notification.method !== "account/login/completed") return undefined;
+  const params = asRecord(notification.params);
+  if (!params || typeof params.success !== "boolean") return undefined;
+  const loginId = params.loginId;
+  if (
+    loginId !== undefined &&
+    loginId !== null &&
+    (typeof loginId !== "string" || loginId.length > LOGIN_ID_MAX_LENGTH)
+  ) {
+    return undefined;
+  }
+  if (
+    expectedLoginId !== undefined &&
+    typeof loginId === "string" &&
+    loginId !== expectedLoginId
+  ) {
+    return undefined;
+  }
+  return { success: params.success };
+}
+
+function readCancelResponse(response: unknown): boolean {
+  const status = asRecord(response)?.status;
+  if (status === "canceled") return true;
+  if (status === "notFound") return false;
+  throw controlError(
+    "PROVIDER_ACCOUNT_PROTOCOL_INVALID",
+    "Codex returned an invalid login cancellation result.",
+    false,
+  );
+}
+
+function readHttpUrl(value: unknown): string | undefined {
+  const text = boundedRequiredString(value, LOGIN_URL_MAX_LENGTH);
+  if (!text) return undefined;
+  try {
+    const parsed = new URL(text);
+    return parsed.protocol === "http:" || parsed.protocol === "https:" ? text : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function boundedRequiredString(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > maxLength) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function boundedOptionalString(value: unknown, maxLength: number): string | null {
+  return boundedRequiredString(value, maxLength) ?? null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function targetKey(target: CodexProviderTarget): string {
+  return `${target.provider}:${target.profileId}`;
+}

--- a/apps/server/src/provider/Layers/ProviderProfileRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderProfileRegistry.test.ts
@@ -153,6 +153,7 @@ describe("ProviderProfileRegistryLive", () => {
         const disabledRuntimeCreatedStorage = fs.existsSync(
           managementResolution.launchContext.home.codexSqliteHomePath,
         );
+        yield* registry.sealManagedAuthentication(managed.target);
         const enabled = yield* registry.setEnabled({ target: managed.target, enabled: true });
         const runtimeResolution = yield* registry.resolveForRuntime(managed.target);
         return {
@@ -189,7 +190,7 @@ describe("ProviderProfileRegistryLive", () => {
 
     expect(result.managementResolution.summary.enabled).toBe(false);
     expect(result.managementResolution.launchContext.registryRevision).toBe(1);
-    expect(result.runtimeResolution.launchContext.registryRevision).toBe(2);
+    expect(result.runtimeResolution.launchContext.registryRevision).toBe(3);
     expect(result.managementResolution.launchContext.home).toEqual(
       result.runtimeResolution.launchContext.home,
     );
@@ -203,7 +204,9 @@ describe("ProviderProfileRegistryLive", () => {
     expect(fs.readdirSync(launchContext.home.codexHomePath)).toEqual(["config.toml"]);
     expect(
       fs.readFileSync(path.join(launchContext.home.codexHomePath, "config.toml"), "utf8"),
-    ).toBe('model = "managed"\n');
+    ).toBe(
+      'project_root_markers = [".synara-provider-profile-root"]\nmodel_provider = "openai"\nforced_login_method = "chatgpt"\ncli_auth_credentials_store = "file"\nmcp_oauth_credentials_store = "file"\n',
+    );
     expect(fs.readdirSync(launchContext.home.codexSqliteHomePath)).toEqual([]);
     expect(fs.readFileSync(path.join(sourceHome, "auth.json"), "utf8")).toBe("source-secret");
     expect(fs.existsSync(path.join(launchContext.home.codexHomePath, "auth.json"))).toBe(false);
@@ -247,6 +250,7 @@ describe("ProviderProfileRegistryLive", () => {
         expect(conflict.code).toBe("PROVIDER_PROFILE_NAME_CONFLICT");
         expect((yield* registry.list({ provider: "codex" })).profiles).toHaveLength(2);
         yield* registry.rename({ target, displayName: "Client" });
+        yield* registry.sealManagedAuthentication(target);
         yield* registry.setEnabled({ target, enabled: true });
         const activeResolution = yield* registry.resolveForManagement(target);
         if (activeResolution.launchContext.home.strategy !== "managed-direct") {
@@ -313,6 +317,7 @@ describe("ProviderProfileRegistryLive", () => {
         const created = yield* registry.create({ provider: "codex", displayName: "Work" });
         const createdTarget = created.profiles[1]!.target;
         target = createdTarget;
+        yield* registry.sealManagedAuthentication(createdTarget);
         yield* registry.setEnabled({ target: createdTarget, enabled: true });
       }),
     );
@@ -438,6 +443,93 @@ describe("ProviderProfileRegistryLive", () => {
 
     expect(error.code).toBe("PROVIDER_PROFILE_REGISTRY_INVALID");
     expect(fs.readFileSync(indexPath, "utf8")).toBe(invalidContents);
+  });
+
+  it("migrates v1 enabled profiles to disabled and unbound with a stable private namespace", async () => {
+    const baseDir = makeBaseDir();
+    const storageKey = "11111111-1111-4111-8111-111111111111";
+    const profile = { ...storedProfile("codex_one", storageKey), enabled: true };
+    const indexPath = path.join(baseDir, "userdata", "provider-profiles", "index.json");
+    fs.mkdirSync(path.dirname(indexPath), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(
+      indexPath,
+      `${JSON.stringify({ version: 1, revision: 7, profiles: [profile] }, null, 2)}\n`,
+      { mode: 0o600 },
+    );
+
+    const result = await runWithRegistry(
+      baseDir,
+      Effect.gen(function* () {
+        const registry = yield* ProviderProfileRegistry;
+        const target = { provider: "codex" as const, profileId: profile.profileId };
+        const snapshot = yield* registry.list({ provider: "codex" });
+        const resolution = yield* registry.resolveForManagement(target);
+        const enableError = yield* registry
+          .setEnabled({ target, enabled: true })
+          .pipe(Effect.flip);
+        return { snapshot, resolution, enableError };
+      }),
+    );
+
+    expect(result.snapshot.profiles[1]?.enabled).toBe(false);
+    expect(JSON.stringify(result.snapshot)).not.toContain(storageKey);
+    expect(result.enableError.code).toBe("PROVIDER_PROFILE_AUTHENTICATION_UNBOUND");
+    expect(result.resolution.launchContext.home.strategy).toBe("managed-direct");
+    if (result.resolution.launchContext.home.strategy !== "managed-direct") {
+      throw new Error("Expected managed launch context");
+    }
+    expect(result.resolution.launchContext.authenticationBoundAt).toBeNull();
+    expect(result.resolution.launchContext.continuationNamespaceId).toBe(storageKey);
+
+    const persisted = JSON.parse(fs.readFileSync(indexPath, "utf8")) as {
+      version: number;
+      revision: number;
+      profiles: Array<{ enabled: boolean; authenticationBoundAt: string | null }>;
+    };
+    expect(persisted).toMatchObject({
+      version: 2,
+      revision: 8,
+      profiles: [{ enabled: false, authenticationBoundAt: null }],
+    });
+
+    const reloaded = await runWithRegistry(
+      baseDir,
+      Effect.gen(function* () {
+        const registry = yield* ProviderProfileRegistry;
+        const target = { provider: "codex" as const, profileId: profile.profileId };
+        return yield* registry.resolveForManagement(target);
+      }),
+    );
+    expect(reloaded.launchContext.registryRevision).toBe(8);
+    expect(fs.readFileSync(indexPath, "utf8")).toBe(
+      `${JSON.stringify(persisted, null, 2)}\n`,
+    );
+  });
+
+  it("rejects a v2 enabled profile with a noncanonical authentication binding", async () => {
+    const baseDir = makeBaseDir();
+    const indexPath = path.join(baseDir, "userdata", "provider-profiles", "index.json");
+    fs.mkdirSync(path.dirname(indexPath), { recursive: true, mode: 0o700 });
+    const profile = {
+      ...storedProfile("codex_one", "11111111-1111-4111-8111-111111111111"),
+      enabled: true,
+      authenticationBoundAt: "x",
+    };
+    fs.writeFileSync(
+      indexPath,
+      `${JSON.stringify({ version: 2, revision: 7, profiles: [profile] }, null, 2)}\n`,
+      { mode: 0o600 },
+    );
+
+    const error = await runWithRegistry(
+      baseDir,
+      Effect.gen(function* () {
+        const registry = yield* ProviderProfileRegistry;
+        return yield* registry.list({ provider: "codex" });
+      }).pipe(Effect.flip),
+    );
+
+    expect(error.code).toBe("PROVIDER_PROFILE_REGISTRY_INVALID");
   });
 
   it("leaves an inert private orphan instead of publishing a profile when index persistence fails", async () => {

--- a/apps/server/src/provider/Layers/ProviderProfileRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderProfileRegistry.ts
@@ -38,10 +38,29 @@ import {
   type ProviderProfileRegistryShape,
 } from "../Services/ProviderProfileRegistry";
 
-const REGISTRY_VERSION = 1;
+const REGISTRY_VERSION = 2;
 const DEFAULT_PROFILE_DISPLAY_NAME = "Default";
 
 const StorageKey = Schema.String.check(Schema.isPattern(/^[0-9a-f-]{36}$/u));
+const CanonicalIsoInstant = Schema.String.check(
+  Schema.makeFilter((value: string) => {
+    try {
+      return new Date(value).toISOString() === value;
+    } catch {
+      return false;
+    }
+  }),
+);
+
+const StoredCodexProfileV1 = Schema.Struct({
+  profileId: ProviderProfileId,
+  storageKey: StorageKey,
+  displayName: ProviderProfileDisplayName,
+  enabled: Schema.Boolean,
+  createdAt: Schema.String,
+  updatedAt: Schema.String,
+  tombstonedAt: Schema.NullOr(Schema.String),
+});
 
 const StoredCodexProfile = Schema.Struct({
   profileId: ProviderProfileId,
@@ -51,8 +70,15 @@ const StoredCodexProfile = Schema.Struct({
   createdAt: Schema.String,
   updatedAt: Schema.String,
   tombstonedAt: Schema.NullOr(Schema.String),
+  authenticationBoundAt: Schema.NullOr(CanonicalIsoInstant),
 });
 type StoredCodexProfile = typeof StoredCodexProfile.Type;
+
+const StoredProviderProfileRegistryV1 = Schema.Struct({
+  version: Schema.Literal(1),
+  revision: NonNegativeInt,
+  profiles: Schema.Array(StoredCodexProfileV1),
+});
 
 const StoredProviderProfileRegistry = Schema.Struct({
   version: Schema.Literal(REGISTRY_VERSION),
@@ -60,6 +86,11 @@ const StoredProviderProfileRegistry = Schema.Struct({
   profiles: Schema.Array(StoredCodexProfile),
 });
 type StoredProviderProfileRegistry = typeof StoredProviderProfileRegistry.Type;
+
+const PersistedProviderProfileRegistry = Schema.Union([
+  StoredProviderProfileRegistryV1,
+  StoredProviderProfileRegistry,
+]);
 
 type ActiveProfileInspection = Readonly<{
   state: StoredProviderProfileRegistry;
@@ -109,6 +140,9 @@ function assertValidRegistry(state: StoredProviderProfileRegistry): StoredProvid
       storageKeys.has(profile.storageKey) ||
       !isCodexProfileStorageKey(profile.storageKey) ||
       (profile.tombstonedAt !== null && profile.enabled) ||
+      (profile.tombstonedAt === null &&
+        profile.enabled &&
+        profile.authenticationBoundAt === null) ||
       (profile.tombstonedAt === null && activeDisplayNames.has(normalizedName))
     ) {
       throw registryError(
@@ -165,6 +199,38 @@ function assertActive(profile: StoredCodexProfile): void {
   }
 }
 
+function assertAuthenticationBound(profile: StoredCodexProfile): void {
+  if (profile.authenticationBoundAt !== null) return;
+  throw registryError(
+    "PROVIDER_PROFILE_AUTHENTICATION_UNBOUND",
+    `Codex provider profile '${profile.profileId}' has not completed account login.`,
+  );
+}
+
+function migrateRegistry(
+  state: typeof PersistedProviderProfileRegistry.Type,
+): { readonly state: StoredProviderProfileRegistry; readonly migrated: boolean } {
+  if (state.version === REGISTRY_VERSION) return { state, migrated: false };
+  if (state.profiles.some((profile) => profile.tombstonedAt !== null && profile.enabled)) {
+    throw registryError(
+      "PROVIDER_PROFILE_REGISTRY_INVALID",
+      "The Codex provider profile registry is invalid.",
+    );
+  }
+  return {
+    migrated: true,
+    state: {
+      version: REGISTRY_VERSION,
+      revision: state.revision + 1,
+      profiles: state.profiles.map((profile) => ({
+        ...profile,
+        enabled: false,
+        authenticationBoundAt: null,
+      })),
+    },
+  };
+}
+
 function normalizedDisplayName(displayName: string): string {
   return displayName.toLowerCase();
 }
@@ -216,6 +282,26 @@ export const makeProviderProfileRegistry = Effect.gen(function* () {
   const profilesRoot = path.join(config.stateDir, "provider-profiles");
   const indexPath = path.join(profilesRoot, "index.json");
 
+  const persist = (state: StoredProviderProfileRegistry) =>
+    Effect.uninterruptible(
+      writeFileStringAtomically({
+        filePath: indexPath,
+        contents: `${JSON.stringify(state, null, 2)}\n`,
+      }).pipe(
+        Effect.mapError((cause) =>
+          registryError(
+            "PROVIDER_PROFILE_STORAGE_ERROR",
+            "Could not save the Codex provider profile registry.",
+            cause,
+          ),
+        ),
+        // The in-memory publication and disk rename are one transaction. An
+        // interrupt between them would let a later mutation overwrite a state
+        // that was already durably committed.
+        Effect.andThen(Ref.set(stateRef, state)),
+      ),
+    );
+
   const readRegistry = Effect.tryPromise({
     try: async () => {
       let handle: fs.FileHandle | undefined;
@@ -242,10 +328,13 @@ export const makeProviderProfileRegistry = Effect.gen(function* () {
   }).pipe(
     Effect.flatMap((contents) => {
       if (contents === null) {
-        return Effect.succeed<StoredProviderProfileRegistry>({
-          version: REGISTRY_VERSION,
-          revision: 0,
-          profiles: [],
+        return Effect.succeed({
+          state: {
+            version: REGISTRY_VERSION,
+            revision: 0,
+            profiles: [],
+          } satisfies StoredProviderProfileRegistry,
+          migrated: false,
         });
       }
       return Effect.try({
@@ -257,7 +346,16 @@ export const makeProviderProfileRegistry = Effect.gen(function* () {
             cause,
           ),
       }).pipe(
-        Effect.flatMap(Schema.decodeUnknownEffect(StoredProviderProfileRegistry)),
+        Effect.flatMap(Schema.decodeUnknownEffect(PersistedProviderProfileRegistry)),
+        Effect.flatMap((state) =>
+          registryAttempt(() => {
+            const migration = migrateRegistry(state);
+            return {
+              ...migration,
+              state: assertValidRegistry(migration.state),
+            };
+          }),
+        ),
         Effect.mapError((cause) =>
           cause instanceof ProviderProfileRegistryError
             ? cause
@@ -267,19 +365,6 @@ export const makeProviderProfileRegistry = Effect.gen(function* () {
                 cause,
               ),
         ),
-        Effect.flatMap((state) =>
-          Effect.try({
-            try: () => assertValidRegistry(state),
-            catch: (cause) =>
-              cause instanceof ProviderProfileRegistryError
-                ? cause
-                : registryError(
-                    "PROVIDER_PROFILE_REGISTRY_INVALID",
-                    "The Codex provider profile registry is invalid.",
-                    cause,
-                  ),
-          }),
-        ),
       );
     }),
   );
@@ -287,30 +372,16 @@ export const makeProviderProfileRegistry = Effect.gen(function* () {
   const loadState = Ref.get(stateRef).pipe(
     Effect.flatMap((cached) =>
       cached === null
-        ? readRegistry.pipe(Effect.tap((loaded) => Ref.set(stateRef, loaded)))
+        ? readRegistry.pipe(
+            Effect.flatMap(({ state, migrated }) =>
+              migrated
+                ? persist(state).pipe(Effect.as(state))
+                : Ref.set(stateRef, state).pipe(Effect.as(state)),
+            ),
+          )
         : Effect.succeed(cached),
     ),
   );
-
-  const persist = (state: StoredProviderProfileRegistry) =>
-    Effect.uninterruptible(
-      writeFileStringAtomically({
-        filePath: indexPath,
-        contents: `${JSON.stringify(state, null, 2)}\n`,
-      }).pipe(
-        Effect.mapError((cause) =>
-          registryError(
-            "PROVIDER_PROFILE_STORAGE_ERROR",
-            "Could not save the Codex provider profile registry.",
-            cause,
-          ),
-        ),
-        // The in-memory publication and disk rename are one transaction. An
-        // interrupt between them would let a later mutation overwrite a state
-        // that was already durably committed.
-        Effect.andThen(Ref.set(stateRef, state)),
-      ),
-    );
 
   const getSettingsSnapshot = serverSettings.getSnapshot.pipe(
     Effect.mapError((cause) =>
@@ -378,6 +449,7 @@ export const makeProviderProfileRegistry = Effect.gen(function* () {
               createdAt: timestamp,
               updatedAt: timestamp,
               tombstonedAt: null,
+              authenticationBoundAt: null,
             },
           ],
         };
@@ -422,6 +494,9 @@ export const makeProviderProfileRegistry = Effect.gen(function* () {
         const state = yield* loadState;
         const profile = yield* registryAttempt(() => findProfile(state, input.target));
         yield* registryAttempt(() => assertActive(profile));
+        if (input.enabled) {
+          yield* registryAttempt(() => assertAuthenticationBound(profile));
+        }
         if (profile.enabled === input.enabled) return yield* snapshot(state);
         const nextState: StoredProviderProfileRegistry = {
           ...state,
@@ -540,6 +615,8 @@ export const makeProviderProfileRegistry = Effect.gen(function* () {
         binaryPath: inspection.codexSettings.binaryPath,
         settingsRevision: inspection.settingsRevision,
         registryRevision: inspection.state.revision,
+        authenticationBoundAt: inspection.profile.authenticationBoundAt,
+        continuationNamespaceId: inspection.profile.storageKey,
         ...home,
       }),
     };
@@ -570,9 +647,39 @@ export const makeProviderProfileRegistry = Effect.gen(function* () {
             `Codex provider profile '${inspection.target.profileId}' is disabled.`,
           );
         }
+        if (inspection.profile !== null) {
+          yield* registryAttempt(() => assertAuthenticationBound(inspection.profile!));
+        }
         return yield* materializeResolvedProfile(inspection);
       }),
     );
+
+  const sealManagedAuthentication: ProviderProfileRegistryShape["sealManagedAuthentication"] =
+    (target) =>
+      lock.withPermits(1)(
+        Effect.gen(function* () {
+          yield* registryAttempt(() => assertManagedTarget(target));
+          const state = yield* loadState;
+          const profile = yield* registryAttempt(() => findProfile(state, target));
+          yield* registryAttempt(() => assertActive(profile));
+          if (profile.authenticationBoundAt !== null) return;
+          const timestamp = new Date().toISOString();
+          const nextState: StoredProviderProfileRegistry = {
+            ...state,
+            revision: state.revision + 1,
+            profiles: state.profiles.map((candidate) =>
+              candidate.profileId === profile.profileId
+                ? {
+                    ...candidate,
+                    authenticationBoundAt: timestamp,
+                    updatedAt: timestamp,
+                  }
+                : candidate,
+            ),
+          };
+          yield* persist(nextState);
+        }),
+      );
 
   return {
     list,
@@ -580,6 +687,7 @@ export const makeProviderProfileRegistry = Effect.gen(function* () {
     rename,
     setEnabled,
     tombstone,
+    sealManagedAuthentication,
     resolveForManagement,
     resolveForRuntime,
   } satisfies ProviderProfileRegistryShape;

--- a/apps/server/src/provider/Services/CodexAccountControl.ts
+++ b/apps/server/src/provider/Services/CodexAccountControl.ts
@@ -1,0 +1,70 @@
+import type {
+  CodexProviderAccountStatus,
+  ProviderProfileAccountReadInput,
+  ProviderProfileLoginCancelInput,
+  ProviderProfileLoginCancelResult,
+  ProviderProfileLoginStartInput,
+  ProviderProfileLoginStartResult,
+  ProviderProfileLogoutInput,
+  ProviderProfileLogoutResult,
+  ProviderProfilesSetEnabledInput,
+  ProviderProfilesSnapshot,
+  ProviderProfilesTombstoneInput,
+} from "@synara/contracts";
+import { Data, ServiceMap } from "effect";
+import type { Effect } from "effect";
+
+import type { ProviderProfileRegistryError } from "./ProviderProfileRegistry";
+
+export type CodexAccountControlErrorCode =
+  | "PROVIDER_ACCOUNT_ALREADY_SIGNED_IN"
+  | "PROVIDER_ACCOUNT_AUTHENTICATION_BOUND"
+  | "PROVIDER_ACCOUNT_CONTROL_FAILED"
+  | "PROVIDER_ACCOUNT_LOGIN_METHOD_CONFLICT"
+  | "PROVIDER_ACCOUNT_LOGIN_METHOD_UNAVAILABLE"
+  | "PROVIDER_ACCOUNT_LOGIN_RESPONSE_INVALID"
+  | "PROVIDER_ACCOUNT_LOGOUT_UNCONFIRMED"
+  | "PROVIDER_ACCOUNT_PROTOCOL_INVALID"
+  | "PROVIDER_ACCOUNT_TARGET_IMMUTABLE"
+  | "PROVIDER_ACCOUNT_UNSUPPORTED_AUTHENTICATION"
+  | "PROVIDER_ACCOUNT_VERSION_UNSUPPORTED";
+
+export class CodexAccountControlError extends Data.TaggedError(
+  "CodexAccountControlError",
+)<{
+  readonly code: CodexAccountControlErrorCode;
+  readonly message: string;
+  readonly retryable: boolean;
+  readonly cause?: unknown;
+}> {}
+
+type AccountControlEffect<A> = Effect.Effect<
+  A,
+  CodexAccountControlError | ProviderProfileRegistryError
+>;
+
+export interface CodexAccountControlShape {
+  readonly readAccount: (
+    input: ProviderProfileAccountReadInput,
+  ) => AccountControlEffect<CodexProviderAccountStatus>;
+  readonly startLogin: (
+    input: ProviderProfileLoginStartInput,
+  ) => AccountControlEffect<ProviderProfileLoginStartResult>;
+  readonly cancelLogin: (
+    input: ProviderProfileLoginCancelInput,
+  ) => AccountControlEffect<ProviderProfileLoginCancelResult>;
+  readonly logout: (
+    input: ProviderProfileLogoutInput,
+  ) => AccountControlEffect<ProviderProfileLogoutResult>;
+  readonly setEnabled: (
+    input: ProviderProfilesSetEnabledInput,
+  ) => AccountControlEffect<ProviderProfilesSnapshot>;
+  readonly tombstone: (
+    input: ProviderProfilesTombstoneInput,
+  ) => AccountControlEffect<ProviderProfilesSnapshot>;
+}
+
+export class CodexAccountControl extends ServiceMap.Service<
+  CodexAccountControl,
+  CodexAccountControlShape
+>()("synara/provider/Services/CodexAccountControl") {}

--- a/apps/server/src/provider/Services/ProviderProfileRegistry.ts
+++ b/apps/server/src/provider/Services/ProviderProfileRegistry.ts
@@ -15,6 +15,7 @@ import type { CodexProviderLaunchContext } from "../codexProviderLaunchContext";
 
 export type ProviderProfileRegistryErrorCode =
   | "PROVIDER_PROFILE_DEFAULT_IMMUTABLE"
+  | "PROVIDER_PROFILE_AUTHENTICATION_UNBOUND"
   | "PROVIDER_PROFILE_DISABLED"
   | "PROVIDER_PROFILE_NAME_CONFLICT"
   | "PROVIDER_PROFILE_NOT_FOUND"
@@ -52,6 +53,9 @@ export interface ProviderProfileRegistryShape {
   readonly tombstone: (
     input: ProviderProfilesTombstoneInput,
   ) => Effect.Effect<ProviderProfilesSnapshot, ProviderProfileRegistryError>;
+  readonly sealManagedAuthentication: (
+    target: CodexProviderTarget,
+  ) => Effect.Effect<void, ProviderProfileRegistryError>;
   /** Resolves active profile storage for login and other control-plane work. */
   readonly resolveForManagement: (
     target: CodexProviderTarget,

--- a/apps/server/src/provider/codexAccountProcessEnv.test.ts
+++ b/apps/server/src/provider/codexAccountProcessEnv.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import { buildProviderChildEnvironment } from "../providerChildEnvironment";
+import {
+  makeLegacyCodexLaunchContext,
+  makeManagedCodexLaunchContext,
+} from "./codexProviderLaunchContext";
+import { buildCodexAccountProcessEnv } from "./codexAccountProcessEnv";
+
+const target = { provider: "codex" as const, profileId: "profile-1" };
+
+describe("buildCodexAccountProcessEnv", () => {
+  it("preserves the legacy account-control environment behavior", () => {
+    const sourceHomePath = "/profiles/legacy-codex";
+    const baseEnv = {
+      PATH: "/usr/bin",
+      HOME: "/home/tester",
+      CODEX_HOME: "/inherited/codex-home",
+      CODEX_SQLITE_HOME: "/inherited/sqlite-home",
+      ANTHROPIC_API_KEY: "legacy-upstream-key",
+      SYNARA_AUTH_TOKEN: "control-plane-secret",
+      NODE_OPTIONS: "--require=/tmp/inject.js",
+      CUSTOM_PROVIDER_TOKEN: "legacy-custom-provider-token",
+    };
+    const launchContext = makeLegacyCodexLaunchContext({
+      target,
+      binaryPath: "/usr/bin/codex",
+      settingsRevision: 3,
+      registryRevision: 0,
+      sourceHomePath,
+    });
+
+    const actual = buildCodexAccountProcessEnv({ launchContext, env: baseEnv });
+    const expected = buildProviderChildEnvironment({
+      provider: "codex",
+      baseEnv: { ...baseEnv, CODEX_HOME: sourceHomePath },
+    });
+
+    expect(actual).toEqual(expected);
+    expect(actual.CODEX_HOME).toBe(sourceHomePath);
+    expect(actual.ANTHROPIC_API_KEY).toBe("legacy-upstream-key");
+    expect(actual.CUSTOM_PROVIDER_TOKEN).toBe("legacy-custom-provider-token");
+  });
+
+  it("anchors a relative legacy home to the account-process cwd", () => {
+    const baseEnv = { PATH: "/usr/bin", HOME: "/home/tester" };
+    const launchContext = makeLegacyCodexLaunchContext({
+      target,
+      binaryPath: "/usr/bin/codex",
+      settingsRevision: 3,
+      registryRevision: 0,
+      sourceHomePath: "relative-codex-home",
+    });
+
+    const actual = buildCodexAccountProcessEnv({
+      launchContext,
+      env: baseEnv,
+      cwd: "/srv/synara-home",
+    });
+
+    expect(actual.CODEX_HOME).toBe("/srv/synara-home/relative-codex-home");
+  });
+
+  it("gives managed account control only operational environment values", () => {
+    const codexHomePath = "/profiles/managed/home";
+    const codexSqliteHomePath = "/profiles/managed/sqlite";
+    const launchContext = makeManagedCodexLaunchContext({
+      target,
+      binaryPath: "/usr/bin/codex",
+      settingsRevision: 3,
+      registryRevision: 4,
+      authenticationBoundAt: null,
+      continuationNamespaceId: "managed-storage-key",
+      codexHomePath,
+      codexSqliteHomePath,
+    });
+    const inheritedEnvironment = {
+      PATH: "/usr/bin:/bin",
+      HOME: "/home/tester",
+      TMPDIR: "/tmp/tester",
+      LANG: "en_US.UTF-8",
+      CODEX_HOME: "/host/codex-home",
+      CODEX_SQLITE_HOME: "/host/codex-sqlite-home",
+      OPENAI_API_KEY: "openai-secret",
+      ANTHROPIC_API_KEY: "anthropic-secret",
+      CUSTOM_PROVIDER_TOKEN: "custom-provider-secret",
+      DATABASE_URL: "postgres://secret@example.test/database",
+      UNRELATED_FEATURE_FLAG: "enabled",
+      SYNARA_AUTH_TOKEN: "control-plane-secret",
+      NODE_OPTIONS: "--require=/tmp/inject.js",
+    };
+
+    const result = buildCodexAccountProcessEnv({
+      launchContext,
+      env: inheritedEnvironment,
+    });
+
+    expect(result).toMatchObject({
+      PATH: inheritedEnvironment.PATH,
+      TMPDIR: inheritedEnvironment.TMPDIR,
+      LANG: inheritedEnvironment.LANG,
+      HOME: "/profiles/managed",
+      USERPROFILE: "/profiles/managed",
+      CODEX_HOME: codexHomePath,
+      CODEX_SQLITE_HOME: codexSqliteHomePath,
+    });
+    expect(result.OPENAI_API_KEY).toBeUndefined();
+    expect(result.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(result.CUSTOM_PROVIDER_TOKEN).toBeUndefined();
+    expect(result.DATABASE_URL).toBeUndefined();
+    expect(result.UNRELATED_FEATURE_FLAG).toBeUndefined();
+    expect(result.SYNARA_AUTH_TOKEN).toBeUndefined();
+    expect(result.NODE_OPTIONS).toBeUndefined();
+    expect(inheritedEnvironment.CODEX_HOME).toBe("/host/codex-home");
+    expect(inheritedEnvironment.CODEX_SQLITE_HOME).toBe("/host/codex-sqlite-home");
+  });
+
+  it("normalizes Windows path variables without copying their ambient casing", () => {
+    const launchContext = makeManagedCodexLaunchContext({
+      target,
+      binaryPath: "C:\\codex.exe",
+      settingsRevision: 3,
+      registryRevision: 4,
+      authenticationBoundAt: null,
+      continuationNamespaceId: "managed-storage-key",
+      codexHomePath: "C:\\profiles\\managed\\home",
+      codexSqliteHomePath: "C:\\profiles\\managed\\sqlite",
+    });
+
+    const result = buildCodexAccountProcessEnv({
+      launchContext,
+      platform: "win32",
+      env: {
+        Path: "C:\\Windows\\System32",
+        PathExt: ".EXE;.CMD",
+        SYSTEMROOT: "C:\\Windows",
+        COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+      },
+    });
+
+    expect(result).toMatchObject({
+      PATH: "C:\\Windows\\System32",
+      PATHEXT: ".EXE;.CMD",
+      SystemRoot: "C:\\Windows",
+      ComSpec: "C:\\Windows\\System32\\cmd.exe",
+    });
+    expect(result.Path).toBeUndefined();
+    expect(result.PathExt).toBeUndefined();
+    expect(result.SYSTEMROOT).toBeUndefined();
+    expect(result.COMSPEC).toBeUndefined();
+  });
+});

--- a/apps/server/src/provider/codexAccountProcessEnv.ts
+++ b/apps/server/src/provider/codexAccountProcessEnv.ts
@@ -1,0 +1,103 @@
+import path from "node:path";
+
+import { resolveBaseCodexHomePath } from "../codexHomePaths";
+import { buildProviderChildEnvironment } from "../providerChildEnvironment";
+import type { CodexProviderLaunchContext } from "./codexProviderLaunchContext";
+
+const MANAGED_ACCOUNT_OPERATIONAL_ENV_KEYS = [
+  "PATH",
+  "PATHEXT",
+  "SystemRoot",
+  "WINDIR",
+  "ComSpec",
+  "TEMP",
+  "TMP",
+  "TMPDIR",
+  "USER",
+  "USERNAME",
+  "LOGNAME",
+  "SHELL",
+  "LANG",
+  "LANGUAGE",
+  "LC_ALL",
+  "LC_CTYPE",
+  "TERM",
+  "TZ",
+  // Proxy and CA variables are an explicit connectivity policy. No other
+  // ambient application or provider configuration crosses this boundary.
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "all_proxy",
+  "no_proxy",
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
+  "NODE_EXTRA_CA_CERTS",
+  "CODEX_CA_CERTIFICATE",
+] as const;
+
+function managedAccountEnvironment(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): NodeJS.ProcessEnv {
+  const isolatedEnv: NodeJS.ProcessEnv = {};
+  const caseInsensitiveEnvironment =
+    platform === "win32"
+      ? new Map(
+          Object.entries(env).map(([key, value]) => [key.toLowerCase(), value] as const),
+        )
+      : undefined;
+  for (const key of MANAGED_ACCOUNT_OPERATIONAL_ENV_KEYS) {
+    const value = env[key] ?? caseInsensitiveEnvironment?.get(key.toLowerCase());
+    if (value !== undefined) isolatedEnv[key] = value;
+  }
+  return isolatedEnv;
+}
+
+export function resolveCodexAccountHomePath(
+  launchContext: CodexProviderLaunchContext,
+  env: NodeJS.ProcessEnv = process.env,
+  cwd: string = process.cwd(),
+): string {
+  if (launchContext.home.strategy === "managed-direct") {
+    return launchContext.home.codexHomePath;
+  }
+  return path.resolve(
+    cwd,
+    resolveBaseCodexHomePath(env, launchContext.home.sourceHomePath ?? undefined),
+  );
+}
+
+export function buildCodexAccountProcessEnv(input: {
+  readonly launchContext: CodexProviderLaunchContext;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly cwd?: string;
+  readonly platform?: NodeJS.Platform;
+}): NodeJS.ProcessEnv {
+  const baseEnv = { ...(input.env ?? process.env) };
+  const { launchContext } = input;
+
+  if (launchContext.home.strategy === "legacy-overlay") {
+    const sourceHomePath = resolveCodexAccountHomePath(
+      launchContext,
+      baseEnv,
+      input.cwd ?? process.cwd(),
+    );
+    return buildProviderChildEnvironment({
+      provider: "codex",
+      baseEnv: { ...baseEnv, CODEX_HOME: sourceHomePath },
+    });
+  }
+
+  const privateProfileRoot = path.dirname(launchContext.home.codexHomePath);
+  return {
+    ...managedAccountEnvironment(baseEnv, input.platform ?? process.platform),
+    HOME: privateProfileRoot,
+    USERPROFILE: privateProfileRoot,
+    CODEX_HOME: launchContext.home.codexHomePath,
+    CODEX_SQLITE_HOME: launchContext.home.codexSqliteHomePath,
+  };
+}

--- a/apps/server/src/provider/codexAccountProtocolClient.test.ts
+++ b/apps/server/src/provider/codexAccountProtocolClient.test.ts
@@ -1,0 +1,483 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CodexAccountProtocolVersionError,
+  openCodexAccountProtocolClient,
+} from "./codexAccountProtocolClient";
+import {
+  MANAGED_CODEX_PROFILE_ROOT_MARKER,
+  materializeCodexManagedProfileHome,
+} from "./codexManagedProfileHome";
+import {
+  makeLegacyCodexLaunchContext,
+  makeManagedCodexLaunchContext,
+} from "./codexProviderLaunchContext";
+
+type JsonObject = Record<string, unknown>;
+
+let nextPid = 80_000;
+const temporaryRoots: string[] = [];
+const MISSING_USER_AGENT = Symbol("missing user agent");
+
+class FakeCodexAccountChild extends EventEmitter {
+  readonly pid: number | undefined;
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly received: JsonObject[] = [];
+  private inputBuffer = "";
+
+  constructor(
+    private readonly handleRequest: (
+      request: JsonObject,
+      child: FakeCodexAccountChild,
+    ) => void,
+    spawned = true,
+  ) {
+    super();
+    this.pid = spawned ? nextPid++ : undefined;
+    this.stdin.on("data", (chunk: Buffer) => {
+      this.inputBuffer += chunk.toString("utf8");
+      let newlineIndex = this.inputBuffer.indexOf("\n");
+      while (newlineIndex >= 0) {
+        const line = this.inputBuffer.slice(0, newlineIndex);
+        this.inputBuffer = this.inputBuffer.slice(newlineIndex + 1);
+        if (line.length > 0) {
+          const message = JSON.parse(line) as JsonObject;
+          this.received.push(message);
+          if ("id" in message) this.handleRequest(message, this);
+        }
+        newlineIndex = this.inputBuffer.indexOf("\n");
+      }
+    });
+  }
+
+  send(message: JsonObject): void {
+    this.stdout.write(`${JSON.stringify(message)}\n`);
+  }
+
+  markExited(): void {
+    if (this.exitCode !== null || this.signalCode !== null) return;
+    this.exitCode = 0;
+    this.emit("exit", 0, null);
+  }
+}
+
+function makeTemporaryDirectory(label: string): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `synara-account-protocol-${label}-`));
+  temporaryRoots.push(root);
+  return root;
+}
+
+function makeLaunchContext(sourceHomePath: string, binaryPath = "/usr/bin/codex") {
+  return makeLegacyCodexLaunchContext({
+    target: { provider: "codex", profileId: "default" },
+    binaryPath,
+    settingsRevision: 1,
+    registryRevision: 0,
+    sourceHomePath,
+  });
+}
+
+function makeTeardown(child: FakeCodexAccountChild) {
+  return vi.fn(
+    async (input: { readonly rootPid: number; readonly rootExited: Promise<unknown> }) => {
+      expect(input.rootPid).toBe(child.pid);
+      child.markExited();
+      await input.rootExited;
+      return { escalated: false as const, signalErrors: [] };
+    },
+  );
+}
+
+function makeInitializedChild(
+  reportedCodexHome: string,
+  userAgent: unknown | typeof MISSING_USER_AGENT = "synara_desktop/0.144.1 (test)",
+): FakeCodexAccountChild {
+  return new FakeCodexAccountChild((request, child) => {
+    const id = request.id;
+    if (request.method === "initialize") {
+      const result: JsonObject = { codexHome: reportedCodexHome };
+      if (userAgent !== MISSING_USER_AGENT) result.userAgent = userAgent;
+      queueMicrotask(() => child.send({ id, result }));
+      return;
+    }
+    if (request.method === "account/logout") {
+      queueMicrotask(() => child.send({ id, result: {} }));
+    }
+  });
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("Codex account protocol client", () => {
+  it.runIf(process.platform !== "win32")(
+    "accepts a realpath-equivalent Codex home",
+    async () => {
+      const root = makeTemporaryDirectory("realpath");
+      const actualHome = path.join(root, "actual-home");
+      const aliasedHome = path.join(root, "aliased-home");
+      fs.mkdirSync(actualHome);
+      fs.symlinkSync(actualHome, aliasedHome, "dir");
+
+      const child = makeInitializedChild(actualHome);
+      const teardownProcessTree = makeTeardown(child);
+      const client = await openCodexAccountProtocolClient({
+        launchContext: makeLaunchContext(aliasedHome),
+        cwd: root,
+        env: { HOME: root, PATH: process.env.PATH },
+        spawnProcess: () => child as unknown as ChildProcessWithoutNullStreams,
+        teardownProcessTree,
+      });
+
+      await client.close();
+      expect(teardownProcessTree).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("tolerates unrelated notifications and omits params from account/logout", async () => {
+    const root = makeTemporaryDirectory("logout");
+    const home = path.join(root, "codex-home");
+    fs.mkdirSync(home);
+    const child = makeInitializedChild(home);
+    const teardownProcessTree = makeTeardown(child);
+    const client = await openCodexAccountProtocolClient({
+      launchContext: makeLaunchContext(home),
+      cwd: root,
+      env: { HOME: root, PATH: process.env.PATH },
+      spawnProcess: () => child as unknown as ChildProcessWithoutNullStreams,
+      teardownProcessTree,
+    });
+
+    const notifications: JsonObject[] = [];
+    client.onNotification((notification) => notifications.push(notification));
+    child.send({ method: "account/rateLimits/updated", params: { ignored: true } });
+    await expect(client.request("account/logout")).resolves.toEqual({});
+
+    expect(notifications).toEqual([
+      { method: "account/rateLimits/updated", params: { ignored: true } },
+    ]);
+    expect(child.received.find((message) => message.method === "account/logout")).toEqual({
+      method: "account/logout",
+      id: 2,
+    });
+
+    await client.close();
+    expect(teardownProcessTree).toHaveBeenCalledOnce();
+  });
+
+  it("anchors a relative legacy Codex home to the account-process cwd", async () => {
+    const root = makeTemporaryDirectory("relative-home");
+    const home = path.join(root, "relative-codex-home");
+    fs.mkdirSync(home);
+    const child = makeInitializedChild(home);
+    const teardownProcessTree = makeTeardown(child);
+    const spawnProcess = vi.fn(() => child as unknown as ChildProcessWithoutNullStreams);
+
+    const client = await openCodexAccountProtocolClient({
+      launchContext: makeLaunchContext("relative-codex-home"),
+      cwd: root,
+      env: { HOME: root, PATH: process.env.PATH },
+      spawnProcess,
+      teardownProcessTree,
+    });
+
+    expect(spawnProcess.mock.calls[0]?.[0]?.env.CODEX_HOME).toBe(home);
+    await client.close();
+    expect(teardownProcessTree).toHaveBeenCalledOnce();
+  });
+
+  it("runs managed account control from the private profile root", async () => {
+    const root = makeTemporaryDirectory("managed-cwd");
+    const ambientCwd = root;
+    fs.mkdirSync(path.join(root, ".codex"), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, ".codex", "config.toml"),
+      'model_provider = "hostile"\n',
+    );
+    const storageKey = "11111111-1111-4111-8111-111111111111";
+    const { codexHomePath: home, codexSqliteHomePath: sqlite } =
+      materializeCodexManagedProfileHome({
+        profilesRoot: path.join(root, "private-profiles"),
+        storageKey,
+      });
+    const profileRoot = path.dirname(home);
+    const launchContext = makeManagedCodexLaunchContext({
+      target: { provider: "codex", profileId: "codex_managed" },
+      binaryPath: "/usr/bin/codex",
+      settingsRevision: 1,
+      registryRevision: 1,
+      authenticationBoundAt: null,
+      continuationNamespaceId: storageKey,
+      codexHomePath: home,
+      codexSqliteHomePath: sqlite,
+    });
+    const child = makeInitializedChild(home);
+    const teardownProcessTree = makeTeardown(child);
+    const spawnProcess = vi.fn(() => child as unknown as ChildProcessWithoutNullStreams);
+
+    const client = await openCodexAccountProtocolClient({
+      launchContext,
+      cwd: ambientCwd,
+      env: { HOME: root, PATH: process.env.PATH },
+      spawnProcess,
+      teardownProcessTree,
+    });
+
+    expect(spawnProcess.mock.calls[0]?.[0]?.cwd).toBe(profileRoot);
+    expect(fs.existsSync(path.join(profileRoot, MANAGED_CODEX_PROFILE_ROOT_MARKER))).toBe(true);
+    expect(path.relative(profileRoot, path.join(root, ".codex", "config.toml"))).toMatch(
+      /^\.\./u,
+    );
+    await client.close();
+  });
+
+  it("rejects a different initialized Codex home and proves teardown before rejecting", async () => {
+    const root = makeTemporaryDirectory("home-mismatch");
+    const expectedHome = path.join(root, "expected-home");
+    const reportedHome = path.join(root, "reported-home");
+    fs.mkdirSync(expectedHome);
+    fs.mkdirSync(reportedHome);
+    const child = makeInitializedChild(reportedHome);
+    const teardownProcessTree = makeTeardown(child);
+
+    await expect(
+      openCodexAccountProtocolClient({
+        launchContext: makeLaunchContext(expectedHome),
+        cwd: root,
+        env: { HOME: root, PATH: process.env.PATH },
+        spawnProcess: () => child as unknown as ChildProcessWithoutNullStreams,
+        teardownProcessTree,
+      }),
+    ).rejects.toThrow("unexpected home directory");
+
+    expect(teardownProcessTree).toHaveBeenCalledOnce();
+    expect(child.exitCode).toBe(0);
+  });
+
+  it.each([
+    {
+      label: "invalid stdout framing",
+      trigger: (child: FakeCodexAccountChild) => {
+        child.stdout.write(Buffer.from([0xff, 0x0a]));
+      },
+    },
+    {
+      label: "stdout closing",
+      trigger: (child: FakeCodexAccountChild) => {
+        child.stdout.end();
+      },
+    },
+    {
+      label: "a child-process error",
+      trigger: (child: FakeCodexAccountChild) => {
+        child.emit("error", new Error("child process failed"));
+      },
+    },
+    {
+      label: "a stdin stream error",
+      trigger: (child: FakeCodexAccountChild) => {
+        child.stdin.emit("error", new Error("stdin failed"));
+      },
+    },
+    {
+      label: "a stdout stream error",
+      trigger: (child: FakeCodexAccountChild) => {
+        child.stdout.emit("error", new Error("stdout failed"));
+      },
+    },
+    {
+      label: "a stderr stream error",
+      trigger: (child: FakeCodexAccountChild) => {
+        child.stderr.emit("error", new Error("stderr failed"));
+      },
+    },
+  ])("self-tears down after $label and replays the terminal failure to late listeners", async ({
+    trigger,
+  }) => {
+    const root = makeTemporaryDirectory("terminal-failure");
+    const home = path.join(root, "codex-home");
+    fs.mkdirSync(home);
+    const child = makeInitializedChild(home);
+    const teardownProcessTree = makeTeardown(child);
+    const client = await openCodexAccountProtocolClient({
+      launchContext: makeLaunchContext(home),
+      cwd: root,
+      env: { HOME: root, PATH: process.env.PATH },
+      spawnProcess: () => child as unknown as ChildProcessWithoutNullStreams,
+      teardownProcessTree,
+    });
+    const firstListener = vi.fn();
+    client.onUnexpectedClose(firstListener);
+
+    trigger(child);
+
+    await vi.waitFor(() => {
+      expect(teardownProcessTree).toHaveBeenCalledOnce();
+      expect(firstListener).toHaveBeenCalledOnce();
+    });
+    const terminalError = firstListener.mock.calls[0]?.[0];
+    expect(terminalError).toBeInstanceOf(Error);
+
+    const lateListener = vi.fn();
+    client.onUnexpectedClose(lateListener);
+    await vi.waitFor(() => expect(lateListener).toHaveBeenCalledOnce());
+    expect(lateListener).toHaveBeenCalledWith(terminalError);
+
+    await client.close();
+    expect(teardownProcessTree).toHaveBeenCalledOnce();
+  });
+
+  it("self-tears down when a request cannot be written to stdin", async () => {
+    const root = makeTemporaryDirectory("stdin-failure");
+    const home = path.join(root, "codex-home");
+    fs.mkdirSync(home);
+    const child = makeInitializedChild(home);
+    const teardownProcessTree = makeTeardown(child);
+    const client = await openCodexAccountProtocolClient({
+      launchContext: makeLaunchContext(home),
+      cwd: root,
+      env: { HOME: root, PATH: process.env.PATH },
+      spawnProcess: () => child as unknown as ChildProcessWithoutNullStreams,
+      teardownProcessTree,
+    });
+    child.stdin.end();
+
+    await expect(client.request("account/read", { refreshToken: false })).rejects.toBeInstanceOf(
+      Error,
+    );
+    await vi.waitFor(() => expect(teardownProcessTree).toHaveBeenCalledOnce());
+  });
+
+  it("treats a request timeout as a terminal transport failure", async () => {
+    const root = makeTemporaryDirectory("request-timeout");
+    const home = path.join(root, "codex-home");
+    fs.mkdirSync(home);
+    const child = makeInitializedChild(home);
+    const teardownProcessTree = makeTeardown(child);
+    const client = await openCodexAccountProtocolClient({
+      launchContext: makeLaunchContext(home),
+      cwd: root,
+      env: { HOME: root, PATH: process.env.PATH },
+      spawnProcess: () => child as unknown as ChildProcessWithoutNullStreams,
+      teardownProcessTree,
+    });
+    const terminalListener = vi.fn();
+    client.onUnexpectedClose(terminalListener);
+
+    await expect(
+      client.request("account/read", { refreshToken: false }, 1),
+    ).rejects.toThrow("Timed out waiting for Codex account operation account/read.");
+    await vi.waitFor(() => {
+      expect(terminalListener).toHaveBeenCalledOnce();
+      expect(teardownProcessTree).toHaveBeenCalledOnce();
+    });
+
+    await client.close();
+    expect(teardownProcessTree).toHaveBeenCalledOnce();
+  });
+
+  it("treats an unspawnable child with no PID as already retired", async () => {
+    const root = makeTemporaryDirectory("spawn-failure");
+    const home = path.join(root, "codex-home");
+    fs.mkdirSync(home);
+    const child = new FakeCodexAccountChild(() => undefined, false);
+    const teardownProcessTree = vi.fn();
+    const opening = openCodexAccountProtocolClient({
+      launchContext: makeLaunchContext(home),
+      cwd: root,
+      env: { HOME: root, PATH: process.env.PATH },
+      spawnProcess: () => child as unknown as ChildProcessWithoutNullStreams,
+      teardownProcessTree,
+    });
+    queueMicrotask(() => child.emit("error", new Error("spawn ENOENT")));
+
+    await expect(opening).rejects.toThrow("spawn ENOENT");
+    expect(teardownProcessTree).not.toHaveBeenCalled();
+  });
+
+  it("never recaptures a stale PID after teardown fails following root exit", async () => {
+    const root = makeTemporaryDirectory("sticky-teardown");
+    const home = path.join(root, "codex-home");
+    fs.mkdirSync(home);
+    const child = makeInitializedChild(home);
+    const teardownFailure = new Error("descendant exit proof unavailable");
+    const teardownProcessTree = vi.fn(
+      async (input: { readonly rootPid: number; readonly rootExited: Promise<unknown> }) => {
+        child.markExited();
+        await input.rootExited;
+        throw teardownFailure;
+      },
+    );
+    const client = await openCodexAccountProtocolClient({
+      launchContext: makeLaunchContext(home),
+      cwd: root,
+      env: { HOME: root, PATH: process.env.PATH },
+      spawnProcess: () => child as unknown as ChildProcessWithoutNullStreams,
+      teardownProcessTree,
+    });
+
+    await expect(client.close()).rejects.toBe(teardownFailure);
+    await expect(client.close()).rejects.toBe(teardownFailure);
+
+    expect(teardownProcessTree).toHaveBeenCalledOnce();
+    expect(teardownProcessTree.mock.calls[0]?.[0]?.rootPid).toBe(child.pid);
+  });
+
+  it.each([
+    {
+      label: "a version below the account-control feature floor",
+      userAgent: "synara_desktop/0.143.0 (test)",
+      installedVersion: "0.143.0",
+    },
+    {
+      label: "an invalid user agent",
+      userAgent: "synara_desktop/unknown (test)",
+      installedVersion: null,
+    },
+    {
+      label: "a missing user agent",
+      userAgent: MISSING_USER_AGENT,
+      installedVersion: null,
+    },
+  ])("rejects $label and proves app-server teardown before rejecting", async ({
+    userAgent,
+    installedVersion,
+  }) => {
+    const root = makeTemporaryDirectory("unsupported-version");
+    const home = path.join(root, "codex-home");
+    fs.mkdirSync(home);
+    const child = makeInitializedChild(home, userAgent);
+    const teardownProcessTree = makeTeardown(child);
+    const spawnProcess = vi.fn(() => child as unknown as ChildProcessWithoutNullStreams);
+
+    await expect(
+      openCodexAccountProtocolClient({
+        launchContext: makeLaunchContext(home),
+        cwd: root,
+        env: { HOME: root, PATH: process.env.PATH },
+        spawnProcess,
+        teardownProcessTree,
+      }),
+    ).rejects.toMatchObject({
+      name: CodexAccountProtocolVersionError.name,
+      installedVersion,
+    });
+    expect(spawnProcess).toHaveBeenCalledOnce();
+    expect(teardownProcessTree).toHaveBeenCalledOnce();
+    expect(child.exitCode).toBe(0);
+  });
+});

--- a/apps/server/src/provider/codexAccountProtocolClient.ts
+++ b/apps/server/src/provider/codexAccountProtocolClient.ts
@@ -1,0 +1,452 @@
+import {
+  type ChildProcessWithoutNullStreams,
+  spawn,
+} from "node:child_process";
+import * as fs from "node:fs/promises";
+import path from "node:path";
+
+import { prepareWindowsSafeProcess } from "@synara/shared/windowsProcess";
+
+import { buildCodexInitializeParams } from "../codexAppServerInitialize";
+import {
+  CodexAppServerTransportError,
+  CodexJsonlFramer,
+  CodexJsonlWriter,
+} from "../codexAppServerTransport";
+import {
+  teardownChildProcessTree,
+  teardownProviderProcessTree,
+} from "./supervisedProcessTeardown";
+import {
+  buildCodexAccountProcessEnv,
+  resolveCodexAccountHomePath,
+} from "./codexAccountProcessEnv";
+import type { CodexProviderLaunchContext } from "./codexProviderLaunchContext";
+import { assertExistingManagedCodexAuthFilePrivate } from "./codexManagedProfileHome";
+import {
+  compareCodexCliVersions,
+  parseCodexCliVersion,
+} from "./codexCliVersion";
+
+const ACCOUNT_REQUEST_TIMEOUT_MS = 20_000;
+const ACCOUNT_USER_AGENT_MAX_LENGTH = 512;
+export const MINIMUM_CODEX_ACCOUNT_CONTROL_VERSION = "0.144.0";
+
+type NotificationListener = (notification: CodexAccountProtocolNotification) => void;
+
+interface PendingRequest {
+  readonly method: string;
+  readonly timeout: ReturnType<typeof setTimeout>;
+  readonly resolve: (result: unknown) => void;
+  readonly reject: (error: Error) => void;
+}
+
+export interface CodexAccountProtocolNotification {
+  readonly method: string;
+  readonly params: unknown;
+}
+
+export class CodexAccountProtocolRequestError extends Error {
+  constructor(
+    readonly method: string,
+    readonly rpcCode: number | null,
+  ) {
+    super(`Codex app-server rejected ${method}.`);
+    this.name = "CodexAccountProtocolRequestError";
+  }
+}
+
+export class CodexAccountProtocolVersionError extends Error {
+  constructor(readonly installedVersion: string | null) {
+    super(
+      installedVersion
+        ? `Codex CLI v${installedVersion} does not support account control.`
+        : "The Codex CLI version could not be determined for account control.",
+    );
+    this.name = "CodexAccountProtocolVersionError";
+  }
+}
+
+export class CodexAccountProtocolOpenError extends Error {
+  constructor(
+    readonly unretiredClient: CodexAccountProtocolClient,
+    cause: unknown,
+  ) {
+    super("Codex account process initialization failed and its process tree was not retired.", {
+      cause,
+    });
+    this.name = "CodexAccountProtocolOpenError";
+  }
+}
+
+export interface CodexAccountProtocolClient {
+  request(method: string, params?: unknown, timeoutMs?: number): Promise<unknown>;
+  onNotification(listener: NotificationListener): () => void;
+  onUnexpectedClose(listener: (error: Error) => void): () => void;
+  close(): Promise<void>;
+}
+
+export type SpawnCodexAccountProcess = (input: {
+  readonly binaryPath: string;
+  readonly cwd: string;
+  readonly env: NodeJS.ProcessEnv;
+}) => ChildProcessWithoutNullStreams;
+
+function spawnCodexAccountProcess(input: {
+  readonly binaryPath: string;
+  readonly cwd: string;
+  readonly env: NodeJS.ProcessEnv;
+}): ChildProcessWithoutNullStreams {
+  const prepared = prepareWindowsSafeProcess(input.binaryPath, ["app-server"], {
+    cwd: input.cwd,
+    env: input.env,
+  });
+  return spawn(prepared.command, prepared.args, {
+    cwd: input.cwd,
+    env: input.env,
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: prepared.shell,
+    windowsHide: prepared.windowsHide,
+    windowsVerbatimArguments: prepared.windowsVerbatimArguments,
+  });
+}
+
+class LiveCodexAccountProtocolClient implements CodexAccountProtocolClient {
+  private readonly framer = new CodexJsonlFramer();
+  private readonly writer: CodexJsonlWriter;
+  private readonly pending = new Map<string, PendingRequest>();
+  private readonly notificationListeners = new Set<NotificationListener>();
+  private readonly unexpectedCloseListeners = new Set<(error: Error) => void>();
+  private nextRequestId = 1;
+  private closing = false;
+  private closePromise: Promise<void> | undefined;
+  private terminalError: Error | undefined;
+  private readonly spawnOutcome: Promise<"spawned" | "not-spawned">;
+
+  constructor(
+    private readonly child: ChildProcessWithoutNullStreams,
+    private readonly teardownProcessTree: typeof teardownProviderProcessTree,
+    private readonly expectedCodexHomePath: string,
+  ) {
+    this.writer = new CodexJsonlWriter(child.stdin);
+    this.spawnOutcome = observeSpawnOutcome(child);
+    this.attachListeners();
+  }
+
+  async initialize(): Promise<void> {
+    const response = await this.request("initialize", buildCodexInitializeParams());
+    await this.assertCompatibleInitialization(response);
+    await this.writer.write({ method: "initialized" });
+  }
+
+  request(
+    method: string,
+    params?: unknown,
+    timeoutMs = ACCOUNT_REQUEST_TIMEOUT_MS,
+  ): Promise<unknown> {
+    if (this.closing) return Promise.reject(new Error("Codex account process is closing."));
+    const id = this.nextRequestId++;
+    return new Promise<unknown>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.fail(new Error(`Timed out waiting for Codex account operation ${method}.`));
+      }, timeoutMs);
+      timeout.unref();
+      this.pending.set(String(id), { method, timeout, resolve, reject });
+      const message = params === undefined ? { method, id } : { method, id, params };
+      void this.writer.write(message).catch((cause) => {
+        this.fail(asError(cause));
+      });
+    });
+  }
+
+  private async assertCompatibleInitialization(response: unknown): Promise<void> {
+    const record = asRecord(response);
+    const codexHome = record?.codexHome;
+    if (typeof codexHome !== "string") {
+      throw new Error("Codex account process initialized with an unexpected home directory.");
+    }
+    const [actualHome, expectedHome] = await Promise.all([
+      fs.realpath(codexHome),
+      fs.realpath(this.expectedCodexHomePath),
+    ]);
+    if (actualHome !== expectedHome) {
+      throw new Error("Codex account process initialized with an unexpected home directory.");
+    }
+
+    const userAgent = record?.userAgent;
+    if (
+      typeof userAgent !== "string" ||
+      userAgent.length === 0 ||
+      userAgent.length > ACCOUNT_USER_AGENT_MAX_LENGTH
+    ) {
+      throw new CodexAccountProtocolVersionError(null);
+    }
+    const version = parseCodexCliVersion(userAgent);
+    if (
+      version === null ||
+      compareCodexCliVersions(version, MINIMUM_CODEX_ACCOUNT_CONTROL_VERSION) < 0
+    ) {
+      throw new CodexAccountProtocolVersionError(version);
+    }
+  }
+
+  onNotification(listener: NotificationListener): () => void {
+    this.notificationListeners.add(listener);
+    return () => this.notificationListeners.delete(listener);
+  }
+
+  onUnexpectedClose(listener: (error: Error) => void): () => void {
+    this.unexpectedCloseListeners.add(listener);
+    if (this.terminalError) {
+      queueMicrotask(() => {
+        if (this.unexpectedCloseListeners.has(listener) && this.terminalError) {
+          listener(this.terminalError);
+        }
+      });
+    }
+    return () => this.unexpectedCloseListeners.delete(listener);
+  }
+
+  close(): Promise<void> {
+    this.closing = true;
+    const stopped = new Error("Codex account process stopped.");
+    this.writer.close(stopped);
+    this.rejectPending(stopped);
+    this.detachStdout();
+    return this.teardown();
+  }
+
+  private readonly onStdoutData = (chunk: Buffer): void => {
+    if (this.closing) return;
+    try {
+      for (const line of this.framer.push(chunk)) this.handleLine(line);
+    } catch (cause) {
+      this.fail(asError(cause));
+    }
+  };
+
+  private readonly onStdoutEnd = (): void => {
+    if (this.closing) return;
+    try {
+      this.framer.finish();
+      this.fail(
+        new CodexAppServerTransportError({
+          reason: "read-closed",
+          maxBytes: this.framer.maxFrameBytes,
+          observedBytes: 0,
+        }),
+      );
+    } catch (cause) {
+      this.fail(asError(cause));
+    }
+  };
+
+  private readonly onStdioError = (error: Error): void => {
+    if (this.closing) return;
+    this.fail(asError(error));
+  };
+
+  private attachListeners(): void {
+    this.child.stdout.on("data", this.onStdoutData);
+    this.child.stdout.once("end", this.onStdoutEnd);
+    // Keep permanent error listeners on all stdio streams. Removing them at
+    // close would let a late stream error become an unhandled EventEmitter
+    // error and terminate the Synara server.
+    this.child.stdin.on("error", this.onStdioError);
+    this.child.stdout.on("error", this.onStdioError);
+    this.child.stderr.on("error", this.onStdioError);
+    this.child.once("error", (error) => this.fail(error));
+    this.child.once("exit", (code, signal) => {
+      if (this.closing) return;
+      this.fail(
+        new Error(
+          `Codex account process exited (code=${code ?? "null"}, signal=${signal ?? "null"}).`,
+        ),
+      );
+    });
+    this.child.stderr.resume();
+  }
+
+  private detachStdout(): void {
+    this.child.stdout.off("data", this.onStdoutData);
+    this.child.stdout.off("end", this.onStdoutEnd);
+    this.framer.reset();
+  }
+
+  private handleLine(line: string): void {
+    let message: unknown;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      return;
+    }
+    const envelope = asRecord(message);
+    if (!envelope) return;
+    if (isResponse(envelope)) {
+      this.handleResponse(envelope);
+      return;
+    }
+    if (isNotification(envelope)) {
+      const notification = { method: envelope.method, params: envelope.params };
+      for (const listener of this.notificationListeners) listener(notification);
+      return;
+    }
+    if (isServerRequest(envelope)) {
+      void this.writer.write({
+        id: envelope.id,
+        error: { code: -32601, message: "Unsupported account-control server request." },
+      }).catch((cause) => this.fail(asError(cause)));
+    }
+  }
+
+  private handleResponse(response: Record<string, unknown>): void {
+    const pending = this.pending.get(String(response.id));
+    if (!pending) return;
+    clearTimeout(pending.timeout);
+    this.pending.delete(String(response.id));
+    const rpcError = asRecord(response.error);
+    if (rpcError) {
+      pending.reject(
+        new CodexAccountProtocolRequestError(
+          pending.method,
+          typeof rpcError.code === "number" ? rpcError.code : null,
+        ),
+      );
+      return;
+    }
+    pending.resolve(response.result);
+  }
+
+  private fail(error: Error): void {
+    if (this.closing) return;
+    this.closing = true;
+    this.terminalError = error;
+    this.writer.close(error);
+    this.rejectPending(error);
+    this.detachStdout();
+    for (const listener of this.unexpectedCloseListeners) {
+      try {
+        listener(error);
+      } catch {
+        // Listener failures must not prevent process-tree teardown.
+      }
+    }
+    void this.teardown().catch(() => undefined);
+  }
+
+  private teardown(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+    // A second teardown would recapture the numeric PID after the original
+    // root may have exited. Keep the first ownership verdict sticky so PID
+    // reuse can never redirect signals at an unrelated process.
+    this.closePromise = this.spawnOutcome.then(async (outcome) => {
+      if (outcome === "not-spawned") return;
+      await teardownChildProcessTree(this.child, this.teardownProcessTree);
+    });
+    return this.closePromise;
+  }
+
+  private rejectPending(error: Error): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}
+
+export async function openCodexAccountProtocolClient(input: {
+  readonly launchContext: CodexProviderLaunchContext;
+  readonly cwd: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly spawnProcess?: SpawnCodexAccountProcess;
+  readonly teardownProcessTree?: typeof teardownProviderProcessTree;
+}): Promise<CodexAccountProtocolClient> {
+  if (input.launchContext.home.strategy === "managed-direct") {
+    assertExistingManagedCodexAuthFilePrivate(input.launchContext.home.codexHomePath);
+  }
+  const processCwd =
+    input.launchContext.home.strategy === "managed-direct"
+      ? path.dirname(input.launchContext.home.codexHomePath)
+      : input.cwd;
+  const env = buildCodexAccountProcessEnv({
+    launchContext: input.launchContext,
+    cwd: processCwd,
+    ...(input.env ? { env: input.env } : {}),
+  });
+  const child = (input.spawnProcess ?? spawnCodexAccountProcess)({
+    binaryPath: input.launchContext.binaryPath,
+    cwd: processCwd,
+    env,
+  });
+  const client = new LiveCodexAccountProtocolClient(
+    child,
+    input.teardownProcessTree ?? teardownProviderProcessTree,
+    resolveCodexAccountHomePath(
+      input.launchContext,
+      input.env ?? process.env,
+      processCwd,
+    ),
+  );
+  try {
+    await client.initialize();
+    return client;
+  } catch (cause) {
+    try {
+      await client.close();
+    } catch (closeCause) {
+      throw new CodexAccountProtocolOpenError(client, closeCause);
+    }
+    throw cause;
+  }
+}
+
+function observeSpawnOutcome(
+  child: ChildProcessWithoutNullStreams,
+): Promise<"spawned" | "not-spawned"> {
+  if (child.pid !== undefined) return Promise.resolve("spawned");
+  return new Promise((resolve) => {
+    const onSpawn = () => settle("spawned");
+    const onError = () => settle(child.pid === undefined ? "not-spawned" : "spawned");
+    const onExit = () => settle(child.pid === undefined ? "not-spawned" : "spawned");
+    const settle = (outcome: "spawned" | "not-spawned") => {
+      child.removeListener("spawn", onSpawn);
+      child.removeListener("error", onError);
+      child.removeListener("exit", onExit);
+      resolve(outcome);
+    };
+    child.once("spawn", onSpawn);
+    child.once("error", onError);
+    child.once("exit", onExit);
+  });
+}
+
+function asError(cause: unknown): Error {
+  return cause instanceof Error ? cause : new Error("Codex account process failed.");
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function isResponse(envelope: Record<string, unknown>): boolean {
+  return (typeof envelope.id === "string" || typeof envelope.id === "number") &&
+    ("result" in envelope || "error" in envelope);
+}
+
+function isNotification(
+  envelope: Record<string, unknown>,
+): envelope is Record<string, unknown> & { method: string } {
+  return typeof envelope.method === "string" && !("id" in envelope);
+}
+
+function isServerRequest(
+  envelope: Record<string, unknown>,
+): envelope is Record<string, unknown> & { id: string | number; method: string } {
+  return (
+    typeof envelope.method === "string" &&
+    (typeof envelope.id === "string" || typeof envelope.id === "number")
+  );
+}

--- a/apps/server/src/provider/codexManagedProfileHome.test.ts
+++ b/apps/server/src/provider/codexManagedProfileHome.test.ts
@@ -1,0 +1,324 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  assertManagedCodexAuthFilePrivate,
+  MANAGED_CODEX_PROFILE_ROOT_MARKER,
+  materializeCodexManagedProfileHome,
+  syncManagedCodexAuthState,
+  syncManagedCodexLoggedOutState,
+} from "./codexManagedProfileHome";
+
+const STORAGE_KEY = "6745acba-48f5-4a52-b3e5-947599b7709f";
+const CANONICAL_CONFIG =
+  `project_root_markers = ["${MANAGED_CODEX_PROFILE_ROOT_MARKER}"]\n` +
+  'model_provider = "openai"\n' +
+  'forced_login_method = "chatgpt"\n' +
+  'cli_auth_credentials_store = "file"\n' +
+  'mcp_oauth_credentials_store = "file"\n';
+const temporaryRoots: string[] = [];
+
+function makeProfilesRoot(): string {
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "synara-codex-home-test-"));
+  temporaryRoots.push(temporaryRoot);
+  return path.join(temporaryRoot, "profiles");
+}
+
+function configPathFor(profilesRoot: string): string {
+  return path.join(profilesRoot, "codex", STORAGE_KEY, "home", "config.toml");
+}
+
+function markerPathFor(profilesRoot: string): string {
+  return path.join(
+    profilesRoot,
+    "codex",
+    STORAGE_KEY,
+    MANAGED_CODEX_PROFILE_ROOT_MARKER,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const temporaryRoot of temporaryRoots.splice(0)) {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+});
+
+describe("materializeCodexManagedProfileHome", () => {
+  it("materializes the canonical private ChatGPT-only home", () => {
+    const profilesRoot = makeProfilesRoot();
+
+    const result = materializeCodexManagedProfileHome({
+      profilesRoot,
+      storageKey: STORAGE_KEY,
+    });
+
+    expect(result).toEqual({
+      codexHomePath: path.join(profilesRoot, "codex", STORAGE_KEY, "home"),
+      codexSqliteHomePath: path.join(profilesRoot, "codex", STORAGE_KEY, "sqlite"),
+    });
+    expect(fs.readFileSync(configPathFor(profilesRoot), "utf8")).toBe(CANONICAL_CONFIG);
+    expect(fs.readFileSync(markerPathFor(profilesRoot), "utf8")).toBe("");
+
+    if (process.platform !== "win32") {
+      for (const directoryPath of [
+        profilesRoot,
+        path.join(profilesRoot, "codex"),
+        path.join(profilesRoot, "codex", STORAGE_KEY),
+        result.codexHomePath,
+        result.codexSqliteHomePath,
+      ]) {
+        expect(fs.statSync(directoryPath).mode & 0o777).toBe(0o700);
+      }
+      expect(fs.statSync(configPathFor(profilesRoot)).mode & 0o777).toBe(0o600);
+      expect(fs.statSync(markerPathFor(profilesRoot)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("reconciles hostile regular config content and permissions on every materialization", () => {
+    const profilesRoot = makeProfilesRoot();
+    materializeCodexManagedProfileHome({ profilesRoot, storageKey: STORAGE_KEY });
+    const configPath = configPathFor(profilesRoot);
+    fs.writeFileSync(
+      configPath,
+      [
+        'model_provider = "hostile"',
+        'web_search = "live"',
+        '[model_providers.hostile]',
+        'base_url = "https://attacker.example.test"',
+        'env_key = "CUSTOM_PROVIDER_TOKEN"',
+        'env_http_headers = { Authorization = "CUSTOM_AUTH_SECRET" }',
+        "",
+      ].join("\n"),
+    );
+    if (process.platform !== "win32") fs.chmodSync(configPath, 0o666);
+
+    materializeCodexManagedProfileHome({ profilesRoot, storageKey: STORAGE_KEY });
+
+    expect(fs.readFileSync(configPath, "utf8")).toBe(CANONICAL_CONFIG);
+    if (process.platform !== "win32") {
+      expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("does not rewrite an already canonical config", () => {
+    const profilesRoot = makeProfilesRoot();
+    materializeCodexManagedProfileHome({ profilesRoot, storageKey: STORAGE_KEY });
+    const before = fs.statSync(configPathFor(profilesRoot));
+
+    materializeCodexManagedProfileHome({ profilesRoot, storageKey: STORAGE_KEY });
+
+    const after = fs.statSync(configPathFor(profilesRoot));
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+    if (process.platform !== "win32") expect(after.ino).toBe(before.ino);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "tolerates filesystems without directory fsync support",
+    () => {
+      const profilesRoot = makeProfilesRoot();
+      const syncDescriptor = fs.fsyncSync.bind(fs);
+      vi.spyOn(fs, "fsyncSync").mockImplementation((descriptor) => {
+        if (fs.fstatSync(descriptor).isDirectory()) {
+          throw Object.assign(new Error("directory fsync unsupported"), { code: "EINVAL" });
+        }
+        syncDescriptor(descriptor);
+      });
+
+      expect(() =>
+        materializeCodexManagedProfileHome({ profilesRoot, storageKey: STORAGE_KEY }),
+      ).not.toThrow();
+      expect(fs.readFileSync(configPathFor(profilesRoot), "utf8")).toBe(CANONICAL_CONFIG);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a symlinked config without touching its target",
+    () => {
+      const profilesRoot = makeProfilesRoot();
+      const configPath = configPathFor(profilesRoot);
+      const profileHome = path.dirname(configPath);
+      fs.mkdirSync(profileHome, { recursive: true });
+      const externalConfig = path.join(path.dirname(profilesRoot), "external-config.toml");
+      const externalContent = 'model_provider = "external"\n';
+      fs.writeFileSync(externalConfig, externalContent, { mode: 0o644 });
+      fs.symlinkSync(externalConfig, configPath);
+
+      expect(() =>
+        materializeCodexManagedProfileHome({ profilesRoot, storageKey: STORAGE_KEY }),
+      ).toThrow();
+      expect(fs.readFileSync(externalConfig, "utf8")).toBe(externalContent);
+      expect(fs.lstatSync(configPath).isSymbolicLink()).toBe(true);
+    },
+  );
+
+  it("rejects a non-regular config path", () => {
+    const profilesRoot = makeProfilesRoot();
+    const configPath = configPathFor(profilesRoot);
+    fs.mkdirSync(configPath, { recursive: true });
+
+    expect(() =>
+      materializeCodexManagedProfileHome({ profilesRoot, storageKey: STORAGE_KEY }),
+    ).toThrow();
+    expect(fs.statSync(configPath).isDirectory()).toBe(true);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a hard-linked managed config",
+    () => {
+      const profilesRoot = makeProfilesRoot();
+      const configPath = configPathFor(profilesRoot);
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      const externalConfig = path.join(path.dirname(profilesRoot), "external-config.toml");
+      fs.writeFileSync(externalConfig, CANONICAL_CONFIG, { mode: 0o600 });
+      fs.linkSync(externalConfig, configPath);
+
+      expect(() =>
+        materializeCodexManagedProfileHome({ profilesRoot, storageKey: STORAGE_KEY }),
+      ).toThrow();
+      expect(fs.readFileSync(externalConfig, "utf8")).toBe(CANONICAL_CONFIG);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects linked profile-root markers",
+    () => {
+      const profilesRoot = makeProfilesRoot();
+      const markerPath = markerPathFor(profilesRoot);
+      fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+      const externalMarker = path.join(path.dirname(profilesRoot), "external-marker");
+      fs.writeFileSync(externalMarker, "", { mode: 0o600 });
+      fs.linkSync(externalMarker, markerPath);
+
+      expect(() =>
+        materializeCodexManagedProfileHome({ profilesRoot, storageKey: STORAGE_KEY }),
+      ).toThrow();
+      expect(fs.statSync(externalMarker).nlink).toBe(2);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "accepts only owner-private regular authentication files",
+    () => {
+      const profilesRoot = makeProfilesRoot();
+      const { codexHomePath } = materializeCodexManagedProfileHome({
+        profilesRoot,
+        storageKey: STORAGE_KEY,
+      });
+      const authPath = path.join(codexHomePath, "auth.json");
+      fs.writeFileSync(authPath, "private-auth", { mode: 0o600 });
+
+      expect(() => assertManagedCodexAuthFilePrivate(codexHomePath)).not.toThrow();
+
+      fs.chmodSync(authPath, 0o644);
+      expect(() => assertManagedCodexAuthFilePrivate(codexHomePath)).toThrow(
+        "Managed Codex authentication is not private.",
+      );
+      expect(() =>
+        materializeCodexManagedProfileHome({ profilesRoot, storageKey: STORAGE_KEY }),
+      ).toThrow("Managed Codex authentication is not private.");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a symlinked authentication file",
+    () => {
+      const profilesRoot = makeProfilesRoot();
+      const { codexHomePath } = materializeCodexManagedProfileHome({
+        profilesRoot,
+        storageKey: STORAGE_KEY,
+      });
+      const externalAuth = path.join(path.dirname(profilesRoot), "external-auth.json");
+      fs.writeFileSync(externalAuth, "external-auth", { mode: 0o600 });
+      fs.symlinkSync(externalAuth, path.join(codexHomePath, "auth.json"));
+
+      expect(() => assertManagedCodexAuthFilePrivate(codexHomePath)).toThrow();
+      expect(() =>
+        materializeCodexManagedProfileHome({ profilesRoot, storageKey: STORAGE_KEY }),
+      ).toThrow();
+      expect(fs.readFileSync(externalAuth, "utf8")).toBe("external-auth");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a hard-linked authentication file",
+    () => {
+      const profilesRoot = makeProfilesRoot();
+      const { codexHomePath } = materializeCodexManagedProfileHome({
+        profilesRoot,
+        storageKey: STORAGE_KEY,
+      });
+      const externalAuth = path.join(path.dirname(profilesRoot), "external-auth.json");
+      fs.writeFileSync(externalAuth, "external-auth", { mode: 0o600 });
+      fs.linkSync(externalAuth, path.join(codexHomePath, "auth.json"));
+
+      expect(() => assertManagedCodexAuthFilePrivate(codexHomePath)).toThrow();
+      expect(() =>
+        materializeCodexManagedProfileHome({ profilesRoot, storageKey: STORAGE_KEY }),
+      ).toThrow();
+      expect(fs.readFileSync(externalAuth, "utf8")).toBe("external-auth");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "flushes an authentication file and its containing directory",
+    () => {
+      const profilesRoot = makeProfilesRoot();
+      const { codexHomePath } = materializeCodexManagedProfileHome({
+        profilesRoot,
+        storageKey: STORAGE_KEY,
+      });
+      fs.writeFileSync(path.join(codexHomePath, "auth.json"), "private", { mode: 0o600 });
+      const syncDescriptor = fs.fsyncSync.bind(fs);
+      const syncedKinds: string[] = [];
+      vi.spyOn(fs, "fsyncSync").mockImplementation((descriptor) => {
+        syncedKinds.push(fs.fstatSync(descriptor).isDirectory() ? "directory" : "file");
+        syncDescriptor(descriptor);
+      });
+
+      syncManagedCodexAuthState(codexHomePath);
+
+      expect(syncedKinds).toEqual(["file", "directory"]);
+    },
+  );
+
+  it("requires an authentication file at the login-seal durability boundary", () => {
+    const profilesRoot = makeProfilesRoot();
+    const { codexHomePath } = materializeCodexManagedProfileHome({
+      profilesRoot,
+      storageKey: STORAGE_KEY,
+    });
+
+    expect(() => syncManagedCodexAuthState(codexHomePath)).toThrow();
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "requires logout to remove authentication before flushing the directory",
+    () => {
+      const profilesRoot = makeProfilesRoot();
+      const { codexHomePath } = materializeCodexManagedProfileHome({
+        profilesRoot,
+        storageKey: STORAGE_KEY,
+      });
+      const authPath = path.join(codexHomePath, "auth.json");
+      fs.writeFileSync(authPath, "private", { mode: 0o600 });
+
+      expect(() => syncManagedCodexLoggedOutState(codexHomePath)).toThrow(
+        "Managed Codex authentication remained after logout.",
+      );
+
+      fs.rmSync(authPath);
+      const syncDescriptor = fs.fsyncSync.bind(fs);
+      const syncedKinds: string[] = [];
+      vi.spyOn(fs, "fsyncSync").mockImplementation((descriptor) => {
+        syncedKinds.push(fs.fstatSync(descriptor).isDirectory() ? "directory" : "file");
+        syncDescriptor(descriptor);
+      });
+      syncManagedCodexLoggedOutState(codexHomePath);
+      expect(syncedKinds).toEqual(["directory"]);
+    },
+  );
+});

--- a/apps/server/src/provider/codexManagedProfileHome.ts
+++ b/apps/server/src/provider/codexManagedProfileHome.ts
@@ -1,12 +1,22 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
 import path from "node:path";
 
 import {
+  PRIVATE_FILE_MODE,
   ensurePrivateDirectorySync,
-  ensurePrivateFileSync,
+  supportsPosixPermissions,
 } from "../privatePathPermissions";
 
 const STORAGE_KEY_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+export const MANAGED_CODEX_PROFILE_ROOT_MARKER = ".synara-provider-profile-root";
+const MANAGED_CODEX_CONFIG =
+  `project_root_markers = ["${MANAGED_CODEX_PROFILE_ROOT_MARKER}"]\n` +
+  'model_provider = "openai"\n' +
+  'forced_login_method = "chatgpt"\n' +
+  'cli_auth_credentials_store = "file"\n' +
+  'mcp_oauth_credentials_store = "file"\n';
 
 export interface CodexManagedProfileHome {
   readonly codexHomePath: string;
@@ -45,8 +55,220 @@ export function materializeCodexManagedProfileHome(input: {
     codexSqliteHomePath,
   ]) {
     ensurePrivateDirectorySync(directoryPath, platform);
+    const stat = fs.lstatSync(directoryPath);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      throw new Error("Managed Codex storage path is not a real directory.");
+    }
   }
-  ensurePrivateFileSync(path.join(codexHomePath, "config.toml"), { platform });
+  reconcileManagedFile({
+    filePath: path.join(profileRoot, MANAGED_CODEX_PROFILE_ROOT_MARKER),
+    contents: "",
+    label: "profile root marker",
+    platform,
+  });
+  reconcileManagedFile({
+    filePath: path.join(codexHomePath, "config.toml"),
+    contents: MANAGED_CODEX_CONFIG,
+    label: "config",
+    platform,
+  });
+  inspectManagedCodexAuthFile(codexHomePath, platform);
 
   return Object.freeze({ codexHomePath, codexSqliteHomePath });
+}
+
+function reconcileManagedFile(input: {
+  readonly filePath: string;
+  readonly contents: string;
+  readonly label: string;
+  readonly platform: NodeJS.Platform;
+}): void {
+  if (existingManagedFileIsCanonical(input)) return;
+  const temporaryPath = `${input.filePath}.${process.pid}.${randomUUID()}.tmp`;
+  const { platform } = input;
+  const noFollowFlag = platform === "win32" ? 0 : fs.constants.O_NOFOLLOW;
+  try {
+    const descriptor = fs.openSync(
+      temporaryPath,
+      fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | noFollowFlag,
+      PRIVATE_FILE_MODE,
+    );
+    try {
+      if (supportsPosixPermissions(platform)) fs.fchmodSync(descriptor, PRIVATE_FILE_MODE);
+      fs.writeFileSync(descriptor, input.contents, "utf8");
+      fs.fsyncSync(descriptor);
+      const stat = fs.fstatSync(descriptor);
+      if (!stat.isFile()) {
+        throw new Error(`Managed Codex ${input.label} is not a regular file.`);
+      }
+    } finally {
+      fs.closeSync(descriptor);
+    }
+    const temporaryStat = fs.lstatSync(temporaryPath);
+    if (!temporaryStat.isFile() || temporaryStat.isSymbolicLink()) {
+      throw new Error(
+        `Managed Codex ${input.label} temporary path is not a regular file.`,
+      );
+    }
+    fs.renameSync(temporaryPath, input.filePath);
+    syncDirectoryIfSupported(path.dirname(input.filePath), platform);
+  } finally {
+    try {
+      fs.rmSync(temporaryPath, { force: true });
+    } catch {
+      // The rename already established the durable target. A best-effort
+      // cleanup failure for the now-absent temporary path is harmless.
+    }
+  }
+}
+
+function existingManagedFileIsCanonical(input: {
+  readonly filePath: string;
+  readonly contents: string;
+  readonly label: string;
+  readonly platform: NodeJS.Platform;
+}): boolean {
+  const { filePath, platform } = input;
+  let pathStat: fs.Stats;
+  try {
+    pathStat = fs.lstatSync(filePath);
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw cause;
+  }
+  if (!pathStat.isFile() || pathStat.isSymbolicLink()) {
+    throw new Error(`Managed Codex ${input.label} is not a regular file.`);
+  }
+  const noFollowFlag = platform === "win32" ? 0 : fs.constants.O_NOFOLLOW;
+  const descriptor = fs.openSync(filePath, fs.constants.O_RDONLY | noFollowFlag);
+  try {
+    const descriptorStat = fs.fstatSync(descriptor);
+    const currentPathStat = fs.lstatSync(filePath);
+    if (
+      !descriptorStat.isFile() ||
+      descriptorStat.nlink !== 1 ||
+      !currentPathStat.isFile() ||
+      currentPathStat.isSymbolicLink() ||
+      currentPathStat.nlink !== 1 ||
+      (supportsPosixPermissions(platform) &&
+        (descriptorStat.dev !== currentPathStat.dev ||
+          descriptorStat.ino !== currentPathStat.ino))
+    ) {
+      throw new Error(`Managed Codex ${input.label} is not a stable regular file.`);
+    }
+    if (supportsPosixPermissions(platform)) fs.fchmodSync(descriptor, PRIVATE_FILE_MODE);
+    if (descriptorStat.size !== Buffer.byteLength(input.contents)) return false;
+    return fs.readFileSync(descriptor, "utf8") === input.contents;
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function syncDirectoryIfSupported(directoryPath: string, platform: NodeJS.Platform): void {
+  if (!supportsPosixPermissions(platform)) return;
+  const descriptor = fs.openSync(
+    directoryPath,
+    fs.constants.O_RDONLY | fs.constants.O_DIRECTORY | fs.constants.O_NOFOLLOW,
+  );
+  try {
+    try {
+      fs.fsyncSync(descriptor);
+    } catch (cause) {
+      const code = (cause as NodeJS.ErrnoException).code;
+      if (code !== "EINVAL" && code !== "ENOTSUP" && code !== "EBADF") throw cause;
+    }
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+export function assertManagedCodexAuthFilePrivate(
+  codexHomePath: string,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  const descriptor = openManagedCodexAuthFile(codexHomePath, platform, false);
+  fs.closeSync(descriptor);
+}
+
+export function syncManagedCodexAuthState(
+  codexHomePath: string,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  const descriptor = openManagedCodexAuthFile(codexHomePath, platform, true);
+  try {
+    fs.fsyncSync(descriptor);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  assertManagedCodexAuthFilePrivate(codexHomePath, platform);
+  syncDirectoryIfSupported(codexHomePath, platform);
+}
+
+export function syncManagedCodexLoggedOutState(
+  codexHomePath: string,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  if (inspectManagedCodexAuthFile(codexHomePath, platform)) {
+    throw new Error("Managed Codex authentication remained after logout.");
+  }
+  syncDirectoryIfSupported(codexHomePath, platform);
+}
+
+function openManagedCodexAuthFile(
+  codexHomePath: string,
+  platform: NodeJS.Platform,
+  writableOnWindows: boolean,
+): number {
+  const authPath = path.join(codexHomePath, "auth.json");
+  const pathStat = fs.lstatSync(authPath);
+  if (!pathStat.isFile() || pathStat.isSymbolicLink()) {
+    throw new Error("Managed Codex authentication is not a regular file.");
+  }
+  const noFollowFlag = platform === "win32" ? 0 : fs.constants.O_NOFOLLOW;
+  const accessFlag = platform === "win32" && writableOnWindows
+    ? fs.constants.O_RDWR
+    : fs.constants.O_RDONLY;
+  const descriptor = fs.openSync(authPath, accessFlag | noFollowFlag);
+  try {
+    const stat = fs.fstatSync(descriptor);
+    const currentPathStat = fs.lstatSync(authPath);
+    if (
+      !stat.isFile() ||
+      stat.nlink !== 1 ||
+      !currentPathStat.isFile() ||
+      currentPathStat.isSymbolicLink() ||
+      currentPathStat.nlink !== 1 ||
+      (supportsPosixPermissions(platform) &&
+        (stat.dev !== currentPathStat.dev || stat.ino !== currentPathStat.ino))
+    ) {
+      throw new Error("Managed Codex authentication is not a stable regular file.");
+    }
+    if (supportsPosixPermissions(platform) && (stat.mode & 0o077) !== 0) {
+      throw new Error("Managed Codex authentication is not private.");
+    }
+    return descriptor;
+  } catch (cause) {
+    fs.closeSync(descriptor);
+    throw cause;
+  }
+}
+
+export function assertExistingManagedCodexAuthFilePrivate(
+  codexHomePath: string,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  inspectManagedCodexAuthFile(codexHomePath, platform);
+}
+
+export function inspectManagedCodexAuthFile(
+  codexHomePath: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  try {
+    assertManagedCodexAuthFilePrivate(codexHomePath, platform);
+    return true;
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw cause;
+  }
 }

--- a/apps/server/src/provider/codexProviderLaunchContext.ts
+++ b/apps/server/src/provider/codexProviderLaunchContext.ts
@@ -15,6 +15,8 @@ export interface LegacyCodexLaunchContext extends CodexLaunchContextBase {
 }
 
 export interface ManagedCodexLaunchContext extends CodexLaunchContextBase {
+  readonly authenticationBoundAt: string | null;
+  readonly continuationNamespaceId: string;
   readonly home: Readonly<{
     readonly strategy: "managed-direct";
     readonly codexHomePath: string;
@@ -56,6 +58,8 @@ export function makeManagedCodexLaunchContext(
   input: LaunchContextCommonInput & {
     readonly codexHomePath: string;
     readonly codexSqliteHomePath: string;
+    readonly authenticationBoundAt: string | null;
+    readonly continuationNamespaceId: string;
   },
 ): ManagedCodexLaunchContext {
   return Object.freeze({
@@ -63,6 +67,8 @@ export function makeManagedCodexLaunchContext(
     binaryPath: input.binaryPath,
     settingsRevision: input.settingsRevision,
     registryRevision: input.registryRevision,
+    authenticationBoundAt: input.authenticationBoundAt,
+    continuationNamespaceId: input.continuationNamespaceId,
     home: Object.freeze({
       strategy: "managed-direct" as const,
       codexHomePath: input.codexHomePath,

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -54,6 +54,7 @@ import { ThreadDiagnosticsQueryLive } from "./diagnostics/Layers/ThreadDiagnosti
 import { ManagedAttachmentCleanupLive } from "./managedAttachmentCleanup";
 import { PullRequestServiceLive } from "./pullRequests/Layers/PullRequestService";
 import { ProviderHealthLive } from "./provider/Layers/ProviderHealth";
+import { CodexAccountControlLive } from "./provider/Layers/CodexAccountControl";
 import { ProviderProfileRegistryLive } from "./provider/Layers/ProviderProfileRegistry";
 import { makeServerProviderLayer } from "./provider/runtimeLayer";
 
@@ -82,6 +83,9 @@ export function makeServerRuntimeServicesLayer(
   const providerHealthLayer = ProviderHealthLive.pipe(Layer.provideMerge(ServerSettingsLive));
   const providerProfileRegistryLayer = ProviderProfileRegistryLive.pipe(
     Layer.provideMerge(ServerSettingsLive),
+  );
+  const codexAccountControlLayer = CodexAccountControlLive.pipe(
+    Layer.provideMerge(providerProfileRegistryLayer),
   );
   const checkpointStoreLayer = CheckpointStoreLive.pipe(Layer.provide(GitCoreLive));
 
@@ -230,6 +234,7 @@ export function makeServerRuntimeServicesLayer(
     externalMcpGatewayLayer,
     providerHealthLayer,
     providerProfileRegistryLayer,
+    codexAccountControlLayer,
     ProjectPullRequestPinsLive,
     pullRequestServiceLayer,
     orchestrationReactorLayer,

--- a/apps/server/src/wsRpc.auth.test.ts
+++ b/apps/server/src/wsRpc.auth.test.ts
@@ -11,18 +11,45 @@ import {
   toProviderProfileWsRpcError,
 } from "./wsRpc";
 import { ProviderProfileRegistryError } from "./provider/Services/ProviderProfileRegistry";
+import { CodexAccountControlError } from "./provider/Services/CodexAccountControl";
 
 it("reserves external MCP management for owner sessions", () => {
   assert.isTrue(canManageExternalMcp("owner"));
   assert.isFalse(canManageExternalMcp("client"));
 });
 
-it("allows clients to list provider profiles but reserves every mutation for owners", () => {
+it("allows clients to list provider profiles but reserves account data and mutations for owners", () => {
   assert.isTrue(canAccessProviderProfiles("client", "list"));
-  for (const operation of ["create", "rename", "setEnabled", "tombstone"] as const) {
+  for (const operation of [
+    "readAccount",
+    "create",
+    "rename",
+    "setEnabled",
+    "tombstone",
+    "startLogin",
+    "cancelLogin",
+    "logout",
+  ] as const) {
     assert.isTrue(canAccessProviderProfiles("owner", operation));
     assert.isFalse(canAccessProviderProfiles("client", operation));
   }
+});
+
+it("redacts account-control causes while preserving safe retry metadata", () => {
+  const secretUrl = "https://auth.example.test/start?token=secret";
+  const rpcError = toProviderProfileWsRpcError(
+    new CodexAccountControlError({
+      code: "PROVIDER_ACCOUNT_CONTROL_FAILED",
+      message: "The Codex account operation failed.",
+      retryable: true,
+      cause: new Error(secretUrl),
+    }),
+  );
+
+  assert.equal(rpcError.code, "PROVIDER_ACCOUNT_CONTROL_FAILED");
+  assert.isTrue(rpcError.retryable);
+  assert.equal(rpcError.cause, undefined);
+  assert.isFalse(JSON.stringify(rpcError).includes(secretUrl));
 });
 
 it("redacts registry error causes before they cross RPC", () => {

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -100,6 +100,10 @@ import { recoverUnregisteredGitHubCheckout } from "./project/githubProjectRegist
 import { ProviderAdapterRegistry } from "./provider/Services/ProviderAdapterRegistry";
 import { ProviderHealth } from "./provider/Services/ProviderHealth";
 import {
+  CodexAccountControl,
+  CodexAccountControlError,
+} from "./provider/Services/CodexAccountControl";
+import {
   ProviderProfileRegistry,
   ProviderProfileRegistryError,
 } from "./provider/Services/ProviderProfileRegistry";
@@ -165,10 +169,14 @@ export function canManageExternalMcp(role: "owner" | "client"): boolean {
 
 export type ProviderProfileRpcOperation =
   | "list"
+  | "readAccount"
   | "create"
   | "rename"
   | "setEnabled"
-  | "tombstone";
+  | "tombstone"
+  | "startLogin"
+  | "cancelLogin"
+  | "logout";
 
 export function canAccessProviderProfiles(
   role: "owner" | "client",
@@ -178,14 +186,14 @@ export function canAccessProviderProfiles(
 }
 
 export function toProviderProfileWsRpcError(
-  cause: ProviderProfileRegistryError | WsRpcError,
+  cause: ProviderProfileRegistryError | CodexAccountControlError | WsRpcError,
 ): WsRpcError {
   return cause instanceof WsRpcError
     ? cause
     : new WsRpcError({
         message: cause.message,
         code: cause.code,
-        retryable: false,
+        retryable: cause instanceof CodexAccountControlError ? cause.retryable : false,
       });
 }
 
@@ -366,6 +374,7 @@ const makeWsRpcHandlersLayer = () =>
       const providerDiscoveryService = yield* ProviderDiscoveryService;
       const providerHealth = yield* ProviderHealth;
       const providerProfiles = yield* ProviderProfileRegistry;
+      const codexAccountControl = yield* CodexAccountControl;
       const providerService = yield* ProviderService;
       const lifecycleEvents = yield* ServerLifecycleEvents;
       const runtimeStartup = yield* ServerRuntimeStartup;
@@ -826,7 +835,11 @@ const makeWsRpcHandlersLayer = () =>
         effect.pipe(Effect.mapError((cause) => toWsRpcError(cause, fallbackMessage)));
 
       const providerProfileRpcEffect = <A, R>(
-        effect: Effect.Effect<A, ProviderProfileRegistryError | WsRpcError, R>,
+        effect: Effect.Effect<
+          A,
+          ProviderProfileRegistryError | CodexAccountControlError | WsRpcError,
+          R
+        >,
       ) =>
         effect.pipe(Effect.mapError(toProviderProfileWsRpcError));
 
@@ -1662,13 +1675,37 @@ const makeWsRpcHandlersLayer = () =>
         [WS_METHODS.providerProfilesSetEnabled]: (input) =>
           providerProfileRpcEffect(
             requireProviderProfileAccess("setEnabled").pipe(
-              Effect.andThen(providerProfiles.setEnabled(input)),
+              Effect.andThen(codexAccountControl.setEnabled(input)),
             ),
           ),
         [WS_METHODS.providerProfilesTombstone]: (input) =>
           providerProfileRpcEffect(
             requireProviderProfileAccess("tombstone").pipe(
-              Effect.andThen(providerProfiles.tombstone(input)),
+              Effect.andThen(codexAccountControl.tombstone(input)),
+            ),
+          ),
+        [WS_METHODS.providerProfilesReadAccount]: (input) =>
+          providerProfileRpcEffect(
+            requireProviderProfileAccess("readAccount").pipe(
+              Effect.andThen(codexAccountControl.readAccount(input)),
+            ),
+          ),
+        [WS_METHODS.providerProfilesStartLogin]: (input) =>
+          providerProfileRpcEffect(
+            requireProviderProfileAccess("startLogin").pipe(
+              Effect.andThen(codexAccountControl.startLogin(input)),
+            ),
+          ),
+        [WS_METHODS.providerProfilesCancelLogin]: (input) =>
+          providerProfileRpcEffect(
+            requireProviderProfileAccess("cancelLogin").pipe(
+              Effect.andThen(codexAccountControl.cancelLogin(input)),
+            ),
+          ),
+        [WS_METHODS.providerProfilesLogout]: (input) =>
+          providerProfileRpcEffect(
+            requireProviderProfileAccess("logout").pipe(
+              Effect.andThen(codexAccountControl.logout(input)),
             ),
           ),
         [WS_METHODS.serverListExternalMcpIntegrations]: () =>

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -662,6 +662,10 @@ describe("wsNativeApi", () => {
     await api.providerProfiles.rename({ target, displayName: "Client" });
     await api.providerProfiles.setEnabled({ target, enabled: true });
     await api.providerProfiles.tombstone({ target });
+    await api.providerProfiles.readAccount({ target });
+    await api.providerProfiles.startLogin({ target, method: "device-code" });
+    await api.providerProfiles.cancelLogin({ target });
+    await api.providerProfiles.logout({ target });
 
     expect(requestMock.mock.calls).toEqual([
       [WS_METHODS.providerProfilesList, { provider: "codex" }],
@@ -669,6 +673,10 @@ describe("wsNativeApi", () => {
       [WS_METHODS.providerProfilesRename, { target, displayName: "Client" }],
       [WS_METHODS.providerProfilesSetEnabled, { target, enabled: true }],
       [WS_METHODS.providerProfilesTombstone, { target }],
+      [WS_METHODS.providerProfilesReadAccount, { target }],
+      [WS_METHODS.providerProfilesStartLogin, { target, method: "device-code" }],
+      [WS_METHODS.providerProfilesCancelLogin, { target }],
+      [WS_METHODS.providerProfilesLogout, { target }],
     ]);
   });
 

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -727,6 +727,10 @@ export function createWsNativeApi(): NativeApi {
       rename: (input) => transport.request(WS_METHODS.providerProfilesRename, input),
       setEnabled: (input) => transport.request(WS_METHODS.providerProfilesSetEnabled, input),
       tombstone: (input) => transport.request(WS_METHODS.providerProfilesTombstone, input),
+      readAccount: (input) => transport.request(WS_METHODS.providerProfilesReadAccount, input),
+      startLogin: (input) => transport.request(WS_METHODS.providerProfilesStartLogin, input),
+      cancelLogin: (input) => transport.request(WS_METHODS.providerProfilesCancelLogin, input),
+      logout: (input) => transport.request(WS_METHODS.providerProfilesLogout, input),
     },
     stats: {
       getProfileStats: (input) => transport.request(WS_METHODS.statsGetProfileStats, input),

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -22,6 +22,14 @@ import type {
   ExternalMcpRevokeIntegrationInput,
 } from "./externalMcp";
 import type {
+  CodexProviderAccountStatus,
+  ProviderProfileAccountReadInput,
+  ProviderProfileLoginCancelInput,
+  ProviderProfileLoginCancelResult,
+  ProviderProfileLoginStartInput,
+  ProviderProfileLoginStartResult,
+  ProviderProfileLogoutInput,
+  ProviderProfileLogoutResult,
   ProviderProfilesCreateInput,
   ProviderProfilesListInput,
   ProviderProfilesRenameInput,
@@ -780,6 +788,14 @@ export interface NativeApi {
     rename: (input: ProviderProfilesRenameInput) => Promise<ProviderProfilesSnapshot>;
     setEnabled: (input: ProviderProfilesSetEnabledInput) => Promise<ProviderProfilesSnapshot>;
     tombstone: (input: ProviderProfilesTombstoneInput) => Promise<ProviderProfilesSnapshot>;
+    readAccount: (input: ProviderProfileAccountReadInput) => Promise<CodexProviderAccountStatus>;
+    startLogin: (
+      input: ProviderProfileLoginStartInput,
+    ) => Promise<ProviderProfileLoginStartResult>;
+    cancelLogin: (
+      input: ProviderProfileLoginCancelInput,
+    ) => Promise<ProviderProfileLoginCancelResult>;
+    logout: (input: ProviderProfileLogoutInput) => Promise<ProviderProfileLogoutResult>;
   };
   stats: {
     getProfileStats: (input: StatsGetProfileStatsInput) => Promise<StatsGetProfileStatsResult>;

--- a/packages/contracts/src/providerProfileManagement.test.ts
+++ b/packages/contracts/src/providerProfileManagement.test.ts
@@ -5,6 +5,7 @@ import { Effect, Schema } from "effect";
 
 import {
   CodexProviderProfileSummary,
+  ProviderProfileLoginStartResult,
   ProviderProfilesCreateInput,
   ProviderProfilesSetEnabledInput,
 } from "./providerProfileManagement";
@@ -51,6 +52,45 @@ it("accepts bounded managed-profile mutations and rejects unsafe targets", () =>
     Schema.is(ProviderProfilesSetEnabledInput)({
       target: { provider: "claudeAgent", profileId: "work" },
       enabled: true,
+    }),
+    false,
+  );
+});
+
+it("accepts only bounded HTTP(S) login challenges", () => {
+  const base = {
+    target: { provider: "codex", profileId: "codex_work" },
+    expiresAt: "2026-08-10T00:15:00.000Z",
+  };
+  assert.equal(
+    Schema.is(ProviderProfileLoginStartResult)({
+      ...base,
+      challenge: { method: "browser", authUrl: "https://auth.example.test/start?x=1" },
+    }),
+    true,
+  );
+  assert.equal(
+    Schema.is(ProviderProfileLoginStartResult)({
+      ...base,
+      challenge: { method: "browser", authUrl: "javascript:alert(1)" },
+    }),
+    false,
+  );
+  assert.equal(
+    Schema.is(ProviderProfileLoginStartResult)({
+      ...base,
+      challenge: { method: "device-code", verificationUrl: "not a URL", userCode: "ABCD" },
+    }),
+    false,
+  );
+  assert.equal(
+    Schema.is(ProviderProfileLoginStartResult)({
+      ...base,
+      challenge: {
+        method: "device-code",
+        verificationUrl: "https://auth.example.test/device",
+        userCode: "x".repeat(257),
+      },
     }),
     false,
   );

--- a/packages/contracts/src/providerProfileManagement.ts
+++ b/packages/contracts/src/providerProfileManagement.ts
@@ -4,6 +4,19 @@ import { TrimmedNonEmptyString } from "./baseSchemas";
 import { ProviderProfileId } from "./providerProfile";
 
 const PROVIDER_PROFILE_DISPLAY_NAME_MAX_LENGTH = 80;
+const PROVIDER_ACCOUNT_EMAIL_MAX_LENGTH = 320;
+const PROVIDER_ACCOUNT_PLAN_MAX_LENGTH = 80;
+const PROVIDER_LOGIN_URL_MAX_LENGTH = 4_096;
+const PROVIDER_LOGIN_USER_CODE_MAX_LENGTH = 256;
+const ProviderAccountIsoInstant = Schema.String.check(
+  Schema.makeFilter((value: string) => {
+    try {
+      return new Date(value).toISOString() === value;
+    } catch {
+      return false;
+    }
+  }),
+);
 
 export const ProviderProfileDisplayName = TrimmedNonEmptyString.check(
   Schema.isMaxLength(PROVIDER_PROFILE_DISPLAY_NAME_MAX_LENGTH),
@@ -33,6 +46,65 @@ export const CodexProviderProfileSummary = Schema.Struct({
   storageKind: CodexProviderProfileStorageKind,
 });
 export type CodexProviderProfileSummary = typeof CodexProviderProfileSummary.Type;
+
+export const CodexProviderAccountAuthMode = Schema.Literals([
+  "api-key",
+  "chatgpt",
+  "amazon-bedrock",
+  "other",
+]);
+export type CodexProviderAccountAuthMode = typeof CodexProviderAccountAuthMode.Type;
+
+export const CodexProviderAccountStatus = Schema.Struct({
+  target: CodexProviderTarget,
+  authentication: Schema.Literals(["signed-in", "signed-out"]),
+  requiresOpenaiAuth: Schema.Boolean,
+  authMode: Schema.NullOr(CodexProviderAccountAuthMode),
+  email: Schema.NullOr(
+    TrimmedNonEmptyString.check(Schema.isMaxLength(PROVIDER_ACCOUNT_EMAIL_MAX_LENGTH)),
+  ),
+  planType: Schema.NullOr(
+    TrimmedNonEmptyString.check(Schema.isMaxLength(PROVIDER_ACCOUNT_PLAN_MAX_LENGTH)),
+  ),
+  pendingLogin: Schema.NullOr(
+    Schema.Struct({
+      method: Schema.Literals(["browser", "device-code"]),
+      expiresAt: ProviderAccountIsoInstant,
+    }),
+  ),
+});
+export type CodexProviderAccountStatus = typeof CodexProviderAccountStatus.Type;
+
+const ProviderLoginHttpUrl = TrimmedNonEmptyString.check(
+  Schema.isMaxLength(PROVIDER_LOGIN_URL_MAX_LENGTH),
+).check(
+  Schema.makeFilter((value: string) => {
+    try {
+      const parsed = new URL(value);
+      return parsed.protocol === "http:" || parsed.protocol === "https:";
+    } catch {
+      return false;
+    }
+  }),
+);
+
+export const CodexProviderLoginMethod = Schema.Literals(["browser", "device-code"]);
+export type CodexProviderLoginMethod = typeof CodexProviderLoginMethod.Type;
+
+export const CodexProviderLoginChallenge = Schema.Union([
+  Schema.Struct({
+    method: Schema.Literal("browser"),
+    authUrl: ProviderLoginHttpUrl,
+  }),
+  Schema.Struct({
+    method: Schema.Literal("device-code"),
+    verificationUrl: ProviderLoginHttpUrl,
+    userCode: TrimmedNonEmptyString.check(
+      Schema.isMaxLength(PROVIDER_LOGIN_USER_CODE_MAX_LENGTH),
+    ),
+  }),
+]);
+export type CodexProviderLoginChallenge = typeof CodexProviderLoginChallenge.Type;
 
 export const ProviderProfilesSnapshot = Schema.Struct({
   // Global Codex switch from server settings, kept separate from each profile switch.
@@ -68,3 +140,43 @@ export const ProviderProfilesTombstoneInput = Schema.Struct({
   target: CodexProviderTarget,
 });
 export type ProviderProfilesTombstoneInput = typeof ProviderProfilesTombstoneInput.Type;
+
+export const ProviderProfileAccountReadInput = Schema.Struct({
+  target: CodexProviderTarget,
+});
+export type ProviderProfileAccountReadInput = typeof ProviderProfileAccountReadInput.Type;
+
+export const ProviderProfileLoginStartInput = Schema.Struct({
+  target: CodexProviderTarget,
+  method: CodexProviderLoginMethod,
+});
+export type ProviderProfileLoginStartInput = typeof ProviderProfileLoginStartInput.Type;
+
+export const ProviderProfileLoginStartResult = Schema.Struct({
+  target: CodexProviderTarget,
+  challenge: CodexProviderLoginChallenge,
+  expiresAt: ProviderAccountIsoInstant,
+});
+export type ProviderProfileLoginStartResult = typeof ProviderProfileLoginStartResult.Type;
+
+export const ProviderProfileLoginCancelInput = Schema.Struct({
+  target: CodexProviderTarget,
+});
+export type ProviderProfileLoginCancelInput = typeof ProviderProfileLoginCancelInput.Type;
+
+export const ProviderProfileLoginCancelResult = Schema.Struct({
+  target: CodexProviderTarget,
+  status: Schema.Literals(["canceled", "not-pending"]),
+});
+export type ProviderProfileLoginCancelResult = typeof ProviderProfileLoginCancelResult.Type;
+
+export const ProviderProfileLogoutInput = Schema.Struct({
+  target: CodexProviderTarget,
+});
+export type ProviderProfileLogoutInput = typeof ProviderProfileLogoutInput.Type;
+
+export const ProviderProfileLogoutResult = Schema.Struct({
+  target: CodexProviderTarget,
+  account: CodexProviderAccountStatus,
+});
+export type ProviderProfileLogoutResult = typeof ProviderProfileLogoutResult.Type;

--- a/packages/contracts/src/rpc.test.ts
+++ b/packages/contracts/src/rpc.test.ts
@@ -9,7 +9,11 @@ import {
   WsProjectsDiscoverScriptsRpc,
   WsProjectsProvisionFromGitHubRpc,
   WsProviderProfilesCreateRpc,
+  WsProviderProfilesCancelLoginRpc,
   WsProviderProfilesListRpc,
+  WsProviderProfilesLogoutRpc,
+  WsProviderProfilesReadAccountRpc,
+  WsProviderProfilesStartLoginRpc,
   WsPullRequestsReviewRequestCountRpc,
   WsRpcError,
   WsRpcGroup,
@@ -48,8 +52,16 @@ describe("WS RPC contracts", () => {
   it("exports the provider profile registry RPCs", () => {
     expect(WsProviderProfilesListRpc).toBeDefined();
     expect(WsProviderProfilesCreateRpc).toBeDefined();
+    expect(WsProviderProfilesReadAccountRpc).toBeDefined();
+    expect(WsProviderProfilesStartLoginRpc).toBeDefined();
+    expect(WsProviderProfilesCancelLoginRpc).toBeDefined();
+    expect(WsProviderProfilesLogoutRpc).toBeDefined();
     expect(WsFeatureRpcGroup.requests.has("providerProfiles.list")).toBe(true);
     expect(WsFeatureRpcGroup.requests.has("providerProfiles.tombstone")).toBe(true);
+    expect(WsFeatureRpcGroup.requests.has("providerProfiles.readAccount")).toBe(true);
+    expect(WsFeatureRpcGroup.requests.has("providerProfiles.startLogin")).toBe(true);
+    expect(WsFeatureRpcGroup.requests.has("providerProfiles.cancelLogin")).toBe(true);
+    expect(WsFeatureRpcGroup.requests.has("providerProfiles.logout")).toBe(true);
   });
 
   it("exports the count-only pull request review RPC", () => {

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -138,6 +138,14 @@ import {
 } from "./orchestration";
 import { ProviderCompactThreadInput } from "./provider";
 import {
+  CodexProviderAccountStatus,
+  ProviderProfileAccountReadInput,
+  ProviderProfileLoginCancelInput,
+  ProviderProfileLoginCancelResult,
+  ProviderProfileLoginStartInput,
+  ProviderProfileLoginStartResult,
+  ProviderProfileLogoutInput,
+  ProviderProfileLogoutResult,
   ProviderProfilesCreateInput,
   ProviderProfilesListInput,
   ProviderProfilesRenameInput,
@@ -954,6 +962,39 @@ export const WsProviderProfilesTombstoneRpc = Rpc.make(WS_METHODS.providerProfil
   error: WsRpcError,
 });
 
+export const WsProviderProfilesReadAccountRpc = Rpc.make(
+  WS_METHODS.providerProfilesReadAccount,
+  {
+    payload: ProviderProfileAccountReadInput,
+    success: CodexProviderAccountStatus,
+    error: WsRpcError,
+  },
+);
+
+export const WsProviderProfilesStartLoginRpc = Rpc.make(
+  WS_METHODS.providerProfilesStartLogin,
+  {
+    payload: ProviderProfileLoginStartInput,
+    success: ProviderProfileLoginStartResult,
+    error: WsRpcError,
+  },
+);
+
+export const WsProviderProfilesCancelLoginRpc = Rpc.make(
+  WS_METHODS.providerProfilesCancelLogin,
+  {
+    payload: ProviderProfileLoginCancelInput,
+    success: ProviderProfileLoginCancelResult,
+    error: WsRpcError,
+  },
+);
+
+export const WsProviderProfilesLogoutRpc = Rpc.make(WS_METHODS.providerProfilesLogout, {
+  payload: ProviderProfileLogoutInput,
+  success: ProviderProfileLogoutResult,
+  error: WsRpcError,
+});
+
 export const WsServerListExternalMcpIntegrationsRpc = Rpc.make(
   WS_METHODS.serverListExternalMcpIntegrations,
   {
@@ -1314,6 +1355,10 @@ export const WsFeatureRpcGroup = RpcGroup.make(
   WsProviderProfilesRenameRpc,
   WsProviderProfilesSetEnabledRpc,
   WsProviderProfilesTombstoneRpc,
+  WsProviderProfilesReadAccountRpc,
+  WsProviderProfilesStartLoginRpc,
+  WsProviderProfilesCancelLoginRpc,
+  WsProviderProfilesLogoutRpc,
   WsServerListExternalMcpIntegrationsRpc,
   WsServerCreateExternalMcpIntegrationRpc,
   WsServerRevokeExternalMcpIntegrationRpc,

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -140,6 +140,10 @@ import {
 } from "./providerDiscovery";
 import { ProviderCompactThreadInput } from "./provider";
 import {
+  ProviderProfileAccountReadInput,
+  ProviderProfileLoginCancelInput,
+  ProviderProfileLoginStartInput,
+  ProviderProfileLogoutInput,
   ProviderProfilesCreateInput,
   ProviderProfilesListInput,
   ProviderProfilesRenameInput,
@@ -270,6 +274,10 @@ export const WS_METHODS = {
   providerProfilesRename: "providerProfiles.rename",
   providerProfilesSetEnabled: "providerProfiles.setEnabled",
   providerProfilesTombstone: "providerProfiles.tombstone",
+  providerProfilesReadAccount: "providerProfiles.readAccount",
+  providerProfilesStartLogin: "providerProfiles.startLogin",
+  providerProfilesCancelLogin: "providerProfiles.cancelLogin",
+  providerProfilesLogout: "providerProfiles.logout",
 
   // Streaming subscriptions
   subscribeTerminalEvents: "terminal.subscribeEvents",
@@ -477,6 +485,10 @@ const WebSocketRequestBody = Schema.Union([
   tagRequestBody(WS_METHODS.providerProfilesRename, ProviderProfilesRenameInput),
   tagRequestBody(WS_METHODS.providerProfilesSetEnabled, ProviderProfilesSetEnabledInput),
   tagRequestBody(WS_METHODS.providerProfilesTombstone, ProviderProfilesTombstoneInput),
+  tagRequestBody(WS_METHODS.providerProfilesReadAccount, ProviderProfileAccountReadInput),
+  tagRequestBody(WS_METHODS.providerProfilesStartLogin, ProviderProfileLoginStartInput),
+  tagRequestBody(WS_METHODS.providerProfilesCancelLogin, ProviderProfileLoginCancelInput),
+  tagRequestBody(WS_METHODS.providerProfilesLogout, ProviderProfileLogoutInput),
 
   // Provider discovery
   tagRequestBody(WS_METHODS.providerGetComposerCapabilities, ProviderGetComposerCapabilitiesInput),


### PR DESCRIPTION
## Summary

- add owner-only Codex account read, browser/device login, cancellation, logout, and account-status RPCs
- keep the legacy default Codex profile read-only and preserve its existing runtime behavior
- run managed account operations in isolated private homes with a minimal Synara-owned ChatGPT/file-store configuration and explicit environment allowlist
- permanently bind each managed profile to its first authenticated account namespace; logout verifies credential deletion before terminally tombstoning the profile
- gate account control on Codex app-server v0.144+ and harden request timeouts, unexpected exits, stdio failures, process-tree retirement, and response redaction
- durably migrate the managed profile registry to its account-binding schema and expose a server-only continuation namespace seam for the runtime-routing follow-up

Stacked on #623. Normal managed runtime, discovery, and text-generation routing remain intentionally out of this PR.

## Safety properties

- browser contracts never expose private home paths, storage keys, auth files, or tokens
- managed account processes never inherit arbitrary parent credentials or custom-provider environment variables
- default-profile login/logout is rejected; Synara cannot silently rebind legacy native history
- a managed profile cannot be enabled before authentication or rebound after it is sealed
- logout tombstones only after a fresh signed-out read, process retirement, confirmed auth-file absence, and directory durability sync
- failed teardown leaves the target poisoned instead of retrying against a potentially reused PID

## Verification

- server focused matrix: 8 files, 201 passed, 2 skipped
- contracts: 2 files, 9 passed
- web transport: 1 file, 36 passed
- two independent exact-head reviews: no PR-local P0/P1/P2 findings
- live installed Codex 0.144.1 managed-root initialization passed with a hostile ancestor config; 0.144/0.147 account protocol shapes were checked
- `git diff --cached --check`

Not run pending explicit repository authorization: `bun fmt`, `bun lint`, `bun typecheck`.

## Follow-ups

- route managed targets through normal runtimes, discovery, text generation, and complete-target cache keys
- persist and enforce the continuation namespace in runtime bindings
- retire exact-target runtimes across account lifecycle mutations
- add account UI and transcript-based cross-account handoff
- separately harden the shared process teardown utility's pre-existing first-teardown PID-reuse edge
