### PR TITLE
fix(opencode): preserve streamed assistant text

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -29,6 +29,7 @@ import {
 import { OpenCodeAdapter } from "../Services/OpenCodeAdapter.ts";
 import { KiloAdapter } from "../Services/KiloAdapter.ts";
 import {
+  appendOpenCodeAssistantTextDelta,
   makeOpenCodeAdapterLive,
   makeKiloAdapterLive,
   normalizeOpenCodeTokenUsage,
@@ -2242,7 +2243,8 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
               id: "part-1",
               messageID: "assistant-message-1",
               type: "text",
-              text: "",
+              // The cumulative snapshot may already contain the earlier buffered delta.
+              text: "Hello",
               time: {
                 start: 1,
               },
@@ -2323,6 +2325,127 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
         itemType: "assistant_message",
         detail: "Hello",
       },
+    });
+  });
+
+  it("keeps a delta buffered after a role-unknown snapshot even when its suffix matches", async () => {
+    const eventQueue = createSubscribedEventQueue();
+    const runtime = createMockOpenCodeRuntime();
+    const client = runtime.runtime.createOpenCodeSdkClient({
+      baseUrl: "http://127.0.0.1:4099",
+      directory: process.cwd(),
+    }) as unknown as {
+      event: {
+        subscribe: () => Promise<{ stream: AsyncIterable<unknown> }>;
+      };
+    };
+    client.event.subscribe = async () => ({ stream: eventQueue.stream });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 6)).pipe(
+          Effect.forkChild,
+        );
+
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId: asThreadId("thread-role-late-delta"),
+          runtimeMode: "full-access",
+        });
+
+        yield* adapter.sendTurn({
+          threadId: asThreadId("thread-role-late-delta"),
+          input: "hello",
+          attachments: [],
+          modelSelection: {
+            provider: "opencode",
+            model: "openai/gpt-5.4",
+          },
+        });
+
+        eventQueue.push({
+          type: "message.part.updated",
+          properties: {
+            sessionID: "opencode-session-1",
+            part: {
+              id: "part-role-late",
+              messageID: "assistant-message-role-late",
+              type: "text",
+              text: "lo",
+              time: { start: 1 },
+            },
+          },
+        });
+        eventQueue.push({
+          type: "message.part.delta",
+          properties: {
+            sessionID: "opencode-session-1",
+            partID: "part-role-late",
+            delta: "lo",
+          },
+        });
+        eventQueue.push({
+          type: "message.updated",
+          properties: {
+            sessionID: "opencode-session-1",
+            info: {
+              id: "assistant-message-role-late",
+              role: "assistant",
+            },
+          },
+        });
+        eventQueue.push({
+          type: "message.part.updated",
+          properties: {
+            sessionID: "opencode-session-1",
+            part: {
+              id: "part-role-late",
+              messageID: "assistant-message-role-late",
+              type: "text",
+              text: "lolo",
+              time: { start: 1, end: 2 },
+            },
+          },
+        });
+        eventQueue.push({
+          type: "session.status",
+          properties: {
+            sessionID: "opencode-session-1",
+            status: { type: "idle" },
+          },
+        });
+
+        const events = Array.from(yield* Fiber.join(eventsFiber));
+        eventQueue.close();
+        return events;
+      }).pipe(
+        Effect.provide(
+          makeOpenCodeAdapterLive({ runtime: runtime.runtime }).pipe(
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-adapter-test-" }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
+      ),
+    );
+
+    expect(result.map((event) => event.type)).toEqual([
+      "session.started",
+      "thread.started",
+      "turn.started",
+      "content.delta",
+      "item.completed",
+      "turn.completed",
+    ]);
+    expect(result[3]).toMatchObject({
+      type: "content.delta",
+      payload: { streamKind: "assistant_text", delta: "lolo" },
+    });
+    expect(result[4]).toMatchObject({
+      type: "item.completed",
+      payload: { itemType: "assistant_message", detail: "lolo" },
     });
   });
 
@@ -5708,6 +5831,23 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
     expect(result.session).toMatchObject({
       status: "running",
       activeTurnId: result.secondTurn.turnId,
+    });
+  });
+});
+
+describe("OpenCode incremental text assembly", () => {
+  it("preserves coincidental suffix/prefix overlap in raw provider deltas", () => {
+    expect(appendOpenCodeAssistantTextDelta("reset", "ting")).toEqual({
+      nextText: "resetting",
+      deltaToEmit: "ting",
+    });
+    expect(appendOpenCodeAssistantTextDelta("plan", "ning")).toEqual({
+      nextText: "planning",
+      deltaToEmit: "ning",
+    });
+    expect(appendOpenCodeAssistantTextDelta("lo", "ose")).toEqual({
+      nextText: "loose",
+      deltaToEmit: "ose",
     });
   });
 });

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -184,7 +184,10 @@ interface OpenCodeSessionContext {
   /** Human replies settled from permission.list while their permission.replied echo is pending. */
   readonly locallyResolvedPermissionIds: Set<string>;
   readonly pendingQuestions: Map<string, QuestionRequest>;
-  readonly pendingTextDeltasByPartId: Map<string, string>;
+  readonly pendingTextDeltasByPartId: Map<
+    string,
+    { readonly text: string; readonly bufferedAfterKnownSnapshot: boolean }
+  >;
   readonly messageRoleById: Map<string, "user" | "assistant">;
   readonly messageSnapshotKeyById: Map<string, string>;
   readonly partById: Map<string, Part>;
@@ -575,16 +578,6 @@ function commonPrefixLength(left: string, right: string): number {
   return index;
 }
 
-function suffixPrefixOverlap(text: string, delta: string): number {
-  const maxLength = Math.min(text.length, delta.length);
-  for (let length = maxLength; length > 0; length -= 1) {
-    if (text.endsWith(delta.slice(0, length))) {
-      return length;
-    }
-  }
-  return 0;
-}
-
 function resolveLatestAssistantText(previousText: string | undefined, nextText: string): string {
   if (previousText && previousText.length > nextText.length && previousText.startsWith(nextText)) {
     return previousText;
@@ -603,14 +596,13 @@ function mergeOpenCodeAssistantText(
   };
 }
 
-function appendOpenCodeAssistantTextDelta(
+export function appendOpenCodeAssistantTextDelta(
   previousText: string,
   delta: string,
 ): { readonly nextText: string; readonly deltaToEmit: string } {
-  const deltaToEmit = delta.slice(suffixPrefixOverlap(previousText, delta));
   return {
-    nextText: previousText + deltaToEmit,
-    deltaToEmit,
+    nextText: previousText + delta,
+    deltaToEmit: delta,
   };
 }
 
@@ -622,9 +614,13 @@ function bufferPendingTextDelta(
   if (delta.length === 0) {
     return;
   }
-  const previousText = context.pendingTextDeltasByPartId.get(partId) ?? "";
-  const { nextText } = appendOpenCodeAssistantTextDelta(previousText, delta);
-  context.pendingTextDeltasByPartId.set(partId, nextText);
+  const previous = context.pendingTextDeltasByPartId.get(partId);
+  const { nextText } = appendOpenCodeAssistantTextDelta(previous?.text ?? "", delta);
+  context.pendingTextDeltasByPartId.set(partId, {
+    text: nextText,
+    bufferedAfterKnownSnapshot:
+      (previous?.bufferedAfterKnownSnapshot ?? false) || context.partById.has(partId),
+  });
 }
 
 function applyPendingTextDeltaToPart(context: OpenCodeSessionContext, part: Part): Part {
@@ -634,11 +630,18 @@ function applyPendingTextDeltaToPart(context: OpenCodeSessionContext, part: Part
   }
 
   const pendingDelta = context.pendingTextDeltasByPartId.get(part.id);
-  if (!pendingDelta || pendingDelta.length === 0) {
+  if (!pendingDelta || pendingDelta.text.length === 0) {
     return part;
   }
 
-  const { nextText } = appendOpenCodeAssistantTextDelta(part.text, pendingDelta);
+  // A delta buffered before the first part snapshot may already be present in
+  // the later cumulative snapshot. A delta buffered after a known snapshot
+  // (for example while the message role is still unknown) is newer than that
+  // snapshot and must be appended even when its text matches the snapshot suffix.
+  const nextText =
+    !pendingDelta.bufferedAfterKnownSnapshot && part.text.endsWith(pendingDelta.text)
+      ? part.text
+      : part.text + pendingDelta.text;
   context.pendingTextDeltasByPartId.delete(part.id);
   return nextText === part.text ? part : { ...part, text: nextText };
 }


### PR DESCRIPTION
## Problem

OpenCode and Kilo can corrupt long streamed assistant replies when an incremental provider chunk starts with characters that happen to match the suffix of the text already accumulated.

Examples such as `reset` + `ting`, `plan` + `ning`, and `lo` + `ose` are valid raw incremental chunks. The current overlap heuristic treats the shared boundary characters as a replay and removes them. Once the local text diverges, a later cumulative part snapshot can re-emit the entire suffix, turning a one-character loss into large duplicated blocks and malformed Markdown tables.

Closes #679.

## Root cause

`appendOpenCodeAssistantTextDelta` calls `suffixPrefixOverlap` and strips the longest content-based suffix/prefix match from every incoming `message.part.delta`.

That is unsafe for a token stream: identical characters at a chunk boundary are normal content and carry no replay semantics.

## What changed

- remove content-based suffix/prefix trimming from incremental OpenCode-compatible text deltas;
- append provider deltas verbatim;
- keep cumulative `message.part.updated` reconciliation on the existing snapshot path;
- add regression coverage for repeated-character chunk boundaries that previously lost characters.

## Behavior

Before:

- `reset` + `ting` could become `reseting`;
- `plan` + `ning` could become `planing`;
- `lo` + `ose` could become `lose`;
- a later authoritative snapshot could then append a very large duplicate suffix.

After:

- incremental chunks preserve their exact provider text;
- the examples above assemble as `resetting`, `planning`, and `loose`;
- the local accumulated text stays prefix-compatible with later provider snapshots.

## Scope

This changes only the shared OpenCode/Kilo adapter text assembly and its focused regression test. It does not alter other providers, Markdown rendering, persistence, or the provider protocol.

## Validation

- focused regression test added for coincidental suffix/prefix overlap;
- branch diff is limited to `OpenCodeAdapter.ts` and `OpenCodeAdapter.test.ts`;
- `git diff --check` passed while constructing the focused commit;
- full repository validation is delegated to this PR's GitHub Actions checks and the PR remains draft while those checks run.

## Out of scope

- event-id based reconnect replay deduplication;
- completion-time transcript replacement;
- renderer-side Markdown repair changes.