### PR TITLE
feat(web): add adaptable chat width presets

### DIFF
--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -46,6 +46,11 @@ import {
   UI_DENSITY_MODES,
   normalizeUiDensity as normalizeUiDensityValue,
 } from "./lib/appDensity";
+import {
+  DEFAULT_CHAT_WIDTH,
+  CHAT_WIDTH_MODES,
+  normalizeChatWidthMode as normalizeChatWidthModeValue,
+} from "./lib/chatWidth";
 
 const APP_SETTINGS_STORAGE_KEY = "synara:app-settings:v1";
 const SERVER_SETTINGS_MIGRATION_STORAGE_KEY = "synara:server-settings-migrated:v1";
@@ -93,6 +98,9 @@ export const DEFAULT_FOLLOW_UP_BEHAVIOR: FollowUpBehavior = "queue";
 export const UiDensity = Schema.Literals(UI_DENSITY_MODES);
 export type UiDensity = typeof UiDensity.Type;
 export { DEFAULT_UI_DENSITY };
+export const ChatWidthMode = Schema.Literals(CHAT_WIDTH_MODES);
+export type ChatWidthMode = typeof ChatWidthMode.Type;
+export { DEFAULT_CHAT_WIDTH };
 
 const AppSnapShortcut = Schema.Union([
   Schema.Struct({ kind: Schema.Literal("both-option-keys") }),
@@ -176,6 +184,7 @@ const PersistedProviderKind = Schema.Literals([
 export const AppSettingsSchema = Schema.Struct({
   claudeBinaryPath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
   uiDensity: UiDensity.pipe(withDefaults(() => DEFAULT_UI_DENSITY)),
+  chatWidth: ChatWidthMode.pipe(withDefaults(() => DEFAULT_CHAT_WIDTH)),
   chatFontSizePx: Schema.Number.pipe(withDefaults(() => DEFAULT_CHAT_FONT_SIZE_PX)),
   chatCodeFontFamily: Schema.String.check(Schema.isMaxLength(256)).pipe(withDefaults(() => "")),
   terminalFontSizePx: Schema.Number.pipe(withDefaults(() => DEFAULT_TERMINAL_FONT_SIZE_PX)),
@@ -534,6 +543,7 @@ function normalizeAppSettings(settings: AppSettings): AppSettings {
     ),
     piBinaryPath: normalizeProviderBinaryPathOverride("pi", settings.piBinaryPath),
     uiDensity: normalizeUiDensityValue(settings.uiDensity),
+    chatWidth: normalizeChatWidthModeValue(settings.chatWidth),
     chatFontSizePx: normalizeChatFontSizePx(settings.chatFontSizePx),
     terminalFontSizePx: normalizeTerminalFontSizePx(settings.terminalFontSizePx),
     terminalFontFamily: normalizeTerminalFontFamily(settings.terminalFontFamily),

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -6845,6 +6845,44 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("applies the selected chat width to the transcript column", async () => {
+    localStorage.setItem("synara:app-settings:v1", JSON.stringify({ chatWidth: "wide" }));
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-chat-width-test" as MessageId,
+        targetText: "chat width test",
+      }),
+    });
+
+    try {
+      // The hook must surface the preset as a root CSS variable.
+      await vi.waitFor(
+        () => {
+          expect(document.documentElement.style.getPropertyValue("--app-chat-max-width")).toBe(
+            "72rem",
+          );
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      // The transcript column frame must pick up the wider max width.
+      await vi.waitFor(
+        () => {
+          const row = document.querySelector(
+            "[data-timeline-row-kind='message'][data-message-role='assistant']",
+          ) as HTMLElement | null;
+          expect(row).not.toBeNull();
+          expect(row?.className ?? "").toContain("max-w-[var(--app-chat-max-width,46rem)]");
+          expect(getComputedStyle(row!).maxWidth).toBe("1152px"); // 72rem at 16px root
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("creates a new thread from the global chat.new shortcut", async () => {
     const mounted = await mountChatView({
       viewport: DEFAULT_VIEWPORT,

--- a/apps/web/src/components/chat/composerPickerStyles.ts
+++ b/apps/web/src/components/chat/composerPickerStyles.ts
@@ -63,7 +63,7 @@ export const COMPOSER_MUTED_ACCENT_TEXT_CLASS_NAME = "text-muted-foreground/45";
 // sync with dropdown group labels like "Git actions". Picker padding is still
 // tuned via the `--picker-section-py` token on `[data-slot="menu-label"]`.
 
-export const COMPOSER_MAX_WIDTH_CLASS_NAME = "max-w-[46rem]";
+export const COMPOSER_MAX_WIDTH_CLASS_NAME = "max-w-[var(--app-chat-max-width,46rem)]";
 /** Main chat column background — matches the theme Background setting exactly. */
 export const CHAT_BACKGROUND_CLASS_NAME = "bg-[var(--color-background-surface)]";
 

--- a/apps/web/src/hooks/useChatWidth.ts
+++ b/apps/web/src/hooks/useChatWidth.ts
@@ -1,0 +1,40 @@
+// FILE: useChatWidth.ts
+// Purpose: Applies the selected chat column width preset as a root CSS variable.
+// Layer: Web route lifecycle hook
+// Exports: useChatWidth
+
+import { useEffect } from "react";
+
+import { useAppSettings } from "../appSettings";
+import {
+  getChatWidthCssVariables,
+  normalizeChatWidthMode,
+  type ChatWidthCssVariable,
+} from "../lib/chatWidth";
+
+const CHAT_WIDTH_CSS_VARIABLES = Object.keys(
+  getChatWidthCssVariables(),
+) as readonly ChatWidthCssVariable[];
+
+export function useChatWidth() {
+  const { settings } = useAppSettings();
+  const chatWidth = normalizeChatWidthMode(settings.chatWidth);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const rootStyle = root.style;
+    const variableValues = getChatWidthCssVariables(chatWidth);
+
+    for (const cssVariable of CHAT_WIDTH_CSS_VARIABLES) {
+      rootStyle.setProperty(cssVariable, variableValues[cssVariable]);
+    }
+    root.dataset.chatWidth = chatWidth;
+
+    return () => {
+      for (const cssVariable of CHAT_WIDTH_CSS_VARIABLES) {
+        rootStyle.removeProperty(cssVariable);
+      }
+      delete root.dataset.chatWidth;
+    };
+  }, [chatWidth]);
+}

--- a/apps/web/src/lib/chatWidth.test.ts
+++ b/apps/web/src/lib/chatWidth.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_CHAT_WIDTH, getChatWidthCssVariables, normalizeChatWidthMode } from "./chatWidth";
+
+describe("chatWidth", () => {
+  it("normalizes unknown values to the default mode", () => {
+    expect(normalizeChatWidthMode("wide")).toBe("wide");
+    expect(normalizeChatWidthMode("full")).toBe("full");
+    expect(normalizeChatWidthMode("invalid")).toBe(DEFAULT_CHAT_WIDTH);
+    expect(normalizeChatWidthMode(undefined)).toBe(DEFAULT_CHAT_WIDTH);
+  });
+
+  it("maps each mode to a chat column max width", () => {
+    expect(getChatWidthCssVariables("standard")["--app-chat-max-width"]).toBe("46rem");
+    expect(getChatWidthCssVariables("wide")["--app-chat-max-width"]).toBe("72rem");
+    expect(getChatWidthCssVariables("full")["--app-chat-max-width"]).toBe("100%");
+  });
+});

--- a/apps/web/src/lib/chatWidth.ts
+++ b/apps/web/src/lib/chatWidth.ts
@@ -1,0 +1,40 @@
+// FILE: chatWidth.ts
+// Purpose: Chat column width presets (standard / wide / full) exposed as a CSS variable.
+// Layer: Web appearance helper
+// Exports: mode normalization and the CSS variable map consumed by useChatWidth
+
+export const CHAT_WIDTH_MODES = ["standard", "wide", "full"] as const;
+export type ChatWidthMode = (typeof CHAT_WIDTH_MODES)[number];
+
+export const DEFAULT_CHAT_WIDTH: ChatWidthMode = "standard";
+
+/**
+ * Max width applied to the centered chat column (transcript + composer).
+ * - standard: the historical 46rem reading column.
+ * - wide: a roomier 72rem column for dense content like tables.
+ * - full: let the column grow to the full available window width.
+ */
+const CHAT_MAX_WIDTH_BY_MODE: Record<ChatWidthMode, string> = {
+  standard: "46rem",
+  wide: "72rem",
+  full: "100%",
+};
+
+export function isChatWidthMode(value: unknown): value is ChatWidthMode {
+  return typeof value === "string" && (CHAT_WIDTH_MODES as readonly string[]).includes(value);
+}
+
+export function normalizeChatWidthMode(
+  value: unknown,
+  fallback: ChatWidthMode = DEFAULT_CHAT_WIDTH,
+): ChatWidthMode {
+  return isChatWidthMode(value) ? value : fallback;
+}
+
+export function getChatWidthCssVariables(mode: ChatWidthMode = DEFAULT_CHAT_WIDTH) {
+  return {
+    "--app-chat-max-width": CHAT_MAX_WIDTH_BY_MODE[mode],
+  } as const;
+}
+
+export type ChatWidthCssVariable = keyof ReturnType<typeof getChatWidthCssVariables>;

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -98,6 +98,7 @@ import { hasPendingTurnDispatch } from "../pendingTurnDispatch";
 import { canApplyThreadSnapshot, selectOrphanedThreadDetailIds } from "./-threadDetailOwnership";
 import { getThreadFromState, getThreadsFromState } from "../threadDerivation";
 import { useAppDensity } from "../hooks/useAppDensity";
+import { useChatWidth } from "../hooks/useChatWidth";
 import { useDesktopAppIcon } from "../hooks/useDesktopAppIcon";
 import { useAppTypography } from "../hooks/useAppTypography";
 import { usePreloadRouteChunks } from "../hooks/usePreloadRouteChunks";
@@ -196,6 +197,7 @@ export const Route = createRootRouteWithContext<{
 function RootRouteView() {
   useAppTypography();
   useAppDensity();
+  useChatWidth();
   useDesktopAppIcon();
   usePreloadRouteChunks();
   useNativeFontSmoothing();

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -13,6 +13,7 @@ import {
   type AppSettings,
   type FollowUpBehavior,
   DEFAULT_UI_DENSITY,
+  DEFAULT_CHAT_WIDTH,
   type UiDensity,
   MAX_CHAT_FONT_SIZE_PX,
   MAX_TERMINAL_FONT_SIZE_PX,
@@ -85,6 +86,7 @@ import { SidebarHeaderNavigationControls } from "../components/SidebarHeaderNavi
 import { useDesktopTopBarTrafficLightGutterClassName } from "../hooks/useDesktopTopBarGutter";
 import { useTheme } from "../hooks/useTheme";
 import { isUiDensity } from "../lib/appDensity";
+import { isChatWidthMode, type ChatWidthMode } from "../lib/chatWidth";
 import { isElectron } from "../env";
 import { RotateCcwIcon } from "../lib/icons";
 import { cn, isMacPlatform } from "../lib/utils";
@@ -118,6 +120,28 @@ const UI_DENSITY_OPTIONS = [
   },
 ] as const satisfies ReadonlyArray<{
   value: UiDensity;
+  label: string;
+  description: string;
+}>;
+
+const CHAT_WIDTH_OPTIONS = [
+  {
+    value: "standard",
+    label: "Standard",
+    description: "Keeps the chat column at the default reading width (46rem).",
+  },
+  {
+    value: "wide",
+    label: "Wide",
+    description: "Gives tables and wide content more room (72rem).",
+  },
+  {
+    value: "full",
+    label: "Full",
+    description: "Lets the chat column use the full window width.",
+  },
+] as const satisfies ReadonlyArray<{
+  value: ChatWidthMode;
   label: string;
   description: string;
 }>;
@@ -221,6 +245,7 @@ function SettingsRouteView() {
     ...(settings.showChatsSection !== defaults.showChatsSection ? ["Chats section"] : []),
     ...(settings.showStudioSection !== defaults.showStudioSection ? ["Studio section"] : []),
     ...(settings.uiDensity !== defaults.uiDensity ? ["UI density"] : []),
+    ...(settings.chatWidth !== defaults.chatWidth ? ["Chat width"] : []),
     ...(settings.desktopAppIcon !== defaults.desktopAppIcon ? ["App icon"] : []),
     ...(settings.chatFontSizePx !== defaults.chatFontSizePx ? ["Base font size"] : []),
     ...(settings.terminalFontSizePx !== defaults.terminalFontSizePx ? ["Terminal font size"] : []),
@@ -709,6 +734,36 @@ function SettingsRouteView() {
               }}
               ariaLabel="UI density"
               options={UI_DENSITY_OPTIONS}
+            />
+          }
+        />
+
+        <SettingsRow
+          title="Chat width"
+          description="Control how wide the chat column grows. Wide and Full give tables and wide content more room."
+          resetAction={
+            settings.chatWidth !== defaults.chatWidth ? (
+              <SettingResetButton
+                label="chat width"
+                onClick={() =>
+                  updateSettings({
+                    chatWidth: DEFAULT_CHAT_WIDTH,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <SettingsSegmentedControl
+              value={settings.chatWidth}
+              onValueChange={(value) => {
+                if (!isChatWidthMode(value)) {
+                  return;
+                }
+                updateSettings({ chatWidth: value });
+              }}
+              ariaLabel="Chat width"
+              options={CHAT_WIDTH_OPTIONS}
             />
           }
         />

--- a/apps/web/src/settingsSearchIndex.ts
+++ b/apps/web/src/settingsSearchIndex.ts
@@ -164,6 +164,13 @@ export const SETTINGS_SEARCH_ENTRIES: readonly SettingsSearchEntry[] = [
       "Control spacing in the sidebar, composer, chat gutters, and settings rows without changing font size. compact comfortable",
   },
   {
+    id: "appearance:chat-width",
+    section: "appearance",
+    title: "Chat width",
+    keywords:
+      "Control how wide the chat column grows so tables and wide content get more room. standard wide full",
+  },
+  {
     id: "appearance:base-font-size",
     section: "appearance",
     title: "Base font size",


### PR DESCRIPTION
## What Changed

Adds a **Chat width** setting (*Settings → Appearance*) with three presets that control how wide the centered chat column may grow:

- **Standard** — 46rem (today's default)
- **Wide** — 72rem, gives tables and dense content more room
- **Full** — the column uses the full window width

The transcript and composer columns previously shared a hard-coded `max-w-[46rem]`, so wide tables compressed their headers onto multiple lines in narrower windows. The setting maps to a root `--app-chat-max-width` CSS variable that `CHAT_COLUMN_FRAME_CLASS_NAME` / `COMPOSER_COLUMN_FRAME_CLASS_NAME` now reference with the old 46rem as fallback, so nothing changes until a preset is chosen.

## Why

Fixes #658. The existing UI density setting already demonstrates the CSS-variable-driven appearance pattern; this follows it, keeping the change small and non-invasive.

## UI Changes

New segmented control in Settings → Appearance:

```
UI density      [ Compact | Comfortable | Spacious ]
Chat width      [ Standard | Wide | Full ]
```

## Verification

- `bunx tsc --noEmit` (apps/web) passes.
- `bunx oxlint` — 0 errors on changed files.
- `bunx oxfmt --check` passes.
- Unit tests: new `chatWidth.test.ts` (mode normalization + CSS variable mapping); `appSettings.test.ts` still passes (new key decodes to its default).
- Browser test `applies the selected chat width to the transcript column` mounts the app with `chatWidth: "wide"` in app settings and asserts the root variable is `72rem` and a rendered transcript row's computed `max-width` is 1152px (72rem).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Included before/after for the new settings control