### PR TITLE
Restore project scripts on the empty landing tray

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -337,7 +337,7 @@ import { randomTerminalId } from "./terminal/terminalIds";
 import { cn, isMacNavigatorPlatform, randomUUID } from "~/lib/utils";
 import { toastManager } from "./ui/toast";
 import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybindings";
-import { type NewProjectScriptInput } from "./ProjectScriptsControl";
+import ProjectScriptsControl, { type NewProjectScriptInput } from "./ProjectScriptsControl";
 import {
   commandForProjectScript,
   nextProjectScriptId,
@@ -11203,6 +11203,21 @@ export default function ChatView({
           />
         ) : null}
       </div>
+      {/* Project scripts moved down from the header, which runs minimal chrome on the
+          empty landing — drafts still need to run/edit actions before the first turn. */}
+      {showEmptyLandingBranchToolbar && activeProjectScripts ? (
+        <ProjectScriptsControl
+          scripts={activeProjectScripts}
+          keybindings={keybindings}
+          preferredScriptId={
+            activeProject ? (lastInvokedScriptByProjectId[activeProject.id] ?? null) : null
+          }
+          onRunScript={onRunProjectScriptFromHeader}
+          onAddScript={saveProjectScript}
+          onUpdateScript={updateProjectScript}
+          onDeleteScript={deleteProjectScript}
+        />
+      ) : null}
       {showEmptyLandingBranchToolbar ? (
         <Button
           type="button"


### PR DESCRIPTION
## Summary

`main` has been red on **Browser test (stable)** since 5bd1f5440 (*Unify empty-landing composer and muted chrome styling*): the empty landing now passes `minimalChrome` to the chat header, which stops rendering `ProjectScriptsControl`. That broke the two ChatView tests that guard script cwd resolution for draft threads (`runs project scripts from local/worktree draft threads`) — and, functionally, left empty drafts with no way to run or edit project scripts.

This restores the scripts control by rendering it in the empty-landing workspace-controls tray (next to the branch toolbar and the Temporary toggle), reusing the exact same handlers and preferred-script state as the header, so behavior and cwd/env resolution are unchanged.

## Testing

- `bun run test:browser:stable -- ChatView.browser` — 87 passed, 12 skipped (includes the two previously failing tests)
- `bun fmt`, `bun lint`, `bun typecheck` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI placement only in ChatView empty-landing path; reuses existing script handlers and state with no auth or data-path changes.
> 
> **Overview**
> **Restores project script run/edit UI on the empty-landing composer** after minimal header chrome stopped rendering `ProjectScriptsControl`.
> 
> When the empty landing shows the branch toolbar (`showEmptyLandingBranchToolbar`), the same `ProjectScriptsControl` is now rendered in the workspace-controls tray above the composer—alongside branch tools and the Temporary toggle—wired to the existing header handlers (`onRunProjectScriptFromHeader`, `saveProjectScript`, etc.) and preferred-script state so draft threads can run scripts before the first message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb099616a2dbe7c7168541344667ea28a12ad377. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->