### PR TITLE
Preview HTML files in the file pane instead of source

### DIFF
--- a/apps/web/src/components/EditorWorkspaceView.test.tsx
+++ b/apps/web/src/components/EditorWorkspaceView.test.tsx
@@ -372,6 +372,78 @@ describe("EditorWorkspaceView", () => {
     expect(markup).toContain('aria-label="Editor options"');
   });
 
+  it("shows the HTML source/preview toggle when an HTML file is selected", () => {
+    const queryClient = new QueryClient();
+    const markup = renderToStaticMarkup(
+      <QueryClientProvider client={queryClient}>
+        <EditorWorkspaceView
+          workspaceRoot="/Users/tester/project"
+          projectName="project"
+          selectedFilePath="decks/finance_deck.html"
+          expandedDirectories={new Set()}
+          centerMode="file"
+          diffFiles={[]}
+          selectedDiffFilePath={null}
+          diffPanel={<div>Diff panel</div>}
+          chatPanel={<div>Chat panel</div>}
+          onSelectFile={vi.fn()}
+          onSelectDiffFile={vi.fn()}
+          onToggleDirectory={vi.fn()}
+          onCenterModeChange={vi.fn()}
+          onExitEditorView={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(markup).toContain('aria-label="File path"');
+    expect(markup).toContain("finance_deck.html");
+    expect(markup).toContain('aria-label="HTML view"');
+    expect(markup).not.toContain('aria-label="Markdown view"');
+  });
+
+  it("renders HTML files as a page preview instead of source", () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(
+      projectQueryKeys.readFile("/Users/tester/project", "decks/finance_deck.html"),
+      {
+        relativePath: "decks/finance_deck.html",
+        contents: "<html><body><h1>Quarterly review</h1></body></html>",
+        truncated: false,
+        version: "1",
+        encoding: "utf8",
+        lineEnding: "lf",
+      },
+    );
+    const markup = renderToStaticMarkup(
+      <QueryClientProvider client={queryClient}>
+        <EditorWorkspaceView
+          workspaceRoot="/Users/tester/project"
+          projectName="project"
+          selectedFilePath="decks/finance_deck.html"
+          expandedDirectories={new Set()}
+          centerMode="file"
+          diffFiles={[]}
+          selectedDiffFilePath={null}
+          diffPanel={<div>Diff panel</div>}
+          chatPanel={<div>Chat panel</div>}
+          onSelectFile={vi.fn()}
+          onSelectDiffFile={vi.fn()}
+          onToggleDirectory={vi.fn()}
+          onCenterModeChange={vi.fn()}
+          onExitEditorView={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(markup).toContain("<iframe");
+    expect(markup).toContain('sandbox="allow-scripts"');
+    expect(markup).toContain("Quarterly review");
+    expect(markup).toContain("editor-html-preview");
+    expect(markup).not.toContain("editor-file-viewer__plain");
+    expect(markup).not.toContain("editor-file-viewer__highlight");
+    expect(markup).not.toContain('aria-label="Edit decks/finance_deck.html"');
+  });
+
   it("renders a search item in the activity bar below files and diff", () => {
     const queryClient = new QueryClient();
     const markup = renderToStaticMarkup(

--- a/apps/web/src/components/HtmlFilePreview.tsx
+++ b/apps/web/src/components/HtmlFilePreview.tsx
@@ -1,0 +1,17 @@
+// FILE: HtmlFilePreview.tsx
+// Purpose: Sandboxed in-pane rendering of workspace HTML files so clicking a
+//          `.html` / `.htm` file shows the page instead of source.
+// Layer: Web chat/editor file-preview component
+// Exports: HtmlFilePreview
+
+export function HtmlFilePreview(props: { contents: string; title: string }) {
+  return (
+    <iframe
+      className="editor-html-preview"
+      title={props.title}
+      sandbox="allow-scripts"
+      referrerPolicy="no-referrer"
+      srcDoc={props.contents}
+    />
+  );
+}

--- a/apps/web/src/components/WorkspaceFilePreview.path.test.ts
+++ b/apps/web/src/components/WorkspaceFilePreview.path.test.ts
@@ -1,0 +1,24 @@
+// FILE: WorkspaceFilePreview.path.test.ts
+// Purpose: Guards which file extensions open as rendered markdown/HTML previews.
+// Layer: Focused unit tests
+
+import { describe, expect, it } from "vitest";
+
+import { isHtmlPreviewablePath, isMarkdownPreviewablePath } from "./WorkspaceFilePreview";
+
+describe("isHtmlPreviewablePath", () => {
+  it("matches html and htm files regardless of case", () => {
+    expect(isHtmlPreviewablePath("decks/finance_deck.html")).toBe(true);
+    expect(isHtmlPreviewablePath("index.HTM")).toBe(true);
+    expect(isHtmlPreviewablePath("page.html.bak")).toBe(false);
+    expect(isHtmlPreviewablePath("README.md")).toBe(false);
+  });
+});
+
+describe("isMarkdownPreviewablePath", () => {
+  it("matches markdown extensions and not HTML", () => {
+    expect(isMarkdownPreviewablePath("docs/README.md")).toBe(true);
+    expect(isMarkdownPreviewablePath("notes.mdx")).toBe(true);
+    expect(isMarkdownPreviewablePath("deck.html")).toBe(false);
+  });
+});

--- a/apps/web/src/components/WorkspaceFilePreview.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.tsx
@@ -1,9 +1,9 @@
 // FILE: WorkspaceFilePreview.tsx
 // Purpose: Shared single-file preview (code with syntax highlighting, parsed
-//          markdown, images, PDFs) for workspace files plus absolute local
-//          file references reused by editor and right-dock panes.
+//          markdown, rendered HTML, images, PDFs) for workspace files plus
+//          absolute local file references reused by editor and right-dock panes.
 // Layer: Web chat presentation component
-// Exports: WorkspaceFilePreview, isMarkdownPreviewablePath
+// Exports: WorkspaceFilePreview, isMarkdownPreviewablePath, isHtmlPreviewablePath
 
 import type {
   ProjectFileEncoding,
@@ -66,15 +66,22 @@ import { useFileLineCommenting } from "./chat/useFileLineCommenting";
 import { WorkspaceFilePreviewHeader } from "./chat/WorkspaceFilePreviewHeader";
 import { TranscriptSelectionAction } from "./chat/TranscriptSelectionAction";
 import { useCodeSelectionAction } from "./chat/useCodeSelectionAction";
+import { HtmlFilePreview } from "./HtmlFilePreview";
 import { LocalImagePreview } from "./LocalImagePreview";
 import { PdfFilePreview } from "./PdfFilePreview";
 import { Skeleton } from "./ui/skeleton";
 
 const MARKDOWN_PREVIEW_EXTENSIONS = new Set([".markdown", ".md", ".mdx"]);
+const HTML_PREVIEW_EXTENSIONS = new Set([".html", ".htm"]);
 
 export function isMarkdownPreviewablePath(filePath: string): boolean {
   const extension = lowerCaseExtensionOf(filePath);
   return extension !== null && MARKDOWN_PREVIEW_EXTENSIONS.has(extension);
+}
+
+export function isHtmlPreviewablePath(filePath: string): boolean {
+  const extension = lowerCaseExtensionOf(filePath);
+  return extension !== null && HTML_PREVIEW_EXTENSIONS.has(extension);
 }
 
 function parentDirectoryFromPath(path: string): string | null {
@@ -296,8 +303,8 @@ export interface WorkspaceFilePreviewProps {
   filePath: string | null;
   /**
    * Initial markdown render mode per file: the dock opens markdown already
-   * parsed, the editor surface stays source-first. The header toggle still
-   * lets the user flip either way.
+   * parsed, the editor surface stays source-first. HTML always opens rendered.
+   * The header toggle still lets the user flip either way.
    */
   markdownPreviewDefault?: boolean;
   /** Enables guarded editing for complete, supported files inside the workspace. */
@@ -396,18 +403,22 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
   const fileNeedsLocalPreviewGrant =
     filePath !== null && fileIsLocalAbsolute && !fileIsScratchBinaryPreview;
   const fileIsMarkdown = filePath !== null && isMarkdownPreviewablePath(filePath);
-  // Per-file override of the markdown-preview default. Deriving (instead of
+  const fileIsHtml = filePath !== null && isHtmlPreviewablePath(filePath);
+  // HTML is a page, so it opens rendered. Markdown stays source-first in the
+  // editor (the dock opts into parsed markdown via markdownPreviewDefault).
+  const renderedPreviewDefault = fileIsHtml ? true : markdownPreviewDefault;
+  // Per-file override of the rendered-preview default. Deriving (instead of
   // syncing state in an effect) means switching files applies the default in
   // the same render, with no stale-value flash, and the override dies with its
   // file automatically.
-  const [markdownPreviewOverride, setMarkdownPreviewOverride] = useState<{
+  const [renderedPreviewOverride, setRenderedPreviewOverride] = useState<{
     filePath: string | null;
     rendered: boolean;
   } | null>(null);
-  const markdownPreviewEnabled =
-    markdownPreviewOverride !== null && markdownPreviewOverride.filePath === filePath
-      ? markdownPreviewOverride.rendered
-      : markdownPreviewDefault;
+  const renderedPreviewEnabled =
+    renderedPreviewOverride !== null && renderedPreviewOverride.filePath === filePath
+      ? renderedPreviewOverride.rendered
+      : renderedPreviewDefault;
   const localPreviewGrantQuery = useQuery(
     projectLocalPreviewGrantQueryOptions({
       path: filePath,
@@ -486,7 +497,10 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
   }, [relocationRequestKey]);
 
   const fileContents = fileQuery.data?.contents ?? "";
-  const showMarkdownPreview = fileIsMarkdown && markdownPreviewEnabled;
+  const showMarkdownPreview = fileIsMarkdown && renderedPreviewEnabled;
+  const showHtmlPreview = fileIsHtml && renderedPreviewEnabled;
+  const showRenderedPreview = showMarkdownPreview || showHtmlPreview;
+  const renderedPreviewKind = fileIsHtml ? "html" : fileIsMarkdown ? "markdown" : null;
   const editableDocument: EditableFileDocument | null =
     props.editable &&
     workspaceRoot !== null &&
@@ -516,7 +530,7 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
   const lineCount =
     displayedFileContents.length === 0 ? 0 : displayedFileContents.split("\n").length;
   const readOnlyReason =
-    !props.editable || showMarkdownPreview || fileQuery.data === undefined
+    !props.editable || showRenderedPreview || fileQuery.data === undefined
       ? null
       : !fileIsWorkspaceRelative
         ? "Only files inside the project can be edited."
@@ -624,14 +638,14 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
   // stays read-only for references (browsing + task-list toggles only); use the
   // Source toggle in the header to get a precise selection reference.
   const readPreviewSelection = (container: HTMLElement): Omit<ChatFileReference, "path"> | null =>
-    showMarkdownPreview ? null : getSelectionWithin(container);
+    showRenderedPreview ? null : getSelectionWithin(container);
   const commitPreviewSelection = (selection: Omit<ChatFileReference, "path">) => {
     if (filePath) {
       onReferenceInChat?.({ path: filePath, ...selection });
     }
   };
   const previewSelectionAction = useCodeSelectionAction({
-    enabled: Boolean(onReferenceInChat && filePath) && !showMarkdownPreview && !editableDocument,
+    enabled: Boolean(onReferenceInChat && filePath) && !showRenderedPreview && !editableDocument,
     readSelection: readPreviewSelection,
     onCommit: commitPreviewSelection,
   });
@@ -640,7 +654,7 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
   // `.line` resolves to an exact line number (the rendered-markdown view
   // restructures the source and cannot map a row back to a file line).
   const lineCommentingEnabled =
-    Boolean(onCommentInChat && filePath) && !showMarkdownPreview && !editableDocument;
+    Boolean(onCommentInChat && filePath) && !showRenderedPreview && !editableDocument;
   const lineCommenting = useFileLineCommenting({
     enabled: lineCommentingEnabled,
     resetKey: filePath,
@@ -749,8 +763,8 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
       });
     void taskWriteQueueRef.current;
   };
-  const handleMarkdownPreviewChange = (rendered: boolean) => {
-    setMarkdownPreviewOverride({ filePath, rendered });
+  const handleRenderedPreviewChange = (rendered: boolean) => {
+    setRenderedPreviewOverride({ filePath, rendered });
   };
   // Toggling a task rewrites the file, so only enable it when the preview
   // holds the complete contents (writing a truncated read would corrupt it).
@@ -829,9 +843,9 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
       <WorkspaceFilePreviewHeader
         workspaceRoot={props.workspaceRoot}
         filePath={filePath}
-        isMarkdown={fileIsMarkdown}
-        markdownPreviewEnabled={showMarkdownPreview}
-        onMarkdownPreviewChange={handleMarkdownPreviewChange}
+        renderedPreviewKind={renderedPreviewKind}
+        renderedPreviewEnabled={showRenderedPreview}
+        onRenderedPreviewChange={handleRenderedPreviewChange}
         onReferenceInChat={onReferenceInChat}
         onAskWhyInChat={onAskWhyInChat}
         contentsForCopy={fileIsImage || fileQuery.data === undefined ? null : displayedFileContents}
@@ -881,7 +895,7 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
             {fileQuery.error instanceof Error ? fileQuery.error.message : "Could not read file."}
           </p>
         </PanelStateMessage>
-      ) : activeEditBuffer && editableDocument && !showMarkdownPreview ? (
+      ) : activeEditBuffer && editableDocument && !showRenderedPreview ? (
         <textarea
           className="editor-file-editor"
           aria-label={`Edit ${filePath}`}
@@ -905,13 +919,16 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
           className={cn(
             "editor-file-viewer min-h-0 flex-1 overflow-auto",
             showMarkdownPreview && "editor-file-viewer--markdown-preview",
+            showHtmlPreview && "editor-file-viewer--html-preview",
           )}
           onContextMenu={handleContentsContextMenu}
           onMouseUp={previewSelectionAction.onContainerMouseUp}
           onMouseMove={lineCommenting.onContainerMouseMove}
           onMouseLeave={lineCommenting.onContainerMouseLeave}
         >
-          {showMarkdownPreview ? (
+          {showHtmlPreview ? (
+            <HtmlFilePreview contents={displayedFileContents} title={basenameOfPath(filePath)} />
+          ) : showMarkdownPreview ? (
             <div className="editor-markdown-preview">
               <ChatMarkdown
                 text={displayedFileContents}
@@ -924,7 +941,7 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
           ) : (
             <FileContentsView path={filePath} contents={fileContents} themeName={diffThemeName} />
           )}
-          {!showMarkdownPreview && lineCount > 0 ? (
+          {!showRenderedPreview && lineCount > 0 ? (
             <span className="sr-only">{lineCount} lines</span>
           ) : null}
           {previewSelectionAction.pendingAction ? (

--- a/apps/web/src/components/chat/DockFilePane.tsx
+++ b/apps/web/src/components/chat/DockFilePane.tsx
@@ -1,6 +1,6 @@
 // FILE: DockFilePane.tsx
 // Purpose: Right-dock pane that previews one workspace file through the shared
-//          WorkspaceFilePreview. Markdown opens already parsed (rendered); the
+//          WorkspaceFilePreview. Markdown and HTML open already rendered; the
 //          shared header carries the source toggle and open-in-editor controls.
 // Layer: Chat right-dock UI
 // Exports: DockFilePane

--- a/apps/web/src/components/chat/WorkspaceFilePreviewHeader.tsx
+++ b/apps/web/src/components/chat/WorkspaceFilePreviewHeader.tsx
@@ -11,7 +11,7 @@
 //          `header-actions` inline-size query container so the "Open" control
 //          sheds its text label for an icon as the pane narrows.
 // Layer: Chat/editor file-preview UI
-// Exports: WorkspaceFilePreviewHeader
+// Exports: WorkspaceFilePreviewHeader, RenderedPreviewKind
 
 import { isWorkspaceRelativePathSafe, joinWorkspaceRelativePath } from "@synara/shared/path";
 import { Fragment, useLayoutEffect, useRef, useState } from "react";
@@ -30,14 +30,16 @@ import {
   type CollapsedBreadcrumbLayout,
 } from "./workspaceFilePreviewBreadcrumb";
 
+export type RenderedPreviewKind = "markdown" | "html";
+
 interface WorkspaceFilePreviewHeaderProps {
   workspaceRoot: string | null;
   filePath: string;
-  /** Markdown files get an inline Source/Preview segmented switcher. */
-  isMarkdown: boolean;
+  /** Markdown and HTML files get an inline Source/Preview segmented switcher. */
+  renderedPreviewKind?: RenderedPreviewKind | null;
   /** True while the rendered preview is shown; false for the source view. */
-  markdownPreviewEnabled: boolean;
-  onMarkdownPreviewChange: (rendered: boolean) => void;
+  renderedPreviewEnabled: boolean;
+  onRenderedPreviewChange: (rendered: boolean) => void;
   /** Whole-file chat actions, surfaced in the overflow menu when wired. */
   onReferenceInChat?: ((reference: ChatFileReference) => void) | undefined;
   onAskWhyInChat?: ((reference: ChatFileReference) => void) | undefined;
@@ -56,10 +58,10 @@ interface WorkspaceFilePreviewHeaderProps {
 }
 
 // Source (raw file, where selecting text yields a precise line/column chat
-// reference) vs. Preview (rendered markdown, read-only — browse + task lists).
+// reference) vs. Preview (rendered markdown/HTML, read-only for selection).
 // Ordered Source-first so the interactive mode reads as the primary surface.
 // Icon-only by design: the title tooltip + sr-only text carry the labels.
-const MARKDOWN_VIEW_SEGMENTS = [
+const PREVIEW_VIEW_SEGMENTS = [
   {
     rendered: false,
     label: "Source",
@@ -69,10 +71,32 @@ const MARKDOWN_VIEW_SEGMENTS = [
   {
     rendered: true,
     label: "Preview",
-    title: "Rendered preview — browse and toggle task lists",
+    title: "Rendered preview",
     Icon: EyeOpenIcon,
   },
 ] as const;
+
+function renderedPreviewToggleCopy(kind: RenderedPreviewKind): {
+  ariaLabel: string;
+  previewTitle: string;
+} {
+  switch (kind) {
+    case "markdown":
+      return {
+        ariaLabel: "Markdown view",
+        previewTitle: "Rendered preview — browse and toggle task lists",
+      };
+    case "html":
+      return {
+        ariaLabel: "HTML view",
+        previewTitle: "Rendered preview — view the page",
+      };
+    default: {
+      const exhaustive: never = kind;
+      return exhaustive;
+    }
+  }
+}
 
 interface BreadcrumbSegment {
   name: string;
@@ -263,6 +287,9 @@ export const WorkspaceFilePreviewHeader = function WorkspaceFilePreviewHeader(
 
   const canCopyContents = contentsForCopy != null;
   const hasOverflowMenu = canCopyContents || Boolean(onReferenceInChat || onAskWhyInChat);
+  const renderedPreviewKind = props.renderedPreviewKind ?? null;
+  const renderedPreviewCopy =
+    renderedPreviewKind === null ? null : renderedPreviewToggleCopy(renderedPreviewKind);
 
   return (
     <div
@@ -292,28 +319,29 @@ export const WorkspaceFilePreviewHeader = function WorkspaceFilePreviewHeader(
       ) : null}
 
       <div className="flex shrink-0 items-center gap-1.5">
-        {props.isMarkdown ? (
+        {renderedPreviewCopy ? (
           <div
             role="radiogroup"
-            aria-label="Markdown view"
+            aria-label={renderedPreviewCopy.ariaLabel}
             className="flex h-7 shrink-0 items-center rounded-lg bg-[var(--color-background-elevated-secondary)] p-0.5"
           >
-            {MARKDOWN_VIEW_SEGMENTS.map((segment) => {
-              const selected = segment.rendered === props.markdownPreviewEnabled;
+            {PREVIEW_VIEW_SEGMENTS.map((segment) => {
+              const selected = segment.rendered === props.renderedPreviewEnabled;
+              const title = segment.rendered ? renderedPreviewCopy.previewTitle : segment.title;
               return (
                 <button
                   key={segment.label}
                   type="button"
                   role="radio"
                   aria-checked={selected}
-                  title={segment.title}
+                  title={title}
                   className={cn(
                     "flex h-6 w-7 cursor-pointer items-center justify-center rounded-md transition-colors",
                     selected
                       ? "bg-[var(--color-background-button-secondary)] text-[var(--color-text-foreground)]"
                       : "text-muted-foreground hover:text-foreground",
                   )}
-                  onClick={() => props.onMarkdownPreviewChange(segment.rendered)}
+                  onClick={() => props.onRenderedPreviewChange(segment.rendered)}
                 >
                   <segment.Icon className="size-3.5 shrink-0" />
                   <span className="sr-only">{segment.label}</span>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1292,6 +1292,20 @@ label:has(> select#reasoning-effort) select {
   background: color-mix(in srgb, var(--background) 96%, var(--card));
 }
 
+.editor-file-viewer--html-preview {
+  overflow: hidden;
+  background: var(--color-background-surface);
+}
+
+.editor-html-preview {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  border: 0;
+  background: #fff;
+}
+
 .editor-markdown-preview {
   min-height: 100%;
   padding: 1rem;


### PR DESCRIPTION
## Summary
- Clicking a `.html` / `.htm` file in the explorer now opens a rendered page preview in the right pane, instead of syntax-highlighted source.
- The existing Source/Preview header toggle still lets you inspect or edit the HTML; Preview is the default for HTML (markdown stays source-first in the editor).
- The page is shown in a sandboxed iframe (`allow-scripts`, no same-origin), matching how markdown already has a rendered mode.

## Test plan
- [ ] Open a workspace HTML file such as a presentation deck from the file explorer and confirm the right pane shows the rendered page, not source.
- [ ] Confirm the header Source/Preview toggle still switches to syntax-highlighted (or editable) source and back.
- [ ] Open a markdown file and confirm it still defaults to source in the editor, with its own toggle unchanged.
- [ ] Open an image and a PDF and confirm those previews are unchanged.

Made with [Cursor](https://cursor.com)