### PR TITLE
fix(web): humanize unmapped rate-limit window labels

### DIFF
--- a/apps/web/src/components/RateLimitsPanel.test.tsx
+++ b/apps/web/src/components/RateLimitsPanel.test.tsx
@@ -228,4 +228,33 @@ describe("RateLimitsPanel helpers", () => {
       },
     ]);
   });
+
+  it("humanizes the claude seven_day_overage_included window instead of leaking the raw key", () => {
+    const rateLimits = deriveAccountRateLimits([
+      {
+        activities: [
+          makeActivity("activity-1", "account.rate-limits.updated", {
+            provider: "claudeAgent",
+            rate_limit_info: {
+              status: "allowed_warning",
+              rateLimitType: "seven_day_overage_included",
+              utilization: 0.78,
+              resetsAt: 4_078_972_980,
+            },
+          }),
+        ],
+      },
+    ]);
+
+    const rows = deriveVisibleRateLimitRows(rateLimits);
+
+    expect(rows).toEqual([
+      {
+        id: "claudeAgent-Weekly (overage)",
+        label: "Weekly (overage)",
+        remainingPercent: 22,
+        resetsAt: "2099-04-04T08:03:00.000Z",
+      },
+    ]);
+  });
 });

--- a/apps/web/src/lib/rateLimits.ts
+++ b/apps/web/src/lib/rateLimits.ts
@@ -35,9 +35,10 @@ export interface VisibleRateLimitRow {
 const WINDOW_ORDER = new Map([
   ["5h", 0],
   ["Weekly", 1],
-  ["Sonnet", 2],
-  ["Opus", 3],
-  ["Current", 4],
+  ["Weekly (overage)", 2],
+  ["Sonnet", 3],
+  ["Opus", 4],
+  ["Current", 5],
 ]);
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -113,7 +114,23 @@ export function normalizeRateLimitLabel(
   if (normalized === "seven_day_opus" || normalized === "weekly_opus" || normalized === "opus") {
     return "Opus";
   }
-  return label;
+  if (
+    normalized === "seven_day_overage_included" ||
+    normalized === "weekly_overage_included" ||
+    normalized === "weekly_overage" ||
+    normalized === "overage"
+  ) {
+    return "Weekly (overage)";
+  }
+  return humanizeLabel(label);
+}
+
+function humanizeLabel(label: string): string {
+  return label
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
 }
 
 function compareWindowLabels(a: string, b: string): number {


### PR DESCRIPTION
## What changed

In `apps/web/src/lib/rateLimits.ts`:
- Map the Claude overage window (`seven_day_overage_included` / `weekly_overage` / `overage`) to the readable label **Weekly (overage)**, with a slot in `WINDOW_ORDER` so it sorts deterministically right after `Weekly`.
- Replace the raw `return label;` fallback in `normalizeRateLimitLabel` with a generic snake_case → Title Case humanizer, so **no unmapped window key can leak verbatim** into the UI again.
- Add a regression test for the overage window.

## Why

Fixes #653. The usage panel showed the raw API key `seven_day_overage_included` instead of a human label, because `normalizeRateLimitLabel` only mapped a fixed set of keys and returned the untouched key for anything else.

## Testing

- `bun run test:web:focused src/components/RateLimitsPanel.test.tsx` — 6 passed (incl. the new overage case).
- `bunx tsc --noEmit -p apps/web/tsconfig.json` — no new errors on the changed files (only a pre-existing unrelated error in `threadBootstrap.ts`).
- `oxlint` on both changed files — 0 warnings, 0 errors.

## Note on before/after media

CONTRIBUTING asks for before/after images on UI changes. I don't have a running instance with a live overage state to capture them. Behavior: **before**, the third Claude window shows `seven_day_overage_included`; **after**, it shows `Weekly (overage)`. Happy to add a screenshot if a maintainer wants one.