### PR TITLE
fix(server): decode process output across UTF-8 chunk boundaries

### DIFF
--- a/apps/server/src/processRunner.test.ts
+++ b/apps/server/src/processRunner.test.ts
@@ -21,6 +21,31 @@ describe("runProcess", () => {
     expect(result.stderrTruncated).toBe(false);
   });
 
+  it("does not emit a replacement character when truncation splits UTF-8 output", async () => {
+    const result = await runProcess("node", ["-e", "process.stdout.write('ab€cd')"], {
+      maxBufferBytes: 4,
+      outputMode: "truncate",
+    });
+
+    expect(result.stdout).toBe("ab");
+    expect(result.stdoutTruncated).toBe(true);
+  });
+
+  it("preserves UTF-8 characters split across process chunks and live observers", async () => {
+    const stdoutChunks: string[] = [];
+    const result = await runProcess(
+      "node",
+      [
+        "-e",
+        "process.stdout.write(Buffer.from([0xe2])); setTimeout(() => process.stdout.write(Buffer.from([0x82, 0xac])), 25)",
+      ],
+      { onStdoutChunk: (chunk) => stdoutChunks.push(chunk) },
+    );
+
+    expect(result.stdout).toBe("€");
+    expect(stdoutChunks.join("")).toBe("€");
+  });
+
   it("reports live stdout and stderr chunks while retaining the final output", async () => {
     const stdoutChunks: string[] = [];
     const stderrChunks: string[] = [];

--- a/apps/server/src/processRunner.ts
+++ b/apps/server/src/processRunner.ts
@@ -1,4 +1,5 @@
 import { type ChildProcess as ChildProcessHandle, spawn, spawnSync } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
 import { prepareWindowsSafeProcess } from "@synara/shared/windowsProcess";
 
 export interface ProcessRunOptions {
@@ -109,6 +110,7 @@ function appendChunkWithinLimit(
   currentBytes: number,
   chunk: Buffer,
   maxBytes: number,
+  decoder: StringDecoder,
 ): {
   next: string;
   nextBytes: number;
@@ -118,17 +120,11 @@ function appendChunkWithinLimit(
   if (remaining <= 0) {
     return { next: target, nextBytes: currentBytes, truncated: true };
   }
-  if (chunk.length <= remaining) {
-    return {
-      next: `${target}${chunk.toString()}`,
-      nextBytes: currentBytes + chunk.length,
-      truncated: false,
-    };
-  }
+  const accepted = chunk.length <= remaining ? chunk : chunk.subarray(0, remaining);
   return {
-    next: `${target}${chunk.subarray(0, remaining).toString()}`,
-    nextBytes: currentBytes + remaining,
-    truncated: true,
+    next: `${target}${decoder.write(accepted)}`,
+    nextBytes: currentBytes + accepted.length,
+    truncated: chunk.length > remaining,
   };
 }
 
@@ -170,6 +166,10 @@ export async function runProcess(
     let settled = false;
     let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
     let forceKillTimer: ReturnType<typeof setTimeout> | null = null;
+    const stdoutDecoder = new StringDecoder("utf8");
+    const stderrDecoder = new StringDecoder("utf8");
+    const stdoutObserverDecoder = options.onStdoutChunk ? new StringDecoder("utf8") : null;
+    const stderrObserverDecoder = options.onStderrChunk ? new StringDecoder("utf8") : null;
 
     const scheduleForceKill = (): void => {
       if (forceKillTimer) clearTimeout(forceKillTimer);
@@ -220,30 +220,41 @@ export async function runProcess(
     const appendOutput = (stream: "stdout" | "stderr", chunk: Buffer | string): Error | null => {
       if (aborted) return null;
       const chunkBuffer = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
-      const text = chunkBuffer.toString();
       const byteLength = chunkBuffer.length;
       if (stream === "stdout") {
         if (outputMode === "truncate") {
-          const appended = appendChunkWithinLimit(stdout, stdoutBytes, chunkBuffer, maxBufferBytes);
+          const appended = appendChunkWithinLimit(
+            stdout,
+            stdoutBytes,
+            chunkBuffer,
+            maxBufferBytes,
+            stdoutDecoder,
+          );
           stdout = appended.next;
           stdoutBytes = appended.nextBytes;
           stdoutTruncated = stdoutTruncated || appended.truncated;
           return null;
         }
-        stdout += text;
+        stdout += stdoutDecoder.write(chunkBuffer);
         stdoutBytes += byteLength;
         if (stdoutBytes > maxBufferBytes) {
           return normalizeBufferError(command, args, "stdout", maxBufferBytes);
         }
       } else {
         if (outputMode === "truncate") {
-          const appended = appendChunkWithinLimit(stderr, stderrBytes, chunkBuffer, maxBufferBytes);
+          const appended = appendChunkWithinLimit(
+            stderr,
+            stderrBytes,
+            chunkBuffer,
+            maxBufferBytes,
+            stderrDecoder,
+          );
           stderr = appended.next;
           stderrBytes = appended.nextBytes;
           stderrTruncated = stderrTruncated || appended.truncated;
           return null;
         }
-        stderr += text;
+        stderr += stderrDecoder.write(chunkBuffer);
         stderrBytes += byteLength;
         if (stderrBytes > maxBufferBytes) {
           return normalizeBufferError(command, args, "stderr", maxBufferBytes);
@@ -254,18 +265,33 @@ export async function runProcess(
 
     const notifyOutputObserver = (
       observer: ((chunk: string) => void) | undefined,
+      decoder: StringDecoder | null,
       chunk: Buffer | string,
     ): void => {
-      if (!observer) return;
+      if (!observer || !decoder) return;
       try {
-        observer(chunk.toString());
+        const text = decoder.write(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+        if (text.length > 0) observer(text);
+      } catch {
+        // Live-output observers are best effort and must never crash the child-process lifecycle.
+      }
+    };
+
+    const flushOutputObserver = (
+      observer: ((chunk: string) => void) | undefined,
+      decoder: StringDecoder | null,
+    ): void => {
+      if (!observer || !decoder) return;
+      try {
+        const text = decoder.end();
+        if (text.length > 0) observer(text);
       } catch {
         // Live-output observers are best effort and must never crash the child-process lifecycle.
       }
     };
 
     child.stdout.on("data", (chunk: Buffer | string) => {
-      notifyOutputObserver(options.onStdoutChunk, chunk);
+      notifyOutputObserver(options.onStdoutChunk, stdoutObserverDecoder, chunk);
       const error = appendOutput("stdout", chunk);
       if (error) {
         fail(error);
@@ -273,7 +299,7 @@ export async function runProcess(
     });
 
     child.stderr.on("data", (chunk: Buffer | string) => {
-      notifyOutputObserver(options.onStderrChunk, chunk);
+      notifyOutputObserver(options.onStderrChunk, stderrObserverDecoder, chunk);
       const error = appendOutput("stderr", chunk);
       if (error) {
         fail(error);
@@ -287,6 +313,11 @@ export async function runProcess(
     });
 
     child.once("close", (code, signal) => {
+      if (!stdoutTruncated) stdout += stdoutDecoder.end();
+      if (!stderrTruncated) stderr += stderrDecoder.end();
+      flushOutputObserver(options.onStdoutChunk, stdoutObserverDecoder);
+      flushOutputObserver(options.onStderrChunk, stderrObserverDecoder);
+
       const result: ProcessRunResult = {
         stdout,
         stderr,


### PR DESCRIPTION
## Summary

`runProcess` decoded each `stdout`/`stderr` data event independently with `Buffer.toString()`. UTF-8 code points can be split across pipe chunks, so a valid multi-byte character could become replacement characters in both retained output and live output observers. Truncate mode could also cut a code point at the byte cap and append `�`.

This PR uses a stateful UTF-8 decoder per stream and per live observer.

## What changed

- preserve incomplete UTF-8 sequences across stdout/stderr chunk boundaries;
- preserve the same behavior for live output callbacks;
- when truncate mode cuts through a code point, retain only complete text instead of emitting a replacement character;
- add focused regressions for split process chunks and byte-limit truncation.

## Validation

Added focused coverage in `processRunner.test.ts`. Repository CI will run the test suite.

## Scope

2 server process-runner files. No process invocation, timeout, cancellation, Windows spawning, provider, or dependency changes.