### PR TITLE
test(provider): enforce adapter capability conformance

### DIFF
--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
@@ -10,6 +10,7 @@
 import { Effect, Layer } from "effect";
 
 import { ProviderUnsupportedError, type ProviderAdapterError } from "../Errors.ts";
+import { assertProviderAdapterConformance } from "../providerAdapterConformance.ts";
 import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
 import {
   ProviderAdapterRegistry,
@@ -45,6 +46,11 @@ const makeProviderAdapterRegistry = (options?: ProviderAdapterRegistryLiveOption
             yield* OpenCodeAdapter,
             yield* PiAdapter,
           ];
+
+    for (const adapter of adapters) {
+      assertProviderAdapterConformance(adapter);
+    }
+
     const byProvider = new Map(adapters.map((adapter) => [adapter.provider, adapter]));
 
     const getByProvider: ProviderAdapterRegistryShape["getByProvider"] = (provider) => {

--- a/apps/server/src/provider/providerAdapterConformance.test.ts
+++ b/apps/server/src/provider/providerAdapterConformance.test.ts
@@ -1,0 +1,102 @@
+import { Effect, Stream } from "effect";
+import { describe, expect, it } from "vitest";
+
+import type { ProviderAdapterShape } from "./Services/ProviderAdapter.ts";
+import {
+  assertProviderAdapterConformance,
+  providerAdapterConformanceIssues,
+} from "./providerAdapterConformance.ts";
+
+function makeAdapter(
+  overrides: Partial<ProviderAdapterShape<never>> = {},
+): ProviderAdapterShape<never> {
+  return {
+    provider: "codex",
+    capabilities: { sessionModelSwitch: "in-session" },
+    startSession: () => Effect.die("unused"),
+    sendTurn: () => Effect.die("unused"),
+    interruptTurn: () => Effect.void,
+    respondToRequest: () => Effect.void,
+    respondToUserInput: () => Effect.void,
+    stopSession: () => Effect.void,
+    listSessions: () => Effect.succeed([]),
+    hasSession: () => Effect.succeed(false),
+    readThread: () => Effect.die("unused"),
+    rollbackThread: () => Effect.die("unused"),
+    stopAll: () => Effect.void,
+    streamEvents: Stream.empty,
+    ...overrides,
+  };
+}
+
+describe("provider adapter conformance", () => {
+  it("requires turn steering when the capability is advertised", () => {
+    const adapter = makeAdapter({
+      capabilities: {
+        sessionModelSwitch: "in-session",
+        supportsTurnSteering: true,
+      },
+    });
+
+    expect(providerAdapterConformanceIssues(adapter)).toEqual([
+      {
+        capability: "supportsTurnSteering",
+        missingMethod: "steerTurn",
+      },
+    ]);
+  });
+
+  it("requires both plugin methods when plugin discovery is advertised", () => {
+    const adapter = makeAdapter({
+      capabilities: {
+        sessionModelSwitch: "in-session",
+        supportsPluginDiscovery: true,
+      },
+      listPlugins: () => Effect.die("unused"),
+    });
+
+    expect(providerAdapterConformanceIssues(adapter)).toEqual([
+      {
+        capability: "supportsPluginDiscovery",
+        missingMethod: "readPlugin",
+      },
+    ]);
+  });
+
+  it("accepts adapters whose advertised discovery and steering methods exist", () => {
+    const adapter = makeAdapter({
+      capabilities: {
+        sessionModelSwitch: "restart-session",
+        supportsTurnSteering: true,
+        supportsSkillDiscovery: true,
+        supportsNativeSlashCommandDiscovery: true,
+        supportsPluginDiscovery: true,
+        supportsRuntimeModelList: true,
+      },
+      steerTurn: () => Effect.die("unused"),
+      listSkills: () => Effect.die("unused"),
+      listCommands: () => Effect.die("unused"),
+      listPlugins: () => Effect.die("unused"),
+      readPlugin: () => Effect.die("unused"),
+      listModels: () => Effect.die("unused"),
+    });
+
+    expect(providerAdapterConformanceIssues(adapter)).toEqual([]);
+    expect(() => assertProviderAdapterConformance(adapter)).not.toThrow();
+  });
+
+  it("reports all invalid capability declarations in one error", () => {
+    const adapter = makeAdapter({
+      provider: "opencode",
+      capabilities: {
+        sessionModelSwitch: "in-session",
+        supportsSkillDiscovery: true,
+        supportsRuntimeModelList: true,
+      },
+    });
+
+    expect(() => assertProviderAdapterConformance(adapter)).toThrow(
+      'Provider adapter "opencode" has invalid capabilities: supportsSkillDiscovery requires listSkills(), supportsRuntimeModelList requires listModels().',
+    );
+  });
+});

--- a/apps/server/src/provider/providerAdapterConformance.ts
+++ b/apps/server/src/provider/providerAdapterConformance.ts
@@ -1,0 +1,69 @@
+import type {
+  ProviderAdapterCapabilities,
+  ProviderAdapterShape,
+} from "./Services/ProviderAdapter.ts";
+
+type CapabilityFlag = Exclude<
+  keyof ProviderAdapterCapabilities,
+  | "sessionModelSwitch"
+  | "conversationRollback"
+  | "supportsSkillMentions"
+  | "supportsPluginMentions"
+  | "supportsLiveTurnDiffPatch"
+>;
+
+type OptionalAdapterMethod =
+  | "steerTurn"
+  | "listSkills"
+  | "listCommands"
+  | "listPlugins"
+  | "readPlugin"
+  | "listModels";
+
+export interface ProviderAdapterConformanceIssue {
+  readonly capability: CapabilityFlag;
+  readonly missingMethod: OptionalAdapterMethod;
+}
+
+const CAPABILITY_METHOD_REQUIREMENTS: ReadonlyArray<{
+  readonly capability: CapabilityFlag;
+  readonly methods: ReadonlyArray<OptionalAdapterMethod>;
+}> = [
+  { capability: "supportsTurnSteering", methods: ["steerTurn"] },
+  { capability: "supportsSkillDiscovery", methods: ["listSkills"] },
+  { capability: "supportsNativeSlashCommandDiscovery", methods: ["listCommands"] },
+  { capability: "supportsPluginDiscovery", methods: ["listPlugins", "readPlugin"] },
+  { capability: "supportsRuntimeModelList", methods: ["listModels"] },
+];
+
+export function providerAdapterConformanceIssues(
+  adapter: ProviderAdapterShape<unknown>,
+): ProviderAdapterConformanceIssue[] {
+  const issues: ProviderAdapterConformanceIssue[] = [];
+  for (const requirement of CAPABILITY_METHOD_REQUIREMENTS) {
+    if (adapter.capabilities[requirement.capability] !== true) {
+      continue;
+    }
+    for (const method of requirement.methods) {
+      if (typeof adapter[method] !== "function") {
+        issues.push({
+          capability: requirement.capability,
+          missingMethod: method,
+        });
+      }
+    }
+  }
+  return issues;
+}
+
+export function assertProviderAdapterConformance(adapter: ProviderAdapterShape<unknown>): void {
+  const issues = providerAdapterConformanceIssues(adapter);
+  if (issues.length === 0) {
+    return;
+  }
+
+  const detail = issues
+    .map((issue) => `${issue.capability} requires ${issue.missingMethod}()`)
+    .join(", ");
+  throw new Error(`Provider adapter "${adapter.provider}" has invalid capabilities: ${detail}.`);
+}


### PR DESCRIPTION
## Problem

Synara's provider registry accepts any object that satisfies the TypeScript `ProviderAdapter` shape. Optional methods and capability flags are separate fields, so an adapter can accidentally advertise a capability while omitting the method required to execute it.

That failure is discovered later at the call site rather than when the adapter enters the runtime.

This is the first implementation slice of #694.

## What changed

- add a small provider-adapter conformance validator;
- require method presence when these capabilities are advertised:
  - turn steering → `steerTurn()`;
  - skill discovery → `listSkills()`;
  - native slash-command discovery → `listCommands()`;
  - plugin discovery → `listPlugins()` + `readPlugin()`;
  - runtime model discovery → `listModels()`;
- run the conformance assertion for every adapter before `ProviderAdapterRegistry` builds its lookup map;
- report every missing method for an adapter in one actionable error;
- add focused tests for steering, plugin discovery, multiple simultaneous violations, and a fully conforming adapter.

## Why this approach

The check lives at the registry boundary instead of being an optional test helper. That means current adapters and future harnesses automatically pass through the same invariant whenever the server builds the provider registry.

The validator is intentionally one-way: a capability set to `true` must have its method. An optional method may still exist while a capability is disabled dynamically or intentionally; this PR does not forbid that pattern.

## Validation

Before opening this PR, GitHub Actions on the fork passed:

- repository formatter over all three touched files;
- `providerAdapterConformance.test.ts`;
- `ProviderAdapterRegistry.test.ts`;
- full `apps/server` typecheck;
- `git diff --check`;
- branch rewritten to one focused commit after validation.

The draft remains subject to the full upstream CI suite.

## Scope

3 server files. No provider protocol/session behavior changes and no new user-facing capability.

## Out of scope

- lifecycle conformance such as interrupt/stop terminal-event cardinality;
- live-provider credentials in CI;
- provider-specific protocol assertions;
- requiring optional method absence when a capability is false.