### PR TITLE
[codex] isolate source desktop data

### DIFF
--- a/apps/desktop/scripts/dev-electron.mjs
+++ b/apps/desktop/scripts/dev-electron.mjs
@@ -5,6 +5,7 @@ import waitOn from "wait-on";
 
 import { buildAppSnapHelper } from "./build-appsnap-helper.mjs";
 import { desktopDir, resolveElectronPath } from "./electron-launcher.mjs";
+import { createSourceDesktopEnvironment } from "./source-desktop-launch.mjs";
 
 const port = Number(process.env.ELECTRON_RENDERER_PORT ?? 5733);
 const devServerUrl = `http://localhost:${port}`;
@@ -34,8 +35,7 @@ await waitOn({
   resources: [`tcp:${port}`, ...requiredFiles.map((filePath) => `file:${filePath}`)],
 });
 
-const childEnv = { ...process.env };
-delete childEnv.ELECTRON_RUN_AS_NODE;
+const childEnv = createSourceDesktopEnvironment();
 
 let shuttingDown = false;
 let restartTimer = null;

--- a/apps/desktop/scripts/electron-launcher.mjs
+++ b/apps/desktop/scripts/electron-launcher.mjs
@@ -17,9 +17,9 @@ import { resolveSynaraDesktopFlavor, synaraDesktopIdentity } from "@synara/share
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const isDevelopment = Boolean(process.env.VITE_DEV_SERVER_URL);
 const desktopFlavor = resolveSynaraDesktopFlavor({
-  isDevelopment,
+  // Packaged apps launch their bundled main directly; this launcher is source-only.
+  isDevelopment: true,
   requestedFlavor: process.env.SYNARA_DESKTOP_FLAVOR,
 });
 const desktopIdentity = synaraDesktopIdentity(desktopFlavor);

--- a/apps/desktop/scripts/smoke-test.mjs
+++ b/apps/desktop/scripts/smoke-test.mjs
@@ -5,27 +5,27 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { SYNARA_DESKTOP_SMOKE_USER_DATA_ENV } from "@synara/shared/desktopIdentity";
-import { createSourceDesktopEnvironment } from "./source-desktop-launch.mjs";
+import { spawnSourceDesktop } from "./source-desktop-launch.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopDir = resolve(__dirname, "..");
 const electronBin = resolve(desktopDir, "node_modules/.bin/electron");
-const mainJs = resolve(desktopDir, "dist-electron/main.js");
 const smokeHome = mkdtempSync(join(tmpdir(), "synara-desktop-smoke-"));
 
 console.log("\nLaunching Electron smoke test...");
 
-const child = spawn(electronBin, [mainJs], {
+const child = spawnSourceDesktop({
+  desktopDirectory: desktopDir,
+  electronPath: electronBin,
+  spawnProcess: spawn,
   stdio: ["pipe", "pipe", "pipe"],
-  env: createSourceDesktopEnvironment({
-    environment: {
-      ...process.env,
-      ELECTRON_ENABLE_LOGGING: "1",
-      SYNARA_HOME: smokeHome,
-      [SYNARA_DESKTOP_SMOKE_USER_DATA_ENV]: join(smokeHome, "electron-user-data"),
-      VITE_DEV_SERVER_URL: "",
-    },
-  }),
+  environment: {
+    ...process.env,
+    ELECTRON_ENABLE_LOGGING: "1",
+    SYNARA_HOME: smokeHome,
+    [SYNARA_DESKTOP_SMOKE_USER_DATA_ENV]: join(smokeHome, "electron-user-data"),
+    VITE_DEV_SERVER_URL: "",
+  },
 });
 
 let output = "";

--- a/apps/desktop/scripts/smoke-test.mjs
+++ b/apps/desktop/scripts/smoke-test.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { SYNARA_DESKTOP_SMOKE_USER_DATA_ENV } from "@synara/shared/desktopIdentity";
 import { createSourceDesktopEnvironment } from "./source-desktop-launch.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -21,6 +22,7 @@ const child = spawn(electronBin, [mainJs], {
       ...process.env,
       ELECTRON_ENABLE_LOGGING: "1",
       SYNARA_HOME: smokeHome,
+      [SYNARA_DESKTOP_SMOKE_USER_DATA_ENV]: join(smokeHome, "electron-user-data"),
       VITE_DEV_SERVER_URL: "",
     },
   }),

--- a/apps/desktop/scripts/smoke-test.mjs
+++ b/apps/desktop/scripts/smoke-test.mjs
@@ -1,21 +1,29 @@
 import { spawn } from "node:child_process";
-import { dirname, resolve } from "node:path";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { createSourceDesktopEnvironment } from "./source-desktop-launch.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopDir = resolve(__dirname, "..");
 const electronBin = resolve(desktopDir, "node_modules/.bin/electron");
 const mainJs = resolve(desktopDir, "dist-electron/main.js");
+const smokeHome = mkdtempSync(join(tmpdir(), "synara-desktop-smoke-"));
 
 console.log("\nLaunching Electron smoke test...");
 
 const child = spawn(electronBin, [mainJs], {
   stdio: ["pipe", "pipe", "pipe"],
-  env: {
-    ...process.env,
-    VITE_DEV_SERVER_URL: "",
-    ELECTRON_ENABLE_LOGGING: "1",
-  },
+  env: createSourceDesktopEnvironment({
+    environment: {
+      ...process.env,
+      ELECTRON_ENABLE_LOGGING: "1",
+      SYNARA_HOME: smokeHome,
+      VITE_DEV_SERVER_URL: "",
+    },
+  }),
 });
 
 let output = "";
@@ -29,6 +37,17 @@ child.stderr.on("data", (chunk) => {
 const timeout = setTimeout(() => {
   child.kill();
 }, 8_000);
+
+function finish(exitCode) {
+  rmSync(smokeHome, { recursive: true, force: true });
+  process.exit(exitCode);
+}
+
+child.on("error", (error) => {
+  clearTimeout(timeout);
+  console.error("Desktop smoke test failed to launch:", error);
+  finish(1);
+});
 
 child.on("exit", () => {
   clearTimeout(timeout);
@@ -49,9 +68,9 @@ child.on("exit", () => {
       console.error(` - ${failure}`);
     }
     console.error("\nFull output:\n" + output);
-    process.exit(1);
+    finish(1);
   }
 
   console.log("Desktop smoke test passed.");
-  process.exit(0);
+  finish(0);
 });

--- a/apps/desktop/scripts/source-desktop-launch.mjs
+++ b/apps/desktop/scripts/source-desktop-launch.mjs
@@ -1,0 +1,38 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import {
+  resolveSynaraDesktopFlavor,
+  synaraDesktopIdentity,
+} from "@synara/shared/desktopIdentity";
+
+function sourceDesktopEnvironment(environment, homeDirectory) {
+  const flavor = resolveSynaraDesktopFlavor({
+    isDevelopment: true,
+    requestedFlavor: environment.SYNARA_DESKTOP_FLAVOR,
+  });
+  const identity = synaraDesktopIdentity(flavor);
+  const childEnvironment = {
+    ...environment,
+    SYNARA_DESKTOP_FLAVOR: flavor,
+    SYNARA_HOME:
+      environment.SYNARA_HOME?.trim() ||
+      join(homeDirectory, identity.defaultHomeDirectoryName),
+  };
+  delete childEnvironment.ELECTRON_RUN_AS_NODE;
+  return childEnvironment;
+}
+
+export function spawnSourceDesktop({
+  desktopDirectory,
+  electronPath,
+  environment = process.env,
+  homeDirectory = homedir(),
+  spawnProcess,
+}) {
+  return spawnProcess(electronPath, ["dist-electron/main.js"], {
+    cwd: desktopDirectory,
+    env: sourceDesktopEnvironment(environment, homeDirectory),
+    stdio: "inherit",
+  });
+}

--- a/apps/desktop/scripts/source-desktop-launch.mjs
+++ b/apps/desktop/scripts/source-desktop-launch.mjs
@@ -1,22 +1,56 @@
+import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { resolveSynaraDesktopFlavor, synaraDesktopIdentity } from "@synara/shared/desktopIdentity";
+import {
+  resolveSynaraDesktopFlavor,
+  SYNARA_SOURCE_DESKTOP_BUILD_MARKER,
+  synaraDesktopIdentity,
+} from "@synara/shared/desktopIdentity";
+import { readWindowsPersistentEnvironment } from "@synara/shared/shell";
 
-function sourceDesktopEnvironment(environment, homeDirectory) {
+function configuredSourceDesktopHome(environment, platform, readWindowsEnvironment) {
+  const inheritedHome = environment.SYNARA_HOME?.trim();
+  if (inheritedHome) return inheritedHome;
+  if (platform !== "win32") return undefined;
+
+  try {
+    return readWindowsEnvironment().SYNARA_HOME?.trim();
+  } catch {
+    return undefined;
+  }
+}
+
+export function createSourceDesktopEnvironment({
+  environment = process.env,
+  homeDirectory = homedir(),
+  platform = process.platform,
+  readWindowsEnvironment = readWindowsPersistentEnvironment,
+} = {}) {
   const flavor = resolveSynaraDesktopFlavor({
     isDevelopment: true,
     requestedFlavor: environment.SYNARA_DESKTOP_FLAVOR,
   });
   const identity = synaraDesktopIdentity(flavor);
+  const configuredHome = configuredSourceDesktopHome(environment, platform, readWindowsEnvironment);
   const childEnvironment = {
     ...environment,
     SYNARA_DESKTOP_FLAVOR: flavor,
-    SYNARA_HOME:
-      environment.SYNARA_HOME?.trim() || join(homeDirectory, identity.defaultHomeDirectoryName),
+    SYNARA_HOME: configuredHome || join(homeDirectory, identity.defaultHomeDirectoryName),
+    SYNARA_SOURCE_DESKTOP_BUILD_MARKER,
   };
   delete childEnvironment.ELECTRON_RUN_AS_NODE;
   return childEnvironment;
+}
+
+function assertCurrentSourceDesktopBuild(desktopDirectory, readBuiltMain) {
+  const builtMainPath = join(desktopDirectory, "dist-electron/main.js");
+  const builtMain = readBuiltMain(builtMainPath, "utf8");
+  if (!builtMain.includes(SYNARA_SOURCE_DESKTOP_BUILD_MARKER)) {
+    throw new Error(
+      "Source desktop build is stale. Run `bun run start:desktop` to rebuild it before launching.",
+    );
+  }
 }
 
 export function spawnSourceDesktop({
@@ -24,11 +58,20 @@ export function spawnSourceDesktop({
   electronPath,
   environment = process.env,
   homeDirectory = homedir(),
+  platform = process.platform,
+  readBuiltMain = readFileSync,
+  readWindowsEnvironment = readWindowsPersistentEnvironment,
   spawnProcess,
 }) {
+  assertCurrentSourceDesktopBuild(desktopDirectory, readBuiltMain);
   return spawnProcess(electronPath, ["dist-electron/main.js"], {
     cwd: desktopDirectory,
-    env: sourceDesktopEnvironment(environment, homeDirectory),
+    env: createSourceDesktopEnvironment({
+      environment,
+      homeDirectory,
+      platform,
+      readWindowsEnvironment,
+    }),
     stdio: "inherit",
   });
 }

--- a/apps/desktop/scripts/source-desktop-launch.mjs
+++ b/apps/desktop/scripts/source-desktop-launch.mjs
@@ -48,7 +48,7 @@ function assertCurrentSourceDesktopBuild(desktopDirectory, readBuiltMain) {
   const builtMain = readBuiltMain(builtMainPath, "utf8");
   if (!builtMain.includes(SYNARA_SOURCE_DESKTOP_BUILD_MARKER)) {
     throw new Error(
-      "Source desktop build is stale. Run `bun run start:desktop` to rebuild it before launching.",
+      "Source desktop build is stale. Run `bun run build:desktop`, then launch it again.",
     );
   }
 }

--- a/apps/desktop/scripts/source-desktop-launch.mjs
+++ b/apps/desktop/scripts/source-desktop-launch.mjs
@@ -73,6 +73,7 @@ export function spawnSourceDesktop({
   readBuiltMain = readFileSync,
   readWindowsEnvironment = readWindowsPersistentEnvironment,
   spawnProcess,
+  stdio = "inherit",
 }) {
   assertCurrentSourceDesktopBuild(desktopDirectory, readBuiltMain);
   return spawnProcess(electronPath, ["dist-electron/main.js"], {
@@ -83,6 +84,6 @@ export function spawnSourceDesktop({
       platform,
       readWindowsEnvironment,
     }),
-    stdio: "inherit",
+    stdio,
   });
 }

--- a/apps/desktop/scripts/source-desktop-launch.mjs
+++ b/apps/desktop/scripts/source-desktop-launch.mjs
@@ -9,13 +9,24 @@ import {
 } from "@synara/shared/desktopIdentity";
 import { readWindowsPersistentEnvironment } from "@synara/shared/shell";
 
+function environmentValue(environment, name, caseInsensitive) {
+  const exactValue = environment[name];
+  if (exactValue !== undefined || !caseInsensitive) return exactValue;
+
+  const matchingName = Object.keys(environment).find(
+    (candidate) => candidate.toUpperCase() === name,
+  );
+  return matchingName ? environment[matchingName] : undefined;
+}
+
 function configuredSourceDesktopHome(environment, platform, readWindowsEnvironment) {
-  const inheritedHome = environment.SYNARA_HOME?.trim();
+  const isWindows = platform === "win32";
+  const inheritedHome = environmentValue(environment, "SYNARA_HOME", isWindows)?.trim();
   if (inheritedHome) return inheritedHome;
-  if (platform !== "win32") return undefined;
+  if (!isWindows) return undefined;
 
   try {
-    return readWindowsEnvironment().SYNARA_HOME?.trim();
+    return environmentValue(readWindowsEnvironment(), "SYNARA_HOME", true)?.trim();
   } catch {
     return undefined;
   }

--- a/apps/desktop/scripts/source-desktop-launch.mjs
+++ b/apps/desktop/scripts/source-desktop-launch.mjs
@@ -1,10 +1,7 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import {
-  resolveSynaraDesktopFlavor,
-  synaraDesktopIdentity,
-} from "@synara/shared/desktopIdentity";
+import { resolveSynaraDesktopFlavor, synaraDesktopIdentity } from "@synara/shared/desktopIdentity";
 
 function sourceDesktopEnvironment(environment, homeDirectory) {
   const flavor = resolveSynaraDesktopFlavor({
@@ -16,8 +13,7 @@ function sourceDesktopEnvironment(environment, homeDirectory) {
     ...environment,
     SYNARA_DESKTOP_FLAVOR: flavor,
     SYNARA_HOME:
-      environment.SYNARA_HOME?.trim() ||
-      join(homeDirectory, identity.defaultHomeDirectoryName),
+      environment.SYNARA_HOME?.trim() || join(homeDirectory, identity.defaultHomeDirectoryName),
   };
   delete childEnvironment.ELECTRON_RUN_AS_NODE;
   return childEnvironment;

--- a/apps/desktop/scripts/source-desktop-launch.test.mjs
+++ b/apps/desktop/scripts/source-desktop-launch.test.mjs
@@ -95,18 +95,23 @@ describe("source desktop launch", () => {
     });
   });
 
-  it("passes the smoke profile override to the spawned desktop", () => {
+  it("guards and spawns the smoke desktop with its isolated environment", () => {
     const smokeHome = "/tmp/synara-desktop-smoke";
     const smokeUserData = join(smokeHome, "electron-user-data");
-    const { spawnProcess } = captureSourceDesktopSpawn({
-      SYNARA_HOME: smokeHome,
-      [SYNARA_DESKTOP_SMOKE_USER_DATA_ENV]: smokeUserData,
-    });
+    const stdio = ["pipe", "pipe", "pipe"];
+    const { spawnProcess } = captureSourceDesktopSpawn(
+      {
+        SYNARA_HOME: smokeHome,
+        [SYNARA_DESKTOP_SMOKE_USER_DATA_ENV]: smokeUserData,
+      },
+      { stdio },
+    );
 
     expect(spawnProcess.mock.calls[0][2].env).toMatchObject({
       SYNARA_HOME: smokeHome,
       [SYNARA_DESKTOP_SMOKE_USER_DATA_ENV]: smokeUserData,
     });
+    expect(spawnProcess.mock.calls[0][2].stdio).toBe(stdio);
   });
 
   it("rejects stale built desktop output before spawning Electron", () => {

--- a/apps/desktop/scripts/source-desktop-launch.test.mjs
+++ b/apps/desktop/scripts/source-desktop-launch.test.mjs
@@ -2,9 +2,10 @@ import { join } from "node:path";
 
 import { describe, expect, it, vi } from "vitest";
 
+import { SYNARA_SOURCE_DESKTOP_BUILD_MARKER } from "@synara/shared/desktopIdentity";
 import { spawnSourceDesktop } from "./source-desktop-launch.mjs";
 
-function captureSourceDesktopSpawn(environment) {
+function captureSourceDesktopSpawn(environment, overrides = {}) {
   const child = { on: vi.fn() };
   const spawnProcess = vi.fn(() => child);
 
@@ -13,14 +14,17 @@ function captureSourceDesktopSpawn(environment) {
     electronPath: "/runtime/electron",
     environment,
     homeDirectory: "/Users/tester",
+    platform: "darwin",
+    readBuiltMain: () => SYNARA_SOURCE_DESKTOP_BUILD_MARKER,
     spawnProcess,
+    ...overrides,
   });
 
   return { child, result, spawnProcess };
 }
 
 describe("source desktop launch", () => {
-  it("pins a safe spawned home even when the built main is stale", () => {
+  it("spawns current source builds with an isolated development environment", () => {
     const environment = {
       ELECTRON_RUN_AS_NODE: "1",
       PATH: "/usr/bin",
@@ -35,6 +39,7 @@ describe("source desktop launch", () => {
         PATH: "/usr/bin",
         SYNARA_DESKTOP_FLAVOR: "development",
         SYNARA_HOME: join("/Users/tester", ".synara-dev"),
+        SYNARA_SOURCE_DESKTOP_BUILD_MARKER,
       },
       stdio: "inherit",
     });
@@ -45,14 +50,35 @@ describe("source desktop launch", () => {
   });
 
   it("preserves an explicit Synara home", () => {
-    const { spawnProcess } = captureSourceDesktopSpawn({
-      SYNARA_HOME: "/tmp/custom-synara-home",
-    });
+    const readWindowsEnvironment = vi.fn(() => ({
+      SYNARA_HOME: "C:\\Users\\tester\\persisted-synara-home",
+    }));
+    const { spawnProcess } = captureSourceDesktopSpawn(
+      { SYNARA_HOME: "/tmp/custom-synara-home" },
+      { platform: "win32", readWindowsEnvironment },
+    );
 
     expect(spawnProcess.mock.calls[0][2].env).toMatchObject({
       SYNARA_DESKTOP_FLAVOR: "development",
       SYNARA_HOME: "/tmp/custom-synara-home",
     });
+    expect(readWindowsEnvironment).not.toHaveBeenCalled();
+  });
+
+  it("preserves a persisted Windows Synara home", () => {
+    const { spawnProcess } = captureSourceDesktopSpawn(
+      {},
+      {
+        platform: "win32",
+        readWindowsEnvironment: () => ({
+          SYNARA_HOME: "C:\\Users\\tester\\persisted-synara-home",
+        }),
+      },
+    );
+
+    expect(spawnProcess.mock.calls[0][2].env.SYNARA_HOME).toBe(
+      "C:\\Users\\tester\\persisted-synara-home",
+    );
   });
 
   it("preserves Canary flavor and storage defaults", () => {
@@ -64,5 +90,22 @@ describe("source desktop launch", () => {
       SYNARA_DESKTOP_FLAVOR: "canary",
       SYNARA_HOME: join("/Users/tester", ".synara-canary"),
     });
+  });
+
+  it("rejects stale built desktop output before spawning Electron", () => {
+    const spawnProcess = vi.fn();
+
+    expect(() =>
+      spawnSourceDesktop({
+        desktopDirectory: "/workspace/apps/desktop",
+        electronPath: "/runtime/electron",
+        environment: {},
+        homeDirectory: "/Users/tester",
+        platform: "darwin",
+        readBuiltMain: () => "stale desktop output",
+        spawnProcess,
+      }),
+    ).toThrow(/desktop build is stale/i);
+    expect(spawnProcess).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/scripts/source-desktop-launch.test.mjs
+++ b/apps/desktop/scripts/source-desktop-launch.test.mjs
@@ -71,7 +71,7 @@ describe("source desktop launch", () => {
       {
         platform: "win32",
         readWindowsEnvironment: () => ({
-          SYNARA_HOME: "C:\\Users\\tester\\persisted-synara-home",
+          Synara_Home: "C:\\Users\\tester\\persisted-synara-home",
         }),
       },
     );

--- a/apps/desktop/scripts/source-desktop-launch.test.mjs
+++ b/apps/desktop/scripts/source-desktop-launch.test.mjs
@@ -2,7 +2,10 @@ import { join } from "node:path";
 
 import { describe, expect, it, vi } from "vitest";
 
-import { SYNARA_SOURCE_DESKTOP_BUILD_MARKER } from "@synara/shared/desktopIdentity";
+import {
+  SYNARA_DESKTOP_SMOKE_USER_DATA_ENV,
+  SYNARA_SOURCE_DESKTOP_BUILD_MARKER,
+} from "@synara/shared/desktopIdentity";
 import { spawnSourceDesktop } from "./source-desktop-launch.mjs";
 
 function captureSourceDesktopSpawn(environment, overrides = {}) {
@@ -89,6 +92,20 @@ describe("source desktop launch", () => {
     expect(spawnProcess.mock.calls[0][2].env).toMatchObject({
       SYNARA_DESKTOP_FLAVOR: "canary",
       SYNARA_HOME: join("/Users/tester", ".synara-canary"),
+    });
+  });
+
+  it("passes the smoke profile override to the spawned desktop", () => {
+    const smokeHome = "/tmp/synara-desktop-smoke";
+    const smokeUserData = join(smokeHome, "electron-user-data");
+    const { spawnProcess } = captureSourceDesktopSpawn({
+      SYNARA_HOME: smokeHome,
+      [SYNARA_DESKTOP_SMOKE_USER_DATA_ENV]: smokeUserData,
+    });
+
+    expect(spawnProcess.mock.calls[0][2].env).toMatchObject({
+      SYNARA_HOME: smokeHome,
+      [SYNARA_DESKTOP_SMOKE_USER_DATA_ENV]: smokeUserData,
     });
   });
 

--- a/apps/desktop/scripts/source-desktop-launch.test.mjs
+++ b/apps/desktop/scripts/source-desktop-launch.test.mjs
@@ -29,19 +29,15 @@ describe("source desktop launch", () => {
     const { child, result, spawnProcess } = captureSourceDesktopSpawn(environment);
 
     expect(result).toBe(child);
-    expect(spawnProcess).toHaveBeenCalledWith(
-      "/runtime/electron",
-      ["dist-electron/main.js"],
-      {
-        cwd: "/workspace/apps/desktop",
-        env: {
-          PATH: "/usr/bin",
-          SYNARA_DESKTOP_FLAVOR: "development",
-          SYNARA_HOME: join("/Users/tester", ".synara-dev"),
-        },
-        stdio: "inherit",
+    expect(spawnProcess).toHaveBeenCalledWith("/runtime/electron", ["dist-electron/main.js"], {
+      cwd: "/workspace/apps/desktop",
+      env: {
+        PATH: "/usr/bin",
+        SYNARA_DESKTOP_FLAVOR: "development",
+        SYNARA_HOME: join("/Users/tester", ".synara-dev"),
       },
-    );
+      stdio: "inherit",
+    });
     expect(environment).toEqual({
       ELECTRON_RUN_AS_NODE: "1",
       PATH: "/usr/bin",

--- a/apps/desktop/scripts/source-desktop-launch.test.mjs
+++ b/apps/desktop/scripts/source-desktop-launch.test.mjs
@@ -1,0 +1,72 @@
+import { join } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { spawnSourceDesktop } from "./source-desktop-launch.mjs";
+
+function captureSourceDesktopSpawn(environment) {
+  const child = { on: vi.fn() };
+  const spawnProcess = vi.fn(() => child);
+
+  const result = spawnSourceDesktop({
+    desktopDirectory: "/workspace/apps/desktop",
+    electronPath: "/runtime/electron",
+    environment,
+    homeDirectory: "/Users/tester",
+    spawnProcess,
+  });
+
+  return { child, result, spawnProcess };
+}
+
+describe("source desktop launch", () => {
+  it("pins a safe spawned home even when the built main is stale", () => {
+    const environment = {
+      ELECTRON_RUN_AS_NODE: "1",
+      PATH: "/usr/bin",
+    };
+
+    const { child, result, spawnProcess } = captureSourceDesktopSpawn(environment);
+
+    expect(result).toBe(child);
+    expect(spawnProcess).toHaveBeenCalledWith(
+      "/runtime/electron",
+      ["dist-electron/main.js"],
+      {
+        cwd: "/workspace/apps/desktop",
+        env: {
+          PATH: "/usr/bin",
+          SYNARA_DESKTOP_FLAVOR: "development",
+          SYNARA_HOME: join("/Users/tester", ".synara-dev"),
+        },
+        stdio: "inherit",
+      },
+    );
+    expect(environment).toEqual({
+      ELECTRON_RUN_AS_NODE: "1",
+      PATH: "/usr/bin",
+    });
+  });
+
+  it("preserves an explicit Synara home", () => {
+    const { spawnProcess } = captureSourceDesktopSpawn({
+      SYNARA_HOME: "/tmp/custom-synara-home",
+    });
+
+    expect(spawnProcess.mock.calls[0][2].env).toMatchObject({
+      SYNARA_DESKTOP_FLAVOR: "development",
+      SYNARA_HOME: "/tmp/custom-synara-home",
+    });
+  });
+
+  it("preserves Canary flavor and storage defaults", () => {
+    const { spawnProcess } = captureSourceDesktopSpawn({
+      SYNARA_DESKTOP_FLAVOR: "canary",
+    });
+
+    expect(spawnProcess.mock.calls[0][2].env).toMatchObject({
+      SYNARA_DESKTOP_FLAVOR: "canary",
+      SYNARA_HOME: join("/Users/tester", ".synara-canary"),
+    });
+  });
+});

--- a/apps/desktop/scripts/start-electron.mjs
+++ b/apps/desktop/scripts/start-electron.mjs
@@ -2,18 +2,16 @@ import { spawn } from "node:child_process";
 
 import { buildAppSnapHelper } from "./build-appsnap-helper.mjs";
 import { desktopDir, resolveElectronPath } from "./electron-launcher.mjs";
+import { spawnSourceDesktop } from "./source-desktop-launch.mjs";
 
 if (process.platform === "darwin") {
   buildAppSnapHelper({ arch: process.arch });
 }
 
-const childEnv = { ...process.env };
-delete childEnv.ELECTRON_RUN_AS_NODE;
-
-const child = spawn(resolveElectronPath(), ["dist-electron/main.js"], {
-  stdio: "inherit",
-  cwd: desktopDir,
-  env: childEnv,
+const child = spawnSourceDesktop({
+  desktopDirectory: desktopDir,
+  electronPath: resolveElectronPath(),
+  spawnProcess: spawn,
 });
 
 child.on("exit", (code, signal) => {

--- a/apps/desktop/src/desktopUserDataProfile.test.ts
+++ b/apps/desktop/src/desktopUserDataProfile.test.ts
@@ -38,6 +38,16 @@ describe("desktopUserDataProfile", () => {
     ).toBe("/Users/tester/Library/Application Support/synara-canary");
   });
 
+  it("uses an explicit smoke profile instead of the development profile", () => {
+    expect(
+      resolveDesktopUserDataPath({
+        appDataBase: "/Users/tester/Library/Application Support",
+        userDataDirectoryName: "synara-dev",
+        testOverridePath: "/tmp/synara-desktop-smoke/electron-user-data",
+      }),
+    ).toBe("/tmp/synara-desktop-smoke/electron-user-data");
+  });
+
   it("uses XDG_CONFIG_HOME on Linux when available", () => {
     expect(
       resolveDesktopAppDataBase({

--- a/apps/desktop/src/desktopUserDataProfile.ts
+++ b/apps/desktop/src/desktopUserDataProfile.ts
@@ -52,7 +52,10 @@ export function resolveDesktopAppDataBase(input?: {
 export function resolveDesktopUserDataPath(input: {
   readonly appDataBase: string;
   readonly userDataDirectoryName: string;
+  readonly testOverridePath?: string;
 }): string {
+  const testOverridePath = input.testOverridePath?.trim();
+  if (testOverridePath) return Path.resolve(testOverridePath);
   return Path.join(input.appDataBase, input.userDataDirectoryName);
 }
 

--- a/apps/desktop/src/desktopUserDataProfile.ts
+++ b/apps/desktop/src/desktopUserDataProfile.ts
@@ -52,7 +52,7 @@ export function resolveDesktopAppDataBase(input?: {
 export function resolveDesktopUserDataPath(input: {
   readonly appDataBase: string;
   readonly userDataDirectoryName: string;
-  readonly testOverridePath?: string;
+  readonly testOverridePath?: string | undefined;
 }): string {
   const testOverridePath = input.testOverridePath?.trim();
   if (testOverridePath) return Path.resolve(testOverridePath);

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -292,8 +292,7 @@ const isDevelopment = Boolean(process.env.VITE_DEV_SERVER_URL);
 const desktopFlavor = resolveSynaraDesktopFlavor({
   isDevelopment,
   requestedFlavor: process.env.SYNARA_DESKTOP_FLAVOR,
-  allowDevelopmentOverride:
-    requestedSourceBuildMarker === SYNARA_SOURCE_DESKTOP_BUILD_MARKER,
+  allowDevelopmentOverride: requestedSourceBuildMarker === SYNARA_SOURCE_DESKTOP_BUILD_MARKER,
 });
 const desktopIdentity = synaraDesktopIdentity(desktopFlavor);
 const BASE_DIR =

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -292,6 +292,8 @@ const isDevelopment = Boolean(process.env.VITE_DEV_SERVER_URL);
 const desktopFlavor = resolveSynaraDesktopFlavor({
   isDevelopment,
   requestedFlavor: process.env.SYNARA_DESKTOP_FLAVOR,
+  allowDevelopmentOverride:
+    requestedSourceBuildMarker === SYNARA_SOURCE_DESKTOP_BUILD_MARKER,
 });
 const desktopIdentity = synaraDesktopIdentity(desktopFlavor);
 const BASE_DIR =

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -54,6 +54,7 @@ import { isKeyboardShortcutsHelpChord } from "@synara/shared/browserShortcuts";
 import { getMacTrafficLightPosition } from "@synara/shared/desktopChrome";
 import { DEVICE_HELPER_SOURCE_DIR_ENV } from "@synara/shared/deviceHelperCache";
 import {
+  SYNARA_DESKTOP_SMOKE_USER_DATA_ENV,
   SYNARA_DESKTOP_UPDATE_CHANNEL,
   SYNARA_SOURCE_DESKTOP_BUILD_MARKER,
   resolveSynaraDesktopFlavor,
@@ -1913,6 +1914,10 @@ function resolveUserDataPath(): string {
   return resolveDesktopUserDataPath({
     appDataBase,
     userDataDirectoryName: desktopIdentity.userDataDirectoryName,
+    testOverridePath:
+      requestedSourceBuildMarker === SYNARA_SOURCE_DESKTOP_BUILD_MARKER
+        ? process.env[SYNARA_DESKTOP_SMOKE_USER_DATA_ENV]
+        : undefined,
   });
 }
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -55,6 +55,7 @@ import { getMacTrafficLightPosition } from "@synara/shared/desktopChrome";
 import { DEVICE_HELPER_SOURCE_DIR_ENV } from "@synara/shared/deviceHelperCache";
 import {
   SYNARA_DESKTOP_UPDATE_CHANNEL,
+  SYNARA_SOURCE_DESKTOP_BUILD_MARKER,
   resolveSynaraDesktopFlavor,
   synaraDesktopIdentity,
 } from "@synara/shared/desktopIdentity";
@@ -257,6 +258,14 @@ import {
   sendAppSnapError,
   sendAppSnapState,
 } from "./appSnapIpc";
+
+const requestedSourceBuildMarker = process.env.SYNARA_SOURCE_DESKTOP_BUILD_MARKER;
+if (
+  requestedSourceBuildMarker !== undefined &&
+  requestedSourceBuildMarker !== SYNARA_SOURCE_DESKTOP_BUILD_MARKER
+) {
+  throw new Error("The source desktop launcher and built main are incompatible. Rebuild Synara.");
+}
 
 // Capture the real archive identity before any explicit app.asar lookup. Static
 // snapshotting and the runtime watcher both use this same generation as their

--- a/packages/shared/src/desktopIdentity.test.ts
+++ b/packages/shared/src/desktopIdentity.test.ts
@@ -48,14 +48,23 @@ describe("desktopIdentity", () => {
     });
   });
 
-  it("selects Canary explicitly without changing normal dev and production defaults", () => {
+  it("selects explicit source flavors without changing packaged Stable", () => {
     expect(resolveSynaraDesktopFlavor({ isDevelopment: false })).toBe("production");
     expect(resolveSynaraDesktopFlavor({ isDevelopment: true })).toBe("development");
+    expect(
+      resolveSynaraDesktopFlavor({ isDevelopment: false, requestedFlavor: "development" }),
+    ).toBe("development");
     expect(resolveSynaraDesktopFlavor({ isDevelopment: false, requestedFlavor: " canary " })).toBe(
       "canary",
     );
     expect(resolveSynaraDesktopFlavor({ isDevelopment: true, requestedFlavor: "canary" })).toBe(
       "canary",
     );
+  });
+
+  it("isolates development and Canary homes from packaged Stable", () => {
+    expect(synaraDesktopIdentity("development").defaultHomeDirectoryName).toBe(".synara-dev");
+    expect(synaraDesktopIdentity("canary").defaultHomeDirectoryName).toBe(".synara-canary");
+    expect(synaraDesktopIdentity("production").defaultHomeDirectoryName).toBe(".synara");
   });
 });

--- a/packages/shared/src/desktopIdentity.test.ts
+++ b/packages/shared/src/desktopIdentity.test.ts
@@ -53,6 +53,13 @@ describe("desktopIdentity", () => {
     expect(resolveSynaraDesktopFlavor({ isDevelopment: true })).toBe("development");
     expect(
       resolveSynaraDesktopFlavor({ isDevelopment: false, requestedFlavor: "development" }),
+    ).toBe("production");
+    expect(
+      resolveSynaraDesktopFlavor({
+        isDevelopment: false,
+        requestedFlavor: "development",
+        allowDevelopmentOverride: true,
+      }),
     ).toBe("development");
     expect(resolveSynaraDesktopFlavor({ isDevelopment: false, requestedFlavor: " canary " })).toBe(
       "canary",

--- a/packages/shared/src/desktopIdentity.ts
+++ b/packages/shared/src/desktopIdentity.ts
@@ -11,7 +11,8 @@ export const SYNARA_CANARY_BUNDLE_ID = `${SYNARA_PRODUCTION_BUNDLE_ID}.canary`;
 export const SYNARA_CANARY_DESKTOP_SCHEME = "synara-canary";
 export const SYNARA_CANARY_DESKTOP_ORIGIN = `${SYNARA_CANARY_DESKTOP_SCHEME}://app`;
 export const SYNARA_CANARY_DESKTOP_ENTRY_URL = `${SYNARA_CANARY_DESKTOP_ORIGIN}/index.html`;
-export const SYNARA_SOURCE_DESKTOP_BUILD_MARKER = "synara-source-desktop-build-v1";
+export const SYNARA_SOURCE_DESKTOP_BUILD_MARKER = "synara-source-desktop-build-v2";
+export const SYNARA_DESKTOP_SMOKE_USER_DATA_ENV = "SYNARA_DESKTOP_SMOKE_USER_DATA";
 
 export type SynaraDesktopFlavor = "production" | "development" | "canary";
 

--- a/packages/shared/src/desktopIdentity.ts
+++ b/packages/shared/src/desktopIdentity.ts
@@ -11,6 +11,7 @@ export const SYNARA_CANARY_BUNDLE_ID = `${SYNARA_PRODUCTION_BUNDLE_ID}.canary`;
 export const SYNARA_CANARY_DESKTOP_SCHEME = "synara-canary";
 export const SYNARA_CANARY_DESKTOP_ORIGIN = `${SYNARA_CANARY_DESKTOP_SCHEME}://app`;
 export const SYNARA_CANARY_DESKTOP_ENTRY_URL = `${SYNARA_CANARY_DESKTOP_ORIGIN}/index.html`;
+export const SYNARA_SOURCE_DESKTOP_BUILD_MARKER = "synara-source-desktop-build-v1";
 
 export type SynaraDesktopFlavor = "production" | "development" | "canary";
 

--- a/packages/shared/src/desktopIdentity.ts
+++ b/packages/shared/src/desktopIdentity.ts
@@ -31,12 +31,16 @@ export interface SynaraDesktopIdentity {
 export function resolveSynaraDesktopFlavor(input: {
   readonly isDevelopment: boolean;
   readonly requestedFlavor?: string | undefined;
+  readonly allowDevelopmentOverride?: boolean | undefined;
 }): SynaraDesktopFlavor {
   const requestedFlavor = input.requestedFlavor?.trim().toLowerCase();
   if (requestedFlavor === "canary") {
     return "canary";
   }
-  if (requestedFlavor === "development") {
+  if (
+    requestedFlavor === "development" &&
+    (input.isDevelopment || input.allowDevelopmentOverride === true)
+  ) {
     return "development";
   }
   return input.isDevelopment ? "development" : "production";

--- a/packages/shared/src/desktopIdentity.ts
+++ b/packages/shared/src/desktopIdentity.ts
@@ -30,8 +30,12 @@ export function resolveSynaraDesktopFlavor(input: {
   readonly isDevelopment: boolean;
   readonly requestedFlavor?: string | undefined;
 }): SynaraDesktopFlavor {
-  if (input.requestedFlavor?.trim().toLowerCase() === "canary") {
+  const requestedFlavor = input.requestedFlavor?.trim().toLowerCase();
+  if (requestedFlavor === "canary") {
     return "canary";
+  }
+  if (requestedFlavor === "development") {
+    return "development";
   }
   return input.isDevelopment ? "development" : "production";
 }
@@ -59,7 +63,7 @@ export function synaraDesktopIdentity(flavor: SynaraDesktopFlavor): SynaraDeskto
       origin: SYNARA_DESKTOP_ORIGIN,
       entryUrl: SYNARA_DESKTOP_ENTRY_URL,
       userDataDirectoryName: "synara-dev",
-      defaultHomeDirectoryName: ".synara",
+      defaultHomeDirectoryName: ".synara-dev",
       usesScriptedUpdates: false,
     };
   }

--- a/scripts/dev-runner.test.ts
+++ b/scripts/dev-runner.test.ts
@@ -176,6 +176,27 @@ it.layer(NodeServices.layer)("dev-runner", (it) => {
       }),
     );
 
+    it.effect("defaults watched desktop development to ~/.synara-dev", () =>
+      Effect.gen(function* () {
+        const env = yield* createDevRunnerEnv({
+          mode: "dev:desktop",
+          baseEnv: {},
+          serverOffset: 0,
+          webOffset: 0,
+          synaraHome: undefined,
+          authToken: undefined,
+          noBrowser: undefined,
+          autoBootstrapProjectFromCwd: undefined,
+          logWebSocketEvents: undefined,
+          host: undefined,
+          port: undefined,
+          devUrl: undefined,
+        });
+
+        assert.equal(env.SYNARA_HOME, resolve(homedir(), ".synara-dev"));
+      }),
+    );
+
     it.effect("normalizes bracketed IPv6 hosts for listen and client URL syntax", () =>
       Effect.gen(function* () {
         const env = yield* createDevRunnerEnv({

--- a/scripts/dev-runner.test.ts
+++ b/scripts/dev-runner.test.ts
@@ -197,6 +197,27 @@ it.layer(NodeServices.layer)("dev-runner", (it) => {
       }),
     );
 
+    it.effect("keeps watched Canary desktop data separate from development", () =>
+      Effect.gen(function* () {
+        const env = yield* createDevRunnerEnv({
+          mode: "dev:desktop",
+          baseEnv: { SYNARA_DESKTOP_FLAVOR: "canary" },
+          serverOffset: 0,
+          webOffset: 0,
+          synaraHome: undefined,
+          authToken: undefined,
+          noBrowser: undefined,
+          autoBootstrapProjectFromCwd: undefined,
+          logWebSocketEvents: undefined,
+          host: undefined,
+          port: undefined,
+          devUrl: undefined,
+        });
+
+        assert.equal(env.SYNARA_HOME, resolve(homedir(), ".synara-canary"));
+      }),
+    );
+
     it.effect("normalizes bracketed IPv6 hosts for listen and client URL syntax", () =>
       Effect.gen(function* () {
         const env = yield* createDevRunnerEnv({

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -12,7 +12,10 @@ import {
   optionalBooleanFlag,
   type BooleanFlagInput,
 } from "@synara/shared/cli";
-import { synaraDesktopIdentity } from "@synara/shared/desktopIdentity";
+import {
+  resolveSynaraDesktopFlavor,
+  synaraDesktopIdentity,
+} from "@synara/shared/desktopIdentity";
 import { applyShellEnvironmentHydrationMarker } from "@synara/shared/shell";
 import { Config, Data, Effect, Hash, Layer, Logger, Option, Path, Schema } from "effect";
 import * as ConfigProvider from "effect/ConfigProvider";
@@ -27,10 +30,6 @@ const MAX_PORT = 65535;
 export const DEFAULT_SYNARA_HOME = Effect.map(Effect.service(Path.Path), (path) =>
   path.join(homedir(), ".synara"),
 );
-const DEFAULT_DESKTOP_DEV_HOME = Effect.map(Effect.service(Path.Path), (path) =>
-  path.join(homedir(), synaraDesktopIdentity("development").defaultHomeDirectoryName),
-);
-
 const MODE_ARGS = {
   dev: [
     "run",
@@ -137,6 +136,7 @@ export function resolveOffset(config: {
 function resolveBaseDir(
   baseDir: string | undefined,
   mode: DevMode,
+  requestedDesktopFlavor?: string | undefined,
 ): Effect.Effect<string, never, Path.Path> {
   return Effect.gen(function* () {
     const path = yield* Path.Path;
@@ -146,7 +146,14 @@ function resolveBaseDir(
       return path.resolve(configured);
     }
 
-    return yield* mode === "dev:desktop" ? DEFAULT_DESKTOP_DEV_HOME : DEFAULT_SYNARA_HOME;
+    if (mode === "dev:desktop") {
+      const flavor = resolveSynaraDesktopFlavor({
+        isDevelopment: true,
+        requestedFlavor: requestedDesktopFlavor,
+      });
+      return path.join(homedir(), synaraDesktopIdentity(flavor).defaultHomeDirectoryName);
+    }
+    return yield* DEFAULT_SYNARA_HOME;
   });
 }
 
@@ -182,7 +189,11 @@ export function createDevRunnerEnv({
   return Effect.gen(function* () {
     const serverPort = port ?? BASE_SERVER_PORT + serverOffset;
     const webPort = BASE_WEB_PORT + webOffset;
-    const resolvedBaseDir = yield* resolveBaseDir(synaraHome, mode);
+    const resolvedBaseDir = yield* resolveBaseDir(
+      synaraHome,
+      mode,
+      baseEnv.SYNARA_DESKTOP_FLAVOR,
+    );
     const configuredHost = host ?? "127.0.0.1";
     // Brackets are URL syntax, not valid listen-host syntax. Keep the bind host
     // portable while adding brackets back only when constructing an IPv6 URL.

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -12,10 +12,7 @@ import {
   optionalBooleanFlag,
   type BooleanFlagInput,
 } from "@synara/shared/cli";
-import {
-  resolveSynaraDesktopFlavor,
-  synaraDesktopIdentity,
-} from "@synara/shared/desktopIdentity";
+import { resolveSynaraDesktopFlavor, synaraDesktopIdentity } from "@synara/shared/desktopIdentity";
 import { applyShellEnvironmentHydrationMarker } from "@synara/shared/shell";
 import { Config, Data, Effect, Hash, Layer, Logger, Option, Path, Schema } from "effect";
 import * as ConfigProvider from "effect/ConfigProvider";
@@ -189,11 +186,7 @@ export function createDevRunnerEnv({
   return Effect.gen(function* () {
     const serverPort = port ?? BASE_SERVER_PORT + serverOffset;
     const webPort = BASE_WEB_PORT + webOffset;
-    const resolvedBaseDir = yield* resolveBaseDir(
-      synaraHome,
-      mode,
-      baseEnv.SYNARA_DESKTOP_FLAVOR,
-    );
+    const resolvedBaseDir = yield* resolveBaseDir(synaraHome, mode, baseEnv.SYNARA_DESKTOP_FLAVOR);
     const configuredHost = host ?? "127.0.0.1";
     // Brackets are URL syntax, not valid listen-host syntax. Keep the bind host
     // portable while adding brackets back only when constructing an IPv6 URL.

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -12,6 +12,7 @@ import {
   optionalBooleanFlag,
   type BooleanFlagInput,
 } from "@synara/shared/cli";
+import { synaraDesktopIdentity } from "@synara/shared/desktopIdentity";
 import { applyShellEnvironmentHydrationMarker } from "@synara/shared/shell";
 import { Config, Data, Effect, Hash, Layer, Logger, Option, Path, Schema } from "effect";
 import * as ConfigProvider from "effect/ConfigProvider";
@@ -25,6 +26,9 @@ const MAX_PORT = 65535;
 
 export const DEFAULT_SYNARA_HOME = Effect.map(Effect.service(Path.Path), (path) =>
   path.join(homedir(), ".synara"),
+);
+const DEFAULT_DESKTOP_DEV_HOME = Effect.map(Effect.service(Path.Path), (path) =>
+  path.join(homedir(), synaraDesktopIdentity("development").defaultHomeDirectoryName),
 );
 
 const MODE_ARGS = {
@@ -130,7 +134,10 @@ export function resolveOffset(config: {
   return { offset, source: `hashed SYNARA_DEV_INSTANCE=${seed}` };
 }
 
-function resolveBaseDir(baseDir: string | undefined): Effect.Effect<string, never, Path.Path> {
+function resolveBaseDir(
+  baseDir: string | undefined,
+  mode: DevMode,
+): Effect.Effect<string, never, Path.Path> {
   return Effect.gen(function* () {
     const path = yield* Path.Path;
     const configured = baseDir?.trim();
@@ -139,7 +146,7 @@ function resolveBaseDir(baseDir: string | undefined): Effect.Effect<string, neve
       return path.resolve(configured);
     }
 
-    return yield* DEFAULT_SYNARA_HOME;
+    return yield* mode === "dev:desktop" ? DEFAULT_DESKTOP_DEV_HOME : DEFAULT_SYNARA_HOME;
   });
 }
 
@@ -175,7 +182,7 @@ export function createDevRunnerEnv({
   return Effect.gen(function* () {
     const serverPort = port ?? BASE_SERVER_PORT + serverOffset;
     const webPort = BASE_WEB_PORT + webOffset;
-    const resolvedBaseDir = yield* resolveBaseDir(synaraHome);
+    const resolvedBaseDir = yield* resolveBaseDir(synaraHome, mode);
     const configuredHost = host ?? "127.0.0.1";
     // Brackets are URL syntax, not valid listen-host syntax. Keep the bind host
     // portable while adding brackets back only when constructing an IPv6 URL.


### PR DESCRIPTION
## Problem

Running `bun run start:desktop` from a source checkout could classify the desktop as Stable because flavor detection depended on `VITE_DEV_SERVER_URL`. That allowed the source build to select `~/.synara` and expose the installed app's real database to branch-specific migrations.

## Root cause

The development identity still used Stable's default home, and the source launcher did not pass source-launch provenance to the Electron child. Updating only the identity constant would also leave stale `dist-electron/main.js` output able to choose the production fallback.

## Fix

- Give the development desktop identity the `.synara-dev` default home while leaving packaged Stable at `.synara` and Canary at `.synara-canary`.
- Treat the Electron launcher as source-only and explicitly propagate the development flavor to the spawned child.
- Share source-launch environment resolution with watched `dev:desktop`, whose default home is now `.synara-dev`.
- Resolve and pass `SYNARA_HOME` before `dist-electron/main.js` starts, while preserving explicit and case-insensitive persisted Windows overrides.
- Stamp compatible desktop builds and reject pre-fix stale output before Electron can select Stable's data or browser profile.
- Give desktop smoke runs disposable Synara data and Electron `userData` roots so they cannot share a Dev profile or single-instance lock.
- Preserve Canary's explicit flavor/home.

This PR intentionally does not change migration recovery behavior tracked by #813 and #814.

## Verification

- `bun run --cwd apps/desktop test scripts/source-desktop-launch.test.mjs src/desktopUserDataProfile.test.ts` — 15 tests passed
- `bun run --cwd scripts test dev-runner.test.ts` — 23 tests passed
- `bun run --cwd packages/shared test src/desktopIdentity.test.ts` — 6 tests passed
- `bun run --cwd apps/desktop build` — passed
- `node --check apps/desktop/scripts/smoke-test.mjs` — passed
- targeted `oxfmt --check` for all changed files — passed
- `git diff --check` and `git diff --cached --check` — passed

Closes #812

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default data directories and flavor resolution for source/desktop dev, which could surprise anyone still expecting dev under `~/.synara` but reduces risk of mutating production Stable data.
> 
> **Overview**
> Source desktop launches no longer risk using packaged Stable’s `~/.synara` database when flavor detection was wrong (e.g. missing `VITE_DEV_SERVER_URL`). **Development** now defaults to **`~/.synara-dev`** (Canary stays **`~/.synara-canary`**, Stable **`~/.synara`**).
> 
> A shared **`source-desktop-launch`** module builds the Electron child env (`SYNARA_HOME`, flavor, source build marker), rejects **stale `dist-electron`** output before spawn, and is wired into **dev**, **start**, and **smoke** scripts. **Main** validates launcher/build marker compatibility and can honor **`SYNARA_DESKTOP_SMOKE_USER_DATA`** for isolated smoke runs. **`dev:desktop`** in the dev runner picks the same flavor-based default home.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6d67f03f9ddca3d653f66de1e518f7a811f1938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->