### PR TITLE
Keep AgentGateway grok tests on the default model

### DIFF
--- a/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
@@ -15,6 +15,7 @@ import type {
 import {
   AutomationId,
   DEFAULT_AUTOMATION_STOP_CONFIDENCE_THRESHOLD,
+  DEFAULT_MODEL_BY_PROVIDER,
   EventId,
   MessageId,
   ModelSelection,
@@ -809,7 +810,7 @@ function makeHarnessLayer(
             ],
           },
         ],
-        grok: [{ slug: "grok-build", name: "Grok Build" }],
+        grok: [{ slug: DEFAULT_MODEL_BY_PROVIDER.grok, name: "Grok 4.6" }],
         droid: [{ slug: "claude-opus-4-8", name: "Claude Opus 4.8" }],
         kilo: [{ slug: "kilo/kilo-auto/free", name: "Kilo Auto" }],
         opencode: [{ slug: "openai/gpt-5", name: "OpenAI GPT-5" }],
@@ -2009,6 +2010,7 @@ describe("AgentGateway", () => {
         assert.strictEqual("parentThreadId" in create, false);
         assert.strictEqual("subagentNickname" in create, false);
         assert.equal(create.modelSelection.provider, "grok");
+        assert.equal(create.modelSelection.model, DEFAULT_MODEL_BY_PROVIDER.grok);
         // Project and runtime mode default from the calling thread.
         assert.equal(create.projectId, PROJECT_ID);
         assert.equal(create.runtimeMode, "approval-required");


### PR DESCRIPTION
## Summary
- After #728, Grok's default model is `grok-4.6`, but the AgentGateway test discovery mock still advertised only `grok-build`.
- `synara_create_thread` with `{ provider: "grok" }` then failed with `model_unavailable`. That is currently red on official `main` and on unrelated PRs, including the Windows taskbar PR #729.
- Point the mock at `DEFAULT_MODEL_BY_PROVIDER.grok` and assert the created thread uses that model, so the catalog cannot drift from the default again.

## Test plan
- [x] `bun run test -- src/agentGateway/Layers/AgentGateway.test.ts` (93 passed)
- [x] `bun fmt`, `bun lint`, `bun typecheck`
- [ ] Confirm CI greens the AgentGateway grok test on this PR
- [ ] After merge, rebase #729 so the taskbar CI is no longer blocked by this
