### PR TITLE
fix(server): truncate oversized provider runtime event payloads instead of quarantining them

### DIFF
--- a/apps/server/src/persistence/Layers/ProviderRuntimeEvents.test.ts
+++ b/apps/server/src/persistence/Layers/ProviderRuntimeEvents.test.ts
@@ -1,5 +1,6 @@
 import {
   EventId,
+  RuntimeItemId,
   RuntimeTaskId,
   ThreadId,
   TurnId,
@@ -15,7 +16,10 @@ import {
   PROVIDER_RUNTIME_INGESTION_CONSUMER,
   ProviderRuntimeEventRepository,
 } from "../Services/ProviderRuntimeEvents.ts";
-import { ProviderRuntimeEventRepositoryLive } from "./ProviderRuntimeEvents.ts";
+import {
+  ProviderRuntimeEventRepositoryLive,
+  truncateUtf8ToBytes,
+} from "./ProviderRuntimeEvents.ts";
 import { SqlitePersistenceMemory } from "./Sqlite.ts";
 import { assignDerivedProviderRuntimeEventIds } from "../../provider/providerRuntimeEventIdentity.ts";
 
@@ -253,6 +257,120 @@ layer("ProviderRuntimeEventRepository", (it) => {
       assert.isNumber(compactedRaw?.originalBytes);
     }),
   );
+
+  it.effect("journals an oversized Pi item.completed by truncating payload string leaves", () =>
+    Effect.gen(function* () {
+      const repository = yield* ProviderRuntimeEventRepository;
+      const oversizedResult = "x".repeat(PROVIDER_RUNTIME_EVENT_MAX_BYTES * 2);
+      const oversizedEvent = {
+        type: "item.completed",
+        eventId: EventId.makeUnsafe("runtime-event-oversized-pi"),
+        provider: "pi",
+        createdAt: "2026-07-14T00:03:00.000Z",
+        threadId: ThreadId.makeUnsafe("thread-runtime-journal"),
+        turnId: TurnId.makeUnsafe("turn-runtime-journal"),
+        itemId: RuntimeItemId.makeUnsafe("item-oversized-pi"),
+        payload: {
+          itemType: "command_execution",
+          status: "completed",
+          title: "Run bash",
+          detail: oversizedResult,
+          data: { toolCallId: "call-1", toolName: "bash", result: oversizedResult },
+        },
+        raw: {
+          source: "pi.sdk.event",
+          messageType: "tool_result",
+          payload: { result: oversizedResult },
+        },
+      } satisfies ProviderRuntimeEvent;
+
+      const persisted = yield* repository.append(oversizedEvent);
+      assert.strictEqual(persisted.event.eventId, oversizedEvent.eventId);
+      if (persisted.event.type === "item.completed") {
+        const detail = persisted.event.payload.detail;
+        assert.isString(detail);
+        if (typeof detail === "string") {
+          assert.isBelow(detail.length, oversizedResult.length);
+        }
+        const data = persisted.event.payload.data as { readonly result?: string } | undefined;
+        const dataResult = data?.result;
+        assert.isString(dataResult);
+        if (typeof dataResult === "string") {
+          assert.isBelow(dataResult.length, oversizedResult.length);
+        }
+      }
+      const rawPayload = persisted.event.raw?.payload as
+        | {
+            readonly synaraTruncated?: unknown;
+            readonly originalBytes?: unknown;
+          }
+        | undefined;
+      assert.deepInclude(rawPayload, { synaraTruncated: true });
+      const originalBytes = rawPayload?.originalBytes;
+      assert.isNumber(originalBytes);
+      if (typeof originalBytes === "number") {
+        assert.isAbove(originalBytes, PROVIDER_RUNTIME_EVENT_MAX_BYTES);
+      }
+
+      const rows = yield* repository.readAfter({
+        sequenceExclusive: persisted.sequence - 1,
+        throughSequenceInclusive: persisted.sequence,
+        limit: 1,
+      });
+      assert.strictEqual(rows[0]?.event.eventId, "runtime-event-oversized-pi");
+
+      const duplicate = yield* repository.append(oversizedEvent);
+      assert.strictEqual(duplicate.sequence, persisted.sequence);
+    }),
+  );
+
+  it.effect("journals an oversized raw-less event by truncating its payload leaves", () =>
+    Effect.gen(function* () {
+      const repository = yield* ProviderRuntimeEventRepository;
+      const oversizedDelta = "y".repeat(PROVIDER_RUNTIME_EVENT_MAX_BYTES * 2);
+      const oversizedEvent = runtimeEvent("runtime-event-oversized-payload", oversizedDelta);
+
+      const persisted = yield* repository.append(oversizedEvent);
+      assert.strictEqual(persisted.event.eventId, oversizedEvent.eventId);
+      assert.strictEqual(persisted.event.raw, undefined);
+      if (persisted.event.type === "content.delta") {
+        assert.isBelow(persisted.event.payload.delta.length, oversizedDelta.length);
+      }
+    }),
+  );
+
+  it.effect("still rejects an event whose oversized bulk is not string leaves", () =>
+    Effect.gen(function* () {
+      const repository = yield* ProviderRuntimeEventRepository;
+      const oversizedEvent = {
+        type: "item.completed",
+        eventId: EventId.makeUnsafe("runtime-event-oversized-numbers"),
+        provider: "pi",
+        createdAt: "2026-07-14T00:04:00.000Z",
+        threadId: ThreadId.makeUnsafe("thread-runtime-journal"),
+        turnId: TurnId.makeUnsafe("turn-runtime-journal"),
+        payload: {
+          itemType: "command_execution",
+          status: "completed",
+          title: "Number flood",
+          data: {
+            values: Array.from({ length: PROVIDER_RUNTIME_EVENT_MAX_BYTES / 5 }, (_, i) => i),
+          },
+        },
+      } satisfies ProviderRuntimeEvent;
+
+      const failure = yield* Effect.flip(repository.append(oversizedEvent));
+      assert.strictEqual(failure._tag, "PersistenceDecodeError");
+    }),
+  );
+
+  it("truncateUtf8ToBytes never splits a UTF-8 code point", () => {
+    const emoji = "🙂".repeat(10_000);
+    const truncated = truncateUtf8ToBytes(emoji, 999);
+    assert.isBelow(Buffer.byteLength(truncated, "utf8"), 1_000);
+    assert.isFalse(truncated.includes("\uFFFD"));
+    assert.strictEqual(Buffer.from(truncated, "utf8").toString("utf8"), truncated);
+  });
 
   it.effect("journals every canonical event derived from one provider notification", () =>
     Effect.gen(function* () {

--- a/apps/server/src/persistence/Layers/ProviderRuntimeEvents.ts
+++ b/apps/server/src/persistence/Layers/ProviderRuntimeEvents.ts
@@ -45,6 +45,49 @@ const StoredRowSchema = Schema.Struct({
 });
 const decodeStoredRow = Schema.decodeUnknownEffect(StoredRowSchema);
 
+/**
+ * Longest-prefix string truncation that never splits a UTF-8 code point.
+ * Returns the whole string when it already fits.
+ */
+export const truncateUtf8ToBytes = (value: string, maxBytes: number): string => {
+  const encoded = Buffer.from(value, "utf8");
+  if (encoded.byteLength <= maxBytes) return value;
+  let prefixEnd = maxBytes;
+  while (prefixEnd > 0 && ((encoded[prefixEnd] ?? 0) & 0xc0) === 0x80) {
+    prefixEnd -= 1;
+  }
+  return encoded.subarray(0, prefixEnd).toString("utf8");
+};
+
+/**
+ * Budget assigned to every string leaf so a single oversized field (typically a
+ * provider tool result copied verbatim into `payload.detail` or `payload.data`)
+ * never exhausts the durable journal budget by itself.
+ */
+const JOURNAL_STRING_LEAF_BUDGET_BYTES = 64 * 1024;
+
+/**
+ * Shrink every string leaf inside a runtime event payload to the per-leaf
+ * budget, recursing through records and arrays. Non-string leaves are kept:
+ * they are either small structural fields or values with no safe truncation.
+ */
+export const shrinkRuntimeEventStrings = (value: unknown): unknown => {
+  if (typeof value === "string") {
+    return truncateUtf8ToBytes(value, JOURNAL_STRING_LEAF_BUDGET_BYTES);
+  }
+  if (Array.isArray(value)) {
+    return value.map(shrinkRuntimeEventStrings);
+  }
+  if (value !== null && typeof value === "object") {
+    const shrunk: Record<string, unknown> = {};
+    for (const [key, leaf] of Object.entries(value as Record<string, unknown>)) {
+      shrunk[key] = shrinkRuntimeEventStrings(leaf);
+    }
+    return shrunk;
+  }
+  return value;
+};
+
 const encodePersistableEvent = (event: ProviderRuntimeEvent) =>
   Effect.gen(function* () {
     const eventJson = yield* encodeEvent(event).pipe(
@@ -55,31 +98,40 @@ const encodePersistableEvent = (event: ProviderRuntimeEvent) =>
       return { event, eventJson };
     }
 
-    if (event.raw !== undefined) {
-      const compactedEvent = {
-        ...event,
-        raw: {
-          source: event.raw.source,
-          ...(event.raw.method !== undefined ? { method: event.raw.method } : {}),
-          ...(event.raw.messageType !== undefined ? { messageType: event.raw.messageType } : {}),
-          payload: {
-            synaraTruncated: true,
-            reason: "provider runtime event exceeded the durable journal size limit",
-            originalBytes,
-          },
-        },
-      } satisfies ProviderRuntimeEvent;
-      const compactedJson = yield* encodeEvent(compactedEvent).pipe(
-        Effect.mapError(toPersistenceDecodeError("ProviderRuntimeEvent.append.compact")),
-      );
-      if (Buffer.byteLength(compactedJson, "utf8") <= PROVIDER_RUNTIME_EVENT_MAX_BYTES) {
-        return { event: compactedEvent, eventJson: compactedJson };
-      }
+    // Shrink oversized string leaves so one huge tool output no longer strands
+    // the live item in quarantine. The raw payload is replaced by a forensics
+    // marker (its own copy of the tool output would otherwise re-blow the
+    // budget), while source/method/messageType survive for diagnostics.
+    const compactedEvent = {
+      ...event,
+      payload: shrinkRuntimeEventStrings(event.payload),
+      ...(event.raw !== undefined
+        ? {
+            raw: {
+              source: event.raw.source,
+              ...(event.raw.method !== undefined ? { method: event.raw.method } : {}),
+              ...(event.raw.messageType !== undefined
+                ? { messageType: event.raw.messageType }
+                : {}),
+              payload: {
+                synaraTruncated: true,
+                reason: "provider runtime event exceeded the durable journal size limit",
+                originalBytes,
+              },
+            },
+          }
+        : {}),
+    } as ProviderRuntimeEvent;
+    const compactedJson = yield* encodeEvent(compactedEvent).pipe(
+      Effect.mapError(toPersistenceDecodeError("ProviderRuntimeEvent.append.compact")),
+    );
+    if (Buffer.byteLength(compactedJson, "utf8") <= PROVIDER_RUNTIME_EVENT_MAX_BYTES) {
+      return { event: compactedEvent, eventJson: compactedJson };
     }
 
     return yield* new PersistenceDecodeError({
       operation: "ProviderRuntimeEvent.append",
-      issue: `Provider runtime event exceeds ${PROVIDER_RUNTIME_EVENT_MAX_BYTES} bytes after raw payload compaction.`,
+      issue: `Provider runtime event exceeds ${PROVIDER_RUNTIME_EVENT_MAX_BYTES} bytes after payload truncation and raw compaction.`,
     });
   });
 


### PR DESCRIPTION
﻿### Problem

Pi and OpenCode copy tool results verbatim into `item.completed` payloads (`payload.detail`, `payload.data.result`) and again into `raw`. When one event exceeds the 2MB durable journal budget, `ProviderRuntimeEvent.append` fails with `PersistenceDecodeError`, which is classified as a permanent journal failure: the event is quarantined and the UI floods the transcript with "Quarantined provider runtime event 'item.completed' after a permanent journal failure" warnings. The live item stays stuck open even though the provider stream is healthy.

### Fix

Before failing the append, truncate every string leaf in the event payload to a 64KB budget (UTF-8-safe prefix truncation, recursive over records and arrays), then compact `raw` as before with the `synaraTruncated` forensics marker plus `originalBytes`. The event is journaled, the item completes, and no warning is emitted. Events whose oversized bulk is non-string data still fail the append and keep the existing quarantine path as a last resort.

### Tests

`ProviderRuntimeEvents.test.ts`:

- oversized Pi `item.completed` with huge `detail`/`data.result`/`raw` is journaled truncated, keeps forensics, and duplicate appends stay idempotent
- oversized raw-less event is journaled with truncated payload leaves
- event whose bulk is non-string data still fails with `PersistenceDecodeError`
- `truncateUtf8ToBytes` never splits a UTF-8 code point
