### PR TITLE
Optimize native session forking across providers

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -308,6 +308,12 @@ const SIDECHAT_BOUNDARY_INSTRUCTION =
 
 type ProviderContextTag = "handoff_context" | "sidechat_context" | "thread_context";
 
+interface BootstrapContextSelection {
+  readonly tag: ProviderContextTag;
+  readonly contextText: string;
+  readonly wrapLatestUserMessage: boolean;
+}
+
 function wrapProviderContext(input: {
   readonly tag: ProviderContextTag;
   readonly contextText: string;
@@ -1549,29 +1555,29 @@ const make = Effect.gen(function* () {
             priorTranscriptBootstrapAvailableChars,
           )
         : null;
-    const providerInput = handoffBootstrapText
-      ? wrapProviderContext({
-          tag: "handoff_context",
-          contextText: handoffBootstrapText,
-          messageText: boundaryMessageText,
-          wrapLatestUserMessage: true,
-        })
-      : sidechatBootstrapText
-        ? wrapProviderContext({
-            tag: "sidechat_context",
-            contextText: sidechatBootstrapText,
-            messageText: boundaryMessageText,
-            wrapLatestUserMessage: false,
-          })
-        : priorTranscriptBootstrapText
-          ? wrapProviderContext({
-              tag: "thread_context",
-              contextText: priorTranscriptBootstrapText,
-              messageText: boundaryMessageText,
-              wrapLatestUserMessage: true,
-            })
-          : boundaryMessageText;
-    const providerInputWithMentionContext = `${providerInput}${mentionContextSuffix}`;
+    // The guards above make the three bootstrap flavors mutually exclusive, so
+    // a turn carries at most one context block.
+    const selectedBootstrapContext: BootstrapContextSelection | null =
+      handoffBootstrapText !== null
+        ? { tag: "handoff_context", contextText: handoffBootstrapText, wrapLatestUserMessage: true }
+        : sidechatBootstrapText !== null
+          ? {
+              tag: "sidechat_context",
+              contextText: sidechatBootstrapText,
+              wrapLatestUserMessage: false,
+            }
+          : priorTranscriptBootstrapText !== null
+            ? {
+                tag: "thread_context",
+                contextText: priorTranscriptBootstrapText,
+                wrapLatestUserMessage: true,
+              }
+            : null;
+    const composeProviderInput = (bootstrap: BootstrapContextSelection | null): string =>
+      bootstrap
+        ? wrapProviderContext({ ...bootstrap, messageText: boundaryMessageText })
+        : boundaryMessageText;
+    const providerInputWithMentionContext = `${composeProviderInput(selectedBootstrapContext)}${mentionContextSuffix}`;
     // Portable skills fallback: providers that cannot load the referenced skill
     // file natively get the skill instructions inlined into the prompt.
     const skillInlineText =
@@ -1596,16 +1602,20 @@ const make = Effect.gen(function* () {
             ),
           )
         : "";
-    const providerInputWithSkills = skillInlineText
-      ? `${providerInputWithMentionContext}\n\n${skillInlineText}`
-      : providerInputWithMentionContext;
-    const normalizedInput = toNonEmptyProviderInput(
-      normalizeSkillMentionTextForProvider({
-        provider: selectedProvider as ProviderKind,
-        messageText: providerInputWithSkills,
-        ...(input.skills !== undefined ? { skills: input.skills } : {}),
-      }),
-    );
+    const finalizeProviderInput = (bootstrap: BootstrapContextSelection | null) => {
+      const withMentionContext = `${composeProviderInput(bootstrap)}${mentionContextSuffix}`;
+      const withSkills = skillInlineText
+        ? `${withMentionContext}\n\n${skillInlineText}`
+        : withMentionContext;
+      return toNonEmptyProviderInput(
+        normalizeSkillMentionTextForProvider({
+          provider: selectedProvider as ProviderKind,
+          messageText: withSkills,
+          ...(input.skills !== undefined ? { skills: input.skills } : {}),
+        }),
+      );
+    };
+    const normalizedInput = finalizeProviderInput(selectedBootstrapContext);
     const normalizedAttachments = yield* resolveProviderDispatchAttachments({
       attachments: input.attachments,
       attachmentsDir: serverConfig.attachmentsDir,
@@ -1746,24 +1756,14 @@ const make = Effect.gen(function* () {
                   priorTranscriptBootstrapAvailableChars,
                 )
               : null;
-          const retryProviderInput = retryBootstrapText
-            ? wrapProviderContext({
-                tag: "thread_context",
-                contextText: retryBootstrapText,
-                messageText: boundaryMessageText,
-                wrapLatestUserMessage: true,
-              })
-            : boundaryMessageText;
-          const retryProviderInputWithMentionContext = `${retryProviderInput}${mentionContextSuffix}`;
-          const retryProviderInputWithSkills = skillInlineText
-            ? `${retryProviderInputWithMentionContext}\n\n${skillInlineText}`
-            : retryProviderInputWithMentionContext;
-          const retryNormalizedInput = toNonEmptyProviderInput(
-            normalizeSkillMentionTextForProvider({
-              provider: selectedProvider as ProviderKind,
-              messageText: retryProviderInputWithSkills,
-              ...(input.skills !== undefined ? { skills: input.skills } : {}),
-            }),
+          const retryNormalizedInput = finalizeProviderInput(
+            retryBootstrapText !== null
+              ? {
+                  tag: "thread_context",
+                  contextText: retryBootstrapText,
+                  wrapLatestUserMessage: true,
+                }
+              : null,
           );
 
           yield* Effect.logWarning(

--- a/apps/server/src/orchestration/handoff.ts
+++ b/apps/server/src/orchestration/handoff.ts
@@ -1,13 +1,8 @@
-import {
-  PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
-  type OrchestrationMessage,
-  type OrchestrationThread,
-} from "@synara/contracts";
+import type { OrchestrationMessage, OrchestrationThread } from "@synara/contracts";
 
 const RECENT_MESSAGE_COUNT = 6;
 const EARLIER_MESSAGE_CHAR_LIMIT = 320;
 const RECENT_MESSAGE_CHAR_LIMIT = 2_400;
-const HANDOFF_BOOTSTRAP_CHAR_BUDGET = Math.floor(PROVIDER_SEND_TURN_MAX_INPUT_CHARS * 0.75);
 // Hard ceiling for any bootstrap transcript: it replays as one uncached user
 // message, so long threads must drop their oldest summaries rather than grow.
 const BOOTSTRAP_TRANSCRIPT_CHAR_BUDGET = 32_000;
@@ -180,7 +175,7 @@ function buildImportedMessagesBootstrapText(input: {
 
 export function buildHandoffBootstrapText(
   thread: Pick<OrchestrationThread, "title" | "branch" | "worktreePath" | "handoff" | "messages">,
-  maxChars = HANDOFF_BOOTSTRAP_CHAR_BUDGET,
+  maxChars = BOOTSTRAP_TRANSCRIPT_CHAR_BUDGET,
 ): string | null {
   const importedMessages = listImportedHandoffMessages(thread);
   if (importedMessages.length === 0 || thread.handoff === null) {
@@ -198,7 +193,7 @@ export function buildHandoffBootstrapText(
 export function buildPriorTranscriptBootstrapText(
   thread: Pick<OrchestrationThread, "title" | "branch" | "worktreePath" | "messages">,
   currentMessageId: string,
-  maxChars = HANDOFF_BOOTSTRAP_CHAR_BUDGET,
+  maxChars = BOOTSTRAP_TRANSCRIPT_CHAR_BUDGET,
 ): string | null {
   const priorMessages = listPriorTranscriptMessages(thread, currentMessageId);
   if (priorMessages.length === 0) {
@@ -216,7 +211,7 @@ export function buildPriorTranscriptBootstrapText(
 
 export function buildForkBootstrapText(
   thread: Pick<OrchestrationThread, "title" | "branch" | "worktreePath" | "messages">,
-  maxChars = HANDOFF_BOOTSTRAP_CHAR_BUDGET,
+  maxChars = BOOTSTRAP_TRANSCRIPT_CHAR_BUDGET,
 ): string | null {
   const importedMessages = listImportedForkMessages(thread);
   if (importedMessages.length === 0) {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -10081,3 +10081,219 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
     );
   });
 });
+
+describe("ClaudeAdapterLive forkThread", () => {
+  const SOURCE_SESSION_ID = "7f9c2f60-1111-4a2b-9c3d-8e5f6a7b8c9d";
+
+  function makeForkLayer(
+    forkNativeSession: NonNullable<ClaudeAdapterLiveOptions["forkNativeSession"]>,
+  ) {
+    return makeClaudeAdapterLive({ forkNativeSession }).pipe(
+      Layer.provideMerge(ServerConfig.layerTest("/tmp/claude-adapter-test", "/tmp")),
+      Layer.provideMerge(NodeServices.layer),
+    );
+  }
+
+  it.effect("forks natively from the persisted cursor and drops source uuid pins", () => {
+    const forkCalls: Array<{
+      readonly sessionId: string;
+      readonly options: { readonly upToMessageId?: string } | undefined;
+    }> = [];
+    const layer = makeForkLayer(async (sessionId, options) => {
+      forkCalls.push({ sessionId, options });
+      return { sessionId: "forked-session-1" };
+    });
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const result = yield* adapter.forkThread!({
+        sourceThreadId: THREAD_ID,
+        threadId: RESUME_THREAD_ID,
+        runtimeMode: "full-access",
+        sourceResumeCursor: {
+          threadId: String(THREAD_ID),
+          resume: SOURCE_SESSION_ID,
+          resumeSessionAt: "assistant-uuid-9",
+          turnCount: 4,
+        },
+      });
+
+      assert.deepEqual(forkCalls, [
+        { sessionId: SOURCE_SESSION_ID, options: { upToMessageId: "assistant-uuid-9" } },
+      ]);
+      // The SDK fork remaps message uuids, so the fork cursor must resume the
+      // new session id without inheriting `resumeSessionAt` or tracked tasks.
+      assert.deepEqual(result, {
+        threadId: RESUME_THREAD_ID,
+        resumeCursor: {
+          threadId: RESUME_THREAD_ID,
+          resume: "forked-session-1",
+          turnCount: 4,
+        },
+      });
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(layer),
+    );
+  });
+
+  it.effect("refuses a native fork while the source turn is in flight", () => {
+    const query = new FakeClaudeQuery();
+    let forkCalls = 0;
+    const layer = makeClaudeAdapterLive({
+      createQuery: () => query,
+      forkNativeSession: async () => {
+        forkCalls += 1;
+        return { sessionId: "unexpected" };
+      },
+    }).pipe(
+      Layer.provideMerge(ServerConfig.layerTest("/tmp/claude-adapter-test", "/tmp")),
+      Layer.provideMerge(NodeServices.layer),
+    );
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "Long-running work",
+        attachments: [],
+      });
+
+      const result = yield* adapter.forkThread!({
+        sourceThreadId: THREAD_ID,
+        threadId: RESUME_THREAD_ID,
+        runtimeMode: "full-access",
+        sourceResumeCursor: {
+          threadId: String(THREAD_ID),
+          resume: SOURCE_SESSION_ID,
+        },
+      }).pipe(Effect.result);
+
+      assert.equal(forkCalls, 0);
+      assert.equal(result._tag, "Failure");
+      if (result._tag !== "Failure") {
+        return;
+      }
+      assert.instanceOf(result.failure, ProviderAdapterValidationError);
+      if (result.failure instanceof ProviderAdapterValidationError) {
+        assert.include(result.failure.issue, "turn in flight");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(layer),
+    );
+  });
+
+  it.effect("keeps the larger persisted turnCount over a freshly resumed live context", () => {
+    const query = new FakeClaudeQuery();
+    const layer = makeClaudeAdapterLive({
+      createQuery: () => query,
+      forkNativeSession: async () => ({ sessionId: "forked-session-2" }),
+    }).pipe(
+      Layer.provideMerge(ServerConfig.layerTest("/tmp/claude-adapter-test", "/tmp")),
+      Layer.provideMerge(NodeServices.layer),
+    );
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      // A live context restarts its turn log at [] on resume; the persisted
+      // cumulative count must win.
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+      });
+
+      const result = yield* adapter.forkThread!({
+        sourceThreadId: THREAD_ID,
+        threadId: RESUME_THREAD_ID,
+        runtimeMode: "full-access",
+        sourceResumeCursor: {
+          threadId: String(THREAD_ID),
+          resume: SOURCE_SESSION_ID,
+          turnCount: 4,
+        },
+      });
+
+      assert.deepEqual(result.resumeCursor, {
+        threadId: RESUME_THREAD_ID,
+        resume: "forked-session-2",
+        turnCount: 4,
+      });
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(layer),
+    );
+  });
+
+  it.effect("fails validation when the source has no resumable native cursor", () => {
+    let forkCalls = 0;
+    const layer = makeForkLayer(async () => {
+      forkCalls += 1;
+      return { sessionId: "unexpected" };
+    });
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const result = yield* adapter.forkThread!({
+        sourceThreadId: THREAD_ID,
+        threadId: RESUME_THREAD_ID,
+        runtimeMode: "full-access",
+      }).pipe(Effect.result);
+
+      assert.equal(forkCalls, 0);
+      assert.equal(result._tag, "Failure");
+      if (result._tag !== "Failure") {
+        return;
+      }
+      assert.deepEqual(
+        result.failure,
+        new ProviderAdapterValidationError({
+          provider: "claudeAgent",
+          operation: "forkThread",
+          issue: "The source Claude session has no resumable native cursor.",
+        }),
+      );
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(layer),
+    );
+  });
+
+  it.effect("maps a native fork failure to a session/fork request error", () => {
+    const layer = makeForkLayer(async () => {
+      throw new Error("session file missing");
+    });
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const result = yield* adapter.forkThread!({
+        sourceThreadId: THREAD_ID,
+        threadId: RESUME_THREAD_ID,
+        runtimeMode: "full-access",
+        sourceResumeCursor: {
+          threadId: String(THREAD_ID),
+          resume: SOURCE_SESSION_ID,
+        },
+      }).pipe(Effect.result);
+
+      assert.equal(result._tag, "Failure");
+      if (result._tag !== "Failure") {
+        return;
+      }
+      assert.instanceOf(result.failure, ProviderAdapterRequestError);
+      if (result.failure instanceof ProviderAdapterRequestError) {
+        assert.equal(result.failure.method, "session/fork");
+        assert.include(result.failure.detail, "session file missing");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(layer),
+    );
+  });
+});

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -10097,7 +10097,7 @@ describe("ClaudeAdapterLive forkThread", () => {
   it.effect("forks natively from the persisted cursor and drops source uuid pins", () => {
     const forkCalls: Array<{
       readonly sessionId: string;
-      readonly options: { readonly upToMessageId?: string } | undefined;
+      readonly options: { readonly dir?: string; readonly upToMessageId?: string } | undefined;
     }> = [];
     const layer = makeForkLayer(async (sessionId, options) => {
       forkCalls.push({ sessionId, options });
@@ -10110,6 +10110,7 @@ describe("ClaudeAdapterLive forkThread", () => {
         sourceThreadId: THREAD_ID,
         threadId: RESUME_THREAD_ID,
         runtimeMode: "full-access",
+        sourceCwd: "/repo/source",
         sourceResumeCursor: {
           threadId: String(THREAD_ID),
           resume: SOURCE_SESSION_ID,
@@ -10119,7 +10120,10 @@ describe("ClaudeAdapterLive forkThread", () => {
       });
 
       assert.deepEqual(forkCalls, [
-        { sessionId: SOURCE_SESSION_ID, options: { upToMessageId: "assistant-uuid-9" } },
+        {
+          sessionId: SOURCE_SESSION_ID,
+          options: { dir: "/repo/source", upToMessageId: "assistant-uuid-9" },
+        },
       ]);
       // The SDK fork remaps message uuids, so the fork cursor must resume the
       // new session id without inheriting `resumeSessionAt` or tracked tasks.

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -561,7 +561,7 @@ export interface ClaudeAdapterLiveOptions {
   }) => ClaudeQueryRuntime | Promise<ClaudeQueryRuntime>;
   readonly forkNativeSession?: (
     sessionId: string,
-    options?: { readonly upToMessageId?: string },
+    options?: { readonly dir?: string; readonly upToMessageId?: string },
   ) => Promise<{ sessionId: string }>;
   readonly nativeEventLogPath?: string;
   readonly nativeEventLogger?: EventNdjsonLogger;
@@ -1761,7 +1761,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
     };
     const forkNativeSession = async (
       sessionId: string,
-      forkOptions?: { readonly upToMessageId?: string },
+      forkOptions?: { readonly dir?: string; readonly upToMessageId?: string },
     ): Promise<{ sessionId: string }> => {
       const override = options?.forkNativeSession;
       if (override) {
@@ -5959,9 +5959,11 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           });
         }
         const upToMessageId = liveSource?.lastAssistantUuid ?? sourceState?.resumeSessionAt;
+        const sourceCwd = liveSource?.session.cwd ?? input.sourceCwd;
         const forked = yield* Effect.tryPromise({
           try: () =>
             forkNativeSession(sourceSessionId, {
+              ...(sourceCwd ? { dir: sourceCwd } : {}),
               ...(upToMessageId ? { upToMessageId } : {}),
             }),
           catch: (cause) =>

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -559,6 +559,10 @@ export interface ClaudeAdapterLiveOptions {
     readonly prompt: AsyncIterable<SDKUserMessage>;
     readonly options: ClaudeQueryOptions;
   }) => ClaudeQueryRuntime | Promise<ClaudeQueryRuntime>;
+  readonly forkNativeSession?: (
+    sessionId: string,
+    options?: { readonly upToMessageId?: string },
+  ) => Promise<{ sessionId: string }>;
   readonly nativeEventLogPath?: string;
   readonly nativeEventLogger?: EventNdjsonLogger;
   // Interval for polling a live workflow's transcript directory. Tests shrink it.
@@ -1754,6 +1758,17 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
       }
       const { query } = await loadClaudeAgentSdk();
       return query({ prompt: input.prompt, options: input.options }) as ClaudeQueryRuntime;
+    };
+    const forkNativeSession = async (
+      sessionId: string,
+      forkOptions?: { readonly upToMessageId?: string },
+    ): Promise<{ sessionId: string }> => {
+      const override = options?.forkNativeSession;
+      if (override) {
+        return override(sessionId, forkOptions);
+      }
+      const { forkSession } = await loadClaudeAgentSdk();
+      return forkSession(sessionId, forkOptions);
     };
     const spawnClaudeProcess = options?.spawnClaudeCodeProcess ?? spawnOwnedClaudeCodeProcess;
     const teardownProcessTree = options?.teardownProcessTree ?? teardownProviderProcessTree;
@@ -5918,6 +5933,57 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         }),
       );
 
+    const forkThread: NonNullable<ClaudeAdapterShape["forkThread"]> = (input) =>
+      Effect.gen(function* () {
+        // Prefer the live session's cursor: the persisted binding may lag the
+        // runtime by a turn.
+        const liveSource = sessions.get(input.sourceThreadId);
+        // Mid-turn `lastAssistantUuid` can point at a tool_use without its
+        // result yet, so a fork now would cut the transcript in an incomplete
+        // state. Let the retained-transcript fallback handle busy sources.
+        if (liveSource?.turnState !== undefined) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "forkThread",
+            issue:
+              "The source Claude session has a turn in flight; Synara will rebuild the fork from its retained transcript.",
+          });
+        }
+        const sourceState = readClaudeResumeState(input.sourceResumeCursor);
+        const sourceSessionId = liveSource?.resumeSessionId ?? sourceState?.resume;
+        if (!sourceSessionId) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "forkThread",
+            issue: "The source Claude session has no resumable native cursor.",
+          });
+        }
+        const upToMessageId = liveSource?.lastAssistantUuid ?? sourceState?.resumeSessionAt;
+        const forked = yield* Effect.tryPromise({
+          try: () =>
+            forkNativeSession(sourceSessionId, {
+              ...(upToMessageId ? { upToMessageId } : {}),
+            }),
+          catch: (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "session/fork",
+              detail: toMessage(cause, "Failed to fork the Claude session transcript."),
+              cause,
+            }),
+        });
+        // The SDK fork remaps every message uuid, so the source's resume pin
+        // (`resumeSessionAt`) and tracked tasks must not carry into the fork.
+        // A live context restarts `turns` at [] on resume, so its length can
+        // undercount the cumulative persisted total — keep the larger of the two.
+        const resumeCursor = {
+          threadId: input.threadId,
+          resume: forked.sessionId,
+          turnCount: Math.max(liveSource?.turns.length ?? 0, sourceState?.turnCount ?? 0),
+        };
+        return { threadId: input.threadId, resumeCursor };
+      });
+
     const respondToRequest: ClaudeAdapterShape["respondToRequest"] = (
       threadId,
       requestId,
@@ -6314,6 +6380,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
       steerSubagent,
       readThread,
       rollbackThread,
+      forkThread,
       respondToRequest,
       respondToUserInput,
       stopSession,

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -60,6 +60,7 @@ import { loadProviderPromptImageBlocks } from "../promptAttachments.ts";
 import {
   ProviderAdapterProcessError,
   ProviderAdapterRequestError,
+  ProviderAdapterSessionClosedError,
   ProviderAdapterSessionNotFoundError,
   ProviderAdapterValidationError,
 } from "../Errors.ts";
@@ -80,6 +81,7 @@ import {
   settleAcpPendingUserInputsAsEmptyAnswers,
 } from "../acp/AcpAdapterSessionSupport.ts";
 import type * as AcpErrors from "../acp/AcpErrors.ts";
+import { forkViaAcpRuntime } from "../acp/acpFork.ts";
 import {
   type AcpSessionRuntimeShape,
   type AcpSessionStartupTimeouts,
@@ -138,6 +140,9 @@ export const takeCursorSynaraHarnessPolicyTextPart = (
   });
 const CURSOR_RESUME_VERSION = 1 as const;
 const CURSOR_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
+// Forking a dead source session must first resume it, which may replay
+// history, so the fork exchange gets a wider budget than plain requests.
+const CURSOR_ACP_FORK_TIMEOUT_MS = 30_000;
 // `cursor-agent` authenticates against the macOS Keychain: 1-12s is normal and it
 // hangs forever when a Keychain prompt cannot be shown, so authenticate gets the
 // widest budget while the aggregate cap keeps a stuck startup from hanging a thread.
@@ -1691,6 +1696,115 @@ export function makeCursorAdapter(
       );
     };
 
+    const cursorForkTimeoutError = (method: string): ProviderAdapterRequestError =>
+      new ProviderAdapterRequestError({
+        provider: PROVIDER,
+        method,
+        detail: `Cursor ACP did not respond to ${method} within ${CURSOR_ACP_FORK_TIMEOUT_MS / 1000}s.`,
+      });
+
+    const forkThread: NonNullable<CursorAdapterShape["forkThread"]> = (input) =>
+      Effect.gen(function* () {
+        const sourceCwd = resolveCursorSessionCwd(input.sourceCwd ?? input.cwd, serverConfig);
+        const targetCwd = resolveCursorSessionCwd(input.cwd ?? input.sourceCwd, serverConfig);
+        if (!sourceCwd || !targetCwd) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "forkThread",
+            issue: "A source and target cwd are required to fork a Cursor session.",
+          });
+        }
+
+        const forkRuntime = (runtime: AcpSessionRuntimeShape) =>
+          forkViaAcpRuntime({
+            provider: PROVIDER,
+            runtime,
+            targetCwd,
+            unsupportedIssue:
+              "This Cursor ACP version does not advertise session/fork; Synara will rebuild the fork from its retained transcript.",
+            requestTimeoutMs: CURSOR_ACP_FORK_TIMEOUT_MS,
+            timeoutError: cursorForkTimeoutError,
+          });
+
+        const activeSource = sessions.get(input.sourceThreadId);
+        // Forking mid-turn would branch from incomplete in-flight state, so
+        // let the retained-transcript fallback handle busy sources.
+        if (activeSource?.activeTurnId !== undefined) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "forkThread",
+            issue:
+              "The source Cursor session has a turn in flight; Synara will rebuild the fork from its retained transcript.",
+          });
+        }
+        const forked = activeSource
+          ? yield* forkRuntime(activeSource.acp)
+          : yield* Effect.gen(function* () {
+              const sourceSessionId = parseCursorResume(input.sourceResumeCursor)?.sessionId;
+              if (!sourceSessionId) {
+                return yield* new ProviderAdapterValidationError({
+                  provider: PROVIDER,
+                  operation: "forkThread",
+                  issue: "The source Cursor session has no resumable native cursor.",
+                });
+              }
+              const providerCursorOptions = input.providerOptions?.cursor;
+              const runtime = yield* makeCursorAcpRuntime({
+                cursorSettings: {
+                  ...(cursorSettings.binaryPath !== undefined
+                    ? { binaryPath: cursorSettings.binaryPath }
+                    : {}),
+                  ...(cursorSettings.apiEndpoint !== undefined
+                    ? { apiEndpoint: cursorSettings.apiEndpoint }
+                    : {}),
+                  ...(providerCursorOptions?.binaryPath !== undefined
+                    ? { binaryPath: providerCursorOptions.binaryPath }
+                    : {}),
+                  ...(providerCursorOptions?.apiEndpoint !== undefined
+                    ? { apiEndpoint: providerCursorOptions.apiEndpoint }
+                    : {}),
+                },
+                childProcessSpawner,
+                cwd: sourceCwd,
+                resumeSessionId: sourceSessionId,
+                clientInfo: { name: "Synara Fork", version: "0.0.0" },
+                startupTimeouts: CURSOR_ACP_STARTUP_TIMEOUTS,
+              });
+              yield* runtime.start().pipe(
+                Effect.timeoutOption(CURSOR_ACP_FORK_TIMEOUT_MS),
+                Effect.flatMap(
+                  Option.match({
+                    onNone: () => Effect.fail(cursorForkTimeoutError("session/resume")),
+                    onSome: Effect.succeed,
+                  }),
+                ),
+              );
+              return yield* forkRuntime(runtime);
+            }).pipe(Effect.scoped);
+
+        // Return only the cursor: ProviderService registers the binding under
+        // a committed lifecycle lease and the target's first turn resumes it
+        // there. Starting the runtime here would capture an undefined
+        // lifecycle generation, orphaning the fork's approval requests.
+        return {
+          threadId: input.threadId,
+          resumeCursor: {
+            schemaVersion: CURSOR_RESUME_VERSION,
+            sessionId: forked.sessionId,
+          },
+        };
+      }).pipe(
+        Effect.mapError((cause) =>
+          cause instanceof ProviderAdapterRequestError ||
+          cause instanceof ProviderAdapterProcessError ||
+          cause instanceof ProviderAdapterSessionClosedError ||
+          cause instanceof ProviderAdapterSessionNotFoundError ||
+          cause instanceof ProviderAdapterValidationError
+            ? cause
+            : mapAcpToAdapterError(PROVIDER, input.sourceThreadId, "session/fork", cause),
+        ),
+      );
+
     const stopAll: CursorAdapterShape["stopAll"] = () =>
       Effect.forEach(sessions.values(), stopSessionInternal, { discard: true });
 
@@ -1714,6 +1828,7 @@ export function makeCursorAdapter(
       interruptTurn,
       readThread,
       rollbackThread,
+      forkThread,
       respondToRequest,
       respondToUserInput,
       stopSession,

--- a/apps/server/src/provider/Layers/DroidAdapter.ts
+++ b/apps/server/src/provider/Layers/DroidAdapter.ts
@@ -87,6 +87,7 @@ import {
   settleAcpPendingUserInputsAsEmptyAnswers,
   withAcpPlanModePrompt,
 } from "../acp/AcpAdapterSessionSupport.ts";
+import { forkViaAcpRuntime } from "../acp/acpFork.ts";
 import { type AcpSessionRuntimeShape } from "../acp/AcpSessionRuntime.ts";
 import {
   makeAcpAssistantItemEvent,
@@ -1945,27 +1946,27 @@ export function makeDroidAdapter(
         }
 
         const forkRuntime = (runtime: AcpSessionRuntimeShape) =>
-          Effect.gen(function* () {
-            if (!(yield* runtime.supportsSessionFork)) {
-              return yield* new ProviderAdapterValidationError({
-                provider: PROVIDER,
-                operation: "forkThread",
-                issue:
-                  "This Droid ACP version does not advertise session/fork; Synara will rebuild the fork from its retained transcript.",
-              });
-            }
-            return yield* runtime.forkSession({ cwd: targetCwd, mcpServers: [] });
-          }).pipe(
-            Effect.timeoutOption(DROID_ACP_REQUEST_TIMEOUT_MS),
-            Effect.flatMap(
-              Option.match({
-                onNone: () => Effect.fail(droidAcpTimeoutError("session/fork")),
-                onSome: Effect.succeed,
-              }),
-            ),
-          );
+          forkViaAcpRuntime({
+            provider: PROVIDER,
+            runtime,
+            targetCwd,
+            unsupportedIssue:
+              "This Droid ACP version does not advertise session/fork; Synara will rebuild the fork from its retained transcript.",
+            requestTimeoutMs: DROID_ACP_REQUEST_TIMEOUT_MS,
+            timeoutError: droidAcpTimeoutError,
+          });
 
         const activeSource = sessions.get(input.sourceThreadId);
+        // Forking mid-turn would branch from incomplete in-flight state, so
+        // let the retained-transcript fallback handle busy sources.
+        if (activeSource?.activeTurnId !== undefined) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "forkThread",
+            issue:
+              "The source Droid session has a turn in flight; Synara will rebuild the fork from its retained transcript.",
+          });
+        }
         const forked = activeSource
           ? yield* forkRuntime(activeSource.acp)
           : yield* Effect.gen(function* () {
@@ -2001,20 +2002,17 @@ export function makeDroidAdapter(
               return yield* forkRuntime(runtime);
             }).pipe(Effect.scoped);
 
-        const resumeCursor = {
-          schemaVersion: DROID_RESUME_VERSION,
-          sessionId: forked.sessionId,
-        };
-        yield* startSession({
+        // Return only the cursor: ProviderService registers the binding under
+        // a committed lifecycle lease and the target's first turn resumes it
+        // there. Starting the runtime here would capture an undefined
+        // lifecycle generation, orphaning the fork's approval requests.
+        return {
           threadId: input.threadId,
-          provider: PROVIDER,
-          cwd: targetCwd,
-          runtimeMode: input.runtimeMode,
-          resumeCursor,
-          ...(input.modelSelection ? { modelSelection: input.modelSelection } : {}),
-          ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
-        });
-        return { threadId: input.threadId, resumeCursor };
+          resumeCursor: {
+            schemaVersion: DROID_RESUME_VERSION,
+            sessionId: forked.sessionId,
+          },
+        };
       }).pipe(
         Effect.mapError((cause) =>
           cause instanceof ProviderAdapterRequestError ||

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -61,7 +61,9 @@ import { buildProviderChildEnvironment } from "../../providerChildEnvironment.ts
 import { appendFileAttachmentsPromptBlock } from "../attachmentProjection.ts";
 import { loadProviderPromptImageBlocks } from "../promptAttachments.ts";
 import {
+  ProviderAdapterProcessError,
   ProviderAdapterRequestError,
+  ProviderAdapterSessionClosedError,
   ProviderAdapterSessionNotFoundError,
   ProviderAdapterValidationError,
 } from "../Errors.ts";
@@ -86,6 +88,7 @@ import {
   settleAcpPendingUserInputsAsEmptyAnswers,
   withAcpPlanModePrompt,
 } from "../acp/AcpAdapterSessionSupport.ts";
+import { forkViaAcpRuntime } from "../acp/acpFork.ts";
 import { type AcpSessionRuntimeShape } from "../acp/AcpSessionRuntime.ts";
 import {
   makeAcpAssistantItemEvent,
@@ -136,6 +139,9 @@ export const takeGrokSynaraHarnessPolicyTextPart = (
   });
 const GROK_RESUME_VERSION = 1 as const;
 const GROK_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
+// Forking a dead source session must first resume it, which replays history,
+// so the fork exchange shares the resume-replay budget.
+const GROK_ACP_FORK_TIMEOUT_MS = 30_000;
 const GROK_ACP_TRANSPORT_DEBUG_MARKER = "grok-acp-meta-stripper-v2";
 const GROK_ACP_LOG_PAYLOAD_LIMIT = 4_000;
 const GROK_ACP_DEBUG_ENV = "SYNARA_GROK_ACP_DEBUG";
@@ -2501,6 +2507,110 @@ export function makeGrokAdapter(
       );
     };
 
+    const grokForkTimeoutError = (method: string): ProviderAdapterRequestError =>
+      new ProviderAdapterRequestError({
+        provider: PROVIDER,
+        method,
+        detail: `Grok ACP did not respond to ${method} within ${GROK_ACP_FORK_TIMEOUT_MS / 1000}s.`,
+      });
+
+    const forkThread: NonNullable<GrokAdapterShape["forkThread"]> = (input) =>
+      Effect.gen(function* () {
+        const sourceCwd = resolveGrokSessionCwd(input.sourceCwd ?? input.cwd, serverConfig);
+        const targetCwd = resolveGrokSessionCwd(input.cwd ?? input.sourceCwd, serverConfig);
+        if (!sourceCwd || !targetCwd) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "forkThread",
+            issue: "A source and target cwd are required to fork a Grok session.",
+          });
+        }
+
+        const forkRuntime = (runtime: AcpSessionRuntimeShape) =>
+          forkViaAcpRuntime({
+            provider: PROVIDER,
+            runtime,
+            targetCwd,
+            unsupportedIssue:
+              "This Grok ACP version does not advertise session/fork; Synara will rebuild the fork from its retained transcript.",
+            requestTimeoutMs: GROK_ACP_FORK_TIMEOUT_MS,
+            timeoutError: grokForkTimeoutError,
+          });
+
+        const activeSource = sessions.get(input.sourceThreadId);
+        // Forking mid-turn would branch from incomplete in-flight state, so
+        // let the retained-transcript fallback handle busy sources.
+        if (activeSource?.activeTurnId !== undefined) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "forkThread",
+            issue:
+              "The source Grok session has a turn in flight; Synara will rebuild the fork from its retained transcript.",
+          });
+        }
+        const forked = activeSource
+          ? yield* forkRuntime(activeSource.acp)
+          : yield* Effect.gen(function* () {
+              const sourceSessionId = parseGrokResume(input.sourceResumeCursor)?.sessionId;
+              if (!sourceSessionId) {
+                return yield* new ProviderAdapterValidationError({
+                  provider: PROVIDER,
+                  operation: "forkThread",
+                  issue: "The source Grok session has no resumable native cursor.",
+                });
+              }
+              const providerGrokOptions = input.providerOptions?.grok;
+              const runtime = yield* makeGrokAcpRuntime({
+                grokSettings: {
+                  ...(grokSettings.binaryPath !== undefined
+                    ? { binaryPath: grokSettings.binaryPath }
+                    : {}),
+                  ...(providerGrokOptions?.binaryPath !== undefined
+                    ? { binaryPath: providerGrokOptions.binaryPath }
+                    : {}),
+                },
+                childProcessSpawner,
+                cwd: sourceCwd,
+                runtimeMode: input.runtimeMode,
+                resumeSessionId: sourceSessionId,
+                clientInfo: { name: "Synara Fork", version: "0.0.0" },
+                sessionMeta: GROK_SESSION_META,
+              });
+              yield* runtime.start().pipe(
+                Effect.timeoutOption(GROK_ACP_FORK_TIMEOUT_MS),
+                Effect.flatMap(
+                  Option.match({
+                    onNone: () => Effect.fail(grokForkTimeoutError("session/resume")),
+                    onSome: Effect.succeed,
+                  }),
+                ),
+              );
+              return yield* forkRuntime(runtime);
+            }).pipe(Effect.scoped);
+
+        // Return only the cursor: ProviderService registers the binding under
+        // a committed lifecycle lease and the target's first turn resumes it
+        // there. Starting the runtime here would capture an undefined
+        // lifecycle generation, orphaning the fork's approval requests.
+        return {
+          threadId: input.threadId,
+          resumeCursor: {
+            schemaVersion: GROK_RESUME_VERSION,
+            sessionId: forked.sessionId,
+          },
+        };
+      }).pipe(
+        Effect.mapError((cause) =>
+          cause instanceof ProviderAdapterRequestError ||
+          cause instanceof ProviderAdapterProcessError ||
+          cause instanceof ProviderAdapterSessionClosedError ||
+          cause instanceof ProviderAdapterSessionNotFoundError ||
+          cause instanceof ProviderAdapterValidationError
+            ? cause
+            : mapAcpToAdapterError(PROVIDER, input.sourceThreadId, "session/fork", cause),
+        ),
+      );
+
     const stopAll: GrokAdapterShape["stopAll"] = () =>
       Effect.forEach(Array.from(sessions.values()), stopSessionInternal, { discard: true });
 
@@ -2523,6 +2633,7 @@ export function makeGrokAdapter(
       interruptTurn,
       readThread,
       rollbackThread,
+      forkThread,
       respondToRequest,
       respondToUserInput,
       stopSession,

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1910,9 +1910,10 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
     );
 
     expect(runtime.forkCalls).toEqual([{ sessionID: "source-session-1" }]);
-    expect(runtime.connectCalls).toHaveLength(2);
+    // Only the scoped fork client connects: the target session starts later
+    // under a ProviderService lifecycle lease, not inside forkThread.
+    expect(runtime.connectCalls).toHaveLength(1);
     expect(runtime.connectCalls[0]).toMatchObject({ cwd: "/repo/source" });
-    expect(runtime.connectCalls[1]).toMatchObject({ cwd: "/repo/source" });
     expect(result.resumeCursor).toMatchObject({
       openCodeSessionId: "forked-session-1",
       cwd: "/repo/source",

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -4365,6 +4365,15 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
       const forkThread: NonNullable<OpenCodeAdapterShape["forkThread"]> = (input) =>
         Effect.gen(function* () {
           const sourceContext = sessions.get(input.sourceThreadId);
+          // Forking mid-turn would branch from incomplete in-flight state, so
+          // let the retained-transcript fallback handle busy sources.
+          if (sourceContext?.activeTurnId !== undefined) {
+            return yield* new ProviderAdapterValidationError({
+              provider,
+              operation: "forkThread",
+              issue: `The source ${adapterConfig.displayName} session has a turn in flight; Synara will rebuild the fork from its retained transcript.`,
+            });
+          }
           const sourceSessionId =
             sourceContext?.openCodeSessionId ?? extractResumeSessionId(input.sourceResumeCursor);
           if (!sourceSessionId) {
@@ -4434,19 +4443,13 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
             });
           }
 
-          const session = yield* startSession({
-            threadId: input.threadId,
-            provider,
-            cwd: targetDirectory,
-            ...(input.modelSelection ? { modelSelection: input.modelSelection } : {}),
-            ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
-            resumeCursor: { openCodeSessionId: forkedSessionId, cwd: targetDirectory },
-            runtimeMode: input.runtimeMode,
-          });
-
+          // Return only the cursor: ProviderService registers the binding under
+          // a committed lifecycle lease and the target's first turn resumes it
+          // there. Starting the runtime here would capture an undefined
+          // lifecycle generation, orphaning the fork's approval requests.
           return {
             threadId: input.threadId,
-            ...(session.resumeCursor !== undefined ? { resumeCursor: session.resumeCursor } : {}),
+            resumeCursor: { openCodeSessionId: forkedSessionId, cwd: targetDirectory },
           };
         });
 

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 
 import type {
   ProviderApprovalDecision,
+  ProviderForkThreadInput,
   ProviderRuntimeEvent,
   ProviderSendTurnInput,
   ProviderSession,
@@ -251,6 +252,19 @@ function makeFakeCodexAdapter(
     (_threadId: ThreadId): Effect.Effect<void, ProviderAdapterError> => Effect.void,
   );
 
+  const forkThread = vi.fn(
+    (
+      input: ProviderForkThreadInput,
+    ): Effect.Effect<
+      { readonly threadId: ThreadId; readonly resumeCursor: { readonly opaque: string } },
+      ProviderAdapterError
+    > =>
+      Effect.succeed({
+        threadId: input.threadId,
+        resumeCursor: { opaque: `fork-${String(input.threadId)}` },
+      }),
+  );
+
   const stopAll = vi.fn(
     (): Effect.Effect<void, ProviderAdapterError> =>
       Effect.sync(() => {
@@ -280,6 +294,7 @@ function makeFakeCodexAdapter(
     readThread,
     rollbackThread,
     compactThread,
+    forkThread,
     stopAll,
     streamEvents: Stream.fromPubSub(runtimeEventPubSub),
   };
@@ -325,6 +340,7 @@ function makeFakeCodexAdapter(
     readThread,
     rollbackThread,
     compactThread,
+    forkThread,
     stopAll,
   };
 }
@@ -702,6 +718,55 @@ it.effect(
 );
 
 routing.layer("ProviderServiceLive routing", (it) => {
+  it.effect("reuses a deferred native fork binding and preserves its inherited cwd", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const sourceThreadId = asThreadId("thread-native-fork-source");
+      const targetThreadId = asThreadId("thread-native-fork-target");
+
+      yield* provider.startSession(sourceThreadId, {
+        provider: "codex",
+        threadId: sourceThreadId,
+        cwd: "/tmp/native-fork-source",
+        runtimeMode: "full-access",
+      });
+      const forkCallCount = routing.codex.forkThread.mock.calls.length;
+      const forkInput = {
+        sourceThreadId,
+        threadId: targetThreadId,
+        runtimeMode: "full-access" as const,
+      };
+
+      const first = yield* provider.forkThread!(forkInput);
+      yield* provider.stopSession({ threadId: sourceThreadId });
+      yield* directory.remove(sourceThreadId);
+      const second = yield* provider.forkThread!(forkInput);
+      const startsBeforeRecovery = routing.codex.startSession.mock.calls.length;
+      yield* provider.sendTurn({
+        threadId: targetThreadId,
+        input: "continue the fork",
+        attachments: [],
+      });
+
+      assert.deepEqual(second, first);
+      assert.equal(routing.codex.forkThread.mock.calls.length - forkCallCount, 1);
+      assert.equal(routing.codex.startSession.mock.calls.length, startsBeforeRecovery + 1);
+      const recoveredStart = routing.codex.startSession.mock.calls.at(-1)?.[0];
+      assert.equal(recoveredStart?.threadId, targetThreadId);
+      assert.equal(recoveredStart?.cwd, "/tmp/native-fork-source");
+      assert.deepEqual(recoveredStart?.resumeCursor, first?.resumeCursor);
+      const targetBinding = Option.getOrUndefined(yield* directory.getBinding(targetThreadId));
+      assert.equal(targetBinding?.status, "running");
+      assert.equal(
+        asRuntimePayloadRecord(targetBinding?.runtimePayload).cwd,
+        "/tmp/native-fork-source",
+      );
+
+      yield* provider.stopSession({ threadId: targetThreadId });
+    }),
+  );
+
   it.effect("fork source overrides explicit and persisted resume cursors", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService;

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -1716,6 +1716,23 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           payload: rawInput,
         });
 
+        const existingTargetBinding = Option.getOrUndefined(
+          yield* directory.getBinding(input.threadId),
+        );
+        if (existingTargetBinding) {
+          const existingTargetPayload = runtimePayloadRecord(existingTargetBinding.runtimePayload);
+          if (
+            existingTargetPayload.lastRuntimeEvent === "provider.thread.forked" &&
+            hasResumeCursor(existingTargetBinding.resumeCursor)
+          ) {
+            return {
+              threadId: input.threadId,
+              resumeCursor: existingTargetBinding.resumeCursor,
+            };
+          }
+          return null;
+        }
+
         const sourceBinding = Option.getOrUndefined(
           yield* directory.getBinding(input.sourceThreadId),
         );
@@ -1723,13 +1740,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           return null;
         }
 
-        if (Option.isSome(yield* directory.getBinding(input.threadId))) {
-          return null;
-        }
-
         const effectiveProviderOptions =
           input.providerOptions ?? readPersistedProviderOptions(sourceBinding.runtimePayload);
         const sourceCwd = readPersistedCwd(sourceBinding.runtimePayload);
+        const targetCwd = input.cwd ?? sourceCwd;
         yield* validateAutoRuntimeMode(
           "ProviderService.forkThread",
           sourceBinding.provider,
@@ -1807,7 +1821,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                 lifecycleGeneration: lease.generation,
                 ...(forked.resumeCursor !== undefined ? { resumeCursor: forked.resumeCursor } : {}),
                 runtimePayload: {
-                  cwd: input.cwd ?? null,
+                  cwd: targetCwd ?? null,
                   model: input.modelSelection?.model ?? null,
                   activeTurnId: null,
                   lastError: null,

--- a/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
+++ b/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
@@ -17,6 +17,8 @@ import {
   type AcpProtocolLogEvent,
   type AcpSessionRequestLogEvent,
 } from "./AcpSessionRuntime.ts";
+import { forkViaAcpRuntime } from "./acpFork.ts";
+import { ProviderAdapterRequestError, ProviderAdapterValidationError } from "../Errors.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const mockAgentPath = path.join(__dirname, "../../../scripts/acp-mock-agent.ts");
@@ -336,6 +338,57 @@ describe("AcpSessionRuntime", () => {
           },
           cwd: process.cwd(),
           clientCapabilities: { _meta: { parameterizedModelPicker: true } },
+          clientInfo: { name: "synara-test", version: "0.0.0" },
+          authMethodId: "test",
+          requestLogger: (event) =>
+            Effect.sync(() => {
+              requestEvents.push(event);
+            }),
+        }),
+      ),
+      Effect.scoped,
+      Effect.provide(NodeServices.layer),
+    );
+  });
+
+  it.effect("rejects fork cursors when the ACP agent cannot reopen sessions", () => {
+    const requestEvents: Array<AcpSessionRequestLogEvent> = [];
+    return Effect.gen(function* () {
+      const runtime = yield* AcpSessionRuntime;
+      yield* runtime.start();
+      expect(yield* runtime.supportsSessionFork).toBe(true);
+      expect(yield* runtime.supportsSessionRecovery).toBe(false);
+
+      const error = yield* forkViaAcpRuntime({
+        provider: "test",
+        runtime,
+        targetCwd: process.cwd(),
+        unsupportedIssue: "fork unsupported",
+        requestTimeoutMs: 1_000,
+        timeoutError: (method) =>
+          new ProviderAdapterRequestError({
+            provider: "test",
+            method,
+            detail: "timed out",
+          }),
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(ProviderAdapterValidationError);
+      expect(error.message).toContain("cannot reopen the forked session");
+      expect(requestEvents.some((event) => event.method === "session/fork")).toBe(false);
+    }).pipe(
+      Effect.provide(
+        AcpSessionRuntime.layer({
+          spawn: {
+            command: bunExe,
+            args: [mockAgentPath],
+            env: {
+              VITEST: "true",
+              SYNARA_ACP_SUPPORT_SESSION_FORK: "1",
+              SYNARA_ACP_SUPPORT_SESSION_LOAD: "0",
+            },
+          },
+          cwd: process.cwd(),
           clientInfo: { name: "synara-test", version: "0.0.0" },
           authMethodId: "test",
           requestLogger: (event) =>

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -310,6 +310,8 @@ export interface AcpSessionRuntimeShape {
   // stream chunk buffering and in-flight handlers, unlike a queue-size probe.
   readonly sessionUpdatesEnqueuedCount: Effect.Effect<number>;
   readonly supportsSessionFork: Effect.Effect<boolean, AcpErrors.AcpError>;
+  /** Whether a persisted session id can be reopened through resume or load. */
+  readonly supportsSessionRecovery: Effect.Effect<boolean, AcpErrors.AcpError>;
   readonly getModeState: Effect.Effect<AcpSessionModeState | undefined>;
   readonly getConfigOptions: Effect.Effect<ReadonlyArray<Acp.SessionConfigOption>>;
   readonly getAvailableCommands: Effect.Effect<ReadonlyArray<Acp.AvailableCommand>>;
@@ -1326,6 +1328,14 @@ const makeAcpSessionRuntime = (
           (started) =>
             started.initializeResult.agentCapabilities?.sessionCapabilities?.fork != null,
         ),
+      ),
+      supportsSessionRecovery: getStartedState.pipe(
+        Effect.map((started) => {
+          const capabilities = started.initializeResult.agentCapabilities;
+          return (
+            capabilities?.sessionCapabilities?.resume != null || capabilities?.loadSession === true
+          );
+        }),
       ),
       setModel: (model) =>
         getStartedState.pipe(

--- a/apps/server/src/provider/acp/acpFork.ts
+++ b/apps/server/src/provider/acp/acpFork.ts
@@ -1,0 +1,48 @@
+// FILE: acpFork.ts
+// Purpose: Shared "probe capability + session/fork" step for ACP-backed provider adapters.
+// Layer: Provider ACP helper
+// Exports: forkViaAcpRuntime
+
+import type * as Acp from "@agentclientprotocol/sdk";
+import { Effect, Option } from "effect";
+import type * as AcpErrors from "./AcpErrors.ts";
+import type { AcpSessionRuntimeShape } from "./AcpSessionRuntime.ts";
+import { ProviderAdapterRequestError, ProviderAdapterValidationError } from "../Errors.ts";
+
+/**
+ * Fork the runtime's active session when the agent advertises `session/fork`.
+ *
+ * Fails with a `ProviderAdapterValidationError` when the capability is missing
+ * so callers fall back to Synara's retained-transcript fork, and bounds the
+ * whole probe+fork exchange with the adapter's request timeout.
+ */
+export function forkViaAcpRuntime(input: {
+  readonly provider: string;
+  readonly runtime: AcpSessionRuntimeShape;
+  readonly targetCwd: string;
+  readonly unsupportedIssue: string;
+  readonly requestTimeoutMs: number;
+  readonly timeoutError: (method: string) => ProviderAdapterRequestError;
+}): Effect.Effect<
+  Acp.ForkSessionResponse,
+  AcpErrors.AcpError | ProviderAdapterRequestError | ProviderAdapterValidationError
+> {
+  return Effect.gen(function* () {
+    if (!(yield* input.runtime.supportsSessionFork)) {
+      return yield* new ProviderAdapterValidationError({
+        provider: input.provider,
+        operation: "forkThread",
+        issue: input.unsupportedIssue,
+      });
+    }
+    return yield* input.runtime.forkSession({ cwd: input.targetCwd, mcpServers: [] });
+  }).pipe(
+    Effect.timeoutOption(input.requestTimeoutMs),
+    Effect.flatMap(
+      Option.match({
+        onNone: () => Effect.fail(input.timeoutError("session/fork")),
+        onSome: Effect.succeed,
+      }),
+    ),
+  );
+}

--- a/apps/server/src/provider/acp/acpFork.ts
+++ b/apps/server/src/provider/acp/acpFork.ts
@@ -35,6 +35,13 @@ export function forkViaAcpRuntime(input: {
         issue: input.unsupportedIssue,
       });
     }
+    if (!(yield* input.runtime.supportsSessionRecovery)) {
+      return yield* new ProviderAdapterValidationError({
+        provider: input.provider,
+        operation: "forkThread",
+        issue: `This ${input.provider} ACP version advertises session/fork but cannot reopen the forked session; Synara will rebuild the fork from its retained transcript.`,
+      });
+    }
     return yield* input.runtime.forkSession({ cwd: input.targetCwd, mcpServers: [] });
   }).pipe(
     Effect.timeoutOption(input.requestTimeoutMs),


### PR DESCRIPTION
## What Changed

- Adds native session forking for Claude, Cursor, Droid, Grok, and OpenCode.
- Centralizes ACP fork behavior, including capability checks, timeout handling, error mapping, and scoped runtime cleanup.
- Prevents native forks while a source turn is in flight and falls back to retained transcript reconstruction when needed.
- Preserves persisted turn counts and clears invalid source-specific cursor state in forked sessions.
- Expands bootstrap transcript budgets and consolidates provider input composition.
- Adds Claude fork coverage and updates OpenCode lifecycle expectations.

## Why

Native session forks were inconsistently implemented across providers and could start target runtimes before their lifecycle lease was committed. This change makes forking more reliable, avoids branching from incomplete turns, preserves resumability metadata, and gives each provider consistent ACP behavior.

## Verification

- Added focused Claude adapter tests covering native forking, in-flight validation, turn-count preservation, missing cursors, and fork failures.
- Updated OpenCode adapter lifecycle assertions.
- Full test and workspace checks were not run.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core provider session lifecycle, resume cursors, and fork paths across many adapters; incorrect binding or cursor handling could break thread recovery or approvals, though validation and tests mitigate this.
> 
> **Overview**
> **Native session forking** is wired through Claude (SDK `forkSession`), Cursor/Droid/Grok (ACP), and OpenCode, with new **`forkViaAcpRuntime`** handling capability probes, recovery checks, timeouts, and validation errors that trigger retained-transcript fallback.
> 
> **Fork lifecycle:** Adapters now return only a **resume cursor** instead of calling `startSession` on the target, so ProviderService owns the lifecycle lease and the first turn resumes the fork. **In-flight source turns** are rejected for native fork. Claude forks clear invalid `resumeSessionAt`/task pins and keep the larger persisted **turn count**.
> 
> **ProviderService** reuses an existing deferred `provider.thread.forked` binding (idempotent fork), persists **target cwd** from source when omitted, and gains integration coverage for native fork recovery.
> 
> **Orchestration:** Bootstrap transcript defaults move to a fixed **32k** budget (replacing a fraction of max input chars). **Provider input** composition is refactored via `composeProviderInput` / `finalizeProviderInput`, including stale Claude retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ea244186def8e7eb5bf4f6bc03c4e9b63325191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->