### PR TITLE
fix(web): show assistant replies without reload after background completion (#548)

### DIFF
--- a/apps/web/src/components/EventRouter.browser.tsx
+++ b/apps/web/src/components/EventRouter.browser.tsx
@@ -963,7 +963,169 @@ describe("EventRouter scoped orchestration sync", () => {
       fixture = buildFixture();
       await mounted.cleanup();
     }
-  }, 60_000);
+  }, 120_000);
+
+  it("keeps the terminal fence until a post-settle snapshot includes the assistant reply", async () => {
+    // Mirrors #548: session-set lands (and a premature detail snapshot is taken)
+    // before buffered assistant finals are projected. Clearing the fence on that
+    // first snapshot left the UI spinning until a full reload.
+    const turnId = TurnId.makeUnsafe("turn-fence-premature-snapshot");
+    const finalMessageId = MessageId.makeUnsafe("msg-fence-premature-final");
+    const startedAt = "2026-03-04T12:00:04.000Z";
+    const completedAt = "2026-03-04T12:00:09.000Z";
+    fixture = {
+      ...fixture,
+      snapshot: createSnapshot({
+        latestTurn: {
+          turnId,
+          state: "running",
+          requestedAt: startedAt,
+          startedAt,
+          completedAt: null,
+          assistantMessageId: null,
+        },
+        session: {
+          threadId: THREAD_ID,
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "full-access",
+          activeTurnId: turnId,
+          lastError: null,
+          updatedAt: startedAt,
+        },
+        updatedAt: startedAt,
+      }),
+    };
+    const mounted = await mountApp();
+
+    try {
+      const currentThread = getThreadDetailFromFixtureSnapshot(THREAD_ID);
+      // Premature authoritative projection: terminal at the session-set sequence,
+      // with an assistantMessageId that has not been projected into messages yet.
+      fixture = {
+        ...fixture,
+        snapshot: {
+          ...fixture.snapshot,
+          snapshotSequence: 2,
+          updatedAt: completedAt,
+          threads: [
+            {
+              ...currentThread,
+              latestTurn: {
+                turnId,
+                state: "completed",
+                requestedAt: startedAt,
+                startedAt,
+                completedAt,
+                assistantMessageId: finalMessageId,
+              },
+              messages: [...currentThread.messages],
+              session: {
+                threadId: THREAD_ID,
+                status: "ready",
+                providerName: "codex",
+                runtimeMode: "full-access",
+                activeTurnId: null,
+                lastError: null,
+                updatedAt: completedAt,
+              },
+              updatedAt: completedAt,
+            },
+          ],
+        },
+      };
+
+      delayNextThreadDetailSnapshotResponse = true;
+
+      sendThreadEventPush({
+        sequence: 2,
+        eventId: EventId.makeUnsafe("event-fence-premature-session-ready"),
+        aggregateKind: "thread",
+        aggregateId: THREAD_ID,
+        occurredAt: completedAt,
+        commandId: null,
+        causationEventId: null,
+        correlationId: null,
+        metadata: {},
+        type: "thread.session-set",
+        payload: {
+          threadId: THREAD_ID,
+          session: {
+            threadId: THREAD_ID,
+            status: "ready",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: completedAt,
+          },
+        },
+      });
+
+      await vi.waitFor(() => {
+        const thread = getThreadFromState(useStore.getState(), THREAD_ID);
+        expect(thread?.latestTurn?.state).toBe("completed");
+        expect(thread?.messages.some((message) => message.id === finalMessageId)).toBe(false);
+      });
+
+      await vi.waitFor(
+        () => {
+          expect(getThreadDetailSnapshotRequestCount).toBeGreaterThan(0);
+          expect(pendingThreadDetailSnapshotResponse).not.toBeNull();
+        },
+        { timeout: 10_000, interval: 16 },
+      );
+
+      sendPendingThreadDetailSnapshotResponse();
+
+      await new Promise<void>((resolve) => window.setTimeout(resolve, 200));
+      expect(
+        getThreadFromState(useStore.getState(), THREAD_ID)?.messages.some(
+          (message) => message.id === finalMessageId,
+        ),
+      ).toBe(false);
+
+      fixture = {
+        ...fixture,
+        snapshot: {
+          ...fixture.snapshot,
+          snapshotSequence: 3,
+          threads: [
+            {
+              ...fixture.snapshot.threads[0]!,
+              messages: [
+                ...currentThread.messages,
+                {
+                  id: finalMessageId,
+                  role: "assistant",
+                  text: "Recovered without a reload.",
+                  turnId,
+                  streaming: false,
+                  source: "native",
+                  createdAt: completedAt,
+                  updatedAt: completedAt,
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      await vi.waitFor(
+        () => {
+          const thread = getThreadFromState(useStore.getState(), THREAD_ID);
+          expect(getThreadDetailSnapshotRequestCount).toBeGreaterThan(1);
+          expect(thread?.messages.find((message) => message.id === finalMessageId)?.text).toBe(
+            "Recovered without a reload.",
+          );
+        },
+        { timeout: 15_000, interval: 16 },
+      );
+    } finally {
+      fixture = buildFixture();
+      await mounted.cleanup();
+    }
+  }, 120_000);
 
   it("reconciles a missed completion from the authoritative thread projection", async () => {
     const turnId = TurnId.makeUnsafe("turn-missed-completion");

--- a/apps/web/src/routes/-threadTerminalFence.test.ts
+++ b/apps/web/src/routes/-threadTerminalFence.test.ts
@@ -1,0 +1,160 @@
+import { MessageId } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+  doesSnapshotSatisfyTerminalFence,
+  isTerminalThreadSessionStatus,
+  TERMINAL_FENCE_EMPTY_TURN_HOLD_MS,
+} from "./-threadTerminalFence";
+
+describe("isTerminalThreadSessionStatus", () => {
+  it.each(["ready", "interrupted", "stopped", "error"] as const)(
+    "treats %s as terminal",
+    (status) => {
+      expect(isTerminalThreadSessionStatus(status)).toBe(true);
+    },
+  );
+
+  it.each(["running", "starting", "connecting"] as const)("treats %s as non-terminal", (status) => {
+    expect(isTerminalThreadSessionStatus(status)).toBe(false);
+  });
+});
+
+describe("doesSnapshotSatisfyTerminalFence", () => {
+  const assistantId = MessageId.makeUnsafe("assistant-1");
+  const armedAtMs = 1_000;
+
+  it("rejects a still-running session even when the snapshot advanced past the fence", () => {
+    expect(
+      doesSnapshotSatisfyTerminalFence({
+        snapshotSequence: 10,
+        fenceSequence: 5,
+        sessionStatus: "running",
+        latestTurn: {
+          state: "running",
+          assistantMessageId: null,
+        },
+        messages: [],
+        armedAtMs,
+        nowMs: armedAtMs + 10_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts a terminal snapshot projected after the session-set fence sequence", () => {
+    expect(
+      doesSnapshotSatisfyTerminalFence({
+        snapshotSequence: 6,
+        fenceSequence: 5,
+        sessionStatus: "ready",
+        latestTurn: {
+          state: "completed",
+          assistantMessageId: assistantId,
+        },
+        messages: [{ id: assistantId }],
+        armedAtMs,
+        nowMs: armedAtMs,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps the fence when the snapshot is still at the session-set sequence without the assistant row", () => {
+    expect(
+      doesSnapshotSatisfyTerminalFence({
+        snapshotSequence: 5,
+        fenceSequence: 5,
+        sessionStatus: "ready",
+        latestTurn: {
+          state: "completed",
+          assistantMessageId: assistantId,
+        },
+        messages: [],
+        armedAtMs,
+        nowMs: armedAtMs + 100,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps a buffered-style completed+null snapshot at the fence sequence before the empty-turn hold", () => {
+    expect(
+      doesSnapshotSatisfyTerminalFence({
+        snapshotSequence: 5,
+        fenceSequence: 5,
+        sessionStatus: "ready",
+        latestTurn: {
+          state: "completed",
+          assistantMessageId: null,
+        },
+        messages: [],
+        armedAtMs,
+        nowMs: armedAtMs + TERMINAL_FENCE_EMPTY_TURN_HOLD_MS - 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts a same-sequence terminal snapshot once the assistant row is present", () => {
+    expect(
+      doesSnapshotSatisfyTerminalFence({
+        snapshotSequence: 5,
+        fenceSequence: 5,
+        sessionStatus: "ready",
+        latestTurn: {
+          state: "completed",
+          assistantMessageId: assistantId,
+        },
+        messages: [{ id: assistantId }],
+        armedAtMs,
+        nowMs: armedAtMs,
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts a same-sequence empty completed turn only after the hold window", () => {
+    expect(
+      doesSnapshotSatisfyTerminalFence({
+        snapshotSequence: 5,
+        fenceSequence: 5,
+        sessionStatus: "ready",
+        latestTurn: {
+          state: "completed",
+          assistantMessageId: null,
+        },
+        messages: [],
+        armedAtMs,
+        nowMs: armedAtMs + TERMINAL_FENCE_EMPTY_TURN_HOLD_MS,
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts interrupted and error turns at the fence sequence immediately", () => {
+    expect(
+      doesSnapshotSatisfyTerminalFence({
+        snapshotSequence: 5,
+        fenceSequence: 5,
+        sessionStatus: "interrupted",
+        latestTurn: {
+          state: "interrupted",
+          assistantMessageId: assistantId,
+        },
+        messages: [],
+        armedAtMs,
+        nowMs: armedAtMs,
+      }),
+    ).toBe(true);
+
+    expect(
+      doesSnapshotSatisfyTerminalFence({
+        snapshotSequence: 5,
+        fenceSequence: 5,
+        sessionStatus: "error",
+        latestTurn: {
+          state: "error",
+          assistantMessageId: null,
+        },
+        messages: [],
+        armedAtMs,
+        nowMs: armedAtMs,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/routes/-threadTerminalFence.test.ts
+++ b/apps/web/src/routes/-threadTerminalFence.test.ts
@@ -75,6 +75,23 @@ describe("doesSnapshotSatisfyTerminalFence", () => {
     ).toBe(false);
   });
 
+  it("keeps the fence when an unrelated projection advanced but the assistant row is absent", () => {
+    expect(
+      doesSnapshotSatisfyTerminalFence({
+        snapshotSequence: 6,
+        fenceSequence: 5,
+        sessionStatus: "ready",
+        latestTurn: {
+          state: "completed",
+          assistantMessageId: assistantId,
+        },
+        messages: [],
+        armedAtMs,
+        nowMs: armedAtMs + 10_000,
+      }),
+    ).toBe(false);
+  });
+
   it("keeps a buffered-style completed+null snapshot at the fence sequence before the empty-turn hold", () => {
     expect(
       doesSnapshotSatisfyTerminalFence({

--- a/apps/web/src/routes/-threadTerminalFence.ts
+++ b/apps/web/src/routes/-threadTerminalFence.ts
@@ -1,0 +1,73 @@
+// FILE: -threadTerminalFence.ts
+// Purpose: Decide when a terminal-session fence can be retired after projection reconcile.
+// Layer: Web EventRouter helper
+// Why: ProviderRuntimeIngestion settles the session before it flushes buffered
+//      assistant finals. A snapshot taken at the session-set sequence can look
+//      terminal while the reply text has not been projected yet. Clearing the
+//      fence there leaves the UI stuck on a spinner until a full reload (#548).
+
+export function isTerminalThreadSessionStatus(status: string): boolean {
+  return (
+    status === "ready" || status === "interrupted" || status === "stopped" || status === "error"
+  );
+}
+
+/**
+ * Empty completed turns never project a post-settle event, so the fence sequence
+ * never advances. After this hold a same-sequence terminal snapshot with no
+ * assistant row is allowed to retire the fence. Buffered finals in the same
+ * ingestion turn normally advance the sequence long before this elapses.
+ */
+export const TERMINAL_FENCE_EMPTY_TURN_HOLD_MS = 1_500;
+
+/**
+ * A terminal fence armed at `fenceSequence` (the session-set / shell upsert that
+ * ended the turn) must keep reconciling until the detail snapshot proves the
+ * post-settle assistant finals have been projected — or that none will arrive.
+ */
+export function doesSnapshotSatisfyTerminalFence(input: {
+  readonly snapshotSequence: number;
+  readonly fenceSequence: number;
+  readonly sessionStatus: string | null | undefined;
+  readonly latestTurn: {
+    readonly state: string;
+    readonly assistantMessageId: string | null;
+  } | null;
+  readonly messages: ReadonlyArray<{ readonly id: string }>;
+  readonly armedAtMs: number;
+  readonly nowMs: number;
+}): boolean {
+  if (
+    input.sessionStatus === null ||
+    input.sessionStatus === undefined ||
+    !isTerminalThreadSessionStatus(input.sessionStatus)
+  ) {
+    return false;
+  }
+
+  // Anything projected after the terminal session-set includes the buffered
+  // assistant finalize commands that follow it in the same ingestion turn.
+  if (input.snapshotSequence > input.fenceSequence) {
+    return true;
+  }
+
+  const latestTurn = input.latestTurn;
+  if (latestTurn === null) {
+    return true;
+  }
+  if (latestTurn.state === "interrupted" || latestTurn.state === "error") {
+    return true;
+  }
+
+  if (
+    latestTurn.assistantMessageId !== null &&
+    input.messages.some((message) => message.id === latestTurn.assistantMessageId)
+  ) {
+    return true;
+  }
+
+  // Still at the session-set sequence without an assistant row. Buffered turns
+  // look like this briefly (completed + null assistantMessageId) before finals
+  // land; only empty turns stay here permanently, so require the hold window.
+  return input.nowMs - input.armedAtMs >= TERMINAL_FENCE_EMPTY_TURN_HOLD_MS;
+}

--- a/apps/web/src/routes/-threadTerminalFence.ts
+++ b/apps/web/src/routes/-threadTerminalFence.ts
@@ -45,11 +45,7 @@ export function doesSnapshotSatisfyTerminalFence(input: {
     return false;
   }
 
-  // Anything projected after the terminal session-set includes the buffered
-  // assistant finalize commands that follow it in the same ingestion turn.
-  if (input.snapshotSequence > input.fenceSequence) {
-    return true;
-  }
+  if (input.snapshotSequence < input.fenceSequence) return false;
 
   const latestTurn = input.latestTurn;
   if (latestTurn === null) {
@@ -66,8 +62,10 @@ export function doesSnapshotSatisfyTerminalFence(input: {
     return true;
   }
 
-  // Still at the session-set sequence without an assistant row. Buffered turns
-  // look like this briefly (completed + null assistantMessageId) before finals
-  // land; only empty turns stay here permanently, so require the hold window.
+  // A global projection sequence can advance because another thread was
+  // updated while this turn's buffered final is still waiting. The expected
+  // assistant row, not sequence advancement alone, is the proof that the reply
+  // is visible. Only genuinely empty turns may retire after the hold window.
+  if (latestTurn.assistantMessageId !== null) return false;
   return input.nowMs - input.armedAtMs >= TERMINAL_FENCE_EMPTY_TURN_HOLD_MS;
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -96,6 +96,10 @@ import {
 } from "../threadDetailResumeCursors";
 import { hasPendingTurnDispatch } from "../pendingTurnDispatch";
 import { canApplyThreadSnapshot, selectOrphanedThreadDetailIds } from "./-threadDetailOwnership";
+import {
+  doesSnapshotSatisfyTerminalFence,
+  isTerminalThreadSessionStatus,
+} from "./-threadTerminalFence";
 import { getThreadFromState, getThreadsFromState } from "../threadDerivation";
 import { useAppDensity } from "../hooks/useAppDensity";
 import { useChatWidth } from "../hooks/useChatWidth";
@@ -146,6 +150,8 @@ import { createDesktopProjectRecoveryAttemptGate } from "./-desktopProjectRecove
 const SHELL_SNAPSHOT_BOOTSTRAP_FALLBACK_DELAY_MS = 1_500;
 const THREAD_DETAIL_CATCHUP_INTERVAL_MS = 1_500;
 const THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS = 4_500;
+/** First terminal-fence reconcile runs quickly so post-settle finals are not left hanging. */
+const THREAD_DETAIL_TERMINAL_FENCE_RECONCILE_DELAY_MS = 500;
 const THREAD_DETAIL_PROJECTION_RECONCILE_MAX_CONCURRENCY = 2;
 // Bounded backoff for the periodic catch-up polls while a healthy live stream
 // keeps delivering everything: consecutive empty replays stretch the 1.5s poll
@@ -980,12 +986,6 @@ function shouldReconcileThreadProjection(threadId: ThreadId): boolean {
   );
 }
 
-function isTerminalThreadSessionStatus(status: string): boolean {
-  return (
-    status === "ready" || status === "interrupted" || status === "stopped" || status === "error"
-  );
-}
-
 /**
  * Frees the detail of threads whose stream lease just dropped and that nothing
  * else owns. Batched into one store write because every write re-runs the
@@ -1116,10 +1116,38 @@ function EventRouter() {
     const threadReplayRequestInFlight = new Set<ThreadId>();
     const threadProjectionReconcileInFlight = new Map<ThreadId, number>();
     const threadProjectionTerminalFencePending = new Set<ThreadId>();
+    // Sequence of the session-set / shell upsert that armed each terminal fence.
+    // Cleared only once a detail snapshot proves post-settle assistant finals
+    // have been projected (see doesSnapshotSatisfyTerminalFence).
+    const threadProjectionTerminalFenceSequenceById = new Map<ThreadId, number>();
+    const threadProjectionTerminalFenceArmedAtById = new Map<ThreadId, number>();
     const threadSubscriptionGenerationById = new Map<ThreadId, number>();
     const nextThreadProjectionReconcileAtById = new Map<ThreadId, number>();
     let nextThreadSubscriptionGeneration = 0;
     let reconcileThreadSubscriptionsChain = Promise.resolve();
+
+    const armThreadProjectionTerminalFence = (threadId: ThreadId, sequence: number): void => {
+      threadProjectionTerminalFencePending.add(threadId);
+      // Keep the earliest arming sequence / clock: a later ready upsert must not
+      // raise the bar past finals that already landed after the first settle.
+      const previousSequence = threadProjectionTerminalFenceSequenceById.get(threadId);
+      if (previousSequence === undefined || sequence < previousSequence) {
+        threadProjectionTerminalFenceSequenceById.set(threadId, sequence);
+      }
+      if (!threadProjectionTerminalFenceArmedAtById.has(threadId)) {
+        threadProjectionTerminalFenceArmedAtById.set(threadId, Date.now());
+      }
+      nextThreadProjectionReconcileAtById.set(
+        threadId,
+        Date.now() + THREAD_DETAIL_TERMINAL_FENCE_RECONCILE_DELAY_MS,
+      );
+    };
+
+    const clearThreadProjectionTerminalFence = (threadId: ThreadId): void => {
+      threadProjectionTerminalFencePending.delete(threadId);
+      threadProjectionTerminalFenceSequenceById.delete(threadId);
+      threadProjectionTerminalFenceArmedAtById.delete(threadId);
+    };
 
     const isDraftThreadAwaitingProjection = (threadId: ThreadId): boolean => {
       if (useComposerDraftStore.getState().draftThreadsByThreadId[threadId] === undefined) {
@@ -1206,7 +1234,7 @@ function EventRouter() {
       threadSnapshotRefreshPending.delete(threadId);
       threadSnapshotNotFoundRetryAttempted.delete(threadId);
       threadProjectionReconcileInFlight.delete(threadId);
-      threadProjectionTerminalFencePending.delete(threadId);
+      clearThreadProjectionTerminalFence(threadId);
       threadCatchupBackoffById.delete(threadId);
       nextThreadSubscriptionGeneration += 1;
       threadSubscriptionGenerationById.set(threadId, nextThreadSubscriptionGeneration);
@@ -1287,7 +1315,7 @@ function EventRouter() {
         threadSnapshotNotFoundRetryAttempted.delete(threadId);
         threadReplayRequestInFlight.delete(threadId);
         threadProjectionReconcileInFlight.delete(threadId);
-        threadProjectionTerminalFencePending.delete(threadId);
+        clearThreadProjectionTerminalFence(threadId);
         threadSubscriptionGenerationById.delete(threadId);
         nextThreadProjectionReconcileAtById.delete(threadId);
         threadCatchupBackoffById.delete(threadId);
@@ -1450,6 +1478,8 @@ function EventRouter() {
           threadReplayRequestInFlight.clear();
           threadProjectionReconcileInFlight.clear();
           threadProjectionTerminalFencePending.clear();
+          threadProjectionTerminalFenceSequenceById.clear();
+          threadProjectionTerminalFenceArmedAtById.clear();
           threadSubscriptionGenerationById.clear();
           nextThreadProjectionReconcileAtById.clear();
           threadCatchupBackoffById.clear();
@@ -1660,6 +1690,7 @@ function EventRouter() {
       }
       threadProjectionReconcileInFlight.set(threadId, subscriptionGeneration);
       let projectionConfirmed = false;
+      let projectionSatisfiesTerminalFence = false;
       let projectionAttemptFailed = false;
       try {
         const snapshot = await api.orchestration.getThreadDetailSnapshot({ threadId });
@@ -1687,6 +1718,20 @@ function EventRouter() {
           snapshot.thread.latestTurn.turnId === currentThread.latestTurn.turnId &&
           snapshot.thread.latestTurn.state !== "running" &&
           snapshot.thread.latestTurn.completedAt !== null;
+        const fenceIsPending = threadProjectionTerminalFencePending.has(threadId);
+        const fenceSequence = threadProjectionTerminalFenceSequenceById.get(threadId) ?? -1;
+        const fenceArmedAtMs = threadProjectionTerminalFenceArmedAtById.get(threadId) ?? Date.now();
+        projectionSatisfiesTerminalFence =
+          fenceIsPending &&
+          doesSnapshotSatisfyTerminalFence({
+            snapshotSequence: snapshot.snapshotSequence,
+            fenceSequence,
+            sessionStatus: snapshot.thread.session?.status,
+            latestTurn: snapshot.thread.latestTurn,
+            messages: snapshot.thread.messages,
+            armedAtMs: fenceArmedAtMs,
+            nowMs: Date.now(),
+          });
         threadSnapshotSequenceById.set(
           threadId,
           Math.max(currentSequence, snapshot.snapshotSequence),
@@ -1730,8 +1775,10 @@ function EventRouter() {
             // snapshot was merely superseded by newer live events.
             resolveThreadCatchupBackoff(threadId).reconcileNoopStreak = 0;
           }
-          if (projectionConfirmed) {
-            threadProjectionTerminalFencePending.delete(threadId);
+          // Never retire the fence on a still-running snapshot or one taken at
+          // the exact session-set sequence before buffered assistant finals land.
+          if (projectionConfirmed && projectionSatisfiesTerminalFence) {
+            clearThreadProjectionTerminalFence(threadId);
           }
           if (
             threadProjectionTerminalFencePending.has(threadId) ||
@@ -1793,11 +1840,7 @@ function EventRouter() {
         item.thread.session !== null &&
         isTerminalThreadSessionStatus(item.thread.session.status)
       ) {
-        threadProjectionTerminalFencePending.add(item.thread.id);
-        nextThreadProjectionReconcileAtById.set(
-          item.thread.id,
-          Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
-        );
+        armThreadProjectionTerminalFence(item.thread.id, item.sequence);
       }
       if (
         item.kind === "thread-upserted" &&
@@ -1855,21 +1898,19 @@ function EventRouter() {
       }
 
       const threadId = ThreadId.makeUnsafe(String(item.event.aggregateId));
-      if (
-        item.event.type === "thread.session-set" &&
-        isTerminalThreadSessionStatus(item.event.payload.session.status)
-      ) {
-        threadProjectionTerminalFencePending.add(threadId);
-        nextThreadProjectionReconcileAtById.set(
-          threadId,
-          Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
-        );
-      }
       const latestThreadSequence = threadSnapshotSequenceById.get(threadId);
       if (latestThreadSequence === undefined) {
         const pendingThreadEvents = pendingThreadEventsById.get(threadId) ?? [];
         appendBounded(pendingThreadEvents, item.event, PENDING_THREAD_EVENT_BUFFER_LIMIT);
         pendingThreadEventsById.set(threadId, pendingThreadEvents);
+        if (
+          item.event.type === "thread.session-set" &&
+          isTerminalThreadSessionStatus(item.event.payload.session.status)
+        ) {
+          // Arm even while buffered: the immediate reconcile below may return a
+          // premature session-set snapshot, and the fence must outlive it (#548).
+          armThreadProjectionTerminalFence(threadId, item.event.sequence);
+        }
         if (subscribedThreadIds.has(threadId)) {
           void reconcileThreadProjection(threadId).catch(() => undefined);
         }
@@ -1881,10 +1922,19 @@ function EventRouter() {
       if (!applyFencedThreadEvent(threadId, item.event)) {
         return;
       }
-      nextThreadProjectionReconcileAtById.set(
-        threadId,
-        Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
-      );
+      if (
+        item.event.type === "thread.session-set" &&
+        isTerminalThreadSessionStatus(item.event.payload.session.status)
+      ) {
+        // Arm after the generic post-event schedule so the fast first-reconcile
+        // delay is not overwritten back to the slower cadence.
+        armThreadProjectionTerminalFence(threadId, item.event.sequence);
+      } else {
+        nextThreadProjectionReconcileAtById.set(
+          threadId,
+          Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,
+        );
+      }
     });
     const unsubThreadStreamFailure = onThreadStreamFailure((failure) => {
       const threadId = ThreadId.makeUnsafe(failure.threadId);
@@ -2170,6 +2220,8 @@ function EventRouter() {
       pendingStudioOutputInvalidationThreadIds = new Set();
       threadProjectionReconcileInFlight.clear();
       threadProjectionTerminalFencePending.clear();
+      threadProjectionTerminalFenceSequenceById.clear();
+      threadProjectionTerminalFenceArmedAtById.clear();
       threadSubscriptionGenerationById.clear();
       nextThreadProjectionReconcileAtById.clear();
       threadCatchupBackoffById.clear();

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1841,6 +1841,14 @@ function EventRouter() {
         isTerminalThreadSessionStatus(item.thread.session.status)
       ) {
         armThreadProjectionTerminalFence(item.thread.id, item.sequence);
+      } else if (
+        item.kind === "thread-upserted" &&
+        subscribedThreadIds.has(item.thread.id) &&
+        item.thread.session !== null
+      ) {
+        // A new turn needs its own terminal fence and hold clock. Do not let an
+        // unresolved fence from the previous turn carry into the running one.
+        clearThreadProjectionTerminalFence(item.thread.id);
       }
       if (
         item.kind === "thread-upserted" &&
@@ -1910,6 +1918,8 @@ function EventRouter() {
           // Arm even while buffered: the immediate reconcile below may return a
           // premature session-set snapshot, and the fence must outlive it (#548).
           armThreadProjectionTerminalFence(threadId, item.event.sequence);
+        } else if (item.event.type === "thread.session-set") {
+          clearThreadProjectionTerminalFence(threadId);
         }
         if (subscribedThreadIds.has(threadId)) {
           void reconcileThreadProjection(threadId).catch(() => undefined);
@@ -1930,6 +1940,9 @@ function EventRouter() {
         // delay is not overwritten back to the slower cadence.
         armThreadProjectionTerminalFence(threadId, item.event.sequence);
       } else {
+        if (item.event.type === "thread.session-set") {
+          clearThreadProjectionTerminalFence(threadId);
+        }
         nextThreadProjectionReconcileAtById.set(
           threadId,
           Date.now() + THREAD_DETAIL_PROJECTION_RECONCILE_INTERVAL_MS,


### PR DESCRIPTION
## Summary
- Fixes #548: assistant replies that finished server-side could stay invisible (spinner stuck) until a manual page reload.
- Root cause: the terminal projection fence was cleared when a detail snapshot arrived at the exact `thread.session-set` sequence, before ProviderRuntimeIngestion flushed buffered assistant finals into the projection.
- Hold the fence until a later snapshot sequence includes those finals (or a short empty-turn hold expires), and keep the fast first reconcile delay from being overwritten by the generic post-event schedule.

## Test plan
- [x] `bun run --cwd apps/web test -- src/routes/-threadTerminalFence.test.ts` (14 passing)
- [x] `bun run --cwd apps/web test:browser -- src/components/EventRouter.browser.tsx -t "keeps the terminal fence|reconciles a missed completion|runs one terminal reconciliation"` (3 passing)
- [x] `bun fmt && bun lint && bun typecheck`
- [ ] Manual: send consecutive messages in a live thread; confirm the assistant reply appears without Ctrl+R after background completion