### PR TITLE
feat(cli): add server status command

### DIFF
--- a/apps/server/src/externalMcp/Layers/ExternalMcpGateway.e2e.test.ts
+++ b/apps/server/src/externalMcp/Layers/ExternalMcpGateway.e2e.test.ts
@@ -26,7 +26,10 @@ import { ProviderDiscoveryService } from "../../provider/Services/ProviderDiscov
 import { ProviderHealth } from "../../provider/Services/ProviderHealth.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { serveExternalMcpStdio, writeExternalMcpClientCredential } from "../bridge.ts";
-import { computeExternalMcpRuntimeProof } from "../runtimeProof.ts";
+import {
+  computeExternalMcpRuntimeProof,
+  EXTERNAL_MCP_RUNTIME_CHALLENGE_HEADER,
+} from "../runtimeProof.ts";
 import { ExternalMcpGateway } from "../Services/ExternalMcpGateway.ts";
 import { ExternalMcpService } from "../Services/ExternalMcpService.ts";
 import { ExternalMcpRepositoryLive } from "./ExternalMcpRepository.ts";
@@ -387,9 +390,9 @@ describe("external MCP gateway stdio flow", () => {
         });
         const fetchImpl = async (url: string | URL | Request, init?: RequestInit) => {
           if (String(url).endsWith("/api/mcp/external/runtime-challenge")) {
-            const challenge = JSON.parse(String(init?.body)) as { nonce: string };
+            const nonce = new Headers(init?.headers).get(EXTERNAL_MCP_RUNTIME_CHALLENGE_HEADER)!;
             return Response.json({
-              proof: computeExternalMcpRuntimeProof(RUNTIME_SECRET, challenge.nonce),
+              proof: computeExternalMcpRuntimeProof(RUNTIME_SECRET, nonce),
             });
           }
           const response = await Effect.runPromise(

--- a/apps/server/src/externalMcp/bridge.test.ts
+++ b/apps/server/src/externalMcp/bridge.test.ts
@@ -18,7 +18,10 @@ import {
   serveExternalMcpStdio,
   writeExternalMcpClientCredential,
 } from "./bridge.ts";
-import { computeExternalMcpRuntimeProof } from "./runtimeProof.ts";
+import {
+  computeExternalMcpRuntimeProof,
+  EXTERNAL_MCP_RUNTIME_CHALLENGE_HEADER,
+} from "./runtimeProof.ts";
 
 const temporaryDirectories: string[] = [];
 const RUNTIME_SECRET = "bridge-test-runtime-secret-000000001";
@@ -52,8 +55,8 @@ function writeRuntime(baseDir: string, kind: "userdata" | "dev", port: number) {
 
 function runtimeChallenge(url: string | URL | Request, init?: RequestInit): Response | null {
   if (!String(url).endsWith("/api/mcp/external/runtime-challenge")) return null;
-  const input = JSON.parse(String(init?.body)) as { nonce: string };
-  return Response.json({ proof: computeExternalMcpRuntimeProof(RUNTIME_SECRET, input.nonce) });
+  const nonce = new Headers(init?.headers).get(EXTERNAL_MCP_RUNTIME_CHALLENGE_HEADER)!;
+  return Response.json({ proof: computeExternalMcpRuntimeProof(RUNTIME_SECRET, nonce) });
 }
 
 afterEach(() => {

--- a/apps/server/src/externalMcp/bridge.ts
+++ b/apps/server/src/externalMcp/bridge.ts
@@ -14,7 +14,11 @@ import {
 
 import type { PersistedServerRuntimeState } from "../serverRuntimeState.ts";
 import { ensurePrivateDirectorySync } from "../privatePathPermissions.ts";
-import { computeExternalMcpRuntimeProof, runtimeProofsMatch } from "./runtimeProof.ts";
+import {
+  computeExternalMcpRuntimeProof,
+  EXTERNAL_MCP_RUNTIME_CHALLENGE_HEADER,
+  runtimeProofsMatch,
+} from "./runtimeProof.ts";
 
 const CLIENT_STORE_VERSION = 1;
 const CLIENT_STORE_DIRECTORY = path.join("mcp", "credentials");
@@ -579,8 +583,10 @@ async function verifyPersistedServerRuntime(
     new URL("/api/mcp/external/runtime-challenge", runtime.state.origin),
     {
       method: "POST",
-      headers: { "Content-Type": "application/json", Accept: "application/json" },
-      body: JSON.stringify({ nonce }),
+      headers: {
+        [EXTERNAL_MCP_RUNTIME_CHALLENGE_HEADER]: nonce,
+        Accept: "application/json",
+      },
     },
     RUNTIME_CHALLENGE_TIMEOUT_MS,
   );

--- a/apps/server/src/externalMcp/bridge.ts
+++ b/apps/server/src/externalMcp/bridge.ts
@@ -148,7 +148,11 @@ export function externalMcpClientStorePath(baseDir: string, integrationId: strin
   return path.join(baseDir, CLIENT_STORE_DIRECTORY, `${safeIntegrationId(integrationId)}.json`);
 }
 
-function parseRuntimeState(raw: string, sourcePath: string): PersistedServerRuntimeState {
+function parseRuntimeState(
+  raw: string,
+  sourcePath: string,
+  options: { readonly requireLoopback: boolean },
+): PersistedServerRuntimeState {
   try {
     const state = JSON.parse(raw) as Partial<PersistedServerRuntimeState>;
     if (
@@ -163,8 +167,11 @@ function parseRuntimeState(raw: string, sourcePath: string): PersistedServerRunt
       throw new Error("invalid runtime-state shape");
     }
     const origin = new URL(state.origin);
+    if (origin.protocol !== "http:") {
+      throw new Error("runtime origin is not HTTP");
+    }
     if (
-      origin.protocol !== "http:" ||
+      options.requireLoopback &&
       !["127.0.0.1", "localhost", "[::1]", "::1"].includes(origin.hostname)
     ) {
       throw new Error("runtime origin is not loopback HTTP");
@@ -287,14 +294,17 @@ function readPrivateRuntimeState(sourcePath: string): string {
   }
 }
 
-export function discoverExternalMcpRuntime(baseDir: string): {
+function discoverRunningRuntime(
+  baseDir: string,
+  options: { readonly requireLoopback: boolean },
+): {
   readonly state: PersistedServerRuntimeState;
   readonly sourcePath: string;
 } {
   const candidates = RUNTIME_STATE_RELATIVE_PATHS.flatMap((relativePath) => {
     const sourcePath = path.join(baseDir, relativePath);
     if (!fs.existsSync(sourcePath)) return [];
-    const state = parseRuntimeState(readPrivateRuntimeState(sourcePath), sourcePath);
+    const state = parseRuntimeState(readPrivateRuntimeState(sourcePath), sourcePath, options);
     return processIsAlive(state.pid) ? [{ state, sourcePath }] : [];
   });
   if (candidates.length === 0) {
@@ -308,6 +318,20 @@ export function discoverExternalMcpRuntime(baseDir: string): {
     );
   }
   return candidates[0]!;
+}
+
+export function discoverServerRuntime(baseDir: string): {
+  readonly state: PersistedServerRuntimeState;
+  readonly sourcePath: string;
+} {
+  return discoverRunningRuntime(baseDir, { requireLoopback: false });
+}
+
+export function discoverExternalMcpRuntime(baseDir: string): {
+  readonly state: PersistedServerRuntimeState;
+  readonly sourcePath: string;
+} {
+  return discoverRunningRuntime(baseDir, { requireLoopback: true });
 }
 
 function assertPrivateFile(filePath: string): void {

--- a/apps/server/src/externalMcp/bridge.ts
+++ b/apps/server/src/externalMcp/bridge.ts
@@ -569,8 +569,8 @@ export async function readExternalMcpResponseText(
   }
 }
 
-export async function verifyExternalMcpRuntime(
-  runtime: ReturnType<typeof discoverExternalMcpRuntime>,
+async function verifyPersistedServerRuntime(
+  runtime: ReturnType<typeof discoverServerRuntime>,
   fetchImpl: ExternalMcpFetch,
 ): Promise<void> {
   const nonce = randomBytes(24).toString("base64url");
@@ -599,9 +599,23 @@ export async function verifyExternalMcpRuntime(
     !runtimeProofsMatch(expected, body.proof)
   ) {
     throw new ExternalMcpBridgeError(
-      "The loopback endpoint did not prove it is the Synara process named by the private runtime-state file.",
+      "The server endpoint did not prove it is the Synara process named by the private runtime-state file.",
     );
   }
+}
+
+export async function verifyServerRuntime(
+  runtime: ReturnType<typeof discoverServerRuntime>,
+  fetchImpl: ExternalMcpFetch,
+): Promise<void> {
+  await verifyPersistedServerRuntime(runtime, fetchImpl);
+}
+
+export async function verifyExternalMcpRuntime(
+  runtime: ReturnType<typeof discoverExternalMcpRuntime>,
+  fetchImpl: ExternalMcpFetch,
+): Promise<void> {
+  await verifyPersistedServerRuntime(runtime, fetchImpl);
 }
 
 export function requestTimeoutForBody(body: string): number {

--- a/apps/server/src/externalMcp/httpRoute.test.ts
+++ b/apps/server/src/externalMcp/httpRoute.test.ts
@@ -149,6 +149,21 @@ async function withExternalMcpServer(
 }
 
 describe("externalMcpRouteLayer", () => {
+  it("keeps the runtime identity challenge available when external MCP is remotely disabled", async () => {
+    await withExternalMcpServer({ host: "0.0.0.0" }, async ({ origin }) => {
+      const response = await fetch(`${origin}/api/mcp/external/runtime-challenge`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ nonce: "remote-runtime-proof-nonce" }),
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        proof: expect.any(String),
+      });
+    });
+  });
+
   it("bounds execution per integration without letting long waits starve another integration", async () => {
     let releaseBlocked!: () => void;
     const blocked = new Promise<void>((resolve) => {

--- a/apps/server/src/externalMcp/httpRoute.test.ts
+++ b/apps/server/src/externalMcp/httpRoute.test.ts
@@ -10,6 +10,7 @@ import { ServerAuth } from "../auth/Services/ServerAuth.ts";
 import { ServerConfig } from "../config.ts";
 import { ExternalMcpGateway } from "./Services/ExternalMcpGateway.ts";
 import { ExternalMcpService } from "./Services/ExternalMcpService.ts";
+import { EXTERNAL_MCP_RUNTIME_CHALLENGE_HEADER } from "./runtimeProof.ts";
 import {
   EXTERNAL_MCP_MAX_BODY_BYTES,
   externalMcpRouteLayer,
@@ -153,8 +154,9 @@ describe("externalMcpRouteLayer", () => {
     await withExternalMcpServer({ host: "0.0.0.0" }, async ({ origin }) => {
       const response = await fetch(`${origin}/api/mcp/external/runtime-challenge`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ nonce: "remote-runtime-proof-nonce" }),
+        headers: {
+          [EXTERNAL_MCP_RUNTIME_CHALLENGE_HEADER]: "remote-runtime-proof-nonce",
+        },
       });
 
       expect(response.status).toBe(200);
@@ -162,6 +164,44 @@ describe("externalMcpRouteLayer", () => {
         proof: expect.any(String),
       });
     });
+  });
+
+  it("does not queue the runtime identity challenge behind stalled management bodies", async () => {
+    let startedReads = 0;
+    const stalledRequest = {
+      headers: {},
+      stream: Stream.concat(
+        Stream.fromEffect(
+          Effect.sync(() => {
+            startedReads += 1;
+            return new Uint8Array();
+          }),
+        ),
+        Stream.never,
+      ),
+    } as never;
+    const stalledManagementReads = Array.from({ length: 2 }, () =>
+      Effect.runPromise(readExternalMcpManagementBody(stalledRequest, 300)),
+    );
+    const deadline = Date.now() + 1_000;
+    while (startedReads < 2 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    }
+    expect(startedReads).toBe(2);
+
+    try {
+      await withExternalMcpServer({ host: "0.0.0.0" }, async ({ origin }) => {
+        const response = await fetch(`${origin}/api/mcp/external/runtime-challenge`, {
+          method: "POST",
+          headers: {
+            [EXTERNAL_MCP_RUNTIME_CHALLENGE_HEADER]: "remote-runtime-proof-nonce",
+          },
+        });
+        expect(response.status).toBe(200);
+      });
+    } finally {
+      await Promise.all(stalledManagementReads);
+    }
   });
 
   it("bounds execution per integration without letting long waits starve another integration", async () => {

--- a/apps/server/src/externalMcp/httpRoute.ts
+++ b/apps/server/src/externalMcp/httpRoute.ts
@@ -322,7 +322,6 @@ const runtimeChallenge = HttpRouter.add(
   "POST",
   "/api/mcp/external/runtime-challenge",
   Effect.gen(function* () {
-    if (!(yield* localExternalMcpEnabled)) return disabledResponse();
     const input = yield* decodeRuntimeChallenge(yield* readManagementBody).pipe(
       Effect.mapError(() => ({ message: "Invalid runtime challenge.", status: 400 as const })),
     );

--- a/apps/server/src/externalMcp/httpRoute.ts
+++ b/apps/server/src/externalMcp/httpRoute.ts
@@ -18,7 +18,11 @@ import { ExternalMcpGateway } from "./Services/ExternalMcpGateway.ts";
 import { ExternalMcpService } from "./Services/ExternalMcpService.ts";
 import { verifyExternalMcpTransportCredential } from "./credentialVerification.ts";
 import { makeExternalMcpExecutionAdmission } from "./executionAdmission.ts";
-import { computeExternalMcpRuntimeProof, externalMcpRuntimeSecret } from "./runtimeProof.ts";
+import {
+  computeExternalMcpRuntimeProof,
+  EXTERNAL_MCP_RUNTIME_CHALLENGE_HEADER,
+  externalMcpRuntimeSecret,
+} from "./runtimeProof.ts";
 
 export const EXTERNAL_MCP_PATH = "/mcp/external";
 // A maximal 100k-character prompt still fits when every character needs JSON
@@ -322,7 +326,10 @@ const runtimeChallenge = HttpRouter.add(
   "POST",
   "/api/mcp/external/runtime-challenge",
   Effect.gen(function* () {
-    const input = yield* decodeRuntimeChallenge(yield* readManagementBody).pipe(
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const input = yield* decodeRuntimeChallenge({
+      nonce: request.headers[EXTERNAL_MCP_RUNTIME_CHALLENGE_HEADER],
+    }).pipe(
       Effect.mapError(() => ({ message: "Invalid runtime challenge.", status: 400 as const })),
     );
     return HttpServerResponse.jsonUnsafe({

--- a/apps/server/src/externalMcp/runtimeProof.ts
+++ b/apps/server/src/externalMcp/runtimeProof.ts
@@ -1,6 +1,7 @@
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 
 export const externalMcpRuntimeSecret = randomBytes(32).toString("base64url");
+export const EXTERNAL_MCP_RUNTIME_CHALLENGE_HEADER = "x-synara-runtime-challenge";
 
 export function computeExternalMcpRuntimeProof(secret: string, nonce: string): string {
   return createHmac("sha256", secret)

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -197,6 +197,45 @@ it.layer(testLayer)("server CLI command", (it) => {
     }),
   );
 
+  it.effect("discovers the persisted runtime origin for the server status subcommand", () =>
+    Effect.gen(function* () {
+      const flagHome = makeTempHome("synara-main-status-flag-");
+      const stateDir = path.join(flagHome, "userdata");
+      fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+      fs.chmodSync(stateDir, 0o700);
+      fs.writeFileSync(
+        path.join(stateDir, "server-runtime.json"),
+        JSON.stringify({
+          version: 1,
+          pid: process.pid,
+          port: 5444,
+          origin: "http://127.0.0.1:5444",
+          startedAt: new Date().toISOString(),
+          externalMcpRuntimeSecret: "x".repeat(32),
+        }),
+        { mode: 0o600 },
+      );
+
+      const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+        assert.equal(String(input), "http://127.0.0.1:5444/health");
+        return Response.json({
+          status: "ok",
+          startupReady: true,
+          projection: { state: "healthy" },
+        });
+      });
+      const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+      try {
+        yield* runCli(["server", "status", "--home-dir", flagHome]);
+      } finally {
+        fetch.mockRestore();
+        stdout.mockRestore();
+      }
+
+      assert.equal(start.mock.calls.length, 0);
+    }),
+  );
+
   it.effect("creates fresh local state directories with private permissions", () =>
     Effect.gen(function* () {
       if (process.platform === "win32") return;

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -209,7 +209,8 @@ it.layer(testLayer)("server CLI command", (it) => {
           version: 1,
           pid: process.pid,
           port: 5444,
-          origin: "http://127.0.0.1:5444",
+          host: "100.64.0.42",
+          origin: "http://100.64.0.42:5444",
           startedAt: new Date().toISOString(),
           externalMcpRuntimeSecret: "x".repeat(32),
         }),
@@ -217,7 +218,7 @@ it.layer(testLayer)("server CLI command", (it) => {
       );
 
       const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-        assert.equal(String(input), "http://127.0.0.1:5444/health");
+        assert.equal(String(input), "http://100.64.0.42:5444/health");
         return Response.json({
           status: "ok",
           startupReady: true,
@@ -232,6 +233,32 @@ it.layer(testLayer)("server CLI command", (it) => {
         stdout.mockRestore();
       }
 
+      assert.equal(start.mock.calls.length, 0);
+    }),
+  );
+
+  it.effect("reports an unreachable result when no persisted runtime exists", () =>
+    Effect.gen(function* () {
+      const flagHome = makeTempHome("synara-main-status-missing-");
+      const previousExitCode = process.exitCode;
+      const output: string[] = [];
+      const stdout = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+        output.push(String(chunk));
+        return true;
+      });
+      try {
+        yield* runCli(["server", "status", "--json", "--home-dir", flagHome]);
+        assert.equal(process.exitCode, 1);
+      } finally {
+        process.exitCode = previousExitCode;
+        stdout.mockRestore();
+      }
+
+      assert.deepInclude(JSON.parse(output.join("")), {
+        reachable: false,
+        ready: false,
+        url: "[undiscovered]",
+      });
       assert.equal(start.mock.calls.length, 0);
     }),
   );

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -18,6 +18,7 @@ import { afterEach, beforeEach, vi } from "vitest";
 import { NetService } from "@synara/shared/Net";
 
 import { ServerConfig, type ServerConfigShape } from "./config";
+import { computeExternalMcpRuntimeProof } from "./externalMcp/runtimeProof.ts";
 import { Open, type OpenShape } from "./open";
 import { Server, type ServerShape } from "./effectServer";
 import { makeServerShutdownController } from "./serverShutdown";
@@ -203,6 +204,7 @@ it.layer(testLayer)("server CLI command", (it) => {
       const stateDir = path.join(flagHome, "userdata");
       fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
       fs.chmodSync(stateDir, 0o700);
+      const runtimeSecret = "x".repeat(32);
       fs.writeFileSync(
         path.join(stateDir, "server-runtime.json"),
         JSON.stringify({
@@ -212,12 +214,18 @@ it.layer(testLayer)("server CLI command", (it) => {
           host: "100.64.0.42",
           origin: "http://100.64.0.42:5444",
           startedAt: new Date().toISOString(),
-          externalMcpRuntimeSecret: "x".repeat(32),
+          externalMcpRuntimeSecret: runtimeSecret,
         }),
         { mode: 0o600 },
       );
 
-      const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+        if (String(input) === "http://100.64.0.42:5444/api/mcp/external/runtime-challenge") {
+          const challenge = JSON.parse(String(init?.body)) as { nonce: string };
+          return Response.json({
+            proof: computeExternalMcpRuntimeProof(runtimeSecret, challenge.nonce),
+          });
+        }
         assert.equal(String(input), "http://100.64.0.42:5444/health");
         return Response.json({
           status: "ok",
@@ -233,6 +241,53 @@ it.layer(testLayer)("server CLI command", (it) => {
         stdout.mockRestore();
       }
 
+      assert.equal(start.mock.calls.length, 0);
+    }),
+  );
+
+  it.effect("rejects a discovered endpoint that cannot prove the persisted runtime identity", () =>
+    Effect.gen(function* () {
+      const flagHome = makeTempHome("synara-main-status-proof-");
+      const stateDir = path.join(flagHome, "userdata");
+      fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+      fs.chmodSync(stateDir, 0o700);
+      fs.writeFileSync(
+        path.join(stateDir, "server-runtime.json"),
+        JSON.stringify({
+          version: 1,
+          pid: process.pid,
+          port: 5444,
+          host: "127.0.0.1",
+          origin: "http://127.0.0.1:5444",
+          startedAt: new Date().toISOString(),
+          externalMcpRuntimeSecret: "x".repeat(32),
+        }),
+        { mode: 0o600 },
+      );
+
+      const fetch = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(Response.json({ proof: "wrong-runtime" }));
+      const output: string[] = [];
+      const stdout = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+        output.push(String(chunk));
+        return true;
+      });
+      const previousExitCode = process.exitCode;
+      try {
+        yield* runCli(["server", "status", "--json", "--home-dir", flagHome]);
+        assert.equal(process.exitCode, 1);
+      } finally {
+        process.exitCode = previousExitCode;
+        fetch.mockRestore();
+        stdout.mockRestore();
+      }
+
+      assert.deepInclude(JSON.parse(output.join("")), {
+        reachable: false,
+        ready: false,
+        url: "http://127.0.0.1:5444",
+      });
       assert.equal(start.mock.calls.length, 0);
     }),
   );

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -18,7 +18,10 @@ import { afterEach, beforeEach, vi } from "vitest";
 import { NetService } from "@synara/shared/Net";
 
 import { ServerConfig, type ServerConfigShape } from "./config";
-import { computeExternalMcpRuntimeProof } from "./externalMcp/runtimeProof.ts";
+import {
+  computeExternalMcpRuntimeProof,
+  EXTERNAL_MCP_RUNTIME_CHALLENGE_HEADER,
+} from "./externalMcp/runtimeProof.ts";
 import { Open, type OpenShape } from "./open";
 import { Server, type ServerShape } from "./effectServer";
 import { makeServerShutdownController } from "./serverShutdown";
@@ -221,9 +224,9 @@ it.layer(testLayer)("server CLI command", (it) => {
 
       const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
         if (String(input) === "http://100.64.0.42:5444/api/mcp/external/runtime-challenge") {
-          const challenge = JSON.parse(String(init?.body)) as { nonce: string };
+          const nonce = new Headers(init?.headers).get(EXTERNAL_MCP_RUNTIME_CHALLENGE_HEADER)!;
           return Response.json({
-            proof: computeExternalMcpRuntimeProof(runtimeSecret, challenge.nonce),
+            proof: computeExternalMcpRuntimeProof(runtimeSecret, nonce),
           });
         }
         assert.equal(String(input), "http://100.64.0.42:5444/health");

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -46,16 +46,13 @@ import { formatHostForUrl, isLoopbackHost, isWildcardHost } from "./startupAcces
 import { OrchestrationEngineService } from "./orchestration/Services/OrchestrationEngine";
 import { startThreadRetentionJob } from "./threadRetention";
 import {
+  discoverExternalMcpRuntime,
   pairExternalMcpClient,
   resolveExternalMcpBaseDir,
   serveExternalMcpStdio,
 } from "./externalMcp/bridge";
 import { externalMcpLauncher, externalMcpShellCommand } from "./externalMcp/launcher";
-import {
-  DEFAULT_SERVER_STATUS_URL,
-  fetchSynaraServerStatus,
-  formatSynaraServerStatus,
-} from "./serverStatusCli";
+import { fetchSynaraServerStatus, formatSynaraServerStatus } from "./serverStatusCli";
 
 export class StartupError extends Data.TaggedError("StartupError")<{
   readonly message: string;
@@ -584,7 +581,7 @@ const serverStatusCommand = Command.make(
   {
     url: Flag.string("url").pipe(
       Flag.withDescription("Synara server base URL to probe."),
-      Flag.withDefault(DEFAULT_SERVER_STATUS_URL),
+      Flag.optional,
     ),
     json: Flag.boolean("json").pipe(
       Flag.withDescription("Print machine-readable JSON."),
@@ -592,19 +589,26 @@ const serverStatusCommand = Command.make(
     ),
   },
   ({ url, json }) =>
-    Effect.promise(() => fetchSynaraServerStatus({ url })).pipe(
-      Effect.tap((result) =>
-        Effect.sync(() => {
-          process.stdout.write(
-            json ? `${JSON.stringify(result, null, 2)}\n` : `${formatSynaraServerStatus(result)}\n`,
-          );
-          if (!result.ready) {
-            process.exitCode = 1;
-          }
-        }),
-      ),
-      Effect.asVoid,
-    ),
+    Effect.gen(function* () {
+      const parent = yield* baseServerCommand;
+      const targetUrl = Option.isSome(url)
+        ? url.value
+        : yield* Effect.try({
+            try: () => {
+              const baseDir = resolveExternalMcpBaseDir(Option.getOrUndefined(parent.synaraHome));
+              return discoverExternalMcpRuntime(baseDir).state.origin;
+            },
+            catch: (cause) =>
+              new StartupError({ message: "Failed to discover a running Synara server.", cause }),
+          });
+      const result = yield* Effect.promise(() => fetchSynaraServerStatus({ url: targetUrl }));
+      process.stdout.write(
+        json ? `${JSON.stringify(result, null, 2)}\n` : `${formatSynaraServerStatus(result)}\n`,
+      );
+      if (!result.ready) {
+        process.exitCode = 1;
+      }
+    }),
 ).pipe(Command.withDescription("Check whether a Synara server is reachable and ready."));
 
 const serverToolsCommand = Command.make("server").pipe(

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -50,6 +50,7 @@ import {
   pairExternalMcpClient,
   resolveExternalMcpBaseDir,
   serveExternalMcpStdio,
+  verifyServerRuntime,
 } from "./externalMcp/bridge";
 import { externalMcpLauncher, externalMcpShellCommand } from "./externalMcp/launcher";
 import { fetchSynaraServerStatus, formatSynaraServerStatus } from "./serverStatusCli";
@@ -596,7 +597,8 @@ const serverStatusCommand = Command.make(
         : (() => {
             const baseDir = resolveExternalMcpBaseDir(Option.getOrUndefined(parent.synaraHome));
             try {
-              return { url: discoverServerRuntime(baseDir).state.origin };
+              const runtime = discoverServerRuntime(baseDir);
+              return { url: runtime.state.origin, runtime };
             } catch (cause) {
               return {
                 error:
@@ -614,7 +616,24 @@ const serverStatusCommand = Command.make(
               url: "[undiscovered]",
               error: discovered.error,
             }
-          : yield* Effect.promise(() => fetchSynaraServerStatus({ url: discovered.url }));
+          : yield* Effect.promise(async () => {
+              try {
+                if ("runtime" in discovered) {
+                  await verifyServerRuntime(discovered.runtime, globalThis.fetch);
+                }
+                return await fetchSynaraServerStatus({ url: discovered.url });
+              } catch (cause) {
+                return {
+                  reachable: false as const,
+                  ready: false as const,
+                  url: discovered.url,
+                  error:
+                    cause instanceof Error
+                      ? cause.message
+                      : "Failed to verify the discovered Synara server.",
+                };
+              }
+            });
       process.stdout.write(
         json ? `${JSON.stringify(result, null, 2)}\n` : `${formatSynaraServerStatus(result)}\n`,
       );

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -51,6 +51,11 @@ import {
   serveExternalMcpStdio,
 } from "./externalMcp/bridge";
 import { externalMcpLauncher, externalMcpShellCommand } from "./externalMcp/launcher";
+import {
+  DEFAULT_SERVER_STATUS_URL,
+  fetchSynaraServerStatus,
+  formatSynaraServerStatus,
+} from "./serverStatusCli";
 
 export class StartupError extends Data.TaggedError("StartupError")<{
   readonly message: string;
@@ -574,6 +579,39 @@ const mcpPairCommand = Command.make(
     }),
 ).pipe(Command.withDescription("Pair this CLI with a user-approved Synara MCP integration."));
 
+const serverStatusCommand = Command.make(
+  "status",
+  {
+    url: Flag.string("url").pipe(
+      Flag.withDescription("Synara server base URL to probe."),
+      Flag.withDefault(DEFAULT_SERVER_STATUS_URL),
+    ),
+    json: Flag.boolean("json").pipe(
+      Flag.withDescription("Print machine-readable JSON."),
+      Flag.withDefault(false),
+    ),
+  },
+  ({ url, json }) =>
+    Effect.promise(() => fetchSynaraServerStatus({ url })).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          process.stdout.write(
+            json ? `${JSON.stringify(result, null, 2)}\n` : `${formatSynaraServerStatus(result)}\n`,
+          );
+          if (!result.ready) {
+            process.exitCode = 1;
+          }
+        }),
+      ),
+      Effect.asVoid,
+    ),
+).pipe(Command.withDescription("Check whether a Synara server is reachable and ready."));
+
+const serverToolsCommand = Command.make("server").pipe(
+  Command.withDescription("Inspect and manage a running Synara server."),
+  Command.withSubcommands([serverStatusCommand]),
+);
+
 const mcpCommand = Command.make("mcp").pipe(
   Command.withDescription("Manage Synara's loopback external MCP bridge."),
   Command.withSubcommands([mcpServeCommand, mcpPairCommand]),
@@ -581,7 +619,7 @@ const mcpCommand = Command.make("mcp").pipe(
 
 const serverCommand = baseServerCommand.pipe(
   Command.withHandler((input) => makeServerProgram(input)),
-  Command.withSubcommands([mcpCommand]),
+  Command.withSubcommands([serverToolsCommand, mcpCommand]),
 );
 
 export const synaraCli = serverCommand;

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -46,7 +46,7 @@ import { formatHostForUrl, isLoopbackHost, isWildcardHost } from "./startupAcces
 import { OrchestrationEngineService } from "./orchestration/Services/OrchestrationEngine";
 import { startThreadRetentionJob } from "./threadRetention";
 import {
-  discoverExternalMcpRuntime,
+  discoverServerRuntime,
   pairExternalMcpClient,
   resolveExternalMcpBaseDir,
   serveExternalMcpStdio,
@@ -591,17 +591,30 @@ const serverStatusCommand = Command.make(
   ({ url, json }) =>
     Effect.gen(function* () {
       const parent = yield* baseServerCommand;
-      const targetUrl = Option.isSome(url)
-        ? url.value
-        : yield* Effect.try({
-            try: () => {
-              const baseDir = resolveExternalMcpBaseDir(Option.getOrUndefined(parent.synaraHome));
-              return discoverExternalMcpRuntime(baseDir).state.origin;
-            },
-            catch: (cause) =>
-              new StartupError({ message: "Failed to discover a running Synara server.", cause }),
-          });
-      const result = yield* Effect.promise(() => fetchSynaraServerStatus({ url: targetUrl }));
+      const discovered = Option.isSome(url)
+        ? { url: url.value }
+        : (() => {
+            const baseDir = resolveExternalMcpBaseDir(Option.getOrUndefined(parent.synaraHome));
+            try {
+              return { url: discoverServerRuntime(baseDir).state.origin };
+            } catch (cause) {
+              return {
+                error:
+                  cause instanceof Error
+                    ? cause.message
+                    : "Failed to discover a running Synara server.",
+              };
+            }
+          })();
+      const result =
+        "error" in discovered
+          ? {
+              reachable: false as const,
+              ready: false as const,
+              url: "[undiscovered]",
+              error: discovered.error,
+            }
+          : yield* Effect.promise(() => fetchSynaraServerStatus({ url: discovered.url }));
       process.stdout.write(
         json ? `${JSON.stringify(result, null, 2)}\n` : `${formatSynaraServerStatus(result)}\n`,
       );

--- a/apps/server/src/serverStatusCli.test.ts
+++ b/apps/server/src/serverStatusCli.test.ts
@@ -47,6 +47,20 @@ describe("server status CLI probe", () => {
     expect(formatSynaraServerStatus(result)).toContain("Synara server: starting");
   });
 
+  it("distinguishes an unhealthy projection from a server that is still starting", async () => {
+    const result = await fetchSynaraServerStatus({
+      fetch: async () =>
+        Response.json({
+          status: "ok",
+          startupReady: true,
+          projection: { state: "degraded" },
+        }),
+    });
+
+    expect(result).toMatchObject({ reachable: true, ready: false });
+    expect(formatSynaraServerStatus(result)).toContain("Synara server: not ready");
+  });
+
   it("treats an unknown or missing projection health state as not ready", async () => {
     for (const projection of [{ state: "unknown" }, undefined]) {
       const result = await fetchSynaraServerStatus({
@@ -76,6 +90,21 @@ describe("server status CLI probe", () => {
       "https://synara.example.com/health",
       expect.objectContaining({ headers: { Accept: "application/json" } }),
     );
+  });
+
+  it("rejects credentials and never reports URL secrets", async () => {
+    const result = await fetchSynaraServerStatus({
+      url: "https://user:password@synara.example.com/path?token=secret#fragment",
+    });
+
+    expect(result).toEqual({
+      reachable: false,
+      ready: false,
+      url: "https://synara.example.com",
+      error: "Server URL must not contain credentials.",
+    });
+    expect(JSON.stringify(result)).not.toContain("password");
+    expect(JSON.stringify(result)).not.toContain("secret");
   });
 
   it("fails closed for invalid URLs and malformed health responses", async () => {

--- a/apps/server/src/serverStatusCli.test.ts
+++ b/apps/server/src/serverStatusCli.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DEFAULT_SERVER_STATUS_URL,
+  fetchSynaraServerStatus,
+  formatSynaraServerStatus,
+} from "./serverStatusCli.ts";
+
+describe("server status CLI probe", () => {
+  it("reports a ready server from the unauthenticated health endpoint", async () => {
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      expect(String(input)).toBe("http://127.0.0.1:3773/health");
+      return Response.json({
+        status: "ok",
+        startupReady: true,
+        projection: { state: "healthy", inFlight: false },
+      });
+    });
+
+    const result = await fetchSynaraServerStatus({ fetch });
+
+    expect(result).toMatchObject({
+      reachable: true,
+      ready: true,
+      url: DEFAULT_SERVER_STATUS_URL,
+      health: {
+        startupReady: true,
+        projection: { state: "healthy" },
+      },
+    });
+    expect(formatSynaraServerStatus(result)).toBe(
+      "Synara server: ready\nURL: http://127.0.0.1:3773\nProjection: healthy",
+    );
+  });
+
+  it("reports a reachable server that is still starting", async () => {
+    const result = await fetchSynaraServerStatus({
+      fetch: async () =>
+        Response.json({
+          status: "ok",
+          startupReady: false,
+          projection: { state: "degraded" },
+        }),
+    });
+
+    expect(result).toMatchObject({ reachable: true, ready: false });
+    expect(formatSynaraServerStatus(result)).toContain("Synara server: starting");
+  });
+
+  it("treats an unknown or missing projection health state as not ready", async () => {
+    for (const projection of [{ state: "unknown" }, undefined]) {
+      const result = await fetchSynaraServerStatus({
+        fetch: async () =>
+          Response.json({
+            status: "ok",
+            startupReady: true,
+            ...(projection ? { projection } : {}),
+          }),
+      });
+
+      expect(result).toMatchObject({ reachable: true, ready: false });
+    }
+  });
+
+  it("normalizes an explicit server base URL to /health", async () => {
+    const fetch = vi.fn(async () =>
+      Response.json({ status: "ok", startupReady: true, projection: { state: "healthy" } }),
+    );
+
+    await fetchSynaraServerStatus({
+      url: "https://synara.example.com/some/path?ignored=1#hash",
+      fetch,
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://synara.example.com/health",
+      expect.objectContaining({ headers: { Accept: "application/json" } }),
+    );
+  });
+
+  it("fails closed for invalid URLs and malformed health responses", async () => {
+    await expect(fetchSynaraServerStatus({ url: "file:///tmp/synara" })).resolves.toMatchObject({
+      reachable: false,
+      ready: false,
+      error: "Server URL must use http:// or https://.",
+    });
+
+    await expect(
+      fetchSynaraServerStatus({ fetch: async () => Response.json({ status: "ok" }) }),
+    ).resolves.toMatchObject({
+      reachable: false,
+      ready: false,
+      error: "Health response did not match the Synara health shape.",
+    });
+  });
+
+  it("reports HTTP and transport failures without throwing", async () => {
+    await expect(
+      fetchSynaraServerStatus({
+        fetch: async () => new Response("offline", { status: 503 }),
+      }),
+    ).resolves.toMatchObject({
+      reachable: false,
+      ready: false,
+      error: "Health request returned HTTP 503.",
+    });
+
+    const result = await fetchSynaraServerStatus({
+      fetch: async () => {
+        throw new Error("connection refused");
+      },
+    });
+    expect(result).toMatchObject({
+      reachable: false,
+      ready: false,
+      error: "connection refused",
+    });
+    expect(formatSynaraServerStatus(result)).toContain("Synara server: unreachable");
+  });
+});

--- a/apps/server/src/serverStatusCli.ts
+++ b/apps/server/src/serverStatusCli.ts
@@ -41,15 +41,31 @@ export interface FetchSynaraServerStatusOptions {
   readonly fetch?: FetchLike;
 }
 
-function healthUrlFromBaseUrl(rawUrl: string): string {
+function displayUrlFromRawUrl(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl);
+    return url.protocol === "http:" || url.protocol === "https:" ? url.origin : "[invalid URL]";
+  } catch {
+    return "[invalid URL]";
+  }
+}
+
+function healthUrlFromBaseUrl(rawUrl: string): {
+  readonly displayUrl: string;
+  readonly url: string;
+} {
   const url = new URL(rawUrl);
   if (url.protocol !== "http:" && url.protocol !== "https:") {
     throw new Error("Server URL must use http:// or https://.");
   }
+  if (url.username.length > 0 || url.password.length > 0) {
+    throw new Error("Server URL must not contain credentials.");
+  }
+  const displayUrl = url.origin;
   url.pathname = "/health";
   url.search = "";
   url.hash = "";
-  return url.toString();
+  return { displayUrl, url: url.toString() };
 }
 
 function decodeHealthSnapshot(value: unknown): SynaraServerHealthSnapshot | null {
@@ -67,14 +83,14 @@ export async function fetchSynaraServerStatus(
   options: FetchSynaraServerStatusOptions = {},
 ): Promise<SynaraServerStatusResult> {
   const rawUrl = options.url ?? DEFAULT_SERVER_STATUS_URL;
-  let healthUrl: string;
+  let healthUrl: { readonly displayUrl: string; readonly url: string };
   try {
     healthUrl = healthUrlFromBaseUrl(rawUrl);
   } catch (cause) {
     return {
       reachable: false,
       ready: false,
-      url: rawUrl,
+      url: displayUrlFromRawUrl(rawUrl),
       error: cause instanceof Error ? cause.message : "Invalid server URL.",
     };
   }
@@ -82,7 +98,7 @@ export async function fetchSynaraServerStatus(
   const request: FetchLike = options.fetch ?? globalThis.fetch;
   const timeoutMs = options.timeoutMs ?? DEFAULT_SERVER_STATUS_TIMEOUT_MS;
   try {
-    const response = await request(healthUrl, {
+    const response = await request(healthUrl.url, {
       signal: AbortSignal.timeout(timeoutMs),
       headers: { Accept: "application/json" },
     });
@@ -90,7 +106,7 @@ export async function fetchSynaraServerStatus(
       return {
         reachable: false,
         ready: false,
-        url: rawUrl,
+        url: healthUrl.displayUrl,
         error: `Health request returned HTTP ${String(response.status)}.`,
       };
     }
@@ -100,7 +116,7 @@ export async function fetchSynaraServerStatus(
       return {
         reachable: false,
         ready: false,
-        url: rawUrl,
+        url: healthUrl.displayUrl,
         error: "Health response did not match the Synara health shape.",
       };
     }
@@ -109,14 +125,14 @@ export async function fetchSynaraServerStatus(
       reachable: true,
       ready:
         health.status === "ok" && health.startupReady && health.projection?.state === "healthy",
-      url: rawUrl,
+      url: healthUrl.displayUrl,
       health,
     };
   } catch (cause) {
     return {
       reachable: false,
       ready: false,
-      url: rawUrl,
+      url: healthUrl.displayUrl,
       error: cause instanceof Error ? cause.message : "Health request failed.",
     };
   }
@@ -128,8 +144,9 @@ export function formatSynaraServerStatus(result: SynaraServerStatusResult): stri
   }
 
   const projectionState = result.health.projection?.state;
+  const status = result.ready ? "ready" : result.health.startupReady ? "not ready" : "starting";
   return [
-    `Synara server: ${result.ready ? "ready" : "starting"}`,
+    `Synara server: ${status}`,
     `URL: ${result.url}`,
     ...(projectionState ? [`Projection: ${projectionState}`] : []),
   ].join("\n");

--- a/apps/server/src/serverStatusCli.ts
+++ b/apps/server/src/serverStatusCli.ts
@@ -1,0 +1,136 @@
+export const DEFAULT_SERVER_STATUS_URL = "http://127.0.0.1:3773";
+const DEFAULT_SERVER_STATUS_TIMEOUT_MS = 3_000;
+
+type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+export interface SynaraServerHealthSnapshot {
+  readonly status: string;
+  readonly startupReady: boolean;
+  readonly pushBusReady?: boolean;
+  readonly keybindingsReady?: boolean;
+  readonly terminalSubscriptionsReady?: boolean;
+  readonly orchestrationSubscriptionsReady?: boolean;
+  readonly projection?: {
+    readonly state?: string;
+    readonly inFlight?: boolean;
+    readonly retryAttempts?: number;
+    readonly hasFailure?: boolean;
+    readonly highWaterSequence?: number;
+    readonly lagByProjector?: unknown;
+    readonly missingProjectors?: unknown;
+  };
+}
+
+export type SynaraServerStatusResult =
+  | {
+      readonly reachable: true;
+      readonly ready: boolean;
+      readonly url: string;
+      readonly health: SynaraServerHealthSnapshot;
+    }
+  | {
+      readonly reachable: false;
+      readonly ready: false;
+      readonly url: string;
+      readonly error: string;
+    };
+
+export interface FetchSynaraServerStatusOptions {
+  readonly url?: string;
+  readonly timeoutMs?: number;
+  readonly fetch?: FetchLike;
+}
+
+function healthUrlFromBaseUrl(rawUrl: string): string {
+  const url = new URL(rawUrl);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Server URL must use http:// or https://.");
+  }
+  url.pathname = "/health";
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+function decodeHealthSnapshot(value: unknown): SynaraServerHealthSnapshot | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const snapshot = value as Record<string, unknown>;
+  if (typeof snapshot.status !== "string" || typeof snapshot.startupReady !== "boolean") {
+    return null;
+  }
+  return snapshot as unknown as SynaraServerHealthSnapshot;
+}
+
+export async function fetchSynaraServerStatus(
+  options: FetchSynaraServerStatusOptions = {},
+): Promise<SynaraServerStatusResult> {
+  const rawUrl = options.url ?? DEFAULT_SERVER_STATUS_URL;
+  let healthUrl: string;
+  try {
+    healthUrl = healthUrlFromBaseUrl(rawUrl);
+  } catch (cause) {
+    return {
+      reachable: false,
+      ready: false,
+      url: rawUrl,
+      error: cause instanceof Error ? cause.message : "Invalid server URL.",
+    };
+  }
+
+  const request: FetchLike = options.fetch ?? globalThis.fetch;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_SERVER_STATUS_TIMEOUT_MS;
+  try {
+    const response = await request(healthUrl, {
+      signal: AbortSignal.timeout(timeoutMs),
+      headers: { Accept: "application/json" },
+    });
+    if (!response.ok) {
+      return {
+        reachable: false,
+        ready: false,
+        url: rawUrl,
+        error: `Health request returned HTTP ${String(response.status)}.`,
+      };
+    }
+
+    const health = decodeHealthSnapshot(await response.json());
+    if (!health) {
+      return {
+        reachable: false,
+        ready: false,
+        url: rawUrl,
+        error: "Health response did not match the Synara health shape.",
+      };
+    }
+
+    return {
+      reachable: true,
+      ready:
+        health.status === "ok" && health.startupReady && health.projection?.state === "healthy",
+      url: rawUrl,
+      health,
+    };
+  } catch (cause) {
+    return {
+      reachable: false,
+      ready: false,
+      url: rawUrl,
+      error: cause instanceof Error ? cause.message : "Health request failed.",
+    };
+  }
+}
+
+export function formatSynaraServerStatus(result: SynaraServerStatusResult): string {
+  if (!result.reachable) {
+    return `Synara server: unreachable\nURL: ${result.url}\nError: ${result.error}`;
+  }
+
+  const projectionState = result.health.projection?.state;
+  return [
+    `Synara server: ${result.ready ? "ready" : "starting"}`,
+    `URL: ${result.url}`,
+    ...(projectionState ? [`Projection: ${projectionState}`] : []),
+  ].join("\n");
+}


### PR DESCRIPTION
## Problem

Synara already exposes an unauthenticated `/health` endpoint, but the published `synara` executable has no supported command for scripts, SSH sessions, or operators to answer the basic question: “is this server reachable and ready?”

Issue #639 proposes a public CLI surface on top of the existing server runtime. This PR implements the smallest read-only slice without introducing a second RPC client or changing server startup behavior.

## What changed

- add `synara server status`;
- default to `http://127.0.0.1:3773` and probe its `/health` endpoint;
- add `--url` for an explicit HTTP/HTTPS Synara server base URL;
- add `--json` for machine-readable output;
- validate the minimum Synara health-response shape instead of accepting arbitrary JSON;
- use a bounded request timeout;
- return human-readable `ready`, `starting`, or `unreachable` status;
- set process exit code `1` when the server is unreachable or not startup-ready, making the command useful in shell/CI health gates;
- add focused tests for ready/starting state, URL normalization, malformed responses, HTTP failures, and transport failures.

## Examples

```bash
synara server status
synara server status --url http://my-host:3773
synara server status --json
```

## Why this approach

`/health` is already deliberately unauthenticated and exposes only shape-level readiness diagnostics, so this command does not need credentials or the private WebSocket protocol.

That keeps the first CLI slice useful and stable while leaving thread/provider/project commands for later work under #639.

The normal root `synara` command still starts the server exactly as before. Only the explicit `server status` subcommand takes the new read-only path.

## Validation

Before opening this PR, GitHub Actions on the fork passed:

- repository formatter over all three touched files;
- `src/serverStatusCli.test.ts` — 5/5 tests;
- full `apps/server` typecheck;
- `git diff --check`;
- branch rewritten to one focused commit after validation.

The draft remains subject to the full upstream CI suite.

## Scope

3 server files. No persistence, provider, orchestration, authentication, WebSocket, desktop, or UI changes.

## Out of scope

- `server start` / daemon management;
- provider/project/thread CLI commands;
- authenticated/private RPC access;
- changing `/health` itself;
- closing #639 — this is only its first read-only command slice.