### PR TITLE
Align Grok reasoning efforts with the Grok CLI ladders

### DIFF
--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -326,14 +326,45 @@ describe("GrokAdapter runtime event scoping", () => {
       { slug: "grok-build-0.1", name: "Grok Build 0.1" },
       { slug: "grok-4.5", name: "Grok 4.5" },
     ]);
-    for (const model of models) {
-      expect(model.defaultReasoningEffort).toBe("low");
-      expect(model.supportedReasoningEfforts?.map((effort) => effort.value)).toEqual([
-        "none",
-        "low",
-        "medium",
-        "high",
-      ]);
-    }
+    expect(models[0]?.defaultReasoningEffort).toBe("low");
+    expect(models[0]?.supportedReasoningEfforts?.map((effort) => effort.value)).toEqual([
+      "none",
+      "low",
+      "medium",
+      "high",
+    ]);
+    expect(models[2]?.defaultReasoningEffort).toBe("high");
+    expect(models[2]?.supportedReasoningEfforts?.map((effort) => effort.value)).toEqual([
+      "low",
+      "medium",
+      "high",
+    ]);
+  });
+
+  it("stamps Grok 4.6 with Extra High instead of the grok-build None ladder", () => {
+    const [model] = mergeGrokModelDescriptors([[{ slug: "grok-4.6", name: "Grok 4.6" }]]);
+    expect(model?.defaultReasoningEffort).toBe("high");
+    expect(model?.supportedReasoningEfforts).toEqual([
+      {
+        value: "low",
+        label: "Low",
+        description: "Quick, fast implementations",
+      },
+      {
+        value: "medium",
+        label: "Medium",
+        description: "Balanced effort with standard implementation and testing",
+      },
+      {
+        value: "high",
+        label: "High",
+        description: "Higher implementation quality with extensive reasoning",
+      },
+      {
+        value: "xhigh",
+        label: "Extra High",
+        description: "Highest effort and reasoning level",
+      },
+    ]);
   });
 });

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -5,7 +5,6 @@
  */
 import {
   ApprovalRequestId,
-  GROK_REASONING_EFFORT_OPTIONS,
   type GrokModelOptions,
   EventId,
   type ProviderComposerCapabilities,
@@ -21,8 +20,9 @@ import {
   type ThreadId,
   TurnId,
 } from "@synara/contracts";
-import { prepareWindowsSafeProcess } from "@synara/shared/windowsProcess";
+import { getDefaultEffort, getModelCapabilities } from "@synara/shared/model";
 import { decodeOutboundJson, decodeOutboundText, outboundHttp } from "@synara/shared/outboundHttp";
+import { prepareWindowsSafeProcess } from "@synara/shared/windowsProcess";
 import {
   Cause,
   DateTime,
@@ -193,8 +193,6 @@ const GROK_TURN_SETTLE_DRAIN_MAX_WAIT_MS = 1_000;
 const GROK_TURN_SETTLE_DRAIN_POLL_MS = 25;
 const GROK_EXIT_PLAN_RESPONSE_GRACE_MS = 25;
 const XAI_API_BASE_URL = "https://api.x.ai/v1";
-const GROK_DEFAULT_REASONING_EFFORT = "low";
-const GROK_RUNTIME_REASONING_EFFORTS = GROK_REASONING_EFFORT_OPTIONS.map((value) => ({ value }));
 const GROK_PLAN_MODE_PROMPT_PREFIX = [
   "Synara requested Grok's native plan mode.",
   "Do not implement or mutate files in this turn.",
@@ -576,11 +574,17 @@ export function mergeGrokModelDescriptors(
         continue;
       }
       seen.add(key);
+      const capabilities = getModelCapabilities("grok", slug);
+      const defaultReasoningEffort = getDefaultEffort(capabilities);
       models.push({
         slug,
         name: model.name.trim() || formatGrokModelName(slug),
-        supportedReasoningEfforts: GROK_RUNTIME_REASONING_EFFORTS,
-        defaultReasoningEffort: GROK_DEFAULT_REASONING_EFFORT,
+        supportedReasoningEfforts: capabilities.reasoningEffortLevels.map((level) => ({
+          value: level.value,
+          label: level.label,
+          ...(level.description ? { description: level.description } : {}),
+        })),
+        ...(defaultReasoningEffort ? { defaultReasoningEffort } : {}),
       });
     }
   }

--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -71,6 +71,30 @@ describe("buildGrokAcpSpawnInput", () => {
     expect(spawn.args).not.toContain("--always-approve");
   });
 
+  it("passes Grok 4.6 extra-high reasoning effort to the CLI", () => {
+    expect(
+      buildGrokAcpSpawnInput(
+        {
+          binaryPath: "/usr/local/bin/grok",
+          model: "grok-4.6",
+          reasoningEffort: "xhigh",
+        },
+        "/tmp/project",
+        "approval-required",
+      ).args,
+    ).toEqual([
+      "--permission-mode",
+      "default",
+      "agent",
+      "--no-leader",
+      "-m",
+      "grok-4.6",
+      "--reasoning-effort",
+      "xhigh",
+      "stdio",
+    ]);
+  });
+
   it("uses Grok's process-scoped approval override only for Full Access", () => {
     expect(buildGrokAcpSpawnInput(undefined, "/tmp/project", "full-access").args).toEqual([
       "--permission-mode",

--- a/apps/web/src/components/chat/ComposerModelEffortPicker.browser.tsx
+++ b/apps/web/src/components/chat/ComposerModelEffortPicker.browser.tsx
@@ -45,7 +45,9 @@ describe("ComposerModelEffortPicker", () => {
       await trigger.click();
       await expect.element(page.getByRole("menuitemradio", { name: "Low" })).toBeVisible();
       await expect.element(page.getByRole("menuitemradio", { name: "Medium" })).toBeVisible();
-      await expect.element(page.getByRole("menuitemradio", { name: "High (default)" })).toBeVisible();
+      await expect
+        .element(page.getByRole("menuitemradio", { name: "High (default)" }))
+        .toBeVisible();
       await expect.element(page.getByRole("menuitemradio", { name: "Extra High" })).toBeVisible();
     } finally {
       await screen.unmount();

--- a/apps/web/src/components/chat/ComposerModelEffortPicker.browser.tsx
+++ b/apps/web/src/components/chat/ComposerModelEffortPicker.browser.tsx
@@ -8,21 +8,21 @@ import { render } from "vitest-browser-react";
 import { ComposerModelEffortPicker } from "./ComposerModelEffortPicker";
 
 const THREAD_ID = ThreadId.makeUnsafe("thread-grok-model-effort-picker");
-const GROK_4_5 = "grok-4.5" as ModelSlug;
+const GROK_4_6 = "grok-4.6" as ModelSlug;
 
 describe("ComposerModelEffortPicker", () => {
-  it("keeps Grok effort visible in compact layouts before runtime discovery", async () => {
+  it("keeps Grok 4.6 effort visible in compact layouts before runtime discovery", async () => {
     const screen = await render(
       <ComposerModelEffortPicker
         provider="grok"
-        model={GROK_4_5}
+        model={GROK_4_6}
         lockedProvider={null}
         modelOptionsByProvider={{
           claudeAgent: [],
           codex: [],
           cursor: [],
           antigravity: [],
-          grok: [{ slug: GROK_4_5, name: "Grok 4.5" }],
+          grok: [{ slug: GROK_4_6, name: "Grok 4.6" }],
           droid: [],
           kilo: [],
           opencode: [],
@@ -39,14 +39,14 @@ describe("ComposerModelEffortPicker", () => {
 
     try {
       const trigger = page.getByRole("button", { name: "Change model and reasoning" });
-      await expect.element(trigger).toHaveAttribute("title", "Low");
+      await expect.element(trigger).toHaveAttribute("title", "High");
       expect(trigger.element().querySelector('[data-slot="central-icon"]')).not.toBeNull();
 
       await trigger.click();
-      await expect.element(page.getByRole("menuitemradio", { name: "None" })).toBeVisible();
       await expect.element(page.getByRole("menuitemradio", { name: "Low" })).toBeVisible();
       await expect.element(page.getByRole("menuitemradio", { name: "Medium" })).toBeVisible();
-      await expect.element(page.getByRole("menuitemradio", { name: "High" })).toBeVisible();
+      await expect.element(page.getByRole("menuitemradio", { name: "High (default)" })).toBeVisible();
+      await expect.element(page.getByRole("menuitemradio", { name: "Extra High" })).toBeVisible();
     } finally {
       await screen.unmount();
     }

--- a/apps/web/src/components/chat/composerProviderRegistry.test.tsx
+++ b/apps/web/src/components/chat/composerProviderRegistry.test.tsx
@@ -97,13 +97,8 @@ const ANTIGRAVITY_RUNTIME_CLAUDE_WITH_SINGLE_EFFORT: ProviderModelDescriptor = {
 const GROK_RUNTIME_4_5_WITH_REASONING: ProviderModelDescriptor = {
   slug: "grok-4.5",
   name: "Grok 4.5",
-  supportedReasoningEfforts: [
-    { value: "none" },
-    { value: "low" },
-    { value: "medium" },
-    { value: "high" },
-  ],
-  defaultReasoningEffort: "low",
+  supportedReasoningEfforts: [{ value: "low" }, { value: "medium" }, { value: "high" }],
+  defaultReasoningEffort: "high",
 };
 
 describe("getComposerProviderState", () => {
@@ -610,7 +605,7 @@ describe("getComposerProviderState", () => {
       "grok",
       "grok-4.5",
       "",
-      { reasoningEffort: "high" },
+      { reasoningEffort: "medium" },
       GROK_RUNTIME_4_5_WITH_REASONING,
     );
     const state = getComposerProviderState({
@@ -618,35 +613,38 @@ describe("getComposerProviderState", () => {
       model: "grok-4.5",
       runtimeModel: GROK_RUNTIME_4_5_WITH_REASONING,
       prompt: "",
-      modelOptions: { grok: { reasoningEffort: "high" } },
+      modelOptions: { grok: { reasoningEffort: "medium" } },
     });
 
     expect(selection.effortLevels.map((effort) => effort.value)).toEqual([
-      "none",
       "low",
       "medium",
       "high",
     ]);
-    expect(selection.defaultEffort).toBe("low");
-    expect(selection.effort).toBe("high");
+    expect(selection.defaultEffort).toBe("high");
+    expect(selection.effort).toBe("medium");
     expect(state).toEqual({
       provider: "grok",
-      promptEffort: "high",
-      modelOptionsForDispatch: { reasoningEffort: "high" },
+      promptEffort: "medium",
+      modelOptionsForDispatch: { reasoningEffort: "medium" },
     });
   });
 
   it("exposes Grok efforts before runtime model discovery resolves", () => {
-    const selection = getComposerTraitSelection("grok", "grok-4.5", "", undefined);
+    const grok45 = getComposerTraitSelection("grok", "grok-4.5", "", undefined);
+    expect(grok45.effortLevels.map((effort) => effort.value)).toEqual(["low", "medium", "high"]);
+    expect(grok45.defaultEffort).toBe("high");
+    expect(grok45.effort).toBe("high");
 
-    expect(selection.effortLevels.map((effort) => effort.value)).toEqual([
-      "none",
+    const grok46 = getComposerTraitSelection("grok", "grok-4.6", "", undefined);
+    expect(grok46.effortLevels.map((effort) => effort.value)).toEqual([
       "low",
       "medium",
       "high",
+      "xhigh",
     ]);
-    expect(selection.defaultEffort).toBe("low");
-    expect(selection.effort).toBe("low");
+    expect(grok46.defaultEffort).toBe("high");
+    expect(grok46.effortLevels.find((effort) => effort.value === "xhigh")?.label).toBe("Extra High");
   });
 
   it("exposes and dispatches runtime-discovered Droid efforts for GPT-5.6", () => {

--- a/apps/web/src/components/chat/composerProviderRegistry.test.tsx
+++ b/apps/web/src/components/chat/composerProviderRegistry.test.tsx
@@ -616,11 +616,7 @@ describe("getComposerProviderState", () => {
       modelOptions: { grok: { reasoningEffort: "medium" } },
     });
 
-    expect(selection.effortLevels.map((effort) => effort.value)).toEqual([
-      "low",
-      "medium",
-      "high",
-    ]);
+    expect(selection.effortLevels.map((effort) => effort.value)).toEqual(["low", "medium", "high"]);
     expect(selection.defaultEffort).toBe("high");
     expect(selection.effort).toBe("medium");
     expect(state).toEqual({
@@ -644,7 +640,9 @@ describe("getComposerProviderState", () => {
       "xhigh",
     ]);
     expect(grok46.defaultEffort).toBe("high");
-    expect(grok46.effortLevels.find((effort) => effort.value === "xhigh")?.label).toBe("Extra High");
+    expect(grok46.effortLevels.find((effort) => effort.value === "xhigh")?.label).toBe(
+      "Extra High",
+    );
   });
 
   it("exposes and dispatches runtime-discovered Droid efforts for GPT-5.6", () => {

--- a/apps/web/src/composerDraftModels.ts
+++ b/apps/web/src/composerDraftModels.ts
@@ -19,6 +19,7 @@ import * as Schema from "effect/Schema";
 
 import {
   getDefaultModel,
+  normalizeGrokModelOptions,
   normalizeModelSlug,
   resolveModelSlugForProvider,
   resolveSelectableModel,
@@ -475,7 +476,7 @@ export function normalizeModelSelection(
         : provider === "antigravity"
           ? modelOptions?.antigravity
           : provider === "grok"
-            ? modelOptions?.grok
+            ? normalizeGrokModelOptions(model, modelOptions?.grok)
             : provider === "droid"
               ? modelOptions?.droid
               : provider === "kilo"
@@ -601,10 +602,14 @@ export function legacySyncModelSelectionOptions(
     return null;
   }
   const options = modelOptions?.[modelSelection.provider];
+  const normalizedOptions =
+    modelSelection.provider === "grok"
+      ? normalizeGrokModelOptions(modelSelection.model, options)
+      : options;
   return makeModelSelection(
     modelSelection.provider,
     modelSelection.model,
-    options,
+    normalizedOptions,
     modelSelection.provider === "claudeAgent" ? modelSelection.supportsAutoMode : undefined,
   );
 }
@@ -654,7 +659,11 @@ export function legacyToModelSelectionByProvider(
         const model =
           modelSelection?.provider === provider ? modelSelection.model : getDefaultModel(provider);
         if (model) {
-          result[provider] = makeModelSelection(provider, model, options);
+          result[provider] = makeModelSelection(
+            provider,
+            model,
+            provider === "grok" ? normalizeGrokModelOptions(model, options) : options,
+          );
         }
       }
     }

--- a/apps/web/src/composerDraftModels.ts
+++ b/apps/web/src/composerDraftModels.ts
@@ -601,11 +601,10 @@ export function legacySyncModelSelectionOptions(
   if (modelSelection === null) {
     return null;
   }
-  const options = modelOptions?.[modelSelection.provider];
   const normalizedOptions =
     modelSelection.provider === "grok"
-      ? normalizeGrokModelOptions(modelSelection.model, options)
-      : options;
+      ? normalizeGrokModelOptions(modelSelection.model, modelOptions?.grok)
+      : modelOptions?.[modelSelection.provider];
   return makeModelSelection(
     modelSelection.provider,
     modelSelection.model,
@@ -662,7 +661,7 @@ export function legacyToModelSelectionByProvider(
           result[provider] = makeModelSelection(
             provider,
             model,
-            provider === "grok" ? normalizeGrokModelOptions(model, options) : options,
+            provider === "grok" ? normalizeGrokModelOptions(model, modelOptions.grok) : options,
           );
         }
       }

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -27,7 +27,18 @@ export const PI_THINKING_LEVEL_OPTIONS = [
   "max",
 ] as const;
 export type PiThinkingLevel = (typeof PI_THINKING_LEVEL_OPTIONS)[number];
-export const GROK_REASONING_EFFORT_OPTIONS = ["none", "low", "medium", "high"] as const;
+// Union of every Grok CLI ladder. Per-model capabilities pick a subset:
+// grok-build keeps none/low/medium/high, Grok 4.5 drops none, Grok 4.6 adds xhigh.
+export const GROK_BUILD_REASONING_EFFORTS = ["none", "low", "medium", "high"] as const;
+export const GROK_4_5_REASONING_EFFORTS = ["low", "medium", "high"] as const;
+export const GROK_4_6_REASONING_EFFORTS = ["low", "medium", "high", "xhigh"] as const;
+export const GROK_REASONING_EFFORT_OPTIONS = [
+  "none",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const;
 export type GrokReasoningEffort = (typeof GROK_REASONING_EFFORT_OPTIONS)[number];
 export const DROID_REASONING_EFFORT_OPTIONS = [
   "off",
@@ -223,18 +234,54 @@ const CODEX_GPT_5_5_CAPABILITIES: ModelCapabilities = {
   ],
 };
 
-const GROK_BUILD_CAPABILITIES: ModelCapabilities = {
-  reasoningEffortLevels: [
-    { value: "none", label: "None" },
-    { value: "low", label: "Low", isDefault: true },
-    { value: "medium", label: "Medium" },
-    { value: "high", label: "High" },
-  ],
-  supportsFastMode: false,
-  supportsThinkingToggle: false,
-  promptInjectedEffortLevels: [],
-  contextWindowOptions: [],
-};
+const GROK_CLI_EFFORT_DESCRIPTIONS = {
+  low: "Quick, fast implementations",
+  medium: "Balanced effort with standard implementation and testing",
+  high: "Higher implementation quality with extensive reasoning",
+  xhigh: "Highest effort and reasoning level",
+} as const;
+
+function grokCliEffortOption(
+  value: Exclude<GrokReasoningEffort, "none">,
+  options: Pick<EffortOption, "isDefault"> = {},
+): EffortOption {
+  return {
+    value,
+    label: value === "xhigh" ? "Extra High" : `${value.charAt(0).toUpperCase()}${value.slice(1)}`,
+    description: GROK_CLI_EFFORT_DESCRIPTIONS[value],
+    ...options,
+  };
+}
+
+function grokCapabilities(reasoningEffortLevels: readonly EffortOption[]): ModelCapabilities {
+  return {
+    reasoningEffortLevels,
+    supportsFastMode: false,
+    supportsThinkingToggle: false,
+    promptInjectedEffortLevels: [],
+    contextWindowOptions: [],
+  };
+}
+
+const GROK_BUILD_CAPABILITIES = grokCapabilities([
+  { value: "none", label: "None" },
+  { value: "low", label: "Low", isDefault: true },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+]);
+
+const GROK_4_5_CAPABILITIES = grokCapabilities([
+  grokCliEffortOption("low"),
+  grokCliEffortOption("medium"),
+  grokCliEffortOption("high", { isDefault: true }),
+]);
+
+const GROK_4_6_CAPABILITIES = grokCapabilities([
+  grokCliEffortOption("low"),
+  grokCliEffortOption("medium"),
+  grokCliEffortOption("high", { isDefault: true }),
+  grokCliEffortOption("xhigh"),
+]);
 
 // Cursor's live catalog is discovered per session (see CursorAdapter.listModels);
 // these entries are the cold-start fallback and mirror the base model ids the
@@ -613,6 +660,16 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
       slug: "grok-build",
       name: "Grok 4.3",
       capabilities: GROK_BUILD_CAPABILITIES,
+    },
+    {
+      slug: "grok-4.5",
+      name: "Grok 4.5",
+      capabilities: GROK_4_5_CAPABILITIES,
+    },
+    {
+      slug: "grok-4.6",
+      name: "Grok 4.6",
+      capabilities: GROK_4_6_CAPABILITIES,
     },
   ],
   droid: [
@@ -1160,6 +1217,10 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Record<ProviderKind, Record<string,
     "grok-code-fast-1": "grok-build-0.1",
     "grok-code-fast-1-0825": "grok-build-0.1",
     "code-fast": "grok-build-0.1",
+    "4.5": "grok-4.5",
+    "grok-4.5": "grok-4.5",
+    "4.6": "grok-4.6",
+    "grok-4.6": "grok-4.6",
   },
   kilo: {},
   opencode: {},

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -32,13 +32,7 @@ export type PiThinkingLevel = (typeof PI_THINKING_LEVEL_OPTIONS)[number];
 export const GROK_BUILD_REASONING_EFFORTS = ["none", "low", "medium", "high"] as const;
 export const GROK_4_5_REASONING_EFFORTS = ["low", "medium", "high"] as const;
 export const GROK_4_6_REASONING_EFFORTS = ["low", "medium", "high", "xhigh"] as const;
-export const GROK_REASONING_EFFORT_OPTIONS = [
-  "none",
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-] as const;
+export const GROK_REASONING_EFFORT_OPTIONS = ["none", "low", "medium", "high", "xhigh"] as const;
 export type GrokReasoningEffort = (typeof GROK_REASONING_EFFORT_OPTIONS)[number];
 export const DROID_REASONING_EFFORT_OPTIONS = [
   "off",

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -381,7 +381,9 @@ describe("getModelCapabilities reasoningEffortLevels", () => {
       controlSource: "api-effort",
     });
     expect(
-      getModelCapabilities("grok", "grok-4.6").reasoningEffortLevels.find((l) => l.value === "xhigh"),
+      getModelCapabilities("grok", "grok-4.6").reasoningEffortLevels.find(
+        (l) => l.value === "xhigh",
+      ),
     ).toMatchObject({
       value: "xhigh",
       label: "Extra High",

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -10,7 +10,9 @@ import {
   MODEL_OPTIONS,
   MODEL_OPTIONS_BY_PROVIDER,
   CODEX_REASONING_EFFORT_OPTIONS,
-  GROK_REASONING_EFFORT_OPTIONS,
+  GROK_4_5_REASONING_EFFORTS,
+  GROK_4_6_REASONING_EFFORTS,
+  GROK_BUILD_REASONING_EFFORTS,
 } from "@synara/contracts";
 
 import {
@@ -41,6 +43,7 @@ import {
   getProviderOptionDescriptors,
   buildProviderOptionSelectionsFromDescriptors,
   hasEffortLevel,
+  resolveGrokEffortFamily,
 } from "./model";
 
 describe("Git text generation defaults", () => {
@@ -102,6 +105,8 @@ describe("normalizeModelSlug", () => {
     expect(normalizeModelSlug("grok-latest", "grok")).toBe("grok-build");
     expect(normalizeModelSlug("grok-code-fast-1", "grok")).toBe("grok-build-0.1");
     expect(normalizeModelSlug("grok-code-fast-1-0825", "grok")).toBe("grok-build-0.1");
+    expect(normalizeModelSlug("4.5", "grok")).toBe("grok-4.5");
+    expect(normalizeModelSlug("grok-4.6", "grok")).toBe("grok-4.6");
   });
 });
 
@@ -347,10 +352,15 @@ describe("getModelCapabilities reasoningEffortLevels", () => {
     expect(values("claudeAgent", "claude-haiku-4-5")).toEqual([]);
   });
 
-  it("returns Grok effort options for Grok Build models", () => {
-    expect(values("grok", "grok-build-0.1")).toEqual([...GROK_REASONING_EFFORT_OPTIONS]);
-    expect(values("grok", "grok-build")).toEqual([...GROK_REASONING_EFFORT_OPTIONS]);
-    expect(values("grok", "grok-4.5")).toEqual([...GROK_REASONING_EFFORT_OPTIONS]);
+  it("returns Grok Build effort options for grok-build models", () => {
+    expect(values("grok", "grok-build-0.1")).toEqual([...GROK_BUILD_REASONING_EFFORTS]);
+    expect(values("grok", "grok-build")).toEqual([...GROK_BUILD_REASONING_EFFORTS]);
+  });
+
+  it("returns Grok 4.5 and 4.6 CLI effort ladders", () => {
+    expect(values("grok", "grok-4.5")).toEqual([...GROK_4_5_REASONING_EFFORTS]);
+    expect(values("grok", "grok-4.6")).toEqual([...GROK_4_6_REASONING_EFFORTS]);
+    expect(values("grok", "grok-4.7")).toEqual([...GROK_4_6_REASONING_EFFORTS]);
   });
 
   it("co-locates labels with effort values", () => {
@@ -370,6 +380,13 @@ describe("getModelCapabilities reasoningEffortLevels", () => {
       label: "Extra High",
       controlSource: "api-effort",
     });
+    expect(
+      getModelCapabilities("grok", "grok-4.6").reasoningEffortLevels.find((l) => l.value === "xhigh"),
+    ).toMatchObject({
+      value: "xhigh",
+      label: "Extra High",
+      description: "Highest effort and reasoning level",
+    });
   });
 });
 
@@ -384,6 +401,8 @@ describe("getDefaultEffort", () => {
     expect(getDefaultEffort(getModelCapabilities("claudeAgent", "claude-haiku-4-5"))).toBeNull();
     expect(getDefaultEffort(getModelCapabilities("grok", "grok-build-0.1"))).toBe("low");
     expect(getDefaultEffort(getModelCapabilities("grok", "grok-build"))).toBe("low");
+    expect(getDefaultEffort(getModelCapabilities("grok", "grok-4.5"))).toBe("high");
+    expect(getDefaultEffort(getModelCapabilities("grok", "grok-4.6"))).toBe("high");
   });
 });
 
@@ -400,9 +419,25 @@ describe("hasEffortLevel", () => {
     expect(hasEffortLevel(codexCaps, "xhigh")).toBe(true);
     expect(hasEffortLevel(codexCaps, "max")).toBe(false);
 
-    const grokCaps = getModelCapabilities("grok", "grok-build-0.1");
-    expect(hasEffortLevel(grokCaps, "high")).toBe(true);
-    expect(hasEffortLevel(grokCaps, "xhigh")).toBe(false);
+    const grokBuildCaps = getModelCapabilities("grok", "grok-build-0.1");
+    expect(hasEffortLevel(grokBuildCaps, "high")).toBe(true);
+    expect(hasEffortLevel(grokBuildCaps, "xhigh")).toBe(false);
+
+    const grok46Caps = getModelCapabilities("grok", "grok-4.6");
+    expect(hasEffortLevel(grok46Caps, "xhigh")).toBe(true);
+    expect(hasEffortLevel(grok46Caps, "none")).toBe(false);
+  });
+});
+
+describe("resolveGrokEffortFamily", () => {
+  it("classifies grok-build, Grok 4.5, and Grok 4.6+ ladders", () => {
+    expect(resolveGrokEffortFamily("grok-build")).toBe("build");
+    expect(resolveGrokEffortFamily("grok-build-0.1")).toBe("build");
+    expect(resolveGrokEffortFamily("grok-code-fast-1")).toBe("build");
+    expect(resolveGrokEffortFamily("grok-4.3")).toBe("build");
+    expect(resolveGrokEffortFamily("grok-4.5")).toBe("4.5");
+    expect(resolveGrokEffortFamily("grok-4.6")).toBe("4.6");
+    expect(resolveGrokEffortFamily("grok-4.7")).toBe("4.6");
   });
 });
 
@@ -439,6 +474,21 @@ describe("provider option descriptor helpers", () => {
       type: "select",
       currentValue: "high",
     });
+
+    const grok46 = getProviderOptionDescriptors({
+      provider: "grok",
+      caps: getModelCapabilities("grok", "grok-4.6"),
+      selections: { reasoningEffort: "xhigh" },
+    });
+    expect(grok46.find((descriptor) => descriptor.id === "reasoningEffort")).toMatchObject({
+      type: "select",
+      currentValue: "xhigh",
+    });
+    expect(
+      getProviderOptionCurrentLabel(
+        grok46.find((descriptor) => descriptor.id === "reasoningEffort"),
+      ),
+    ).toBe("Extra High");
   });
 
   it("maps Pi reasoning controls onto the thinkingLevel option", () => {
@@ -873,9 +923,12 @@ describe("normalizeGrokModelOptions", () => {
     expect(normalizeGrokModelOptions("grok-build-0.1", { reasoningEffort: "high" })).toEqual({
       reasoningEffort: "high",
     });
-    expect(normalizeGrokModelOptions("grok-4.5", { reasoningEffort: "high" })).toEqual({
-      reasoningEffort: "high",
+    expect(normalizeGrokModelOptions("grok-4.5", { reasoningEffort: "high" })).toBeUndefined();
+    expect(normalizeGrokModelOptions("grok-4.6", { reasoningEffort: "high" })).toBeUndefined();
+    expect(normalizeGrokModelOptions("grok-4.6", { reasoningEffort: "xhigh" })).toEqual({
+      reasoningEffort: "xhigh",
     });
+    expect(normalizeGrokModelOptions("grok-4.6", { reasoningEffort: "none" })).toBeUndefined();
   });
 });
 

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -425,11 +425,50 @@ export function getModelCapabilities(
   }
   if (provider === "grok" && slug) {
     // Grok exposes reasoning effort as a provider-level CLI option, while its
-    // runtime model catalog contains only model ids. New models must inherit the
-    // provider ladder even before runtime discovery has returned their descriptor.
-    return MODEL_CAPABILITIES_INDEX.grok["grok-build"] ?? EMPTY_MODEL_CAPABILITIES;
+    // runtime model catalog contains only model ids. New models inherit the
+    // matching CLI ladder (grok-build vs Grok 4.5 vs Grok 4.6+) before discovery
+    // returns a descriptor.
+    return grokCapabilitiesForFamily(resolveGrokEffortFamily(slug));
   }
   return EMPTY_MODEL_CAPABILITIES;
+}
+
+export function resolveGrokEffortFamily(model: string): "build" | "4.5" | "4.6" {
+  const slug = model.trim().toLowerCase();
+  if (
+    slug.includes("build") ||
+    slug.includes("code-fast") ||
+    slug === "grok-4" ||
+    slug === "grok-4.3" ||
+    slug.startsWith("grok-4.3-")
+  ) {
+    return "build";
+  }
+
+  const version = /grok-(\d+)\.(\d+)/u.exec(slug);
+  if (!version) {
+    return "4.6";
+  }
+  const major = Number(version[1]);
+  const minor = Number(version[2]);
+  if (major < 4 || (major === 4 && minor <= 3)) {
+    return "build";
+  }
+  if (major === 4 && minor === 5) {
+    return "4.5";
+  }
+  return "4.6";
+}
+
+function grokCapabilitiesForFamily(family: "build" | "4.5" | "4.6"): ModelCapabilities {
+  const grokCaps = MODEL_CAPABILITIES_INDEX.grok;
+  if (family === "build") {
+    return grokCaps["grok-build"] ?? EMPTY_MODEL_CAPABILITIES;
+  }
+  if (family === "4.5") {
+    return grokCaps["grok-4.5"] ?? grokCaps["grok-4.6"] ?? EMPTY_MODEL_CAPABILITIES;
+  }
+  return grokCaps["grok-4.6"] ?? EMPTY_MODEL_CAPABILITIES;
 }
 
 export function isClaudeUltrathinkPrompt(text: string | null | undefined): boolean {


### PR DESCRIPTION
## Summary
- Map Grok reasoning effort pickers to the real CLI ladders: grok-build stays None/Low/Medium/High (default Low), Grok 4.5 is Low/Medium/High (default High), and Grok 4.6+ adds Extra High (`xhigh`).
- Stamp those per-model efforts onto discovered Grok descriptors so the composer and ACP spawn use the same values as `grok --reasoning-effort`.
- Drop unsupported restored efforts (for example Extra High on grok-build) from composer drafts, and type that restore path against Grok options only so web typecheck stays green.

## Test plan
- [ ] Select grok-build and confirm the effort menu is None / Low (default) / Medium / High, with no Extra High.
- [ ] Select Grok 4.6 and confirm Low / Medium / High (default) / Extra High; Extra High should spawn `--reasoning-effort xhigh`.
- [ ] Restore a legacy composer draft that stored grok-build + Extra High and confirm the invalid effort is dropped.
- [ ] CI: `fmt:check`, `lint`, `typecheck`, and unit tests covering `packages/shared` Grok ladders, `GrokAdapter` descriptors, ACP spawn, and composer draft restore.

Made with [Cursor](https://cursor.com)