### PR TITLE
fix(web): keep file preview contents across expensive-read capacity (#778)

### DIFF
--- a/apps/web/src/components/WorkspaceFilePreview.capacity.browser.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.capacity.browser.tsx
@@ -1,0 +1,100 @@
+// FILE: WorkspaceFilePreview.capacity.browser.tsx
+// Purpose: Browser regressions for last-good file preview during capacity errors.
+// Layer: Focused component integration tests
+
+import "../index.css";
+
+import type { NativeApi, ProjectReadFileResult } from "@synara/contracts";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { page } from "vitest/browser";
+import { afterEach, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { invalidateProjectFileQueriesForCwds } from "~/lib/projectReactQuery";
+import { WorkspaceFilePreview } from "./WorkspaceFilePreview";
+
+const WORKSPACE_ROOT = "/Users/tester/project";
+const FILE_PATH = "src/app.ts";
+const LOADED_VERSION = `sha256:${"1".repeat(64)}`;
+const CAPACITY_MESSAGE = "WebSocket expensive-read request capacity exceeded.";
+
+function installNativeApi(api: NativeApi): () => void {
+  const previousDescriptor = Object.getOwnPropertyDescriptor(window, "nativeApi");
+  Object.defineProperty(window, "nativeApi", {
+    configurable: true,
+    value: api,
+  });
+  return () => {
+    if (previousDescriptor) {
+      Object.defineProperty(window, "nativeApi", previousDescriptor);
+    } else {
+      Reflect.deleteProperty(window, "nativeApi");
+    }
+  };
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+}
+
+function loadedFile(overrides: Partial<ProjectReadFileResult> = {}): ProjectReadFileResult {
+  return {
+    relativePath: FILE_PATH,
+    contents: "export const value = 1;\n",
+    truncated: false,
+    version: LOADED_VERSION,
+    encoding: "utf8",
+    lineEnding: "lf",
+    ...overrides,
+  };
+}
+
+function capacityError(): Error {
+  return Object.assign(new Error(CAPACITY_MESSAGE), {
+    code: "RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED",
+    retryable: true,
+    retryAfterMs: 1,
+  });
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+it("keeps last-good file contents when a refetch hits expensive-read capacity", async () => {
+  const readFile = vi.fn().mockResolvedValueOnce(loadedFile()).mockRejectedValue(capacityError());
+  const restoreNativeApi = installNativeApi({
+    projects: { readFile },
+  } as unknown as NativeApi);
+  const queryClient = makeQueryClient();
+
+  try {
+    await render(
+      <QueryClientProvider client={queryClient}>
+        <WorkspaceFilePreview workspaceRoot={WORKSPACE_ROOT} filePath={FILE_PATH} />
+      </QueryClientProvider>,
+    );
+
+    await expect.element(page.getByText("export const value = 1;")).toBeVisible();
+
+    await invalidateProjectFileQueriesForCwds(queryClient, [WORKSPACE_ROOT]);
+
+    await vi.waitFor(
+      () => {
+        const text = document.body.textContent ?? "";
+        expect(text).toContain("export const value = 1;");
+        expect(text).not.toContain(CAPACITY_MESSAGE);
+        expect(text.includes("File refresh delayed.") || text.includes("Refreshing file...")).toBe(
+          true,
+        );
+      },
+      { timeout: 10_000 },
+    );
+  } finally {
+    restoreNativeApi();
+  }
+});

--- a/apps/web/src/components/WorkspaceFilePreview.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.tsx
@@ -42,6 +42,7 @@ import { formatFileCommentRange, type FileCommentSelection } from "~/lib/fileCom
 import { showFileReferenceContextMenu } from "~/lib/fileReferenceContextMenu";
 import { PlusIcon } from "~/lib/icons";
 import { toggleMarkdownTaskMarker } from "~/lib/markdownTaskList";
+import { isRpcCapacityExceededError } from "~/lib/expensiveReadRetry";
 import {
   isLocalPreviewGrantUsable,
   projectLocalPreviewGrantQueryOptions,
@@ -441,11 +442,15 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
   // workspace file invalidation restore that priority when the local file is
   // created later.
   const binaryPreviewFailed = binaryPreviewErrorKey === relocationRequestKey;
+  const fileReadFailedWithoutContents =
+    fileQuery.isError &&
+    fileQuery.data === undefined &&
+    !isRpcCapacityExceededError(fileQuery.error);
   const outOfRootResolutionEnabled =
     workspaceRoot !== null &&
     requestedFilePath !== null &&
     isWorkspaceRelativePathSafe(requestedFilePath) &&
-    (fileQuery.isError || binaryPreviewFailed || relocatedFullPath !== null);
+    (fileReadFailedWithoutContents || binaryPreviewFailed || relocatedFullPath !== null);
   const outOfRootResolutionQuery = useQuery(
     projectResolveOutOfRootFileReferenceQueryOptions({
       cwd: workspaceRoot,
@@ -823,6 +828,11 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
 
   const hoveredCommentLine = lineCommenting.hoveredLine;
   const activeCommentLine = lineCommenting.activeLine;
+  const hasFileContents = fileQuery.data !== undefined;
+  const fileReadError = fileQuery.error;
+  const fileReadCapacityError = isRpcCapacityExceededError(fileReadError);
+  const showFileReadErrorIndicator =
+    hasFileContents && fileReadError !== null && !activeEditBuffer?.error;
 
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col bg-[var(--color-background-surface)]">
@@ -853,6 +863,23 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
             Reload from disk
           </button>
         </div>
+      ) : showFileReadErrorIndicator ? (
+        <div
+          role={fileReadCapacityError ? "status" : "alert"}
+          className={
+            fileReadCapacityError
+              ? "flex shrink-0 items-center border-b border-border/60 px-3 py-2 text-[11px] text-muted-foreground"
+              : "flex shrink-0 items-center border-b border-destructive/25 bg-destructive/5 px-3 py-2 text-[11px] text-destructive"
+          }
+        >
+          {fileReadCapacityError
+            ? fileQuery.isFetching
+              ? "Refreshing file..."
+              : "File refresh delayed."
+            : fileReadError instanceof Error
+              ? fileReadError.message
+              : "Could not refresh file."}
+        </div>
       ) : null}
       {locatingOutOfRootFile ? (
         <FilePreviewLoadingState />
@@ -875,12 +902,14 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
         </div>
       ) : fileQuery.isLoading ? (
         <FilePreviewLoadingState />
-      ) : fileQuery.error ? (
+      ) : !hasFileContents && fileReadError ? (
         <PanelStateMessage density="compact" fill="flex" className="items-start justify-start p-3">
           <p className="text-left text-[11px] text-destructive/85">
-            {fileQuery.error instanceof Error ? fileQuery.error.message : "Could not read file."}
+            {fileReadError instanceof Error ? fileReadError.message : "Could not read file."}
           </p>
         </PanelStateMessage>
+      ) : !hasFileContents ? (
+        <FilePreviewLoadingState />
       ) : activeEditBuffer && editableDocument && !showMarkdownPreview ? (
         <textarea
           className="editor-file-editor"

--- a/apps/web/src/lib/expensiveReadRetry.test.ts
+++ b/apps/web/src/lib/expensiveReadRetry.test.ts
@@ -1,0 +1,85 @@
+// FILE: expensiveReadRetry.test.ts
+// Purpose: Locks down capacity-retry delay and error-only self-heal intervals.
+// Layer: Web data-fetching unit tests
+
+import { describe, expect, it } from "vitest";
+
+import {
+  expensiveReadErrorRefetchInterval,
+  expensiveReadRetryDelay,
+  getUnaryRpcCapacityRetryDelayMs,
+  isRpcCapacityExceededError,
+  MAX_UNARY_RPC_CAPACITY_RETRY_ATTEMPTS,
+  shouldRetryExpensiveRead,
+  shouldRetryExpensiveReadCapacityOnly,
+} from "./expensiveReadRetry";
+
+const capacityError = {
+  code: "RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED",
+  retryable: true,
+  retryAfterMs: 375,
+};
+
+describe("expensive-read capacity retry", () => {
+  it("recognizes typed capacity errors and honors the server retry delay", () => {
+    expect(isRpcCapacityExceededError(capacityError)).toBe(true);
+    expect(
+      isRpcCapacityExceededError({
+        code: "RPC_REQUEST_CAPACITY_EXCEEDED",
+        retryable: true,
+        retryAfterMs: 250,
+      }),
+    ).toBe(true);
+    expect(isRpcCapacityExceededError(new Error("network"))).toBe(false);
+
+    expect(shouldRetryExpensiveRead(0, capacityError)).toBe(true);
+    expect(shouldRetryExpensiveRead(11, capacityError)).toBe(true);
+    expect(shouldRetryExpensiveRead(12, capacityError)).toBe(false);
+    expect(shouldRetryExpensiveRead(0, new Error("Workspace file not found"))).toBe(true);
+    expect(shouldRetryExpensiveReadCapacityOnly(0, capacityError)).toBe(true);
+    expect(shouldRetryExpensiveReadCapacityOnly(0, new Error("Workspace file not found"))).toBe(
+      false,
+    );
+    expect(expensiveReadRetryDelay(0, capacityError)).toBe(375);
+    expect(
+      expensiveReadRetryDelay(0, {
+        code: "RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED",
+        retryable: true,
+      }),
+    ).toBe(250);
+  });
+
+  it("uses a bounded in-place unary retry that honors retryAfterMs", () => {
+    expect(getUnaryRpcCapacityRetryDelayMs(capacityError, 0)).toBe(375);
+    expect(getUnaryRpcCapacityRetryDelayMs(capacityError, 11)).toBe(375);
+    expect(
+      getUnaryRpcCapacityRetryDelayMs(capacityError, MAX_UNARY_RPC_CAPACITY_RETRY_ATTEMPTS),
+    ).toBeNull();
+    expect(
+      getUnaryRpcCapacityRetryDelayMs(
+        { code: "RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED", retryable: false, retryAfterMs: 375 },
+        0,
+      ),
+    ).toBeNull();
+    expect(getUnaryRpcCapacityRetryDelayMs(new Error("boom"), 0)).toBeNull();
+  });
+
+  it("self-heals only while a retryable capacity error is retained", () => {
+    expect(expensiveReadErrorRefetchInterval({ state: { error: capacityError } })).toBe(375);
+    expect(expensiveReadErrorRefetchInterval({ state: { error: null } })).toBe(false);
+    expect(expensiveReadErrorRefetchInterval({ state: { error: new Error("ENOENT") } })).toBe(
+      false,
+    );
+    expect(
+      expensiveReadErrorRefetchInterval({
+        state: {
+          error: {
+            code: "RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED",
+            retryable: false,
+            retryAfterMs: 375,
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/lib/expensiveReadRetry.test.ts
+++ b/apps/web/src/lib/expensiveReadRetry.test.ts
@@ -9,9 +9,9 @@ import {
   expensiveReadRetryDelay,
   getUnaryRpcCapacityRetryDelayMs,
   isRpcCapacityExceededError,
+  MAX_EXPENSIVE_READ_ERROR_REFETCH_INTERVAL_MS,
   MAX_UNARY_RPC_CAPACITY_RETRY_ATTEMPTS,
   shouldRetryExpensiveRead,
-  shouldRetryExpensiveReadCapacityOnly,
 } from "./expensiveReadRetry";
 
 const capacityError = {
@@ -32,14 +32,11 @@ describe("expensive-read capacity retry", () => {
     ).toBe(true);
     expect(isRpcCapacityExceededError(new Error("network"))).toBe(false);
 
-    expect(shouldRetryExpensiveRead(0, capacityError)).toBe(true);
-    expect(shouldRetryExpensiveRead(11, capacityError)).toBe(true);
-    expect(shouldRetryExpensiveRead(12, capacityError)).toBe(false);
+    expect(shouldRetryExpensiveRead(0, capacityError)).toBe(false);
+    expect(getUnaryRpcCapacityRetryDelayMs(capacityError, 0)).toBe(375);
     expect(shouldRetryExpensiveRead(0, new Error("Workspace file not found"))).toBe(true);
-    expect(shouldRetryExpensiveReadCapacityOnly(0, capacityError)).toBe(true);
-    expect(shouldRetryExpensiveReadCapacityOnly(0, new Error("Workspace file not found"))).toBe(
-      false,
-    );
+    expect(shouldRetryExpensiveRead(2, new Error("network"))).toBe(true);
+    expect(shouldRetryExpensiveRead(3, new Error("network"))).toBe(false);
     expect(expensiveReadRetryDelay(0, capacityError)).toBe(375);
     expect(
       expensiveReadRetryDelay(0, {
@@ -65,7 +62,15 @@ describe("expensive-read capacity retry", () => {
   });
 
   it("self-heals only while a retryable capacity error is retained", () => {
-    expect(expensiveReadErrorRefetchInterval({ state: { error: capacityError } })).toBe(375);
+    expect(
+      expensiveReadErrorRefetchInterval({ state: { error: capacityError, errorUpdateCount: 1 } }),
+    ).toBe(375);
+    expect(
+      expensiveReadErrorRefetchInterval({ state: { error: capacityError, errorUpdateCount: 2 } }),
+    ).toBe(750);
+    expect(
+      expensiveReadErrorRefetchInterval({ state: { error: capacityError, errorUpdateCount: 8 } }),
+    ).toBe(MAX_EXPENSIVE_READ_ERROR_REFETCH_INTERVAL_MS);
     expect(expensiveReadErrorRefetchInterval({ state: { error: null } })).toBe(false);
     expect(expensiveReadErrorRefetchInterval({ state: { error: new Error("ENOENT") } })).toBe(
       false,

--- a/apps/web/src/lib/expensiveReadRetry.ts
+++ b/apps/web/src/lib/expensiveReadRetry.ts
@@ -1,0 +1,106 @@
+// FILE: expensiveReadRetry.ts
+// Purpose: Shared retry policy for WebSocket RPC capacity backpressure.
+// Layer: Web data-fetching helpers
+// The server rejects saturated unary calls before the handler runs
+// (retryable: true, retryAfterMs: 250). Callers must honor that contract
+// instead of treating capacity as a hard failure.
+
+const RPC_CAPACITY_EXCEEDED_CODES = new Set([
+  "RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED",
+  "RPC_REQUEST_CAPACITY_EXCEEDED",
+]);
+
+export const RPC_CAPACITY_RETRY_LIMIT = 12;
+export const MAX_UNARY_RPC_CAPACITY_RETRY_ATTEMPTS = RPC_CAPACITY_RETRY_LIMIT;
+export const DEFAULT_RPC_CAPACITY_RETRY_MS = 250;
+const DEFAULT_GENERIC_RETRY_LIMIT = 3;
+
+export function isRpcCapacityExceededError(error: unknown): error is {
+  readonly code: string;
+  readonly retryAfterMs?: unknown;
+  readonly retryable?: unknown;
+} {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string" &&
+    RPC_CAPACITY_EXCEEDED_CODES.has(error.code)
+  );
+}
+
+function isRetryableRpcCapacityExceededError(error: unknown): boolean {
+  return isRpcCapacityExceededError(error) && error.retryable !== false;
+}
+
+export function getRpcCapacityRetryAfterMs(error: unknown): number {
+  if (!isRpcCapacityExceededError(error)) return DEFAULT_RPC_CAPACITY_RETRY_MS;
+  const retryAfterMs = error.retryAfterMs;
+  return typeof retryAfterMs === "number" && retryAfterMs > 0
+    ? retryAfterMs
+    : DEFAULT_RPC_CAPACITY_RETRY_MS;
+}
+
+/**
+ * Delay for a bounded in-place unary retry. Returns null when the error is not
+ * a retryable capacity rejection or the attempt budget is exhausted.
+ */
+export function getUnaryRpcCapacityRetryDelayMs(
+  error: unknown,
+  previousAttempts: number,
+): number | null {
+  if (previousAttempts >= MAX_UNARY_RPC_CAPACITY_RETRY_ATTEMPTS) return null;
+  if (!isRetryableRpcCapacityExceededError(error)) return null;
+  return getRpcCapacityRetryAfterMs(error);
+}
+
+export function shouldRetryExpensiveRead(failureCount: number, error: unknown): boolean {
+  return isRetryableRpcCapacityExceededError(error)
+    ? failureCount < RPC_CAPACITY_RETRY_LIMIT
+    : failureCount < DEFAULT_GENERIC_RETRY_LIMIT;
+}
+
+export function shouldRetryExpensiveReadCapacityOnly(
+  failureCount: number,
+  error: unknown,
+): boolean {
+  return isRetryableRpcCapacityExceededError(error)
+    ? failureCount < RPC_CAPACITY_RETRY_LIMIT
+    : false;
+}
+
+export function expensiveReadRetryDelay(attemptIndex: number, error: unknown): number {
+  if (isRetryableRpcCapacityExceededError(error)) {
+    return getRpcCapacityRetryAfterMs(error);
+  }
+  return Math.min(1_000 * 2 ** attemptIndex, 30_000);
+}
+
+type ExpensiveReadRetryFns = {
+  readonly retry: (failureCount: number, error: Error) => boolean;
+  readonly retryDelay: (attemptIndex: number, error: Error) => number;
+};
+
+export const EXPENSIVE_READ_RETRY_OPTIONS: ExpensiveReadRetryFns = {
+  retry: shouldRetryExpensiveRead as ExpensiveReadRetryFns["retry"],
+  retryDelay: expensiveReadRetryDelay as ExpensiveReadRetryFns["retryDelay"],
+};
+
+// Capacity-only: do not override QueryClient retry for generic misses
+// such as "file not found", which must surface immediately for relocation.
+export const EXPENSIVE_READ_CAPACITY_RETRY_OPTIONS: ExpensiveReadRetryFns = {
+  retry: shouldRetryExpensiveReadCapacityOnly as ExpensiveReadRetryFns["retry"],
+  retryDelay: expensiveReadRetryDelay as ExpensiveReadRetryFns["retryDelay"],
+};
+
+/**
+ * Error-only refetch so a saturated read recovers without waiting for another
+ * file-change, window focus, or reconnect. Successful queries stay event-driven.
+ */
+export function expensiveReadErrorRefetchInterval(query: {
+  readonly state: { readonly error: unknown };
+}): number | false {
+  return isRetryableRpcCapacityExceededError(query.state.error)
+    ? getRpcCapacityRetryAfterMs(query.state.error)
+    : false;
+}

--- a/apps/web/src/lib/expensiveReadRetry.ts
+++ b/apps/web/src/lib/expensiveReadRetry.ts
@@ -55,18 +55,10 @@ export function getUnaryRpcCapacityRetryDelayMs(
 }
 
 export function shouldRetryExpensiveRead(failureCount: number, error: unknown): boolean {
-  return isRetryableRpcCapacityExceededError(error)
-    ? failureCount < RPC_CAPACITY_RETRY_LIMIT
-    : failureCount < DEFAULT_GENERIC_RETRY_LIMIT;
-}
-
-export function shouldRetryExpensiveReadCapacityOnly(
-  failureCount: number,
-  error: unknown,
-): boolean {
-  return isRetryableRpcCapacityExceededError(error)
-    ? failureCount < RPC_CAPACITY_RETRY_LIMIT
-    : false;
+  // Capacity rejections are already retried in-place by wsTransport.request().
+  // A second query-level budget would multiply into 13×13 admission probes.
+  if (isRetryableRpcCapacityExceededError(error)) return false;
+  return failureCount < DEFAULT_GENERIC_RETRY_LIMIT;
 }
 
 export function expensiveReadRetryDelay(attemptIndex: number, error: unknown): number {
@@ -86,21 +78,20 @@ export const EXPENSIVE_READ_RETRY_OPTIONS: ExpensiveReadRetryFns = {
   retryDelay: expensiveReadRetryDelay as ExpensiveReadRetryFns["retryDelay"],
 };
 
-// Capacity-only: do not override QueryClient retry for generic misses
-// such as "file not found", which must surface immediately for relocation.
-export const EXPENSIVE_READ_CAPACITY_RETRY_OPTIONS: ExpensiveReadRetryFns = {
-  retry: shouldRetryExpensiveReadCapacityOnly as ExpensiveReadRetryFns["retry"],
-  retryDelay: expensiveReadRetryDelay as ExpensiveReadRetryFns["retryDelay"],
-};
+export const MAX_EXPENSIVE_READ_ERROR_REFETCH_INTERVAL_MS = 10_000;
 
 /**
  * Error-only refetch so a saturated read recovers without waiting for another
  * file-change, window focus, or reconnect. Successful queries stay event-driven.
+ * Back off from retryAfterMs so each tick does not immediately re-arm a full
+ * unary capacity-retry loop.
  */
 export function expensiveReadErrorRefetchInterval(query: {
-  readonly state: { readonly error: unknown };
+  readonly state: { readonly error: unknown; readonly errorUpdateCount?: number };
 }): number | false {
-  return isRetryableRpcCapacityExceededError(query.state.error)
-    ? getRpcCapacityRetryAfterMs(query.state.error)
-    : false;
+  if (!isRetryableRpcCapacityExceededError(query.state.error)) return false;
+  const base = getRpcCapacityRetryAfterMs(query.state.error);
+  const failures = Math.max(1, query.state.errorUpdateCount ?? 1);
+  const exponent = Math.min(failures - 1, 16);
+  return Math.min(base * 2 ** exponent, MAX_EXPENSIVE_READ_ERROR_REFETCH_INTERVAL_MS);
 }

--- a/apps/web/src/lib/gitReactQuery.test.ts
+++ b/apps/web/src/lib/gitReactQuery.test.ts
@@ -375,9 +375,9 @@ describe("git expensive-read capacity retry", () => {
     expect(typeof options.retryDelay).toBe("function");
     if (typeof options.retry !== "function" || typeof options.retryDelay !== "function") return;
 
-    expect(options.retry(0, capacityError)).toBe(true);
-    expect(options.retry(12, capacityError)).toBe(false);
-    expect(options.retryDelay(0, capacityError)).toBe(375);
+    expect(options.retry(0, capacityError as never)).toBe(true);
+    expect(options.retry(12, capacityError as never)).toBe(false);
+    expect(options.retryDelay(0, capacityError as never)).toBe(375);
   });
 });
 

--- a/apps/web/src/lib/gitReactQuery.test.ts
+++ b/apps/web/src/lib/gitReactQuery.test.ts
@@ -375,8 +375,9 @@ describe("git expensive-read capacity retry", () => {
     expect(typeof options.retryDelay).toBe("function");
     if (typeof options.retry !== "function" || typeof options.retryDelay !== "function") return;
 
-    expect(options.retry(0, capacityError as never)).toBe(true);
-    expect(options.retry(12, capacityError as never)).toBe(false);
+    expect(options.retry(0, capacityError as never)).toBe(false);
+    expect(options.retry(0, new Error("network"))).toBe(true);
+    expect(options.retry(3, new Error("network"))).toBe(false);
     expect(options.retryDelay(0, capacityError as never)).toBe(375);
   });
 });

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -8,6 +8,7 @@ import type {
 } from "@synara/contracts";
 import { mutationOptions, queryOptions, type QueryClient } from "@tanstack/react-query";
 import { ensureNativeApi } from "../nativeApi";
+import { EXPENSIVE_READ_RETRY_OPTIONS, isRpcCapacityExceededError } from "./expensiveReadRetry";
 
 const GIT_STATUS_STALE_TIME_MS = 30_000;
 // Freshness is driven primarily by event-based invalidation (turn lifecycle +
@@ -19,41 +20,14 @@ const GIT_BRANCHES_STALE_TIME_MS = 15_000;
 const GIT_BRANCHES_REFETCH_INTERVAL_MS = 300_000;
 const GIT_WORKING_TREE_DIFF_STALE_TIME_MS = 5_000;
 export const GIT_WORKING_TREE_DIFF_LIVE_REFETCH_INTERVAL_MS = 4_000;
-const RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED = "RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED";
-const GIT_CAPACITY_RETRY_LIMIT = 12;
-const DEFAULT_GIT_CAPACITY_RETRY_MS = 250;
 
 export function isGitExpensiveReadCapacityError(
   error: unknown,
 ): error is { readonly code: string; readonly retryAfterMs?: unknown } {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    error.code === RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED
-  );
+  return isRpcCapacityExceededError(error);
 }
 
-function shouldRetryGitExpensiveRead(failureCount: number, error: unknown): boolean {
-  return isGitExpensiveReadCapacityError(error)
-    ? failureCount < GIT_CAPACITY_RETRY_LIMIT
-    : failureCount < 3;
-}
-
-function gitExpensiveReadRetryDelay(attemptIndex: number, error: unknown): number {
-  if (isGitExpensiveReadCapacityError(error)) {
-    const retryAfterMs = "retryAfterMs" in error ? error.retryAfterMs : undefined;
-    return typeof retryAfterMs === "number" && retryAfterMs > 0
-      ? retryAfterMs
-      : DEFAULT_GIT_CAPACITY_RETRY_MS;
-  }
-  return Math.min(1_000 * 2 ** attemptIndex, 30_000);
-}
-
-const GIT_EXPENSIVE_READ_RETRY_OPTIONS = {
-  retry: shouldRetryGitExpensiveRead,
-  retryDelay: gitExpensiveReadRetryDelay,
-} as const;
+const GIT_EXPENSIVE_READ_RETRY_OPTIONS = EXPENSIVE_READ_RETRY_OPTIONS;
 
 export const gitQueryKeys = {
   all: ["git"] as const,

--- a/apps/web/src/lib/projectReactQuery.test.ts
+++ b/apps/web/src/lib/projectReactQuery.test.ts
@@ -1,11 +1,16 @@
-import { describe, expect, it } from "vitest";
+import type { NativeApi } from "@synara/contracts";
+import { QueryClient } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import * as nativeApi from "../nativeApi";
 import {
   isLocalPreviewGrantUsable,
   LOCAL_PREVIEW_GRANT_MAX_REFETCH_INTERVAL_MS,
   localPreviewGrantRefetchIntervalMs,
   projectLocalPreviewGrantQueryOptions,
+  projectQueryKeys,
   projectReadFileQueryOptions,
+  projectSearchEntriesQueryOptions,
 } from "./projectReactQuery";
 
 describe("local preview grant query options", () => {
@@ -59,6 +64,10 @@ describe("local preview grant query options", () => {
   });
 });
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("project read file capacity retry", () => {
   const capacityError = {
     code: "RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED",
@@ -66,28 +75,69 @@ describe("project read file capacity retry", () => {
     retryAfterMs: 375,
   };
 
-  it("honors retryAfterMs and self-heals only while the read is in a capacity error", () => {
+  it("does not stack query-level capacity retries on top of transport", () => {
     const options = projectReadFileQueryOptions({
       cwd: "/repo",
       relativePath: "src/app.ts",
     });
-    expect(typeof options.retry).toBe("function");
-    expect(typeof options.retryDelay).toBe("function");
+    expect(options.retry).toBe(false);
     expect(typeof options.refetchInterval).toBe("function");
-    if (
-      typeof options.retry !== "function" ||
-      typeof options.retryDelay !== "function" ||
-      typeof options.refetchInterval !== "function"
-    ) {
-      throw new Error("Expected capacity retry options on projectReadFileQueryOptions.");
+    if (typeof options.refetchInterval !== "function") {
+      throw new Error("Expected error-only refetchInterval on projectReadFileQueryOptions.");
     }
 
-    expect(options.retry(0, capacityError as never)).toBe(true);
-    expect(options.retry(12, capacityError as never)).toBe(false);
-    expect(options.retry(0, new Error("Workspace file not found"))).toBe(false);
-    expect(options.retryDelay(0, capacityError as never)).toBe(375);
-    expect(options.refetchInterval({ state: { error: capacityError } } as never)).toBe(375);
+    expect(
+      options.refetchInterval({ state: { error: capacityError, errorUpdateCount: 1 } } as never),
+    ).toBe(375);
+    expect(
+      options.refetchInterval({ state: { error: capacityError, errorUpdateCount: 2 } } as never),
+    ).toBe(750);
     expect(options.refetchInterval({ state: { error: null } } as never)).toBe(false);
     expect(options.refetchInterval({ state: { error: new Error("ENOENT") } } as never)).toBe(false);
+  });
+
+  it("aborts an in-flight read when the query is cancelled", async () => {
+    let seenSignal: AbortSignal | undefined;
+    const readFile = vi.fn((_input: unknown, options?: { signal?: AbortSignal }) => {
+      seenSignal = options?.signal;
+      return new Promise(() => undefined);
+    });
+    vi.spyOn(nativeApi, "ensureNativeApi").mockReturnValue({
+      projects: { readFile },
+    } as unknown as NativeApi);
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const fetchPromise = queryClient.fetchQuery(
+      projectReadFileQueryOptions({ cwd: "/repo", relativePath: "src/app.ts" }),
+    );
+    await vi.waitFor(() => expect(readFile).toHaveBeenCalledTimes(1));
+    expect(seenSignal?.aborted).toBe(false);
+
+    await queryClient.cancelQueries({
+      queryKey: projectQueryKeys.readFile("/repo", "src/app.ts"),
+    });
+
+    expect(seenSignal?.aborted).toBe(true);
+    await expect(fetchPromise).rejects.toBeDefined();
+    queryClient.clear();
+  });
+});
+
+describe("project search capacity retry", () => {
+  const capacityError = {
+    code: "RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED",
+    retryable: true,
+    retryAfterMs: 375,
+  };
+
+  it("retries generic search failures without stacking capacity retries", () => {
+    const options = projectSearchEntriesQueryOptions({ cwd: "/repo", query: "app" });
+    expect(typeof options.retry).toBe("function");
+    if (typeof options.retry !== "function") {
+      throw new Error("Expected retry on projectSearchEntriesQueryOptions.");
+    }
+    expect(options.retry(0, capacityError as never)).toBe(false);
+    expect(options.retry(0, new Error("network"))).toBe(true);
+    expect(options.retry(3, new Error("network"))).toBe(false);
   });
 });

--- a/apps/web/src/lib/projectReactQuery.test.ts
+++ b/apps/web/src/lib/projectReactQuery.test.ts
@@ -5,6 +5,7 @@ import {
   LOCAL_PREVIEW_GRANT_MAX_REFETCH_INTERVAL_MS,
   localPreviewGrantRefetchIntervalMs,
   projectLocalPreviewGrantQueryOptions,
+  projectReadFileQueryOptions,
 } from "./projectReactQuery";
 
 describe("local preview grant query options", () => {
@@ -55,5 +56,38 @@ describe("local preview grant query options", () => {
         state: { data: { grant: "grant-token", expiresAt: "not-a-date" } },
       } as never),
     ).toBe(LOCAL_PREVIEW_GRANT_MAX_REFETCH_INTERVAL_MS);
+  });
+});
+
+describe("project read file capacity retry", () => {
+  const capacityError = {
+    code: "RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED",
+    retryable: true,
+    retryAfterMs: 375,
+  };
+
+  it("honors retryAfterMs and self-heals only while the read is in a capacity error", () => {
+    const options = projectReadFileQueryOptions({
+      cwd: "/repo",
+      relativePath: "src/app.ts",
+    });
+    expect(typeof options.retry).toBe("function");
+    expect(typeof options.retryDelay).toBe("function");
+    expect(typeof options.refetchInterval).toBe("function");
+    if (
+      typeof options.retry !== "function" ||
+      typeof options.retryDelay !== "function" ||
+      typeof options.refetchInterval !== "function"
+    ) {
+      throw new Error("Expected capacity retry options on projectReadFileQueryOptions.");
+    }
+
+    expect(options.retry(0, capacityError as never)).toBe(true);
+    expect(options.retry(12, capacityError as never)).toBe(false);
+    expect(options.retry(0, new Error("Workspace file not found"))).toBe(false);
+    expect(options.retryDelay(0, capacityError as never)).toBe(375);
+    expect(options.refetchInterval({ state: { error: capacityError } } as never)).toBe(375);
+    expect(options.refetchInterval({ state: { error: null } } as never)).toBe(false);
+    expect(options.refetchInterval({ state: { error: new Error("ENOENT") } } as never)).toBe(false);
   });
 });

--- a/apps/web/src/lib/projectReactQuery.ts
+++ b/apps/web/src/lib/projectReactQuery.ts
@@ -13,6 +13,10 @@ import { PROJECT_SEARCH_CONTENT_MIN_QUERY_LENGTH } from "@synara/contracts";
 import { isLocalAbsolutePath } from "@synara/shared/path";
 import { queryOptions, type QueryClient } from "@tanstack/react-query";
 import { ensureNativeApi } from "~/nativeApi";
+import {
+  EXPENSIVE_READ_CAPACITY_RETRY_OPTIONS,
+  expensiveReadErrorRefetchInterval,
+} from "./expensiveReadRetry";
 
 export const projectQueryKeys = {
   all: ["projects"] as const,
@@ -190,6 +194,8 @@ export function projectReadFileQueryOptions(input: {
     },
     enabled: (input.enabled ?? true) && effectiveCwd !== null && input.relativePath !== null,
     staleTime: input.staleTime ?? DEFAULT_READ_FILE_STALE_TIME,
+    ...EXPENSIVE_READ_CAPACITY_RETRY_OPTIONS,
+    refetchInterval: expensiveReadErrorRefetchInterval,
   });
 }
 
@@ -290,6 +296,7 @@ export function projectSearchEntriesQueryOptions(input: {
     enabled: (input.enabled ?? true) && input.cwd !== null && input.query.length > 0,
     staleTime: input.staleTime ?? DEFAULT_SEARCH_ENTRIES_STALE_TIME,
     placeholderData: (previous) => previous ?? EMPTY_SEARCH_ENTRIES_RESULT,
+    ...EXPENSIVE_READ_CAPACITY_RETRY_OPTIONS,
   });
 }
 
@@ -320,6 +327,7 @@ export function projectSearchLocalEntriesQueryOptions(input: {
     enabled: (input.enabled ?? true) && input.rootPath !== null && trimmedQuery.length >= 2,
     staleTime: input.staleTime ?? DEFAULT_SEARCH_LOCAL_ENTRIES_STALE_TIME,
     placeholderData: (previous) => previous ?? EMPTY_SEARCH_LOCAL_ENTRIES_RESULT,
+    ...EXPENSIVE_READ_CAPACITY_RETRY_OPTIONS,
   });
 }
 
@@ -351,5 +359,6 @@ export function projectSearchContentQueryOptions(input: {
       trimmedQuery.length >= SEARCH_CONTENT_MIN_QUERY_LENGTH,
     staleTime: input.staleTime ?? DEFAULT_SEARCH_CONTENT_STALE_TIME,
     placeholderData: (previous) => previous ?? EMPTY_SEARCH_CONTENT_RESULT,
+    ...EXPENSIVE_READ_CAPACITY_RETRY_OPTIONS,
   });
 }

--- a/apps/web/src/lib/projectReactQuery.ts
+++ b/apps/web/src/lib/projectReactQuery.ts
@@ -14,7 +14,7 @@ import { isLocalAbsolutePath } from "@synara/shared/path";
 import { queryOptions, type QueryClient } from "@tanstack/react-query";
 import { ensureNativeApi } from "~/nativeApi";
 import {
-  EXPENSIVE_READ_CAPACITY_RETRY_OPTIONS,
+  EXPENSIVE_READ_RETRY_OPTIONS,
   expensiveReadErrorRefetchInterval,
 } from "./expensiveReadRetry";
 
@@ -181,20 +181,25 @@ export function projectReadFileQueryOptions(input: {
       : null);
   return queryOptions<ProjectReadFileResult>({
     queryKey: projectQueryKeys.readFile(input.cwd, input.relativePath),
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const api = ensureNativeApi();
       if (!effectiveCwd || !input.relativePath) {
         throw new Error("Workspace file read is unavailable.");
       }
-      return api.projects.readFile({
-        cwd: effectiveCwd,
-        relativePath: input.relativePath,
-        ...(input.previewGrant ? { previewGrant: input.previewGrant } : {}),
-      });
+      return api.projects.readFile(
+        {
+          cwd: effectiveCwd,
+          relativePath: input.relativePath,
+          ...(input.previewGrant ? { previewGrant: input.previewGrant } : {}),
+        },
+        { signal },
+      );
     },
     enabled: (input.enabled ?? true) && effectiveCwd !== null && input.relativePath !== null,
     staleTime: input.staleTime ?? DEFAULT_READ_FILE_STALE_TIME,
-    ...EXPENSIVE_READ_CAPACITY_RETRY_OPTIONS,
+    // File-not-found must surface immediately for out-of-root relocation.
+    // Capacity is retried in-place by the transport; do not stack another budget.
+    retry: false,
     refetchInterval: expensiveReadErrorRefetchInterval,
   });
 }
@@ -296,7 +301,7 @@ export function projectSearchEntriesQueryOptions(input: {
     enabled: (input.enabled ?? true) && input.cwd !== null && input.query.length > 0,
     staleTime: input.staleTime ?? DEFAULT_SEARCH_ENTRIES_STALE_TIME,
     placeholderData: (previous) => previous ?? EMPTY_SEARCH_ENTRIES_RESULT,
-    ...EXPENSIVE_READ_CAPACITY_RETRY_OPTIONS,
+    ...EXPENSIVE_READ_RETRY_OPTIONS,
   });
 }
 
@@ -327,7 +332,7 @@ export function projectSearchLocalEntriesQueryOptions(input: {
     enabled: (input.enabled ?? true) && input.rootPath !== null && trimmedQuery.length >= 2,
     staleTime: input.staleTime ?? DEFAULT_SEARCH_LOCAL_ENTRIES_STALE_TIME,
     placeholderData: (previous) => previous ?? EMPTY_SEARCH_LOCAL_ENTRIES_RESULT,
-    ...EXPENSIVE_READ_CAPACITY_RETRY_OPTIONS,
+    ...EXPENSIVE_READ_RETRY_OPTIONS,
   });
 }
 
@@ -359,6 +364,6 @@ export function projectSearchContentQueryOptions(input: {
       trimmedQuery.length >= SEARCH_CONTENT_MIN_QUERY_LENGTH,
     staleTime: input.staleTime ?? DEFAULT_SEARCH_CONTENT_STALE_TIME,
     placeholderData: (previous) => previous ?? EMPTY_SEARCH_CONTENT_RESULT,
-    ...EXPENSIVE_READ_CAPACITY_RETRY_OPTIONS,
+    ...EXPENSIVE_READ_RETRY_OPTIONS,
   });
 }

--- a/apps/web/src/lib/serverReactQuery.test.ts
+++ b/apps/web/src/lib/serverReactQuery.test.ts
@@ -2,7 +2,7 @@
 // Purpose: Locks down server React Query polling profiles and cache options.
 // Layer: Web data-fetching unit tests
 
-import type { ServerConfig, ServerProviderStatus } from "@synara/contracts";
+import { ThreadId, type ServerConfig, type ServerProviderStatus } from "@synara/contracts";
 import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, it } from "vitest";
 
@@ -16,6 +16,7 @@ import {
   serverProviderUsageSnapshotQueryOptions,
   serverQueryKeys,
   sidebarLocalServersQueryOptions,
+  studioThreadOutputsQueryOptions,
 } from "./serverReactQuery";
 
 const READY_CODEX_STATUS = {
@@ -226,5 +227,26 @@ describe("serverProviderUsageSnapshotQueryOptions", () => {
     });
 
     expect(options.enabled).toBe(false);
+  });
+});
+
+describe("studio thread outputs query options", () => {
+  const capacityError = {
+    code: "RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED",
+    retryable: true,
+    retryAfterMs: 375,
+  };
+
+  it("retries generic output failures without stacking capacity retries", () => {
+    const options = studioThreadOutputsQueryOptions({
+      threadId: ThreadId.makeUnsafe("thread-1"),
+    });
+    expect(typeof options.retry).toBe("function");
+    if (typeof options.retry !== "function") {
+      throw new Error("Expected retry on studioThreadOutputsQueryOptions.");
+    }
+    expect(options.retry(0, capacityError as never)).toBe(false);
+    expect(options.retry(0, new Error("network"))).toBe(true);
+    expect(options.retry(3, new Error("network"))).toBe(false);
   });
 });

--- a/apps/web/src/lib/serverReactQuery.ts
+++ b/apps/web/src/lib/serverReactQuery.ts
@@ -8,6 +8,7 @@ import type {
 } from "@synara/contracts";
 import { mutationOptions, queryOptions, type QueryClient } from "@tanstack/react-query";
 import { ensureNativeApi } from "~/nativeApi";
+import { EXPENSIVE_READ_CAPACITY_RETRY_OPTIONS } from "./expensiveReadRetry";
 
 export const LOCAL_SERVERS_VISIBLE_REFETCH_INTERVAL_MS = 10_000;
 const LOCAL_SERVERS_DEFAULT_STALE_TIME_MS = 3_000;
@@ -263,6 +264,7 @@ export function studioThreadOutputsQueryOptions(input: {
     staleTime: STUDIO_THREAD_OUTPUTS_STALE_TIME_MS,
     refetchOnWindowFocus: true,
     refetchOnReconnect: true,
+    ...EXPENSIVE_READ_CAPACITY_RETRY_OPTIONS,
   });
 }
 

--- a/apps/web/src/lib/serverReactQuery.ts
+++ b/apps/web/src/lib/serverReactQuery.ts
@@ -8,7 +8,7 @@ import type {
 } from "@synara/contracts";
 import { mutationOptions, queryOptions, type QueryClient } from "@tanstack/react-query";
 import { ensureNativeApi } from "~/nativeApi";
-import { EXPENSIVE_READ_CAPACITY_RETRY_OPTIONS } from "./expensiveReadRetry";
+import { EXPENSIVE_READ_RETRY_OPTIONS } from "./expensiveReadRetry";
 
 export const LOCAL_SERVERS_VISIBLE_REFETCH_INTERVAL_MS = 10_000;
 const LOCAL_SERVERS_DEFAULT_STALE_TIME_MS = 3_000;
@@ -264,7 +264,7 @@ export function studioThreadOutputsQueryOptions(input: {
     staleTime: STUDIO_THREAD_OUTPUTS_STALE_TIME_MS,
     refetchOnWindowFocus: true,
     refetchOnReconnect: true,
-    ...EXPENSIVE_READ_CAPACITY_RETRY_OPTIONS,
+    ...EXPENSIVE_READ_RETRY_OPTIONS,
   });
 }
 

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -597,6 +597,37 @@ describe("wsNativeApi", () => {
     });
   });
 
+  it("forwards an abort signal on projects.readFile to the transport", async () => {
+    requestMock.mockResolvedValue({
+      relativePath: "src/app.ts",
+      contents: "export {};\n",
+      truncated: false,
+      version: `sha256:${"1".repeat(64)}`,
+      encoding: "utf8",
+      lineEnding: "lf",
+    });
+    const { createWsNativeApi } = await import("./wsNativeApi");
+    const controller = new AbortController();
+    const api = createWsNativeApi();
+
+    await api.projects.readFile(
+      {
+        cwd: "/tmp/project",
+        relativePath: "src/app.ts",
+      },
+      { signal: controller.signal },
+    );
+
+    expect(requestMock).toHaveBeenCalledWith(
+      WS_METHODS.projectsReadFile,
+      {
+        cwd: "/tmp/project",
+        relativePath: "src/app.ts",
+      },
+      { signal: controller.signal },
+    );
+  });
+
   it("forwards local preview grant creation to the websocket project method", async () => {
     requestMock.mockResolvedValue({
       grant: "grant-token",

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -527,7 +527,10 @@ export function createWsNativeApi(): NativeApi {
       searchContent: (input) => transport.request(WS_METHODS.projectsSearchContent, input),
       prewarmSearchIndex: (input) =>
         transport.request(WS_METHODS.projectsPrewarmSearchIndex, input),
-      readFile: (input) => transport.request(WS_METHODS.projectsReadFile, input),
+      readFile: (input, options) =>
+        options?.signal
+          ? transport.request(WS_METHODS.projectsReadFile, input, { signal: options.signal })
+          : transport.request(WS_METHODS.projectsReadFile, input),
       resolveOutOfRootFileReference: (input) =>
         transport.request(WS_METHODS.projectsResolveOutOfRootFileReference, input),
       createLocalFilePreviewGrant: (input) =>

--- a/apps/web/src/wsTransport.test.ts
+++ b/apps/web/src/wsTransport.test.ts
@@ -33,6 +33,8 @@ import {
   makeNegotiateHttpUrl,
   getResnapshotRetryDelayMs,
   getSnapshotFaultRetryDelayMs,
+  getUnaryRpcCapacityRetryDelayMs,
+  MAX_UNARY_RPC_CAPACITY_RETRY_ATTEMPTS,
   SNAPSHOT_FAULT_RETRY_MS,
   isRuntimeInterruptFailure,
   makeRequestAbortScope,
@@ -703,6 +705,96 @@ describe("WsTransport", () => {
         Cause.fail({ code: "WS_PROTOCOL_INCOMPATIBLE", retryable: false }),
       ),
     ).toBeNull();
+  });
+
+  it("retries capacity-rejected unary requests in place with the server-provided delay", async () => {
+    vi.useFakeTimers();
+    bindWindowTimersToCurrentGlobals();
+    try {
+      const { transport, internals } = makeBareTransport();
+      const capacityError = {
+        code: "RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED",
+        retryable: true,
+        retryAfterMs: 250,
+        message: "WebSocket expensive-read request capacity exceeded.",
+      };
+      const runPromise = vi
+        .fn()
+        .mockRejectedValueOnce(capacityError)
+        .mockResolvedValueOnce({ contents: "ok" });
+      Object.assign(internals, {
+        getClient: vi.fn(async () => ({
+          "projects.readFile": () => Effect.succeed({ contents: "ok" }),
+        })),
+        getClientRuntime: () => ({ runPromise }),
+      });
+
+      const pending = transport.request(WS_METHODS.projectsReadFile, {}, { timeoutMs: null });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(runPromise).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(249);
+      expect(runPromise).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(pending).resolves.toEqual({ contents: "ok" });
+      expect(runPromise).toHaveBeenCalledTimes(2);
+      expect(getUnaryRpcCapacityRetryDelayMs(capacityError, 0)).toBe(250);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops retrying a unary capacity rejection after the bounded attempt budget", async () => {
+    vi.useFakeTimers();
+    bindWindowTimersToCurrentGlobals();
+    try {
+      const { transport, internals } = makeBareTransport();
+      const capacityError = {
+        code: "RPC_REQUEST_CAPACITY_EXCEEDED",
+        retryable: true,
+        retryAfterMs: 250,
+        message: "WebSocket standard request capacity exceeded.",
+      };
+      const runPromise = vi.fn().mockRejectedValue(capacityError);
+      Object.assign(internals, {
+        getClient: vi.fn(async () => ({
+          "projects.readFile": () => Effect.succeed({ contents: "ok" }),
+        })),
+        getClientRuntime: () => ({ runPromise }),
+      });
+
+      const pending = transport.request(WS_METHODS.projectsReadFile, {}, { timeoutMs: null });
+      const rejected = expect(pending).rejects.toMatchObject({
+        code: "RPC_REQUEST_CAPACITY_EXCEEDED",
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      for (let attempt = 0; attempt < MAX_UNARY_RPC_CAPACITY_RETRY_ATTEMPTS; attempt += 1) {
+        await vi.advanceTimersByTimeAsync(250);
+      }
+
+      await rejected;
+      expect(runPromise).toHaveBeenCalledTimes(MAX_UNARY_RPC_CAPACITY_RETRY_ATTEMPTS + 1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not retry a non-capacity unary failure in place", async () => {
+    const { transport, internals } = makeBareTransport();
+    const failure = new Error("file missing");
+    const runPromise = vi.fn().mockRejectedValue(failure);
+    Object.assign(internals, {
+      getClient: vi.fn(async () => ({
+        "projects.readFile": () => Effect.succeed({ contents: "ok" }),
+      })),
+      getClientRuntime: () => ({ runPromise }),
+    });
+
+    await expect(
+      transport.request(WS_METHODS.projectsReadFile, {}, { timeoutMs: null }),
+    ).rejects.toBe(failure);
+    expect(runPromise).toHaveBeenCalledTimes(1);
   });
 
   it("backs off unexpected normal stream completions with a bounded delay", () => {

--- a/apps/web/src/wsTransport.test.ts
+++ b/apps/web/src/wsTransport.test.ts
@@ -780,6 +780,49 @@ describe("WsTransport", () => {
     }
   });
 
+  it("aborts an in-place unary capacity retry when the request signal aborts", async () => {
+    vi.useFakeTimers();
+    bindWindowTimersToCurrentGlobals();
+    try {
+      const { transport, internals } = makeBareTransport();
+      const capacityError = {
+        code: "RPC_EXPENSIVE_READ_CAPACITY_EXCEEDED",
+        retryable: true,
+        retryAfterMs: 250,
+        message: "WebSocket expensive-read request capacity exceeded.",
+      };
+      const runPromise = vi.fn().mockRejectedValue(capacityError);
+      Object.assign(internals, {
+        getClient: vi.fn(async () => ({
+          "projects.readFile": () => Effect.succeed({ contents: "ok" }),
+        })),
+        getClientRuntime: () => ({ runPromise }),
+      });
+
+      const controller = new AbortController();
+      const pending = transport.request(
+        WS_METHODS.projectsReadFile,
+        {},
+        {
+          timeoutMs: null,
+          signal: controller.signal,
+        },
+      );
+      const rejected = expect(pending).rejects.toMatchObject({
+        code: "WS_REQUEST_ABORTED",
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(runPromise).toHaveBeenCalledTimes(1);
+
+      controller.abort();
+      await rejected;
+      await vi.advanceTimersByTimeAsync(250);
+      expect(runPromise).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not retry a non-capacity unary failure in place", async () => {
     const { transport, internals } = makeBareTransport();
     const failure = new Error("file missing");

--- a/apps/web/src/wsTransport.ts
+++ b/apps/web/src/wsTransport.ts
@@ -65,6 +65,10 @@ import * as Socket from "effect/unstable/socket/Socket";
 import { APP_VERSION } from "./branding";
 import { useDeviceStateStore } from "./deviceStateStore";
 import {
+  getUnaryRpcCapacityRetryDelayMs,
+  MAX_UNARY_RPC_CAPACITY_RETRY_ATTEMPTS,
+} from "./lib/expensiveReadRetry";
+import {
   buildThreadSubscribeInput,
   clearThreadDetailResumeCursor,
   resetThreadDetailResumeCursors,
@@ -224,6 +228,13 @@ function delayWithAbort(ms: number, signal: AbortSignal): Promise<void> {
       signal.removeEventListener("abort", onAbort);
     };
     signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function delayMs(ms: number, signal: AbortSignal | undefined): Promise<void> {
+  if (signal) return delayWithAbort(ms, signal);
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
   });
 }
 
@@ -456,6 +467,8 @@ export function getUnexpectedStreamCompletionRetryDelayMs(attempt: number): numb
     MAX_UNEXPECTED_STREAM_COMPLETION_RETRY_MS,
   );
 }
+
+export { getUnaryRpcCapacityRetryDelayMs, MAX_UNARY_RPC_CAPACITY_RETRY_ATTEMPTS };
 
 /**
  * Capacity rejections are admission failures the server marks retryable: the
@@ -822,10 +835,18 @@ export class WsTransport {
       )[method];
       if (!call) throw new WsTransportRpcError({ message: `Unknown RPC method: ${method}` });
       const clientRuntime = this.getClientRuntime(client);
-      return (await clientRuntime.runPromise(
-        call(normalizedRpcInput),
-        abortScope.signal ? { signal: abortScope.signal } : undefined,
-      )) as T;
+      const runOptions = abortScope.signal ? { signal: abortScope.signal } : undefined;
+      let capacityAttempts = 0;
+      while (true) {
+        try {
+          return (await clientRuntime.runPromise(call(normalizedRpcInput), runOptions)) as T;
+        } catch (error) {
+          const retryDelayMs = getUnaryRpcCapacityRetryDelayMs(error, capacityAttempts);
+          if (retryDelayMs === null) throw error;
+          capacityAttempts += 1;
+          await delayMs(retryDelayMs, abortScope.signal);
+        }
+      }
     } catch (error) {
       if (abortScope.didTimeout()) {
         throw new WsTransportRequestInterruptedError({

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -685,7 +685,10 @@ export interface NativeApi {
     prewarmSearchIndex: (
       input: ProjectPrewarmSearchIndexInput,
     ) => Promise<ProjectPrewarmSearchIndexResult>;
-    readFile: (input: ProjectReadFileInput) => Promise<ProjectReadFileResult>;
+    readFile: (
+      input: ProjectReadFileInput,
+      options?: { readonly signal?: AbortSignal },
+    ) => Promise<ProjectReadFileResult>;
     resolveOutOfRootFileReference: (
       input: ProjectResolveOutOfRootFileReferenceInput,
     ) => Promise<ProjectResolveOutOfRootFileReferenceResult>;


### PR DESCRIPTION
Fixes #778

The right-dock file preview blanked to `WebSocket expensive-read request capacity exceeded` during agent edit bursts. Server admission (2 expensive-read slots, `retryable` + `retryAfterMs: 250`) is working as designed; the client treated capacity rejections as hard failures and rendered `error` over retained file contents.

## What changed
- Unary WS retries honor `retryable` / `retryAfterMs` for capacity errors (single budget in transport, not stacked under query retries).
- Preview keeps last-good contents and demotes the failure to a delayed-refresh hint.
- File reads self-heal with a bounded error-only refetch interval.
- In-flight reads abort with Query’s `AbortSignal` on invalidate.
- Search/studio keep generic retries; file-not-found still fails immediately for relocation.

## Test plan
- [ ] Open a workspace file in the right-dock preview, run a turn that edits many files including that one — preview should keep contents, not the raw capacity error.
