### PR TITLE
Show Grok usage limits on the Settings usage cards

### DIFF
--- a/apps/server/src/providerUsage/parsers.test.ts
+++ b/apps/server/src/providerUsage/parsers.test.ts
@@ -1,9 +1,11 @@
 import type { ServerProviderUsageSnapshot } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
+import { formatUsd } from "./parse.ts";
 import { parseClaudeUsage } from "./providers/claude.ts";
 import { parseCodexUsage } from "./providers/codex.ts";
 import { parseCursorUsage } from "./providers/cursor.ts";
+import { parseGrokUsage } from "./providers/grok.ts";
 
 const NOW_MS = 1_738_000_000_000;
 
@@ -99,5 +101,104 @@ describe("parseCursorUsage", () => {
     expect(usageLine(snapshot, "On-demand")?.value).toContain("60.00");
     // remaining = (5000 - 1200) / 100 = $38.00 of $50.00
     expect(usageLine(snapshot, "Credits")?.value).toContain("38.00");
+  });
+});
+
+const GROK_WEEKLY_START = "2026-08-17T23:14:37.093714+00:00";
+const GROK_WEEKLY_END = "2026-08-24T23:14:37.093714+00:00";
+const GROK_WEEKLY_RESETS_AT = new Date(GROK_WEEKLY_END).toISOString();
+
+function grokWeeklyBilling(config: Record<string, unknown> = {}) {
+  return {
+    config: {
+      currentPeriod: {
+        type: "USAGE_PERIOD_TYPE_WEEKLY",
+        start: GROK_WEEKLY_START,
+        end: GROK_WEEKLY_END,
+      },
+      creditUsagePercent: 44,
+      onDemandCap: { val: 0 },
+      onDemandUsed: { val: 0 },
+      prepaidBalance: { val: 0 },
+      isUnifiedBillingUser: true,
+      billingPeriodEnd: GROK_WEEKLY_END,
+      ...config,
+    },
+  };
+}
+
+describe("parseGrokUsage", () => {
+  it("maps a weekly Heavy snapshot without zero-value extra lines", () => {
+    const snapshot = parseGrokUsage({
+      billing: grokWeeklyBilling(),
+      planName: "SuperGrok Heavy",
+      nowMs: NOW_MS,
+    });
+
+    expect(snapshot.provider).toBe("grok");
+    expect(snapshot.status).toBe("ok");
+    expect(snapshot.planName).toBe("SuperGrok Heavy");
+    expect(limit(snapshot, "Weekly")?.usedPercent).toBe(44);
+    expect(limit(snapshot, "Weekly")?.windowDurationMins).toBe(10_080);
+    expect(limit(snapshot, "Weekly")?.resetsAt).toBe(GROK_WEEKLY_RESETS_AT);
+    expect(usageLine(snapshot, "Credits")).toBeUndefined();
+    expect(usageLine(snapshot, "On-demand")).toBeUndefined();
+  });
+
+  it("formats extra credits and on-demand amounts from cents", () => {
+    const snapshot = parseGrokUsage({
+      billing: grokWeeklyBilling({
+        prepaidBalance: { val: 1_250 },
+        onDemandCap: { val: 5_000 },
+        onDemandUsed: { val: 300 },
+      }),
+      planName: "SuperGrok Heavy",
+      nowMs: NOW_MS,
+    });
+
+    const credits = usageLine(snapshot, "Credits");
+    const onDemand = usageLine(snapshot, "On-demand");
+    expect(credits?.value).toContain(formatUsd(12.5));
+    expect(onDemand?.value).toContain(formatUsd(3));
+    expect(onDemand?.value).toContain(formatUsd(50));
+  });
+
+  it("treats a weekly period without creditUsagePercent as 0% used", () => {
+    const config = { ...grokWeeklyBilling().config };
+    delete (config as { creditUsagePercent?: number }).creditUsagePercent;
+    const snapshot = parseGrokUsage({
+      billing: { config },
+      nowMs: NOW_MS,
+    });
+
+    expect(snapshot.status).toBe("ok");
+    expect(limit(snapshot, "Weekly")?.usedPercent).toBe(0);
+    expect(limit(snapshot, "Weekly")?.resetsAt).toBe(GROK_WEEKLY_RESETS_AT);
+  });
+
+  it("keeps a display-ready planName", () => {
+    const snapshot = parseGrokUsage({
+      billing: grokWeeklyBilling(),
+      planName: "SuperGrok Heavy",
+      nowMs: NOW_MS,
+    });
+    expect(snapshot.planName).toBe("SuperGrok Heavy");
+  });
+
+  it("maps compact plan aliases to SuperGrok Heavy", () => {
+    expect(
+      parseGrokUsage({
+        billing: grokWeeklyBilling(),
+        planName: "heavy",
+        nowMs: NOW_MS,
+      }).planName,
+    ).toBe("SuperGrok Heavy");
+    expect(
+      parseGrokUsage({
+        billing: grokWeeklyBilling(),
+        planName: "supergrokheavy",
+        nowMs: NOW_MS,
+      }).planName,
+    ).toBe("SuperGrok Heavy");
   });
 });

--- a/apps/server/src/providerUsage/providers/grok.test.ts
+++ b/apps/server/src/providerUsage/providers/grok.test.ts
@@ -1,0 +1,280 @@
+// FILE: providerUsage/providers/grok.test.ts
+// Purpose: Covers Grok CLI auth-file resolution (GROK_HOME vs ~/.grok), team/API-key
+// unsupported paths, and CLI-proxy billing/settings fetches. No real network.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import nodePath from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { outboundHttp } from "@synara/shared/outboundHttp";
+import { grokUsageFetcher } from "./grok";
+
+const NOW_MS = 1_780_000_000_000;
+const WEEKLY_END = "2026-08-24T23:14:37.093714+00:00";
+const AUTH_TOKEN = "test-access-token";
+
+const WEEKLY_BILLING = {
+  config: {
+    currentPeriod: {
+      type: "USAGE_PERIOD_TYPE_WEEKLY",
+      start: "2026-08-17T23:14:37.093714+00:00",
+      end: WEEKLY_END,
+    },
+    creditUsagePercent: 44,
+    onDemandCap: { val: 0 },
+    onDemandUsed: { val: 0 },
+    prepaidBalance: { val: 0 },
+    isUnifiedBillingUser: true,
+    billingPeriodEnd: WEEKLY_END,
+  },
+};
+
+const SETTINGS_BODY = {
+  subscription_tier_display: "SuperGrok Heavy",
+  subscriptionTierDisplay: "SuperGrok Heavy",
+};
+
+const tempDirs: string[] = [];
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function stubOutboundFetch(
+  fetchMock: (url: string | URL | Request, init?: RequestInit) => Promise<Response>,
+): void {
+  vi.spyOn(outboundHttp, "request").mockImplementation(async (input) => {
+    const response = await fetchMock(input.url, {
+      ...(input.method === undefined ? {} : { method: input.method }),
+      headers: input.headers,
+      ...(input.body === undefined ? {} : { body: input.body }),
+    });
+    return {
+      status: response.status,
+      headers: response.headers,
+      body: new Uint8Array(await response.arrayBuffer()),
+      url: String(input.url),
+    };
+  });
+}
+
+function rejectNetwork(): void {
+  stubOutboundFetch(async () => {
+    throw new Error("grok usage tests must not perform real network I/O");
+  });
+}
+
+function writeGrokAuth(grokHome: string, entry: Record<string, unknown> = {}): void {
+  mkdirSync(grokHome, { recursive: true });
+  writeFileSync(
+    nodePath.join(grokHome, "auth.json"),
+    JSON.stringify({
+      "https://auth.x.ai::test-client": {
+        key: AUTH_TOKEN,
+        principal_type: "User",
+        expires_at: new Date(NOW_MS + 8 * 24 * 60 * 60 * 1000).toISOString(),
+        ...entry,
+      },
+    }),
+    "utf8",
+  );
+}
+
+function makeHomeDir(): string {
+  const homeDir = mkdtempSync(nodePath.join(os.tmpdir(), "synara-grok-usage-"));
+  tempDirs.push(homeDir);
+  return homeDir;
+}
+
+function makeHomeWithAuth(entry: Record<string, unknown> = {}): string {
+  const homeDir = makeHomeDir();
+  writeGrokAuth(nodePath.join(homeDir, ".grok"), entry);
+  return homeDir;
+}
+
+function makeCtx(homeDir: string, env: NodeJS.ProcessEnv = {}) {
+  return {
+    homeDir,
+    env,
+    platform: "linux" as const,
+    nowMs: NOW_MS,
+  };
+}
+
+function requestUrl(url: string | URL | Request): string {
+  return String(url);
+}
+
+function isBillingUrl(url: string): boolean {
+  return url.includes("/billing");
+}
+
+function isSettingsUrl(url: string): boolean {
+  return url.includes("/settings");
+}
+
+function authorization(init?: RequestInit): string | undefined {
+  const headers = init?.headers;
+  if (headers instanceof Headers) {
+    return headers.get("Authorization") ?? undefined;
+  }
+  if (Array.isArray(headers)) {
+    const match = headers.find((entry) => entry[0]?.toLowerCase() === "authorization");
+    return match?.[1];
+  }
+  if (headers && typeof headers === "object") {
+    return (headers as Record<string, string>).Authorization;
+  }
+  return undefined;
+}
+
+beforeEach(() => {
+  rejectNetwork();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("grokUsageFetcher", () => {
+  it("returns needs-auth when auth.json is missing", async () => {
+    const snapshot = await grokUsageFetcher.fetch(makeCtx(makeHomeDir()));
+    expect(snapshot.provider).toBe("grok");
+    expect(snapshot.status).toBe("needs-auth");
+    expect(outboundHttp.request).not.toHaveBeenCalled();
+  });
+
+  it("returns a weekly snapshot from billing and settings", async () => {
+    const homeDir = makeHomeWithAuth();
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      expect(authorization(init)).toBe(`Bearer ${AUTH_TOKEN}`);
+      const target = requestUrl(url);
+      if (isBillingUrl(target)) {
+        return jsonResponse(WEEKLY_BILLING);
+      }
+      if (isSettingsUrl(target)) {
+        return jsonResponse(SETTINGS_BODY);
+      }
+      throw new Error(`unexpected grok usage URL: ${target}`);
+    });
+    stubOutboundFetch(fetchMock);
+
+    const snapshot = await grokUsageFetcher.fetch(makeCtx(homeDir));
+
+    expect(snapshot.status).toBe("ok");
+    expect(snapshot.provider).toBe("grok");
+    expect(snapshot.planName).toBe("SuperGrok Heavy");
+    expect(snapshot.limits.find((entry) => entry.window === "Weekly")?.usedPercent).toBe(44);
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it("reads GROK_HOME instead of ~/.grok", async () => {
+    const homeDir = makeHomeWithAuth({ key: "home-dir-token" });
+    const grokHome = mkdtempSync(nodePath.join(os.tmpdir(), "synara-grok-home-"));
+    tempDirs.push(grokHome);
+    writeGrokAuth(grokHome, { key: "grok-home-token" });
+
+    const authorizations: string[] = [];
+    stubOutboundFetch(async (url, init) => {
+      const header = authorization(init);
+      if (header !== undefined) {
+        authorizations.push(header);
+      }
+      const target = requestUrl(url);
+      if (isBillingUrl(target)) {
+        return jsonResponse(WEEKLY_BILLING);
+      }
+      if (isSettingsUrl(target)) {
+        return jsonResponse(SETTINGS_BODY);
+      }
+      throw new Error(`unexpected grok usage URL: ${target}`);
+    });
+
+    const snapshot = await grokUsageFetcher.fetch(makeCtx(homeDir, { GROK_HOME: grokHome }));
+
+    expect(snapshot.status).toBe("ok");
+    expect(authorizations.length).toBeGreaterThan(0);
+    expect(authorizations.every((header) => header === "Bearer grok-home-token")).toBe(true);
+    expect(authorizations).not.toContain("Bearer home-dir-token");
+  });
+
+  it("returns unsupported for a Team principal", async () => {
+    const homeDir = makeHomeWithAuth({ principal_type: "Team" });
+    const snapshot = await grokUsageFetcher.fetch(makeCtx(homeDir));
+    expect(snapshot.provider).toBe("grok");
+    expect(snapshot.status).toBe("unsupported");
+    expect(outboundHttp.request).not.toHaveBeenCalled();
+  });
+
+  it("returns unsupported when only XAI_API_KEY is set", async () => {
+    const snapshot = await grokUsageFetcher.fetch(
+      makeCtx(makeHomeDir(), { XAI_API_KEY: "xai-test-key" }),
+    );
+    expect(snapshot.provider).toBe("grok");
+    expect(snapshot.status).toBe("unsupported");
+    expect(outboundHttp.request).not.toHaveBeenCalled();
+  });
+
+  it("returns needs-auth when billing rejects the token", async () => {
+    const homeDir = makeHomeWithAuth();
+    stubOutboundFetch(async (url) => {
+      const target = requestUrl(url);
+      if (isBillingUrl(target)) {
+        return jsonResponse({ error: "unauthorized" }, 401);
+      }
+      if (isSettingsUrl(target)) {
+        return jsonResponse(SETTINGS_BODY);
+      }
+      throw new Error(`unexpected grok usage URL: ${target}`);
+    });
+
+    const snapshot = await grokUsageFetcher.fetch(makeCtx(homeDir));
+    expect(snapshot.provider).toBe("grok");
+    expect(snapshot.status).toBe("needs-auth");
+  });
+
+  it("returns error when billing fails with a server error", async () => {
+    const homeDir = makeHomeWithAuth();
+    stubOutboundFetch(async (url) => {
+      const target = requestUrl(url);
+      if (isBillingUrl(target)) {
+        return jsonResponse({ error: "server_error" }, 500);
+      }
+      if (isSettingsUrl(target)) {
+        return jsonResponse(SETTINGS_BODY);
+      }
+      throw new Error(`unexpected grok usage URL: ${target}`);
+    });
+
+    const snapshot = await grokUsageFetcher.fetch(makeCtx(homeDir));
+    expect(snapshot.provider).toBe("grok");
+    expect(snapshot.status).toBe("error");
+  });
+
+  it("keeps an ok billing snapshot when settings fail", async () => {
+    const homeDir = makeHomeWithAuth();
+    stubOutboundFetch(async (url) => {
+      const target = requestUrl(url);
+      if (isBillingUrl(target)) {
+        return jsonResponse(WEEKLY_BILLING);
+      }
+      if (isSettingsUrl(target)) {
+        return jsonResponse({ error: "server_error" }, 500);
+      }
+      throw new Error(`unexpected grok usage URL: ${target}`);
+    });
+
+    const snapshot = await grokUsageFetcher.fetch(makeCtx(homeDir));
+    expect(snapshot.provider).toBe("grok");
+    expect(snapshot.status).toBe("ok");
+    expect(snapshot.limits.find((entry) => entry.window === "Weekly")?.usedPercent).toBe(44);
+  });
+});

--- a/apps/server/src/providerUsage/providers/grok.ts
+++ b/apps/server/src/providerUsage/providers/grok.ts
@@ -1,0 +1,624 @@
+// FILE: providerUsage/providers/grok.ts
+// Purpose: Live Grok (SuperGrok) usage fetcher. Reads the OIDC bearer from the Grok CLI
+// auth.json (`$GROK_HOME/auth.json` or `~/.grok/auth.json`) and calls the CLI-proxy
+// billing API (`/v1/billing?format=credits`) for the SuperGrok / SuperGrok Heavy weekly pool.
+//
+// Access tokens last ~6 hours. Like Codex, file-sourced credentials are refreshed here
+// with the care rotating refresh tokens demand: re-read the live auth.json right before
+// redeeming (the CLI may have rotated it since we loaded), redeem at most once per fetch,
+// and atomically persist the rotated pair back to the same file so the CLI's login
+// survives. Never refresh when we cannot write the rotation back. API keys have no
+// weekly pool — SuperGrok usage requires `grok login`. Team principals are unsupported.
+
+import nodePath from "node:path";
+
+import type { ServerProviderUsageLimit, ServerProviderUsageLine } from "@synara/contracts";
+
+import { createLogger } from "../../logger";
+import {
+  credentialFingerprint,
+  decodeJwtExpMs,
+  readJsonFile,
+  refreshOAuthAccessToken,
+  writeJsonFileAtomic,
+  type OAuthRefreshResult,
+} from "../credentials";
+import { fetchJson, isAuthFailureStatus } from "../http";
+import {
+  asFiniteNumber,
+  asRecord,
+  asString,
+  buildSnapshot,
+  clampPercent,
+  errorSnapshot,
+  formatUsd,
+  isoFromString,
+  needsAuthSnapshot,
+  unsupportedSnapshot,
+} from "../parse";
+import type { ProviderUsageContext, ProviderUsageFetcher } from "../types";
+
+const log = createLogger("provider-usage:grok");
+
+const SOURCE = "grok-cli-proxy-credits";
+const BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
+const SETTINGS_URL = "https://cli-chat-proxy.grok.com/v1/settings";
+const CLI_PROXY_ORIGIN = new URL(BILLING_URL).origin;
+const DEFAULT_ISSUER = "https://auth.x.ai";
+const DEFAULT_TOKEN_URL = "https://auth.x.ai/oauth2/token";
+const PREFERRED_SCOPE_PREFIX = "https://auth.x.ai::";
+const SIGN_IN_SCOPE = "https://accounts.x.ai/sign-in";
+const ACCESS_TOKEN_REFRESH_WINDOW_MS = 5 * 60 * 1000;
+const SETTINGS_TIMEOUT_MS = 2_000;
+const WELL_KNOWN_TIMEOUT_MS = 5_000;
+const WEEKLY_WINDOW_MINS = 10_080;
+
+const REFRESH_TOKEN_DEAD_CODES = new Set([
+  "invalid_grant",
+  "invalid_client",
+  "refresh_token_expired",
+  "refresh_token_invalidated",
+]);
+const REFRESH_TOKEN_REUSED_CODE = "refresh_token_reused";
+
+interface GrokOAuthState {
+  kind: "oauth";
+  /** Absolute auth.json path; rotations are written back here. */
+  path: string;
+  /** Full parsed auth.json map, kept for a field-preserving write-back after rotation. */
+  root: Record<string, unknown>;
+  /** Map key of the selected credential entry (scope URL). */
+  scope: string;
+  entry: Record<string, unknown>;
+  accessToken: string;
+  refreshToken: string | undefined;
+  expiresAtMs: number | undefined;
+  clientId: string | undefined;
+  issuer: string | undefined;
+  principalType: string | undefined;
+}
+
+type GrokAuth = GrokOAuthState | { kind: "api-key" };
+
+function grokAuthFilePath(ctx: ProviderUsageContext): string {
+  const grokHome = asString(ctx.env.GROK_HOME);
+  if (grokHome) {
+    return nodePath.join(grokHome, "auth.json");
+  }
+  return nodePath.join(ctx.homeDir, ".grok", "auth.json");
+}
+
+function grokEnvHasApiKey(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(asString(env.XAI_API_KEY) || asString(env.GROK_CODE_XAI_API_KEY));
+}
+
+function isTeamPrincipal(principalType: string | undefined): boolean {
+  return principalType?.toLowerCase() === "team";
+}
+
+function entryAccessToken(
+  value: unknown,
+): { entry: Record<string, unknown>; accessToken: string } | null {
+  const entry = asRecord(value);
+  const accessToken = asString(entry?.key);
+  return entry && accessToken ? { entry, accessToken } : null;
+}
+
+function pickAuthEntry(
+  root: Record<string, unknown>,
+): { scope: string; entry: Record<string, unknown>; accessToken: string } | null {
+  for (const [scope, value] of Object.entries(root)) {
+    if (!scope.startsWith(PREFERRED_SCOPE_PREFIX)) {
+      continue;
+    }
+    const picked = entryAccessToken(value);
+    if (picked) {
+      return { scope, ...picked };
+    }
+  }
+
+  const signIn = entryAccessToken(root[SIGN_IN_SCOPE]);
+  if (signIn) {
+    return { scope: SIGN_IN_SCOPE, ...signIn };
+  }
+
+  for (const [scope, value] of Object.entries(root)) {
+    const picked = entryAccessToken(value);
+    if (picked) {
+      return { scope, ...picked };
+    }
+  }
+  return null;
+}
+
+function readExpiresAtMs(entry: Record<string, unknown>): number | undefined {
+  const text = asString(entry.expires_at);
+  if (text) {
+    const parsed = Date.parse(text);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  const numeric = asFiniteNumber(entry.expires_at);
+  if (numeric === undefined) {
+    return undefined;
+  }
+  return numeric > 1e12 ? numeric : numeric * 1000;
+}
+
+function readGrokAuthState(
+  path: string,
+  root: Record<string, unknown> | null,
+  preferredScope?: string,
+): GrokOAuthState | null {
+  if (!root) {
+    return null;
+  }
+
+  let picked: { scope: string; entry: Record<string, unknown>; accessToken: string } | null = null;
+  if (preferredScope) {
+    const preferred = entryAccessToken(root[preferredScope]);
+    if (preferred) {
+      picked = { scope: preferredScope, ...preferred };
+    }
+  }
+  picked ??= pickAuthEntry(root);
+  if (!picked) {
+    return null;
+  }
+
+  return {
+    kind: "oauth",
+    path,
+    root,
+    scope: picked.scope,
+    entry: picked.entry,
+    accessToken: picked.accessToken,
+    refreshToken: asString(picked.entry.refresh_token),
+    expiresAtMs: readExpiresAtMs(picked.entry),
+    clientId: asString(picked.entry.oidc_client_id),
+    issuer: asString(picked.entry.oidc_issuer),
+    principalType: asString(picked.entry.principal_type),
+  };
+}
+
+async function reloadGrokAuth(state: GrokOAuthState): Promise<GrokOAuthState | null> {
+  return readGrokAuthState(state.path, asRecord(await readJsonFile(state.path)), state.scope);
+}
+
+async function resolveGrokAuth(ctx: ProviderUsageContext): Promise<GrokAuth | null> {
+  const path = grokAuthFilePath(ctx);
+  const state = readGrokAuthState(path, asRecord(await readJsonFile(path)));
+  if (state) {
+    return state;
+  }
+  return grokEnvHasApiKey(ctx.env) ? { kind: "api-key" } : null;
+}
+
+function grokAuthCacheKey(ctx: ProviderUsageContext, auth: GrokAuth | null): string {
+  if (!auth || auth.kind === "api-key") {
+    return `${ctx.homeDir}:none`;
+  }
+  return `${ctx.homeDir}:${credentialFingerprint(auth.refreshToken ?? auth.accessToken)}`;
+}
+
+/** Refresh once the access token is within 5 minutes of `expires_at` or its JWT `exp`. */
+function grokAuthNeedsRefresh(state: GrokOAuthState, nowMs: number): boolean {
+  const jwtExpMs = decodeJwtExpMs(state.accessToken);
+  const candidates: number[] = [];
+  if (state.expiresAtMs !== undefined) {
+    candidates.push(state.expiresAtMs);
+  }
+  if (jwtExpMs !== null) {
+    candidates.push(jwtExpMs);
+  }
+  if (candidates.length === 0) {
+    return false;
+  }
+  return Math.min(...candidates) - nowMs <= ACCESS_TOKEN_REFRESH_WINDOW_MS;
+}
+
+const refreshLocks = new Map<string, Promise<unknown>>();
+function withRefreshLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const prev = refreshLocks.get(key) ?? Promise.resolve();
+  const run = prev.then(fn, fn);
+  refreshLocks.set(
+    key,
+    run.then(
+      () => undefined,
+      () => undefined,
+    ),
+  );
+  return run;
+}
+
+const tokenEndpointCache = new Map<string, string>();
+
+async function resolveTokenUrl(issuer: string | undefined): Promise<string> {
+  const normalized = (issuer ?? DEFAULT_ISSUER).replace(/\/$/u, "");
+  if (normalized === DEFAULT_ISSUER) {
+    return DEFAULT_TOKEN_URL;
+  }
+
+  const cached = tokenEndpointCache.get(normalized);
+  if (cached) {
+    return cached;
+  }
+
+  try {
+    const wellKnownUrl = `${normalized}/.well-known/openid-configuration`;
+    const result = await fetchJson({
+      service: "provider-usage-grok-oidc",
+      url: wellKnownUrl,
+      allowedOrigins: [new URL(wellKnownUrl).origin],
+      headers: { Accept: "application/json", "User-Agent": "Synara" },
+      timeoutMs: WELL_KNOWN_TIMEOUT_MS,
+    });
+    const tokenEndpoint = asString(asRecord(result.json)?.token_endpoint);
+    if (result.ok && tokenEndpoint) {
+      tokenEndpointCache.set(normalized, tokenEndpoint);
+      return tokenEndpoint;
+    }
+  } catch {
+    // Fall back to the SpaceXAI token endpoint.
+  }
+
+  return DEFAULT_TOKEN_URL;
+}
+
+function expiresAtIso(refreshed: Extract<OAuthRefreshResult, { ok: true }>): string | undefined {
+  if (refreshed.expiresAtMs !== undefined) {
+    return new Date(refreshed.expiresAtMs).toISOString();
+  }
+  const jwtExpMs = decodeJwtExpMs(refreshed.accessToken);
+  return jwtExpMs !== null ? new Date(jwtExpMs).toISOString() : undefined;
+}
+
+/** Apply a token-endpoint rotation to the in-memory state and persist it back to auth.json.
+ * Persistence failures are logged loudly but don't fail the fetch: the refreshed token still
+ * works for this pass, while the stranded rotation is the thing worth surfacing. */
+async function persistRotatedGrokAuth(
+  state: GrokOAuthState,
+  refreshed: Extract<OAuthRefreshResult, { ok: true }>,
+): Promise<GrokOAuthState> {
+  const liveRoot = asRecord(await readJsonFile(state.path)) ?? state.root;
+  const liveEntry = asRecord(liveRoot[state.scope]) ?? state.entry;
+  const entry: Record<string, unknown> = {
+    ...liveEntry,
+    key: refreshed.accessToken,
+  };
+  if (refreshed.refreshToken) {
+    entry.refresh_token = refreshed.refreshToken;
+  }
+  const expiresAt = expiresAtIso(refreshed);
+  if (expiresAt) {
+    entry.expires_at = expiresAt;
+  }
+  const root: Record<string, unknown> = {
+    ...liveRoot,
+    [state.scope]: entry,
+  };
+  try {
+    await writeJsonFileAtomic(state.path, root);
+  } catch (cause) {
+    log.error(
+      "failed to persist rotated grok credentials; the CLI may need a re-login if the old refresh token is gone",
+      { message: cause instanceof Error ? cause.message : String(cause) },
+    );
+  }
+  return {
+    ...state,
+    root,
+    entry,
+    accessToken: refreshed.accessToken,
+    refreshToken: refreshed.refreshToken ?? state.refreshToken,
+    expiresAtMs:
+      refreshed.expiresAtMs ?? decodeJwtExpMs(refreshed.accessToken) ?? state.expiresAtMs,
+  };
+}
+
+type GrokRefreshOutcome =
+  | { kind: "updated"; state: GrokOAuthState; redeemed: boolean }
+  | { kind: "needs-auth" }
+  | { kind: "unavailable" };
+
+/**
+ * Bring a stale/rejected credential up to date. Order matters: adopt an out-of-band rotation
+ * from the live file first (redeeming our stale copy would trip `refresh_token_reused`), then
+ * redeem the refresh token ourselves at most once (`allowRedeem`), persisting the rotation.
+ */
+async function refreshGrokAuth(
+  ctx: ProviderUsageContext,
+  state: GrokOAuthState,
+  options: { allowRedeem: boolean },
+): Promise<GrokRefreshOutcome> {
+  return withRefreshLock(state.path, async () => {
+    try {
+      const live = (await reloadGrokAuth(state)) ?? state;
+      if (live.accessToken !== state.accessToken && !grokAuthNeedsRefresh(live, ctx.nowMs)) {
+        return { kind: "updated", state: live, redeemed: false };
+      }
+      if (!options.allowRedeem) {
+        return live.accessToken !== state.accessToken
+          ? { kind: "updated", state: live, redeemed: false }
+          : { kind: "needs-auth" };
+      }
+      // Rotating refresh tokens must not be redeemed unless we can write the new pair back.
+      if (!live.refreshToken || !live.clientId) {
+        return { kind: "needs-auth" };
+      }
+
+      let refreshUrl: string;
+      try {
+        refreshUrl = await resolveTokenUrl(live.issuer);
+      } catch {
+        log.warn("grok token endpoint discovery failed; continuing with the stored access token");
+        return { kind: "unavailable" };
+      }
+
+      const refreshed = await refreshOAuthAccessToken({
+        service: "provider-usage-grok-refresh",
+        refreshUrl,
+        allowedOrigins: [new URL(refreshUrl).origin],
+        refreshToken: live.refreshToken,
+        clientId: live.clientId,
+        bodyFormat: "form",
+      });
+      if (refreshed.ok) {
+        return {
+          kind: "updated",
+          state: await persistRotatedGrokAuth(live, refreshed),
+          redeemed: true,
+        };
+      }
+      if (refreshed.errorCode === REFRESH_TOKEN_REUSED_CODE) {
+        const rotated = await reloadGrokAuth(state);
+        if (rotated && rotated.accessToken !== live.accessToken) {
+          return { kind: "updated", state: rotated, redeemed: false };
+        }
+        log.warn("grok refresh token already redeemed and no rotated credential found on disk");
+        return { kind: "needs-auth" };
+      }
+      if (refreshed.errorCode && REFRESH_TOKEN_DEAD_CODES.has(refreshed.errorCode)) {
+        log.warn("grok refresh token rejected; re-login required", {
+          errorCode: refreshed.errorCode,
+        });
+        return { kind: "needs-auth" };
+      }
+      log.warn(
+        "grok token refresh unavailable; continuing with the stored access token",
+        refreshed.status !== undefined ? { status: refreshed.status } : undefined,
+      );
+      return { kind: "unavailable" };
+    } catch (cause) {
+      log.warn("grok token refresh unavailable; continuing with the stored access token", {
+        message: cause instanceof Error ? cause.message : String(cause),
+      });
+      return { kind: "unavailable" };
+    }
+  });
+}
+
+function grokHeaders(accessToken: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    "x-xai-token-auth": "xai-grok-cli",
+    Accept: "application/json",
+    "User-Agent": "Synara",
+  };
+}
+
+function protoVal(value: unknown): number | undefined {
+  const direct = asFiniteNumber(value);
+  if (direct !== undefined) {
+    return direct;
+  }
+  return asFiniteNumber(asRecord(value)?.val);
+}
+
+/** CLI-proxy amounts are integer cents (Cursor-style); fractional values are already dollars. */
+function usdFromCentsish(amount: number): string {
+  return formatUsd(Number.isInteger(amount) ? amount / 100 : amount);
+}
+
+function compactLetters(value: string): string {
+  return value.toLowerCase().replace(/[^a-z]/gu, "");
+}
+
+function grokPlanName(raw: string | undefined): string | undefined {
+  const trimmed = asString(raw);
+  if (!trimmed) {
+    return undefined;
+  }
+  const compact = compactLetters(trimmed);
+  if (compact.includes("supergrokheavy") || compact === "heavy") {
+    return "SuperGrok Heavy";
+  }
+  if (compact.includes("supergrok")) {
+    return "SuperGrok";
+  }
+  return trimmed;
+}
+
+function readSettingsPlanName(json: unknown): string | undefined {
+  const root = asRecord(json);
+  if (!root) {
+    return undefined;
+  }
+  return (
+    asString(root.subscription_tier_display) ??
+    asString(asRecord(root.settings)?.subscription_tier_display) ??
+    asString(asRecord(root.config)?.subscription_tier_display)
+  );
+}
+
+export function parseGrokUsage(input: { billing: unknown; planName?: string; nowMs: number }) {
+  const root = asRecord(input.billing);
+  const config = asRecord(root?.config) ?? root;
+  const limits: ServerProviderUsageLimit[] = [];
+  const usageLines: ServerProviderUsageLine[] = [];
+  const planName = grokPlanName(input.planName);
+
+  if (config) {
+    const currentPeriod = asRecord(config.currentPeriod);
+    const periodType = asString(currentPeriod?.type) ?? "";
+    const isUnified = config.isUnifiedBillingUser === true;
+    const isWeekly = /weekly/iu.test(periodType) || (periodType.length === 0 && isUnified);
+
+    let usedPercent = clampPercent(asFiniteNumber(config.creditUsagePercent));
+    if (usedPercent === undefined) {
+      const onDemandUsed = protoVal(config.onDemandUsed);
+      const onDemandCap = protoVal(config.onDemandCap);
+      if (onDemandUsed !== undefined && onDemandCap !== undefined && onDemandCap > 0) {
+        usedPercent = clampPercent((onDemandUsed / onDemandCap) * 100);
+      } else if (currentPeriod) {
+        usedPercent = 0;
+      }
+    }
+
+    const resetsAt = isoFromString(currentPeriod?.end) ?? isoFromString(config.billingPeriodEnd);
+    if (usedPercent !== undefined || resetsAt) {
+      limits.push({
+        window: isWeekly ? "Weekly" : "Current",
+        ...(usedPercent !== undefined ? { usedPercent } : {}),
+        ...(resetsAt ? { resetsAt } : {}),
+        ...(isWeekly ? { windowDurationMins: WEEKLY_WINDOW_MINS } : {}),
+      });
+    }
+
+    const prepaid = protoVal(config.prepaidBalance);
+    if (prepaid !== undefined && prepaid > 0) {
+      usageLines.push({ label: "Credits", value: `${usdFromCentsish(prepaid)} remaining` });
+    }
+
+    const onDemandCap = protoVal(config.onDemandCap);
+    if (onDemandCap !== undefined && onDemandCap > 0) {
+      const onDemandUsed = protoVal(config.onDemandUsed);
+      usageLines.push({
+        label: "On-demand",
+        value:
+          onDemandUsed !== undefined
+            ? `${usdFromCentsish(onDemandUsed)} of ${usdFromCentsish(onDemandCap)}`
+            : `${usdFromCentsish(onDemandCap)} limit`,
+      });
+    }
+  }
+
+  return buildSnapshot({
+    provider: "grok",
+    nowMs: input.nowMs,
+    status: "ok",
+    source: SOURCE,
+    limits,
+    usageLines,
+    ...(planName ? { planName } : {}),
+  });
+}
+
+function fetchGrokBilling(accessToken: string) {
+  return fetchJson({
+    service: "provider-usage-grok",
+    url: BILLING_URL,
+    allowedOrigins: [CLI_PROXY_ORIGIN],
+    headers: grokHeaders(accessToken),
+  });
+}
+
+async function fetchGrokPlanName(accessToken: string): Promise<string | undefined> {
+  try {
+    const result = await fetchJson({
+      service: "provider-usage-grok",
+      url: SETTINGS_URL,
+      allowedOrigins: [CLI_PROXY_ORIGIN],
+      headers: grokHeaders(accessToken),
+      timeoutMs: SETTINGS_TIMEOUT_MS,
+    });
+    if (!result.ok) {
+      return undefined;
+    }
+    return grokPlanName(readSettingsPlanName(result.json));
+  } catch {
+    return undefined;
+  }
+}
+
+export const grokUsageFetcher: ProviderUsageFetcher = {
+  provider: "grok",
+  async cacheKey(ctx) {
+    return grokAuthCacheKey(ctx, await resolveGrokAuth(ctx));
+  },
+  async fetch(ctx) {
+    try {
+      const auth = await resolveGrokAuth(ctx);
+      if (!auth) {
+        return needsAuthSnapshot("grok", ctx.nowMs, SOURCE);
+      }
+      if (auth.kind === "api-key") {
+        return unsupportedSnapshot(
+          "grok",
+          ctx.nowMs,
+          SOURCE,
+          "SuperGrok usage requires `grok login`. API keys have no weekly pool.",
+        );
+      }
+      if (isTeamPrincipal(auth.principalType)) {
+        return unsupportedSnapshot(
+          "grok",
+          ctx.nowMs,
+          SOURCE,
+          "Grok team-account usage is unavailable.",
+        );
+      }
+
+      let state = auth;
+      // At most one token-endpoint redemption per fetch: if a just-refreshed token still comes
+      // back 401, a second redemption can only burn credentials, not fix anything.
+      let allowRedeem = true;
+
+      if (grokAuthNeedsRefresh(state, ctx.nowMs)) {
+        const outcome = await refreshGrokAuth(ctx, state, { allowRedeem });
+        if (outcome.kind === "needs-auth") {
+          return needsAuthSnapshot("grok", ctx.nowMs, SOURCE);
+        }
+        if (outcome.kind === "updated") {
+          allowRedeem = allowRedeem && !outcome.redeemed;
+          state = outcome.state;
+        }
+      }
+
+      let result = await fetchGrokBilling(state.accessToken);
+      if (isAuthFailureStatus(result.status)) {
+        const outcome = await refreshGrokAuth(ctx, state, { allowRedeem });
+        if (outcome.kind === "updated" && outcome.state.accessToken !== state.accessToken) {
+          state = outcome.state;
+          result = await fetchGrokBilling(state.accessToken);
+        }
+      }
+      if (isAuthFailureStatus(result.status)) {
+        log.warn("grok usage request unauthorized after refresh", { status: result.status });
+        return needsAuthSnapshot("grok", ctx.nowMs, SOURCE);
+      }
+      if (!result.ok) {
+        log.warn("grok usage request failed", { status: result.status });
+        return errorSnapshot(
+          "grok",
+          ctx.nowMs,
+          SOURCE,
+          `Grok usage request failed (${result.status}).`,
+        );
+      }
+
+      const planName = await fetchGrokPlanName(state.accessToken);
+      return parseGrokUsage({
+        billing: result.json,
+        nowMs: ctx.nowMs,
+        ...(planName ? { planName } : {}),
+      });
+    } catch (cause) {
+      log.warn("grok usage endpoint unreachable", {
+        message: cause instanceof Error ? cause.message : String(cause),
+      });
+      return errorSnapshot("grok", ctx.nowMs, SOURCE, "Could not reach the Grok usage endpoint.");
+    }
+  },
+};

--- a/apps/server/src/providerUsage/registry.ts
+++ b/apps/server/src/providerUsage/registry.ts
@@ -7,10 +7,12 @@ import type { ProviderKind } from "@synara/contracts";
 import { claudeUsageFetcher } from "./providers/claude";
 import { codexUsageFetcher } from "./providers/codex";
 import { cursorUsageFetcher } from "./providers/cursor";
+import { grokUsageFetcher } from "./providers/grok";
 import type { ProviderUsageFetcher } from "./types";
 
 export const PROVIDER_USAGE_FETCHERS: Partial<Record<ProviderKind, ProviderUsageFetcher>> = {
   codex: codexUsageFetcher,
   claudeAgent: claudeUsageFetcher,
   cursor: cursorUsageFetcher,
+  grok: grokUsageFetcher,
 };

--- a/packages/shared/src/providerMetadata.ts
+++ b/packages/shared/src/providerMetadata.ts
@@ -64,7 +64,10 @@ export const PROVIDER_DESCRIPTORS = [
     displayName: PROVIDER_DISPLAY_NAMES.grok,
     available: true,
     supportsNativeTurnSteering: false,
-    usage: null,
+    usage: {
+      signInCommand: "grok login",
+      learnMoreHref: "https://grok.com/?_s=usage",
+    },
   },
   {
     kind: "droid",


### PR DESCRIPTION
Closes #757

## What Changed

Grok now appears on Settings → Usage next to Codex, Claude, and Cursor.

- Flip Grok's usage metadata so the existing cards pick it up
- Register a fetcher that reads `~/.grok/auth.json` (`GROK_HOME` if set)
- Call the CLI-proxy weekly credits endpoint and `/v1/settings` for the plan name (`SuperGrok Heavy` vs `SuperGrok`)
- Refresh the short-lived OIDC token and write it back, same caution as Codex

No new card UI. API-key-only and team principals stay `unsupported`.

## Why

Settings already shows remaining quota for the other signed-in CLIs. SuperGrok / Heavy has a weekly pool (Build, Chat, Imagine, etc.) but Synara never asked for it, so you had to check grok.com.

This is the same registry + snapshot path the other three providers use. One Weekly meter and a plan pill.

## UI Changes

**Before:** Settings → Usage shows Codex, Claude, and Cursor only.

**After:** same cards, plus Grok with SuperGrok Heavy, a Weekly remaining bar, reset countdown, and pace — same chrome as Codex/Cursor.

No motion or interaction change (Refresh already existed).

## Verification

- [x] `bun run --cwd apps/server test src/providerUsage/parsers.test.ts src/providerUsage/providers/grok.test.ts` (17 passed)
- [x] `bun fmt`
- [x] `bun lint` (0 errors)
- [x] `bun typecheck`
- [x] Live fetch against a SuperGrok Heavy `grok login`: Weekly pool + plan name
- [x] Settings → Usage on desktop and a 390px viewport
- [x] `bun run test` (full workspace). `@synara/cli` had 1 pre-existing failure in `ThreadDiagnosticsQuery.test.ts`, unrelated to this change. Other packages passed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

<img width="736" height="941" alt="image" src="https://github.com/user-attachments/assets/6905d55d-1213-4a04-97a5-8f5a7effab2d" />
