### PR TITLE
docs: refresh quick start commands

### DIFF
--- a/.docs/quick-start.md
+++ b/.docs/quick-start.md
@@ -1,7 +1,11 @@
 # Quick start
 
+## Local development
+
 ```bash
-# Development (with hot reload)
+bun install --frozen-lockfile
+
+# Full development stack with hot reload
 bun run dev
 
 # Desktop development
@@ -9,14 +13,34 @@ bun run dev:desktop
 
 # Desktop development on an isolated port set
 SYNARA_DEV_INSTANCE=feature-xyz bun run dev:desktop
+```
 
-# Production
+## Production-style local run
+
+```bash
 bun run build
 bun run start
+```
 
-# Build a shareable macOS .dmg (arm64 by default)
+## Desktop artifacts
+
+```bash
+# Shareable macOS DMG (arm64 by default)
 bun run dist:desktop:dmg
 
-# Or from any project directory after publishing:
-npx synara
+# Linux AppImage
+bun run dist:desktop:linux
+
+# Windows NSIS installer
+bun run dist:desktop:win
 ```
+
+## Published CLI package
+
+The server package is published as `@synara/cli` and exposes the `synara` executable. To run an npm-published version without installing it globally:
+
+```bash
+npx --yes --package=@synara/cli synara --help
+```
+
+For repository scripts, release packaging, and multi-instance development details, see [scripts.md](./scripts.md).


### PR DESCRIPTION
## Problem

`.docs/quick-start.md` skips dependency installation and shows `npx synara` for the published CLI. The actual server package is named `@synara/cli` and exposes `synara` as its executable.

The page also only mentions the macOS artifact even though root scripts expose the supported Linux and Windows desktop builds.

## What changed

- add the repository-pinned install step (`bun install --frozen-lockfile`);
- keep the existing full-stack and desktop development commands;
- keep the production-style `build` + `start` path;
- list the root macOS/Linux/Windows artifact scripts;
- correct the one-off npm invocation to `npx --package=@synara/cli synara`;
- link to `scripts.md` for the longer tooling reference.

## Why

Quick-start instructions should be copy/pasteable from a fresh checkout and should name the package that is actually staged/published by the server workspace.

## Scope

Documentation only. One short file; no package, script, or release behavior changes.

## Validation

Cross-checked against the root `package.json` scripts and `apps/server/package.json` package/bin metadata. Normal GitHub Actions validation remains enabled on this draft.

## Out of scope

- npm publication policy;
- release signing instructions;
- detailed development/release documentation already covered by `scripts.md` and `docs/release.md`.