### PR TITLE
fix: support UNC paths in local folder mentions

### DIFF
--- a/apps/web/src/lib/localFolderMentions.test.ts
+++ b/apps/web/src/lib/localFolderMentions.test.ts
@@ -21,7 +21,12 @@ describe("localFolderMentions", () => {
   it("detects mac and windows absolute-path mention browsing", () => {
     expect(isLocalFolderMentionQuery("/Users/test")).toBe(true);
     expect(isLocalFolderMentionQuery("C:\\Users\\test")).toBe(true);
+    expect(isLocalFolderMentionQuery("\\\\server\\share\\project")).toBe(true);
     expect(isLocalFolderMentionQuery("local")).toBe(false);
+  });
+
+  it("does not treat an incomplete UNC server path as a browseable share", () => {
+    expect(isLocalFolderMentionQuery("\\\\server")).toBe(false);
   });
 
   it("detects `~/` and `~\\` as local folder browsing triggers", () => {
@@ -35,7 +40,13 @@ describe("localFolderMentions", () => {
   it("derives the filesystem root from the server home directory when requested", () => {
     expect(getLocalFolderBrowseRootPath("/Users/test", true)).toBe("/");
     expect(getLocalFolderBrowseRootPath("C:\\Users\\test", true)).toBe("C:\\");
+    expect(getLocalFolderBrowseRootPath("\\\\server\\share\\Users\\test", true)).toBe(
+      "\\\\server\\share\\",
+    );
     expect(getLocalFolderBrowseRootPath("/Users/test", false)).toBe("/Users/test");
+    expect(getLocalFolderBrowseRootPath("\\\\server\\share\\Users\\test", false)).toBe(
+      "\\\\server\\share\\Users\\test",
+    );
   });
 
   describe("expandLocalFolderPath", () => {

--- a/apps/web/src/lib/localFolderMentions.ts
+++ b/apps/web/src/lib/localFolderMentions.ts
@@ -5,6 +5,8 @@
 
 export const LOCAL_FOLDER_MENTION_NAME = "local";
 
+const UNC_SHARE_ROOT_PATTERN = /^(\\\\[^\\/]+[\\/][^\\/]+)(?:[\\/]|$)/;
+
 export function matchesLocalFolderMentionShortcut(query: string): boolean {
   const normalizedQuery = query.trim().toLowerCase();
   if (normalizedQuery.length === 0) {
@@ -17,6 +19,7 @@ export function isLocalFolderMentionQuery(query: string): boolean {
   const normalizedQuery = query.trim();
   if (normalizedQuery.startsWith("/")) return true;
   if (/^[A-Za-z]:[\\/]/.test(normalizedQuery)) return true;
+  if (UNC_SHARE_ROOT_PATTERN.test(normalizedQuery)) return true;
   if (normalizedQuery.startsWith("~/") || normalizedQuery.startsWith("~\\")) return true;
   return false;
 }
@@ -37,6 +40,11 @@ export function getLocalFolderBrowseRootPath(
   const windowsRootMatch = /^[A-Za-z]:[\\/]/.exec(normalizedHomeDir);
   if (windowsRootMatch) {
     return windowsRootMatch[0].replace(/\//g, "\\");
+  }
+
+  const uncShareRootMatch = UNC_SHARE_ROOT_PATTERN.exec(normalizedHomeDir);
+  if (uncShareRootMatch?.[1]) {
+    return `${uncShareRootMatch[1].replace(/\//g, "\\")}\\`;
   }
 
   if (normalizedHomeDir.startsWith("/")) {


### PR DESCRIPTION
## Summary
- recognize complete UNC share paths such as `\\server\share\project` as local-folder browse queries
- derive the UNC share root when filesystem-root browsing is requested from a UNC home directory
- keep incomplete `\\server` paths out of browse mode until a share is present
- add regression coverage for detection and root derivation

## Why
The local-folder mention helpers handled POSIX roots, Windows drive roots, and tilde paths, but omitted UNC shares. On Windows this prevented direct `@local` browsing of network shares and produced the wrong browse root when the configured home directory itself lived on a UNC share.