### PR TITLE
fix(server): settle stale-generation terminal events instead of dropping them

### DIFF
--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -937,178 +937,178 @@ routing.layer("ProviderServiceLive routing", (it) => {
 
   staleSettlementRouting.layer("ProviderServiceLive stale-generation settlement", (it) => {
     it.effect("processes stale terminal events when no lifecycle generation is current", () =>
-    Effect.gen(function* () {
-      const provider = yield* ProviderService;
-      const threadId = asThreadId("thread-stale-terminal-no-generation");
-      yield* staleSettlementRouting.codex.waitForRuntimeSubscribers();
+      Effect.gen(function* () {
+        const provider = yield* ProviderService;
+        const threadId = asThreadId("thread-stale-terminal-no-generation");
+        yield* staleSettlementRouting.codex.waitForRuntimeSubscribers();
 
-      // A thread with no current lifecycle generation (retired/stopped runtime)
-      // must still accept the old session's terminal events: they are the only
-      // signal left that can settle the binding and projection. Non-terminal
-      // stale events stay dropped.
-      staleSettlementRouting.codex.emit({
-        type: "content.delta",
-        eventId: asEventId("stale-delta-no-generation"),
-        provider: "codex",
-        threadId,
-        createdAt: "2026-07-14T14:00:00.000Z",
-        lifecycleGeneration: "old-generation",
-        payload: { streamKind: "assistant_text", delta: "invisible" },
-      });
-      staleSettlementRouting.codex.emit({
-        type: "session.exited",
-        eventId: asEventId("stale-exit-no-generation"),
-        provider: "codex",
-        threadId,
-        createdAt: "2026-07-14T14:00:01.000Z",
-        lifecycleGeneration: "old-generation",
-        payload: { reason: "late old-runtime exit", recoverable: false, exitKind: "error" },
-      });
-      staleSettlementRouting.codex.emit({
-        type: "runtime.error",
-        eventId: asEventId("stale-error-no-generation"),
-        provider: "codex",
-        threadId,
-        createdAt: "2026-07-14T14:00:02.000Z",
-        lifecycleGeneration: "old-generation",
-        payload: {
-          message: "OpenCode server exited unexpectedly (130).",
-          class: "transport_error",
-        },
-      });
+        // A thread with no current lifecycle generation (retired/stopped runtime)
+        // must still accept the old session's terminal events: they are the only
+        // signal left that can settle the binding and projection. Non-terminal
+        // stale events stay dropped.
+        staleSettlementRouting.codex.emit({
+          type: "content.delta",
+          eventId: asEventId("stale-delta-no-generation"),
+          provider: "codex",
+          threadId,
+          createdAt: "2026-07-14T14:00:00.000Z",
+          lifecycleGeneration: "old-generation",
+          payload: { streamKind: "assistant_text", delta: "invisible" },
+        });
+        staleSettlementRouting.codex.emit({
+          type: "session.exited",
+          eventId: asEventId("stale-exit-no-generation"),
+          provider: "codex",
+          threadId,
+          createdAt: "2026-07-14T14:00:01.000Z",
+          lifecycleGeneration: "old-generation",
+          payload: { reason: "late old-runtime exit", recoverable: false, exitKind: "error" },
+        });
+        staleSettlementRouting.codex.emit({
+          type: "runtime.error",
+          eventId: asEventId("stale-error-no-generation"),
+          provider: "codex",
+          threadId,
+          createdAt: "2026-07-14T14:00:02.000Z",
+          lifecycleGeneration: "old-generation",
+          payload: {
+            message: "OpenCode server exited unexpectedly (130).",
+            class: "transport_error",
+          },
+        });
 
-      yield* waitUntil(
-        () => staleSettlementPersistedEvents.has("stale-exit-no-generation"),
-        500,
-        10,
-        "stale session.exited to be persisted",
-      );
-      assert.equal(staleSettlementPersistedEvents.has("stale-delta-no-generation"), false);
-      assert.equal(
-        staleSettlementPersistedEvents.get("stale-exit-no-generation")?.type,
-        "session.exited",
-      );
-      assert.equal(
-        staleSettlementPersistedEvents.get("stale-error-no-generation")?.type,
-        "runtime.error",
-      );
-    }),
-  );
+        yield* waitUntil(
+          () => staleSettlementPersistedEvents.has("stale-exit-no-generation"),
+          500,
+          10,
+          "stale session.exited to be persisted",
+        );
+        assert.equal(staleSettlementPersistedEvents.has("stale-delta-no-generation"), false);
+        assert.equal(
+          staleSettlementPersistedEvents.get("stale-exit-no-generation")?.type,
+          "session.exited",
+        );
+        assert.equal(
+          staleSettlementPersistedEvents.get("stale-error-no-generation")?.type,
+          "runtime.error",
+        );
+      }),
+    );
 
-  it.effect("settles a stale terminal event naming the binding's active turn", () =>
-    Effect.gen(function* () {
-      const provider = yield* ProviderService;
-      const directory = yield* ProviderSessionDirectory;
-      const threadId = asThreadId("thread-stale-terminal-matching-turn");
-      yield* staleSettlementRouting.codex.waitForRuntimeSubscribers();
+    it.effect("settles a stale terminal event naming the binding's active turn", () =>
+      Effect.gen(function* () {
+        const provider = yield* ProviderService;
+        const directory = yield* ProviderSessionDirectory;
+        const threadId = asThreadId("thread-stale-terminal-matching-turn");
+        yield* staleSettlementRouting.codex.waitForRuntimeSubscribers();
 
-      yield* provider.startSession(threadId, {
-        provider: "codex",
-        threadId,
-        cwd: "/tmp/project",
-        runtimeMode: "full-access",
-      });
-      yield* provider.sendTurn({ threadId, input: "hello", attachments: [] });
-      const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
-      const activeTurnId = asRuntimePayloadRecord(binding?.runtimePayload).activeTurnId;
-      assert.equal(typeof activeTurnId, "string");
+        yield* provider.startSession(threadId, {
+          provider: "codex",
+          threadId,
+          cwd: "/tmp/project",
+          runtimeMode: "full-access",
+        });
+        yield* provider.sendTurn({ threadId, input: "hello", attachments: [] });
+        const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+        const activeTurnId = asRuntimePayloadRecord(binding?.runtimePayload).activeTurnId;
+        assert.equal(typeof activeTurnId, "string");
 
-      // A stale terminal event that still names the binding's active turn is
-      // accepted (it settles the same turn a newer epoch has not replaced); a
-      // stale terminal event for a different turn stays dropped.
-      staleSettlementRouting.codex.emit({
-        type: "turn.aborted",
-        eventId: asEventId("stale-abort-matching-turn"),
-        provider: "codex",
-        threadId,
-        turnId: TurnId.makeUnsafe(String(activeTurnId)),
-        createdAt: "2026-07-14T14:00:00.000Z",
-        lifecycleGeneration: "old-generation",
-        payload: { reason: "late abort for the bound turn" },
-      });
-      staleSettlementRouting.codex.emit({
-        type: "turn.aborted",
-        eventId: asEventId("stale-abort-other-turn"),
-        provider: "codex",
-        threadId,
-        turnId: TurnId.makeUnsafe("turn-some-other"),
-        createdAt: "2026-07-14T14:00:01.000Z",
-        lifecycleGeneration: "old-generation",
-        payload: { reason: "late abort for a different turn" },
-      });
+        // A stale terminal event that still names the binding's active turn is
+        // accepted (it settles the same turn a newer epoch has not replaced); a
+        // stale terminal event for a different turn stays dropped.
+        staleSettlementRouting.codex.emit({
+          type: "turn.aborted",
+          eventId: asEventId("stale-abort-matching-turn"),
+          provider: "codex",
+          threadId,
+          turnId: TurnId.makeUnsafe(String(activeTurnId)),
+          createdAt: "2026-07-14T14:00:00.000Z",
+          lifecycleGeneration: "old-generation",
+          payload: { reason: "late abort for the bound turn" },
+        });
+        staleSettlementRouting.codex.emit({
+          type: "turn.aborted",
+          eventId: asEventId("stale-abort-other-turn"),
+          provider: "codex",
+          threadId,
+          turnId: TurnId.makeUnsafe("turn-some-other"),
+          createdAt: "2026-07-14T14:00:01.000Z",
+          lifecycleGeneration: "old-generation",
+          payload: { reason: "late abort for a different turn" },
+        });
 
-      yield* waitUntil(
-        () => staleSettlementPersistedEvents.has("stale-abort-matching-turn"),
-        500,
-        10,
-        "matching stale turn.aborted to be persisted",
-      );
-      const settledBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
-      assert.equal(asRuntimePayloadRecord(settledBinding?.runtimePayload).activeTurnId, null);
-      assert.equal(settledBinding?.status, "stopped");
-      assert.equal(staleSettlementPersistedEvents.has("stale-abort-other-turn"), false);
-    }),
-  );
+        yield* waitUntil(
+          () => staleSettlementPersistedEvents.has("stale-abort-matching-turn"),
+          500,
+          10,
+          "matching stale turn.aborted to be persisted",
+        );
+        const settledBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+        assert.equal(asRuntimePayloadRecord(settledBinding?.runtimePayload).activeTurnId, null);
+        assert.equal(settledBinding?.status, "stopped");
+        assert.equal(staleSettlementPersistedEvents.has("stale-abort-other-turn"), false);
+      }),
+    );
 
-  it.effect("recovers instead of routing into a session whose binding generation is stale", () =>
-    Effect.gen(function* () {
-      const provider = yield* ProviderService;
-      const directory = yield* ProviderSessionDirectory;
-      const threadId = asThreadId("thread-stale-binding-routing");
-      yield* staleSettlementRouting.codex.waitForRuntimeSubscribers();
+    it.effect("recovers instead of routing into a session whose binding generation is stale", () =>
+      Effect.gen(function* () {
+        const provider = yield* ProviderService;
+        const directory = yield* ProviderSessionDirectory;
+        const threadId = asThreadId("thread-stale-binding-routing");
+        yield* staleSettlementRouting.codex.waitForRuntimeSubscribers();
 
-      yield* provider.startSession(threadId, {
-        provider: "codex",
-        threadId,
-        cwd: "/tmp/project",
-        runtimeMode: "full-access",
-      });
-      // Rotate the runtime generation (as a stop does), keep a live adapter
-      // session around (the zombie), and rewind the persisted binding to the
-      // old generation — a turn send must not fast-path into that session,
-      // whose events the stale-generation gate would reject.
-      assert.equal(typeof provider.stopRuntimeSession, "function");
-      if (!provider.stopRuntimeSession) assert.fail("Expected stopRuntimeSession");
-      yield* provider.stopRuntimeSession({ threadId });
-      yield* directory.upsert({
-        threadId,
-        provider: "codex",
-        status: "running",
-        lifecycleGeneration: "old-generation",
-        resumeCursor: { opaque: `resume-${String(threadId)}` },
-        runtimePayload: { activeTurnId: null },
-      });
-      yield* staleSettlementRouting.codex.startSession({
-        threadId,
-        provider: "codex",
-        cwd: "/tmp/project",
-        runtimeMode: "full-access",
-      });
+        yield* provider.startSession(threadId, {
+          provider: "codex",
+          threadId,
+          cwd: "/tmp/project",
+          runtimeMode: "full-access",
+        });
+        // Rotate the runtime generation (as a stop does), keep a live adapter
+        // session around (the zombie), and rewind the persisted binding to the
+        // old generation — a turn send must not fast-path into that session,
+        // whose events the stale-generation gate would reject.
+        assert.equal(typeof provider.stopRuntimeSession, "function");
+        if (!provider.stopRuntimeSession) assert.fail("Expected stopRuntimeSession");
+        yield* provider.stopRuntimeSession({ threadId });
+        yield* directory.upsert({
+          threadId,
+          provider: "codex",
+          status: "running",
+          lifecycleGeneration: "old-generation",
+          resumeCursor: { opaque: `resume-${String(threadId)}` },
+          runtimePayload: { activeTurnId: null },
+        });
+        yield* staleSettlementRouting.codex.startSession({
+          threadId,
+          provider: "codex",
+          cwd: "/tmp/project",
+          runtimeMode: "full-access",
+        });
 
-      const sendCallsBefore = staleSettlementRouting.codex.sendTurn.mock.calls.length;
-      yield* provider.sendTurn({ threadId, input: "after the wedge", attachments: [] });
-      assert.equal(staleSettlementRouting.codex.sendTurn.mock.calls.length, sendCallsBefore + 1);
+        const sendCallsBefore = staleSettlementRouting.codex.sendTurn.mock.calls.length;
+        yield* provider.sendTurn({ threadId, input: "after the wedge", attachments: [] });
+        assert.equal(staleSettlementRouting.codex.sendTurn.mock.calls.length, sendCallsBefore + 1);
 
-      // Recovery re-adopts the persisted generation, so the still-live
-      // session's events become visible again instead of being dropped.
-      staleSettlementRouting.codex.emit({
-        type: "content.delta",
-        eventId: asEventId("stale-binding-delta"),
-        provider: "codex",
-        threadId,
-        createdAt: "2026-07-14T14:00:00.000Z",
-        lifecycleGeneration: "old-generation",
-        payload: { streamKind: "assistant_text", delta: "visible again" },
-      });
-      yield* waitUntil(
-        () => staleSettlementPersistedEvents.has("stale-binding-delta"),
-        500,
-        10,
-        "delta from the re-adopted generation to be persisted",
-      );
-    }),
-  );
-});
+        // Recovery re-adopts the persisted generation, so the still-live
+        // session's events become visible again instead of being dropped.
+        staleSettlementRouting.codex.emit({
+          type: "content.delta",
+          eventId: asEventId("stale-binding-delta"),
+          provider: "codex",
+          threadId,
+          createdAt: "2026-07-14T14:00:00.000Z",
+          lifecycleGeneration: "old-generation",
+          payload: { streamKind: "assistant_text", delta: "visible again" },
+        });
+        yield* waitUntil(
+          () => staleSettlementPersistedEvents.has("stale-binding-delta"),
+          500,
+          10,
+          "delta from the re-adopted generation to be persisted",
+        );
+      }),
+    );
+  });
 
   it.effect("serializes overlapping same-provider and cross-provider starts", () =>
     Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -924,6 +924,192 @@ routing.layer("ProviderServiceLive routing", (it) => {
     }),
   );
 
+  const staleSettlementPersistedEvents = new Map<string, ProviderRuntimeEvent>();
+  const staleSettlementRouting = makeProviderServiceLayer({
+    persistRuntimeEvent: (event) =>
+      Effect.suspend(() => {
+        staleSettlementPersistedEvents.set(String(event.eventId), event);
+        return Effect.succeed({ sequence: staleSettlementPersistedEvents.size, event });
+      }),
+    runtimeEventRetryBaseDelayMs: 1,
+    runtimeEventRetryMaxDelayMs: 1,
+  });
+
+  staleSettlementRouting.layer("ProviderServiceLive stale-generation settlement", (it) => {
+    it.effect("processes stale terminal events when no lifecycle generation is current", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const threadId = asThreadId("thread-stale-terminal-no-generation");
+      yield* staleSettlementRouting.codex.waitForRuntimeSubscribers();
+
+      // A thread with no current lifecycle generation (retired/stopped runtime)
+      // must still accept the old session's terminal events: they are the only
+      // signal left that can settle the binding and projection. Non-terminal
+      // stale events stay dropped.
+      staleSettlementRouting.codex.emit({
+        type: "content.delta",
+        eventId: asEventId("stale-delta-no-generation"),
+        provider: "codex",
+        threadId,
+        createdAt: "2026-07-14T14:00:00.000Z",
+        lifecycleGeneration: "old-generation",
+        payload: { streamKind: "assistant_text", delta: "invisible" },
+      });
+      staleSettlementRouting.codex.emit({
+        type: "session.exited",
+        eventId: asEventId("stale-exit-no-generation"),
+        provider: "codex",
+        threadId,
+        createdAt: "2026-07-14T14:00:01.000Z",
+        lifecycleGeneration: "old-generation",
+        payload: { reason: "late old-runtime exit", recoverable: false, exitKind: "error" },
+      });
+      staleSettlementRouting.codex.emit({
+        type: "runtime.error",
+        eventId: asEventId("stale-error-no-generation"),
+        provider: "codex",
+        threadId,
+        createdAt: "2026-07-14T14:00:02.000Z",
+        lifecycleGeneration: "old-generation",
+        payload: {
+          message: "OpenCode server exited unexpectedly (130).",
+          class: "transport_error",
+        },
+      });
+
+      yield* waitUntil(
+        () => staleSettlementPersistedEvents.has("stale-exit-no-generation"),
+        500,
+        10,
+        "stale session.exited to be persisted",
+      );
+      assert.equal(staleSettlementPersistedEvents.has("stale-delta-no-generation"), false);
+      assert.equal(
+        staleSettlementPersistedEvents.get("stale-exit-no-generation")?.type,
+        "session.exited",
+      );
+      assert.equal(
+        staleSettlementPersistedEvents.get("stale-error-no-generation")?.type,
+        "runtime.error",
+      );
+    }),
+  );
+
+  it.effect("settles a stale terminal event naming the binding's active turn", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-stale-terminal-matching-turn");
+      yield* staleSettlementRouting.codex.waitForRuntimeSubscribers();
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        cwd: "/tmp/project",
+        runtimeMode: "full-access",
+      });
+      yield* provider.sendTurn({ threadId, input: "hello", attachments: [] });
+      const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      const activeTurnId = asRuntimePayloadRecord(binding?.runtimePayload).activeTurnId;
+      assert.equal(typeof activeTurnId, "string");
+
+      // A stale terminal event that still names the binding's active turn is
+      // accepted (it settles the same turn a newer epoch has not replaced); a
+      // stale terminal event for a different turn stays dropped.
+      staleSettlementRouting.codex.emit({
+        type: "turn.aborted",
+        eventId: asEventId("stale-abort-matching-turn"),
+        provider: "codex",
+        threadId,
+        turnId: TurnId.makeUnsafe(String(activeTurnId)),
+        createdAt: "2026-07-14T14:00:00.000Z",
+        lifecycleGeneration: "old-generation",
+        payload: { reason: "late abort for the bound turn" },
+      });
+      staleSettlementRouting.codex.emit({
+        type: "turn.aborted",
+        eventId: asEventId("stale-abort-other-turn"),
+        provider: "codex",
+        threadId,
+        turnId: TurnId.makeUnsafe("turn-some-other"),
+        createdAt: "2026-07-14T14:00:01.000Z",
+        lifecycleGeneration: "old-generation",
+        payload: { reason: "late abort for a different turn" },
+      });
+
+      yield* waitUntil(
+        () => staleSettlementPersistedEvents.has("stale-abort-matching-turn"),
+        500,
+        10,
+        "matching stale turn.aborted to be persisted",
+      );
+      const settledBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      assert.equal(asRuntimePayloadRecord(settledBinding?.runtimePayload).activeTurnId, null);
+      assert.equal(settledBinding?.status, "stopped");
+      assert.equal(staleSettlementPersistedEvents.has("stale-abort-other-turn"), false);
+    }),
+  );
+
+  it.effect("recovers instead of routing into a session whose binding generation is stale", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-stale-binding-routing");
+      yield* staleSettlementRouting.codex.waitForRuntimeSubscribers();
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        cwd: "/tmp/project",
+        runtimeMode: "full-access",
+      });
+      // Rotate the runtime generation (as a stop does), keep a live adapter
+      // session around (the zombie), and rewind the persisted binding to the
+      // old generation — a turn send must not fast-path into that session,
+      // whose events the stale-generation gate would reject.
+      assert.equal(typeof provider.stopRuntimeSession, "function");
+      if (!provider.stopRuntimeSession) assert.fail("Expected stopRuntimeSession");
+      yield* provider.stopRuntimeSession({ threadId });
+      yield* directory.upsert({
+        threadId,
+        provider: "codex",
+        status: "running",
+        lifecycleGeneration: "old-generation",
+        resumeCursor: { opaque: `resume-${String(threadId)}` },
+        runtimePayload: { activeTurnId: null },
+      });
+      yield* staleSettlementRouting.codex.startSession({
+        threadId,
+        provider: "codex",
+        cwd: "/tmp/project",
+        runtimeMode: "full-access",
+      });
+
+      const sendCallsBefore = staleSettlementRouting.codex.sendTurn.mock.calls.length;
+      yield* provider.sendTurn({ threadId, input: "after the wedge", attachments: [] });
+      assert.equal(staleSettlementRouting.codex.sendTurn.mock.calls.length, sendCallsBefore + 1);
+
+      // Recovery re-adopts the persisted generation, so the still-live
+      // session's events become visible again instead of being dropped.
+      staleSettlementRouting.codex.emit({
+        type: "content.delta",
+        eventId: asEventId("stale-binding-delta"),
+        provider: "codex",
+        threadId,
+        createdAt: "2026-07-14T14:00:00.000Z",
+        lifecycleGeneration: "old-generation",
+        payload: { streamKind: "assistant_text", delta: "visible again" },
+      });
+      yield* waitUntil(
+        () => staleSettlementPersistedEvents.has("stale-binding-delta"),
+        500,
+        10,
+        "delta from the re-adopted generation to be persisted",
+      );
+    }),
+  );
+});
+
   it.effect("serializes overlapping same-provider and cross-provider starts", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService;

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -290,6 +290,21 @@ function hasResumeCursor(value: unknown): boolean {
   return value !== null && value !== undefined;
 }
 
+/**
+ * True for events that settle a turn/session lifecycle (as opposed to stream
+ * or item-level events). Terminal events are the only stale-generation events
+ * that may still be processed: they are the sole signal that can settle a
+ * thread whose runtime died after its lifecycle generation was rotated away.
+ */
+function isTerminalRuntimeEvent(event: ProviderRuntimeEvent): boolean {
+  return (
+    event.type === "turn.completed" ||
+    event.type === "turn.aborted" ||
+    event.type === "session.exited" ||
+    event.type === "runtime.error"
+  );
+}
+
 function runtimeStatusForEvent(
   event: ProviderRuntimeEvent,
   activeTurnId?: unknown,
@@ -1053,7 +1068,20 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             event.lifecycleGeneration !== undefined &&
             binding.lifecycleGeneration !== event.lifecycleGeneration
           ) {
-            return;
+            // The pump gate lets a stale terminal event through only when it
+            // can safely settle the thread: no current generation exists, or
+            // the event still names the turn the binding has active. Mirror
+            // that acceptance here, otherwise the accepted event is journaled
+            // and published but the durable binding keeps the dead turn active
+            // forever and the thread stays a reconciliation candidate.
+            const staleTerminalSettlesThread =
+              isTerminalRuntimeEvent(event) &&
+              (lifecycle.currentGeneration(event.threadId) === undefined ||
+                (event.turnId !== undefined &&
+                  runtimeActiveTurnId(binding.runtimePayload) === String(event.turnId)));
+            if (!staleTerminalSettlesThread) {
+              return;
+            }
           }
 
           const currentActiveTurnId = runtimeActiveTurnId(binding.runtimePayload);
@@ -1174,39 +1202,95 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     const processRuntimeEvent = (event: ProviderRuntimeEvent): Effect.Effect<void, unknown> =>
       Effect.uninterruptible(
         Effect.suspend(() => {
+          const journalAndPublish = (acceptedEvent: ProviderRuntimeEvent) =>
+            persistCanonicalRuntimeEvent(acceptedEvent).pipe(
+              Effect.flatMap((persisted) =>
+                Effect.sync(() => {
+                  if (acceptedEvent.type === "turn.started") {
+                    reconcileRuntimeIdleTimer(acceptedEvent);
+                  }
+                }).pipe(
+                  Effect.andThen(updateSessionBindingFromRuntimeEvent(acceptedEvent)),
+                  Effect.andThen(publishRuntimeEvent(acceptedEvent, persisted)),
+                  Effect.andThen(scheduleRetiredGatewaySessionRecovery(acceptedEvent)),
+                ),
+              ),
+            );
+          const canonicalEvent = event;
           if (
             event.lifecycleGeneration !== undefined &&
             lifecycle.currentGeneration(event.threadId) !== event.lifecycleGeneration
           ) {
-            // Warn, not debug: a persistent mismatch silently discards every
-            // runtime event for the thread — the provider runs, the UI shows
-            // nothing, and the runtime reconciler later settles the turn as
-            // interrupted. This log line is the only way to see it happening.
-            return Effect.logWarning("provider.session.stale_generation_event_ignored", {
-              threadId: event.threadId,
-              provider: event.provider,
-              eventType: event.type,
-              eventLifecycleGeneration: event.lifecycleGeneration,
-              currentLifecycleGeneration: lifecycle.currentGeneration(event.threadId),
-            });
+            const currentGeneration = lifecycle.currentGeneration(event.threadId);
+            // A stale-generation event is normally noise from a superseded
+            // session, but terminal events are the exception: they are the
+            // only signal that can settle a turn whose runtime died after its
+            // generation was rotated or retired (a stop, a recovery, or an
+            // idle retire). Dropping them strands the thread "working" with a
+            // dead runtime until the reconciler or an app restart intervenes,
+            // and silently discards the very error that explains the death.
+            //
+            // A stale terminal event is safe to let through when either:
+            //  - no current generation exists (nothing newer can be corrupted
+            //    by settling the old session's state), or
+            //  - the event still names the turn the binding considers active
+            //    (a newer epoch has not started a different turn, so settling
+            //    this turn cannot clobber newer state).
+            const staleTerminalIsSettling =
+              isTerminalRuntimeEvent(event) &&
+              (currentGeneration === undefined || event.turnId !== undefined);
+            if (!staleTerminalIsSettling) {
+              // Warn, not debug: a persistent mismatch silently discards every
+              // runtime event for the thread — the provider runs, the UI shows
+              // nothing, and the runtime reconciler later settles the turn as
+              // interrupted. This log line is the only way to see it happening.
+              return Effect.logWarning("provider.session.stale_generation_event_ignored", {
+                threadId: event.threadId,
+                provider: event.provider,
+                eventType: event.type,
+                eventLifecycleGeneration: event.lifecycleGeneration,
+                currentLifecycleGeneration: currentGeneration,
+              });
+            }
+            if (currentGeneration !== undefined) {
+              // A newer generation exists: only accept the stale terminal event
+              // when it still names the turn the binding has active. If the
+              // binding already moved on (or is gone), keep dropping it.
+              return directory.getBinding(event.threadId).pipe(
+                Effect.flatMap((maybeBinding) => {
+                  const binding = Option.getOrUndefined(maybeBinding);
+                  const boundActiveTurnId = binding
+                    ? runtimeActiveTurnId(binding.runtimePayload)
+                    : undefined;
+                  if (binding === undefined || boundActiveTurnId !== String(event.turnId)) {
+                    return Effect.logWarning(
+                      "provider.session.stale_generation_event_ignored",
+                      {
+                        threadId: event.threadId,
+                        provider: event.provider,
+                        eventType: event.type,
+                        eventLifecycleGeneration: event.lifecycleGeneration,
+                        currentLifecycleGeneration: currentGeneration,
+                      },
+                    );
+                  }
+                  return Effect.logInfo(
+                    "provider.session.stale_generation_terminal_event_accepted",
+                    {
+                      threadId: event.threadId,
+                      provider: event.provider,
+                      eventType: event.type,
+                      eventLifecycleGeneration: event.lifecycleGeneration,
+                      currentLifecycleGeneration: currentGeneration,
+                    },
+                  ).pipe(Effect.andThen(() => journalAndPublish(canonicalEvent)));
+                }),
+              );
+            }
+            // No current generation and the event is terminal: fall through so
+            // the stale session's exit/error settles the binding and projection.
           }
-          const canonicalEvent = event;
-          // Journal before mutating lifecycle/task state. If durable persistence
-          // fails, the supervised pump retries the same event while its source
-          // generation is still current and no recovery waiter has been released.
-          return persistCanonicalRuntimeEvent(canonicalEvent).pipe(
-            Effect.flatMap((persisted) =>
-              Effect.sync(() => {
-                if (canonicalEvent.type === "turn.started") {
-                  reconcileRuntimeIdleTimer(canonicalEvent);
-                }
-              }).pipe(
-                Effect.andThen(updateSessionBindingFromRuntimeEvent(canonicalEvent)),
-                Effect.andThen(publishRuntimeEvent(canonicalEvent, persisted)),
-                Effect.andThen(scheduleRetiredGatewaySessionRecovery(canonicalEvent)),
-              ),
-            ),
-          );
+          return journalAndPublish(canonicalEvent);
         }),
       );
 
@@ -1490,7 +1574,22 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           runtimePayloadRecord(binding.runtimePayload)[
             AGENT_GATEWAY_CREDENTIAL_ROTATION_REQUIRED
           ] === true;
-        if (hasActiveSession && (!input.allowRecovery || !requiresCredentialRotation)) {
+        // A live adapter session whose persisted generation no longer matches
+        // the thread's current generation is a zombie: its runtime events are
+        // rejected by the stale-generation gate, so a turn routed into it can
+        // produce no visible output and the thread appears wedged. Recovery-
+        // capable callers (turn sends) must replace it instead of fast-pathing
+        // into it. Control-plane callers (interrupts, responses) keep routing
+        // to the live session — stopping a wedged runtime is the user's escape
+        // hatch and must keep working.
+        const bindingMatchesCurrentGeneration =
+          binding.lifecycleGeneration === undefined ||
+          binding.lifecycleGeneration === lifecycle.currentGeneration(input.threadId);
+        if (
+          hasActiveSession &&
+          (!input.allowRecovery ||
+            (bindingMatchesCurrentGeneration && !requiresCredentialRotation))
+        ) {
           return {
             adapter,
             isActive: true,

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -1263,16 +1263,13 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                     ? runtimeActiveTurnId(binding.runtimePayload)
                     : undefined;
                   if (binding === undefined || boundActiveTurnId !== String(event.turnId)) {
-                    return Effect.logWarning(
-                      "provider.session.stale_generation_event_ignored",
-                      {
-                        threadId: event.threadId,
-                        provider: event.provider,
-                        eventType: event.type,
-                        eventLifecycleGeneration: event.lifecycleGeneration,
-                        currentLifecycleGeneration: currentGeneration,
-                      },
-                    );
+                    return Effect.logWarning("provider.session.stale_generation_event_ignored", {
+                      threadId: event.threadId,
+                      provider: event.provider,
+                      eventType: event.type,
+                      eventLifecycleGeneration: event.lifecycleGeneration,
+                      currentLifecycleGeneration: currentGeneration,
+                    });
                   }
                   return Effect.logInfo(
                     "provider.session.stale_generation_terminal_event_accepted",
@@ -1587,8 +1584,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           binding.lifecycleGeneration === lifecycle.currentGeneration(input.threadId);
         if (
           hasActiveSession &&
-          (!input.allowRecovery ||
-            (bindingMatchesCurrentGeneration && !requiresCredentialRotation))
+          (!input.allowRecovery || (bindingMatchesCurrentGeneration && !requiresCredentialRotation))
         ) {
           return {
             adapter,


### PR DESCRIPTION
## Summary

Provider threads whose runtime lifecycle generation was rotated or retired while the session was still alive silently discard **every runtime event the dying session emits**. The stale-generation gate in `ProviderService.processRuntimeEvent` dropped `turn.aborted` / `runtime.error` / `session.exited` wholesale whenever the event's generation did not match the in-memory current generation — including when there was **no current generation at all** (`currentLifecycleGeneration: undefined`).

This is the server-side root cause behind the "thread stuck Working / terminates without warning / cannot be interacted with afterwards" symptom family, observed with the OpenCode adapter (and reported for Antigravity in #465).

## Observed failure chain (production logs)

1. A turn is running; the provider session dies, or the lifecycle generation is rotated/retired by a stop, a recovery, or an idle retire.
2. The session's terminal events — the only signal that can settle the turn and surface the actual error — arrive with the old generation and are dropped as stale.
3. The thread stays "Working" with a dead runtime. The runtime reconciler later settles the projection as interrupted ("Synara recovered a stale running state") **without the error reason**, while the durable binding keeps the dead turn active. New turns route into the dead session whose events are invisible, so the thread cannot be interacted with until an app restart or archive/unarchive.

Log signature: `provider.session.stale_generation_event_ignored` with `currentLifecycleGeneration: undefined` (or a newer generation) while the thread's turn never settles.

## Changes

- **`processRuntimeEvent`** — stale terminal events are now accepted when they can safely settle the thread:
  - no current generation exists (nothing newer can be corrupted), or
  - the event's `turnId` still matches the turn the binding has active (a newer epoch has not replaced it).
  - Non-terminal stale events (content deltas, item lifecycle, `turn.started`, …) are still dropped with the existing warning, and stale terminal events for a *different* turn are still dropped.
- **`updateSessionBindingFromRuntimeEvent`** — mirrors the same acceptance so an accepted stale terminal event actually settles the durable binding (clears the dead `activeTurnId`, records `lastError`, flips status) instead of being journaled/published and then ignored by the inner generation check.
- **`resolveRoutableSession`** — turn-sending callers no longer fast-path into a live adapter session whose persisted lifecycle generation does not match the thread's current generation; they go through session recovery, which re-adopts the persisted generation so a still-live session's events become visible again (or replaces the session). Control-plane callers (`interruptTurn`, `respondTo*`) keep routing to the live session so Stop always works even on a wedged runtime.

## Tests

Three regression tests in `ProviderService.test.ts`:

1. Stale **terminal** events are processed (journaled) when no lifecycle generation is current, while stale non-terminal events stay dropped.
2. A stale terminal event naming the binding's active turn settles the binding (active turn cleared, status stopped); a stale terminal event for a different turn stays dropped.
3. A turn send against a generation-stale binding goes through recovery and re-adopts the generation so the session's events flow again.

Existing behavior preserved: the pre-existing test asserting a stale `session.exited` is ignored while a **newer** session is running still passes.

## Verification

- `tsc --noEmit` clean (apps/server)
- Full server test suite: **3823 passed / 16 skipped / 0 failed**

## Related

- Fixes the same symptom family as #465 (Antigravity flavor) at the server layer, provider-agnostic
- Complements #476 (lifecycle recovery hardening), which does not touch the stale-generation gate
- Adjacent to the runtime-event quarantine fixes #630 / #667 (event *content* issues) — this PR is about event *attribution* issues