### PR TITLE
fix: fully redact quoted sensitive process flags

### DIFF
--- a/apps/server/src/processArgumentRedaction.quotedFlags.test.ts
+++ b/apps/server/src/processArgumentRedaction.quotedFlags.test.ts
@@ -5,9 +5,7 @@ import { redactSensitiveProcessArgs } from "./processArgumentRedaction";
 describe("redactSensitiveProcessArgs quoted flags", () => {
   it("redacts quoted sensitive flag values containing spaces", () => {
     expect(
-      redactSensitiveProcessArgs(
-        `tool --password "correct horse" --token='alpha beta' --verbose`,
-      ),
+      redactSensitiveProcessArgs(`tool --password "correct horse" --token='alpha beta' --verbose`),
     ).toBe("tool --password [redacted] --token=[redacted] --verbose");
   });
 

--- a/apps/server/src/processArgumentRedaction.quotedFlags.test.ts
+++ b/apps/server/src/processArgumentRedaction.quotedFlags.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { redactSensitiveProcessArgs } from "./processArgumentRedaction";
+
+describe("redactSensitiveProcessArgs quoted flags", () => {
+  it("redacts quoted sensitive flag values containing spaces", () => {
+    expect(
+      redactSensitiveProcessArgs(
+        `tool --password "correct horse" --token='alpha beta' --verbose`,
+      ),
+    ).toBe("tool --password [redacted] --token=[redacted] --verbose");
+  });
+
+  it("fails closed for an unterminated quoted sensitive flag value", () => {
+    expect(redactSensitiveProcessArgs('tool --password "correct horse')).toBe(
+      "tool --password [redacted]",
+    );
+  });
+});

--- a/apps/server/src/processArgumentRedaction.quotedFlags.test.ts
+++ b/apps/server/src/processArgumentRedaction.quotedFlags.test.ts
@@ -9,6 +9,17 @@ describe("redactSensitiveProcessArgs quoted flags", () => {
     ).toBe("tool --password [redacted] --token=[redacted] --verbose");
   });
 
+  it("redacts complete shell-composed sensitive flag values", () => {
+    expect(
+      redactSensitiveProcessArgs(
+        `tool --password=prefix"correct horse"suffix --token='alpha'" beta" --verbose`,
+      ),
+    ).toBe("tool --password=[redacted] --token=[redacted] --verbose");
+    expect(redactSensitiveProcessArgs("tool --secret=`gamma delta`suffix --verbose")).toBe(
+      "tool --secret=[redacted] --verbose",
+    );
+  });
+
   it("fails closed for an unterminated quoted sensitive flag value", () => {
     expect(redactSensitiveProcessArgs('tool --password "correct horse')).toBe(
       "tool --password [redacted]",

--- a/apps/server/src/processArgumentRedaction.ts
+++ b/apps/server/src/processArgumentRedaction.ts
@@ -5,7 +5,7 @@ const SENSITIVE_ENV_NAME =
 const SENSITIVE_ENV_NAME_SUFFIX =
   /_(?:API_?KEY|ACCESS_TOKEN|AUTH|AUTH_TOKEN|AUTHORIZATION|CREDENTIALS?|KEY|PASS|PASSWORD|PASSPHRASE|SECRET|TOKEN)$/;
 const SENSITIVE_FLAG_VALUE_PATTERN =
-  /(--?(?:api[-_]?key|auth|authorization|key|password|secret|token)(?:=|\s+))(?:"(?:\\.|[^"\\])*(?:"|$)|'(?:\\.|[^'\\])*(?:'|$)|\S+)/gi;
+  /(--?(?:api[-_]?key|auth|authorization|key|password|secret|token)(?:=|\s+))(?:(?:"(?:\\.|[^"\\])*(?:"|$)|'(?:\\.|[^'\\])*(?:'|$)|`(?:\\.|[^`\\])*(?:`|$)|[^\s'"`]+)+)/gi;
 const URL_CREDENTIALS_AT_VALUE_START = /^["']?[a-z][a-z0-9+.-]*:\/\/[^/?#\s]+@/i;
 const URL_CREDENTIALS_PATTERN = /\b([a-z][a-z0-9+.-]*:\/\/)[^/?#\s]+@/giu;
 const MAX_SHELL_ASSIGNMENT_SCAN_CHARS = 16_384;

--- a/apps/server/src/processArgumentRedaction.ts
+++ b/apps/server/src/processArgumentRedaction.ts
@@ -4,6 +4,8 @@ const SENSITIVE_ENV_NAME =
   /^(?:API_?KEY|ACCESS_TOKEN|AUTH|AUTH_TOKEN|AUTHORIZATION|CREDENTIALS?|KEY|MYSQL_PWD|PASS|PASSWORD|PASSPHRASE|PGPASSWORD|REDISCLI_AUTH|SECRET|TOKEN)$/;
 const SENSITIVE_ENV_NAME_SUFFIX =
   /_(?:API_?KEY|ACCESS_TOKEN|AUTH|AUTH_TOKEN|AUTHORIZATION|CREDENTIALS?|KEY|PASS|PASSWORD|PASSPHRASE|SECRET|TOKEN)$/;
+const SENSITIVE_FLAG_VALUE_PATTERN =
+  /(--?(?:api[-_]?key|auth|authorization|key|password|secret|token)(?:=|\s+))(?:"(?:\\.|[^"\\])*(?:"|$)|'(?:\\.|[^'\\])*(?:'|$)|\S+)/gi;
 const URL_CREDENTIALS_AT_VALUE_START = /^["']?[a-z][a-z0-9+.-]*:\/\/[^/?#\s]+@/i;
 const URL_CREDENTIALS_PATTERN = /\b([a-z][a-z0-9+.-]*:\/\/)[^/?#\s]+@/giu;
 const MAX_SHELL_ASSIGNMENT_SCAN_CHARS = 16_384;
@@ -352,10 +354,7 @@ export function redactSensitiveProcessArgs(
     ? redactSensitiveEnvironmentRemainder(args)
     : redactBoundedSensitiveEnvironmentValues(args);
   return environmentRedacted
-    .replace(
-      /(--?(?:api[-_]?key|auth|authorization|key|password|secret|token)(?:=|\s+))(\S+)/gi,
-      "$1[redacted]",
-    )
+    .replace(SENSITIVE_FLAG_VALUE_PATTERN, "$1[redacted]")
     .replace(URL_CREDENTIALS_PATTERN, "$1[redacted]@")
     .replace(/(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, "$1[redacted]")
     .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, "[redacted]")


### PR DESCRIPTION
## Summary
- redact the complete value of sensitive CLI flags when the value is single- or double-quoted and contains whitespace
- fail closed when a quoted sensitive flag value is unterminated
- add focused regression coverage for both cases

## Why
The previous flag redaction matched sensitive values with `\S+`. For a diagnostic string such as `--password "correct horse"`, only the first token was consumed, leaving the remainder of the secret visible after the redaction marker.

## Verification
Added Vitest regression cases for quoted multi-word password/token values and an unterminated quoted password value.