### PR TITLE
Handoff floating browser to the sidebar and keep agent clicks reliable

### DIFF
--- a/apps/desktop/scripts/dev-electron.mjs
+++ b/apps/desktop/scripts/dev-electron.mjs
@@ -12,12 +12,13 @@ const requiredFiles = [
   "dist-electron/main.js",
   "dist-electron/preload.js",
   "dist-electron/guestPreload.js",
+  "dist-electron/floatingBrowserChromePreload.js",
   "../server/dist/index.mjs",
 ];
 const watchedDirectories = [
   {
     directory: "dist-electron",
-    files: new Set(["main.js", "preload.js", "guestPreload.js"]),
+    files: new Set(["main.js", "preload.js", "guestPreload.js", "floatingBrowserChromePreload.js"]),
   },
   { directory: "../server/dist", files: new Set(["index.mjs"]) },
 ];

--- a/apps/desktop/src/browserAnnotations/coordinator.test.ts
+++ b/apps/desktop/src/browserAnnotations/coordinator.test.ts
@@ -517,4 +517,71 @@ describe("BrowserAnnotationCoordinator", () => {
       restartedHarness.coordinator.resolveNavigationTarget(THREAD_ID, "annotation-private", TAB_ID),
     ).toEqual({ tabId: TAB_ID, liveUrl: firstLiveUrl });
   });
+
+  it("replays a guest ready that arrived before the webview was bound", () => {
+    let bound = false;
+    const sent: Array<{ channel: string; payload: Record<string, unknown> }> = [];
+    const webContents = {
+      id: 77,
+      isDestroyed: () => false,
+      getURL: () => "https://example.test/app",
+      send: (channel: string, payload: Record<string, unknown>) => {
+        sent.push({ channel, payload });
+      },
+    } as unknown as WebContents;
+    const runtime = { threadId: THREAD_ID, tabId: TAB_ID, webContents };
+    const coordinator = new BrowserAnnotationCoordinator({
+      resolveVisibleRuntime: () => runtime,
+      resolveRuntimeByWebContentsId: (id) => (bound && id === webContents.id ? runtime : null),
+      markHumanControl: vi.fn(),
+    });
+
+    coordinator.handleGuestMessage(webContents, {
+      version: 1,
+      kind: "ready",
+      documentToken: "early-document",
+      source: { url: "https://example.test/app", pageTitle: "Page" },
+    });
+    expect(() =>
+      coordinator.start({
+        threadId: THREAD_ID,
+        tabId: TAB_ID,
+        theme: LIGHT_ANNOTATION_THEME,
+      }),
+    ).toThrow(/not ready/i);
+
+    bound = true;
+    coordinator.adoptAttachedWebContents(webContents);
+    expect(() =>
+      coordinator.start({
+        threadId: THREAD_ID,
+        tabId: TAB_ID,
+        theme: LIGHT_ANNOTATION_THEME,
+      }),
+    ).not.toThrow();
+  });
+
+  it("asks the guest to announce after a same-guest runtime replace", () => {
+    const harness = createHarness();
+    harness.ready("document-a");
+    harness.coordinator.handleRuntimeDetached(THREAD_ID, TAB_ID, harness.webContents.id, "replaced");
+    expect(() =>
+      harness.coordinator.start({
+        threadId: THREAD_ID,
+        tabId: TAB_ID,
+        theme: LIGHT_ANNOTATION_THEME,
+      }),
+    ).toThrow(/not ready/i);
+
+    harness.coordinator.requestDocumentReady(THREAD_ID, TAB_ID, harness.webContents.id);
+    expect(harness.sent.at(-1)?.payload).toMatchObject({ kind: "announce-ready" });
+    harness.ready("document-a");
+    expect(() =>
+      harness.coordinator.start({
+        threadId: THREAD_ID,
+        tabId: TAB_ID,
+        theme: LIGHT_ANNOTATION_THEME,
+      }),
+    ).not.toThrow();
+  });
 });

--- a/apps/desktop/src/browserAnnotations/coordinator.test.ts
+++ b/apps/desktop/src/browserAnnotations/coordinator.test.ts
@@ -564,7 +564,12 @@ describe("BrowserAnnotationCoordinator", () => {
   it("asks the guest to announce after a same-guest runtime replace", () => {
     const harness = createHarness();
     harness.ready("document-a");
-    harness.coordinator.handleRuntimeDetached(THREAD_ID, TAB_ID, harness.webContents.id, "replaced");
+    harness.coordinator.handleRuntimeDetached(
+      THREAD_ID,
+      TAB_ID,
+      harness.webContents.id,
+      "replaced",
+    );
     expect(() =>
       harness.coordinator.start({
         threadId: THREAD_ID,
@@ -576,6 +581,26 @@ describe("BrowserAnnotationCoordinator", () => {
     harness.coordinator.requestDocumentReady(THREAD_ID, TAB_ID, harness.webContents.id);
     expect(harness.sent.at(-1)?.payload).toMatchObject({ kind: "announce-ready" });
     harness.ready("document-a");
+    expect(() =>
+      harness.coordinator.start({
+        threadId: THREAD_ID,
+        tabId: TAB_ID,
+        theme: LIGHT_ANNOTATION_THEME,
+      }),
+    ).not.toThrow();
+  });
+
+  it("refreshes an already-ready overlay when the same guest rebinds", () => {
+    const harness = createHarness();
+    harness.ready("document-a");
+    harness.sent.length = 0;
+
+    harness.coordinator.requestDocumentReady(THREAD_ID, TAB_ID, harness.webContents.id);
+
+    expect(harness.sent.at(-1)?.payload).toMatchObject({
+      kind: "refresh-document",
+      documentToken: "document-a",
+    });
     expect(() =>
       harness.coordinator.start({
         threadId: THREAD_ID,

--- a/apps/desktop/src/browserAnnotations/coordinator.ts
+++ b/apps/desktop/src/browserAnnotations/coordinator.ts
@@ -24,6 +24,7 @@ import {
   parseAnnotationGuestMessage,
   parseBrowserAnnotationTheme,
   parseBrowserAnnotationMarkers,
+  type AnnotationGuestCommand,
 } from "./protocol";
 
 export interface BrowserAnnotationRuntime {
@@ -94,6 +95,7 @@ export class BrowserAnnotationCoordinator {
   private readonly sessionsByRuntimeKey = new Map<string, ActiveSession>();
   private readonly projectionsByRuntimeKey = new Map<string, MarkerProjection>();
   private readonly invalidatedDocumentRuntimeKeys = new Set<string>();
+  private readonly pendingReadyByWebContentsId = new Map<number, unknown>();
   private readonly listeners = new Set<BrowserAnnotationEventListener>();
   private readonly committedAnnotationIds = new Set<string>();
   private readonly affinityByAnnotationId = new Map<string, BrowserAnnotationAffinity>();
@@ -210,7 +212,14 @@ export class BrowserAnnotationCoordinator {
 
   handleGuestMessage(sender: WebContents, rawMessage: unknown): void {
     const runtime = this.options.resolveRuntimeByWebContentsId(sender.id);
-    if (!runtime || runtime.webContents !== sender || sender.isDestroyed()) return;
+    if (!runtime || runtime.webContents !== sender || sender.isDestroyed()) {
+      const message = parseAnnotationGuestMessage(rawMessage);
+      if (message?.kind === "ready" && !sender.isDestroyed()) {
+        this.pendingReadyByWebContentsId.set(sender.id, rawMessage);
+      }
+      return;
+    }
+    this.pendingReadyByWebContentsId.delete(sender.id);
     const message = parseAnnotationGuestMessage(rawMessage);
     if (!message) return;
     const key = runtimeKey(runtime.threadId, runtime.tabId);
@@ -371,20 +380,51 @@ export class BrowserAnnotationCoordinator {
   recoverNavigation(threadId: ThreadId, tabId: string, webContentsId: number): void {
     const key = runtimeKey(threadId, tabId);
     if (!this.invalidatedDocumentRuntimeKeys.has(key)) return;
-    const documentState = this.documentsByRuntimeKey.get(key);
+    this.requestDocumentReady(threadId, tabId, webContentsId);
+  }
+
+  /**
+   * Replays a guest `ready` that arrived before this WebContents was bound to a
+   * logical tab, then asks the overlay to announce again when that handshake was
+   * lost (handoff, zoom, or a runtime replace of the same guest).
+   */
+  adoptAttachedWebContents(webContents: WebContents): void {
+    const pending = this.pendingReadyByWebContentsId.get(webContents.id);
+    if (pending === undefined) return;
+    this.pendingReadyByWebContentsId.delete(webContents.id);
+    this.handleGuestMessage(webContents, pending);
+  }
+
+  requestDocumentReady(threadId: ThreadId, tabId: string, webContentsId: number): void {
     const runtime = this.options.resolveRuntimeByWebContentsId(webContentsId);
     if (
-      !documentState ||
-      documentState.webContentsId !== webContentsId ||
       !runtime ||
+      runtime.threadId !== threadId ||
+      runtime.tabId !== tabId ||
       runtime.webContents.isDestroyed()
     ) {
       return;
     }
-    runtime.webContents.send(BROWSER_ANNOTATION_GUEST_COMMAND_CHANNEL, {
+    const key = runtimeKey(threadId, tabId);
+    const documentState = this.documentsByRuntimeKey.get(key);
+    if (
+      documentState &&
+      documentState.webContentsId === webContentsId &&
+      !this.invalidatedDocumentRuntimeKeys.has(key)
+    ) {
+      return;
+    }
+    if (documentState && documentState.webContentsId === webContentsId) {
+      this.sendGuestCommand(runtime, {
+        version: BROWSER_ANNOTATION_PROTOCOL_VERSION,
+        kind: "refresh-document",
+        documentToken: documentState.document.token,
+      });
+      return;
+    }
+    this.sendGuestCommand(runtime, {
       version: BROWSER_ANNOTATION_PROTOCOL_VERSION,
-      kind: "refresh-document",
-      documentToken: documentState.document.token,
+      kind: "announce-ready",
     });
   }
 
@@ -420,6 +460,9 @@ export class BrowserAnnotationCoordinator {
       this.documentsByRuntimeKey.delete(key);
     }
     this.invalidatedDocumentRuntimeKeys.delete(key);
+    if (reason === "destroyed") {
+      this.pendingReadyByWebContentsId.delete(webContentsId);
+    }
   }
 
   clearProjection(threadId: ThreadId, tabId: string): void {
@@ -434,9 +477,24 @@ export class BrowserAnnotationCoordinator {
     this.documentsByRuntimeKey.clear();
     this.projectionsByRuntimeKey.clear();
     this.invalidatedDocumentRuntimeKeys.clear();
+    this.pendingReadyByWebContentsId.clear();
     this.listeners.clear();
     this.committedAnnotationIds.clear();
     this.affinityByAnnotationId.clear();
+  }
+
+  private sendGuestCommand(
+    runtime: BrowserAnnotationRuntime,
+    command: AnnotationGuestCommand,
+  ): void {
+    if (runtime.webContents.isDestroyed() || typeof runtime.webContents.send !== "function") {
+      return;
+    }
+    try {
+      runtime.webContents.send(BROWSER_ANNOTATION_GUEST_COMMAND_CHANNEL, command);
+    } catch {
+      // The guest can disappear between attach and overlay handshake.
+    }
   }
 
   private finishSession(

--- a/apps/desktop/src/browserAnnotations/coordinator.ts
+++ b/apps/desktop/src/browserAnnotations/coordinator.ts
@@ -407,13 +407,6 @@ export class BrowserAnnotationCoordinator {
     }
     const key = runtimeKey(threadId, tabId);
     const documentState = this.documentsByRuntimeKey.get(key);
-    if (
-      documentState &&
-      documentState.webContentsId === webContentsId &&
-      !this.invalidatedDocumentRuntimeKeys.has(key)
-    ) {
-      return;
-    }
     if (documentState && documentState.webContentsId === webContentsId) {
       this.sendGuestCommand(runtime, {
         version: BROWSER_ANNOTATION_PROTOCOL_VERSION,

--- a/apps/desktop/src/browserAnnotations/guestPreload.ts
+++ b/apps/desktop/src/browserAnnotations/guestPreload.ts
@@ -1391,7 +1391,13 @@ function initializeOverlay(): void {
 }
 
 ipcRenderer.on(BROWSER_ANNOTATION_GUEST_COMMAND_CHANNEL, (_event, rawCommand: unknown) => {
-  if (!isGuestAnnotationCommand(rawCommand) || rawCommand.documentToken !== documentToken) return;
+  if (!isGuestAnnotationCommand(rawCommand)) return;
+  if (rawCommand.kind === "announce-ready") {
+    if (host) sendReady();
+    else initializeOverlay();
+    return;
+  }
+  if (rawCommand.documentToken !== documentToken) return;
   initializeOverlay();
   if (rawCommand.kind === "start") {
     activeSession = { sessionId: rawCommand.sessionId };

--- a/apps/desktop/src/browserAnnotations/guestProtocol.ts
+++ b/apps/desktop/src/browserAnnotations/guestProtocol.ts
@@ -71,11 +71,13 @@ function validMarker(value: unknown): value is BrowserAnnotationMarker {
 }
 
 export function isGuestAnnotationCommand(value: unknown): value is AnnotationGuestCommand {
-  if (
-    !isRecord(value) ||
-    value.version !== GUEST_ANNOTATION_PROTOCOL_VERSION ||
-    !validIdentifier(value.documentToken)
-  ) {
+  if (!isRecord(value) || value.version !== GUEST_ANNOTATION_PROTOCOL_VERSION) {
+    return false;
+  }
+  if (value.kind === "announce-ready") {
+    return true;
+  }
+  if (!validIdentifier(value.documentToken)) {
     return false;
   }
   if (value.kind === "start") {

--- a/apps/desktop/src/browserAnnotations/protocol.test.ts
+++ b/apps/desktop/src/browserAnnotations/protocol.test.ts
@@ -67,6 +67,7 @@ describe("browser annotation protocol", () => {
         theme,
       }),
     ).toBe(true);
+    expect(isGuestAnnotationCommand({ version: 1, kind: "announce-ready" })).toBe(true);
     expect(
       parseBrowserAnnotationTheme({
         ...theme,

--- a/apps/desktop/src/browserAnnotations/protocol.ts
+++ b/apps/desktop/src/browserAnnotations/protocol.ts
@@ -81,6 +81,10 @@ export type AnnotationGuestCommand =
       readonly version: 1;
       readonly kind: "refresh-document";
       readonly documentToken: string;
+    }
+  | {
+      readonly version: 1;
+      readonly kind: "announce-ready";
     };
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/desktop/src/browserAnnotations/webviewSecurity.ts
+++ b/apps/desktop/src/browserAnnotations/webviewSecurity.ts
@@ -1,6 +1,6 @@
 import type { WebPreferences } from "electron";
 
-export function hardenBrowserAnnotationWebviewPreferences(input: {
+export function hardenIsolatedWebviewPreferences(input: {
   readonly partition: string;
   readonly expectedPartition: string;
   readonly preloadPath: string;
@@ -16,4 +16,13 @@ export function hardenBrowserAnnotationWebviewPreferences(input: {
   input.webPreferences.webSecurity = true;
   input.webPreferences.allowRunningInsecureContent = false;
   return true;
+}
+
+export function hardenBrowserAnnotationWebviewPreferences(input: {
+  readonly partition: string;
+  readonly expectedPartition: string;
+  readonly preloadPath: string;
+  readonly webPreferences: WebPreferences;
+}): boolean {
+  return hardenIsolatedWebviewPreferences(input);
 }

--- a/apps/desktop/src/browserAutomation/browserManagerAutomation.test.ts
+++ b/apps/desktop/src/browserAutomation/browserManagerAutomation.test.ts
@@ -170,6 +170,7 @@ describe("DesktopBrowserManager automation runtime boundary", () => {
       threadId: THREAD_ID,
       surface: "renderer",
       bounds: { x: 40, y: 80, width: 320, height: 220 },
+      pageZoomFactor: 0.25,
     });
     expect(nativeWebContents.close).not.toHaveBeenCalled();
     expect(nativeView.setVisible).toHaveBeenCalledWith(false);
@@ -186,6 +187,7 @@ describe("DesktopBrowserManager automation runtime boundary", () => {
       { threadId: THREAD_ID, tabId: opened.activeTabId!, webContentsId: 202 },
       41,
     );
+    expect(guest.setZoomFactor).toHaveBeenLastCalledWith(0.25);
     expect(nativeWebContents.close).toHaveBeenCalled();
     expect(
       manager.getVisibleAutomationRuntime({ threadId: THREAD_ID, tabId: opened.activeTabId! })

--- a/apps/desktop/src/browserAutomation/browserManagerAutomation.test.ts
+++ b/apps/desktop/src/browserAutomation/browserManagerAutomation.test.ts
@@ -75,7 +75,11 @@ class FakeWebContents extends EventEmitter {
   canGoForward = () => false;
   close = vi.fn();
   loadURL = vi.fn(() => Promise.resolve());
-  setZoomFactor = vi.fn();
+  zoomFactor = 1;
+  setZoomFactor = vi.fn((value: number) => {
+    this.zoomFactor = value;
+  });
+  getZoomFactor = () => this.zoomFactor;
 }
 
 describe("DesktopBrowserManager automation runtime boundary", () => {
@@ -781,6 +785,62 @@ describe("DesktopBrowserManager automation runtime boundary", () => {
     );
     expect(manager.getAutomationHumanControlEpoch(THREAD_ID)).toBe(2);
     releaseUnmatched();
+  });
+
+  it("does not classify a zoomed agent click as human when Electron reports widget DIPs", () => {
+    const manager = new DesktopBrowserManager();
+    const prepared = manager.prepareAutomationTab({ threadId: THREAD_ID, reuse: true });
+    const tabId = prepared.activeTabId!;
+    const webContents = new FakeWebContents();
+    webContents.zoomFactor = 0.25;
+    const runtime = {
+      key: `${THREAD_ID}:${tabId}`,
+      threadId: THREAD_ID,
+      tabId,
+      webContents: webContents as unknown as WebContents,
+      view: null,
+      ownsWebContents: false as const,
+      listenerDisposers: [] as Array<() => void>,
+    };
+    const access = manager as unknown as {
+      runtimes: Map<string, typeof runtime>;
+      configureRuntimeWebContents(value: typeof runtime): void;
+    };
+    access.runtimes.set(runtime.key, runtime);
+    access.configureRuntimeWebContents(runtime);
+    const visible = manager.getVisibleAutomationRuntime({ threadId: THREAD_ID, tabId });
+
+    const releasePointer = visible.expectAgentInput!({
+      kind: "mouse",
+      type: "mouseDown",
+      button: "left",
+      x: 640,
+      y: 400,
+    });
+    webContents.emit(
+      "before-mouse-event",
+      {},
+      {
+        type: "mouseDown",
+        button: "left",
+        x: 160,
+        y: 100,
+      },
+    );
+    expect(manager.getAutomationHumanControlEpoch(THREAD_ID)).toBe(0);
+    releasePointer();
+
+    webContents.emit(
+      "before-mouse-event",
+      {},
+      {
+        type: "mouseDown",
+        button: "left",
+        x: 40,
+        y: 40,
+      },
+    );
+    expect(manager.getAutomationHumanControlEpoch(THREAD_ID)).toBe(1);
   });
 
   it("keeps an agent-owned native runtime when its tab is reselected", async () => {

--- a/apps/desktop/src/browserManager.ts
+++ b/apps/desktop/src/browserManager.ts
@@ -377,9 +377,39 @@ function normalizeAutomationKey(value: string): string {
   return value.length === 1 ? value.toLocaleLowerCase("en-US") : value;
 }
 
+const AUTOMATION_MOUSE_CSS_TOLERANCE_PX = 1.5;
+const AUTOMATION_MOUSE_DIP_TOLERANCE_PX = 2;
+
+function mouseCoordinatesMatch(
+  expectedX: number,
+  expectedY: number,
+  actualX: number,
+  actualY: number,
+  pageZoomFactor: number,
+): boolean {
+  if (
+    Math.abs(expectedX - actualX) <= AUTOMATION_MOUSE_CSS_TOLERANCE_PX &&
+    Math.abs(expectedY - actualY) <= AUTOMATION_MOUSE_CSS_TOLERANCE_PX
+  ) {
+    return true;
+  }
+  const zoom =
+    Number.isFinite(pageZoomFactor) && pageZoomFactor > 0 ? pageZoomFactor : 1;
+  if (Math.abs(zoom - 1) < 0.001) {
+    return false;
+  }
+  // CDP/actionability points are CSS layout pixels. Electron's before-mouse-event
+  // reports widget DIPs, which shrink with page zoom on the floating card.
+  return (
+    Math.abs(expectedX * zoom - actualX) <= AUTOMATION_MOUSE_DIP_TOLERANCE_PX &&
+    Math.abs(expectedY * zoom - actualY) <= AUTOMATION_MOUSE_DIP_TOLERANCE_PX
+  );
+}
+
 function browserAutomationInputMatches(
   expected: BrowserAutomationExpectedInput,
   actual: BrowserAutomationExpectedInput,
+  pageZoomFactor = 1,
 ): boolean {
   if (expected.kind !== actual.kind) return false;
   if (expected.kind === "key" && actual.kind === "key") {
@@ -395,8 +425,7 @@ function browserAutomationInputMatches(
   return (
     expected.type === actual.type &&
     (expected.button === undefined || expected.button === actual.button) &&
-    Math.abs(expected.x - actual.x) <= 1.5 &&
-    Math.abs(expected.y - actual.y) <= 1.5
+    mouseCoordinatesMatch(expected.x, expected.y, actual.x, actual.y, pageZoomFactor)
   );
 }
 
@@ -3253,6 +3282,26 @@ export class DesktopBrowserManager {
     }
   }
 
+  private resolveAutomationPageZoomFactor(threadId: ThreadId, tabId: string): number {
+    const key = buildRuntimeKey(threadId, tabId);
+    const runtime = this.runtimes.get(key);
+    if (runtime && !runtime.webContents.isDestroyed()) {
+      try {
+        const live = runtime.webContents.getZoomFactor();
+        if (typeof live === "number" && Number.isFinite(live) && live > 0) {
+          return live;
+        }
+      } catch {
+        // The guest may be mid-teardown while a late native event is delivered.
+      }
+    }
+    const stored = this.runtimePageZoomFactors.get(key);
+    if (typeof stored === "number" && stored > 0) {
+      return stored;
+    }
+    return this.getVisiblePageZoomFactor(threadId);
+  }
+
   private consumeExpectedAutomationInput(
     threadId: ThreadId,
     tabId: string,
@@ -3264,7 +3313,11 @@ export class DesktopBrowserManager {
       (entry) => entry.expiresAt > now,
     );
     const matchedIndex = pending.findIndex((entry) =>
-      browserAutomationInputMatches(entry.signal, signal),
+      browserAutomationInputMatches(
+        entry.signal,
+        signal,
+        this.resolveAutomationPageZoomFactor(threadId, tabId),
+      ),
     );
     if (matchedIndex < 0) {
       if (pending.length === 0) this.expectedAutomationInputsByRuntimeKey.delete(key);

--- a/apps/desktop/src/browserManager.ts
+++ b/apps/desktop/src/browserManager.ts
@@ -1599,11 +1599,7 @@ export class DesktopBrowserManager {
       // WebContents until attachWebview adopts the guest. Destroying here drops
       // CDP and makes every in-flight agent tool miss the host.
       this.promoteTabToRendererSurface(input.threadId, activeTabId);
-      this.activateThreadForPendingRenderer(
-        input.threadId,
-        nextBounds,
-        nextPageZoomFactor,
-      );
+      this.activateThreadForPendingRenderer(input.threadId, nextBounds, nextPageZoomFactor);
       this.attachRuntime(activeRuntime, nextBounds, nextPageZoomFactor);
       return;
     }

--- a/apps/desktop/src/browserManager.ts
+++ b/apps/desktop/src/browserManager.ts
@@ -1599,7 +1599,12 @@ export class DesktopBrowserManager {
       // WebContents until attachWebview adopts the guest. Destroying here drops
       // CDP and makes every in-flight agent tool miss the host.
       this.promoteTabToRendererSurface(input.threadId, activeTabId);
-      this.activateThreadForPendingRenderer(input.threadId, nextBounds, 1);
+      this.activateThreadForPendingRenderer(
+        input.threadId,
+        nextBounds,
+        nextPageZoomFactor,
+      );
+      this.attachRuntime(activeRuntime, nextBounds, nextPageZoomFactor);
       return;
     }
 
@@ -1728,7 +1733,7 @@ export class DesktopBrowserManager {
     const bounds = this.getVisibleBoundsForThread(input.threadId);
     const runtime = this.runtimes.get(key);
     if (runtime && bounds) {
-      this.attachRuntime(runtime, bounds);
+      this.attachRuntime(runtime, bounds, this.getVisiblePageZoomFactor(input.threadId));
     }
 
     const expectedUrl = normalizeUrlInput(tab.lastCommittedUrl ?? tab.url);
@@ -2131,10 +2136,6 @@ export class DesktopBrowserManager {
 
   private setRuntimePageZoomFactor(runtime: LiveTabRuntime, pageZoomFactor: number): void {
     const nextPageZoomFactor = normalizeBrowserPageZoomFactor(pageZoomFactor);
-    if (this.runtimePageZoomFactors.get(runtime.key) === nextPageZoomFactor) {
-      return;
-    }
-
     try {
       runtime.webContents.setZoomFactor(nextPageZoomFactor);
     } catch {
@@ -2779,6 +2780,9 @@ export class DesktopBrowserManager {
     const didStopLoading = () => {
       this.queueRuntimeStateSync(threadId, tabId);
       this.annotations.recoverNavigation(threadId, tabId, webContents.id);
+      if (this.activeThreadId === threadId) {
+        this.setRuntimePageZoomFactor(runtime, this.getVisiblePageZoomFactor(threadId));
+      }
     };
     webContents.on("did-stop-loading", didStopLoading);
     runtime.listenerDisposers.push(() => {

--- a/apps/desktop/src/browserManager.ts
+++ b/apps/desktop/src/browserManager.ts
@@ -393,8 +393,7 @@ function mouseCoordinatesMatch(
   ) {
     return true;
   }
-  const zoom =
-    Number.isFinite(pageZoomFactor) && pageZoomFactor > 0 ? pageZoomFactor : 1;
+  const zoom = Number.isFinite(pageZoomFactor) && pageZoomFactor > 0 ? pageZoomFactor : 1;
   if (Math.abs(zoom - 1) < 0.001) {
     return false;
   }

--- a/apps/desktop/src/browserManager.ts
+++ b/apps/desktop/src/browserManager.ts
@@ -1736,6 +1736,12 @@ export class DesktopBrowserManager {
       this.attachRuntime(runtime, bounds, this.getVisiblePageZoomFactor(input.threadId));
     }
 
+    // Guest `ready` can fire before this bind, and zoom/reparent can invalidate
+    // the overlay without a real navigation. Re-adopt or re-ask so annotate
+    // does not stay stuck on "page is not ready".
+    this.annotations.adoptAttachedWebContents(webContents);
+    this.annotations.requestDocumentReady(input.threadId, tab.id, webContents.id);
+
     const expectedUrl = normalizeUrlInput(tab.lastCommittedUrl ?? tab.url);
     const requiresLocalPreviewBootstrap =
       isLocalFileUrl(expectedUrl) &&
@@ -2807,13 +2813,22 @@ export class DesktopBrowserManager {
 
     const didStartNavigation = (
       _event: Electron.Event,
-      _url: string,
-      _isInPlace: boolean,
+      url: string,
+      isInPlace: boolean,
       isMainFrame: boolean,
     ) => {
-      if (isMainFrame && !_isInPlace) {
-        this.annotations.handleNavigation(threadId, tabId, webContents.id);
+      if (!isMainFrame || isInPlace) {
+        return;
       }
+      const state = this.states.get(threadId);
+      const tab = state ? this.getTab(state, tabId) : null;
+      const committedUrl = tab ? normalizeUrlInput(tab.lastCommittedUrl ?? tab.url) : "";
+      // Zoom and webview reparent can emit a main-frame start for the current
+      // URL. Invalidating then would leave annotate stuck until a real load.
+      if (committedUrl !== "" && normalizeUrlInput(url) === committedUrl) {
+        return;
+      }
+      this.annotations.handleNavigation(threadId, tabId, webContents.id);
     };
     webContents.on("did-start-navigation", didStartNavigation);
     runtime.listenerDisposers.push(() => {

--- a/apps/desktop/src/floatingBrowserChromePreload.ts
+++ b/apps/desktop/src/floatingBrowserChromePreload.ts
@@ -1,0 +1,17 @@
+// FILE: floatingBrowserChromePreload.ts
+// Purpose: Lets the floating-card chrome webview talk to its embedder.
+// Layer: Desktop webview preload
+// Depends on: Electron contextBridge
+
+import { contextBridge, ipcRenderer } from "electron";
+
+contextBridge.exposeInMainWorld("synaraFloatingChrome", {
+  send(type: string, payload?: unknown) {
+    ipcRenderer.sendToHost(type, payload ?? null);
+  },
+  onHost(listener: (payload: unknown) => void) {
+    ipcRenderer.on("synara-floating-chrome-host", (_event, payload: unknown) => {
+      listener(payload);
+    });
+  },
+});

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -249,7 +249,8 @@ import {
 } from "./desktopStorageMigration";
 import { DESKTOP_IPC_CHANNELS } from "./ipcChannels";
 import { DesktopAppSnapManager } from "./appSnapManager";
-import { hardenBrowserAnnotationWebviewPreferences } from "./browserAnnotations/webviewSecurity";
+import { FLOATING_BROWSER_CHROME_PARTITION } from "@synara/shared/browserSession";
+import { hardenIsolatedWebviewPreferences } from "./browserAnnotations/webviewSecurity";
 import { LOCAL_HTML_PREVIEW_SCHEME } from "./localHtmlPreviewProtocol";
 import {
   registerAppSnapIpcHandlers,
@@ -383,6 +384,7 @@ let restoreStdIoCapture: (() => void) | null = null;
 let unreadBackgroundNotificationCount = 0;
 let browserPerfInterval: ReturnType<typeof setInterval> | null = null;
 const annotationGuestPreload = Path.join(__dirname, "guestPreload.js");
+const floatingChromePreload = Path.join(__dirname, "floatingBrowserChromePreload.js");
 const browserManager = new DesktopBrowserManager({
   annotationPreloadPath: annotationGuestPreload,
   beforeInputEvent: (event, input) => {
@@ -4475,9 +4477,24 @@ function createWindow(): BrowserWindow {
 
   window.webContents.on("will-attach-webview", (event, webPreferences, params) => {
     const partition = params.partition;
+    if (partition === FLOATING_BROWSER_CHROME_PARTITION) {
+      if (
+        !hardenIsolatedWebviewPreferences({
+          partition,
+          expectedPartition: FLOATING_BROWSER_CHROME_PARTITION,
+          preloadPath: floatingChromePreload,
+          webPreferences,
+        })
+      ) {
+        event.preventDefault();
+        return;
+      }
+      webPreferences.backgroundThrottling = false;
+      return;
+    }
     if (
       partition === undefined ||
-      !hardenBrowserAnnotationWebviewPreferences({
+      !hardenIsolatedWebviewPreferences({
         partition,
         expectedPartition: BROWSER_SESSION_PARTITION,
         preloadPath: annotationGuestPreload,

--- a/apps/desktop/tsdown.config.mts
+++ b/apps/desktop/tsdown.config.mts
@@ -37,4 +37,8 @@ export default defineConfig([
     ...shared,
     entry: ["src/browserAnnotations/guestPreload.ts"],
   },
+  {
+    ...shared,
+    entry: ["src/floatingBrowserChromePreload.ts"],
+  },
 ]);

--- a/apps/web/e2e/fixtures/visibleBrowserMain.ts
+++ b/apps/web/e2e/fixtures/visibleBrowserMain.ts
@@ -9,7 +9,8 @@ import {
 } from "../../../desktop/src/browserManager";
 import { BrowserUsePipeServer } from "../../../desktop/src/browserUsePipeServer";
 import { BROWSER_IPC_CHANNELS } from "../../../desktop/src/ipcChannels";
-import { hardenBrowserAnnotationWebviewPreferences } from "../../../desktop/src/browserAnnotations/webviewSecurity";
+import { hardenIsolatedWebviewPreferences } from "../../../desktop/src/browserAnnotations/webviewSecurity";
+import { FLOATING_BROWSER_CHROME_PARTITION } from "@synara/shared/browserSession";
 import { createBrowserPanelHideScheduler } from "../../src/components/BrowserPanel.logic";
 
 const pipePath = process.env.SYNARA_BROWSER_HOST_PIPE_PATH;
@@ -115,9 +116,24 @@ app.whenReady().then(async () => {
   });
   browserManager.setWindow(mainWindow);
   mainWindow.webContents.on("will-attach-webview", (event, webPreferences, params) => {
+    const partition = params.partition;
+    if (partition === FLOATING_BROWSER_CHROME_PARTITION) {
+      if (
+        !hardenIsolatedWebviewPreferences({
+          partition,
+          expectedPartition: FLOATING_BROWSER_CHROME_PARTITION,
+          preloadPath: annotationPreloadPath,
+          webPreferences,
+        })
+      ) {
+        event.preventDefault();
+      }
+      return;
+    }
     if (
-      !hardenBrowserAnnotationWebviewPreferences({
-        partition: params.partition,
+      partition === undefined ||
+      !hardenIsolatedWebviewPreferences({
+        partition,
         expectedPartition: BROWSER_SESSION_PARTITION,
         preloadPath: annotationPreloadPath,
         webPreferences,

--- a/apps/web/src/components/BrowserPanel.logic.test.ts
+++ b/apps/web/src/components/BrowserPanel.logic.test.ts
@@ -10,6 +10,7 @@ import {
   createBrowserPanelHideScheduler,
   createBrowserPanelRendererHandoff,
   createBrowserRendererLossHandler,
+  createFloatingBrowserChromePark,
   formatBrowserAnnotationActionError,
   hasObscuringHitStackElementAboveSurface,
   isBrowserAnnotationEventInScope,
@@ -361,6 +362,143 @@ describe("createBrowserPanelRendererHandoff", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("flushes a parked renderer guest immediately on close", () => {
+    vi.useFakeTimers();
+    try {
+      const dispose = vi.fn();
+      const handoff = createBrowserPanelRendererHandoff({ parkUntilMs: 1_000 });
+
+      handoff.parkGuest("thread-a", {
+        tabId: "tab-a",
+        webContentsId: 41,
+        stage: {} as HTMLElement,
+        webview: {} as HTMLElement,
+        dispose,
+      });
+      handoff.flushParkedGuest("thread-a");
+      expect(dispose).toHaveBeenCalledTimes(1);
+      expect(handoff.takeParkedGuest("thread-a")).toBeNull();
+      vi.runAllTimers();
+      expect(dispose).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("flushing without a parked guest is a no-op", () => {
+    const dispose = vi.fn();
+    const handoff = createBrowserPanelRendererHandoff({ parkUntilMs: 1_000 });
+
+    expect(() => handoff.flushParkedGuest("thread-a")).not.toThrow();
+    expect(dispose).not.toHaveBeenCalled();
+  });
+});
+
+describe("createFloatingBrowserChromePark", () => {
+  type FakeChromeSlot = HTMLElement & { removed: boolean };
+
+  function fakeChromeSlot(): FakeChromeSlot {
+    const slot: {
+      removed: boolean;
+      style: CSSStyleDeclaration;
+      getAttribute: (name: string) => string | null;
+      setAttribute: (name: string, value: string) => void;
+      querySelectorAll: (selector: string) => NodeListOf<Element>;
+      remove: () => void;
+    } = {
+      removed: false,
+      style: {} as CSSStyleDeclaration,
+      getAttribute: () => null,
+      setAttribute: () => {},
+      querySelectorAll: () => [] as unknown as NodeListOf<Element>,
+      remove: () => {
+        slot.removed = true;
+      },
+    };
+    return slot as unknown as FakeChromeSlot;
+  }
+
+  it("parks the chrome slot hidden and disposes it after the park window", () => {
+    vi.useFakeTimers();
+    try {
+      const slots = new Map<string, FakeChromeSlot>([["thread-a", fakeChromeSlot()]]);
+      const park = createFloatingBrowserChromePark({
+        parkUntilMs: 1_000,
+        findSlot: (threadId) => slots.get(threadId) ?? null,
+        ensureSlot: (threadId) => {
+          let slot = slots.get(threadId);
+          if (!slot) {
+            slot = fakeChromeSlot();
+            slots.set(threadId, slot);
+          }
+          return slot;
+        },
+      });
+
+      park.park("thread-a");
+      expect(slots.get("thread-a")?.style.pointerEvents).toBe("none");
+      vi.advanceTimersByTime(1_000);
+      expect(slots.get("thread-a")?.removed).toBe(true);
+
+      park.park("missing-thread");
+      vi.runAllTimers();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("take cancels a pending chrome disposal and reuses the same slot", () => {
+    vi.useFakeTimers();
+    try {
+      const slot = fakeChromeSlot();
+      const park = createFloatingBrowserChromePark({
+        parkUntilMs: 1_000,
+        findSlot: () => slot,
+        ensureSlot: () => slot,
+      });
+
+      park.park("thread-a");
+      expect(park.take("thread-a")).toBe(slot);
+      vi.advanceTimersByTime(5_000);
+      expect(slot.removed).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("flush destroys the parked chrome webview immediately", () => {
+    vi.useFakeTimers();
+    try {
+      const slot = fakeChromeSlot();
+      const park = createFloatingBrowserChromePark({
+        parkUntilMs: 60_000,
+        findSlot: () => slot,
+        ensureSlot: () => slot,
+      });
+
+      park.park("thread-a");
+      park.flush("thread-a");
+      expect(slot.removed).toBe(true);
+      vi.runAllTimers();
+      expect(slot.removed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("flush destroys a live chrome slot that was never parked", () => {
+    const slot = fakeChromeSlot();
+    const park = createFloatingBrowserChromePark({
+      parkUntilMs: 60_000,
+      findSlot: () => (slot.removed ? null : slot),
+      ensureSlot: () => slot,
+    });
+
+    expect(park.take("thread-a")).toBe(slot);
+    park.flush("thread-a");
+    expect(slot.removed).toBe(true);
   });
 });
 
@@ -726,7 +864,7 @@ describe("resolveBrowserChromeStatus", () => {
 describe("floating browser webview presentation", () => {
   it("fills the slot and clips to the card radius, then restores docked layout", () => {
     const webview = { style: {} } as HTMLElement;
-    const stage = { style: {}, firstElementChild: webview } as HTMLElement;
+    const stage = { style: {}, firstElementChild: webview } as unknown as HTMLElement;
     applyBrowserWebviewPresentation(stage, {
       floating: true,
       slotWidth: 320,
@@ -752,7 +890,11 @@ describe("floating browser webview presentation", () => {
       },
       setZoomFactor: vi.fn(),
     } as HTMLElement & { setZoomFactor: ReturnType<typeof vi.fn> };
-    const stage = { style: {}, firstElementChild: webview, querySelector: () => webview } as unknown as HTMLElement;
+    const stage = {
+      style: {},
+      firstElementChild: webview,
+      querySelector: () => webview,
+    } as unknown as HTMLElement;
     const slot = {
       style: {},
       querySelector(selector: string) {
@@ -782,8 +924,10 @@ describe("floating browser webview presentation", () => {
 
 describe("floating browser webview presentation restore", () => {
   it("restores docked layout", () => {
-    const webview = { style: { overflow: "hidden", clipPath: "inset(0 round 12px)" } } as HTMLElement;
-    const stage = { style: {}, firstElementChild: webview } as HTMLElement;
+    const webview = {
+      style: { overflow: "hidden", clipPath: "inset(0 round 12px)" },
+    } as HTMLElement;
+    const stage = { style: {}, firstElementChild: webview } as unknown as HTMLElement;
     applyBrowserWebviewPresentation(stage, {
       floating: false,
       slotWidth: 320,

--- a/apps/web/src/components/BrowserPanel.logic.test.ts
+++ b/apps/web/src/components/BrowserPanel.logic.test.ts
@@ -17,8 +17,12 @@ import {
   resolveBrowserChromeStatus,
   resolveBrowserAddressSync,
   shouldOccludeBrowserWebview,
+  applyBrowserWebviewPageZoom,
   applyBrowserWebviewPresentation,
+  applyFloatingBrowserChromeSlotStyle,
   isBrowserPanelBoundsHiddenKey,
+  resolveBrowserRendererGuestSlotStyle,
+  shouldAssignBrowserWebviewSrc,
 } from "./BrowserPanel.logic";
 import { ThreadId, type BrowserAnnotationEvent } from "@synara/contracts";
 import type { BrowserAnnotationDraft } from "../lib/browserAnnotations";
@@ -314,6 +318,141 @@ describe("createBrowserPanelRendererHandoff", () => {
 
     await expect(handoff.waitForDetach("thread-a")).resolves.toBeUndefined();
   });
+
+  it("rehomes a parked renderer guest instead of destroying it", () => {
+    vi.useFakeTimers();
+    try {
+      const dispose = vi.fn();
+      const handoff = createBrowserPanelRendererHandoff({ parkUntilMs: 1_000 });
+      const guest = {
+        tabId: "tab-a",
+        webContentsId: 41,
+        stage: {} as HTMLElement,
+        webview: {} as HTMLElement,
+        dispose,
+      };
+
+      handoff.parkGuest("thread-a", guest);
+      expect(handoff.takeParkedGuest("thread-a")).toBe(guest);
+      vi.runAllTimers();
+      expect(dispose).not.toHaveBeenCalled();
+      expect(handoff.takeParkedGuest("thread-a")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("disposes a parked renderer guest when no successor claims it", () => {
+    vi.useFakeTimers();
+    try {
+      const dispose = vi.fn();
+      const handoff = createBrowserPanelRendererHandoff({ parkUntilMs: 1_000 });
+
+      handoff.parkGuest("thread-a", {
+        tabId: "tab-a",
+        webContentsId: 41,
+        stage: {} as HTMLElement,
+        webview: {} as HTMLElement,
+        dispose,
+      });
+      vi.advanceTimersByTime(1_000);
+      expect(dispose).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("browser renderer guest slot layout", () => {
+  it("does not assign src when the same guest is rebound to the same tab", () => {
+    expect(
+      shouldAssignBrowserWebviewSrc({
+        activeTabId: "tab-a",
+        boundTabId: null,
+        guestTabId: "tab-a",
+      }),
+    ).toBe(false);
+    expect(
+      shouldAssignBrowserWebviewSrc({
+        activeTabId: "tab-b",
+        boundTabId: "tab-a",
+        guestTabId: "tab-a",
+      }),
+    ).toBe(true);
+    expect(
+      shouldAssignBrowserWebviewSrc({
+        activeTabId: "tab-a",
+        boundTabId: null,
+        guestTabId: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("moves a guest slot by rectangle instead of changing its parent", () => {
+    expect(resolveBrowserRendererGuestSlotStyle(null)).toEqual({
+      left: "-10000px",
+      top: "0px",
+      width: "1280px",
+      height: "800px",
+      pointerEvents: "none",
+      borderRadius: "0px",
+      clipPath: "none",
+    });
+    expect(
+      resolveBrowserRendererGuestSlotStyle(
+        { left: 24, top: 48, width: 640, height: 400 },
+        { borderRadius: "12px" },
+      ),
+    ).toEqual({
+      left: "24px",
+      top: "48px",
+      width: "640px",
+      height: "400px",
+      pointerEvents: "auto",
+      borderRadius: "12px",
+      clipPath: "inset(0 round 12px)",
+    });
+  });
+});
+
+describe("floating browser chrome slot", () => {
+  it("pins the native chrome overlay to the card's top-right", () => {
+    const attributes: Record<string, string> = {};
+    const slot = {
+      style: {},
+      getAttribute(name: string) {
+        return attributes[name] ?? null;
+      },
+      setAttribute(name: string, value: string) {
+        attributes[name] = value;
+      },
+    } as HTMLElement;
+    applyFloatingBrowserChromeSlotStyle(slot, {
+      left: 100,
+      top: 200,
+      width: 320,
+      height: 200,
+    });
+    expect(slot.style.left).toBe("380px");
+    expect(slot.style.width).toBe("32px");
+    expect(slot.style.top).toBe("208px");
+    expect(slot.style.pointerEvents).toBe("auto");
+    applyFloatingBrowserChromeSlotStyle(
+      slot,
+      {
+        left: 100,
+        top: 200,
+        width: 320,
+        height: 200,
+      },
+      { expanded: true },
+    );
+    expect(slot.style.left).toBe("326px");
+    expect(slot.style.width).toBe("86px");
+    applyFloatingBrowserChromeSlotStyle(slot, null);
+    expect(slot.style.left).toBe("-10000px");
+    expect(slot.style.pointerEvents).toBe("none");
+  });
 });
 
 describe("shouldOccludeBrowserWebview", () => {
@@ -565,18 +704,36 @@ describe("resolveBrowserChromeStatus", () => {
 });
 
 describe("floating browser webview presentation", () => {
-  it("scales a CSS stage around the frozen guest, then restores fill layout", () => {
-    const stage = { style: {} } as HTMLElement;
+  it("fills the slot and clips to the card radius, then restores docked layout", () => {
+    const webview = { style: {} } as HTMLElement;
+    const stage = { style: {}, firstElementChild: webview } as HTMLElement;
     applyBrowserWebviewPresentation(stage, {
       floating: true,
       slotWidth: 320,
       slotHeight: 220,
+      borderRadius: "12px",
     });
-    expect(stage.style.width).toBe("1280px");
-    expect(stage.style.height).toBe("800px");
-    expect(stage.style.transform).toBe("scale(0.25)");
-    expect(stage.style.top).toBe("10px");
+    expect(stage.style.width).toBe("100%");
+    expect(stage.style.height).toBe("100%");
+    expect(stage.style.transform).toBe("");
+    expect(stage.style.borderRadius).toBe("12px");
+    expect(stage.style.clipPath).toBe("inset(0 round 12px)");
+    expect(webview.style.clipPath).toBe("inset(0 round 12px)");
+  });
 
+  it("applies miniature page zoom onto the renderer webview", () => {
+    const setZoomFactor = vi.fn();
+    applyBrowserWebviewPageZoom({ setZoomFactor } as HTMLElement, 0.25);
+    expect(setZoomFactor).toHaveBeenCalledWith(0.25);
+    applyBrowserWebviewPageZoom({ setZoomFactor } as HTMLElement, Number.NaN);
+    expect(setZoomFactor).toHaveBeenLastCalledWith(1);
+  });
+});
+
+describe("floating browser webview presentation restore", () => {
+  it("restores docked layout", () => {
+    const webview = { style: {} } as HTMLElement;
+    const stage = { style: {}, firstElementChild: webview } as HTMLElement;
     applyBrowserWebviewPresentation(stage, {
       floating: false,
       slotWidth: 320,
@@ -584,7 +741,8 @@ describe("floating browser webview presentation", () => {
     });
     expect(stage.style.width).toBe("100%");
     expect(stage.style.height).toBe("100%");
-    expect(stage.style.transform).toBe("");
+    expect(stage.style.borderRadius).toBe("");
+    expect(stage.style.clipPath).toBe("");
   });
 });
 

--- a/apps/web/src/components/BrowserPanel.logic.test.ts
+++ b/apps/web/src/components/BrowserPanel.logic.test.ts
@@ -17,9 +17,10 @@ import {
   resolveBrowserChromeStatus,
   resolveBrowserAddressSync,
   shouldOccludeBrowserWebview,
-  applyBrowserWebviewPageZoom,
-  applyBrowserWebviewPresentation,
   applyFloatingBrowserChromeSlotStyle,
+  applyBrowserWebviewPresentation,
+  handoffBrowserGuestToDockedSurface,
+  isBrowserRendererGuestHitTarget,
   isBrowserPanelBoundsHiddenKey,
   resolveBrowserRendererGuestSlotStyle,
   shouldAssignBrowserWebviewSrc,
@@ -527,6 +528,25 @@ describe("hasObscuringHitStackElementAboveSurface", () => {
   });
 });
 
+describe("isBrowserRendererGuestHitTarget", () => {
+  it("treats the parked renderer guest as the live surface, not an overlay", () => {
+    expect(isBrowserRendererGuestHitTarget({ tagName: "WEBVIEW" })).toBe(true);
+    expect(
+      isBrowserRendererGuestHitTarget({
+        tagName: "DIV",
+        closest: (selector: string) =>
+          selector.includes("data-browser-guest-thread") ? ({} as Element) : null,
+      }),
+    ).toBe(true);
+    expect(
+      isBrowserRendererGuestHitTarget({
+        tagName: "DIV",
+        closest: () => null,
+      }),
+    ).toBe(false);
+  });
+});
+
 describe("browserAddressDisplayValue", () => {
   it("hides about:blank for new tabs", () => {
     expect(browserAddressDisplayValue({ url: "about:blank" })).toBe("");
@@ -721,18 +741,48 @@ describe("floating browser webview presentation", () => {
     expect(webview.style.clipPath).toBe("inset(0 round 12px)");
   });
 
-  it("applies miniature page zoom onto the renderer webview", () => {
-    const setZoomFactor = vi.fn();
-    applyBrowserWebviewPageZoom({ setZoomFactor } as HTMLElement, 0.25);
-    expect(setZoomFactor).toHaveBeenCalledWith(0.25);
-    applyBrowserWebviewPageZoom({ setZoomFactor } as HTMLElement, Number.NaN);
-    expect(setZoomFactor).toHaveBeenLastCalledWith(1);
+  it("resets miniature zoom and clipping when the guest is handed to the sidebar", () => {
+    const attributes: Record<string, string> = {};
+    const webview = {
+      style: {
+        overflow: "hidden",
+        clipPath: "inset(0 round 12px)",
+        width: "100%",
+        height: "100%",
+      },
+      setZoomFactor: vi.fn(),
+    } as HTMLElement & { setZoomFactor: ReturnType<typeof vi.fn> };
+    const stage = { style: {}, firstElementChild: webview, querySelector: () => webview } as unknown as HTMLElement;
+    const slot = {
+      style: {},
+      querySelector(selector: string) {
+        return selector === "webview" ? webview : stage;
+      },
+      getAttribute(name: string) {
+        return attributes[name] ?? null;
+      },
+      setAttribute(name: string, value: string) {
+        attributes[name] = value;
+      },
+    } as unknown as HTMLElement;
+    handoffBrowserGuestToDockedSurface({
+      slot,
+      host: { left: 40, top: 80, width: 480, height: 640 },
+      stage,
+      webview,
+    });
+    expect(webview.setZoomFactor).toHaveBeenCalledWith(1);
+    expect(webview.style.overflow).toBe("");
+    expect(webview.style.clipPath).toBe("");
+    expect(slot.style.left).toBe("40px");
+    expect(slot.style.width).toBe("480px");
+    expect(slot.style.height).toBe("640px");
   });
 });
 
 describe("floating browser webview presentation restore", () => {
   it("restores docked layout", () => {
-    const webview = { style: {} } as HTMLElement;
+    const webview = { style: { overflow: "hidden", clipPath: "inset(0 round 12px)" } } as HTMLElement;
     const stage = { style: {}, firstElementChild: webview } as HTMLElement;
     applyBrowserWebviewPresentation(stage, {
       floating: false,
@@ -743,6 +793,8 @@ describe("floating browser webview presentation restore", () => {
     expect(stage.style.height).toBe("100%");
     expect(stage.style.borderRadius).toBe("");
     expect(stage.style.clipPath).toBe("");
+    expect(webview.style.overflow).toBe("");
+    expect(webview.style.clipPath).toBe("");
   });
 });
 

--- a/apps/web/src/components/BrowserPanel.logic.ts
+++ b/apps/web/src/components/BrowserPanel.logic.ts
@@ -99,12 +99,24 @@ interface BrowserPanelRendererHandoffOptions {
 export const BROWSER_RENDERER_GUEST_SLOT_Z_INDEX = "40";
 export const FLOATING_BROWSER_CHROME_SLOT_Z_INDEX = "50";
 export const FLOATING_BROWSER_CHROME_THREAD_ATTRIBUTE = "data-floating-browser-chrome-thread";
+export const FLOATING_BROWSER_CHROME_EXPANDED_ATTRIBUTE = "data-floating-browser-chrome-expanded";
 export const FLOATING_BROWSER_CHROME_COLLAPSED_WIDTH_PX = 32;
 export const FLOATING_BROWSER_CHROME_EXPANDED_WIDTH_PX = 86;
 export const FLOATING_BROWSER_CHROME_WIDTH_PX = FLOATING_BROWSER_CHROME_EXPANDED_WIDTH_PX;
 export const FLOATING_BROWSER_CHROME_HEIGHT_PX = 32;
 export const FLOATING_BROWSER_CHROME_INSET_PX = 8;
-export const FLOATING_BROWSER_CHROME_EXPANDED_ATTRIBUTE = "data-floating-browser-chrome-expanded";
+
+export function isBrowserRendererGuestHitTarget(element: { tagName?: string; closest?: (selector: string) => Element | null }): boolean {
+  const tagName = element.tagName?.toLowerCase();
+  if (tagName === "webview") {
+    return true;
+  }
+  return (
+    element.closest?.(`[${BROWSER_RENDERER_GUEST_THREAD_ATTRIBUTE}]`) != null ||
+    element.closest?.(`#${BROWSER_RENDERER_PARKING_CONTAINER_ID}`) != null ||
+    element.closest?.(`[${FLOATING_BROWSER_CHROME_THREAD_ATTRIBUTE}]`) != null
+  );
+}
 
 export interface BrowserRendererGuestSlotBox {
   readonly left: number;
@@ -470,13 +482,50 @@ export function setFloatingBrowserChromeMenuOpen(webview: HTMLElement, open: boo
   );
 }
 
-export function nudgeFloatingBrowserChromeNativeView(slot: HTMLElement): void {
+export function nudgeElectronWebviewNativeView(slot: HTMLElement): void {
   const webview = slot.querySelector("webview");
-  if (!(webview instanceof HTMLElement)) {
+  if (!webview || !("style" in webview)) {
     return;
   }
-  webview.style.transform =
-    webview.style.transform === "translateZ(0px)" ? "translateZ(0.01px)" : "translateZ(0px)";
+  const guest = webview as HTMLElement;
+  guest.style.transform =
+    guest.style.transform === "translateZ(0px)" ? "translateZ(0.01px)" : "translateZ(0px)";
+}
+
+export function nudgeFloatingBrowserChromeNativeView(slot: HTMLElement): void {
+  nudgeElectronWebviewNativeView(slot);
+}
+
+export function handoffBrowserGuestToDockedSurface(input: {
+  slot: HTMLElement;
+  host: BrowserRendererGuestSlotBox;
+  stage?: HTMLElement | null;
+  webview?: HTMLElement | null;
+}): void {
+  applyBrowserRendererGuestSlotStyle(input.slot, input.host, { borderRadius: "0px" });
+  input.slot.style.border = "";
+  input.slot.style.boxShadow = "";
+  const stage =
+    input.stage ??
+    input.slot.querySelector<HTMLElement>("[data-floating-browser-stage='true']");
+  if (stage) {
+    applyBrowserWebviewPresentation(stage, {
+      floating: false,
+      slotWidth: input.host.width,
+      slotHeight: input.host.height,
+    });
+  }
+  const webview = input.webview ?? input.slot.querySelector("webview");
+  if (webview && "style" in webview) {
+    const guest = webview as HTMLElement;
+    guest.style.width = "100%";
+    guest.style.height = "100%";
+    guest.style.overflow = "";
+    guest.style.clipPath = "";
+    guest.style.borderRadius = "";
+    applyBrowserWebviewPageZoom(guest, 1);
+  }
+  nudgeElectronWebviewNativeView(input.slot);
 }
 
 export function ensureFloatingBrowserChromeWebview(slot: HTMLElement): HTMLElement {
@@ -1049,6 +1098,7 @@ export function applyBrowserWebviewPresentation(
       const guest = webview as HTMLElement;
       guest.style.borderRadius = "";
       guest.style.clipPath = "";
+      guest.style.overflow = "";
     }
     return;
   }

--- a/apps/web/src/components/BrowserPanel.logic.ts
+++ b/apps/web/src/components/BrowserPanel.logic.ts
@@ -7,8 +7,9 @@
 import {
   BROWSER_BLANK_URL,
   BROWSER_SEARCH_URL_PREFIX,
+  FLOATING_BROWSER_CHROME_PARTITION,
+  normalizeBrowserPageZoomFactor,
   normalizeBrowserUrlInput,
-  resolveFloatingBrowserGuestLayout,
 } from "@synara/shared/browserSession";
 import type {
   BrowserAnnotationEvent,
@@ -70,18 +71,151 @@ export interface BrowserPanelHideScheduler {
   readonly schedule: (threadId: string, hide: () => void) => void;
 }
 
+export const BROWSER_RENDERER_GUEST_PARK_MS = 8_000;
+export const BROWSER_RENDERER_PARKING_CONTAINER_ID = "synara-browser-renderer-parking";
+export const BROWSER_RENDERER_GUEST_THREAD_ATTRIBUTE = "data-browser-guest-thread";
+
+export interface ParkedBrowserRendererGuest {
+  readonly tabId: string;
+  readonly webContentsId: number | null;
+  readonly stage: HTMLElement;
+  readonly webview: HTMLElement;
+  readonly dispose: () => void;
+}
+
 export interface BrowserPanelRendererHandoff {
   readonly trackDetach: (threadId: string, detach: Promise<unknown>) => void;
   readonly waitForDetach: (threadId: string) => Promise<void>;
+  readonly parkGuest: (threadId: string, guest: ParkedBrowserRendererGuest) => void;
+  readonly takeParkedGuest: (threadId: string) => ParkedBrowserRendererGuest | null;
+}
+
+interface BrowserPanelRendererHandoffOptions {
+  readonly parkUntilMs?: number;
+  readonly setTimer?: (callback: () => void, delayMs: number) => BrowserPanelHideTimer;
+  readonly clearTimer?: (timer: BrowserPanelHideTimer) => void;
+}
+
+export const BROWSER_RENDERER_GUEST_SLOT_Z_INDEX = "40";
+export const FLOATING_BROWSER_CHROME_SLOT_Z_INDEX = "50";
+export const FLOATING_BROWSER_CHROME_THREAD_ATTRIBUTE = "data-floating-browser-chrome-thread";
+export const FLOATING_BROWSER_CHROME_COLLAPSED_WIDTH_PX = 32;
+export const FLOATING_BROWSER_CHROME_EXPANDED_WIDTH_PX = 86;
+export const FLOATING_BROWSER_CHROME_WIDTH_PX = FLOATING_BROWSER_CHROME_EXPANDED_WIDTH_PX;
+export const FLOATING_BROWSER_CHROME_HEIGHT_PX = 32;
+export const FLOATING_BROWSER_CHROME_INSET_PX = 8;
+export const FLOATING_BROWSER_CHROME_EXPANDED_ATTRIBUTE = "data-floating-browser-chrome-expanded";
+
+export interface BrowserRendererGuestSlotBox {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface BrowserRendererGuestSlotStyle {
+  readonly left: string;
+  readonly top: string;
+  readonly width: string;
+  readonly height: string;
+  readonly pointerEvents: "auto" | "none";
+  readonly borderRadius: string;
+  readonly clipPath: string;
+}
+
+/**
+ * Electron recreates a <webview> when its DOM parent changes, which reloads the
+ * page and drops in-memory form state. Keep the guest in one body slot and only
+ * change its fixed rectangle.
+ */
+export function resolveBrowserRendererGuestSlotStyle(
+  host: BrowserRendererGuestSlotBox | null,
+  options: { borderRadius?: string } = {},
+): BrowserRendererGuestSlotStyle {
+  const borderRadius = options.borderRadius ?? "0px";
+  if (!host || host.width <= 0 || host.height <= 0) {
+    return {
+      left: "-10000px",
+      top: "0px",
+      width: "1280px",
+      height: "800px",
+      pointerEvents: "none",
+      borderRadius,
+      clipPath: "none",
+    };
+  }
+  return {
+    left: `${host.left}px`,
+    top: `${host.top}px`,
+    width: `${host.width}px`,
+    height: `${host.height}px`,
+    pointerEvents: "auto",
+    borderRadius,
+    clipPath: borderRadius === "0px" ? "none" : `inset(0 round ${borderRadius})`,
+  };
+}
+
+export function applyBrowserRendererGuestSlotStyle(
+  slot: HTMLElement,
+  host: BrowserRendererGuestSlotBox | null,
+  options: { borderRadius?: string } = {},
+): void {
+  const next = resolveBrowserRendererGuestSlotStyle(host, options);
+  slot.style.position = "fixed";
+  slot.style.margin = "0";
+  slot.style.overflow = host ? "hidden" : "visible";
+  slot.style.zIndex = BROWSER_RENDERER_GUEST_SLOT_Z_INDEX;
+  slot.style.left = next.left;
+  slot.style.top = next.top;
+  slot.style.width = next.width;
+  slot.style.height = next.height;
+  slot.style.pointerEvents = next.pointerEvents;
+  slot.style.borderRadius = next.borderRadius;
+  slot.style.clipPath = next.clipPath;
+}
+
+export function readFloatingBrowserPanelBorderRadius(host: HTMLElement): string {
+  const panel = host.closest("[data-floating-browser-panel]");
+  if (!(panel instanceof HTMLElement)) {
+    return "0px";
+  }
+  const radius = window.getComputedStyle(panel).borderTopLeftRadius.trim();
+  return radius.length > 0 ? radius : "0px";
+}
+
+export function shouldAssignBrowserWebviewSrc(input: {
+  activeTabId: string;
+  boundTabId: string | null;
+  guestTabId: string | null;
+}): boolean {
+  const inferredBoundTabId = input.boundTabId ?? input.guestTabId;
+  return inferredBoundTabId !== input.activeTabId;
 }
 
 /**
  * Serializes renderer guest replacement across dock/floating BrowserPanel instances.
  * React can mount the replacement before the old panel's IPC cleanup has completed;
  * waiting here keeps browserManager's duplicate-runtime guard from stranding the guest.
+ *
+ * Park/take keeps the same <webview> WebContents alive across hosts so a sidebar
+ * handoff does not reload the page and drop in-memory form state. The guest node
+ * must stay under one parent: Electron destroys <webview> on reparent.
  */
-export function createBrowserPanelRendererHandoff(): BrowserPanelRendererHandoff {
+export function createBrowserPanelRendererHandoff(
+  options: BrowserPanelRendererHandoffOptions = {},
+): BrowserPanelRendererHandoff {
+  const parkUntilMs = options.parkUntilMs ?? BROWSER_RENDERER_GUEST_PARK_MS;
+  const setTimer =
+    options.setTimer ??
+    ((callback, delayMs) => globalThis.setTimeout(callback, delayMs) as BrowserPanelHideTimer);
+  const clearTimer =
+    options.clearTimer ??
+    ((timer) => globalThis.clearTimeout(timer as ReturnType<typeof globalThis.setTimeout>));
   const pendingByThreadId = new Map<string, Promise<void>>();
+  const parkedByThreadId = new Map<
+    string,
+    { guest: ParkedBrowserRendererGuest; timer: BrowserPanelHideTimer }
+  >();
 
   function trackDetach(threadId: string, detach: Promise<unknown>): void {
     const previous = pendingByThreadId.get(threadId);
@@ -101,7 +235,262 @@ export function createBrowserPanelRendererHandoff(): BrowserPanelRendererHandoff
     return pendingByThreadId.get(threadId) ?? Promise.resolve();
   }
 
-  return { trackDetach, waitForDetach };
+  function clearParked(threadId: string): ParkedBrowserRendererGuest | null {
+    const parked = parkedByThreadId.get(threadId);
+    if (!parked) {
+      return null;
+    }
+    parkedByThreadId.delete(threadId);
+    clearTimer(parked.timer);
+    return parked.guest;
+  }
+
+  function parkGuest(threadId: string, guest: ParkedBrowserRendererGuest): void {
+    const replaced = clearParked(threadId);
+    if (replaced && replaced.webview !== guest.webview) {
+      replaced.dispose();
+    }
+    const timer = setTimer(() => {
+      parkedByThreadId.delete(threadId);
+      guest.dispose();
+    }, parkUntilMs);
+    parkedByThreadId.set(threadId, { guest, timer });
+  }
+
+  function takeParkedGuest(threadId: string): ParkedBrowserRendererGuest | null {
+    return clearParked(threadId);
+  }
+
+  return { trackDetach, waitForDetach, parkGuest, takeParkedGuest };
+}
+
+export function getBrowserRendererParkingContainer(): HTMLElement {
+  const existing = document.getElementById(BROWSER_RENDERER_PARKING_CONTAINER_ID);
+  if (existing) {
+    return existing;
+  }
+  const container = document.createElement("div");
+  container.id = BROWSER_RENDERER_PARKING_CONTAINER_ID;
+  container.style.cssText = `position:fixed;inset:0;pointer-events:none;z-index:${FLOATING_BROWSER_CHROME_SLOT_Z_INDEX};`;
+  document.body.append(container);
+  return container;
+}
+
+export function getBrowserRendererGuestSlot(threadId: string): HTMLElement {
+  const container = getBrowserRendererParkingContainer();
+  for (const child of container.children) {
+    if (
+      child instanceof HTMLElement &&
+      child.getAttribute(BROWSER_RENDERER_GUEST_THREAD_ATTRIBUTE) === threadId
+    ) {
+      return child;
+    }
+  }
+  const slot = document.createElement("div");
+  slot.setAttribute(BROWSER_RENDERER_GUEST_THREAD_ATTRIBUTE, threadId);
+  applyBrowserRendererGuestSlotStyle(slot, null);
+  container.append(slot);
+  return slot;
+}
+
+function floatingBrowserChromeSlotWidth(slot: HTMLElement): number {
+  return slot.getAttribute(FLOATING_BROWSER_CHROME_EXPANDED_ATTRIBUTE) === "true"
+    ? FLOATING_BROWSER_CHROME_EXPANDED_WIDTH_PX
+    : FLOATING_BROWSER_CHROME_COLLAPSED_WIDTH_PX;
+}
+
+export function applyFloatingBrowserChromeSlotStyle(
+  slot: HTMLElement,
+  panel: BrowserRendererGuestSlotBox | null,
+  options: { expanded?: boolean } = {},
+): void {
+  if (options.expanded != null) {
+    slot.setAttribute(FLOATING_BROWSER_CHROME_EXPANDED_ATTRIBUTE, options.expanded ? "true" : "false");
+  }
+  const width = floatingBrowserChromeSlotWidth(slot);
+  slot.style.position = "fixed";
+  slot.style.margin = "0";
+  slot.style.overflow = "visible";
+  slot.style.zIndex = FLOATING_BROWSER_CHROME_SLOT_Z_INDEX;
+  slot.style.width = `${width}px`;
+  slot.style.height = `${FLOATING_BROWSER_CHROME_HEIGHT_PX}px`;
+  if (!panel || panel.width <= 0 || panel.height <= 0) {
+    slot.style.left = "-10000px";
+    slot.style.top = "0px";
+    slot.style.pointerEvents = "none";
+    return;
+  }
+  slot.style.left = `${panel.left + panel.width - FLOATING_BROWSER_CHROME_INSET_PX - width}px`;
+  slot.style.top = `${panel.top + FLOATING_BROWSER_CHROME_INSET_PX}px`;
+  slot.style.pointerEvents = "auto";
+}
+
+export function getFloatingBrowserChromeSlot(threadId: string): HTMLElement {
+  const container = getBrowserRendererParkingContainer();
+  for (const child of container.children) {
+    if (
+      child instanceof HTMLElement &&
+      child.getAttribute(FLOATING_BROWSER_CHROME_THREAD_ATTRIBUTE) === threadId
+    ) {
+      return child;
+    }
+  }
+  const slot = document.createElement("div");
+  slot.setAttribute(FLOATING_BROWSER_CHROME_THREAD_ATTRIBUTE, threadId);
+  applyFloatingBrowserChromeSlotStyle(slot, null);
+  container.append(slot);
+  return slot;
+}
+
+export const FLOATING_BROWSER_CHROME_SRCDOC = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      html, body {
+        margin: 0;
+        background: transparent;
+        overflow: hidden;
+        width: 100%;
+        height: 100%;
+        pointer-events: none;
+      }
+      .pill {
+        position: absolute;
+        top: 0;
+        right: 0;
+        display: flex;
+        align-items: center;
+        gap: 2px;
+        padding: 2px;
+        border-radius: 999px;
+        border: 1px solid color-mix(in srgb, #fff 18%, transparent);
+        background: color-mix(in srgb, #18181b 90%, transparent);
+        box-shadow: 0 1px 2px rgb(0 0 0 / 0.2);
+        backdrop-filter: blur(12px);
+        pointer-events: auto;
+      }
+      .actions {
+        display: flex;
+        align-items: center;
+        gap: 2px;
+        width: 0;
+        overflow: hidden;
+        transition: width 220ms ease-out;
+      }
+      body.open .actions { width: 50px; }
+      @media (prefers-reduced-motion: reduce) {
+        .actions { transition: none; }
+      }
+      button {
+        width: 24px;
+        height: 24px;
+        flex: 0 0 24px;
+        border: 0;
+        border-radius: 999px;
+        background: transparent;
+        color: #a1a1aa;
+        display: grid;
+        place-items: center;
+        cursor: pointer;
+      }
+      button:hover { background: rgb(255 255 255 / 0.08); color: #fafafa; }
+      #drag { cursor: grab; }
+      #drag:active { cursor: grabbing; }
+      svg { width: 14px; height: 14px; }
+    </style>
+  </head>
+  <body>
+    <div class="pill">
+      <button id="drag" type="button" title="Drag to move, click for actions" aria-label="Floating browser actions" aria-haspopup="true" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="currentColor"><circle cx="6" cy="12" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="18" cy="12" r="1.6"/></svg>
+      </button>
+      <div class="actions" id="actions">
+        <button id="pop" type="button" title="Open browser in sidebar" aria-label="Open browser in sidebar">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M15 4v16"/><path d="M11 12H8"/><path d="m10 9-3 3 3 3"/></svg>
+        </button>
+        <button id="close" type="button" title="Close floating browser" aria-label="Close floating browser">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M6 6l12 12M18 6 6 18"/></svg>
+        </button>
+      </div>
+    </div>
+    <script>
+      const api = window.synaraFloatingChrome;
+      const send = (type, payload) => api && api.send(type, payload);
+      const drag = document.getElementById("drag");
+      window.__synaraSetFloatingChrome = (open) => {
+        document.body.classList.toggle("open", Boolean(open));
+        drag.setAttribute("aria-expanded", open ? "true" : "false");
+        return Boolean(open);
+      };
+      window.__synaraToggleFloatingChrome = () =>
+        window.__synaraSetFloatingChrome(!document.body.classList.contains("open"));
+      if (api && api.onHost) {
+        api.onHost((payload) => {
+          if (payload && typeof payload.open === "boolean") {
+            window.__synaraSetFloatingChrome(payload.open);
+          }
+        });
+      }
+      drag.addEventListener("pointerdown", (event) => {
+        event.preventDefault();
+        send("drag", { x: event.clientX, y: event.clientY, button: event.button });
+      });
+      document.getElementById("pop").addEventListener("click", (event) => {
+        event.stopPropagation();
+        document.body.classList.remove("open");
+        drag.setAttribute("aria-expanded", "false");
+        send("pop");
+      });
+      document.getElementById("close").addEventListener("click", (event) => {
+        event.stopPropagation();
+        send("close");
+      });
+    </script>
+  </body>
+</html>`;
+
+function floatingBrowserChromeGuest(
+  webview: HTMLElement,
+): HTMLElement & {
+  executeJavaScript?: (code: string) => Promise<unknown>;
+  send?: (channel: string, ...args: unknown[]) => void;
+} {
+  return webview as HTMLElement & {
+    executeJavaScript?: (code: string) => Promise<unknown>;
+    send?: (channel: string, ...args: unknown[]) => void;
+  };
+}
+
+export function setFloatingBrowserChromeMenuOpen(webview: HTMLElement, open: boolean): void {
+  const guest = floatingBrowserChromeGuest(webview);
+  guest.send?.("synara-floating-chrome-host", { open });
+  void guest.executeJavaScript?.(
+    `window.__synaraSetFloatingChrome && window.__synaraSetFloatingChrome(${open ? "true" : "false"})`,
+  );
+}
+
+export function nudgeFloatingBrowserChromeNativeView(slot: HTMLElement): void {
+  const webview = slot.querySelector("webview");
+  if (!(webview instanceof HTMLElement)) {
+    return;
+  }
+  webview.style.transform =
+    webview.style.transform === "translateZ(0px)" ? "translateZ(0.01px)" : "translateZ(0px)";
+}
+
+export function ensureFloatingBrowserChromeWebview(slot: HTMLElement): HTMLElement {
+  let webview = slot.querySelector("webview");
+  if (webview instanceof HTMLElement) {
+    return webview;
+  }
+  webview = document.createElement("webview");
+  webview.setAttribute("partition", FLOATING_BROWSER_CHROME_PARTITION);
+  webview.setAttribute("allowtransparency", "on");
+  webview.style.cssText = "display:flex;width:100%;height:100%;background:transparent;";
+  webview.setAttribute("src", `data:text/html;charset=utf-8,${encodeURIComponent(FLOATING_BROWSER_CHROME_SRCDOC)}`);
+  slot.append(webview);
+  return webview;
 }
 
 type BrowserPanelHideTimer = ReturnType<typeof globalThis.setTimeout>;
@@ -634,38 +1023,59 @@ export function isBrowserPanelBoundsHiddenKey(key: string): boolean {
 
 export function applyBrowserWebviewPresentation(
   stage: HTMLElement,
-  input: { floating: boolean; slotWidth: number; slotHeight: number },
+  input: {
+    floating: boolean;
+    slotWidth: number;
+    slotHeight: number;
+    borderRadius?: string;
+  },
 ): void {
-  // Scale a CSS stage around a frozen 1280×800 guest. Transforming the
-  // <webview> itself during drag/resize blacks the guest and can kill CDP.
+  // Keep the <webview> sized to its slot. Scaling the native guest with a CSS
+  // transform leaves an unclipped 1280×800 surface that ignores the card radius.
+  stage.style.position = "absolute";
+  stage.style.inset = "0";
+  stage.style.left = "";
+  stage.style.top = "";
+  stage.style.width = "100%";
+  stage.style.height = "100%";
+  stage.style.transform = "";
+  stage.style.transformOrigin = "";
+  stage.style.overflow = "hidden";
   if (!input.floating) {
-    stage.style.position = "absolute";
-    stage.style.inset = "0";
-    stage.style.left = "";
-    stage.style.top = "";
-    stage.style.width = "100%";
-    stage.style.height = "100%";
-    stage.style.transform = "";
-    stage.style.transformOrigin = "";
     stage.style.borderRadius = "";
     stage.style.clipPath = "";
-    stage.style.overflow = "hidden";
+    const webview = stage.firstElementChild;
+    if (webview && "style" in webview) {
+      const guest = webview as HTMLElement;
+      guest.style.borderRadius = "";
+      guest.style.clipPath = "";
+    }
     return;
   }
+  const borderRadius = input.borderRadius ?? "12px";
+  stage.style.borderRadius = borderRadius;
+  stage.style.clipPath = `inset(0 round ${borderRadius})`;
+  const webview = stage.firstElementChild;
+  if (webview && "style" in webview) {
+    const guest = webview as HTMLElement;
+    guest.style.borderRadius = borderRadius;
+    guest.style.overflow = "hidden";
+    guest.style.clipPath = `inset(0 round ${borderRadius})`;
+  }
+}
 
-  const layout = resolveFloatingBrowserGuestLayout({
-    width: input.slotWidth,
-    height: input.slotHeight,
-  });
-  stage.style.position = "absolute";
-  stage.style.inset = "";
-  stage.style.left = `${layout.x}px`;
-  stage.style.top = `${layout.y}px`;
-  stage.style.width = `${layout.width}px`;
-  stage.style.height = `${layout.height}px`;
-  stage.style.transform = layout.scale === 1 ? "" : `scale(${layout.scale})`;
-  stage.style.transformOrigin = "top left";
-  stage.style.borderRadius = "10px";
-  stage.style.clipPath = "inset(0 round 10px)";
-  stage.style.overflow = "hidden";
+export function applyBrowserWebviewPageZoom(
+  webview: HTMLElement | null | undefined,
+  pageZoomFactor: number,
+): void {
+  if (!webview) {
+    return;
+  }
+  const factor = normalizeBrowserPageZoomFactor(pageZoomFactor);
+  const guest = webview as HTMLElement & { setZoomFactor?: (value: number) => void };
+  try {
+    guest.setZoomFactor?.(factor);
+  } catch {
+    // The guest may not be attached yet; the next load or bounds sync retries.
+  }
 }

--- a/apps/web/src/components/BrowserPanel.logic.ts
+++ b/apps/web/src/components/BrowserPanel.logic.ts
@@ -88,6 +88,7 @@ export interface BrowserPanelRendererHandoff {
   readonly waitForDetach: (threadId: string) => Promise<void>;
   readonly parkGuest: (threadId: string, guest: ParkedBrowserRendererGuest) => void;
   readonly takeParkedGuest: (threadId: string) => ParkedBrowserRendererGuest | null;
+  readonly flushParkedGuest: (threadId: string) => void;
 }
 
 interface BrowserPanelRendererHandoffOptions {
@@ -106,7 +107,10 @@ export const FLOATING_BROWSER_CHROME_WIDTH_PX = FLOATING_BROWSER_CHROME_EXPANDED
 export const FLOATING_BROWSER_CHROME_HEIGHT_PX = 32;
 export const FLOATING_BROWSER_CHROME_INSET_PX = 8;
 
-export function isBrowserRendererGuestHitTarget(element: { tagName?: string; closest?: (selector: string) => Element | null }): boolean {
+export function isBrowserRendererGuestHitTarget(element: {
+  tagName?: string;
+  closest?: (selector: string) => Element | null;
+}): boolean {
   const tagName = element.tagName?.toLowerCase();
   if (tagName === "webview") {
     return true;
@@ -273,8 +277,14 @@ export function createBrowserPanelRendererHandoff(
     return clearParked(threadId);
   }
 
-  return { trackDetach, waitForDetach, parkGuest, takeParkedGuest };
+  function flushParkedGuest(threadId: string): void {
+    clearParked(threadId)?.dispose();
+  }
+
+  return { trackDetach, waitForDetach, parkGuest, takeParkedGuest, flushParkedGuest };
 }
+
+export const browserPanelRendererHandoff = createBrowserPanelRendererHandoff();
 
 export function getBrowserRendererParkingContainer(): HTMLElement {
   const existing = document.getElementById(BROWSER_RENDERER_PARKING_CONTAINER_ID);
@@ -317,7 +327,10 @@ export function applyFloatingBrowserChromeSlotStyle(
   options: { expanded?: boolean } = {},
 ): void {
   if (options.expanded != null) {
-    slot.setAttribute(FLOATING_BROWSER_CHROME_EXPANDED_ATTRIBUTE, options.expanded ? "true" : "false");
+    slot.setAttribute(
+      FLOATING_BROWSER_CHROME_EXPANDED_ATTRIBUTE,
+      options.expanded ? "true" : "false",
+    );
   }
   const width = floatingBrowserChromeSlotWidth(slot);
   slot.style.position = "fixed";
@@ -353,6 +366,125 @@ export function getFloatingBrowserChromeSlot(threadId: string): HTMLElement {
   container.append(slot);
   return slot;
 }
+
+export function findFloatingBrowserChromeSlot(threadId: string): HTMLElement | null {
+  const container = document.getElementById(BROWSER_RENDERER_PARKING_CONTAINER_ID);
+  if (!container) {
+    return null;
+  }
+  for (const child of container.children) {
+    if (
+      child instanceof HTMLElement &&
+      child.getAttribute(FLOATING_BROWSER_CHROME_THREAD_ATTRIBUTE) === threadId
+    ) {
+      return child;
+    }
+  }
+  return null;
+}
+
+export interface FloatingBrowserGuestSlotFrame {
+  readonly rect: BrowserRendererGuestSlotBox;
+  readonly borderRadius: string;
+  readonly border: string;
+  readonly boxShadow: string;
+}
+
+export function applyFloatingBrowserGuestSlotFrame(
+  threadId: string,
+  frame: FloatingBrowserGuestSlotFrame,
+): void {
+  const slot = getBrowserRendererGuestSlot(threadId);
+  applyBrowserRendererGuestSlotStyle(slot, frame.rect, { borderRadius: frame.borderRadius });
+  slot.style.border = frame.border;
+  slot.style.boxShadow = frame.boxShadow;
+  applyFloatingBrowserChromeSlotStyle(getFloatingBrowserChromeSlot(threadId), frame.rect);
+}
+
+export const FLOATING_BROWSER_CHROME_PARK_MS = 8_000;
+
+export interface FloatingBrowserChromePark {
+  readonly take: (threadId: string) => HTMLElement;
+  readonly park: (threadId: string) => void;
+  readonly flush: (threadId: string) => void;
+}
+
+interface FloatingBrowserChromeParkOptions {
+  readonly parkUntilMs?: number;
+  readonly setTimer?: (callback: () => void, delayMs: number) => BrowserPanelHideTimer;
+  readonly clearTimer?: (timer: BrowserPanelHideTimer) => void;
+  readonly ensureSlot?: (threadId: string) => HTMLElement;
+  readonly findSlot?: (threadId: string) => HTMLElement | null;
+}
+
+export function createFloatingBrowserChromePark(
+  options: FloatingBrowserChromeParkOptions = {},
+): FloatingBrowserChromePark {
+  const parkUntilMs = options.parkUntilMs ?? FLOATING_BROWSER_CHROME_PARK_MS;
+  const setTimer =
+    options.setTimer ??
+    ((callback, delayMs) => globalThis.setTimeout(callback, delayMs) as BrowserPanelHideTimer);
+  const clearTimer =
+    options.clearTimer ??
+    ((timer) => globalThis.clearTimeout(timer as ReturnType<typeof globalThis.setTimeout>));
+  const ensureSlot = options.ensureSlot ?? getFloatingBrowserChromeSlot;
+  const findSlot = options.findSlot ?? findFloatingBrowserChromeSlot;
+  const parkedByThreadId = new Map<string, { slot: HTMLElement; timer: BrowserPanelHideTimer }>();
+
+  function disposeChromeSlot(slot: HTMLElement): void {
+    for (const webview of Array.from(slot.querySelectorAll("webview"))) {
+      webview.remove();
+    }
+    slot.remove();
+  }
+
+  function clearParked(threadId: string): HTMLElement | null {
+    const parked = parkedByThreadId.get(threadId);
+    if (!parked) {
+      return null;
+    }
+    parkedByThreadId.delete(threadId);
+    clearTimer(parked.timer);
+    return parked.slot;
+  }
+
+  function take(threadId: string): HTMLElement {
+    clearParked(threadId);
+    return ensureSlot(threadId);
+  }
+
+  function park(threadId: string): void {
+    const slot = findSlot(threadId);
+    if (!slot) {
+      return;
+    }
+    applyFloatingBrowserChromeSlotStyle(slot, null);
+    const replaced = clearParked(threadId);
+    if (replaced && replaced !== slot) {
+      disposeChromeSlot(replaced);
+    }
+    const timer = setTimer(() => {
+      parkedByThreadId.delete(threadId);
+      disposeChromeSlot(slot);
+    }, parkUntilMs);
+    parkedByThreadId.set(threadId, { slot, timer });
+  }
+
+  function flush(threadId: string): void {
+    const parked = clearParked(threadId);
+    const live = findSlot(threadId);
+    if (parked && parked !== live) {
+      disposeChromeSlot(parked);
+    }
+    if (live) {
+      disposeChromeSlot(live);
+    }
+  }
+
+  return { take, park, flush };
+}
+
+export const floatingBrowserChromePark = createFloatingBrowserChromePark();
 
 export const FLOATING_BROWSER_CHROME_SRCDOC = `<!doctype html>
 <html>
@@ -462,9 +594,7 @@ export const FLOATING_BROWSER_CHROME_SRCDOC = `<!doctype html>
   </body>
 </html>`;
 
-function floatingBrowserChromeGuest(
-  webview: HTMLElement,
-): HTMLElement & {
+function floatingBrowserChromeGuest(webview: HTMLElement): HTMLElement & {
   executeJavaScript?: (code: string) => Promise<unknown>;
   send?: (channel: string, ...args: unknown[]) => void;
 } {
@@ -506,8 +636,7 @@ export function handoffBrowserGuestToDockedSurface(input: {
   input.slot.style.border = "";
   input.slot.style.boxShadow = "";
   const stage =
-    input.stage ??
-    input.slot.querySelector<HTMLElement>("[data-floating-browser-stage='true']");
+    input.stage ?? input.slot.querySelector<HTMLElement>("[data-floating-browser-stage='true']");
   if (stage) {
     applyBrowserWebviewPresentation(stage, {
       floating: false,
@@ -529,15 +658,18 @@ export function handoffBrowserGuestToDockedSurface(input: {
 }
 
 export function ensureFloatingBrowserChromeWebview(slot: HTMLElement): HTMLElement {
-  let webview = slot.querySelector("webview");
-  if (webview instanceof HTMLElement) {
-    return webview;
+  const existing = slot.querySelector<HTMLElement>("webview");
+  if (existing) {
+    return existing;
   }
-  webview = document.createElement("webview");
+  const webview = document.createElement("webview");
   webview.setAttribute("partition", FLOATING_BROWSER_CHROME_PARTITION);
   webview.setAttribute("allowtransparency", "on");
   webview.style.cssText = "display:flex;width:100%;height:100%;background:transparent;";
-  webview.setAttribute("src", `data:text/html;charset=utf-8,${encodeURIComponent(FLOATING_BROWSER_CHROME_SRCDOC)}`);
+  webview.setAttribute(
+    "src",
+    `data:text/html;charset=utf-8,${encodeURIComponent(FLOATING_BROWSER_CHROME_SRCDOC)}`,
+  );
   slot.append(webview);
   return webview;
 }

--- a/apps/web/src/components/BrowserPanel.tsx
+++ b/apps/web/src/components/BrowserPanel.tsx
@@ -71,8 +71,13 @@ import {
   applyBrowserRendererGuestSlotStyle,
   applyBrowserWebviewPageZoom,
   applyBrowserWebviewPresentation,
+  BROWSER_RENDERER_GUEST_THREAD_ATTRIBUTE,
+  BROWSER_RENDERER_PARKING_CONTAINER_ID,
+  FLOATING_BROWSER_CHROME_THREAD_ATTRIBUTE,
   getBrowserRendererGuestSlot,
+  handoffBrowserGuestToDockedSurface,
   hasObscuringHitStackElementAboveSurface,
+  isBrowserRendererGuestHitTarget,
   isBrowserPanelBoundsHiddenKey,
   normalizeBrowserAddressInput,
   readFloatingBrowserPanelBorderRadius,
@@ -192,6 +197,10 @@ const NATIVE_BROWSER_NON_OBSCURING_OVERLAY_SELECTOR = [
   "[data-slot='toast-viewport']",
   "[data-slot='toast-viewport-anchored']",
   "[data-slot='toast-positioner']",
+  `[${BROWSER_RENDERER_GUEST_THREAD_ATTRIBUTE}]`,
+  `#${BROWSER_RENDERER_PARKING_CONTAINER_ID}`,
+  `[${FLOATING_BROWSER_CHROME_THREAD_ATTRIBUTE}]`,
+  "webview",
 ].join(", ");
 
 interface BrowserViewportPerfCounters {
@@ -339,6 +348,9 @@ function rectsIntersect(a: DOMRect, b: DOMRect): boolean {
 }
 
 function candidateObscuresNativeBrowser(candidate: HTMLElement, element: HTMLElement): boolean {
+  if (isBrowserRendererGuestHitTarget(candidate)) {
+    return false;
+  }
   if (candidate === element || candidate.contains(element) || element.contains(candidate)) {
     return false;
   }
@@ -375,7 +387,8 @@ function hasTopLayerDomObstruction(element: HTMLElement): boolean {
       hasObscuringHitStackElementAboveSurface(hitElements, {
         isSurfaceBoundary: (hitElement) =>
           hitElement === element ||
-          (hitElement instanceof HTMLElement && element.contains(hitElement)),
+          (hitElement instanceof HTMLElement &&
+            (element.contains(hitElement) || isBrowserRendererGuestHitTarget(hitElement))),
         isNonObscuring: (hitElement) =>
           hitElement instanceof HTMLElement &&
           isNativeBrowserNonObscuringOverlayElement(hitElement),
@@ -837,7 +850,8 @@ export function BrowserPanel({
         if (webview.parentElement !== parkStage) {
           parkStage.append(webview);
         }
-        layoutBrowserRendererGuestSlot(slot, null, isFloatingMode);
+        layoutBrowserRendererGuestSlot(slot, null, false);
+        applyBrowserWebviewPageZoom(webview, 1);
         browserPanelRendererHandoff.parkGuest(threadId, {
           tabId,
           webContentsId,
@@ -1037,7 +1051,18 @@ export function BrowserPanel({
         : {}),
     });
     if (!isFloatingMode) {
-      layoutBrowserRendererGuestSlot(slot, host, false);
+      const rect = host.getBoundingClientRect();
+      handoffBrowserGuestToDockedSurface({
+        slot,
+        host: {
+          left: rect.left,
+          top: rect.top,
+          width: rect.width,
+          height: rect.height,
+        },
+        stage,
+        webview,
+      });
     }
 
     const initialUrl = activeTabInitialUrlRef.current;
@@ -1279,38 +1304,47 @@ export function BrowserPanel({
       // While the local-servers home is up, force the browser surface hidden instead of
       // trusting the obscuring-overlay heuristic. The native/inline webview otherwise paints
       // about:blank white over our dark DOM home — the "always white" empty state.
+      const occlusionSurface =
+        !isFloatingMode && !usesNativeRuntime ? getBrowserRendererGuestSlot(threadId) : element;
       const obscuredByOverlay =
         !isFloatingMode &&
         (browserPageError !== null ||
           shouldOccludeBrowserWebview({
             showLocalServersHome,
             browserActionsMenuOpen,
-            hasObscuringOverlay: hasNativeBrowserObscuringOverlay(element),
+            hasObscuringOverlay: hasNativeBrowserObscuringOverlay(occlusionSurface),
           }));
       lastOverlayObscuredRef.current = obscuredByOverlay;
       setBrowserWebviewOverlayOcclusion(browserWebviewRef.current, obscuredByOverlay);
       const webview = browserWebviewRef.current;
       const stage = browserWebviewStageRef.current;
+      const rect = element.getBoundingClientRect();
       if (!isFloatingMode) {
-        layoutBrowserRendererGuestSlot(getBrowserRendererGuestSlot(threadId), element, false);
-      }
-      if (stage) {
+        handoffBrowserGuestToDockedSurface({
+          slot: getBrowserRendererGuestSlot(threadId),
+          host: {
+            left: rect.left,
+            top: rect.top,
+            width: rect.width,
+            height: rect.height,
+          },
+          stage,
+          webview,
+        });
+      } else if (stage) {
         applyBrowserWebviewPresentation(stage, {
-          floating: isFloatingMode,
+          floating: true,
           slotWidth: element.clientWidth,
           slotHeight: element.clientHeight,
-          ...(isFloatingMode
-            ? { borderRadius: readFloatingBrowserPanelBorderRadius(element) }
-            : {}),
+          borderRadius: readFloatingBrowserPanelBorderRadius(element),
         });
       } else if (webview) {
         applyBrowserWebviewPresentation(webview, {
-          floating: isFloatingMode,
+          floating: true,
           slotWidth: element.clientWidth,
           slotHeight: element.clientHeight,
         });
       }
-      const rect = element.getBoundingClientRect();
       const bounds = obscuredByOverlay
         ? null
         : (() => {

--- a/apps/web/src/components/BrowserPanel.tsx
+++ b/apps/web/src/components/BrowserPanel.tsx
@@ -36,7 +36,7 @@ import {
   BROWSER_BLANK_URL,
   isBlankBrowserTabUrl,
   resolveCopyableBrowserTabUrl,
-  resolveFloatingBrowserGuestLayout,
+  resolveBrowserFloatingZoomFactor,
 } from "@synara/shared/browserSession";
 import {
   BROWSER_COPY_LINK_TOAST_TITLE,
@@ -68,13 +68,18 @@ import {
   createBrowserPanelHideScheduler,
   createBrowserPanelRendererHandoff,
   createBrowserRendererLossHandler,
-  hasObscuringHitStackElementAboveSurface,
-  normalizeBrowserAddressInput,
-  resolveBrowserChromeStatus,
-  resolveBrowserAddressSync,
-  shouldOccludeBrowserWebview,
+  applyBrowserRendererGuestSlotStyle,
+  applyBrowserWebviewPageZoom,
   applyBrowserWebviewPresentation,
+  getBrowserRendererGuestSlot,
+  hasObscuringHitStackElementAboveSurface,
   isBrowserPanelBoundsHiddenKey,
+  normalizeBrowserAddressInput,
+  readFloatingBrowserPanelBorderRadius,
+  resolveBrowserAddressSync,
+  resolveBrowserChromeStatus,
+  shouldAssignBrowserWebviewSrc,
+  shouldOccludeBrowserWebview,
   type BrowserAddressSuggestion,
 } from "./BrowserPanel.logic";
 import { DiffPanelLoadingState, DiffPanelShell, type DiffPanelMode } from "./DiffPanelShell";
@@ -204,6 +209,7 @@ interface BrowserViewportPerfCounters {
 
 interface BrowserWebviewElement extends HTMLElement {
   getWebContentsId?: () => number;
+  setZoomFactor?: (factor: number) => void;
 }
 
 const VIEWPORT_TRANSITION_PROPERTIES = new Set([
@@ -254,6 +260,43 @@ function ignoreBrowserBoundsSyncError(): void {
 
 function ignoreBrowserWebviewDetachError(): void {
   // Renderer webview detach is best-effort cleanup; a stale/destroyed guest is already gone.
+}
+
+function layoutBrowserRendererGuestSlot(
+  slot: HTMLElement,
+  host: HTMLElement | null,
+  floating: boolean,
+): void {
+  const borderRadius =
+    floating && host ? readFloatingBrowserPanelBorderRadius(host) : "0px";
+  if (!host) {
+    applyBrowserRendererGuestSlotStyle(slot, null, { borderRadius });
+    slot.style.border = "";
+    slot.style.boxShadow = "";
+    return;
+  }
+  const rect = host.getBoundingClientRect();
+  applyBrowserRendererGuestSlotStyle(
+    slot,
+    {
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+      height: rect.height,
+    },
+    { borderRadius },
+  );
+  if (floating) {
+    const panel = host.closest("[data-floating-browser-panel]");
+    if (panel instanceof HTMLElement) {
+      const styles = window.getComputedStyle(panel);
+      slot.style.border = styles.border;
+      slot.style.boxShadow = styles.boxShadow;
+    }
+  } else {
+    slot.style.border = "";
+    slot.style.boxShadow = "";
+  }
 }
 
 function setBrowserWebviewOverlayOcclusion(
@@ -716,24 +759,15 @@ export function BrowserPanel({
     }
   }, []);
 
-  // Renderer-owned <webview>s are adopted by the desktop manager. Always detach before
-  // removing the DOM node so main never keeps a stale webContents runtime.
-  const detachRendererBrowserWebview = useCallback(
-    (expectedWebview?: BrowserWebviewElement) => {
-      const webview = browserWebviewRef.current;
-      if (
-        !webview ||
-        (expectedWebview !== undefined && webview !== expectedWebview) ||
-        detachedBrowserWebviewsRef.current.has(webview)
-      ) {
+  const destroyRendererBrowserWebview = useCallback(
+    (webview: BrowserWebviewElement, tabId: string | null, webContentsIdHint: number | null) => {
+      if (detachedBrowserWebviewsRef.current.has(webview)) {
         return;
       }
       detachedBrowserWebviewsRef.current.add(webview);
 
-      const tabId = browserWebviewTabIdRef.current;
-
-      if (api && isLiveRuntime && tabId) {
-        let webContentsId = browserWebviewWebContentsIdRef.current ?? undefined;
+      if (api && tabId) {
+        let webContentsId = webContentsIdHint ?? undefined;
         try {
           webContentsId ??= webview.getWebContentsId?.();
         } catch {
@@ -755,7 +789,29 @@ export function BrowserPanel({
         webview.remove();
       } catch {
         ignoreBrowserWebviewDetachError();
-      } finally {
+      }
+    },
+    [api, threadId],
+  );
+
+  // Renderer-owned <webview>s are adopted by the desktop manager. Destroy the guest
+  // when the page is gone for good; otherwise park it so a dock/floating successor
+  // can reparent the same WebContents instead of reloading the URL.
+  const detachRendererBrowserWebview = useCallback(
+    (expectedWebview?: BrowserWebviewElement, destroyGuest = false) => {
+      const webview = browserWebviewRef.current;
+      if (
+        !webview ||
+        (expectedWebview !== undefined && webview !== expectedWebview) ||
+        detachedBrowserWebviewsRef.current.has(webview)
+      ) {
+        return;
+      }
+
+      const tabId = browserWebviewTabIdRef.current;
+      const webContentsId = browserWebviewWebContentsIdRef.current;
+      const stage = browserWebviewStageRef.current;
+      const releaseRefs = () => {
         if (browserWebviewRef.current === webview) {
           browserWebviewRef.current = null;
           browserWebviewTabIdRef.current = null;
@@ -763,14 +819,59 @@ export function BrowserPanel({
           browserWebviewAttachKeyRef.current = null;
           browserWebviewAttachInFlightKeyRef.current = null;
         }
-        const stage = browserWebviewStageRef.current;
-        if (stage && stage.childElementCount === 0) {
-          stage.remove();
+        if (stage && browserWebviewStageRef.current === stage) {
           browserWebviewStageRef.current = null;
         }
+      };
+
+      if (!destroyGuest && tabId) {
+        const slot = getBrowserRendererGuestSlot(threadId);
+        let parkStage = stage;
+        if (!parkStage) {
+          parkStage = document.createElement("div");
+          parkStage.dataset.floatingBrowserStage = "true";
+        }
+        if (parkStage.parentElement !== slot) {
+          slot.append(parkStage);
+        }
+        if (webview.parentElement !== parkStage) {
+          parkStage.append(webview);
+        }
+        layoutBrowserRendererGuestSlot(slot, null, isFloatingMode);
+        browserPanelRendererHandoff.parkGuest(threadId, {
+          tabId,
+          webContentsId,
+          stage: parkStage,
+          webview,
+          dispose: () => {
+            const liveSlot = getBrowserRendererGuestSlot(threadId);
+            if (webview.isConnected && liveSlot.contains(webview) && liveSlot.style.pointerEvents === "auto") {
+              return;
+            }
+            destroyRendererBrowserWebview(webview, tabId, webContentsId);
+            if (parkStage.childElementCount === 0) {
+              parkStage.remove();
+            }
+            if (liveSlot.childElementCount === 0) {
+              liveSlot.remove();
+            }
+          },
+        });
+        releaseRefs();
+        return;
       }
+
+      destroyRendererBrowserWebview(webview, tabId, webContentsId);
+      if (stage && stage.childElementCount === 0) {
+        stage.remove();
+      }
+      const slot = getBrowserRendererGuestSlot(threadId);
+      if (slot.childElementCount === 0) {
+        slot.remove();
+      }
+      releaseRefs();
     },
-    [api, isLiveRuntime, threadId],
+    [destroyRendererBrowserWebview, isFloatingMode, threadId],
   );
 
   useEffect(() => {
@@ -851,12 +952,12 @@ export function BrowserPanel({
   }, [activeTab]);
 
   useLayoutEffect(() => {
-    if (!api || !isLiveRuntime || !workspaceReady || !activeTabId) {
+    if (!api || !isLiveRuntime || !activeTabId) {
       return;
     }
 
     if (showLocalServersHome || usesNativeRuntime) {
-      detachRendererBrowserWebview();
+      detachRendererBrowserWebview(undefined, true);
       return;
     }
 
@@ -865,18 +966,43 @@ export function BrowserPanel({
       return;
     }
 
-    let stage = browserWebviewStageRef.current;
+    const slot = getBrowserRendererGuestSlot(threadId);
+    browserPanelRendererHandoff.takeParkedGuest(threadId);
+    const existingStage = slot.querySelector<HTMLDivElement>("[data-floating-browser-stage='true']");
+    const existingWebview = (existingStage?.querySelector("webview") ??
+      slot.querySelector("webview")) as BrowserWebviewElement | null;
+
+    let stage = existingStage ?? browserWebviewStageRef.current;
     if (!stage) {
       stage = document.createElement("div");
       stage.dataset.floatingBrowserStage = "true";
-      browserWebviewStageRef.current = stage;
     }
-    if (stage.parentElement !== host) {
-      host.append(stage);
+    if (stage.parentElement !== slot) {
+      slot.append(stage);
+    }
+    browserWebviewStageRef.current = stage;
+    if (existingWebview) {
+      browserWebviewRef.current = existingWebview;
+      browserWebviewTabIdRef.current =
+        existingWebview.dataset.tabId ?? browserWebviewTabIdRef.current;
+      try {
+        browserWebviewWebContentsIdRef.current = existingWebview.getWebContentsId?.() ?? null;
+      } catch {
+        browserWebviewWebContentsIdRef.current = browserWebviewWebContentsIdRef.current;
+      }
+      browserWebviewAttachKeyRef.current = null;
+      browserWebviewAttachInFlightKeyRef.current = null;
+    }
+
+    if (!isFloatingMode) {
+      layoutBrowserRendererGuestSlot(slot, host, false);
     }
 
     let webview = browserWebviewRef.current;
     if (!webview) {
+      if (!workspaceReady) {
+        return;
+      }
       webview = document.createElement("webview") as BrowserWebviewElement;
       webview.className = "h-full w-full";
       webview.style.display = "flex";
@@ -899,21 +1025,37 @@ export function BrowserPanel({
       browserWebviewWebContentsIdRef.current = null;
       browserWebviewRef.current = webview;
     }
-    if (webview.parentElement !== stage) {
+    if (webview.parentElement !== stage && stage !== webview) {
       stage.append(webview);
     }
     applyBrowserWebviewPresentation(stage, {
       floating: isFloatingMode,
       slotWidth: host.clientWidth,
       slotHeight: host.clientHeight,
+      ...(isFloatingMode
+        ? { borderRadius: readFloatingBrowserPanelBorderRadius(host) }
+        : {}),
     });
+    if (!isFloatingMode) {
+      layoutBrowserRendererGuestSlot(slot, host, false);
+    }
 
     const initialUrl = activeTabInitialUrlRef.current;
-    const shouldLoadInitialUrl = browserWebviewTabIdRef.current !== activeTabId;
+    const guestTabId = webview.dataset.tabId ?? null;
+    const shouldLoadInitialUrl = shouldAssignBrowserWebviewSrc({
+      activeTabId,
+      boundTabId: browserWebviewTabIdRef.current,
+      guestTabId,
+    });
     if (shouldLoadInitialUrl) {
       browserWebviewTabIdRef.current = activeTabId;
       browserWebviewAttachKeyRef.current = null;
       webview.dataset.tabId = activeTabId;
+    } else {
+      browserWebviewTabIdRef.current = activeTabId;
+      if (!webview.dataset.tabId) {
+        webview.dataset.tabId = activeTabId;
+      }
     }
 
     let cancelled = false;
@@ -1025,20 +1167,34 @@ export function BrowserPanel({
       tabId: activeTabId,
       isCurrent: (candidate) =>
         browserWebviewRef.current === candidate && browserWebviewTabIdRef.current === activeTabId,
-      detach: detachRendererBrowserWebview,
+      detach: (renderer) => detachRendererBrowserWebview(renderer, true),
       recover: ({ generation }) => {
         setBrowserRendererGeneration((current) => Math.max(current + 1, generation));
       },
     });
+
+    const applyGuestPageZoom = () => {
+      const host = browserViewportRef.current;
+      const width = host?.getBoundingClientRect().width ?? 0;
+      applyBrowserWebviewPageZoom(
+        webview,
+        isFloatingMode ? resolveBrowserFloatingZoomFactor(width) : 1,
+      );
+    };
 
     // Subscribe before assigning src: a cached/blank page may begin loading
     // synchronously, before getWebContentsId() becomes available. The bounded
     // backoff below makes that renderer-to-main handshake reliable even while
     // Electron throttles requestAnimationFrame in the background.
     webview.addEventListener("dom-ready", attachVisibleWebview);
+    webview.addEventListener("dom-ready", applyGuestPageZoom);
     webview.addEventListener("did-start-loading", attachVisibleWebview);
+    webview.addEventListener("did-finish-load", applyGuestPageZoom);
+    webview.addEventListener("did-navigate", applyGuestPageZoom);
+    webview.addEventListener("did-navigate-in-page", applyGuestPageZoom);
     webview.addEventListener("render-process-gone", handleRendererLoss);
     webview.addEventListener("destroyed", handleRendererLoss);
+    applyGuestPageZoom();
     if (shouldLoadInitialUrl) {
       webview.setAttribute(
         "src",
@@ -1053,7 +1209,11 @@ export function BrowserPanel({
         window.clearTimeout(attachRetryTimer);
       }
       webview.removeEventListener("dom-ready", attachVisibleWebview);
+      webview.removeEventListener("dom-ready", applyGuestPageZoom);
       webview.removeEventListener("did-start-loading", attachVisibleWebview);
+      webview.removeEventListener("did-finish-load", applyGuestPageZoom);
+      webview.removeEventListener("did-navigate", applyGuestPageZoom);
+      webview.removeEventListener("did-navigate-in-page", applyGuestPageZoom);
       webview.removeEventListener("render-process-gone", handleRendererLoss);
       webview.removeEventListener("destroyed", handleRendererLoss);
     };
@@ -1131,11 +1291,17 @@ export function BrowserPanel({
       setBrowserWebviewOverlayOcclusion(browserWebviewRef.current, obscuredByOverlay);
       const webview = browserWebviewRef.current;
       const stage = browserWebviewStageRef.current;
+      if (!isFloatingMode) {
+        layoutBrowserRendererGuestSlot(getBrowserRendererGuestSlot(threadId), element, false);
+      }
       if (stage) {
         applyBrowserWebviewPresentation(stage, {
           floating: isFloatingMode,
           slotWidth: element.clientWidth,
           slotHeight: element.clientHeight,
+          ...(isFloatingMode
+            ? { borderRadius: readFloatingBrowserPanelBorderRadius(element) }
+            : {}),
         });
       } else if (webview) {
         applyBrowserWebviewPresentation(webview, {
@@ -1155,33 +1321,18 @@ export function BrowserPanel({
             // pixels measured above while the shell sits at 100% zoom. Convert, or a
             // zoomed shell leaves the browser surface sized 1/zoom off its DOM slot.
             const zoom = readDesktopZoomFactor();
-            if (isFloatingMode) {
-              // Keep the guest viewport frozen at 1280×800. Slot resize is CSS scale
-              // only, so main/CDP do not see a new page size on every drag frame.
-              const layout = resolveFloatingBrowserGuestLayout({
-                width: rect.width,
-                height: rect.height,
-              });
-              return resolveDesktopDipRectFromCssRect(
-                {
-                  x: rect.left + layout.x,
-                  y: rect.top + layout.y,
-                  width: layout.width,
-                  height: layout.height,
-                },
-                zoom,
-              );
-            }
             return resolveDesktopDipRectFromCssRect(
               { x: rect.left, y: rect.top, width: rect.width, height: rect.height },
               zoom,
             );
           })();
       const surface = isFloatingMode || !usesNativeRuntime ? "renderer" : "native";
-      // Native WebContentsViews and adopted renderer <webview>s share the same main-process
-      // WebContents. Floating presentation is a CSS scale of the frozen 1280x800 guest, so
-      // keep page zoom at 1 and avoid reflowing the live page as the card moves.
-      const pageZoomFactor = 1;
+      // Fit the 1280px desktop page into the floating card without reflowing it
+      // as a tiny mobile viewport (which looks zoomed in).
+      const pageZoomFactor = isFloatingMode
+        ? resolveBrowserFloatingZoomFactor(rect.width)
+        : 1;
+      applyBrowserWebviewPageZoom(webview, pageZoomFactor);
       const nextKey = bounds
         ? `${surface}:${Math.round(bounds.x)}:${Math.round(bounds.y)}:${Math.round(bounds.width)}:${Math.round(bounds.height)}:zoom-${pageZoomFactor}`
         : `${surface}:hidden:zoom-${pageZoomFactor}`;
@@ -1999,7 +2150,7 @@ export function BrowserPanel({
               className={cn(
                 "absolute overflow-hidden",
                 isFloatingMode ? "bg-transparent" : "bg-[#0d0d0d]",
-                isFloatingMode && "rounded-[10px] [clip-path:inset(0_round_10px)]",
+                isFloatingMode && "rounded-xl [clip-path:inset(0_round_12px)]",
                 "inset-0",
               )}
             />

--- a/apps/web/src/components/BrowserPanel.tsx
+++ b/apps/web/src/components/BrowserPanel.tsx
@@ -65,8 +65,8 @@ import {
   browserAddressDisplayValue,
   browserWebviewInitialUrl,
   buildBrowserAddressSuggestions,
+  browserPanelRendererHandoff,
   createBrowserPanelHideScheduler,
-  createBrowserPanelRendererHandoff,
   createBrowserRendererLossHandler,
   applyBrowserRendererGuestSlotStyle,
   applyBrowserWebviewPageZoom,
@@ -115,7 +115,6 @@ const BROWSER_WEBVIEW_PARTITION = "persist:synara-browser";
 const BROWSER_PERF_SAMPLE_INTERVAL_MS = 5_000;
 const SYNARA_BROWSER_LABEL = "Synara browser";
 const browserPanelHideScheduler = createBrowserPanelHideScheduler();
-const browserPanelRendererHandoff = createBrowserPanelRendererHandoff();
 // The address field and tab pills share one chrome-control surface so the whole row reads
 // as a single cohesive control: matching height, radius, border width, and type scale.
 const BROWSER_CHROME_CONTROL_CLASS_NAME = "h-8 rounded-lg border text-xs";
@@ -276,8 +275,7 @@ function layoutBrowserRendererGuestSlot(
   host: HTMLElement | null,
   floating: boolean,
 ): void {
-  const borderRadius =
-    floating && host ? readFloatingBrowserPanelBorderRadius(host) : "0px";
+  const borderRadius = floating && host ? readFloatingBrowserPanelBorderRadius(host) : "0px";
   if (!host) {
     applyBrowserRendererGuestSlotStyle(slot, null, { borderRadius });
     slot.style.border = "";
@@ -858,10 +856,9 @@ export function BrowserPanel({
           stage: parkStage,
           webview,
           dispose: () => {
+            // takeParkedGuest is the claim path. dispose means this park lease
+            // expired or was flushed — always tear the guest down.
             const liveSlot = getBrowserRendererGuestSlot(threadId);
-            if (webview.isConnected && liveSlot.contains(webview) && liveSlot.style.pointerEvents === "auto") {
-              return;
-            }
             destroyRendererBrowserWebview(webview, tabId, webContentsId);
             if (parkStage.childElementCount === 0) {
               parkStage.remove();
@@ -885,7 +882,7 @@ export function BrowserPanel({
       }
       releaseRefs();
     },
-    [destroyRendererBrowserWebview, isFloatingMode, threadId],
+    [destroyRendererBrowserWebview, threadId],
   );
 
   useEffect(() => {
@@ -982,7 +979,9 @@ export function BrowserPanel({
 
     const slot = getBrowserRendererGuestSlot(threadId);
     browserPanelRendererHandoff.takeParkedGuest(threadId);
-    const existingStage = slot.querySelector<HTMLDivElement>("[data-floating-browser-stage='true']");
+    const existingStage = slot.querySelector<HTMLDivElement>(
+      "[data-floating-browser-stage='true']",
+    );
     const existingWebview = (existingStage?.querySelector("webview") ??
       slot.querySelector("webview")) as BrowserWebviewElement | null;
 
@@ -1002,7 +1001,7 @@ export function BrowserPanel({
       try {
         browserWebviewWebContentsIdRef.current = existingWebview.getWebContentsId?.() ?? null;
       } catch {
-        browserWebviewWebContentsIdRef.current = browserWebviewWebContentsIdRef.current;
+        // A not-yet-ready guest cannot answer; attachment below re-captures the id.
       }
       browserWebviewAttachKeyRef.current = null;
       browserWebviewAttachInFlightKeyRef.current = null;
@@ -1046,9 +1045,7 @@ export function BrowserPanel({
       floating: isFloatingMode,
       slotWidth: host.clientWidth,
       slotHeight: host.clientHeight,
-      ...(isFloatingMode
-        ? { borderRadius: readFloatingBrowserPanelBorderRadius(host) }
-        : {}),
+      ...(isFloatingMode ? { borderRadius: readFloatingBrowserPanelBorderRadius(host) } : {}),
     });
     if (!isFloatingMode) {
       const rect = host.getBoundingClientRect();
@@ -1363,9 +1360,7 @@ export function BrowserPanel({
       const surface = isFloatingMode || !usesNativeRuntime ? "renderer" : "native";
       // Fit the 1280px desktop page into the floating card without reflowing it
       // as a tiny mobile viewport (which looks zoomed in).
-      const pageZoomFactor = isFloatingMode
-        ? resolveBrowserFloatingZoomFactor(rect.width)
-        : 1;
+      const pageZoomFactor = isFloatingMode ? resolveBrowserFloatingZoomFactor(rect.width) : 1;
       applyBrowserWebviewPageZoom(webview, pageZoomFactor);
       const nextKey = bounds
         ? `${surface}:${Math.round(bounds.x)}:${Math.round(bounds.y)}:${Math.round(bounds.width)}:${Math.round(bounds.height)}:zoom-${pageZoomFactor}`

--- a/apps/web/src/components/chat/FloatingBrowserPanel.tsx
+++ b/apps/web/src/components/chat/FloatingBrowserPanel.tsx
@@ -24,7 +24,17 @@ import {
   removePanelResizeOverlay,
 } from "../../lib/panelResize";
 import { cn } from "../../lib/utils";
+import { isElectron } from "../../env";
 import { IconButton } from "../ui/icon-button";
+import {
+  applyBrowserRendererGuestSlotStyle,
+  applyFloatingBrowserChromeSlotStyle,
+  ensureFloatingBrowserChromeWebview,
+  getBrowserRendererGuestSlot,
+  getFloatingBrowserChromeSlot,
+  nudgeFloatingBrowserChromeNativeView,
+  setFloatingBrowserChromeMenuOpen,
+} from "../BrowserPanel.logic";
 import {
   clampFloatingBrowserPanelRect,
   FLOATING_BROWSER_PANEL_DEFAULT_SIZE,
@@ -75,6 +85,61 @@ function hostSize(host: HTMLElement): FloatingBrowserPanelHostSize {
   };
 }
 
+function syncFloatingBrowserGuestSlot(threadId: ThreadId, panel: HTMLElement): void {
+  const slot = getBrowserRendererGuestSlot(threadId);
+  const rect = panel.getBoundingClientRect();
+  const styles = window.getComputedStyle(panel);
+  applyBrowserRendererGuestSlotStyle(
+    slot,
+    {
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+      height: rect.height,
+    },
+    { borderRadius: styles.borderTopLeftRadius },
+  );
+  slot.style.border = styles.border;
+  slot.style.boxShadow = styles.boxShadow;
+  applyFloatingBrowserChromeSlotStyle(
+    getFloatingBrowserChromeSlot(threadId),
+    {
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+      height: rect.height,
+    },
+  );
+}
+
+function setFloatingChromeExpanded(
+  threadId: ThreadId,
+  panel: HTMLElement | null,
+  expanded: boolean,
+): void {
+  const slot = getFloatingBrowserChromeSlot(threadId);
+  const webview = slot.querySelector("webview");
+  if (webview instanceof HTMLElement) {
+    setFloatingBrowserChromeMenuOpen(webview, expanded);
+  }
+  if (!panel) {
+    applyFloatingBrowserChromeSlotStyle(slot, null, { expanded });
+    return;
+  }
+  const rect = panel.getBoundingClientRect();
+  applyFloatingBrowserChromeSlotStyle(
+    slot,
+    {
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+      height: rect.height,
+    },
+    { expanded },
+  );
+  nudgeFloatingBrowserChromeNativeView(slot);
+}
+
 export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
   const hostRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -85,6 +150,9 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
   const panelRectRef = useRef<FloatingBrowserPanelRect>(DEFAULT_FLOATING_RECT);
   const [panelRect, setPanelRect] = useState<FloatingBrowserPanelRect>(DEFAULT_FLOATING_RECT);
   const [controlsOpen, setControlsOpen] = useState(false);
+  const startDragFromClientRef = useRef<
+    (x: number, y: number, options: { reopenMenuOnRelease: boolean }) => void
+  >(() => {});
 
   const applyPanelRect = useCallback((next: FloatingBrowserPanelRect, host: HTMLElement) => {
     const clamped = clampFloatingBrowserPanelRect(next, hostSize(host));
@@ -95,9 +163,10 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
       panel.style.top = `${clamped.top}px`;
       panel.style.width = `${clamped.width}px`;
       panel.style.height = `${clamped.height}px`;
+      syncFloatingBrowserGuestSlot(props.threadId, panel);
     }
     return clamped;
-  }, []);
+  }, [props.threadId]);
 
   const commitPanelRect = useCallback(
     (next: FloatingBrowserPanelRect, host: HTMLElement) => {
@@ -140,12 +209,22 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
     return () => {
       activeInteractionCleanupRef.current?.();
       activeInteractionCleanupRef.current = null;
+      applyFloatingBrowserChromeSlotStyle(getFloatingBrowserChromeSlot(props.threadId), null);
     };
-  }, []);
+  }, [props.threadId]);
 
   useLayoutEffect(() => {
     requestBrowserPanelBoundsSync();
-  }, [panelRect]);
+    if (!isElectron) {
+      return;
+    }
+    const panel = panelRef.current;
+    if (!panel) {
+      return;
+    }
+    syncFloatingBrowserGuestSlot(props.threadId, panel);
+    nudgeFloatingBrowserChromeNativeView(getFloatingBrowserChromeSlot(props.threadId));
+  }, [panelRect, props.threadId]);
 
   const startResize = (event: ReactPointerEvent<HTMLDivElement>) => {
     const host = hostRef.current;
@@ -213,19 +292,20 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
     activeInteractionCleanupRef.current = finish;
   };
 
-  const startHandleGesture = (event: ReactPointerEvent<HTMLElement>) => {
+  const startDragFromClient = (
+    startClientX: number,
+    startClientY: number,
+    options: { reopenMenuOnRelease: boolean },
+  ) => {
     const host = hostRef.current;
-    if (!host || event.button !== 0) return;
+    if (!host) return;
 
-    event.preventDefault();
-    event.stopPropagation();
     activeInteractionCleanupRef.current?.();
     didDragRef.current = false;
-    const reopenMenuOnRelease = !controlsOpen;
+    const reopenMenuOnRelease = options.reopenMenuOnRelease && !controlsOpen;
     setControlsOpen(false);
+    setFloatingChromeExpanded(props.threadId, panelRef.current, false);
 
-    const startClientX = event.clientX;
-    const startClientY = event.clientY;
     const startRect = panelRectRef.current;
     const resizeOverlay = createPanelResizeOverlay("grabbing");
     const previousBodyCursor = document.body.style.cursor;
@@ -250,6 +330,7 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
       }
       if (openMenu && reopenMenuOnRelease) {
         setControlsOpen(true);
+        setFloatingChromeExpanded(props.threadId, panelRef.current, true);
       }
     };
     const finishWithRelease = () => finish(true);
@@ -277,12 +358,59 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
     });
     activeInteractionCleanupRef.current = finishWithRelease;
   };
+  startDragFromClientRef.current = startDragFromClient;
+
+  const startHandleGesture = (event: ReactPointerEvent<HTMLElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    startDragFromClient(event.clientX, event.clientY, { reopenMenuOnRelease: true });
+  };
+
+  useLayoutEffect(() => {
+    if (!isElectron) {
+      return;
+    }
+    const slot = getFloatingBrowserChromeSlot(props.threadId);
+    const webview = ensureFloatingBrowserChromeWebview(slot);
+    const panel = panelRef.current;
+    if (panel) {
+      syncFloatingBrowserGuestSlot(props.threadId, panel);
+      nudgeFloatingBrowserChromeNativeView(slot);
+    }
+    const onIpcMessage = (event: Event) => {
+      const message = event as Event & { channel?: string; args?: unknown[] };
+      const channel = message.channel;
+      const payload = message.args?.[0];
+      if (channel === "drag") {
+        const point = payload as { x?: number; y?: number; button?: number } | undefined;
+        if (point?.button != null && point.button !== 0) return;
+        const rect = slot.getBoundingClientRect();
+        startDragFromClientRef.current(rect.left + (point?.x ?? 0), rect.top + (point?.y ?? 0), {
+          reopenMenuOnRelease: true,
+        });
+        return;
+      }
+      if (channel === "pop") {
+        setFloatingChromeExpanded(props.threadId, panelRef.current, false);
+        props.onPopToSidebar();
+        return;
+      }
+      if (channel === "close") {
+        props.onClose();
+      }
+    };
+    webview.addEventListener("ipc-message", onIpcMessage);
+    return () => {
+      webview.removeEventListener("ipc-message", onIpcMessage);
+    };
+  }, [props.onClose, props.onPopToSidebar, props.threadId]);
 
   return (
     <div
       ref={hostRef}
       data-floating-browser-host="true"
-      className="pointer-events-none absolute inset-x-0 bottom-0 z-30 overflow-hidden"
+      className="pointer-events-none absolute inset-x-0 bottom-0 z-30 overflow-visible"
       style={{ top: `${CHAT_SURFACE_HEADER_HEIGHT_PX}px` }}
     >
       <div
@@ -290,7 +418,7 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
         data-floating-browser-panel="true"
         role="region"
         aria-label="Floating browser"
-        className="group/floating-browser pointer-events-auto absolute flex flex-col overflow-visible rounded-xl border border-border bg-transparent text-foreground shadow-2xl ring-1 ring-black/10"
+        className="group/floating-browser pointer-events-none absolute flex flex-col overflow-visible rounded-xl border border-border bg-background text-foreground shadow-2xl ring-1 ring-black/10"
         style={{
           left: `${panelRect.left}px`,
           top: `${panelRect.top}px`,
@@ -301,22 +429,13 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
         onPointerDown={startResize}
       >
         <div
-          data-floating-browser-content="true"
-          className="absolute inset-0 min-h-0 min-w-0 overflow-hidden rounded-[inherit]"
-        >
-          <Suspense fallback={<FloatingBrowserPanelFallback />}>
-            <LazyBrowserPanel
-              mode="floating"
-              threadId={props.threadId}
-              onClosePanel={props.onClose}
-            />
-          </Suspense>
-        </div>
-        <div
           data-floating-browser-controls="true"
-          className="pointer-events-none absolute right-2 top-2 z-[70]"
+          className={cn(
+            "pointer-events-auto absolute right-2 top-2 z-20",
+            isElectron && "hidden",
+          )}
         >
-          <div className="pointer-events-auto flex items-center gap-0.5 rounded-full border border-border/80 bg-background/90 p-0.5 shadow-sm backdrop-blur-md">
+          <div className="flex items-center gap-0.5 rounded-full border border-border/80 bg-background/90 p-0.5 shadow-sm backdrop-blur-md">
             <IconButton
               type="button"
               variant="ghost"
@@ -336,7 +455,9 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
               className={disclosureWidthClassName(controlsOpen, "w-[50px]")}
               inert={!controlsOpen}
             >
-              <div className={cn(DISCLOSURE_INNER_CLASS, "flex w-[50px] items-center gap-0.5")}>
+              <div
+                className={cn(DISCLOSURE_INNER_CLASS, "flex w-[50px] items-center gap-0.5")}
+              >
                 <IconButton
                   type="button"
                   variant="ghost"
@@ -375,13 +496,25 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
             </div>
           </div>
         </div>
+        <div
+          data-floating-browser-content="true"
+          className="pointer-events-none absolute inset-0 min-h-0 min-w-0 overflow-hidden rounded-[inherit]"
+        >
+          <Suspense fallback={<FloatingBrowserPanelFallback />}>
+            <LazyBrowserPanel
+              mode="floating"
+              threadId={props.threadId}
+              onClosePanel={props.onClose}
+            />
+          </Suspense>
+        </div>
         {RESIZE_HANDLES.map(({ edge, className }) => (
           <div
             key={edge}
             aria-hidden="true"
             data-panel-resize-overlay="true"
             data-floating-resize-edge={edge}
-            className={cn("z-[60]", className)}
+            className={cn("pointer-events-auto z-10", className)}
           />
         ))}
       </div>

--- a/apps/web/src/components/chat/FloatingBrowserPanel.tsx
+++ b/apps/web/src/components/chat/FloatingBrowserPanel.tsx
@@ -7,7 +7,6 @@ import {
   type PointerEvent as ReactPointerEvent,
   Suspense,
   useCallback,
-  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -27,10 +26,11 @@ import { cn } from "../../lib/utils";
 import { isElectron } from "../../env";
 import { IconButton } from "../ui/icon-button";
 import {
-  applyBrowserRendererGuestSlotStyle,
   applyFloatingBrowserChromeSlotStyle,
+  applyFloatingBrowserGuestSlotFrame,
+  browserPanelRendererHandoff,
   ensureFloatingBrowserChromeWebview,
-  getBrowserRendererGuestSlot,
+  floatingBrowserChromePark,
   getFloatingBrowserChromeSlot,
   nudgeFloatingBrowserChromeNativeView,
   setFloatingBrowserChromeMenuOpen,
@@ -40,7 +40,7 @@ import {
   FLOATING_BROWSER_PANEL_DEFAULT_SIZE,
   FLOATING_BROWSER_PANEL_MARGIN_PX,
   floatingBrowserResizeCursor,
-  initialFloatingBrowserPanelRect,
+  restoreFloatingBrowserPanelRect,
   isFloatingBrowserDragGesture,
   moveFloatingBrowserPanelRect,
   resizeFloatingBrowserPanelRect,
@@ -48,6 +48,7 @@ import {
   type FloatingBrowserPanelRect,
   type FloatingBrowserResizeEdge,
 } from "./floatingBrowserPanel.logic";
+import { useFloatingBrowserRequestStore } from "./floatingBrowserRequestStore";
 import { LazyBrowserPanel } from "./ChatThreadSurfacePrimitives";
 import { PanelStateMessage } from "./PanelStateMessage";
 
@@ -86,30 +87,22 @@ function hostSize(host: HTMLElement): FloatingBrowserPanelHostSize {
 }
 
 function syncFloatingBrowserGuestSlot(threadId: ThreadId, panel: HTMLElement): void {
-  const slot = getBrowserRendererGuestSlot(threadId);
+  if (!isElectron) {
+    return;
+  }
   const rect = panel.getBoundingClientRect();
   const styles = window.getComputedStyle(panel);
-  applyBrowserRendererGuestSlotStyle(
-    slot,
-    {
+  applyFloatingBrowserGuestSlotFrame(threadId, {
+    rect: {
       left: rect.left,
       top: rect.top,
       width: rect.width,
       height: rect.height,
     },
-    { borderRadius: styles.borderTopLeftRadius },
-  );
-  slot.style.border = styles.border;
-  slot.style.boxShadow = styles.boxShadow;
-  applyFloatingBrowserChromeSlotStyle(
-    getFloatingBrowserChromeSlot(threadId),
-    {
-      left: rect.left,
-      top: rect.top,
-      width: rect.width,
-      height: rect.height,
-    },
-  );
+    borderRadius: styles.borderTopLeftRadius,
+    border: styles.border,
+    boxShadow: styles.boxShadow,
+  });
 }
 
 function setFloatingChromeExpanded(
@@ -117,6 +110,9 @@ function setFloatingChromeExpanded(
   panel: HTMLElement | null,
   expanded: boolean,
 ): void {
+  if (!isElectron) {
+    return;
+  }
   const slot = getFloatingBrowserChromeSlot(threadId);
   const webview = slot.querySelector("webview");
   if (webview instanceof HTMLElement) {
@@ -147,32 +143,57 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
   const interactingRef = useRef(false);
   const didDragRef = useRef(false);
   const hasMeasuredHostRef = useRef(false);
-  const panelRectRef = useRef<FloatingBrowserPanelRect>(DEFAULT_FLOATING_RECT);
-  const [panelRect, setPanelRect] = useState<FloatingBrowserPanelRect>(DEFAULT_FLOATING_RECT);
+  const [panelRect, setPanelRect] = useState<FloatingBrowserPanelRect>(
+    () =>
+      useFloatingBrowserRequestStore.getState().rectByThreadId[props.threadId] ??
+      DEFAULT_FLOATING_RECT,
+  );
+  const panelRectRef = useRef<FloatingBrowserPanelRect>(panelRect);
+  const rememberPanelRect = useFloatingBrowserRequestStore((store) => store.rememberRect);
   const [controlsOpen, setControlsOpen] = useState(false);
+  const closeIntentRef = useRef<"close" | "handoff">("handoff");
   const startDragFromClientRef = useRef<
     (x: number, y: number, options: { reopenMenuOnRelease: boolean }) => void
   >(() => {});
 
-  const applyPanelRect = useCallback((next: FloatingBrowserPanelRect, host: HTMLElement) => {
-    const clamped = clampFloatingBrowserPanelRect(next, hostSize(host));
-    panelRectRef.current = clamped;
-    const panel = panelRef.current;
-    if (panel) {
-      panel.style.left = `${clamped.left}px`;
-      panel.style.top = `${clamped.top}px`;
-      panel.style.width = `${clamped.width}px`;
-      panel.style.height = `${clamped.height}px`;
-      syncFloatingBrowserGuestSlot(props.threadId, panel);
-    }
-    return clamped;
-  }, [props.threadId]);
+  const handleClose = useCallback(() => {
+    closeIntentRef.current = "close";
+    props.onClose();
+  }, [props.onClose]);
+
+  const handlePopToSidebar = useCallback(() => {
+    closeIntentRef.current = "handoff";
+    props.onPopToSidebar();
+  }, [props.onPopToSidebar]);
+  const handleCloseRef = useRef(handleClose);
+  const handlePopToSidebarRef = useRef(handlePopToSidebar);
+  handleCloseRef.current = handleClose;
+  handlePopToSidebarRef.current = handlePopToSidebar;
+
+  const applyPanelRect = useCallback(
+    (next: FloatingBrowserPanelRect, host: HTMLElement) => {
+      const clamped = clampFloatingBrowserPanelRect(next, hostSize(host));
+      panelRectRef.current = clamped;
+      const panel = panelRef.current;
+      if (panel) {
+        panel.style.left = `${clamped.left}px`;
+        panel.style.top = `${clamped.top}px`;
+        panel.style.width = `${clamped.width}px`;
+        panel.style.height = `${clamped.height}px`;
+        syncFloatingBrowserGuestSlot(props.threadId, panel);
+      }
+      return clamped;
+    },
+    [props.threadId],
+  );
 
   const commitPanelRect = useCallback(
     (next: FloatingBrowserPanelRect, host: HTMLElement) => {
-      setPanelRect(applyPanelRect(next, host));
+      const clamped = applyPanelRect(next, host);
+      setPanelRect(clamped);
+      rememberPanelRect(props.threadId, clamped);
     },
-    [applyPanelRect],
+    [applyPanelRect, props.threadId, rememberPanelRect],
   );
 
   useLayoutEffect(() => {
@@ -184,7 +205,13 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
       const size = hostSize(host);
       if (!hasMeasuredHostRef.current) {
         hasMeasuredHostRef.current = true;
-        commitPanelRect(initialFloatingBrowserPanelRect(size), host);
+        commitPanelRect(
+          restoreFloatingBrowserPanelRect(
+            size,
+            useFloatingBrowserRequestStore.getState().rectByThreadId[props.threadId],
+          ),
+          host,
+        );
         return;
       }
       const clamped = clampFloatingBrowserPanelRect(panelRectRef.current, size);
@@ -203,13 +230,21 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
     const observer = new ResizeObserver(measure);
     observer.observe(host);
     return () => observer.disconnect();
-  }, [commitPanelRect]);
+  }, [commitPanelRect, props.threadId]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     return () => {
       activeInteractionCleanupRef.current?.();
       activeInteractionCleanupRef.current = null;
-      applyFloatingBrowserChromeSlotStyle(getFloatingBrowserChromeSlot(props.threadId), null);
+      if (!isElectron) {
+        return;
+      }
+      if (closeIntentRef.current === "close") {
+        floatingBrowserChromePark.flush(props.threadId);
+        browserPanelRendererHandoff.flushParkedGuest(props.threadId);
+        return;
+      }
+      floatingBrowserChromePark.park(props.threadId);
     };
   }, [props.threadId]);
 
@@ -358,7 +393,10 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
     });
     activeInteractionCleanupRef.current = finishWithRelease;
   };
-  startDragFromClientRef.current = startDragFromClient;
+
+  useLayoutEffect(() => {
+    startDragFromClientRef.current = startDragFromClient;
+  });
 
   const startHandleGesture = (event: ReactPointerEvent<HTMLElement>) => {
     if (event.button !== 0) return;
@@ -371,7 +409,7 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
     if (!isElectron) {
       return;
     }
-    const slot = getFloatingBrowserChromeSlot(props.threadId);
+    const slot = floatingBrowserChromePark.take(props.threadId);
     const webview = ensureFloatingBrowserChromeWebview(slot);
     const panel = panelRef.current;
     if (panel) {
@@ -393,18 +431,18 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
       }
       if (channel === "pop") {
         setFloatingChromeExpanded(props.threadId, panelRef.current, false);
-        props.onPopToSidebar();
+        handlePopToSidebarRef.current();
         return;
       }
       if (channel === "close") {
-        props.onClose();
+        handleCloseRef.current();
       }
     };
     webview.addEventListener("ipc-message", onIpcMessage);
     return () => {
       webview.removeEventListener("ipc-message", onIpcMessage);
     };
-  }, [props.onClose, props.onPopToSidebar, props.threadId]);
+  }, [props.threadId]);
 
   return (
     <div
@@ -430,10 +468,7 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
       >
         <div
           data-floating-browser-controls="true"
-          className={cn(
-            "pointer-events-auto absolute right-2 top-2 z-20",
-            isElectron && "hidden",
-          )}
+          className={cn("pointer-events-auto absolute right-2 top-2 z-20", isElectron && "hidden")}
         >
           <div className="flex items-center gap-0.5 rounded-full border border-border/80 bg-background/90 p-0.5 shadow-sm backdrop-blur-md">
             <IconButton
@@ -455,9 +490,7 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
               className={disclosureWidthClassName(controlsOpen, "w-[50px]")}
               inert={!controlsOpen}
             >
-              <div
-                className={cn(DISCLOSURE_INNER_CLASS, "flex w-[50px] items-center gap-0.5")}
-              >
+              <div className={cn(DISCLOSURE_INNER_CLASS, "flex w-[50px] items-center gap-0.5")}>
                 <IconButton
                   type="button"
                   variant="ghost"
@@ -470,7 +503,7 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
                   onClick={(event) => {
                     event.stopPropagation();
                     setControlsOpen(false);
-                    props.onPopToSidebar();
+                    handlePopToSidebar();
                   }}
                 >
                   <PanelRightCloseIcon />
@@ -487,7 +520,7 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
                   onClick={(event) => {
                     event.stopPropagation();
                     setControlsOpen(false);
-                    props.onClose();
+                    handleClose();
                   }}
                 >
                   <XIcon />
@@ -504,7 +537,7 @@ export function FloatingBrowserPanel(props: FloatingBrowserPanelProps) {
             <LazyBrowserPanel
               mode="floating"
               threadId={props.threadId}
-              onClosePanel={props.onClose}
+              onClosePanel={handleClose}
             />
           </Suspense>
         </div>

--- a/apps/web/src/components/chat/floatingBrowserPanel.logic.test.ts
+++ b/apps/web/src/components/chat/floatingBrowserPanel.logic.test.ts
@@ -27,9 +27,9 @@ describe("floating browser panel geometry", () => {
       initialFloatingBrowserPanelRect(host),
     );
     expect(restoreFloatingBrowserPanelRect(host, saved)).toEqual(saved);
-    expect(
-      restoreFloatingBrowserPanelRect({ width: 400, height: 300 }, saved),
-    ).toEqual(clampFloatingBrowserPanelRect(saved, { width: 400, height: 300 }));
+    expect(restoreFloatingBrowserPanelRect({ width: 400, height: 300 }, saved)).toEqual(
+      clampFloatingBrowserPanelRect(saved, { width: 400, height: 300 }),
+    );
   });
 
   it("clamps movement and size inside a small host", () => {

--- a/apps/web/src/components/chat/floatingBrowserPanel.logic.test.ts
+++ b/apps/web/src/components/chat/floatingBrowserPanel.logic.test.ts
@@ -5,6 +5,7 @@ import {
   initialFloatingBrowserPanelRect,
   moveFloatingBrowserPanelRect,
   resizeFloatingBrowserPanelRect,
+  restoreFloatingBrowserPanelRect,
   shouldRenderFloatingBrowserPanel,
   isFloatingBrowserDragGesture,
 } from "./floatingBrowserPanel.logic";
@@ -17,6 +18,18 @@ describe("floating browser panel geometry", () => {
       width: 320,
       height: 200,
     });
+  });
+
+  it("restores a saved rect instead of the default bottom-right placement", () => {
+    const host = { width: 1_000, height: 700 };
+    const saved = { left: 48, top: 64, width: 480, height: 300 };
+    expect(restoreFloatingBrowserPanelRect(host, undefined)).toEqual(
+      initialFloatingBrowserPanelRect(host),
+    );
+    expect(restoreFloatingBrowserPanelRect(host, saved)).toEqual(saved);
+    expect(
+      restoreFloatingBrowserPanelRect({ width: 400, height: 300 }, saved),
+    ).toEqual(clampFloatingBrowserPanelRect(saved, { width: 400, height: 300 }));
   });
 
   it("clamps movement and size inside a small host", () => {

--- a/apps/web/src/components/chat/floatingBrowserPanel.logic.ts
+++ b/apps/web/src/components/chat/floatingBrowserPanel.logic.ts
@@ -43,18 +43,6 @@ export const FLOATING_BROWSER_PANEL_MAX_SIZE: FloatingBrowserPanelSize = {
   height: 475,
 };
 
-interface FloatingBrowserPanelConstraints {
-  minWidth: number;
-  maxWidth: number;
-  minHeight: number;
-  maxHeight: number;
-}
-
-function clamp(value: number, min: number, max: number): number {
-  if (!Number.isFinite(value)) return min;
-  return Math.min(max, Math.max(min, value));
-}
-
 function heightForGuestWidth(width: number): number {
   return Math.max(
     1,
@@ -67,6 +55,18 @@ function widthForGuestHeight(height: number): number {
     1,
     Math.round((height * BROWSER_AUTOMATION_VIEWPORT_WIDTH) / BROWSER_AUTOMATION_VIEWPORT_HEIGHT),
   );
+}
+
+interface FloatingBrowserPanelConstraints {
+  minWidth: number;
+  maxWidth: number;
+  minHeight: number;
+  maxHeight: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, value));
 }
 
 function hugGuestAspectSize(

--- a/apps/web/src/components/chat/floatingBrowserPanel.logic.ts
+++ b/apps/web/src/components/chat/floatingBrowserPanel.logic.ts
@@ -177,6 +177,21 @@ export function clampFloatingBrowserPanelRect(
   };
 }
 
+export function restoreFloatingBrowserPanelRect(
+  host: FloatingBrowserPanelHostSize,
+  saved: FloatingBrowserPanelRect | null | undefined,
+  options: {
+    defaultSize?: FloatingBrowserPanelSize;
+    minSize?: FloatingBrowserPanelSize;
+    maxSize?: FloatingBrowserPanelSize;
+  } = {},
+): FloatingBrowserPanelRect {
+  if (!saved) {
+    return initialFloatingBrowserPanelRect(host, options);
+  }
+  return clampFloatingBrowserPanelRect(saved, host, options);
+}
+
 export function initialFloatingBrowserPanelRect(
   host: FloatingBrowserPanelHostSize,
   options: {

--- a/apps/web/src/components/chat/floatingBrowserRequestStore.test.ts
+++ b/apps/web/src/components/chat/floatingBrowserRequestStore.test.ts
@@ -40,19 +40,19 @@ describe("floating browser request store", () => {
     store.rememberRect(THREAD_A, RECT_A);
     store.rememberRect(THREAD_B, RECT_B);
 
-    expect(selectFloatingBrowserPanelRect(THREAD_A)(useFloatingBrowserRequestStore.getState())).toEqual(
-      RECT_A,
-    );
-    expect(selectFloatingBrowserPanelRect(THREAD_B)(useFloatingBrowserRequestStore.getState())).toEqual(
-      RECT_B,
-    );
+    expect(
+      selectFloatingBrowserPanelRect(THREAD_A)(useFloatingBrowserRequestStore.getState()),
+    ).toEqual(RECT_A);
+    expect(
+      selectFloatingBrowserPanelRect(THREAD_B)(useFloatingBrowserRequestStore.getState()),
+    ).toEqual(RECT_B);
 
     store.dismiss(THREAD_A);
-    expect(selectFloatingBrowserPanelRect(THREAD_A)(useFloatingBrowserRequestStore.getState())).toBe(
-      undefined,
-    );
-    expect(selectFloatingBrowserPanelRect(THREAD_B)(useFloatingBrowserRequestStore.getState())).toEqual(
-      RECT_B,
-    );
+    expect(
+      selectFloatingBrowserPanelRect(THREAD_A)(useFloatingBrowserRequestStore.getState()),
+    ).toBe(undefined);
+    expect(
+      selectFloatingBrowserPanelRect(THREAD_B)(useFloatingBrowserRequestStore.getState()),
+    ).toEqual(RECT_B);
   });
 });

--- a/apps/web/src/components/chat/floatingBrowserRequestStore.test.ts
+++ b/apps/web/src/components/chat/floatingBrowserRequestStore.test.ts
@@ -2,16 +2,19 @@ import { ThreadId } from "@synara/contracts";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import {
+  selectFloatingBrowserPanelRect,
   selectFloatingBrowserRequested,
   useFloatingBrowserRequestStore,
 } from "./floatingBrowserRequestStore";
 
 const THREAD_A = ThreadId.makeUnsafe("thread-a");
 const THREAD_B = ThreadId.makeUnsafe("thread-b");
+const RECT_A = { left: 40, top: 80, width: 320, height: 200 };
+const RECT_B = { left: 120, top: 60, width: 480, height: 300 };
 
 describe("floating browser request store", () => {
   beforeEach(() => {
-    useFloatingBrowserRequestStore.setState({ requestedByThreadId: {} });
+    useFloatingBrowserRequestStore.setState({ requestedByThreadId: {}, rectByThreadId: {} });
   });
 
   it("remembers a background thread until it is dismissed", () => {
@@ -29,5 +32,27 @@ describe("floating browser request store", () => {
     expect(
       selectFloatingBrowserRequested(THREAD_B)(useFloatingBrowserRequestStore.getState()),
     ).toBe(true);
+  });
+
+  it("keeps each thread's card rect until that thread is dismissed", () => {
+    const store = useFloatingBrowserRequestStore.getState();
+    store.request(THREAD_A);
+    store.rememberRect(THREAD_A, RECT_A);
+    store.rememberRect(THREAD_B, RECT_B);
+
+    expect(selectFloatingBrowserPanelRect(THREAD_A)(useFloatingBrowserRequestStore.getState())).toEqual(
+      RECT_A,
+    );
+    expect(selectFloatingBrowserPanelRect(THREAD_B)(useFloatingBrowserRequestStore.getState())).toEqual(
+      RECT_B,
+    );
+
+    store.dismiss(THREAD_A);
+    expect(selectFloatingBrowserPanelRect(THREAD_A)(useFloatingBrowserRequestStore.getState())).toBe(
+      undefined,
+    );
+    expect(selectFloatingBrowserPanelRect(THREAD_B)(useFloatingBrowserRequestStore.getState())).toEqual(
+      RECT_B,
+    );
   });
 });

--- a/apps/web/src/components/chat/floatingBrowserRequestStore.ts
+++ b/apps/web/src/components/chat/floatingBrowserRequestStore.ts
@@ -1,5 +1,6 @@
 // FILE: floatingBrowserRequestStore.ts
-// Purpose: Remember which threads have an undocked floating browser across route changes.
+// Purpose: Remember which threads have an undocked floating browser across route changes,
+//   including the last card rect so switching chats does not reset placement.
 // Layer: Chat surface UI state
 // A background agent can open a page while another chat is focused. The request
 // must survive that visit — and survive a temporarily visible dock browser — so
@@ -8,14 +9,32 @@
 import type { ThreadId } from "@synara/contracts";
 import { create } from "zustand";
 
+import type { FloatingBrowserPanelRect } from "./floatingBrowserPanel.logic";
+
 interface FloatingBrowserRequestStore {
   requestedByThreadId: Record<string, true | undefined>;
+  rectByThreadId: Record<string, FloatingBrowserPanelRect | undefined>;
   request: (threadId: ThreadId) => void;
   dismiss: (threadId: ThreadId) => void;
+  rememberRect: (threadId: ThreadId, rect: FloatingBrowserPanelRect) => void;
+}
+
+function sameFloatingBrowserPanelRect(
+  left: FloatingBrowserPanelRect | undefined,
+  right: FloatingBrowserPanelRect,
+): boolean {
+  return (
+    left !== undefined &&
+    left.left === right.left &&
+    left.top === right.top &&
+    left.width === right.width &&
+    left.height === right.height
+  );
 }
 
 export const useFloatingBrowserRequestStore = create<FloatingBrowserRequestStore>((set) => ({
   requestedByThreadId: {},
+  rectByThreadId: {},
   request: (threadId) =>
     set((current) => {
       if (current.requestedByThreadId[threadId]) {
@@ -30,12 +49,26 @@ export const useFloatingBrowserRequestStore = create<FloatingBrowserRequestStore
     }),
   dismiss: (threadId) =>
     set((current) => {
-      if (!current.requestedByThreadId[threadId]) {
+      if (!current.requestedByThreadId[threadId] && current.rectByThreadId[threadId] === undefined) {
         return current;
       }
       const requestedByThreadId = { ...current.requestedByThreadId };
+      const rectByThreadId = { ...current.rectByThreadId };
       delete requestedByThreadId[threadId];
-      return { requestedByThreadId };
+      delete rectByThreadId[threadId];
+      return { requestedByThreadId, rectByThreadId };
+    }),
+  rememberRect: (threadId, rect) =>
+    set((current) => {
+      if (sameFloatingBrowserPanelRect(current.rectByThreadId[threadId], rect)) {
+        return current;
+      }
+      return {
+        rectByThreadId: {
+          ...current.rectByThreadId,
+          [threadId]: rect,
+        },
+      };
     }),
 }));
 
@@ -43,4 +76,10 @@ export function selectFloatingBrowserRequested(
   threadId: ThreadId,
 ): (store: FloatingBrowserRequestStore) => boolean {
   return (store) => store.requestedByThreadId[threadId] === true;
+}
+
+export function selectFloatingBrowserPanelRect(
+  threadId: ThreadId,
+): (store: FloatingBrowserRequestStore) => FloatingBrowserPanelRect | undefined {
+  return (store) => store.rectByThreadId[threadId];
 }

--- a/apps/web/src/components/chat/floatingBrowserRequestStore.ts
+++ b/apps/web/src/components/chat/floatingBrowserRequestStore.ts
@@ -49,7 +49,10 @@ export const useFloatingBrowserRequestStore = create<FloatingBrowserRequestStore
     }),
   dismiss: (threadId) =>
     set((current) => {
-      if (!current.requestedByThreadId[threadId] && current.rectByThreadId[threadId] === undefined) {
+      if (
+        !current.requestedByThreadId[threadId] &&
+        current.rectByThreadId[threadId] === undefined
+      ) {
         return current;
       }
       const requestedByThreadId = { ...current.requestedByThreadId };

--- a/apps/web/src/components/ui/menu.tsx
+++ b/apps/web/src/components/ui/menu.tsx
@@ -94,7 +94,13 @@ function MenuPopupBase({
         align={align}
         alignOffset={alignOffset}
         anchor={anchor}
-        className={cn("z-50 min-w-32", isComposerSurface ? undefined : className)}
+        className={cn(
+          // Portals overlay drag-region chrome (browser tab strip, dock headers).
+          // Electron hit-tests app-region in DOM order, not paint order, so without
+          // no-drag the OS swallows the overlapping rows as a window drag.
+          "z-50 min-w-32 [-webkit-app-region:no-drag]",
+          isComposerSurface ? undefined : className,
+        )}
         data-slot="menu-positioner"
         side={side}
         sideOffset={sideOffset}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -183,7 +183,7 @@ function SelectPopup({
           alignItemWithTrigger={alignItemWithTrigger}
           alignOffset={alignOffset}
           anchor={anchor}
-          className="z-50 select-none"
+          className="z-50 select-none [-webkit-app-region:no-drag]"
           data-slot="select-positioner"
           side={side}
           sideOffset={sideOffset}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -591,6 +591,13 @@ input {
   -webkit-app-region: no-drag;
 }
 
+/* Portaled menus/selects sit over drag-region chrome. Subtract their rects so
+   Electron does not treat the overlapping rows as a title-bar drag. */
+[data-slot="menu-positioner"],
+[data-slot="select-positioner"] {
+  -webkit-app-region: no-drag;
+}
+
 /* Scrollbar styling.
    The 2px transparent border + `background-clip: padding-box` insets the thumb so
    it floats with a small gap from the track edges instead of hugging them. Use

--- a/packages/shared/src/browserSession.ts
+++ b/packages/shared/src/browserSession.ts
@@ -17,6 +17,8 @@ export const BROWSER_AUTOMATION_VIEWPORT_WIDTH = 1_280;
 export const BROWSER_AUTOMATION_VIEWPORT_HEIGHT = 800;
 /** Matches the environment overlay's `p-3` edge gutter. */
 export const BROWSER_FLOATING_PANEL_MARGIN_PX = 12;
+/** Isolated guest used only for floating-card chrome stacked above the page webview. */
+export const FLOATING_BROWSER_CHROME_PARTITION = "synara-floating-browser-chrome";
 
 export function resolveBrowserFloatingZoomFactor(physicalViewportWidth: number): number {
   if (!Number.isFinite(physicalViewportWidth) || physicalViewportWidth <= 0) {


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Follow-up to the floating in-chat browser (#735). This PR does not add a new surface; it makes the existing floating card hand off to the docked sidebar without killing the guest, and it stops agent clicks from being treated as human input on the zoomed miniature.

**Sidebar handoff.** Popping the card into the dock now parks and reuses the same Electron guest (and the small native chrome webview) instead of tearing the page down and attaching a new one. Close flushes parked slots so a chrome pill cannot linger. Same-guest reattach refreshes annotation overlays. Drag/layout only syncs native guest slots on Electron.

**Floating chrome and zoom.** Electron paints the page `<webview>` above React, so the original HTML `...` pill never received clicks. The card stacks a tiny native chrome webview for drag / pop-to-sidebar / close, and re-applies page zoom after navigation so the frozen 1280×800 layout still fits the miniature.

**Placement and menus.** The card remembers its last rect per thread, so switching chats and back does not slam it to the default corner. Portaled menus/selects use `-webkit-app-region: no-drag` so items over the tab-strip drag region (e.g. “New tab”) are clickable.

**Agent clicks on the zoomed card.** Automation clicks in CSS layout pixels. With floating page zoom (~0.25), Electron’s `before-mouse-event` reports widget DIPs. The mismatch looked like a human click and aborted tools with `BrowserInterruptedByHuman`. Matching now accounts for page zoom; a real click elsewhere still takes over.

## Why

After #735, popping the PiP browser into the dock dropped the live guest: the page reloaded, chrome could remain on screen, and annotations went stale. Agents filling forms in the miniature also failed because their own clicks were classified as human takeover. Those are correctness bugs on the existing floating browser, not a new feature.

Parking the guest is the right handoff: the dock and the card are two presentations of one tab. Zoom-aware input matching is required because the miniature is page-zoomed, not CSS-scaled, so native coordinates are not 1:1 with actionability points.

## UI Changes

- Native chrome pill on the floating card (drag, pop to sidebar, close) sits above the page guest.
- Pop-to-sidebar keeps the current page; the docked browser takes over the same guest.
- Floating card position is restored per thread.
- Sidebar ⋯ “New tab” (and other top menu rows) can be clicked over the drag region.

No new screenshots in this follow-up; the overlay itself shipped in #735. Interaction (handoff + chrome hit-testing) is the change.

## Verification

- `bunx vitest run src/components/BrowserPanel.logic.test.ts src/components/chat/floatingBrowserPanel.logic.test.ts src/components/chat/floatingBrowserRequestStore.test.ts` in `apps/web`
- `bunx vitest run src/browserAnnotations/coordinator.test.ts src/browserAutomation/browserManagerAutomation.test.ts` in `apps/desktop`
- Manual: float a page, pop to sidebar (same URL/session, no leftover chrome), close (nothing parked on screen), switch threads and back (position restored)
- Manual: agent `browser_click` into a form on the zoomed card (e.g. onlinenotepad.org) should not return `BrowserInterruptedByHuman`
- Manual: sidebar ⋯ → New tab is clickable

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes