### PR TITLE
fix(web): fence route restore snapshots

### DIFF
--- a/apps/web/src/chatRouteRecovery.test.ts
+++ b/apps/web/src/chatRouteRecovery.test.ts
@@ -1,98 +1,27 @@
-import type {
-  NativeApi,
-  OrchestrationReadModel,
-  OrchestrationShellSnapshot,
-} from "@synara/contracts";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-const storeMocks = vi.hoisted(() => ({
-  syncServerReadModel: vi.fn(),
-  syncServerShellSnapshot: vi.fn(),
-}));
-
-vi.mock("./store", () => ({
-  useStore: {
-    getState: () => storeMocks,
-  },
-}));
+import type { NativeApi } from "@synara/contracts";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { refreshEmptyRouteRestoreSnapshot } from "./chatRouteRecovery";
+import { registerEmptyRouteRestoreRefresh } from "./routeRestoreRefreshCoordinator";
 
-function shellSnapshot(input: {
-  projects?: unknown[];
-  threads?: unknown[];
-}): OrchestrationShellSnapshot {
-  return {
-    projects: input.projects ?? [],
-    threads: input.threads ?? [],
-  } as unknown as OrchestrationShellSnapshot;
-}
+let unregister: (() => void) | undefined;
 
-function readModel(input: { projects?: unknown[]; threads?: unknown[] }): OrchestrationReadModel {
-  return {
-    projects: input.projects ?? [],
-    threads: input.threads ?? [],
-  } as unknown as OrchestrationReadModel;
-}
-
-function makeApi(input: {
-  shell: OrchestrationShellSnapshot;
-  snapshot: OrchestrationReadModel;
-  repaired: OrchestrationReadModel;
-}) {
-  const orchestration = {
-    getShellSnapshot: vi.fn().mockResolvedValue(input.shell),
-    getSnapshot: vi.fn().mockResolvedValue(input.snapshot),
-    repairState: vi.fn().mockResolvedValue(input.repaired),
-  };
-
-  return {
-    api: { orchestration } as unknown as NativeApi,
-    orchestration,
-  };
-}
+afterEach(() => {
+  unregister?.();
+  unregister = undefined;
+});
 
 describe("refreshEmptyRouteRestoreSnapshot", () => {
-  beforeEach(() => {
-    storeMocks.syncServerReadModel.mockClear();
-    storeMocks.syncServerShellSnapshot.mockClear();
+  it("returns false when the backend is unavailable", async () => {
+    await expect(refreshEmptyRouteRestoreSnapshot(undefined)).resolves.toBe(false);
   });
 
-  it("continues to repair when shell and full snapshots only contain projects", async () => {
-    const shell = shellSnapshot({ projects: [{ id: "project-1" }] });
-    const snapshot = readModel({ projects: [{ id: "project-1" }] });
-    const repaired = readModel({
-      projects: [{ id: "project-1" }],
-      threads: [{ id: "thread-1" }],
-    });
-    const { api, orchestration } = makeApi({ shell, snapshot, repaired });
+  it("delegates snapshot recovery to EventRouter's registered coordinator", async () => {
+    const refresh = vi.fn().mockResolvedValue(true);
+    unregister = registerEmptyRouteRestoreRefresh(refresh);
 
-    await expect(refreshEmptyRouteRestoreSnapshot(api)).resolves.toBe(true);
+    await expect(refreshEmptyRouteRestoreSnapshot({} as NativeApi)).resolves.toBe(true);
 
-    expect(orchestration.getSnapshot).toHaveBeenCalledTimes(1);
-    expect(orchestration.repairState).toHaveBeenCalledTimes(1);
-    expect(storeMocks.syncServerShellSnapshot).toHaveBeenCalledWith(shell);
-    expect(storeMocks.syncServerReadModel).toHaveBeenNthCalledWith(1, snapshot);
-    expect(storeMocks.syncServerReadModel).toHaveBeenNthCalledWith(2, repaired);
-  });
-
-  it("stops at the shell snapshot when it already has threads", async () => {
-    const shell = shellSnapshot({
-      projects: [{ id: "project-1" }],
-      threads: [{ id: "thread-1" }],
-    });
-    const snapshot = readModel({ projects: [{ id: "project-1" }] });
-    const repaired = readModel({
-      projects: [{ id: "project-1" }],
-      threads: [{ id: "thread-1" }],
-    });
-    const { api, orchestration } = makeApi({ shell, snapshot, repaired });
-
-    await expect(refreshEmptyRouteRestoreSnapshot(api)).resolves.toBe(true);
-
-    expect(orchestration.getSnapshot).not.toHaveBeenCalled();
-    expect(orchestration.repairState).not.toHaveBeenCalled();
-    expect(storeMocks.syncServerShellSnapshot).toHaveBeenCalledWith(shell);
-    expect(storeMocks.syncServerReadModel).not.toHaveBeenCalled();
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/chatRouteRecovery.ts
+++ b/apps/web/src/chatRouteRecovery.ts
@@ -3,30 +3,10 @@
 // Layer: Routing support
 // Exports: empty-startup snapshot recovery helper shared by chat index and thread routes.
 
-import type {
-  NativeApi,
-  OrchestrationReadModel,
-  OrchestrationShellSnapshot,
-} from "@synara/contracts";
+import type { NativeApi } from "@synara/contracts";
 
 import { EMPTY_ROUTE_RESTORE_FALLBACK_DELAY_MS } from "./chatRouteRestore";
-import { useStore } from "./store";
-
-function shellSnapshotHasProjectsOrThreads(snapshot: OrchestrationShellSnapshot): boolean {
-  return snapshot.projects.length > 0 || snapshot.threads.length > 0;
-}
-
-function shellSnapshotHasThreads(snapshot: OrchestrationShellSnapshot): boolean {
-  return snapshot.threads.length > 0;
-}
-
-function readModelHasProjectsOrThreads(snapshot: OrchestrationReadModel): boolean {
-  return snapshot.projects.length > 0 || snapshot.threads.length > 0;
-}
-
-function readModelHasThreads(snapshot: OrchestrationReadModel): boolean {
-  return snapshot.threads.length > 0;
-}
+import { requestEmptyRouteRestoreRefresh } from "./routeRestoreRefreshCoordinator";
 
 export function waitForEmptyRouteRestoreFallbackDelay(): Promise<void> {
   return new Promise((resolve) => {
@@ -34,8 +14,8 @@ export function waitForEmptyRouteRestoreFallbackDelay(): Promise<void> {
   });
 }
 
-// Empty shell snapshots can arrive before desktop projection startup catches up.
-// Try progressively stronger reads so route guards do not replace valid thread URLs.
+// EventRouter owns the live shell sequence fence. Route restore must request its
+// recovery path instead of applying backend snapshots directly to the store.
 export async function refreshEmptyRouteRestoreSnapshot(
   api: NativeApi | undefined,
 ): Promise<boolean> {
@@ -43,32 +23,5 @@ export async function refreshEmptyRouteRestoreSnapshot(
     return false;
   }
 
-  const shellSnapshot = await api.orchestration.getShellSnapshot();
-  if (shellSnapshotHasProjectsOrThreads(shellSnapshot)) {
-    useStore.getState().syncServerShellSnapshot(shellSnapshot);
-    if (shellSnapshotHasThreads(shellSnapshot)) {
-      return true;
-    }
-    // Project-only shell snapshots do not prove route recovery is done; thread
-    // projections may still need the full snapshot or repair path below.
-  }
-
-  const readModel = await api.orchestration.getSnapshot();
-  if (readModelHasProjectsOrThreads(readModel)) {
-    useStore.getState().syncServerReadModel(readModel);
-    if (readModelHasThreads(readModel)) {
-      return true;
-    }
-    // A project-only read model can still be repaired into thread projections.
-  }
-
-  const repairedReadModel = await api.orchestration.repairState();
-  if (readModelHasProjectsOrThreads(repairedReadModel)) {
-    useStore.getState().syncServerReadModel(repairedReadModel);
-  }
-  if (readModelHasThreads(repairedReadModel)) {
-    return true;
-  }
-
-  return false;
+  return await requestEmptyRouteRestoreRefresh();
 }

--- a/apps/web/src/routeRestoreRefreshCoordinator.test.ts
+++ b/apps/web/src/routeRestoreRefreshCoordinator.test.ts
@@ -1,0 +1,131 @@
+import type { OrchestrationReadModel, OrchestrationShellSnapshot } from "@synara/contracts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  registerEmptyRouteRestoreRefresh,
+  requestEmptyRouteRestoreRefresh,
+  runEmptyRouteRestoreRefresh,
+} from "./routeRestoreRefreshCoordinator";
+
+function shellSnapshot(threadIds: readonly string[]): OrchestrationShellSnapshot {
+  return {
+    projects: [],
+    spaces: [],
+    threads: threadIds.map((id) => ({ id })),
+    snapshotSequence: 1,
+  } as unknown as OrchestrationShellSnapshot;
+}
+
+function readModel(threadIds: readonly string[]): OrchestrationReadModel {
+  return {
+    projects: [],
+    threads: threadIds.map((id) => ({ id })),
+  } as unknown as OrchestrationReadModel;
+}
+
+let unregister: (() => void) | undefined;
+
+afterEach(() => {
+  unregister?.();
+  unregister = undefined;
+});
+
+describe("route restore refresh coordinator", () => {
+  it("delegates requests to the registered EventRouter handler", async () => {
+    const handler = vi.fn().mockResolvedValue(true);
+    unregister = registerEmptyRouteRestoreRefresh(handler);
+
+    await expect(requestEmptyRouteRestoreRefresh()).resolves.toBe(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let an older unregister clear a newer handler", async () => {
+    const first = vi.fn().mockResolvedValue(false);
+    const second = vi.fn().mockResolvedValue(true);
+    const unregisterFirst = registerEmptyRouteRestoreRefresh(first);
+    unregister = registerEmptyRouteRestoreRefresh(second);
+
+    unregisterFirst();
+
+    await expect(requestEmptyRouteRestoreRefresh()).resolves.toBe(true);
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops after the fenced shell refresh restores threads", async () => {
+    let hasThreads = false;
+    const getShellSnapshot = vi.fn().mockResolvedValue(shellSnapshot(["thread-1"]));
+    const getSnapshot = vi.fn();
+    const repairState = vi.fn();
+
+    await expect(
+      runEmptyRouteRestoreRefresh({
+        getShellSnapshot,
+        getSnapshot,
+        repairState,
+        applyShellSnapshot: (snapshot) => {
+          hasThreads = snapshot.threads.length > 0;
+        },
+        hasThreads: () => hasThreads,
+      }),
+    ).resolves.toBe(true);
+
+    expect(getShellSnapshot).toHaveBeenCalledTimes(1);
+    expect(getSnapshot).not.toHaveBeenCalled();
+    expect(repairState).not.toHaveBeenCalled();
+  });
+
+  it("uses the full snapshot only as a probe and re-reads the fenced shell", async () => {
+    let hasThreads = false;
+    const getShellSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce(shellSnapshot([]))
+      .mockResolvedValueOnce(shellSnapshot(["thread-1"]));
+    const getSnapshot = vi.fn().mockResolvedValue(readModel(["thread-1"]));
+    const repairState = vi.fn();
+    const appliedShellSnapshots: OrchestrationShellSnapshot[] = [];
+
+    await expect(
+      runEmptyRouteRestoreRefresh({
+        getShellSnapshot,
+        getSnapshot,
+        repairState,
+        applyShellSnapshot: (snapshot) => {
+          appliedShellSnapshots.push(snapshot);
+          hasThreads = snapshot.threads.length > 0;
+        },
+        hasThreads: () => hasThreads,
+      }),
+    ).resolves.toBe(true);
+
+    expect(getSnapshot).toHaveBeenCalledTimes(1);
+    expect(repairState).not.toHaveBeenCalled();
+    expect(getShellSnapshot).toHaveBeenCalledTimes(2);
+    expect(appliedShellSnapshots).toHaveLength(2);
+  });
+
+  it("repairs an empty projection then consumes a fresh fenced shell snapshot", async () => {
+    let hasThreads = false;
+    const getShellSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce(shellSnapshot([]))
+      .mockResolvedValueOnce(shellSnapshot(["thread-repaired"]));
+    const getSnapshot = vi.fn().mockResolvedValue(readModel([]));
+    const repairState = vi.fn().mockResolvedValue(readModel(["thread-repaired"]));
+
+    await expect(
+      runEmptyRouteRestoreRefresh({
+        getShellSnapshot,
+        getSnapshot,
+        repairState,
+        applyShellSnapshot: (snapshot) => {
+          hasThreads = snapshot.threads.length > 0;
+        },
+        hasThreads: () => hasThreads,
+      }),
+    ).resolves.toBe(true);
+
+    expect(repairState).toHaveBeenCalledTimes(1);
+    expect(getShellSnapshot).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/routeRestoreRefreshCoordinator.ts
+++ b/apps/web/src/routeRestoreRefreshCoordinator.ts
@@ -1,0 +1,53 @@
+import type { OrchestrationReadModel, OrchestrationShellSnapshot } from "@synara/contracts";
+
+type EmptyRouteRestoreRefreshHandler = () => Promise<boolean>;
+
+let activeEmptyRouteRestoreRefreshHandler: EmptyRouteRestoreRefreshHandler | null = null;
+
+export function registerEmptyRouteRestoreRefresh(
+  handler: EmptyRouteRestoreRefreshHandler,
+): () => void {
+  activeEmptyRouteRestoreRefreshHandler = handler;
+  return () => {
+    if (activeEmptyRouteRestoreRefreshHandler === handler) {
+      activeEmptyRouteRestoreRefreshHandler = null;
+    }
+  };
+}
+
+export function requestEmptyRouteRestoreRefresh(): Promise<boolean> {
+  return activeEmptyRouteRestoreRefreshHandler?.() ?? Promise.resolve(false);
+}
+
+export async function runEmptyRouteRestoreRefresh(input: {
+  readonly getShellSnapshot: () => Promise<OrchestrationShellSnapshot>;
+  readonly getSnapshot: () => Promise<OrchestrationReadModel>;
+  readonly repairState: () => Promise<OrchestrationReadModel>;
+  readonly applyShellSnapshot: (snapshot: OrchestrationShellSnapshot) => void;
+  readonly hasThreads: () => boolean;
+}): Promise<boolean> {
+  const applyFreshShellSnapshot = async () => {
+    const snapshot = await input.getShellSnapshot();
+    input.applyShellSnapshot(snapshot);
+    return input.hasThreads();
+  };
+
+  if (await applyFreshShellSnapshot()) {
+    return true;
+  }
+
+  // The full projection is only a recovery probe. Applying it here would bypass
+  // EventRouter's shell sequence fence, which is the race this coordinator exists
+  // to remove. If it already contains threads, re-read the shell projection and
+  // let EventRouter apply that snapshot through its normal fenced path.
+  const readModel = await input.getSnapshot();
+  if (readModel.threads.length > 0) {
+    return await applyFreshShellSnapshot();
+  }
+
+  // Repair may rebuild projections, but its returned full read model has no
+  // EventRouter shell fence. Ignore the payload and consume a fresh shell
+  // snapshot after repair instead.
+  await input.repairState();
+  return await applyFreshShellSnapshot();
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -107,6 +107,10 @@ import { useTheme } from "../hooks/useTheme";
 import { useNativeFontSmoothing } from "../hooks/useNativeFontSmoothing";
 import { invalidateGitQueries, invalidateGitQueriesForCwds } from "../lib/gitReactQuery";
 import { shouldRepairDesktopProjectSnapshot } from "../lib/desktopProjectRecovery";
+import {
+  registerEmptyRouteRestoreRefresh,
+  runEmptyRouteRestoreRefresh,
+} from "../routeRestoreRefreshCoordinator";
 import { useDiffRouteSearch } from "../hooks/useDiffRouteSearch";
 import {
   PROVIDER_AUTH_REFRESH_MIN_INTERVAL_MS,
@@ -1393,10 +1397,13 @@ function EventRouter() {
       }
     }
 
-    const loadShellSnapshotOnce = async () => {
+    const applyQueriedShellSnapshot = (snapshot: OrchestrationShellSnapshot) => {
       if (disposed) return;
-      const snapshot = await api.orchestration.getShellSnapshot();
-      if (disposed) return;
+      // A query can resolve after the live shell stream has already moved
+      // forward. Never roll the store back behind the EventRouter fence.
+      if (shellSnapshotSequence >= 0 && snapshot.snapshotSequence < shellSnapshotSequence) {
+        return;
+      }
       if (!shouldApplyBootstrapShellSnapshot(snapshot)) {
         return;
       }
@@ -1408,6 +1415,23 @@ function EventRouter() {
       flushShellBuffer(snapshot.snapshotSequence);
       reconcileMissingSubscribedThreadProjections(promotedDraftThreadIds);
     };
+
+    const loadShellSnapshotOnce = async () => {
+      if (disposed) return;
+      const snapshot = await api.orchestration.getShellSnapshot();
+      if (disposed) return;
+      applyQueriedShellSnapshot(snapshot);
+    };
+
+    const unregisterEmptyRouteRestoreRefresh = registerEmptyRouteRestoreRefresh(() =>
+      runEmptyRouteRestoreRefresh({
+        getShellSnapshot: () => api.orchestration.getShellSnapshot(),
+        getSnapshot: () => api.orchestration.getSnapshot(),
+        repairState: () => api.orchestration.repairState(),
+        applyShellSnapshot: applyQueriedShellSnapshot,
+        hasThreads: () => (useStore.getState().threadIds?.length ?? 0) > 0,
+      }),
+    );
 
     let scopedSubscriptionRefresh: Promise<void> | null = null;
     const ensureScopedSubscriptions = () => {
@@ -2151,6 +2175,7 @@ function EventRouter() {
       threadCatchupBackoffById.clear();
       domainEventFlushThrottler.cancel();
       reconcileThreadSubscriptionsRef.current = null;
+      unregisterEmptyRouteRestoreRefresh();
       void api.orchestration.unsubscribeShell().catch(() => undefined);
       // Same shape as reconnect: every lease drops at once, and a remount re-leases
       // only the visible threads. Keeping those avoids blanking the open chat, and


### PR DESCRIPTION
## Problem

`refreshEmptyRouteRestoreSnapshot()` applies `getShellSnapshot()`, `getSnapshot()`, and `repairState()` results directly to the Zustand store. That bypasses the shell sequence fence owned by `EventRouter`.

A route-restore query can therefore resolve after newer live shell events and roll the client back to an older projection. This is the duplicate snapshot-application path described in #329.

Closes #329.

## Root cause

Route recovery and EventRouter evolved separate snapshot-application models:

- EventRouter buffers/fences live shell events by sequence;
- route recovery performed progressively stronger backend reads and wrote their results directly to the store.

The stronger recovery ladder is useful, but the direct writes are not safe once EventRouter has an authoritative live sequence.

## What changed

- add a small route-restore refresh coordinator registered by `EventRouter`;
- make `chatRouteRecovery` request that coordinator instead of mutating the store;
- keep the recovery ladder: shell snapshot → full read-model probe → repair;
- use full read models only as recovery probes, never as direct route-level store writes;
- after a full snapshot or repair indicates progress, fetch a fresh shell snapshot and apply it through EventRouter;
- reject queried shell snapshots whose `snapshotSequence` is older than the current live shell fence;
- deregister the coordinator with the EventRouter lifecycle;
- add focused tests for coordinator ownership, shell-only recovery, full-snapshot probing, and repair recovery.

## Behavior

Before:

1. live shell stream advances;
2. route recovery starts an older query;
3. query resolves late;
4. route helper directly replaces store state with the stale snapshot.

After:

1. route recovery asks EventRouter to refresh;
2. EventRouter owns every shell snapshot application;
3. a queried snapshot older than the live sequence is ignored;
4. full snapshots/repair results never bypass that fence.

## Why this approach

The change keeps route policy separate from projection ownership. Route code still requests one stronger recovery attempt before falling back, but only EventRouter decides whether a snapshot is safe to apply.

The coordinator is intentionally small and single-owner. Its unregister function is identity-safe, so a stale cleanup cannot remove a newer EventRouter registration.

## Validation

On the branch before opening this PR:

- repository formatter (`oxfmt`) run on every touched file;
- focused web tests passed:
  - `src/chatRouteRecovery.test.ts`
  - `src/routeRestoreRefreshCoordinator.test.ts`
- `git diff --check` passed;
- branch rewritten to one focused commit after validation.

The draft remains subject to the full upstream GitHub Actions suite.

## Scope

5 web files. No server, contract, persistence, provider, or visual changes.

## Out of scope

- changing the route fallback delay;
- changing EventRouter thread-detail fencing;
- changing desktop project recovery policy;
- changing `repairState()` semantics.