### PR TITLE
docs: refresh provider architecture

### DIFF
--- a/.docs/provider-architecture.md
+++ b/.docs/provider-architecture.md
@@ -1,6 +1,6 @@
 # Provider architecture
 
-Synara treats provider integrations as adapters behind one server-owned orchestration boundary. The web app does not talk to Codex, Claude, Cursor, or another coding-agent runtime directly: provider operations enter the server through the typed contracts in `@synara/contracts`, are routed by `ProviderService`, and reach one concrete `ProviderAdapter` implementation.
+Synara treats provider integrations as adapters behind server-owned orchestration and discovery boundaries. The web app does not talk to Codex, Claude, Cursor, or another coding-agent runtime directly: provider operations enter the server through the typed contracts in `@synara/contracts`. Session and turn lifecycle calls route through `ProviderService`; model, agent, skill, command, and plugin discovery routes through `ProviderDiscoveryService`; both ultimately resolve concrete `ProviderAdapter` implementations from the registry. Voice operations may access the registry directly where the provider capability is itself the boundary.
 
 ## Implemented providers
 
@@ -33,7 +33,7 @@ Optional methods advertise richer native behavior without forcing every provider
 
 Adapters also expose explicit capabilities rather than making the UI infer support from provider names. Current capability flags cover session model switching, conversation rollback strategy, skill/plugin discovery and mentions, native slash-command discovery, runtime model lists, turn steering, and live diff patches.
 
-The adapter runtime-event queue is bounded. If durable consumers fall behind, backpressure is applied at the provider boundary instead of allowing unbounded process-memory growth.
+Provider runtime-event ingress is bounded. Effect-stream producers can be backpressured by the downstream queue, but callback-style native producers cannot always be paused synchronously. Those adapters use bounded callback ingress with explicit overload outcomes such as dropped events, terminal-event eviction, or terminal overflow rather than allowing unbounded process-memory growth. Adapter implementations must therefore preserve terminal-event guarantees and handle their ingress overflow policy deliberately.
 
 ## Runtime flow
 
@@ -41,13 +41,15 @@ A normal provider-backed turn follows this path:
 
 1. The client dispatches an orchestration command through the typed server API.
 2. Orchestration persists the intent and `ProviderCommandReactor` performs the provider-side operation.
-3. `ProviderService` resolves the thread's provider/session and routes the call through `ProviderAdapterRegistry`.
+3. `ProviderService` resolves the thread's provider/session and routes lifecycle calls through `ProviderAdapterRegistry`.
 4. The concrete adapter translates the request into its native protocol or CLI.
 5. Native output is normalized into canonical `ProviderRuntimeEvent` values.
 6. `ProviderRuntimeIngestion` converts those runtime events back into durable orchestration commands/events.
 7. Projection streams update the shell/thread read models consumed by the web app.
 
-This separation is important: provider-native session IDs, protocol frames, tool shapes, and subprocess behavior stay inside the adapter layer. Orchestration consumes canonical events and remains provider-agnostic.
+Discovery follows a parallel read path: RPC handlers delegate provider model, agent, skill, command, and plugin queries to `ProviderDiscoveryService`, which resolves the relevant adapter and optional capability without creating a session lifecycle dependency.
+
+This separation is important: orchestration does not consume arbitrary native protocol frames. Provider-native information crosses the adapter boundary only through controlled canonical fields such as `providerRefs`, opaque resume cursors, selected thread identifiers, and the sanitized/raw diagnostic envelope carried by runtime events. Those fields exist where orchestration or recovery needs native identity while the rest of the protocol and subprocess behavior remains adapter-owned.
 
 ## Provider-specific state
 
@@ -63,11 +65,17 @@ Provider configuration is split across typed server settings, discovery/health s
 
 Capability and discovery data should be authoritative. UI surfaces should consume the shared provider metadata instead of hard-coding behavior from `ProviderKind` where a capability exists.
 
-## OpenCode-compatible providers
+## Shared provider families
+
+### OpenCode-compatible providers
 
 OpenCode and Kilo share the OpenCode-compatible runtime/adapter family while remaining distinct provider kinds. Shared transport code belongs in that family; provider-specific defaults, health/configuration, model discovery, and presentation stay explicit.
 
-Other providers use their own native integration paths where doing so exposes richer semantics than a lowest-common-denominator protocol.
+### ACP providers
+
+Cursor, Droid, and Grok share the Agent Client Protocol infrastructure under `provider/acp`, including `AcpSessionRuntime` and common adapter/session/event helpers. Provider-specific ACP support should extend that shared lifecycle and protocol machinery rather than duplicating it. Individual providers can still layer their own spawn, authentication, model-selection, or compatibility behavior around the shared ACP runtime.
+
+Codex, Claude, Antigravity, and Pi retain provider-specific integration paths where their native runtimes expose semantics that are not represented by the shared OpenCode or ACP families.
 
 ## Adding a provider
 
@@ -87,7 +95,10 @@ Prefer capability-driven behavior and existing shared protocol helpers. Do not a
 
 - `apps/server/src/provider/Services/ProviderAdapter.ts` — adapter contract and capabilities
 - `apps/server/src/provider/Layers/ProviderAdapterRegistry.ts` — concrete provider registry
-- `apps/server/src/provider/Layers/ProviderService.ts` — session-aware provider routing
+- `apps/server/src/provider/Layers/ProviderService.ts` — session-aware lifecycle routing
+- `apps/server/src/provider/Layers/ProviderDiscoveryService.ts` — model/agent/skill/command/plugin discovery routing
+- `apps/server/src/provider/acp/AcpSessionRuntime.ts` — shared ACP session runtime
+- `apps/server/src/provider/boundedCallbackIngress.ts` — bounded callback-producer ingress policy
 - `apps/server/src/orchestration/Layers/ProviderCommandReactor.ts` — orchestration intent to provider calls
 - `apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts` — provider events to durable orchestration
 - `packages/contracts/src/orchestration.ts` — provider kinds, runtime modes, session/turn contracts

--- a/.docs/provider-architecture.md
+++ b/.docs/provider-architecture.md
@@ -1,30 +1,94 @@
 # Provider architecture
 
-The web app communicates with the server via WebSocket using a simple JSON-RPC-style protocol:
+Synara treats provider integrations as adapters behind one server-owned orchestration boundary. The web app does not talk to Codex, Claude, Cursor, or another coding-agent runtime directly: provider operations enter the server through the typed contracts in `@synara/contracts`, are routed by `ProviderService`, and reach one concrete `ProviderAdapter` implementation.
 
-- **Request/Response**: `{ id, method, params }` → `{ id, result }` or `{ id, error }`
-- **Push events**: typed envelopes with `channel`, `sequence` (monotonic per connection), and channel-specific `data`
+## Implemented providers
 
-Push channels: `server.welcome`, `server.configUpdated`, `terminal.event`, `orchestration.domainEvent`. Payloads are schema-validated at the transport boundary (`wsTransport.ts`). Decode failures produce structured `WsDecodeDiagnostic` with `code`, `reason`, and path info.
+`ProviderAdapterRegistryLive` currently registers nine first-class provider kinds:
 
-Methods mirror the `NativeApi` interface defined in `@synara/contracts`:
+- `codex`
+- `claudeAgent`
+- `cursor`
+- `antigravity`
+- `grok`
+- `droid`
+- `kilo`
+- `opencode`
+- `pi`
 
-- `providers.startSession`, `providers.sendTurn`, `providers.interruptTurn`
-- `providers.respondToRequest`, `providers.stopSession`
-- `shell.openInEditor`, `server.getConfig`
+The registry is intentionally small. It maps `ProviderKind` to an adapter and lists the registered providers; it does not own session routing, persistence, or cross-provider orchestration.
 
-Codex is the only implemented provider. `claudeCode` is reserved in contracts/UI.
+## Adapter contract
 
-## Client transport
+`apps/server/src/provider/Services/ProviderAdapter.ts` is the provider boundary. Every adapter exposes the same core lifecycle:
 
-`wsTransport.ts` manages connection state: `connecting` → `open` → `reconnecting` → `closed` → `disposed`. Outbound requests are queued while disconnected and flushed on reconnect. Inbound pushes are decoded and validated at the boundary, then cached per channel. Subscribers can opt into `replayLatest` to receive the last push on subscribe.
+- start, list, inspect, stop, and interrupt sessions;
+- send turns and, where supported, steer an active turn;
+- answer approvals and structured user-input requests;
+- read and roll back provider thread state;
+- stop all resources owned by the adapter;
+- emit one canonical `ProviderRuntimeEvent` stream.
 
-## Server-side orchestration layers
+Optional methods advertise richer native behavior without forcing every provider to emulate it. These include native review, task stop/backgrounding, subagent steering, compaction, thread forking, runtime model/agent discovery, skills, slash commands, plugins, and voice prewarm/transcription.
 
-Provider runtime events flow through queue-based workers:
+Adapters also expose explicit capabilities rather than making the UI infer support from provider names. Current capability flags cover session model switching, conversation rollback strategy, skill/plugin discovery and mentions, native slash-command discovery, runtime model lists, turn steering, and live diff patches.
 
-1. **ProviderRuntimeIngestion** — consumes provider runtime streams, emits orchestration commands
-2. **ProviderCommandReactor** — reacts to orchestration intent events, dispatches provider calls
-3. **CheckpointReactor** — captures git checkpoints on turn start/complete, publishes runtime receipts
+The adapter runtime-event queue is bounded. If durable consumers fall behind, backpressure is applied at the provider boundary instead of allowing unbounded process-memory growth.
 
-All three use `DrainableWorker` internally and expose `drain()` for deterministic test synchronization.
+## Runtime flow
+
+A normal provider-backed turn follows this path:
+
+1. The client dispatches an orchestration command through the typed server API.
+2. Orchestration persists the intent and `ProviderCommandReactor` performs the provider-side operation.
+3. `ProviderService` resolves the thread's provider/session and routes the call through `ProviderAdapterRegistry`.
+4. The concrete adapter translates the request into its native protocol or CLI.
+5. Native output is normalized into canonical `ProviderRuntimeEvent` values.
+6. `ProviderRuntimeIngestion` converts those runtime events back into durable orchestration commands/events.
+7. Projection streams update the shell/thread read models consumed by the web app.
+
+This separation is important: provider-native session IDs, protocol frames, tool shapes, and subprocess behavior stay inside the adapter layer. Orchestration consumes canonical events and remains provider-agnostic.
+
+## Provider-specific state
+
+Provider configuration is split across typed server settings, discovery/health services, and adapter start options. A provider integration may contribute:
+
+- binary/config-path settings;
+- health and authentication probes;
+- runtime model, agent, skill, command, or plugin discovery;
+- provider-specific model options and runtime modes;
+- session resume cursors and native thread identifiers;
+- handoff/import support;
+- provider update metadata.
+
+Capability and discovery data should be authoritative. UI surfaces should consume the shared provider metadata instead of hard-coding behavior from `ProviderKind` where a capability exists.
+
+## OpenCode-compatible providers
+
+OpenCode and Kilo share the OpenCode-compatible runtime/adapter family while remaining distinct provider kinds. Shared transport code belongs in that family; provider-specific defaults, health/configuration, model discovery, and presentation stay explicit.
+
+Other providers use their own native integration paths where doing so exposes richer semantics than a lowest-common-denominator protocol.
+
+## Adding a provider
+
+A new first-class provider normally needs changes across several boundaries:
+
+1. contracts/shared provider metadata and model/options types;
+2. a server adapter implementing the required `ProviderAdapter` lifecycle;
+3. registry/runtime-layer wiring;
+4. health/auth and, when applicable, update/discovery support;
+5. persistence/model-selection compatibility;
+6. web settings, provider/model picker metadata, icons, and handoff surfaces;
+7. focused adapter tests plus regression coverage for lifecycle, interruption, resume, approvals, and event normalization.
+
+Prefer capability-driven behavior and existing shared protocol helpers. Do not add provider-specific branches to orchestration when the difference can stay inside the adapter.
+
+## Related code
+
+- `apps/server/src/provider/Services/ProviderAdapter.ts` — adapter contract and capabilities
+- `apps/server/src/provider/Layers/ProviderAdapterRegistry.ts` — concrete provider registry
+- `apps/server/src/provider/Layers/ProviderService.ts` — session-aware provider routing
+- `apps/server/src/orchestration/Layers/ProviderCommandReactor.ts` — orchestration intent to provider calls
+- `apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts` — provider events to durable orchestration
+- `packages/contracts/src/orchestration.ts` — provider kinds, runtime modes, session/turn contracts
+- `packages/shared/src/providerMetadata.ts` — shared provider metadata


### PR DESCRIPTION
## Problem

`.docs/provider-architecture.md` no longer describes the provider system that ships on `main`. It still says Codex is the only implemented provider and documents an older transport/provider surface, while the current registry contains nine adapters and provider behavior is routed through the shared `ProviderAdapter` contract.

That makes the document actively misleading for contributors trying to add or modify a provider.

## What changed

- document the nine providers currently registered by `ProviderAdapterRegistryLive`;
- describe the current `ProviderAdapter` lifecycle and optional capability surface;
- explain the provider command/runtime-event flow through `ProviderService`, `ProviderCommandReactor`, and `ProviderRuntimeIngestion`;
- document the capability-driven boundary between provider-native behavior and provider-agnostic orchestration;
- call out the shared OpenCode/Kilo adapter family;
- add a concise first-class-provider integration checklist and pointers to the authoritative files.

## Why this approach

The document now points readers at the live contracts and architectural boundaries instead of copying fragile method inventories. Provider support and optional behavior can evolve without making the overview immediately obsolete again.

## Scope

Documentation only. No runtime, contracts, settings, persistence, or UI behavior changes.

## Validation

- cross-checked the provider list against `ProviderAdapterRegistryLive`;
- cross-checked required/optional operations and capabilities against `ProviderAdapterShape`;
- cross-checked orchestration boundaries against the current ProviderService / reactor / ingestion layout;
- GitHub Actions will run the repository's normal validation on this draft.

## Out of scope

- a per-provider feature support matrix;
- provider implementation changes;
- changes to the public contribution policy.