### PR TITLE
[codex] Clear stale Claude context usage after compaction

### DIFF
--- a/apps/server/src/orchestration/providerRuntimeActivityProjection.test.ts
+++ b/apps/server/src/orchestration/providerRuntimeActivityProjection.test.ts
@@ -605,6 +605,23 @@ describe("provider runtime activity projection", () => {
       },
     });
 
+    const [accountingOnlyUsage] = projectProviderRuntimeActivities(
+      runtimeEvent({
+        type: "thread.token-usage.updated",
+        eventId: "context-usage-accounting-only",
+        provider: "claudeAgent",
+        payload: { usage: { usedTokens: 0, totalProcessedTokens: 340_000 } },
+      }),
+    );
+    expect(accountingOnlyUsage).toMatchObject({
+      kind: "context-window.updated",
+      payload: {
+        usedTokens: 0,
+        totalProcessedTokens: 340_000,
+        provider: "claudeAgent",
+      },
+    });
+
     const [configured] = projectProviderRuntimeActivities(
       runtimeEvent({
         type: "session.configured",

--- a/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
+++ b/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
@@ -382,7 +382,11 @@ function buildContextWindowActivityPayload(
   const hasPercentUsage =
     typeof usage.usedPercent === "number" && Number.isFinite(usage.usedPercent);
   const hasKnownWindow = typeof usage.maxTokens === "number" && Number.isFinite(usage.maxTokens);
-  if (!hasTokenUsage && !hasPercentUsage && !hasKnownWindow) {
+  const hasProcessedTokens =
+    typeof usage.totalProcessedTokens === "number" &&
+    Number.isFinite(usage.totalProcessedTokens) &&
+    usage.totalProcessedTokens > 0;
+  if (!hasTokenUsage && !hasPercentUsage && !hasKnownWindow && !hasProcessedTokens) {
     return undefined;
   }
   // Stamp the emitting provider so token stats can attribute usage to the

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -6086,6 +6086,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
             inputTokens: 23863,
             outputTokens: 679,
             maxTokens: 200000,
+            totalProcessedTokens: 24542,
           },
         });
       }
@@ -8648,7 +8649,6 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
       )?.resumeCursor as Record<string, unknown> | undefined;
       assert.equal(resumeCursor?.processedTokenTotal, 370_000);
       assert.equal(resumeCursor?.processedTokenBaselineKnown, true);
-      assert.equal(resumeCursor?.cumulativeTokenAccountingActive, true);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
@@ -8672,7 +8672,6 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
           threadId: THREAD_ID,
           processedTokenTotal: 350_000,
           processedTokenBaselineKnown: true,
-          cumulativeTokenAccountingActive: true,
         },
       });
       yield* adapter.sendTurn({
@@ -10450,6 +10449,8 @@ describe("ClaudeAdapterLive forkThread", () => {
           threadId: RESUME_THREAD_ID,
           resume: "forked-session-1",
           turnCount: 4,
+          processedTokenTotal: 0,
+          processedTokenBaselineKnown: true,
         },
       });
     }).pipe(
@@ -10545,6 +10546,8 @@ describe("ClaudeAdapterLive forkThread", () => {
         threadId: RESUME_THREAD_ID,
         resume: "forked-session-2",
         turnCount: 4,
+        processedTokenTotal: 0,
+        processedTokenBaselineKnown: true,
       });
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -8610,7 +8610,12 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
       yield* Deferred.await(freshUsageObserved);
       assert.deepEqual(
         events.map((event) => event.type),
-        ["thread.token-usage.updated", "thread.state.changed", "thread.token-usage.updated"],
+        [
+          "thread.token-usage.updated",
+          "thread.state.changed",
+          "thread.token-usage.updated",
+          "thread.token-usage.updated",
+        ],
       );
       const firstUsage = events[0];
       assert.equal(firstUsage?.type, "thread.token-usage.updated");
@@ -8622,7 +8627,15 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
       if (compaction?.type === "thread.state.changed") {
         assert.equal(compaction.payload.state, "compacted");
       }
-      const freshUsage = events[2];
+      const accountingUsage = events[2];
+      assert.equal(accountingUsage?.type, "thread.token-usage.updated");
+      if (accountingUsage?.type === "thread.token-usage.updated") {
+        assert.deepEqual(accountingUsage.payload.usage, {
+          usedTokens: 0,
+          totalProcessedTokens: 340_000,
+        });
+      }
+      const freshUsage = events[3];
       assert.equal(freshUsage?.type, "thread.token-usage.updated");
       if (freshUsage?.type === "thread.token-usage.updated") {
         assert.equal(freshUsage.turnId, nextTurn.turnId);

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -8730,12 +8730,18 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
       const events: Array<ProviderRuntimeEvent> = [];
-      const turnCompleted = yield* Deferred.make<void>();
+      const compactionTurnCompleted = yield* Deferred.make<void>();
+      const freshTurnCompleted = yield* Deferred.make<void>();
+      let completedTurns = 0;
       yield* adapter.streamEvents.pipe(
         Stream.runForEach((event) =>
           Effect.gen(function* () {
             if (event.type === "turn.completed") {
-              yield* Deferred.succeed(turnCompleted, undefined);
+              completedTurns += 1;
+              yield* Deferred.succeed(
+                completedTurns === 1 ? compactionTurnCompleted : freshTurnCompleted,
+                undefined,
+              );
               return;
             }
             if (
@@ -8788,11 +8794,44 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         usage: { total_tokens: 190_000 },
       } as unknown as SDKMessage);
 
-      yield* Deferred.await(turnCompleted);
+      yield* Deferred.await(compactionTurnCompleted);
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "continue",
+        attachments: [],
+      });
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-legacy-compact",
+        uuid: "legacy-fresh-assistant",
+        parent_tool_use_id: null,
+        message: {
+          id: "legacy-fresh-assistant",
+          content: [{ type: "text", text: "Fresh response" }],
+          usage: { total_tokens: 20_000 },
+        },
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-legacy-compact",
+        uuid: "legacy-fresh-result",
+        usage: { total_tokens: 50_000 },
+      } as unknown as SDKMessage);
+
+      yield* Deferred.await(freshTurnCompleted);
       assert.deepEqual(
         events.map((event) => event.type),
-        ["thread.state.changed"],
+        ["thread.state.changed", "thread.token-usage.updated", "thread.token-usage.updated"],
       );
+      for (const event of events) {
+        if (event.type === "thread.token-usage.updated") {
+          assert.equal(event.payload.usage.totalProcessedTokens, undefined);
+        }
+      }
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -8579,6 +8579,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         session_id: "sdk-session-compact",
         uuid: "result-compact",
         usage: {
+          total_tokens: 350_000,
           input_tokens: 2,
           cache_read_input_tokens: 339_998,
           output_tokens: 0,
@@ -8632,7 +8633,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
       if (accountingUsage?.type === "thread.token-usage.updated") {
         assert.deepEqual(accountingUsage.payload.usage, {
           usedTokens: 0,
-          totalProcessedTokens: 340_000,
+          totalProcessedTokens: 350_000,
         });
       }
       const freshUsage = events[3];
@@ -8640,8 +8641,159 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
       if (freshUsage?.type === "thread.token-usage.updated") {
         assert.equal(freshUsage.turnId, nextTurn.turnId);
         assert.equal(freshUsage.payload.usage.usedTokens, 20_000);
-        assert.equal(freshUsage.payload.usage.totalProcessedTokens, 360_000);
+        assert.equal(freshUsage.payload.usage.totalProcessedTokens, 370_000);
       }
+      const resumeCursor = (yield* adapter.listSessions()).find(
+        (candidate) => candidate.threadId === session.threadId,
+      )?.resumeCursor as Record<string, unknown> | undefined;
+      assert.equal(resumeCursor?.processedTokenTotal, 370_000);
+      assert.equal(resumeCursor?.processedTokenBaselineKnown, true);
+      assert.equal(resumeCursor?.cumulativeTokenAccountingActive, true);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("resumes cumulative token accounting from the durable cursor", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const usageFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "thread.token-usage.updated",
+      ).pipe(Stream.take(2), Stream.runCollect, Effect.forkChild);
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+        resumeCursor: {
+          threadId: THREAD_ID,
+          processedTokenTotal: 350_000,
+          processedTokenBaselineKnown: true,
+          cumulativeTokenAccountingActive: true,
+        },
+      });
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "continue",
+        attachments: [],
+      });
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-resumed-accounting",
+        uuid: "assistant-resumed-accounting",
+        parent_tool_use_id: null,
+        message: {
+          id: "assistant-resumed-accounting",
+          content: [{ type: "text", text: "Fresh response" }],
+          usage: {
+            input_tokens: 1,
+            cache_read_input_tokens: 19_999,
+            output_tokens: 0,
+          },
+        },
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-resumed-accounting",
+        uuid: "result-resumed-accounting",
+        usage: { total_tokens: 50_000 },
+      } as unknown as SDKMessage);
+
+      const usageEvents = Array.from(yield* Fiber.join(usageFiber));
+      assert.equal(usageEvents[0]?.type, "thread.token-usage.updated");
+      if (usageEvents[0]?.type === "thread.token-usage.updated") {
+        assert.deepEqual(usageEvents[0].payload.usage, {
+          usedTokens: 20_000,
+          lastUsedTokens: 20_000,
+          totalProcessedTokens: 370_000,
+          maxTokens: 200_000,
+          inputTokens: 20_000,
+        });
+      }
+      assert.equal(usageEvents[1]?.type, "thread.token-usage.updated");
+      if (usageEvents[1]?.type === "thread.token-usage.updated") {
+        assert.equal(usageEvents[1].payload.usage.totalProcessedTokens, 400_000);
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("does not promote partial accounting from a legacy resume cursor", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const events: Array<ProviderRuntimeEvent> = [];
+      const turnCompleted = yield* Deferred.make<void>();
+      yield* adapter.streamEvents.pipe(
+        Stream.runForEach((event) =>
+          Effect.gen(function* () {
+            if (event.type === "turn.completed") {
+              yield* Deferred.succeed(turnCompleted, undefined);
+              return;
+            }
+            if (
+              event.type === "thread.token-usage.updated" ||
+              (event.type === "thread.state.changed" && event.payload.state === "compacted")
+            ) {
+              events.push(event);
+            }
+          }),
+        ),
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+        resumeCursor: { threadId: THREAD_ID, turnCount: 1 },
+      });
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "/compact",
+        attachments: [],
+      });
+      harness.query.emit({
+        type: "system",
+        subtype: "compact_boundary",
+        compact_metadata: { trigger: "manual", pre_tokens: 150_000 },
+        session_id: "sdk-session-legacy-compact",
+        uuid: "legacy-compact-boundary",
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-legacy-compact",
+        uuid: "legacy-compaction-call",
+        parent_tool_use_id: null,
+        message: {
+          id: "legacy-compaction-call",
+          content: [{ type: "text", text: "Compacted" }],
+          usage: { total_tokens: 190_000 },
+        },
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-legacy-compact",
+        uuid: "legacy-result-compact",
+        usage: { total_tokens: 190_000 },
+      } as unknown as SDKMessage);
+
+      yield* Deferred.await(turnCompleted);
+      assert.deepEqual(
+        events.map((event) => event.type),
+        ["thread.state.changed"],
+      );
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -32,7 +32,7 @@ import {
 import { ServerConfig } from "../../config.ts";
 import { MINIMUM_CLAUDE_AUTO_MODE_CLI_VERSION } from "../claudeCliVersion.ts";
 import { ProviderAdapterRequestError, ProviderAdapterValidationError } from "../Errors.ts";
-import { ClaudeAdapter } from "../Services/ClaudeAdapter.ts";
+import { ClaudeAdapter, type ClaudeAdapterShape } from "../Services/ClaudeAdapter.ts";
 import {
   buildEmbeddedClaudeSystemPromptAppend,
   makeClaudeAdapterLive as makeClaudeAdapterLiveBase,
@@ -351,6 +351,90 @@ function makeDeterministicRandomService(seed = 0x1234_5678): {
     nextIntUnsafe,
     nextDoubleUnsafe: () => nextIntUnsafe() / 0x1_0000_0000,
   };
+}
+
+function emitAssistantUsage(
+  query: FakeClaudeQuery,
+  sessionId: string,
+  uuid: string,
+  text: string,
+  usage: Record<string, number>,
+): void {
+  query.emit({
+    type: "assistant",
+    session_id: sessionId,
+    uuid,
+    parent_tool_use_id: null,
+    message: {
+      id: uuid,
+      content: [{ type: "text", text }],
+      usage,
+    },
+  } as unknown as SDKMessage);
+}
+
+function emitSuccessResult(
+  query: FakeClaudeQuery,
+  sessionId: string,
+  uuid: string,
+  usage: Record<string, number>,
+): void {
+  query.emit({
+    type: "result",
+    subtype: "success",
+    is_error: false,
+    errors: [],
+    session_id: sessionId,
+    uuid,
+    usage,
+  } as unknown as SDKMessage);
+}
+
+function emitCompactionBoundary(query: FakeClaudeQuery, sessionId: string, uuid: string): void {
+  query.emit({
+    type: "system",
+    subtype: "compact_boundary",
+    compact_metadata: { trigger: "manual", pre_tokens: 150_000 },
+    session_id: sessionId,
+    uuid,
+  } as unknown as SDKMessage);
+}
+
+function isCompactionUsageEvent(event: ProviderRuntimeEvent): boolean {
+  return (
+    event.type === "thread.token-usage.updated" ||
+    (event.type === "thread.state.changed" && event.payload.state === "compacted")
+  );
+}
+
+function observeCompactionUsageEvents(adapter: ClaudeAdapterShape, expectedEventCount: number) {
+  return Effect.gen(function* () {
+    const events: Array<ProviderRuntimeEvent> = [];
+    const turnCompleted = yield* Deferred.make<void>();
+    const eventsObserved = yield* Deferred.make<void>();
+    yield* adapter.streamEvents.pipe(
+      Stream.runForEach((event) => {
+        if (event.type === "turn.completed") {
+          return Deferred.succeed(turnCompleted, undefined);
+        }
+        if (!isCompactionUsageEvent(event)) {
+          return Effect.void;
+        }
+        events.push(event);
+        return events.length >= expectedEventCount
+          ? Deferred.succeed(eventsObserved, undefined)
+          : Effect.void;
+      }),
+      Effect.forkChild,
+    );
+    return { events, eventsObserved, turnCompleted };
+  });
+}
+
+function assertTokenUsageEvent(
+  event: ProviderRuntimeEvent | undefined,
+): asserts event is Extract<ProviderRuntimeEvent, { type: "thread.token-usage.updated" }> {
+  assert.equal(event?.type, "thread.token-usage.updated");
 }
 
 async function readFirstPromptText(
@@ -8489,33 +8573,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
     const harness = makeHarness();
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
-      const events: Array<ProviderRuntimeEvent> = [];
-      const turnCompleted = yield* Deferred.make<void>();
-      const freshUsageObserved = yield* Deferred.make<void>();
-      yield* adapter.streamEvents.pipe(
-        Stream.runForEach((event) =>
-          Effect.gen(function* () {
-            if (event.type === "turn.completed") {
-              yield* Deferred.succeed(turnCompleted, undefined);
-              return;
-            }
-            if (
-              event.type !== "thread.token-usage.updated" &&
-              (event.type !== "thread.state.changed" || event.payload.state !== "compacted")
-            ) {
-              return;
-            }
-            events.push(event);
-            if (
-              event.type === "thread.token-usage.updated" &&
-              event.payload.usage.usedTokens === 20_000
-            ) {
-              yield* Deferred.succeed(freshUsageObserved, undefined);
-            }
-          }),
-        ),
-        Effect.forkChild,
-      );
+      const observation = yield* observeCompactionUsageEvents(adapter, 4);
 
       const session = yield* adapter.startSession({
         threadId: THREAD_ID,
@@ -8528,21 +8586,13 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         attachments: [],
       });
 
-      harness.query.emit({
-        type: "assistant",
-        session_id: "sdk-session-compact",
-        uuid: "assistant-before-compact",
-        parent_tool_use_id: null,
-        message: {
-          id: "assistant-before-compact",
-          content: [{ type: "text", text: "Preparing to compact" }],
-          usage: {
-            input_tokens: 1,
-            cache_read_input_tokens: 149_999,
-            output_tokens: 0,
-          },
-        },
-      } as unknown as SDKMessage);
+      emitAssistantUsage(
+        harness.query,
+        "sdk-session-compact",
+        "assistant-before-compact",
+        "Preparing to compact",
+        { input_tokens: 1, cache_read_input_tokens: 149_999, output_tokens: 0 },
+      );
       harness.query.emit({
         type: "system",
         subtype: "status",
@@ -8550,66 +8600,37 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         session_id: "sdk-session-compact",
         uuid: "status-compacting",
       } as unknown as SDKMessage);
-      harness.query.emit({
-        type: "system",
-        subtype: "compact_boundary",
-        compact_metadata: { trigger: "manual", pre_tokens: 150_000 },
-        session_id: "sdk-session-compact",
-        uuid: "compact-boundary",
-      } as unknown as SDKMessage);
-      harness.query.emit({
-        type: "assistant",
-        session_id: "sdk-session-compact",
-        uuid: "assistant-compaction-call",
-        parent_tool_use_id: null,
-        message: {
-          id: "assistant-compaction-call",
-          content: [{ type: "text", text: "Compacted" }],
-          usage: {
-            input_tokens: 1,
-            cache_read_input_tokens: 189_999,
-            output_tokens: 0,
-          },
-        },
-      } as unknown as SDKMessage);
-      harness.query.emit({
-        type: "result",
-        subtype: "success",
-        is_error: false,
-        errors: [],
-        session_id: "sdk-session-compact",
-        uuid: "result-compact",
-        usage: {
-          total_tokens: 350_000,
-          input_tokens: 2,
-          cache_read_input_tokens: 339_998,
-          output_tokens: 0,
-        },
-      } as unknown as SDKMessage);
-      yield* Deferred.await(turnCompleted);
+      emitCompactionBoundary(harness.query, "sdk-session-compact", "compact-boundary");
+      emitAssistantUsage(
+        harness.query,
+        "sdk-session-compact",
+        "assistant-compaction-call",
+        "Compacted",
+        { input_tokens: 1, cache_read_input_tokens: 189_999, output_tokens: 0 },
+      );
+      emitSuccessResult(harness.query, "sdk-session-compact", "result-compact", {
+        total_tokens: 350_000,
+        input_tokens: 2,
+        cache_read_input_tokens: 339_998,
+        output_tokens: 0,
+      });
+      yield* Deferred.await(observation.turnCompleted);
 
       const nextTurn = yield* adapter.sendTurn({
         threadId: session.threadId,
         input: "continue",
         attachments: [],
       });
-      harness.query.emit({
-        type: "assistant",
-        session_id: "sdk-session-compact",
-        uuid: "assistant-after-compact",
-        parent_tool_use_id: null,
-        message: {
-          id: "assistant-after-compact",
-          content: [{ type: "text", text: "Fresh response" }],
-          usage: {
-            input_tokens: 1,
-            cache_read_input_tokens: 19_999,
-            output_tokens: 0,
-          },
-        },
-      } as unknown as SDKMessage);
+      emitAssistantUsage(
+        harness.query,
+        "sdk-session-compact",
+        "assistant-after-compact",
+        "Fresh response",
+        { input_tokens: 1, cache_read_input_tokens: 19_999, output_tokens: 0 },
+      );
 
-      yield* Deferred.await(freshUsageObserved);
+      yield* Deferred.await(observation.eventsObserved);
+      const { events } = observation;
       assert.deepEqual(
         events.map((event) => event.type),
         [
@@ -8620,35 +8641,28 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         ],
       );
       const firstUsage = events[0];
-      assert.equal(firstUsage?.type, "thread.token-usage.updated");
-      if (firstUsage?.type === "thread.token-usage.updated") {
-        assert.equal(firstUsage.payload.usage.usedTokens, 150_000);
-      }
+      assertTokenUsageEvent(firstUsage);
+      assert.equal(firstUsage.payload.usage.usedTokens, 150_000);
       const compaction = events[1];
       assert.equal(compaction?.type, "thread.state.changed");
       if (compaction?.type === "thread.state.changed") {
         assert.equal(compaction.payload.state, "compacted");
       }
       const accountingUsage = events[2];
-      assert.equal(accountingUsage?.type, "thread.token-usage.updated");
-      if (accountingUsage?.type === "thread.token-usage.updated") {
-        assert.deepEqual(accountingUsage.payload.usage, {
-          usedTokens: 0,
-          totalProcessedTokens: 350_000,
-        });
-      }
+      assertTokenUsageEvent(accountingUsage);
+      assert.deepEqual(accountingUsage.payload.usage, {
+        usedTokens: 0,
+        totalProcessedTokens: 350_000,
+      });
       const freshUsage = events[3];
-      assert.equal(freshUsage?.type, "thread.token-usage.updated");
-      if (freshUsage?.type === "thread.token-usage.updated") {
-        assert.equal(freshUsage.turnId, nextTurn.turnId);
-        assert.equal(freshUsage.payload.usage.usedTokens, 20_000);
-        assert.equal(freshUsage.payload.usage.totalProcessedTokens, 370_000);
-      }
+      assertTokenUsageEvent(freshUsage);
+      assert.equal(freshUsage.turnId, nextTurn.turnId);
+      assert.equal(freshUsage.payload.usage.usedTokens, 20_000);
+      assert.equal(freshUsage.payload.usage.totalProcessedTokens, 370_000);
       const resumeCursor = (yield* adapter.listSessions()).find(
         (candidate) => candidate.threadId === session.threadId,
       )?.resumeCursor as Record<string, unknown> | undefined;
       assert.equal(resumeCursor?.processedTokenTotal, 370_000);
-      assert.equal(resumeCursor?.processedTokenBaselineKnown, true);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
@@ -8671,7 +8685,6 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         resumeCursor: {
           threadId: THREAD_ID,
           processedTokenTotal: 350_000,
-          processedTokenBaselineKnown: true,
         },
       });
       yield* adapter.sendTurn({
@@ -8679,46 +8692,31 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         input: "continue",
         attachments: [],
       });
-      harness.query.emit({
-        type: "assistant",
-        session_id: "sdk-session-resumed-accounting",
-        uuid: "assistant-resumed-accounting",
-        parent_tool_use_id: null,
-        message: {
-          id: "assistant-resumed-accounting",
-          content: [{ type: "text", text: "Fresh response" }],
-          usage: {
-            input_tokens: 1,
-            cache_read_input_tokens: 19_999,
-            output_tokens: 0,
-          },
-        },
-      } as unknown as SDKMessage);
-      harness.query.emit({
-        type: "result",
-        subtype: "success",
-        is_error: false,
-        errors: [],
-        session_id: "sdk-session-resumed-accounting",
-        uuid: "result-resumed-accounting",
-        usage: { total_tokens: 50_000 },
-      } as unknown as SDKMessage);
+      emitAssistantUsage(
+        harness.query,
+        "sdk-session-resumed-accounting",
+        "assistant-resumed-accounting",
+        "Fresh response",
+        { input_tokens: 1, cache_read_input_tokens: 19_999, output_tokens: 0 },
+      );
+      emitSuccessResult(
+        harness.query,
+        "sdk-session-resumed-accounting",
+        "result-resumed-accounting",
+        { total_tokens: 50_000 },
+      );
 
       const usageEvents = Array.from(yield* Fiber.join(usageFiber));
-      assert.equal(usageEvents[0]?.type, "thread.token-usage.updated");
-      if (usageEvents[0]?.type === "thread.token-usage.updated") {
-        assert.deepEqual(usageEvents[0].payload.usage, {
-          usedTokens: 20_000,
-          lastUsedTokens: 20_000,
-          totalProcessedTokens: 370_000,
-          maxTokens: 200_000,
-          inputTokens: 20_000,
-        });
-      }
-      assert.equal(usageEvents[1]?.type, "thread.token-usage.updated");
-      if (usageEvents[1]?.type === "thread.token-usage.updated") {
-        assert.equal(usageEvents[1].payload.usage.totalProcessedTokens, 400_000);
-      }
+      assertTokenUsageEvent(usageEvents[0]);
+      assert.deepEqual(usageEvents[0].payload.usage, {
+        usedTokens: 20_000,
+        lastUsedTokens: 20_000,
+        totalProcessedTokens: 370_000,
+        maxTokens: 200_000,
+        inputTokens: 20_000,
+      });
+      assertTokenUsageEvent(usageEvents[1]);
+      assert.equal(usageEvents[1].payload.usage.totalProcessedTokens, 400_000);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
@@ -8729,31 +8727,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
     const harness = makeHarness();
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
-      const events: Array<ProviderRuntimeEvent> = [];
-      const compactionTurnCompleted = yield* Deferred.make<void>();
-      const freshTurnCompleted = yield* Deferred.make<void>();
-      let completedTurns = 0;
-      yield* adapter.streamEvents.pipe(
-        Stream.runForEach((event) =>
-          Effect.gen(function* () {
-            if (event.type === "turn.completed") {
-              completedTurns += 1;
-              yield* Deferred.succeed(
-                completedTurns === 1 ? compactionTurnCompleted : freshTurnCompleted,
-                undefined,
-              );
-              return;
-            }
-            if (
-              event.type === "thread.token-usage.updated" ||
-              (event.type === "thread.state.changed" && event.payload.state === "compacted")
-            ) {
-              events.push(event);
-            }
-          }),
-        ),
-        Effect.forkChild,
-      );
+      const observation = yield* observeCompactionUsageEvents(adapter, 3);
 
       const session = yield* adapter.startSession({
         threadId: THREAD_ID,
@@ -8766,63 +8740,42 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         input: "/compact",
         attachments: [],
       });
-      harness.query.emit({
-        type: "system",
-        subtype: "compact_boundary",
-        compact_metadata: { trigger: "manual", pre_tokens: 150_000 },
-        session_id: "sdk-session-legacy-compact",
-        uuid: "legacy-compact-boundary",
-      } as unknown as SDKMessage);
-      harness.query.emit({
-        type: "assistant",
-        session_id: "sdk-session-legacy-compact",
-        uuid: "legacy-compaction-call",
-        parent_tool_use_id: null,
-        message: {
-          id: "legacy-compaction-call",
-          content: [{ type: "text", text: "Compacted" }],
-          usage: { total_tokens: 190_000 },
-        },
-      } as unknown as SDKMessage);
-      harness.query.emit({
-        type: "result",
-        subtype: "success",
-        is_error: false,
-        errors: [],
-        session_id: "sdk-session-legacy-compact",
-        uuid: "legacy-result-compact",
-        usage: { total_tokens: 190_000 },
-      } as unknown as SDKMessage);
+      emitCompactionBoundary(
+        harness.query,
+        "sdk-session-legacy-compact",
+        "legacy-compact-boundary",
+      );
+      emitAssistantUsage(
+        harness.query,
+        "sdk-session-legacy-compact",
+        "legacy-compaction-call",
+        "Compacted",
+        { total_tokens: 190_000 },
+      );
+      emitSuccessResult(harness.query, "sdk-session-legacy-compact", "legacy-result-compact", {
+        total_tokens: 190_000,
+      });
 
-      yield* Deferred.await(compactionTurnCompleted);
+      yield* Deferred.await(observation.turnCompleted);
 
       yield* adapter.sendTurn({
         threadId: session.threadId,
         input: "continue",
         attachments: [],
       });
-      harness.query.emit({
-        type: "assistant",
-        session_id: "sdk-session-legacy-compact",
-        uuid: "legacy-fresh-assistant",
-        parent_tool_use_id: null,
-        message: {
-          id: "legacy-fresh-assistant",
-          content: [{ type: "text", text: "Fresh response" }],
-          usage: { total_tokens: 20_000 },
-        },
-      } as unknown as SDKMessage);
-      harness.query.emit({
-        type: "result",
-        subtype: "success",
-        is_error: false,
-        errors: [],
-        session_id: "sdk-session-legacy-compact",
-        uuid: "legacy-fresh-result",
-        usage: { total_tokens: 50_000 },
-      } as unknown as SDKMessage);
+      emitAssistantUsage(
+        harness.query,
+        "sdk-session-legacy-compact",
+        "legacy-fresh-assistant",
+        "Fresh response",
+        { total_tokens: 20_000 },
+      );
+      emitSuccessResult(harness.query, "sdk-session-legacy-compact", "legacy-fresh-result", {
+        total_tokens: 50_000,
+      });
 
-      yield* Deferred.await(freshTurnCompleted);
+      yield* Deferred.await(observation.eventsObserved);
+      const { events } = observation;
       assert.deepEqual(
         events.map((event) => event.type),
         ["thread.state.changed", "thread.token-usage.updated", "thread.token-usage.updated"],
@@ -10489,7 +10442,6 @@ describe("ClaudeAdapterLive forkThread", () => {
           resume: "forked-session-1",
           turnCount: 4,
           processedTokenTotal: 0,
-          processedTokenBaselineKnown: true,
         },
       });
     }).pipe(
@@ -10586,7 +10538,6 @@ describe("ClaudeAdapterLive forkThread", () => {
         resume: "forked-session-2",
         turnCount: 4,
         processedTokenTotal: 0,
-        processedTokenBaselineKnown: true,
       });
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -8640,6 +8640,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
       if (freshUsage?.type === "thread.token-usage.updated") {
         assert.equal(freshUsage.turnId, nextTurn.turnId);
         assert.equal(freshUsage.payload.usage.usedTokens, 20_000);
+        assert.equal(freshUsage.payload.usage.totalProcessedTokens, 360_000);
       }
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -21,7 +21,7 @@ import {
   TurnId,
 } from "@synara/contracts";
 import { assert, describe, it } from "@effect/vitest";
-import { Effect, Exit, Fiber, Layer, Random, Stream } from "effect";
+import { Deferred, Effect, Exit, Fiber, Layer, Random, Stream } from "effect";
 
 import { attachmentRelativePath } from "../../attachmentStore.ts";
 import { SYNARA_HARNESS_POLICY_MARKER } from "../../agentGateway/harnessPolicy.ts";
@@ -8481,6 +8481,156 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(layer),
+    );
+  });
+
+  it.effect("invalidates compaction-call usage until the next assistant response", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const events: Array<ProviderRuntimeEvent> = [];
+      const turnCompleted = yield* Deferred.make<void>();
+      const freshUsageObserved = yield* Deferred.make<void>();
+      yield* adapter.streamEvents.pipe(
+        Stream.runForEach((event) =>
+          Effect.gen(function* () {
+            if (event.type === "turn.completed") {
+              yield* Deferred.succeed(turnCompleted, undefined);
+              return;
+            }
+            if (
+              event.type !== "thread.token-usage.updated" &&
+              (event.type !== "thread.state.changed" || event.payload.state !== "compacted")
+            ) {
+              return;
+            }
+            events.push(event);
+            if (
+              event.type === "thread.token-usage.updated" &&
+              event.payload.usage.usedTokens === 20_000
+            ) {
+              yield* Deferred.succeed(freshUsageObserved, undefined);
+            }
+          }),
+        ),
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "/compact",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-compact",
+        uuid: "assistant-before-compact",
+        parent_tool_use_id: null,
+        message: {
+          id: "assistant-before-compact",
+          content: [{ type: "text", text: "Preparing to compact" }],
+          usage: {
+            input_tokens: 1,
+            cache_read_input_tokens: 149_999,
+            output_tokens: 0,
+          },
+        },
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "system",
+        subtype: "status",
+        status: "compacting",
+        session_id: "sdk-session-compact",
+        uuid: "status-compacting",
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "system",
+        subtype: "compact_boundary",
+        compact_metadata: { trigger: "manual", pre_tokens: 150_000 },
+        session_id: "sdk-session-compact",
+        uuid: "compact-boundary",
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-compact",
+        uuid: "assistant-compaction-call",
+        parent_tool_use_id: null,
+        message: {
+          id: "assistant-compaction-call",
+          content: [{ type: "text", text: "Compacted" }],
+          usage: {
+            input_tokens: 1,
+            cache_read_input_tokens: 189_999,
+            output_tokens: 0,
+          },
+        },
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-compact",
+        uuid: "result-compact",
+        usage: {
+          input_tokens: 2,
+          cache_read_input_tokens: 339_998,
+          output_tokens: 0,
+        },
+      } as unknown as SDKMessage);
+      yield* Deferred.await(turnCompleted);
+
+      const nextTurn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "continue",
+        attachments: [],
+      });
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-compact",
+        uuid: "assistant-after-compact",
+        parent_tool_use_id: null,
+        message: {
+          id: "assistant-after-compact",
+          content: [{ type: "text", text: "Fresh response" }],
+          usage: {
+            input_tokens: 1,
+            cache_read_input_tokens: 19_999,
+            output_tokens: 0,
+          },
+        },
+      } as unknown as SDKMessage);
+
+      yield* Deferred.await(freshUsageObserved);
+      assert.deepEqual(
+        events.map((event) => event.type),
+        ["thread.token-usage.updated", "thread.state.changed", "thread.token-usage.updated"],
+      );
+      const firstUsage = events[0];
+      assert.equal(firstUsage?.type, "thread.token-usage.updated");
+      if (firstUsage?.type === "thread.token-usage.updated") {
+        assert.equal(firstUsage.payload.usage.usedTokens, 150_000);
+      }
+      const compaction = events[1];
+      assert.equal(compaction?.type, "thread.state.changed");
+      if (compaction?.type === "thread.state.changed") {
+        assert.equal(compaction.payload.state, "compacted");
+      }
+      const freshUsage = events[2];
+      assert.equal(freshUsage?.type, "thread.token-usage.updated");
+      if (freshUsage?.type === "thread.token-usage.updated") {
+        assert.equal(freshUsage.turnId, nextTurn.turnId);
+        assert.equal(freshUsage.payload.usage.usedTokens, 20_000);
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
     );
   });
 

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2733,9 +2733,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           context.tokenUsageState = "awaiting-fresh-assistant";
         }
         const accountingOnlyUsage =
-          totalProcessedTokens !== undefined
-            ? { usedTokens: 0, totalProcessedTokens }
-            : undefined;
+          totalProcessedTokens !== undefined ? { usedTokens: 0, totalProcessedTokens } : undefined;
         const usageSnapshot: ThreadTokenUsageSnapshot | undefined =
           context.tokenUsageState !== "current"
             ? accountingOnlyUsage

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -190,7 +190,6 @@ interface ClaudeResumeState {
   readonly trackedTasks?: ReadonlyArray<ClaudeTrackedTask>;
   readonly processedTokenTotal?: number;
   readonly processedTokenBaselineKnown?: true;
-  readonly cumulativeTokenAccountingActive?: boolean;
 }
 
 interface ClaudeTurnState {
@@ -371,7 +370,6 @@ interface ClaudeSessionContext {
   processedTokenTotal: number;
   processedTokenTurnBaseline: number;
   processedTokenBaselineKnown: boolean;
-  cumulativeTokenAccountingActive: boolean;
   lastAssistantUuid: string | undefined;
   lastThreadStartedId: string | undefined;
   // Original API model id the runtime rerouted away from (safeguard refusal
@@ -885,7 +883,6 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
     trackedTasks?: unknown;
     processedTokenTotal?: unknown;
     processedTokenBaselineKnown?: unknown;
-    cumulativeTokenAccountingActive?: unknown;
   };
 
   const threadIdCandidate = typeof cursor.threadId === "string" ? cursor.threadId : undefined;
@@ -910,7 +907,6 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
     cursor.processedTokenTotal >= 0
       ? cursor.processedTokenTotal
       : undefined;
-  const cumulativeTokenAccountingActive = cursor.cumulativeTokenAccountingActive === true;
   const processedTokenBaselineKnown = cursor.processedTokenBaselineKnown === true;
 
   return {
@@ -923,8 +919,12 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
     ...(trackedTasks.length > 0 ? { trackedTasks } : {}),
     ...(processedTokenTotal !== undefined ? { processedTokenTotal } : {}),
     ...(processedTokenBaselineKnown ? { processedTokenBaselineKnown: true } : {}),
-    ...(cumulativeTokenAccountingActive ? { cumulativeTokenAccountingActive: true } : {}),
   };
+}
+
+function withoutProcessedTokenTotal(snapshot: ThreadTokenUsageSnapshot): ThreadTokenUsageSnapshot {
+  const { totalProcessedTokens: _totalProcessedTokens, ...contextUsage } = snapshot;
+  return contextUsage;
 }
 
 function classifyToolItemType(toolName: string): CanonicalItemType {
@@ -2056,9 +2056,6 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             ? {
                 processedTokenTotal: context.processedTokenTotal,
                 processedTokenBaselineKnown: true,
-                ...(context.cumulativeTokenAccountingActive
-                  ? { cumulativeTokenAccountingActive: true }
-                  : {}),
               }
             : {}),
         };
@@ -2766,13 +2763,11 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         }
         const totalProcessedTokens =
           context.processedTokenTotal > 0 ? context.processedTokenTotal : resultProcessedTokens;
-        const accountedAccumulatedSnapshot =
-          accumulatedSnapshot &&
-          totalProcessedTokens !== undefined &&
-          (context.cumulativeTokenAccountingActive ||
-            totalProcessedTokens > accumulatedSnapshot.usedTokens)
+        const accountedAccumulatedSnapshot = accumulatedSnapshot
+          ? context.processedTokenBaselineKnown && totalProcessedTokens !== undefined
             ? { ...accumulatedSnapshot, totalProcessedTokens }
-            : accumulatedSnapshot;
+            : withoutProcessedTokenTotal(accumulatedSnapshot)
+          : undefined;
         const liveSnapshot = liveContextUsage
           ? snapshotFromClaudeContextUsage(liveContextUsage, totalProcessedTokens)
           : undefined;
@@ -2796,9 +2791,6 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
                 )
               : accountedAccumulatedSnapshot;
         context.processedTokenTurnBaseline = context.processedTokenTotal;
-        if (usageSnapshot?.totalProcessedTokens !== undefined) {
-          context.cumulativeTokenAccountingActive = true;
-        }
 
         // A safeguard reroute only applies to the turn that just finished.
         // Restore the user-selected model so subsequent turns do not silently
@@ -3056,7 +3048,6 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           processedTokenTotal: 0,
           processedTokenTurnBaseline: 0,
           processedTokenBaselineKnown: true,
-          cumulativeTokenAccountingActive: false,
           lastAssistantUuid: undefined,
           lastThreadStartedId: undefined,
           rerouteOriginalApiModelId: undefined,
@@ -3739,7 +3730,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           } else {
             yield* maybeEmitContextUsageWarning(context, perCallUsage as Record<string, unknown>);
             if (normalizedPerCallUsage) {
-              const currentUsage = context.cumulativeTokenAccountingActive
+              const currentUsage = context.processedTokenBaselineKnown
                 ? {
                     ...normalizedPerCallUsage,
                     totalProcessedTokens: context.processedTokenTotal,
@@ -5425,9 +5416,6 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
                 ? {
                     processedTokenTotal: resumeState?.processedTokenTotal ?? 0,
                     processedTokenBaselineKnown: true,
-                    ...(resumeState?.cumulativeTokenAccountingActive
-                      ? { cumulativeTokenAccountingActive: true }
-                      : {}),
                   }
                 : {}),
             },
@@ -5479,9 +5467,6 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             processedTokenTotal: resumeState?.processedTokenTotal ?? 0,
             processedTokenTurnBaseline: resumeState?.processedTokenTotal ?? 0,
             processedTokenBaselineKnown,
-            cumulativeTokenAccountingActive:
-              processedTokenBaselineKnown &&
-              (resumeState?.cumulativeTokenAccountingActive ?? false),
             lastAssistantUuid: resumeState?.resumeSessionAt,
             lastThreadStartedId: undefined,
             rerouteOriginalApiModelId: undefined,
@@ -6119,6 +6104,8 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           threadId: input.threadId,
           resume: forked.sessionId,
           turnCount: Math.max(liveSource?.turns.length ?? 0, sourceState?.turnCount ?? 0),
+          processedTokenTotal: 0,
+          processedTokenBaselineKnown: true,
         };
         return { threadId: input.threadId, resumeCursor };
       });

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -188,6 +188,9 @@ interface ClaudeResumeState {
   readonly resumeSessionAt?: string;
   readonly turnCount?: number;
   readonly trackedTasks?: ReadonlyArray<ClaudeTrackedTask>;
+  readonly processedTokenTotal?: number;
+  readonly processedTokenBaselineKnown?: true;
+  readonly cumulativeTokenAccountingActive?: boolean;
 }
 
 interface ClaudeTurnState {
@@ -366,7 +369,8 @@ interface ClaudeSessionContext {
   // accounting separately from the current context size so compaction can clear
   // the meter without resetting the cumulative counter used by profile stats.
   processedTokenTotal: number;
-  processedUsageObservedSinceResult: boolean;
+  processedTokenTurnBaseline: number;
+  processedTokenBaselineKnown: boolean;
   cumulativeTokenAccountingActive: boolean;
   lastAssistantUuid: string | undefined;
   lastThreadStartedId: string | undefined;
@@ -879,6 +883,9 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
     resumeSessionAt?: unknown;
     turnCount?: unknown;
     trackedTasks?: unknown;
+    processedTokenTotal?: unknown;
+    processedTokenBaselineKnown?: unknown;
+    cumulativeTokenAccountingActive?: unknown;
   };
 
   const threadIdCandidate = typeof cursor.threadId === "string" ? cursor.threadId : undefined;
@@ -897,6 +904,14 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
     typeof cursor.resumeSessionAt === "string" ? cursor.resumeSessionAt : undefined;
   const turnCountValue = typeof cursor.turnCount === "number" ? cursor.turnCount : undefined;
   const trackedTasks = parseClaudeTrackedTasks(cursor.trackedTasks);
+  const processedTokenTotal =
+    typeof cursor.processedTokenTotal === "number" &&
+    Number.isSafeInteger(cursor.processedTokenTotal) &&
+    cursor.processedTokenTotal >= 0
+      ? cursor.processedTokenTotal
+      : undefined;
+  const cumulativeTokenAccountingActive = cursor.cumulativeTokenAccountingActive === true;
+  const processedTokenBaselineKnown = cursor.processedTokenBaselineKnown === true;
 
   return {
     ...(threadId ? { threadId } : {}),
@@ -906,6 +921,9 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
       ? { turnCount: turnCountValue }
       : {}),
     ...(trackedTasks.length > 0 ? { trackedTasks } : {}),
+    ...(processedTokenTotal !== undefined ? { processedTokenTotal } : {}),
+    ...(processedTokenBaselineKnown ? { processedTokenBaselineKnown: true } : {}),
+    ...(cumulativeTokenAccountingActive ? { cumulativeTokenAccountingActive: true } : {}),
   };
 }
 
@@ -2034,6 +2052,15 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           ...(context.trackedTasks.size > 0
             ? { trackedTasks: Array.from(context.trackedTasks.values()) }
             : {}),
+          ...(context.processedTokenBaselineKnown
+            ? {
+                processedTokenTotal: context.processedTokenTotal,
+                processedTokenBaselineKnown: true,
+                ...(context.cumulativeTokenAccountingActive
+                  ? { cumulativeTokenAccountingActive: true }
+                  : {}),
+              }
+            : {}),
         };
 
         context.session = {
@@ -2730,12 +2757,22 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         );
         const resultProcessedTokens =
           accumulatedSnapshot?.totalProcessedTokens ?? accumulatedSnapshot?.usedTokens;
-        if (resultProcessedTokens !== undefined && !context.processedUsageObservedSinceResult) {
-          context.processedTokenTotal += resultProcessedTokens;
+        if (resultProcessedTokens !== undefined) {
+          const resultBaseline = context.turnState ? context.processedTokenTurnBaseline : 0;
+          context.processedTokenTotal = Math.max(
+            context.processedTokenTotal,
+            resultBaseline + resultProcessedTokens,
+          );
         }
-        context.processedUsageObservedSinceResult = false;
         const totalProcessedTokens =
           context.processedTokenTotal > 0 ? context.processedTokenTotal : resultProcessedTokens;
+        const accountedAccumulatedSnapshot =
+          accumulatedSnapshot &&
+          totalProcessedTokens !== undefined &&
+          (context.cumulativeTokenAccountingActive ||
+            totalProcessedTokens > accumulatedSnapshot.usedTokens)
+            ? { ...accumulatedSnapshot, totalProcessedTokens }
+            : accumulatedSnapshot;
         const liveSnapshot = liveContextUsage
           ? snapshotFromClaudeContextUsage(liveContextUsage, totalProcessedTokens)
           : undefined;
@@ -2745,13 +2782,20 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           context.tokenUsageState = "awaiting-fresh-assistant";
         }
         const accountingOnlyUsage =
-          totalProcessedTokens !== undefined ? { usedTokens: 0, totalProcessedTokens } : undefined;
+          context.processedTokenBaselineKnown && totalProcessedTokens !== undefined
+            ? { usedTokens: 0, totalProcessedTokens }
+            : undefined;
         const usageSnapshot: ThreadTokenUsageSnapshot | undefined =
           context.tokenUsageState !== "current"
             ? accountingOnlyUsage
             : lastGoodUsage
-              ? mergeClaudeTokenUsageSnapshot(lastGoodUsage, accumulatedSnapshot, maxTokens)
-              : accumulatedSnapshot;
+              ? mergeClaudeTokenUsageSnapshot(
+                  lastGoodUsage,
+                  accountedAccumulatedSnapshot,
+                  maxTokens,
+                )
+              : accountedAccumulatedSnapshot;
+        context.processedTokenTurnBaseline = context.processedTokenTotal;
         if (usageSnapshot?.totalProcessedTokens !== undefined) {
           context.cumulativeTokenAccountingActive = true;
         }
@@ -3010,7 +3054,8 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           lastKnownTokenUsage: undefined,
           tokenUsageState: "current",
           processedTokenTotal: 0,
-          processedUsageObservedSinceResult: false,
+          processedTokenTurnBaseline: 0,
+          processedTokenBaselineKnown: true,
           cumulativeTokenAccountingActive: false,
           lastAssistantUuid: undefined,
           lastThreadStartedId: undefined,
@@ -3506,6 +3551,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           nextSyntheticAssistantBlockIndex: -1,
           assistantMessageBlockBase: 0,
         };
+        context.processedTokenTurnBaseline = context.processedTokenTotal;
         context.lastTurnId = turnId;
         context.session = {
           ...context.session,
@@ -3687,7 +3733,6 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           if (normalizedPerCallUsage) {
             context.processedTokenTotal +=
               normalizedPerCallUsage.totalProcessedTokens ?? normalizedPerCallUsage.usedTokens;
-            context.processedUsageObservedSinceResult = true;
           }
           if (context.tokenUsageState === "skip-compaction-call") {
             context.tokenUsageState = "awaiting-fresh-assistant";
@@ -5356,6 +5401,10 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               });
           }
 
+          const processedTokenBaselineKnown =
+            input.resumeCursor === undefined ||
+            resumeState?.processedTokenBaselineKnown === true ||
+            resumeState?.processedTokenTotal !== undefined;
           const session: ProviderSession = {
             threadId,
             provider: PROVIDER,
@@ -5372,6 +5421,15 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
                 : {}),
               turnCount: resumeState?.turnCount ?? 0,
               ...(trackedTasks.size > 0 ? { trackedTasks: Array.from(trackedTasks.values()) } : {}),
+              ...(processedTokenBaselineKnown
+                ? {
+                    processedTokenTotal: resumeState?.processedTokenTotal ?? 0,
+                    processedTokenBaselineKnown: true,
+                    ...(resumeState?.cumulativeTokenAccountingActive
+                      ? { cumulativeTokenAccountingActive: true }
+                      : {}),
+                  }
+                : {}),
             },
             createdAt: startedAt,
             updatedAt: startedAt,
@@ -5418,9 +5476,12 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             contextUsageControlEnabled: true,
             lastKnownTokenUsage: undefined,
             tokenUsageState: "current",
-            processedTokenTotal: 0,
-            processedUsageObservedSinceResult: false,
-            cumulativeTokenAccountingActive: false,
+            processedTokenTotal: resumeState?.processedTokenTotal ?? 0,
+            processedTokenTurnBaseline: resumeState?.processedTokenTotal ?? 0,
+            processedTokenBaselineKnown,
+            cumulativeTokenAccountingActive:
+              processedTokenBaselineKnown &&
+              (resumeState?.cumulativeTokenAccountingActive ?? false),
             lastAssistantUuid: resumeState?.resumeSessionAt,
             lastThreadStartedId: undefined,
             rerouteOriginalApiModelId: undefined,
@@ -5726,6 +5787,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         );
 
         const turnId = TurnId.makeUnsafe(yield* Random.nextUUIDv4);
+        context.processedTokenTurnBaseline = context.processedTokenTotal;
         const turnState: ClaudeTurnState = {
           turnId,
           startedAt: yield* nowIso,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -304,6 +304,8 @@ interface ClaudeSubagentRun {
   readonly context: ClaudeSessionContext;
 }
 
+type ClaudeTokenUsageState = "current" | "skip-compaction-call" | "awaiting-fresh-assistant";
+
 interface ClaudeSessionContext {
   readonly gatewaySessionLease?: AgentGatewaySessionLease;
   session: ProviderSession;
@@ -359,6 +361,7 @@ interface ClaudeSessionContext {
   lastKnownAutoCompactThreshold: number | undefined;
   contextUsageControlEnabled: boolean;
   lastKnownTokenUsage: ThreadTokenUsageSnapshot | undefined;
+  tokenUsageState: ClaudeTokenUsageState;
   lastAssistantUuid: string | undefined;
   lastThreadStartedId: string | undefined;
   // Original API model id the runtime rerouted away from (safeguard refusal
@@ -2726,9 +2729,15 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           : undefined;
         const lastGoodUsage = liveSnapshot ?? context.lastKnownTokenUsage;
         const maxTokens = claudeEffectiveContextBudget(context);
-        const usageSnapshot: ThreadTokenUsageSnapshot | undefined = lastGoodUsage
-          ? mergeClaudeTokenUsageSnapshot(lastGoodUsage, accumulatedSnapshot, maxTokens)
-          : accumulatedSnapshot;
+        if (context.tokenUsageState === "skip-compaction-call") {
+          context.tokenUsageState = "awaiting-fresh-assistant";
+        }
+        const usageSnapshot: ThreadTokenUsageSnapshot | undefined =
+          context.tokenUsageState !== "current"
+            ? undefined
+            : lastGoodUsage
+              ? mergeClaudeTokenUsageSnapshot(lastGoodUsage, accumulatedSnapshot, maxTokens)
+              : accumulatedSnapshot;
 
         // A safeguard reroute only applies to the turn that just finished.
         // Restore the user-selected model so subsequent turns do not silently
@@ -2982,6 +2991,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           // only; subagent completion must not poll them.
           contextUsageControlEnabled: false,
           lastKnownTokenUsage: undefined,
+          tokenUsageState: "current",
           lastAssistantUuid: undefined,
           lastThreadStartedId: undefined,
           rerouteOriginalApiModelId: undefined,
@@ -3650,29 +3660,36 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         // this reflects the actual prompt + output size for this single API call.
         const perCallUsage = (message.message as { usage?: unknown } | undefined)?.usage;
         if (perCallUsage) {
-          yield* maybeEmitContextUsageWarning(context, perCallUsage as Record<string, unknown>);
-          const normalizedPerCallUsage = normalizeClaudeTokenUsage(
-            perCallUsage as Record<string, unknown>,
-            claudeEffectiveContextBudget(context),
-          );
-          if (normalizedPerCallUsage) {
-            context.lastKnownTokenUsage = normalizedPerCallUsage;
-            const usageStamp = yield* makeEventStamp();
-            yield* offerRuntimeEvent(context, {
-              type: "thread.token-usage.updated",
-              eventId: usageStamp.eventId,
-              provider: PROVIDER,
-              createdAt: usageStamp.createdAt,
-              threadId: context.session.threadId,
-              ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
-              payload: { usage: normalizedPerCallUsage },
-              providerRefs: nativeProviderRefs(context),
-              raw: {
-                source: "claude.sdk.message",
-                method: "claude/assistant-usage",
-                payload: perCallUsage,
-              },
-            });
+          if (context.tokenUsageState === "skip-compaction-call") {
+            context.tokenUsageState = "awaiting-fresh-assistant";
+          } else {
+            yield* maybeEmitContextUsageWarning(context, perCallUsage as Record<string, unknown>);
+            const normalizedPerCallUsage = normalizeClaudeTokenUsage(
+              perCallUsage as Record<string, unknown>,
+              claudeEffectiveContextBudget(context),
+            );
+            if (normalizedPerCallUsage) {
+              context.lastKnownTokenUsage = normalizedPerCallUsage;
+              context.tokenUsageState = "current";
+              const usageStamp = yield* makeEventStamp();
+              yield* offerRuntimeEvent(context, {
+                type: "thread.token-usage.updated",
+                eventId: usageStamp.eventId,
+                provider: PROVIDER,
+                createdAt: usageStamp.createdAt,
+                threadId: context.session.threadId,
+                ...(context.turnState
+                  ? { turnId: asCanonicalTurnId(context.turnState.turnId) }
+                  : {}),
+                payload: { usage: normalizedPerCallUsage },
+                providerRefs: nativeProviderRefs(context),
+                raw: {
+                  source: "claude.sdk.message",
+                  method: "claude/assistant-usage",
+                  payload: perCallUsage,
+                },
+              });
+            }
           }
         }
 
@@ -3738,6 +3755,9 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         }
         const run = subagentRunForTask(context, message.tool_use_id, message.task_id);
         const target = run?.context ?? context;
+        if (target.tokenUsageState !== "current") {
+          return;
+        }
         const normalizedUsage = normalizeClaudeTokenUsage(
           message.usage,
           claudeEffectiveContextBudget(target),
@@ -4080,6 +4100,8 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             });
             return;
           case "compact_boundary":
+            context.lastKnownTokenUsage = undefined;
+            context.tokenUsageState = "skip-compaction-call";
             yield* offerRuntimeEvent(context, {
               ...base,
               type: "thread.state.changed",
@@ -5364,6 +5386,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             lastKnownAutoCompactThreshold: requestedAutoCompactWindowTokens,
             contextUsageControlEnabled: true,
             lastKnownTokenUsage: undefined,
+            tokenUsageState: "current",
             lastAssistantUuid: resumeState?.resumeSessionAt,
             lastThreadStartedId: undefined,
             rerouteOriginalApiModelId: undefined,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -362,6 +362,12 @@ interface ClaudeSessionContext {
   contextUsageControlEnabled: boolean;
   lastKnownTokenUsage: ThreadTokenUsageSnapshot | undefined;
   tokenUsageState: ClaudeTokenUsageState;
+  // Assistant snapshots report one API call at a time. Keep their processed-token
+  // accounting separately from the current context size so compaction can clear
+  // the meter without resetting the cumulative counter used by profile stats.
+  processedTokenTotal: number;
+  processedUsageObservedSinceResult: boolean;
+  cumulativeTokenAccountingActive: boolean;
   lastAssistantUuid: string | undefined;
   lastThreadStartedId: string | undefined;
   // Original API model id the runtime rerouted away from (safeguard refusal
@@ -2722,8 +2728,14 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           result?.usage,
           claudeEffectiveContextBudget(context),
         );
-        const totalProcessedTokens =
+        const resultProcessedTokens =
           accumulatedSnapshot?.totalProcessedTokens ?? accumulatedSnapshot?.usedTokens;
+        if (resultProcessedTokens !== undefined && !context.processedUsageObservedSinceResult) {
+          context.processedTokenTotal += resultProcessedTokens;
+        }
+        context.processedUsageObservedSinceResult = false;
+        const totalProcessedTokens =
+          context.processedTokenTotal > 0 ? context.processedTokenTotal : resultProcessedTokens;
         const liveSnapshot = liveContextUsage
           ? snapshotFromClaudeContextUsage(liveContextUsage, totalProcessedTokens)
           : undefined;
@@ -2740,6 +2752,9 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             : lastGoodUsage
               ? mergeClaudeTokenUsageSnapshot(lastGoodUsage, accumulatedSnapshot, maxTokens)
               : accumulatedSnapshot;
+        if (usageSnapshot?.totalProcessedTokens !== undefined) {
+          context.cumulativeTokenAccountingActive = true;
+        }
 
         // A safeguard reroute only applies to the turn that just finished.
         // Restore the user-selected model so subsequent turns do not silently
@@ -2994,6 +3009,9 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           contextUsageControlEnabled: false,
           lastKnownTokenUsage: undefined,
           tokenUsageState: "current",
+          processedTokenTotal: 0,
+          processedUsageObservedSinceResult: false,
+          cumulativeTokenAccountingActive: false,
           lastAssistantUuid: undefined,
           lastThreadStartedId: undefined,
           rerouteOriginalApiModelId: undefined,
@@ -3662,16 +3680,27 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         // this reflects the actual prompt + output size for this single API call.
         const perCallUsage = (message.message as { usage?: unknown } | undefined)?.usage;
         if (perCallUsage) {
+          const normalizedPerCallUsage = normalizeClaudeTokenUsage(
+            perCallUsage as Record<string, unknown>,
+            claudeEffectiveContextBudget(context),
+          );
+          if (normalizedPerCallUsage) {
+            context.processedTokenTotal +=
+              normalizedPerCallUsage.totalProcessedTokens ?? normalizedPerCallUsage.usedTokens;
+            context.processedUsageObservedSinceResult = true;
+          }
           if (context.tokenUsageState === "skip-compaction-call") {
             context.tokenUsageState = "awaiting-fresh-assistant";
           } else {
             yield* maybeEmitContextUsageWarning(context, perCallUsage as Record<string, unknown>);
-            const normalizedPerCallUsage = normalizeClaudeTokenUsage(
-              perCallUsage as Record<string, unknown>,
-              claudeEffectiveContextBudget(context),
-            );
             if (normalizedPerCallUsage) {
-              context.lastKnownTokenUsage = normalizedPerCallUsage;
+              const currentUsage = context.cumulativeTokenAccountingActive
+                ? {
+                    ...normalizedPerCallUsage,
+                    totalProcessedTokens: context.processedTokenTotal,
+                  }
+                : normalizedPerCallUsage;
+              context.lastKnownTokenUsage = currentUsage;
               context.tokenUsageState = "current";
               const usageStamp = yield* makeEventStamp();
               yield* offerRuntimeEvent(context, {
@@ -3683,7 +3712,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
                 ...(context.turnState
                   ? { turnId: asCanonicalTurnId(context.turnState.turnId) }
                   : {}),
-                payload: { usage: normalizedPerCallUsage },
+                payload: { usage: currentUsage },
                 providerRefs: nativeProviderRefs(context),
                 raw: {
                   source: "claude.sdk.message",
@@ -5389,6 +5418,9 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             contextUsageControlEnabled: true,
             lastKnownTokenUsage: undefined,
             tokenUsageState: "current",
+            processedTokenTotal: 0,
+            processedUsageObservedSinceResult: false,
+            cumulativeTokenAccountingActive: false,
             lastAssistantUuid: resumeState?.resumeSessionAt,
             lastThreadStartedId: undefined,
             rerouteOriginalApiModelId: undefined,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2769,7 +2769,10 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             : withoutProcessedTokenTotal(accumulatedSnapshot)
           : undefined;
         const liveSnapshot = liveContextUsage
-          ? snapshotFromClaudeContextUsage(liveContextUsage, totalProcessedTokens)
+          ? snapshotFromClaudeContextUsage(
+              liveContextUsage,
+              context.processedTokenBaselineKnown ? totalProcessedTokens : undefined,
+            )
           : undefined;
         const lastGoodUsage = liveSnapshot ?? context.lastKnownTokenUsage;
         const maxTokens = claudeEffectiveContextBudget(context);
@@ -2783,13 +2786,15 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         const usageSnapshot: ThreadTokenUsageSnapshot | undefined =
           context.tokenUsageState !== "current"
             ? accountingOnlyUsage
-            : lastGoodUsage
-              ? mergeClaudeTokenUsageSnapshot(
-                  lastGoodUsage,
-                  accountedAccumulatedSnapshot,
-                  maxTokens,
-                )
-              : accountedAccumulatedSnapshot;
+            : !context.processedTokenBaselineKnown
+              ? (lastGoodUsage ?? accountedAccumulatedSnapshot)
+              : lastGoodUsage
+                ? mergeClaudeTokenUsageSnapshot(
+                    lastGoodUsage,
+                    accountedAccumulatedSnapshot,
+                    maxTokens,
+                  )
+                : accountedAccumulatedSnapshot;
         context.processedTokenTurnBaseline = context.processedTokenTotal;
 
         // A safeguard reroute only applies to the turn that just finished.

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -189,7 +189,6 @@ interface ClaudeResumeState {
   readonly turnCount?: number;
   readonly trackedTasks?: ReadonlyArray<ClaudeTrackedTask>;
   readonly processedTokenTotal?: number;
-  readonly processedTokenBaselineKnown?: true;
 }
 
 interface ClaudeTurnState {
@@ -882,7 +881,6 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
     turnCount?: unknown;
     trackedTasks?: unknown;
     processedTokenTotal?: unknown;
-    processedTokenBaselineKnown?: unknown;
   };
 
   const threadIdCandidate = typeof cursor.threadId === "string" ? cursor.threadId : undefined;
@@ -907,7 +905,6 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
     cursor.processedTokenTotal >= 0
       ? cursor.processedTokenTotal
       : undefined;
-  const processedTokenBaselineKnown = cursor.processedTokenBaselineKnown === true;
 
   return {
     ...(threadId ? { threadId } : {}),
@@ -918,7 +915,6 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
       : {}),
     ...(trackedTasks.length > 0 ? { trackedTasks } : {}),
     ...(processedTokenTotal !== undefined ? { processedTokenTotal } : {}),
-    ...(processedTokenBaselineKnown ? { processedTokenBaselineKnown: true } : {}),
   };
 }
 
@@ -2053,10 +2049,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             ? { trackedTasks: Array.from(context.trackedTasks.values()) }
             : {}),
           ...(context.processedTokenBaselineKnown
-            ? {
-                processedTokenTotal: context.processedTokenTotal,
-                processedTokenBaselineKnown: true,
-              }
+            ? { processedTokenTotal: context.processedTokenTotal }
             : {}),
         };
 
@@ -5398,9 +5391,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           }
 
           const processedTokenBaselineKnown =
-            input.resumeCursor === undefined ||
-            resumeState?.processedTokenBaselineKnown === true ||
-            resumeState?.processedTokenTotal !== undefined;
+            input.resumeCursor === undefined || resumeState?.processedTokenTotal !== undefined;
           const session: ProviderSession = {
             threadId,
             provider: PROVIDER,
@@ -5418,10 +5409,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               turnCount: resumeState?.turnCount ?? 0,
               ...(trackedTasks.size > 0 ? { trackedTasks: Array.from(trackedTasks.values()) } : {}),
               ...(processedTokenBaselineKnown
-                ? {
-                    processedTokenTotal: resumeState?.processedTokenTotal ?? 0,
-                    processedTokenBaselineKnown: true,
-                  }
+                ? { processedTokenTotal: resumeState?.processedTokenTotal ?? 0 }
                 : {}),
             },
             createdAt: startedAt,
@@ -6110,7 +6098,6 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           resume: forked.sessionId,
           turnCount: Math.max(liveSource?.turns.length ?? 0, sourceState?.turnCount ?? 0),
           processedTokenTotal: 0,
-          processedTokenBaselineKnown: true,
         };
         return { threadId: input.threadId, resumeCursor };
       });

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2732,9 +2732,13 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         if (context.tokenUsageState === "skip-compaction-call") {
           context.tokenUsageState = "awaiting-fresh-assistant";
         }
+        const accountingOnlyUsage =
+          totalProcessedTokens !== undefined
+            ? { usedTokens: 0, totalProcessedTokens }
+            : undefined;
         const usageSnapshot: ThreadTokenUsageSnapshot | undefined =
           context.tokenUsageState !== "current"
-            ? undefined
+            ? accountingOnlyUsage
             : lastGoodUsage
               ? mergeClaudeTokenUsageSnapshot(lastGoodUsage, accumulatedSnapshot, maxTokens)
               : accumulatedSnapshot;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -428,7 +428,7 @@ import {
 import {
   deriveContextWindowSelectionStatus,
   deriveCumulativeCostUsd,
-  deriveLatestContextWindowSnapshot,
+  deriveLatestContextWindowState,
   deriveSelectedContextWindowSnapshot,
 } from "../lib/contextWindow";
 import { useComposerVoiceController } from "./chat/useComposerVoiceController";
@@ -1963,10 +1963,11 @@ export default function ChatView({
     activities: threadActivities,
     session: activeThread?.session ?? null,
   });
-  const activeContextWindow = useMemo(
-    () => deriveLatestContextWindowSnapshot(threadActivities),
+  const activeContextWindowState = useMemo(
+    () => deriveLatestContextWindowState(threadActivities),
     [threadActivities],
   );
+  const activeContextWindow = activeContextWindowState.snapshot;
   const activeCumulativeCostUsd = useMemo(
     () => deriveCumulativeCostUsd(threadActivities),
     [threadActivities],
@@ -9674,11 +9675,18 @@ export default function ChatView({
   );
   const runtimeUsageContextWindow = useMemo(
     () =>
-      activeContextWindow ??
-      (selectedProvider === "claudeAgent"
-        ? deriveSelectedContextWindowSnapshot(composerTraitSelection.contextWindow)
-        : null),
-    [activeContextWindow, composerTraitSelection.contextWindow, selectedProvider],
+      activeContextWindowState.invalidatedByCompaction
+        ? null
+        : (activeContextWindow ??
+          (selectedProvider === "claudeAgent"
+            ? deriveSelectedContextWindowSnapshot(composerTraitSelection.contextWindow)
+            : null)),
+    [
+      activeContextWindow,
+      activeContextWindowState.invalidatedByCompaction,
+      composerTraitSelection.contextWindow,
+      selectedProvider,
+    ],
   );
   const contextWindowSelectionStatus = useMemo(
     () =>

--- a/apps/web/src/components/chat/ComposerSlashStatusDialog.tsx
+++ b/apps/web/src/components/chat/ComposerSlashStatusDialog.tsx
@@ -144,40 +144,41 @@ export function ComposerSlashStatusDialog(props: {
                 />
               ) : null}
             </div>
-            {contextWindow ? (
-              <div className="grid gap-3 text-sm sm:grid-cols-2">
+            <div className="grid gap-3 text-sm sm:grid-cols-2">
+              {contextWindow ? (
+                <>
+                  <div>
+                    <p className="text-muted-foreground">Used</p>
+                    <p className="font-medium text-foreground">
+                      {formatContextWindowTokens(contextWindow.usedTokens)}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-muted-foreground">Remaining</p>
+                    <p className="font-medium text-foreground">
+                      {formatContextWindowTokens(contextWindow.remainingTokens)}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-muted-foreground">Window</p>
+                    <p className="font-medium text-foreground">
+                      {formatContextWindowTokens(contextWindow.maxTokens)}
+                    </p>
+                  </div>
+                </>
+              ) : (
                 <div>
-                  <p className="text-muted-foreground">Used</p>
-                  <p className="font-medium text-foreground">
-                    {formatContextWindowTokens(contextWindow.usedTokens)}
-                  </p>
+                  <p className="text-muted-foreground">Context usage</p>
+                  <p className="font-medium text-foreground">Not reported yet</p>
                 </div>
-                <div>
-                  <p className="text-muted-foreground">Remaining</p>
-                  <p className="font-medium text-foreground">
-                    {formatContextWindowTokens(contextWindow.remainingTokens)}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-muted-foreground">Window</p>
-                  <p className="font-medium text-foreground">
-                    {formatContextWindowTokens(contextWindow.maxTokens)}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-muted-foreground">Cost</p>
-                  <p className="font-medium text-foreground">
-                    {cumulativeCostUsd !== null
-                      ? formatCostUsd(cumulativeCostUsd)
-                      : "Not available"}
-                  </p>
-                </div>
+              )}
+              <div>
+                <p className="text-muted-foreground">Cost</p>
+                <p className="font-medium text-foreground">
+                  {cumulativeCostUsd !== null ? formatCostUsd(cumulativeCostUsd) : "Not available"}
+                </p>
               </div>
-            ) : (
-              <p className="text-sm text-muted-foreground">
-                Context usage has not been reported yet for this thread.
-              </p>
-            )}
+            </div>
           </div>
 
           <div className="space-y-2 rounded-lg border border-border/60 bg-card p-4">

--- a/apps/web/src/lib/contextWindow.test.ts
+++ b/apps/web/src/lib/contextWindow.test.ts
@@ -49,6 +49,30 @@ describe("contextWindow", () => {
     expect(snapshot?.compactsAutomatically).toBe(true);
   });
 
+  it("invalidates earlier usage at a completed compaction until fresh usage arrives", () => {
+    const beforeCompaction = [
+      makeActivity("activity-1", "context-window.updated", {
+        usedTokens: 180_000,
+        maxTokens: 200_000,
+      }),
+      makeActivity("activity-2", "context-compaction", {
+        state: "compacted",
+      }),
+    ];
+
+    expect(deriveLatestContextWindowSnapshot(beforeCompaction)).toBeNull();
+
+    const afterFreshUsage = deriveLatestContextWindowSnapshot([
+      ...beforeCompaction,
+      makeActivity("activity-3", "context-window.updated", {
+        usedTokens: 20_000,
+        maxTokens: 200_000,
+      }),
+    ]);
+
+    expect(afterFreshUsage?.usedTokens).toBe(20_000);
+  });
+
   it("ignores malformed payloads", () => {
     const snapshot = deriveLatestContextWindowSnapshot([
       makeActivity("activity-1", "context-window.updated", {}),

--- a/apps/web/src/lib/contextWindow.test.ts
+++ b/apps/web/src/lib/contextWindow.test.ts
@@ -5,6 +5,7 @@ import {
   deriveContextWindowSelectionStatus,
   deriveContextWindowMeterDisplay,
   deriveCumulativeCostUsd,
+  deriveLatestContextWindowState,
   deriveLatestContextWindowSnapshot,
   deriveSelectedContextWindowSnapshot,
   formatContextWindowSelectionLabel,
@@ -51,20 +52,29 @@ describe("contextWindow", () => {
 
   it("invalidates earlier usage at a completed compaction until fresh usage arrives", () => {
     const beforeCompaction = [
-      makeActivity("activity-1", "context-window.updated", {
+      makeActivity("activity-1", "context-window.configured", {
+        contextWindow: "200k",
+        maxTokens: 200_000,
+      }),
+      makeActivity("activity-2", "context-window.updated", {
         usedTokens: 180_000,
         maxTokens: 200_000,
       }),
-      makeActivity("activity-2", "context-compaction", {
+      makeActivity("activity-3", "context-compaction", {
         state: "compacted",
+      }),
+      makeActivity("activity-4", "context-window.updated", {
+        usedTokens: 0,
+        totalProcessedTokens: 340_000,
       }),
     ];
 
     expect(deriveLatestContextWindowSnapshot(beforeCompaction)).toBeNull();
+    expect(deriveLatestContextWindowState(beforeCompaction).invalidatedByCompaction).toBe(true);
 
     const afterFreshUsage = deriveLatestContextWindowSnapshot([
       ...beforeCompaction,
-      makeActivity("activity-3", "context-window.updated", {
+      makeActivity("activity-5", "context-window.updated", {
         usedTokens: 20_000,
         maxTokens: 200_000,
       }),

--- a/apps/web/src/lib/contextWindow.ts
+++ b/apps/web/src/lib/contextWindow.ts
@@ -33,6 +33,11 @@ export type ContextWindowSnapshot = NullableContextWindowUsage & {
   readonly updatedAt: string;
 };
 
+export interface ContextWindowState {
+  readonly snapshot: ContextWindowSnapshot | null;
+  readonly invalidatedByCompaction: boolean;
+}
+
 export interface ContextWindowSelectionStatus {
   readonly activeLabel: string | null;
   readonly selectedLabel: string | null;
@@ -62,16 +67,16 @@ function isCompletedContextCompaction(activity: OrchestrationThreadActivity): bo
 }
 
 // Read the latest token-usage snapshot emitted by the runtime.
-function deriveLatestUsageContextWindowSnapshot(
+function deriveLatestUsageContextWindowState(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
-): ContextWindowSnapshot | null {
+): ContextWindowState {
   for (let index = activities.length - 1; index >= 0; index -= 1) {
     const activity = activities[index];
     if (!activity) {
       continue;
     }
     if (isCompletedContextCompaction(activity)) {
-      return null;
+      return { snapshot: null, invalidatedByCompaction: true };
     }
     if (activity.kind !== "context-window.updated") {
       continue;
@@ -99,30 +104,33 @@ function deriveLatestUsageContextWindowSnapshot(
     const remainingPercentage = usedPercentage !== null ? Math.max(0, 100 - usedPercentage) : null;
 
     return {
-      usedTokens,
-      usedPercent: payloadUsedPercent,
-      totalProcessedTokens: asFiniteNumber(payload?.totalProcessedTokens),
-      maxTokens,
-      remainingTokens,
-      usedPercentage,
-      remainingPercentage,
-      inputTokens: asFiniteNumber(payload?.inputTokens),
-      cachedInputTokens: asFiniteNumber(payload?.cachedInputTokens),
-      outputTokens: asFiniteNumber(payload?.outputTokens),
-      reasoningOutputTokens: asFiniteNumber(payload?.reasoningOutputTokens),
-      lastUsedTokens: asFiniteNumber(payload?.lastUsedTokens),
-      lastInputTokens: asFiniteNumber(payload?.lastInputTokens),
-      lastCachedInputTokens: asFiniteNumber(payload?.lastCachedInputTokens),
-      lastOutputTokens: asFiniteNumber(payload?.lastOutputTokens),
-      lastReasoningOutputTokens: asFiniteNumber(payload?.lastReasoningOutputTokens),
-      toolUses: asFiniteNumber(payload?.toolUses),
-      durationMs: asFiniteNumber(payload?.durationMs),
-      compactsAutomatically: asBoolean(payload?.compactsAutomatically) ?? false,
-      updatedAt: activity.createdAt,
+      snapshot: {
+        usedTokens,
+        usedPercent: payloadUsedPercent,
+        totalProcessedTokens: asFiniteNumber(payload?.totalProcessedTokens),
+        maxTokens,
+        remainingTokens,
+        usedPercentage,
+        remainingPercentage,
+        inputTokens: asFiniteNumber(payload?.inputTokens),
+        cachedInputTokens: asFiniteNumber(payload?.cachedInputTokens),
+        outputTokens: asFiniteNumber(payload?.outputTokens),
+        reasoningOutputTokens: asFiniteNumber(payload?.reasoningOutputTokens),
+        lastUsedTokens: asFiniteNumber(payload?.lastUsedTokens),
+        lastInputTokens: asFiniteNumber(payload?.lastInputTokens),
+        lastCachedInputTokens: asFiniteNumber(payload?.lastCachedInputTokens),
+        lastOutputTokens: asFiniteNumber(payload?.lastOutputTokens),
+        lastReasoningOutputTokens: asFiniteNumber(payload?.lastReasoningOutputTokens),
+        toolUses: asFiniteNumber(payload?.toolUses),
+        durationMs: asFiniteNumber(payload?.durationMs),
+        compactsAutomatically: asBoolean(payload?.compactsAutomatically) ?? false,
+        updatedAt: activity.createdAt,
+      },
+      invalidatedByCompaction: false,
     };
   }
 
-  return null;
+  return { snapshot: null, invalidatedByCompaction: false };
 }
 
 // Use the configured session window as the source of truth for the meter denominator.
@@ -143,14 +151,19 @@ function deriveLatestConfiguredContextWindowMaxTokens(
   return null;
 }
 
-export function deriveLatestContextWindowSnapshot(
+export function deriveLatestContextWindowState(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
-): ContextWindowSnapshot | null {
-  const usageSnapshot = deriveLatestUsageContextWindowSnapshot(activities);
+): ContextWindowState {
+  const usageState = deriveLatestUsageContextWindowState(activities);
+  if (usageState.invalidatedByCompaction) {
+    return usageState;
+  }
+
+  const usageSnapshot = usageState.snapshot;
   const configuredMaxTokens = deriveLatestConfiguredContextWindowMaxTokens(activities);
 
   if (usageSnapshot === null && configuredMaxTokens === null) {
-    return null;
+    return usageState;
   }
 
   const usedTokens = usageSnapshot?.usedTokens ?? 0;
@@ -170,27 +183,36 @@ export function deriveLatestContextWindowSnapshot(
   const remainingPercentage = usedPercentage !== null ? Math.max(0, 100 - usedPercentage) : null;
 
   return {
-    usedTokens,
-    usedPercent: usageSnapshot?.usedPercent ?? null,
-    totalProcessedTokens: usageSnapshot?.totalProcessedTokens ?? null,
-    maxTokens,
-    remainingTokens,
-    usedPercentage,
-    remainingPercentage,
-    inputTokens: usageSnapshot?.inputTokens ?? null,
-    cachedInputTokens: usageSnapshot?.cachedInputTokens ?? null,
-    outputTokens: usageSnapshot?.outputTokens ?? null,
-    reasoningOutputTokens: usageSnapshot?.reasoningOutputTokens ?? null,
-    lastUsedTokens: usageSnapshot?.lastUsedTokens ?? null,
-    lastInputTokens: usageSnapshot?.lastInputTokens ?? null,
-    lastCachedInputTokens: usageSnapshot?.lastCachedInputTokens ?? null,
-    lastOutputTokens: usageSnapshot?.lastOutputTokens ?? null,
-    lastReasoningOutputTokens: usageSnapshot?.lastReasoningOutputTokens ?? null,
-    toolUses: usageSnapshot?.toolUses ?? null,
-    durationMs: usageSnapshot?.durationMs ?? null,
-    compactsAutomatically: usageSnapshot?.compactsAutomatically ?? false,
-    updatedAt: usageSnapshot?.updatedAt ?? activities[activities.length - 1]?.createdAt ?? "",
+    snapshot: {
+      usedTokens,
+      usedPercent: usageSnapshot?.usedPercent ?? null,
+      totalProcessedTokens: usageSnapshot?.totalProcessedTokens ?? null,
+      maxTokens,
+      remainingTokens,
+      usedPercentage,
+      remainingPercentage,
+      inputTokens: usageSnapshot?.inputTokens ?? null,
+      cachedInputTokens: usageSnapshot?.cachedInputTokens ?? null,
+      outputTokens: usageSnapshot?.outputTokens ?? null,
+      reasoningOutputTokens: usageSnapshot?.reasoningOutputTokens ?? null,
+      lastUsedTokens: usageSnapshot?.lastUsedTokens ?? null,
+      lastInputTokens: usageSnapshot?.lastInputTokens ?? null,
+      lastCachedInputTokens: usageSnapshot?.lastCachedInputTokens ?? null,
+      lastOutputTokens: usageSnapshot?.lastOutputTokens ?? null,
+      lastReasoningOutputTokens: usageSnapshot?.lastReasoningOutputTokens ?? null,
+      toolUses: usageSnapshot?.toolUses ?? null,
+      durationMs: usageSnapshot?.durationMs ?? null,
+      compactsAutomatically: usageSnapshot?.compactsAutomatically ?? false,
+      updatedAt: usageSnapshot?.updatedAt ?? activities[activities.length - 1]?.createdAt ?? "",
+    },
+    invalidatedByCompaction: false,
   };
+}
+
+export function deriveLatestContextWindowSnapshot(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): ContextWindowSnapshot | null {
+  return deriveLatestContextWindowState(activities).snapshot;
 }
 
 export function deriveSelectedContextWindowSnapshot(

--- a/apps/web/src/lib/contextWindow.ts
+++ b/apps/web/src/lib/contextWindow.ts
@@ -58,7 +58,7 @@ const KNOWN_CONTEXT_WINDOW_MAX_TOKENS = {
   "1m": 1_000_000,
 } as const;
 
-function isCompletedContextCompaction(activity: OrchestrationThreadActivity): boolean {
+export function isCompletedContextCompaction(activity: OrchestrationThreadActivity): boolean {
   if (activity.kind !== "context-compaction") {
     return false;
   }

--- a/apps/web/src/lib/contextWindow.ts
+++ b/apps/web/src/lib/contextWindow.ts
@@ -53,13 +53,27 @@ const KNOWN_CONTEXT_WINDOW_MAX_TOKENS = {
   "1m": 1_000_000,
 } as const;
 
+function isCompletedContextCompaction(activity: OrchestrationThreadActivity): boolean {
+  if (activity.kind !== "context-compaction") {
+    return false;
+  }
+  const payload = asRecord(activity.payload);
+  return payload?.state === "compacted" || payload?.status === "completed";
+}
+
 // Read the latest token-usage snapshot emitted by the runtime.
 function deriveLatestUsageContextWindowSnapshot(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): ContextWindowSnapshot | null {
   for (let index = activities.length - 1; index >= 0; index -= 1) {
     const activity = activities[index];
-    if (!activity || activity.kind !== "context-window.updated") {
+    if (!activity) {
+      continue;
+    }
+    if (isCompletedContextCompaction(activity)) {
+      return null;
+    }
+    if (activity.kind !== "context-window.updated") {
       continue;
     }
 

--- a/apps/web/src/lib/threadHandoff.test.ts
+++ b/apps/web/src/lib/threadHandoff.test.ts
@@ -101,14 +101,17 @@ describe("threadHandoff", () => {
     ).toHaveLength(4);
   });
 
-  it("does not import a source provider's configured context window", () => {
-    const activity = (kind: string): OrchestrationThreadActivity => ({
+  it("imports usage and compaction boundaries without the source provider's configured window", () => {
+    const activity = (
+      kind: string,
+      payload: OrchestrationThreadActivity["payload"] = {},
+    ): OrchestrationThreadActivity => ({
       id: EventId.makeUnsafe(`activity-${kind}`),
       createdAt: "2026-07-21T00:00:00.000Z",
       tone: "info",
       kind,
       summary: kind,
-      payload: {},
+      payload,
       turnId: null,
     });
 
@@ -116,11 +119,15 @@ describe("threadHandoff", () => {
       activities: [
         activity("context-window.configured"),
         activity("context-window.updated"),
+        activity("context-compaction", { state: "compacted" }),
         activity("tool.started"),
       ],
     });
 
-    expect(imported.map(({ kind }) => kind)).toEqual(["context-window.updated"]);
+    expect(imported.map(({ kind }) => kind)).toEqual([
+      "context-window.updated",
+      "context-compaction",
+    ]);
   });
 
   it("excludes disabled, missing, unavailable, and unauthenticated handoff targets", () => {

--- a/apps/web/src/lib/threadHandoff.test.ts
+++ b/apps/web/src/lib/threadHandoff.test.ts
@@ -101,7 +101,7 @@ describe("threadHandoff", () => {
     ).toHaveLength(4);
   });
 
-  it("imports usage and compaction boundaries without the source provider's configured window", () => {
+  it("drops usage invalidated by the latest compaction before handoff appends", () => {
     const activity = (
       kind: string,
       payload: OrchestrationThreadActivity["payload"] = {},
@@ -120,13 +120,14 @@ describe("threadHandoff", () => {
         activity("context-window.configured"),
         activity("context-window.updated"),
         activity("context-compaction", { state: "compacted" }),
+        activity("context-window.updated", { usedTokens: 20_000 }),
         activity("tool.started"),
       ],
     });
 
     expect(imported.map(({ kind }) => kind)).toEqual([
-      "context-window.updated",
       "context-compaction",
+      "context-window.updated",
     ]);
   });
 

--- a/apps/web/src/lib/threadHandoff.ts
+++ b/apps/web/src/lib/threadHandoff.ts
@@ -25,6 +25,7 @@ import { randomUUID } from "./utils";
 const IMPORTABLE_THREAD_ACTIVITY_KINDS = new Set([
   "account.rate-limits.updated",
   "account.rate-limited",
+  "context-compaction",
   "context-window.updated",
 ]);
 

--- a/apps/web/src/lib/threadHandoff.ts
+++ b/apps/web/src/lib/threadHandoff.ts
@@ -19,6 +19,7 @@ import { type Thread } from "../types";
 import { DEFAULT_PROVIDER_ORDER } from "../providerOrdering";
 import { stripEmbeddedAssistantSelections } from "./assistantSelections";
 import { extractTrailingBrowserAnnotations } from "./browserAnnotations";
+import { isCompletedContextCompaction } from "./contextWindow";
 import { findProviderStatus, isProviderUsable } from "./providerAvailability";
 import { randomUUID } from "./utils";
 
@@ -145,13 +146,32 @@ export function buildThreadHandoffImportedMessages(
 export function buildThreadHandoffImportedActivities(
   thread: Pick<Thread, "activities">,
 ): ReadonlyArray<OrchestrationThreadActivity> {
-  return thread.activities.filter(isImportableThreadActivity).map((activity) => {
-    const { sequence: _sequence, ...rest } = activity;
-    return {
-      ...rest,
-      id: EventId.makeUnsafe(randomUUID()),
-    };
-  });
+  // Activity appends are not transactional. Start context history at the latest
+  // durable boundary so a partial handoff can never persist already-invalid usage.
+  let latestCompactionIndex = -1;
+  for (let index = thread.activities.length - 1; index >= 0; index -= 1) {
+    const activity = thread.activities[index];
+    if (activity && isCompletedContextCompaction(activity)) {
+      latestCompactionIndex = index;
+      break;
+    }
+  }
+
+  return thread.activities
+    .filter(
+      (activity, index) =>
+        isImportableThreadActivity(activity) &&
+        (latestCompactionIndex < 0 ||
+          (activity.kind !== "context-window.updated" && activity.kind !== "context-compaction") ||
+          index >= latestCompactionIndex),
+    )
+    .map((activity) => {
+      const { sequence: _sequence, ...rest } = activity;
+      return {
+        ...rest,
+        id: EventId.makeUnsafe(randomUUID()),
+      };
+    });
 }
 
 export function hasNativeThreadHandoffMessages(thread: Pick<Thread, "messages">): boolean {


### PR DESCRIPTION
Closes #791

## What changed

- invalidate Claude's cached context snapshot when the SDK emits the durable compaction boundary
- ignore the compaction API call's assistant usage and terminal accumulated fallback until a genuine assistant response reports fresh usage
- stop the web context selector from scanning past a successful compaction activity, while allowing later usage to repopulate the meter
- keep the existing token-usage runtime contract unchanged instead of adding a nullable usage event

## Why

Claude reports the compaction request as an API call against the full pre-compaction context. Synara previously promoted that usage as the current context and the renderer continued finding older usage behind the durable compaction marker. The meter therefore stayed near full until the next user turn.

The adapter now models the compact-boundary ordering explicitly, and the renderer treats successful compaction as a history boundary. The stale value disappears immediately and the next real assistant usage becomes current.

## Verification

- `bun run --cwd apps/server test -- src/provider/Layers/ClaudeAdapter.test.ts` (149 passed)
- `bun run --cwd apps/web test -- src/lib/contextWindow.test.ts` (18 passed)
- `git diff --check`

Per task constraints, the heavyweight `bun fmt`, `bun lint`, and `bun typecheck` checks were not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Claude runtime token accounting, durable resume cursors, and how the UI derives context usage after compaction; incorrect logic could misreport window fill or profile token totals.
> 
> **Overview**
> Fixes the context meter staying near full after Claude compaction by treating a completed compaction as a **history boundary** and ignoring misleading usage from the compaction API call until the next real assistant response.
> 
> **Server (`ClaudeAdapter`)** adds explicit compaction ordering: on `compact_boundary` it clears the live context snapshot and enters a state that skips promoting compaction-call assistant/result usage as current window size, while still emitting **accounting-only** `thread.token-usage.updated` events (`usedTokens: 0`, `totalProcessedTokens` from accumulated SDK totals). Cumulative processed tokens are tracked in session state, persisted on the resume cursor as `processedTokenTotal` when the baseline is known, resumed on session start, and reset on fork; legacy cursors without that field do not surface `totalProcessedTokens`.
> 
> **Orchestration projection** now maps token-usage updates that only carry `totalProcessedTokens` to `context-window.updated` activities.
> 
> **Web** introduces `deriveLatestContextWindowState` with `invalidatedByCompaction` so the composer meter hides stale usage after compaction until fresh usage arrives; the slash status dialog shows a clearer empty state. **Thread handoff** imports `context-compaction` and drops pre-compaction `context-window.updated` activities so handoffs cannot reintroduce invalid usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51db59f71eb8f83f677164bb176653b4ace9a42e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->