### PR TITLE
Send Grok reasoning effort on ACP session setup

### DIFF
--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { resolveAcpPermissionPolicy } from "./AcpAdapterSupport.ts";
 import {
   applyGrokAcpModelSelection,
+  buildGrokAcpSessionMeta,
   buildGrokAcpSpawnInput,
   isGrokSessionStoragePathNotFoundError,
   resolveGrokAcpAuthMethodId,
@@ -104,6 +105,31 @@ describe("buildGrokAcpSpawnInput", () => {
       "--always-approve",
       "stdio",
     ]);
+  });
+});
+
+describe("buildGrokAcpSessionMeta", () => {
+  it("omits _meta when there are no hooks and no effort", () => {
+    expect(buildGrokAcpSessionMeta({})).toBeUndefined();
+    expect(buildGrokAcpSessionMeta({ reasoningEffort: "   " })).toBeUndefined();
+  });
+
+  it("preserves Synara hook metadata and adds extra-high effort for ACP session setup", () => {
+    expect(
+      buildGrokAcpSessionMeta({
+        base: {
+          "x.ai/hooks": {
+            PreToolUse: [{ matcher: "*", hookCallbackIds: ["synara-plan-guard"] }],
+          },
+        },
+        reasoningEffort: "xhigh",
+      }),
+    ).toEqual({
+      "x.ai/hooks": {
+        PreToolUse: [{ matcher: "*", hookCallbackIds: ["synara-plan-guard"] }],
+      },
+      reasoningEffort: "xhigh",
+    });
   });
 });
 

--- a/apps/server/src/provider/acp/GrokAcpSupport.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.ts
@@ -129,6 +129,24 @@ export function buildGrokAcpSpawnInput(
   };
 }
 
+/**
+ * Grok 1.0+ reads reasoning effort from session/new, session/load, and
+ * session/resume `_meta.reasoningEffort`. `session/load` ignores the
+ * `--reasoning-effort` process flag, so ACP clients must send the value here
+ * or a resumed thread keeps its previous effort.
+ */
+export function buildGrokAcpSessionMeta(input: {
+  readonly base?: Record<string, unknown>;
+  readonly reasoningEffort?: string | null | undefined;
+}): Record<string, unknown> | undefined {
+  const reasoningEffort = input.reasoningEffort?.trim();
+  const meta = {
+    ...(input.base ?? {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+  };
+  return Object.keys(meta).length > 0 ? meta : undefined;
+}
+
 function availableAuthMethodIds(initializeResult: Acp.InitializeResponse): ReadonlySet<string> {
   return new Set(
     (initializeResult.authMethods ?? [])
@@ -194,10 +212,15 @@ export const makeGrokAcpRuntime = (
   input: GrokAcpRuntimeInput,
 ): Effect.Effect<AcpSessionRuntimeShape, AcpErrors.AcpError, Scope.Scope> =>
   Effect.gen(function* () {
+    const sessionMeta = buildGrokAcpSessionMeta({
+      ...(input.sessionMeta ? { base: input.sessionMeta } : {}),
+      reasoningEffort: input.grokSettings?.reasoningEffort,
+    });
     const acpContext = yield* Layer.build(
       AcpSessionRuntime.layer({
         ...input,
         spawn: buildGrokAcpSpawnInput(input.grokSettings, input.cwd, input.runtimeMode),
+        ...(sessionMeta ? { sessionMeta } : {}),
         resolveAuthMethodId: resolveGrokAcpAuthMethodId,
         authenticateMeta: { headless: true },
         freshSessionRetry: {
@@ -223,8 +246,8 @@ export function applyGrokAcpModelSelection<E>(input: {
   readonly mapError: (context: GrokAcpModelSelectionErrorContext) => E;
 }): Effect.Effect<void, E> {
   void input;
-  // Grok ACP 0.1.210 advertises models in initialize/session responses but does
-  // not implement `session/set_config_option`. Model and effort are therefore
-  // process-start settings supplied by `buildGrokAcpSpawnInput`.
+  // Grok ACP still does not implement `session/set_config_option`. Model and
+  // effort are process-start settings: CLI `-m` / `--reasoning-effort` plus
+  // `session/*` `_meta.reasoningEffort` from `buildGrokAcpSessionMeta`.
   return Effect.void;
 }


### PR DESCRIPTION
## What Changed

Grok session setup now sends `_meta.reasoningEffort` on `session/new`, `session/load`, and `session/resume`, next to the existing hook metadata. `--reasoning-effort` is still passed on process start.

## Why

Grok 1.0+ applies effort from ACP session `_meta.reasoningEffort`. `session/load` ignores the CLI flag, so Extra High and other non-default efforts did not stick when Synara restarted a Grok thread by loading the previous ACP session.

Probed against `grok` 1.0.5: load with `--reasoning-effort xhigh` kept the old effort. Load with `_meta.reasoningEffort: "xhigh"` applied Extra High.

This is not a picker change. Grok 4.6 already lists Extra High. The bug was that the selected effort did not survive ACP load.

## Verification

- [x] `bun run --cwd apps/server test src/provider/acp/GrokAcpSupport.test.ts src/provider/Layers/GrokAdapter.test.ts` (46 passed)
- [x] `bun typecheck`
- [x] `bun lint` (0 errors)
- [x] `bun fmt`
- [x] `bun run test` (full workspace). `@synara/cli` had 1 pre-existing failure in `ThreadDiagnosticsQuery.test.ts`, unrelated to this change. Other packages passed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why


<img width="818" height="260" alt="image" src="https://github.com/user-attachments/assets/2fad36b6-9cbe-42a8-a24b-c3c0c194770b" />


<img width="371" height="272" alt="image" src="https://github.com/user-attachments/assets/0f3c1ec7-f3d6-499d-b82a-bbf98961f304" />
