### PR TITLE
fix(server): preserve provider resume cursor after idle stop (#773)

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -29,6 +29,7 @@ import {
 import {
   buildCodexInitializeParams,
   buildCodexThreadOpenRequest,
+  shouldWarnCodexFreshStartWithoutResume,
   CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS,
   CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS,
   __codexCliVersionGateTesting,
@@ -1448,6 +1449,29 @@ describe("buildCodexThreadOpenRequest", () => {
   });
 });
 
+describe("shouldWarnCodexFreshStartWithoutResume", () => {
+  it("warns only when a previously bound thread is opened with thread/start", () => {
+    expect(
+      shouldWarnCodexFreshStartWithoutResume({
+        threadOpenMethod: "thread/start",
+        previouslyBound: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldWarnCodexFreshStartWithoutResume({
+        threadOpenMethod: "thread/start",
+        previouslyBound: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldWarnCodexFreshStartWithoutResume({
+        threadOpenMethod: "thread/resume",
+        previouslyBound: true,
+      }),
+    ).toBe(false);
+  });
+});
+
 describe("formatCodexThreadResumeError", () => {
   it("explains how to resolve an active writer conflict", () => {
     const formatted = formatCodexThreadResumeError(
@@ -1531,6 +1555,43 @@ describe("resolveCodexModelForAccount", () => {
 });
 
 describe("startSession", () => {
+  it("emits session/started after any successful thread open", () => {
+    const manager = new CodexAppServerManager();
+    const methods: string[] = [];
+    manager.on("event", (event) => {
+      methods.push(event.method);
+    });
+    const context = {
+      session: {
+        provider: "codex" as const,
+        status: "connecting" as const,
+        threadId: asThreadId("thread-1"),
+        runtimeMode: "full-access" as const,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        resumeCursor: undefined as unknown,
+      },
+    };
+
+    for (const threadOpenMethod of ["thread/start", "thread/resume", "thread/fork"] as const) {
+      methods.length = 0;
+      (
+        manager as unknown as {
+          markSessionReadyAfterThreadOpen: (
+            context: unknown,
+            input: { threadOpenMethod: string; providerThreadId: string },
+          ) => void;
+        }
+      ).markSessionReadyAfterThreadOpen(context, {
+        threadOpenMethod,
+        providerThreadId: "native-thread-1",
+      });
+      expect(methods).toEqual(["session/threadOpenResolved", "session/ready", "session/started"]);
+      expect(context.session.status).toBe("ready");
+      expect(context.session.resumeCursor).toEqual({ threadId: "native-thread-1" });
+    }
+  });
+
   it("enables Codex experimental api capabilities during initialize", () => {
     expect(buildCodexInitializeParams()).toEqual({
       clientInfo: {

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -3527,10 +3527,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       "session/ready",
       `Connected to thread ${input.providerThreadId}`,
     );
-    // Codex does not emit session/started on thread/resume or thread/fork.
-    // ProviderService only re-arms the cursor-preserving idle-stop timer on
-    // session.started / thread.started / terminal turn events, so we emit it
-    // after every successful open.
+    // Resume/fork do not notify session start; emit it so idle-stop re-arms.
     this.emitLifecycleEvent(
       context,
       "session/started",

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -648,6 +648,13 @@ export function buildCodexThreadOpenRequest(input: {
   };
 }
 
+export function shouldWarnCodexFreshStartWithoutResume(input: {
+  readonly threadOpenMethod: string;
+  readonly previouslyBound: boolean;
+}): boolean {
+  return input.threadOpenMethod === "thread/start" && input.previouslyBound;
+}
+
 // turn/start uses sandboxPolicy objects, so keep this separate from thread/start.
 function mapCodexRuntimeModeToTurnOverrides(runtimeMode: RuntimeMode): {
   readonly approvalPolicy: CodexApprovalPolicy;
@@ -953,6 +960,7 @@ function setRecentCacheEntry<K, V>(
 
 export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEvents> {
   private readonly sessions = new Map<ThreadId, CodexSessionContext>();
+  private readonly previouslyBoundThreadIds = new Set<ThreadId>();
   private readonly discoverySessions = new Map<string, CodexSessionContext>();
   private readonly discoverySessionStartups = new Map<string, Promise<CodexSessionContext>>();
   private readonly discoverySessionIdleTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -1154,6 +1162,28 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         ...(resumeThreadId ? { resumeThreadId } : {}),
         sessionOverrides,
       });
+      const previouslyBound =
+        this.previouslyBoundThreadIds.has(threadId) || input.resumeCursor !== undefined;
+      if (
+        shouldWarnCodexFreshStartWithoutResume({
+          threadOpenMethod: threadOpenRequest.method,
+          previouslyBound,
+        })
+      ) {
+        this.emitLifecycleEvent(
+          context,
+          "session/threadStartWithoutResume",
+          "Starting a new Codex thread for a Synara thread that previously had a provider binding.",
+        );
+        await Effect.logWarning(
+          "codex app-server starting a fresh thread for a previously bound Synara thread",
+          {
+            threadId,
+            threadOpenMethod: "thread/start",
+            resumeThreadId: resumeThreadId ?? null,
+          },
+        ).pipe(this.runPromise);
+      }
       this.emitLifecycleEvent(
         context,
         "session/threadOpenRequested",
@@ -1241,15 +1271,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       }
       const providerThreadId = threadIdRaw;
 
-      this.updateSession(context, {
-        status: "ready",
-        resumeCursor: { threadId: providerThreadId },
+      this.markSessionReadyAfterThreadOpen(context, {
+        threadOpenMethod,
+        providerThreadId,
       });
-      this.emitLifecycleEvent(
-        context,
-        "session/threadOpenResolved",
-        `Codex ${threadOpenMethod} resolved.`,
-      );
       await Effect.logInfo("codex app-server thread open resolved", {
         threadId,
         threadOpenMethod,
@@ -1258,7 +1283,6 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         resolvedThreadId: providerThreadId,
         requestedRuntimeMode: input.runtimeMode,
       }).pipe(this.runPromise);
-      this.emitLifecycleEvent(context, "session/ready", `Connected to thread ${providerThreadId}`);
       return { ...context.session };
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to start Codex session.";
@@ -1933,16 +1957,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       const response = await this.sendRequest(context, "thread/fork", forkParams);
       const forkedProviderThreadId = this.readThreadIdFromResponse("thread/fork", response);
 
-      this.updateSession(context, {
-        status: "ready",
-        resumeCursor: { threadId: forkedProviderThreadId },
+      this.markSessionReadyAfterThreadOpen(context, {
+        threadOpenMethod: "thread/fork",
+        providerThreadId: forkedProviderThreadId,
       });
-      this.emitLifecycleEvent(context, "session/threadOpenResolved", "Codex thread/fork resolved.");
-      this.emitLifecycleEvent(
-        context,
-        "session/ready",
-        `Connected to thread ${forkedProviderThreadId}`,
-      );
 
       return {
         threadId,
@@ -3485,6 +3503,39 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       this.handleTransportFailure(context, cause);
       throw cause;
     });
+  }
+
+  private markSessionReadyAfterThreadOpen(
+    context: CodexSessionContext,
+    input: {
+      readonly threadOpenMethod: string;
+      readonly providerThreadId: string;
+    },
+  ): void {
+    this.updateSession(context, {
+      status: "ready",
+      resumeCursor: { threadId: input.providerThreadId },
+    });
+    this.previouslyBoundThreadIds.add(context.session.threadId);
+    this.emitLifecycleEvent(
+      context,
+      "session/threadOpenResolved",
+      `Codex ${input.threadOpenMethod} resolved.`,
+    );
+    this.emitLifecycleEvent(
+      context,
+      "session/ready",
+      `Connected to thread ${input.providerThreadId}`,
+    );
+    // Codex does not emit session/started on thread/resume or thread/fork.
+    // ProviderService only re-arms the cursor-preserving idle-stop timer on
+    // session.started / thread.started / terminal turn events, so we emit it
+    // after every successful open.
+    this.emitLifecycleEvent(
+      context,
+      "session/started",
+      `Codex session ready for thread ${input.providerThreadId}`,
+    );
   }
 
   private emitLifecycleEvent(context: CodexSessionContext, method: string, message: string): void {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -6377,7 +6377,7 @@ describe("ProviderCommandReactor", () => {
         createdAt: now,
       }),
     );
-    await waitFor(() => harness.stopSession.mock.calls.length === 1);
+    await waitFor(() => harness.stopRuntimeSession.mock.calls.length === 1);
 
     harness.setRuntimeSessionTurnState({ threadId: "thread-1", status: "ready" });
     await harness.emitRuntimeEvent({
@@ -9597,7 +9597,7 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
-  it("reacts to thread.session.stop by stopping provider session and clearing thread session state", async () => {
+  it("reacts to thread.session.stop by stopping the runtime without deleting the binding", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();
 
@@ -9629,7 +9629,7 @@ describe("ProviderCommandReactor", () => {
     );
 
     await waitFor(async () => {
-      if (harness.stopSession.mock.calls.length !== 1) return false;
+      if (harness.stopRuntimeSession.mock.calls.length !== 1) return false;
       const readModel = await Effect.runPromise(harness.engine.getReadModel());
       const thread = readModel.threads.find(
         (entry) => entry.id === ThreadId.makeUnsafe("thread-1"),
@@ -9642,6 +9642,10 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.status).toBe("stopped");
     expect(thread?.session?.threadId).toBe("thread-1");
     expect(thread?.session?.activeTurnId).toBeNull();
+    expect(harness.stopRuntimeSession).toHaveBeenCalledWith({
+      threadId: ThreadId.makeUnsafe("thread-1"),
+    });
+    expect(harness.stopSession).not.toHaveBeenCalled();
   });
 
   it("serializes archive cleanup through the durable provider intent source", async () => {
@@ -9675,7 +9679,7 @@ describe("ProviderCommandReactor", () => {
     );
 
     await waitFor(async () => {
-      if (harness.stopSession.mock.calls.length !== 1) return false;
+      if (harness.stopRuntimeSession.mock.calls.length !== 1) return false;
       const readModel = await Effect.runPromise(harness.engine.getReadModel());
       const thread = readModel.threads.find(
         (entry) => entry.id === ThreadId.makeUnsafe("thread-1"),
@@ -9683,9 +9687,10 @@ describe("ProviderCommandReactor", () => {
       return thread?.archivedAt !== null && thread?.session?.status === "stopped";
     });
 
-    expect(harness.stopSession).toHaveBeenCalledWith({
+    expect(harness.stopRuntimeSession).toHaveBeenCalledWith({
       threadId: ThreadId.makeUnsafe("thread-1"),
     });
+    expect(harness.stopSession).not.toHaveBeenCalled();
   });
 
   it("does not restore pending sidechat context after an explicit session stop", async () => {
@@ -9762,7 +9767,7 @@ describe("ProviderCommandReactor", () => {
     await waitFor(async () => {
       const readModel = await Effect.runPromise(harness.engine.getReadModel());
       return (
-        harness.stopSession.mock.calls.length === 1 &&
+        harness.stopRuntimeSession.mock.calls.length === 1 &&
         readModel.threads.find((thread) => thread.id === threadId)?.session?.status === "stopped"
       );
     });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -210,6 +210,7 @@ describe("ProviderCommandReactor", () => {
     readonly commandEventTimeout?: Duration.Duration;
     readonly gatewayOperationId?: string;
     readonly gitWritingModelSelection?: ModelSelection;
+    readonly omitStopRuntimeSession?: boolean;
   }) {
     const now = new Date().toISOString();
     const baseDir = input?.baseDir ?? fs.mkdtempSync(path.join(os.tmpdir(), "synara-reactor-"));
@@ -473,9 +474,13 @@ describe("ProviderCommandReactor", () => {
       respondToRequest: respondToRequest as ProviderServiceShape["respondToRequest"],
       respondToUserInput: respondToUserInput as ProviderServiceShape["respondToUserInput"],
       stopSession: stopSession as ProviderServiceShape["stopSession"],
-      stopRuntimeSession: stopRuntimeSession as NonNullable<
-        ProviderServiceShape["stopRuntimeSession"]
-      >,
+      ...(input?.omitStopRuntimeSession
+        ? {}
+        : {
+            stopRuntimeSession: stopRuntimeSession as NonNullable<
+              ProviderServiceShape["stopRuntimeSession"]
+            >,
+          }),
       clearSessionResumeCursor: clearSessionResumeCursor as NonNullable<
         ProviderServiceShape["clearSessionResumeCursor"]
       >,
@@ -9646,6 +9651,62 @@ describe("ProviderCommandReactor", () => {
       threadId: ThreadId.makeUnsafe("thread-1"),
     });
     expect(harness.stopSession).not.toHaveBeenCalled();
+  });
+
+  it("does not delete the resume cursor when stopRuntimeSession is unavailable", async () => {
+    const harness = await createHarness({ omitStopRuntimeSession: true });
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-set-for-missing-runtime-stop"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "ready",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.stop",
+        commandId: CommandId.makeUnsafe("cmd-session-stop-missing-runtime-stop"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(async () => {
+      const readModel = await Effect.runPromise(harness.engine.getReadModel());
+      const thread = readModel.threads.find(
+        (entry) => entry.id === ThreadId.makeUnsafe("thread-1"),
+      );
+      return (
+        thread?.session?.status === "stopped" &&
+        thread.activities.some((activity) => activity.kind === "provider.session.stop.failed")
+      );
+    });
+    const readModel = await Effect.runPromise(harness.engine.getReadModel());
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"));
+    expect(thread?.session?.status).toBe("stopped");
+    expect(
+      thread?.activities.find((activity) => activity.kind === "provider.session.stop.failed"),
+    ).toMatchObject({
+      summary: "Provider session stop failed",
+      payload: {
+        detail: "The cursor-preserving runtime stop is unavailable.",
+      },
+    });
+    expect(harness.stopSession).not.toHaveBeenCalled();
+    expect(harness.stopRuntimeSession).not.toHaveBeenCalled();
   });
 
   it("serializes archive cleanup through the durable provider intent source", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -3663,25 +3663,37 @@ const make = Effect.gen(function* () {
     if (thread.session && thread.session.status !== "stopped" && ownsProviderSession) {
       // A stop that cannot finish must still settle the projection: the session
       // row below is the only thing that releases the turn in the UI.
-      // User-facing session stop (and archive, which shares this path) must
-      // kill the runtime without deleting the durable resume cursor.
-      // Destructive stopSession stays reserved for thread deletion.
-      const stopProviderRuntime = providerService.stopRuntimeSession ?? providerService.stopSession;
-      const stopped = yield* runBoundedProviderCall({
-        label: "The provider session stop",
-        timeout: PROVIDER_COMMAND_STOP_TIMEOUT,
-        call: stopProviderRuntime({ threadId: providerThread.id }),
-      });
-      if (stopped._tag !== "ok") {
+      if (!providerService.stopRuntimeSession) {
+        yield* Effect.logWarning(
+          "provider command reactor skipped session stop: stopRuntimeSession is unavailable",
+          { threadId: thread.id },
+        );
         yield* appendProviderFailureActivity({
           threadId: thread.id,
           kind: "provider.session.stop.failed",
           summary: "Provider session stop failed",
-          detail: stopped._tag === "timeout" ? stopped.detail : stopped.outcome.detail,
+          detail: "The cursor-preserving runtime stop is unavailable.",
           turnId: null,
           createdAt: input.createdAt,
           settlementStatus: "uncertain",
         });
+      } else {
+        const stopped = yield* runBoundedProviderCall({
+          label: "The provider session stop",
+          timeout: PROVIDER_COMMAND_STOP_TIMEOUT,
+          call: providerService.stopRuntimeSession({ threadId: providerThread.id }),
+        });
+        if (stopped._tag !== "ok") {
+          yield* appendProviderFailureActivity({
+            threadId: thread.id,
+            kind: "provider.session.stop.failed",
+            summary: "Provider session stop failed",
+            detail: stopped._tag === "timeout" ? stopped.detail : stopped.outcome.detail,
+            turnId: null,
+            createdAt: input.createdAt,
+            settlementStatus: "uncertain",
+          });
+        }
       }
     }
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -3663,10 +3663,14 @@ const make = Effect.gen(function* () {
     if (thread.session && thread.session.status !== "stopped" && ownsProviderSession) {
       // A stop that cannot finish must still settle the projection: the session
       // row below is the only thing that releases the turn in the UI.
+      // User-facing session stop (and archive, which shares this path) must
+      // kill the runtime without deleting the durable resume cursor.
+      // Destructive stopSession stays reserved for thread deletion.
+      const stopProviderRuntime = providerService.stopRuntimeSession ?? providerService.stopSession;
       const stopped = yield* runBoundedProviderCall({
         label: "The provider session stop",
         timeout: PROVIDER_COMMAND_STOP_TIMEOUT,
-        call: providerService.stopSession({ threadId: providerThread.id }),
+        call: stopProviderRuntime({ threadId: providerThread.id }),
       });
       if (stopped._tag !== "ok") {
         yield* appendProviderFailureActivity({

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -462,6 +462,37 @@ const lifecycleLayer = it.layer(
 );
 
 lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
+  it.effect("maps session/started to a canonical session.started runtime event", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+
+      lifecycleManager.emit("event", {
+        id: asEventId("evt-session-started"),
+        kind: "session",
+        provider: "codex",
+        createdAt: new Date().toISOString(),
+        method: "session/started",
+        threadId: asThreadId("thread-1"),
+        message: "Codex session ready for thread native-thread-1",
+      } satisfies ProviderEvent);
+
+      const firstEvent = yield* Fiber.join(firstEventFiber);
+      assert.equal(firstEvent._tag, "Some");
+      if (firstEvent._tag !== "Some") {
+        return;
+      }
+      assert.equal(firstEvent.value.type, "session.started");
+      if (firstEvent.value.type !== "session.started") {
+        return;
+      }
+      assert.equal(
+        firstEvent.value.payload.message,
+        "Codex session ready for thread native-thread-1",
+      );
+    }),
+  );
+
   it.effect("normalizes whitespace in configuration warnings at the provider boundary", () =>
     Effect.gen(function* () {
       const adapter = yield* CodexAdapter;

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -75,7 +75,7 @@ function makeLayer(input: {
 
 function makeProviderServiceStub(input: {
   readonly stopSession: ProviderServiceShape["stopSession"];
-  readonly stopRuntimeSession: NonNullable<ProviderServiceShape["stopRuntimeSession"]>;
+  readonly stopRuntimeSession?: NonNullable<ProviderServiceShape["stopRuntimeSession"]>;
 }): ProviderServiceShape {
   return {
     startSession: () => unsupported(),
@@ -89,7 +89,7 @@ function makeProviderServiceStub(input: {
     respondToRequest: () => unsupported(),
     respondToUserInput: () => unsupported(),
     stopSession: input.stopSession,
-    stopRuntimeSession: input.stopRuntimeSession,
+    ...(input.stopRuntimeSession ? { stopRuntimeSession: input.stopRuntimeSession } : {}),
     listSessions: () => Effect.succeed([]),
     getCapabilities: () => unsupported(),
     rollbackConversation: () => unsupported(),
@@ -252,6 +252,50 @@ describe("ProviderSessionReaperLive", () => {
     }
 
     expect(stopRuntimeSession).not.toHaveBeenCalled();
+    expect(stopSession).not.toHaveBeenCalled();
+  });
+
+  it("skips idle sweep when stopRuntimeSession is unavailable", async () => {
+    const threadId = ThreadId.makeUnsafe("thread-reaper-missing-runtime-stop");
+    const stopSession = vi.fn<ProviderServiceShape["stopSession"]>(() => Effect.void);
+    const directory: ProviderSessionDirectoryShape = {
+      upsert: () => Effect.void,
+      getProvider: () => unsupported(),
+      getBinding: () => unsupported(),
+      remove: () => Effect.void,
+      listThreadIds: () => Effect.succeed([]),
+      listBindings: () =>
+        Effect.succeed([
+          {
+            threadId,
+            provider: "codex",
+            status: "running",
+            lastSeenAt: "2026-01-01T00:00:00.000Z",
+            resumeCursor: { threadId: "native-thread-reaper-missing-runtime-stop" },
+          },
+        ]),
+    };
+
+    const scope = await Effect.runPromise(Scope.make());
+    try {
+      await Effect.gen(function* () {
+        const reaper = yield* ProviderSessionReaper;
+        yield* Scope.provide(reaper.start(), scope);
+      }).pipe(
+        Effect.provide(
+          makeLayer({
+            threadShell: makeThreadShell({ threadId, activeTurnId: null }),
+            directory,
+            providerService: makeProviderServiceStub({ stopSession }),
+          }),
+        ),
+        Effect.runPromise,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    } finally {
+      await Effect.runPromise(Scope.close(scope, Exit.void));
+    }
+
     expect(stopSession).not.toHaveBeenCalled();
   });
 

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -1,15 +1,30 @@
-import { ThreadId, TurnId, type OrchestrationThreadShell } from "@synara/contracts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import {
+  type ProviderKind,
+  type ProviderSession,
+  type ProviderSessionStartInput,
+  ThreadId,
+  TurnId,
+  type OrchestrationThreadShell,
+} from "@synara/contracts";
 import { Effect, Exit, Layer, Option, Scope, Stream } from "effect";
 import { describe, expect, it, vi } from "vitest";
 
+import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
+import { ProviderSessionRuntimeRepositoryLive } from "../../persistence/Layers/ProviderSessionRuntime.ts";
 import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery";
 import { fakeProjectionSnapshotQuery } from "../../orchestration/testing/fakeProjectionSnapshotQuery";
+import { ProviderUnsupportedError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
+import { ProviderAdapterRegistry } from "../Services/ProviderAdapterRegistry.ts";
 import {
   ProviderSessionDirectory,
   type ProviderSessionDirectoryShape,
 } from "../Services/ProviderSessionDirectory";
 import { ProviderSessionReaper } from "../Services/ProviderSessionReaper";
 import { ProviderService, type ProviderServiceShape } from "../Services/ProviderService";
+import { makeProviderServiceLive } from "./ProviderService.ts";
+import { ProviderSessionDirectoryLive } from "./ProviderSessionDirectory.ts";
 import { makeProviderSessionReaperLive } from "./ProviderSessionReaper";
 
 const unsupported = () => Effect.die(new Error("Unsupported test call")) as never;
@@ -58,10 +73,97 @@ function makeLayer(input: {
   );
 }
 
+function makeProviderServiceStub(input: {
+  readonly stopSession: ProviderServiceShape["stopSession"];
+  readonly stopRuntimeSession: NonNullable<ProviderServiceShape["stopRuntimeSession"]>;
+}): ProviderServiceShape {
+  return {
+    startSession: () => unsupported(),
+    sendTurn: () => unsupported(),
+    steerTurn: () => unsupported(),
+    startReview: () => unsupported(),
+    interruptTurn: () => unsupported(),
+    stopTask: () => unsupported(),
+    backgroundTask: () => unsupported(),
+    steerSubagent: () => unsupported(),
+    respondToRequest: () => unsupported(),
+    respondToUserInput: () => unsupported(),
+    stopSession: input.stopSession,
+    stopRuntimeSession: input.stopRuntimeSession,
+    listSessions: () => Effect.succeed([]),
+    getCapabilities: () => unsupported(),
+    rollbackConversation: () => unsupported(),
+    compactThread: () => unsupported(),
+    closeRuntimeEvents: Effect.void,
+    streamEvents: Stream.empty,
+  };
+}
+
+function makeFakeAdapter(provider: ProviderKind) {
+  const sessions = new Map<ThreadId, ProviderSession>();
+
+  const startSession = vi.fn((input: ProviderSessionStartInput) =>
+    Effect.sync(() => {
+      const now = new Date().toISOString();
+      const session: ProviderSession = {
+        provider,
+        status: "ready",
+        runtimeMode: input.runtimeMode,
+        threadId: input.threadId,
+        resumeCursor: input.resumeCursor ?? { threadId: `native-${String(input.threadId)}` },
+        cwd: input.cwd ?? process.cwd(),
+        createdAt: now,
+        updatedAt: now,
+      };
+      sessions.set(session.threadId, session);
+      return session;
+    }),
+  );
+
+  const stopSession = vi.fn((threadId: ThreadId) =>
+    Effect.sync(() => {
+      sessions.delete(threadId);
+    }),
+  );
+
+  const adapter: ProviderAdapterShape<never> = {
+    provider,
+    capabilities: { sessionModelSwitch: "in-session" },
+    startSession,
+    sendTurn: () => unsupported(),
+    interruptTurn: () => Effect.void,
+    respondToRequest: () => Effect.void,
+    respondToUserInput: () => Effect.void,
+    stopSession,
+    stopAll: () =>
+      Effect.sync(() => {
+        sessions.clear();
+      }),
+    listSessions: () => Effect.sync(() => Array.from(sessions.values())),
+    hasSession: (threadId) => Effect.succeed(sessions.has(threadId)),
+    readThread: (threadId) =>
+      Effect.succeed({
+        threadId,
+        turns: [],
+      }),
+    rollbackThread: (threadId) =>
+      Effect.succeed({
+        threadId,
+        turns: [],
+      }),
+    streamEvents: Stream.never,
+  };
+
+  return { adapter, startSession, stopSession };
+}
+
 describe("ProviderSessionReaperLive", () => {
-  it("stops stale sessions without active turns", async () => {
+  it("stops stale sessions without active turns using a cursor-preserving runtime stop", async () => {
     const threadId = ThreadId.makeUnsafe("thread-reaper-stale");
     const stopSession = vi.fn<ProviderServiceShape["stopSession"]>(() => Effect.void);
+    const stopRuntimeSession = vi.fn<NonNullable<ProviderServiceShape["stopRuntimeSession"]>>(
+      () => Effect.void,
+    );
     const directory: ProviderSessionDirectoryShape = {
       upsert: () => Effect.void,
       getProvider: () => unsupported(),
@@ -75,27 +177,9 @@ describe("ProviderSessionReaperLive", () => {
             provider: "codex",
             status: "running",
             lastSeenAt: "2026-01-01T00:00:00.000Z",
+            resumeCursor: { threadId: "native-thread-reaper-stale" },
           },
         ]),
-    };
-    const providerService: ProviderServiceShape = {
-      startSession: () => unsupported(),
-      sendTurn: () => unsupported(),
-      steerTurn: () => unsupported(),
-      startReview: () => unsupported(),
-      interruptTurn: () => unsupported(),
-      stopTask: () => unsupported(),
-      backgroundTask: () => unsupported(),
-      steerSubagent: () => unsupported(),
-      respondToRequest: () => unsupported(),
-      respondToUserInput: () => unsupported(),
-      stopSession,
-      listSessions: () => Effect.succeed([]),
-      getCapabilities: () => unsupported(),
-      rollbackConversation: () => unsupported(),
-      compactThread: () => unsupported(),
-      closeRuntimeEvents: Effect.void,
-      streamEvents: Stream.empty,
     };
 
     const scope = await Effect.runPromise(Scope.make());
@@ -108,23 +192,27 @@ describe("ProviderSessionReaperLive", () => {
           makeLayer({
             threadShell: makeThreadShell({ threadId, activeTurnId: null }),
             directory,
-            providerService,
+            providerService: makeProviderServiceStub({ stopSession, stopRuntimeSession }),
           }),
         ),
         Effect.runPromise,
       );
-      await waitFor(() => stopSession.mock.calls.length === 1);
+      await waitFor(() => stopRuntimeSession.mock.calls.length === 1);
     } finally {
       await Effect.runPromise(Scope.close(scope, Exit.void));
     }
 
-    expect(stopSession).toHaveBeenCalledWith({ threadId });
+    expect(stopRuntimeSession).toHaveBeenCalledWith({ threadId });
+    expect(stopSession).not.toHaveBeenCalled();
   });
 
   it("skips stale sessions with active turns", async () => {
     const threadId = ThreadId.makeUnsafe("thread-reaper-active");
     const turnId = TurnId.makeUnsafe("turn-reaper-active");
     const stopSession = vi.fn<ProviderServiceShape["stopSession"]>(() => Effect.void);
+    const stopRuntimeSession = vi.fn<NonNullable<ProviderServiceShape["stopRuntimeSession"]>>(
+      () => Effect.void,
+    );
     const directory: ProviderSessionDirectoryShape = {
       upsert: () => Effect.void,
       getProvider: () => unsupported(),
@@ -138,27 +226,9 @@ describe("ProviderSessionReaperLive", () => {
             provider: "codex",
             status: "running",
             lastSeenAt: "2026-01-01T00:00:00.000Z",
+            resumeCursor: { threadId: "native-thread-reaper-active" },
           },
         ]),
-    };
-    const providerService: ProviderServiceShape = {
-      startSession: () => unsupported(),
-      sendTurn: () => unsupported(),
-      steerTurn: () => unsupported(),
-      startReview: () => unsupported(),
-      interruptTurn: () => unsupported(),
-      stopTask: () => unsupported(),
-      backgroundTask: () => unsupported(),
-      steerSubagent: () => unsupported(),
-      respondToRequest: () => unsupported(),
-      respondToUserInput: () => unsupported(),
-      stopSession,
-      listSessions: () => Effect.succeed([]),
-      getCapabilities: () => unsupported(),
-      rollbackConversation: () => unsupported(),
-      compactThread: () => unsupported(),
-      closeRuntimeEvents: Effect.void,
-      streamEvents: Stream.empty,
     };
 
     const scope = await Effect.runPromise(Scope.make());
@@ -171,7 +241,7 @@ describe("ProviderSessionReaperLive", () => {
           makeLayer({
             threadShell: makeThreadShell({ threadId, activeTurnId: turnId }),
             directory,
-            providerService,
+            providerService: makeProviderServiceStub({ stopSession, stopRuntimeSession }),
           }),
         ),
         Effect.runPromise,
@@ -181,6 +251,107 @@ describe("ProviderSessionReaperLive", () => {
       await Effect.runPromise(Scope.close(scope, Exit.void));
     }
 
+    expect(stopRuntimeSession).not.toHaveBeenCalled();
     expect(stopSession).not.toHaveBeenCalled();
   });
+
+  it("keeps the Codex resume cursor after an idle reaper sweep of a pre-warmed running session", async () => {
+    await assertIdleReaperPreservesResumeCursor("codex", "thread-reaper-idle-codex");
+  });
+
+  it("keeps the resume cursor without session.started emission", async () => {
+    await assertIdleReaperPreservesResumeCursor("claudeAgent", "thread-reaper-idle-claude");
+  });
 });
+
+async function assertIdleReaperPreservesResumeCursor(
+  provider: ProviderKind,
+  threadIdValue: string,
+): Promise<void> {
+  const threadId = ThreadId.makeUnsafe(threadIdValue);
+  const fake = makeFakeAdapter(provider);
+  const registry: typeof ProviderAdapterRegistry.Service = {
+    getByProvider: (requested) =>
+      requested === provider
+        ? Effect.succeed(fake.adapter)
+        : Effect.fail(new ProviderUnsupportedError({ provider: requested })),
+    listProviders: () => Effect.succeed([provider]),
+  };
+  const runtimeRepositoryLayer = ProviderSessionRuntimeRepositoryLive.pipe(
+    Layer.provide(SqlitePersistenceMemory),
+  );
+  const directoryLayer = ProviderSessionDirectoryLive.pipe(Layer.provide(runtimeRepositoryLayer));
+  const providerLayer = makeProviderServiceLive({ runtimeIdleStopMs: 0 }).pipe(
+    Layer.provide(Layer.succeed(ProviderAdapterRegistry, registry)),
+    Layer.provide(directoryLayer),
+  );
+  const sharedLayer = Layer.mergeAll(providerLayer, directoryLayer, NodeServices.layer);
+  const reaperLayer = makeProviderSessionReaperLive({
+    inactivityThresholdMs: 1,
+    sweepIntervalMs: 60_000,
+  }).pipe(
+    Layer.provide(sharedLayer),
+    Layer.provide(
+      Layer.succeed(
+        ProjectionSnapshotQuery,
+        fakeProjectionSnapshotQuery({
+          getThreadShellById: () =>
+            Effect.succeed(Option.some(makeThreadShell({ threadId, activeTurnId: null }))),
+        }),
+      ),
+    ),
+  );
+  const layer = Layer.mergeAll(sharedLayer, reaperLayer);
+  const expectedResumeCursor = { threadId: `native-${threadIdValue}` };
+
+  await Effect.gen(function* () {
+    const providerService = yield* ProviderService;
+    const directory = yield* ProviderSessionDirectory;
+    const reaper = yield* ProviderSessionReaper;
+
+    const started = yield* providerService.startSession(threadId, {
+      provider,
+      threadId,
+      cwd: "/tmp/reaper-idle",
+      runtimeMode: "full-access",
+    });
+    expect(started.resumeCursor).toEqual(expectedResumeCursor);
+
+    if (!providerService.stopRuntimeSession) {
+      throw new Error("Expected stopRuntimeSession");
+    }
+    yield* providerService.stopRuntimeSession({ threadId });
+    fake.startSession.mockClear();
+    const prewarmed = yield* providerService.startSession(threadId, {
+      provider,
+      threadId,
+      cwd: "/tmp/reaper-idle",
+      runtimeMode: "full-access",
+    });
+    expect(fake.startSession.mock.calls[0]?.[0]?.resumeCursor).toEqual(expectedResumeCursor);
+    const prewarmedBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+    expect(prewarmedBinding?.status).toBe("running");
+    expect(prewarmedBinding?.resumeCursor).toEqual(prewarmed.resumeCursor);
+
+    yield* Effect.promise(() => new Promise<void>((resolve) => setTimeout(resolve, 20)));
+    const adapterStopsBeforeSweep = fake.stopSession.mock.calls.length;
+    yield* reaper.start();
+    yield* Effect.promise(() =>
+      waitFor(() => fake.stopSession.mock.calls.length === adapterStopsBeforeSweep + 1),
+    );
+
+    const afterSweep = Option.getOrUndefined(yield* directory.getBinding(threadId));
+    expect(afterSweep).toBeDefined();
+    expect(afterSweep?.resumeCursor).toEqual(expectedResumeCursor);
+    expect(afterSweep?.status).toBe("stopped");
+
+    fake.startSession.mockClear();
+    yield* providerService.startSession(threadId, {
+      provider,
+      threadId,
+      cwd: "/tmp/reaper-idle",
+      runtimeMode: "full-access",
+    });
+    expect(fake.startSession.mock.calls[0]?.[0]?.resumeCursor).toEqual(expectedResumeCursor);
+  }).pipe(Effect.provide(layer), Effect.scoped, Effect.runPromise);
+}

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.ts
@@ -54,7 +54,11 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
           .pipe(Effect.map(Option.getOrUndefined));
         if (thread?.session?.activeTurnId != null) continue;
 
-        yield* providerService.stopSession({ threadId: binding.threadId }).pipe(
+        // Idle reaping must preserve the durable resume cursor. stopSession
+        // deletes the binding row, so the next open issues thread/start with
+        // no provider history.
+        const stopIdleSession = providerService.stopRuntimeSession ?? providerService.stopSession;
+        yield* stopIdleSession({ threadId: binding.threadId }).pipe(
           Effect.catchCause((cause) =>
             Effect.logWarning("provider session reaper failed to stop stale session", {
               threadId: binding.threadId,

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.ts
@@ -29,6 +29,13 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
     const sweepIntervalMs = Math.max(1, options?.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS);
 
     const sweep = Effect.gen(function* () {
+      if (!providerService.stopRuntimeSession) {
+        yield* Effect.logWarning(
+          "provider session reaper skipped sweep: stopRuntimeSession is unavailable",
+        );
+        return;
+      }
+      const stopRuntimeSession = providerService.stopRuntimeSession;
       const bindings = yield* directory.listBindings();
       const now = Date.now();
 
@@ -54,11 +61,7 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
           .pipe(Effect.map(Option.getOrUndefined));
         if (thread?.session?.activeTurnId != null) continue;
 
-        // Idle reaping must preserve the durable resume cursor. stopSession
-        // deletes the binding row, so the next open issues thread/start with
-        // no provider history.
-        const stopIdleSession = providerService.stopRuntimeSession ?? providerService.stopSession;
-        yield* stopIdleSession({ threadId: binding.threadId }).pipe(
+        yield* stopRuntimeSession({ threadId: binding.threadId }).pipe(
           Effect.catchCause((cause) =>
             Effect.logWarning("provider session reaper failed to stop stale session", {
               threadId: binding.threadId,


### PR DESCRIPTION
Fixes #773

Idle Codex threads were losing provider history after ~30 minutes (or after the UI Stop control). The session reaper and Stop both called destructive `stopSession`, which deleted the durable resume cursor, so the next message opened a brand-new Codex thread with no context.

## What changed
- Idle reaping and UI/archive Stop now use cursor-preserving `stopRuntimeSession` instead of deleting the binding.
- Codex emits `session/started` after `thread/start`, `thread/resume`, and `thread/fork` so the 10-minute idle-stop re-arms.
- Warn when a previously bound thread is opened with `thread/start`.
- No fallback to `stopSession` if `stopRuntimeSession` is missing.

## Test plan
- [ ] Codex thread, memorable fact, wait 35+ minutes (or Stop session), ask the fact back — model should remember.
- [ ] Binding still has a resume cursor after reaper/Stop.
