### PR TITLE
fix: reject diagnostic cursors beyond their high-water mark

### DIFF
--- a/apps/server/src/agentGateway/diagnosticCursor.test.ts
+++ b/apps/server/src/agentGateway/diagnosticCursor.test.ts
@@ -60,6 +60,26 @@ describe("diagnostic cursor", () => {
     ).toThrow("thread-2");
   });
 
+  it("rejects a cursor whose page boundary exceeds its stable high-water mark", () => {
+    const filterFingerprint = diagnosticFilterFingerprint({ kinds: [] });
+    const encoded = encodeDiagnosticCursor({
+      version: 1,
+      kind: "activity",
+      threadId: "thread-1",
+      filterFingerprint,
+      highWaterSequence: 42,
+      beforeSequence: 43,
+    });
+
+    expect(() =>
+      decodeDiagnosticCursor(encoded, {
+        kind: "activity",
+        threadId: "thread-1",
+        filterFingerprint,
+      }),
+    ).toThrow("valid activity cursor");
+  });
+
   it("normalizes set-like filters and rejects a cursor when filters change", () => {
     const originalFingerprint = diagnosticFilterFingerprint({
       kinds: ["tool", "message", "tool"],

--- a/apps/server/src/agentGateway/diagnosticCursor.ts
+++ b/apps/server/src/agentGateway/diagnosticCursor.ts
@@ -47,7 +47,9 @@ export function decodeDiagnosticCursor(
       !Number.isSafeInteger(value.highWaterSequence) ||
       !Number.isSafeInteger(value.beforeSequence) ||
       (value.highWaterSequence ?? -1) < 0 ||
-      (value.beforeSequence ?? -1) < 0
+      (value.beforeSequence ?? -1) < 0 ||
+      (value.beforeSequence ?? Number.POSITIVE_INFINITY) >
+        (value.highWaterSequence ?? Number.NEGATIVE_INFINITY)
     ) {
       throw new Error("cursor fields are invalid");
     }


### PR DESCRIPTION
## Summary
- reject decoded diagnostic cursors whose `beforeSequence` is greater than `highWaterSequence`
- add regression coverage for the invalid cursor relation

## Why
Diagnostic pagination freezes each cursor to a stable high-water mark and then pages strictly before `beforeSequence`. Every cursor emitted by Synara therefore has `beforeSequence <= highWaterSequence`. A forged or corrupted cursor could previously violate that invariant and cause the query to restart from the high-water window instead of advancing its page boundary.

## Verification
Added a focused Vitest case in `diagnosticCursor.test.ts`.