### PR TITLE
fix(server): preserve extensions from multi-dot attachment names

### DIFF
--- a/apps/server/src/imageMime.test.ts
+++ b/apps/server/src/imageMime.test.ts
@@ -40,4 +40,16 @@ describe("imageMime", () => {
     expect(inferAttachmentExtension({ mimeType: "application/pdf" })).toBe(".pdf");
     expect(inferAttachmentExtension({ mimeType: "text/plain" })).toBe(".txt");
   });
+
+  it("preserves the final extension from multi-dot attachment filenames", () => {
+    expect(
+      inferAttachmentExtension({ mimeType: "application/octet-stream", fileName: "archive.tar.gz" }),
+    ).toBe(".gz");
+  });
+
+  it("does not treat a dotfile name as an attachment extension", () => {
+    expect(
+      inferAttachmentExtension({ mimeType: "application/octet-stream", fileName: ".env" }),
+    ).toBe(".bin");
+  });
 });

--- a/apps/server/src/imageMime.test.ts
+++ b/apps/server/src/imageMime.test.ts
@@ -43,13 +43,19 @@ describe("imageMime", () => {
 
   it("preserves the final extension from multi-dot attachment filenames", () => {
     expect(
-      inferAttachmentExtension({ mimeType: "application/octet-stream", fileName: "archive.tar.gz" }),
+      inferAttachmentExtension({
+        mimeType: "application/octet-stream",
+        fileName: "archive.tar.gz",
+      }),
     ).toBe(".gz");
   });
 
   it("does not treat a dotfile name as an attachment extension", () => {
     expect(
-      inferAttachmentExtension({ mimeType: "application/octet-stream", fileName: ".env" }),
+      inferAttachmentExtension({
+        mimeType: "application/octet-stream",
+        fileName: ".env",
+      }),
     ).toBe(".bin");
   });
 });

--- a/apps/server/src/imageMime.ts
+++ b/apps/server/src/imageMime.ts
@@ -81,7 +81,7 @@ export function inferImageExtension(input: { mimeType: string; fileName?: string
 export function inferAttachmentExtension(input: { mimeType: string; fileName?: string }): string {
   const fileName = input.fileName?.trim() ?? "";
   if (fileName.length > 0 && !/[\\/]/.test(fileName)) {
-    const extensionMatch = /^.[^.]*\.([a-z0-9]{1,8})$/i.exec(fileName);
+    const extensionMatch = /^.+\.([a-z0-9]{1,8})$/i.exec(fileName);
     const extension = extensionMatch?.[1]?.toLowerCase();
     if (extension && /^[a-z0-9]{1,8}$/.test(extension)) {
       return `.${extension}`;


### PR DESCRIPTION
## Summary

`inferAttachmentExtension` only accepted filenames with a single dot before the extension. Multi-dot names such as `archive.tar.gz` therefore ignored the user filename and fell back to the MIME-derived extension, which can be `.bin` for generic uploads.

This PR keeps the same final-extension validation but allows earlier dots in the basename.

## What changed

- accept the final 1–8 character alphanumeric extension from multi-dot filenames;
- keep path separators rejected;
- keep dotfiles such as `.env` from being treated as having an extension;
- add focused regressions for both cases.

## Validation

Added focused unit coverage in `imageMime.test.ts`. Repository CI will run the test suite.

## Scope

2 server MIME helper files. No attachment storage format, upload protocol, UI, or dependency changes.