### PR TITLE
fix: accept Claude Auto context-window model variants

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -237,6 +237,48 @@ function providerValidationIssue(error: unknown): string {
   return error.issue;
 }
 
+type ClaudeAutoSessionStartExpectation =
+  | { readonly status: "started"; readonly model: string }
+  | { readonly status: "rejected"; readonly issue: RegExp };
+
+function verifyClaudeAutoSessionStart(input: {
+  readonly models: Array<ModelInfo>;
+  readonly requestedModel: string;
+  readonly expected: ClaudeAutoSessionStartExpectation;
+}) {
+  const { layer } = makeClaudeModelCatalogHarness(input.models);
+  return Effect.gen(function* () {
+    const adapter = yield* ClaudeAdapter;
+    const startSession = () =>
+      adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "auto",
+        modelSelection: {
+          provider: "claudeAgent",
+          model: input.requestedModel,
+        },
+      });
+
+    if (input.expected.status === "started") {
+      const session = yield* startSession();
+      assert.equal(session.model, input.expected.model);
+      assert.equal(yield* adapter.hasSession(THREAD_ID), true);
+      return;
+    }
+
+    const result = yield* startSession().pipe(Effect.result);
+    assert.equal(result._tag, "Failure");
+    if (result._tag === "Failure") {
+      assert.match(providerValidationIssue(result.failure), input.expected.issue);
+    }
+    assert.equal(yield* adapter.hasSession(THREAD_ID), false);
+  }).pipe(
+    Effect.provideService(Random.Random, makeDeterministicRandomService()),
+    Effect.provide(layer),
+  );
+}
+
 function makeHarness(config?: {
   readonly nativeEventLogPath?: string;
   readonly nativeEventLogger?: ClaudeAdapterLiveOptions["nativeEventLogger"];
@@ -8483,235 +8525,128 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
     );
   });
 
-  it.effect("starts Auto when Claude discovers only supported context-window variants", () => {
-    const { layer } = makeClaudeModelCatalogHarness([
-      {
-        value: "default",
-        resolvedModel: "claude-opus-5[1m]",
-        displayName: "Default (recommended)",
-        description: "Default Claude model",
-        supportsAutoMode: true,
-      },
-      {
-        value: "opus[1m]",
-        resolvedModel: "claude-opus-5[1m]",
-        displayName: "Claude Opus 5 (1M context)",
-        description: "Claude Opus 5",
-        supportsAutoMode: true,
-      },
-    ]);
+  it.effect(
+    "starts Auto when Claude discovers only supported context-window variants",
+    () =>
+      verifyClaudeAutoSessionStart({
+        requestedModel: "claude-opus-5",
+        models: [
+          {
+            value: "default",
+            resolvedModel: "claude-opus-5[1m]",
+            displayName: "Default (recommended)",
+            description: "Default Claude model",
+            supportsAutoMode: true,
+          },
+          {
+            value: "opus[1m]",
+            resolvedModel: "claude-opus-5[1m]",
+            displayName: "Claude Opus 5 (1M context)",
+            description: "Claude Opus 5",
+            supportsAutoMode: true,
+          },
+        ],
+        expected: { status: "started", model: "claude-opus-5" },
+      }),
+  );
 
-    return Effect.gen(function* () {
-      const adapter = yield* ClaudeAdapter;
-      const session = yield* adapter.startSession({
-        threadId: THREAD_ID,
-        provider: "claudeAgent",
-        runtimeMode: "auto",
-        modelSelection: {
-          provider: "claudeAgent",
-          model: "claude-opus-5",
+  it.effect("keeps exact Claude Auto capability matches authoritative", () =>
+    verifyClaudeAutoSessionStart({
+      requestedModel: "claude-opus-5",
+      models: [
+        {
+          value: "claude-opus-5",
+          displayName: "Claude Opus 5",
+          description: "Claude Opus 5",
+          supportsAutoMode: true,
         },
-      });
-
-      assert.equal(session.model, "claude-opus-5");
-      assert.equal(yield* adapter.hasSession(THREAD_ID), true);
-    }).pipe(
-      Effect.provideService(Random.Random, makeDeterministicRandomService()),
-      Effect.provide(layer),
-    );
-  });
-
-  it.effect("keeps exact Claude Auto capability matches authoritative", () => {
-    const { layer } = makeClaudeModelCatalogHarness([
-      {
-        value: "claude-opus-5",
-        displayName: "Claude Opus 5",
-        description: "Claude Opus 5",
-        supportsAutoMode: true,
-      },
-      {
-        value: "claude-opus-5[1m]",
-        displayName: "Claude Opus 5 (1M context)",
-        description: "Claude Opus 5",
-        supportsAutoMode: false,
-      },
-    ]);
-
-    return Effect.gen(function* () {
-      const adapter = yield* ClaudeAdapter;
-      yield* adapter.startSession({
-        threadId: THREAD_ID,
-        provider: "claudeAgent",
-        runtimeMode: "auto",
-        modelSelection: {
-          provider: "claudeAgent",
-          model: "claude-opus-5",
+        {
+          value: "claude-opus-5[1m]",
+          displayName: "Claude Opus 5 (1M context)",
+          description: "Claude Opus 5",
+          supportsAutoMode: false,
         },
-      });
+      ],
+      expected: { status: "started", model: "claude-opus-5" },
+    }),
+  );
 
-      assert.equal(yield* adapter.hasSession(THREAD_ID), true);
-    }).pipe(
-      Effect.provideService(Random.Random, makeDeterministicRandomService()),
-      Effect.provide(layer),
-    );
-  });
+  it.effect("rejects conflicting normalized Claude Auto capability matches", () =>
+    verifyClaudeAutoSessionStart({
+      requestedModel: "claude-opus-5",
+      models: [
+        {
+          value: "opus[1m]",
+          resolvedModel: "claude-opus-5[1m]",
+          displayName: "Claude Opus 5 (1M context)",
+          description: "Claude Opus 5",
+          supportsAutoMode: true,
+        },
+        {
+          value: "claude-opus-5[200k]",
+          displayName: "Claude Opus 5 (200K context)",
+          description: "Claude Opus 5",
+          supportsAutoMode: false,
+        },
+      ],
+      expected: { status: "rejected", issue: /conflicting Auto mode capability metadata/u },
+    }),
+  );
 
-  it.effect("rejects conflicting normalized Claude Auto capability matches", () => {
-    const { layer } = makeClaudeModelCatalogHarness([
-      {
-        value: "opus[1m]",
-        resolvedModel: "claude-opus-5[1m]",
-        displayName: "Claude Opus 5 (1M context)",
-        description: "Claude Opus 5",
-        supportsAutoMode: true,
-      },
-      {
-        value: "claude-opus-5[200k]",
-        displayName: "Claude Opus 5 (200K context)",
-        description: "Claude Opus 5",
-        supportsAutoMode: false,
-      },
-    ]);
-
-    return Effect.gen(function* () {
-      const adapter = yield* ClaudeAdapter;
-      const result = yield* adapter
-        .startSession({
-          threadId: THREAD_ID,
-          provider: "claudeAgent",
-          runtimeMode: "auto",
-          modelSelection: {
-            provider: "claudeAgent",
-            model: "claude-opus-5",
+  it.effect(
+    "rejects false Auto capability after context-window normalization",
+    () =>
+      verifyClaudeAutoSessionStart({
+        requestedModel: "claude-opus-5",
+        models: [
+          {
+            value: "opus[1m]",
+            resolvedModel: "claude-opus-5[1m]",
+            displayName: "Claude Opus 5 (1M context)",
+            description: "Claude Opus 5",
+            supportsAutoMode: false,
           },
-        })
-        .pipe(Effect.result);
+        ],
+        expected: {
+          status: "rejected",
+          issue: /^Claude model "Claude Opus 5 \(1M context\)" does not support Auto mode\.$/u,
+        },
+      }),
+  );
 
-      assert.equal(result._tag, "Failure");
-      if (result._tag === "Failure") {
-        assert.include(
-          providerValidationIssue(result.failure),
-          "conflicting Auto mode capability metadata",
-        );
-      }
-      assert.equal(yield* adapter.hasSession(THREAD_ID), false);
-    }).pipe(
-      Effect.provideService(Random.Random, makeDeterministicRandomService()),
-      Effect.provide(layer),
-    );
-  });
-
-  it.effect("rejects false Auto capability after context-window normalization", () => {
-    const { layer } = makeClaudeModelCatalogHarness([
-      {
-        value: "opus[1m]",
-        resolvedModel: "claude-opus-5[1m]",
-        displayName: "Claude Opus 5 (1M context)",
-        description: "Claude Opus 5",
-        supportsAutoMode: false,
-      },
-    ]);
-
-    return Effect.gen(function* () {
-      const adapter = yield* ClaudeAdapter;
-      const result = yield* adapter
-        .startSession({
-          threadId: THREAD_ID,
-          provider: "claudeAgent",
-          runtimeMode: "auto",
-          modelSelection: {
-            provider: "claudeAgent",
-            model: "claude-opus-5",
+  it.effect(
+    "reports a model absent when only an unsupported qualifier resembles it",
+    () =>
+      verifyClaudeAutoSessionStart({
+        requestedModel: "claude-opus-5",
+        models: [
+          {
+            value: "claude-opus-5[preview]",
+            displayName: "Claude Opus 5 Preview",
+            description: "Claude Opus 5 preview",
+            supportsAutoMode: true,
           },
-        })
-        .pipe(Effect.result);
+        ],
+        expected: { status: "rejected", issue: /was not returned by Claude model discovery/u },
+      }),
+  );
 
-      assert.equal(result._tag, "Failure");
-      if (result._tag === "Failure") {
-        assert.equal(
-          providerValidationIssue(result.failure),
-          'Claude model "Claude Opus 5 (1M context)" does not support Auto mode.',
-        );
-      }
-    }).pipe(
-      Effect.provideService(Random.Random, makeDeterministicRandomService()),
-      Effect.provide(layer),
-    );
-  });
-
-  it.effect("reports a model absent when only an unsupported qualifier resembles it", () => {
-    const { layer } = makeClaudeModelCatalogHarness([
-      {
-        value: "claude-opus-5[preview]",
-        displayName: "Claude Opus 5 Preview",
-        description: "Claude Opus 5 preview",
-        supportsAutoMode: true,
-      },
-    ]);
-
-    return Effect.gen(function* () {
-      const adapter = yield* ClaudeAdapter;
-      const result = yield* adapter
-        .startSession({
-          threadId: THREAD_ID,
-          provider: "claudeAgent",
-          runtimeMode: "auto",
-          modelSelection: {
-            provider: "claudeAgent",
-            model: "claude-opus-5",
+  it.effect(
+    "does not normalize an explicit context-window request to a bare model",
+    () =>
+      verifyClaudeAutoSessionStart({
+        requestedModel: "claude-opus-5[1m]",
+        models: [
+          {
+            value: "claude-opus-5",
+            displayName: "Claude Opus 5",
+            description: "Claude Opus 5",
+            supportsAutoMode: true,
           },
-        })
-        .pipe(Effect.result);
-
-      assert.equal(result._tag, "Failure");
-      if (result._tag === "Failure") {
-        assert.include(
-          providerValidationIssue(result.failure),
-          "was not returned by Claude model discovery",
-        );
-      }
-    }).pipe(
-      Effect.provideService(Random.Random, makeDeterministicRandomService()),
-      Effect.provide(layer),
-    );
-  });
-
-  it.effect("does not normalize an explicit context-window request to a bare model", () => {
-    const { layer } = makeClaudeModelCatalogHarness([
-      {
-        value: "claude-opus-5",
-        displayName: "Claude Opus 5",
-        description: "Claude Opus 5",
-        supportsAutoMode: true,
-      },
-    ]);
-
-    return Effect.gen(function* () {
-      const adapter = yield* ClaudeAdapter;
-      const result = yield* adapter
-        .startSession({
-          threadId: THREAD_ID,
-          provider: "claudeAgent",
-          runtimeMode: "auto",
-          modelSelection: {
-            provider: "claudeAgent",
-            model: "claude-opus-5[1m]",
-          },
-        })
-        .pipe(Effect.result);
-
-      assert.equal(result._tag, "Failure");
-      if (result._tag === "Failure") {
-        assert.include(
-          providerValidationIssue(result.failure),
-          "was not returned by Claude model discovery",
-        );
-      }
-    }).pipe(
-      Effect.provideService(Random.Random, makeDeterministicRandomService()),
-      Effect.provide(layer),
-    );
-  });
+        ],
+        expected: { status: "rejected", issue: /was not returned by Claude model discovery/u },
+      }),
+  );
 
   it.effect("rejects Auto when the selected Claude model omits capability metadata", () => {
     const query = new FakeClaudeQuery();

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -230,6 +230,13 @@ function makeClaudeModelCatalogHarness(models: Array<ModelInfo>) {
   return { query, layer };
 }
 
+function providerValidationIssue(error: unknown): string {
+  if (!(error instanceof ProviderAdapterValidationError)) {
+    assert.fail("Expected a provider adapter validation error.");
+  }
+  return error.issue;
+}
+
 function makeHarness(config?: {
   readonly nativeEventLogPath?: string;
   readonly nativeEventLogger?: ClaudeAdapterLiveOptions["nativeEventLogger"];
@@ -8582,7 +8589,10 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
 
       assert.equal(result._tag, "Failure");
       if (result._tag === "Failure") {
-        assert.include(result.failure.issue, "conflicting Auto mode capability metadata");
+        assert.include(
+          providerValidationIssue(result.failure),
+          "conflicting Auto mode capability metadata",
+        );
       }
       assert.equal(yield* adapter.hasSession(THREAD_ID), false);
     }).pipe(
@@ -8619,7 +8629,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
       assert.equal(result._tag, "Failure");
       if (result._tag === "Failure") {
         assert.equal(
-          result.failure.issue,
+          providerValidationIssue(result.failure),
           'Claude model "Claude Opus 5 (1M context)" does not support Auto mode.',
         );
       }
@@ -8655,7 +8665,10 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
 
       assert.equal(result._tag, "Failure");
       if (result._tag === "Failure") {
-        assert.include(result.failure.issue, "was not returned by Claude model discovery");
+        assert.include(
+          providerValidationIssue(result.failure),
+          "was not returned by Claude model discovery",
+        );
       }
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
@@ -8725,7 +8738,10 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
 
       assert.equal(result._tag, "Failure");
       if (result._tag === "Failure") {
-        assert.include(result.failure.issue, "Claude model capability discovery failed");
+        assert.include(
+          providerValidationIssue(result.failure),
+          "Claude model capability discovery failed",
+        );
       }
       assert.equal(query.closeCalls, 1);
       assert.equal(yield* adapter.hasSession(THREAD_ID), false);

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -8676,6 +8676,43 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
     );
   });
 
+  it.effect("does not normalize an explicit context-window request to a bare model", () => {
+    const { layer } = makeClaudeModelCatalogHarness([
+      {
+        value: "claude-opus-5",
+        displayName: "Claude Opus 5",
+        description: "Claude Opus 5",
+        supportsAutoMode: true,
+      },
+    ]);
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const result = yield* adapter
+        .startSession({
+          threadId: THREAD_ID,
+          provider: "claudeAgent",
+          runtimeMode: "auto",
+          modelSelection: {
+            provider: "claudeAgent",
+            model: "claude-opus-5[1m]",
+          },
+        })
+        .pipe(Effect.result);
+
+      assert.equal(result._tag, "Failure");
+      if (result._tag === "Failure") {
+        assert.include(
+          providerValidationIssue(result.failure),
+          "was not returned by Claude model discovery",
+        );
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(layer),
+    );
+  });
+
   it.effect("rejects Auto when the selected Claude model omits capability metadata", () => {
     const query = new FakeClaudeQuery();
     (

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -241,11 +241,120 @@ type ClaudeAutoSessionStartExpectation =
   | { readonly status: "started"; readonly model: string }
   | { readonly status: "rejected"; readonly issue: RegExp };
 
-function verifyClaudeAutoSessionStart(input: {
+type ClaudeAutoSessionStartCase = {
+  readonly name: string;
   readonly models: Array<ModelInfo>;
   readonly requestedModel: string;
   readonly expected: ClaudeAutoSessionStartExpectation;
-}) {
+};
+
+const CLAUDE_AUTO_SESSION_START_CASES: Array<ClaudeAutoSessionStartCase> = [
+  {
+    name: "starts Auto when Claude discovers only supported context-window variants",
+    requestedModel: "claude-opus-5",
+    models: [
+      {
+        value: "default",
+        resolvedModel: "claude-opus-5[1m]",
+        displayName: "Default (recommended)",
+        description: "Default Claude model",
+        supportsAutoMode: true,
+      },
+      {
+        value: "opus[1m]",
+        resolvedModel: "claude-opus-5[1m]",
+        displayName: "Claude Opus 5 (1M context)",
+        description: "Claude Opus 5",
+        supportsAutoMode: true,
+      },
+    ],
+    expected: { status: "started", model: "claude-opus-5" },
+  },
+  {
+    name: "keeps exact Claude Auto capability matches authoritative",
+    requestedModel: "claude-opus-5",
+    models: [
+      {
+        value: "claude-opus-5",
+        displayName: "Claude Opus 5",
+        description: "Claude Opus 5",
+        supportsAutoMode: true,
+      },
+      {
+        value: "claude-opus-5[1m]",
+        displayName: "Claude Opus 5 (1M context)",
+        description: "Claude Opus 5",
+        supportsAutoMode: false,
+      },
+    ],
+    expected: { status: "started", model: "claude-opus-5" },
+  },
+  {
+    name: "rejects conflicting normalized Claude Auto capability matches",
+    requestedModel: "claude-opus-5",
+    models: [
+      {
+        value: "opus[1m]",
+        resolvedModel: "claude-opus-5[1m]",
+        displayName: "Claude Opus 5 (1M context)",
+        description: "Claude Opus 5",
+        supportsAutoMode: true,
+      },
+      {
+        value: "claude-opus-5[200k]",
+        displayName: "Claude Opus 5 (200K context)",
+        description: "Claude Opus 5",
+        supportsAutoMode: false,
+      },
+    ],
+    expected: { status: "rejected", issue: /conflicting Auto mode capability metadata/u },
+  },
+  {
+    name: "rejects false Auto capability after context-window normalization",
+    requestedModel: "claude-opus-5",
+    models: [
+      {
+        value: "opus[1m]",
+        resolvedModel: "claude-opus-5[1m]",
+        displayName: "Claude Opus 5 (1M context)",
+        description: "Claude Opus 5",
+        supportsAutoMode: false,
+      },
+    ],
+    expected: {
+      status: "rejected",
+      issue: /^Claude model "Claude Opus 5 \(1M context\)" does not support Auto mode\.$/u,
+    },
+  },
+  {
+    name: "reports a model absent when only an unsupported qualifier resembles it",
+    requestedModel: "claude-opus-5",
+    models: [
+      {
+        value: "claude-opus-5[preview]",
+        displayName: "Claude Opus 5 Preview",
+        description: "Claude Opus 5 preview",
+        supportsAutoMode: true,
+      },
+    ],
+    expected: { status: "rejected", issue: /was not returned by Claude model discovery/u },
+  },
+  {
+    name: "does not normalize an explicit context-window request to a bare model",
+    requestedModel: "claude-opus-5[1m]",
+    models: [
+      {
+        value: "claude-opus-5",
+        displayName: "Claude Opus 5",
+        description: "Claude Opus 5",
+        supportsAutoMode: true,
+      },
+    ],
+    expected: { status: "rejected", issue: /was not returned by Claude model discovery/u },
+  },
+];
+
+function verifyClaudeAutoSessionStart(input: ClaudeAutoSessionStartCase) {
   const { layer } = makeClaudeModelCatalogHarness(input.models);
   return Effect.gen(function* () {
     const adapter = yield* ClaudeAdapter;
@@ -8525,127 +8634,8 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
     );
   });
 
-  it.effect(
-    "starts Auto when Claude discovers only supported context-window variants",
-    () =>
-      verifyClaudeAutoSessionStart({
-        requestedModel: "claude-opus-5",
-        models: [
-          {
-            value: "default",
-            resolvedModel: "claude-opus-5[1m]",
-            displayName: "Default (recommended)",
-            description: "Default Claude model",
-            supportsAutoMode: true,
-          },
-          {
-            value: "opus[1m]",
-            resolvedModel: "claude-opus-5[1m]",
-            displayName: "Claude Opus 5 (1M context)",
-            description: "Claude Opus 5",
-            supportsAutoMode: true,
-          },
-        ],
-        expected: { status: "started", model: "claude-opus-5" },
-      }),
-  );
-
-  it.effect("keeps exact Claude Auto capability matches authoritative", () =>
-    verifyClaudeAutoSessionStart({
-      requestedModel: "claude-opus-5",
-      models: [
-        {
-          value: "claude-opus-5",
-          displayName: "Claude Opus 5",
-          description: "Claude Opus 5",
-          supportsAutoMode: true,
-        },
-        {
-          value: "claude-opus-5[1m]",
-          displayName: "Claude Opus 5 (1M context)",
-          description: "Claude Opus 5",
-          supportsAutoMode: false,
-        },
-      ],
-      expected: { status: "started", model: "claude-opus-5" },
-    }),
-  );
-
-  it.effect("rejects conflicting normalized Claude Auto capability matches", () =>
-    verifyClaudeAutoSessionStart({
-      requestedModel: "claude-opus-5",
-      models: [
-        {
-          value: "opus[1m]",
-          resolvedModel: "claude-opus-5[1m]",
-          displayName: "Claude Opus 5 (1M context)",
-          description: "Claude Opus 5",
-          supportsAutoMode: true,
-        },
-        {
-          value: "claude-opus-5[200k]",
-          displayName: "Claude Opus 5 (200K context)",
-          description: "Claude Opus 5",
-          supportsAutoMode: false,
-        },
-      ],
-      expected: { status: "rejected", issue: /conflicting Auto mode capability metadata/u },
-    }),
-  );
-
-  it.effect(
-    "rejects false Auto capability after context-window normalization",
-    () =>
-      verifyClaudeAutoSessionStart({
-        requestedModel: "claude-opus-5",
-        models: [
-          {
-            value: "opus[1m]",
-            resolvedModel: "claude-opus-5[1m]",
-            displayName: "Claude Opus 5 (1M context)",
-            description: "Claude Opus 5",
-            supportsAutoMode: false,
-          },
-        ],
-        expected: {
-          status: "rejected",
-          issue: /^Claude model "Claude Opus 5 \(1M context\)" does not support Auto mode\.$/u,
-        },
-      }),
-  );
-
-  it.effect(
-    "reports a model absent when only an unsupported qualifier resembles it",
-    () =>
-      verifyClaudeAutoSessionStart({
-        requestedModel: "claude-opus-5",
-        models: [
-          {
-            value: "claude-opus-5[preview]",
-            displayName: "Claude Opus 5 Preview",
-            description: "Claude Opus 5 preview",
-            supportsAutoMode: true,
-          },
-        ],
-        expected: { status: "rejected", issue: /was not returned by Claude model discovery/u },
-      }),
-  );
-
-  it.effect(
-    "does not normalize an explicit context-window request to a bare model",
-    () =>
-      verifyClaudeAutoSessionStart({
-        requestedModel: "claude-opus-5[1m]",
-        models: [
-          {
-            value: "claude-opus-5",
-            displayName: "Claude Opus 5",
-            description: "Claude Opus 5",
-            supportsAutoMode: true,
-          },
-        ],
-        expected: { status: "rejected", issue: /was not returned by Claude model discovery/u },
-      }),
+  it.effect.each(CLAUDE_AUTO_SESSION_START_CASES)("$name", (input) =>
+    verifyClaudeAutoSessionStart(input),
   );
 
   it.effect("rejects Auto when the selected Claude model omits capability metadata", () => {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -215,6 +215,21 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
   }
 }
 
+function setSupportedModels(query: FakeClaudeQuery, models: Array<ModelInfo>): void {
+  (query as { supportedModels: () => Promise<Array<ModelInfo>> }).supportedModels = async () =>
+    models;
+}
+
+function makeClaudeModelCatalogHarness(models: Array<ModelInfo>) {
+  const query = new FakeClaudeQuery();
+  setSupportedModels(query, models);
+  const layer = makeClaudeAdapterLive({ createQuery: () => query }).pipe(
+    Layer.provideMerge(ServerConfig.layerTest("/tmp/claude-adapter-test", "/tmp")),
+    Layer.provideMerge(NodeServices.layer),
+  );
+  return { query, layer };
+}
+
 function makeHarness(config?: {
   readonly nativeEventLogPath?: string;
   readonly nativeEventLogger?: ClaudeAdapterLiveOptions["nativeEventLogger"];
@@ -7670,6 +7685,52 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
     );
   });
 
+  it.effect("matches a supported context-window qualifier during an Auto model switch", () => {
+    const { query, layer } = makeClaudeModelCatalogHarness([
+      {
+        value: "claude-sonnet-5",
+        displayName: "Claude Sonnet 5",
+        description: "Claude Sonnet 5",
+        supportsAutoMode: true,
+      },
+      {
+        value: "opus[1m]",
+        resolvedModel: "claude-opus-5[1m]",
+        displayName: "Claude Opus 5 (1M context)",
+        description: "Claude Opus 5",
+        supportsAutoMode: true,
+      },
+    ]);
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "auto",
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-sonnet-5",
+        },
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "switch to Opus",
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-opus-5",
+        },
+        attachments: [],
+      });
+
+      assert.deepEqual(query.setModelCalls, ["claude-opus-5"]);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(layer),
+    );
+  });
+
   it.effect("updates the auto-compact budget live without changing the Claude model id", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
@@ -8415,6 +8476,193 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
     );
   });
 
+  it.effect("starts Auto when Claude discovers only supported context-window variants", () => {
+    const { layer } = makeClaudeModelCatalogHarness([
+      {
+        value: "default",
+        resolvedModel: "claude-opus-5[1m]",
+        displayName: "Default (recommended)",
+        description: "Default Claude model",
+        supportsAutoMode: true,
+      },
+      {
+        value: "opus[1m]",
+        resolvedModel: "claude-opus-5[1m]",
+        displayName: "Claude Opus 5 (1M context)",
+        description: "Claude Opus 5",
+        supportsAutoMode: true,
+      },
+    ]);
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "auto",
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-opus-5",
+        },
+      });
+
+      assert.equal(session.model, "claude-opus-5");
+      assert.equal(yield* adapter.hasSession(THREAD_ID), true);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(layer),
+    );
+  });
+
+  it.effect("keeps exact Claude Auto capability matches authoritative", () => {
+    const { layer } = makeClaudeModelCatalogHarness([
+      {
+        value: "claude-opus-5",
+        displayName: "Claude Opus 5",
+        description: "Claude Opus 5",
+        supportsAutoMode: true,
+      },
+      {
+        value: "claude-opus-5[1m]",
+        displayName: "Claude Opus 5 (1M context)",
+        description: "Claude Opus 5",
+        supportsAutoMode: false,
+      },
+    ]);
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "auto",
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-opus-5",
+        },
+      });
+
+      assert.equal(yield* adapter.hasSession(THREAD_ID), true);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(layer),
+    );
+  });
+
+  it.effect("rejects conflicting normalized Claude Auto capability matches", () => {
+    const { layer } = makeClaudeModelCatalogHarness([
+      {
+        value: "opus[1m]",
+        resolvedModel: "claude-opus-5[1m]",
+        displayName: "Claude Opus 5 (1M context)",
+        description: "Claude Opus 5",
+        supportsAutoMode: true,
+      },
+      {
+        value: "claude-opus-5[200k]",
+        displayName: "Claude Opus 5 (200K context)",
+        description: "Claude Opus 5",
+        supportsAutoMode: false,
+      },
+    ]);
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const result = yield* adapter
+        .startSession({
+          threadId: THREAD_ID,
+          provider: "claudeAgent",
+          runtimeMode: "auto",
+          modelSelection: {
+            provider: "claudeAgent",
+            model: "claude-opus-5",
+          },
+        })
+        .pipe(Effect.result);
+
+      assert.equal(result._tag, "Failure");
+      if (result._tag === "Failure") {
+        assert.include(result.failure.issue, "conflicting Auto mode capability metadata");
+      }
+      assert.equal(yield* adapter.hasSession(THREAD_ID), false);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(layer),
+    );
+  });
+
+  it.effect("rejects false Auto capability after context-window normalization", () => {
+    const { layer } = makeClaudeModelCatalogHarness([
+      {
+        value: "opus[1m]",
+        resolvedModel: "claude-opus-5[1m]",
+        displayName: "Claude Opus 5 (1M context)",
+        description: "Claude Opus 5",
+        supportsAutoMode: false,
+      },
+    ]);
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const result = yield* adapter
+        .startSession({
+          threadId: THREAD_ID,
+          provider: "claudeAgent",
+          runtimeMode: "auto",
+          modelSelection: {
+            provider: "claudeAgent",
+            model: "claude-opus-5",
+          },
+        })
+        .pipe(Effect.result);
+
+      assert.equal(result._tag, "Failure");
+      if (result._tag === "Failure") {
+        assert.equal(
+          result.failure.issue,
+          'Claude model "Claude Opus 5 (1M context)" does not support Auto mode.',
+        );
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(layer),
+    );
+  });
+
+  it.effect("reports a model absent when only an unsupported qualifier resembles it", () => {
+    const { layer } = makeClaudeModelCatalogHarness([
+      {
+        value: "claude-opus-5[preview]",
+        displayName: "Claude Opus 5 Preview",
+        description: "Claude Opus 5 preview",
+        supportsAutoMode: true,
+      },
+    ]);
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const result = yield* adapter
+        .startSession({
+          threadId: THREAD_ID,
+          provider: "claudeAgent",
+          runtimeMode: "auto",
+          modelSelection: {
+            provider: "claudeAgent",
+            model: "claude-opus-5",
+          },
+        })
+        .pipe(Effect.result);
+
+      assert.equal(result._tag, "Failure");
+      if (result._tag === "Failure") {
+        assert.include(result.failure.issue, "was not returned by Claude model discovery");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(layer),
+    );
+  });
+
   it.effect("rejects Auto when the selected Claude model omits capability metadata", () => {
     const query = new FakeClaudeQuery();
     (
@@ -8467,15 +8715,18 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
 
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
-      const result = yield* Effect.exit(
-        adapter.startSession({
+      const result = yield* adapter
+        .startSession({
           threadId: THREAD_ID,
           provider: "claudeAgent",
           runtimeMode: "auto",
-        }),
-      );
+        })
+        .pipe(Effect.result);
 
-      assert.ok(Exit.isFailure(result));
+      assert.equal(result._tag, "Failure");
+      if (result._tag === "Failure") {
+        assert.include(result.failure.issue, "Claude model capability discovery failed");
+      }
       assert.equal(query.closeCalls, 1);
       assert.equal(yield* adapter.hasSession(THREAD_ID), false);
     }).pipe(

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -658,12 +658,14 @@ function resolveClaudeAutoModeModel(
     return { status: "matched", model: exactMatch };
   }
 
-  const normalizedRequestedModelIds = new Set(
-    [...requestedModelIds].map(stripSupportedClaudeContextWindowQualifier),
+  const unqualifiedRequestedModelIds = new Set(
+    [...requestedModelIds].filter(
+      (modelId) => stripSupportedClaudeContextWindowQualifier(modelId) === modelId,
+    ),
   );
   const normalizedMatches = discoveredModels.filter((model) =>
     claudeModelIdentifiers(model).some((identifier) =>
-      normalizedRequestedModelIds.has(stripSupportedClaudeContextWindowQualifier(identifier)),
+      unqualifiedRequestedModelIds.has(stripSupportedClaudeContextWindowQualifier(identifier)),
     ),
   );
   const firstMatch = normalizedMatches[0];

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -627,6 +627,59 @@ function toMessage(cause: unknown, fallback: string): string {
   return fallback;
 }
 
+type ClaudeAutoModeModelResolution =
+  | { readonly status: "matched"; readonly model: ModelInfo }
+  | { readonly status: "absent" }
+  | { readonly status: "conflicting" };
+
+function stripSupportedClaudeContextWindowQualifier(modelId: string): string {
+  const qualifierMatch = /\[([^\]]+)\]$/u.exec(modelId);
+  if (
+    !qualifierMatch ||
+    !Object.hasOwn(CLAUDE_CONTEXT_WINDOW_MAX_TOKENS, qualifierMatch[1] ?? "")
+  ) {
+    return modelId;
+  }
+  return modelId.slice(0, qualifierMatch.index);
+}
+
+function claudeModelIdentifiers(model: ModelInfo): ReadonlyArray<string> {
+  return model.resolvedModel === undefined ? [model.value] : [model.value, model.resolvedModel];
+}
+
+function resolveClaudeAutoModeModel(
+  discoveredModels: ReadonlyArray<ModelInfo>,
+  requestedModelIds: ReadonlySet<string>,
+): ClaudeAutoModeModelResolution {
+  const exactMatch = discoveredModels.find((model) =>
+    claudeModelIdentifiers(model).some((identifier) => requestedModelIds.has(identifier)),
+  );
+  if (exactMatch) {
+    return { status: "matched", model: exactMatch };
+  }
+
+  const normalizedRequestedModelIds = new Set(
+    [...requestedModelIds].map(stripSupportedClaudeContextWindowQualifier),
+  );
+  const normalizedMatches = discoveredModels.filter((model) =>
+    claudeModelIdentifiers(model).some((identifier) =>
+      normalizedRequestedModelIds.has(stripSupportedClaudeContextWindowQualifier(identifier)),
+    ),
+  );
+  const firstMatch = normalizedMatches[0];
+  if (!firstMatch) {
+    return { status: "absent" };
+  }
+  if (
+    normalizedMatches.some(
+      (model) => model.supportsAutoMode !== firstMatch.supportsAutoMode,
+    )
+  ) {
+    return { status: "conflicting" };
+  }
+  return { status: "matched", model: firstMatch };
+}
+
 function toError(cause: unknown, fallback: string): Error {
   return cause instanceof Error ? cause : new Error(toMessage(cause, fallback));
 }
@@ -1809,10 +1862,9 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             new ProviderAdapterValidationError({
               provider: PROVIDER,
               operation: input.operation,
-              issue: toMessage(
-                cause,
-                `Could not verify that Claude model "${requestedModel}" supports Auto mode.`,
-              ),
+              issue:
+                `Claude model capability discovery failed while verifying Auto mode support for "${requestedModel}": ` +
+                toMessage(cause, "unknown discovery error"),
             }),
         }).pipe(
           // ProviderService gives session startup 60 seconds. Let cold startup
@@ -1839,18 +1891,26 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             (model): model is string => model !== undefined,
           ),
         );
-        const selectedModel = discoveredModels.find(
-          (model) =>
-            requestedModels.has(model.value) ||
-            (model.resolvedModel !== undefined && requestedModels.has(model.resolvedModel)),
-        );
-        if (selectedModel?.supportsAutoMode !== true) {
+        const resolution = resolveClaudeAutoModeModel(discoveredModels, requestedModels);
+        if (resolution.status === "absent") {
           return yield* new ProviderAdapterValidationError({
             provider: PROVIDER,
             operation: input.operation,
-            issue: selectedModel
-              ? `Claude model "${selectedModel.displayName}" does not support Auto mode.`
-              : `Could not verify that Claude model "${requestedModel}" supports Auto mode.`,
+            issue: `Claude model "${requestedModel}" was not returned by Claude model discovery, so Auto mode support cannot be verified.`,
+          });
+        }
+        if (resolution.status === "conflicting") {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: input.operation,
+            issue: `Claude model "${requestedModel}" has conflicting Auto mode capability metadata across context-window variants.`,
+          });
+        }
+        if (resolution.model.supportsAutoMode !== true) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: input.operation,
+            issue: `Claude model "${resolution.model.displayName}" does not support Auto mode.`,
           });
         }
       });

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -670,11 +670,7 @@ function resolveClaudeAutoModeModel(
   if (!firstMatch) {
     return { status: "absent" };
   }
-  if (
-    normalizedMatches.some(
-      (model) => model.supportsAutoMode !== firstMatch.supportsAutoMode,
-    )
-  ) {
+  if (normalizedMatches.some((model) => model.supportsAutoMode !== firstMatch.supportsAutoMode)) {
     return { status: "conflicting" };
   }
   return { status: "matched", model: firstMatch };


### PR DESCRIPTION
Closes #817

Summary
- preserve exact Claude model capability matches before normalization
- match only supported trailing context-window qualifiers and reject conflicting capability metadata
- distinguish absent models from discovery failures while preserving explicit unsupported-capability errors
- cover Auto session startup and live model switching with focused Claude adapter regressions

Verification
- bun run --cwd apps/server test src/provider/Layers/ClaudeAdapter.test.ts --configLoader runner (154 passed)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Auto-mode gating and model matching in the Claude adapter at session start and on turns; wrong normalization could allow or block sessions incorrectly, but behavior is heavily regression-tested.
> 
> **Overview**
> **Claude Auto mode** now resolves requested model IDs against discovery results using **exact matches first**, then **normalized matches** that strip only **known trailing context-window qualifiers** (e.g. `[1m]`, `[200k]`). That lets sessions and live switches accept bare IDs like `claude-opus-5` when discovery only exposes aliased variants such as `opus[1m]` / `resolvedModel`, without treating unrelated suffixes (e.g. `[preview]`) as the same model.
> 
> Validation errors are **split by cause**: model not in discovery, **conflicting `supportsAutoMode` across normalized variants**, explicit unsupported Auto for the matched variant, and **discovery failures** with a dedicated message instead of a generic “could not verify” string.
> 
> Tests add a **table-driven Auto session-start suite**, a **mid-turn model switch** case for qualified Opus, and tighten the simulated discovery-failure assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6395bb62a0d9e9078fa2a6b52c73392532690457. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->