### PR TITLE
fix(web): show Pull in the chat header when behind upstream

### DIFF
--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -16,10 +16,13 @@ import {
   resolveDefaultCreateBranchName,
   resolveDefaultBranchActionDialogCopy,
   resolveLiveThreadBranchUpdate,
+  resolvePromotedPullPresentation,
   resolvePullActionAvailability,
   resolveQuickAction,
   shouldOfferCreateBranchPrompt,
+  shouldPromotePullAction,
   shouldShowEnvironmentPanelPullRow,
+  shouldShowHeaderPullAction,
   summarizeGitResult,
 } from "./GitActionsControl.logic";
 
@@ -467,6 +470,15 @@ describe("when: branch is behind upstream", () => {
     );
   });
 
+  it("shouldShowHeaderPullAction surfaces Pull next to Hand off while behind", () => {
+    const quick = resolveQuickAction(status({ behindCount: 2 }), false);
+    assert.equal(shouldShowHeaderPullAction({ quickAction: quick, isPullRunning: false }), true);
+    assert.equal(shouldPromotePullAction({ quickAction: quick, isPullRunning: false }), true);
+    assert.deepEqual(resolvePromotedPullPresentation({ quickAction: quick, isPullRunning: false }), {
+      label: "Pull",
+    });
+  });
+
   it("shouldShowEnvironmentPanelPullRow keeps the Pull row visible while pulling", () => {
     const busyQuickAction = resolveQuickAction(status({ behindCount: 2 }), true);
     assert.equal(
@@ -475,6 +487,32 @@ describe("when: branch is behind upstream", () => {
         isPullRunning: true,
       }),
       true,
+    );
+    assert.equal(
+      shouldShowHeaderPullAction({
+        quickAction: busyQuickAction,
+        isPullRunning: true,
+      }),
+      true,
+    );
+    assert.deepEqual(
+      resolvePromotedPullPresentation({
+        quickAction: busyQuickAction,
+        isPullRunning: true,
+      }),
+      { label: "Pulling..." },
+    );
+  });
+
+  it("resolvePromotedPullPresentation does not use the busy Commit hint", () => {
+    const busyQuickAction = resolveQuickAction(status({ behindCount: 2 }), true);
+    assert.deepInclude(busyQuickAction, { label: "Commit", kind: "show_hint", disabled: true });
+    assert.equal(
+      resolvePromotedPullPresentation({
+        quickAction: busyQuickAction,
+        isPullRunning: false,
+      }),
+      null,
     );
   });
 
@@ -551,6 +589,11 @@ describe("when: branch is up to date", () => {
     assert.equal(
       shouldShowEnvironmentPanelPullRow({ quickAction: quick, isPullRunning: false }),
       false,
+    );
+    assert.equal(shouldShowHeaderPullAction({ quickAction: quick, isPullRunning: false }), false);
+    assert.equal(
+      resolvePromotedPullPresentation({ quickAction: quick, isPullRunning: false }),
+      null,
     );
   });
 });

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -474,9 +474,12 @@ describe("when: branch is behind upstream", () => {
     const quick = resolveQuickAction(status({ behindCount: 2 }), false);
     assert.equal(shouldShowHeaderPullAction({ quickAction: quick, isPullRunning: false }), true);
     assert.equal(shouldPromotePullAction({ quickAction: quick, isPullRunning: false }), true);
-    assert.deepEqual(resolvePromotedPullPresentation({ quickAction: quick, isPullRunning: false }), {
-      label: "Pull",
-    });
+    assert.deepEqual(
+      resolvePromotedPullPresentation({ quickAction: quick, isPullRunning: false }),
+      {
+        label: "Pull",
+      },
+    );
   });
 
   it("shouldShowEnvironmentPanelPullRow keeps the Pull row visible while pulling", () => {

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -644,14 +644,47 @@ export function resolvePullActionAvailability(input: {
   return { canRun: true, hint: null };
 }
 
-/** Environment panel should promote Pull while it is available or already running. */
-export function shouldShowEnvironmentPanelPullRow(input: {
+/** Promote Pull as the primary git affordance while it is available or already running. */
+export function shouldPromotePullAction(input: {
   quickAction: GitQuickAction;
   isPullRunning: boolean;
 }): boolean {
   return (
     input.isPullRunning || (input.quickAction.kind === "run_pull" && !input.quickAction.disabled)
   );
+}
+
+export interface PromotedPullPresentation {
+  label: string;
+}
+
+/**
+ * Chrome for a promoted Pull control. `resolveQuickAction` collapses to a disabled
+ * "Commit" hint while any git action is running, so callers must not use that label
+ * while Pull is the promoted affordance.
+ */
+export function resolvePromotedPullPresentation(input: {
+  quickAction: GitQuickAction;
+  isPullRunning: boolean;
+}): PromotedPullPresentation | null {
+  if (!shouldPromotePullAction(input)) return null;
+  return { label: input.isPullRunning ? "Pulling..." : "Pull" };
+}
+
+/** Environment panel should promote Pull while it is available or already running. */
+export function shouldShowEnvironmentPanelPullRow(input: {
+  quickAction: GitQuickAction;
+  isPullRunning: boolean;
+}): boolean {
+  return shouldPromotePullAction(input);
+}
+
+/** Header Environment mode should surface Pull next to Hand off / Add action. */
+export function shouldShowHeaderPullAction(input: {
+  quickAction: GitQuickAction;
+  isPullRunning: boolean;
+}): boolean {
+  return shouldPromotePullAction(input);
 }
 
 export function shouldOfferCreateBranchPrompt(input: {

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -13,7 +13,7 @@ import type {
   ThreadId,
 } from "@synara/contracts";
 import { useIsMutating, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import {
   ChevronDownIcon,
   CloudSyncIcon,
@@ -44,7 +44,7 @@ import {
   resolveCreatePrExecution,
   resolveQuickAction,
   resolvePullActionAvailability,
-  shouldShowEnvironmentPanelPullRow,
+  resolvePromotedPullPresentation,
   shouldOfferCreateBranchPrompt,
   summarizeGitResult,
 } from "./GitActionsControl.logic";
@@ -57,6 +57,7 @@ import { getProviderStartOptions, useAppSettings } from "~/appSettings";
 import { formatClockDuration } from "~/session-logic";
 import { Button } from "~/components/ui/button";
 import {
+  ChatHeaderButton,
   ChatHeaderSplitDivider,
   ChatHeaderSplitGroup,
   CHAT_HEADER_CONTROL_CLASS_NAME,
@@ -120,6 +121,10 @@ interface GitActionsControlProps {
   // `header` renders the split quick-action button; `panel` collapses git actions into
   // an Environment row + dropdown, promoting Pull as the primary row when behind upstream.
   variant?: "header" | "panel";
+  // `always` (default) keeps the control mounted. `pull-available` hides the header
+  // control unless Pull is the current action or a pull is already running — used
+  // next to Hand off / Add action while Environment owns the rest of git actions.
+  visibleWhen?: "always" | "pull-available";
   // Lets a parent capture "run commit & push for this instance's repo" so a global
   // keyboard shortcut can trigger it without duplicating the action logic. Called with
   // `null` on unmount/dependency change so a stale trigger never lingers.
@@ -359,11 +364,14 @@ export default function GitActionsControl({
   activeThreadId,
   hideQuickActionLabel: hideQuickActionLabelProp,
   variant: variantProp,
+  visibleWhen: visibleWhenProp,
   onRegisterCommitAndPushTrigger,
 }: GitActionsControlProps) {
   const hideQuickActionLabel = hideQuickActionLabelProp ?? false;
   const variant = variantProp ?? "header";
+  const visibleWhen = visibleWhenProp ?? "always";
   const isPanel = variant === "panel";
+  const createBranchNameFieldId = useId();
   const { settings } = useAppSettings();
   // Manual memoization kept: this file does not compile under React Compiler (see compile-report).
   const providerOptions = useMemo(() => getProviderStartOptions(settings), [settings]);
@@ -1390,6 +1398,9 @@ export default function GitActionsControl({
 
   useEffect(() => {
     if (!onRegisterCommitAndPushTrigger) return;
+    // Pull-only header instances must not steal the Environment panel's commit &
+    // push shortcut registration, including while they are hidden.
+    if (visibleWhen === "pull-available") return;
     const target = findRunnableCommitPushMenuItem(gitActionMenuItems);
     if (!target) {
       onRegisterCommitAndPushTrigger(null);
@@ -1397,7 +1408,7 @@ export default function GitActionsControl({
     }
     onRegisterCommitAndPushTrigger(() => openDialogForMenuItem(target));
     return () => onRegisterCommitAndPushTrigger(null);
-  }, [gitActionMenuItems, onRegisterCommitAndPushTrigger, openDialogForMenuItem]);
+  }, [gitActionMenuItems, onRegisterCommitAndPushTrigger, openDialogForMenuItem, visibleWhen]);
 
   const gitPickerMenuItems = useMemo<GitPickerMenuItem[]>(() => {
     const items: GitPickerMenuItem[] = [];
@@ -1565,6 +1576,33 @@ export default function GitActionsControl({
   );
 
   if (!gitCwd) return null;
+
+  const promotedPull = resolvePromotedPullPresentation({
+    quickAction,
+    isPullRunning,
+  });
+  const showPromotedPullAction = promotedPull !== null;
+  if (visibleWhen === "pull-available") {
+    if (!promotedPull) return null;
+    // Pull-only chrome: Environment already owns commit/push/PR dialogs, so this
+    // instance must not mount a second copy of them beside the panel control.
+    return (
+      <ChatHeaderButton
+        type="button"
+        tone="outline"
+        className={hideQuickActionLabel ? "gap-1" : "gap-1.5"}
+        aria-label={promotedPull.label}
+        title={promotedPull.label}
+        disabled={isGitActionRunning}
+        onClick={runSyncWithRemote}
+      >
+        <GitActionGlyph name="sync" />
+        {!hideQuickActionLabel ? (
+          <span className="truncate font-normal">{promotedPull.label}</span>
+        ) : null}
+      </ChatHeaderButton>
+    );
+  }
 
   const hasRunnableCommitPushAction = findRunnableCommitPushMenuItem(gitActionMenuItems) !== null;
   const shouldDimPanelCommitPushRow = isGitActionRunning || !hasRunnableCommitPushAction;
@@ -1892,12 +1930,12 @@ export default function GitActionsControl({
               }}
             >
               <div className="space-y-1.5">
-                <label className="block font-medium text-sm" htmlFor="create-branch-name">
+                <label className="block font-medium text-sm" htmlFor={createBranchNameFieldId}>
                   Branch name
                 </label>
                 <Input
                   autoFocus
-                  id="create-branch-name"
+                  id={createBranchNameFieldId}
                   placeholder="feature/my-change"
                   value={createBranchName}
                   onChange={(event) => setCreateBranchName(event.target.value)}
@@ -1934,10 +1972,7 @@ export default function GitActionsControl({
   );
 
   if (isPanel) {
-    const showPanelPullRow = shouldShowEnvironmentPanelPullRow({
-      quickAction,
-      isPullRunning,
-    });
+    const showPanelPullRow = showPromotedPullAction;
     const panelGitActionsMenu = (
       <Menu
         onOpenChange={(open) => {
@@ -2001,14 +2036,14 @@ export default function GitActionsControl({
             <button
               type="button"
               className={cn(ENVIRONMENT_ROW_CLASS_NAME, "min-w-0 flex-1")}
-              aria-label="Pull"
-              title="Pull"
+              aria-label={promotedPull?.label ?? "Pull"}
+              title={promotedPull?.label ?? "Pull"}
               disabled={isGitActionRunning}
-              onClick={runQuickAction}
+              onClick={runSyncWithRemote}
             >
               <EnvironmentRowBody
                 icon={<GitActionGlyph name="sync" className={ENVIRONMENT_ROW_ICON_CLASS_NAME} />}
-                label={isPullRunning ? "Pulling..." : "Pull"}
+                label={promotedPull?.label ?? "Pull"}
               />
             </button>
             {panelGitActionsMenu}
@@ -2035,7 +2070,28 @@ export default function GitActionsControl({
         </Button>
       ) : (
         <ChatHeaderSplitGroup label="Git actions">
-          {quickActionDisabledReason ? (
+          {promotedPull ? (
+            <Button
+              variant="chrome-outline"
+              size={hideQuickActionLabel ? "icon-xs" : "xs"}
+              className={cn(
+                hideQuickActionLabel
+                  ? CHAT_HEADER_ICON_CONTROL_CLASS_NAME
+                  : CHAT_HEADER_CONTROL_CLASS_NAME,
+                CHAT_HEADER_ICON_STRENGTH_CLASS_NAME,
+                CHAT_HEADER_SPLIT_LEADING_CLASS_NAME,
+              )}
+              disabled={isGitActionRunning}
+              aria-label={promotedPull.label}
+              title={promotedPull.label}
+              onClick={runSyncWithRemote}
+            >
+              <GitActionGlyph name="sync" />
+              {!hideQuickActionLabel ? (
+                <span className="font-normal">{promotedPull.label}</span>
+              ) : null}
+            </Button>
+          ) : quickActionDisabledReason ? (
             <Popover>
               <PopoverTrigger
                 openOnHover

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -832,6 +832,15 @@ export function ChatHeader({
           />
         ) : null}
 
+        {environment && activeProjectName && showGitActions ? (
+          <GitActionsControl
+            gitCwd={gitCwd}
+            activeThreadId={activeThreadId}
+            hideQuickActionLabel={compact}
+            visibleWhen="pull-available"
+          />
+        ) : null}
+
         {inlineChatLayoutAction ? (
           <Tooltip>
             <TooltipTrigger
@@ -867,8 +876,9 @@ export function ChatHeader({
           </Tooltip>
         ) : null}
 
-        {/* Environment: one button consolidating Open-in-editor and git actions into the
-            Environment panel. The right-side panel control stays beside it, acting as the
+        {/* Environment: one button consolidating Open-in-editor and most git actions into
+            the Environment panel. Pull still appears in this action cluster when the
+            branch is behind. The right-side panel control stays beside it, acting as the
             multi-pane dock toggle on single chats and the legacy diff toggle in split hosts.
             Falls back to the legacy controls when no environment is resolved. */}
         {environment ? (


### PR DESCRIPTION
## What Changed

When Environment mode is on, git actions live in the Environment panel, so **Pull** never appeared in the chat header next to Hand off / Add action even if the branch was behind upstream.

This surfaces a Pull-only header button in that case, keeps **Pull** / **Pulling...** chrome while a pull runs (instead of collapsing to a disabled Commit hint), and leaves commit/push/PR dialogs in Environment.

## Why

A fast-forward pull is a common, time-sensitive action. Hiding it behind Environment made it look like Pull was unavailable. Reusing the full git-actions control in the header would duplicate dialogs, so the header instance is Pull-only.

Fixes #661

## UI Changes

<img width="366" height="48" alt="image" src="https://github.com/user-attachments/assets/e92de361-ed8b-438c-85fb-d4a871cedbc6" />

Header action cluster when the branch is behind upstream:

- Before: `Hand off · Add action · Environment`
- After: `Hand off · Add action · Pull · Environment`

While a pull is running the header stays on **Pulling...** instead of switching to a disabled **Commit** button.

## Verification

- `bun run test src/components/GitActionsControl.logic.test.ts` (apps/web) — 123 passed, including promoted Pull chrome while busy and hidden when up to date.
- `bunx oxfmt` on the changed test file (CI `fmt:check` failure).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes