### PR TITLE
fix(server): 10x faster startup on large databases — keep PK range scan in projector replay

### DIFF
--- a/apps/server/src/persistence/Layers/OrchestrationEventStore.test.ts
+++ b/apps/server/src/persistence/Layers/OrchestrationEventStore.test.ts
@@ -5,7 +5,10 @@ import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import { PersistenceDecodeError } from "../Errors.ts";
 import { OrchestrationEventStore } from "../Services/OrchestrationEventStore.ts";
-import { OrchestrationEventStoreLive } from "./OrchestrationEventStore.ts";
+import {
+  buildReadEventRowsFromSequenceQuery,
+  OrchestrationEventStoreLive,
+} from "./OrchestrationEventStore.ts";
 import { SqlitePersistenceMemory } from "./Sqlite.ts";
 
 const layer = it.layer(
@@ -13,6 +16,91 @@ const layer = it.layer(
 );
 
 layer("OrchestrationEventStore", (it) => {
+  it.effect("projector replay pages keep the primary-key range scan for every filter shape", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const baseRequest = {
+        sequenceExclusive: 10,
+        throughSequenceInclusive: 1_000,
+        limit: 500,
+      };
+      // One request per replayFilter branch in buildReadEventRowsFromSequenceQuery.
+      const requests = [
+        {
+          ...baseRequest,
+          filterEnabled: false,
+          includeBoundaryEvent: false,
+          eventTypes: [],
+          activityKinds: [],
+        },
+        {
+          ...baseRequest,
+          filterEnabled: true,
+          includeBoundaryEvent: true,
+          eventTypes: ["thread.activity-appended", "thread.created"],
+          activityKinds: [],
+        },
+        {
+          ...baseRequest,
+          filterEnabled: true,
+          includeBoundaryEvent: true,
+          eventTypes: ["thread.activity-appended"],
+          activityKinds: ["approval.requested"],
+        },
+        // Empty eventTypes yields the constant-0 predicate (checkpoints projector).
+        {
+          ...baseRequest,
+          filterEnabled: true,
+          includeBoundaryEvent: true,
+          eventTypes: [],
+          activityKinds: [],
+        },
+        {
+          ...baseRequest,
+          filterEnabled: true,
+          includeBoundaryEvent: false,
+          eventTypes: ["thread.activity-appended"],
+          activityKinds: ["approval.requested"],
+        },
+      ];
+
+      for (const request of requests) {
+        const [query, params] = buildReadEventRowsFromSequenceQuery(sql, request).compile();
+        const plan = yield* sql.unsafe<{ readonly detail: string }>(
+          `EXPLAIN QUERY PLAN ${query}`,
+          params,
+        );
+        const details = plan.map((row) => row.detail).join("\n");
+        // The boundary OR must never demote the sequence cursor to a
+        // MULTI-INDEX OR plan: with a large event log that plan rescans the
+        // whole event_type index per page and turns projection bootstrap
+        // into minutes of startup time.
+        //
+        // EXPLAIN QUERY PLAN text is not a stable format across SQLite
+        // releases, so assert independent fragments of the required plan
+        // (table search, integer PK usage, both rowid range bounds) instead
+        // of one exact phrase.
+        for (const fragment of [
+          /SEARCH orchestration_events/,
+          /USING INTEGER PRIMARY KEY/,
+          /rowid>/,
+          /rowid</,
+        ]) {
+          assert.match(
+            details,
+            fragment,
+            `expected PK range scan (${fragment}), got plan:\n${details}\nfor request: ${JSON.stringify(request)}`,
+          );
+        }
+        assert.notMatch(
+          details,
+          /MULTI-INDEX OR|TEMP B-TREE/,
+          `plan regressed to index-OR or temp sort:\n${details}\nfor request: ${JSON.stringify(request)}`,
+        );
+      }
+    }),
+  );
+
   it.effect("reads stable newest-first pages from one thread stream", () =>
     Effect.gen(function* () {
       const eventStore = yield* OrchestrationEventStore;

--- a/apps/server/src/persistence/Layers/OrchestrationEventStore.ts
+++ b/apps/server/src/persistence/Layers/OrchestrationEventStore.ts
@@ -336,6 +336,66 @@ function inferActorKind(
   return "client";
 }
 
+/**
+ * Builds the paged projector-replay query. Exported so tests can pin its query
+ * plan with EXPLAIN QUERY PLAN.
+ *
+ * Every predicate below the sequence range uses SQLite's unary + to stay
+ * ineligible for index selection. Without it the planner turns the boundary OR
+ * into a MULTI-INDEX OR that scans the whole event_type index and re-sorts
+ * through a temp b-tree for every page, which makes projector bootstrap
+ * quadratic in event-log size (minutes of startup on multi-GB logs). The +
+ * keeps the integer-primary-key range scan: a sparse filter can still walk a
+ * long sequence interval to fill one page, but the whole replay stays linear
+ * in the covered range (each row visited once), and rows already come back
+ * in sequence order with no sort step.
+ */
+export const buildReadEventRowsFromSequenceQuery = (
+  sql: SqlClient.SqlClient,
+  request: typeof ReadFromSequenceRequestSchema.Type,
+) => {
+  const activityKindFilter =
+    request.activityKinds.length === 0
+      ? sql``
+      : sql`
+          AND (
+            +event_type <> 'thread.activity-appended'
+            OR json_extract(payload_json, '$.activity.kind') IN ${sql.in(request.activityKinds)}
+          )
+        `;
+  const filteredEventPredicate =
+    request.eventTypes.length === 0
+      ? sql`0`
+      : sql`(+event_type IN ${sql.in(request.eventTypes)} ${activityKindFilter})`;
+  const replayFilter = !request.filterEnabled
+    ? sql``
+    : request.includeBoundaryEvent
+      ? sql`AND (+sequence = ${request.throughSequenceInclusive} OR ${filteredEventPredicate})`
+      : sql`
+          AND ${filteredEventPredicate}
+        `;
+  return sql`
+    SELECT
+      sequence,
+      event_id AS "eventId",
+      event_type AS "type",
+      aggregate_kind AS "aggregateKind",
+      stream_id AS "aggregateId",
+      occurred_at AS "occurredAt",
+      command_id AS "commandId",
+      causation_event_id AS "causationEventId",
+      correlation_id AS "correlationId",
+      payload_json AS "payloadJson",
+      metadata_json AS "metadataJson"
+    FROM orchestration_events
+    WHERE sequence > ${request.sequenceExclusive}
+      AND sequence <= ${request.throughSequenceInclusive}
+      ${replayFilter}
+    ORDER BY sequence ASC
+    LIMIT ${request.limit}
+  `;
+};
+
 const makeEventStore = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
 
@@ -400,48 +460,7 @@ const makeEventStore = Effect.gen(function* () {
   const readEventRowsFromSequence = SqlSchema.findAll({
     Request: ReadFromSequenceRequestSchema,
     Result: RawPersistedEventRowSchema,
-    execute: (request) => {
-      const activityKindFilter =
-        request.activityKinds.length === 0
-          ? sql``
-          : sql`
-              AND (
-                event_type <> 'thread.activity-appended'
-                OR json_extract(payload_json, '$.activity.kind') IN ${sql.in(request.activityKinds)}
-              )
-            `;
-      const filteredEventPredicate =
-        request.eventTypes.length === 0
-          ? sql`0`
-          : sql`(event_type IN ${sql.in(request.eventTypes)} ${activityKindFilter})`;
-      const replayFilter = !request.filterEnabled
-        ? sql``
-        : request.includeBoundaryEvent
-          ? sql`AND (sequence = ${request.throughSequenceInclusive} OR ${filteredEventPredicate})`
-          : sql`
-              AND ${filteredEventPredicate}
-            `;
-      return sql`
-        SELECT
-          sequence,
-          event_id AS "eventId",
-          event_type AS "type",
-          aggregate_kind AS "aggregateKind",
-          stream_id AS "aggregateId",
-          occurred_at AS "occurredAt",
-          command_id AS "commandId",
-          causation_event_id AS "causationEventId",
-          correlation_id AS "correlationId",
-          payload_json AS "payloadJson",
-          metadata_json AS "metadataJson"
-        FROM orchestration_events
-        WHERE sequence > ${request.sequenceExclusive}
-          AND sequence <= ${request.throughSequenceInclusive}
-          ${replayFilter}
-        ORDER BY sequence ASC
-        LIMIT ${request.limit}
-      `;
-    },
+    execute: (request) => buildReadEventRowsFromSequenceQuery(sql, request),
   });
 
   const readThreadEventRowsFromSequence = SqlSchema.findAll({

--- a/apps/server/src/persistence/Layers/Sqlite.test.ts
+++ b/apps/server/src/persistence/Layers/Sqlite.test.ts
@@ -62,6 +62,19 @@ describe("SQLite persistence", () => {
         expect(lockingMode?.locking_mode).toBe("exclusive");
         expect(journalMode?.journal_mode).toBe("wal");
 
+        // Large-database tuning must actually take effect, not silently
+        // no-op: a reverted or ignored cache_size reintroduces multi-minute
+        // startups on multi-GB event logs. mmap_size may be capped by the
+        // runtime build, so only require that mapping is enabled at all.
+        const [cacheSize] = yield* sql<{ readonly cache_size: number }>`
+          PRAGMA cache_size;
+        `;
+        const [mmapSize] = yield* sql<{ readonly mmap_size: number }>`
+          PRAGMA mmap_size;
+        `;
+        expect(cacheSize?.cache_size).toBe(-262144);
+        expect(mmapSize?.mmap_size).toBeGreaterThan(0);
+
         yield* sql`CREATE TABLE ownership_probe(value TEXT NOT NULL)`;
         yield* sql`INSERT INTO ownership_probe(value) VALUES ('owned-by-synara')`;
         yield* Effect.promise(async () => {

--- a/apps/server/src/persistence/Layers/Sqlite.ts
+++ b/apps/server/src/persistence/Layers/Sqlite.ts
@@ -94,7 +94,26 @@ const makeSetup = (dbPath?: string, pendingRecovery: MigrationRecoveryMarker | n
       // power loss is acceptable.
       yield* sql`PRAGMA synchronous = NORMAL;`;
       yield* sql`PRAGMA foreign_keys = ON;`;
+      // The event log alone can exceed a gigabyte, so the 2MB default page
+      // cache thrashes during projector replay and large projection reads.
+      // 256MB of page cache (negative value = KiB) keeps the hot b-tree
+      // interior pages resident. It is an on-demand ceiling for the single
+      // serialized connection, not an upfront allocation. temp_store stays at
+      // its default deliberately: the snapshot window queries can build
+      // temp b-trees proportional to live-thread history, and MEMORY would
+      // turn those into unbounded native RSS; the disk default already keeps
+      // small temp structures in memory and only spills when they grow.
+      yield* sql`PRAGMA cache_size = -262144;`;
       if (dbPath) {
+        // mmap serves large sequential reads (event replay, VACUUM INTO
+        // backups) through the OS page cache without double-buffering into
+        // the SQLite heap cache. In-memory databases have nothing to map.
+        // Accepted tradeoff: with mmap, a device I/O error or an external
+        // process truncating the file surfaces as a signal (SIGBUS) instead
+        // of a recoverable SQLite error. locking_mode=EXCLUSIVE plus the
+        // lifecycle lock make external mutation effectively impossible, and
+        // no internal path truncates the live database.
+        yield* sql`PRAGMA mmap_size = 1073741824;`;
         // Setting locking_mode changes connection policy; this transaction
         // actually acquires and retains the database lock before startup
         // continues, closing the window where another client could attach.

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -1,9 +1,6 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { dirname } from "node:path";
-import {
-  DEFAULT_GIT_TEXT_GENERATION_MODEL,
-  DEFAULT_MODEL_BY_PROVIDER,
-} from "@synara/contracts";
+import { DEFAULT_GIT_TEXT_GENERATION_MODEL, DEFAULT_MODEL_BY_PROVIDER } from "@synara/contracts";
 import { Effect, FileSystem, Layer } from "effect";
 import { describe, expect, it } from "vitest";
 import { ServerConfig } from "./config";


### PR DESCRIPTION
## Problem

With a large `state.sqlite` (2.9GB, ~950k `orchestration_events`), server startup took **5+ minutes** before the HTTP/WS server started listening. The time went to projector bootstrap: `bootstrapProjector` replays the event log in 500-row pages, and the replay query's `includeBoundaryEvent` clause —

```sql
WHERE sequence > ? AND sequence <= ?
  AND (sequence = ? OR event_type IN (...))
```

— makes SQLite pick a **MULTI-INDEX OR** plan instead of the integer-primary-key range scan. Every page then scans the entire `event_type` index (~750k entries) and re-sorts through a temp b-tree, so a lagging projector cursor costs ~1,500 pages × ~225ms ≈ minutes, serialized on the single connection before the server is functional.

```
QUERY PLAN
|--MULTI-INDEX OR
|  |--SEARCH orchestration_events USING INTEGER PRIMARY KEY (rowid=?)
|  `--SEARCH orchestration_events USING COVERING INDEX idx_orchestration_events_profile_turn_events (event_type=?)
`--USE TEMP B-TREE FOR ORDER BY
```

## Fix

- Add SQLite unary-`+` planner hints to every predicate below the sequence cursor in the replay query (extracted as `buildReadEventRowsFromSequenceQuery`), so the PK range scan is the only eligible plan. `+column` is semantics-preserving here (TEXT NOT NULL / INTEGER PK operands, default BINARY collation); returned rows are identical, now with no sort step.
- Tune the connection for multi-GB databases: `cache_size = 256MB` (on-demand ceiling for the single serialized connection; default was 2MB) and `mmap_size = 1GB` for file-backed databases. `temp_store` deliberately stays on its default — the snapshot window queries can build temp b-trees proportional to live-thread history, and `MEMORY` would turn those into unbounded native RSS.

## Measured (real 2.9GB database, projector cursor 928k events behind)

| | before | after |
|---|---|---|
| one 500-row replay page | ~225ms | ~5ms |
| full 732k-event replay incl. schema decode | ~3.5–5.5 min | **24s** |

Normal startups (cursors current) do near-zero replay work either way; the fix removes the cliff when a cursor is behind (fresh cursor row, migration cursor reset, or long-lived lag).

## Regression protection

- New test compiles the replay query for all five filter shapes and asserts via `EXPLAIN QUERY PLAN` that the PK range scan survives and `MULTI-INDEX OR` / `TEMP B-TREE` never reappear (fragment-based assertions, since EQP text is not stable across SQLite releases).
- The file-backed persistence test now reads back `cache_size` and `mmap_size` so a silently ignored pragma fails loudly.

## Verification

- Full `apps/server` suite: 3,716 passed; the single failure (`GitCore.test.ts` wall-clock timing assertion) fails identically on a clean tree.
- `bun fmt` / `bun lint` clean; the one typecheck error on this base (`decider.ts` fork-lineage type) pre-exists and is untouched.