### PR TITLE
fix: enforce exhaustive provider metadata at compile time

### DIFF
--- a/packages/shared/src/providerMetadata.ts
+++ b/packages/shared/src/providerMetadata.ts
@@ -21,7 +21,16 @@ export interface ProviderDescriptor {
   } | null;
 }
 
-export const PROVIDER_DESCRIPTORS = [
+type ExhaustiveProviderDescriptors<Descriptors extends readonly ProviderDescriptor[]> =
+  Exclude<ProviderKind, Descriptors[number]["kind"]> extends never ? Descriptors : never;
+
+function defineProviderDescriptors<const Descriptors extends readonly ProviderDescriptor[]>(
+  descriptors: ExhaustiveProviderDescriptors<Descriptors>,
+): Descriptors {
+  return descriptors;
+}
+
+export const PROVIDER_DESCRIPTORS = defineProviderDescriptors([
   {
     kind: "codex",
     displayName: PROVIDER_DISPLAY_NAMES.codex,
@@ -94,7 +103,7 @@ export const PROVIDER_DESCRIPTORS = [
     supportsNativeTurnSteering: true,
     usage: null,
   },
-] as const satisfies readonly ProviderDescriptor[];
+] as const satisfies readonly ProviderDescriptor[]);
 
 export const PROVIDER_DESCRIPTOR_BY_KIND = Object.fromEntries(
   PROVIDER_DESCRIPTORS.map((descriptor) => [descriptor.kind, descriptor]),


### PR DESCRIPTION
## Summary
- make the provider descriptor declaration prove that every `ProviderKind` is represented
- preserve the existing literal descriptor types and runtime data shape

## Why
`PROVIDER_DESCRIPTORS` is the shared source for ordering and several UI/provider metadata surfaces and is documented as exhaustive. The previous `satisfies readonly ProviderDescriptor[]` only verified that each listed descriptor had a valid kind; it did not fail when a valid `ProviderKind` was omitted. Adding a provider to the contract could therefore compile while silently disappearing from metadata-derived surfaces.

## Verification
The new generic declaration turns any missing `ProviderKind` into a type error, so the repository typecheck is the regression guard.