### PR TITLE
Consolidate Git actions and streamline commit/push dialogs

### DIFF
--- a/apps/web/src/components/AppNavigationButtons.tsx
+++ b/apps/web/src/components/AppNavigationButtons.tsx
@@ -5,15 +5,14 @@
 
 import { goBackInAppHistory, goForwardInAppHistory, useAppNavigationState } from "~/appNavigation";
 import { isElectron } from "~/env";
-import { cn } from "~/lib/utils";
+import { cn, isMacNavigatorPlatform } from "~/lib/utils";
 import { IoIosArrowRoundBack, IoIosArrowRoundForward } from "react-icons/io";
 import { Button } from "./ui/button";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 
 export function AppNavigationButtons({ className }: { className?: string }) {
   const { canGoBack, canGoForward } = useAppNavigationState();
-  const platform = typeof navigator === "undefined" ? "" : navigator.platform;
-  const isMac = /Mac|iPhone|iPad|iPod/i.test(platform);
+  const isMac = isMacNavigatorPlatform();
   const backShortcutLabel = isMac ? "⌘[" : "Alt+Left";
   const forwardShortcutLabel = isMac ? "⌘]" : "Alt+Right";
 

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -38,6 +38,7 @@ import {
   shouldSyncLocalThreadBranch,
 } from "./BranchToolbar.logic";
 import { Button } from "./ui/button";
+import { DiffStat } from "./ui/diff-stat";
 import {
   Dialog,
   DialogDescription,
@@ -827,12 +828,11 @@ export function BranchToolbarBranchSelector({
                   Uncommitted: {currentBranchChangeSummary.fileCount.toLocaleString()}{" "}
                   {pluralize(currentBranchChangeSummary.fileCount, "file")}
                 </span>
-                <span className="font-mono tabular-nums text-success">
-                  +{currentBranchChangeSummary.insertions.toLocaleString()}
-                </span>
-                <span className="font-mono tabular-nums text-destructive">
-                  -{currentBranchChangeSummary.deletions.toLocaleString()}
-                </span>
+                <DiffStat
+                  className="font-mono"
+                  insertions={currentBranchChangeSummary.insertions}
+                  deletions={currentBranchChangeSummary.deletions}
+                />
               </div>
             ) : null}
           </div>

--- a/apps/web/src/components/BrowserPanel.tsx
+++ b/apps/web/src/components/BrowserPanel.tsx
@@ -48,7 +48,7 @@ import type { DockPaneRuntimeMode } from "~/lib/dockPaneActivation";
 import { readDesktopZoomFactor, subscribeDesktopZoomFactor } from "~/lib/desktopZoom";
 import { NATIVE_SURFACE_OCCLUSION_SYNC_EVENT } from "~/lib/nativeSurfaceOcclusion";
 import { serverLocalServersQueryOptions } from "~/lib/serverReactQuery";
-import { cn, isMacPlatform } from "~/lib/utils";
+import { cn, isMacNavigatorPlatform } from "~/lib/utils";
 
 import {
   useBrowserStateStore,
@@ -1468,7 +1468,7 @@ export function BrowserPanel({
           alt: event.altKey,
           key: event.key,
         },
-        isMacPlatform(navigator.platform),
+        isMacNavigatorPlatform(),
       );
       if (!matches) {
         return;

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -45,7 +45,7 @@ import {
   removeInlineTerminalContextPlaceholder,
 } from "../lib/terminalContext";
 import { extractTrailingBrowserAnnotations } from "../lib/browserAnnotations";
-import { isMacPlatform } from "../lib/utils";
+import { isMacNavigatorPlatform } from "../lib/utils";
 import { readNativeApi } from "../nativeApi";
 import { resetHomeChatProjectPrewarmStateForTests } from "../lib/chatProjects";
 import { resetStudioProjectPrewarmStateForTests } from "../lib/studioProjects";
@@ -1671,7 +1671,7 @@ async function waitForServerConfigToApply(): Promise<void> {
 }
 
 function dispatchComposerPickerShortcut(target: EventTarget, key: "m" | "e"): void {
-  const useMetaForMod = isMacPlatform(navigator.platform);
+  const useMetaForMod = isMacNavigatorPlatform();
   target.dispatchEvent(
     new KeyboardEvent("keydown", {
       key,
@@ -1712,7 +1712,7 @@ function dispatchConfiguredShortcut(
   target: EventTarget,
   input: { key: string; shiftKey?: boolean; altKey?: boolean },
 ): void {
-  const useMetaForMod = isMacPlatform(navigator.platform);
+  const useMetaForMod = isMacNavigatorPlatform();
   target.dispatchEvent(
     new KeyboardEvent("keydown", {
       key: input.key,
@@ -1758,7 +1758,7 @@ function dispatchTerminalThreadShortcut(): void {
 }
 
 function dispatchThreadShortcut(key: string): void {
-  const useMetaForMod = isMacPlatform(navigator.platform);
+  const useMetaForMod = isMacNavigatorPlatform();
   window.dispatchEvent(
     new KeyboardEvent("keydown", {
       key,
@@ -7142,7 +7142,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
       composerEditor.focus();
       await waitForLayout();
       const dispatchNewChatShortcut = () => {
-        const useMetaForMod = isMacPlatform(navigator.platform);
+        const useMetaForMod = isMacNavigatorPlatform();
         window.dispatchEvent(
           new KeyboardEvent("keydown", {
             key: "n",

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -330,7 +330,7 @@ import { Button } from "./ui/button";
 import { Skeleton } from "./ui/skeleton";
 import { Menu, MenuItem, MenuTrigger } from "./ui/menu";
 import { randomTerminalId } from "./terminal/terminalIds";
-import { cn, isMacPlatform, randomUUID } from "~/lib/utils";
+import { cn, isMacNavigatorPlatform, randomUUID } from "~/lib/utils";
 import { toastManager } from "./ui/toast";
 import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybindings";
 import { type NewProjectScriptInput } from "./ProjectScriptsControl";
@@ -3619,11 +3619,10 @@ export default function ChatView({
   const composerTriggerKind = composerTrigger?.kind ?? null;
   const mentionTriggerQuery = composerTrigger?.kind === "mention" ? composerTrigger.query : "";
   const isMentionTrigger = composerTriggerKind === "mention";
-  const platform = typeof navigator === "undefined" ? "" : navigator.platform;
   const branchesQuery = useQuery(gitBranchesQueryOptions(gitBranchSourceCwd));
   const localFolderBrowseRootPath = getLocalFolderBrowseRootPath(
     serverConfigQuery.data?.homeDir ?? null,
-    isMacPlatform(platform),
+    isMacNavigatorPlatform(),
   );
   const isLocalFolderBrowserOpen =
     composerCommandPicker === null &&
@@ -6288,7 +6287,7 @@ export default function ChatView({
       // Mirror terminal interrupt semantics without stealing regular copy shortcuts.
       if (
         hasLiveTurn &&
-        isMacPlatform(navigator.platform) &&
+        isMacNavigatorPlatform() &&
         event.ctrlKey &&
         !event.metaKey &&
         !event.altKey &&

--- a/apps/web/src/components/DesktopWindowControls.tsx
+++ b/apps/web/src/components/DesktopWindowControls.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import type { DesktopWindowState } from "@synara/contracts";
 
 import { isElectron } from "~/env";
-import { cn, isWindowsPlatform } from "~/lib/utils";
+import { cn, getNavigatorPlatform, isWindowsPlatform } from "~/lib/utils";
 
 const DEFAULT_WINDOW_STATE: DesktopWindowState = {
   isMaximized: false,
@@ -44,7 +44,7 @@ function CaptionGlyph({ glyph }: { glyph: string }) {
 
 export function DesktopWindowControls({ className }: { className?: string }) {
   const [windowState, setWindowState] = useState<DesktopWindowState>(DEFAULT_WINDOW_STATE);
-  const platform = typeof navigator === "undefined" ? "" : navigator.platform;
+  const platform = getNavigatorPlatform();
   const isWindowsDesktop = isWindowsPlatform(platform);
   const controls = typeof window === "undefined" ? undefined : window.desktopBridge?.windowControls;
 

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -13,6 +13,7 @@ import {
   resolveCreatePrDialogRuntimeStatus,
   resolveCreatePrDialogView,
   resolveCreatePrExecution,
+  resolveCommitDialogActions,
   resolveDefaultCreateBranchName,
   resolveDefaultBranchActionDialogCopy,
   resolveLiveThreadBranchUpdate,
@@ -1388,6 +1389,116 @@ describe("resolveCreatePrDialogExecution", () => {
       kind: "unavailable",
       hint: "Branch is behind upstream. Pull before creating a PR.",
     });
+  });
+});
+
+describe("resolveCommitDialogActions", () => {
+  const baseContext = {
+    isBusy: false,
+    isDefaultBranch: false,
+    hasOriginRemote: true,
+    defaultBranchName: "main",
+  };
+  const dirtyStatus = status({
+    hasWorkingTreeChanges: true,
+    workingTree: {
+      files: [{ path: "a.ts", insertions: 3, deletions: 1 }],
+      insertions: 3,
+      deletions: 1,
+    },
+  });
+  const byId = (context: Parameters<typeof resolveCommitDialogActions>[0]) =>
+    Object.fromEntries(resolveCommitDialogActions(context).map((action) => [action.id, action]));
+
+  it("offers commit, commit & push, and PR on a dirty feature branch", () => {
+    const actions = byId({
+      context: { ...baseContext, gitStatus: dirtyStatus },
+      hasFileSelection: true,
+    });
+    assert.deepInclude(actions.commit, {
+      label: "Commit",
+      action: "commit",
+      featureBranch: false,
+      disabled: false,
+    });
+    assert.deepInclude(actions.commit_new_branch, {
+      label: "Commit on new branch",
+      action: "commit",
+      featureBranch: true,
+      disabled: false,
+    });
+    assert.deepInclude(actions.commit_push, {
+      label: "Commit & push",
+      action: "commit_push",
+      disabled: false,
+    });
+    assert.deepInclude(actions.create_pr, { label: "Create PR", disabled: false });
+  });
+
+  it("blocks every commit row while all files are excluded", () => {
+    const actions = byId({
+      context: { ...baseContext, gitStatus: dirtyStatus },
+      hasFileSelection: false,
+    });
+    assert.equal(actions.commit?.disabled, true);
+    assert.equal(actions.commit?.disabledReason, "Select at least one file to commit.");
+    assert.equal(actions.commit_new_branch?.disabled, true);
+    assert.equal(actions.commit_push?.disabled, true);
+    // The PR row hands off to the Create PR dialog, so it ignores the file selection.
+    assert.equal(actions.create_pr?.disabled, false);
+  });
+
+  it("collapses the push row to a pure push on a clean branch that is ahead", () => {
+    const actions = byId({
+      context: { ...baseContext, gitStatus: status({ aheadCount: 2 }) },
+      hasFileSelection: true,
+    });
+    assert.deepInclude(actions.commit_push, {
+      label: "Push",
+      action: "push",
+      disabled: false,
+    });
+    assert.equal(actions.commit?.disabled, true);
+    assert.equal(
+      actions.commit?.disabledReason,
+      "Worktree is clean. Make changes before committing.",
+    );
+  });
+
+  it("explains why commit & push is blocked behind upstream", () => {
+    const actions = byId({
+      context: {
+        ...baseContext,
+        gitStatus: status({ hasWorkingTreeChanges: true, behindCount: 1 }),
+      },
+      hasFileSelection: true,
+    });
+    assert.equal(actions.commit?.disabled, false);
+    assert.equal(actions.commit_push?.disabled, true);
+    assert.equal(
+      actions.commit_push?.disabledReason,
+      "Branch is behind upstream. Pull/rebase before committing and pushing.",
+    );
+  });
+
+  it("labels the PR row as View PR when one is already open", () => {
+    const actions = byId({
+      context: {
+        ...baseContext,
+        gitStatus: status({ hasWorkingTreeChanges: true, pr: statusPr() }),
+      },
+      hasFileSelection: true,
+    });
+    assert.deepInclude(actions.create_pr, { label: "View PR", disabled: false });
+  });
+
+  it("disables everything while a git action is running", () => {
+    const actions = resolveCommitDialogActions({
+      context: { ...baseContext, gitStatus: dirtyStatus, isBusy: true },
+      hasFileSelection: true,
+    });
+    assert.isTrue(actions.every((action) => action.disabled));
+    assert.isTrue(actions.every((action) => action.disabledReason === "Git action in progress."));
   });
 });
 

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -1481,6 +1481,22 @@ describe("resolveCommitDialogActions", () => {
     );
   });
 
+  it("uses the commit & push reason for the default-branch push menu item", () => {
+    const actions = byId({
+      context: {
+        ...baseContext,
+        isDefaultBranch: true,
+        gitStatus: status({ branch: "main", hasWorkingTreeChanges: true, behindCount: 1 }),
+      },
+      hasFileSelection: true,
+    });
+    assert.equal(actions.commit_push?.disabled, true);
+    assert.equal(
+      actions.commit_push?.disabledReason,
+      "Branch is behind upstream. Pull/rebase before committing and pushing.",
+    );
+  });
+
   it("labels the PR row as View PR when one is already open", () => {
     const actions = byId({
       context: {

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -7,6 +7,9 @@ import { isTemporaryWorktreeBranch, resolveUniqueSynaraBranchName } from "@synar
 
 export type GitActionIconName = "commit" | "push" | "pr";
 
+/** Every glyph a git affordance can render — see `gitActionGlyphs.tsx` for the map. */
+export type GitGlyphName = GitActionIconName | "sync" | "branch";
+
 export type GitDialogAction = "commit" | "push" | "commit_push" | "create_pr";
 
 export interface GitActionMenuItem {
@@ -194,7 +197,8 @@ function tracksDefaultUpstream(
   return FALLBACK_DEFAULT_BRANCH_NAMES.has(trackedBranchName);
 }
 
-export interface CreatePrDialogContext {
+/** Git state a dialog resolves its available actions from — shared by Create PR and Commit. */
+export interface GitDialogContext {
   gitStatus: GitStatusResult | null;
   isBusy: boolean;
   isDefaultBranch: boolean;
@@ -245,7 +249,7 @@ export function resolveCreatePrDialogRuntimeStatus(input: {
  * correctly reports unavailability when nothing is committed).
  */
 export function resolveCreatePrDialogExecution(
-  context: CreatePrDialogContext,
+  context: GitDialogContext,
   includeLocalChanges: boolean,
 ): CreatePrExecution {
   const { gitStatus } = context;
@@ -271,7 +275,7 @@ export interface CreatePrDialogView {
   deletions: number;
 }
 
-export function resolveCreatePrDialogView(context: CreatePrDialogContext): CreatePrDialogView {
+export function resolveCreatePrDialogView(context: GitDialogContext): CreatePrDialogView {
   const gitStatus = context.gitStatus;
   return {
     branchName: gitStatus?.branch ?? null,
@@ -295,7 +299,7 @@ export type CreatePrBrowserPreparation =
  * and then opens the GitHub compare page, leaving PR authoring to the browser.
  */
 export function resolveCreatePrBrowserPreparation(
-  context: CreatePrDialogContext,
+  context: GitDialogContext,
   includeLocalChanges: boolean,
 ): CreatePrBrowserPreparation {
   const execution = resolveCreatePrDialogExecution(context, includeLocalChanges);
@@ -422,6 +426,202 @@ export function buildMenuItems(
           kind: "open_dialog",
           dialogAction: "create_pr",
         },
+  ];
+}
+
+/**
+ * Human-readable reason a git menu item is unavailable. Shared by the dropdown picker
+ * rows and the Commit dialog action rows so the same blocked action always explains
+ * itself with the same sentence.
+ */
+export function resolveGitMenuActionDisabledReason(input: {
+  item: GitActionMenuItem;
+  gitStatus: GitStatusResult | null;
+  isBusy: boolean;
+  hasOriginRemote: boolean;
+  isDefaultBranch: boolean;
+  defaultBranchName: string | null | undefined;
+}): string | null {
+  const { item, gitStatus, isBusy, hasOriginRemote, isDefaultBranch, defaultBranchName } = input;
+  if (!item.disabled) return null;
+  if (isBusy) return "Git action in progress.";
+  if (!gitStatus) return "Git status is unavailable.";
+
+  const hasBranch = gitStatus.branch !== null;
+  const hasChanges = gitStatus.hasWorkingTreeChanges;
+  const hasOpenPr = gitStatus.pr?.state === "open";
+  const isAhead = gitStatus.aheadCount > 0;
+  const isBehind = gitStatus.behindCount > 0;
+
+  if (item.id === "commit") {
+    if (!hasChanges) {
+      return "Worktree is clean. Make changes before committing.";
+    }
+    return "Commit is currently unavailable.";
+  }
+
+  if (item.id === "push") {
+    if (!hasBranch) {
+      return "Detached HEAD: checkout a branch before pushing.";
+    }
+    if (hasChanges) {
+      return "Commit or stash local changes before pushing.";
+    }
+    if (isBehind) {
+      return "Branch is behind upstream. Pull/rebase before pushing.";
+    }
+    if (!gitStatus.hasUpstream && !hasOriginRemote) {
+      return 'Add an "origin" remote before pushing.';
+    }
+    if (!isAhead) {
+      return "No local commits to push.";
+    }
+    return "Push is currently unavailable.";
+  }
+
+  if (item.id === "commit_push") {
+    if (!hasBranch) {
+      return "Detached HEAD: checkout a branch before committing and pushing.";
+    }
+    if (isBehind) {
+      return "Branch is behind upstream. Pull/rebase before committing and pushing.";
+    }
+    if (!gitStatus.hasUpstream && !hasOriginRemote) {
+      return 'Add an "origin" remote before committing and pushing.';
+    }
+    if (!hasChanges && !isAhead) {
+      return "No local changes or commits to push.";
+    }
+    return "Commit & push is currently unavailable.";
+  }
+
+  if (hasOpenPr) {
+    return "View PR is currently unavailable.";
+  }
+  const prExecution = resolveCreatePrExecution({
+    gitStatus,
+    isBusy,
+    isDefaultBranch,
+    hasOriginRemote,
+    defaultBranchName,
+  });
+  if (prExecution.kind === "unavailable") {
+    return prExecution.hint;
+  }
+  return "Create PR is currently unavailable.";
+}
+
+export type GitCommitDialogActionId = "commit_new_branch" | "commit" | "commit_push" | "create_pr";
+
+export interface GitCommitDialogAction {
+  id: GitCommitDialogActionId;
+  label: string;
+  icon: GitGlyphName;
+  /** Stacked action to dispatch; `create_pr` hands off to the Create PR dialog. */
+  action: "commit" | "push" | "commit_push" | "create_pr";
+  /** Commit onto a freshly created feature branch instead of the current one. */
+  featureBranch: boolean;
+  disabled: boolean;
+  disabledReason: string | null;
+}
+
+const NO_FILE_SELECTION_HINT = "Select at least one file to commit.";
+
+/**
+ * Action rows offered by the Commit dialog. Commit-family rows reuse the dropdown
+ * menu's availability and wording (so "Commit & push" collapses to "Push" on a clean
+ * tree exactly as the menu does), while the PR row mirrors the one-click Create PR
+ * resolution and only ever hands off to the Create PR dialog.
+ */
+export function resolveCommitDialogActions(input: {
+  context: GitDialogContext;
+  /** False when the user excluded every changed file in the dialog's file list. */
+  hasFileSelection: boolean;
+}): GitCommitDialogAction[] {
+  const { gitStatus, isBusy, isDefaultBranch, hasOriginRemote, defaultBranchName } = input.context;
+  const menuItems = buildMenuItems(
+    gitStatus,
+    isBusy,
+    hasOriginRemote,
+    isDefaultBranch,
+    defaultBranchName,
+  );
+  const commitItem = menuItems.find((item) => item.id === "commit") ?? null;
+  const pushItem =
+    menuItems.find((item) => item.id === "commit_push") ??
+    menuItems.find((item) => item.id === "push") ??
+    null;
+  const reasonInput = {
+    gitStatus,
+    isBusy,
+    hasOriginRemote,
+    isDefaultBranch,
+    defaultBranchName,
+  };
+
+  const resolveRowState = (item: GitActionMenuItem | null, gateOnSelection: boolean) => {
+    if (!item) {
+      return {
+        disabled: true,
+        disabledReason: isBusy ? "Git action in progress." : "Git status is unavailable.",
+      };
+    }
+    if (item.disabled) {
+      return {
+        disabled: true,
+        disabledReason: resolveGitMenuActionDisabledReason({ item, ...reasonInput }),
+      };
+    }
+    if (gateOnSelection && !input.hasFileSelection) {
+      return { disabled: true, disabledReason: NO_FILE_SELECTION_HINT };
+    }
+    return { disabled: false, disabledReason: null };
+  };
+
+  const prExecution = resolveCreatePrExecution({
+    gitStatus,
+    isBusy,
+    isDefaultBranch,
+    hasOriginRemote,
+    defaultBranchName,
+  });
+  // A pure push needs no working-tree selection; anything that commits does.
+  const pushCommits = pushItem?.dialogAction !== "push";
+
+  return [
+    {
+      id: "commit_new_branch",
+      label: "Commit on new branch",
+      icon: "branch",
+      action: "commit",
+      featureBranch: true,
+      ...resolveRowState(commitItem, true),
+    },
+    {
+      id: "commit",
+      label: "Commit",
+      icon: "commit",
+      action: "commit",
+      featureBranch: false,
+      ...resolveRowState(commitItem, true),
+    },
+    {
+      id: "commit_push",
+      label: pushItem?.label ?? "Commit & push",
+      icon: "push",
+      action: pushItem?.dialogAction === "push" ? "push" : "commit_push",
+      featureBranch: false,
+      ...resolveRowState(pushItem, pushCommits),
+    },
+    {
+      id: "create_pr",
+      label: prExecution.kind === "open_pr" ? "View PR" : "Create PR",
+      icon: "pr",
+      action: "create_pr",
+      featureBranch: false,
+      disabled: prExecution.kind === "unavailable",
+      disabledReason: prExecution.kind === "unavailable" ? prExecution.hint : null,
+    },
   ];
 }
 

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -452,15 +452,16 @@ export function resolveGitMenuActionDisabledReason(input: {
   const hasOpenPr = gitStatus.pr?.state === "open";
   const isAhead = gitStatus.aheadCount > 0;
   const isBehind = gitStatus.behindCount > 0;
+  const action = item.dialogAction ?? item.id;
 
-  if (item.id === "commit") {
+  if (action === "commit") {
     if (!hasChanges) {
       return "Worktree is clean. Make changes before committing.";
     }
     return "Commit is currently unavailable.";
   }
 
-  if (item.id === "push") {
+  if (action === "push") {
     if (!hasBranch) {
       return "Detached HEAD: checkout a branch before pushing.";
     }
@@ -479,7 +480,7 @@ export function resolveGitMenuActionDisabledReason(input: {
     return "Push is currently unavailable.";
   }
 
-  if (item.id === "commit_push") {
+  if (action === "commit_push") {
     if (!hasBranch) {
       return "Detached HEAD: checkout a branch before committing and pushing.";
     }

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -14,27 +14,19 @@ import type {
 } from "@synara/contracts";
 import { useIsMutating, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
-import {
-  ChevronDownIcon,
-  CloudSyncIcon,
-  GitBranchIcon,
-  GitCommitIcon,
-  InfoIcon,
-  type LucideIcon,
-  PushIcon,
-} from "~/lib/icons";
+import { ChevronDownIcon, InfoIcon } from "~/lib/icons";
 import { Input } from "~/components/ui/input";
-import { GitHubIcon } from "./Icons";
 import {
   buildGitActionProgressStages,
   buildMenuItems,
-  type CreatePrDialogContext,
+  type GitDialogContext,
   type GitActionMenuItem,
-  type GitActionIconName,
+  type GitGlyphName,
   type GitQuickAction,
   type DefaultBranchConfirmableAction,
   requiresFeatureBranchForDefaultBranchAction,
   requiresDefaultBranchConfirmation,
+  resolveGitMenuActionDisabledReason,
   resolveLiveThreadBranchUpdate,
   resolveDefaultCreateBranchName,
   resolveDefaultBranchActionDialogCopy,
@@ -48,6 +40,8 @@ import {
   shouldOfferCreateBranchPrompt,
   summarizeGitResult,
 } from "./GitActionsControl.logic";
+import { GIT_ACTION_ICON_CLASS, GitActionGlyph } from "./gitActionGlyphs";
+import { GitCommitDialog, type GitCommitDialogSubmission } from "./GitCommitDialog";
 import {
   GitCreatePrDialog,
   type GitCreatePrDialogBrowserRequest,
@@ -73,7 +67,6 @@ import {
   EnvironmentRowBody,
   EnvironmentRowChevron,
 } from "./chat/environment/EnvironmentRow";
-import { Checkbox } from "~/components/ui/checkbox";
 import {
   Dialog,
   DialogDescription,
@@ -93,8 +86,6 @@ import {
 } from "~/components/ui/menu";
 import { ComposerPickerMenuPopup } from "~/components/chat/ComposerPickerMenuPopup";
 import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
-import { ScrollArea } from "~/components/ui/scroll-area";
-import { Textarea } from "~/components/ui/textarea";
 import { toastManager } from "~/components/ui/toast";
 import { openInPreferredEditor } from "~/editorPreferences";
 import {
@@ -186,7 +177,7 @@ interface GitPickerMenuItem {
   label: string;
   disabled: boolean;
   disabledReason: string | null;
-  icon: GitActionIconName | "sync" | "branch";
+  icon: GitGlyphName;
   onSelect: () => void;
 }
 
@@ -207,115 +198,6 @@ function resolveProgressDescription(progress: ActiveGitActionProgress): string |
     return progress.lastOutputLine;
   }
   return formatElapsedDescription(progress.hookStartedAtMs ?? progress.phaseStartedAtMs);
-}
-
-function getMenuActionDisabledReason({
-  item,
-  gitStatus,
-  isBusy,
-  hasOriginRemote,
-  isDefaultBranch,
-  defaultBranchName,
-}: {
-  item: GitActionMenuItem;
-  gitStatus: GitStatusResult | null;
-  isBusy: boolean;
-  hasOriginRemote: boolean;
-  isDefaultBranch: boolean;
-  defaultBranchName: string | null;
-}): string | null {
-  if (!item.disabled) return null;
-  if (isBusy) return "Git action in progress.";
-  if (!gitStatus) return "Git status is unavailable.";
-
-  const hasBranch = gitStatus.branch !== null;
-  const hasChanges = gitStatus.hasWorkingTreeChanges;
-  const hasOpenPr = gitStatus.pr?.state === "open";
-  const isAhead = gitStatus.aheadCount > 0;
-  const isBehind = gitStatus.behindCount > 0;
-
-  if (item.id === "commit") {
-    if (!hasChanges) {
-      return "Worktree is clean. Make changes before committing.";
-    }
-    return "Commit is currently unavailable.";
-  }
-
-  if (item.id === "push") {
-    if (!hasBranch) {
-      return "Detached HEAD: checkout a branch before pushing.";
-    }
-    if (hasChanges) {
-      return "Commit or stash local changes before pushing.";
-    }
-    if (isBehind) {
-      return "Branch is behind upstream. Pull/rebase before pushing.";
-    }
-    if (!gitStatus.hasUpstream && !hasOriginRemote) {
-      return 'Add an "origin" remote before pushing.';
-    }
-    if (!isAhead) {
-      return "No local commits to push.";
-    }
-    return "Push is currently unavailable.";
-  }
-
-  if (item.id === "commit_push") {
-    if (!hasBranch) {
-      return "Detached HEAD: checkout a branch before committing and pushing.";
-    }
-    if (isBehind) {
-      return "Branch is behind upstream. Pull/rebase before committing and pushing.";
-    }
-    if (!gitStatus.hasUpstream && !hasOriginRemote) {
-      return 'Add an "origin" remote before committing and pushing.';
-    }
-    if (!hasChanges && !isAhead) {
-      return "No local changes or commits to push.";
-    }
-    return "Commit & push is currently unavailable.";
-  }
-
-  if (hasOpenPr) {
-    return "View PR is currently unavailable.";
-  }
-  const prExecution = resolveCreatePrExecution({
-    gitStatus,
-    isBusy,
-    isDefaultBranch,
-    hasOriginRemote,
-    defaultBranchName,
-  });
-  if (prExecution.kind === "unavailable") {
-    return prExecution.hint;
-  }
-  return "Create PR is currently unavailable.";
-}
-
-const COMMIT_DIALOG_TITLE = "Commit changes";
-const COMMIT_DIALOG_DESCRIPTION =
-  "Review and confirm your commit. Leave the message blank to auto-generate one.";
-
-// Central icons render as masked spans (not <svg>), so size them explicitly here
-// rather than relying on parent `[&>svg]` selectors.
-const GIT_ACTION_ICON_CLASS = "size-3.5";
-
-/** Semantic name → glyph for every git affordance. Single source of truth shared by
- *  the header quick action and the dropdown picker rows so the same action always
- *  renders the same icon (e.g. push-family → the cloud PushIcon, PR → GitHub mark). */
-type GitGlyphName = GitActionIconName | "sync" | "branch";
-
-const GIT_ACTION_GLYPH: Record<GitGlyphName, LucideIcon> = {
-  commit: GitCommitIcon,
-  push: PushIcon,
-  pr: GitHubIcon,
-  sync: CloudSyncIcon,
-  branch: GitBranchIcon,
-};
-
-function GitActionGlyph({ name, className }: { name: GitGlyphName; className?: string }) {
-  const Glyph = GIT_ACTION_GLYPH[name];
-  return <Glyph className={className ?? GIT_ACTION_ICON_CLASS} />;
 }
 
 // Map a header quick action onto its shared glyph name; null falls back to a hint icon.
@@ -392,9 +274,6 @@ export default function GitActionsControl({
   );
   const queryClient = useQueryClient();
   const [isCommitDialogOpen, setIsCommitDialogOpen] = useState(false);
-  const [dialogCommitMessage, setDialogCommitMessage] = useState("");
-  const [excludedFiles, setExcludedFiles] = useState<ReadonlySet<string>>(new Set());
-  const [isEditingFiles, setIsEditingFiles] = useState(false);
   const [pendingDefaultBranchAction, setPendingDefaultBranchAction] =
     useState<PendingDefaultBranchAction | null>(null);
   const [isCreateBranchDialogOpen, setIsCreateBranchDialogOpen] = useState(false);
@@ -453,11 +332,6 @@ export default function GitActionsControl({
   }, [isGitStatusOutOfSync, requestGitActionAvailabilityRefresh]);
 
   const gitStatusForActions = isGitStatusOutOfSync ? null : gitStatus;
-
-  const allFiles = gitStatusForActions?.workingTree.files ?? [];
-  const selectedFiles = allFiles.filter((f) => !excludedFiles.has(f.path));
-  const allSelected = excludedFiles.size === 0;
-  const noneSelected = selectedFiles.length === 0;
 
   const initMutation = useMutation(gitInitMutationOptions({ cwd: gitCwd, queryClient }));
 
@@ -1151,7 +1025,7 @@ export default function GitActionsControl({
     ],
   );
 
-  const createPrDialogContext = useMemo<CreatePrDialogContext>(
+  const createPrDialogContext = useMemo<GitDialogContext>(
     () => ({
       gitStatus: createPrDialogRuntimeStatus.gitStatus,
       isBusy: isGitActionRunning,
@@ -1160,6 +1034,19 @@ export default function GitActionsControl({
       defaultBranchName,
     }),
     [createPrDialogRuntimeStatus, defaultBranchName, hasOriginRemote, isGitActionRunning],
+  );
+
+  // The Commit dialog always resolves against live status — unlike Create PR it is never
+  // opened from a surface carrying a post-push snapshot.
+  const commitDialogContext = useMemo<GitDialogContext>(
+    () => ({
+      gitStatus: gitStatusForActions,
+      isBusy: isGitActionRunning,
+      isDefaultBranch,
+      hasOriginRemote,
+      defaultBranchName,
+    }),
+    [defaultBranchName, gitStatusForActions, hasOriginRemote, isDefaultBranch, isGitActionRunning],
   );
 
   const continuePendingDefaultBranchAction = useCallback(() => {
@@ -1194,23 +1081,24 @@ export default function GitActionsControl({
     });
   }, [pendingDefaultBranchAction, runGitActionWithToast]);
 
-  const runDialogActionOnNewBranch = useCallback(() => {
-    if (!isCommitDialogOpen) return;
-    const commitMessage = dialogCommitMessage.trim();
-
-    setIsCommitDialogOpen(false);
-    setDialogCommitMessage("");
-    setExcludedFiles(new Set());
-    setIsEditingFiles(false);
-
-    void runGitActionWithToast({
-      action: "commit",
-      ...(commitMessage ? { commitMessage } : {}),
-      ...(!allSelected ? { filePaths: selectedFiles.map((f) => f.path) } : {}),
-      featureBranch: true,
-      skipDefaultBranchPrompt: true,
-    });
-  }, [allSelected, isCommitDialogOpen, dialogCommitMessage, runGitActionWithToast, selectedFiles]);
+  const handleCommitDialogSubmit = useCallback(
+    (submission: GitCommitDialogSubmission) => {
+      setIsCommitDialogOpen(false);
+      // Create PR owns its own authoring dialog (title/description/draft), so the
+      // commit dialog hands off instead of dispatching a PR chain itself.
+      if (submission.action === "create_pr") {
+        openCreatePrDialog();
+        return;
+      }
+      void runGitActionWithToast({
+        action: submission.action,
+        ...(submission.message ? { commitMessage: submission.message } : {}),
+        ...(submission.filePaths ? { filePaths: submission.filePaths } : {}),
+        ...(submission.featureBranch ? { featureBranch: true, skipDefaultBranchPrompt: true } : {}),
+      });
+    },
+    [openCreatePrDialog, runGitActionWithToast],
+  );
 
   const openCreateBranchDialog = useCallback(() => {
     setCreateBranchName(suggestedCreateBranchName);
@@ -1259,8 +1147,6 @@ export default function GitActionsControl({
   ]);
 
   const openCommitDialog = useCallback(() => {
-    setExcludedFiles(new Set());
-    setIsEditingFiles(false);
     setIsCommitDialogOpen(true);
   }, []);
 
@@ -1427,7 +1313,7 @@ export default function GitActionsControl({
         id: "commit",
         label: commitMenuItem.label,
         disabled: commitMenuItem.disabled,
-        disabledReason: getMenuActionDisabledReason({
+        disabledReason: resolveGitMenuActionDisabledReason({
           item: commitMenuItem,
           gitStatus: gitStatusForActions,
           isBusy: isGitActionRunning,
@@ -1445,7 +1331,7 @@ export default function GitActionsControl({
         id: "commit_push",
         label: commitPushMenuItem.label,
         disabled: commitPushMenuItem.disabled,
-        disabledReason: getMenuActionDisabledReason({
+        disabledReason: resolveGitMenuActionDisabledReason({
           item: commitPushMenuItem,
           gitStatus: gitStatusForActions,
           isBusy: isGitActionRunning,
@@ -1472,7 +1358,7 @@ export default function GitActionsControl({
         id: "push",
         label: pushMenuItem.label,
         disabled: pushMenuItem.disabled,
-        disabledReason: getMenuActionDisabledReason({
+        disabledReason: resolveGitMenuActionDisabledReason({
           item: pushMenuItem,
           gitStatus: gitStatusForActions,
           isBusy: isGitActionRunning,
@@ -1490,7 +1376,7 @@ export default function GitActionsControl({
         id: "pr",
         label: prMenuItem.label,
         disabled: prMenuItem.disabled,
-        disabledReason: getMenuActionDisabledReason({
+        disabledReason: resolveGitMenuActionDisabledReason({
           item: prMenuItem,
           gitStatus: gitStatusForActions,
           isBusy: isGitActionRunning,
@@ -1527,28 +1413,6 @@ export default function GitActionsControl({
     openCreateBranchDialog,
     openDialogForMenuItem,
     runSyncWithRemote,
-  ]);
-
-  const runDialogAction = useCallback(() => {
-    if (!isCommitDialogOpen) return;
-    const commitMessage = dialogCommitMessage.trim();
-    setIsCommitDialogOpen(false);
-    setDialogCommitMessage("");
-    setExcludedFiles(new Set());
-    setIsEditingFiles(false);
-    void runGitActionWithToast({
-      action: "commit",
-      ...(commitMessage ? { commitMessage } : {}),
-      ...(!allSelected ? { filePaths: selectedFiles.map((f) => f.path) } : {}),
-    });
-  }, [
-    allSelected,
-    dialogCommitMessage,
-    isCommitDialogOpen,
-    runGitActionWithToast,
-    selectedFiles,
-    setDialogCommitMessage,
-    setIsCommitDialogOpen,
   ]);
 
   const openChangedFileInEditor = useCallback(
@@ -1604,8 +1468,7 @@ export default function GitActionsControl({
     );
   }
 
-  const hasRunnableCommitPushAction = findRunnableCommitPushMenuItem(gitActionMenuItems) !== null;
-  const shouldDimPanelCommitPushRow = isGitActionRunning || !hasRunnableCommitPushAction;
+  const runnableCommitPushMenuItem = findRunnableCommitPushMenuItem(gitActionMenuItems);
 
   // Shared dropdown body — the picker rows plus the contextual git-status warnings.
   // Rendered identically by the header split button and the panel "Commit and Push" row.
@@ -1683,173 +1546,15 @@ export default function GitActionsControl({
         onOpenInBrowser={handleCreatePrDialogBrowser}
       />
 
-      <Dialog
+      <GitCommitDialog
         open={isCommitDialogOpen}
         onOpenChange={(open) => {
-          if (!open) {
-            setIsCommitDialogOpen(false);
-            setDialogCommitMessage("");
-            setExcludedFiles(new Set());
-            setIsEditingFiles(false);
-          }
+          if (!open) setIsCommitDialogOpen(false);
         }}
-      >
-        <DialogPopup>
-          <DialogHeader>
-            <DialogTitle>{COMMIT_DIALOG_TITLE}</DialogTitle>
-            <DialogDescription>{COMMIT_DIALOG_DESCRIPTION}</DialogDescription>
-          </DialogHeader>
-          <DialogPanel className="space-y-4">
-            <div className="space-y-3 rounded-lg border border-[color:var(--color-border)] bg-[var(--color-background-elevated-secondary)] p-3 text-xs">
-              <div className="grid grid-cols-[auto_1fr] items-center gap-x-2 gap-y-1">
-                <span className="text-muted-foreground">Branch</span>
-                <span className="flex items-center justify-between gap-2">
-                  <span className="font-medium">
-                    {gitStatusForActions?.branch ?? "(detached HEAD)"}
-                  </span>
-                  {isDefaultBranch && (
-                    <span className="text-right text-warning text-xs">Warning: default branch</span>
-                  )}
-                </span>
-              </div>
-              <div className="space-y-1">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    {isEditingFiles && allFiles.length > 0 && (
-                      <Checkbox
-                        checked={allSelected}
-                        indeterminate={!allSelected && !noneSelected}
-                        onCheckedChange={() => {
-                          setExcludedFiles(
-                            allSelected ? new Set(allFiles.map((f) => f.path)) : new Set(),
-                          );
-                        }}
-                      />
-                    )}
-                    <span className="text-muted-foreground">Files</span>
-                    {!allSelected && !isEditingFiles && (
-                      <span className="text-muted-foreground">
-                        ({selectedFiles.length} of {allFiles.length})
-                      </span>
-                    )}
-                  </div>
-                  {allFiles.length > 0 && (
-                    <Button
-                      variant="ghost"
-                      size="xs"
-                      onClick={() => setIsEditingFiles((prev) => !prev)}
-                    >
-                      {isEditingFiles ? "Done" : "Edit"}
-                    </Button>
-                  )}
-                </div>
-                {!gitStatusForActions || allFiles.length === 0 ? (
-                  <p className="font-medium">none</p>
-                ) : (
-                  <div className="space-y-2">
-                    <ScrollArea className="h-44 rounded-md border border-[color:var(--color-border)] bg-[var(--color-background-elevated-primary-opaque)]">
-                      <div className="space-y-1 p-1">
-                        {allFiles.map((file) => {
-                          const isExcluded = excludedFiles.has(file.path);
-                          return (
-                            <div
-                              key={file.path}
-                              className="flex w-full items-center gap-2 rounded-md px-2 py-1 font-mono text-xs transition-colors hover:bg-[var(--color-background-button-secondary-hover)]"
-                            >
-                              {isEditingFiles && (
-                                <Checkbox
-                                  checked={!excludedFiles.has(file.path)}
-                                  onCheckedChange={() => {
-                                    setExcludedFiles((prev) => {
-                                      const next = new Set(prev);
-                                      if (next.has(file.path)) {
-                                        next.delete(file.path);
-                                      } else {
-                                        next.add(file.path);
-                                      }
-                                      return next;
-                                    });
-                                  }}
-                                />
-                              )}
-                              {/* Raw <button> intentionally — list-row click target, not a shadcn Button. */}
-                              <button
-                                type="button"
-                                className="group flex flex-1 items-center justify-between gap-3 text-left truncate"
-                                onClick={() => openChangedFileInEditor(file.path)}
-                              >
-                                <span
-                                  className={`truncate underline-offset-2 group-hover:underline group-focus-visible:underline${isExcluded ? " text-muted-foreground" : ""}`}
-                                >
-                                  {file.path}
-                                </span>
-                                <span className="shrink-0">
-                                  {isExcluded ? (
-                                    <span className="text-muted-foreground">Excluded</span>
-                                  ) : (
-                                    <>
-                                      <span className="text-success">+{file.insertions}</span>
-                                      <span className="text-muted-foreground"> / </span>
-                                      <span className="text-destructive">-{file.deletions}</span>
-                                    </>
-                                  )}
-                                </span>
-                              </button>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </ScrollArea>
-                    <div className="flex justify-end font-mono">
-                      <span className="text-success">
-                        +{selectedFiles.reduce((sum, f) => sum + f.insertions, 0)}
-                      </span>
-                      <span className="text-muted-foreground"> / </span>
-                      <span className="text-destructive">
-                        -{selectedFiles.reduce((sum, f) => sum + f.deletions, 0)}
-                      </span>
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
-            <div className="space-y-1">
-              <p className="text-xs font-medium">Commit message (optional)</p>
-              <Textarea
-                value={dialogCommitMessage}
-                onChange={(event) => setDialogCommitMessage(event.target.value)}
-                placeholder="Leave empty to auto-generate"
-                size="sm"
-              />
-            </div>
-          </DialogPanel>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                setIsCommitDialogOpen(false);
-                setDialogCommitMessage("");
-                setExcludedFiles(new Set());
-                setIsEditingFiles(false);
-              }}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={noneSelected}
-              onClick={runDialogActionOnNewBranch}
-            >
-              Commit on new branch
-            </Button>
-            <Button size="sm" disabled={noneSelected} onClick={runDialogAction}>
-              Commit
-            </Button>
-          </DialogFooter>
-        </DialogPopup>
-      </Dialog>
+        context={commitDialogContext}
+        onSubmit={handleCommitDialogSubmit}
+        onOpenFile={openChangedFileInEditor}
+      />
 
       <Dialog
         open={pendingDefaultBranchAction !== null}
@@ -1973,6 +1678,21 @@ export default function GitActionsControl({
 
   if (isPanel) {
     const showPanelPullRow = showPromotedPullAction;
+    // The panel row runs its action on click — exactly like Pull — and the chevron
+    // beside it is the only way into the git actions menu (and its dialogs).
+    const panelPrimaryLabel = showPanelPullRow
+      ? (promotedPull?.label ?? "Pull")
+      : (runnableCommitPushMenuItem?.label ?? "Commit and Push");
+    const panelPrimaryGlyph: GitGlyphName = showPanelPullRow ? "sync" : "push";
+    const runPanelPrimaryAction = () => {
+      if (showPanelPullRow) {
+        runSyncWithRemote();
+        return;
+      }
+      if (runnableCommitPushMenuItem) {
+        openDialogForMenuItem(runnableCommitPushMenuItem);
+      }
+    };
     const panelGitActionsMenu = (
       <Menu
         onOpenChange={(open) => {
@@ -1983,38 +1703,13 @@ export default function GitActionsControl({
           render={
             <button
               type="button"
-              className={cn(
-                ENVIRONMENT_ROW_CLASS_NAME,
-                showPanelPullRow
-                  ? "w-auto shrink-0 px-1.5"
-                  : shouldDimPanelCommitPushRow && "opacity-55",
-              )}
-              aria-label={
-                showPanelPullRow
-                  ? "Git action options"
-                  : shouldDimPanelCommitPushRow
-                    ? "Commit and Push unavailable; open Git actions menu"
-                    : "Commit and Push"
-              }
-              title={
-                showPanelPullRow
-                  ? "More Git actions"
-                  : shouldDimPanelCommitPushRow
-                    ? "Commit and Push unavailable. Open for more Git actions."
-                    : "Commit and Push"
-              }
+              className={cn(ENVIRONMENT_ROW_CLASS_NAME, "w-auto shrink-0 px-1.5")}
+              aria-label="Git action options"
+              title="More Git actions"
             />
           }
         >
-          {showPanelPullRow ? (
-            <EnvironmentRowChevron />
-          ) : (
-            <EnvironmentRowBody
-              icon={<GitActionGlyph name="push" className={ENVIRONMENT_ROW_ICON_CLASS_NAME} />}
-              label="Commit and Push"
-              trailing={<EnvironmentRowChevron />}
-            />
-          )}
+          <EnvironmentRowChevron />
         </MenuTrigger>
         <ComposerPickerMenuPopup align="start" side="bottom" className="w-60 min-w-60">
           {gitMenuContent}
@@ -2031,25 +1726,28 @@ export default function GitActionsControl({
             disabled={initMutation.isPending}
             onClick={() => initMutation.mutate()}
           />
-        ) : showPanelPullRow ? (
+        ) : (
           <div className="flex w-full items-center">
             <button
               type="button"
               className={cn(ENVIRONMENT_ROW_CLASS_NAME, "min-w-0 flex-1")}
-              aria-label={promotedPull?.label ?? "Pull"}
-              title={promotedPull?.label ?? "Pull"}
-              disabled={isGitActionRunning}
-              onClick={runSyncWithRemote}
+              aria-label={panelPrimaryLabel}
+              title={panelPrimaryLabel}
+              disabled={isGitActionRunning || (!showPanelPullRow && !runnableCommitPushMenuItem)}
+              onClick={runPanelPrimaryAction}
             >
               <EnvironmentRowBody
-                icon={<GitActionGlyph name="sync" className={ENVIRONMENT_ROW_ICON_CLASS_NAME} />}
-                label={promotedPull?.label ?? "Pull"}
+                icon={
+                  <GitActionGlyph
+                    name={panelPrimaryGlyph}
+                    className={ENVIRONMENT_ROW_ICON_CLASS_NAME}
+                  />
+                }
+                label={panelPrimaryLabel}
               />
             </button>
             {panelGitActionsMenu}
           </div>
-        ) : (
-          panelGitActionsMenu
         )}
         {gitActionDialogs}
       </>

--- a/apps/web/src/components/GitCommitDialog.tsx
+++ b/apps/web/src/components/GitCommitDialog.tsx
@@ -1,0 +1,251 @@
+// FILE: GitCommitDialog.tsx
+// Purpose: Render the Commit dialog: branch summary, commit message, a compact
+//          file selection with diff stats, and the shared git action rows
+//          (commit on new branch / commit / commit & push / create PR).
+// Layer: Header action control
+// Depends on: GitActionsControl.logic resolvers and the shared git dialog chrome.
+
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "~/components/ui/button";
+import { Checkbox } from "~/components/ui/checkbox";
+import { DiffStat } from "~/components/ui/diff-stat";
+import { SubmitShortcutKbd } from "~/components/ui/kbd";
+import { ScrollArea } from "~/components/ui/scroll-area";
+import {
+  type GitCommitDialogAction,
+  type GitDialogContext,
+  resolveCommitDialogActions,
+} from "./GitActionsControl.logic";
+import { GitActionGlyph } from "./gitActionGlyphs";
+import {
+  GIT_DIALOG_FIELD_CLASS,
+  GitDialogActionList,
+  GitDialogActionRow,
+  GitDialogBody,
+  GitDialogHeading,
+  GitDialogShell,
+} from "./GitDialogChrome";
+import { cn } from "~/lib/utils";
+
+export interface GitCommitDialogSubmission {
+  action: GitCommitDialogAction["action"];
+  featureBranch: boolean;
+  message: string | null;
+  /** null commits every changed file; otherwise only the listed paths. */
+  filePaths: string[] | null;
+}
+
+interface ChangedFile {
+  path: string;
+  insertions: number;
+  deletions: number;
+}
+
+interface GitCommitDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  context: GitDialogContext;
+  onSubmit: (submission: GitCommitDialogSubmission) => void;
+  onOpenFile: (filePath: string) => void;
+}
+
+export function GitCommitDialog({
+  open,
+  onOpenChange,
+  context,
+  onSubmit,
+  onOpenFile,
+}: GitCommitDialogProps) {
+  const [message, setMessage] = useState("");
+  const [excludedFiles, setExcludedFiles] = useState<ReadonlySet<string>>(new Set());
+  const [isEditingFiles, setIsEditingFiles] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setMessage("");
+    setExcludedFiles(new Set());
+    setIsEditingFiles(false);
+  }, [open]);
+
+  const gitStatus = context.gitStatus;
+  const allFiles = useMemo(() => gitStatus?.workingTree.files ?? [], [gitStatus]);
+  const selectedFiles = useMemo(
+    () => allFiles.filter((file) => !excludedFiles.has(file.path)),
+    [allFiles, excludedFiles],
+  );
+  const allSelected = excludedFiles.size === 0;
+  const noneSelected = selectedFiles.length === 0;
+  // With nothing to select the file gate is vacuous — a pure push must stay runnable.
+  const hasFileSelection = allFiles.length === 0 || !noneSelected;
+
+  const actions = useMemo(
+    () => resolveCommitDialogActions({ context, hasFileSelection }),
+    [context, hasFileSelection],
+  );
+
+  const submit = (action: GitCommitDialogAction) => {
+    if (action.disabled) return;
+    onSubmit({
+      action: action.action,
+      featureBranch: action.featureBranch,
+      message: message.trim() || null,
+      filePaths: allSelected ? null : selectedFiles.map((file) => file.path),
+    });
+  };
+
+  const submitPrimary = () => {
+    const primary = actions.find((action) => action.id === "commit");
+    if (primary) submit(primary);
+  };
+
+  const toggleFile = (path: string) => {
+    setExcludedFiles((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <GitDialogShell open={open} onOpenChange={onOpenChange} onSubmitShortcut={submitPrimary}>
+      <GitDialogHeading
+        eyebrow="Commit"
+        eyebrowTrailing={
+          context.isDefaultBranch ? <span className="text-warning">Default branch</span> : null
+        }
+        subject={gitStatus?.branch ?? "(detached HEAD)"}
+      />
+      <GitDialogBody>
+        <textarea
+          autoFocus
+          aria-label="Commit message"
+          className={cn(GIT_DIALOG_FIELD_CLASS, "resize-none")}
+          maxLength={20_000}
+          placeholder="Message (leave empty to generate)"
+          rows={2}
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+        />
+        <div className="space-y-1">
+          <div className="flex items-center gap-2 py-1 text-sm">
+            {isEditingFiles && allFiles.length > 0 ? (
+              <Checkbox
+                checked={allSelected}
+                indeterminate={!allSelected && !noneSelected}
+                onCheckedChange={() => {
+                  setExcludedFiles(
+                    allSelected ? new Set(allFiles.map((file) => file.path)) : new Set(),
+                  );
+                }}
+              />
+            ) : null}
+            <span className="min-w-0 flex-1 truncate text-muted-foreground">
+              {summarizeSelection(allFiles.length, selectedFiles.length, allSelected)}
+            </span>
+            <DiffStat
+              className="shrink-0 font-mono text-xs"
+              insertions={selectedFiles.reduce((sum, file) => sum + file.insertions, 0)}
+              deletions={selectedFiles.reduce((sum, file) => sum + file.deletions, 0)}
+            />
+            {allFiles.length > 0 ? (
+              <Button
+                variant="ghost"
+                size="xs"
+                className="shrink-0"
+                onClick={() => setIsEditingFiles((prev) => !prev)}
+              >
+                {isEditingFiles ? "Done" : "Edit"}
+              </Button>
+            ) : null}
+          </div>
+          {allFiles.length > 0 ? (
+            <ScrollArea className="h-32 rounded-md border border-[color:var(--color-border)] bg-[var(--color-background-elevated-primary-opaque)]">
+              <div className="space-y-1 p-1">
+                {allFiles.map((file) => (
+                  <ChangedFileRow
+                    key={file.path}
+                    file={file}
+                    excluded={excludedFiles.has(file.path)}
+                    selectable={isEditingFiles}
+                    onToggle={() => toggleFile(file.path)}
+                    onOpen={() => onOpenFile(file.path)}
+                  />
+                ))}
+              </div>
+            </ScrollArea>
+          ) : null}
+        </div>
+      </GitDialogBody>
+      <GitDialogActionList>
+        {actions.map((action) => (
+          <GitDialogActionRow
+            key={action.id}
+            highlighted={action.id === "commit"}
+            disabled={action.disabled}
+            disabledReason={action.disabledReason}
+            icon={<GitActionGlyph name={action.icon} className="size-4" />}
+            label={action.label}
+            {...(action.id === "commit" ? { trailing: <SubmitShortcutKbd /> } : {})}
+            onClick={() => submit(action)}
+          />
+        ))}
+      </GitDialogActionList>
+    </GitDialogShell>
+  );
+}
+
+function summarizeSelection(total: number, selected: number, allSelected: boolean): string {
+  if (total === 0) return "No local changes";
+  if (allSelected) return `${total} ${total === 1 ? "file" : "files"}`;
+  return `${selected} of ${total} files`;
+}
+
+function ChangedFileRow({
+  file,
+  excluded,
+  selectable,
+  onToggle,
+  onOpen,
+}: {
+  file: ChangedFile;
+  excluded: boolean;
+  selectable: boolean;
+  onToggle: () => void;
+  onOpen: () => void;
+}) {
+  return (
+    <div className="flex w-full items-center gap-2 rounded-md px-2 py-1 font-mono text-xs transition-colors hover:bg-[var(--color-background-button-secondary-hover)]">
+      {selectable ? <Checkbox checked={!excluded} onCheckedChange={onToggle} /> : null}
+      {/* Raw <button> intentionally — list-row click target, not a shadcn Button. */}
+      <button
+        type="button"
+        className="group flex flex-1 items-center justify-between gap-3 truncate text-left"
+        onClick={onOpen}
+      >
+        <span
+          className={cn(
+            "truncate underline-offset-2 group-hover:underline group-focus-visible:underline",
+            excluded && "text-muted-foreground",
+          )}
+        >
+          {file.path}
+        </span>
+        <span className="shrink-0">
+          {excluded ? (
+            <span className="text-muted-foreground">Excluded</span>
+          ) : (
+            <DiffStat
+              insertions={file.insertions}
+              deletions={file.deletions}
+              separator={<span className="text-muted-foreground">/</span>}
+            />
+          )}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/GitCreatePrDialog.tsx
+++ b/apps/web/src/components/GitCreatePrDialog.tsx
@@ -2,28 +2,29 @@
 // Purpose: Render the Create PR dialog: branch summary, optional PR title/description,
 //          local-changes toggle with diff stats, and create/draft/browser actions.
 // Layer: Header action control
-// Depends on: GitActionsControl.logic resolvers and shared dialog/checkbox/kbd primitives.
+// Depends on: GitActionsControl.logic resolvers and the shared git dialog chrome.
 
 import { useEffect, useMemo, useState } from "react";
 import { Checkbox } from "~/components/ui/checkbox";
-import {
-  Dialog,
-  DialogDescription,
-  DialogHeader,
-  DialogPanel,
-  DialogPopup,
-  DialogTitle,
-} from "~/components/ui/dialog";
-import { Kbd } from "~/components/ui/kbd";
+import { DiffStat } from "~/components/ui/diff-stat";
+import { SubmitShortcutKbd } from "~/components/ui/kbd";
 import {
   type CreatePrBrowserPreparation,
-  type CreatePrDialogContext,
+  type GitDialogContext,
   resolveCreatePrBrowserPreparation,
   resolveCreatePrDialogExecution,
   resolveCreatePrDialogView,
 } from "./GitActionsControl.logic";
+import {
+  GIT_DIALOG_FIELD_CLASS,
+  GitDialogActionList,
+  GitDialogActionRow,
+  GitDialogBody,
+  GitDialogHeading,
+  GitDialogShell,
+} from "./GitDialogChrome";
 import { ArrowUpRightIcon, GitPullRequestDraftIcon, GitPullRequestIcon } from "~/lib/icons";
-import { cn, isMacPlatform } from "~/lib/utils";
+import { cn } from "~/lib/utils";
 
 export interface GitCreatePrDialogSubmission {
   action: "create_pr" | "commit_push_pr";
@@ -41,43 +42,9 @@ export interface GitCreatePrDialogBrowserRequest {
 interface GitCreatePrDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  context: CreatePrDialogContext;
+  context: GitDialogContext;
   onSubmit: (submission: GitCreatePrDialogSubmission) => void;
   onOpenInBrowser: (request: GitCreatePrDialogBrowserRequest) => void;
-}
-
-function CreatePrActionRow({
-  highlighted,
-  disabled,
-  onClick,
-  icon,
-  label,
-  trailing,
-}: {
-  highlighted?: boolean;
-  disabled?: boolean;
-  onClick: () => void;
-  icon: React.ReactNode;
-  label: string;
-  trailing?: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      disabled={disabled}
-      onClick={onClick}
-      className={cn(
-        "flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-sm outline-none transition-colors",
-        "hover:bg-[var(--color-background-button-secondary-hover)] focus-visible:bg-[var(--color-background-button-secondary-hover)]",
-        highlighted && "bg-[var(--color-background-button-secondary-hover)]",
-        disabled && "pointer-events-none opacity-50",
-      )}
-    >
-      <span className="shrink-0 text-muted-foreground [&_svg]:size-4">{icon}</span>
-      <span className="flex-1 truncate">{label}</span>
-      {trailing}
-    </button>
-  );
 }
 
 export function GitCreatePrDialog({
@@ -110,7 +77,6 @@ export function GitCreatePrDialog({
   const canCreate = execution.kind === "run_action";
   const canOpenInBrowser = browserPreparation.kind !== "unavailable";
   const unavailableHint = execution.kind === "unavailable" ? execution.hint : null;
-  const isMac = isMacPlatform(typeof navigator === "undefined" ? "" : navigator.platform);
 
   const submit = (draft: boolean) => {
     if (execution.kind !== "run_action") return;
@@ -124,93 +90,73 @@ export function GitCreatePrDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogPopup
-        className="max-w-md"
-        showCloseButton={false}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
-            event.preventDefault();
-            submit(false);
-          }
-        }}
-      >
-        <DialogHeader className="gap-0.5">
-          <DialogTitle className="font-normal font-sans text-muted-foreground text-xs">
-            {view.isNewBranch ? "New branch" : "Branch"} → {view.baseBranchName}
-          </DialogTitle>
-          <DialogDescription
-            className={cn(
-              "truncate font-medium text-sm",
-              view.willCreateFeatureBranch
-                ? "text-muted-foreground italic"
-                : "text-[var(--color-text-foreground)]",
-            )}
-          >
-            {view.willCreateFeatureBranch
-              ? "Auto-named feature branch"
-              : (view.branchName ?? "(detached HEAD)")}
-          </DialogDescription>
-        </DialogHeader>
-        <DialogPanel className="space-y-1 pt-2">
-          <input
-            autoFocus
-            aria-label="Pull request title"
-            className="w-full bg-transparent py-1 font-system-ui text-sm outline-none placeholder:text-muted-foreground/70"
-            maxLength={300}
-            placeholder="Title (leave empty to generate)"
-            value={title}
-            onChange={(event) => setTitle(event.target.value)}
-          />
-          <textarea
-            aria-label="Pull request description"
-            className="w-full resize-none bg-transparent py-1 font-system-ui text-sm outline-none placeholder:text-muted-foreground/70"
-            maxLength={60_000}
-            placeholder="Description (leave empty to generate)"
-            rows={2}
-            value={body}
-            onChange={(event) => setBody(event.target.value)}
-          />
-          {view.showCommitToggle && (
-            <label className="flex cursor-pointer items-center gap-2 py-1 text-sm">
-              <Checkbox
-                checked={includeLocalChanges}
-                onCheckedChange={(checked) => setIncludeLocalChanges(checked === true)}
-              />
-              <span className="flex-1">Commit and push local changes</span>
-              <span className="shrink-0 font-mono text-xs">
-                <span className="text-success">+{view.insertions}</span>{" "}
-                <span className="text-destructive">−{view.deletions}</span>
-              </span>
-            </label>
-          )}
-          {unavailableHint && <p className="py-1 text-warning text-xs">{unavailableHint}</p>}
-        </DialogPanel>
-        <div className="border-[color:var(--color-border)] border-t p-2">
-          <CreatePrActionRow
-            disabled={!canCreate}
-            icon={<GitPullRequestDraftIcon />}
-            label="Create draft PR"
-            onClick={() => submit(true)}
-          />
-          <CreatePrActionRow
-            highlighted
-            disabled={!canCreate}
-            icon={<GitPullRequestIcon />}
-            label="Create PR"
-            trailing={<Kbd>{isMac ? "⌘↵" : "Ctrl ↵"}</Kbd>}
-            onClick={() => submit(false)}
-          />
-          <CreatePrActionRow
-            disabled={!canOpenInBrowser}
-            icon={<ArrowUpRightIcon />}
-            label="Open PR in browser"
-            onClick={() =>
-              onOpenInBrowser({ preparation: browserPreparation, includeLocalChanges })
-            }
-          />
-        </div>
-      </DialogPopup>
-    </Dialog>
+    <GitDialogShell open={open} onOpenChange={onOpenChange} onSubmitShortcut={() => submit(false)}>
+      <GitDialogHeading
+        eyebrow={`${view.isNewBranch ? "New branch" : "Branch"} → ${view.baseBranchName}`}
+        subject={
+          view.willCreateFeatureBranch
+            ? "Auto-named feature branch"
+            : (view.branchName ?? "(detached HEAD)")
+        }
+        subjectMuted={view.willCreateFeatureBranch}
+      />
+      <GitDialogBody>
+        <input
+          autoFocus
+          aria-label="Pull request title"
+          className={GIT_DIALOG_FIELD_CLASS}
+          maxLength={300}
+          placeholder="Title (leave empty to generate)"
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+        />
+        <textarea
+          aria-label="Pull request description"
+          className={cn(GIT_DIALOG_FIELD_CLASS, "resize-none")}
+          maxLength={60_000}
+          placeholder="Description (leave empty to generate)"
+          rows={2}
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+        />
+        {view.showCommitToggle && (
+          <label className="flex cursor-pointer items-center gap-2 py-1 text-sm">
+            <Checkbox
+              checked={includeLocalChanges}
+              onCheckedChange={(checked) => setIncludeLocalChanges(checked === true)}
+            />
+            <span className="flex-1">Commit and push local changes</span>
+            <DiffStat
+              className="shrink-0 font-mono text-xs"
+              insertions={view.insertions}
+              deletions={view.deletions}
+            />
+          </label>
+        )}
+        {unavailableHint && <p className="py-1 text-warning text-xs">{unavailableHint}</p>}
+      </GitDialogBody>
+      <GitDialogActionList>
+        <GitDialogActionRow
+          disabled={!canCreate}
+          icon={<GitPullRequestDraftIcon />}
+          label="Create draft PR"
+          onClick={() => submit(true)}
+        />
+        <GitDialogActionRow
+          highlighted
+          disabled={!canCreate}
+          icon={<GitPullRequestIcon />}
+          label="Create PR"
+          trailing={<SubmitShortcutKbd />}
+          onClick={() => submit(false)}
+        />
+        <GitDialogActionRow
+          disabled={!canOpenInBrowser}
+          icon={<ArrowUpRightIcon />}
+          label="Open PR in browser"
+          onClick={() => onOpenInBrowser({ preparation: browserPreparation, includeLocalChanges })}
+        />
+      </GitDialogActionList>
+    </GitDialogShell>
   );
 }

--- a/apps/web/src/components/GitDialogChrome.tsx
+++ b/apps/web/src/components/GitDialogChrome.tsx
@@ -1,0 +1,152 @@
+// FILE: GitDialogChrome.tsx
+// Purpose: The shared shell of every git dialog (Create PR, Commit) — popup sizing and
+//          submit chord, the branch heading, the borderless message fields, and the
+//          bottom action rows with their "why is this unavailable" tooltip.
+// Layer: Git dialog UI primitive
+
+import type { ReactNode } from "react";
+import {
+  Dialog,
+  DialogDescription,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "~/components/ui/dialog";
+import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
+import { cn } from "~/lib/utils";
+
+/**
+ * Popup shell shared by the git dialogs: same width, no close button, and ⌘/Ctrl+↵
+ * runs the dialog's primary action.
+ */
+export function GitDialogShell({
+  open,
+  onOpenChange,
+  onSubmitShortcut,
+  children,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmitShortcut: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPopup
+        className="max-w-md"
+        showCloseButton={false}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+            event.preventDefault();
+            onSubmitShortcut();
+          }
+        }}
+      >
+        {children}
+      </DialogPopup>
+    </Dialog>
+  );
+}
+
+/** Muted context line (branch flow, dialog kind) above the branch the action targets. */
+export function GitDialogHeading({
+  eyebrow,
+  eyebrowTrailing,
+  subject,
+  subjectMuted,
+}: {
+  eyebrow: ReactNode;
+  eyebrowTrailing?: ReactNode;
+  subject: string;
+  /** Marks a subject the dialog will derive rather than one that already exists. */
+  subjectMuted?: boolean;
+}) {
+  return (
+    <DialogHeader className="gap-0.5">
+      <DialogTitle className="flex items-center justify-between gap-2 font-normal font-sans text-muted-foreground text-xs">
+        <span className="truncate">{eyebrow}</span>
+        {eyebrowTrailing}
+      </DialogTitle>
+      <DialogDescription
+        className={cn(
+          "truncate font-medium text-sm",
+          subjectMuted ? "text-muted-foreground italic" : "text-[var(--color-text-foreground)]",
+        )}
+      >
+        {subject}
+      </DialogDescription>
+    </DialogHeader>
+  );
+}
+
+/** Body between the heading and the action rows. */
+export function GitDialogBody({ children }: { children: ReactNode }) {
+  return <DialogPanel className="space-y-1 pt-2">{children}</DialogPanel>;
+}
+
+/** Borderless authoring field (PR title/description, commit message). */
+export const GIT_DIALOG_FIELD_CLASS =
+  "w-full bg-transparent py-1 font-system-ui text-sm outline-none placeholder:text-muted-foreground/70";
+
+/** Hairline-separated action strip pinned to the bottom of a git dialog. */
+export function GitDialogActionList({ children }: { children: ReactNode }) {
+  return <div className="border-[color:var(--color-border)] border-t p-2">{children}</div>;
+}
+
+export function GitDialogActionRow({
+  highlighted,
+  disabled,
+  disabledReason,
+  onClick,
+  icon,
+  label,
+  trailing,
+}: {
+  highlighted?: boolean;
+  disabled?: boolean;
+  /** Shown as a hover tooltip while the row is disabled. */
+  disabledReason?: string | null;
+  onClick: () => void;
+  icon: ReactNode;
+  label: string;
+  trailing?: ReactNode;
+}) {
+  const row = (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-sm outline-none transition-colors",
+        "hover:bg-[var(--color-background-button-secondary-hover)] focus-visible:bg-[var(--color-background-button-secondary-hover)]",
+        highlighted && "bg-[var(--color-background-button-secondary-hover)]",
+        disabled && "pointer-events-none opacity-50",
+      )}
+    >
+      <span className="shrink-0 text-muted-foreground [&_svg]:size-4">{icon}</span>
+      <span className="flex-1 truncate">{label}</span>
+      {trailing}
+    </button>
+  );
+
+  if (!disabled || !disabledReason) {
+    return row;
+  }
+
+  // The disabled button drops pointer events, so the trigger span owns the hover.
+  return (
+    <Popover>
+      <PopoverTrigger
+        openOnHover
+        nativeButton={false}
+        render={<span className="block cursor-not-allowed" />}
+      >
+        {row}
+      </PopoverTrigger>
+      <PopoverPopup tooltipStyle side="top" align="center">
+        {disabledReason}
+      </PopoverPopup>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -101,7 +101,13 @@ import {
 } from "../appSettings";
 import { isElectron } from "../env";
 import { formatRelativeTime } from "../lib/relativeTime";
-import { isMacPlatform, newCommandId, newProjectId, newThreadId, randomUUID } from "../lib/utils";
+import {
+  isMacNavigatorPlatform,
+  newCommandId,
+  newProjectId,
+  newThreadId,
+  randomUUID,
+} from "../lib/utils";
 import { isOrdinarySpaceProject } from "../lib/spaces";
 import { expandProjectHomePath, joinProjectPath } from "../lib/projectPaths";
 import { reconcileDeletedThreadsFromClient } from "../lib/deletedThreadClientReconciliation";
@@ -1533,14 +1539,14 @@ export default function Sidebar() {
   const newTerminalThreadShortcutLabel = shortcutLabelForCommand(keybindings, "chat.newTerminal");
   const searchShortcutLabel =
     shortcutLabelForCommand(keybindings, "sidebar.search") ??
-    (isMacPlatform(navigator.platform) ? "⌘K" : "Ctrl+K");
+    (isMacNavigatorPlatform() ? "⌘K" : "Ctrl+K");
   const activityShortcutLabel = shortcutLabelForCommand(keybindings, "sidebar.activity");
   const importThreadShortcutLabel =
     shortcutLabelForCommand(keybindings, "sidebar.importThread") ??
-    (isMacPlatform(navigator.platform) ? "⌘I" : "Ctrl+I");
+    (isMacNavigatorPlatform() ? "⌘I" : "Ctrl+I");
   const addProjectShortcutLabel =
     shortcutLabelForCommand(keybindings, "sidebar.addProject") ??
-    (isMacPlatform(navigator.platform) ? "⇧⌘O" : "Ctrl+Shift+O");
+    (isMacNavigatorPlatform() ? "⇧⌘O" : "Ctrl+Shift+O");
   const usageSettingsShortcutLabel = shortcutLabelForCommand(keybindings, "settings.usage");
   const { activeProjectId: focusedProjectId } = useFocusedChatContext();
   const latestProjectId = useLatestProjectStore((state) => state.latestProjectId);
@@ -3989,7 +3995,7 @@ export default function Sidebar() {
 
   const handleThreadClick = useCallback(
     (event: MouseEvent, threadId: ThreadId, orderedProjectThreadIds: readonly ThreadId[]) => {
-      const isMac = isMacPlatform(navigator.platform);
+      const isMac = isMacNavigatorPlatform();
       const isModClick = isMac ? event.metaKey : event.ctrlKey;
       const isShiftClick = event.shiftKey;
 
@@ -5697,7 +5703,7 @@ export default function Sidebar() {
   // Only macOS draws the traffic lights in the renderer's top-left, so only there
   // does the open-sidebar header need to reserve the gutter (mirrors the mac guard
   // in useDesktopTopBarTrafficLightGutterClassName used by the closed-state surfaces).
-  const isMacDesktop = typeof navigator !== "undefined" ? isMacPlatform(navigator.platform) : false;
+  const isMacDesktop = isMacNavigatorPlatform();
 
   // Open-sidebar (in-sidebar) and non-electron wordmark clusters share the one
   // SidebarLeadingControls primitive with the closed-state host headers, so the

--- a/apps/web/src/components/SidebarSearchPalette.tsx
+++ b/apps/web/src/components/SidebarSearchPalette.tsx
@@ -25,7 +25,7 @@ import { FolderClosed } from "./FolderClosed";
 import { ProviderIcon as SharedProviderIcon } from "./ProviderIcon";
 import { formatRelativeTime } from "~/lib/relativeTime";
 import { readNativeApi } from "~/nativeApi";
-import { isMacPlatform } from "~/lib/utils";
+import { getNavigatorPlatform, isMacPlatform } from "~/lib/utils";
 import { Kbd, KbdGroup } from "./ui/kbd";
 import {
   appendBrowsePathSegment,
@@ -396,7 +396,7 @@ export function SidebarSearchPalette(props: SidebarSearchPaletteProps) {
     return () => window.clearTimeout(timeoutId);
   }, [props.importProviders, props.open]);
 
-  const platform = typeof navigator === "undefined" ? "" : navigator.platform;
+  const platform = getNavigatorPlatform();
   const trimmedQuery = query.trim();
   const unsupportedWindowsPath = isUnsupportedWindowsProjectPath(trimmedQuery, platform);
   const isBrowsing = trimmedQuery.length > 0 && isFilesystemBrowseQuery(trimmedQuery, platform);

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -38,6 +38,7 @@ import {
   SurfaceChipIcon,
   SurfaceTabChip,
 } from "./chatHeaderControls";
+import { DiffStat } from "../ui/diff-stat";
 import { IconButton } from "../ui/icon-button";
 import { Badge } from "../ui/badge";
 import { Menu, MenuItem, MenuTrigger } from "../ui/menu";
@@ -628,14 +629,11 @@ export function ChatHeader({
             }
           >
             {!togglesRightDock && showDiffTotals ? (
-              <span className="inline-flex items-center gap-1">
-                <span className="font-system-ui text-[length:var(--app-font-size-ui-sm,11px)] sm:text-[length:var(--app-font-size-ui-xs,10px)] font-normal tracking-normal tabular-nums text-success">
-                  +{diffAdditions}
-                </span>
-                <span className="font-system-ui text-[length:var(--app-font-size-ui-sm,11px)] sm:text-[length:var(--app-font-size-ui-xs,10px)] font-normal tracking-normal tabular-nums text-destructive">
-                  -{diffDeletions}
-                </span>
-              </span>
+              <DiffStat
+                className="font-system-ui text-[length:var(--app-font-size-ui-sm,11px)] sm:text-[length:var(--app-font-size-ui-xs,10px)] font-normal tracking-normal"
+                insertions={diffAdditions}
+                deletions={diffDeletions}
+              />
             ) : null}
             <SurfaceChipIcon icon={PanelRightCloseIcon} className="size-4" />
           </Toggle>

--- a/apps/web/src/components/chat/environment/EnvironmentPanel.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentPanel.tsx
@@ -32,6 +32,7 @@ import BranchToolbar, { type BranchToolbarProps } from "~/components/BranchToolb
 import ChatMarkdown from "~/components/ChatMarkdown";
 import { FolderClosed } from "~/components/FolderClosed";
 import GitActionsControl from "~/components/GitActionsControl";
+import { DiffStat } from "~/components/ui/diff-stat";
 import { IconButton } from "~/components/ui/icon-button";
 import { toastManager } from "~/components/ui/toast";
 import { isElectron } from "~/env";
@@ -347,14 +348,7 @@ export function EnvironmentPanel({
         <EnvironmentRow
           icon={<ChangesIcon className={ENVIRONMENT_ROW_ICON_CLASS_NAME} aria-hidden />}
           label="Changes"
-          trailing={
-            hasChanges ? (
-              <>
-                <span className="text-success">+{additions}</span>
-                <span className="text-destructive">-{deletions}</span>
-              </>
-            ) : null
-          }
+          trailing={hasChanges ? <DiffStat insertions={additions} deletions={deletions} /> : null}
           disabled={changesDisabled}
           onClick={() => {
             onToggleDiff();

--- a/apps/web/src/components/gitActionGlyphs.tsx
+++ b/apps/web/src/components/gitActionGlyphs.tsx
@@ -1,0 +1,32 @@
+// FILE: gitActionGlyphs.tsx
+// Purpose: Single source of truth mapping every git affordance to its glyph, so the
+//          header quick action, the dropdown picker rows, and the git dialogs always
+//          render the same icon for the same action.
+// Layer: Git UI primitive
+
+import {
+  CloudSyncIcon,
+  GitBranchIcon,
+  GitCommitIcon,
+  type LucideIcon,
+  PushIcon,
+} from "~/lib/icons";
+import type { GitGlyphName } from "./GitActionsControl.logic";
+import { GitHubIcon } from "./Icons";
+
+// Central icons render as masked spans (not <svg>), so size them explicitly here
+// rather than relying on parent `[&>svg]` selectors.
+export const GIT_ACTION_ICON_CLASS = "size-3.5";
+
+const GIT_ACTION_GLYPH: Record<GitGlyphName, LucideIcon> = {
+  commit: GitCommitIcon,
+  push: PushIcon,
+  pr: GitHubIcon,
+  sync: CloudSyncIcon,
+  branch: GitBranchIcon,
+};
+
+export function GitActionGlyph({ name, className }: { name: GitGlyphName; className?: string }) {
+  const Glyph = GIT_ACTION_GLYPH[name];
+  return <Glyph className={className ?? GIT_ACTION_ICON_CLASS} />;
+}

--- a/apps/web/src/components/kanban/KanbanView.tsx
+++ b/apps/web/src/components/kanban/KanbanView.tsx
@@ -21,24 +21,20 @@ import { useNowMs } from "~/hooks/useNowMs";
 import { useThreadPullRequests } from "~/hooks/useThreadPullRequests";
 import { splitShortcutLabel } from "~/keybindings";
 import { ArrowLeftIcon, PlusIcon } from "~/lib/icons";
-import { cn, isMacPlatform } from "~/lib/utils";
+import { cn, isMacNavigatorPlatform } from "~/lib/utils";
 
 // Kanban-scoped "Create task" shortcut: ⌘⌥T on macOS, Ctrl+Alt+T elsewhere —
 // matching the app's mod convention (meta on mac, ctrl otherwise) and the ⌘⌥
 // "create new X" family. Matched on event.code so it survives Alt remapping the
 // produced character on some layouts.
-function getNavigatorPlatform(): string {
-  return typeof navigator === "undefined" ? "" : navigator.platform;
-}
-
-const NEW_TASK_SHORTCUT_LABEL = isMacPlatform(getNavigatorPlatform()) ? "⌥⌘T" : "Ctrl+Alt+T";
+const NEW_TASK_SHORTCUT_LABEL = isMacNavigatorPlatform() ? "⌥⌘T" : "Ctrl+Alt+T";
 const NEW_TASK_SHORTCUT_PARTS = splitShortcutLabel(NEW_TASK_SHORTCUT_LABEL);
 
 function isNewTaskShortcut(event: KeyboardEvent): boolean {
   if (event.code !== "KeyT" || event.repeat || event.shiftKey || !event.altKey) {
     return false;
   }
-  return isMacPlatform(getNavigatorPlatform())
+  return isMacNavigatorPlatform()
     ? event.metaKey && !event.ctrlKey
     : event.ctrlKey && !event.metaKey;
 }

--- a/apps/web/src/components/kanban/useKanbanTaskComposerDiscovery.ts
+++ b/apps/web/src/components/kanban/useKanbanTaskComposerDiscovery.ts
@@ -35,7 +35,7 @@ import {
   supportsSkillDiscovery,
 } from "~/lib/providerDiscoveryReactQuery";
 import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
-import { isMacPlatform } from "~/lib/utils";
+import { isMacNavigatorPlatform } from "~/lib/utils";
 import { AVAILABLE_PROVIDER_OPTIONS } from "../chat/ProviderModelPicker";
 import type { ProviderModelOption } from "../../providerModelOptions";
 
@@ -91,10 +91,9 @@ export function useKanbanTaskComposerDiscovery(input: UseKanbanTaskComposerDisco
     piAgentDir,
   } = input;
 
-  const platform = typeof navigator === "undefined" ? "" : navigator.platform;
   const localFolderBrowseRootPath = getLocalFolderBrowseRootPath(
     serverHomeDir,
-    isMacPlatform(platform),
+    isMacNavigatorPlatform(),
   );
   const composerTriggerKind = composerTrigger?.kind ?? null;
   const mentionTriggerQuery = composerTrigger?.kind === "mention" ? composerTrigger.query : "";

--- a/apps/web/src/components/settings/ExternalMcpSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ExternalMcpSettingsPanel.tsx
@@ -13,7 +13,7 @@ import { Input } from "~/components/ui/input";
 import { Switch } from "~/components/ui/switch";
 import { toastManager } from "~/components/ui/toast";
 import { copyTextToClipboard } from "~/hooks/useCopyToClipboard";
-import { cn } from "~/lib/utils";
+import { cn, getNavigatorPlatform } from "~/lib/utils";
 import { ensureNativeApi } from "~/nativeApi";
 import {
   buildExternalMcpClientConfiguration,
@@ -226,7 +226,7 @@ export function ExternalMcpSettingsPanel(props: { active: boolean }) {
           : pairingExpired
             ? "Pairing code expired"
             : "Waiting for pairing";
-  const platform = typeof navigator === "undefined" ? "" : navigator.platform;
+  const platform = getNavigatorPlatform();
   const setupPrompt = setup
     ? buildExternalMcpSetupPrompt({
         setupCommand: paired ? null : setup.setupCommand,

--- a/apps/web/src/components/settings/KeyboardShortcutsSettingsPanel.tsx
+++ b/apps/web/src/components/settings/KeyboardShortcutsSettingsPanel.tsx
@@ -21,7 +21,7 @@ import { CentralIcon } from "~/lib/central-icons";
 import { keybindingFromKeyboardEvent, keybindingValueFromShortcut } from "~/lib/keybindingCapture";
 import { ensureNativeApi } from "~/nativeApi";
 import { serverConfigQueryOptions, serverQueryKeys } from "~/lib/serverReactQuery";
-import { cn } from "~/lib/utils";
+import { cn, getNavigatorPlatform } from "~/lib/utils";
 import {
   buildShortcutSheetSections,
   filterShortcutSheetSections,
@@ -65,7 +65,7 @@ export function KeyboardShortcutsSettingsPanel() {
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
   const queryClient = useQueryClient();
   const keybindings = serverConfigQuery.data?.keybindings ?? EMPTY_KEYBINDINGS;
-  const platform = typeof navigator === "undefined" ? "" : navigator.platform;
+  const platform = getNavigatorPlatform();
 
   const sections = buildShortcutSheetSections({
     keybindings,

--- a/apps/web/src/components/ui/diff-stat.tsx
+++ b/apps/web/src/components/ui/diff-stat.tsx
@@ -1,0 +1,32 @@
+// FILE: diff-stat.tsx
+// Purpose: Single source of truth for the "+insertions −deletions" pair rendered
+//          wherever the app surfaces diff size (git dialogs, environment panel,
+//          branch selector, chat header).
+// Layer: UI primitive
+
+import type { ReactNode } from "react";
+import { cn } from "~/lib/utils";
+
+export function DiffStat({
+  insertions,
+  deletions,
+  separator,
+  className,
+}: {
+  insertions: number;
+  deletions: number;
+  /** Rendered between the two counts — e.g. a "/" in dense file rows. */
+  separator?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn("inline-flex items-center gap-1 tabular-nums", className)}
+      data-slot="diff-stat"
+    >
+      <span className="text-success">+{insertions.toLocaleString()}</span>
+      {separator}
+      <span className="text-destructive">−{deletions.toLocaleString()}</span>
+    </span>
+  );
+}

--- a/apps/web/src/components/ui/kbd.tsx
+++ b/apps/web/src/components/ui/kbd.tsx
@@ -1,6 +1,6 @@
 import type * as React from "react";
 
-import { cn } from "~/lib/utils";
+import { cn, isMacNavigatorPlatform } from "~/lib/utils";
 
 function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
   return (
@@ -25,4 +25,9 @@ function KbdGroup({ className, ...props }: React.ComponentProps<"kbd">) {
   );
 }
 
-export { Kbd, KbdGroup };
+/** The "submit this dialog" chord, spelled for the host platform. */
+function SubmitShortcutKbd({ className }: { className?: string }) {
+  return <Kbd className={className}>{isMacNavigatorPlatform() ? "⌘↵" : "Ctrl ↵"}</Kbd>;
+}
+
+export { Kbd, KbdGroup, SubmitShortcutKbd };

--- a/apps/web/src/hooks/useDesktopTopBarGutter.ts
+++ b/apps/web/src/hooks/useDesktopTopBarGutter.ts
@@ -12,7 +12,7 @@ import { useLayoutEffect } from "react";
 import { isElectron } from "~/env";
 import { useSidebar } from "~/components/ui/sidebar";
 import { readDesktopZoomFactor, subscribeDesktopZoomFactor } from "~/lib/desktopZoom";
-import { isMacPlatform, isWindowsPlatform } from "~/lib/utils";
+import { isMacNavigatorPlatform, isWindowsPlatform } from "~/lib/utils";
 
 /**
  * Class name backed by `index.css` (not Tailwind) so the gutter survives zoom
@@ -58,7 +58,7 @@ function applyTrafficLightGutterCssVar(zoomFactor: number): void {
  * Mount once near the app root (see `__root.tsx`).
  */
 export function useSyncDesktopTopBarTrafficLightGutterZoom(): void {
-  const isMacDesktop = typeof navigator !== "undefined" ? isMacPlatform(navigator.platform) : false;
+  const isMacDesktop = isMacNavigatorPlatform();
 
   useLayoutEffect(() => {
     if (!isElectron || !isMacDesktop) {
@@ -91,7 +91,7 @@ export function useSyncDesktopTopBarTrafficLightGutterZoom(): void {
  */
 export function useDesktopTopBarTrafficLightGutterClassName(): string | null {
   const { isMobile, open } = useSidebar();
-  const isMacDesktop = typeof navigator !== "undefined" ? isMacPlatform(navigator.platform) : false;
+  const isMacDesktop = isMacNavigatorPlatform();
   return shouldReserveDesktopTopBarTrafficLightGutter({
     isElectron,
     isMacDesktop,

--- a/apps/web/src/hooks/useNativeFontSmoothing.ts
+++ b/apps/web/src/hooks/useNativeFontSmoothing.ts
@@ -5,13 +5,11 @@
 
 import { useEffect } from "react";
 import { useAppSettings } from "../appSettings";
-import { isMacPlatform } from "../lib/utils";
+import { isMacNavigatorPlatform } from "../lib/utils";
 
 export function useNativeFontSmoothing() {
   const { settings } = useAppSettings();
-  const shouldApply =
-    settings.enableNativeFontSmoothing &&
-    isMacPlatform(typeof navigator === "undefined" ? "" : navigator.platform);
+  const shouldApply = settings.enableNativeFontSmoothing && isMacNavigatorPlatform();
 
   useEffect(() => {
     const rootStyle = document.documentElement.style;

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -5,7 +5,7 @@
 
 import { useEffect, useSyncExternalStore } from "react";
 import { isElectron } from "../env";
-import { isMacPlatform } from "../lib/utils";
+import { isMacNavigatorPlatform } from "../lib/utils";
 import {
   DEFAULT_THEME_STATE,
   type ChromeTheme,
@@ -157,7 +157,7 @@ function applyThemeState(state: ThemeState, suppressTransitions = false) {
   const activeTheme = resolveThemePack(state, variant);
   const cssVariableBuild = buildThemeCssVariables(activeTheme, variant, {
     electron: isElectron,
-    isMac: isMacPlatform(typeof navigator === "undefined" ? "" : navigator.platform),
+    isMac: isMacNavigatorPlatform(),
     systemUiFont: state.systemUiFont,
   });
 

--- a/apps/web/src/lib/fileReferenceContextMenu.ts
+++ b/apps/web/src/lib/fileReferenceContextMenu.ts
@@ -6,7 +6,7 @@
 
 import { formatSelectionLabel, type ChatFileReference } from "~/lib/chatReferences";
 import { copyTextToClipboard } from "~/hooks/useCopyToClipboard";
-import { isMacPlatform, isWindowsPlatform } from "~/lib/utils";
+import { getNavigatorPlatform, isMacPlatform, isWindowsPlatform } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
 import { toastManager } from "~/components/ui/toast";
 
@@ -74,9 +74,7 @@ export async function showFileReferenceContextMenu(input: {
         ? [
             {
               id: "reveal-in-folder" as const,
-              label: getRevealInFolderLabel(
-                typeof navigator === "undefined" ? "" : navigator.platform,
-              ),
+              label: getRevealInFolderLabel(getNavigatorPlatform()),
             },
           ]
         : []),

--- a/apps/web/src/lib/keybindingCapture.ts
+++ b/apps/web/src/lib/keybindingCapture.ts
@@ -1,6 +1,6 @@
 import type { KeybindingShortcut } from "@synara/contracts";
 
-import { isMacPlatform } from "~/lib/utils";
+import { getNavigatorPlatform, isMacPlatform } from "~/lib/utils";
 
 /**
  * Converts the browser's key representation into the stable tokens accepted by
@@ -49,7 +49,7 @@ export function normalizeShortcutKeyToken(key: string): string | null {
  */
 export function keybindingFromKeyboardEvent(
   event: Pick<KeyboardEvent, "key" | "ctrlKey" | "metaKey" | "shiftKey" | "altKey">,
-  platform = typeof navigator === "undefined" ? "" : navigator.platform,
+  platform = getNavigatorPlatform(),
 ): string | null {
   const keyToken = normalizeShortcutKeyToken(event.key);
   if (!keyToken) return null;

--- a/apps/web/src/lib/projectPaths.ts
+++ b/apps/web/src/lib/projectPaths.ts
@@ -4,7 +4,7 @@ import {
   isWindowsAbsolutePath,
   isWindowsDrivePath,
 } from "@synara/shared/path";
-import { isWindowsPlatform } from "./utils";
+import { getNavigatorPlatform, isWindowsPlatform } from "./utils";
 
 function isRootPath(value: string): boolean {
   return value === "/" || value === "\\" || /^[a-zA-Z]:[/\\]?$/.test(value);
@@ -118,10 +118,7 @@ function splitAbsolutePath(value: string): {
   return null;
 }
 
-export function isFilesystemBrowseQuery(
-  value: string,
-  platform = typeof navigator === "undefined" ? "" : navigator.platform,
-): boolean {
+export function isFilesystemBrowseQuery(value: string, platform = getNavigatorPlatform()): boolean {
   const allowWindowsPaths = isWindowsPlatform(platform);
   return (
     value.startsWith("./") ||

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -1,6 +1,11 @@
-import { assert, describe, it } from "vitest";
+import { afterEach, assert, describe, it, vi } from "vitest";
 
-import { isMacPlatform, isWindowsPlatform } from "./utils";
+import {
+  getNavigatorPlatform,
+  isMacNavigatorPlatform,
+  isMacPlatform,
+  isWindowsPlatform,
+} from "./utils";
 
 describe("isMacPlatform", () => {
   it("matches browser and Node.js macOS platform identifiers", () => {
@@ -23,5 +28,35 @@ describe("isWindowsPlatform", () => {
 
   it("does not match darwin", () => {
     assert.isFalse(isWindowsPlatform("darwin"));
+  });
+});
+
+describe("navigator platform helpers", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reads the host platform, falling back to an empty string without a navigator", () => {
+    vi.stubGlobal("navigator", undefined);
+    assert.equal(getNavigatorPlatform(), "");
+
+    vi.stubGlobal("navigator", { platform: "MacIntel" });
+    assert.equal(getNavigatorPlatform(), "MacIntel");
+  });
+
+  it("detects macOS hosts, including the Node.js-style identifier", () => {
+    vi.stubGlobal("navigator", { platform: "MacIntel" });
+    assert.isTrue(isMacNavigatorPlatform());
+
+    vi.stubGlobal("navigator", { platform: "darwin" });
+    assert.isTrue(isMacNavigatorPlatform());
+  });
+
+  it("is false on other hosts and without a navigator", () => {
+    vi.stubGlobal("navigator", { platform: "Win32" });
+    assert.isFalse(isMacNavigatorPlatform());
+
+    vi.stubGlobal("navigator", undefined);
+    assert.isFalse(isMacNavigatorPlatform());
   });
 });

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -16,6 +16,16 @@ export function isWindowsPlatform(platform: string): boolean {
   return /^win(dows)?/i.test(platform);
 }
 
+/** The host platform string, safe to read where `navigator` may be absent (SSR, node tests). */
+export function getNavigatorPlatform(): string {
+  return typeof navigator === "undefined" ? "" : navigator.platform;
+}
+
+/** Single source of truth for "render the ⌘ affordance instead of the Ctrl one". */
+export function isMacNavigatorPlatform(): boolean {
+  return isMacPlatform(getNavigatorPlatform());
+}
+
 export function randomUUID(): string {
   if (typeof crypto.randomUUID === "function") {
     return crypto.randomUUID();

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -120,6 +120,7 @@ import { arraysShallowEqual } from "../storeNormalization";
 import { providerModelDiscoveryInvalidationFingerprint } from "../lib/providerDiscoveryInvalidation";
 import { providerDiscoveryQueryKeys } from "../lib/providerDiscoveryReactQuery";
 import { useAppSettings } from "../appSettings";
+import { getNavigatorPlatform } from "../lib/utils";
 import {
   getNotifiableProviderUpdateStatuses,
   isProviderUpdateActive,
@@ -665,7 +666,7 @@ function GlobalShortcutsDialog() {
   const { focusedThreadId, activeProject } = useFocusedChatContext();
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
   const keybindings = serverConfigQuery.data?.keybindings ?? [];
-  const platform = typeof navigator === "undefined" ? "" : navigator.platform;
+  const platform = getNavigatorPlatform();
   const activeThreadTerminalState = useTerminalStateStore((state) =>
     focusedThreadId
       ? selectThreadTerminalState(state.terminalStateByThreadId, focusedThreadId)

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -89,7 +89,7 @@ import { isUiDensity } from "../lib/appDensity";
 import { isChatWidthMode, type ChatWidthMode } from "../lib/chatWidth";
 import { isElectron } from "../env";
 import { RotateCcwIcon } from "../lib/icons";
-import { cn, isMacPlatform } from "../lib/utils";
+import { cn, getNavigatorPlatform, isMacPlatform } from "../lib/utils";
 import { ensureNativeApi, readNativeApi } from "../nativeApi";
 import { sameProviderOrder } from "../providerOrdering";
 import {
@@ -205,7 +205,7 @@ function SettingsRouteView() {
   const desktopTopBarTrafficLightGutterClassName = useDesktopTopBarTrafficLightGutterClassName();
   const [releaseHistoryOpen, setReleaseHistoryOpen] = useState(false);
   const [resetEpoch, setResetEpoch] = useState(0);
-  const platform = typeof navigator === "undefined" ? "" : navigator.platform;
+  const platform = getNavigatorPlatform();
   const shouldShowFontSmoothing = isMacPlatform(platform);
   const visibleTerminalFontFamilySuggestions = useMemo(() => {
     const query = settings.terminalFontFamily.trim().toLowerCase();

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -51,7 +51,7 @@ import {
   useSidebar,
 } from "~/components/ui/sidebar";
 import type { SidebarResizableOptions } from "~/components/ui/sidebar";
-import { cn } from "~/lib/utils";
+import { cn, getNavigatorPlatform, isMacPlatform } from "~/lib/utils";
 
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
 const THREAD_SIDEBAR_WIDTH_STORAGE_KEY = "chat_thread_sidebar_width";
@@ -170,7 +170,7 @@ function resolveBrowserNavigationShortcut(
   event: KeyboardEvent,
   platform: string,
 ): "back" | "forward" | null {
-  const isMac = /Mac|iPhone|iPad|iPod/i.test(platform);
+  const isMac = isMacPlatform(platform);
   const key = event.key.toLowerCase();
 
   if (
@@ -246,7 +246,7 @@ function ChatRouteGlobalShortcuts() {
   useTemporaryThreadLifecycle(activeContextThreadId);
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
   const keybindings = serverConfigQuery.data?.keybindings ?? EMPTY_KEYBINDINGS;
-  const platform = typeof navigator === "undefined" ? "" : navigator.platform;
+  const platform = getNavigatorPlatform();
   const providerStatuses = useProviderStatusesForLocalConfig();
   const refreshProviderStatuses = useRefreshProviderStatusesNow();
   const activeThreadTerminalState = activeContextThreadId

--- a/apps/web/src/terminal-links.ts
+++ b/apps/web/src/terminal-links.ts
@@ -1,4 +1,4 @@
-import { isMacPlatform } from "./lib/utils";
+import { getNavigatorPlatform, isMacPlatform } from "./lib/utils";
 
 export type TerminalLinkKind = "url" | "path";
 
@@ -258,7 +258,7 @@ export function wrappedTerminalLinkRangeIntersectsBufferLine(
 
 export function isTerminalLinkActivation(
   event: Pick<MouseEvent, "metaKey" | "ctrlKey">,
-  platform = typeof navigator === "undefined" ? "" : navigator.platform,
+  platform = getNavigatorPlatform(),
 ): boolean {
   if (platform.length === 0) return false;
   return isMacPlatform(platform)


### PR DESCRIPTION
## What Changed

- Extracted shared Git dialog chrome and added a dedicated commit dialog.
- Simplified `GitActionsControl` and consolidated Git action presentation across the web UI.
- Added shared Git action glyphs and diff-stat components.
- Simplified branch synchronization and removed settled-thread branch mismatch handling from the composer.
- Centralized navigator platform detection and updated related shortcuts and window controls.
- Cleaned up obsolete browser fixtures and logic tests, while strengthening cancellation-state coverage.

## Why

This reduces duplicated Git UI logic and makes commit, push, and related actions more consistent. It also removes branch-state handling that added complexity to thread resumption without being part of the core Git action flow.

## UI Changes

The Git action controls, commit dialog, branch selector diff stats, and related dialog surfaces have changed. Before/after screenshots should be attached to the PR, along with a short video if interaction or animation changes need demonstration.

## Verification

- Not provided in the supplied change details.
- Focused web tests should be run for the updated Git action and branch-selector components.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how users commit, push, and open PRs from the header and environment panel, but behavior is largely preserved via shared logic resolvers and new unit tests for commit dialog actions.
> 
> **Overview**
> **Git actions** move from an inline commit dialog in `GitActionsControl` to a dedicated **`GitCommitDialog`**, with **`GitDialogChrome`** shared by Commit and Create PR (heading, fields, action rows with disabled tooltips, ⌘/Ctrl+↵ submit). Commit/PR availability and disabled copy now flow through **`resolveCommitDialogActions`** and **`resolveGitMenuActionDisabledReason`** in logic (menu and dialog stay aligned); **`CreatePrDialogContext`** is renamed **`GitDialogContext`**. Icons live in **`gitActionGlyphs`**, and the environment **panel** uses a primary row (Pull or Commit & push) plus a chevron-only menu instead of a single oversized menu trigger.
> 
> **UI polish:** a reusable **`DiffStat`** replaces ad-hoc +/- spans in the branch selector, chat header, environment panel, and git dialogs; **`SubmitShortcutKbd`** centralizes dialog submit hints.
> 
> **Platform:** **`getNavigatorPlatform`** / **`isMacNavigatorPlatform`** replace scattered `navigator.platform` checks for shortcuts, gutters, and keybinding capture across the shell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0162b5c298991365aaf65f64ad1c1827c5fc4ea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->