### PR TITLE
[codex] Reveal macOS files in Finder

### DIFF
--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -399,31 +399,54 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
     }),
   );
 
-  it.effect("maps file-manager editor to OS open commands", () =>
+  it.effect("reveals macOS files in Finder while opening directories", () =>
     Effect.gen(function* () {
-      const launch1 = yield* resolveEditorLaunch(
-        { cwd: "/tmp/workspace", editor: "file-manager" },
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const parentPath = yield* fs.makeTempDirectoryScoped({
+        prefix: "synara-file-manager-",
+      });
+      const directoryPath = path.join(parentPath, "Project Folder");
+      const filePath = path.join(directoryPath, "source file.ts");
+      yield* fs.makeDirectory(directoryPath);
+      yield* fs.writeFileString(filePath, "");
+
+      const fileLaunch = yield* resolveEditorLaunch(
+        { cwd: filePath, editor: "file-manager" },
         "darwin",
       );
-      assert.deepEqual(launch1, {
+      assert.deepEqual(fileLaunch, {
         command: "open",
-        args: ["/tmp/workspace"],
+        args: ["-R", filePath],
       });
 
-      const launch2 = yield* resolveEditorLaunch(
+      const directoryLaunch = yield* resolveEditorLaunch(
+        { cwd: directoryPath, editor: "file-manager" },
+        "darwin",
+      );
+      assert.deepEqual(directoryLaunch, {
+        command: "open",
+        args: [directoryPath],
+      });
+    }),
+  );
+
+  it.effect("maps file-manager editor to Windows and Linux open commands", () =>
+    Effect.gen(function* () {
+      const windowsLaunch = yield* resolveEditorLaunch(
         { cwd: "C:\\workspace", editor: "file-manager" },
         "win32",
       );
-      assert.deepEqual(launch2, {
+      assert.deepEqual(windowsLaunch, {
         command: "explorer",
         args: ["C:\\workspace"],
       });
 
-      const launch3 = yield* resolveEditorLaunch(
+      const linuxLaunch = yield* resolveEditorLaunch(
         { cwd: "/tmp/workspace", editor: "file-manager" },
         "linux",
       );
-      assert.deepEqual(launch3, {
+      assert.deepEqual(linuxLaunch, {
         command: "xdg-open",
         args: ["/tmp/workspace"],
       });

--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -431,6 +431,21 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
     }),
   );
 
+  it.effect("falls back to opening macOS targets when metadata lookup fails", () =>
+    Effect.gen(function* () {
+      const targetPath = `/${"unavailable".repeat(500)}`;
+      const launch = yield* resolveEditorLaunch(
+        { cwd: targetPath, editor: "file-manager" },
+        "darwin",
+      );
+
+      assert.deepEqual(launch, {
+        command: "open",
+        args: [targetPath],
+      });
+    }),
+  );
+
   it.effect("maps file-manager editor to Windows and Linux open commands", () =>
     Effect.gen(function* () {
       const windowsLaunch = yield* resolveEditorLaunch(

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -147,6 +147,15 @@ function fileManagerCommandForPlatform(platform: NodeJS.Platform): string {
   }
 }
 
+function resolveFileManagerLaunch(target: string, platform: NodeJS.Platform): EditorLaunch {
+  const command = fileManagerCommandForPlatform(platform);
+  const shouldReveal =
+    platform === "darwin" &&
+    statSync(target, { throwIfNoEntry: false })?.isDirectory() === false;
+
+  return { command, args: shouldReveal ? ["-R", target] : [target] };
+}
+
 // Terminal integrations should receive a directory even when the source target is file:line:column.
 function resolveTerminalWorkingDirectory(target: string): string {
   const targetPath = parseTargetPathAndPosition(target)?.path ?? target;
@@ -402,7 +411,7 @@ export const resolveEditorLaunch = Effect.fnUntraced(function* (
     return yield* new OpenError({ message: `Unsupported editor: ${input.editor}` });
   }
 
-  return { command: fileManagerCommandForPlatform(platform), args: [input.cwd] };
+  return resolveFileManagerLaunch(input.cwd, platform);
 });
 
 function editorLaunchesEqual(left: EditorLaunch, right: EditorLaunch): boolean {

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -150,8 +150,7 @@ function fileManagerCommandForPlatform(platform: NodeJS.Platform): string {
 function resolveFileManagerLaunch(target: string, platform: NodeJS.Platform): EditorLaunch {
   const command = fileManagerCommandForPlatform(platform);
   const shouldReveal =
-    platform === "darwin" &&
-    statSync(target, { throwIfNoEntry: false })?.isDirectory() === false;
+    platform === "darwin" && statSync(target, { throwIfNoEntry: false })?.isDirectory() === false;
 
   return { command, args: shouldReveal ? ["-R", target] : [target] };
 }

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -147,10 +147,17 @@ function fileManagerCommandForPlatform(platform: NodeJS.Platform): string {
   }
 }
 
+function shouldRevealInFinder(target: string): boolean {
+  try {
+    return statSync(target, { throwIfNoEntry: false })?.isDirectory() === false;
+  } catch {
+    return false;
+  }
+}
+
 function resolveFileManagerLaunch(target: string, platform: NodeJS.Platform): EditorLaunch {
   const command = fileManagerCommandForPlatform(platform);
-  const shouldReveal =
-    platform === "darwin" && statSync(target, { throwIfNoEntry: false })?.isDirectory() === false;
+  const shouldReveal = platform === "darwin" && shouldRevealInFinder(target);
 
   return { command, args: shouldReveal ? ["-R", target] : [target] };
 }


### PR DESCRIPTION
## Summary

The shared `file-manager` launcher now reveals existing macOS file targets in Finder with `open -R`, while preserving plain `open <directory>` behavior for folder targets. Windows and Linux launch behavior remains unchanged because portable selection semantics there require file-manager-specific handling outside this macOS issue.

## Problem and root cause

The Finder entry in Synara's "Open in" picker resolves through the `file-manager` pseudo-editor. Its generic fallback previously launched every macOS target as `open <path>`. That command opens regular files with their default application, so selecting Finder could launch VS Code, LibreOffice, or another handler instead of revealing the file.

The fallback now delegates to a focused file-manager launch resolver. On macOS it checks an existing target's filesystem type: non-directory items receive the Finder reveal flag, while directories keep the existing folder-opening behavior. Keeping the decision in the shared server primitive means later file-action surfaces, including the work tracked in #805, inherit the same semantics when they launch absolute file paths through `shell.openInEditor`.

## Verification

- `bun run test -- src/open.test.ts` from `apps/server` — 24 tests passed
- Added deterministic temporary file and directory coverage with spaces in both paths
- `git diff --check`

Closes #802

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to macOS file-manager launch args with safe fallback when paths cannot be stat'd; no auth or data handling.
> 
> **Overview**
> **macOS Finder** behavior for the `file-manager` pseudo-editor now distinguishes files from folders instead of always running plain `open <path>`.
> 
> For existing **non-directory** targets on darwin, launch args become `open -R <path>` so Finder reveals the file instead of opening it with its default app. **Directories** still use `open <directory>`. **Windows** (`explorer`) and **Linux** (`xdg-open`) stay the same.
> 
> `resolveEditorLaunch` delegates file-manager resolution to `resolveFileManagerLaunch`, which uses `statSync` to decide reveal vs open; if metadata lookup fails, it falls back to the previous plain-open args. Tests cover temp paths with spaces, directory vs file, and the stat-failure fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 375ccb8ef1c9c8650bcd8ab1dbd346476467ec15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->