### PR TITLE
fix(shared): compare Windows workspace paths case-insensitively

### DIFF
--- a/packages/shared/src/path.test.ts
+++ b/packages/shared/src/path.test.ts
@@ -46,10 +46,23 @@ describe("workspaceRelativePathOf", () => {
     expect(workspaceRelativePathOf("/repo/application/file.ts", "/repo/app")).toBeNull();
   });
 
-  it("normalizes Windows separators and drive-letter casing", () => {
-    expect(workspaceRelativePathOf("C:\\repo\\app\\src\\page.tsx", "c:/repo/app")).toBe(
-      "src/page.tsx",
+  it("normalizes Windows separators and path casing while preserving relative casing", () => {
+    expect(workspaceRelativePathOf("C:\\Repo\\App\\Src\\Page.tsx", "c:/repo/app")).toBe(
+      "Src/Page.tsx",
     );
+  });
+
+  it("compares UNC workspace paths case-insensitively", () => {
+    expect(
+      workspaceRelativePathOf(
+        "\\\\Server\\Share\\Repo\\Src\\Page.tsx",
+        "\\\\server\\share\\repo",
+      ),
+    ).toBe("Src/Page.tsx");
+  });
+
+  it("keeps POSIX path comparisons case-sensitive", () => {
+    expect(workspaceRelativePathOf("/Repo/App/src/page.tsx", "/repo/app")).toBeNull();
   });
 
   it("returns null for empty inputs", () => {

--- a/packages/shared/src/path.test.ts
+++ b/packages/shared/src/path.test.ts
@@ -46,19 +46,10 @@ describe("workspaceRelativePathOf", () => {
     expect(workspaceRelativePathOf("/repo/application/file.ts", "/repo/app")).toBeNull();
   });
 
-  it("normalizes Windows separators and path casing while preserving relative casing", () => {
+  it("normalizes Windows separators and path casing", () => {
     expect(workspaceRelativePathOf("C:\\Repo\\App\\Src\\Page.tsx", "c:/repo/app")).toBe(
       "Src/Page.tsx",
     );
-  });
-
-  it("compares UNC workspace paths case-insensitively", () => {
-    expect(
-      workspaceRelativePathOf(
-        "\\\\Server\\Share\\Repo\\Src\\Page.tsx",
-        "\\\\server\\share\\repo",
-      ),
-    ).toBe("Src/Page.tsx");
   });
 
   it("keeps POSIX path comparisons case-sensitive", () => {

--- a/packages/shared/src/path.test.ts
+++ b/packages/shared/src/path.test.ts
@@ -52,6 +52,16 @@ describe("workspaceRelativePathOf", () => {
     );
   });
 
+  it("compares normalized UNC paths case-insensitively", () => {
+    expect(
+      workspaceRelativePathOf("//Server/Share/Repo/Src/Page.tsx", "\\\\server\\share\\repo"),
+    ).toBe("Src/Page.tsx");
+  });
+
+  it("derives Windows relative paths from segments after length-changing case folds", () => {
+    expect(workspaceRelativePathOf("C:\\İ\\secret", "c:\\i̇")).toBe("secret");
+  });
+
   it("keeps POSIX path comparisons case-sensitive", () => {
     expect(workspaceRelativePathOf("/Repo/App/src/page.tsx", "/repo/app")).toBeNull();
   });

--- a/packages/shared/src/path.ts
+++ b/packages/shared/src/path.ts
@@ -35,12 +35,8 @@ export function isExplicitRelativePath(value: string): boolean {
   );
 }
 
-function normalizePathForComparison(value: string): string {
-  const withForwardSlashes = value.replace(/\\/g, "/");
-  // Normalize the drive letter so "C:/foo" and "c:/foo" compare equal.
-  return isWindowsDrivePath(withForwardSlashes)
-    ? withForwardSlashes.charAt(0).toLowerCase() + withForwardSlashes.slice(1)
-    : withForwardSlashes;
+function normalizePathSeparators(value: string): string {
+  return value.replace(/\\/g, "/");
 }
 
 // Converts an absolute path inside `workspaceRoot` to its workspace-relative
@@ -48,12 +44,21 @@ function normalizePathForComparison(value: string): string {
 // outside the root, and for anything that still fails the relative-path safety
 // check (so callers can hand the result straight to workspace file RPCs).
 export function workspaceRelativePathOf(targetPath: string, workspaceRoot: string): string | null {
-  const normalizedTarget = normalizePathForComparison(targetPath.trim());
-  const normalizedRoot = normalizePathForComparison(workspaceRoot.trim()).replace(/\/+$/, "");
+  const trimmedTarget = targetPath.trim();
+  const trimmedRoot = workspaceRoot.trim();
+  const normalizedTarget = normalizePathSeparators(trimmedTarget);
+  const normalizedRoot = normalizePathSeparators(trimmedRoot).replace(/\/+$/, "");
   if (normalizedRoot.length === 0 || normalizedTarget.length === 0) {
     return null;
   }
-  if (!normalizedTarget.startsWith(`${normalizedRoot}/`)) {
+
+  const compareCaseInsensitively =
+    isWindowsAbsolutePath(trimmedTarget) && isWindowsAbsolutePath(trimmedRoot);
+  const comparisonTarget = compareCaseInsensitively
+    ? normalizedTarget.toLowerCase()
+    : normalizedTarget;
+  const comparisonRoot = compareCaseInsensitively ? normalizedRoot.toLowerCase() : normalizedRoot;
+  if (!comparisonTarget.startsWith(`${comparisonRoot}/`)) {
     return null;
   }
   const relativePath = normalizedTarget.slice(normalizedRoot.length + 1).replace(/\/+$/, "");

--- a/packages/shared/src/path.ts
+++ b/packages/shared/src/path.ts
@@ -39,6 +39,22 @@ function normalizePathSeparators(value: string): string {
   return value.replace(/\\/g, "/");
 }
 
+function isNormalizedWindowsAbsolutePath(value: string): boolean {
+  return isWindowsDrivePath(value) || value.startsWith("//");
+}
+
+function windowsRelativePathOf(targetPath: string, workspaceRoot: string): string | null {
+  const targetSegments = targetPath.split("/");
+  const rootSegments = workspaceRoot.split("/");
+  if (targetSegments.length <= rootSegments.length) {
+    return null;
+  }
+  const rootMatches = rootSegments.every(
+    (segment, index) => segment.toLowerCase() === targetSegments[index]?.toLowerCase(),
+  );
+  return rootMatches ? targetSegments.slice(rootSegments.length).join("/") : null;
+}
+
 // Converts an absolute path inside `workspaceRoot` to its workspace-relative
 // form (forward-slash separated). Returns null for the root itself, for paths
 // outside the root, and for anything that still fails the relative-path safety
@@ -53,15 +69,18 @@ export function workspaceRelativePathOf(targetPath: string, workspaceRoot: strin
   }
 
   const compareCaseInsensitively =
-    isWindowsAbsolutePath(trimmedTarget) && isWindowsAbsolutePath(trimmedRoot);
-  const comparisonTarget = compareCaseInsensitively
-    ? normalizedTarget.toLowerCase()
-    : normalizedTarget;
-  const comparisonRoot = compareCaseInsensitively ? normalizedRoot.toLowerCase() : normalizedRoot;
-  if (!comparisonTarget.startsWith(`${comparisonRoot}/`)) {
+    isNormalizedWindowsAbsolutePath(normalizedTarget) &&
+    isNormalizedWindowsAbsolutePath(normalizedRoot);
+  const relativePath = (
+    compareCaseInsensitively
+      ? windowsRelativePathOf(normalizedTarget, normalizedRoot)
+      : normalizedTarget.startsWith(`${normalizedRoot}/`)
+        ? normalizedTarget.slice(normalizedRoot.length + 1)
+        : null
+  )?.replace(/\/+$/, "");
+  if (!relativePath) {
     return null;
   }
-  const relativePath = normalizedTarget.slice(normalizedRoot.length + 1).replace(/\/+$/, "");
   return isWorkspaceRelativePathSafe(relativePath) ? relativePath : null;
 }
 


### PR DESCRIPTION
## Summary

`workspaceRelativePathOf` normalized Windows separators and drive-letter casing, but still compared every other path segment case-sensitively. On normal Windows filesystems, equivalent paths such as `C:\Repo\App\Src\Page.tsx` and `c:\repo\app` could therefore be misclassified as outside the workspace.

This PR compares Windows drive and UNC paths case-insensitively while preserving the original casing in the returned relative path. POSIX comparisons remain case-sensitive.

## What changed

- normalize separators without lowercasing the returned path;
- use a case-insensitive comparison only when both target and root are Windows absolute paths;
- cover drive-path casing, UNC casing, preserved relative casing, and unchanged POSIX behavior.

## Validation

Added focused coverage in `packages/shared/src/path.test.ts`. Repository CI will run the test suite.

## Scope

2 shared path utility files. No filesystem mutations, project storage, UI, or dependency changes.