### PR TITLE
fix(desktop): refresh Windows taskbar icon after runtime icon changes

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -86,6 +86,7 @@ import {
   isDesktopAppIcon,
   shouldUpdateDesktopAppIcon,
 } from "./desktopAppIcon";
+import { refreshWindowsTaskbarIcon } from "./windowsTaskbarIcon";
 import {
   makeUpdateInstallPreparationCoordinator,
   type UpdateInstallPreparationAttempt,
@@ -1951,6 +1952,12 @@ function applyDesktopAppIcon(icon: DesktopAppIcon): void {
     return;
   }
   mainWindow?.setIcon(image);
+  // setIcon updates the window chrome and Alt-Tab artwork, but the Windows
+  // shell caches the taskbar button icon registered for the app identity, so
+  // re-register the live taskbar button to make the new icon take effect.
+  if (process.platform === "win32") {
+    refreshWindowsTaskbarIcon(mainWindow);
+  }
 }
 
 function applyInitialMacDockIcon(): void {

--- a/apps/desktop/src/windowsTaskbarIcon.test.ts
+++ b/apps/desktop/src/windowsTaskbarIcon.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { BrowserWindow } from "electron";
+
+import { refreshWindowsTaskbarIcon } from "./windowsTaskbarIcon";
+
+interface FakeWindowState {
+  destroyed?: boolean;
+  visible?: boolean;
+}
+
+function makeWindow({ destroyed = false, visible = true }: FakeWindowState = {}) {
+  return {
+    isDestroyed: vi.fn(() => destroyed),
+    isVisible: vi.fn(() => visible),
+    setSkipTaskbar: vi.fn(),
+  } as unknown as BrowserWindow;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("refreshWindowsTaskbarIcon", () => {
+  it("detaches the taskbar button and re-registers it after the refresh delay", () => {
+    vi.useFakeTimers();
+    const window = makeWindow();
+
+    refreshWindowsTaskbarIcon(window);
+
+    expect(window.setSkipTaskbar).toHaveBeenCalledWith(true);
+    expect(window.setSkipTaskbar).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(249);
+    expect(window.setSkipTaskbar).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1);
+    expect(window.setSkipTaskbar).toHaveBeenCalledWith(false);
+    expect(window.setSkipTaskbar).toHaveBeenCalledTimes(2);
+  });
+
+  it("does nothing when there is no window", () => {
+    vi.useFakeTimers();
+    expect(() => refreshWindowsTaskbarIcon(null)).not.toThrow();
+  });
+
+  it("does nothing when the window is destroyed", () => {
+    vi.useFakeTimers();
+    const window = makeWindow({ destroyed: true });
+
+    refreshWindowsTaskbarIcon(window);
+
+    expect(window.setSkipTaskbar).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the window is hidden", () => {
+    vi.useFakeTimers();
+    const window = makeWindow({ visible: false });
+
+    refreshWindowsTaskbarIcon(window);
+
+    expect(window.setSkipTaskbar).not.toHaveBeenCalled();
+  });
+
+  it("never re-registers the button when the window is destroyed before the delay elapses", () => {
+    vi.useFakeTimers();
+    const window = makeWindow();
+
+    refreshWindowsTaskbarIcon(window);
+    expect(window.setSkipTaskbar).toHaveBeenCalledWith(true);
+
+    vi.advanceTimersByTime(249);
+    (window.isDestroyed as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    vi.advanceTimersByTime(1);
+
+    expect(window.setSkipTaskbar).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/windowsTaskbarIcon.ts
+++ b/apps/desktop/src/windowsTaskbarIcon.ts
@@ -1,0 +1,23 @@
+// FILE: windowsTaskbarIcon.ts
+// Purpose: Force the Windows shell to re-read the taskbar icon after a runtime change.
+// Layer: Desktop-native preference logic
+
+import type { BrowserWindow } from "electron";
+
+// Explorer coalesces a synchronous setSkipTaskbar(true) -> setSkipTaskbar(false)
+// toggle and keeps rendering its cached button icon, so the button must stay
+// detached long enough for the shell to process the removal before it is
+// re-registered and re-reads the window icon.
+const WINDOWS_TASKBAR_ICON_REFRESH_DELAY_MS = 250;
+
+export function refreshWindowsTaskbarIcon(window: BrowserWindow | null): void {
+  if (!window || window.isDestroyed() || !window.isVisible()) {
+    return;
+  }
+  window.setSkipTaskbar(true);
+  setTimeout(() => {
+    if (!window.isDestroyed()) {
+      window.setSkipTaskbar(false);
+    }
+  }, WINDOWS_TASKBAR_ICON_REFRESH_DELAY_MS);
+}


### PR DESCRIPTION
## Summary

When the app icon changes at runtime (e.g. appearance/theme switch), `setIcon` updates the window chrome and Alt-Tab artwork, but the Windows shell keeps showing the cached taskbar button icon. This PR re-registers the taskbar button so the new icon takes effect immediately.

## Implementation

- New `apps/desktop/src/windowsTaskbarIcon.ts`: `refreshWindowsTaskbarIcon(window)` detaches the taskbar button (`setSkipTaskbar(true)`) and re-registers it after a 250ms delay (`setSkipTaskbar(false)`). Explorer coalesces a synchronous toggle and keeps the cached button, so the delay lets the shell process the removal first. No-ops for null/destroyed/hidden windows, and skips re-registration when the window is destroyed while the delay elapses.
- `apps/desktop/src/main.ts`: `applyDesktopAppIcon` now calls `refreshWindowsTaskbarIcon` after `setIcon` on `win32`.

## Testing

- 5 new unit tests (`windowsTaskbarIcon.test.ts`): detach/re-register sequence with fake timers, null/destroyed/hidden guards, destroyed-before-delay case.
- `fmt`, `lint`, `typecheck` pass (no new warnings); desktop `windowsTaskbarIcon` tests 5/5.
- Manually verified on Windows: the taskbar icon updates after a runtime icon change without restarting the app.
