### PR TITLE
Resume Antigravity print-mode turns from the brain conversation id

### DIFF
--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -24,6 +24,9 @@ import {
   buildAntigravityTurnProcessEnvironment,
   buildAntigravityTurnPrompt,
   ensureCapturePlugin,
+  discoverAntigravityConversationId,
+  extractAntigravityConversationId,
+  extractAntigravityConversationIdFromText,
   hookScriptSource,
   makeAntigravityRuntimeEventBase,
   makeAntigravityAdapterLive,
@@ -897,6 +900,242 @@ describe("Antigravity turn settle on cancel (#465)", () => {
             }).pipe(
               Layer.provideMerge(
                 ServerConfig.layerTest(root, { prefix: "antigravity-interrupt-hung-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("Antigravity conversation resume", () => {
+  it("reads conversation ids from nested hook payloads and CLI logs", () => {
+    expect(
+      extractAntigravityConversationId({
+        session: { conversationId: "conv-from-session" },
+      }),
+    ).toBe("conv-from-session");
+    expect(
+      extractAntigravityConversationIdFromText(
+        'opened ~/.gemini/antigravity-cli/brain/conv-from-brain/.system_generated/logs/transcript.jsonl',
+      ),
+    ).toBe("conv-from-brain");
+    expect(extractAntigravityConversationIdFromText('conversationId: "conv-from-log"')).toBe(
+      "conv-from-log",
+    );
+  });
+
+  it("prefers a cwd-matched new brain directory over other new conversations", () => {
+    expect(
+      discoverAntigravityConversationId({
+        before: new Map([["old-conv-1", 1]]),
+        after: new Map([
+          ["old-conv-1", 1],
+          ["conv-other", 3],
+          ["conv-cwd-id", 2],
+        ]),
+        lastConversationIdBefore: "old-conv-1",
+        lastConversationIdAfter: "conv-cwd-id",
+      }),
+    ).toBe("conv-cwd-id");
+  });
+
+  it("falls back to the newest new brain directory when the cwd cache is stale", () => {
+    expect(
+      discoverAntigravityConversationId({
+        before: new Map(),
+        after: new Map([
+          ["conv-older", 10],
+          ["conv-newer", 20],
+        ]),
+      }),
+    ).toBe("conv-newer");
+  });
+
+  it("reuses the learned conversation id on the next print-mode turn", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-resume-"));
+    const spawnedArgs: string[][] = [];
+    let processSequence = 0;
+    const spawnProcess = ((
+      _command: string,
+      args: readonly string[],
+      options: { readonly env?: NodeJS.ProcessEnv },
+    ) => {
+      spawnedArgs.push([...args]);
+      const eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS;
+      const child = new EventEmitter() as ChildProcess;
+      Object.assign(child, {
+        pid: 20_000 + ++processSequence,
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        killed: false,
+        kill: () => true,
+      });
+      setTimeout(() => {
+        if (eventFile && spawnedArgs.length === 1) {
+          void fs
+            .appendFile(eventFile, 'stop\t{"session":{"conversationId":"conv-keep"}}\n')
+            .then(() => child.emit("close", 0, null));
+          return;
+        }
+        child.emit("close", 0, null);
+      }, 40).unref();
+      return child;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-resume");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+          const waitUntilReady = Effect.gen(function* () {
+            for (let attempt = 0; attempt < 100; attempt += 1) {
+              const session = (yield* adapter.listSessions()).find(
+                (candidate) => candidate.threadId === threadId,
+              );
+              if (session?.status === "ready" && session.resumeCursor !== undefined) return;
+              yield* Effect.sleep(10);
+            }
+            throw new Error("Antigravity resume test turn did not settle.");
+          });
+
+          yield* adapter.sendTurn({ threadId, input: "shall we do this?", attachments: [] });
+          yield* waitUntilReady;
+          expect(spawnedArgs[0]).toContain("--new-project");
+          expect(spawnedArgs[0]).not.toContain("--conversation");
+
+          yield* adapter.sendTurn({ threadId, input: "yes, do that", attachments: [] });
+          yield* Effect.gen(function* () {
+            for (let attempt = 0; attempt < 100; attempt += 1) {
+              if (spawnedArgs.length >= 2) return;
+              yield* Effect.sleep(10);
+            }
+            throw new Error("Antigravity follow-up turn did not spawn.");
+          });
+          const conversationIndex = spawnedArgs[1]?.indexOf("--conversation") ?? -1;
+          expect(conversationIndex).toBeGreaterThanOrEqual(0);
+          expect(spawnedArgs[1]?.[conversationIndex + 1]).toBe("conv-keep");
+          expect(spawnedArgs[1]).not.toContain("--new-project");
+          const waitUntilFollowUpReady = Effect.gen(function* () {
+            for (let attempt = 0; attempt < 100; attempt += 1) {
+              const session = (yield* adapter.listSessions()).find(
+                (candidate) => candidate.threadId === threadId,
+              );
+              if (session?.status === "ready") return;
+              yield* Effect.sleep(10);
+            }
+            throw new Error("Antigravity follow-up turn did not settle.");
+          });
+          yield* waitUntilFollowUpReady;
+          yield* adapter.stopSession(threadId);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+            }).pipe(
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-resume-test-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("learns the conversation id from the new brain directory when hooks omit it", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-brain-"));
+    const brainRoot = path.join(root, "brain");
+    await fs.mkdir(brainRoot, { recursive: true });
+    const spawnedArgs: string[][] = [];
+    let processSequence = 0;
+    const spawnProcess = ((
+      _command: string,
+      args: readonly string[],
+    ) => {
+      spawnedArgs.push([...args]);
+      const child = new EventEmitter() as ChildProcess;
+      Object.assign(child, {
+        pid: 21_000 + ++processSequence,
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        killed: false,
+        kill: () => true,
+      });
+      setTimeout(() => {
+        if (spawnedArgs.length === 1) {
+          void fs.mkdir(path.join(brainRoot, "conv-brain1")).then(() => child.emit("close", 0, null));
+          return;
+        }
+        child.emit("close", 0, null);
+      }, 40).unref();
+      return child;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-brain");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+          const waitUntilReady = Effect.gen(function* () {
+            for (let attempt = 0; attempt < 100; attempt += 1) {
+              const session = (yield* adapter.listSessions()).find(
+                (candidate) => candidate.threadId === threadId,
+              );
+              if (session?.status === "ready" && session.resumeCursor !== undefined) return;
+              yield* Effect.sleep(10);
+            }
+            throw new Error("Antigravity brain-dir resume test turn did not settle.");
+          });
+
+          yield* adapter.sendTurn({ threadId, input: "propose three ideas", attachments: [] });
+          yield* waitUntilReady;
+          expect(spawnedArgs[0]).toContain("--new-project");
+
+          yield* adapter.sendTurn({ threadId, input: "what about the third?", attachments: [] });
+          yield* Effect.gen(function* () {
+            for (let attempt = 0; attempt < 100; attempt += 1) {
+              if (spawnedArgs.length >= 2) return;
+              yield* Effect.sleep(10);
+            }
+            throw new Error("Antigravity brain-dir follow-up turn did not spawn.");
+          });
+          const conversationIndex = spawnedArgs[1]?.indexOf("--conversation") ?? -1;
+          expect(conversationIndex).toBeGreaterThanOrEqual(0);
+          expect(spawnedArgs[1]?.[conversationIndex + 1]).toBe("conv-brain1");
+          expect(spawnedArgs[1]).not.toContain("--new-project");
+          yield* adapter.stopSession(threadId);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+              brainRoot,
+            }).pipe(
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-brain-resume-" }),
               ),
               Layer.provideMerge(NodeServices.layer),
             ),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -147,8 +147,7 @@ function resumeConversationId(value: unknown): string | undefined {
 const ANTIGRAVITY_CONVERSATION_ID_PATTERN = /^[A-Za-z0-9._-]{8,}$/;
 const ANTIGRAVITY_CONVERSATION_KEY_IN_TEXT =
   /(?:conversationId|conversation_id)\s*[:=]\s*["']?([A-Za-z0-9._-]{8,})/i;
-const ANTIGRAVITY_BRAIN_CONVERSATION_IN_TEXT =
-  /antigravity-cli[/\\]brain[/\\]([A-Za-z0-9._-]{8,})/;
+const ANTIGRAVITY_BRAIN_CONVERSATION_IN_TEXT = /antigravity-cli[/\\]brain[/\\]([A-Za-z0-9._-]{8,})/;
 
 function asAntigravityConversationId(value: string | undefined): string | undefined {
   const trimmed = value?.trim();

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -144,17 +144,138 @@ function resumeConversationId(value: unknown): string | undefined {
   return undefined;
 }
 
-function transcriptPathForConversation(conversationId: string): string {
+const ANTIGRAVITY_CONVERSATION_ID_PATTERN = /^[A-Za-z0-9._-]{8,}$/;
+const ANTIGRAVITY_CONVERSATION_KEY_IN_TEXT =
+  /(?:conversationId|conversation_id)\s*[:=]\s*["']?([A-Za-z0-9._-]{8,})/i;
+const ANTIGRAVITY_BRAIN_CONVERSATION_IN_TEXT =
+  /antigravity-cli[/\\]brain[/\\]([A-Za-z0-9._-]{8,})/;
+
+function asAntigravityConversationId(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && ANTIGRAVITY_CONVERSATION_ID_PATTERN.test(trimmed) ? trimmed : undefined;
+}
+
+/** Read a conversation id from hook payloads, including nested session objects. */
+export function extractAntigravityConversationId(value: unknown): string | undefined {
+  if (typeof value === "string") return asAntigravityConversationId(value);
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  for (const key of ["conversationId", "conversation_id", "providerThreadId"]) {
+    const found = extractAntigravityConversationId(record[key]);
+    if (found) return found;
+  }
+  for (const nestedKey of ["session", "conversation", "payload"]) {
+    const found = extractAntigravityConversationId(record[nestedKey]);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+/** Recover a conversation id from `agy` logs or print-mode stdout. */
+export function extractAntigravityConversationIdFromText(text: string): string | undefined {
+  return (
+    asAntigravityConversationId(text.match(ANTIGRAVITY_CONVERSATION_KEY_IN_TEXT)?.[1]) ??
+    asAntigravityConversationId(text.match(ANTIGRAVITY_BRAIN_CONVERSATION_IN_TEXT)?.[1])
+  );
+}
+
+export function antigravityCliHome(homeDir: string = os.homedir()): string {
+  return path.join(homeDir, ".gemini", "antigravity-cli");
+}
+
+export function antigravityBrainRoot(homeDir: string = os.homedir()): string {
+  return path.join(antigravityCliHome(homeDir), "brain");
+}
+
+export function antigravityLastConversationsPath(homeDir: string = os.homedir()): string {
+  return path.join(antigravityCliHome(homeDir), "cache", "last_conversations.json");
+}
+
+function transcriptPathForConversation(
+  conversationId: string,
+  brainRoot: string = antigravityBrainRoot(),
+): string {
   return path.join(
-    os.homedir(),
-    ".gemini",
-    "antigravity-cli",
-    "brain",
+    brainRoot,
     conversationId,
     ".system_generated",
     "logs",
     "transcript.jsonl",
   );
+}
+
+/** Map of conversation id → directory mtime, for print-mode resume set-diff. */
+export async function listAntigravityBrainConversationIds(
+  brainRoot: string,
+): Promise<Map<string, number>> {
+  const result = new Map<string, number>();
+  let entries: Awaited<ReturnType<typeof fs.readdir>>;
+  try {
+    entries = await fs.readdir(brainRoot, { withFileTypes: true });
+  } catch {
+    return result;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const id = asAntigravityConversationId(entry.name);
+    if (!id) continue;
+    try {
+      const stats = await fs.stat(path.join(brainRoot, entry.name));
+      result.set(id, stats.mtimeMs);
+    } catch {
+      // Directory vanished between readdir and stat.
+    }
+  }
+  return result;
+}
+
+export async function readAntigravityLastConversationId(
+  cachePath: string,
+  cwd: string,
+): Promise<string | undefined> {
+  try {
+    const parsed: unknown = JSON.parse(await fs.readFile(cachePath, "utf8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+    const record = parsed as Record<string, unknown>;
+    const direct = record[cwd];
+    if (typeof direct === "string") return asAntigravityConversationId(direct);
+    const normalized = path.resolve(cwd);
+    for (const [key, value] of Object.entries(record)) {
+      if (typeof value !== "string") continue;
+      if (path.resolve(key) === normalized) return asAntigravityConversationId(value);
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Print-mode `agy -p` does not put conversationId on stdout. The durable id is
+ * the new `brain/<id>` directory (and `last_conversations.json` for the cwd).
+ */
+export function discoverAntigravityConversationId(input: {
+  readonly before: ReadonlyMap<string, number>;
+  readonly after: ReadonlyMap<string, number>;
+  readonly lastConversationIdBefore?: string;
+  readonly lastConversationIdAfter?: string;
+}): string | undefined {
+  const added = [...input.after.keys()].filter((id) => !input.before.has(id));
+  if (input.lastConversationIdAfter && added.includes(input.lastConversationIdAfter)) {
+    return input.lastConversationIdAfter;
+  }
+  if (added.length > 0) {
+    return added
+      .map((id) => ({ id, mtime: input.after.get(id) ?? 0 }))
+      .sort((left, right) => right.mtime - left.mtime)[0]?.id;
+  }
+  if (
+    input.lastConversationIdAfter &&
+    input.lastConversationIdAfter !== input.lastConversationIdBefore
+  ) {
+    return input.lastConversationIdAfter;
+  }
+  return undefined;
 }
 
 function shellQuote(value: string, platform: NodeJS.Platform = process.platform): string {
@@ -592,6 +713,8 @@ export interface AntigravityAdapterDependencies {
     args: readonly string[],
     options: SpawnOptions,
   ) => AntigravityChildProcess;
+  readonly brainRoot?: string;
+  readonly lastConversationsPath?: string;
 }
 
 const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {}) =>
@@ -654,6 +777,74 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       return context
         ? Effect.succeed(context)
         : Effect.fail(new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }));
+    };
+
+    const brainRoot = dependencies.brainRoot ?? antigravityBrainRoot();
+    const lastConversationsPath =
+      dependencies.lastConversationsPath ?? antigravityLastConversationsPath();
+
+    const rememberConversation = (
+      context: AntigravitySessionContext,
+      conversationId: string,
+      source: string,
+      payload: unknown = { conversationId },
+    ) => {
+      const learned = conversationId !== context.conversationId;
+      context.conversationId = conversationId;
+      if (!context.transcriptPath) {
+        context.transcriptPath = transcriptPathForConversation(conversationId, brainRoot);
+      }
+      if (!learned) return;
+      context.session = {
+        ...context.session,
+        resumeCursor: conversationId,
+        updatedAt: new Date().toISOString(),
+      };
+      offer({
+        ...base(context, { includeTurn: false }),
+        type: "thread.started",
+        payload: { providerThreadId: conversationId },
+        raw: raw(source, payload),
+      } satisfies ProviderRuntimeEvent);
+    };
+
+    const learnConversationFromTurnArtifacts = async (
+      context: AntigravitySessionContext,
+      artifacts: {
+        readonly logFile: string;
+        readonly stdout: string;
+        readonly brainBefore: ReadonlyMap<string, number>;
+        readonly lastConversationIdBefore?: string;
+      },
+    ) => {
+      if (context.conversationId) return;
+      const brainAfter = await listAntigravityBrainConversationIds(brainRoot);
+      const lastConversationIdAfter = await readAntigravityLastConversationId(
+        lastConversationsPath,
+        context.session.cwd ?? "",
+      );
+      const fromBrain = discoverAntigravityConversationId({
+        before: artifacts.brainBefore,
+        after: brainAfter,
+        lastConversationIdBefore: artifacts.lastConversationIdBefore,
+        lastConversationIdAfter,
+      });
+      if (fromBrain) {
+        rememberConversation(context, fromBrain, "brain-dir");
+        return;
+      }
+      try {
+        const logText = await fs.readFile(artifacts.logFile, "utf8");
+        const fromLog = extractAntigravityConversationIdFromText(logText);
+        if (fromLog) {
+          rememberConversation(context, fromLog, "log-file");
+          return;
+        }
+      } catch {
+        // The CLI log is best-effort; the brain directory is the primary source.
+      }
+      const fromStdout = extractAntigravityConversationIdFromText(artifacts.stdout);
+      if (fromStdout) rememberConversation(context, fromStdout, "stdout");
     };
 
     const releaseTurnGatewayLease = (
@@ -867,32 +1058,17 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         } catch {
           continue;
         }
-        const conversationId =
-          typeof payload.conversationId === "string" ? payload.conversationId : undefined;
+        const conversationId = extractAntigravityConversationId(payload);
         const transcriptPath =
           typeof payload.transcriptPath === "string" ? payload.transcriptPath : undefined;
         const modelName = typeof payload.modelName === "string" ? payload.modelName : undefined;
-        const learnedConversation = conversationId && conversationId !== context.conversationId;
-        if (conversationId) context.conversationId = conversationId;
+        if (conversationId) rememberConversation(context, conversationId, eventName, payload);
         if (transcriptPath && transcriptPath !== context.transcriptPath) {
           context.transcriptPath = transcriptPath;
           context.processedTranscriptBytes = 0;
           delete context.processedTranscriptPath;
         }
         if (modelName) context.modelName = modelName;
-        if (learnedConversation) {
-          context.session = {
-            ...context.session,
-            resumeCursor: conversationId,
-            updatedAt: new Date().toISOString(),
-          };
-          offer({
-            ...base(context, { includeTurn: false }),
-            type: "thread.started",
-            payload: { providerThreadId: conversationId },
-            raw: raw(eventName, payload),
-          } satisfies ProviderRuntimeEvent);
-        }
         const stepIndex =
           typeof payload.stepIdx === "number" &&
           Number.isInteger(payload.stepIdx) &&
@@ -1031,7 +1207,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           ...(conversationId ? { conversationId } : {}),
           ...(modelSelection?.options ? { modelOptions: modelSelection.options } : {}),
           ...(conversationId
-            ? { transcriptPath: transcriptPathForConversation(conversationId) }
+            ? { transcriptPath: transcriptPathForConversation(conversationId, brainRoot) }
             : {}),
           processedHookBytes: 0,
           processedTranscriptBytes: 0,
@@ -1176,6 +1352,15 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         } satisfies ProviderRuntimeEvent);
 
         const conversationId = context.conversationId;
+        const cwd = context.session.cwd ?? serverConfig.cwd;
+        const brainBefore = conversationId
+          ? new Map<string, number>()
+          : yield* Effect.promise(() => listAntigravityBrainConversationIds(brainRoot));
+        const lastConversationIdBefore = conversationId
+          ? undefined
+          : yield* Effect.promise(() =>
+              readAntigravityLastConversationId(lastConversationsPath, cwd),
+            );
         const args: string[] = [
           ...(conversationId ? ["--conversation", conversationId] : ["--new-project"]),
           "--dangerously-skip-permissions",
@@ -1195,7 +1380,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
             ((command: string, spawnArgs: readonly string[], options: SpawnOptions) =>
               spawn(command, spawnArgs, options) as AntigravityChildProcess);
           child = spawnProcess(context.binaryPath, args, {
-            cwd: context.session.cwd ?? serverConfig.cwd,
+            cwd,
             env: buildAntigravityTurnProcessEnvironment({
               eventFile,
               ...(gatewaySessionLease && gatewayBootstrapToken
@@ -1267,6 +1452,12 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
             // into the next turn's authority.
             releaseTurnGatewayLease(context, gatewaySessionLease);
             await pollHookFile(context).catch(() => undefined);
+            await learnConversationFromTurnArtifacts(context, {
+              logFile,
+              stdout,
+              brainBefore,
+              lastConversationIdBefore,
+            }).catch(() => undefined);
             if (!ownsTurn()) {
               await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
               return;

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -208,9 +208,9 @@ export async function listAntigravityBrainConversationIds(
   brainRoot: string,
 ): Promise<Map<string, number>> {
   const result = new Map<string, number>();
-  let entries: Awaited<ReturnType<typeof fs.readdir>>;
+  let entries: ReadonlyArray<{ readonly name: string; isDirectory(): boolean }>;
   try {
-    entries = await fs.readdir(brainRoot, { withFileTypes: true });
+    entries = await fs.readdir(brainRoot, { encoding: "utf8", withFileTypes: true });
   } catch {
     return result;
   }
@@ -256,8 +256,8 @@ export async function readAntigravityLastConversationId(
 export function discoverAntigravityConversationId(input: {
   readonly before: ReadonlyMap<string, number>;
   readonly after: ReadonlyMap<string, number>;
-  readonly lastConversationIdBefore?: string;
-  readonly lastConversationIdAfter?: string;
+  readonly lastConversationIdBefore?: string | undefined;
+  readonly lastConversationIdAfter?: string | undefined;
 }): string | undefined {
   const added = [...input.after.keys()].filter((id) => !input.before.has(id));
   if (input.lastConversationIdAfter && added.includes(input.lastConversationIdAfter)) {
@@ -813,7 +813,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         readonly logFile: string;
         readonly stdout: string;
         readonly brainBefore: ReadonlyMap<string, number>;
-        readonly lastConversationIdBefore?: string;
+        readonly lastConversationIdBefore?: string | undefined;
       },
     ) => {
       if (context.conversationId) return;


### PR DESCRIPTION
## What Changed

Antigravity print-mode (`agy -p`) now learns the CLI conversation id after the first turn and reuses `--conversation` on later turns. The adapter snapshots `~/.gemini/antigravity-cli/brain` before spawn, set-diffs new conversation directories after the process exits, and also consults `last_conversations.json` for the current cwd.

## Why

Each print-mode turn starts a new process. Without `--conversation`, later turns had no history, so Antigravity looked like it forgot the thread. The real ids live in the brain directories, not in a stable CLI flag on first launch.

## Verification

- [x] `bun run --cwd apps/server test src/provider/Layers/AntigravityAdapter.test.ts`: 25 passed, including the new resume tests. The 2 remaining failures are the pre-existing Windows `cmd.exe` hook-quoting cases; they also fail on current `main` and are unrelated to this change (CI is Linux).
- [x] `bun run --cwd apps/server typecheck`
- [x] `bun lint` (0 errors; existing warnings only)
- [ ] In Synara, start an Antigravity thread, send a turn that establishes context, send a follow-up that depends on that context, and confirm the second turn still knows the first

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Made with [Cursor](https://cursor.com)