### PR TITLE
fix(antigravity): keep background task turns alive instead of killing the CLI

### DIFF
--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -23,12 +23,15 @@ import {
   buildAntigravityHookConfig,
   buildAntigravityTurnProcessEnvironment,
   buildAntigravityTurnPrompt,
+  detectAntigravityBackgroundTaskStart,
   ensureCapturePlugin,
   hookScriptSource,
   makeAntigravityRuntimeEventBase,
   makeAntigravityAdapterLive,
+  matchAntigravityTrackedTaskId,
   parseAntigravityCliModelLabel,
   parseAntigravityModelLines,
+  parseAntigravitySystemMessage,
   readCompleteAntigravityLines,
   resolveAntigravityCliModelLabel,
   runAntigravityHelperProcess,
@@ -372,7 +375,7 @@ describe("Antigravity CLI integration helpers", () => {
         {
           command: "/usr/local/bin/agy",
           args: ["plugin", "install", pluginDir],
-          options: { timeoutMs: 30_000 },
+          options: { timeoutMs: 45_000 },
         },
       ]);
       expect(
@@ -1717,5 +1720,112 @@ describe("Antigravity turn settle on cancel (#465)", () => {
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("Antigravity background task helpers (#752)", () => {
+  it("parses system message task ids and exit codes", () => {
+    expect(parseAntigravitySystemMessage("plain assistant text")).toBeNull();
+    expect(parseAntigravitySystemMessage(undefined)).toBeNull();
+
+    const success = parseAntigravitySystemMessage(
+      "<SYSTEM_MESSAGE> Task id 'task-abc123' exited with code 0",
+    );
+    expect(success).toMatchObject({
+      isSystemMessage: true,
+      taskId: "task-abc123",
+      exitCode: 0,
+      isFailure: false,
+    });
+
+    const failure = parseAntigravitySystemMessage(
+      '<SYSTEM_MESSAGE> sender=task-9f2 Task id "task-9f2" exited with code 1',
+    );
+    expect(failure).toMatchObject({
+      isSystemMessage: true,
+      taskId: "task-9f2",
+      sender: "task-9f2",
+      exitCode: 1,
+      isFailure: true,
+    });
+
+    const senderOnly = parseAntigravitySystemMessage("<SYSTEM_MESSAGE> sender=task-x77 done");
+    expect(senderOnly).toMatchObject({ isSystemMessage: true, taskId: "task-x77" });
+  });
+
+  it("detects background task starts from run_command tool output", () => {
+    expect(
+      detectAntigravityBackgroundTaskStart(
+        "run_command",
+        { CommandLine: "npm run dev" },
+        {
+          toolOutput: "Task id 'task-42' is now running in the background",
+        },
+      ),
+    ).toEqual({
+      taskId: "task-42",
+      description: "npm run dev",
+      isBackground: true,
+    });
+
+    expect(
+      detectAntigravityBackgroundTaskStart(
+        "run_command",
+        { CommandLine: "npm run dev" },
+        {
+          result: "sent to the background",
+        },
+      ),
+    ).toEqual({ description: "npm run dev", isBackground: true });
+
+    expect(
+      detectAntigravityBackgroundTaskStart(
+        "run_command",
+        { command: "npm run dev", WaitMsBeforeAsync: 1000 },
+        {},
+      ),
+    ).toEqual({ description: "npm run dev", isBackground: true });
+
+    expect(
+      detectAntigravityBackgroundTaskStart(
+        "run_command",
+        { CommandLine: "npm run dev", WaitMsBeforeAsync: 1000 },
+        { toolOutput: "exited with code 0" },
+      ),
+    ).toBeNull();
+  });
+
+  it("detects schedule timers and ignores unrelated tools", () => {
+    expect(
+      detectAntigravityBackgroundTaskStart(
+        "schedule",
+        { Prompt: "remind me later" },
+        {
+          toolOutput: "Scheduled timer-77 created",
+        },
+      ),
+    ).toEqual({
+      taskId: "timer-77",
+      description: "remind me later",
+      isBackground: true,
+    });
+
+    expect(detectAntigravityBackgroundTaskStart("schedule", {})).toEqual({
+      description: "Scheduled timer",
+      isBackground: true,
+    });
+
+    expect(detectAntigravityBackgroundTaskStart("list_files")).toBeNull();
+  });
+
+  it("matches completion task ids against tracked tasks", () => {
+    const tracked = ["task-1", "task-2"];
+
+    expect(matchAntigravityTrackedTaskId("task-1", tracked)).toBe("task-1");
+    expect(matchAntigravityTrackedTaskId("job/task-2", tracked)).toBe("task-2");
+    expect(matchAntigravityTrackedTaskId("unknown-99", tracked)).toBeUndefined();
+    expect(matchAntigravityTrackedTaskId(undefined, ["task-solo"])).toBe("task-solo");
+    expect(matchAntigravityTrackedTaskId(undefined, tracked)).toBeUndefined();
+    expect(matchAntigravityTrackedTaskId("task-1", [])).toBeUndefined();
   });
 });

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -1,5 +1,6 @@
 import { spawnSync, type ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -1793,6 +1794,13 @@ describe("Antigravity background task helpers (#752)", () => {
         { toolOutput: "exited with code 0" },
       ),
     ).toBeNull();
+
+    expect(
+      detectAntigravityBackgroundTaskStart("run_command", {
+        CommandLine: "npm run dev",
+        WaitMsBeforeAsync: 1000,
+      }),
+    ).toBeNull();
   });
 
   it("detects schedule timers and ignores unrelated tools", () => {
@@ -1825,7 +1833,229 @@ describe("Antigravity background task helpers (#752)", () => {
     expect(matchAntigravityTrackedTaskId("job/task-2", tracked)).toBe("task-2");
     expect(matchAntigravityTrackedTaskId("unknown-99", tracked)).toBeUndefined();
     expect(matchAntigravityTrackedTaskId(undefined, ["task-solo"])).toBe("task-solo");
+    expect(matchAntigravityTrackedTaskId("another-task", ["task-solo"])).toBeUndefined();
     expect(matchAntigravityTrackedTaskId(undefined, tracked)).toBeUndefined();
     expect(matchAntigravityTrackedTaskId("task-1", [])).toBeUndefined();
+  });
+
+  it("settles a completed background task before handling the final stop hook", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-background-stop-"));
+    const transcriptFile = path.join(root, "transcript.jsonl");
+    await fs.writeFile(transcriptFile, "");
+
+    let eventFile: string | undefined;
+    let child: ChildProcess | undefined;
+    let teardownCalls = 0;
+    const spawnProcess = ((
+      _command: string,
+      _args: readonly string[],
+      options: { readonly env?: NodeJS.ProcessEnv },
+    ) => {
+      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS;
+      const spawned = new EventEmitter() as ChildProcess;
+      Object.assign(spawned, {
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        killed: false,
+        kill: () => true,
+      });
+      child = spawned;
+      return spawned;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const taskEventsFiber = yield* adapter.streamEvents.pipe(
+            Stream.filter(
+              (event) => event.type === "task.started" || event.type === "task.completed",
+            ),
+            Stream.take(2),
+            Stream.runCollect,
+            Effect.forkChild,
+          );
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-background-stop");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+          yield* adapter.sendTurn({ threadId, input: "run tests", attachments: [] });
+
+          yield* Effect.promise(() =>
+            fs.appendFile(
+              eventFile!,
+              [
+                `pre-invocation\t${JSON.stringify({
+                  conversationId: "conversation-background-stop",
+                  transcriptPath: transcriptFile,
+                })}`,
+                'pre-tool\t{"stepIdx":1,"toolCall":{"name":"run_command","args":{"CommandLine":"npm test","WaitMsBeforeAsync":1000}}}',
+                'post-tool\t{"stepIdx":1,"toolCall":{"name":"run_command"},"toolOutput":"Task id \'task-42\' is now running in the background"}',
+                'stop\t{"stepIdx":2}',
+                "",
+              ].join("\n"),
+            ),
+          );
+          yield* Effect.sleep("150 millis");
+          expect(teardownCalls).toBe(0);
+
+          yield* Effect.sync(() => {
+            fsSync.appendFileSync(
+              transcriptFile,
+              `${JSON.stringify({
+                step_index: 3,
+                type: "SYSTEM_MESSAGE",
+                content: "<SYSTEM_MESSAGE> Task id 'task-42' exited with code 0",
+              })}\n`,
+            );
+            fsSync.appendFileSync(eventFile!, 'stop\t{"stepIdx":4}\n');
+          });
+          yield* Effect.sleep("150 millis");
+
+          const taskEvents = Array.from(
+            yield* Fiber.join(taskEventsFiber).pipe(Effect.timeout("2 seconds")),
+          );
+          expect(taskEvents.map((event) => event.type)).toEqual(["task.started", "task.completed"]);
+          expect(teardownCalls).toBe(1);
+
+          child?.emit("close", 0, null);
+          yield* Effect.sleep("25 millis");
+          yield* adapter.stopSession(threadId);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+              teardownProcessTree: async () => {
+                teardownCalls += 1;
+              },
+            }).pipe(
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-background-stop-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("settles pending background tasks on session replacement and process exit", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-background-restart-"));
+    let eventFile: string | undefined;
+    let child: ChildProcess | undefined;
+    const spawnProcess = ((
+      _command: string,
+      _args: readonly string[],
+      options: { readonly env?: NodeJS.ProcessEnv },
+    ) => {
+      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS;
+      const spawned = new EventEmitter() as ChildProcess;
+      Object.assign(spawned, {
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        killed: false,
+        kill: () => true,
+      });
+      child = spawned;
+      return spawned;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const taskEventsFiber = yield* adapter.streamEvents.pipe(
+            Stream.filter(
+              (event) =>
+                event.type === "task.started" ||
+                event.type === "task.updated" ||
+                event.type === "task.completed",
+            ),
+            Stream.take(4),
+            Stream.runCollect,
+            Effect.forkChild,
+          );
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-background-restart");
+          const sessionInput = {
+            provider: "antigravity" as const,
+            threadId,
+            runtimeMode: "full-access" as const,
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          };
+          yield* adapter.startSession(sessionInput);
+          yield* adapter.sendTurn({ threadId, input: "run tests", attachments: [] });
+
+          yield* Effect.promise(() =>
+            fs.appendFile(
+              eventFile!,
+              [
+                'pre-tool\t{"stepIdx":1,"toolCall":{"name":"run_command","args":{"CommandLine":"npm test","WaitMsBeforeAsync":1000}}}',
+                'post-tool\t{"stepIdx":1,"toolCall":{"name":"run_command"},"toolOutput":"Task id \'task-restart\' is now running in the background"}',
+                "",
+              ].join("\n"),
+            ),
+          );
+          yield* Effect.sleep("150 millis");
+          yield* adapter.startSession(sessionInput);
+
+          yield* adapter.sendTurn({ threadId, input: "run more tests", attachments: [] });
+          yield* Effect.promise(() =>
+            fs.appendFile(
+              eventFile!,
+              [
+                'pre-tool\t{"stepIdx":2,"toolCall":{"name":"run_command","args":{"CommandLine":"npm test","WaitMsBeforeAsync":1000}}}',
+                'post-tool\t{"stepIdx":2,"toolCall":{"name":"run_command"},"toolOutput":"Task id \'task-exit\' is now running in the background"}',
+                "",
+              ].join("\n"),
+            ),
+          );
+          yield* Effect.sleep("150 millis");
+          child?.emit("close", 1, null);
+
+          const taskEvents = Array.from(
+            yield* Fiber.join(taskEventsFiber).pipe(Effect.timeout("2 seconds")),
+          );
+          expect(taskEvents.map((event) => event.type)).toEqual([
+            "task.started",
+            "task.updated",
+            "task.started",
+            "task.completed",
+          ]);
+          expect(taskEvents[1]?.payload).toMatchObject({
+            taskId: "task-restart",
+            status: "killed",
+          });
+          expect(taskEvents[3]?.payload).toMatchObject({
+            taskId: "task-exit",
+            status: "failed",
+          });
+          yield* adapter.stopSession(threadId);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              spawnProcess,
+              teardownProcessTree: async () => undefined,
+            }).pipe(
+              Layer.provideMerge(
+                ServerConfig.layerTest(root, { prefix: "antigravity-background-restart-" }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -8,7 +8,7 @@ import { PassThrough } from "node:stream";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { ThreadId } from "@synara/contracts";
-import { Effect, Fiber, Layer, Stream } from "effect";
+import { Deferred, Effect, Fiber, Layer, Stream } from "effect";
 import { describe, expect, it } from "vitest";
 
 import { ServerConfig } from "../../config";
@@ -1758,6 +1758,11 @@ describe("Antigravity background task helpers (#752)", () => {
         "<SYSTEM_MESSAGE> Task id 'task-clean' completed with 0 failed and no error",
       ),
     ).toMatchObject({ taskId: "task-clean", isFailure: false });
+    expect(
+      parseAntigravitySystemMessage(
+        "<SYSTEM_MESSAGE> Task id 'task-tests' completed with 0 tests failed",
+      ),
+    ).toMatchObject({ taskId: "task-tests", isFailure: false });
   });
 
   it("detects background task starts from run_command tool output", () => {
@@ -1899,11 +1904,30 @@ describe("Antigravity background task helpers (#752)", () => {
       await Effect.runPromise(
         Effect.gen(function* () {
           const adapter = yield* AntigravityAdapter;
+          const firstTaskStarted = yield* Deferred.make<void>();
+          const secondTaskStarted = yield* Deferred.make<void>();
+          const firstTaskCompleted = yield* Deferred.make<void>();
+          const secondTaskCompleted = yield* Deferred.make<void>();
           const taskEventsFiber = yield* adapter.streamEvents.pipe(
+            Stream.tap((event) => {
+              if (event.type === "task.started" && event.payload.taskId === "task-1") {
+                return Deferred.succeed(firstTaskStarted, undefined);
+              }
+              if (event.type === "task.started" && event.payload.taskId === "task-2") {
+                return Deferred.succeed(secondTaskStarted, undefined);
+              }
+              if (event.type === "task.completed" && event.payload.taskId === "task-1") {
+                return Deferred.succeed(firstTaskCompleted, undefined);
+              }
+              if (event.type === "task.completed" && event.payload.taskId === "task-2") {
+                return Deferred.succeed(secondTaskCompleted, undefined);
+              }
+              return Effect.void;
+            }),
             Stream.filter(
               (event) => event.type === "task.started" || event.type === "task.completed",
             ),
-            Stream.take(2),
+            Stream.take(4),
             Stream.runCollect,
             Effect.forkChild,
           );
@@ -1926,31 +1950,56 @@ describe("Antigravity background task helpers (#752)", () => {
                   transcriptPath: transcriptFile,
                 })}`,
                 'post-tool\t{"stepIdx":1,"toolCall":{"name":"run_command","args":{"CommandLine":"npm test","WaitMsBeforeAsync":1000}},"toolOutput":"sent to the background"}',
-                'stop\t{"stepIdx":2}',
+                'post-tool\t{"stepIdx":2,"toolCall":{"name":"run_command","args":{"CommandLine":"npm run dev","WaitMsBeforeAsync":1000}},"toolOutput":"sent to the background"}',
+                'stop\t{"stepIdx":3}',
                 "",
               ].join("\n"),
             ),
           );
-          yield* Effect.sleep("150 millis");
+          yield* Effect.all([Deferred.await(firstTaskStarted), Deferred.await(secondTaskStarted)], {
+            discard: true,
+          }).pipe(Effect.timeout("2 seconds"));
           expect(teardownCalls).toBe(0);
 
           yield* Effect.sync(() => {
             fsSync.appendFileSync(
               transcriptFile,
-              `${JSON.stringify({
-                step_index: 3,
-                type: "SYSTEM_MESSAGE",
-                content: "<SYSTEM_MESSAGE> Task id 'task-42' exited with code 0",
-              })}\n`,
+              [
+                JSON.stringify({
+                  step_index: 4,
+                  type: "SYSTEM_MESSAGE",
+                  content: "<SYSTEM_MESSAGE> Task id 'task-real-a' exited with code 0",
+                }),
+                JSON.stringify({
+                  step_index: 5,
+                  type: "SYSTEM_MESSAGE",
+                  content: "<SYSTEM_MESSAGE> Task id 'task-real-b' exited with code 0",
+                }),
+                "",
+              ].join("\n"),
             );
-            fsSync.appendFileSync(eventFile!, 'stop\t{"stepIdx":4}\n');
+            fsSync.appendFileSync(eventFile!, 'stop\t{"stepIdx":6}\n');
           });
-          yield* Effect.sleep("150 millis");
+          yield* Effect.all(
+            [Deferred.await(firstTaskCompleted), Deferred.await(secondTaskCompleted)],
+            { discard: true },
+          ).pipe(Effect.timeout("2 seconds"));
 
           const taskEvents = Array.from(
             yield* Fiber.join(taskEventsFiber).pipe(Effect.timeout("2 seconds")),
           );
-          expect(taskEvents.map((event) => event.type)).toEqual(["task.started", "task.completed"]);
+          expect(taskEvents.map((event) => event.type)).toEqual([
+            "task.started",
+            "task.started",
+            "task.completed",
+            "task.completed",
+          ]);
+          expect(taskEvents.map((event) => event.payload.taskId)).toEqual([
+            "task-1",
+            "task-2",
+            "task-1",
+            "task-2",
+          ]);
           expect(teardownCalls).toBe(1);
 
           child?.emit("close", 0, null);
@@ -2005,7 +2054,39 @@ describe("Antigravity background task helpers (#752)", () => {
       await Effect.runPromise(
         Effect.gen(function* () {
           const adapter = yield* AntigravityAdapter;
+          const firstTaskStarted = yield* Deferred.make<void>();
+          const conversationReady = yield* Deferred.make<void>();
+          const completionBuffered = yield* Deferred.make<void>();
+          const bufferedTaskCompleted = yield* Deferred.make<void>();
+          const secondTurnCompleted = yield* Deferred.make<void>();
+          const exitTaskStarted = yield* Deferred.make<void>();
           const taskEventsFiber = yield* adapter.streamEvents.pipe(
+            Stream.tap((event) =>
+              Effect.all(
+                [
+                  event.type === "task.started" && event.payload.taskId === "task-restart"
+                    ? Deferred.succeed(firstTaskStarted, undefined)
+                    : Effect.void,
+                  event.type === "thread.started" &&
+                  event.payload.providerThreadId === "conversation-background-restart"
+                    ? Deferred.succeed(conversationReady, undefined)
+                    : Effect.void,
+                  event.type === "item.completed" && event.payload.itemType === "assistant_message"
+                    ? Deferred.succeed(completionBuffered, undefined)
+                    : Effect.void,
+                  event.type === "task.completed" && event.payload.taskId === "task-1"
+                    ? Deferred.succeed(bufferedTaskCompleted, undefined)
+                    : Effect.void,
+                  event.type === "turn.completed"
+                    ? Deferred.succeed(secondTurnCompleted, undefined)
+                    : Effect.void,
+                  event.type === "task.started" && event.payload.taskId === "task-exit"
+                    ? Deferred.succeed(exitTaskStarted, undefined)
+                    : Effect.void,
+                ],
+                { discard: true },
+              ),
+            ),
             Stream.filter(
               (event) =>
                 event.type === "task.started" ||
@@ -2037,7 +2118,7 @@ describe("Antigravity background task helpers (#752)", () => {
               ].join("\n"),
             ),
           );
-          yield* Effect.sleep("150 millis");
+          yield* Deferred.await(firstTaskStarted).pipe(Effect.timeout("2 seconds"));
           yield* adapter.startSession(sessionInput);
 
           yield* adapter.sendTurn({ threadId, input: "run more tests", attachments: [] });
@@ -2050,18 +2131,26 @@ describe("Antigravity background task helpers (#752)", () => {
               })}\n`,
             ),
           );
-          yield* Effect.sleep("150 millis");
+          yield* Deferred.await(conversationReady).pipe(Effect.timeout("2 seconds"));
           yield* Effect.promise(() =>
             fs.appendFile(
               transcriptFile,
-              `${JSON.stringify({
-                step_index: 2,
-                type: "SYSTEM_MESSAGE",
-                content: "<SYSTEM_MESSAGE> Task id 'task-buffered' exited with code 0",
-              })}\n`,
+              [
+                JSON.stringify({
+                  step_index: 2,
+                  type: "SYSTEM_MESSAGE",
+                  content: "<SYSTEM_MESSAGE> Task id 'task-buffered' exited with code 0",
+                }),
+                JSON.stringify({
+                  step_index: 3,
+                  type: "PLANNER_RESPONSE",
+                  content: "buffer-ready",
+                }),
+                "",
+              ].join("\n"),
             ),
           );
-          yield* Effect.sleep("150 millis");
+          yield* Deferred.await(completionBuffered).pipe(Effect.timeout("2 seconds"));
           yield* Effect.promise(() =>
             fs.appendFile(
               eventFile!,
@@ -2071,9 +2160,9 @@ describe("Antigravity background task helpers (#752)", () => {
               ].join("\n"),
             ),
           );
-          yield* Effect.sleep("150 millis");
+          yield* Deferred.await(bufferedTaskCompleted).pipe(Effect.timeout("2 seconds"));
           child?.emit("close", 0, null);
-          yield* Effect.sleep("50 millis");
+          yield* Deferred.await(secondTurnCompleted).pipe(Effect.timeout("2 seconds"));
 
           yield* adapter.sendTurn({ threadId, input: "run final tests", attachments: [] });
           yield* Effect.promise(() =>
@@ -2085,7 +2174,7 @@ describe("Antigravity background task helpers (#752)", () => {
               ].join("\n"),
             ),
           );
-          yield* Effect.sleep("150 millis");
+          yield* Deferred.await(exitTaskStarted).pipe(Effect.timeout("2 seconds"));
           child?.emit("close", 1, null);
 
           const taskEvents = Array.from(

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -1909,6 +1909,7 @@ describe("Antigravity background task helpers (#752)", () => {
         Effect.gen(function* () {
           const adapter = yield* AntigravityAdapter;
           const toolsCompleted = yield* Deferred.make<void>();
+          const followupObserved = yield* Deferred.make<void>();
           const runtimeTaskEvents: string[] = [];
           let completedTools = 0;
           const eventsFiber = yield* adapter.streamEvents.pipe(
@@ -1917,6 +1918,12 @@ describe("Antigravity background task helpers (#752)", () => {
                 if (event.type.startsWith("task.")) runtimeTaskEvents.push(event.type);
                 if (event.type === "item.completed" && ++completedTools === 2) {
                   yield* Deferred.succeed(toolsCompleted, undefined);
+                }
+                if (
+                  event.type === "item.completed" &&
+                  event.payload.itemType === "assistant_message"
+                ) {
+                  yield* Deferred.succeed(followupObserved, undefined);
                 }
               }),
             ),
@@ -1962,11 +1969,18 @@ describe("Antigravity background task helpers (#752)", () => {
                   type: "SYSTEM_MESSAGE",
                   content: "<SYSTEM_MESSAGE> Task id 'task-real-b' exited with code 0",
                 }),
+                JSON.stringify({
+                  step_index: 6,
+                  type: "PLANNER_RESPONSE",
+                  content: "background work completed",
+                }),
                 "",
               ].join("\n"),
             );
-            fsSync.appendFileSync(eventFile!, 'stop\t{"stepIdx":6}\n');
           });
+          yield* Deferred.await(followupObserved).pipe(Effect.timeout("2 seconds"));
+          expect(teardownCalls).toBe(0);
+          yield* Effect.sync(() => fsSync.appendFileSync(eventFile!, "stop\t{}\n"));
           yield* Effect.promise(() => teardownObserved).pipe(Effect.timeout("2 seconds"));
           expect(teardownCalls).toBe(1);
           expect(runtimeTaskEvents).toEqual([]);
@@ -1988,6 +2002,134 @@ describe("Antigravity background task helpers (#752)", () => {
               Layer.provideMerge(
                 ServerConfig.layerTest(root, { prefix: "antigravity-background-stop-" }),
               ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("performs a fresh final hook drain when the process closes during a poll", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-final-drain-"));
+    const transcriptFile = path.join(root, "transcript.jsonl");
+    await fs.writeFile(transcriptFile, "");
+
+    let eventFile: string | undefined;
+    let child: ChildProcess | undefined;
+    let blockNextTranscriptRead = false;
+    let transcriptReadBlocked = false;
+    let resolveTranscriptReadStarted = (): void => undefined;
+    const transcriptReadStarted = new Promise<void>((resolve) => {
+      resolveTranscriptReadStarted = resolve;
+    });
+    let releaseTranscriptRead = (): void => undefined;
+    const transcriptReadRelease = new Promise<void>((resolve) => {
+      releaseTranscriptRead = resolve;
+    });
+    const spawnProcess = ((
+      _command: string,
+      _args: readonly string[],
+      options: { readonly env?: NodeJS.ProcessEnv },
+    ) => {
+      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS;
+      const spawned = new EventEmitter() as ChildProcess;
+      Object.assign(spawned, {
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        killed: false,
+        kill: () => true,
+      });
+      child = spawned;
+      return spawned;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+    const readCompleteLines: NonNullable<
+      AntigravityAdapterDependencies["readCompleteLines"]
+    > = async (filePath, offset) => {
+      if (filePath === transcriptFile && blockNextTranscriptRead && !transcriptReadBlocked) {
+        transcriptReadBlocked = true;
+        resolveTranscriptReadStarted();
+        await transcriptReadRelease;
+      }
+      return readCompleteAntigravityLines(filePath, offset);
+    };
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const turnCompleted = yield* Deferred.make<void>();
+          const itemsObserved = yield* Deferred.make<void>();
+          const itemEventTypes: string[] = [];
+          const itemEventTitles: string[] = [];
+          const eventsFiber = yield* adapter.streamEvents.pipe(
+            Stream.runForEach((event) =>
+              Effect.gen(function* () {
+                if (event.type === "item.started" || event.type === "item.completed") {
+                  itemEventTypes.push(event.type);
+                  itemEventTitles.push(event.payload.title);
+                  if (itemEventTypes.length === 2) {
+                    yield* Deferred.succeed(itemsObserved, undefined);
+                  }
+                }
+                if (event.type === "turn.completed") {
+                  yield* Deferred.succeed(turnCompleted, undefined);
+                }
+              }),
+            ),
+            Effect.forkChild,
+          );
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-final-drain");
+          yield* adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          });
+          yield* adapter.sendTurn({ threadId, input: "list files", attachments: [] });
+          blockNextTranscriptRead = true;
+          yield* Effect.promise(() =>
+            fs.appendFile(
+              eventFile!,
+              `pre-invocation\t${JSON.stringify({
+                conversationId: "conversation-final-drain",
+                transcriptPath: transcriptFile,
+              })}\n`,
+            ),
+          );
+          yield* Effect.promise(() => transcriptReadStarted).pipe(Effect.timeout("2 seconds"));
+          yield* Effect.promise(() =>
+            fs.appendFile(
+              eventFile!,
+              [
+                'pre-tool\t{"stepIdx":1,"toolCall":{"name":"list_files","args":{"Path":"."}}}',
+                'post-tool\t{"stepIdx":1,"toolCall":{"name":"list_files","args":{"Path":"."}},"toolOutput":"ok"}',
+                'stop\t{"stepIdx":2}',
+                "",
+              ].join("\n"),
+            ),
+          );
+          child?.emit("close", 0, null);
+          releaseTranscriptRead();
+
+          yield* Deferred.await(itemsObserved).pipe(Effect.timeout("2 seconds"));
+          yield* Deferred.await(turnCompleted).pipe(Effect.timeout("2 seconds"));
+          expect(itemEventTypes).toEqual(["item.started", "item.completed"]);
+          expect(itemEventTitles).toEqual(["list_files", "list_files"]);
+          yield* Fiber.interrupt(eventsFiber);
+          yield* adapter.stopSession(threadId);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              readCompleteLines,
+              spawnProcess,
+              teardownProcessTree: async () => undefined,
+            }).pipe(
+              Layer.provideMerge(ServerConfig.layerTest(root, { prefix: "final-drain-" })),
               Layer.provideMerge(NodeServices.layer),
             ),
           ),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -1883,6 +1883,10 @@ describe("Antigravity background task helpers (#752)", () => {
     let eventFile: string | undefined;
     let child: ChildProcess | undefined;
     let teardownCalls = 0;
+    let resolveTeardown = (): void => undefined;
+    const teardownObserved = new Promise<void>((resolve) => {
+      resolveTeardown = resolve;
+    });
     const spawnProcess = ((
       _command: string,
       _args: readonly string[],
@@ -1904,31 +1908,18 @@ describe("Antigravity background task helpers (#752)", () => {
       await Effect.runPromise(
         Effect.gen(function* () {
           const adapter = yield* AntigravityAdapter;
-          const firstTaskStarted = yield* Deferred.make<void>();
-          const secondTaskStarted = yield* Deferred.make<void>();
-          const firstTaskCompleted = yield* Deferred.make<void>();
-          const secondTaskCompleted = yield* Deferred.make<void>();
-          const taskEventsFiber = yield* adapter.streamEvents.pipe(
-            Stream.tap((event) => {
-              if (event.type === "task.started" && event.payload.taskId === "task-1") {
-                return Deferred.succeed(firstTaskStarted, undefined);
-              }
-              if (event.type === "task.started" && event.payload.taskId === "task-2") {
-                return Deferred.succeed(secondTaskStarted, undefined);
-              }
-              if (event.type === "task.completed" && event.payload.taskId === "task-1") {
-                return Deferred.succeed(firstTaskCompleted, undefined);
-              }
-              if (event.type === "task.completed" && event.payload.taskId === "task-2") {
-                return Deferred.succeed(secondTaskCompleted, undefined);
-              }
-              return Effect.void;
-            }),
-            Stream.filter(
-              (event) => event.type === "task.started" || event.type === "task.completed",
+          const toolsCompleted = yield* Deferred.make<void>();
+          const runtimeTaskEvents: string[] = [];
+          let completedTools = 0;
+          const eventsFiber = yield* adapter.streamEvents.pipe(
+            Stream.runForEach((event) =>
+              Effect.gen(function* () {
+                if (event.type.startsWith("task.")) runtimeTaskEvents.push(event.type);
+                if (event.type === "item.completed" && ++completedTools === 2) {
+                  yield* Deferred.succeed(toolsCompleted, undefined);
+                }
+              }),
             ),
-            Stream.take(4),
-            Stream.runCollect,
             Effect.forkChild,
           );
           const threadId = ThreadId.makeUnsafe("thread-antigravity-background-stop");
@@ -1949,27 +1940,23 @@ describe("Antigravity background task helpers (#752)", () => {
                   conversationId: "conversation-background-stop",
                   transcriptPath: transcriptFile,
                 })}`,
+                'pre-tool\t{"stepIdx":1,"toolCall":{"name":"run_command","args":{"CommandLine":"npm test","WaitMsBeforeAsync":1000}}}',
                 'post-tool\t{"stepIdx":1,"toolCall":{"name":"run_command","args":{"CommandLine":"npm test","WaitMsBeforeAsync":1000}},"toolOutput":"sent to the background"}',
+                'pre-tool\t{"stepIdx":2,"toolCall":{"name":"run_command","args":{"CommandLine":"npm run dev","WaitMsBeforeAsync":1000}}}',
                 'post-tool\t{"stepIdx":2,"toolCall":{"name":"run_command","args":{"CommandLine":"npm run dev","WaitMsBeforeAsync":1000}},"toolOutput":"sent to the background"}',
-                'stop\t{"stepIdx":3}',
+                'post-tool\t{"stepIdx":3,"toolCall":{"name":"manage_task","args":{"Action":"kill","TaskId":"task-real-a"}}}',
+                'stop\t{"stepIdx":4}',
                 "",
               ].join("\n"),
             ),
           );
-          yield* Effect.all([Deferred.await(firstTaskStarted), Deferred.await(secondTaskStarted)], {
-            discard: true,
-          }).pipe(Effect.timeout("2 seconds"));
+          yield* Deferred.await(toolsCompleted).pipe(Effect.timeout("2 seconds"));
           expect(teardownCalls).toBe(0);
 
           yield* Effect.sync(() => {
             fsSync.appendFileSync(
               transcriptFile,
               [
-                JSON.stringify({
-                  step_index: 4,
-                  type: "SYSTEM_MESSAGE",
-                  content: "<SYSTEM_MESSAGE> Task id 'task-real-a' exited with code 0",
-                }),
                 JSON.stringify({
                   step_index: 5,
                   type: "SYSTEM_MESSAGE",
@@ -1980,27 +1967,10 @@ describe("Antigravity background task helpers (#752)", () => {
             );
             fsSync.appendFileSync(eventFile!, 'stop\t{"stepIdx":6}\n');
           });
-          yield* Effect.all(
-            [Deferred.await(firstTaskCompleted), Deferred.await(secondTaskCompleted)],
-            { discard: true },
-          ).pipe(Effect.timeout("2 seconds"));
-
-          const taskEvents = Array.from(
-            yield* Fiber.join(taskEventsFiber).pipe(Effect.timeout("2 seconds")),
-          );
-          expect(taskEvents.map((event) => event.type)).toEqual([
-            "task.started",
-            "task.started",
-            "task.completed",
-            "task.completed",
-          ]);
-          expect(taskEvents.map((event) => event.payload.taskId)).toEqual([
-            "task-1",
-            "task-2",
-            "task-1",
-            "task-2",
-          ]);
+          yield* Effect.promise(() => teardownObserved).pipe(Effect.timeout("2 seconds"));
           expect(teardownCalls).toBe(1);
+          expect(runtimeTaskEvents).toEqual([]);
+          yield* Fiber.interrupt(eventsFiber);
 
           child?.emit("close", 0, null);
           yield* Effect.sleep("25 millis");
@@ -2012,6 +1982,7 @@ describe("Antigravity background task helpers (#752)", () => {
               spawnProcess,
               teardownProcessTree: async () => {
                 teardownCalls += 1;
+                resolveTeardown();
               },
             }).pipe(
               Layer.provideMerge(
@@ -2074,7 +2045,7 @@ describe("Antigravity background task helpers (#752)", () => {
                   event.type === "item.completed" && event.payload.itemType === "assistant_message"
                     ? Deferred.succeed(completionBuffered, undefined)
                     : Effect.void,
-                  event.type === "task.completed" && event.payload.taskId === "task-1"
+                  event.type === "task.completed" && event.payload.taskId === "task-buffered"
                     ? Deferred.succeed(bufferedTaskCompleted, undefined)
                     : Effect.void,
                   event.type === "turn.completed"
@@ -2155,7 +2126,7 @@ describe("Antigravity background task helpers (#752)", () => {
             fs.appendFile(
               eventFile!,
               [
-                'post-tool\t{"stepIdx":2,"toolCall":{"name":"run_command","args":{"CommandLine":"npm test","WaitMsBeforeAsync":1000}},"toolOutput":"sent to the background"}',
+                'post-tool\t{"stepIdx":2,"toolCall":{"name":"run_command","args":{"CommandLine":"npm test","WaitMsBeforeAsync":1000}},"toolOutput":"Task id \'task-buffered\' is now running in the background"}',
                 "",
               ].join("\n"),
             ),
@@ -2193,7 +2164,7 @@ describe("Antigravity background task helpers (#752)", () => {
             status: "killed",
           });
           expect(taskEvents[3]?.payload).toMatchObject({
-            taskId: "task-1",
+            taskId: "task-buffered",
             status: "completed",
           });
           expect(taskEvents[5]?.payload).toMatchObject({

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -1952,7 +1952,6 @@ describe("Antigravity background task helpers (#752)", () => {
                 'pre-tool\t{"stepIdx":2,"toolCall":{"name":"run_command","args":{"CommandLine":"npm run dev","WaitMsBeforeAsync":1000}}}',
                 'post-tool\t{"stepIdx":2,"toolCall":{"name":"run_command","args":{"CommandLine":"npm run dev","WaitMsBeforeAsync":1000}},"toolOutput":"sent to the background"}',
                 'post-tool\t{"stepIdx":3,"toolCall":{"name":"manage_task","args":{"Action":"kill","TaskId":"task-real-a"}}}',
-                'stop\t{"stepIdx":4}',
                 "",
               ].join("\n"),
             ),
@@ -1965,7 +1964,6 @@ describe("Antigravity background task helpers (#752)", () => {
               transcriptFile,
               [
                 JSON.stringify({
-                  step_index: 5,
                   type: "SYSTEM_MESSAGE",
                   content: "<SYSTEM_MESSAGE> Task id 'task-real-b' exited with code 0",
                 }),
@@ -1977,6 +1975,7 @@ describe("Antigravity background task helpers (#752)", () => {
                 "",
               ].join("\n"),
             );
+            fsSync.appendFileSync(eventFile!, 'stop\t{"stepIdx":4}\n');
           });
           yield* Deferred.await(followupObserved).pipe(Effect.timeout("2 seconds"));
           expect(teardownCalls).toBe(0);
@@ -2140,6 +2139,118 @@ describe("Antigravity background task helpers (#752)", () => {
     }
   });
 
+  it("ignores a hook poll that resumes after session replacement", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-stale-poll-"));
+    const transcriptFile = path.join(root, "transcript.jsonl");
+    await fs.writeFile(transcriptFile, "");
+
+    let eventFile: string | undefined;
+    let blockedEventFile: string | undefined;
+    let replacementEventFile: string | undefined;
+    let hookReadBlocked = false;
+    let resolveHookReadStarted = (): void => undefined;
+    const hookReadStarted = new Promise<void>((resolve) => {
+      resolveHookReadStarted = resolve;
+    });
+    let releaseHookRead = (): void => undefined;
+    const hookReadRelease = new Promise<void>((resolve) => {
+      releaseHookRead = resolve;
+    });
+    let resolveReplacementPoll = (): void => undefined;
+    const replacementPollObserved = new Promise<void>((resolve) => {
+      resolveReplacementPoll = resolve;
+    });
+    const spawnProcess = ((
+      _command: string,
+      _args: readonly string[],
+      options: { readonly env?: NodeJS.ProcessEnv },
+    ) => {
+      eventFile = options.env?.SYNARA_ANTIGRAVITY_EVENTS;
+      const spawned = new EventEmitter() as ChildProcess;
+      Object.assign(spawned, {
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        killed: false,
+        kill: () => true,
+      });
+      return spawned;
+    }) as NonNullable<AntigravityAdapterDependencies["spawnProcess"]>;
+    const readCompleteLines: NonNullable<
+      AntigravityAdapterDependencies["readCompleteLines"]
+    > = async (filePath, offset) => {
+      const batch = await readCompleteAntigravityLines(filePath, offset);
+      if (filePath === blockedEventFile && !hookReadBlocked) {
+        hookReadBlocked = true;
+        resolveHookReadStarted();
+        await hookReadRelease;
+      }
+      if (filePath === replacementEventFile) resolveReplacementPoll();
+      return batch;
+    };
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const adapter = yield* AntigravityAdapter;
+          const staleTaskIds: string[] = [];
+          const eventsFiber = yield* adapter.streamEvents.pipe(
+            Stream.runForEach((event) =>
+              Effect.sync(() => {
+                if (event.type === "task.started") staleTaskIds.push(event.payload.taskId);
+              }),
+            ),
+            Effect.forkChild,
+          );
+          const threadId = ThreadId.makeUnsafe("thread-antigravity-stale-poll");
+          const sessionInput = {
+            provider: "antigravity" as const,
+            threadId,
+            runtimeMode: "full-access" as const,
+            cwd: root,
+            providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+          };
+          yield* adapter.startSession(sessionInput);
+          yield* adapter.sendTurn({ threadId, input: "start a task", attachments: [] });
+          blockedEventFile = eventFile;
+          yield* Effect.promise(() =>
+            fs.appendFile(
+              blockedEventFile!,
+              [
+                'post-tool\t{"stepIdx":1,"toolCall":{"name":"run_command","args":{"CommandLine":"npm test","WaitMsBeforeAsync":1000}},"toolOutput":"Task id \'task-stale\' is now running in the background"}',
+                "",
+              ].join("\n"),
+            ),
+          );
+          yield* Effect.promise(() => hookReadStarted).pipe(Effect.timeout("2 seconds"));
+
+          yield* adapter.startSession(sessionInput);
+          releaseHookRead();
+          yield* adapter.sendTurn({ threadId, input: "replacement turn", attachments: [] });
+          replacementEventFile = eventFile;
+          yield* Effect.promise(() => replacementPollObserved).pipe(Effect.timeout("2 seconds"));
+
+          expect(staleTaskIds).toEqual([]);
+          yield* Fiber.interrupt(eventsFiber);
+          yield* adapter.stopSession(threadId);
+        }).pipe(
+          Effect.provide(
+            makeAntigravityAdapterLive({
+              ensurePlugin: async () => undefined,
+              readCompleteLines,
+              spawnProcess,
+              teardownProcessTree: async () => undefined,
+            }).pipe(
+              Layer.provideMerge(ServerConfig.layerTest(root, { prefix: "stale-poll-" })),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("settles pending background tasks on session replacement and process exit", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-background-restart-"));
     const transcriptFile = path.join(root, "transcript.jsonl");
@@ -2268,7 +2379,8 @@ describe("Antigravity background task helpers (#752)", () => {
             fs.appendFile(
               eventFile!,
               [
-                'post-tool\t{"stepIdx":2,"toolCall":{"name":"run_command","args":{"CommandLine":"npm test","WaitMsBeforeAsync":1000}},"toolOutput":"Task id \'task-buffered\' is now running in the background"}',
+                'post-tool\t{"stepIdx":2,"toolCall":{"name":"run_command","args":{"CommandLine":"npm run dev","WaitMsBeforeAsync":1000}},"toolOutput":"sent to the background"}',
+                'post-tool\t{"stepIdx":3,"toolCall":{"name":"run_command","args":{"CommandLine":"npm test","WaitMsBeforeAsync":1000}},"toolOutput":"Task id \'task-buffered\' is now running in the background"}',
                 "",
               ].join("\n"),
             ),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -1752,6 +1752,12 @@ describe("Antigravity background task helpers (#752)", () => {
 
     const senderOnly = parseAntigravitySystemMessage("<SYSTEM_MESSAGE> sender=task-x77 done");
     expect(senderOnly).toMatchObject({ isSystemMessage: true, taskId: "task-x77" });
+
+    expect(
+      parseAntigravitySystemMessage(
+        "<SYSTEM_MESSAGE> Task id 'task-clean' completed with 0 failed and no error",
+      ),
+    ).toMatchObject({ taskId: "task-clean", isFailure: false });
   });
 
   it("detects background task starts from run_command tool output", () => {
@@ -1796,6 +1802,22 @@ describe("Antigravity background task helpers (#752)", () => {
     ).toBeNull();
 
     expect(
+      detectAntigravityBackgroundTaskStart(
+        "run_command",
+        { CommandLine: "echo task-42" },
+        { toolOutput: "foreground command printed task-42 and exited with code 0" },
+      ),
+    ).toBeNull();
+
+    expect(
+      detectAntigravityBackgroundTaskStart(
+        "run_command",
+        { CommandLine: "npm run dev", WaitMsBeforeAsync: 1000 },
+        { failed: true },
+      ),
+    ).toBeNull();
+
+    expect(
       detectAntigravityBackgroundTaskStart("run_command", {
         CommandLine: "npm run dev",
         WaitMsBeforeAsync: 1000,
@@ -1822,6 +1844,16 @@ describe("Antigravity background task helpers (#752)", () => {
       description: "Scheduled timer",
       isBackground: true,
     });
+
+    expect(
+      detectAntigravityBackgroundTaskStart(
+        "schedule",
+        { Prompt: "remind me later" },
+        {
+          error: "scheduler unavailable",
+        },
+      ),
+    ).toBeNull();
 
     expect(detectAntigravityBackgroundTaskStart("list_files")).toBeNull();
   });
@@ -1893,8 +1925,7 @@ describe("Antigravity background task helpers (#752)", () => {
                   conversationId: "conversation-background-stop",
                   transcriptPath: transcriptFile,
                 })}`,
-                'pre-tool\t{"stepIdx":1,"toolCall":{"name":"run_command","args":{"CommandLine":"npm test","WaitMsBeforeAsync":1000}}}',
-                'post-tool\t{"stepIdx":1,"toolCall":{"name":"run_command"},"toolOutput":"Task id \'task-42\' is now running in the background"}',
+                'post-tool\t{"stepIdx":1,"toolCall":{"name":"run_command","args":{"CommandLine":"npm test","WaitMsBeforeAsync":1000}},"toolOutput":"sent to the background"}',
                 'stop\t{"stepIdx":2}',
                 "",
               ].join("\n"),
@@ -1949,6 +1980,8 @@ describe("Antigravity background task helpers (#752)", () => {
 
   it("settles pending background tasks on session replacement and process exit", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-antigravity-background-restart-"));
+    const transcriptFile = path.join(root, "transcript.jsonl");
+    await fs.writeFile(transcriptFile, "");
     let eventFile: string | undefined;
     let child: ChildProcess | undefined;
     const spawnProcess = ((
@@ -1979,7 +2012,7 @@ describe("Antigravity background task helpers (#752)", () => {
                 event.type === "task.updated" ||
                 event.type === "task.completed",
             ),
-            Stream.take(4),
+            Stream.take(6),
             Stream.runCollect,
             Effect.forkChild,
           );
@@ -2011,9 +2044,43 @@ describe("Antigravity background task helpers (#752)", () => {
           yield* Effect.promise(() =>
             fs.appendFile(
               eventFile!,
+              `pre-invocation\t${JSON.stringify({
+                conversationId: "conversation-background-restart",
+                transcriptPath: transcriptFile,
+              })}\n`,
+            ),
+          );
+          yield* Effect.sleep("150 millis");
+          yield* Effect.promise(() =>
+            fs.appendFile(
+              transcriptFile,
+              `${JSON.stringify({
+                step_index: 2,
+                type: "SYSTEM_MESSAGE",
+                content: "<SYSTEM_MESSAGE> Task id 'task-buffered' exited with code 0",
+              })}\n`,
+            ),
+          );
+          yield* Effect.sleep("150 millis");
+          yield* Effect.promise(() =>
+            fs.appendFile(
+              eventFile!,
               [
-                'pre-tool\t{"stepIdx":2,"toolCall":{"name":"run_command","args":{"CommandLine":"npm test","WaitMsBeforeAsync":1000}}}',
-                'post-tool\t{"stepIdx":2,"toolCall":{"name":"run_command"},"toolOutput":"Task id \'task-exit\' is now running in the background"}',
+                'post-tool\t{"stepIdx":2,"toolCall":{"name":"run_command","args":{"CommandLine":"npm test","WaitMsBeforeAsync":1000}},"toolOutput":"sent to the background"}',
+                "",
+              ].join("\n"),
+            ),
+          );
+          yield* Effect.sleep("150 millis");
+          child?.emit("close", 0, null);
+          yield* Effect.sleep("50 millis");
+
+          yield* adapter.sendTurn({ threadId, input: "run final tests", attachments: [] });
+          yield* Effect.promise(() =>
+            fs.appendFile(
+              eventFile!,
+              [
+                'post-tool\t{"stepIdx":3,"toolCall":{"name":"run_command","args":{"CommandLine":"npm test","WaitMsBeforeAsync":1000}},"toolOutput":"Task id \'task-exit\' is now running in the background"}',
                 "",
               ].join("\n"),
             ),
@@ -2029,12 +2096,18 @@ describe("Antigravity background task helpers (#752)", () => {
             "task.updated",
             "task.started",
             "task.completed",
+            "task.started",
+            "task.completed",
           ]);
           expect(taskEvents[1]?.payload).toMatchObject({
             taskId: "task-restart",
             status: "killed",
           });
           expect(taskEvents[3]?.payload).toMatchObject({
+            taskId: "task-1",
+            status: "completed",
+          });
+          expect(taskEvents[5]?.payload).toMatchObject({
             taskId: "task-exit",
             status: "failed",
           });

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -164,6 +164,7 @@ type AntigravitySessionContext = ToolSurfaceCounters & {
   sawAssistant: boolean;
   interrupted: boolean;
   stopped: boolean;
+  stopAwaitingBackgroundTasks: boolean;
   /** Guards against double turn.completed (process close + interrupt/stop). */
   turnTerminalEmitted: boolean;
 };
@@ -756,7 +757,7 @@ export function parseAntigravitySystemMessage(
   const exitCodeMatch = trimmed.match(/exited with code (\d+)/iu);
   const exitCode = exitCodeMatch ? parseInt(exitCodeMatch[1] ?? "0", 10) : undefined;
   const failureText = trimmed
-    .replace(/\b(?:0|no)\s+failed\b/giu, "")
+    .replace(/\b(?:0|no)(?:\s+[\p{L}\p{N}_-]+){0,3}\s+failed\b/giu, "")
     .replace(/\b(?:no|without)\s+errors?\b/giu, "");
   const isFailure =
     exitCode !== undefined ? exitCode !== 0 : /\bfailed\b|\berror\b/iu.test(failureText);
@@ -1134,9 +1135,11 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         candidateId,
         context.pendingBackgroundTasks.keys(),
       );
-      if (direct || !candidateId || context.pendingBackgroundTasks.size !== 1) return direct;
-      const only = context.pendingBackgroundTasks.values().next().value;
-      return only?.providerTaskId === undefined ? only?.taskId : undefined;
+      if (direct || !candidateId) return direct;
+      for (const task of context.pendingBackgroundTasks.values()) {
+        if (task.providerTaskId === undefined) return task.taskId;
+      }
+      return undefined;
     };
 
     const settleTrackedBackgroundTask = (
@@ -1198,6 +1201,26 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       if (completion) settleTrackedBackgroundTask(context, taskId, completion);
     };
 
+    const teardownStoppedTurnIfIdle = (context: AntigravitySessionContext): void => {
+      if (
+        !context.stopAwaitingBackgroundTasks ||
+        !context.activeProcess ||
+        context.turnTerminalEmitted ||
+        context.pendingBackgroundTasks.size > 0
+      ) {
+        return;
+      }
+      context.stopAwaitingBackgroundTasks = false;
+      const child = context.activeProcess;
+      void teardownProcessTree(child).catch(() => {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // Process may already be gone.
+        }
+      });
+    };
+
     /**
      * Emit a single terminal turn.completed for the active turn and mark the
      * session idle. Idempotent so process-close, interrupt, and stop-hook
@@ -1234,6 +1257,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         }),
       });
       context.turnTerminalEmitted = true;
+      context.stopAwaitingBackgroundTasks = false;
       delete context.activeProcess;
       delete context.activeTurnId;
       const {
@@ -1837,29 +1861,10 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         // alive by design to wait for the background completion and stream the
         // follow-up response; killing it aborts the task and fails the turn
         // with "Error: timeout waiting for response" (#752).
-        if (eventName === "stop") {
-          // A background completion can be committed to the transcript before
-          // its final stop hook reaches this file. Drain it before deciding
-          // whether the print process is still waiting on live work.
-          await readTranscript(context);
-        }
-        if (
-          eventName === "stop" &&
-          context.activeProcess &&
-          !context.turnTerminalEmitted &&
-          context.pendingBackgroundTasks.size === 0
-        ) {
-          const child = context.activeProcess;
-          void teardownProcessTree(child).catch(() => {
-            try {
-              child.kill("SIGKILL");
-            } catch {
-              // Process may already be gone.
-            }
-          });
-        }
+        if (eventName === "stop") context.stopAwaitingBackgroundTasks = true;
       }
       await readTranscript(context);
+      teardownStoppedTurnIfIdle(context);
     };
 
     const startSession: AntigravityAdapterShape["startSession"] = (input) =>
@@ -1942,6 +1947,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           sawAssistant: false,
           interrupted: false,
           stopped: false,
+          stopAwaitingBackgroundTasks: false,
           turnTerminalEmitted: false,
         };
         sessions.set(input.threadId, context);
@@ -2065,6 +2071,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         context.hookToolCallCounts.clear();
         context.sawAssistant = false;
         context.interrupted = false;
+        context.stopAwaitingBackgroundTasks = false;
         context.turnTerminalEmitted = false;
         context.turns.push({ id: turnId, items: [] });
         context.session = {

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -12,6 +12,7 @@ import {
   type ProviderRuntimeEvent,
   type ProviderSession,
   RuntimeItemId,
+  RuntimeTaskId,
   ThreadId,
   TurnId,
 } from "@synara/contracts";
@@ -67,8 +68,8 @@ const PROVIDER = "antigravity" as const;
 const DEFAULT_MODEL = "Gemini 3.5 Flash";
 const PRINT_TIMEOUT = "30m";
 const POLL_INTERVAL_MS = 75;
-const MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
-const PLUGIN_INSTALL_TIMEOUT_MS = 30_000;
+const MODEL_DISCOVERY_TIMEOUT_MS = 30_000;
+const PLUGIN_INSTALL_TIMEOUT_MS = 45_000;
 const HELPER_OUTPUT_MAX_CHARS = 128 * 1024;
 const WINDOWS_PROMPT_MAX_CHARS = 24_000;
 
@@ -96,6 +97,13 @@ type PendingTool = {
 type StoredTurn = {
   readonly id: TurnId;
   readonly items: unknown[];
+};
+
+export type AntigravityTrackedBackgroundTask = {
+  readonly taskId: string;
+  readonly taskType: string;
+  readonly description?: string;
+  readonly startedAt: string;
 };
 
 type ToolSurfaceCounters = {
@@ -132,6 +140,8 @@ type AntigravitySessionContext = ToolSurfaceCounters & {
   processedSteps: Set<number>;
   pendingTools: PendingTool[];
   nextToolSequence: number;
+  pendingBackgroundTasks: Map<string, AntigravityTrackedBackgroundTask>;
+  nextBackgroundTaskId: number;
   /**
    * Conversations owned by spawned subagents, keyed by conversation id.
    * The capture hook is installed globally, so a subagent CLI spawned by the
@@ -716,6 +726,138 @@ function buildAntigravityToolItemData(
   };
 }
 
+export interface AntigravitySystemMessageInfo {
+  readonly isSystemMessage: boolean;
+  readonly fullContent: string;
+  readonly taskId?: string;
+  readonly sender?: string;
+  readonly exitCode?: number;
+  readonly isFailure: boolean;
+}
+
+export function parseAntigravitySystemMessage(
+  content: string | undefined,
+): AntigravitySystemMessageInfo | null {
+  if (!content || typeof content !== "string") return null;
+  const trimmed = content.trim();
+  if (!trimmed.includes("<SYSTEM_MESSAGE>")) return null;
+
+  const senderMatch = trimmed.match(/sender=([^\s]+)/u);
+  const sender = senderMatch?.[1];
+
+  const taskIdMatch =
+    trimmed.match(/Task id ["']([^"']+)["']/iu) ??
+    trimmed.match(/Task ID:?\s*["']?([^\s\n,"']+)["']?/iu);
+  const rawTaskId = taskIdMatch?.[1] ?? (sender?.includes("task-") ? sender : undefined);
+  const taskId = rawTaskId?.trim();
+
+  const exitCodeMatch = trimmed.match(/exited with code (\d+)/iu);
+  const exitCode = exitCodeMatch ? parseInt(exitCodeMatch[1] ?? "0", 10) : undefined;
+  const isFailure =
+    exitCode !== undefined ? exitCode !== 0 : /\bfailed\b|\berror\b/iu.test(trimmed);
+
+  return {
+    isSystemMessage: true,
+    fullContent: trimmed,
+    ...(taskId ? { taskId } : {}),
+    ...(sender ? { sender } : {}),
+    ...(exitCode !== undefined ? { exitCode } : {}),
+    isFailure,
+  };
+}
+
+export function detectAntigravityBackgroundTaskStart(
+  name: string,
+  args?: Record<string, unknown>,
+  postPayload?: Record<string, unknown>,
+): { taskId?: string; description?: string; isBackground: boolean } | null {
+  if (name === "run_command") {
+    const rawOutput =
+      typeof postPayload?.toolOutput === "string"
+        ? postPayload.toolOutput
+        : typeof postPayload?.result === "string"
+          ? postPayload.result
+          : undefined;
+    const command =
+      typeof args?.CommandLine === "string"
+        ? args.CommandLine
+        : typeof args?.command === "string"
+          ? args.command
+          : typeof args?.cmd === "string"
+            ? args.cmd
+            : undefined;
+
+    if (rawOutput) {
+      const match =
+        rawOutput.match(/Task id ["']?([\w.-]+)["']?/iu) ?? rawOutput.match(/\b(task-[\w.-]+)\b/iu);
+      if (match || /background task|sent to the background/iu.test(rawOutput)) {
+        const taskId = match?.[1] ?? match?.[0];
+        return {
+          ...(taskId ? { taskId } : {}),
+          ...(command ? { description: command } : {}),
+          isBackground: true,
+        };
+      }
+    }
+    if (
+      typeof args?.WaitMsBeforeAsync === "number" &&
+      (!rawOutput || !/exited with code/iu.test(rawOutput))
+    ) {
+      const match = rawOutput?.match(/\b(task-[\w.-]+)\b/iu);
+      return {
+        ...(match?.[0] ? { taskId: match[0] } : {}),
+        ...(command ? { description: command } : {}),
+        isBackground: true,
+      };
+    }
+  }
+
+  if (name === "schedule") {
+    const prompt = typeof args?.Prompt === "string" ? args.Prompt : undefined;
+    const rawOutput =
+      typeof postPayload?.toolOutput === "string"
+        ? postPayload.toolOutput
+        : typeof postPayload?.result === "string"
+          ? postPayload.result
+          : undefined;
+    const match = rawOutput
+      ? (rawOutput.match(/\b(task-[\w.-]+)\b/iu) ?? rawOutput.match(/\b(timer-[\w.-]+)\b/iu))
+      : undefined;
+    return {
+      ...(match?.[0] ? { taskId: match[0] } : {}),
+      description: prompt ?? "Scheduled timer",
+      isBackground: true,
+    };
+  }
+
+  return null;
+}
+
+export function matchAntigravityTrackedTaskId(
+  candidateId: string | undefined,
+  trackedTaskIds: Iterable<string>,
+): string | undefined {
+  const ids = Array.from(trackedTaskIds);
+  if (ids.length === 0) return undefined;
+  if (!candidateId) {
+    return ids.length === 1 ? ids[0] : undefined;
+  }
+  const cleanCandidate = candidateId.trim();
+  if (ids.includes(cleanCandidate)) return cleanCandidate;
+  for (const id of ids) {
+    if (cleanCandidate.endsWith(`/${id}`) || cleanCandidate.endsWith(`:${id}`)) {
+      return id;
+    }
+  }
+  for (const id of ids) {
+    if (id.endsWith(`/${cleanCandidate}`) || id.endsWith(`:${cleanCandidate}`)) {
+      return id;
+    }
+  }
+  if (ids.length === 1) return ids[0];
+  return undefined;
+}
+
 export function makeAntigravityRuntimeEventBase(input: {
   readonly threadId: ThreadId;
   readonly lifecycleGeneration?: string;
@@ -1089,14 +1231,67 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           },
           raw: raw("transcript-tool-call", { stepIdx: stepIndex, name, args }),
         } satisfies ProviderRuntimeEvent);
+
+        const bgStart = detectAntigravityBackgroundTaskStart(name, args);
+        if (bgStart?.isBackground) {
+          const taskId = bgStart.taskId ?? `task-${context.nextBackgroundTaskId++}`;
+          if (!context.pendingBackgroundTasks.has(taskId)) {
+            context.pendingBackgroundTasks.set(taskId, {
+              taskId,
+              taskType: itemType,
+              ...(bgStart.description ? { description: bgStart.description } : {}),
+              startedAt: new Date().toISOString(),
+            });
+            offer({
+              ...base(context),
+              type: "task.started",
+              payload: {
+                taskId: RuntimeTaskId.makeUnsafe(taskId),
+                taskType: itemType,
+                ...(bgStart.description ? { description: bgStart.description } : {}),
+              },
+              raw: raw("transcript-background-task-started", { taskId, name, args }),
+            } satisfies ProviderRuntimeEvent);
+          }
+        }
       }
     };
 
     const processTranscriptStep = (context: AntigravitySessionContext, step: TranscriptStep) => {
       const stepIndex = step.step_index;
-      if (typeof stepIndex !== "number" || context.processedSteps.has(stepIndex)) return;
-      context.processedSteps.add(stepIndex);
+      if (typeof stepIndex === "number") {
+        if (context.processedSteps.has(stepIndex)) return;
+        context.processedSteps.add(stepIndex);
+      }
       currentTurn(context)?.items.push(step);
+
+      const systemMessage = parseAntigravitySystemMessage(
+        typeof step.content === "string" ? step.content : undefined,
+      );
+      if (systemMessage?.isSystemMessage) {
+        const matchedTaskId = matchAntigravityTrackedTaskId(
+          systemMessage.taskId ?? systemMessage.sender,
+          context.pendingBackgroundTasks.keys(),
+        );
+        if (matchedTaskId) {
+          const tracked = context.pendingBackgroundTasks.get(matchedTaskId);
+          context.pendingBackgroundTasks.delete(matchedTaskId);
+          offer({
+            ...base(context),
+            type: "task.completed",
+            payload: {
+              taskId: RuntimeTaskId.makeUnsafe(matchedTaskId),
+              status: systemMessage.isFailure ? "failed" : "completed",
+            },
+            raw: raw("background-task-completed", {
+              taskId: matchedTaskId,
+              systemMessage,
+              tracked,
+            }),
+          } satisfies ProviderRuntimeEvent);
+        }
+        return;
+      }
 
       if (step.type === "PLANNER_RESPONSE") {
         const calls = Array.isArray(step.tool_calls) ? step.tool_calls : [];
@@ -1111,7 +1306,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           if (reasoning) {
             emitTextItem(context, step, "reasoning", "reasoning_text", reasoning);
           }
-          emitTranscriptToolCalls(context, stepIndex, calls);
+          emitTranscriptToolCalls(context, stepIndex ?? 0, calls);
         } else {
           const assistantText = trim(
             typeof step.content === "string"
@@ -1160,7 +1355,8 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           )
         : -1;
       for (const step of steps) {
-        if (typeof step.step_index === "number" && step.step_index > latestUserIndex) {
+        const idx = typeof step.step_index === "number" ? step.step_index : Number.MAX_SAFE_INTEGER;
+        if (idx > latestUserIndex) {
           processTranscriptStep(context, step);
         }
       }
@@ -1491,11 +1687,72 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
                 failed,
               }),
             } satisfies ProviderRuntimeEvent);
+
+            const bgStart = detectAntigravityBackgroundTaskStart(
+              pending.name,
+              pending.args,
+              payload,
+            );
+            if (bgStart?.isBackground) {
+              const taskId = bgStart.taskId ?? `task-${context.nextBackgroundTaskId++}`;
+              context.pendingBackgroundTasks.set(taskId, {
+                taskId,
+                taskType: pending.itemType,
+                ...(bgStart.description ? { description: bgStart.description } : {}),
+                startedAt: new Date().toISOString(),
+              });
+              offer({
+                ...base(context),
+                type: "task.started",
+                payload: {
+                  taskId: RuntimeTaskId.makeUnsafe(taskId),
+                  taskType: pending.itemType,
+                  ...(bgStart.description ? { description: bgStart.description } : {}),
+                },
+                raw: raw("background-task-started", {
+                  taskId,
+                  name: pending.name,
+                  args: pending.args,
+                }),
+              } satisfies ProviderRuntimeEvent);
+            } else if (pending.name === "manage_task") {
+              const action =
+                typeof pending.args?.Action === "string" ? pending.args.Action : undefined;
+              const targetTaskId =
+                typeof pending.args?.TaskId === "string" ? pending.args.TaskId : undefined;
+              if (action === "kill" && targetTaskId) {
+                const matchedId = matchAntigravityTrackedTaskId(
+                  targetTaskId,
+                  context.pendingBackgroundTasks.keys(),
+                );
+                if (matchedId) {
+                  context.pendingBackgroundTasks.delete(matchedId);
+                  offer({
+                    ...base(context),
+                    type: "task.updated",
+                    payload: {
+                      taskId: RuntimeTaskId.makeUnsafe(matchedId),
+                      status: "killed",
+                    },
+                    raw: raw("background-task-killed", { taskId: matchedId }),
+                  } satisfies ProviderRuntimeEvent);
+                }
+              }
+            }
           }
         }
         // Agent finished: if the print process lingers, tear it down so the
         // close handler (or interrupt fallback) can settle the turn (#465).
-        if (eventName === "stop" && context.activeProcess && !context.turnTerminalEmitted) {
+        // Skip the teardown while background tasks are pending: the CLI stays
+        // alive by design to wait for the background completion and stream the
+        // follow-up response; killing it aborts the task and fails the turn
+        // with "Error: timeout waiting for response" (#752).
+        if (
+          eventName === "stop" &&
+          context.activeProcess &&
+          !context.turnTerminalEmitted &&
+          context.pendingBackgroundTasks.size === 0
+        ) {
           const child = context.activeProcess;
           void teardownProcessTree(child).catch(() => {
             try {
@@ -1538,6 +1795,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         if (existing) {
           existing.stopped = true;
           existing.interrupted = true;
+          existing.pendingBackgroundTasks.clear();
           settleForeignConversations(existing, {
             state: "interrupted",
             raw: raw("session-restart", { threadId: input.threadId }),
@@ -1579,6 +1837,8 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           processedSteps: new Set(),
           pendingTools: [],
           nextToolSequence: 0,
+          pendingBackgroundTasks: new Map(),
+          nextBackgroundTaskId: 1,
           foreignConversations: new Map(),
           surfacedToolCallCounts: new Map(),
           hookToolCallCounts: new Map(),
@@ -1876,6 +2136,18 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           });
           return;
         }
+        for (const [taskId] of context.pendingBackgroundTasks) {
+          offer({
+            ...base(context),
+            type: "task.updated",
+            payload: {
+              taskId: RuntimeTaskId.makeUnsafe(taskId),
+              status: "killed",
+            },
+            raw: raw("interrupt-background-task-killed", { taskId }),
+          } satisfies ProviderRuntimeEvent);
+        }
+        context.pendingBackgroundTasks.clear();
         const activeTurnId = turnId ?? context.activeTurnId;
         yield* withAgentGatewayTurnCancellation(
           context.gatewaySessionLease,
@@ -1936,6 +2208,18 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         if (!context) return;
         context.stopped = true;
         context.interrupted = true;
+        for (const [taskId] of context.pendingBackgroundTasks) {
+          offer({
+            ...base(context),
+            type: "task.updated",
+            payload: {
+              taskId: RuntimeTaskId.makeUnsafe(taskId),
+              status: "killed",
+            },
+            raw: raw("session-stop-background-task-killed", { taskId }),
+          } satisfies ProviderRuntimeEvent);
+        }
+        context.pendingBackgroundTasks.clear();
         settleForeignConversations(context, {
           state: "interrupted",
           raw: raw("session-stop", { threadId }),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -800,6 +800,7 @@ export function detectAntigravityBackgroundTaskStart(
       }
     }
     if (
+      postPayload !== undefined &&
       typeof args?.WaitMsBeforeAsync === "number" &&
       (!rawOutput || !/exited with code/iu.test(rawOutput))
     ) {
@@ -854,7 +855,6 @@ export function matchAntigravityTrackedTaskId(
       return id;
     }
   }
-  if (ids.length === 1) return ids[0];
   return undefined;
 }
 
@@ -1073,6 +1073,43 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       }).pipe(Effect.asVoid);
     };
 
+    const completePendingBackgroundTasks = (
+      context: AntigravitySessionContext,
+      status: "completed" | "failed" | "stopped",
+      source: string,
+    ): void => {
+      for (const [taskId, tracked] of context.pendingBackgroundTasks) {
+        offer({
+          ...base(context),
+          type: "task.completed",
+          payload: {
+            taskId: RuntimeTaskId.makeUnsafe(taskId),
+            status,
+          },
+          raw: raw(source, { taskId, tracked, status }),
+        } satisfies ProviderRuntimeEvent);
+      }
+      context.pendingBackgroundTasks.clear();
+    };
+
+    const killPendingBackgroundTasks = (
+      context: AntigravitySessionContext,
+      source: string,
+    ): void => {
+      for (const [taskId, tracked] of context.pendingBackgroundTasks) {
+        offer({
+          ...base(context),
+          type: "task.updated",
+          payload: {
+            taskId: RuntimeTaskId.makeUnsafe(taskId),
+            status: "killed",
+          },
+          raw: raw(source, { taskId, tracked }),
+        } satisfies ProviderRuntimeEvent);
+      }
+      context.pendingBackgroundTasks.clear();
+    };
+
     /**
      * Emit a single terminal turn.completed for the active turn and mark the
      * session idle. Idempotent so process-close, interrupt, and stop-hook
@@ -1091,6 +1128,15 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         return false;
       }
       const completionBase = base(context);
+      completePendingBackgroundTasks(
+        context,
+        input.state === "interrupted"
+          ? "stopped"
+          : input.state === "failed"
+            ? "failed"
+            : "completed",
+        "parent-turn-background-task-terminal",
+      );
       settleForeignConversations(context, {
         state: input.state,
         ...(input.errorMessage ? { errorMessage: input.errorMessage } : {}),
@@ -1231,29 +1277,6 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           },
           raw: raw("transcript-tool-call", { stepIdx: stepIndex, name, args }),
         } satisfies ProviderRuntimeEvent);
-
-        const bgStart = detectAntigravityBackgroundTaskStart(name, args);
-        if (bgStart?.isBackground) {
-          const taskId = bgStart.taskId ?? `task-${context.nextBackgroundTaskId++}`;
-          if (!context.pendingBackgroundTasks.has(taskId)) {
-            context.pendingBackgroundTasks.set(taskId, {
-              taskId,
-              taskType: itemType,
-              ...(bgStart.description ? { description: bgStart.description } : {}),
-              startedAt: new Date().toISOString(),
-            });
-            offer({
-              ...base(context),
-              type: "task.started",
-              payload: {
-                taskId: RuntimeTaskId.makeUnsafe(taskId),
-                taskType: itemType,
-                ...(bgStart.description ? { description: bgStart.description } : {}),
-              },
-              raw: raw("transcript-background-task-started", { taskId, name, args }),
-            } satisfies ProviderRuntimeEvent);
-          }
-        }
       }
     };
 
@@ -1747,6 +1770,12 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         // alive by design to wait for the background completion and stream the
         // follow-up response; killing it aborts the task and fails the turn
         // with "Error: timeout waiting for response" (#752).
+        if (eventName === "stop") {
+          // A background completion can be committed to the transcript before
+          // its final stop hook reaches this file. Drain it before deciding
+          // whether the print process is still waiting on live work.
+          await readTranscript(context);
+        }
         if (
           eventName === "stop" &&
           context.activeProcess &&
@@ -1795,7 +1824,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         if (existing) {
           existing.stopped = true;
           existing.interrupted = true;
-          existing.pendingBackgroundTasks.clear();
+          killPendingBackgroundTasks(existing, "session-restart-background-task-killed");
           settleForeignConversations(existing, {
             state: "interrupted",
             raw: raw("session-restart", { threadId: input.threadId }),
@@ -2136,18 +2165,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           });
           return;
         }
-        for (const [taskId] of context.pendingBackgroundTasks) {
-          offer({
-            ...base(context),
-            type: "task.updated",
-            payload: {
-              taskId: RuntimeTaskId.makeUnsafe(taskId),
-              status: "killed",
-            },
-            raw: raw("interrupt-background-task-killed", { taskId }),
-          } satisfies ProviderRuntimeEvent);
-        }
-        context.pendingBackgroundTasks.clear();
+        killPendingBackgroundTasks(context, "interrupt-background-task-killed");
         const activeTurnId = turnId ?? context.activeTurnId;
         yield* withAgentGatewayTurnCancellation(
           context.gatewaySessionLease,
@@ -2208,18 +2226,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         if (!context) return;
         context.stopped = true;
         context.interrupted = true;
-        for (const [taskId] of context.pendingBackgroundTasks) {
-          offer({
-            ...base(context),
-            type: "task.updated",
-            payload: {
-              taskId: RuntimeTaskId.makeUnsafe(taskId),
-              status: "killed",
-            },
-            raw: raw("session-stop-background-task-killed", { taskId }),
-          } satisfies ProviderRuntimeEvent);
-        }
-        context.pendingBackgroundTasks.clear();
+        killPendingBackgroundTasks(context, "session-stop-background-task-killed");
         settleForeignConversations(context, {
           state: "interrupted",
           raw: raw("session-stop", { threadId }),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -101,7 +101,6 @@ type StoredTurn = {
 
 export type AntigravityTrackedBackgroundTask = {
   readonly taskId: string;
-  readonly providerTaskId?: string;
   readonly taskType: string;
   readonly description?: string;
   readonly startedAt: string;
@@ -136,14 +135,16 @@ type AntigravitySessionContext = ToolSurfaceCounters & {
   modelName?: string | undefined;
   modelOptions?: AntigravityModelOptions | undefined;
   processedHookBytes: number;
+  hookPollPromise?: Promise<void>;
   processedTranscriptBytes: number;
   processedTranscriptPath?: string | undefined;
   processedSteps: Set<number>;
   pendingTools: PendingTool[];
   nextToolSequence: number;
   pendingBackgroundTasks: Map<string, AntigravityTrackedBackgroundTask>;
+  pendingAnonymousBackgroundTasks: number;
   pendingBackgroundTaskCompletions: AntigravitySystemMessageInfo[];
-  nextBackgroundTaskId: number;
+  latestBackgroundCompletionStepIndex?: number;
   /**
    * Conversations owned by spawned subagents, keyed by conversation id.
    * The capture hook is installed globally, so a subagent CLI spawned by the
@@ -164,7 +165,6 @@ type AntigravitySessionContext = ToolSurfaceCounters & {
   sawAssistant: boolean;
   interrupted: boolean;
   stopped: boolean;
-  stopAwaitingBackgroundTasks: boolean;
   /** Guards against double turn.completed (process close + interrupt/stop). */
   turnTerminalEmitted: boolean;
 };
@@ -1101,6 +1101,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         } satisfies ProviderRuntimeEvent);
       }
       context.pendingBackgroundTasks.clear();
+      context.pendingAnonymousBackgroundTasks = 0;
       context.pendingBackgroundTaskCompletions.length = 0;
     };
 
@@ -1120,27 +1121,13 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         } satisfies ProviderRuntimeEvent);
       }
       context.pendingBackgroundTasks.clear();
+      context.pendingAnonymousBackgroundTasks = 0;
       context.pendingBackgroundTaskCompletions.length = 0;
     };
 
     const backgroundCompletionCandidate = (
       message: AntigravitySystemMessageInfo,
     ): string | undefined => message.taskId ?? message.sender;
-
-    const matchTrackedBackgroundTaskId = (
-      context: AntigravitySessionContext,
-      candidateId: string | undefined,
-    ): string | undefined => {
-      const direct = matchAntigravityTrackedTaskId(
-        candidateId,
-        context.pendingBackgroundTasks.keys(),
-      );
-      if (direct || !candidateId) return direct;
-      for (const task of context.pendingBackgroundTasks.values()) {
-        if (task.providerTaskId === undefined) return task.taskId;
-      }
-      return undefined;
-    };
 
     const settleTrackedBackgroundTask = (
       context: AntigravitySessionContext,
@@ -1172,11 +1159,18 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       taskType: string,
       source: { readonly name: string; readonly args?: Record<string, unknown> },
     ): void => {
-      const taskId = start.taskId ?? `task-${context.nextBackgroundTaskId++}`;
+      if (!start.taskId) {
+        if (context.pendingBackgroundTaskCompletions.length > 0) {
+          context.pendingBackgroundTaskCompletions.shift();
+        } else {
+          context.pendingAnonymousBackgroundTasks += 1;
+        }
+        return;
+      }
+      const taskId = start.taskId;
       if (context.pendingBackgroundTasks.has(taskId)) return;
       context.pendingBackgroundTasks.set(taskId, {
         taskId,
-        ...(start.taskId ? { providerTaskId: start.taskId } : {}),
         taskType,
         ...(start.description ? { description: start.description } : {}),
         startedAt: new Date().toISOString(),
@@ -1194,7 +1188,10 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
 
       const completionIndex = context.pendingBackgroundTaskCompletions.findIndex(
         (message) =>
-          matchTrackedBackgroundTaskId(context, backgroundCompletionCandidate(message)) === taskId,
+          matchAntigravityTrackedTaskId(
+            backgroundCompletionCandidate(message),
+            context.pendingBackgroundTasks.keys(),
+          ) === taskId,
       );
       if (completionIndex < 0) return;
       const [completion] = context.pendingBackgroundTaskCompletions.splice(completionIndex, 1);
@@ -1203,14 +1200,13 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
 
     const teardownStoppedTurnIfIdle = (context: AntigravitySessionContext): void => {
       if (
-        !context.stopAwaitingBackgroundTasks ||
         !context.activeProcess ||
         context.turnTerminalEmitted ||
-        context.pendingBackgroundTasks.size > 0
+        context.pendingBackgroundTasks.size > 0 ||
+        context.pendingAnonymousBackgroundTasks > 0
       ) {
         return;
       }
-      context.stopAwaitingBackgroundTasks = false;
       const child = context.activeProcess;
       void teardownProcessTree(child).catch(() => {
         try {
@@ -1257,7 +1253,6 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         }),
       });
       context.turnTerminalEmitted = true;
-      context.stopAwaitingBackgroundTasks = false;
       delete context.activeProcess;
       delete context.activeTurnId;
       const {
@@ -1405,9 +1400,20 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       );
       if (systemMessage?.isSystemMessage) {
         const candidateId = backgroundCompletionCandidate(systemMessage);
-        const matchedTaskId = matchTrackedBackgroundTaskId(context, candidateId);
+        if (candidateId && typeof stepIndex === "number") {
+          context.latestBackgroundCompletionStepIndex = Math.max(
+            context.latestBackgroundCompletionStepIndex ?? -1,
+            stepIndex,
+          );
+        }
+        const matchedTaskId = matchAntigravityTrackedTaskId(
+          candidateId,
+          context.pendingBackgroundTasks.keys(),
+        );
         if (matchedTaskId) {
           settleTrackedBackgroundTask(context, matchedTaskId, systemMessage);
+        } else if (candidateId && context.pendingAnonymousBackgroundTasks > 0) {
+          context.pendingAnonymousBackgroundTasks -= 1;
         } else if (candidateId) {
           context.pendingBackgroundTaskCompletions.push(systemMessage);
           if (context.pendingBackgroundTaskCompletions.length > 32) {
@@ -1662,9 +1668,11 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       }
     };
 
-    const pollHookFile = async (context: AntigravitySessionContext) => {
+    const pollHookFileOnce = async (context: AntigravitySessionContext) => {
       if (context.stopped) return;
       if (!context.eventFile) return;
+      let latestStopStepIndex: number | undefined;
+      let sawStopWithoutStepIndex = false;
       let batch: Awaited<ReturnType<typeof readCompleteAntigravityLines>>;
       try {
         batch = await readCompleteAntigravityLines(context.eventFile, context.processedHookBytes);
@@ -1851,6 +1859,11 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
                   },
                   raw: raw("background-task-killed", { taskId: matchedId }),
                 } satisfies ProviderRuntimeEvent);
+              } else if (action === "kill" && targetTaskId) {
+                context.pendingAnonymousBackgroundTasks = Math.max(
+                  0,
+                  context.pendingAnonymousBackgroundTasks - 1,
+                );
               }
             }
           }
@@ -1861,10 +1874,30 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         // alive by design to wait for the background completion and stream the
         // follow-up response; killing it aborts the task and fails the turn
         // with "Error: timeout waiting for response" (#752).
-        if (eventName === "stop") context.stopAwaitingBackgroundTasks = true;
+        if (eventName === "stop") {
+          if (stepIndex === undefined) {
+            sawStopWithoutStepIndex = true;
+          } else {
+            latestStopStepIndex = Math.max(latestStopStepIndex ?? -1, stepIndex);
+          }
+        }
       }
       await readTranscript(context);
-      teardownStoppedTurnIfIdle(context);
+      const completionStepIndex = context.latestBackgroundCompletionStepIndex;
+      const stopFollowsLatestCompletion =
+        latestStopStepIndex !== undefined
+          ? latestStopStepIndex > (completionStepIndex ?? -1)
+          : sawStopWithoutStepIndex && completionStepIndex === undefined;
+      if (stopFollowsLatestCompletion) teardownStoppedTurnIfIdle(context);
+    };
+
+    const pollHookFile = (context: AntigravitySessionContext): Promise<void> => {
+      if (context.hookPollPromise) return context.hookPollPromise;
+      const poll = pollHookFileOnce(context).finally(() => {
+        if (context.hookPollPromise === poll) delete context.hookPollPromise;
+      });
+      context.hookPollPromise = poll;
+      return poll;
     };
 
     const startSession: AntigravityAdapterShape["startSession"] = (input) =>
@@ -1939,15 +1972,14 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           pendingTools: [],
           nextToolSequence: 0,
           pendingBackgroundTasks: new Map(),
+          pendingAnonymousBackgroundTasks: 0,
           pendingBackgroundTaskCompletions: [],
-          nextBackgroundTaskId: 1,
           foreignConversations: new Map(),
           surfacedToolCallCounts: new Map(),
           hookToolCallCounts: new Map(),
           sawAssistant: false,
           interrupted: false,
           stopped: false,
-          stopAwaitingBackgroundTasks: false,
           turnTerminalEmitted: false,
         };
         sessions.set(input.threadId, context);
@@ -2064,14 +2096,15 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         context.processedSteps.clear();
         yield* Effect.promise(() => markExistingTranscriptStepsProcessed(context));
         context.pendingTools = [];
+        context.pendingAnonymousBackgroundTasks = 0;
         context.pendingBackgroundTaskCompletions.length = 0;
+        delete context.latestBackgroundCompletionStepIndex;
         context.nextToolSequence = 0;
         context.foreignConversations.clear();
         context.surfacedToolCallCounts.clear();
         context.hookToolCallCounts.clear();
         context.sawAssistant = false;
         context.interrupted = false;
-        context.stopAwaitingBackgroundTasks = false;
         context.turnTerminalEmitted = false;
         context.turns.push({ id: turnId, items: [] });
         context.session = {

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -893,6 +893,7 @@ type AntigravityChildProcess = ChildProcess & {
 
 export interface AntigravityAdapterDependencies {
   readonly ensurePlugin?: typeof ensureCapturePlugin;
+  readonly readCompleteLines?: typeof readCompleteAntigravityLines;
   readonly teardownProcessTree?: typeof teardownChildProcessTree;
   readonly spawnProcess?: (
     command: string,
@@ -904,6 +905,7 @@ export interface AntigravityAdapterDependencies {
 const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {}) =>
   Effect.gen(function* () {
     const serverConfig = yield* ServerConfig;
+    const readCompleteLines = dependencies.readCompleteLines ?? readCompleteAntigravityLines;
     const teardownProcessTree = dependencies.teardownProcessTree ?? teardownChildProcessTree;
     const agentGatewayCredentials = Option.getOrUndefined(
       yield* Effect.serviceOption(AgentGatewayCredentials),
@@ -1459,10 +1461,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       if (isInitialRead) context.processedTranscriptBytes = 0;
       let batch: Awaited<ReturnType<typeof readCompleteAntigravityLines>>;
       try {
-        batch = await readCompleteAntigravityLines(
-          context.transcriptPath,
-          context.processedTranscriptBytes,
-        );
+        batch = await readCompleteLines(context.transcriptPath, context.processedTranscriptBytes);
       } catch {
         return;
       }
@@ -1495,7 +1494,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
     const markExistingTranscriptStepsProcessed = async (context: AntigravitySessionContext) => {
       if (!context.transcriptPath) return;
       try {
-        const batch = await readCompleteAntigravityLines(context.transcriptPath, 0);
+        const batch = await readCompleteLines(context.transcriptPath, 0);
         context.processedTranscriptBytes = batch.nextOffset;
         context.processedTranscriptPath = context.transcriptPath;
       } catch {
@@ -1671,11 +1670,12 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
     const pollHookFileOnce = async (context: AntigravitySessionContext) => {
       if (context.stopped) return;
       if (!context.eventFile) return;
+      const completionStepIndexBeforePoll = context.latestBackgroundCompletionStepIndex;
       let latestStopStepIndex: number | undefined;
       let sawStopWithoutStepIndex = false;
       let batch: Awaited<ReturnType<typeof readCompleteAntigravityLines>>;
       try {
-        batch = await readCompleteAntigravityLines(context.eventFile, context.processedHookBytes);
+        batch = await readCompleteLines(context.eventFile, context.processedHookBytes);
       } catch {
         return;
       }
@@ -1884,10 +1884,13 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       }
       await readTranscript(context);
       const completionStepIndex = context.latestBackgroundCompletionStepIndex;
+      const indexedStopFollowsLatestCompletion =
+        latestStopStepIndex !== undefined && latestStopStepIndex > (completionStepIndex ?? -1);
+      const unindexedStopFollowsLatestCompletion =
+        sawStopWithoutStepIndex &&
+        (completionStepIndex === undefined || completionStepIndexBeforePoll !== undefined);
       const stopFollowsLatestCompletion =
-        latestStopStepIndex !== undefined
-          ? latestStopStepIndex > (completionStepIndex ?? -1)
-          : sawStopWithoutStepIndex && completionStepIndex === undefined;
+        indexedStopFollowsLatestCompletion || unindexedStopFollowsLatestCompletion;
       if (stopFollowsLatestCompletion) teardownStoppedTurnIfIdle(context);
     };
 
@@ -2211,6 +2214,14 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
             // can begin, so an unconsumed bootstrap from this turn cannot cross
             // into the next turn's authority.
             releaseTurnGatewayLease(context, gatewaySessionLease);
+            const pollInFlightAtClose = context.hookPollPromise;
+            if (pollInFlightAtClose) {
+              await pollInFlightAtClose.catch(() => undefined);
+              if (!ownsTurn()) {
+                await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
+                return;
+              }
+            }
             await pollHookFile(context).catch(() => undefined);
             if (!ownsTurn()) {
               await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -101,6 +101,7 @@ type StoredTurn = {
 
 export type AntigravityTrackedBackgroundTask = {
   readonly taskId: string;
+  readonly providerTaskId?: string;
   readonly taskType: string;
   readonly description?: string;
   readonly startedAt: string;
@@ -141,6 +142,7 @@ type AntigravitySessionContext = ToolSurfaceCounters & {
   pendingTools: PendingTool[];
   nextToolSequence: number;
   pendingBackgroundTasks: Map<string, AntigravityTrackedBackgroundTask>;
+  pendingBackgroundTaskCompletions: AntigravitySystemMessageInfo[];
   nextBackgroundTaskId: number;
   /**
    * Conversations owned by spawned subagents, keyed by conversation id.
@@ -753,8 +755,11 @@ export function parseAntigravitySystemMessage(
 
   const exitCodeMatch = trimmed.match(/exited with code (\d+)/iu);
   const exitCode = exitCodeMatch ? parseInt(exitCodeMatch[1] ?? "0", 10) : undefined;
+  const failureText = trimmed
+    .replace(/\b(?:0|no)\s+failed\b/giu, "")
+    .replace(/\b(?:no|without)\s+errors?\b/giu, "");
   const isFailure =
-    exitCode !== undefined ? exitCode !== 0 : /\bfailed\b|\berror\b/iu.test(trimmed);
+    exitCode !== undefined ? exitCode !== 0 : /\bfailed\b|\berror\b/iu.test(failureText);
 
   return {
     isSystemMessage: true,
@@ -771,6 +776,11 @@ export function detectAntigravityBackgroundTaskStart(
   args?: Record<string, unknown>,
   postPayload?: Record<string, unknown>,
 ): { taskId?: string; description?: string; isBackground: boolean } | null {
+  const failed =
+    postPayload?.failed === true ||
+    (typeof postPayload?.error === "string" && postPayload.error.trim().length > 0);
+  if (failed) return null;
+
   if (name === "run_command") {
     const rawOutput =
       typeof postPayload?.toolOutput === "string"
@@ -790,7 +800,7 @@ export function detectAntigravityBackgroundTaskStart(
     if (rawOutput) {
       const match =
         rawOutput.match(/Task id ["']?([\w.-]+)["']?/iu) ?? rawOutput.match(/\b(task-[\w.-]+)\b/iu);
-      if (match || /background task|sent to the background/iu.test(rawOutput)) {
+      if (/background task|sent to the background|running in the background/iu.test(rawOutput)) {
         const taskId = match?.[1] ?? match?.[0];
         return {
           ...(taskId ? { taskId } : {}),
@@ -1090,6 +1100,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         } satisfies ProviderRuntimeEvent);
       }
       context.pendingBackgroundTasks.clear();
+      context.pendingBackgroundTaskCompletions.length = 0;
     };
 
     const killPendingBackgroundTasks = (
@@ -1108,6 +1119,83 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         } satisfies ProviderRuntimeEvent);
       }
       context.pendingBackgroundTasks.clear();
+      context.pendingBackgroundTaskCompletions.length = 0;
+    };
+
+    const backgroundCompletionCandidate = (
+      message: AntigravitySystemMessageInfo,
+    ): string | undefined => message.taskId ?? message.sender;
+
+    const matchTrackedBackgroundTaskId = (
+      context: AntigravitySessionContext,
+      candidateId: string | undefined,
+    ): string | undefined => {
+      const direct = matchAntigravityTrackedTaskId(
+        candidateId,
+        context.pendingBackgroundTasks.keys(),
+      );
+      if (direct || !candidateId || context.pendingBackgroundTasks.size !== 1) return direct;
+      const only = context.pendingBackgroundTasks.values().next().value;
+      return only?.providerTaskId === undefined ? only?.taskId : undefined;
+    };
+
+    const settleTrackedBackgroundTask = (
+      context: AntigravitySessionContext,
+      taskId: string,
+      systemMessage: AntigravitySystemMessageInfo,
+    ): boolean => {
+      const tracked = context.pendingBackgroundTasks.get(taskId);
+      if (!tracked) return false;
+      context.pendingBackgroundTasks.delete(taskId);
+      offer({
+        ...base(context),
+        type: "task.completed",
+        payload: {
+          taskId: RuntimeTaskId.makeUnsafe(taskId),
+          status: systemMessage.isFailure ? "failed" : "completed",
+        },
+        raw: raw("background-task-completed", {
+          taskId,
+          systemMessage,
+          tracked,
+        }),
+      } satisfies ProviderRuntimeEvent);
+      return true;
+    };
+
+    const registerBackgroundTask = (
+      context: AntigravitySessionContext,
+      start: { readonly taskId?: string; readonly description?: string },
+      taskType: string,
+      source: { readonly name: string; readonly args?: Record<string, unknown> },
+    ): void => {
+      const taskId = start.taskId ?? `task-${context.nextBackgroundTaskId++}`;
+      if (context.pendingBackgroundTasks.has(taskId)) return;
+      context.pendingBackgroundTasks.set(taskId, {
+        taskId,
+        ...(start.taskId ? { providerTaskId: start.taskId } : {}),
+        taskType,
+        ...(start.description ? { description: start.description } : {}),
+        startedAt: new Date().toISOString(),
+      });
+      offer({
+        ...base(context),
+        type: "task.started",
+        payload: {
+          taskId: RuntimeTaskId.makeUnsafe(taskId),
+          taskType,
+          ...(start.description ? { description: start.description } : {}),
+        },
+        raw: raw("background-task-started", { taskId, ...source }),
+      } satisfies ProviderRuntimeEvent);
+
+      const completionIndex = context.pendingBackgroundTaskCompletions.findIndex(
+        (message) =>
+          matchTrackedBackgroundTaskId(context, backgroundCompletionCandidate(message)) === taskId,
+      );
+      if (completionIndex < 0) return;
+      const [completion] = context.pendingBackgroundTaskCompletions.splice(completionIndex, 1);
+      if (completion) settleTrackedBackgroundTask(context, taskId, completion);
     };
 
     /**
@@ -1292,26 +1380,15 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         typeof step.content === "string" ? step.content : undefined,
       );
       if (systemMessage?.isSystemMessage) {
-        const matchedTaskId = matchAntigravityTrackedTaskId(
-          systemMessage.taskId ?? systemMessage.sender,
-          context.pendingBackgroundTasks.keys(),
-        );
+        const candidateId = backgroundCompletionCandidate(systemMessage);
+        const matchedTaskId = matchTrackedBackgroundTaskId(context, candidateId);
         if (matchedTaskId) {
-          const tracked = context.pendingBackgroundTasks.get(matchedTaskId);
-          context.pendingBackgroundTasks.delete(matchedTaskId);
-          offer({
-            ...base(context),
-            type: "task.completed",
-            payload: {
-              taskId: RuntimeTaskId.makeUnsafe(matchedTaskId),
-              status: systemMessage.isFailure ? "failed" : "completed",
-            },
-            raw: raw("background-task-completed", {
-              taskId: matchedTaskId,
-              systemMessage,
-              tracked,
-            }),
-          } satisfies ProviderRuntimeEvent);
+          settleTrackedBackgroundTask(context, matchedTaskId, systemMessage);
+        } else if (candidateId) {
+          context.pendingBackgroundTaskCompletions.push(systemMessage);
+          if (context.pendingBackgroundTaskCompletions.length > 32) {
+            context.pendingBackgroundTaskCompletions.shift();
+          }
         }
         return;
       }
@@ -1673,21 +1750,30 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
               raw: raw("tool-lifecycle", { eventName, stepIdx: stepIndex, name, args: toolArgs }),
             } satisfies ProviderRuntimeEvent);
           }
-        } else if (eventName === "post-tool" && stepIndex !== undefined) {
+        } else if (eventName === "post-tool") {
           const toolCall =
             payload.toolCall && typeof payload.toolCall === "object"
               ? (payload.toolCall as Record<string, unknown>)
               : undefined;
           const name = typeof toolCall?.name === "string" ? trim(toolCall.name) : undefined;
-          const pendingIndex = context.pendingTools.findIndex(
-            (pending) => pending.stepIndex === stepIndex && (!name || pending.name === name),
-          );
+          const hookArgs =
+            toolCall?.args && typeof toolCall.args === "object"
+              ? (toolCall.args as Record<string, unknown>)
+              : undefined;
+          const pendingIndex =
+            stepIndex === undefined
+              ? -1
+              : context.pendingTools.findIndex(
+                  (pending) => pending.stepIndex === stepIndex && (!name || pending.name === name),
+                );
           const pending =
             pendingIndex >= 0 ? context.pendingTools.splice(pendingIndex, 1)[0] : undefined;
+          const toolName = pending?.name ?? name;
+          const toolArgs = pending?.args ?? hookArgs;
+          const failed =
+            payload.failed === true ||
+            (typeof payload.error === "string" && payload.error.trim().length > 0);
           if (pending) {
-            const failed =
-              payload.failed === true ||
-              (typeof payload.error === "string" && payload.error.trim().length > 0);
             offer({
               ...base(context, { itemId: pending.itemId }),
               type: "item.completed",
@@ -1710,56 +1796,37 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
                 failed,
               }),
             } satisfies ProviderRuntimeEvent);
+          }
 
-            const bgStart = detectAntigravityBackgroundTaskStart(
-              pending.name,
-              pending.args,
-              payload,
-            );
+          if (!failed && toolName) {
+            const bgStart = detectAntigravityBackgroundTaskStart(toolName, toolArgs, payload);
             if (bgStart?.isBackground) {
-              const taskId = bgStart.taskId ?? `task-${context.nextBackgroundTaskId++}`;
-              context.pendingBackgroundTasks.set(taskId, {
-                taskId,
-                taskType: pending.itemType,
-                ...(bgStart.description ? { description: bgStart.description } : {}),
-                startedAt: new Date().toISOString(),
+              registerBackgroundTask(context, bgStart, toolItemType(toolName), {
+                name: toolName,
+                ...(toolArgs ? { args: toolArgs } : {}),
               });
-              offer({
-                ...base(context),
-                type: "task.started",
-                payload: {
-                  taskId: RuntimeTaskId.makeUnsafe(taskId),
-                  taskType: pending.itemType,
-                  ...(bgStart.description ? { description: bgStart.description } : {}),
-                },
-                raw: raw("background-task-started", {
-                  taskId,
-                  name: pending.name,
-                  args: pending.args,
-                }),
-              } satisfies ProviderRuntimeEvent);
-            } else if (pending.name === "manage_task") {
-              const action =
-                typeof pending.args?.Action === "string" ? pending.args.Action : undefined;
+            } else if (toolName === "manage_task") {
+              const action = typeof toolArgs?.Action === "string" ? toolArgs.Action : undefined;
               const targetTaskId =
-                typeof pending.args?.TaskId === "string" ? pending.args.TaskId : undefined;
-              if (action === "kill" && targetTaskId) {
-                const matchedId = matchAntigravityTrackedTaskId(
-                  targetTaskId,
-                  context.pendingBackgroundTasks.keys(),
-                );
-                if (matchedId) {
-                  context.pendingBackgroundTasks.delete(matchedId);
-                  offer({
-                    ...base(context),
-                    type: "task.updated",
-                    payload: {
-                      taskId: RuntimeTaskId.makeUnsafe(matchedId),
-                      status: "killed",
-                    },
-                    raw: raw("background-task-killed", { taskId: matchedId }),
-                  } satisfies ProviderRuntimeEvent);
-                }
+                typeof toolArgs?.TaskId === "string" ? toolArgs.TaskId : undefined;
+              const matchedId =
+                action === "kill" && targetTaskId
+                  ? matchAntigravityTrackedTaskId(
+                      targetTaskId,
+                      context.pendingBackgroundTasks.keys(),
+                    )
+                  : undefined;
+              if (matchedId) {
+                context.pendingBackgroundTasks.delete(matchedId);
+                offer({
+                  ...base(context),
+                  type: "task.updated",
+                  payload: {
+                    taskId: RuntimeTaskId.makeUnsafe(matchedId),
+                    status: "killed",
+                  },
+                  raw: raw("background-task-killed", { taskId: matchedId }),
+                } satisfies ProviderRuntimeEvent);
               }
             }
           }
@@ -1867,6 +1934,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           pendingTools: [],
           nextToolSequence: 0,
           pendingBackgroundTasks: new Map(),
+          pendingBackgroundTaskCompletions: [],
           nextBackgroundTaskId: 1,
           foreignConversations: new Map(),
           surfacedToolCallCounts: new Map(),
@@ -1990,6 +2058,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         context.processedSteps.clear();
         yield* Effect.promise(() => markExistingTranscriptStepsProcessed(context));
         context.pendingTools = [];
+        context.pendingBackgroundTaskCompletions.length = 0;
         context.nextToolSequence = 0;
         context.foreignConversations.clear();
         context.surfacedToolCallCounts.clear();

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -144,6 +144,7 @@ type AntigravitySessionContext = ToolSurfaceCounters & {
   pendingBackgroundTasks: Map<string, AntigravityTrackedBackgroundTask>;
   pendingAnonymousBackgroundTasks: number;
   pendingBackgroundTaskCompletions: AntigravitySystemMessageInfo[];
+  backgroundCompletionSequence: number;
   latestBackgroundCompletionStepIndex?: number;
   /**
    * Conversations owned by spawned subagents, keyed by conversation id.
@@ -1161,12 +1162,9 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       taskType: string,
       source: { readonly name: string; readonly args?: Record<string, unknown> },
     ): void => {
+      if (context.stopped) return;
       if (!start.taskId) {
-        if (context.pendingBackgroundTaskCompletions.length > 0) {
-          context.pendingBackgroundTaskCompletions.shift();
-        } else {
-          context.pendingAnonymousBackgroundTasks += 1;
-        }
+        context.pendingAnonymousBackgroundTasks += 1;
         return;
       }
       const taskId = start.taskId;
@@ -1390,6 +1388,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
     };
 
     const processTranscriptStep = (context: AntigravitySessionContext, step: TranscriptStep) => {
+      if (context.stopped) return;
       const stepIndex = step.step_index;
       if (typeof stepIndex === "number") {
         if (context.processedSteps.has(stepIndex)) return;
@@ -1402,11 +1401,16 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       );
       if (systemMessage?.isSystemMessage) {
         const candidateId = backgroundCompletionCandidate(systemMessage);
-        if (candidateId && typeof stepIndex === "number") {
-          context.latestBackgroundCompletionStepIndex = Math.max(
-            context.latestBackgroundCompletionStepIndex ?? -1,
-            stepIndex,
-          );
+        if (candidateId) {
+          context.backgroundCompletionSequence += 1;
+          if (typeof stepIndex === "number") {
+            context.latestBackgroundCompletionStepIndex = Math.max(
+              context.latestBackgroundCompletionStepIndex ?? -1,
+              stepIndex,
+            );
+          } else {
+            delete context.latestBackgroundCompletionStepIndex;
+          }
         }
         const matchedTaskId = matchAntigravityTrackedTaskId(
           candidateId,
@@ -1465,6 +1469,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       } catch {
         return;
       }
+      if (context.stopped) return;
       context.processedTranscriptBytes = batch.nextOffset;
       context.processedTranscriptPath = context.transcriptPath;
       const steps = batch.lines.flatMap((line) => {
@@ -1670,7 +1675,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
     const pollHookFileOnce = async (context: AntigravitySessionContext) => {
       if (context.stopped) return;
       if (!context.eventFile) return;
-      const completionStepIndexBeforePoll = context.latestBackgroundCompletionStepIndex;
+      const completionSequenceBeforePoll = context.backgroundCompletionSequence;
       let latestStopStepIndex: number | undefined;
       let sawStopWithoutStepIndex = false;
       let batch: Awaited<ReturnType<typeof readCompleteAntigravityLines>>;
@@ -1679,8 +1684,10 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       } catch {
         return;
       }
+      if (context.stopped) return;
       context.processedHookBytes = batch.nextOffset;
       for (const line of batch.lines) {
+        if (context.stopped) return;
         const tab = line.indexOf("\t");
         if (tab < 0) continue;
         const eventName = line.slice(0, tab);
@@ -1883,12 +1890,17 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         }
       }
       await readTranscript(context);
+      if (context.stopped) return;
       const completionStepIndex = context.latestBackgroundCompletionStepIndex;
+      const completionObservedDuringPoll =
+        context.backgroundCompletionSequence > completionSequenceBeforePoll;
       const indexedStopFollowsLatestCompletion =
-        latestStopStepIndex !== undefined && latestStopStepIndex > (completionStepIndex ?? -1);
+        latestStopStepIndex !== undefined &&
+        (completionStepIndex !== undefined
+          ? latestStopStepIndex > completionStepIndex
+          : !completionObservedDuringPoll);
       const unindexedStopFollowsLatestCompletion =
-        sawStopWithoutStepIndex &&
-        (completionStepIndex === undefined || completionStepIndexBeforePoll !== undefined);
+        sawStopWithoutStepIndex && !completionObservedDuringPoll;
       const stopFollowsLatestCompletion =
         indexedStopFollowsLatestCompletion || unindexedStopFollowsLatestCompletion;
       if (stopFollowsLatestCompletion) teardownStoppedTurnIfIdle(context);
@@ -1977,6 +1989,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           pendingBackgroundTasks: new Map(),
           pendingAnonymousBackgroundTasks: 0,
           pendingBackgroundTaskCompletions: [],
+          backgroundCompletionSequence: 0,
           foreignConversations: new Map(),
           surfacedToolCallCounts: new Map(),
           hookToolCallCounts: new Map(),
@@ -2101,6 +2114,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         context.pendingTools = [];
         context.pendingAnonymousBackgroundTasks = 0;
         context.pendingBackgroundTaskCompletions.length = 0;
+        context.backgroundCompletionSequence = 0;
         delete context.latestBackgroundCompletionStepIndex;
         context.nextToolSequence = 0;
         context.foreignConversations.clear();


### PR DESCRIPTION
Fixes #752

## What Changed

- `apps/server/src/provider/Layers/AntigravityAdapter.ts`
  - Stop-hook teardown (#465) is now skipped while background tasks are
    pending, so the agy print process stays alive until it exits normally
    after streaming the wakeup response.
  - Track background task lifecycle for the UI:
    - `task.started` from `run_command`/`schedule` tool output or args
      (`WaitMsBeforeAsync`, "sent to the background").
    - `task.completed` from `<SYSTEM_MESSAGE>` transcript steps, with
      status `completed`/`failed` derived from the exit code.
    - `task.updated: killed` when the task is killed via `manage_task`,
      an interrupt, or session stop.
  - Relaxed helper timeouts (model discovery 15s → 30s, plugin install
    30s → 45s) that were tripping on slow machines.
- `apps/server/src/provider/Layers/AntigravityAdapter.test.ts`
  - Unit tests for the new task parsing/matching helpers and the updated
    plugin-install timeout.

## Why

When an Antigravity agent backgrounds a `run_command`/`schedule` task and
ends its turn to wait for it, the CLI print process stays alive by design:
it waits for the background task and then streams the follow-up response
itself. Synara's stop-hook teardown killed that process as soon as the
agent yielded. agy catches the SIGTERM and exits 1 with `Error: timeout
waiting for response`, so every background-task turn failed at ~11s
instead of completing with the task result.

Reproduced the failure directly: running the same scenario with plain agy
works (stays alive ~30s, wakes the agent, exits 0), and sending SIGTERM
mid-wait prints exactly `Error: timeout waiting for response` and exits 1.

## UI Changes

None. (Delete this section when submitting.)

## Verification

- `bun run test` on `AntigravityAdapter.test.ts`: 33/33 pass.
- `bun fmt`, `bun lint` (0 errors), `bun typecheck` (7/7) all clean.
- End-to-end through the real adapter with the actual agy CLI: turn stays
  `running` during a 20s background task, the completion `SYSTEM_MESSAGE`
  arrives, the agent wakes up, reads the result file, and the turn
  completes with the expected output.
- Note: the full workspace suite has 2 failures in unrelated tests
  (`ThreadDiagnosticsQuery`, `GitCore`) that also fail on the base branch
  on this machine (environment-specific).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A)
- [x] I included a video for animation/interaction changes (N/A)
