### PR TITLE
fix(contracts): accept untrimmed tool output in item lifecycle detail

### DIFF
--- a/packages/contracts/src/providerRuntime.test.ts
+++ b/packages/contracts/src/providerRuntime.test.ts
@@ -171,4 +171,32 @@ describe("ProviderRuntimeEvent", () => {
     expect(parsed.payload.usage.usedTokens).toBe(31251);
     expect(parsed.payload.usage.usedPercent).toBe(15.6255);
   });
+
+  it("decodes item.completed with raw (untrimmed) tool output in detail", () => {
+    // Tool output legitimately carries leading/trailing whitespace; the durable
+    // journal must not reject it (previously quarantined with
+    // "Expected a string with no leading or trailing whitespace").
+    const rawOutput = "COMMAND   PID  USER   FD   TYPE\nbun.exe 33263 zachz   10u  IPv4\ndone\n";
+    const parsed = decodeRuntimeEvent({
+      type: "item.completed",
+      eventId: "event-tool-1",
+      provider: "pi",
+      sessionId: "runtime-session-4",
+      createdAt: "2026-02-28T00:00:05.000Z",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      payload: {
+        itemType: "command_execution",
+        status: "completed",
+        title: "bash",
+        detail: rawOutput,
+      },
+    });
+
+    expect(parsed.type).toBe("item.completed");
+    if (parsed.type !== "item.completed") {
+      throw new Error("expected item.completed");
+    }
+    expect(parsed.payload.detail).toBe(rawOutput);
+  });
 });

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -420,7 +420,12 @@ export const ItemLifecyclePayload = Schema.Struct({
   itemType: CanonicalItemType,
   status: Schema.optional(RuntimeItemStatus),
   title: Schema.optional(TrimmedNonEmptyStringSchema),
-  detail: Schema.optional(TrimmedNonEmptyStringSchema),
+  // Free-form body (e.g. raw tool output), which legitimately carries leading
+  // and/or trailing whitespace. Keep it unconstrained so item events from
+  // provider adapters (pi, opencode, codex, ...) always pass the durable
+  // journal's encode step; a TrimmedNonEmptyString here rejects ordinary
+  // tool output and forces the event into quarantine.
+  detail: Schema.optional(Schema.String),
   data: Schema.optional(Schema.Unknown),
 });
 export type ItemLifecyclePayload = typeof ItemLifecyclePayload.Type;


### PR DESCRIPTION
## Summary

`ItemLifecyclePayload.detail` is declared as `TrimmedNonEmptyStringSchema`, but provider adapters (pi, opencode, codex, ...) put **raw, multi-line tool output** into it — e.g. `PiAdapter` sets `detail: textFromToolResult(event.result)` on `item.completed`/`item.updated`. Ordinary tool output ends in a newline or starts with a space, so encoding the event into the durable journal fails with:

```
Decode error in ProviderRuntimeEvent.append.encode:
Expected a string with no leading or trailing whitespace, got "COMMAND   PID  USER ...\ndone\n"
  at ["payload"]["detail"]
```

The runtime-event pump classifies `PersistenceDecodeError` as a permanent failure, so instead of retrying it **quarantines the event**: the real event is dropped and replaced by a `runtime.warning` — the message users see in the UI every turn:

> Quarantined provider runtime event 'item.completed' after a permanent journal failure.

## Why this matters

- Not cosmetic: quarantined tool-call events are never written to the journal, so tool-call activity is missing from activity/history, live diffs, and resume cursors.
- It fires constantly: ~1,000 quarantine events in a month of normal use in my environment, split roughly evenly between the `pi` and `opencode` providers (`item.completed` and `item.updated`).
- It also triggers on other adapters that set free-form detail (e.g. `CodexAdapter` sets `detail: event.payload`).

## Change

Relax only the `detail` field of `ItemLifecyclePayload` from `TrimmedNonEmptyStringSchema` to `Schema.String`:

```ts
export const ItemLifecyclePayload = Schema.Struct({
  itemType: CanonicalItemType,
  status: Schema.optional(RuntimeItemStatus),
  title: Schema.optional(TrimmedNonEmptyStringSchema),
  detail: Schema.optional(Schema.String),   // was TrimmedNonEmptyStringSchema
  data: Schema.optional(Schema.Unknown),
});
```

`title` stays trimmed — it is generated by adapters (e.g. `toolTitle(...)`) and has no observed failure. Consumers already render `detail` verbatim (`ToolCallDetailsDialog`, `stripTrailingExitCode(...)`), so no downstream behavior changes. `TrimmedNonEmptyString`'s schema `Type` is `string`, so the TS type of `payload.detail` is unchanged.

## Verification

- Added a regression test decoding an `item.completed` event with raw, untrimmed multi-line tool output in `detail` — it **fails against the old schema** with the exact quarantine error and passes with the fix.
- Full `packages/contracts` suite: 199 tests pass.

## Checklist

- [x] Small, single-purpose change
- [x] Regression test included
- [x] No UI change
