### PR TITLE
fix(web): stop duplicating streamed replies on completion drift (#776)

### DIFF
--- a/apps/web/src/storeEventReducer.test.ts
+++ b/apps/web/src/storeEventReducer.test.ts
@@ -14,7 +14,7 @@ import {
   ThreadMarkerId,
   TurnId,
 } from "@synara/contracts";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { applyOrchestrationEvents, applyOrchestrationEventsHotPath } from "./storeEventReducer";
 import {
@@ -520,56 +520,64 @@ describe("store event reducer", () => {
     expect(threadsOf(next)[0]?.runtimeMode).toBe("full-access");
   });
 
-  it("does not truncate streamed assistant text when completion only carries the trailing chunk", () => {
+  it("replaces streamed assistant text when a non-streaming completion diverges from the local prefix", () => {
     const assistantId = MessageId.makeUnsafe("assistant-message");
     const turnId = TurnId.makeUnsafe("turn-1");
-    const initialState = makeState(
-      makeThread({
-        messages: [
-          {
-            id: assistantId,
-            role: "assistant",
-            text: "Hello",
+    const localText = "The reply begins here and then drifts.";
+    const serverText = "The reply begins here, then continues to the end.";
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const initialState = makeState(
+        makeThread({
+          messages: [
+            {
+              id: assistantId,
+              role: "assistant",
+              text: localText,
+              turnId,
+              createdAt: "2026-02-27T00:01:05.000Z",
+              streaming: true,
+              source: "native",
+            },
+          ],
+          latestTurn: {
             turnId,
-            createdAt: "2026-02-27T00:01:05.000Z",
-            streaming: true,
-            source: "native",
+            state: "running",
+            requestedAt: "2026-02-27T00:01:00.000Z",
+            startedAt: "2026-02-27T00:01:05.000Z",
+            completedAt: null,
+            assistantMessageId: assistantId,
           },
-        ],
-        latestTurn: {
+        }),
+      );
+
+      const next = applyOrchestrationEvents(initialState, [
+        makeDomainEvent("thread.message-sent", {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          messageId: assistantId,
+          role: "assistant",
+          text: serverText,
           turnId,
-          state: "running",
-          requestedAt: "2026-02-27T00:01:00.000Z",
-          startedAt: "2026-02-27T00:01:05.000Z",
-          completedAt: null,
-          assistantMessageId: assistantId,
+          streaming: false,
+          createdAt: "2026-02-27T00:01:05.000Z",
+          updatedAt: "2026-02-27T00:01:06.000Z",
+          attachments: [],
+          source: "native",
+        }),
+      ]);
+
+      expect(threadsOf(next)[0]?.messages).toMatchObject([
+        {
+          id: assistantId,
+          text: serverText,
+          streaming: false,
+          completedAt: "2026-02-27T00:01:06.000Z",
         },
-      }),
-    );
-
-    const next = applyOrchestrationEvents(initialState, [
-      makeDomainEvent("thread.message-sent", {
-        threadId: ThreadId.makeUnsafe("thread-1"),
-        messageId: assistantId,
-        role: "assistant",
-        text: " world",
-        turnId,
-        streaming: false,
-        createdAt: "2026-02-27T00:01:05.000Z",
-        updatedAt: "2026-02-27T00:01:06.000Z",
-        attachments: [],
-        source: "native",
-      }),
-    ]);
-
-    expect(threadsOf(next)[0]?.messages).toMatchObject([
-      {
-        id: assistantId,
-        text: "Hello world",
-        streaming: false,
-        completedAt: "2026-02-27T00:01:06.000Z",
-      },
-    ]);
+      ]);
+      expect(threadsOf(next)[0]?.messages[0]?.text).not.toBe(`${localText}${serverText}`);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("replaces a non-streaming user message when an active-tail edit reuses its message id", () => {

--- a/apps/web/src/storeEventReducer.test.ts
+++ b/apps/web/src/storeEventReducer.test.ts
@@ -580,6 +580,62 @@ describe("store event reducer", () => {
     }
   });
 
+  it("replaces duplicated local streamed text with the authoritative completion", () => {
+    const assistantId = MessageId.makeUnsafe("assistant-message");
+    const turnId = TurnId.makeUnsafe("turn-1");
+    const serverText = "final text";
+    const initialState = makeState(
+      makeThread({
+        messages: [
+          {
+            id: assistantId,
+            role: "assistant",
+            text: `${serverText}${serverText}`,
+            turnId,
+            createdAt: "2026-02-27T00:01:05.000Z",
+            streaming: true,
+            source: "native",
+          },
+        ],
+        latestTurn: {
+          turnId,
+          state: "running",
+          requestedAt: "2026-02-27T00:01:00.000Z",
+          startedAt: "2026-02-27T00:01:05.000Z",
+          completedAt: null,
+          assistantMessageId: assistantId,
+        },
+      }),
+    );
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    try {
+      const next = applyOrchestrationEvents(initialState, [
+        makeDomainEvent("thread.message-sent", {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          messageId: assistantId,
+          role: "assistant",
+          text: serverText,
+          turnId,
+          streaming: false,
+          createdAt: "2026-02-27T00:01:05.000Z",
+          updatedAt: "2026-02-27T00:01:06.000Z",
+          attachments: [],
+          source: "native",
+        }),
+      ]);
+
+      expect(threadsOf(next)[0]?.messages[0]).toMatchObject({
+        id: assistantId,
+        text: serverText,
+        streaming: false,
+        completedAt: "2026-02-27T00:01:06.000Z",
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("replaces a non-streaming user message when an active-tail edit reuses its message id", () => {
     const userId = MessageId.makeUnsafe("user-active-edit");
     const initialState = makeState(

--- a/apps/web/src/storeEventReducer.ts
+++ b/apps/web/src/storeEventReducer.ts
@@ -613,14 +613,15 @@ function mergeStreamingMessage(
     nextText = incomingMessage.text;
   } else if (incomingMessage.streaming || incomingMessage.text.length === 0) {
     nextText = `${existingMessage.text}${incomingMessage.text}`;
-  } else if (incomingMessage.text.startsWith(existingMessage.text)) {
-    nextText = incomingMessage.text;
-  } else if (existingMessage.text.startsWith(incomingMessage.text)) {
-    nextText = existingMessage.text;
   } else {
-    // Completions carry the server's full accumulated text. If mid-stream drift
-    // broke the prefix invariant, concatenating would duplicate the bubble.
-    if (import.meta.env.DEV) {
+    // Non-streaming completions carry the server's authoritative accumulated
+    // text. Always prefer them so a duplicated or divergent local stream cannot
+    // survive after the turn settles.
+    if (
+      import.meta.env.DEV &&
+      incomingMessage.text !== existingMessage.text &&
+      !incomingMessage.text.startsWith(existingMessage.text)
+    ) {
       console.warn("[transcript] completion text diverged from local stream", {
         messageId: existingMessage.id,
         existing: describeStreamText(existingMessage.text),

--- a/apps/web/src/storeEventReducer.ts
+++ b/apps/web/src/storeEventReducer.ts
@@ -586,6 +586,20 @@ function applyTurnDiffSummaryToThread(
   };
 }
 
+const STREAM_TEXT_AFFIX_LENGTH = 48;
+
+function describeStreamText(text: string): {
+  length: number;
+  prefix: string;
+  suffix: string;
+} {
+  return {
+    length: text.length,
+    prefix: text.slice(0, STREAM_TEXT_AFFIX_LENGTH),
+    suffix: text.slice(-STREAM_TEXT_AFFIX_LENGTH),
+  };
+}
+
 function mergeStreamingMessage(
   existingMessage: ChatMessage,
   incomingMessage: ChatMessage,
@@ -604,7 +618,16 @@ function mergeStreamingMessage(
   } else if (existingMessage.text.startsWith(incomingMessage.text)) {
     nextText = existingMessage.text;
   } else {
-    nextText = `${existingMessage.text}${incomingMessage.text}`;
+    // Completions carry the server's full accumulated text. If mid-stream drift
+    // broke the prefix invariant, concatenating would duplicate the bubble.
+    if (import.meta.env.DEV) {
+      console.warn("[transcript] completion text diverged from local stream", {
+        messageId: existingMessage.id,
+        existing: describeStreamText(existingMessage.text),
+        incoming: describeStreamText(incomingMessage.text),
+      });
+    }
+    nextText = incomingMessage.text;
   }
   const nextAttachments = incomingMessage.attachments ?? existingMessage.attachments;
   const nextSkills =

--- a/apps/web/src/storeNormalization.test.ts
+++ b/apps/web/src/storeNormalization.test.ts
@@ -1,16 +1,18 @@
 // FILE: storeNormalization.test.ts
 // Purpose: Pins the incremental activity accumulator to the `normalizeActivities` fold it replaces.
 
-import { describe, expect, it } from "vitest";
+import { MessageId, TurnId } from "@synara/contracts";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   createThreadActivityAccumulator,
   dedupeActivitiesById,
   dedupeActivitiesByIdAfterAppend,
+  mergeReadModelThreadDetailWithLiveHotPath,
   normalizeActivities,
   type ThreadActivityAccumulator,
 } from "./storeNormalization";
-import { makeActivity } from "./storeTestFixtures";
+import { makeActivity, makeReadModelThread, makeThread } from "./storeTestFixtures";
 import type { Thread } from "./types";
 
 type ThreadActivity = Thread["activities"][number];
@@ -234,5 +236,143 @@ describe("dedupeActivitiesByIdAfterAppend", () => {
     expect(dedupeActivitiesByIdAfterAppend(next, undefined, undefined)).toEqual(
       dedupeActivitiesById(next),
     );
+  });
+});
+
+describe("mergeReadModelThreadDetailWithLiveHotPath", () => {
+  it("takes snapshot text when a completed local message is longer than the server twin", () => {
+    const assistantId = MessageId.makeUnsafe("assistant-completed-duplicate");
+    const turnId = TurnId.makeUnsafe("turn-completed-duplicate");
+    const serverText = "Final reply text from the server.";
+    const localText = `${serverText}${serverText}`;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const previousThread = makeThread({
+        latestTurn: {
+          turnId,
+          state: "completed",
+          requestedAt: "2026-02-27T00:00:00.000Z",
+          startedAt: "2026-02-27T00:00:01.000Z",
+          completedAt: "2026-02-27T00:00:05.000Z",
+          assistantMessageId: assistantId,
+        },
+        messages: [
+          {
+            id: assistantId,
+            role: "assistant",
+            text: localText,
+            turnId,
+            createdAt: "2026-02-27T00:00:01.000Z",
+            completedAt: "2026-02-27T00:00:05.000Z",
+            streaming: false,
+            source: "native",
+          },
+        ],
+      });
+
+      const incoming = makeReadModelThread({
+        latestTurn: {
+          turnId,
+          state: "completed",
+          requestedAt: "2026-02-27T00:00:00.000Z",
+          startedAt: "2026-02-27T00:00:01.000Z",
+          completedAt: "2026-02-27T00:00:05.000Z",
+          assistantMessageId: assistantId,
+        },
+        messages: [
+          {
+            id: assistantId,
+            role: "assistant",
+            text: serverText,
+            turnId,
+            streaming: false,
+            source: "native",
+            createdAt: "2026-02-27T00:00:01.000Z",
+            updatedAt: "2026-02-27T00:00:05.000Z",
+            attachments: [],
+          },
+        ],
+      });
+
+      const merged = mergeReadModelThreadDetailWithLiveHotPath(incoming, previousThread);
+
+      expect(merged.messages.find((message) => message.id === assistantId)?.text).toBe(serverText);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("prefers longer local assistant text while the live message is still streaming", () => {
+    const assistantId = MessageId.makeUnsafe("assistant-still-streaming");
+    const turnId = TurnId.makeUnsafe("turn-still-streaming");
+    const localText = "I'll start by scanning the repo. Then I'll summarize.";
+    const snapshotText = "I'll start by scanning the repo.";
+    const previousThread = makeThread({
+      session: {
+        provider: "codex",
+        status: "running",
+        orchestrationStatus: "running",
+        activeTurnId: turnId,
+        createdAt: "2026-02-27T00:00:00.000Z",
+        updatedAt: "2026-02-27T00:00:02.000Z",
+      },
+      latestTurn: {
+        turnId,
+        state: "running",
+        requestedAt: "2026-02-27T00:00:00.000Z",
+        startedAt: "2026-02-27T00:00:01.000Z",
+        completedAt: null,
+        assistantMessageId: assistantId,
+      },
+      messages: [
+        {
+          id: assistantId,
+          role: "assistant",
+          text: localText,
+          turnId,
+          createdAt: "2026-02-27T00:00:01.000Z",
+          streaming: true,
+          source: "native",
+        },
+      ],
+    });
+
+    const incoming = makeReadModelThread({
+      session: {
+        threadId: previousThread.id,
+        status: "running",
+        providerName: "codex",
+        runtimeMode: "full-access",
+        activeTurnId: turnId,
+        lastError: null,
+        updatedAt: "2026-02-27T00:00:02.000Z",
+      },
+      latestTurn: {
+        turnId,
+        state: "running",
+        requestedAt: "2026-02-27T00:00:00.000Z",
+        startedAt: "2026-02-27T00:00:01.000Z",
+        completedAt: null,
+        assistantMessageId: assistantId,
+      },
+      messages: [
+        {
+          id: assistantId,
+          role: "assistant",
+          text: snapshotText,
+          turnId,
+          streaming: false,
+          source: "native",
+          createdAt: "2026-02-27T00:00:01.000Z",
+          updatedAt: "2026-02-27T00:00:02.000Z",
+          attachments: [],
+        },
+      ],
+    });
+
+    const merged = mergeReadModelThreadDetailWithLiveHotPath(incoming, previousThread);
+
+    expect(merged.messages.find((message) => message.id === assistantId)?.text).toBe(localText);
+    expect(merged.messages.find((message) => message.id === assistantId)?.streaming).toBe(true);
   });
 });

--- a/apps/web/src/storeNormalization.ts
+++ b/apps/web/src/storeNormalization.ts
@@ -714,15 +714,28 @@ function mergeReadModelMessagesWithLiveHotPath(
     }
 
     const incomingCompletedAt = incomingMessage.streaming ? undefined : incomingMessage.updatedAt;
+    const localStreamingTextIsAhead =
+      previousMessage.streaming && previousMessage.text.length > incomingMessage.text.length;
     const shouldPreferLiveMessage =
       (authoritativeTurnId === null || incomingMessage.turnId !== authoritativeTurnId) &&
-      (previousMessage.text.length > incomingMessage.text.length ||
+      (localStreamingTextIsAhead ||
         (!previousMessage.streaming && incomingMessage.streaming) ||
         (previousMessage.completedAt !== undefined &&
           (incomingCompletedAt === undefined ||
             previousMessage.completedAt > incomingCompletedAt)));
 
     if (!shouldPreferLiveMessage) {
+      if (
+        import.meta.env.DEV &&
+        !previousMessage.streaming &&
+        previousMessage.text.length > incomingMessage.text.length
+      ) {
+        console.warn("[transcript] replacing longer completed local message with snapshot text", {
+          messageId: incomingMessage.id,
+          localLength: previousMessage.text.length,
+          snapshotLength: incomingMessage.text.length,
+        });
+      }
       mergedById.set(incomingMessage.id, {
         ...incomingMessage,
         ...(!incomingMessage.mentions || incomingMessage.mentions.length === 0

--- a/apps/web/src/storeProjection.test.ts
+++ b/apps/web/src/storeProjection.test.ts
@@ -13,7 +13,7 @@ import {
   type OrchestrationShellStreamEvent,
   type ThreadMarker,
 } from "@synara/contracts";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   applyShellEvent,
@@ -961,7 +961,7 @@ describe("store projection", () => {
             dispatchOrigin: "automation",
             turnId: null,
             createdAt: "2026-02-27T00:00:00.000Z",
-            streaming: false,
+            streaming: true,
             source: "native",
           },
         ],
@@ -998,6 +998,7 @@ describe("store projection", () => {
   });
 
   it("stops preserving a live assistant intro once the read model settles the same turn", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const threadId = ThreadId.makeUnsafe("thread-hot-path-settled");
     const turnId = TurnId.makeUnsafe("turn-hot-path-settled");
     const assistantId = MessageId.makeUnsafe("assistant-hot-path-settled");
@@ -1100,10 +1101,14 @@ describe("store projection", () => {
       }),
     );
 
-    expect(next.threadTurnStateById?.[threadId]?.latestTurn?.state).toBe("completed");
-    expect(next.threadTurnStateById?.[threadId]?.latestTurn?.completedAt).toBe(completedAt);
-    expect(next.threadSessionById?.[threadId]?.orchestrationStatus).toBe("ready");
-    expect(next.threadSessionById?.[threadId]?.activeTurnId).toBeUndefined();
+    try {
+      expect(next.threadTurnStateById?.[threadId]?.latestTurn?.state).toBe("completed");
+      expect(next.threadTurnStateById?.[threadId]?.latestTurn?.completedAt).toBe(completedAt);
+      expect(next.threadSessionById?.[threadId]?.orchestrationStatus).toBe("ready");
+      expect(next.threadSessionById?.[threadId]?.activeTurnId).toBeUndefined();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("adopts a settled session when the snapshot's terminal turn supersedes the preserved one", () => {


### PR DESCRIPTION
Fixes #776

A streamed assistant reply could appear almost twice in the transcript and never self-heal. Persistence was correct (one message, full text); the client merge appended the full completion on prefix mismatch, then snapshot merge kept the longer local copy forever.

This is **not** a regression of #679 / #692 (server-side OpenCode adapter). Here every durable layer is clean; the duplicate is renderer-only.

## What changed
- Non-streaming completions with prefix mismatch **replace** instead of concatenating.
- Longer local text is preferred only while `streaming === true`; completed snapshot text wins.

## Test plan
- [ ] Long OpenCode/Kimi reply: one bubble after settle, no “almost duplicate” text.
- [ ] Reload should not be required to repair the transcript.
