### PR TITLE
fix(web): update Git panel diff preview when switching files

### DIFF
--- a/apps/web/src/components/chat/GitPanel.tsx
+++ b/apps/web/src/components/chat/GitPanel.tsx
@@ -352,7 +352,11 @@ export function GitPanel(props: {
 
       <div className="diff-panel-viewport min-h-0 min-w-0 flex-1 overflow-hidden border-t border-border/70">
         {selectedFileDiff ? (
-          <SelectedFileDiff fileDiff={selectedFileDiff} theme={theme} />
+          <SelectedFileDiff
+            key={`${buildFileDiffRenderKey(selectedFileDiff)}:${theme}`}
+            fileDiff={selectedFileDiff}
+            theme={theme}
+          />
         ) : (
           <PanelStateMessage density="compact">Select a file to view its diff.</PanelStateMessage>
         )}


### PR DESCRIPTION
## What changed

Keyed `SelectedFileDiff` in `GitPanel.tsx` by the file render key (and theme) so the bottom diff preview remounts when the selected file changes.

## Why

Fixes #649. The Source Control panel renders its bottom diff preview through a single un-keyed `@pierre/diffs` `FileDiff` instance. That component treats its diff content as **mount-time config** and does not re-render the body when its `fileDiff` prop changes on an already-mounted instance. As a result, clicking a second changed file moved the row highlight but left the preview **frozen on the first file**.

The sibling component `DiffPanelFileList.tsx` already relies on this remount-key pattern (with an explicit comment: *"@pierre/diffs remounts when ... diffStyle is effectively mount-time config on FileDiff"*). This change applies the same pattern to the single preview in `GitPanel`.

## Diff

```diff
-          <SelectedFileDiff fileDiff={selectedFileDiff} theme={theme} />
+          <SelectedFileDiff
+            key={`${buildFileDiffRenderKey(selectedFileDiff)}:${theme}`}
+            fileDiff={selectedFileDiff}
+            theme={theme}
+          />
```

`buildFileDiffRenderKey` was already imported in the file. Keying by the render key (content/path) rather than array index also avoids reusing a stale instance when a file moves between the staged/unstaged lists.

## Testing

- `bunx tsc --noEmit -p apps/web/tsconfig.json` — no new errors on `GitPanel.tsx` (only pre-existing unrelated errors in `threadBootstrap.ts`).
- `oxlint` on the changed file — 0 warnings, 0 errors.

## Note on before/after media

CONTRIBUTING asks for before/after images on UI changes. I don't have a running instance to capture them here — the behavior change is: **before**, clicking a second file leaves the diff frozen on the first; **after**, the diff tracks the selected file. Happy to add a capture if a maintainer wants one.