### PR TITLE
docs: correct desktop packaging notes

### DIFF
--- a/.docs/scripts.md
+++ b/.docs/scripts.md
@@ -18,18 +18,20 @@
 
 ## Desktop `.dmg` packaging notes
 
-- Default build is unsigned/not notarized for local sharing.
-- The DMG build uses `assets/macos-icon-1024.png` as the production app icon source.
+- Default local builds are unsigned/not notarized unless `--signed` is supplied with the required platform credentials.
+- Production icon sources are centralized in `scripts/lib/brand-assets.ts`. The current macOS source is `assets/prod/black-macos-1024.png` (with the legacy macOS variant alongside it); do not hard-code a separate packaging icon path in docs or scripts.
 - Desktop production windows load the bundled UI from `synara://app/index.html` (not a `127.0.0.1` document URL).
 - Desktop packaging includes `apps/server/dist` (the `synara` backend) and starts it on loopback with an auth token for WebSocket/API traffic.
-- Your tester can still open it on macOS by right-clicking the app and choosing **Open** on first launch.
-- To keep staging files for debugging package contents, run: `bun run dist:desktop:dmg -- --keep-stage`
-- To allow code-signing/notarization when configured in CI/secrets, add: `--signed`.
+- Your tester can still open an unsigned local macOS build by right-clicking the app and choosing **Open** on first launch.
+- To keep staging files for debugging package contents, run: `bun run dist:desktop:dmg -- --keep-stage`.
+- To enable code-signing/notarization when the required credentials are configured, add `--signed`.
 - Windows `--signed` uses Azure Trusted Signing and expects:
   `AZURE_TRUSTED_SIGNING_ENDPOINT`, `AZURE_TRUSTED_SIGNING_ACCOUNT_NAME`,
-  `AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME`, and `AZURE_TRUSTED_SIGNING_PUBLISHER_NAME`.
-- Azure authentication env vars are also required (for example service principal with secret):
+  `AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME`, `AZURE_TRUSTED_SIGNING_PUBLISHER_NAME`,
+  and `AZURE_TRUSTED_SIGNING_SUBJECT_DN`.
+- Azure authentication env vars are also required (for example a service principal with secret):
   `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`.
+- Release publication has stricter signing/provenance policy than a local artifact build; use `docs/release.md` as the source of truth for release requirements.
 
 ## Running multiple dev instances
 


### PR DESCRIPTION
## Problem

`.docs/scripts.md` contains desktop-packaging details that have drifted from the current build scripts:

- it points at `assets/macos-icon-1024.png`, while production icon paths are now centralized in `scripts/lib/brand-assets.ts` and the current macOS source is `assets/prod/black-macos-1024.png`;
- the Windows signing variable list omits `AZURE_TRUSTED_SIGNING_SUBJECT_DN`;
- local unsigned-artifact behavior and release publication policy are easy to read as the same thing even though the release workflow applies stricter signing/provenance gates.

## What changed

- point packaging docs at `scripts/lib/brand-assets.ts` as the source of truth for production icon assets;
- document the current macOS production/legacy icon location without encouraging another hard-coded path;
- clarify that local builds are unsigned unless `--signed` is explicitly used with credentials;
- add the missing Azure Trusted Signing subject-DN variable;
- clarify that release publication has stricter signing/provenance requirements and link to `docs/release.md`;
- keep the existing dev/multi-instance/artifact command reference intact.

## Why

Packaging documentation should not duplicate paths/configuration that already have a code-level source of truth. The stale path is especially confusing when debugging why a packaged icon differs from a runtime/development icon.

## Scope

Documentation only. One file; no build, signing, asset, or release behavior changes.

## Validation

Cross-checked against `scripts/lib/brand-assets.ts`, the current root artifact scripts, and the release workflow's Windows signing environment. Normal GitHub Actions validation remains enabled on this draft.

## Out of scope

- changing icons;
- changing signing requirements;
- changing artifact targets or release policy.