### PR TITLE
feat: attach headless server tarball to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,10 +423,50 @@ jobs:
       - name: Publish CLI package
         run: node apps/server/scripts/cli.ts publish --tag latest --app-version "${{ needs.preflight.outputs.version }}" --verbose
 
+  build_server_tarball:
+    name: Build server tarball
+    if: ${{ needs.preflight.outputs.publish_release == 'true' }}
+    needs: [preflight, build]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.preflight.outputs.ref }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
+
+      - name: Install dependencies
+        # Preflight already validates lifecycle scripts; this job only needs
+        # dependencies available to build the package.
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Build server package
+        run: bun run build --filter=@synara/web --filter=@synara/cli
+
+      - name: Pack server tarball
+        run: node apps/server/scripts/cli.ts pack --out release-server --app-version "${{ needs.preflight.outputs.version }}"
+
+      - name: Upload server tarball
+        uses: actions/upload-artifact@v7
+        with:
+          name: server-tarball
+          path: release-server/*.tar.gz
+          if-no-files-found: error
+
   release:
     name: Publish GitHub Release
     if: ${{ needs.preflight.outputs.publish_release == 'true' }}
-    needs: [preflight, build]
+    needs: [preflight, build, build_server_tarball]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -447,6 +487,12 @@ jobs:
         with:
           pattern: desktop-*
           merge-multiple: true
+          path: release-assets
+
+      - name: Download server tarball
+        uses: actions/download-artifact@v8
+        with:
+          name: server-tarball
           path: release-assets
 
       - name: Merge macOS updater manifests
@@ -552,6 +598,7 @@ jobs:
             release-assets/*.blockmap
             release-assets/*.yml
             release-assets/*.provenance.json
+            release-assets/*.tar.gz
           fail_on_unmatched_files: true
 
       - name: Mirror Synara artifacts onto the pinned updater feed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -429,6 +429,8 @@ jobs:
     needs: [preflight, build]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -166,6 +166,90 @@ const buildCmd = Command.make(
 ).pipe(Command.withDescription("Build the server package (tsdown + bundle web client)."));
 
 // ---------------------------------------------------------------------------
+// distribution staging (shared by publish and pack)
+// ---------------------------------------------------------------------------
+
+const stageDistributionPackage = Effect.fn("stageDistributionPackage")(function* (
+  appVersion: Option.Option<string>,
+) {
+  const path = yield* Path.Path;
+  const fs = yield* FileSystem.FileSystem;
+  const repoRoot = yield* RepoRoot;
+  const serverDir = path.join(repoRoot, "apps/server");
+
+  // Assert build assets exist
+  for (const relPath of [
+    "dist/index.mjs",
+    "dist/restoreMigrationBackup.mjs",
+    "dist/client/index.html",
+  ]) {
+    const abs = path.join(serverDir, relPath);
+    if (!(yield* fs.exists(abs))) {
+      return yield* new CliError({
+        message: `Missing build asset: ${abs}. Run the build subcommand first.`,
+      });
+    }
+  }
+
+  const version = Option.getOrElse(appVersion, () => serverPackageJson.version);
+  const pkg = {
+    name: serverPackageJson.name,
+    license: serverPackageJson.license,
+    repository: serverPackageJson.repository,
+    bin: serverPackageJson.bin,
+    type: serverPackageJson.type,
+    version,
+    engines: serverPackageJson.engines,
+    files: serverPackageJson.files,
+    dependencies: resolveCatalogDependencies(
+      serverPackageJson.dependencies as Record<string, unknown>,
+      resolveRootWorkspaceCatalog(),
+      "apps/server dependencies",
+    ),
+  };
+
+  const stagedPackageDir = yield* fs.makeTempDirectoryScoped({
+    prefix: "synara-cli-publish-",
+  });
+  yield* fs.copy(path.join(serverDir, "dist"), path.join(stagedPackageDir, "dist"));
+  for (const binTarget of Object.values(pkg.bin)) {
+    if (typeof binTarget !== "string" || !binTarget.startsWith("dist/")) {
+      return yield* new CliError({
+        message: `CLI bin target must stay inside the staged dist directory: ${String(binTarget)}`,
+      });
+    }
+    const stagedBinPath = path.join(stagedPackageDir, binTarget);
+    if (!(yield* fs.exists(stagedBinPath))) {
+      return yield* new CliError({ message: `Missing staged CLI bin target: ${binTarget}` });
+    }
+    const stagedBin = yield* fs.readFileString(stagedBinPath);
+    if (!stagedBin.startsWith("#!/usr/bin/env node\n")) {
+      return yield* new CliError({
+        message: `Staged CLI bin target is missing its Node shebang: ${binTarget}`,
+      });
+    }
+    yield* fs.chmod(stagedBinPath, 0o755);
+  }
+  yield* applyPublishIconOverrides(repoRoot, stagedPackageDir);
+  yield* fs.writeFileString(
+    path.join(stagedPackageDir, "package.json"),
+    `${JSON.stringify(pkg, null, 2)}\n`,
+  );
+  const stagedRootEntries = (yield* fs.readDirectory(stagedPackageDir)).sort();
+  if (
+    stagedRootEntries.length !== 2 ||
+    stagedRootEntries[0] !== "dist" ||
+    stagedRootEntries[1] !== "package.json"
+  ) {
+    return yield* new CliError({
+      message: `Unexpected CLI publish-stage entries: ${stagedRootEntries.join(", ")}`,
+    });
+  }
+
+  return { stagedPackageDir, version };
+});
+
+// ---------------------------------------------------------------------------
 // publish subcommand
 // ---------------------------------------------------------------------------
 
@@ -181,79 +265,7 @@ const publishCmd = Command.make(
   },
   (config) =>
     Effect.gen(function* () {
-      const path = yield* Path.Path;
-      const fs = yield* FileSystem.FileSystem;
-      const repoRoot = yield* RepoRoot;
-      const serverDir = path.join(repoRoot, "apps/server");
-
-      // Assert build assets exist
-      for (const relPath of [
-        "dist/index.mjs",
-        "dist/restoreMigrationBackup.mjs",
-        "dist/client/index.html",
-      ]) {
-        const abs = path.join(serverDir, relPath);
-        if (!(yield* fs.exists(abs))) {
-          return yield* new CliError({
-            message: `Missing build asset: ${abs}. Run the build subcommand first.`,
-          });
-        }
-      }
-
-      const version = Option.getOrElse(config.appVersion, () => serverPackageJson.version);
-      const pkg = {
-        name: serverPackageJson.name,
-        license: serverPackageJson.license,
-        repository: serverPackageJson.repository,
-        bin: serverPackageJson.bin,
-        type: serverPackageJson.type,
-        version,
-        engines: serverPackageJson.engines,
-        files: serverPackageJson.files,
-        dependencies: resolveCatalogDependencies(
-          serverPackageJson.dependencies as Record<string, unknown>,
-          resolveRootWorkspaceCatalog(),
-          "apps/server dependencies",
-        ),
-      };
-
-      const stagedPackageDir = yield* fs.makeTempDirectoryScoped({
-        prefix: "synara-cli-publish-",
-      });
-      yield* fs.copy(path.join(serverDir, "dist"), path.join(stagedPackageDir, "dist"));
-      for (const binTarget of Object.values(pkg.bin)) {
-        if (typeof binTarget !== "string" || !binTarget.startsWith("dist/")) {
-          return yield* new CliError({
-            message: `CLI bin target must stay inside the staged dist directory: ${String(binTarget)}`,
-          });
-        }
-        const stagedBinPath = path.join(stagedPackageDir, binTarget);
-        if (!(yield* fs.exists(stagedBinPath))) {
-          return yield* new CliError({ message: `Missing staged CLI bin target: ${binTarget}` });
-        }
-        const stagedBin = yield* fs.readFileString(stagedBinPath);
-        if (!stagedBin.startsWith("#!/usr/bin/env node\n")) {
-          return yield* new CliError({
-            message: `Staged CLI bin target is missing its Node shebang: ${binTarget}`,
-          });
-        }
-        yield* fs.chmod(stagedBinPath, 0o755);
-      }
-      yield* applyPublishIconOverrides(repoRoot, stagedPackageDir);
-      yield* fs.writeFileString(
-        path.join(stagedPackageDir, "package.json"),
-        `${JSON.stringify(pkg, null, 2)}\n`,
-      );
-      const stagedRootEntries = (yield* fs.readDirectory(stagedPackageDir)).sort();
-      if (
-        stagedRootEntries.length !== 2 ||
-        stagedRootEntries[0] !== "dist" ||
-        stagedRootEntries[1] !== "package.json"
-      ) {
-        return yield* new CliError({
-          message: `Unexpected CLI publish-stage entries: ${stagedRootEntries.join(", ")}`,
-        });
-      }
+      const { stagedPackageDir } = yield* stageDistributionPackage(config.appVersion);
 
       const args = ["publish", "--access", config.access, "--tag", config.tag];
       if (config.provenance) args.push("--provenance");
@@ -273,12 +285,51 @@ const publishCmd = Command.make(
 ).pipe(Command.withDescription("Publish the server package to npm."));
 
 // ---------------------------------------------------------------------------
+// pack subcommand
+// ---------------------------------------------------------------------------
+
+const packCmd = Command.make(
+  "pack",
+  {
+    out: Flag.string("out").pipe(Flag.withDefault("release-server")),
+    appVersion: Flag.string("app-version").pipe(Flag.optional),
+  },
+  (config) =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const fs = yield* FileSystem.FileSystem;
+
+      const { stagedPackageDir, version } = yield* stageDistributionPackage(config.appVersion);
+
+      const outDir = path.isAbsolute(config.out)
+        ? config.out
+        : path.join(process.cwd(), config.out);
+      yield* fs.makeDirectory(outDir, { recursive: true });
+
+      const tarballPath = path.join(outDir, `synara-server-${version}.tar.gz`);
+      yield* runCommand(
+        ChildProcess.make("tar", ["-czf", tarballPath, "dist", "package.json"], {
+          cwd: stagedPackageDir,
+          stdout: "inherit",
+          stderr: "inherit",
+          // Windows needs shell mode to resolve .cmd shims.
+          shell: process.platform === "win32",
+        }),
+      );
+
+      yield* Effect.log(`[cli] Wrote server tarball: ${tarballPath}`);
+    }),
+).pipe(
+  Command.withDescription("Produce a synara-server-<version>.tar.gz from the staged package."),
+);
+
+// ---------------------------------------------------------------------------
 // root command
 // ---------------------------------------------------------------------------
 
 const cli = Command.make("cli").pipe(
   Command.withDescription("Synara server build & publish CLI."),
-  Command.withSubcommands([buildCmd, publishCmd]),
+  Command.withSubcommands([buildCmd, publishCmd, packCmd]),
 );
 
 Command.run(cli, { version: "0.0.0" }).pipe(

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -153,7 +153,12 @@ function verifyReleaseWorkflowSafety(): void {
   );
   assertContains(
     workflow,
-    "  release:\n    name: Publish GitHub Release\n    if: ${{ needs.preflight.outputs.publish_release == 'true' }}\n    needs: [preflight, build]\n    runs-on: ubuntu-24.04\n    timeout-minutes: 10\n    permissions:\n      contents: write",
+    "  build_server_tarball:\n    name: Build server tarball\n    if: ${{ needs.preflight.outputs.publish_release == 'true' }}\n    needs: [preflight, build]\n    runs-on: ubuntu-24.04\n    timeout-minutes: 10\n    permissions:\n      contents: read",
+    "Expected server tarball builds to receive read-only repository access.",
+  );
+  assertContains(
+    workflow,
+    "  release:\n    name: Publish GitHub Release\n    if: ${{ needs.preflight.outputs.publish_release == 'true' }}\n    needs: [preflight, build, build_server_tarball]\n    runs-on: ubuntu-24.04\n    timeout-minutes: 10\n    permissions:\n      contents: write",
     "Expected only GitHub release publication to receive contents write access.",
   );
   assertContains(


### PR DESCRIPTION
Closes #404. Revives the unmerged approach from #401 onto current main.

## Problem

Releases ship desktop installers plus optional npm publishing of `@synara/cli`, but there is no plain tarball of the headless server (tsdown bundle with the web client embedded) attached to the GitHub Release. Self-hosting a specific version means building from source or relying on the npm registry. Remote hosts work in #366 will later fetch exactly this artifact when bootstrapping a host.

## Change

- Extract shared `stageDistributionPackage` from the publish path in `apps/server/scripts/cli.ts` (assert build assets, stage `dist/` + rewritten `package.json` with catalog deps resolved, bin shebang checks, publish icon overrides). `publish` behavior is unchanged.
- New `pack` subcommand: `node apps/server/scripts/cli.ts pack --out <dir> [--app-version <v>]` stages the same layout and writes `synara-server-<version>.tar.gz` containing only `dist/` and `package.json`.
- New `build_server_tarball` job in `release.yml` (modeled on `publish_cli`, not gated on `SYNARA_PUBLISH_CLI`). The `release` job downloads it and includes `*.tar.gz` in release assets.

## How to use the artifact

```bash
tar -xzf synara-server-<version>.tar.gz
npm install --omit=dev
node dist/index.mjs
```

## Testing

- Built locally (`bun run build --filter=@synara/web --filter=@synara/cli`), ran `pack`, verified tarball contains `package.json`, `dist/index.mjs`, and `dist/client/index.html`.
- Extracted to a clean directory, ran `npm install --omit=dev` and `node dist/index.mjs --version` → `synara v0.7.2`.
- `bun fmt`, `bun lint`, and `bun typecheck` pass.