### PR TITLE
fix(web): dispatch queued composer turns for backgrounded threads (#775)

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -166,9 +166,9 @@ import {
   armQueuedComposerSteerGate,
   claimQueuedComposerAutoDispatch,
   clearQueuedComposerSteerGate,
-  endQueuedComposerAutoDispatch,
   getQueuedComposerSteerGate,
   releaseQueuedComposerAutoDispatch,
+  runLockedQueuedComposerAutoDispatch,
   shouldAutoDispatchQueuedComposerTurn,
   tryBeginQueuedComposerAutoDispatch,
 } from "../lib/queuedComposerDrain";
@@ -9429,17 +9429,18 @@ export default function ChatView({
       return () => window.clearTimeout(timer);
     }
     autoDispatchingQueuedTurnRef.current = true;
-    void (async () => {
-      try {
+    void runLockedQueuedComposerAutoDispatch({
+      threadId,
+      run: async () => {
         const succeeded = await dispatchQueuedComposerTurn(nextQueuedTurn, "queue");
         if (succeeded) {
           removeQueuedComposerTurnFromDraft(threadId, nextQueuedTurn.id);
         }
-      } finally {
+      },
+      onSettled: () => {
         autoDispatchingQueuedTurnRef.current = false;
-        endQueuedComposerAutoDispatch(threadId);
-      }
-    })();
+      },
+    });
   }, [
     activeLatestTurn,
     activePendingApproval,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -166,8 +166,11 @@ import {
   armQueuedComposerSteerGate,
   claimQueuedComposerAutoDispatch,
   clearQueuedComposerSteerGate,
+  endQueuedComposerAutoDispatch,
+  getQueuedComposerSteerGate,
   releaseQueuedComposerAutoDispatch,
   shouldAutoDispatchQueuedComposerTurn,
+  tryBeginQueuedComposerAutoDispatch,
 } from "../lib/queuedComposerDrain";
 import { extractChatAutomationInvocation } from "../lib/automationIntent";
 import {
@@ -1628,8 +1631,11 @@ export default function ChatView({
   const autoDispatchingQueuedTurnRef = useRef(false);
   // Holds queued-composer auto-dispatch through a non-natively-steerable
   // provider steer's interrupt→re-dispatch gap; see
-  // resolveQueuedSteerGateTransition.
-  const [queuedSteerGate, setQueuedSteerGate] = useState<QueuedSteerGate | null>(null);
+  // resolveQueuedSteerGateTransition. Seed from the shared map so a remount
+  // during the interrupt gap still sees the gate the watcher has been holding.
+  const [queuedSteerGate, setQueuedSteerGate] = useState<QueuedSteerGate | null>(() =>
+    getQueuedComposerSteerGate(threadId),
+  );
   // Bumped to re-evaluate auto-dispatch when only non-reactive guards (refs)
   // blocked it; nothing else re-triggers the effect once they reset.
   const [queuedAutoDispatchTick, setQueuedAutoDispatchTick] = useState(0);
@@ -5637,17 +5643,11 @@ export default function ChatView({
 
   useEffect(() => {
     autoDispatchingQueuedTurnRef.current = false;
-    // Async setState (post-paint) keeps this thread-change reset out of the
-    // render->effect->render cascade. Do not clear the shared steer gate: a
-    // backgrounded thread may still need it until the watcher advances it.
-    const settle = window.setTimeout(() => {
-      setQueuedSteerGate(null);
-    }, 0);
-    return () => window.clearTimeout(settle);
   }, [threadId]);
 
   useLayoutEffect(() => {
     claimQueuedComposerAutoDispatch(threadId);
+    setQueuedSteerGate(getQueuedComposerSteerGate(threadId));
     return () => {
       releaseQueuedComposerAutoDispatch(threadId);
     };
@@ -9396,7 +9396,7 @@ export default function ChatView({
         session: activeThread?.session ?? null,
         messages: activeThread?.messages ?? EMPTY_MESSAGES,
         isConnecting,
-        queuedSteerGate,
+        queuedSteerGate: getQueuedComposerSteerGate(threadId) ?? queuedSteerGate,
         hasPendingApproval: activePendingApproval !== null,
         hasPendingProgress: activePendingProgress !== null,
         hasPendingUserInput: pendingUserInputs.length > 0,
@@ -9422,13 +9422,23 @@ export default function ChatView({
     if (!nextQueuedTurn) {
       return;
     }
+    if (!tryBeginQueuedComposerAutoDispatch(threadId)) {
+      // The watcher already owns this thread's queue head (background drain
+      // started before this ChatView claimed). Poll until that send settles.
+      const timer = window.setTimeout(() => setQueuedAutoDispatchTick((tick) => tick + 1), 250);
+      return () => window.clearTimeout(timer);
+    }
     autoDispatchingQueuedTurnRef.current = true;
     void (async () => {
-      const succeeded = await dispatchQueuedComposerTurn(nextQueuedTurn, "queue");
-      if (succeeded) {
-        removeQueuedComposerTurnFromDraft(threadId, nextQueuedTurn.id);
+      try {
+        const succeeded = await dispatchQueuedComposerTurn(nextQueuedTurn, "queue");
+        if (succeeded) {
+          removeQueuedComposerTurnFromDraft(threadId, nextQueuedTurn.id);
+        }
+      } finally {
+        autoDispatchingQueuedTurnRef.current = false;
+        endQueuedComposerAutoDispatch(threadId);
       }
-      autoDispatchingQueuedTurnRef.current = false;
     })();
   }, [
     activeLatestTurn,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -162,6 +162,13 @@ import {
 } from "../lib/composerSend";
 import { composerImageBlobKey, persistComposerImageBlob } from "../lib/composerImageBlobStore";
 import { reconcileDeletedThreadFromClient } from "../lib/deletedThreadClientReconciliation";
+import {
+  armQueuedComposerSteerGate,
+  claimQueuedComposerAutoDispatch,
+  clearQueuedComposerSteerGate,
+  releaseQueuedComposerAutoDispatch,
+  shouldAutoDispatchQueuedComposerTurn,
+} from "../lib/queuedComposerDrain";
 import { extractChatAutomationInvocation } from "../lib/automationIntent";
 import {
   automationClarificationPrompt,
@@ -5631,11 +5638,19 @@ export default function ChatView({
   useEffect(() => {
     autoDispatchingQueuedTurnRef.current = false;
     // Async setState (post-paint) keeps this thread-change reset out of the
-    // render->effect->render cascade.
+    // render->effect->render cascade. Do not clear the shared steer gate: a
+    // backgrounded thread may still need it until the watcher advances it.
     const settle = window.setTimeout(() => {
       setQueuedSteerGate(null);
     }, 0);
     return () => window.clearTimeout(settle);
+  }, [threadId]);
+
+  useLayoutEffect(() => {
+    claimQueuedComposerAutoDispatch(threadId);
+    return () => {
+      releaseQueuedComposerAutoDispatch(threadId);
+    };
   }, [threadId]);
 
   useEffect(() => {
@@ -8557,11 +8572,13 @@ export default function ChatView({
         dispatchMode === "steer" &&
         !providerSupportsNativeTurnSteering(liveProviderForSteerGate)
       ) {
-        setQueuedSteerGate({
+        const nextSteerGate = {
           sawInterruptGap: false,
           gapStartedAt: null,
           armedActiveTurnId: activeThread?.session?.activeTurnId ?? null,
-        });
+        };
+        setQueuedSteerGate(nextSteerGate);
+        armQueuedComposerSteerGate(threadId, nextSteerGate);
       }
       if (sourceProposedPlanForSend) {
         planSidebarDismissedForTurnRef.current = null;
@@ -9097,11 +9114,13 @@ export default function ChatView({
         dispatchMode === "steer" &&
         !providerSupportsNativeTurnSteering(livePlanProviderForSteerGate)
       ) {
-        setQueuedSteerGate({
+        const nextSteerGate = {
           sawInterruptGap: false,
           gapStartedAt: null,
           armedActiveTurnId: activeThread?.session?.activeTurnId ?? null,
-        });
+        };
+        setQueuedSteerGate(nextSteerGate);
+        armQueuedComposerSteerGate(threadId, nextSteerGate);
       }
       // Optimistically open the plan sidebar when implementing (not refining).
       // "default" mode here means the agent is executing the plan, which produces
@@ -9346,6 +9365,7 @@ export default function ChatView({
     });
     if (transition.kind === "clear") {
       setQueuedSteerGate(null);
+      clearQueuedComposerSteerGate(threadId);
       return;
     }
     if (
@@ -9354,14 +9374,18 @@ export default function ChatView({
       transition.gate.armedActiveTurnId !== queuedSteerGate.armedActiveTurnId
     ) {
       setQueuedSteerGate(transition.gate);
+      armQueuedComposerSteerGate(threadId, transition.gate);
       return;
     }
     if (transition.expiresInMs === null) {
       return;
     }
-    const timer = window.setTimeout(() => setQueuedSteerGate(null), transition.expiresInMs);
+    const timer = window.setTimeout(() => {
+      setQueuedSteerGate(null);
+      clearQueuedComposerSteerGate(threadId);
+    }, transition.expiresInMs);
     return () => window.clearTimeout(timer);
-  }, [activeTurnIdForSteerGate, phase, queuedSteerGate, sessionErroredForSteerGate]);
+  }, [activeTurnIdForSteerGate, phase, queuedSteerGate, sessionErroredForSteerGate, threadId]);
 
   useEffect(() => {
     if (

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -167,9 +167,9 @@ import {
   claimQueuedComposerAutoDispatch,
   clearQueuedComposerSteerGate,
   getQueuedComposerSteerGate,
+  isQueuedComposerAwaitingTurnStart,
   releaseQueuedComposerAutoDispatch,
   runLockedQueuedComposerAutoDispatch,
-  shouldAutoDispatchQueuedComposerTurn,
   tryBeginQueuedComposerAutoDispatch,
 } from "../lib/queuedComposerDrain";
 import { extractChatAutomationInvocation } from "../lib/automationIntent";
@@ -9389,6 +9389,7 @@ export default function ChatView({
 
   useEffect(() => {
     if (
+      isQueuedComposerAwaitingTurnStart(threadId) ||
       resolveQueuedComposerAutoDispatchHold({
         localDispatch,
         phase,

--- a/apps/web/src/components/QueuedComposerDrainCoordinator.tsx
+++ b/apps/web/src/components/QueuedComposerDrainCoordinator.tsx
@@ -1,0 +1,27 @@
+// FILE: QueuedComposerDrainCoordinator.tsx
+// Purpose: Keep the headless queued-composer drain running for the app session
+//          so backgrounded threads dispatch when their live turn settles.
+// Layer: Web app shell
+
+import { useEffect } from "react";
+
+import { resolveAssistantDeliveryMode, useAppSettings } from "../appSettings";
+import {
+  setQueuedComposerDrainAssistantDeliveryMode,
+  startQueuedComposerDrainWatcher,
+} from "../lib/queuedComposerDrain";
+
+export function QueuedComposerDrainCoordinator() {
+  const { settings } = useAppSettings();
+  const assistantDeliveryMode = resolveAssistantDeliveryMode(settings);
+
+  useEffect(() => {
+    return startQueuedComposerDrainWatcher();
+  }, []);
+
+  useEffect(() => {
+    setQueuedComposerDrainAssistantDeliveryMode(assistantDeliveryMode);
+  }, [assistantDeliveryMode]);
+
+  return null;
+}

--- a/apps/web/src/lib/queuedComposerDispatch.test.ts
+++ b/apps/web/src/lib/queuedComposerDispatch.test.ts
@@ -1,0 +1,148 @@
+import { ThreadId } from "@synara/contracts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { QueuedComposerTurn } from "../composerDraftStore";
+import { resetComposerDraftStore } from "../composerDraftStoreTestFixtures";
+import { useStore } from "../store";
+import { initialState } from "../storeState";
+import { makeState, makeThread } from "../storeTestFixtures";
+import { dispatchQueuedComposerTurnHeadless } from "./queuedComposerDispatch";
+
+const nativeApiMocks = vi.hoisted(() => ({
+  dispatchCommand: vi.fn(async () => undefined),
+}));
+
+vi.mock("../nativeApi", () => ({
+  readNativeApi: () => ({
+    orchestration: {
+      dispatchCommand: nativeApiMocks.dispatchCommand,
+    },
+  }),
+}));
+
+const THREAD_ID = ThreadId.makeUnsafe("thread-1");
+
+function makeQueuedChatTurn(): QueuedComposerTurn {
+  return {
+    id: "queued-chat-1",
+    kind: "chat",
+    createdAt: "2026-03-13T12:00:00.000Z",
+    previewText: "follow up after the turn",
+    prompt: "follow up after the turn",
+    images: [],
+    files: [],
+    assistantSelections: [],
+    browserAnnotations: [],
+    terminalContexts: [],
+    fileComments: [],
+    pastedTexts: [],
+    skills: [],
+    mentions: [],
+    selectedProvider: "codex",
+    selectedModel: "gpt-5",
+    selectedPromptEffort: null,
+    modelSelection: {
+      provider: "codex",
+      model: "gpt-5",
+    },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    envMode: "local",
+  };
+}
+
+function makeQueuedPlanFollowUp(): QueuedComposerTurn {
+  return {
+    id: "queued-plan-1",
+    kind: "plan-follow-up",
+    createdAt: "2026-03-13T12:00:00.000Z",
+    previewText: "implement the plan",
+    text: "implement the plan",
+    interactionMode: "default",
+    selectedProvider: "codex",
+    selectedModel: "gpt-5",
+    selectedPromptEffort: null,
+    modelSelection: {
+      provider: "codex",
+      model: "gpt-5",
+    },
+    runtimeMode: "full-access",
+  };
+}
+
+describe("dispatchQueuedComposerTurnHeadless", () => {
+  beforeEach(() => {
+    resetComposerDraftStore();
+    useStore.setState(initialState);
+    nativeApiMocks.dispatchCommand.mockClear();
+    useStore.setState(makeState(makeThread({ id: THREAD_ID })));
+  });
+
+  afterEach(() => {
+    resetComposerDraftStore();
+    useStore.setState(initialState);
+  });
+
+  it("dispatches a snapshotted chat turn with dispatchMode queue", async () => {
+    const queuedTurn = makeQueuedChatTurn();
+    const succeeded = await dispatchQueuedComposerTurnHeadless({
+      threadId: THREAD_ID,
+      queuedTurn,
+      dispatchMode: "queue",
+      assistantDeliveryMode: "streaming",
+    });
+
+    expect(succeeded).toBe(true);
+    expect(nativeApiMocks.dispatchCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "thread.turn.start",
+        threadId: THREAD_ID,
+        dispatchMode: "queue",
+        interactionMode: "default",
+        runtimeMode: "full-access",
+        assistantDeliveryMode: "streaming",
+        message: expect.objectContaining({
+          role: "user",
+          text: "follow up after the turn",
+        }),
+      }),
+    );
+  });
+
+  it("dispatches a snapshotted plan follow-up as its own turn kind", async () => {
+    const succeeded = await dispatchQueuedComposerTurnHeadless({
+      threadId: THREAD_ID,
+      queuedTurn: makeQueuedPlanFollowUp(),
+      dispatchMode: "queue",
+      assistantDeliveryMode: "buffered",
+    });
+
+    expect(succeeded).toBe(true);
+    expect(nativeApiMocks.dispatchCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "thread.turn.start",
+        threadId: THREAD_ID,
+        dispatchMode: "queue",
+        interactionMode: "default",
+        assistantDeliveryMode: "buffered",
+        message: expect.objectContaining({
+          role: "user",
+          text: "implement the plan",
+          attachments: [],
+        }),
+      }),
+    );
+  });
+
+  it("returns false when the thread is not in the store", async () => {
+    useStore.setState(initialState);
+    const succeeded = await dispatchQueuedComposerTurnHeadless({
+      threadId: THREAD_ID,
+      queuedTurn: makeQueuedChatTurn(),
+      dispatchMode: "queue",
+      assistantDeliveryMode: "streaming",
+    });
+    expect(succeeded).toBe(false);
+    expect(nativeApiMocks.dispatchCommand).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/queuedComposerDispatch.ts
+++ b/apps/web/src/lib/queuedComposerDispatch.ts
@@ -1,0 +1,244 @@
+// FILE: queuedComposerDispatch.ts
+// Purpose: Dispatch a snapshotted QueuedComposerTurn against a thread without ChatView.
+// Layer: Web orchestration helper
+// Exports: dispatchQueuedComposerTurnHeadless
+
+import type { AssistantDeliveryMode, ThreadId } from "@synara/contracts";
+
+import { persistModelSelectionBeforeRuntimeMode } from "../components/ChatView.logic";
+import { useComposerDraftStore, type QueuedComposerTurn } from "../composerDraftStore";
+import { readNativeApi } from "../nativeApi";
+import { clearPendingTurnDispatch, markPendingTurnDispatch } from "../pendingTurnDispatch";
+import {
+  buildSourceProposedPlanReference,
+  findLatestProposedPlan,
+  hasActionableProposedPlan,
+} from "../session-logic";
+import { useStore } from "../store";
+import { getThreadFromState } from "../threadDerivation";
+import { appendAssistantSelectionsToPrompt } from "./assistantSelections";
+import { appendBrowserAnnotationsToPrompt } from "./browserAnnotations";
+import {
+  filterPromptProviderMentionReferences,
+  filterPromptSkillReferences,
+} from "./composerMentions";
+import { appendPastedTextsToPrompt, filterPastedTextsWithText } from "./composerPastedText";
+import { formatOutgoingComposerPrompt, stageUploadComposerAttachments } from "./composerSend";
+import { appendFileCommentsToPrompt } from "./fileComments";
+import {
+  appendTerminalContextsToPrompt,
+  filterTerminalContextsWithText,
+  IMAGE_ONLY_BOOTSTRAP_PROMPT,
+} from "./terminalContext";
+import { newCommandId, newMessageId } from "./utils";
+
+export async function dispatchQueuedComposerTurnHeadless(input: {
+  threadId: ThreadId;
+  queuedTurn: QueuedComposerTurn;
+  dispatchMode: "queue" | "steer";
+  assistantDeliveryMode: AssistantDeliveryMode;
+}): Promise<boolean> {
+  const api = readNativeApi();
+  if (!api) {
+    return false;
+  }
+
+  const thread = getThreadFromState(useStore.getState(), input.threadId);
+  if (!thread) {
+    return false;
+  }
+
+  const createdAt = new Date().toISOString();
+  const messageId = newMessageId();
+  const queuedTurn = input.queuedTurn;
+
+  if (queuedTurn.kind === "plan-follow-up") {
+    const trimmed = queuedTurn.text.trim();
+    if (!trimmed) {
+      return false;
+    }
+    const outgoingMessageText = formatOutgoingComposerPrompt({
+      provider: queuedTurn.selectedProvider,
+      model: queuedTurn.selectedModel,
+      effort: queuedTurn.selectedPromptEffort,
+      text: trimmed,
+    });
+    const latestProposedPlan = findLatestProposedPlan(
+      thread.proposedPlans,
+      thread.latestTurn?.turnId,
+    );
+    const sourceProposedPlan =
+      queuedTurn.interactionMode === "default"
+        ? buildSourceProposedPlanReference({
+            threadId: input.threadId,
+            proposedPlan: hasActionableProposedPlan(latestProposedPlan) ? latestProposedPlan : null,
+          })
+        : undefined;
+
+    markPendingTurnDispatch(input.threadId);
+    try {
+      await persistQueuedTurnThreadSettings({
+        api,
+        thread,
+        queuedTurn,
+        createdAt,
+      });
+      useComposerDraftStore
+        .getState()
+        .setInteractionMode(input.threadId, queuedTurn.interactionMode);
+      await api.orchestration.dispatchCommand({
+        type: "thread.turn.start",
+        commandId: newCommandId(),
+        threadId: input.threadId,
+        message: {
+          messageId,
+          role: "user",
+          text: outgoingMessageText,
+          attachments: [],
+        },
+        modelSelection: queuedTurn.modelSelection,
+        ...(queuedTurn.providerOptionsForDispatch
+          ? { providerOptions: queuedTurn.providerOptionsForDispatch }
+          : {}),
+        assistantDeliveryMode: input.assistantDeliveryMode,
+        dispatchMode: input.dispatchMode,
+        runtimeMode: queuedTurn.runtimeMode,
+        interactionMode: queuedTurn.interactionMode,
+        ...(sourceProposedPlan ? { sourceProposedPlan } : {}),
+        createdAt,
+      });
+      return true;
+    } catch {
+      clearPendingTurnDispatch(input.threadId);
+      return false;
+    }
+  }
+
+  const sendableTerminalContexts = filterTerminalContextsWithText(queuedTurn.terminalContexts);
+  const sendablePastedTexts = filterPastedTextsWithText(queuedTurn.pastedTexts);
+  const messageText = appendBrowserAnnotationsToPrompt(
+    appendPastedTextsToPrompt(
+      appendFileCommentsToPrompt(
+        appendTerminalContextsToPrompt(
+          appendAssistantSelectionsToPrompt(queuedTurn.prompt, queuedTurn.assistantSelections),
+          sendableTerminalContexts,
+        ),
+        queuedTurn.fileComments,
+      ),
+      sendablePastedTexts,
+    ),
+    queuedTurn.browserAnnotations,
+    messageId,
+  );
+  const outgoingTextSeed =
+    messageText || (queuedTurn.images.length > 0 ? IMAGE_ONLY_BOOTSTRAP_PROMPT : "");
+  if (!outgoingTextSeed.trim() && queuedTurn.images.length === 0) {
+    return false;
+  }
+  const outgoingMessageText = formatOutgoingComposerPrompt({
+    provider: queuedTurn.selectedProvider,
+    model: queuedTurn.selectedModel,
+    effort: queuedTurn.selectedPromptEffort,
+    text: outgoingTextSeed,
+  });
+  const mentionedSkills = filterPromptSkillReferences(
+    outgoingMessageText,
+    queuedTurn.skills,
+    queuedTurn.selectedProvider,
+  );
+  const mentionedMentions = filterPromptProviderMentionReferences(
+    outgoingMessageText,
+    queuedTurn.mentions,
+  );
+  const turnAttachmentsPromise = stageUploadComposerAttachments({
+    threadId: input.threadId,
+    images: queuedTurn.images,
+    files: queuedTurn.files,
+    assistantSelections: queuedTurn.assistantSelections,
+  });
+
+  markPendingTurnDispatch(input.threadId);
+  try {
+    await persistQueuedTurnThreadSettings({
+      api,
+      thread,
+      queuedTurn,
+      createdAt,
+    });
+    const stagedTurnAttachments = await turnAttachmentsPromise;
+    await stagedTurnAttachments.runWithDispatch((turnAttachments) =>
+      api.orchestration.dispatchCommand({
+        type: "thread.turn.start",
+        commandId: newCommandId(),
+        threadId: input.threadId,
+        message: {
+          messageId,
+          role: "user",
+          text: outgoingMessageText,
+          attachments: turnAttachments,
+          ...(mentionedSkills.length > 0 ? { skills: mentionedSkills } : {}),
+          ...(mentionedMentions.length > 0 ? { mentions: mentionedMentions } : {}),
+        },
+        modelSelection: queuedTurn.modelSelection,
+        ...(queuedTurn.providerOptionsForDispatch
+          ? { providerOptions: queuedTurn.providerOptionsForDispatch }
+          : {}),
+        assistantDeliveryMode: input.assistantDeliveryMode,
+        dispatchMode: input.dispatchMode,
+        runtimeMode: queuedTurn.runtimeMode,
+        interactionMode: queuedTurn.interactionMode,
+        ...(queuedTurn.sourceProposedPlan
+          ? { sourceProposedPlan: queuedTurn.sourceProposedPlan }
+          : {}),
+        createdAt,
+      }),
+    );
+    return true;
+  } catch {
+    await turnAttachmentsPromise.then(
+      (staged) => staged.cleanup(),
+      () => undefined,
+    );
+    clearPendingTurnDispatch(input.threadId);
+    return false;
+  }
+}
+
+async function persistQueuedTurnThreadSettings(input: {
+  api: NonNullable<ReturnType<typeof readNativeApi>>;
+  thread: NonNullable<ReturnType<typeof getThreadFromState>>;
+  queuedTurn: QueuedComposerTurn;
+  createdAt: string;
+}): Promise<void> {
+  await persistModelSelectionBeforeRuntimeMode({
+    currentModelSelection: input.thread.modelSelection,
+    nextModelSelection: input.queuedTurn.modelSelection,
+    currentRuntimeMode: input.thread.runtimeMode,
+    nextRuntimeMode: input.queuedTurn.runtimeMode,
+    persistModelSelection: (modelSelection) =>
+      input.api.orchestration.dispatchCommand({
+        type: "thread.meta.update",
+        commandId: newCommandId(),
+        threadId: input.thread.id,
+        modelSelection,
+      }),
+    persistRuntimeMode: (runtimeMode) =>
+      input.api.orchestration.dispatchCommand({
+        type: "thread.runtime-mode.set",
+        commandId: newCommandId(),
+        threadId: input.thread.id,
+        runtimeMode,
+        createdAt: input.createdAt,
+      }),
+  });
+
+  if (input.queuedTurn.interactionMode !== input.thread.interactionMode) {
+    await input.api.orchestration.dispatchCommand({
+      type: "thread.interaction-mode.set",
+      commandId: newCommandId(),
+      threadId: input.thread.id,
+      interactionMode: input.queuedTurn.interactionMode,
+      createdAt: input.createdAt,
+    });
+  }
+}

--- a/apps/web/src/lib/queuedComposerDrain.test.ts
+++ b/apps/web/src/lib/queuedComposerDrain.test.ts
@@ -11,10 +11,13 @@ import type { Thread, ThreadSession } from "../types";
 import {
   armQueuedComposerSteerGate,
   claimQueuedComposerAutoDispatch,
+  endQueuedComposerAutoDispatch,
+  getQueuedComposerSteerGate,
   releaseQueuedComposerAutoDispatch,
   resetQueuedComposerDrainForTests,
   shouldAutoDispatchQueuedComposerTurn,
   startQueuedComposerDrainWatcher,
+  tryBeginQueuedComposerAutoDispatch,
   type QueuedComposerAutoDispatchGates,
 } from "./queuedComposerDrain";
 
@@ -295,5 +298,104 @@ describe("queued composer drain watcher", () => {
 
     await flushDrain();
     expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("gives ChatView and the watcher one exclusive per-thread drain lock", () => {
+    expect(tryBeginQueuedComposerAutoDispatch(THREAD_ID)).toBe(true);
+    expect(tryBeginQueuedComposerAutoDispatch(THREAD_ID)).toBe(false);
+    endQueuedComposerAutoDispatch(THREAD_ID);
+    expect(tryBeginQueuedComposerAutoDispatch(THREAD_ID)).toBe(true);
+    endQueuedComposerAutoDispatch(THREAD_ID);
+  });
+
+  it("does not let ChatView send the same queue head the watcher already started", async () => {
+    let resolveDispatch: ((value: boolean) => void) | undefined;
+    dispatch.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveDispatch = resolve;
+        }),
+    );
+    seedThread(
+      makeThread({
+        id: THREAD_ID,
+        session: makeSession("ready"),
+      }),
+    );
+    useComposerDraftStore
+      .getState()
+      .enqueueQueuedTurn(THREAD_ID, makeQueuedChatTurn("queued-overlap-focus"));
+
+    await vi.waitFor(() => {
+      expect(dispatch).toHaveBeenCalledTimes(1);
+    });
+
+    claimQueuedComposerAutoDispatch(THREAD_ID);
+    expect(tryBeginQueuedComposerAutoDispatch(THREAD_ID)).toBe(false);
+
+    resolveDispatch?.(true);
+    await vi.waitFor(() => {
+      expect(
+        useComposerDraftStore.getState().draftsByThreadId[THREAD_ID]?.queuedTurns ?? [],
+      ).toEqual([]);
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let the watcher send a queue head ChatView already started after unmount", async () => {
+    seedThread(
+      makeThread({
+        id: THREAD_ID,
+        session: makeSession("ready"),
+      }),
+    );
+    claimQueuedComposerAutoDispatch(THREAD_ID);
+    useComposerDraftStore
+      .getState()
+      .enqueueQueuedTurn(THREAD_ID, makeQueuedChatTurn("queued-overlap-unmount"));
+    expect(tryBeginQueuedComposerAutoDispatch(THREAD_ID)).toBe(true);
+
+    releaseQueuedComposerAutoDispatch(THREAD_ID);
+    await flushDrain();
+    expect(dispatch).not.toHaveBeenCalled();
+
+    endQueuedComposerAutoDispatch(THREAD_ID);
+    await vi.waitFor(() => {
+      expect(dispatch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("restores the shared steer gate after ChatView unmounts and remounts during the interrupt gap", async () => {
+    seedThread(
+      makeThread({
+        id: THREAD_ID,
+        session: makeSession("ready"),
+      }),
+    );
+    const armedGate = {
+      sawInterruptGap: false,
+      gapStartedAt: null,
+      armedActiveTurnId: "turn-original",
+    };
+    armQueuedComposerSteerGate(THREAD_ID, armedGate);
+    useComposerDraftStore
+      .getState()
+      .enqueueQueuedTurn(THREAD_ID, makeQueuedChatTurn("queued-steer-remount"));
+
+    claimQueuedComposerAutoDispatch(THREAD_ID);
+    releaseQueuedComposerAutoDispatch(THREAD_ID);
+    await flushDrain();
+    expect(dispatch).not.toHaveBeenCalled();
+
+    const restoredGate = getQueuedComposerSteerGate(THREAD_ID);
+    expect(restoredGate).not.toBeNull();
+    claimQueuedComposerAutoDispatch(THREAD_ID);
+    expect(getQueuedComposerSteerGate(THREAD_ID)).toEqual(restoredGate);
+    expect(
+      shouldAutoDispatchQueuedComposerTurn({
+        ...OPEN_GATES,
+        steerGate: restoredGate,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/lib/queuedComposerDrain.test.ts
+++ b/apps/web/src/lib/queuedComposerDrain.test.ts
@@ -1,0 +1,299 @@
+import { ApprovalRequestId, ThreadId, TurnId } from "@synara/contracts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { QueuedComposerTurn } from "../composerDraftStore";
+import { useComposerDraftStore } from "../composerDraftStore";
+import { resetComposerDraftStore } from "../composerDraftStoreTestFixtures";
+import { useStore } from "../store";
+import { initialState } from "../storeState";
+import { makeActivity, makeState, makeThread } from "../storeTestFixtures";
+import type { Thread, ThreadSession } from "../types";
+import {
+  armQueuedComposerSteerGate,
+  claimQueuedComposerAutoDispatch,
+  releaseQueuedComposerAutoDispatch,
+  resetQueuedComposerDrainForTests,
+  shouldAutoDispatchQueuedComposerTurn,
+  startQueuedComposerDrainWatcher,
+  type QueuedComposerAutoDispatchGates,
+} from "./queuedComposerDrain";
+
+const THREAD_ID = ThreadId.makeUnsafe("thread-1");
+const LIVE_TURN_ID = TurnId.makeUnsafe("turn-live");
+
+const OPEN_GATES: QueuedComposerAutoDispatchGates = {
+  hasQueueableLiveTurn: false,
+  phase: "ready",
+  isSendBusy: false,
+  isConnecting: false,
+  steerGate: null,
+  hasPendingApproval: false,
+  hasPendingProgress: false,
+  pendingUserInputCount: 0,
+  queuedTurnCount: 1,
+};
+
+function makeQueuedChatTurn(id: string): QueuedComposerTurn {
+  return {
+    id,
+    kind: "chat",
+    createdAt: "2026-03-13T12:00:00.000Z",
+    previewText: `queued ${id}`,
+    prompt: `queued ${id}`,
+    images: [],
+    files: [],
+    assistantSelections: [],
+    browserAnnotations: [],
+    terminalContexts: [],
+    fileComments: [],
+    pastedTexts: [],
+    skills: [],
+    mentions: [],
+    selectedProvider: "codex",
+    selectedModel: "gpt-5",
+    selectedPromptEffort: null,
+    modelSelection: {
+      provider: "codex",
+      model: "gpt-5",
+    },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    envMode: "local",
+  };
+}
+
+function makeSession(status: ThreadSession["status"], activeTurnId?: TurnId): ThreadSession {
+  return {
+    provider: "codex",
+    status,
+    orchestrationStatus: status === "running" ? "running" : "ready",
+    createdAt: "2026-02-13T00:00:00.000Z",
+    updatedAt: "2026-02-13T00:00:00.000Z",
+    ...(activeTurnId ? { activeTurnId } : {}),
+  };
+}
+
+function seedThread(thread: Thread): void {
+  useStore.setState(makeState(thread));
+}
+
+async function flushDrain(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("shouldAutoDispatchQueuedComposerTurn", () => {
+  it("allows drain when the thread is idle with a queued turn", () => {
+    expect(shouldAutoDispatchQueuedComposerTurn(OPEN_GATES)).toBe(true);
+  });
+
+  it("blocks drain while a live turn still has an active turn id", () => {
+    expect(
+      shouldAutoDispatchQueuedComposerTurn({
+        ...OPEN_GATES,
+        hasQueueableLiveTurn: true,
+        phase: "running",
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks drain while disconnected, connecting, or send-busy", () => {
+    expect(shouldAutoDispatchQueuedComposerTurn({ ...OPEN_GATES, phase: "disconnected" })).toBe(
+      false,
+    );
+    expect(
+      shouldAutoDispatchQueuedComposerTurn({
+        ...OPEN_GATES,
+        phase: "connecting",
+        isConnecting: true,
+      }),
+    ).toBe(false);
+    expect(shouldAutoDispatchQueuedComposerTurn({ ...OPEN_GATES, isSendBusy: true })).toBe(false);
+  });
+
+  it("blocks drain while a steer gate, approval, or user input is outstanding", () => {
+    expect(
+      shouldAutoDispatchQueuedComposerTurn({
+        ...OPEN_GATES,
+        steerGate: {
+          sawInterruptGap: false,
+          gapStartedAt: null,
+          armedActiveTurnId: "turn-original",
+        },
+      }),
+    ).toBe(false);
+    expect(shouldAutoDispatchQueuedComposerTurn({ ...OPEN_GATES, hasPendingApproval: true })).toBe(
+      false,
+    );
+    expect(shouldAutoDispatchQueuedComposerTurn({ ...OPEN_GATES, hasPendingProgress: true })).toBe(
+      false,
+    );
+    expect(shouldAutoDispatchQueuedComposerTurn({ ...OPEN_GATES, pendingUserInputCount: 1 })).toBe(
+      false,
+    );
+  });
+
+  it("blocks drain when the queue is empty", () => {
+    expect(shouldAutoDispatchQueuedComposerTurn({ ...OPEN_GATES, queuedTurnCount: 0 })).toBe(false);
+  });
+});
+
+describe("queued composer drain watcher", () => {
+  const dispatch = vi.fn(async () => true);
+
+  beforeEach(() => {
+    resetQueuedComposerDrainForTests();
+    resetComposerDraftStore();
+    useStore.setState(initialState);
+    dispatch.mockReset();
+    dispatch.mockResolvedValue(true);
+    startQueuedComposerDrainWatcher({ dispatch });
+  });
+
+  afterEach(() => {
+    resetQueuedComposerDrainForTests();
+    resetComposerDraftStore();
+    useStore.setState(initialState);
+  });
+
+  it("drains a backgrounded thread when its live turn settles and ChatView is unmounted", async () => {
+    seedThread(
+      makeThread({
+        id: THREAD_ID,
+        session: makeSession("running", LIVE_TURN_ID),
+      }),
+    );
+    useComposerDraftStore.getState().enqueueQueuedTurn(THREAD_ID, makeQueuedChatTurn("queued-1"));
+
+    await flushDrain();
+    expect(dispatch).not.toHaveBeenCalled();
+
+    seedThread(
+      makeThread({
+        id: THREAD_ID,
+        session: makeSession("ready"),
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(dispatch).toHaveBeenCalledTimes(1);
+    });
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: THREAD_ID,
+        dispatchMode: "queue",
+        queuedTurn: expect.objectContaining({ id: "queued-1" }),
+      }),
+    );
+    expect(useComposerDraftStore.getState().draftsByThreadId[THREAD_ID]?.queuedTurns ?? []).toEqual(
+      [],
+    );
+  });
+
+  it("does not drain a claimed thread, then drains after ChatView unmounts", async () => {
+    seedThread(
+      makeThread({
+        id: THREAD_ID,
+        session: makeSession("ready"),
+      }),
+    );
+    claimQueuedComposerAutoDispatch(THREAD_ID);
+    useComposerDraftStore
+      .getState()
+      .enqueueQueuedTurn(THREAD_ID, makeQueuedChatTurn("queued-open"));
+
+    await flushDrain();
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(useComposerDraftStore.getState().draftsByThreadId[THREAD_ID]?.queuedTurns).toHaveLength(
+      1,
+    );
+
+    releaseQueuedComposerAutoDispatch(THREAD_ID);
+
+    await vi.waitFor(() => {
+      expect(dispatch).toHaveBeenCalledTimes(1);
+    });
+    expect(useComposerDraftStore.getState().draftsByThreadId[THREAD_ID]?.queuedTurns ?? []).toEqual(
+      [],
+    );
+  });
+
+  it("does not drain while a live turn still has an active turn id", async () => {
+    seedThread(
+      makeThread({
+        id: THREAD_ID,
+        session: makeSession("running", LIVE_TURN_ID),
+      }),
+    );
+    useComposerDraftStore
+      .getState()
+      .enqueueQueuedTurn(THREAD_ID, makeQueuedChatTurn("queued-live"));
+
+    await flushDrain();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("does not drain while an approval is pending", async () => {
+    seedThread(
+      makeThread({
+        id: THREAD_ID,
+        session: makeSession("ready"),
+        hasPendingApprovals: true,
+        activities: [
+          makeActivity({
+            id: "approval-requested",
+            kind: "approval.requested",
+            summary: "Command approval requested",
+            tone: "approval",
+            payload: {
+              requestId: "req-drain-approval",
+              lifecycleGeneration: "generation-drain",
+              requestKind: "command",
+            },
+          }),
+        ],
+        pendingInteractions: [
+          {
+            interactionKind: "approval",
+            requestId: ApprovalRequestId.makeUnsafe("req-drain-approval"),
+            threadId: THREAD_ID,
+            turnId: null,
+            lifecycleGeneration: "generation-drain",
+            status: "pending",
+            decision: null,
+            responseCommandId: null,
+            responseRequestedAt: null,
+            createdAt: "2026-02-13T00:00:01.000Z",
+            resolvedAt: null,
+          },
+        ],
+      }),
+    );
+    useComposerDraftStore
+      .getState()
+      .enqueueQueuedTurn(THREAD_ID, makeQueuedChatTurn("queued-approval"));
+
+    await flushDrain();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("does not drain while a steer gate is armed", async () => {
+    seedThread(
+      makeThread({
+        id: THREAD_ID,
+        session: makeSession("ready"),
+      }),
+    );
+    armQueuedComposerSteerGate(THREAD_ID, {
+      sawInterruptGap: false,
+      gapStartedAt: null,
+      armedActiveTurnId: "turn-original",
+    });
+    useComposerDraftStore
+      .getState()
+      .enqueueQueuedTurn(THREAD_ID, makeQueuedChatTurn("queued-steer"));
+
+    await flushDrain();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/queuedComposerDrain.test.ts
+++ b/apps/web/src/lib/queuedComposerDrain.test.ts
@@ -1,4 +1,4 @@
-import { ApprovalRequestId, ThreadId, TurnId } from "@synara/contracts";
+import { ApprovalRequestId, MessageId, ThreadId, TurnId } from "@synara/contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { QueuedComposerTurn } from "../composerDraftStore";
@@ -13,6 +13,7 @@ import {
   claimQueuedComposerAutoDispatch,
   endQueuedComposerAutoDispatch,
   getQueuedComposerSteerGate,
+  isQueuedComposerAwaitingTurnStart,
   releaseQueuedComposerAutoDispatch,
   resetQueuedComposerDrainForTests,
   shouldAutoDispatchQueuedComposerTurn,
@@ -29,6 +30,7 @@ const OPEN_GATES: QueuedComposerAutoDispatchGates = {
   phase: "ready",
   isSendBusy: false,
   isConnecting: false,
+  isAwaitingTurnStart: false,
   steerGate: null,
   hasPendingApproval: false,
   hasPendingProgress: false,
@@ -154,6 +156,7 @@ describe("queued composer drain watcher", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     resetQueuedComposerDrainForTests();
     resetComposerDraftStore();
     useStore.setState(initialState);
@@ -191,6 +194,119 @@ describe("queued composer drain watcher", () => {
     expect(useComposerDraftStore.getState().draftsByThreadId[THREAD_ID]?.queuedTurns ?? []).toEqual(
       [],
     );
+  });
+
+  it("waits for the dispatched background turn to start before sending the next item", async () => {
+    seedThread(
+      makeThread({
+        id: THREAD_ID,
+        session: makeSession("ready"),
+      }),
+    );
+    useComposerDraftStore.getState().enqueueQueuedTurn(THREAD_ID, makeQueuedChatTurn("queued-1"));
+    useComposerDraftStore.getState().enqueueQueuedTurn(THREAD_ID, makeQueuedChatTurn("queued-2"));
+
+    await vi.waitFor(() => {
+      expect(dispatch).toHaveBeenCalledTimes(1);
+    });
+    await flushDrain();
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(isQueuedComposerAwaitingTurnStart(THREAD_ID)).toBe(true);
+    expect(
+      useComposerDraftStore.getState().draftsByThreadId[THREAD_ID]?.queuedTurns.map(({ id }) => id),
+    ).toEqual(["queued-2"]);
+
+    seedThread(
+      makeThread({
+        id: THREAD_ID,
+        session: makeSession("running", LIVE_TURN_ID),
+      }),
+    );
+    await flushDrain();
+    expect(dispatch).toHaveBeenCalledTimes(1);
+
+    seedThread(
+      makeThread({
+        id: THREAD_ID,
+        session: makeSession("ready"),
+      }),
+    );
+    await vi.waitFor(() => {
+      expect(dispatch).toHaveBeenCalledTimes(2);
+    });
+    expect(dispatch.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({
+        queuedTurn: expect.objectContaining({ id: "queued-2" }),
+      }),
+    );
+  });
+
+  it("bounds retries when background dispatch keeps failing", async () => {
+    vi.useFakeTimers();
+    dispatch.mockResolvedValue(false);
+    seedThread(
+      makeThread({
+        id: THREAD_ID,
+        session: makeSession("ready"),
+      }),
+    );
+    useComposerDraftStore
+      .getState()
+      .enqueueQueuedTurn(THREAD_ID, makeQueuedChatTurn("queued-failing"));
+
+    await flushDrain();
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    await flushDrain();
+    expect(dispatch).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(dispatch).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(dispatch).toHaveBeenCalledTimes(4);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await flushDrain();
+    expect(dispatch).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not schedule drain work for unrelated streaming message updates", async () => {
+    resetQueuedComposerDrainForTests();
+    const now = vi.fn(() => Date.now());
+    startQueuedComposerDrainWatcher({ dispatch, now });
+    const streamingMessage = {
+      id: MessageId.makeUnsafe("assistant-streaming"),
+      role: "assistant" as const,
+      text: "first chunk",
+      createdAt: "2026-02-13T00:00:01.000Z",
+      streaming: true,
+    };
+    seedThread(
+      makeThread({
+        id: THREAD_ID,
+        session: makeSession("running", LIVE_TURN_ID),
+        messages: [streamingMessage],
+      }),
+    );
+    useComposerDraftStore
+      .getState()
+      .enqueueQueuedTurn(THREAD_ID, makeQueuedChatTurn("queued-streaming"));
+    await flushDrain();
+    expect(dispatch).not.toHaveBeenCalled();
+    now.mockClear();
+
+    seedThread(
+      makeThread({
+        id: THREAD_ID,
+        session: makeSession("running", LIVE_TURN_ID),
+        messages: [{ ...streamingMessage, text: "first chunk, second chunk" }],
+      }),
+    );
+    await flushDrain();
+
+    expect(now).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
   });
 
   it("does not drain a claimed thread, then drains after ChatView unmounts", async () => {

--- a/apps/web/src/lib/queuedComposerDrain.ts
+++ b/apps/web/src/lib/queuedComposerDrain.ts
@@ -1,0 +1,299 @@
+// FILE: queuedComposerDrain.ts
+// Purpose: Auto-dispatch composer queued turns for every thread, including ones
+//          whose ChatView is unmounted, using the same gates as the open chat.
+// Layer: Web subscription utility
+// Exports: drain gates, steer-gate sharing, ChatView claim/release, watcher start
+
+import type { AssistantDeliveryMode, ThreadId } from "@synara/contracts";
+
+import {
+  type QueuedSteerGate,
+  resolveQueuedSteerGateTransition,
+} from "../components/ChatView.logic";
+import { useComposerDraftStore, type QueuedComposerTurn } from "../composerDraftStore";
+import { derivePendingApprovals, derivePendingUserInputs, derivePhase } from "../session-logic";
+import { useStore } from "../store";
+import { getThreadFromState } from "../threadDerivation";
+import type { SessionPhase } from "../types";
+import { dispatchQueuedComposerTurnHeadless } from "./queuedComposerDispatch";
+
+export interface QueuedComposerAutoDispatchGates {
+  hasQueueableLiveTurn: boolean;
+  phase: SessionPhase;
+  isSendBusy: boolean;
+  isConnecting: boolean;
+  steerGate: QueuedSteerGate | null;
+  hasPendingApproval: boolean;
+  hasPendingProgress: boolean;
+  pendingUserInputCount: number;
+  queuedTurnCount: number;
+}
+
+export function shouldAutoDispatchQueuedComposerTurn(
+  gates: QueuedComposerAutoDispatchGates,
+): boolean {
+  return !(
+    gates.hasQueueableLiveTurn ||
+    gates.phase === "disconnected" ||
+    gates.isSendBusy ||
+    gates.isConnecting ||
+    gates.steerGate !== null ||
+    gates.hasPendingApproval ||
+    gates.hasPendingProgress ||
+    gates.pendingUserInputCount > 0 ||
+    gates.queuedTurnCount === 0
+  );
+}
+
+type QueuedComposerDispatchFn = (input: {
+  threadId: ThreadId;
+  queuedTurn: QueuedComposerTurn;
+  dispatchMode: "queue" | "steer";
+  assistantDeliveryMode: AssistantDeliveryMode;
+}) => Promise<boolean>;
+
+const claimedThreadIds = new Set<ThreadId>();
+const inFlightThreadIds = new Set<ThreadId>();
+const steerGatesByThreadId = new Map<ThreadId, QueuedSteerGate>();
+
+let drainStartCount = 0;
+let stopDrainSubscriptions: (() => void) | null = null;
+let tickScheduled = false;
+let steerExpiryTimer: ReturnType<typeof setTimeout> | null = null;
+let assistantDeliveryMode: AssistantDeliveryMode = "streaming";
+let dispatchQueuedTurn: QueuedComposerDispatchFn = dispatchQueuedComposerTurnHeadless;
+let nowMs: () => number = () => Date.now();
+
+export function armQueuedComposerSteerGate(threadId: ThreadId, gate: QueuedSteerGate): void {
+  steerGatesByThreadId.set(threadId, gate);
+  requestQueuedComposerDrainPass();
+}
+
+export function clearQueuedComposerSteerGate(threadId: ThreadId): void {
+  if (!steerGatesByThreadId.delete(threadId)) {
+    return;
+  }
+  requestQueuedComposerDrainPass();
+}
+
+function getQueuedComposerSteerGate(threadId: ThreadId): QueuedSteerGate | null {
+  return steerGatesByThreadId.get(threadId) ?? null;
+}
+
+export function claimQueuedComposerAutoDispatch(threadId: ThreadId): void {
+  claimedThreadIds.add(threadId);
+}
+
+export function releaseQueuedComposerAutoDispatch(threadId: ThreadId): void {
+  claimedThreadIds.delete(threadId);
+  requestQueuedComposerDrainPass();
+}
+
+export function setQueuedComposerDrainAssistantDeliveryMode(nextMode: AssistantDeliveryMode): void {
+  assistantDeliveryMode = nextMode;
+}
+
+export function startQueuedComposerDrainWatcher(options?: {
+  dispatch?: QueuedComposerDispatchFn;
+  now?: () => number;
+  assistantDeliveryMode?: AssistantDeliveryMode;
+}): () => void {
+  drainStartCount += 1;
+  if (options?.dispatch) {
+    dispatchQueuedTurn = options.dispatch;
+  }
+  if (options?.now) {
+    nowMs = options.now;
+  }
+  if (options?.assistantDeliveryMode) {
+    assistantDeliveryMode = options.assistantDeliveryMode;
+  }
+  if (drainStartCount === 1) {
+    const unsubscribeDrafts = useComposerDraftStore.subscribe(() => {
+      requestQueuedComposerDrainPass();
+    });
+    const unsubscribeStore = useStore.subscribe(() => {
+      requestQueuedComposerDrainPass();
+    });
+    stopDrainSubscriptions = () => {
+      unsubscribeDrafts();
+      unsubscribeStore();
+    };
+    requestQueuedComposerDrainPass();
+  }
+  return () => {
+    drainStartCount = Math.max(0, drainStartCount - 1);
+    if (drainStartCount > 0) {
+      return;
+    }
+    stopDrainSubscriptions?.();
+    stopDrainSubscriptions = null;
+    if (steerExpiryTimer !== null) {
+      clearTimeout(steerExpiryTimer);
+      steerExpiryTimer = null;
+    }
+    tickScheduled = false;
+    dispatchQueuedTurn = dispatchQueuedComposerTurnHeadless;
+    nowMs = () => Date.now();
+  };
+}
+
+function requestQueuedComposerDrainPass(): void {
+  if (tickScheduled) {
+    return;
+  }
+  tickScheduled = true;
+  queueMicrotask(() => {
+    tickScheduled = false;
+    void runQueuedComposerDrainPass();
+  });
+}
+
+export function resetQueuedComposerDrainForTests(): void {
+  claimedThreadIds.clear();
+  inFlightThreadIds.clear();
+  steerGatesByThreadId.clear();
+  drainStartCount = 0;
+  stopDrainSubscriptions?.();
+  stopDrainSubscriptions = null;
+  if (steerExpiryTimer !== null) {
+    clearTimeout(steerExpiryTimer);
+    steerExpiryTimer = null;
+  }
+  tickScheduled = false;
+  assistantDeliveryMode = "streaming";
+  dispatchQueuedTurn = dispatchQueuedComposerTurnHeadless;
+  nowMs = () => Date.now();
+}
+
+function collectThreadIdsWithQueuedTurns(): ThreadId[] {
+  const drafts = useComposerDraftStore.getState().draftsByThreadId;
+  const threadIds: ThreadId[] = [];
+  for (const [threadId, draft] of Object.entries(drafts)) {
+    if (draft.queuedTurns.length > 0) {
+      threadIds.push(threadId as ThreadId);
+    }
+  }
+  return threadIds;
+}
+
+function readQueuedComposerAutoDispatchGates(threadId: ThreadId): QueuedComposerAutoDispatchGates {
+  const draft = useComposerDraftStore.getState().draftsByThreadId[threadId];
+  const thread = getThreadFromState(useStore.getState(), threadId);
+  const phase = derivePhase(thread?.session ?? null);
+  const hasLiveTurn = phase === "running";
+  const pendingApprovals = derivePendingApprovals(
+    thread?.activities ?? [],
+    thread?.pendingInteractions,
+    {
+      authoritativeHasPending: thread?.hasPendingApprovals,
+      latestTurnId: thread?.latestTurn?.turnId,
+    },
+  );
+  const pendingUserInputs = derivePendingUserInputs(
+    thread?.activities ?? [],
+    thread?.pendingInteractions,
+    {
+      authoritativeHasPending: thread?.hasPendingUserInput,
+      latestTurnId: thread?.latestTurn?.turnId,
+    },
+  );
+  return {
+    hasQueueableLiveTurn: hasLiveTurn && thread?.session?.activeTurnId != null,
+    phase,
+    isSendBusy: false,
+    isConnecting: phase === "connecting",
+    steerGate: getQueuedComposerSteerGate(threadId),
+    hasPendingApproval: pendingApprovals.length > 0,
+    hasPendingProgress: pendingUserInputs.length > 0,
+    pendingUserInputCount: pendingUserInputs.length,
+    queuedTurnCount: draft?.queuedTurns.length ?? 0,
+  };
+}
+
+function advanceSteerGates(): number | null {
+  let earliestExpiryMs: number | null = null;
+  const now = nowMs();
+  for (const [threadId, gate] of [...steerGatesByThreadId.entries()]) {
+    const thread = getThreadFromState(useStore.getState(), threadId);
+    const transition = resolveQueuedSteerGateTransition({
+      gate,
+      phase: derivePhase(thread?.session ?? null),
+      sessionErrored: thread?.session?.status === "error",
+      activeTurnId: thread?.session?.activeTurnId ?? null,
+      now,
+    });
+    if (transition.kind === "clear") {
+      steerGatesByThreadId.delete(threadId);
+      continue;
+    }
+    const nextGate = transition.gate;
+    if (
+      nextGate.sawInterruptGap !== gate.sawInterruptGap ||
+      nextGate.gapStartedAt !== gate.gapStartedAt ||
+      nextGate.armedActiveTurnId !== gate.armedActiveTurnId
+    ) {
+      steerGatesByThreadId.set(threadId, nextGate);
+    }
+    if (transition.expiresInMs !== null) {
+      earliestExpiryMs =
+        earliestExpiryMs === null
+          ? transition.expiresInMs
+          : Math.min(earliestExpiryMs, transition.expiresInMs);
+    }
+  }
+  return earliestExpiryMs;
+}
+
+function runQueuedComposerDrainPass(): void {
+  const steerExpiryMs = advanceSteerGates();
+  if (steerExpiryTimer !== null) {
+    clearTimeout(steerExpiryTimer);
+    steerExpiryTimer = null;
+  }
+  if (steerExpiryMs !== null) {
+    steerExpiryTimer = setTimeout(
+      () => {
+        steerExpiryTimer = null;
+        requestQueuedComposerDrainPass();
+      },
+      Math.max(0, steerExpiryMs),
+    );
+  }
+
+  const threadIds = collectThreadIdsWithQueuedTurns();
+  for (const threadId of threadIds) {
+    if (claimedThreadIds.has(threadId) || inFlightThreadIds.has(threadId)) {
+      continue;
+    }
+    const draft = useComposerDraftStore.getState().draftsByThreadId[threadId];
+    const nextQueuedTurn = draft?.queuedTurns[0];
+    if (!nextQueuedTurn) {
+      continue;
+    }
+    const gates = readQueuedComposerAutoDispatchGates(threadId);
+    if (!shouldAutoDispatchQueuedComposerTurn(gates)) {
+      continue;
+    }
+    inFlightThreadIds.add(threadId);
+    void (async () => {
+      let succeeded = false;
+      try {
+        succeeded = await dispatchQueuedTurn({
+          threadId,
+          queuedTurn: nextQueuedTurn,
+          dispatchMode: "queue",
+          assistantDeliveryMode,
+        });
+        if (succeeded) {
+          useComposerDraftStore.getState().removeQueuedTurn(threadId, nextQueuedTurn.id);
+        }
+      } finally {
+        inFlightThreadIds.delete(threadId);
+      }
+      if (succeeded) {
+        requestQueuedComposerDrainPass();
+      }
+    })();
+  }
+}

--- a/apps/web/src/lib/queuedComposerDrain.ts
+++ b/apps/web/src/lib/queuedComposerDrain.ts
@@ -466,13 +466,9 @@ function scheduleQueuedComposerDrainWake(expiresInMs: number | null): void {
   );
 }
 
-function recordQueuedComposerDispatchFailure(
-  threadId: ThreadId,
-  queuedTurnId: string,
-): void {
+function recordQueuedComposerDispatchFailure(threadId: ThreadId, queuedTurnId: string): void {
   const previous = retryStateByThreadId.get(threadId);
-  const failureCount =
-    previous?.queuedTurnId === queuedTurnId ? previous.failureCount + 1 : 1;
+  const failureCount = previous?.queuedTurnId === queuedTurnId ? previous.failureCount + 1 : 1;
   const retryDelay = QUEUED_COMPOSER_RETRY_DELAYS_MS[failureCount - 1];
   retryStateByThreadId.set(threadId, {
     queuedTurnId,

--- a/apps/web/src/lib/queuedComposerDrain.ts
+++ b/apps/web/src/lib/queuedComposerDrain.ts
@@ -2,7 +2,8 @@
 // Purpose: Auto-dispatch composer queued turns for every thread, including ones
 //          whose ChatView is unmounted, using the same gates as the open chat.
 // Layer: Web subscription utility
-// Exports: drain gates, steer-gate sharing, ChatView claim/release, watcher start
+// Exports: drain gates, exclusive per-thread send lock, steer-gate sharing,
+//          ChatView claim/release, watcher start
 
 import type { AssistantDeliveryMode, ThreadId } from "@synara/contracts";
 
@@ -53,7 +54,7 @@ type QueuedComposerDispatchFn = (input: {
 }) => Promise<boolean>;
 
 const claimedThreadIds = new Set<ThreadId>();
-const inFlightThreadIds = new Set<ThreadId>();
+const autoDispatchLocks = new Set<ThreadId>();
 const steerGatesByThreadId = new Map<ThreadId, QueuedSteerGate>();
 
 let drainStartCount = 0;
@@ -76,8 +77,23 @@ export function clearQueuedComposerSteerGate(threadId: ThreadId): void {
   requestQueuedComposerDrainPass();
 }
 
-function getQueuedComposerSteerGate(threadId: ThreadId): QueuedSteerGate | null {
+export function getQueuedComposerSteerGate(threadId: ThreadId): QueuedSteerGate | null {
   return steerGatesByThreadId.get(threadId) ?? null;
+}
+
+export function tryBeginQueuedComposerAutoDispatch(threadId: ThreadId): boolean {
+  if (autoDispatchLocks.has(threadId)) {
+    return false;
+  }
+  autoDispatchLocks.add(threadId);
+  return true;
+}
+
+export function endQueuedComposerAutoDispatch(threadId: ThreadId): void {
+  if (!autoDispatchLocks.delete(threadId)) {
+    return;
+  }
+  requestQueuedComposerDrainPass();
 }
 
 export function claimQueuedComposerAutoDispatch(threadId: ThreadId): void {
@@ -151,7 +167,7 @@ function requestQueuedComposerDrainPass(): void {
 
 export function resetQueuedComposerDrainForTests(): void {
   claimedThreadIds.clear();
-  inFlightThreadIds.clear();
+  autoDispatchLocks.clear();
   steerGatesByThreadId.clear();
   drainStartCount = 0;
   stopDrainSubscriptions?.();
@@ -263,7 +279,7 @@ function runQueuedComposerDrainPass(): void {
 
   const threadIds = collectThreadIdsWithQueuedTurns();
   for (const threadId of threadIds) {
-    if (claimedThreadIds.has(threadId) || inFlightThreadIds.has(threadId)) {
+    if (claimedThreadIds.has(threadId)) {
       continue;
     }
     const draft = useComposerDraftStore.getState().draftsByThreadId[threadId];
@@ -275,11 +291,12 @@ function runQueuedComposerDrainPass(): void {
     if (!shouldAutoDispatchQueuedComposerTurn(gates)) {
       continue;
     }
-    inFlightThreadIds.add(threadId);
+    if (!tryBeginQueuedComposerAutoDispatch(threadId)) {
+      continue;
+    }
     void (async () => {
-      let succeeded = false;
       try {
-        succeeded = await dispatchQueuedTurn({
+        const succeeded = await dispatchQueuedTurn({
           threadId,
           queuedTurn: nextQueuedTurn,
           dispatchMode: "queue",
@@ -289,10 +306,7 @@ function runQueuedComposerDrainPass(): void {
           useComposerDraftStore.getState().removeQueuedTurn(threadId, nextQueuedTurn.id);
         }
       } finally {
-        inFlightThreadIds.delete(threadId);
-      }
-      if (succeeded) {
-        requestQueuedComposerDrainPass();
+        endQueuedComposerAutoDispatch(threadId);
       }
     })();
   }

--- a/apps/web/src/lib/queuedComposerDrain.ts
+++ b/apps/web/src/lib/queuedComposerDrain.ts
@@ -8,12 +8,16 @@
 import type { AssistantDeliveryMode, ThreadId } from "@synara/contracts";
 
 import {
+  createLocalDispatchSnapshot,
+  hasLiveTurnTakenOver,
+  LOCAL_DISPATCH_TURN_TAKEOVER_TIMEOUT_MS,
+  type LocalDispatchSnapshot,
   type QueuedSteerGate,
   resolveQueuedSteerGateTransition,
 } from "../components/ChatView.logic";
 import { useComposerDraftStore, type QueuedComposerTurn } from "../composerDraftStore";
 import { derivePendingApprovals, derivePendingUserInputs, derivePhase } from "../session-logic";
-import { useStore } from "../store";
+import { useStore, type AppState } from "../store";
 import { getThreadFromState } from "../threadDerivation";
 import type { SessionPhase } from "../types";
 import { dispatchQueuedComposerTurnHeadless } from "./queuedComposerDispatch";
@@ -23,6 +27,7 @@ export interface QueuedComposerAutoDispatchGates {
   phase: SessionPhase;
   isSendBusy: boolean;
   isConnecting: boolean;
+  isAwaitingTurnStart: boolean;
   steerGate: QueuedSteerGate | null;
   hasPendingApproval: boolean;
   hasPendingProgress: boolean;
@@ -38,6 +43,7 @@ export function shouldAutoDispatchQueuedComposerTurn(
     gates.phase === "disconnected" ||
     gates.isSendBusy ||
     gates.isConnecting ||
+    gates.isAwaitingTurnStart ||
     gates.steerGate !== null ||
     gates.hasPendingApproval ||
     gates.hasPendingProgress ||
@@ -56,11 +62,24 @@ type QueuedComposerDispatchFn = (input: {
 const claimedThreadIds = new Set<ThreadId>();
 const autoDispatchLocks = new Set<ThreadId>();
 const steerGatesByThreadId = new Map<ThreadId, QueuedSteerGate>();
+const awaitingTurnStartsByThreadId = new Map<ThreadId, LocalDispatchSnapshot>();
+
+interface QueuedComposerRetryState {
+  readonly queuedTurnId: string;
+  readonly failureCount: number;
+  readonly retryAt: number | null;
+}
+
+// Three delayed retries cover transient RPC failures without turning a
+// persistent failure into an endless timer loop. Once exhausted, a queue-head
+// or relevant thread-state change gives the item a fresh budget.
+const QUEUED_COMPOSER_RETRY_DELAYS_MS = [1_000, 5_000, 15_000] as const;
+const retryStateByThreadId = new Map<ThreadId, QueuedComposerRetryState>();
 
 let drainStartCount = 0;
 let stopDrainSubscriptions: (() => void) | null = null;
 let tickScheduled = false;
-let steerExpiryTimer: ReturnType<typeof setTimeout> | null = null;
+let drainWakeTimer: ReturnType<typeof setTimeout> | null = null;
 let assistantDeliveryMode: AssistantDeliveryMode = "streaming";
 let dispatchQueuedTurn: QueuedComposerDispatchFn = dispatchQueuedComposerTurnHeadless;
 let nowMs: () => number = () => Date.now();
@@ -79,6 +98,10 @@ export function clearQueuedComposerSteerGate(threadId: ThreadId): void {
 
 export function getQueuedComposerSteerGate(threadId: ThreadId): QueuedSteerGate | null {
   return steerGatesByThreadId.get(threadId) ?? null;
+}
+
+export function isQueuedComposerAwaitingTurnStart(threadId: ThreadId): boolean {
+  return awaitingTurnStartsByThreadId.has(threadId);
 }
 
 export function tryBeginQueuedComposerAutoDispatch(threadId: ThreadId): boolean {
@@ -140,10 +163,18 @@ export function startQueuedComposerDrainWatcher(options?: {
     assistantDeliveryMode = options.assistantDeliveryMode;
   }
   if (drainStartCount === 1) {
-    const unsubscribeDrafts = useComposerDraftStore.subscribe(() => {
+    const unsubscribeDrafts = useComposerDraftStore.subscribe((current, previous) => {
+      if (!haveQueuedTurnsChanged(current.draftsByThreadId, previous.draftsByThreadId)) {
+        return;
+      }
+      resetRetriesForChangedQueueHeads(current.draftsByThreadId);
       requestQueuedComposerDrainPass();
     });
-    const unsubscribeStore = useStore.subscribe(() => {
+    const unsubscribeStore = useStore.subscribe((current, previous) => {
+      if (!hasRelevantThreadStateChanged(current, previous)) {
+        return;
+      }
+      resetRetriesForRelevantThreadChanges(current, previous);
       requestQueuedComposerDrainPass();
     });
     stopDrainSubscriptions = () => {
@@ -159,9 +190,9 @@ export function startQueuedComposerDrainWatcher(options?: {
     }
     stopDrainSubscriptions?.();
     stopDrainSubscriptions = null;
-    if (steerExpiryTimer !== null) {
-      clearTimeout(steerExpiryTimer);
-      steerExpiryTimer = null;
+    if (drainWakeTimer !== null) {
+      clearTimeout(drainWakeTimer);
+      drainWakeTimer = null;
     }
     tickScheduled = false;
     dispatchQueuedTurn = dispatchQueuedComposerTurnHeadless;
@@ -170,7 +201,7 @@ export function startQueuedComposerDrainWatcher(options?: {
 }
 
 function requestQueuedComposerDrainPass(): void {
-  if (tickScheduled) {
+  if (tickScheduled || !hasQueuedComposerDrainWork()) {
     return;
   }
   tickScheduled = true;
@@ -184,12 +215,14 @@ export function resetQueuedComposerDrainForTests(): void {
   claimedThreadIds.clear();
   autoDispatchLocks.clear();
   steerGatesByThreadId.clear();
+  awaitingTurnStartsByThreadId.clear();
+  retryStateByThreadId.clear();
   drainStartCount = 0;
   stopDrainSubscriptions?.();
   stopDrainSubscriptions = null;
-  if (steerExpiryTimer !== null) {
-    clearTimeout(steerExpiryTimer);
-    steerExpiryTimer = null;
+  if (drainWakeTimer !== null) {
+    clearTimeout(drainWakeTimer);
+    drainWakeTimer = null;
   }
   tickScheduled = false;
   assistantDeliveryMode = "streaming";
@@ -206,6 +239,97 @@ function collectThreadIdsWithQueuedTurns(): ThreadId[] {
     }
   }
   return threadIds;
+}
+
+function hasQueuedComposerDrainWork(): boolean {
+  return (
+    collectThreadIdsWithQueuedTurns().length > 0 ||
+    steerGatesByThreadId.size > 0 ||
+    awaitingTurnStartsByThreadId.size > 0
+  );
+}
+
+function haveQueuedTurnsChanged(
+  current: ReturnType<typeof useComposerDraftStore.getState>["draftsByThreadId"],
+  previous: ReturnType<typeof useComposerDraftStore.getState>["draftsByThreadId"],
+): boolean {
+  const threadIds = new Set([...Object.keys(current), ...Object.keys(previous)]);
+  for (const threadId of threadIds) {
+    if (current[threadId]?.queuedTurns !== previous[threadId]?.queuedTurns) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function resetRetriesForChangedQueueHeads(
+  draftsByThreadId: ReturnType<typeof useComposerDraftStore.getState>["draftsByThreadId"],
+): void {
+  for (const [threadId, retryState] of retryStateByThreadId) {
+    const queuedTurnId = draftsByThreadId[threadId]?.queuedTurns[0]?.id;
+    if (queuedTurnId !== retryState.queuedTurnId) {
+      retryStateByThreadId.delete(threadId);
+    }
+  }
+}
+
+function collectTrackedThreadIds(): Set<ThreadId> {
+  return new Set([
+    ...collectThreadIdsWithQueuedTurns(),
+    ...steerGatesByThreadId.keys(),
+    ...awaitingTurnStartsByThreadId.keys(),
+  ]);
+}
+
+function threadDrainSignal(state: AppState, threadId: ThreadId): string {
+  const thread = getThreadFromState(state, threadId);
+  if (!thread) {
+    return "missing";
+  }
+  const pendingApprovalCount = derivePendingApprovals(
+    thread.activities,
+    thread.pendingInteractions,
+    {
+      authoritativeHasPending: thread.hasPendingApprovals,
+      latestTurnId: thread.latestTurn?.turnId,
+    },
+  ).length;
+  const pendingUserInputCount = derivePendingUserInputs(
+    thread.activities,
+    thread.pendingInteractions,
+    {
+      authoritativeHasPending: thread.hasPendingUserInput,
+      latestTurnId: thread.latestTurn?.turnId,
+    },
+  ).length;
+  return [
+    thread.session?.status ?? "",
+    thread.session?.orchestrationStatus ?? "",
+    thread.session?.activeTurnId ?? "",
+    thread.latestTurn?.turnId ?? "",
+    thread.latestTurn?.startedAt ?? "",
+    thread.latestTurn?.completedAt ?? "",
+    thread.error ?? "",
+    pendingApprovalCount,
+    pendingUserInputCount,
+  ].join("|");
+}
+
+function hasRelevantThreadStateChanged(current: AppState, previous: AppState): boolean {
+  for (const threadId of collectTrackedThreadIds()) {
+    if (threadDrainSignal(current, threadId) !== threadDrainSignal(previous, threadId)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function resetRetriesForRelevantThreadChanges(current: AppState, previous: AppState): void {
+  for (const threadId of retryStateByThreadId.keys()) {
+    if (threadDrainSignal(current, threadId) !== threadDrainSignal(previous, threadId)) {
+      retryStateByThreadId.delete(threadId);
+    }
+  }
 }
 
 function readQueuedComposerAutoDispatchGates(threadId: ThreadId): QueuedComposerAutoDispatchGates {
@@ -232,14 +356,63 @@ function readQueuedComposerAutoDispatchGates(threadId: ThreadId): QueuedComposer
   return {
     hasQueueableLiveTurn: hasLiveTurn && thread?.session?.activeTurnId != null,
     phase,
-    isSendBusy: false,
+    isSendBusy: autoDispatchLocks.has(threadId),
     isConnecting: phase === "connecting",
+    isAwaitingTurnStart: awaitingTurnStartsByThreadId.has(threadId),
     steerGate: getQueuedComposerSteerGate(threadId),
     hasPendingApproval: pendingApprovals.length > 0,
     hasPendingProgress: pendingUserInputs.length > 0,
     pendingUserInputCount: pendingUserInputs.length,
     queuedTurnCount: draft?.queuedTurns.length ?? 0,
   };
+}
+
+function advanceAwaitingTurnStarts(): number | null {
+  let earliestExpiryMs: number | null = null;
+  const now = nowMs();
+  for (const [threadId, localDispatch] of awaitingTurnStartsByThreadId) {
+    const thread = getThreadFromState(useStore.getState(), threadId);
+    const pendingApprovals = derivePendingApprovals(
+      thread?.activities ?? [],
+      thread?.pendingInteractions,
+      {
+        authoritativeHasPending: thread?.hasPendingApprovals,
+        latestTurnId: thread?.latestTurn?.turnId,
+      },
+    );
+    const pendingUserInputs = derivePendingUserInputs(
+      thread?.activities ?? [],
+      thread?.pendingInteractions,
+      {
+        authoritativeHasPending: thread?.hasPendingUserInput,
+        latestTurnId: thread?.latestTurn?.turnId,
+      },
+    );
+    if (
+      hasLiveTurnTakenOver({
+        localDispatch,
+        phase: derivePhase(thread?.session ?? null),
+        latestTurn: thread?.latestTurn ?? null,
+        session: thread?.session ?? null,
+        hasPendingApproval: pendingApprovals.length > 0,
+        hasPendingUserInput: pendingUserInputs.length > 0,
+        threadError: thread?.error,
+        now,
+      })
+    ) {
+      awaitingTurnStartsByThreadId.delete(threadId);
+      continue;
+    }
+    const startedAtMs = Date.parse(localDispatch.startedAt);
+    if (!Number.isFinite(startedAtMs)) {
+      awaitingTurnStartsByThreadId.delete(threadId);
+      continue;
+    }
+    const expiresInMs = LOCAL_DISPATCH_TURN_TAKEOVER_TIMEOUT_MS - (now - startedAtMs);
+    earliestExpiryMs =
+      earliestExpiryMs === null ? expiresInMs : Math.min(earliestExpiryMs, expiresInMs);
+  }
+  return earliestExpiryMs;
 }
 
 function advanceSteerGates(): number | null {
@@ -276,21 +449,58 @@ function advanceSteerGates(): number | null {
   return earliestExpiryMs;
 }
 
+function scheduleQueuedComposerDrainWake(expiresInMs: number | null): void {
+  if (drainWakeTimer !== null) {
+    clearTimeout(drainWakeTimer);
+    drainWakeTimer = null;
+  }
+  if (expiresInMs === null) {
+    return;
+  }
+  drainWakeTimer = setTimeout(
+    () => {
+      drainWakeTimer = null;
+      requestQueuedComposerDrainPass();
+    },
+    Math.max(0, expiresInMs),
+  );
+}
+
+function recordQueuedComposerDispatchFailure(
+  threadId: ThreadId,
+  queuedTurnId: string,
+): void {
+  const previous = retryStateByThreadId.get(threadId);
+  const failureCount =
+    previous?.queuedTurnId === queuedTurnId ? previous.failureCount + 1 : 1;
+  const retryDelay = QUEUED_COMPOSER_RETRY_DELAYS_MS[failureCount - 1];
+  retryStateByThreadId.set(threadId, {
+    queuedTurnId,
+    failureCount,
+    retryAt: retryDelay === undefined ? null : nowMs() + retryDelay,
+  });
+}
+
+function retryDelayForThread(threadId: ThreadId, queuedTurnId: string): number | null | undefined {
+  const retryState = retryStateByThreadId.get(threadId);
+  if (!retryState || retryState.queuedTurnId !== queuedTurnId) {
+    return undefined;
+  }
+  if (retryState.retryAt === null) {
+    return null;
+  }
+  return retryState.retryAt - nowMs();
+}
+
 function runQueuedComposerDrainPass(): void {
   const steerExpiryMs = advanceSteerGates();
-  if (steerExpiryTimer !== null) {
-    clearTimeout(steerExpiryTimer);
-    steerExpiryTimer = null;
-  }
-  if (steerExpiryMs !== null) {
-    steerExpiryTimer = setTimeout(
-      () => {
-        steerExpiryTimer = null;
-        requestQueuedComposerDrainPass();
-      },
-      Math.max(0, steerExpiryMs),
-    );
-  }
+  const awaitingStartExpiryMs = advanceAwaitingTurnStarts();
+  let earliestWakeMs =
+    steerExpiryMs === null
+      ? awaitingStartExpiryMs
+      : awaitingStartExpiryMs === null
+        ? steerExpiryMs
+        : Math.min(steerExpiryMs, awaitingStartExpiryMs);
 
   const threadIds = collectThreadIdsWithQueuedTurns();
   for (const threadId of threadIds) {
@@ -302,6 +512,14 @@ function runQueuedComposerDrainPass(): void {
     if (!nextQueuedTurn) {
       continue;
     }
+    const retryDelay = retryDelayForThread(threadId, nextQueuedTurn.id);
+    if (retryDelay === null) {
+      continue;
+    }
+    if (retryDelay !== undefined && retryDelay > 0) {
+      earliestWakeMs = earliestWakeMs === null ? retryDelay : Math.min(earliestWakeMs, retryDelay);
+      continue;
+    }
     const gates = readQueuedComposerAutoDispatchGates(threadId);
     if (!shouldAutoDispatchQueuedComposerTurn(gates)) {
       continue;
@@ -309,6 +527,11 @@ function runQueuedComposerDrainPass(): void {
     if (!tryBeginQueuedComposerAutoDispatch(threadId)) {
       continue;
     }
+    const thread = getThreadFromState(useStore.getState(), threadId);
+    const localDispatch = {
+      ...createLocalDispatchSnapshot(thread),
+      startedAt: new Date(nowMs()).toISOString(),
+    };
     void runLockedQueuedComposerAutoDispatch({
       threadId,
       run: async () => {
@@ -319,9 +542,14 @@ function runQueuedComposerDrainPass(): void {
           assistantDeliveryMode,
         });
         if (succeeded) {
+          retryStateByThreadId.delete(threadId);
+          awaitingTurnStartsByThreadId.set(threadId, localDispatch);
           useComposerDraftStore.getState().removeQueuedTurn(threadId, nextQueuedTurn.id);
+          return;
         }
+        recordQueuedComposerDispatchFailure(threadId, nextQueuedTurn.id);
       },
     });
   }
+  scheduleQueuedComposerDrainWake(earliestWakeMs);
 }

--- a/apps/web/src/lib/queuedComposerDrain.ts
+++ b/apps/web/src/lib/queuedComposerDrain.ts
@@ -2,8 +2,8 @@
 // Purpose: Auto-dispatch composer queued turns for every thread, including ones
 //          whose ChatView is unmounted, using the same gates as the open chat.
 // Layer: Web subscription utility
-// Exports: drain gates, exclusive per-thread send lock, steer-gate sharing,
-//          ChatView claim/release, watcher start
+// Exports: drain gates, exclusive per-thread send lock, locked-dispatch helper,
+//          steer-gate sharing, ChatView claim/release, watcher start
 
 import type { AssistantDeliveryMode, ThreadId } from "@synara/contracts";
 
@@ -94,6 +94,21 @@ export function endQueuedComposerAutoDispatch(threadId: ThreadId): void {
     return;
   }
   requestQueuedComposerDrainPass();
+}
+
+// Module-scope try/finally: ChatView is a hot-path compiler target and cannot
+// lower TryStatement without a catch. Callers must already hold the lock.
+export async function runLockedQueuedComposerAutoDispatch(input: {
+  threadId: ThreadId;
+  run: () => Promise<void>;
+  onSettled?: () => void;
+}): Promise<void> {
+  try {
+    await input.run();
+  } finally {
+    input.onSettled?.();
+    endQueuedComposerAutoDispatch(input.threadId);
+  }
 }
 
 export function claimQueuedComposerAutoDispatch(threadId: ThreadId): void {
@@ -294,8 +309,9 @@ function runQueuedComposerDrainPass(): void {
     if (!tryBeginQueuedComposerAutoDispatch(threadId)) {
       continue;
     }
-    void (async () => {
-      try {
+    void runLockedQueuedComposerAutoDispatch({
+      threadId,
+      run: async () => {
         const succeeded = await dispatchQueuedTurn({
           threadId,
           queuedTurn: nextQueuedTurn,
@@ -305,9 +321,7 @@ function runQueuedComposerDrainPass(): void {
         if (succeeded) {
           useComposerDraftStore.getState().removeQueuedTurn(threadId, nextQueuedTurn.id);
         }
-      } finally {
-        endQueuedComposerAutoDispatch(threadId);
-      }
-    })();
+      },
+    });
   }
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -28,6 +28,7 @@ import { DesktopWindowControls } from "../components/DesktopWindowControls";
 import { RunningChatsQuitCoordinator } from "../components/RunningChatsQuitCoordinator";
 import { AppSnapCoordinator } from "../components/AppSnapCoordinator";
 import { AppSnapWelcomeDialog } from "../components/AppSnapWelcomeDialog";
+import { QueuedComposerDrainCoordinator } from "../components/QueuedComposerDrainCoordinator";
 import { FeedbackDialog } from "../components/FeedbackDialog";
 import { SETTINGS_TARGETS } from "../settingsNavigation";
 import ShortcutsDialog from "../components/ShortcutsDialog";
@@ -292,6 +293,7 @@ function RootRouteView() {
           <GlobalFeedbackDialog />
           <GlobalWhatsNewSurface />
           <TaskCompletionNotifications />
+          <QueuedComposerDrainCoordinator />
           <AppSnapWelcomeDialog />
           <AppSnapCoordinator />
           <DesktopProjectBootstrap />


### PR DESCRIPTION
Fixes #775

Queued composer follow-ups only drained while that thread’s `ChatView` was mounted. Switching conversations left the queue stuck until you reopened the thread.

## What changed
- Headless dispatch of a snapshotted queued turn, driven by a process-wide watcher.
- Open chat still drains itself via claim/release; backgrounded threads drain when their live turn settles.
- Exclusive per-thread lock so ChatView and the watcher cannot double-send the same queue head.
- Shared steer gate is restored on remount / thread switch-back.

## Test plan
- [ ] Queue a follow-up, switch to another chat before the live turn finishes — the follow-up should send without reopening the original thread.
- [ ] Two queued items + switch chat — only the head should send (pair with #774).

Note: overlaps `ChatView.tsx` with #774 and #777. Prefer merge order #774 → #775 → #777.
