### PR TITLE
Add stacked pull request support

### DIFF
--- a/apps/server/src/git/Layers/GitHubCli.test.ts
+++ b/apps/server/src/git/Layers/GitHubCli.test.ts
@@ -1,5 +1,6 @@
 import { assert, it } from "@effect/vitest";
-import { Effect } from "effect";
+import { Effect, Fiber } from "effect";
+import { TestClock } from "effect/testing";
 import { afterEach, expect, vi } from "vitest";
 
 vi.mock("../../processRunner", () => ({
@@ -49,7 +50,6 @@ layer("GitHubCliLive", (it) => {
         signal: null,
         timedOut: false,
       });
-
       const result = yield* Effect.gen(function* () {
         const gh = yield* GitHubCli;
         return yield* gh.getPullRequest({
@@ -742,6 +742,22 @@ layer("GitHubCliLive", (it) => {
         signal: null,
         timedOut: false,
       });
+      mockedRunProcess.mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pr_9: {
+                stackEntry: { position: 2 },
+                stack: { number: 4, size: 3, baseRefName: "main" },
+              },
+            },
+          },
+        }),
+        stderr: "",
+        code: 0,
+        signal: null,
+        timedOut: false,
+      });
 
       const gh = yield* GitHubCli;
       const result = yield* gh.listRepositoryPullRequests({
@@ -756,6 +772,12 @@ layer("GitHubCliLive", (it) => {
       assert.equal(result.entries.length, 1);
       assert.equal(result.entries[0]?.title, "Healthy PR");
       assert.deepStrictEqual(result.entries[0]?.reviewRequestLogins, ["reviewer"]);
+      assert.deepStrictEqual(result.entries[0]?.stack, {
+        number: 4,
+        size: 3,
+        position: 2,
+        baseBranch: "main",
+      });
       expect(mockedRunProcess.mock.calls[0]?.[1]).toEqual([
         "pr",
         "list",
@@ -769,6 +791,18 @@ layer("GitHubCliLive", (it) => {
         "50",
         "--json",
         expect.any(String),
+      ]);
+      expect(mockedRunProcess.mock.calls[1]?.[1]).toEqual([
+        "api",
+        "graphql",
+        "--hostname",
+        "github.com",
+        "-f",
+        expect.stringContaining("pr_9: pullRequest(number: 9)"),
+        "-F",
+        "owner=acme",
+        "-F",
+        "repo=app",
       ]);
     }),
   );
@@ -803,6 +837,96 @@ layer("GitHubCliLive", (it) => {
           "50",
         ]),
       );
+    }),
+  );
+
+  it.effect("enriches an individually recovered pull request with stack metadata", () =>
+    Effect.gen(function* () {
+      mockedRunProcess.mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: 99,
+          title: "Pinned beyond the list cap",
+          url: "https://github.com/acme/app/pull/99",
+          headRefName: "stack-top",
+          baseRefName: "stack-base",
+          state: "OPEN",
+          createdAt: "2026-07-01T00:00:00Z",
+          updatedAt: "2026-07-02T00:00:00Z",
+        }),
+        stderr: "",
+        code: 0,
+        signal: null,
+        timedOut: false,
+      });
+      mockedRunProcess.mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pr_99: {
+                stackEntry: { position: 3 },
+                stack: { number: 7, size: 3, baseRefName: "main" },
+              },
+            },
+          },
+        }),
+        stderr: "",
+        code: 0,
+        signal: null,
+        timedOut: false,
+      });
+
+      const gh = yield* GitHubCli;
+      const result = yield* gh.getPullRequestListItem({
+        cwd: "/repo",
+        repository: "acme/app",
+        number: 99,
+      });
+
+      assert.deepStrictEqual(result.stack, {
+        number: 7,
+        size: 3,
+        position: 3,
+        baseBranch: "main",
+      });
+      expect(mockedRunProcess.mock.calls[1]?.[1]).toEqual(
+        expect.arrayContaining([expect.stringContaining("pr_99: pullRequest(number: 99)")]),
+      );
+    }),
+  );
+
+  it.effect("keeps repository rows when optional stack enrichment fails", () =>
+    Effect.gen(function* () {
+      mockedRunProcess.mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            number: 11,
+            title: "Still visible",
+            url: "https://github.com/acme/app/pull/11",
+            headRefName: "feature",
+            baseRefName: "main",
+            state: "OPEN",
+            createdAt: "2026-07-01T00:00:00Z",
+            updatedAt: "2026-07-02T00:00:00Z",
+          },
+        ]),
+        stderr: "",
+        code: 0,
+        signal: null,
+        timedOut: false,
+      });
+      mockedRunProcess.mockRejectedValueOnce(new Error("GraphQL field unavailable"));
+
+      const gh = yield* GitHubCli;
+      const result = yield* gh.listRepositoryPullRequests({
+        cwd: "/repo",
+        repository: "acme/app",
+        state: "open",
+        involvement: "all",
+        viewer: "octocat",
+      });
+
+      assert.equal(result.entries[0]?.title, "Still visible");
+      assert.equal(result.entries[0]?.stack, null);
     }),
   );
 
@@ -969,7 +1093,10 @@ layer("GitHubCliLive", (it) => {
           stderrTruncated: false,
         })
         .mockResolvedValueOnce({
-          stdout: "",
+          stdout: JSON.stringify({
+            status: "merged",
+            details: { message: "Pull request was merged." },
+          }),
           stderr: "",
           code: 0,
           signal: null,
@@ -982,7 +1109,7 @@ layer("GitHubCliLive", (it) => {
         repository: "acme/app",
         number: 9,
       });
-      yield* gh.runPullRequestAction({
+      const action = yield* gh.runPullRequestAction({
         cwd: "/repo",
         repository: "acme/app",
         number: 9,
@@ -991,16 +1118,202 @@ layer("GitHubCliLive", (it) => {
       });
 
       assert.equal(diff.truncated, true);
+      assert.deepStrictEqual(action, { mergeOutcome: "merged" });
       expect(mockedRunProcess.mock.calls[0]?.[1]).toEqual(
         expect.arrayContaining(["pr", "diff", "9", "--repo", "github.com/acme/app", "--patch"]),
       );
+      expect(mockedRunProcess.mock.calls[1]?.[1]).toEqual([
+        "api",
+        "--hostname",
+        "github.com",
+        "--method",
+        "PUT",
+        "repos/acme/app/pulls/9/merge-async",
+        "--input",
+        "-",
+      ]);
+      expect(mockedRunProcess.mock.calls[1]?.[2]).toEqual(
+        expect.objectContaining({
+          allowNonZeroExit: true,
+          stdin: JSON.stringify({ merge_method: "squash", merge_action: "default" }),
+        }),
+      );
+    }),
+  );
+
+  it.effect("loads full stack metadata in bottom-to-top order", () =>
+    Effect.gen(function* () {
+      mockedRunProcess.mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                stackEntry: { position: 2 },
+                stack: {
+                  number: 17,
+                  size: 2,
+                  baseRefName: "main",
+                  entries: {
+                    totalCount: 2,
+                    nodes: [
+                      {
+                        position: 2,
+                        pullRequest: {
+                          number: 12,
+                          title: "UI layer",
+                          url: "https://github.com/acme/app/pull/12",
+                          headRefName: "feature/ui",
+                          baseRefName: "feature/api",
+                          state: "OPEN",
+                          isDraft: false,
+                          mergedAt: null,
+                          mergeable: "UNKNOWN",
+                          mergeStateStatus: "UNKNOWN",
+                        },
+                      },
+                      {
+                        position: 1,
+                        pullRequest: {
+                          number: 11,
+                          title: "API layer",
+                          url: "https://github.com/acme/app/pull/11",
+                          headRefName: "feature/api",
+                          baseRefName: "main",
+                          state: "MERGED",
+                          isDraft: false,
+                          mergedAt: "2026-08-10T10:00:00Z",
+                          mergeable: "MERGEABLE",
+                          mergeStateStatus: "CLEAN",
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+        code: 0,
+        signal: null,
+        timedOut: false,
+      });
+
+      const gh = yield* GitHubCli;
+      const result = yield* gh.getPullRequestStack({
+        cwd: "/repo",
+        repository: "acme/app",
+        number: 12,
+      });
+
+      expect(result).toMatchObject({
+        number: 17,
+        size: 2,
+        position: 2,
+        baseBranch: "main",
+      });
+      expect(result?.entries.map((entry) => [entry.position, entry.number, entry.state])).toEqual([
+        [1, 11, "merged"],
+        [2, 12, "open"],
+      ]);
+      expect(mockedRunProcess.mock.calls[0]?.[1]).toEqual(
+        expect.arrayContaining([
+          "api",
+          "graphql",
+          "--hostname",
+          "github.com",
+          "-F",
+          "number=12",
+          "-F",
+          "first=100",
+        ]),
+      );
+    }),
+  );
+
+  it.effect("falls back to the legacy merge path when async merge is unavailable", () =>
+    Effect.gen(function* () {
+      mockedRunProcess
+        .mockResolvedValueOnce({
+          stdout: "",
+          stderr: "gh: Not Found (HTTP 404)",
+          code: 1,
+          signal: null,
+          timedOut: false,
+        })
+        .mockResolvedValueOnce({
+          stdout: "",
+          stderr: "",
+          code: 0,
+          signal: null,
+          timedOut: false,
+        });
+
+      const gh = yield* GitHubCli;
+      const result = yield* gh.runPullRequestAction({
+        cwd: "/repo",
+        repository: "acme/app",
+        number: 9,
+        action: "merge",
+        mergeMethod: "rebase",
+      });
+
+      expect(result).toEqual({ mergeOutcome: "merged" });
       expect(mockedRunProcess.mock.calls[1]?.[1]).toEqual([
         "pr",
         "merge",
         "9",
         "--repo",
         "github.com/acme/app",
-        "--squash",
+        "--rebase",
+      ]);
+    }),
+  );
+
+  it.effect("polls a pending stack merge until GitHub enqueues it", () =>
+    Effect.gen(function* () {
+      mockedRunProcess
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify({
+            status: "pending",
+            details: { message: "Merge request enqueued.", uuid: "merge-request-1" },
+          }),
+          stderr: "",
+          code: 0,
+          signal: null,
+          timedOut: false,
+        })
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify({
+            status: "enqueued",
+            details: { message: "Pull request was added to the merge queue." },
+          }),
+          stderr: "",
+          code: 0,
+          signal: null,
+          timedOut: false,
+        });
+
+      const gh = yield* GitHubCli;
+      const mergeFiber = yield* gh
+        .runPullRequestAction({
+          cwd: "/repo",
+          repository: "acme/app",
+          number: 12,
+          action: "merge",
+          mergeMethod: "merge",
+        })
+        .pipe(Effect.forkChild);
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust("1 second");
+      const result = yield* Fiber.join(mergeFiber);
+
+      expect(result).toEqual({ mergeOutcome: "enqueued" });
+      expect(mockedRunProcess.mock.calls[1]?.[1]).toEqual([
+        "api",
+        "--hostname",
+        "github.com",
+        "repos/acme/app/pulls/12/merge-async/merge-request-1",
       ]);
     }),
   );

--- a/apps/server/src/git/Layers/GitHubCli.test.ts
+++ b/apps/server/src/git/Layers/GitHubCli.test.ts
@@ -1231,6 +1231,78 @@ layer("GitHubCliLive", (it) => {
     }),
   );
 
+  it.effect("paginates stacks larger than the GraphQL page size", () =>
+    Effect.gen(function* () {
+      const makeEntry = (position: number) => ({
+        position,
+        pullRequest: {
+          number: 1_000 + position,
+          title: `Stack entry ${position}`,
+          url: `https://github.com/acme/app/pull/${1_000 + position}`,
+          headRefName: `feature/stack-${position}`,
+          baseRefName: position === 1 ? "main" : `feature/stack-${position - 1}`,
+          state: "OPEN",
+          isDraft: false,
+          mergedAt: null,
+          mergeable: "MERGEABLE",
+          mergeStateStatus: "CLEAN",
+        },
+      });
+      const makeResponse = (
+        nodes: ReadonlyArray<ReturnType<typeof makeEntry>>,
+        pageInfo: { readonly hasNextPage: boolean; readonly endCursor: string | null },
+      ) =>
+        JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                stackEntry: { position: 101 },
+                stack: {
+                  number: 29,
+                  size: 101,
+                  baseRefName: "main",
+                  entries: { totalCount: 101, nodes, pageInfo },
+                },
+              },
+            },
+          },
+        });
+
+      mockedRunProcess
+        .mockResolvedValueOnce({
+          stdout: makeResponse(
+            Array.from({ length: 100 }, (_, index) => makeEntry(index + 1)),
+            { hasNextPage: true, endCursor: "cursor-100" },
+          ),
+          stderr: "",
+          code: 0,
+          signal: null,
+          timedOut: false,
+        })
+        .mockResolvedValueOnce({
+          stdout: makeResponse([makeEntry(101)], { hasNextPage: false, endCursor: null }),
+          stderr: "",
+          code: 0,
+          signal: null,
+          timedOut: false,
+        });
+
+      const gh = yield* GitHubCli;
+      const result = yield* gh.getPullRequestStack({
+        cwd: "/repo",
+        repository: "acme/app",
+        number: 1_101,
+      });
+
+      expect(result?.entries).toHaveLength(101);
+      expect(result?.entries.at(-1)).toMatchObject({ position: 101, number: 1_101 });
+      expect(mockedRunProcess).toHaveBeenCalledTimes(2);
+      expect(mockedRunProcess.mock.calls[1]?.[1]).toEqual(
+        expect.arrayContaining(["-F", "after=cursor-100"]),
+      );
+    }),
+  );
+
   it.effect("falls back to the legacy merge path when async merge is unavailable", () =>
     Effect.gen(function* () {
       mockedRunProcess

--- a/apps/server/src/git/Layers/GitHubCli.ts
+++ b/apps/server/src/git/Layers/GitHubCli.ts
@@ -11,6 +11,8 @@ import {
   type PullRequestCommit,
   type PullRequestLabel,
   type PullRequestMergeCapabilities,
+  type PullRequestStack,
+  type PullRequestStackSummary,
 } from "@synara/contracts";
 import { githubAvatarUrlForLogin } from "@synara/shared/githubAvatar";
 import {
@@ -283,6 +285,8 @@ const RawGitHubPullRequestWithChecksSchema = Schema.Struct({
 const PULL_REQUEST_REVIEW_THREAD_PAGE_SIZE = 50;
 const PULL_REQUEST_REVIEW_THREAD_PAGE_LIMIT = 5;
 const PULL_REQUEST_REVIEW_COMMENT_LIMIT = 20;
+const PULL_REQUEST_STACK_ENTRY_LIMIT = 100;
+const PULL_REQUEST_ASYNC_MERGE_POLL_LIMIT = 300;
 
 // GraphQL review-threads query: resolved threads are filtered after fetch because GitHub's
 // reviewThreads connection does not expose an unresolved-only argument.
@@ -311,6 +315,53 @@ const PULL_REQUEST_REVIEW_THREADS_QUERY = `query($owner: String!, $repo: String!
     }
   }
 }`;
+
+const PULL_REQUEST_STACK_QUERY = `query($owner: String!, $repo: String!, $number: Int!, $first: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      stackEntry { position }
+      stack {
+        number
+        size
+        baseRefName
+        entries(first: $first) {
+          totalCount
+          nodes {
+            position
+            pullRequest {
+              number
+              title
+              url
+              headRefName
+              baseRefName
+              state
+              isDraft
+              mergedAt
+              mergeable
+              mergeStateStatus
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+function buildPullRequestStackSummariesQuery(numbers: ReadonlyArray<number>): string {
+  const selections = numbers
+    .map(
+      (number) => `    pr_${number}: pullRequest(number: ${number}) {
+      stackEntry { position }
+      stack { number size baseRefName }
+    }`,
+    )
+    .join("\n");
+  return `query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+${selections}
+  }
+}`;
+}
 
 const RawGraphQlErrorSchema = Schema.Struct({
   message: Schema.optional(Schema.NullOr(Schema.String)),
@@ -381,6 +432,104 @@ const RawReviewThreadsResponseSchema = Schema.Struct({
       }),
     ),
   ),
+});
+
+const RawPullRequestStackEntrySchema = Schema.Struct({
+  position: PositiveInt,
+  pullRequest: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        number: PositiveInt,
+        title: TrimmedNonEmptyString,
+        url: TrimmedNonEmptyString,
+        headRefName: TrimmedNonEmptyString,
+        baseRefName: TrimmedNonEmptyString,
+        state: Schema.optional(Schema.NullOr(Schema.String)),
+        isDraft: Schema.optional(Schema.NullOr(Schema.Boolean)),
+        mergedAt: Schema.optional(Schema.NullOr(Schema.String)),
+        mergeable: Schema.optional(Schema.NullOr(Schema.String)),
+        mergeStateStatus: Schema.optional(Schema.NullOr(Schema.String)),
+      }),
+    ),
+  ),
+});
+
+const RawPullRequestStackResponseSchema = Schema.Struct({
+  errors: Schema.optional(Schema.NullOr(Schema.Array(Schema.NullOr(RawGraphQlErrorSchema)))),
+  data: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        repository: Schema.optional(
+          Schema.NullOr(
+            Schema.Struct({
+              pullRequest: Schema.optional(
+                Schema.NullOr(
+                  Schema.Struct({
+                    stackEntry: Schema.optional(
+                      Schema.NullOr(Schema.Struct({ position: PositiveInt })),
+                    ),
+                    stack: Schema.optional(
+                      Schema.NullOr(
+                        Schema.Struct({
+                          number: PositiveInt,
+                          size: PositiveInt,
+                          baseRefName: TrimmedNonEmptyString,
+                          entries: Schema.Struct({
+                            totalCount: PositiveInt,
+                            nodes: Schema.optional(
+                              Schema.NullOr(
+                                Schema.Array(Schema.NullOr(RawPullRequestStackEntrySchema)),
+                              ),
+                            ),
+                          }),
+                        }),
+                      ),
+                    ),
+                  }),
+                ),
+              ),
+            }),
+          ),
+        ),
+      }),
+    ),
+  ),
+});
+
+const RawPullRequestStackSummarySchema = Schema.Struct({
+  stackEntry: Schema.optional(Schema.NullOr(Schema.Struct({ position: PositiveInt }))),
+  stack: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        number: PositiveInt,
+        size: PositiveInt,
+        baseRefName: TrimmedNonEmptyString,
+      }),
+    ),
+  ),
+});
+
+const RawPullRequestStackSummariesResponseSchema = Schema.Struct({
+  errors: Schema.optional(Schema.NullOr(Schema.Array(Schema.NullOr(RawGraphQlErrorSchema)))),
+  data: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        repository: Schema.optional(
+          Schema.NullOr(
+            Schema.Record(Schema.String, Schema.NullOr(RawPullRequestStackSummarySchema)),
+          ),
+        ),
+      }),
+    ),
+  ),
+});
+
+const RawAsyncMergeResultSchema = Schema.Struct({
+  status: Schema.Literals(["pending", "merged", "enqueued", "failed"]),
+  details: Schema.Struct({
+    message: Schema.optional(Schema.NullOr(Schema.String)),
+    uuid: Schema.optional(Schema.NullOr(Schema.String)),
+  }),
 });
 
 function normalizePullRequestSummary(
@@ -522,6 +671,7 @@ function normalizePullRequestListItem(
     ),
     labels: normalizeLabels(raw.labels),
     mergeability: normalizePullRequestMergeability(raw.mergeable),
+    stack: null,
   };
 }
 
@@ -673,7 +823,11 @@ function normalizePullRequestReviewComments(
 }
 
 function getGraphQlErrorDetail(
-  raw: Schema.Schema.Type<typeof RawReviewThreadsResponseSchema>,
+  raw: {
+    readonly errors?:
+      | ReadonlyArray<{ readonly message?: string | null | undefined } | null>
+      | null;
+  },
 ): string | null {
   const messages =
     raw.errors
@@ -693,6 +847,123 @@ function getPullRequestReviewThreadsPageInfo(
     hasNextPage: pageInfo?.hasNextPage === true,
     endCursor: pageInfo?.endCursor?.trim() || null,
   };
+}
+
+function normalizePullRequestStack(
+  raw: Schema.Schema.Type<typeof RawPullRequestStackResponseSchema>,
+  selectedPullRequestNumber: number,
+): Effect.Effect<PullRequestStack | null, GitHubCliError> {
+  const graphQlErrorDetail = getGraphQlErrorDetail(raw);
+  if (graphQlErrorDetail) {
+    return Effect.fail(
+      new GitHubCliError({
+        operation: "getPullRequestStack",
+        detail: graphQlErrorDetail,
+        reason: "other",
+      }),
+    );
+  }
+
+  const pullRequest = raw.data?.repository?.pullRequest;
+  const stack = pullRequest?.stack;
+  const selectedEntry = pullRequest?.stackEntry;
+  if (!stack && !selectedEntry) return Effect.succeed(null);
+  if (!stack || !selectedEntry) {
+    return Effect.fail(
+      new GitHubCliError({
+        operation: "getPullRequestStack",
+        detail: "GitHub returned incomplete pull request stack metadata.",
+        reason: "other",
+      }),
+    );
+  }
+
+  const entries = (stack.entries.nodes ?? [])
+    .flatMap((entry) => {
+      const member = entry?.pullRequest;
+      if (!entry || !member) return [];
+      return [
+        {
+          position: entry.position,
+          number: member.number,
+          title: member.title,
+          url: member.url,
+          headBranch: member.headRefName,
+          baseBranch: member.baseRefName,
+          state: normalizePullRequestState(member),
+          isDraft: member.isDraft === true,
+          mergeability: normalizePullRequestMergeability(member.mergeable),
+          mergeStateStatus: member.mergeStateStatus?.trim() || null,
+        },
+      ];
+    })
+    .toSorted((left, right) => left.position - right.position);
+
+  if (
+    stack.size !== stack.entries.totalCount ||
+    entries.length !== stack.size ||
+    selectedEntry.position > stack.size ||
+    entries.some((entry, index) => entry.position !== index + 1) ||
+    entries[selectedEntry.position - 1]?.number !== selectedPullRequestNumber
+  ) {
+    return Effect.fail(
+      new GitHubCliError({
+        operation: "getPullRequestStack",
+        detail: "GitHub returned a partial or inconsistent pull request stack.",
+        reason: "other",
+      }),
+    );
+  }
+
+  return Effect.succeed({
+    number: stack.number,
+    size: stack.size,
+    position: selectedEntry.position,
+    baseBranch: stack.baseRefName,
+    entries,
+  });
+}
+
+function normalizePullRequestStackSummaries(
+  raw: Schema.Schema.Type<typeof RawPullRequestStackSummariesResponseSchema>,
+  numbers: ReadonlyArray<number>,
+): Effect.Effect<ReadonlyMap<number, PullRequestStackSummary>, GitHubCliError> {
+  const graphQlErrorDetail = getGraphQlErrorDetail(raw);
+  if (graphQlErrorDetail) {
+    return Effect.fail(
+      new GitHubCliError({
+        operation: "listRepositoryPullRequests",
+        detail: graphQlErrorDetail,
+        reason: "other",
+      }),
+    );
+  }
+
+  const repository = raw.data?.repository;
+  if (!repository) {
+    return Effect.fail(
+      new GitHubCliError({
+        operation: "listRepositoryPullRequests",
+        detail: "GitHub returned incomplete pull request stack summaries.",
+        reason: "other",
+      }),
+    );
+  }
+
+  const summaries = new Map<number, PullRequestStackSummary>();
+  for (const number of numbers) {
+    const pullRequest = repository[`pr_${number}`];
+    const stack = pullRequest?.stack;
+    const stackEntry = pullRequest?.stackEntry;
+    if (!stack || !stackEntry || stackEntry.position > stack.size) continue;
+    summaries.set(number, {
+      number: stack.number,
+      size: stack.size,
+      position: stackEntry.position,
+      baseBranch: stack.baseRefName,
+    });
+  }
+  return Effect.succeed(summaries);
 }
 
 function normalizeRepositoryCloneUrls(
@@ -715,11 +986,13 @@ function decodeGitHubJson<S extends Schema.Top>(
     | "getRepositoryCloneUrls"
     | "getPullRequestWithChecks"
     | "getPullRequestReviewComments"
+    | "getPullRequestStack"
     | "listRepositoryPullRequests"
     | "getPullRequestDetail"
     | "getPullRequestListItem"
     | "listReviewRequestedPullRequestNumbers"
-    | "getRepositoryMergeCapabilities",
+    | "getRepositoryMergeCapabilities"
+    | "runPullRequestAction",
   invalidDetail: string,
 ): Effect.Effect<S["Type"], GitHubCliError, S["DecodingServices"]> {
   return Schema.decodeEffect(Schema.fromJsonString(schema))(raw).pipe(
@@ -782,6 +1055,9 @@ const makeGitHubCli = Effect.sync(() => {
           env: { ...process.env, ...input.env, GH_HOST: GITHUB_HOST },
           ...(input.maxBufferBytes !== undefined ? { maxBufferBytes: input.maxBufferBytes } : {}),
           ...(input.outputMode !== undefined ? { outputMode: input.outputMode } : {}),
+          ...(input.allowNonZeroExit !== undefined
+            ? { allowNonZeroExit: input.allowNonZeroExit }
+            : {}),
           ...(input.stdin !== undefined ? { stdin: input.stdin } : {}),
           ...(input.onStdoutChunk !== undefined ? { onStdoutChunk: input.onStdoutChunk } : {}),
           ...(input.onStderrChunk !== undefined ? { onStderrChunk: input.onStderrChunk } : {}),
@@ -979,6 +1255,50 @@ const makeGitHubCli = Effect.sync(() => {
   };
   const repositorySelector = (repository: string) => `${GITHUB_HOST}/${repository}`;
 
+  const enrichPullRequestListItemsWithStack = (input: {
+    cwd: string;
+    repository: string;
+    entries: ReadonlyArray<GitHubPullRequestListItem>;
+  }): Effect.Effect<ReadonlyArray<GitHubPullRequestListItem>> => {
+    const numbers = [...new Set(input.entries.map((entry) => entry.number))];
+    if (numbers.length === 0) return Effect.succeed(input.entries);
+    const [owner = "", repo = ""] = input.repository.split("/");
+    return execute({
+      cwd: input.cwd,
+      args: [
+        "api",
+        "graphql",
+        "--hostname",
+        GITHUB_HOST,
+        "-f",
+        `query=${buildPullRequestStackSummariesQuery(numbers)}`,
+        "-F",
+        `owner=${owner}`,
+        "-F",
+        `repo=${repo}`,
+      ],
+    }).pipe(
+      Effect.flatMap((result) =>
+        decodeGitHubJson(
+          result.stdout.trim(),
+          RawPullRequestStackSummariesResponseSchema,
+          "listRepositoryPullRequests",
+          "GitHub CLI returned invalid pull request stack summaries JSON.",
+        ),
+      ),
+      Effect.flatMap((raw) => normalizePullRequestStackSummaries(raw, numbers)),
+      Effect.map((summaries) =>
+        input.entries.map((entry) => ({
+          ...entry,
+          stack: summaries.get(entry.number) ?? null,
+        })),
+      ),
+      // Stack metadata is a progressive enhancement. A GraphQL/version/auth mismatch must not
+      // make the primary pull request list disappear.
+      Effect.catch(() => Effect.succeed(input.entries)),
+    );
+  };
+
   // One implementation behind both list methods so the field list, decoding, and
   // normalization cannot drift between the open-only and any-state lookups.
   const listPullRequestsWithState = (
@@ -1006,6 +1326,109 @@ const makeGitHubCli = Effect.sync(() => {
     }).pipe(
       Effect.flatMap((result) => decodePullRequestListJson(result.stdout, options.operation)),
     );
+
+  const decodeAsyncMergeResult = (result: Awaited<ReturnType<typeof runProcess>>) => {
+    if (result.timedOut) {
+      return Effect.fail(
+        new GitHubCliError({
+          operation: "runPullRequestAction",
+          detail: "GitHub's asynchronous merge request timed out.",
+          reason: "other",
+        }),
+      );
+    }
+    if (!result.stdout.trim()) {
+      return Effect.fail(
+        new GitHubCliError({
+          operation: "runPullRequestAction",
+          detail:
+            result.stderr.trim() ||
+            `GitHub returned an empty asynchronous merge response (command exit ${result.code ?? "unknown"}).`,
+          reason: "other",
+        }),
+      );
+    }
+    return decodeGitHubJson(
+      result.stdout.trim(),
+      RawAsyncMergeResultSchema,
+      "runPullRequestAction",
+      "GitHub returned an invalid asynchronous merge response.",
+    );
+  };
+
+  const runAsyncPullRequestMerge = (input: {
+    readonly cwd: string;
+    readonly repository: string;
+    readonly number: number;
+    readonly mergeMethod: "merge" | "squash" | "rebase";
+  }): Effect.Effect<
+    { readonly mergeOutcome: "merged" | "enqueued" | "unavailable" },
+    GitHubCliError
+  > =>
+    Effect.gen(function* () {
+      const endpoint = `repos/${input.repository}/pulls/${input.number}/merge-async`;
+      const submission = yield* execute({
+        cwd: input.cwd,
+        args: ["api", "--hostname", GITHUB_HOST, "--method", "PUT", endpoint, "--input", "-"],
+        stdin: JSON.stringify({ merge_method: input.mergeMethod, merge_action: "default" }),
+        // A duplicate in-flight request is HTTP 409 but returns the existing UUID, while a
+        // closed/draft PR is HTTP 400 with a terminal `failed` result. Both bodies are useful.
+        allowNonZeroExit: true,
+      });
+      if (
+        submission.code !== 0 &&
+        /(?:HTTP\s+404|not found)/i.test(`${submission.stdout}\n${submission.stderr}`)
+      ) {
+        // Async merge is a stacked-PR preview API. A repository without the preview returns 404;
+        // its standalone PRs must retain the existing synchronous merge path.
+        return { mergeOutcome: "unavailable" };
+      }
+      let result = yield* decodeAsyncMergeResult(submission);
+
+      for (let pollCount = 0; pollCount <= PULL_REQUEST_ASYNC_MERGE_POLL_LIMIT; pollCount += 1) {
+        switch (result.status) {
+          case "merged":
+            return { mergeOutcome: "merged" };
+          case "enqueued":
+            return { mergeOutcome: "enqueued" };
+          case "failed":
+            return yield* Effect.fail(
+              new GitHubCliError({
+                operation: "runPullRequestAction",
+                detail: result.details.message?.trim() || "GitHub could not merge the pull request.",
+                reason: "other",
+              }),
+            );
+          case "pending": {
+            const uuid = result.details.uuid?.trim();
+            if (!uuid) {
+              return yield* Effect.fail(
+                new GitHubCliError({
+                  operation: "runPullRequestAction",
+                  detail: "GitHub returned a pending merge request without an identifier.",
+                  reason: "other",
+                }),
+              );
+            }
+            if (pollCount === PULL_REQUEST_ASYNC_MERGE_POLL_LIMIT) break;
+            yield* Effect.sleep("1 second");
+            result = yield* execute({
+              cwd: input.cwd,
+              args: ["api", "--hostname", GITHUB_HOST, `${endpoint}/${uuid}`],
+            }).pipe(Effect.flatMap(decodeAsyncMergeResult));
+            break;
+          }
+        }
+      }
+
+      return yield* Effect.fail(
+        new GitHubCliError({
+          operation: "runPullRequestAction",
+          detail: "GitHub's asynchronous merge did not finish within five minutes.",
+          reason: "other",
+        }),
+      );
+    });
 
   const service = {
     execute,
@@ -1053,9 +1476,17 @@ const makeGitHubCli = Effect.sync(() => {
               "--json",
               PULL_REQUEST_LIST_JSON_FIELDS,
             ],
-          }),
+          }).pipe(
+            Effect.flatMap((result) => decodeRepositoryPullRequestListJson(result.stdout)),
+            Effect.flatMap((batch) =>
+              enrichPullRequestListItemsWithStack({
+                cwd: input.cwd,
+                repository,
+                entries: batch.entries,
+              }).pipe(Effect.map((entries) => ({ ...batch, entries }))),
+            ),
+          ),
         ),
-        Effect.flatMap((result) => decodeRepositoryPullRequestListJson(result.stdout)),
       );
     },
     getPullRequestListItem: (input) =>
@@ -1072,26 +1503,34 @@ const makeGitHubCli = Effect.sync(() => {
               "--json",
               PULL_REQUEST_LIST_JSON_FIELDS,
             ],
-          }),
-        ),
-        Effect.flatMap((result) =>
-          decodeGitHubJson(
-            result.stdout.trim(),
-            Schema.Unknown,
-            "getPullRequestListItem",
-            "GitHub CLI returned invalid pull request JSON.",
-          ),
-        ),
-        Effect.flatMap((entry) =>
-          Effect.try({
-            try: () => normalizePullRequestListItem(decodeRawPullRequestListItem(entry)),
-            catch: () =>
-              new GitHubCliError({
-                operation: "getPullRequestListItem",
-                detail: "GitHub CLI returned an unrecognized pull request shape.",
-                reason: "other",
+          }).pipe(
+            Effect.flatMap((result) =>
+              decodeGitHubJson(
+                result.stdout.trim(),
+                Schema.Unknown,
+                "getPullRequestListItem",
+                "GitHub CLI returned invalid pull request JSON.",
+              ),
+            ),
+            Effect.flatMap((entry) =>
+              Effect.try({
+                try: () => normalizePullRequestListItem(decodeRawPullRequestListItem(entry)),
+                catch: () =>
+                  new GitHubCliError({
+                    operation: "getPullRequestListItem",
+                    detail: "GitHub CLI returned an unrecognized pull request shape.",
+                    reason: "other",
+                  }),
               }),
-          }),
+            ),
+            Effect.flatMap((entry) =>
+              enrichPullRequestListItemsWithStack({
+                cwd: input.cwd,
+                repository,
+                entries: [entry],
+              }).pipe(Effect.map((entries) => entries[0] ?? entry)),
+            ),
+          ),
         ),
       ),
     listReviewRequestedPullRequestNumbers: (input) =>
@@ -1150,6 +1589,40 @@ const makeGitHubCli = Effect.sync(() => {
           ),
         ),
         Effect.map(normalizePullRequestDetail),
+      ),
+    getPullRequestStack: (input) =>
+      validateRepository(input.repository, "getPullRequestStack").pipe(
+        Effect.flatMap((repository) => {
+          const [owner = "", repo = ""] = repository.split("/");
+          return execute({
+            cwd: input.cwd,
+            args: [
+              "api",
+              "graphql",
+              "--hostname",
+              GITHUB_HOST,
+              "-f",
+              `query=${PULL_REQUEST_STACK_QUERY}`,
+              "-F",
+              `owner=${owner}`,
+              "-F",
+              `repo=${repo}`,
+              "-F",
+              `number=${input.number}`,
+              "-F",
+              `first=${PULL_REQUEST_STACK_ENTRY_LIMIT}`,
+            ],
+          });
+        }),
+        Effect.flatMap((result) =>
+          decodeGitHubJson(
+            result.stdout.trim(),
+            RawPullRequestStackResponseSchema,
+            "getPullRequestStack",
+            "GitHub CLI returned invalid pull request stack JSON.",
+          ),
+        ),
+        Effect.flatMap((raw) => normalizePullRequestStack(raw, input.number)),
       ),
     getRepositoryMergeCapabilities: (input) =>
       validateRepository(input.repository, "getRepositoryMergeCapabilities").pipe(
@@ -1221,10 +1694,31 @@ const makeGitHubCli = Effect.sync(() => {
         Effect.flatMap((repository) => {
           const reference = String(input.number);
           const repoArgs = ["--repo", repositorySelector(repository)];
+          if (input.action === "merge") {
+            return runAsyncPullRequestMerge({
+              cwd: input.cwd,
+              repository,
+              number: input.number,
+              mergeMethod: input.mergeMethod ?? "merge",
+            }).pipe(
+              Effect.flatMap((result) =>
+                result.mergeOutcome !== "unavailable"
+                  ? Effect.succeed(result)
+                  : execute({
+                      cwd: input.cwd,
+                      args: [
+                        "pr",
+                        "merge",
+                        reference,
+                        ...repoArgs,
+                        `--${input.mergeMethod ?? "merge"}`,
+                      ],
+                    }).pipe(Effect.as({ mergeOutcome: "merged" as const })),
+              ),
+            );
+          }
           const args = (() => {
             switch (input.action) {
-              case "merge":
-                return ["pr", "merge", reference, ...repoArgs, `--${input.mergeMethod ?? "merge"}`];
               case "ready":
                 return ["pr", "ready", reference, ...repoArgs];
               case "draft":
@@ -1233,9 +1727,13 @@ const makeGitHubCli = Effect.sync(() => {
                 return ["pr", "close", reference, ...repoArgs];
               case "reopen":
                 return ["pr", "reopen", reference, ...repoArgs];
+              case "merge":
+                return [];
             }
           })();
-          return execute({ cwd: input.cwd, args }).pipe(Effect.asVoid);
+          return execute({ cwd: input.cwd, args }).pipe(
+            Effect.as({ mergeOutcome: null as const }),
+          );
         }),
       ),
     commentOnPullRequest: (input) =>

--- a/apps/server/src/git/Layers/GitHubCli.ts
+++ b/apps/server/src/git/Layers/GitHubCli.ts
@@ -316,7 +316,7 @@ const PULL_REQUEST_REVIEW_THREADS_QUERY = `query($owner: String!, $repo: String!
   }
 }`;
 
-const PULL_REQUEST_STACK_QUERY = `query($owner: String!, $repo: String!, $number: Int!, $first: Int!) {
+const PULL_REQUEST_STACK_QUERY = `query($owner: String!, $repo: String!, $number: Int!, $first: Int!, $after: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
       stackEntry { position }
@@ -324,7 +324,7 @@ const PULL_REQUEST_STACK_QUERY = `query($owner: String!, $repo: String!, $number
         number
         size
         baseRefName
-        entries(first: $first) {
+        entries(first: $first, after: $after) {
           totalCount
           nodes {
             position
@@ -340,6 +340,10 @@ const PULL_REQUEST_STACK_QUERY = `query($owner: String!, $repo: String!, $number
               mergeable
               mergeStateStatus
             }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
           }
         }
       }
@@ -481,6 +485,14 @@ const RawPullRequestStackResponseSchema = Schema.Struct({
                                 Schema.Array(Schema.NullOr(RawPullRequestStackEntrySchema)),
                               ),
                             ),
+                            pageInfo: Schema.optional(
+                              Schema.NullOr(
+                                Schema.Struct({
+                                  hasNextPage: Schema.optional(Schema.NullOr(Schema.Boolean)),
+                                  endCursor: Schema.optional(Schema.NullOr(Schema.String)),
+                                }),
+                              ),
+                            ),
                           }),
                         }),
                       ),
@@ -495,6 +507,9 @@ const RawPullRequestStackResponseSchema = Schema.Struct({
     ),
   ),
 });
+
+type RawPullRequestStackEntry = Schema.Schema.Type<typeof RawPullRequestStackEntrySchema>;
+type RawPullRequestStackResponse = Schema.Schema.Type<typeof RawPullRequestStackResponseSchema>;
 
 const RawPullRequestStackSummarySchema = Schema.Struct({
   stackEntry: Schema.optional(Schema.NullOr(Schema.Struct({ position: PositiveInt }))),
@@ -849,8 +864,9 @@ function getPullRequestReviewThreadsPageInfo(
 }
 
 function normalizePullRequestStack(
-  raw: Schema.Schema.Type<typeof RawPullRequestStackResponseSchema>,
+  raw: RawPullRequestStackResponse,
   selectedPullRequestNumber: number,
+  rawEntries = raw.data?.repository?.pullRequest?.stack?.entries.nodes ?? [],
 ): Effect.Effect<PullRequestStack | null, GitHubCliError> {
   const graphQlErrorDetail = getGraphQlErrorDetail(raw);
   if (graphQlErrorDetail) {
@@ -877,7 +893,7 @@ function normalizePullRequestStack(
     );
   }
 
-  const entries = (stack.entries.nodes ?? [])
+  const entries = rawEntries
     .flatMap((entry) => {
       const member = entry?.pullRequest;
       if (!entry || !member) return [];
@@ -921,6 +937,17 @@ function normalizePullRequestStack(
     baseBranch: stack.baseRefName,
     entries,
   });
+}
+
+function getPullRequestStackPageInfo(raw: RawPullRequestStackResponse): {
+  hasNextPage: boolean;
+  endCursor: string | null;
+} {
+  const pageInfo = raw.data?.repository?.pullRequest?.stack?.entries.pageInfo;
+  return {
+    hasNextPage: pageInfo?.hasNextPage === true,
+    endCursor: pageInfo?.endCursor?.trim() || null,
+  };
 }
 
 function normalizePullRequestStackSummaries(
@@ -1591,39 +1618,76 @@ const makeGitHubCli = Effect.sync(() => {
         Effect.map(normalizePullRequestDetail),
       ),
     getPullRequestStack: (input) =>
-      validateRepository(input.repository, "getPullRequestStack").pipe(
-        Effect.flatMap((repository) => {
-          const [owner = "", repo = ""] = repository.split("/");
-          return execute({
-            cwd: input.cwd,
-            args: [
-              "api",
-              "graphql",
-              "--hostname",
-              GITHUB_HOST,
-              "-f",
-              `query=${PULL_REQUEST_STACK_QUERY}`,
-              "-F",
-              `owner=${owner}`,
-              "-F",
-              `repo=${repo}`,
-              "-F",
-              `number=${input.number}`,
-              "-F",
-              `first=${PULL_REQUEST_STACK_ENTRY_LIMIT}`,
-            ],
+      Effect.gen(function* () {
+        const repository = yield* validateRepository(input.repository, "getPullRequestStack");
+        const [owner = "", repo = ""] = repository.split("/");
+        const loadPage = (after: string | null) =>
+          Effect.gen(function* () {
+            const result = yield* execute({
+              cwd: input.cwd,
+              args: [
+                "api",
+                "graphql",
+                "--hostname",
+                GITHUB_HOST,
+                "-f",
+                `query=${PULL_REQUEST_STACK_QUERY}`,
+                "-F",
+                `owner=${owner}`,
+                "-F",
+                `repo=${repo}`,
+                "-F",
+                `number=${input.number}`,
+                "-F",
+                `first=${PULL_REQUEST_STACK_ENTRY_LIMIT}`,
+                ...(after ? ["-F", `after=${after}`] : []),
+              ],
+            });
+            const page = yield* decodeGitHubJson(
+              result.stdout.trim(),
+              RawPullRequestStackResponseSchema,
+              "getPullRequestStack",
+              "GitHub CLI returned invalid pull request stack JSON.",
+            );
+            const graphQlErrorDetail = getGraphQlErrorDetail(page);
+            if (graphQlErrorDetail) {
+              return yield* Effect.fail(
+                new GitHubCliError({
+                  operation: "getPullRequestStack",
+                  detail: graphQlErrorDetail,
+                  reason: "other",
+                }),
+              );
+            }
+            return page;
           });
-        }),
-        Effect.flatMap((result) =>
-          decodeGitHubJson(
-            result.stdout.trim(),
-            RawPullRequestStackResponseSchema,
-            "getPullRequestStack",
-            "GitHub CLI returned invalid pull request stack JSON.",
-          ),
-        ),
-        Effect.flatMap((raw) => normalizePullRequestStack(raw, input.number)),
-      ),
+
+        const firstPage = yield* loadPage(null);
+        const entries: Array<RawPullRequestStackEntry | null> = [];
+        const seenCursors = new Set<string>();
+        let page = firstPage;
+
+        while (true) {
+          entries.push(...(page.data?.repository?.pullRequest?.stack?.entries.nodes ?? []));
+          const pageInfo = getPullRequestStackPageInfo(page);
+          if (!pageInfo.hasNextPage) {
+            break;
+          }
+          if (pageInfo.endCursor === null || seenCursors.has(pageInfo.endCursor)) {
+            return yield* Effect.fail(
+              new GitHubCliError({
+                operation: "getPullRequestStack",
+                detail: "GitHub returned invalid pull request stack pagination metadata.",
+                reason: "other",
+              }),
+            );
+          }
+          seenCursors.add(pageInfo.endCursor);
+          page = yield* loadPage(pageInfo.endCursor);
+        }
+
+        return yield* normalizePullRequestStack(firstPage, input.number, entries);
+      }),
     getRepositoryMergeCapabilities: (input) =>
       validateRepository(input.repository, "getRepositoryMergeCapabilities").pipe(
         Effect.flatMap((repository) =>

--- a/apps/server/src/git/Layers/GitHubCli.ts
+++ b/apps/server/src/git/Layers/GitHubCli.ts
@@ -822,13 +822,12 @@ function normalizePullRequestReviewComments(
   return comments;
 }
 
-function getGraphQlErrorDetail(
-  raw: {
-    readonly errors?:
-      | ReadonlyArray<{ readonly message?: string | null | undefined } | null>
-      | null;
-  },
-): string | null {
+function getGraphQlErrorDetail(raw: {
+  readonly errors?:
+    | ReadonlyArray<{ readonly message?: string | null | undefined } | null>
+    | null
+    | undefined;
+}): string | null {
   const messages =
     raw.errors
       ?.flatMap((error) => {
@@ -1395,7 +1394,8 @@ const makeGitHubCli = Effect.sync(() => {
             return yield* Effect.fail(
               new GitHubCliError({
                 operation: "runPullRequestAction",
-                detail: result.details.message?.trim() || "GitHub could not merge the pull request.",
+                detail:
+                  result.details.message?.trim() || "GitHub could not merge the pull request.",
                 reason: "other",
               }),
             );
@@ -1691,50 +1691,58 @@ const makeGitHubCli = Effect.sync(() => {
       ),
     runPullRequestAction: (input) =>
       validateRepository(input.repository, "runPullRequestAction").pipe(
-        Effect.flatMap((repository) => {
-          const reference = String(input.number);
-          const repoArgs = ["--repo", repositorySelector(repository)];
-          if (input.action === "merge") {
-            return runAsyncPullRequestMerge({
-              cwd: input.cwd,
-              repository,
-              number: input.number,
-              mergeMethod: input.mergeMethod ?? "merge",
-            }).pipe(
-              Effect.flatMap((result) =>
-                result.mergeOutcome !== "unavailable"
-                  ? Effect.succeed(result)
-                  : execute({
-                      cwd: input.cwd,
-                      args: [
-                        "pr",
-                        "merge",
-                        reference,
-                        ...repoArgs,
-                        `--${input.mergeMethod ?? "merge"}`,
-                      ],
-                    }).pipe(Effect.as({ mergeOutcome: "merged" as const })),
-              ),
-            );
-          }
-          const args = (() => {
+        Effect.flatMap(
+          (
+            repository,
+          ): Effect.Effect<
+            { readonly mergeOutcome: "merged" | "enqueued" | null },
+            GitHubCliError
+          > => {
+            const reference = String(input.number);
+            const repoArgs = ["--repo", repositorySelector(repository)];
+            if (input.action === "merge") {
+              return runAsyncPullRequestMerge({
+                cwd: input.cwd,
+                repository,
+                number: input.number,
+                mergeMethod: input.mergeMethod ?? "merge",
+              }).pipe(
+                Effect.flatMap((result) =>
+                  result.mergeOutcome !== "unavailable"
+                    ? Effect.succeed({ mergeOutcome: result.mergeOutcome })
+                    : execute({
+                        cwd: input.cwd,
+                        args: [
+                          "pr",
+                          "merge",
+                          reference,
+                          ...repoArgs,
+                          `--${input.mergeMethod ?? "merge"}`,
+                        ],
+                      }).pipe(Effect.as({ mergeOutcome: "merged" as const })),
+                ),
+              );
+            }
+            let args: string[];
             switch (input.action) {
               case "ready":
-                return ["pr", "ready", reference, ...repoArgs];
+                args = ["pr", "ready", reference, ...repoArgs];
+                break;
               case "draft":
-                return ["pr", "ready", reference, ...repoArgs, "--undo"];
+                args = ["pr", "ready", reference, ...repoArgs, "--undo"];
+                break;
               case "close":
-                return ["pr", "close", reference, ...repoArgs];
+                args = ["pr", "close", reference, ...repoArgs];
+                break;
               case "reopen":
-                return ["pr", "reopen", reference, ...repoArgs];
-              case "merge":
-                return [];
+                args = ["pr", "reopen", reference, ...repoArgs];
+                break;
             }
-          })();
-          return execute({ cwd: input.cwd, args }).pipe(
-            Effect.as({ mergeOutcome: null as const }),
-          );
-        }),
+            return execute({ cwd: input.cwd, args }).pipe(
+              Effect.as({ mergeOutcome: null } as const),
+            );
+          },
+        ),
       ),
     commentOnPullRequest: (input) =>
       validateRepository(input.repository, "commentOnPullRequest").pipe(

--- a/apps/server/src/git/Services/GitHubCli.ts
+++ b/apps/server/src/git/Services/GitHubCli.ts
@@ -18,6 +18,8 @@ import type {
   PullRequestLabel,
   PullRequestMergeCapabilities,
   PullRequestMergeMethod,
+  PullRequestStack,
+  PullRequestStackSummary,
   PullRequestState,
 } from "@synara/contracts";
 
@@ -82,6 +84,7 @@ export interface GitHubPullRequestListItem {
   readonly reviewRequestLogins: ReadonlyArray<string>;
   readonly labels: ReadonlyArray<PullRequestLabel>;
   readonly mergeability: "mergeable" | "conflicting" | "unknown";
+  readonly stack: PullRequestStackSummary | null;
 }
 
 /** Internal list result retaining the raw array cardinality before malformed entries are dropped. */
@@ -132,6 +135,7 @@ export interface GitHubCliShape {
     readonly timeoutMs?: number;
     readonly maxBufferBytes?: number;
     readonly outputMode?: "error" | "truncate";
+    readonly allowNonZeroExit?: boolean;
     /** Piped to the child's stdin — for payloads that must never appear in argv. */
     readonly stdin?: string;
     readonly env?: NodeJS.ProcessEnv;
@@ -180,6 +184,13 @@ export interface GitHubCliShape {
     readonly number: number;
   }) => Effect.Effect<GitHubPullRequestDetailData, GitHubCliError>;
 
+  /** Read the selected PR's full GitHub stack, or null for a standalone pull request. */
+  readonly getPullRequestStack: (input: {
+    readonly cwd: string;
+    readonly repository: string;
+    readonly number: number;
+  }) => Effect.Effect<PullRequestStack | null, GitHubCliError>;
+
   readonly getRepositoryMergeCapabilities: (input: {
     readonly cwd: string;
     readonly repository: string;
@@ -197,7 +208,10 @@ export interface GitHubCliShape {
     readonly number: number;
     readonly action: "merge" | "ready" | "draft" | "close" | "reopen";
     readonly mergeMethod?: PullRequestMergeMethod;
-  }) => Effect.Effect<void, GitHubCliError>;
+  }) => Effect.Effect<
+    { readonly mergeOutcome: "merged" | "enqueued" | null },
+    GitHubCliError
+  >;
 
   /**
    * Post an issue comment on a pull request as the authenticated gh user.

--- a/apps/server/src/git/Services/GitHubCli.ts
+++ b/apps/server/src/git/Services/GitHubCli.ts
@@ -208,10 +208,7 @@ export interface GitHubCliShape {
     readonly number: number;
     readonly action: "merge" | "ready" | "draft" | "close" | "reopen";
     readonly mergeMethod?: PullRequestMergeMethod;
-  }) => Effect.Effect<
-    { readonly mergeOutcome: "merged" | "enqueued" | null },
-    GitHubCliError
-  >;
+  }) => Effect.Effect<{ readonly mergeOutcome: "merged" | "enqueued" | null }, GitHubCliError>;
 
   /**
    * Post an issue comment on a pull request as the authenticated gh user.

--- a/apps/server/src/git/testing/fakeGitHubCli.ts
+++ b/apps/server/src/git/testing/fakeGitHubCli.ts
@@ -12,6 +12,7 @@ import type {
   GitPullRequestCheck,
   GitPullRequestComment,
   PullRequestMergeCapabilities,
+  PullRequestStack,
 } from "@synara/contracts";
 
 import { GitHubCliError } from "../Errors.ts";
@@ -54,10 +55,12 @@ export interface FakeGhScenario {
   viewerLogin?: string;
   repositoryPullRequestListJson?: string;
   pullRequestDetail?: GitHubPullRequestDetailData;
+  pullRequestStack?: PullRequestStack | null;
   pullRequestListItems?: GitHubPullRequestListItem[];
   reviewRequestedPullRequestNumbers?: number[];
   mergeCapabilities?: PullRequestMergeCapabilities;
   pullRequestDiff?: { patch: string; truncated: boolean };
+  mergeOutcome?: "merged" | "enqueued";
 }
 
 export type FakePullRequest = NonNullable<FakeGhScenario["pullRequest"]>;
@@ -306,6 +309,12 @@ export function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
               }),
             );
       },
+      getPullRequestStack: (input) => {
+        ghCalls.push(`graphql stack ${input.number} --repo ${input.repository}`);
+        return scenario.failWith
+          ? Effect.fail(scenario.failWith)
+          : Effect.succeed(scenario.pullRequestStack ?? null);
+      },
       getRepositoryMergeCapabilities: (input) => {
         ghCalls.push(`repo view ${input.repository} --json merge-capabilities`);
         return Effect.succeed(
@@ -325,7 +334,9 @@ export function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
         ghCalls.push(
           `pr action ${input.action} ${input.number} --repo ${input.repository}${input.mergeMethod ? ` --${input.mergeMethod}` : ""}`,
         );
-        return scenario.failWith ? Effect.fail(scenario.failWith) : Effect.void;
+        return scenario.failWith
+          ? Effect.fail(scenario.failWith)
+          : Effect.succeed({ mergeOutcome: scenario.mergeOutcome ?? null });
       },
       getPullRequestListItem: (input) => {
         ghCalls.push(`pr view ${input.number} --repo ${input.repository} (list-item)`);

--- a/apps/server/src/orchestration/forkThreadTitle.ts
+++ b/apps/server/src/orchestration/forkThreadTitle.ts
@@ -6,8 +6,8 @@ interface ForkLineageThread {
   readonly id: string;
   readonly projectId: string;
   readonly title: string;
-  readonly forkSourceThreadId?: string | null;
-  readonly sidechatSourceThreadId?: string | null;
+  readonly forkSourceThreadId?: string | null | undefined;
+  readonly sidechatSourceThreadId?: string | null | undefined;
 }
 
 interface LineageRoot {

--- a/apps/server/src/pullRequests.logic.test.ts
+++ b/apps/server/src/pullRequests.logic.test.ts
@@ -44,6 +44,7 @@ function makeEntry(overrides: Partial<PullRequestListEntry> = {}): PullRequestLi
       },
     ],
     mergeability: "unknown",
+    stack: null,
     labels: [],
     ...overrides,
   };

--- a/apps/server/src/pullRequests.logic.ts
+++ b/apps/server/src/pullRequests.logic.ts
@@ -124,6 +124,7 @@ export function buildPullRequestListEntry(input: {
       },
     ],
     mergeability: pullRequest.mergeability,
+    stack: pullRequest.stack,
     labels: pullRequest.labels,
   };
 }

--- a/apps/server/src/pullRequests/Layers/PullRequestService.test.ts
+++ b/apps/server/src/pullRequests/Layers/PullRequestService.test.ts
@@ -52,6 +52,7 @@ function makeItem(number: number, repository = "acme/shared"): GitHubPullRequest
     reviewRequestLogins: [],
     labels: [],
     mergeability: "unknown",
+    stack: null,
   };
 }
 
@@ -112,7 +113,12 @@ describe("PullRequestService", () => {
       listRepositoryPullRequests: () =>
         Effect.sync(() => {
           listReads += 1;
-          return makeBatch([makeItem(1)]);
+          return makeBatch([
+            {
+              ...makeItem(1),
+              stack: { number: 2, size: 3, position: 1, baseBranch: "main" },
+            },
+          ]);
         }),
     };
 
@@ -138,6 +144,12 @@ describe("PullRequestService", () => {
     expect(result.entries).toHaveLength(1);
     expect(result.entries[0]?.projectId).toBe(projectB.id);
     expect(result.entries[0]?.projectContexts).toHaveLength(2);
+    expect(result.entries[0]?.stack).toEqual({
+      number: 2,
+      size: 3,
+      position: 1,
+      baseBranch: "main",
+    });
     expect(result.repositoryBatches).toHaveLength(1);
   });
 

--- a/apps/server/src/pullRequests/pullRequestOperations.test.ts
+++ b/apps/server/src/pullRequests/pullRequestOperations.test.ts
@@ -2,6 +2,7 @@ import { ProjectId, type OrchestrationProject } from "@synara/contracts";
 import { Deferred, Effect, Fiber } from "effect";
 import { describe, expect, it } from "vitest";
 
+import { GitHubCliError } from "../git/Errors";
 import type { GitHubPullRequestDetailData } from "../git/Services/GitHubCli";
 import { createGitHubCliWithFakeGh } from "../git/testing/fakeGitHubCli";
 import type { ProjectPullRequestPinsShape } from "../persistence/Services/ProjectPullRequestPins";
@@ -107,5 +108,46 @@ describe("makePullRequestOperations", () => {
         }),
       ),
     );
+  });
+
+  it("keeps pull request detail available when stack metadata cannot be loaded", async () => {
+    const base = createGitHubCliWithFakeGh().service;
+    const pins: ProjectPullRequestPinsShape = {
+      listByProjectIds: () => Effect.succeed([]),
+      setPinned: () => Effect.void,
+    };
+    const operations = makePullRequestOperations({
+      github: {
+        ...base,
+        getPullRequestDetail: () => Effect.succeed(detail),
+        getPullRequestStack: () =>
+          Effect.fail(
+            new GitHubCliError({
+              operation: "getPullRequestStack",
+              detail: "Stack GraphQL is unavailable.",
+            }),
+          ),
+      },
+      pins,
+      findProject: () => Effect.succeed(project),
+      validateRepository: (repository) => Effect.succeed(repository),
+      validateProjectRepository: (_project, repository) => Effect.succeed(repository),
+      loadMergeCapabilities: () =>
+        Effect.succeed({
+          merge: true,
+          squash: true,
+          rebase: true,
+          deleteBranchOnMerge: false,
+        }),
+      withGitHubRead: (effect) => effect,
+      finalizeMutationCaches: () => Effect.void,
+    });
+
+    const result = await Effect.runPromise(
+      operations.detail({ projectId: project.id, repository: "acme/widgets", number: 42 }),
+    );
+
+    expect(result.stack).toBeNull();
+    expect(result.number).toBe(42);
   });
 });

--- a/apps/server/src/pullRequests/pullRequestOperations.test.ts
+++ b/apps/server/src/pullRequests/pullRequestOperations.test.ts
@@ -1,9 +1,9 @@
 import { ProjectId, type OrchestrationProject } from "@synara/contracts";
 import { Deferred, Effect, Fiber } from "effect";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { GitHubCliError } from "../git/Errors";
-import type { GitHubPullRequestDetailData } from "../git/Services/GitHubCli";
+import type { GitHubCliShape, GitHubPullRequestDetailData } from "../git/Services/GitHubCli";
 import { createGitHubCliWithFakeGh } from "../git/testing/fakeGitHubCli";
 import type { ProjectPullRequestPinsShape } from "../persistence/Services/ProjectPullRequestPins";
 import { makePullRequestOperations } from "./pullRequestOperations";
@@ -51,6 +51,29 @@ const detail: GitHubPullRequestDetailData = {
   comments: [],
   commits: [],
 };
+
+function makeTestOperations(github: GitHubCliShape) {
+  const pins: ProjectPullRequestPinsShape = {
+    listByProjectIds: () => Effect.succeed([]),
+    setPinned: () => Effect.void,
+  };
+  return makePullRequestOperations({
+    github,
+    pins,
+    findProject: () => Effect.succeed(project),
+    validateRepository: (repository) => Effect.succeed(repository),
+    validateProjectRepository: (_project, repository) => Effect.succeed(repository),
+    loadMergeCapabilities: () =>
+      Effect.succeed({
+        merge: true,
+        squash: true,
+        rebase: true,
+        deleteBranchOnMerge: false,
+      }),
+    withGitHubRead: (effect) => effect,
+    finalizeMutationCaches: () => Effect.void,
+  });
+}
 
 describe("makePullRequestOperations", () => {
   it("starts detail, merge-capability, and review-comment reads together", async () => {
@@ -112,35 +135,16 @@ describe("makePullRequestOperations", () => {
 
   it("keeps pull request detail available when stack metadata cannot be loaded", async () => {
     const base = createGitHubCliWithFakeGh().service;
-    const pins: ProjectPullRequestPinsShape = {
-      listByProjectIds: () => Effect.succeed([]),
-      setPinned: () => Effect.void,
-    };
-    const operations = makePullRequestOperations({
-      github: {
-        ...base,
-        getPullRequestDetail: () => Effect.succeed(detail),
-        getPullRequestStack: () =>
-          Effect.fail(
-            new GitHubCliError({
-              operation: "getPullRequestStack",
-              detail: "Stack GraphQL is unavailable.",
-            }),
-          ),
-      },
-      pins,
-      findProject: () => Effect.succeed(project),
-      validateRepository: (repository) => Effect.succeed(repository),
-      validateProjectRepository: (_project, repository) => Effect.succeed(repository),
-      loadMergeCapabilities: () =>
-        Effect.succeed({
-          merge: true,
-          squash: true,
-          rebase: true,
-          deleteBranchOnMerge: false,
-        }),
-      withGitHubRead: (effect) => effect,
-      finalizeMutationCaches: () => Effect.void,
+    const operations = makeTestOperations({
+      ...base,
+      getPullRequestDetail: () => Effect.succeed(detail),
+      getPullRequestStack: () =>
+        Effect.fail(
+          new GitHubCliError({
+            operation: "getPullRequestStack",
+            detail: "Stack GraphQL is unavailable.",
+          }),
+        ),
     });
 
     const result = await Effect.runPromise(
@@ -148,6 +152,36 @@ describe("makePullRequestOperations", () => {
     );
 
     expect(result.stack).toBeNull();
+    expect(result.stackMetadataIncomplete).toBe(true);
     expect(result.number).toBe(42);
+  });
+
+  it("does not merge when stack metadata cannot be verified", async () => {
+    const base = createGitHubCliWithFakeGh().service;
+    const runPullRequestAction = vi.fn(base.runPullRequestAction);
+    const operations = makeTestOperations({
+      ...base,
+      getPullRequestStack: () =>
+        Effect.fail(
+          new GitHubCliError({
+            operation: "getPullRequestStack",
+            detail: "Stack GraphQL is unavailable.",
+          }),
+        ),
+      runPullRequestAction,
+    });
+
+    const exit = await Effect.runPromiseExit(
+      operations.action({
+        projectId: project.id,
+        repository: "acme/widgets",
+        number: 42,
+        action: "merge",
+        mergeMethod: "squash",
+      }),
+    );
+
+    expect(exit._tag).toBe("Failure");
+    expect(runPullRequestAction).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/pullRequests/pullRequestOperations.ts
+++ b/apps/server/src/pullRequests/pullRequestOperations.ts
@@ -64,13 +64,15 @@ export function makePullRequestOperations(dependencies: {
                 Effect.succeed({ comments: [], truncated: false, incomplete: true }),
               ),
             ),
-          dependencies.withGitHubRead(
-            dependencies.github.getPullRequestStack({
-              cwd: project.workspaceRoot,
-              repository,
-              number,
-            }),
-          ),
+          dependencies
+            .withGitHubRead(
+              dependencies.github.getPullRequestStack({
+                cwd: project.workspaceRoot,
+                repository,
+                number,
+              }),
+            )
+            .pipe(Effect.catch(() => Effect.succeed(null))),
         ],
         { concurrency: 4 },
       );

--- a/apps/server/src/pullRequests/pullRequestOperations.ts
+++ b/apps/server/src/pullRequests/pullRequestOperations.ts
@@ -38,7 +38,7 @@ export function makePullRequestOperations(dependencies: {
     Effect.gen(function* () {
       const repository = yield* dependencies.validateProjectRepository(project, repositoryInput);
       const [owner = "", repo = ""] = repository.split("/");
-      const [detail, mergeCapabilities, reviewCommentsResult, stack] = yield* Effect.all(
+      const [detail, mergeCapabilities, reviewCommentsResult, stackResult] = yield* Effect.all(
         [
           dependencies.withGitHubRead(
             dependencies.github.getPullRequestDetail({
@@ -72,7 +72,10 @@ export function makePullRequestOperations(dependencies: {
                 number,
               }),
             )
-            .pipe(Effect.catch(() => Effect.succeed(null))),
+            .pipe(
+              Effect.map((stack) => ({ stack, incomplete: false as const })),
+              Effect.catch(() => Effect.succeed({ stack: null, incomplete: true as const })),
+            ),
         ],
         { concurrency: 4 },
       );
@@ -107,7 +110,8 @@ export function makePullRequestOperations(dependencies: {
         commentsTruncated: reviewCommentsResult.truncated,
         commentsIncomplete: reviewCommentsResult.incomplete,
         mergeCapabilities,
-        stack,
+        stack: stackResult.stack,
+        stackMetadataIncomplete: stackResult.incomplete,
       } satisfies PullRequestDetail;
     });
 
@@ -144,6 +148,13 @@ export function makePullRequestOperations(dependencies: {
             new Error(`The repository does not allow the ${mergeMethod} merge method.`),
           );
         }
+        yield* dependencies.withGitHubRead(
+          dependencies.github.getPullRequestStack({
+            cwd: project.workspaceRoot,
+            repository,
+            number: input.number,
+          }),
+        );
       }
       const result = yield* dependencies.github
         .runPullRequestAction({

--- a/apps/server/src/pullRequests/pullRequestOperations.ts
+++ b/apps/server/src/pullRequests/pullRequestOperations.ts
@@ -38,7 +38,7 @@ export function makePullRequestOperations(dependencies: {
     Effect.gen(function* () {
       const repository = yield* dependencies.validateProjectRepository(project, repositoryInput);
       const [owner = "", repo = ""] = repository.split("/");
-      const [detail, mergeCapabilities, reviewCommentsResult] = yield* Effect.all(
+      const [detail, mergeCapabilities, reviewCommentsResult, stack] = yield* Effect.all(
         [
           dependencies.withGitHubRead(
             dependencies.github.getPullRequestDetail({
@@ -64,8 +64,15 @@ export function makePullRequestOperations(dependencies: {
                 Effect.succeed({ comments: [], truncated: false, incomplete: true }),
               ),
             ),
+          dependencies.withGitHubRead(
+            dependencies.github.getPullRequestStack({
+              cwd: project.workspaceRoot,
+              repository,
+              number,
+            }),
+          ),
         ],
-        { concurrency: 3 },
+        { concurrency: 4 },
       );
       const comments = [
         ...detail.comments,
@@ -98,6 +105,7 @@ export function makePullRequestOperations(dependencies: {
         commentsTruncated: reviewCommentsResult.truncated,
         commentsIncomplete: reviewCommentsResult.incomplete,
         mergeCapabilities,
+        stack,
       } satisfies PullRequestDetail;
     });
 
@@ -135,7 +143,7 @@ export function makePullRequestOperations(dependencies: {
           );
         }
       }
-      yield* dependencies.github
+      const result = yield* dependencies.github
         .runPullRequestAction({
           cwd: project.workspaceRoot,
           repository,
@@ -155,6 +163,7 @@ export function makePullRequestOperations(dependencies: {
         repository,
         number: input.number,
         workspaceRoot: project.workspaceRoot,
+        mergeOutcome: result.mergeOutcome,
       };
     });
 
@@ -181,6 +190,7 @@ export function makePullRequestOperations(dependencies: {
         repository,
         number: input.number,
         workspaceRoot: project.workspaceRoot,
+        mergeOutcome: null,
       };
     });
 

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -139,6 +139,8 @@ beforeAll(() => {
 });
 
 describe("MessagesTimeline", () => {
+  // The first test pays the full dynamic-import cost of the MessagesTimeline
+  // module graph, which can exceed 10s under CI thread contention.
   it("renders an accent deep link to the immediate fork source", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const markup = renderToStaticMarkup(
@@ -161,7 +163,7 @@ describe("MessagesTimeline", () => {
     expect(markup.indexOf('data-fork-source-divider="true"')).toBeLessThan(
       markup.indexOf("Fork-only turn"),
     );
-  });
+  }, 30_000);
 
   it("keeps the divider after imported history while waiting for the first fork turn", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
@@ -221,11 +223,7 @@ describe("MessagesTimeline", () => {
     expect(markup).not.toContain('data-index="0"');
     expect(markup).not.toContain('class="relative" style="height:');
     expect(markup).toContain('data-timeline-row-kind="message"');
-    // First test in the file pays the full dynamic-import cost of the
-    // MessagesTimeline module graph, which exceeds 10s under CI thread
-    // contention (observed flaking on 4-thread runners while passing in
-    // ~2s locally).
-  }, 30_000);
+  });
 
   it("renders assistant math through the shared markdown renderer", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");

--- a/apps/web/src/components/chat/SingleChatSurface.tsx
+++ b/apps/web/src/components/chat/SingleChatSurface.tsx
@@ -803,6 +803,12 @@ export function SingleChatSurface(props: {
               pane={pane}
               pollingEnabled={context.isVisible}
               onClose={() => closePane(props.threadId, pane.id)}
+              onSelectPullRequest={(number) =>
+                updatePane(props.threadId, pane.id, {
+                  pullRequestNumber: number,
+                  pullRequestInitialTab: "summary",
+                })
+              }
             />
           </Suspense>
         );

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -79,7 +79,7 @@ import { PullRequestStackPopover } from "./PullRequestStackPopover";
 import { PullRequestTimelineTab } from "./PullRequestTimelineTab";
 import { PullRequestsUnavailableState } from "./PullRequestsUnavailableState";
 import { PullRequestWarningNote } from "./PullRequestWarningNote";
-import { assessPullRequestStack } from "./pullRequestStack.logic";
+import { assessPullRequestStack, pullRequestMergeBlocker } from "./pullRequestStack.logic";
 
 type DetailTab = "summary" | "timeline" | "code";
 
@@ -328,12 +328,7 @@ export function PullRequestDetailPanel({
     : null;
   const stackAssessment = detail?.stack ? assessPullRequestStack(detail.stack) : null;
   const stackMergeTargetCount = stackAssessment?.mergeTargetCount ?? 0;
-  const mergeBlocker =
-    stackAssessment?.canAttemptMerge === false
-      ? (stackAssessment.blocker ?? "This stack is not ready to merge.")
-      : detail?.mergeability === "conflicting"
-        ? "Resolve merge conflicts before merging"
-        : null;
+  const mergeBlocker = detail ? pullRequestMergeBlocker(detail, stackAssessment) : null;
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col bg-[var(--color-background-surface)] text-foreground">
@@ -591,6 +586,11 @@ export function PullRequestDetailPanel({
           </Empty>
         ) : (
           <div className="flex h-full min-h-0 flex-col">
+            {detail.stackMetadataIncomplete === true ? (
+              <PullRequestWarningNote shape="banner" className="shrink-0" role="status">
+                Stack details could not be loaded. Refresh before merging.
+              </PullRequestWarningNote>
+            ) : null}
             {detailErrorState.backgroundError ? (
               <PullRequestWarningNote shape="banner" className="shrink-0" role="status">
                 Could not refresh pull request details. Showing saved data.

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -75,9 +75,11 @@ import { ensureNativeApi } from "~/nativeApi";
 import { useHandleNewThread } from "~/hooks/useHandleNewThread";
 import { copyTextToClipboard } from "~/hooks/useCopyToClipboard";
 import { PullRequestSummaryTab } from "./PullRequestSummaryTab";
+import { PullRequestStackPopover } from "./PullRequestStackPopover";
 import { PullRequestTimelineTab } from "./PullRequestTimelineTab";
 import { PullRequestsUnavailableState } from "./PullRequestsUnavailableState";
 import { PullRequestWarningNote } from "./PullRequestWarningNote";
+import { assessPullRequestStack } from "./pullRequestStack.logic";
 
 type DetailTab = "summary" | "timeline" | "code";
 
@@ -131,11 +133,13 @@ export function PullRequestDetailPanel({
   input,
   initialTab: initialTabProp,
   onClose,
+  onSelectPullRequest,
   pollingEnabled: pollingEnabledProp,
 }: {
   input: PullRequestDetailInput;
   initialTab?: DetailTab;
   onClose?: () => void;
+  onSelectPullRequest?: (number: number) => void;
   pollingEnabled?: boolean;
 }) {
   const initialTab = initialTabProp ?? "summary";
@@ -197,8 +201,16 @@ export function PullRequestDetailPanel({
         action,
         ...(method ? { mergeMethod: method } : {}),
       })
-      .then(() => {
-        toastManager.add({ type: "success", title: ACTION_SUCCESS_LABELS[action] });
+      .then((result) => {
+        const title =
+          action === "merge" && result.mergeOutcome === "enqueued"
+            ? detail?.stack
+              ? "Stack added to merge queue"
+              : "Pull request added to merge queue"
+            : action === "merge" && detail?.stack
+              ? "Stack merged"
+              : ACTION_SUCCESS_LABELS[action];
+        toastManager.add({ type: "success", title });
       })
       .catch((error: unknown) => {
         toastManager.add({
@@ -314,6 +326,14 @@ export function PullRequestDetailPanel({
   const pendingAction = actionMutation.isPending
     ? (actionMutation.variables?.action ?? null)
     : null;
+  const stackAssessment = detail?.stack ? assessPullRequestStack(detail.stack) : null;
+  const stackMergeTargetCount = stackAssessment?.mergeTargetCount ?? 0;
+  const mergeBlocker =
+    stackAssessment?.canAttemptMerge === false
+      ? (stackAssessment.blocker ?? "This stack is not ready to merge.")
+      : detail?.mergeability === "conflicting"
+        ? "Resolve merge conflicts before merging"
+        : null;
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col bg-[var(--color-background-surface)] text-foreground">
@@ -344,6 +364,13 @@ export function PullRequestDetailPanel({
         <div className="ml-auto flex shrink-0 items-center gap-1">
           {detail ? (
             <>
+              {detail.stack ? (
+                <PullRequestStackPopover
+                  stack={detail.stack}
+                  currentNumber={detail.number}
+                  {...(onSelectPullRequest ? { onSelectPullRequest } : {})}
+                />
+              ) : null}
               <IconButton
                 variant="chrome"
                 label="Open in external browser"
@@ -397,7 +424,7 @@ export function PullRequestDetailPanel({
                       "Ready for review". Hidden while conflicting — every method would fail. */}
                   {detail.state === "open" &&
                   !detail.isDraft &&
-                  detail.mergeability !== "conflicting" &&
+                  mergeBlocker === null &&
                   allowedMethods.length > 0 ? (
                     <>
                       <MenuRadioGroup
@@ -466,7 +493,7 @@ export function PullRequestDetailPanel({
                 >
                   Ready for review
                 </Button>
-              ) : detail.state === "open" && detail.mergeability === "conflicting" ? (
+              ) : detail.state === "open" && mergeBlocker !== null ? (
                 // Non-draft only (a draft's next step is "Ready for review"). The header keeps
                 // saying Merge — the action the PR is heading for — but the pill is inert until
                 // the branch is reconciled, and hovering it says why. No method chevron: there
@@ -489,9 +516,18 @@ export function PullRequestDetailPanel({
                       />
                     }
                   >
-                    Merge
+                    {detail.stack && stackAssessment ? (
+                      <>
+                        <span>Merge stack</span>
+                        <span className="rounded-full bg-primary-foreground/16 px-1.5 text-[10px] tabular-nums">
+                          {stackAssessment.mergeTargetCount}
+                        </span>
+                      </>
+                    ) : (
+                      "Merge"
+                    )}
                   </TooltipTrigger>
-                  <TooltipPopup side="bottom">Resolve merge conflicts before merging</TooltipPopup>
+                  <TooltipPopup side="bottom">{mergeBlocker}</TooltipPopup>
                 </Tooltip>
               ) : detail.state === "open" && !detail.isDraft && allowedMethods.length > 0 ? (
                 // One pill, no method chevron beside it: a split button's label can never sit
@@ -508,7 +544,14 @@ export function PullRequestDetailPanel({
                   {pendingAction === "merge" ? (
                     <>
                       <LoaderIcon className="size-3.5 animate-spin" />
-                      Merging…
+                      {detail.stack ? "Merging stack…" : "Merging…"}
+                    </>
+                  ) : detail.stack && stackAssessment ? (
+                    <>
+                      <span>Merge stack</span>
+                      <span className="rounded-full bg-primary-foreground/16 px-1.5 text-[10px] tabular-nums">
+                        {stackAssessment.mergeTargetCount}
+                      </span>
                     </>
                   ) : (
                     "Merge"
@@ -575,11 +618,21 @@ export function PullRequestDetailPanel({
         <AlertDialogPopup>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              {confirmAction === "merge" ? "Merge pull request?" : "Close pull request?"}
+              {confirmAction === "merge"
+                ? detail?.stack
+                  ? `Merge ${stackMergeTargetCount} ${stackMergeTargetCount === 1 ? "pull request" : "pull requests"}?`
+                  : "Merge pull request?"
+                : "Close pull request?"}
             </AlertDialogTitle>
             <AlertDialogDescription>
               {confirmAction === "merge"
-                ? `This will merge #${input.number} using ${selectedMergeMethod}.`
+                ? detail?.stack
+                  ? `This will atomically merge every open pull request through #${input.number} into ${detail.stack.baseBranch} using ${selectedMergeMethod}.${
+                      detail.stack.position < detail.stack.size
+                        ? " Pull requests above it will remain open and GitHub will retarget them."
+                        : ""
+                    }`
+                  : `This will merge #${input.number} using ${selectedMergeMethod}.`
                 : `This will close #${input.number} without merging it.`}
             </AlertDialogDescription>
           </AlertDialogHeader>
@@ -598,7 +651,7 @@ export function PullRequestDetailPanel({
                 if (action === "close") void runAction("close");
               }}
             >
-              {confirmAction === "merge" ? "Merge" : "Close"}
+              {confirmAction === "merge" ? (detail?.stack ? "Merge stack" : "Merge") : "Close"}
             </Button>
           </AlertDialogFooter>
         </AlertDialogPopup>

--- a/apps/web/src/components/pullRequest/PullRequestDockPane.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDockPane.tsx
@@ -18,10 +18,12 @@ import { PullRequestDetailPanel } from "./PullRequestDetailPanel";
 export function PullRequestDockPane({
   pane,
   onClose,
+  onSelectPullRequest,
   pollingEnabled: pollingEnabledProp,
 }: {
   pane: RightDockPane;
   onClose?: (() => void) | undefined;
+  onSelectPullRequest?: ((number: number) => void) | undefined;
   pollingEnabled?: boolean;
 }) {
   const pollingEnabled = pollingEnabledProp ?? true;
@@ -36,6 +38,7 @@ export function PullRequestDockPane({
       initialTab={pane.pullRequestInitialTab ?? "summary"}
       pollingEnabled={pollingEnabled}
       {...(onClose ? { onClose } : {})}
+      {...(onSelectPullRequest ? { onSelectPullRequest } : {})}
     />
   );
 }

--- a/apps/web/src/components/pullRequest/PullRequestRow.browser.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.browser.tsx
@@ -45,6 +45,7 @@ function makeEntry(isPinned: boolean): PullRequestListEntry {
       },
     ],
     mergeability: "unknown",
+    stack: null,
     labels: [],
   };
 }
@@ -223,6 +224,23 @@ describe("PullRequestRow pin control", () => {
 
     expect(document.body.textContent).not.toContain("Project One");
     expect(page.getByRole("button", { name: "Pin pull request #42" })).toBeVisible();
+  });
+
+  it("shows compact stack position metadata in the pull request list", async () => {
+    await render(
+      <PullRequestRow
+        entry={{
+          ...makeEntry(false),
+          stack: { number: 8, size: 3, position: 2, baseBranch: "main" },
+        }}
+        selected={false}
+        onClick={vi.fn()}
+        onTogglePinned={vi.fn()}
+      />,
+    );
+
+    expect(page.getByText("2/3", { exact: true })).toBeVisible();
+    expect(page.getByLabelText("Stack #8, pull request 2 of 3")).toBeVisible();
   });
 
   it("renders neutral diff statistics when colors are disabled", async () => {

--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -22,13 +22,19 @@ import { PullRequestAvatar } from "./PullRequestAvatar";
 import { PullRequestDiffStat } from "./PullRequestDiffStat";
 import { PullRequestMetaLine } from "./PullRequestMetaLine";
 import { PullRequestStateGlyph } from "./PullRequestStateGlyph";
+import { PullRequestStackPosition } from "./PullRequestStackPosition";
 
 function TruncatedTitle({ title, number }: { title: string; number: number }) {
   return (
     <Tooltip>
       <TooltipTrigger
         render={
-          <span className={cn(PR_BODY_TEXT_CLASS_NAME, "truncate font-medium text-foreground")}>
+          <span
+            className={cn(
+              PR_BODY_TEXT_CLASS_NAME,
+              "min-w-0 flex-1 truncate font-medium text-foreground",
+            )}
+          >
             {title}
           </span>
         }
@@ -103,6 +109,7 @@ export const PullRequestRow = function PullRequestRow({
         <span className="min-w-0">
           <span className="flex min-w-0 items-center gap-2">
             <TruncatedTitle title={entry.title} number={entry.number} />
+            {entry.stack ? <PullRequestStackPosition stack={entry.stack} /> : null}
           </span>
           {/* Fine print, set once on the line: author, repository and branch are one thought at
               one size — the branch used to be the only part stepped down, which made the line

--- a/apps/web/src/components/pullRequest/PullRequestStackPopover.browser.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestStackPopover.browser.tsx
@@ -1,0 +1,59 @@
+// FILE: PullRequestStackPopover.browser.tsx
+// Purpose: Browser coverage for the detail-header stack navigator and shared position indicator.
+// Layer: Pull request presentation test
+
+import "../../index.css";
+
+import type { PullRequestStack, PullRequestStackEntry } from "@synara/contracts";
+import { page } from "vitest/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { PullRequestStackPopover } from "./PullRequestStackPopover";
+
+function entry(position: number): PullRequestStackEntry {
+  return {
+    position,
+    number: 40 + position,
+    title: `Layer ${position}`,
+    url: `https://github.com/acme/app/pull/${40 + position}`,
+    headBranch: `layer-${position}`,
+    baseBranch: position === 1 ? "main" : `layer-${position - 1}`,
+    state: "open",
+    isDraft: false,
+    mergeability: "mergeable",
+    mergeStateStatus: "CLEAN",
+  };
+}
+
+const stack: PullRequestStack = {
+  number: 8,
+  size: 3,
+  position: 2,
+  baseBranch: "main",
+  entries: [entry(1), entry(2), entry(3)],
+};
+
+describe("PullRequestStackPopover", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("opens the full top-down stack and navigates to another pull request", async () => {
+    const onSelectPullRequest = vi.fn();
+    await render(
+      <PullRequestStackPopover
+        stack={stack}
+        currentNumber={42}
+        onSelectPullRequest={onSelectPullRequest}
+      />,
+    );
+
+    await page.getByRole("button", { name: "View stack 8, pull request 2 of 3" }).click();
+
+    expect(page.getByText("Ready to merge")).toBeVisible();
+    expect(page.getByText("Stack #8 · targets main")).toBeVisible();
+    await page.getByRole("button", { name: /Layer 3/ }).click();
+    expect(onSelectPullRequest).toHaveBeenCalledWith(43);
+  });
+});

--- a/apps/web/src/components/pullRequest/PullRequestStackPopover.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestStackPopover.tsx
@@ -1,0 +1,132 @@
+// FILE: PullRequestStackPopover.tsx
+// Purpose: Compact stack position control plus a full bottom-to-top stack navigator for the
+//          pull request detail header. GitHub stack state stays visible without duplicating a
+//          second pull request surface.
+// Layer: Pull request presentation
+// Exports: PullRequestStackPopover
+
+import type { PullRequestStack } from "@synara/contracts";
+import { useState } from "react";
+
+import { CHAT_HEADER_CONTROL_CLASS_NAME } from "~/components/chat/chatHeaderControls";
+import { Button } from "~/components/ui/button";
+import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
+import { ArrowUpRightIcon } from "~/lib/icons";
+import { cn } from "~/lib/utils";
+
+import { PullRequestStateGlyph } from "./PullRequestStateGlyph";
+import { PullRequestStackPosition } from "./PullRequestStackPosition";
+import { assessPullRequestStack } from "./pullRequestStack.logic";
+
+const ASSESSMENT_COLOR_CLASS = {
+  ready: "text-status-open",
+  blocked: "text-status-failure",
+  pending: "text-muted-foreground",
+  warning: "text-status-failure",
+  complete: "text-status-merged",
+} as const;
+
+export function PullRequestStackPopover({
+  stack,
+  currentNumber,
+  onSelectPullRequest,
+}: {
+  stack: PullRequestStack;
+  currentNumber: number;
+  onSelectPullRequest?: ((number: number) => void) | undefined;
+}) {
+  const [open, setOpen] = useState(false);
+  const assessment = assessPullRequestStack(stack);
+  const entriesTopDown = stack.entries.toReversed();
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            variant="chrome-outline"
+            size="xs"
+            className={cn(CHAT_HEADER_CONTROL_CLASS_NAME, "gap-1.5 px-2 font-normal")}
+            aria-label={`View stack ${stack.number}, pull request ${stack.position} of ${stack.size}`}
+            title={`Stack #${stack.number}`}
+          >
+            <PullRequestStackPosition stack={stack} appearance="plain" />
+          </Button>
+        }
+      />
+      <PopoverPopup
+        align="end"
+        side="bottom"
+        sideOffset={6}
+        className="w-[min(26rem,calc(100vw-1rem))] p-0 [&_[data-slot=popover-viewport]]:p-0"
+      >
+        <div className="border-b border-border px-4 py-3">
+          <div className={cn("text-sm font-medium", ASSESSMENT_COLOR_CLASS[assessment.tone])}>
+            {assessment.label}
+          </div>
+          <div className="mt-0.5 text-xs text-muted-foreground">
+            Stack #{stack.number} · targets {stack.baseBranch}
+          </div>
+        </div>
+
+        <div className="max-h-[min(28rem,70vh)] overflow-y-auto py-1.5">
+          {entriesTopDown.map((entry, index) => {
+            const current = entry.number === currentNumber;
+            return (
+              <div key={entry.number} className="relative px-2">
+                {index < entriesTopDown.length - 1 ? (
+                  <span
+                    aria-hidden="true"
+                    className="absolute left-[1.6875rem] top-8 h-[calc(100%-1rem)] w-px bg-border"
+                  />
+                ) : null}
+                <button
+                  type="button"
+                  aria-current={current ? "page" : undefined}
+                  className={cn(
+                    "group relative flex w-full items-start gap-3 rounded-md px-2 py-2 text-left outline-none focus-visible:ring-1 focus-visible:ring-ring/60",
+                    current
+                      ? "bg-[var(--color-background-elevated-secondary)]"
+                      : "hover:bg-[var(--color-background-elevated-secondary)]",
+                  )}
+                  onClick={() => {
+                    setOpen(false);
+                    if (!current) onSelectPullRequest?.(entry.number);
+                  }}
+                >
+                  <PullRequestStateGlyph
+                    state={entry.state}
+                    isDraft={entry.isDraft}
+                    mergeability={entry.mergeability}
+                    className="mt-0.5 bg-[var(--color-background-elevated-primary-opaque)]"
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm text-foreground">{entry.title}</span>
+                    <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+                      #{entry.number} · {entry.headBranch}
+                    </span>
+                  </span>
+                  {!current ? (
+                    <ArrowUpRightIcon className="mt-0.5 size-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100" />
+                  ) : null}
+                </button>
+              </div>
+            );
+          })}
+
+          <div className="relative mx-2 flex items-center gap-3 px-2 py-2 text-xs text-muted-foreground">
+            <span
+              aria-hidden="true"
+              className="absolute -top-2 left-4 h-6 w-px bg-border"
+            />
+            <span
+              aria-hidden="true"
+              className="flex size-4 shrink-0 items-center justify-center rounded-full border border-border bg-[var(--color-background-elevated-primary-opaque)]"
+            />
+            <span className="truncate">{stack.baseBranch}</span>
+          </div>
+        </div>
+      </PopoverPopup>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/pullRequest/PullRequestStackPopover.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestStackPopover.tsx
@@ -115,10 +115,7 @@ export function PullRequestStackPopover({
           })}
 
           <div className="relative mx-2 flex items-center gap-3 px-2 py-2 text-xs text-muted-foreground">
-            <span
-              aria-hidden="true"
-              className="absolute -top-2 left-4 h-6 w-px bg-border"
-            />
+            <span aria-hidden="true" className="absolute -top-2 left-4 h-6 w-px bg-border" />
             <span
               aria-hidden="true"
               className="flex size-4 shrink-0 items-center justify-center rounded-full border border-border bg-[var(--color-background-elevated-primary-opaque)]"

--- a/apps/web/src/components/pullRequest/PullRequestStackPosition.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestStackPosition.tsx
@@ -1,0 +1,70 @@
+// FILE: PullRequestStackPosition.tsx
+// Purpose: Shared compact stack-position indicator for pull request list and detail surfaces.
+// Layer: Pull request presentation
+// Exports: PullRequestStackPosition
+
+import type { PullRequestStackSummary } from "@synara/contracts";
+
+import { Badge } from "~/components/ui/badge";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
+import { GitForkIcon } from "~/lib/icons";
+import { cn } from "~/lib/utils";
+
+type StackPosition = Pick<
+  PullRequestStackSummary,
+  "number" | "size" | "position" | "baseBranch"
+>;
+
+function stackPositionAriaLabel(stack: StackPosition): string {
+  return `Stack #${stack.number}, pull request ${stack.position} of ${stack.size}`;
+}
+
+function StackPositionContents({ stack }: { stack: StackPosition }) {
+  return (
+    <>
+      <GitForkIcon className="size-3" aria-hidden />
+      <span className="tabular-nums">
+        {stack.position}/{stack.size}
+      </span>
+    </>
+  );
+}
+
+export function PullRequestStackPosition({
+  stack,
+  appearance = "badge",
+  className,
+}: {
+  stack: StackPosition;
+  appearance?: "badge" | "plain";
+  className?: string;
+}) {
+  if (appearance === "plain") {
+    return (
+      <span className={cn("inline-flex items-center gap-1.5", className)} aria-hidden="true">
+        <StackPositionContents stack={stack} />
+      </span>
+    );
+  }
+
+  const label = stackPositionAriaLabel(stack);
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Badge
+            variant="outline"
+            size="sm"
+            aria-label={label}
+            className={cn("gap-1 font-normal text-muted-foreground", className)}
+          >
+            <StackPositionContents stack={stack} />
+          </Badge>
+        }
+      />
+      <TooltipPopup side="top">
+        Stack #{stack.number} · PR {stack.position} of {stack.size} · targets {stack.baseBranch}
+      </TooltipPopup>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/components/pullRequest/PullRequestStackPosition.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestStackPosition.tsx
@@ -10,10 +10,7 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { GitForkIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
 
-type StackPosition = Pick<
-  PullRequestStackSummary,
-  "number" | "size" | "position" | "baseBranch"
->;
+type StackPosition = Pick<PullRequestStackSummary, "number" | "size" | "position" | "baseBranch">;
 
 function stackPositionAriaLabel(stack: StackPosition): string {
   return `Stack #${stack.number}, pull request ${stack.position} of ${stack.size}`;

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -38,6 +38,7 @@ function makeEntry(overrides: Partial<PullRequestListEntry> = {}): PullRequestLi
     isPinned: false,
     projectContexts: [],
     mergeability: "unknown",
+    stack: null,
     labels: [],
     ...overrides,
   };

--- a/apps/web/src/components/pullRequest/pullRequestStack.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestStack.logic.test.ts
@@ -1,7 +1,11 @@
 import type { PullRequestStack, PullRequestStackEntry } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
-import { assessPullRequestStack, pullRequestStackTargetEntries } from "./pullRequestStack.logic";
+import {
+  assessPullRequestStack,
+  pullRequestMergeBlocker,
+  pullRequestStackTargetEntries,
+} from "./pullRequestStack.logic";
 
 function entry(
   position: number,
@@ -68,5 +72,13 @@ describe("assessPullRequestStack", () => {
       label: "Merge status pending",
       canAttemptMerge: true,
     });
+  });
+});
+
+describe("pullRequestMergeBlocker", () => {
+  it("blocks merge when stack metadata could not be verified", () => {
+    expect(
+      pullRequestMergeBlocker({ stackMetadataIncomplete: true, mergeability: "mergeable" }, null),
+    ).toBe("Stack details are temporarily unavailable. Refresh before merging.");
   });
 });

--- a/apps/web/src/components/pullRequest/pullRequestStack.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestStack.logic.test.ts
@@ -1,0 +1,74 @@
+import type { PullRequestStack, PullRequestStackEntry } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+
+import { assessPullRequestStack, pullRequestStackTargetEntries } from "./pullRequestStack.logic";
+
+function entry(
+  position: number,
+  overrides: Partial<PullRequestStackEntry> = {},
+): PullRequestStackEntry {
+  return {
+    position,
+    number: 100 + position,
+    title: `Layer ${position}`,
+    url: `https://github.com/acme/app/pull/${100 + position}`,
+    headBranch: `layer-${position}`,
+    baseBranch: position === 1 ? "main" : `layer-${position - 1}`,
+    state: "open",
+    isDraft: false,
+    mergeability: "mergeable",
+    mergeStateStatus: "CLEAN",
+    ...overrides,
+  };
+}
+
+function stack(overrides: Partial<PullRequestStack> = {}): PullRequestStack {
+  return {
+    number: 7,
+    size: 3,
+    position: 2,
+    baseBranch: "main",
+    entries: [entry(1), entry(2), entry(3)],
+    ...overrides,
+  };
+}
+
+describe("pullRequestStackTargetEntries", () => {
+  it("includes only unmerged entries through the selected pull request", () => {
+    const source = stack({ entries: [entry(1, { state: "merged" }), entry(2), entry(3)] });
+    expect(pullRequestStackTargetEntries(source).map((member) => member.number)).toEqual([102]);
+  });
+});
+
+describe("assessPullRequestStack", () => {
+  it("reports a ready atomic merge and its effective target count", () => {
+    expect(assessPullRequestStack(stack())).toMatchObject({
+      label: "Ready to merge",
+      mergeTargetCount: 2,
+      canAttemptMerge: true,
+    });
+  });
+
+  it("blocks a stack when any affected pull request is a draft", () => {
+    expect(
+      assessPullRequestStack(
+        stack({ entries: [entry(1, { isDraft: true }), entry(2), entry(3)] }),
+      ),
+    ).toMatchObject({
+      label: "Stack needs attention",
+      canAttemptMerge: false,
+      blocker: "#101 is still a draft.",
+    });
+  });
+
+  it("keeps uncertain GitHub state attemptable so the async merge API stays authoritative", () => {
+    expect(
+      assessPullRequestStack(
+        stack({ entries: [entry(1), entry(2, { mergeStateStatus: "UNKNOWN" }), entry(3)] }),
+      ),
+    ).toMatchObject({
+      label: "Merge status pending",
+      canAttemptMerge: true,
+    });
+  });
+});

--- a/apps/web/src/components/pullRequest/pullRequestStack.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestStack.logic.test.ts
@@ -51,9 +51,7 @@ describe("assessPullRequestStack", () => {
 
   it("blocks a stack when any affected pull request is a draft", () => {
     expect(
-      assessPullRequestStack(
-        stack({ entries: [entry(1, { isDraft: true }), entry(2), entry(3)] }),
-      ),
+      assessPullRequestStack(stack({ entries: [entry(1, { isDraft: true }), entry(2), entry(3)] })),
     ).toMatchObject({
       label: "Stack needs attention",
       canAttemptMerge: false,

--- a/apps/web/src/components/pullRequest/pullRequestStack.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestStack.logic.ts
@@ -1,4 +1,4 @@
-import type { PullRequestStack, PullRequestStackEntry } from "@synara/contracts";
+import type { PullRequestDetail, PullRequestStack, PullRequestStackEntry } from "@synara/contracts";
 
 export type PullRequestStackAssessment = {
   readonly label:
@@ -104,4 +104,17 @@ export function assessPullRequestStack(stack: PullRequestStack): PullRequestStac
     canAttemptMerge: true,
     blocker: null,
   };
+}
+
+export function pullRequestMergeBlocker(
+  detail: Pick<PullRequestDetail, "mergeability" | "stackMetadataIncomplete">,
+  stackAssessment: PullRequestStackAssessment | null,
+): string | null {
+  if (detail.stackMetadataIncomplete === true) {
+    return "Stack details are temporarily unavailable. Refresh before merging.";
+  }
+  if (stackAssessment?.canAttemptMerge === false) {
+    return stackAssessment.blocker ?? "This stack is not ready to merge.";
+  }
+  return detail.mergeability === "conflicting" ? "Resolve merge conflicts before merging" : null;
 }

--- a/apps/web/src/components/pullRequest/pullRequestStack.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestStack.logic.ts
@@ -1,0 +1,107 @@
+import type { PullRequestStack, PullRequestStackEntry } from "@synara/contracts";
+
+export type PullRequestStackAssessment = {
+  readonly label:
+    | "Ready to merge"
+    | "Stack needs attention"
+    | "Merge status pending"
+    | "Mergeable with failing checks"
+    | "Stack merged";
+  readonly tone: "ready" | "blocked" | "pending" | "warning" | "complete";
+  readonly mergeTargetCount: number;
+  readonly canAttemptMerge: boolean;
+  readonly blocker: string | null;
+};
+
+/** Entries affected by merging the selected PR, ordered from the base branch upwards. */
+export function pullRequestStackTargetEntries(
+  stack: PullRequestStack,
+): ReadonlyArray<PullRequestStackEntry> {
+  return stack.entries.filter(
+    (entry) => entry.position <= stack.position && entry.state !== "merged",
+  );
+}
+
+export function assessPullRequestStack(stack: PullRequestStack): PullRequestStackAssessment {
+  const targets = pullRequestStackTargetEntries(stack);
+  if (targets.length === 0) {
+    return {
+      label: "Stack merged",
+      tone: "complete",
+      mergeTargetCount: 0,
+      canAttemptMerge: false,
+      blocker: null,
+    };
+  }
+
+  const closed = targets.find((entry) => entry.state === "closed");
+  if (closed) {
+    return {
+      label: "Stack needs attention",
+      tone: "blocked",
+      mergeTargetCount: targets.length,
+      canAttemptMerge: false,
+      blocker: `#${closed.number} is closed without being merged.`,
+    };
+  }
+
+  const draft = targets.find((entry) => entry.isDraft);
+  if (draft) {
+    return {
+      label: "Stack needs attention",
+      tone: "blocked",
+      mergeTargetCount: targets.length,
+      canAttemptMerge: false,
+      blocker: `#${draft.number} is still a draft.`,
+    };
+  }
+
+  const conflicting = targets.find(
+    (entry) =>
+      entry.mergeability === "conflicting" ||
+      ["BLOCKED", "DIRTY", "DRAFT"].includes(entry.mergeStateStatus ?? ""),
+  );
+  if (conflicting) {
+    return {
+      label: "Stack needs attention",
+      tone: "blocked",
+      mergeTargetCount: targets.length,
+      canAttemptMerge: false,
+      blocker: `#${conflicting.number} is not ready to merge.`,
+    };
+  }
+
+  if (targets.some((entry) => entry.mergeStateStatus === "UNSTABLE")) {
+    return {
+      label: "Mergeable with failing checks",
+      tone: "warning",
+      mergeTargetCount: targets.length,
+      canAttemptMerge: true,
+      blocker: null,
+    };
+  }
+
+  const pending = targets.some(
+    (entry) =>
+      entry.mergeability === "unknown" ||
+      entry.mergeStateStatus === null ||
+      ["BEHIND", "UNKNOWN"].includes(entry.mergeStateStatus),
+  );
+  if (pending) {
+    return {
+      label: "Merge status pending",
+      tone: "pending",
+      mergeTargetCount: targets.length,
+      canAttemptMerge: true,
+      blocker: null,
+    };
+  }
+
+  return {
+    label: "Ready to merge",
+    tone: "ready",
+    mergeTargetCount: targets.length,
+    canAttemptMerge: true,
+    blocker: null,
+  };
+}

--- a/apps/web/src/lib/pullRequestMutationOptions.ts
+++ b/apps/web/src/lib/pullRequestMutationOptions.ts
@@ -128,6 +128,27 @@ function pullRequestActionTargetState(
   }
 }
 
+function invalidatePullRequestActionDetails(
+  queryClient: QueryClient,
+  input: PullRequestActionInput,
+) {
+  if (input.action !== "merge") {
+    return queryClient.invalidateQueries({
+      queryKey: pullRequestQueryKeys.detail(input),
+      exact: true,
+    });
+  }
+  // A stacked merge changes every PR through the selected stack position. The action payload is
+  // intentionally small, so invalidate all cached details for this repository; standalone merges
+  // pay the same bounded invalidation and avoid a second pre-merge stack lookup.
+  return queryClient.invalidateQueries({
+    predicate: (query) => {
+      const key = query.queryKey;
+      return key[0] === "pull-requests" && key[1] === "detail" && key[3] === input.repository;
+    },
+  });
+}
+
 export function pullRequestActionMutationOptions(queryClient: QueryClient) {
   return mutationOptions({
     mutationKey: pullRequestMutationKeys.action,
@@ -205,20 +226,14 @@ export function pullRequestActionMutationOptions(queryClient: QueryClient) {
         context
           ? invalidatePullRequestListScopes(queryClient, context.affectedScopes)
           : Promise.resolve(),
-        queryClient.invalidateQueries({
-          queryKey: pullRequestQueryKeys.detail(input),
-          exact: true,
-        }),
+        invalidatePullRequestActionDetails(queryClient, input),
       ]);
       refreshPullRequestReviewRequestCounts(queryClient);
     },
     onSuccess: async (result, input, context) => {
       await Promise.all([
         invalidatePullRequestListScopes(queryClient, context.affectedScopes),
-        queryClient.invalidateQueries({
-          queryKey: pullRequestQueryKeys.detail(input),
-          exact: true,
-        }),
+        invalidatePullRequestActionDetails(queryClient, input),
         queryClient.invalidateQueries({
           queryKey: gitQueryKeys.pullRequest(result.workspaceRoot),
         }),

--- a/apps/web/src/lib/pullRequestReactQuery.action.test.ts
+++ b/apps/web/src/lib/pullRequestReactQuery.action.test.ts
@@ -124,6 +124,46 @@ describe("pullRequestActionMutationOptions", () => {
     expect(queryClient.getQueryState(unrelatedGitPullRequestKey)?.isInvalidated).toBe(false);
   });
 
+  it("invalidates every cached detail in the repository after an atomic merge", async () => {
+    const queryClient = new QueryClient();
+    const projectId = "project-a" as ProjectId;
+    const input = {
+      projectId,
+      repository: "acme/widgets",
+      number: 42,
+      action: "merge",
+      mergeMethod: "squash",
+    } as const;
+    const selectedDetail = pullRequestQueryKeys.detail(input);
+    const lowerStackDetail = pullRequestQueryKeys.detail({
+      projectId,
+      repository: "acme/widgets",
+      number: 41,
+    });
+    const unrelatedDetail = pullRequestQueryKeys.detail({
+      projectId,
+      repository: "acme/other",
+      number: 41,
+    });
+    for (const key of [selectedDetail, lowerStackDetail, unrelatedDetail]) {
+      queryClient.setQueryData(key, {});
+    }
+
+    const options = pullRequestActionMutationOptions(queryClient);
+    if (!options.onMutate || !options.onSuccess) throw new Error("Action hooks are missing.");
+    const context = await Reflect.apply(options.onMutate, undefined, [input, undefined]);
+    await Reflect.apply(options.onSuccess, undefined, [
+      { workspaceRoot: "/repo", mergeOutcome: "merged" },
+      input,
+      context,
+      undefined,
+    ]);
+
+    expect(queryClient.getQueryState(selectedDetail)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(lowerStackDetail)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(unrelatedDetail)?.isInvalidated).toBe(false);
+  });
+
   it("updates the global row when an action starts from another associated project", async () => {
     const queryClient = new QueryClient();
     const projectA = "project-a" as ProjectId;

--- a/apps/web/src/routes/_chat.pull-requests.index.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.index.tsx
@@ -551,7 +551,18 @@ function PullRequestsRouteView() {
         onAddPane={() => {}}
         renderPane={(pane, context) => (
           <Suspense fallback={<PanelStateMessage>Loading pull request...</PanelStateMessage>}>
-            <PullRequestDockPane pane={pane} pollingEnabled={context.isVisible} />
+            <PullRequestDockPane
+              pane={pane}
+              pollingEnabled={context.isVisible}
+              onSelectPullRequest={(number) =>
+                renderedInput &&
+                updateSearch({
+                  selectedProjectId: renderedInput.projectId,
+                  selectedRepo: renderedInput.repository,
+                  number,
+                })
+              }
+            />
           </Suspense>
         )}
       />

--- a/packages/contracts/src/pullRequests.test.ts
+++ b/packages/contracts/src/pullRequests.test.ts
@@ -114,6 +114,10 @@ describe("PullRequestDetail", () => {
 
     expect(decoded.mergeability).toBe("unknown");
     expect(decoded.stack).toBeNull();
+    expect(decoded.stackMetadataIncomplete).toBe(false);
+    expect(
+      decodeDetail({ ...decoded, stackMetadataIncomplete: true }).stackMetadataIncomplete,
+    ).toBe(true);
   });
 
   it("decodes a complete stack while preserving bottom-to-top positions", () => {

--- a/packages/contracts/src/pullRequests.test.ts
+++ b/packages/contracts/src/pullRequests.test.ts
@@ -3,6 +3,7 @@ import { Schema } from "effect";
 
 import {
   PullRequestCommentInput,
+  PullRequestActionResult,
   PullRequestDetail,
   PullRequestListEntry,
   PullRequestReviewRequestCountResult,
@@ -16,6 +17,7 @@ const decodeSetPinnedInput = Schema.decodeUnknownSync(PullRequestSetPinnedInput)
 const decodeReviewRequestCountResult = Schema.decodeUnknownSync(
   PullRequestReviewRequestCountResult,
 );
+const decodeActionResult = Schema.decodeUnknownSync(PullRequestActionResult);
 
 function listEntry() {
   return {
@@ -47,9 +49,24 @@ describe("PullRequestListEntry", () => {
     expect(decoded.isPinned).toBe(false);
     expect(decoded.projectContexts).toEqual([]);
     expect(decoded.mergeability).toBe("unknown");
+    expect(decoded.stack).toBeNull();
     expect(
       decodeListEntry({ ...listEntry(), isPinned: true, mergeability: "conflicting" }),
     ).toMatchObject({ isPinned: true, mergeability: "conflicting" });
+  });
+
+  it("decodes compact stack metadata for list rows", () => {
+    expect(
+      decodeListEntry({
+        ...listEntry(),
+        stack: {
+          number: 8,
+          size: 3,
+          position: 2,
+          baseBranch: "main",
+        },
+      }).stack,
+    ).toEqual({ number: 8, size: 3, position: 2, baseBranch: "main" });
   });
 });
 
@@ -96,6 +113,97 @@ describe("PullRequestDetail", () => {
     });
 
     expect(decoded.mergeability).toBe("unknown");
+    expect(decoded.stack).toBeNull();
+  });
+
+  it("decodes a complete stack while preserving bottom-to-top positions", () => {
+    const decoded = decodeDetail({
+      projectId: "project-1",
+      projectTitle: "Project One",
+      workspaceRoot: "/workspace/project-one",
+      repository: "acme/widgets",
+      number: 43,
+      title: "Top layer",
+      body: "Description",
+      url: "https://github.com/acme/widgets/pull/43",
+      author: null,
+      state: "open",
+      isDraft: false,
+      mergeable: "MERGEABLE",
+      mergeability: "mergeable",
+      mergeStateStatus: "CLEAN",
+      reviewDecision: null,
+      additions: 2,
+      deletions: 1,
+      changedFiles: 1,
+      headBranch: "feature/top",
+      baseBranch: "feature/base",
+      createdAt: "2026-07-13T08:00:00.000Z",
+      updatedAt: "2026-07-14T08:00:00.000Z",
+      mergedAt: null,
+      closedAt: null,
+      maintainerCanModify: true,
+      reviewers: [],
+      labels: [],
+      checks: [],
+      comments: [],
+      commentsTruncated: false,
+      commentsIncomplete: false,
+      commits: [],
+      mergeCapabilities: {
+        merge: true,
+        squash: true,
+        rebase: true,
+        deleteBranchOnMerge: false,
+      },
+      stack: {
+        number: 8,
+        size: 2,
+        position: 2,
+        baseBranch: "main",
+        entries: [
+          {
+            position: 1,
+            number: 42,
+            title: "Base layer",
+            url: "https://github.com/acme/widgets/pull/42",
+            headBranch: "feature/base",
+            baseBranch: "main",
+            state: "open",
+            isDraft: false,
+            mergeability: "mergeable",
+            mergeStateStatus: "CLEAN",
+          },
+          {
+            position: 2,
+            number: 43,
+            title: "Top layer",
+            url: "https://github.com/acme/widgets/pull/43",
+            headBranch: "feature/top",
+            baseBranch: "feature/base",
+            state: "open",
+            isDraft: false,
+            mergeability: "mergeable",
+            mergeStateStatus: "CLEAN",
+          },
+        ],
+      },
+    });
+
+    expect(decoded.stack?.entries.map((entry) => entry.number)).toEqual([42, 43]);
+  });
+});
+
+describe("PullRequestActionResult", () => {
+  it("defaults old mutation acknowledgements to no merge outcome", () => {
+    expect(
+      decodeActionResult({
+        projectId: "project-1",
+        repository: "acme/widgets",
+        number: 42,
+        workspaceRoot: "/workspace/project-one",
+      }).mergeOutcome,
+    ).toBeNull();
   });
 });
 

--- a/packages/contracts/src/pullRequests.ts
+++ b/packages/contracts/src/pullRequests.ts
@@ -92,6 +92,42 @@ export const PullRequestMergeCapabilities = Schema.Struct({
 });
 export type PullRequestMergeCapabilities = typeof PullRequestMergeCapabilities.Type;
 
+export const PullRequestStackEntry = Schema.Struct({
+  position: PositiveInt,
+  number: PositiveInt,
+  title: TrimmedNonEmptyString,
+  url: TrimmedNonEmptyString,
+  headBranch: TrimmedNonEmptyString,
+  baseBranch: TrimmedNonEmptyString,
+  state: PullRequestState,
+  isDraft: Schema.Boolean,
+  mergeability: GitPullRequestMergeability,
+  mergeStateStatus: Schema.NullOr(Schema.String),
+});
+export type PullRequestStackEntry = typeof PullRequestStackEntry.Type;
+
+/**
+ * GitHub orders stack entries from the ultimate base branch upwards. `position` is the selected
+ * pull request's one-based position, so merging that PR affects entries `1...position` atomically.
+ */
+export const PullRequestStack = Schema.Struct({
+  number: PositiveInt,
+  size: PositiveInt,
+  position: PositiveInt,
+  baseBranch: TrimmedNonEmptyString,
+  entries: Schema.Array(PullRequestStackEntry),
+});
+export type PullRequestStack = typeof PullRequestStack.Type;
+
+/** Compact stack identity used by list rows; full entries stay detail-only. */
+export const PullRequestStackSummary = Schema.Struct({
+  number: PositiveInt,
+  size: PositiveInt,
+  position: PositiveInt,
+  baseBranch: TrimmedNonEmptyString,
+});
+export type PullRequestStackSummary = typeof PullRequestStackSummary.Type;
+
 export const PullRequestProjectContext = Schema.Struct({
   projectId: ProjectId,
   projectTitle: TrimmedNonEmptyString,
@@ -127,6 +163,10 @@ export const PullRequestListEntry = Schema.Struct({
   // the field (brief version skew during dev restarts must not reject whole payloads).
   mergeability: Schema.optional(GitPullRequestMergeability).pipe(
     Schema.withDecodingDefault(() => "unknown"),
+  ),
+  // Stack support is additive and the server may briefly be on an older build during restarts.
+  stack: Schema.optional(Schema.NullOr(PullRequestStackSummary)).pipe(
+    Schema.withDecodingDefault(() => null),
   ),
   labels: Schema.Array(PullRequestLabel),
 });
@@ -219,6 +259,10 @@ export const PullRequestDetail = Schema.Struct({
   commentsIncomplete: Schema.Boolean,
   commits: Schema.Array(PullRequestCommit),
   mergeCapabilities: PullRequestMergeCapabilities,
+  // A missing field is a standalone PR or a brief older-server/newer-client version skew.
+  stack: Schema.optional(Schema.NullOr(PullRequestStack)).pipe(
+    Schema.withDecodingDefault(() => null),
+  ),
 });
 export type PullRequestDetail = typeof PullRequestDetail.Type;
 
@@ -270,6 +314,11 @@ export const PullRequestActionResult = Schema.Struct({
   repository: TrimmedNonEmptyString,
   number: PositiveInt,
   workspaceRoot: TrimmedNonEmptyString,
+  // Async merges may finish immediately or be handed to GitHub's merge queue. Older servers and
+  // non-merge actions omit the field, which decodes as null for rolling dev restarts.
+  mergeOutcome: Schema.optional(Schema.NullOr(Schema.Literals(["merged", "enqueued"]))).pipe(
+    Schema.withDecodingDefault(() => null),
+  ),
 });
 export type PullRequestActionResult = typeof PullRequestActionResult.Type;
 

--- a/packages/contracts/src/pullRequests.ts
+++ b/packages/contracts/src/pullRequests.ts
@@ -263,6 +263,11 @@ export const PullRequestDetail = Schema.Struct({
   stack: Schema.optional(Schema.NullOr(PullRequestStack)).pipe(
     Schema.withDecodingDefault(() => null),
   ),
+  // Stack lookup is optional for rendering detail, but merge UX must distinguish an unavailable
+  // lookup from a confirmed standalone pull request.
+  stackMetadataIncomplete: Schema.optional(Schema.Boolean).pipe(
+    Schema.withDecodingDefault(() => false),
+  ),
 });
 export type PullRequestDetail = typeof PullRequestDetail.Type;
 

--- a/scripts/node-pty-smoke.mjs
+++ b/scripts/node-pty-smoke.mjs
@@ -47,6 +47,7 @@ try {
   fail("Failed to spawn node-pty process.", error instanceof Error ? error.stack : String(error));
 }
 
+const outputTimeoutMs = isWindows ? 15_000 : 5_000;
 const timeout = setTimeout(() => {
   try {
     terminal.kill();
@@ -54,7 +55,7 @@ const timeout = setTimeout(() => {
     // Best-effort cleanup; the failure below is the useful signal.
   }
   fail("Timed out waiting for node-pty output.", output);
-}, 5_000);
+}, outputTimeoutMs);
 
 const dataSubscription = terminal.onData((chunk) => {
   output += chunk;


### PR DESCRIPTION
## Summary

- Add GitHub CLI and server operations for stacked pull request workflows
- Model pull request stack relationships and positions across shared contracts, server logic, and tests
- Add web UI for stack navigation, positioning, dock details, and pull request mutations

## Testing

- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the pull-request merge path to an async GitHub API with polling and fallback, and gates merges on stack metadata verification—security-adjacent mutation behavior with broad cache invalidation.
> 
> **Overview**
> Adds **stacked pull request** support across contracts, GitHub CLI, server ops, and the web UI.
> 
> **Backend:** Fetches stack metadata via GraphQL (paginated full stacks + best-effort list enrichment). Merges now prefer GitHub’s async `merge-async` API with polling for `merged`/`enqueued`, falling back to legacy `gh pr merge` when unavailable. Detail loads keep working if stack lookup fails (`stackMetadataIncomplete`), but **merge is blocked** until stack metadata can be verified.
> 
> **UI:** List rows show compact stack position (`2/3`). Detail adds a stack navigator popover, stack-aware merge copy/confirmations, and readiness blockers (drafts, conflicts, incomplete metadata). After a merge, all cached details for that repository are invalidated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 038af5c48df3961983c952beb0e6d989a061d5cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->