### PR TITLE
fix(server): fail closed on malformed Claude auth JSON

### DIFF
--- a/apps/server/src/provider/claudeAuthStatus.malformedJson.test.ts
+++ b/apps/server/src/provider/claudeAuthStatus.malformedJson.test.ts
@@ -4,26 +4,24 @@ import { parseClaudeAuthStatusFromOutput } from "./claudeAuthStatus";
 
 describe("Claude auth status malformed JSON", () => {
   it("does not treat malformed JSON with exit code zero as authenticated", () => {
-    expect(
-      parseClaudeAuthStatusFromOutput({
-        stdout: '{"loggedIn":',
-        stderr: "",
-        code: 0,
-      }),
-    ).toEqual({
-      status: "warning",
-      authStatus: "unknown",
-      message: "Could not verify Claude authentication status from JSON output (missing auth marker).",
+    const result = parseClaudeAuthStatusFromOutput({
+      stdout: '{"loggedIn":',
+      stderr: "",
+      code: 0,
     });
+
+    expect(result.status).toBe("warning");
+    expect(result.authStatus).toBe("unknown");
+    expect(result.message).toContain("missing auth marker");
   });
 
   it("keeps plain successful non-JSON output on the legacy authenticated fallback", () => {
-    expect(
-      parseClaudeAuthStatusFromOutput({
-        stdout: "Authenticated",
-        stderr: "",
-        code: 0,
-      }),
-    ).toEqual({ status: "ready", authStatus: "authenticated" });
+    const result = parseClaudeAuthStatusFromOutput({
+      stdout: "Authenticated",
+      stderr: "",
+      code: 0,
+    });
+
+    expect(result).toEqual({ status: "ready", authStatus: "authenticated" });
   });
 });

--- a/apps/server/src/provider/claudeAuthStatus.malformedJson.test.ts
+++ b/apps/server/src/provider/claudeAuthStatus.malformedJson.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { parseClaudeAuthStatusFromOutput } from "./claudeAuthStatus";
+
+describe("Claude auth status malformed JSON", () => {
+  it("does not treat malformed JSON with exit code zero as authenticated", () => {
+    expect(
+      parseClaudeAuthStatusFromOutput({
+        stdout: '{"loggedIn":',
+        stderr: "",
+        code: 0,
+      }),
+    ).toEqual({
+      status: "warning",
+      authStatus: "unknown",
+      message: "Could not verify Claude authentication status from JSON output (missing auth marker).",
+    });
+  });
+
+  it("keeps plain successful non-JSON output on the legacy authenticated fallback", () => {
+    expect(
+      parseClaudeAuthStatusFromOutput({
+        stdout: "Authenticated",
+        stderr: "",
+        code: 0,
+      }),
+    ).toEqual({ status: "ready", authStatus: "authenticated" });
+  });
+});

--- a/apps/server/src/provider/claudeAuthStatus.ts
+++ b/apps/server/src/provider/claudeAuthStatus.ts
@@ -54,7 +54,7 @@ function readClaudeAuthStatusJsonMarker(result: CommandResult): {
       auth: extractAuthBoolean(JSON.parse(trimmed)),
     };
   } catch {
-    return { attemptedJsonParse: false, auth: undefined };
+    return { attemptedJsonParse: true, auth: undefined };
   }
 }
 


### PR DESCRIPTION
## Summary

`claude auth status` JSON is parsed before the legacy exit-code fallback. When stdout starts like JSON but parsing fails, `readClaudeAuthStatusJsonMarker` currently reports `attemptedJsonParse: false`. A malformed JSON response with exit code `0` therefore falls through to the legacy `code === 0` path and is reported as authenticated.

This PR preserves the fact that JSON parsing was attempted, so malformed structured output resolves to the existing `unknown`/warning state instead of authenticated.

## What changed

- mark malformed JSON-shaped stdout as an attempted JSON parse;
- reuse the existing unknown-auth warning path;
- add coverage for malformed JSON with exit code zero while preserving the legacy plain-text success fallback.

## Validation

Added focused server tests. Repository CI will run the full suite.

## Scope

One Claude auth parser line plus one focused test file. No process spawning, credential storage, provider protocol, UI, or dependency changes.