### PR TITLE
Harden release workflow token permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,7 @@ on:
         default: false
         type: boolean
 
-permissions:
-  contents: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: synara-desktop-release
@@ -29,6 +27,8 @@ jobs:
     name: Preflight
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.release_meta.outputs.version }}
       tag: ${{ steps.release_meta.outputs.tag }}
@@ -158,6 +158,8 @@ jobs:
     needs: preflight
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -390,6 +392,9 @@ jobs:
     needs: [preflight, build]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -424,6 +429,8 @@ jobs:
     needs: [preflight, build]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -613,6 +620,8 @@ jobs:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -122,7 +122,45 @@ function verifyCanonicalIdentity(): void {
 }
 
 function verifyReleaseWorkflowSafety(): void {
-  const workflow = readFileSync(resolve(repoRoot, ".github/workflows/release.yml"), "utf8");
+  const workflow = readFileSync(resolve(repoRoot, ".github/workflows/release.yml"), "utf8").replaceAll(
+    "\r\n",
+    "\n",
+  );
+  assertContains(
+    workflow,
+    "\npermissions: {}\n",
+    "Expected the release workflow to deny GITHUB_TOKEN permissions by default.",
+  );
+  assertNotContains(
+    workflow,
+    "permissions:\n  contents: write\n  id-token: write",
+    "Release-wide publication permissions must not be inherited by every job.",
+  );
+  assertContains(
+    workflow,
+    "  preflight:\n    name: Preflight\n    runs-on: ubuntu-24.04\n    timeout-minutes: 15\n    permissions:\n      contents: read",
+    "Expected preflight to receive read-only repository access.",
+  );
+  assertContains(
+    workflow,
+    "  build:\n    name: Build ${{ matrix.label }}\n    needs: preflight\n    runs-on: ${{ matrix.runner }}\n    timeout-minutes: 30\n    permissions:\n      contents: read",
+    "Expected artifact builds to receive read-only repository access.",
+  );
+  assertContains(
+    workflow,
+    "    permissions:\n      contents: read\n      id-token: write\n    steps:",
+    "Expected only CLI publication to combine repository reads with npm OIDC.",
+  );
+  assertContains(
+    workflow,
+    "  release:\n    name: Publish GitHub Release\n    if: ${{ needs.preflight.outputs.publish_release == 'true' }}\n    needs: [preflight, build]\n    runs-on: ubuntu-24.04\n    timeout-minutes: 10\n    permissions:\n      contents: write",
+    "Expected only GitHub release publication to receive contents write access.",
+  );
+  assertContains(
+    workflow,
+    "repositories: ${{ github.event.repository.name }}\n          permission-contents: write",
+    "Expected release finalization to mint a repository-scoped contents token.",
+  );
   assertContains(
     workflow,
     "publish_release:\n        description:",

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -122,10 +122,10 @@ function verifyCanonicalIdentity(): void {
 }
 
 function verifyReleaseWorkflowSafety(): void {
-  const workflow = readFileSync(resolve(repoRoot, ".github/workflows/release.yml"), "utf8").replaceAll(
-    "\r\n",
-    "\n",
-  );
+  const workflow = readFileSync(
+    resolve(repoRoot, ".github/workflows/release.yml"),
+    "utf8",
+  ).replaceAll("\r\n", "\n");
   assertContains(
     workflow,
     "\npermissions: {}\n",


### PR DESCRIPTION
## Summary

- deny all GITHUB_TOKEN permissions by default in the desktop release workflow
- grant read-only contents access to preflight and artifact builds
- isolate npm OIDC and GitHub release write access to their publishing jobs
- scope the finalizer GitHub App token to this repository and contents write only
- extend the release smoke check to preserve those boundaries and normalize Windows line endings

## Verification

- `bun run release:smoke` passed with Bun 1.3.12
- release workflow parsed successfully as YAML
- `git diff --check` passed