### PR TITLE
Fix semantic foreground tokens in custom themes

### DIFF
--- a/apps/web/src/theme/theme.logic.test.ts
+++ b/apps/web/src/theme/theme.logic.test.ts
@@ -292,9 +292,26 @@ describe("buildThemeCssVariables", () => {
     expect(cssVariables.variables["--codex-base-accent"]).toBe("#606acc");
     expect(cssVariables.variables["--background"]).toBe("#0d0d0f");
     expect(cssVariables.variables["--card"]).toBe("#151517");
-    expect(cssVariables.variables["--sidebar-accent"]).toBe("rgba(227, 228, 230, 0.038)");
+    expect(cssVariables.variables["--sidebar-accent"]).toBe("rgba(227, 228, 230, 0.077)");
+    expect(cssVariables.variables["--destructive-foreground"]).toBe("#ff7e78");
+    expect(cssVariables.variables["--success-foreground"]).toBe("#69c967");
+    expect(cssVariables.variables["--warning-foreground"]).toBe("#f5b44a");
     expect(cssVariables.variables["--theme-font-ui-family"]).toBe("Inter");
     expect(cssVariables.variables["--theme-font-code-family"]).toBe('"Jetbrains Mono"');
+  });
+
+  it("uses mode-appropriate semantic colors for foreground text", () => {
+    for (const variant of ["light", "dark"] as const) {
+      const pack = resolveThemePack(DEFAULT_THEME_STATE, variant);
+      const { variables } = buildThemeCssVariables(pack, variant, { electron: false });
+
+      expect(variables["--destructive-foreground"]).toBe(pack.theme.semanticColors.diffRemoved);
+      expect(variables["--success-foreground"]).toBe(pack.theme.semanticColors.diffAdded);
+      expect(variables["--warning-foreground"]).toBe(variables["--warning"]);
+      expect(variables["--destructive-foreground"]).not.toBe(pack.theme.surface);
+      expect(variables["--success-foreground"]).not.toBe(pack.theme.surface);
+      expect(variables["--warning-foreground"]).not.toBe(pack.theme.surface);
+    }
   });
 
   it("exposes a structured derived-token surface for retrieving non-stored colors", () => {
@@ -313,7 +330,7 @@ describe("buildThemeCssVariables", () => {
     expect(tokens.derived.buttonSecondaryBackground).toBe("rgba(227, 228, 230, 0.039)");
     expect(tokens.aliases["--color-token-side-bar-background"]).toBe("#0d0d0f");
     expect(tokens.aliases["--color-token-list-hover-background"]).toBe(
-      "rgba(227, 228, 230, 0.038)",
+      "rgba(227, 228, 230, 0.077)",
     );
     expect(tokens.aliases["--color-token-input-background"]).toBe("rgba(36, 36, 38, 0.96)");
   });

--- a/apps/web/src/theme/theme.logic.ts
+++ b/apps/web/src/theme/theme.logic.ts
@@ -698,7 +698,7 @@ export function buildThemeCssVariables(
     "--card": readCodexVariable("--color-background-panel"),
     "--card-foreground": readCodexVariable("--color-text-foreground"),
     "--destructive": pack.theme.semanticColors.diffRemoved,
-    "--destructive-foreground": pack.theme.surface,
+    "--destructive-foreground": pack.theme.semanticColors.diffRemoved,
     "--foreground": readCodexVariable("--color-text-foreground"),
     "--info": pack.theme.accent,
     // Keep legacy app-level "info" consumers on Codex's accent-text path so
@@ -721,11 +721,11 @@ export function buildThemeCssVariables(
     "--sidebar-border": readCodexVariable("--color-border"),
     "--sidebar-foreground": readCodexVariable("--color-text-foreground"),
     "--success": pack.theme.semanticColors.diffAdded,
-    "--success-foreground": pack.theme.surface,
+    "--success-foreground": pack.theme.semanticColors.diffAdded,
     "--theme-font-code-family": pack.theme.fonts.code ?? "",
     "--theme-font-ui-family": pack.theme.fonts.ui ?? "",
     "--warning": warningColor,
-    "--warning-foreground": pack.theme.surface,
+    "--warning-foreground": warningColor,
   };
 
   return {


### PR DESCRIPTION
## Summary

- supersede #30 without reintroducing its obsolete parallel theme implementation
- keep destructive, success, and warning foreground tokens on their mode-appropriate semantic colors
- add light/dark regression coverage for semantic foreground projection
- refresh two stale sidebar-hover token expectations left by the current target branch

## Verification

- `bun run --cwd apps/web test src/theme/theme.logic.test.ts` (15 tests passed)

## Context

PR #30 cannot be updated by this account, and its preset/import/font work is already superseded by the newer theme engine on `dpcode/electron-theme-engine`. This replacement preserves that engine and fixes the remaining user-visible semantic-color regression in a focused diff.