### PR TITLE
Cut renderer/GPU cost of streaming and trim server event overhead

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -975,6 +975,10 @@ protocol.registerSchemesAsPrivileged([
       secure: true,
       supportFetchAPI: true,
       corsEnabled: true,
+      // Let V8 persist compiled bytecode for renderer bundles served over this scheme
+      // (Chromium only code-caches http(s) by default), so cold launches skip
+      // recompiling the multi-MB app bundle.
+      codeCache: true,
     },
   },
   {

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -344,11 +344,12 @@ function asString(value: unknown): string | undefined {
 }
 
 function normalizeCodexProcessLine(rawLine: string): string {
-  return rawLine.replaceAll(ANSI_ESCAPE_REGEX, "").trim();
+  return (
+    rawLine.includes(ANSI_ESCAPE_CHAR) ? rawLine.replaceAll(ANSI_ESCAPE_REGEX, "") : rawLine
+  ).trim();
 }
 
-function isIgnorableCodexProcessLine(rawLine: string): boolean {
-  const line = normalizeCodexProcessLine(rawLine);
+function isIgnorableCodexProcessLine(line: string): boolean {
   if (!line) {
     return true;
   }
@@ -367,10 +368,10 @@ function isCodexProtocolEnvelope(value: Record<string, unknown>): boolean {
   );
 }
 
-function logIgnoredCodexStdout(rawLine: string, reason: string): void {
+function logIgnoredCodexStdout(rawLine: string, line: string, reason: string): void {
   log.warn("ignoring non-protocol codex app-server stdout", {
     reason,
-    preview: normalizeCodexProcessLine(rawLine).slice(0, 160),
+    preview: line.slice(0, 160),
     length: rawLine.length,
   });
 }
@@ -871,10 +872,10 @@ export function parseCodexUserInputQuestions(
 }
 
 export function classifyCodexStderrLine(rawLine: string): { message: string } | null {
-  if (isIgnorableCodexProcessLine(rawLine)) {
+  const line = normalizeCodexProcessLine(rawLine);
+  if (isIgnorableCodexProcessLine(line)) {
     return null;
   }
-  const line = normalizeCodexProcessLine(rawLine);
 
   const match = line.match(CODEX_STDERR_LOG_REGEX);
   if (match) {
@@ -2872,7 +2873,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       if (context.stopping) return;
       try {
         for (const line of context.stdoutFramer.push(chunk)) {
-          if (!isIgnorableCodexProcessLine(line)) this.handleStdoutLine(context, line);
+          this.handleStdoutLine(context, line);
         }
       } catch (cause) {
         this.handleTransportFailure(context, cause);
@@ -2975,20 +2976,21 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     });
   }
 
-  private handleStdoutLine(context: CodexSessionContext, line: string): void {
+  private handleStdoutLine(context: CodexSessionContext, rawLine: string): void {
+    const line = normalizeCodexProcessLine(rawLine);
     if (isIgnorableCodexProcessLine(line)) {
       return;
     }
 
     let parsed: unknown;
     try {
-      parsed = JSON.parse(line);
+      parsed = JSON.parse(rawLine);
     } catch {
       // App-server stdout is JSONL, but Codex subprocesses and hooks can leak
       // arbitrary output onto the same pipe, including fragments that begin
       // like JSON-RPC. An unparseable line cannot be a usable protocol frame;
       // ignore it and let any affected request fail through its normal timeout.
-      logIgnoredCodexStdout(line, "invalid JSON fragment");
+      logIgnoredCodexStdout(rawLine, line, "invalid JSON fragment");
       return;
     }
 
@@ -2996,7 +2998,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     if (!protocolEnvelope || !isCodexProtocolEnvelope(protocolEnvelope)) {
       // Command output can also be valid standalone JSON (`{}`, `[]`, strings,
       // numbers). Only JSON-RPC-shaped envelopes belong to app-server itself.
-      logIgnoredCodexStdout(line, "valid JSON without a JSON-RPC envelope");
+      logIgnoredCodexStdout(rawLine, line, "valid JSON without a JSON-RPC envelope");
       return;
     }
 

--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
+import { summarizeUnifiedPatchTotals } from "@synara/shared/unifiedPatchStats";
 import { Effect, Exit, FileSystem, Layer, PlatformError, Schema, Scope, Stream } from "effect";
 import { describe, expect, vi } from "vitest";
 
@@ -2130,6 +2131,7 @@ it.layer(TestLayer)("git integration", (it) => {
         const tmp = yield* makeTmpDir();
         yield* initRepoWithCommit(tmp);
         const core = yield* GitCore;
+        const fileSystem = yield* FileSystem.FileSystem;
 
         yield* core.createBranch({ cwd: tmp, branch: "feature/diff-scopes" });
         yield* core.checkoutBranch({ cwd: tmp, branch: "feature/diff-scopes" });
@@ -2141,6 +2143,7 @@ it.layer(TestLayer)("git integration", (it) => {
         yield* git(tmp, ["add", "staged.txt"]);
         yield* writeTextFile(path.join(tmp, "README.md"), "# test\nunstaged change\n");
         yield* writeTextFile(path.join(tmp, "untracked.txt"), "untracked change\n");
+        yield* fileSystem.writeFile(path.join(tmp, "untracked.bin"), new Uint8Array([0, 1, 2, 3]));
 
         const branchPatch = (yield* core.readBranchPatch(tmp)).patch;
         expect(branchPatch).toContain("diff --git a/branch.txt b/branch.txt");
@@ -2157,6 +2160,75 @@ it.layer(TestLayer)("git integration", (it) => {
         expect(unstagedPatch).toContain("diff --git a/README.md b/README.md");
         expect(unstagedPatch).toContain("diff --git a/untracked.txt b/untracked.txt");
         expect(unstagedPatch).not.toContain("staged.txt");
+
+        const scopePatches = [
+          ["branch", branchPatch],
+          ["staged", stagedPatch],
+          ["unstaged", unstagedPatch],
+          ["workingTree", (yield* core.readWorkingTreePatch(tmp)).patch],
+        ] as const;
+        for (const [scope, patch] of scopePatches) {
+          expect(yield* core.readDiffStats(tmp, scope)).toEqual(
+            summarizeUnifiedPatchTotals(patch) ?? {
+              additions: 0,
+              deletions: 0,
+              fileCount: 0,
+            },
+          );
+        }
+      }),
+    );
+
+    it.effect("surfaces tracked numstat failures", () =>
+      Effect.gen(function* () {
+        const core = yield* makeIsolatedGitCore(() =>
+          Effect.succeed({
+            code: 128,
+            stdout: "",
+            stderr: "fatal: bad object",
+          }),
+        );
+
+        const result = yield* Effect.result(core.readDiffStats("/repo", "staged"));
+
+        expect(result._tag).toBe("Failure");
+        if (result._tag === "Failure") {
+          expect(result.failure).toMatchObject({
+            _tag: "GitCommandError",
+            operation: "GitCore.readDiffStats.tracked",
+            detail: "fatal: bad object",
+          });
+        }
+      }),
+    );
+
+    it.effect("surfaces untracked numstat failures instead of undercounting", () =>
+      Effect.gen(function* () {
+        const core = yield* makeIsolatedGitCore((input) => {
+          if (input.operation.endsWith(".untrackedFiles")) {
+            return Effect.succeed({ code: 0, stdout: "vanished.txt\0", stderr: "" });
+          }
+          if (input.operation.endsWith(".untrackedNumstat")) {
+            // `--no-index` also exits 1 when the path cannot be read.
+            return Effect.succeed({
+              code: 1,
+              stdout: "",
+              stderr: "error: Could not access 'vanished.txt'",
+            });
+          }
+          return Effect.succeed({ code: 0, stdout: "", stderr: "" });
+        });
+
+        const result = yield* Effect.result(core.readDiffStats("/repo", "unstaged"));
+
+        expect(result._tag).toBe("Failure");
+        if (result._tag === "Failure") {
+          expect(result.failure).toMatchObject({
+            _tag: "GitCommandError",
+            operation: "GitCore.readDiffStats.untrackedNumstat",
+            detail: "error: Could not access 'vanished.txt'",
+          });
+        }
       }),
     );
 

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -1601,6 +1601,92 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
         ),
       );
 
+    // `git diff --no-index` exits 1 both when it found differences (the expected
+    // outcome for an untracked file vs /dev/null) and when it could not read the
+    // path (e.g. the file vanished between `ls-files` and the diff). Only the former
+    // may be treated as success: it produces a numstat record and no stderr.
+    const readUntrackedNumstats = (cwd: string, operationPrefix: string) =>
+      runGitStdout(`${operationPrefix}.untrackedFiles`, cwd, [
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+        "-z",
+      ]).pipe(
+        Effect.map((stdout) => stdout.split("\0").filter((entry) => entry.length > 0)),
+        Effect.flatMap((untrackedFiles) =>
+          Effect.forEach(
+            untrackedFiles,
+            (filePath) => {
+              const operation = `${operationPrefix}.untrackedNumstat`;
+              const args = ["diff", "--no-index", "--numstat", "-z", "--", "/dev/null", filePath];
+              return executeGit(operation, cwd, args, {
+                allowNonZeroExit: true,
+                timeoutMs: WORKING_TREE_DIFF_TIMEOUT_MS,
+              }).pipe(
+                Effect.flatMap((result) => {
+                  const stderr = result.stderr.trim();
+                  if (
+                    result.code === 0 ||
+                    (result.code === 1 && stderr.length === 0 && result.stdout.length > 0)
+                  ) {
+                    return Effect.succeed(result.stdout);
+                  }
+                  return Effect.fail(
+                    createGitCommandError(
+                      operation,
+                      cwd,
+                      args,
+                      stderr.length > 0
+                        ? stderr
+                        : `${commandLabel(args)} failed: code=${result.code ?? "null"}`,
+                    ),
+                  );
+                }),
+              );
+            },
+            { concurrency: MAX_UNTRACKED_DIFF_CONCURRENCY },
+          ),
+        ),
+      );
+
+    const resolveBranchMergeBase = (cwd: string) =>
+      Effect.gen(function* () {
+        const details = yield* statusDetails(cwd);
+        const baseBranch =
+          details.upstreamRef ??
+          (details.branch
+            ? yield* resolveBaseBranchForNoUpstream(cwd, details.branch).pipe(
+                Effect.catch(() => Effect.succeed(null)),
+              )
+            : null);
+        if (!baseBranch) {
+          return yield* createGitCommandError(
+            "GitCore.readBranchPatch.base",
+            cwd,
+            ["merge-base", "<base>", "HEAD"],
+            "Cannot resolve a base branch for the current branch diff.",
+          );
+        }
+
+        const mergeBase = yield* executeGit(
+          "GitCore.readBranchPatch.mergeBase",
+          cwd,
+          ["merge-base", baseBranch, "HEAD"],
+          {
+            fallbackErrorMessage: "Cannot resolve the merge base for the current branch diff.",
+          },
+        ).pipe(Effect.map((result) => result.stdout.trim()));
+        if (mergeBase.length === 0) {
+          return yield* createGitCommandError(
+            "GitCore.readBranchPatch.mergeBase",
+            cwd,
+            ["merge-base", baseBranch, "HEAD"],
+            "Cannot resolve the merge base for the current branch diff.",
+          );
+        }
+        return mergeBase;
+      });
+
     const readUnstagedPatch: GitCoreShape["readUnstagedPatch"] = (cwd) =>
       Effect.gen(function* () {
         const trackedPatch = yield* executeGit(
@@ -1660,39 +1746,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
 
     const readBranchPatch: GitCoreShape["readBranchPatch"] = (cwd) =>
       Effect.gen(function* () {
-        const details = yield* statusDetails(cwd);
-        const baseBranch =
-          details.upstreamRef ??
-          (details.branch
-            ? yield* resolveBaseBranchForNoUpstream(cwd, details.branch).pipe(
-                Effect.catch(() => Effect.succeed(null)),
-              )
-            : null);
-        if (!baseBranch) {
-          return yield* createGitCommandError(
-            "GitCore.readBranchPatch.base",
-            cwd,
-            ["merge-base", "<base>", "HEAD"],
-            "Cannot resolve a base branch for the current branch diff.",
-          );
-        }
-
-        const mergeBase = yield* executeGit(
-          "GitCore.readBranchPatch.mergeBase",
-          cwd,
-          ["merge-base", baseBranch, "HEAD"],
-          {
-            fallbackErrorMessage: "Cannot resolve the merge base for the current branch diff.",
-          },
-        ).pipe(Effect.map((result) => result.stdout.trim()));
-        if (mergeBase.length === 0) {
-          return yield* createGitCommandError(
-            "GitCore.readBranchPatch.mergeBase",
-            cwd,
-            ["merge-base", baseBranch, "HEAD"],
-            "Cannot resolve the merge base for the current branch diff.",
-          );
-        }
+        const mergeBase = yield* resolveBranchMergeBase(cwd);
 
         const trackedPatch = yield* executeGit(
           "GitCore.readBranchPatch.trackedPatch",
@@ -1707,6 +1761,58 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
 
         return {
           patch: joinPatchSegments([trackedPatch, ...untrackedPatches]),
+        };
+      });
+
+    const readDiffStats: GitCoreShape["readDiffStats"] = (cwd, scope) =>
+      Effect.gen(function* () {
+        let trackedArgs: ReadonlyArray<string>;
+        let includeUntracked = false;
+        switch (scope) {
+          case "staged":
+            trackedArgs = ["diff", "--cached", "--numstat", "-z", "--no-ext-diff"];
+            break;
+          case "unstaged":
+            trackedArgs = ["diff", "--numstat", "-z", "--no-ext-diff"];
+            includeUntracked = true;
+            break;
+          case "branch": {
+            const mergeBase = yield* resolveBranchMergeBase(cwd);
+            trackedArgs = ["diff", "--numstat", "-z", "--minimal", "--no-ext-diff", mergeBase];
+            includeUntracked = true;
+            break;
+          }
+          case "workingTree":
+          default: {
+            const headExists = yield* executeGit(
+              "GitCore.readDiffStats.headExists",
+              cwd,
+              ["rev-parse", "--verify", "HEAD"],
+              { allowNonZeroExit: true },
+            ).pipe(Effect.map((result) => result.code === 0));
+            trackedArgs = [
+              "diff",
+              "--numstat",
+              "-z",
+              "--no-ext-diff",
+              headExists ? "HEAD" : EMPTY_TREE_OBJECT_ID,
+            ];
+            includeUntracked = true;
+          }
+        }
+
+        const tracked = yield* executeGit("GitCore.readDiffStats.tracked", cwd, trackedArgs, {
+          timeoutMs: WORKING_TREE_DIFF_TIMEOUT_MS,
+          maxOutputBytes: 10_000_000,
+        }).pipe(Effect.map((result) => result.stdout));
+        const untracked = includeUntracked
+          ? yield* readUntrackedNumstats(cwd, "GitCore.readDiffStats")
+          : [];
+        const totals = summarizeGitNumstatOutputs([tracked, ...untracked]);
+        return {
+          additions: totals.insertions,
+          deletions: totals.deletions,
+          fileCount: totals.files.length,
         };
       });
 
@@ -3313,6 +3419,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
       readUnstagedPatch,
       readStagedPatch,
       readBranchPatch,
+      readDiffStats,
       prepareCommitContext,
       commit,
       pushCurrentBranch,

--- a/apps/server/src/git/Layers/GitManager.ts
+++ b/apps/server/src/git/Layers/GitManager.ts
@@ -15,7 +15,6 @@ import {
   sanitizeFeatureBranchName,
 } from "@synara/shared/git";
 import { parseGitHubRepositoryNameWithOwnerFromRemoteUrl } from "@synara/shared/githubRepository";
-import { summarizeUnifiedPatchTotals } from "@synara/shared/unifiedPatchStats";
 import { resolveWorktreeHandoffIntent } from "@synara/shared/worktreeHandoff";
 
 import { GitManagerError } from "../Errors.ts";
@@ -1425,15 +1424,9 @@ export const makeGitManager = Effect.gen(function* () {
       }
     },
   );
-
-  // Same reason as summarizeDiff below: the badge surfaces need three integers, not the patch.
-  // Deriving them from the very patch readWorkingTreeDiff would have returned keeps the numbers
-  // identical to the ones a client-side parse produced, so no surface changes what it displays.
   const readWorkingTreeDiffStats: GitManagerShape["readWorkingTreeDiffStats"] = Effect.fnUntraced(
     function* (input) {
-      const { patch } = yield* readWorkingTreeDiff(input);
-      const totals = summarizeUnifiedPatchTotals(patch);
-      return totals ?? { additions: 0, deletions: 0, fileCount: 0 };
+      return yield* gitCore.readDiffStats(input.cwd, input.scope ?? "workingTree");
     },
   );
 

--- a/apps/server/src/git/Services/GitCore.ts
+++ b/apps/server/src/git/Services/GitCore.ts
@@ -28,6 +28,7 @@ import type {
   GitStashInfoResult,
   GitStatusInput,
   GitStatusResult,
+  GitWorkingTreeDiffStatsResult,
 } from "@synara/contracts";
 
 import type { GitCheckoutDirtyWorktreeError, GitCommandError } from "../Errors.ts";
@@ -62,6 +63,8 @@ export interface GitBranchContext {
   readonly branch: string | null;
   readonly upstreamRef: string | null;
 }
+
+export type GitDiffScope = "branch" | "staged" | "unstaged" | "workingTree";
 
 export interface GitPreparedCommitContext {
   stagedSummary: string;
@@ -235,6 +238,12 @@ export interface GitCoreShape {
    * Read aggregate branch changes from the upstream/base merge-base through the working tree.
    */
   readonly readBranchPatch: (cwd: string) => Effect.Effect<GitWorkingTreePatch, GitCommandError>;
+
+  /** Read aggregate diff counts without materializing a unified patch. */
+  readonly readDiffStats: (
+    cwd: string,
+    scope: GitDiffScope,
+  ) => Effect.Effect<GitWorkingTreeDiffStatsResult, GitCommandError>;
 
   /**
    * Build staged change context for commit generation.

--- a/apps/server/src/orchestration/providerRuntimeActivityProjection.test.ts
+++ b/apps/server/src/orchestration/providerRuntimeActivityProjection.test.ts
@@ -354,6 +354,44 @@ describe("provider runtime activity projection", () => {
     expect(providerActivityUpdateFingerprint(activity!)).toContain('"kind":"tool.updated"');
   });
 
+  it("keeps the fast JSON fingerprint byte-identical to the legacy JSON-like serializer", () => {
+    const [activity] = projectProviderRuntimeActivities(
+      runtimeEvent({
+        type: "tool.progress",
+        eventId: "tool-progress-fingerprint",
+        turnId: TURN_ID,
+        payload: {
+          toolUseId: "tool-fingerprint",
+          toolName: "mcp__github__fetch_pr",
+          summary: "Fetching PR",
+          elapsedSeconds: 2.4,
+        },
+      }),
+    );
+    const legacyFingerprint = JSON.stringify(
+      {
+        kind: activity!.kind,
+        summary: activity!.summary,
+        payload: activity!.payload,
+        turnId: activity!.turnId,
+      },
+      (() => {
+        const seen = new WeakSet<object>();
+        return (_key: string, entry: unknown) => {
+          if (typeof entry === "bigint") return entry.toString();
+          if (typeof entry === "function" || typeof entry === "symbol") return undefined;
+          if (entry && typeof entry === "object") {
+            if (seen.has(entry)) return "[Circular]";
+            seen.add(entry);
+          }
+          return entry;
+        };
+      })(),
+    );
+
+    expect(providerActivityUpdateFingerprint(activity!)).toBe(legacyFingerprint);
+  });
+
   it.each(["antigravity", "codex"] as const)(
     "projects %s tool lifecycle events through the same canonical activities",
     (provider) => {

--- a/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
+++ b/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
@@ -109,7 +109,33 @@ function truncateDetail(value: string, limit = 180): string {
   return value.length > limit ? `${value.slice(0, limit - 3)}...` : value;
 }
 
-function stringifyJsonLike(value: unknown): string {
+function isPlainJsonTree(value: unknown, seen: Set<object>): boolean {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean" ||
+    (typeof value === "number" && Number.isFinite(value))
+  ) {
+    return true;
+  }
+  if (typeof value !== "object") {
+    return false;
+  }
+  if (seen.has(value)) {
+    return false;
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.every((entry) => isPlainJsonTree(entry, seen));
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    return false;
+  }
+  return Object.values(value).every((entry) => isPlainJsonTree(entry, seen));
+}
+
+function stringifyJsonLikeFallback(value: unknown): string {
   const seen = new WeakSet<object>();
   return (
     JSON.stringify(value, (_key, entry) => {
@@ -128,6 +154,21 @@ function stringifyJsonLike(value: unknown): string {
       return entry;
     }) ?? "null"
   );
+}
+
+function serializeJsonLike(value: unknown): {
+  readonly text: string;
+  readonly plain: boolean;
+} {
+  const plain = isPlainJsonTree(value, new Set<object>());
+  return {
+    text: plain ? (JSON.stringify(value) ?? "null") : stringifyJsonLikeFallback(value),
+    plain,
+  };
+}
+
+function stringifyJsonLike(value: unknown): string {
+  return serializeJsonLike(value).text;
 }
 
 function truncateJsonString(value: string, limit: number): string {
@@ -250,9 +291,10 @@ function truncateJsonValue(
 }
 
 function boundActivityData(value: unknown): unknown {
-  const serialized = stringifyJsonLike(value);
+  const serialization = serializeJsonLike(value);
+  const serialized = serialization.text;
   if (serialized.length <= MAX_ACTIVITY_DATA_JSON_CHARS) {
-    return JSON.parse(serialized);
+    return serialization.plain ? value : JSON.parse(serialized);
   }
 
   const withTruncationMetadata = (bounded: unknown): Record<string, unknown> => {

--- a/apps/server/src/persistence/Layers/ProviderRuntimeEvents.ts
+++ b/apps/server/src/persistence/Layers/ProviderRuntimeEvents.ts
@@ -44,6 +44,8 @@ const StoredRowSchema = Schema.Struct({
   eventJson: Schema.String,
 });
 const decodeStoredRow = Schema.decodeUnknownEffect(StoredRowSchema);
+const SequenceRowSchema = Schema.Struct({ sequence: NonNegativeInt });
+const decodeSequenceRow = Schema.decodeUnknownEffect(SequenceRowSchema);
 
 /**
  * Longest-prefix string truncation that never splits a UTF-8 code point.
@@ -143,16 +145,12 @@ const make = Effect.gen(function* () {
       const persistable = yield* encodePersistableEvent(event);
       const persistedEvent = persistable.event;
       const eventJson = persistable.eventJson;
-      const rows = yield* sql
+      const appendResult = yield* sql
         .withTransaction(
           Effect.gen(function* () {
-            const existing = yield* sql<Record<string, unknown>>`
-            SELECT sequence, event_json AS "eventJson"
-            FROM provider_runtime_events
-            WHERE event_id = ${event.eventId}
-          `;
-            if (existing.length > 0) return existing;
-            return yield* sql<Record<string, unknown>>`
+            // SQLite reserves the AUTOINCREMENT rowid before conflict handling, so duplicate event
+            // IDs consume sequence values. Sequence is a cursor, not a dense counter; gaps are valid.
+            const inserted = yield* sql<Record<string, unknown>>`
             INSERT INTO provider_runtime_events (
               event_id, thread_id, turn_id, lifecycle_generation, event_type,
               event_json, persisted_at
@@ -161,22 +159,38 @@ const make = Effect.gen(function* () {
               ${event.lifecycleGeneration ?? null},
               ${event.type}, ${eventJson}, ${new Date().toISOString()}
             )
-            RETURNING sequence, event_json AS "eventJson"
+            ON CONFLICT(event_id) DO NOTHING
+            RETURNING sequence
+            `;
+            if (inserted[0] !== undefined) {
+              return { inserted: true as const, row: inserted[0] };
+            }
+
+            const existing = yield* sql<Record<string, unknown>>`
+              SELECT sequence, event_json AS "eventJson"
+              FROM provider_runtime_events
+              WHERE event_id = ${event.eventId}
           `;
+            return { inserted: false as const, row: existing[0] };
           }),
         )
         .pipe(Effect.mapError(toPersistenceSqlError("ProviderRuntimeEvent.append")));
-      const row = yield* decodeStoredRow(rows[0]).pipe(
-        Effect.mapError(toPersistenceDecodeError("ProviderRuntimeEvent.append.row")),
-      );
-      if (row.eventJson !== eventJson) {
+      const persisted = appendResult.inserted
+        ? yield* decodeSequenceRow(appendResult.row).pipe(
+            Effect.map((row) => ({ sequence: row.sequence, eventJson })),
+            Effect.mapError(toPersistenceDecodeError("ProviderRuntimeEvent.append.row")),
+          )
+        : yield* decodeStoredRow(appendResult.row).pipe(
+            Effect.mapError(toPersistenceDecodeError("ProviderRuntimeEvent.append.conflictRow")),
+          );
+      if (persisted.eventJson !== eventJson) {
         return yield* new PersistenceDecodeError({
           operation: "ProviderRuntimeEvent.append",
           issue: `Provider event '${event.eventId}' was reused with different content.`,
         });
       }
       return {
-        sequence: row.sequence,
+        sequence: persisted.sequence,
         event: persistedEvent,
       } satisfies PersistedProviderRuntimeEvent;
     });

--- a/apps/server/src/persistence/NodeSqliteClient.ts
+++ b/apps/server/src/persistence/NodeSqliteClient.ts
@@ -173,7 +173,7 @@ const makeWithDatabase = (
           return runValues(sql, params);
         },
         executeUnprepared(sql, params, rowTransform) {
-          const effect = runStatement(db.prepare(sql), params ?? [], false);
+          const effect = run(sql, params ?? []);
           return rowTransform ? Effect.map(effect, rowTransform) : effect;
         },
         executeStream(_sql, _params) {

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -60,7 +60,7 @@ import {
   isTerminalProviderRuntimeEvent,
   PROVIDER_RUNTIME_CALLBACK_BUFFER_MAX_BYTES,
   PROVIDER_RUNTIME_CALLBACK_TERMINAL_RESERVE,
-  providerRuntimeEventBytes,
+  type SizedProviderRuntimeEvent,
 } from "../providerRuntimeEventIngress.ts";
 import { teardownChildProcessTree } from "../supervisedProcessTeardown.ts";
 
@@ -917,14 +917,14 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
     const sessions = new Map<ThreadId, AntigravitySessionContext>();
     const defaultEffortByModel = new Map(Object.entries(DEFAULT_EFFORT_BY_MODEL));
 
-    const eventIngress = yield* makeBoundedCallbackIngress<ProviderRuntimeEvent, never, never>(
-      (event) => Queue.offer(eventQueue, event).pipe(Effect.asVoid),
+    const eventIngress = yield* makeBoundedCallbackIngress<SizedProviderRuntimeEvent, never, never>(
+      (item) => Queue.offer(eventQueue, item.event).pipe(Effect.asVoid),
       {
         capacity: PROVIDER_ADAPTER_RUNTIME_EVENT_BUFFER_CAPACITY,
         maxBufferedBytes: PROVIDER_RUNTIME_CALLBACK_BUFFER_MAX_BYTES,
         terminalReserve: PROVIDER_RUNTIME_CALLBACK_TERMINAL_RESERVE,
-        isTerminal: isTerminalProviderRuntimeEvent,
-        sizeOf: providerRuntimeEventBytes,
+        isTerminal: (item) => isTerminalProviderRuntimeEvent(item.event),
+        sizeOf: (item) => item.bytes,
       },
     );
 

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1524,6 +1524,7 @@ describe("ClaudeAdapterLive", () => {
       if (deltaEvent?.type === "content.delta") {
         assert.equal(deltaEvent.payload.delta, "Hi");
         assert.equal(String(deltaEvent.turnId), String(turn.turnId));
+        assert.deepEqual(deltaEvent.raw?.payload, {});
       }
 
       const toolStarted = runtimeEvents.find((event) => event.type === "item.started");

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -978,7 +978,11 @@ function classifyRequestType(toolName: string): CanonicalRequestType {
       : "dynamic_tool_call";
 }
 
-function summarizeToolRequest(toolName: string, input: Record<string, unknown>): string {
+function summarizeToolRequest(
+  toolName: string,
+  input: Record<string, unknown>,
+  serializedInput = JSON.stringify(input),
+): string {
   const commandValue = input.command ?? input.cmd;
   const command = typeof commandValue === "string" ? commandValue : undefined;
   if (command && command.trim().length > 0) {
@@ -986,12 +990,10 @@ function summarizeToolRequest(toolName: string, input: Record<string, unknown>):
     // command. Runtime-event display metadata must itself end trimmed.
     return `${toolName}: ${command.trim().slice(0, 400).trimEnd()}`;
   }
-
-  const serialized = JSON.stringify(input);
-  if (serialized.length <= 400) {
-    return `${toolName}: ${serialized}`;
+  if (serializedInput.length <= 400) {
+    return `${toolName}: ${serializedInput}`;
   }
-  return `${toolName}: ${serialized.slice(0, 397)}...`;
+  return `${toolName}: ${serializedInput.slice(0, 397)}...`;
 }
 
 // Tools whose result is surfaced through a dedicated runtime channel — AskUserQuestion
@@ -1463,12 +1465,24 @@ function exitPlanCaptureKey(input: {
     : `plan:${input.planMarkdown}`;
 }
 
-function tryParseJsonRecord(value: string): Record<string, unknown> | undefined {
+interface ParsedJsonRecord {
+  readonly value: Record<string, unknown>;
+  readonly serialized: string;
+}
+
+function tryParseCompleteJsonRecord(value: string): ParsedJsonRecord | undefined {
+  if (!value.trimEnd().endsWith("}")) {
+    return undefined;
+  }
   try {
     const parsed = JSON.parse(value);
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : undefined;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return undefined;
+    }
+    return {
+      value: parsed as Record<string, unknown>,
+      serialized: JSON.stringify(parsed),
+    };
   } catch {
     return undefined;
   }
@@ -2127,7 +2141,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
                   raw: {
                     source: "claude.sdk.message" as const,
                     ...(options.rawMethod ? { method: options.rawMethod } : {}),
-                    payload: options?.rawPayload,
+                    payload: {},
                   },
                 }
               : {}),
@@ -3013,11 +3027,14 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
     ): Effect.Effect<void> =>
       Effect.gen(function* () {
         const itemType = classifyToolItemType(input.toolName);
-        const detail = summarizeToolRequest(input.toolName, input.toolInput);
+        const serializedInput = toolInputFingerprint(input.toolInput);
         const inputFingerprint =
-          Object.keys(input.toolInput).length > 0
-            ? toolInputFingerprint(input.toolInput)
-            : undefined;
+          Object.keys(input.toolInput).length > 0 ? serializedInput : undefined;
+        const detail = summarizeToolRequest(
+          input.toolName,
+          input.toolInput,
+          serializedInput ?? undefined,
+        );
 
         const tool: ToolInFlight = {
           itemId: input.itemId,
@@ -3123,7 +3140,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               raw: {
                 source: "claude.sdk.message",
                 method: "claude/stream_event/content_block_delta",
-                payload: message,
+                payload: {},
               },
             });
             return;
@@ -3136,20 +3153,20 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             }
 
             const partialInputJson = tool.partialInputJson + event.delta.partial_json;
-            const parsedInput = tryParseJsonRecord(partialInputJson);
+            const parsedInput = tryParseCompleteJsonRecord(partialInputJson);
             const detail = parsedInput
-              ? summarizeToolRequest(tool.toolName, parsedInput)
+              ? summarizeToolRequest(tool.toolName, parsedInput.value, parsedInput.serialized)
               : tool.detail;
             let nextTool: ToolInFlight = {
               ...tool,
               partialInputJson,
-              ...(parsedInput ? { input: parsedInput } : {}),
+              ...(parsedInput ? { input: parsedInput.value } : {}),
               ...(detail ? { detail } : {}),
             };
 
             const nextFingerprint =
-              parsedInput && Object.keys(parsedInput).length > 0
-                ? toolInputFingerprint(parsedInput)
+              parsedInput && Object.keys(parsedInput.value).length > 0
+                ? parsedInput.serialized
                 : undefined;
             context.inFlightTools.set(event.index, nextTool);
 
@@ -3187,7 +3204,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               raw: {
                 source: "claude.sdk.message",
                 method: "claude/stream_event/content_block_delta/input_json_delta",
-                payload: message,
+                payload: {},
               },
             });
             if (nextTool.toolName === "TodoWrite") {
@@ -3335,7 +3352,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               raw: {
                 source: "claude.sdk.message",
                 method: "claude/user",
-                payload: message,
+                payload: {},
               },
             });
           }

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -614,10 +614,12 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
       if (events[0]?.type === "content.delta") {
         assert.equal(events[0].payload.streamKind, "reasoning_text");
         assert.equal(events[0].payload.contentIndex, 2);
+        assert.deepEqual(events[0].raw?.payload, {});
       }
       if (events[1]?.type === "content.delta") {
         assert.equal(events[1].payload.streamKind, "reasoning_summary_text");
         assert.equal(events[1].payload.summaryIndex, 1);
+        assert.deepEqual(events[1].raw?.payload, {});
       }
     }),
   );
@@ -1403,6 +1405,7 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
         assert.equal(events[2].itemId, "rs_reasoning_1");
         assert.equal(events[2].payload.streamKind, "reasoning_summary_text");
         assert.equal(events[2].payload.summaryIndex, 0);
+        assert.deepEqual(events[2].raw?.payload, {});
       }
 
       assert.equal(events[3]?.type, "task.completed");

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -78,7 +78,6 @@ import {
   PROVIDER_RUNTIME_CALLBACK_BUFFER_MAX_BYTES,
   PROVIDER_RUNTIME_CALLBACK_TERMINAL_RESERVE,
   PROVIDER_RUNTIME_INGRESS_EVENT_MAX_BYTES,
-  providerRuntimeEventBytes,
 } from "../providerRuntimeEventIngress.ts";
 import {
   makeUnmappedProviderEventGate,
@@ -110,9 +109,13 @@ interface CodexTurnWatchdogEntry {
 type CodexRuntimeIngressItem = {
   readonly nativeEvent: ProviderEvent;
   readonly runtimeEvents: ReadonlyArray<ProviderRuntimeEvent>;
+  readonly bytes: number;
 };
 
-function compactCodexNativeEventForIngress(event: ProviderEvent): ProviderEvent {
+function compactCodexNativeEventForIngress(event: ProviderEvent): {
+  readonly event: ProviderEvent;
+  readonly bytes: number;
+} {
   let originalBytes: number;
   try {
     originalBytes = Buffer.byteLength(JSON.stringify(event), "utf8");
@@ -120,9 +123,9 @@ function compactCodexNativeEventForIngress(event: ProviderEvent): ProviderEvent 
     originalBytes = PROVIDER_RUNTIME_INGRESS_EVENT_MAX_BYTES + 1;
   }
   if (originalBytes <= PROVIDER_RUNTIME_INGRESS_EVENT_MAX_BYTES) {
-    return event;
+    return { event, bytes: originalBytes };
   }
-  return {
+  const compactedEvent: ProviderEvent = {
     ...event,
     payload: {
       synaraTruncated: true,
@@ -130,19 +133,13 @@ function compactCodexNativeEventForIngress(event: ProviderEvent): ProviderEvent 
       originalBytes,
     },
   };
-}
-
-function codexRuntimeIngressItemBytes(item: CodexRuntimeIngressItem): number {
-  let nativeBytes: number;
+  let compactedBytes: number;
   try {
-    nativeBytes = Buffer.byteLength(JSON.stringify(item.nativeEvent), "utf8");
+    compactedBytes = Buffer.byteLength(JSON.stringify(compactedEvent), "utf8");
   } catch {
-    nativeBytes = PROVIDER_RUNTIME_INGRESS_EVENT_MAX_BYTES;
+    compactedBytes = PROVIDER_RUNTIME_INGRESS_EVENT_MAX_BYTES;
   }
-  return (
-    nativeBytes +
-    item.runtimeEvents.reduce((total, event) => total + providerRuntimeEventBytes(event), 0)
-  );
+  return { event: compactedEvent, bytes: compactedBytes };
 }
 
 export interface CodexAdapterLiveOptions {
@@ -817,6 +814,35 @@ function runtimeEventBase(
   };
 }
 
+function runtimeDeltaEventBase(
+  event: ProviderEvent,
+  canonicalThreadId: ThreadId,
+): Omit<ProviderRuntimeEvent, "type" | "payload"> {
+  return withMinimalRawPayload(runtimeEventBase(event, canonicalThreadId), event);
+}
+
+function codexDeltaEventBase(
+  event: ProviderEvent,
+  canonicalThreadId: ThreadId,
+): Omit<ProviderRuntimeEvent, "type" | "payload"> {
+  return withMinimalRawPayload(codexEventBase(event, canonicalThreadId), event);
+}
+
+function withMinimalRawPayload(
+  base: Omit<ProviderRuntimeEvent, "type" | "payload">,
+  event: ProviderEvent,
+): Omit<ProviderRuntimeEvent, "type" | "payload"> {
+  return {
+    ...base,
+    raw: {
+      source: base.raw?.source ?? eventRawSource(event),
+      ...(base.raw?.method !== undefined ? { method: base.raw.method } : {}),
+      ...(base.raw?.messageType !== undefined ? { messageType: base.raw.messageType } : {}),
+      payload: {},
+    },
+  };
+}
+
 function mapItemLifecycle(
   event: ProviderEvent,
   canonicalThreadId: ThreadId,
@@ -1304,7 +1330,7 @@ function mapToRuntimeEvents(
     }
     return [
       {
-        ...runtimeEventBase(event, canonicalThreadId),
+        ...runtimeDeltaEventBase(event, canonicalThreadId),
         type: "turn.proposed.delta",
         payload: {
           delta,
@@ -1330,7 +1356,7 @@ function mapToRuntimeEvents(
     }
     return [
       {
-        ...runtimeEventBase(event, canonicalThreadId),
+        ...runtimeDeltaEventBase(event, canonicalThreadId),
         type: "content.delta",
         payload: {
           streamKind: contentStreamKindFromMethod(event.method),
@@ -1486,7 +1512,7 @@ function mapToRuntimeEvents(
     }
     return [
       {
-        ...codexEventBase(event, canonicalThreadId),
+        ...codexDeltaEventBase(event, canonicalThreadId),
         type: "content.delta",
         payload: {
           streamKind:
@@ -1614,7 +1640,7 @@ function mapToRuntimeEvents(
     return [
       {
         type: "thread.realtime.audio.delta",
-        ...runtimeEventBase(event, canonicalThreadId),
+        ...runtimeDeltaEventBase(event, canonicalThreadId),
         payload: {
           audio: event.payload ?? {},
         },
@@ -2243,7 +2269,7 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
             maxBufferedBytes: PROVIDER_RUNTIME_CALLBACK_BUFFER_MAX_BYTES,
             terminalReserve: PROVIDER_RUNTIME_CALLBACK_TERMINAL_RESERVE,
             isTerminal: (item) => item.runtimeEvents.some(isTerminalProviderRuntimeEvent),
-            sizeOf: codexRuntimeIngressItemBytes,
+            sizeOf: (item) => item.bytes,
           },
         );
         const listener = (event: ProviderEvent) => {
@@ -2253,18 +2279,22 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
           const hasUnmappedEvent = mappedRuntimeEvents.some(
             (runtimeEvent) => runtimeEvent.type === "event.unmapped",
           );
-          const runtimeEvents = mappedRuntimeEvents
+          const sizedRuntimeEvents = mappedRuntimeEvents
             .filter(
               (runtimeEvent) =>
                 runtimeEvent.type !== "event.unmapped" || shouldSurfaceUnmappedEvent(event),
             )
             .map(compactProviderRuntimeEventForIngress);
+          const runtimeEvents = sizedRuntimeEvents.map((item) => item.event);
           trackTurnWatchdogActivity(event.threadId, runtimeEvents);
+          const nativeEvent = compactCodexNativeEventForIngress(
+            hasUnmappedEvent ? sanitizeUnmappedProviderEvent(event) : event,
+          );
           const result = ingress.offer({
-            nativeEvent: compactCodexNativeEventForIngress(
-              hasUnmappedEvent ? sanitizeUnmappedProviderEvent(event) : event,
-            ),
+            nativeEvent: nativeEvent.event,
             runtimeEvents,
+            bytes:
+              nativeEvent.bytes + sizedRuntimeEvents.reduce((total, item) => total + item.bytes, 0),
           });
           if (result === "terminal-overflow") {
             // This means the reserved terminal budget itself was exhausted.

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -80,7 +80,7 @@ import {
   isTerminalProviderRuntimeEvent,
   PROVIDER_RUNTIME_CALLBACK_BUFFER_MAX_BYTES,
   PROVIDER_RUNTIME_CALLBACK_TERMINAL_RESERVE,
-  providerRuntimeEventBytes,
+  type SizedProviderRuntimeEvent,
 } from "../providerRuntimeEventIngress.ts";
 import { clampUsagePercent, nonNegativeFiniteNumber, positiveFiniteNumber } from "../tokenUsage.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
@@ -1324,21 +1324,21 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         ? yield* makeEventNdjsonLogger(options.nativeEventLogPath, { stream: "native" })
         : undefined);
     const runtimeEventIngress = yield* makeBoundedCallbackIngress<
-      ProviderRuntimeEvent,
+      SizedProviderRuntimeEvent,
       never,
       never
     >(
-      (event) =>
-        (nativeEventLogger && event.raw
-          ? nativeEventLogger.write(event.raw, event.threadId).pipe(Effect.ignore)
+      (item) =>
+        (nativeEventLogger && item.event.raw
+          ? nativeEventLogger.write(item.event.raw, item.event.threadId).pipe(Effect.ignore)
           : Effect.void
-        ).pipe(Effect.andThen(Queue.offer(runtimeEventQueue, event)), Effect.asVoid),
+        ).pipe(Effect.andThen(Queue.offer(runtimeEventQueue, item.event)), Effect.asVoid),
       {
         capacity: PROVIDER_ADAPTER_RUNTIME_EVENT_BUFFER_CAPACITY,
         maxBufferedBytes: PROVIDER_RUNTIME_CALLBACK_BUFFER_MAX_BYTES,
         terminalReserve: PROVIDER_RUNTIME_CALLBACK_TERMINAL_RESERVE,
-        isTerminal: isTerminalProviderRuntimeEvent,
-        sizeOf: providerRuntimeEventBytes,
+        isTerminal: (item) => isTerminalProviderRuntimeEvent(item.event),
+        sizeOf: (item) => item.bytes,
       },
     );
 

--- a/apps/server/src/provider/providerRuntimeEventIngress.test.ts
+++ b/apps/server/src/provider/providerRuntimeEventIngress.test.ts
@@ -1,0 +1,58 @@
+import { EventId, ThreadId, TurnId, type ProviderRuntimeEvent } from "@synara/contracts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  compactProviderRuntimeEventForIngress,
+  PROVIDER_RUNTIME_INGRESS_EVENT_MAX_BYTES,
+} from "./providerRuntimeEventIngress.ts";
+
+function runtimeDelta(rawPayload: unknown): ProviderRuntimeEvent {
+  return {
+    type: "content.delta",
+    eventId: EventId.makeUnsafe("runtime-ingress-event"),
+    provider: "codex",
+    createdAt: "2026-08-20T00:00:00.000Z",
+    threadId: ThreadId.makeUnsafe("runtime-ingress-thread"),
+    turnId: TurnId.makeUnsafe("runtime-ingress-turn"),
+    payload: { streamKind: "assistant_text", delta: "hello" },
+    raw: {
+      source: "codex.app-server.notification",
+      method: "item/agentMessage/delta",
+      payload: rawPayload,
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("provider runtime event ingress sizing", () => {
+  it("measures a normal event once and carries its exact byte count", () => {
+    const event = runtimeDelta({ delta: "hello" });
+    const expectedBytes = Buffer.byteLength(JSON.stringify(event), "utf8");
+    const stringify = vi.spyOn(JSON, "stringify");
+    const sized = compactProviderRuntimeEventForIngress(event);
+
+    expect(sized.event).toBe(event);
+    expect(sized.bytes).toBe(expectedBytes);
+    expect(stringify).toHaveBeenCalledTimes(1);
+  });
+
+  it("measures the original and replacement objects once when compaction is required", () => {
+    const stringify = vi.spyOn(JSON, "stringify");
+    const event = runtimeDelta({
+      output: "x".repeat(PROVIDER_RUNTIME_INGRESS_EVENT_MAX_BYTES),
+    });
+    const sized = compactProviderRuntimeEventForIngress(event);
+    const callsBeforeAssertion = stringify.mock.calls.length;
+
+    expect(sized.event).not.toBe(event);
+    expect(sized.event.raw?.payload).toMatchObject({
+      synaraTruncated: true,
+      originalBytes: expect.any(Number),
+    });
+    expect(callsBeforeAssertion).toBe(2);
+    expect(sized.bytes).toBe(Buffer.byteLength(JSON.stringify(sized.event), "utf8"));
+  });
+});

--- a/apps/server/src/provider/providerRuntimeEventIngress.ts
+++ b/apps/server/src/provider/providerRuntimeEventIngress.ts
@@ -4,11 +4,15 @@ export const PROVIDER_RUNTIME_CALLBACK_BUFFER_MAX_BYTES = 32 * 1024 * 1024;
 export const PROVIDER_RUNTIME_CALLBACK_TERMINAL_RESERVE = 64;
 export const PROVIDER_RUNTIME_INGRESS_EVENT_MAX_BYTES = 512 * 1024;
 
+export interface SizedProviderRuntimeEvent {
+  readonly event: ProviderRuntimeEvent;
+  readonly bytes: number;
+}
+
 export function isTerminalProviderRuntimeEvent(event: ProviderRuntimeEvent): boolean {
   return event.type === "turn.completed" || event.type === "session.exited";
 }
-
-export function providerRuntimeEventBytes(event: ProviderRuntimeEvent): number {
+function providerRuntimeEventBytes(event: ProviderRuntimeEvent): number {
   try {
     return Buffer.byteLength(JSON.stringify(event), "utf8");
   } catch {
@@ -22,12 +26,12 @@ export function providerRuntimeEventBytes(event: ProviderRuntimeEvent): number {
  */
 export function compactProviderRuntimeEventForIngress(
   event: ProviderRuntimeEvent,
-): ProviderRuntimeEvent {
+): SizedProviderRuntimeEvent {
   const originalBytes = providerRuntimeEventBytes(event);
   if (originalBytes <= PROVIDER_RUNTIME_INGRESS_EVENT_MAX_BYTES || event.raw === undefined) {
-    return event;
+    return { event, bytes: originalBytes };
   }
-  return {
+  const compactedEvent: ProviderRuntimeEvent = {
     ...event,
     raw: {
       source: event.raw.source,
@@ -39,5 +43,9 @@ export function compactProviderRuntimeEventForIngress(
         originalBytes,
       },
     },
+  };
+  return {
+    event: compactedEvent,
+    bytes: providerRuntimeEventBytes(compactedEvent),
   };
 }

--- a/apps/web/perf/metrics.ts
+++ b/apps/web/perf/metrics.ts
@@ -125,8 +125,8 @@ export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/** Style-level cost toggles driven by URL params (animations=off, shimmer=off, scrollFade=off)
- *  so paired runs can isolate a single cost without code changes. */
+/** Style-level cost toggles driven by URL params (animations=off, shimmer=off, scrollFade=off,
+ *  glass=off|<filter>, mask=off) so paired runs can isolate a single cost without code changes. */
 export function installCostToggleStyles(): void {
   const params = new URLSearchParams(window.location.search);
   const style = document.createElement("style");
@@ -142,6 +142,24 @@ export function installCostToggleStyles(): void {
     style.textContent += `
       .shimmer {
         animation: none !important;
+      }
+    `;
+  }
+  // Composer glass: `glass=off` drops the backdrop blur; any other value is used verbatim
+  // as the filter (e.g. `glass=blur(20px)`), so paired runs can cost alternative radii.
+  const glass = params.get("glass");
+  if (glass !== null) {
+    style.textContent += `
+      :root {
+        --composer-glass-filter: ${glass === "off" ? "none" : glass} !important;
+      }
+    `;
+  }
+  if (params.get("mask") === "off") {
+    style.textContent += `
+      [data-chat-scroll-container] {
+        -webkit-mask-image: none !important;
+        mask-image: none !important;
       }
     `;
   }

--- a/apps/web/perf/pipeline.tsx
+++ b/apps/web/perf/pipeline.tsx
@@ -30,6 +30,12 @@ import {
 import { createRoot } from "react-dom/client";
 
 import { ChatTranscriptPane } from "../src/components/chat/ChatTranscriptPane";
+import { composerTranscriptBottomInsetPx } from "../src/components/chat/composerOverlay";
+import {
+  COMPOSER_INPUT_SHELL_CLASS_NAME,
+  COMPOSER_INPUT_SURFACE_CLASS_NAME,
+} from "../src/components/chat/composerPickerStyles";
+import { cn } from "../src/lib/utils";
 import { useStore } from "../src/store";
 import { createThreadSelector } from "../src/storeSelectors";
 import { makeActivity, makeDomainEvent, makeState, makeThread } from "../src/storeTestFixtures";
@@ -130,6 +136,15 @@ const params = new URLSearchParams(window.location.search);
 const seedMessageCount = Math.max(1, Number(params.get("messages") ?? 200));
 const working = params.get("working") !== "0";
 const instrumentLayout = params.get("instrument") === "1";
+// `composer=0` drops the floating composer overlay. By default the harness mounts the
+// same frosted composer surface the app floats over the transcript (and the matching
+// bottom inset + viewport mask), because that overlay is where the compositor cost of a
+// streaming turn lives and a transcript-only harness cannot see it.
+const composerOverlay = params.get("composer") !== "0";
+const COMPOSER_OVERLAY_HEIGHT_PX = 148;
+const composerInsetBottomPx = composerOverlay
+  ? composerTranscriptBottomInsetPx(COMPOSER_OVERLAY_HEIGHT_PX)
+  : 0;
 
 installCostToggleStyles();
 
@@ -483,8 +498,9 @@ function PipelineHarness() {
   );
 
   return (
-    <main className="flex h-screen min-h-0 w-screen bg-background text-foreground">
+    <main className="relative flex h-screen min-h-0 w-screen bg-background text-foreground">
       <ChatTranscriptPane
+        {...(composerInsetBottomPx ? { contentInsetBottomPx: composerInsetBottomPx } : {})}
         activeThreadId={THREAD_ID}
         activeTurnId={working ? STREAM_TURN_ID : null}
         activeTurnInProgress={working}
@@ -524,6 +540,22 @@ function PipelineHarness() {
         workspaceRoot={undefined}
         worktreeSetup={null}
       />
+      {composerOverlay ? (
+        // Same shell/surface classes as the real composer so index.css applies the
+        // identical glass (`.chat-composer-surface::before` backdrop-filter).
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center px-4"
+          style={{ height: COMPOSER_OVERLAY_HEIGHT_PX }}
+        >
+          <div className={cn(COMPOSER_INPUT_SHELL_CLASS_NAME, "w-full max-w-3xl")}>
+            <div
+              className={cn(COMPOSER_INPUT_SURFACE_CLASS_NAME, "h-32 rounded-3xl")}
+              data-perf-composer-overlay="true"
+            />
+          </div>
+        </div>
+      ) : null}
     </main>
   );
 }

--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -37,6 +37,17 @@ async function renderUserMarkdown(text: string) {
   );
 }
 
+describe("streamingCodeHighlightIntervalMs", () => {
+  it("keeps the base cadence for small blocks and stretches it with block size", async () => {
+    const { streamingCodeHighlightIntervalMs } = await import("./ChatMarkdown");
+    expect(streamingCodeHighlightIntervalMs(0)).toBe(160);
+    expect(streamingCodeHighlightIntervalMs(8_000)).toBe(160);
+    expect(streamingCodeHighlightIntervalMs(44_000)).toBe(580);
+    expect(streamingCodeHighlightIntervalMs(80_000)).toBe(1_000);
+    expect(streamingCodeHighlightIntervalMs(500_000)).toBe(1_000);
+  });
+});
+
 describe("ChatMarkdown", () => {
   it("uses the theme foreground token for markdown text", async () => {
     const markup = await renderMarkdown("Theme-aware text");

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -38,6 +38,7 @@ import { repairMarkdownTableDelimiters } from "../lib/markdownTableRepair";
 import { showFileReferenceContextMenu } from "../lib/fileReferenceContextMenu";
 import { useTheme } from "../hooks/useTheme";
 import { useSmoothStreamedText } from "../hooks/useSmoothStreamedText";
+import { useThrottledStreamingValue } from "../hooks/useThrottledStreamingValue";
 import { openWorkspaceFileReference, useWorkspaceFileOpener } from "../lib/workspaceFileOpener";
 import { resolveMarkdownFileLinkTarget, rewriteMarkdownFileUriHref } from "../markdown-links";
 import type { ExpandedImagePreview } from "./chat/ExpandedImagePreview";
@@ -945,12 +946,46 @@ function getSyntaxHighlightingModulePromise(): Promise<SyntaxHighlightingModule>
   return syntaxHighlightingModulePromise;
 }
 
+// While a message streams, its open code block grows on every reveal commit (~25/s) and
+// each commit re-tokenizes the whole block — quadratic in block length and the single
+// largest renderer cost of a code-heavy turn. Highlight at most this often while
+// streaming; the prefix already on screen stays put and the trailing value always lands,
+// so the block converges to exactly the settled highlight.
+// Each highlight costs roughly linearly in block length, so the cadence also stretches
+// with size: small blocks stay at the base interval, a block at
+// `STREAMING_CODE_HIGHLIGHT_SLOW_CHARS` is highlighted at most once per
+// `STREAMING_CODE_HIGHLIGHT_MAX_INTERVAL_MS`, keeping per-second tokenization work bounded.
+const STREAMING_CODE_HIGHLIGHT_INTERVAL_MS = 160;
+const STREAMING_CODE_HIGHLIGHT_MAX_INTERVAL_MS = 1_000;
+const STREAMING_CODE_HIGHLIGHT_BASE_CHARS = 8_000;
+const STREAMING_CODE_HIGHLIGHT_SLOW_CHARS = 80_000;
+
+export function streamingCodeHighlightIntervalMs(codeLength: number): number {
+  if (codeLength <= STREAMING_CODE_HIGHLIGHT_BASE_CHARS) {
+    return STREAMING_CODE_HIGHLIGHT_INTERVAL_MS;
+  }
+  const progress = Math.min(
+    1,
+    (codeLength - STREAMING_CODE_HIGHLIGHT_BASE_CHARS) /
+      (STREAMING_CODE_HIGHLIGHT_SLOW_CHARS - STREAMING_CODE_HIGHLIGHT_BASE_CHARS),
+  );
+  return Math.round(
+    STREAMING_CODE_HIGHLIGHT_INTERVAL_MS +
+      progress * (STREAMING_CODE_HIGHLIGHT_MAX_INTERVAL_MS - STREAMING_CODE_HIGHLIGHT_INTERVAL_MS),
+  );
+}
+
 function SuspenseShikiCodeBlock({
   language,
-  code,
+  code: liveCode,
   themeName,
   isStreaming,
 }: SuspenseShikiCodeBlockProps) {
+  const code = useThrottledStreamingValue(
+    liveCode,
+    isStreaming,
+    streamingCodeHighlightIntervalMs(liveCode.length),
+  );
   const syntaxHighlighting = use(getSyntaxHighlightingModulePromise());
   return (
     <LoadedShikiCodeBlock

--- a/apps/web/src/hooks/useThrottledStreamingValue.browser.tsx
+++ b/apps/web/src/hooks/useThrottledStreamingValue.browser.tsx
@@ -1,0 +1,60 @@
+// FILE: useThrottledStreamingValue.browser.tsx
+// Purpose: Hook-level regressions for the streaming value throttle — first change passes
+//          through, intermediate changes coalesce to the trailing edge, and deactivating
+//          snaps to the live value.
+// Layer: Web browser tests
+
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "vitest-browser-react";
+
+import { useThrottledStreamingValue } from "~/hooks/useThrottledStreamingValue";
+
+interface ThrottleProps {
+  readonly value: string;
+  readonly active: boolean;
+}
+
+const INTERVAL_MS = 200;
+
+function renderThrottle(initialProps: ThrottleProps) {
+  return renderHook(
+    (props?: ThrottleProps) =>
+      useThrottledStreamingValue(
+        props?.value ?? initialProps.value,
+        props?.active ?? initialProps.active,
+        INTERVAL_MS,
+      ),
+    { initialProps },
+  );
+}
+
+describe("useThrottledStreamingValue", () => {
+  it("passes values through verbatim while inactive", async () => {
+    const hook = await renderThrottle({ value: "a", active: false });
+    expect(hook.result.current).toBe("a");
+    await hook.rerender({ value: "ab", active: false });
+    expect(hook.result.current).toBe("ab");
+    await hook.unmount();
+  });
+
+  it("holds intermediate values back and lands the latest one on the trailing edge", async () => {
+    const hook = await renderThrottle({ value: "a", active: true });
+    expect(hook.result.current).toBe("a");
+    await hook.rerender({ value: "ab", active: true });
+    await hook.rerender({ value: "abc", active: true });
+    expect(hook.result.current).toBe("a");
+    await vi.waitFor(() => expect(hook.result.current).toBe("abc"), {
+      timeout: INTERVAL_MS * 4,
+    });
+    await hook.unmount();
+  });
+
+  it("snaps to the live value the moment streaming ends", async () => {
+    const hook = await renderThrottle({ value: "a", active: true });
+    await hook.rerender({ value: "ab", active: true });
+    expect(hook.result.current).toBe("a");
+    await hook.rerender({ value: "abc", active: false });
+    expect(hook.result.current).toBe("abc");
+    await hook.unmount();
+  });
+});

--- a/apps/web/src/hooks/useThrottledStreamingValue.test.ts
+++ b/apps/web/src/hooks/useThrottledStreamingValue.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { planThrottledCommit } from "./useThrottledStreamingValue";
+
+describe("planThrottledCommit", () => {
+  it("commits immediately at the start of a burst", () => {
+    expect(planThrottledCommit(0, 1_000, 160)).toEqual({ immediate: true });
+  });
+
+  it("commits immediately once the interval has elapsed", () => {
+    expect(planThrottledCommit(1_000, 1_160, 160)).toEqual({ immediate: true });
+    expect(planThrottledCommit(1_000, 1_500, 160)).toEqual({ immediate: true });
+  });
+
+  it("defers to the trailing edge of the current interval otherwise", () => {
+    expect(planThrottledCommit(1_000, 1_040, 160)).toEqual({ immediate: false, delayMs: 120 });
+    expect(planThrottledCommit(1_000, 1_159, 160)).toEqual({ immediate: false, delayMs: 1 });
+  });
+});

--- a/apps/web/src/hooks/useThrottledStreamingValue.ts
+++ b/apps/web/src/hooks/useThrottledStreamingValue.ts
@@ -1,0 +1,84 @@
+// FILE: useThrottledStreamingValue.ts
+// Purpose: Rate-limit how often a fast-changing streamed value reaches an expensive
+//          consumer (e.g. a Shiki re-highlight of a growing code block) while a message is
+//          streaming, without ever dropping the final value.
+// Layer: Web UI streaming primitive
+// Exports: useThrottledStreamingValue, planThrottledCommit (pure, unit-tested)
+// Why: The reveal cadence (useSmoothStreamedText, ~25 commits/s) is right for prose but
+//      far too fast for consumers whose cost grows with the value — re-tokenizing a whole
+//      code block 25×/s is quadratic in its length. This hook passes the first change
+//      through immediately, then coalesces further changes to at most one per
+//      `intervalMs` (trailing edge always delivered). When `active` is false the value is
+//      returned verbatim, so settled content never lags.
+
+import { useEffect, useRef, useState } from "react";
+
+export type ThrottledCommitPlan =
+  | { readonly immediate: true }
+  | { readonly immediate: false; readonly delayMs: number };
+
+/**
+ * Decide whether a new value may commit now or must wait for the trailing edge of the
+ * current interval. `lastCommitAtMs === 0` marks a fresh burst and always commits.
+ */
+export function planThrottledCommit(
+  lastCommitAtMs: number,
+  nowMs: number,
+  intervalMs: number,
+): ThrottledCommitPlan {
+  const elapsed = lastCommitAtMs === 0 ? Number.POSITIVE_INFINITY : nowMs - lastCommitAtMs;
+  return elapsed >= intervalMs
+    ? { immediate: true }
+    : { immediate: false, delayMs: Math.max(0, intervalMs - elapsed) };
+}
+
+export function useThrottledStreamingValue<T>(value: T, active: boolean, intervalMs: number): T {
+  const [throttled, setThrottled] = useState(value);
+  const lastCommitAtRef = useRef(0);
+  const timerRef = useRef<number | null>(null);
+  const latestRef = useRef(value);
+
+  useEffect(() => {
+    latestRef.current = value;
+    const clearTimer = () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+    if (!active) {
+      clearTimer();
+      lastCommitAtRef.current = 0;
+      setThrottled(value);
+      return;
+    }
+    const plan = planThrottledCommit(lastCommitAtRef.current, performance.now(), intervalMs);
+    if (plan.immediate) {
+      clearTimer();
+      lastCommitAtRef.current = performance.now();
+      setThrottled(value);
+      return;
+    }
+    if (timerRef.current !== null) {
+      // A trailing commit is already scheduled; it reads the latest value when it fires.
+      return;
+    }
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null;
+      lastCommitAtRef.current = performance.now();
+      setThrottled(latestRef.current);
+    }, plan.delayMs);
+  }, [active, intervalMs, value]);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    },
+    [],
+  );
+
+  return active ? throttled : value;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2191,6 +2191,8 @@ label:has(> select#reasoning-effort) select {
    "Working for …" status line via the `shimmer` class. Provides `shimmer`,
    `shimmer-duration-*`, `shimmer-spread-*`, `shimmer-angle-*`,
    `shimmer-color-*`, `shimmer-once`, `shimmer-reverse`, and `shimmer-none`.
+   One deliberate deviation: the animation is duty-cycled via `--shimmer-timing`
+   (see the note inside `@utility shimmer`).
    Docs: https://ui.shadcn.com/docs/utils/shimmer */
 @property --shimmer-angle {
   syntax: "<angle>";
@@ -2239,7 +2241,15 @@ label:has(> select#reasoning-effort) select {
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: var(--shimmer-text-fill, transparent);
-  animation: tw-shimmer var(--shimmer-duration, 2s) linear infinite;
+  /* Local deviation from the vendored utility: the sweep is duty-cycled with a stepped
+     timing function instead of `linear`. A `background-position` animation on a
+     `background-clip: text` element cannot run on the compositor, so every animation
+     frame re-rasterizes the label and — because the "Working…" line sits under the
+     composer's backdrop blur — re-blurs the glass. At 120 Hz that is ~240 repaints per
+     2 s cycle; 60 steps keep 30 hops/s (video-smooth on a label this small) and measured
+     ~-6 CPU points (renderer + GPU process) on the transcript perf harness while
+     streaming. `--shimmer-timing` lets a caller restore `linear` where the hop would show. */
+  animation: tw-shimmer var(--shimmer-duration, 2s) var(--shimmer-timing, steps(60)) infinite;
 
   @variant dark {
     --_highlight: var(


### PR DESCRIPTION
## Summary

First batch from the Synara-vs-T3-Code performance comparison. Targets the renderer/GPU cost that dominated streaming, plus server-side serialization and Git-stat overhead. No visible UI change.

## What changed

**Renderer**
- `.shimmer` now animates with `steps(60)` (`apps/web/src/index.css`). The shimmer on the "Working…" label sits under the composer's `backdrop-filter: blur(40px)` glass; a continuous `background-position` animation forced a re-raster + re-blur every frame. Duty-cycling keeps the same 2 s sweep, visually identical, at a fraction of the GPU work.
- Streaming Shiki re-highlighting is throttled via the new `useThrottledStreamingValue` hook, with a size-adaptive interval (`streamingCodeHighlightIntervalMs`: 160 ms ≤ 8k chars → 1 s at 80k chars). Trailing commit always lands, so the block converges to the exact settled highlight.
- Electron `codeCache: true` on the desktop scheme (`apps/desktop/src/main.ts`).
- Perf harness: composer overlay + `glass` / `mask` / `composer=0` cost toggles (`apps/web/perf/*`).

**Server**
- `providerRuntimeEventIngress` returns `{event, bytes}` (no double serialization); Codex/Claude delta events carry `raw.payload: {}`; ClaudeAdapter `input_json_delta` parse is gated on a complete object and serialized once.
- `ProviderRuntimeEvents` journal insert is insert-first (`ON CONFLICT(event_id) DO NOTHING RETURNING sequence`).
- `NodeSqliteClient.executeUnprepared` reuses the prepared-statement cache (defaults unchanged).
- `codexAppServerManager`: ANSI-strip fast path, JSON parsed from the raw stdout line.
- `providerRuntimeActivityProjection`: plain-JSON fast path.
- `GitCore.readDiffStats` (tracked `--numstat` + per-file `diff --no-index` for untracked files, strict error handling) replaces patch materialization in `GitManager` for diff statistics.

## Measurements

Renderer harness (`apps/web/perf/pipeline.tsx`, headless Chromium, 30 s × 2, whole Chromium process tree):

| Metric | Before | After | Δ |
| --- | ---: | ---: | ---: |
| CPU avg | 30.5% | 23.8% | −22% |
| CPU p95 | 37.0% | 29.8% | −19% |
| Renderer CPU | 21.7% | 18.6% | −14% |
| GPU process CPU | 8.8% | 5.0% | −43% |
| Dropped frames (>20 ms) | 2 | 0.5 | — |
| JS heap | — | — | −13% |

End-to-end production-like Electron runs (same isolated scratch repo, real Codex task, 2 runs per arm, whole Synara process tree incl. provider child; from the follow-up benchmark in #764):

| Metric | Before (`e17505500`) | This PR (`80e683a0d`) | Δ |
| --- | ---: | ---: | ---: |
| Average CPU | 38.3% | 34.4% | −10.2% |
| p95 CPU | 53.0% | 46.3% | −12.6% |
| Peak CPU | 118.1% | 98.9% | −16.3% |
| Average RSS | 1,254.9 MB | 1,201.3 MB | −4.3% |
| Peak RSS | 1,699.9 MB | 1,452.8 MB | −14.5% |

Caveats: e2e tasks ran 3.6–5.5 min (not 8–10), sampling ~0.5 Hz, provider/MCP startup variance is large (reported separately in #764).

## Review

Independently reviewed by gpt-5.6-sol (xhigh); its one finding (untracked `--no-index` numstat accepted exit-1-with-stderr as success and silently dropped the file) is fixed here with a regression test. Its suggestion to bump the SQLite prepare cache was dropped for lack of hit-rate data.

## Verification

- `bun fmt`, `bun lint` (0 errors), `bun typecheck` pass.
- Server suite green (GitCore/GitManager, persistence, provider adapters, ingress); new unit + browser tests for `useThrottledStreamingValue` and `streamingCodeHighlightIntervalMs`.

## Stack

#764 (idle Codex discovery-session teardown + full e2e benchmark report) is stacked on top of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persistence insert/conflict handling, git diff-stat correctness, and strips diagnostic raw payloads from high-volume runtime events. Logic is performance-oriented with tests, but a bug could undercount diffs or drop event diagnostics.
> 
> **Overview**
> Cuts streaming renderer/GPU work and server-side serialization without intended UI changes.
> 
> **Renderer:** duty-cycles the “Working…” shimmer (`steps(60)`) so backdrop-blur glass is not re-rasterized every frame; throttles Shiki re-highlight of growing code blocks via `useThrottledStreamingValue` (160ms–1s by size, trailing value always lands); enables Electron `codeCache` on the desktop scheme. Perf harness now includes the composer glass overlay and extra cost toggles.
> 
> **Server events:** ingress sizing returns `{event, bytes}` once; Codex/Claude delta `raw.payload` is emptied; Claude `input_json_delta` only parses complete objects and reuses one stringify. Runtime-event append is insert-first (`ON CONFLICT DO NOTHING`); SQLite `executeUnprepared` uses the prepared-statement cache. Codex stdout ANSI-strip is a fast path; activity fingerprints skip a custom serializer for plain JSON.
> 
> **Git:** `readWorkingTreeDiffStats` uses `GitCore.readDiffStats` (`--numstat` + untracked `--no-index`) instead of materializing unified patches. Untracked exit-1-with-stderr is now a hard error so vanished files are not silently undercounted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80e683a0d7c85ccf448584fb4e3c44494da2e617. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->