### PR TITLE
feat(web): allow /side to target another provider

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -10290,6 +10290,7 @@ export default function ChatView({
       activeThread?.session !== null &&
       activeThread?.session?.status !== "closed",
     canOfferSideCommand,
+    sidechatTargetProviders: handoffTargetProviders,
     canOfferExportCommand,
     supportsTextNativeReviewCommand,
     fastModeEnabled,

--- a/apps/web/src/composerSlashCommands.test.ts
+++ b/apps/web/src/composerSlashCommands.test.ts
@@ -16,6 +16,7 @@ import {
   parseFastSlashCommandAction,
   parseForkSlashCommandArgs,
   parseGoalSlashCommandArgs,
+  parseSideSlashCommandArgs,
   providerSupportsTextNativeReviewCommand,
   shouldHideProviderNativeCommandFromComposerMenu,
 } from "./composerSlashCommands";
@@ -170,6 +171,43 @@ describe("composerSlashCommands", () => {
         interactionMode: "plan",
       }),
     ).toBe(false);
+  });
+
+  it("parses an optional leading provider token in /side args", () => {
+    const context = {
+      currentProvider: "claudeAgent",
+      availableTargetProviders: ["codex", "cursor"],
+    } as const;
+    expect(parseSideSlashCommandArgs("codex is this safe?", context)).toEqual({
+      targetProvider: "codex",
+      prompt: "is this safe?",
+      unavailableProvider: null,
+    });
+    expect(parseSideSlashCommandArgs("Codex", context)).toEqual({
+      targetProvider: "codex",
+      prompt: "",
+      unavailableProvider: null,
+    });
+    expect(parseSideSlashCommandArgs("claude compare this", context)).toEqual({
+      targetProvider: null,
+      prompt: "compare this",
+      unavailableProvider: null,
+    });
+    expect(parseSideSlashCommandArgs("is this safe?", context)).toEqual({
+      targetProvider: null,
+      prompt: "is this safe?",
+      unavailableProvider: null,
+    });
+    expect(parseSideSlashCommandArgs("", context)).toEqual({
+      targetProvider: null,
+      prompt: "",
+      unavailableProvider: null,
+    });
+    expect(parseSideSlashCommandArgs("grok compare this", context)).toEqual({
+      targetProvider: null,
+      prompt: "compare this",
+      unavailableProvider: "grok",
+    });
   });
 
   it("only offers /side for a main-thread empty default composer", () => {

--- a/apps/web/src/composerSlashCommands.ts
+++ b/apps/web/src/composerSlashCommands.ts
@@ -1,9 +1,11 @@
 import {
+  PROVIDER_DISPLAY_NAMES,
   THREAD_GOAL_MAX_CHARS,
   type GitBranch,
   type ProviderInteractionMode,
   type ProviderKind,
 } from "@synara/contracts";
+import { DEFAULT_PROVIDER_ORDER } from "./providerOrdering";
 import {
   BUILT_IN_COMPOSER_SLASH_COMMANDS,
   isBuiltInComposerSlashCommandName,
@@ -207,7 +209,7 @@ const COMPOSER_SLASH_COMMAND_DEFINITIONS: Record<
   side: {
     command: "side",
     label: "/side",
-    description: "Open a guarded Side from this thread",
+    description: "Open a guarded Side from this thread, optionally on another provider",
     source: "app",
   },
   status: {
@@ -513,6 +515,48 @@ export function buildSlashReviewComposerPrompt(args: string): string {
       : basePrompt;
   }
   return `${basePrompt}\nFocus especially on: ${trimmedArgs}`;
+}
+
+export interface SideSlashCommandArgs {
+  targetProvider: ProviderKind | null;
+  prompt: string;
+  unavailableProvider: ProviderKind | null;
+}
+
+function matchSideProviderToken(token: string): ProviderKind | null {
+  const normalized = token.toLowerCase();
+  return (
+    DEFAULT_PROVIDER_ORDER.find(
+      (provider) =>
+        provider.toLowerCase() === normalized ||
+        PROVIDER_DISPLAY_NAMES[provider].toLowerCase() === normalized,
+    ) ?? null
+  );
+}
+
+// `/side [provider] [prompt]`: an optional leading provider token (kind or
+// display name) starts the sidechat on that provider.
+export function parseSideSlashCommandArgs(
+  args: string,
+  input: {
+    currentProvider: ProviderKind;
+    availableTargetProviders: ReadonlyArray<ProviderKind>;
+  },
+): SideSlashCommandArgs {
+  const trimmedArgs = args.trim();
+  const firstToken = trimmedArgs.split(/\s+/, 1)[0] ?? "";
+  const matchedProvider = firstToken.length > 0 ? matchSideProviderToken(firstToken) : null;
+  if (!matchedProvider) {
+    return { targetProvider: null, prompt: trimmedArgs, unavailableProvider: null };
+  }
+  const prompt = trimmedArgs.slice(firstToken.length).trim();
+  if (matchedProvider === input.currentProvider) {
+    return { targetProvider: null, prompt, unavailableProvider: null };
+  }
+  if (!input.availableTargetProviders.includes(matchedProvider)) {
+    return { targetProvider: null, prompt, unavailableProvider: matchedProvider };
+  }
+  return { targetProvider: matchedProvider, prompt, unavailableProvider: null };
 }
 
 // `/fork` optionally accepts only an explicit target shorthand like `/fork local`.

--- a/apps/web/src/hooks/useComposerSlashCommands.ts
+++ b/apps/web/src/hooks/useComposerSlashCommands.ts
@@ -1,4 +1,5 @@
 import {
+  PROVIDER_DISPLAY_NAMES,
   THREAD_GOAL_MAX_CHARS,
   type MessageId,
   type ModelSelection,
@@ -26,9 +27,13 @@ import {
   parseFastSlashCommandAction,
   parseForkSlashCommandArgs,
   parseGoalSlashCommandArgs,
+  parseSideSlashCommandArgs,
   type ForkSlashCommandTarget,
 } from "../composerSlashCommands";
-import { buildThreadHandoffImportedMessages } from "../lib/threadHandoff";
+import {
+  buildThreadHandoffImportedMessages,
+  resolveThreadHandoffModelSelection,
+} from "../lib/threadHandoff";
 import { toastManager } from "../components/ui/toast";
 import type { ComposerCommandItem } from "../components/chat/ComposerCommandMenu";
 import { buildNextProviderOptions } from "../providerModelOptions";
@@ -68,6 +73,7 @@ export function useComposerSlashCommands(input: {
   supportsFastSlashCommand: boolean;
   canOfferCompactCommand: boolean;
   canOfferSideCommand: boolean;
+  sidechatTargetProviders: ReadonlyArray<ProviderKind>;
   canOfferExportCommand: boolean;
   supportsTextNativeReviewCommand: boolean;
   fastModeEnabled: boolean;
@@ -119,6 +125,7 @@ export function useComposerSlashCommands(input: {
     supportsFastSlashCommand,
     canOfferCompactCommand,
     canOfferSideCommand,
+    sidechatTargetProviders,
     canOfferExportCommand,
     supportsTextNativeReviewCommand,
     fastModeEnabled,
@@ -432,7 +439,7 @@ export function useComposerSlashCommands(input: {
 
   const sidechatCreationBySourceThreadIdRef = useRef(new Map<ThreadId, SidechatCreationFlight>());
   const createSidechatFromSlashCommand = useCallback(
-    (inputOptions?: { initialPrompt?: string }): Promise<true> => {
+    (inputOptions?: { initialPrompt?: string; targetProvider?: ProviderKind }): Promise<true> => {
       const api = readNativeApi();
       if (
         !api ||
@@ -449,6 +456,18 @@ export function useComposerSlashCommands(input: {
         return Promise.resolve(true);
       }
 
+      const targetProvider = inputOptions?.targetProvider ?? null;
+      const sidechatModelSelection =
+        targetProvider && targetProvider !== selectedModelSelection.provider
+          ? resolveThreadHandoffModelSelection({
+              sourceThread: activeThread,
+              targetProvider,
+              projectDefaultModelSelection: activeProject.defaultModelSelection,
+              stickyModelSelectionByProvider:
+                useComposerDraftStore.getState().stickyModelSelectionByProvider,
+            })
+          : selectedModelSelection;
+
       return createOrJoinSidechat({
         inFlightBySourceThreadId: sidechatCreationBySourceThreadIdRef.current,
         sourceThreadId: activeThread.id,
@@ -458,7 +477,7 @@ export function useComposerSlashCommands(input: {
             api,
             project: activeProject,
             sourceThread: activeThread,
-            selectedModelSelection,
+            selectedModelSelection: sidechatModelSelection,
             initialPrompt,
             openSidechat: (sidechatThreadId) => {
               useRightDockStore.getState().openPane(activeThread.id, {
@@ -472,7 +491,7 @@ export function useComposerSlashCommands(input: {
           sendSidechatPrompt({
             api,
             threadId: sidechatThreadId,
-            selectedModelSelection,
+            selectedModelSelection: sidechatModelSelection,
             prompt,
           }),
         onCreationResult: (result) => {
@@ -910,9 +929,29 @@ export function useComposerSlashCommands(input: {
           });
           return true;
         }
+        const { targetProvider, prompt, unavailableProvider } = parseSideSlashCommandArgs(
+          slashInvocation.args,
+          {
+            currentProvider: selectedModelSelection.provider,
+            availableTargetProviders: sidechatTargetProviders,
+          },
+        );
+        if (unavailableProvider) {
+          toastManager.add({
+            type: "warning",
+            title: `${PROVIDER_DISPLAY_NAMES[unavailableProvider]} is unavailable for Side`,
+            description: "Enable and sign in to that provider, then run /side again.",
+          });
+          return true;
+        }
+        // Hoisted out of the `try` below: React Compiler cannot lower `?:` inside
+        // a try block and would bail out of compiling this whole hook.
+        const sidechatOptions = targetProvider
+          ? { initialPrompt: prompt, targetProvider }
+          : { initialPrompt: prompt };
         try {
           editorActions.clearComposerSlashDraft();
-          await createSidechatFromSlashCommand({ initialPrompt: slashInvocation.args });
+          await createSidechatFromSlashCommand(sidechatOptions);
         } catch (error) {
           toastManager.add({
             type: "error",
@@ -939,6 +978,8 @@ export function useComposerSlashCommands(input: {
       openFeedbackDialog,
       openReviewTargetPicker,
       selectedProvider,
+      selectedModelSelection.provider,
+      sidechatTargetProviders,
       supportsTextNativeReviewCommand,
       runCodexReviewStart,
       runExportSlashCommand,

--- a/apps/web/src/hooks/useComposerSlashCommands.ts
+++ b/apps/web/src/hooks/useComposerSlashCommands.ts
@@ -437,7 +437,7 @@ export function useComposerSlashCommands(input: {
     ],
   );
 
-  const sidechatCreationBySourceThreadIdRef = useRef(new Map<ThreadId, SidechatCreationFlight>());
+  const sidechatCreationByKeyRef = useRef(new Map<string, SidechatCreationFlight>());
   const createSidechatFromSlashCommand = useCallback(
     (inputOptions?: { initialPrompt?: string; targetProvider?: ProviderKind }): Promise<true> => {
       const api = readNativeApi();
@@ -469,8 +469,8 @@ export function useComposerSlashCommands(input: {
           : selectedModelSelection;
 
       return createOrJoinSidechat({
-        inFlightBySourceThreadId: sidechatCreationBySourceThreadIdRef.current,
-        sourceThreadId: activeThread.id,
+        inFlightByKey: sidechatCreationByKeyRef.current,
+        flightKey: `${activeThread.id}:${sidechatModelSelection.provider}`,
         initialPrompt: inputOptions?.initialPrompt,
         startCreation: (initialPrompt) =>
           createSidechatThread({

--- a/apps/web/src/lib/sidechatCreation.test.ts
+++ b/apps/web/src/lib/sidechatCreation.test.ts
@@ -234,15 +234,16 @@ describe("createOrJoinSidechat", () => {
   } satisfies SidechatCreationResult;
 
   function run(input: {
-    flights: Map<ThreadId, SidechatCreationFlight>;
+    flights: Map<string, SidechatCreationFlight>;
     sourceThreadId: ThreadId;
+    targetProvider?: string;
     initialPrompt?: string | undefined;
     startCreation: (initialPrompt?: string | undefined) => Promise<SidechatCreationResult>;
     sendQueuedPrompt: (threadId: ThreadId, prompt: string) => Promise<void>;
   }): Promise<true> {
     return createOrJoinSidechat({
-      inFlightBySourceThreadId: input.flights,
-      sourceThreadId: input.sourceThreadId,
+      inFlightByKey: input.flights,
+      flightKey: `${input.sourceThreadId}:${input.targetProvider ?? "codex"}`,
       initialPrompt: input.initialPrompt,
       startCreation: input.startCreation,
       sendQueuedPrompt: input.sendQueuedPrompt,
@@ -260,7 +261,7 @@ describe("createOrJoinSidechat", () => {
         }),
     );
     const sendQueuedPrompt = vi.fn().mockResolvedValue(undefined);
-    const flights = new Map<ThreadId, SidechatCreationFlight>();
+    const flights = new Map<string, SidechatCreationFlight>();
     const sourceThreadId = ThreadId.makeUnsafe("source-a");
 
     const first = run({ flights, sourceThreadId, startCreation, sendQueuedPrompt });
@@ -287,7 +288,7 @@ describe("createOrJoinSidechat", () => {
         }),
     );
     const sendQueuedPrompt = vi.fn().mockResolvedValue(undefined);
-    const flights = new Map<ThreadId, SidechatCreationFlight>();
+    const flights = new Map<string, SidechatCreationFlight>();
     const sourceThreadId = ThreadId.makeUnsafe("source-a");
 
     const first = run({
@@ -313,7 +314,7 @@ describe("createOrJoinSidechat", () => {
   });
 
   it("allows different host threads to create sidechats concurrently", async () => {
-    const flights = new Map<ThreadId, SidechatCreationFlight>();
+    const flights = new Map<string, SidechatCreationFlight>();
     const startFirst = vi.fn().mockResolvedValue(result);
     const startSecond = vi.fn().mockResolvedValue({
       ...result,
@@ -341,5 +342,35 @@ describe("createOrJoinSidechat", () => {
 
     expect(startFirst).toHaveBeenCalledOnce();
     expect(startSecond).toHaveBeenCalledOnce();
+  });
+
+  it("creates separate in-flight sidechats for different target providers", async () => {
+    const flights = new Map<string, SidechatCreationFlight>();
+    const sourceThreadId = ThreadId.makeUnsafe("source-a");
+    const startCodex = vi.fn().mockResolvedValue(result);
+    const startCursor = vi.fn().mockResolvedValue({
+      ...result,
+      threadId: ThreadId.makeUnsafe("cursor-sidechat"),
+    });
+
+    await Promise.all([
+      run({
+        flights,
+        sourceThreadId,
+        targetProvider: "codex",
+        startCreation: startCodex,
+        sendQueuedPrompt: vi.fn().mockResolvedValue(undefined),
+      }),
+      run({
+        flights,
+        sourceThreadId,
+        targetProvider: "cursor",
+        startCreation: startCursor,
+        sendQueuedPrompt: vi.fn().mockResolvedValue(undefined),
+      }),
+    ]);
+
+    expect(startCodex).toHaveBeenCalledOnce();
+    expect(startCursor).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/lib/sidechatCreation.ts
+++ b/apps/web/src/lib/sidechatCreation.ts
@@ -56,8 +56,8 @@ export interface SidechatCreationFlight {
 }
 
 function scheduleSidechatFlightCleanup(
-  inFlightBySourceThreadId: Map<ThreadId, SidechatCreationFlight>,
-  sourceThreadId: ThreadId,
+  inFlightByKey: Map<string, SidechatCreationFlight>,
+  flightKey: string,
   flight: SidechatCreationFlight,
 ): void {
   const observedTail = flight.promptTail;
@@ -66,26 +66,26 @@ function scheduleSidechatFlightCleanup(
       if (
         flight.creationSettled &&
         flight.promptTail === observedTail &&
-        inFlightBySourceThreadId.get(sourceThreadId) === flight
+        inFlightByKey.get(flightKey) === flight
       ) {
-        inFlightBySourceThreadId.delete(sourceThreadId);
+        inFlightByKey.delete(flightKey);
       }
     },
     () => {
       if (
         flight.creationSettled &&
         flight.promptTail === observedTail &&
-        inFlightBySourceThreadId.get(sourceThreadId) === flight
+        inFlightByKey.get(flightKey) === flight
       ) {
-        inFlightBySourceThreadId.delete(sourceThreadId);
+        inFlightByKey.delete(flightKey);
       }
     },
   );
 }
 
 export function createOrJoinSidechat(input: {
-  inFlightBySourceThreadId: Map<ThreadId, SidechatCreationFlight>;
-  sourceThreadId: ThreadId;
+  inFlightByKey: Map<string, SidechatCreationFlight>;
+  flightKey: string;
   initialPrompt?: string | undefined;
   startCreation: (initialPrompt?: string) => Promise<SidechatCreationResult>;
   sendQueuedPrompt: (threadId: ThreadId, prompt: string) => Promise<void>;
@@ -93,7 +93,7 @@ export function createOrJoinSidechat(input: {
   onQueuedPromptError: (error: unknown) => void;
 }): Promise<true> {
   const prompt = input.initialPrompt?.trim() ?? "";
-  const existing = input.inFlightBySourceThreadId.get(input.sourceThreadId);
+  const existing = input.inFlightByKey.get(input.flightKey);
   if (existing) {
     if (prompt.length === 0) {
       return existing.completion;
@@ -111,7 +111,7 @@ export function createOrJoinSidechat(input: {
       }
     });
     if (existing.creationSettled) {
-      scheduleSidechatFlightCleanup(input.inFlightBySourceThreadId, input.sourceThreadId, existing);
+      scheduleSidechatFlightCleanup(input.inFlightByKey, input.flightKey, existing);
     }
     return existing.promptTail.then(() => true as const);
   }
@@ -128,15 +128,15 @@ export function createOrJoinSidechat(input: {
     promptTail: Promise.resolve(),
     creationSettled: false,
   };
-  input.inFlightBySourceThreadId.set(input.sourceThreadId, flight);
+  input.inFlightByKey.set(input.flightKey, flight);
   void flight.completion.then(
     () => {
       flight.creationSettled = true;
-      scheduleSidechatFlightCleanup(input.inFlightBySourceThreadId, input.sourceThreadId, flight);
+      scheduleSidechatFlightCleanup(input.inFlightByKey, input.flightKey, flight);
     },
     () => {
       flight.creationSettled = true;
-      scheduleSidechatFlightCleanup(input.inFlightBySourceThreadId, input.sourceThreadId, flight);
+      scheduleSidechatFlightCleanup(input.inFlightByKey, input.flightKey, flight);
     },
   );
   return flight.completion;


### PR DESCRIPTION
Closes #733

## What

`/side` accepts an optional leading provider token (kind or display name):

```
/side codex is this approach safe?
/side claude
```

Without a token, behavior is unchanged (inherits the composer's current selection).

## How

- `parseSideSlashCommandArgs` (`composerSlashCommands.ts`): matches the first token against provider kinds/display names; naming the current provider is a no-op; a known-but-ineligible provider surfaces a warning toast instead of being silently sent as prompt text.
- Eligibility reuses the handoff rules: `ChatView` passes its existing `handoffTargetProviders` into the hook — no new subscriptions.
- Model resolution reuses `resolveThreadHandoffModelSelection` (sticky > project default > provider default) for both the fork and the initial prompt turn.
- No server changes: `thread.fork.create` already accepts any provider.

## Tests

- Parser unit tests in `composerSlashCommands.test.ts` (provider token, display name, current-provider no-op, plain prompt, unavailable provider).
- `chatHotPath.compiler.test.ts` still passes (options object hoisted out of the `try` per the React Compiler constraint).
- `bun fmt`, `bun lint`, `bun typecheck` all pass.