### PR TITLE
fix(stream): preserve UTF-8 boundaries when truncating output

### DIFF
--- a/apps/server/src/stream/collectUint8StreamText.test.ts
+++ b/apps/server/src/stream/collectUint8StreamText.test.ts
@@ -33,4 +33,33 @@ describe("collectUint8StreamText", () => {
       truncated: true,
     });
   });
+
+  it("does not emit a replacement character when truncation splits a UTF-8 sequence", async () => {
+    const result = await Effect.runPromise(
+      collectUint8StreamText({
+        stream: Stream.fromIterable([encoder.encode("ab€cd")]),
+        maxBytes: 4,
+      }),
+    );
+
+    expect(result).toEqual({
+      text: "ab",
+      truncated: true,
+    });
+    expect(result.text).not.toContain("�");
+  });
+
+  it("drops an incomplete four-byte UTF-8 suffix at the byte limit", async () => {
+    const result = await Effect.runPromise(
+      collectUint8StreamText({
+        stream: Stream.fromIterable([encoder.encode("ok🙂done")]),
+        maxBytes: 5,
+      }),
+    );
+
+    expect(result).toEqual({
+      text: "ok",
+      truncated: true,
+    });
+  });
 });

--- a/apps/server/src/stream/collectUint8StreamText.ts
+++ b/apps/server/src/stream/collectUint8StreamText.ts
@@ -12,6 +12,28 @@ interface CollectState {
   readonly truncated: boolean;
 }
 
+function utf8SequenceLength(leadByte: number): number {
+  if ((leadByte & 0x80) === 0) return 1;
+  if ((leadByte & 0xe0) === 0xc0) return 2;
+  if ((leadByte & 0xf0) === 0xe0) return 3;
+  if ((leadByte & 0xf8) === 0xf0) return 4;
+  return 1;
+}
+
+function trimIncompleteUtf8Suffix(bytes: Buffer): Buffer {
+  if (bytes.length === 0) return bytes;
+
+  let sequenceStart = bytes.length - 1;
+  while (sequenceStart >= 0 && (bytes[sequenceStart]! & 0xc0) === 0x80) {
+    sequenceStart -= 1;
+  }
+  if (sequenceStart < 0) return bytes;
+
+  const expectedLength = utf8SequenceLength(bytes[sequenceStart]!);
+  const availableLength = bytes.length - sequenceStart;
+  return expectedLength > availableLength ? bytes.subarray(0, sequenceStart) : bytes;
+}
+
 export function collectUint8StreamText<E>(input: {
   readonly stream: Stream.Stream<Uint8Array, E>;
   readonly maxBytes?: number;
@@ -39,9 +61,12 @@ export function collectUint8StreamText<E>(input: {
       };
     },
   ).pipe(
-    Effect.map((state) => ({
-      text: Buffer.concat(state.chunks, state.byteLength).toString("utf8"),
-      truncated: state.truncated,
-    })),
+    Effect.map((state) => {
+      const bytes = Buffer.concat(state.chunks, state.byteLength);
+      return {
+        text: (state.truncated ? trimIncompleteUtf8Suffix(bytes) : bytes).toString("utf8"),
+        truncated: state.truncated,
+      };
+    }),
   );
 }


### PR DESCRIPTION
## Summary

`collectUint8StreamText` enforces byte limits before decoding collected output. When `maxBytes` landed in the middle of a multi-byte UTF-8 code point, `Buffer.toString("utf8")` emitted a replacement character (`�`) at the end of otherwise valid output.

This PR keeps the existing byte cap and drain behavior, but when truncation actually occurred it drops only an incomplete trailing UTF-8 sequence before decoding.

## What changed

- detect a partial 2/3/4-byte UTF-8 sequence at the truncated suffix;
- leave complete and non-truncated buffers unchanged;
- add regressions for a split three-byte character and a split four-byte emoji.

## Why

The helper is shared by bounded provider/process output collection, where truncation is expected behavior. A byte cap should not manufacture invalid text at an arbitrary code-point boundary.

## Validation

Added focused regression coverage in `collectUint8StreamText.test.ts`. Repository CI will run the test suite.

## Scope

2 server stream files. No protocol, provider, persistence, UI, or dependency changes.