### PR TITLE
fix: stop large-state projection repair thrash (#618)

### DIFF
--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -1374,6 +1374,62 @@ describe("OrchestrationEngine", () => {
     await runtime.dispose();
   });
 
+  it("coalesces concurrent projection repairs and skips an immediate repeat", async () => {
+    let bootstrapCalls = 0;
+    let repairBootstrapCalls = 0;
+    let resolveBootstrapStarted: (() => void) | undefined;
+    let releaseBootstrap: (() => void) | undefined;
+    const bootstrapStarted = new Promise<void>((resolve) => {
+      resolveBootstrapStarted = resolve;
+    });
+    const bootstrapGate = new Promise<void>((resolve) => {
+      releaseBootstrap = resolve;
+    });
+    const blockingProjectionPipeline: OrchestrationProjectionPipelineShape = {
+      bootstrap: Effect.sync(() => (bootstrapCalls += 1)).pipe(
+        Effect.flatMap((call) => {
+          if (call === 1) {
+            return Effect.void;
+          }
+          repairBootstrapCalls += 1;
+          resolveBootstrapStarted?.();
+          return Effect.promise(() => bootstrapGate);
+        }),
+      ),
+      projectMetadataEvent: () => Effect.void,
+      projectEvent: () => Effect.void,
+      projectHotEventInCurrentTransaction: () => Effect.void,
+      projectDeferredEvent: () => Effect.void,
+    };
+    const runtime = ManagedRuntime.make(
+      OrchestrationEngineLive.pipe(
+        Layer.provide(Layer.succeed(OrchestrationProjectionPipeline, blockingProjectionPipeline)),
+        Layer.provide(OrchestrationProjectionSnapshotQueryLive),
+        Layer.provide(OrchestrationEventStoreLive),
+        Layer.provide(OrchestrationCommandReceiptRepositoryLive),
+        Layer.provide(SqlitePersistenceMemory),
+        Layer.provideMerge(TestServerConfigLayer),
+        Layer.provideMerge(NodeServices.layer),
+      ),
+    );
+    const engine = await runtime.runPromise(Effect.service(OrchestrationEngineService));
+
+    const firstRepair = runtime.runPromise(engine.repairState());
+    await bootstrapStarted;
+    const secondRepair = runtime.runPromise(engine.repairState());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    releaseBootstrap?.();
+
+    const [firstSnapshot, secondSnapshot] = await Promise.all([firstRepair, secondRepair]);
+    expect(secondSnapshot).toEqual(firstSnapshot);
+    expect(repairBootstrapCalls).toBe(1);
+
+    await runtime.runPromise(engine.repairState());
+    expect(repairBootstrapCalls).toBe(1);
+
+    await runtime.dispose();
+  });
+
   it("retires an empty existing project when re-adding the same workspace root", async () => {
     const system = await createOrchestrationSystem();
     const { engine } = system;

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -192,9 +192,10 @@ const makeOrchestrationEngine = Effect.gen(function* () {
   // Full projection repair is multi-minute on large state DBs. Coalesce concurrent
   // callers onto one rebuild and skip thrash when a repair just completed.
   type ProjectionRepairError = OrchestrationDispatchError | OrchestrationEventStoreError;
-  const projectionRepairInFlight = yield* Ref.make<
-    Deferred.Deferred<OrchestrationReadModel, ProjectionRepairError> | null
-  >(null);
+  const projectionRepairInFlight = yield* Ref.make<Deferred.Deferred<
+    OrchestrationReadModel,
+    ProjectionRepairError
+  > | null>(null);
   const lastSuccessfulProjectionRepairAtMs = yield* Ref.make(0);
 
   // Committed events are durable before they reach this boundary. Once
@@ -1437,10 +1438,7 @@ const makeOrchestrationEngine = Effect.gen(function* () {
     Effect.gen(function* () {
       const nowMs = Date.now();
       const lastSuccessMs = yield* Ref.get(lastSuccessfulProjectionRepairAtMs);
-      if (
-        lastSuccessMs > 0 &&
-        nowMs - lastSuccessMs < PROJECTION_REPAIR_COOLDOWN_MS
-      ) {
+      if (lastSuccessMs > 0 && nowMs - lastSuccessMs < PROJECTION_REPAIR_COOLDOWN_MS) {
         yield* Effect.log(
           "skipping orchestration projection repair (recent successful rebuild)",
         ).pipe(
@@ -1452,19 +1450,16 @@ const makeOrchestrationEngine = Effect.gen(function* () {
         return yield* maintenanceLock.withPermits(1)(refreshCommandReadModelFromProjectionState);
       }
 
-      const joinDeferred = yield* Deferred.make<
-        OrchestrationReadModel,
-        ProjectionRepairError
-      >();
+      const joinDeferred = yield* Deferred.make<OrchestrationReadModel, ProjectionRepairError>();
       const claim = yield* Ref.modify(
         projectionRepairInFlight,
         (
           current,
         ): readonly [
-          { readonly kind: "join" | "start"; readonly deferred: Deferred.Deferred<
-            OrchestrationReadModel,
-            ProjectionRepairError
-          > },
+          {
+            readonly kind: "join" | "start";
+            readonly deferred: Deferred.Deferred<OrchestrationReadModel, ProjectionRepairError>;
+          },
           Deferred.Deferred<OrchestrationReadModel, ProjectionRepairError> | null,
         ] => {
           if (current !== null) {

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -25,7 +25,11 @@ import {
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import { ServerConfig } from "../../config.ts";
-import { toPersistenceSqlError, type PersistenceSqlError } from "../../persistence/Errors.ts";
+import {
+  toPersistenceSqlError,
+  type OrchestrationEventStoreError,
+  type PersistenceSqlError,
+} from "../../persistence/Errors.ts";
 import { OrchestrationEventStore } from "../../persistence/Services/OrchestrationEventStore.ts";
 import {
   OrchestrationCommandReceiptRepository,
@@ -77,6 +81,8 @@ import {
 
 const ORCHESTRATION_DISPATCH_TIMEOUT_MS = 45_000;
 const DEFERRED_PROJECTION_RETRY_DELAYS_MS = [100, 500, 2_000, 10_000, 30_000] as const;
+/** Coalesce/skip full projection rebuilds when large state DBs make repair multi-minute. */
+const PROJECTION_REPAIR_COOLDOWN_MS = 120_000;
 const REQUIRED_REPAIR_PROJECTORS = Object.values(ORCHESTRATION_PROJECTOR_NAMES);
 
 type CommandExecutionState = "queued" | "in-flight" | "abandoned";
@@ -183,6 +189,13 @@ const makeOrchestrationEngine = Effect.gen(function* () {
   const deferredProjectionRetryAttempts = yield* Ref.make(0);
   const deferredProjectionLastFailure = yield* Ref.make<string | null>(null);
   const deferredProjectionScope = yield* Scope.make("sequential");
+  // Full projection repair is multi-minute on large state DBs. Coalesce concurrent
+  // callers onto one rebuild and skip thrash when a repair just completed.
+  type ProjectionRepairError = OrchestrationDispatchError | OrchestrationEventStoreError;
+  const projectionRepairInFlight = yield* Ref.make<
+    Deferred.Deferred<OrchestrationReadModel, ProjectionRepairError> | null
+  >(null);
+  const lastSuccessfulProjectionRepairAtMs = yield* Ref.make(0);
 
   // Committed events are durable before they reach this boundary. Once
   // publication starts, a dispatch deadline must not interrupt it and leave
@@ -1291,7 +1304,8 @@ const makeOrchestrationEngine = Effect.gen(function* () {
     });
 
   // Used by the settings screen to rebuild local indexes without deleting chats.
-  const repairState: OrchestrationEngineShape["repairState"] = () =>
+  // Also invoked by empty-route / desktop recovery paths — those can stampede.
+  const runProjectionRepair: OrchestrationEngineShape["repairState"] = () =>
     maintenanceLock.withPermits(1)(
       Effect.gen(function* () {
         yield* Effect.log("repairing orchestration projection state");
@@ -1418,6 +1432,64 @@ const makeOrchestrationEngine = Effect.gen(function* () {
         return snapshot;
       }),
     );
+
+  const repairState: OrchestrationEngineShape["repairState"] = () =>
+    Effect.gen(function* () {
+      const nowMs = Date.now();
+      const lastSuccessMs = yield* Ref.get(lastSuccessfulProjectionRepairAtMs);
+      if (
+        lastSuccessMs > 0 &&
+        nowMs - lastSuccessMs < PROJECTION_REPAIR_COOLDOWN_MS
+      ) {
+        yield* Effect.log(
+          "skipping orchestration projection repair (recent successful rebuild)",
+        ).pipe(
+          Effect.annotateLogs({
+            cooldownMs: PROJECTION_REPAIR_COOLDOWN_MS,
+            ageMs: nowMs - lastSuccessMs,
+          }),
+        );
+        return yield* maintenanceLock.withPermits(1)(refreshCommandReadModelFromProjectionState);
+      }
+
+      const joinDeferred = yield* Deferred.make<
+        OrchestrationReadModel,
+        ProjectionRepairError
+      >();
+      const claim = yield* Ref.modify(
+        projectionRepairInFlight,
+        (
+          current,
+        ): readonly [
+          { readonly kind: "join" | "start"; readonly deferred: Deferred.Deferred<
+            OrchestrationReadModel,
+            ProjectionRepairError
+          > },
+          Deferred.Deferred<OrchestrationReadModel, ProjectionRepairError> | null,
+        ] => {
+          if (current !== null) {
+            return [{ kind: "join", deferred: current }, current];
+          }
+          return [{ kind: "start", deferred: joinDeferred }, joinDeferred];
+        },
+      );
+
+      if (claim.kind === "join") {
+        yield* Effect.log("joining in-flight orchestration projection repair");
+        return yield* Deferred.await(claim.deferred);
+      }
+
+      return yield* Effect.gen(function* () {
+        const exit = yield* Effect.exit(runProjectionRepair());
+        if (exit._tag === "Success") {
+          yield* Ref.set(lastSuccessfulProjectionRepairAtMs, Date.now());
+          yield* Deferred.succeed(claim.deferred, exit.value).pipe(Effect.orDie);
+          return exit.value;
+        }
+        yield* Deferred.failCause(claim.deferred, exit.cause).pipe(Effect.orDie);
+        return yield* Effect.failCause(exit.cause);
+      }).pipe(Effect.ensuring(Ref.set(projectionRepairInFlight, null)));
+    });
 
   return {
     quiesce,

--- a/apps/server/src/provider/unmappedProviderEvents.ts
+++ b/apps/server/src/provider/unmappedProviderEvents.ts
@@ -24,8 +24,7 @@ const CREDENTIAL_ASSIGNMENT_PATTERN =
   /\b((?:(?:proxy[-_ ]?)?authorization|api[-_ ]?key|private[-_ ]?key|(?:set[-_ ]?)?cookie|(?:access|refresh|session)[-_ ]?token|token|password|passwd|passphrase|client[-_ ]?secret|(?:aws[-_ ]?)?secret(?:[-_ ]?(?:access[-_ ]?)?key)?|credentials?)\s*(?::|=)\s*)(?:bearer\s+)?(?!\[REDACTED\])(?:\$'(?:\\[\s\S]|[^'\\])*(?:'|$)|"(?:\\[\s\S]|[^"\\])*(?:"|$)|'(?:\\[\s\S]|[^'\\])*(?:'|$)|(?:\\[\s\S]|[^\s,;\\])+)/giu;
 const ENV_CREDENTIAL_ASSIGNMENT_PREFIX_PATTERN =
   /(?<![A-Za-z0-9_.-])((["']?)([A-Za-z0-9_.-]+)\2\s*(?::|=)\s*)/giu;
-const ENV_CREDENTIAL_TUPLE_PREFIX_PATTERN =
-  /((?:^|,|\[)\s*(["'])([A-Za-z0-9_.-]+)\2\s*,\s*)/giu;
+const ENV_CREDENTIAL_TUPLE_PREFIX_PATTERN = /((?:^|,|\[)\s*(["'])([A-Za-z0-9_.-]+)\2\s*,\s*)/giu;
 const JSON_NAME_FIELD_PATTERN =
   /(?:"name"|'name'|\bname)\s*:\s*(["'])((?:\\[\s\S]|(?!\1)[\s\S])*)\1/giu;
 const JSON_VALUE_FIELD_PATTERN =
@@ -475,11 +474,7 @@ function redactInspectedNamedValueObjects(value: string): string {
   return redacted;
 }
 
-function redactValue(
-  value: unknown,
-  seen = new WeakSet<object>(),
-  depth = 0,
-): unknown {
+function redactValue(value: unknown, seen = new WeakSet<object>(), depth = 0): unknown {
   if (typeof value === "string") return redactText(value);
   if (typeof value === "bigint") return value.toString();
   if (typeof value === "number") return Number.isFinite(value) ? value : null;

--- a/apps/web/src/routeRestoreRefreshCoordinator.test.ts
+++ b/apps/web/src/routeRestoreRefreshCoordinator.test.ts
@@ -1,9 +1,11 @@
 import type { OrchestrationReadModel, OrchestrationShellSnapshot } from "@synara/contracts";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS,
   registerEmptyRouteRestoreRefresh,
   requestEmptyRouteRestoreRefresh,
+  resetEmptyRouteRestoreSingleFlightForTests,
   runEmptyRouteRestoreRefresh,
 } from "./routeRestoreRefreshCoordinator";
 
@@ -23,11 +25,28 @@ function readModel(threadIds: readonly string[]): OrchestrationReadModel {
   } as unknown as OrchestrationReadModel;
 }
 
+function emptyUntilRepairShell(getShellSnapshotCalls: { count: number }) {
+  return vi.fn().mockImplementation(async () => {
+    getShellSnapshotCalls.count += 1;
+    if (getShellSnapshotCalls.count <= EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS) {
+      return shellSnapshot([]);
+    }
+    return shellSnapshot(["thread-repaired"]);
+  });
+}
+
 let unregister: (() => void) | undefined;
+
+beforeEach(() => {
+  resetEmptyRouteRestoreSingleFlightForTests();
+  vi.useFakeTimers();
+});
 
 afterEach(() => {
   unregister?.();
   unregister = undefined;
+  resetEmptyRouteRestoreSingleFlightForTests();
+  vi.useRealTimers();
 });
 
 describe("route restore refresh coordinator", () => {
@@ -104,28 +123,115 @@ describe("route restore refresh coordinator", () => {
     expect(appliedShellSnapshots).toHaveLength(2);
   });
 
-  it("repairs an empty projection then consumes a fresh fenced shell snapshot", async () => {
+  it("polls before repairing when projections stay empty during catch-up", async () => {
     let hasThreads = false;
-    const getShellSnapshot = vi
-      .fn()
-      .mockResolvedValueOnce(shellSnapshot([]))
-      .mockResolvedValueOnce(shellSnapshot(["thread-repaired"]));
+    const shellCalls = { count: 0 };
+    const getShellSnapshot = emptyUntilRepairShell(shellCalls);
     const getSnapshot = vi.fn().mockResolvedValue(readModel([]));
     const repairState = vi.fn().mockResolvedValue(readModel(["thread-repaired"]));
 
-    await expect(
-      runEmptyRouteRestoreRefresh({
-        getShellSnapshot,
-        getSnapshot,
-        repairState,
-        applyShellSnapshot: (snapshot) => {
-          hasThreads = snapshot.threads.length > 0;
-        },
-        hasThreads: () => hasThreads,
-      }),
-    ).resolves.toBe(true);
+    const recovery = runEmptyRouteRestoreRefresh({
+      getShellSnapshot,
+      getSnapshot,
+      repairState,
+      applyShellSnapshot: (snapshot) => {
+        hasThreads = snapshot.threads.length > 0;
+      },
+      hasThreads: () => hasThreads,
+    });
+    await vi.runAllTimersAsync();
+    await expect(recovery).resolves.toBe(true);
+
+    expect(getShellSnapshot).toHaveBeenCalledTimes(EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS + 1);
+    expect(getSnapshot).toHaveBeenCalledTimes(EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS);
+    expect(repairState).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops early when threads appear during the poll window", async () => {
+    let hasThreads = false;
+    let shellCalls = 0;
+    const getShellSnapshot = vi.fn().mockImplementation(async () => {
+      shellCalls += 1;
+      return shellCalls === 1 ? shellSnapshot([]) : shellSnapshot(["thread-1"]);
+    });
+    const getSnapshot = vi.fn().mockResolvedValue(readModel([]));
+    const repairState = vi.fn();
+
+    const recovery = runEmptyRouteRestoreRefresh({
+      getShellSnapshot,
+      getSnapshot,
+      repairState,
+      applyShellSnapshot: (snapshot) => {
+        hasThreads = snapshot.threads.length > 0;
+      },
+      hasThreads: () => hasThreads,
+    });
+    await vi.runAllTimersAsync();
+    await expect(recovery).resolves.toBe(true);
+
+    expect(getShellSnapshot).toHaveBeenCalledTimes(2);
+    expect(repairState).not.toHaveBeenCalled();
+  });
+
+  it("coalesces concurrent empty-route recoveries into one repair", async () => {
+    let hasThreads = false;
+    const shellCalls = { count: 0 };
+    let resolveRepair: (() => void) | null = null;
+    const getShellSnapshot = emptyUntilRepairShell(shellCalls);
+    const getSnapshot = vi.fn().mockResolvedValue(readModel([]));
+    const repairState = vi.fn(
+      () =>
+        new Promise<OrchestrationReadModel>((resolve) => {
+          resolveRepair = () => resolve(readModel(["thread-repaired"]));
+        }),
+    );
+
+    const first = runEmptyRouteRestoreRefresh({
+      getShellSnapshot,
+      getSnapshot,
+      repairState,
+      applyShellSnapshot: (snapshot) => {
+        hasThreads = snapshot.threads.length > 0;
+      },
+      hasThreads: () => hasThreads,
+    });
+    const second = runEmptyRouteRestoreRefresh({
+      getShellSnapshot,
+      getSnapshot,
+      repairState,
+      applyShellSnapshot: (snapshot) => {
+        hasThreads = snapshot.threads.length > 0;
+      },
+      hasThreads: () => hasThreads,
+    });
+
+    await vi.runAllTimersAsync();
+    expect(repairState).toHaveBeenCalledTimes(1);
+    resolveRepair?.();
+    await expect(first).resolves.toBe(true);
+    await expect(second).resolves.toBe(true);
+  });
+
+  it("repairs an empty projection then consumes a fresh fenced shell snapshot", async () => {
+    let hasThreads = false;
+    const shellCalls = { count: 0 };
+    const getShellSnapshot = emptyUntilRepairShell(shellCalls);
+    const getSnapshot = vi.fn().mockResolvedValue(readModel([]));
+    const repairState = vi.fn().mockResolvedValue(readModel(["thread-repaired"]));
+
+    const recovery = runEmptyRouteRestoreRefresh({
+      getShellSnapshot,
+      getSnapshot,
+      repairState,
+      applyShellSnapshot: (snapshot) => {
+        hasThreads = snapshot.threads.length > 0;
+      },
+      hasThreads: () => hasThreads,
+    });
+    await vi.runAllTimersAsync();
+    await expect(recovery).resolves.toBe(true);
 
     expect(repairState).toHaveBeenCalledTimes(1);
-    expect(getShellSnapshot).toHaveBeenCalledTimes(2);
+    expect(getShellSnapshot).toHaveBeenCalledTimes(EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS + 1);
   });
 });

--- a/apps/web/src/routeRestoreRefreshCoordinator.test.ts
+++ b/apps/web/src/routeRestoreRefreshCoordinator.test.ts
@@ -179,13 +179,17 @@ describe("route restore refresh coordinator", () => {
   it("coalesces concurrent empty-route recoveries into one repair", async () => {
     let hasThreads = false;
     const shellCalls = { count: 0 };
-    let resolveRepair: (() => void) | null = null;
+    const repairControl = {
+      resolve: (): void => {
+        throw new Error("repair promise resolver was not initialized");
+      },
+    };
     const getShellSnapshot = emptyUntilRepairShell(shellCalls);
     const getSnapshot = vi.fn().mockResolvedValue(readModel([]));
     const repairState = vi.fn(
       () =>
         new Promise<OrchestrationReadModel>((resolve) => {
-          resolveRepair = () => resolve(readModel(["thread-repaired"]));
+          repairControl.resolve = () => resolve(readModel(["thread-repaired"]));
         }),
     );
 
@@ -205,17 +209,21 @@ describe("route restore refresh coordinator", () => {
 
     await vi.runAllTimersAsync();
     expect(repairState).toHaveBeenCalledTimes(1);
-    resolveRepair?.();
+    repairControl.resolve();
     await expect(first).resolves.toBe(true);
     await expect(second).resolves.toBe(true);
   });
 
   it("starts a fresh recovery when the registered EventRouter changes", async () => {
-    let resolveFirst: ((value: boolean) => void) | null = null;
+    const firstControl = {
+      resolve: (_value: boolean): void => {
+        throw new Error("first recovery resolver was not initialized");
+      },
+    };
     const firstHandler = vi.fn(
       () =>
         new Promise<boolean>((resolve) => {
-          resolveFirst = resolve;
+          firstControl.resolve = resolve;
         }),
     );
     const unregisterFirst = registerEmptyRouteRestoreRefresh(firstHandler);
@@ -229,7 +237,7 @@ describe("route restore refresh coordinator", () => {
     await expect(second).resolves.toBe(true);
     expect(secondHandler).toHaveBeenCalledTimes(1);
 
-    resolveFirst?.(false);
+    firstControl.resolve(false);
     await expect(first).resolves.toBe(false);
   });
 

--- a/apps/web/src/routeRestoreRefreshCoordinator.test.ts
+++ b/apps/web/src/routeRestoreRefreshCoordinator.test.ts
@@ -5,7 +5,6 @@ import {
   EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS,
   registerEmptyRouteRestoreRefresh,
   requestEmptyRouteRestoreRefresh,
-  resetEmptyRouteRestoreSingleFlightForTests,
   runEmptyRouteRestoreRefresh,
 } from "./routeRestoreRefreshCoordinator";
 
@@ -38,14 +37,12 @@ function emptyUntilRepairShell(getShellSnapshotCalls: { count: number }) {
 let unregister: (() => void) | undefined;
 
 beforeEach(() => {
-  resetEmptyRouteRestoreSingleFlightForTests();
   vi.useFakeTimers();
 });
 
 afterEach(() => {
   unregister?.();
   unregister = undefined;
-  resetEmptyRouteRestoreSingleFlightForTests();
   vi.useRealTimers();
 });
 
@@ -94,33 +91,38 @@ describe("route restore refresh coordinator", () => {
     expect(repairState).not.toHaveBeenCalled();
   });
 
-  it("uses the full snapshot only as a probe and re-reads the fenced shell", async () => {
+  it("uses one full snapshot only as a probe and re-reads the fenced shell", async () => {
     let hasThreads = false;
+    let fullSnapshotProbed = false;
     const getShellSnapshot = vi
       .fn()
-      .mockResolvedValueOnce(shellSnapshot([]))
-      .mockResolvedValueOnce(shellSnapshot(["thread-1"]));
-    const getSnapshot = vi.fn().mockResolvedValue(readModel(["thread-1"]));
+      .mockImplementation(async () =>
+        fullSnapshotProbed ? shellSnapshot(["thread-1"]) : shellSnapshot([]),
+      );
+    const getSnapshot = vi.fn().mockImplementation(async () => {
+      fullSnapshotProbed = true;
+      return readModel(["thread-1"]);
+    });
     const repairState = vi.fn();
     const appliedShellSnapshots: OrchestrationShellSnapshot[] = [];
 
-    await expect(
-      runEmptyRouteRestoreRefresh({
-        getShellSnapshot,
-        getSnapshot,
-        repairState,
-        applyShellSnapshot: (snapshot) => {
-          appliedShellSnapshots.push(snapshot);
-          hasThreads = snapshot.threads.length > 0;
-        },
-        hasThreads: () => hasThreads,
-      }),
-    ).resolves.toBe(true);
+    const recovery = runEmptyRouteRestoreRefresh({
+      getShellSnapshot,
+      getSnapshot,
+      repairState,
+      applyShellSnapshot: (snapshot) => {
+        appliedShellSnapshots.push(snapshot);
+        hasThreads = snapshot.threads.length > 0;
+      },
+      hasThreads: () => hasThreads,
+    });
+    await vi.runAllTimersAsync();
+    await expect(recovery).resolves.toBe(true);
 
     expect(getSnapshot).toHaveBeenCalledTimes(1);
     expect(repairState).not.toHaveBeenCalled();
-    expect(getShellSnapshot).toHaveBeenCalledTimes(2);
-    expect(appliedShellSnapshots).toHaveLength(2);
+    expect(getShellSnapshot).toHaveBeenCalledTimes(EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS + 1);
+    expect(appliedShellSnapshots).toHaveLength(EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS + 1);
   });
 
   it("polls before repairing when projections stay empty during catch-up", async () => {
@@ -143,7 +145,7 @@ describe("route restore refresh coordinator", () => {
     await expect(recovery).resolves.toBe(true);
 
     expect(getShellSnapshot).toHaveBeenCalledTimes(EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS + 1);
-    expect(getSnapshot).toHaveBeenCalledTimes(EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS);
+    expect(getSnapshot).toHaveBeenCalledTimes(1);
     expect(repairState).toHaveBeenCalledTimes(1);
   });
 
@@ -170,6 +172,7 @@ describe("route restore refresh coordinator", () => {
     await expect(recovery).resolves.toBe(true);
 
     expect(getShellSnapshot).toHaveBeenCalledTimes(2);
+    expect(getSnapshot).not.toHaveBeenCalled();
     expect(repairState).not.toHaveBeenCalled();
   });
 
@@ -186,30 +189,48 @@ describe("route restore refresh coordinator", () => {
         }),
     );
 
-    const first = runEmptyRouteRestoreRefresh({
-      getShellSnapshot,
-      getSnapshot,
-      repairState,
-      applyShellSnapshot: (snapshot) => {
-        hasThreads = snapshot.threads.length > 0;
-      },
-      hasThreads: () => hasThreads,
-    });
-    const second = runEmptyRouteRestoreRefresh({
-      getShellSnapshot,
-      getSnapshot,
-      repairState,
-      applyShellSnapshot: (snapshot) => {
-        hasThreads = snapshot.threads.length > 0;
-      },
-      hasThreads: () => hasThreads,
-    });
+    unregister = registerEmptyRouteRestoreRefresh(() =>
+      runEmptyRouteRestoreRefresh({
+        getShellSnapshot,
+        getSnapshot,
+        repairState,
+        applyShellSnapshot: (snapshot) => {
+          hasThreads = snapshot.threads.length > 0;
+        },
+        hasThreads: () => hasThreads,
+      }),
+    );
+    const first = requestEmptyRouteRestoreRefresh();
+    const second = requestEmptyRouteRestoreRefresh();
 
     await vi.runAllTimersAsync();
     expect(repairState).toHaveBeenCalledTimes(1);
     resolveRepair?.();
     await expect(first).resolves.toBe(true);
     await expect(second).resolves.toBe(true);
+  });
+
+  it("starts a fresh recovery when the registered EventRouter changes", async () => {
+    let resolveFirst: ((value: boolean) => void) | null = null;
+    const firstHandler = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+    const unregisterFirst = registerEmptyRouteRestoreRefresh(firstHandler);
+    const first = requestEmptyRouteRestoreRefresh();
+
+    unregisterFirst();
+    const secondHandler = vi.fn().mockResolvedValue(true);
+    unregister = registerEmptyRouteRestoreRefresh(secondHandler);
+    const second = requestEmptyRouteRestoreRefresh();
+
+    await expect(second).resolves.toBe(true);
+    expect(secondHandler).toHaveBeenCalledTimes(1);
+
+    resolveFirst?.(false);
+    await expect(first).resolves.toBe(false);
   });
 
   it("repairs an empty projection then consumes a fresh fenced shell snapshot", async () => {
@@ -232,6 +253,7 @@ describe("route restore refresh coordinator", () => {
     await expect(recovery).resolves.toBe(true);
 
     expect(repairState).toHaveBeenCalledTimes(1);
+    expect(getSnapshot).toHaveBeenCalledTimes(1);
     expect(getShellSnapshot).toHaveBeenCalledTimes(EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS + 1);
   });
 });

--- a/apps/web/src/routeRestoreRefreshCoordinator.ts
+++ b/apps/web/src/routeRestoreRefreshCoordinator.ts
@@ -2,7 +2,12 @@ import type { OrchestrationReadModel, OrchestrationShellSnapshot } from "@synara
 
 type EmptyRouteRestoreRefreshHandler = () => Promise<boolean>;
 
+/** Wait for projection catch-up before a full rebuild on large state DBs. */
+export const EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS = 12;
+export const EMPTY_ROUTE_PROJECTION_POLL_INTERVAL_MS = 500;
+
 let activeEmptyRouteRestoreRefreshHandler: EmptyRouteRestoreRefreshHandler | null = null;
+let inFlightEmptyRouteRestoreRefresh: Promise<boolean> | null = null;
 
 export function registerEmptyRouteRestoreRefresh(
   handler: EmptyRouteRestoreRefreshHandler,
@@ -19,6 +24,24 @@ export function requestEmptyRouteRestoreRefresh(): Promise<boolean> {
   return activeEmptyRouteRestoreRefreshHandler?.() ?? Promise.resolve(false);
 }
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    globalThis.setTimeout(resolve, ms);
+  });
+}
+
+/** Test-only: reset module single-flight state between cases. */
+export function resetEmptyRouteRestoreSingleFlightForTests(): void {
+  inFlightEmptyRouteRestoreRefresh = null;
+}
+
+/**
+ * Recover an empty route shell without bypassing EventRouter's sequence fence.
+ *
+ * Full projection rebuilds thrash multi-GB state DBs and hold the server
+ * maintenance lock for minutes. Poll shell/snapshot first so catch-up can win;
+ * only then call repair once. Concurrent callers join the same recovery promise.
+ */
 export async function runEmptyRouteRestoreRefresh(input: {
   readonly getShellSnapshot: () => Promise<OrchestrationShellSnapshot>;
   readonly getSnapshot: () => Promise<OrchestrationReadModel>;
@@ -26,28 +49,48 @@ export async function runEmptyRouteRestoreRefresh(input: {
   readonly applyShellSnapshot: (snapshot: OrchestrationShellSnapshot) => void;
   readonly hasThreads: () => boolean;
 }): Promise<boolean> {
-  const applyFreshShellSnapshot = async () => {
-    const snapshot = await input.getShellSnapshot();
-    input.applyShellSnapshot(snapshot);
-    return input.hasThreads();
-  };
-
-  if (await applyFreshShellSnapshot()) {
-    return true;
+  if (inFlightEmptyRouteRestoreRefresh) {
+    return inFlightEmptyRouteRestoreRefresh;
   }
 
-  // The full projection is only a recovery probe. Applying it here would bypass
-  // EventRouter's shell sequence fence, which is the race this coordinator exists
-  // to remove. If it already contains threads, re-read the shell projection and
-  // let EventRouter apply that snapshot through its normal fenced path.
-  const readModel = await input.getSnapshot();
-  if (readModel.threads.length > 0) {
+  const recoveryPromise = (async () => {
+    const applyFreshShellSnapshot = async () => {
+      const snapshot = await input.getShellSnapshot();
+      input.applyShellSnapshot(snapshot);
+      return input.hasThreads();
+    };
+
+    for (let attempt = 0; attempt < EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS; attempt += 1) {
+      if (await applyFreshShellSnapshot()) {
+        return true;
+      }
+
+      // The full projection is only a recovery probe. Applying it here would bypass
+      // EventRouter's shell sequence fence, which is the race this coordinator exists
+      // to remove. If it already contains threads, re-read the shell projection and
+      // let EventRouter apply that snapshot through its normal fenced path.
+      const readModel = await input.getSnapshot();
+      if (readModel.threads.length > 0) {
+        return await applyFreshShellSnapshot();
+      }
+
+      if (attempt + 1 < EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS) {
+        await delay(EMPTY_ROUTE_PROJECTION_POLL_INTERVAL_MS);
+      }
+    }
+
+    // Repair may rebuild projections, but its returned full read model has no
+    // EventRouter shell fence. Ignore the payload and consume a fresh shell
+    // snapshot after repair instead. Server-side repairState also coalesces and
+    // cools down concurrent rebuilds on large DBs.
+    await input.repairState();
     return await applyFreshShellSnapshot();
-  }
+  })().finally(() => {
+    if (inFlightEmptyRouteRestoreRefresh === recoveryPromise) {
+      inFlightEmptyRouteRestoreRefresh = null;
+    }
+  });
 
-  // Repair may rebuild projections, but its returned full read model has no
-  // EventRouter shell fence. Ignore the payload and consume a fresh shell
-  // snapshot after repair instead.
-  await input.repairState();
-  return await applyFreshShellSnapshot();
+  inFlightEmptyRouteRestoreRefresh = recoveryPromise;
+  return recoveryPromise;
 }

--- a/apps/web/src/routeRestoreRefreshCoordinator.ts
+++ b/apps/web/src/routeRestoreRefreshCoordinator.ts
@@ -7,14 +7,29 @@ export const EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS = 12;
 export const EMPTY_ROUTE_PROJECTION_POLL_INTERVAL_MS = 500;
 
 let activeEmptyRouteRestoreRefreshHandler: EmptyRouteRestoreRefreshHandler | null = null;
-let inFlightEmptyRouteRestoreRefresh: Promise<boolean> | null = null;
 
 export function registerEmptyRouteRestoreRefresh(
   handler: EmptyRouteRestoreRefreshHandler,
 ): () => void {
-  activeEmptyRouteRestoreRefreshHandler = handler;
+  let inFlight: Promise<boolean> | null = null;
+  const singleFlightHandler = () => {
+    if (inFlight) {
+      return inFlight;
+    }
+
+    const recovery = Promise.resolve().then(handler);
+    const sharedRecovery = recovery.finally(() => {
+      if (inFlight === sharedRecovery) {
+        inFlight = null;
+      }
+    });
+    inFlight = sharedRecovery;
+    return sharedRecovery;
+  };
+
+  activeEmptyRouteRestoreRefreshHandler = singleFlightHandler;
   return () => {
-    if (activeEmptyRouteRestoreRefreshHandler === handler) {
+    if (activeEmptyRouteRestoreRefreshHandler === singleFlightHandler) {
       activeEmptyRouteRestoreRefreshHandler = null;
     }
   };
@@ -30,17 +45,12 @@ function delay(ms: number): Promise<void> {
   });
 }
 
-/** Test-only: reset module single-flight state between cases. */
-export function resetEmptyRouteRestoreSingleFlightForTests(): void {
-  inFlightEmptyRouteRestoreRefresh = null;
-}
-
 /**
  * Recover an empty route shell without bypassing EventRouter's sequence fence.
  *
  * Full projection rebuilds thrash multi-GB state DBs and hold the server
- * maintenance lock for minutes. Poll shell/snapshot first so catch-up can win;
- * only then call repair once. Concurrent callers join the same recovery promise.
+ * maintenance lock for minutes. Poll the lightweight shell first so catch-up
+ * can win, then use one full snapshot probe before calling repair.
  */
 export async function runEmptyRouteRestoreRefresh(input: {
   readonly getShellSnapshot: () => Promise<OrchestrationShellSnapshot>;
@@ -49,48 +59,35 @@ export async function runEmptyRouteRestoreRefresh(input: {
   readonly applyShellSnapshot: (snapshot: OrchestrationShellSnapshot) => void;
   readonly hasThreads: () => boolean;
 }): Promise<boolean> {
-  if (inFlightEmptyRouteRestoreRefresh) {
-    return inFlightEmptyRouteRestoreRefresh;
+  const applyFreshShellSnapshot = async () => {
+    const snapshot = await input.getShellSnapshot();
+    input.applyShellSnapshot(snapshot);
+    return input.hasThreads();
+  };
+
+  for (let attempt = 0; attempt < EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS; attempt += 1) {
+    if (await applyFreshShellSnapshot()) {
+      return true;
+    }
+
+    if (attempt + 1 < EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS) {
+      await delay(EMPTY_ROUTE_PROJECTION_POLL_INTERVAL_MS);
+    }
   }
 
-  const recoveryPromise = (async () => {
-    const applyFreshShellSnapshot = async () => {
-      const snapshot = await input.getShellSnapshot();
-      input.applyShellSnapshot(snapshot);
-      return input.hasThreads();
-    };
-
-    for (let attempt = 0; attempt < EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS; attempt += 1) {
-      if (await applyFreshShellSnapshot()) {
-        return true;
-      }
-
-      // The full projection is only a recovery probe. Applying it here would bypass
-      // EventRouter's shell sequence fence, which is the race this coordinator exists
-      // to remove. If it already contains threads, re-read the shell projection and
-      // let EventRouter apply that snapshot through its normal fenced path.
-      const readModel = await input.getSnapshot();
-      if (readModel.threads.length > 0) {
-        return await applyFreshShellSnapshot();
-      }
-
-      if (attempt + 1 < EMPTY_ROUTE_PROJECTION_POLL_ATTEMPTS) {
-        await delay(EMPTY_ROUTE_PROJECTION_POLL_INTERVAL_MS);
-      }
-    }
-
-    // Repair may rebuild projections, but its returned full read model has no
-    // EventRouter shell fence. Ignore the payload and consume a fresh shell
-    // snapshot after repair instead. Server-side repairState also coalesces and
-    // cools down concurrent rebuilds on large DBs.
-    await input.repairState();
+  // The full projection is only a recovery probe. Applying it here would bypass
+  // EventRouter's shell sequence fence, which is the race this coordinator exists
+  // to remove. If it already contains threads, re-read the shell projection and
+  // let EventRouter apply that snapshot through its normal fenced path.
+  const readModel = await input.getSnapshot();
+  if (readModel.threads.length > 0) {
     return await applyFreshShellSnapshot();
-  })().finally(() => {
-    if (inFlightEmptyRouteRestoreRefresh === recoveryPromise) {
-      inFlightEmptyRouteRestoreRefresh = null;
-    }
-  });
+  }
 
-  inFlightEmptyRouteRestoreRefresh = recoveryPromise;
-  return recoveryPromise;
+  // Repair may rebuild projections, but its returned full read model has no
+  // EventRouter shell fence. Ignore the payload and consume a fresh shell
+  // snapshot after repair instead. Server-side repairState also coalesces and
+  // cools down concurrent rebuilds on large DBs.
+  await input.repairState();
+  return await applyFreshShellSnapshot();
 }


### PR DESCRIPTION
## Summary

Partial fix for **#618** focusing on the **repair-loop / frozen-UI** facet (not full worktree/backup lifecycle cleanup yet).

On multi-GB `state.sqlite`, concurrent empty-route / desktop recovery paths could stampede `repairState()`, each doing a full orchestration projection rebuild while holding the maintenance lock for minutes. Live turns then hit the 45s dispatch timeout and the UI looks dead even though the server is healthy.

### Changes

**Server (`OrchestrationEngine`)**
- Coalesce concurrent `repairState()` callers onto one in-flight rebuild
- After a successful rebuild, skip thrash for **2 minutes** (refresh read model only)

**Client (`routeRestoreRefreshCoordinator`)**
- Poll fenced shell + snapshot probes before calling repair (12 × 500ms)
- Single-flight concurrent empty-route recoveries
- Still never applies full read models outside EventRouter’s shell fence

### Out of scope for this PR (still #618)
- Automatic worktree removal on permanent project/task delete
- Dirty-worktree confirmation UX
- Backup retention bounds / storage report UI

## Test plan

- [x] `apps/web` `routeRestoreRefreshCoordinator.test.ts` — **8/8**
- [ ] CI full suite on PR
- [ ] Manual: cold start with large state should not spam “repairing orchestration projection state” after one successful repair