### PR TITLE
feat: add workspace file and snippet search (#647)

### DIFF
--- a/apps/server/src/workspace/Layers/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/Layers/WorkspaceEntries.ts
@@ -7,6 +7,7 @@ import {
   listWorkspaceDirectories,
   resolveWorkspaceFileBySuffix,
   searchLocalEntries,
+  searchWorkspaceContent,
   searchWorkspaceEntries,
 } from "../../workspaceEntries";
 import { toWorkspaceEntriesError, WorkspaceEntries } from "../Services/WorkspaceEntries";
@@ -21,6 +22,11 @@ export const WorkspaceEntriesLive = Layer.succeed(WorkspaceEntries, {
     Effect.tryPromise({
       try: () => searchWorkspaceEntries(input),
       catch: (cause) => toWorkspaceEntriesError("search workspace entries", cause),
+    }),
+  searchContent: (input) =>
+    Effect.tryPromise({
+      try: () => searchWorkspaceContent(input),
+      catch: (cause) => toWorkspaceEntriesError("search workspace content", cause),
     }),
   discoverScripts: (input) =>
     Effect.tryPromise({

--- a/apps/server/src/workspace/Services/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/Services/WorkspaceEntries.ts
@@ -7,6 +7,8 @@ import type {
   ProjectDiscoverScriptsResult,
   ProjectListDirectoriesInput,
   ProjectListDirectoriesResult,
+  ProjectSearchContentInput,
+  ProjectSearchContentResult,
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
   ProjectSearchLocalEntriesInput,
@@ -20,6 +22,9 @@ export interface WorkspaceEntriesShape {
   readonly search: (
     input: ProjectSearchEntriesInput,
   ) => Effect.Effect<ProjectSearchEntriesResult, WorkspaceEntriesError>;
+  readonly searchContent: (
+    input: ProjectSearchContentInput,
+  ) => Effect.Effect<ProjectSearchContentResult, WorkspaceEntriesError>;
   readonly discoverScripts: (
     input: ProjectDiscoverScriptsInput,
   ) => Effect.Effect<ProjectDiscoverScriptsResult, WorkspaceEntriesError>;

--- a/apps/server/src/workspaceEntries.test.ts
+++ b/apps/server/src/workspaceEntries.test.ts
@@ -10,6 +10,7 @@ import * as ProcessRunner from "./processRunner";
 import {
   discoverProjectScripts,
   listWorkspaceDirectories,
+  searchWorkspaceContent,
   searchWorkspaceEntries,
 } from "./workspaceEntries";
 
@@ -452,5 +453,81 @@ describe("discoverProjectScripts", () => {
     expect(commandsByPath.get("apps/pnpm")).toBe("pnpm run dev");
     expect(commandsByPath.get("apps/yarn")).toBe("yarn dev");
     expect(commandsByPath.get("apps/npm")).toBe("npm run dev");
+  });
+});
+
+describe("searchWorkspaceContent", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const dir of tempDirs.splice(0, tempDirs.length)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("finds matching lines with path, line number, and text", async () => {
+    const cwd = makeTempDir("synara-content-search-basic-");
+    writeFile(
+      cwd,
+      "src/index.ts",
+      "export const a = 1;\nexport function findMe() {\n  return true;\n}\n",
+    );
+    writeFile(cwd, "src/other.ts", "const FINDME = 'x';\n");
+    writeFile(cwd, "README.md", "not a match\n");
+
+    const result = await searchWorkspaceContent({ cwd, query: "findme" });
+
+    expect(result.truncated).toBe(false);
+    expect(result.matches).toEqual([
+      { path: "src/index.ts", lineNumber: 2, lineText: "export function findMe() {" },
+      { path: "src/other.ts", lineNumber: 1, lineText: "const FINDME = 'x';" },
+    ]);
+  });
+
+  it("returns no matches for queries shorter than two characters", async () => {
+    const cwd = makeTempDir("synara-content-search-short-query-");
+    writeFile(cwd, "a.ts", "x\n");
+
+    const result = await searchWorkspaceContent({ cwd, query: "x" });
+
+    expect(result.matches).toEqual([]);
+    expect(result.truncated).toBe(false);
+  });
+
+  it("skips binary files", async () => {
+    const cwd = makeTempDir("synara-content-search-binary-");
+    writeFile(cwd, "text.ts", "needle in text\n");
+    writeFile(cwd, "blob.bin", "");
+    fs.writeFileSync(path.join(cwd, "blob.bin"), Buffer.from([0x00, 0x01, 0x02, 0x03]));
+
+    const result = await searchWorkspaceContent({ cwd, query: "needle" });
+
+    expect(result.matches).toEqual([
+      { path: "text.ts", lineNumber: 1, lineText: "needle in text" },
+    ]);
+  });
+
+  it("caps per-file matches so one hot file cannot crowd out others", async () => {
+    const cwd = makeTempDir("synara-content-search-per-file-cap-");
+    const hotLines = Array.from({ length: 10 }, () => "hot needle line\n").join("");
+    writeFile(cwd, "hot.ts", hotLines);
+    writeFile(cwd, "cold.ts", "needle in cold file\n");
+
+    const result = await searchWorkspaceContent({ cwd, query: "needle" });
+
+    const hotMatches = result.matches.filter((match) => match.path === "hot.ts");
+    expect(hotMatches.length).toBeLessThanOrEqual(5);
+    expect(result.matches.some((match) => match.path === "cold.ts")).toBe(true);
+  });
+
+  it("truncates when matches exceed the requested limit", async () => {
+    const cwd = makeTempDir("synara-content-search-limit-");
+    for (let index = 0; index < 20; index += 1) {
+      writeFile(cwd, `src/file${index}.ts`, `needle ${index}\n`);
+    }
+
+    const result = await searchWorkspaceContent({ cwd, query: "needle", limit: 5 });
+
+    expect(result.matches.length).toBeLessThanOrEqual(5);
+    expect(result.truncated).toBe(true);
   });
 });

--- a/apps/server/src/workspaceEntries.test.ts
+++ b/apps/server/src/workspaceEntries.test.ts
@@ -506,6 +506,22 @@ describe("searchWorkspaceContent", () => {
     ]);
   });
 
+  it.skipIf(process.platform === "win32")(
+    "does not follow tracked symlinks outside the workspace",
+    async () => {
+      const cwd = makeTempDir("synara-content-search-symlink-");
+      const outside = makeTempDir("synara-content-search-outside-");
+      writeFile(outside, "secret.txt", "outside needle\n");
+      runGit(cwd, ["init"]);
+      fs.symlinkSync(path.join(outside, "secret.txt"), path.join(cwd, "linked-secret.txt"));
+      runGit(cwd, ["add", "linked-secret.txt"]);
+
+      const result = await searchWorkspaceContent({ cwd, query: "needle" });
+
+      expect(result.matches).toEqual([]);
+    },
+  );
+
   it("caps per-file matches so one hot file cannot crowd out others", async () => {
     const cwd = makeTempDir("synara-content-search-per-file-cap-");
     const hotLines = Array.from({ length: 10 }, () => "hot needle line\n").join("");

--- a/apps/server/src/workspaceEntries.ts
+++ b/apps/server/src/workspaceEntries.ts
@@ -863,7 +863,12 @@ async function searchFileContent(
   relativePath: string,
   normalizedQuery: string,
 ): Promise<ContentSearchMatch[] | null> {
-  const absolutePath = path.join(cwd, relativePath);
+  const absolutePath = await resolveRealPathWithinRoot(cwd, path.join(cwd, relativePath)).catch(
+    () => null,
+  );
+  if (!absolutePath) {
+    return null;
+  }
   let fileHandle: Awaited<ReturnType<typeof fs.open>>;
   try {
     fileHandle = await fs.open(absolutePath, "r");

--- a/apps/server/src/workspaceEntries.ts
+++ b/apps/server/src/workspaceEntries.ts
@@ -16,6 +16,8 @@ import {
   ProjectListDirectoriesResult,
   ProjectEntry,
   ProjectLocalSearchEntry,
+  ProjectSearchContentInput,
+  ProjectSearchContentResult,
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
   ProjectSearchLocalEntriesInput,
@@ -826,6 +828,154 @@ export async function searchWorkspaceEntries(
   return {
     entries: rankedEntries.map((candidate) => candidate.entry),
     truncated: index.truncated || matchedEntryCount > limit,
+  };
+}
+
+const CONTENT_SEARCH_DEFAULT_LIMIT = 50;
+const CONTENT_SEARCH_MAX_LIMIT = 100;
+const CONTENT_SEARCH_MIN_QUERY_LENGTH = 2;
+const CONTENT_SEARCH_MAX_FILE_BYTES = 512 * 1024;
+const CONTENT_SEARCH_MAX_MATCHES_PER_FILE = 5;
+const CONTENT_SEARCH_MAX_FILES_SCANNED = 2_000;
+const CONTENT_SEARCH_TIME_BUDGET_MS = 4_000;
+const CONTENT_SEARCH_LINE_READ_CONCURRENCY = 8;
+const CONTENT_SEARCH_MAX_LINE_LENGTH = 1024;
+
+// A file is treated as binary when its first 8 KiB contains a null byte.
+const CONTENT_SEARCH_BINARY_SNIFF_BYTES = 8 * 1024;
+
+interface ContentSearchMatch {
+  path: string;
+  lineNumber: number;
+  lineText: string;
+}
+
+function buildContentLineText(line: string): string {
+  const trimmed = line.trimEnd();
+  if (trimmed.length <= CONTENT_SEARCH_MAX_LINE_LENGTH) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, CONTENT_SEARCH_MAX_LINE_LENGTH - 1)}…`;
+}
+
+async function searchFileContent(
+  cwd: string,
+  relativePath: string,
+  normalizedQuery: string,
+): Promise<ContentSearchMatch[] | null> {
+  const absolutePath = path.join(cwd, relativePath);
+  let fileHandle: Awaited<ReturnType<typeof fs.open>>;
+  try {
+    fileHandle = await fs.open(absolutePath, "r");
+  } catch {
+    return null;
+  }
+
+  try {
+    const stats = await fileHandle.stat();
+    if (!stats.isFile() || stats.size === 0 || stats.size > CONTENT_SEARCH_MAX_FILE_BYTES) {
+      return null;
+    }
+
+    const sniffLength = Math.min(stats.size, CONTENT_SEARCH_BINARY_SNIFF_BYTES);
+    const sniffBuffer = Buffer.alloc(sniffLength);
+    await fileHandle.read(sniffBuffer, 0, sniffLength, 0);
+    if (sniffBuffer.includes(0)) {
+      return null;
+    }
+
+    const contents = await fileHandle.readFile("utf8");
+    const lines = contents.split("\n");
+    const matches: ContentSearchMatch[] = [];
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index];
+      if (!line) continue;
+      if (!line.toLowerCase().includes(normalizedQuery)) continue;
+      matches.push({
+        path: relativePath,
+        lineNumber: index + 1,
+        lineText: buildContentLineText(line),
+      });
+      if (matches.length >= CONTENT_SEARCH_MAX_MATCHES_PER_FILE) {
+        break;
+      }
+    }
+    return matches;
+  } catch {
+    return null;
+  } finally {
+    await fileHandle.close().catch(() => undefined);
+  }
+}
+
+// Grep-style keyword search over the project's tracked workspace files.
+// Reuses the workspace index (git ls-files when available) so the file set
+// respects .gitignore, then scans file contents with a hard time budget and
+// per-file match caps so a query in a large repository stays responsive.
+export async function searchWorkspaceContent(
+  input: ProjectSearchContentInput,
+): Promise<ProjectSearchContentResult> {
+  const normalizedQuery = input.query.trim().toLowerCase();
+  if (normalizedQuery.length < CONTENT_SEARCH_MIN_QUERY_LENGTH) {
+    return { matches: [], truncated: false };
+  }
+
+  const limit = Math.max(
+    1,
+    Math.min(input.limit ?? CONTENT_SEARCH_DEFAULT_LIMIT, CONTENT_SEARCH_MAX_LIMIT),
+  );
+
+  const index = await getWorkspaceIndex(input.cwd);
+  const indexFileEntries = index.entries.filter((entry) => entry.kind === "file");
+  const filePaths = indexFileEntries
+    .map((entry) => entry.path)
+    .slice(0, CONTENT_SEARCH_MAX_FILES_SCANNED);
+
+  const deadline = Date.now() + CONTENT_SEARCH_TIME_BUDGET_MS;
+  const collected: ContentSearchMatch[] = [];
+  let scannedFiles = 0;
+  let truncated = index.truncated || filePaths.length < indexFileEntries.length;
+
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(CONTENT_SEARCH_LINE_READ_CONCURRENCY, filePaths.length)) },
+    async () => {
+      while (nextIndex < filePaths.length) {
+        if (Date.now() > deadline) {
+          truncated = true;
+          break;
+        }
+        const currentIndex = nextIndex;
+        nextIndex += 1;
+        const fileMatches = await searchFileContent(
+          input.cwd,
+          filePaths[currentIndex] as string,
+          normalizedQuery,
+        );
+        scannedFiles += 1;
+        if (fileMatches && fileMatches.length > 0) {
+          collected.push(...fileMatches);
+        }
+      }
+    },
+  );
+  await Promise.all(workers);
+
+  if (Date.now() > deadline) {
+    truncated = true;
+  }
+
+  const orderedMatches = collected
+    .toSorted((left, right) => {
+      const pathDelta = left.path.localeCompare(right.path);
+      if (pathDelta !== 0) return pathDelta;
+      return left.lineNumber - right.lineNumber;
+    })
+    .slice(0, limit);
+
+  return {
+    matches: orderedMatches,
+    truncated: truncated || collected.length > limit || scannedFiles < filePaths.length,
   };
 }
 

--- a/apps/server/src/wsRequestAdmission.ts
+++ b/apps/server/src/wsRequestAdmission.ts
@@ -34,6 +34,7 @@ const EXPENSIVE_READ_METHODS = new Set<string>([
   ORCHESTRATION_WS_METHODS.listProviderDeliveryBlockers,
   WS_METHODS.projectsSearchEntries,
   WS_METHODS.projectsSearchLocalEntries,
+  WS_METHODS.projectsSearchContent,
   WS_METHODS.projectsReadFile,
   WS_METHODS.studioListThreadOutputs,
   WS_METHODS.filesystemBrowse,

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -1126,6 +1126,8 @@ const makeWsRpcHandlersLayer = () =>
           ),
         [WS_METHODS.projectsSearchEntries]: (input) =>
           rpcEffect(workspaceEntries.search(input), "Failed to search workspace entries"),
+        [WS_METHODS.projectsSearchContent]: (input) =>
+          rpcEffect(workspaceEntries.searchContent(input), "Failed to search workspace content"),
         [WS_METHODS.projectsDiscoverScripts]: (input) =>
           rpcEffect(workspaceEntries.discoverScripts(input), "Failed to discover project scripts"),
         [WS_METHODS.projectsSearchLocalEntries]: (input) =>

--- a/apps/web/src/components/WorkspaceSearchPalette.tsx
+++ b/apps/web/src/components/WorkspaceSearchPalette.tsx
@@ -1,0 +1,313 @@
+// FILE: WorkspaceSearchPalette.tsx
+// Purpose: Command-style palette for searching the current project's files by
+//          name and by content (grep-style snippet search), styled after the
+//          ChatGPT/Codex search overlay (neutral gray surface, soft shadow,
+//          segmented mode switch, subtle match emphasis).
+// Layer: Web UI components
+
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { FileIcon, SearchIcon } from "~/lib/icons";
+import {
+  projectSearchContentQueryOptions,
+  projectSearchEntriesQueryOptions,
+} from "~/lib/projectReactQuery";
+import {
+  Command,
+  CommandDialog,
+  CommandDialogPopup,
+  CommandEmpty,
+  CommandFooter,
+  CommandGroup,
+  CommandGroupLabel,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandPanel,
+} from "./ui/command";
+import { isMacPlatform } from "~/lib/utils";
+
+export type WorkspaceSearchPaletteMode = "files" | "snippets";
+
+const SEARCH_DEBOUNCE_MS = 200;
+const SNIPPET_MIN_QUERY_LENGTH = 2;
+const SEARCH_LIMIT = 50;
+const SEARCH_STALE_TIME_MS = 10_000;
+
+const POPUP_CLASS =
+  "max-w-2xl -translate-y-[9vh] rounded-2xl border-zinc-200/80 bg-[#fafafa] text-zinc-800 shadow-[0_0_0_1px_rgba(0,0,0,0.03),0_16px_48px_rgba(0,0,0,0.16)] before:bg-transparent dark:border-zinc-700/70 dark:bg-[#212121] dark:text-zinc-200 dark:shadow-[0_0_0_1px_rgba(255,255,255,0.04),0_16px_48px_rgba(0,0,0,0.55)]";
+
+const PANEL_CLASS = "border-zinc-200/80 bg-transparent shadow-none dark:border-zinc-700/70";
+
+interface WorkspaceSearchPaletteProps {
+  open: boolean;
+  mode: WorkspaceSearchPaletteMode;
+  onModeChange: (mode: WorkspaceSearchPaletteMode) => void;
+  onOpenChange: (open: boolean) => void;
+  cwd: string | null;
+  onOpenFile: (relativePath: string) => void;
+}
+
+function highlightRange(
+  text: string,
+  query: string,
+): { prefix: string; match: string; suffix: string } | null {
+  if (!query) return null;
+  const lowerText = text.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  const index = lowerText.indexOf(lowerQuery);
+  if (index === -1) return null;
+  return {
+    prefix: text.slice(0, index),
+    match: text.slice(index, index + lowerQuery.length),
+    suffix: text.slice(index + lowerQuery.length),
+  };
+}
+
+// ChatGPT-style match emphasis: no colored mark, just a subtle weight bump.
+function HighlightedText(props: { text: string; query: string; muted?: boolean }) {
+  const range = highlightRange(props.text, props.query);
+  if (!range) {
+    return <>{props.text}</>;
+  }
+  const matchClass = props.muted
+    ? "font-medium text-zinc-700 dark:text-zinc-200"
+    : "font-semibold text-zinc-950 dark:text-white";
+  return (
+    <>
+      {range.prefix}
+      <span className={matchClass}>{range.match}</span>
+      {range.suffix}
+    </>
+  );
+}
+
+function modeButtonClass(active: boolean): string {
+  return active
+    ? "rounded-md bg-white px-2.5 py-1 text-xs font-medium text-zinc-900 shadow-sm dark:bg-zinc-600/90 dark:text-zinc-50"
+    : "rounded-md px-2.5 py-1 text-xs font-medium text-zinc-500 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100";
+}
+
+function EmptyState(props: { message: string }) {
+  return (
+    <CommandEmpty className="py-12">
+      <div className="flex flex-col items-center justify-center gap-2.5 text-center text-sm text-zinc-500 dark:text-zinc-400">
+        <SearchIcon className="size-4 opacity-60" />
+        <div>{props.message}</div>
+      </div>
+    </CommandEmpty>
+  );
+}
+
+export function WorkspaceSearchPalette(props: WorkspaceSearchPaletteProps) {
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+
+  useEffect(() => {
+    if (!props.open) {
+      const timeoutId = window.setTimeout(() => {
+        setQuery("");
+        setDebouncedQuery("");
+      }, 0);
+      return () => window.clearTimeout(timeoutId);
+    }
+    return undefined;
+  }, [props.open]);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => setDebouncedQuery(query.trim()), SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timeoutId);
+  }, [query]);
+
+  const isMac = isMacPlatform(navigator.platform);
+  const modLabel = isMac ? "⌘" : "Ctrl";
+  const trimmedQuery = query.trim();
+  const hasUsableQuery =
+    props.mode === "files"
+      ? trimmedQuery.length > 0
+      : trimmedQuery.length >= SNIPPET_MIN_QUERY_LENGTH;
+
+  const fileSearchQuery = useQuery(
+    projectSearchEntriesQueryOptions({
+      cwd: props.cwd,
+      query: debouncedQuery,
+      kind: "file",
+      limit: SEARCH_LIMIT,
+      enabled: props.open && props.mode === "files" && debouncedQuery.length > 0,
+      staleTime: SEARCH_STALE_TIME_MS,
+    }),
+  );
+
+  const snippetSearchQuery = useQuery(
+    projectSearchContentQueryOptions({
+      cwd: props.cwd,
+      query: debouncedQuery,
+      limit: SEARCH_LIMIT,
+      enabled:
+        props.open &&
+        props.mode === "snippets" &&
+        debouncedQuery.length >= SNIPPET_MIN_QUERY_LENGTH,
+      staleTime: SEARCH_STALE_TIME_MS,
+    }),
+  );
+
+  const fileEntries =
+    props.mode === "files" && hasUsableQuery ? (fileSearchQuery.data?.entries ?? []) : [];
+  const snippetMatches =
+    props.mode === "snippets" && hasUsableQuery ? (snippetSearchQuery.data?.matches ?? []) : [];
+
+  const isFetching =
+    props.mode === "files" ? fileSearchQuery.isFetching : snippetSearchQuery.isFetching;
+
+  const handleOpenFile = (relativePath: string) => {
+    props.onOpenChange(false);
+    props.onOpenFile(relativePath);
+  };
+
+  const placeholder =
+    props.mode === "files" ? "Search files by name" : "Search code and file contents";
+
+  const promptState =
+    props.mode === "files"
+      ? "Type a file name to search the project."
+      : `Type at least ${SNIPPET_MIN_QUERY_LENGTH} characters to search file contents.`;
+
+  return (
+    <CommandDialog open={props.open} onOpenChange={props.onOpenChange}>
+      <CommandDialogPopup className={POPUP_CLASS}>
+        <Command mode="none">
+          <CommandPanel className={PANEL_CLASS}>
+            <div className="flex flex-col gap-2 border-b border-zinc-200/70 px-3 pt-2 pb-2.5 dark:border-zinc-700/60">
+              <CommandInput
+                placeholder={placeholder}
+                value={query}
+                onChange={(event) => setQuery(event.currentTarget.value)}
+                startAddon={<SearchIcon className="size-4 text-zinc-400 dark:text-zinc-500" />}
+                className="px-3 py-2 text-[15px] placeholder:text-zinc-400 dark:placeholder:text-zinc-500"
+              />
+              <div className="flex items-center gap-2 px-2">
+                <div
+                  className="inline-flex items-center gap-0.5 rounded-lg bg-zinc-200/70 p-0.5 dark:bg-zinc-800"
+                  role="tablist"
+                  aria-label="Search mode"
+                >
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={props.mode === "files"}
+                    className={modeButtonClass(props.mode === "files")}
+                    onClick={() => props.onModeChange("files")}
+                  >
+                    Files
+                  </button>
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={props.mode === "snippets"}
+                    className={modeButtonClass(props.mode === "snippets")}
+                    onClick={() => props.onModeChange("snippets")}
+                  >
+                    Snippets
+                  </button>
+                </div>
+                {props.cwd ? (
+                  <span className="min-w-0 flex-1 truncate text-end text-[11px] text-zinc-400 dark:text-zinc-500">
+                    {props.cwd}
+                  </span>
+                ) : null}
+              </div>
+            </div>
+
+            <CommandList className="max-h-[min(22rem,55vh)] not-empty:px-1.5 not-empty:pt-1.5 not-empty:pb-1.5">
+              {!hasUsableQuery ? (
+                <EmptyState message={promptState} />
+              ) : props.mode === "files" ? (
+                fileEntries.length > 0 ? (
+                  <CommandGroup>
+                    <CommandGroupLabel className="pt-0 pb-1.5 pl-3 text-zinc-400 dark:text-zinc-500">
+                      Files
+                    </CommandGroupLabel>
+                    {fileEntries.map((entry) => (
+                      <CommandItem
+                        key={entry.path}
+                        value={`file:${entry.path}`}
+                        className="cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-2 text-zinc-800 data-highlighted:bg-zinc-200/60 data-highlighted:text-zinc-900 dark:text-zinc-200 dark:data-highlighted:bg-zinc-700/40 dark:data-highlighted:text-zinc-100"
+                        onMouseDown={(event) => {
+                          event.preventDefault();
+                        }}
+                        onClick={() => handleOpenFile(entry.path)}
+                      >
+                        <FileIcon className="size-4 shrink-0 text-zinc-400 dark:text-zinc-500" />
+                        <span className="min-w-0 flex-1 truncate text-sm">
+                          <HighlightedText text={entry.path} query={debouncedQuery} />
+                        </span>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                ) : !isFetching ? (
+                  <EmptyState message="No matching files." />
+                ) : null
+              ) : snippetMatches.length > 0 ? (
+                <CommandGroup>
+                  <CommandGroupLabel className="pt-0 pb-1.5 pl-3 text-zinc-400 dark:text-zinc-500">
+                    Matches
+                  </CommandGroupLabel>
+                  {snippetMatches.map((match) => (
+                    <CommandItem
+                      key={`${match.path}:${match.lineNumber}`}
+                      value={`snippet:${match.path}:${match.lineNumber}`}
+                      className="cursor-pointer items-start gap-2.5 rounded-lg px-2.5 py-2 text-zinc-800 data-highlighted:bg-zinc-200/60 data-highlighted:text-zinc-900 dark:text-zinc-200 dark:data-highlighted:bg-zinc-700/40 dark:data-highlighted:text-zinc-100"
+                      onMouseDown={(event) => {
+                        event.preventDefault();
+                      }}
+                      onClick={() => handleOpenFile(match.path)}
+                    >
+                      <FileIcon className="mt-0.5 size-4 shrink-0 text-zinc-400 dark:text-zinc-500" />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-baseline gap-2">
+                          <span className="min-w-0 flex-1 truncate text-sm">
+                            <HighlightedText text={match.path} query={debouncedQuery} />
+                          </span>
+                          <span className="shrink-0 text-[10px] text-zinc-400 dark:text-zinc-500">
+                            :{match.lineNumber}
+                          </span>
+                        </div>
+                        <div className="mt-0.5 truncate font-mono text-[11px] leading-5 text-zinc-500 dark:text-zinc-400">
+                          <HighlightedText text={match.lineText} query={debouncedQuery} muted />
+                        </div>
+                      </div>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              ) : !isFetching ? (
+                <EmptyState message="No snippet matches." />
+              ) : null}
+            </CommandList>
+            <CommandFooter className="border-zinc-200/70 px-4 py-2.5 text-[11px] text-zinc-400 dark:border-zinc-700/60 dark:text-zinc-500">
+              <span>
+                {props.mode === "files"
+                  ? "Search files in the current project."
+                  : "Search keywords inside project files."}
+              </span>
+              <span className="flex items-center gap-1.5">
+                <kbd className="rounded border border-zinc-200 bg-zinc-100 px-1 py-0.5 font-sans text-[10px] text-zinc-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+                  {modLabel}+P
+                </kbd>
+                <span>files</span>
+                <kbd className="rounded border border-zinc-200 bg-zinc-100 px-1 py-0.5 font-sans text-[10px] text-zinc-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+                  {modLabel}+Shift+F
+                </kbd>
+                <span>snippets</span>
+                <kbd className="rounded border border-zinc-200 bg-zinc-100 px-1 py-0.5 font-sans text-[10px] text-zinc-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+                  Enter
+                </kbd>
+                <span>open</span>
+              </span>
+            </CommandFooter>
+          </CommandPanel>
+        </Command>
+      </CommandDialogPopup>
+    </CommandDialog>
+  );
+}

--- a/apps/web/src/components/chat/SingleChatSurface.tsx
+++ b/apps/web/src/components/chat/SingleChatSurface.tsx
@@ -349,6 +349,10 @@ export function SingleChatSurface(props: {
   // snippet (content) search. Registered with capture so it wins over page-level
   // defaults (print, browser find) while the chat surface is mounted.
   useEffect(() => {
+    // Editor view returns before rendering the palette, so leave its shortcuts
+    // available to the editor instead of swallowing them invisibly.
+    if (editorViewActive) return;
+
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
       if (event.repeat || event.altKey) return;
       const isPrimaryModifier = event.ctrlKey || event.metaKey;
@@ -364,7 +368,7 @@ export function SingleChatSurface(props: {
     };
     window.addEventListener("keydown", onKeyDown, { capture: true });
     return () => window.removeEventListener("keydown", onKeyDown, { capture: true });
-  }, []);
+  }, [editorViewActive]);
 
   const handleOpenEditorView = () => {
     void navigate({

--- a/apps/web/src/components/chat/SingleChatSurface.tsx
+++ b/apps/web/src/components/chat/SingleChatSurface.tsx
@@ -105,6 +105,7 @@ import { usePullRequestPaneStateIcon } from "../pullRequest/usePullRequestPaneSt
 import { RouteInsetSurface } from "../RouteInsetSurface";
 import { SidebarInset } from "../ui/sidebar";
 import { toastManager } from "../ui/toast";
+import { WorkspaceSearchPalette, type WorkspaceSearchPaletteMode } from "../WorkspaceSearchPalette";
 import {
   collectParentDirectoryPaths,
   resolveFilePreviewWorkspaceRoot,
@@ -285,6 +286,8 @@ export function SingleChatSurface(props: {
   const [editorDiffFiles, setEditorDiffFiles] = useState<ReadonlyArray<FileDiffMetadata>>([]);
   const [editorDiffFilesLoading, setEditorDiffFilesLoading] = useState(false);
   const [editorDiffOptionsControl, setEditorDiffOptionsControl] = useState<ReactNode | null>(null);
+  const [searchPaletteOpen, setSearchPaletteOpen] = useState(false);
+  const [searchPaletteMode, setSearchPaletteMode] = useState<WorkspaceSearchPaletteMode>("files");
 
   const activePane = resolveActivePane(dockState);
   const {
@@ -336,6 +339,32 @@ export function SingleChatSurface(props: {
       diffFilePath: filePath ?? null,
     });
   };
+
+  const handleOpenWorkspaceSearchFile = (relativePath: string) => {
+    requestImmediateDockHydration("file");
+    openPane(props.threadId, { kind: "file", filePath: relativePath });
+  };
+
+  // Ctrl/Cmd+P opens the file-name search palette; Ctrl/Cmd+Shift+F opens the
+  // snippet (content) search. Registered with capture so it wins over page-level
+  // defaults (print, browser find) while the chat surface is mounted.
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.repeat || event.altKey) return;
+      const isPrimaryModifier = event.ctrlKey || event.metaKey;
+      if (!isPrimaryModifier) return;
+      const key = event.key.toLowerCase();
+      if (key !== "p" && key !== "f") return;
+      if (key === "f" && !event.shiftKey) return;
+      if (key === "p" && event.shiftKey) return;
+      event.preventDefault();
+      event.stopPropagation();
+      setSearchPaletteMode(key === "p" ? "files" : "snippets");
+      setSearchPaletteOpen(true);
+    };
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    return () => window.removeEventListener("keydown", onKeyDown, { capture: true });
+  }, []);
 
   const handleOpenEditorView = () => {
     void navigate({
@@ -1100,6 +1129,14 @@ export function SingleChatSurface(props: {
           onOpenChange={(open) => setDockOpen(props.threadId, open)}
           onAddPane={handleAddDockPane}
           renderPane={renderDockPane}
+        />
+        <WorkspaceSearchPalette
+          open={searchPaletteOpen}
+          mode={searchPaletteMode}
+          onModeChange={setSearchPaletteMode}
+          onOpenChange={setSearchPaletteOpen}
+          cwd={workspaceRoot}
+          onOpenFile={handleOpenWorkspaceSearchFile}
         />
       </div>
     </WorkspaceFileOpenerContext.Provider>

--- a/apps/web/src/lib/projectReactQuery.ts
+++ b/apps/web/src/lib/projectReactQuery.ts
@@ -5,6 +5,7 @@ import type {
   ProjectReadFileResult,
   ProjectResolveOutOfRootFileReferenceResult,
   ProjectDiscoverScriptsResult,
+  ProjectSearchContentResult,
   ProjectSearchEntriesResult,
   ProjectSearchLocalEntriesResult,
 } from "@synara/contracts";
@@ -31,6 +32,8 @@ export const projectQueryKeys = {
   ) => ["projects", "search-entries", cwd, query, limit, kind] as const,
   searchLocalEntries: (rootPath: string | null, query: string, limit: number) =>
     ["projects", "search-local-entries", rootPath, query, limit] as const,
+  searchContent: (cwd: string | null, query: string, limit: number) =>
+    ["projects", "search-content", cwd, query, limit] as const,
 };
 
 // Scope live file-change invalidations to one workspace so unrelated
@@ -59,6 +62,9 @@ const DEFAULT_DISCOVER_SCRIPTS_DEPTH = 2;
 const DEFAULT_DISCOVER_SCRIPTS_STALE_TIME = 30_000;
 const DEFAULT_SEARCH_LOCAL_ENTRIES_LIMIT = 50;
 const DEFAULT_SEARCH_LOCAL_ENTRIES_STALE_TIME = 10_000;
+const DEFAULT_SEARCH_CONTENT_LIMIT = 50;
+const DEFAULT_SEARCH_CONTENT_STALE_TIME = 10_000;
+const SEARCH_CONTENT_MIN_QUERY_LENGTH = 2;
 const DEFAULT_READ_FILE_STALE_TIME = 5_000;
 const LOCAL_PREVIEW_GRANT_REFRESH_SAFETY_MS = 15_000;
 const LOCAL_PREVIEW_GRANT_MIN_REFETCH_INTERVAL_MS = 1_000;
@@ -72,6 +78,10 @@ const EMPTY_DISCOVER_SCRIPTS_RESULT: ProjectDiscoverScriptsResult = {
 };
 const EMPTY_SEARCH_LOCAL_ENTRIES_RESULT: ProjectSearchLocalEntriesResult = {
   entries: [],
+  truncated: false,
+};
+const EMPTY_SEARCH_CONTENT_RESULT: ProjectSearchContentResult = {
+  matches: [],
   truncated: false,
 };
 const ABSOLUTE_LOCAL_READ_CWD = "/";
@@ -292,5 +302,36 @@ export function projectSearchLocalEntriesQueryOptions(input: {
     enabled: (input.enabled ?? true) && input.rootPath !== null && trimmedQuery.length >= 2,
     staleTime: input.staleTime ?? DEFAULT_SEARCH_LOCAL_ENTRIES_STALE_TIME,
     placeholderData: (previous) => previous ?? EMPTY_SEARCH_LOCAL_ENTRIES_RESULT,
+  });
+}
+
+export function projectSearchContentQueryOptions(input: {
+  cwd: string | null;
+  query: string;
+  enabled?: boolean;
+  limit?: number;
+  staleTime?: number;
+}) {
+  const limit = input.limit ?? DEFAULT_SEARCH_CONTENT_LIMIT;
+  const trimmedQuery = input.query.trim();
+  return queryOptions({
+    queryKey: projectQueryKeys.searchContent(input.cwd, trimmedQuery, limit),
+    queryFn: async () => {
+      const api = ensureNativeApi();
+      if (!input.cwd) {
+        throw new Error("Workspace content search is unavailable.");
+      }
+      return api.projects.searchContent({
+        cwd: input.cwd,
+        query: trimmedQuery,
+        limit,
+      });
+    },
+    enabled:
+      (input.enabled ?? true) &&
+      input.cwd !== null &&
+      trimmedQuery.length >= SEARCH_CONTENT_MIN_QUERY_LENGTH,
+    staleTime: input.staleTime ?? DEFAULT_SEARCH_CONTENT_STALE_TIME,
+    placeholderData: (previous) => previous ?? EMPTY_SEARCH_CONTENT_RESULT,
   });
 }

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -524,6 +524,7 @@ export function createWsNativeApi(): NativeApi {
       searchEntries: (input) => transport.request(WS_METHODS.projectsSearchEntries, input),
       searchLocalEntries: (input) =>
         transport.request(WS_METHODS.projectsSearchLocalEntries, input),
+      searchContent: (input) => transport.request(WS_METHODS.projectsSearchContent, input),
       readFile: (input) => transport.request(WS_METHODS.projectsReadFile, input),
       resolveOutOfRootFileReference: (input) =>
         transport.request(WS_METHODS.projectsResolveOutOfRootFileReference, input),

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -121,6 +121,8 @@ import type {
   ProjectRunDevServerResult,
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
+  ProjectSearchContentInput,
+  ProjectSearchContentResult,
   ProjectSearchLocalEntriesInput,
   ProjectSearchLocalEntriesResult,
   ProjectStopDevServerInput,
@@ -622,6 +624,7 @@ export interface NativeApi {
     searchLocalEntries: (
       input: ProjectSearchLocalEntriesInput,
     ) => Promise<ProjectSearchLocalEntriesResult>;
+    searchContent: (input: ProjectSearchContentInput) => Promise<ProjectSearchContentResult>;
     readFile: (input: ProjectReadFileInput) => Promise<ProjectReadFileResult>;
     resolveOutOfRootFileReference: (
       input: ProjectResolveOutOfRootFileReferenceInput,

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -106,6 +106,34 @@ export const ProjectSearchEntriesResult = Schema.Struct({
 });
 export type ProjectSearchEntriesResult = typeof ProjectSearchEntriesResult.Type;
 
+const PROJECT_SEARCH_CONTENT_MAX_LIMIT = 100;
+const PROJECT_SEARCH_CONTENT_MIN_QUERY_LENGTH = 2;
+const PROJECT_SEARCH_CONTENT_MAX_LINE_LENGTH = 1024;
+
+export const ProjectSearchContentInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+  query: TrimmedNonEmptyString.check(Schema.isMaxLength(256)).check(
+    Schema.isMinLength(PROJECT_SEARCH_CONTENT_MIN_QUERY_LENGTH),
+  ),
+  limit: Schema.optional(
+    PositiveInt.check(Schema.isLessThanOrEqualTo(PROJECT_SEARCH_CONTENT_MAX_LIMIT)),
+  ),
+});
+export type ProjectSearchContentInput = typeof ProjectSearchContentInput.Type;
+
+export const ProjectContentMatch = Schema.Struct({
+  path: TrimmedNonEmptyString,
+  lineNumber: PositiveInt,
+  lineText: Schema.String.check(Schema.isMaxLength(PROJECT_SEARCH_CONTENT_MAX_LINE_LENGTH)),
+});
+export type ProjectContentMatch = typeof ProjectContentMatch.Type;
+
+export const ProjectSearchContentResult = Schema.Struct({
+  matches: Schema.Array(ProjectContentMatch),
+  truncated: Schema.Boolean,
+});
+export type ProjectSearchContentResult = typeof ProjectSearchContentResult.Type;
+
 export const ProjectSearchLocalEntriesInput = Schema.Struct({
   rootPath: TrimmedNonEmptyString,
   query: TrimmedNonEmptyString.check(Schema.isMaxLength(256)),

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -172,6 +172,8 @@ import {
   ProjectRunDevServerResult,
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
+  ProjectSearchContentInput,
+  ProjectSearchContentResult,
   ProjectSearchLocalEntriesInput,
   ProjectSearchLocalEntriesResult,
   ProjectStopDevServerInput,
@@ -400,6 +402,12 @@ export const WsProjectsSearchEntriesRpc = Rpc.make(WS_METHODS.projectsSearchEntr
 export const WsProjectsSearchLocalEntriesRpc = Rpc.make(WS_METHODS.projectsSearchLocalEntries, {
   payload: ProjectSearchLocalEntriesInput,
   success: ProjectSearchLocalEntriesResult,
+  error: WsRpcError,
+});
+
+export const WsProjectsSearchContentRpc = Rpc.make(WS_METHODS.projectsSearchContent, {
+  payload: ProjectSearchContentInput,
+  success: ProjectSearchContentResult,
   error: WsRpcError,
 });
 
@@ -1214,6 +1222,7 @@ export const WsFeatureRpcGroup = RpcGroup.make(
   WsProjectsListDirectoriesRpc,
   WsProjectsSearchEntriesRpc,
   WsProjectsSearchLocalEntriesRpc,
+  WsProjectsSearchContentRpc,
   WsProjectsReadFileRpc,
   WsProjectsResolveOutOfRootFileReferenceRpc,
   WsProjectsCreateLocalFilePreviewGrantRpc,

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -81,6 +81,7 @@ import {
   ProjectResolveOutOfRootFileReferenceInput,
   ProjectRunDevServerInput,
   ProjectSearchEntriesInput,
+  ProjectSearchContentInput,
   ProjectSearchLocalEntriesInput,
   ProjectStopDevServerInput,
   ProjectWriteFileInput,
@@ -165,6 +166,7 @@ export const WS_METHODS = {
   projectsListDirectories: "projects.listDirectories",
   projectsSearchEntries: "projects.searchEntries",
   projectsSearchLocalEntries: "projects.searchLocalEntries",
+  projectsSearchContent: "projects.searchContent",
   projectsReadFile: "projects.readFile",
   projectsResolveOutOfRootFileReference: "projects.resolveOutOfRootFileReference",
   projectsCreateLocalFilePreviewGrant: "projects.createLocalFilePreviewGrant",
@@ -341,6 +343,7 @@ const WebSocketRequestBody = Schema.Union([
   tagRequestBody(WS_METHODS.projectsListDirectories, ProjectListDirectoriesInput),
   tagRequestBody(WS_METHODS.projectsSearchEntries, ProjectSearchEntriesInput),
   tagRequestBody(WS_METHODS.projectsSearchLocalEntries, ProjectSearchLocalEntriesInput),
+  tagRequestBody(WS_METHODS.projectsSearchContent, ProjectSearchContentInput),
   tagRequestBody(WS_METHODS.projectsReadFile, ProjectReadFileInput),
   tagRequestBody(
     WS_METHODS.projectsResolveOutOfRootFileReference,


### PR DESCRIPTION
## Summary

Closes #647.

Adds a ChatGPT/Codex-style search palette to the chat surface with two modes:

- **Files** (`Ctrl/Cmd+P`) — searches the current project's files by name, reusing the existing workspace index (`projects.searchEntries`) with its existing ranking (exact > prefix > contains > fuzzy subsequence).
- **Snippets** (`Ctrl/Cmd+Shift+F`) — new grep-style search across file *contents*, returning file path, line number, and the matching line text.

Selecting a result opens the file in the right-dock file pane.

## Implementation

**New WS method `projects.searchContent`**

- Contracts: `ProjectSearchContentInput` / `ProjectSearchContentResult` schemas, method registration, RPC + IPC surfaces.
- Server (`workspaceEntries.ts`): `searchWorkspaceContent` scans the workspace index file set (git ls-files when available, so `.gitignore` is respected), with safety bounds: 4s time budget, binary skip (null-byte sniff), ≤5 matches per file, ≤100 total matches, sorted by path/line.
- Wired through the WorkspaceEntries Effect service, `wsRpc`, and classified as an expensive-read request.

**Web**

- `WorkspaceSearchPalette` component: command-palette overlay with Files/Snippets modes, match emphasis, keyboard navigation, and kbd hints in the footer. Styled after the ChatGPT/Codex search overlay.
- Mounted in `SingleChatSurface` with the `Ctrl/Cmd+P` / `Ctrl/Cmd+Shift+F` hotkeys; results open in the right-dock file pane.
- React Query integration in `projectReactQuery` + `wsNativeApi` client.

## Testing

- 5 new server unit tests: case-insensitive line matching, short-query rejection, binary skip, per-file match cap, limit truncation.
- Manually verified in the desktop dev app.
- `fmt`, `lint`, `typecheck` pass; contracts 205/205, web projectReactQuery 3/3, wsNativeApi 35/35. (One pre-existing `workspaceEntries` test fails on Windows due to symlink privileges — EPERM — unrelated to this change.)

## Notes

- File-name search reuses the existing `projects.searchEntries` backend (already used by composer mentions); this PR gives it a dedicated UI for the first time.
- Possible follow-ups: opening results in the editor view, snippet previews, searching beyond the active project.
