### PR TITLE
docs: refresh CI quality gates

### DIFF
--- a/.docs/ci.md
+++ b/.docs/ci.md
@@ -1,6 +1,45 @@
 # CI quality gates
 
-- `.github/workflows/ci.yml` runs `bun run lint`, `bun run typecheck`, and `bun run test` on pull requests and pushes to `main`.
-- `.github/workflows/release.yml` builds macOS (`arm64` and `x64`), Linux (`x64`), and Windows (`x64`) desktop artifacts from a single `v*.*.*` tag and publishes one GitHub release.
-- The release workflow auto-enables signing only when secrets are present: Apple credentials for macOS and Azure Trusted Signing credentials for Windows. Without secrets, it still releases unsigned artifacts.
-- See `docs/release.md` for full release/signing setup checklist.
+`.github/workflows/ci.yml` runs on pull requests and pushes to `main`. It has four independent jobs so a platform-specific or release-specific regression is visible separately from the main Linux quality pipeline.
+
+## Main quality job
+
+`Format, Lint, Typecheck, Test, Browser Test, Build` runs on Ubuntu and blocks on:
+
+- Synara identity/brand validation;
+- `bun run fmt:check`;
+- `bun run lint`;
+- `bun run typecheck`;
+- the full unit/integration test suite (`bun run test`);
+- the stable Chromium browser-test suite;
+- the desktop build pipeline;
+- preload bundle output verification.
+
+Linux geometry/pixel browser tests run in a separately named quarantine step with `continue-on-error` while the tracked rendering differences in `apps/web/BROWSER_TEST_QUARANTINE.md` are resolved. Untagged browser tests still run in the blocking stable suite.
+
+CI installs Electron and Playwright explicitly and verifies the Linux `node-pty` native dependency before the quality commands run.
+
+## Windows process regression job
+
+`Windows Process Regression` runs on Windows Server 2022 and covers behavior that Linux cannot validate reliably, including:
+
+- Bun/`node-pty` startup;
+- Windows-safe process planning and Effect process spawning;
+- desktop backend shutdown;
+- migration recovery markers;
+- desktop migration recovery;
+- migration backup/restore and replay.
+
+## Migration lineage
+
+`Migration Lineage` fetches release history and verifies that released `(id, name)` migration pairs have not been renamed or renumbered. Those identifiers are persisted in user databases, so this is a compatibility gate rather than a formatting convention.
+
+## Release smoke
+
+`Release Smoke` exercises release-only scripts and policy checks on every PR without publishing artifacts. It also runs the identity check with a production-style dependency install.
+
+## Desktop releases
+
+`.github/workflows/release.yml` builds tagged desktop releases for macOS arm64/x64, Linux x64, and Windows x64 from one verified source commit. Publication uses platform signing/notarization credentials where required; build-only workflow runs may produce unsigned artifacts when publication is disabled.
+
+The release workflow also verifies source and artifact provenance before publication. See `docs/release.md` for the current signing, provenance, and release checklist.


### PR DESCRIPTION
## Problem

`.docs/ci.md` describes an older CI/release setup. It currently says PR CI runs only lint, typecheck, and tests, and it implies release signing is simply optional when secrets are absent.

The current workflow is substantially stricter: format, browser tests, desktop build/preload verification, Windows-native regressions, migration lineage, and release-smoke checks all run independently. The release workflow also distinguishes build-only unsigned artifacts from publication paths that require platform credentials.

## What changed

- document the blocking Linux quality pipeline (brand, format, lint, typecheck, tests, browser tests, build, preload verification);
- explain the Linux geometry browser-test quarantine separately from the stable blocking browser suite;
- document the Windows Process Regression job and the Windows-specific behaviors it covers;
- explain the migration-lineage compatibility gate;
- explain the release-smoke job;
- correct the desktop-release/signing wording and point readers to provenance/release documentation.

## Why

This page is contributor-facing. Keeping it aligned with `.github/workflows/ci.yml` makes it clear what a PR is actually expected to pass and why failures can appear in independent jobs.

## Scope

Documentation only. No workflow or release behavior changes.

## Validation

Cross-checked against the current `ci.yml` and `release.yml`. Normal GitHub Actions validation is left enabled on this draft.

## Out of scope

- changing CI policy;
- changing the geometry-test quarantine;
- changing signing or release requirements.