### PR TITLE
docs: refresh workspace layout

### DIFF
--- a/.docs/workspace-layout.md
+++ b/.docs/workspace-layout.md
@@ -4,18 +4,18 @@ Synara is a Bun/Turbo monorepo. Runtime ownership is split across the app worksp
 
 - `/apps/server` — The authoritative Synara backend and published `@synara/cli` package. Owns orchestration/persistence, provider adapters and health/discovery, Git/worktrees, terminals, automation, workspace files, HTTP/WebSocket RPC, and the bundled web client used outside Vite development.
 - `/apps/web` — React + Vite application. Owns presentation, client transport/state coordination, chat/composer/editor/dock surfaces, and subscription-driven projection of server-authoritative state.
-- `/apps/desktop` — Electron host for the shared web client. Supervises a desktop-scoped Synara server process and provides native window, update, and OS integration.
+- `/apps/desktop` — Electron host for the shared web client. Supervises a desktop-scoped Synara server process and provides native window, update, IPC, browser-automation, and other OS/Electron integrations.
 - `/apps/marketing` — Public marketing/download site. Kept separate from the product runtime and desktop/web application bundles.
 - `/packages/contracts` — Shared Effect Schema and TypeScript contracts for orchestration, provider/session/model data, RPC methods, settings, keybindings, automation, device/browser surfaces, and other cross-process payloads.
-- `/packages/shared` — Runtime-neutral helpers consumed by multiple apps/packages. Uses explicit subpath exports (for example `@synara/shared/git` and `@synara/shared/threadWorkspace`) rather than one catch-all barrel.
-- `/scripts` — Repository-level development, packaging, release, migration-lineage, canary, and smoke-test tooling. Desktop artifact/release code lives here rather than inside the Electron app.
+- `/packages/shared` — Shared runtime utilities consumed by multiple apps/packages, including pure helpers as well as intentionally cross-runtime logging, worker, filesystem/network, and platform-boundary utilities. Uses explicit subpath exports (for example `@synara/shared/git` and `@synara/shared/threadWorkspace`) rather than one catch-all barrel.
+- `/scripts` — Repository-level development, packaging, release, migration-lineage, canary, and smoke-test tooling. Package-specific scripts remain with their owning app when they depend on that workspace's package context or Turbo task ownership.
 
 ## Ownership rule of thumb
 
-- Durable application truth or side effects belong in `apps/server`.
-- Browser/Electron presentation belongs in `apps/web`; desktop-only native hosting belongs in `apps/desktop`.
+- Durable application truth and server-authoritative/backend side effects belong in `apps/server`.
+- Browser presentation belongs in `apps/web`; desktop-only native hosting and Electron/OS side effects belong in `apps/desktop`.
 - Cross-process data shapes belong in `packages/contracts`.
-- Pure utilities shared across runtimes belong in `packages/shared`.
-- Build/release/developer automation belongs in `scripts`.
+- Runtime utilities genuinely shared across multiple workspaces belong in `packages/shared`, whether pure or stateful/I/O-bound when the cross-runtime abstraction is intentional.
+- Repository-level build/release/developer automation belongs in `/scripts`; app-specific automation stays in the owning workspace when it relies on local dependencies or package tasks.
 
 See [architecture.md](./architecture.md) for the runtime/data-flow overview and [provider-architecture.md](./provider-architecture.md) for provider integration boundaries.

--- a/.docs/workspace-layout.md
+++ b/.docs/workspace-layout.md
@@ -1,7 +1,21 @@
 # Workspace layout
 
-- `/apps/server`: Node.js WebSocket server. Wraps Codex app-server, serves the built web app, and opens the browser on start.
-- `/apps/web`: React + Vite UI. Session control, conversation, and provider event rendering. Connects to the server via WebSocket.
-- `/apps/desktop`: Electron shell. Spawns a desktop-scoped `synara` backend process and loads the shared web app.
-- `/packages/contracts`: Shared effect/Schema schemas and TypeScript contracts for provider events, WebSocket protocol, and model/session types.
-- `/packages/shared`: Shared runtime utilities consumed by both server and web. Uses explicit subpath exports (e.g. `@synara/shared/git`, `@synara/shared/DrainableWorker`) — no barrel index.
+Synara is a Bun/Turbo monorepo. Runtime ownership is split across the app workspaces, while shared schemas and cross-runtime helpers live under `packages`.
+
+- `/apps/server` — The authoritative Synara backend and published `@synara/cli` package. Owns orchestration/persistence, provider adapters and health/discovery, Git/worktrees, terminals, automation, workspace files, HTTP/WebSocket RPC, and the bundled web client used outside Vite development.
+- `/apps/web` — React + Vite application. Owns presentation, client transport/state coordination, chat/composer/editor/dock surfaces, and subscription-driven projection of server-authoritative state.
+- `/apps/desktop` — Electron host for the shared web client. Supervises a desktop-scoped Synara server process and provides native window, update, and OS integration.
+- `/apps/marketing` — Public marketing/download site. Kept separate from the product runtime and desktop/web application bundles.
+- `/packages/contracts` — Shared Effect Schema and TypeScript contracts for orchestration, provider/session/model data, RPC methods, settings, keybindings, automation, device/browser surfaces, and other cross-process payloads.
+- `/packages/shared` — Runtime-neutral helpers consumed by multiple apps/packages. Uses explicit subpath exports (for example `@synara/shared/git` and `@synara/shared/threadWorkspace`) rather than one catch-all barrel.
+- `/scripts` — Repository-level development, packaging, release, migration-lineage, canary, and smoke-test tooling. Desktop artifact/release code lives here rather than inside the Electron app.
+
+## Ownership rule of thumb
+
+- Durable application truth or side effects belong in `apps/server`.
+- Browser/Electron presentation belongs in `apps/web`; desktop-only native hosting belongs in `apps/desktop`.
+- Cross-process data shapes belong in `packages/contracts`.
+- Pure utilities shared across runtimes belong in `packages/shared`.
+- Build/release/developer automation belongs in `scripts`.
+
+See [architecture.md](./architecture.md) for the runtime/data-flow overview and [provider-architecture.md](./provider-architecture.md) for provider integration boundaries.


### PR DESCRIPTION
## Problem

`.docs/workspace-layout.md` still describes `apps/server` as a Codex wrapper and omits active workspaces such as the marketing app and repository scripts package. Its contracts/shared descriptions also predate the current orchestration/provider/RPC surface.

## What changed

- describe `apps/server` as the authoritative multi-provider backend and published `@synara/cli` package;
- clarify `apps/web` vs `apps/desktop` ownership;
- add the `apps/marketing` workspace;
- expand the contracts description to the current cross-process domain/RPC/settings surfaces;
- clarify the explicit-subpath role of `packages/shared`;
- document the top-level `scripts` workspace and release/developer tooling ownership;
- add a short ownership rule-of-thumb and links to the architecture/provider docs.

## Why

This page is meant to answer “where should this change live?” Keeping workspace ownership accurate reduces accidental provider/runtime logic in the UI and avoids sending contributors to the wrong package.

## Scope

Documentation only. One small file; no code or build changes.

## Validation

Cross-checked against the root workspace configuration, current package names, and runtime boundaries. Normal GitHub Actions validation is enabled on this draft.

## Out of scope

- detailed package dependency diagrams;
- provider implementation details;
- changing workspace structure.