### PR TITLE
fix(server): preserve full Codex prerelease versions

### DIFF
--- a/apps/server/src/provider/codexCliVersion.prerelease.test.ts
+++ b/apps/server/src/provider/codexCliVersion.prerelease.test.ts
@@ -4,12 +4,12 @@ import { compareCodexCliVersions, parseCodexCliVersion } from "./codexCliVersion
 
 describe("Codex CLI prerelease versions", () => {
   it("preserves hyphens inside the prerelease suffix", () => {
-    expect(parseCodexCliVersion("codex-cli 0.124.0-alpha-beta\n")).toBe(
-      "0.124.0-alpha-beta",
-    );
+    const version = parseCodexCliVersion("codex-cli 0.124.0-alpha-beta\n");
+    expect(version).toBe("0.124.0-alpha-beta");
   });
 
   it("keeps distinct hyphenated prereleases distinct", () => {
-    expect(compareCodexCliVersions("0.124.0-alpha-beta", "0.124.0-alpha-gamma")).toBeLessThan(0);
+    const comparison = compareCodexCliVersions("0.124.0-alpha-beta", "0.124.0-alpha-gamma");
+    expect(comparison).toBeLessThan(0);
   });
 });

--- a/apps/server/src/provider/codexCliVersion.prerelease.test.ts
+++ b/apps/server/src/provider/codexCliVersion.prerelease.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { compareCodexCliVersions, parseCodexCliVersion } from "./codexCliVersion";
+
+describe("Codex CLI prerelease versions", () => {
+  it("preserves hyphens inside the prerelease suffix", () => {
+    expect(parseCodexCliVersion("codex-cli 0.124.0-alpha-beta\n")).toBe(
+      "0.124.0-alpha-beta",
+    );
+  });
+
+  it("keeps distinct hyphenated prereleases distinct", () => {
+    expect(compareCodexCliVersions("0.124.0-alpha-beta", "0.124.0-alpha-gamma")).toBeLessThan(0);
+  });
+});

--- a/apps/server/src/provider/codexCliVersion.ts
+++ b/apps/server/src/provider/codexCliVersion.ts
@@ -11,9 +11,20 @@ interface ParsedSemver {
   readonly prerelease: ReadonlyArray<string>;
 }
 
+function splitPrerelease(version: string): { main: string; prerelease: string | undefined } {
+  const separatorIndex = version.indexOf("-");
+  if (separatorIndex === -1) {
+    return { main: version, prerelease: undefined };
+  }
+  return {
+    main: version.slice(0, separatorIndex),
+    prerelease: version.slice(separatorIndex + 1),
+  };
+}
+
 function normalizeCodexVersion(version: string): string {
-  const [main, prerelease] = version.trim().split("-", 2);
-  const segments = (main ?? "")
+  const { main, prerelease } = splitPrerelease(version.trim());
+  const segments = main
     .split(".")
     .map((segment) => segment.trim())
     .filter((segment) => segment.length > 0);
@@ -27,7 +38,7 @@ function normalizeCodexVersion(version: string): string {
 
 function parseSemver(version: string): ParsedSemver | null {
   const normalized = normalizeCodexVersion(version);
-  const [main = "", prerelease] = normalized.split("-", 2);
+  const { main, prerelease } = splitPrerelease(normalized);
   const segments = main.split(".");
   if (segments.length !== 3) {
     return null;


### PR DESCRIPTION
## Summary

The Codex version parser accepts prerelease suffixes containing hyphens, but both normalization and comparison split version strings with `split("-", 2)`. JavaScript drops the remaining segments in that form, so a valid version such as `0.124.0-alpha-beta` was normalized to `0.124.0-alpha`.

This PR splits at the first prerelease separator while preserving the full suffix.

## What changed

- preserve all characters after the first `-` as the prerelease suffix;
- use the same split logic during normalization and semver comparison;
- add regressions proving hyphenated prereleases round-trip and remain distinguishable.

## Validation

Added focused server tests. Repository CI will run the full suite.

## Scope

One Codex version helper plus one focused test file. No provider runtime, update command, UI, or dependency changes.