### PR TITLE
feat(chat): add file link context actions

### DIFF
--- a/apps/web/src/components/ChatMarkdown.fileContextMenu.browser.tsx
+++ b/apps/web/src/components/ChatMarkdown.fileContextMenu.browser.tsx
@@ -1,0 +1,55 @@
+// FILE: ChatMarkdown.fileContextMenu.browser.tsx
+// Purpose: Verifies assistant file links replace the browser menu with Synara's file actions.
+// Layer: Web chat browser tests
+
+import { render } from "vitest-browser-react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  showFileReferenceContextMenu: vi.fn(),
+}));
+
+vi.mock("../lib/fileReferenceContextMenu", () => ({
+  showFileReferenceContextMenu: harness.showFileReferenceContextMenu,
+}));
+
+vi.mock("../hooks/useTheme", () => ({
+  useTheme: () => ({ resolvedTheme: "light" }),
+}));
+
+import ChatMarkdown from "./ChatMarkdown";
+
+beforeEach(() => {
+  harness.showFileReferenceContextMenu.mockReset();
+  harness.showFileReferenceContextMenu.mockResolvedValue(undefined);
+});
+
+describe("ChatMarkdown file context menu", () => {
+  it("opens the shared file menu with a position-free absolute path", async () => {
+    const screen = await render(
+      <ChatMarkdown
+        text="[Download video](/repo/output/video.mp4:42)"
+        cwd="/repo"
+        isStreaming={false}
+      />,
+    );
+    const link = screen.getByRole("link", { name: "Download video" }).element();
+    const event = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 15,
+      clientY: 28,
+    });
+
+    link.dispatchEvent(event);
+
+    await vi.waitFor(() => expect(harness.showFileReferenceContextMenu).toHaveBeenCalledOnce());
+    expect(event.defaultPrevented).toBe(true);
+    expect(harness.showFileReferenceContextMenu).toHaveBeenCalledWith({
+      path: "/repo/output/video.mp4",
+      revealPath: "/repo/output/video.mp4",
+      position: { x: 15, y: 28 },
+      onReferenceInChat: undefined,
+    });
+  });
+});

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -5,6 +5,7 @@
 
 import { CheckIcon, CopyIcon, TextWrapIcon } from "~/lib/icons";
 import type { ProviderMentionReference, ThreadMarker } from "@synara/contracts";
+import { isLocalAbsolutePath } from "@synara/shared/path";
 import "katex/dist/katex.min.css";
 import React, {
   Children,
@@ -34,6 +35,7 @@ import { getFileIconName, pathLooksLikeKnownFile } from "../file-icons";
 import { CentralIcon } from "~/lib/central-icons";
 import { isLocalImageMarkdownSrc } from "../lib/localImageUrls";
 import { repairMarkdownTableDelimiters } from "../lib/markdownTableRepair";
+import { showFileReferenceContextMenu } from "../lib/fileReferenceContextMenu";
 import { useTheme } from "../hooks/useTheme";
 import { useSmoothStreamedText } from "../hooks/useSmoothStreamedText";
 import { openWorkspaceFileReference, useWorkspaceFileOpener } from "../lib/workspaceFileOpener";
@@ -770,6 +772,7 @@ function OpenableFileChip(props: {
 }) {
   const opener = useWorkspaceFileOpener();
   const chipPath = props.targetPath.replace(MARKDOWN_LINK_POSITION_SUFFIX_PATTERN, "");
+  const revealPath = isLocalAbsolutePath(chipPath) ? chipPath : undefined;
   return (
     <InlineMentionChip
       path={chipPath}
@@ -780,6 +783,16 @@ function OpenableFileChip(props: {
         event.stopPropagation();
         const forceExternalEditor = event.metaKey || event.ctrlKey;
         openWorkspaceFileReference(forceExternalEditor ? null : opener, props.targetPath);
+      }}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        void showFileReferenceContextMenu({
+          path: chipPath,
+          ...(revealPath ? { revealPath } : {}),
+          position: { x: event.clientX, y: event.clientY },
+          onReferenceInChat: undefined,
+        });
       }}
       {...(opener?.prefetchFile
         ? { onHoverPrefetch: () => opener.prefetchFile?.(props.targetPath) }

--- a/apps/web/src/components/chat/InlineMentionChip.tsx
+++ b/apps/web/src/components/chat/InlineMentionChip.tsx
@@ -31,6 +31,7 @@ interface InlineMentionChipProps {
   /** When set, the chip renders as an openable anchor instead of a static span. */
   href?: string;
   onActivate?: (event: MouseEvent<HTMLAnchorElement>) => void;
+  onContextMenu?: (event: MouseEvent<HTMLAnchorElement>) => void;
   /** Warm-up hook fired on hover/focus so activating the chip feels instant. */
   onHoverPrefetch?: (() => void) | undefined;
 }
@@ -89,6 +90,7 @@ export function InlineMentionChip(props: InlineMentionChipProps) {
         title={props.path}
         {...(href !== undefined ? { href } : {})}
         {...(handleActivate ? { onClick: handleActivate } : {})}
+        {...(props.onContextMenu ? { onContextMenu: props.onContextMenu } : {})}
         {...(handleHoverPrefetch
           ? { onPointerEnter: handleHoverPrefetch, onFocus: handleHoverPrefetch }
           : {})}

--- a/apps/web/src/lib/fileReferenceContextMenu.test.ts
+++ b/apps/web/src/lib/fileReferenceContextMenu.test.ts
@@ -9,6 +9,7 @@ const harness = vi.hoisted(() => ({
   copyText: vi.fn(),
   showContextMenu: vi.fn(),
   showInFolder: vi.fn(),
+  toast: vi.fn(),
 }));
 
 vi.mock("~/hooks/useCopyToClipboard", () => ({
@@ -22,6 +23,10 @@ vi.mock("~/nativeApi", () => ({
   }),
 }));
 
+vi.mock("~/components/ui/toast", () => ({
+  toastManager: { add: harness.toast },
+}));
+
 import { getRevealInFolderLabel, showFileReferenceContextMenu } from "./fileReferenceContextMenu";
 
 beforeEach(() => {
@@ -31,6 +36,7 @@ beforeEach(() => {
   harness.copyText.mockReset();
   harness.showContextMenu.mockReset();
   harness.showInFolder.mockReset();
+  harness.toast.mockReset();
   harness.showContextMenu.mockImplementation(async () => harness.clicked);
   harness.copyText.mockResolvedValue(undefined);
   harness.showInFolder.mockResolvedValue(undefined);
@@ -94,6 +100,26 @@ describe("showFileReferenceContextMenu", () => {
 
     expect(harness.showInFolder).toHaveBeenCalledWith("/repo/output/video.mp4");
     expect(harness.copyText).not.toHaveBeenCalled();
+  });
+
+  it("reports a stale file without leaking the shell rejection", async () => {
+    harness.clicked = "reveal-in-folder";
+    harness.showInFolder.mockRejectedValue(new Error("Folder not found: /repo/output/video.mp4"));
+
+    await expect(
+      showFileReferenceContextMenu({
+        path: "/repo/output/video.mp4",
+        revealPath: "/repo/output/video.mp4",
+        position: { x: 12, y: 34 },
+        onReferenceInChat: undefined,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(harness.toast).toHaveBeenCalledWith({
+      type: "error",
+      title: "Unable to reveal file",
+      description: "Folder not found: /repo/output/video.mp4",
+    });
   });
 
   it("copies the displayed filesystem path with the shared clipboard fallback", async () => {

--- a/apps/web/src/lib/fileReferenceContextMenu.test.ts
+++ b/apps/web/src/lib/fileReferenceContextMenu.test.ts
@@ -1,0 +1,112 @@
+// FILE: fileReferenceContextMenu.test.ts
+// Purpose: Verifies file-reference menu labels and desktop reveal/copy actions.
+// Layer: Web UI helper tests
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  clicked: null as string | null,
+  copyText: vi.fn(),
+  showContextMenu: vi.fn(),
+  showInFolder: vi.fn(),
+}));
+
+vi.mock("~/hooks/useCopyToClipboard", () => ({
+  copyTextToClipboard: harness.copyText,
+}));
+
+vi.mock("~/nativeApi", () => ({
+  readNativeApi: () => ({
+    contextMenu: { show: harness.showContextMenu },
+    shell: { showInFolder: harness.showInFolder },
+  }),
+}));
+
+import { getRevealInFolderLabel, showFileReferenceContextMenu } from "./fileReferenceContextMenu";
+
+beforeEach(() => {
+  vi.stubGlobal("window", { desktopBridge: {} });
+  vi.stubGlobal("navigator", { platform: "Win32" });
+  harness.clicked = null;
+  harness.copyText.mockReset();
+  harness.showContextMenu.mockReset();
+  harness.showInFolder.mockReset();
+  harness.showContextMenu.mockImplementation(async () => harness.clicked);
+  harness.copyText.mockResolvedValue(undefined);
+  harness.showInFolder.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("getRevealInFolderLabel", () => {
+  it("uses the native file-manager name on supported desktop platforms", () => {
+    expect(getRevealInFolderLabel("Win32")).toBe("Open in Explorer");
+    expect(getRevealInFolderLabel("MacIntel")).toBe("Reveal in Finder");
+    expect(getRevealInFolderLabel("Linux x86_64")).toBe("Show in folder");
+  });
+});
+
+describe("showFileReferenceContextMenu", () => {
+  it("offers reveal before copy when an absolute reveal path is available", async () => {
+    await showFileReferenceContextMenu({
+      path: "/repo/output/video.mp4",
+      revealPath: "/repo/output/video.mp4",
+      position: { x: 12, y: 34 },
+      onReferenceInChat: undefined,
+    });
+
+    expect(harness.showContextMenu).toHaveBeenCalledWith(
+      [
+        { id: "reveal-in-folder", label: "Open in Explorer" },
+        { id: "copy-path", label: "Copy path" },
+      ],
+      { x: 12, y: 34 },
+    );
+  });
+
+  it("hides the desktop-only reveal action in the browser", async () => {
+    vi.stubGlobal("window", {});
+
+    await showFileReferenceContextMenu({
+      path: "/repo/output/video.mp4",
+      revealPath: "/repo/output/video.mp4",
+      position: { x: 12, y: 34 },
+      onReferenceInChat: undefined,
+    });
+
+    expect(harness.showContextMenu).toHaveBeenCalledWith(
+      [{ id: "copy-path", label: "Copy path" }],
+      { x: 12, y: 34 },
+    );
+  });
+
+  it("reveals the requested file through the desktop shell", async () => {
+    harness.clicked = "reveal-in-folder";
+
+    await showFileReferenceContextMenu({
+      path: "/repo/output/video.mp4",
+      revealPath: "/repo/output/video.mp4",
+      position: { x: 12, y: 34 },
+      onReferenceInChat: undefined,
+    });
+
+    expect(harness.showInFolder).toHaveBeenCalledWith("/repo/output/video.mp4");
+    expect(harness.copyText).not.toHaveBeenCalled();
+  });
+
+  it("copies the displayed filesystem path with the shared clipboard fallback", async () => {
+    harness.clicked = "copy-path";
+
+    await showFileReferenceContextMenu({
+      path: "/repo/output/video.mp4",
+      revealPath: "/repo/output/video.mp4",
+      position: { x: 12, y: 34 },
+      onReferenceInChat: undefined,
+    });
+
+    expect(harness.copyText).toHaveBeenCalledWith("/repo/output/video.mp4");
+    expect(harness.showInFolder).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/fileReferenceContextMenu.ts
+++ b/apps/web/src/lib/fileReferenceContextMenu.ts
@@ -8,6 +8,7 @@ import { formatSelectionLabel, type ChatFileReference } from "~/lib/chatReferenc
 import { copyTextToClipboard } from "~/hooks/useCopyToClipboard";
 import { isMacPlatform, isWindowsPlatform } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
+import { toastManager } from "~/components/ui/toast";
 
 export function getRevealInFolderLabel(platform: string): string {
   if (isWindowsPlatform(platform)) {
@@ -92,7 +93,16 @@ export async function showFileReferenceContextMenu(input: {
     return;
   }
   if (clicked === "reveal-in-folder" && revealPath) {
-    await api.shell.showInFolder(revealPath);
+    try {
+      await api.shell.showInFolder(revealPath);
+    } catch (error) {
+      toastManager.add({
+        type: "error",
+        title: "Unable to reveal file",
+        description:
+          error instanceof Error ? error.message : "An unknown error occurred opening the file.",
+      });
+    }
     return;
   }
   if (clicked === "copy-path") {

--- a/apps/web/src/lib/fileReferenceContextMenu.ts
+++ b/apps/web/src/lib/fileReferenceContextMenu.ts
@@ -1,16 +1,31 @@
 // FILE: fileReferenceContextMenu.ts
-// Purpose: Right-click menu shared by file rows and file previews (editor
-//          explorer, changed-file lists, dock file pane).
+// Purpose: Right-click menu shared by file rows, file previews, and chat file
+//          links (editor explorer, changed-file lists, dock file pane).
 // Layer: Web UI helpers
-// Exports: showFileReferenceContextMenu
+// Exports: showFileReferenceContextMenu, getRevealInFolderLabel
 
 import { formatSelectionLabel, type ChatFileReference } from "~/lib/chatReferences";
+import { copyTextToClipboard } from "~/hooks/useCopyToClipboard";
+import { isMacPlatform, isWindowsPlatform } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
+
+export function getRevealInFolderLabel(platform: string): string {
+  if (isWindowsPlatform(platform)) {
+    return "Open in Explorer";
+  }
+  if (isMacPlatform(platform)) {
+    return "Reveal in Finder";
+  }
+  return "Show in folder";
+}
 
 // Right-click menu shared by explorer rows, changed-file rows, and the file
 // preview. Falls back to a DOM menu outside the desktop app.
 export async function showFileReferenceContextMenu(input: {
   path: string;
+  /** Absolute path to reveal in the platform file manager. Omit when the
+   * surface only knows a repository-relative path. */
+  revealPath?: string;
   position: { x: number; y: number };
   /** Line/column range from source views, or a quoted snippet from surfaces
    * without stable source lines (rendered markdown preview). */
@@ -22,6 +37,10 @@ export async function showFileReferenceContextMenu(input: {
   if (!api) {
     return;
   }
+  const revealPath =
+    input.revealPath && typeof window !== "undefined" && window.desktopBridge
+      ? input.revealPath
+      : undefined;
   const reference: ChatFileReference = {
     path: input.path,
     ...input.selection,
@@ -50,6 +69,16 @@ export async function showFileReferenceContextMenu(input: {
             },
           ]
         : []),
+      ...(revealPath
+        ? [
+            {
+              id: "reveal-in-folder" as const,
+              label: getRevealInFolderLabel(
+                typeof navigator === "undefined" ? "" : navigator.platform,
+              ),
+            },
+          ]
+        : []),
       { id: "copy-path" as const, label: "Copy path" },
     ],
     input.position,
@@ -62,7 +91,11 @@ export async function showFileReferenceContextMenu(input: {
     input.onAskWhyInChat?.(reference);
     return;
   }
+  if (clicked === "reveal-in-folder" && revealPath) {
+    await api.shell.showInFolder(revealPath);
+    return;
+  }
   if (clicked === "copy-path") {
-    void navigator.clipboard?.writeText(input.path);
+    await copyTextToClipboard(input.path);
   }
 }


### PR DESCRIPTION
## What Changed

- Adds a native context menu to local file links rendered in assistant messages.
- Offers Open in Explorer on Windows, Reveal in Finder on macOS, and Show in folder on Linux.
- Adds Copy path with the shared clipboard fallback.
- Removes line and column suffixes before revealing or copying a path.
- Keeps the reveal action desktop-only while preserving browser behavior.

## Why

Generated file outputs currently fall back to the generic browser context menu. These focused actions make it possible to locate an output on disk or copy its filesystem path directly from the transcript.

## UI Changes

Right-clicking a local file link now opens the native Synara file menu with the platform-specific reveal action followed by Copy path. No layout, motion, or visual styling changes.

## Verification

- 30 focused unit tests passed: fileReferenceContextMenu.test.ts and ChatMarkdown.test.tsx
- 1 Chromium interaction test passed: ChatMarkdown.fileContextMenu.browser.tsx
- Targeted oxlint passed with 0 warnings and 0 errors
- Targeted oxfmt check passed
- git diff --check passed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] No animation or motion changes require a video