### PR TITLE
fix: keep websocket auth tokens on the server origin

### DIFF
--- a/apps/web/src/lib/wsHttpUrl.test.ts
+++ b/apps/web/src/lib/wsHttpUrl.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveWsHttpUrl } from "./wsHttpUrl";
+
+describe("resolveWsHttpUrl", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("forwards the websocket token to relative server routes", () => {
+    vi.stubGlobal("window", {
+      desktopBridge: {
+        getWsUrl: () => "ws://127.0.0.1:4111/ws?token=legacy-secret",
+      },
+      location: { origin: "http://fallback.test" },
+    });
+
+    expect(resolveWsHttpUrl("/api/attachment")).toBe(
+      "http://127.0.0.1:4111/api/attachment?token=legacy-secret",
+    );
+  });
+
+  it("does not forward the websocket token to an absolute external URL", () => {
+    vi.stubGlobal("window", {
+      desktopBridge: {
+        getWsUrl: () => "wss://synara.test/ws?token=legacy-secret",
+      },
+      location: { origin: "https://fallback.test" },
+    });
+
+    expect(resolveWsHttpUrl("https://example.test/image.png")).toBe(
+      "https://example.test/image.png",
+    );
+  });
+});

--- a/apps/web/src/lib/wsHttpUrl.ts
+++ b/apps/web/src/lib/wsHttpUrl.ts
@@ -24,9 +24,12 @@ export function resolveWsHttpUrl(rawPath: string): string {
     const wsUrl = new URL(wsCandidate);
     const protocol =
       wsUrl.protocol === "wss:" ? "https:" : wsUrl.protocol === "ws:" ? "http:" : wsUrl.protocol;
-    const httpUrl = new URL(rawPath, `${protocol}//${wsUrl.host}`);
+    const serverUrl = new URL(`${protocol}//${wsUrl.host}`);
+    const httpUrl = new URL(rawPath, serverUrl);
     const legacyToken = wsUrl.searchParams.get("token");
-    if (legacyToken && !httpUrl.searchParams.has("token")) {
+    const targetsServerOrigin =
+      httpUrl.protocol === serverUrl.protocol && httpUrl.host === serverUrl.host;
+    if (legacyToken && targetsServerOrigin && !httpUrl.searchParams.has("token")) {
       httpUrl.searchParams.set("token", legacyToken);
     }
     return httpUrl.toString();


### PR DESCRIPTION
## Summary
- forward the legacy WebSocket token only when the resolved HTTP URL still targets the Synara server origin
- preserve existing behavior for relative/internal routes
- add regression coverage for both same-origin forwarding and absolute external URLs

## Why
`resolveWsHttpUrl()` accepts any URL-compatible string. `new URL(rawPath, serverOrigin)` preserves an absolute external URL, but the previous implementation still appended the WebSocket `token` query parameter to it. The current callers mostly pass internal routes, yet the exported helper did not enforce the same-server invariant described by its own contract.

This change prevents a future or accidental absolute URL from receiving the server startup token.