### PR TITLE
fix: avoid stale feature flags after malformed storage

### DIFF
--- a/apps/web/src/featureFlags.test.ts
+++ b/apps/web/src/featureFlags.test.ts
@@ -1,0 +1,42 @@
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("react", () => ({
+  useSyncExternalStore: (
+    _subscribe: (listener: () => void) => () => void,
+    getSnapshot: () => unknown,
+  ) => getSnapshot(),
+}));
+
+import { setFeatureFlagEnabled, useFeatureFlags } from "./featureFlags";
+
+const FEATURE_FLAG_STORAGE_KEY = "synara:feature-flags";
+
+function createLocalStorage(): Pick<Storage, "getItem" | "setItem" | "removeItem"> {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => {
+      values.set(key, value);
+    },
+    removeItem: (key) => {
+      values.delete(key);
+    },
+  };
+}
+
+describe("feature flag storage recovery", () => {
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not resurrect cached flags after malformed storage is read twice", () => {
+    const localStorage = createLocalStorage();
+    vi.stubGlobal("window", { localStorage });
+
+    setFeatureFlagEnabled("show-debug-task-banner", true);
+    localStorage.setItem(FEATURE_FLAG_STORAGE_KEY, "{malformed");
+
+    expect(useFeatureFlags()["show-debug-task-banner"]).toBe(false);
+    expect(useFeatureFlags()["show-debug-task-banner"]).toBe(false);
+  });
+});

--- a/apps/web/src/featureFlags.ts
+++ b/apps/web/src/featureFlags.ts
@@ -102,10 +102,15 @@ function readFeatureFlagState(): FeatureFlagState {
       return cachedFeatureFlagState;
     }
 
+    const nextState = normalizeFeatureFlagState(raw ? JSON.parse(raw) : null);
     cachedRawFeatureFlagState = raw;
-    cachedFeatureFlagState = normalizeFeatureFlagState(raw ? JSON.parse(raw) : null);
-    return cachedFeatureFlagState;
+    cachedFeatureFlagState = nextState;
+    return nextState;
   } catch {
+    // Do not cache a raw value whose parse/read failed. Otherwise a later read of
+    // that same value would match the cache key and resurrect the previous state.
+    cachedRawFeatureFlagState = undefined;
+    cachedFeatureFlagState = DEFAULT_FEATURE_FLAG_STATE;
     return DEFAULT_FEATURE_FLAG_STATE;
   }
 }


### PR DESCRIPTION
## Summary
- only update the feature-flag cache after stored JSON parses successfully
- reset cache state when storage reads or parsing fail
- add a regression test proving repeated reads cannot resurrect the previous cached flags

## Why
`readFeatureFlagState()` assigned `cachedRawFeatureFlagState` before `JSON.parse`. If parsing threw, the first read returned defaults but the malformed raw value remained cached alongside the previous decoded state. A second read of the same malformed value then hit the cache and returned that stale state.

## Verification
Added a Vitest regression covering two consecutive reads after malformed localStorage data.