### PR TITLE
feat(web): opt-in full-width side panels

### DIFF
--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -218,6 +218,12 @@ export const AppSettingsSchema = Schema.Struct({
   confirmThreadArchive: Schema.Boolean.pipe(withDefaults(() => false)),
   confirmTerminalTabClose: Schema.Boolean.pipe(withDefaults(() => true)),
   diffWordWrap: Schema.Boolean.pipe(withDefaults(() => false)),
+  // Local-only UI preference: let side panels (browser, diff, terminal, file, git, side
+  // chat) take the full window width. Off keeps the composer feasibility clamp that stops a
+  // drag as soon as the chat column can no longer render its composer, so the widest a panel
+  // can get is "chat still usable". On, the dock opens at full width and can be dragged edge
+  // to edge, collapsing the chat column out of view.
+  allowFullWidthPanels: Schema.Boolean.pipe(withDefaults(() => false)),
   showPullRequestDiffColors: Schema.Boolean.pipe(withDefaults(() => true)),
   // Local-only UI preferences for hiding sidebar surfaces a user doesn't want.
   // `showChatsSection` controls the standalone "Chats" list in the sidebar footer

--- a/apps/web/src/components/chat/RightDock.tsx
+++ b/apps/web/src/components/chat/RightDock.tsx
@@ -19,6 +19,7 @@ import {
   reconcileKeepMountedPaneIds,
 } from "~/lib/dockPaneActivation";
 import { PanelRightCloseIcon, PlusIcon } from "~/lib/icons";
+import { resolveDockOpenWidth } from "~/lib/panelWidthPolicy";
 import type {
   RightDockPane,
   RightDockPaneKind,
@@ -70,6 +71,9 @@ interface RightDockProps {
   minWidth: number;
   defaultWidth: string;
   shouldAcceptWidth: (context: { nextWidth: number; wrapper: HTMLElement }) => boolean;
+  // When true the dock opens at the full width of the chat shell instead of an even
+  // split. Driven by the `allowFullWidthPanels` app setting.
+  openFullWidth?: boolean;
   paneLabelOverrides?: Record<string, string | undefined>;
   // Per-pane tab glyph overrides (same shape as label overrides) — e.g. a pull request pane
   // swapping the generic kind icon for its live state glyph.
@@ -196,6 +200,7 @@ export function RightDock(props: RightDockProps) {
   // freely; the next open re-centers the split.
   const contentRef = useRef<HTMLDivElement | null>(null);
   const minWidth = props.minWidth;
+  const openFullWidth = props.openFullWidth ?? false;
   const activePaneKind = activePane?.kind ?? null;
   useEffect(() => {
     if (!props.state.open) {
@@ -209,12 +214,16 @@ export function RightDock(props: RightDockProps) {
     // A phone-shaped pane has a natural width: half the shell leaves the device
     // stranded in empty space, so kinds that render a fixed-aspect object open
     // at their own comfortable size instead of the even split.
-    const preferredWidth = activePaneKind ? RIGHT_DOCK_PREFERRED_WIDTH[activePaneKind] : undefined;
-    const openWidth = preferredWidth ?? Math.round(shell.getBoundingClientRect().width / 2);
-    if (openWidth > 0) {
-      wrapper.style.setProperty("--sidebar-width", `${Math.max(minWidth, openWidth)}px`);
+    const openWidth = resolveDockOpenWidth({
+      shellWidth: shell.getBoundingClientRect().width,
+      minWidth,
+      preferredWidth: activePaneKind ? RIGHT_DOCK_PREFERRED_WIDTH[activePaneKind] : undefined,
+      fullWidth: openFullWidth,
+    });
+    if (openWidth !== null) {
+      wrapper.style.setProperty("--sidebar-width", `${openWidth}px`);
     }
-  }, [props.state.open, minWidth, activePaneKind]);
+  }, [props.state.open, minWidth, activePaneKind, openFullWidth]);
   const renderedPanes = props.state.panes.filter(
     (pane) => pane.id === activePane?.id || keepMountedPaneIds.has(pane.id),
   );

--- a/apps/web/src/components/chat/SingleChatSurface.tsx
+++ b/apps/web/src/components/chat/SingleChatSurface.tsx
@@ -44,6 +44,7 @@ import type { DockPaneRuntimeMode } from "../../lib/dockPaneActivation";
 import type { FileCommentSelection } from "../../lib/fileComments";
 import { gitBranchesQueryOptions } from "../../lib/gitReactQuery";
 import { canComposerHandlePanelWidth } from "../../lib/panelResize";
+import { acceptsFullWidthPanelDrag } from "../../lib/panelWidthPolicy";
 import { projectListDirectoriesQueryOptions } from "../../lib/projectReactQuery";
 import { waitForSidechatCreator } from "../../lib/sidechatCreatorRegistry";
 import {
@@ -143,10 +144,20 @@ const allowAnySplitDirection = (_direction: SplitDirection) => true;
 function shouldAcceptDockWidth({
   nextWidth,
   wrapper,
+  allowFullWidth,
 }: {
   nextWidth: number;
   wrapper: HTMLElement;
+  allowFullWidth: boolean;
 }) {
+  // Full width opts out of the composer feasibility probe: the user has asked for a
+  // panel wider than the chat column can survive, so the only bound left is the shell.
+  if (allowFullWidth) {
+    return acceptsFullWidthPanelDrag({
+      nextWidth,
+      shellWidth: wrapper.parentElement?.clientWidth ?? 0,
+    });
+  }
   const previousSidebarWidth = wrapper.style.getPropertyValue("--sidebar-width");
   return canComposerHandlePanelWidth({
     nextWidth,
@@ -239,6 +250,12 @@ export function SingleChatSurface(props: {
   const projects = useStore((store) => store.projects);
   const threadsHydrated = useStore((store) => store.threadsHydrated);
   const { settings: appSettings } = useAppSettings();
+  const allowFullWidthPanels = appSettings.allowFullWidthPanels;
+  const handleShouldAcceptDockWidth = useCallback(
+    (context: { nextWidth: number; wrapper: HTMLElement }) =>
+      shouldAcceptDockWidth({ ...context, allowFullWidth: allowFullWidthPanels }),
+    [allowFullWidthPanels],
+  );
   const { handleNewThread } = useHandleNewThread();
   const queryClient = useQueryClient();
   const lastAppliedRoutePanelSearchKeyRef = useRef<string | null>(null);
@@ -1137,7 +1154,8 @@ export function SingleChatSurface(props: {
           state={dockState}
           minWidth={SINGLE_PANEL_MIN_WIDTH}
           defaultWidth={DIFF_INLINE_DEFAULT_WIDTH}
-          shouldAcceptWidth={shouldAcceptDockWidth}
+          shouldAcceptWidth={handleShouldAcceptDockWidth}
+          openFullWidth={appSettings.allowFullWidthPanels}
           addMenuKinds={availableDockPaneKinds}
           launcherItems={dockLauncherItems}
           motionKey={props.threadId}

--- a/apps/web/src/components/chat/SplitChatSurface.tsx
+++ b/apps/web/src/components/chat/SplitChatSurface.tsx
@@ -33,6 +33,8 @@ import {
   createPanelResizeOverlay,
   removePanelResizeOverlay,
 } from "../../lib/panelResize";
+import { acceptsFullWidthPanelDrag, resolveSplitPanelMaxWidth } from "../../lib/panelWidthPolicy";
+import { useAppSettings } from "../../appSettings";
 import { splitViewPaneScopeId } from "../../lib/chatPaneScope";
 import { resolveActiveSplitView } from "../../splitViewRoute";
 import { canSubdividePane, collectLeaves, findLeafPaneById } from "../../splitView.logic";
@@ -111,6 +113,8 @@ function SplitPaneEmbeddedPanel(props: {
   ) => void;
 }) {
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const { settings: appSettings } = useAppSettings();
+  const allowFullWidthPanels = appSettings.allowFullWidthPanels;
   const panelWidthStorageKey =
     props.panel === "browser" ? "browser" : props.panel === "diff" ? "diff" : "panel";
   const storageKey = `${RIGHT_PANEL_SIDEBAR_WIDTH_STORAGE_KEY}:${props.splitViewId}:${props.paneId}:${panelWidthStorageKey}`;
@@ -135,6 +139,14 @@ function SplitPaneEmbeddedPanel(props: {
   const shouldAcceptEmbeddedWidth = (nextWidth: number) => {
     const wrapper = wrapperRef.current;
     if (!wrapper) return true;
+    // Full width opts out of the composer feasibility probe: the user has asked for a
+    // panel wider than the chat column can survive, so the only bound left is the pane.
+    if (allowFullWidthPanels) {
+      return acceptsFullWidthPanelDrag({
+        nextWidth,
+        shellWidth: wrapper.parentElement?.clientWidth ?? 0,
+      });
+    }
     return canComposerHandlePanelWidth({
       nextWidth,
       paneScopeId: props.paneScopeId,
@@ -156,7 +168,12 @@ function SplitPaneEmbeddedPanel(props: {
     event.stopPropagation();
     const startX = event.clientX;
     const startWidth = wrapper.getBoundingClientRect().width;
-    const maxWidth = Math.max(minPanelWidth, parent.clientWidth - SPLIT_PANE_CHAT_MIN_WIDTH);
+    const maxWidth = resolveSplitPanelMaxWidth({
+      paneWidth: parent.clientWidth,
+      minPanelWidth,
+      chatMinWidth: SPLIT_PANE_CHAT_MIN_WIDTH,
+      fullWidth: allowFullWidthPanels,
+    });
     const resizeOverlay = createPanelResizeOverlay();
 
     const onPointerMove = (moveEvent: PointerEvent) => {
@@ -197,7 +214,7 @@ function SplitPaneEmbeddedPanel(props: {
       style={
         {
           width: `${panelWidth}px`,
-          maxWidth: `calc(100% - ${SPLIT_PANE_CHAT_MIN_WIDTH}px)`,
+          maxWidth: allowFullWidthPanels ? "100%" : `calc(100% - ${SPLIT_PANE_CHAT_MIN_WIDTH}px)`,
           minWidth: minPanelWidth,
         } as CSSProperties
       }

--- a/apps/web/src/lib/panelWidthPolicy.test.ts
+++ b/apps/web/src/lib/panelWidthPolicy.test.ts
@@ -1,0 +1,108 @@
+// FILE: panelWidthPolicy.test.ts
+// Purpose: Characterizes the half-width vs full-width side panel policy.
+// Layer: Web panel layout utility tests
+
+import { describe, expect, it } from "vitest";
+
+import {
+  acceptsFullWidthPanelDrag,
+  resolveDockOpenWidth,
+  resolveSplitPanelMaxWidth,
+} from "./panelWidthPolicy";
+
+describe("resolveDockOpenWidth", () => {
+  it("opens to half the shell by default", () => {
+    expect(resolveDockOpenWidth({ shellWidth: 1200, minWidth: 416, fullWidth: false })).toBe(600);
+  });
+
+  it("opens to the whole shell under full width", () => {
+    expect(resolveDockOpenWidth({ shellWidth: 1200, minWidth: 416, fullWidth: true })).toBe(1200);
+  });
+
+  it("floors a fractional shell so the dock never overflows its row", () => {
+    expect(resolveDockOpenWidth({ shellWidth: 1200.75, minWidth: 416, fullWidth: true })).toBe(
+      1200,
+    );
+  });
+
+  it("keeps the minimum width when half the shell is narrower", () => {
+    expect(resolveDockOpenWidth({ shellWidth: 300, minWidth: 416, fullWidth: false })).toBe(416);
+    expect(resolveDockOpenWidth({ shellWidth: 300, minWidth: 416, fullWidth: true })).toBe(416);
+  });
+
+  it("keeps a per-kind preferred width in both modes", () => {
+    expect(
+      resolveDockOpenWidth({
+        shellWidth: 1200,
+        minWidth: 416,
+        preferredWidth: 520,
+        fullWidth: true,
+      }),
+    ).toBe(520);
+    expect(
+      resolveDockOpenWidth({
+        shellWidth: 1200,
+        minWidth: 416,
+        preferredWidth: 520,
+        fullWidth: false,
+      }),
+    ).toBe(520);
+  });
+
+  it("returns null when the shell cannot be measured", () => {
+    expect(resolveDockOpenWidth({ shellWidth: 0, minWidth: 416, fullWidth: true })).toBeNull();
+    expect(
+      resolveDockOpenWidth({ shellWidth: Number.NaN, minWidth: 416, fullWidth: false }),
+    ).toBeNull();
+  });
+});
+
+describe("acceptsFullWidthPanelDrag", () => {
+  it("accepts a drag up to the shell edge", () => {
+    expect(acceptsFullWidthPanelDrag({ nextWidth: 1200, shellWidth: 1200 })).toBe(true);
+    expect(acceptsFullWidthPanelDrag({ nextWidth: 900, shellWidth: 1200 })).toBe(true);
+  });
+
+  it("rejects a drag past the shell edge", () => {
+    expect(acceptsFullWidthPanelDrag({ nextWidth: 1201, shellWidth: 1200 })).toBe(false);
+  });
+
+  it("accepts the drag when the shell cannot be measured", () => {
+    expect(acceptsFullWidthPanelDrag({ nextWidth: 1201, shellWidth: 0 })).toBe(true);
+  });
+});
+
+describe("resolveSplitPanelMaxWidth", () => {
+  it("reserves a readable chat column by default", () => {
+    expect(
+      resolveSplitPanelMaxWidth({
+        paneWidth: 1000,
+        minPanelWidth: 416,
+        chatMinWidth: 320,
+        fullWidth: false,
+      }),
+    ).toBe(680);
+  });
+
+  it("reserves nothing under full width", () => {
+    expect(
+      resolveSplitPanelMaxWidth({
+        paneWidth: 1000,
+        minPanelWidth: 416,
+        chatMinWidth: 320,
+        fullWidth: true,
+      }),
+    ).toBe(1000);
+  });
+
+  it("never resolves below the panel minimum", () => {
+    expect(
+      resolveSplitPanelMaxWidth({
+        paneWidth: 400,
+        minPanelWidth: 336,
+        chatMinWidth: 320,
+        fullWidth: false,
+      }),
+    ).toBe(336);
+  });
+});

--- a/apps/web/src/lib/panelWidthPolicy.ts
+++ b/apps/web/src/lib/panelWidthPolicy.ts
@@ -1,0 +1,58 @@
+// FILE: panelWidthPolicy.ts
+// Purpose: Pure width math for side panels (right dock + split-pane panel) so the
+//          "open half" vs "open full width" policy has one testable source of truth
+//          shared by every surface that hosts a panel.
+// Layer: Web panel layout utilities
+
+// Resolve the width the right dock should take when it opens.
+//
+// `preferredWidth` is a per-kind natural size (a phone-shaped device pane). It still
+// wins under full width: stretching a fixed-aspect object edge to edge strands it in
+// more empty space, not less. The kinds the full-width preference exists for (browser,
+// diff, terminal, file, git, side chat) have no preferred width, so they fall through
+// to the shell measurement.
+//
+// Returns null when the shell cannot be measured, so the caller leaves the CSS default
+// in place rather than pinning a bogus width.
+export function resolveDockOpenWidth(input: {
+  shellWidth: number;
+  minWidth: number;
+  preferredWidth?: number | undefined;
+  fullWidth: boolean;
+}): number | null {
+  if (input.preferredWidth !== undefined && input.preferredWidth > 0) {
+    return Math.max(input.minWidth, input.preferredWidth);
+  }
+  if (!Number.isFinite(input.shellWidth) || input.shellWidth <= 0) {
+    return null;
+  }
+  // Floor (not round) the full-width case so a fractional shell can never resolve to a
+  // dock wider than the row it lives in, which would overflow the chat surface.
+  const target = input.fullWidth ? Math.floor(input.shellWidth) : Math.round(input.shellWidth / 2);
+  return Math.max(input.minWidth, target);
+}
+
+// Under full width the composer feasibility probe no longer gates a drag, so the only
+// remaining bound is the shell itself: accept anything that still fits the row. An
+// unmeasurable shell accepts the drag rather than freezing the handle.
+export function acceptsFullWidthPanelDrag(input: {
+  nextWidth: number;
+  shellWidth: number;
+}): boolean {
+  if (!Number.isFinite(input.shellWidth) || input.shellWidth <= 0) {
+    return true;
+  }
+  return input.nextWidth <= input.shellWidth;
+}
+
+// Largest width a split-pane panel may reach. Half mode reserves a readable chat
+// column; full width reserves nothing and lets the panel take the whole pane.
+export function resolveSplitPanelMaxWidth(input: {
+  paneWidth: number;
+  minPanelWidth: number;
+  chatMinWidth: number;
+  fullWidth: boolean;
+}): number {
+  const reservedForChat = input.fullWidth ? 0 : input.chatMinWidth;
+  return Math.max(input.minPanelWidth, input.paneWidth - reservedForChat);
+}

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -278,6 +278,9 @@ function SettingsRouteView() {
       ? ["Provider update checks"]
       : []),
     ...(settings.diffWordWrap !== defaults.diffWordWrap ? ["Diff line wrapping"] : []),
+    ...(settings.allowFullWidthPanels !== defaults.allowFullWidthPanels
+      ? ["Full-width panels"]
+      : []),
     ...(settings.showPullRequestDiffColors !== defaults.showPullRequestDiffColors
       ? ["Pull request diff colors"]
       : []),
@@ -1023,6 +1026,17 @@ function SettingsRouteView() {
           description: "Show token-by-token output while a response is in progress.",
           resetLabel: "assistant output",
           ariaLabel: "Stream assistant messages",
+        })}
+      </SettingsSection>
+
+      <SettingsSection title="Panels">
+        {renderBooleanSettingRow({
+          settingKey: "allowFullWidthPanels",
+          title: "Full-width panels",
+          description:
+            "Let the browser, diff, terminal, file, git, and side chat panels open at the full window width and be dragged edge to edge. Off, a panel stops widening once the chat column can no longer fit its composer.",
+          resetLabel: "full-width panels",
+          ariaLabel: "Allow full-width panels",
         })}
       </SettingsSection>
 

--- a/apps/web/src/settingsSearchIndex.ts
+++ b/apps/web/src/settingsSearchIndex.ts
@@ -286,6 +286,13 @@ export const SETTINGS_SEARCH_ENTRIES: readonly SettingsSearchEntry[] = [
     keywords: "Set the default wrap state when the diff panel opens. word wrap",
   },
   {
+    id: "behavior:full-width-panels",
+    section: "behavior",
+    title: "Full-width panels",
+    keywords:
+      "Let the browser, diff, terminal, file, git, and side chat panels open at the full window width. fullscreen full screen maximize expand wide resize dock split",
+  },
+  {
     id: "behavior:delete-confirmation",
     section: "behavior",
     title: "Delete confirmation",


### PR DESCRIPTION
## What Changed

Adds an off-by-default **Full-width panels** setting under Settings > Behavior > Panels.

When it is on:

- the right dock opens at the full width of the chat shell instead of an even 50/50 split
- the right dock and split-pane panels can be dragged all the way to the edge of their row, collapsing the chat column out of view
- panes with a natural size (the phone-shaped device pane) keep their preferred width, since stretching a fixed-aspect surface only adds empty space around it

When it is off, behavior is exactly what it is today.

The width math moved into a new pure module, `apps/web/src/lib/panelWidthPolicy.ts`, so `RightDock` and `SplitChatSurface` share one testable source of truth instead of each carrying its own arithmetic inline.

## Why

Panel width is currently bounded by `canComposerHandlePanelWidth` in `apps/web/src/lib/panelResize.ts`. Every resize drag on the right dock and on split-pane panels runs that probe, and the drag is rejected as soon as the chat composer would overflow its viewport or fall under `COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX`. In practice a panel tops out near half the window, and there is no affordance to go past it.

That default is right for a diff you are reading alongside the conversation. It is wrong for the embedded browser, which is the surface people most want to hand the whole window to. Real sites assume a desktop viewport, so at roughly half a laptop screen sign-in flows and dense app UIs end up cramped, wrap badly, and push controls out of reach, with no maximize control to escape it. Google sign-in pages are the case that prompted this: comfortable at full width, awkward at half.

The fix keeps the safe default and gives the user an explicit way out of it. A setting rather than a new default, because the clamp exists for a good reason and most panels should keep it.

## Scope note

This changes how wide a panel is allowed to be. It does not change how `BrowserPanel` renders inside the panel, does not add an OS-level fullscreen mode for the webview, and does not touch scrolling inside the embedded page. If any of those are separate defects, happy to file them separately rather than fold them in here.

## UI Changes

No screenshots attached, and I would rather say so than pad the PR: I could not get reliable before/after captures of the drag out of my dev environment. Happy to add them if that blocks review. The visible differences are:

1. A new row in Settings > Behavior, in a new "Panels" section above "Review", titled "Full-width panels", using the shared `renderBooleanSettingRow` switch plus its reset affordance. It is also indexed in settings search under `behavior:full-width-panels`.
2. With the setting on, opening the right dock puts its inner edge flush with the edge of the chat row instead of halfway across, and the resize handle drags to that same edge.
3. With the setting off, nothing changes.

## Verification

- `bun run typecheck`: 7/7 tasks pass, 0 errors
- `oxfmt`: clean
- `oxlint`: 0 errors (433 pre-existing warnings, count unchanged)
- `bun run test:web:focused src/lib/panelWidthPolicy.test.ts`: 12/12 pass
- Full `apps/web` suite: 3970 passed, 6 failed. All 6 are "test timed out" in `src/components/ChatMarkdown.test.tsx` and `src/components/Sidebar.import.test.ts` on a slow Windows box. I re-ran both files with `apps/web/src` reverted to unmodified `origin/main` in the same checkout and they fail identically, so they are not from this change.

## Checklist

- [x] This PR is small and focused (8 files, +245 / -8, one new module plus its test)
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
