### PR TITLE
Hide provider updates when the CLI is missing

### DIFF
--- a/apps/web/src/providerUpdates.test.ts
+++ b/apps/web/src/providerUpdates.test.ts
@@ -294,6 +294,44 @@ describe("withProviderUpdateTimeout", () => {
 });
 
 describe("shouldOfferProviderUpdateAction", () => {
+  it("does not offer updates without a confirmed CLI version", () => {
+    const uninstalledPi = providerStatus("pi", {
+      status: "warning",
+      available: true,
+      version: null,
+      versionAdvisory: {
+        status: "unknown",
+        currentVersion: null,
+        latestVersion: null,
+        updateCommand: "pi update",
+        canUpdate: true,
+        checkedAt: "2026-07-15T14:00:00.000Z",
+        message: null,
+      },
+    });
+    const uninstalledDroid = providerStatus("droid", {
+      status: "error",
+      available: false,
+      version: null,
+      versionAdvisory: {
+        status: "unknown",
+        currentVersion: null,
+        latestVersion: null,
+        updateCommand: "droid update",
+        canUpdate: true,
+        checkedAt: "2026-07-15T14:00:00.000Z",
+        message: null,
+      },
+    });
+
+    expect(shouldOfferProviderUpdateAction(uninstalledPi)).toBe(false);
+    expect(shouldOfferProviderUpdateAction(uninstalledDroid)).toBe(false);
+  });
+
+  it("offers updates for installed outdated CLIs", () => {
+    expect(shouldOfferProviderUpdateAction(providerStatus("codex"))).toBe(true);
+  });
+
   it("offers native AGY updates even when upstream latest-version metadata is unavailable", () => {
     expect(
       shouldOfferProviderUpdateAction(

--- a/apps/web/src/providerUpdates.ts
+++ b/apps/web/src/providerUpdates.ts
@@ -87,6 +87,7 @@ export function shouldOfferProviderUpdateAction(provider: ServerProviderStatus):
   const advisory = provider.versionAdvisory;
   return (
     advisory?.canUpdate === true &&
+    advisory.currentVersion !== null &&
     advisory.updateCommand !== null &&
     (advisory.status === "behind_latest" || advisory.status === "unknown")
   );


### PR DESCRIPTION
## Summary
- require confirmed CLI version evidence before offering a provider update action
- keep installed outdated and self-managed CLI updates available
- cover missing Pi and Droid CLI statuses

## Verification
- bun run --cwd apps/web test src/providerUpdates.test.ts
- git diff --check

Closes #788

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard in shared update-offer logic with focused tests; no auth or data-path changes.
> 
> **Overview**
> **Provider update actions** no longer appear when Synara has no confirmed installed CLI version (`currentVersion` is null), even if an update command and `canUpdate` are present.
> 
> `shouldOfferProviderUpdateAction` now requires a non-null `currentVersion`, so missing or unverified Pi/Droid (and similar) statuses stop showing misleading “update” affordances in settings. **Installed** providers that are behind or on self-managed CLIs with a known current version (e.g. Codex, Antigravity with `status: unknown`) still get update actions; header prompts remain governed by `shouldPromptProviderUpdate` unchanged.
> 
> Tests cover the no-version and still-offers-when-installed cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf8e49e63a3b4100fd01be9fdf8dce862624003d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->