### PR TITLE
Resume in-flight chats after desktop quit

### DIFF
--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -80,6 +80,7 @@ export interface ServerDerivedPaths {
   readonly logsDir: string;
   readonly serverLogPath: string;
   readonly serverRuntimeStatePath: string;
+  readonly quitResumeStatePath: string;
   readonly providerLogsDir: string;
   readonly providerEventLogPath: string;
   readonly terminalLogsDir: string;
@@ -158,6 +159,7 @@ export const deriveServerPaths = Effect.fn(function* (
     logsDir,
     serverLogPath: join(logsDir, "server.log"),
     serverRuntimeStatePath: join(stateDir, "server-runtime.json"),
+    quitResumeStatePath: join(stateDir, "quit-resume.json"),
     providerLogsDir,
     providerEventLogPath: join(providerLogsDir, "events.log"),
     terminalLogsDir: join(logsDir, "terminals"),

--- a/apps/server/src/effectServer.ts
+++ b/apps/server/src/effectServer.ts
@@ -31,7 +31,10 @@ import {
 import { OrchestrationReactor } from "./orchestration/Services/OrchestrationReactor";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery";
 import { ThreadDeletionReactor } from "./orchestration/Services/ThreadDeletionReactor";
-import { resumeQuitInterruptedChats } from "./orchestration/quitResume";
+import {
+  claimQuitResumeRecordAtStartup,
+  resumeQuitInterruptedChats,
+} from "./orchestration/quitResume";
 import { reconcileRestartStuckTurns } from "./orchestration/startupTurnReconciliation";
 import { ProviderSessionReaper } from "./provider/Services/ProviderSessionReaper";
 import { ProviderRuntimeReconciler } from "./provider/Services/ProviderRuntimeReconciler";
@@ -224,11 +227,13 @@ export const createEffectServer = Effect.fn(function* (
       (cause) => new ServerLifecycleError({ operation: "recoverGitHandoffOperations", cause }),
     ),
   );
+  // Claim the previous quit's "Resume chats automatically" record while no
+  // command (and so no new quit) can run yet; a missing record costs one stat.
+  const quitResumeRecord = yield* claimQuitResumeRecordAtStartup;
   yield* runtimeStartup.markCommandReady;
-  // Chats the user quit with "Resume chats automatically" get their continuation
-  // turn now that the orphaned turns above are settled. Forked so the (rare)
-  // dispatch work never delays readiness; a missing record costs one stat.
-  yield* resumeQuitInterruptedChats.pipe(Effect.forkIn(subscriptionsScope));
+  // The recorded chats get their continuation turn now that the orphaned turns
+  // above are settled. Forked so the (rare) dispatch work never delays readiness.
+  yield* resumeQuitInterruptedChats(quitResumeRecord).pipe(Effect.forkIn(subscriptionsScope));
 
   yield* lifecycleEvents.publish({
     type: "welcome",

--- a/apps/server/src/effectServer.ts
+++ b/apps/server/src/effectServer.ts
@@ -31,6 +31,7 @@ import {
 import { OrchestrationReactor } from "./orchestration/Services/OrchestrationReactor";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery";
 import { ThreadDeletionReactor } from "./orchestration/Services/ThreadDeletionReactor";
+import { resumeQuitInterruptedChats } from "./orchestration/quitResume";
 import { reconcileRestartStuckTurns } from "./orchestration/startupTurnReconciliation";
 import { ProviderSessionReaper } from "./provider/Services/ProviderSessionReaper";
 import { ProviderRuntimeReconciler } from "./provider/Services/ProviderRuntimeReconciler";
@@ -224,6 +225,10 @@ export const createEffectServer = Effect.fn(function* (
     ),
   );
   yield* runtimeStartup.markCommandReady;
+  // Chats the user quit with "Resume chats automatically" get their continuation
+  // turn now that the orphaned turns above are settled. Forked so the (rare)
+  // dispatch work never delays readiness; a missing record costs one stat.
+  yield* resumeQuitInterruptedChats.pipe(Effect.forkIn(subscriptionsScope));
 
   yield* lifecycleEvents.publish({
     type: "welcome",

--- a/apps/server/src/orchestration/commandInvariants.ts
+++ b/apps/server/src/orchestration/commandInvariants.ts
@@ -479,39 +479,48 @@ export function requireNonNegativeInteger(input: {
 
 export type ThreadResumePreconditionViolation =
   | "thread-archived"
-  | "turn-changed"
   | "turn-completed"
   | "turn-in-flight";
 
 export interface ThreadResumePrecondition {
-  readonly expectedLatestTurnId: TurnId;
+  /** Turn in flight when the chat was recorded; null while the provider was still connecting. */
+  readonly recordedTurnId: TurnId | null;
+  readonly recordedAt: string;
 }
 
 /**
  * Shared by the boot-time quit-resume planner and the decider: a chat remembered
- * at quit is continued only while the thread is still exactly as it was recorded
- * — not archived, same latest turn, nothing in flight — and that turn did not
- * finish on its own (a naturally completed turn has nothing to continue; an
- * interrupted or errored one does).
+ * at quit is continued only while the thread is not archived, has nothing in
+ * flight, and no turn finished on its own since the record was taken — neither
+ * the recorded turn (it was running then, so it can only have completed later)
+ * nor any newer one. A turn that completed before the record is the previous
+ * turn of a chat that was still connecting and does not count; an interrupted or
+ * errored turn is exactly what a continuation is for.
  */
 export function threadResumePreconditionViolation(
   thread: {
     readonly archivedAt?: string | null | undefined;
     readonly session: Pick<OrchestrationSession, "status" | "activeTurnId"> | null;
-    readonly latestTurn: Pick<OrchestrationLatestTurn, "turnId" | "state"> | null;
+    readonly latestTurn: Pick<OrchestrationLatestTurn, "turnId" | "state" | "completedAt"> | null;
   },
   precondition: ThreadResumePrecondition,
 ): ThreadResumePreconditionViolation | null {
   if (thread.archivedAt != null) {
     return "thread-archived";
   }
-  if ((thread.latestTurn?.turnId ?? null) !== precondition.expectedLatestTurnId) {
-    return "turn-changed";
-  }
   if (threadHasInFlightTurn(thread)) {
     return "turn-in-flight";
   }
-  if (thread.latestTurn?.state === "completed") {
+  const latestTurn = thread.latestTurn;
+  if (
+    latestTurn !== null &&
+    latestTurn.state === "completed" &&
+    (latestTurn.turnId === precondition.recordedTurnId ||
+      // A completed turn without a completion time is unknowable; stay on the
+      // side of not sending an unwanted message.
+      latestTurn.completedAt === null ||
+      latestTurn.completedAt >= precondition.recordedAt)
+  ) {
     return "turn-completed";
   }
   return null;
@@ -524,8 +533,6 @@ export function threadResumePreconditionDetail(
   switch (violation) {
     case "thread-archived":
       return `Thread '${threadId}' was archived after it was remembered for resume.`;
-    case "turn-changed":
-      return `Thread '${threadId}' moved on after it was remembered for resume.`;
     case "turn-completed":
       return `Thread '${threadId}' finished on its own; there is nothing to resume.`;
     case "turn-in-flight":

--- a/apps/server/src/orchestration/commandInvariants.ts
+++ b/apps/server/src/orchestration/commandInvariants.ts
@@ -12,6 +12,7 @@ import type {
   ProjectId,
   SpaceId,
   ThreadId,
+  TurnId,
 } from "@synara/contracts";
 import { THREAD_NOT_ARCHIVED_INVARIANT_MARKER } from "@synara/shared/errorMessages";
 import {
@@ -474,4 +475,60 @@ export function requireNonNegativeInteger(input: {
       `${input.field} must be an integer greater than or equal to 0.`,
     ),
   );
+}
+
+export type ThreadResumePreconditionViolation =
+  | "thread-archived"
+  | "turn-changed"
+  | "turn-completed"
+  | "turn-in-flight";
+
+export interface ThreadResumePrecondition {
+  readonly expectedLatestTurnId: TurnId;
+}
+
+/**
+ * Shared by the boot-time quit-resume planner and the decider: a chat remembered
+ * at quit is continued only while the thread is still exactly as it was recorded
+ * — not archived, same latest turn, nothing in flight — and that turn did not
+ * finish on its own (a naturally completed turn has nothing to continue; an
+ * interrupted or errored one does).
+ */
+export function threadResumePreconditionViolation(
+  thread: {
+    readonly archivedAt?: string | null | undefined;
+    readonly session: Pick<OrchestrationSession, "status" | "activeTurnId"> | null;
+    readonly latestTurn: Pick<OrchestrationLatestTurn, "turnId" | "state"> | null;
+  },
+  precondition: ThreadResumePrecondition,
+): ThreadResumePreconditionViolation | null {
+  if (thread.archivedAt != null) {
+    return "thread-archived";
+  }
+  if ((thread.latestTurn?.turnId ?? null) !== precondition.expectedLatestTurnId) {
+    return "turn-changed";
+  }
+  if (threadHasInFlightTurn(thread)) {
+    return "turn-in-flight";
+  }
+  if (thread.latestTurn?.state === "completed") {
+    return "turn-completed";
+  }
+  return null;
+}
+
+export function threadResumePreconditionDetail(
+  threadId: ThreadId,
+  violation: ThreadResumePreconditionViolation,
+): string {
+  switch (violation) {
+    case "thread-archived":
+      return `Thread '${threadId}' was archived after it was remembered for resume.`;
+    case "turn-changed":
+      return `Thread '${threadId}' moved on after it was remembered for resume.`;
+    case "turn-completed":
+      return `Thread '${threadId}' finished on its own; there is nothing to resume.`;
+    case "turn-in-flight":
+      return `Thread '${threadId}' already has a turn in flight.`;
+  }
 }

--- a/apps/server/src/orchestration/decider.resumePrecondition.test.ts
+++ b/apps/server/src/orchestration/decider.resumePrecondition.test.ts
@@ -1,0 +1,139 @@
+import {
+  CommandId,
+  DEFAULT_PROVIDER_INTERACTION_MODE,
+  MessageId,
+  ProjectId,
+  ThreadId,
+  TurnId,
+  type OrchestrationCommand,
+  type OrchestrationLatestTurn,
+  type OrchestrationReadModel,
+  type OrchestrationSession,
+} from "@synara/contracts";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { decideOrchestrationCommand } from "./decider.ts";
+
+const NOW = "2026-07-19T00:00:00.000Z";
+const THREAD_ID = ThreadId.makeUnsafe("thread-resume");
+const RECORDED_TURN_ID = TurnId.makeUnsafe("turn-recorded");
+
+function makeReadModel(input: {
+  readonly session?: OrchestrationSession | null;
+  readonly latestTurn?: OrchestrationLatestTurn | null;
+  readonly archivedAt?: string;
+}): OrchestrationReadModel {
+  return {
+    snapshotSequence: 1,
+    updatedAt: NOW,
+    spaces: [],
+    projects: [],
+    threads: [
+      {
+        id: THREAD_ID,
+        projectId: ProjectId.makeUnsafe("project-resume"),
+        title: "Resume",
+        modelSelection: { provider: "codex", model: "gpt-5-codex" },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "full-access",
+        branch: null,
+        worktreePath: null,
+        createdAt: NOW,
+        updatedAt: NOW,
+        latestTurn: input.latestTurn ?? null,
+        handoff: null,
+        messages: [],
+        session: input.session ?? null,
+        activities: [],
+        proposedPlans: [],
+        checkpoints: [],
+        deletedAt: null,
+        ...(input.archivedAt !== undefined ? { archivedAt: input.archivedAt } : {}),
+      },
+    ],
+  };
+}
+
+function makeLatestTurn(
+  state: OrchestrationLatestTurn["state"],
+  id: TurnId = RECORDED_TURN_ID,
+): OrchestrationLatestTurn {
+  return {
+    turnId: id,
+    state,
+    requestedAt: NOW,
+    startedAt: NOW,
+    completedAt: state === "running" ? null : NOW,
+    assistantMessageId: null,
+  };
+}
+
+function resumeTurnStart(): OrchestrationCommand {
+  return {
+    type: "thread.turn.start",
+    commandId: CommandId.makeUnsafe("cmd-resume"),
+    threadId: THREAD_ID,
+    message: {
+      messageId: MessageId.makeUnsafe("message-resume"),
+      role: "user",
+      text: "Continue where you left off.",
+      attachments: [],
+    },
+    dispatchMode: "queue",
+    interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+    runtimeMode: "full-access",
+    resumePrecondition: { expectedLatestTurnId: RECORDED_TURN_ID },
+    createdAt: NOW,
+  };
+}
+
+const decide = (readModel: OrchestrationReadModel) =>
+  decideOrchestrationCommand({ command: resumeTurnStart(), readModel });
+
+const expectRejected = async (readModel: OrchestrationReadModel, detail: string) => {
+  const error = await Effect.runPromise(Effect.flip(decide(readModel)));
+  expect(error).toMatchObject({
+    _tag: "OrchestrationCommandInvariantError",
+    commandType: "thread.turn.start",
+    detail,
+  });
+};
+
+describe("decider thread.turn.start resumePrecondition", () => {
+  it("accepts the continuation while the recorded turn is still the latest and ended by interruption", async () => {
+    const decided = await Effect.runPromise(
+      decide(makeReadModel({ latestTurn: makeLatestTurn("interrupted") })),
+    );
+    const events = Array.isArray(decided) ? decided : [decided];
+    expect(events.map((event) => event.type)).toContain("thread.turn-start-requested");
+  });
+
+  it("rejects when the thread moved on to another turn", async () => {
+    await expectRejected(
+      makeReadModel({ latestTurn: makeLatestTurn("completed", TurnId.makeUnsafe("turn-newer")) }),
+      "Thread 'thread-resume' moved on after it was remembered for resume.",
+    );
+  });
+
+  it("rejects when the recorded turn completed on its own", async () => {
+    await expectRejected(
+      makeReadModel({ latestTurn: makeLatestTurn("completed") }),
+      "Thread 'thread-resume' finished on its own; there is nothing to resume.",
+    );
+  });
+
+  it("rejects when a turn is in flight", async () => {
+    await expectRejected(
+      makeReadModel({ latestTurn: makeLatestTurn("running") }),
+      "Thread 'thread-resume' already has a turn in flight.",
+    );
+  });
+
+  it("rejects when the thread was archived", async () => {
+    await expectRejected(
+      makeReadModel({ latestTurn: makeLatestTurn("interrupted"), archivedAt: NOW }),
+      "Thread 'thread-resume' was archived after it was remembered for resume.",
+    );
+  });
+});

--- a/apps/server/src/orchestration/decider.resumePrecondition.test.ts
+++ b/apps/server/src/orchestration/decider.resumePrecondition.test.ts
@@ -25,6 +25,8 @@ function makeReadModel(input: {
   readonly session?: OrchestrationSession | null;
   readonly latestTurn?: OrchestrationLatestTurn | null;
   readonly archivedAt?: string;
+  readonly runtimeMode?: OrchestrationReadModel["threads"][number]["runtimeMode"];
+  readonly interactionMode?: OrchestrationReadModel["threads"][number]["interactionMode"];
 }): OrchestrationReadModel {
   return {
     snapshotSequence: 1,
@@ -37,8 +39,8 @@ function makeReadModel(input: {
         projectId: ProjectId.makeUnsafe("project-resume"),
         title: "Resume",
         modelSelection: { provider: "codex", model: "gpt-5-codex" },
-        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-        runtimeMode: "full-access",
+        interactionMode: input.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: input.runtimeMode ?? "full-access",
         branch: null,
         worktreePath: null,
         createdAt: NOW,
@@ -162,5 +164,27 @@ describe("decider thread.turn.start resumePrecondition", () => {
       makeReadModel({ latestTurn: makeLatestTurn("interrupted"), archivedAt: NOW }),
       "Thread 'thread-resume' was archived after it was remembered for resume.",
     );
+  });
+
+  it("uses permission and interaction modes changed before the serialized resume dispatch", async () => {
+    const decided = await Effect.runPromise(
+      decide(
+        makeReadModel({
+          latestTurn: makeLatestTurn("interrupted"),
+          runtimeMode: "approval-required",
+          interactionMode: "plan",
+        }),
+      ),
+    );
+    const events = Array.isArray(decided) ? decided : [decided];
+    const requested = events.find((event) => event.type === "thread.turn-start-requested");
+
+    expect(requested).toMatchObject({
+      type: "thread.turn-start-requested",
+      payload: {
+        runtimeMode: "approval-required",
+        interactionMode: "plan",
+      },
+    });
   });
 });

--- a/apps/server/src/orchestration/decider.resumePrecondition.test.ts
+++ b/apps/server/src/orchestration/decider.resumePrecondition.test.ts
@@ -16,6 +16,8 @@ import { describe, expect, it } from "vitest";
 import { decideOrchestrationCommand } from "./decider.ts";
 
 const NOW = "2026-07-19T00:00:00.000Z";
+const RECORDED_AT = "2026-07-18T23:00:00.000Z";
+const BEFORE_RECORD = "2026-07-18T22:00:00.000Z";
 const THREAD_ID = ThreadId.makeUnsafe("thread-resume");
 const RECORDED_TURN_ID = TurnId.makeUnsafe("turn-recorded");
 
@@ -58,18 +60,19 @@ function makeReadModel(input: {
 function makeLatestTurn(
   state: OrchestrationLatestTurn["state"],
   id: TurnId = RECORDED_TURN_ID,
+  completedAt: string = NOW,
 ): OrchestrationLatestTurn {
   return {
     turnId: id,
     state,
     requestedAt: NOW,
     startedAt: NOW,
-    completedAt: state === "running" ? null : NOW,
+    completedAt: state === "running" ? null : completedAt,
     assistantMessageId: null,
   };
 }
 
-function resumeTurnStart(): OrchestrationCommand {
+function resumeTurnStart(recordedTurnId: TurnId | null = RECORDED_TURN_ID): OrchestrationCommand {
   return {
     type: "thread.turn.start",
     commandId: CommandId.makeUnsafe("cmd-resume"),
@@ -83,16 +86,29 @@ function resumeTurnStart(): OrchestrationCommand {
     dispatchMode: "queue",
     interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
     runtimeMode: "full-access",
-    resumePrecondition: { expectedLatestTurnId: RECORDED_TURN_ID },
+    resumePrecondition: { recordedTurnId, recordedAt: RECORDED_AT },
     createdAt: NOW,
   };
 }
 
-const decide = (readModel: OrchestrationReadModel) =>
-  decideOrchestrationCommand({ command: resumeTurnStart(), readModel });
+const decide = (readModel: OrchestrationReadModel, recordedTurnId?: TurnId | null) =>
+  decideOrchestrationCommand({ command: resumeTurnStart(recordedTurnId), readModel });
 
-const expectRejected = async (readModel: OrchestrationReadModel, detail: string) => {
-  const error = await Effect.runPromise(Effect.flip(decide(readModel)));
+const expectAccepted = async (
+  readModel: OrchestrationReadModel,
+  recordedTurnId?: TurnId | null,
+) => {
+  const decided = await Effect.runPromise(decide(readModel, recordedTurnId));
+  const events = Array.isArray(decided) ? decided : [decided];
+  expect(events.map((event) => event.type)).toContain("thread.turn-start-requested");
+};
+
+const expectRejected = async (
+  readModel: OrchestrationReadModel,
+  detail: string,
+  recordedTurnId?: TurnId | null,
+) => {
+  const error = await Effect.runPromise(Effect.flip(decide(readModel, recordedTurnId)));
   expect(error).toMatchObject({
     _tag: "OrchestrationCommandInvariantError",
     commandType: "thread.turn.start",
@@ -101,18 +117,29 @@ const expectRejected = async (readModel: OrchestrationReadModel, detail: string)
 };
 
 describe("decider thread.turn.start resumePrecondition", () => {
-  it("accepts the continuation while the recorded turn is still the latest and ended by interruption", async () => {
-    const decided = await Effect.runPromise(
-      decide(makeReadModel({ latestTurn: makeLatestTurn("interrupted") })),
-    );
-    const events = Array.isArray(decided) ? decided : [decided];
-    expect(events.map((event) => event.type)).toContain("thread.turn-start-requested");
+  it("accepts the continuation while the recorded turn ended by interruption", async () => {
+    await expectAccepted(makeReadModel({ latestTurn: makeLatestTurn("interrupted") }));
   });
 
-  it("rejects when the thread moved on to another turn", async () => {
+  it("accepts a chat that was still connecting when recorded", async () => {
+    await expectAccepted(makeReadModel({ latestTurn: null }), null);
+    await expectAccepted(
+      makeReadModel({
+        latestTurn: makeLatestTurn("completed", TurnId.makeUnsafe("turn-older"), BEFORE_RECORD),
+      }),
+      null,
+    );
+  });
+
+  it("rejects when a newer turn completed on its own since the record", async () => {
     await expectRejected(
       makeReadModel({ latestTurn: makeLatestTurn("completed", TurnId.makeUnsafe("turn-newer")) }),
-      "Thread 'thread-resume' moved on after it was remembered for resume.",
+      "Thread 'thread-resume' finished on its own; there is nothing to resume.",
+    );
+    await expectRejected(
+      makeReadModel({ latestTurn: makeLatestTurn("completed", TurnId.makeUnsafe("turn-newer")) }),
+      "Thread 'thread-resume' finished on its own; there is nothing to resume.",
+      null,
     );
   });
 

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -63,6 +63,8 @@ import {
   requireThreadNotArchived,
   threadHasInFlightTurn,
   threadHasCheckpointRevertInProgress,
+  threadResumePreconditionDetail,
+  threadResumePreconditionViolation,
 } from "./commandInvariants.ts";
 
 const nowIso = () => new Date().toISOString();
@@ -1658,6 +1660,20 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         threadId: command.threadId,
       });
+      if (command.resumePrecondition !== undefined) {
+        // Quit-resume continuations are only valid while the thread is exactly as
+        // it was recorded; checked here so it holds inside the serialized dispatch.
+        const violation = threadResumePreconditionViolation(
+          targetThread,
+          command.resumePrecondition,
+        );
+        if (violation !== null) {
+          return yield* new OrchestrationCommandInvariantError({
+            commandType: command.type,
+            detail: threadResumePreconditionDetail(command.threadId, violation),
+          });
+        }
+      }
       if (threadHasCheckpointRevertInProgress(targetThread)) {
         return yield* new OrchestrationCommandInvariantError({
           commandType: command.type,

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1681,10 +1681,19 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         });
       }
       const sourceProposedPlan = command.sourceProposedPlan;
+      // A quit-resume command is planned just before commands are admitted.
+      // Respect settings changed before its serialized dispatch instead of
+      // replaying the planner's stale permission or interaction mode.
+      const runtimeMode =
+        command.resumePrecondition === undefined ? command.runtimeMode : targetThread.runtimeMode;
+      const interactionMode =
+        command.resumePrecondition === undefined
+          ? command.interactionMode
+          : targetThread.interactionMode;
       yield* validateAutoRuntimeMode(
         command,
         command.modelSelection ?? targetThread.modelSelection,
-        command.runtimeMode,
+        runtimeMode,
       );
       const sourceThread = sourceProposedPlan
         ? yield* requireThread({
@@ -1751,8 +1760,8 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         assistantDeliveryMode: command.assistantDeliveryMode ?? DEFAULT_ASSISTANT_DELIVERY_MODE,
         dispatchMode,
         dispatchOrigin: command.dispatchOrigin ?? "user",
-        runtimeMode: command.runtimeMode,
-        interactionMode: command.interactionMode,
+        runtimeMode,
+        interactionMode,
         ...(sourceProposedPlan !== undefined ? { sourceProposedPlan } : {}),
         createdAt: command.createdAt,
       } as const;

--- a/apps/server/src/orchestration/quitResume.test.ts
+++ b/apps/server/src/orchestration/quitResume.test.ts
@@ -366,7 +366,11 @@ describe("quit resume record file", () => {
         const next = yield* claimQuitResumeRecord(path);
         const fs = yield* FileSystem.FileSystem;
         const leftovers = yield* fs.exists(`${path}.claimed`);
-        return { nothing, claimed, afterClaim, next, leftovers };
+        // A private copy left by a crash mid-claim is never mistaken for a record.
+        yield* fs.writeFileString(`${path}.claimed`, JSON.stringify(first));
+        const stale = yield* claimQuitResumeRecord(path);
+        const staleRemoved = !(yield* fs.exists(`${path}.claimed`));
+        return { nothing, claimed, afterClaim, next, leftovers, stale, staleRemoved };
       }),
     );
 
@@ -375,6 +379,8 @@ describe("quit resume record file", () => {
     expect(result.afterClaim).toEqual({ kind: "absent" });
     expect(result.next).toEqual({ kind: "record", record: second });
     expect(result.leftovers).toBe(false);
+    expect(result.stale).toEqual({ kind: "absent" });
+    expect(result.staleRemoved).toBe(true);
   });
 
   it("prepareQuitResume records in-flight threads, interrupts them, and drops the record if the quit never happens", async () => {

--- a/apps/server/src/orchestration/quitResume.test.ts
+++ b/apps/server/src/orchestration/quitResume.test.ts
@@ -1,0 +1,215 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { ProjectId, ThreadId, TurnId } from "@synara/contracts";
+import { Effect, FileSystem, Layer, Option } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { ServerConfig } from "../config";
+import {
+  buildQuitInterruptCommand,
+  buildQuitResumeRecord,
+  clearQuitResumeRecord,
+  persistQuitResumeRecord,
+  planQuitResumeTurns,
+  readQuitResumeRecord,
+  type QuitResumeRecord,
+  type QuitResumeThread,
+} from "./quitResume.ts";
+
+const RECORDED_AT = "2026-06-14T10:00:00.000Z";
+const NOW = "2026-06-14T10:05:00.000Z";
+const PROMPT = "Synara was closed while this chat was still running. Continue where you left off.";
+
+const threadId = (id: string) => ThreadId.makeUnsafe(id);
+const turnId = (id: string) => TurnId.makeUnsafe(id);
+const PROJECT = ProjectId.makeUnsafe("project-1");
+
+const makeLatestTurn = (
+  id: string,
+  state: NonNullable<QuitResumeThread["latestTurn"]>["state"] = "interrupted",
+): NonNullable<QuitResumeThread["latestTurn"]> => ({
+  turnId: turnId(id),
+  state,
+  requestedAt: "2026-06-14T09:00:00.000Z",
+  startedAt: "2026-06-14T09:00:01.000Z",
+  completedAt: state === "running" ? null : "2026-06-14T09:59:00.000Z",
+  assistantMessageId: null,
+});
+
+const makeThread = (id: string, overrides: Partial<QuitResumeThread> = {}): QuitResumeThread => ({
+  id: threadId(id),
+  projectId: PROJECT,
+  deletedAt: null,
+  archivedAt: null,
+  latestTurn: makeLatestTurn(`${id}-turn`),
+  session: null,
+  runtimeMode: "full-access",
+  interactionMode: "default",
+  ...overrides,
+});
+
+const makeRecord = (
+  threads: ReadonlyArray<{ threadId: string; turnId: string | null }>,
+): QuitResumeRecord => ({
+  version: 1,
+  recordedAt: RECORDED_AT,
+  continuationPrompt: PROMPT,
+  threads: threads.map((entry) => ({
+    threadId: threadId(entry.threadId),
+    turnId: entry.turnId === null ? null : turnId(entry.turnId),
+  })),
+});
+
+const liveProjects = [{ id: PROJECT, deletedAt: null }];
+
+describe("buildQuitResumeRecord", () => {
+  it("snapshots known live threads with their latest turn, dropping unknown, deleted, and duplicate ids", () => {
+    const record = buildQuitResumeRecord({
+      request: {
+        threadIds: [threadId("a"), threadId("b"), threadId("a"), threadId("gone"), threadId("c")],
+        continuationPrompt: PROMPT,
+      },
+      threads: [
+        makeThread("a"),
+        makeThread("b", { latestTurn: null }),
+        makeThread("c", { deletedAt: "2026-06-14T09:30:00.000Z" }),
+      ],
+      now: RECORDED_AT,
+    });
+
+    expect(record).toEqual({
+      version: 1,
+      recordedAt: RECORDED_AT,
+      continuationPrompt: PROMPT,
+      threads: [
+        { threadId: threadId("a"), turnId: turnId("a-turn") },
+        { threadId: threadId("b"), turnId: null },
+      ],
+    });
+  });
+});
+
+describe("buildQuitInterruptCommand", () => {
+  it("derives a deterministic command id and forwards the recorded turn id when present", () => {
+    expect(
+      buildQuitInterruptCommand({
+        threadId: threadId("a"),
+        turnId: turnId("a-turn"),
+        recordedAt: RECORDED_AT,
+      }),
+    ).toEqual({
+      type: "thread.turn.interrupt",
+      commandId: `quit-resume-interrupt:a:${RECORDED_AT}`,
+      threadId: threadId("a"),
+      turnId: turnId("a-turn"),
+      createdAt: RECORDED_AT,
+    });
+    expect(
+      buildQuitInterruptCommand({ threadId: threadId("b"), turnId: null, recordedAt: RECORDED_AT }),
+    ).not.toHaveProperty("turnId");
+  });
+});
+
+describe("planQuitResumeTurns", () => {
+  it("queues an ordinary user turn on each unchanged thread using its own runtime settings", () => {
+    const plan = planQuitResumeTurns({
+      record: makeRecord([{ threadId: "a", turnId: "a-turn" }]),
+      threads: [makeThread("a", { runtimeMode: "approval-required", interactionMode: "plan" })],
+      projects: liveProjects,
+      now: NOW,
+    });
+
+    expect(plan.skipped).toEqual([]);
+    expect(plan.commands).toEqual([
+      {
+        type: "thread.turn.start",
+        commandId: `quit-resume:a:${RECORDED_AT}`,
+        threadId: threadId("a"),
+        message: {
+          messageId: `quit-resume:a:${RECORDED_AT}`,
+          role: "user",
+          text: PROMPT,
+          attachments: [],
+        },
+        dispatchMode: "queue",
+        runtimeMode: "approval-required",
+        interactionMode: "plan",
+        createdAt: NOW,
+      },
+    ]);
+    // Model selection is intentionally omitted so the thread's current selection is used.
+    expect(plan.commands[0]).not.toHaveProperty("modelSelection");
+  });
+
+  it("skips threads that are missing, deleted, archived, project-less, turn-less, progressed, or in flight", () => {
+    const plan = planQuitResumeTurns({
+      record: makeRecord([
+        { threadId: "missing", turnId: "missing-turn" },
+        { threadId: "deleted", turnId: "deleted-turn" },
+        { threadId: "archived", turnId: "archived-turn" },
+        { threadId: "orphan", turnId: "orphan-turn" },
+        { threadId: "no-turn", turnId: null },
+        { threadId: "progressed", turnId: "progressed-turn" },
+        { threadId: "running", turnId: "running-turn" },
+        { threadId: "ok", turnId: "ok-turn" },
+      ]),
+      threads: [
+        makeThread("deleted", { deletedAt: "2026-06-14T10:01:00.000Z" }),
+        makeThread("archived", { archivedAt: "2026-06-14T10:01:00.000Z" }),
+        makeThread("orphan", { projectId: ProjectId.makeUnsafe("project-gone") }),
+        makeThread("no-turn", { latestTurn: null }),
+        makeThread("progressed", { latestTurn: makeLatestTurn("progressed-turn-2") }),
+        makeThread("running", { latestTurn: makeLatestTurn("running-turn", "running") }),
+        makeThread("ok"),
+      ],
+      projects: [...liveProjects, { id: ProjectId.makeUnsafe("project-gone"), deletedAt: NOW }],
+      now: NOW,
+    });
+
+    expect(plan.commands.map((command) => command.threadId)).toEqual([threadId("ok")]);
+    expect(plan.skipped).toEqual([
+      { threadId: threadId("missing"), reason: "thread-missing" },
+      { threadId: threadId("deleted"), reason: "thread-deleted" },
+      { threadId: threadId("archived"), reason: "thread-archived" },
+      { threadId: threadId("orphan"), reason: "project-missing" },
+      { threadId: threadId("no-turn"), reason: "no-turn" },
+      { threadId: threadId("progressed"), reason: "turn-changed" },
+      { threadId: threadId("running"), reason: "turn-in-flight" },
+    ]);
+  });
+});
+
+describe("quit resume record file", () => {
+  const serverConfigLayer = ServerConfig.layerTest(process.cwd(), {
+    prefix: "synara-quit-resume-",
+  }).pipe(Layer.provide(NodeServices.layer));
+  const testLayer = Layer.merge(NodeServices.layer, serverConfigLayer);
+  const run = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    Effect.runPromise(effect.pipe(Effect.provide(testLayer)) as Effect.Effect<A, E, never>);
+
+  it("persists, reads, and clears the record; a missing or corrupt file reads as none", async () => {
+    const record = makeRecord([{ threadId: "a", turnId: "a-turn" }]);
+    const result = await run(
+      Effect.gen(function* () {
+        const config = yield* ServerConfig;
+        const path = config.quitResumeStatePath;
+        const missing = yield* readQuitResumeRecord(path);
+        yield* persistQuitResumeRecord({ path, record });
+        const persisted = yield* readQuitResumeRecord(path);
+        yield* clearQuitResumeRecord(path);
+        const cleared = yield* readQuitResumeRecord(path);
+        // Clearing twice is fine (force remove).
+        yield* clearQuitResumeRecord(path);
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs.writeFileString(path, "{ not json");
+        const corrupt = yield* readQuitResumeRecord(path);
+        yield* clearQuitResumeRecord(path);
+        return { missing, persisted, cleared, corrupt };
+      }),
+    );
+
+    expect(Option.isNone(result.missing)).toBe(true);
+    expect(Option.getOrNull(result.persisted)).toEqual(record);
+    expect(Option.isNone(result.cleared)).toBe(true);
+    expect(Option.isNone(result.corrupt)).toBe(true);
+  });
+});

--- a/apps/server/src/orchestration/quitResume.test.ts
+++ b/apps/server/src/orchestration/quitResume.test.ts
@@ -7,6 +7,7 @@ import { ServerConfig } from "../config";
 import {
   buildQuitInterruptCommand,
   buildQuitResumeRecord,
+  claimQuitResumeRecord,
   clearQuitResumeRecord,
   persistQuitResumeRecord,
   planQuitResumeTurns,
@@ -18,6 +19,8 @@ import {
 
 const RECORD_ID = "record-1";
 const RECORDED_AT = "2026-06-14T10:00:00.000Z";
+const BEFORE_RECORD = "2026-06-14T09:59:00.000Z";
+const AFTER_RECORD = "2026-06-14T10:00:30.000Z";
 const NOW = "2026-06-14T10:05:00.000Z";
 const PROMPT = "Synara was closed while this chat was still running. Continue where you left off.";
 
@@ -28,12 +31,13 @@ const PROJECT = ProjectId.makeUnsafe("project-1");
 const makeLatestTurn = (
   id: string,
   state: NonNullable<QuitResumeThread["latestTurn"]>["state"] = "interrupted",
+  completedAt: string = AFTER_RECORD,
 ): NonNullable<QuitResumeThread["latestTurn"]> => ({
   turnId: turnId(id),
   state,
   requestedAt: "2026-06-14T09:00:00.000Z",
   startedAt: "2026-06-14T09:00:01.000Z",
-  completedAt: state === "running" ? null : "2026-06-14T09:59:00.000Z",
+  completedAt: state === "running" ? null : completedAt,
   assistantMessageId: null,
 });
 
@@ -72,7 +76,7 @@ const makeRunningThread = (id: string, overrides: Partial<QuitResumeThread> = {}
   });
 
 const makeRecord = (
-  threads: ReadonlyArray<{ threadId: string; turnId: string }>,
+  threads: ReadonlyArray<{ threadId: string; turnId: string | null }>,
 ): QuitResumeRecord => ({
   version: 1,
   recordId: RECORD_ID,
@@ -80,9 +84,17 @@ const makeRecord = (
   continuationPrompt: PROMPT,
   threads: threads.map((entry) => ({
     threadId: threadId(entry.threadId),
-    turnId: turnId(entry.turnId),
+    turnId: entry.turnId === null ? null : turnId(entry.turnId),
   })),
 });
+
+/** A thread whose provider is still connecting: session starting, no turn yet. */
+const makeConnectingThread = (id: string, overrides: Partial<QuitResumeThread> = {}) =>
+  makeThread(id, {
+    latestTurn: null,
+    session: makeSession(id, { status: "starting", activeTurnId: null }),
+    ...overrides,
+  });
 
 const liveProjects = [{ id: PROJECT, deletedAt: null }];
 
@@ -96,7 +108,8 @@ describe("buildQuitResumeRecord", () => {
           threadId("a"),
           threadId("gone"),
           threadId("deleted"),
-          threadId("no-turn"),
+          threadId("connecting"),
+          threadId("reconnecting"),
           threadId("b"),
         ],
         continuationPrompt: PROMPT,
@@ -106,7 +119,11 @@ describe("buildQuitResumeRecord", () => {
         // Finished while the dialog was open: nothing to resume.
         makeThread("finished", { latestTurn: makeLatestTurn("finished-turn", "completed") }),
         makeRunningThread("deleted", { deletedAt: "2026-06-14T09:30:00.000Z" }),
-        makeThread("no-turn", { latestTurn: null, session: makeSession("no-turn") }),
+        // Provider still starting: in flight, but no turn to name yet.
+        makeConnectingThread("connecting"),
+        makeConnectingThread("reconnecting", {
+          latestTurn: makeLatestTurn("reconnecting-old", "completed", BEFORE_RECORD),
+        }),
         makeRunningThread("b"),
       ],
       recordId: RECORD_ID,
@@ -120,6 +137,8 @@ describe("buildQuitResumeRecord", () => {
       continuationPrompt: PROMPT,
       threads: [
         { threadId: threadId("a"), turnId: turnId("a-turn") },
+        { threadId: threadId("connecting"), turnId: null },
+        { threadId: threadId("reconnecting"), turnId: null },
         { threadId: threadId("b"), turnId: turnId("b-turn") },
       ],
     });
@@ -127,7 +146,7 @@ describe("buildQuitResumeRecord", () => {
 });
 
 describe("buildQuitInterruptCommand", () => {
-  it("derives a deterministic command id and targets the recorded turn", () => {
+  it("derives a deterministic command id and targets the recorded turn when there is one", () => {
     expect(
       buildQuitInterruptCommand({
         threadId: threadId("a"),
@@ -142,6 +161,14 @@ describe("buildQuitInterruptCommand", () => {
       turnId: turnId("a-turn"),
       createdAt: RECORDED_AT,
     });
+    expect(
+      buildQuitInterruptCommand({
+        threadId: threadId("b"),
+        turnId: null,
+        recordId: RECORD_ID,
+        recordedAt: RECORDED_AT,
+      }),
+    ).not.toHaveProperty("turnId");
   });
 });
 
@@ -170,7 +197,7 @@ describe("planQuitResumeTurns", () => {
         runtimeMode: "approval-required",
         interactionMode: "plan",
         // Re-checked by the decider inside the serialized dispatch.
-        resumePrecondition: { expectedLatestTurnId: turnId("a-turn") },
+        resumePrecondition: { recordedTurnId: turnId("a-turn"), recordedAt: RECORDED_AT },
         createdAt: NOW,
       },
     ]);
@@ -183,12 +210,19 @@ describe("planQuitResumeTurns", () => {
       record: makeRecord([
         { threadId: "interrupted", turnId: "interrupted-turn" },
         { threadId: "errored", turnId: "errored-turn" },
+        // A later turn interrupted by the quit still counts as "where you left off".
+        { threadId: "superseded", turnId: "superseded-turn" },
         { threadId: "completed", turnId: "completed-turn" },
+        { threadId: "completed-later", turnId: "completed-later-turn" },
       ]),
       threads: [
         makeThread("interrupted"),
         makeThread("errored", { latestTurn: makeLatestTurn("errored-turn", "error") }),
+        makeThread("superseded", { latestTurn: makeLatestTurn("superseded-turn-2") }),
         makeThread("completed", { latestTurn: makeLatestTurn("completed-turn", "completed") }),
+        makeThread("completed-later", {
+          latestTurn: makeLatestTurn("completed-later-turn-2", "completed", AFTER_RECORD),
+        }),
       ],
       projects: liveProjects,
       now: NOW,
@@ -197,29 +231,69 @@ describe("planQuitResumeTurns", () => {
     expect(plan.commands.map((command) => command.threadId)).toEqual([
       threadId("interrupted"),
       threadId("errored"),
+      threadId("superseded"),
     ]);
-    expect(plan.skipped).toEqual([{ threadId: threadId("completed"), reason: "turn-completed" }]);
+    expect(plan.skipped).toEqual([
+      { threadId: threadId("completed"), reason: "turn-completed" },
+      { threadId: threadId("completed-later"), reason: "turn-completed" },
+    ]);
   });
 
-  it("skips threads that are missing, deleted, archived, project-less, progressed, or in flight", () => {
+  it("resumes chats that were still connecting at quit unless a turn completed since", () => {
+    const plan = planQuitResumeTurns({
+      record: makeRecord([
+        { threadId: "fresh", turnId: null },
+        { threadId: "follow-up", turnId: null },
+        { threadId: "started-then-stopped", turnId: null },
+        { threadId: "answered", turnId: null },
+      ]),
+      threads: [
+        // Never reached the provider: still no turn after restart reconciliation.
+        makeThread("fresh", { latestTurn: null }),
+        // Previous turn had completed before the record; the new one never started.
+        makeThread("follow-up", {
+          latestTurn: makeLatestTurn("follow-up-old", "completed", BEFORE_RECORD),
+        }),
+        // The pending turn started after the record and was interrupted by the quit.
+        makeThread("started-then-stopped", { latestTurn: makeLatestTurn("started-turn") }),
+        // A turn finished on its own after the record: nothing left to continue.
+        makeThread("answered", {
+          latestTurn: makeLatestTurn("answered-turn", "completed", AFTER_RECORD),
+        }),
+      ],
+      projects: liveProjects,
+      now: NOW,
+    });
+
+    expect(plan.commands.map((command) => command.threadId)).toEqual([
+      threadId("fresh"),
+      threadId("follow-up"),
+      threadId("started-then-stopped"),
+    ]);
+    expect(plan.commands[0]?.resumePrecondition).toEqual({
+      recordedTurnId: null,
+      recordedAt: RECORDED_AT,
+    });
+    expect(plan.skipped).toEqual([{ threadId: threadId("answered"), reason: "turn-completed" }]);
+  });
+
+  it("skips threads that are missing, deleted, archived, project-less, or in flight", () => {
     const plan = planQuitResumeTurns({
       record: makeRecord([
         { threadId: "missing", turnId: "missing-turn" },
         { threadId: "deleted", turnId: "deleted-turn" },
         { threadId: "archived", turnId: "archived-turn" },
         { threadId: "orphan", turnId: "orphan-turn" },
-        { threadId: "no-turn", turnId: "no-turn-turn" },
-        { threadId: "progressed", turnId: "progressed-turn" },
         { threadId: "running", turnId: "running-turn" },
+        { threadId: "connecting", turnId: "connecting-turn" },
         { threadId: "ok", turnId: "ok-turn" },
       ]),
       threads: [
         makeThread("deleted", { deletedAt: "2026-06-14T10:01:00.000Z" }),
         makeThread("archived", { archivedAt: "2026-06-14T10:01:00.000Z" }),
         makeThread("orphan", { projectId: ProjectId.makeUnsafe("project-gone") }),
-        makeThread("no-turn", { latestTurn: null }),
-        makeThread("progressed", { latestTurn: makeLatestTurn("progressed-turn-2") }),
         makeRunningThread("running"),
+        makeConnectingThread("connecting"),
         makeThread("ok"),
       ],
       projects: [...liveProjects, { id: ProjectId.makeUnsafe("project-gone"), deletedAt: NOW }],
@@ -232,9 +306,8 @@ describe("planQuitResumeTurns", () => {
       { threadId: threadId("deleted"), reason: "thread-deleted" },
       { threadId: threadId("archived"), reason: "thread-archived" },
       { threadId: threadId("orphan"), reason: "project-missing" },
-      { threadId: threadId("no-turn"), reason: "turn-changed" },
-      { threadId: threadId("progressed"), reason: "turn-changed" },
       { threadId: threadId("running"), reason: "turn-in-flight" },
+      { threadId: threadId("connecting"), reason: "turn-in-flight" },
     ]);
   });
 });
@@ -277,6 +350,33 @@ describe("quit resume record file", () => {
     expect(result.empty).toEqual({ kind: "invalid" });
   });
 
+  it("claiming consumes the record atomically and leaves a record written meanwhile alone", async () => {
+    const first = makeRecord([{ threadId: "a", turnId: "a-turn" }]);
+    const second = { ...first, recordId: "record-2" };
+    const result = await run(
+      Effect.gen(function* () {
+        const config = yield* ServerConfig;
+        const path = config.quitResumeStatePath;
+        const nothing = yield* claimQuitResumeRecord(path);
+        yield* persistQuitResumeRecord({ path, record: first });
+        const claimed = yield* claimQuitResumeRecord(path);
+        const afterClaim = yield* readQuitResumeRecord(path);
+        // A quit prepared while boot is still running must keep its own record.
+        yield* persistQuitResumeRecord({ path, record: second });
+        const next = yield* claimQuitResumeRecord(path);
+        const fs = yield* FileSystem.FileSystem;
+        const leftovers = yield* fs.exists(`${path}.claimed`);
+        return { nothing, claimed, afterClaim, next, leftovers };
+      }),
+    );
+
+    expect(result.nothing).toEqual({ kind: "absent" });
+    expect(result.claimed).toEqual({ kind: "record", record: first });
+    expect(result.afterClaim).toEqual({ kind: "absent" });
+    expect(result.next).toEqual({ kind: "record", record: second });
+    expect(result.leftovers).toBe(false);
+  });
+
   it("prepareQuitResume records in-flight threads, interrupts them, and drops the record if the quit never happens", async () => {
     const dispatched: OrchestrationCommand[] = [];
     const result = await run(
@@ -285,7 +385,7 @@ describe("quit resume record file", () => {
         const path = config.quitResumeStatePath;
         const prepared = yield* prepareQuitResume({
           request: {
-            threadIds: [threadId("a"), threadId("finished")],
+            threadIds: [threadId("a"), threadId("connecting"), threadId("finished")],
             continuationPrompt: PROMPT,
           },
           recordPath: path,
@@ -293,6 +393,7 @@ describe("quit resume record file", () => {
             Effect.succeed({
               threads: [
                 makeRunningThread("a"),
+                makeConnectingThread("connecting"),
                 makeThread("finished", {
                   latestTurn: makeLatestTurn("finished-turn", "completed"),
                 }),
@@ -313,11 +414,12 @@ describe("quit resume record file", () => {
       }),
     );
 
-    expect(result.prepared.recordedThreadIds).toEqual([threadId("a")]);
+    expect(result.prepared.recordedThreadIds).toEqual([threadId("a"), threadId("connecting")]);
     expect(result.persisted.kind).toBe("record");
     if (result.persisted.kind === "record") {
       expect(result.persisted.record.threads).toEqual([
         { threadId: threadId("a"), turnId: turnId("a-turn") },
+        { threadId: threadId("connecting"), turnId: null },
       ]);
       expect(result.persisted.record.recordedAt).toBe(result.prepared.recordedAt);
     }
@@ -327,7 +429,9 @@ describe("quit resume record file", () => {
         threadId: threadId("a"),
         turnId: turnId("a-turn"),
       }),
+      expect.objectContaining({ type: "thread.turn.interrupt", threadId: threadId("connecting") }),
     ]);
+    expect(dispatched[1]).not.toHaveProperty("turnId");
     expect(result.abandoned).toEqual({ kind: "absent" });
   });
 });

--- a/apps/server/src/orchestration/quitResume.test.ts
+++ b/apps/server/src/orchestration/quitResume.test.ts
@@ -15,6 +15,7 @@ import {
   type QuitResumeThread,
 } from "./quitResume.ts";
 
+const RECORD_ID = "record-1";
 const RECORDED_AT = "2026-06-14T10:00:00.000Z";
 const NOW = "2026-06-14T10:05:00.000Z";
 const PROMPT = "Synara was closed while this chat was still running. Continue where you left off.";
@@ -51,6 +52,7 @@ const makeRecord = (
   threads: ReadonlyArray<{ threadId: string; turnId: string | null }>,
 ): QuitResumeRecord => ({
   version: 1,
+  recordId: RECORD_ID,
   recordedAt: RECORDED_AT,
   continuationPrompt: PROMPT,
   threads: threads.map((entry) => ({
@@ -73,11 +75,13 @@ describe("buildQuitResumeRecord", () => {
         makeThread("b", { latestTurn: null }),
         makeThread("c", { deletedAt: "2026-06-14T09:30:00.000Z" }),
       ],
+      recordId: RECORD_ID,
       now: RECORDED_AT,
     });
 
     expect(record).toEqual({
       version: 1,
+      recordId: RECORD_ID,
       recordedAt: RECORDED_AT,
       continuationPrompt: PROMPT,
       threads: [
@@ -94,17 +98,23 @@ describe("buildQuitInterruptCommand", () => {
       buildQuitInterruptCommand({
         threadId: threadId("a"),
         turnId: turnId("a-turn"),
+        recordId: RECORD_ID,
         recordedAt: RECORDED_AT,
       }),
     ).toEqual({
       type: "thread.turn.interrupt",
-      commandId: `quit-resume-interrupt:a:${RECORDED_AT}`,
+      commandId: `quit-resume-interrupt:${RECORD_ID}:a`,
       threadId: threadId("a"),
       turnId: turnId("a-turn"),
       createdAt: RECORDED_AT,
     });
     expect(
-      buildQuitInterruptCommand({ threadId: threadId("b"), turnId: null, recordedAt: RECORDED_AT }),
+      buildQuitInterruptCommand({
+        threadId: threadId("b"),
+        turnId: null,
+        recordId: RECORD_ID,
+        recordedAt: RECORDED_AT,
+      }),
     ).not.toHaveProperty("turnId");
   });
 });
@@ -122,10 +132,10 @@ describe("planQuitResumeTurns", () => {
     expect(plan.commands).toEqual([
       {
         type: "thread.turn.start",
-        commandId: `quit-resume:a:${RECORDED_AT}`,
+        commandId: `quit-resume:${RECORD_ID}:a`,
         threadId: threadId("a"),
         message: {
-          messageId: `quit-resume:a:${RECORDED_AT}`,
+          messageId: `quit-resume:${RECORD_ID}:a`,
           role: "user",
           text: PROMPT,
           attachments: [],

--- a/apps/server/src/orchestration/quitResume.test.ts
+++ b/apps/server/src/orchestration/quitResume.test.ts
@@ -364,13 +364,12 @@ describe("quit resume record file", () => {
         // A quit prepared while boot is still running must keep its own record.
         yield* persistQuitResumeRecord({ path, record: second });
         const next = yield* claimQuitResumeRecord(path);
-        const fs = yield* FileSystem.FileSystem;
-        const leftovers = yield* fs.exists(`${path}.claimed`);
-        // A private copy left by a crash mid-claim is never mistaken for a record.
-        yield* fs.writeFileString(`${path}.claimed`, JSON.stringify(first));
-        const stale = yield* claimQuitResumeRecord(path);
-        const staleRemoved = !(yield* fs.exists(`${path}.claimed`));
-        return { nothing, claimed, afterClaim, next, leftovers, stale, staleRemoved };
+        yield* persistQuitResumeRecord({ path, record: first });
+        const concurrent = yield* Effect.all(
+          [claimQuitResumeRecord(path), claimQuitResumeRecord(path)],
+          { concurrency: "unbounded" },
+        );
+        return { nothing, claimed, afterClaim, next, concurrent };
       }),
     );
 
@@ -378,9 +377,8 @@ describe("quit resume record file", () => {
     expect(result.claimed).toEqual({ kind: "record", record: first });
     expect(result.afterClaim).toEqual({ kind: "absent" });
     expect(result.next).toEqual({ kind: "record", record: second });
-    expect(result.leftovers).toBe(false);
-    expect(result.stale).toEqual({ kind: "absent" });
-    expect(result.staleRemoved).toBe(true);
+    expect(result.concurrent.filter((entry) => entry.kind === "record")).toHaveLength(1);
+    expect(result.concurrent.filter((entry) => entry.kind === "absent")).toHaveLength(1);
   });
 
   it("prepareQuitResume records in-flight threads, interrupts them, and drops the record if the quit never happens", async () => {
@@ -439,5 +437,42 @@ describe("quit resume record file", () => {
     ]);
     expect(dispatched[1]).not.toHaveProperty("turnId");
     expect(result.abandoned).toEqual({ kind: "absent" });
+  });
+
+  it("acknowledges the durable record without waiting for best-effort interrupts", async () => {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const result = await Promise.race([
+        run(
+          Effect.gen(function* () {
+            const config = yield* ServerConfig;
+            const prepared = yield* prepareQuitResume({
+              request: {
+                threadIds: [threadId("a")],
+                continuationPrompt: PROMPT,
+              },
+              recordPath: config.quitResumeStatePath,
+              getReadModel: () => Effect.succeed({ threads: [makeRunningThread("a")] }),
+              dispatch: () => Effect.never,
+              abandonAfter: Duration.hours(1),
+            });
+            const persisted = yield* readQuitResumeRecord(config.quitResumeStatePath);
+            yield* clearQuitResumeRecord(config.quitResumeStatePath);
+            return { prepared, persisted };
+          }),
+        ),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("prepareQuitResume waited for an interrupt")),
+            250,
+          );
+        }),
+      ]);
+
+      expect(result.prepared.recordedThreadIds).toEqual([threadId("a")]);
+      expect(result.persisted.kind).toBe("record");
+    } finally {
+      clearTimeout(timeout);
+    }
   });
 });

--- a/apps/server/src/orchestration/quitResume.test.ts
+++ b/apps/server/src/orchestration/quitResume.test.ts
@@ -1,6 +1,6 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { ProjectId, ThreadId, TurnId } from "@synara/contracts";
-import { Effect, FileSystem, Layer, Option } from "effect";
+import { ProjectId, ThreadId, TurnId, type OrchestrationCommand } from "@synara/contracts";
+import { Duration, Effect, FileSystem, Layer } from "effect";
 import { describe, expect, it } from "vitest";
 
 import { ServerConfig } from "../config";
@@ -10,6 +10,7 @@ import {
   clearQuitResumeRecord,
   persistQuitResumeRecord,
   planQuitResumeTurns,
+  prepareQuitResume,
   readQuitResumeRecord,
   type QuitResumeRecord,
   type QuitResumeThread,
@@ -36,6 +37,20 @@ const makeLatestTurn = (
   assistantMessageId: null,
 });
 
+const makeSession = (
+  id: string,
+  overrides: Partial<NonNullable<QuitResumeThread["session"]>> = {},
+): NonNullable<QuitResumeThread["session"]> => ({
+  threadId: threadId(id),
+  providerName: "codex",
+  runtimeMode: "full-access",
+  status: "running",
+  activeTurnId: turnId(`${id}-turn`),
+  lastError: null,
+  updatedAt: "2026-06-14T09:00:01.000Z",
+  ...overrides,
+});
+
 const makeThread = (id: string, overrides: Partial<QuitResumeThread> = {}): QuitResumeThread => ({
   id: threadId(id),
   projectId: PROJECT,
@@ -48,8 +63,16 @@ const makeThread = (id: string, overrides: Partial<QuitResumeThread> = {}): Quit
   ...overrides,
 });
 
+/** A thread whose latest turn is genuinely running right now. */
+const makeRunningThread = (id: string, overrides: Partial<QuitResumeThread> = {}) =>
+  makeThread(id, {
+    latestTurn: makeLatestTurn(`${id}-turn`, "running"),
+    session: makeSession(id),
+    ...overrides,
+  });
+
 const makeRecord = (
-  threads: ReadonlyArray<{ threadId: string; turnId: string | null }>,
+  threads: ReadonlyArray<{ threadId: string; turnId: string }>,
 ): QuitResumeRecord => ({
   version: 1,
   recordId: RECORD_ID,
@@ -57,23 +80,34 @@ const makeRecord = (
   continuationPrompt: PROMPT,
   threads: threads.map((entry) => ({
     threadId: threadId(entry.threadId),
-    turnId: entry.turnId === null ? null : turnId(entry.turnId),
+    turnId: turnId(entry.turnId),
   })),
 });
 
 const liveProjects = [{ id: PROJECT, deletedAt: null }];
 
 describe("buildQuitResumeRecord", () => {
-  it("snapshots known live threads with their latest turn, dropping unknown, deleted, and duplicate ids", () => {
+  it("snapshots only threads that are in flight right now, dropping unknown, deleted, idle, and duplicate ids", () => {
     const record = buildQuitResumeRecord({
       request: {
-        threadIds: [threadId("a"), threadId("b"), threadId("a"), threadId("gone"), threadId("c")],
+        threadIds: [
+          threadId("a"),
+          threadId("finished"),
+          threadId("a"),
+          threadId("gone"),
+          threadId("deleted"),
+          threadId("no-turn"),
+          threadId("b"),
+        ],
         continuationPrompt: PROMPT,
       },
       threads: [
-        makeThread("a"),
-        makeThread("b", { latestTurn: null }),
-        makeThread("c", { deletedAt: "2026-06-14T09:30:00.000Z" }),
+        makeRunningThread("a"),
+        // Finished while the dialog was open: nothing to resume.
+        makeThread("finished", { latestTurn: makeLatestTurn("finished-turn", "completed") }),
+        makeRunningThread("deleted", { deletedAt: "2026-06-14T09:30:00.000Z" }),
+        makeThread("no-turn", { latestTurn: null, session: makeSession("no-turn") }),
+        makeRunningThread("b"),
       ],
       recordId: RECORD_ID,
       now: RECORDED_AT,
@@ -86,14 +120,14 @@ describe("buildQuitResumeRecord", () => {
       continuationPrompt: PROMPT,
       threads: [
         { threadId: threadId("a"), turnId: turnId("a-turn") },
-        { threadId: threadId("b"), turnId: null },
+        { threadId: threadId("b"), turnId: turnId("b-turn") },
       ],
     });
   });
 });
 
 describe("buildQuitInterruptCommand", () => {
-  it("derives a deterministic command id and forwards the recorded turn id when present", () => {
+  it("derives a deterministic command id and targets the recorded turn", () => {
     expect(
       buildQuitInterruptCommand({
         threadId: threadId("a"),
@@ -108,14 +142,6 @@ describe("buildQuitInterruptCommand", () => {
       turnId: turnId("a-turn"),
       createdAt: RECORDED_AT,
     });
-    expect(
-      buildQuitInterruptCommand({
-        threadId: threadId("b"),
-        turnId: null,
-        recordId: RECORD_ID,
-        recordedAt: RECORDED_AT,
-      }),
-    ).not.toHaveProperty("turnId");
   });
 });
 
@@ -143,6 +169,8 @@ describe("planQuitResumeTurns", () => {
         dispatchMode: "queue",
         runtimeMode: "approval-required",
         interactionMode: "plan",
+        // Re-checked by the decider inside the serialized dispatch.
+        resumePrecondition: { expectedLatestTurnId: turnId("a-turn") },
         createdAt: NOW,
       },
     ]);
@@ -150,14 +178,37 @@ describe("planQuitResumeTurns", () => {
     expect(plan.commands[0]).not.toHaveProperty("modelSelection");
   });
 
-  it("skips threads that are missing, deleted, archived, project-less, turn-less, progressed, or in flight", () => {
+  it("resumes turns that ended as interrupted or error, not ones that completed on their own", () => {
+    const plan = planQuitResumeTurns({
+      record: makeRecord([
+        { threadId: "interrupted", turnId: "interrupted-turn" },
+        { threadId: "errored", turnId: "errored-turn" },
+        { threadId: "completed", turnId: "completed-turn" },
+      ]),
+      threads: [
+        makeThread("interrupted"),
+        makeThread("errored", { latestTurn: makeLatestTurn("errored-turn", "error") }),
+        makeThread("completed", { latestTurn: makeLatestTurn("completed-turn", "completed") }),
+      ],
+      projects: liveProjects,
+      now: NOW,
+    });
+
+    expect(plan.commands.map((command) => command.threadId)).toEqual([
+      threadId("interrupted"),
+      threadId("errored"),
+    ]);
+    expect(plan.skipped).toEqual([{ threadId: threadId("completed"), reason: "turn-completed" }]);
+  });
+
+  it("skips threads that are missing, deleted, archived, project-less, progressed, or in flight", () => {
     const plan = planQuitResumeTurns({
       record: makeRecord([
         { threadId: "missing", turnId: "missing-turn" },
         { threadId: "deleted", turnId: "deleted-turn" },
         { threadId: "archived", turnId: "archived-turn" },
         { threadId: "orphan", turnId: "orphan-turn" },
-        { threadId: "no-turn", turnId: null },
+        { threadId: "no-turn", turnId: "no-turn-turn" },
         { threadId: "progressed", turnId: "progressed-turn" },
         { threadId: "running", turnId: "running-turn" },
         { threadId: "ok", turnId: "ok-turn" },
@@ -168,7 +219,7 @@ describe("planQuitResumeTurns", () => {
         makeThread("orphan", { projectId: ProjectId.makeUnsafe("project-gone") }),
         makeThread("no-turn", { latestTurn: null }),
         makeThread("progressed", { latestTurn: makeLatestTurn("progressed-turn-2") }),
-        makeThread("running", { latestTurn: makeLatestTurn("running-turn", "running") }),
+        makeRunningThread("running"),
         makeThread("ok"),
       ],
       projects: [...liveProjects, { id: ProjectId.makeUnsafe("project-gone"), deletedAt: NOW }],
@@ -181,7 +232,7 @@ describe("planQuitResumeTurns", () => {
       { threadId: threadId("deleted"), reason: "thread-deleted" },
       { threadId: threadId("archived"), reason: "thread-archived" },
       { threadId: threadId("orphan"), reason: "project-missing" },
-      { threadId: threadId("no-turn"), reason: "no-turn" },
+      { threadId: threadId("no-turn"), reason: "turn-changed" },
       { threadId: threadId("progressed"), reason: "turn-changed" },
       { threadId: threadId("running"), reason: "turn-in-flight" },
     ]);
@@ -196,7 +247,7 @@ describe("quit resume record file", () => {
   const run = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
     Effect.runPromise(effect.pipe(Effect.provide(testLayer)) as Effect.Effect<A, E, never>);
 
-  it("persists, reads, and clears the record; a missing or corrupt file reads as none", async () => {
+  it("persists, reads, and clears the record; missing reads as absent, corrupt as invalid", async () => {
     const record = makeRecord([{ threadId: "a", turnId: "a-turn" }]);
     const result = await run(
       Effect.gen(function* () {
@@ -212,14 +263,71 @@ describe("quit resume record file", () => {
         const fs = yield* FileSystem.FileSystem;
         yield* fs.writeFileString(path, "{ not json");
         const corrupt = yield* readQuitResumeRecord(path);
+        yield* fs.writeFileString(path, "   \n");
+        const empty = yield* readQuitResumeRecord(path);
         yield* clearQuitResumeRecord(path);
-        return { missing, persisted, cleared, corrupt };
+        return { missing, persisted, cleared, corrupt, empty };
       }),
     );
 
-    expect(Option.isNone(result.missing)).toBe(true);
-    expect(Option.getOrNull(result.persisted)).toEqual(record);
-    expect(Option.isNone(result.cleared)).toBe(true);
-    expect(Option.isNone(result.corrupt)).toBe(true);
+    expect(result.missing).toEqual({ kind: "absent" });
+    expect(result.persisted).toEqual({ kind: "record", record });
+    expect(result.cleared).toEqual({ kind: "absent" });
+    expect(result.corrupt).toEqual({ kind: "invalid" });
+    expect(result.empty).toEqual({ kind: "invalid" });
+  });
+
+  it("prepareQuitResume records in-flight threads, interrupts them, and drops the record if the quit never happens", async () => {
+    const dispatched: OrchestrationCommand[] = [];
+    const result = await run(
+      Effect.gen(function* () {
+        const config = yield* ServerConfig;
+        const path = config.quitResumeStatePath;
+        const prepared = yield* prepareQuitResume({
+          request: {
+            threadIds: [threadId("a"), threadId("finished")],
+            continuationPrompt: PROMPT,
+          },
+          recordPath: path,
+          getReadModel: () =>
+            Effect.succeed({
+              threads: [
+                makeRunningThread("a"),
+                makeThread("finished", {
+                  latestTurn: makeLatestTurn("finished-turn", "completed"),
+                }),
+              ],
+            }),
+          dispatch: (command) =>
+            Effect.sync(() => {
+              dispatched.push(command);
+            }),
+          abandonAfter: Duration.millis(50),
+        });
+        const persisted = yield* readQuitResumeRecord(path);
+        // Still alive well after the abandon delay → the quit was cancelled.
+        const abandoned = yield* Effect.sleep(Duration.millis(400)).pipe(
+          Effect.andThen(readQuitResumeRecord(path)),
+        );
+        return { prepared, persisted, abandoned };
+      }),
+    );
+
+    expect(result.prepared.recordedThreadIds).toEqual([threadId("a")]);
+    expect(result.persisted.kind).toBe("record");
+    if (result.persisted.kind === "record") {
+      expect(result.persisted.record.threads).toEqual([
+        { threadId: threadId("a"), turnId: turnId("a-turn") },
+      ]);
+      expect(result.persisted.record.recordedAt).toBe(result.prepared.recordedAt);
+    }
+    expect(dispatched).toEqual([
+      expect.objectContaining({
+        type: "thread.turn.interrupt",
+        threadId: threadId("a"),
+        turnId: turnId("a-turn"),
+      }),
+    ]);
+    expect(result.abandoned).toEqual({ kind: "absent" });
   });
 });

--- a/apps/server/src/orchestration/quitResume.ts
+++ b/apps/server/src/orchestration/quitResume.ts
@@ -74,7 +74,10 @@ export const QUIT_RESUME_ABANDON_AFTER_MS = 30_000;
 /** Sleep without keeping the Node process alive during a normal desktop shutdown. */
 const sleepUnref = (duration: Duration.Input) =>
   Effect.callback<void>((resume) => {
-    const timer = setTimeout(() => resume(Effect.void), Duration.toMillis(duration));
+    const timer = setTimeout(
+      () => resume(Effect.void),
+      Duration.toMillis(Duration.fromInputUnsafe(duration)),
+    );
     timer.unref();
     return Effect.sync(() => clearTimeout(timer));
   });

--- a/apps/server/src/orchestration/quitResume.ts
+++ b/apps/server/src/orchestration/quitResume.ts
@@ -71,6 +71,14 @@ import { OrchestrationEngineService } from "./Services/OrchestrationEngine.ts";
  */
 export const QUIT_RESUME_ABANDON_AFTER_MS = 30_000;
 
+/** Sleep without keeping the Node process alive during a normal desktop shutdown. */
+const sleepUnref = (duration: Duration.Input) =>
+  Effect.callback<void>((resume) => {
+    const timer = setTimeout(() => resume(Effect.void), Duration.toMillis(duration));
+    timer.unref();
+    return Effect.sync(() => clearTimeout(timer));
+  });
+
 export const QuitResumeRecord = Schema.Struct({
   version: Schema.Literal(1),
   /** Unique per quit; command/message ids derive from it so replays dedup and quits never collide. */
@@ -306,19 +314,17 @@ export const readQuitResumeRecord = (
 
 /**
  * Take exclusive ownership of whatever record is at `path`: an atomic rename to a
- * private path (so a second process claiming the same state dir can win at most
- * once), read it, remove the private copy. `absent` when there was nothing to
- * claim. A private copy left behind by a crash mid-claim is discarded first —
- * its resume was already lost by then and it must never be mistaken for a fresh
- * record.
+ * claimant-unique private path (so a second process claiming the same state dir
+ * can win at most once without deleting the first claimant's file), read it,
+ * then remove the private copy. `absent` when there was nothing to claim. A
+ * private copy left behind by a crash is never mistaken for a fresh record.
  */
 export const claimQuitResumeRecord = (
   path: string,
 ): Effect.Effect<QuitResumeRecordRead, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const claimedPath = `${path}.claimed`;
-    yield* clearQuitResumeRecord(claimedPath).pipe(Effect.ignore);
+    const claimedPath = `${path}.${process.pid}.${randomUUID()}.claimed`;
     const exists = yield* fs.exists(path).pipe(Effect.orElseSucceed(() => false));
     if (!exists) {
       return { kind: "absent" } as const;
@@ -396,7 +402,7 @@ export const prepareQuitResume = (input: {
       threadIds: record.threads.map((entry) => entry.threadId),
     });
 
-    yield* Effect.sleep(input.abandonAfter ?? Duration.millis(QUIT_RESUME_ABANDON_AFTER_MS)).pipe(
+    yield* sleepUnref(input.abandonAfter ?? Duration.millis(QUIT_RESUME_ABANDON_AFTER_MS)).pipe(
       Effect.andThen(clearQuitResumeRecordIfOwned(input.recordPath, record.recordId)),
       Effect.flatMap((cleared) =>
         cleared
@@ -413,6 +419,9 @@ export const prepareQuitResume = (input: {
       Effect.forkDetach,
     );
 
+    // The durable write is the RPC acknowledgement contract. Interrupts are
+    // best-effort and must not make the renderer miss its bounded quit wait;
+    // process shutdown itself will stop any provider command that remains live.
     yield* Effect.forEach(
       record.threads,
       (entry) =>
@@ -433,8 +442,8 @@ export const prepareQuitResume = (input: {
               }),
             ),
           ),
-      { discard: true },
-    );
+      { discard: true, concurrency: "unbounded" },
+    ).pipe(Effect.forkDetach);
 
     return {
       recordedThreadIds: record.threads.map((entry) => entry.threadId),

--- a/apps/server/src/orchestration/quitResume.ts
+++ b/apps/server/src/orchestration/quitResume.ts
@@ -37,6 +37,7 @@ import {
   TurnId,
 } from "@synara/contracts";
 import { Effect, FileSystem, Option, Schema } from "effect";
+import { randomUUID } from "node:crypto";
 
 import { writeFileStringAtomically } from "../atomicWrite";
 import { ServerConfig } from "../config";
@@ -45,6 +46,8 @@ import { OrchestrationEngineService } from "./Services/OrchestrationEngine.ts";
 
 export const QuitResumeRecord = Schema.Struct({
   version: Schema.Literal(1),
+  /** Unique per quit; command/message ids derive from it so replays dedup and quits never collide. */
+  recordId: TrimmedNonEmptyString,
   recordedAt: IsoDateTime,
   continuationPrompt: TrimmedNonEmptyString.check(Schema.isMaxLength(QUIT_RESUME_MAX_PROMPT_CHARS)),
   threads: Schema.Array(
@@ -65,7 +68,13 @@ type ThreadTurnInterruptCommand = Extract<
   { readonly type: "thread.turn.interrupt" }
 >;
 
-/** Read-model thread fields the pure planners inspect (a superset is fine). */
+/** Read-model thread fields needed to snapshot a thread into the record. */
+export type QuitResumeRecordableThread = Pick<
+  OrchestrationThread,
+  "id" | "deletedAt" | "latestTurn"
+>;
+
+/** Read-model thread fields the boot-time planner inspects (a superset is fine). */
 export type QuitResumeThread = Pick<
   OrchestrationThread,
   | "id"
@@ -102,7 +111,8 @@ export interface QuitResumePlan {
  */
 export function buildQuitResumeRecord(input: {
   readonly request: OrchestrationPrepareQuitResumeInput;
-  readonly threads: ReadonlyArray<Pick<OrchestrationThread, "id" | "deletedAt" | "latestTurn">>;
+  readonly threads: ReadonlyArray<QuitResumeRecordableThread>;
+  readonly recordId: string;
   readonly now: string;
 }): QuitResumeRecord {
   const threadsById = new Map(input.threads.map((thread) => [thread.id, thread] as const));
@@ -121,6 +131,7 @@ export function buildQuitResumeRecord(input: {
   }
   return {
     version: 1,
+    recordId: input.recordId,
     recordedAt: input.now,
     continuationPrompt: input.request.continuationPrompt,
     threads,
@@ -130,11 +141,12 @@ export function buildQuitResumeRecord(input: {
 export function buildQuitInterruptCommand(input: {
   readonly threadId: ThreadId;
   readonly turnId: TurnId | null;
+  readonly recordId: string;
   readonly recordedAt: string;
 }): ThreadTurnInterruptCommand {
   return {
     type: "thread.turn.interrupt",
-    commandId: CommandId.makeUnsafe(`quit-resume-interrupt:${input.threadId}:${input.recordedAt}`),
+    commandId: CommandId.makeUnsafe(`quit-resume-interrupt:${input.recordId}:${input.threadId}`),
     threadId: input.threadId,
     ...(input.turnId !== null ? { turnId: input.turnId } : {}),
     createdAt: input.recordedAt,
@@ -198,7 +210,7 @@ export function planQuitResumeTurns(input: {
       skip(entry.threadId, "turn-in-flight");
       continue;
     }
-    const key = `quit-resume:${entry.threadId}:${input.record.recordedAt}`;
+    const key = `quit-resume:${input.record.recordId}:${entry.threadId}`;
     commands.push({
       type: "thread.turn.start",
       commandId: CommandId.makeUnsafe(key),
@@ -260,20 +272,18 @@ export const prepareQuitResume = (input: {
   readonly request: OrchestrationPrepareQuitResumeInput;
   readonly recordPath: string;
   readonly getReadModel: () => Effect.Effect<
-    {
-      readonly threads: ReadonlyArray<Pick<OrchestrationThread, "id" | "deletedAt" | "latestTurn">>;
-    },
+    { readonly threads: ReadonlyArray<QuitResumeRecordableThread> },
     never
   >;
   readonly dispatch: (command: OrchestrationCommand) => Effect.Effect<unknown, unknown>;
 }): Effect.Effect<OrchestrationPrepareQuitResumeResult, unknown> =>
   Effect.gen(function* () {
     const readModel = yield* input.getReadModel();
-    const now = new Date().toISOString();
     const record = buildQuitResumeRecord({
       request: input.request,
       threads: readModel.threads,
-      now,
+      recordId: randomUUID(),
+      now: new Date().toISOString(),
     });
     yield* persistQuitResumeRecord({ path: input.recordPath, record });
     yield* Effect.logInfo("recorded running chats for resume after quit", {
@@ -288,6 +298,7 @@ export const prepareQuitResume = (input: {
             buildQuitInterruptCommand({
               threadId: entry.threadId,
               turnId: entry.turnId,
+              recordId: record.recordId,
               recordedAt: record.recordedAt,
             }),
           )

--- a/apps/server/src/orchestration/quitResume.ts
+++ b/apps/server/src/orchestration/quitResume.ts
@@ -17,15 +17,21 @@
  * after writing it, the quit evidently did not happen and the record is removed
  * so an unrelated later restart never resumes those chats.
  *
- * At the next server start `resumeQuitInterruptedChats` claims the record
- * (atomic rename, then delete — a crash in between loses the resume rather than
- * doubling it, and a quit prepared during boot keeps its own fresh record),
- * filters out threads that moved on since the record was written, and dispatches
- * one ordinary user turn per remaining thread with the recorded continuation
- * prompt. Each turn carries a `resumePrecondition` so the decider re-checks the
- * same conditions atomically inside the serialized dispatch — a client command
- * landing between the plan and the dispatch cannot slip a stale continuation
- * through. No record → one `exists` check and nothing else.
+ * At the next server start `claimQuitResumeRecordAtStartup` consumes the record
+ * before commands are admitted (so no new quit can race it; atomic rename then
+ * delete — a crash in between loses the resume rather than doubling it), then
+ * `resumeQuitInterruptedChats` filters out threads that moved on since the record
+ * was written and dispatches one ordinary user turn per remaining thread with the
+ * recorded continuation prompt. Each turn carries a `resumePrecondition` so the
+ * decider re-checks the same conditions atomically inside the serialized
+ * dispatch — a client command landing between the plan and the dispatch cannot
+ * slip a stale continuation through. No record → one `exists` check and nothing
+ * else.
+ *
+ * Accepted residual windows (all require a second quit or a new turn to land
+ * within microseconds of the first): a turn that replaces the recorded one inside
+ * the prepare RPC is interrupted and not resumed; a second quit prepared exactly
+ * when the first one's abandon sweep fires loses its record.
  *
  * @module quitResume
  */
@@ -299,21 +305,24 @@ export const readQuitResumeRecord = (
   });
 
 /**
- * Take exclusive ownership of whatever record is at `path` right now: an atomic
- * rename to a private path, so a quit prepared concurrently writes a fresh file
- * that is left untouched for the next boot. Returns the claimed content and
- * removes the private copy; `absent` when there was nothing to claim.
+ * Take exclusive ownership of whatever record is at `path`: an atomic rename to a
+ * private path (so a second process claiming the same state dir can win at most
+ * once), read it, remove the private copy. `absent` when there was nothing to
+ * claim. A private copy left behind by a crash mid-claim is discarded first —
+ * its resume was already lost by then and it must never be mistaken for a fresh
+ * record.
  */
 export const claimQuitResumeRecord = (
   path: string,
 ): Effect.Effect<QuitResumeRecordRead, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
+    const claimedPath = `${path}.claimed`;
+    yield* clearQuitResumeRecord(claimedPath).pipe(Effect.ignore);
     const exists = yield* fs.exists(path).pipe(Effect.orElseSucceed(() => false));
     if (!exists) {
       return { kind: "absent" } as const;
     }
-    const claimedPath = `${path}.claimed`;
     const claimed = yield* fs.rename(path, claimedPath).pipe(
       Effect.as(true),
       Effect.catchCause((cause) =>
@@ -371,12 +380,15 @@ export const prepareQuitResume = (input: {
   readonly abandonAfter?: Duration.Input;
 }): Effect.Effect<OrchestrationPrepareQuitResumeResult, unknown, FileSystem.FileSystem> =>
   Effect.gen(function* () {
+    // Stamp before the snapshot: anything that completes after the snapshot is
+    // then provably "completed since the record" for the resume precondition.
+    const now = new Date().toISOString();
     const readModel = yield* input.getReadModel();
     const record = buildQuitResumeRecord({
       request: input.request,
       threads: readModel.threads,
       recordId: randomUUID(),
-      now: new Date().toISOString(),
+      now,
     });
     yield* persistQuitResumeRecord({ path: input.recordPath, record });
     yield* Effect.logInfo("recorded running chats for resume after quit", {
@@ -431,78 +443,94 @@ export const prepareQuitResume = (input: {
   });
 
 /**
- * Boot-time consumer. Runs once after restart reconciliation has settled the
- * orphaned turns; cheap when there is nothing to resume (one `exists` probe).
- * Every failure is contained and logged — resuming is best-effort and must never
- * affect server startup.
+ * Boot-time claim. Must run before commands are admitted so no quit prepared by
+ * a freshly connected client can interleave with it; cheap when there is nothing
+ * to resume (one `exists` probe). Never fails — resuming is best-effort.
  */
-export const resumeQuitInterruptedChats: Effect.Effect<
-  void,
+export const claimQuitResumeRecordAtStartup: Effect.Effect<
+  QuitResumeRecordRead,
   never,
-  OrchestrationEngineService | ServerConfig | FileSystem.FileSystem
+  ServerConfig | FileSystem.FileSystem
 > = Effect.gen(function* () {
   const config = yield* ServerConfig;
-  const engine = yield* OrchestrationEngineService;
-  const path = config.quitResumeStatePath;
-
   // Claim before dispatching: a second process or a crash mid-dispatch must
   // never resume the same chats twice. An unreadable record is consumed too, so
   // it does not get re-parsed (and silently ignored) on every later boot.
-  const claimed = yield* claimQuitResumeRecord(path);
-  if (claimed.kind === "absent") {
-    return;
-  }
+  const claimed = yield* claimQuitResumeRecord(config.quitResumeStatePath);
   if (claimed.kind === "invalid") {
-    yield* Effect.logWarning("dropped an unreadable quit-resume record", { path });
-    return;
-  }
-  const record = claimed.record;
-
-  const readModel = yield* engine.getReadModel();
-  const plan = planQuitResumeTurns({
-    record,
-    threads: readModel.threads,
-    projects: readModel.projects,
-    now: new Date().toISOString(),
-  });
-
-  if (plan.skipped.length > 0) {
-    yield* Effect.logInfo("skipping quit-resume for threads that moved on", {
-      recordId: record.recordId,
-      skipped: plan.skipped,
+    yield* Effect.logWarning("dropped an unreadable quit-resume record", {
+      path: config.quitResumeStatePath,
     });
   }
-  if (plan.commands.length === 0) {
-    return;
-  }
-
-  yield* Effect.logInfo("resuming chats interrupted by the previous quit", {
-    recordId: record.recordId,
-    recordedAt: record.recordedAt,
-    threadIds: plan.commands.map((command) => command.threadId),
-  });
-
-  yield* Effect.forEach(
-    plan.commands,
-    (command) =>
-      engine.dispatch(command).pipe(
-        // The decider re-checks the resume precondition atomically; a rejection
-        // here means the thread moved on between the plan and the dispatch.
-        Effect.catchTag("OrchestrationCommandInvariantError", (error) =>
-          Effect.logInfo("quit-resume turn was not accepted", {
-            threadId: command.threadId,
-            detail: error.detail,
-          }),
-        ),
-        Effect.catchCause((cause) =>
-          Effect.logWarning("quit-resume turn failed to dispatch", {
-            threadId: command.threadId,
-            cause,
-          }),
-        ),
-      ),
-    { discard: true },
-  );
+  return claimed;
 }).pipe(
-  Effect.catchCause((cause) => Effect.logWarning("resuming chats after quit failed", { cause })),
+  Effect.catchCause((cause) =>
+    Effect.logWarning("claiming the quit-resume record failed", { cause }).pipe(
+      Effect.as({ kind: "absent" } as const),
+    ),
+  ),
 );
+
+/**
+ * Boot-time consumer of a claimed record. Runs once after restart reconciliation
+ * has settled the orphaned turns. Every failure is contained and logged —
+ * resuming must never affect server startup.
+ */
+export const resumeQuitInterruptedChats = (
+  claimed: QuitResumeRecordRead,
+): Effect.Effect<void, never, OrchestrationEngineService> =>
+  Effect.gen(function* () {
+    if (claimed.kind !== "record") {
+      return;
+    }
+    const record = claimed.record;
+    const engine = yield* OrchestrationEngineService;
+
+    const readModel = yield* engine.getReadModel();
+    const plan = planQuitResumeTurns({
+      record,
+      threads: readModel.threads,
+      projects: readModel.projects,
+      now: new Date().toISOString(),
+    });
+
+    if (plan.skipped.length > 0) {
+      yield* Effect.logInfo("skipping quit-resume for threads that moved on", {
+        recordId: record.recordId,
+        skipped: plan.skipped,
+      });
+    }
+    if (plan.commands.length === 0) {
+      return;
+    }
+
+    yield* Effect.logInfo("resuming chats interrupted by the previous quit", {
+      recordId: record.recordId,
+      recordedAt: record.recordedAt,
+      threadIds: plan.commands.map((command) => command.threadId),
+    });
+
+    yield* Effect.forEach(
+      plan.commands,
+      (command) =>
+        engine.dispatch(command).pipe(
+          // The decider re-checks the resume precondition atomically; a rejection
+          // here means the thread moved on between the plan and the dispatch.
+          Effect.catchTag("OrchestrationCommandInvariantError", (error) =>
+            Effect.logInfo("quit-resume turn was not accepted", {
+              threadId: command.threadId,
+              detail: error.detail,
+            }),
+          ),
+          Effect.catchCause((cause) =>
+            Effect.logWarning("quit-resume turn failed to dispatch", {
+              threadId: command.threadId,
+              cause,
+            }),
+          ),
+        ),
+      { discard: true },
+    );
+  }).pipe(
+    Effect.catchCause((cause) => Effect.logWarning("resuming chats after quit failed", { cause })),
+  );

--- a/apps/server/src/orchestration/quitResume.ts
+++ b/apps/server/src/orchestration/quitResume.ts
@@ -1,0 +1,386 @@
+/**
+ * quitResume - "Resume chats automatically" after a desktop quit.
+ *
+ * When the user quits the desktop app while chats are running and leaves the
+ * "Resume chats automatically" box checked, the renderer calls the
+ * `orchestration.prepareQuitResume` RPC *before* answering the quit request.
+ * `prepareQuitResume` durably records the listed threads (with the turn that was
+ * running at that moment) in a small JSON file next to the other server state,
+ * then interrupts those turns. Because the record is written before the renderer
+ * replies `allow`, it survives the renderer and the backend being torn down
+ * mid-flight; a failed write fails the RPC and the renderer falls back to a plain
+ * interrupt-and-quit.
+ *
+ * At the next server start `resumeQuitInterruptedChats` consumes the record
+ * (delete first, then dispatch — a crash in between loses the resume rather than
+ * doubling it), filters out threads that moved on since the record was written,
+ * and dispatches one ordinary user turn per remaining thread with the recorded
+ * continuation prompt. No record → one `exists` check and nothing else.
+ *
+ * @module quitResume
+ */
+import type {
+  OrchestrationCommand,
+  OrchestrationPrepareQuitResumeInput,
+  OrchestrationPrepareQuitResumeResult,
+  OrchestrationProject,
+  OrchestrationThread,
+} from "@synara/contracts";
+import {
+  CommandId,
+  IsoDateTime,
+  MessageId,
+  QUIT_RESUME_MAX_PROMPT_CHARS,
+  QUIT_RESUME_MAX_THREADS,
+  ThreadId,
+  TrimmedNonEmptyString,
+  TurnId,
+} from "@synara/contracts";
+import { Effect, FileSystem, Option, Schema } from "effect";
+
+import { writeFileStringAtomically } from "../atomicWrite";
+import { ServerConfig } from "../config";
+import { threadHasInFlightTurn } from "./commandInvariants.ts";
+import { OrchestrationEngineService } from "./Services/OrchestrationEngine.ts";
+
+export const QuitResumeRecord = Schema.Struct({
+  version: Schema.Literal(1),
+  recordedAt: IsoDateTime,
+  continuationPrompt: TrimmedNonEmptyString.check(Schema.isMaxLength(QUIT_RESUME_MAX_PROMPT_CHARS)),
+  threads: Schema.Array(
+    Schema.Struct({
+      threadId: ThreadId,
+      /** Latest turn when the record was written; `null` when the thread had none yet. */
+      turnId: Schema.NullOr(TurnId),
+    }),
+  ).check(Schema.isMaxLength(QUIT_RESUME_MAX_THREADS)),
+});
+export type QuitResumeRecord = typeof QuitResumeRecord.Type;
+
+const decodeQuitResumeRecord = Schema.decodeUnknownEffect(Schema.fromJsonString(QuitResumeRecord));
+
+type ThreadTurnStartCommand = Extract<OrchestrationCommand, { readonly type: "thread.turn.start" }>;
+type ThreadTurnInterruptCommand = Extract<
+  OrchestrationCommand,
+  { readonly type: "thread.turn.interrupt" }
+>;
+
+/** Read-model thread fields the pure planners inspect (a superset is fine). */
+export type QuitResumeThread = Pick<
+  OrchestrationThread,
+  | "id"
+  | "projectId"
+  | "deletedAt"
+  | "archivedAt"
+  | "latestTurn"
+  | "session"
+  | "runtimeMode"
+  | "interactionMode"
+>;
+export type QuitResumeProject = Pick<OrchestrationProject, "id" | "deletedAt">;
+
+export type QuitResumeSkipReason =
+  | "thread-missing"
+  | "thread-deleted"
+  | "thread-archived"
+  | "project-missing"
+  | "no-turn"
+  | "turn-changed"
+  | "turn-in-flight";
+
+export interface QuitResumePlan {
+  readonly commands: ReadonlyArray<ThreadTurnStartCommand>;
+  readonly skipped: ReadonlyArray<{
+    readonly threadId: ThreadId;
+    readonly reason: QuitResumeSkipReason;
+  }>;
+}
+
+/**
+ * Pure: snapshot the requested threads into a record. Unknown and deleted threads
+ * are dropped (nothing to resume), duplicates collapse, order is preserved.
+ */
+export function buildQuitResumeRecord(input: {
+  readonly request: OrchestrationPrepareQuitResumeInput;
+  readonly threads: ReadonlyArray<Pick<OrchestrationThread, "id" | "deletedAt" | "latestTurn">>;
+  readonly now: string;
+}): QuitResumeRecord {
+  const threadsById = new Map(input.threads.map((thread) => [thread.id, thread] as const));
+  const seen = new Set<ThreadId>();
+  const threads: Array<QuitResumeRecord["threads"][number]> = [];
+  for (const threadId of input.request.threadIds) {
+    if (seen.has(threadId)) {
+      continue;
+    }
+    seen.add(threadId);
+    const thread = threadsById.get(threadId);
+    if (!thread || thread.deletedAt !== null) {
+      continue;
+    }
+    threads.push({ threadId, turnId: thread.latestTurn?.turnId ?? null });
+  }
+  return {
+    version: 1,
+    recordedAt: input.now,
+    continuationPrompt: input.request.continuationPrompt,
+    threads,
+  };
+}
+
+export function buildQuitInterruptCommand(input: {
+  readonly threadId: ThreadId;
+  readonly turnId: TurnId | null;
+  readonly recordedAt: string;
+}): ThreadTurnInterruptCommand {
+  return {
+    type: "thread.turn.interrupt",
+    commandId: CommandId.makeUnsafe(`quit-resume-interrupt:${input.threadId}:${input.recordedAt}`),
+    threadId: input.threadId,
+    ...(input.turnId !== null ? { turnId: input.turnId } : {}),
+    createdAt: input.recordedAt,
+  };
+}
+
+/**
+ * Pure: map a consumed record onto the current read model. A thread is resumed
+ * only when it still exists, is neither deleted nor archived, its project exists,
+ * its latest turn is exactly the one recorded at quit time, and nothing is in
+ * flight on it. The continuation is an ordinary user turn on the thread's own
+ * model/runtime/interaction settings (model omitted → provider reactor uses the
+ * thread's current selection).
+ *
+ * Command and message ids are derived from the record so an accidental re-run
+ * collides with the engine's receipt dedup instead of starting a second turn.
+ */
+export function planQuitResumeTurns(input: {
+  readonly record: QuitResumeRecord;
+  readonly threads: ReadonlyArray<QuitResumeThread>;
+  readonly projects: ReadonlyArray<QuitResumeProject>;
+  readonly now: string;
+}): QuitResumePlan {
+  const threadsById = new Map(input.threads.map((thread) => [thread.id, thread] as const));
+  const liveProjectIds = new Set(
+    input.projects.filter((project) => project.deletedAt === null).map((project) => project.id),
+  );
+  const commands: ThreadTurnStartCommand[] = [];
+  const skipped: Array<{ threadId: ThreadId; reason: QuitResumeSkipReason }> = [];
+  const skip = (threadId: ThreadId, reason: QuitResumeSkipReason) => {
+    skipped.push({ threadId, reason });
+  };
+
+  for (const entry of input.record.threads) {
+    const thread = threadsById.get(entry.threadId);
+    if (!thread) {
+      skip(entry.threadId, "thread-missing");
+      continue;
+    }
+    if (thread.deletedAt !== null) {
+      skip(entry.threadId, "thread-deleted");
+      continue;
+    }
+    if (thread.archivedAt != null) {
+      skip(entry.threadId, "thread-archived");
+      continue;
+    }
+    if (!liveProjectIds.has(thread.projectId)) {
+      skip(entry.threadId, "project-missing");
+      continue;
+    }
+    if (entry.turnId === null) {
+      skip(entry.threadId, "no-turn");
+      continue;
+    }
+    if ((thread.latestTurn?.turnId ?? null) !== entry.turnId) {
+      skip(entry.threadId, "turn-changed");
+      continue;
+    }
+    if (threadHasInFlightTurn(thread)) {
+      skip(entry.threadId, "turn-in-flight");
+      continue;
+    }
+    const key = `quit-resume:${entry.threadId}:${input.record.recordedAt}`;
+    commands.push({
+      type: "thread.turn.start",
+      commandId: CommandId.makeUnsafe(key),
+      threadId: entry.threadId,
+      message: {
+        messageId: MessageId.makeUnsafe(key),
+        role: "user",
+        text: input.record.continuationPrompt,
+        attachments: [],
+      },
+      dispatchMode: "queue",
+      runtimeMode: thread.runtimeMode,
+      interactionMode: thread.interactionMode,
+      createdAt: input.now,
+    });
+  }
+
+  return { commands, skipped };
+}
+
+export const persistQuitResumeRecord = (input: {
+  readonly path: string;
+  readonly record: QuitResumeRecord;
+}) =>
+  writeFileStringAtomically({
+    filePath: input.path,
+    contents: `${JSON.stringify(input.record)}\n`,
+  });
+
+export const clearQuitResumeRecord = (path: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    yield* fs.remove(path, { force: true });
+  });
+
+/** `None` when the file is absent, empty, or does not decode (a corrupt record is ignored). */
+export const readQuitResumeRecord = (path: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const exists = yield* fs.exists(path).pipe(Effect.orElseSucceed(() => false));
+    if (!exists) {
+      return Option.none<QuitResumeRecord>();
+    }
+    const raw = yield* fs.readFileString(path).pipe(Effect.orElseSucceed(() => ""));
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) {
+      return Option.none<QuitResumeRecord>();
+    }
+    return yield* decodeQuitResumeRecord(trimmed).pipe(Effect.option);
+  });
+
+/**
+ * RPC body: record first (failure fails the call so the renderer can fall back to
+ * a plain interrupt), then interrupt every recorded thread. Interrupt failures
+ * are logged, not surfaced — the record is already durable and the restart
+ * reconciliation heals any turn the interrupt did not reach.
+ */
+export const prepareQuitResume = (input: {
+  readonly request: OrchestrationPrepareQuitResumeInput;
+  readonly recordPath: string;
+  readonly getReadModel: () => Effect.Effect<
+    {
+      readonly threads: ReadonlyArray<Pick<OrchestrationThread, "id" | "deletedAt" | "latestTurn">>;
+    },
+    never
+  >;
+  readonly dispatch: (command: OrchestrationCommand) => Effect.Effect<unknown, unknown>;
+}): Effect.Effect<OrchestrationPrepareQuitResumeResult, unknown> =>
+  Effect.gen(function* () {
+    const readModel = yield* input.getReadModel();
+    const now = new Date().toISOString();
+    const record = buildQuitResumeRecord({
+      request: input.request,
+      threads: readModel.threads,
+      now,
+    });
+    yield* persistQuitResumeRecord({ path: input.recordPath, record });
+    yield* Effect.logInfo("recorded running chats for resume after quit", {
+      threadIds: record.threads.map((entry) => entry.threadId),
+    });
+
+    yield* Effect.forEach(
+      record.threads,
+      (entry) =>
+        input
+          .dispatch(
+            buildQuitInterruptCommand({
+              threadId: entry.threadId,
+              turnId: entry.turnId,
+              recordedAt: record.recordedAt,
+            }),
+          )
+          .pipe(
+            Effect.catchCause((cause) =>
+              Effect.logWarning("failed to interrupt chat for quit", {
+                threadId: entry.threadId,
+                cause,
+              }),
+            ),
+          ),
+      { discard: true },
+    );
+
+    return {
+      recordedThreadIds: record.threads.map((entry) => entry.threadId),
+      recordedAt: record.recordedAt,
+    };
+  });
+
+/**
+ * Boot-time consumer. Runs once after restart reconciliation has settled the
+ * orphaned turns; cheap when there is nothing to resume (one `exists` probe).
+ * Every failure is contained and logged — resuming is best-effort and must never
+ * affect server startup.
+ */
+export const resumeQuitInterruptedChats: Effect.Effect<
+  void,
+  never,
+  OrchestrationEngineService | ServerConfig | FileSystem.FileSystem
+> = Effect.gen(function* () {
+  const config = yield* ServerConfig;
+  const engine = yield* OrchestrationEngineService;
+  const path = config.quitResumeStatePath;
+
+  const recordOption = yield* readQuitResumeRecord(path);
+  if (Option.isNone(recordOption)) {
+    return;
+  }
+  const record = recordOption.value;
+
+  // Consume before dispatching: a second process or a crash mid-dispatch must
+  // never resume the same chats twice.
+  const cleared = yield* clearQuitResumeRecord(path).pipe(
+    Effect.as(true),
+    Effect.catchCause((cause) =>
+      Effect.logWarning("quit-resume record could not be consumed; skipping resume", {
+        path,
+        cause,
+      }).pipe(Effect.as(false)),
+    ),
+  );
+  if (!cleared) {
+    return;
+  }
+
+  const readModel = yield* engine.getReadModel();
+  const plan = planQuitResumeTurns({
+    record,
+    threads: readModel.threads,
+    projects: readModel.projects,
+    now: new Date().toISOString(),
+  });
+
+  if (plan.skipped.length > 0) {
+    yield* Effect.logInfo("skipping quit-resume for threads that moved on", {
+      skipped: plan.skipped,
+    });
+  }
+  if (plan.commands.length === 0) {
+    return;
+  }
+
+  yield* Effect.logInfo("resuming chats interrupted by the previous quit", {
+    recordedAt: record.recordedAt,
+    threadIds: plan.commands.map((command) => command.threadId),
+  });
+
+  yield* Effect.forEach(
+    plan.commands,
+    (command) =>
+      engine.dispatch(command).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning("failed to resume chat after quit", {
+            threadId: command.threadId,
+            cause,
+          }),
+        ),
+      ),
+    { discard: true },
+  );
+}).pipe(
+  Effect.catchCause((cause) =>
+    Effect.logWarning("quit-resume failed; continuing startup", { cause }),
+  ),
+);

--- a/apps/server/src/orchestration/quitResume.ts
+++ b/apps/server/src/orchestration/quitResume.ts
@@ -4,18 +4,26 @@
  * When the user quits the desktop app while chats are running and leaves the
  * "Resume chats automatically" box checked, the renderer calls the
  * `orchestration.prepareQuitResume` RPC *before* answering the quit request.
- * `prepareQuitResume` durably records the listed threads (with the turn that was
- * running at that moment) in a small JSON file next to the other server state,
- * then interrupts those turns. Because the record is written before the renderer
- * replies `allow`, it survives the renderer and the backend being torn down
- * mid-flight; a failed write fails the RPC and the renderer falls back to a plain
- * interrupt-and-quit.
+ * `prepareQuitResume` durably records the listed threads that are genuinely
+ * in flight (with the turn that was running at that moment) in a small JSON
+ * file next to the other server state, then interrupts those turns. Because the
+ * record is written before the renderer replies `allow`, it survives the renderer
+ * and the backend being torn down mid-flight; a failed write fails the RPC and the
+ * renderer falls back to a plain interrupt-and-quit.
+ *
+ * A quit can still be cancelled after the record exists (renderer crash, desktop
+ * refusing to quit). If this process is still alive `QUIT_RESUME_ABANDON_AFTER_MS`
+ * later, the quit evidently did not happen and the record is removed so an
+ * unrelated later restart never resumes those chats.
  *
  * At the next server start `resumeQuitInterruptedChats` consumes the record
  * (delete first, then dispatch — a crash in between loses the resume rather than
  * doubling it), filters out threads that moved on since the record was written,
  * and dispatches one ordinary user turn per remaining thread with the recorded
- * continuation prompt. No record → one `exists` check and nothing else.
+ * continuation prompt. Each turn carries a `resumePrecondition` so the decider
+ * re-checks the same conditions atomically inside the serialized dispatch — a
+ * client command landing between the plan and the dispatch cannot slip a stale
+ * continuation through. No record → one `exists` check and nothing else.
  *
  * @module quitResume
  */
@@ -36,13 +44,24 @@ import {
   TrimmedNonEmptyString,
   TurnId,
 } from "@synara/contracts";
-import { Effect, FileSystem, Option, Schema } from "effect";
+import { Duration, Effect, FileSystem, Schema } from "effect";
 import { randomUUID } from "node:crypto";
 
 import { writeFileStringAtomically } from "../atomicWrite";
 import { ServerConfig } from "../config";
-import { threadHasInFlightTurn } from "./commandInvariants.ts";
+import {
+  threadHasInFlightTurn,
+  threadResumePreconditionViolation,
+  type ThreadResumePreconditionViolation,
+} from "./commandInvariants.ts";
 import { OrchestrationEngineService } from "./Services/OrchestrationEngine.ts";
+
+/**
+ * A quit normally stops this process within seconds (desktop shutdown timeout is
+ * 10s). A record still owned by a live process this long after it was written
+ * belongs to a quit that was cancelled and must not survive.
+ */
+export const QUIT_RESUME_ABANDON_AFTER_MS = 30_000;
 
 export const QuitResumeRecord = Schema.Struct({
   version: Schema.Literal(1),
@@ -53,8 +72,8 @@ export const QuitResumeRecord = Schema.Struct({
   threads: Schema.Array(
     Schema.Struct({
       threadId: ThreadId,
-      /** Latest turn when the record was written; `null` when the thread had none yet. */
-      turnId: Schema.NullOr(TurnId),
+      /** The turn that was in flight when the record was written. */
+      turnId: TurnId,
     }),
   ).check(Schema.isMaxLength(QUIT_RESUME_MAX_THREADS)),
 });
@@ -71,7 +90,7 @@ type ThreadTurnInterruptCommand = Extract<
 /** Read-model thread fields needed to snapshot a thread into the record. */
 export type QuitResumeRecordableThread = Pick<
   OrchestrationThread,
-  "id" | "deletedAt" | "latestTurn"
+  "id" | "deletedAt" | "latestTurn" | "session"
 >;
 
 /** Read-model thread fields the boot-time planner inspects (a superset is fine). */
@@ -91,11 +110,8 @@ export type QuitResumeProject = Pick<OrchestrationProject, "id" | "deletedAt">;
 export type QuitResumeSkipReason =
   | "thread-missing"
   | "thread-deleted"
-  | "thread-archived"
   | "project-missing"
-  | "no-turn"
-  | "turn-changed"
-  | "turn-in-flight";
+  | ThreadResumePreconditionViolation;
 
 export interface QuitResumePlan {
   readonly commands: ReadonlyArray<ThreadTurnStartCommand>;
@@ -106,8 +122,10 @@ export interface QuitResumePlan {
 }
 
 /**
- * Pure: snapshot the requested threads into a record. Unknown and deleted threads
- * are dropped (nothing to resume), duplicates collapse, order is preserved.
+ * Pure: snapshot the requested threads into a record. Only threads that are
+ * genuinely in flight with a known turn are remembered — the dialog shows a
+ * snapshot, and a chat that finished while it was open has nothing to resume.
+ * Unknown and deleted threads are dropped, duplicates collapse, order is kept.
  */
 export function buildQuitResumeRecord(input: {
   readonly request: OrchestrationPrepareQuitResumeInput;
@@ -124,10 +142,15 @@ export function buildQuitResumeRecord(input: {
     }
     seen.add(threadId);
     const thread = threadsById.get(threadId);
-    if (!thread || thread.deletedAt !== null) {
+    if (
+      !thread ||
+      thread.deletedAt !== null ||
+      thread.latestTurn === null ||
+      !threadHasInFlightTurn(thread)
+    ) {
       continue;
     }
-    threads.push({ threadId, turnId: thread.latestTurn?.turnId ?? null });
+    threads.push({ threadId, turnId: thread.latestTurn.turnId });
   }
   return {
     version: 1,
@@ -140,7 +163,7 @@ export function buildQuitResumeRecord(input: {
 
 export function buildQuitInterruptCommand(input: {
   readonly threadId: ThreadId;
-  readonly turnId: TurnId | null;
+  readonly turnId: TurnId;
   readonly recordId: string;
   readonly recordedAt: string;
 }): ThreadTurnInterruptCommand {
@@ -148,20 +171,21 @@ export function buildQuitInterruptCommand(input: {
     type: "thread.turn.interrupt",
     commandId: CommandId.makeUnsafe(`quit-resume-interrupt:${input.recordId}:${input.threadId}`),
     threadId: input.threadId,
-    ...(input.turnId !== null ? { turnId: input.turnId } : {}),
+    turnId: input.turnId,
     createdAt: input.recordedAt,
   };
 }
 
 /**
  * Pure: map a consumed record onto the current read model. A thread is resumed
- * only when it still exists, is neither deleted nor archived, its project exists,
- * its latest turn is exactly the one recorded at quit time, and nothing is in
- * flight on it. The continuation is an ordinary user turn on the thread's own
- * model/runtime/interaction settings (model omitted → provider reactor uses the
- * thread's current selection).
+ * only when it still exists, is not deleted, its project exists, and
+ * `threadResumePreconditionViolation` is clear (not archived, latest turn is
+ * exactly the recorded one, nothing in flight, not completed on its own). The
+ * continuation is an ordinary user turn on the thread's own runtime/interaction
+ * settings (model omitted → provider reactor uses the thread's current selection)
+ * and carries the same precondition for the decider to enforce atomically.
  *
- * Command and message ids are derived from the record so an accidental re-run
+ * Command and message ids derive from the record so an accidental re-run
  * collides with the engine's receipt dedup instead of starting a second turn.
  */
 export function planQuitResumeTurns(input: {
@@ -190,24 +214,14 @@ export function planQuitResumeTurns(input: {
       skip(entry.threadId, "thread-deleted");
       continue;
     }
-    if (thread.archivedAt != null) {
-      skip(entry.threadId, "thread-archived");
-      continue;
-    }
     if (!liveProjectIds.has(thread.projectId)) {
       skip(entry.threadId, "project-missing");
       continue;
     }
-    if (entry.turnId === null) {
-      skip(entry.threadId, "no-turn");
-      continue;
-    }
-    if ((thread.latestTurn?.turnId ?? null) !== entry.turnId) {
-      skip(entry.threadId, "turn-changed");
-      continue;
-    }
-    if (threadHasInFlightTurn(thread)) {
-      skip(entry.threadId, "turn-in-flight");
+    const resumePrecondition = { expectedLatestTurnId: entry.turnId };
+    const violation = threadResumePreconditionViolation(thread, resumePrecondition);
+    if (violation) {
+      skip(entry.threadId, violation);
       continue;
     }
     const key = `quit-resume:${input.record.recordId}:${entry.threadId}`;
@@ -224,6 +238,7 @@ export function planQuitResumeTurns(input: {
       dispatchMode: "queue",
       runtimeMode: thread.runtimeMode,
       interactionMode: thread.interactionMode,
+      resumePrecondition,
       createdAt: input.now,
     });
   }
@@ -246,27 +261,53 @@ export const clearQuitResumeRecord = (path: string) =>
     yield* fs.remove(path, { force: true });
   });
 
-/** `None` when the file is absent, empty, or does not decode (a corrupt record is ignored). */
-export const readQuitResumeRecord = (path: string) =>
+export type QuitResumeRecordRead =
+  | { readonly kind: "absent" }
+  | { readonly kind: "invalid" }
+  | { readonly kind: "record"; readonly record: QuitResumeRecord };
+
+/** `absent` when the file is missing or unreadable, `invalid` when present but not a record. */
+export const readQuitResumeRecord = (
+  path: string,
+): Effect.Effect<QuitResumeRecordRead, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const exists = yield* fs.exists(path).pipe(Effect.orElseSucceed(() => false));
     if (!exists) {
-      return Option.none<QuitResumeRecord>();
+      return { kind: "absent" } as const;
     }
     const raw = yield* fs.readFileString(path).pipe(Effect.orElseSucceed(() => ""));
     const trimmed = raw.trim();
     if (trimmed.length === 0) {
-      return Option.none<QuitResumeRecord>();
+      return { kind: "invalid" } as const;
     }
-    return yield* decodeQuitResumeRecord(trimmed).pipe(Effect.option);
+    return yield* decodeQuitResumeRecord(trimmed).pipe(
+      Effect.map((record) => ({ kind: "record", record }) as const),
+      Effect.orElseSucceed(() => ({ kind: "invalid" }) as const),
+    );
+  });
+
+/**
+ * Remove the record only if it is still the one with `recordId`: a newer quit
+ * may have replaced it in the meantime and must keep its own record.
+ */
+const clearQuitResumeRecordIfOwned = (path: string, recordId: string) =>
+  Effect.gen(function* () {
+    const current = yield* readQuitResumeRecord(path);
+    if (current.kind !== "record" || current.record.recordId !== recordId) {
+      return false;
+    }
+    yield* clearQuitResumeRecord(path);
+    return true;
   });
 
 /**
  * RPC body: record first (failure fails the call so the renderer can fall back to
  * a plain interrupt), then interrupt every recorded thread. Interrupt failures
  * are logged, not surfaced — the record is already durable and the restart
- * reconciliation heals any turn the interrupt did not reach.
+ * reconciliation heals any turn the interrupt did not reach. Finally arm the
+ * abandon sweep: if this process is still running after
+ * `QUIT_RESUME_ABANDON_AFTER_MS`, the quit was cancelled and the record is dropped.
  */
 export const prepareQuitResume = (input: {
   readonly request: OrchestrationPrepareQuitResumeInput;
@@ -276,7 +317,8 @@ export const prepareQuitResume = (input: {
     never
   >;
   readonly dispatch: (command: OrchestrationCommand) => Effect.Effect<unknown, unknown>;
-}): Effect.Effect<OrchestrationPrepareQuitResumeResult, unknown> =>
+  readonly abandonAfter?: Duration.Input;
+}): Effect.Effect<OrchestrationPrepareQuitResumeResult, unknown, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const readModel = yield* input.getReadModel();
     const record = buildQuitResumeRecord({
@@ -287,6 +329,7 @@ export const prepareQuitResume = (input: {
     });
     yield* persistQuitResumeRecord({ path: input.recordPath, record });
     yield* Effect.logInfo("recorded running chats for resume after quit", {
+      recordId: record.recordId,
       threadIds: record.threads.map((entry) => entry.threadId),
     });
 
@@ -313,6 +356,23 @@ export const prepareQuitResume = (input: {
       { discard: true },
     );
 
+    yield* Effect.sleep(input.abandonAfter ?? Duration.millis(QUIT_RESUME_ABANDON_AFTER_MS)).pipe(
+      Effect.andThen(clearQuitResumeRecordIfOwned(input.recordPath, record.recordId)),
+      Effect.flatMap((cleared) =>
+        cleared
+          ? Effect.logWarning("quit did not complete; dropped the quit-resume record", {
+              recordId: record.recordId,
+            })
+          : Effect.void,
+      ),
+      Effect.catchCause((cause) =>
+        Effect.logWarning("quit-resume abandon sweep failed", { recordId: record.recordId, cause }),
+      ),
+      // Detached on purpose: the sweep must outlive this request. If the process
+      // exits first (the normal quit), the fiber simply dies with it.
+      Effect.forkDetach,
+    );
+
     return {
       recordedThreadIds: record.threads.map((entry) => entry.threadId),
       recordedAt: record.recordedAt,
@@ -334,14 +394,14 @@ export const resumeQuitInterruptedChats: Effect.Effect<
   const engine = yield* OrchestrationEngineService;
   const path = config.quitResumeStatePath;
 
-  const recordOption = yield* readQuitResumeRecord(path);
-  if (Option.isNone(recordOption)) {
+  const read = yield* readQuitResumeRecord(path);
+  if (read.kind === "absent") {
     return;
   }
-  const record = recordOption.value;
 
   // Consume before dispatching: a second process or a crash mid-dispatch must
-  // never resume the same chats twice.
+  // never resume the same chats twice. An unreadable record is dropped too, so
+  // it does not get re-parsed (and silently ignored) on every later boot.
   const cleared = yield* clearQuitResumeRecord(path).pipe(
     Effect.as(true),
     Effect.catchCause((cause) =>
@@ -354,6 +414,11 @@ export const resumeQuitInterruptedChats: Effect.Effect<
   if (!cleared) {
     return;
   }
+  if (read.kind === "invalid") {
+    yield* Effect.logWarning("dropped an unreadable quit-resume record", { path });
+    return;
+  }
+  const record = read.record;
 
   const readModel = yield* engine.getReadModel();
   const plan = planQuitResumeTurns({
@@ -365,6 +430,7 @@ export const resumeQuitInterruptedChats: Effect.Effect<
 
   if (plan.skipped.length > 0) {
     yield* Effect.logInfo("skipping quit-resume for threads that moved on", {
+      recordId: record.recordId,
       skipped: plan.skipped,
     });
   }
@@ -373,6 +439,7 @@ export const resumeQuitInterruptedChats: Effect.Effect<
   }
 
   yield* Effect.logInfo("resuming chats interrupted by the previous quit", {
+    recordId: record.recordId,
     recordedAt: record.recordedAt,
     threadIds: plan.commands.map((command) => command.threadId),
   });
@@ -381,8 +448,10 @@ export const resumeQuitInterruptedChats: Effect.Effect<
     plan.commands,
     (command) =>
       engine.dispatch(command).pipe(
+        // The decider re-checks the resume precondition atomically; a rejection
+        // here means the thread moved on between the plan and the dispatch.
         Effect.catchCause((cause) =>
-          Effect.logWarning("failed to resume chat after quit", {
+          Effect.logInfo("quit-resume turn was not accepted", {
             threadId: command.threadId,
             cause,
           }),
@@ -391,7 +460,5 @@ export const resumeQuitInterruptedChats: Effect.Effect<
     { discard: true },
   );
 }).pipe(
-  Effect.catchCause((cause) =>
-    Effect.logWarning("quit-resume failed; continuing startup", { cause }),
-  ),
+  Effect.catchCause((cause) => Effect.logWarning("resuming chats after quit failed", { cause })),
 );

--- a/apps/server/src/orchestration/quitResume.ts
+++ b/apps/server/src/orchestration/quitResume.ts
@@ -5,25 +5,27 @@
  * "Resume chats automatically" box checked, the renderer calls the
  * `orchestration.prepareQuitResume` RPC *before* answering the quit request.
  * `prepareQuitResume` durably records the listed threads that are genuinely
- * in flight (with the turn that was running at that moment) in a small JSON
- * file next to the other server state, then interrupts those turns. Because the
- * record is written before the renderer replies `allow`, it survives the renderer
- * and the backend being torn down mid-flight; a failed write fails the RPC and the
- * renderer falls back to a plain interrupt-and-quit.
+ * in flight (with the turn that was running at that moment, or none while the
+ * provider was still connecting) in a small JSON file next to the other server
+ * state, then interrupts those turns. Because the record is written before the
+ * renderer replies `allow`, it survives the renderer and the backend being torn
+ * down mid-flight; a failed write fails the RPC and the renderer falls back to a
+ * plain interrupt-and-quit.
  *
  * A quit can still be cancelled after the record exists (renderer crash, desktop
  * refusing to quit). If this process is still alive `QUIT_RESUME_ABANDON_AFTER_MS`
- * later, the quit evidently did not happen and the record is removed so an
- * unrelated later restart never resumes those chats.
+ * after writing it, the quit evidently did not happen and the record is removed
+ * so an unrelated later restart never resumes those chats.
  *
- * At the next server start `resumeQuitInterruptedChats` consumes the record
- * (delete first, then dispatch — a crash in between loses the resume rather than
- * doubling it), filters out threads that moved on since the record was written,
- * and dispatches one ordinary user turn per remaining thread with the recorded
- * continuation prompt. Each turn carries a `resumePrecondition` so the decider
- * re-checks the same conditions atomically inside the serialized dispatch — a
- * client command landing between the plan and the dispatch cannot slip a stale
- * continuation through. No record → one `exists` check and nothing else.
+ * At the next server start `resumeQuitInterruptedChats` claims the record
+ * (atomic rename, then delete — a crash in between loses the resume rather than
+ * doubling it, and a quit prepared during boot keeps its own fresh record),
+ * filters out threads that moved on since the record was written, and dispatches
+ * one ordinary user turn per remaining thread with the recorded continuation
+ * prompt. Each turn carries a `resumePrecondition` so the decider re-checks the
+ * same conditions atomically inside the serialized dispatch — a client command
+ * landing between the plan and the dispatch cannot slip a stale continuation
+ * through. No record → one `exists` check and nothing else.
  *
  * @module quitResume
  */
@@ -72,8 +74,8 @@ export const QuitResumeRecord = Schema.Struct({
   threads: Schema.Array(
     Schema.Struct({
       threadId: ThreadId,
-      /** The turn that was in flight when the record was written. */
-      turnId: TurnId,
+      /** The turn in flight when the record was written; null while the provider was still connecting. */
+      turnId: Schema.NullOr(TurnId),
     }),
   ).check(Schema.isMaxLength(QUIT_RESUME_MAX_THREADS)),
 });
@@ -121,11 +123,19 @@ export interface QuitResumePlan {
   }>;
 }
 
+/** The turn a thread is running right now, or null while its provider is still connecting. */
+function inFlightTurnId(thread: QuitResumeRecordableThread): TurnId | null {
+  return (
+    thread.session?.activeTurnId ??
+    (thread.latestTurn?.state === "running" ? thread.latestTurn.turnId : null)
+  );
+}
+
 /**
  * Pure: snapshot the requested threads into a record. Only threads that are
- * genuinely in flight with a known turn are remembered — the dialog shows a
- * snapshot, and a chat that finished while it was open has nothing to resume.
- * Unknown and deleted threads are dropped, duplicates collapse, order is kept.
+ * genuinely in flight are remembered — the dialog shows a snapshot, and a chat
+ * that finished while it was open has nothing to resume. Unknown and deleted
+ * threads are dropped, duplicates collapse, order is kept.
  */
 export function buildQuitResumeRecord(input: {
   readonly request: OrchestrationPrepareQuitResumeInput;
@@ -142,15 +152,10 @@ export function buildQuitResumeRecord(input: {
     }
     seen.add(threadId);
     const thread = threadsById.get(threadId);
-    if (
-      !thread ||
-      thread.deletedAt !== null ||
-      thread.latestTurn === null ||
-      !threadHasInFlightTurn(thread)
-    ) {
+    if (!thread || thread.deletedAt !== null || !threadHasInFlightTurn(thread)) {
       continue;
     }
-    threads.push({ threadId, turnId: thread.latestTurn.turnId });
+    threads.push({ threadId, turnId: inFlightTurnId(thread) });
   }
   return {
     version: 1,
@@ -163,7 +168,7 @@ export function buildQuitResumeRecord(input: {
 
 export function buildQuitInterruptCommand(input: {
   readonly threadId: ThreadId;
-  readonly turnId: TurnId;
+  readonly turnId: TurnId | null;
   readonly recordId: string;
   readonly recordedAt: string;
 }): ThreadTurnInterruptCommand {
@@ -171,7 +176,7 @@ export function buildQuitInterruptCommand(input: {
     type: "thread.turn.interrupt",
     commandId: CommandId.makeUnsafe(`quit-resume-interrupt:${input.recordId}:${input.threadId}`),
     threadId: input.threadId,
-    turnId: input.turnId,
+    ...(input.turnId !== null ? { turnId: input.turnId } : {}),
     createdAt: input.recordedAt,
   };
 }
@@ -179,11 +184,11 @@ export function buildQuitInterruptCommand(input: {
 /**
  * Pure: map a consumed record onto the current read model. A thread is resumed
  * only when it still exists, is not deleted, its project exists, and
- * `threadResumePreconditionViolation` is clear (not archived, latest turn is
- * exactly the recorded one, nothing in flight, not completed on its own). The
- * continuation is an ordinary user turn on the thread's own runtime/interaction
- * settings (model omitted → provider reactor uses the thread's current selection)
- * and carries the same precondition for the decider to enforce atomically.
+ * `threadResumePreconditionViolation` is clear (not archived, nothing in flight,
+ * no turn completed on its own since the record). The continuation is an
+ * ordinary user turn on the thread's own runtime/interaction settings (model
+ * omitted → provider reactor uses the thread's current selection) and carries
+ * the same precondition for the decider to enforce atomically.
  *
  * Command and message ids derive from the record so an accidental re-run
  * collides with the engine's receipt dedup instead of starting a second turn.
@@ -218,7 +223,10 @@ export function planQuitResumeTurns(input: {
       skip(entry.threadId, "project-missing");
       continue;
     }
-    const resumePrecondition = { expectedLatestTurnId: entry.turnId };
+    const resumePrecondition = {
+      recordedTurnId: entry.turnId,
+      recordedAt: input.record.recordedAt,
+    };
     const violation = threadResumePreconditionViolation(thread, resumePrecondition);
     if (violation) {
       skip(entry.threadId, violation);
@@ -266,7 +274,10 @@ export type QuitResumeRecordRead =
   | { readonly kind: "invalid" }
   | { readonly kind: "record"; readonly record: QuitResumeRecord };
 
-/** `absent` when the file is missing or unreadable, `invalid` when present but not a record. */
+/**
+ * `absent` when there is no file, `invalid` when a file is there but cannot be
+ * read or is not a record.
+ */
 export const readQuitResumeRecord = (
   path: string,
 ): Effect.Effect<QuitResumeRecordRead, never, FileSystem.FileSystem> =>
@@ -288,6 +299,46 @@ export const readQuitResumeRecord = (
   });
 
 /**
+ * Take exclusive ownership of whatever record is at `path` right now: an atomic
+ * rename to a private path, so a quit prepared concurrently writes a fresh file
+ * that is left untouched for the next boot. Returns the claimed content and
+ * removes the private copy; `absent` when there was nothing to claim.
+ */
+export const claimQuitResumeRecord = (
+  path: string,
+): Effect.Effect<QuitResumeRecordRead, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const exists = yield* fs.exists(path).pipe(Effect.orElseSucceed(() => false));
+    if (!exists) {
+      return { kind: "absent" } as const;
+    }
+    const claimedPath = `${path}.claimed`;
+    const claimed = yield* fs.rename(path, claimedPath).pipe(
+      Effect.as(true),
+      Effect.catchCause((cause) =>
+        Effect.logWarning("quit-resume record could not be claimed; skipping resume", {
+          path,
+          cause,
+        }).pipe(Effect.as(false)),
+      ),
+    );
+    if (!claimed) {
+      return { kind: "absent" } as const;
+    }
+    const read = yield* readQuitResumeRecord(claimedPath);
+    yield* clearQuitResumeRecord(claimedPath).pipe(
+      Effect.catchCause((cause) =>
+        Effect.logWarning("claimed quit-resume record could not be removed", {
+          path: claimedPath,
+          cause,
+        }),
+      ),
+    );
+    return read;
+  });
+
+/**
  * Remove the record only if it is still the one with `recordId`: a newer quit
  * may have replaced it in the meantime and must keep its own record.
  */
@@ -303,11 +354,11 @@ const clearQuitResumeRecordIfOwned = (path: string, recordId: string) =>
 
 /**
  * RPC body: record first (failure fails the call so the renderer can fall back to
- * a plain interrupt), then interrupt every recorded thread. Interrupt failures
+ * a plain interrupt) and immediately arm the abandon sweep — if this process is
+ * still running `QUIT_RESUME_ABANDON_AFTER_MS` later, the quit was cancelled and
+ * the record is dropped. Then interrupt every recorded thread. Interrupt failures
  * are logged, not surfaced — the record is already durable and the restart
- * reconciliation heals any turn the interrupt did not reach. Finally arm the
- * abandon sweep: if this process is still running after
- * `QUIT_RESUME_ABANDON_AFTER_MS`, the quit was cancelled and the record is dropped.
+ * reconciliation heals any turn the interrupt did not reach.
  */
 export const prepareQuitResume = (input: {
   readonly request: OrchestrationPrepareQuitResumeInput;
@@ -333,6 +384,23 @@ export const prepareQuitResume = (input: {
       threadIds: record.threads.map((entry) => entry.threadId),
     });
 
+    yield* Effect.sleep(input.abandonAfter ?? Duration.millis(QUIT_RESUME_ABANDON_AFTER_MS)).pipe(
+      Effect.andThen(clearQuitResumeRecordIfOwned(input.recordPath, record.recordId)),
+      Effect.flatMap((cleared) =>
+        cleared
+          ? Effect.logWarning("quit did not complete; dropped the quit-resume record", {
+              recordId: record.recordId,
+            })
+          : Effect.void,
+      ),
+      Effect.catchCause((cause) =>
+        Effect.logWarning("quit-resume abandon sweep failed", { recordId: record.recordId, cause }),
+      ),
+      // Detached on purpose: the sweep must outlive this request. If the process
+      // exits first (the normal quit), the fiber simply dies with it.
+      Effect.forkDetach,
+    );
+
     yield* Effect.forEach(
       record.threads,
       (entry) =>
@@ -356,23 +424,6 @@ export const prepareQuitResume = (input: {
       { discard: true },
     );
 
-    yield* Effect.sleep(input.abandonAfter ?? Duration.millis(QUIT_RESUME_ABANDON_AFTER_MS)).pipe(
-      Effect.andThen(clearQuitResumeRecordIfOwned(input.recordPath, record.recordId)),
-      Effect.flatMap((cleared) =>
-        cleared
-          ? Effect.logWarning("quit did not complete; dropped the quit-resume record", {
-              recordId: record.recordId,
-            })
-          : Effect.void,
-      ),
-      Effect.catchCause((cause) =>
-        Effect.logWarning("quit-resume abandon sweep failed", { recordId: record.recordId, cause }),
-      ),
-      // Detached on purpose: the sweep must outlive this request. If the process
-      // exits first (the normal quit), the fiber simply dies with it.
-      Effect.forkDetach,
-    );
-
     return {
       recordedThreadIds: record.threads.map((entry) => entry.threadId),
       recordedAt: record.recordedAt,
@@ -394,31 +445,18 @@ export const resumeQuitInterruptedChats: Effect.Effect<
   const engine = yield* OrchestrationEngineService;
   const path = config.quitResumeStatePath;
 
-  const read = yield* readQuitResumeRecord(path);
-  if (read.kind === "absent") {
-    return;
-  }
-
-  // Consume before dispatching: a second process or a crash mid-dispatch must
-  // never resume the same chats twice. An unreadable record is dropped too, so
+  // Claim before dispatching: a second process or a crash mid-dispatch must
+  // never resume the same chats twice. An unreadable record is consumed too, so
   // it does not get re-parsed (and silently ignored) on every later boot.
-  const cleared = yield* clearQuitResumeRecord(path).pipe(
-    Effect.as(true),
-    Effect.catchCause((cause) =>
-      Effect.logWarning("quit-resume record could not be consumed; skipping resume", {
-        path,
-        cause,
-      }).pipe(Effect.as(false)),
-    ),
-  );
-  if (!cleared) {
+  const claimed = yield* claimQuitResumeRecord(path);
+  if (claimed.kind === "absent") {
     return;
   }
-  if (read.kind === "invalid") {
+  if (claimed.kind === "invalid") {
     yield* Effect.logWarning("dropped an unreadable quit-resume record", { path });
     return;
   }
-  const record = read.record;
+  const record = claimed.record;
 
   const readModel = yield* engine.getReadModel();
   const plan = planQuitResumeTurns({
@@ -450,8 +488,14 @@ export const resumeQuitInterruptedChats: Effect.Effect<
       engine.dispatch(command).pipe(
         // The decider re-checks the resume precondition atomically; a rejection
         // here means the thread moved on between the plan and the dispatch.
-        Effect.catchCause((cause) =>
+        Effect.catchTag("OrchestrationCommandInvariantError", (error) =>
           Effect.logInfo("quit-resume turn was not accepted", {
+            threadId: command.threadId,
+            detail: error.detail,
+          }),
+        ),
+        Effect.catchCause((cause) =>
+          Effect.logWarning("quit-resume turn failed to dispatch", {
             threadId: command.threadId,
             cause,
           }),

--- a/apps/server/src/wsRequestAdmission.ts
+++ b/apps/server/src/wsRequestAdmission.ts
@@ -14,6 +14,7 @@ export const WS_REQUEST_CLASS_LIMITS: Readonly<Record<WsRequestClass, number>> =
 const CONTROL_METHODS = new Set<string>([
   ORCHESTRATION_WS_METHODS.dispatchCommand,
   ORCHESTRATION_WS_METHODS.reconcileProviderDelivery,
+  ORCHESTRATION_WS_METHODS.prepareQuitResume,
   WS_METHODS.terminalWrite,
   WS_METHODS.terminalAckOutput,
   WS_METHODS.terminalResize,

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -89,6 +89,7 @@ import {
 } from "./managedAttachmentPrincipal";
 import { Open, resolveAvailableEditors } from "./open";
 import { makeDispatchCommandNormalizer } from "./orchestration/dispatchCommandNormalization";
+import { prepareQuitResume } from "./orchestration/quitResume";
 import { makeImportThreadHandler } from "./orchestration/importThreadRoute";
 import { OrchestrationEngineService } from "./orchestration/Services/OrchestrationEngine";
 import { ProviderCommandReactor } from "./orchestration/Services/ProviderCommandReactor";
@@ -928,6 +929,16 @@ const makeWsRpcHandlersLayer = () =>
               limit: input.limit ?? 50,
             }),
             "Failed to load provider delivery blockers",
+          ),
+        [ORCHESTRATION_WS_METHODS.prepareQuitResume]: (input) =>
+          rpcEffect(
+            prepareQuitResume({
+              request: input,
+              recordPath: config.quitResumeStatePath,
+              getReadModel: orchestrationEngine.getReadModel,
+              dispatch: dispatchOrchestrationCommand,
+            }),
+            "Failed to prepare chats for resume after quit",
           ),
         [ORCHESTRATION_WS_METHODS.reconcileProviderDelivery]: (input) =>
           rpcEffect(

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -932,12 +932,16 @@ const makeWsRpcHandlersLayer = () =>
           ),
         [ORCHESTRATION_WS_METHODS.prepareQuitResume]: (input) =>
           rpcEffect(
-            prepareQuitResume({
-              request: input,
-              recordPath: config.quitResumeStatePath,
-              getReadModel: orchestrationEngine.getReadModel,
-              dispatch: dispatchOrchestrationCommand,
-            }),
+            // Gated as a whole (not just its dispatches) so the record can never be
+            // written while startup is still claiming the previous quit's record.
+            runtimeStartup.enqueueCommand(
+              prepareQuitResume({
+                request: input,
+                recordPath: config.quitResumeStatePath,
+                getReadModel: orchestrationEngine.getReadModel,
+                dispatch: dispatchOrchestrationCommand,
+              }),
+            ),
             "Failed to prepare chats for resume after quit",
           ),
         [ORCHESTRATION_WS_METHODS.reconcileProviderDelivery]: (input) =>

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -215,6 +215,8 @@ export const AppSettingsSchema = Schema.Struct({
   openCodeExperimentalWebSockets: Schema.Boolean.pipe(withDefaults(() => false)),
   defaultThreadEnvMode: EnvMode.pipe(withDefaults(() => "local" as const satisfies EnvMode)),
   confirmThreadDelete: Schema.Boolean.pipe(withDefaults(() => true)),
+  // Desktop quit dialog: remember interrupted chats and continue them on the next launch.
+  resumeChatsAfterQuit: Schema.Boolean.pipe(withDefaults(() => true)),
   confirmThreadArchive: Schema.Boolean.pipe(withDefaults(() => false)),
   confirmTerminalTabClose: Schema.Boolean.pipe(withDefaults(() => true)),
   diffWordWrap: Schema.Boolean.pipe(withDefaults(() => false)),

--- a/apps/web/src/components/RunningChatsQuitCoordinator.tsx
+++ b/apps/web/src/components/RunningChatsQuitCoordinator.tsx
@@ -21,6 +21,9 @@ import { RunningChatsQuitDialog, type RunningChatsQuitDecision } from "./Running
 
 export function RunningChatsQuitCoordinator() {
   const [chats, setChats] = useState<ReadonlyArray<RunningChatQuitSummary> | null>(null);
+  // True while the resume record is being written: the dialog stays up (inert) so the
+  // user does not see a bare window for the bounded wait before the desktop hides it.
+  const [quitting, setQuitting] = useState(false);
   const pendingRequestIdRef = useRef<string | null>(null);
 
   const settle = useCallback(
@@ -32,7 +35,9 @@ export function RunningChatsQuitCoordinator() {
       const allow = decision != null;
       const chatsToStop = allow ? chats : null;
       pendingRequestIdRef.current = null;
-      setChats(null);
+      if (!decision?.resume) {
+        setChats(null);
+      }
 
       const reply = (allowQuit: boolean) => {
         window.desktopBridge?.replyQuitConfirmation({
@@ -82,7 +87,12 @@ export function RunningChatsQuitCoordinator() {
       if (decision.resume) {
         // The resume record must be durable before the desktop is allowed to stop the
         // backend; the wait is bounded so quit stays snappy even if the server is slow.
-        void stopped.finally(() => reply(true));
+        setQuitting(true);
+        void stopped.finally(() => {
+          reply(true);
+          setQuitting(false);
+          setChats(null);
+        });
         return;
       }
       // Interrupt in the background so the window can close immediately.
@@ -117,5 +127,12 @@ export function RunningChatsQuitCoordinator() {
     });
   }, []);
 
-  return <RunningChatsQuitDialog chats={chats} onStay={() => settle(null)} onQuit={settle} />;
+  return (
+    <RunningChatsQuitDialog
+      chats={chats}
+      quitting={quitting}
+      onStay={() => settle(null)}
+      onQuit={settle}
+    />
+  );
 }

--- a/apps/web/src/components/RunningChatsQuitCoordinator.tsx
+++ b/apps/web/src/components/RunningChatsQuitCoordinator.tsx
@@ -1,13 +1,15 @@
 // FILE: RunningChatsQuitCoordinator.tsx
 // Purpose: Answers Electron quit requests with the running-chats confirmation.
 // Layer: Root web coordinator
-// Depends on: Desktop bridge quit IPC and the orchestration store.
+// Depends on: Desktop bridge quit IPC, the orchestration store, and the quit-resume RPC.
 
 import { ThreadId } from "@synara/contracts";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { APP_DISPLAY_NAME } from "~/branding";
 import {
   listRunningChatsFromDesktopStore,
+  quitResumeContinuationPrompt,
   stopRunningChatsForQuit,
   type RunningChatQuitSummary,
 } from "~/lib/runningChatsQuitConfirmation";
@@ -15,18 +17,19 @@ import { newCommandId } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
 import { useStore } from "~/store";
 
-import { RunningChatsQuitDialog } from "./RunningChatsQuitDialog";
+import { RunningChatsQuitDialog, type RunningChatsQuitDecision } from "./RunningChatsQuitDialog";
 
 export function RunningChatsQuitCoordinator() {
   const [chats, setChats] = useState<ReadonlyArray<RunningChatQuitSummary> | null>(null);
   const pendingRequestIdRef = useRef<string | null>(null);
 
   const settle = useCallback(
-    (allow: boolean) => {
+    (decision: RunningChatsQuitDecision | null) => {
       const requestId = pendingRequestIdRef.current;
       if (!requestId) {
         return;
       }
+      const allow = decision != null;
       const chatsToStop = allow ? chats : null;
       pendingRequestIdRef.current = null;
       setChats(null);
@@ -44,8 +47,7 @@ export function RunningChatsQuitCoordinator() {
         return;
       }
 
-      // Stop in the background so the window can close immediately.
-      void stopRunningChatsForQuit({
+      const stopped = stopRunningChatsForQuit({
         chats: chatsToStop,
         dispatchInterrupt: (threadId) => {
           const api = readNativeApi();
@@ -59,7 +61,32 @@ export function RunningChatsQuitCoordinator() {
             createdAt: new Date().toISOString(),
           });
         },
+        ...(decision.resume
+          ? {
+              resume: {
+                prepare: (threadIds: ReadonlyArray<string>) => {
+                  const api = readNativeApi();
+                  if (!api) {
+                    return Promise.reject(new Error("Native API unavailable"));
+                  }
+                  return api.orchestration.prepareQuitResume({
+                    threadIds: threadIds.map((threadId) => ThreadId.makeUnsafe(threadId)),
+                    continuationPrompt: quitResumeContinuationPrompt(APP_DISPLAY_NAME),
+                  });
+                },
+              },
+            }
+          : {}),
       });
+
+      if (decision.resume) {
+        // The resume record must be durable before the desktop is allowed to stop the
+        // backend; the wait is bounded so quit stays snappy even if the server is slow.
+        void stopped.finally(() => reply(true));
+        return;
+      }
+      // Interrupt in the background so the window can close immediately.
+      void stopped;
       reply(true);
     },
     [chats],
@@ -90,11 +117,5 @@ export function RunningChatsQuitCoordinator() {
     });
   }, []);
 
-  return (
-    <RunningChatsQuitDialog
-      chats={chats}
-      onStay={() => settle(false)}
-      onQuit={() => settle(true)}
-    />
-  );
+  return <RunningChatsQuitDialog chats={chats} onStay={() => settle(null)} onQuit={settle} />;
 }

--- a/apps/web/src/components/RunningChatsQuitDialog.tsx
+++ b/apps/web/src/components/RunningChatsQuitDialog.tsx
@@ -34,6 +34,8 @@ export interface RunningChatsQuitDecision {
 
 export interface RunningChatsQuitDialogProps {
   readonly chats: ReadonlyArray<RunningChatQuitSummary> | null;
+  /** Quit was confirmed and is being finalized; the dialog stays visible but inert. */
+  readonly quitting?: boolean;
   readonly onStay: () => void;
   readonly onQuit: (decision: RunningChatsQuitDecision) => void;
 }
@@ -48,7 +50,12 @@ const BODY_CLASS =
 const FOOTER_CLASS = "relative flex items-center gap-2 px-3 py-2";
 const KEY_HINT_CLASS = "text-[11px] font-normal tabular-nums opacity-55";
 
-export function RunningChatsQuitDialog({ chats, onStay, onQuit }: RunningChatsQuitDialogProps) {
+export function RunningChatsQuitDialog({
+  chats,
+  quitting = false,
+  onStay,
+  onQuit,
+}: RunningChatsQuitDialogProps) {
   const copy = chats && chats.length > 0 ? runningChatsQuitCopy(chats, APP_DISPLAY_NAME) : null;
 
   return (
@@ -70,7 +77,12 @@ export function RunningChatsQuitDialog({ chats, onStay, onQuit }: RunningChatsQu
             )}
           >
             {copy && chats ? (
-              <RunningChatsQuitDialogContent chats={chats} copy={copy} onQuit={onQuit} />
+              <RunningChatsQuitDialogContent
+                chats={chats}
+                copy={copy}
+                quitting={quitting}
+                onQuit={onQuit}
+              />
             ) : null}
           </AlertDialogPrimitive.Popup>
         </AlertDialogViewport>
@@ -83,10 +95,12 @@ export function RunningChatsQuitDialog({ chats, onStay, onQuit }: RunningChatsQu
 function RunningChatsQuitDialogContent({
   chats,
   copy,
+  quitting,
   onQuit,
 }: {
   readonly chats: ReadonlyArray<RunningChatQuitSummary>;
   readonly copy: RunningChatsQuitCopy;
+  readonly quitting: boolean;
   readonly onQuit: (decision: RunningChatsQuitDecision) => void;
 }) {
   const { settings, updateSettings } = useAppSettings();
@@ -129,6 +143,7 @@ function RunningChatsQuitDialogContent({
           <Checkbox
             id={resumeCheckboxId}
             checked={resume}
+            disabled={quitting}
             onCheckedChange={(checked) => {
               updateSettings({ resumeChatsAfterQuit: checked === true });
             }}
@@ -137,6 +152,7 @@ function RunningChatsQuitDialogContent({
         </label>
         <div className="ml-auto flex items-center gap-2">
           <AlertDialogClose
+            disabled={quitting}
             render={<Button variant="ghost" size="sm" className={cn(uiFont, "gap-1.5")} />}
           >
             {copy.stayLabel}
@@ -147,6 +163,7 @@ function RunningChatsQuitDialogContent({
             variant="default"
             size="sm"
             className={cn(uiFont, "gap-1.5")}
+            disabled={quitting}
             onClick={() => onQuit({ resume })}
           >
             {copy.quitLabel}

--- a/apps/web/src/components/RunningChatsQuitDialog.tsx
+++ b/apps/web/src/components/RunningChatsQuitDialog.tsx
@@ -1,10 +1,13 @@
 // FILE: RunningChatsQuitDialog.tsx
 // Purpose: Confirms desktop quit while chats are still running.
 // Layer: Root web overlay
-// Depends on: Base UI alert-dialog primitives, the ⌘P palette surface, and the shared running spinner.
+// Depends on: Base UI alert-dialog primitives, the ⌘P palette surface, the shared running spinner,
+// and the persisted "resume chats after quit" app setting.
 
 import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
+import { useId } from "react";
 
+import { useAppSettings } from "~/appSettings";
 import { APP_DISPLAY_NAME } from "~/branding";
 import { ThreadRunningSpinner } from "~/components/ThreadRunningSpinner";
 import {
@@ -15,17 +18,24 @@ import {
   AlertDialogViewport,
 } from "~/components/ui/alert-dialog";
 import { Button } from "~/components/ui/button";
+import { Checkbox } from "~/components/ui/checkbox";
 import { commandDialogPopupClassName } from "~/components/ui/command";
 import {
   runningChatsQuitCopy,
   type RunningChatQuitSummary,
+  type RunningChatsQuitCopy,
 } from "~/lib/runningChatsQuitConfirmation";
 import { cn } from "~/lib/utils";
+
+export interface RunningChatsQuitDecision {
+  /** Remember the listed chats and continue them automatically on the next launch. */
+  readonly resume: boolean;
+}
 
 export interface RunningChatsQuitDialogProps {
   readonly chats: ReadonlyArray<RunningChatQuitSummary> | null;
   readonly onStay: () => void;
-  readonly onQuit: () => void;
+  readonly onQuit: (decision: RunningChatsQuitDecision) => void;
 }
 
 const uiFont = "font-[family-name:var(--font-ui-family)]";
@@ -34,8 +44,8 @@ const uiFont = "font-[family-name:var(--font-ui-family)]";
 // shows the popup's lighter overlay through, separated by a hairline — mirroring CommandPanel +
 // CommandFooter without the palette's scroll chrome.
 const BODY_CLASS =
-  "relative rounded-t-[calc(var(--radius-2xl)-1px)] border-b border-[color:var(--color-border-light)] bg-[var(--color-background-surface-under)] px-5 pt-4 pb-5";
-const FOOTER_CLASS = "relative flex items-center justify-end gap-2 px-3.5 py-2.5";
+  "relative rounded-t-[calc(var(--radius-2xl)-1px)] border-b border-[color:var(--color-border-light)] bg-[var(--color-background-surface-under)] px-4 pt-3 pb-3.5";
+const FOOTER_CLASS = "relative flex items-center gap-2 px-3 py-2";
 const KEY_HINT_CLASS = "text-[11px] font-normal tabular-nums opacity-55";
 
 export function RunningChatsQuitDialog({ chats, onStay, onQuit }: RunningChatsQuitDialogProps) {
@@ -55,66 +65,97 @@ export function RunningChatsQuitDialog({ chats, onStay, onQuit }: RunningChatsQu
             className={cn(
               commandDialogPopupClassName,
               uiFont,
-              "w-[440px] max-w-[calc(100vw-2rem)] max-h-full text-[12px]",
+              // Keep the palette's hairline border but drop its inner top highlight/shadow.
+              "w-[520px] max-w-[calc(100vw-2rem)] max-h-full text-[12px] before:shadow-none dark:before:shadow-none",
             )}
           >
             {copy && chats ? (
-              <>
-                <div className={BODY_CLASS}>
-                  <AlertDialogPrimitive.Title
-                    className={cn(uiFont, "m-0 text-[14px] font-medium leading-5")}
-                  >
-                    {copy.title}
-                  </AlertDialogPrimitive.Title>
-                  <AlertDialogPrimitive.Description
-                    className={cn(
-                      uiFont,
-                      "m-0 mt-1 text-[12.5px] font-normal leading-[18px] text-muted-foreground",
-                    )}
-                  >
-                    {copy.description}
-                  </AlertDialogPrimitive.Description>
-                  <ul className="m-0 mt-4 flex max-h-[40vh] list-none flex-col gap-2 overflow-y-auto p-0">
-                    {chats.map((chat) => (
-                      <li key={chat.id} className="flex min-w-0 items-center gap-2.5">
-                        <ThreadRunningSpinner />
-                        <span
-                          className={cn(
-                            uiFont,
-                            "truncate text-[12.5px] font-normal leading-[18px]",
-                          )}
-                        >
-                          {chat.title}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-                <div className={FOOTER_CLASS}>
-                  <AlertDialogClose
-                    render={<Button variant="ghost" size="sm" className={cn(uiFont, "gap-1.5")} />}
-                  >
-                    {copy.stayLabel}
-                    <span className={KEY_HINT_CLASS}>Esc</span>
-                  </AlertDialogClose>
-                  <Button
-                    autoFocus
-                    variant="default"
-                    size="sm"
-                    className={cn(uiFont, "gap-1.5")}
-                    onClick={onQuit}
-                  >
-                    {copy.quitLabel}
-                    <span aria-hidden className={KEY_HINT_CLASS}>
-                      ↵
-                    </span>
-                  </Button>
-                </div>
-              </>
+              <RunningChatsQuitDialogContent chats={chats} copy={copy} onQuit={onQuit} />
             ) : null}
           </AlertDialogPrimitive.Popup>
         </AlertDialogViewport>
       </AlertDialogPortal>
     </AlertDialog>
+  );
+}
+
+// Mounted only while the dialog is open so the settings subscription costs nothing otherwise.
+function RunningChatsQuitDialogContent({
+  chats,
+  copy,
+  onQuit,
+}: {
+  readonly chats: ReadonlyArray<RunningChatQuitSummary>;
+  readonly copy: RunningChatsQuitCopy;
+  readonly onQuit: (decision: RunningChatsQuitDecision) => void;
+}) {
+  const { settings, updateSettings } = useAppSettings();
+  const resume = settings.resumeChatsAfterQuit;
+  const resumeCheckboxId = useId();
+
+  return (
+    <>
+      <div className={BODY_CLASS}>
+        <AlertDialogPrimitive.Title className={cn(uiFont, "m-0 text-[14px] font-medium leading-5")}>
+          {copy.title}
+        </AlertDialogPrimitive.Title>
+        <AlertDialogPrimitive.Description
+          className={cn(
+            uiFont,
+            "m-0 mt-1 text-[12.5px] font-normal leading-[18px] text-muted-foreground",
+          )}
+        >
+          {copy.description}
+        </AlertDialogPrimitive.Description>
+        <ul className="m-0 mt-3 flex max-h-[40vh] list-none flex-col gap-2 overflow-y-auto p-0">
+          {chats.map((chat) => (
+            <li key={chat.id} className="flex min-w-0 items-center gap-2.5">
+              <ThreadRunningSpinner />
+              <span className={cn(uiFont, "truncate text-[12.5px] font-normal leading-[18px]")}>
+                {chat.title}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className={FOOTER_CLASS}>
+        <label
+          htmlFor={resumeCheckboxId}
+          className={cn(
+            uiFont,
+            "flex min-w-0 cursor-pointer select-none items-center gap-2 px-1 text-[12px] font-normal leading-[18px] text-muted-foreground",
+          )}
+        >
+          <Checkbox
+            id={resumeCheckboxId}
+            checked={resume}
+            onCheckedChange={(checked) => {
+              updateSettings({ resumeChatsAfterQuit: checked === true });
+            }}
+          />
+          <span className="truncate">{copy.resumeLabel}</span>
+        </label>
+        <div className="ml-auto flex items-center gap-2">
+          <AlertDialogClose
+            render={<Button variant="ghost" size="sm" className={cn(uiFont, "gap-1.5")} />}
+          >
+            {copy.stayLabel}
+            <span className={KEY_HINT_CLASS}>Esc</span>
+          </AlertDialogClose>
+          <Button
+            autoFocus
+            variant="default"
+            size="sm"
+            className={cn(uiFont, "gap-1.5")}
+            onClick={() => onQuit({ resume })}
+          >
+            {copy.quitLabel}
+            <span aria-hidden className={KEY_HINT_CLASS}>
+              ↵
+            </span>
+          </Button>
+        </div>
+      </div>
+    </>
   );
 }

--- a/apps/web/src/lib/runningChatsQuitConfirmation.test.ts
+++ b/apps/web/src/lib/runningChatsQuitConfirmation.test.ts
@@ -156,7 +156,7 @@ describe("running chats quit confirmation", () => {
     expect(interrupted).toEqual(["a"]);
   });
 
-  it("falls back to plain interrupts when recording does not ack in time", async () => {
+  it("falls back to plain interrupts when recording does not ack in time, without waiting on them", async () => {
     const interrupted: string[] = [];
 
     await expect(
@@ -164,6 +164,8 @@ describe("running chats quit confirmation", () => {
         chats: [{ id: "a" }],
         dispatchInterrupt: (threadId) => {
           interrupted.push(threadId);
+          // A hanging interrupt (unresponsive server) must not hold the quit.
+          return new Promise(() => {});
         },
         resume: {
           prepare: () => new Promise(() => {}),
@@ -173,6 +175,17 @@ describe("running chats quit confirmation", () => {
     ).resolves.toEqual({ resumeRecorded: false });
 
     expect(interrupted).toEqual(["a"]);
+  });
+
+  it("survives an interrupt dispatcher that throws synchronously", async () => {
+    await expect(
+      stopRunningChatsForQuit({
+        chats: [{ id: "a" }],
+        dispatchInterrupt: () => {
+          throw new Error("sync failure");
+        },
+      }),
+    ).resolves.toEqual({ resumeRecorded: false });
   });
 
   it("skips recording entirely when there is nothing running", async () => {

--- a/apps/web/src/lib/runningChatsQuitConfirmation.test.ts
+++ b/apps/web/src/lib/runningChatsQuitConfirmation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   isRunningChatForQuit,
   listRunningChatsFromDesktopStore,
+  quitResumeContinuationPrompt,
   runningChatDisplayTitle,
   runningChatsQuitCopy,
   stopRunningChatsForQuit,
@@ -50,6 +51,7 @@ describe("running chats quit confirmation", () => {
     expect(runningChatsQuitCopy([{ id: "a", title: "Fix the tray" }])).toEqual({
       title: "A chat is still running",
       description: "Work in progress will stop when Synara is closed.",
+      resumeLabel: "Resume chat automatically",
       stayLabel: "Cancel",
       quitLabel: "Quit",
     });
@@ -64,9 +66,19 @@ describe("running chats quit confirmation", () => {
     ).toEqual({
       title: "Chats are still running",
       description: "Work in progress will stop when Synara Canary is closed.",
+      resumeLabel: "Resume chats automatically",
       stayLabel: "Cancel",
       quitLabel: "Quit",
     });
+  });
+
+  it("builds the continuation prompt from the app name", () => {
+    expect(quitResumeContinuationPrompt()).toBe(
+      "Synara was closed while this chat was still running. Continue where you left off.",
+    );
+    expect(quitResumeContinuationPrompt("Synara Canary")).toBe(
+      "Synara Canary was closed while this chat was still running. Continue where you left off.",
+    );
   });
 
   it("interrupts running chats without waiting for them to settle", async () => {
@@ -99,6 +111,83 @@ describe("running chats quit confirmation", () => {
           throw new Error("rpc failed");
         },
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ resumeRecorded: false });
+  });
+
+  it("lets the server record and interrupt when resume is requested", async () => {
+    const prepared: ReadonlyArray<string>[] = [];
+    const interrupted: string[] = [];
+
+    await expect(
+      stopRunningChatsForQuit({
+        chats: [{ id: "a" }, { id: "b" }],
+        dispatchInterrupt: (threadId) => {
+          interrupted.push(threadId);
+        },
+        resume: {
+          prepare: async (threadIds) => {
+            prepared.push(threadIds);
+          },
+        },
+      }),
+    ).resolves.toEqual({ resumeRecorded: true });
+
+    expect(prepared).toEqual([["a", "b"]]);
+    expect(interrupted).toEqual([]);
+  });
+
+  it("falls back to plain interrupts when recording fails", async () => {
+    const interrupted: string[] = [];
+
+    await expect(
+      stopRunningChatsForQuit({
+        chats: [{ id: "a" }],
+        dispatchInterrupt: (threadId) => {
+          interrupted.push(threadId);
+        },
+        resume: {
+          prepare: async () => {
+            throw new Error("rpc failed");
+          },
+        },
+      }),
+    ).resolves.toEqual({ resumeRecorded: false });
+
+    expect(interrupted).toEqual(["a"]);
+  });
+
+  it("falls back to plain interrupts when recording does not ack in time", async () => {
+    const interrupted: string[] = [];
+
+    await expect(
+      stopRunningChatsForQuit({
+        chats: [{ id: "a" }],
+        dispatchInterrupt: (threadId) => {
+          interrupted.push(threadId);
+        },
+        resume: {
+          prepare: () => new Promise(() => {}),
+          timeoutMs: 5,
+        },
+      }),
+    ).resolves.toEqual({ resumeRecorded: false });
+
+    expect(interrupted).toEqual(["a"]);
+  });
+
+  it("skips recording entirely when there is nothing running", async () => {
+    let prepared = false;
+    await expect(
+      stopRunningChatsForQuit({
+        chats: [],
+        dispatchInterrupt: () => {},
+        resume: {
+          prepare: async () => {
+            prepared = true;
+          },
+        },
+      }),
+    ).resolves.toEqual({ resumeRecorded: false });
+    expect(prepared).toBe(false);
   });
 });

--- a/apps/web/src/lib/runningChatsQuitConfirmation.ts
+++ b/apps/web/src/lib/runningChatsQuitConfirmation.ts
@@ -18,9 +18,13 @@ export interface RunningChatQuitSummary {
 export interface RunningChatsQuitCopy {
   readonly title: string;
   readonly description: string;
+  readonly resumeLabel: string;
   readonly stayLabel: string;
   readonly quitLabel: string;
 }
+
+/** Bounded wait for the server to record the resume intent; quit must stay snappy. */
+export const QUIT_RESUME_PREPARE_TIMEOUT_MS = 1500;
 
 export interface RunningChatsQuitStoreSlice {
   readonly sidebarThreadSummaryById: Readonly<Record<string, RunningChatQuitCandidate>>;
@@ -90,22 +94,79 @@ export function runningChatsQuitCopy(
   return {
     title: chats.length === 1 ? "A chat is still running" : "Chats are still running",
     description: `Work in progress will stop when ${appName} is closed.`,
+    resumeLabel: chats.length === 1 ? "Resume chat automatically" : "Resume chats automatically",
     stayLabel: "Cancel",
     quitLabel: "Quit",
   };
 }
 
-export async function stopRunningChatsForQuit(input: {
+/** The ordinary user turn dispatched on each remembered chat at the next launch. */
+export function quitResumeContinuationPrompt(appName = "Synara"): string {
+  return `${appName} was closed while this chat was still running. Continue where you left off.`;
+}
+
+export interface StopRunningChatsForQuitInput {
   readonly chats: ReadonlyArray<Pick<RunningChatQuitSummary, "id">>;
   readonly dispatchInterrupt: (threadId: string) => Promise<unknown> | unknown;
-}): Promise<void> {
+  /**
+   * When set, ask the server to durably record the chats for resume (it also
+   * interrupts them) and wait — bounded — for that ack. On failure or timeout
+   * fall back to plain interrupts so quit never hangs and never double-resumes.
+   */
+  readonly resume?: {
+    readonly prepare: (threadIds: ReadonlyArray<string>) => Promise<unknown>;
+    readonly timeoutMs?: number;
+  };
+}
+
+export interface StopRunningChatsForQuitResult {
+  /** True when the server acknowledged the resume record (and owns the interrupts). */
+  readonly resumeRecorded: boolean;
+}
+
+export async function stopRunningChatsForQuit(
+  input: StopRunningChatsForQuitInput,
+): Promise<StopRunningChatsForQuitResult> {
   if (input.chats.length === 0) {
-    return;
+    return { resumeRecorded: false };
+  }
+  const threadIds = input.chats.map((chat) => chat.id);
+
+  if (input.resume) {
+    const recorded = await withBoundedWait(
+      () => input.resume!.prepare(threadIds),
+      input.resume.timeoutMs ?? QUIT_RESUME_PREPARE_TIMEOUT_MS,
+    );
+    if (recorded) {
+      return { resumeRecorded: true };
+    }
   }
 
   await Promise.allSettled(
-    input.chats.map((chat) => Promise.resolve(input.dispatchInterrupt(chat.id))),
+    threadIds.map((threadId) => Promise.resolve(input.dispatchInterrupt(threadId))),
   );
+  return { resumeRecorded: false };
+}
+
+/** Resolves true only when `run` settles successfully within `timeoutMs`. */
+async function withBoundedWait(run: () => Promise<unknown>, timeoutMs: number): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<false>((resolve) => {
+    timer = setTimeout(() => resolve(false), timeoutMs);
+  });
+  try {
+    return await Promise.race([
+      Promise.resolve()
+        .then(run)
+        .then(
+          () => true,
+          () => false,
+        ),
+      timeout,
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 function compareRunningChatSummaries(

--- a/apps/web/src/lib/runningChatsQuitConfirmation.ts
+++ b/apps/web/src/lib/runningChatsQuitConfirmation.ts
@@ -142,9 +142,12 @@ export async function stopRunningChatsForQuit(
     }
   }
 
-  await Promise.allSettled(
-    threadIds.map((threadId) => Promise.resolve(input.dispatchInterrupt(threadId))),
-  );
+  // Fire-and-forget: the window must close as soon as the outcome is known, and an
+  // interrupt RPC against an unresponsive server could otherwise hold quit for its
+  // full transport timeout.
+  for (const threadId of threadIds) {
+    void new Promise((resolve) => resolve(input.dispatchInterrupt(threadId))).catch(() => {});
+  }
   return { resumeRecorded: false };
 }
 

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -768,6 +768,8 @@ export function createWsNativeApi(): NativeApi {
         transport.request(ORCHESTRATION_WS_METHODS.listProviderDeliveryBlockers, input),
       reconcileProviderDelivery: (input) =>
         transport.request(ORCHESTRATION_WS_METHODS.reconcileProviderDelivery, input),
+      prepareQuitResume: (input) =>
+        transport.request(ORCHESTRATION_WS_METHODS.prepareQuitResume, input),
       subscribeShell: () => transport.request<void>(ORCHESTRATION_WS_METHODS.subscribeShell, {}),
       unsubscribeShell: () =>
         transport.request<void>(ORCHESTRATION_WS_METHODS.unsubscribeShell, {}),

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -218,6 +218,8 @@ import type {
   OrchestrationListProviderDeliveryBlockersResult,
   OrchestrationReconcileProviderDeliveryInput,
   OrchestrationReconcileProviderDeliveryResult,
+  OrchestrationPrepareQuitResumeInput,
+  OrchestrationPrepareQuitResumeResult,
   OrchestrationGetTurnDiffInput,
   OrchestrationGetTurnDiffResult,
   OrchestrationEvent,
@@ -871,6 +873,9 @@ export interface NativeApi {
     reconcileProviderDelivery: (
       input: OrchestrationReconcileProviderDeliveryInput,
     ) => Promise<OrchestrationReconcileProviderDeliveryResult>;
+    prepareQuitResume: (
+      input: OrchestrationPrepareQuitResumeInput,
+    ) => Promise<OrchestrationPrepareQuitResumeResult>;
     subscribeShell: () => Promise<void>;
     unsubscribeShell: () => Promise<void>;
     subscribeThread: (input: OrchestrationSubscribeThreadInput) => Promise<void>;

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1363,11 +1363,17 @@ export const ThreadTurnStartCommand = Schema.Struct({
     Schema.withDecodingDefault(() => DEFAULT_PROVIDER_INTERACTION_MODE),
   ),
   sourceProposedPlan: Schema.optional(SourceProposedPlanReference),
-  // Server-only (quit resume): accept the turn only while the thread is still exactly
-  // as recorded — same latest turn, not archived, nothing in flight, not completed on
-  // its own. Clients cannot set it: ClientThreadTurnStartCommand omits the field, so
-  // decoding strips any spoofed value.
-  resumePrecondition: Schema.optional(Schema.Struct({ expectedLatestTurnId: TurnId })),
+  // Server-only (quit resume): accept the turn only while the thread is not archived,
+  // has nothing in flight, and no turn finished on its own since the record was
+  // taken (the recorded turn itself, or any later one). Clients cannot set it:
+  // ClientThreadTurnStartCommand omits the field, so decoding strips a spoofed value.
+  resumePrecondition: Schema.optional(
+    Schema.Struct({
+      /** Turn in flight when the chat was recorded; null while the provider was still connecting. */
+      recordedTurnId: Schema.NullOr(TurnId),
+      recordedAt: IsoDateTime,
+    }),
+  ),
   createdAt: IsoDateTime,
 });
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1363,6 +1363,11 @@ export const ThreadTurnStartCommand = Schema.Struct({
     Schema.withDecodingDefault(() => DEFAULT_PROVIDER_INTERACTION_MODE),
   ),
   sourceProposedPlan: Schema.optional(SourceProposedPlanReference),
+  // Server-only (quit resume): accept the turn only while the thread is still exactly
+  // as recorded — same latest turn, not archived, nothing in flight, not completed on
+  // its own. Clients cannot set it: ClientThreadTurnStartCommand omits the field, so
+  // decoding strips any spoofed value.
+  resumePrecondition: Schema.optional(Schema.Struct({ expectedLatestTurnId: TurnId })),
   createdAt: IsoDateTime,
 });
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -41,6 +41,7 @@ export const ORCHESTRATION_WS_METHODS = {
   replayEvents: "orchestration.replayEvents",
   listProviderDeliveryBlockers: "orchestration.listProviderDeliveryBlockers",
   reconcileProviderDelivery: "orchestration.reconcileProviderDelivery",
+  prepareQuitResume: "orchestration.prepareQuitResume",
   subscribeShell: "orchestration.subscribeShell",
   unsubscribeShell: "orchestration.unsubscribeShell",
   subscribeThread: "orchestration.subscribeThread",
@@ -2549,6 +2550,31 @@ export const OrchestrationReconcileProviderDeliveryResult = Schema.Struct({
 export type OrchestrationReconcileProviderDeliveryResult =
   typeof OrchestrationReconcileProviderDeliveryResult.Type;
 
+/**
+ * Desktop quit with "Resume chats automatically": the server durably records the
+ * listed threads (plus their current turn) and interrupts them in one step, so
+ * the renderer can reply to the quit request only after the record exists.
+ */
+export const QUIT_RESUME_MAX_THREADS = 256;
+export const QUIT_RESUME_MAX_PROMPT_CHARS = 2_000;
+
+export const OrchestrationPrepareQuitResumeInput = Schema.Struct({
+  threadIds: Schema.Array(ThreadId).check(
+    Schema.isMinLength(1),
+    Schema.isMaxLength(QUIT_RESUME_MAX_THREADS),
+  ),
+  /** User-turn text dispatched on each recorded thread at the next server start. */
+  continuationPrompt: TrimmedNonEmptyString.check(Schema.isMaxLength(QUIT_RESUME_MAX_PROMPT_CHARS)),
+});
+export type OrchestrationPrepareQuitResumeInput = typeof OrchestrationPrepareQuitResumeInput.Type;
+
+export const OrchestrationPrepareQuitResumeResult = Schema.Struct({
+  /** Threads durably recorded for resume (unknown or deleted threads are dropped). */
+  recordedThreadIds: Schema.Array(ThreadId),
+  recordedAt: IsoDateTime,
+});
+export type OrchestrationPrepareQuitResumeResult = typeof OrchestrationPrepareQuitResumeResult.Type;
+
 export const OrchestrationSubscribeShellInput = Schema.Struct({});
 export type OrchestrationSubscribeShellInput = typeof OrchestrationSubscribeShellInput.Type;
 
@@ -2637,6 +2663,10 @@ export const OrchestrationRpcSchemas = {
   reconcileProviderDelivery: {
     input: OrchestrationReconcileProviderDeliveryInput,
     output: OrchestrationReconcileProviderDeliveryResult,
+  },
+  prepareQuitResume: {
+    input: OrchestrationPrepareQuitResumeInput,
+    output: OrchestrationPrepareQuitResumeResult,
   },
   subscribeShell: {
     input: OrchestrationSubscribeShellInput,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -338,6 +338,15 @@ export const WsOrchestrationReconcileProviderDeliveryRpc = Rpc.make(
   },
 );
 
+export const WsOrchestrationPrepareQuitResumeRpc = Rpc.make(
+  ORCHESTRATION_WS_METHODS.prepareQuitResume,
+  {
+    payload: OrchestrationRpcSchemas.prepareQuitResume.input,
+    success: OrchestrationRpcSchemas.prepareQuitResume.output,
+    error: WsRpcError,
+  },
+);
+
 export const WsOrchestrationSubscribeShellRpc = Rpc.make(ORCHESTRATION_WS_METHODS.subscribeShell, {
   payload: OrchestrationRpcSchemas.subscribeShell.input,
   success: OrchestrationShellStreamItem,
@@ -1221,6 +1230,7 @@ export const WsFeatureRpcGroup = RpcGroup.make(
   WsOrchestrationReplayEventsRpc,
   WsOrchestrationListProviderDeliveryBlockersRpc,
   WsOrchestrationReconcileProviderDeliveryRpc,
+  WsOrchestrationPrepareQuitResumeRpc,
   WsOrchestrationSubscribeShellRpc,
   WsOrchestrationUnsubscribeShellRpc,
   WsOrchestrationSubscribeThreadRpc,


### PR DESCRIPTION
## What Changed

- Added a "Resume chats automatically" option to the quit dialog.
- Persisted only genuinely in-flight chats, including chats still connecting, before allowing the desktop quit to proceed.
- Interrupted recorded turns during shutdown and resumed eligible chats automatically on the next server startup.
- Added atomic record claiming, cleanup for abandoned quits, deterministic command IDs, and resume precondition checks to prevent duplicate or stale continuations.
- Added focused orchestration and decider coverage for persistence, planning, interruption, startup claiming, and race-prevention behavior.

## Why

Chats could be interrupted when the desktop application quit, with no reliable way to continue them after restart. This change preserves eligible in-flight chats across a quit while avoiding unwanted messages when a chat finished, was archived or deleted, already has work in flight, or otherwise changed before restart.

## UI Changes

The quit dialog now includes a "Resume chats automatically" option. The dialog remains open until the resume record has been written, and falls back to the normal interrupt-and-quit flow if persistence fails.

Screenshots and video are not included.

## Verification

- Added focused Vitest coverage in `apps/server/src/orchestration/quitResume.test.ts`.
- Added decider precondition coverage in `apps/server/src/orchestration/decider.resumePrecondition.test.ts`.
- Added UI quit-confirmation coverage in `apps/web/src/lib/runningChatsQuitConfirmation.test.ts`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration startup, the turn-start decider, and durable on-disk state so chats can auto-continue after quit. Guards (atomic claim, resume preconditions, client-stripped fields, bounded wait) limit duplicate or stale turns, but a bug could still dispatch unwanted messages.
> 
> **Overview**
> Lets users check **Resume chats automatically** on desktop quit so in-flight chats (including still-connecting ones) continue on the next launch instead of being lost.
> 
> On confirm, the renderer waits (bounded, with interrupt fallback) for `orchestration.prepareQuitResume`, which writes `quit-resume.json` then best-effort interrupts. A cancelled quit drops the record after 30s. At boot the server claims the file before commands are admitted, then forks continuation turns after restart reconciliation.
> 
> Continuations are ordinary user turns with a server-only `resumePrecondition` (clients cannot spoof it). The planner and decider skip archived/deleted/in-flight threads and chats that finished on their own; runtime/interaction modes come from the thread at dispatch time. The preference defaults on and is persisted as `resumeChatsAfterQuit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e573a3e1c020ad84c62c08eb2d7b24ee39a34302. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->