### PR TITLE
fix(server): bound Codex usage archive reads

### DIFF
--- a/apps/server/src/providerUsageSnapshot.test.ts
+++ b/apps/server/src/providerUsageSnapshot.test.ts
@@ -1,0 +1,91 @@
+// FILE: providerUsageSnapshot.test.ts
+// Purpose: Verifies Codex usage scans stay bounded for large local session archives.
+// Layer: Server provider usage tests
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { readCodexSessionSummary } from "./providerUsageSnapshot";
+
+const tempDirs: string[] = [];
+
+function tokenCountLine(timestamp: string, totalTokens: number, note?: string): string {
+  return JSON.stringify({
+    timestamp,
+    ...(note ? { note } : {}),
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      info: { total_token_usage: { total_tokens: totalTokens } },
+      rate_limits: {
+        primary: { used_percent: 25, window_minutes: 300 },
+      },
+    },
+  });
+}
+
+async function makeSessionFile(contents: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "synara-provider-usage-"));
+  tempDirs.push(dir);
+  const file = path.join(dir, "rollout.jsonl");
+  await fs.writeFile(file, contents);
+  return file;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("readCodexSessionSummary", () => {
+  it("reads the latest token count from the file tail without readFile", async () => {
+    const file = await makeSessionFile(
+      [
+        tokenCountLine("2026-08-13T10:00:00.000Z", 100),
+        JSON.stringify({ type: "event_msg", payload: { type: "task_complete" } }),
+        tokenCountLine("2026-08-14T10:00:00.000Z", 250),
+        "not-json",
+      ].join("\n"),
+    );
+    const probe = await fs.open(file, "r");
+    const handlePrototype: Pick<typeof probe, "read"> = Object.getPrototypeOf(probe);
+    await probe.close();
+    const read = vi.spyOn(handlePrototype, "read");
+    const readFile = vi.spyOn(fs, "readFile");
+
+    await expect(readCodexSessionSummary(file)).resolves.toEqual({
+      timestampMs: Date.parse("2026-08-14T10:00:00.000Z"),
+      totalTokens: 250,
+      limits: [{ window: "5h", usedPercent: 25, windowDurationMins: 300 }],
+    });
+    expect(readFile).not.toHaveBeenCalled();
+    expect(read.mock.calls.every((call) => (call[2] ?? 0) <= 64 * 1024)).toBe(true);
+  });
+
+  it("parses a CRLF token record split across read chunks", async () => {
+    const tokenLine = tokenCountLine("2026-08-14T10:00:00.000Z", 250, "café 🧠");
+    const trailingLength = 64 * 1024 - Math.floor(Buffer.byteLength(tokenLine) / 2) - 2;
+    const file = await makeSessionFile(
+      `ignored\r\n${tokenLine}\r\n${"x".repeat(trailingLength)}`,
+    );
+
+    await expect(readCodexSessionSummary(file)).resolves.toMatchObject({
+      timestampMs: Date.parse("2026-08-14T10:00:00.000Z"),
+      totalTokens: 250,
+    });
+  });
+
+  it("skips an oversized trailing record without retaining it in memory", async () => {
+    const file = await makeSessionFile(
+      `${tokenCountLine("2026-08-14T10:00:00.000Z", 250)}\n${"x".repeat(2 * 1024 * 1024)}`,
+    );
+
+    await expect(readCodexSessionSummary(file)).resolves.toMatchObject({
+      timestampMs: Date.parse("2026-08-14T10:00:00.000Z"),
+      totalTokens: 250,
+    });
+  });
+});

--- a/apps/server/src/providerUsageSnapshot.ts
+++ b/apps/server/src/providerUsageSnapshot.ts
@@ -25,6 +25,8 @@ const USAGE_CACHE_TTL_MS = 30_000;
 // for heavy local usage without scanning the full historical archive every refresh.
 const MAX_RECENT_USAGE_FILES = 2_000;
 const PROVIDER_USAGE_FILE_READ_CONCURRENCY = 16;
+const CODEX_SESSION_READ_CHUNK_BYTES = 64 * 1024;
+const MAX_CODEX_SESSION_LINE_BYTES = 1024 * 1024;
 
 type UsageSnapshot = Exclude<ServerGetProviderUsageSnapshotResult, null>;
 
@@ -281,55 +283,123 @@ async function listRecentCodexSessionFiles(sessionsRoot: string): Promise<Readon
   return listRecentFiles(candidates);
 }
 
-async function readCodexSessionSummary(path: string): Promise<CodexSessionSummary | null> {
-  let fileContents: string;
+async function readFileRange(
+  handle: Awaited<ReturnType<typeof fs.open>>,
+  position: number,
+  length: number,
+): Promise<Buffer> {
+  const buffer = Buffer.allocUnsafe(length);
+  let bytesRead = 0;
+  while (bytesRead < length) {
+    const result = await handle.read(buffer, bytesRead, length - bytesRead, position + bytesRead);
+    if (result.bytesRead === 0) {
+      break;
+    }
+    bytesRead += result.bytesRead;
+  }
+  return buffer.subarray(0, bytesRead);
+}
+
+function parseCodexSessionSummaryLine(line: string): CodexSessionSummary | null {
+  if (!line.trim()) {
+    return null;
+  }
+
+  let parsed: unknown;
   try {
-    fileContents = await fs.readFile(path, "utf8");
+    parsed = JSON.parse(line);
   } catch {
     return null;
   }
 
-  const lines = fileContents.split(/\r?\n/u);
-  for (let index = lines.length - 1; index >= 0; index -= 1) {
-    const line = lines[index];
-    if (!line || !line.trim()) {
-      continue;
-    }
-
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(line);
-    } catch {
-      continue;
-    }
-
-    const record = asRecord(parsed);
-    if (!record || record.type !== "event_msg") {
-      continue;
-    }
-
-    const payload = asRecord(record.payload);
-    if (!payload || payload.type !== "token_count") {
-      continue;
-    }
-
-    const timestampMs = parseTimestampMs(record.timestamp ?? payload.timestamp);
-    if (timestampMs === null) {
-      continue;
-    }
-
-    const summary = {
-      timestampMs,
-      totalTokens: readCodexTotalTokens(payload),
-      limits: normalizeCodexUsageLimits(payload.rate_limits ?? payload.rateLimits),
-    } satisfies CodexSessionSummary;
-
-    // Codex session JSONL is chronological; only the final token_count event is
-    // needed for lifetime accounting and the latest quota snapshot per file.
-    return summary;
+  const record = asRecord(parsed);
+  if (!record || record.type !== "event_msg") {
+    return null;
   }
 
-  return null;
+  const payload = asRecord(record.payload);
+  if (!payload || payload.type !== "token_count") {
+    return null;
+  }
+
+  const timestampMs = parseTimestampMs(record.timestamp ?? payload.timestamp);
+  if (timestampMs === null) {
+    return null;
+  }
+
+  return {
+    timestampMs,
+    totalTokens: readCodexTotalTokens(payload),
+    limits: normalizeCodexUsageLimits(payload.rate_limits ?? payload.rateLimits),
+  };
+}
+
+export async function readCodexSessionSummary(path: string): Promise<CodexSessionSummary | null> {
+  let handle: Awaited<ReturnType<typeof fs.open>>;
+  try {
+    handle = await fs.open(path, "r");
+  } catch {
+    return null;
+  }
+
+  try {
+    const { size } = await handle.stat();
+    let position = size;
+    let partialLine = Buffer.alloc(0);
+    let skippingOversizedLine = false;
+
+    while (position > 0) {
+      const length = Math.min(CODEX_SESSION_READ_CHUNK_BYTES, position);
+      position -= length;
+      const bytes = await readFileRange(handle, position, length);
+      let lineEnd = bytes.length;
+
+      for (let index = bytes.length - 1; index >= 0; index -= 1) {
+        if (bytes[index] !== 0x0a) {
+          continue;
+        }
+
+        const linePrefix = bytes.subarray(index + 1, lineEnd);
+        if (skippingOversizedLine) {
+          skippingOversizedLine = false;
+        } else {
+          const lineLength = linePrefix.length + partialLine.length;
+          if (lineLength <= MAX_CODEX_SESSION_LINE_BYTES) {
+            const summary = parseCodexSessionSummaryLine(
+              Buffer.concat([linePrefix, partialLine], lineLength).toString("utf8"),
+            );
+            if (summary) {
+              return summary;
+            }
+          }
+        }
+
+        partialLine = Buffer.alloc(0);
+        lineEnd = index;
+      }
+
+      if (skippingOversizedLine) {
+        continue;
+      }
+
+      const linePrefix = bytes.subarray(0, lineEnd);
+      const lineLength = linePrefix.length + partialLine.length;
+      if (lineLength > MAX_CODEX_SESSION_LINE_BYTES) {
+        partialLine = Buffer.alloc(0);
+        skippingOversizedLine = true;
+        continue;
+      }
+      partialLine = Buffer.concat([linePrefix, partialLine], lineLength);
+    }
+
+    return skippingOversizedLine
+      ? null
+      : parseCodexSessionSummaryLine(partialLine.toString("utf8"));
+  } catch {
+    return null;
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
 }
 
 function readClaudeTotalTokens(value: unknown): number {


### PR DESCRIPTION
## What Changed

- Read Codex session JSONL files backward in 64 KiB chunks instead of loading each archive in full.
- Handle short positional reads and stop retaining malformed records above 1 MiB.
- Add regression coverage for bounded reads, chunk-boundary CRLF/UTF-8 data, and oversized trailing records.

## Why

The provider usage control can scan up to 2,000 recent Codex sessions with 16 concurrent reads. Loading every file in full makes large local archives exhaust the desktop backend heap. The backend then aborts while the Electron frontend stays open, which produces both the backend failure dialog and a misleading macOS app crash report.

The usage snapshot only needs the newest valid `token_count` record from each chronological JSONL file, so a bounded reverse scan avoids retaining unrelated transcript content.

Fixes #677

## Verification

- `bun run --cwd apps/server test src/providerUsageSnapshot.test.ts` — 3 passed
- `bun run --cwd apps/server build`
- `SHELL=/bin/zsh bun run --cwd apps/server test` — 3,823 passed, 16 skipped
- Manual archive scan: 304 recent files completed in 16 ms with 123 MB peak RSS; a 561 MB session completed in 3 ms with a 2 MB RSS increase

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI screenshots are not applicable
- [x] Interaction video is not applicable
