### PR TITLE
fix(desktop): bump electron 40.10.6 -> 43.4.1 (CVE-2026-70608)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "effect": "catalog:",
-    "electron": "40.10.6",
+    "electron": "43.4.1",
     "electron-updater": "^6.6.2"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
       "version": "0.7.3",
       "dependencies": {
         "effect": "catalog:",
-        "electron": "40.10.6",
+        "electron": "43.4.1",
         "electron-updater": "^6.6.2",
       },
       "devDependencies": {
@@ -1466,7 +1466,7 @@
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
-    "electron": ["electron@40.10.6", "", { "dependencies": { "@electron-internal/extract-zip": "^1.0.1", "@electron/get": "^5.0.0", "@types/node": "^24.9.0" }, "bin": { "electron": "cli.js" } }, "sha512-TGjlkOU9Lg6K4KjDbsErywCWCIDaNgLh0q+xj0nlpRoQhevI7VBIxBTtJI/V30lypyLAaXMpnP9O9jui1/qRFw=="],
+    "electron": ["electron@43.4.1", "", { "dependencies": { "@electron-internal/extract-zip": "^1.0.1", "@electron/get": "^5.0.0", "@types/node": "^24.9.0" }, "bin": { "electron": "cli.js", "install-electron": "install.js" } }, "sha512-5b+EuiwkgG5iRcsEL34rimgRpkYp15SsfZOa0pC5kXs0Tb82TH4n95rpQzTZa7yRCbA7tm0WoEbuBL6NaAhAcA=="],
 
     "electron-builder": ["electron-builder@26.15.3", "", { "dependencies": { "app-builder-lib": "26.15.3", "builder-util": "26.15.3", "builder-util-runtime": "9.7.0", "chalk": "^4.1.2", "ci-info": "^4.2.0", "dmg-builder": "26.15.3", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "simple-update-notifier": "2.0.0", "yargs": "^17.6.2" }, "bin": { "electron-builder": "./cli.js", "install-app-deps": "./install-app-deps.js" } }, "sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA=="],
 


### PR DESCRIPTION
## What Changed

Bump Electron `40.10.6` → `43.4.1` in `apps/desktop/package.json`, with `bun.lock` regenerated. One dependency version + its lockfile entry. No code changes.

## Why

`40.10.6` is in the vulnerable range of **GHSA-9f4c-93c8-jc8g / CVE-2026-70608** (High): a sandboxed iframe can bypass the `allow-popups` restriction and open a window / trigger `setWindowOpenHandler` without user interaction, via the OpenURL navigation path.

- Fixed upstream in `39.8.10`, `41.10.3`, `42.0.1`. `43.4.1` is well past all fixes.
- **`43.4.1` is the highest release that builds cleanly against the current code.** `44.0.0` (latest) breaks the desktop build: it removes `Clipboard.writeImage`, which `src/browserManager.ts` and `src/main.ts` call → typecheck fails. So this lands the security fix on the newest usable line rather than forcing an unrelated API migration.

## UI Changes

N/A — dependency bump only, no UI change.

## Verification

- `bun run --filter @synara/desktop typecheck` — pass
- `bun run --filter @synara/desktop build` — pass
- `bun install` — lockfile resolves cleanly (only the electron entry changed)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A)
- [x] I included a video for animation/interaction changes (N/A)
