### PR TITLE
fix(desktop): refresh the Windows taskbar icon when the app icon changes

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -86,7 +86,12 @@ import {
   isDesktopAppIcon,
   shouldUpdateDesktopAppIcon,
 } from "./desktopAppIcon";
-import { refreshWindowsTaskbarIcon } from "./windowsTaskbarIcon";
+import {
+  applyWindowsTaskbarIcon,
+  collectWindowsShortcutPaths,
+  syncWindowsShortcutIcons,
+  windowsShellIconCachePath,
+} from "./windowsTaskbarIcon";
 import {
   makeUpdateInstallPreparationCoordinator,
   type UpdateInstallPreparationAttempt,
@@ -1928,7 +1933,87 @@ function persistDesktopAppIcon(icon: DesktopAppIcon): void {
   FS.writeFileSync(DESKTOP_APP_ICON_PATH, icon, "utf8");
 }
 
-function applyDesktopAppIcon(icon: DesktopAppIcon): void {
+function windowsShortcutSearchDirectories(): string[] {
+  const appData = process.env.APPDATA?.trim() ?? "";
+  const programData =
+    process.env.ProgramData?.trim() ?? Path.join(Path.parse(OS.homedir()).root, "ProgramData");
+  return [
+    Path.join(OS.homedir(), "Desktop"),
+    Path.join(OS.homedir(), "OneDrive", "Desktop"),
+    Path.join(programData, "Microsoft", "Windows", "Start Menu", "Programs"),
+    Path.join(OS.homedir(), "..", "Public", "Desktop"),
+    ...(appData.length > 0
+      ? [
+          Path.join(appData, "Microsoft", "Windows", "Start Menu", "Programs"),
+          Path.join(
+            appData,
+            "Microsoft",
+            "Internet Explorer",
+            "Quick Launch",
+            "User Pinned",
+            "TaskBar",
+          ),
+        ]
+      : []),
+  ];
+}
+
+function syncWindowsTaskbarShortcuts(icon: DesktopAppIcon, shellIconPath: string): void {
+  const shortcutIconPath = icon === "default" ? process.execPath : shellIconPath;
+  const shortcutPaths = collectWindowsShortcutPaths({
+    directories: windowsShortcutSearchDirectories(),
+    readdir: (directory) => FS.readdirSync(directory),
+    isDirectory: (path) => {
+      try {
+        return FS.statSync(path).isDirectory();
+      } catch {
+        return false;
+      }
+    },
+  });
+  syncWindowsShortcutIcons({
+    iconPath: shortcutIconPath,
+    iconIndex: 0,
+    appId: APP_USER_MODEL_ID,
+    executablePath: process.execPath,
+    shortcutPaths,
+    readShortcut: (shortcutPath) => {
+      try {
+        return shell.readShortcutLink(shortcutPath);
+      } catch {
+        return null;
+      }
+    },
+    updateShortcut: (shortcutPath, iconPath, iconIndex) => {
+      try {
+        const current = shell.readShortcutLink(shortcutPath);
+        return shell.writeShortcutLink(shortcutPath, "update", {
+          ...current,
+          icon: iconPath,
+          iconIndex,
+        });
+      } catch {
+        return false;
+      }
+    },
+  });
+}
+
+function materializeWindowsShellIcon(icon: DesktopAppIcon, sourcePath: string): string {
+  const cacheDirectory = Path.join(STATE_DIR, "taskbar-icons");
+  FS.mkdirSync(cacheDirectory, { recursive: true });
+  const destinationPath = windowsShellIconCachePath(cacheDirectory, icon);
+  // Explorer cannot load ICOs from asar. Copy to a real path and keep a distinct
+  // file per preference so the shell icon cache cannot keep serving the previous art.
+  FS.writeFileSync(destinationPath, FS.readFileSync(sourcePath));
+  return destinationPath;
+}
+
+function applyDesktopAppIcon(
+  icon: DesktopAppIcon,
+  window: BrowserWindow | null = mainWindow,
+  options?: { reregisterTaskbarButton?: boolean },
+): void {
   if (
     process.platform !== "darwin" &&
     process.platform !== "linux" &&
@@ -1951,13 +2036,46 @@ function applyDesktopAppIcon(icon: DesktopAppIcon): void {
     app.dock?.setIcon(image);
     return;
   }
-  mainWindow?.setIcon(image);
-  // setIcon updates the window chrome and Alt-Tab artwork, but the Windows
-  // shell caches the taskbar button icon registered for the app identity, so
-  // re-register the live taskbar button to make the new icon take effect.
   if (process.platform === "win32") {
-    refreshWindowsTaskbarIcon(mainWindow);
+    let shellIconPath = iconPath;
+    try {
+      shellIconPath = materializeWindowsShellIcon(icon, iconPath);
+    } catch (error) {
+      console.warn(
+        `[desktop] Failed to materialize Windows taskbar icon: ${formatErrorMessage(error)}`,
+      );
+    }
+    try {
+      syncWindowsTaskbarShortcuts(icon, shellIconPath);
+    } catch (error) {
+      console.warn(`[desktop] Failed to sync Windows shortcut icons: ${formatErrorMessage(error)}`);
+    }
+    try {
+      applyWindowsTaskbarIcon({
+        window,
+        iconPath: shellIconPath,
+        identity: {
+          appId: APP_USER_MODEL_ID,
+          relaunchCommand: `"${process.execPath}"`,
+          relaunchDisplayName: APP_DISPLAY_NAME,
+        },
+        ...(options?.reregisterTaskbarButton === undefined
+          ? {}
+          : { reregisterTaskbarButton: options.reregisterTaskbarButton }),
+      });
+    } catch (error) {
+      console.warn(`[desktop] Failed to apply Windows taskbar icon: ${formatErrorMessage(error)}`);
+      try {
+        window?.setIcon(shellIconPath);
+      } catch (iconError) {
+        console.warn(
+          `[desktop] Failed to set Windows window icon: ${formatErrorMessage(iconError)}`,
+        );
+      }
+    }
+    return;
   }
+  window?.setIcon(image);
 }
 
 function applyInitialMacDockIcon(): void {
@@ -3964,13 +4082,23 @@ function registerIpcHandlers(): void {
 function getIconOption(): { icon: string } | Record<string, never> {
   if (process.platform === "darwin") return {}; // macOS uses .icns from app bundle
   if (process.platform !== "linux" && process.platform !== "win32") return {};
+  const icon = readDesktopAppIcon();
   const resourceName = desktopAppIconResourceName({
-    icon: readDesktopAppIcon(),
+    icon,
     platform: process.platform,
     isDarkAppearance: false,
   });
   const iconPath = resolveResourcePath(resourceName);
-  return iconPath ? { icon: iconPath } : {};
+  if (!iconPath) return {};
+  if (process.platform !== "win32") return { icon: iconPath };
+  try {
+    return { icon: materializeWindowsShellIcon(icon, iconPath) };
+  } catch (error) {
+    console.warn(
+      `[desktop] Failed to materialize Windows window icon: ${formatErrorMessage(error)}`,
+    );
+    return { icon: iconPath };
+  }
 }
 
 // macOS backs the translucent shell with window vibrancy, so the window is created
@@ -4130,6 +4258,12 @@ function createWindow(): BrowserWindow {
       window.maximize();
     }
     window.show();
+    if (process.platform === "win32") {
+      const icon = readDesktopAppIcon();
+      applyDesktopAppIcon(icon, window, {
+        reregisterTaskbarButton: icon !== "default",
+      });
+    }
     emitDesktopWindowState(window);
   });
 
@@ -4165,6 +4299,14 @@ function createWindow(): BrowserWindow {
     window.webContents.openDevTools({ mode: "detach" });
   } else {
     void window.loadURL(desktopIdentity.entryUrl);
+  }
+
+  if (process.platform === "linux" || process.platform === "win32") {
+    try {
+      applyDesktopAppIcon(readDesktopAppIcon(), window, { reregisterTaskbarButton: false });
+    } catch (error) {
+      console.warn(`[desktop] Failed to apply startup app icon: ${formatErrorMessage(error)}`);
+    }
   }
 
   window.on("closed", () => {

--- a/apps/desktop/src/windowsTaskbarIcon.test.ts
+++ b/apps/desktop/src/windowsTaskbarIcon.test.ts
@@ -2,6 +2,7 @@ import Path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { SYNARA_PRODUCTION_BUNDLE_ID } from "@synara/shared/desktopIdentity";
 import type { BrowserWindow } from "electron";
 
 import {
@@ -28,7 +29,7 @@ function makeWindow({ destroyed = false, visible = true }: FakeWindowState = {})
 }
 
 const identity = {
-  appId: "com.synara.app",
+  appId: SYNARA_PRODUCTION_BUNDLE_ID,
   relaunchCommand: "C:\\Program Files\\Synara\\Synara.exe",
   relaunchDisplayName: "Synara",
 } as const;
@@ -81,13 +82,13 @@ describe("syncWindowsShortcutIcons", () => {
 
     const updated = syncWindowsShortcutIcons({
       iconPath: Path.join("cache", "taskbar-icon.ico"),
-      appId: "com.synara.app",
+      appId: SYNARA_PRODUCTION_BUNDLE_ID,
       executablePath: Path.join("Program Files", "Synara", "Synara.exe"),
       shortcutPaths: ["synara.lnk", "other.lnk", "already.lnk"],
       readShortcut: (shortcutPath) => {
         if (shortcutPath === "synara.lnk") {
           return {
-            appUserModelId: "com.synara.app",
+            appUserModelId: SYNARA_PRODUCTION_BUNDLE_ID,
             target: Path.join("Program Files", "Synara", "Synara.exe"),
             icon: Path.join("Program Files", "Synara", "Synara.exe"),
             iconIndex: 0,
@@ -95,7 +96,7 @@ describe("syncWindowsShortcutIcons", () => {
         }
         if (shortcutPath === "already.lnk") {
           return {
-            appUserModelId: "com.synara.app",
+            appUserModelId: SYNARA_PRODUCTION_BUNDLE_ID,
             icon: Path.join("cache", "taskbar-icon.ico"),
             iconIndex: 0,
           };
@@ -119,7 +120,7 @@ describe("syncWindowsShortcutIcons", () => {
 
     const updated = syncWindowsShortcutIcons({
       iconPath: Path.join("cache", "taskbar-icon.ico"),
-      appId: "com.synara.app",
+      appId: SYNARA_PRODUCTION_BUNDLE_ID,
       executablePath: Path.join("node_modules", "electron", "electron.exe"),
       shortcutPaths: ["electron.lnk"],
       readShortcut: () => ({

--- a/apps/desktop/src/windowsTaskbarIcon.test.ts
+++ b/apps/desktop/src/windowsTaskbarIcon.test.ts
@@ -1,8 +1,16 @@
+import Path from "node:path";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { BrowserWindow } from "electron";
 
-import { refreshWindowsTaskbarIcon } from "./windowsTaskbarIcon";
+import {
+  applyWindowsTaskbarIcon,
+  clearWindowsTaskbarIconRefresh,
+  collectWindowsShortcutPaths,
+  syncWindowsShortcutIcons,
+  windowsShellIconCachePath,
+} from "./windowsTaskbarIcon";
 
 interface FakeWindowState {
   destroyed?: boolean;
@@ -13,52 +21,191 @@ function makeWindow({ destroyed = false, visible = true }: FakeWindowState = {})
   return {
     isDestroyed: vi.fn(() => destroyed),
     isVisible: vi.fn(() => visible),
+    setIcon: vi.fn(),
+    setAppDetails: vi.fn(),
     setSkipTaskbar: vi.fn(),
   } as unknown as BrowserWindow;
 }
 
+const identity = {
+  appId: "com.synara.app",
+  relaunchCommand: "C:\\Program Files\\Synara\\Synara.exe",
+  relaunchDisplayName: "Synara",
+} as const;
+
+const iconPath = "C:\\Users\\synara\\userdata\\taskbar-icons\\taskbar-icon.ico";
+
 afterEach(() => {
+  clearWindowsTaskbarIconRefresh();
   vi.useRealTimers();
 });
 
-describe("refreshWindowsTaskbarIcon", () => {
-  it("detaches the taskbar button and re-registers it after the refresh delay", () => {
+describe("windowsShellIconCachePath", () => {
+  it("keeps a distinct on-disk ICO per preference so Explorer cannot reuse a stale cache entry", () => {
+    expect(windowsShellIconCachePath(Path.join("cache"), "default")).toBe(
+      Path.join("cache", "taskbar-default.ico"),
+    );
+    expect(windowsShellIconCachePath(Path.join("cache"), "icon")).toBe(
+      Path.join("cache", "taskbar-icon.ico"),
+    );
+  });
+});
+
+describe("collectWindowsShortcutPaths", () => {
+  it("includes Start Menu and nested program-folder shortcuts while skipping missing roots", () => {
+    const files: Record<string, string[]> = {
+      [Path.join("Start Menu", "Programs")]: ["Synara.lnk", "Other", "Readme.txt"],
+      [Path.join("Start Menu", "Programs", "Other")]: ["Synara Dev.lnk"],
+    };
+
+    expect(
+      collectWindowsShortcutPaths({
+        directories: [Path.join("Start Menu", "Programs"), "missing"],
+        readdir: (directory) => {
+          const entries = files[directory];
+          if (!entries) throw new Error(`missing ${directory}`);
+          return entries;
+        },
+        isDirectory: (path) => path === Path.join("Start Menu", "Programs", "Other"),
+      }),
+    ).toEqual([
+      Path.join("Start Menu", "Programs", "Synara.lnk"),
+      Path.join("Start Menu", "Programs", "Other", "Synara Dev.lnk"),
+    ]);
+  });
+});
+
+describe("syncWindowsShortcutIcons", () => {
+  it("updates shortcuts that share the app identity and skips unrelated links", () => {
+    const updateShortcut = vi.fn(() => true);
+
+    const updated = syncWindowsShortcutIcons({
+      iconPath: Path.join("cache", "taskbar-icon.ico"),
+      appId: "com.synara.app",
+      executablePath: Path.join("Program Files", "Synara", "Synara.exe"),
+      shortcutPaths: ["synara.lnk", "other.lnk", "already.lnk"],
+      readShortcut: (shortcutPath) => {
+        if (shortcutPath === "synara.lnk") {
+          return {
+            appUserModelId: "com.synara.app",
+            target: Path.join("Program Files", "Synara", "Synara.exe"),
+            icon: Path.join("Program Files", "Synara", "Synara.exe"),
+            iconIndex: 0,
+          };
+        }
+        if (shortcutPath === "already.lnk") {
+          return {
+            appUserModelId: "com.synara.app",
+            icon: Path.join("cache", "taskbar-icon.ico"),
+            iconIndex: 0,
+          };
+        }
+        return { appUserModelId: "com.other.app", target: Path.join("Other", "App.exe") };
+      },
+      updateShortcut,
+    });
+
+    expect(updated).toEqual(["synara.lnk"]);
+    expect(updateShortcut).toHaveBeenCalledTimes(1);
+    expect(updateShortcut).toHaveBeenCalledWith(
+      "synara.lnk",
+      Path.join("cache", "taskbar-icon.ico"),
+      0,
+    );
+  });
+
+  it("does not treat the Electron dev binary as a shortcut target", () => {
+    const updateShortcut = vi.fn(() => true);
+
+    const updated = syncWindowsShortcutIcons({
+      iconPath: Path.join("cache", "taskbar-icon.ico"),
+      appId: "com.synara.app",
+      executablePath: Path.join("node_modules", "electron", "electron.exe"),
+      shortcutPaths: ["electron.lnk"],
+      readShortcut: () => ({
+        target: Path.join("node_modules", "electron", "electron.exe"),
+      }),
+      updateShortcut,
+    });
+
+    expect(updated).toEqual([]);
+    expect(updateShortcut).not.toHaveBeenCalled();
+  });
+});
+
+describe("applyWindowsTaskbarIcon", () => {
+  it("binds a shell-visible ICO before recreating the taskbar button, then rebinds it after the delay", () => {
     vi.useFakeTimers();
     const window = makeWindow();
 
-    refreshWindowsTaskbarIcon(window);
+    applyWindowsTaskbarIcon({ window, iconPath, identity });
 
+    expect(window.setIcon).toHaveBeenCalledWith(iconPath);
+    expect(window.setAppDetails).toHaveBeenCalledWith({
+      appId: identity.appId,
+      appIconPath: iconPath,
+      appIconIndex: 0,
+      relaunchCommand: identity.relaunchCommand,
+      relaunchDisplayName: identity.relaunchDisplayName,
+    });
     expect(window.setSkipTaskbar).toHaveBeenCalledWith(true);
     expect(window.setSkipTaskbar).toHaveBeenCalledTimes(1);
 
     vi.advanceTimersByTime(249);
     expect(window.setSkipTaskbar).toHaveBeenCalledTimes(1);
+    expect(window.setIcon).toHaveBeenCalledTimes(1);
 
     vi.advanceTimersByTime(1);
+    expect(window.setIcon).toHaveBeenLastCalledWith(iconPath);
+    expect(window.setAppDetails).toHaveBeenCalledTimes(2);
     expect(window.setSkipTaskbar).toHaveBeenCalledWith(false);
     expect(window.setSkipTaskbar).toHaveBeenCalledTimes(2);
   });
 
+  it("binds a visible window without recreating the taskbar button when reregister is disabled", () => {
+    vi.useFakeTimers();
+    const window = makeWindow();
+
+    applyWindowsTaskbarIcon({
+      window,
+      iconPath,
+      identity,
+      reregisterTaskbarButton: false,
+    });
+
+    expect(window.setIcon).toHaveBeenCalledWith(iconPath);
+    expect(window.setAppDetails).toHaveBeenCalledTimes(1);
+    expect(window.setSkipTaskbar).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(250);
+    expect(window.setSkipTaskbar).not.toHaveBeenCalled();
+  });
+
+  it("binds the icon on a hidden window without touching the taskbar button", () => {
+    vi.useFakeTimers();
+    const window = makeWindow({ visible: false });
+
+    applyWindowsTaskbarIcon({ window, iconPath, identity });
+
+    expect(window.setIcon).toHaveBeenCalledWith(iconPath);
+    expect(window.setAppDetails).toHaveBeenCalledTimes(1);
+    expect(window.setSkipTaskbar).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(250);
+    expect(window.setSkipTaskbar).not.toHaveBeenCalled();
+  });
+
   it("does nothing when there is no window", () => {
     vi.useFakeTimers();
-    expect(() => refreshWindowsTaskbarIcon(null)).not.toThrow();
+    expect(() => applyWindowsTaskbarIcon({ window: null, iconPath, identity })).not.toThrow();
   });
 
   it("does nothing when the window is destroyed", () => {
     vi.useFakeTimers();
     const window = makeWindow({ destroyed: true });
 
-    refreshWindowsTaskbarIcon(window);
+    applyWindowsTaskbarIcon({ window, iconPath, identity });
 
-    expect(window.setSkipTaskbar).not.toHaveBeenCalled();
-  });
-
-  it("does nothing when the window is hidden", () => {
-    vi.useFakeTimers();
-    const window = makeWindow({ visible: false });
-
-    refreshWindowsTaskbarIcon(window);
-
+    expect(window.setIcon).not.toHaveBeenCalled();
+    expect(window.setAppDetails).not.toHaveBeenCalled();
     expect(window.setSkipTaskbar).not.toHaveBeenCalled();
   });
 
@@ -66,7 +213,7 @@ describe("refreshWindowsTaskbarIcon", () => {
     vi.useFakeTimers();
     const window = makeWindow();
 
-    refreshWindowsTaskbarIcon(window);
+    applyWindowsTaskbarIcon({ window, iconPath, identity });
     expect(window.setSkipTaskbar).toHaveBeenCalledWith(true);
 
     vi.advanceTimersByTime(249);
@@ -74,5 +221,24 @@ describe("refreshWindowsTaskbarIcon", () => {
     vi.advanceTimersByTime(1);
 
     expect(window.setSkipTaskbar).toHaveBeenCalledTimes(1);
+    expect(window.setIcon).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels an in-flight reregister when a newer icon is applied", () => {
+    vi.useFakeTimers();
+    const window = makeWindow();
+    const nextIconPath = "C:\\Users\\synara\\userdata\\taskbar-icons\\taskbar-default.ico";
+
+    applyWindowsTaskbarIcon({ window, iconPath, identity });
+    applyWindowsTaskbarIcon({ window, iconPath: nextIconPath, identity });
+
+    expect(window.setSkipTaskbar).toHaveBeenNthCalledWith(1, true);
+    expect(window.setSkipTaskbar).toHaveBeenNthCalledWith(2, true);
+    expect(window.setSkipTaskbar).toHaveBeenCalledTimes(2);
+
+    vi.advanceTimersByTime(250);
+    expect(window.setIcon).toHaveBeenLastCalledWith(nextIconPath);
+    expect(window.setSkipTaskbar).toHaveBeenCalledWith(false);
+    expect(window.setSkipTaskbar).toHaveBeenCalledTimes(3);
   });
 });

--- a/apps/desktop/src/windowsTaskbarIcon.ts
+++ b/apps/desktop/src/windowsTaskbarIcon.ts
@@ -1,23 +1,154 @@
 // FILE: windowsTaskbarIcon.ts
-// Purpose: Force the Windows shell to re-read the taskbar icon after a runtime change.
+// Purpose: Bind a shell-visible ICO to the Windows taskbar and force Explorer to re-read it.
 // Layer: Desktop-native preference logic
+
+import Path from "node:path";
 
 import type { BrowserWindow } from "electron";
 
 // Explorer coalesces a synchronous setSkipTaskbar(true) -> setSkipTaskbar(false)
 // toggle and keeps rendering its cached button icon, so the button must stay
 // detached long enough for the shell to process the removal before it is
-// re-registered and re-reads the window icon.
+// re-registered and re-reads the window icon and AppUserModel properties.
 const WINDOWS_TASKBAR_ICON_REFRESH_DELAY_MS = 250;
 
-export function refreshWindowsTaskbarIcon(window: BrowserWindow | null): void {
-  if (!window || window.isDestroyed() || !window.isVisible()) {
-    return;
-  }
-  window.setSkipTaskbar(true);
-  setTimeout(() => {
-    if (!window.isDestroyed()) {
-      window.setSkipTaskbar(false);
+export interface WindowsTaskbarIconIdentity {
+  readonly appId: string;
+  readonly relaunchCommand: string;
+  readonly relaunchDisplayName: string;
+}
+
+export interface ApplyWindowsTaskbarIconInput {
+  readonly window: BrowserWindow | null;
+  readonly iconPath: string;
+  readonly identity: WindowsTaskbarIconIdentity;
+  readonly reregisterTaskbarButton?: boolean;
+}
+
+let taskbarReregisterTimer: ReturnType<typeof setTimeout> | null = null;
+
+export function windowsShellIconCachePath(cacheDirectory: string, iconKey: string): string {
+  return Path.join(cacheDirectory, `taskbar-${iconKey}.ico`);
+}
+
+export interface WindowsShortcutDetails {
+  readonly target?: string;
+  readonly appUserModelId?: string;
+  readonly icon?: string;
+  readonly iconIndex?: number;
+}
+
+export function collectWindowsShortcutPaths(input: {
+  readonly directories: readonly string[];
+  readonly readdir: (directory: string) => readonly string[];
+  readonly isDirectory: (path: string) => boolean;
+}): string[] {
+  const shortcuts: string[] = [];
+  for (const directory of input.directories) {
+    let entries: readonly string[] = [];
+    try {
+      entries = input.readdir(directory);
+    } catch {
+      continue;
     }
+    for (const entry of entries) {
+      const fullPath = Path.join(directory, entry);
+      if (entry.toLowerCase().endsWith(".lnk")) {
+        shortcuts.push(fullPath);
+        continue;
+      }
+      if (!input.isDirectory(fullPath)) continue;
+      let nested: readonly string[] = [];
+      try {
+        nested = input.readdir(fullPath);
+      } catch {
+        continue;
+      }
+      for (const nestedEntry of nested) {
+        if (nestedEntry.toLowerCase().endsWith(".lnk")) {
+          shortcuts.push(Path.join(fullPath, nestedEntry));
+        }
+      }
+    }
+  }
+  return shortcuts;
+}
+
+export function syncWindowsShortcutIcons(input: {
+  readonly iconPath: string;
+  readonly iconIndex?: number;
+  readonly appId: string;
+  readonly executablePath: string;
+  readonly shortcutPaths: readonly string[];
+  readonly readShortcut: (shortcutPath: string) => WindowsShortcutDetails | null;
+  readonly updateShortcut: (shortcutPath: string, iconPath: string, iconIndex: number) => boolean;
+}): string[] {
+  const iconIndex = input.iconIndex ?? 0;
+  const normalizedExe = Path.normalize(input.executablePath);
+  const canMatchByTarget = !/^electron(?:\.exe)?$/i.test(Path.basename(input.executablePath));
+  const updated: string[] = [];
+  for (const shortcutPath of input.shortcutPaths) {
+    const details = input.readShortcut(shortcutPath);
+    if (!details) continue;
+    const matchesId = details.appUserModelId === input.appId;
+    const matchesTarget =
+      canMatchByTarget &&
+      typeof details.target === "string" &&
+      Path.normalize(details.target) === normalizedExe;
+    if (!matchesId && !matchesTarget) continue;
+    if (details.icon === input.iconPath && (details.iconIndex ?? 0) === iconIndex) continue;
+    if (input.updateShortcut(shortcutPath, input.iconPath, iconIndex)) {
+      updated.push(shortcutPath);
+    }
+  }
+  return updated;
+}
+
+export function clearWindowsTaskbarIconRefresh(): void {
+  if (taskbarReregisterTimer === null) return;
+  clearTimeout(taskbarReregisterTimer);
+  taskbarReregisterTimer = null;
+}
+
+export function applyWindowsTaskbarIcon(input: ApplyWindowsTaskbarIconInput): void {
+  const { window } = input;
+  if (!window || window.isDestroyed()) return;
+
+  bindWindowsTaskbarIcon(window, input);
+  if (!window.isVisible() || input.reregisterTaskbarButton === false) return;
+
+  scheduleWindowsTaskbarReregister(window, input);
+}
+
+function bindWindowsTaskbarIcon(window: BrowserWindow, input: ApplyWindowsTaskbarIconInput): void {
+  // Pass a real filesystem path. NativeImage flattening and asar-backed paths
+  // update window chrome, but Explorer's taskbar button reads an ICO from disk
+  // through the window's AppUserModel properties.
+  window.setIcon(input.iconPath);
+  try {
+    window.setAppDetails({
+      appId: input.identity.appId,
+      appIconPath: input.iconPath,
+      appIconIndex: 0,
+      relaunchCommand: input.identity.relaunchCommand,
+      relaunchDisplayName: input.identity.relaunchDisplayName,
+    });
+  } catch {
+    // setAppDetails can throw on a window that is not yet fully realized.
+    // The ICO path and skip-taskbar refresh still give Explorer a new button.
+  }
+}
+
+function scheduleWindowsTaskbarReregister(
+  window: BrowserWindow,
+  input: ApplyWindowsTaskbarIconInput,
+): void {
+  clearWindowsTaskbarIconRefresh();
+  window.setSkipTaskbar(true);
+  taskbarReregisterTimer = setTimeout(() => {
+    taskbarReregisterTimer = null;
+    if (window.isDestroyed()) return;
+    bindWindowsTaskbarIcon(window, input);
+    window.setSkipTaskbar(false);
   }, WINDOWS_TASKBAR_ICON_REFRESH_DELAY_MS);
 }


### PR DESCRIPTION
## What Changed

Windows 11 was keeping the default Synara mark in the taskbar after Settings → App icon switched to the alternate artwork. `BrowserWindow.setIcon` plus a `setSkipTaskbar` flicker is not enough: Explorer reads the ICO from the AppUserModelID shortcut (Start Menu / pin), and it cannot load icons from asar.

This change:

- Copies the selected `.ico` to a real per-preference file under userdata so the shell has a path it can read
- Binds that path with `setAppDetails({ appIconPath })` in addition to `setIcon`
- Updates matching Start Menu, Desktop, and pinned `.lnk` shortcuts via Electron's shortcut APIs
- Recreates the live taskbar button and rebinds the ICO after the delay
- Does not let icon/shortcut failures block window creation (so a bad shell call cannot leave the window hidden)

## Why

The previous runtime refresh only toggled taskbar registration. On Windows 10/11 the running button still follows the AUMID shortcut / exe icon, so the settings picker updated while the taskbar stayed on the original mark.

## UI Changes

No renderer UI. Native Windows taskbar / shortcut icon should follow the App icon setting.

## Verification

- `bun fmt`
- `bun lint` (0 errors; existing repo warnings only)
- `bun typecheck`
- `bun run test src/windowsTaskbarIcon.test.ts src/desktopAppIcon.test.ts` from `apps/desktop` (17 passed)

Manual: packaged Windows 10/11 build, Settings → App icon, confirm the taskbar (and pin, if present) switches to the alternate ICO and back to default. A local Electron dev run cannot prove this, because the process is `electron.exe` rather than `Synara.exe`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
