### PR TITLE
fix(opencode): trim running tool titles before persistence

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -4696,7 +4696,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
               callID: "task-call-1",
               state: {
                 status: "running",
-                title: "Find changelog implementation",
+                title: "\nFind changelog implementation\n",
                 input: {
                   description: "Find changelog implementation",
                   prompt: "Explore changelog files.",

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -2459,7 +2459,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
               rememberRelatedOpenCodeSession(context, part);
               const itemType = toToolLifecycleItemType(part.tool);
               const title =
-                part.state.status === "running" ? (part.state.title ?? part.tool) : part.tool;
+                part.state.status === "running" ? part.state.title?.trim() || part.tool : part.tool;
               const detail = detailFromToolPart(part);
               const payload = {
                 itemType,


### PR DESCRIPTION
## Problem

OpenCode running-tool titles arrive straight from the event stream and can carry surrounding whitespace. `ItemLifecyclePayload.title` requires `TrimmedNonEmptyString`, so an untrimmed title fails the durable journal's encode step. The runtime-event pump treats that as a permanent failure and quarantines the event: the real `item.started`/`item.updated` is dropped from the journal, replaced by a `runtime.warning`, and the pump goes degraded.

This is the same failure mode reported in #660 and fixed for `detail` by #630. `title` was the one item-lifecycle field still fed untrimmed provider text.

## Fix

Trim the running title at the adapter boundary and fall back to the tool name when trimming leaves nothing:

```ts
part.state.status === "running" ? part.state.title?.trim() || part.tool : part.tool
```

One expression, identical to the pattern GrokAdapter already uses. Titles stay non-empty as the contract requires, which is why this is adapter-side rather than another contract relaxation (a blank title is a broken UI label; the tool-name fallback only exists at the adapter).

## Testing

- Regression fixture: the existing child-session tool test now feeds a newline-padded running title; it fails without the fix and passes with it (red-green verified on this exact diff)
- `apps/server` OpenCodeAdapter suite: 76/76
- Full `apps/server` suite: 3752 passed / 16 pre-existing platform skips
- Real-provider e2e against the live opencode CLI (free model, real `bash` + `read` tools): turn completes, all events journaled, 0 quarantine rows, pump healthy — across multiple runs
- CI-parity gates run locally: `brand:check`, `fmt:check`, `lint`, `typecheck` (7/7 workspaces), contracts suite (205/205)

## Related

- Fixes the remaining half of #660 (reporter's version, v0.7.1, predates both #630 and this PR)
- Supersedes my earlier closed #505, which normalized both detail and title at the adapter boundary; detail is now handled by #630, so this PR keeps only the title piece
- Other adapters were audited: grok already trims, antigravity already trims, claude/codex/pi derive titles instead of passing raw text, cursor/droid emit no title field — no other provider needs this change
