### PR TITLE
[codex] Page long thread messages losslessly

### DIFF
--- a/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
@@ -1493,6 +1493,25 @@ describe("AgentGateway", () => {
         ["approval-required", "full-access"],
       );
 
+      const readThread = tools.find((tool) => tool.name === "synara_read_thread");
+      const readThreadProperties = readThread?.inputSchema.properties as
+        | Record<string, { maximum?: number; minimum?: number; type?: string }>
+        | undefined;
+      assert.include(readThread?.description ?? "", "long message losslessly");
+      assert.deepInclude(readThreadProperties?.maxMessageChars, {
+        type: "integer",
+        minimum: 50,
+        maximum: 20_000,
+      });
+      assert.deepInclude(readThreadProperties?.messageIndex, {
+        type: "integer",
+        minimum: 0,
+      });
+      assert.deepInclude(readThreadProperties?.messageOffsetChars, {
+        type: "integer",
+        minimum: 0,
+      });
+
       const setThreadGoal = tools.find((tool) => tool.name === "synara_set_thread_goal");
       assert.include(
         setThreadGoal?.description ?? "",
@@ -4922,6 +4941,73 @@ describe("AgentGateway", () => {
 
       assert.isFalse(isToolError(response.result), toolErrorText(response.result));
       assert.equal(toolResultJson(response.result).goal, goal);
+    }).pipe(Effect.provide(gatewayLayer));
+  });
+
+  it.effect("reads a long message losslessly and rejects a stale offset", () => {
+    const shell = makeThreadShell("thread-child");
+    const longText = Array.from({ length: 25_007 }, (_, index) => String(index % 10)).join("");
+    const detail: OrchestrationThread = {
+      ...makeThreadDetail(shell),
+      messages: [
+        {
+          id: MessageId.makeUnsafe("message-long"),
+          role: "assistant",
+          text: longText,
+          turnId: null,
+          streaming: false,
+          source: "native",
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+      ],
+    };
+    const { gatewayLayer, makeHarness } = makeHarnessLayer(
+      [...baseThreads.filter((thread) => thread.id !== shell.id), shell],
+      [],
+      {
+        threadDetails: new Map([[shell.id, detail]]),
+      },
+    );
+    return Effect.gen(function* () {
+      const harness = yield* makeHarness;
+      const slices: string[] = [];
+      let messageOffsetChars = 0;
+
+      while (true) {
+        const response = yield* harness.callTool({
+          token: "token-parent",
+          name: "synara_read_thread",
+          args: {
+            threadId: shell.id,
+            messageIndex: 0,
+            messageOffsetChars,
+            maxMessageChars: 10_000,
+          },
+        });
+        assert.isFalse(isToolError(response.result), toolErrorText(response.result));
+        const result = toolResultJson(response.result);
+        slices.push((result.messages as Array<{ text: string }>)[0]?.text ?? "");
+        assert.equal(result.effectiveMessageLimit, 1);
+        assert.equal(result.effectiveMaxMessageChars, 10_000);
+        const nextOffsetChars = (result.messagePage as { nextOffsetChars?: number })
+          .nextOffsetChars;
+        if (nextOffsetChars === undefined) break;
+        messageOffsetChars = nextOffsetChars;
+      }
+
+      assert.equal(slices.join(""), longText);
+      harness.setThreadDetail({
+        ...detail,
+        messages: [{ ...detail.messages[0]!, text: "shorter now" }],
+      });
+      const stale = yield* harness.callTool({
+        token: "token-parent",
+        name: "synara_read_thread",
+        args: { threadId: shell.id, messageIndex: 0, messageOffsetChars: 20_000 },
+      });
+      assert.isTrue(isToolError(stale.result));
+      assert.include(toolErrorText(stale.result), "no longer valid");
     }).pipe(Effect.provide(gatewayLayer));
   });
 

--- a/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
@@ -1512,6 +1512,7 @@ describe("AgentGateway", () => {
         minimum: 0,
       });
       assert.deepInclude(readThreadProperties?.messageId, { type: "string" });
+      assert.deepInclude(readThreadProperties?.messageVersion, { type: "string" });
 
       const setThreadGoal = tools.find((tool) => tool.name === "synara_set_thread_goal");
       assert.include(
@@ -4972,9 +4973,20 @@ describe("AgentGateway", () => {
     );
     return Effect.gen(function* () {
       const harness = yield* makeHarness;
+      const summaryResponse = yield* harness.callTool({
+        token: "token-parent",
+        name: "synara_read_thread",
+        args: { threadId: shell.id },
+      });
+      assert.isFalse(isToolError(summaryResponse.result), toolErrorText(summaryResponse.result));
+      const summaryMessage = (
+        toolResultJson(summaryResponse.result).messages as Array<{
+          messageId: string;
+          messageVersion: string;
+        }>
+      )[0]!;
       const slices: string[] = [];
       let messageOffsetChars = 0;
-      let messageId: string | undefined;
 
       while (true) {
         const response = yield* harness.callTool({
@@ -4984,7 +4996,8 @@ describe("AgentGateway", () => {
             threadId: shell.id,
             messageIndex: 0,
             messageOffsetChars,
-            ...(messageId === undefined ? {} : { messageId }),
+            messageId: summaryMessage.messageId,
+            messageVersion: summaryMessage.messageVersion,
             maxMessageChars: 10_000,
           },
         });
@@ -4995,9 +5008,11 @@ describe("AgentGateway", () => {
         assert.equal(result.effectiveMaxMessageChars, 10_000);
         const messagePage = result.messagePage as {
           messageId: string;
+          messageVersion: string;
           nextOffsetChars?: number;
         };
-        messageId = messagePage.messageId;
+        assert.equal(messagePage.messageId, summaryMessage.messageId);
+        assert.equal(messagePage.messageVersion, summaryMessage.messageVersion);
         const nextOffsetChars = messagePage.nextOffsetChars;
         if (nextOffsetChars === undefined) break;
         messageOffsetChars = nextOffsetChars;
@@ -5021,7 +5036,8 @@ describe("AgentGateway", () => {
           threadId: shell.id,
           messageIndex: 0,
           messageOffsetChars: 20_000,
-          messageId,
+          messageId: summaryMessage.messageId,
+          messageVersion: summaryMessage.messageVersion,
         },
       });
       assert.isTrue(isToolError(stale.result));

--- a/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
@@ -1511,6 +1511,7 @@ describe("AgentGateway", () => {
         type: "integer",
         minimum: 0,
       });
+      assert.deepInclude(readThreadProperties?.messageId, { type: "string" });
 
       const setThreadGoal = tools.find((tool) => tool.name === "synara_set_thread_goal");
       assert.include(
@@ -4973,6 +4974,7 @@ describe("AgentGateway", () => {
       const harness = yield* makeHarness;
       const slices: string[] = [];
       let messageOffsetChars = 0;
+      let messageId: string | undefined;
 
       while (true) {
         const response = yield* harness.callTool({
@@ -4982,6 +4984,7 @@ describe("AgentGateway", () => {
             threadId: shell.id,
             messageIndex: 0,
             messageOffsetChars,
+            ...(messageId === undefined ? {} : { messageId }),
             maxMessageChars: 10_000,
           },
         });
@@ -4990,8 +4993,12 @@ describe("AgentGateway", () => {
         slices.push((result.messages as Array<{ text: string }>)[0]?.text ?? "");
         assert.equal(result.effectiveMessageLimit, 1);
         assert.equal(result.effectiveMaxMessageChars, 10_000);
-        const nextOffsetChars = (result.messagePage as { nextOffsetChars?: number })
-          .nextOffsetChars;
+        const messagePage = result.messagePage as {
+          messageId: string;
+          nextOffsetChars?: number;
+        };
+        messageId = messagePage.messageId;
+        const nextOffsetChars = messagePage.nextOffsetChars;
         if (nextOffsetChars === undefined) break;
         messageOffsetChars = nextOffsetChars;
       }
@@ -4999,15 +5006,26 @@ describe("AgentGateway", () => {
       assert.equal(slices.join(""), longText);
       harness.setThreadDetail({
         ...detail,
-        messages: [{ ...detail.messages[0]!, text: "shorter now" }],
+        messages: [
+          {
+            ...detail.messages[0]!,
+            id: MessageId.makeUnsafe("message-replacement"),
+            text: "x".repeat(25_007),
+          },
+        ],
       });
       const stale = yield* harness.callTool({
         token: "token-parent",
         name: "synara_read_thread",
-        args: { threadId: shell.id, messageIndex: 0, messageOffsetChars: 20_000 },
+        args: {
+          threadId: shell.id,
+          messageIndex: 0,
+          messageOffsetChars: 20_000,
+          messageId,
+        },
       });
       assert.isTrue(isToolError(stale.result));
-      assert.include(toolErrorText(stale.result), "no longer valid");
+      assert.include(toolErrorText(stale.result), "now identifies message");
     }).pipe(Effect.provide(gatewayLayer));
   });
 

--- a/apps/server/src/agentGateway/threadReadTools.ts
+++ b/apps/server/src/agentGateway/threadReadTools.ts
@@ -24,6 +24,8 @@ import {
 } from "./targetResolver.ts";
 import {
   deriveAgentThreadStatus,
+  READ_THREAD_MAX_MESSAGE_CHARS,
+  READ_THREAD_MAX_MESSAGE_LIMIT,
   summarizeThreadDetail,
   summarizeThreadShell,
   summarizeWaitThreadText,
@@ -286,17 +288,34 @@ export function makeThreadReadTools(input: ThreadReadToolsInput): ReadonlyArray<
     requiredCapability: "thread:read",
     definition: {
       name: "synara_read_thread",
-      description:
-        "Read one Synara thread's status and recent messages (newest last, truncated). Pass the returned nextCursor as cursor to page older messages.",
+      description: `Read one Synara thread's status and recent messages (newest last). Pass nextCursor as cursor to page older messages. To read one long message losslessly in bounded slices, pass its index as messageIndex, start messageOffsetChars at 0, then follow messagePage.nextOffsetChars.`,
       inputSchema: {
         type: "object",
         properties: {
           threadId: { type: "string", description: "Thread to read." },
           cursor: { type: "string", description: "Pagination cursor from a previous call." },
-          messageLimit: { type: "number", description: "Messages per page (default 20, max 100)." },
+          messageLimit: {
+            type: "integer",
+            minimum: 1,
+            maximum: READ_THREAD_MAX_MESSAGE_LIMIT,
+            description: `Messages per transcript page (default 20, max ${READ_THREAD_MAX_MESSAGE_LIMIT}).`,
+          },
           maxMessageChars: {
-            type: "number",
-            description: "Per-message truncation limit (default 1500).",
+            type: "integer",
+            minimum: 50,
+            maximum: READ_THREAD_MAX_MESSAGE_CHARS,
+            description: `Characters per message or single-message slice (default 1500, max ${READ_THREAD_MAX_MESSAGE_CHARS}). The response reports the effective value.`,
+          },
+          messageIndex: {
+            type: "integer",
+            minimum: 0,
+            description: "Stable transcript index of one message to read losslessly.",
+          },
+          messageOffsetChars: {
+            type: "integer",
+            minimum: 0,
+            description:
+              "Character offset within messageIndex (default 0); follow messagePage.nextOffsetChars until absent.",
           },
         },
         required: ["threadId"],
@@ -310,6 +329,8 @@ export function makeThreadReadTools(input: ThreadReadToolsInput): ReadonlyArray<
         const cursor = readStringArg(args, "cursor");
         const messageLimit = readNumberArg(args, "messageLimit");
         const maxMessageChars = readNumberArg(args, "maxMessageChars");
+        const messageIndex = readNumberArg(args, "messageIndex");
+        const messageOffsetChars = readNumberArg(args, "messageOffsetChars");
         const detail = yield* snapshotQuery.getThreadDetailById(ThreadId.makeUnsafe(threadId)).pipe(
           Effect.mapError((error) => new ToolInputError(errorText(error))),
           Effect.flatMap(
@@ -325,6 +346,8 @@ export function makeThreadReadTools(input: ThreadReadToolsInput): ReadonlyArray<
             cursor,
             messageLimit,
             maxMessageChars,
+            messageIndex,
+            messageOffsetChars,
           }),
         );
       }).pipe(Effect.catch((error) => Effect.succeed(mcpToolResultError(errorText(error))))),

--- a/apps/server/src/agentGateway/threadReadTools.ts
+++ b/apps/server/src/agentGateway/threadReadTools.ts
@@ -288,7 +288,7 @@ export function makeThreadReadTools(input: ThreadReadToolsInput): ReadonlyArray<
     requiredCapability: "thread:read",
     definition: {
       name: "synara_read_thread",
-      description: `Read one Synara thread's status and recent messages (newest last). Pass nextCursor as cursor to page older messages. To read one settled long message losslessly in bounded slices, pass its index as messageIndex, start messageOffsetChars at 0, then pass messagePage.messageId with each messagePage.nextOffsetChars.`,
+      description: `Read one Synara thread's status and recent messages (newest last). Pass nextCursor as cursor to page older messages. To read one settled long message losslessly, pass the summary's index, messageId, and messageVersion with messageOffsetChars 0, then follow messagePage.nextOffsetChars with the same identity and version.`,
       inputSchema: {
         type: "object",
         properties: {
@@ -309,7 +309,8 @@ export function makeThreadReadTools(input: ThreadReadToolsInput): ReadonlyArray<
           messageIndex: {
             type: "integer",
             minimum: 0,
-            description: "Stable transcript index of one message to read losslessly.",
+            description:
+              "Current transcript index of one message to read losslessly; messageId and messageVersion detect stale coordinates.",
           },
           messageOffsetChars: {
             type: "integer",
@@ -320,7 +321,12 @@ export function makeThreadReadTools(input: ThreadReadToolsInput): ReadonlyArray<
           messageId: {
             type: "string",
             description:
-              "Message identity returned in messagePage; required with continuation offsets greater than 0.",
+              "Message identity returned in each message summary; required with messageIndex.",
+          },
+          messageVersion: {
+            type: "string",
+            description:
+              "Opaque version returned in each message summary; required with messageIndex so slices stay bound to one snapshot.",
           },
         },
         required: ["threadId"],
@@ -337,6 +343,7 @@ export function makeThreadReadTools(input: ThreadReadToolsInput): ReadonlyArray<
         const messageIndex = readNumberArg(args, "messageIndex");
         const messageOffsetChars = readNumberArg(args, "messageOffsetChars");
         const messageId = readStringArg(args, "messageId");
+        const messageVersion = readStringArg(args, "messageVersion");
         const detail = yield* snapshotQuery.getThreadDetailById(ThreadId.makeUnsafe(threadId)).pipe(
           Effect.mapError((error) => new ToolInputError(errorText(error))),
           Effect.flatMap(
@@ -355,6 +362,7 @@ export function makeThreadReadTools(input: ThreadReadToolsInput): ReadonlyArray<
             messageIndex,
             messageOffsetChars,
             messageId,
+            messageVersion,
           }),
         );
       }).pipe(Effect.catch((error) => Effect.succeed(mcpToolResultError(errorText(error))))),

--- a/apps/server/src/agentGateway/threadReadTools.ts
+++ b/apps/server/src/agentGateway/threadReadTools.ts
@@ -288,7 +288,7 @@ export function makeThreadReadTools(input: ThreadReadToolsInput): ReadonlyArray<
     requiredCapability: "thread:read",
     definition: {
       name: "synara_read_thread",
-      description: `Read one Synara thread's status and recent messages (newest last). Pass nextCursor as cursor to page older messages. To read one long message losslessly in bounded slices, pass its index as messageIndex, start messageOffsetChars at 0, then pass messagePage.messageId with each messagePage.nextOffsetChars.`,
+      description: `Read one Synara thread's status and recent messages (newest last). Pass nextCursor as cursor to page older messages. To read one settled long message losslessly in bounded slices, pass its index as messageIndex, start messageOffsetChars at 0, then pass messagePage.messageId with each messagePage.nextOffsetChars.`,
       inputSchema: {
         type: "object",
         properties: {

--- a/apps/server/src/agentGateway/threadReadTools.ts
+++ b/apps/server/src/agentGateway/threadReadTools.ts
@@ -288,7 +288,7 @@ export function makeThreadReadTools(input: ThreadReadToolsInput): ReadonlyArray<
     requiredCapability: "thread:read",
     definition: {
       name: "synara_read_thread",
-      description: `Read one Synara thread's status and recent messages (newest last). Pass nextCursor as cursor to page older messages. To read one long message losslessly in bounded slices, pass its index as messageIndex, start messageOffsetChars at 0, then follow messagePage.nextOffsetChars.`,
+      description: `Read one Synara thread's status and recent messages (newest last). Pass nextCursor as cursor to page older messages. To read one long message losslessly in bounded slices, pass its index as messageIndex, start messageOffsetChars at 0, then pass messagePage.messageId with each messagePage.nextOffsetChars.`,
       inputSchema: {
         type: "object",
         properties: {
@@ -317,6 +317,11 @@ export function makeThreadReadTools(input: ThreadReadToolsInput): ReadonlyArray<
             description:
               "Character offset within messageIndex (default 0); follow messagePage.nextOffsetChars until absent.",
           },
+          messageId: {
+            type: "string",
+            description:
+              "Message identity returned in messagePage; required with continuation offsets greater than 0.",
+          },
         },
         required: ["threadId"],
         additionalProperties: false,
@@ -331,6 +336,7 @@ export function makeThreadReadTools(input: ThreadReadToolsInput): ReadonlyArray<
         const maxMessageChars = readNumberArg(args, "maxMessageChars");
         const messageIndex = readNumberArg(args, "messageIndex");
         const messageOffsetChars = readNumberArg(args, "messageOffsetChars");
+        const messageId = readStringArg(args, "messageId");
         const detail = yield* snapshotQuery.getThreadDetailById(ThreadId.makeUnsafe(threadId)).pipe(
           Effect.mapError((error) => new ToolInputError(errorText(error))),
           Effect.flatMap(
@@ -348,6 +354,7 @@ export function makeThreadReadTools(input: ThreadReadToolsInput): ReadonlyArray<
             maxMessageChars,
             messageIndex,
             messageOffsetChars,
+            messageId,
           }),
         );
       }).pipe(Effect.catch((error) => Effect.succeed(mcpToolResultError(errorText(error))))),

--- a/apps/server/src/agentGateway/threadSummary.test.ts
+++ b/apps/server/src/agentGateway/threadSummary.test.ts
@@ -135,16 +135,18 @@ describe("paginateThreadMessages", () => {
   });
 
   it("recovers a long message exactly from bounded slices", () => {
-    const longText = Array.from({ length: 25_007 }, (_, index) => String(index % 10)).join("");
+    const longText = `${"a".repeat(9_999)}😀${"b".repeat(15_006)}`;
     const messages = [makeMessage(0, longText)];
     const slices: string[] = [];
     let messageOffsetChars = 0;
+    let messageId: string | undefined;
 
     while (true) {
       const page = paginateThreadMessages({
         messages,
         messageIndex: 0,
         messageOffsetChars,
+        messageId,
         maxMessageChars: 10_000,
       });
       slices.push(page.messages[0]?.text ?? "");
@@ -152,6 +154,7 @@ describe("paginateThreadMessages", () => {
       assert.equal(page.effectiveMaxMessageChars, 10_000);
       assert.equal(page.messagePage?.index, 0);
       assert.equal(page.messagePage?.offsetChars, messageOffsetChars);
+      messageId = page.messagePage?.messageId;
       const nextOffset = page.messagePage?.nextOffsetChars;
       if (nextOffset === undefined) break;
       messageOffsetChars = nextOffset;
@@ -177,12 +180,43 @@ describe("paginateThreadMessages", () => {
           messages,
           messageIndex: 0,
           messageOffsetChars: 20_000,
+          messageId: "m-0",
         }),
       /Message offset 20000 is no longer valid/,
     );
     assert.throws(
       () => paginateThreadMessages({ messages, cursor: "1", messageIndex: 0 }),
       /cursor.*cannot be combined.*messageIndex/,
+    );
+
+    const emojiMessage = makeMessage(0, `${"a".repeat(9_999)}😀tail`);
+    assert.throws(
+      () =>
+        paginateThreadMessages({
+          messages: [emojiMessage],
+          messageIndex: 0,
+          messageOffsetChars: 10_000,
+          messageId: "m-0",
+          maxMessageChars: 10_000,
+        }),
+      /splits a Unicode character/,
+    );
+
+    const firstPage = paginateThreadMessages({
+      messages: [makeMessage(0, "x".repeat(25_000))],
+      messageIndex: 0,
+      maxMessageChars: 10_000,
+    });
+    assert.throws(
+      () =>
+        paginateThreadMessages({
+          messages: [makeMessage(1, "y".repeat(25_000))],
+          messageIndex: 0,
+          messageOffsetChars: firstPage.messagePage?.nextOffsetChars,
+          messageId: firstPage.messagePage?.messageId,
+          maxMessageChars: 10_000,
+        }),
+      /now identifies message "m-1".*expected "m-0"/,
     );
   });
 

--- a/apps/server/src/agentGateway/threadSummary.test.ts
+++ b/apps/server/src/agentGateway/threadSummary.test.ts
@@ -137,9 +137,11 @@ describe("paginateThreadMessages", () => {
   it("recovers a long message exactly from bounded slices", () => {
     const longText = `${"a".repeat(9_999)}😀${"b".repeat(15_006)}`;
     const messages = [makeMessage(0, longText)];
+    const summary = paginateThreadMessages({ messages });
     const slices: string[] = [];
     let messageOffsetChars = 0;
-    let messageId: string | undefined;
+    const messageId = summary.messages[0]?.messageId;
+    const messageVersion = summary.messages[0]?.messageVersion;
 
     while (true) {
       const page = paginateThreadMessages({
@@ -147,6 +149,7 @@ describe("paginateThreadMessages", () => {
         messageIndex: 0,
         messageOffsetChars,
         messageId,
+        messageVersion,
         maxMessageChars: 10_000,
       });
       slices.push(page.messages[0]?.text ?? "");
@@ -154,7 +157,8 @@ describe("paginateThreadMessages", () => {
       assert.equal(page.effectiveMaxMessageChars, 10_000);
       assert.equal(page.messagePage?.index, 0);
       assert.equal(page.messagePage?.offsetChars, messageOffsetChars);
-      messageId = page.messagePage?.messageId;
+      assert.equal(page.messagePage?.messageId, messageId);
+      assert.equal(page.messagePage?.messageVersion, messageVersion);
       const nextOffset = page.messagePage?.nextOffsetChars;
       if (nextOffset === undefined) break;
       messageOffsetChars = nextOffset;
@@ -165,6 +169,9 @@ describe("paginateThreadMessages", () => {
 
   it("rejects invalid and stale single-message coordinates clearly", () => {
     const messages = [makeMessage(0, "short")];
+    const summary = paginateThreadMessages({ messages });
+    const messageId = summary.messages[0]?.messageId;
+    const messageVersion = summary.messages[0]?.messageVersion;
 
     assert.throws(
       () => paginateThreadMessages({ messages, messageOffsetChars: 1 }),
@@ -172,6 +179,20 @@ describe("paginateThreadMessages", () => {
     );
     assert.throws(
       () => paginateThreadMessages({ messages, messageIndex: 1 }),
+      /messageId.*required.*messageIndex/,
+    );
+    assert.throws(
+      () => paginateThreadMessages({ messages, messageIndex: 0, messageId }),
+      /messageVersion.*required.*messageIndex/,
+    );
+    assert.throws(
+      () =>
+        paginateThreadMessages({
+          messages,
+          messageIndex: 1,
+          messageId,
+          messageVersion,
+        }),
       /Message index 1 is no longer available/,
     );
     assert.throws(
@@ -180,7 +201,8 @@ describe("paginateThreadMessages", () => {
           messages,
           messageIndex: 0,
           messageOffsetChars: 20_000,
-          messageId: "m-0",
+          messageId,
+          messageVersion,
         }),
       /Message offset 20000 is no longer valid/,
     );
@@ -190,42 +212,58 @@ describe("paginateThreadMessages", () => {
     );
 
     const emojiMessage = makeMessage(0, `${"a".repeat(9_999)}😀tail`);
+    const emojiSummary = paginateThreadMessages({ messages: [emojiMessage] }).messages[0]!;
     assert.throws(
       () =>
         paginateThreadMessages({
           messages: [emojiMessage],
           messageIndex: 0,
           messageOffsetChars: 10_000,
-          messageId: "m-0",
+          messageId: emojiSummary.messageId,
+          messageVersion: emojiSummary.messageVersion,
           maxMessageChars: 10_000,
         }),
       /splits a Unicode character/,
     );
 
-    const firstPage = paginateThreadMessages({
+    const firstSummary = paginateThreadMessages({
       messages: [makeMessage(0, "x".repeat(25_000))],
-      messageIndex: 0,
-      maxMessageChars: 10_000,
     });
     assert.throws(
       () =>
         paginateThreadMessages({
           messages: [makeMessage(1, "y".repeat(25_000))],
           messageIndex: 0,
-          messageOffsetChars: firstPage.messagePage?.nextOffsetChars,
-          messageId: firstPage.messagePage?.messageId,
+          messageOffsetChars: 0,
+          messageId: firstSummary.messages[0]?.messageId,
+          messageVersion: firstSummary.messages[0]?.messageVersion,
           maxMessageChars: 10_000,
         }),
       /now identifies message "m-1".*expected "m-0"/,
     );
 
+    const streamingMessage = { ...makeMessage(0, "in progress"), streaming: true };
+    const streamingSummary = paginateThreadMessages({ messages: [streamingMessage] }).messages[0]!;
     assert.throws(
       () =>
         paginateThreadMessages({
-          messages: [{ ...makeMessage(0, "in progress"), streaming: true }],
+          messages: [streamingMessage],
           messageIndex: 0,
+          messageId: streamingSummary.messageId,
+          messageVersion: streamingSummary.messageVersion,
         }),
       /still streaming.*Retry after it settles/,
+    );
+
+    assert.throws(
+      () =>
+        paginateThreadMessages({
+          messages: [{ ...messages[0]!, text: "changed" }],
+          messageIndex: 0,
+          messageId,
+          messageVersion,
+        }),
+      /changed since version/,
     );
   });
 

--- a/apps/server/src/agentGateway/threadSummary.test.ts
+++ b/apps/server/src/agentGateway/threadSummary.test.ts
@@ -218,6 +218,15 @@ describe("paginateThreadMessages", () => {
         }),
       /now identifies message "m-1".*expected "m-0"/,
     );
+
+    assert.throws(
+      () =>
+        paginateThreadMessages({
+          messages: [{ ...makeMessage(0, "in progress"), streaming: true }],
+          messageIndex: 0,
+        }),
+      /still streaming.*Retry after it settles/,
+    );
   });
 
   it("ignores garbage cursors", () => {

--- a/apps/server/src/agentGateway/threadSummary.test.ts
+++ b/apps/server/src/agentGateway/threadSummary.test.ts
@@ -120,6 +120,70 @@ describe("paginateThreadMessages", () => {
     });
     assert.equal(page.messages[0]?.truncated, true);
     assert.include(page.messages[0]?.text, "[... truncated 4900 chars]");
+    assert.equal(page.effectiveMessageLimit, 20);
+    assert.equal(page.effectiveMaxMessageChars, 100);
+  });
+
+  it("reports the effective hard cap instead of silently hiding it", () => {
+    const page = paginateThreadMessages({
+      messages: [makeMessage(0, "x".repeat(25_000))],
+      maxMessageChars: 100_000,
+    });
+
+    assert.equal(page.effectiveMaxMessageChars, 20_000);
+    assert.equal(page.messages[0]?.truncated, true);
+  });
+
+  it("recovers a long message exactly from bounded slices", () => {
+    const longText = Array.from({ length: 25_007 }, (_, index) => String(index % 10)).join("");
+    const messages = [makeMessage(0, longText)];
+    const slices: string[] = [];
+    let messageOffsetChars = 0;
+
+    while (true) {
+      const page = paginateThreadMessages({
+        messages,
+        messageIndex: 0,
+        messageOffsetChars,
+        maxMessageChars: 10_000,
+      });
+      slices.push(page.messages[0]?.text ?? "");
+      assert.equal(page.effectiveMessageLimit, 1);
+      assert.equal(page.effectiveMaxMessageChars, 10_000);
+      assert.equal(page.messagePage?.index, 0);
+      assert.equal(page.messagePage?.offsetChars, messageOffsetChars);
+      const nextOffset = page.messagePage?.nextOffsetChars;
+      if (nextOffset === undefined) break;
+      messageOffsetChars = nextOffset;
+    }
+
+    assert.equal(slices.join(""), longText);
+  });
+
+  it("rejects invalid and stale single-message coordinates clearly", () => {
+    const messages = [makeMessage(0, "short")];
+
+    assert.throws(
+      () => paginateThreadMessages({ messages, messageOffsetChars: 1 }),
+      /messageOffsetChars.*requires.*messageIndex/,
+    );
+    assert.throws(
+      () => paginateThreadMessages({ messages, messageIndex: 1 }),
+      /Message index 1 is no longer available/,
+    );
+    assert.throws(
+      () =>
+        paginateThreadMessages({
+          messages,
+          messageIndex: 0,
+          messageOffsetChars: 20_000,
+        }),
+      /Message offset 20000 is no longer valid/,
+    );
+    assert.throws(
+      () => paginateThreadMessages({ messages, cursor: "1", messageIndex: 0 }),
+      /cursor.*cannot be combined.*messageIndex/,
+    );
   });
 
   it("ignores garbage cursors", () => {

--- a/apps/server/src/agentGateway/threadSummary.ts
+++ b/apps/server/src/agentGateway/threadSummary.ts
@@ -92,6 +92,8 @@ export const WAIT_THREAD_SUMMARY_MAX_CHARS = 2_000;
 
 export interface AgentThreadMessageSummary {
   readonly index: number;
+  readonly messageId: string;
+  readonly messageVersion: string;
   readonly role: string;
   readonly text: string;
   readonly truncated: boolean;
@@ -102,6 +104,7 @@ export interface AgentThreadMessageSummary {
 export interface AgentThreadSingleMessagePage {
   readonly index: number;
   readonly messageId: string;
+  readonly messageVersion: string;
   readonly offsetChars: number;
   readonly endOffsetChars: number;
   readonly totalChars: number;
@@ -146,6 +149,8 @@ function summarizeMessage(
 ): AgentThreadMessageSummary {
   return {
     index,
+    messageId: message.id,
+    messageVersion: threadMessageVersion(message),
     role: message.role,
     text,
     truncated,
@@ -154,13 +159,25 @@ function summarizeMessage(
   };
 }
 
-function assertMessageCoordinates(input: {
+function threadMessageVersion(message: OrchestrationMessage): string {
+  return `${message.updatedAt}:${message.text.length}`;
+}
+
+interface ThreadMessageCoordinates {
+  readonly messageIndex: number;
+  readonly messageOffsetChars: number;
+  readonly messageId: string;
+  readonly messageVersion: string;
+}
+
+function readMessageCoordinates(input: {
   readonly cursor?: string | undefined;
   readonly messageIndex?: number | undefined;
   readonly messageOffsetChars?: number | undefined;
   readonly messageId?: string | undefined;
+  readonly messageVersion?: string | undefined;
   readonly totalMessages: number;
-}): void {
+}): ThreadMessageCoordinates | undefined {
   if (input.messageIndex === undefined) {
     if (input.messageOffsetChars !== undefined) {
       throw new Error('"messageOffsetChars" requires "messageIndex".');
@@ -168,13 +185,22 @@ function assertMessageCoordinates(input: {
     if (input.messageId !== undefined) {
       throw new Error('"messageId" requires "messageIndex".');
     }
-    return;
+    if (input.messageVersion !== undefined) {
+      throw new Error('"messageVersion" requires "messageIndex".');
+    }
+    return undefined;
   }
   if (input.cursor !== undefined) {
     throw new Error('"cursor" cannot be combined with "messageIndex".');
   }
   if (!Number.isInteger(input.messageIndex) || input.messageIndex < 0) {
     throw new Error('"messageIndex" must be a non-negative integer.');
+  }
+  if (input.messageId === undefined) {
+    throw new Error('"messageId" is required with "messageIndex".');
+  }
+  if (input.messageVersion === undefined) {
+    throw new Error('"messageVersion" is required with "messageIndex".');
   }
   if (input.messageIndex >= input.totalMessages) {
     throw new Error(
@@ -187,9 +213,12 @@ function assertMessageCoordinates(input: {
   ) {
     throw new Error('"messageOffsetChars" must be a non-negative integer.');
   }
-  if ((input.messageOffsetChars ?? 0) > 0 && input.messageId === undefined) {
-    throw new Error('"messageId" is required when "messageOffsetChars" is greater than 0.');
-  }
+  return {
+    messageIndex: input.messageIndex,
+    messageOffsetChars: input.messageOffsetChars ?? 0,
+    messageId: input.messageId,
+    messageVersion: input.messageVersion,
+  };
 }
 
 function splitsSurrogatePair(text: string, offsetChars: number): boolean {
@@ -214,14 +243,21 @@ function paginateSingleMessage(input: {
   readonly messages: ReadonlyArray<OrchestrationMessage>;
   readonly messageIndex: number;
   readonly messageOffsetChars: number;
-  readonly messageId?: string | undefined;
+  readonly messageId: string;
+  readonly messageVersion: string;
   readonly maxChars: number;
 }): AgentThreadMessagePage {
   const message = input.messages[input.messageIndex]!;
   const totalChars = message.text.length;
-  if (input.messageId !== undefined && message.id !== input.messageId) {
+  if (message.id !== input.messageId) {
     throw new Error(
       `Message index ${input.messageIndex} now identifies message "${message.id}"; expected "${input.messageId}". Re-read the thread before continuing.`,
+    );
+  }
+  const currentMessageVersion = threadMessageVersion(message);
+  if (currentMessageVersion !== input.messageVersion) {
+    throw new Error(
+      `Message ${input.messageIndex} changed since version "${input.messageVersion}" (current version "${currentMessageVersion}"). Re-read the thread before continuing.`,
     );
   }
   if (message.streaming) {
@@ -257,6 +293,7 @@ function paginateSingleMessage(input: {
     messagePage: {
       index: input.messageIndex,
       messageId: message.id,
+      messageVersion: currentMessageVersion,
       offsetChars: input.messageOffsetChars,
       endOffsetChars,
       totalChars,
@@ -289,8 +326,8 @@ export function summarizeWaitThreadText(text: string | null | undefined): {
 /**
  * Page a thread's messages newest-first. `cursor` is the opaque value returned
  * by the previous page; the first call omits it and gets the tail of the
- * transcript. Message indexes are stable positions in the full transcript so
- * agents can reason about ordering across pages.
+ * transcript. Message indexes identify positions in the current bounded
+ * transcript; single-message reads bind them to message identity and version.
  */
 export function paginateThreadMessages(input: {
   readonly messages: ReadonlyArray<OrchestrationMessage>;
@@ -300,6 +337,7 @@ export function paginateThreadMessages(input: {
   readonly messageIndex?: number | undefined;
   readonly messageOffsetChars?: number | undefined;
   readonly messageId?: string | undefined;
+  readonly messageVersion?: string | undefined;
 }): AgentThreadMessagePage {
   const limit = boundedInteger(
     input.messageLimit,
@@ -314,19 +352,18 @@ export function paginateThreadMessages(input: {
     READ_THREAD_MAX_MESSAGE_CHARS,
   );
   const total = input.messages.length;
-  assertMessageCoordinates({
+  const messageCoordinates = readMessageCoordinates({
     cursor: input.cursor,
     messageIndex: input.messageIndex,
     messageOffsetChars: input.messageOffsetChars,
     messageId: input.messageId,
+    messageVersion: input.messageVersion,
     totalMessages: total,
   });
-  if (input.messageIndex !== undefined) {
+  if (messageCoordinates !== undefined) {
     return paginateSingleMessage({
       messages: input.messages,
-      messageIndex: input.messageIndex,
-      messageOffsetChars: input.messageOffsetChars ?? 0,
-      messageId: input.messageId,
+      ...messageCoordinates,
       maxChars,
     });
   }
@@ -388,6 +425,7 @@ export function summarizeThreadDetail(input: {
   readonly messageIndex?: number | undefined;
   readonly messageOffsetChars?: number | undefined;
   readonly messageId?: string | undefined;
+  readonly messageVersion?: string | undefined;
 }): AgentThreadDetail {
   const { thread } = input;
   const page = paginateThreadMessages({
@@ -398,6 +436,7 @@ export function summarizeThreadDetail(input: {
     messageIndex: input.messageIndex,
     messageOffsetChars: input.messageOffsetChars,
     messageId: input.messageId,
+    messageVersion: input.messageVersion,
   });
   return {
     threadId: thread.id,

--- a/apps/server/src/agentGateway/threadSummary.ts
+++ b/apps/server/src/agentGateway/threadSummary.ts
@@ -101,6 +101,7 @@ export interface AgentThreadMessageSummary {
 
 export interface AgentThreadSingleMessagePage {
   readonly index: number;
+  readonly messageId: string;
   readonly offsetChars: number;
   readonly endOffsetChars: number;
   readonly totalChars: number;
@@ -157,11 +158,15 @@ function assertMessageCoordinates(input: {
   readonly cursor?: string | undefined;
   readonly messageIndex?: number | undefined;
   readonly messageOffsetChars?: number | undefined;
+  readonly messageId?: string | undefined;
   readonly totalMessages: number;
 }): void {
   if (input.messageIndex === undefined) {
     if (input.messageOffsetChars !== undefined) {
       throw new Error('"messageOffsetChars" requires "messageIndex".');
+    }
+    if (input.messageId !== undefined) {
+      throw new Error('"messageId" requires "messageIndex".');
     }
     return;
   }
@@ -182,22 +187,55 @@ function assertMessageCoordinates(input: {
   ) {
     throw new Error('"messageOffsetChars" must be a non-negative integer.');
   }
+  if ((input.messageOffsetChars ?? 0) > 0 && input.messageId === undefined) {
+    throw new Error('"messageId" is required when "messageOffsetChars" is greater than 0.');
+  }
+}
+
+function splitsSurrogatePair(text: string, offsetChars: number): boolean {
+  if (offsetChars <= 0 || offsetChars >= text.length) return false;
+  const previousCodeUnit = text.charCodeAt(offsetChars - 1);
+  const nextCodeUnit = text.charCodeAt(offsetChars);
+  return (
+    previousCodeUnit >= 0xd800 &&
+    previousCodeUnit <= 0xdbff &&
+    nextCodeUnit >= 0xdc00 &&
+    nextCodeUnit <= 0xdfff
+  );
+}
+
+function unicodeSafeEndOffset(text: string, requestedEndOffsetChars: number): number {
+  return splitsSurrogatePair(text, requestedEndOffsetChars)
+    ? requestedEndOffsetChars - 1
+    : requestedEndOffsetChars;
 }
 
 function paginateSingleMessage(input: {
   readonly messages: ReadonlyArray<OrchestrationMessage>;
   readonly messageIndex: number;
   readonly messageOffsetChars: number;
+  readonly messageId?: string | undefined;
   readonly maxChars: number;
 }): AgentThreadMessagePage {
   const message = input.messages[input.messageIndex]!;
   const totalChars = message.text.length;
+  if (input.messageId !== undefined && message.id !== input.messageId) {
+    throw new Error(
+      `Message index ${input.messageIndex} now identifies message "${message.id}"; expected "${input.messageId}". Re-read the thread before continuing.`,
+    );
+  }
   if (input.messageOffsetChars > 0 && input.messageOffsetChars >= totalChars) {
     throw new Error(
       `Message offset ${input.messageOffsetChars} is no longer valid for message ${input.messageIndex} (current length ${totalChars}). Re-read the message from offset 0.`,
     );
   }
-  const endOffsetChars = Math.min(input.messageOffsetChars + input.maxChars, totalChars);
+  if (splitsSurrogatePair(message.text, input.messageOffsetChars)) {
+    throw new Error(
+      `Message offset ${input.messageOffsetChars} splits a Unicode character in message ${input.messageIndex}. Re-read from the previous reported boundary.`,
+    );
+  }
+  const requestedEndOffsetChars = Math.min(input.messageOffsetChars + input.maxChars, totalChars);
+  const endOffsetChars = unicodeSafeEndOffset(message.text, requestedEndOffsetChars);
   const nextOffsetChars = endOffsetChars < totalChars ? endOffsetChars : undefined;
   return {
     messages: [
@@ -213,6 +251,7 @@ function paginateSingleMessage(input: {
     effectiveMaxMessageChars: input.maxChars,
     messagePage: {
       index: input.messageIndex,
+      messageId: message.id,
       offsetChars: input.messageOffsetChars,
       endOffsetChars,
       totalChars,
@@ -255,6 +294,7 @@ export function paginateThreadMessages(input: {
   readonly maxMessageChars?: number | undefined;
   readonly messageIndex?: number | undefined;
   readonly messageOffsetChars?: number | undefined;
+  readonly messageId?: string | undefined;
 }): AgentThreadMessagePage {
   const limit = boundedInteger(
     input.messageLimit,
@@ -273,6 +313,7 @@ export function paginateThreadMessages(input: {
     cursor: input.cursor,
     messageIndex: input.messageIndex,
     messageOffsetChars: input.messageOffsetChars,
+    messageId: input.messageId,
     totalMessages: total,
   });
   if (input.messageIndex !== undefined) {
@@ -280,6 +321,7 @@ export function paginateThreadMessages(input: {
       messages: input.messages,
       messageIndex: input.messageIndex,
       messageOffsetChars: input.messageOffsetChars ?? 0,
+      messageId: input.messageId,
       maxChars,
     });
   }
@@ -340,6 +382,7 @@ export function summarizeThreadDetail(input: {
   readonly maxMessageChars?: number | undefined;
   readonly messageIndex?: number | undefined;
   readonly messageOffsetChars?: number | undefined;
+  readonly messageId?: string | undefined;
 }): AgentThreadDetail {
   const { thread } = input;
   const page = paginateThreadMessages({
@@ -349,6 +392,7 @@ export function summarizeThreadDetail(input: {
     maxMessageChars: input.maxMessageChars,
     messageIndex: input.messageIndex,
     messageOffsetChars: input.messageOffsetChars,
+    messageId: input.messageId,
   });
   return {
     threadId: thread.id,

--- a/apps/server/src/agentGateway/threadSummary.ts
+++ b/apps/server/src/agentGateway/threadSummary.ts
@@ -224,6 +224,11 @@ function paginateSingleMessage(input: {
       `Message index ${input.messageIndex} now identifies message "${message.id}"; expected "${input.messageId}". Re-read the thread before continuing.`,
     );
   }
+  if (message.streaming) {
+    throw new Error(
+      `Message ${input.messageIndex} is still streaming. Retry after it settles to read it losslessly.`,
+    );
+  }
   if (input.messageOffsetChars > 0 && input.messageOffsetChars >= totalChars) {
     throw new Error(
       `Message offset ${input.messageOffsetChars} is no longer valid for message ${input.messageIndex} (current length ${totalChars}). Re-read the message from offset 0.`,

--- a/apps/server/src/agentGateway/threadSummary.ts
+++ b/apps/server/src/agentGateway/threadSummary.ts
@@ -99,11 +99,22 @@ export interface AgentThreadMessageSummary {
   readonly createdAt: string;
 }
 
+export interface AgentThreadSingleMessagePage {
+  readonly index: number;
+  readonly offsetChars: number;
+  readonly endOffsetChars: number;
+  readonly totalChars: number;
+  readonly nextOffsetChars?: number;
+}
+
 export interface AgentThreadMessagePage {
   readonly messages: ReadonlyArray<AgentThreadMessageSummary>;
   readonly totalMessages: number;
+  readonly effectiveMessageLimit: number;
+  readonly effectiveMaxMessageChars: number;
   /** Pass back as `cursor` to fetch the next (older) page; absent when done. */
   readonly nextCursor?: string;
+  readonly messagePage?: AgentThreadSingleMessagePage;
 }
 
 function truncateMessageText(
@@ -114,6 +125,99 @@ function truncateMessageText(
   return {
     text: `${text.slice(0, maxChars)}\n[... truncated ${text.length - maxChars} chars]`,
     truncated: true,
+  };
+}
+
+function boundedInteger(
+  value: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+) {
+  return Math.max(minimum, Math.min(Math.trunc(value ?? fallback), maximum));
+}
+
+function summarizeMessage(
+  message: OrchestrationMessage,
+  index: number,
+  text: string,
+  truncated: boolean,
+): AgentThreadMessageSummary {
+  return {
+    index,
+    role: message.role,
+    text,
+    truncated,
+    ...(message.dispatchOrigin !== undefined ? { dispatchOrigin: message.dispatchOrigin } : {}),
+    createdAt: message.createdAt,
+  };
+}
+
+function assertMessageCoordinates(input: {
+  readonly cursor?: string | undefined;
+  readonly messageIndex?: number | undefined;
+  readonly messageOffsetChars?: number | undefined;
+  readonly totalMessages: number;
+}): void {
+  if (input.messageIndex === undefined) {
+    if (input.messageOffsetChars !== undefined) {
+      throw new Error('"messageOffsetChars" requires "messageIndex".');
+    }
+    return;
+  }
+  if (input.cursor !== undefined) {
+    throw new Error('"cursor" cannot be combined with "messageIndex".');
+  }
+  if (!Number.isInteger(input.messageIndex) || input.messageIndex < 0) {
+    throw new Error('"messageIndex" must be a non-negative integer.');
+  }
+  if (input.messageIndex >= input.totalMessages) {
+    throw new Error(
+      `Message index ${input.messageIndex} is no longer available (thread currently has ${input.totalMessages} messages). Re-read the thread before continuing.`,
+    );
+  }
+  if (
+    input.messageOffsetChars !== undefined &&
+    (!Number.isInteger(input.messageOffsetChars) || input.messageOffsetChars < 0)
+  ) {
+    throw new Error('"messageOffsetChars" must be a non-negative integer.');
+  }
+}
+
+function paginateSingleMessage(input: {
+  readonly messages: ReadonlyArray<OrchestrationMessage>;
+  readonly messageIndex: number;
+  readonly messageOffsetChars: number;
+  readonly maxChars: number;
+}): AgentThreadMessagePage {
+  const message = input.messages[input.messageIndex]!;
+  const totalChars = message.text.length;
+  if (input.messageOffsetChars > 0 && input.messageOffsetChars >= totalChars) {
+    throw new Error(
+      `Message offset ${input.messageOffsetChars} is no longer valid for message ${input.messageIndex} (current length ${totalChars}). Re-read the message from offset 0.`,
+    );
+  }
+  const endOffsetChars = Math.min(input.messageOffsetChars + input.maxChars, totalChars);
+  const nextOffsetChars = endOffsetChars < totalChars ? endOffsetChars : undefined;
+  return {
+    messages: [
+      summarizeMessage(
+        message,
+        input.messageIndex,
+        message.text.slice(input.messageOffsetChars, endOffsetChars),
+        nextOffsetChars !== undefined,
+      ),
+    ],
+    totalMessages: input.messages.length,
+    effectiveMessageLimit: 1,
+    effectiveMaxMessageChars: input.maxChars,
+    messagePage: {
+      index: input.messageIndex,
+      offsetChars: input.messageOffsetChars,
+      endOffsetChars,
+      totalChars,
+      ...(nextOffsetChars !== undefined ? { nextOffsetChars } : {}),
+    },
   };
 }
 
@@ -149,22 +253,36 @@ export function paginateThreadMessages(input: {
   readonly cursor?: string | undefined;
   readonly messageLimit?: number | undefined;
   readonly maxMessageChars?: number | undefined;
+  readonly messageIndex?: number | undefined;
+  readonly messageOffsetChars?: number | undefined;
 }): AgentThreadMessagePage {
-  const limit = Math.max(
+  const limit = boundedInteger(
+    input.messageLimit,
+    READ_THREAD_DEFAULT_MESSAGE_LIMIT,
     1,
-    Math.min(
-      input.messageLimit ?? READ_THREAD_DEFAULT_MESSAGE_LIMIT,
-      READ_THREAD_MAX_MESSAGE_LIMIT,
-    ),
+    READ_THREAD_MAX_MESSAGE_LIMIT,
   );
-  const maxChars = Math.max(
+  const maxChars = boundedInteger(
+    input.maxMessageChars,
+    READ_THREAD_DEFAULT_MESSAGE_CHARS,
     50,
-    Math.min(
-      input.maxMessageChars ?? READ_THREAD_DEFAULT_MESSAGE_CHARS,
-      READ_THREAD_MAX_MESSAGE_CHARS,
-    ),
+    READ_THREAD_MAX_MESSAGE_CHARS,
   );
   const total = input.messages.length;
+  assertMessageCoordinates({
+    cursor: input.cursor,
+    messageIndex: input.messageIndex,
+    messageOffsetChars: input.messageOffsetChars,
+    totalMessages: total,
+  });
+  if (input.messageIndex !== undefined) {
+    return paginateSingleMessage({
+      messages: input.messages,
+      messageIndex: input.messageIndex,
+      messageOffsetChars: input.messageOffsetChars ?? 0,
+      maxChars,
+    });
+  }
   // endExclusive is the transcript index right after the newest message of
   // this page; the cursor carries the start of the previous (newer) page.
   let endExclusive = total;
@@ -177,18 +295,13 @@ export function paginateThreadMessages(input: {
   const startInclusive = Math.max(0, endExclusive - limit);
   const messages = input.messages.slice(startInclusive, endExclusive).map((message, offset) => {
     const { text, truncated } = truncateMessageText(message.text, maxChars);
-    return {
-      index: startInclusive + offset,
-      role: message.role,
-      text,
-      truncated,
-      ...(message.dispatchOrigin !== undefined ? { dispatchOrigin: message.dispatchOrigin } : {}),
-      createdAt: message.createdAt,
-    } satisfies AgentThreadMessageSummary;
+    return summarizeMessage(message, startInclusive + offset, text, truncated);
   });
   return {
     messages,
     totalMessages: total,
+    effectiveMessageLimit: limit,
+    effectiveMaxMessageChars: maxChars,
     ...(startInclusive > 0 ? { nextCursor: String(startInclusive) } : {}),
   };
 }
@@ -214,7 +327,10 @@ export interface AgentThreadDetail {
   readonly updatedAt: string;
   readonly messages: ReadonlyArray<AgentThreadMessageSummary>;
   readonly totalMessages: number;
+  readonly effectiveMessageLimit: number;
+  readonly effectiveMaxMessageChars: number;
   readonly nextCursor?: string;
+  readonly messagePage?: AgentThreadSingleMessagePage;
 }
 
 export function summarizeThreadDetail(input: {
@@ -222,6 +338,8 @@ export function summarizeThreadDetail(input: {
   readonly cursor?: string | undefined;
   readonly messageLimit?: number | undefined;
   readonly maxMessageChars?: number | undefined;
+  readonly messageIndex?: number | undefined;
+  readonly messageOffsetChars?: number | undefined;
 }): AgentThreadDetail {
   const { thread } = input;
   const page = paginateThreadMessages({
@@ -229,6 +347,8 @@ export function summarizeThreadDetail(input: {
     cursor: input.cursor,
     messageLimit: input.messageLimit,
     maxMessageChars: input.maxMessageChars,
+    messageIndex: input.messageIndex,
+    messageOffsetChars: input.messageOffsetChars,
   });
   return {
     threadId: thread.id,
@@ -251,6 +371,9 @@ export function summarizeThreadDetail(input: {
     updatedAt: thread.updatedAt,
     messages: page.messages,
     totalMessages: page.totalMessages,
+    effectiveMessageLimit: page.effectiveMessageLimit,
+    effectiveMaxMessageChars: page.effectiveMaxMessageChars,
     ...(page.nextCursor !== undefined ? { nextCursor: page.nextCursor } : {}),
+    ...(page.messagePage !== undefined ? { messagePage: page.messagePage } : {}),
   };
 }

--- a/apps/server/src/externalMcp/Layers/ExternalMcpGateway.e2e.test.ts
+++ b/apps/server/src/externalMcp/Layers/ExternalMcpGateway.e2e.test.ts
@@ -450,6 +450,7 @@ describe("external MCP gateway stdio flow", () => {
           minimum: 0,
         });
         expect(readTaskProperties?.messageId).toMatchObject({ type: "string" });
+        expect(readTaskProperties?.messageVersion).toMatchObject({ type: "string" });
 
         const prompt = "Implement the external MCP end-to-end proof.";
         stdin.write(
@@ -518,11 +519,27 @@ describe("external MCP gateway stdio flow", () => {
           ),
         });
 
+        stdin.write(
+          `${JSON.stringify({
+            jsonrpc: "2.0",
+            id: 4,
+            method: "tools/call",
+            params: { name: "synara_read_task", arguments: { threadId } },
+          })}\n`,
+        );
+        yield* Effect.promise(() => waitForOutput(outputLines, 4));
+        const summaryMessages = toolPayload(outputLines[3]!).messages as Array<{
+          index: number;
+          messageId: string;
+          messageVersion: string;
+        }>;
+        const assistantSummary = summaryMessages.find((message) => message.index === 1)!;
+
         for (const [index, messageOffsetChars] of [0, 10_000, 20_000].entries()) {
           stdin.write(
             `${JSON.stringify({
               jsonrpc: "2.0",
-              id: index + 4,
+              id: index + 5,
               method: "tools/call",
               params: {
                 name: "synara_read_task",
@@ -530,7 +547,8 @@ describe("external MCP gateway stdio flow", () => {
                   threadId,
                   messageIndex: 1,
                   messageOffsetChars,
-                  messageId: "message-external-e2e-result",
+                  messageId: assistantSummary.messageId,
+                  messageVersion: assistantSummary.messageVersion,
                   maxMessageChars: 10_000,
                 },
               },
@@ -540,7 +558,8 @@ describe("external MCP gateway stdio flow", () => {
         stdin.end();
         yield* Effect.promise(() => serving);
         expect(errors).toEqual([]);
-        const messagePages = outputLines.slice(3, 6).map(toolPayload);
+        const responseById = new Map(outputLines.map((response) => [response.id, response]));
+        const messagePages = [5, 6, 7].map((id) => toolPayload(responseById.get(id)!));
         expect(messagePages.map((page) => page.effectiveMaxMessageChars)).toEqual([
           10_000, 10_000, 10_000,
         ]);
@@ -553,6 +572,7 @@ describe("external MCP gateway stdio flow", () => {
           {
             index: 1,
             messageId: "message-external-e2e-result",
+            messageVersion: assistantSummary.messageVersion,
             offsetChars: 0,
             endOffsetChars: 10_000,
             totalChars: 25_007,
@@ -561,6 +581,7 @@ describe("external MCP gateway stdio flow", () => {
           {
             index: 1,
             messageId: "message-external-e2e-result",
+            messageVersion: assistantSummary.messageVersion,
             offsetChars: 10_000,
             endOffsetChars: 20_000,
             totalChars: 25_007,
@@ -569,6 +590,7 @@ describe("external MCP gateway stdio flow", () => {
           {
             index: 1,
             messageId: "message-external-e2e-result",
+            messageVersion: assistantSummary.messageVersion,
             offsetChars: 20_000,
             endOffsetChars: 25_007,
             totalChars: 25_007,
@@ -648,7 +670,7 @@ describe("external MCP gateway stdio flow", () => {
           FROM external_mcp_audit_log
           ORDER BY created_at ASC, audit_id ASC
         `;
-        expect(auditRows).toHaveLength(8);
+        expect(auditRows).toHaveLength(9);
         expect(auditRows.find((row) => row.requestId === "external-e2e-request")).toMatchObject({
           projectId: PROJECT_ID,
           runtimeMode: "approval-required",

--- a/apps/server/src/externalMcp/Layers/ExternalMcpGateway.e2e.test.ts
+++ b/apps/server/src/externalMcp/Layers/ExternalMcpGateway.e2e.test.ts
@@ -449,6 +449,7 @@ describe("external MCP gateway stdio flow", () => {
           type: "integer",
           minimum: 0,
         });
+        expect(readTaskProperties?.messageId).toMatchObject({ type: "string" });
 
         const prompt = "Implement the external MCP end-to-end proof.";
         stdin.write(
@@ -529,6 +530,7 @@ describe("external MCP gateway stdio flow", () => {
                   threadId,
                   messageIndex: 1,
                   messageOffsetChars,
+                  messageId: "message-external-e2e-result",
                   maxMessageChars: 10_000,
                 },
               },
@@ -550,6 +552,7 @@ describe("external MCP gateway stdio flow", () => {
         expect(messagePages.map((page) => page.messagePage)).toEqual([
           {
             index: 1,
+            messageId: "message-external-e2e-result",
             offsetChars: 0,
             endOffsetChars: 10_000,
             totalChars: 25_007,
@@ -557,6 +560,7 @@ describe("external MCP gateway stdio flow", () => {
           },
           {
             index: 1,
+            messageId: "message-external-e2e-result",
             offsetChars: 10_000,
             endOffsetChars: 20_000,
             totalChars: 25_007,
@@ -564,6 +568,7 @@ describe("external MCP gateway stdio flow", () => {
           },
           {
             index: 1,
+            messageId: "message-external-e2e-result",
             offsetChars: 20_000,
             endOffsetChars: 25_007,
             totalChars: 25_007,

--- a/apps/server/src/externalMcp/Layers/ExternalMcpGateway.e2e.test.ts
+++ b/apps/server/src/externalMcp/Layers/ExternalMcpGateway.e2e.test.ts
@@ -419,9 +419,14 @@ describe("external MCP gateway stdio flow", () => {
         );
         yield* Effect.promise(() => waitForOutput(outputLines, 1));
         const listedTools = (
-          outputLines[0]!.result as { tools: Array<{ name: string }> }
-        ).tools.map((tool) => tool.name);
-        expect(listedTools).toEqual([
+          outputLines[0]!.result as {
+            tools: Array<{
+              name: string;
+              inputSchema: { properties?: Record<string, unknown> };
+            }>;
+          }
+        ).tools;
+        expect(listedTools.map((tool) => tool.name)).toEqual([
           "synara_overview",
           "synara_capabilities",
           "synara_list_allowed_projects",
@@ -429,6 +434,21 @@ describe("external MCP gateway stdio flow", () => {
           "synara_wait_for_task",
           "synara_read_task",
         ]);
+        const readTaskProperties = listedTools.find((tool) => tool.name === "synara_read_task")
+          ?.inputSchema.properties;
+        expect(readTaskProperties?.maxMessageChars).toMatchObject({
+          type: "integer",
+          minimum: 50,
+          maximum: 10_000,
+        });
+        expect(readTaskProperties?.messageIndex).toMatchObject({
+          type: "integer",
+          minimum: 0,
+        });
+        expect(readTaskProperties?.messageOffsetChars).toMatchObject({
+          type: "integer",
+          minimum: 0,
+        });
 
         const prompt = "Implement the external MCP end-to-end proof.";
         stdin.write(
@@ -488,20 +508,72 @@ describe("external MCP gateway stdio flow", () => {
           summary: "Finished from external MCP.",
         });
 
-        stdin.write(
-          `${JSON.stringify({
-            jsonrpc: "2.0",
-            id: 4,
-            method: "tools/call",
-            params: { name: "synara_read_task", arguments: { threadId } },
-          })}\n`,
-        );
+        const longText = Array.from(
+          { length: 25_007 },
+          (_, index) => String(index % 10),
+        ).join("");
+        const currentDetail = details.get(threadId)!;
+        details.set(threadId, {
+          ...currentDetail,
+          messages: currentDetail.messages.map((message) =>
+            message.role === "assistant" ? { ...message, text: longText } : message,
+          ),
+        });
+
+        for (const [index, messageOffsetChars] of [0, 10_000, 20_000].entries()) {
+          stdin.write(
+            `${JSON.stringify({
+              jsonrpc: "2.0",
+              id: index + 4,
+              method: "tools/call",
+              params: {
+                name: "synara_read_task",
+                arguments: {
+                  threadId,
+                  messageIndex: 1,
+                  messageOffsetChars,
+                  maxMessageChars: 10_000,
+                },
+              },
+            })}\n`,
+          );
+        }
         stdin.end();
         yield* Effect.promise(() => serving);
         expect(errors).toEqual([]);
-        expect(JSON.stringify(toolPayload(outputLines[3]!))).toContain(
-          "Finished from external MCP.",
-        );
+        const messagePages = outputLines.slice(3, 6).map(toolPayload);
+        expect(messagePages.map((page) => page.effectiveMaxMessageChars)).toEqual([
+          10_000,
+          10_000,
+          10_000,
+        ]);
+        expect(
+          messagePages
+            .map((page) => (page.messages as Array<{ text: string }>)[0]?.text ?? "")
+            .join(""),
+        ).toBe(longText);
+        expect(messagePages.map((page) => page.messagePage)).toEqual([
+          {
+            index: 1,
+            offsetChars: 0,
+            endOffsetChars: 10_000,
+            totalChars: 25_007,
+            nextOffsetChars: 10_000,
+          },
+          {
+            index: 1,
+            offsetChars: 10_000,
+            endOffsetChars: 20_000,
+            totalChars: 25_007,
+            nextOffsetChars: 20_000,
+          },
+          {
+            index: 1,
+            offsetChars: 20_000,
+            endOffsetChars: 25_007,
+            totalChars: 25_007,
+          },
+        ]);
 
         const interruptedWait = yield* gateway
           .handlePost({
@@ -576,7 +648,7 @@ describe("external MCP gateway stdio flow", () => {
           FROM external_mcp_audit_log
           ORDER BY created_at ASC, audit_id ASC
         `;
-        expect(auditRows).toHaveLength(6);
+        expect(auditRows).toHaveLength(8);
         expect(auditRows.find((row) => row.requestId === "external-e2e-request")).toMatchObject({
           projectId: PROJECT_ID,
           runtimeMode: "approval-required",

--- a/apps/server/src/externalMcp/Layers/ExternalMcpGateway.e2e.test.ts
+++ b/apps/server/src/externalMcp/Layers/ExternalMcpGateway.e2e.test.ts
@@ -508,10 +508,7 @@ describe("external MCP gateway stdio flow", () => {
           summary: "Finished from external MCP.",
         });
 
-        const longText = Array.from(
-          { length: 25_007 },
-          (_, index) => String(index % 10),
-        ).join("");
+        const longText = Array.from({ length: 25_007 }, (_, index) => String(index % 10)).join("");
         const currentDetail = details.get(threadId)!;
         details.set(threadId, {
           ...currentDetail,
@@ -543,9 +540,7 @@ describe("external MCP gateway stdio flow", () => {
         expect(errors).toEqual([]);
         const messagePages = outputLines.slice(3, 6).map(toolPayload);
         expect(messagePages.map((page) => page.effectiveMaxMessageChars)).toEqual([
-          10_000,
-          10_000,
-          10_000,
+          10_000, 10_000, 10_000,
         ]);
         expect(
           messagePages

--- a/apps/server/src/externalMcp/Layers/ExternalMcpGateway.ts
+++ b/apps/server/src/externalMcp/Layers/ExternalMcpGateway.ts
@@ -1,5 +1,6 @@
 import {
   EXTERNAL_MCP_DEFAULT_WAIT_MS,
+  EXTERNAL_MCP_MAX_MESSAGE_CHARS,
   EXTERNAL_MCP_MAX_PROMPT_CHARS,
   EXTERNAL_MCP_MAX_WAIT_MS,
   ExternalMcpCreateTaskInput,
@@ -455,14 +456,30 @@ export const makeExternalMcpGateway = Effect.gen(function* () {
     definition: {
       name: "synara_read_task",
       description:
-        "Read one task created by this integration, or an allowed-project task when tasks:read-project was explicitly granted.",
+        "Read one task created by this integration, or an allowed-project task when tasks:read-project was explicitly granted. To read one long message losslessly, pass messageIndex, start messageOffsetChars at 0, then follow messagePage.nextOffsetChars.",
       inputSchema: {
         type: "object",
         properties: {
           threadId: { type: "string" },
           cursor: { type: "string" },
           messageLimit: { type: "integer", minimum: 1, maximum: 100 },
-          maxMessageChars: { type: "integer", minimum: 50, maximum: 10_000 },
+          maxMessageChars: {
+            type: "integer",
+            minimum: 50,
+            maximum: EXTERNAL_MCP_MAX_MESSAGE_CHARS,
+            description: `Characters per message or single-message slice (default 1500, max ${EXTERNAL_MCP_MAX_MESSAGE_CHARS}). The response reports the effective value.`,
+          },
+          messageIndex: {
+            type: "integer",
+            minimum: 0,
+            description: "Stable transcript index of one message to read losslessly.",
+          },
+          messageOffsetChars: {
+            type: "integer",
+            minimum: 0,
+            description:
+              "Character offset within messageIndex (default 0); follow messagePage.nextOffsetChars until absent.",
+          },
         },
         required: ["threadId"],
         additionalProperties: false,
@@ -490,6 +507,8 @@ export const makeExternalMcpGateway = Effect.gen(function* () {
             cursor: input.cursor,
             messageLimit: input.messageLimit,
             maxMessageChars: input.maxMessageChars,
+            messageIndex: input.messageIndex,
+            messageOffsetChars: input.messageOffsetChars,
           }),
         );
       }).pipe(Effect.catch((error) => Effect.succeed(externalErrorResult(error)))),

--- a/apps/server/src/externalMcp/Layers/ExternalMcpGateway.ts
+++ b/apps/server/src/externalMcp/Layers/ExternalMcpGateway.ts
@@ -456,7 +456,7 @@ export const makeExternalMcpGateway = Effect.gen(function* () {
     definition: {
       name: "synara_read_task",
       description:
-        "Read one task created by this integration, or an allowed-project task when tasks:read-project was explicitly granted. To read one long message losslessly, pass messageIndex, start messageOffsetChars at 0, then follow messagePage.nextOffsetChars.",
+        "Read one task created by this integration, or an allowed-project task when tasks:read-project was explicitly granted. To read one long message losslessly, pass messageIndex, start messageOffsetChars at 0, then pass messagePage.messageId with each messagePage.nextOffsetChars.",
       inputSchema: {
         type: "object",
         properties: {
@@ -479,6 +479,11 @@ export const makeExternalMcpGateway = Effect.gen(function* () {
             minimum: 0,
             description:
               "Character offset within messageIndex (default 0); follow messagePage.nextOffsetChars until absent.",
+          },
+          messageId: {
+            type: "string",
+            description:
+              "Message identity returned in messagePage; required with continuation offsets greater than 0.",
           },
         },
         required: ["threadId"],
@@ -509,6 +514,7 @@ export const makeExternalMcpGateway = Effect.gen(function* () {
             maxMessageChars: input.maxMessageChars,
             messageIndex: input.messageIndex,
             messageOffsetChars: input.messageOffsetChars,
+            messageId: input.messageId,
           }),
         );
       }).pipe(Effect.catch((error) => Effect.succeed(externalErrorResult(error)))),

--- a/apps/server/src/externalMcp/Layers/ExternalMcpGateway.ts
+++ b/apps/server/src/externalMcp/Layers/ExternalMcpGateway.ts
@@ -456,7 +456,7 @@ export const makeExternalMcpGateway = Effect.gen(function* () {
     definition: {
       name: "synara_read_task",
       description:
-        "Read one task created by this integration, or an allowed-project task when tasks:read-project was explicitly granted. To read one long message losslessly, pass messageIndex, start messageOffsetChars at 0, then pass messagePage.messageId with each messagePage.nextOffsetChars.",
+        "Read one task created by this integration, or an allowed-project task when tasks:read-project was explicitly granted. To read one settled long message losslessly, pass messageIndex, start messageOffsetChars at 0, then pass messagePage.messageId with each messagePage.nextOffsetChars.",
       inputSchema: {
         type: "object",
         properties: {

--- a/apps/server/src/externalMcp/Layers/ExternalMcpGateway.ts
+++ b/apps/server/src/externalMcp/Layers/ExternalMcpGateway.ts
@@ -456,7 +456,7 @@ export const makeExternalMcpGateway = Effect.gen(function* () {
     definition: {
       name: "synara_read_task",
       description:
-        "Read one task created by this integration, or an allowed-project task when tasks:read-project was explicitly granted. To read one settled long message losslessly, pass messageIndex, start messageOffsetChars at 0, then pass messagePage.messageId with each messagePage.nextOffsetChars.",
+        "Read one task created by this integration, or an allowed-project task when tasks:read-project was explicitly granted. To read one settled long message losslessly, pass the summary's index, messageId, and messageVersion with messageOffsetChars 0, then follow messagePage.nextOffsetChars with the same identity and version.",
       inputSchema: {
         type: "object",
         properties: {
@@ -472,7 +472,8 @@ export const makeExternalMcpGateway = Effect.gen(function* () {
           messageIndex: {
             type: "integer",
             minimum: 0,
-            description: "Stable transcript index of one message to read losslessly.",
+            description:
+              "Current transcript index of one message to read losslessly; messageId and messageVersion detect stale coordinates.",
           },
           messageOffsetChars: {
             type: "integer",
@@ -483,7 +484,12 @@ export const makeExternalMcpGateway = Effect.gen(function* () {
           messageId: {
             type: "string",
             description:
-              "Message identity returned in messagePage; required with continuation offsets greater than 0.",
+              "Message identity returned in each message summary; required with messageIndex.",
+          },
+          messageVersion: {
+            type: "string",
+            description:
+              "Opaque version returned in each message summary; required with messageIndex so slices stay bound to one snapshot.",
           },
         },
         required: ["threadId"],
@@ -515,6 +521,7 @@ export const makeExternalMcpGateway = Effect.gen(function* () {
             messageIndex: input.messageIndex,
             messageOffsetChars: input.messageOffsetChars,
             messageId: input.messageId,
+            messageVersion: input.messageVersion,
           }),
         );
       }).pipe(Effect.catch((error) => Effect.succeed(externalErrorResult(error)))),

--- a/packages/contracts/src/externalMcp.ts
+++ b/packages/contracts/src/externalMcp.ts
@@ -149,6 +149,7 @@ export const ExternalMcpReadTaskInput = Schema.Struct({
   messageIndex: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
   messageOffsetChars: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
   messageId: Schema.optional(MessageId),
+  messageVersion: Schema.optional(TrimmedNonEmptyString),
 }).annotate({ parseOptions: { onExcessProperty: "error" } });
 export type ExternalMcpReadTaskInput = typeof ExternalMcpReadTaskInput.Type;
 

--- a/packages/contracts/src/externalMcp.ts
+++ b/packages/contracts/src/externalMcp.ts
@@ -9,6 +9,7 @@ export const EXTERNAL_MCP_MAX_REQUEST_ID_LENGTH = 256;
 export const EXTERNAL_MCP_DEFAULT_WAIT_MS = 30_000;
 export const EXTERNAL_MCP_MAX_WAIT_MS = 60_000;
 export const EXTERNAL_MCP_CREATE_TIMEOUT_MS = 10 * 60_000;
+export const EXTERNAL_MCP_MAX_MESSAGE_CHARS = 10_000;
 
 export const ExternalMcpCapability = Schema.Literals([
   "projects:read",
@@ -141,8 +142,12 @@ export const ExternalMcpReadTaskInput = Schema.Struct({
     Schema.Int.check(Schema.isGreaterThanOrEqualTo(1)).check(Schema.isLessThanOrEqualTo(100)),
   ),
   maxMessageChars: Schema.optional(
-    Schema.Int.check(Schema.isGreaterThanOrEqualTo(50)).check(Schema.isLessThanOrEqualTo(10_000)),
+    Schema.Int.check(Schema.isGreaterThanOrEqualTo(50)).check(
+      Schema.isLessThanOrEqualTo(EXTERNAL_MCP_MAX_MESSAGE_CHARS),
+    ),
   ),
+  messageIndex: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
+  messageOffsetChars: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
 }).annotate({ parseOptions: { onExcessProperty: "error" } });
 export type ExternalMcpReadTaskInput = typeof ExternalMcpReadTaskInput.Type;
 

--- a/packages/contracts/src/externalMcp.ts
+++ b/packages/contracts/src/externalMcp.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect";
 
-import { IsoDateTime, ProjectId, ThreadId, TrimmedNonEmptyString } from "./baseSchemas";
+import { IsoDateTime, MessageId, ProjectId, ThreadId, TrimmedNonEmptyString } from "./baseSchemas";
 import { ProviderKind, RuntimeMode } from "./orchestration";
 
 export const EXTERNAL_MCP_AUDIENCE = "synara.external-mcp" as const;
@@ -148,6 +148,7 @@ export const ExternalMcpReadTaskInput = Schema.Struct({
   ),
   messageIndex: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
   messageOffsetChars: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
+  messageId: Schema.optional(MessageId),
 }).annotate({ parseOptions: { onExcessProperty: "error" } });
 export type ExternalMcpReadTaskInput = typeof ExternalMcpReadTaskInput.Type;
 


### PR DESCRIPTION
## Problem

`synara_read_thread` capped every message at 20,000 characters but only paged between messages. A caller could discover that a message was truncated, yet no agent-facing coordinate could reach the discarded tail. The internal schema also omitted the hard limit, and the external MCP reader had the same reachability gap behind its separate 10,000-character ceiling.

## Fix

- add bounded single-message reads through `messageIndex` and `messageOffsetChars`
- return raw slices plus `messagePage` offsets and `nextOffsetChars` so callers can recover the full message exactly
- expose `messageId` and `messageVersion` in ordinary summaries, then require both from the first slice onward so retention or later message mutation cannot silently change the reconstructed message
- keep automatic boundaries outside UTF-16 surrogate pairs and reject caller offsets that split a Unicode character
- reject lossless single-message reads while a message is still streaming, so an absent continuation always means the settled message is complete
- reject missing, conflicting, out-of-range, and stale coordinates with clear tool errors
- report `effectiveMessageLimit` and `effectiveMaxMessageChars` on every read
- document integer bounds and hard character limits in both MCP tool schemas
- preserve the existing numeric `cursor` behavior for inter-message pagination
- mirror the shared reachability behavior through `synara_read_task` while retaining its 10,000-character external limit

The diagnostic event sanitizer, wait summaries, and transcript search are intentionally unchanged.

## Verification

`bun run --cwd apps/server test -- --configLoader runner src/agentGateway/threadSummary.test.ts src/agentGateway/Layers/AgentGateway.test.ts src/externalMcp/Layers/ExternalMcpGateway.e2e.test.ts`

- 3 files passed
- 106 tests passed
- internal and external tests concatenate bounded slices back into the exact original 25,007-character message
- the pure reconstruction fixture places an emoji across the original 10,000-unit boundary
- stale indexes, stale offsets, changed message versions, Unicode-splitting offsets, and active streaming messages return explicit errors
- the external stdio proof correlates concurrent JSON-RPC responses by request ID rather than arrival order

`git diff --check`

Closes #799

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent-facing read APIs and pagination semantics for thread transcripts; behavior is heavily tested but affects how integrations reconstruct long assistant output.
> 
> **Overview**
> **`synara_read_thread`** and **`synara_read_task`** can now recover full message bodies that exceed per-call character limits, instead of only seeing truncated summaries with no way to read the tail.
> 
> Callers use **`messageIndex`**, **`messageId`**, **`messageVersion`**, and **`messageOffsetChars`**, then follow **`messagePage.nextOffsetChars`** until it is absent. Ordinary message summaries now include **`messageId`** and **`messageVersion`** so slices stay tied to one snapshot; mismatches, out-of-range coordinates, edits after the version, offsets that split UTF-16 surrogate pairs, and reads while a message is still **streaming** fail with explicit errors. **`cursor`**-based transcript paging is unchanged and cannot be combined with single-message mode.
> 
> Responses always include **`effectiveMessageLimit`** and **`effectiveMaxMessageChars`** (hard caps remain 20,000 for the agent gateway and 10,000 for external MCP). Tool schemas document integer bounds and the new optional fields; **`ExternalMcpReadTaskInput`** is extended to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87d07d5f3c6060ee2d8445a17d8ad35d0064c543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->