### PR TITLE
Support Xcode 27 beta's relocated SimulatorKit.framework

### DIFF
--- a/apps/server/native/device-helper/Sources/CoreSimulatorBridge.swift
+++ b/apps/server/native/device-helper/Sources/CoreSimulatorBridge.swift
@@ -56,6 +56,20 @@ func resolveDeveloperDirectory() -> String {
   return path.isEmpty ? "/Applications/Xcode.app/Contents/Developer" : path
 }
 
+/// Candidate locations for the SimulatorKit binary inside an Xcode bundle.
+///
+/// Xcode 27 beta 4 moved SimulatorKit from
+/// `Contents/Developer/Library/PrivateFrameworks` to `Contents/SharedFrameworks`;
+/// both are tried so one helper spans stable and beta toolchains. Order matters
+/// only for error messages — at most one exists in any given install.
+func simulatorKitCandidatePaths(developerDirectory: String) -> [String] {
+  let contentsDirectory = (developerDirectory as NSString).deletingLastPathComponent
+  return [
+    developerDirectory + "/Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit",
+    contentsDirectory + "/SharedFrameworks/SimulatorKit.framework/SimulatorKit",
+  ]
+}
+
 /// The dlopen handles the capability probe needs for `dlsym` lookups.
 struct PrivateFrameworkHandles {
   /// nil when SimulatorKit itself would not load. The probe reports that as one
@@ -81,12 +95,19 @@ func loadPrivateFrameworks(
     throw SimulatorError.frameworkLoadFailed("CoreSimulator (\(message))")
   }
 
-  let simulatorKitPath = developerDirectory
-    + "/Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit"
-  let simulatorKit = dlopen(simulatorKitPath, RTLD_NOW)
+  let simulatorKitPaths = simulatorKitCandidatePaths(developerDirectory: developerDirectory)
+  var simulatorKit: UnsafeMutableRawPointer?
+  var loadFailures: [String] = []
+  for candidate in simulatorKitPaths {
+    if let handle = dlopen(candidate, RTLD_NOW) {
+      simulatorKit = handle
+      break
+    }
+    loadFailures.append("\(candidate) (\(String(cString: dlerror())))")
+  }
   if simulatorKit == nil && requireSimulatorKit {
-    let message = String(cString: dlerror())
-    throw SimulatorError.frameworkLoadFailed("SimulatorKit at \(simulatorKitPath) (\(message))")
+    throw SimulatorError.frameworkLoadFailed(
+      "SimulatorKit at " + loadFailures.joined(separator: ", "))
   }
 
   // Accessibility translation is optional: without it `describe-ui` degrades,

--- a/apps/server/native/device-helper/Sources/HIDBridge.m
+++ b/apps/server/native/device-helper/Sources/HIDBridge.m
@@ -234,15 +234,27 @@ static const uint32_t kUsageLeftShift = 225;
   if (developerDir.length == 0) {
     developerDir = @"/Applications/Xcode.app/Contents/Developer";
   }
-  NSString *kitPath = [developerDir
-      stringByAppendingPathComponent:@"Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit"];
-  void *kit = dlopen(kitPath.fileSystemRepresentation, RTLD_NOW);
+  // Same candidate order as simulatorKitCandidatePaths in CoreSimulatorBridge:
+  // Xcode ≤26 keeps SimulatorKit under the developer dir, Xcode 27 beta 4 moved
+  // it to Contents/SharedFrameworks.
+  NSArray<NSString *> *kitPaths = @[
+    [developerDir
+        stringByAppendingPathComponent:@"Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit"],
+    [[developerDir stringByDeletingLastPathComponent]
+        stringByAppendingPathComponent:@"SharedFrameworks/SimulatorKit.framework/SimulatorKit"],
+  ];
+  void *kit = NULL;
+  for (NSString *kitPath in kitPaths) {
+    kit = dlopen(kitPath.fileSystemRepresentation, RTLD_NOW);
+    if (kit != NULL) break;
+  }
   if (kit == NULL) {
     if (error) {
       *error = [NSError errorWithDomain:@"dev.synara.device-helper.hid"
                                    code:1
                                userInfo:@{NSLocalizedDescriptionKey:
-                                            [NSString stringWithFormat:@"cannot load SimulatorKit at %@", kitPath]}];
+                                            [NSString stringWithFormat:@"cannot load SimulatorKit at %@",
+                                                                       [kitPaths componentsJoinedByString:@" or "]]}];
     }
     return NO;
   }

--- a/apps/server/native/device-helper/build.sh
+++ b/apps/server/native/device-helper/build.sh
@@ -35,7 +35,11 @@ if [ -z "$DEVELOPER_DIR_PATH" ]; then
   echo "error: no active developer directory; run 'sudo xcode-select -s /Applications/Xcode.app'" >&2
   exit 1
 fi
-if [ ! -d "$DEVELOPER_DIR_PATH/Library/PrivateFrameworks/SimulatorKit.framework" ]; then
+# Xcode ≤26 ships SimulatorKit under the developer dir; Xcode 27 beta 4 moved it
+# to Contents/SharedFrameworks. Mirrors simulatorKitCandidatePaths in
+# CoreSimulatorBridge.swift.
+if [ ! -d "$DEVELOPER_DIR_PATH/Library/PrivateFrameworks/SimulatorKit.framework" ] \
+  && [ ! -d "$(dirname "$DEVELOPER_DIR_PATH")/SharedFrameworks/SimulatorKit.framework" ]; then
   echo "error: SimulatorKit not found under $DEVELOPER_DIR_PATH" >&2
   echo "       point xcode-select at a full Xcode install, not the command line tools" >&2
   exit 1

--- a/apps/server/src/device/IosSimulatorBackend.betaToolchain.test.ts
+++ b/apps/server/src/device/IosSimulatorBackend.betaToolchain.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { IosSimulatorBackend } from "./IosSimulatorBackend.ts";
+import { IosSimulatorBackend, orderXcodeAppCandidates } from "./IosSimulatorBackend.ts";
 
 const BETA_DIR = "/Applications/Xcode-beta.app/Contents/Developer";
 const STABLE_DIR = "/Applications/Xcode.app/Contents/Developer";
+const CLT_DIR = "/Library/Developer/CommandLineTools";
 
 interface RunCall {
   readonly command: string;
@@ -11,8 +12,17 @@ interface RunCall {
   readonly env: NodeJS.ProcessEnv | undefined;
 }
 
-function makeBackend(processEnv: NodeJS.ProcessEnv) {
+interface BackendSetup {
+  readonly processEnv?: NodeJS.ProcessEnv;
+  /** What `xcode-select -p` reports; defaults to stable Xcode. */
+  readonly selected?: string;
+  /** `/Applications` listing for discovery; defaults to none. */
+  readonly applications?: readonly string[];
+}
+
+function makeBackend(setup: BackendSetup) {
   const calls: RunCall[] = [];
+  const selected = setup.selected ?? STABLE_DIR;
   const run = (async (
     command: string,
     args: readonly string[],
@@ -20,7 +30,7 @@ function makeBackend(processEnv: NodeJS.ProcessEnv) {
   ) => {
     calls.push({ command, args, env: options?.env });
     if (command === "xcode-select") {
-      return { stdout: `${STABLE_DIR}\n`, stderr: "", code: 0, signal: null, timedOut: false };
+      return { stdout: `${selected}\n`, stderr: "", code: 0, signal: null, timedOut: false };
     }
     if (command === "xcodebuild") {
       return {
@@ -36,8 +46,10 @@ function makeBackend(processEnv: NodeJS.ProcessEnv) {
 
   const backend = new IosSimulatorBackend({
     platform: "darwin",
-    processEnv,
+    processEnv: setup.processEnv ?? {},
     run,
+    listApplications: () => Promise.resolve(setup.applications ?? []),
+    xcodeBundleUsable: () => Promise.resolve(true),
   });
   return { backend, calls };
 }
@@ -46,7 +58,7 @@ describe("Xcode beta toolchain", () => {
   it("targets the beta named by DEVELOPER_DIR rather than the machine-wide selection", async () => {
     // Pointing one process at a beta is how a beta is tried at all; changing
     // the machine-wide selection would move every other build onto it too.
-    const { backend, calls } = makeBackend({ DEVELOPER_DIR: BETA_DIR });
+    const { backend, calls } = makeBackend({ processEnv: { DEVELOPER_DIR: BETA_DIR } });
     await backend.listDevices({});
 
     const simctl = calls.find((call) => call.command === "xcrun");
@@ -64,10 +76,66 @@ describe("Xcode beta toolchain", () => {
   });
 
   it("ignores an empty variable instead of pinning to nothing", async () => {
-    const { backend, calls } = makeBackend({ DEVELOPER_DIR: "   " });
+    const { backend, calls } = makeBackend({ processEnv: { DEVELOPER_DIR: "   " } });
     await backend.listDevices({});
 
     const simctl = calls.find((call) => call.command === "xcrun");
     expect(simctl?.env?.DEVELOPER_DIR).toBe(STABLE_DIR);
+  });
+});
+
+describe("Xcode discovery", () => {
+  it("finds a beta-only Xcode when xcode-select points at CommandLineTools", async () => {
+    // The macOS default after installing git: CommandLineTools selected, a full
+    // Xcode installed but never `xcode-select -s`'d. Discovery should use it
+    // without requiring the user to set anything.
+    const { backend, calls } = makeBackend({
+      selected: CLT_DIR,
+      applications: ["Safari.app", "Xcode-beta.app"],
+    });
+    await backend.listDevices({});
+
+    const simctl = calls.find((call) => call.command === "xcrun");
+    expect(simctl?.env?.DEVELOPER_DIR).toBe(BETA_DIR);
+  });
+
+  it("prefers stable Xcode.app over a beta when both are installed", async () => {
+    const { backend, calls } = makeBackend({
+      selected: CLT_DIR,
+      applications: ["Xcode-beta.app", "Xcode.app"],
+    });
+    await backend.listDevices({});
+
+    const simctl = calls.find((call) => call.command === "xcrun");
+    expect(simctl?.env?.DEVELOPER_DIR).toBe(STABLE_DIR);
+  });
+
+  it("keeps the CommandLineTools selection when no Xcode bundle exists", async () => {
+    // Nothing to discover: the availability checklist still needs the selected
+    // path to say "install Xcode", not a null that reads as no toolchain.
+    const { backend, calls } = makeBackend({ selected: CLT_DIR, applications: ["Safari.app"] });
+    await backend.listDevices({});
+
+    const simctl = calls.find((call) => call.command === "xcrun");
+    expect(simctl?.env?.DEVELOPER_DIR).toBe(CLT_DIR);
+  });
+
+  it("does not second-guess an explicit full-Xcode selection", async () => {
+    const { backend, calls } = makeBackend({
+      selected: BETA_DIR,
+      applications: ["Xcode.app", "Xcode-beta.app"],
+    });
+    await backend.listDevices({});
+
+    const simctl = calls.find((call) => call.command === "xcrun");
+    expect(simctl?.env?.DEVELOPER_DIR).toBe(BETA_DIR);
+  });
+});
+
+describe("orderXcodeAppCandidates", () => {
+  it("puts stable first and ignores non-Xcode bundles", () => {
+    expect(
+      orderXcodeAppCandidates(["Xcode-27.0.app", "Numbers.app", "Xcode.app", "Xcode-beta.app"]),
+    ).toEqual(["Xcode.app", "Xcode-27.0.app", "Xcode-beta.app"]);
   });
 });

--- a/apps/server/src/device/IosSimulatorBackend.ts
+++ b/apps/server/src/device/IosSimulatorBackend.ts
@@ -129,6 +129,10 @@ export interface IosSimulatorBackendOptions {
   readonly now?: () => number;
   /** Overridden in tests to exercise DEVELOPER_DIR without mutating process.env. */
   readonly processEnv?: NodeJS.ProcessEnv;
+  /** Overridden in tests to simulate `/Applications` without touching the disk. */
+  readonly listApplications?: () => Promise<readonly string[]>;
+  /** Overridden alongside listApplications to control which bundles look real. */
+  readonly xcodeBundleUsable?: (developerDir: string) => Promise<boolean>;
 }
 
 interface ActiveRecording {
@@ -222,6 +226,23 @@ export function hasBootableIosRuntime(devices: readonly DeviceDescriptor[]): boo
   return devices.length > 0;
 }
 
+/**
+ * Order `/Applications` entries into Xcode bundle candidates, stable first.
+ *
+ * Stable `Xcode.app` wins when present because it is the predictable default;
+ * a beta or versioned install (`Xcode-beta.app`, `Xcode-27.0.app`) is only
+ * picked when it is the sole full Xcode on the machine. Exported for tests.
+ */
+export function orderXcodeAppCandidates(entries: readonly string[]): readonly string[] {
+  return entries
+    .filter((name) => name.startsWith("Xcode") && name.endsWith(".app"))
+    .toSorted((a, b) => {
+      if (a === "Xcode.app") return -1;
+      if (b === "Xcode.app") return 1;
+      return a.localeCompare(b);
+    });
+}
+
 export async function selectRecordingDirectory(
   candidates: readonly string[],
   fallback: string,
@@ -261,6 +282,8 @@ export class IosSimulatorBackend implements DeviceBackend {
   private readonly now: () => number;
   /** Injected so a test can set DEVELOPER_DIR without touching the real process. */
   private readonly processEnv: NodeJS.ProcessEnv;
+  private readonly listApplications: () => Promise<readonly string[]>;
+  private readonly xcodeBundleUsable: (developerDir: string) => Promise<boolean>;
 
   /** Geometry learned from helper attachments, keyed by udid. */
   private readonly deviceGeometry = new Map<string, DeviceGeometry>();
@@ -271,6 +294,8 @@ export class IosSimulatorBackend implements DeviceBackend {
    * every listing would spawn a hundred processes per picker open.
    */
   private deviceTypes: Promise<DeviceTypeCatalogue> | null = null;
+  /** One `/Applications` scan per process; see discoverXcodeDeveloperDir. */
+  private xcodeDiscovery: Promise<string | null> | null = null;
   private helper: HelperClient | null = null;
   private helperBuildFailure: string | null = null;
   private helperCompilation: Promise<string> | null = null;
@@ -302,6 +327,16 @@ export class IosSimulatorBackend implements DeviceBackend {
       ((command, args) => spawn(command, [...args], { stdio: "pipe", windowsHide: true }));
     this.recordingDirectoryOverride = options.recordingDirectory;
     this.now = options.now ?? Date.now;
+    this.listApplications = options.listApplications ?? (() => readdir("/Applications"));
+    this.xcodeBundleUsable =
+      options.xcodeBundleUsable ??
+      ((developerDir) =>
+        // `xcrun` is what every downstream command needs; its presence is what
+        // separates a full Xcode from a leftover or half-deleted bundle.
+        access(path.join(developerDir, "usr", "bin", "xcrun")).then(
+          () => true,
+          () => false,
+        ));
   }
 
   // ── Availability ───────────────────────────────────────────────────
@@ -990,9 +1025,35 @@ export class IosSimulatorBackend implements DeviceBackend {
       timeoutMs: 10_000,
       allowNonZeroExit: true,
     }).catch(() => null);
-    if (!result || result.code !== 0) return null;
-    const trimmed = result.stdout.trim();
-    return trimmed.length > 0 ? trimmed : null;
+    const selected =
+      result !== null && result.code === 0 && result.stdout.trim().length > 0
+        ? result.stdout.trim()
+        : null;
+    if (selected !== null && !selected.includes("CommandLineTools")) return selected;
+    // The machine-wide selection is CommandLineTools (the macOS default after
+    // installing git) or absent, but a full Xcode may still be installed —
+    // beta-only machines commonly have `Xcode-beta.app` and never ran
+    // `xcode-select -s`. Discovering it here turns "run sudo xcode-select"
+    // from a setup blocker into a fallback instruction.
+    return (await this.discoverXcodeDeveloperDir()) ?? selected;
+  }
+
+  /**
+   * Find a full Xcode under `/Applications` without `xcode-select`.
+   *
+   * Cached for the process lifetime: installs are rare, and this backs
+   * `toolchainEnv()`, which runs for every simctl call.
+   */
+  private discoverXcodeDeveloperDir(): Promise<string | null> {
+    this.xcodeDiscovery ??= (async () => {
+      const entries = await this.listApplications().catch(() => [] as string[]);
+      for (const name of orderXcodeAppCandidates(entries)) {
+        const developerDir = path.join("/Applications", name, "Contents", "Developer");
+        if (await this.xcodeBundleUsable(developerDir)) return developerDir;
+      }
+      return null;
+    })();
+    return this.xcodeDiscovery;
   }
 
   private async xcodeLicenseAccepted(): Promise<boolean> {


### PR DESCRIPTION
## Problem

On the Xcode 27 beta the simulator helper fails to start:

> Device helper build failed: error: SimulatorKit not found under /Applications/Xcode-beta.app/Contents/Developer

Xcode 27 beta moved `SimulatorKit.framework` from `Contents/Developer/Library/PrivateFrameworks` to `Contents/SharedFrameworks` (the same relocation that broke XcodeBuildMCP and other simulator tooling). Three places assume the old location: the `build.sh` preflight (which produced the reported error), the `loadPrivateFrameworks` dlopen in `CoreSimulatorBridge.swift`, and the HID bridge's independent re-derivation in `HIDBridge.m`.

## Fix

- Each SimulatorKit lookup now tries both locations — classic `PrivateFrameworks` under the developer dir first, then `SharedFrameworks` under `Contents` — so one helper supports stable and beta toolchains; nothing is dropped for Xcode ≤26. When neither loads, the error lists every candidate path tried.
- `IosSimulatorBackend` now auto-discovers a full Xcode under `/Applications` when `xcode-select` points at CommandLineTools or nothing: beta-only machines (`Xcode-beta.app` installed, never `xcode-select -s`'d) previously showed 'Install Xcode' in the setup checklist and required setting `DEVELOPER_DIR` by hand. Stable `Xcode.app` is preferred when both exist; an explicit `DEVELOPER_DIR` or full-Xcode machine-wide selection is never second-guessed.

No sandbox profile change needed: the Seatbelt profile already covers the whole `.app` bundle via `XCODE_APP`, which includes `Contents/SharedFrameworks`.

## Verification

Verified end to end against a real Xcode 27 beta 5 install (27A5237l) and against stable Xcode:

- Beta 5 confirms the diagnosis: SimulatorKit exists only under `Contents/SharedFrameworks`; the pre-fix preflight fails against it (reproducing the report) and the fixed one passes.
- `bun run test:device` under `DEVELOPER_DIR=/Applications/Xcode-beta.app/...`: **PASS** — helper compiled with the beta toolchain, booted an iPhone 17 Pro simulator, attached with input+accessibility, streamed 78 verified H.264 frames, injected a tap, pressed home, dumped the accessibility tree, took a screenshot (sandbox on).
- `bun run test:device` with stable Xcode: **PASS** (classic PrivateFrameworks path regression check).
- Helper `--probe` under the beta reports all four capabilities ok (framebuffer, hid, accessibility, encoder).
- New unit tests cover discovery ordering and the CommandLineTools fallback; `apps/server` typecheck, fmt and lint pass. The `@synara/cli` typecheck failure is pre-existing on the base commit (unrelated `providerUsageSnapshot.test.ts` tuple error).
- The helper cache key already hashes `build.sh` and all `Sources/`, so existing users rebuild automatically on update.