### PR TITLE
Continue active thread goals with pause and recovery handling

### DIFF
--- a/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
@@ -1504,7 +1504,9 @@ describe("AgentGateway", () => {
         ["string", "null"],
       );
       assert.property(setThreadGoal?.inputSchema.properties, "achieved");
+      assert.property(setThreadGoal?.inputSchema.properties, "blocked");
       assert.include(setThreadGoal?.description ?? "", "achieved: true");
+      assert.include(setThreadGoal?.description ?? "", "blocked: true");
 
       const createAutomation = tools.find((tool) => tool.name === "synara_create_automation");
       assert.include(createAutomation?.description ?? "", "self-contained brief");
@@ -4871,6 +4873,34 @@ describe("AgentGateway", () => {
       assert.isTrue(isToolError(response.result));
       assert.include(toolErrorText(response.result), "no active goal");
       assert.equal(harness.dispatched.length, 0);
+    }).pipe(Effect.provide(gatewayLayer));
+  });
+
+  it.effect("pauses an active goal when the agent reports a repeated blocker", () => {
+    const { gatewayLayer, makeHarness } = makeHarnessLayer([
+      ...baseThreads.filter((thread) => thread.id !== "thread-child"),
+      makeThreadShell("thread-child", { goal: "Ship the gateway feature" }),
+    ]);
+    return Effect.gen(function* () {
+      const harness = yield* makeHarness;
+      const response = yield* harness.callTool({
+        token: "token-parent",
+        name: "synara_set_thread_goal",
+        args: { threadId: "thread-child", blocked: true },
+      });
+
+      assert.isFalse(isToolError(response.result), toolErrorText(response.result));
+      assert.deepEqual(toolResultJson(response.result), {
+        threadId: "thread-child",
+        goal: "Ship the gateway feature",
+        blocked: true,
+        paused: true,
+      });
+      assert.deepInclude(harness.dispatched[0] as unknown as Record<string, unknown>, {
+        type: "thread.meta.update",
+        threadId: "thread-child",
+        goalPaused: true,
+      });
     }).pipe(Effect.provide(gatewayLayer));
   });
 

--- a/apps/server/src/agentGateway/Layers/AgentGateway.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.ts
@@ -605,7 +605,7 @@ export const makeAgentGateway = Effect.gen(function* () {
     definition: {
       name: "synara_set_thread_goal",
       description:
-        "Set a persistent goal for a thread. Only set a goal when the user has explicitly asked for one (for example, 'keep working until X' or 'the goal of this thread is Y') or when dispatching a thread explicitly created to pursue a stated objective. Do NOT infer or invent goals from ordinary tasks or set one as a side effect of normal work. Clearing requires the same explicit user intent. When the active goal's objective has been accomplished, pass achieved: true instead of clearing: Synara records the achievement (with the time it took) and clears the goal.",
+        "Set a persistent goal for a thread. Only set a goal when the user has explicitly asked for one (for example, 'keep working until X' or 'the goal of this thread is Y') or when dispatching a thread explicitly created to pursue a stated objective. Do NOT infer or invent goals from ordinary tasks or set one as a side effect of normal work. Clearing requires the same explicit user intent. When the active goal's objective has been accomplished, pass achieved: true instead of clearing: Synara records the achievement (with the time it took) and clears the goal. If the same external blocker prevents meaningful progress for three consecutive goal turns, pass blocked: true to pause the goal. Do not mark a goal blocked merely because the work is difficult, incomplete, or would benefit from clarification.",
       inputSchema: {
         type: "object",
         properties: {
@@ -617,12 +617,17 @@ export const makeAgentGateway = Effect.gen(function* () {
             type: ["string", "null"],
             maxLength: THREAD_GOAL_MAX_CHARS,
             description:
-              "Persistent objective. Pass null or an empty string to clear it. Ignored when achieved is true.",
+              "Persistent objective. Pass null or an empty string to clear it. Ignored when achieved or blocked is true.",
           },
           achieved: {
             type: "boolean",
             description:
               "Pass true when the active goal's objective has been accomplished. Records a goal achievement and clears the goal.",
+          },
+          blocked: {
+            type: "boolean",
+            description:
+              "Pass true only after the same external blocker prevents meaningful progress for three consecutive goal turns. Pauses the active goal.",
           },
         },
         required: [],
@@ -636,14 +641,25 @@ export const makeAgentGateway = Effect.gen(function* () {
         if ("achieved" in args && typeof args.achieved !== "boolean") {
           return yield* Effect.fail(new ToolInputError(`Argument "achieved" must be a boolean.`));
         }
+        if ("blocked" in args && typeof args.blocked !== "boolean") {
+          return yield* Effect.fail(new ToolInputError(`Argument "blocked" must be a boolean.`));
+        }
         const achieved = args.achieved === true;
-        const goal = achieved ? "" : readThreadGoalArg(args);
+        const blocked = args.blocked === true;
+        if (achieved && blocked) {
+          return yield* Effect.fail(
+            new ToolInputError(`Arguments "achieved" and "blocked" are mutually exclusive.`),
+          );
+        }
+        const goal = achieved || blocked ? "" : readThreadGoalArg(args);
         const caller = yield* requireThreadShell(context.callerThreadId);
         const target = yield* requireThreadShell(threadId);
         yield* assertCallerMayDriveThread(caller, target);
-        if (achieved && (target.goal ?? "").trim().length === 0) {
+        if ((achieved || blocked) && (target.goal ?? "").trim().length === 0) {
           return yield* Effect.fail(
-            new ToolInputError("Thread has no active goal to mark achieved."),
+            new ToolInputError(
+              `Thread has no active goal to mark ${achieved ? "achieved" : "blocked"}.`,
+            ),
           );
         }
         yield* orchestrationEngine
@@ -651,12 +667,14 @@ export const makeAgentGateway = Effect.gen(function* () {
             type: "thread.meta.update",
             commandId: CommandId.makeUnsafe(`agent:${randomUUID()}:goal`),
             threadId: target.id,
-            ...(achieved ? { goalAchieved: true } : { goal }),
+            ...(achieved ? { goalAchieved: true } : blocked ? { goalPaused: true } : { goal }),
           })
           .pipe(Effect.mapError((error) => new ToolInputError(errorText(error))));
         return mcpToolResultJson(
           achieved
             ? { threadId: target.id, goal: null, achieved: true }
+            : blocked
+              ? { threadId: target.id, goal: target.goal, blocked: true, paused: true }
             : { threadId: target.id, goal: goal || null },
         );
       }).pipe(Effect.catch((error) => Effect.succeed(mcpToolResultError(errorText(error))))),

--- a/apps/server/src/agentGateway/Layers/AgentGateway.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.ts
@@ -675,7 +675,7 @@ export const makeAgentGateway = Effect.gen(function* () {
             ? { threadId: target.id, goal: null, achieved: true }
             : blocked
               ? { threadId: target.id, goal: target.goal, blocked: true, paused: true }
-            : { threadId: target.id, goal: goal || null },
+              : { threadId: target.id, goal: goal || null },
         );
       }).pipe(Effect.catch((error) => Effect.succeed(mcpToolResultError(errorText(error))))),
   };

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2522,6 +2522,31 @@ describe("ProviderCommandReactor", () => {
     expect(harness.sendTurn).not.toHaveBeenCalled();
   });
 
+  it("does not continue an active goal for a wording-only edit", async () => {
+    const harness = await createHarness();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-goal-before-wording-edit"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goal: "Finish the implementation",
+        goalStartBehavior: "defer",
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-goal-wording-edit"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goal: "Finish the implementation and tests",
+      }),
+    );
+
+    await harness.drain();
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+  });
+
   it("resumes a paused idle goal immediately", async () => {
     const harness = await createHarness();
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2690,6 +2690,24 @@ describe("ProviderCommandReactor", () => {
     expect(harness.sendTurn).not.toHaveBeenCalled();
 
     await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-interrupted-session-before-goal-retry"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "interrupted",
+          providerName: "codex",
+          runtimeMode: "full-access",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+
+    await Effect.runPromise(
       harness.pendingInteractionRepository.deleteByIdentity({
         threadId: ThreadId.makeUnsafe("thread-1"),
         interactionKind: "approval",

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2639,6 +2639,128 @@ describe("ProviderCommandReactor", () => {
     );
   });
 
+  it("retries a goal continuation after a pending interaction clears", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+    const requestId = asApprovalRequestId("approval-before-goal-continuation");
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-goal-before-pending-approval"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goal: "Continue after the approval settles",
+        goalStartBehavior: "defer",
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.activity.append",
+        commandId: CommandId.makeUnsafe("cmd-pending-approval-before-goal"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        activity: {
+          id: EventId.makeUnsafe("activity-pending-approval-before-goal"),
+          tone: "approval",
+          kind: "approval.requested",
+          summary: "Command approval requested",
+          payload: {
+            requestId,
+            requestKind: "command",
+          },
+          turnId: null,
+          createdAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+    const goalStartedAt = (await readHarnessThread(harness))?.goalStartedAt;
+    expect(goalStartedAt).toBeTruthy();
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.goal.continue",
+        commandId: CommandId.makeUnsafe("cmd-goal-blocked-by-approval"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goalStartedAt: goalStartedAt!,
+        trigger: "startup-recovery",
+        createdAt: now,
+      }),
+    );
+
+    await harness.drain();
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+
+    await Effect.runPromise(
+      harness.pendingInteractionRepository.deleteByIdentity({
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        interactionKind: "approval",
+        requestId,
+      }),
+    );
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect(harness.sendTurn.mock.calls[0]?.[0].input).toContain(
+      "Continue working toward the active thread goal",
+    );
+  });
+
+  it("interrupts a continuation that races a user stop", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+    let releaseSend:
+      | ((result: { readonly threadId: ThreadId; readonly turnId: TurnId }) => void)
+      | null = null;
+    const sendGate = new Promise<{ readonly threadId: ThreadId; readonly turnId: TurnId }>(
+      (resolve) => {
+        releaseSend = resolve;
+      },
+    );
+    harness.sendTurn.mockImplementationOnce(() => Effect.promise(() => sendGate));
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-goal-before-stop-race"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goal: "Stop this continuation",
+        goalStartBehavior: "defer",
+      }),
+    );
+    const goalStartedAt = (await readHarnessThread(harness))?.goalStartedAt;
+    expect(goalStartedAt).toBeTruthy();
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.goal.continue",
+        commandId: CommandId.makeUnsafe("cmd-goal-continuation-before-stop"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goalStartedAt: goalStartedAt!,
+        trigger: "turn-completed",
+        createdAt: now,
+      }),
+    );
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.interrupt",
+        commandId: CommandId.makeUnsafe("cmd-stop-racing-goal-continuation"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        turnId: asTurnId("turn-before-goal-continuation"),
+        createdAt: now,
+      }),
+    );
+    releaseSend?.({
+      threadId: ThreadId.makeUnsafe("thread-1"),
+      turnId: asTurnId("turn-goal-continuation-after-stop"),
+    });
+
+    await waitFor(() => harness.interruptTurn.mock.calls.length >= 1);
+    expect(harness.interruptTurn.mock.calls[0]?.[0]).toMatchObject({
+      threadId: ThreadId.makeUnsafe("thread-1"),
+      turnId: asTurnId("turn-goal-continuation-after-stop"),
+    });
+    expect((await readHarnessThread(harness))?.goalPausedAt).toBeTruthy();
+  });
+
   it("preserves pending sidechat context when the first turn is an overlong provider review", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();
@@ -8072,6 +8194,50 @@ describe("ProviderCommandReactor", () => {
     expect(harness.interruptTurn.mock.calls[0]?.[0]).toEqual({
       threadId: "thread-1",
       turnId: "turn-1",
+    });
+  });
+
+  it("targets the live provider turn when an interrupt carries a stale projected turn", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-set-stale-interrupt"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: asTurnId("turn-projected-stale"),
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+    harness.setRuntimeSessionTurnState({
+      threadId: "thread-1",
+      status: "running",
+      activeTurnId: asTurnId("turn-live-current"),
+    });
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.interrupt",
+        commandId: CommandId.makeUnsafe("cmd-turn-interrupt-stale-projection"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        turnId: asTurnId("turn-projected-stale"),
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.interruptTurn.mock.calls.length === 1);
+    expect(harness.interruptTurn.mock.calls[0]?.[0]).toEqual({
+      threadId: "thread-1",
+      turnId: "turn-live-current",
     });
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2706,10 +2706,7 @@ describe("ProviderCommandReactor", () => {
   it("interrupts a continuation that races a user stop", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();
-    let releaseSend!: (result: {
-      readonly threadId: ThreadId;
-      readonly turnId: TurnId;
-    }) => void;
+    let releaseSend!: (result: { readonly threadId: ThreadId; readonly turnId: TurnId }) => void;
     const sendGate = new Promise<{ readonly threadId: ThreadId; readonly turnId: TurnId }>(
       (resolve) => {
         releaseSend = resolve;

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2343,6 +2343,7 @@ describe("ProviderCommandReactor", () => {
         commandId: CommandId.makeUnsafe("cmd-max-input-goal-set"),
         threadId: ThreadId.makeUnsafe("thread-1"),
         goal: "Preserve the full objective",
+        goalStartBehavior: "defer",
       }),
     );
     await Effect.runPromise(
@@ -2366,6 +2367,200 @@ describe("ProviderCommandReactor", () => {
     expect(harness.sendTurn).not.toHaveBeenCalled();
     expect((await readHarnessThread(harness))?.session?.lastError).toContain(
       "too long to include the persistent thread goal",
+    );
+  });
+
+  it("starts an idle active goal with an internal continuation turn", async () => {
+    const harness = await createHarness();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-goal-autostart"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goal: "Finish the complete implementation",
+      }),
+    );
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    const providerInput = harness.sendTurn.mock.calls[0]?.[0].input;
+    expect(providerInput).toContain("<synara_goal>");
+    expect(providerInput).toContain("Finish the complete implementation");
+    expect(providerInput).toContain("Continue working toward the active thread goal");
+    expect((await readHarnessThread(harness))?.messages).toEqual([]);
+  });
+
+  it("defers a staged draft goal until the first real user turn", async () => {
+    const harness = await createHarness();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-goal-deferred-draft"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goal: "Carry this through the first turn",
+        goalStartBehavior: "defer",
+      }),
+    );
+
+    await harness.drain();
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+  });
+
+  it("recovers an active idle goal when the reactor restarts", async () => {
+    const harness = await createHarness({ startReactor: false });
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-goal-before-reactor-restart"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goal: "Resume after Synara restarts",
+        goalStartBehavior: "defer",
+      }),
+    );
+    await harness.startReactor();
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect(harness.sendTurn.mock.calls[0]?.[0].input).toContain(
+      "Continue working toward the active thread goal",
+    );
+  });
+
+  it("ignores a stale continuation request after the goal is cleared", async () => {
+    const harness = await createHarness();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.goal.continue",
+        commandId: CommandId.makeUnsafe("cmd-stale-goal-continuation"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goalStartedAt: null,
+        trigger: "turn-completed",
+        createdAt: new Date().toISOString(),
+      }),
+    );
+
+    await harness.drain();
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+  });
+
+  it("waits for plan mode to end before continuing an active goal", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.interaction-mode.set",
+        commandId: CommandId.makeUnsafe("cmd-plan-before-goal"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        interactionMode: "plan",
+        createdAt: now,
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-goal-in-plan-mode"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goal: "Implement the approved plan",
+      }),
+    );
+
+    await harness.drain();
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.interaction-mode.set",
+        commandId: CommandId.makeUnsafe("cmd-default-after-plan-goal"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        interactionMode: "default",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect(harness.sendTurn.mock.calls[0]?.[0].input).toContain(
+      "Continue working toward the active thread goal",
+    );
+  });
+
+  it("resumes a paused idle goal immediately", async () => {
+    const harness = await createHarness();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-goal-paused-seed"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goal: "Resume the full objective",
+        goalStartBehavior: "defer",
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-goal-paused"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goalPaused: true,
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-goal-resumed"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goalPaused: false,
+      }),
+    );
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect(harness.sendTurn.mock.calls[0]?.[0].input).toContain(
+      "Continue working toward the active thread goal",
+    );
+  });
+
+  it("promotes queued user work before an automatic goal continuation", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-goal-queue-priority"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goal: "Finish after handling user input",
+        goalStartBehavior: "defer",
+      }),
+    );
+    await seedQueuedTurnBehindLiveTurn(harness, {
+      liveTurnId: asTurnId("turn-before-goal-continuation"),
+      messageId: asMessageId("msg-user-before-goal-continuation"),
+      text: "User follow-up wins",
+    });
+    harness.setRuntimeSessionTurnState({ threadId: "thread-1", status: "ready" });
+    const goalStartedAt = (await readHarnessThread(harness))?.goalStartedAt;
+    expect(goalStartedAt).toBeTruthy();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.goal.continue",
+        commandId: CommandId.makeUnsafe("cmd-goal-continue-after-user-queue"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goalStartedAt: goalStartedAt!,
+        trigger: "turn-completed",
+        sourceTurnId: asTurnId("turn-before-goal-continuation"),
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({
+      input: expect.stringContaining("User follow-up wins"),
+    });
+    expect(harness.sendTurn.mock.calls[0]?.[0].input).not.toContain(
+      "Continue working toward the active thread goal",
     );
   });
 
@@ -3692,6 +3887,7 @@ describe("ProviderCommandReactor", () => {
         commandId: CommandId.makeUnsafe("cmd-thread-goal-before-turn"),
         threadId: ThreadId.makeUnsafe("thread-1"),
         goal: "Deliver <all> providers safely",
+        goalStartBehavior: "defer",
       }),
     );
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2706,9 +2706,10 @@ describe("ProviderCommandReactor", () => {
   it("interrupts a continuation that races a user stop", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();
-    let releaseSend:
-      | ((result: { readonly threadId: ThreadId; readonly turnId: TurnId }) => void)
-      | null = null;
+    let releaseSend!: (result: {
+      readonly threadId: ThreadId;
+      readonly turnId: TurnId;
+    }) => void;
     const sendGate = new Promise<{ readonly threadId: ThreadId; readonly turnId: TurnId }>(
       (resolve) => {
         releaseSend = resolve;
@@ -2748,7 +2749,7 @@ describe("ProviderCommandReactor", () => {
         createdAt: now,
       }),
     );
-    releaseSend?.({
+    releaseSend({
       threadId: ThreadId.makeUnsafe("thread-1"),
       turnId: asTurnId("turn-goal-continuation-after-stop"),
     });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2486,6 +2486,42 @@ describe("ProviderCommandReactor", () => {
     );
   });
 
+  it("does not continue an active goal when toggling between Default and Debug", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-goal-before-debug-toggle"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goal: "Keep this goal idle",
+        goalStartBehavior: "defer",
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.interaction-mode.set",
+        commandId: CommandId.makeUnsafe("cmd-debug-with-active-goal"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        interactionMode: "debug",
+        createdAt: now,
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.interaction-mode.set",
+        commandId: CommandId.makeUnsafe("cmd-default-after-debug-with-active-goal"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        createdAt: now,
+      }),
+    );
+
+    await harness.drain();
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+  });
+
   it("resumes a paused idle goal immediately", async () => {
     const harness = await createHarness();
 
@@ -2506,6 +2542,20 @@ describe("ProviderCommandReactor", () => {
         goalPaused: true,
       }),
     );
+    await harness.drain();
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-goal-edited-while-paused"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goal: "Resume the edited objective",
+      }),
+    );
+    await harness.drain();
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+
     await Effect.runPromise(
       harness.engine.dispatch({
         type: "thread.meta.update",
@@ -4540,6 +4590,80 @@ describe("ProviderCommandReactor", () => {
     expect(retrySendInput.input).toContain("<latest_user_message>");
     expect(retrySendInput.input).toContain("nice but bring it on the left.");
     expect(retrySendInput.input?.split(PROVIDER_DEBUG_MODE_PROMPT_PREFIX)).toHaveLength(2);
+  });
+
+  it("keeps transcript context when replaying a stale Claude goal continuation", async () => {
+    const harness = await createHarness({
+      threadModelSelection: { provider: "claudeAgent", model: "claude-opus-4-8" },
+    });
+    const now = new Date().toISOString();
+    const staleResumeFailure = () =>
+      Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: "claudeAgent",
+          method: "turn/setModel",
+          detail:
+            "Claude Code returned an error result: No conversation found with session ID: b469168a-2625-4447-927f-d86d94bb7237",
+        }),
+      );
+    harness.sendTurn
+      .mockImplementationOnce(staleResumeFailure)
+      .mockImplementationOnce(staleResumeFailure);
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.messages.import",
+        commandId: CommandId.makeUnsafe("cmd-import-goal-continuation-history"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        messages: [
+          {
+            messageId: asMessageId("user-message-before-goal-continuation"),
+            role: "user",
+            text: "Implement the persistence layer first.",
+            createdAt: now,
+            updatedAt: now,
+          },
+          {
+            messageId: asMessageId("assistant-message-before-goal-continuation"),
+            role: "assistant",
+            text: "The persistence layer is complete.",
+            createdAt: now,
+            updatedAt: now,
+          },
+        ],
+        createdAt: now,
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-stale-continuation-goal"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goal: "Finish the remaining goal work",
+        goalStartBehavior: "defer",
+      }),
+    );
+    const goalStartedAt = (await readHarnessThread(harness))?.goalStartedAt;
+    expect(goalStartedAt).toBeTruthy();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.goal.continue",
+        commandId: CommandId.makeUnsafe("cmd-stale-goal-continuation-retry"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goalStartedAt: goalStartedAt!,
+        trigger: "turn-completed",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 3);
+    const retrySendInput = harness.sendTurn.mock.calls[2]?.[0] as { readonly input?: string };
+    expect(retrySendInput.input).toContain("<thread_context>");
+    expect(retrySendInput.input).toContain("Implement the persistence layer first.");
+    expect(retrySendInput.input).toContain("The persistence layer is complete.");
+    expect(retrySendInput.input).toContain("Finish the remaining goal work");
+    expect(retrySendInput.input).toContain("Continue working toward the active thread goal");
   });
 
   it("retries a stale Claude resume natively before paying the transcript bootstrap", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1841,7 +1841,7 @@ const make = Effect.gen(function* () {
             priorTranscriptBootstrapAvailableChars > 0
               ? buildPriorTranscriptBootstrapText(
                   thread,
-                  input.messageId,
+                  transcriptBoundaryMessageId,
                   priorTranscriptBootstrapAvailableChars,
                 )
               : null;
@@ -3647,25 +3647,14 @@ const make = Effect.gen(function* () {
           return;
         case "thread.meta-updated": {
           const thread = yield* resolveThread(event.payload.threadId);
-          const goalTimingChanged =
-            event.payload.goal !== undefined ||
-            event.payload.goalStartedAt !== undefined ||
-            event.payload.goalPausedAt !== undefined;
           const startsOrResumesGoal =
             event.payload.goalPausedAt == null && event.payload.goalStartedAt != null;
-          if (
-            goalTimingChanged &&
-            event.payload.goalStartBehavior !== "defer" &&
-            (startsOrResumesGoal ||
-              (thread !== undefined &&
-                Boolean(activeThreadGoal(thread)?.trim()) &&
-                thread.goalPausedAt == null))
-          ) {
+          if (event.payload.goalStartBehavior !== "defer" && startsOrResumesGoal) {
             yield* orchestrationEngine.dispatch({
               type: "thread.goal.continue",
               commandId: CommandId.makeUnsafe(`server:goal-continue:${event.eventId}`),
               threadId: event.payload.threadId,
-              goalStartedAt: event.payload.goalStartedAt ?? thread?.goalStartedAt ?? null,
+              goalStartedAt: event.payload.goalStartedAt,
               trigger: "goal-updated",
               createdAt: event.payload.updatedAt,
             });
@@ -3719,7 +3708,10 @@ const make = Effect.gen(function* () {
           return;
         }
         case "thread.interaction-mode-set": {
-          if (event.payload.interactionMode === "plan") {
+          if (
+            event.payload.previousInteractionMode !== "plan" ||
+            event.payload.interactionMode === "plan"
+          ) {
             return;
           }
           const thread = yield* resolveThread(event.payload.threadId);

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -80,6 +80,7 @@ import {
 } from "../../provider/debugMode.ts";
 import {
   activeThreadGoal,
+  buildGoalContinuationInput,
   providerGoalPromptOverheadChars,
   withProviderGoalPrompt,
 } from "../../provider/goalMode.ts";
@@ -1400,6 +1401,7 @@ const make = Effect.gen(function* () {
     readonly runtimeMode?: RuntimeMode;
     readonly interactionMode?: ProviderInteractionMode;
     readonly dispatchMode?: "queue" | "steer";
+    readonly turnKind?: "user" | "goal-continuation";
     readonly createdAt: string;
   }) {
     const thread = yield* resolveThread(input.threadId);
@@ -1530,9 +1532,11 @@ const make = Effect.gen(function* () {
       ? `<sidechat_boundary>\n${SIDECHAT_BOUNDARY_INSTRUCTION}\n</sidechat_boundary>\n\n<latest_user_message>\n${input.messageText}\n</latest_user_message>`
       : input.messageText;
     const bootstrapBudgetMessageText = `${boundaryMessageText}${mentionContextSuffix}`;
+    const transcriptBoundaryMessageId =
+      input.turnKind === "goal-continuation" ? undefined : input.messageId;
     const shouldBootstrapHandoff =
       thread.handoff?.bootstrapStatus === "pending" &&
-      !hasNativeAssistantMessagesBefore(thread, input.messageId);
+      !hasNativeAssistantMessagesBefore(thread, transcriptBoundaryMessageId);
     const handoffBootstrapAvailableChars = availableProviderContextChars({
       tag: "handoff_context",
       messageText: bootstrapBudgetMessageText,
@@ -1568,7 +1572,7 @@ const make = Effect.gen(function* () {
     const shouldBootstrapSidechatContext =
       thread.sidechatSourceThreadId !== null &&
       sidechatContextBootstrapThreadIds.has(input.threadId) &&
-      !hasNativeAssistantMessagesBefore(thread, input.messageId) &&
+      !hasNativeAssistantMessagesBefore(thread, transcriptBoundaryMessageId) &&
       !shouldBootstrapHandoff &&
       !hasPendingPriorTranscriptBootstrap;
     const sidechatBootstrapAvailableChars = availableProviderContextChars({
@@ -1603,7 +1607,7 @@ const make = Effect.gen(function* () {
       !shouldBootstrapSidechatContext;
     const hasPriorTranscriptBootstrapContent =
       shouldBootstrapPriorTranscriptContext &&
-      listPriorTranscriptMessages(thread, input.messageId).length > 0;
+      listPriorTranscriptMessages(thread, transcriptBoundaryMessageId).length > 0;
     const priorTranscriptBootstrapAvailableChars = availableProviderContextChars({
       tag: "thread_context",
       messageText: bootstrapBudgetMessageText,
@@ -1628,7 +1632,7 @@ const make = Effect.gen(function* () {
       shouldBootstrapPriorTranscriptContext && priorTranscriptBootstrapAvailableChars > 0
         ? buildPriorTranscriptBootstrapText(
             thread,
-            input.messageId,
+            transcriptBoundaryMessageId,
             priorTranscriptBootstrapAvailableChars,
           )
         : null;
@@ -2591,6 +2595,141 @@ const make = Effect.gen(function* () {
     }
   });
 
+  const hasPendingQueuedTurnForSession = Effect.fnUntraced(function* (threadId: ThreadId) {
+    const sessionThreadId = (yield* resolveProviderSessionThread(threadId))?.id ?? threadId;
+    if (pendingQueuedDispatchBySessionThread.has(sessionThreadId)) {
+      return true;
+    }
+    for (const queuedThreadId of yield* queuedTurnPromotions.listPendingThreadIds) {
+      const queuedThread = ThreadId.makeUnsafe(queuedThreadId);
+      const providerThread = yield* resolveProviderSessionThread(queuedThread);
+      if ((providerThread?.id ?? queuedThread) === sessionThreadId) {
+        return true;
+      }
+    }
+    return false;
+  });
+
+  const pauseActiveThreadGoal = Effect.fnUntraced(function* (input: {
+    readonly threadId: ThreadId;
+    readonly expectedGoalStartedAt: string | null;
+    readonly createdAt: string;
+  }) {
+    const thread = (yield* orchestrationEngine.getReadModel()).threads.find(
+      (candidate) => candidate.id === input.threadId,
+    );
+    if (
+      !thread ||
+      !activeThreadGoal(thread)?.trim() ||
+      thread.goalPausedAt != null ||
+      (thread.goalStartedAt ?? null) !== input.expectedGoalStartedAt
+    ) {
+      return;
+    }
+    yield* orchestrationEngine.dispatch({
+      type: "thread.meta.update",
+      commandId: serverCommandId("goal-auto-pause"),
+      threadId: input.threadId,
+      goalPaused: true,
+      createdAt: input.createdAt,
+    });
+  });
+
+  const processGoalContinuationRequested = (
+    event: Extract<ProviderIntentEvent, { type: "thread.goal-continuation-requested" }>,
+  ) =>
+    withProviderSessionLease(
+      event.payload.threadId,
+      Effect.gen(function* () {
+        const thread = yield* resolveThread(event.payload.threadId);
+        if (
+          !thread ||
+          thread.deletedAt != null ||
+          thread.archivedAt != null ||
+          thread.parentThreadId != null ||
+          thread.interactionMode === "plan" ||
+          !activeThreadGoal(thread)?.trim() ||
+          thread.goalPausedAt != null ||
+          (thread.goalStartedAt ?? null) !== event.payload.goalStartedAt
+        ) {
+          return;
+        }
+
+        const pendingInteractionCounts = yield* pendingInteractions.getPendingCountsByThreadId({
+          threadId: thread.id,
+        });
+        if (
+          pendingInteractionCounts.pendingApprovalCount > 0 ||
+          pendingInteractionCounts.pendingUserInputCount > 0 ||
+          (yield* hasLiveProviderTurn(thread.id))
+        ) {
+          return;
+        }
+
+        // User-authored queued work always wins. Its terminal event will ask for
+        // the next goal iteration if the goal is still active afterwards.
+        yield* drainQueuedTurnsForSession(thread.id);
+        if (yield* hasPendingQueuedTurnForSession(thread.id)) {
+          return;
+        }
+
+        const createdAt = event.payload.createdAt;
+        const providerName = thread.session?.providerName ?? thread.modelSelection.provider;
+        const turnStartSession = deriveTurnStartSession({
+          threadId: thread.id,
+          currentSession: thread.session,
+          providerName,
+          requestedRuntimeMode: thread.runtimeMode,
+          requestedAt: createdAt,
+        });
+        if (turnStartSession !== null) {
+          yield* setThreadSession({
+            threadId: thread.id,
+            session: turnStartSession,
+            createdAt,
+          });
+        }
+
+        yield* dispatchTurnForThread({
+          threadId: thread.id,
+          messageId: MessageId.makeUnsafe(`goal-continuation:${event.eventId}`),
+          messageText: buildGoalContinuationInput(),
+          runtimeMode: thread.runtimeMode,
+          interactionMode: thread.interactionMode,
+          dispatchMode: "queue",
+          turnKind: "goal-continuation",
+          createdAt,
+        }).pipe(
+          Effect.catchCause((cause) =>
+            Cause.hasInterruptsOnly(cause)
+              ? Effect.failCause(cause)
+              : Effect.gen(function* () {
+                  const detail = Cause.pretty(cause);
+                  yield* appendProviderFailureActivity({
+                    threadId: thread.id,
+                    kind: "provider.turn.start.failed",
+                    summary: "Goal continuation failed",
+                    detail,
+                    turnId: null,
+                    createdAt,
+                  });
+                  yield* setThreadSessionError({
+                    threadId: thread.id,
+                    runtimeMode: thread.runtimeMode,
+                    detail,
+                    createdAt,
+                  });
+                  yield* pauseActiveThreadGoal({
+                    threadId: thread.id,
+                    expectedGoalStartedAt: event.payload.goalStartedAt,
+                    createdAt,
+                  });
+                }),
+          ),
+        );
+      }),
+    );
+
   const processQueueDrainEvent = Effect.fnUntraced(function* (event: ProviderQueueDrainEvent) {
     observePendingContextBootstrapTerminalEvent(event);
     const sessionThreadId =
@@ -3439,6 +3578,40 @@ const make = Effect.gen(function* () {
     });
   });
 
+  const surfaceTimedOutGoalContinuation = Effect.fnUntraced(function* (
+    event: Extract<ProviderIntentEvent, { type: "thread.goal-continuation-requested" }>,
+    detail: string,
+  ) {
+    const createdAt = new Date().toISOString();
+    const thread = yield* resolveThread(event.payload.threadId);
+    if (thread?.session?.status === "starting" && thread.session.activeTurnId === null) {
+      yield* setThreadSessionError({
+        threadId: event.payload.threadId,
+        runtimeMode: thread.runtimeMode,
+        detail,
+        expectedSession: {
+          status: thread.session.status,
+          updatedAt: thread.session.updatedAt,
+        },
+        createdAt,
+      });
+    }
+    yield* appendProviderFailureActivity({
+      threadId: event.payload.threadId,
+      kind: "provider.turn.start.failed",
+      summary: "Goal continuation timed out",
+      detail,
+      turnId: null,
+      createdAt,
+      settlementStatus: "uncertain",
+    });
+    yield* pauseActiveThreadGoal({
+      threadId: event.payload.threadId,
+      expectedGoalStartedAt: event.payload.goalStartedAt,
+      createdAt,
+    });
+  });
+
   const processDomainEvent = (event: ProviderIntentEvent) =>
     Effect.gen(function* () {
       switch (event.type) {
@@ -3478,6 +3651,30 @@ const make = Effect.gen(function* () {
           return;
         case "thread.meta-updated": {
           const thread = yield* resolveThread(event.payload.threadId);
+          const goalTimingChanged =
+            event.payload.goal !== undefined ||
+            event.payload.goalStartedAt !== undefined ||
+            event.payload.goalPausedAt !== undefined;
+          const startsOrResumesGoal =
+            event.payload.goalPausedAt == null &&
+            event.payload.goalStartedAt != null;
+          if (
+            goalTimingChanged &&
+            event.payload.goalStartBehavior !== "defer" &&
+            (startsOrResumesGoal ||
+              (thread !== undefined &&
+                Boolean(activeThreadGoal(thread)?.trim()) &&
+                thread.goalPausedAt == null))
+          ) {
+            yield* orchestrationEngine.dispatch({
+              type: "thread.goal.continue",
+              commandId: CommandId.makeUnsafe(`server:goal-continue:${event.eventId}`),
+              threadId: event.payload.threadId,
+              goalStartedAt: event.payload.goalStartedAt ?? thread?.goalStartedAt ?? null,
+              trigger: "goal-updated",
+              createdAt: event.payload.updatedAt,
+            });
+          }
           if (event.payload.modelSelection === undefined) {
             return;
           }
@@ -3526,11 +3723,36 @@ const make = Effect.gen(function* () {
           });
           return;
         }
+        case "thread.interaction-mode-set": {
+          if (event.payload.interactionMode === "plan") {
+            return;
+          }
+          const thread = yield* resolveThread(event.payload.threadId);
+          if (
+            thread &&
+            thread.parentThreadId == null &&
+            activeThreadGoal(thread)?.trim() &&
+            thread.goalPausedAt == null
+          ) {
+            yield* orchestrationEngine.dispatch({
+              type: "thread.goal.continue",
+              commandId: CommandId.makeUnsafe(`server:goal-continue:${event.eventId}`),
+              threadId: thread.id,
+              goalStartedAt: thread.goalStartedAt ?? null,
+              trigger: "interaction-mode-updated",
+              createdAt: event.payload.updatedAt,
+            });
+          }
+          return;
+        }
         case "thread.turn-queued":
           yield* processTurnQueued(event);
           return;
         case "thread.turn-start-requested":
           yield* processTurnStartRequested(event);
+          return;
+        case "thread.goal-continuation-requested":
+          yield* processGoalContinuationRequested(event);
           return;
         case "thread.turn-interrupt-requested":
           yield* processTurnInterruptRequested(event);
@@ -3878,6 +4100,16 @@ const make = Effect.gen(function* () {
                 }),
               ),
             );
+          } else if (event.type === "thread.goal-continuation-requested") {
+            yield* surfaceTimedOutGoalContinuation(event, workerResult.detail).pipe(
+              Effect.catchCause((cause) =>
+                Effect.logError("failed to surface timed-out goal continuation", {
+                  eventSequence: event.sequence,
+                  threadId: event.payload.threadId,
+                  cause: Cause.pretty(cause),
+                }),
+              ),
+            );
           }
           yield* settleTerminalFailure({
             event,
@@ -4214,10 +4446,37 @@ const make = Effect.gen(function* () {
     );
   });
 
+  const recoverActiveThreadGoals = Effect.gen(function* () {
+    const snapshot = yield* orchestrationEngine.getReadModel();
+    yield* Effect.forEach(
+      snapshot.threads.filter(
+        (thread) =>
+          thread.deletedAt == null &&
+          thread.archivedAt == null &&
+          thread.parentThreadId == null &&
+          Boolean(activeThreadGoal(thread)?.trim()) &&
+          thread.goalPausedAt == null,
+      ),
+      (thread) =>
+        orchestrationEngine.dispatch({
+          type: "thread.goal.continue",
+          commandId: serverCommandId("goal-startup-recovery"),
+          threadId: thread.id,
+          goalStartedAt: thread.goalStartedAt ?? null,
+          trigger: "startup-recovery",
+          createdAt: new Date().toISOString(),
+        }),
+      { discard: true },
+    );
+  });
+
   const start = seedThreadModelSelections.pipe(
     Effect.andThen(
       Effect.all([
-        startProviderIntentSource.pipe(Effect.andThen(recoverQueuedTurnPromotions)),
+        startProviderIntentSource.pipe(
+          Effect.andThen(recoverQueuedTurnPromotions),
+          Effect.andThen(recoverActiveThreadGoals),
+        ),
         Stream.runForEach(providerService.streamEvents, (event) => {
           if (event.type !== "turn.completed" && event.type !== "turn.aborted") {
             return Effect.void;

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -634,6 +634,17 @@ const make = Effect.gen(function* () {
   const editResendTurnStartKeys = new Set<string>();
   const quarantinedThreads = new Set<string>();
   const drainingQueuedTurns = new Set<string>();
+  type BlockedGoalContinuation = Pick<
+    Extract<ProviderIntentEvent, { type: "thread.goal-continuation-requested" }>["payload"],
+    "goalStartedAt" | "trigger" | "sourceTurnId"
+  >;
+  // A blocked continuation cannot keep its durable delivery open: approval,
+  // input, and queued-work intents behind it may be the only way to clear the
+  // blocker. Retry outside the single delivery lock; startup recovery recreates
+  // the request if the process exits while this transient retry is pending.
+  const blockedGoalContinuations = new Map<string, BlockedGoalContinuation>();
+  const queuedGoalContinuationRetries = new Set<string>();
+  const goalContinuationRetryQueue = yield* Queue.unbounded<ThreadId>();
   // Provider sessions with a drained queued turn whose promotion is in flight.
   // The reservation survives provider startup and binds to the exact turn that
   // must settle before another queue can drain, preventing late terminal events
@@ -952,6 +963,8 @@ const make = Effect.gen(function* () {
         }
       }
       quarantinedThreads.delete(threadId);
+      blockedGoalContinuations.delete(threadId);
+      queuedGoalContinuationRetries.delete(threadId);
       // NOTE: `drainingQueuedTurns` is intentionally NOT cleared here. It is a
       // turn-scoped in-flight guard that each drain self-clears when it settles;
       // deleting it here would let a concurrent second drain start for the same
@@ -2610,6 +2623,129 @@ const make = Effect.gen(function* () {
     return false;
   });
 
+  const scheduleBlockedGoalContinuationRetry = Effect.fnUntraced(function* (threadId: ThreadId) {
+    if (queuedGoalContinuationRetries.has(threadId)) {
+      return;
+    }
+    queuedGoalContinuationRetries.add(threadId);
+    yield* Queue.offer(goalContinuationRetryQueue, threadId);
+  });
+
+  const deferGoalContinuation = Effect.fnUntraced(function* (
+    event: Extract<ProviderIntentEvent, { type: "thread.goal-continuation-requested" }>,
+  ) {
+    blockedGoalContinuations.set(event.payload.threadId, {
+      goalStartedAt: event.payload.goalStartedAt,
+      trigger: event.payload.trigger,
+      ...(event.payload.sourceTurnId !== undefined
+        ? { sourceTurnId: event.payload.sourceTurnId }
+        : {}),
+    });
+    yield* scheduleBlockedGoalContinuationRetry(event.payload.threadId);
+  });
+
+  const retryBlockedGoalContinuation = Effect.fnUntraced(function* (threadId: ThreadId) {
+    const pending = blockedGoalContinuations.get(threadId);
+    if (!pending) {
+      return;
+    }
+
+    const thread = yield* resolveThread(threadId);
+    if (
+      !thread ||
+      thread.deletedAt != null ||
+      thread.archivedAt != null ||
+      thread.parentThreadId != null ||
+      thread.interactionMode === "plan" ||
+      !activeThreadGoal(thread)?.trim() ||
+      thread.goalPausedAt != null ||
+      (thread.goalStartedAt ?? null) !== pending.goalStartedAt
+    ) {
+      blockedGoalContinuations.delete(threadId);
+      return;
+    }
+
+    const pendingInteractionCounts = yield* pendingInteractions.getPendingCountsByThreadId({
+      threadId,
+    });
+    if (
+      pendingInteractionCounts.pendingApprovalCount > 0 ||
+      pendingInteractionCounts.pendingUserInputCount > 0 ||
+      (thread.session !== null &&
+        thread.session.status !== "ready" &&
+        thread.session.status !== "stopped") ||
+      (yield* hasLiveProviderTurn(threadId))
+    ) {
+      yield* scheduleBlockedGoalContinuationRetry(threadId);
+      return;
+    }
+
+    yield* drainQueuedTurnsForSession(threadId);
+    if (yield* hasPendingQueuedTurnForSession(threadId)) {
+      yield* scheduleBlockedGoalContinuationRetry(threadId);
+      return;
+    }
+
+    if (blockedGoalContinuations.get(threadId) !== pending) {
+      return;
+    }
+    blockedGoalContinuations.delete(threadId);
+    yield* orchestrationEngine
+      .dispatch({
+        type: "thread.goal.continue",
+        commandId: serverCommandId("goal-blocker-cleared"),
+        threadId,
+        goalStartedAt: pending.goalStartedAt,
+        trigger: pending.trigger,
+        ...(pending.sourceTurnId !== undefined ? { sourceTurnId: pending.sourceTurnId } : {}),
+        createdAt: new Date().toISOString(),
+      })
+      .pipe(
+        Effect.catchCause((cause) =>
+          Cause.hasInterruptsOnly(cause)
+            ? Effect.failCause(cause)
+            : Effect.sync(() => {
+                if (!blockedGoalContinuations.has(threadId)) {
+                  blockedGoalContinuations.set(threadId, pending);
+                }
+              }).pipe(
+                Effect.andThen(scheduleBlockedGoalContinuationRetry(threadId)),
+                Effect.andThen(
+                  Effect.logWarning("provider command reactor failed to retry goal continuation", {
+                    threadId,
+                    cause: Cause.pretty(cause),
+                  }),
+                ),
+              ),
+        ),
+      );
+  });
+
+  const runBlockedGoalContinuationRetries = Stream.fromQueue(goalContinuationRetryQueue).pipe(
+    Stream.runForEach((threadId) =>
+      Effect.sleep(Duration.millis(500)).pipe(
+        Effect.andThen(
+          Effect.sync(() => {
+            queuedGoalContinuationRetries.delete(threadId);
+          }),
+        ),
+        Effect.andThen(retryBlockedGoalContinuation(threadId)),
+        Effect.catchCause((cause) =>
+          Cause.hasInterruptsOnly(cause)
+            ? Effect.failCause(cause)
+            : scheduleBlockedGoalContinuationRetry(threadId).pipe(
+                Effect.andThen(
+                  Effect.logWarning("provider command reactor goal continuation retry failed", {
+                    threadId,
+                    cause: Cause.pretty(cause),
+                  }),
+                ),
+              ),
+        ),
+      ),
+    ),
+  );
+
   const pauseActiveThreadGoal = Effect.fnUntraced(function* (input: {
     readonly threadId: ThreadId;
     readonly expectedGoalStartedAt: string | null;
@@ -2650,6 +2786,7 @@ const make = Effect.gen(function* () {
           thread.goalPausedAt != null ||
           (thread.goalStartedAt ?? null) !== event.payload.goalStartedAt
         ) {
+          blockedGoalContinuations.delete(event.payload.threadId);
           return;
         }
 
@@ -2661,6 +2798,7 @@ const make = Effect.gen(function* () {
           pendingInteractionCounts.pendingUserInputCount > 0 ||
           (yield* hasLiveProviderTurn(thread.id))
         ) {
+          yield* deferGoalContinuation(event);
           return;
         }
 
@@ -2668,8 +2806,11 @@ const make = Effect.gen(function* () {
         // the next goal iteration if the goal is still active afterwards.
         yield* drainQueuedTurnsForSession(thread.id);
         if (yield* hasPendingQueuedTurnForSession(thread.id)) {
+          yield* deferGoalContinuation(event);
           return;
         }
+
+        blockedGoalContinuations.delete(thread.id);
 
         const createdAt = event.payload.createdAt;
         const providerName = thread.session?.providerName ?? thread.modelSelection.provider;
@@ -2688,7 +2829,7 @@ const make = Effect.gen(function* () {
           });
         }
 
-        yield* dispatchTurnForThread({
+        const startedTurn = yield* dispatchTurnForThread({
           threadId: thread.id,
           messageId: MessageId.makeUnsafe(`goal-continuation:${event.eventId}`),
           messageText: buildGoalContinuationInput(),
@@ -2724,6 +2865,25 @@ const make = Effect.gen(function* () {
                 }),
           ),
         );
+        const latestThread = (yield* orchestrationEngine.getReadModel()).threads.find(
+          (candidate) => candidate.id === thread.id,
+        );
+        // Stop/pause can commit while provider dispatch is awaiting acceptance.
+        // Fence the accepted turn against the authoritative command model so it
+        // cannot escape the interrupt event that raced it with a stale turn id.
+        if (
+          startedTurn &&
+          (!latestThread ||
+            latestThread.goalPausedAt != null ||
+            !activeThreadGoal(latestThread)?.trim() ||
+            (latestThread.goalStartedAt ?? null) !== event.payload.goalStartedAt)
+        ) {
+          yield* interruptProviderTurn({
+            threadId: thread.id,
+            turnId: startedTurn.turnId,
+            createdAt: new Date().toISOString(),
+          });
+        }
       }),
     );
 
@@ -2819,7 +2979,8 @@ const make = Effect.gen(function* () {
     // Forward the observed turn only as an expectation. ProviderService owns the
     // exact generation-scoped provider turn and rejects a stale mismatch.
     const providerThreadId = resolveSubagentProviderThreadId(thread.id, providerThread.id);
-    const turnId = input.turnId ?? thread.session?.activeTurnId ?? undefined;
+    const liveTurnId = yield* resolveLiveProviderTurnId(input.threadId);
+    const turnId = liveTurnId ?? input.turnId ?? thread.session?.activeTurnId ?? undefined;
     const result = yield* runBoundedProviderCall({
       label: "The provider interrupt",
       timeout: PROVIDER_COMMAND_INTERRUPT_TIMEOUT,
@@ -4470,6 +4631,7 @@ const make = Effect.gen(function* () {
           }
           return processQueueDrainEventSafely(event);
         }).pipe(Effect.forkScoped),
+        runBlockedGoalContinuationRetries.pipe(Effect.forkScoped),
       ]).pipe(Effect.asVoid),
     ),
     Effect.orDie,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -2671,9 +2671,8 @@ const make = Effect.gen(function* () {
     if (
       pendingInteractionCounts.pendingApprovalCount > 0 ||
       pendingInteractionCounts.pendingUserInputCount > 0 ||
-      (thread.session !== null &&
-        thread.session.status !== "ready" &&
-        thread.session.status !== "stopped") ||
+      thread.session?.status === "starting" ||
+      thread.session?.status === "running" ||
       (yield* hasLiveProviderTurn(threadId))
     ) {
       yield* scheduleBlockedGoalContinuationRetry(threadId);

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -3656,8 +3656,7 @@ const make = Effect.gen(function* () {
             event.payload.goalStartedAt !== undefined ||
             event.payload.goalPausedAt !== undefined;
           const startsOrResumesGoal =
-            event.payload.goalPausedAt == null &&
-            event.payload.goalStartedAt != null;
+            event.payload.goalPausedAt == null && event.payload.goalStartedAt != null;
           if (
             goalTimingChanged &&
             event.payload.goalStartBehavior !== "defer" &&

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -2613,7 +2613,6 @@ const make = Effect.gen(function* () {
   const pauseActiveThreadGoal = Effect.fnUntraced(function* (input: {
     readonly threadId: ThreadId;
     readonly expectedGoalStartedAt: string | null;
-    readonly createdAt: string;
   }) {
     const thread = (yield* orchestrationEngine.getReadModel()).threads.find(
       (candidate) => candidate.id === input.threadId,
@@ -2631,7 +2630,6 @@ const make = Effect.gen(function* () {
       commandId: serverCommandId("goal-auto-pause"),
       threadId: input.threadId,
       goalPaused: true,
-      createdAt: input.createdAt,
     });
   });
 
@@ -2722,7 +2720,6 @@ const make = Effect.gen(function* () {
                   yield* pauseActiveThreadGoal({
                     threadId: thread.id,
                     expectedGoalStartedAt: event.payload.goalStartedAt,
-                    createdAt,
                   });
                 }),
           ),
@@ -3608,7 +3605,6 @@ const make = Effect.gen(function* () {
     yield* pauseActiveThreadGoal({
       threadId: event.payload.threadId,
       expectedGoalStartedAt: event.payload.goalStartedAt,
-      createdAt,
     });
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -1050,6 +1050,101 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.lastError).toBe("turn failed");
   });
 
+  it("requests another goal turn after a clean active-goal completion", async () => {
+    const harness = await createHarness();
+    const turnId = asTurnId("turn-active-goal");
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-active-goal"),
+        threadId: asThreadId("thread-1"),
+        goal: "Finish every requirement",
+      }),
+    );
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-active-goal-started"),
+      provider: "codex",
+      threadId: asThreadId("thread-1"),
+      createdAt: new Date().toISOString(),
+      turnId,
+    });
+    await waitForThread(harness.engine, (thread) => thread.session?.activeTurnId === turnId);
+
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-active-goal-completed"),
+      provider: "codex",
+      threadId: asThreadId("thread-1"),
+      createdAt: new Date().toISOString(),
+      turnId,
+      payload: { state: "completed" },
+    });
+    await harness.drain();
+
+    const events = await Effect.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((collected) => Array.from(collected)),
+      ),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "thread.goal-continuation-requested",
+        payload: expect.objectContaining({
+          threadId: asThreadId("thread-1"),
+          sourceTurnId: turnId,
+          trigger: "turn-completed",
+        }),
+      }),
+    );
+  });
+
+  it("pauses an active goal instead of continuing after an interrupted completion", async () => {
+    const harness = await createHarness();
+    const turnId = asTurnId("turn-interrupted-goal");
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-interrupted-goal"),
+        threadId: asThreadId("thread-1"),
+        goal: "Do not resurrect after interrupt",
+      }),
+    );
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-interrupted-goal-started"),
+      provider: "codex",
+      threadId: asThreadId("thread-1"),
+      createdAt: new Date().toISOString(),
+      turnId,
+    });
+    await waitForThread(harness.engine, (thread) => thread.session?.activeTurnId === turnId);
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-interrupted-goal-completed"),
+      provider: "codex",
+      threadId: asThreadId("thread-1"),
+      createdAt: new Date().toISOString(),
+      turnId,
+      payload: { state: "interrupted" },
+    });
+
+    const thread = await waitForThread(
+      harness.engine,
+      (entry) => entry.session?.status === "interrupted" && entry.goalPausedAt != null,
+    );
+    expect(thread.goalPausedAt).toBeTruthy();
+    await harness.drain();
+    const events = await Effect.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((collected) => Array.from(collected)),
+      ),
+    );
+    expect(events.some((event) => event.type === "thread.goal-continuation-requested")).toBe(false);
+  });
+
   it("applies provider session.state.changed transitions directly", async () => {
     const harness = await createHarness();
     const waitingAt = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -38,6 +38,7 @@ import {
 import { copyAndAttributeStudioGeneratedImage } from "../../studioGeneratedImages.ts";
 import { parseCheckpointFilesFromUnifiedDiff } from "../../checkpointing/Diffs.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
+import { activeThreadGoal } from "../../provider/goalMode.ts";
 import {
   classifyTerminalTurnApplicability,
   isStartedTurnApplicable,
@@ -2273,6 +2274,45 @@ const make = Effect.gen(function* () {
             },
             createdAt: now,
           });
+
+          if (isTerminalTurnEvent) {
+            // The command read model advances synchronously with goal tools.
+            // Reading it here prevents a fast terminal provider event from
+            // overtaking the projection of achieved/blocked/pause metadata.
+            const settledThread = (yield* orchestrationEngine.getReadModel()).threads.find(
+              (candidate) => candidate.id === thread.id,
+            );
+            if (
+              settledThread &&
+              settledThread.deletedAt == null &&
+              settledThread.archivedAt == null &&
+              settledThread.parentThreadId == null &&
+              Boolean(activeThreadGoal(settledThread)?.trim()) &&
+              settledThread.goalPausedAt == null
+            ) {
+              if (event.type === "turn.completed" && runtimeTurnState(event) === "completed") {
+                yield* orchestrationEngine.dispatch({
+                  type: "thread.goal.continue",
+                  commandId: providerCommandId(event, "goal-continue", thread.id),
+                  threadId: thread.id,
+                  goalStartedAt: settledThread.goalStartedAt ?? null,
+                  trigger: "turn-completed",
+                  ...(eventTurnId !== undefined ? { sourceTurnId: eventTurnId } : {}),
+                  createdAt: now,
+                });
+              } else {
+                // A failed, aborted, cancelled, or interrupted turn must stop
+                // autonomous resurrection until the user explicitly resumes.
+                yield* orchestrationEngine.dispatch({
+                  type: "thread.meta.update",
+                  commandId: providerCommandId(event, "goal-auto-pause", thread.id),
+                  threadId: thread.id,
+                  goalPaused: true,
+                  createdAt: now,
+                });
+              }
+            }
+          }
         }
       }
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -2308,7 +2308,6 @@ const make = Effect.gen(function* () {
                   commandId: providerCommandId(event, "goal-auto-pause", thread.id),
                   threadId: thread.id,
                   goalPaused: true,
-                  createdAt: now,
                 });
               }
             }

--- a/apps/server/src/orchestration/decider.goalTiming.test.ts
+++ b/apps/server/src/orchestration/decider.goalTiming.test.ts
@@ -398,4 +398,37 @@ describe("decider thread goal timing", () => {
     expect(achievements?.[0]?.goal).toBe("Objective 1");
     expect(achievements?.[19]?.goal).toBe("Objective 20");
   });
+
+  it("pauses an active goal atomically before interrupting its turn", async () => {
+    const now = new Date().toISOString();
+    let readModel = await createThreadReadModel(now);
+    const setEvent = await decideGoalUpdate(readModel, {
+      commandId: "cmd-goal-set-before-interrupt",
+      goal: "Finish the implementation",
+    });
+    readModel = await applyEvent(readModel, setEvent, 3);
+
+    const result = await Effect.runPromise(
+      decideOrchestrationCommand({
+        command: {
+          type: "thread.turn.interrupt",
+          commandId: CommandId.makeUnsafe("cmd-interrupt-active-goal"),
+          threadId: THREAD_ID,
+          createdAt: now,
+        },
+        readModel,
+      }),
+    );
+
+    expect(Array.isArray(result)).toBe(true);
+    if (!Array.isArray(result)) return;
+    expect(result.map((event) => event.type)).toEqual([
+      "thread.meta-updated",
+      "thread.turn-interrupt-requested",
+    ]);
+    const pauseEvent = result[0];
+    expect(pauseEvent?.type).toBe("thread.meta-updated");
+    if (pauseEvent?.type !== "thread.meta-updated") return;
+    expect(pauseEvent.payload.goalPausedAt).toBe(pauseEvent.occurredAt);
+  });
 });

--- a/apps/server/src/orchestration/decider.goalTiming.test.ts
+++ b/apps/server/src/orchestration/decider.goalTiming.test.ts
@@ -140,8 +140,8 @@ describe("decider thread goal timing", () => {
       commandId: "cmd-goal-edit",
       goal: "Ship the feature and tests",
     });
-    expect("goalStartedAt" in editEvent.payload).toBe(false);
-    expect("goalPausedAt" in editEvent.payload).toBe(false);
+    expect(editEvent.payload.goalStartedAt).toBe(setEvent.occurredAt);
+    expect(editEvent.payload.goalPausedAt).toBeNull();
 
     readModel = await applyEvent(readModel, editEvent, 4);
     expect(readModel.threads[0]?.goal).toBe("Ship the feature and tests");

--- a/apps/server/src/orchestration/decider.goalTiming.test.ts
+++ b/apps/server/src/orchestration/decider.goalTiming.test.ts
@@ -140,8 +140,8 @@ describe("decider thread goal timing", () => {
       commandId: "cmd-goal-edit",
       goal: "Ship the feature and tests",
     });
-    expect(editEvent.payload.goalStartedAt).toBe(setEvent.occurredAt);
-    expect(editEvent.payload.goalPausedAt).toBeNull();
+    expect("goalStartedAt" in editEvent.payload).toBe(false);
+    expect("goalPausedAt" in editEvent.payload).toBe(false);
 
     readModel = await applyEvent(readModel, editEvent, 4);
     expect(readModel.threads[0]?.goal).toBe("Ship the feature and tests");

--- a/apps/server/src/orchestration/decider.projectScripts.test.ts
+++ b/apps/server/src/orchestration/decider.projectScripts.test.ts
@@ -603,6 +603,7 @@ describe("decider project scripts", () => {
       type: "thread.interaction-mode-set",
       payload: {
         threadId: ThreadId.makeUnsafe("thread-1"),
+        previousInteractionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         interactionMode: "plan",
       },
     });

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -375,11 +375,7 @@ function resolveThreadGoalPatch(
       return { goal: command.goal, goalStartedAt: null, goalPausedAt: null };
     }
     if (activeGoal.length > 0) {
-      return {
-        goal: command.goal,
-        goalStartedAt: currentThread.goalStartedAt ?? null,
-        goalPausedAt: currentThread.goalPausedAt ?? null,
-      };
+      return { goal: command.goal };
     }
     return { goal: command.goal, goalStartedAt: occurredAt, goalPausedAt: null };
   }

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -375,7 +375,11 @@ function resolveThreadGoalPatch(
       return { goal: command.goal, goalStartedAt: null, goalPausedAt: null };
     }
     if (activeGoal.length > 0) {
-      return { goal: command.goal };
+      return {
+        goal: command.goal,
+        goalStartedAt: currentThread.goalStartedAt ?? null,
+        goalPausedAt: currentThread.goalPausedAt ?? null,
+      };
     }
     return { goal: command.goal, goalStartedAt: occurredAt, goalPausedAt: null };
   }
@@ -1628,7 +1632,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
     }
 
     case "thread.interaction-mode.set": {
-      yield* requireThread({
+      const thread = yield* requireThread({
         readModel,
         command,
         threadId: command.threadId,
@@ -1644,6 +1648,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         type: "thread.interaction-mode-set",
         payload: {
           threadId: command.threadId,
+          previousInteractionMode: thread.interactionMode,
           interactionMode: command.interactionMode,
           updatedAt: occurredAt,
         },

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1345,6 +1345,9 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
             ? { pinnedMessages: command.pinnedMessages }
             : {}),
           ...(command.notes !== undefined ? { notes: command.notes } : {}),
+          ...(command.goalStartBehavior !== undefined
+            ? { goalStartBehavior: command.goalStartBehavior }
+            : {}),
           ...resolveThreadGoalPatch(command, thread, occurredAt),
           updatedAt: occurredAt,
         },
@@ -1832,12 +1835,12 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
     }
 
     case "thread.turn.interrupt": {
-      yield* requireThread({
+      const thread = yield* requireThread({
         readModel,
         command,
         threadId: command.threadId,
       });
-      return {
+      const interruptEvent: Omit<OrchestrationEvent, "sequence"> = {
         ...withEventBase({
           aggregateKind: "thread",
           aggregateId: command.threadId,
@@ -1851,6 +1854,32 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           createdAt: command.createdAt,
         },
       };
+      if ((thread.goal ?? "").trim().length === 0 || thread.goalPausedAt != null) {
+        return interruptEvent;
+      }
+
+      const pausedAt = nowIso();
+      const pauseEvent: Omit<OrchestrationEvent, "sequence"> = {
+        ...withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: pausedAt,
+          commandId: command.commandId,
+        }),
+        type: "thread.meta-updated",
+        payload: {
+          threadId: command.threadId,
+          goalPausedAt: pausedAt,
+          updatedAt: pausedAt,
+        },
+      };
+      return [
+        pauseEvent,
+        {
+          ...interruptEvent,
+          causationEventId: pauseEvent.eventId,
+        },
+      ];
     }
 
     case "thread.task.stop": {
@@ -2161,6 +2190,30 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         type: "thread.session-stop-requested",
         payload: {
           threadId: command.threadId,
+          createdAt: command.createdAt,
+        },
+      };
+    }
+
+    case "thread.goal.continue": {
+      yield* requireThread({
+        readModel,
+        command,
+        threadId: command.threadId,
+      });
+      return {
+        ...withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        }),
+        type: "thread.goal-continuation-requested",
+        payload: {
+          threadId: command.threadId,
+          goalStartedAt: command.goalStartedAt,
+          trigger: command.trigger,
+          ...(command.sourceTurnId !== undefined ? { sourceTurnId: command.sourceTurnId } : {}),
           createdAt: command.createdAt,
         },
       };

--- a/apps/server/src/orchestration/handoff.ts
+++ b/apps/server/src/orchestration/handoff.ts
@@ -66,9 +66,12 @@ export function hasNativeHandoffMessages(thread: Pick<OrchestrationThread, "mess
 
 export function hasNativeAssistantMessagesBefore(
   thread: Pick<OrchestrationThread, "messages">,
-  currentMessageId: string,
+  currentMessageId?: string,
 ): boolean {
-  const currentIndex = thread.messages.findIndex((message) => message.id === currentMessageId);
+  const currentIndex =
+    currentMessageId === undefined
+      ? thread.messages.length
+      : thread.messages.findIndex((message) => message.id === currentMessageId);
   if (currentIndex <= 0) {
     return false;
   }
@@ -81,9 +84,12 @@ export function hasNativeAssistantMessagesBefore(
 
 export function listPriorTranscriptMessages(
   thread: Pick<OrchestrationThread, "messages">,
-  currentMessageId: string,
+  currentMessageId?: string,
 ): ReadonlyArray<OrchestrationMessage> {
-  const currentIndex = thread.messages.findIndex((message) => message.id === currentMessageId);
+  const currentIndex =
+    currentMessageId === undefined
+      ? thread.messages.length
+      : thread.messages.findIndex((message) => message.id === currentMessageId);
   if (currentIndex <= 0) {
     return [];
   }
@@ -192,7 +198,7 @@ export function buildHandoffBootstrapText(
 
 export function buildPriorTranscriptBootstrapText(
   thread: Pick<OrchestrationThread, "title" | "branch" | "worktreePath" | "messages">,
-  currentMessageId: string,
+  currentMessageId: string | undefined,
   maxChars = BOOTSTRAP_TRANSCRIPT_CHAR_BUDGET,
 ): string | null {
   const priorMessages = listPriorTranscriptMessages(thread, currentMessageId);

--- a/apps/server/src/orchestration/providerIntentClassification.ts
+++ b/apps/server/src/orchestration/providerIntentClassification.ts
@@ -10,8 +10,10 @@ export type ProviderIntentEvent = Extract<
       | "thread.meta-updated"
       | "thread.session-set"
       | "thread.runtime-mode-set"
+      | "thread.interaction-mode-set"
       | "thread.turn-queued"
       | "thread.turn-start-requested"
+      | "thread.goal-continuation-requested"
       | "thread.turn-interrupt-requested"
       | "thread.task-stop-requested"
       | "thread.task-background-requested"
@@ -30,8 +32,10 @@ const PROVIDER_INTENT_EVENT_TYPES = new Set<ProviderIntentEvent["type"]>([
   "thread.meta-updated",
   "thread.session-set",
   "thread.runtime-mode-set",
+  "thread.interaction-mode-set",
   "thread.turn-queued",
   "thread.turn-start-requested",
+  "thread.goal-continuation-requested",
   "thread.turn-interrupt-requested",
   "thread.task-stop-requested",
   "thread.task-background-requested",

--- a/apps/server/src/provider/goalMode.test.ts
+++ b/apps/server/src/provider/goalMode.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   activeThreadGoal,
+  buildGoalContinuationInput,
   providerGoalPromptOverheadChars,
   withProviderGoalPrompt,
 } from "./goalMode.ts";
@@ -54,5 +55,14 @@ describe("provider thread goal prompt", () => {
     expect(activeThreadGoal({ goal, goalPausedAt: null })).toBe(goal);
     expect(activeThreadGoal({ goal, goalPausedAt: "2026-08-13T10:00:00.000Z" })).toBeUndefined();
     expect(activeThreadGoal({ goalPausedAt: null })).toBeUndefined();
+  });
+
+  it("builds an internal continuation that keeps working until the goal is settled", () => {
+    const input = buildGoalContinuationInput();
+
+    expect(input).toContain("Continue working toward the active thread goal");
+    expect(input).toContain("synara_set_thread_goal");
+    expect(input).toContain("achieved: true");
+    expect(input).toContain("blocked: true");
   });
 });

--- a/apps/server/src/provider/goalMode.ts
+++ b/apps/server/src/provider/goalMode.ts
@@ -55,3 +55,13 @@ export function withProviderGoalPrompt(input: {
 
   return input.text.length > 0 ? `${prompt}\n\n${input.text}` : prompt;
 }
+
+export function buildGoalContinuationInput(): string {
+  return `Continue working toward the active thread goal.
+
+The goal persists across turns. Make concrete progress toward the full objective and do not redefine success around a smaller task that fits this turn.
+
+Before claiming completion, inspect the current state and verify every requirement against authoritative evidence. When the full objective is complete, call synara_set_thread_goal with achieved: true before ending the turn so Synara can stop the continuation loop and record the achievement.
+
+If the same external blocker prevents meaningful progress for three consecutive goal turns, call synara_set_thread_goal with blocked: true so Synara pauses the goal instead of looping. Do not mark the goal blocked merely because the work is difficult, incomplete, or would benefit from clarification.`;
+}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -8391,7 +8391,9 @@ export default function ChatView({
         const draftGoalForSend = activeThread.goal?.trim() ?? "";
         if (draftGoalForSend.length > 0) {
           try {
-            await dispatchThreadGoal(threadIdForSend, draftGoalForSend);
+            await dispatchThreadGoal(threadIdForSend, draftGoalForSend, {
+              startBehavior: "defer",
+            });
           } catch {
             // Non-critical: the goal can be set again with /goal on the live thread.
           }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -11412,7 +11412,9 @@ export default function ChatView({
                   goalPausedAt={activeThread.goalPausedAt}
                   canPause={isServerThread}
                   onEdit={editThreadGoalInComposer}
-                  onSetPaused={setThreadGoalPaused}
+                  onSetPaused={async (paused) => {
+                    await setThreadGoalPaused(paused);
+                  }}
                   onClear={clearThreadGoal}
                   attachedToPrevious={
                     showComposerLiveChangesHeader ||

--- a/apps/web/src/composerSlashCommands.test.ts
+++ b/apps/web/src/composerSlashCommands.test.ts
@@ -122,9 +122,12 @@ describe("composerSlashCommands", () => {
     });
   });
 
-  it("parses /goal show, clear, set, and length-limit actions", () => {
+  it("parses /goal controls, set, and length-limit actions", () => {
     expect(parseGoalSlashCommandArgs("")).toEqual({ action: "show" });
     expect(parseGoalSlashCommandArgs("  CLEAR  ")).toEqual({ action: "clear" });
+    expect(parseGoalSlashCommandArgs("pause")).toEqual({ action: "pause" });
+    expect(parseGoalSlashCommandArgs("RESUME")).toEqual({ action: "resume" });
+    expect(parseGoalSlashCommandArgs(" edit ")).toEqual({ action: "edit" });
     expect(parseGoalSlashCommandArgs("Ship the release safely")).toEqual({
       action: "set",
       goal: "Ship the release safely",

--- a/apps/web/src/composerSlashCommands.ts
+++ b/apps/web/src/composerSlashCommands.ts
@@ -33,6 +33,9 @@ export type ForkSlashCommandTarget = "local" | "worktree";
 export type GoalSlashCommandAction =
   | { readonly action: "show" }
   | { readonly action: "clear" }
+  | { readonly action: "pause" }
+  | { readonly action: "resume" }
+  | { readonly action: "edit" }
   | { readonly action: "set"; readonly goal: string }
   | { readonly action: "too-long" };
 
@@ -230,7 +233,7 @@ const COMPOSER_SLASH_COMMAND_DEFINITIONS: Record<
   goal: {
     command: "goal",
     label: "/goal",
-    description: "View, set, replace, or clear this thread's persistent goal",
+    description: "Set, edit, pause, resume, or clear this thread's persistent goal",
     source: "app",
   },
   feedback: {
@@ -389,8 +392,12 @@ export function parseGoalSlashCommandArgs(args: string): GoalSlashCommandAction 
   if (!goal) {
     return { action: "show" };
   }
-  if (goal.toLowerCase() === "clear") {
+  const control = goal.toLowerCase();
+  if (control === "clear") {
     return { action: "clear" };
+  }
+  if (control === "pause" || control === "resume" || control === "edit") {
+    return { action: control };
   }
   if (goal.length > THREAD_GOAL_MAX_CHARS) {
     return { action: "too-long" };

--- a/apps/web/src/hooks/useComposerSlashCommands.ts
+++ b/apps/web/src/hooks/useComposerSlashCommands.ts
@@ -296,12 +296,13 @@ export function useComposerSlashCommands(input: {
   }, [persistThreadGoal]);
 
   const setThreadGoalPaused = useCallback(
-    async (paused: boolean) => {
+    async (paused: boolean): Promise<boolean> => {
       if (!isServerThread || !activeThread) {
-        return;
+        return false;
       }
       try {
         await dispatchThreadGoalPaused(activeThread.id, paused);
+        return true;
       } catch (error) {
         toastManager.add({
           type: "error",
@@ -309,6 +310,7 @@ export function useComposerSlashCommands(input: {
           description:
             error instanceof Error ? error.message : "An error occurred while updating the goal.",
         });
+        return false;
       }
     },
     [activeThread, isServerThread],
@@ -338,11 +340,27 @@ export function useComposerSlashCommands(input: {
         await clearThreadGoal();
         return;
       }
+      if (action.action === "pause" || action.action === "resume") {
+        const paused = action.action === "pause";
+        if (await setThreadGoalPaused(paused)) {
+          toastManager.add({
+            type: "success",
+            title: `Thread goal ${paused ? "paused" : "resumed"}`,
+          });
+        }
+        return;
+      }
+      if (action.action === "edit") {
+        const currentGoal = activeThread?.goal?.trim() ?? "";
+        editorActions.setComposerPromptValue(`/goal ${currentGoal}`);
+        editorActions.scheduleComposerFocus();
+        return;
+      }
       if (await persistThreadGoal(action.goal)) {
         toastManager.add({ type: "success", title: "Thread goal updated" });
       }
     },
-    [activeThread?.goal, clearThreadGoal, persistThreadGoal],
+    [activeThread?.goal, clearThreadGoal, editorActions, persistThreadGoal, setThreadGoalPaused],
   );
 
   const createForkThreadFromSlashCommand = useCallback(

--- a/apps/web/src/threadGoal.test.ts
+++ b/apps/web/src/threadGoal.test.ts
@@ -16,7 +16,9 @@ describe("dispatchThreadGoal", () => {
   it("sets and clears the persisted goal through thread.meta.update", async () => {
     dispatchCommand.mockReset().mockResolvedValue(undefined);
 
-    await dispatchThreadGoal("thread-server" as never, "Ship the complete feature");
+    await dispatchThreadGoal("thread-server" as never, "Ship the complete feature", {
+      startBehavior: "defer",
+    });
     await dispatchThreadGoal("thread-server" as never, "");
 
     expect(dispatchCommand).toHaveBeenCalledTimes(2);
@@ -24,6 +26,7 @@ describe("dispatchThreadGoal", () => {
       type: "thread.meta.update",
       threadId: "thread-server",
       goal: "Ship the complete feature",
+      goalStartBehavior: "defer",
     });
     expect(dispatchCommand.mock.calls[1]?.[0]).toMatchObject({
       type: "thread.meta.update",

--- a/apps/web/src/threadGoal.ts
+++ b/apps/web/src/threadGoal.ts
@@ -17,9 +17,7 @@ export async function dispatchThreadGoal(
     commandId: newCommandId(),
     threadId,
     goal,
-    ...(options.startBehavior !== undefined
-      ? { goalStartBehavior: options.startBehavior }
-      : {}),
+    ...(options.startBehavior !== undefined ? { goalStartBehavior: options.startBehavior } : {}),
   });
 }
 

--- a/apps/web/src/threadGoal.ts
+++ b/apps/web/src/threadGoal.ts
@@ -1,9 +1,13 @@
-import { type ThreadId } from "@synara/contracts";
+import { type ThreadGoalStartBehavior, type ThreadId } from "@synara/contracts";
 
 import { newCommandId } from "./lib/utils";
 import { readNativeApi } from "./nativeApi";
 
-export async function dispatchThreadGoal(threadId: ThreadId, goal: string): Promise<void> {
+export async function dispatchThreadGoal(
+  threadId: ThreadId,
+  goal: string,
+  options: { readonly startBehavior?: ThreadGoalStartBehavior } = {},
+): Promise<void> {
   const api = readNativeApi();
   if (!api) {
     throw new Error("Synara API is unavailable.");
@@ -13,6 +17,9 @@ export async function dispatchThreadGoal(threadId: ThreadId, goal: string): Prom
     commandId: newCommandId(),
     threadId,
     goal,
+    ...(options.startBehavior !== undefined
+      ? { goalStartBehavior: options.startBehavior }
+      : {}),
   });
 }
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -648,6 +648,15 @@ export const ThreadNotes = Schema.String.check(Schema.isMaxLength(THREAD_NOTES_M
 export type ThreadNotes = typeof ThreadNotes.Type;
 export const ThreadGoal = Schema.String.check(Schema.isMaxLength(THREAD_GOAL_MAX_CHARS));
 export type ThreadGoal = typeof ThreadGoal.Type;
+export const ThreadGoalStartBehavior = Schema.Literals(["start-if-idle", "defer"]);
+export type ThreadGoalStartBehavior = typeof ThreadGoalStartBehavior.Type;
+export const ThreadGoalContinuationTrigger = Schema.Literals([
+  "goal-updated",
+  "interaction-mode-updated",
+  "turn-completed",
+  "startup-recovery",
+]);
+export type ThreadGoalContinuationTrigger = typeof ThreadGoalContinuationTrigger.Type;
 /**
  * Goal pursuit timing. `goalStartedAt` is (re)stamped by the decider whenever a
  * non-empty goal is set and rebased on resume so `now - goalStartedAt` is always
@@ -1234,6 +1243,7 @@ const ThreadMetaUpdateCommand = Schema.Struct({
   threadMarkers: Schema.optional(ThreadMarkers),
   notes: Schema.optional(ThreadNotes),
   goal: Schema.optional(ThreadGoal),
+  goalStartBehavior: Schema.optional(ThreadGoalStartBehavior),
   // Desired paused state; the decider stamps the authoritative goal timestamps.
   goalPaused: Schema.optional(Schema.Boolean),
   // Marks the active goal accomplished: the decider records a ThreadGoalAchievement
@@ -1581,6 +1591,16 @@ const ThreadSessionSetCommand = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+const ThreadGoalContinueCommand = Schema.Struct({
+  type: Schema.Literal("thread.goal.continue"),
+  commandId: CommandId,
+  threadId: ThreadId,
+  goalStartedAt: Schema.NullOr(IsoDateTime),
+  trigger: ThreadGoalContinuationTrigger,
+  sourceTurnId: Schema.optional(TurnId),
+  createdAt: IsoDateTime,
+});
+
 const ThreadMessagesImportCommand = Schema.Struct({
   type: Schema.Literal("thread.messages.import"),
   commandId: CommandId,
@@ -1658,6 +1678,7 @@ const ThreadConversationRollbackCompleteCommand = Schema.Struct({
 
 const InternalOrchestrationCommand = Schema.Union([
   ThreadSessionSetCommand,
+  ThreadGoalContinueCommand,
   ThreadMessagesImportCommand,
   ThreadMessageAssistantDeltaCommand,
   ThreadMessageAssistantCompleteCommand,
@@ -1704,6 +1725,7 @@ export const OrchestrationEventType = Schema.Literals([
   "thread.message-sent",
   "thread.turn-queued",
   "thread.turn-start-requested",
+  "thread.goal-continuation-requested",
   "thread.turn-interrupt-requested",
   "thread.task-stop-requested",
   "thread.task-background-requested",
@@ -1884,6 +1906,7 @@ export const ThreadMetaUpdatedPayload = Schema.Struct({
   threadMarkers: Schema.optional(ThreadMarkers),
   notes: Schema.optional(ThreadNotes),
   goal: Schema.optional(ThreadGoal),
+  goalStartBehavior: Schema.optional(ThreadGoalStartBehavior),
   goalStartedAt: Schema.optional(Schema.NullOr(IsoDateTime)),
   goalPausedAt: Schema.optional(Schema.NullOr(IsoDateTime)),
   goalAchievements: Schema.optional(ThreadGoalAchievements),
@@ -1996,6 +2019,14 @@ export const ThreadTurnStartRequestedPayload = Schema.Struct({
 });
 
 export const ThreadTurnQueuedPayload = ThreadTurnStartRequestedPayload;
+
+export const ThreadGoalContinuationRequestedPayload = Schema.Struct({
+  threadId: ThreadId,
+  goalStartedAt: Schema.NullOr(IsoDateTime),
+  trigger: ThreadGoalContinuationTrigger,
+  sourceTurnId: Schema.optional(TurnId),
+  createdAt: IsoDateTime,
+});
 
 export const ThreadTurnInterruptRequestedPayload = Schema.Struct({
   threadId: ThreadId,
@@ -2252,6 +2283,11 @@ export const OrchestrationEvent = Schema.Union([
     ...EventBaseFields,
     type: Schema.Literal("thread.turn-start-requested"),
     payload: ThreadTurnStartRequestedPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.goal-continuation-requested"),
+    payload: ThreadGoalContinuationRequestedPayload,
   }),
   Schema.Struct({
     ...EventBaseFields,

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1973,6 +1973,7 @@ export const ThreadRuntimeModeSetPayload = Schema.Struct({
 
 export const ThreadInteractionModeSetPayload = Schema.Struct({
   threadId: ThreadId,
+  previousInteractionMode: Schema.optional(ProviderInteractionMode),
   interactionMode: ProviderInteractionMode.pipe(
     Schema.withDecodingDefault(() => DEFAULT_PROVIDER_INTERACTION_MODE),
   ),


### PR DESCRIPTION
## Summary

- Automatically continue active thread goals after clean turn completion.
- Recover eligible goals after reactor startup and resume them after plan mode or pause state ends.
- Pause goals after interruptions, failures, timeouts, or repeated external blockers.
- Prioritize queued user work over automatic goal continuations.
- Add `blocked` support to `synara_set_thread_goal` with validation and focused coverage.

## Testing

- Added focused gateway, orchestration reactor, runtime ingestion, and decider tests covering continuation, recovery, queue priority, pausing, blocking, and stale requests.
- Not run (not requested).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large orchestration/provider reactor changes that auto-start turns, race with interrupts and queued work, and alter goal lifecycle—mistakes could loop agents, drop user messages, or pause goals incorrectly.
> 
> **Overview**
> Introduces an **autonomous continuation loop** for persistent thread goals: after a clean provider turn completes, the system can dispatch internal **goal-continuation** turns (via `thread.goal.continue` / `thread.goal-continuation-requested`) instead of waiting for the user. Continuations are gated by plan mode, pending approvals/user input, queued user turns, and pauses; blocked continuations retry outside the durable delivery lock.
> 
> **Starting and staging:** `goalStartBehavior` (`start-if-idle` vs `defer`) controls whether setting a goal immediately kicks off a continuation or waits for the first real user turn; draft goals from the composer use `defer`. Startup recovery re-dispatches continuations for eligible active goals after reactor restart.
> 
> **Pause and stop:** Goals auto-pause on non-completed terminal turns, continuation failures/timeouts, user interrupt (atomic pause before interrupt), and agent `synara_set_thread_goal` with **`blocked: true`** (mutually exclusive with `achieved`). Resuming unpause triggers continuation when idle.
> 
> **Provider path:** Goal continuations use `buildGoalContinuationInput()` and `turnKind: "goal-continuation"` so transcript/bootstrap logic treats the full prior history as context (not a fake user message). Interrupts prefer the **live** provider turn id when projections are stale.
> 
> **UI:** `/goal` gains pause, resume, and edit; draft goal persistence passes `startBehavior: "defer"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c2a138a5abb97d6f32b37292ad0eb8b2459d00a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->