### PR TITLE
fix(web): hold queued follow-ups until the previous turn starts (#774)

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -5502,6 +5502,202 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("auto-dispatches only the queue head until the previous turn is live", async () => {
+    const restoreNativeApi = installDeterministicSendNativeApi();
+    const firstQueuedPrompt = "queued follow-up A stays the only dispatch";
+    const secondQueuedPrompt = "queued follow-up B must wait for the live turn";
+    let currentSnapshot = createSnapshotForTargetUser({
+      targetMessageId: "msg-user-queued-gap-target" as MessageId,
+      targetText: "queued gap target",
+      sessionStatus: "running",
+    });
+
+    const enqueueQueuedChatTurn = (id: string, prompt: string) => {
+      useComposerDraftStore.getState().enqueueQueuedTurn(THREAD_ID, {
+        id,
+        kind: "chat",
+        createdAt: NOW_ISO,
+        previewText: prompt,
+        prompt,
+        images: [],
+        files: [],
+        assistantSelections: [],
+        browserAnnotations: [],
+        terminalContexts: [],
+        fileComments: [],
+        pastedTexts: [],
+        skills: [],
+        mentions: [],
+        selectedProvider: "codex",
+        selectedModel: "gpt-5",
+        selectedPromptEffort: null,
+        modelSelection: {
+          provider: "codex",
+          model: "gpt-5",
+        },
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        envMode: "local",
+      });
+    };
+
+    const turnStartCommands = () =>
+      wsRequests.flatMap((request) => {
+        if (request._tag !== ORCHESTRATION_WS_METHODS.dispatchCommand) {
+          return [];
+        }
+        const command = request.command;
+        if (
+          typeof command !== "object" ||
+          command === null ||
+          !("type" in command) ||
+          command.type !== "thread.turn.start"
+        ) {
+          return [];
+        }
+        return [
+          command as {
+            threadId?: unknown;
+            message?: { messageId?: unknown; text?: unknown };
+          },
+        ];
+      });
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: currentSnapshot,
+    });
+
+    const syncActiveThread = (
+      update: (
+        thread: OrchestrationReadModel["threads"][number],
+      ) => OrchestrationReadModel["threads"][number],
+    ) => {
+      currentSnapshot = {
+        ...currentSnapshot,
+        snapshotSequence: currentSnapshot.snapshotSequence + 1,
+        threads: currentSnapshot.threads.map((thread) =>
+          thread.id === THREAD_ID ? update(thread) : thread,
+        ),
+        updatedAt: isoAt(currentSnapshot.snapshotSequence + 1_200),
+      };
+      fixture = { ...fixture, snapshot: currentSnapshot };
+      useStore.getState().syncServerReadModel(currentSnapshot);
+    };
+
+    try {
+      enqueueQueuedChatTurn("queued-turn-gap-a", firstQueuedPrompt);
+      enqueueQueuedChatTurn("queued-turn-gap-b", secondQueuedPrompt);
+
+      await vi.waitFor(
+        () => {
+          expect(document.querySelectorAll('[data-testid="queued-follow-up-row"]')).toHaveLength(2);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      syncActiveThread((thread) => ({
+        ...thread,
+        session: thread.session
+          ? {
+              ...thread.session,
+              status: "ready",
+              activeTurnId: null,
+              updatedAt: isoAt(1_200),
+            }
+          : null,
+        updatedAt: isoAt(1_200),
+      }));
+
+      const firstCommand = await vi.waitFor(
+        () => {
+          const match = turnStartCommands().find((command) =>
+            String(command.message?.text ?? "").includes(firstQueuedPrompt),
+          );
+          expect(match, "first queued turn should auto-dispatch").toBeTruthy();
+          return match!;
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+      const sentMessageId = String(firstCommand.message?.messageId ?? "");
+      expect(sentMessageId, "dispatched user message id").not.toBe("");
+
+      const requestedTurnId = TurnId.makeUnsafe("turn-queued-gap");
+      syncActiveThread((thread) => ({
+        ...thread,
+        messages: [
+          ...thread.messages,
+          {
+            id: MessageId.makeUnsafe(sentMessageId),
+            role: "user" as const,
+            text: firstQueuedPrompt,
+            turnId: requestedTurnId,
+            streaming: false,
+            source: "native" as const,
+            createdAt: isoAt(1_300),
+            updatedAt: isoAt(1_300),
+          },
+        ],
+        latestTurn: {
+          turnId: requestedTurnId,
+          state: "running",
+          requestedAt: isoAt(1_300),
+          startedAt: null,
+          completedAt: null,
+          assistantMessageId: null,
+        },
+        session: thread.session
+          ? {
+              ...thread.session,
+              status: "ready",
+              activeTurnId: null,
+              updatedAt: isoAt(1_300),
+            }
+          : null,
+        updatedAt: isoAt(1_300),
+      }));
+
+      await new Promise<void>((resolve) => {
+        window.setTimeout(resolve, 500);
+      });
+
+      expect(turnStartCommands()).toHaveLength(1);
+      expect(String(turnStartCommands()[0]?.message?.text ?? "")).toContain(firstQueuedPrompt);
+      expect(document.querySelectorAll('[data-testid="queued-follow-up-row"]')).toHaveLength(1);
+      expect(document.body.textContent).toContain(secondQueuedPrompt);
+
+      syncActiveThread((thread) => ({
+        ...thread,
+        latestTurn: thread.latestTurn
+          ? {
+              ...thread.latestTurn,
+              startedAt: isoAt(1_301),
+            }
+          : thread.latestTurn,
+        session: thread.session
+          ? {
+              ...thread.session,
+              status: "running",
+              activeTurnId: requestedTurnId,
+              updatedAt: isoAt(1_301),
+            }
+          : null,
+        updatedAt: isoAt(1_301),
+      }));
+
+      await new Promise<void>((resolve) => {
+        window.setTimeout(resolve, 400);
+      });
+
+      expect(turnStartCommands()).toHaveLength(1);
+      expect(document.querySelectorAll('[data-testid="queued-follow-up-row"]')).toHaveLength(1);
+      expect(document.body.textContent).toContain(secondQueuedPrompt);
+    } finally {
+      await mounted.cleanup();
+      restoreNativeApi();
+    }
+  });
+
   it("keeps the new thread selected after clicking the new-thread button", async () => {
     const mounted = await mountChatView({
       viewport: DEFAULT_VIEWPORT,

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -1457,15 +1457,6 @@ export function resolveQueuedSteerGateTransition(input: {
   };
 }
 
-/**
- * Guards the queued-composer auto-dispatch effect. After sending
- * `queuedTurns[0]`, the thread can look idle: the user-message echo and
- * `thread.turn-start-requested` are not live-turn takeover, so
- * `hasQueueableLiveTurn` is still false. Holding through
- * `isAwaitingTurnStart` (`localDispatch` set, takeover not observed)
- * stops the rest of the queue from flushing in that gap. Same failure
- * mode the steer gate already covers for interrupt→re-dispatch.
- */
 export function shouldHoldQueuedComposerAutoDispatch(input: {
   hasQueueableLiveTurn: boolean;
   phase: SessionPhase;
@@ -1490,6 +1481,58 @@ export function shouldHoldQueuedComposerAutoDispatch(input: {
     input.hasPendingUserInput ||
     input.queuedTurnCount === 0
   );
+}
+
+/** The post-ack gap is not live-turn takeover, so hold until `hasLiveTurnTakenOver` or fail-open. */
+export function resolveQueuedComposerAutoDispatchHold(input: {
+  localDispatch: LocalDispatchSnapshot | null;
+  phase: SessionPhase;
+  latestTurn: Thread["latestTurn"] | null;
+  session: Thread["session"] | null;
+  messages: readonly ChatMessage[];
+  isConnecting: boolean;
+  queuedSteerGate: QueuedSteerGate | null;
+  hasPendingApproval: boolean;
+  hasPendingProgress: boolean;
+  hasPendingUserInput: boolean;
+  queuedTurnCount: number;
+  threadError: string | null | undefined;
+  now?: number;
+}): boolean {
+  const isSendBusy =
+    input.localDispatch !== null &&
+    !hasServerAcknowledgedLocalDispatch({
+      localDispatch: input.localDispatch,
+      phase: input.phase,
+      latestTurn: input.latestTurn,
+      session: input.session,
+      messages: input.messages,
+      hasPendingApproval: input.hasPendingApproval,
+      hasPendingUserInput: input.hasPendingUserInput,
+      threadError: input.threadError,
+    });
+  const turnTakenOver = hasLiveTurnTakenOver({
+    localDispatch: input.localDispatch,
+    phase: input.phase,
+    latestTurn: input.latestTurn,
+    session: input.session,
+    hasPendingApproval: input.hasPendingApproval,
+    hasPendingUserInput: input.hasPendingUserInput,
+    threadError: input.threadError,
+    ...(input.now === undefined ? {} : { now: input.now }),
+  });
+  return shouldHoldQueuedComposerAutoDispatch({
+    hasQueueableLiveTurn: input.phase === "running" && input.session?.activeTurnId != null,
+    phase: input.phase,
+    isSendBusy,
+    isConnecting: input.isConnecting,
+    isAwaitingTurnStart: input.localDispatch !== null && !turnTakenOver,
+    queuedSteerGate: input.queuedSteerGate,
+    hasPendingApproval: input.hasPendingApproval,
+    hasPendingProgress: input.hasPendingProgress,
+    hasPendingUserInput: input.hasPendingUserInput,
+    queuedTurnCount: input.queuedTurnCount,
+  });
 }
 
 export const ACTIVE_TURN_LAYOUT_SETTLE_DELAY_MS = 180;

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -1457,6 +1457,41 @@ export function resolveQueuedSteerGateTransition(input: {
   };
 }
 
+/**
+ * Guards the queued-composer auto-dispatch effect. After sending
+ * `queuedTurns[0]`, the thread can look idle: the user-message echo and
+ * `thread.turn-start-requested` are not live-turn takeover, so
+ * `hasQueueableLiveTurn` is still false. Holding through
+ * `isAwaitingTurnStart` (`localDispatch` set, takeover not observed)
+ * stops the rest of the queue from flushing in that gap. Same failure
+ * mode the steer gate already covers for interrupt→re-dispatch.
+ */
+export function shouldHoldQueuedComposerAutoDispatch(input: {
+  hasQueueableLiveTurn: boolean;
+  phase: SessionPhase;
+  isSendBusy: boolean;
+  isConnecting: boolean;
+  isAwaitingTurnStart: boolean;
+  queuedSteerGate: QueuedSteerGate | null;
+  hasPendingApproval: boolean;
+  hasPendingProgress: boolean;
+  hasPendingUserInput: boolean;
+  queuedTurnCount: number;
+}): boolean {
+  return (
+    input.hasQueueableLiveTurn ||
+    input.phase === "disconnected" ||
+    input.isSendBusy ||
+    input.isConnecting ||
+    input.isAwaitingTurnStart ||
+    input.queuedSteerGate !== null ||
+    input.hasPendingApproval ||
+    input.hasPendingProgress ||
+    input.hasPendingUserInput ||
+    input.queuedTurnCount === 0
+  );
+}
+
 export const ACTIVE_TURN_LAYOUT_SETTLE_DELAY_MS = 180;
 
 export function shouldStartActiveTurnLayoutGrace(options: {

--- a/apps/web/src/components/ChatView.queuedAutoDispatch.test.ts
+++ b/apps/web/src/components/ChatView.queuedAutoDispatch.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatMessage, Thread } from "../types";
+import {
+  hasLiveTurnTakenOver,
+  hasServerAcknowledgedLocalDispatch,
+  LOCAL_DISPATCH_TURN_TAKEOVER_TIMEOUT_MS,
+  type LocalDispatchSnapshot,
+  type QueuedSteerGate,
+  shouldHoldQueuedComposerAutoDispatch,
+} from "./ChatView.logic";
+
+const localDispatch: LocalDispatchSnapshot = {
+  startedAt: "2026-04-13T00:00:00.000Z",
+  worktreeSetup: null,
+  expectedUserMessageId: "message-for-dispatch" as never,
+  latestTurnTurnId: null,
+  latestTurnRequestedAt: null,
+  latestTurnStartedAt: null,
+  latestTurnCompletedAt: null,
+  sessionOrchestrationStatus: "ready",
+  sessionUpdatedAt: "2026-04-13T00:00:00.000Z",
+};
+
+const echoedUserMessage: ChatMessage = {
+  id: "message-for-dispatch" as never,
+  role: "user",
+  text: "queued follow-up A",
+  createdAt: "2026-04-13T00:00:01.000Z",
+  streaming: false,
+};
+
+/** Idle-looking gap after `thread.message-sent` + `thread.turn-start-requested`. */
+const gapLatestTurn: Thread["latestTurn"] = {
+  turnId: "turn-1" as never,
+  state: "running",
+  requestedAt: "2026-04-13T00:00:01.000Z",
+  startedAt: null,
+  completedAt: null,
+  assistantMessageId: null,
+  sourceProposedPlan: undefined,
+};
+
+const gapSession: Thread["session"] = {
+  provider: "codex",
+  status: "ready",
+  orchestrationStatus: "ready",
+  createdAt: "2026-04-13T00:00:00.000Z",
+  updatedAt: "2026-04-13T00:00:01.000Z",
+};
+
+/**
+ * Mirrors ChatView's auto-dispatch early-return derivation so this file locks
+ * the #774 composition: message echo acks the send, takeover has not happened,
+ * remaining queued turns must stay parked.
+ */
+function resolveQueuedComposerAutoDispatchHold(input: {
+  localDispatch: LocalDispatchSnapshot | null;
+  phase: "disconnected" | "connecting" | "ready" | "running";
+  latestTurn: Thread["latestTurn"] | null;
+  session: Thread["session"] | null;
+  messages: readonly ChatMessage[];
+  queuedTurnCount: number;
+  isConnecting?: boolean;
+  queuedSteerGate?: QueuedSteerGate | null;
+  hasPendingApproval?: boolean;
+  hasPendingProgress?: boolean;
+  hasPendingUserInput?: boolean;
+  threadError?: string | null;
+  now?: number;
+}): boolean {
+  const hasPendingApproval = input.hasPendingApproval ?? false;
+  const hasPendingUserInput = input.hasPendingUserInput ?? false;
+  const isSendBusy =
+    input.localDispatch !== null &&
+    !hasServerAcknowledgedLocalDispatch({
+      localDispatch: input.localDispatch,
+      phase: input.phase,
+      latestTurn: input.latestTurn,
+      session: input.session,
+      messages: input.messages,
+      hasPendingApproval,
+      hasPendingUserInput,
+      threadError: input.threadError,
+    });
+  const turnTakenOver = hasLiveTurnTakenOver({
+    localDispatch: input.localDispatch,
+    phase: input.phase,
+    latestTurn: input.latestTurn,
+    session: input.session,
+    hasPendingApproval,
+    hasPendingUserInput,
+    threadError: input.threadError,
+    ...(input.now === undefined ? {} : { now: input.now }),
+  });
+  const isAwaitingTurnStart = input.localDispatch !== null && !turnTakenOver;
+  const hasQueueableLiveTurn = input.phase === "running" && input.session?.activeTurnId != null;
+  return shouldHoldQueuedComposerAutoDispatch({
+    hasQueueableLiveTurn,
+    phase: input.phase,
+    isSendBusy,
+    isConnecting: input.isConnecting ?? false,
+    isAwaitingTurnStart,
+    queuedSteerGate: input.queuedSteerGate ?? null,
+    hasPendingApproval,
+    hasPendingProgress: input.hasPendingProgress ?? false,
+    hasPendingUserInput,
+    queuedTurnCount: input.queuedTurnCount,
+  });
+}
+
+describe("shouldHoldQueuedComposerAutoDispatch", () => {
+  const idleRelease = {
+    hasQueueableLiveTurn: false,
+    phase: "ready" as const,
+    isSendBusy: false,
+    isConnecting: false,
+    isAwaitingTurnStart: false,
+    queuedSteerGate: null,
+    hasPendingApproval: false,
+    hasPendingProgress: false,
+    hasPendingUserInput: false,
+    queuedTurnCount: 1,
+  };
+
+  it("releases the queue head when the thread is idle and not awaiting a turn start", () => {
+    expect(shouldHoldQueuedComposerAutoDispatch(idleRelease)).toBe(false);
+  });
+
+  it("holds through the post-dispatch awaiting-turn gap even when send is no longer busy", () => {
+    expect(
+      shouldHoldQueuedComposerAutoDispatch({
+        ...idleRelease,
+        isSendBusy: false,
+        isAwaitingTurnStart: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("holds while a live turn is queueable, the steer gate is armed, or the queue is empty", () => {
+    expect(
+      shouldHoldQueuedComposerAutoDispatch({ ...idleRelease, hasQueueableLiveTurn: true }),
+    ).toBe(true);
+    expect(
+      shouldHoldQueuedComposerAutoDispatch({
+        ...idleRelease,
+        queuedSteerGate: {
+          sawInterruptGap: true,
+          gapStartedAt: 1_000,
+          armedActiveTurnId: "turn-original",
+        },
+      }),
+    ).toBe(true);
+    expect(shouldHoldQueuedComposerAutoDispatch({ ...idleRelease, queuedTurnCount: 0 })).toBe(true);
+  });
+});
+
+describe("queued composer auto-dispatch gap (#774)", () => {
+  it("does not drain remaining queued turns after message-sent / turn-start-requested", () => {
+    const now = Date.parse("2026-04-13T00:00:02.000Z");
+    expect(
+      hasServerAcknowledgedLocalDispatch({
+        localDispatch,
+        phase: "ready",
+        latestTurn: gapLatestTurn,
+        session: gapSession,
+        messages: [echoedUserMessage],
+        hasPendingApproval: false,
+        hasPendingUserInput: false,
+        threadError: null,
+      }),
+    ).toBe(true);
+    expect(
+      hasLiveTurnTakenOver({
+        localDispatch,
+        phase: "ready",
+        latestTurn: gapLatestTurn,
+        session: gapSession,
+        hasPendingApproval: false,
+        hasPendingUserInput: false,
+        threadError: null,
+        now,
+      }),
+    ).toBe(false);
+
+    expect(
+      resolveQueuedComposerAutoDispatchHold({
+        localDispatch,
+        phase: "ready",
+        latestTurn: gapLatestTurn,
+        session: gapSession,
+        messages: [echoedUserMessage],
+        queuedTurnCount: 1,
+        now,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps holding once the dispatched turn is observably live", () => {
+    expect(
+      resolveQueuedComposerAutoDispatchHold({
+        localDispatch,
+        phase: "running",
+        latestTurn: {
+          ...gapLatestTurn,
+          startedAt: "2026-04-13T00:00:02.000Z",
+        },
+        session: {
+          ...gapSession,
+          status: "running",
+          orchestrationStatus: "running",
+          activeTurnId: "turn-1" as never,
+        },
+        messages: [echoedUserMessage],
+        queuedTurnCount: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it("releases the next queued turn after the previous one finished and dispatch cleared", () => {
+    expect(
+      resolveQueuedComposerAutoDispatchHold({
+        localDispatch: null,
+        phase: "ready",
+        latestTurn: {
+          ...gapLatestTurn,
+          state: "completed",
+          startedAt: "2026-04-13T00:00:02.000Z",
+          completedAt: "2026-04-13T00:00:10.000Z",
+        },
+        session: {
+          ...gapSession,
+          status: "ready",
+          orchestrationStatus: "ready",
+        },
+        messages: [echoedUserMessage],
+        queuedTurnCount: 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("fails open after the awaiting-turn timeout so a stuck start cannot wedge the queue", () => {
+    const now = Date.parse(localDispatch.startedAt) + LOCAL_DISPATCH_TURN_TAKEOVER_TIMEOUT_MS;
+    expect(
+      hasLiveTurnTakenOver({
+        localDispatch,
+        phase: "ready",
+        latestTurn: gapLatestTurn,
+        session: gapSession,
+        hasPendingApproval: false,
+        hasPendingUserInput: false,
+        threadError: null,
+        now,
+      }),
+    ).toBe(true);
+    expect(
+      resolveQueuedComposerAutoDispatchHold({
+        localDispatch,
+        phase: "ready",
+        latestTurn: gapLatestTurn,
+        session: gapSession,
+        messages: [echoedUserMessage],
+        queuedTurnCount: 1,
+        now,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/components/ChatView.queuedAutoDispatch.test.ts
+++ b/apps/web/src/components/ChatView.queuedAutoDispatch.test.ts
@@ -6,7 +6,7 @@ import {
   hasServerAcknowledgedLocalDispatch,
   LOCAL_DISPATCH_TURN_TAKEOVER_TIMEOUT_MS,
   type LocalDispatchSnapshot,
-  type QueuedSteerGate,
+  resolveQueuedComposerAutoDispatchHold,
   shouldHoldQueuedComposerAutoDispatch,
 } from "./ChatView.logic";
 
@@ -49,63 +49,29 @@ const gapSession: Thread["session"] = {
   updatedAt: "2026-04-13T00:00:01.000Z",
 };
 
-/**
- * Mirrors ChatView's auto-dispatch early-return derivation so this file locks
- * the #774 composition: message echo acks the send, takeover has not happened,
- * remaining queued turns must stay parked.
- */
-function resolveQueuedComposerAutoDispatchHold(input: {
-  localDispatch: LocalDispatchSnapshot | null;
-  phase: "disconnected" | "connecting" | "ready" | "running";
-  latestTurn: Thread["latestTurn"] | null;
-  session: Thread["session"] | null;
-  messages: readonly ChatMessage[];
-  queuedTurnCount: number;
-  isConnecting?: boolean;
-  queuedSteerGate?: QueuedSteerGate | null;
-  hasPendingApproval?: boolean;
-  hasPendingProgress?: boolean;
-  hasPendingUserInput?: boolean;
-  threadError?: string | null;
+function resolveHold(overrides: {
+  localDispatch?: LocalDispatchSnapshot | null;
+  phase?: "disconnected" | "connecting" | "ready" | "running";
+  latestTurn?: Thread["latestTurn"] | null;
+  session?: Thread["session"] | null;
+  messages?: readonly ChatMessage[];
+  queuedTurnCount?: number;
   now?: number;
 }): boolean {
-  const hasPendingApproval = input.hasPendingApproval ?? false;
-  const hasPendingUserInput = input.hasPendingUserInput ?? false;
-  const isSendBusy =
-    input.localDispatch !== null &&
-    !hasServerAcknowledgedLocalDispatch({
-      localDispatch: input.localDispatch,
-      phase: input.phase,
-      latestTurn: input.latestTurn,
-      session: input.session,
-      messages: input.messages,
-      hasPendingApproval,
-      hasPendingUserInput,
-      threadError: input.threadError,
-    });
-  const turnTakenOver = hasLiveTurnTakenOver({
-    localDispatch: input.localDispatch,
-    phase: input.phase,
-    latestTurn: input.latestTurn,
-    session: input.session,
-    hasPendingApproval,
-    hasPendingUserInput,
-    threadError: input.threadError,
-    ...(input.now === undefined ? {} : { now: input.now }),
-  });
-  const isAwaitingTurnStart = input.localDispatch !== null && !turnTakenOver;
-  const hasQueueableLiveTurn = input.phase === "running" && input.session?.activeTurnId != null;
-  return shouldHoldQueuedComposerAutoDispatch({
-    hasQueueableLiveTurn,
-    phase: input.phase,
-    isSendBusy,
-    isConnecting: input.isConnecting ?? false,
-    isAwaitingTurnStart,
-    queuedSteerGate: input.queuedSteerGate ?? null,
-    hasPendingApproval,
-    hasPendingProgress: input.hasPendingProgress ?? false,
-    hasPendingUserInput,
-    queuedTurnCount: input.queuedTurnCount,
+  return resolveQueuedComposerAutoDispatchHold({
+    localDispatch: overrides.localDispatch === undefined ? localDispatch : overrides.localDispatch,
+    phase: overrides.phase ?? "ready",
+    latestTurn: overrides.latestTurn === undefined ? gapLatestTurn : overrides.latestTurn,
+    session: overrides.session === undefined ? gapSession : overrides.session,
+    messages: overrides.messages ?? [echoedUserMessage],
+    isConnecting: false,
+    queuedSteerGate: null,
+    hasPendingApproval: false,
+    hasPendingProgress: false,
+    hasPendingUserInput: false,
+    queuedTurnCount: overrides.queuedTurnCount ?? 1,
+    threadError: null,
+    ...(overrides.now === undefined ? {} : { now: overrides.now }),
   });
 }
 
@@ -155,7 +121,7 @@ describe("shouldHoldQueuedComposerAutoDispatch", () => {
   });
 });
 
-describe("queued composer auto-dispatch gap (#774)", () => {
+describe("resolveQueuedComposerAutoDispatchHold", () => {
   it("does not drain remaining queued turns after message-sent / turn-start-requested", () => {
     const now = Date.parse("2026-04-13T00:00:02.000Z");
     expect(
@@ -182,24 +148,12 @@ describe("queued composer auto-dispatch gap (#774)", () => {
         now,
       }),
     ).toBe(false);
-
-    expect(
-      resolveQueuedComposerAutoDispatchHold({
-        localDispatch,
-        phase: "ready",
-        latestTurn: gapLatestTurn,
-        session: gapSession,
-        messages: [echoedUserMessage],
-        queuedTurnCount: 1,
-        now,
-      }),
-    ).toBe(true);
+    expect(resolveHold({ now })).toBe(true);
   });
 
   it("keeps holding once the dispatched turn is observably live", () => {
     expect(
-      resolveQueuedComposerAutoDispatchHold({
-        localDispatch,
+      resolveHold({
         phase: "running",
         latestTurn: {
           ...gapLatestTurn,
@@ -211,30 +165,20 @@ describe("queued composer auto-dispatch gap (#774)", () => {
           orchestrationStatus: "running",
           activeTurnId: "turn-1" as never,
         },
-        messages: [echoedUserMessage],
-        queuedTurnCount: 1,
       }),
     ).toBe(true);
   });
 
   it("releases the next queued turn after the previous one finished and dispatch cleared", () => {
     expect(
-      resolveQueuedComposerAutoDispatchHold({
+      resolveHold({
         localDispatch: null,
-        phase: "ready",
         latestTurn: {
           ...gapLatestTurn,
           state: "completed",
           startedAt: "2026-04-13T00:00:02.000Z",
           completedAt: "2026-04-13T00:00:10.000Z",
         },
-        session: {
-          ...gapSession,
-          status: "ready",
-          orchestrationStatus: "ready",
-        },
-        messages: [echoedUserMessage],
-        queuedTurnCount: 1,
       }),
     ).toBe(false);
   });
@@ -253,16 +197,6 @@ describe("queued composer auto-dispatch gap (#774)", () => {
         now,
       }),
     ).toBe(true);
-    expect(
-      resolveQueuedComposerAutoDispatchHold({
-        localDispatch,
-        phase: "ready",
-        latestTurn: gapLatestTurn,
-        session: gapSession,
-        messages: [echoedUserMessage],
-        queuedTurnCount: 1,
-        now,
-      }),
-    ).toBe(false);
+    expect(resolveHold({ now })).toBe(false);
   });
 });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -593,6 +593,7 @@ import {
   PullRequestDialogState,
   type QueuedSteerGate,
   resolveQueuedSteerGateTransition,
+  shouldHoldQueuedComposerAutoDispatch,
   shouldRenderProviderHealthBanner,
   resolveRuntimeModeAfterApprovalDecision,
   revokeBlobPreviewUrl,
@@ -9363,16 +9364,23 @@ export default function ChatView({
   }, [activeTurnIdForSteerGate, phase, queuedSteerGate, sessionErroredForSteerGate]);
 
   useEffect(() => {
+    // After dispatching queuedTurns[0], the thread can look idle until the
+    // provider session reports running + activeTurnId. Message echo and
+    // turn-start-requested are not takeover, so isAwaitingTurnStart holds
+    // the rest of the queue through that gap (#774).
     if (
-      hasQueueableLiveTurn ||
-      phase === "disconnected" ||
-      isSendBusy ||
-      isConnecting ||
-      queuedSteerGate !== null ||
-      activePendingApproval !== null ||
-      activePendingProgress !== null ||
-      pendingUserInputs.length > 0 ||
-      queuedComposerTurns.length === 0
+      shouldHoldQueuedComposerAutoDispatch({
+        hasQueueableLiveTurn,
+        phase,
+        isSendBusy,
+        isConnecting,
+        isAwaitingTurnStart,
+        queuedSteerGate,
+        hasPendingApproval: activePendingApproval !== null,
+        hasPendingProgress: activePendingProgress !== null,
+        hasPendingUserInput: pendingUserInputs.length > 0,
+        queuedTurnCount: queuedComposerTurns.length,
+      })
     ) {
       return;
     }
@@ -9404,6 +9412,7 @@ export default function ChatView({
     activePendingProgress,
     dispatchQueuedComposerTurn,
     phase,
+    isAwaitingTurnStart,
     isConnecting,
     isSendBusy,
     pendingUserInputs.length,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -593,7 +593,7 @@ import {
   PullRequestDialogState,
   type QueuedSteerGate,
   resolveQueuedSteerGateTransition,
-  shouldHoldQueuedComposerAutoDispatch,
+  resolveQueuedComposerAutoDispatchHold,
   shouldRenderProviderHealthBanner,
   resolveRuntimeModeAfterApprovalDecision,
   revokeBlobPreviewUrl,
@@ -9364,22 +9364,21 @@ export default function ChatView({
   }, [activeTurnIdForSteerGate, phase, queuedSteerGate, sessionErroredForSteerGate]);
 
   useEffect(() => {
-    // After dispatching queuedTurns[0], the thread can look idle until the
-    // provider session reports running + activeTurnId. Message echo and
-    // turn-start-requested are not takeover, so isAwaitingTurnStart holds
-    // the rest of the queue through that gap (#774).
     if (
-      shouldHoldQueuedComposerAutoDispatch({
-        hasQueueableLiveTurn,
+      resolveQueuedComposerAutoDispatchHold({
+        localDispatch,
         phase,
-        isSendBusy,
+        latestTurn: activeLatestTurn,
+        session: activeThread?.session ?? null,
+        messages: activeThread?.messages ?? EMPTY_MESSAGES,
         isConnecting,
-        isAwaitingTurnStart,
         queuedSteerGate,
         hasPendingApproval: activePendingApproval !== null,
         hasPendingProgress: activePendingProgress !== null,
         hasPendingUserInput: pendingUserInputs.length > 0,
         queuedTurnCount: queuedComposerTurns.length,
+        threadError: activeThread?.error,
+        now: Date.now(),
       })
     ) {
       return;
@@ -9408,15 +9407,17 @@ export default function ChatView({
       autoDispatchingQueuedTurnRef.current = false;
     })();
   }, [
+    activeLatestTurn,
     activePendingApproval,
     activePendingProgress,
+    activeThread?.error,
+    activeThread?.messages,
+    activeThread?.session,
     dispatchQueuedComposerTurn,
-    phase,
-    isAwaitingTurnStart,
     isConnecting,
-    isSendBusy,
+    localDispatch,
     pendingUserInputs.length,
-    hasQueueableLiveTurn,
+    phase,
     queuedAutoDispatchTick,
     queuedComposerTurns,
     queuedSteerGate,


### PR DESCRIPTION
Fixes #774

Queued composer follow-ups could all flush in the idle-looking gap after `thread.message-sent` / `thread.turn-start-requested`, before the provider session was actually `running` with an `activeTurnId`. Observed: two distinct prompts dispatched ~189ms apart.

## What changed
- Auto-dispatch holds on `isAwaitingTurnStart` (`localDispatch` set, live turn not taken over yet), same idea as the existing steer gate.
- Shared hold derivation is used by ChatView and tests so dropping the gate fails unit tests.
- Browser coverage: two queued items, message-echo + `turn-start-requested` gap, only the head sends.

## Test plan
- [ ] Start a long turn, queue two different follow-ups, let the turn finish — only the first should send; the second stays queued until the next turn is live.

Note: #775 also touches `ChatView.tsx` (background drain). Merge #774 before #775 if both are open.
