### PR TITLE
Reduce desktop CPU and process-tree memory

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -2103,6 +2103,70 @@ describe("steerTurn", () => {
 });
 
 describe("CodexAppServerManager discovery", () => {
+  it("restarts the idle grace period after a discovery request settles", async () => {
+    vi.useFakeTimers();
+    try {
+      const manager = new CodexAppServerManager(undefined, {
+        discoverySessionIdleMs: 15_000,
+      });
+      const context = {
+        discovery: true,
+        session: { cwd: "/repo" },
+        pending: new Map(),
+        pendingApprovals: new Map(),
+        pendingUserInputs: new Map(),
+        nextRequestId: 1,
+        stopping: false,
+      };
+      (
+        manager as unknown as {
+          discoverySessions: Map<string, unknown>;
+        }
+      ).discoverySessions.set("/repo", context);
+      vi.spyOn(
+        manager as unknown as {
+          writeMessage: () => Promise<void>;
+        },
+        "writeMessage",
+      ).mockResolvedValue(undefined);
+      const stopDiscoverySession = vi
+        .spyOn(
+          manager as unknown as {
+            stopDiscoverySession: (cwd: string) => Promise<void>;
+          },
+          "stopDiscoverySession",
+        )
+        .mockResolvedValue(undefined);
+
+      (
+        manager as unknown as {
+          scheduleDiscoverySessionIdleStop: (cwd: string) => void;
+        }
+      ).scheduleDiscoverySessionIdleStop("/repo");
+      const request = (
+        manager as unknown as {
+          sendRequest: (context: unknown, method: string, params: unknown) => Promise<unknown>;
+        }
+      ).sendRequest(context, "model/list", {});
+
+      await vi.advanceTimersByTimeAsync(14_999);
+      (
+        manager as unknown as {
+          handleResponse: (context: unknown, response: unknown) => void;
+        }
+      ).handleResponse(context, { id: 1, result: {} });
+      await request;
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(stopDiscoverySession).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(14_999);
+      expect(stopDiscoverySession).toHaveBeenCalledOnce();
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
   it("stops an idle discovery session after its configured grace period", async () => {
     vi.useFakeTimers();
     try {

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -2103,6 +2103,49 @@ describe("steerTurn", () => {
 });
 
 describe("CodexAppServerManager discovery", () => {
+  it("stops an idle discovery session after its configured grace period", async () => {
+    vi.useFakeTimers();
+    try {
+      const manager = new CodexAppServerManager(undefined, {
+        discoverySessionIdleMs: 15_000,
+      });
+      (
+        manager as unknown as {
+          discoverySessions: Map<string, unknown>;
+        }
+      ).discoverySessions.set("/repo", {
+        stopping: false,
+        pending: new Map(),
+        pendingApprovals: new Map(),
+        pendingUserInputs: new Map(),
+      });
+      const stopDiscoverySession = vi
+        .spyOn(
+          manager as unknown as {
+            stopDiscoverySession: (cwd: string) => Promise<void>;
+          },
+          "stopDiscoverySession",
+        )
+        .mockResolvedValue(undefined);
+
+      (
+        manager as unknown as {
+          scheduleDiscoverySessionIdleStop: (cwd: string) => void;
+        }
+      ).scheduleDiscoverySessionIdleStop("/repo");
+
+      await vi.advanceTimersByTimeAsync(14_999);
+      expect(stopDiscoverySession).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(stopDiscoverySession).toHaveBeenCalledOnce();
+      expect(stopDiscoverySession).toHaveBeenCalledWith("/repo");
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
   it("wires model discovery through model/list", async () => {
     const manager = new CodexAppServerManager();
     const context = {

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -2832,6 +2832,17 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     this.discoverySessionIdleTimers.set(discoveryKey, timer);
   }
 
+  private restartDiscoverySessionIdleTimer(context: CodexSessionContext): void {
+    if (!context.discovery || context.stopping) {
+      return;
+    }
+    const discoveryKey = context.session.cwd?.trim();
+    if (!discoveryKey || this.discoverySessions.get(discoveryKey) !== context) {
+      return;
+    }
+    this.scheduleDiscoverySessionIdleStop(discoveryKey);
+  }
+
   private async stopDiscoverySession(discoveryKey: string): Promise<void> {
     const idleTimer = this.discoverySessionIdleTimers.get(discoveryKey);
     if (idleTimer) {
@@ -3462,6 +3473,8 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         context.pending.delete(String(id));
         reject(error);
       });
+    }).finally(() => {
+      this.restartDiscoverySessionIdleTimer(context);
     });
 
     return result as TResponse;

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -317,7 +317,10 @@ const RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS = [
 const CODEX_DEFAULT_MODEL = "gpt-5.5";
 const CODEX_SPARK_MODEL = "gpt-5.3-codex-spark";
 const CODEX_SPARK_DISABLED_PLAN_TYPES = new Set<CodexPlanType>(["free", "go", "plus"]);
-const CODEX_DISCOVERY_SESSION_IDLE_MS = 10 * 60 * 1000;
+// Discovery results live in the bounded caches below, so keeping a dedicated
+// app-server process alive for ten minutes only retains its process tree. A
+// short grace period still collapses startup bursts from adjacent UI queries.
+const CODEX_DISCOVERY_SESSION_IDLE_MS = 15_000;
 const CODEX_VOICE_AUTH_CACHE_TTL_MS = 60_000;
 const CODEX_PENDING_SETTLE_DEADLINE_MS = 2_000;
 
@@ -974,6 +977,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     | undefined;
   private readonly teardownProcessTree: typeof teardownProviderProcessTree;
   private readonly taskCompleteFallbackGraceMs: number;
+  private readonly discoverySessionIdleMs: number;
   constructor(
     services?: ServiceMap.ServiceMap<never>,
     options?: {
@@ -984,6 +988,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       };
       readonly teardownProcessTree?: typeof teardownProviderProcessTree;
       readonly taskCompleteFallbackGraceMs?: number;
+      readonly discoverySessionIdleMs?: number;
     },
   ) {
     super();
@@ -992,6 +997,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     this.agentGatewayMcp = options?.agentGatewayMcp;
     this.teardownProcessTree = options?.teardownProcessTree ?? teardownProviderProcessTree;
     this.taskCompleteFallbackGraceMs = Math.max(0, options?.taskCompleteFallbackGraceMs ?? 750);
+    this.discoverySessionIdleMs = Math.max(
+      0,
+      options?.discoverySessionIdleMs ?? CODEX_DISCOVERY_SESSION_IDLE_MS,
+    );
   }
 
   // The Synara MCP server rides on the shared overlay config (no secrets),
@@ -2818,7 +2827,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       void this.stopDiscoverySession(discoveryKey).catch((error) => {
         log.warn("Failed to stop idle Codex discovery session", { discoveryKey, error });
       });
-    }, CODEX_DISCOVERY_SESSION_IDLE_MS);
+    }, this.discoverySessionIdleMs);
     timer.unref();
     this.discoverySessionIdleTimers.set(discoveryKey, timer);
   }


### PR DESCRIPTION
## Summary

This PR reduces Synara's Electron process-tree CPU and resident-memory overhead during long Codex turns. It combines the previously measured renderer/server performance batch with a final lifecycle fix that stops discovery-only Codex app-server trees after a short burst-coalescing grace period.

The branch was audited as a whole against `main` before publication: 27 changed files across Electron startup, renderer streaming, provider event ingress/projection/persistence, Git diff statistics, and Codex discovery lifecycle. The audit traced the changed paths through their callers, caches, process teardown, pending-request handling, and focused tests. No additional correctness defect remained to fix.

## What changed

- Duty-cycle the Working shimmer and adaptively throttle streaming Shiki highlighting, eliminating needless per-frame blur/raster work while preserving live output.
- Enable Electron code caching for the desktop scheme.
- Remove redundant provider-event serialization and parsing, reduce delta payload retention, reuse SQLite prepared statements, and make event journal conflict handling insert-first.
- Read Git diff statistics without materializing full patches, including strict handling for disappearing untracked files.
- Stop idle discovery-only Codex app-server sessions after 15 seconds instead of retaining each process tree for ten minutes. Bounded discovery result caches remain intact; active thread sessions are unaffected.

No visible scroller-mask change is included. Replacing that mask remains an explicit design decision.

## Measurements

Two completed production-like Electron runs per arm, using the same isolated scratch repository and real Codex task:

| Metric | Before (`e17505500`) | Final (`881ed0d5b`) | Delta |
| --- | ---: | ---: | ---: |
| Average CPU | 38.3% | 31.0% | -19.1% |
| p95 CPU | 53.0% | 45.0% | -15.1% |
| Peak CPU | 118.1% | 106.6% | -9.8% |
| Average RSS | 1,254.9 MB | 1,065.9 MB | -15.1% |
| Peak RSS | 1,699.9 MB | 1,652.8 MB | -2.8% |
| Pre-task idle RSS | 891.6 MB | 749.1 MB | -16.0% |

The discovery lifecycle change specifically reduced average Codex app-server RSS from 313.1 MB to 104.9 MB (-66.5%) and removed six idle discovery processes after settling.

Caveats: tasks completed in 3m38s-5m28s rather than 8-10 minutes; effective sampling was approximately 0.44-0.50 Hz despite a requested 1 Hz cadence; the host had 32 GiB RAM; system load and provider/MCP startup peaks varied; and no paired T3 run was performed on this host. These results show a material controlled improvement within Synara, not proven T3 parity.

## Deep audit result

- Verified process teardown defers while discovery requests, approvals, or user inputs are pending, and the existing replacement barrier prevents overlapping replacement trees.
- Verified event deduplication, sequence-gap behavior, payload sizing, provider raw-payload reduction, Git error handling, and streaming throttle trailing updates.
- Confirmed renderer and server heaps release after the task; remaining peaks are primarily Codex/MCP helper startup, while steady CPU remains mainly native renderer/GPU work.
- No speculative cache resizing, journal batching, transcript reveal changes, or visual mask changes were added.

## Verification

- Focused Vitest: 14 files passed, 584 tests passed, 2 skipped.
- Browser Vitest: 3 tests passed.
- `bun fmt` passed.
- `bun lint` passed with 0 errors (444 existing workspace warnings).
- `bun typecheck` passed in all 7 packages.
- `bun run build:desktop` passed.

## Risk

A forced metadata refresh more than 15 seconds after the last discovery request now starts a fresh Codex app-server, trading a small refresh-startup cost for substantially lower idle memory. Normal cached discovery, adjacent startup bursts, and active coding sessions retain their existing behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex discovery process lifecycle and teardown timing. A refresh more than 15s after the last discovery request now pays a process-startup cost instead of reusing a long-lived idle tree.
> 
> **Overview**
> Cuts idle **discovery-only** Codex app-server process trees from a 10-minute hold to a **15s** burst-coalescing grace period. Cached discovery results stay; live thread sessions are unchanged.
> 
> After each discovery RPC settles, `sendRequest` now **restarts** the idle timer so in-flight work cannot be torn down at the original deadline. The timeout is injectable via `discoverySessionIdleMs` for tests.
> 
> A late metadata refresh after 15s of idle will spawn a fresh discovery process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 604bb15726c8fc3a048fd547c5b067c75b22d6d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->