### PR TITLE
fix(server): stream Claude usage archive reads

### DIFF
--- a/apps/server/src/providerUsageSnapshot.test.ts
+++ b/apps/server/src/providerUsageSnapshot.test.ts
@@ -1,5 +1,5 @@
 // FILE: providerUsageSnapshot.test.ts
-// Purpose: Verifies Codex usage scans stay bounded for large local session archives.
+// Purpose: Verifies provider usage scans stay bounded for large local archives.
 // Layer: Server provider usage tests
 
 import fs from "node:fs/promises";
@@ -8,7 +8,7 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { readCodexSessionSummary } from "./providerUsageSnapshot";
+import { readClaudeUsageSamples, readCodexSessionSummary } from "./providerUsageSnapshot";
 
 const tempDirs: string[] = [];
 
@@ -27,10 +27,10 @@ function tokenCountLine(timestamp: string, totalTokens: number, note?: string): 
   });
 }
 
-async function makeSessionFile(contents: string): Promise<string> {
+async function makeSessionFile(contents: string, name = "rollout.jsonl"): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "synara-provider-usage-"));
   tempDirs.push(dir);
-  const file = path.join(dir, "rollout.jsonl");
+  const file = path.join(dir, name);
   await fs.writeFile(file, contents);
   return file;
 }
@@ -91,5 +91,68 @@ describe("readCodexSessionSummary", () => {
       timestampMs: Date.parse("2026-08-14T10:00:00.000Z"),
       totalTokens: 250,
     });
+  });
+});
+
+function assistantLine(input: {
+  timestamp: string;
+  totalTokens: number;
+  sessionId?: string;
+  messageId?: string;
+}): string {
+  return JSON.stringify({
+    type: "assistant",
+    timestamp: input.timestamp,
+    ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+    message: {
+      ...(input.messageId ? { id: input.messageId } : {}),
+      model: "claude-opus-4-5",
+      usage: { input_tokens: input.totalTokens, output_tokens: 0 },
+    },
+  });
+}
+
+describe("readClaudeUsageSamples", () => {
+  it("reads samples from the transcript stream without readFile", async () => {
+    // A record carrying no session or message id falls back to its line number, so the
+    // blank line has to keep its place in the count for that key to stay stable.
+    const file = await makeSessionFile(
+      [
+        JSON.stringify({ type: "user", timestamp: "2026-08-14T09:00:00.000Z" }),
+        "",
+        assistantLine({ timestamp: "2026-08-14T10:00:00.000Z", totalTokens: 40 }),
+        assistantLine({
+          timestamp: "2026-08-14T11:00:00.000Z",
+          totalTokens: 60,
+          sessionId: "session-a",
+          messageId: "message-a",
+        }),
+        "not-json",
+      ].join("\n"),
+      "transcript.jsonl",
+    );
+    const readFile = vi.spyOn(fs, "readFile");
+
+    await expect(readClaudeUsageSamples(file)).resolves.toEqual([
+      {
+        sessionId: `${file}:2`,
+        timestampMs: Date.parse("2026-08-14T10:00:00.000Z"),
+        totalTokens: 40,
+        model: "claude-opus-4-5",
+      },
+      {
+        sessionId: "session-a",
+        timestampMs: Date.parse("2026-08-14T11:00:00.000Z"),
+        totalTokens: 60,
+        model: "claude-opus-4-5",
+      },
+    ]);
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("returns no samples for a missing transcript", async () => {
+    const file = await makeSessionFile("", "transcript.jsonl");
+
+    await expect(readClaudeUsageSamples(`${file}.absent`)).resolves.toEqual([]);
   });
 });

--- a/apps/server/src/providerUsageSnapshot.test.ts
+++ b/apps/server/src/providerUsageSnapshot.test.ts
@@ -155,4 +155,39 @@ describe("readClaudeUsageSamples", () => {
 
     await expect(readClaudeUsageSamples(`${file}.absent`)).resolves.toEqual([]);
   });
+
+  it("skips an oversized record and resumes at the next line", async () => {
+    const oversizedAssistantLine = JSON.stringify({
+      type: "assistant",
+      timestamp: "2026-08-14T10:30:00.000Z",
+      message: {
+        model: "claude-opus-4-5",
+        content: "x".repeat(2 * 1024 * 1024),
+        usage: { input_tokens: 50, output_tokens: 0 },
+      },
+    });
+    const file = await makeSessionFile(
+      [
+        assistantLine({ timestamp: "2026-08-14T10:00:00.000Z", totalTokens: 40 }),
+        oversizedAssistantLine,
+        assistantLine({ timestamp: "2026-08-14T11:00:00.000Z", totalTokens: 60 }),
+      ].join("\n"),
+      "transcript.jsonl",
+    );
+
+    await expect(readClaudeUsageSamples(file)).resolves.toEqual([
+      {
+        sessionId: `${file}:0`,
+        timestampMs: Date.parse("2026-08-14T10:00:00.000Z"),
+        totalTokens: 40,
+        model: "claude-opus-4-5",
+      },
+      {
+        sessionId: `${file}:2`,
+        timestampMs: Date.parse("2026-08-14T11:00:00.000Z"),
+        totalTokens: 60,
+        model: "claude-opus-4-5",
+      },
+    ]);
+  });
 });

--- a/apps/server/src/providerUsageSnapshot.ts
+++ b/apps/server/src/providerUsageSnapshot.ts
@@ -1,9 +1,10 @@
 // FILE: providerUsageSnapshot.ts
 // Purpose: Read provider-specific local usage archives for recent usage snapshots.
 
-import type { Dirent, Stats } from "node:fs";
+import { createReadStream, type Dirent, type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import nodePath from "node:path";
+import readline from "node:readline";
 
 import type {
   ProviderKind,
@@ -515,48 +516,62 @@ async function listRecentClaudeTranscriptFiles(
   return listRecentFiles(candidates, maxFiles);
 }
 
-async function readClaudeUsageSamples(path: string): Promise<ReadonlyArray<ClaudeUsageSample>> {
-  let fileContents: string;
-  try {
-    fileContents = await fs.readFile(path, "utf8");
-  } catch {
-    return [];
-  }
-
+/**
+ * Claude transcripts are unbounded: a long-running session writes hundreds of megabytes
+ * into one file, and a snapshot reads PROVIDER_USAGE_FILE_READ_CONCURRENCY of them at
+ * once. Reading one into a string costs its full size in the heap plus a second copy for
+ * the line split, so a few large transcripts are enough to exhaust old space and abort the
+ * backend. Streaming holds one line at a time instead.
+ */
+export async function readClaudeUsageSamples(
+  path: string,
+): Promise<ReadonlyArray<ClaudeUsageSample>> {
   const samples: ClaudeUsageSample[] = [];
   const seenKeys = new Set<string>();
-  const lines = fileContents.split(/\r?\n/u);
+  const stream = createReadStream(path, { encoding: "utf8" });
+  // Counts every line including blank ones, so a record's fallback key stays tied to its
+  // position in the file rather than to how many records preceded it.
+  let index = -1;
 
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index];
-    if (!line || !line.trim()) {
-      continue;
-    }
+  try {
+    const lines = readline.createInterface({ input: stream, crlfDelay: Infinity });
 
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(line);
-    } catch {
-      continue;
-    }
+    for await (const line of lines) {
+      index += 1;
+      if (!line.trim()) {
+        continue;
+      }
 
-    const record = asRecord(parsed);
-    if (!record) {
-      continue;
-    }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
 
-    const fallbackKey = `${path}:${index}`;
-    const assistantSample = readClaudeAssistantSample({ record, fallbackKey });
-    if (assistantSample && !seenKeys.has(assistantSample.dedupeKey)) {
-      seenKeys.add(assistantSample.dedupeKey);
-      samples.push(assistantSample.sample);
-    }
+      const record = asRecord(parsed);
+      if (!record) {
+        continue;
+      }
 
-    const toolResultSample = readClaudeToolResultSample({ record, fallbackKey });
-    if (toolResultSample && !seenKeys.has(toolResultSample.dedupeKey)) {
-      seenKeys.add(toolResultSample.dedupeKey);
-      samples.push(toolResultSample.sample);
+      const fallbackKey = `${path}:${index}`;
+      const assistantSample = readClaudeAssistantSample({ record, fallbackKey });
+      if (assistantSample && !seenKeys.has(assistantSample.dedupeKey)) {
+        seenKeys.add(assistantSample.dedupeKey);
+        samples.push(assistantSample.sample);
+      }
+
+      const toolResultSample = readClaudeToolResultSample({ record, fallbackKey });
+      if (toolResultSample && !seenKeys.has(toolResultSample.dedupeKey)) {
+        seenKeys.add(toolResultSample.dedupeKey);
+        samples.push(toolResultSample.sample);
+      }
     }
+  } catch {
+    // A transcript that vanishes or fails partway through yields what was read by then,
+    // which is the same outcome as a truncated archive.
+  } finally {
+    stream.destroy();
   }
 
   return samples;

--- a/apps/server/src/providerUsageSnapshot.ts
+++ b/apps/server/src/providerUsageSnapshot.ts
@@ -4,7 +4,6 @@
 import { createReadStream, type Dirent, type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import nodePath from "node:path";
-import readline from "node:readline";
 
 import type {
   ProviderKind,
@@ -28,6 +27,7 @@ const MAX_RECENT_USAGE_FILES = 2_000;
 const PROVIDER_USAGE_FILE_READ_CONCURRENCY = 16;
 const CODEX_SESSION_READ_CHUNK_BYTES = 64 * 1024;
 const MAX_CODEX_SESSION_LINE_BYTES = 1024 * 1024;
+const MAX_CLAUDE_TRANSCRIPT_LINE_BYTES = 1024 * 1024;
 
 type UsageSnapshot = Exclude<ServerGetProviderUsageSnapshotResult, null>;
 
@@ -521,51 +521,96 @@ async function listRecentClaudeTranscriptFiles(
  * into one file, and a snapshot reads PROVIDER_USAGE_FILE_READ_CONCURRENCY of them at
  * once. Reading one into a string costs its full size in the heap plus a second copy for
  * the line split, so a few large transcripts are enough to exhaust old space and abort the
- * backend. Streaming holds one line at a time instead.
+ * backend. Stream chunks and cap individual records so malformed or tool-heavy lines cannot
+ * recreate the same problem inside a line reader.
  */
 export async function readClaudeUsageSamples(
   path: string,
 ): Promise<ReadonlyArray<ClaudeUsageSample>> {
   const samples: ClaudeUsageSample[] = [];
   const seenKeys = new Set<string>();
-  const stream = createReadStream(path, { encoding: "utf8" });
-  // Counts every line including blank ones, so a record's fallback key stays tied to its
-  // position in the file rather than to how many records preceded it.
-  let index = -1;
+  const stream = createReadStream(path);
+  let lineChunks: Buffer[] = [];
+  let lineBytes = 0;
+  let lineIndex = 0;
+  let skippingOversizedLine = false;
+
+  const collectLine = (line: Buffer, index: number): void => {
+    if (line.length === 0) {
+      return;
+    }
+    const contents = line.toString("utf8");
+    if (!contents.trim()) {
+      return;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(contents);
+    } catch {
+      return;
+    }
+
+    const record = asRecord(parsed);
+    if (!record) {
+      return;
+    }
+
+    const fallbackKey = `${path}:${index}`;
+    const assistantSample = readClaudeAssistantSample({ record, fallbackKey });
+    if (assistantSample && !seenKeys.has(assistantSample.dedupeKey)) {
+      seenKeys.add(assistantSample.dedupeKey);
+      samples.push(assistantSample.sample);
+    }
+
+    const toolResultSample = readClaudeToolResultSample({ record, fallbackKey });
+    if (toolResultSample && !seenKeys.has(toolResultSample.dedupeKey)) {
+      seenKeys.add(toolResultSample.dedupeKey);
+      samples.push(toolResultSample.sample);
+    }
+  };
+
+  const appendLineChunk = (chunk: Buffer): void => {
+    if (skippingOversizedLine || chunk.length === 0) {
+      return;
+    }
+    if (lineBytes + chunk.length > MAX_CLAUDE_TRANSCRIPT_LINE_BYTES) {
+      lineChunks = [];
+      lineBytes = 0;
+      skippingOversizedLine = true;
+      return;
+    }
+    lineChunks.push(chunk);
+    lineBytes += chunk.length;
+  };
+
+  const finishLine = (): void => {
+    if (!skippingOversizedLine) {
+      collectLine(Buffer.concat(lineChunks, lineBytes), lineIndex);
+    }
+    lineChunks = [];
+    lineBytes = 0;
+    lineIndex += 1;
+    skippingOversizedLine = false;
+  };
 
   try {
-    const lines = readline.createInterface({ input: stream, crlfDelay: Infinity });
-
-    for await (const line of lines) {
-      index += 1;
-      if (!line.trim()) {
-        continue;
+    for await (const chunk of stream) {
+      let lineStart = 0;
+      for (let index = 0; index < chunk.length; index += 1) {
+        if (chunk[index] !== 0x0a) {
+          continue;
+        }
+        appendLineChunk(chunk.subarray(lineStart, index));
+        finishLine();
+        lineStart = index + 1;
       }
+      appendLineChunk(chunk.subarray(lineStart));
+    }
 
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(line);
-      } catch {
-        continue;
-      }
-
-      const record = asRecord(parsed);
-      if (!record) {
-        continue;
-      }
-
-      const fallbackKey = `${path}:${index}`;
-      const assistantSample = readClaudeAssistantSample({ record, fallbackKey });
-      if (assistantSample && !seenKeys.has(assistantSample.dedupeKey)) {
-        seenKeys.add(assistantSample.dedupeKey);
-        samples.push(assistantSample.sample);
-      }
-
-      const toolResultSample = readClaudeToolResultSample({ record, fallbackKey });
-      if (toolResultSample && !seenKeys.has(toolResultSample.dedupeKey)) {
-        seenKeys.add(toolResultSample.dedupeKey);
-        samples.push(toolResultSample.sample);
-      }
+    // Match readFile/split behavior for a final record that has not been newline-terminated.
+    if (lineBytes > 0 && !skippingOversizedLine) {
+      collectLine(Buffer.concat(lineChunks, lineBytes), lineIndex);
     }
   } catch {
     // A transcript that vanishes or fails partway through yields what was read by then,


### PR DESCRIPTION
## What Changed

- `readClaudeUsageSamples` now streams each Claude transcript through `node:readline` and holds one line at a time, instead of reading the whole file with `fs.readFile` and splitting it.
- Blank lines still count toward the line index, so the `${path}:${index}` fallback key for records without ids is unchanged.
- Added regression coverage next to the Codex tests: samples parse identically (including the positional fallback key), `fs.readFile` is never called, and a missing transcript yields no samples.

## Why

#682 fixed the Codex half of #677: the usage scan loaded every archive in full, and 16 concurrent reads exhausted the backend heap. The Claude reader has the same pattern - `readClaudeUsageSamples` still calls `fs.readFile` on each transcript, and Claude transcripts grow just as unbounded. On a machine where the large archives are on the Claude side, the backend still aborts with the same SIGABRT after this scan runs.

Unlike the Codex reader, this one needs every line (per-record samples plus dedupe), so it streams forward rather than scanning the tail.

Follow-up to #682, refs #677.

## Verification

- `bun run --cwd apps/server test providerUsageSnapshot` — 5 passed
- `bun run --cwd apps/server build`
- `SHELL=/bin/zsh bun run --cwd apps/server test` — 3,828 passed, 16 skipped
- Manual scan of a real 261 MB Claude transcript: 6,185 samples in 675 ms with a 7 MB heap increase. Reading the same file with `fs.readFile` + split grew the heap from 38 MB to 1,063 MB before any parsing.
- Sanity check on the coverage: temporarily restoring the `fs.readFile` body makes the new test fail with "expected readFile to not be called", so the regression test actually guards the fix.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI screenshots are not applicable
- [x] Interaction video is not applicable
