### PR TITLE
fix(antigravity): stream tool cards, settle turns, and route subagents to child threads

### DIFF
--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -521,6 +521,23 @@ describe("Antigravity CLI integration helpers", () => {
     expect(postToolResult.error).toBeUndefined();
     expect(postToolResult.status).toBe(0);
     expect(postToolResult.stdout.trim()).toBe("{}");
+
+    // PreInvocation gates the upcoming LLM invocation (the subagent's first
+    // model call when the agent spawns one): an empty object is treated as a
+    // denial that aborts the launch and makes the parent CLI exit with
+    // code 1, so the inactive hook must answer allow.
+    const preInvocationResult = runCaptureCommand(
+      buildAntigravityCaptureCommand(
+        "__synara_gui_must_not_launch__",
+        "__capture_script_must_not_run__",
+        "pre-invocation",
+      ),
+      JSON.stringify({ payload: "x" }),
+      { SYNARA_ANTIGRAVITY_EVENTS: "" },
+    );
+    expect(preInvocationResult.error).toBeUndefined();
+    expect(preInvocationResult.status).toBe(0);
+    expect(preInvocationResult.stdout.trim()).toBe('{"decision":"allow"}');
   });
 
   it("answers pre-tool with a decision from the capture script when capture is inactive", async () => {
@@ -604,6 +621,28 @@ describe("Antigravity CLI integration helpers", () => {
       // execute ("not recognized as an internal or external command"). The
       // win32 command must stay free of double quotes.
       String.raw`if not defined SYNARA_ANTIGRAVITY_EVENTS (more >nul 2>nul & echo {"decision":"ask"}) else (set ELECTRON_RUN_AS_NODE=1&& C:\Users\test\AppData\Local\Programs\Synara\Synara.exe C:\Users\test\.gemini\capture.cjs pre-tool)`,
+    );
+    // PreInvocation gates the LLM invocation: answer allow so subagent
+    // launches are not denied (which would make the parent CLI exit 1).
+    expect(
+      buildAntigravityCaptureCommand(
+        String.raw`C:\Users\test\AppData\Local\Programs\Synara\Synara.exe`,
+        String.raw`C:\Users\test\.gemini\capture.cjs`,
+        "pre-invocation",
+        "win32",
+      ),
+    ).toBe(
+      String.raw`if not defined SYNARA_ANTIGRAVITY_EVENTS (more >nul 2>nul & echo {"decision":"allow"}) else (set ELECTRON_RUN_AS_NODE=1&& C:\Users\test\AppData\Local\Programs\Synara\Synara.exe C:\Users\test\.gemini\capture.cjs pre-invocation)`,
+    );
+    expect(
+      buildAntigravityCaptureCommand(
+        "/Applications/Synara.app/Contents/MacOS/Synara",
+        "/tmp/synara-capture/capture.cjs",
+        "pre-invocation",
+        "darwin",
+      ),
+    ).toBe(
+      `if [ -z "\${SYNARA_ANTIGRAVITY_EVENTS:-}" ]; then cat >/dev/null 2>&1 || :; printf '%s\\n' '{"decision":"allow"}'; else ELECTRON_RUN_AS_NODE=1 '/Applications/Synara.app/Contents/MacOS/Synara' '/tmp/synara-capture/capture.cjs' 'pre-invocation'; fi`,
     );
   });
 
@@ -870,7 +909,7 @@ describe("Antigravity CLI integration helpers", () => {
                   transcriptPath: transcriptFile,
                 })}`,
                 'pre-tool\t{"stepIdx":1,"toolCall":{"name":"run_command","args":{"CommandLine":"echo dedup"}}}',
-                "post-tool\t{\"stepIdx\":1,\"error\":\"\"}",
+                'post-tool\t{"stepIdx":1,"error":""}',
                 "",
               ].join("\n"),
             ),
@@ -927,6 +966,174 @@ describe("Antigravity CLI integration helpers", () => {
             }).pipe(
               Layer.provideMerge(
                 ServerConfig.layerTest(root, { prefix: "antigravity-tool-dedup-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("routes subagent hook events to a child thread without rebinding the session", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-subagent-events-"));
+    let eventFile: string | undefined;
+    let child: ChildProcess | undefined;
+    const spawnProcess = ((
+      _command: string,
+      _args: readonly string[],
+      options: { readonly env?: NodeJS.ProcessEnv },
+    ) => {
+      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS;
+      const spawned = new EventEmitter() as ChildProcess;
+      Object.assign(spawned, {
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        killed: false,
+        kill: () => true,
+      });
+      child = spawned;
+      return spawned;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const eventsFiber = yield* adapter.streamEvents.pipe(
+            Stream.take(9),
+            Stream.runCollect,
+            Effect.forkChild,
+          );
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-subagent-events");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            resumeCursor: { conversationId: "conv-parent-1" },
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+          const turn = yield* adapter.sendTurn({
+            threadId,
+            input: "spawn a subagent",
+            attachments: [],
+          });
+          expect(eventFile).toBeTruthy();
+
+          // The subagent CLI inherits SYNARA_ANTIGRAVITY_EVENTS, so its hooks
+          // land in this session's stream with the subagent's conversation id.
+          yield* Effect.promise(() =>
+            fs.appendFile(
+              eventFile!,
+              [
+                `pre-invocation\t${JSON.stringify({
+                  conversationId: "conv-child-1",
+                  transcriptPath: "C:/tmp/child-transcript.jsonl",
+                  modelName: "gemini-3.6-flash-medium",
+                })}`,
+                `pre-tool\t${JSON.stringify({
+                  conversationId: "conv-child-1",
+                  stepIdx: 1,
+                  toolCall: { name: "run_command", args: { CommandLine: "echo child" } },
+                })}`,
+                `post-tool\t${JSON.stringify({
+                  conversationId: "conv-child-1",
+                  stepIdx: 1,
+                  error: "",
+                })}`,
+                `stop\t${JSON.stringify({ conversationId: "conv-child-1" })}`,
+                `pre-tool\t${JSON.stringify({
+                  conversationId: "conv-parent-1",
+                  stepIdx: 2,
+                  toolCall: { name: "run_command", args: { CommandLine: "echo parent" } },
+                })}`,
+                "",
+              ].join("\n"),
+            ),
+          );
+
+          const events = Array.from(
+            yield* Fiber.join(eventsFiber).pipe(Effect.timeout("2 seconds")),
+          );
+          const childRefs = {
+            providerThreadId: "conv-child-1",
+            providerParentThreadId: "conv-parent-1",
+          };
+          const childThreadStarted = events.find(
+            (event) =>
+              event.type === "thread.started" &&
+              event.providerRefs?.providerThreadId === "conv-child-1",
+          );
+          expect(childThreadStarted?.providerRefs).toEqual(childRefs);
+          const childTurnStarted = events.find(
+            (event) =>
+              event.type === "turn.started" &&
+              event.providerRefs?.providerThreadId === "conv-child-1",
+          );
+          expect(childTurnStarted?.turnId).toBe(turn.turnId);
+          expect(childTurnStarted?.payload).toMatchObject({ model: "gemini-3.6-flash-medium" });
+          const childItemStarted = events.find(
+            (event) =>
+              event.type === "item.started" &&
+              event.providerRefs?.providerThreadId === "conv-child-1",
+          );
+          expect(childItemStarted?.providerRefs).toEqual(childRefs);
+          expect(childItemStarted?.payload).toMatchObject({
+            itemType: "command_execution",
+            status: "inProgress",
+            title: "run_command",
+          });
+          const childItemCompleted = events.find(
+            (event) =>
+              event.type === "item.completed" &&
+              event.providerRefs?.providerThreadId === "conv-child-1",
+          );
+          expect(childItemCompleted?.payload).toMatchObject({
+            itemType: "command_execution",
+            status: "completed",
+            title: "run_command",
+          });
+          const childTurnCompleted = events.find(
+            (event) =>
+              event.type === "turn.completed" &&
+              event.providerRefs?.providerThreadId === "conv-child-1",
+          );
+          expect(childTurnCompleted?.payload).toEqual({
+            state: "completed",
+            stopReason: "model_stop",
+          });
+          // The parent thread must not be re-emitted for the subagent, and the
+          // session keeps its own conversation: its own tool events stay bound
+          // to conv-parent-1 without a parent ref.
+          expect(
+            events.filter(
+              (event) =>
+                event.type === "thread.started" &&
+                event.providerRefs?.providerThreadId === "conv-parent-1",
+            ),
+          ).toHaveLength(1);
+          const parentItem = events.find(
+            (event) =>
+              event.type === "item.started" &&
+              event.providerRefs?.providerThreadId === "conv-parent-1",
+          );
+          expect(parentItem?.providerRefs).toEqual({ providerThreadId: "conv-parent-1" });
+          expect(parentItem?.payload).toMatchObject({ title: "run_command" });
+
+          child?.emit("close", 0, null);
+          yield* Effect.sleep("25 millis");
+          yield* adapter.stopSession(threadId);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+            }).pipe(
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-subagent-events-" }),
               ),
               Layer.provideMerge(NodeServices.layer),
             ),
@@ -1135,9 +1342,9 @@ describe("Antigravity turn settle on cancel (#465)", () => {
 
   it("resolves default reasoning effort for Gemini 3.7 Flash and DeepSeek models", () => {
     expect(resolveAntigravityCliModelLabel("Gemini 3.7 Flash")).toBe("Gemini 3.7 Flash (High)");
-    expect(
-      resolveAntigravityCliModelLabel("Gemini 3.7 Flash", { reasoningEffort: "medium" }),
-    ).toBe("Gemini 3.7 Flash (Medium)");
+    expect(resolveAntigravityCliModelLabel("Gemini 3.7 Flash", { reasoningEffort: "medium" })).toBe(
+      "Gemini 3.7 Flash (Medium)",
+    );
     expect(resolveAntigravityCliModelLabel("DeepSeek V4 Flash Max")).toBe(
       "DeepSeek V4 Flash Max (High)",
     );

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -593,13 +593,17 @@ describe("Antigravity CLI integration helpers", () => {
     );
     expect(
       buildAntigravityCaptureCommand(
-        String.raw`C:\Program Files\Synara\Synara.exe`,
+        String.raw`C:\Users\test\AppData\Local\Programs\Synara\Synara.exe`,
         String.raw`C:\Users\test\.gemini\capture.cjs`,
         "pre-tool",
         "win32",
       ),
     ).toBe(
-      String.raw`if not defined SYNARA_ANTIGRAVITY_EVENTS (more >nul 2>nul & echo {"decision":"ask"}) else (set ELECTRON_RUN_AS_NODE=1&& "C:\Program Files\Synara\Synara.exe" "C:\Users\test\.gemini\capture.cjs" "pre-tool")`,
+      // The Antigravity CLI runs hook commands through cmd.exe with JSON
+      // escapes intact, so `"` arrives as `\"` and quoted paths fail to
+      // execute ("not recognized as an internal or external command"). The
+      // win32 command must stay free of double quotes.
+      String.raw`if not defined SYNARA_ANTIGRAVITY_EVENTS (more >nul 2>nul & echo {"decision":"ask"}) else (set ELECTRON_RUN_AS_NODE=1&& C:\Users\test\AppData\Local\Programs\Synara\Synara.exe C:\Users\test\.gemini\capture.cjs pre-tool)`,
     );
   });
 

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -42,6 +42,7 @@ function runCaptureCommand(command: string, input: string, env: NodeJS.ProcessEn
     input,
     encoding: "utf8",
     timeout: 5_000,
+    ...(process.platform === "win32" ? { windowsVerbatimArguments: true } : {}),
   });
 }
 
@@ -571,9 +572,9 @@ describe("Antigravity CLI integration helpers", () => {
       expect(result.stdout.trim()).toBe('{"decision":"allow"}');
       const captured = await fs.readFile(eventPath, "utf8");
       expect(captured).toBe(
-        'pre-tool\t{"conversationId":"conversation-1","transcriptPath":"/tmp/transcript.jsonl","stepIdx":12,"toolCall":{"name":"run_command"}}\n',
+        'pre-tool\t{"conversationId":"conversation-1","transcriptPath":"/tmp/transcript.jsonl","stepIdx":12,"toolCall":{"name":"run_command","args":{"CommandLine":"echo super-secret-token"}}}\n',
       );
-      expect(captured).not.toContain("super-secret-token");
+      expect(captured).toContain("super-secret-token");
     } finally {
       await fs.rm(directory, { recursive: true, force: true });
     }
@@ -598,7 +599,7 @@ describe("Antigravity CLI integration helpers", () => {
         "win32",
       ),
     ).toBe(
-      String.raw`if not defined SYNARA_ANTIGRAVITY_EVENTS (more >nul 2>nul & echo {"decision":"ask"}) else (set "ELECTRON_RUN_AS_NODE=1" && "C:\Program Files\Synara\Synara.exe" "C:\Users\test\.gemini\capture.cjs" "pre-tool")`,
+      String.raw`if not defined SYNARA_ANTIGRAVITY_EVENTS (more >nul 2>nul & echo {"decision":"ask"}) else (set ELECTRON_RUN_AS_NODE=1&& "C:\Program Files\Synara\Synara.exe" "C:\Users\test\.gemini\capture.cjs" "pre-tool")`,
     );
   });
 
@@ -648,7 +649,7 @@ describe("Antigravity CLI integration helpers", () => {
     }
   });
 
-  it("streams hook tool names and terminal states without arguments", async () => {
+  it("streams hook tool names and terminal states with arguments", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-tool-events-"));
     let eventFile: string | undefined;
     let child: ChildProcess | undefined;
@@ -726,6 +727,9 @@ describe("Antigravity CLI integration helpers", () => {
               data: {
                 toolCallId: `antigravity-${turn.turnId}-tool-0`,
                 toolName: "run_command",
+                arguments: { token: "super-secret-token" },
+                input: { token: "super-secret-token" },
+                rawInput: { token: "super-secret-token" },
               },
             },
             {
@@ -735,6 +739,10 @@ describe("Antigravity CLI integration helpers", () => {
               data: {
                 toolCallId: `antigravity-${turn.turnId}-tool-0`,
                 toolName: "run_command",
+                arguments: { token: "super-secret-token" },
+                input: { token: "super-secret-token" },
+                rawInput: { token: "super-secret-token" },
+                rawOutput: "super-secret-error",
               },
             },
             {
@@ -744,6 +752,9 @@ describe("Antigravity CLI integration helpers", () => {
               data: {
                 toolCallId: `antigravity-${turn.turnId}-tool-1`,
                 toolName: "write_to_file",
+                arguments: { content: "super-secret-content" },
+                input: { content: "super-secret-content" },
+                rawInput: { content: "super-secret-content" },
               },
             },
             {
@@ -753,10 +764,13 @@ describe("Antigravity CLI integration helpers", () => {
               data: {
                 toolCallId: `antigravity-${turn.turnId}-tool-1`,
                 toolName: "write_to_file",
+                arguments: { content: "super-secret-content" },
+                input: { content: "super-secret-content" },
+                rawInput: { content: "super-secret-content" },
+                rawOutput: "",
               },
             },
           ]);
-          expect(JSON.stringify(events)).not.toContain("super-secret");
 
           child?.emit("close", 0, null);
           yield* Effect.sleep("25 millis");
@@ -769,6 +783,146 @@ describe("Antigravity CLI integration helpers", () => {
             }).pipe(
               Layer.provideMerge(
                 ServerConfig.layerTest(root, { prefix: "antigravity-tool-events-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("renders a transcript tool call exactly once when the hook also reports it", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-tool-dedup-"));
+    const transcriptDir = path.join(
+      root,
+      ".gemini",
+      "antigravity-cli",
+      "brain",
+      "conv-dedup-1",
+      ".system_generated",
+      "logs",
+    );
+    await fs.mkdir(transcriptDir, { recursive: true });
+    const transcriptFile = path.join(transcriptDir, "transcript.jsonl");
+
+    let eventFile: string | undefined;
+    let child: ChildProcess | undefined;
+    const spawnProcess = ((
+      _command: string,
+      _args: readonly string[],
+      options: { readonly env?: NodeJS.ProcessEnv },
+    ) => {
+      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS;
+      const spawned = new EventEmitter() as ChildProcess;
+      Object.assign(spawned, {
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        killed: false,
+        kill: () => true,
+      });
+      child = spawned;
+      return spawned;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const toolEventsFiber = yield* adapter.streamEvents.pipe(
+            Stream.filter(
+              (event) => event.type === "item.started" || event.type === "item.completed",
+            ),
+            Stream.take(2),
+            Stream.runCollect,
+            Effect.forkChild,
+          );
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-tool-dedup");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+          const turn = yield* adapter.sendTurn({
+            threadId,
+            input: "run a command",
+            attachments: [],
+          });
+          expect(eventFile).toBeTruthy();
+
+          // Both the pre-tool hook and the transcript report the same call
+          // (step 1). The timeline must show it once — started + completed —
+          // and the transcript fallback must not duplicate it.
+          yield* Effect.promise(() =>
+            fs.appendFile(
+              eventFile!,
+              [
+                `pre-invocation\t${JSON.stringify({
+                  conversationId: "conv-dedup-1",
+                  transcriptPath: transcriptFile,
+                })}`,
+                'pre-tool\t{"stepIdx":1,"toolCall":{"name":"run_command","args":{"CommandLine":"echo dedup"}}}',
+                "post-tool\t{\"stepIdx\":1,\"error\":\"\"}",
+                "",
+              ].join("\n"),
+            ),
+          );
+          yield* Effect.promise(() =>
+            fs.appendFile(
+              transcriptFile,
+              [
+                JSON.stringify({
+                  step_index: 1,
+                  type: "PLANNER_RESPONSE",
+                  thinking: "planning",
+                  tool_calls: [{ name: "run_command", args: { CommandLine: "echo dedup" } }],
+                }),
+                "",
+              ].join("\n"),
+            ),
+          );
+
+          const events = Array.from(
+            yield* Fiber.join(toolEventsFiber).pipe(Effect.timeout("2 seconds")),
+          );
+          expect(events).toHaveLength(2);
+          expect(events.map((event) => event.type)).toEqual(["item.started", "item.completed"]);
+          const comparable = events.map((event) => ({
+            type: event.type,
+            itemType: event.payload.itemType,
+            title: event.payload.title,
+            toolCallId: (event.payload.data as { toolCallId?: string })?.toolCallId,
+          }));
+          expect(comparable).toEqual([
+            {
+              type: "item.started",
+              itemType: "command_execution",
+              title: "run_command",
+              toolCallId: `antigravity-${turn.turnId}-tool-0`,
+            },
+            {
+              type: "item.completed",
+              itemType: "command_execution",
+              title: "run_command",
+              toolCallId: `antigravity-${turn.turnId}-tool-0`,
+            },
+          ]);
+
+          child?.emit("close", 0, null);
+          yield* Effect.sleep("25 millis");
+          yield* adapter.stopSession(threadId);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+            }).pipe(
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-tool-dedup-" }),
               ),
               Layer.provideMerge(NodeServices.layer),
             ),
@@ -897,6 +1051,310 @@ describe("Antigravity turn settle on cancel (#465)", () => {
             }).pipe(
               Layer.provideMerge(
                 ServerConfig.layerTest(root, { prefix: "antigravity-interrupt-hung-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("emits a terminal interrupted turn.completed so the stop button unlocks", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-stop-button-"));
+    const children: ChildProcess[] = [];
+    const spawnProcess = makeSpawnProcess(children);
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-stop-button");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+          const turn = yield* adapter.sendTurn({
+            threadId,
+            input: "long running work",
+            attachments: [],
+          });
+
+          const terminalFiber = yield* adapter.streamEvents.pipe(
+            Stream.filter((event) => event.type === "turn.completed"),
+            Stream.take(1),
+            Stream.runCollect,
+            Effect.forkChild,
+          );
+
+          // The UI's Stop button dispatches thread.turn.interrupt, which lands
+          // on interruptTurn. It must settle the live turn terminal so the
+          // projection flips the session back to ready and the button clears.
+          yield* adapter.interruptTurn(threadId, turn.turnId);
+
+          const terminal = Array.from(
+            yield* Fiber.join(terminalFiber).pipe(Effect.timeout("2 seconds")),
+          );
+          expect(terminal).toHaveLength(1);
+          expect(terminal[0]?.turnId).toBe(turn.turnId);
+          expect(terminal[0]?.payload).toMatchObject({
+            state: "interrupted",
+            stopReason: "interrupted",
+          });
+
+          children[0]?.emit("close", 0, null);
+          yield* Effect.sleep("25 millis");
+          yield* adapter.stopSession(threadId);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+            }).pipe(
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-stop-button-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves default reasoning effort for Gemini 3.7 Flash and DeepSeek models", () => {
+    expect(resolveAntigravityCliModelLabel("Gemini 3.7 Flash")).toBe("Gemini 3.7 Flash (High)");
+    expect(
+      resolveAntigravityCliModelLabel("Gemini 3.7 Flash", { reasoningEffort: "medium" }),
+    ).toBe("Gemini 3.7 Flash (Medium)");
+    expect(resolveAntigravityCliModelLabel("DeepSeek V4 Flash Max")).toBe(
+      "DeepSeek V4 Flash Max (High)",
+    );
+  });
+
+  it("compacts multiline pre-invocation and stop hook payloads into single NDJSON lines", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-compact-"));
+    const scriptPath = path.join(directory, "capture.cjs");
+    const eventPath = path.join(directory, "events.ndjson");
+    try {
+      await fs.writeFile(scriptPath, hookScriptSource(), { mode: 0o700 });
+      const multilinePayload = JSON.stringify(
+        {
+          conversationId: "conv-123",
+          transcriptPath: "C:\\path\\to\\transcript.jsonl",
+          modelName: "Gemini 3.7 Flash",
+          workspacePaths: ["C:\\workspace"],
+        },
+        null,
+        2,
+      );
+
+      const preInvResult = runCaptureCommand(
+        buildAntigravityCaptureCommand(process.execPath, scriptPath, "pre-invocation"),
+        multilinePayload,
+        { SYNARA_ANTIGRAVITY_EVENTS: eventPath },
+      );
+      expect(preInvResult.status).toBe(0);
+
+      const stopResult = runCaptureCommand(
+        buildAntigravityCaptureCommand(process.execPath, scriptPath, "stop"),
+        multilinePayload,
+        { SYNARA_ANTIGRAVITY_EVENTS: eventPath },
+      );
+      expect(stopResult.status).toBe(0);
+
+      const fileContent = await fs.readFile(eventPath, "utf8");
+      const lines = fileContent.split("\n").filter(Boolean);
+      expect(lines).toHaveLength(2);
+      expect(lines[0]?.startsWith("pre-invocation\t{")).toBe(true);
+      expect(lines[1]?.startsWith("stop\t{")).toBe(true);
+      expect(JSON.parse(lines[0]!.split("\t")[1]!)).toMatchObject({
+        conversationId: "conv-123",
+        transcriptPath: "C:\\path\\to\\transcript.jsonl",
+        modelName: "Gemini 3.7 Flash",
+      });
+    } finally {
+      await fs.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("streams reasoning traces from thinking steps and assistant text from final steps in transcript", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-transcript-test-"));
+    const transcriptDir = path.join(
+      root,
+      ".gemini",
+      "antigravity-cli",
+      "brain",
+      "conv-test-1",
+      ".system_generated",
+      "logs",
+    );
+    await fs.mkdir(transcriptDir, { recursive: true });
+    const transcriptFile = path.join(transcriptDir, "transcript.jsonl");
+
+    let eventFile: string | undefined;
+    let child: ChildProcess | undefined;
+    const spawnProcess = ((
+      _command: string,
+      _args: readonly string[],
+      options: { readonly env?: NodeJS.ProcessEnv },
+    ) => {
+      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS;
+      const spawned = new EventEmitter() as ChildProcess;
+      Object.assign(spawned, {
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        killed: false,
+        kill: () => true,
+      });
+      child = spawned;
+      return spawned;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const eventsFiber = yield* adapter.streamEvents.pipe(
+            Stream.filter(
+              (event) =>
+                event.type === "item.started" ||
+                event.type === "content.delta" ||
+                event.type === "item.completed",
+            ),
+            Stream.take(8),
+            Stream.runCollect,
+            Effect.forkChild,
+          );
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-transcript");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+          yield* adapter.sendTurn({
+            threadId,
+            input: "solve problem",
+            attachments: [],
+          });
+
+          expect(eventFile).toBeTruthy();
+          // 1. Hook fires with learned transcriptPath
+          yield* Effect.promise(() =>
+            fs.appendFile(
+              eventFile!,
+              `pre-invocation\t${JSON.stringify({
+                conversationId: "conv-test-1",
+                transcriptPath: transcriptFile,
+              })}\n`,
+            ),
+          );
+
+          // 2. Transcript records a reasoning step (with tool_calls and thinking) + an assistant completion step
+          yield* Effect.promise(() =>
+            fs.appendFile(
+              transcriptFile,
+              [
+                JSON.stringify({
+                  step_index: 0,
+                  type: "USER_INPUT",
+                  content: "solve problem",
+                }),
+                JSON.stringify({
+                  step_index: 1,
+                  type: "PLANNER_RESPONSE",
+                  thinking: "Analyzing problem requirements...",
+                  tool_calls: [{ name: "run_command", args: { CommandLine: "echo test" } }],
+                }),
+                JSON.stringify({
+                  step_index: 2,
+                  type: "PLANNER_RESPONSE",
+                  content: "Here is the solution.",
+                }),
+                "",
+              ].join("\n"),
+            ),
+          );
+
+          const events = Array.from(
+            yield* Fiber.join(eventsFiber).pipe(Effect.timeout("2 seconds")),
+          );
+          expect(events).toHaveLength(8);
+          // Reasoning item: started -> delta -> completed
+          expect(events[0]?.payload).toMatchObject({
+            itemType: "reasoning",
+            status: "inProgress",
+            title: "Reasoning",
+          });
+          expect(events[1]?.payload).toMatchObject({
+            streamKind: "reasoning_text",
+            delta: "Analyzing problem requirements...",
+          });
+          expect(events[2]?.payload).toMatchObject({
+            itemType: "reasoning",
+            status: "completed",
+            title: "Reasoning",
+            detail: "Analyzing problem requirements...",
+          });
+          // Tool call from the transcript body surfaces as a tool lifecycle
+          // item even though no pre/post-tool hook event fired: reasoning ->
+          // run_command -> assistant. (#antigravity tool calls are displayed)
+          expect(events[3]?.payload).toMatchObject({
+            itemType: "command_execution",
+            status: "inProgress",
+            title: "run_command",
+            data: {
+              toolName: "run_command",
+              command: "echo test",
+              arguments: { CommandLine: "echo test" },
+            },
+          });
+          expect(events[4]?.payload).toMatchObject({
+            itemType: "command_execution",
+            status: "completed",
+            title: "run_command",
+            data: {
+              toolName: "run_command",
+              command: "echo test",
+              arguments: { CommandLine: "echo test" },
+            },
+          });
+          // Assistant message: started -> delta -> completed
+          expect(events[5]?.payload).toMatchObject({
+            itemType: "assistant_message",
+            status: "inProgress",
+            title: "Assistant",
+          });
+          expect(events[6]?.payload).toMatchObject({
+            streamKind: "assistant_text",
+            delta: "Here is the solution.",
+          });
+          expect(events[7]?.payload).toMatchObject({
+            itemType: "assistant_message",
+            status: "completed",
+            title: "Assistant",
+          });
+
+          child?.emit("close", 0, null);
+          yield* Effect.sleep("25 millis");
+          yield* adapter.stopSession(threadId);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+            }).pipe(
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-transcript-test-" }),
               ),
               Layer.provideMerge(NodeServices.layer),
             ),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -837,7 +837,7 @@ describe("Antigravity CLI integration helpers", () => {
     }
   });
 
-  it("renders a transcript tool call exactly once when the hook also reports it", async () => {
+  it("dedupes hook and transcript copies without collapsing repeated tool names", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-tool-dedup-"));
     const transcriptDir = path.join(
       root,
@@ -878,7 +878,7 @@ describe("Antigravity CLI integration helpers", () => {
             Stream.filter(
               (event) => event.type === "item.started" || event.type === "item.completed",
             ),
-            Stream.take(2),
+            Stream.take(4),
             Stream.runCollect,
             Effect.forkChild,
           );
@@ -897,9 +897,9 @@ describe("Antigravity CLI integration helpers", () => {
           });
           expect(eventFile).toBeTruthy();
 
-          // Both the pre-tool hook and the transcript report the same call
-          // (step 1). The timeline must show it once — started + completed —
-          // and the transcript fallback must not duplicate it.
+          // Both sources report two run_command calls in the same planner step.
+          // Each real call must render once, without either duplicating the
+          // hook/transcript copy or collapsing the repeated tool name.
           yield* Effect.promise(() =>
             fs.appendFile(
               eventFile!,
@@ -908,8 +908,10 @@ describe("Antigravity CLI integration helpers", () => {
                   conversationId: "conv-dedup-1",
                   transcriptPath: transcriptFile,
                 })}`,
-                'pre-tool\t{"stepIdx":1,"toolCall":{"name":"run_command","args":{"CommandLine":"echo dedup"}}}',
-                'post-tool\t{"stepIdx":1,"error":""}',
+                'pre-tool\t{"stepIdx":1,"toolCall":{"name":"run_command","args":{"CommandLine":"echo first"}}}',
+                'post-tool\t{"stepIdx":1,"toolCall":{"name":"run_command"},"error":""}',
+                'pre-tool\t{"stepIdx":1,"toolCall":{"name":"run_command","args":{"CommandLine":"echo second"}}}',
+                'post-tool\t{"stepIdx":1,"toolCall":{"name":"run_command"},"error":""}',
                 "",
               ].join("\n"),
             ),
@@ -922,7 +924,10 @@ describe("Antigravity CLI integration helpers", () => {
                   step_index: 1,
                   type: "PLANNER_RESPONSE",
                   thinking: "planning",
-                  tool_calls: [{ name: "run_command", args: { CommandLine: "echo dedup" } }],
+                  tool_calls: [
+                    { name: "run_command", args: { CommandLine: "echo first" } },
+                    { name: "run_command", args: { CommandLine: "echo second" } },
+                  ],
                 }),
                 "",
               ].join("\n"),
@@ -932,8 +937,13 @@ describe("Antigravity CLI integration helpers", () => {
           const events = Array.from(
             yield* Fiber.join(toolEventsFiber).pipe(Effect.timeout("2 seconds")),
           );
-          expect(events).toHaveLength(2);
-          expect(events.map((event) => event.type)).toEqual(["item.started", "item.completed"]);
+          expect(events).toHaveLength(4);
+          expect(events.map((event) => event.type)).toEqual([
+            "item.started",
+            "item.completed",
+            "item.started",
+            "item.completed",
+          ]);
           const comparable = events.map((event) => ({
             type: event.type,
             itemType: event.payload.itemType,
@@ -952,6 +962,18 @@ describe("Antigravity CLI integration helpers", () => {
               itemType: "command_execution",
               title: "run_command",
               toolCallId: `antigravity-${turn.turnId}-tool-0`,
+            },
+            {
+              type: "item.started",
+              itemType: "command_execution",
+              title: "run_command",
+              toolCallId: `antigravity-${turn.turnId}-tool-1`,
+            },
+            {
+              type: "item.completed",
+              itemType: "command_execution",
+              title: "run_command",
+              toolCallId: `antigravity-${turn.turnId}-tool-1`,
             },
           ]);
 
@@ -1003,7 +1025,11 @@ describe("Antigravity CLI integration helpers", () => {
         Effect.gen(function* () {
           const adapter = yield* AntigravityAdapter;
           const eventsFiber = yield* adapter.streamEvents.pipe(
-            Stream.take(9),
+            Stream.takeUntil(
+              (event) =>
+                event.type === "item.started" &&
+                event.providerRefs?.providerThreadId === "conv-parent-1",
+            ),
             Stream.runCollect,
             Effect.forkChild,
           );
@@ -1044,6 +1070,7 @@ describe("Antigravity CLI integration helpers", () => {
                   stepIdx: 1,
                   error: "",
                 })}`,
+                `stop\t${JSON.stringify({ conversationId: "conv-child-1" })}`,
                 `stop\t${JSON.stringify({ conversationId: "conv-child-1" })}`,
                 `pre-tool\t${JSON.stringify({
                   conversationId: "conv-parent-1",
@@ -1105,6 +1132,13 @@ describe("Antigravity CLI integration helpers", () => {
             state: "completed",
             stopReason: "model_stop",
           });
+          expect(
+            events.filter(
+              (event) =>
+                event.type === "turn.completed" &&
+                event.providerRefs?.providerThreadId === "conv-child-1",
+            ),
+          ).toHaveLength(1);
           // The parent thread must not be re-emitted for the subagent, and the
           // session keeps its own conversation: its own tool events stay bound
           // to conv-parent-1 without a parent ref.
@@ -1134,6 +1168,114 @@ describe("Antigravity CLI integration helpers", () => {
             }).pipe(
               Layer.provideMerge(
                 ServerConfig.layerTest(root, { prefix: "antigravity-subagent-events-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("settles an unfinished child turn when the parent process fails", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-child-failure-"));
+    let eventFile: string | undefined;
+    let child: ChildProcess | undefined;
+    const spawnProcess = ((
+      _command: string,
+      _args: readonly string[],
+      options: { readonly env?: NodeJS.ProcessEnv },
+    ) => {
+      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS;
+      const spawned = new EventEmitter() as ChildProcess;
+      Object.assign(spawned, {
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        killed: false,
+        kill: () => true,
+      });
+      child = spawned;
+      return spawned;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const eventsFiber = yield* adapter.streamEvents.pipe(
+            Stream.takeUntil(
+              (event) =>
+                event.type === "turn.completed" &&
+                event.providerRefs?.providerParentThreadId === undefined,
+            ),
+            Stream.runCollect,
+            Effect.forkChild,
+          );
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-child-failure");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            resumeCursor: { conversationId: "conv-parent-failure" },
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+          yield* adapter.sendTurn({
+            threadId,
+            input: "spawn a failing subagent",
+            attachments: [],
+          });
+          expect(eventFile).toBeTruthy();
+
+          yield* Effect.promise(() =>
+            fs.appendFile(
+              eventFile!,
+              `pre-invocation\t${JSON.stringify({
+                conversationId: "conv-child-failure",
+                modelName: "gemini-3.6-flash-medium",
+              })}\n`,
+            ),
+          );
+          child?.emit("close", 1, null);
+
+          const events = Array.from(
+            yield* Fiber.join(eventsFiber).pipe(Effect.timeout("2 seconds")),
+          );
+          const childTerminalIndex = events.findIndex(
+            (event) =>
+              event.type === "turn.completed" &&
+              event.providerRefs?.providerThreadId === "conv-child-failure",
+          );
+          const parentTerminalIndex = events.findIndex(
+            (event) =>
+              event.type === "turn.completed" &&
+              event.providerRefs?.providerParentThreadId === undefined,
+          );
+          expect(childTerminalIndex).toBeGreaterThanOrEqual(0);
+          expect(childTerminalIndex).toBeLessThan(parentTerminalIndex);
+          expect(events[childTerminalIndex]?.payload).toMatchObject({
+            state: "failed",
+            stopReason: "error",
+          });
+          expect(
+            events.filter(
+              (event) =>
+                event.type === "turn.completed" &&
+                event.providerRefs?.providerThreadId === "conv-child-failure",
+            ),
+          ).toHaveLength(1);
+
+          yield* adapter.stopSession(threadId);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+            }).pipe(
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-child-failure-" }),
               ),
               Layer.provideMerge(NodeServices.layer),
             ),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -120,6 +120,24 @@ type AntigravitySessionContext = {
   pendingTools: PendingTool[];
   nextToolSequence: number;
   /**
+   * Conversations owned by spawned subagents, keyed by conversation id.
+   * The capture hook is installed globally, so a subagent CLI spawned by the
+   * session's own CLI inherits `SYNARA_ANTIGRAVITY_EVENTS` and writes its
+   * pre-invocation/tool/stop events into this session's hook stream. Those
+   * events describe a different process and conversation and must never
+   * rebind the session; they are forwarded as child-thread events carrying
+   * `providerParentThreadId` so the ingestion layer materializes a visible
+   * subagent thread.
+   */
+  foreignConversations: Map<
+    string,
+    {
+      pendingTools: PendingTool[];
+      surfacedToolCalls: Set<string>;
+      nextToolSequence: number;
+    }
+  >;
+  /**
    * Tool calls already surfaced as work-log items, keyed by
    * `${stepIndex}:${toolName}`. Both the capture-hook stream (pre-tool events)
    * and the transcript body (PLANNER_RESPONSE.tool_calls) feed this set so the
@@ -177,6 +195,15 @@ function shellQuote(value: string, platform: NodeJS.Platform = process.platform)
  * object is treated as a denial with an empty reason, which blocks every tool
  * call because the hook is installed globally with `matcher: "*"` (#490).
  * "ask" preserves the permission flow the user would have without the hook.
+ *
+ * PreInvocation fires immediately before an LLM invocation and is a veto
+ * point with the same decision semantics: an empty object is treated as a
+ * denial that aborts the invocation. The CLI raises a PreInvocation for the
+ * subagent's first model call when the parent agent invokes a subagent, so
+ * `{}` there denies the subagent launch and the parent CLI exits with code 1
+ * ("Antigravity CLI exited with code 1."). Synara-managed sessions spawn
+ * subagents deliberately, so pre-invocation must answer "allow".
+ *
  * `{}` stays correct for the other hook points, including Stop, where an
  * inactive hook must not force a decision over Antigravity's default.
  *
@@ -187,7 +214,9 @@ function shellQuote(value: string, platform: NodeJS.Platform = process.platform)
  * "Working" and Cancel has nothing left to kill (#465).
  */
 function inactiveHookOutput(event: string): string {
-  return event === "pre-tool" ? '{"decision":"ask"}' : "{}";
+  if (event === "pre-tool") return '{"decision":"ask"}';
+  if (event === "pre-invocation") return '{"decision":"allow"}';
+  return "{}";
 }
 
 export function buildAntigravityCaptureCommand(
@@ -222,8 +251,16 @@ process.stdin.on("end", () => {
   const target = process.env.SYNARA_ANTIGRAVITY_EVENTS;
   if (!target) {
     // Mirrors the shell wrapper's inactive fallback: PreToolUse must carry a
-    // decision or Antigravity denies the tool call with an empty reason.
-    process.stdout.write((event === "pre-tool" ? '{"decision":"ask"}' : "{}") + "\\n");
+    // decision or Antigravity denies the tool call with an empty reason, and
+    // PreInvocation must carry "allow" or the subagent launch it gates is
+    // denied and the parent CLI exits with code 1.
+    process.stdout.write(
+      (event === "pre-tool"
+        ? '{"decision":"ask"}'
+        : event === "pre-invocation"
+          ? '{"decision":"allow"}'
+          : "{}") + "\\n",
+    );
     return;
   }
   let capturedPayload = payload.trim();
@@ -271,6 +308,11 @@ process.stdin.on("end", () => {
   if (event === "pre-tool") {
     const decision = process.env.SYNARA_ANTIGRAVITY_HOOK_DECISION === "allow" ? "allow" : "ask";
     process.stdout.write(JSON.stringify({ decision }) + "\\n");
+  } else if (event === "pre-invocation") {
+    // PreInvocation vetoes the upcoming LLM invocation; Synara-managed
+    // sessions run subagents deliberately, so never block them here. An
+    // empty object would deny the launch and the parent CLI exits 1.
+    process.stdout.write('{"decision":"allow"}\\n');
   } else {
     // Stop and other non-tool hooks: empty object allows the agent to exit.
     // Do not emit decision:"stop" — it is not a recognized stop decision and
@@ -617,11 +659,7 @@ function buildAntigravityToolItemData(
           ? args.cmd
           : undefined;
   const cwd =
-    typeof args?.Cwd === "string"
-      ? args.Cwd
-      : typeof args?.cwd === "string"
-        ? args.cwd
-        : undefined;
+    typeof args?.Cwd === "string" ? args.Cwd : typeof args?.cwd === "string" ? args.cwd : undefined;
   const pathValue =
     typeof args?.TargetFile === "string"
       ? args.TargetFile
@@ -644,10 +682,7 @@ function buildAntigravityToolItemData(
         : undefined;
 
   const rawOutput =
-    postPayload?.toolOutput ??
-    postPayload?.result ??
-    postPayload?.error ??
-    undefined;
+    postPayload?.toolOutput ?? postPayload?.result ?? postPayload?.error ?? undefined;
 
   return {
     toolCallId: itemId,
@@ -1018,6 +1053,179 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       }
     };
 
+    const withForeignProviderRefs = (
+      event: ProviderRuntimeEvent,
+      conversationId: string,
+      parentConversationId: string,
+    ): ProviderRuntimeEvent => ({
+      ...event,
+      providerRefs: {
+        providerThreadId: conversationId,
+        providerParentThreadId: parentConversationId,
+      },
+    });
+
+    /**
+     * Forward a hook event that belongs to a subagent conversation spawned by
+     * the session's own CLI. The capture hook is installed globally, so the
+     * subagent CLI inherits `SYNARA_ANTIGRAVITY_EVENTS` and writes its
+     * events into this session's hook stream. Those events describe a
+     * different process and conversation: they must never rebind the session
+     * (cursor, transcript, thread) — instead they are surfaced as child-thread
+     * events carrying `providerParentThreadId` so the ingestion layer
+     * materializes a visible subagent thread.
+     */
+    const handleForeignHookEvent = async (
+      context: AntigravitySessionContext,
+      input: {
+        readonly eventName: string;
+        readonly payload: Record<string, unknown>;
+        readonly conversationId: string;
+        readonly ownConversationId: string;
+        readonly modelName?: string;
+      },
+    ): Promise<void> => {
+      const { eventName, payload, conversationId, ownConversationId, modelName } = input;
+      let child = context.foreignConversations.get(conversationId);
+      if (!child) {
+        child = { pendingTools: [], surfacedToolCalls: new Set(), nextToolSequence: 0 };
+        context.foreignConversations.set(conversationId, child);
+        offer(
+          withForeignProviderRefs(
+            {
+              ...base(context, { includeTurn: false }),
+              type: "thread.started",
+              payload: { providerThreadId: conversationId },
+              raw: raw(eventName, payload),
+            } satisfies ProviderRuntimeEvent,
+            conversationId,
+            ownConversationId,
+          ),
+        );
+        offer(
+          withForeignProviderRefs(
+            {
+              ...base(context),
+              type: "turn.started",
+              payload: { model: modelName ?? context.modelName ?? DEFAULT_MODEL },
+              raw: raw(eventName, payload),
+            } satisfies ProviderRuntimeEvent,
+            conversationId,
+            ownConversationId,
+          ),
+        );
+      }
+      const stepIndex =
+        typeof payload.stepIdx === "number" &&
+        Number.isInteger(payload.stepIdx) &&
+        payload.stepIdx >= 0
+          ? payload.stepIdx
+          : undefined;
+      if (eventName === "pre-tool" && stepIndex !== undefined) {
+        const toolCall =
+          payload.toolCall && typeof payload.toolCall === "object"
+            ? (payload.toolCall as Record<string, unknown>)
+            : undefined;
+        const name = typeof toolCall?.name === "string" ? trim(toolCall.name) : undefined;
+        const toolArgs =
+          toolCall?.args && typeof toolCall.args === "object"
+            ? (toolCall.args as Record<string, unknown>)
+            : undefined;
+        if (name) {
+          const surfaceKey = `${stepIndex}:${name}`;
+          if (child.surfacedToolCalls.has(surfaceKey)) return;
+          child.surfacedToolCalls.add(surfaceKey);
+          const itemId = RuntimeItemId.makeUnsafe(
+            `antigravity-${context.activeTurnId ?? "turn"}-tool-${child.nextToolSequence++}`,
+          );
+          const itemType = toolItemType(name);
+          child.pendingTools.push({
+            stepIndex,
+            itemId,
+            itemType,
+            name,
+            ...(toolArgs ? { args: toolArgs } : {}),
+          } satisfies PendingTool);
+          offer(
+            withForeignProviderRefs(
+              {
+                ...base(context, { itemId }),
+                type: "item.started",
+                payload: {
+                  itemType,
+                  status: "inProgress",
+                  title: name,
+                  data: buildAntigravityToolItemData(name, itemType, itemId, toolArgs),
+                },
+                raw: raw("tool-lifecycle", {
+                  eventName,
+                  stepIdx: stepIndex,
+                  name,
+                  args: toolArgs,
+                }),
+              } satisfies ProviderRuntimeEvent,
+              conversationId,
+              ownConversationId,
+            ),
+          );
+        }
+      } else if (eventName === "post-tool" && stepIndex !== undefined) {
+        const pendingIndex = child.pendingTools.findIndex(
+          (pending) => pending.stepIndex === stepIndex,
+        );
+        const pending =
+          pendingIndex >= 0 ? child.pendingTools.splice(pendingIndex, 1)[0] : undefined;
+        if (pending) {
+          const failed =
+            payload.failed === true ||
+            (typeof payload.error === "string" && payload.error.trim().length > 0);
+          offer(
+            withForeignProviderRefs(
+              {
+                ...base(context, { itemId: pending.itemId }),
+                type: "item.completed",
+                payload: {
+                  itemType: pending.itemType,
+                  status: failed ? "failed" : "completed",
+                  title: pending.name,
+                  data: buildAntigravityToolItemData(
+                    pending.name,
+                    pending.itemType,
+                    pending.itemId,
+                    pending.args,
+                    payload,
+                  ),
+                },
+                raw: raw("tool-lifecycle", {
+                  eventName,
+                  stepIdx: stepIndex,
+                  name: pending.name,
+                  failed,
+                }),
+              } satisfies ProviderRuntimeEvent,
+              conversationId,
+              ownConversationId,
+            ),
+          );
+        }
+      } else if (eventName === "stop") {
+        // The subagent finished; settle its child turn. Never tear down the
+        // session's own CLI process for a foreign stop.
+        offer(
+          withForeignProviderRefs(
+            {
+              ...base(context),
+              type: "turn.completed",
+              payload: { state: "completed", stopReason: "model_stop" },
+              raw: raw(eventName, payload),
+            } satisfies ProviderRuntimeEvent,
+            conversationId,
+            ownConversationId,
+          ),
+        );
+      }
+    };
+
     const pollHookFile = async (context: AntigravitySessionContext) => {
       if (context.stopped) return;
       if (!context.eventFile) return;
@@ -1043,6 +1251,24 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         const transcriptPath =
           typeof payload.transcriptPath === "string" ? payload.transcriptPath : undefined;
         const modelName = typeof payload.modelName === "string" ? payload.modelName : undefined;
+        const ownConversationId = context.conversationId;
+        if (
+          conversationId !== undefined &&
+          ownConversationId !== undefined &&
+          conversationId !== ownConversationId
+        ) {
+          // The session's CLI spawned a subagent that writes into the same
+          // hook stream. Forward the event to the subagent's child thread and
+          // never rebind this session.
+          await handleForeignHookEvent(context, {
+            eventName,
+            payload,
+            conversationId,
+            ownConversationId,
+            ...(modelName ? { modelName } : {}),
+          });
+          continue;
+        }
         const learnedConversation = conversationId && conversationId !== context.conversationId;
         if (conversationId) context.conversationId = conversationId;
         if (transcriptPath && transcriptPath !== context.transcriptPath) {
@@ -1228,6 +1454,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           processedSteps: new Set(),
           pendingTools: [],
           nextToolSequence: 0,
+          foreignConversations: new Map(),
           surfacedToolCalls: new Set(),
           sawAssistant: false,
           interrupted: false,

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -90,6 +90,7 @@ type PendingTool = {
   readonly itemId: RuntimeItemId;
   readonly itemType: "command_execution" | "file_change" | "dynamic_tool_call" | "web_search";
   readonly name: string;
+  readonly args?: Record<string, unknown>;
 };
 
 type StoredTurn = {
@@ -118,6 +119,14 @@ type AntigravitySessionContext = {
   processedSteps: Set<number>;
   pendingTools: PendingTool[];
   nextToolSequence: number;
+  /**
+   * Tool calls already surfaced as work-log items, keyed by
+   * `${stepIndex}:${toolName}`. Both the capture-hook stream (pre-tool events)
+   * and the transcript body (PLANNER_RESPONSE.tool_calls) feed this set so the
+   * same call is rendered exactly once regardless of which source arrives
+   * first — and a call the hook never reports still appears in the timeline.
+   */
+  surfacedToolCalls: Set<string>;
   sawAssistant: boolean;
   interrupted: boolean;
   stopped: boolean;
@@ -190,7 +199,7 @@ export function buildAntigravityCaptureCommand(
   const invocation = `${shellQuote(executablePath, platform)} ${shellQuote(scriptPath, platform)} ${shellQuote(event, platform)}`;
   const fallback = inactiveHookOutput(event);
   if (platform === "win32") {
-    return `if not defined SYNARA_ANTIGRAVITY_EVENTS (more >nul 2>nul & echo ${fallback}) else (set "ELECTRON_RUN_AS_NODE=1" && ${invocation})`;
+    return `if not defined SYNARA_ANTIGRAVITY_EVENTS (more >nul 2>nul & echo ${fallback}) else (set ELECTRON_RUN_AS_NODE=1&& ${invocation})`;
   }
   return `if [ -z "\${SYNARA_ANTIGRAVITY_EVENTS:-}" ]; then cat >/dev/null 2>&1 || :; printf '%s\\n' '${fallback}'; else ELECTRON_RUN_AS_NODE=1 ${invocation}; fi`;
 }
@@ -210,26 +219,45 @@ process.stdin.on("end", () => {
     return;
   }
   let capturedPayload = payload.trim();
-  if (event === "pre-tool" || event === "post-tool") {
-    try {
-      const input = JSON.parse(capturedPayload);
-      const sanitized = {};
-      for (const key of ["conversationId", "transcriptPath", "modelName"]) {
-        if (typeof input[key] === "string" && input[key].trim()) sanitized[key] = input[key];
-      }
-      if (Number.isInteger(input.stepIdx) && input.stepIdx >= 0) sanitized.stepIdx = input.stepIdx;
-      if (event === "pre-tool") {
-        const name = input.toolCall && typeof input.toolCall.name === "string"
-          ? input.toolCall.name.trim()
-          : "";
-        if (name) sanitized.toolCall = { name };
-      } else {
-        sanitized.failed = typeof input.error === "string" && input.error.trim().length > 0;
-      }
-      capturedPayload = JSON.stringify(sanitized);
-    } catch {
-      capturedPayload = "{}";
+  try {
+    const input = JSON.parse(capturedPayload);
+    const sanitized = {};
+    for (const key of ["conversationId", "transcriptPath", "modelName"]) {
+      if (typeof input[key] === "string" && input[key].trim()) sanitized[key] = input[key];
     }
+    if (Number.isInteger(input.stepIdx) && input.stepIdx >= 0) sanitized.stepIdx = input.stepIdx;
+    if (event === "pre-tool") {
+      const name = input.toolCall && typeof input.toolCall.name === "string"
+        ? input.toolCall.name.trim()
+        : "";
+      if (name) {
+        sanitized.toolCall = {
+          name,
+          ...(input.toolCall.args && typeof input.toolCall.args === "object"
+            ? { args: input.toolCall.args }
+            : {}),
+        };
+      }
+    } else if (event === "post-tool") {
+      const name = input.toolCall && typeof input.toolCall.name === "string"
+        ? input.toolCall.name.trim()
+        : "";
+      if (name) {
+        sanitized.toolCall = {
+          name,
+          ...(input.toolCall.args && typeof input.toolCall.args === "object"
+            ? { args: input.toolCall.args }
+            : {}),
+        };
+      }
+      sanitized.failed = typeof input.error === "string" && input.error.trim().length > 0;
+      if (typeof input.error === "string" && input.error.trim()) sanitized.error = input.error;
+      if (input.toolOutput !== undefined) sanitized.toolOutput = input.toolOutput;
+      if (input.result !== undefined) sanitized.result = input.result;
+    }
+    capturedPayload = JSON.stringify(sanitized);
+  } catch {
+    capturedPayload = "{}";
   }
   fs.appendFileSync(target, event + "\\t" + capturedPayload + "\\n");
   if (event === "pre-tool") {
@@ -442,11 +470,14 @@ export function buildAntigravityTurnPrompt(
 }
 
 const DEFAULT_EFFORT_BY_MODEL: Readonly<Record<string, string>> = {
+  "Gemini 3.7 Flash": "high",
   "Gemini 3.6 Flash": "medium",
   "Gemini 3.5 Flash": "medium",
   "Gemini 3.1 Pro": "low",
   "Claude Sonnet 4.6": "thinking",
   "Claude Opus 4.6": "thinking",
+  "Claude 3.7 Sonnet": "thinking",
+  "DeepSeek V4 Flash Max": "high",
   "GPT-OSS 120B": "medium",
 };
 
@@ -560,6 +591,66 @@ function toolItemType(name: string): PendingTool["itemType"] {
   }
   if (name === "search_web" || name.startsWith("browser_")) return "web_search";
   return "dynamic_tool_call";
+}
+
+function buildAntigravityToolItemData(
+  name: string,
+  _itemType: PendingTool["itemType"],
+  itemId: RuntimeItemId,
+  args?: Record<string, unknown>,
+  postPayload?: Record<string, unknown>,
+): Record<string, unknown> {
+  const command =
+    typeof args?.CommandLine === "string"
+      ? args.CommandLine
+      : typeof args?.command === "string"
+        ? args.command
+        : typeof args?.cmd === "string"
+          ? args.cmd
+          : undefined;
+  const cwd =
+    typeof args?.Cwd === "string"
+      ? args.Cwd
+      : typeof args?.cwd === "string"
+        ? args.cwd
+        : undefined;
+  const pathValue =
+    typeof args?.TargetFile === "string"
+      ? args.TargetFile
+      : typeof args?.AbsolutePath === "string"
+        ? args.AbsolutePath
+        : typeof args?.DirectoryPath === "string"
+          ? args.DirectoryPath
+          : typeof args?.SearchPath === "string"
+            ? args.SearchPath
+            : typeof args?.path === "string"
+              ? args.path
+              : typeof args?.file === "string"
+                ? args.file
+                : undefined;
+  const query =
+    typeof args?.Query === "string"
+      ? args.Query
+      : typeof args?.query === "string"
+        ? args.query
+        : undefined;
+
+  const rawOutput =
+    postPayload?.toolOutput ??
+    postPayload?.result ??
+    postPayload?.error ??
+    undefined;
+
+  return {
+    toolCallId: itemId,
+    toolName: name,
+    ...(command ? { command } : {}),
+    ...(cwd ? { cwd } : {}),
+    ...(pathValue ? { path: pathValue, file: pathValue } : {}),
+    ...(query ? { query } : {}),
+    ...(args ? { arguments: args, input: args, rawInput: args } : {}),
+    ...(rawOutput !== undefined ? { rawOutput } : {}),
+  };
 }
 
 export function makeAntigravityRuntimeEventBase(input: {
@@ -744,8 +835,9 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       step: TranscriptStep,
       itemType: "assistant_message" | "reasoning",
       streamKind: "assistant_text" | "reasoning_text",
+      explicitContent?: string,
     ) => {
-      const content = trim(step.content);
+      const content = trim(explicitContent ?? step.content);
       if (!content) return;
       const itemId = RuntimeItemId.makeUnsafe(
         `antigravity-${context.activeTurnId ?? "turn"}-${step.step_index ?? crypto.randomUUID()}-${itemType}`,
@@ -781,6 +873,58 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       if (itemType === "assistant_message") context.sawAssistant = true;
     };
 
+    /**
+     * Surface tool calls recorded in the transcript body as tool lifecycle
+     * items. This is the fallback for calls the capture hook never reported
+     * (plugin not installed this session, hook payload missing stepIdx, ...).
+     * `surfacedToolCalls` dedupes against the hook stream so a call the hook
+     * already rendered — or will render — is not emitted twice.
+     */
+    const emitTranscriptToolCalls = (
+      context: AntigravitySessionContext,
+      stepIndex: number,
+      calls: ReadonlyArray<NonNullable<TranscriptStep["tool_calls"]>[number]>,
+    ) => {
+      for (const call of calls) {
+        const name = typeof call?.name === "string" ? trim(call.name) : undefined;
+        if (!name) continue;
+        const surfaceKey = `${stepIndex}:${name}`;
+        if (context.surfacedToolCalls.has(surfaceKey)) continue;
+        context.surfacedToolCalls.add(surfaceKey);
+        const args =
+          call.args && typeof call.args === "object"
+            ? (call.args as Record<string, unknown>)
+            : undefined;
+        const itemId = RuntimeItemId.makeUnsafe(
+          `antigravity-${context.activeTurnId ?? "turn"}-tool-${context.nextToolSequence++}`,
+        );
+        const itemType = toolItemType(name);
+        const data = buildAntigravityToolItemData(name, itemType, itemId, args);
+        offer({
+          ...base(context, { itemId }),
+          type: "item.started",
+          payload: {
+            itemType,
+            status: "inProgress",
+            title: name,
+            data,
+          },
+          raw: raw("transcript-tool-call", { stepIdx: stepIndex, name, args }),
+        } satisfies ProviderRuntimeEvent);
+        offer({
+          ...base(context, { itemId }),
+          type: "item.completed",
+          payload: {
+            itemType,
+            status: "completed",
+            title: name,
+            data,
+          },
+          raw: raw("transcript-tool-call", { stepIdx: stepIndex, name, args }),
+        } satisfies ProviderRuntimeEvent);
+      }
+    };
+
     const processTranscriptStep = (context: AntigravitySessionContext, step: TranscriptStep) => {
       const stepIndex = step.step_index;
       if (typeof stepIndex !== "number" || context.processedSteps.has(stepIndex)) return;
@@ -790,9 +934,28 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       if (step.type === "PLANNER_RESPONSE") {
         const calls = Array.isArray(step.tool_calls) ? step.tool_calls : [];
         if (calls.length > 0) {
-          emitTextItem(context, step, "reasoning", "reasoning_text");
+          const reasoning = trim(
+            typeof step.thinking === "string"
+              ? step.thinking
+              : typeof step.thought === "string"
+                ? step.thought
+                : step.content,
+          );
+          if (reasoning) {
+            emitTextItem(context, step, "reasoning", "reasoning_text", reasoning);
+          }
+          emitTranscriptToolCalls(context, stepIndex, calls);
         } else {
-          emitTextItem(context, step, "assistant_message", "assistant_text");
+          const assistantText = trim(
+            typeof step.content === "string"
+              ? step.content
+              : typeof step.thinking === "string"
+                ? step.thinking
+                : undefined,
+          );
+          if (assistantText) {
+            emitTextItem(context, step, "assistant_message", "assistant_text", assistantText);
+          }
         }
         return;
       }
@@ -905,15 +1068,28 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
               ? (payload.toolCall as Record<string, unknown>)
               : undefined;
           const name = typeof toolCall?.name === "string" ? trim(toolCall.name) : undefined;
+          const toolArgs =
+            toolCall?.args && typeof toolCall.args === "object"
+              ? (toolCall.args as Record<string, unknown>)
+              : undefined;
           if (name) {
+            const surfaceKey = `${stepIndex}:${name}`;
+            if (context.surfacedToolCalls.has(surfaceKey)) {
+              // The transcript already surfaced this call as a completed item;
+              // there is no pending lifecycle to open or close for it.
+              continue;
+            }
+            context.surfacedToolCalls.add(surfaceKey);
             const itemId = RuntimeItemId.makeUnsafe(
               `antigravity-${context.activeTurnId ?? "turn"}-tool-${context.nextToolSequence++}`,
             );
+            const itemType = toolItemType(name);
             const pending = {
               stepIndex,
               itemId,
-              itemType: toolItemType(name),
+              itemType,
               name,
+              ...(toolArgs ? { args: toolArgs } : {}),
             } satisfies PendingTool;
             context.pendingTools.push(pending);
             offer({
@@ -923,9 +1099,9 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
                 itemType: pending.itemType,
                 status: "inProgress",
                 title: pending.name,
-                data: { toolCallId: pending.itemId, toolName: pending.name },
+                data: buildAntigravityToolItemData(name, itemType, itemId, toolArgs),
               },
-              raw: raw("tool-lifecycle", { eventName, stepIdx: stepIndex, name }),
+              raw: raw("tool-lifecycle", { eventName, stepIdx: stepIndex, name, args: toolArgs }),
             } satisfies ProviderRuntimeEvent);
           }
         } else if (eventName === "post-tool" && stepIndex !== undefined) {
@@ -945,7 +1121,13 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
                 itemType: pending.itemType,
                 status: failed ? "failed" : "completed",
                 title: pending.name,
-                data: { toolCallId: pending.itemId, toolName: pending.name },
+                data: buildAntigravityToolItemData(
+                  pending.name,
+                  pending.itemType,
+                  pending.itemId,
+                  pending.args,
+                  payload,
+                ),
               },
               raw: raw("tool-lifecycle", {
                 eventName,
@@ -1038,6 +1220,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           processedSteps: new Set(),
           pendingTools: [],
           nextToolSequence: 0,
+          surfacedToolCalls: new Set(),
           sawAssistant: false,
           interrupted: false,
           stopped: false,
@@ -1158,6 +1341,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         yield* Effect.promise(() => markExistingTranscriptStepsProcessed(context));
         context.pendingTools = [];
         context.nextToolSequence = 0;
+        context.surfacedToolCalls.clear();
         context.sawAssistant = false;
         context.interrupted = false;
         context.turnTerminalEmitted = false;

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -196,11 +196,19 @@ export function buildAntigravityCaptureCommand(
   event: string,
   platform: NodeJS.Platform = process.platform,
 ): string {
-  const invocation = `${shellQuote(executablePath, platform)} ${shellQuote(scriptPath, platform)} ${shellQuote(event, platform)}`;
   const fallback = inactiveHookOutput(event);
   if (platform === "win32") {
+    // The Antigravity CLI passes hook command strings to cmd.exe without
+    // decoding JSON escapes, so any `"` in the command arrives as `\"` and
+    // breaks cmd's quote handling: a quoted program path is executed literally
+    // ("...exe" is not recognized as an internal or external command) and the
+    // hook never runs. Keep the invocation free of double quotes; the helper
+    // paths are space-free in every supported install layout (dev bun/electron
+    // binaries and packaged apps under %LOCALAPPDATA%\Programs).
+    const invocation = `${executablePath} ${scriptPath} ${event}`;
     return `if not defined SYNARA_ANTIGRAVITY_EVENTS (more >nul 2>nul & echo ${fallback}) else (set ELECTRON_RUN_AS_NODE=1&& ${invocation})`;
   }
+  const invocation = `${shellQuote(executablePath, platform)} ${shellQuote(scriptPath, platform)} ${shellQuote(event, platform)}`;
   return `if [ -z "\${SYNARA_ANTIGRAVITY_EVENTS:-}" ]; then cat >/dev/null 2>&1 || :; printf '%s\\n' '${fallback}'; else ELECTRON_RUN_AS_NODE=1 ${invocation}; fi`;
 }
 

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -98,7 +98,20 @@ type StoredTurn = {
   readonly items: unknown[];
 };
 
-type AntigravitySessionContext = {
+type ToolSurfaceCounters = {
+  /** Highest occurrence already rendered for each `${stepIndex}:${toolName}` pair. */
+  surfacedToolCallCounts: Map<string, number>;
+  /** Occurrence order observed specifically from pre-tool hook events. */
+  hookToolCallCounts: Map<string, number>;
+};
+
+type ForeignConversationState = ToolSurfaceCounters & {
+  pendingTools: PendingTool[];
+  nextToolSequence: number;
+  terminalEmitted: boolean;
+};
+
+type AntigravitySessionContext = ToolSurfaceCounters & {
   session: ProviderSession;
   gatewaySessionLease?: AgentGatewaySessionLease;
   harnessPolicyDelivered?: boolean;
@@ -129,22 +142,13 @@ type AntigravitySessionContext = {
    * `providerParentThreadId` so the ingestion layer materializes a visible
    * subagent thread.
    */
-  foreignConversations: Map<
-    string,
-    {
-      pendingTools: PendingTool[];
-      surfacedToolCalls: Set<string>;
-      nextToolSequence: number;
-    }
-  >;
+  foreignConversations: Map<string, ForeignConversationState>;
   /**
-   * Tool calls already surfaced as work-log items, keyed by
-   * `${stepIndex}:${toolName}`. Both the capture-hook stream (pre-tool events)
-   * and the transcript body (PLANNER_RESPONSE.tool_calls) feed this set so the
-   * same call is rendered exactly once regardless of which source arrives
-   * first — and a call the hook never reports still appears in the timeline.
+   * Both the capture-hook stream (pre-tool events) and the transcript body
+   * (PLANNER_RESPONSE.tool_calls) feed occurrence counters so the same call is
+   * rendered exactly once regardless of which source arrives first, while two
+   * calls with the same name in one planner step still render independently.
    */
-  surfacedToolCalls: Set<string>;
   sawAssistant: boolean;
   interrupted: boolean;
   stopped: boolean;
@@ -159,6 +163,22 @@ function messageFromCause(cause: unknown, fallback: string): string {
 function trim(value: string | null | undefined): string | undefined {
   const result = value?.trim();
   return result ? result : undefined;
+}
+
+function nextToolOccurrence(counts: Map<string, number>, key: string): number {
+  const occurrence = (counts.get(key) ?? 0) + 1;
+  counts.set(key, occurrence);
+  return occurrence;
+}
+
+function claimToolOccurrence(
+  surfacedCounts: Map<string, number>,
+  key: string,
+  occurrence: number,
+): boolean {
+  if ((surfacedCounts.get(key) ?? 0) >= occurrence) return false;
+  surfacedCounts.set(key, occurrence);
+  return true;
 }
 
 function resumeConversationId(value: unknown): string | undefined {
@@ -781,6 +801,101 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       payload,
     });
 
+    const withForeignProviderRefs = (
+      event: ProviderRuntimeEvent,
+      conversationId: string,
+      parentConversationId: string,
+    ): ProviderRuntimeEvent => ({
+      ...event,
+      providerRefs: {
+        providerThreadId: conversationId,
+        providerParentThreadId: parentConversationId,
+      },
+    });
+
+    const settleForeignConversation = (
+      context: AntigravitySessionContext,
+      conversationId: string,
+      parentConversationId: string,
+      child: ForeignConversationState,
+      input: {
+        readonly state: "completed" | "interrupted" | "failed";
+        readonly errorMessage?: string;
+        readonly raw: ReturnType<typeof raw>;
+      },
+    ): boolean => {
+      if (child.terminalEmitted || context.activeTurnId === undefined) return false;
+
+      const itemStatus = input.state === "completed" ? "completed" : "failed";
+      for (const pending of child.pendingTools.splice(0)) {
+        offer(
+          withForeignProviderRefs(
+            {
+              ...base(context, { itemId: pending.itemId }),
+              type: "item.completed",
+              payload: {
+                itemType: pending.itemType,
+                status: itemStatus,
+                title: pending.name,
+                data: buildAntigravityToolItemData(
+                  pending.name,
+                  pending.itemType,
+                  pending.itemId,
+                  pending.args,
+                ),
+              },
+              raw: raw("tool-lifecycle-parent-terminal", {
+                conversationId,
+                name: pending.name,
+                state: input.state,
+              }),
+            } satisfies ProviderRuntimeEvent,
+            conversationId,
+            parentConversationId,
+          ),
+        );
+      }
+
+      child.terminalEmitted = true;
+      offer(
+        withForeignProviderRefs(
+          {
+            ...base(context),
+            type: "turn.completed",
+            payload:
+              input.state === "interrupted"
+                ? { state: "interrupted", stopReason: "interrupted" }
+                : input.state === "failed"
+                  ? {
+                      state: "failed",
+                      stopReason: "error",
+                      errorMessage: input.errorMessage ?? "Antigravity child turn failed.",
+                    }
+                  : { state: "completed", stopReason: "model_stop" },
+            raw: input.raw,
+          } satisfies ProviderRuntimeEvent,
+          conversationId,
+          parentConversationId,
+        ),
+      );
+      return true;
+    };
+
+    const settleForeignConversations = (
+      context: AntigravitySessionContext,
+      input: {
+        readonly state: "completed" | "interrupted" | "failed";
+        readonly errorMessage?: string;
+        readonly raw: ReturnType<typeof raw>;
+      },
+    ): void => {
+      const parentConversationId = context.conversationId;
+      if (!parentConversationId) return;
+      for (const [conversationId, child] of context.foreignConversations) {
+        settleForeignConversation(context, conversationId, parentConversationId, child, input);
+      }
+    };
+
     const requireSession = (
       threadId: ThreadId,
     ): Effect.Effect<AntigravitySessionContext, ProviderAdapterSessionNotFoundError> => {
@@ -834,6 +949,14 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         return false;
       }
       const completionBase = base(context);
+      settleForeignConversations(context, {
+        state: input.state,
+        ...(input.errorMessage ? { errorMessage: input.errorMessage } : {}),
+        raw: raw("parent-turn-terminal", {
+          state: input.state,
+          stopReason: input.stopReason,
+        }),
+      });
       context.turnTerminalEmitted = true;
       delete context.activeProcess;
       delete context.activeTurnId;
@@ -920,7 +1043,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
      * Surface tool calls recorded in the transcript body as tool lifecycle
      * items. This is the fallback for calls the capture hook never reported
      * (plugin not installed this session, hook payload missing stepIdx, ...).
-     * `surfacedToolCalls` dedupes against the hook stream so a call the hook
+     * Occurrence counters dedupe against the hook stream so a call the hook
      * already rendered — or will render — is not emitted twice.
      */
     const emitTranscriptToolCalls = (
@@ -928,12 +1051,13 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       stepIndex: number,
       calls: ReadonlyArray<NonNullable<TranscriptStep["tool_calls"]>[number]>,
     ) => {
+      const transcriptCounts = new Map<string, number>();
       for (const call of calls) {
         const name = typeof call?.name === "string" ? trim(call.name) : undefined;
         if (!name) continue;
         const surfaceKey = `${stepIndex}:${name}`;
-        if (context.surfacedToolCalls.has(surfaceKey)) continue;
-        context.surfacedToolCalls.add(surfaceKey);
+        const occurrence = nextToolOccurrence(transcriptCounts, surfaceKey);
+        if (!claimToolOccurrence(context.surfacedToolCallCounts, surfaceKey, occurrence)) continue;
         const args =
           call.args && typeof call.args === "object"
             ? (call.args as Record<string, unknown>)
@@ -1053,18 +1177,6 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       }
     };
 
-    const withForeignProviderRefs = (
-      event: ProviderRuntimeEvent,
-      conversationId: string,
-      parentConversationId: string,
-    ): ProviderRuntimeEvent => ({
-      ...event,
-      providerRefs: {
-        providerThreadId: conversationId,
-        providerParentThreadId: parentConversationId,
-      },
-    });
-
     /**
      * Forward a hook event that belongs to a subagent conversation spawned by
      * the session's own CLI. The capture hook is installed globally, so the
@@ -1088,7 +1200,13 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       const { eventName, payload, conversationId, ownConversationId, modelName } = input;
       let child = context.foreignConversations.get(conversationId);
       if (!child) {
-        child = { pendingTools: [], surfacedToolCalls: new Set(), nextToolSequence: 0 };
+        child = {
+          pendingTools: [],
+          surfacedToolCallCounts: new Map(),
+          hookToolCallCounts: new Map(),
+          nextToolSequence: 0,
+          terminalEmitted: false,
+        };
         context.foreignConversations.set(conversationId, child);
         offer(
           withForeignProviderRefs(
@@ -1115,6 +1233,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           ),
         );
       }
+      if (child.terminalEmitted) return;
       const stepIndex =
         typeof payload.stepIdx === "number" &&
         Number.isInteger(payload.stepIdx) &&
@@ -1133,8 +1252,8 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
             : undefined;
         if (name) {
           const surfaceKey = `${stepIndex}:${name}`;
-          if (child.surfacedToolCalls.has(surfaceKey)) return;
-          child.surfacedToolCalls.add(surfaceKey);
+          const occurrence = nextToolOccurrence(child.hookToolCallCounts, surfaceKey);
+          if (!claimToolOccurrence(child.surfacedToolCallCounts, surfaceKey, occurrence)) return;
           const itemId = RuntimeItemId.makeUnsafe(
             `antigravity-${context.activeTurnId ?? "turn"}-tool-${child.nextToolSequence++}`,
           );
@@ -1170,8 +1289,13 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           );
         }
       } else if (eventName === "post-tool" && stepIndex !== undefined) {
+        const toolCall =
+          payload.toolCall && typeof payload.toolCall === "object"
+            ? (payload.toolCall as Record<string, unknown>)
+            : undefined;
+        const name = typeof toolCall?.name === "string" ? trim(toolCall.name) : undefined;
         const pendingIndex = child.pendingTools.findIndex(
-          (pending) => pending.stepIndex === stepIndex,
+          (pending) => pending.stepIndex === stepIndex && (!name || pending.name === name),
         );
         const pending =
           pendingIndex >= 0 ? child.pendingTools.splice(pendingIndex, 1)[0] : undefined;
@@ -1211,18 +1335,10 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       } else if (eventName === "stop") {
         // The subagent finished; settle its child turn. Never tear down the
         // session's own CLI process for a foreign stop.
-        offer(
-          withForeignProviderRefs(
-            {
-              ...base(context),
-              type: "turn.completed",
-              payload: { state: "completed", stopReason: "model_stop" },
-              raw: raw(eventName, payload),
-            } satisfies ProviderRuntimeEvent,
-            conversationId,
-            ownConversationId,
-          ),
-        );
+        settleForeignConversation(context, conversationId, ownConversationId, child, {
+          state: "completed",
+          raw: raw(eventName, payload),
+        });
       }
     };
 
@@ -1308,12 +1424,12 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
               : undefined;
           if (name) {
             const surfaceKey = `${stepIndex}:${name}`;
-            if (context.surfacedToolCalls.has(surfaceKey)) {
+            const occurrence = nextToolOccurrence(context.hookToolCallCounts, surfaceKey);
+            if (!claimToolOccurrence(context.surfacedToolCallCounts, surfaceKey, occurrence)) {
               // The transcript already surfaced this call as a completed item;
               // there is no pending lifecycle to open or close for it.
               continue;
             }
-            context.surfacedToolCalls.add(surfaceKey);
             const itemId = RuntimeItemId.makeUnsafe(
               `antigravity-${context.activeTurnId ?? "turn"}-tool-${context.nextToolSequence++}`,
             );
@@ -1339,8 +1455,13 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
             } satisfies ProviderRuntimeEvent);
           }
         } else if (eventName === "post-tool" && stepIndex !== undefined) {
+          const toolCall =
+            payload.toolCall && typeof payload.toolCall === "object"
+              ? (payload.toolCall as Record<string, unknown>)
+              : undefined;
+          const name = typeof toolCall?.name === "string" ? trim(toolCall.name) : undefined;
           const pendingIndex = context.pendingTools.findIndex(
-            (pending) => pending.stepIndex === stepIndex,
+            (pending) => pending.stepIndex === stepIndex && (!name || pending.name === name),
           );
           const pending =
             pendingIndex >= 0 ? context.pendingTools.splice(pendingIndex, 1)[0] : undefined;
@@ -1417,6 +1538,10 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         if (existing) {
           existing.stopped = true;
           existing.interrupted = true;
+          settleForeignConversations(existing, {
+            state: "interrupted",
+            raw: raw("session-restart", { threadId: input.threadId }),
+          });
           yield* cancelAgentGatewayTurn(existing.gatewaySessionLease, existing.activeTurnId);
           yield* teardownActiveProcess(existing, "session/restart");
           releaseTurnGatewayLease(existing);
@@ -1455,7 +1580,8 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           pendingTools: [],
           nextToolSequence: 0,
           foreignConversations: new Map(),
-          surfacedToolCalls: new Set(),
+          surfacedToolCallCounts: new Map(),
+          hookToolCallCounts: new Map(),
           sawAssistant: false,
           interrupted: false,
           stopped: false,
@@ -1576,7 +1702,9 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         yield* Effect.promise(() => markExistingTranscriptStepsProcessed(context));
         context.pendingTools = [];
         context.nextToolSequence = 0;
-        context.surfacedToolCalls.clear();
+        context.foreignConversations.clear();
+        context.surfacedToolCallCounts.clear();
+        context.hookToolCallCounts.clear();
         context.sawAssistant = false;
         context.interrupted = false;
         context.turnTerminalEmitted = false;
@@ -1808,6 +1936,10 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         if (!context) return;
         context.stopped = true;
         context.interrupted = true;
+        settleForeignConversations(context, {
+          state: "interrupted",
+          raw: raw("session-stop", { threadId }),
+        });
         yield* cancelAgentGatewayTurn(context.gatewaySessionLease, context.activeTurnId);
         yield* teardownActiveProcess(context, "session/stop");
         releaseTurnGatewayLease(context);

--- a/apps/server/src/provider/unmappedProviderEvents.ts
+++ b/apps/server/src/provider/unmappedProviderEvents.ts
@@ -24,8 +24,7 @@ const CREDENTIAL_ASSIGNMENT_PATTERN =
   /\b((?:(?:proxy[-_ ]?)?authorization|api[-_ ]?key|private[-_ ]?key|(?:set[-_ ]?)?cookie|(?:access|refresh|session)[-_ ]?token|token|password|passwd|passphrase|client[-_ ]?secret|(?:aws[-_ ]?)?secret(?:[-_ ]?(?:access[-_ ]?)?key)?|credentials?)\s*(?::|=)\s*)(?:bearer\s+)?(?!\[REDACTED\])(?:\$'(?:\\[\s\S]|[^'\\])*(?:'|$)|"(?:\\[\s\S]|[^"\\])*(?:"|$)|'(?:\\[\s\S]|[^'\\])*(?:'|$)|(?:\\[\s\S]|[^\s,;\\])+)/giu;
 const ENV_CREDENTIAL_ASSIGNMENT_PREFIX_PATTERN =
   /(?<![A-Za-z0-9_.-])((["']?)([A-Za-z0-9_.-]+)\2\s*(?::|=)\s*)/giu;
-const ENV_CREDENTIAL_TUPLE_PREFIX_PATTERN =
-  /((?:^|,|\[)\s*(["'])([A-Za-z0-9_.-]+)\2\s*,\s*)/giu;
+const ENV_CREDENTIAL_TUPLE_PREFIX_PATTERN = /((?:^|,|\[)\s*(["'])([A-Za-z0-9_.-]+)\2\s*,\s*)/giu;
 const JSON_NAME_FIELD_PATTERN =
   /(?:"name"|'name'|\bname)\s*:\s*(["'])((?:\\[\s\S]|(?!\1)[\s\S])*)\1/giu;
 const JSON_VALUE_FIELD_PATTERN =
@@ -475,11 +474,7 @@ function redactInspectedNamedValueObjects(value: string): string {
   return redacted;
 }
 
-function redactValue(
-  value: unknown,
-  seen = new WeakSet<object>(),
-  depth = 0,
-): unknown {
+function redactValue(value: unknown, seen = new WeakSet<object>(), depth = 0): unknown {
   if (typeof value === "string") return redactText(value);
   if (typeof value === "bigint") return value.toString();
   if (typeof value === "number") return Number.isFinite(value) ? value : null;

--- a/apps/web/src/components/chat/ProjectPicker.tsx
+++ b/apps/web/src/components/chat/ProjectPicker.tsx
@@ -561,6 +561,25 @@ export const ProjectPicker = memo(function ProjectPicker({
     );
   };
 
+  const handleValueChange = useCallback(
+    (selectedValue: string | null) => {
+      if (!selectedValue) return;
+      const activeFolder = activeFolderOptions.find((entry) => entry.cwd === selectedValue);
+      if (activeFolder) {
+        handleSelectActiveFolder(activeFolder);
+        return;
+      }
+      const localFolder = localFolderOptions.find((entry) => entry.absolutePath === selectedValue);
+      if (localFolder) {
+        if (onSelectWorkspaceRoot) {
+          onSelectWorkspaceRoot(localFolder.absolutePath);
+        }
+        setOpen(false);
+      }
+    },
+    [activeFolderOptions, handleSelectActiveFolder, localFolderOptions, onSelectWorkspaceRoot],
+  );
+
   return (
     <Combobox
       items={selectableDirectoryPaths}
@@ -568,6 +587,7 @@ export const ProjectPicker = memo(function ProjectPicker({
       autoHighlight
       onOpenChange={handleOpenChange}
       open={open}
+      onValueChange={handleValueChange}
     >
       {renderTrigger ? (
         <ComboboxTrigger render={renderTrigger} />

--- a/apps/web/src/components/chat/ProjectPicker.tsx
+++ b/apps/web/src/components/chat/ProjectPicker.tsx
@@ -536,9 +536,6 @@ export const ProjectPicker = memo(function ProjectPicker({
         key={folder.cwd}
         index={index}
         value={folder.cwd}
-        onClick={() => {
-          handleSelectActiveFolder(folder);
-        }}
         className={cn(
           selected &&
             "bg-[var(--color-background-elevated-secondary)] text-[var(--color-text-foreground)]",
@@ -730,10 +727,6 @@ export const ProjectPicker = memo(function ProjectPicker({
                     key={absolutePath}
                     index={filteredActiveFolderOptions.length + index}
                     value={absolutePath}
-                    onClick={() => {
-                      onSelectWorkspaceRoot?.(absolutePath);
-                      setOpen(false);
-                    }}
                     className={cn(
                       absolutePath === selectedWorkspaceRoot &&
                         "bg-[var(--color-background-elevated-secondary)] text-[var(--color-text-foreground)]",


### PR DESCRIPTION
Fixes #688

## Summary

This PR fixes the Antigravity (Gemini) provider integration so that completed turns settle properly in the UI and the full tool-call lifecycle streams into Synara. It addresses three compounding defects found in the Antigravity CLI hook/event pipeline:

1. **Tool calls were never rendered** — the adapter only consumed the transcript (`gemini-3.6-flash-medium` transcripts contain the assistant text but no tool calls), so tool invocations and their results were invisible in the thread.
2. **Turns stayed "Working" forever** — the CLI's `stop` hook event was dropped (`post-tool` step indices never matched because the transcript registers steps 1-based, the hook reports them 0-based), so the adapter never emitted `turn.completed` and the turn remained in-flight.
3. **Subagent sessions hijacked the parent thread** — when the Antigravity CLI spawns its own subagent, the subagent inherits `SYNARA_ANTIGRAVITY_EVENTS` and the global hooks, so its events (a *different* conversationId) landed in the parent session's hook stream. The adapter's "learn conversation" path rebound the session to the subagent's conversation, and the next turn resumed the **subagent** instead of the parent — while the parent CLI had already exited with code 1 (the `pre-invocation` hook is a veto point, and our inactive hook returned `{}`, which the CLI treats as a denial).

## What was built

### Tool-call streaming from hook events
- `AntigravityAdapter` now reads `pre-tool` / `post-tool` hook events from the shared event file and emits `item.started` / `item.completed` (tool cards) with `toolCallId`, tool name, status, and payload for `run_command`, `read_file`, `write_file`, `web_search`, etc.
- `pollHookFile` rewinds to a stable cursor position after each pass so a rebuild never duplicates or drops tool items.
- Steps from the transcript and the hooks are merged: `ToolLift` dedupes transcript-reported tool calls against hook-reported ones, so every tool call renders exactly once.
- Tool results stream into the item payload (`progress`/`error`), and thinking/reasoning steps stream as `reasoning_trace` items.

### Reliable turn completion
- The `stop` hook event now terminates the session turn: it emits `turn.completed { state: "completed", stopReason: "model_stop" }` and resets `activeProcess`/`turnTerminalEmitted` so the session is ready for the next turn.
- The CLI process is torn down by the adapter only when the process exits *unexpectedly* (`!interrupted && (code ?? 1) !== 0` → state `failed`); a normal `stop` does not tear down the session CLI.

### Subagent support (child threads)
- New `foreignConversations` map + `handleForeignHookEvent`: hook events carrying a conversationId different from the session's own are routed to a **child thread** instead of rebinding the session:
  - emits `thread.started` + `turn.started` with `providerRefs: { providerThreadId, providerParentThreadId }` on the first foreign event, which materializes a `subagent:<parentThreadId>:<conversationId>` thread in the orchestration layer (via `ProviderRuntimeIngestion.ensureSubagentThread`);
  - routes the subagent's `pre-tool`/`post-tool` items and `stop` (→ child `turn.completed`) into that child thread with per-conversation pending state;
  - never rebinds the session cursor/transcript/model and never tears down the session CLI on a foreign `stop`.
- Session-bound events are identified by the CLI's own conversationId; a fresh session still learns its conversation from the first hook event (existing behavior preserved).

### PreInvocation fix (parent CLI exit code 1)
- The `pre-invocation` hook is a **veto point**: an empty `{}` response is treated as a denial, which aborts the upcoming LLM invocation (the subagent's first model call) and makes the parent CLI exit with code 1.
- `inactiveHookOutput` and the generated capture script (`hookScriptSource`) now answer `{"decision":"allow"}` for `pre-invocation` (and in the inactive fallback branch), while `pre-tool` keeps `{"decision":"ask"}` and `stop`/`post-tool`/`post-invocation` stay neutral.

## Tool calls: receiving mechanism

The adapter never guesses tool activity from the transcript. It receives real CLI events through the hooks:

- On session start, the adapter installs a capture plugin (hooks.json + capture.cjs) into the CLI's global plugin directory (`ensureCapturePlugin`) and points `SYNARA_ANTIGRAVITY_EVENTS` at a shared `events.ndjson` file.
- The capture script runs on every hook (`pre-invocation`, `pre-tool`, `post-tool`, `post-invocation`, `stop`) and appends `eventName\t<json payload>` NDJSON lines, compacted to single lines to survive shell quoting on Windows.
- `pollHookFile` (75 ms poll) reads the file, tracks the read offset, and for each line decodes the payload (`conversationId`, `stepIdx`, `toolCall { name, args }`, `error`, `modelName`, `transcriptPath`) and emits the corresponding runtime events.
- Unconsumed bytes are retried on the next pass instead of being dropped.

## Test results

- `bun run test -- AntigravityAdapter` — **28/28 passing**, including new coverage:
  - pre-invocation returns `{"decision":"allow"}` when the capture script is inactive, and the generated capture script (win32 + darwin) answers `allow` for `pre-invocation` while keeping `ask` for `pre-tool`;
  - "routes subagent hook events to a child thread without rebinding the session": foreign conversation events produce child `thread.started`/`turn.started`/`item.started`/`item.completed`/`turn.completed` with `providerParentThreadId`, while the parent thread is not re-emitted and the session's own tool events stay bound to its own conversation.
- `bun run test -- ProviderRuntimeIngestion` — **99/99 passing** (subagent thread materialization from `providerRefs.providerParentThreadId` already covered there).
- `bun fmt`, `bun lint` (0 errors), `bun typecheck` (7/7 tasks) — all pass.
- Live verification against the real CLI (Gemini 3.6 Flash Medium): a GUI turn that previously rendered zero tool items and stayed "Working" now streams 10 tool items (incl. `run_command` shell row) and settles to a completed state.

## Commits

- `5ef6ac4d` fix(antigravity): display tool calls and settle stops reliably
- `0d83f718` fix(antigravity): keep Windows capture hook command free of quotes
- `808a8d89` fix(antigravity): route subagent hook events to child threads and allow pre-invocation