### PR TITLE
Allow Grok /plan inspection so Plan turns can finish

### DIFF
--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -882,6 +882,7 @@ export function makeCursorAdapter(
                   runtimeMode: input.runtimeMode,
                   interactionMode: ctx?.activeInteractionMode,
                   options: params.options,
+                  toolCall: params.toolCall,
                 });
                 if (policyOutcome !== undefined) {
                   return { outcome: policyOutcome };

--- a/apps/server/src/provider/Layers/DroidAdapter.ts
+++ b/apps/server/src/provider/Layers/DroidAdapter.ts
@@ -891,6 +891,7 @@ export function makeDroidAdapter(
                   runtimeMode: input.runtimeMode,
                   interactionMode: ctx?.activeInteractionMode,
                   options: params.options,
+                  toolCall: params.toolCall,
                 });
                 if (policyOutcome !== undefined) {
                   if (policyOutcome.outcome === "selected") {

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -73,7 +73,7 @@ describe("Grok native plan approval", () => {
         hookEventName: "pre_tool_use",
         toolName: "run_terminal_cmd",
       }),
-    ).toMatchObject({ decision: "deny" });
+    ).toEqual({});
     expect(
       resolveGrokPlanHookResponse("plan", {
         hookCallbackId: "synara-plan-guard",
@@ -111,6 +111,21 @@ describe("Grok native plan approval", () => {
         input: { name: "synara_create_threads" },
       }),
     ).toMatchObject({ decision: "deny" });
+    expect(
+      resolveGrokPlanHookResponse("plan", {
+        hookCallbackId: "synara-plan-guard",
+        hookEventName: "pre_tool_use",
+        toolName: "run_terminal_command",
+      }),
+    ).toEqual({});
+    expect(
+      resolveGrokPlanHookResponse("plan", {
+        hookCallbackId: "synara-plan-guard",
+        hookEventName: "pre_tool_use",
+        toolName: "run_terminal_command",
+        input: { command: "Get-ChildItem $env:USERPROFILE\\.synara" },
+      }),
+    ).toEqual({});
     expect(
       resolveGrokPlanHookResponse("default", {
         hookCallbackId: "synara-plan-guard",

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -100,6 +100,14 @@ describe("Grok native plan approval", () => {
         hookCallbackId: "synara-plan-guard",
         hookEventName: "pre_tool_use",
         toolName: "use_tool",
+        input: { tool_name: "synara__synara_context" },
+      }),
+    ).toEqual({});
+    expect(
+      resolveGrokPlanHookResponse("plan", {
+        hookCallbackId: "synara-plan-guard",
+        hookEventName: "pre_tool_use",
+        toolName: "use_tool",
         input: { name: "synara_create_threads" },
       }),
     ).toMatchObject({ decision: "deny" });

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -82,6 +82,28 @@ describe("Grok native plan approval", () => {
       }),
     ).toMatchObject({ decision: "deny" });
     expect(
+      resolveGrokPlanHookResponse("plan", {
+        hookCallbackId: "synara-plan-guard",
+        hookEventName: "pre_tool_use",
+        toolName: "synara_context",
+      }),
+    ).toEqual({});
+    expect(
+      resolveGrokPlanHookResponse("plan", {
+        hookCallbackId: "synara-plan-guard",
+        hookEventName: "pre_tool_use",
+        toolName: "use_tool",
+      }),
+    ).toEqual({});
+    expect(
+      resolveGrokPlanHookResponse("plan", {
+        hookCallbackId: "synara-plan-guard",
+        hookEventName: "pre_tool_use",
+        toolName: "use_tool",
+        input: { name: "synara_create_threads" },
+      }),
+    ).toMatchObject({ decision: "deny" });
+    expect(
       resolveGrokPlanHookResponse("default", {
         hookCallbackId: "synara-plan-guard",
         hookEventName: "pre_tool_use",
@@ -164,6 +186,14 @@ describe("Grok native plan approval", () => {
         interactionMode: "plan",
         capturedPlanFingerprint: "# Native plan",
         assistantText: "# Duplicate",
+      }),
+    ).toBeUndefined();
+    expect(
+      extractGrokTerminalPlanMarkdown({
+        interactionMode: "plan",
+        capturedPlanFingerprint: undefined,
+        assistantText: "Checking Synara context before planning.",
+        failedToolDetail: "User rejected the execution for tool 'use_tool'",
       }),
     ).toBeUndefined();
   });

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -69,6 +69,7 @@ import {
 } from "../Errors.ts";
 import {
   classifyAcpPromptTurnCompletion,
+  isAcpPlanModeInspectionToolCall,
   mapAcpToAdapterError,
   readAcpFailedToolDetail,
   resolveAcpPermissionPolicy,
@@ -266,8 +267,13 @@ export function extractGrokTerminalPlanMarkdown(input: {
   readonly interactionMode: ProviderInteractionMode | undefined;
   readonly capturedPlanFingerprint: string | undefined;
   readonly assistantText: string;
+  readonly failedToolDetail?: string | undefined;
 }): string | undefined {
-  if (input.interactionMode !== "plan" || input.capturedPlanFingerprint !== undefined) {
+  if (
+    input.interactionMode !== "plan" ||
+    input.capturedPlanFingerprint !== undefined ||
+    input.failedToolDetail?.trim()
+  ) {
     return undefined;
   }
   const planMarkdown = input.assistantText.trim();
@@ -291,7 +297,13 @@ export function resolveGrokPlanHookResponse(
   }
   const toolName =
     typeof payload.toolName === "string" ? payload.toolName.trim().toLowerCase() : "";
-  if (GROK_PLAN_READ_ONLY_TOOL_NAMES.has(toolName)) {
+  if (
+    GROK_PLAN_READ_ONLY_TOOL_NAMES.has(toolName) ||
+    isAcpPlanModeInspectionToolCall({
+      title: toolName || undefined,
+      rawInput: payload,
+    })
+  ) {
     return {};
   }
   return {
@@ -1229,6 +1241,7 @@ export function makeGrokAdapter(
                   runtimeMode: input.runtimeMode,
                   interactionMode: ctx?.activeInteractionMode,
                   options: params.options,
+                  toolCall: params.toolCall,
                 });
                 if (policyOutcome !== undefined) {
                   if (policyOutcome.outcome === "selected") {
@@ -1955,6 +1968,7 @@ export function makeGrokAdapter(
                   interactionMode: ctx.activeInteractionMode,
                   capturedPlanFingerprint: ctx.lastPlanFingerprint,
                   assistantText: ctx.activePlanResponseText,
+                  ...(failedToolDetail !== undefined ? { failedToolDetail } : {}),
                 });
                 if (terminalPlanMarkdown !== undefined) {
                   ctx.lastPlanFingerprint = terminalPlanMarkdown;

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -70,6 +70,7 @@ import {
 import {
   classifyAcpPromptTurnCompletion,
   isAcpPlanModeInspectionToolCall,
+  isAcpPlanModeShellToolName,
   mapAcpToAdapterError,
   readAcpFailedToolDetail,
   resolveAcpPermissionPolicy,
@@ -299,6 +300,7 @@ export function resolveGrokPlanHookResponse(
     typeof payload.toolName === "string" ? payload.toolName.trim().toLowerCase() : "";
   if (
     GROK_PLAN_READ_ONLY_TOOL_NAMES.has(toolName) ||
+    isAcpPlanModeShellToolName(toolName) ||
     isAcpPlanModeInspectionToolCall({
       title: toolName || undefined,
       rawInput: payload,

--- a/apps/server/src/provider/acp/AcpAdapterSupport.test.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSupport.test.ts
@@ -100,6 +100,14 @@ describe("AcpAdapterSupport", () => {
         options,
       }),
     ).toEqual({ outcome: "selected", optionId: "implement-once" });
+    expect(
+      resolveAcpPermissionPolicy({
+        runtimeMode: "full-access",
+        interactionMode: "plan",
+        options,
+        toolCall: { kind: "read", title: "synara_context" },
+      }),
+    ).toEqual({ outcome: "selected", optionId: "implement-once" });
   });
 
   it("surfaces Default prompts only for active approval-required turns", () => {

--- a/apps/server/src/provider/acp/AcpAdapterSupport.test.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSupport.test.ts
@@ -5,6 +5,7 @@ import {
   acpPermissionOutcome,
   canonicalItemTypeFromAcpToolKind,
   classifyAcpPromptTurnCompletion,
+  isAcpPlanModeInspectionToolCall,
   mapAcpToAdapterError,
   readAcpFailedToolDetail,
   resolveAcpFullAccessPermissionOutcome,
@@ -108,6 +109,32 @@ describe("AcpAdapterSupport", () => {
         toolCall: { kind: "read", title: "synara_context" },
       }),
     ).toEqual({ outcome: "selected", optionId: "implement-once" });
+    expect(
+      resolveAcpPermissionPolicy({
+        runtimeMode: "full-access",
+        interactionMode: "plan",
+        options,
+        toolCall: {
+          kind: "other",
+          title: "use_tool",
+          rawInput: { tool_name: "synara__synara_context", tool_input: {} },
+        },
+      }),
+    ).toEqual({ outcome: "selected", optionId: "implement-once" });
+    expect(
+      isAcpPlanModeInspectionToolCall({
+        kind: "other",
+        title: "synara__synara_context",
+        rawInput: { variant: "UseTool", tool_name: "synara__synara_context", tool_input: {} },
+      }),
+    ).toBe(true);
+    expect(
+      isAcpPlanModeInspectionToolCall({
+        kind: "execute",
+        title: "use_tool",
+        rawInput: { tool_name: "synara__synara_create_threads" },
+      }),
+    ).toBe(false);
   });
 
   it("surfaces Default prompts only for active approval-required turns", () => {

--- a/apps/server/src/provider/acp/AcpAdapterSupport.test.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSupport.test.ts
@@ -135,6 +135,35 @@ describe("AcpAdapterSupport", () => {
         rawInput: { tool_name: "synara__synara_create_threads" },
       }),
     ).toBe(false);
+    expect(
+      isAcpPlanModeInspectionToolCall({
+        kind: "execute",
+        title: "run_terminal_command",
+        rawInput: {
+          command:
+            'if (Test-Path "$env:USERPROFILE\\.synara") { Get-ChildItem "$env:USERPROFILE\\.synara" -Force | Select-Object Name, Mode, Length, LastWriteTime } else { Write-Output "NO_SYNARA_HOME" }',
+        },
+      }),
+    ).toBe(true);
+    expect(
+      resolveAcpPermissionPolicy({
+        runtimeMode: "full-access",
+        interactionMode: "plan",
+        options,
+        toolCall: {
+          kind: "execute",
+          title: "run_terminal_command",
+          rawInput: { command: "Get-ChildItem $env:USERPROFILE\\.synara -Force" },
+        },
+      }),
+    ).toEqual({ outcome: "selected", optionId: "implement-once" });
+    expect(
+      isAcpPlanModeInspectionToolCall({
+        kind: "execute",
+        title: "run_terminal_command",
+        rawInput: { command: 'Set-Content -Path README.md -Value "plan"' },
+      }),
+    ).toBe(false);
   });
 
   it("surfaces Default prompts only for active approval-required turns", () => {

--- a/apps/server/src/provider/acp/AcpAdapterSupport.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSupport.ts
@@ -307,7 +307,7 @@ export function isAcpPlanModeReadOnlyShellCommand(command: string): boolean {
 }
 
 export function isAcpPlanModeInspectionToolCall(toolCall: {
-  readonly kind?: string | undefined;
+  readonly kind?: string | null | undefined;
   readonly title?: string | null | undefined;
   readonly rawInput?: unknown;
 }): boolean {
@@ -365,7 +365,7 @@ export function resolveAcpPermissionPolicy(input: {
   readonly interactionMode: ProviderInteractionMode | undefined;
   readonly options: ReadonlyArray<AcpPermissionOptionLike>;
   readonly toolCall?: {
-    readonly kind?: string | undefined;
+    readonly kind?: string | null | undefined;
     readonly title?: string | null | undefined;
     readonly rawInput?: unknown;
   };

--- a/apps/server/src/provider/acp/AcpAdapterSupport.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSupport.ts
@@ -140,6 +140,119 @@ export function resolveAcpFullAccessPermissionOutcome(
   return optionId === undefined ? { outcome: "cancelled" } : { outcome: "selected", optionId };
 }
 
+const ACP_PLAN_MODE_INSPECTION_KINDS = new Set(["read", "search", "fetch", "think"]);
+const ACP_PLAN_MODE_MUTATING_KINDS = new Set(["execute", "edit", "delete", "move"]);
+const ACP_PLAN_MODE_MCP_WRAPPER_NAMES = new Set(["use_tool", "call_mcp_tool", "mcp_tool", "mcp"]);
+const ACP_PLAN_MODE_SYNARA_READ_TOOLS = new Set([
+  "synara_context",
+  "synara_capabilities",
+  "synara_overview",
+  "synara_list_allowed_projects",
+  "synara_list_projects",
+  "synara_list_threads",
+  "synara_read_thread",
+  "synara_read_thread_activity",
+  "synara_read_thread_events",
+  "synara_read_thread_runtime_events",
+  "synara_diagnose_thread",
+  "synara_wait_for_threads",
+  "synara_wait_for_task",
+  "synara_read_task",
+  "synara_list_automations",
+  "synara_view_automation",
+]);
+const ACP_PLAN_MODE_SYNARA_WRITE_TOOLS = new Set([
+  "synara_create_thread",
+  "synara_create_threads",
+  "synara_create_task",
+  "synara_send_message",
+  "synara_interrupt_thread",
+  "synara_set_thread_title",
+  "synara_set_thread_archived",
+  "synara_set_thread_goal",
+  "synara_create_automation",
+  "synara_update_automation",
+  "synara_update_automation_memory",
+  "synara_cancel_automation",
+  "synara_report_automation_result",
+]);
+
+function normalizeAcpPlanToolName(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function canonicalizeAcpPlanToolName(value: string): string {
+  const normalized = normalizeAcpPlanToolName(value);
+  if (normalized.startsWith("mcp_synara_synara_")) {
+    return `synara_${normalized.slice("mcp_synara_synara_".length)}`;
+  }
+  if (normalized.startsWith("mcp_synara_")) {
+    return `synara_${normalized.slice("mcp_synara_".length)}`;
+  }
+  if (normalized.startsWith("synara_synara_")) {
+    return `synara_${normalized.slice("synara_".length)}`;
+  }
+  return normalized;
+}
+
+function collectAcpPlanToolNameCandidates(value: unknown, depth = 0, into: string[] = []): string[] {
+  if (depth > 4 || into.length >= 16 || value == null) {
+    return into;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed && trimmed.length < 200) into.push(canonicalizeAcpPlanToolName(trimmed));
+    return into;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) collectAcpPlanToolNameCandidates(entry, depth + 1, into);
+    return into;
+  }
+  if (typeof value !== "object") {
+    return into;
+  }
+  const record = value as Record<string, unknown>;
+  for (const key of ["toolName", "tool_name", "name", "tool", "title"]) {
+    if (typeof record[key] === "string") {
+      into.push(canonicalizeAcpPlanToolName(record[key]));
+    }
+  }
+  for (const nested of ["input", "rawInput", "arguments", "params", "toolCall", "call"]) {
+    if (nested in record) collectAcpPlanToolNameCandidates(record[nested], depth + 1, into);
+  }
+  return into;
+}
+
+export function isAcpPlanModeInspectionToolCall(toolCall: {
+  readonly kind?: string | undefined;
+  readonly title?: string | null | undefined;
+  readonly rawInput?: unknown;
+}): boolean {
+  const kind = toolCall.kind?.trim().toLowerCase();
+  if (kind && ACP_PLAN_MODE_MUTATING_KINDS.has(kind)) {
+    return false;
+  }
+  const names = collectAcpPlanToolNameCandidates({
+    kind: toolCall.kind,
+    title: toolCall.title,
+    rawInput: toolCall.rawInput,
+  });
+  if (names.some((name) => ACP_PLAN_MODE_SYNARA_WRITE_TOOLS.has(name))) {
+    return false;
+  }
+  if (kind && ACP_PLAN_MODE_INSPECTION_KINDS.has(kind)) {
+    return true;
+  }
+  if (names.some((name) => ACP_PLAN_MODE_SYNARA_READ_TOOLS.has(name))) {
+    return true;
+  }
+  return names.length > 0 && names.every((name) => ACP_PLAN_MODE_MCP_WRAPPER_NAMES.has(name));
+}
+
 /**
  * Applies Synara's turn-scoped permission precedence to ACP reverse requests.
  *
@@ -147,13 +260,26 @@ export function resolveAcpFullAccessPermissionOutcome(
  * requests are cancelled so replay or late provider activity cannot inherit a
  * previous Plan turn or a future Full Access turn. Active adapters normalize
  * an omitted turn mode to `default` before dispatching the prompt.
+ *
+ * Plan mode stays fail-closed for mutating tools. Inspection tools (read,
+ * search, fetch, Synara context/MCP reads, and Grok's `use_tool` wrapper)
+ * may auto-allow so a Plan turn can look around without treating that as a
+ * user rejection.
  */
 export function resolveAcpPermissionPolicy(input: {
   readonly runtimeMode: RuntimeMode;
   readonly interactionMode: ProviderInteractionMode | undefined;
   readonly options: ReadonlyArray<AcpPermissionOptionLike>;
+  readonly toolCall?: {
+    readonly kind?: string | undefined;
+    readonly title?: string | null | undefined;
+    readonly rawInput?: unknown;
+  };
 }): AcpPermissionPolicyOutcome | undefined {
   if (input.interactionMode === "plan") {
+    if (input.toolCall && isAcpPlanModeInspectionToolCall(input.toolCall)) {
+      return resolveAcpFullAccessPermissionOutcome(input.options);
+    }
     const optionId = selectAcpPermissionOptionId("decline", input.options);
     return optionId === undefined ? { outcome: "cancelled" } : { outcome: "selected", optionId };
   }

--- a/apps/server/src/provider/acp/AcpAdapterSupport.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSupport.ts
@@ -239,7 +239,11 @@ function canonicalizeAcpPlanToolName(value: string): string {
   return normalized;
 }
 
-function collectAcpPlanToolNameCandidates(value: unknown, depth = 0, into: string[] = []): string[] {
+function collectAcpPlanToolNameCandidates(
+  value: unknown,
+  depth = 0,
+  into: string[] = [],
+): string[] {
   if (depth > 4 || into.length >= 16 || value == null) {
     return into;
   }

--- a/apps/server/src/provider/acp/AcpAdapterSupport.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSupport.ts
@@ -186,15 +186,13 @@ function normalizeAcpPlanToolName(value: string): string {
 }
 
 function canonicalizeAcpPlanToolName(value: string): string {
-  const normalized = normalizeAcpPlanToolName(value);
-  if (normalized.startsWith("mcp_synara_synara_")) {
-    return `synara_${normalized.slice("mcp_synara_synara_".length)}`;
-  }
+  let normalized = normalizeAcpPlanToolName(value);
   if (normalized.startsWith("mcp_synara_")) {
-    return `synara_${normalized.slice("mcp_synara_".length)}`;
+    normalized = `synara_${normalized.slice("mcp_synara_".length)}`;
   }
-  if (normalized.startsWith("synara_synara_")) {
-    return `synara_${normalized.slice("synara_".length)}`;
+  // Grok MCP exposes Synara tools as `synara__synara_context`.
+  while (normalized.startsWith("synara_synara_")) {
+    normalized = `synara_${normalized.slice("synara_synara_".length)}`;
   }
   return normalized;
 }
@@ -233,9 +231,6 @@ export function isAcpPlanModeInspectionToolCall(toolCall: {
   readonly rawInput?: unknown;
 }): boolean {
   const kind = toolCall.kind?.trim().toLowerCase();
-  if (kind && ACP_PLAN_MODE_MUTATING_KINDS.has(kind)) {
-    return false;
-  }
   const names = collectAcpPlanToolNameCandidates({
     kind: toolCall.kind,
     title: toolCall.title,
@@ -244,13 +239,19 @@ export function isAcpPlanModeInspectionToolCall(toolCall: {
   if (names.some((name) => ACP_PLAN_MODE_SYNARA_WRITE_TOOLS.has(name))) {
     return false;
   }
-  if (kind && ACP_PLAN_MODE_INSPECTION_KINDS.has(kind)) {
-    return true;
-  }
   if (names.some((name) => ACP_PLAN_MODE_SYNARA_READ_TOOLS.has(name))) {
     return true;
   }
-  return names.length > 0 && names.every((name) => ACP_PLAN_MODE_MCP_WRAPPER_NAMES.has(name));
+  if (names.length > 0 && names.every((name) => ACP_PLAN_MODE_MCP_WRAPPER_NAMES.has(name))) {
+    return true;
+  }
+  if (kind && ACP_PLAN_MODE_INSPECTION_KINDS.has(kind)) {
+    return true;
+  }
+  if (kind && ACP_PLAN_MODE_MUTATING_KINDS.has(kind)) {
+    return false;
+  }
+  return false;
 }
 
 /**

--- a/apps/server/src/provider/acp/AcpAdapterSupport.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSupport.ts
@@ -143,6 +143,48 @@ export function resolveAcpFullAccessPermissionOutcome(
 const ACP_PLAN_MODE_INSPECTION_KINDS = new Set(["read", "search", "fetch", "think"]);
 const ACP_PLAN_MODE_MUTATING_KINDS = new Set(["execute", "edit", "delete", "move"]);
 const ACP_PLAN_MODE_MCP_WRAPPER_NAMES = new Set(["use_tool", "call_mcp_tool", "mcp_tool", "mcp"]);
+const ACP_PLAN_MODE_SHELL_TOOL_NAMES = new Set([
+  "run_terminal_command",
+  "run_terminal_cmd",
+  "bash",
+  "shell",
+  "sh",
+  "zsh",
+  "powershell",
+  "pwsh",
+  "cmd",
+  "terminal",
+]);
+const ACP_PLAN_MODE_GENERIC_READ_TOOLS = new Set([
+  "ask_user_question",
+  "enter_plan_mode",
+  "exit_plan_mode",
+  "fetch_mcp_resource",
+  "get_command_or_subagent_output",
+  "get_task_output",
+  "get_terminal_command_output",
+  "grep",
+  "hashline_grep",
+  "hashline_read",
+  "list_dir",
+  "list_mcp_resources",
+  "lsp",
+  "memory_get",
+  "memory_search",
+  "read_file",
+  "scheduler_list",
+  "search_tool",
+  "skill",
+  "todo_write",
+  "update_goal",
+  "wait_tasks",
+  "web_fetch",
+  "web_search",
+]);
+const ACP_PLAN_MODE_SHELL_INSPECTION_RE =
+  /\b(?:Get-ChildItem|Get-Content|Get-Item|Get-Acl|Get-Location|Get-Command|Get-Help|Get-Process|Get-Date|Test-Path|Select-Object|Select-String|Format-Table|Format-List|Format-Wide|Measure-Object|Write-Output|Write-Host|ForEach-Object|Where-Object|Sort-Object|Out-String|gci|gc|gi|pwd|ls|dir|cat|type|head|tail|tree|whoami|hostname|uname|printenv|findstr|rg|grep|echo|git\s+(?:status|log|diff|show|branch|rev-parse|ls-files|describe))\b/iu;
+const ACP_PLAN_MODE_SHELL_MUTATION_RE =
+  /(?:^|[\n;&|])\s*(?:Remove-Item|New-Item|Set-Content|Add-Content|Out-File|Copy-Item|Move-Item|Rename-Item|Clear-Content|Set-Item(?:Property)?|New-ItemProperty|Start-Process|Stop-Process|Invoke-Expression|Invoke-WebRequest|Invoke-RestMethod)\b|\b(?:rmdir|mkdir)\b|\b(?:rm|del|erase|rd|md|ren)\s+|\b(?:copy|move)\s+(?:\/|-|\S)|\b(?:git\s+(?:add|commit|push|checkout|reset|rebase|merge|rm|mv|restore|clean))\b|\b(?:npm|pnpm|yarn|bun)\s+(?:i|install|add|remove|uninstall)\b|\b(?:pip|uv)\s+install\b|\b(?:python|py|node|bun|deno)\s+-[ec]\b|\b(?:curl|wget)\b.+\s(?:-o|-O|--output)\b|(?:^|[^=<>])>(?!>)|>>/iu;
 const ACP_PLAN_MODE_SYNARA_READ_TOOLS = new Set([
   "synara_context",
   "synara_capabilities",
@@ -225,6 +267,41 @@ function collectAcpPlanToolNameCandidates(value: unknown, depth = 0, into: strin
   return into;
 }
 
+function extractAcpPlanShellCommand(value: unknown, depth = 0): string | undefined {
+  if (depth > 4 || value == null) {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  for (const key of ["command", "cmd", "script", "code"]) {
+    if (typeof record[key] === "string" && record[key].trim()) {
+      return record[key].trim();
+    }
+  }
+  for (const nested of ["input", "rawInput", "arguments", "params", "tool_input"]) {
+    const found = extractAcpPlanShellCommand(record[nested], depth + 1);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+export function isAcpPlanModeShellToolName(name: string): boolean {
+  return ACP_PLAN_MODE_SHELL_TOOL_NAMES.has(normalizeAcpPlanToolName(name));
+}
+
+export function isAcpPlanModeReadOnlyShellCommand(command: string): boolean {
+  const text = command.trim();
+  if (!text) return false;
+  if (ACP_PLAN_MODE_SHELL_MUTATION_RE.test(text)) return false;
+  return ACP_PLAN_MODE_SHELL_INSPECTION_RE.test(text);
+}
+
 export function isAcpPlanModeInspectionToolCall(toolCall: {
   readonly kind?: string | undefined;
   readonly title?: string | null | undefined;
@@ -242,7 +319,18 @@ export function isAcpPlanModeInspectionToolCall(toolCall: {
   if (names.some((name) => ACP_PLAN_MODE_SYNARA_READ_TOOLS.has(name))) {
     return true;
   }
+  if (names.some((name) => ACP_PLAN_MODE_GENERIC_READ_TOOLS.has(name))) {
+    return true;
+  }
   if (names.length > 0 && names.every((name) => ACP_PLAN_MODE_MCP_WRAPPER_NAMES.has(name))) {
+    return true;
+  }
+  const command = extractAcpPlanShellCommand(toolCall.rawInput);
+  if (
+    (names.some((name) => ACP_PLAN_MODE_SHELL_TOOL_NAMES.has(name)) || kind === "execute") &&
+    command !== undefined &&
+    isAcpPlanModeReadOnlyShellCommand(command)
+  ) {
     return true;
   }
   if (kind && ACP_PLAN_MODE_INSPECTION_KINDS.has(kind)) {
@@ -263,9 +351,10 @@ export function isAcpPlanModeInspectionToolCall(toolCall: {
  * an omitted turn mode to `default` before dispatching the prompt.
  *
  * Plan mode stays fail-closed for mutating tools. Inspection tools (read,
- * search, fetch, Synara context/MCP reads, and Grok's `use_tool` wrapper)
- * may auto-allow so a Plan turn can look around without treating that as a
- * user rejection.
+ * search, fetch, Synara context/MCP reads, Grok's `use_tool` wrapper, and
+ * read-only shell lookups) may auto-allow so a Plan turn can look around
+ * without treating that as a user rejection. Grok cancels the whole turn
+ * when a permission is declined, so inspection shells must not be rejected.
  */
 export function resolveAcpPermissionPolicy(input: {
   readonly runtimeMode: RuntimeMode;

--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -287,6 +287,33 @@ describe("Grok ACP permission policy", () => {
         runtimeMode: "full-access",
         interactionMode: "plan",
         options,
+        toolCall: {
+          kind: "execute",
+          title: "run_terminal_command",
+          rawInput: {
+            command:
+              'if (Test-Path "$env:USERPROFILE\\.synara") { Get-ChildItem "$env:USERPROFILE\\.synara" -Force | Select-Object Name } else { Write-Output "NO_SYNARA_HOME" }',
+          },
+        },
+      }),
+    ).toEqual({ outcome: "selected", optionId: "allow-once" });
+    expect(
+      resolveAcpPermissionPolicy({
+        runtimeMode: "full-access",
+        interactionMode: "plan",
+        options,
+        toolCall: {
+          kind: "execute",
+          title: "run_terminal_command",
+          rawInput: { command: "Remove-Item -Recurse -Force .synara" },
+        },
+      }),
+    ).toEqual({ outcome: "selected", optionId: "reject-once" });
+    expect(
+      resolveAcpPermissionPolicy({
+        runtimeMode: "full-access",
+        interactionMode: "plan",
+        options,
         toolCall: { title: "use_tool", rawInput: { name: "synara_create_threads" } },
       }),
     ).toEqual({ outcome: "selected", optionId: "reject-once" });

--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -252,6 +252,33 @@ describe("Grok ACP permission policy", () => {
       }),
     ).toEqual({ outcome: "selected", optionId: "reject-once" });
   });
+
+  it("auto-allows Plan-mode inspection tools instead of treating them as a user rejection", () => {
+    expect(
+      resolveAcpPermissionPolicy({
+        runtimeMode: "full-access",
+        interactionMode: "plan",
+        options,
+        toolCall: { title: "use_tool", rawInput: { name: "synara_context" } },
+      }),
+    ).toEqual({ outcome: "selected", optionId: "allow-once" });
+    expect(
+      resolveAcpPermissionPolicy({
+        runtimeMode: "full-access",
+        interactionMode: "plan",
+        options,
+        toolCall: { kind: "execute", title: "Shell" },
+      }),
+    ).toEqual({ outcome: "selected", optionId: "reject-once" });
+    expect(
+      resolveAcpPermissionPolicy({
+        runtimeMode: "full-access",
+        interactionMode: "plan",
+        options,
+        toolCall: { title: "use_tool", rawInput: { name: "synara_create_threads" } },
+      }),
+    ).toEqual({ outcome: "selected", optionId: "reject-once" });
+  });
 });
 
 describe("applyGrokAcpModelSelection", () => {

--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -267,6 +267,18 @@ describe("Grok ACP permission policy", () => {
         runtimeMode: "full-access",
         interactionMode: "plan",
         options,
+        toolCall: {
+          kind: "other",
+          title: "use_tool",
+          rawInput: { tool_name: "synara__synara_context", tool_input: {} },
+        },
+      }),
+    ).toEqual({ outcome: "selected", optionId: "allow-once" });
+    expect(
+      resolveAcpPermissionPolicy({
+        runtimeMode: "full-access",
+        interactionMode: "plan",
+        options,
         toolCall: { kind: "execute", title: "Shell" },
       }),
     ).toEqual({ outcome: "selected", optionId: "reject-once" });


### PR DESCRIPTION
## What Changed

Plan mode no longer auto-declines the inspection tools Grok needs to write a real plan. The shared ACP permission policy now auto-allows read/search/fetch, Synara context/MCP reads (including Grok's `synara__synara_context` name), Grok's `use_tool` wrapper when the inner tool is not a write, and read-only shells such as `Get-ChildItem` / `ls`. Writes, installs, and mutating shells stay declined.

Cursor and Droid permission handlers now pass `toolCall` into the same policy so inspection can be classified there instead of only from the tool name.

## Why

Grok treats a declined permission as a user rejection and cancels the whole turn. Fail-closed Plan mode was aborting `/plan` on read-only lookups, so Grok never reached a Proposed plan. Inspection has to be allowed; mutating tools must stay blocked.

## Verification

- [x] `bun run --cwd apps/server test src/provider/acp/AcpAdapterSupport.test.ts src/provider/acp/GrokAcpSupport.test.ts src/provider/Layers/GrokAdapter.test.ts` (53 passed)
- [x] `bun run --cwd apps/server typecheck`
- [x] `bun lint` (0 errors; existing warnings only)
- [ ] In Synara, start a Grok thread, run `/plan`, and confirm it can inspect the repo and finish a Proposed plan
- [ ] Confirm a mutating Plan-mode tool (write / `Remove-Item` / `Set-Content`) is still declined

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Made with [Cursor](https://cursor.com)