### PR TITLE
fix(server): isolate malformed model descriptors

### DIFF
--- a/apps/server/src/provider/Layers/ProviderDiscoveryService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderDiscoveryService.test.ts
@@ -272,4 +272,27 @@ describe("ProviderDiscoveryService.listModels", () => {
     expect(result.models).toEqual([{ slug: "cursor-model", name: "Cursor Model" }]);
     expect(adapterCalls).toBe(1);
   });
+
+  it("omits malformed model descriptors while preserving valid entries", async () => {
+    const result = await runListModels({
+      adapter: {
+        listModels: () =>
+          Effect.succeed({
+            models: [
+              { slug: "valid-model", name: "Valid Model" },
+              { slug: "invalid-model", name: " " },
+            ],
+            source: "cursor.cli",
+            cached: false,
+          } as ProviderListModelsResult),
+      },
+      enabled: true,
+    });
+
+    expect(result).toEqual({
+      models: [{ slug: "valid-model", name: "Valid Model" }],
+      source: "cursor.cli",
+      cached: false,
+    });
+  });
 });

--- a/apps/server/src/provider/Layers/ProviderDiscoveryService.ts
+++ b/apps/server/src/provider/Layers/ProviderDiscoveryService.ts
@@ -5,13 +5,15 @@ import {
   ProviderListAgentsInput,
   ProviderListCommandsInput,
   ProviderListModelsInput,
+  type ProviderListModelsResult,
   ProviderListPluginsInput,
+  ProviderModelDescriptor,
   ProviderListSkillsInput,
   type ProviderListSkillsResult,
   ProviderReadPluginInput,
   type ProviderSkillDescriptor,
 } from "@synara/contracts";
-import { Effect, Layer, Schema, SchemaIssue } from "effect";
+import { Effect, Layer, Option, Schema, SchemaIssue } from "effect";
 
 import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
@@ -56,6 +58,32 @@ const disabledCapabilitiesForProvider = (
   supportsThreadCompaction: false,
   supportsThreadImport: false,
 });
+
+const decodeProviderModelDescriptorOption = Schema.decodeUnknownOption(ProviderModelDescriptor);
+
+function isolateMalformedModelDescriptors(input: {
+  readonly provider: ProviderListModelsInput["provider"];
+  readonly result: ProviderListModelsResult;
+}): Effect.Effect<ProviderListModelsResult> {
+  const models = input.result.models.flatMap((model) => {
+    const decoded = decodeProviderModelDescriptorOption(model);
+    return Option.isSome(decoded) ? [decoded.value] : [];
+  });
+  const omittedCount = input.result.models.length - models.length;
+  if (omittedCount === 0) {
+    return Effect.succeed(input.result);
+  }
+  return Effect.logWarning("provider model discovery omitted malformed descriptors", {
+    provider: input.provider,
+    source: input.result.source ?? "unknown",
+    omittedCount,
+  }).pipe(
+    Effect.as({
+      ...input.result,
+      models,
+    }),
+  );
+}
 
 const make = Effect.gen(function* () {
   const registry = yield* ProviderAdapterRegistry;
@@ -219,7 +247,11 @@ const make = Effect.gen(function* () {
           cached: false,
         };
       }
-      return yield* adapter.listModels(parsed);
+      const result = yield* adapter.listModels(parsed);
+      return yield* isolateMalformedModelDescriptors({
+        provider: parsed.provider,
+        result,
+      });
     });
 
   const listAgents: ProviderDiscoveryServiceShape["listAgents"] = (input) =>


### PR DESCRIPTION
## What Changed

- Filter provider `listModels` results through the existing `ProviderModelDescriptor` schema one entry at a time.
- Preserve valid model descriptors when a malformed external descriptor appears.
- Log a safe diagnostic with provider, source, and omitted count only.
- Add regression coverage for valid and invalid descriptors returned together.

Closes #502.

## Why

External catalog metadata can contain malformed model descriptors. The RPC boundary should still return only descriptors satisfying the existing contract, but one bad entry should not hide every valid model from that provider.

## UI Changes

Not applicable.

## Verification

- `bun run --cwd apps/server test src/provider/Layers/ProviderDiscoveryService.test.ts` -> 8 passed
- `bun run --cwd apps/desktop test src/browserUsePipeServer.test.ts` -> 15 passed after running Electron install script locally
- `bun run fmt:check` -> passed
- `bun run lint` -> 416 warnings, 0 errors
- `bun run typecheck` -> 7 successful
- `git diff --check` -> passed
- `bun run test` -> fails in unrelated `src/provider/acp/AcpSdkConformance.test.ts` timeout: `preserves early session updates and prompt update ordering` timed out at 90000ms; reproduced with the single test file

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A)
- [x] I included a video for animation/interaction changes (N/A)