### PR TITLE
feat(server): add OpenCode usage tracking from local CLI archive

### DIFF
--- a/apps/server/src/providerUsage/providers/opencode.test.ts
+++ b/apps/server/src/providerUsage/providers/opencode.test.ts
@@ -1,0 +1,268 @@
+// FILE: providerUsage/providers/opencode.test.ts
+// Purpose: Covers the OpenCode native usage fetcher — the pure row normalization + window
+// aggregation, and the fetcher against a real (temp) opencode.db so the SQL and DB-path
+// resolution are exercised end to end. A missing DB must read as healthy-but-empty, while an
+// unreadable DB must surface as an error rather than silently blank usage.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import nodePath from "node:path";
+
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildOpenCodeUsageLines,
+  normalizeOpenCodeMessageRows,
+  opencodeUsageFetcher,
+  type OpenCodeMessageUsageRow,
+} from "./opencode";
+
+const NOW_MS = 1_780_000_000_000;
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(nodePath.join(os.tmpdir(), "synara-opencode-usage-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeCtx(homeDir: string, env: NodeJS.ProcessEnv = {}) {
+  return {
+    homeDir,
+    env,
+    platform: "darwin" as const,
+    nowMs: NOW_MS,
+  };
+}
+
+function row(input: {
+  sessionId?: string;
+  timestampMs: number;
+  tokens?: number;
+  cost?: number;
+}): OpenCodeMessageUsageRow {
+  return {
+    sessionId: input.sessionId ?? "ses_default",
+    timestampMs: input.timestampMs,
+    tokens: input.tokens ?? 1_000,
+    cost: input.cost ?? 0,
+  };
+}
+
+/** Create an OpenCode Go `message` table and insert rows with the same JSON shape the CLI writes. */
+function writeOpenCodeDb(input: {
+  homeDir: string;
+  rows: ReadonlyArray<{
+    id?: string;
+    sessionId: string;
+    role?: string;
+    tokens?: number;
+    cost?: number;
+    createdAtMs: number;
+  }>;
+}): string {
+  const dbPath = nodePath.join(input.homeDir, ".local", "share", "opencode", "opencode.db");
+  mkdirSync(nodePath.dirname(dbPath), { recursive: true });
+  const database = new DatabaseSync(dbPath);
+  try {
+    database.exec(`
+      CREATE TABLE message (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        time_updated INTEGER NOT NULL,
+        data TEXT NOT NULL
+      );
+      CREATE INDEX message_session_time_created_id_idx
+        ON message (session_id, time_created, id);
+    `);
+    const insert = database.prepare(
+      "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+    );
+    input.rows.forEach((row, index) => {
+      const id = row.id ?? `msg_${index}_${row.createdAtMs}_${row.sessionId}`;
+      const data = JSON.stringify({
+        role: row.role ?? "assistant",
+        tokens: { total: row.tokens ?? 1_000 },
+        cost: row.cost ?? 0,
+        time: { created: row.createdAtMs },
+      });
+      insert.run(id, row.sessionId, row.createdAtMs, row.createdAtMs, data);
+    });
+  } finally {
+    database.close();
+  }
+  return dbPath;
+}
+
+describe("normalizeOpenCodeMessageRows", () => {
+  it("drops rows without a usable timestamp or token total", () => {
+    const rows = normalizeOpenCodeMessageRows([
+      { time_created: NOW_MS, tokens: 500, cost: 0.1, session_id: "ses_a" },
+      { time_created: NOW_MS, tokens: undefined, cost: 0.1, session_id: "ses_a" },
+      { time_created: "not-a-number", tokens: 500, cost: 0.1, session_id: "ses_a" },
+      { time_created: -1, tokens: 500, cost: 0.1, session_id: "ses_a" },
+    ]);
+    expect(rows).toEqual([{ sessionId: "ses_a", timestampMs: NOW_MS, tokens: 500, cost: 0.1 }]);
+  });
+
+  it("coerces non-string session ids", () => {
+    const rows = normalizeOpenCodeMessageRows([
+      { time_created: NOW_MS, tokens: 100, cost: 0, session_id: 123 },
+    ]);
+    expect(rows[0]?.sessionId).toBe("123");
+  });
+});
+
+describe("buildOpenCodeUsageLines", () => {
+  it("returns no lines for an empty row set", () => {
+    expect(buildOpenCodeUsageLines({ rows: [], nowMs: NOW_MS })).toEqual([]);
+  });
+
+  it("buckets tokens and sessions into 24h/7d/30d windows", () => {
+    const lines = buildOpenCodeUsageLines({
+      nowMs: NOW_MS,
+      rows: [
+        row({ sessionId: "ses_a", timestampMs: NOW_MS - 1 * HOUR_MS, tokens: 1_000 }),
+        row({ sessionId: "ses_b", timestampMs: NOW_MS - 2 * DAY_MS, tokens: 2_000 }),
+        row({ sessionId: "ses_a", timestampMs: NOW_MS - 20 * DAY_MS, tokens: 4_000 }),
+      ],
+    });
+
+    const byLabel = new Map(lines.map((line) => [line.label, line]));
+    expect(byLabel.get("24h")?.value).toBe("1K tokens");
+    expect(byLabel.get("24h")?.subtitle).toBe("1 recent session");
+    expect(byLabel.get("7d")?.value).toBe("3K tokens");
+    expect(byLabel.get("7d")?.subtitle).toBe("2 recent sessions");
+    expect(byLabel.get("30d")?.value).toBe("7K tokens");
+    expect(byLabel.get("30d")?.subtitle).toBe("2 recent sessions");
+  });
+
+  it("appends a Spend line only when 30d cost is positive", () => {
+    const withCost = buildOpenCodeUsageLines({
+      nowMs: NOW_MS,
+      rows: [row({ timestampMs: NOW_MS, tokens: 100, cost: 1.5 })],
+    });
+    expect(withCost.at(-1)).toEqual({
+      label: "Spend",
+      value: "$1.50",
+      subtitle: "last 30d",
+    });
+
+    const withoutCost = buildOpenCodeUsageLines({
+      nowMs: NOW_MS,
+      rows: [row({ timestampMs: NOW_MS, tokens: 100, cost: 0 })],
+    });
+    expect(withoutCost.some((line) => line.label === "Spend")).toBe(false);
+  });
+});
+
+describe("opencodeUsageFetcher", () => {
+  it("reports a healthy empty snapshot when no database exists", async () => {
+    const snapshot = await opencodeUsageFetcher.fetch(makeCtx(makeTempDir()));
+    expect(snapshot.status).toBe("ok");
+    expect(snapshot.source).toBe("opencode-native-db");
+    expect(snapshot.usageLines).toEqual([]);
+  });
+
+  it("aggregates a real opencode.db into usage lines", async () => {
+    const homeDir = makeTempDir();
+    writeOpenCodeDb({
+      homeDir,
+      rows: [
+        { sessionId: "ses_a", createdAtMs: NOW_MS - HOUR_MS, tokens: 1_000, cost: 0.5 },
+        { sessionId: "ses_a", createdAtMs: NOW_MS - HOUR_MS, tokens: 500, cost: 0.25 },
+        { sessionId: "ses_b", createdAtMs: NOW_MS - 2 * DAY_MS, tokens: 2_000, cost: 0.1 },
+      ],
+    });
+
+    const snapshot = await opencodeUsageFetcher.fetch(makeCtx(homeDir));
+    expect(snapshot.status).toBe("ok");
+    const byLabel = new Map(snapshot.usageLines.map((line) => [line.label, line]));
+    expect(byLabel.get("24h")?.value).toBe("1.5K tokens");
+    expect(byLabel.get("24h")?.subtitle).toBe("1 recent session");
+    expect(byLabel.get("7d")?.value).toBe("3.5K tokens");
+    expect(byLabel.get("30d")?.value).toBe("3.5K tokens");
+    expect(byLabel.get("Spend")?.value).toBe("$0.85");
+  });
+
+  it("ignores user messages and rows without token usage", async () => {
+    const homeDir = makeTempDir();
+    writeOpenCodeDb({
+      homeDir,
+      rows: [
+        { sessionId: "ses_a", role: "user", createdAtMs: NOW_MS, tokens: 999_999 },
+        { sessionId: "ses_b", createdAtMs: NOW_MS, tokens: 1_000, cost: 0.01 },
+      ],
+    });
+
+    const snapshot = await opencodeUsageFetcher.fetch(makeCtx(homeDir));
+    expect(snapshot.status).toBe("ok");
+    expect(snapshot.usageLines[0]?.value).toBe("1K tokens");
+  });
+
+  it("honors XDG_DATA_HOME for the database path", async () => {
+    const xdgRoot = makeTempDir();
+    const dbPath = nodePath.join(xdgRoot, "opencode", "opencode.db");
+    mkdirSync(nodePath.dirname(dbPath), { recursive: true });
+    const database = new DatabaseSync(dbPath);
+    database.exec(
+      "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL);",
+    );
+    database
+      .prepare(
+        "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+      )
+      .run(
+        "msg_1",
+        "ses_a",
+        NOW_MS,
+        NOW_MS,
+        JSON.stringify({
+          role: "assistant",
+          tokens: { total: 42 },
+          cost: 0,
+          time: { created: NOW_MS },
+        }),
+      );
+    database.close();
+
+    const snapshot = await opencodeUsageFetcher.fetch(
+      makeCtx(makeTempDir(), { XDG_DATA_HOME: xdgRoot }),
+    );
+    expect(snapshot.status).toBe("ok");
+    expect(snapshot.usageLines[0]?.value).toBe("42 tokens");
+  });
+
+  it("returns an error snapshot when the database cannot be read", async () => {
+    const homeDir = makeTempDir();
+    // A directory where the DB file should be: exists, but is not a readable SQLite DB.
+    mkdirSync(nodePath.join(homeDir, ".local", "share", "opencode"), { recursive: true });
+    writeFileSync(
+      nodePath.join(homeDir, ".local", "share", "opencode", "opencode.db"),
+      "not sqlite",
+    );
+
+    const snapshot = await opencodeUsageFetcher.fetch(makeCtx(homeDir));
+    expect(snapshot.status).toBe("error");
+    expect(snapshot.detail).toMatch(/local usage database/);
+  });
+
+  it("derives a cache key from the resolved database path", async () => {
+    const homeDir = makeTempDir();
+    expect(await opencodeUsageFetcher.cacheKey?.(makeCtx(homeDir))).toBe(`${homeDir}:none`);
+    writeOpenCodeDb({ homeDir, rows: [{ sessionId: "ses_a", createdAtMs: NOW_MS }] });
+    const key = await opencodeUsageFetcher.cacheKey?.(makeCtx(homeDir));
+    expect(key).toMatch(/opencode\.db$/);
+  });
+});

--- a/apps/server/src/providerUsage/providers/opencode.ts
+++ b/apps/server/src/providerUsage/providers/opencode.ts
@@ -1,0 +1,209 @@
+// FILE: providerUsage/providers/opencode.ts
+// Purpose: Native OpenCode usage fetcher. OpenCode (the Go CLI) keeps per-message token totals
+// and model costs in a local SQLite database (`opencode.db`), so unlike Codex/Claude/Cursor there
+// is no remote endpoint to call and nothing to authenticate against. We read the DB read-only and
+// roll per-message `tokens.total`/`cost` up into the shared 24h/7d/30d usage-line shape.
+//
+// Defensive by design: a missing DB just means "no local usage yet" (ok snapshot, no lines),
+// while an unreadable DB surfaces as an error snapshot so a corrupted file isn't mistaken for an
+// unused CLI. The snapshot cache in the orchestrator bounds how often we touch a potentially large
+// DB file.
+
+import type { Stats } from "node:fs";
+import fs from "node:fs/promises";
+import nodePath from "node:path";
+
+import type { ServerProviderUsageLine, ServerProviderUsageSnapshot } from "@synara/contracts";
+
+import { createLogger } from "../../logger";
+import { buildUsageLines } from "../../providerUsageSnapshot";
+import { asNonNegativeNumber, buildSnapshot, errorSnapshot, formatUsd } from "../parse";
+import { readSqliteRows } from "../sqlite";
+import type { ProviderUsageContext, ProviderUsageFetcher } from "../types";
+
+const log = createLogger("provider-usage:opencode");
+
+const SOURCE = "opencode-native-db";
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const LOOKBACK_7D_MS = 7 * ONE_DAY_MS;
+const LOOKBACK_30D_MS = 30 * ONE_DAY_MS;
+
+/** Per-message usage row lifted out of the OpenCode `message` table. */
+export interface OpenCodeMessageUsageRow {
+  readonly sessionId: string;
+  readonly timestampMs: number;
+  readonly tokens: number;
+  readonly cost: number;
+}
+
+function resolveOpenCodeDbPaths(ctx: ProviderUsageContext): string[] {
+  const paths: string[] = [];
+  const xdgDataHome = ctx.env.XDG_DATA_HOME?.trim();
+  if (xdgDataHome) {
+    paths.push(nodePath.join(xdgDataHome, "opencode", "opencode.db"));
+  }
+  if (ctx.platform === "win32") {
+    const appData = ctx.env.APPDATA?.trim() ?? ctx.env.LOCALAPPDATA?.trim();
+    if (appData) {
+      paths.push(nodePath.join(appData, "opencode", "opencode.db"));
+    }
+    return paths;
+  }
+  paths.push(nodePath.join(ctx.homeDir, ".local", "share", "opencode", "opencode.db"));
+  return paths;
+}
+
+async function safeStat(path: string): Promise<Stats | null> {
+  try {
+    return await fs.stat(path);
+  } catch {
+    return null;
+  }
+}
+
+async function findOpenCodeDbPath(ctx: ProviderUsageContext): Promise<string | null> {
+  for (const path of resolveOpenCodeDbPaths(ctx)) {
+    if ((await safeStat(path))?.isFile()) {
+      return path;
+    }
+  }
+  return null;
+}
+
+// Rows are read within the 30d window only; the 24h/7d buckets are derived in JS so the SQL
+// stays a single scan regardless of how many windows we report. `time_created` is epoch ms,
+// which is what the OpenCode Go CLI writes for the same field.
+const MESSAGE_USAGE_SQL = `
+  SELECT session_id, time_created,
+         json_extract(data, '$.tokens.total') AS tokens,
+         json_extract(data, '$.cost') AS cost
+  FROM message
+  WHERE json_extract(data, '$.role') = 'assistant'
+    AND json_extract(data, '$.tokens.total') > 0
+    AND time_created >= ?
+  ORDER BY time_created
+`;
+
+function coerceSessionId(value: unknown): string {
+  return typeof value === "string" ? value : String(value ?? "");
+}
+
+/** Map raw SQLite rows into the usage-row shape, dropping rows that carry no usable data. */
+export function normalizeOpenCodeMessageRows(
+  rows: ReadonlyArray<Record<string, unknown>>,
+): OpenCodeMessageUsageRow[] {
+  const normalized: OpenCodeMessageUsageRow[] = [];
+  for (const row of rows) {
+    const timestampMs = asNonNegativeNumber(row.time_created);
+    const tokens = asNonNegativeNumber(row.tokens);
+    if (timestampMs === undefined || tokens === undefined) {
+      continue;
+    }
+    const cost = asNonNegativeNumber(row.cost);
+    normalized.push({
+      sessionId: coerceSessionId(row.session_id),
+      timestampMs,
+      tokens,
+      cost: cost ?? 0,
+    });
+  }
+  return normalized;
+}
+
+/**
+ * Roll per-message usage into the shared 24h/7d/30d usage-line shape. Exported for tests:
+ * pure aggregation over an already-fetched row set.
+ */
+export function buildOpenCodeUsageLines(input: {
+  rows: ReadonlyArray<OpenCodeMessageUsageRow>;
+  nowMs: number;
+}): ReadonlyArray<ServerProviderUsageLine> {
+  const { rows, nowMs } = input;
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const cutoffs = {
+    "24h": nowMs - ONE_DAY_MS,
+    "7d": nowMs - LOOKBACK_7D_MS,
+    "30d": nowMs - LOOKBACK_30D_MS,
+  } as const;
+
+  const recent24h: OpenCodeMessageUsageRow[] = [];
+  const recent7d: OpenCodeMessageUsageRow[] = [];
+  const recent30d: OpenCodeMessageUsageRow[] = [];
+  for (const row of rows) {
+    if (row.timestampMs >= cutoffs["24h"]) {
+      recent24h.push(row);
+    }
+    if (row.timestampMs >= cutoffs["7d"]) {
+      recent7d.push(row);
+    }
+    if (row.timestampMs >= cutoffs["30d"]) {
+      recent30d.push(row);
+    }
+  }
+
+  const cost30d = recent30d.reduce((total, row) => total + row.cost, 0);
+  const lines = [
+    ...buildUsageLines({
+      tokens24h: recent24h.reduce((total, row) => total + row.tokens, 0),
+      tokens7d: recent7d.reduce((total, row) => total + row.tokens, 0),
+      tokens30d: recent30d.reduce((total, row) => total + row.tokens, 0),
+      sessions24h: new Set(recent24h.map((row) => row.sessionId)).size,
+      sessions7d: new Set(recent7d.map((row) => row.sessionId)).size,
+      sessions30d: new Set(recent30d.map((row) => row.sessionId)).size,
+    }),
+  ];
+  if (cost30d > 0) {
+    lines.push({ label: "Spend", value: formatUsd(cost30d), subtitle: "last 30d" });
+  }
+  return lines;
+}
+
+export const opencodeUsageFetcher: ProviderUsageFetcher = {
+  provider: "opencode",
+  async cacheKey(ctx) {
+    return `${ctx.homeDir}:${(await findOpenCodeDbPath(ctx)) ?? "none"}`;
+  },
+  async fetch(ctx): Promise<ServerProviderUsageSnapshot> {
+    const dbPath = await findOpenCodeDbPath(ctx);
+    if (!dbPath) {
+      // No database on disk yet: the CLI is either not installed or has never recorded a
+      // message. Report a healthy-but-empty snapshot rather than an auth/error state.
+      return buildSnapshot({
+        provider: "opencode",
+        nowMs: ctx.nowMs,
+        status: "ok",
+        source: SOURCE,
+      });
+    }
+
+    try {
+      const rows = normalizeOpenCodeMessageRows(
+        await readSqliteRows({
+          dbPath,
+          sql: MESSAGE_USAGE_SQL,
+          params: [ctx.nowMs - LOOKBACK_30D_MS],
+        }),
+      );
+      return buildSnapshot({
+        provider: "opencode",
+        nowMs: ctx.nowMs,
+        status: "ok",
+        source: SOURCE,
+        usageLines: buildOpenCodeUsageLines({ rows, nowMs: ctx.nowMs }),
+      });
+    } catch (cause) {
+      log.warn("could not read the OpenCode usage database", {
+        message: cause instanceof Error ? cause.message : String(cause),
+      });
+      return errorSnapshot(
+        "opencode",
+        ctx.nowMs,
+        SOURCE,
+        "Could not read OpenCode's local usage database.",
+      );
+    }
+  },
+};

--- a/apps/server/src/providerUsage/registry.ts
+++ b/apps/server/src/providerUsage/registry.ts
@@ -7,10 +7,12 @@ import type { ProviderKind } from "@synara/contracts";
 import { claudeUsageFetcher } from "./providers/claude";
 import { codexUsageFetcher } from "./providers/codex";
 import { cursorUsageFetcher } from "./providers/cursor";
+import { opencodeUsageFetcher } from "./providers/opencode";
 import type { ProviderUsageFetcher } from "./types";
 
 export const PROVIDER_USAGE_FETCHERS: Partial<Record<ProviderKind, ProviderUsageFetcher>> = {
   codex: codexUsageFetcher,
   claudeAgent: claudeUsageFetcher,
   cursor: cursorUsageFetcher,
+  opencode: opencodeUsageFetcher,
 };

--- a/apps/server/src/providerUsage/sqlite.ts
+++ b/apps/server/src/providerUsage/sqlite.ts
@@ -1,7 +1,10 @@
 // FILE: providerUsage/sqlite.ts
-// Purpose: Read-only key/value lookups from VS Code-style `ItemTable` SQLite databases
-// (e.g. Cursor's state.vscdb). Mirrors the bun:sqlite / node:sqlite runtime branching used in
-// homeMigration.ts so it works under both runtimes. Defensive: returns {} on any failure.
+// Purpose: Read-only SQLite access for provider usage fetchers — key/value lookups from VS
+// Code-style `ItemTable` databases (e.g. Cursor's state.vscdb) and generic read-only SELECTs
+// (e.g. the OpenCode Go `opencode.db` message archive). Mirrors the bun:sqlite / node:sqlite
+// runtime branching used in homeMigration.ts so it works under both runtimes. Defensive:
+// `readItemTableValues` returns {} on any failure; `readSqliteRows` throws so callers can
+// distinguish "no rows" from "database unreadable".
 
 // Loaded dynamically so bundlers don't try to resolve the runtime-only "bun:sqlite" specifier.
 const importRuntimeModule = (specifier: string): Promise<unknown> =>
@@ -9,6 +12,7 @@ const importRuntimeModule = (specifier: string): Promise<unknown> =>
 
 interface ReadonlyStatement {
   get: (...params: ReadonlyArray<unknown>) => unknown;
+  all: (...params: ReadonlyArray<unknown>) => ReadonlyArray<Record<string, unknown>>;
 }
 
 interface ReadonlyDatabase {
@@ -72,4 +76,32 @@ export async function readItemTableValues(input: {
     }
   }
   return result;
+}
+
+/**
+ * Run a read-only SELECT and return every row as a string-keyed object. Unlike
+ * `readItemTableValues` this propagates failures (missing/malformed DB, bad SQL, a WAL read
+ * error) so callers can tell "query returned no rows" apart from "database unreadable" — the
+ * OpenCode fetcher needs that distinction to report errors instead of blank usage.
+ */
+export async function readSqliteRows(input: {
+  dbPath: string;
+  sql: string;
+  params?: ReadonlyArray<unknown>;
+}): Promise<ReadonlyArray<Record<string, unknown>>> {
+  let database: ReadonlyDatabase | null = null;
+  try {
+    database = await openReadOnlyDatabase(input.dbPath);
+    const statement = database.query?.(input.sql) ?? database.prepare?.(input.sql);
+    if (!statement) {
+      throw new Error(`Unsupported sqlite runtime for ${input.dbPath}`);
+    }
+    return statement.all(...(input.params ?? []));
+  } finally {
+    try {
+      database?.close();
+    } catch {
+      // ignore close failures
+    }
+  }
 }

--- a/apps/server/src/providerUsageSnapshot.ts
+++ b/apps/server/src/providerUsageSnapshot.ts
@@ -166,7 +166,9 @@ async function listRecentFiles(
     .map((entry) => entry.path);
 }
 
-function buildUsageLines(input: {
+// Reused by the OpenCode fetcher to format its 24h/7d/30d token totals with the same
+// compact "N tokens" / "N recent sessions" styling as the Codex and Claude archives.
+export function buildUsageLines(input: {
   tokens24h: number;
   tokens7d: number;
   tokens30d: number;

--- a/packages/shared/src/providerMetadata.ts
+++ b/packages/shared/src/providerMetadata.ts
@@ -85,7 +85,10 @@ export const PROVIDER_DESCRIPTORS = [
     displayName: PROVIDER_DISPLAY_NAMES.opencode,
     available: true,
     supportsNativeTurnSteering: false,
-    usage: null,
+    usage: {
+      signInCommand: "opencode auth login",
+      learnMoreHref: "https://opencode.ai/docs/",
+    },
   },
   {
     kind: "pi",


### PR DESCRIPTION
## What Changed

Adds a **Settings → Usage** card for **OpenCode** alongside the existing Codex / Claude / Cursor cards. The card reads the OpenCode Go CLI's local SQLite database (`opencode.db`) — the same on-device archive OpenUsage and other tools already lean on — and rolls per-message `tokens.total` and `cost` rows into:

- **24h / 7d / 30d token totals** with "N recent sessions" subtitles
- **Spend** line for 30-day cost

No live API call. No cookie or workspace ID. The card always shows whatever the CLI has recorded on this device. This is the same data source OpenUsage uses; it is **device-local observed spend**, which can be lower than the account-wide numbers if you also use OpenCode Go on other machines (treat the caps as a guide rather than the last word — same caveat OpenUsage documents).

## Why

The OpenCode Go CLI is a supported provider in Synara's provider picker, but its usage was completely invisible on the Usage page. The CLI keeps real per-message token and cost data in a SQLite archive locally, so showing it costs nothing extra and removes a notable gap.

## UI Changes

### Settings → Usage — OpenCode card added

The OpenCode card sits at the bottom of the Provider usage list, next to Codex / Claude / Cursor, using the existing card shell and the shared `ProviderUsageLineList` renderer so spacing, dividers, and typography match the rest of the panel.

### Settings → Providers → OpenCode unchanged

(I'll be honest: the branch I pushed *also* carried cookie/web-fetch plumbing in earlier commits, which I pulled out before this push so this PR is the small focused feature maintainers prefer. See "Notes for reviewers" below.)

## Verification

- `apps/server/src/providerUsage/providers/opencode.test.ts` — 11 tests:
  - Pure row normalization (drops invalid rows; coerces session ids)
  - Window aggregation + Spend-line presence/absence
  - Real temp `opencode.db` reads (fixture with the actual Go schema)
  - Cache-key fingerprint, missing DB → healthy-but-empty, malformed DB → error snapshot
  - `XDG_DATA_HOME` honored, custom-models path preserved
- Web: `apps/web/src/providerUsage.web` and panel tests already covered `PROVIDER_USAGE_PROVIDERS` additions automatically.
- `bun run typecheck` — 7/7 workspace tasks pass.
- `bun run lint` — 0 errors (no new warnings).
- `bun run fmt` — clean.
- Manually validated the local layer against a real `opencode.db` (~3B 30-day tokens, ~134 sessions, $6.83 spend).

## Notes for reviewers

The earlier scope of this branch was a CodexBar-style live web sync (session cookie → `opencode.ai/_server` → rolling 5h / weekly / monthly Go plan meters). I pulled that out of this push for three reasons:

1. **The opencode.ai `_server` endpoint is undocumented and unversioned** — its server-function IDs are content hashes that change per build, the args envelope is structured (`{"t":..., "f":…, "m":[…]}`), and there is no official Go usage API yet. CodexBar ships the same brittle scrape.
2. **The function IDs I borrowed from public docs were already stale** against the current opencode.ai (verified via live request shape comparison in the dev build), so the previous hybrid commit effectively fell back to the local-only card anyway.
3. **The maintainers' CONTRIBUTING.md prefers small, focused PRs**; the parse-the-RPC-envelope work easily bumps this past that bar and is the kind of direction-changing change they explicitly mention closing quickly.

So this is now the **foundation** PR: a properly-bounded local-archive card, plus the reusable bits (a generic `readSqliteRows` helper in `providerUsage/sqlite.ts`, an exported `buildUsageLines` formatter reused by the local archive, and the metadata entry so OpenCode joins the Provider usage rendering) that a future PR can build on for the rolling-window live sync once someone is willing to take on the reverse-engineering. The cookie and workspace ID fields are intentionally **not** in this PR.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
