### PR TITLE
fix(web): type queued composer drain state

### DIFF
--- a/apps/web/src/lib/queuedComposerDrain.test.ts
+++ b/apps/web/src/lib/queuedComposerDrain.test.ts
@@ -144,7 +144,10 @@ describe("shouldAutoDispatchQueuedComposerTurn", () => {
 });
 
 describe("queued composer drain watcher", () => {
-  const dispatch = vi.fn(async () => true);
+  type DrainDispatch = NonNullable<
+    NonNullable<Parameters<typeof startQueuedComposerDrainWatcher>[0]>["dispatch"]
+  >;
+  const dispatch = vi.fn<DrainDispatch>(async () => true);
 
   beforeEach(() => {
     resetQueuedComposerDrainForTests();

--- a/apps/web/src/lib/queuedComposerDrain.ts
+++ b/apps/web/src/lib/queuedComposerDrain.ts
@@ -253,7 +253,10 @@ function haveQueuedTurnsChanged(
   current: ReturnType<typeof useComposerDraftStore.getState>["draftsByThreadId"],
   previous: ReturnType<typeof useComposerDraftStore.getState>["draftsByThreadId"],
 ): boolean {
-  const threadIds = new Set([...Object.keys(current), ...Object.keys(previous)]);
+  const threadIds = new Set<ThreadId>([
+    ...(Object.keys(current) as ThreadId[]),
+    ...(Object.keys(previous) as ThreadId[]),
+  ]);
   for (const threadId of threadIds) {
     if (current[threadId]?.queuedTurns !== previous[threadId]?.queuedTurns) {
       return true;


### PR DESCRIPTION
Fixes the two TypeScript regressions introduced with the queued composer drain merge: preserves branded ThreadId keys across Object.keys and gives the dispatch mock its real call signature.\n\nFocused verification: 17 queued composer drain tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only and test mock typing fixes; no logic or runtime path changes.
> 
> **Overview**
> Fixes **TypeScript regressions** from the queued composer drain work without changing runtime behavior.
> 
> In `haveQueuedTurnsChanged`, draft map keys from `Object.keys` are now treated as branded **`ThreadId`** when building the comparison set, so indexing `current`/`previous` type-checks again.
> 
> In **`queuedComposerDrain.test.ts`**, the drain watcher **`dispatch`** mock is typed from `startQueuedComposerDrainWatcher`’s real **`dispatch`** callback signature instead of a loose `vi.fn`, so test calls match production dispatch args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8616e04151b86e2313b038479b96ef4ea35d3c06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->