### PR TITLE
feat(kanban): v2 attention-first board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ __screenshots__/
 /browser-sidebar-comment-preload.js.map
 /preload.js.map
 /bootstrap.js.map
+/decisions.tsv

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,11 @@ __screenshots__/
 /preload.js.map
 /bootstrap.js.map
 /decisions.tsv
+
+# Local kanban v2 e2e probe/seed scripts — scratch tooling for manual
+# verification against an isolated instance, not part of the shipped feature.
+/.e2e-probe/
+/apps/web/e2e-seed-prs.ts
+/apps/web/e2e-seed-state.ts
+/apps/web/e2e-wsdispatch.ts
+/apps/web/f1-derivation.ts

--- a/apps/server/src/diagnostics/Layers/ThreadDiagnosticsQuery.test.ts
+++ b/apps/server/src/diagnostics/Layers/ThreadDiagnosticsQuery.test.ts
@@ -47,6 +47,9 @@ layer("ThreadDiagnosticsQuery", (it) => {
   it.effect("stores bounded structured incidents and reads only the requested thread", () =>
     Effect.gen(function* () {
       const diagnostics = yield* ThreadDiagnosticsQuery;
+      // Relative stamps: retention purges rows older than 30 days, so absolute
+      // fixture dates silently vanish once real time moves past them.
+      const dayAgoIso = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
       yield* diagnostics.recordOperationalDiagnostic({
         threadId: "thread-1",
         source: "server",
@@ -54,7 +57,7 @@ layer("ThreadDiagnosticsQuery", (it) => {
         severity: "warning",
         code: "THREAD_STREAM_CAPACITY_EXCEEDED",
         detail: { reason: "thread-capacity", activeThreads: 16 },
-        occurredAt: "2026-07-20T10:00:00.000Z",
+        occurredAt: dayAgoIso,
       });
       yield* diagnostics.recordOperationalDiagnostic({
         threadId: "thread-2",
@@ -62,7 +65,7 @@ layer("ThreadDiagnosticsQuery", (it) => {
         kind: "ws.stream-admission-rejected",
         severity: "warning",
         detail: { reason: "duplicate" },
-        occurredAt: "2026-07-20T10:00:01.000Z",
+        occurredAt: dayAgoIso,
       });
 
       const incidents = yield* diagnostics.listOperationalDiagnostics({

--- a/apps/web/src/components/kanban/KanbanCardView.tsx
+++ b/apps/web/src/components/kanban/KanbanCardView.tsx
@@ -28,8 +28,14 @@ import { formatRelativeTime } from "~/lib/relativeTime";
 import { cn } from "~/lib/utils";
 import { formatElapsed } from "../../session-logic";
 import { RAISED_SURFACE_CHROME_CLASS_NAME } from "../chat/composerPickerStyles";
+import { KANBAN_ATTENTION_LABELS } from "@synara/shared/kanban";
 import { KanbanStatusIcon } from "./KanbanStatusIcon";
-import { KANBAN_COLUMN_LABELS, kanbanThreadCardId, type KanbanCard } from "./kanban.logic";
+import {
+  kanbanThreadCardId,
+  refineAttentionFlagsForLivePr,
+  resolveKanbanColumnLabel,
+  type KanbanCard,
+} from "./kanban.logic";
 
 /** Resolved PR badge per thread from the board root's useThreadPullRequests call. */
 export type KanbanCardPrLookup = ReadonlyMap<ThreadId, ThreadPullRequest>;
@@ -64,7 +70,7 @@ function KanbanCardColumnLabel({ card }: { card: KanbanCard }) {
   return (
     <span className="flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground/80">
       <KanbanStatusIcon column={card.column} className="size-3" />
-      {KANBAN_COLUMN_LABELS[card.column]}
+      {resolveKanbanColumnLabel(card.column)}
     </span>
   );
 }
@@ -87,6 +93,55 @@ function KanbanCardStatusPill({ card }: { card: KanbanCard }) {
     return null;
   }
   return <ThreadStatusPillChip pill={pill} />;
+}
+
+/**
+ * v2-path red attention pills. Failed and stuck render their label so the card is
+ * never a silent normal card (D1); awaiting-approval/awaiting-input/needs-review
+ * also carry their pill flags. A card can carry more than one flag (stuck +
+ * needs-review), so up to two pills render — kept compact, never a wall of red.
+ * Classic cards never set `attention`, so this stays empty for the 3-column
+ * escape hatch.
+ */
+function KanbanCardAttentionPill({
+  card,
+  pr,
+}: {
+  card: KanbanCard;
+  pr: ReturnType<typeof resolveThreadPullRequestFallback> | null;
+}) {
+  if (!card.attention || card.attention.length === 0) {
+    return null;
+  }
+  // Preserve the resolved-empty vs not-yet-resolved distinction: an explicit
+  // `null` PR means live resolution settled with no open PR (drop needs-review),
+  // while `undefined` means the row has not resolved yet (keep the initial pill).
+  // Refinement operates on raw flags (`card.attention`); display copy is mapped
+  // after, so the comparison never drifts from the flag set.
+  const refinedFlags = refineAttentionFlagsForLivePr(
+    card.attention,
+    pr === null ? null : pr?.state,
+  );
+  // Tone follows what the pill actually renders — a refined-out needs-review can
+  // never hide a failed/stuck flag behind a red pill (M1). Up to two labels.
+  const visibleFlags = refinedFlags.slice(0, 2);
+  const tone = visibleFlags.some((flag) => flag === "failed" || flag === "stuck")
+    ? "text-red-600 dark:text-red-300/90"
+    : "text-amber-600 dark:text-amber-300/90";
+  const pillClassName = cn(
+    "shrink-0 rounded-full px-2 py-0.5 text-[10.5px] font-medium ring-1 ring-inset",
+    "bg-red-500/[0.07] ring-red-500/30",
+    tone,
+  );
+  return (
+    <>
+      {visibleFlags.map((flag) => (
+        <span key={flag} className={pillClassName}>
+          {KANBAN_ATTENTION_LABELS[flag]}
+        </span>
+      ))}
+    </>
+  );
 }
 
 function KanbanCardViewComponent({
@@ -212,6 +267,9 @@ function KanbanCardViewComponent({
           ) : (
             <>
               <KanbanCardStatusPill card={card} />
+              {card.attention && card.attention.length > 0 ? (
+                <KanbanCardAttentionPill card={card} pr={pr} />
+              ) : null}
               {activeWorkElapsed ? (
                 <span className="shrink-0 text-[11px] text-muted-foreground/70">
                   Worked for {activeWorkElapsed}

--- a/apps/web/src/components/kanban/KanbanColumn.tsx
+++ b/apps/web/src/components/kanban/KanbanColumn.tsx
@@ -15,7 +15,7 @@ import { cn } from "~/lib/utils";
 import { KanbanCardView, type KanbanCardPrLookup } from "./KanbanCardView";
 import { KanbanStatusIcon } from "./KanbanStatusIcon";
 import {
-  KANBAN_COLUMN_LABELS,
+  resolveKanbanColumnLabel,
   resolveDraftDropAction,
   type KanbanCard,
   type KanbanColumnKey,
@@ -35,7 +35,12 @@ export function parseKanbanColumnDropId(
   if (prefix !== COLUMN_DROP_ID_PREFIX || projectIdParts.length === 0) {
     return null;
   }
-  if (column !== "draft" && column !== "inProgress" && column !== "done") {
+  if (
+    column !== "draft" &&
+    column !== "inProgress" &&
+    column !== "awaitingYou" &&
+    column !== "done"
+  ) {
     return null;
   }
   return { projectId: projectIdParts.join("|"), column };
@@ -90,6 +95,7 @@ function KanbanColumnComponent({
   onNewCard,
   prByThreadId,
   nowMs,
+  uncapped,
 }: {
   projectId: ProjectId;
   columnKey: KanbanColumnKey;
@@ -108,6 +114,12 @@ function KanbanColumnComponent({
   prByThreadId: KanbanCardPrLookup;
   /** Shared board clock for live elapsed labels. */
   nowMs?: number;
+  /**
+   * Board-level uncapped build (needs-review reveal): the per-column done cap is
+   * suppressed so the folded tail renders (C2) — a single source of truth for the
+   * fold instead of two stacked caps.
+   */
+  uncapped?: boolean;
 }) {
   const sortable = sortableProp ?? false;
   const droppable = droppableProp ?? false;
@@ -117,9 +129,10 @@ function KanbanColumnComponent({
   const [showAll, setShowAll] = useState(false);
 
   // Done columns can grow unbounded; cap the initial render so opening the board
-  // stays cheap for long-lived projects.
+  // stays cheap for long-lived projects. The board-level needs-review reveal
+  // (uncapped) lifts this inner cap so the folded tail renders (C2).
   const cappedCards =
-    columnKey === "done" && !showAll && cards.length > DONE_RENDER_CAP
+    columnKey === "done" && !uncapped && !showAll && cards.length > DONE_RENDER_CAP
       ? cards.slice(0, DONE_RENDER_CAP)
       : cards;
   const hiddenCount = cards.length - cappedCards.length;
@@ -158,7 +171,7 @@ function KanbanColumnComponent({
     <section className="flex min-h-0 min-w-64 flex-1 flex-col">
       <header className="flex shrink-0 items-center gap-2 px-1.5 pb-2">
         <h3 className="text-[13px] font-medium text-foreground/90">
-          {KANBAN_COLUMN_LABELS[columnKey]}
+          {resolveKanbanColumnLabel(columnKey)}
         </h3>
         <span className="text-xs text-muted-foreground/70">{cards.length}</span>
         <span className="ml-auto flex shrink-0 items-center gap-1.5">

--- a/apps/web/src/components/kanban/KanbanOverview.tsx
+++ b/apps/web/src/components/kanban/KanbanOverview.tsx
@@ -1,6 +1,7 @@
 // FILE: KanbanOverview.tsx
 // Purpose: Top kanban layer — one column per project (In Progress → Draft → Done cards);
-//          clicking a project drills into its full 3-column board.
+//          clicking a project drills into its full 3-column board. v2 mode threads the
+//          attention-first flatten order and the needs-review filter.
 // Layer: UI component (read-only; drag & drop lives in the project board)
 // Exports: KanbanOverview
 
@@ -8,7 +9,9 @@ import type { ProjectId } from "@synara/contracts";
 import { Button } from "~/components/ui/button";
 import { ChevronRightIcon, PlusIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
+import type { KanbanViewMode } from "../../kanbanUiStore";
 import { KanbanCardView, type KanbanCardPrLookup } from "./KanbanCardView";
+import { NeedsReviewFilter } from "./NeedsReviewFilter";
 import {
   overviewVisibleKanbanCards,
   type KanbanBoard,
@@ -24,6 +27,7 @@ const OverviewProjectColumn = function OverviewProjectColumn({
   onNewTask,
   prByThreadId,
   nowMs,
+  viewMode,
 }: {
   projectBoard: KanbanProjectBoard;
   onOpenProject: (projectId: ProjectId) => void;
@@ -32,8 +36,9 @@ const OverviewProjectColumn = function OverviewProjectColumn({
   onNewTask: (projectId: ProjectId) => void;
   prByThreadId: KanbanCardPrLookup;
   nowMs?: number;
+  viewMode: KanbanViewMode;
 }) {
-  const { visibleCards, hiddenCount } = overviewVisibleKanbanCards(projectBoard);
+  const { visibleCards, hiddenCount } = overviewVisibleKanbanCards(projectBoard, viewMode === "v2");
 
   return (
     <section className="flex w-72 shrink-0 flex-col">
@@ -99,6 +104,7 @@ export function KanbanOverview({
   onNewTask,
   prByThreadId,
   nowMs,
+  viewMode,
 }: {
   board: KanbanBoard;
   onOpenProject: (projectId: ProjectId) => void;
@@ -107,6 +113,7 @@ export function KanbanOverview({
   onNewTask: (projectId: ProjectId) => void;
   prByThreadId: KanbanCardPrLookup;
   nowMs?: number;
+  viewMode: KanbanViewMode;
 }) {
   // Projects without any cards are pure noise on the overview; their boards stay
   // reachable through /kanban/$projectId if linked directly.
@@ -126,19 +133,27 @@ export function KanbanOverview({
   }
 
   return (
-    <div className="flex h-full min-h-0 gap-4 overflow-x-auto px-4 pb-4">
-      {visibleProjects.map((projectBoard) => (
-        <OverviewProjectColumn
-          key={projectBoard.projectId}
-          projectBoard={projectBoard}
-          onOpenProject={onOpenProject}
-          onOpenCard={onOpenCard}
-          onCardContextMenu={onCardContextMenu}
-          onNewTask={onNewTask}
-          prByThreadId={prByThreadId}
-          {...(nowMs !== undefined ? { nowMs } : {})}
-        />
-      ))}
+    <div className="flex h-full min-h-0 flex-col">
+      {viewMode === "v2" ? (
+        <div className="flex shrink-0 items-center gap-2 px-4 pb-2">
+          <NeedsReviewFilter />
+        </div>
+      ) : null}
+      <div className="flex min-h-0 flex-1 gap-4 overflow-x-auto px-4 pb-4">
+        {visibleProjects.map((projectBoard) => (
+          <OverviewProjectColumn
+            key={projectBoard.projectId}
+            projectBoard={projectBoard}
+            onOpenProject={onOpenProject}
+            onOpenCard={onOpenCard}
+            onCardContextMenu={onCardContextMenu}
+            onNewTask={onNewTask}
+            prByThreadId={prByThreadId}
+            {...(nowMs !== undefined ? { nowMs } : {})}
+            viewMode={viewMode}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/kanban/KanbanProjectBoardView.browser.tsx
+++ b/apps/web/src/components/kanban/KanbanProjectBoardView.browser.tsx
@@ -1,0 +1,132 @@
+// FILE: KanbanProjectBoardView.browser.tsx
+// Purpose: Real-chromium render of the v2 attention-first board over seeded state.
+import "../../index.css";
+
+import { page } from "vitest/browser";
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+vi.mock("~/appSettings", () => ({
+  useAppSettings: () => ({
+    settings: {
+      defaultProvider: "codex",
+      sidebarProjectSortOrder: "manual",
+      kanbanProviderStartOptions: [],
+    },
+    setSetting: vi.fn(),
+  }),
+  getProviderStartOptions: () => [],
+  resolveAssistantDeliveryMode: () => "default",
+}));
+vi.mock("~/hooks/useProviderStatusesForLocalConfig", () => ({
+  useProviderStatusesForLocalConfig: () => [],
+}));
+vi.mock("~/hooks/useProviderStatusRefresh", () => ({
+  useRefreshProviderStatusesNow: () => () => undefined,
+}));
+vi.mock("../../lib/kanbanDispatch", () => ({
+  dispatchKanbanDraftCard: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+import type { ThreadId } from "@synara/contracts";
+import { KANBAN_ATTENTION_LABELS, KANBAN_COLUMN_V2_LABELS } from "@synara/shared/kanban";
+import { KanbanProjectBoardView } from "./KanbanProjectBoardView";
+import type { KanbanCard, KanbanProjectBoard } from "./kanban.logic";
+
+const NOW_MS = Date.parse("2026-08-21T12:00:00.000Z");
+const NOW_ISO = new Date(NOW_MS).toISOString();
+
+function makeCard(
+  id: string,
+  column: KanbanCard["column"],
+  overrides?: Partial<KanbanCard>,
+): KanbanCard {
+  return {
+    cardId: `thread:${id}`,
+    threadId: id as ThreadId,
+    projectId: "project-1" as KanbanCard["projectId"],
+    column,
+    title: `Card ${id}`,
+    provider: "codex",
+    isTerminal: false,
+    branch: null,
+    envMode: null,
+    worktreePath: null,
+    thread: null,
+    draftPrompt: "",
+    draftHasAttachments: false,
+    sortTimestamp: NOW_MS,
+    timestamp: NOW_ISO,
+    activeWorkStartedAt: column === "inProgress" ? NOW_ISO : null,
+    isOptimisticDispatch: false,
+    ...(overrides ?? {}),
+  };
+}
+
+const board: KanbanProjectBoard = {
+  projectId: "project-1" as KanbanProjectBoard["projectId"],
+  projectName: "Demo",
+  projectKind: "project",
+  draft: [makeCard("draft-1", "draft")],
+  inProgress: [makeCard("live-1", "inProgress")],
+  awaitingYou: [
+    makeCard("awaiting-1", "awaitingYou", {
+      attention: ["awaiting-approval"],
+      needsReview: true,
+    }),
+  ],
+  done: [makeCard("done-1", "done")],
+  totalCount: 4,
+  hiddenCount: 0,
+};
+
+describe("KanbanProjectBoardView v2 (browser)", () => {
+  it("renders the four-column attention-first layout with pills and filter", async () => {
+    await render(
+      <KanbanProjectBoardView
+        board={board}
+        onOpenCard={vi.fn()}
+        onNewTask={vi.fn()}
+        prByThreadId={new Map()}
+        nowMs={NOW_MS}
+        viewMode="v2"
+      />,
+    );
+
+    for (const label of Object.values(KANBAN_COLUMN_V2_LABELS)) {
+      await expect.element(page.getByRole("heading", { name: label })).toBeVisible();
+    }
+    for (const cardTitle of ["Card draft-1", "Card live-1", "Card awaiting-1", "Card done-1"]) {
+      await expect.element(page.getByText(cardTitle)).toBeVisible();
+    }
+    await expect
+      .element(page.getByText(KANBAN_ATTENTION_LABELS["awaiting-approval"]))
+      .toBeVisible();
+    await expect.element(page.getByText("Needs review")).toBeVisible();
+  });
+
+  it("keeps classic mode at three columns without the awaiting-you column", async () => {
+    const { unmount } = await render(
+      <KanbanProjectBoardView
+        board={{ ...board, awaitingYou: [] }}
+        onOpenCard={vi.fn()}
+        onNewTask={vi.fn()}
+        prByThreadId={new Map()}
+        nowMs={NOW_MS}
+        viewMode="classic"
+      />,
+    );
+
+    await expect
+      .element(page.getByRole("heading", { name: KANBAN_COLUMN_V2_LABELS.draft }))
+      .toBeVisible();
+    await expect
+      .element(page.getByRole("heading", { name: KANBAN_COLUMN_V2_LABELS.inProgress }))
+      .toBeVisible();
+    await expect
+      .element(page.getByRole("heading", { name: KANBAN_COLUMN_V2_LABELS.done }))
+      .toBeVisible();
+    expect(document.body.textContent).not.toContain(KANBAN_COLUMN_V2_LABELS.awaitingYou);
+    await unmount();
+  });
+});

--- a/apps/web/src/components/kanban/KanbanProjectBoardView.browser.tsx
+++ b/apps/web/src/components/kanban/KanbanProjectBoardView.browser.tsx
@@ -1,5 +1,4 @@
-// FILE: KanbanProjectBoardView.browser.tsx
-// Purpose: Real-chromium render of the v2 attention-first board over seeded state.
+// Real-chromium render of the v2 attention-first board over seeded state.
 import "../../index.css";
 
 import { page } from "vitest/browser";
@@ -8,11 +7,7 @@ import { render } from "vitest-browser-react";
 
 vi.mock("~/appSettings", () => ({
   useAppSettings: () => ({
-    settings: {
-      defaultProvider: "codex",
-      sidebarProjectSortOrder: "manual",
-      kanbanProviderStartOptions: [],
-    },
+    settings: { defaultProvider: "codex", sidebarProjectSortOrder: "manual" },
     setSetting: vi.fn(),
   }),
   getProviderStartOptions: () => [],
@@ -34,13 +29,8 @@ import { KanbanProjectBoardView } from "./KanbanProjectBoardView";
 import type { KanbanCard, KanbanProjectBoard } from "./kanban.logic";
 
 const NOW_MS = Date.parse("2026-08-21T12:00:00.000Z");
-const NOW_ISO = new Date(NOW_MS).toISOString();
 
-function makeCard(
-  id: string,
-  column: KanbanCard["column"],
-  overrides?: Partial<KanbanCard>,
-): KanbanCard {
+function makeCard(id: string, column: KanbanCard["column"], overrides?: Partial<KanbanCard>) {
   return {
     cardId: `thread:${id}`,
     threadId: id as ThreadId,
@@ -56,29 +46,26 @@ function makeCard(
     draftPrompt: "",
     draftHasAttachments: false,
     sortTimestamp: NOW_MS,
-    timestamp: NOW_ISO,
-    activeWorkStartedAt: column === "inProgress" ? NOW_ISO : null,
+    timestamp: new Date(NOW_MS).toISOString(),
+    activeWorkStartedAt: column === "inProgress" ? new Date(NOW_MS).toISOString() : null,
     isOptimisticDispatch: false,
-    ...(overrides ?? {}),
-  };
+    ...overrides,
+  } satisfies KanbanCard;
 }
 
-const board: KanbanProjectBoard = {
+const board = {
   projectId: "project-1" as KanbanProjectBoard["projectId"],
   projectName: "Demo",
-  projectKind: "project",
+  projectKind: "project" as const,
   draft: [makeCard("draft-1", "draft")],
   inProgress: [makeCard("live-1", "inProgress")],
   awaitingYou: [
-    makeCard("awaiting-1", "awaitingYou", {
-      attention: ["awaiting-approval"],
-      needsReview: true,
-    }),
+    makeCard("awaiting-1", "awaitingYou", { attention: ["awaiting-approval"], needsReview: true }),
   ],
   done: [makeCard("done-1", "done")],
   totalCount: 4,
   hiddenCount: 0,
-};
+} satisfies KanbanProjectBoard;
 
 describe("KanbanProjectBoardView v2 (browser)", () => {
   it("renders the four-column attention-first layout with pills and filter", async () => {
@@ -117,15 +104,9 @@ describe("KanbanProjectBoardView v2 (browser)", () => {
       />,
     );
 
-    await expect
-      .element(page.getByRole("heading", { name: KANBAN_COLUMN_V2_LABELS.draft }))
-      .toBeVisible();
-    await expect
-      .element(page.getByRole("heading", { name: KANBAN_COLUMN_V2_LABELS.inProgress }))
-      .toBeVisible();
-    await expect
-      .element(page.getByRole("heading", { name: KANBAN_COLUMN_V2_LABELS.done }))
-      .toBeVisible();
+    for (const label of ["Draft", "In Progress"] as const) {
+      await expect.element(page.getByRole("heading", { name: label })).toBeVisible();
+    }
     expect(document.body.textContent).not.toContain(KANBAN_COLUMN_V2_LABELS.awaitingYou);
     await unmount();
   });

--- a/apps/web/src/components/kanban/KanbanProjectBoardView.tsx
+++ b/apps/web/src/components/kanban/KanbanProjectBoardView.tsx
@@ -23,6 +23,7 @@ import {
   resolveAssistantDeliveryMode,
   useAppSettings,
 } from "~/appSettings";
+import { Button } from "~/components/ui/button";
 import { toastManager } from "~/components/ui/toast";
 import { useProviderStatusesForLocalConfig } from "~/hooks/useProviderStatusesForLocalConfig";
 import { useRefreshProviderStatusesNow } from "~/hooks/useProviderStatusRefresh";
@@ -30,8 +31,11 @@ import { resolveProviderSendAvailabilityWithRefresh } from "~/lib/providerAvaila
 import { dispatchKanbanDraftCard } from "../../lib/kanbanDispatch";
 import { KanbanCardView, type KanbanCardPrLookup } from "./KanbanCardView";
 import { KanbanColumn, parseKanbanColumnDropId } from "./KanbanColumn";
+import { NeedsReviewFilter } from "./NeedsReviewFilter";
 import {
   reorderDraftCardIds,
+  resolveReviewFoldToggleLabel,
+  shouldShowReviewFoldToggle,
   type KanbanCard,
   type KanbanColumnKey,
   type KanbanProjectBoard,
@@ -41,6 +45,11 @@ import { useKanbanUiStore } from "../../kanbanUiStore";
 function resolveDropColumn(board: KanbanProjectBoard, overId: string): KanbanColumnKey | null {
   const columnDrop = parseKanbanColumnDropId(overId);
   if (columnDrop) {
+    // Awaiting you is derived-only (D1/S1-P6) — the drop is reported so the
+    // board can explain instead of silently no-op (L1), like the Done column.
+    if (columnDrop.column === "awaitingYou") {
+      return "awaitingYou";
+    }
     return columnDrop.projectId === board.projectId ? columnDrop.column : null;
   }
   // Sortable draft cards are the only non-column droppables on this board.
@@ -62,6 +71,7 @@ export function KanbanProjectBoardView({
   onNewTask,
   prByThreadId,
   nowMs,
+  viewMode,
 }: {
   board: KanbanProjectBoard;
   onOpenCard: (card: KanbanCard) => void;
@@ -69,6 +79,8 @@ export function KanbanProjectBoardView({
   onNewTask: () => void;
   prByThreadId: KanbanCardPrLookup;
   nowMs?: number;
+  /** v2 four-column layout vs classic 3-column escape hatch. */
+  viewMode: "classic" | "v2";
 }) {
   const { settings } = useAppSettings();
   const assistantDeliveryMode = resolveAssistantDeliveryMode(settings);
@@ -76,6 +88,8 @@ export function KanbanProjectBoardView({
   const providerStatuses = useProviderStatusesForLocalConfig();
   const refreshProviderStatuses = useRefreshProviderStatusesNow();
   const setDraftOrder = useKanbanUiStore((state) => state.setDraftOrder);
+  const hasRevealedReviewFold = useKanbanUiStore((state) => state.hasRevealedReviewFold);
+  const setHasRevealedReviewFold = useKanbanUiStore((state) => state.setHasRevealedReviewFold);
   const [activeCard, setActiveCard] = useState<KanbanCard | null>(null);
   // A completed drag still emits a click on the source card; swallow exactly that one
   // so dropping a card never also opens its chat.
@@ -215,6 +229,14 @@ export function KanbanProjectBoardView({
         title: "Done is derived automatically",
         description: "Cards move here when their runs complete.",
       });
+      return;
+    }
+    if (targetColumn === "awaitingYou") {
+      toastManager.add({
+        type: "info",
+        title: "Awaiting you is derived automatically",
+        description: "Cards move here when they need your approval, input, or a retry.",
+      });
     }
   };
 
@@ -226,42 +248,77 @@ export function KanbanProjectBoardView({
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
     >
-      <div className="flex h-full min-h-0 gap-3 overflow-x-auto px-4 pb-4">
-        <KanbanColumn
-          projectId={board.projectId}
-          columnKey="draft"
-          cards={board.draft}
-          onOpenCard={handleOpenCard}
-          onCardContextMenu={onCardContextMenu}
-          sortable
-          droppable
-          activeCard={activeCard}
-          onNewCard={onNewTask}
-          prByThreadId={prByThreadId}
-          {...(nowMs !== undefined ? { nowMs } : {})}
-        />
-        <KanbanColumn
-          projectId={board.projectId}
-          columnKey="inProgress"
-          cards={board.inProgress}
-          onOpenCard={handleOpenCard}
-          onCardContextMenu={onCardContextMenu}
-          droppable
-          activeCard={activeCard}
-          prByThreadId={prByThreadId}
-          {...(nowMs !== undefined ? { nowMs } : {})}
-        />
-        <KanbanColumn
-          projectId={board.projectId}
-          columnKey="done"
-          cards={board.done}
-          onOpenCard={handleOpenCard}
-          onCardContextMenu={onCardContextMenu}
-          droppable
-          activeCard={activeCard}
-          prByThreadId={prByThreadId}
-          {...(nowMs !== undefined ? { nowMs } : {})}
-        />
+      <div className="flex h-full min-h-0 flex-col">
+        {viewMode === "v2" ? (
+          <div className="flex shrink-0 items-center gap-2 px-4 pb-2">
+            <NeedsReviewFilter />
+            {shouldShowReviewFoldToggle(hasRevealedReviewFold, board.hiddenCount) ? (
+              <Button
+                size="xs"
+                variant="ghost"
+                className="text-xs text-muted-foreground/80 hover:text-foreground"
+                onClick={() => setHasRevealedReviewFold(!hasRevealedReviewFold)}
+              >
+                {resolveReviewFoldToggleLabel(hasRevealedReviewFold, board.hiddenCount)}
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+        <div className="flex min-h-0 flex-1 gap-3 overflow-x-auto px-4 pb-4">
+          <KanbanColumn
+            projectId={board.projectId}
+            columnKey="draft"
+            cards={board.draft}
+            onOpenCard={handleOpenCard}
+            onCardContextMenu={onCardContextMenu}
+            sortable
+            droppable
+            activeCard={activeCard}
+            onNewCard={onNewTask}
+            prByThreadId={prByThreadId}
+            {...(nowMs !== undefined ? { nowMs } : {})}
+          />
+          <KanbanColumn
+            projectId={board.projectId}
+            columnKey="inProgress"
+            cards={board.inProgress}
+            onOpenCard={handleOpenCard}
+            onCardContextMenu={onCardContextMenu}
+            droppable
+            activeCard={activeCard}
+            prByThreadId={prByThreadId}
+            {...(nowMs !== undefined ? { nowMs } : {})}
+          />
+          {viewMode === "v2" ? (
+            <KanbanColumn
+              projectId={board.projectId}
+              columnKey="awaitingYou"
+              cards={board.awaitingYou}
+              onOpenCard={handleOpenCard}
+              onCardContextMenu={onCardContextMenu}
+              // Droppable so a drop onto it produces the explaining toast rather
+              // than silently falling through to empty space (L1).
+              droppable
+              activeCard={activeCard}
+              prByThreadId={prByThreadId}
+              {...(nowMs !== undefined ? { nowMs } : {})}
+            />
+          ) : null}
+          <KanbanColumn
+            projectId={board.projectId}
+            columnKey="done"
+            cards={board.done}
+            onOpenCard={handleOpenCard}
+            onCardContextMenu={onCardContextMenu}
+            droppable
+            activeCard={activeCard}
+            prByThreadId={prByThreadId}
+            {...(nowMs !== undefined ? { nowMs } : {})}
+            // Fold the inner done-column cap under the board-level reveal so a
+            // >30 done column's tail is reachable in one unfold (C2).
+            {...(viewMode === "v2" && hasRevealedReviewFold ? { uncapped: true } : {})}
+          />
+        </div>
       </div>
       <DragOverlay dropAnimation={null}>
         {activeCard ? (

--- a/apps/web/src/components/kanban/KanbanStatusIcon.tsx
+++ b/apps/web/src/components/kanban/KanbanStatusIcon.tsx
@@ -1,7 +1,8 @@
 // FILE: KanbanStatusIcon.tsx
 // Purpose: Linear-style column status glyph — dashed circle (Draft), half-filled
-//          yellow pie (In Progress), filled indigo check (Done). Shared by board
-//          column headers and card status labels.
+//          yellow pie (In Progress), filled indigo check (Done), raised hand
+//          (Awaiting you, attention-colored). Shared by board column headers
+//          and card status labels.
 // Layer: Kanban UI component
 // Exports: KanbanStatusIcon
 
@@ -43,6 +44,33 @@ export function KanbanStatusIcon({
       >
         <circle cx="7" cy="7" r="6" fill="none" stroke="currentColor" strokeWidth="1.7" />
         <path d="M7 3.5 A3.5 3.5 0 0 1 7 10.5 Z" fill="currentColor" />
+      </svg>
+    );
+  }
+  if (column === "awaitingYou") {
+    // Raised-hand glyph — the human's ball is in play, distinct from the draft
+    // dashed circle and the in-progress pie. Attention-colored (amber) like the
+    // awaiting-you pills so the column reads coherently at a glance.
+    return (
+      <svg
+        viewBox="0 0 14 14"
+        className={cn("size-3.5 shrink-0 text-amber-600 dark:text-amber-300/90", className)}
+        aria-hidden
+      >
+        <path
+          d="M4.3 8.4V5.2M6 8.4V4.9M7.7 8.4V5M9.4 8.4V5.6"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+        <path
+          d="M3.9 9.7a3.1 3.1 0 0 0 6.2 0"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
       </svg>
     );
   }

--- a/apps/web/src/components/kanban/KanbanView.tsx
+++ b/apps/web/src/components/kanban/KanbanView.tsx
@@ -51,6 +51,7 @@ import { KanbanProjectBoardView } from "./KanbanProjectBoardView";
 import { useKanbanBoard } from "./useKanbanBoard";
 import { useKanbanCardContextMenu } from "./useKanbanCardContextMenu";
 import { overviewVisibleKanbanCards, type KanbanCard } from "./kanban.logic";
+import { useKanbanUiStore } from "../../kanbanUiStore";
 
 export default function KanbanView({ projectId }: { projectId: string | null }) {
   const navigate = useNavigate();
@@ -59,6 +60,8 @@ export default function KanbanView({ projectId }: { projectId: string | null }) 
   const desktopTopBarTrafficLightGutterClassName = useDesktopTopBarTrafficLightGutterClassName();
   const desktopTopBarWindowControlsGutterClassName =
     useDesktopTopBarWindowControlsGutterClassName();
+  const kanbanViewMode = useKanbanUiStore((state) => state.kanbanViewMode);
+  const setKanbanViewMode = useKanbanUiStore((state) => state.setKanbanViewMode);
 
   const projectBoard =
     projectId === null
@@ -78,11 +81,19 @@ export default function KanbanView({ projectId }: { projectId: string | null }) 
     [allProjects],
   );
   const renderedCardThreads = useMemo(() => {
+    const isV2 = kanbanViewMode === "v2";
     const cards = projectBoard
-      ? [...projectBoard.inProgress, ...projectBoard.draft, ...projectBoard.done]
-      : board.projects.flatMap((candidate) => overviewVisibleKanbanCards(candidate).visibleCards);
+      ? [
+          ...projectBoard.inProgress,
+          ...(isV2 ? projectBoard.awaitingYou : []),
+          ...projectBoard.draft,
+          ...projectBoard.done,
+        ]
+      : board.projects.flatMap(
+          (candidate) => overviewVisibleKanbanCards(candidate, isV2).visibleCards,
+        );
     return cards.flatMap((card) => (card.thread ? [card.thread] : []));
-  }, [board.projects, projectBoard]);
+  }, [board.projects, kanbanViewMode, projectBoard]);
   const prByThreadId = useThreadPullRequests({
     threads: renderedCardThreads,
     projectCwdById,
@@ -200,6 +211,28 @@ export default function KanbanView({ projectId }: { projectId: string | null }) 
               <span className="shrink-0 text-xs text-muted-foreground/70">
                 {projectBoard ? projectBoard.totalCount : board.totalCount} tasks
               </span>
+              <div
+                role="radiogroup"
+                aria-label="Kanban view"
+                className="ml-auto flex shrink-0 items-center gap-1 rounded-lg p-0.5 ring-1 ring-inset ring-border/60"
+              >
+                {(["classic", "v2"] as const).map((mode) => {
+                  const isActive = kanbanViewMode === mode;
+                  return (
+                    <Button
+                      key={mode}
+                      role="radio"
+                      aria-checked={isActive}
+                      size="xs"
+                      variant={isActive ? "secondary" : "ghost"}
+                      className={cn("h-6 px-2 text-[11px]", !isActive && "text-muted-foreground")}
+                      onClick={() => setKanbanViewMode(mode)}
+                    >
+                      {mode === "v2" ? "Attention" : "Classic"}
+                    </Button>
+                  );
+                })}
+              </div>
               <Tooltip>
                 <TooltipTrigger
                   render={
@@ -239,6 +272,7 @@ export default function KanbanView({ projectId }: { projectId: string | null }) 
               onNewTask={handleNewDraftInProjectBoard}
               prByThreadId={prByThreadId}
               nowMs={nowMs}
+              viewMode={kanbanViewMode}
             />
           ) : (
             <KanbanOverview
@@ -249,6 +283,7 @@ export default function KanbanView({ projectId }: { projectId: string | null }) 
               onNewTask={handleNewTask}
               prByThreadId={prByThreadId}
               nowMs={nowMs}
+              viewMode={kanbanViewMode}
             />
           )}
         </div>

--- a/apps/web/src/components/kanban/KanbanView.tsx
+++ b/apps/web/src/components/kanban/KanbanView.tsx
@@ -67,8 +67,10 @@ export default function KanbanView({ projectId }: { projectId: string | null }) 
     projectId === null
       ? null
       : (board.projects.find((candidate) => candidate.projectId === projectId) ?? null);
-  const hasActiveCardWork = board.projects.some((project) =>
-    project.inProgress.some((card) => card.activeWorkStartedAt !== null),
+  const hasActiveCardWork = board.projects.some(
+    (project) =>
+      project.inProgress.some((card) => card.activeWorkStartedAt !== null) ||
+      project.awaitingYou.some((card) => card.activeWorkStartedAt !== null),
   );
   const nowMs = useNowMs(hasActiveCardWork);
 

--- a/apps/web/src/components/kanban/NeedsReviewFilter.tsx
+++ b/apps/web/src/components/kanban/NeedsReviewFilter.tsx
@@ -1,0 +1,24 @@
+// FILE: NeedsReviewFilter.tsx
+// Purpose: The v2-only "Needs review" toggle. Reads and writes the persisted
+//          `kanbanNeedsReviewFilter` store flag directly, so the project board
+//          and the overview render one identical control (component-level single
+//          source, mirroring the disclosureMotion convention).
+// Layer: Kanban UI component (store-aware)
+// Exports: NeedsReviewFilter
+
+import { Checkbox } from "../ui/checkbox";
+import { useKanbanUiStore } from "../../kanbanUiStore";
+
+export function NeedsReviewFilter() {
+  const needsReviewEnabled = useKanbanUiStore((state) => state.kanbanNeedsReviewFilter);
+  const setNeedsReviewEnabled = useKanbanUiStore((state) => state.setKanbanNeedsReviewFilter);
+  return (
+    <label className="flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground/80">
+      <Checkbox
+        checked={needsReviewEnabled}
+        onCheckedChange={(checked) => setNeedsReviewEnabled(checked === true)}
+      />
+      Needs review
+    </label>
+  );
+}

--- a/apps/web/src/components/kanban/kanban.logic.test.ts
+++ b/apps/web/src/components/kanban/kanban.logic.test.ts
@@ -7,16 +7,22 @@ import {
   areKanbanComposerDraftSnapshotsEqual,
   buildKanbanComposerDraftSnapshot,
   buildKanbanBoard,
+  deriveKanbanCardAttention,
   deriveKanbanColumn,
-  flattenProjectBoardForOverview,
+  deriveKanbanColumnV2,
   isKanbanDraftOnlyCard,
   kanbanDraftCardId,
   kanbanThreadCardId,
+  KANBAN_NEEDS_REVIEW_CAP,
   orderDraftCards,
   overviewVisibleKanbanCards,
   reorderDraftCardIds,
+  refineAttentionFlagsForLivePr,
   resolveDraftDropAction,
   resolveOptimisticDispatchOutcome,
+  resolveReviewFoldToggleLabel,
+  shouldShowReviewFoldToggle,
+  shouldToastForExpiredDispatch,
   type BuildKanbanBoardInput,
   type KanbanCard,
   type KanbanOptimisticDispatchSnapshot,
@@ -940,7 +946,7 @@ describe("resolveDraftDropAction", () => {
   });
 });
 
-describe("flattenProjectBoardForOverview", () => {
+describe("overviewVisibleKanbanCards", () => {
   const card = (cardId: string, column: KanbanCard["column"]): KanbanCard => ({
     cardId,
     threadId: ThreadId.makeUnsafe(cardId),
@@ -960,9 +966,12 @@ describe("flattenProjectBoardForOverview", () => {
     activeWorkStartedAt: null,
     isOptimisticDispatch: false,
   });
-  const board = (columns: Partial<Pick<KanbanProjectBoard, "draft" | "inProgress" | "done">>) => {
+  const board = (
+    columns: Partial<Pick<KanbanProjectBoard, "draft" | "inProgress" | "awaitingYou" | "done">>,
+  ) => {
     const draft = columns.draft ?? [];
     const inProgress = columns.inProgress ?? [];
+    const awaitingYou = columns.awaitingYou ?? [];
     const done = columns.done ?? [];
     return {
       projectId: ProjectId.makeUnsafe("project-1"),
@@ -970,30 +979,36 @@ describe("flattenProjectBoardForOverview", () => {
       projectKind: "project" as const,
       draft,
       inProgress,
+      awaitingYou,
       done,
-      totalCount: draft.length + inProgress.length + done.length,
+      totalCount: draft.length + inProgress.length + awaitingYou.length + done.length,
+      hiddenCount: 0,
     };
   };
 
-  it("orders cards In Progress, then Draft, then Done", () => {
-    const flattened = flattenProjectBoardForOverview(
-      board({
-        draft: [card("d", "draft")],
-        inProgress: [card("w", "inProgress")],
-        done: [card("x", "done")],
-      }),
-    );
+  it("caps each column before flattening and reports the folded remainder (H3)", () => {
+    const inProgress = Array.from({ length: 25 }, (_, index) => card(`w-${index}`, "inProgress"));
+    const done = Array.from({ length: 25 }, (_, index) => card(`d-${index}`, "done"));
+    const { visibleCards, hiddenCount } = overviewVisibleKanbanCards(board({ inProgress, done }));
 
-    expect(flattened.map((entry) => entry.cardId)).toEqual(["w", "d", "x"]);
+    // Per-column cap: 20 each, so no In Progress card is pushed off the window
+    // by the Done tail — the attention-first contract of the overview.
+    expect(visibleCards).toHaveLength(40);
+    expect(hiddenCount).toBe(10);
+    expect(visibleCards.slice(0, 20).map((entry) => entry.cardId)[0]).toBe("w-0");
+    expect(visibleCards.at(-1)?.cardId).toBe("d-19");
   });
 
-  it("caps the overview's visible cards and reports the folded remainder", () => {
-    const done = Array.from({ length: 25 }, (_, index) => card(`done-${index}`, "done"));
-    const { visibleCards, hiddenCount } = overviewVisibleKanbanCards(board({ done }));
+  it("routes Awaiting you after In Progress in v2 overview order", () => {
+    const boardData = board({
+      inProgress: [card("w", "inProgress")],
+      awaitingYou: [card("a", "awaitingYou")],
+      draft: [card("s", "draft")],
+      done: [card("x", "done")],
+    });
+    const { visibleCards } = overviewVisibleKanbanCards(boardData, true);
 
-    expect(visibleCards).toHaveLength(20);
-    expect(hiddenCount).toBe(5);
-    expect(visibleCards.at(-1)?.cardId).toBe("done-19");
+    expect(visibleCards.map((entry) => entry.cardId)).toEqual(["w", "a", "s", "x"]);
   });
 
   it("shows every card when the overview cap is not reached", () => {
@@ -1003,5 +1018,357 @@ describe("flattenProjectBoardForOverview", () => {
 
     expect(visibleCards.map((entry) => entry.cardId)).toEqual(["w"]);
     expect(hiddenCount).toBe(0);
+  });
+
+  it("caps only the overflowing columns in v2 routing, not the whole project", () => {
+    const awaitingYou = Array.from({ length: 30 }, (_, index) => card(`a-${index}`, "awaitingYou"));
+    const { visibleCards, hiddenCount } = overviewVisibleKanbanCards(
+      board({ awaitingYou, done: [card("x", "done")] }),
+      true,
+    );
+
+    expect(visibleCards).toHaveLength(21);
+    expect(hiddenCount).toBe(10);
+    expect(visibleCards.at(-1)?.cardId).toBe("x");
+  });
+});
+
+const FROZEN_NOW_MS = Date.parse("2026-03-09T12:00:00.000Z");
+const FROZEN_NOW_ISO = new Date(FROZEN_NOW_MS).toISOString();
+
+describe("deriveKanbanColumnV2 (web adapter)", () => {
+  it("maps the web summary into the shared derivation and returns awaitingYou for pending approval", () => {
+    const thread = makeSidebarThreadSummary({
+      hasPendingApprovals: true,
+      session: makeSession({
+        status: "running",
+        orchestrationStatus: "running",
+        updatedAt: FROZEN_NOW_ISO,
+      }),
+      latestTurn: makeLatestTurn({ state: "running", completedAt: null }),
+    });
+    expect(deriveKanbanColumnV2(thread, FROZEN_NOW_MS)).toBe("awaitingYou");
+  });
+
+  it("falls back to the shared function without `now` for non-staleness cases", () => {
+    const settled = makeSidebarThreadSummary({ latestTurn: makeLatestTurn() });
+    expect(deriveKanbanColumnV2(settled)).toBe("done");
+    expect(deriveKanbanColumnV2(makeSidebarThreadSummary())).toBe("draft");
+    expect(deriveKanbanColumnV2(makeSidebarThreadSummary({ hasLiveTailWork: true }))).toBe(
+      "inProgress",
+    );
+  });
+
+  it("uses orchestrationStatus as the session status label", () => {
+    // `status: "connecting"` maps from the legacy phase; the adapter reads
+    // `orchestrationStatus` (the shared union) instead.
+    const connecting = makeSidebarThreadSummary({
+      session: makeSession({
+        status: "connecting",
+        orchestrationStatus: "starting",
+        updatedAt: FROZEN_NOW_ISO,
+      }),
+    });
+    expect(deriveKanbanColumnV2(connecting, FROZEN_NOW_MS)).toBe("inProgress");
+  });
+
+  it("parity with the shared module for a dead-session pending thread", () => {
+    const deadPending = makeSidebarThreadSummary({
+      hasPendingUserInput: true,
+      latestTurn: makeLatestTurn(),
+      session: makeSession({ status: "closed", orchestrationStatus: "stopped" }),
+    });
+    expect(deriveKanbanColumnV2(deadPending, FROZEN_NOW_MS)).toBe("done");
+  });
+});
+
+describe("deriveKanbanCardAttention", () => {
+  it("produces no attention on a plain settled card", () => {
+    const { attention, attentionLabels } = deriveKanbanCardAttention(
+      makeSidebarThreadSummary({
+        latestTurn: makeLatestTurn(),
+        session: makeSession({ orchestrationStatus: "ready", updatedAt: FROZEN_NOW_ISO }),
+      }),
+      { now: FROZEN_NOW_MS },
+    );
+    expect(attention).toEqual([]);
+    expect(attentionLabels).toEqual([]);
+  });
+
+  it("surfaces the failed pill when the session errored", () => {
+    const { attention, attentionLabels } = deriveKanbanCardAttention(
+      makeSidebarThreadSummary({
+        latestTurn: makeLatestTurn({ state: "error" }),
+        session: makeSession({
+          status: "error",
+          orchestrationStatus: "error",
+          lastError: "boom",
+          updatedAt: FROZEN_NOW_ISO,
+        }),
+      }),
+      { now: FROZEN_NOW_MS },
+    );
+    expect(attention).toContain("failed");
+    expect(attentionLabels).toContain("Failed");
+  });
+
+  it("adds needs-review when the caller passes an open PR", () => {
+    const { attention } = deriveKanbanCardAttention(
+      makeSidebarThreadSummary({
+        latestTurn: makeLatestTurn(),
+        session: makeSession({ orchestrationStatus: "ready", updatedAt: FROZEN_NOW_ISO }),
+      }),
+      { now: FROZEN_NOW_MS, needsReview: true },
+    );
+    expect(attention).toContain("needs-review");
+  });
+});
+
+describe("buildKanbanBoard v2 mode", () => {
+  const v2Options = (overrides: Partial<Parameters<typeof buildKanbanBoard>[1]> = {}) => ({
+    now: FROZEN_NOW_MS,
+    ...overrides,
+  });
+
+  it("buckets awaitingYou cards separately from inProgress", () => {
+    const awaiting = makeSidebarThreadSummary({
+      id: ThreadId.makeUnsafe("thread-awaited"),
+      hasPendingApprovals: true,
+      latestTurn: makeLatestTurn({ state: "running", completedAt: null }),
+      session: makeSession({
+        status: "running",
+        orchestrationStatus: "running",
+        updatedAt: FROZEN_NOW_ISO,
+      }),
+    });
+    const running = makeSidebarThreadSummary({
+      id: ThreadId.makeUnsafe("thread-running"),
+      hasLiveTailWork: true,
+      latestTurn: makeLatestTurn({ state: "running", completedAt: null }),
+      session: makeSession({
+        status: "running",
+        orchestrationStatus: "running",
+        updatedAt: FROZEN_NOW_ISO,
+      }),
+    });
+    const board = buildKanbanBoard(makeBoardInput({ threads: [awaiting, running] }), v2Options());
+    const project = board.projects[0]!;
+    expect(project.inProgress.map((card) => card.threadId)).toEqual(["thread-running"]);
+    expect(project.awaitingYou.map((card) => card.threadId)).toEqual(["thread-awaited"]);
+  });
+
+  it("fills attention and attentionLabel on thread cards in v2 mode", () => {
+    const failed = makeSidebarThreadSummary({
+      id: ThreadId.makeUnsafe("thread-failed"),
+      latestTurn: makeLatestTurn({ state: "error" }),
+      session: makeSession({
+        status: "error",
+        orchestrationStatus: "error",
+        lastError: "x",
+        updatedAt: FROZEN_NOW_ISO,
+      }),
+    });
+    const board = buildKanbanBoard(makeBoardInput({ threads: [failed] }), v2Options());
+    const card = board.projects[0]!.awaitingYou[0]!;
+    expect(card.attention).toContain("failed");
+    expect(card.attentionLabels).toContain("Failed");
+  });
+
+  it("leaves classic cards with no attention fields", () => {
+    const failed = makeSidebarThreadSummary({
+      id: ThreadId.makeUnsafe("thread-failed"),
+      latestTurn: makeLatestTurn({ state: "error" }),
+      session: makeSession({ status: "error", orchestrationStatus: "error" }),
+    });
+    const board = buildKanbanBoard(makeBoardInput({ threads: [failed] }));
+    const doneCard = board.projects[0]!.done[0]!;
+    expect(doneCard.attention).toBeUndefined();
+    expect(doneCard.attentionLabels).toBeUndefined();
+  });
+
+  it("applies the needs-review filter in v2 mode", () => {
+    const noReview = makeSidebarThreadSummary({
+      id: ThreadId.makeUnsafe("thread-noreview"),
+      latestTurn: makeLatestTurn(),
+    });
+    const withReview = makeSidebarThreadSummary({
+      id: ThreadId.makeUnsafe("thread-review"),
+      latestTurn: makeLatestTurn(),
+      lastKnownPr: {
+        number: 1,
+        title: "Open PR",
+        url: "https://example.com/pr/1",
+        baseBranch: "main",
+        headBranch: "fix",
+        state: "open",
+      },
+    });
+    const filtered = buildKanbanBoard(
+      makeBoardInput({ threads: [noReview, withReview] }),
+      v2Options({
+        needsReviewByThreadId: { "thread-review": true },
+        isNeedsReviewActive: true,
+      }),
+    );
+    const project = filtered.projects[0]!;
+    expect(project.done.map((card) => card.threadId)).toEqual(["thread-review"]);
+    expect(project.totalCount).toBe(1);
+    expect(project.done[0]!.needsReview).toBe(true);
+  });
+
+  it("caps each column at KANBAN_NEEDS_REVIEW_CAP rows in the filtered view", () => {
+    const reviewThreads = Array.from({ length: KANBAN_NEEDS_REVIEW_CAP + 8 }, (_, index) =>
+      makeSidebarThreadSummary({
+        id: ThreadId.makeUnsafe(`thread-review-${index}`),
+        latestTurn: makeLatestTurn(),
+        lastKnownPr: {
+          number: index + 1,
+          title: "Open PR",
+          url: "https://example.com/pr",
+          baseBranch: "main",
+          headBranch: `fix-${index}`,
+          state: "open",
+        },
+      }),
+    );
+    const needsReviewByThreadId: Record<string, boolean> = {};
+    for (const thread of reviewThreads) {
+      needsReviewByThreadId[thread.id] = true;
+    }
+    const filtered = buildKanbanBoard(
+      makeBoardInput({ threads: reviewThreads }),
+      v2Options({ needsReviewByThreadId, isNeedsReviewActive: true }),
+    );
+    expect(filtered.projects[0]!.done).toHaveLength(KANBAN_NEEDS_REVIEW_CAP);
+    // The header count stays the true pre-cap total (H1): the cap only narrows
+    // what renders, so all review threads count toward it.
+    expect(filtered.projects[0]!.totalCount).toBe(KANBAN_NEEDS_REVIEW_CAP + 8);
+    // Cards folded behind the per-column cap are reported for a reveal affordance.
+    expect(filtered.projects[0]!.hiddenCount).toBe(8);
+  });
+
+  it("reveals the folded needs-review tail when the board is built uncapped (H1)", () => {
+    const reviewThreads = Array.from({ length: KANBAN_NEEDS_REVIEW_CAP + 5 }, (_, index) =>
+      makeSidebarThreadSummary({
+        id: ThreadId.makeUnsafe(`thread-review-fold-${index}`),
+        latestTurn: makeLatestTurn(),
+        lastKnownPr: {
+          number: index + 1,
+          title: "Open PR",
+          url: "https://example.com/pr",
+          baseBranch: "main",
+          headBranch: `fix-${index}`,
+          state: "open",
+        },
+      }),
+    );
+    const needsReviewByThreadId: Record<string, boolean> = {};
+    for (const thread of reviewThreads) {
+      needsReviewByThreadId[thread.id] = true;
+    }
+    const revealed = buildKanbanBoard(
+      makeBoardInput({ threads: reviewThreads }),
+      v2Options({ needsReviewByThreadId, isNeedsReviewActive: true, uncapped: true }),
+    );
+    const project = revealed.projects[0]!;
+    expect(project.done).toHaveLength(KANBAN_NEEDS_REVIEW_CAP + 5);
+    expect(project.hiddenCount).toBe(0);
+    // The header count is unchanged by the reveal — it was already the pre-cap total.
+    expect(project.totalCount).toBe(KANBAN_NEEDS_REVIEW_CAP + 5);
+  });
+
+  it("keeps all cards when the needs-review filter is off", () => {
+    const board = buildKanbanBoard(
+      makeBoardInput({ threads: [makeSidebarThreadSummary({ latestTurn: makeLatestTurn() })] }),
+      v2Options(),
+    );
+    expect(board.projects[0]!.done).toHaveLength(1);
+  });
+});
+
+describe("refineAttentionFlagsForLivePr", () => {
+  // Attention labels flow through as raw flag identifiers, not display copy.
+  const failedFlag = "failed";
+  const needsReviewFlag = "needs-review";
+
+  it("keeps labels while the row has not resolved yet (undefined)", () => {
+    expect(refineAttentionFlagsForLivePr([failedFlag, needsReviewFlag], undefined)).toEqual([
+      failedFlag,
+      needsReviewFlag,
+    ]);
+  });
+
+  it("keeps needs-review while the live row is open", () => {
+    expect(refineAttentionFlagsForLivePr([failedFlag, needsReviewFlag], "open")).toEqual([
+      failedFlag,
+      needsReviewFlag,
+    ]);
+  });
+
+  it("drops needs-review once the live row settles merged", () => {
+    expect(refineAttentionFlagsForLivePr([failedFlag, needsReviewFlag], "merged")).toEqual([
+      failedFlag,
+    ]);
+  });
+
+  it("drops needs-review when live resolution settled empty (null, C3/M3)", () => {
+    expect(refineAttentionFlagsForLivePr([failedFlag, needsReviewFlag], null)).toEqual([
+      failedFlag,
+    ]);
+  });
+
+  it("drops needs-review once the live row settles closed", () => {
+    expect(refineAttentionFlagsForLivePr([needsReviewFlag], "closed")).toEqual([]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(refineAttentionFlagsForLivePr(undefined, undefined)).toEqual([]);
+    expect(refineAttentionFlagsForLivePr([], "open")).toEqual([]);
+  });
+});
+
+describe("shouldToastForExpiredDispatch (H5)", () => {
+  it("stays silent when the thread left the display set", () => {
+    expect(shouldToastForExpiredDispatch(undefined)).toBe(false);
+  });
+
+  it("stays silent while the thread still derives In Progress (slow provider)", () => {
+    expect(shouldToastForExpiredDispatch(makeSidebarThreadSummary({ hasLiveTailWork: true }))).toBe(
+      false,
+    );
+    expect(
+      shouldToastForExpiredDispatch(
+        makeSidebarThreadSummary({
+          session: makeSession({ status: "running", orchestrationStatus: "running" }),
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("toasts when the thread reverted to a non-progress column", () => {
+    // A plain thread with a settled turn derives Done after the expiry window —
+    // the revert toast is accurate, so it must surface.
+    expect(
+      shouldToastForExpiredDispatch(makeSidebarThreadSummary({ latestTurn: makeLatestTurn() })),
+    ).toBe(true);
+    expect(shouldToastForExpiredDispatch(makeSidebarThreadSummary())).toBe(true);
+  });
+});
+
+describe("needs-review reveal affordance (H1)", () => {
+  it("renders when there is a fold but the tail is not revealed", () => {
+    expect(shouldShowReviewFoldToggle(false, 3)).toBe(true);
+    expect(resolveReviewFoldToggleLabel(false, 3)).toBe("Show 3 more");
+  });
+
+  it("keeps the toggle reachable once revealed even with zero hidden cards", () => {
+    expect(shouldShowReviewFoldToggle(true, 0)).toBe(true);
+    expect(resolveReviewFoldToggleLabel(true, 0)).toBe("Show fewer");
+    expect(shouldShowReviewFoldToggle(true, 5)).toBe(true);
+    expect(resolveReviewFoldToggleLabel(true, 5)).toBe("Show fewer");
+  });
+
+  it("hides the toggle when there is no fold and nothing is revealed", () => {
+    expect(shouldShowReviewFoldToggle(false, 0)).toBe(false);
   });
 });

--- a/apps/web/src/components/kanban/kanban.logic.test.ts
+++ b/apps/web/src/components/kanban/kanban.logic.test.ts
@@ -36,8 +36,8 @@ function makeLatestTurn(
     turnId: "turn-1" as never,
     state: "completed",
     assistantMessageId: null,
-    requestedAt: "2026-03-09T10:00:00.000Z",
-    startedAt: "2026-03-09T10:00:00.000Z",
+    requestedAt: T0,
+    startedAt: T0,
     completedAt: "2026-03-09T10:05:00.000Z",
     ...overrides,
   };
@@ -47,30 +47,30 @@ function makeSession(overrides: Partial<ThreadSession> = {}): ThreadSession {
   return {
     provider: "codex",
     status: "ready",
-    createdAt: "2026-03-09T10:00:00.000Z",
-    updatedAt: "2026-03-09T10:00:00.000Z",
+    createdAt: T0,
+    updatedAt: T0,
     orchestrationStatus: "ready",
     ...overrides,
   };
 }
+
+const T0 = "2026-03-09T10:00:00.000Z";
+const PROJECT_1 = ProjectId.makeUnsafe("project-1");
 
 function makeSidebarThreadSummary(
   overrides: Partial<SidebarThreadSummary> = {},
 ): SidebarThreadSummary {
   return {
     id: ThreadId.makeUnsafe("thread-1"),
-    projectId: ProjectId.makeUnsafe("project-1"),
+    projectId: PROJECT_1,
     title: "Thread",
-    modelSelection: {
-      provider: "codex",
-      model: "gpt-5.4",
-    },
+    modelSelection: { provider: "codex", model: "gpt-5.4" },
     interactionMode: DEFAULT_INTERACTION_MODE,
     branch: null,
     worktreePath: null,
     session: null,
-    createdAt: "2026-03-09T10:00:00.000Z",
-    updatedAt: "2026-03-09T10:00:00.000Z",
+    createdAt: T0,
+    updatedAt: T0,
     latestTurn: null,
     latestUserMessageAt: null,
     hasPendingApprovals: false,
@@ -88,6 +88,19 @@ function makeBoardInput(overrides: Partial<BuildKanbanBoardInput> = {}): BuildKa
     draftThreads: [],
     composerDraftByThreadId: {},
     draftOrderByProjectId: {},
+    ...overrides,
+  };
+}
+
+function makeDraftThread(
+  threadId: ThreadId,
+  overrides: Partial<BuildKanbanBoardInput["draftThreads"][number]> = {},
+): BuildKanbanBoardInput["draftThreads"][number] {
+  return {
+    threadId,
+    projectId: PROJECT_1,
+    createdAt: T0,
+    branch: null,
     ...overrides,
   };
 }
@@ -251,18 +264,8 @@ describe("buildKanbanBoard", () => {
       makeBoardInput({
         threads: [makeSidebarThreadSummary({ id: promotedId })],
         draftThreads: [
-          {
-            threadId: promotedId,
-            projectId: ProjectId.makeUnsafe("project-1"),
-            createdAt: "2026-03-09T10:00:00.000Z",
-            branch: null,
-          },
-          {
-            threadId: localId,
-            projectId: ProjectId.makeUnsafe("project-1"),
-            createdAt: "2026-03-09T10:30:00.000Z",
-            branch: null,
-          },
+          makeDraftThread(promotedId),
+          makeDraftThread(localId, { createdAt: "2026-03-09T10:30:00.000Z" }),
         ],
         composerDraftByThreadId: {
           [localId]: {
@@ -347,12 +350,9 @@ describe("buildKanbanBoard", () => {
       makeBoardInput({
         threads: [makeSidebarThreadSummary({ projectId: ProjectId.makeUnsafe("project-unknown") })],
         draftThreads: [
-          {
-            threadId: ThreadId.makeUnsafe("thread-orphan"),
+          makeDraftThread(ThreadId.makeUnsafe("thread-orphan"), {
             projectId: ProjectId.makeUnsafe("project-unknown"),
-            createdAt: "2026-03-09T10:00:00.000Z",
-            branch: null,
-          },
+          }),
         ],
         composerDraftByThreadId: {
           "thread-orphan": { prompt: "orphan", hasAttachments: false, provider: null },
@@ -367,14 +367,7 @@ describe("buildKanbanBoard", () => {
   it("skips local drafts whose composer is empty", () => {
     const board = buildKanbanBoard(
       makeBoardInput({
-        draftThreads: [
-          {
-            threadId: ThreadId.makeUnsafe("thread-empty"),
-            projectId: ProjectId.makeUnsafe("project-1"),
-            createdAt: "2026-03-09T10:00:00.000Z",
-            branch: null,
-          },
-        ],
+        draftThreads: [makeDraftThread(ThreadId.makeUnsafe("thread-empty"))],
       }),
     );
 
@@ -385,14 +378,7 @@ describe("buildKanbanBoard", () => {
     const threadId = ThreadId.makeUnsafe("thread-image-only");
     const board = buildKanbanBoard(
       makeBoardInput({
-        draftThreads: [
-          {
-            threadId,
-            projectId: ProjectId.makeUnsafe("project-1"),
-            createdAt: "2026-03-09T10:00:00.000Z",
-            branch: null,
-          },
-        ],
+        draftThreads: [makeDraftThread(threadId)],
         composerDraftByThreadId: {
           [threadId]: { prompt: "", hasAttachments: true, provider: "cursor" },
         },
@@ -413,24 +399,9 @@ describe("buildKanbanBoard", () => {
     const board = buildKanbanBoard(
       makeBoardInput({
         draftThreads: [
-          {
-            threadId: first,
-            projectId: ProjectId.makeUnsafe("project-1"),
-            createdAt: "2026-03-09T10:00:00.000Z",
-            branch: null,
-          },
-          {
-            threadId: second,
-            projectId: ProjectId.makeUnsafe("project-1"),
-            createdAt: "2026-03-09T11:00:00.000Z",
-            branch: null,
-          },
-          {
-            threadId: newest,
-            projectId: ProjectId.makeUnsafe("project-1"),
-            createdAt: "2026-03-09T12:00:00.000Z",
-            branch: null,
-          },
+          makeDraftThread(first),
+          makeDraftThread(second, { createdAt: "2026-03-09T11:00:00.000Z" }),
+          makeDraftThread(newest, { createdAt: "2026-03-09T12:00:00.000Z" }),
         ],
         composerDraftByThreadId: {
           [first]: { prompt: "a", hasAttachments: false, provider: null },
@@ -455,7 +426,7 @@ describe("buildKanbanBoard optimistic dispatch", () => {
   const makeOptimisticEntry = (
     overrides: Partial<KanbanOptimisticDispatchSnapshot> = {},
   ): KanbanOptimisticDispatchSnapshot => ({
-    projectId: ProjectId.makeUnsafe("project-1"),
+    projectId: PROJECT_1,
     title: "Fix the flaky reconnect test",
     provider: "cursor",
     baselineTurnId: null,
@@ -463,56 +434,69 @@ describe("buildKanbanBoard optimistic dispatch", () => {
     ...overrides,
   });
 
-  it("forces a dispatched draft thread into In Progress and suppresses its draft card", () => {
-    const threadId = ThreadId.makeUnsafe("thread-1");
-    const board = buildKanbanBoard(
-      makeBoardInput({
+  // A dispatched drop renders its thread In Progress ahead of runtime state and
+  // suppresses the draft/done duplicates; a thread that is already naturally
+  // In Progress is left untouched by a stale entry.
+  it.each([
+    {
+      name: "draft thread",
+      input: (threadId: ThreadId): Partial<BuildKanbanBoardInput> => ({
         threads: [makeSidebarThreadSummary({ id: threadId })],
-        optimisticDispatchByThreadId: { [threadId]: makeOptimisticEntry() },
       }),
-    );
-
-    const project = board.projects[0]!;
-    expect(project.draft).toHaveLength(0);
-    expect(project.inProgress.map((card) => card.cardId)).toEqual([kanbanThreadCardId(threadId)]);
-    const card = project.inProgress[0]!;
-    expect(card.isOptimisticDispatch).toBe(true);
-    expect(card.column).toBe("inProgress");
-    expect(card.title).toBe("Thread");
-    expect(card.draftPrompt).toBe("");
-  });
-
-  it("moves a settled thread's dispatched unsent prompt In Progress and hides the done duplicate", () => {
-    const threadId = ThreadId.makeUnsafe("thread-done");
-    const board = buildKanbanBoard(
-      makeBoardInput({
+      suppressed: ["draft"],
+      title: "Thread",
+      cardIdOf: kanbanThreadCardId,
+    },
+    {
+      name: "settled thread with an unsent prompt",
+      input: (threadId: ThreadId): Partial<BuildKanbanBoardInput> => ({
         threads: [makeSidebarThreadSummary({ id: threadId, latestTurn: makeLatestTurn() })],
         composerDraftByThreadId: {
           [threadId]: { prompt: "Follow up", hasAttachments: false, provider: null },
         },
-        optimisticDispatchByThreadId: {
-          [threadId]: makeOptimisticEntry({ baselineTurnId: "turn-1" }),
-        },
       }),
-    );
-
-    const project = board.projects[0]!;
-    expect(project.draft).toHaveLength(0);
-    expect(project.done).toHaveLength(0);
-    expect(project.inProgress.map((card) => card.cardId)).toEqual([kanbanThreadCardId(threadId)]);
-    expect(project.inProgress[0]!.isOptimisticDispatch).toBe(true);
-  });
+      suppressed: ["draft", "done"],
+      entryOverrides: { baselineTurnId: "turn-1" },
+      title: "Thread",
+      cardIdOf: kanbanThreadCardId,
+    },
+    {
+      name: "local draft",
+      input: (threadId: ThreadId): Partial<BuildKanbanBoardInput> => ({
+        draftThreads: [makeDraftThread(threadId)],
+      }),
+      suppressed: ["draft"],
+      title: "Fix the flaky reconnect test",
+      cardIdOf: kanbanDraftCardId,
+    },
+  ] as const)(
+    "forces a dispatched $name card In Progress behind the optimistic overlay",
+    ({ name, input, suppressed, entryOverrides, title, cardIdOf }) => {
+      const threadId = ThreadId.makeUnsafe(`thread-${name.replace(/ /g, "-")}`);
+      const project = buildKanbanBoard(
+        makeBoardInput({
+          ...input(threadId),
+          optimisticDispatchByThreadId: { [threadId]: makeOptimisticEntry(entryOverrides) },
+        }),
+      ).projects[0]!;
+      for (const column of suppressed) {
+        expect(project[column as "draft" | "done"]).toHaveLength(0);
+      }
+      expect(project.inProgress.map((card) => card.cardId)).toEqual([cardIdOf(threadId)]);
+      expect(project.inProgress[0]!.isOptimisticDispatch).toBe(true);
+      expect(project.inProgress[0]!.title).toBe(title);
+    },
+  );
 
   it("leaves naturally In Progress threads untouched by a stale entry", () => {
     const threadId = ThreadId.makeUnsafe("thread-live");
-    const board = buildKanbanBoard(
+    const project = buildKanbanBoard(
       makeBoardInput({
         threads: [makeSidebarThreadSummary({ id: threadId, hasLiveTailWork: true })],
         optimisticDispatchByThreadId: { [threadId]: makeOptimisticEntry() },
       }),
-    );
+    ).projects[0]!;
 
-    const project = board.projects[0]!;
     expect(project.inProgress).toHaveLength(1);
     expect(project.inProgress[0]!.isOptimisticDispatch).toBe(false);
   });
@@ -521,14 +505,7 @@ describe("buildKanbanBoard optimistic dispatch", () => {
     const threadId = ThreadId.makeUnsafe("thread-local");
     const board = buildKanbanBoard(
       makeBoardInput({
-        draftThreads: [
-          {
-            threadId,
-            projectId: ProjectId.makeUnsafe("project-1"),
-            createdAt: "2026-03-09T10:00:00.000Z",
-            branch: null,
-          },
-        ],
+        draftThreads: [makeDraftThread(threadId)],
         optimisticDispatchByThreadId: { [threadId]: makeOptimisticEntry() },
       }),
     );
@@ -604,143 +581,101 @@ describe("buildKanbanBoard optimistic dispatch", () => {
 describe("resolveOptimisticDispatchOutcome", () => {
   const DROPPED_AT_MS = Date.parse("2026-03-09T12:00:00.000Z");
   const entry = (baselineTurnId: string | null) => ({ baselineTurnId, droppedAtMs: DROPPED_AT_MS });
+  const outcome = (baselineTurnId: string | null, overrides: Partial<SidebarThreadSummary>) =>
+    resolveOptimisticDispatchOutcome(entry(baselineTurnId), makeSidebarThreadSummary(overrides));
 
-  it("settles when a turn other than the baseline appears", () => {
-    expect(
-      resolveOptimisticDispatchOutcome(
-        entry(null),
-        makeSidebarThreadSummary({ latestTurn: makeLatestTurn() }),
-      ),
-    ).toBe("settled");
-    expect(
-      resolveOptimisticDispatchOutcome(
-        entry("turn-1"),
-        makeSidebarThreadSummary({ latestTurn: makeLatestTurn({ turnId: "turn-2" as never }) }),
-      ),
-    ).toBe("settled");
+  it.each([
+    {
+      name: "a turn other than the baseline appears",
+      baseline: null as string | null,
+      thread: { latestTurn: makeLatestTurn() },
+      outcome: "settled",
+    },
+    {
+      name: "the baseline turn was replaced",
+      baseline: "turn-1",
+      thread: { latestTurn: makeLatestTurn({ turnId: "turn-2" as never }) },
+      outcome: "settled",
+    },
+    {
+      name: "the session runs before a new turn registers",
+      baseline: null,
+      thread: { session: makeSession({ status: "running", orchestrationStatus: "running" }) },
+      outcome: "settled",
+    },
+    {
+      name: "the connecting pre-init window is still live",
+      baseline: null,
+      thread: { session: makeSession({ status: "connecting" }) },
+      outcome: "pending",
+    },
+    {
+      name: "the dispatch-time baseline still matches",
+      baseline: null,
+      thread: {},
+      outcome: "pending",
+    },
+    {
+      name: "the baseline turn has not changed",
+      baseline: "turn-1",
+      thread: { latestTurn: makeLatestTurn() },
+      outcome: "pending",
+    },
+  ] as const)("settles to $outcome when $name", ({ baseline, thread, outcome: expected }) => {
+    expect(outcome(baseline, thread as Partial<SidebarThreadSummary>)).toBe(expected);
   });
 
-  it("settles when the session is running even before a new turn registers", () => {
-    expect(
-      resolveOptimisticDispatchOutcome(
-        entry(null),
-        makeSidebarThreadSummary({
-          session: makeSession({ status: "running", orchestrationStatus: "running" }),
+  // Manual stop or silent provider shutdown mid-init fails the dispatch; a
+  // terminal state from before the drop must not revert a fresh dispatch.
+  it.each([
+    {
+      status: "error",
+      orchestrationStatus: "error",
+      at: "2026-03-09T12:00:00.000Z",
+      expected: "failed",
+    },
+    {
+      status: "error",
+      orchestrationStatus: "error",
+      at: "2026-03-09T12:00:03.000Z",
+      expected: "failed",
+    },
+    {
+      status: "closed",
+      orchestrationStatus: "stopped",
+      at: "2026-03-09T12:00:02.000Z",
+      expected: "failed",
+    },
+    {
+      status: "closed",
+      orchestrationStatus: "stopped",
+      at: "2026-03-09T11:00:00.000Z",
+      expected: "pending",
+    },
+    {
+      status: "error",
+      orchestrationStatus: "error",
+      at: "2026-03-09T11:59:00.000Z",
+      expected: "pending",
+    },
+  ] as const)(
+    "resolves a $status session ending at $at to $expected",
+    ({ status, orchestrationStatus, at, expected }) => {
+      expect(
+        outcome(null, {
+          session: makeSession({ status, orchestrationStatus, updatedAt: at }),
         }),
-      ),
-    ).toBe("settled");
-  });
-
-  it("keeps watching through the connecting pre-init window", () => {
-    // The early "starting" status must not settle the entry: provider init can
-    // still fail, and the failure toast depends on the entry being alive.
-    expect(
-      resolveOptimisticDispatchOutcome(
-        entry(null),
-        makeSidebarThreadSummary({ session: makeSession({ status: "connecting" }) }),
-      ),
-    ).toBe("pending");
-  });
-
-  it("stays pending while the thread still matches the dispatch-time baseline", () => {
-    expect(resolveOptimisticDispatchOutcome(entry(null), makeSidebarThreadSummary())).toBe(
-      "pending",
-    );
-    expect(
-      resolveOptimisticDispatchOutcome(
-        entry("turn-1"),
-        makeSidebarThreadSummary({ latestTurn: makeLatestTurn() }),
-      ),
-    ).toBe("pending");
-  });
-
-  it("fails when the session errors at or after the drop without a turn", () => {
-    expect(
-      resolveOptimisticDispatchOutcome(
-        entry(null),
-        makeSidebarThreadSummary({
-          session: makeSession({
-            status: "error",
-            orchestrationStatus: "error",
-            updatedAt: "2026-03-09T12:00:00.000Z",
-          }),
-        }),
-      ),
-    ).toBe("failed");
-    expect(
-      resolveOptimisticDispatchOutcome(
-        entry(null),
-        makeSidebarThreadSummary({
-          session: makeSession({
-            status: "error",
-            orchestrationStatus: "error",
-            updatedAt: "2026-03-09T12:00:03.000Z",
-          }),
-        }),
-      ),
-    ).toBe("failed");
-  });
-
-  it("fails when the session closes after the drop without a turn", () => {
-    // Manual stop or silent provider shutdown mid-init: the dispatch never ran.
-    expect(
-      resolveOptimisticDispatchOutcome(
-        entry(null),
-        makeSidebarThreadSummary({
-          session: makeSession({
-            status: "closed",
-            orchestrationStatus: "stopped",
-            updatedAt: "2026-03-09T12:00:02.000Z",
-          }),
-        }),
-      ),
-    ).toBe("failed");
-  });
-
-  it("ignores a stale closed session from before the drop", () => {
-    expect(
-      resolveOptimisticDispatchOutcome(
-        entry(null),
-        makeSidebarThreadSummary({
-          session: makeSession({
-            status: "closed",
-            orchestrationStatus: "stopped",
-            updatedAt: "2026-03-09T11:00:00.000Z",
-          }),
-        }),
-      ),
-    ).toBe("pending");
-  });
-
-  it("ignores a stale error from before the drop", () => {
-    expect(
-      resolveOptimisticDispatchOutcome(
-        entry(null),
-        makeSidebarThreadSummary({
-          session: makeSession({
-            status: "error",
-            orchestrationStatus: "error",
-            updatedAt: "2026-03-09T11:59:00.000Z",
-          }),
-        }),
-      ),
-    ).toBe("pending");
-  });
+      ).toBe(expected);
+    },
+  );
 
   it("prefers settled over failed when the turn ran before erroring", () => {
     // The turn existed (even if it errored): real runtime state owns the card.
     expect(
-      resolveOptimisticDispatchOutcome(
-        entry(null),
-        makeSidebarThreadSummary({
-          latestTurn: makeLatestTurn({ state: "error" }),
-          session: makeSession({
-            status: "error",
-            orchestrationStatus: "error",
-            updatedAt: "2026-03-09T12:00:01.000Z",
-          }),
-        }),
-      ),
+      outcome(null, {
+        latestTurn: makeLatestTurn({ state: "error" }),
+        session: makeSession({ status: "error", orchestrationStatus: "error" }),
+      }),
     ).toBe("settled");
   });
 });
@@ -751,57 +686,57 @@ const makeComposerSnapshot = (prompt: string) => ({
   provider: null,
 });
 
+const makeDraftSource = (
+  overrides: Partial<Parameters<typeof buildKanbanComposerDraftSnapshot>[0]> = {},
+) => ({
+  prompt: "",
+  files: [],
+  images: [],
+  persistedAttachments: [],
+  terminalContexts: [],
+  assistantSelections: [],
+  fileComments: [],
+  activeProvider: null,
+  ...overrides,
+});
+
 describe("buildKanbanComposerDraftSnapshot", () => {
   it("ignores terminal contexts whose text is not available anymore", () => {
-    const snapshot = buildKanbanComposerDraftSnapshot({
-      prompt: "",
-      files: [],
-      images: [],
-      persistedAttachments: [],
-      terminalContexts: [
-        {
-          id: "ctx-expired",
-          threadId: ThreadId.makeUnsafe("thread-1"),
-          terminalId: "terminal-1",
-          terminalLabel: "Terminal",
-          lineStart: 1,
-          lineEnd: 2,
-          text: "",
-          createdAt: "2026-03-09T10:00:00.000Z",
-        },
-      ],
-      assistantSelections: [],
-      fileComments: [],
-      activeProvider: null,
-    });
+    const snapshot = buildKanbanComposerDraftSnapshot(
+      makeDraftSource({
+        terminalContexts: [
+          {
+            id: "ctx-expired",
+            threadId: ThreadId.makeUnsafe("thread-1"),
+            terminalId: "terminal-1",
+            terminalLabel: "Terminal",
+            lineStart: 1,
+            lineEnd: 2,
+            text: "",
+            createdAt: T0,
+          },
+        ],
+      }),
+    );
 
-    expect(snapshot).toEqual({
-      prompt: "",
-      hasAttachments: false,
-      provider: null,
-    });
+    expect(snapshot).toEqual(makeComposerSnapshot(""));
   });
 
   it("counts file attachments as pending draft attachments", () => {
-    const snapshot = buildKanbanComposerDraftSnapshot({
-      prompt: "",
-      files: [
-        {
-          type: "file",
-          id: "file-1",
-          name: "notes.txt",
-          mimeType: "text/plain",
-          sizeBytes: 12,
-          file: new File(["hello"], "notes.txt", { type: "text/plain" }),
-        },
-      ],
-      images: [],
-      persistedAttachments: [],
-      terminalContexts: [],
-      assistantSelections: [],
-      fileComments: [],
-      activeProvider: null,
-    });
+    const snapshot = buildKanbanComposerDraftSnapshot(
+      makeDraftSource({
+        files: [
+          {
+            type: "file",
+            id: "file-1",
+            name: "notes.txt",
+            mimeType: "text/plain",
+            sizeBytes: 12,
+            file: new File(["hello"], "notes.txt", { type: "text/plain" }),
+          },
+        ],
+      }),
+    );
 
     expect(snapshot?.hasAttachments).toBe(true);
   });
@@ -810,42 +745,36 @@ describe("buildKanbanComposerDraftSnapshot", () => {
 describe("areKanbanComposerDraftSnapshotsEqual", () => {
   const snapshot = makeComposerSnapshot;
 
-  it("treats value-equal maps as equal regardless of object identity", () => {
-    expect(
-      areKanbanComposerDraftSnapshotsEqual(
-        { "thread-1": snapshot("hello"), "thread-2": snapshot("world") },
-        { "thread-1": snapshot("hello"), "thread-2": snapshot("world") },
-      ),
-    ).toBe(true);
-    expect(areKanbanComposerDraftSnapshotsEqual({}, {})).toBe(true);
-  });
-
-  it("detects differing prompts, flags, providers, and key sets", () => {
-    expect(
-      areKanbanComposerDraftSnapshotsEqual(
-        { "thread-1": snapshot("hello") },
-        { "thread-1": snapshot("hello!") },
-      ),
-    ).toBe(false);
-    expect(
-      areKanbanComposerDraftSnapshotsEqual(
-        { "thread-1": snapshot("hello") },
-        { "thread-1": { ...snapshot("hello"), hasAttachments: true } },
-      ),
-    ).toBe(false);
-    expect(
-      areKanbanComposerDraftSnapshotsEqual(
-        { "thread-1": snapshot("hello") },
-        { "thread-1": { ...snapshot("hello"), provider: "cursor" } },
-      ),
-    ).toBe(false);
-    expect(
-      areKanbanComposerDraftSnapshotsEqual(
-        { "thread-1": snapshot("hello") },
-        { "thread-2": snapshot("hello") },
-      ),
-    ).toBe(false);
-    expect(areKanbanComposerDraftSnapshotsEqual({ "thread-1": snapshot("hello") }, {})).toBe(false);
+  it.each([
+    { left: {}, right: {}, equal: true },
+    {
+      left: { "thread-1": snapshot("hello"), "thread-2": snapshot("world") },
+      right: { "thread-1": snapshot("hello"), "thread-2": snapshot("world") },
+      equal: true,
+    },
+    {
+      left: { "thread-1": snapshot("hello") },
+      right: { "thread-1": snapshot("hello!") },
+      equal: false,
+    },
+    {
+      left: { "thread-1": snapshot("hello") },
+      right: { "thread-1": { ...snapshot("hello"), hasAttachments: true } },
+      equal: false,
+    },
+    {
+      left: { "thread-1": snapshot("hello") },
+      right: { "thread-1": { ...snapshot("hello"), provider: "cursor" } },
+      equal: false,
+    },
+    {
+      left: { "thread-1": snapshot("hello") },
+      right: { "thread-2": snapshot("hello") },
+      equal: false,
+    },
+    { left: { "thread-1": snapshot("hello") }, right: {}, equal: false },
+  ] as const)("compares $left vs $right to $equal", ({ left, right, equal }) => {
+    expect(areKanbanComposerDraftSnapshotsEqual(left, right)).toBe(equal);
   });
 });
 
@@ -853,7 +782,7 @@ describe("orderDraftCards", () => {
   const makeCard = (cardId: string, sortTimestamp: number): KanbanCard => ({
     cardId,
     threadId: ThreadId.makeUnsafe(cardId),
-    projectId: ProjectId.makeUnsafe("project-1"),
+    projectId: PROJECT_1,
     column: "draft",
     title: cardId,
     provider: null,
@@ -900,7 +829,7 @@ describe("resolveDraftDropAction", () => {
   const baseCard: KanbanCard = {
     cardId: "draft:thread-1",
     threadId: ThreadId.makeUnsafe("thread-1"),
-    projectId: ProjectId.makeUnsafe("project-1"),
+    projectId: PROJECT_1,
     column: "draft",
     title: "Draft",
     provider: null,
@@ -950,7 +879,7 @@ describe("overviewVisibleKanbanCards", () => {
   const card = (cardId: string, column: KanbanCard["column"]): KanbanCard => ({
     cardId,
     threadId: ThreadId.makeUnsafe(cardId),
-    projectId: ProjectId.makeUnsafe("project-1"),
+    projectId: PROJECT_1,
     column,
     title: cardId,
     provider: null,
@@ -974,7 +903,7 @@ describe("overviewVisibleKanbanCards", () => {
     const awaitingYou = columns.awaitingYou ?? [];
     const done = columns.done ?? [];
     return {
-      projectId: ProjectId.makeUnsafe("project-1"),
+      projectId: PROJECT_1,
       projectName: "Synara",
       projectKind: "project" as const,
       draft,
@@ -1037,100 +966,95 @@ const FROZEN_NOW_MS = Date.parse("2026-03-09T12:00:00.000Z");
 const FROZEN_NOW_ISO = new Date(FROZEN_NOW_MS).toISOString();
 
 describe("deriveKanbanColumnV2 (web adapter)", () => {
-  it("maps the web summary into the shared derivation and returns awaitingYou for pending approval", () => {
-    const thread = makeSidebarThreadSummary({
-      hasPendingApprovals: true,
-      session: makeSession({
-        status: "running",
-        orchestrationStatus: "running",
-        updatedAt: FROZEN_NOW_ISO,
-      }),
-      latestTurn: makeLatestTurn({ state: "running", completedAt: null }),
-    });
-    expect(deriveKanbanColumnV2(thread, FROZEN_NOW_MS)).toBe("awaitingYou");
-  });
-
-  it("derives draft/done/inProgress from runtime state with the clock injected", () => {
-    const settled = makeSidebarThreadSummary({ latestTurn: makeLatestTurn() });
-    expect(deriveKanbanColumnV2(settled, FROZEN_NOW_MS)).toBe("done");
-    expect(deriveKanbanColumnV2(makeSidebarThreadSummary(), FROZEN_NOW_MS)).toBe("draft");
-    // A fresh heartbeat keeps live-tail work In Progress; a stale one would age
-    // into stuck/awaitingYou instead.
-    expect(
-      deriveKanbanColumnV2(
-        makeSidebarThreadSummary({
-          hasLiveTailWork: true,
-          session: makeSession({
-            status: "running",
-            orchestrationStatus: "running",
-            updatedAt: FROZEN_NOW_ISO,
-          }),
-        }),
-        FROZEN_NOW_MS,
-      ),
-    ).toBe("inProgress");
-  });
-
-  it("uses orchestrationStatus as the session status label", () => {
-    // `status: "connecting"` maps from the legacy phase; the adapter reads
-    // `orchestrationStatus` (the shared union) instead.
-    const connecting = makeSidebarThreadSummary({
-      session: makeSession({
-        status: "connecting",
-        orchestrationStatus: "starting",
-        updatedAt: FROZEN_NOW_ISO,
-      }),
-    });
-    expect(deriveKanbanColumnV2(connecting, FROZEN_NOW_MS)).toBe("inProgress");
-  });
-
-  it("parity with the shared module for a dead-session pending thread", () => {
-    const deadPending = makeSidebarThreadSummary({
-      hasPendingUserInput: true,
-      latestTurn: makeLatestTurn(),
-      session: makeSession({ status: "closed", orchestrationStatus: "stopped" }),
-    });
-    expect(deriveKanbanColumnV2(deadPending, FROZEN_NOW_MS)).toBe("done");
+  // The adapter projects the web summary into the shared derivation with the
+  // board clock; a fresh heartbeat keeps live work In Progress (a stale one
+  // ages into stuck/awaitingYou instead), and the adapter reads the shared
+  // `orchestrationStatus` union, not the legacy phase.
+  it.each([
+    {
+      name: "pending approval under a live session",
+      thread: { hasPendingApprovals: true, latestTurn: { state: "running" } },
+      expected: "awaitingYou",
+    },
+    { name: "settled thread", thread: { latestTurn: { state: "completed" } }, expected: "done" },
+    { name: "bare thread", thread: {}, expected: "draft" },
+    {
+      name: "live-tail work with a fresh heartbeat",
+      thread: {
+        hasLiveTailWork: true,
+        session: { status: "running", orchestrationStatus: "running" },
+      },
+      expected: "inProgress",
+    },
+    {
+      name: "connecting phase mapped to the shared starting label",
+      thread: { session: { status: "connecting", orchestrationStatus: "starting" } },
+      expected: "inProgress",
+    },
+    {
+      name: "dead-session pending falls through to done",
+      thread: {
+        hasPendingUserInput: true,
+        latestTurn: { state: "completed" },
+        session: { status: "closed", orchestrationStatus: "stopped" },
+      },
+      expected: "done",
+    },
+  ] as const)("derives $expected for $name", ({ thread, expected }) => {
+    const summary = makeSidebarThreadSummary({
+      ...thread,
+      latestTurn:
+        "latestTurn" in thread && thread.latestTurn
+          ? makeLatestTurn({
+              state: thread.latestTurn.state,
+              completedAt: thread.latestTurn.state === "running" ? null : FROZEN_NOW_ISO,
+            })
+          : null,
+      session:
+        "session" in thread && thread.session
+          ? makeSession({ ...thread.session, updatedAt: FROZEN_NOW_ISO })
+          : null,
+    } as Partial<SidebarThreadSummary>);
+    expect(deriveKanbanColumnV2(summary, FROZEN_NOW_MS)).toBe(expected);
   });
 });
 
 describe("deriveKanbanCardAttention", () => {
-  it("produces no attention on a plain settled card", () => {
+  it.each([
+    {
+      name: "settled card",
+      thread: { latestTurn: { state: "completed" }, session: { orchestrationStatus: "ready" } },
+      expected: [],
+    },
+    {
+      name: "errored session",
+      thread: {
+        latestTurn: { state: "error" },
+        session: { status: "error", orchestrationStatus: "error", lastError: "boom" },
+      },
+      expected: ["failed"],
+    },
+    {
+      name: "open PR from the caller",
+      thread: { latestTurn: { state: "completed" }, session: { orchestrationStatus: "ready" } },
+      needsReview: true,
+      expected: ["needs-review"],
+    },
+  ] as const)("maps $name to $expected", ({ thread, needsReview, expected }) => {
     const attention = deriveKanbanCardAttention(
       makeSidebarThreadSummary({
-        latestTurn: makeLatestTurn(),
-        session: makeSession({ orchestrationStatus: "ready", updatedAt: FROZEN_NOW_ISO }),
-      }),
-      { now: FROZEN_NOW_MS },
+        latestTurn:
+          "latestTurn" in thread && thread.latestTurn
+            ? makeLatestTurn({ state: thread.latestTurn.state })
+            : null,
+        session:
+          "session" in thread && thread.session
+            ? makeSession({ ...thread.session, updatedAt: FROZEN_NOW_ISO })
+            : null,
+      } as Partial<SidebarThreadSummary>),
+      { now: FROZEN_NOW_MS, ...(needsReview ? { needsReview } : {}) },
     );
-    expect(attention).toEqual([]);
-  });
-
-  it("surfaces the failed pill when the session errored", () => {
-    const attention = deriveKanbanCardAttention(
-      makeSidebarThreadSummary({
-        latestTurn: makeLatestTurn({ state: "error" }),
-        session: makeSession({
-          status: "error",
-          orchestrationStatus: "error",
-          lastError: "boom",
-          updatedAt: FROZEN_NOW_ISO,
-        }),
-      }),
-      { now: FROZEN_NOW_MS },
-    );
-    expect(attention).toContain("failed");
-  });
-
-  it("adds needs-review when the caller passes an open PR", () => {
-    const attention = deriveKanbanCardAttention(
-      makeSidebarThreadSummary({
-        latestTurn: makeLatestTurn(),
-        session: makeSession({ orchestrationStatus: "ready", updatedAt: FROZEN_NOW_ISO }),
-      }),
-      { now: FROZEN_NOW_MS, needsReview: true },
-    );
-    expect(attention).toContain("needs-review");
+    expect(attention).toEqual(expected);
   });
 });
 
@@ -1139,32 +1063,43 @@ describe("buildKanbanBoard v2 mode", () => {
     now: FROZEN_NOW_MS,
     ...overrides,
   });
+  const liveSession = () =>
+    makeSession({ status: "running", orchestrationStatus: "running", updatedAt: FROZEN_NOW_ISO });
+  const makeOpenPrThread = (id: string, index = 0) =>
+    makeSidebarThreadSummary({
+      id: ThreadId.makeUnsafe(id),
+      latestTurn: makeLatestTurn(),
+      lastKnownPr: {
+        number: index + 1,
+        title: "Open PR",
+        url: "https://example.com/pr",
+        baseBranch: "main",
+        headBranch: `fix-${index}`,
+        state: "open",
+      },
+    });
+  const reviewMapFor = (threads: ReadonlyArray<SidebarThreadSummary>) => {
+    const map: Record<string, boolean> = {};
+    for (const thread of threads) map[thread.id] = true;
+    return map;
+  };
 
   it("buckets awaitingYou cards separately from inProgress", () => {
     const awaiting = makeSidebarThreadSummary({
       id: ThreadId.makeUnsafe("thread-awaited"),
       hasPendingApprovals: true,
       latestTurn: makeLatestTurn({ state: "running", completedAt: null }),
-      session: makeSession({
-        status: "running",
-        orchestrationStatus: "running",
-        updatedAt: FROZEN_NOW_ISO,
-      }),
+      session: liveSession(),
     });
     const running = makeSidebarThreadSummary({
       id: ThreadId.makeUnsafe("thread-running"),
       hasLiveTailWork: true,
       latestTurn: makeLatestTurn({ state: "running", completedAt: null }),
-      session: makeSession({
-        status: "running",
-        orchestrationStatus: "running",
-        updatedAt: FROZEN_NOW_ISO,
-      }),
+      session: liveSession(),
     });
     const board = buildKanbanBoard(makeBoardInput({ threads: [awaiting, running] }), v2Options());
-    const project = board.projects[0]!;
-    expect(project.inProgress.map((card) => card.threadId)).toEqual(["thread-running"]);
-    expect(project.awaitingYou.map((card) => card.threadId)).toEqual(["thread-awaited"]);
+    expect(board.projects[0]!.inProgress.map((card) => card.threadId)).toEqual(["thread-running"]);
+    expect(board.projects[0]!.awaitingYou.map((card) => card.threadId)).toEqual(["thread-awaited"]);
   });
 
   it("fills attention on thread cards in v2 mode", () => {
@@ -1224,66 +1159,30 @@ describe("buildKanbanBoard v2 mode", () => {
     expect(project.done[0]!.needsReview).toBe(true);
   });
 
-  it("caps each column at KANBAN_NEEDS_REVIEW_CAP rows in the filtered view", () => {
-    const reviewThreads = Array.from({ length: KANBAN_NEEDS_REVIEW_CAP + 8 }, (_, index) =>
-      makeSidebarThreadSummary({
-        id: ThreadId.makeUnsafe(`thread-review-${index}`),
-        latestTurn: makeLatestTurn(),
-        lastKnownPr: {
-          number: index + 1,
-          title: "Open PR",
-          url: "https://example.com/pr",
-          baseBranch: "main",
-          headBranch: `fix-${index}`,
-          state: "open",
-        },
-      }),
-    );
-    const needsReviewByThreadId: Record<string, boolean> = {};
-    for (const thread of reviewThreads) {
-      needsReviewByThreadId[thread.id] = true;
-    }
-    const filtered = buildKanbanBoard(
-      makeBoardInput({ threads: reviewThreads }),
-      v2Options({ needsReviewByThreadId, isNeedsReviewActive: true }),
-    );
-    expect(filtered.projects[0]!.done).toHaveLength(KANBAN_NEEDS_REVIEW_CAP);
-    // The header count stays the true pre-cap total (H1): the cap only narrows
-    // what renders, so all review threads count toward it.
-    expect(filtered.projects[0]!.totalCount).toBe(KANBAN_NEEDS_REVIEW_CAP + 8);
-    // Cards folded behind the per-column cap are reported for a reveal affordance.
-    expect(filtered.projects[0]!.hiddenCount).toBe(8);
-  });
-
-  it("reveals the folded needs-review tail when the board is built uncapped (H1)", () => {
-    const reviewThreads = Array.from({ length: KANBAN_NEEDS_REVIEW_CAP + 5 }, (_, index) =>
-      makeSidebarThreadSummary({
-        id: ThreadId.makeUnsafe(`thread-review-fold-${index}`),
-        latestTurn: makeLatestTurn(),
-        lastKnownPr: {
-          number: index + 1,
-          title: "Open PR",
-          url: "https://example.com/pr",
-          baseBranch: "main",
-          headBranch: `fix-${index}`,
-          state: "open",
-        },
-      }),
-    );
-    const needsReviewByThreadId: Record<string, boolean> = {};
-    for (const thread of reviewThreads) {
-      needsReviewByThreadId[thread.id] = true;
-    }
-    const revealed = buildKanbanBoard(
-      makeBoardInput({ threads: reviewThreads }),
-      v2Options({ needsReviewByThreadId, isNeedsReviewActive: true, uncapped: true }),
-    );
-    const project = revealed.projects[0]!;
-    expect(project.done).toHaveLength(KANBAN_NEEDS_REVIEW_CAP + 5);
-    expect(project.hiddenCount).toBe(0);
-    // The header count is unchanged by the reveal — it was already the pre-cap total.
-    expect(project.totalCount).toBe(KANBAN_NEEDS_REVIEW_CAP + 5);
-  });
+  it.each([
+    { uncapped: false, extra: 8, rendered: KANBAN_NEEDS_REVIEW_CAP, hidden: 8 },
+    { uncapped: true, extra: 5, rendered: KANBAN_NEEDS_REVIEW_CAP + 5, hidden: 0 },
+  ])(
+    "$renders done rows with hidden=$hidden when uncapped=$uncapped (H1)",
+    ({ uncapped, extra, rendered, hidden }) => {
+      const reviewThreads = Array.from({ length: KANBAN_NEEDS_REVIEW_CAP + extra }, (_, index) =>
+        makeOpenPrThread(`thread-review-${index}`, index),
+      );
+      const project = buildKanbanBoard(
+        makeBoardInput({ threads: reviewThreads }),
+        v2Options({
+          needsReviewByThreadId: reviewMapFor(reviewThreads),
+          isNeedsReviewActive: true,
+          uncapped,
+        }),
+      ).projects[0]!;
+      expect(project.done).toHaveLength(rendered);
+      // The header count stays the pre-cap total either way; the fold is
+      // reported for the reveal affordance.
+      expect(project.totalCount).toBe(KANBAN_NEEDS_REVIEW_CAP + extra);
+      expect(project.hiddenCount).toBe(hidden);
+    },
+  );
 
   it("keeps all cards when the needs-review filter is off", () => {
     const board = buildKanbanBoard(
@@ -1295,62 +1194,48 @@ describe("buildKanbanBoard v2 mode", () => {
 });
 
 describe("refineAttentionFlagsForLivePr", () => {
-  // Attention labels flow through as raw flag identifiers, not display copy.
-  const failedFlag = "failed";
-  const needsReviewFlag = "needs-review";
-
-  it("keeps labels while the row has not resolved yet (undefined)", () => {
-    expect(refineAttentionFlagsForLivePr([failedFlag, needsReviewFlag], undefined)).toEqual([
-      failedFlag,
-      needsReviewFlag,
-    ]);
-  });
-
-  it("keeps needs-review while the live row is open", () => {
-    expect(refineAttentionFlagsForLivePr([failedFlag, needsReviewFlag], "open")).toEqual([
-      failedFlag,
-      needsReviewFlag,
-    ]);
-  });
-
-  it("drops needs-review once the live row settles merged, closed, or empty (C3/M3)", () => {
-    expect(refineAttentionFlagsForLivePr([failedFlag, needsReviewFlag], "merged")).toEqual([
-      failedFlag,
-    ]);
-    expect(refineAttentionFlagsForLivePr([failedFlag, needsReviewFlag], null)).toEqual([
-      failedFlag,
-    ]);
-    expect(refineAttentionFlagsForLivePr([needsReviewFlag], "closed")).toEqual([]);
-  });
-
-  it("returns an empty array for empty input", () => {
-    expect(refineAttentionFlagsForLivePr(undefined, undefined)).toEqual([]);
-    expect(refineAttentionFlagsForLivePr([], "open")).toEqual([]);
+  // Operates on raw flag identifiers; display copy maps after refinement.
+  it.each([
+    { flags: undefined as readonly string[] | undefined, live: undefined, out: [] },
+    { flags: [], live: "open", out: [] },
+    { flags: ["failed", "needs-review"], live: undefined, out: ["failed", "needs-review"] },
+    { flags: ["failed", "needs-review"], live: "open", out: ["failed", "needs-review"] },
+    { flags: ["failed", "needs-review"], live: "merged", out: ["failed"] },
+    { flags: ["failed", "needs-review"], live: null, out: ["failed"] },
+    { flags: ["needs-review"], live: "closed", out: [] },
+  ] as const)("keeps $flags with live=$live -> $out", ({ flags, live, out }) => {
+    expect(
+      refineAttentionFlagsForLivePr(
+        flags as Parameters<typeof refineAttentionFlagsForLivePr>[0],
+        live as "open" | "closed" | "merged" | null | undefined,
+      ),
+    ).toEqual(out);
   });
 });
 
 describe("shouldToastForExpiredDispatch (H5)", () => {
-  it("stays silent when the thread left the display set or still derives In Progress", () => {
-    expect(shouldToastForExpiredDispatch(undefined)).toBe(false);
-    expect(shouldToastForExpiredDispatch(makeSidebarThreadSummary({ hasLiveTailWork: true }))).toBe(
-      false,
-    );
-    expect(
-      shouldToastForExpiredDispatch(
-        makeSidebarThreadSummary({
-          session: makeSession({ status: "running", orchestrationStatus: "running" }),
-        }),
-      ),
-    ).toBe(false);
-  });
-
-  it("toasts when the thread reverted to a non-progress column", () => {
-    // A plain thread with a settled turn derives Done after the expiry window —
-    // the revert toast is accurate, so it must surface.
-    expect(
-      shouldToastForExpiredDispatch(makeSidebarThreadSummary({ latestTurn: makeLatestTurn() })),
-    ).toBe(true);
-    expect(shouldToastForExpiredDispatch(makeSidebarThreadSummary())).toBe(true);
+  it.each([
+    { name: "thread left the display set", thread: undefined, toast: false },
+    {
+      name: "live-tail work still in progress",
+      thread: makeSidebarThreadSummary({ hasLiveTailWork: true }),
+      toast: false,
+    },
+    {
+      name: "running session still in progress",
+      thread: makeSidebarThreadSummary({
+        session: makeSession({ status: "running", orchestrationStatus: "running" }),
+      }),
+      toast: false,
+    },
+    {
+      name: "reverted to done",
+      thread: makeSidebarThreadSummary({ latestTurn: makeLatestTurn() }),
+      toast: true,
+    },
+    { name: "bare draft", thread: makeSidebarThreadSummary(), toast: true },
+  ] as const)("toasts=$toast for $name", ({ thread, toast }) => {
+    expect(shouldToastForExpiredDispatch(thread)).toBe(toast);
   });
 });
 
@@ -1360,8 +1245,6 @@ describe("needs-review reveal affordance (H1)", () => {
     expect(resolveReviewFoldToggleLabel(false, 3)).toBe("Show 3 more");
     expect(shouldShowReviewFoldToggle(true, 0)).toBe(true);
     expect(resolveReviewFoldToggleLabel(true, 0)).toBe("Show fewer");
-    expect(shouldShowReviewFoldToggle(true, 5)).toBe(true);
-    expect(resolveReviewFoldToggleLabel(true, 5)).toBe("Show fewer");
     expect(shouldShowReviewFoldToggle(false, 0)).toBe(false);
   });
 });

--- a/apps/web/src/components/kanban/kanban.logic.test.ts
+++ b/apps/web/src/components/kanban/kanban.logic.test.ts
@@ -1050,13 +1050,25 @@ describe("deriveKanbanColumnV2 (web adapter)", () => {
     expect(deriveKanbanColumnV2(thread, FROZEN_NOW_MS)).toBe("awaitingYou");
   });
 
-  it("falls back to the shared function without `now` for non-staleness cases", () => {
+  it("derives draft/done/inProgress from runtime state with the clock injected", () => {
     const settled = makeSidebarThreadSummary({ latestTurn: makeLatestTurn() });
-    expect(deriveKanbanColumnV2(settled)).toBe("done");
-    expect(deriveKanbanColumnV2(makeSidebarThreadSummary())).toBe("draft");
-    expect(deriveKanbanColumnV2(makeSidebarThreadSummary({ hasLiveTailWork: true }))).toBe(
-      "inProgress",
-    );
+    expect(deriveKanbanColumnV2(settled, FROZEN_NOW_MS)).toBe("done");
+    expect(deriveKanbanColumnV2(makeSidebarThreadSummary(), FROZEN_NOW_MS)).toBe("draft");
+    // A fresh heartbeat keeps live-tail work In Progress; a stale one would age
+    // into stuck/awaitingYou instead.
+    expect(
+      deriveKanbanColumnV2(
+        makeSidebarThreadSummary({
+          hasLiveTailWork: true,
+          session: makeSession({
+            status: "running",
+            orchestrationStatus: "running",
+            updatedAt: FROZEN_NOW_ISO,
+          }),
+        }),
+        FROZEN_NOW_MS,
+      ),
+    ).toBe("inProgress");
   });
 
   it("uses orchestrationStatus as the session status label", () => {
@@ -1084,7 +1096,7 @@ describe("deriveKanbanColumnV2 (web adapter)", () => {
 
 describe("deriveKanbanCardAttention", () => {
   it("produces no attention on a plain settled card", () => {
-    const { attention, attentionLabels } = deriveKanbanCardAttention(
+    const attention = deriveKanbanCardAttention(
       makeSidebarThreadSummary({
         latestTurn: makeLatestTurn(),
         session: makeSession({ orchestrationStatus: "ready", updatedAt: FROZEN_NOW_ISO }),
@@ -1092,11 +1104,10 @@ describe("deriveKanbanCardAttention", () => {
       { now: FROZEN_NOW_MS },
     );
     expect(attention).toEqual([]);
-    expect(attentionLabels).toEqual([]);
   });
 
   it("surfaces the failed pill when the session errored", () => {
-    const { attention, attentionLabels } = deriveKanbanCardAttention(
+    const attention = deriveKanbanCardAttention(
       makeSidebarThreadSummary({
         latestTurn: makeLatestTurn({ state: "error" }),
         session: makeSession({
@@ -1109,11 +1120,10 @@ describe("deriveKanbanCardAttention", () => {
       { now: FROZEN_NOW_MS },
     );
     expect(attention).toContain("failed");
-    expect(attentionLabels).toContain("Failed");
   });
 
   it("adds needs-review when the caller passes an open PR", () => {
-    const { attention } = deriveKanbanCardAttention(
+    const attention = deriveKanbanCardAttention(
       makeSidebarThreadSummary({
         latestTurn: makeLatestTurn(),
         session: makeSession({ orchestrationStatus: "ready", updatedAt: FROZEN_NOW_ISO }),
@@ -1157,7 +1167,7 @@ describe("buildKanbanBoard v2 mode", () => {
     expect(project.awaitingYou.map((card) => card.threadId)).toEqual(["thread-awaited"]);
   });
 
-  it("fills attention and attentionLabel on thread cards in v2 mode", () => {
+  it("fills attention on thread cards in v2 mode", () => {
     const failed = makeSidebarThreadSummary({
       id: ThreadId.makeUnsafe("thread-failed"),
       latestTurn: makeLatestTurn({ state: "error" }),
@@ -1171,7 +1181,6 @@ describe("buildKanbanBoard v2 mode", () => {
     const board = buildKanbanBoard(makeBoardInput({ threads: [failed] }), v2Options());
     const card = board.projects[0]!.awaitingYou[0]!;
     expect(card.attention).toContain("failed");
-    expect(card.attentionLabels).toContain("Failed");
   });
 
   it("leaves classic cards with no attention fields", () => {
@@ -1183,7 +1192,6 @@ describe("buildKanbanBoard v2 mode", () => {
     const board = buildKanbanBoard(makeBoardInput({ threads: [failed] }));
     const doneCard = board.projects[0]!.done[0]!;
     expect(doneCard.attention).toBeUndefined();
-    expect(doneCard.attentionLabels).toBeUndefined();
   });
 
   it("applies the needs-review filter in v2 mode", () => {
@@ -1305,19 +1313,13 @@ describe("refineAttentionFlagsForLivePr", () => {
     ]);
   });
 
-  it("drops needs-review once the live row settles merged", () => {
+  it("drops needs-review once the live row settles merged, closed, or empty (C3/M3)", () => {
     expect(refineAttentionFlagsForLivePr([failedFlag, needsReviewFlag], "merged")).toEqual([
       failedFlag,
     ]);
-  });
-
-  it("drops needs-review when live resolution settled empty (null, C3/M3)", () => {
     expect(refineAttentionFlagsForLivePr([failedFlag, needsReviewFlag], null)).toEqual([
       failedFlag,
     ]);
-  });
-
-  it("drops needs-review once the live row settles closed", () => {
     expect(refineAttentionFlagsForLivePr([needsReviewFlag], "closed")).toEqual([]);
   });
 
@@ -1328,11 +1330,8 @@ describe("refineAttentionFlagsForLivePr", () => {
 });
 
 describe("shouldToastForExpiredDispatch (H5)", () => {
-  it("stays silent when the thread left the display set", () => {
+  it("stays silent when the thread left the display set or still derives In Progress", () => {
     expect(shouldToastForExpiredDispatch(undefined)).toBe(false);
-  });
-
-  it("stays silent while the thread still derives In Progress (slow provider)", () => {
     expect(shouldToastForExpiredDispatch(makeSidebarThreadSummary({ hasLiveTailWork: true }))).toBe(
       false,
     );
@@ -1356,19 +1355,13 @@ describe("shouldToastForExpiredDispatch (H5)", () => {
 });
 
 describe("needs-review reveal affordance (H1)", () => {
-  it("renders when there is a fold but the tail is not revealed", () => {
+  it("renders when there is a fold, stays reachable once revealed, hides when idle", () => {
     expect(shouldShowReviewFoldToggle(false, 3)).toBe(true);
     expect(resolveReviewFoldToggleLabel(false, 3)).toBe("Show 3 more");
-  });
-
-  it("keeps the toggle reachable once revealed even with zero hidden cards", () => {
     expect(shouldShowReviewFoldToggle(true, 0)).toBe(true);
     expect(resolveReviewFoldToggleLabel(true, 0)).toBe("Show fewer");
     expect(shouldShowReviewFoldToggle(true, 5)).toBe(true);
     expect(resolveReviewFoldToggleLabel(true, 5)).toBe("Show fewer");
-  });
-
-  it("hides the toggle when there is no fold and nothing is revealed", () => {
     expect(shouldShowReviewFoldToggle(false, 0)).toBe(false);
   });
 });

--- a/apps/web/src/components/kanban/kanban.logic.ts
+++ b/apps/web/src/components/kanban/kanban.logic.ts
@@ -6,6 +6,16 @@
 
 import type { ProjectId, ProviderKind, ThreadEnvironmentMode, ThreadId } from "@synara/contracts";
 import { buildPromptThreadTitleFallback } from "@synara/shared/chatThreads";
+import {
+  KANBAN_ATTENTION_LABELS,
+  KANBAN_COLUMN_V2_LABELS,
+  deriveKanbanAttention as deriveKanbanAttentionShared,
+  deriveKanbanColumnV2 as deriveKanbanColumnV2Shared,
+  hasKanbanLiveWork as hasKanbanLiveWorkShared,
+  type KanbanAttentionFlag,
+  type KanbanColumnV2Key,
+  type KanbanThreadDerivationInput,
+} from "@synara/shared/kanban";
 import { isPendingThreadWorktree } from "@synara/shared/threadEnvironment";
 import type { ComposerThreadDraftState } from "../../composerDraftStore";
 import {
@@ -15,13 +25,34 @@ import {
 } from "../../session-logic";
 import type { Project, SidebarThreadSummary } from "../../types";
 
-export type KanbanColumnKey = "draft" | "inProgress" | "done";
+/**
+ * Web column vocabulary. The classic path speaks draft/inProgress/done; the v2
+ * path (S1-P5) additionally renders `awaitingYou`. Classic derivation and label
+ * maps stay untouched — this is vocabulary for the v2 boards only. `awaitingYou`
+ * resolves from the shared v2 label map when a consumer spans both vocabularies.
+ */
+export type KanbanColumnKey = KanbanClassicColumnKey | "awaitingYou";
 
-export const KANBAN_COLUMN_LABELS: Record<KanbanColumnKey, string> = {
+/** Classic 3-column vocabulary — `KANBAN_COLUMN_LABELS` stays scoped to it. */
+export type KanbanClassicColumnKey = "draft" | "inProgress" | "done";
+
+export const KANBAN_COLUMN_LABELS: Record<KanbanClassicColumnKey, string> = {
   draft: "Draft",
   inProgress: "In Progress",
   done: "Done",
 };
+
+/**
+ * Display label for a kanban column, spanning both vocabularies. The classic map
+ * stays scoped to the classic keys; the v2-specific label resolves from the
+ * shared v2 map (`KANBAN_COLUMN_V2_LABELS`) so the copy never re-literalizes.
+ */
+export function resolveKanbanColumnLabel(column: KanbanColumnKey): string {
+  if (column === "awaitingYou") {
+    return KANBAN_COLUMN_V2_LABELS.awaitingYou;
+  }
+  return KANBAN_COLUMN_LABELS[column];
+}
 
 export const KANBAN_FALLBACK_DRAFT_TITLE = "New thread";
 
@@ -154,6 +185,19 @@ export interface KanbanCard {
   activeWorkStartedAt: string | null;
   /** Shown In Progress ahead of runtime state — renders the "Starting…" affordance. */
   isOptimisticDispatch: boolean;
+  /**
+   * v2-path attention flags (failed / stuck / awaiting-approval / awaiting-input /
+   * needs-review). Present only for v2 boards; classic cards never set it.
+   */
+  attention?: KanbanAttentionFlag[] | undefined;
+  /**
+   * v2-path red-pill copy for every `attention` flag (the renderer shows up to
+   * two). Present only for v2 boards; undefined for classic so the classic pill
+   * renderer is untouched.
+   */
+  attentionLabels?: string[] | undefined;
+  /** needs-review (open PR per the live PR view) — set on v2-path thread cards. */
+  needsReview?: boolean | undefined;
 }
 
 export interface KanbanProjectBoard {
@@ -162,13 +206,49 @@ export interface KanbanProjectBoard {
   projectKind: Project["kind"];
   draft: KanbanCard[];
   inProgress: KanbanCard[];
+  /** v2-path attention column — always present, empty in classic mode. */
+  awaitingYou: KanbanCard[];
   done: KanbanCard[];
   totalCount: number;
+  /**
+   * Cards folded behind a per-column render cap (needs-review filter, S1-P8).
+   * Classic/unfiltered boards never exceed their column arrays, so this is 0.
+   */
+  hiddenCount: number;
 }
 
 export interface KanbanBoard {
   projects: KanbanProjectBoard[];
   totalCount: number;
+}
+
+/**
+ * v2-path board build options. The derivation and the injected now-tick make the
+ * board attention-aware (awaiting-you column + attention pills); `needsReview`
+ * scopes the per-card open-PR flag (S1-P8) and `isNeedsReviewActive` gates the
+ * filtered view.
+ */
+export interface KanbanV2BuildOptions {
+  /** Injected wall-clock tick (epoch ms) from the board hook for stuck staleness. */
+  now: number;
+  /** Per-thread open-PR view (S1-P8) — hidden when omitted. */
+  needsReviewByThreadId?: Readonly<Record<string, boolean | undefined>>;
+  /** Whether the needs-review filter is currently on (S1-P8). */
+  isNeedsReviewActive?: boolean;
+  /**
+   * Drop the per-column needs-review render cap so the current v2 build renders
+   * every card behind the fold. The reveal affordance drives this — the header
+   * count stays the pre-cap total either way (H1).
+   */
+  uncapped?: boolean;
+  /**
+   * Durable last-activity stamp per thread (epoch ms), keyed by thread id. The
+   * heartbeat takes the max of session/thread stamps and this so a busy-but-quiet
+   * streaming turn never reads as stale even though `SidebarThreadSummary.updatedAt`
+   * is frozen on the streaming hot path (F1). Sourced from the durable thread
+   * shell's `updatedAt`, which advances per appended message.
+   */
+  lastActivityTimestampMsByThreadId?: Readonly<Record<string, number | null>>;
 }
 
 export interface BuildKanbanBoardInput {
@@ -219,7 +299,7 @@ function toSortableTimestamp(iso: string | null | undefined): number | null {
  * count as In Progress; a thread that never ran a turn is a Draft; settled
  * threads land in Done.
  */
-export function deriveKanbanColumn(thread: SidebarThreadSummary): KanbanColumnKey {
+export function deriveKanbanColumn(thread: SidebarThreadSummary): KanbanClassicColumnKey {
   // Pending requests whose session died (crash, close) are unanswerable — they
   // must not pin the thread to In Progress forever.
   const hasActionablePendingRequests =
@@ -247,6 +327,129 @@ export function deriveKanbanColumn(thread: SidebarThreadSummary): KanbanColumnKe
   return "done";
 }
 
+/** Projection of a `SidebarThreadSummary` into the shared structural derivation input. */
+function toKanbanThreadDerivationInput(
+  thread: SidebarThreadSummary,
+  lastActivityTimestampMs?: number | null,
+): KanbanThreadDerivationInput {
+  return {
+    latestTurn: thread.latestTurn
+      ? {
+          state: thread.latestTurn.state,
+          startedAt: thread.latestTurn.startedAt,
+          completedAt: thread.latestTurn.completedAt,
+        }
+      : null,
+    session: thread.session
+      ? {
+          status: thread.session.orchestrationStatus,
+          updatedAt: thread.session.updatedAt,
+          lastError: thread.session.lastError ?? null,
+        }
+      : null,
+    // The thread stamp advances per appended message; the shared heartbeat takes
+    // the later of it and `session.updatedAt` so a busy-but-quiet turn never
+    // reads as stale (mirrors providerRuntimeReconciliation.projectedLifecycleAgeMs).
+    threadUpdatedAt: thread.updatedAt ?? null,
+    // `SidebarThreadSummary.updatedAt` freezes while the summary build is skipped
+    // on the streaming hot path, so feed the durable last-activity stamp as well —
+    // the heartbeat then stays live on every delta (F1).
+    lastActivityTimestampMs: lastActivityTimestampMs ?? null,
+    hasPendingApprovals: thread.hasPendingApprovals,
+    hasPendingUserInput: thread.hasPendingUserInput,
+    hasLiveTailWork: thread.hasLiveTailWork,
+  };
+}
+
+/**
+ * v2 clock-gate (C2): whether this thread could age into a stuck state, so the
+ * board only ticks the wall clock while a live-work candidate exists. This is
+ * the shared `hasKanbanLiveWork` over the same structural input the derivation
+ * uses — one liveness definition for the gate and the column/attention math.
+ * A wedged `starting` session, a running session with no settled turn, and a
+ * live-tail-only thread all count as live, so they tick and can earn a stuck
+ * pill; a fresh-but-idle thread does not.
+ */
+export function hasKanbanAttentionCandidate(
+  thread: SidebarThreadSummary,
+  lastActivityTimestampMs?: number | null,
+): boolean {
+  return hasKanbanLiveWorkShared(toKanbanThreadDerivationInput(thread, lastActivityTimestampMs));
+}
+
+/**
+ * Needs-review pill refinement (H2): the pill and the on-card PR chip must never
+ * contradict. The board seeds `needs-review` from `lastKnownPr` on first paint,
+ * while the chip renders the live resolved PR row. When a live row exists (open /
+ * merged / closed) it is the source of truth — a merged PR drops the pill; the
+ * persisted `lastKnownPr` stays the seed only for rows the live lookup has not
+ * resolved yet. Pure so the pill logic is unit-testable and identical on every
+ * surface that renders attention pills.
+ *
+ * Operates on RAW flag identifiers (`KanbanAttentionFlag`), which is the domain
+ * `card.attention` carries; display copy is mapped after refinement so the
+ * comparison never drifts from the flag set.
+ *
+ * State contract: `undefined` means "not yet resolved" (keep the initial pill);
+ * `null` means "live resolution settled with no open PR" (drop it); `"open" |
+ * "closed" | "merged"` is the live row state.
+ */
+export function refineAttentionFlagsForLivePr(
+  attentionFlags: readonly KanbanAttentionFlag[] | undefined,
+  livePrState: "open" | "closed" | "merged" | null | undefined,
+): KanbanAttentionFlag[] {
+  if (!attentionFlags || attentionFlags.length === 0) {
+    return [];
+  }
+  if (livePrState === undefined) {
+    return [...attentionFlags];
+  }
+  const liveNeedsReview = livePrState === "open";
+  return attentionFlags.filter((flag) => flag !== "needs-review" || liveNeedsReview);
+}
+
+/**
+ * v2-path column adapter. The web ↔ shared mapping lives only here: it projects
+ * the web thread summary into the shared structural input and delegates to
+ * `@synara/shared/kanban`. `now` is the injected ticking clock from the board
+ * hook (S1-P5); without it the derivation never consults staleness. Typed as the
+ * shared `KanbanColumnV2Key` so `awaitingYou` cannot leak into the classic path.
+ */
+export function deriveKanbanColumnV2(
+  thread: SidebarThreadSummary,
+  now?: number,
+  lastActivityTimestampMs?: number | null,
+): KanbanColumnV2Key {
+  const input = toKanbanThreadDerivationInput(thread, lastActivityTimestampMs);
+  return now !== undefined
+    ? deriveKanbanColumnV2Shared(input, { now })
+    : deriveKanbanColumnV2Shared(input);
+}
+
+/**
+ * v2-path attention projection for a thread card: the shared flag set plus the
+ * display label map. `now` feeds the stuck staleness check. `needsReview` is the
+ * per-thread open-PR view (S1-P8) that the shared module also turns into a pill.
+ */
+export function deriveKanbanCardAttention(
+  thread: SidebarThreadSummary,
+  opts: {
+    now: number;
+    needsReview?: boolean;
+    lastActivityTimestampMs?: number | null;
+  },
+): { attention: KanbanAttentionFlag[]; attentionLabels: string[] } {
+  const input = toKanbanThreadDerivationInput(thread, opts.lastActivityTimestampMs);
+  const attention = deriveKanbanAttentionShared(input, {
+    now: opts.now,
+    needsReview: opts.needsReview ?? false,
+  });
+  return {
+    attention,
+    attentionLabels: attention.map((flag) => KANBAN_ATTENTION_LABELS[flag]),
+  };
+}
+
 function resolveThreadCardTimestamp(
   thread: SidebarThreadSummary,
   column: KanbanColumnKey,
@@ -254,7 +457,7 @@ function resolveThreadCardTimestamp(
   if (column === "done" && thread.latestTurn?.completedAt) {
     return thread.latestTurn.completedAt;
   }
-  if (column === "inProgress") {
+  if (column === "inProgress" || column === "awaitingYou") {
     const liveTimestamp = thread.latestTurn?.startedAt ?? thread.latestTurn?.requestedAt ?? null;
     if (liveTimestamp) {
       return liveTimestamp;
@@ -279,15 +482,31 @@ function buildThreadCard(
   thread: SidebarThreadSummary,
   composerDraftByThreadId: BuildKanbanBoardInput["composerDraftByThreadId"],
   isTerminal: boolean,
+  v2?: KanbanV2BuildOptions,
 ): KanbanCard {
-  const column = deriveKanbanColumn(thread);
+  const lastActivityTimestampMs = v2?.lastActivityTimestampMsByThreadId?.[thread.id] ?? null;
+  const column = v2
+    ? deriveKanbanColumnV2(thread, v2.now, lastActivityTimestampMs)
+    : deriveKanbanColumn(thread);
   const composerDraft = resolveComposerDraft(composerDraftByThreadId, thread.id);
   const timestamp = resolveThreadCardTimestamp(thread, column);
   const threadProvider = isTerminal
     ? null
     : (thread.session?.provider ?? thread.modelSelection.provider);
+  const attentionFields = v2
+    ? deriveKanbanCardAttention(thread, {
+        now: v2.now,
+        needsReview: v2.needsReviewByThreadId?.[thread.id] ?? false,
+        lastActivityTimestampMs,
+      })
+    : null;
+  // In Progress cards and Awaiting-you cards whose reason is staleness (stuck)
+  // are both live work: the elapsed label tracks their active stretch. Other
+  // Awaiting-you reasons (pending/failed) center on the human, not the work.
+  const isAwaitingStuck =
+    column === "awaitingYou" && attentionFields?.attention.includes("stuck") === true;
   const activeWorkStartedAt =
-    column === "inProgress"
+    column === "inProgress" || isAwaitingStuck
       ? deriveActiveWorkStartedAt(thread.latestTurn, thread.session, timestamp)
       : null;
   return {
@@ -309,6 +528,13 @@ function buildThreadCard(
     timestamp,
     activeWorkStartedAt,
     isOptimisticDispatch: false,
+    ...(v2
+      ? {
+          attention: attentionFields?.attention ?? [],
+          attentionLabels: attentionFields?.attentionLabels ?? [],
+          needsReview: v2.needsReviewByThreadId?.[thread.id] ?? false,
+        }
+      : {}),
   };
 }
 
@@ -442,6 +668,18 @@ function buildSyntheticOptimisticCard(
 export type KanbanOptimisticDispatchOutcome = "pending" | "settled" | "failed";
 
 /**
+ * Resolve whether an expired optimistic dispatch should surface a revert toast.
+ * A thread that left the display set (gone from the board/sidebar projection)
+ * while its dispatch was still on the wire cannot be confirmed as reverting
+ * here — stay silent rather than claim a revert we can't verify (H5). A thread
+ * that still derives In Progress (slow provider init) also stays silent: the
+ * card is already correct from derived state, so a revert toast would be a lie.
+ */
+export function shouldToastForExpiredDispatch(thread: SidebarThreadSummary | undefined): boolean {
+  return thread !== undefined && deriveKanbanColumn(thread) !== "inProgress";
+}
+
+/**
  * How runtime state relates to an optimistic dispatch:
  * - "settled": the dispatch produced visible runtime state — the thread derives
  *   In Progress, or a turn other than the dispatch-time baseline exists (covers
@@ -539,12 +777,29 @@ export function reorderDraftCardIds(
   return next;
 }
 
-export function buildKanbanBoard(input: BuildKanbanBoardInput): KanbanBoard {
+interface KanbanProjectBuckets {
+  draft: KanbanCard[];
+  inProgress: KanbanCard[];
+  awaitingYou: KanbanCard[];
+  done: KanbanCard[];
+}
+
+const EMPTY_BUCKETS: KanbanProjectBuckets = {
+  draft: [],
+  inProgress: [],
+  awaitingYou: [],
+  done: [],
+};
+
+/** Rows per column kept in the v2 needs-review filtered view (S1-P8). */
+export const KANBAN_NEEDS_REVIEW_CAP = 30;
+
+export function buildKanbanBoard(
+  input: BuildKanbanBoardInput,
+  v2?: KanbanV2BuildOptions,
+): KanbanBoard {
   const threadIds = new Set<string>();
-  const cardsByProjectId = new Map<
-    ProjectId,
-    { draft: KanbanCard[]; inProgress: KanbanCard[]; done: KanbanCard[] }
-  >();
+  const cardsByProjectId = new Map<ProjectId, KanbanProjectBuckets>();
   const knownProjectIds = new Set<string>(input.projects.map((project) => project.id));
   const optimisticDispatchByThreadId = input.optimisticDispatchByThreadId ?? {};
   const handledOptimisticThreadIds = new Set<string>();
@@ -552,14 +807,18 @@ export function buildKanbanBoard(input: BuildKanbanBoardInput): KanbanBoard {
   const resolveBoardProjectId = (projectId: ProjectId): ProjectId =>
     input.projectIdAliases?.[projectId] ?? projectId;
 
-  const bucketFor = (projectId: ProjectId) => {
+  const bucketFor = (projectId: ProjectId): KanbanProjectBuckets => {
     let bucket = cardsByProjectId.get(projectId);
     if (!bucket) {
-      bucket = { draft: [], inProgress: [], done: [] };
+      bucket = { draft: [], inProgress: [], awaitingYou: [], done: [] };
       cardsByProjectId.set(projectId, bucket);
     }
     return bucket;
   };
+
+  const needsReviewActive = v2?.isNeedsReviewActive === true;
+  const cardPassesNeedsReviewFilter = (card: KanbanCard): boolean =>
+    !needsReviewActive || card.needsReview === true;
 
   for (const thread of input.threads) {
     const boardProjectId = resolveBoardProjectId(thread.projectId);
@@ -569,7 +828,7 @@ export function buildKanbanBoard(input: BuildKanbanBoardInput): KanbanBoard {
     threadIds.add(thread.id);
     const bucket = bucketFor(boardProjectId);
     const isTerminal = input.terminalEntryThreadIds?.has(thread.id) ?? false;
-    const card = buildThreadCard(thread, input.composerDraftByThreadId, isTerminal);
+    const card = buildThreadCard(thread, input.composerDraftByThreadId, isTerminal, v2);
     const optimisticEntry = optimisticDispatchByThreadId[thread.id];
     if (optimisticEntry) {
       handledOptimisticThreadIds.add(thread.id);
@@ -580,6 +839,9 @@ export function buildKanbanBoard(input: BuildKanbanBoardInput): KanbanBoard {
         bucket.inProgress.push(forceOptimisticInProgressCard(card, optimisticEntry));
         continue;
       }
+    }
+    if (!cardPassesNeedsReviewFilter(card)) {
+      continue;
     }
     bucket[card.column].push(card);
     if (card.column === "done") {
@@ -637,11 +899,27 @@ export function buildKanbanBoard(input: BuildKanbanBoardInput): KanbanBoard {
 
   let totalCount = 0;
   const projects = input.projects.map((project): KanbanProjectBoard => {
-    const bucket = cardsByProjectId.get(project.id) ?? { draft: [], inProgress: [], done: [] };
-    const draft = orderDraftCards(bucket.draft, input.draftOrderByProjectId[project.id]);
-    const inProgress = bucket.inProgress.toSorted(compareByRecencyDesc);
-    const done = bucket.done.toSorted(compareByRecencyDesc);
-    const projectTotalCount = draft.length + inProgress.length + done.length;
+    const bucket = cardsByProjectId.get(project.id) ?? EMPTY_BUCKETS;
+    // In the needs-review filtered view (S1-P8) each column is capped at
+    // KANBAN_NEEDS_REVIEW_CAP rows so live PR lookup stays bounded even on huge
+    // boards. The unfiltered view is uncapped — attention surfaces every card.
+    // When the user reveals the folded tail, the cap drops for this build so
+    // every review card renders (H1).
+    const cap = needsReviewActive && !v2?.uncapped ? KANBAN_NEEDS_REVIEW_CAP : Infinity;
+    const draft = orderDraftCards(bucket.draft, input.draftOrderByProjectId[project.id]).slice(
+      0,
+      cap,
+    );
+    const inProgress = bucket.inProgress.toSorted(compareByRecencyDesc).slice(0, cap);
+    const awaitingYou = bucket.awaitingYou.toSorted(compareByRecencyDesc).slice(0, cap);
+    const done = bucket.done.toSorted(compareByRecencyDesc).slice(0, cap);
+    // The header count is the true pre-cap total of cards matching the current
+    // filter — the capped columns only narrow what renders (H1).
+    const projectTotalCount =
+      bucket.draft.length +
+      bucket.inProgress.length +
+      bucket.awaitingYou.length +
+      bucket.done.length;
     totalCount += projectTotalCount;
     return {
       projectId: project.id,
@@ -649,17 +927,40 @@ export function buildKanbanBoard(input: BuildKanbanBoardInput): KanbanBoard {
       projectKind: project.kind,
       draft,
       inProgress,
+      awaitingYou,
       done,
       totalCount: projectTotalCount,
+      // v2 needs-review views expose the folded remainder behind their cap.
+      hiddenCount: Math.max(
+        0,
+        bucket.draft.length -
+          draft.length +
+          (bucket.inProgress.length - inProgress.length) +
+          (bucket.awaitingYou.length - awaitingYou.length) +
+          (bucket.done.length - done.length),
+      ),
     };
   });
 
   return { projects, totalCount };
 }
 
-/** Overview project columns list cards In Progress → Draft → Done. */
-export function flattenProjectBoardForOverview(board: KanbanProjectBoard): KanbanCard[] {
-  return [...board.inProgress, ...board.draft, ...board.done];
+/**
+ * Whether the board-level needs-review reveal affordance renders (H1). It stays
+ * reachable once the user has revealed the fold — a revealed board with no
+ * hidden cards must still offer "Show fewer" so the fold can be re-closed even
+ * after the filter count drops.
+ */
+export function shouldShowReviewFoldToggle(hasRevealed: boolean, hiddenCount: number): boolean {
+  return hasRevealed || hiddenCount > 0;
+}
+
+/**
+ * Button copy for the needs-review reveal: "Show N more" while there is a fold,
+ * "Show fewer" once the tail is revealed.
+ */
+export function resolveReviewFoldToggleLabel(hasRevealed: boolean, hiddenCount: number): string {
+  return hasRevealed ? "Show fewer" : `Show ${hiddenCount} more`;
 }
 
 const OVERVIEW_RENDER_CAP = 20;
@@ -667,16 +968,36 @@ const OVERVIEW_RENDER_CAP = 20;
 /**
  * The capped card list an overview project column actually renders, plus the count folded
  * behind its "Show more" affordance. Shared with the board root so per-card data (PR
- * badges) is fetched for exactly the rendered set.
+ * badges) is fetched for exactly the rendered set. The cap applies PER COLUMN before
+ * flattening, so attention cards (In Progress / Awaiting you) are never pushed off the
+ * visible window by a Done-heavy tail — the exact cards the attention-first overview
+ * exists to surface (H3). Classic flattens In Progress → Draft → Done; v2 routes
+ * Awaiting you after In Progress.
  */
-export function overviewVisibleKanbanCards(board: KanbanProjectBoard): {
+export function overviewVisibleKanbanCards(
+  board: KanbanProjectBoard,
+  v2?: boolean,
+): {
   visibleCards: KanbanCard[];
   hiddenCount: number;
 } {
-  const cards = flattenProjectBoardForOverview(board);
-  const visibleCards =
-    cards.length > OVERVIEW_RENDER_CAP ? cards.slice(0, OVERVIEW_RENDER_CAP) : cards;
-  return { visibleCards, hiddenCount: cards.length - visibleCards.length };
+  const cappedDraft = board.draft.slice(0, OVERVIEW_RENDER_CAP);
+  const cappedInProgress = board.inProgress.slice(0, OVERVIEW_RENDER_CAP);
+  const cappedAwaitingYou = board.awaitingYou.slice(0, OVERVIEW_RENDER_CAP);
+  const cappedDone = board.done.slice(0, OVERVIEW_RENDER_CAP);
+  const visibleCards = v2
+    ? [...cappedInProgress, ...cappedAwaitingYou, ...cappedDraft, ...cappedDone]
+    : [...cappedInProgress, ...cappedDraft, ...cappedDone];
+  const hiddenCount =
+    board.draft.length -
+    cappedDraft.length +
+    (board.inProgress.length - cappedInProgress.length) +
+    (board.awaitingYou.length - cappedAwaitingYou.length) +
+    (board.done.length - cappedDone.length) +
+    // Cards the needs-review filter already folded behind its 30-row column cap
+    // are also invisible on the overview and must count toward its affordance.
+    board.hiddenCount;
+  return { visibleCards, hiddenCount };
 }
 
 export type KanbanDraftOpenThreadReason = "not-draft" | "empty" | "worktree-pending";

--- a/apps/web/src/components/kanban/kanban.logic.ts
+++ b/apps/web/src/components/kanban/kanban.logic.ts
@@ -7,7 +7,6 @@
 import type { ProjectId, ProviderKind, ThreadEnvironmentMode, ThreadId } from "@synara/contracts";
 import { buildPromptThreadTitleFallback } from "@synara/shared/chatThreads";
 import {
-  KANBAN_ATTENTION_LABELS,
   KANBAN_COLUMN_V2_LABELS,
   deriveKanbanAttention as deriveKanbanAttentionShared,
   deriveKanbanColumnV2 as deriveKanbanColumnV2Shared,
@@ -187,15 +186,10 @@ export interface KanbanCard {
   isOptimisticDispatch: boolean;
   /**
    * v2-path attention flags (failed / stuck / awaiting-approval / awaiting-input /
-   * needs-review). Present only for v2 boards; classic cards never set it.
+   * needs-review). Present only for v2 boards; classic cards never set it. Display
+   * copy maps through `KANBAN_ATTENTION_LABELS` at render time.
    */
   attention?: KanbanAttentionFlag[] | undefined;
-  /**
-   * v2-path red-pill copy for every `attention` flag (the renderer shows up to
-   * two). Present only for v2 boards; undefined for classic so the classic pill
-   * renderer is untouched.
-   */
-  attentionLabels?: string[] | undefined;
   /** needs-review (open PR per the live PR view) — set on v2-path thread cards. */
   needsReview?: boolean | undefined;
 }
@@ -411,25 +405,25 @@ export function refineAttentionFlagsForLivePr(
 /**
  * v2-path column adapter. The web ↔ shared mapping lives only here: it projects
  * the web thread summary into the shared structural input and delegates to
- * `@synara/shared/kanban`. `now` is the injected ticking clock from the board
- * hook (S1-P5); without it the derivation never consults staleness. Typed as the
- * shared `KanbanColumnV2Key` so `awaitingYou` cannot leak into the classic path.
+ * `@synara/shared/kanban` with the injected board clock (`now`) that drives the
+ * stuck-staleness rules. Typed as the shared `KanbanColumnV2Key` so `awaitingYou`
+ * cannot leak into the classic path.
  */
 export function deriveKanbanColumnV2(
   thread: SidebarThreadSummary,
-  now?: number,
+  now: number,
   lastActivityTimestampMs?: number | null,
 ): KanbanColumnV2Key {
-  const input = toKanbanThreadDerivationInput(thread, lastActivityTimestampMs);
-  return now !== undefined
-    ? deriveKanbanColumnV2Shared(input, { now })
-    : deriveKanbanColumnV2Shared(input);
+  return deriveKanbanColumnV2Shared(
+    toKanbanThreadDerivationInput(thread, lastActivityTimestampMs),
+    { now },
+  );
 }
 
 /**
- * v2-path attention projection for a thread card: the shared flag set plus the
- * display label map. `now` feeds the stuck staleness check. `needsReview` is the
- * per-thread open-PR view (S1-P8) that the shared module also turns into a pill.
+ * v2-path attention projection for a thread card. `now` feeds the stuck staleness
+ * check. `needsReview` is the per-thread open-PR view (S1-P8) that the shared
+ * module also turns into a pill.
  */
 export function deriveKanbanCardAttention(
   thread: SidebarThreadSummary,
@@ -438,16 +432,12 @@ export function deriveKanbanCardAttention(
     needsReview?: boolean;
     lastActivityTimestampMs?: number | null;
   },
-): { attention: KanbanAttentionFlag[]; attentionLabels: string[] } {
+): KanbanAttentionFlag[] {
   const input = toKanbanThreadDerivationInput(thread, opts.lastActivityTimestampMs);
-  const attention = deriveKanbanAttentionShared(input, {
+  return deriveKanbanAttentionShared(input, {
     now: opts.now,
     needsReview: opts.needsReview ?? false,
   });
-  return {
-    attention,
-    attentionLabels: attention.map((flag) => KANBAN_ATTENTION_LABELS[flag]),
-  };
 }
 
 function resolveThreadCardTimestamp(
@@ -493,7 +483,7 @@ function buildThreadCard(
   const threadProvider = isTerminal
     ? null
     : (thread.session?.provider ?? thread.modelSelection.provider);
-  const attentionFields = v2
+  const attention = v2
     ? deriveKanbanCardAttention(thread, {
         now: v2.now,
         needsReview: v2.needsReviewByThreadId?.[thread.id] ?? false,
@@ -503,8 +493,7 @@ function buildThreadCard(
   // In Progress cards and Awaiting-you cards whose reason is staleness (stuck)
   // are both live work: the elapsed label tracks their active stretch. Other
   // Awaiting-you reasons (pending/failed) center on the human, not the work.
-  const isAwaitingStuck =
-    column === "awaitingYou" && attentionFields?.attention.includes("stuck") === true;
+  const isAwaitingStuck = column === "awaitingYou" && attention?.includes("stuck") === true;
   const activeWorkStartedAt =
     column === "inProgress" || isAwaitingStuck
       ? deriveActiveWorkStartedAt(thread.latestTurn, thread.session, timestamp)
@@ -530,8 +519,7 @@ function buildThreadCard(
     isOptimisticDispatch: false,
     ...(v2
       ? {
-          attention: attentionFields?.attention ?? [],
-          attentionLabels: attentionFields?.attentionLabels ?? [],
+          attention: attention ?? [],
           needsReview: v2.needsReviewByThreadId?.[thread.id] ?? false,
         }
       : {}),
@@ -844,7 +832,7 @@ export function buildKanbanBoard(
       continue;
     }
     bucket[card.column].push(card);
-    if (card.column === "done") {
+    if (card.column === "done" || card.column === "awaitingYou") {
       const unsentPromptCard = buildUnsentPromptCard(
         thread,
         input.composerDraftByThreadId,

--- a/apps/web/src/components/kanban/useKanbanBoard.ts
+++ b/apps/web/src/components/kanban/useKanbanBoard.ts
@@ -4,17 +4,22 @@
 // Exports: useKanbanBoard
 
 import type { ProjectId, ThreadId } from "@synara/contracts";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { useAppSettings } from "~/appSettings";
+import { useNowMs } from "~/hooks/useNowMs";
 import { useStableValue } from "~/hooks/useStableValue";
+import { useThreadPullRequests } from "~/hooks/useThreadPullRequests";
 import { toastManager } from "~/components/ui/toast";
 import { useComposerDraftStore } from "../../composerDraftStore";
 import { useKanbanUiStore } from "../../kanbanUiStore";
 import { isHomeChatContainerProject } from "../../lib/chatProjects";
 import { isStudioContainerProject } from "../../lib/studioProjects";
 import { useStore } from "../../store";
-import { createSidebarDisplayThreadsSelector } from "../../storeSelectors";
+import {
+  createLastActivityTimestampSelector,
+  createSidebarDisplayThreadsSelector,
+} from "../../storeSelectors";
 import { useTerminalStateStore } from "../../terminalStateStore";
 import { useWorkspacePathsStore } from "../../workspacePathsStore";
 import { sortProjectsForSidebar } from "../Sidebar.logic";
@@ -22,8 +27,9 @@ import {
   areKanbanComposerDraftSnapshotsEqual,
   buildKanbanBoard,
   buildKanbanComposerDraftSnapshot,
-  deriveKanbanColumn,
+  hasKanbanAttentionCandidate,
   resolveOptimisticDispatchOutcome,
+  shouldToastForExpiredDispatch,
   type KanbanBoard,
   type KanbanComposerDraftSnapshot,
   type KanbanDraftThreadSnapshot,
@@ -43,10 +49,14 @@ export function useKanbanBoard(): KanbanBoard {
   const threads = useStore(selectDisplayThreads);
   const allProjects = useStore((state) => state.projects);
   const threadsHydrated = useStore((state) => state.threadsHydrated);
+  const lastActivityTimestampMsByThreadId = useStore(createLastActivityTimestampSelector());
   const homeDir = useWorkspacePathsStore((state) => state.homeDir);
   const chatWorkspaceRoot = useWorkspacePathsStore((state) => state.chatWorkspaceRoot);
   const studioWorkspaceRoot = useWorkspacePathsStore((state) => state.studioWorkspaceRoot);
   const projectSortOrder = settings.sidebarProjectSortOrder;
+  const kanbanViewMode = useKanbanUiStore((state) => state.kanbanViewMode);
+  const kanbanNeedsReviewFilter = useKanbanUiStore((state) => state.kanbanNeedsReviewFilter);
+  const hasRevealedReviewFold = useKanbanUiStore((state) => state.hasRevealedReviewFold);
 
   // Mirror the sidebar's grouping: projects in the user's sidebar sort order, then one
   // "Chats" board for the hidden home chat container. Stale duplicate containers (cleaned
@@ -159,7 +169,10 @@ export function useKanbanBoard(): KanbanBoard {
         // (slow provider) just stop watching for failure — the card is already
         // In Progress from derived state, so a revert toast would be a lie.
         const thread = threadsRef.current.find((candidate) => candidate.id === threadId);
-        if (thread && deriveKanbanColumn(thread) === "inProgress") {
+        // A thread that left the display set while its dispatch was still on
+        // the wire cannot be confirmed as reverted here — stay silent rather
+        // than claim a revert we can't verify (H5).
+        if (!shouldToastForExpiredDispatch(thread)) {
           continue;
         }
         toastManager.add({
@@ -205,14 +218,80 @@ export function useKanbanBoard(): KanbanBoard {
     });
   }
 
-  return buildKanbanBoard({
-    projects,
-    threads,
-    draftThreads,
-    composerDraftByThreadId,
-    draftOrderByProjectId,
-    projectIdAliases,
-    terminalEntryThreadIds,
-    optimisticDispatchByThreadId,
+  // v2 attention-first boards only tick the wall clock while a live-work
+  // candidate could still go stale: a thread with live pending/attention state
+  // that can move into Awaiting you as the heartbeat ages. Classic boards never
+  // tick (they have no staleness rules). The gate reuses the shared liveness
+  // definition (`hasKanbanLiveWork` via `hasKanbanAttentionCandidate`) so a
+  // wedged starting session, a running no-turn session, and live-tail threads
+  // all tick too (C2).
+  const hasAttentionCandidate = threads.some((thread) =>
+    hasKanbanAttentionCandidate(thread, lastActivityTimestampMsByThreadId[thread.id]),
+  );
+  const nowMs = useNowMs(kanbanViewMode === "v2" && hasAttentionCandidate);
+
+  // The needs-review filter is a v2-only surface (S1-P8). Its active predicate
+  // ("at least one card has an open PR") and the per-thread flag consult the same
+  // live resolved PR rows the card chips render — a merged PR drops the "Needs
+  // review" flag even though `lastKnownPr` still says open (H2). Polling is
+  // bounded: only threads whose persisted seed says open (the filter candidates)
+  // run live lookups, and only while the filter can actually change cards. When
+  // the filter is off, the map stays at `lastKnownPr` seeds so nothing churns.
+  const projectCwdById = useMemo(
+    () => new Map(allProjects.map((project) => [project.id, project.cwd] as const)),
+    [allProjects],
+  );
+  const needsReviewSeedThreads = useMemo(
+    () =>
+      kanbanViewMode === "v2"
+        ? threads.filter((t) => t.worktreePath !== null && t.lastKnownPr?.state === "open")
+        : [],
+    [kanbanViewMode, threads],
+  );
+  const needsReviewPrLookup = useThreadPullRequests({
+    threads: needsReviewSeedThreads,
+    projectCwdById,
   });
+  const needsReviewByThreadId = useMemo(() => {
+    const map: Record<string, boolean> = {};
+    for (const thread of threads) {
+      // Needs-review is a live-confirmed claim: only threads with a dedicated
+      // worktree can be verified against git. A no-worktree thread with a
+      // persisted-open PR (e.g. the checkout was deleted after opening) cannot be
+      // confirmed, so it must not keep a stale "Needs review" flag (C3/H2).
+      if (thread.worktreePath === null) {
+        continue;
+      }
+      const livePr = needsReviewPrLookup.get(thread.id);
+      if (livePr?.state === "open") {
+        map[thread.id] = true;
+      }
+    }
+    return map;
+  }, [needsReviewPrLookup, threads]);
+
+  const board = buildKanbanBoard(
+    {
+      projects,
+      threads,
+      draftThreads,
+      composerDraftByThreadId,
+      draftOrderByProjectId,
+      projectIdAliases,
+      terminalEntryThreadIds,
+      optimisticDispatchByThreadId,
+    },
+    kanbanViewMode === "v2"
+      ? {
+          now: nowMs,
+          needsReviewByThreadId,
+          isNeedsReviewActive: kanbanNeedsReviewFilter,
+          // The board-level "Show more" affordance drops the per-column review
+          // cap so the folded tail renders (H1).
+          uncapped: hasRevealedReviewFold,
+          lastActivityTimestampMsByThreadId,
+        }
+      : undefined,
+  );
+  return board;
 }

--- a/apps/web/src/components/kanban/useKanbanBoard.ts
+++ b/apps/web/src/components/kanban/useKanbanBoard.ts
@@ -43,9 +43,16 @@ const OPTIMISTIC_DISPATCH_EXPIRY_CHECK_MS = 5_000;
 
 export function useKanbanBoard(): KanbanBoard {
   const { settings } = useAppSettings();
-  const selectDisplayThreads = createSidebarDisplayThreadsSelector({
-    hideAutomationRunThreads: !settings.showAutomationRunThreads,
-  });
+  // Stable across renders: a fresh selector closure per render would hand the
+  // store a new filter function each time and re-derive `threads` (and thus the
+  // whole board) on every unrelated store write.
+  const selectDisplayThreads = useMemo(
+    () =>
+      createSidebarDisplayThreadsSelector({
+        hideAutomationRunThreads: !settings.showAutomationRunThreads,
+      }),
+    [settings.showAutomationRunThreads],
+  );
   const threads = useStore(selectDisplayThreads);
   const allProjects = useStore((state) => state.projects);
   const threadsHydrated = useStore((state) => state.threadsHydrated);
@@ -234,9 +241,9 @@ export function useKanbanBoard(): KanbanBoard {
   // ("at least one card has an open PR") and the per-thread flag consult the same
   // live resolved PR rows the card chips render — a merged PR drops the "Needs
   // review" flag even though `lastKnownPr` still says open (H2). Polling is
-  // bounded: only threads whose persisted seed says open (the filter candidates)
-  // run live lookups, and only while the filter can actually change cards. When
-  // the filter is off, the map stays at `lastKnownPr` seeds so nothing churns.
+  // bounded: only threads whose persisted seed says open (pill and filter
+  // candidates) run live lookups, in v2 mode only — the pills need the live
+  // state even when the filter itself is off. When v2 is off, nothing polls.
   const projectCwdById = useMemo(
     () => new Map(allProjects.map((project) => [project.id, project.cwd] as const)),
     [allProjects],
@@ -270,8 +277,32 @@ export function useKanbanBoard(): KanbanBoard {
     return map;
   }, [needsReviewPrLookup, threads]);
 
-  const board = buildKanbanBoard(
-    {
+  const board = useMemo(
+    () =>
+      buildKanbanBoard(
+        {
+          projects,
+          threads,
+          draftThreads,
+          composerDraftByThreadId,
+          draftOrderByProjectId,
+          projectIdAliases,
+          terminalEntryThreadIds,
+          optimisticDispatchByThreadId,
+        },
+        kanbanViewMode === "v2"
+          ? {
+              now: nowMs,
+              needsReviewByThreadId,
+              isNeedsReviewActive: kanbanNeedsReviewFilter,
+              // The board-level "Show more" affordance drops the per-column review
+              // cap so the folded tail renders (H1).
+              uncapped: hasRevealedReviewFold,
+              lastActivityTimestampMsByThreadId,
+            }
+          : undefined,
+      ),
+    [
       projects,
       threads,
       draftThreads,
@@ -280,18 +311,13 @@ export function useKanbanBoard(): KanbanBoard {
       projectIdAliases,
       terminalEntryThreadIds,
       optimisticDispatchByThreadId,
-    },
-    kanbanViewMode === "v2"
-      ? {
-          now: nowMs,
-          needsReviewByThreadId,
-          isNeedsReviewActive: kanbanNeedsReviewFilter,
-          // The board-level "Show more" affordance drops the per-column review
-          // cap so the folded tail renders (H1).
-          uncapped: hasRevealedReviewFold,
-          lastActivityTimestampMsByThreadId,
-        }
-      : undefined,
+      kanbanViewMode,
+      nowMs,
+      needsReviewByThreadId,
+      kanbanNeedsReviewFilter,
+      hasRevealedReviewFold,
+      lastActivityTimestampMsByThreadId,
+    ],
   );
   return board;
 }

--- a/apps/web/src/kanbanUiStore.persistence.test.ts
+++ b/apps/web/src/kanbanUiStore.persistence.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { useKanbanUiStore } from "./kanbanUiStore";
+
+function installMemoryLocalStorage() {
+  const entries = new Map<string, string>();
+
+  vi.stubGlobal("localStorage", {
+    getItem: vi.fn((key: string) => entries.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      entries.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      entries.delete(key);
+    }),
+    clear: vi.fn(() => {
+      entries.clear();
+    }),
+    key: vi.fn((index: number) => Array.from(entries.keys())[index] ?? null),
+    get length() {
+      return entries.size;
+    },
+  });
+}
+
+type KanbanUiStore = typeof useKanbanUiStore;
+
+function getPersistApi(store: KanbanUiStore) {
+  return store.persist as unknown as {
+    getOptions: () => {
+      partialize: (state: ReturnType<typeof store.getState>) => unknown;
+      merge: (
+        persistedState: unknown,
+        currentState: ReturnType<typeof store.getState>,
+      ) => ReturnType<typeof store.getState>;
+    };
+  };
+}
+
+describe("kanbanUiStore view-mode persistence", () => {
+  beforeEach(() => {
+    installMemoryLocalStorage();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults to the v2 board in fresh state", async () => {
+    const { useKanbanUiStore } = await import("./kanbanUiStore");
+    const store = useKanbanUiStore as KanbanUiStore;
+    expect(store.getState().kanbanViewMode).toBe("v2");
+    expect(store.getState().kanbanNeedsReviewFilter).toBe(false);
+  });
+
+  it("round-trips a persisted classic mode through partialize and merge", async () => {
+    const { useKanbanUiStore } = await import("./kanbanUiStore");
+    const store = useKanbanUiStore as KanbanUiStore;
+    store.setState((state) => ({
+      ...state,
+      kanbanViewMode: "classic",
+      kanbanNeedsReviewFilter: true,
+    }));
+    const persistedState = getPersistApi(store)
+      .getOptions()
+      .partialize(store.getState()) as Partial<ReturnType<typeof store.getState>>;
+
+    expect(persistedState.kanbanViewMode).toBe("classic");
+    expect(persistedState.kanbanNeedsReviewFilter).toBe(true);
+
+    const merged = getPersistApi(store).getOptions().merge(persistedState, store.getInitialState());
+    expect(merged.kanbanViewMode).toBe("classic");
+    expect(merged.kanbanNeedsReviewFilter).toBe(true);
+  });
+
+  it("sanitizes unknown persisted view modes back to v2", async () => {
+    const { useKanbanUiStore } = await import("./kanbanUiStore");
+    const store = useKanbanUiStore as KanbanUiStore;
+    const merged = getPersistApi(store)
+      .getOptions()
+      .merge({ kanbanViewMode: "fancy", kanbanNeedsReviewFilter: "yes" }, store.getInitialState());
+    expect(merged.kanbanViewMode).toBe("v2");
+    expect(merged.kanbanNeedsReviewFilter).toBe(false);
+  });
+
+  it("sanitizes legacy persisted drafts that lack the new fields", async () => {
+    const { useKanbanUiStore } = await import("./kanbanUiStore");
+    const store = useKanbanUiStore as KanbanUiStore;
+    const merged = getPersistApi(store)
+      .getOptions()
+      .merge({ draftOrderByProjectId: { "proj-1": ["card-a"] } }, store.getInitialState());
+    expect(merged.kanbanViewMode).toBe("v2");
+    expect(merged.kanbanNeedsReviewFilter).toBe(false);
+    expect(merged.draftOrderByProjectId).toEqual({ "proj-1": ["card-a"] });
+  });
+
+  it("excludes ephemeral optimistic-dispatch state from persistence", async () => {
+    const { useKanbanUiStore } = await import("./kanbanUiStore");
+    const store = useKanbanUiStore as KanbanUiStore;
+    const persistedState = getPersistApi(store)
+      .getOptions()
+      .partialize(store.getState()) as Partial<ReturnType<typeof store.getState>>;
+    expect(persistedState.optimisticDispatchByThreadId).toBeUndefined();
+  });
+
+  it("round-trips a revealed needs-review fold through partialize and merge", async () => {
+    const { useKanbanUiStore } = await import("./kanbanUiStore");
+    const store = useKanbanUiStore as KanbanUiStore;
+    store.setState((state) => ({
+      ...state,
+      kanbanNeedsReviewFilter: true,
+      hasRevealedReviewFold: true,
+    }));
+    const persistedState = getPersistApi(store)
+      .getOptions()
+      .partialize(store.getState()) as Partial<ReturnType<typeof store.getState>>;
+
+    expect(persistedState.hasRevealedReviewFold).toBe(true);
+
+    const merged = getPersistApi(store).getOptions().merge(persistedState, store.getInitialState());
+    expect(merged.hasRevealedReviewFold).toBe(true);
+    expect(merged.kanbanNeedsReviewFilter).toBe(true);
+  });
+
+  it("sanitizes a non-boolean persisted reveal back to the folded default", async () => {
+    const { useKanbanUiStore } = await import("./kanbanUiStore");
+    const store = useKanbanUiStore as KanbanUiStore;
+    const merged = getPersistApi(store)
+      .getOptions()
+      .merge({ hasRevealedReviewFold: "yes" }, store.getInitialState());
+    expect(merged.hasRevealedReviewFold).toBe(false);
+  });
+
+  it("turns the filter off with the reveal so a stale fold never persists alone (H1)", async () => {
+    const { useKanbanUiStore } = await import("./kanbanUiStore");
+    const store = useKanbanUiStore as KanbanUiStore;
+    store.setState((state) => ({
+      ...state,
+      kanbanNeedsReviewFilter: true,
+      hasRevealedReviewFold: true,
+    }));
+    store.getState().setKanbanNeedsReviewFilter(false);
+    const state = store.getState();
+    expect(state.kanbanNeedsReviewFilter).toBe(false);
+    expect(state.hasRevealedReviewFold).toBe(false);
+  });
+});

--- a/apps/web/src/kanbanUiStore.persistence.test.ts
+++ b/apps/web/src/kanbanUiStore.persistence.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { useKanbanUiStore } from "./kanbanUiStore";
 
+type KanbanUiStore = typeof useKanbanUiStore;
+
 function installMemoryLocalStorage() {
   const entries = new Map<string, string>();
 
@@ -22,12 +24,16 @@ function installMemoryLocalStorage() {
   });
 }
 
-type KanbanUiStore = typeof useKanbanUiStore;
+// Each test must import the module fresh so the resetModules in beforeEach
+// rebuilds the zustand persist layer against the stubbed localStorage.
+const loadStore = async () => (await import("./kanbanUiStore")).useKanbanUiStore as KanbanUiStore;
 
-function getPersistApi(store: KanbanUiStore) {
+function persistApi(store: KanbanUiStore) {
   return store.persist as unknown as {
     getOptions: () => {
-      partialize: (state: ReturnType<typeof store.getState>) => unknown;
+      partialize: (
+        state: ReturnType<typeof store.getState>,
+      ) => Partial<ReturnType<typeof store.getState>>;
       merge: (
         persistedState: unknown,
         currentState: ReturnType<typeof store.getState>,
@@ -46,94 +52,75 @@ describe("kanbanUiStore view-mode persistence", () => {
     vi.unstubAllGlobals();
   });
 
-  it("defaults to the v2 board in fresh state", async () => {
-    const { useKanbanUiStore } = await import("./kanbanUiStore");
-    const store = useKanbanUiStore as KanbanUiStore;
-    expect(store.getState().kanbanViewMode).toBe("v2");
-    expect(store.getState().kanbanNeedsReviewFilter).toBe(false);
+  it("defaults fresh state to the v2 board with folded review", async () => {
+    const state = (await loadStore()).getState();
+    expect(state.kanbanViewMode).toBe("v2");
+    expect(state.kanbanNeedsReviewFilter).toBe(false);
   });
 
-  it("round-trips a persisted classic mode through partialize and merge", async () => {
-    const { useKanbanUiStore } = await import("./kanbanUiStore");
-    const store = useKanbanUiStore as KanbanUiStore;
+  it("round-trips persisted classic mode through partialize and merge", async () => {
+    const store = await loadStore();
     store.setState((state) => ({
       ...state,
       kanbanViewMode: "classic",
       kanbanNeedsReviewFilter: true,
     }));
-    const persistedState = getPersistApi(store)
-      .getOptions()
-      .partialize(store.getState()) as Partial<ReturnType<typeof store.getState>>;
+    const options = persistApi(store).getOptions();
+    const persistedState = options.partialize(store.getState());
 
     expect(persistedState.kanbanViewMode).toBe("classic");
     expect(persistedState.kanbanNeedsReviewFilter).toBe(true);
 
-    const merged = getPersistApi(store).getOptions().merge(persistedState, store.getInitialState());
+    const merged = options.merge(persistedState, store.getInitialState());
     expect(merged.kanbanViewMode).toBe("classic");
     expect(merged.kanbanNeedsReviewFilter).toBe(true);
   });
 
-  it("sanitizes unknown persisted view modes back to v2", async () => {
-    const { useKanbanUiStore } = await import("./kanbanUiStore");
-    const store = useKanbanUiStore as KanbanUiStore;
-    const merged = getPersistApi(store)
-      .getOptions()
-      .merge({ kanbanViewMode: "fancy", kanbanNeedsReviewFilter: "yes" }, store.getInitialState());
-    expect(merged.kanbanViewMode).toBe("v2");
-    expect(merged.kanbanNeedsReviewFilter).toBe(false);
-  });
-
-  it("sanitizes legacy persisted drafts that lack the new fields", async () => {
-    const { useKanbanUiStore } = await import("./kanbanUiStore");
-    const store = useKanbanUiStore as KanbanUiStore;
-    const merged = getPersistApi(store)
-      .getOptions()
-      .merge({ draftOrderByProjectId: { "proj-1": ["card-a"] } }, store.getInitialState());
-    expect(merged.kanbanViewMode).toBe("v2");
-    expect(merged.kanbanNeedsReviewFilter).toBe(false);
-    expect(merged.draftOrderByProjectId).toEqual({ "proj-1": ["card-a"] });
-  });
-
-  it("excludes ephemeral optimistic-dispatch state from persistence", async () => {
-    const { useKanbanUiStore } = await import("./kanbanUiStore");
-    const store = useKanbanUiStore as KanbanUiStore;
-    const persistedState = getPersistApi(store)
-      .getOptions()
-      .partialize(store.getState()) as Partial<ReturnType<typeof store.getState>>;
-    expect(persistedState.optimisticDispatchByThreadId).toBeUndefined();
-  });
-
-  it("round-trips a revealed needs-review fold through partialize and merge", async () => {
-    const { useKanbanUiStore } = await import("./kanbanUiStore");
-    const store = useKanbanUiStore as KanbanUiStore;
+  it("round-trips a revealed needs-review fold and excludes ephemeral optimistic dispatches", async () => {
+    const store = await loadStore();
     store.setState((state) => ({
       ...state,
       kanbanNeedsReviewFilter: true,
       hasRevealedReviewFold: true,
     }));
-    const persistedState = getPersistApi(store)
-      .getOptions()
-      .partialize(store.getState()) as Partial<ReturnType<typeof store.getState>>;
+    const options = persistApi(store).getOptions();
+    const persistedState = options.partialize(store.getState());
 
     expect(persistedState.hasRevealedReviewFold).toBe(true);
+    expect(persistedState.optimisticDispatchByThreadId).toBeUndefined();
 
-    const merged = getPersistApi(store).getOptions().merge(persistedState, store.getInitialState());
+    const merged = options.merge(persistedState, store.getInitialState());
     expect(merged.hasRevealedReviewFold).toBe(true);
     expect(merged.kanbanNeedsReviewFilter).toBe(true);
   });
 
-  it("sanitizes a non-boolean persisted reveal back to the folded default", async () => {
-    const { useKanbanUiStore } = await import("./kanbanUiStore");
-    const store = useKanbanUiStore as KanbanUiStore;
-    const merged = getPersistApi(store)
-      .getOptions()
-      .merge({ hasRevealedReviewFold: "yes" }, store.getInitialState());
-    expect(merged.hasRevealedReviewFold).toBe(false);
+  it("sanitizes malformed or legacy persisted state back to safe defaults", async () => {
+    const store = await loadStore();
+    const { merge } = persistApi(store).getOptions();
+    const initialState = () => store.getInitialState();
+
+    // Unknown view mode and non-boolean filter snap back to v2/false.
+    const fancy = merge(
+      { kanbanViewMode: "fancy", kanbanNeedsReviewFilter: "yes" },
+      initialState(),
+    );
+    expect(fancy.kanbanViewMode).toBe("v2");
+    expect(fancy.kanbanNeedsReviewFilter).toBe(false);
+
+    // Legacy persisted drafts lacking the new fields keep their draft order.
+    const legacy = merge({ draftOrderByProjectId: { "proj-1": ["card-a"] } }, initialState());
+    expect(legacy.draftOrderByProjectId).toEqual({ "proj-1": ["card-a"] });
+    expect(legacy.kanbanViewMode).toBe("v2");
+    expect(legacy.kanbanNeedsReviewFilter).toBe(false);
+
+    // A non-boolean reveal folds back instead of leaking truthy strings.
+    expect(merge({ hasRevealedReviewFold: "yes" }, initialState()).hasRevealedReviewFold).toBe(
+      false,
+    );
   });
 
   it("turns the filter off with the reveal so a stale fold never persists alone (H1)", async () => {
-    const { useKanbanUiStore } = await import("./kanbanUiStore");
-    const store = useKanbanUiStore as KanbanUiStore;
+    const store = await loadStore();
     store.setState((state) => ({
       ...state,
       kanbanNeedsReviewFilter: true,

--- a/apps/web/src/kanbanUiStore.ts
+++ b/apps/web/src/kanbanUiStore.ts
@@ -9,11 +9,26 @@ import { createJSONStorage, persist } from "zustand/middleware";
 
 import type { KanbanOptimisticDispatchSnapshot } from "./components/kanban/kanban.logic";
 
+/** Which kanban board the user sees: the classic 3-column escape hatch or the v2 board. */
+export type KanbanViewMode = "classic" | "v2";
+
 interface KanbanUiStoreState {
   /** Manual order of draft-column card ids per project, captured after a drag. */
   draftOrderByProjectId: Record<string, string[]>;
   setDraftOrder: (projectId: string, order: readonly string[]) => void;
   clearDraftOrder: (projectId: string) => void;
+  /** Board flavor: classic 3-column escape hatch vs v2 attention-first board. */
+  kanbanViewMode: KanbanViewMode;
+  setKanbanViewMode: (mode: KanbanViewMode) => void;
+  /** v2-only needs-review filter (S1-P8): narrows cards to those with an open PR. */
+  kanbanNeedsReviewFilter: boolean;
+  setKanbanNeedsReviewFilter: (enabled: boolean) => void;
+  /**
+   * v2-only board-level reveal of the needs-review folded tail (H1): once on,
+   * the per-column review cap drops until the filter itself changes.
+   */
+  hasRevealedReviewFold: boolean;
+  setHasRevealedReviewFold: (revealed: boolean) => void;
   /**
    * Ephemeral (never persisted): dispatched drops still waiting for their first
    * runtime signal. The board renders these In Progress; reconciliation clears them
@@ -65,6 +80,18 @@ function sanitizeDraftOrderByProjectId(value: unknown): Record<string, string[]>
   return result;
 }
 
+function sanitizeViewMode(value: unknown): KanbanViewMode {
+  return value === "classic" ? "classic" : "v2";
+}
+
+function sanitizeNeedsReviewFilter(value: unknown): boolean {
+  return value === true;
+}
+
+function sanitizeHasRevealedReviewFold(value: unknown): boolean {
+  return value === true;
+}
+
 export const useKanbanUiStore = create<KanbanUiStoreState>()(
   persist(
     (set) => ({
@@ -98,6 +125,29 @@ export const useKanbanUiStore = create<KanbanUiStoreState>()(
           delete next[projectId];
           return { draftOrderByProjectId: next };
         });
+      },
+      kanbanViewMode: "v2",
+      setKanbanViewMode: (mode) => {
+        set((state) => (state.kanbanViewMode === mode ? state : { kanbanViewMode: mode }));
+      },
+      kanbanNeedsReviewFilter: false,
+      setKanbanNeedsReviewFilter: (enabled) => {
+        set((state) => {
+          if (state.kanbanNeedsReviewFilter === enabled) {
+            return state;
+          }
+          // Turning the filter off also closes any open reveal — the folded-tail
+          // affordance is meaningless without the filter this session (H1).
+          return enabled
+            ? { kanbanNeedsReviewFilter: true }
+            : { kanbanNeedsReviewFilter: false, hasRevealedReviewFold: false };
+        });
+      },
+      hasRevealedReviewFold: false,
+      setHasRevealedReviewFold: (revealed) => {
+        set((state) =>
+          state.hasRevealedReviewFold === revealed ? state : { hasRevealedReviewFold: revealed },
+        );
       },
       optimisticDispatchByThreadId: {},
       markOptimisticDispatch: (threadId, entry) => {
@@ -140,14 +190,28 @@ export const useKanbanUiStore = create<KanbanUiStoreState>()(
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
         draftOrderByProjectId: state.draftOrderByProjectId,
+        kanbanViewMode: state.kanbanViewMode,
+        kanbanNeedsReviewFilter: state.kanbanNeedsReviewFilter,
+        hasRevealedReviewFold: state.hasRevealedReviewFold,
       }),
-      merge: (persistedState, currentState) => ({
-        ...currentState,
-        draftOrderByProjectId: sanitizeDraftOrderByProjectId(
-          (persistedState as Partial<Pick<KanbanUiStoreState, "draftOrderByProjectId">> | undefined)
-            ?.draftOrderByProjectId,
-        ),
-      }),
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as Partial<
+          Pick<
+            KanbanUiStoreState,
+            | "draftOrderByProjectId"
+            | "kanbanViewMode"
+            | "kanbanNeedsReviewFilter"
+            | "hasRevealedReviewFold"
+          >
+        > | null;
+        return {
+          ...currentState,
+          draftOrderByProjectId: sanitizeDraftOrderByProjectId(persisted?.draftOrderByProjectId),
+          kanbanViewMode: sanitizeViewMode(persisted?.kanbanViewMode),
+          kanbanNeedsReviewFilter: sanitizeNeedsReviewFilter(persisted?.kanbanNeedsReviewFilter),
+          hasRevealedReviewFold: sanitizeHasRevealedReviewFold(persisted?.hasRevealedReviewFold),
+        };
+      },
     },
   ),
 );

--- a/apps/web/src/storeSelectors.test.ts
+++ b/apps/web/src/storeSelectors.test.ts
@@ -8,6 +8,7 @@ import {
   createAllThreadsSelector,
   createAllThreadsMessagelessSelector,
   createComposerThreadMentionSourcesSelector,
+  createLastActivityTimestampSelector,
   createProjectLastActivityAtSelector,
   createSidebarDisplayThreadsSelector,
   createSidebarTreeThreadsSelector,
@@ -486,5 +487,67 @@ describe("createProjectLastActivityAtSelector", () => {
     );
 
     expect(after).toBe(before);
+  });
+});
+
+describe("createLastActivityTimestampSelector", () => {
+  it("excludes threads whose shell has no updatedAt (sparse map, C1)", () => {
+    const selectTimestamps = createLastActivityTimestampSelector();
+    const state = makeState({
+      threadIds: [threadIdA, threadIdB],
+      threadShellById: {
+        // Shell A has a durable stamp; shell B is present but stale/pruned.
+        [threadIdA]: { ...shellA, updatedAt: "2026-03-09T11:00:00.000Z" },
+        [threadIdB]: { ...shellB },
+      },
+    });
+    const result = selectTimestamps(state);
+    expect(Object.keys(result)).toEqual([threadIdA]);
+    expect(result[threadIdA]).toBe(Date.parse("2026-03-09T11:00:00.000Z"));
+    // Absent shells must not be conflated with an explicit null.
+    expect(threadIdB in result).toBe(false);
+  });
+
+  it("returns the empty constant when no thread has a durable stamp", () => {
+    const selectTimestamps = createLastActivityTimestampSelector();
+    const state = makeState({
+      threadIds: [threadIdA],
+      threadShellById: { [threadIdA]: { ...shellA } },
+    });
+    expect(selectTimestamps(state)).toEqual({});
+  });
+
+  it("keeps the previous result reference while stamps do not move", () => {
+    const selectTimestamps = createLastActivityTimestampSelector();
+    const threadIds = [threadIdA] as readonly ThreadId[];
+    const threadShellById = {
+      [threadIdA]: { ...shellA, updatedAt: "2026-03-09T11:00:00.000Z" },
+    };
+    const before = selectTimestamps(makeState({ threadIds, threadShellById }));
+    const after = selectTimestamps(
+      makeState({ threadIds, threadShellById, messageIdsByThreadId: { [threadIdA]: [messageId] } }),
+    );
+    expect(after).toBe(before);
+  });
+
+  it("keeps the previous result reference when a shell ref changes but the stamp does not", () => {
+    const selectTimestamps = createLastActivityTimestampSelector();
+    const threadIds = [threadIdA] as readonly ThreadId[];
+    const stamp = "2026-03-09T11:00:00.000Z";
+    const before = selectTimestamps(
+      makeState({ threadIds, threadShellById: { [threadIdA]: { ...shellA, updatedAt: stamp } } }),
+    );
+    // A meta-only shell update (new object, same durable stamp) must not churn
+    // the result — the fast path returns the previous object by reference (F1).
+    const after = selectTimestamps(
+      makeState({
+        threadIds,
+        threadShellById: {
+          [threadIdA]: { ...shellA, updatedAt: stamp, title: "renamed" },
+        },
+      }),
+    );
+    expect(after).toBe(before);
+    expect(after[threadIdA]).toBe(Date.parse(stamp));
   });
 });

--- a/apps/web/src/storeSelectors.test.ts
+++ b/apps/web/src/storeSelectors.test.ts
@@ -62,45 +62,38 @@ function makeActivity(id: string, kind: string) {
 }
 
 describe("createThreadShellsSelector", () => {
-  it("returns shells in threadIds order", () => {
+  it("orders by threadIds, ignores streaming messages, and rebuilds when shells change", () => {
     const selectShells = createThreadShellsSelector();
-    const state = makeState({
-      threadIds: [threadIdB, threadIdA],
-      threadShellById: { [threadIdA]: shellA, [threadIdB]: shellB },
-    });
+    expect(
+      selectShells(
+        makeState({
+          threadIds: [threadIdB, threadIdA],
+          threadShellById: { [threadIdA]: shellA, [threadIdB]: shellB },
+        }),
+      ).map((shell) => shell.id),
+    ).toEqual([threadIdB, threadIdA]);
 
-    expect(selectShells(state).map((shell) => shell.id)).toEqual([threadIdB, threadIdA]);
-  });
-
-  it("stays reference-stable when unrelated state changes (e.g. streaming messages)", () => {
-    const selectShells = createThreadShellsSelector();
+    // The slices are shared by identity across both states so the derivation
+    // cache (keyed on slice identity) can prove streaming changes don't churn.
     const threadIds = [threadIdA];
     const threadShellById = { [threadIdA]: shellA };
-
     const before = selectShells(makeState({ threadIds, threadShellById }));
-    const after = selectShells(
-      makeState({
-        threadIds,
-        threadShellById,
-        messageIdsByThreadId: { [threadIdA]: [messageId] },
-      }),
-    );
+    expect(
+      selectShells(
+        makeState({
+          threadIds,
+          threadShellById,
+          messageIdsByThreadId: { [threadIdA]: [messageId] },
+        }),
+      ),
+    ).toBe(before);
 
-    expect(after).toBe(before);
-  });
-
-  it("returns a new array when shells change", () => {
-    const selectShells = createThreadShellsSelector();
-    const threadIds = [threadIdA];
-
-    const before = selectShells(makeState({ threadIds, threadShellById: { [threadIdA]: shellA } }));
     const after = selectShells(
       makeState({
         threadIds,
         threadShellById: { [threadIdA]: { ...shellA, title: "renamed" } },
       }),
     );
-
     expect(after).not.toBe(before);
     expect(after[0]?.title).toBe("renamed");
   });
@@ -109,6 +102,11 @@ describe("createThreadShellsSelector", () => {
 describe("createAccountRateLimitThreadsSelector", () => {
   const rateLimitActivity = makeActivity("activity-rate", "account.rate-limits.updated");
   const toolActivity = makeActivity("activity-tool", "provider.tool-call");
+  const onlyRateLimit = {
+    threadIds: [threadIdA],
+    activityIdsByThreadId: { [threadIdA]: [rateLimitActivity.id] },
+    activityByThreadId: { [threadIdA]: { [rateLimitActivity.id]: rateLimitActivity } },
+  } as const;
 
   it("collects only account rate-limit activities", () => {
     const selectRateLimitThreads = createAccountRateLimitThreadsSelector();
@@ -129,72 +127,40 @@ describe("createAccountRateLimitThreadsSelector", () => {
     expect(result[0]?.activities).toEqual([rateLimitActivity]);
   });
 
-  it("stays reference-stable when message slices change (streaming deltas)", () => {
+  it("stays reference-stable through streaming deltas and non-rate-limit appends", () => {
     const selectRateLimitThreads = createAccountRateLimitThreadsSelector();
-    const threadIds = [threadIdA];
-    const activityIdsByThreadId = { [threadIdA]: [rateLimitActivity.id] };
-    const activityByThreadId = { [threadIdA]: { [rateLimitActivity.id]: rateLimitActivity } };
+    const before = selectRateLimitThreads(makeState(onlyRateLimit));
 
-    const before = selectRateLimitThreads(
-      makeState({ threadIds, activityIdsByThreadId, activityByThreadId }),
-    );
-    const after = selectRateLimitThreads(
-      makeState({
-        threadIds,
-        activityIdsByThreadId,
-        activityByThreadId,
-        messageIdsByThreadId: { [threadIdA]: [messageId] },
-      }),
-    );
-
-    expect(after).toBe(before);
-  });
-
-  it("stays reference-stable when a non-rate-limit activity is appended", () => {
-    const selectRateLimitThreads = createAccountRateLimitThreadsSelector();
-    const threadIds = [threadIdA];
-
-    const before = selectRateLimitThreads(
-      makeState({
-        threadIds,
-        activityIdsByThreadId: { [threadIdA]: [rateLimitActivity.id] },
-        activityByThreadId: { [threadIdA]: { [rateLimitActivity.id]: rateLimitActivity } },
-      }),
-    );
-    const after = selectRateLimitThreads(
-      makeState({
-        threadIds,
-        activityIdsByThreadId: { [threadIdA]: [rateLimitActivity.id, toolActivity.id] },
-        activityByThreadId: {
-          [threadIdA]: {
-            [rateLimitActivity.id]: rateLimitActivity,
-            [toolActivity.id]: toolActivity,
+    expect(
+      selectRateLimitThreads(
+        makeState({ ...onlyRateLimit, messageIdsByThreadId: { [threadIdA]: [messageId] } }),
+      ),
+    ).toBe(before);
+    expect(
+      selectRateLimitThreads(
+        makeState({
+          ...onlyRateLimit,
+          activityIdsByThreadId: { [threadIdA]: [rateLimitActivity.id, toolActivity.id] },
+          activityByThreadId: {
+            [threadIdA]: {
+              [rateLimitActivity.id]: rateLimitActivity,
+              [toolActivity.id]: toolActivity,
+            },
           },
-        },
-      }),
-    );
-
-    expect(after).toBe(before);
+        }),
+      ),
+    ).toBe(before);
   });
 
-  it("returns a new result when a rate-limit activity is appended", () => {
+  it("returns a new result when a rate-limit activity is appended, else the empty constant", () => {
     const selectRateLimitThreads = createAccountRateLimitThreadsSelector();
-    const threadIds = [threadIdA];
     const laterRateLimitActivity = makeActivity("activity-rate-2", "account.rate-limited");
+    const before = selectRateLimitThreads(makeState(onlyRateLimit));
 
-    const before = selectRateLimitThreads(
-      makeState({
-        threadIds,
-        activityIdsByThreadId: { [threadIdA]: [rateLimitActivity.id] },
-        activityByThreadId: { [threadIdA]: { [rateLimitActivity.id]: rateLimitActivity } },
-      }),
-    );
     const after = selectRateLimitThreads(
       makeState({
-        threadIds,
-        activityIdsByThreadId: {
-          [threadIdA]: [rateLimitActivity.id, laterRateLimitActivity.id],
-        },
+        ...onlyRateLimit,
+        activityIdsByThreadId: { [threadIdA]: [rateLimitActivity.id, laterRateLimitActivity.id] },
         activityByThreadId: {
           [threadIdA]: {
             [rateLimitActivity.id]: rateLimitActivity,
@@ -203,7 +169,6 @@ describe("createAccountRateLimitThreadsSelector", () => {
         },
       }),
     );
-
     expect(after).not.toBe(before);
     expect(after[0]?.activities).toEqual([rateLimitActivity, laterRateLimitActivity]);
   });
@@ -253,25 +218,17 @@ describe("sidebar thread visibility", () => {
     expect(isSidebarThreadVisible(normalSummary, options)).toBe(true);
   });
 
-  it("filters run threads out of the display and tree selectors", () => {
+  it("filters run threads out of the display and tree selectors only when the option is set", () => {
     const selectDisplay = createSidebarDisplayThreadsSelector({ hideAutomationRunThreads: true });
     const selectTree = createSidebarTreeThreadsSelector({ hideAutomationRunThreads: true });
 
     expect(selectDisplay(state).map((thread) => thread.id)).toEqual([threadIdB, threadIdC]);
     expect(selectTree(state).map((thread) => thread.id)).toEqual([threadIdB, threadIdC]);
-  });
-
-  it("keeps run threads in the selectors when the option is unset", () => {
-    const selectDisplay = createSidebarDisplayThreadsSelector();
-    expect(selectDisplay(state).map((thread) => thread.id)).toEqual([
+    expect(createSidebarDisplayThreadsSelector()(state).map((thread) => thread.id)).toEqual([
       threadIdA,
       threadIdB,
       threadIdC,
     ]);
-  });
-
-  it("stays reference-stable while the underlying summaries do not change", () => {
-    const selectDisplay = createSidebarDisplayThreadsSelector({ hideAutomationRunThreads: true });
     expect(selectDisplay(state)).toBe(selectDisplay(state));
   });
 });
@@ -332,27 +289,25 @@ describe("createAllThreadsSelector", () => {
 });
 
 describe("createAllThreadsMessagelessSelector", () => {
-  it("is vacuously true with no threads", () => {
+  it("is true until any thread has a message", () => {
     const selectMessageless = createAllThreadsMessagelessSelector();
     expect(selectMessageless(makeState({}))).toBe(true);
-  });
-
-  it("is true when every thread has no message ids", () => {
-    const selectMessageless = createAllThreadsMessagelessSelector();
-    const state = makeState({
-      threadIds: [threadIdA, threadIdB],
-      messageIdsByThreadId: { [threadIdA]: [] },
-    });
-    expect(selectMessageless(state)).toBe(true);
-  });
-
-  it("is false once any thread has a message", () => {
-    const selectMessageless = createAllThreadsMessagelessSelector();
-    const state = makeState({
-      threadIds: [threadIdA, threadIdB],
-      messageIdsByThreadId: { [threadIdB]: [messageId] },
-    });
-    expect(selectMessageless(state)).toBe(false);
+    expect(
+      selectMessageless(
+        makeState({
+          threadIds: [threadIdA, threadIdB],
+          messageIdsByThreadId: { [threadIdA]: [] },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      selectMessageless(
+        makeState({
+          threadIds: [threadIdA, threadIdB],
+          messageIdsByThreadId: { [threadIdB]: [messageId] },
+        }),
+      ),
+    ).toBe(false);
   });
 });
 
@@ -402,28 +357,23 @@ describe("thread shell route selectors", () => {
 
   it("updates workspace metadata when a Studio working directory changes", () => {
     const selectWorkspaceMetadata = createThreadWorkspaceMetadataSelector(threadIdA);
+    const shellWithWorkingDirectory = (workingDirectory: string) => ({
+      [threadIdA]: {
+        ...shellA,
+        envMode: "local" as const,
+        workingDirectory,
+      },
+    });
     const before = selectWorkspaceMetadata(
       makeState({
         threadIds: [threadIdA],
-        threadShellById: {
-          [threadIdA]: {
-            ...shellA,
-            envMode: "local",
-            workingDirectory: "/repo/one",
-          },
-        },
+        threadShellById: shellWithWorkingDirectory("/repo/one"),
       }),
     );
     const after = selectWorkspaceMetadata(
       makeState({
         threadIds: [threadIdA],
-        threadShellById: {
-          [threadIdA]: {
-            ...shellA,
-            envMode: "local",
-            workingDirectory: "/repo/two",
-          },
-        },
+        threadShellById: shellWithWorkingDirectory("/repo/two"),
       }),
     );
 
@@ -439,9 +389,9 @@ describe("thread shell route selectors", () => {
 describe("createProjectLastActivityAtSelector", () => {
   const otherProjectId = "project-2" as ProjectId;
 
-  it("keeps the newest user message per project", () => {
+  it("keeps the newest user message per project, falling back to thread creation time", () => {
     const selectActivity = createProjectLastActivityAtSelector();
-    const activity = selectActivity(
+    const mixed = selectActivity(
       makeState({
         threadIds: [threadIdA, threadIdB],
         sidebarThreadSummaryById: {
@@ -454,21 +404,16 @@ describe("createProjectLastActivityAtSelector", () => {
         },
       }),
     );
+    expect(mixed.get(projectId)).toBe("2026-03-01T00:00:00.000Z");
 
-    expect(activity.get(projectId)).toBe("2026-03-01T00:00:00.000Z");
-  });
-
-  it("falls back to the thread creation time when nothing was written yet", () => {
-    const selectActivity = createProjectLastActivityAtSelector();
-    const activity = selectActivity(
+    const fallback = selectActivity(
       makeState({
         threadIds: [threadIdA],
         sidebarThreadSummaryById: { [threadIdA]: summaryA },
       }),
     );
-
-    expect(activity.get(projectId)).toBe("2026-01-01T00:00:00.000Z");
-    expect(activity.has(otherProjectId)).toBe(false);
+    expect(fallback.get(projectId)).toBe("2026-01-01T00:00:00.000Z");
+    expect(fallback.has(otherProjectId)).toBe(false);
   });
 
   it("keeps a stable identity when the summaries change without moving activity", () => {
@@ -491,63 +436,53 @@ describe("createProjectLastActivityAtSelector", () => {
 });
 
 describe("createLastActivityTimestampSelector", () => {
-  it("excludes threads whose shell has no updatedAt (sparse map, C1)", () => {
+  const stamped = "2026-03-09T11:00:00.000Z";
+  const withStamp = {
+    threadIds: [threadIdA] as readonly ThreadId[],
+    threadShellById: { [threadIdA]: { ...shellA, updatedAt: stamped } },
+  };
+
+  it("maps only shells that carry a durable stamp (sparse map, C1)", () => {
     const selectTimestamps = createLastActivityTimestampSelector();
     const state = makeState({
       threadIds: [threadIdA, threadIdB],
       threadShellById: {
         // Shell A has a durable stamp; shell B is present but stale/pruned.
-        [threadIdA]: { ...shellA, updatedAt: "2026-03-09T11:00:00.000Z" },
+        [threadIdA]: { ...shellA, updatedAt: stamped },
         [threadIdB]: { ...shellB },
       },
     });
     const result = selectTimestamps(state);
     expect(Object.keys(result)).toEqual([threadIdA]);
-    expect(result[threadIdA]).toBe(Date.parse("2026-03-09T11:00:00.000Z"));
+    expect(result[threadIdA]).toBe(Date.parse(stamped));
     // Absent shells must not be conflated with an explicit null.
     expect(threadIdB in result).toBe(false);
+    expect(
+      selectTimestamps(
+        makeState({ threadIds: [threadIdA], threadShellById: { [threadIdA]: { ...shellA } } }),
+      ),
+    ).toEqual({});
   });
 
-  it("returns the empty constant when no thread has a durable stamp", () => {
+  it("keeps the previous result while neither streaming nor meta-only shell churn moves a stamp (F1)", () => {
     const selectTimestamps = createLastActivityTimestampSelector();
-    const state = makeState({
-      threadIds: [threadIdA],
-      threadShellById: { [threadIdA]: { ...shellA } },
-    });
-    expect(selectTimestamps(state)).toEqual({});
-  });
+    const before = selectTimestamps(makeState(withStamp));
 
-  it("keeps the previous result reference while stamps do not move", () => {
-    const selectTimestamps = createLastActivityTimestampSelector();
-    const threadIds = [threadIdA] as readonly ThreadId[];
-    const threadShellById = {
-      [threadIdA]: { ...shellA, updatedAt: "2026-03-09T11:00:00.000Z" },
-    };
-    const before = selectTimestamps(makeState({ threadIds, threadShellById }));
-    const after = selectTimestamps(
-      makeState({ threadIds, threadShellById, messageIdsByThreadId: { [threadIdA]: [messageId] } }),
-    );
-    expect(after).toBe(before);
-  });
+    expect(
+      selectTimestamps(
+        makeState({ ...withStamp, messageIdsByThreadId: { [threadIdA]: [messageId] } }),
+      ),
+    ).toBe(before);
 
-  it("keeps the previous result reference when a shell ref changes but the stamp does not", () => {
-    const selectTimestamps = createLastActivityTimestampSelector();
-    const threadIds = [threadIdA] as readonly ThreadId[];
-    const stamp = "2026-03-09T11:00:00.000Z";
-    const before = selectTimestamps(
-      makeState({ threadIds, threadShellById: { [threadIdA]: { ...shellA, updatedAt: stamp } } }),
-    );
     // A meta-only shell update (new object, same durable stamp) must not churn
     // the result — the fast path returns the previous object by reference (F1).
     const after = selectTimestamps(
       makeState({
-        threadIds,
-        threadShellById: {
-          [threadIdA]: { ...shellA, updatedAt: stamp, title: "renamed" },
-        },
+        ...withStamp,
+        threadShellById: { [threadIdA]: { ...shellA, updatedAt: stamped, title: "renamed" } },
       }),
     );
     expect(after).toBe(before);
-    expect(after[threadIdA]).toBe(Date.parse(stamp));
+    expect(after[threadIdA]).toBe(Date.parse(stamped));
   });
 });

--- a/apps/web/src/storeSelectors.ts
+++ b/apps/web/src/storeSelectors.ts
@@ -308,6 +308,82 @@ export function createSidebarThreadSummariesSelector(): (
   };
 }
 
+/**
+ * Per-thread durable last-activity stamp (epoch ms), keyed by thread id. The
+ * kanban heartbeat reads this because `SidebarThreadSummary.updatedAt` freezes
+ * during streaming (the sidebar summary build is skipped on the streaming hot
+ * path), while the durable thread shell's `updatedAt` advances on every appended
+ * message — a busy-but-quiet turn must keep its heartbeat fresh. Derives only
+ * from reference-stable records (`threadIds` / `threadShellById`) and returns
+ * the previous result by reference when no surfaced timestamp actually advanced,
+ * so the board only re-derives when a thread's durable activity really moved.
+ */
+const EMPTY_LAST_ACTIVITY_TIMESTAMP: Readonly<Record<string, number | null>> = Object.freeze({});
+
+export function createLastActivityTimestampSelector(): (
+  state: AppState,
+) => Readonly<Record<string, number | null>> {
+  let previousThreadIds: readonly ThreadId[] | undefined;
+  let previousThreadShellById: AppState["threadShellById"] | undefined;
+  let previousResult: Readonly<Record<string, number | null>> = EMPTY_LAST_ACTIVITY_TIMESTAMP;
+  let previousShellUpdatedAtByThreadId: Record<string, string | undefined> = {};
+
+  return (state) => {
+    if (
+      state.threadIds === previousThreadIds &&
+      state.threadShellById === previousThreadShellById
+    ) {
+      return previousResult;
+    }
+    previousThreadIds = state.threadIds;
+    previousThreadShellById = state.threadShellById;
+
+    if (!previousThreadIds || previousThreadIds.length === 0) {
+      previousResult = EMPTY_LAST_ACTIVITY_TIMESTAMP;
+      previousShellUpdatedAtByThreadId = {};
+      return previousResult;
+    }
+
+    // Fast path: when no thread's durable stamp moved since the last surface,
+    // keep the existing result object so board consumers do not re-derive for
+    // unrelated shell churn (e.g. meta-only bumps that keep `updatedAt`).
+    let anyChanged = false;
+    for (const threadId of previousThreadIds) {
+      const stamp = previousThreadShellById?.[threadId]?.updatedAt;
+      if (stamp !== previousShellUpdatedAtByThreadId[threadId]) {
+        anyChanged = true;
+        break;
+      }
+    }
+    if (!anyChanged) {
+      return previousResult;
+    }
+    const nextShellUpdatedAtByThreadId: Record<string, string | undefined> = {};
+    for (const threadId of previousThreadIds) {
+      const stamp = previousThreadShellById?.[threadId]?.updatedAt;
+      nextShellUpdatedAtByThreadId[threadId] = stamp;
+    }
+    previousShellUpdatedAtByThreadId = nextShellUpdatedAtByThreadId;
+
+    const nextResult: Record<string, number | null> = {};
+    let hasEntry = false;
+    for (const threadId of previousThreadIds) {
+      const stamp = nextShellUpdatedAtByThreadId[threadId];
+      if (!stamp) {
+        // Absent shell / stamp: do not conflate with an explicit null — a
+        // pruned shell must read as "no durable stamp" (C1) so the heartbeat
+        // never falls back to the frozen sidebar summary.
+        continue;
+      }
+      const parsed = Date.parse(stamp);
+      nextResult[threadId] = Number.isFinite(parsed) ? parsed : null;
+      hasEntry = true;
+    }
+    previousResult = hasEntry ? nextResult : EMPTY_LAST_ACTIVITY_TIMESTAMP;
+    return previousResult;
+  };
+}
+
 export function createComposerThreadMentionSourcesSelector(): (
   state: AppState,
 ) => readonly ComposerThreadMentionSource[] {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,6 +16,10 @@
       "types": "./src/git.ts",
       "import": "./src/git.ts"
     },
+    "./kanban": {
+      "types": "./src/kanban.ts",
+      "import": "./src/kanban.ts"
+    },
     "./githubAvatar": {
       "types": "./src/githubAvatar.ts",
       "import": "./src/githubAvatar.ts"

--- a/packages/shared/src/kanban.test.ts
+++ b/packages/shared/src/kanban.test.ts
@@ -1,0 +1,519 @@
+import { describe, expect, it } from "vitest";
+import {
+  KANBAN_ATTENTION_LABELS,
+  KANBAN_COLUMN_V2_LABELS,
+  KANBAN_STUCK_HARD_MS,
+  KANBAN_STUCK_WARN_MS,
+  deriveKanbanAttention,
+  deriveKanbanAwaitingYouReason,
+  deriveKanbanColumnV2,
+  hasKanbanLiveWork,
+  isKanbanTurnSettled,
+  type KanbanAttentionFlag,
+  type KanbanColumnV2Key,
+  type KanbanThreadDerivationInput,
+} from "./kanban";
+
+const COLUMN_V2_KEYS = [
+  "draft",
+  "inProgress",
+  "awaitingYou",
+  "done",
+] as const satisfies readonly KanbanColumnV2Key[];
+
+const ATTENTION_FLAGS = [
+  "failed",
+  "stuck",
+  "awaiting-approval",
+  "awaiting-input",
+  "needs-review",
+] as const satisfies readonly KanbanAttentionFlag[];
+
+// Frozen clock: anything far in the future is a "fresh heartbeat" anchor.
+const NOW = Date.parse("2026-03-09T12:00:00.000Z");
+
+function makeInput(
+  overrides: Partial<KanbanThreadDerivationInput> = {},
+): KanbanThreadDerivationInput {
+  return {
+    latestTurn: null,
+    // A thread that never ran has no session yet (mirrors the web fixture), so
+    // callers that want a session pass one explicitly.
+    session: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasLiveTailWork: false,
+    ...overrides,
+  };
+}
+
+function makeTurn(
+  overrides: Partial<NonNullable<KanbanThreadDerivationInput["latestTurn"]>> = {},
+): NonNullable<KanbanThreadDerivationInput["latestTurn"]> {
+  return {
+    state: "completed",
+    startedAt: "2026-03-09T10:00:00.000Z",
+    completedAt: "2026-03-09T10:05:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeSession(
+  overrides: Partial<NonNullable<KanbanThreadDerivationInput["session"]>> = {},
+): NonNullable<KanbanThreadDerivationInput["session"]> {
+  return {
+    status: "idle",
+    updatedAt: new Date(NOW).toISOString(),
+    ...overrides,
+  };
+}
+
+describe("kanban v2 vocabulary", () => {
+  it("labels every v2 column key and nothing else", () => {
+    expect(Object.keys(KANBAN_COLUMN_V2_LABELS).toSorted()).toEqual([...COLUMN_V2_KEYS].toSorted());
+    for (const key of COLUMN_V2_KEYS) {
+      expect(KANBAN_COLUMN_V2_LABELS[key]).toBeTypeOf("string");
+      expect(KANBAN_COLUMN_V2_LABELS[key].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("labels every attention flag and nothing else", () => {
+    expect(Object.keys(KANBAN_ATTENTION_LABELS).toSorted()).toEqual(
+      [...ATTENTION_FLAGS].toSorted(),
+    );
+    for (const flag of ATTENTION_FLAGS) {
+      expect(KANBAN_ATTENTION_LABELS[flag]).toBeTypeOf("string");
+      expect(KANBAN_ATTENTION_LABELS[flag].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps the awaiting-you column label distinct from the other columns", () => {
+    expect(KANBAN_COLUMN_V2_LABELS.awaitingYou).toBe("Awaiting you");
+    expect(KANBAN_COLUMN_V2_LABELS.awaitingYou).not.toBe(KANBAN_COLUMN_V2_LABELS.inProgress);
+  });
+});
+
+describe("isKanbanTurnSettled", () => {
+  it("treats a requested-but-not-started turn as live", () => {
+    expect(
+      isKanbanTurnSettled(
+        makeInput({ latestTurn: makeTurn({ startedAt: null, completedAt: null }) }),
+      ),
+    ).toBe(false);
+  });
+
+  it("treats a completed-and-stamped turn as settled under a non-running session", () => {
+    expect(isKanbanTurnSettled(makeInput({ latestTurn: makeTurn() }))).toBe(true);
+  });
+
+  it("keeps a completed turn live while the session still runs", () => {
+    expect(
+      isKanbanTurnSettled(
+        makeInput({
+          latestTurn: makeTurn(),
+          session: makeSession({
+            status: "running",
+            updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
+          }),
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("treats interrupted/error turns as settled even without a completedAt stamp", () => {
+    expect(isKanbanTurnSettled(makeInput({ latestTurn: makeTurn({ state: "interrupted" }) }))).toBe(
+      true,
+    );
+    expect(isKanbanTurnSettled(makeInput({ latestTurn: makeTurn({ state: "error" }) }))).toBe(true);
+  });
+});
+
+describe("hasKanbanLiveWork", () => {
+  it("counts actionable pending requests and live tail work as live", () => {
+    expect(hasKanbanLiveWork(makeInput({ hasPendingApprovals: true }))).toBe(true);
+    expect(hasKanbanLiveWork(makeInput({ hasPendingUserInput: true }))).toBe(true);
+    expect(hasKanbanLiveWork(makeInput({ hasLiveTailWork: true }))).toBe(true);
+  });
+
+  it("ignores pending requests once the session is dead", () => {
+    expect(
+      hasKanbanLiveWork(
+        makeInput({ hasPendingUserInput: true, session: makeSession({ status: "stopped" }) }),
+      ),
+    ).toBe(false);
+    expect(
+      hasKanbanLiveWork(
+        makeInput({ hasPendingApprovals: true, session: makeSession({ status: "error" }) }),
+      ),
+    ).toBe(false);
+  });
+
+  it("treats a live latest turn as live work", () => {
+    expect(
+      hasKanbanLiveWork({
+        latestTurn: makeTurn({ state: "running", completedAt: null }),
+        session: makeSession({
+          status: "running",
+          updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("treats connecting/starting sessions as live work", () => {
+    expect(hasKanbanLiveWork(makeInput({ session: makeSession({ status: "starting" }) }))).toBe(
+      true,
+    );
+  });
+
+  it("treats a running session without a settled turn as live work", () => {
+    expect(
+      hasKanbanLiveWork(
+        makeInput({
+          latestTurn: makeTurn({ completedAt: null }),
+          session: makeSession({
+            status: "running",
+            updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
+          }),
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat an idle/no-turn thread as live", () => {
+    expect(hasKanbanLiveWork(makeInput())).toBe(false);
+  });
+});
+
+describe("deriveKanbanColumnV2 (no `now`: base matrix)", () => {
+  it("puts live turn work in progress", () => {
+    expect(
+      deriveKanbanColumnV2(
+        makeInput({
+          latestTurn: makeTurn({ state: "running", completedAt: null }),
+          session: makeSession({
+            status: "running",
+            updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
+          }),
+        }),
+      ),
+    ).toBe("inProgress");
+  });
+
+  it("puts a session running with no turn in progress", () => {
+    expect(deriveKanbanColumnV2(makeInput({ session: makeSession({ status: "running" }) }))).toBe(
+      "inProgress",
+    );
+  });
+
+  it("puts live-tail work in progress", () => {
+    expect(deriveKanbanColumnV2(makeInput({ hasLiveTailWork: true }))).toBe("inProgress");
+  });
+
+  it("treats a never-ran thread as draft", () => {
+    expect(deriveKanbanColumnV2(makeInput({ session: makeSession({ status: "ready" }) }))).toBe(
+      "draft",
+    );
+  });
+
+  it("puts settled threads in done", () => {
+    expect(deriveKanbanColumnV2(makeInput({ latestTurn: makeTurn() }))).toBe("done");
+  });
+
+  it("puts settled interrupted/error threads in done", () => {
+    expect(
+      deriveKanbanColumnV2(makeInput({ latestTurn: makeTurn({ state: "interrupted" }) })),
+    ).toBe("done");
+    expect(deriveKanbanColumnV2(makeInput({ latestTurn: makeTurn({ state: "error" }) }))).toBe(
+      "done",
+    );
+  });
+
+  it("falls dead-session pending requests through to their underlying state", () => {
+    // pending approval on a dead session with a settled turn → done; with no turn → draft
+    expect(
+      deriveKanbanColumnV2(
+        makeInput({
+          hasPendingApprovals: true,
+          latestTurn: makeTurn(),
+          session: makeSession({ status: "stopped" }),
+        }),
+      ),
+    ).toBe("done");
+    expect(
+      deriveKanbanColumnV2(
+        makeInput({
+          hasPendingUserInput: true,
+          session: makeSession({ status: "error" }),
+        }),
+      ),
+    ).toBe("draft");
+    // A live (or unknown) session keeps the request actionable.
+    expect(
+      deriveKanbanColumnV2(
+        makeInput({ hasPendingUserInput: true, session: makeSession({ status: "running" }) }),
+      ),
+    ).toBe("inProgress");
+    expect(deriveKanbanColumnV2(makeInput({ hasPendingUserInput: true, session: null }))).toBe(
+      "inProgress",
+    );
+  });
+
+  it("treats actionable pending requests as in progress regardless of turn state", () => {
+    expect(deriveKanbanColumnV2(makeInput({ hasPendingApprovals: true }))).toBe("inProgress");
+  });
+});
+
+describe("deriveKanbanAwaitingYouReason + deriveKanbanColumnV2 with frozen clock", () => {
+  const freshNow = { now: NOW };
+
+  it("flags actionable pending approvals as pending-approval (awaitingYou)", () => {
+    const input = makeInput({ hasPendingApprovals: true });
+    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBe("pending-approval");
+    expect(deriveKanbanColumnV2(input, freshNow)).toBe("awaitingYou");
+  });
+
+  it("flags actionable pending user input as pending-input (awaitingYou)", () => {
+    const input = makeInput({
+      hasPendingUserInput: true,
+      session: makeSession({
+        status: "running",
+        updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
+      }),
+    });
+    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBe("pending-input");
+    expect(deriveKanbanColumnV2(input, freshNow)).toBe("awaitingYou");
+  });
+
+  it("hoists a running turn blocked on the human to awaitingYou (D12)", () => {
+    const input = makeInput({
+      hasPendingApprovals: true,
+      latestTurn: makeTurn({ state: "running", completedAt: null }),
+      session: makeSession({
+        status: "running",
+        updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
+      }),
+    });
+    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBe("pending-approval");
+    expect(deriveKanbanColumnV2(input, freshNow)).toBe("awaitingYou");
+  });
+
+  it("flags a failed agent as failed (awaitingYou)", () => {
+    const errorTurn = makeInput({
+      latestTurn: makeTurn({ state: "error", completedAt: "2026-03-09T10:05:00.000Z" }),
+      session: makeSession({ status: "error", lastError: "boom" }),
+    });
+    expect(deriveKanbanAwaitingYouReason(errorTurn, freshNow)).toBe("failed");
+    expect(deriveKanbanColumnV2(errorTurn, freshNow)).toBe("awaitingYou");
+
+    const lastErrorOnly = makeInput({
+      latestTurn: makeTurn(),
+      session: makeSession({ status: "ready", lastError: "boom" }),
+    });
+    expect(deriveKanbanAwaitingYouReason(lastErrorOnly, freshNow)).toBe("failed");
+  });
+
+  it("flags a live thread with a stale heartbeat past the hard threshold as stuck (awaitingYou)", () => {
+    const stale = new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString();
+    const input = makeInput({
+      latestTurn: makeTurn({ state: "running", completedAt: null }),
+      session: makeSession({ status: "running", updatedAt: stale }),
+    });
+    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBe("stuck");
+    expect(deriveKanbanColumnV2(input, freshNow)).toBe("awaitingYou");
+  });
+
+  it("keeps a fresh heartbeat in progress (not stuck, not awaiting)", () => {
+    const input = makeInput({
+      latestTurn: makeTurn({ state: "running", completedAt: null }),
+      session: makeSession({ status: "running", updatedAt: new Date(NOW).toISOString() }),
+    });
+    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBeNull();
+    expect(deriveKanbanColumnV2(input, freshNow)).toBe("inProgress");
+  });
+
+  it("falls pending + dead-session requests through (no awaitingYou)", () => {
+    const deadPending = makeInput({
+      hasPendingUserInput: true,
+      latestTurn: makeTurn(),
+      session: makeSession({ status: "stopped" }),
+    });
+    expect(deriveKanbanAwaitingYouReason(deadPending, freshNow)).toBeNull();
+    expect(deriveKanbanColumnV2(deadPending, freshNow)).toBe("done");
+  });
+
+  it("does not flag a settled thread as stuck even with a stale heartbeat", () => {
+    const stale = new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString();
+    const input = makeInput({
+      latestTurn: makeTurn({ state: "completed" }),
+      session: makeSession({ status: "ready", updatedAt: stale }),
+    });
+    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBeNull();
+    expect(deriveKanbanColumnV2(input, freshNow)).toBe("done");
+  });
+
+  it("flags a warn-stale live thread as still in progress (hard not reached)", () => {
+    const warnStale = new Date(NOW - KANBAN_STUCK_WARN_MS - 60_000).toISOString();
+    const input = makeInput({
+      latestTurn: makeTurn({ state: "running", completedAt: null }),
+      session: makeSession({ status: "running", updatedAt: warnStale }),
+    });
+    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBeNull();
+    expect(deriveKanbanColumnV2(input, freshNow)).toBe("inProgress");
+    // the warn-stale heartbeat still earns a "stuck"-colored pill
+    expect(deriveKanbanAttention(input, freshNow)).toContain("stuck");
+  });
+
+  it("keeps a busy-but-quiet turn fresh via the thread heartbeat (C1)", () => {
+    // The session row only moves on lifecycle transitions, but the thread stamp
+    // advances per appended message — the later of the two is the heartbeat.
+    const staleSession = new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString();
+    const busyThread = new Date(NOW - 60_000).toISOString();
+    const input = makeInput({
+      latestTurn: makeTurn({ state: "running", completedAt: null }),
+      session: makeSession({ status: "running", updatedAt: staleSession }),
+      threadUpdatedAt: busyThread,
+    });
+    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBeNull();
+    expect(deriveKanbanColumnV2(input, freshNow)).toBe("inProgress");
+    expect(deriveKanbanAttention(input, freshNow)).toEqual([]);
+  });
+
+  it("falls the busy-quiet turn back to stuck when the thread heartbeat also ages out (C1)", () => {
+    const stale = new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString();
+    const input = makeInput({
+      latestTurn: makeTurn({ state: "running", completedAt: null }),
+      session: makeSession({ status: "running", updatedAt: stale }),
+      threadUpdatedAt: stale,
+    });
+    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBe("stuck");
+  });
+
+  it("never produces a negative heartbeat age at or before the heartbeat (C1)", () => {
+    // A heartbeat stamped after the injected `now` (clock skew) must floor at 0,
+    // not report a negative stale age.
+    const futureHeartbeat = new Date(NOW + 60_000).toISOString();
+    const input = makeInput({
+      latestTurn: makeTurn({ state: "running", completedAt: null }),
+      session: makeSession({ status: "running", updatedAt: futureHeartbeat }),
+    });
+    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBeNull();
+    expect(deriveKanbanColumnV2(input, freshNow)).toBe("inProgress");
+    expect(deriveKanbanAttention(input, freshNow)).toEqual([]);
+  });
+
+  it("keeps a busy-but-quiet streaming turn fresh via the durable last-activity stamp (F1)", () => {
+    // `SidebarThreadSummary.updatedAt` freezes on the streaming hot path, and the
+    // session row only moves on lifecycle transitions — but the durable per-thread
+    // last-activity stamp advances per appended message. A fresh stamp must keep
+    // the turn In Progress with no stuck pill despite the frozen summary.
+    const staleSession = new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString();
+    const freshActivity = NOW - 30_000;
+    const input = makeInput({
+      latestTurn: makeTurn({ state: "running", completedAt: null }),
+      session: makeSession({ status: "running", updatedAt: staleSession }),
+      threadUpdatedAt: null,
+      lastActivityTimestampMs: freshActivity,
+    });
+    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBeNull();
+    expect(deriveKanbanColumnV2(input, freshNow)).toBe("inProgress");
+    expect(deriveKanbanAttention(input, freshNow)).toEqual([]);
+  });
+
+  it("trips the warn boundary when the durable last-activity stamp ages past 20 min (F1)", () => {
+    const input = makeInput({
+      latestTurn: makeTurn({ state: "running", completedAt: null }),
+      session: makeSession({
+        status: "running",
+        updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
+      }),
+      lastActivityTimestampMs: NOW - KANBAN_STUCK_WARN_MS - 60_000,
+    });
+    expect(deriveKanbanAttention(input, freshNow)).toContain("stuck");
+  });
+
+  it("trips the hard boundary and hoists to awaitingYou past 40 min (F1)", () => {
+    const input = makeInput({
+      latestTurn: makeTurn({ state: "running", completedAt: null }),
+      session: makeSession({
+        status: "running",
+        updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
+      }),
+      lastActivityTimestampMs: NOW - KANBAN_STUCK_HARD_MS - 60_000,
+    });
+    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBe("stuck");
+    expect(deriveKanbanColumnV2(input, freshNow)).toBe("awaitingYou");
+  });
+
+  it("flags the warn boundary exactly at 20:00.000 (C4)", () => {
+    const input = makeInput({
+      latestTurn: makeTurn({ state: "running", completedAt: null }),
+      session: makeSession({
+        status: "running",
+        updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
+      }),
+      lastActivityTimestampMs: NOW - KANBAN_STUCK_WARN_MS,
+    });
+    expect(deriveKanbanAttention(input, freshNow)).toContain("stuck");
+    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBeNull();
+  });
+
+  it("flags the hard boundary exactly at 40:00.000 (C4)", () => {
+    const input = makeInput({
+      latestTurn: makeTurn({ state: "running", completedAt: null }),
+      session: makeSession({
+        status: "running",
+        updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
+      }),
+      lastActivityTimestampMs: NOW - KANBAN_STUCK_HARD_MS,
+    });
+    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBe("stuck");
+    expect(deriveKanbanColumnV2(input, freshNow)).toBe("awaitingYou");
+  });
+});
+
+describe("deriveKanbanAttention", () => {
+  it("produces no flags for a plain settled thread", () => {
+    expect(deriveKanbanAttention(makeInput({ latestTurn: makeTurn() }), { now: NOW })).toEqual([]);
+  });
+
+  it("maps awaiting-you reasons to their pill flags", () => {
+    expect(deriveKanbanAttention(makeInput({ hasPendingApprovals: true }), { now: NOW })).toEqual([
+      "awaiting-approval",
+    ]);
+    expect(deriveKanbanAttention(makeInput({ hasPendingUserInput: true }), { now: NOW })).toEqual([
+      "awaiting-input",
+    ]);
+    expect(
+      deriveKanbanAttention(
+        makeInput({
+          latestTurn: makeTurn({ state: "error" }),
+          session: makeSession({ status: "error" }),
+        }),
+        { now: NOW },
+      ),
+    ).toEqual(["failed"]);
+    const stale = new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString();
+    expect(
+      deriveKanbanAttention(
+        makeInput({
+          latestTurn: makeTurn({ state: "running", completedAt: null }),
+          session: makeSession({ status: "running", updatedAt: stale }),
+        }),
+        { now: NOW },
+      ),
+    ).toEqual(["stuck"]);
+  });
+
+  it("adds needs-review from the caller's PR view", () => {
+    expect(
+      deriveKanbanAttention(makeInput({ latestTurn: makeTurn() }), { now: NOW, needsReview: true }),
+    ).toEqual(["needs-review"]);
+    expect(
+      deriveKanbanAttention(makeInput({ hasPendingApprovals: true }), {
+        now: NOW,
+        needsReview: true,
+      }),
+    ).toEqual(["awaiting-approval", "needs-review"]);
+  });
+});

--- a/packages/shared/src/kanban.test.ts
+++ b/packages/shared/src/kanban.test.ts
@@ -31,42 +31,46 @@ const ATTENTION_FLAGS = [
 
 // Frozen clock: anything far in the future is a "fresh heartbeat" anchor.
 const NOW = Date.parse("2026-03-09T12:00:00.000Z");
+const FRESH_NOW = { now: NOW };
+// Canonical stale anchors: one tick past the warn/hard thresholds.
+const HARD_STALE_MS = NOW - KANBAN_STUCK_HARD_MS - 60_000;
+const WARN_STALE_MS = NOW - KANBAN_STUCK_WARN_MS - 60_000;
+const STALE_ISO = new Date(HARD_STALE_MS).toISOString();
 
-function makeInput(
+type Turn = NonNullable<KanbanThreadDerivationInput["latestTurn"]>;
+type Session = NonNullable<KanbanThreadDerivationInput["session"]>;
+
+const makeInput = (
   overrides: Partial<KanbanThreadDerivationInput> = {},
-): KanbanThreadDerivationInput {
-  return {
-    latestTurn: null,
-    // A thread that never ran has no session yet (mirrors the web fixture), so
-    // callers that want a session pass one explicitly.
-    session: null,
-    hasPendingApprovals: false,
-    hasPendingUserInput: false,
-    hasLiveTailWork: false,
-    ...overrides,
-  };
-}
+): KanbanThreadDerivationInput => ({
+  latestTurn: null,
+  // A thread that never ran has no session yet (mirrors the web fixture), so
+  // callers that want a session pass one explicitly.
+  session: null,
+  hasPendingApprovals: false,
+  hasPendingUserInput: false,
+  hasLiveTailWork: false,
+  ...overrides,
+});
 
-function makeTurn(
-  overrides: Partial<NonNullable<KanbanThreadDerivationInput["latestTurn"]>> = {},
-): NonNullable<KanbanThreadDerivationInput["latestTurn"]> {
-  return {
-    state: "completed",
-    startedAt: "2026-03-09T10:00:00.000Z",
-    completedAt: "2026-03-09T10:05:00.000Z",
-    ...overrides,
-  };
-}
+const makeTurn = (overrides: Partial<Turn> = {}): Turn => ({
+  state: "completed",
+  startedAt: "2026-03-09T10:00:00.000Z",
+  completedAt: "2026-03-09T10:05:00.000Z",
+  ...overrides,
+});
 
-function makeSession(
-  overrides: Partial<NonNullable<KanbanThreadDerivationInput["session"]>> = {},
-): NonNullable<KanbanThreadDerivationInput["session"]> {
-  return {
-    status: "idle",
-    updatedAt: new Date(NOW).toISOString(),
-    ...overrides,
-  };
-}
+const makeSession = (overrides: Partial<Session> = {}): Session => ({
+  status: "idle",
+  updatedAt: new Date(NOW).toISOString(),
+  ...overrides,
+});
+
+const LIVE_TURN = { state: "running", completedAt: null } as const;
+// Running session whose heartbeat aged past the hard threshold.
+const RUNNING_SESSION = () => makeSession({ status: "running", updatedAt: STALE_ISO });
+const liveInput = (overrides: Partial<KanbanThreadDerivationInput> = {}) =>
+  makeInput({ latestTurn: makeTurn(LIVE_TURN), session: RUNNING_SESSION(), ...overrides });
 
 describe("kanban v2 vocabulary", () => {
   it("labels every v2 column key and nothing else, with awaiting-you distinct", () => {
@@ -91,37 +95,21 @@ describe("kanban v2 vocabulary", () => {
 });
 
 describe("isKanbanTurnSettled", () => {
-  it("treats a requested-but-not-started turn as live", () => {
+  it("treats stamped, interrupted, and error turns as settled under a non-running session", () => {
+    expect(isKanbanTurnSettled(makeInput({ latestTurn: makeTurn() }))).toBe(true);
+    expect(isKanbanTurnSettled(makeInput({ latestTurn: makeTurn({ state: "interrupted" }) }))).toBe(
+      true,
+    );
+    expect(isKanbanTurnSettled(makeInput({ latestTurn: makeTurn({ state: "error" }) }))).toBe(true);
+  });
+
+  it("keeps requested-but-unstarted turns and running-session turns live", () => {
     expect(
       isKanbanTurnSettled(
         makeInput({ latestTurn: makeTurn({ startedAt: null, completedAt: null }) }),
       ),
     ).toBe(false);
-  });
-
-  it("treats a completed-and-stamped turn as settled under a non-running session", () => {
-    expect(isKanbanTurnSettled(makeInput({ latestTurn: makeTurn() }))).toBe(true);
-  });
-
-  it("keeps a completed turn live while the session still runs", () => {
-    expect(
-      isKanbanTurnSettled(
-        makeInput({
-          latestTurn: makeTurn(),
-          session: makeSession({
-            status: "running",
-            updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
-          }),
-        }),
-      ),
-    ).toBe(false);
-  });
-
-  it("treats interrupted/error turns as settled even without a completedAt stamp", () => {
-    expect(isKanbanTurnSettled(makeInput({ latestTurn: makeTurn({ state: "interrupted" }) }))).toBe(
-      true,
-    );
-    expect(isKanbanTurnSettled(makeInput({ latestTurn: makeTurn({ state: "error" }) }))).toBe(true);
+    expect(isKanbanTurnSettled(liveInput())).toBe(false);
   });
 });
 
@@ -145,34 +133,14 @@ describe("hasKanbanLiveWork", () => {
     ).toBe(false);
   });
 
-  it("treats a live latest turn as live work", () => {
-    expect(
-      hasKanbanLiveWork({
-        latestTurn: makeTurn({ state: "running", completedAt: null }),
-        session: makeSession({
-          status: "running",
-          updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
-        }),
-      }),
-    ).toBe(true);
-  });
-
-  it("treats connecting/starting sessions as live work", () => {
+  it("treats running/connecting sessions and unsettled turns as live work", () => {
+    expect(hasKanbanLiveWork(liveInput())).toBe(true);
     expect(hasKanbanLiveWork(makeInput({ session: makeSession({ status: "starting" }) }))).toBe(
       true,
     );
-  });
-
-  it("treats a running session without a settled turn as live work", () => {
     expect(
       hasKanbanLiveWork(
-        makeInput({
-          latestTurn: makeTurn({ completedAt: null }),
-          session: makeSession({
-            status: "running",
-            updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
-          }),
-        }),
+        makeInput({ latestTurn: makeTurn({ completedAt: null }), session: RUNNING_SESSION() }),
       ),
     ).toBe(true);
   });
@@ -182,42 +150,20 @@ describe("hasKanbanLiveWork", () => {
   });
 });
 
-describe("deriveKanbanColumnV2 (no `now`: base matrix)", () => {
-  it("puts live turn work in progress", () => {
-    expect(
-      deriveKanbanColumnV2(
-        makeInput({
-          latestTurn: makeTurn({ state: "running", completedAt: null }),
-          session: makeSession({
-            status: "running",
-            updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
-          }),
-        }),
-      ),
-    ).toBe("inProgress");
-  });
-
-  it("puts a session running with no turn in progress", () => {
+describe("deriveKanbanColumnV2 (base matrix)", () => {
+  it("puts live turn work, bare running sessions, and live tail work in progress", () => {
+    expect(deriveKanbanColumnV2(liveInput())).toBe("inProgress");
     expect(deriveKanbanColumnV2(makeInput({ session: makeSession({ status: "running" }) }))).toBe(
       "inProgress",
     );
-  });
-
-  it("puts live-tail work in progress", () => {
     expect(deriveKanbanColumnV2(makeInput({ hasLiveTailWork: true }))).toBe("inProgress");
   });
 
-  it("treats a never-ran thread as draft", () => {
+  it("puts never-ran threads in draft and settled threads in done regardless of outcome", () => {
     expect(deriveKanbanColumnV2(makeInput({ session: makeSession({ status: "ready" }) }))).toBe(
       "draft",
     );
-  });
-
-  it("puts settled threads in done", () => {
     expect(deriveKanbanColumnV2(makeInput({ latestTurn: makeTurn() }))).toBe("done");
-  });
-
-  it("puts settled interrupted/error threads in done", () => {
     expect(
       deriveKanbanColumnV2(makeInput({ latestTurn: makeTurn({ state: "interrupted" }) })),
     ).toBe("done");
@@ -227,7 +173,7 @@ describe("deriveKanbanColumnV2 (no `now`: base matrix)", () => {
   });
 
   it("falls dead-session pending requests through to their underlying state", () => {
-    // pending approval on a dead session with a settled turn → done; with no turn → draft
+    // Pending approval on a dead session with a settled turn → done; no turn → draft.
     expect(
       deriveKanbanColumnV2(
         makeInput({
@@ -239,10 +185,7 @@ describe("deriveKanbanColumnV2 (no `now`: base matrix)", () => {
     ).toBe("done");
     expect(
       deriveKanbanColumnV2(
-        makeInput({
-          hasPendingUserInput: true,
-          session: makeSession({ status: "error" }),
-        }),
+        makeInput({ hasPendingUserInput: true, session: makeSession({ status: "error" }) }),
       ),
     ).toBe("draft");
     // A live (or unknown) session keeps the request actionable.
@@ -251,9 +194,7 @@ describe("deriveKanbanColumnV2 (no `now`: base matrix)", () => {
         makeInput({ hasPendingUserInput: true, session: makeSession({ status: "running" }) }),
       ),
     ).toBe("inProgress");
-    expect(deriveKanbanColumnV2(makeInput({ hasPendingUserInput: true, session: null }))).toBe(
-      "inProgress",
-    );
+    expect(deriveKanbanColumnV2(makeInput({ hasPendingUserInput: true }))).toBe("inProgress");
   });
 
   it("treats actionable pending requests as in progress regardless of turn state", () => {
@@ -262,223 +203,133 @@ describe("deriveKanbanColumnV2 (no `now`: base matrix)", () => {
 });
 
 describe("deriveKanbanAwaitingYouReason + deriveKanbanColumnV2 with frozen clock", () => {
-  const freshNow = { now: NOW };
+  it("hoists actionable pending requests to awaitingYou, including blocked running turns (D12)", () => {
+    const pendingApproval = makeInput({ hasPendingApprovals: true });
+    expect(deriveKanbanAwaitingYouReason(pendingApproval, FRESH_NOW)).toBe("pending-approval");
+    expect(deriveKanbanColumnV2(pendingApproval, FRESH_NOW)).toBe("awaitingYou");
 
-  it("flags actionable pending approvals as pending-approval (awaitingYou)", () => {
-    const input = makeInput({ hasPendingApprovals: true });
-    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBe("pending-approval");
-    expect(deriveKanbanColumnV2(input, freshNow)).toBe("awaitingYou");
+    const pendingInput = makeInput({ hasPendingUserInput: true, session: RUNNING_SESSION() });
+    expect(deriveKanbanAwaitingYouReason(pendingInput, FRESH_NOW)).toBe("pending-input");
+    expect(deriveKanbanColumnV2(pendingInput, FRESH_NOW)).toBe("awaitingYou");
+
+    const blockedTurn = liveInput({ hasPendingApprovals: true });
+    expect(deriveKanbanAwaitingYouReason(blockedTurn, FRESH_NOW)).toBe("pending-approval");
+    expect(deriveKanbanColumnV2(blockedTurn, FRESH_NOW)).toBe("awaitingYou");
   });
 
-  it("flags actionable pending user input as pending-input (awaitingYou)", () => {
-    const input = makeInput({
-      hasPendingUserInput: true,
-      session: makeSession({
-        status: "running",
-        updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
-      }),
-    });
-    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBe("pending-input");
-    expect(deriveKanbanColumnV2(input, freshNow)).toBe("awaitingYou");
-  });
-
-  it("hoists a running turn blocked on the human to awaitingYou (D12)", () => {
-    const input = makeInput({
-      hasPendingApprovals: true,
-      latestTurn: makeTurn({ state: "running", completedAt: null }),
-      session: makeSession({
-        status: "running",
-        updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
-      }),
-    });
-    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBe("pending-approval");
-    expect(deriveKanbanColumnV2(input, freshNow)).toBe("awaitingYou");
-  });
-
-  it("flags a failed agent as failed (awaitingYou)", () => {
+  it("flags errored sessions and error turns as failed", () => {
     const errorTurn = makeInput({
-      latestTurn: makeTurn({ state: "error", completedAt: "2026-03-09T10:05:00.000Z" }),
+      latestTurn: makeTurn({ state: "error" }),
       session: makeSession({ status: "error", lastError: "boom" }),
     });
-    expect(deriveKanbanAwaitingYouReason(errorTurn, freshNow)).toBe("failed");
-    expect(deriveKanbanColumnV2(errorTurn, freshNow)).toBe("awaitingYou");
-
-    const lastErrorOnly = makeInput({
-      latestTurn: makeTurn(),
-      session: makeSession({ status: "ready", lastError: "boom" }),
-    });
-    expect(deriveKanbanAwaitingYouReason(lastErrorOnly, freshNow)).toBe("failed");
+    expect(deriveKanbanAwaitingYouReason(errorTurn, FRESH_NOW)).toBe("failed");
+    expect(deriveKanbanColumnV2(errorTurn, FRESH_NOW)).toBe("awaitingYou");
+    expect(
+      deriveKanbanAwaitingYouReason(
+        makeInput({
+          latestTurn: makeTurn(),
+          session: makeSession({ status: "ready", lastError: "boom" }),
+        }),
+        FRESH_NOW,
+      ),
+    ).toBe("failed");
   });
 
-  it("flags a live thread with a stale heartbeat past the hard threshold as stuck (awaitingYou)", () => {
-    const stale = new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString();
-    const input = makeInput({
-      latestTurn: makeTurn({ state: "running", completedAt: null }),
-      session: makeSession({ status: "running", updatedAt: stale }),
+  it("trips stuck past the hard threshold; warn-stale and fresh heartbeats stay in progress", () => {
+    expect(deriveKanbanAwaitingYouReason(liveInput(), FRESH_NOW)).toBe("stuck");
+    expect(deriveKanbanColumnV2(liveInput(), FRESH_NOW)).toBe("awaitingYou");
+
+    // Warn-stale still earns a "stuck"-colored pill without leaving In Progress.
+    const warnStale = liveInput({
+      session: makeSession({ status: "running", updatedAt: new Date(WARN_STALE_MS).toISOString() }),
     });
-    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBe("stuck");
-    expect(deriveKanbanColumnV2(input, freshNow)).toBe("awaitingYou");
+    expect(deriveKanbanAwaitingYouReason(warnStale, FRESH_NOW)).toBeNull();
+    expect(deriveKanbanColumnV2(warnStale, FRESH_NOW)).toBe("inProgress");
+    expect(deriveKanbanAttention(warnStale, FRESH_NOW)).toContain("stuck");
+
+    const fresh = liveInput({ session: makeSession({ status: "running" }) });
+    expect(deriveKanbanAwaitingYouReason(fresh, FRESH_NOW)).toBeNull();
+    expect(deriveKanbanColumnV2(fresh, FRESH_NOW)).toBe("inProgress");
   });
 
-  it("keeps a fresh heartbeat in progress (not stuck, not awaiting)", () => {
-    const input = makeInput({
-      latestTurn: makeTurn({ state: "running", completedAt: null }),
-      session: makeSession({ status: "running", updatedAt: new Date(NOW).toISOString() }),
-    });
-    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBeNull();
-    expect(deriveKanbanColumnV2(input, freshNow)).toBe("inProgress");
-  });
-
-  it("falls pending + dead-session requests through (no awaitingYou)", () => {
-    const deadPending = makeInput({
-      hasPendingUserInput: true,
-      latestTurn: makeTurn(),
-      session: makeSession({ status: "stopped" }),
-    });
-    expect(deriveKanbanAwaitingYouReason(deadPending, freshNow)).toBeNull();
-    expect(deriveKanbanColumnV2(deadPending, freshNow)).toBe("done");
-  });
-
-  it("does not flag a settled thread as stuck even with a stale heartbeat", () => {
-    const stale = new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString();
-    const input = makeInput({
-      latestTurn: makeTurn({ state: "completed" }),
-      session: makeSession({ status: "ready", updatedAt: stale }),
-    });
-    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBeNull();
-    expect(deriveKanbanColumnV2(input, freshNow)).toBe("done");
-  });
-
-  it("flags a warn-stale live thread as still in progress (hard not reached)", () => {
-    const warnStale = new Date(NOW - KANBAN_STUCK_WARN_MS - 60_000).toISOString();
-    const input = makeInput({
-      latestTurn: makeTurn({ state: "running", completedAt: null }),
-      session: makeSession({ status: "running", updatedAt: warnStale }),
-    });
-    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBeNull();
-    expect(deriveKanbanColumnV2(input, freshNow)).toBe("inProgress");
-    // the warn-stale heartbeat still earns a "stuck"-colored pill
-    expect(deriveKanbanAttention(input, freshNow)).toContain("stuck");
-  });
-
-  it("keeps a busy-but-quiet turn fresh via the thread heartbeat (C1)", () => {
+  it("keeps a busy-but-quiet turn fresh via the thread heartbeat, then stuck once it ages out (C1)", () => {
     // The session row only moves on lifecycle transitions, but the thread stamp
     // advances per appended message — the later of the two is the heartbeat.
-    const staleSession = new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString();
-    const busyThread = new Date(NOW - 60_000).toISOString();
-    const input = makeInput({
-      latestTurn: makeTurn({ state: "running", completedAt: null }),
-      session: makeSession({ status: "running", updatedAt: staleSession }),
-      threadUpdatedAt: busyThread,
-    });
-    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBeNull();
-    expect(deriveKanbanColumnV2(input, freshNow)).toBe("inProgress");
-    expect(deriveKanbanAttention(input, freshNow)).toEqual([]);
-  });
-
-  it("falls the busy-quiet turn back to stuck when the thread heartbeat also ages out (C1)", () => {
-    const stale = new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString();
-    const input = makeInput({
-      latestTurn: makeTurn({ state: "running", completedAt: null }),
-      session: makeSession({ status: "running", updatedAt: stale }),
-      threadUpdatedAt: stale,
-    });
-    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBe("stuck");
+    const busyThread = liveInput({ threadUpdatedAt: new Date(NOW - 60_000).toISOString() });
+    expect(deriveKanbanAwaitingYouReason(busyThread, FRESH_NOW)).toBeNull();
+    expect(deriveKanbanColumnV2(busyThread, FRESH_NOW)).toBe("inProgress");
+    expect(deriveKanbanAttention(busyThread, FRESH_NOW)).toEqual([]);
+    expect(
+      deriveKanbanAwaitingYouReason(liveInput({ threadUpdatedAt: STALE_ISO }), FRESH_NOW),
+    ).toBe("stuck");
   });
 
   it("never produces a negative heartbeat age at or before the heartbeat (C1)", () => {
     // A heartbeat stamped after the injected `now` (clock skew) must floor at 0,
     // not report a negative stale age.
-    const futureHeartbeat = new Date(NOW + 60_000).toISOString();
-    const input = makeInput({
-      latestTurn: makeTurn({ state: "running", completedAt: null }),
-      session: makeSession({ status: "running", updatedAt: futureHeartbeat }),
+    const skewed = liveInput({
+      session: makeSession({ status: "running", updatedAt: new Date(NOW + 60_000).toISOString() }),
     });
-    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBeNull();
-    expect(deriveKanbanColumnV2(input, freshNow)).toBe("inProgress");
-    expect(deriveKanbanAttention(input, freshNow)).toEqual([]);
+    expect(deriveKanbanAwaitingYouReason(skewed, FRESH_NOW)).toBeNull();
+    expect(deriveKanbanColumnV2(skewed, FRESH_NOW)).toBe("inProgress");
+    expect(deriveKanbanAttention(skewed, FRESH_NOW)).toEqual([]);
   });
 
-  it("keeps a busy-but-quiet streaming turn fresh via the durable last-activity stamp (F1)", () => {
-    // `SidebarThreadSummary.updatedAt` freezes on the streaming hot path, and the
-    // session row only moves on lifecycle transitions — but the durable per-thread
-    // last-activity stamp advances per appended message. A fresh stamp must keep
-    // the turn In Progress with no stuck pill despite the frozen summary.
-    const staleSession = new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString();
-    const freshActivity = NOW - 30_000;
-    const input = makeInput({
-      latestTurn: makeTurn({ state: "running", completedAt: null }),
-      session: makeSession({ status: "running", updatedAt: staleSession }),
-      threadUpdatedAt: null,
-      lastActivityTimestampMs: freshActivity,
-    });
-    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBeNull();
-    expect(deriveKanbanColumnV2(input, freshNow)).toBe("inProgress");
-    expect(deriveKanbanAttention(input, freshNow)).toEqual([]);
+  it("keeps streaming turns fresh via the durable last-activity stamp until boundaries trip (F1)", () => {
+    // `SidebarThreadSummary.updatedAt` freezes on the streaming hot path and the
+    // session row only moves on lifecycle transitions — but the durable
+    // per-thread last-activity stamp advances per appended message. A fresh
+    // stamp must keep the turn In Progress despite the frozen summary.
+    const fresh = liveInput({ threadUpdatedAt: null, lastActivityTimestampMs: NOW - 30_000 });
+    expect(deriveKanbanAwaitingYouReason(fresh, FRESH_NOW)).toBeNull();
+    expect(deriveKanbanColumnV2(fresh, FRESH_NOW)).toBe("inProgress");
+    expect(deriveKanbanAttention(fresh, FRESH_NOW)).toEqual([]);
+
+    const warned = liveInput({ lastActivityTimestampMs: WARN_STALE_MS });
+    expect(deriveKanbanAttention(warned, FRESH_NOW)).toContain("stuck");
+
+    const hardened = liveInput({ lastActivityTimestampMs: HARD_STALE_MS });
+    expect(deriveKanbanAwaitingYouReason(hardened, FRESH_NOW)).toBe("stuck");
+    expect(deriveKanbanColumnV2(hardened, FRESH_NOW)).toBe("awaitingYou");
   });
 
-  it("trips the warn boundary when the durable last-activity stamp ages past 20 min (F1)", () => {
-    const input = makeInput({
-      latestTurn: makeTurn({ state: "running", completedAt: null }),
-      session: makeSession({
-        status: "running",
-        updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
-      }),
-      lastActivityTimestampMs: NOW - KANBAN_STUCK_WARN_MS - 60_000,
-    });
-    expect(deriveKanbanAttention(input, freshNow)).toContain("stuck");
+  it("flags the exact 20 min and 40 min boundaries (C4)", () => {
+    const warnExact = liveInput({ lastActivityTimestampMs: NOW - KANBAN_STUCK_WARN_MS });
+    expect(deriveKanbanAttention(warnExact, FRESH_NOW)).toContain("stuck");
+    expect(deriveKanbanAwaitingYouReason(warnExact, FRESH_NOW)).toBeNull();
+
+    const hardExact = liveInput({ lastActivityTimestampMs: NOW - KANBAN_STUCK_HARD_MS });
+    expect(deriveKanbanAwaitingYouReason(hardExact, FRESH_NOW)).toBe("stuck");
+    expect(deriveKanbanColumnV2(hardExact, FRESH_NOW)).toBe("awaitingYou");
   });
 
-  it("trips the hard boundary and hoists to awaitingYou past 40 min (F1)", () => {
-    const input = makeInput({
-      latestTurn: makeTurn({ state: "running", completedAt: null }),
-      session: makeSession({
-        status: "running",
-        updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
-      }),
-      lastActivityTimestampMs: NOW - KANBAN_STUCK_HARD_MS - 60_000,
+  it("never lets staleness override settled or dead-session threads", () => {
+    // Falls pending + dead-session requests through (no awaitingYou).
+    const deadPending = makeInput({
+      hasPendingUserInput: true,
+      latestTurn: makeTurn(),
+      session: makeSession({ status: "stopped" }),
     });
-    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBe("stuck");
-    expect(deriveKanbanColumnV2(input, freshNow)).toBe("awaitingYou");
-  });
+    expect(deriveKanbanAwaitingYouReason(deadPending, FRESH_NOW)).toBeNull();
+    expect(deriveKanbanColumnV2(deadPending, FRESH_NOW)).toBe("done");
 
-  it("flags the warn boundary exactly at 20:00.000 (C4)", () => {
-    const input = makeInput({
-      latestTurn: makeTurn({ state: "running", completedAt: null }),
-      session: makeSession({
-        status: "running",
-        updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
-      }),
-      lastActivityTimestampMs: NOW - KANBAN_STUCK_WARN_MS,
+    // A settled thread with a stale heartbeat stays done.
+    const settled = makeInput({
+      latestTurn: makeTurn(),
+      session: makeSession({ status: "ready", updatedAt: STALE_ISO }),
     });
-    expect(deriveKanbanAttention(input, freshNow)).toContain("stuck");
-    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBeNull();
-  });
-
-  it("flags the hard boundary exactly at 40:00.000 (C4)", () => {
-    const input = makeInput({
-      latestTurn: makeTurn({ state: "running", completedAt: null }),
-      session: makeSession({
-        status: "running",
-        updatedAt: new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString(),
-      }),
-      lastActivityTimestampMs: NOW - KANBAN_STUCK_HARD_MS,
-    });
-    expect(deriveKanbanAwaitingYouReason(input, freshNow)).toBe("stuck");
-    expect(deriveKanbanColumnV2(input, freshNow)).toBe("awaitingYou");
+    expect(deriveKanbanAwaitingYouReason(settled, FRESH_NOW)).toBeNull();
+    expect(deriveKanbanColumnV2(settled, FRESH_NOW)).toBe("done");
   });
 });
 
 describe("deriveKanbanAttention", () => {
-  it("produces no flags for a plain settled thread", () => {
-    expect(deriveKanbanAttention(makeInput({ latestTurn: makeTurn() }), { now: NOW })).toEqual([]);
-  });
-
-  it("maps awaiting-you reasons to their pill flags", () => {
-    expect(deriveKanbanAttention(makeInput({ hasPendingApprovals: true }), { now: NOW })).toEqual([
+  it("maps awaiting-you reasons and caller PR views to pills, staying quiet otherwise", () => {
+    expect(deriveKanbanAttention(makeInput({ latestTurn: makeTurn() }), FRESH_NOW)).toEqual([]);
+    expect(deriveKanbanAttention(makeInput({ hasPendingApprovals: true }), FRESH_NOW)).toEqual([
       "awaiting-approval",
     ]);
-    expect(deriveKanbanAttention(makeInput({ hasPendingUserInput: true }), { now: NOW })).toEqual([
+    expect(deriveKanbanAttention(makeInput({ hasPendingUserInput: true }), FRESH_NOW)).toEqual([
       "awaiting-input",
     ]);
     expect(
@@ -487,28 +338,19 @@ describe("deriveKanbanAttention", () => {
           latestTurn: makeTurn({ state: "error" }),
           session: makeSession({ status: "error" }),
         }),
-        { now: NOW },
+        FRESH_NOW,
       ),
     ).toEqual(["failed"]);
-    const stale = new Date(NOW - KANBAN_STUCK_HARD_MS - 60_000).toISOString();
+    expect(deriveKanbanAttention(liveInput(), FRESH_NOW)).toEqual(["stuck"]);
     expect(
-      deriveKanbanAttention(
-        makeInput({
-          latestTurn: makeTurn({ state: "running", completedAt: null }),
-          session: makeSession({ status: "running", updatedAt: stale }),
-        }),
-        { now: NOW },
-      ),
-    ).toEqual(["stuck"]);
-  });
-
-  it("adds needs-review from the caller's PR view", () => {
-    expect(
-      deriveKanbanAttention(makeInput({ latestTurn: makeTurn() }), { now: NOW, needsReview: true }),
+      deriveKanbanAttention(makeInput({ latestTurn: makeTurn() }), {
+        ...FRESH_NOW,
+        needsReview: true,
+      }),
     ).toEqual(["needs-review"]);
     expect(
       deriveKanbanAttention(makeInput({ hasPendingApprovals: true }), {
-        now: NOW,
+        ...FRESH_NOW,
         needsReview: true,
       }),
     ).toEqual(["awaiting-approval", "needs-review"]);

--- a/packages/shared/src/kanban.test.ts
+++ b/packages/shared/src/kanban.test.ts
@@ -69,12 +69,14 @@ function makeSession(
 }
 
 describe("kanban v2 vocabulary", () => {
-  it("labels every v2 column key and nothing else", () => {
+  it("labels every v2 column key and nothing else, with awaiting-you distinct", () => {
     expect(Object.keys(KANBAN_COLUMN_V2_LABELS).toSorted()).toEqual([...COLUMN_V2_KEYS].toSorted());
     for (const key of COLUMN_V2_KEYS) {
       expect(KANBAN_COLUMN_V2_LABELS[key]).toBeTypeOf("string");
       expect(KANBAN_COLUMN_V2_LABELS[key].length).toBeGreaterThan(0);
     }
+    expect(KANBAN_COLUMN_V2_LABELS.awaitingYou).toBe("Awaiting you");
+    expect(KANBAN_COLUMN_V2_LABELS.awaitingYou).not.toBe(KANBAN_COLUMN_V2_LABELS.inProgress);
   });
 
   it("labels every attention flag and nothing else", () => {
@@ -85,11 +87,6 @@ describe("kanban v2 vocabulary", () => {
       expect(KANBAN_ATTENTION_LABELS[flag]).toBeTypeOf("string");
       expect(KANBAN_ATTENTION_LABELS[flag].length).toBeGreaterThan(0);
     }
-  });
-
-  it("keeps the awaiting-you column label distinct from the other columns", () => {
-    expect(KANBAN_COLUMN_V2_LABELS.awaitingYou).toBe("Awaiting you");
-    expect(KANBAN_COLUMN_V2_LABELS.awaitingYou).not.toBe(KANBAN_COLUMN_V2_LABELS.inProgress);
   });
 });
 

--- a/packages/shared/src/kanban.ts
+++ b/packages/shared/src/kanban.ts
@@ -1,0 +1,337 @@
+// FILE: kanban.ts
+// Purpose: Shared kanban domain vocabulary and v2 column derivation (Draft / In
+//          Progress / Awaiting you / Done) consumed by both the web v2 board and
+//          the server-side read-board tool. One derivation, two surfaces (D2).
+// Layer: Shared domain logic — structural inputs only, no web/server imports.
+//
+// No wall-clock calls in this module: staleness consults an injected `now`
+// (epoch ms) so tests run against a frozen clock. Live-work rules mirror the
+// classic web derivation (`deriveKanbanColumn` in apps/web Kanban.logic) and the
+// pending-request dead-session rule (`canSessionAnswerPendingRequests`).
+
+import type { OrchestrationSessionStatus } from "@synara/contracts";
+
+export type KanbanColumnV2Key = "draft" | "inProgress" | "awaitingYou" | "done";
+
+export const KANBAN_COLUMN_V2_LABELS: Record<KanbanColumnV2Key, string> = {
+  draft: "Draft",
+  inProgress: "In Progress",
+  awaitingYou: "Awaiting you",
+  done: "Done",
+};
+
+export type KanbanAttentionFlag =
+  | "failed"
+  | "stuck"
+  | "awaiting-approval"
+  | "awaiting-input"
+  | "needs-review";
+
+/** Red-pill copy for the attention flags a card can carry. */
+export const KANBAN_ATTENTION_LABELS: Record<KanbanAttentionFlag, string> = {
+  failed: "Failed",
+  stuck: "Stuck",
+  "awaiting-approval": "Awaiting approval",
+  "awaiting-input": "Awaiting your input",
+  "needs-review": "Needs review",
+};
+
+/**
+ * Structural minimal view a thread must expose for the v2 derivation. Deliberately
+ * not `SidebarThreadSummary` (web) or `OrchestrationThreadShell` (server) so the
+ * same derivation serves both surfaces; each side projects its own thread shape
+ * into this input at the adapter boundary. `session.status` is the
+ * `OrchestrationSessionStatus` label in practice (both surfaces feed it).
+ */
+export interface KanbanThreadDerivationInput {
+  latestTurn: {
+    state: "running" | "interrupted" | "completed" | "error";
+    startedAt: string | null;
+    completedAt: string | null;
+  } | null;
+  session: {
+    /** The orchestrator's session status label (`OrchestrationSessionStatus`). */
+    status: OrchestrationSessionStatus;
+    updatedAt: string;
+    lastError?: string | null;
+  } | null;
+  /**
+   * Thread-level activity timestamp advanced on every appended message (e.g. a
+   * streamed assistant reply). The authoritative heartbeat is the later of this
+   * and `session.updatedAt` — the session row only moves on lifecycle
+   * transitions, so a busy-but-quiet turn must never read as stale (mirrors
+   * `projectedLifecycleAgeMs` in providerRuntimeReconciliation.ts).
+   *
+   * Web consumers feed the durable thread's last-message stamp here when their
+   * summary projection freezes `updatedAt` on streaming deltas (see the web
+   * adapter in kanban.logic.ts); the server consumes the durable row directly.
+   */
+  threadUpdatedAt?: string | null;
+  /**
+   * Epoch-ms stamp of the thread's last durable activity (messages appended).
+   * A strictly fresher liveness input than `threadUpdatedAt` for surfaces whose
+   * summary projection does not advance during streaming: the heartbeat is the
+   * max of `session.updatedAt`, `threadUpdatedAt`, and this. Safely ignored when
+   * the caller already carries a live thread stamp.
+   */
+  lastActivityTimestampMs?: number | null;
+  hasPendingApprovals?: boolean;
+  hasPendingUserInput?: boolean;
+  hasLiveTailWork?: boolean;
+}
+
+/** Default warn threshold for a stale session heartbeat (20 min). */
+export const KANBAN_STUCK_WARN_MS = 20 * 60_000;
+/** Default hard threshold for a definite stuck session (40 min). */
+export const KANBAN_STUCK_HARD_MS = 40 * 60_000;
+
+export type KanbanAwaitingYouReason = "pending-approval" | "pending-input" | "failed" | "stuck";
+
+/**
+ * Statuses in which a session can no longer receive an answer to a pending
+ * approval/input request. Mirrors the web classic dead set (`"closed"`/`"error"`
+ * in `canSessionAnswerPendingRequests`), written against the orchestrator's real
+ * status vocabulary: `OrchestrationSessionStatus` has no `"closed"` literal —
+ * the session-lifecycle terminal states are `stopped` (user/manual stop) and
+ * `error` (provider failure). `idle` is a live-but-unstarted session that can
+ * still receive the answer, unlike the legacy web phase it mapped through.
+ */
+const SESSION_ANSWER_UNANSWERABLE: ReadonlySet<OrchestrationSessionStatus> = new Set([
+  "stopped",
+  "error",
+]);
+
+/**
+ * Pending approval / user-input requests are only actionable while the session
+ * that raised them can still receive the answer. Once the session is stopped or
+ * errored the request is dead — status surfaces must not present the thread as
+ * awaiting action forever after a provider crash. A thread with no session yet
+ * keeps the request actionable: the flag can arrive ahead of the session
+ * snapshot. Mirrors `canSessionAnswerPendingRequests` (apps/web session-logic).
+ */
+function canSessionAnswerPendingRequests(session: KanbanThreadDerivationInput["session"]): boolean {
+  if (!session) {
+    return true;
+  }
+  return !SESSION_ANSWER_UNANSWERABLE.has(session.status);
+}
+
+/**
+ * Whether the latest turn is settled (its flow reached a terminal outcome). Mirrors
+ * `isLatestTurnSettled` in apps/web session-logic: a requested-but-not-started turn is
+ * not settled; an interrupted/error turn is settled even without a completedAt stamp;
+ * a completed-and-stamped turn stays live while its session still reports running.
+ */
+export function isKanbanTurnSettled(
+  t: Pick<KanbanThreadDerivationInput, "latestTurn" | "session">,
+): boolean {
+  const turn = t.latestTurn;
+  if (!turn?.startedAt) {
+    return false;
+  }
+  if (!turn.completedAt) {
+    return false;
+  }
+  if (turn.state === "interrupted" || turn.state === "error") {
+    return true;
+  }
+  if (!t.session) {
+    return true;
+  }
+  if (t.session.status === "running") {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Whether the latest turn is live right now. Mirrors `hasLiveLatestTurn`: a null or
+ * not-yet-started turn is never live (those cases are handled by the explicit running
+ * / starting / running-no-turn branches in `hasKanbanLiveWork`).
+ */
+export function hasKanbanLiveLatestTurn(
+  t: Pick<KanbanThreadDerivationInput, "latestTurn" | "session">,
+): boolean {
+  if (!t.latestTurn?.startedAt) {
+    return false;
+  }
+  return !isKanbanTurnSettled(t);
+}
+
+/**
+ * Whether the thread currently has live work. Mirrors the classic web derivation
+ * (`deriveKanbanColumn`, apps/web Kanban.logic) with the shared session status label:
+ *   - actionable pending requests (answerable by a living session) or a live-tail signal
+ *   - a requested turn that has not produced startedAt yet (state "running")
+ *   - a live latest turn under a running session
+ *   - a starting session (the orchestrator's pre-init status)
+ *   - a running session with no settled turn yet
+ */
+export function hasKanbanLiveWork(t: KanbanThreadDerivationInput): boolean {
+  const canAnswerPending = canSessionAnswerPendingRequests(t.session);
+  if ((t.hasPendingApprovals === true || t.hasPendingUserInput === true) && canAnswerPending) {
+    return true;
+  }
+  if (t.hasLiveTailWork === true) {
+    return true;
+  }
+  // A requested turn that has not produced startedAt yet is still live work.
+  if (t.latestTurn?.state === "running") {
+    return true;
+  }
+  if (hasKanbanLiveLatestTurn(t)) {
+    return true;
+  }
+  const status = t.session?.status;
+  if (status === "starting" || status === "running") {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Parses the effective heartbeat timestamp (epoch ms) for a thread: the later of
+ * the session lifecycle stamp, the thread activity stamp (messages appended),
+ * and — when provided — the durable last-activity stamp (epoch ms). Returns null
+ * when nothing parses. Mirrors `projectedLifecycleAgeMs` in the server
+ * reconciler, extended with `lastActivityTimestampMs` so surfaces with a frozen
+ * summary projection can feed a fresher liveness input without touching their
+ * hot-path dedupe.
+ */
+export function kanbanHeartbeatTimestampMs(
+  t: Pick<KanbanThreadDerivationInput, "session" | "threadUpdatedAt" | "lastActivityTimestampMs">,
+): number | null {
+  const sessionObservedAt = t.session ? Date.parse(t.session.updatedAt) : Number.NaN;
+  const threadObservedAt = Date.parse(t.threadUpdatedAt ?? "");
+  const activityObservedAt =
+    typeof t.lastActivityTimestampMs === "number" && Number.isFinite(t.lastActivityTimestampMs)
+      ? t.lastActivityTimestampMs
+      : Number.NaN;
+  const observedAt = Math.max(
+    Number.isFinite(sessionObservedAt) ? sessionObservedAt : Number.NEGATIVE_INFINITY,
+    Number.isFinite(threadObservedAt) ? threadObservedAt : Number.NEGATIVE_INFINITY,
+    Number.isFinite(activityObservedAt) ? activityObservedAt : Number.NEGATIVE_INFINITY,
+  );
+  return Number.isFinite(observedAt) ? observedAt : null;
+}
+
+type HeartbeatInput = Pick<
+  KanbanThreadDerivationInput,
+  "session" | "threadUpdatedAt" | "lastActivityTimestampMs"
+>;
+
+/** Seconds-aware staleness: heartbeat age floored at 0 (never negative). */
+function heartbeatAgeMs(t: HeartbeatInput, opts: { now: number }): number | null {
+  const heartbeat = kanbanHeartbeatTimestampMs(t);
+  return heartbeat !== null ? Math.max(0, opts.now - heartbeat) : null;
+}
+
+/** Whether the effective heartbeat is stale past-or-at the hard stuck threshold. */
+function isHardStuck(t: HeartbeatInput, opts: { now: number }): boolean {
+  const ageMs = heartbeatAgeMs(t, opts);
+  return ageMs !== null && ageMs >= KANBAN_STUCK_HARD_MS;
+}
+
+/** Whether the effective heartbeat is stale past-or-at the warn stuck threshold. */
+function isWarnStuck(t: HeartbeatInput, opts: { now: number }): boolean {
+  const ageMs = heartbeatAgeMs(t, opts);
+  return ageMs !== null && ageMs >= KANBAN_STUCK_WARN_MS;
+}
+
+/**
+ * While the human is the binding constraint, the thread reads as Awaiting you:
+ * actionable pending approval/input (only if a living session can answer — a dead
+ * session falls through to its underlying live/done state), a failed agent (error
+ * turn / error session / last error), or a stuck session (live-work claim with a
+ * heartbeat stale past the hard threshold). Awaiting-you wins precedence over
+ * In Progress (D1/D12).
+ */
+export function deriveKanbanAwaitingYouReason(
+  t: KanbanThreadDerivationInput,
+  opts: { now: number },
+): KanbanAwaitingYouReason | null {
+  // Failed wins precedence over actionable pending: an errored turn/session is
+  // the agent's terminal state, so a pending flag on top of it must not read as
+  // "awaiting your approval" — it reads as "this failed".
+  if (t.latestTurn?.state === "error") {
+    return "failed";
+  }
+  if (t.session?.status === "error" || (t.session?.lastError ?? null) != null) {
+    return "failed";
+  }
+  const canAnswerPending = canSessionAnswerPendingRequests(t.session);
+  if (canAnswerPending) {
+    if (t.hasPendingApprovals === true) {
+      return "pending-approval";
+    }
+    if (t.hasPendingUserInput === true) {
+      return "pending-input";
+    }
+  }
+  if (hasKanbanLiveWork(t) && isHardStuck(t, opts)) {
+    return "stuck";
+  }
+  return null;
+}
+
+/**
+ * Classifies a thread into the v2 column vocabulary (Draft / In Progress / Awaiting
+ * you / Done). Classic rules for non-attention cases:
+ *   - actionable pending + live tail → inProgress
+ *   - live latest turn / starting session / running session → inProgress
+ *   - no latestTurn ever → draft
+ *   - everything else (settled) → done
+ * Awaiting-you wins over In Progress when the human is the binding constraint.
+ */
+export function deriveKanbanColumnV2(
+  t: KanbanThreadDerivationInput,
+  opts?: { now?: number },
+): KanbanColumnV2Key {
+  if (opts?.now !== undefined) {
+    const reason = deriveKanbanAwaitingYouReason(t, { now: opts.now });
+    if (reason !== null) {
+      return "awaitingYou";
+    }
+  }
+  if (hasKanbanLiveWork(t)) {
+    return "inProgress";
+  }
+  if (!t.latestTurn) {
+    return "draft";
+  }
+  return "done";
+}
+
+/**
+ * The attention-flag set for a card, consumed by the web pill (S1-P6) and the read
+ * tool's `attention` field (S2-P1). Awaiting-you reasons map to their pill flags;
+ * a warn-stale heartbeat surfaces a "stuck" pill while the card is still In
+ * Progress (the hard threshold hoists it to Awaiting you). `needsReview` is fed by
+ * the caller from its PR source of truth (open `lastKnownPr` on first paint).
+ */
+export function deriveKanbanAttention(
+  t: KanbanThreadDerivationInput,
+  opts: { now: number; needsReview?: boolean },
+): KanbanAttentionFlag[] {
+  const flags: KanbanAttentionFlag[] = [];
+  const reason = deriveKanbanAwaitingYouReason(t, opts);
+  if (reason === "pending-approval") {
+    flags.push("awaiting-approval");
+  } else if (reason === "pending-input") {
+    flags.push("awaiting-input");
+  } else if (reason === "failed") {
+    flags.push("failed");
+  } else if (reason === "stuck") {
+    flags.push("stuck");
+  }
+  // A warn-stale heartbeat earns the "stuck" pill while the card is still In
+  // Progress; once the hard threshold hoists it to Awaiting you the reason flag
+  // already carries "stuck", so do not double-push it.
+  if (hasKanbanLiveWork(t) && isWarnStuck(t, opts) && reason !== "stuck") {
+    flags.push("stuck");
+  }
+  if (opts.needsReview === true) {
+    flags.push("needs-review");
+  }
+  return flags;
+}

--- a/packages/shared/src/kanban.ts
+++ b/packages/shared/src/kanban.ts
@@ -1,13 +1,7 @@
-// FILE: kanban.ts
-// Purpose: Shared kanban domain vocabulary and v2 column derivation (Draft / In
-//          Progress / Awaiting you / Done) consumed by both the web v2 board and
-//          the server-side read-board tool. One derivation, two surfaces (D2).
-// Layer: Shared domain logic — structural inputs only, no web/server imports.
-//
-// No wall-clock calls in this module: staleness consults an injected `now`
-// (epoch ms) so tests run against a frozen clock. Live-work rules mirror the
-// classic web derivation (`deriveKanbanColumn` in apps/web Kanban.logic) and the
-// pending-request dead-session rule (`canSessionAnswerPendingRequests`).
+// Shared kanban vocabulary and v2 column derivation (Draft / In Progress /
+// Awaiting you / Done), one derivation serving both the web board and the
+// server read tool. Staleness consults an injected epoch-ms `now`; no
+// wall-clock calls here.
 
 import type { OrchestrationSessionStatus } from "@synara/contracts";
 
@@ -37,11 +31,8 @@ export const KANBAN_ATTENTION_LABELS: Record<KanbanAttentionFlag, string> = {
 };
 
 /**
- * Structural minimal view a thread must expose for the v2 derivation. Deliberately
- * not `SidebarThreadSummary` (web) or `OrchestrationThreadShell` (server) so the
- * same derivation serves both surfaces; each side projects its own thread shape
- * into this input at the adapter boundary. `session.status` is the
- * `OrchestrationSessionStatus` label in practice (both surfaces feed it).
+ * Structural view a thread must expose for the derivation — deliberately not
+ * either surface's native type, so both project into it at their adapter.
  */
 export interface KanbanThreadDerivationInput {
   latestTurn: {
@@ -56,24 +47,12 @@ export interface KanbanThreadDerivationInput {
     lastError?: string | null;
   } | null;
   /**
-   * Thread-level activity timestamp advanced on every appended message (e.g. a
-   * streamed assistant reply). The authoritative heartbeat is the later of this
-   * and `session.updatedAt` — the session row only moves on lifecycle
-   * transitions, so a busy-but-quiet turn must never read as stale (mirrors
-   * `projectedLifecycleAgeMs` in providerRuntimeReconciliation.ts).
-   *
-   * Web consumers feed the durable thread's last-message stamp here when their
-   * summary projection freezes `updatedAt` on streaming deltas (see the web
-   * adapter in kanban.logic.ts); the server consumes the durable row directly.
+   * Thread-level activity stamps; the heartbeat is the latest of these and
+   * `session.updatedAt`, so a busy-but-quiet turn never reads as stale even
+   * when a summary projection freezes `updatedAt` on streaming deltas.
    */
   threadUpdatedAt?: string | null;
-  /**
-   * Epoch-ms stamp of the thread's last durable activity (messages appended).
-   * A strictly fresher liveness input than `threadUpdatedAt` for surfaces whose
-   * summary projection does not advance during streaming: the heartbeat is the
-   * max of `session.updatedAt`, `threadUpdatedAt`, and this. Safely ignored when
-   * the caller already carries a live thread stamp.
-   */
+  /** Epoch-ms durable last-activity stamp (fresher still; optional). */
   lastActivityTimestampMs?: number | null;
   hasPendingApprovals?: boolean;
   hasPendingUserInput?: boolean;
@@ -102,12 +81,9 @@ const SESSION_ANSWER_UNANSWERABLE: ReadonlySet<OrchestrationSessionStatus> = new
 ]);
 
 /**
- * Pending approval / user-input requests are only actionable while the session
- * that raised them can still receive the answer. Once the session is stopped or
- * errored the request is dead — status surfaces must not present the thread as
- * awaiting action forever after a provider crash. A thread with no session yet
- * keeps the request actionable: the flag can arrive ahead of the session
- * snapshot. Mirrors `canSessionAnswerPendingRequests` (apps/web session-logic).
+ * Pending requests die with their session: once it is stopped or errored the
+ * request can never be answered, so the card must stop reading as awaiting
+ * action. No session yet keeps the request actionable (flag may arrive first).
  */
 function canSessionAnswerPendingRequests(session: KanbanThreadDerivationInput["session"]): boolean {
   if (!session) {
@@ -116,12 +92,7 @@ function canSessionAnswerPendingRequests(session: KanbanThreadDerivationInput["s
   return !SESSION_ANSWER_UNANSWERABLE.has(session.status);
 }
 
-/**
- * Whether the latest turn is settled (its flow reached a terminal outcome). Mirrors
- * `isLatestTurnSettled` in apps/web session-logic: a requested-but-not-started turn is
- * not settled; an interrupted/error turn is settled even without a completedAt stamp;
- * a completed-and-stamped turn stays live while its session still reports running.
- */
+/** Settled = terminal outcome: interrupted/error, or completed with a non-running session. */
 export function isKanbanTurnSettled(
   t: Pick<KanbanThreadDerivationInput, "latestTurn" | "session">,
 ): boolean {
@@ -144,11 +115,7 @@ export function isKanbanTurnSettled(
   return true;
 }
 
-/**
- * Whether the latest turn is live right now. Mirrors `hasLiveLatestTurn`: a null or
- * not-yet-started turn is never live (those cases are handled by the explicit running
- * / starting / running-no-turn branches in `hasKanbanLiveWork`).
- */
+/** Live latest turn; null/unstarted turns are handled by hasKanbanLiveWork branches. */
 export function hasKanbanLiveLatestTurn(
   t: Pick<KanbanThreadDerivationInput, "latestTurn" | "session">,
 ): boolean {
@@ -158,15 +125,7 @@ export function hasKanbanLiveLatestTurn(
   return !isKanbanTurnSettled(t);
 }
 
-/**
- * Whether the thread currently has live work. Mirrors the classic web derivation
- * (`deriveKanbanColumn`, apps/web Kanban.logic) with the shared session status label:
- *   - actionable pending requests (answerable by a living session) or a live-tail signal
- *   - a requested turn that has not produced startedAt yet (state "running")
- *   - a live latest turn under a running session
- *   - a starting session (the orchestrator's pre-init status)
- *   - a running session with no settled turn yet
- */
+/** Whether the thread currently has live work (pending requests, live tail, or live turn/session). */
 export function hasKanbanLiveWork(t: KanbanThreadDerivationInput): boolean {
   const canAnswerPending = canSessionAnswerPendingRequests(t.session);
   if ((t.hasPendingApprovals === true || t.hasPendingUserInput === true) && canAnswerPending) {
@@ -189,15 +148,7 @@ export function hasKanbanLiveWork(t: KanbanThreadDerivationInput): boolean {
   return false;
 }
 
-/**
- * Parses the effective heartbeat timestamp (epoch ms) for a thread: the later of
- * the session lifecycle stamp, the thread activity stamp (messages appended),
- * and — when provided — the durable last-activity stamp (epoch ms). Returns null
- * when nothing parses. Mirrors `projectedLifecycleAgeMs` in the server
- * reconciler, extended with `lastActivityTimestampMs` so surfaces with a frozen
- * summary projection can feed a fresher liveness input without touching their
- * hot-path dedupe.
- */
+/** Effective heartbeat (epoch ms): the latest of the three activity stamps, null if none parses. */
 export function kanbanHeartbeatTimestampMs(
   t: Pick<KanbanThreadDerivationInput, "session" | "threadUpdatedAt" | "lastActivityTimestampMs">,
 ): number | null {
@@ -239,12 +190,9 @@ function isWarnStuck(t: HeartbeatInput, opts: { now: number }): boolean {
 }
 
 /**
- * While the human is the binding constraint, the thread reads as Awaiting you:
- * actionable pending approval/input (only if a living session can answer — a dead
- * session falls through to its underlying live/done state), a failed agent (error
- * turn / error session / last error), or a stuck session (live-work claim with a
- * heartbeat stale past the hard threshold). Awaiting-you wins precedence over
- * In Progress (D1/D12).
+ * Why the human is the binding constraint: failed > pending approval/input >
+ * stuck (live work with a heartbeat past the hard threshold). A dead session's
+ * pending flags fall through to the underlying live/done state.
  */
 export function deriveKanbanAwaitingYouReason(
   t: KanbanThreadDerivationInput,
@@ -275,13 +223,8 @@ export function deriveKanbanAwaitingYouReason(
 }
 
 /**
- * Classifies a thread into the v2 column vocabulary (Draft / In Progress / Awaiting
- * you / Done). Classic rules for non-attention cases:
- *   - actionable pending + live tail → inProgress
- *   - live latest turn / starting session / running session → inProgress
- *   - no latestTurn ever → draft
- *   - everything else (settled) → done
- * Awaiting-you wins over In Progress when the human is the binding constraint.
+ * Column classification: awaitingYou wins over live work; then inProgress,
+ * draft (never ran a turn), done (settled).
  */
 export function deriveKanbanColumnV2(
   t: KanbanThreadDerivationInput,
@@ -303,11 +246,8 @@ export function deriveKanbanColumnV2(
 }
 
 /**
- * The attention-flag set for a card, consumed by the web pill (S1-P6) and the read
- * tool's `attention` field (S2-P1). Awaiting-you reasons map to their pill flags;
- * a warn-stale heartbeat surfaces a "stuck" pill while the card is still In
- * Progress (the hard threshold hoists it to Awaiting you). `needsReview` is fed by
- * the caller from its PR source of truth (open `lastKnownPr` on first paint).
+ * Card attention flags: the awaiting-you reason as a pill, plus "stuck" on a
+ * warn-stale heartbeat while still In Progress, plus needs-review per caller.
  */
 export function deriveKanbanAttention(
   t: KanbanThreadDerivationInput,


### PR DESCRIPTION
## Summary

Land the S1 "Kanban v2" redesign as a small ordered set of commits. New shared domain module first, then the web-side attention-first board, the needs-review filter with its fold/reveal, stuck detection, and the F1/C2/H5 reliability fixes:

- **`feat(kanban): add shared v2 attention-first domain module`** — `packages/shared/src/kanban.ts` + tests: v2 column/attention derivation over a structural input with an injected clock (no wall-clock calls), scheduled wait `KANBAN_STUCK_WARN_MS` (20 min) / `KANBAN_STUCK_HARD_MS` (40 min), label maps. Exposed via the `@synara/shared/kanban` subpath export.
- **`fix(kanban): refine needs-review pill on raw flags, not display copy`** — `refineAttentionFlagsForLivePr` operates on raw `KanbanAttentionFlag` entries; the pill maps display copy through `KANBAN_ATTENTION_LABELS` after refinement so it never drifts from the flag set (M3/C3). F1 durable thread-shell last-activity heartbeat feeds the derivation; C2 gates the board clock on live-work candidates. Persists the needs-review filter and reveal fold in the kanban UI store. H5: expired optimistic dispatches stay silent when the thread left the display set.
- **`feat(kanban): render the attention-first v2 board and reveal fold`** — v2 view-mode toggle, Awaiting-you column, needs-review filter control, per-column render caps with the fold/reveal and a reachable "Show fewer" even at zero hidden cards, plus the raising-hand status glyph.

`decisions.tsv` (a coordinator decision trail) is ignored at the repo root and is not part of this PR.

### Review pass (2026-08-21)

- `useKanbanBoard` now memoizes the board build and the display-threads selector, so the C2 clock gate, the durable-heartbeat selector, and the composer-draft equality check actually prevent rebuilds instead of being discarded every render.
- Awaiting-you cards keep their unsent-prompt companion draft card (previously Done-only), and the view clock keeps ticking while a stuck Awaiting-you card shows "Worked for".
- Dropped the dead `attentionLabels` card field (the renderer maps flags through `KANBAN_ATTENTION_LABELS` itself) and made `now` required in the web column adapter — its only production caller always passed it.
- New real-chromium browser test renders the four-column v2 board with attention pills and the needs-review filter.
- `ThreadDiagnosticsQuery.test` now uses relative timestamps: the 30-day retention purge deletes rows older than a month, so the old absolute fixture dates silently vanished once real time moved past them (this is what turned CI red on Aug 21 with no code change).

## Test plan

- `bun fmt` — clean
- `bun lint` — 0 errors
- `bun typecheck` — web + shared clean (server untouched by this PR)
- `bun run test` — server 334 files / 3824 tests green, web 3973/3978 (5 pre-existing local env failures in ChatMarkdown/Sidebar, reproduced on the pristine branch), shared 574 green
- Browser E2E: `KanbanProjectBoardView.browser.tsx` green in chromium
- Focused kanban suites: web 112 tests, shared 40 tests green

### Manual checks worth a glance

- v2 board: cards land in Draft / In Progress / Awaiting you / Done with attention pills on failed/stuck/awaiting-*/needs-review.
- Needs-review filter folds each column at 30 rows; the reveal toggle shows the tail and keeps "Show fewer" reachable while revealed.
- A busy-but-quiet streaming turn must not flip to "Stuck" until the durable heartbeat genuinely ages out (20/40 min).

Made with [Cursor](https://cursor.com)