### PR TITLE
fix: recognize Windows home paths in project browser

### DIFF
--- a/apps/web/src/lib/projectPaths.test.ts
+++ b/apps/web/src/lib/projectPaths.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { expandProjectHomePath, joinProjectPath } from "./projectPaths";
+import { expandProjectHomePath, isFilesystemBrowseQuery, joinProjectPath } from "./projectPaths";
 
 describe("joinProjectPath", () => {
   it.each([
@@ -22,5 +22,15 @@ describe("expandProjectHomePath", () => {
     ["~/Developer", null, "~/Developer"],
   ])("expands %s against %s", (value, homeDir, expected) => {
     expect(expandProjectHomePath(value, homeDir)).toBe(expected);
+  });
+});
+
+describe("isFilesystemBrowseQuery", () => {
+  it("recognizes a Windows-style home path on Windows", () => {
+    expect(isFilesystemBrowseQuery("~\\Developer", "Win32")).toBe(true);
+  });
+
+  it("does not treat a Windows-style home path as a browse query on macOS", () => {
+    expect(isFilesystemBrowseQuery("~\\Developer", "MacIntel")).toBe(false);
   });
 });

--- a/apps/web/src/lib/projectPaths.ts
+++ b/apps/web/src/lib/projectPaths.ts
@@ -127,6 +127,7 @@ export function isFilesystemBrowseQuery(value: string, platform = getNavigatorPl
     value.startsWith("..\\") ||
     value.startsWith("/") ||
     value.startsWith("~/") ||
+    (allowWindowsPaths && value.startsWith("~\\")) ||
     (allowWindowsPaths && isWindowsAbsolutePath(value))
   );
 }


### PR DESCRIPTION
## Summary
- recognize `~\...` as a filesystem browse query on Windows
- keep that Windows-specific shorthand disabled on non-Windows platforms
- add regression coverage for both platform cases

## Why
The project path helpers already expand `~\Developer` against the configured home directory, but `isFilesystemBrowseQuery` only recognized the forward-slash `~/...` form. In the sidebar project browser, typing the native Windows home-path form therefore did not enter filesystem browse mode.

## Verification
Added Vitest coverage in `projectPaths.test.ts` for Windows and macOS platform inputs.