### PR TITLE
fix(web): collapse task-list updates into one progressing work-log row

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1561,6 +1561,50 @@ describe("MessagesTimeline", () => {
     expect(markup).not.toContain("data-work-entry-action-word");
   });
 
+  it("renders the complete task-list progress heading", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const activeTurnId = TurnId.makeUnsafe("turn-task-progress");
+    const timelineEntries = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "tasks-live",
+          kind: "turn.tasks.updated",
+          summary: "Tasks updated",
+          tone: "info",
+          turnId: activeTurnId,
+          payload: {
+            tasks: [
+              { task: "Implement inline editing", status: "completed" },
+              { task: "Run verification", status: "inProgress" },
+              { task: "Ship", status: "pending" },
+            ],
+          },
+        }),
+      ],
+      activeTurnId,
+    ).map((entry) => ({
+      id: entry.id,
+      kind: "work" as const,
+      createdAt: entry.createdAt,
+      entry,
+    }));
+
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...makeTimelineBaseProps()}
+        isWorking
+        activeTurnInProgress
+        activeTurnId={activeTurnId}
+        activeTurnStartedAt="2026-05-09T16:31:20.000Z"
+        timelineEntries={timelineEntries}
+      />,
+    );
+
+    expect(markup).toContain(
+      '<span data-work-entry-display-text="true">1 out of 3 tasks completed Run verification</span>',
+    );
+  });
+
   it("renders Claude agent task output through the shared markdown renderer", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const markup = renderToStaticMarkup(

--- a/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
+++ b/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
@@ -350,6 +350,12 @@ function capitalizePhrase(value: string): string {
 }
 
 function toolWorkEntryHeading(workEntry: TimelineWorkEntry): string {
+  // Task progress is semantic copy, not a tool lifecycle status. Preserve the
+  // trailing "completed" instead of passing it through the compact tool-label
+  // normalizer, which intentionally strips lifecycle suffixes.
+  if (workEntry.activityKind === "turn.tasks.updated") {
+    return capitalizePhrase(workEntry.label);
+  }
   const synaraTitle = deriveSynaraMcpToolTitle({
     toolName: workEntry.toolName,
     title: workEntry.toolTitle,

--- a/apps/web/src/composerDraftStore.persistence.test.ts
+++ b/apps/web/src/composerDraftStore.persistence.test.ts
@@ -10,7 +10,11 @@ import {
   modelSelection,
   resetComposerDraftStore,
 } from "./composerDraftStoreTestFixtures";
-import { createDeferredPersistStorage, flushStorageBeforePageHide } from "./lib/storage";
+import {
+  createDeferredPersistStorage,
+  flushStorageBeforePageHide,
+  type FlushBeforePageHideEnv,
+} from "./lib/storage";
 import {
   INLINE_TERMINAL_CONTEXT_PLACEHOLDER,
   insertInlineTerminalContextPlaceholder,
@@ -827,5 +831,19 @@ describe("flushStorageBeforePageHide", () => {
     harness.setVisibility("visible");
     harness.fireDocument("visibilitychange");
     expect(flush).not.toHaveBeenCalled();
+  });
+
+  it("no-ops on partial DOM stubs without listener APIs", () => {
+    // SSR-style test environments stub `window`/`document` with only the
+    // fields under test (e.g. `{ documentElement }`); wiring must not crash
+    // module evaluation of stores that call this at import time.
+    expect(() =>
+      flushStorageBeforePageHide(vi.fn(), {
+        window: {} as unknown as NonNullable<FlushBeforePageHideEnv["window"]>,
+        document: { documentElement: {} } as unknown as NonNullable<
+          FlushBeforePageHideEnv["document"]
+        >,
+      }),
+    ).not.toThrow();
   });
 });

--- a/apps/web/src/lib/storage.ts
+++ b/apps/web/src/lib/storage.ts
@@ -73,14 +73,23 @@ export function flushStorageBeforePageHide(
     document: typeof document !== "undefined" ? document : undefined,
   },
 ): void {
-  env.window?.addEventListener("beforeunload", flush);
-  env.window?.addEventListener("pagehide", flush);
+  // Guard each capability separately: SSR-style test environments stub partial
+  // globals (e.g. a `document` with only `documentElement`), and this runs at
+  // module scope in store files — a missing listener API must degrade to a
+  // no-op, never crash module evaluation.
+  const win = env.window;
+  if (typeof win?.addEventListener === "function") {
+    win.addEventListener("beforeunload", flush);
+    win.addEventListener("pagehide", flush);
+  }
   const doc = env.document;
-  doc?.addEventListener("visibilitychange", () => {
-    if (doc.visibilityState === "hidden") {
-      flush();
-    }
-  });
+  if (typeof doc?.addEventListener === "function") {
+    doc.addEventListener("visibilitychange", () => {
+      if (doc.visibilityState === "hidden") {
+        flush();
+      }
+    });
+  }
 }
 
 export function createDeferredPersistStorage<State, Persisted = State>(options: {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -8,7 +8,7 @@ import {
 } from "@synara/contracts";
 import { PROVIDER_DESCRIPTORS } from "@synara/shared/providerMetadata";
 
-import { orderedActivities } from "./workLog";
+import { orderedActivities, parseTaskListTasks } from "./workLog";
 
 import type {
   ChatMessage,
@@ -225,33 +225,8 @@ function toActiveTaskListState(activity: OrchestrationThreadActivity): ActiveTas
     activity.payload && typeof activity.payload === "object"
       ? (activity.payload as Record<string, unknown>)
       : null;
-  const rawTasks = payload?.tasks;
-  if (!Array.isArray(rawTasks)) {
-    return null;
-  }
-  const tasks = rawTasks
-    .map((entry) => {
-      if (!entry || typeof entry !== "object") return null;
-      const record = entry as Record<string, unknown>;
-      if (typeof record.task !== "string") {
-        return null;
-      }
-      const status =
-        record.status === "completed" || record.status === "inProgress" ? record.status : "pending";
-      return {
-        task: record.task,
-        status,
-      };
-    })
-    .filter(
-      (
-        task,
-      ): task is {
-        task: string;
-        status: "pending" | "inProgress" | "completed";
-      } => task !== null,
-    );
-  if (rawTasks.length > 0 && tasks.length === 0) {
+  const tasks = parseTaskListTasks(payload);
+  if (!tasks) {
     return null;
   }
   return {

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -97,6 +97,125 @@ describe("deriveWorkLogEntries", () => {
     expect(entries.map((entry) => entry.id)).toEqual(["task-progress"]);
   });
 
+  it("collapses task-list snapshots into one progressing row per turn", () => {
+    const taskListActivity = (
+      id: string,
+      createdAt: string,
+      tasks: Array<{ task: string; status: string }>,
+    ) =>
+      makeActivity({
+        id,
+        createdAt,
+        kind: "turn.tasks.updated",
+        summary: "Tasks updated",
+        tone: "info",
+        turnId: "turn-1",
+        payload: { tasks },
+      });
+    const activities: OrchestrationThreadActivity[] = [
+      taskListActivity("tasks-1", "2026-02-23T00:00:01.000Z", [
+        { task: "Implement inline editing", status: "inProgress" },
+        { task: "Run verification", status: "pending" },
+      ]),
+      makeActivity({
+        id: "tool-between",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.started",
+        summary: "Tool call",
+        turnId: "turn-1",
+      }),
+      taskListActivity("tasks-2", "2026-02-23T00:00:03.000Z", [
+        { task: "Implement inline editing", status: "completed" },
+        { task: "Run verification", status: "inProgress" },
+      ]),
+      taskListActivity("tasks-3", "2026-02-23T00:00:04.000Z", [
+        { task: "Implement inline editing", status: "completed" },
+        { task: "Run verification", status: "completed" },
+      ]),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, TurnId.makeUnsafe("turn-1"));
+    const taskListEntries = entries.filter((entry) => entry.activityKind === "turn.tasks.updated");
+    expect(taskListEntries).toHaveLength(1);
+    // Anchored at the first snapshot (stable id/createdAt), showing the latest state.
+    expect(taskListEntries[0]?.id).toBe("tasks-1");
+    expect(taskListEntries[0]?.createdAt).toBe("2026-02-23T00:00:01.000Z");
+    expect(taskListEntries[0]?.label).toBe("2 out of 2 tasks completed");
+    expect(taskListEntries[0]?.detail).toBeUndefined();
+    expect(entries.map((entry) => entry.id)).toEqual(["tasks-1", "tool-between"]);
+  });
+
+  it("labels task-list rows with progress and the in-progress task", () => {
+    const [entry] = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "tasks-live",
+          kind: "turn.tasks.updated",
+          summary: "Tasks updated",
+          tone: "info",
+          turnId: "turn-1",
+          payload: {
+            tasks: [
+              { task: "Workstream A server: failure tolerance", status: "completed" },
+              { task: "Implementing inline editing UI", status: "inProgress" },
+              { task: "Final verification pass", status: "pending" },
+            ],
+          },
+        }),
+      ],
+      TurnId.makeUnsafe("turn-1"),
+    );
+
+    expect(entry?.label).toBe("1 out of 3 tasks completed");
+    expect(entry?.detail).toBe("Implementing inline editing UI");
+  });
+
+  it("keeps separate task-list rows for separate turns", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "tasks-turn-1",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "turn.tasks.updated",
+        summary: "Tasks updated",
+        tone: "info",
+        turnId: "turn-1",
+        payload: { tasks: [{ task: "First turn work", status: "completed" }] },
+      }),
+      makeActivity({
+        id: "tasks-turn-2",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "turn.tasks.updated",
+        summary: "Tasks updated",
+        tone: "info",
+        turnId: "turn-2",
+        payload: { tasks: [{ task: "Second turn work", status: "inProgress" }] },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined, {
+      visibleTurnIds: new Set([TurnId.makeUnsafe("turn-1"), TurnId.makeUnsafe("turn-2")]),
+    });
+    expect(entries.map((entry) => entry.id)).toEqual(["tasks-turn-1", "tasks-turn-2"]);
+  });
+
+  it("keeps the generic label for a task-list snapshot without readable tasks", () => {
+    const [entry] = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "tasks-empty",
+          kind: "turn.tasks.updated",
+          summary: "Tasks updated",
+          tone: "info",
+          turnId: "turn-1",
+          payload: { tasks: [] },
+        }),
+      ],
+      TurnId.makeUnsafe("turn-1"),
+    );
+
+    expect(entry?.label).toBe("Tasks updated");
+  });
+
   it("omits quiet turn lifecycle entries while keeping failed turn state visible", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -207,7 +207,6 @@ describe("deriveWorkLogEntries", () => {
         kind: "turn.tasks.updated",
         summary: "Tasks updated",
         tone: "info",
-        turnId: null,
         payload: { tasks: [{ task: "First turn work", status: "completed" }] },
       }),
       makeActivity({
@@ -216,7 +215,6 @@ describe("deriveWorkLogEntries", () => {
         kind: "turn.tasks.updated",
         summary: "Tasks updated",
         tone: "info",
-        turnId: null,
         payload: { tasks: [{ task: "Later turn work", status: "inProgress" }] },
       }),
     ];

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -216,6 +216,40 @@ describe("deriveWorkLogEntries", () => {
     expect(entry?.label).toBe("Tasks updated");
   });
 
+  it("keeps the progressed label when a later snapshot clears the task list", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "tasks-progressed",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "turn.tasks.updated",
+        summary: "Tasks updated",
+        tone: "info",
+        turnId: "turn-1",
+        payload: {
+          tasks: [
+            { task: "Implement inline editing", status: "completed" },
+            { task: "Run verification", status: "inProgress" },
+          ],
+        },
+      }),
+      makeActivity({
+        id: "tasks-cleared",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "turn.tasks.updated",
+        summary: "Tasks updated",
+        tone: "info",
+        turnId: "turn-1",
+        payload: { tasks: [] },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, TurnId.makeUnsafe("turn-1"));
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.id).toBe("tasks-progressed");
+    expect(entries[0]?.label).toBe("1 out of 2 tasks completed");
+    expect(entries[0]?.detail).toBe("Run verification");
+  });
+
   it("omits quiet turn lifecycle entries while keeping failed turn state visible", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -168,6 +168,7 @@ describe("deriveWorkLogEntries", () => {
 
     expect(entry?.label).toBe("1 out of 3 tasks completed");
     expect(entry?.detail).toBe("Implementing inline editing UI");
+    expect(entry?.toolTitle).toBeUndefined();
   });
 
   it("keeps separate task-list rows for separate turns", () => {
@@ -196,6 +197,32 @@ describe("deriveWorkLogEntries", () => {
       visibleTurnIds: new Set([TurnId.makeUnsafe("turn-1"), TurnId.makeUnsafe("turn-2")]),
     });
     expect(entries.map((entry) => entry.id)).toEqual(["tasks-turn-1", "tasks-turn-2"]);
+  });
+
+  it("keeps turnless task-list snapshots independent across unknown turn boundaries", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "tasks-turnless-1",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "turn.tasks.updated",
+        summary: "Tasks updated",
+        tone: "info",
+        turnId: null,
+        payload: { tasks: [{ task: "First turn work", status: "completed" }] },
+      }),
+      makeActivity({
+        id: "tasks-turnless-2",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "turn.tasks.updated",
+        summary: "Tasks updated",
+        tone: "info",
+        turnId: null,
+        payload: { tasks: [{ task: "Later turn work", status: "inProgress" }] },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+    expect(entries.map((entry) => entry.id)).toEqual(["tasks-turnless-1", "tasks-turnless-2"]);
   });
 
   it("keeps the generic label for a task-list snapshot without readable tasks", () => {

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -546,8 +546,12 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
       }
     }
     // Providers snapshot the whole checklist on every change, so one row per
-    // turn (keep-latest) is the entire task history — key the collapse on it.
-    entry.collapseKey = `taskList:${activity.turnId ?? "thread"}`;
+    // turn (keep-latest) is the entire task history. Without a turn id there is
+    // no safe boundary between separate turns, so keep those snapshots
+    // independent instead of collapsing the whole thread into one row.
+    if (activity.turnId !== null) {
+      entry.collapseKey = `taskList:${activity.turnId}`;
+    }
   }
   if (commandPreview.command) {
     entry.command = commandPreview.command;
@@ -614,7 +618,10 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
       payload,
       isRunning: activity.kind !== "tool.completed",
     });
-  if (readableTitle) {
+  // Task-list rows derive their own progress heading above. The generic
+  // activity summary ("Tasks updated") would otherwise become toolTitle and
+  // take precedence over that progress label in TimelineWorkEntryRow.
+  if (readableTitle && activity.kind !== "turn.tasks.updated") {
     entry.toolTitle = readableTitle;
   }
   const liveActivity = deriveWorkLogLiveActivity(activity, payload, entry);

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -436,6 +436,43 @@ function extractWorkLogSynaraThreadCreation(
   return { operationId, requestedCount, createdCount, threads };
 }
 
+export interface TaskListTaskSnapshot {
+  task: string;
+  status: "pending" | "inProgress" | "completed";
+}
+
+// Shared parser for `turn.tasks.updated` payloads. Returns null when the
+// payload carries no readable task list (missing/non-array `tasks`, or a
+// non-empty list where every entry is malformed); an explicit empty snapshot
+// parses to an empty array. Consumed here for transcript rows and by
+// session-logic's composer task-list card state.
+export function parseTaskListTasks(payload: unknown): TaskListTaskSnapshot[] | null {
+  const record =
+    payload && typeof payload === "object" ? (payload as Record<string, unknown>) : null;
+  const rawTasks = record?.tasks;
+  if (!Array.isArray(rawTasks)) {
+    return null;
+  }
+  const tasks = rawTasks
+    .map((entry): TaskListTaskSnapshot | null => {
+      if (!entry || typeof entry !== "object") return null;
+      const taskRecord = entry as Record<string, unknown>;
+      if (typeof taskRecord.task !== "string") {
+        return null;
+      }
+      const status =
+        taskRecord.status === "completed" || taskRecord.status === "inProgress"
+          ? taskRecord.status
+          : "pending";
+      return { task: taskRecord.task, status };
+    })
+    .filter((task): task is TaskListTaskSnapshot => task !== null);
+  if (rawTasks.length > 0 && tasks.length === 0) {
+    return null;
+  }
+  return tasks;
+}
+
 function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWorkLogEntry {
   const payload =
     activity.payload && typeof activity.payload === "object"
@@ -492,6 +529,22 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   if (runtimeWarningMessage) {
     entry.detail = runtimeWarningMessage;
     entry.runtimeWarningMessage = runtimeWarningMessage;
+  }
+  if (activity.kind === "turn.tasks.updated") {
+    const tasks = parseTaskListTasks(payload);
+    if (tasks && tasks.length > 0) {
+      const completedCount = tasks.filter((task) => task.status === "completed").length;
+      entry.label = `${completedCount} out of ${tasks.length} ${pluralize(tasks.length, "task")} completed`;
+      const inProgressTask = tasks.find((task) => task.status === "inProgress");
+      if (inProgressTask) {
+        entry.detail = inProgressTask.task;
+      } else {
+        delete entry.detail;
+      }
+    }
+    // Providers snapshot the whole checklist on every change, so one row per
+    // turn (keep-latest) is the entire task history — key the collapse on it.
+    entry.collapseKey = `taskList:${activity.turnId ?? "thread"}`;
   }
   if (commandPreview.command) {
     entry.command = commandPreview.command;
@@ -841,6 +894,11 @@ function collapseDerivedWorkLogEntries(
   // converged. Preserve the first row for each semantic repair and hide only
   // exact repeats; different turns/actions remain independently visible.
   const seenRuntimeReconciliationKeys = new Set<string>();
+  // Task-list snapshots (collapseKey "taskList:<turnId>") fold into one row per
+  // turn: each update replaces the row's content while the row itself stays
+  // anchored at the first update's position, so the transcript shows a single
+  // progressing checklist row instead of one "Tasks updated" row per snapshot.
+  const taskListIndexByKey = new Map<string, number>();
   for (const entry of entries) {
     const runtimeReconciliationKey = entry.collapseKey?.startsWith("provider-runtime-reconcile:")
       ? entry.collapseKey
@@ -850,6 +908,17 @@ function collapseDerivedWorkLogEntries(
         continue;
       }
       seenRuntimeReconciliationKeys.add(runtimeReconciliationKey);
+    }
+    const taskListKey = entry.collapseKey?.startsWith("taskList:") ? entry.collapseKey : undefined;
+    if (taskListKey !== undefined) {
+      const existingIndex = taskListIndexByKey.get(taskListKey);
+      if (existingIndex !== undefined) {
+        collapsed[existingIndex] = mergeTaskListEntries(collapsed[existingIndex]!, entry);
+        continue;
+      }
+      taskListIndexByKey.set(taskListKey, collapsed.length);
+      collapsed.push(entry);
+      continue;
     }
     const previous = collapsed.at(-1);
     if (previous && shouldCollapseRuntimeWarningEntries(previous, entry)) {
@@ -931,6 +1000,17 @@ function mergeRuntimeWarningEntries(
     detail: repeatPreview,
     preview: repeatPreview,
   };
+}
+
+// A later task-list snapshot supersedes the earlier one wholesale (providers
+// resend the full checklist), so keep the newest content while preserving the
+// first row's id and createdAt: the id keeps React rows stable across updates
+// and the createdAt keeps the row anchored where the checklist first appeared.
+function mergeTaskListEntries(
+  previous: DerivedWorkLogEntry,
+  next: DerivedWorkLogEntry,
+): DerivedWorkLogEntry {
+  return { ...next, id: previous.id, createdAt: previous.createdAt };
 }
 
 // Ingestion emits compaction progress ("Compacting conversation...") and its

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -156,6 +156,7 @@ interface DerivedWorkLogEntry extends WorkLogEntry {
   runtimeWarningRepeatCount?: number;
   runtimeWarningMessage?: string;
   suppressStandaloneCommandStart?: boolean;
+  taskListHasTasks?: boolean;
 }
 
 export function isFileChangeWorkLogEntry(
@@ -297,6 +298,7 @@ export function deriveWorkLogEntries(
         runtimeWarningMessage: _runtimeWarningMessage,
         runtimeWarningRepeatCount: _runtimeWarningRepeatCount,
         suppressStandaloneCommandStart: _suppressStandaloneCommandStart,
+        taskListHasTasks: _taskListHasTasks,
         ...entry
       }) => entry,
     );
@@ -533,6 +535,7 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   if (activity.kind === "turn.tasks.updated") {
     const tasks = parseTaskListTasks(payload);
     if (tasks && tasks.length > 0) {
+      entry.taskListHasTasks = true;
       const completedCount = tasks.filter((task) => task.status === "completed").length;
       entry.label = `${completedCount} out of ${tasks.length} ${pluralize(tasks.length, "task")} completed`;
       const inProgressTask = tasks.find((task) => task.status === "inProgress");
@@ -1006,10 +1009,16 @@ function mergeRuntimeWarningEntries(
 // resend the full checklist), so keep the newest content while preserving the
 // first row's id and createdAt: the id keeps React rows stable across updates
 // and the createdAt keeps the row anchored where the checklist first appeared.
+// A snapshot without readable tasks (explicit clear, or an unreadable payload)
+// carries no progress copy, so it must not overwrite a progressed row with the
+// generic "Tasks updated" label — keep the previous row's content instead.
 function mergeTaskListEntries(
   previous: DerivedWorkLogEntry,
   next: DerivedWorkLogEntry,
 ): DerivedWorkLogEntry {
+  if (previous.taskListHasTasks && !next.taskListHasTasks) {
+    return previous;
+  }
   return { ...next, id: previous.id, createdAt: previous.createdAt };
 }
 


### PR DESCRIPTION
## Problem

Providers that track their work with a checklist (Claude `TodoWrite`) emit a `turn.tasks.updated` snapshot on every status change. Each snapshot rendered as its own generic **"Tasks updated"** transcript row, so a single turn piled up 5–10 identical rows, clumped together at the edge of the work group (the status-row split extracts info-tone rows from chronological order).

## Fix

- **One row per turn**: `collapseDerivedWorkLogEntries` now folds task-list snapshots via a keyed keep-latest merge (`collapseKey: taskList:<turnId>`, same pattern as the stable tool-id merge). The row keeps the first snapshot's `id`/`createdAt`, so it stays anchored where the checklist first appeared and React keys stay stable while its content updates in place.
- **Meaningful label**: the row now reads e.g. **"1 out of 3 tasks completed"** (mirroring the composer card copy), with the current in-progress task as the muted detail text. Unreadable/empty snapshots keep the generic "Tasks updated" fallback.
- **Shared parser**: extracted `parseTaskListTasks` in `workLog.ts`; `toActiveTaskListState` (composer task-list card) now reuses it instead of duplicating the payload parse in `session-logic.ts`.

## Also: fixes the CI breakage on main (red since #632)

#632 made `fileReferenceContextMenu` import `chatReferences`, which pulls `composerDraftStore`'s module-scope `flushStorageBeforePageHide` call into `MessagesTimeline.test.tsx`'s SSR import graph. That test stubs `document` with only `documentElement`, so module evaluation crashed on `doc.addEventListener` and failed all 54 tests in the file. `flushStorageBeforePageHide` now guards each listener capability, degrading to its documented no-op on partial DOM environments; added a regression test.

## Tests

- Four new cases in `workLog.test.ts`: collapse-to-one-row with anchoring + latest-state assertions, progress/in-progress labeling, per-turn row separation, and the generic-label fallback.
- New partial-DOM-stub regression test for `flushStorageBeforePageHide`.
- Full web unit suite green locally (301 files / 3815 tests, including the 54 previously failing `MessagesTimeline` tests); `bun fmt` / `bun lint` / `bun typecheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only work-log and persistence wiring changes with broad test coverage; no auth, security, or server behavior changes.
> 
> **Overview**
> Repeated **`turn.tasks.updated`** snapshots no longer spam the transcript with identical **"Tasks updated"** rows. The work log **collapses them to one row per turn** (keep-latest merge on `taskList:<turnId>`), keeps the first snapshot’s **id/createdAt** for stable placement and React keys, and shows copy like **"1 out of 3 tasks completed"** with the in-progress task as detail. Turnless snapshots stay separate; an empty later snapshot does not wipe a progressed label.
> 
> **`parseTaskListTasks`** is shared from `workLog.ts` for transcript rows and composer task-list state (`session-logic`). **`TimelineWorkEntryRow`** treats task progress as semantic copy so **"completed"** is not stripped by tool-label normalization.
> 
> **`flushStorageBeforePageHide`** now checks `addEventListener` before registering listeners so partial DOM stubs in tests/SSR do not crash module load; a regression test covers that.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 937f7398290c94fbbf159a476f15e29528206db8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->