### PR TITLE
fix(server): restrict scratch workspace permissions

### DIFF
--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -64,7 +64,7 @@ import {
   teardownChildProcessTree,
   teardownProviderProcessTree,
 } from "./provider/supervisedProcessTeardown.ts";
-import { ensureIsolatedScratchWorkspace } from "./scratchWorkspaces.ts";
+import { ensureIsolatedScratchWorkspace, resolveScratchWorkspaceCwd } from "./scratchWorkspaces.ts";
 import { createLogger } from "./logger";
 import { transcribeVoiceWithChatGptSession } from "./voiceTranscription.ts";
 import {
@@ -1043,7 +1043,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         await this.stopSession(threadId);
       }
 
-      const resolvedCwd = input.cwd ?? ensureIsolatedScratchWorkspace(threadId);
+      const resolvedCwd = resolveScratchWorkspaceCwd(threadId, input.cwd);
 
       const session: ProviderSession = {
         provider: "codex",

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -973,6 +973,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     | undefined;
   private readonly teardownProcessTree: typeof teardownProviderProcessTree;
   private readonly taskCompleteFallbackGraceMs: number;
+  private readonly scratchWorkspacesRoot: string | undefined;
   constructor(
     services?: ServiceMap.ServiceMap<never>,
     options?: {
@@ -983,6 +984,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       };
       readonly teardownProcessTree?: typeof teardownProviderProcessTree;
       readonly taskCompleteFallbackGraceMs?: number;
+      readonly scratchWorkspacesRoot?: string;
     },
   ) {
     super();
@@ -991,6 +993,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     this.agentGatewayMcp = options?.agentGatewayMcp;
     this.teardownProcessTree = options?.teardownProcessTree ?? teardownProviderProcessTree;
     this.taskCompleteFallbackGraceMs = Math.max(0, options?.taskCompleteFallbackGraceMs ?? 750);
+    this.scratchWorkspacesRoot = options?.scratchWorkspacesRoot;
   }
 
   // The Synara MCP server rides on the shared overlay config (no secrets),
@@ -1043,7 +1046,8 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         await this.stopSession(threadId);
       }
 
-      const resolvedCwd = input.cwd ?? ensureIsolatedScratchWorkspace(threadId);
+      const resolvedCwd =
+        input.cwd ?? ensureIsolatedScratchWorkspace(threadId, this.scratchWorkspacesRoot);
 
       const session: ProviderSession = {
         provider: "codex",
@@ -1821,7 +1825,8 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         throw new Error("Provider fork is missing the source thread resume id.");
       }
 
-      const resolvedCwd = input.cwd ?? ensureIsolatedScratchWorkspace(threadId);
+      const resolvedCwd =
+        input.cwd ?? ensureIsolatedScratchWorkspace(threadId, this.scratchWorkspacesRoot);
       const session: ProviderSession = {
         provider: "codex",
         status: "connecting",

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -973,7 +973,6 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     | undefined;
   private readonly teardownProcessTree: typeof teardownProviderProcessTree;
   private readonly taskCompleteFallbackGraceMs: number;
-  private readonly scratchWorkspacesRoot: string | undefined;
   constructor(
     services?: ServiceMap.ServiceMap<never>,
     options?: {
@@ -984,7 +983,6 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       };
       readonly teardownProcessTree?: typeof teardownProviderProcessTree;
       readonly taskCompleteFallbackGraceMs?: number;
-      readonly scratchWorkspacesRoot?: string;
     },
   ) {
     super();
@@ -993,7 +991,6 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     this.agentGatewayMcp = options?.agentGatewayMcp;
     this.teardownProcessTree = options?.teardownProcessTree ?? teardownProviderProcessTree;
     this.taskCompleteFallbackGraceMs = Math.max(0, options?.taskCompleteFallbackGraceMs ?? 750);
-    this.scratchWorkspacesRoot = options?.scratchWorkspacesRoot;
   }
 
   // The Synara MCP server rides on the shared overlay config (no secrets),
@@ -1046,8 +1043,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         await this.stopSession(threadId);
       }
 
-      const resolvedCwd =
-        input.cwd ?? ensureIsolatedScratchWorkspace(threadId, this.scratchWorkspacesRoot);
+      const resolvedCwd = input.cwd ?? ensureIsolatedScratchWorkspace(threadId);
 
       const session: ProviderSession = {
         provider: "codex",
@@ -1825,8 +1821,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         throw new Error("Provider fork is missing the source thread resume id.");
       }
 
-      const resolvedCwd =
-        input.cwd ?? ensureIsolatedScratchWorkspace(threadId, this.scratchWorkspacesRoot);
+      const resolvedCwd = input.cwd ?? ensureIsolatedScratchWorkspace(threadId);
       const session: ProviderSession = {
         provider: "codex",
         status: "connecting",

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -18,6 +18,7 @@ import {
 } from "@synara/shared/binaryTransfer";
 import { EDITOR_ICON_ROUTE_PATH } from "@synara/shared/editorIcons";
 import { threadExportBlockedReason } from "@synara/shared/threadExport";
+import { SCRATCH_WORKSPACES_DIRNAME } from "@synara/shared/threadWorkspace";
 import { Cause, DateTime, Effect, FileSystem, Layer, Option, Path, Schema, Stream } from "effect";
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 
@@ -808,6 +809,7 @@ export const localImageEffectRouteLayer = HttpRouter.add(
       resolveAllowedLocalPreviewFile({
         requestedPath: url.searchParams.get("path"),
         cwd: url.searchParams.get("cwd"),
+        scratchWorkspacesRoot: nodePath.join(config.stateDir, SCRATCH_WORKSPACES_DIRNAME),
         allowAbsoluteLocalPreviewFile: true,
         previewGrant: url.searchParams.get("grant"),
       }).catch(() => null),

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -18,7 +18,6 @@ import {
 } from "@synara/shared/binaryTransfer";
 import { EDITOR_ICON_ROUTE_PATH } from "@synara/shared/editorIcons";
 import { threadExportBlockedReason } from "@synara/shared/threadExport";
-import { SCRATCH_WORKSPACES_DIRNAME } from "@synara/shared/threadWorkspace";
 import { Cause, DateTime, Effect, FileSystem, Layer, Option, Path, Schema, Stream } from "effect";
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 
@@ -35,6 +34,7 @@ import { deriveAuthClientMetadata } from "./auth/utils";
 import { ServerConfig, type ServerConfigShape } from "./config";
 import { resolveCachedEditorIcon } from "./editorAppIcons";
 import { LOCAL_IMAGE_ROUTE_PATH, resolveAllowedLocalPreviewFile } from "./localImageFiles.ts";
+import { resolveScratchWorkspacesRoot } from "./scratchWorkspaces.ts";
 import { ProjectFaviconResolver } from "./project/Services/ProjectFaviconResolver";
 import { OrchestrationEngineService } from "./orchestration/Services/OrchestrationEngine";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery";
@@ -809,7 +809,7 @@ export const localImageEffectRouteLayer = HttpRouter.add(
       resolveAllowedLocalPreviewFile({
         requestedPath: url.searchParams.get("path"),
         cwd: url.searchParams.get("cwd"),
-        scratchWorkspacesRoot: nodePath.join(config.stateDir, SCRATCH_WORKSPACES_DIRNAME),
+        scratchWorkspacesRoot: resolveScratchWorkspacesRoot(),
         allowAbsoluteLocalPreviewFile: true,
         previewGrant: url.searchParams.get("grant"),
       }).catch(() => null),

--- a/apps/server/src/localImageFiles.test.ts
+++ b/apps/server/src/localImageFiles.test.ts
@@ -147,8 +147,8 @@ describe("resolveAllowedLocalPreviewFile", () => {
   });
 
   it("allows PDFs inside the configured private scratch root without a cwd", async () => {
-    const stateDir = makeTempDir("synara-private-state-");
-    const scratchRoot = path.join(stateDir, "synara-codex-workspaces");
+    const privateTempRoot = makeTempDir("synara-private-scratch-");
+    const scratchRoot = path.join(privateTempRoot, "synara-codex-workspaces");
     const threadDir = path.join(scratchRoot, "private-thread");
     const pdfPath = path.join(threadDir, "private-scratch.pdf");
     mkdirSync(threadDir, { recursive: true });

--- a/apps/server/src/localImageFiles.test.ts
+++ b/apps/server/src/localImageFiles.test.ts
@@ -146,6 +146,24 @@ describe("resolveAllowedLocalPreviewFile", () => {
     }
   });
 
+  it("allows PDFs inside the configured private scratch root without a cwd", async () => {
+    const stateDir = makeTempDir("synara-private-state-");
+    const scratchRoot = path.join(stateDir, "synara-codex-workspaces");
+    const threadDir = path.join(scratchRoot, "private-thread");
+    const pdfPath = path.join(threadDir, "private-scratch.pdf");
+    mkdirSync(threadDir, { recursive: true });
+    writeFileSync(pdfPath, Buffer.from("%PDF-1.4"));
+
+    const result = await resolveAllowedLocalPreviewFile({
+      requestedPath: pdfPath,
+      cwd: null,
+      scratchWorkspacesRoot: scratchRoot,
+    });
+
+    assert.equal(result?.path, realpathSync(pdfPath));
+    assert.equal(result?.fileName, "private-scratch.pdf");
+  });
+
   it("rejects PDFs outside the workspace even under the temp-dir image roots", async () => {
     // Temp/generated-image roots exist for agent-produced images in chat
     // markdown; documents must only ever be served from the workspace.

--- a/apps/server/src/localImageFiles.ts
+++ b/apps/server/src/localImageFiles.ts
@@ -125,6 +125,7 @@ export async function resolveAllowedLocalPreviewFile(input: {
   readonly requestedPath: string | null;
   readonly cwd: string | null;
   readonly codexHomePath?: string;
+  readonly scratchWorkspacesRoot?: string;
   readonly allowAbsoluteLocalPreviewFile?: boolean;
   readonly previewGrant?: string | null;
 }): Promise<ResolvedLocalPreviewFile | null> {
@@ -163,12 +164,15 @@ export async function resolveAllowedLocalPreviewFile(input: {
   }
 
   // Sessions that start before a project workspace exists run in per-thread
-  // scratch directories under the OS temp dir. Files agents create there are
-  // workspace-equivalent, so every preview type is servable from that root.
+  // scratch directories. Files agents create there are workspace-equivalent,
+  // so every preview type is servable from the configured private root. Keep
+  // the former temp roots readable for threads created before this migration.
   const tempRoots = await temporaryDirectoryRoots();
-  const scratchWorkspaceRoots = tempRoots.map((root) =>
-    path.join(root, SCRATCH_WORKSPACES_DIRNAME),
-  );
+  const configuredScratchRoot = await realpathOrNull(input.scratchWorkspacesRoot);
+  const scratchWorkspaceRoots = [
+    ...(configuredScratchRoot ? [configuredScratchRoot] : []),
+    ...tempRoots.map((root) => path.join(root, SCRATCH_WORKSPACES_DIRNAME)),
+  ];
   if (scratchWorkspaceRoots.some((root) => isPathInside(realFilePath, root))) {
     return resolved;
   }

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -32,8 +32,6 @@ import {
   TurnId,
 } from "@synara/contracts";
 import { Cause, Effect, Layer, Option, Queue, Schema, ServiceMap, Stream } from "effect";
-import path from "node:path";
-import { SCRATCH_WORKSPACES_DIRNAME } from "@synara/shared/threadWorkspace";
 
 import {
   ProviderAdapterProcessError,
@@ -1744,7 +1742,6 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
           options?.makeManager?.(services) ??
           new CodexAppServerManager(services, {
             synaraSkillsDir: synaraSkillsDir(serverConfig.baseDir),
-            scratchWorkspacesRoot: path.join(serverConfig.stateDir, SCRATCH_WORKSPACES_DIRNAME),
             ...(agentGatewayCredentials
               ? {
                   agentGatewayMcp: {

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -32,6 +32,8 @@ import {
   TurnId,
 } from "@synara/contracts";
 import { Cause, Effect, Layer, Option, Queue, Schema, ServiceMap, Stream } from "effect";
+import path from "node:path";
+import { SCRATCH_WORKSPACES_DIRNAME } from "@synara/shared/threadWorkspace";
 
 import {
   ProviderAdapterProcessError,
@@ -1742,6 +1744,7 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
           options?.makeManager?.(services) ??
           new CodexAppServerManager(services, {
             synaraSkillsDir: synaraSkillsDir(serverConfig.baseDir),
+            scratchWorkspacesRoot: path.join(serverConfig.stateDir, SCRATCH_WORKSPACES_DIRNAME),
             ...(agentGatewayCredentials
               ? {
                   agentGatewayMcp: {

--- a/apps/server/src/scratchWorkspaces.test.ts
+++ b/apps/server/src/scratchWorkspaces.test.ts
@@ -11,7 +11,7 @@ import { ThreadId } from "@synara/contracts";
 import { SCRATCH_WORKSPACES_DIRNAME } from "@synara/shared/threadWorkspace";
 import { afterAll, describe, expect, it } from "vitest";
 
-import { ensureIsolatedScratchWorkspace } from "./scratchWorkspaces";
+import { ensureIsolatedScratchWorkspace, resolveScratchWorkspacesRoot } from "./scratchWorkspaces";
 
 const testScratchParent = mkdtempSync(path.join(tmpdir(), "synara-scratch-test-"));
 const testScratchRoot = path.join(testScratchParent, SCRATCH_WORKSPACES_DIRNAME);
@@ -25,6 +25,18 @@ function ensureTestScratchWorkspace(threadId: ThreadId): string {
 }
 
 describe("ensureIsolatedScratchWorkspace", () => {
+  it("keeps the default scratch root in a per-user temporary container outside the checkout", () => {
+    const root = resolveScratchWorkspacesRoot();
+    const workspace = ensureIsolatedScratchWorkspace(ThreadId.makeUnsafe("default-root"));
+    try {
+      expect(path.relative(process.cwd(), root).startsWith("..")).toBe(true);
+      expect(path.dirname(root)).toMatch(/\.synara-[a-f0-9]{16}$/);
+      expect(workspace.startsWith(`${root}${path.sep}`)).toBe(true);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
   it("creates a readable per-thread directory under the scratch root", () => {
     const workspace = ensureTestScratchWorkspace(ThreadId.makeUnsafe("thread-1"));
     try {

--- a/apps/server/src/scratchWorkspaces.test.ts
+++ b/apps/server/src/scratchWorkspaces.test.ts
@@ -1,6 +1,6 @@
 // FILE: scratchWorkspaces.test.ts
-// Purpose: Verifies per-thread scratch workspace paths stay inside the shared
-//          temp root even when thread ids contain path-like characters.
+// Purpose: Verifies per-thread scratch workspace paths stay inside their
+//          private root even when thread ids contain path-like characters.
 // Layer: Server filesystem utility tests
 
 import {
@@ -13,7 +13,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 
 import { ThreadId } from "@synara/contracts";
@@ -38,17 +38,72 @@ function ensureTestScratchWorkspace(threadId: ThreadId): string {
 }
 
 describe("ensureIsolatedScratchWorkspace", () => {
-  it("keeps the default scratch root in a per-user temporary container outside the checkout", () => {
+  it("keeps the default scratch root in a private user cache outside the checkout", () => {
     const root = resolveScratchWorkspacesRoot();
     const workspace = ensureIsolatedScratchWorkspace(ThreadId.makeUnsafe("default-root"));
     try {
       expect(path.relative(process.cwd(), root).startsWith("..")).toBe(true);
+      expect(path.relative(homedir(), root).startsWith("..")).toBe(false);
       expect(path.dirname(root)).toMatch(/\.synara-[a-f0-9]{16}$/);
       expect(workspace.startsWith(`${root}${path.sep}`)).toBe(true);
     } finally {
       rmSync(workspace, { recursive: true, force: true });
     }
   });
+
+  it("reuses a validated private workspace in place after the temporary root changes", () => {
+    const threadId = ThreadId.makeUnsafe("prior-private-thread");
+    const currentRoot = path.join(testScratchParent, "current", SCRATCH_WORKSPACES_DIRNAME);
+    const ownerContainerName = path.basename(path.dirname(resolveScratchWorkspacesRoot()));
+    const priorRoot = path.join(
+      testScratchParent,
+      "old-tmp",
+      ownerContainerName,
+      SCRATCH_WORKSPACES_DIRNAME,
+    );
+    const priorWorkspace = ensureIsolatedScratchWorkspace(threadId, priorRoot);
+    writeFileSync(path.join(priorWorkspace, "resume.txt"), "preserved");
+
+    const resumedWorkspace = resolveScratchWorkspaceCwd(threadId, priorWorkspace, {
+      workspaceRoot: currentRoot,
+      legacyWorkspaceRoot: path.join(testScratchParent, "unused-legacy"),
+    });
+
+    expect(resumedWorkspace).toBe(priorWorkspace);
+    expect(readFileSync(path.join(resumedWorkspace, "resume.txt"), "utf8")).toBe("preserved");
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "uses a fresh private workspace when an earlier temporary cwd is a symlink",
+    () => {
+      const threadId = ThreadId.makeUnsafe("unsafe-prior-private-thread");
+      const currentRoot = path.join(testScratchParent, "fresh-current", SCRATCH_WORKSPACES_DIRNAME);
+      const ownerContainerName = path.basename(path.dirname(resolveScratchWorkspacesRoot()));
+      const priorRoot = path.join(
+        testScratchParent,
+        "unsafe-old-tmp",
+        ownerContainerName,
+        SCRATCH_WORKSPACES_DIRNAME,
+      );
+      const priorWorkspace = ensureIsolatedScratchWorkspace(threadId, priorRoot);
+      const redirected = mkdtempSync(path.join(tmpdir(), "synara-prior-redirect-"));
+      try {
+        rmSync(priorWorkspace, { recursive: true, force: true });
+        symlinkSync(redirected, priorWorkspace, "dir");
+
+        const resumedWorkspace = resolveScratchWorkspaceCwd(threadId, priorWorkspace, {
+          workspaceRoot: currentRoot,
+          legacyWorkspaceRoot: path.join(testScratchParent, "unused-legacy"),
+        });
+
+        expect(resumedWorkspace).not.toBe(priorWorkspace);
+        expect(resumedWorkspace.startsWith(`${currentRoot}${path.sep}`)).toBe(true);
+      } finally {
+        rmSync(priorWorkspace, { force: true });
+        rmSync(redirected, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("creates a readable per-thread directory under the scratch root", () => {
     const workspace = ensureTestScratchWorkspace(ThreadId.makeUnsafe("thread-1"));
@@ -80,7 +135,7 @@ describe("ensureIsolatedScratchWorkspace", () => {
     expect(resumedWorkspace).toBe(legacyWorkspace);
     expect(readFileSync(path.join(resumedWorkspace, "resume.txt"), "utf8")).toBe("preserved");
     if (process.platform !== "win32") {
-      expect(statSync(legacyRoot).mode & 0o1777).toBe(0o1777);
+      expect(statSync(legacyRoot).mode & 0o1777).toBe(0o777);
       expect(statSync(resumedWorkspace).mode & 0o777).toBe(0o700);
     }
   });

--- a/apps/server/src/scratchWorkspaces.test.ts
+++ b/apps/server/src/scratchWorkspaces.test.ts
@@ -9,29 +9,36 @@ import path from "node:path";
 
 import { ThreadId } from "@synara/contracts";
 import { SCRATCH_WORKSPACES_DIRNAME } from "@synara/shared/threadWorkspace";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 
 import { ensureIsolatedScratchWorkspace } from "./scratchWorkspaces";
 
-function scratchRoot(): string {
-  return path.join(tmpdir(), SCRATCH_WORKSPACES_DIRNAME);
+const testScratchParent = mkdtempSync(path.join(tmpdir(), "synara-scratch-test-"));
+const testScratchRoot = path.join(testScratchParent, SCRATCH_WORKSPACES_DIRNAME);
+
+afterAll(() => {
+  rmSync(testScratchParent, { recursive: true, force: true });
+});
+
+function ensureTestScratchWorkspace(threadId: ThreadId): string {
+  return ensureIsolatedScratchWorkspace(threadId, testScratchRoot);
 }
 
 describe("ensureIsolatedScratchWorkspace", () => {
   it("creates a readable per-thread directory under the scratch root", () => {
-    const workspace = ensureIsolatedScratchWorkspace(ThreadId.makeUnsafe("thread-1"));
+    const workspace = ensureTestScratchWorkspace(ThreadId.makeUnsafe("thread-1"));
     try {
       expect(workspace).toContain(`${path.sep}${SCRATCH_WORKSPACES_DIRNAME}${path.sep}thread-1-`);
-      expect(path.relative(scratchRoot(), workspace).startsWith("..")).toBe(false);
+      expect(path.relative(testScratchRoot, workspace).startsWith("..")).toBe(false);
     } finally {
       rmSync(workspace, { recursive: true, force: true });
     }
   });
 
   it("does not let path-like thread ids escape the scratch root", () => {
-    const workspace = ensureIsolatedScratchWorkspace(ThreadId.makeUnsafe("../outside/thread"));
+    const workspace = ensureTestScratchWorkspace(ThreadId.makeUnsafe("../outside/thread"));
     try {
-      const relative = path.relative(scratchRoot(), workspace);
+      const relative = path.relative(testScratchRoot, workspace);
       expect(relative.startsWith("..")).toBe(false);
       expect(path.isAbsolute(relative)).toBe(false);
       expect(workspace).not.toContain(`${path.sep}..${path.sep}`);
@@ -41,7 +48,7 @@ describe("ensureIsolatedScratchWorkspace", () => {
   });
 
   it.skipIf(process.platform === "win32")("uses owner-only permissions on POSIX", () => {
-    const workspace = ensureIsolatedScratchWorkspace(ThreadId.makeUnsafe("private-thread"));
+    const workspace = ensureTestScratchWorkspace(ThreadId.makeUnsafe("private-thread"));
     try {
       expect(statSync(workspace).mode & 0o777).toBe(0o700);
     } finally {
@@ -53,12 +60,12 @@ describe("ensureIsolatedScratchWorkspace", () => {
     "tightens permissions when reusing an existing scratch workspace",
     () => {
       const threadId = ThreadId.makeUnsafe("reused-private-thread");
-      const workspace = ensureIsolatedScratchWorkspace(threadId);
+      const workspace = ensureTestScratchWorkspace(threadId);
       try {
         chmodSync(workspace, 0o755);
         expect(statSync(workspace).mode & 0o777).toBe(0o755);
 
-        expect(ensureIsolatedScratchWorkspace(threadId)).toBe(workspace);
+        expect(ensureTestScratchWorkspace(threadId)).toBe(workspace);
         expect(statSync(workspace).mode & 0o777).toBe(0o700);
       } finally {
         rmSync(workspace, { recursive: true, force: true });
@@ -69,15 +76,15 @@ describe("ensureIsolatedScratchWorkspace", () => {
   it.skipIf(process.platform === "win32")(
     "tightens permissions when reusing the shared scratch root",
     () => {
-      const workspace = ensureIsolatedScratchWorkspace(ThreadId.makeUnsafe("private-root"));
+      const workspace = ensureTestScratchWorkspace(ThreadId.makeUnsafe("private-root"));
       try {
-        chmodSync(scratchRoot(), 0o777);
+        chmodSync(testScratchRoot, 0o777);
 
-        ensureIsolatedScratchWorkspace(ThreadId.makeUnsafe("private-root"));
+        ensureTestScratchWorkspace(ThreadId.makeUnsafe("private-root"));
 
-        expect(statSync(scratchRoot()).mode & 0o777).toBe(0o700);
+        expect(statSync(testScratchRoot).mode & 0o777).toBe(0o700);
       } finally {
-        chmodSync(scratchRoot(), 0o700);
+        chmodSync(testScratchRoot, 0o700);
         rmSync(workspace, { recursive: true, force: true });
       }
     },
@@ -87,12 +94,12 @@ describe("ensureIsolatedScratchWorkspace", () => {
     "refuses to follow a reused scratch workspace symlink",
     () => {
       const threadId = ThreadId.makeUnsafe("symlinked-private-thread");
-      const workspace = ensureIsolatedScratchWorkspace(threadId);
+      const workspace = ensureTestScratchWorkspace(threadId);
       const redirected = mkdtempSync(path.join(tmpdir(), "synara-scratch-redirect-"));
       rmSync(workspace, { recursive: true, force: true });
       symlinkSync(redirected, workspace, "dir");
       try {
-        expect(() => ensureIsolatedScratchWorkspace(threadId)).toThrow(
+        expect(() => ensureTestScratchWorkspace(threadId)).toThrow(
           /open without following symlinks/,
         );
       } finally {

--- a/apps/server/src/scratchWorkspaces.test.ts
+++ b/apps/server/src/scratchWorkspaces.test.ts
@@ -3,7 +3,7 @@
 //          temp root even when thread ids contain path-like characters.
 // Layer: Server filesystem utility tests
 
-import { rmSync, statSync } from "node:fs";
+import { chmodSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -48,4 +48,21 @@ describe("ensureIsolatedScratchWorkspace", () => {
       rmSync(workspace, { recursive: true, force: true });
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "tightens permissions when reusing an existing scratch workspace",
+    () => {
+      const threadId = ThreadId.makeUnsafe("reused-private-thread");
+      const workspace = ensureIsolatedScratchWorkspace(threadId);
+      try {
+        chmodSync(workspace, 0o755);
+        expect(statSync(workspace).mode & 0o777).toBe(0o755);
+
+        expect(ensureIsolatedScratchWorkspace(threadId)).toBe(workspace);
+        expect(statSync(workspace).mode & 0o777).toBe(0o700);
+      } finally {
+        rmSync(workspace, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/apps/server/src/scratchWorkspaces.test.ts
+++ b/apps/server/src/scratchWorkspaces.test.ts
@@ -71,13 +71,16 @@ describe("ensureIsolatedScratchWorkspace", () => {
     const legacyWorkspace = path.join(legacyRoot, workspaceSegment);
     mkdirSync(legacyWorkspace, { recursive: true });
     writeFileSync(path.join(legacyWorkspace, "resume.txt"), "preserved");
+    if (process.platform !== "win32") {
+      chmodSync(legacyRoot, 0o777);
+    }
 
     const resumedWorkspace = ensureIsolatedScratchWorkspace(threadId, migratedRoot, legacyRoot);
 
     expect(resumedWorkspace).toBe(legacyWorkspace);
     expect(readFileSync(path.join(resumedWorkspace, "resume.txt"), "utf8")).toBe("preserved");
     if (process.platform !== "win32") {
-      expect(statSync(legacyRoot).mode & 0o777).toBe(0o700);
+      expect(statSync(legacyRoot).mode & 0o1777).toBe(0o1777);
       expect(statSync(resumedWorkspace).mode & 0o777).toBe(0o700);
     }
   });
@@ -109,8 +112,28 @@ describe("ensureIsolatedScratchWorkspace", () => {
       }),
     ).toBe(legacyWorkspace);
     if (process.platform !== "win32") {
-      expect(statSync(legacyRoot).mode & 0o777).toBe(0o700);
+      expect(statSync(legacyRoot).mode & 0o777).toBe(0o755);
       expect(statSync(legacyWorkspace).mode & 0o777).toBe(0o700);
+    }
+  });
+
+  it("revalidates a persisted private scratch cwd before session recovery", () => {
+    const threadId = ThreadId.makeUnsafe("persisted-private-thread");
+    const privateRoot = path.join(testScratchParent, "private", SCRATCH_WORKSPACES_DIRNAME);
+    const legacyRoot = path.join(testScratchParent, "unused-legacy");
+    const privateWorkspace = ensureIsolatedScratchWorkspace(threadId, privateRoot, legacyRoot);
+    if (process.platform !== "win32") {
+      chmodSync(privateWorkspace, 0o755);
+    }
+
+    expect(
+      resolveScratchWorkspaceCwd(threadId, privateWorkspace, {
+        workspaceRoot: privateRoot,
+        legacyWorkspaceRoot: legacyRoot,
+      }),
+    ).toBe(privateWorkspace);
+    if (process.platform !== "win32") {
+      expect(statSync(privateWorkspace).mode & 0o777).toBe(0o700);
     }
   });
 

--- a/apps/server/src/scratchWorkspaces.test.ts
+++ b/apps/server/src/scratchWorkspaces.test.ts
@@ -3,7 +3,17 @@
 //          temp root even when thread ids contain path-like characters.
 // Layer: Server filesystem utility tests
 
-import { chmodSync, mkdtempSync, rmSync, statSync, symlinkSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -45,6 +55,24 @@ describe("ensureIsolatedScratchWorkspace", () => {
     } finally {
       rmSync(workspace, { recursive: true, force: true });
     }
+  });
+
+  it("moves a matching legacy workspace into the private per-user root", () => {
+    const threadId = ThreadId.makeUnsafe("legacy-thread");
+    const migratedRoot = path.join(testScratchParent, "migrated", SCRATCH_WORKSPACES_DIRNAME);
+    const legacyRoot = path.join(testScratchParent, "legacy", SCRATCH_WORKSPACES_DIRNAME);
+    const initialWorkspace = ensureIsolatedScratchWorkspace(threadId, migratedRoot);
+    const workspaceSegment = path.basename(initialWorkspace);
+    rmSync(migratedRoot, { recursive: true, force: true });
+
+    const legacyWorkspace = path.join(legacyRoot, workspaceSegment);
+    mkdirSync(legacyWorkspace, { recursive: true });
+    writeFileSync(path.join(legacyWorkspace, "resume.txt"), "preserved");
+
+    const migratedWorkspace = ensureIsolatedScratchWorkspace(threadId, migratedRoot, legacyRoot);
+
+    expect(readFileSync(path.join(migratedWorkspace, "resume.txt"), "utf8")).toBe("preserved");
+    expect(existsSync(legacyWorkspace)).toBe(false);
   });
 
   it("does not let path-like thread ids escape the scratch root", () => {

--- a/apps/server/src/scratchWorkspaces.test.ts
+++ b/apps/server/src/scratchWorkspaces.test.ts
@@ -5,7 +5,6 @@
 
 import {
   chmodSync,
-  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -21,7 +20,11 @@ import { ThreadId } from "@synara/contracts";
 import { SCRATCH_WORKSPACES_DIRNAME } from "@synara/shared/threadWorkspace";
 import { afterAll, describe, expect, it } from "vitest";
 
-import { ensureIsolatedScratchWorkspace, resolveScratchWorkspacesRoot } from "./scratchWorkspaces";
+import {
+  ensureIsolatedScratchWorkspace,
+  resolveScratchWorkspaceCwd,
+  resolveScratchWorkspacesRoot,
+} from "./scratchWorkspaces";
 
 const testScratchParent = mkdtempSync(path.join(tmpdir(), "synara-scratch-test-"));
 const testScratchRoot = path.join(testScratchParent, SCRATCH_WORKSPACES_DIRNAME);
@@ -57,7 +60,7 @@ describe("ensureIsolatedScratchWorkspace", () => {
     }
   });
 
-  it("moves a matching legacy workspace into the private per-user root", () => {
+  it("securely reuses a matching legacy workspace without breaking historical paths", () => {
     const threadId = ThreadId.makeUnsafe("legacy-thread");
     const migratedRoot = path.join(testScratchParent, "migrated", SCRATCH_WORKSPACES_DIRNAME);
     const legacyRoot = path.join(testScratchParent, "legacy", SCRATCH_WORKSPACES_DIRNAME);
@@ -69,10 +72,46 @@ describe("ensureIsolatedScratchWorkspace", () => {
     mkdirSync(legacyWorkspace, { recursive: true });
     writeFileSync(path.join(legacyWorkspace, "resume.txt"), "preserved");
 
-    const migratedWorkspace = ensureIsolatedScratchWorkspace(threadId, migratedRoot, legacyRoot);
+    const resumedWorkspace = ensureIsolatedScratchWorkspace(threadId, migratedRoot, legacyRoot);
 
-    expect(readFileSync(path.join(migratedWorkspace, "resume.txt"), "utf8")).toBe("preserved");
-    expect(existsSync(legacyWorkspace)).toBe(false);
+    expect(resumedWorkspace).toBe(legacyWorkspace);
+    expect(readFileSync(path.join(resumedWorkspace, "resume.txt"), "utf8")).toBe("preserved");
+    if (process.platform !== "win32") {
+      expect(statSync(legacyRoot).mode & 0o777).toBe(0o700);
+      expect(statSync(resumedWorkspace).mode & 0o777).toBe(0o700);
+    }
+  });
+
+  it("leaves non-scratch persisted workspaces unchanged", () => {
+    const projectCwd = path.join(testScratchParent, "project");
+    expect(resolveScratchWorkspaceCwd(ThreadId.makeUnsafe("project-thread"), projectCwd)).toBe(
+      projectCwd,
+    );
+  });
+
+  it("repairs a persisted legacy cwd before session recovery", () => {
+    const threadId = ThreadId.makeUnsafe("persisted-legacy-thread");
+    const privateRoot = path.join(testScratchParent, "recovery", SCRATCH_WORKSPACES_DIRNAME);
+    const legacyRoot = path.join(testScratchParent, "persisted", SCRATCH_WORKSPACES_DIRNAME);
+    const workspaceSegment = path.basename(ensureIsolatedScratchWorkspace(threadId, privateRoot));
+    rmSync(privateRoot, { recursive: true, force: true });
+    const legacyWorkspace = path.join(legacyRoot, workspaceSegment);
+    mkdirSync(legacyWorkspace, { recursive: true });
+    if (process.platform !== "win32") {
+      chmodSync(legacyRoot, 0o755);
+      chmodSync(legacyWorkspace, 0o755);
+    }
+
+    expect(
+      resolveScratchWorkspaceCwd(threadId, legacyWorkspace, {
+        workspaceRoot: privateRoot,
+        legacyWorkspaceRoot: legacyRoot,
+      }),
+    ).toBe(legacyWorkspace);
+    if (process.platform !== "win32") {
+      expect(statSync(legacyRoot).mode & 0o777).toBe(0o700);
+      expect(statSync(legacyWorkspace).mode & 0o777).toBe(0o700);
+    }
   });
 
   it("does not let path-like thread ids escape the scratch root", () => {

--- a/apps/server/src/scratchWorkspaces.test.ts
+++ b/apps/server/src/scratchWorkspaces.test.ts
@@ -51,60 +51,6 @@ describe("ensureIsolatedScratchWorkspace", () => {
     }
   });
 
-  it("reuses a validated private workspace in place after the temporary root changes", () => {
-    const threadId = ThreadId.makeUnsafe("prior-private-thread");
-    const currentRoot = path.join(testScratchParent, "current", SCRATCH_WORKSPACES_DIRNAME);
-    const ownerContainerName = path.basename(path.dirname(resolveScratchWorkspacesRoot()));
-    const priorRoot = path.join(
-      testScratchParent,
-      "old-tmp",
-      ownerContainerName,
-      SCRATCH_WORKSPACES_DIRNAME,
-    );
-    const priorWorkspace = ensureIsolatedScratchWorkspace(threadId, priorRoot);
-    writeFileSync(path.join(priorWorkspace, "resume.txt"), "preserved");
-
-    const resumedWorkspace = resolveScratchWorkspaceCwd(threadId, priorWorkspace, {
-      workspaceRoot: currentRoot,
-      legacyWorkspaceRoot: path.join(testScratchParent, "unused-legacy"),
-    });
-
-    expect(resumedWorkspace).toBe(priorWorkspace);
-    expect(readFileSync(path.join(resumedWorkspace, "resume.txt"), "utf8")).toBe("preserved");
-  });
-
-  it.skipIf(process.platform === "win32")(
-    "uses a fresh private workspace when an earlier temporary cwd is a symlink",
-    () => {
-      const threadId = ThreadId.makeUnsafe("unsafe-prior-private-thread");
-      const currentRoot = path.join(testScratchParent, "fresh-current", SCRATCH_WORKSPACES_DIRNAME);
-      const ownerContainerName = path.basename(path.dirname(resolveScratchWorkspacesRoot()));
-      const priorRoot = path.join(
-        testScratchParent,
-        "unsafe-old-tmp",
-        ownerContainerName,
-        SCRATCH_WORKSPACES_DIRNAME,
-      );
-      const priorWorkspace = ensureIsolatedScratchWorkspace(threadId, priorRoot);
-      const redirected = mkdtempSync(path.join(tmpdir(), "synara-prior-redirect-"));
-      try {
-        rmSync(priorWorkspace, { recursive: true, force: true });
-        symlinkSync(redirected, priorWorkspace, "dir");
-
-        const resumedWorkspace = resolveScratchWorkspaceCwd(threadId, priorWorkspace, {
-          workspaceRoot: currentRoot,
-          legacyWorkspaceRoot: path.join(testScratchParent, "unused-legacy"),
-        });
-
-        expect(resumedWorkspace).not.toBe(priorWorkspace);
-        expect(resumedWorkspace.startsWith(`${currentRoot}${path.sep}`)).toBe(true);
-      } finally {
-        rmSync(priorWorkspace, { force: true });
-        rmSync(redirected, { recursive: true, force: true });
-      }
-    },
-  );
-
   it("creates a readable per-thread directory under the scratch root", () => {
     const workspace = ensureTestScratchWorkspace(ThreadId.makeUnsafe("thread-1"));
     try {
@@ -135,10 +81,44 @@ describe("ensureIsolatedScratchWorkspace", () => {
     expect(resumedWorkspace).toBe(legacyWorkspace);
     expect(readFileSync(path.join(resumedWorkspace, "resume.txt"), "utf8")).toBe("preserved");
     if (process.platform !== "win32") {
-      expect(statSync(legacyRoot).mode & 0o1777).toBe(0o777);
+      expect(statSync(legacyRoot).mode & 0o1777).toBe(0o1777);
       expect(statSync(resumedWorkspace).mode & 0o777).toBe(0o700);
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "does not reuse a workspace through an untrusted legacy-root symlink",
+    () => {
+      const threadId = ThreadId.makeUnsafe("symlinked-legacy-root");
+      const privateRoot = path.join(
+        testScratchParent,
+        "private-fallback",
+        SCRATCH_WORKSPACES_DIRNAME,
+      );
+      const legacyRoot = path.join(testScratchParent, "legacy-link");
+      const redirectedRoot = mkdtempSync(path.join(tmpdir(), "synara-legacy-redirect-"));
+      const workspaceSegment = path.basename(
+        ensureIsolatedScratchWorkspace(threadId, privateRoot, redirectedRoot),
+      );
+      rmSync(privateRoot, { recursive: true, force: true });
+      mkdirSync(path.join(redirectedRoot, workspaceSegment), { recursive: true });
+      symlinkSync(redirectedRoot, legacyRoot, "dir");
+      try {
+        const workspace = resolveScratchWorkspaceCwd(
+          threadId,
+          path.join(legacyRoot, workspaceSegment),
+          {
+            workspaceRoot: privateRoot,
+            legacyWorkspaceRoot: legacyRoot,
+          },
+        );
+        expect(workspace).toBe(path.join(privateRoot, workspaceSegment));
+      } finally {
+        rmSync(legacyRoot, { force: true });
+        rmSync(redirectedRoot, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("leaves non-scratch persisted workspaces unchanged", () => {
     const projectCwd = path.join(testScratchParent, "project");

--- a/apps/server/src/scratchWorkspaces.test.ts
+++ b/apps/server/src/scratchWorkspaces.test.ts
@@ -3,7 +3,7 @@
 //          temp root even when thread ids contain path-like characters.
 // Layer: Server filesystem utility tests
 
-import { rmSync } from "node:fs";
+import { rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -35,6 +35,15 @@ describe("ensureIsolatedScratchWorkspace", () => {
       expect(relative.startsWith("..")).toBe(false);
       expect(path.isAbsolute(relative)).toBe(false);
       expect(workspace).not.toContain(`${path.sep}..${path.sep}`);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("uses owner-only permissions on POSIX", () => {
+    const workspace = ensureIsolatedScratchWorkspace(ThreadId.makeUnsafe("private-thread"));
+    try {
+      expect(statSync(workspace).mode & 0o777).toBe(0o700);
     } finally {
       rmSync(workspace, { recursive: true, force: true });
     }

--- a/apps/server/src/scratchWorkspaces.test.ts
+++ b/apps/server/src/scratchWorkspaces.test.ts
@@ -3,7 +3,7 @@
 //          temp root even when thread ids contain path-like characters.
 // Layer: Server filesystem utility tests
 
-import { chmodSync, rmSync, statSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, statSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -62,6 +62,42 @@ describe("ensureIsolatedScratchWorkspace", () => {
         expect(statSync(workspace).mode & 0o777).toBe(0o700);
       } finally {
         rmSync(workspace, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "tightens permissions when reusing the shared scratch root",
+    () => {
+      const workspace = ensureIsolatedScratchWorkspace(ThreadId.makeUnsafe("private-root"));
+      try {
+        chmodSync(scratchRoot(), 0o777);
+
+        ensureIsolatedScratchWorkspace(ThreadId.makeUnsafe("private-root"));
+
+        expect(statSync(scratchRoot()).mode & 0o777).toBe(0o700);
+      } finally {
+        chmodSync(scratchRoot(), 0o700);
+        rmSync(workspace, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "refuses to follow a reused scratch workspace symlink",
+    () => {
+      const threadId = ThreadId.makeUnsafe("symlinked-private-thread");
+      const workspace = ensureIsolatedScratchWorkspace(threadId);
+      const redirected = mkdtempSync(path.join(tmpdir(), "synara-scratch-redirect-"));
+      rmSync(workspace, { recursive: true, force: true });
+      symlinkSync(redirected, workspace, "dir");
+      try {
+        expect(() => ensureIsolatedScratchWorkspace(threadId)).toThrow(
+          /open without following symlinks/,
+        );
+      } finally {
+        rmSync(workspace, { force: true });
+        rmSync(redirected, { recursive: true, force: true });
       }
     },
   );

--- a/apps/server/src/scratchWorkspaces.ts
+++ b/apps/server/src/scratchWorkspaces.ts
@@ -1,8 +1,8 @@
 // FILE: scratchWorkspaces.ts
 // Purpose: Per-thread scratch working directories for provider sessions that
 //          start before any project workspace exists (e.g. a chat's first
-//          turn). The root stays in a per-user OS-temporary container so it is
-//          outside project ancestry and remains eligible for system cleanup.
+//          turn). The root stays in the user's cache so it is outside project
+//          ancestry and outside temporary directories writable by agents.
 // Layer: Server filesystem utility
 // Exports: ensureIsolatedScratchWorkspace
 
@@ -15,15 +15,32 @@ import type { ThreadId } from "@synara/contracts";
 import { SCRATCH_WORKSPACES_DIRNAME } from "@synara/shared/threadWorkspace";
 import { ensurePrivateDirectorySync } from "./privatePathPermissions";
 
-function scratchOwnerSegment(): string {
+function scratchOwnerSegment(homeDirectory = homedir()): string {
   const owner =
-    typeof process.getuid === "function" ? `uid:${String(process.getuid())}` : homedir();
+    typeof process.getuid === "function" ? `uid:${String(process.getuid())}` : homeDirectory;
   return createHash("sha256").update(owner).digest("hex").slice(0, 16);
 }
 
-export function resolveScratchWorkspacesRoot(): string {
-  const privateTempRoot = path.join(tmpdir(), `.synara-${scratchOwnerSegment()}`);
-  return path.join(privateTempRoot, SCRATCH_WORKSPACES_DIRNAME);
+function scratchCacheRoot(homeDirectory: string, platform: NodeJS.Platform): string {
+  if (platform === "darwin") return path.join(homeDirectory, "Library", "Caches", "synara");
+  if (platform === "win32") {
+    return path.join(homeDirectory, "AppData", "Local", "Synara", "Cache");
+  }
+  return path.join(homeDirectory, ".cache", "synara");
+}
+
+export function resolveScratchWorkspacesRoot(
+  options: {
+    readonly homeDirectory?: string;
+    readonly platform?: NodeJS.Platform;
+  } = {},
+): string {
+  const homeDirectory = options.homeDirectory ?? homedir();
+  const ownerContainer = path.join(
+    scratchCacheRoot(homeDirectory, options.platform ?? process.platform),
+    `.synara-${scratchOwnerSegment(homeDirectory)}`,
+  );
+  return path.join(ownerContainer, SCRATCH_WORKSPACES_DIRNAME);
 }
 
 function scratchWorkspaceSegment(threadId: ThreadId): string {
@@ -49,11 +66,8 @@ function isOwnedRealDirectory(directoryPath: string): boolean {
   }
 }
 
-function ensureSafeSharedLegacyRoot(directoryPath: string): boolean {
-  if (process.platform === "win32") {
-    return isOwnedRealDirectory(directoryPath);
-  }
-
+function openOwnedDirectoryDescriptor(directoryPath: string): number | undefined {
+  if (process.platform === "win32") return isOwnedRealDirectory(directoryPath) ? -1 : undefined;
   let descriptor: number;
   try {
     descriptor = openSync(
@@ -62,22 +76,52 @@ function ensureSafeSharedLegacyRoot(directoryPath: string): boolean {
     );
   } catch (cause) {
     if (["ELOOP", "ENOENT", "ENOTDIR"].includes((cause as NodeJS.ErrnoException).code ?? "")) {
-      return false;
+      return undefined;
     }
     throw cause;
   }
-  try {
-    const stat = fstatSync(descriptor);
-    if (!stat.isDirectory()) return false;
-    const writableByOtherUsers = (stat.mode & 0o022) !== 0;
-    const hasStickyBit = (stat.mode & 0o1000) !== 0;
-    if (!writableByOtherUsers || hasStickyBit) return true;
-    if (typeof process.getuid !== "function" || stat.uid !== process.getuid()) return false;
+  const stat = fstatSync(descriptor);
+  if (
+    !stat.isDirectory() ||
+    (typeof process.getuid === "function" && stat.uid !== process.getuid())
+  ) {
+    closeSync(descriptor);
+    return undefined;
+  }
+  return descriptor;
+}
 
-    // Preserve shared access for other legacy users while preventing them from
-    // renaming one another's owned workspace entries.
-    fchmodSync(descriptor, (stat.mode & 0o7777) | 0o1000);
-    return true;
+function ensurePrivateScratchRoot(workspaceRoot: string): void {
+  if (workspaceRoot === resolveScratchWorkspacesRoot()) {
+    const ownerContainer = path.dirname(workspaceRoot);
+    ensurePrivateDirectorySync(path.dirname(ownerContainer));
+    ensurePrivateDirectorySync(ownerContainer);
+  }
+  ensurePrivateDirectorySync(workspaceRoot);
+}
+
+function repairOwnedScratchWorkspace(workspacePath: string): string | undefined {
+  const descriptor = openOwnedDirectoryDescriptor(workspacePath);
+  if (descriptor === undefined) return undefined;
+  if (descriptor === -1) return workspacePath;
+  try {
+    const openedStat = fstatSync(descriptor);
+    fchmodSync(descriptor, 0o700);
+    const currentStat = lstatSync(workspacePath);
+    if (
+      !currentStat.isDirectory() ||
+      currentStat.isSymbolicLink() ||
+      currentStat.dev !== openedStat.dev ||
+      currentStat.ino !== openedStat.ino
+    ) {
+      return undefined;
+    }
+    return workspacePath;
+  } catch (cause) {
+    if (["ELOOP", "ENOENT", "ENOTDIR"].includes((cause as NodeJS.ErrnoException).code ?? "")) {
+      return undefined;
+    }
+    throw cause;
   } finally {
     closeSync(descriptor);
   }
@@ -88,24 +132,11 @@ function repairLegacyScratchWorkspace(
   workspaceSegment: string,
 ): string | undefined {
   const legacyWorkspaceDir = path.join(legacyWorkspaceRoot, workspaceSegment);
-  if (
-    !ensureSafeSharedLegacyRoot(legacyWorkspaceRoot) ||
-    !isOwnedRealDirectory(legacyWorkspaceDir)
-  ) {
-    return undefined;
-  }
-
-  // Preserve historical absolute paths while making the legacy workspace safe
-  // to resume. O_NOFOLLOW inside the helper rejects symlink swaps.
-  ensurePrivateDirectorySync(legacyWorkspaceDir);
-  return legacyWorkspaceDir;
+  return repairOwnedScratchWorkspace(legacyWorkspaceDir);
 }
 
 function ensurePrivateScratchWorkspace(workspaceRoot: string, workspaceSegment: string): string {
-  if (workspaceRoot === resolveScratchWorkspacesRoot()) {
-    ensurePrivateDirectorySync(path.dirname(workspaceRoot));
-  }
-  ensurePrivateDirectorySync(workspaceRoot);
+  ensurePrivateScratchRoot(workspaceRoot);
   const workspaceDir = path.join(workspaceRoot, workspaceSegment);
   ensurePrivateDirectorySync(workspaceDir);
   return workspaceDir;
@@ -152,7 +183,23 @@ export function resolveScratchWorkspaceCwd(
   }
 
   const legacyWorkspace = path.join(legacyWorkspaceRoot, workspaceSegment);
-  if (path.resolve(persistedCwd) !== path.resolve(legacyWorkspace)) return persistedCwd;
+  if (path.resolve(persistedCwd) === path.resolve(legacyWorkspace)) {
+    return (
+      repairOwnedScratchWorkspace(persistedCwd) ??
+      ensurePrivateScratchWorkspace(workspaceRoot, workspaceSegment)
+    );
+  }
 
-  return ensureIsolatedScratchWorkspace(threadId, workspaceRoot, legacyWorkspaceRoot);
+  const persistedWorkspaceRoot = path.dirname(persistedCwd);
+  const persistedOwnerContainer = path.dirname(persistedWorkspaceRoot);
+  const matchesPriorPrivateLayout =
+    path.basename(persistedCwd) === workspaceSegment &&
+    path.basename(persistedWorkspaceRoot) === SCRATCH_WORKSPACES_DIRNAME &&
+    path.basename(persistedOwnerContainer) === `.synara-${scratchOwnerSegment()}`;
+  if (!matchesPriorPrivateLayout) return persistedCwd;
+
+  return (
+    repairOwnedScratchWorkspace(persistedCwd) ??
+    ensurePrivateScratchWorkspace(workspaceRoot, workspaceSegment)
+  );
 }

--- a/apps/server/src/scratchWorkspaces.ts
+++ b/apps/server/src/scratchWorkspaces.ts
@@ -7,12 +7,12 @@
 // Exports: ensureIsolatedScratchWorkspace
 
 import { createHash } from "node:crypto";
-import { chmodSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import type { ThreadId } from "@synara/contracts";
 import { SCRATCH_WORKSPACES_DIRNAME } from "@synara/shared/threadWorkspace";
+import { ensurePrivateDirectorySync } from "./privatePathPermissions";
 
 function scratchWorkspaceSegment(threadId: ThreadId): string {
   const raw = String(threadId);
@@ -27,9 +27,7 @@ function scratchWorkspaceSegment(threadId: ThreadId): string {
 export function ensureIsolatedScratchWorkspace(threadId: ThreadId): string {
   const workspaceRoot = path.join(tmpdir(), SCRATCH_WORKSPACES_DIRNAME);
   const workspaceDir = path.join(workspaceRoot, scratchWorkspaceSegment(threadId));
-  mkdirSync(workspaceDir, { recursive: true, mode: 0o700 });
-  if (process.platform !== "win32") {
-    chmodSync(workspaceDir, 0o700);
-  }
+  ensurePrivateDirectorySync(workspaceRoot);
+  ensurePrivateDirectorySync(workspaceDir);
   return workspaceDir;
 }

--- a/apps/server/src/scratchWorkspaces.ts
+++ b/apps/server/src/scratchWorkspaces.ts
@@ -127,10 +127,41 @@ function repairOwnedScratchWorkspace(workspacePath: string): string | undefined 
   }
 }
 
+function secureOwnedLegacyRoot(legacyWorkspaceRoot: string): boolean {
+  const descriptor = openOwnedDirectoryDescriptor(legacyWorkspaceRoot);
+  if (descriptor === undefined) return false;
+  if (descriptor === -1) return true;
+  try {
+    const openedStat = fstatSync(descriptor);
+    const writableByOtherUsers = (openedStat.mode & 0o022) !== 0;
+    const hasStickyBit = (openedStat.mode & 0o1000) !== 0;
+    if (writableByOtherUsers && !hasStickyBit) {
+      // Keep legacy multi-user access, but prevent other users from replacing
+      // an owned workspace entry between validation and provider startup.
+      fchmodSync(descriptor, (openedStat.mode & 0o7777) | 0o1000);
+    }
+    const currentStat = lstatSync(legacyWorkspaceRoot);
+    return (
+      currentStat.isDirectory() &&
+      !currentStat.isSymbolicLink() &&
+      currentStat.dev === openedStat.dev &&
+      currentStat.ino === openedStat.ino
+    );
+  } catch (cause) {
+    if (["ELOOP", "ENOENT", "ENOTDIR"].includes((cause as NodeJS.ErrnoException).code ?? "")) {
+      return false;
+    }
+    throw cause;
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
 function repairLegacyScratchWorkspace(
   legacyWorkspaceRoot: string,
   workspaceSegment: string,
 ): string | undefined {
+  if (!secureOwnedLegacyRoot(legacyWorkspaceRoot)) return undefined;
   const legacyWorkspaceDir = path.join(legacyWorkspaceRoot, workspaceSegment);
   return repairOwnedScratchWorkspace(legacyWorkspaceDir);
 }
@@ -185,21 +216,10 @@ export function resolveScratchWorkspaceCwd(
   const legacyWorkspace = path.join(legacyWorkspaceRoot, workspaceSegment);
   if (path.resolve(persistedCwd) === path.resolve(legacyWorkspace)) {
     return (
-      repairOwnedScratchWorkspace(persistedCwd) ??
+      repairLegacyScratchWorkspace(legacyWorkspaceRoot, workspaceSegment) ??
       ensurePrivateScratchWorkspace(workspaceRoot, workspaceSegment)
     );
   }
 
-  const persistedWorkspaceRoot = path.dirname(persistedCwd);
-  const persistedOwnerContainer = path.dirname(persistedWorkspaceRoot);
-  const matchesPriorPrivateLayout =
-    path.basename(persistedCwd) === workspaceSegment &&
-    path.basename(persistedWorkspaceRoot) === SCRATCH_WORKSPACES_DIRNAME &&
-    path.basename(persistedOwnerContainer) === `.synara-${scratchOwnerSegment()}`;
-  if (!matchesPriorPrivateLayout) return persistedCwd;
-
-  return (
-    repairOwnedScratchWorkspace(persistedCwd) ??
-    ensurePrivateScratchWorkspace(workspaceRoot, workspaceSegment)
-  );
+  return persistedCwd;
 }

--- a/apps/server/src/scratchWorkspaces.ts
+++ b/apps/server/src/scratchWorkspaces.ts
@@ -7,6 +7,7 @@
 // Exports: ensureIsolatedScratchWorkspace
 
 import { createHash } from "node:crypto";
+import { lstatSync, renameSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 
@@ -22,7 +23,6 @@ function scratchOwnerSegment(): string {
 
 export function resolveScratchWorkspacesRoot(): string {
   const privateTempRoot = path.join(tmpdir(), `.synara-${scratchOwnerSegment()}`);
-  ensurePrivateDirectorySync(privateTempRoot);
   return path.join(privateTempRoot, SCRATCH_WORKSPACES_DIRNAME);
 }
 
@@ -36,12 +36,64 @@ function scratchWorkspaceSegment(threadId: ThreadId): string {
   return `${safePrefix || "thread"}-${digest}`;
 }
 
+function isOwnedRealDirectory(directoryPath: string): boolean {
+  try {
+    const stat = lstatSync(directoryPath);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    return typeof process.getuid !== "function" || stat.uid === process.getuid();
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw cause;
+  }
+}
+
+function migrateLegacyScratchWorkspace(
+  legacyWorkspaceRoot: string,
+  workspaceRoot: string,
+  workspaceSegment: string,
+): void {
+  const workspaceDir = path.join(workspaceRoot, workspaceSegment);
+  const legacyWorkspaceDir = path.join(legacyWorkspaceRoot, workspaceSegment);
+  if (
+    isOwnedRealDirectory(workspaceDir) ||
+    !isOwnedRealDirectory(legacyWorkspaceRoot) ||
+    !isOwnedRealDirectory(legacyWorkspaceDir)
+  ) {
+    return;
+  }
+
+  // Tighten both old paths before moving user content out of the former
+  // process-wide temp root. O_NOFOLLOW inside the helper rejects symlink swaps.
+  ensurePrivateDirectorySync(legacyWorkspaceRoot);
+  ensurePrivateDirectorySync(legacyWorkspaceDir);
+  try {
+    renameSync(legacyWorkspaceDir, workspaceDir);
+  } catch (cause) {
+    // Another concurrent session may have completed the same migration.
+    if (!isOwnedRealDirectory(workspaceDir)) throw cause;
+  }
+}
+
 export function ensureIsolatedScratchWorkspace(
   threadId: ThreadId,
   workspaceRoot = resolveScratchWorkspacesRoot(),
+  legacyWorkspaceRoot?: string,
 ): string {
-  const workspaceDir = path.join(workspaceRoot, scratchWorkspaceSegment(threadId));
+  const defaultWorkspaceRoot = resolveScratchWorkspacesRoot();
+  const workspaceSegment = scratchWorkspaceSegment(threadId);
+  const workspaceDir = path.join(workspaceRoot, workspaceSegment);
+  if (workspaceRoot === defaultWorkspaceRoot) {
+    ensurePrivateDirectorySync(path.dirname(workspaceRoot));
+  }
   ensurePrivateDirectorySync(workspaceRoot);
+  const legacyRoot =
+    legacyWorkspaceRoot ??
+    (workspaceRoot === defaultWorkspaceRoot
+      ? path.join(tmpdir(), SCRATCH_WORKSPACES_DIRNAME)
+      : undefined);
+  if (legacyRoot) {
+    migrateLegacyScratchWorkspace(legacyRoot, workspaceRoot, workspaceSegment);
+  }
   ensurePrivateDirectorySync(workspaceDir);
   return workspaceDir;
 }

--- a/apps/server/src/scratchWorkspaces.ts
+++ b/apps/server/src/scratchWorkspaces.ts
@@ -1,17 +1,30 @@
 // FILE: scratchWorkspaces.ts
 // Purpose: Per-thread scratch working directories for provider sessions that
 //          start before any project workspace exists (e.g. a chat's first
-//          turn). The production root lives inside Synara's private state tree.
+//          turn). The root stays in a per-user OS-temporary container so it is
+//          outside project ancestry and remains eligible for system cleanup.
 // Layer: Server filesystem utility
 // Exports: ensureIsolatedScratchWorkspace
 
 import { createHash } from "node:crypto";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 
 import type { ThreadId } from "@synara/contracts";
-import { resolveSynaraHomeDirectory } from "@synara/shared/synaraHome";
 import { SCRATCH_WORKSPACES_DIRNAME } from "@synara/shared/threadWorkspace";
 import { ensurePrivateDirectorySync } from "./privatePathPermissions";
+
+function scratchOwnerSegment(): string {
+  const owner =
+    typeof process.getuid === "function" ? `uid:${String(process.getuid())}` : homedir();
+  return createHash("sha256").update(owner).digest("hex").slice(0, 16);
+}
+
+export function resolveScratchWorkspacesRoot(): string {
+  const privateTempRoot = path.join(tmpdir(), `.synara-${scratchOwnerSegment()}`);
+  ensurePrivateDirectorySync(privateTempRoot);
+  return path.join(privateTempRoot, SCRATCH_WORKSPACES_DIRNAME);
+}
 
 function scratchWorkspaceSegment(threadId: ThreadId): string {
   const raw = String(threadId);
@@ -25,7 +38,7 @@ function scratchWorkspaceSegment(threadId: ThreadId): string {
 
 export function ensureIsolatedScratchWorkspace(
   threadId: ThreadId,
-  workspaceRoot = path.join(resolveSynaraHomeDirectory(), SCRATCH_WORKSPACES_DIRNAME),
+  workspaceRoot = resolveScratchWorkspacesRoot(),
 ): string {
   const workspaceDir = path.join(workspaceRoot, scratchWorkspaceSegment(threadId));
   ensurePrivateDirectorySync(workspaceRoot);

--- a/apps/server/src/scratchWorkspaces.ts
+++ b/apps/server/src/scratchWorkspaces.ts
@@ -7,7 +7,7 @@
 // Exports: ensureIsolatedScratchWorkspace
 
 import { createHash } from "node:crypto";
-import { lstatSync, renameSync } from "node:fs";
+import { lstatSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 
@@ -47,31 +47,20 @@ function isOwnedRealDirectory(directoryPath: string): boolean {
   }
 }
 
-function migrateLegacyScratchWorkspace(
+function repairLegacyScratchWorkspace(
   legacyWorkspaceRoot: string,
-  workspaceRoot: string,
   workspaceSegment: string,
-): void {
-  const workspaceDir = path.join(workspaceRoot, workspaceSegment);
+): string | undefined {
   const legacyWorkspaceDir = path.join(legacyWorkspaceRoot, workspaceSegment);
-  if (
-    isOwnedRealDirectory(workspaceDir) ||
-    !isOwnedRealDirectory(legacyWorkspaceRoot) ||
-    !isOwnedRealDirectory(legacyWorkspaceDir)
-  ) {
-    return;
+  if (!isOwnedRealDirectory(legacyWorkspaceRoot) || !isOwnedRealDirectory(legacyWorkspaceDir)) {
+    return undefined;
   }
 
-  // Tighten both old paths before moving user content out of the former
-  // process-wide temp root. O_NOFOLLOW inside the helper rejects symlink swaps.
+  // Preserve historical absolute paths while making the legacy workspace safe
+  // to resume. O_NOFOLLOW inside the helper rejects symlink swaps.
   ensurePrivateDirectorySync(legacyWorkspaceRoot);
   ensurePrivateDirectorySync(legacyWorkspaceDir);
-  try {
-    renameSync(legacyWorkspaceDir, workspaceDir);
-  } catch (cause) {
-    // Another concurrent session may have completed the same migration.
-    if (!isOwnedRealDirectory(workspaceDir)) throw cause;
-  }
+  return legacyWorkspaceDir;
 }
 
 export function ensureIsolatedScratchWorkspace(
@@ -82,18 +71,40 @@ export function ensureIsolatedScratchWorkspace(
   const defaultWorkspaceRoot = resolveScratchWorkspacesRoot();
   const workspaceSegment = scratchWorkspaceSegment(threadId);
   const workspaceDir = path.join(workspaceRoot, workspaceSegment);
-  if (workspaceRoot === defaultWorkspaceRoot) {
-    ensurePrivateDirectorySync(path.dirname(workspaceRoot));
-  }
-  ensurePrivateDirectorySync(workspaceRoot);
   const legacyRoot =
     legacyWorkspaceRoot ??
     (workspaceRoot === defaultWorkspaceRoot
       ? path.join(tmpdir(), SCRATCH_WORKSPACES_DIRNAME)
       : undefined);
   if (legacyRoot) {
-    migrateLegacyScratchWorkspace(legacyRoot, workspaceRoot, workspaceSegment);
+    const repairedLegacyWorkspace = repairLegacyScratchWorkspace(legacyRoot, workspaceSegment);
+    if (repairedLegacyWorkspace) return repairedLegacyWorkspace;
   }
+  if (workspaceRoot === defaultWorkspaceRoot) {
+    ensurePrivateDirectorySync(path.dirname(workspaceRoot));
+  }
+  ensurePrivateDirectorySync(workspaceRoot);
   ensurePrivateDirectorySync(workspaceDir);
   return workspaceDir;
+}
+
+export function resolveScratchWorkspaceCwd(
+  threadId: ThreadId,
+  persistedCwd?: string,
+  roots: {
+    readonly workspaceRoot?: string;
+    readonly legacyWorkspaceRoot?: string;
+  } = {},
+): string {
+  const workspaceRoot = roots.workspaceRoot ?? resolveScratchWorkspacesRoot();
+  const legacyWorkspaceRoot =
+    roots.legacyWorkspaceRoot ?? path.join(tmpdir(), SCRATCH_WORKSPACES_DIRNAME);
+  if (!persistedCwd) {
+    return ensureIsolatedScratchWorkspace(threadId, workspaceRoot, legacyWorkspaceRoot);
+  }
+
+  const legacyWorkspace = path.join(legacyWorkspaceRoot, scratchWorkspaceSegment(threadId));
+  if (path.resolve(persistedCwd) !== path.resolve(legacyWorkspace)) return persistedCwd;
+
+  return ensureIsolatedScratchWorkspace(threadId, workspaceRoot, legacyWorkspaceRoot);
 }

--- a/apps/server/src/scratchWorkspaces.ts
+++ b/apps/server/src/scratchWorkspaces.ts
@@ -1,16 +1,15 @@
 // FILE: scratchWorkspaces.ts
 // Purpose: Per-thread scratch working directories for provider sessions that
 //          start before any project workspace exists (e.g. a chat's first
-//          turn). Files agents create here are workspace-equivalent, so the
-//          local-preview allowlist also treats this root as servable.
+//          turn). The production root lives inside Synara's private state tree.
 // Layer: Server filesystem utility
 // Exports: ensureIsolatedScratchWorkspace
 
 import { createHash } from "node:crypto";
-import { tmpdir } from "node:os";
 import path from "node:path";
 
 import type { ThreadId } from "@synara/contracts";
+import { resolveSynaraHomeDirectory } from "@synara/shared/synaraHome";
 import { SCRATCH_WORKSPACES_DIRNAME } from "@synara/shared/threadWorkspace";
 import { ensurePrivateDirectorySync } from "./privatePathPermissions";
 
@@ -24,8 +23,10 @@ function scratchWorkspaceSegment(threadId: ThreadId): string {
   return `${safePrefix || "thread"}-${digest}`;
 }
 
-export function ensureIsolatedScratchWorkspace(threadId: ThreadId): string {
-  const workspaceRoot = path.join(tmpdir(), SCRATCH_WORKSPACES_DIRNAME);
+export function ensureIsolatedScratchWorkspace(
+  threadId: ThreadId,
+  workspaceRoot = path.join(resolveSynaraHomeDirectory(), SCRATCH_WORKSPACES_DIRNAME),
+): string {
   const workspaceDir = path.join(workspaceRoot, scratchWorkspaceSegment(threadId));
   ensurePrivateDirectorySync(workspaceRoot);
   ensurePrivateDirectorySync(workspaceDir);

--- a/apps/server/src/scratchWorkspaces.ts
+++ b/apps/server/src/scratchWorkspaces.ts
@@ -27,6 +27,6 @@ function scratchWorkspaceSegment(threadId: ThreadId): string {
 export function ensureIsolatedScratchWorkspace(threadId: ThreadId): string {
   const workspaceRoot = path.join(tmpdir(), SCRATCH_WORKSPACES_DIRNAME);
   const workspaceDir = path.join(workspaceRoot, scratchWorkspaceSegment(threadId));
-  mkdirSync(workspaceDir, { recursive: true });
+  mkdirSync(workspaceDir, { recursive: true, mode: 0o700 });
   return workspaceDir;
 }

--- a/apps/server/src/scratchWorkspaces.ts
+++ b/apps/server/src/scratchWorkspaces.ts
@@ -7,7 +7,7 @@
 // Exports: ensureIsolatedScratchWorkspace
 
 import { createHash } from "node:crypto";
-import { mkdirSync } from "node:fs";
+import { chmodSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -28,5 +28,8 @@ export function ensureIsolatedScratchWorkspace(threadId: ThreadId): string {
   const workspaceRoot = path.join(tmpdir(), SCRATCH_WORKSPACES_DIRNAME);
   const workspaceDir = path.join(workspaceRoot, scratchWorkspaceSegment(threadId));
   mkdirSync(workspaceDir, { recursive: true, mode: 0o700 });
+  if (process.platform !== "win32") {
+    chmodSync(workspaceDir, 0o700);
+  }
   return workspaceDir;
 }

--- a/apps/server/src/scratchWorkspaces.ts
+++ b/apps/server/src/scratchWorkspaces.ts
@@ -7,7 +7,7 @@
 // Exports: ensureIsolatedScratchWorkspace
 
 import { createHash } from "node:crypto";
-import { lstatSync } from "node:fs";
+import { closeSync, constants, fchmodSync, fstatSync, lstatSync, openSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 
@@ -42,8 +42,44 @@ function isOwnedRealDirectory(directoryPath: string): boolean {
     if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
     return typeof process.getuid !== "function" || stat.uid === process.getuid();
   } catch (cause) {
-    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return false;
+    if (["ELOOP", "ENOENT", "ENOTDIR"].includes((cause as NodeJS.ErrnoException).code ?? "")) {
+      return false;
+    }
     throw cause;
+  }
+}
+
+function ensureSafeSharedLegacyRoot(directoryPath: string): boolean {
+  if (process.platform === "win32") {
+    return isOwnedRealDirectory(directoryPath);
+  }
+
+  let descriptor: number;
+  try {
+    descriptor = openSync(
+      directoryPath,
+      constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+    );
+  } catch (cause) {
+    if (["ELOOP", "ENOENT", "ENOTDIR"].includes((cause as NodeJS.ErrnoException).code ?? "")) {
+      return false;
+    }
+    throw cause;
+  }
+  try {
+    const stat = fstatSync(descriptor);
+    if (!stat.isDirectory()) return false;
+    const writableByOtherUsers = (stat.mode & 0o022) !== 0;
+    const hasStickyBit = (stat.mode & 0o1000) !== 0;
+    if (!writableByOtherUsers || hasStickyBit) return true;
+    if (typeof process.getuid !== "function" || stat.uid !== process.getuid()) return false;
+
+    // Preserve shared access for other legacy users while preventing them from
+    // renaming one another's owned workspace entries.
+    fchmodSync(descriptor, (stat.mode & 0o7777) | 0o1000);
+    return true;
+  } finally {
+    closeSync(descriptor);
   }
 }
 
@@ -52,15 +88,27 @@ function repairLegacyScratchWorkspace(
   workspaceSegment: string,
 ): string | undefined {
   const legacyWorkspaceDir = path.join(legacyWorkspaceRoot, workspaceSegment);
-  if (!isOwnedRealDirectory(legacyWorkspaceRoot) || !isOwnedRealDirectory(legacyWorkspaceDir)) {
+  if (
+    !ensureSafeSharedLegacyRoot(legacyWorkspaceRoot) ||
+    !isOwnedRealDirectory(legacyWorkspaceDir)
+  ) {
     return undefined;
   }
 
   // Preserve historical absolute paths while making the legacy workspace safe
   // to resume. O_NOFOLLOW inside the helper rejects symlink swaps.
-  ensurePrivateDirectorySync(legacyWorkspaceRoot);
   ensurePrivateDirectorySync(legacyWorkspaceDir);
   return legacyWorkspaceDir;
+}
+
+function ensurePrivateScratchWorkspace(workspaceRoot: string, workspaceSegment: string): string {
+  if (workspaceRoot === resolveScratchWorkspacesRoot()) {
+    ensurePrivateDirectorySync(path.dirname(workspaceRoot));
+  }
+  ensurePrivateDirectorySync(workspaceRoot);
+  const workspaceDir = path.join(workspaceRoot, workspaceSegment);
+  ensurePrivateDirectorySync(workspaceDir);
+  return workspaceDir;
 }
 
 export function ensureIsolatedScratchWorkspace(
@@ -70,7 +118,6 @@ export function ensureIsolatedScratchWorkspace(
 ): string {
   const defaultWorkspaceRoot = resolveScratchWorkspacesRoot();
   const workspaceSegment = scratchWorkspaceSegment(threadId);
-  const workspaceDir = path.join(workspaceRoot, workspaceSegment);
   const legacyRoot =
     legacyWorkspaceRoot ??
     (workspaceRoot === defaultWorkspaceRoot
@@ -80,12 +127,7 @@ export function ensureIsolatedScratchWorkspace(
     const repairedLegacyWorkspace = repairLegacyScratchWorkspace(legacyRoot, workspaceSegment);
     if (repairedLegacyWorkspace) return repairedLegacyWorkspace;
   }
-  if (workspaceRoot === defaultWorkspaceRoot) {
-    ensurePrivateDirectorySync(path.dirname(workspaceRoot));
-  }
-  ensurePrivateDirectorySync(workspaceRoot);
-  ensurePrivateDirectorySync(workspaceDir);
-  return workspaceDir;
+  return ensurePrivateScratchWorkspace(workspaceRoot, workspaceSegment);
 }
 
 export function resolveScratchWorkspaceCwd(
@@ -99,11 +141,17 @@ export function resolveScratchWorkspaceCwd(
   const workspaceRoot = roots.workspaceRoot ?? resolveScratchWorkspacesRoot();
   const legacyWorkspaceRoot =
     roots.legacyWorkspaceRoot ?? path.join(tmpdir(), SCRATCH_WORKSPACES_DIRNAME);
+  const workspaceSegment = scratchWorkspaceSegment(threadId);
   if (!persistedCwd) {
     return ensureIsolatedScratchWorkspace(threadId, workspaceRoot, legacyWorkspaceRoot);
   }
 
-  const legacyWorkspace = path.join(legacyWorkspaceRoot, scratchWorkspaceSegment(threadId));
+  const privateWorkspace = path.join(workspaceRoot, workspaceSegment);
+  if (path.resolve(persistedCwd) === path.resolve(privateWorkspace)) {
+    return ensurePrivateScratchWorkspace(workspaceRoot, workspaceSegment);
+  }
+
+  const legacyWorkspace = path.join(legacyWorkspaceRoot, workspaceSegment);
   if (path.resolve(persistedCwd) !== path.resolve(legacyWorkspace)) return persistedCwd;
 
   return ensureIsolatedScratchWorkspace(threadId, workspaceRoot, legacyWorkspaceRoot);

--- a/packages/shared/src/threadWorkspace.ts
+++ b/packages/shared/src/threadWorkspace.ts
@@ -96,9 +96,9 @@ export function isWorkspaceRootWithin(
   return normalizedCandidate.startsWith(prefix);
 }
 
-// Per-thread scratch working directories used when a provider session starts
-// before any project workspace exists, e.g. a chat's first turn racing its
-// workspace provisioning.
+// Per-thread scratch working directories (under a per-user OS temp container)
+// used when a provider session starts before any project workspace exists,
+// e.g. a chat's first turn racing its workspace provisioning.
 export const SCRATCH_WORKSPACES_DIRNAME = "synara-codex-workspaces";
 
 // True when an absolute path points inside a per-thread scratch workspace.

--- a/packages/shared/src/threadWorkspace.ts
+++ b/packages/shared/src/threadWorkspace.ts
@@ -96,7 +96,7 @@ export function isWorkspaceRootWithin(
   return normalizedCandidate.startsWith(prefix);
 }
 
-// Per-thread scratch working directories (under a per-user OS temp container)
+// Per-thread scratch working directories (under a per-user cache container)
 // used when a provider session starts before any project workspace exists,
 // e.g. a chat's first turn racing its workspace provisioning.
 export const SCRATCH_WORKSPACES_DIRNAME = "synara-codex-workspaces";

--- a/packages/shared/src/threadWorkspace.ts
+++ b/packages/shared/src/threadWorkspace.ts
@@ -96,9 +96,9 @@ export function isWorkspaceRootWithin(
   return normalizedCandidate.startsWith(prefix);
 }
 
-// Per-thread scratch working directories (under the OS temp dir) used when a
-// provider session starts before any project workspace exists, e.g. a chat's
-// first turn racing its workspace provisioning.
+// Per-thread scratch working directories used when a provider session starts
+// before any project workspace exists, e.g. a chat's first turn racing its
+// workspace provisioning.
 export const SCRATCH_WORKSPACES_DIRNAME = "synara-codex-workspaces";
 
 // True when an absolute path points inside a per-thread scratch workspace.


### PR DESCRIPTION
## Summary

Per-thread scratch workspaces are created under the system temp directory and can contain the same agent-created files as a normal workspace. They were created with the platform/default mkdir mode, which on typical POSIX systems can leave a new directory readable/traversable by other local users depending on the process umask.

This PR creates new scratch workspace directories with owner-only permissions (`0700`) on POSIX-compatible filesystems.

## What changed

- pass `mode: 0o700` when recursively creating a scratch workspace;
- add POSIX regression coverage for the resulting permission bits;
- leave Windows behavior unchanged (the permission assertion is skipped there).

## Validation

Added focused coverage in `scratchWorkspaces.test.ts`. Repository CI will run the test suite.

## Scope

2 small server files. No workspace naming, routing, provider, persistence, or UI changes.