### PR TITLE
fix(server): classify normalized command-not-found errors

### DIFF
--- a/apps/server/src/provider/providerCliOutput.missingCommand.test.ts
+++ b/apps/server/src/provider/providerCliOutput.missingCommand.test.ts
@@ -1,0 +1,28 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { isCommandMissingCause } from "./providerCliOutput";
+import { probeProviderCliVersion } from "./providerCliVersionProbe";
+
+describe("provider CLI missing-command classification", () => {
+  it("recognizes the process runner's normalized command-not-found error", () => {
+    expect(isCommandMissingCause(new Error("Command not found: codex"))).toBe(true);
+  });
+
+  it("keeps existing ENOENT and NotFound classifications", () => {
+    expect(isCommandMissingCause(new Error("spawn codex ENOENT"))).toBe(true);
+    expect(isCommandMissingCause(new Error("NotFound: codex"))).toBe(true);
+  });
+
+  it("classifies normalized runner failures as a missing provider CLI", async () => {
+    const outcome = await Effect.runPromise(
+      probeProviderCliVersion(Effect.fail(new Error("Command not found: codex")), 1_000),
+    );
+
+    expect(outcome.outcome).toBe("missing");
+  });
+
+  it("does not classify unrelated failures as missing commands", () => {
+    expect(isCommandMissingCause(new Error("Authentication failed"))).toBe(false);
+  });
+});

--- a/apps/server/src/provider/providerCliOutput.ts
+++ b/apps/server/src/provider/providerCliOutput.ts
@@ -23,7 +23,11 @@ export function nonEmptyTrimmed(value: string | undefined): string | undefined {
 export function isCommandMissingCause(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   const lower = error.message.toLowerCase();
-  return lower.includes("enoent") || lower.includes("notfound");
+  return (
+    lower.includes("enoent") ||
+    lower.includes("notfound") ||
+    lower.includes("command not found")
+  );
 }
 
 export function detailFromResult(

--- a/apps/server/src/provider/providerCliOutput.ts
+++ b/apps/server/src/provider/providerCliOutput.ts
@@ -20,14 +20,12 @@ export function nonEmptyTrimmed(value: string | undefined): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+const COMMAND_MISSING_MARKERS = ["enoent", "notfound", "command not found"] as const;
+
 export function isCommandMissingCause(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   const lower = error.message.toLowerCase();
-  return (
-    lower.includes("enoent") ||
-    lower.includes("notfound") ||
-    lower.includes("command not found")
-  );
+  return COMMAND_MISSING_MARKERS.some((marker) => lower.includes(marker));
 }
 
 export function detailFromResult(


### PR DESCRIPTION
## Summary

Provider CLI version probing uses `isCommandMissingCause` to distinguish a missing executable from a generic probe failure. The shared process runner normalizes ENOENT into `Command not found: <command>`, but the classifier only recognized `enoent` and the unspaced token `notfound`.

As a result, the runner's own normalized missing-command error could be reported as a generic provider failure instead of a missing CLI.

## What changed

- recognize the exact `Command not found` form emitted by the process runner;
- keep the existing ENOENT/NotFound handling;
- add coverage at both the classifier and `probeProviderCliVersion` outcome level.

## Validation

Added focused server tests. Repository CI will run the full suite.

## Scope

One provider CLI output helper plus one focused test file. No process spawning, provider protocol, UI, or dependency changes.