### PR TITLE
test(provider): add sanitized event fixtures

### DIFF
--- a/apps/server/src/provider/providerEventFixture.test.ts
+++ b/apps/server/src/provider/providerEventFixture.test.ts
@@ -56,8 +56,8 @@ describe("provider event fixtures", () => {
       },
     ]) as Array<Record<string, any>>;
 
-    expect(sanitized.properties.sessionID).toBe("<id-1>");
-    expect(sanitized.properties.partID).toBe("<id-2>");
+    expect(sanitized!.properties.sessionID).toBe("<id-1>");
+    expect(sanitized!.properties.partID).toBe("<id-2>");
   });
 
   it("preserves timestamp types while normalizing values", () => {
@@ -69,8 +69,8 @@ describe("provider event fixtures", () => {
       },
     ]) as Array<Record<string, any>>;
 
-    expect(sanitized.createdAt).toBe("2000-01-01T00:00:00.000Z");
-    expect(sanitized.properties.timestamp).toBe(0);
+    expect(sanitized!.createdAt).toBe("2000-01-01T00:00:00.000Z");
+    expect(sanitized!.properties.timestamp).toBe(0);
   });
 
   it("preserves safe native event methods", () => {
@@ -81,8 +81,8 @@ describe("provider event fixtures", () => {
       },
     ]) as Array<Record<string, any>>;
 
-    expect(sanitized.method).toBe("thread/started");
-    expect(sanitized.params.sessionID).toBe("<id-1>");
+    expect(sanitized!.method).toBe("thread/started");
+    expect(sanitized!.params.sessionID).toBe("<id-1>");
   });
 
   it("fails closed for an unclassified string field", () => {
@@ -122,6 +122,106 @@ describe("provider event fixtures", () => {
         },
       ]),
     ).toThrow(/unclassified string field/u);
+  });
+
+  it("does not trust discriminator-looking strings inside provider payloads", () => {
+    expect(() =>
+      serializeProviderEventFixture([{ type: "custom.event", status: "private-project-codename" }]),
+    ).toThrow(/unclassified string field/u);
+    for (const container of ["properties", "payload", "params"] as const) {
+      expect(() =>
+        serializeProviderEventFixture([
+          {
+            type: "custom.event",
+            [container]: { status: "private-project-codename" },
+          },
+        ]),
+      ).toThrow(/unclassified string field/u);
+    }
+  });
+
+  it("rejects sensitive data embedded in property names", () => {
+    expect(() =>
+      serializeProviderEventFixture([
+        {
+          type: "custom.event",
+          metadata: { "authorization-Bearer-private-secret": true },
+        },
+      ]),
+    ).toThrow(/unclassified object key/u);
+  });
+
+  it("supports classified Claude and OpenCode payload shapes", () => {
+    const [claude, openCode] = sanitizeProviderEventFixtureEvents([
+      {
+        type: "stream_event",
+        payload: {
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          parent_tool_use_id: null,
+        },
+      },
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            time: { startedAt: 123, endedAt: 456 },
+          },
+        },
+      },
+    ]) as Array<Record<string, any>>;
+
+    expect(claude!.payload).toMatchObject({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      parent_tool_use_id: null,
+    });
+    expect(openCode!.properties.info.time).toEqual({ startedAt: 0, endedAt: 0 });
+  });
+
+  it("preserves numeric usage fields while redacting credential tokens", () => {
+    const [sanitized] = sanitizeProviderEventFixtureEvents([
+      {
+        type: "thread/tokenUsage/updated",
+        payload: {
+          tokenUsage: {
+            inputTokens: 10,
+            outputTokens: 5,
+            totalTokens: 15,
+          },
+          token: "credential",
+        },
+      },
+    ]) as Array<Record<string, any>>;
+
+    expect(sanitized!.payload.tokenUsage).toEqual({
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+    });
+    expect(sanitized!.payload.token).toBe("<redacted>");
+  });
+
+  it("redacts string-valued message fields", () => {
+    const [sanitized] = sanitizeProviderEventFixtureEvents([
+      { type: "process/stderr", message: "private stderr text" },
+    ]) as Array<Record<string, any>>;
+
+    expect(sanitized!.message).toBe("<redacted>");
+  });
+
+  it("rejects non-object events and non-finite numbers before serialization", () => {
+    for (const event of [null, 1, []]) {
+      expect(() => serializeProviderEventFixture([event])).toThrow(/events must be objects/u);
+    }
+    expect(() =>
+      serializeProviderEventFixture([{ type: "custom.event", attempt: Number.NaN }]),
+    ).toThrow(/numbers must be finite/u);
+    expect(() =>
+      serializeProviderEventFixture([{ type: "custom.event", usage: [Infinity] }]),
+    ).toThrow(/numbers must be finite/u);
   });
 
   it("rejects prototype-shaped keys instead of mutating the sanitizer result prototype", () => {
@@ -187,6 +287,17 @@ describe("provider event fixtures", () => {
 
     expect(() => parseProviderEventFixture(one, { maxBytes: 1 })).toThrow(/exceeds 1 bytes/u);
     expect(() => parseProviderEventFixture(two, { maxEvents: 1 })).toThrow(/exceeds 1 events/u);
+    expect(() => serializeProviderEventFixture(Array.from({ length: 2_001 }, () => ({})))).toThrow(
+      /exceeds 2000 events/u,
+    );
+    expect(() =>
+      serializeProviderEventFixture([
+        {
+          type: "custom.event",
+          usage: Array.from({ length: 300_000 }, () => 1),
+        },
+      ]),
+    ).toThrow(/exceeds 524288 bytes/u);
   });
 
   it("replays records sequentially in fixture order", async () => {

--- a/apps/server/src/provider/providerEventFixture.test.ts
+++ b/apps/server/src/provider/providerEventFixture.test.ts
@@ -124,6 +124,15 @@ describe("provider event fixtures", () => {
     ).toThrow(/unclassified string field/u);
   });
 
+  it("only preserves explicitly classified root protocol discriminators", () => {
+    for (const event of [
+      { type: "/home/alice/private-project" },
+      { method: "thread/private-project-codename" },
+    ]) {
+      expect(() => serializeProviderEventFixture([event])).toThrow(/unclassified string field/u);
+    }
+  });
+
   it("does not trust discriminator-looking strings inside provider payloads", () => {
     expect(() =>
       serializeProviderEventFixture([{ type: "custom.event", status: "private-project-codename" }]),

--- a/apps/server/src/provider/providerEventFixture.test.ts
+++ b/apps/server/src/provider/providerEventFixture.test.ts
@@ -212,6 +212,19 @@ describe("provider event fixtures", () => {
     expect(sanitized!.message).toBe("<redacted>");
   });
 
+  it("redacts structured sensitive values instead of traversing them", () => {
+    const [sanitized] = sanitizeProviderEventFixtureEvents([
+      {
+        type: "custom.event",
+        input: { count: 42 },
+        body: [true, false],
+      },
+    ]) as Array<Record<string, any>>;
+
+    expect(sanitized!.input).toBe("<redacted>");
+    expect(sanitized!.body).toBe("<redacted>");
+  });
+
   it("rejects non-object events and non-finite numbers before serialization", () => {
     for (const event of [null, 1, []]) {
       expect(() => serializeProviderEventFixture([event])).toThrow(/events must be objects/u);

--- a/apps/server/src/provider/providerEventFixture.test.ts
+++ b/apps/server/src/provider/providerEventFixture.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  parseProviderEventFixture,
+  ProviderEventFixtureError,
+  replayProviderEventFixture,
+  sanitizeProviderEventFixtureEvents,
+  serializeProviderEventFixture,
+} from "./providerEventFixture";
+
+describe("provider event fixtures", () => {
+  it("redacts content and preserves deterministic identifier relationships", () => {
+    const sanitized = sanitizeProviderEventFixtureEvents([
+      {
+        type: "message.part.delta",
+        properties: {
+          sessionID: "session-private",
+          partID: "part-private",
+          timestamp: 1_786_000_000,
+          text: "private assistant text",
+          token: "secret-token",
+        },
+      },
+      {
+        type: "message.part.updated",
+        properties: {
+          sessionID: "session-private",
+          partID: "part-private",
+          timestamp: 1_786_000_100,
+          status: "completed",
+        },
+      },
+    ]) as Array<Record<string, any>>;
+    const first = sanitized[0]!;
+    const second = sanitized[1]!;
+
+    expect(first.properties.sessionID).toBe("<id-1>");
+    expect(first.properties.partID).toBe("<id-2>");
+    expect(first.properties.timestamp).toBe(0);
+    expect(first.properties.text).toBe("<redacted>");
+    expect(first.properties.token).toBe("<redacted>");
+    expect(second.properties.sessionID).toBe("<id-1>");
+    expect(second.properties.partID).toBe("<id-2>");
+    expect(second.properties.status).toBe("completed");
+  });
+
+  it("keeps numeric and string identifiers distinct", () => {
+    const [sanitized] = sanitizeProviderEventFixtureEvents([
+      {
+        type: "message.part.updated",
+        properties: {
+          sessionID: 1,
+          partID: "1",
+          status: "completed",
+        },
+      },
+    ]) as Array<Record<string, any>>;
+
+    expect(sanitized.properties.sessionID).toBe("<id-1>");
+    expect(sanitized.properties.partID).toBe("<id-2>");
+  });
+
+  it("preserves timestamp types while normalizing values", () => {
+    const [sanitized] = sanitizeProviderEventFixtureEvents([
+      {
+        type: "turn.completed",
+        createdAt: "2026-08-15T12:34:56.000Z",
+        properties: { timestamp: 1_786_000_000, state: "completed" },
+      },
+    ]) as Array<Record<string, any>>;
+
+    expect(sanitized.createdAt).toBe("2000-01-01T00:00:00.000Z");
+    expect(sanitized.properties.timestamp).toBe(0);
+  });
+
+  it("preserves safe native event methods", () => {
+    const [sanitized] = sanitizeProviderEventFixtureEvents([
+      {
+        method: "thread/started",
+        params: { sessionID: "session-private", status: "ready" },
+      },
+    ]) as Array<Record<string, any>>;
+
+    expect(sanitized.method).toBe("thread/started");
+    expect(sanitized.params.sessionID).toBe("<id-1>");
+  });
+
+  it("fails closed for an unclassified string field", () => {
+    expect(() =>
+      serializeProviderEventFixture([
+        {
+          type: "custom.event",
+          properties: {
+            mystery: "could contain user data",
+          },
+        },
+      ]),
+    ).toThrow(ProviderEventFixtureError);
+  });
+
+  it("rejects unclassified object keys even when their values are not strings", () => {
+    expect(() =>
+      serializeProviderEventFixture([
+        {
+          type: "custom.event",
+          metadata: {
+            "/home/alice/private-project": true,
+          },
+        },
+      ]),
+    ).toThrow(/unclassified object key/u);
+  });
+
+  it("does not trust globally safe-looking keys inside arbitrary metadata", () => {
+    expect(() =>
+      serializeProviderEventFixture([
+        {
+          type: "custom.event",
+          metadata: {
+            type: "private-project",
+          },
+        },
+      ]),
+    ).toThrow(/unclassified string field/u);
+  });
+
+  it("rejects prototype-shaped keys instead of mutating the sanitizer result prototype", () => {
+    const metadata = JSON.parse('{"__proto__":{"status":"completed"}}') as unknown;
+    expect(() =>
+      serializeProviderEventFixture([
+        {
+          type: "custom.event",
+          metadata,
+        },
+      ]),
+    ).toThrow(/unclassified object key/u);
+  });
+
+  it("round-trips a sanitized line-oriented fixture", () => {
+    const serialized = serializeProviderEventFixture([
+      {
+        type: "session.state.changed",
+        properties: {
+          sessionID: "session-private",
+          status: "ready",
+          timestamp: 123,
+        },
+      },
+      {
+        type: "turn.completed",
+        properties: {
+          sessionID: "session-private",
+          state: "completed",
+          timestamp: 456,
+        },
+      },
+    ]);
+
+    const records = parseProviderEventFixture(serialized);
+
+    expect(records).toHaveLength(2);
+    expect(records.map((record) => record.index)).toEqual([0, 1]);
+    expect(records[0]?.event).toMatchObject({
+      type: "session.state.changed",
+      properties: { sessionID: "<id-1>", status: "ready", timestamp: 0 },
+    });
+  });
+
+  it("rejects malformed, version-mismatched, out-of-order, and non-object events", () => {
+    expect(() => parseProviderEventFixture("not-json")).toThrow(ProviderEventFixtureError);
+    expect(() =>
+      parseProviderEventFixture(JSON.stringify({ version: 2, index: 0, event: {} })),
+    ).toThrow(/unsupported version/u);
+    expect(() =>
+      parseProviderEventFixture(JSON.stringify({ version: 1, index: 1, event: {} })),
+    ).toThrow(/out-of-order index/u);
+    for (const event of [null, "event", 1, []]) {
+      expect(() =>
+        parseProviderEventFixture(JSON.stringify({ version: 1, index: 0, event })),
+      ).toThrow(/event must be an object/u);
+    }
+  });
+
+  it("enforces byte and event-count bounds", () => {
+    const one = JSON.stringify({ version: 1, index: 0, event: {} });
+    const two = `${one}\n${JSON.stringify({ version: 1, index: 1, event: {} })}`;
+
+    expect(() => parseProviderEventFixture(one, { maxBytes: 1 })).toThrow(/exceeds 1 bytes/u);
+    expect(() => parseProviderEventFixture(two, { maxEvents: 1 })).toThrow(/exceeds 1 events/u);
+  });
+
+  it("replays records sequentially in fixture order", async () => {
+    const records = parseProviderEventFixture(
+      [
+        JSON.stringify({ version: 1, index: 0, event: { type: "first" } }),
+        JSON.stringify({ version: 1, index: 1, event: { type: "second" } }),
+      ].join("\n"),
+    );
+    const observed: string[] = [];
+    const consume = vi.fn(async (event: unknown) => {
+      await Promise.resolve();
+      observed.push((event as { type: string }).type);
+    });
+
+    await replayProviderEventFixture(records, consume);
+
+    expect(observed).toEqual(["first", "second"]);
+    expect(consume).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/server/src/provider/providerEventFixture.test.ts
+++ b/apps/server/src/provider/providerEventFixture.test.ts
@@ -204,6 +204,33 @@ describe("provider event fixtures", () => {
     expect(sanitized!.payload.token).toBe("<redacted>");
   });
 
+  it("preserves the structured OpenCode token-usage counters", () => {
+    const [sanitized] = sanitizeProviderEventFixtureEvents([
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            tokens: {
+              total: 18,
+              input: 10,
+              output: 5,
+              reasoning: 1,
+              cache: { read: 2, write: 0 },
+            },
+          },
+        },
+      },
+    ]) as Array<Record<string, any>>;
+
+    expect(sanitized!.properties.info.tokens).toEqual({
+      total: 18,
+      input: 10,
+      output: 5,
+      reasoning: 1,
+      cache: { read: 2, write: 0 },
+    });
+  });
+
   it("redacts string-valued message fields", () => {
     const [sanitized] = sanitizeProviderEventFixtureEvents([
       { type: "process/stderr", message: "private stderr text" },

--- a/apps/server/src/provider/providerEventFixture.ts
+++ b/apps/server/src/provider/providerEventFixture.ts
@@ -36,9 +36,24 @@ const IDENTIFIER_KEY_PATTERN = /(?:^|_)(?:id|uuid)$/i;
 const CAMEL_IDENTIFIER_KEY_PATTERN = /(?:Id|ID|Uuid|UUID)$/;
 const TIMESTAMP_KEY_PATTERN =
   /(?:timestamp|createdAt|updatedAt|observedAt|startedAt|endedAt|time)$/i;
-const SAFE_DISCRIMINATOR_VALUE_PATTERN = /^[A-Za-z0-9_.:/@-]{1,128}$/u;
 const OPENCODE_TOKEN_COUNTER_KEYS = new Set(["input", "output", "reasoning"]);
 const OPENCODE_CACHE_COUNTER_KEYS = new Set(["read", "write"]);
+
+// Root protocol discriminators are part of the fixture replay contract. Keep this
+// allowlist explicit so a user-controlled path or label cannot cross the safe-to-commit
+// boundary merely because it resembles an event name.
+const SAFE_ROOT_TYPE_VALUES = new Set([
+  "custom.event",
+  "message.part.delta",
+  "message.part.updated",
+  "message.updated",
+  "process/stderr",
+  "session.state.changed",
+  "stream_event",
+  "thread/tokenUsage/updated",
+  "turn.completed",
+]);
+const SAFE_ROOT_METHOD_VALUES = new Set(["thread/started"]);
 
 const SAFE_STRING_KEYS = new Set([
   "type",
@@ -271,8 +286,8 @@ function sanitizeValue(
       key &&
       SAFE_STRING_KEYS.has(key) &&
       ((!context.untrustedStrings &&
-        (key === "type" || key === "method") &&
-        SAFE_DISCRIMINATOR_VALUE_PATTERN.test(value)) ||
+        ((key === "type" && SAFE_ROOT_TYPE_VALUES.has(value)) ||
+          (key === "method" && SAFE_ROOT_METHOD_VALUES.has(value)))) ||
         SAFE_UNTRUSTED_STRING_VALUES.has(value))
     ) {
       return value;

--- a/apps/server/src/provider/providerEventFixture.ts
+++ b/apps/server/src/provider/providerEventFixture.ts
@@ -1,0 +1,274 @@
+const PROVIDER_EVENT_FIXTURE_VERSION = 1 as const;
+const DEFAULT_MAX_FIXTURE_BYTES = 512 * 1024;
+const DEFAULT_MAX_FIXTURE_EVENTS = 2_000;
+
+const REDACTED_VALUE = "<redacted>";
+const NORMALIZED_ISO_TIMESTAMP = "2000-01-01T00:00:00.000Z";
+
+const SENSITIVE_KEY_PATTERN =
+  /(?:authorization|bearer|cookie|credential|secret|token|api.?key|prompt|content|text|body|input|output|attachment|file|path|cwd|environment|env|header|url)/i;
+const IDENTIFIER_KEY_PATTERN = /(?:^|_)(?:id|uuid)$/i;
+const CAMEL_IDENTIFIER_KEY_PATTERN = /(?:Id|ID|Uuid|UUID)$/;
+const TIMESTAMP_KEY_PATTERN =
+  /(?:timestamp|createdAt|updatedAt|observedAt|startedAt|endedAt|time)$/i;
+const SAFE_DISCRIMINATOR_VALUE_PATTERN = /^[A-Za-z0-9_.:/@-]{1,128}$/u;
+
+const SAFE_STRING_KEYS = new Set([
+  "type",
+  "provider",
+  "source",
+  "method",
+  "role",
+  "status",
+  "state",
+  "finish",
+  "permission",
+  "reply",
+  "action",
+  "kind",
+  "phase",
+  "streamKind",
+]);
+
+const SAFE_SCALAR_KEYS = new Set([
+  "code",
+  "sequence",
+  "count",
+  "total",
+  "attempt",
+  "retryCount",
+  "durationMs",
+  "enabled",
+  "completed",
+  "synthetic",
+  "ignored",
+]);
+
+const SAFE_CONTAINER_KEYS = new Set([
+  "event",
+  "properties",
+  "payload",
+  "params",
+  "info",
+  "part",
+  "raw",
+  "data",
+  "metadata",
+  "message",
+  "item",
+  "session",
+  "request",
+  "response",
+  "result",
+  "error",
+  "usage",
+  "cache",
+  "tokens",
+  "time",
+]);
+
+const UNTRUSTED_STRING_CONTAINER_KEYS = new Set(["data", "metadata", "raw"]);
+
+export interface ProviderEventFixtureRecord {
+  readonly version: typeof PROVIDER_EVENT_FIXTURE_VERSION;
+  readonly index: number;
+  readonly event: unknown;
+}
+
+export interface ProviderEventFixtureParseOptions {
+  readonly maxBytes?: number;
+  readonly maxEvents?: number;
+}
+
+export class ProviderEventFixtureError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProviderEventFixtureError";
+  }
+}
+
+type SanitizerState = {
+  readonly ids: Map<string, string>;
+  nextId: number;
+};
+
+type SanitizerContext = {
+  readonly untrustedStrings: boolean;
+};
+
+function redactIdentifier(value: unknown, state: SanitizerState): string {
+  if (typeof value !== "string" && typeof value !== "number") {
+    throw new ProviderEventFixtureError("Identifier fields must be strings or numbers.");
+  }
+  const mapKey = `${typeof value}:${String(value)}`;
+  const existing = state.ids.get(mapKey);
+  if (existing) {
+    return existing;
+  }
+  const replacement = `<id-${String(state.nextId)}>`;
+  state.nextId += 1;
+  state.ids.set(mapKey, replacement);
+  return replacement;
+}
+
+function normalizeTimestamp(value: unknown): string | number {
+  if (typeof value === "string") {
+    return NORMALIZED_ISO_TIMESTAMP;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return 0;
+  }
+  throw new ProviderEventFixtureError("Timestamp fields must be strings or finite numbers.");
+}
+
+function isClassifiedFixtureKey(key: string): boolean {
+  return (
+    SAFE_CONTAINER_KEYS.has(key) ||
+    SAFE_STRING_KEYS.has(key) ||
+    SAFE_SCALAR_KEYS.has(key) ||
+    SENSITIVE_KEY_PATTERN.test(key) ||
+    IDENTIFIER_KEY_PATTERN.test(key) ||
+    CAMEL_IDENTIFIER_KEY_PATTERN.test(key) ||
+    TIMESTAMP_KEY_PATTERN.test(key)
+  );
+}
+
+function sanitizeValue(
+  value: unknown,
+  key: string | null,
+  state: SanitizerState,
+  context: SanitizerContext,
+): unknown {
+  if (key && SENSITIVE_KEY_PATTERN.test(key)) {
+    return REDACTED_VALUE;
+  }
+  if (key && (IDENTIFIER_KEY_PATTERN.test(key) || CAMEL_IDENTIFIER_KEY_PATTERN.test(key))) {
+    return redactIdentifier(value, state);
+  }
+  if (key && TIMESTAMP_KEY_PATTERN.test(key)) {
+    return normalizeTimestamp(value);
+  }
+
+  if (value === null || typeof value === "boolean" || typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "string") {
+    if (
+      key &&
+      SAFE_STRING_KEYS.has(key) &&
+      !context.untrustedStrings &&
+      SAFE_DISCRIMINATOR_VALUE_PATTERN.test(value)
+    ) {
+      return value;
+    }
+    throw new ProviderEventFixtureError(
+      `Refusing to preserve unclassified string field${key ? ` "${key}"` : ""}.`,
+    );
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeValue(entry, null, state, context));
+  }
+  if (typeof value !== "object") {
+    throw new ProviderEventFixtureError("Fixture values must be JSON-compatible.");
+  }
+
+  const result = Object.create(null) as Record<string, unknown>;
+  for (const [childKey, childValue] of Object.entries(value)) {
+    if (!isClassifiedFixtureKey(childKey)) {
+      throw new ProviderEventFixtureError(
+        `Refusing to preserve unclassified object key "${childKey}".`,
+      );
+    }
+    result[childKey] = sanitizeValue(childValue, childKey, state, {
+      untrustedStrings: context.untrustedStrings || UNTRUSTED_STRING_CONTAINER_KEYS.has(childKey),
+    });
+  }
+  return result;
+}
+
+export function sanitizeProviderEventFixtureEvents(events: readonly unknown[]): unknown[] {
+  const state: SanitizerState = { ids: new Map(), nextId: 1 };
+  return events.map((event) =>
+    sanitizeValue(event, null, state, {
+      untrustedStrings: false,
+    }),
+  );
+}
+
+export function serializeProviderEventFixture(events: readonly unknown[]): string {
+  return sanitizeProviderEventFixtureEvents(events)
+    .map((event, index) =>
+      JSON.stringify({
+        version: PROVIDER_EVENT_FIXTURE_VERSION,
+        index,
+        event,
+      } satisfies ProviderEventFixtureRecord),
+    )
+    .join("\n");
+}
+
+function parseFixtureRecord(line: string, expectedIndex: number): ProviderEventFixtureRecord {
+  let value: unknown;
+  try {
+    value = JSON.parse(line);
+  } catch (cause) {
+    throw new ProviderEventFixtureError(
+      `Fixture record ${String(expectedIndex)} is not valid JSON: ${String(cause)}`,
+    );
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ProviderEventFixtureError(
+      `Fixture record ${String(expectedIndex)} must be an object.`,
+    );
+  }
+  const record = value as Record<string, unknown>;
+  if (record.version !== PROVIDER_EVENT_FIXTURE_VERSION) {
+    throw new ProviderEventFixtureError(
+      `Fixture record ${String(expectedIndex)} has unsupported version ${String(record.version)}.`,
+    );
+  }
+  if (record.index !== expectedIndex) {
+    throw new ProviderEventFixtureError(
+      `Fixture record ${String(expectedIndex)} has out-of-order index ${String(record.index)}.`,
+    );
+  }
+  if (!record.event || typeof record.event !== "object" || Array.isArray(record.event)) {
+    throw new ProviderEventFixtureError(
+      `Fixture record ${String(expectedIndex)} event must be an object.`,
+    );
+  }
+  return {
+    version: PROVIDER_EVENT_FIXTURE_VERSION,
+    index: expectedIndex,
+    event: record.event,
+  };
+}
+
+export function parseProviderEventFixture(
+  text: string,
+  options: ProviderEventFixtureParseOptions = {},
+): ProviderEventFixtureRecord[] {
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_FIXTURE_BYTES;
+  const maxEvents = options.maxEvents ?? DEFAULT_MAX_FIXTURE_EVENTS;
+  if (Buffer.byteLength(text, "utf8") > maxBytes) {
+    throw new ProviderEventFixtureError(`Fixture exceeds ${String(maxBytes)} bytes.`);
+  }
+
+  const lines = text
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines.length > maxEvents) {
+    throw new ProviderEventFixtureError(`Fixture exceeds ${String(maxEvents)} events.`);
+  }
+  return lines.map((line, index) => parseFixtureRecord(line, index));
+}
+
+export async function replayProviderEventFixture(
+  records: readonly ProviderEventFixtureRecord[],
+  consume: (event: unknown, index: number) => void | Promise<void>,
+): Promise<void> {
+  for (const record of records) {
+    await consume(record.event, record.index);
+  }
+}

--- a/apps/server/src/provider/providerEventFixture.ts
+++ b/apps/server/src/provider/providerEventFixture.ts
@@ -227,8 +227,12 @@ function sanitizeValue(
   state: SanitizerState,
   context: SanitizerContext,
 ): unknown {
-  if (key && SENSITIVE_VALUE_KEYS.has(key) && (value === null || typeof value !== "object")) {
-    return REDACTED_VALUE;
+  if (key && SENSITIVE_VALUE_KEYS.has(key)) {
+    const isStructuredMessage =
+      key === "message" && value !== null && typeof value === "object" && !Array.isArray(value);
+    if (!isStructuredMessage) {
+      return REDACTED_VALUE;
+    }
   }
   if (key && (IDENTIFIER_KEY_PATTERN.test(key) || CAMEL_IDENTIFIER_KEY_PATTERN.test(key))) {
     if (value === null) {

--- a/apps/server/src/provider/providerEventFixture.ts
+++ b/apps/server/src/provider/providerEventFixture.ts
@@ -37,6 +37,8 @@ const CAMEL_IDENTIFIER_KEY_PATTERN = /(?:Id|ID|Uuid|UUID)$/;
 const TIMESTAMP_KEY_PATTERN =
   /(?:timestamp|createdAt|updatedAt|observedAt|startedAt|endedAt|time)$/i;
 const SAFE_DISCRIMINATOR_VALUE_PATTERN = /^[A-Za-z0-9_.:/@-]{1,128}$/u;
+const OPENCODE_TOKEN_COUNTER_KEYS = new Set(["input", "output", "reasoning"]);
+const OPENCODE_CACHE_COUNTER_KEYS = new Set(["read", "write"]);
 
 const SAFE_STRING_KEYS = new Set([
   "type",
@@ -182,6 +184,7 @@ type SanitizerState = {
 
 type SanitizerContext = {
   readonly untrustedStrings: boolean;
+  readonly openCodeTokenLocation: "none" | "tokens" | "cache";
 };
 
 function redactIdentifier(value: unknown, state: SanitizerState): string {
@@ -209,8 +212,10 @@ function normalizeTimestamp(value: unknown): string | number {
   throw new ProviderEventFixtureError("Timestamp fields must be strings or finite numbers.");
 }
 
-function isClassifiedFixtureKey(key: string): boolean {
+function isClassifiedFixtureKey(key: string, context: SanitizerContext): boolean {
   return (
+    (context.openCodeTokenLocation === "tokens" && OPENCODE_TOKEN_COUNTER_KEYS.has(key)) ||
+    (context.openCodeTokenLocation === "cache" && OPENCODE_CACHE_COUNTER_KEYS.has(key)) ||
     SAFE_CONTAINER_KEYS.has(key) ||
     SAFE_STRING_KEYS.has(key) ||
     SAFE_SCALAR_KEYS.has(key) ||
@@ -228,9 +233,13 @@ function sanitizeValue(
   context: SanitizerContext,
 ): unknown {
   if (key && SENSITIVE_VALUE_KEYS.has(key)) {
+    const isOpenCodeTokenCounter =
+      context.openCodeTokenLocation === "tokens" &&
+      OPENCODE_TOKEN_COUNTER_KEYS.has(key) &&
+      typeof value === "number";
     const isStructuredMessage =
       key === "message" && value !== null && typeof value === "object" && !Array.isArray(value);
-    if (!isStructuredMessage) {
+    if (!isStructuredMessage && !isOpenCodeTokenCounter) {
       return REDACTED_VALUE;
     }
   }
@@ -280,14 +289,24 @@ function sanitizeValue(
   }
 
   const result = Object.create(null) as Record<string, unknown>;
+  const childContext: SanitizerContext = {
+    untrustedStrings: context.untrustedStrings,
+    openCodeTokenLocation:
+      key === "tokens"
+        ? "tokens"
+        : key === "cache" && context.openCodeTokenLocation === "tokens"
+          ? "cache"
+          : "none",
+  };
   for (const [childKey, childValue] of Object.entries(value)) {
-    if (!isClassifiedFixtureKey(childKey)) {
+    if (!isClassifiedFixtureKey(childKey, childContext)) {
       throw new ProviderEventFixtureError(
         `Refusing to preserve unclassified object key "${childKey}".`,
       );
     }
     result[childKey] = sanitizeValue(childValue, childKey, state, {
       untrustedStrings: context.untrustedStrings || UNTRUSTED_STRING_CONTAINER_KEYS.has(childKey),
+      openCodeTokenLocation: childContext.openCodeTokenLocation,
     });
   }
   return result;
@@ -301,6 +320,7 @@ export function sanitizeProviderEventFixtureEvents(events: readonly unknown[]): 
     }
     return sanitizeValue(event, null, state, {
       untrustedStrings: false,
+      openCodeTokenLocation: "none",
     });
   });
 }

--- a/apps/server/src/provider/providerEventFixture.ts
+++ b/apps/server/src/provider/providerEventFixture.ts
@@ -5,8 +5,33 @@ const DEFAULT_MAX_FIXTURE_EVENTS = 2_000;
 const REDACTED_VALUE = "<redacted>";
 const NORMALIZED_ISO_TIMESTAMP = "2000-01-01T00:00:00.000Z";
 
-const SENSITIVE_KEY_PATTERN =
-  /(?:authorization|bearer|cookie|credential|secret|token|api.?key|prompt|content|text|body|input|output|attachment|file|path|cwd|environment|env|header|url)/i;
+const SENSITIVE_VALUE_KEYS = new Set([
+  "authorization",
+  "bearer",
+  "body",
+  "content",
+  "cookie",
+  "credential",
+  "cwd",
+  "environment",
+  "env",
+  "file",
+  "filePath",
+  "header",
+  "headers",
+  "input",
+  "message",
+  "output",
+  "path",
+  "prompt",
+  "secret",
+  "text",
+  "token",
+  "url",
+  "apiKey",
+  "api_key",
+  "attachment",
+]);
 const IDENTIFIER_KEY_PATTERN = /(?:^|_)(?:id|uuid)$/i;
 const CAMEL_IDENTIFIER_KEY_PATTERN = /(?:Id|ID|Uuid|UUID)$/;
 const TIMESTAMP_KEY_PATTERN =
@@ -28,6 +53,61 @@ const SAFE_STRING_KEYS = new Set([
   "kind",
   "phase",
   "streamKind",
+  "subtype",
+]);
+
+const SAFE_UNTRUSTED_STRING_VALUES = new Set([
+  "accepted",
+  "allow",
+  "always",
+  "approved",
+  "assistant",
+  "assistant_text",
+  "antigravity",
+  "cancelled",
+  "canceled",
+  "claudeAgent",
+  "client",
+  "codex",
+  "complete",
+  "completed",
+  "cursor",
+  "denied",
+  "deny",
+  "desktop",
+  "droid",
+  "error",
+  "failed",
+  "grok",
+  "idle",
+  "in_progress",
+  "inProgress",
+  "input_text",
+  "kilo",
+  "once",
+  "output_text",
+  "opencode",
+  "pending",
+  "pi",
+  "provider",
+  "ready",
+  "reasoning",
+  "reasoning_text",
+  "rejected",
+  "result",
+  "running",
+  "started",
+  "stderr",
+  "stdout",
+  "stopped",
+  "success",
+  "server",
+  "system",
+  "terminal",
+  "text",
+  "tool",
+  "user",
+  "web",
 ]);
 
 const SAFE_SCALAR_KEYS = new Set([
@@ -42,6 +122,13 @@ const SAFE_SCALAR_KEYS = new Set([
   "completed",
   "synthetic",
   "ignored",
+  "is_error",
+  "inputTokens",
+  "outputTokens",
+  "cachedInputTokens",
+  "reasoningOutputTokens",
+  "totalTokens",
+  "contextWindow",
 ]);
 
 const SAFE_CONTAINER_KEYS = new Set([
@@ -64,10 +151,11 @@ const SAFE_CONTAINER_KEYS = new Set([
   "usage",
   "cache",
   "tokens",
+  "tokenUsage",
   "time",
 ]);
 
-const UNTRUSTED_STRING_CONTAINER_KEYS = new Set(["data", "metadata", "raw"]);
+const UNTRUSTED_STRING_CONTAINER_KEYS = new Set(SAFE_CONTAINER_KEYS);
 
 export interface ProviderEventFixtureRecord {
   readonly version: typeof PROVIDER_EVENT_FIXTURE_VERSION;
@@ -126,7 +214,7 @@ function isClassifiedFixtureKey(key: string): boolean {
     SAFE_CONTAINER_KEYS.has(key) ||
     SAFE_STRING_KEYS.has(key) ||
     SAFE_SCALAR_KEYS.has(key) ||
-    SENSITIVE_KEY_PATTERN.test(key) ||
+    SENSITIVE_VALUE_KEYS.has(key) ||
     IDENTIFIER_KEY_PATTERN.test(key) ||
     CAMEL_IDENTIFIER_KEY_PATTERN.test(key) ||
     TIMESTAMP_KEY_PATTERN.test(key)
@@ -139,25 +227,40 @@ function sanitizeValue(
   state: SanitizerState,
   context: SanitizerContext,
 ): unknown {
-  if (key && SENSITIVE_KEY_PATTERN.test(key)) {
+  if (key && SENSITIVE_VALUE_KEYS.has(key) && (value === null || typeof value !== "object")) {
     return REDACTED_VALUE;
   }
   if (key && (IDENTIFIER_KEY_PATTERN.test(key) || CAMEL_IDENTIFIER_KEY_PATTERN.test(key))) {
+    if (value === null) {
+      return null;
+    }
     return redactIdentifier(value, state);
   }
-  if (key && TIMESTAMP_KEY_PATTERN.test(key)) {
+  if (
+    key &&
+    TIMESTAMP_KEY_PATTERN.test(key) &&
+    (typeof value === "string" || typeof value === "number")
+  ) {
     return normalizeTimestamp(value);
   }
 
-  if (value === null || typeof value === "boolean" || typeof value === "number") {
+  if (value === null || typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new ProviderEventFixtureError("Fixture numbers must be finite.");
+    }
     return value;
   }
   if (typeof value === "string") {
     if (
       key &&
       SAFE_STRING_KEYS.has(key) &&
-      !context.untrustedStrings &&
-      SAFE_DISCRIMINATOR_VALUE_PATTERN.test(value)
+      ((!context.untrustedStrings &&
+        (key === "type" || key === "method") &&
+        SAFE_DISCRIMINATOR_VALUE_PATTERN.test(value)) ||
+        SAFE_UNTRUSTED_STRING_VALUES.has(value))
     ) {
       return value;
     }
@@ -188,15 +291,23 @@ function sanitizeValue(
 
 export function sanitizeProviderEventFixtureEvents(events: readonly unknown[]): unknown[] {
   const state: SanitizerState = { ids: new Map(), nextId: 1 };
-  return events.map((event) =>
-    sanitizeValue(event, null, state, {
+  return events.map((event) => {
+    if (!event || typeof event !== "object" || Array.isArray(event)) {
+      throw new ProviderEventFixtureError("Fixture events must be objects.");
+    }
+    return sanitizeValue(event, null, state, {
       untrustedStrings: false,
-    }),
-  );
+    });
+  });
 }
 
 export function serializeProviderEventFixture(events: readonly unknown[]): string {
-  return sanitizeProviderEventFixtureEvents(events)
+  if (events.length > DEFAULT_MAX_FIXTURE_EVENTS) {
+    throw new ProviderEventFixtureError(
+      `Fixture exceeds ${String(DEFAULT_MAX_FIXTURE_EVENTS)} events.`,
+    );
+  }
+  const serialized = sanitizeProviderEventFixtureEvents(events)
     .map((event, index) =>
       JSON.stringify({
         version: PROVIDER_EVENT_FIXTURE_VERSION,
@@ -205,6 +316,12 @@ export function serializeProviderEventFixture(events: readonly unknown[]): strin
       } satisfies ProviderEventFixtureRecord),
     )
     .join("\n");
+  if (Buffer.byteLength(serialized, "utf8") > DEFAULT_MAX_FIXTURE_BYTES) {
+    throw new ProviderEventFixtureError(
+      `Fixture exceeds ${String(DEFAULT_MAX_FIXTURE_BYTES)} bytes.`,
+    );
+  }
+  return serialized;
 }
 
 function parseFixtureRecord(line: string, expectedIndex: number): ProviderEventFixtureRecord {


### PR DESCRIPTION
## Problem

Real provider regressions are often diagnosed from native event logs, but turning those failures into hermetic CI coverage currently means hand-writing an approximation of the original event sequence.

That loses ordering/payload details. Committing raw provider logs is not acceptable either because they may contain prompts, assistant text, filesystem paths, credentials, headers, tool inputs, or other user data.

This is the first implementation slice of #695.

## What changed

- add a versioned line-oriented provider-event fixture format;
- add a conservative sanitizer that:
  - redacts known content/secrets/path/header/environment fields;
  - replaces identifiers with deterministic synthetic `<id-N>` values while preserving equality relationships;
  - normalizes timestamps;
  - fails closed on unclassified string fields instead of silently preserving possible user data;
- add fixture parser bounds for maximum UTF-8 bytes and event count;
- validate version, record order, and required event payloads while reading;
- add deterministic sequential replay for adapter/runtime tests;
- add focused tests for redaction, deterministic id mapping, fail-closed behavior, round-trip parsing, malformed/version/index rejection, bounds, and replay ordering.

## Safety model

The sanitizer is intentionally restrictive. A field is not preserved merely because it appears harmless in one provider today. Unknown string fields are rejected until they are explicitly classified.

The default sensitive-key policy covers credentials/tokens, prompts/content/text/body/input/output, attachments/files/paths/cwd, environment values, headers, URLs, and related variants.

No production event capture or user conversation is included in this PR.

## Why this approach

The first slice establishes the safe committed-fixture boundary before adding a developer-facing recorder. Future regression tests can consume tiny sanitized fixtures without needing provider credentials or network access in CI.

Keeping recorder/export functionality out of this PR also means the privacy boundary can be reviewed independently.

## Validation

Before opening this PR, the fork branch ran successfully on GitHub Actions:

- repository formatter (`oxfmt`) over both new files;
- `bun run --cwd apps/server test -- src/provider/providerEventFixture.test.ts`;
- `git diff --check`;
- branch rewritten to one focused commit after validation.

The draft remains subject to the full upstream CI suite.

## Scope

2 new server test-support files. No provider runtime, persistence, network, settings, or UI behavior changes.

## Out of scope

- exporting local native-event logs into fixture files;
- storing raw production conversations;
- timing simulation beyond deterministic event order;
- replacing small hand-written provider tests where a fixture would add no value.