### PR TITLE
fix(server): reject duplicate Origin headers

### DIFF
--- a/apps/server/src/trustedOrigins.duplicateOrigin.test.ts
+++ b/apps/server/src/trustedOrigins.duplicateOrigin.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import type { ServerConfigShape } from "./config";
+import { normalizeCorsOrigin, shouldRejectUntrustedRequestOrigin } from "./trustedOrigins";
+
+const config = {
+  devUrl: new URL("http://localhost:5173/"),
+} as ServerConfigShape;
+
+describe("trusted origin duplicate-header handling", () => {
+  it("accepts a single origin value represented as an array", () => {
+    expect(normalizeCorsOrigin(["http://localhost:5173"])).toBe("http://localhost:5173");
+  });
+
+  it("rejects duplicate origin values instead of trusting the first", () => {
+    const rawOrigin = ["http://localhost:5173", "https://example.test"];
+
+    expect(normalizeCorsOrigin(rawOrigin)).toBeNull();
+    expect(
+      shouldRejectUntrustedRequestOrigin({
+        rawOrigin,
+        requestOrigin: "http://127.0.0.1:58090",
+        config,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/server/src/trustedOrigins.ts
+++ b/apps/server/src/trustedOrigins.ts
@@ -19,6 +19,9 @@ export const DESKTOP_APP_CORS_ORIGINS: ReadonlySet<string> = new Set([
 ]);
 
 export function normalizeCorsOrigin(rawOrigin: string | ReadonlyArray<string> | undefined) {
+  if (Array.isArray(rawOrigin) && rawOrigin.length !== 1) {
+    return null;
+  }
   const value = Array.isArray(rawOrigin) ? rawOrigin[0] : rawOrigin;
   const trimmed = value?.trim();
   if (!trimmed || trimmed === "null") {


### PR DESCRIPTION
## Summary

The origin normalizer accepts `string | ReadonlyArray<string>` and previously trusted the first array entry. If a framework surfaces duplicate `Origin` headers as multiple values, a request containing both a trusted and an untrusted origin would therefore be evaluated using only the first value.

This PR treats multiple Origin values as malformed and fails closed. A single value represented as a one-element array remains supported.

## What changed

- reject Origin arrays unless they contain exactly one value;
- preserve the existing normalization for ordinary string and single-array inputs;
- add focused coverage proving a trusted-first duplicate is rejected.

## Validation

Added a focused server test. Repository CI will run the full suite.

## Scope

One security utility plus one focused test file. No auth/session model, routing, UI, or dependency changes.