### PR TITLE
fix(web): preserve new-chat drafts across thread switches

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -6845,6 +6845,163 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("preserves a new-chat draft when switching to another thread and back via New chat", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: withActiveHomeChatThread(
+        addThreadToSnapshot(
+          createSnapshotForTargetUser({
+            targetMessageId: "msg-user-home-draft-switch" as MessageId,
+            targetText: "home draft switch target",
+          }),
+          OTHER_THREAD_ID,
+        ),
+      ),
+      configureFixture: (nextFixture) => {
+        nextFixture.welcome = {
+          ...nextFixture.welcome,
+          homeDir: "/Users/tester",
+          chatWorkspaceRoot: "/Users/tester/Documents/Synara",
+          studioWorkspaceRoot: "/Users/tester/Documents/Synara/Studio",
+        };
+      },
+    });
+
+    try {
+      // Start a brand-new home chat (draft thread)
+      const newChatButton = page.getByLabelText("Open new chat home");
+      await expect.element(newChatButton).toBeInTheDocument();
+      await newChatButton.click();
+      const newThreadPath = await waitForURL(
+        mounted.router,
+        (path) => UUID_ROUTE_RE.test(path),
+        "Route should have changed to a new draft thread UUID.",
+      );
+      const newThreadId = newThreadPath.slice(1) as ThreadId;
+
+      // Type a draft in the new chat
+      const prompt = "draft typed in a brand-new home chat";
+      useComposerDraftStore.getState().setPrompt(newThreadId, prompt);
+      const composerEditor = await waitForComposerEditor();
+      await vi.waitFor(
+        () => {
+          expect(composerEditor.textContent ?? "").toContain(prompt);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      // Switch to another thread to check on it
+      await mounted.router.navigate({
+        to: "/$threadId",
+        params: { threadId: OTHER_THREAD_ID },
+      });
+      await waitForLayout();
+      await vi.waitFor(
+        () => {
+          expect(mounted.router.state.location.pathname).toBe(`/${OTHER_THREAD_ID}`);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      // Come back via "New chat" — must return to the SAME draft thread with the draft intact
+      const newChatButtonAgain = page.getByLabelText("Open new chat home");
+      await expect.element(newChatButtonAgain).toBeInTheDocument();
+      await newChatButtonAgain.click();
+      const returnedPath = await waitForURL(
+        mounted.router,
+        (path) => UUID_ROUTE_RE.test(path),
+        "Route should have changed to a draft thread UUID.",
+      );
+
+      await vi.waitFor(
+        () => {
+          expect(returnedPath).toBe(newThreadPath);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      const composerEditorAfter = await waitForComposerEditor();
+      await vi.waitFor(
+        () => {
+          expect(composerEditorAfter.textContent ?? "").toContain(prompt);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      // The original draft thread must still be registered with its content
+      expect(useComposerDraftStore.getState().draftsByThreadId[newThreadId]?.prompt).toBe(prompt);
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("preserves a new-chat draft when returning via the project New thread button", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: addThreadToSnapshot(
+        createSnapshotForTargetUser({
+          targetMessageId: "msg-user-project-draft-switch" as MessageId,
+          targetText: "project draft switch target",
+        }),
+        OTHER_THREAD_ID,
+      ),
+    });
+
+    try {
+      const newThreadButton = page.getByLabelText("Create new thread in Project");
+      await expect.element(newThreadButton).toBeInTheDocument();
+      await newThreadButton.click();
+      const newThreadPath = await waitForURL(
+        mounted.router,
+        (path) => UUID_ROUTE_RE.test(path),
+        "Route should have changed to a new draft thread UUID.",
+      );
+      const newThreadId = newThreadPath.slice(1) as ThreadId;
+
+      const prompt = "draft typed in a brand-new project thread";
+      useComposerDraftStore.getState().setPrompt(newThreadId, prompt);
+      const composerEditor = await waitForComposerEditor();
+      await vi.waitFor(
+        () => {
+          expect(composerEditor.textContent ?? "").toContain(prompt);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      await mounted.router.navigate({
+        to: "/$threadId",
+        params: { threadId: OTHER_THREAD_ID },
+      });
+      await waitForLayout();
+
+      const newThreadButtonAgain = page.getByLabelText("Create new thread in Project");
+      await expect.element(newThreadButtonAgain).toBeInTheDocument();
+      await newThreadButtonAgain.click();
+      const returnedPath = await waitForURL(
+        mounted.router,
+        (path) => UUID_ROUTE_RE.test(path),
+        "Route should have changed to a draft thread UUID.",
+      );
+
+      await vi.waitFor(
+        () => {
+          expect(returnedPath).toBe(newThreadPath);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      const composerEditorAfter = await waitForComposerEditor();
+      await vi.waitFor(
+        () => {
+          expect(composerEditorAfter.textContent ?? "").toContain(prompt);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("creates a new thread from the global chat.new shortcut", async () => {
     const mounted = await mountChatView({
       viewport: DEFAULT_VIEWPORT,
@@ -6886,6 +7043,126 @@ describe("ChatView timeline estimator parity (full app)", () => {
         mounted.router,
         (path) => UUID_ROUTE_RE.test(path),
         "Route should have changed to a new draft thread UUID from the shortcut.",
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("preserves a home-chat draft when the chat.newChat shortcut is reused after a thread switch", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: withActiveHomeChatThread(
+        addThreadToSnapshot(
+          createSnapshotForTargetUser({
+            targetMessageId: "msg-user-home-draft-shortcut-switch" as MessageId,
+            targetText: "home draft shortcut switch target",
+          }),
+          OTHER_THREAD_ID,
+        ),
+      ),
+      configureFixture: (nextFixture) => {
+        nextFixture.welcome = {
+          ...nextFixture.welcome,
+          homeDir: "/Users/tester",
+          chatWorkspaceRoot: "/Users/tester/Documents/Synara",
+          studioWorkspaceRoot: "/Users/tester/Documents/Synara/Studio",
+        };
+        nextFixture.serverConfig = {
+          ...nextFixture.serverConfig,
+          keybindings: [
+            {
+              command: "chat.newChat",
+              shortcut: {
+                key: "n",
+                metaKey: false,
+                ctrlKey: false,
+                shiftKey: false,
+                altKey: true,
+                modKey: true,
+              },
+              whenAst: {
+                type: "not",
+                node: { type: "identifier", name: "terminalFocus" },
+              },
+            },
+          ],
+        };
+      },
+    });
+
+    try {
+      await waitForServerConfigToApply();
+      const composerEditor = await waitForComposerEditor();
+      composerEditor.focus();
+      await waitForLayout();
+      const dispatchNewChatShortcut = () => {
+        const useMetaForMod = isMacPlatform(navigator.platform);
+        window.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "n",
+            metaKey: useMetaForMod,
+            ctrlKey: !useMetaForMod,
+            altKey: true,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      };
+      const newThreadPath = await triggerThreadShortcutUntilPath(
+        mounted.router,
+        dispatchNewChatShortcut,
+        (path) => UUID_ROUTE_RE.test(path),
+        "chat.newChat should route to a new draft thread UUID.",
+      );
+      const newThreadId = newThreadPath.slice(1) as ThreadId;
+
+      // Type a draft in the new home chat
+      const prompt = "draft typed via chat.newChat";
+      useComposerDraftStore.getState().setPrompt(newThreadId, prompt);
+      await vi.waitFor(
+        () => {
+          expect(useComposerDraftStore.getState().draftsByThreadId[newThreadId]?.prompt).toBe(
+            prompt,
+          );
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      // Switch to another thread and come back via the same shortcut
+      await mounted.router.navigate({
+        to: "/$threadId",
+        params: { threadId: OTHER_THREAD_ID },
+      });
+      await waitForLayout();
+      await vi.waitFor(
+        () => {
+          expect(mounted.router.state.location.pathname).toBe(`/${OTHER_THREAD_ID}`);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      const returnedPath = await triggerThreadShortcutUntilPath(
+        mounted.router,
+        dispatchNewChatShortcut,
+        (path) => UUID_ROUTE_RE.test(path),
+        "chat.newChat should route back to a draft thread UUID.",
+      );
+      await vi.waitFor(
+        () => {
+          expect(returnedPath).toBe(newThreadPath);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      // The draft must survive the round trip on the same thread
+      expect(useComposerDraftStore.getState().draftsByThreadId[newThreadId]?.prompt).toBe(prompt);
+      const composerEditorAfter = await waitForComposerEditor();
+      await vi.waitFor(
+        () => {
+          expect(composerEditorAfter.textContent ?? "").toContain(prompt);
+        },
+        { timeout: 8_000, interval: 16 },
       );
     } finally {
       await mounted.cleanup();

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2411,7 +2411,10 @@ export default function Sidebar() {
         return;
       }
 
-      void handleNewChat({ fresh: true });
+      // Reuse the stored home-chat draft when one exists (same as the "New chat"
+      // button) so switching back to the Chats view never destroys an in-progress
+      // draft; only mint a fresh draft when there is nothing to resume.
+      void handleNewChat();
     },
     [
       handleNewChat,
@@ -2453,7 +2456,11 @@ export default function Sidebar() {
   // Opens a fresh home-chat draft directly on the draft thread route so the first send
   // does not need a second route swap from "/" to "/$threadId".
   const handleCreateHomeChat = useCallback(async () => {
-    await handleNewChat({ fresh: true });
+    // Reuse the stored home-chat draft thread when one exists (matching the
+    // project "New thread" button), so a draft typed in a new chat survives
+    // switching to another thread and back. Only mint a fresh draft when there
+    // is no stored draft to resume.
+    await handleNewChat();
   }, [handleNewChat]);
   const handleCreateStudioChat = useCallback(async () => {
     await handleNewStudioChat({ fresh: true });

--- a/apps/web/src/lib/startContainerChat.test.ts
+++ b/apps/web/src/lib/startContainerChat.test.ts
@@ -71,7 +71,9 @@ describe("startFreshChatForActiveSurface", () => {
       });
 
       expect(handleNewChat).toHaveBeenCalledOnce();
-      expect(handleNewChat).toHaveBeenCalledWith({ fresh: true });
+      // Home chat reuses the stored draft thread when one exists (so an in-progress
+      // draft survives switching threads) instead of forcing a fresh thread.
+      expect(handleNewChat).toHaveBeenCalledWith();
       expect(handleNewStudioChat).not.toHaveBeenCalled();
     }
   });

--- a/apps/web/src/lib/startContainerChat.ts
+++ b/apps/web/src/lib/startContainerChat.ts
@@ -14,7 +14,7 @@ export type StartContainerChatResult =
   | { ok: true; threadId: ThreadId | null }
   | { ok: false; error: string };
 
-type StartFreshContainerChat = (options: { fresh: true }) => Promise<StartContainerChatResult>;
+type StartFreshContainerChat = (options?: { fresh?: boolean }) => Promise<StartContainerChatResult>;
 
 /**
  * Starts a fresh chat in the surface that owns the active project. Thread routes are shared by
@@ -27,11 +27,13 @@ export function startFreshChatForActiveSurface(input: {
   readonly handleNewChat: StartFreshContainerChat;
   readonly handleNewStudioChat: StartFreshContainerChat;
 }): Promise<StartContainerChatResult> {
-  const handler =
-    input.isStudioRoute || isStudioContainerProject(input.activeProject, input.paths)
-      ? input.handleNewStudioChat
-      : input.handleNewChat;
-  return handler({ fresh: true });
+  const isStudio =
+    input.isStudioRoute || isStudioContainerProject(input.activeProject, input.paths);
+  const handler = isStudio ? input.handleNewStudioChat : input.handleNewChat;
+  // Studio always mints a fresh draft; home chat reuses the stored draft thread
+  // when one exists (so a draft typed in a new chat survives switching threads),
+  // falling back to a fresh draft only when there is nothing to resume.
+  return isStudio ? handler({ fresh: true }) : handler();
 }
 
 /**


### PR DESCRIPTION
## What Changed

Home-chat *New chat* entry points no longer force a fresh draft thread when a stored draft exists. The four affected entry points — the sidebar *New chat* button (`handleCreateHomeChat`), the command-palette *New chat* action, the `chat.newChat`/`chat.newLocal` shortcuts (`startFreshChatForActiveSurface`), and the Chats-view switch fallback (`handleSidebarViewChange`) — previously passed `fresh: true` to `handleNewThread`, which minted a new draft UUID and **deleted the previous draft thread** via `setProjectDraftThreadId` → `removeDraftThreadIfUnmapped`.

Now they reuse the stored draft thread when one exists (matching the project *New thread* button, which never passed `fresh` and always preserved drafts), and only mint a fresh draft when there is nothing to resume. Studio keeps its test-locked forced-fresh behavior.

## Why

Fixes #656. Typing a draft in a new chat, switching to another thread to check something, and coming back via *New chat* destroyed the draft — on home chat only, because project *New thread* buttons never passed `fresh`. This was a regression from #8f9a6f ("Add distinct shortcuts for new chat and latest project thread"), which changed `handleCreateHomeChat` from a draft-reusing `handleNewThread` call to `handleNewChat({ fresh: true })`.

## UI Changes

No visual change — this restores expected draft persistence.

## Verification

- `bunx tsc --noEmit -p tsconfig.json` passes (apps/web).
- `bunx oxlint` — 0 errors (only pre-existing warnings).
- `bunx oxfmt --check` passes on changed files.
- Unit tests: `startContainerChat.test.ts`, `composerDraftStore*.test.ts`, `Sidebar.logic.test.ts`, `keybindings.test.ts`, `threadBootstrap.test.ts` — all pass.
- Browser tests (vitest browser config): new regression tests pass —
  - `preserves a new-chat draft when switching to another thread and back via New chat`
  - `preserves a new-chat draft when returning via the project New thread button`
  - `preserves a home-chat draft when the chat.newChat shortcut is reused after a thread switch`
  - Existing `reuses the existing draft thread when the user clicks new thread again` and Studio `coalesces repeated Studio new-chat clicks` still pass (Studio fresh behavior unchanged).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes (draft-persistence restoration only)