### PR TITLE
fix: derive confirmed provider kinds from canonical metadata

### DIFF
--- a/apps/web/src/confirmedCustomBinaryPathStore.ts
+++ b/apps/web/src/confirmedCustomBinaryPathStore.ts
@@ -6,23 +6,14 @@
 // Exports: load/save helpers for the confirmed-path record.
 
 import type { ProviderKind } from "@synara/contracts";
+import { PROVIDER_DESCRIPTORS } from "@synara/shared/providerMetadata";
 import { isPlainObject } from "./persistedRecord";
 
 const STORAGE_KEY = "synara:confirmed-custom-binary-paths:v1";
 
-// Mirror of the ProviderKind literal union; the explicit annotation makes the
-// compiler reject this list if a new provider is added without updating it.
-const PROVIDER_KINDS: ReadonlySet<ProviderKind> = new Set<ProviderKind>([
-  "codex",
-  "claudeAgent",
-  "cursor",
-  "antigravity",
-  "grok",
-  "droid",
-  "kilo",
-  "opencode",
-  "pi",
-]);
+const PROVIDER_KINDS: ReadonlySet<ProviderKind> = new Set(
+  PROVIDER_DESCRIPTORS.map((descriptor) => descriptor.kind),
+);
 
 function isProviderKind(value: string): value is ProviderKind {
   return PROVIDER_KINDS.has(value as ProviderKind);


### PR DESCRIPTION
## Summary
- remove the manually duplicated provider-kind set from confirmed custom binary-path persistence
- derive accepted provider kinds from the shared canonical provider descriptors

## Why
The previous comment claimed `ReadonlySet<ProviderKind>` would make TypeScript reject the list when a new provider was added. It does not: a set may legally contain only a subset of the union. A future provider could therefore be omitted and have its persisted confirmed custom path silently discarded on reload.

Using the shared descriptor catalog removes that drift surface entirely.