### PR TITLE
fix: add server-backed provider enablement controls

### DIFF
--- a/apps/server/src/authEffectRoute.test.ts
+++ b/apps/server/src/authEffectRoute.test.ts
@@ -5,14 +5,15 @@ import path from "node:path";
 
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { AuthSessionId } from "@synara/contracts";
+import { AuthSessionId, DEFAULT_SERVER_SETTINGS } from "@synara/contracts";
 import {
   ATTACHMENT_CANCEL_ROUTE_PATH,
   ATTACHMENT_UPLOAD_ROUTE_PATH,
+  VOICE_TRANSCRIPTION_UPLOAD_ROUTE_PATH,
 } from "@synara/shared/binaryTransfer";
 import { DateTime, Effect, Exit, Layer, Scope } from "effect";
 import { HttpRouter } from "effect/unstable/http";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { AuthError, ServerAuth, type ServerAuthShape } from "./auth/Services/ServerAuth";
 import {
@@ -27,7 +28,11 @@ import {
   authEffectRouteLayer,
   binaryUploadEffectRouteLayer,
 } from "./http";
-import { ProviderAdapterRegistry } from "./provider/Services/ProviderAdapterRegistry";
+import {
+  ProviderAdapterRegistry,
+  type ProviderAdapterRegistryShape,
+} from "./provider/Services/ProviderAdapterRegistry";
+import { ServerSettingsService, type ServerSettingsShape } from "./serverSettings";
 
 const currentSessionId = AuthSessionId.makeUnsafe("11111111-1111-4111-8111-111111111111");
 const otherSessionId = AuthSessionId.makeUnsafe("22222222-2222-4222-8222-222222222222");
@@ -110,6 +115,10 @@ async function withAuthEffectServer(
   routeLayer:
     | typeof authEffectRouteLayer
     | typeof binaryUploadEffectRouteLayer = authEffectRouteLayer,
+  overrides?: {
+    readonly providerAdapterRegistry?: ProviderAdapterRegistryShape;
+    readonly serverSettings?: ServerSettingsShape;
+  },
 ): Promise<void> {
   const scope = await Effect.runPromise(Scope.make("sequential"));
   let nodeServer: http.Server | null = null;
@@ -120,10 +129,18 @@ async function withAuthEffectServer(
           Layer.succeed(ServerConfig, config),
           Layer.succeed(ServerAuth, serverAuth),
           Layer.succeed(SessionCredentialService, makeSessionCredentialService()),
-          Layer.succeed(ProviderAdapterRegistry, {
-            getByProvider: () => Effect.die("voice adapter not used in this test"),
-            listProviders: () => Effect.succeed([]),
-          }),
+          Layer.succeed(
+            ProviderAdapterRegistry,
+            overrides?.providerAdapterRegistry ?? {
+              getByProvider: () => Effect.die("voice adapter not used in this test"),
+              listProviders: () => Effect.succeed([]),
+            },
+          ),
+          Layer.succeed(
+            ServerSettingsService,
+            overrides?.serverSettings ??
+              ({ getSettings: Effect.succeed(DEFAULT_SERVER_SETTINGS) } as ServerSettingsShape),
+          ),
           ManagedAttachmentRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
           NodeServices.layer,
         ),
@@ -342,6 +359,54 @@ describe("authEffectRouteLayer", () => {
 });
 
 describe("binaryUploadEffectRouteLayer", () => {
+  it("rejects voice uploads before transcription when the provider is disabled", async () => {
+    const transcribeVoice = vi.fn(() => Effect.succeed({ text: "unexpected" }));
+    const disabledSettings = {
+      ...DEFAULT_SERVER_SETTINGS,
+      providers: {
+        ...DEFAULT_SERVER_SETTINGS.providers,
+        codex: { ...DEFAULT_SERVER_SETTINGS.providers.codex, enabled: false },
+      },
+    };
+    await withAuthEffectServer(
+      { host: "127.0.0.1", publicUrl: undefined } as ServerConfigShape,
+      makeServerAuth({ count: 0 }),
+      async (serverOrigin) => {
+        const params = new URLSearchParams({
+          provider: "codex",
+          cwd: "/tmp/project",
+          mimeType: "audio/wav",
+          sampleRateHz: "16000",
+          durationMs: "250",
+        });
+        const response = await fetch(
+          `${serverOrigin}${VOICE_TRANSCRIPTION_UPLOAD_ROUTE_PATH}?${params.toString()}`,
+          {
+            method: "POST",
+            headers: { Authorization: "Bearer bearer-token" },
+            body: Uint8Array.from([1]),
+          },
+        );
+
+        expect(response.status).toBe(409);
+        await expect(response.json()).resolves.toEqual({
+          error: "Codex is disabled in Settings > Providers.",
+        });
+        expect(transcribeVoice).not.toHaveBeenCalled();
+      },
+      binaryUploadEffectRouteLayer,
+      {
+        providerAdapterRegistry: {
+          getByProvider: () => Effect.succeed({ provider: "codex", transcribeVoice } as never),
+          listProviders: () => Effect.succeed(["codex"]),
+        },
+        serverSettings: {
+          getSettings: Effect.succeed(disabledSettings),
+        } as ServerSettingsShape,
+      },
+    );
+  });
+
   it("allows credentialed Canary attachment upload preflights", async () => {
     const config = {
       host: "127.0.0.1",

--- a/apps/server/src/authEffectRoute.test.ts
+++ b/apps/server/src/authEffectRoute.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { AuthSessionId, DEFAULT_SERVER_SETTINGS } from "@synara/contracts";
+import { AuthSessionId } from "@synara/contracts";
 import {
   ATTACHMENT_CANCEL_ROUTE_PATH,
   ATTACHMENT_UPLOAD_ROUTE_PATH,
@@ -32,7 +32,7 @@ import {
   ProviderAdapterRegistry,
   type ProviderAdapterRegistryShape,
 } from "./provider/Services/ProviderAdapterRegistry";
-import { ServerSettingsService, type ServerSettingsShape } from "./serverSettings";
+import { ServerSettingsService } from "./serverSettings";
 
 const currentSessionId = AuthSessionId.makeUnsafe("11111111-1111-4111-8111-111111111111");
 const otherSessionId = AuthSessionId.makeUnsafe("22222222-2222-4222-8222-222222222222");
@@ -117,7 +117,7 @@ async function withAuthEffectServer(
     | typeof binaryUploadEffectRouteLayer = authEffectRouteLayer,
   overrides?: {
     readonly providerAdapterRegistry?: ProviderAdapterRegistryShape;
-    readonly serverSettings?: ServerSettingsShape;
+    readonly serverSettingsLayer?: Layer.Layer<ServerSettingsService>;
   },
 ): Promise<void> {
   const scope = await Effect.runPromise(Scope.make("sequential"));
@@ -136,11 +136,7 @@ async function withAuthEffectServer(
               listProviders: () => Effect.succeed([]),
             },
           ),
-          Layer.succeed(
-            ServerSettingsService,
-            overrides?.serverSettings ??
-              ({ getSettings: Effect.succeed(DEFAULT_SERVER_SETTINGS) } as ServerSettingsShape),
-          ),
+          overrides?.serverSettingsLayer ?? ServerSettingsService.layerTest(),
           ManagedAttachmentRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
           NodeServices.layer,
         ),
@@ -361,13 +357,6 @@ describe("authEffectRouteLayer", () => {
 describe("binaryUploadEffectRouteLayer", () => {
   it("rejects voice uploads before transcription when the provider is disabled", async () => {
     const transcribeVoice = vi.fn(() => Effect.succeed({ text: "unexpected" }));
-    const disabledSettings = {
-      ...DEFAULT_SERVER_SETTINGS,
-      providers: {
-        ...DEFAULT_SERVER_SETTINGS.providers,
-        codex: { ...DEFAULT_SERVER_SETTINGS.providers.codex, enabled: false },
-      },
-    };
     await withAuthEffectServer(
       { host: "127.0.0.1", publicUrl: undefined } as ServerConfigShape,
       makeServerAuth({ count: 0 }),
@@ -400,9 +389,9 @@ describe("binaryUploadEffectRouteLayer", () => {
           getByProvider: () => Effect.succeed({ provider: "codex", transcribeVoice } as never),
           listProviders: () => Effect.succeed(["codex"]),
         },
-        serverSettings: {
-          getSettings: Effect.succeed(disabledSettings),
-        } as ServerSettingsShape,
+        serverSettingsLayer: ServerSettingsService.layerTest({
+          providers: { codex: { enabled: false } },
+        }),
       },
     );
   });

--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -1489,6 +1489,7 @@ layer("AutomationService", (it) => {
           input: {
             ...createInput("local"),
             schedule: { type: "interval", everySeconds: 300 },
+            maxIterations: 1,
             stopAfterConsecutiveFailures: 1,
           },
           now,
@@ -1507,6 +1508,7 @@ layer("AutomationService", (it) => {
         assert.strictEqual(pausedRun?.status, "skipped");
         assert.match(pausedRun?.result?.summary ?? "", /disabled in Settings/);
         assert.strictEqual(pausedDefinition?.enabled, true);
+        assert.strictEqual(pausedDefinition?.iterationCount, 0);
         assert.strictEqual(pausedDefinition?.consecutiveFailureCount, 0);
         assert.strictEqual(dispatchedCommands.length, 0);
 
@@ -1517,8 +1519,12 @@ layer("AutomationService", (it) => {
           leaseOwnerId: "test-scheduler",
         });
         const resumedRun = resumed.find((entry) => entry.run.automationId === automationId)?.run;
+        const resumedDefinition = (yield* service.list({ projectId })).definitions.find(
+          (definition) => definition.id === automationId,
+        );
 
         assert.strictEqual(resumedRun?.status, "running");
+        assert.strictEqual(resumedDefinition?.iterationCount, 1);
         assert.isAtLeast(dispatchedCommands.length, 2);
       }),
   );

--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -3466,7 +3466,7 @@ layer("AutomationService", (it) => {
       }),
   );
 
-  it.effect("defers stop evaluation until its provider is re-enabled", () =>
+  it.effect("defers stop evaluation until the router's fallback provider is re-enabled", () =>
     Effect.gen(function* () {
       resetHarness();
       const service = yield* AutomationService;
@@ -3475,10 +3475,27 @@ layer("AutomationService", (it) => {
       const automationTurnId = TurnId.makeUnsafe("turn-stop-provider-disabled");
       threadShell = Option.some(makeThreadShell({ id: targetThreadId }));
 
+      yield* serverSettings.updateSettings({
+        textGenerationModelSelection: {
+          provider: "claudeAgent",
+          model: "claude-opus-4-8",
+        },
+        providers: {
+          codex: { enabled: false },
+          cursor: { enabled: false },
+          kilo: { enabled: false },
+          opencode: { enabled: false },
+        },
+      });
+
       const created = yield* service.create({
         ...createInput("local"),
         mode: "heartbeat",
         targetThreadId,
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-opus-4-8",
+        },
         completionPolicy: aiCompletionPolicy("the PR is ready"),
       });
       const { run } = yield* service.runNow({ automationId: created.id });
@@ -3487,8 +3504,6 @@ layer("AutomationService", (it) => {
         threadId: targetThreadId,
         turnId: automationTurnId,
       });
-      yield* serverSettings.updateSettings({ providers: { codex: { enabled: false } } });
-
       yield* service.reconcileThread({ threadId: targetThreadId });
       yield* realDelay(25);
 

--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -1474,6 +1474,100 @@ layer("AutomationService", (it) => {
     }),
   );
 
+  it.effect(
+    "skips recurring runs without failure accounting while their provider is disabled",
+    () =>
+      Effect.gen(function* () {
+        resetHarness();
+        const service = yield* AutomationService;
+        const repository = yield* AutomationRepository;
+        const serverSettings = yield* ServerSettingsService;
+        const automationId = AutomationId.makeUnsafe("automation-provider-disabled");
+        yield* serverSettings.updateSettings({ providers: { codex: { enabled: false } } });
+        yield* repository.createDefinition({
+          id: automationId,
+          input: {
+            ...createInput("local"),
+            schedule: { type: "interval", everySeconds: 300 },
+            stopAfterConsecutiveFailures: 1,
+          },
+          now,
+        });
+
+        const paused = yield* service.runDueOnce({
+          now,
+          limit: 10,
+          leaseOwnerId: "test-scheduler",
+        });
+        const pausedDefinition = (yield* service.list({ projectId })).definitions.find(
+          (definition) => definition.id === automationId,
+        );
+        const pausedRun = paused.find((entry) => entry.run.automationId === automationId)?.run;
+
+        assert.strictEqual(pausedRun?.status, "skipped");
+        assert.match(pausedRun?.result?.summary ?? "", /disabled in Settings/);
+        assert.strictEqual(pausedDefinition?.enabled, true);
+        assert.strictEqual(pausedDefinition?.consecutiveFailureCount, 0);
+        assert.strictEqual(dispatchedCommands.length, 0);
+
+        yield* serverSettings.updateSettings({ providers: { codex: { enabled: true } } });
+        const resumed = yield* service.runDueOnce({
+          now: "2026-06-16T10:05:00.000Z",
+          limit: 10,
+          leaseOwnerId: "test-scheduler",
+        });
+        const resumedRun = resumed.find((entry) => entry.run.automationId === automationId)?.run;
+
+        assert.strictEqual(resumedRun?.status, "running");
+        assert.isAtLeast(dispatchedCommands.length, 2);
+      }),
+  );
+
+  it.effect("defers a disabled one-shot until its provider is re-enabled", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const repository = yield* AutomationRepository;
+      const serverSettings = yield* ServerSettingsService;
+      const automationId = AutomationId.makeUnsafe("automation-provider-disabled-once");
+      const runAt = "2026-06-16T10:00:15.000Z";
+      yield* serverSettings.updateSettings({ providers: { codex: { enabled: false } } });
+      yield* repository.createDefinition({
+        id: automationId,
+        input: {
+          ...createInput("local"),
+          schedule: { type: "once", runAt },
+        },
+        now,
+      });
+
+      const paused = yield* service.runDueOnce({
+        now: runAt,
+        limit: 10,
+        leaseOwnerId: "test-scheduler",
+      });
+      const deferred = paused.find((entry) => entry.run.automationId === automationId)?.run;
+      assert.isDefined(deferred?.deferredUntil);
+      assert.strictEqual(dispatchedCommands.length, 0);
+
+      yield* serverSettings.updateSettings({ providers: { codex: { enabled: true } } });
+      const resumed = yield* service.runDueOnce({
+        now: deferred!.deferredUntil!,
+        limit: 10,
+        leaseOwnerId: "test-scheduler",
+      });
+      const completedDefinition = (yield* service.list({ projectId })).definitions.find(
+        (definition) => definition.id === automationId,
+      );
+
+      const resumedRun = resumed.find((entry) => entry.run.id === deferred?.id)?.run;
+      assert.strictEqual(resumedRun?.id, deferred?.id);
+      assert.strictEqual(resumedRun?.status, "running");
+      assert.strictEqual(completedDefinition?.enabled, false);
+      assert.strictEqual(dispatchedCommands.length, 2);
+    }),
+  );
+
   it.effect("records and advances missed scheduled occurrences when misfire policy is skip", () =>
     Effect.gen(function* () {
       resetHarness();

--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -3466,6 +3466,53 @@ layer("AutomationService", (it) => {
       }),
   );
 
+  it.effect("defers stop evaluation until its provider is re-enabled", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const serverSettings = yield* ServerSettingsService;
+      const targetThreadId = ThreadId.makeUnsafe("heartbeat-stop-provider-disabled");
+      const automationTurnId = TurnId.makeUnsafe("turn-stop-provider-disabled");
+      threadShell = Option.some(makeThreadShell({ id: targetThreadId }));
+
+      const created = yield* service.create({
+        ...createInput("local"),
+        mode: "heartbeat",
+        targetThreadId,
+        completionPolicy: aiCompletionPolicy("the PR is ready"),
+      });
+      const { run } = yield* service.runNow({ automationId: created.id });
+      yield* completeAutomationRun({
+        run,
+        threadId: targetThreadId,
+        turnId: automationTurnId,
+      });
+      yield* serverSettings.updateSettings({ providers: { codex: { enabled: false } } });
+
+      yield* service.reconcileThread({ threadId: targetThreadId });
+      yield* realDelay(25);
+
+      const deferredRun = (yield* service.list({ projectId })).runs.find(
+        (entry) => entry.id === run.id,
+      );
+      assert.isUndefined(deferredRun?.result?.completionEvaluation);
+      assert.strictEqual(completionEvaluationInputs.length, 0);
+
+      yield* serverSettings.updateSettings({ providers: { codex: { enabled: true } } });
+      const resumed = yield* waitForAutomationList({
+        service,
+        description: "re-enabled provider stop evaluation",
+        predicate: (listed) =>
+          listed.runs.find((entry) => entry.id === run.id)?.result?.completionEvaluation !==
+          undefined,
+      });
+      const resumedRun = resumed.runs.find((entry) => entry.id === run.id);
+
+      assert.strictEqual(resumedRun?.result?.completionEvaluation?.stopMatched, false);
+      assert.strictEqual(completionEvaluationInputs.length, 1);
+    }),
+  );
+
   it.effect("does not auto-stop a heartbeat automation without a completion policy", () =>
     Effect.gen(function* () {
       resetHarness();

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -615,6 +615,21 @@ export const AutomationServiceLive = Layer.effect(
         ),
         Effect.mapError(toServiceError("Failed to read provider settings.")),
       );
+    const completionEvaluationProviderDisabledReason = (definition: AutomationDefinition) =>
+      serverSettings.getSettings.pipe(
+        Effect.map((settings) => {
+          const directInput = resolveTextGenerationInputForSelection(
+            definition.modelSelection,
+            definition.providerOptions,
+          );
+          const provider =
+            directInput?.modelSelection.provider ?? settings.textGenerationModelSelection.provider;
+          return settings.providers[provider].enabled
+            ? null
+            : `${PROVIDER_DISPLAY_NAMES[provider]} is disabled in Settings > Providers.`;
+        }),
+        Effect.mapError(toServiceError("Failed to read completion-evaluation provider settings.")),
+      );
     const orchestrationEngine = yield* OrchestrationEngineService;
     const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
     const projectionTurnRepository = yield* ProjectionTurnRepository;
@@ -1585,6 +1600,9 @@ export const AutomationServiceLive = Layer.effect(
       policy: Extract<AutomationCompletionPolicy, { type: "ai-evaluated" }>,
     ) =>
       Effect.gen(function* () {
+        if (yield* completionEvaluationProviderDisabledReason(definition)) {
+          return false;
+        }
         if (!run.threadId) {
           yield* recordCompletionEvaluation({
             run,
@@ -1705,6 +1723,23 @@ export const AutomationServiceLive = Layer.effect(
       }).pipe(
         Effect.catch((error) =>
           Effect.gen(function* () {
+            const disabledReason = yield* completionEvaluationProviderDisabledReason(
+              definition,
+            ).pipe(
+              Effect.catch((settingsError) =>
+                Effect.logWarning(
+                  "automation completion evaluation provider state could not be rechecked",
+                  {
+                    automationId: definition.id,
+                    runId: run.id,
+                    error: errorMessage(settingsError),
+                  },
+                ).pipe(Effect.as(null)),
+              ),
+            );
+            if (disabledReason) {
+              return false;
+            }
             const reason = completionFailureReason(error);
             yield* Effect.logWarning("automation completion evaluation failed", {
               automationId: definition.id,
@@ -1785,11 +1820,17 @@ export const AutomationServiceLive = Layer.effect(
               if (!runUsesCurrentCompletionPolicy(run, definition)) {
                 return Effect.void;
               }
-              return enqueueCompletionEvaluationJob({
-                definition,
-                run,
-                policy,
-              });
+              return completionEvaluationProviderDisabledReason(definition).pipe(
+                Effect.flatMap((disabledReason) =>
+                  disabledReason
+                    ? Effect.void
+                    : enqueueCompletionEvaluationJob({
+                        definition,
+                        run,
+                        policy,
+                      }),
+                ),
+              );
             },
           }),
         ),
@@ -1848,6 +1889,20 @@ export const AutomationServiceLive = Layer.effect(
           error: errorMessage(error),
         }),
       ),
+    );
+
+    yield* serverSettings.streamChanges.pipe(
+      Stream.runForEach(() =>
+        enqueuePendingCompletionEvaluations().pipe(
+          Effect.catch((error) =>
+            Effect.logWarning(
+              "automation pending stop evaluations could not be reconciled after settings changed",
+              { error: errorMessage(error) },
+            ),
+          ),
+        ),
+      ),
+      Effect.forkScoped,
     );
 
     const appendFailureAutoDisableResult = (

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -9,7 +9,6 @@ import {
   DEFAULT_AUTOMATION_MINIMUM_INTERVAL_SECONDS,
   DEFAULT_AUTOMATION_STOP_AFTER_CONSECUTIVE_FAILURES,
   MessageId,
-  PROVIDER_DISPLAY_NAMES,
   ThreadId,
   type AutomationAllowedCapability,
   type AutomationCompletionPolicy,
@@ -46,6 +45,7 @@ import {
 } from "../../git/textGenerationSelection.ts";
 import { OrchestrationEngineService } from "../../orchestration/Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { providerDisabledSettingsMessage } from "../../provider/enabledProviderAdapter.ts";
 import { threadHasInFlightTurn } from "../../orchestration/commandInvariants.ts";
 import {
   AutomationRepository,
@@ -614,7 +614,7 @@ export const AutomationServiceLive = Layer.effect(
         Effect.map((settings) =>
           settings.providers[definition.modelSelection.provider].enabled
             ? null
-            : `${PROVIDER_DISPLAY_NAMES[definition.modelSelection.provider]} is disabled in Settings > Providers.`,
+            : providerDisabledSettingsMessage(definition.modelSelection.provider),
         ),
         Effect.mapError(toServiceError("Failed to read provider settings.")),
       );
@@ -632,7 +632,7 @@ export const AutomationServiceLive = Layer.effect(
               : "codex");
           return settings.providers[provider].enabled
             ? null
-            : `${PROVIDER_DISPLAY_NAMES[provider]} is disabled in Settings > Providers.`;
+            : providerDisabledSettingsMessage(provider);
         }),
         Effect.mapError(toServiceError("Failed to read completion-evaluation provider settings.")),
       );

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -40,7 +40,10 @@ import { Cause, Effect, Layer, Option, PubSub, Queue, Stream } from "effect";
 
 import { GitCore } from "../../git/Services/GitCore.ts";
 import { TextGeneration } from "../../git/Services/TextGeneration.ts";
-import { resolveTextGenerationInputForSelection } from "../../git/textGenerationSelection.ts";
+import {
+  hasDedicatedTextGenerationProvider,
+  resolveTextGenerationInputForSelection,
+} from "../../git/textGenerationSelection.ts";
 import { OrchestrationEngineService } from "../../orchestration/Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
 import { threadHasInFlightTurn } from "../../orchestration/commandInvariants.ts";
@@ -623,7 +626,10 @@ export const AutomationServiceLive = Layer.effect(
             definition.providerOptions,
           );
           const provider =
-            directInput?.modelSelection.provider ?? settings.textGenerationModelSelection.provider;
+            directInput?.modelSelection.provider ??
+            (hasDedicatedTextGenerationProvider(settings.textGenerationModelSelection.provider)
+              ? settings.textGenerationModelSelection.provider
+              : "codex");
           return settings.providers[provider].enabled
             ? null
             : `${PROVIDER_DISPLAY_NAMES[provider]} is disabled in Settings > Providers.`;

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -1398,7 +1398,11 @@ export const AutomationServiceLive = Layer.effect(
       trigger: AutomationRun["trigger"],
       scheduledFor: string,
       now: string,
-      scheduleAdvance?: { readonly nextRunAt: string | null; readonly disable: boolean },
+      scheduleAdvance?: {
+        readonly nextRunAt: string | null;
+        readonly disable: boolean;
+        readonly consumeIteration?: boolean;
+      },
       deferredUntil?: string | null,
       threadIdOverride?: ThreadId | null,
     ) =>
@@ -3152,17 +3156,19 @@ export const AutomationServiceLive = Layer.effect(
           });
         }
         if (disabledReason) {
-          const { run, inserted } = yield* createPendingRun(
+          const claimedRun = yield* claimPendingRun(
             definition,
             { type: "scheduled" },
             scheduledFor,
             now,
-            { threadIdOverride: null },
+            { nextRunAt, disable: false, consumeIteration: false },
+            undefined,
+            null,
           );
-          const skipped = inserted
-            ? yield* markScheduledRunSkipped(run, disabledReason, now)
+          yield* publishDefinition(definition.id);
+          const skipped = Option.isSome(claimedRun)
+            ? yield* markScheduledRunSkipped(claimedRun.value, disabledReason, now)
             : null;
-          yield* advanceScheduledDefinition(definition, nextRunAt, now);
           return skipped
             ? Option.some<AutomationRunNowResult>({ run: skipped })
             : Option.none<AutomationRunNowResult>();

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -3090,6 +3090,22 @@ export const AutomationServiceLive = Layer.effect(
             onSome: (run) => Option.some({ run }),
           });
         }
+        if (disabledReason) {
+          const { run, inserted } = yield* createPendingRun(
+            definition,
+            { type: "scheduled" },
+            scheduledFor,
+            now,
+            { threadIdOverride: null },
+          );
+          const skipped = inserted
+            ? yield* markScheduledRunSkipped(run, disabledReason, now)
+            : null;
+          yield* advanceScheduledDefinition(definition, nextRunAt, now);
+          return skipped
+            ? Option.some<AutomationRunNowResult>({ run: skipped })
+            : Option.none<AutomationRunNowResult>();
+        }
 
         if (automationRequiresTargetThread(definition.mode) && !definition.targetThreadId) {
           return yield* Effect.fail(
@@ -3209,10 +3225,6 @@ export const AutomationServiceLive = Layer.effect(
         }
 
         const run = claimedRun.value;
-        if (disabledReason) {
-          const skipped = yield* markScheduledRunSkipped(run, disabledReason, now);
-          return Option.some({ run: skipped });
-        }
         const result = yield* dispatchRun(definition, run, now).pipe(
           Effect.catch(() =>
             automationRepository.getRunById({ id: run.id }).pipe(
@@ -3250,6 +3262,17 @@ export const AutomationServiceLive = Layer.effect(
           return Option.none<AutomationRunNowResult>();
         }
         if (!automationContinuesThread(definition.mode)) {
+          const plannedThreadId = run.threadId ?? deriveAutomationRunIds(run.id).threadId;
+          const reserved = yield* automationRepository
+            .reserveDeferredRun({
+              id: run.id,
+              threadId: plannedThreadId,
+              reservedAt: now,
+            })
+            .pipe(Effect.mapError(toServiceError("Failed to reserve deferred automation run.")));
+          if (!reserved) {
+            return Option.none<AutomationRunNowResult>();
+          }
           yield* completeDeferredOneShotDefinition(definition, now);
           const result = yield* dispatchRun(definition, run, now).pipe(
             Effect.catch(() =>

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_AUTOMATION_MINIMUM_INTERVAL_SECONDS,
   DEFAULT_AUTOMATION_STOP_AFTER_CONSECUTIVE_FAILURES,
   MessageId,
+  PROVIDER_DISPLAY_NAMES,
   ThreadId,
   type AutomationAllowedCapability,
   type AutomationCompletionPolicy,
@@ -605,6 +606,15 @@ export const AutomationServiceLive = Layer.effect(
     const git = yield* GitCore;
     const textGeneration = yield* TextGeneration;
     const serverSettings = yield* ServerSettingsService;
+    const providerDisabledReason = (definition: AutomationDefinition) =>
+      serverSettings.getSettings.pipe(
+        Effect.map((settings) =>
+          settings.providers[definition.modelSelection.provider].enabled
+            ? null
+            : `${PROVIDER_DISPLAY_NAMES[definition.modelSelection.provider]} is disabled in Settings > Providers.`,
+        ),
+        Effect.mapError(toServiceError("Failed to read provider settings.")),
+      );
     const orchestrationEngine = yield* OrchestrationEngineService;
     const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
     const projectionTurnRepository = yield* ProjectionTurnRepository;
@@ -2900,6 +2910,14 @@ export const AutomationServiceLive = Layer.effect(
             }),
           );
         }
+        const disabledReason = yield* providerDisabledReason(definition);
+        if (disabledReason) {
+          return yield* Effect.fail(
+            new AutomationServiceError({
+              message: `Automation is paused because ${disabledReason}`,
+            }),
+          );
+        }
         const now = isoNow();
         let heartbeatRunState:
           | { readonly activeRuns: number; readonly pendingCompletionEvaluations: number }
@@ -3056,6 +3074,23 @@ export const AutomationServiceLive = Layer.effect(
           return Option.none<AutomationRunNowResult>();
         }
 
+        const disabledReason = yield* providerDisabledReason(definition);
+        if (disabledReason && definition.schedule.type === "once") {
+          const deferredRun = yield* claimPendingRun(
+            definition,
+            { type: "scheduled" },
+            scheduledFor,
+            now,
+            { nextRunAt, disable: false },
+            new Date(Date.parse(now) + AUTOMATION_HEARTBEAT_DEFER_RETRY_MS).toISOString(),
+          );
+          yield* publishDefinition(definition.id);
+          return Option.match(deferredRun, {
+            onNone: () => Option.none<AutomationRunNowResult>(),
+            onSome: (run) => Option.some({ run }),
+          });
+        }
+
         if (automationRequiresTargetThread(definition.mode) && !definition.targetThreadId) {
           return yield* Effect.fail(
             new AutomationServiceError({
@@ -3174,6 +3209,10 @@ export const AutomationServiceLive = Layer.effect(
         }
 
         const run = claimedRun.value;
+        if (disabledReason) {
+          const skipped = yield* markScheduledRunSkipped(run, disabledReason, now);
+          return Option.some({ run: skipped });
+        }
         const result = yield* dispatchRun(definition, run, now).pipe(
           Effect.catch(() =>
             automationRepository.getRunById({ id: run.id }).pipe(
@@ -3196,12 +3235,36 @@ export const AutomationServiceLive = Layer.effect(
         if (!definition.enabled) {
           return Option.none<AutomationRunNowResult>();
         }
+        const disabledReason = yield* providerDisabledReason(definition);
+        if (disabledReason) {
+          const deferred = yield* automationRepository
+            .setRunDeferred({
+              id: run.id,
+              deferredUntil: new Date(
+                Date.parse(now) + AUTOMATION_HEARTBEAT_DEFER_RETRY_MS,
+              ).toISOString(),
+              updatedAt: now,
+            })
+            .pipe(Effect.mapError(toServiceError("Failed to defer automation run.")));
+          yield* publish({ type: "run-upserted", run: deferred });
+          return Option.none<AutomationRunNowResult>();
+        }
         if (!automationContinuesThread(definition.mode)) {
-          return yield* Effect.fail(
-            new AutomationServiceError({
-              message: "Only automation runs that continue a thread may be deferred.",
-            }),
+          yield* completeDeferredOneShotDefinition(definition, now);
+          const result = yield* dispatchRun(definition, run, now).pipe(
+            Effect.catch(() =>
+              automationRepository.getRunById({ id: run.id }).pipe(
+                Effect.mapError(toServiceError("Failed to load automation run.")),
+                Effect.map((runOption) =>
+                  Option.match(runOption, {
+                    onNone: (): AutomationRunNowResult => ({ run }),
+                    onSome: (failed): AutomationRunNowResult => ({ run: failed }),
+                  }),
+                ),
+              ),
+            ),
           );
+          return Option.some(result);
         }
         const deferState = heartbeatDeferState(run.scheduledFor, now);
         const continuationThreadId = automationContinuationThreadId(definition);

--- a/apps/server/src/git/Layers/ProviderTextGeneration.test.ts
+++ b/apps/server/src/git/Layers/ProviderTextGeneration.test.ts
@@ -1,6 +1,7 @@
 import { Effect, Layer } from "effect";
 import { describe, expect, it, vi } from "vitest";
 
+import { ServerSettingsService } from "../../serverSettings.ts";
 import {
   CodexTextGeneration,
   CursorTextGeneration,
@@ -90,7 +91,9 @@ function createTextGenerationDouble(label: string) {
   };
 }
 
-function makeProviderTextGenerationTestLayer() {
+function makeProviderTextGenerationTestLayer(
+  settingsOverrides: Parameters<typeof ServerSettingsService.layerTest>[0] = {},
+) {
   const codex = createTextGenerationDouble("codex");
   const cursor = createTextGenerationDouble("cursor");
   const kilo = createTextGenerationDouble("kilo");
@@ -100,12 +103,44 @@ function makeProviderTextGenerationTestLayer() {
     Layer.provide(Layer.succeed(CursorTextGeneration, cursor.service)),
     Layer.provide(Layer.succeed(KiloTextGeneration, kilo.service)),
     Layer.provide(Layer.succeed(OpenCodeTextGeneration, opencode.service)),
+    Layer.provide(ServerSettingsService.layerTest(settingsOverrides)),
   );
 
   return { layer, codex, cursor, kilo, opencode };
 }
 
 describe("ProviderTextGenerationLive", () => {
+  it("blocks generation when the selected provider is disabled", async () => {
+    const { layer, codex, cursor, kilo, opencode } = makeProviderTextGenerationTestLayer({
+      providers: {
+        codex: { enabled: false },
+        cursor: { enabled: false },
+        kilo: { enabled: false },
+        opencode: { enabled: false },
+      },
+    });
+
+    await expect(
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const textGeneration = yield* TextGeneration;
+          return yield* textGeneration.generateDiffSummary({
+            cwd: "/repo",
+            patch: "diff --git a/file.ts b/file.ts",
+            modelSelection: { provider: "codex", model: "gpt-5.5" },
+          });
+        }).pipe(Effect.provide(layer)),
+      ),
+    ).rejects.toMatchObject({
+      _tag: "TextGenerationError",
+      detail: "Codex is disabled in Settings > Providers.",
+    });
+    expect(codex.generateDiffSummary).not.toHaveBeenCalled();
+    expect(cursor.generateDiffSummary).not.toHaveBeenCalled();
+    expect(kilo.generateDiffSummary).not.toHaveBeenCalled();
+    expect(opencode.generateDiffSummary).not.toHaveBeenCalled();
+  });
+
   it("routes standard git-writing models to Codex", async () => {
     const { layer, codex, cursor, opencode } = makeProviderTextGenerationTestLayer();
 

--- a/apps/server/src/git/Layers/ProviderTextGeneration.test.ts
+++ b/apps/server/src/git/Layers/ProviderTextGeneration.test.ts
@@ -141,6 +141,32 @@ describe("ProviderTextGenerationLive", () => {
     expect(opencode.generateDiffSummary).not.toHaveBeenCalled();
   });
 
+  it("routes unsupported selections through the configured supported fallback", async () => {
+    const { layer, codex, cursor } = makeProviderTextGenerationTestLayer({
+      textGenerationModelSelection: { provider: "cursor", model: "composer-2" },
+    });
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const textGeneration = yield* TextGeneration;
+        yield* textGeneration.generateDiffSummary({
+          cwd: "/repo",
+          patch: "diff --git a/file.ts b/file.ts",
+          model: "claude-opus-4-8",
+          modelSelection: { provider: "claudeAgent", model: "claude-opus-4-8" },
+        });
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(codex.generateDiffSummary).not.toHaveBeenCalled();
+    expect(cursor.generateDiffSummary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "composer-2",
+        modelSelection: { provider: "cursor", model: "composer-2" },
+      }),
+    );
+  });
+
   it("routes standard git-writing models to Codex", async () => {
     const { layer, codex, cursor, opencode } = makeProviderTextGenerationTestLayer();
 

--- a/apps/server/src/git/Layers/ProviderTextGeneration.ts
+++ b/apps/server/src/git/Layers/ProviderTextGeneration.ts
@@ -1,6 +1,13 @@
+import { PROVIDER_DISPLAY_NAMES, type ProviderKind } from "@synara/contracts";
 import { Effect, Layer } from "effect";
 
 import { parseOpenCodeModelSlug } from "../../provider/opencodeRuntime.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import { TextGenerationError } from "../Errors.ts";
+import {
+  hasDedicatedTextGenerationProvider,
+  type GitTextGenerationProvider,
+} from "../textGenerationSelection.ts";
 import {
   CodexTextGeneration,
   CursorTextGeneration,
@@ -15,36 +22,123 @@ const makeProviderTextGeneration = Effect.gen(function* () {
   const cursorTextGeneration = yield* CursorTextGeneration;
   const kiloTextGeneration = yield* KiloTextGeneration;
   const openCodeTextGeneration = yield* OpenCodeTextGeneration;
+  const serverSettings = yield* ServerSettingsService;
 
-  const resolveImplementation = (input: {
+  const resolveRequestedProvider = (input: {
     readonly model?: string;
-    readonly modelSelection?: { provider: string };
-  }): TextGenerationShape => {
-    if (input.modelSelection?.provider === "cursor") {
-      return cursorTextGeneration;
+    readonly modelSelection?: { provider: ProviderKind };
+  }): ProviderKind => {
+    if (input.modelSelection?.provider) {
+      return input.modelSelection.provider;
     }
-    if (input.modelSelection?.provider === "kilo") {
-      return kiloTextGeneration;
-    }
-    if (input.modelSelection?.provider === "opencode") {
-      return openCodeTextGeneration;
-    }
-    return parseOpenCodeModelSlug(input.model) !== null
-      ? openCodeTextGeneration
-      : codexTextGeneration;
+    return parseOpenCodeModelSlug(input.model) !== null ? "opencode" : "codex";
   };
 
+  const implementationForProvider = (provider: GitTextGenerationProvider): TextGenerationShape => {
+    switch (provider) {
+      case "cursor":
+        return cursorTextGeneration;
+      case "kilo":
+        return kiloTextGeneration;
+      case "opencode":
+        return openCodeTextGeneration;
+      case "codex":
+        return codexTextGeneration;
+    }
+  };
+
+  const resolveImplementation = (
+    operation: string,
+    input: {
+      readonly model?: string;
+      readonly modelSelection?: { provider: ProviderKind };
+    },
+  ) =>
+    Effect.gen(function* () {
+      const provider = resolveRequestedProvider(input);
+      if (!hasDedicatedTextGenerationProvider(provider)) {
+        return yield* Effect.fail(
+          new TextGenerationError({
+            operation,
+            detail: `${PROVIDER_DISPLAY_NAMES[provider]} does not support Git text generation.`,
+          }),
+        );
+      }
+      const settings = yield* serverSettings.getSettings.pipe(
+        Effect.mapError(
+          (cause) =>
+            new TextGenerationError({
+              operation,
+              detail: "Failed to read provider enablement settings.",
+              cause,
+            }),
+        ),
+      );
+      if (!settings.providers[provider].enabled) {
+        return yield* Effect.fail(
+          new TextGenerationError({
+            operation,
+            detail: `${PROVIDER_DISPLAY_NAMES[provider]} is disabled in Settings > Providers.`,
+          }),
+        );
+      }
+      return implementationForProvider(provider);
+    });
+
+  const runWithProvider = <Output>(
+    operation: string,
+    input: {
+      readonly model?: string;
+      readonly modelSelection?: { provider: ProviderKind };
+    },
+    run: (implementation: TextGenerationShape) => Effect.Effect<Output, TextGenerationError>,
+  ) => resolveImplementation(operation, input).pipe(Effect.flatMap(run));
+
+  const call = <
+    Input extends { readonly model?: string; readonly modelSelection?: { provider: ProviderKind } },
+    Output,
+  >(
+    operation: string,
+    input: Input,
+    run: (
+      implementation: TextGenerationShape,
+      input: Input,
+    ) => Effect.Effect<Output, TextGenerationError>,
+  ) => runWithProvider(operation, input, (implementation) => run(implementation, input));
+
   return {
-    generateCommitMessage: (input) => resolveImplementation(input).generateCommitMessage(input),
-    generatePrContent: (input) => resolveImplementation(input).generatePrContent(input),
-    generateDiffSummary: (input) => resolveImplementation(input).generateDiffSummary(input),
-    generateBranchName: (input) => resolveImplementation(input).generateBranchName(input),
-    generateThreadTitle: (input) => resolveImplementation(input).generateThreadTitle(input),
-    generateThreadRecap: (input) => resolveImplementation(input).generateThreadRecap(input),
+    generateCommitMessage: (input) =>
+      call("generateCommitMessage", input, (implementation, value) =>
+        implementation.generateCommitMessage(value),
+      ),
+    generatePrContent: (input) =>
+      call("generatePrContent", input, (implementation, value) =>
+        implementation.generatePrContent(value),
+      ),
+    generateDiffSummary: (input) =>
+      call("generateDiffSummary", input, (implementation, value) =>
+        implementation.generateDiffSummary(value),
+      ),
+    generateBranchName: (input) =>
+      call("generateBranchName", input, (implementation, value) =>
+        implementation.generateBranchName(value),
+      ),
+    generateThreadTitle: (input) =>
+      call("generateThreadTitle", input, (implementation, value) =>
+        implementation.generateThreadTitle(value),
+      ),
+    generateThreadRecap: (input) =>
+      call("generateThreadRecap", input, (implementation, value) =>
+        implementation.generateThreadRecap(value),
+      ),
     generateAutomationIntent: (input) =>
-      resolveImplementation(input).generateAutomationIntent(input),
+      call("generateAutomationIntent", input, (implementation, value) =>
+        implementation.generateAutomationIntent(value),
+      ),
     evaluateAutomationCompletion: (input) =>
-      resolveImplementation(input).evaluateAutomationCompletion(input),
+      call("evaluateAutomationCompletion", input, (implementation, value) =>
+        implementation.evaluateAutomationCompletion(value),
+      ),
   } satisfies TextGenerationShape;
 });
 

--- a/apps/server/src/git/Layers/ProviderTextGeneration.ts
+++ b/apps/server/src/git/Layers/ProviderTextGeneration.ts
@@ -2,6 +2,7 @@ import { PROVIDER_DISPLAY_NAMES, type ModelSelection, type ProviderKind } from "
 import { Effect, Layer } from "effect";
 
 import { parseOpenCodeModelSlug } from "../../provider/opencodeRuntime.ts";
+import { providerDisabledSettingsMessage } from "../../provider/enabledProviderAdapter.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { TextGenerationError } from "../Errors.ts";
 import {
@@ -82,7 +83,7 @@ const makeProviderTextGeneration = Effect.gen(function* () {
         return yield* Effect.fail(
           new TextGenerationError({
             operation,
-            detail: `${PROVIDER_DISPLAY_NAMES[provider]} is disabled in Settings > Providers.`,
+            detail: providerDisabledSettingsMessage(provider),
           }),
         );
       }

--- a/apps/server/src/git/Layers/ProviderTextGeneration.ts
+++ b/apps/server/src/git/Layers/ProviderTextGeneration.ts
@@ -1,4 +1,4 @@
-import { PROVIDER_DISPLAY_NAMES, type ProviderKind } from "@synara/contracts";
+import { PROVIDER_DISPLAY_NAMES, type ModelSelection, type ProviderKind } from "@synara/contracts";
 import { Effect, Layer } from "effect";
 
 import { parseOpenCodeModelSlug } from "../../provider/opencodeRuntime.ts";
@@ -26,7 +26,7 @@ const makeProviderTextGeneration = Effect.gen(function* () {
 
   const resolveRequestedProvider = (input: {
     readonly model?: string;
-    readonly modelSelection?: { provider: ProviderKind };
+    readonly modelSelection?: ModelSelection;
   }): ProviderKind => {
     if (input.modelSelection?.provider) {
       return input.modelSelection.provider;
@@ -51,19 +51,11 @@ const makeProviderTextGeneration = Effect.gen(function* () {
     operation: string,
     input: {
       readonly model?: string;
-      readonly modelSelection?: { provider: ProviderKind };
+      readonly modelSelection?: ModelSelection;
     },
   ) =>
     Effect.gen(function* () {
-      const provider = resolveRequestedProvider(input);
-      if (!hasDedicatedTextGenerationProvider(provider)) {
-        return yield* Effect.fail(
-          new TextGenerationError({
-            operation,
-            detail: `${PROVIDER_DISPLAY_NAMES[provider]} does not support Git text generation.`,
-          }),
-        );
-      }
+      const requestedProvider = resolveRequestedProvider(input);
       const settings = yield* serverSettings.getSettings.pipe(
         Effect.mapError(
           (cause) =>
@@ -74,6 +66,18 @@ const makeProviderTextGeneration = Effect.gen(function* () {
             }),
         ),
       );
+      const fallbackModelSelection = hasDedicatedTextGenerationProvider(requestedProvider)
+        ? undefined
+        : settings.textGenerationModelSelection;
+      const provider = fallbackModelSelection?.provider ?? requestedProvider;
+      if (!hasDedicatedTextGenerationProvider(provider)) {
+        return yield* Effect.fail(
+          new TextGenerationError({
+            operation,
+            detail: `${PROVIDER_DISPLAY_NAMES[requestedProvider]} does not support Git text generation, and no supported fallback is enabled.`,
+          }),
+        );
+      }
       if (!settings.providers[provider].enabled) {
         return yield* Effect.fail(
           new TextGenerationError({
@@ -82,20 +86,14 @@ const makeProviderTextGeneration = Effect.gen(function* () {
           }),
         );
       }
-      return implementationForProvider(provider);
+      return {
+        implementation: implementationForProvider(provider),
+        fallbackModelSelection,
+      };
     });
 
-  const runWithProvider = <Output>(
-    operation: string,
-    input: {
-      readonly model?: string;
-      readonly modelSelection?: { provider: ProviderKind };
-    },
-    run: (implementation: TextGenerationShape) => Effect.Effect<Output, TextGenerationError>,
-  ) => resolveImplementation(operation, input).pipe(Effect.flatMap(run));
-
   const call = <
-    Input extends { readonly model?: string; readonly modelSelection?: { provider: ProviderKind } },
+    Input extends { readonly model?: string; readonly modelSelection?: ModelSelection },
     Output,
   >(
     operation: string,
@@ -104,7 +102,21 @@ const makeProviderTextGeneration = Effect.gen(function* () {
       implementation: TextGenerationShape,
       input: Input,
     ) => Effect.Effect<Output, TextGenerationError>,
-  ) => runWithProvider(operation, input, (implementation) => run(implementation, input));
+  ) =>
+    resolveImplementation(operation, input).pipe(
+      Effect.flatMap(({ implementation, fallbackModelSelection }) =>
+        run(
+          implementation,
+          fallbackModelSelection
+            ? ({
+                ...input,
+                model: fallbackModelSelection.model,
+                modelSelection: fallbackModelSelection,
+              } as Input)
+            : input,
+        ),
+      ),
+    );
 
   return {
     generateCommitMessage: (input) =>

--- a/apps/server/src/git/runtimeLayer.ts
+++ b/apps/server/src/git/runtimeLayer.ts
@@ -12,6 +12,7 @@ import {
 } from "./Layers/OpenCodeTextGeneration";
 import { ProviderTextGenerationLive } from "./Layers/ProviderTextGeneration";
 import { OpenCodeRuntimeLive } from "../provider/opencodeRuntime";
+import { ServerSettingsLive } from "../serverSettings";
 import {
   makeProviderServerPasswordResolver,
   ProviderCredentials,
@@ -35,6 +36,7 @@ export const TextGenerationLayerLive = ProviderTextGenerationLive.pipe(
   Layer.provide(CodexTextGenerationServiceLive),
   Layer.provide(CursorTextGenerationServiceLive),
   Layer.provide(textGenerationProviderLayers),
+  Layer.provide(ServerSettingsLive),
 );
 
 export const GitManagerLayerLive = GitManagerLive.pipe(

--- a/apps/server/src/git/textGenerationSelection.ts
+++ b/apps/server/src/git/textGenerationSelection.ts
@@ -1,15 +1,26 @@
 import type { ModelSelection, ProviderKind, ProviderStartOptions } from "@synara/contracts";
 
+export const GIT_TEXT_GENERATION_PROVIDER_ORDER = [
+  "codex",
+  "cursor",
+  "kilo",
+  "opencode",
+] as const satisfies readonly ProviderKind[];
+
+export type GitTextGenerationProvider = (typeof GIT_TEXT_GENERATION_PROVIDER_ORDER)[number];
+
+const GIT_TEXT_GENERATION_PROVIDER_SET = new Set<ProviderKind>(GIT_TEXT_GENERATION_PROVIDER_ORDER);
+
 export interface TextGenerationProviderInput {
   readonly modelSelection: ModelSelection;
   readonly providerOptions?: ProviderStartOptions;
   readonly codexHomePath?: string;
 }
 
-export function hasDedicatedTextGenerationProvider(provider: ProviderKind | undefined): boolean {
-  return (
-    provider === "codex" || provider === "cursor" || provider === "kilo" || provider === "opencode"
-  );
+export function hasDedicatedTextGenerationProvider(
+  provider: ProviderKind | undefined,
+): provider is GitTextGenerationProvider {
+  return provider !== undefined && GIT_TEXT_GENERATION_PROVIDER_SET.has(provider);
 }
 
 export function resolveTextGenerationInputForSelection(

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -39,8 +39,10 @@ import { ProjectFaviconResolver } from "./project/Services/ProjectFaviconResolve
 import { OrchestrationEngineService } from "./orchestration/Services/OrchestrationEngine";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery";
 import { ProviderAdapterRegistry } from "./provider/Services/ProviderAdapterRegistry";
+import { getEnabledProviderAdapter } from "./provider/enabledProviderAdapter";
 import { threadArchiveChunks, threadArchiveFileName } from "./orchestration/exportThreadArchive";
 import type { ServerReadiness } from "./server/readiness";
+import { ServerSettingsService } from "./serverSettings";
 import { isLoopbackHost } from "./startupAccess";
 import {
   attachmentPrincipalForSession,
@@ -994,7 +996,8 @@ const binaryUploadEffectHandler = Effect.gen(function* () {
     return yield* Effect.gen(function* () {
       const bytes = yield* readEffectBinary(request, SERVER_VOICE_TRANSCRIPTION_MAX_AUDIO_BYTES);
       const registry = yield* ProviderAdapterRegistry;
-      const adapter = yield* registry.getByProvider(provider as never);
+      const serverSettings = yield* ServerSettingsService;
+      const adapter = yield* getEnabledProviderAdapter(provider as never, serverSettings, registry);
       if (!adapter.transcribeVoice) {
         return HttpServerResponse.jsonUnsafe(
           { error: `Voice transcription is unavailable for provider '${provider}'.` },

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -7,7 +7,18 @@
  * @module CliConfig
  */
 import OS from "node:os";
-import { Config, Data, Effect, FileSystem, Layer, Option, Path, Schema, ServiceMap } from "effect";
+import {
+  Config,
+  Data,
+  Effect,
+  FileSystem,
+  Layer,
+  Option,
+  Path,
+  Schema,
+  ServiceMap,
+  Stream,
+} from "effect";
 import { Command, Flag } from "effect/unstable/cli";
 import { NetService } from "@synara/shared/Net";
 import {
@@ -35,7 +46,7 @@ import * as SqlitePersistence from "./persistence/Layers/Sqlite";
 import { ProviderRuntimeEventRepositoryLive } from "./persistence/Layers/ProviderRuntimeEvents";
 import { makeServerApplicationLayers } from "./serverLayers";
 import { startServerMemoryDiagnostics } from "./memoryDiagnostics";
-import { startClaudeCredentialKeepalive } from "./provider/claudeCredentialKeepalive";
+import { createClaudeCredentialKeepaliveController } from "./provider/claudeCredentialKeepalive";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery";
 import { ProviderSessionReaperLive } from "./provider/Layers/ProviderSessionReaper";
 import { ProviderRuntimeReconcilerLive } from "./provider/Layers/ProviderRuntimeReconciler";
@@ -382,20 +393,26 @@ const makeServerProgram = (input: CliInput) =>
     // Optional Claude OAuth keepalive. Disabled by default because it touches
     // Claude Code auth data in the background; users can opt in with
     // SYNARA_CLAUDE_KEEPALIVE=1.
-    yield* Effect.forkChild(
-      Effect.gen(function* () {
-        const settings = yield* serverSettings.getSettings;
-        if (settings.providers.claudeAgent.enabled === false) {
-          return;
-        }
-        yield* Effect.sync(() =>
-          startClaudeCredentialKeepalive({
-            binaryPath: settings.providers.claudeAgent.binaryPath,
-            homeDir: config.homeDir,
-            log: (message) => Effect.runFork(Effect.logInfo(message)),
-          }),
-        );
-      }),
+    const claudeKeepalive = createClaudeCredentialKeepaliveController({
+      homeDir: config.homeDir,
+      log: (message) => Effect.runFork(Effect.logInfo(message)),
+    });
+    const reconcileClaudeKeepalive = (settings: {
+      readonly providers: {
+        readonly claudeAgent: { readonly enabled: boolean; readonly binaryPath?: string };
+      };
+    }) =>
+      Effect.sync(() =>
+        claudeKeepalive.reconcile({
+          enabled: settings.providers.claudeAgent.enabled,
+          binaryPath: settings.providers.claudeAgent.binaryPath,
+        }),
+      );
+    yield* reconcileClaudeKeepalive(yield* serverSettings.getSettings);
+    yield* serverSettings.streamChanges.pipe(
+      Stream.runForEach(reconcileClaudeKeepalive),
+      Effect.ensuring(Effect.sync(claudeKeepalive.stop)),
+      Effect.forkChild,
     );
 
     yield* Effect.logInfo("Synara running", makeServerStartupLogData(config));

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -410,8 +410,14 @@ const makeServerProgram = (input: CliInput) =>
             : {}),
         }),
       );
+    // Attach before reading the initial snapshot. The settings PubSub does not
+    // replay, so reading first could miss a disable/path update in the small
+    // window before the stream consumer subscribes.
+    const claudeKeepaliveSettingsChanges = yield* serverSettings.streamChanges.pipe(
+      Stream.toQueue({ capacity: "unbounded" }),
+    );
     yield* reconcileClaudeKeepalive(yield* serverSettings.getSettings);
-    yield* serverSettings.streamChanges.pipe(
+    yield* Stream.fromQueue(claudeKeepaliveSettingsChanges).pipe(
       Stream.runForEach(reconcileClaudeKeepalive),
       Effect.ensuring(Effect.sync(claudeKeepalive.stop)),
       Effect.forkChild,

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -405,7 +405,9 @@ const makeServerProgram = (input: CliInput) =>
       Effect.sync(() =>
         claudeKeepalive.reconcile({
           enabled: settings.providers.claudeAgent.enabled,
-          binaryPath: settings.providers.claudeAgent.binaryPath,
+          ...(settings.providers.claudeAgent.binaryPath !== undefined
+            ? { binaryPath: settings.providers.claudeAgent.binaryPath }
+            : {}),
         }),
       );
     yield* reconcileClaudeKeepalive(yield* serverSettings.getSettings);

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -402,7 +402,7 @@ const makeServerProgram = (input: CliInput) =>
         readonly claudeAgent: { readonly enabled: boolean; readonly binaryPath?: string };
       };
     }) =>
-      Effect.sync(() =>
+      Effect.promise(() =>
         claudeKeepalive.reconcile({
           enabled: settings.providers.claudeAgent.enabled,
           ...(settings.providers.claudeAgent.binaryPath !== undefined
@@ -419,7 +419,7 @@ const makeServerProgram = (input: CliInput) =>
     yield* reconcileClaudeKeepalive(yield* serverSettings.getSettings);
     yield* Stream.fromQueue(claudeKeepaliveSettingsChanges).pipe(
       Stream.runForEach(reconcileClaudeKeepalive),
-      Effect.ensuring(Effect.sync(claudeKeepalive.stop)),
+      Effect.ensuring(Effect.promise(() => claudeKeepalive.stop())),
       Effect.forkChild,
     );
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -532,14 +532,12 @@ describe("ProviderCommandReactor", () => {
         } as unknown as TextGenerationShape),
       ),
       Layer.provideMerge(
-        ServerSettingsService.layerTest(
-          {
-            ...input?.serverSettings,
-            ...(input?.gitWritingModelSelection
-              ? { textGenerationModelSelection: input.gitWritingModelSelection }
-              : {}),
-          },
-        ),
+        ServerSettingsService.layerTest({
+          ...input?.serverSettings,
+          ...(input?.gitWritingModelSelection
+            ? { textGenerationModelSelection: input.gitWritingModelSelection }
+            : {}),
+        }),
       ),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -5572,6 +5572,14 @@ describe("ProviderCommandReactor", () => {
         provider: "claudeAgent",
         model: "claude-opus-4-8",
       },
+      serverSettings: {
+        providers: {
+          codex: { enabled: false },
+          cursor: { enabled: false },
+          kilo: { enabled: false },
+          opencode: { enabled: false },
+        },
+      },
     });
     const now = new Date().toISOString();
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -14,6 +14,7 @@ import type {
   ProviderForkThreadResult,
   ProviderRuntimeEvent,
   ProviderSession,
+  ServerSettings,
 } from "@synara/contracts";
 import {
   ApprovalRequestId,
@@ -29,6 +30,7 @@ import {
   TurnId,
 } from "@synara/contracts";
 import { PROVIDER_DELIVERY_BLOCK_SUMMARY } from "@synara/shared/providerDeliveryBlock";
+import type { DeepPartial } from "@synara/shared/Struct";
 import {
   Duration,
   Effect,
@@ -211,6 +213,7 @@ describe("ProviderCommandReactor", () => {
     readonly gatewayOperationId?: string;
     readonly gitWritingModelSelection?: ModelSelection;
     readonly omitStopRuntimeSession?: boolean;
+    readonly serverSettings?: DeepPartial<ServerSettings>;
   }) {
     const now = new Date().toISOString();
     const baseDir = input?.baseDir ?? fs.mkdtempSync(path.join(os.tmpdir(), "synara-reactor-"));
@@ -530,9 +533,12 @@ describe("ProviderCommandReactor", () => {
       ),
       Layer.provideMerge(
         ServerSettingsService.layerTest(
-          input?.gitWritingModelSelection
-            ? { textGenerationModelSelection: input.gitWritingModelSelection }
-            : {},
+          {
+            ...input?.serverSettings,
+            ...(input?.gitWritingModelSelection
+              ? { textGenerationModelSelection: input.gitWritingModelSelection }
+              : {}),
+          },
         ),
       ),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
@@ -562,6 +568,7 @@ describe("ProviderCommandReactor", () => {
         interceptor(command) ?? passthroughDispatch(command, context);
     };
     const reactor = await runtime.runPromise(Effect.service(ProviderCommandReactor));
+    const serverSettings = await runtime.runPromise(Effect.service(ServerSettingsService));
     const deliveryRepository = await runtime.runPromise(
       Effect.service(OrchestrationEventDeliveryRepository),
     );
@@ -627,6 +634,7 @@ describe("ProviderCommandReactor", () => {
     return {
       engine,
       reactor,
+      serverSettings,
       startSession,
       listSessions,
       sendTurn,
@@ -4148,6 +4156,67 @@ describe("ProviderCommandReactor", () => {
     // One scan rechecks the provider's live-turn race before dispatch; the
     // session ensure then performs the only full lookup needed for startup.
     expect(harness.listSessions).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves existing threads while a provider is disabled and resumes after re-enabling", async () => {
+    const harness = await createHarness({
+      threadModelSelection: { provider: "opencode", model: "openai/gpt-5" },
+      serverSettings: { providers: { opencode: { enabled: false } } },
+    });
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-opencode-disabled"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-opencode-disabled"),
+          role: "user",
+          text: "try while disabled",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(async () => (await readHarnessThread(harness))?.session?.status === "error");
+    const disabledThread = await readHarnessThread(harness);
+    expect(disabledThread).toBeDefined();
+    expect(disabledThread?.session?.lastError).toContain(
+      "OpenCode is disabled in Settings > Providers",
+    );
+    expect(harness.startSession).not.toHaveBeenCalled();
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+
+    await Effect.runPromise(
+      harness.serverSettings.updateSettings({ providers: { opencode: { enabled: true } } }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-opencode-reenabled"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-opencode-reenabled"),
+          role: "user",
+          text: "continue after re-enable",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({
+      threadId: ThreadId.makeUnsafe("thread-1"),
+    });
+    expect(harness.sendTurn.mock.calls[0]?.[0].input).toContain("continue after re-enable");
   });
 
   it("routes subagent-thread turn starts to the parent session as steers", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -10,7 +10,6 @@ import {
   type ModelSelection,
   MessageId,
   type OrchestrationEvent,
-  PROVIDER_DISPLAY_NAMES,
   PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
   type ProviderMentionReference,
   type ProviderInteractionMode,
@@ -97,6 +96,7 @@ import {
 } from "../../git/Services/TextGeneration.ts";
 import { resolveTextGenerationInputForSelection } from "../../git/textGenerationSelection.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
+import { providerDisabledSettingsMessage } from "../../provider/enabledProviderAdapter.ts";
 import { resolveProviderDispatchAttachments } from "../../provider/providerAttachmentPaths.ts";
 import { OrchestrationEventDeliveryRepositoryLive } from "../../persistence/Layers/OrchestrationEventDeliveries.ts";
 import { ProjectionPendingInteractionRepositoryLive } from "../../persistence/Layers/ProjectionPendingInteractions.ts";
@@ -1190,7 +1190,7 @@ const make = Effect.gen(function* () {
       return yield* new ProviderAdapterValidationError({
         provider: preferredProvider,
         operation: "thread.turn.start",
-        issue: `${PROVIDER_DISPLAY_NAMES[preferredProvider]} is disabled in Settings > Providers. Re-enable it to continue this thread.`,
+        issue: `${providerDisabledSettingsMessage(preferredProvider)} Re-enable it to continue this thread.`,
       });
     }
     const resolvedProviderOptions = providerStartOptionsFromServerSettings(settings);

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -10,6 +10,7 @@ import {
   type ModelSelection,
   MessageId,
   type OrchestrationEvent,
+  PROVIDER_DISPLAY_NAMES,
   PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
   type ProviderMentionReference,
   type ProviderInteractionMode,
@@ -1184,17 +1185,15 @@ const make = Effect.gen(function* () {
     }
     const preferredProvider: ProviderKind = currentProvider ?? threadProvider;
     const desiredModelSelection = requestedModelSelection ?? thread.modelSelection;
-    const settingsSnapshot = yield* serverSettings.getSnapshot;
-    if (!settingsSnapshot.settings.providers[preferredProvider].enabled) {
+    const settings = yield* serverSettings.getSettings;
+    if (!settings.providers[preferredProvider].enabled) {
       return yield* new ProviderAdapterValidationError({
         provider: preferredProvider,
         operation: "thread.turn.start",
-        issue: `Provider '${preferredProvider}' is disabled in server settings revision ${settingsSnapshot.revision}.`,
+        issue: `${PROVIDER_DISPLAY_NAMES[preferredProvider]} is disabled in Settings > Providers. Re-enable it to continue this thread.`,
       });
     }
-    const resolvedProviderOptions = providerStartOptionsFromServerSettings(
-      settingsSnapshot.settings,
-    );
+    const resolvedProviderOptions = providerStartOptionsFromServerSettings(settings);
     const effectiveCwd = yield* resolveProjectedThreadWorkspaceCwd(thread);
     const workspaceState = resolveThreadWorkspaceState({
       envMode: thread.envMode,

--- a/apps/server/src/orchestration/importThreadRoute.test.ts
+++ b/apps/server/src/orchestration/importThreadRoute.test.ts
@@ -183,6 +183,7 @@ it.effect("rejects imports before inspecting a disabled provider adapter", () =>
       handler({ threadId, externalId: "prepared-before-disable" }),
     );
 
+    assert.ok(failure);
     assert.match(failure.message, /OpenCode is disabled/);
     assert.equal(getByProvider.mock.calls.length, 0);
     assert.equal(startSession.mock.calls.length, 0);

--- a/apps/server/src/orchestration/importThreadRoute.test.ts
+++ b/apps/server/src/orchestration/importThreadRoute.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+  DEFAULT_SERVER_SETTINGS,
   type OrchestrationCommand,
   type OrchestrationThread,
   ProjectId,
@@ -12,6 +13,7 @@ import { Effect, FileSystem, Option, Path } from "effect";
 
 import type { ProviderAdapterRegistryShape } from "../provider/Services/ProviderAdapterRegistry";
 import type { ProviderServiceShape } from "../provider/Services/ProviderService";
+import type { ServerSettingsShape } from "../serverSettings";
 import type { OrchestrationEngineShape } from "./Services/OrchestrationEngine";
 import type { ProjectionSnapshotQueryShape } from "./Services/ProjectionSnapshotQuery";
 import { makeImportThreadHandler } from "./importThreadRoute";
@@ -112,6 +114,9 @@ it.effect("imports Codex history through a provider-owned fork", () =>
         startSession,
         stopSession: () => Effect.void,
       } as unknown as ProviderServiceShape,
+      serverSettings: {
+        getSettings: Effect.succeed(DEFAULT_SERVER_SETTINGS),
+      } as unknown as ServerSettingsShape,
     });
 
     const result = yield* handler({ threadId, externalId });
@@ -129,5 +134,57 @@ it.effect("imports Codex history through a provider-owned fork", () =>
     ]);
     assert.deepEqual(readThread.mock.calls, [[threadId]]);
     assert.equal(dispatchedCommands.at(-1)?.type, "thread.session.set");
+  }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.effect("rejects imports before inspecting a disabled provider adapter", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const thread = {
+      ...makeCodexThread(),
+      modelSelection: { provider: "opencode" as const, model: "openai/gpt-5" },
+    };
+    const getByProvider = vi.fn(() => Effect.die("disabled provider adapter must not be read"));
+    const startSession = vi.fn(() => Effect.die("disabled provider session must not start"));
+
+    const handler = makeImportThreadHandler({
+      fileSystem,
+      path,
+      platform: process.platform,
+      orchestrationEngine: {
+        dispatch: () => Effect.die("disabled import must not dispatch"),
+      } as unknown as OrchestrationEngineShape,
+      projectionSnapshotQuery: {
+        getThreadDetailById: () => Effect.succeed(Option.some(thread)),
+        getProjectShellById: () => Effect.die("disabled import must stop before project lookup"),
+      } as unknown as ProjectionSnapshotQueryShape,
+      providerAdapterRegistry: {
+        getByProvider,
+      } as unknown as ProviderAdapterRegistryShape,
+      providerService: {
+        startSession,
+      } as unknown as ProviderServiceShape,
+      serverSettings: {
+        getSettings: Effect.succeed({
+          ...DEFAULT_SERVER_SETTINGS,
+          providers: {
+            ...DEFAULT_SERVER_SETTINGS.providers,
+            opencode: {
+              ...DEFAULT_SERVER_SETTINGS.providers.opencode,
+              enabled: false,
+            },
+          },
+        }),
+      } as unknown as ServerSettingsShape,
+    });
+
+    const failure = yield* Effect.flip(
+      handler({ threadId, externalId: "prepared-before-disable" }),
+    );
+
+    assert.match(failure.message, /OpenCode is disabled/);
+    assert.equal(getByProvider.mock.calls.length, 0);
+    assert.equal(startSession.mock.calls.length, 0);
   }).pipe(Effect.provide(NodeServices.layer)),
 );

--- a/apps/server/src/orchestration/importThreadRoute.ts
+++ b/apps/server/src/orchestration/importThreadRoute.ts
@@ -19,10 +19,12 @@ import { Data, Effect, Option } from "effect";
 
 import { resolveThreadWorkspaceCwd } from "../checkpointing/Utils";
 import { loadClaudeAgentSdk } from "../provider/claudeAgentSdk.ts";
+import { ensureProviderEnabled } from "../provider/enabledProviderAdapter";
 import type { OrchestrationEngineShape } from "./Services/OrchestrationEngine";
 import type { ProjectionSnapshotQueryShape } from "./Services/ProjectionSnapshotQuery";
 import type { ProviderAdapterRegistryShape } from "../provider/Services/ProviderAdapterRegistry";
 import type { ProviderServiceShape } from "../provider/Services/ProviderService";
+import type { ServerSettingsShape } from "../serverSettings";
 import { parseManagedWorktreeWorkspaceRoot } from "../workspace/managedWorktree";
 import {
   mapClaudeSessionMessages,
@@ -81,6 +83,7 @@ export interface ImportThreadHandlerOptions {
   readonly projectionSnapshotQuery: ProjectionSnapshotQueryShape;
   readonly providerAdapterRegistry: ProviderAdapterRegistryShape;
   readonly providerService: ProviderServiceShape;
+  readonly serverSettings: ServerSettingsShape;
 }
 
 export function makeImportThreadHandler(options: ImportThreadHandlerOptions) {
@@ -351,6 +354,8 @@ export function makeImportThreadHandler(options: ImportThreadHandlerOptions) {
         importMessagesError(`Thread '${body.threadId}' already has an active provider session.`),
       );
     }
+
+    yield* ensureProviderEnabled(thread.modelSelection.provider, options.serverSettings);
 
     const projectOption = yield* options.projectionSnapshotQuery.getProjectShellById(
       thread.projectId,

--- a/apps/server/src/persistence/Layers/AutomationRepository.test.ts
+++ b/apps/server/src/persistence/Layers/AutomationRepository.test.ts
@@ -144,6 +144,51 @@ layer("AutomationRepository", (it) => {
     }),
   );
 
+  it.effect("atomically advances a skipped occurrence without consuming an iteration", () =>
+    Effect.gen(function* () {
+      const repository = yield* AutomationRepository;
+      yield* runMigrations();
+      const definition = yield* repository.createDefinition({
+        id: AutomationId.makeUnsafe("automation-skipped-occurrence"),
+        input: {
+          ...createInputForProject("project-skipped-occurrence"),
+          schedule: { type: "interval", everySeconds: 300 },
+        },
+        now: "2026-06-16T10:00:00.000Z",
+      });
+
+      const claimed = yield* repository.createRunAndIncrementDefinition(
+        {
+          id: AutomationRunId.makeUnsafe("run-skipped-occurrence"),
+          automationId: definition.id,
+          projectId: definition.projectId,
+          threadId: null,
+          trigger: { type: "scheduled" },
+          scheduledFor: "2026-06-16T10:00:00.000Z",
+          permissionSnapshot,
+          now: "2026-06-16T10:00:01.000Z",
+        },
+        {
+          nextRunAt: "2026-06-16T10:05:00.000Z",
+          disable: false,
+          expectedDefinitionUpdatedAt: definition.updatedAt,
+          consumeIteration: false,
+        },
+      );
+
+      assert.isTrue(Option.isSome(claimed));
+      const reloaded = Option.getOrThrow(
+        yield* repository.getDefinitionById({ id: definition.id }),
+      );
+      assert.strictEqual(reloaded.iterationCount, 0);
+      assert.strictEqual(reloaded.nextRunAt, "2026-06-16T10:05:00.000Z");
+      yield* repository.archiveDefinition({
+        id: definition.id,
+        archivedAt: "2026-06-16T10:00:02.000Z",
+      });
+    }),
+  );
+
   it.effect("decodes a pre-007 persisted definition row with additive defaults", () =>
     Effect.gen(function* () {
       const repository = yield* AutomationRepository;

--- a/apps/server/src/persistence/Layers/AutomationRepository.ts
+++ b/apps/server/src/persistence/Layers/AutomationRepository.ts
@@ -166,6 +166,7 @@ const ClaimAutomationIterationInput = Schema.Struct({
   id: AutomationDefinition.fields.id,
   now: Schema.String,
   expectedDefinitionUpdatedAt: Schema.NullOr(Schema.String),
+  consumeIteration: Schema.Number,
 });
 
 function toDefinition(row: AutomationDefinitionDbRow) {
@@ -1465,10 +1466,11 @@ const makeAutomationRepository = Effect.gen(function* () {
   const incrementIterationIfRunnableRow = SqlSchema.findAll({
     Request: ClaimAutomationIterationInput,
     Result: Schema.Struct({ id: AutomationDefinition.fields.id }),
-    execute: ({ id, now, expectedDefinitionUpdatedAt }) =>
+    execute: ({ id, now, expectedDefinitionUpdatedAt, consumeIteration }) =>
       sql`
         UPDATE automation_definitions
-        SET iteration_count = iteration_count + 1, updated_at = ${now}
+        SET iteration_count = iteration_count + CASE WHEN ${consumeIteration} = 1 THEN 1 ELSE 0 END,
+            updated_at = ${now}
         WHERE automation_id = ${id}
           AND archived_at IS NULL
           AND (max_iterations IS NULL OR iteration_count < max_iterations)
@@ -1753,11 +1755,12 @@ const makeAutomationRepository = Effect.gen(function* () {
           Effect.gen(function* () {
             const run = yield* createRun(input);
             const inserted = run.id === input.id;
-            if (inserted) {
+            if (inserted || scheduleAdvance !== undefined) {
               const updated = yield* incrementIterationIfRunnableRow({
                 id: input.automationId,
                 now: input.now,
                 expectedDefinitionUpdatedAt: scheduleAdvance?.expectedDefinitionUpdatedAt ?? null,
+                consumeIteration: inserted && scheduleAdvance?.consumeIteration !== false ? 1 : 0,
               });
               if (updated.length === 0) {
                 return yield* Effect.fail(new AutomationRunClaimRejected());

--- a/apps/server/src/persistence/Services/AutomationRepository.ts
+++ b/apps/server/src/persistence/Services/AutomationRepository.ts
@@ -367,13 +367,14 @@ export interface AutomationRepositoryShape {
   readonly createRun: (
     input: CreateAutomationRunInput,
   ) => Effect.Effect<AutomationRun, AutomationRepositoryError>;
-  /** Atomically inserts a fresh run and consumes one definition iteration. */
+  /** Atomically inserts a fresh run, claims the definition, and advances its schedule. */
   readonly createRunAndIncrementDefinition: (
     input: CreateAutomationRunInput,
     scheduleAdvance?: {
       readonly nextRunAt: string | null;
       readonly disable: boolean;
       readonly expectedDefinitionUpdatedAt: string;
+      readonly consumeIteration?: boolean;
     },
   ) => Effect.Effect<Option.Option<AutomationRun>, AutomationRepositoryError>;
   readonly getRunById: (

--- a/apps/server/src/provider/Layers/ProviderDiscoveryService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderDiscoveryService.test.ts
@@ -231,17 +231,9 @@ describe("ProviderDiscoveryService.getComposerCapabilities", () => {
 });
 
 describe("ProviderDiscoveryService.listModels", () => {
-  it("skips OpenCode discovery while disabled and resumes it after re-enabling", async () => {
+  it("skips OpenCode agent and command discovery until re-enabled", async () => {
     const adapterCalls: string[] = [];
     const adapter: Partial<ProviderAdapterShape<ProviderAdapterError>> = {
-      listModels: () => {
-        adapterCalls.push("models");
-        return Effect.succeed({
-          models: [{ slug: "openai/gpt-5", name: "GPT-5" }],
-          source: "opencode",
-          cached: false,
-        });
-      },
       listAgents: () => {
         adapterCalls.push("agents");
         return Effect.succeed({ agents: [], source: "opencode", cached: false });
@@ -264,29 +256,23 @@ describe("ProviderDiscoveryService.listModels", () => {
       Effect.gen(function* () {
         const discovery = yield* ProviderDiscoveryService;
         const settings = yield* ServerSettingsService;
-        const disabledModels = yield* discovery.listModels({ provider: "opencode", cwd });
         const disabledAgents = yield* discovery.listAgents({ provider: "opencode", cwd });
         const disabledCommands = yield* discovery.listCommands({ provider: "opencode", cwd });
 
         yield* settings.updateSettings({ providers: { opencode: { enabled: true } } });
-        const enabledModels = yield* discovery.listModels({ provider: "opencode", cwd });
         const enabledAgents = yield* discovery.listAgents({ provider: "opencode", cwd });
         const enabledCommands = yield* discovery.listCommands({ provider: "opencode", cwd });
 
         return {
-          disabledModels,
           disabledAgents,
           disabledCommands,
-          enabledModels,
           enabledAgents,
           enabledCommands,
         };
       }).pipe(Effect.provide(testLayer)) as Effect.Effect<
         {
-          disabledModels: ProviderListModelsResult;
           disabledAgents: ProviderListAgentsResult;
           disabledCommands: ProviderListCommandsResult;
-          enabledModels: ProviderListModelsResult;
           enabledAgents: ProviderListAgentsResult;
           enabledCommands: ProviderListCommandsResult;
         },
@@ -295,13 +281,11 @@ describe("ProviderDiscoveryService.listModels", () => {
       >,
     );
 
-    expect(result.disabledModels).toMatchObject({ models: [], source: "disabled" });
     expect(result.disabledAgents).toMatchObject({ agents: [], source: "disabled" });
     expect(result.disabledCommands).toMatchObject({ commands: [], source: "disabled" });
-    expect(result.enabledModels.models).toHaveLength(1);
     expect(result.enabledAgents.source).toBe("opencode");
     expect(result.enabledCommands.source).toBe("opencode");
-    expect(adapterCalls).toEqual(["models", "agents", "commands"]);
+    expect(adapterCalls).toEqual(["agents", "commands"]);
   });
 
   it("does not invoke the adapter for a disabled provider", async () => {

--- a/apps/server/src/provider/Layers/ProviderDiscoveryService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderDiscoveryService.test.ts
@@ -12,6 +12,8 @@ import * as path from "node:path";
 import type {
   ProviderComposerCapabilities,
   ProviderKind,
+  ProviderListAgentsResult,
+  ProviderListCommandsResult,
   ProviderListModelsResult,
   ProviderListSkillsResult,
 } from "@synara/contracts";
@@ -229,6 +231,79 @@ describe("ProviderDiscoveryService.getComposerCapabilities", () => {
 });
 
 describe("ProviderDiscoveryService.listModels", () => {
+  it("skips OpenCode discovery while disabled and resumes it after re-enabling", async () => {
+    const adapterCalls: string[] = [];
+    const adapter: Partial<ProviderAdapterShape<ProviderAdapterError>> = {
+      listModels: () => {
+        adapterCalls.push("models");
+        return Effect.succeed({
+          models: [{ slug: "openai/gpt-5", name: "GPT-5" }],
+          source: "opencode",
+          cached: false,
+        });
+      },
+      listAgents: () => {
+        adapterCalls.push("agents");
+        return Effect.succeed({ agents: [], source: "opencode", cached: false });
+      },
+      listCommands: () => {
+        adapterCalls.push("commands");
+        return Effect.succeed({ commands: [], source: "opencode", cached: false });
+      },
+    };
+    const baseLayer = Layer.mergeAll(
+      makeConfigLayer(),
+      ServerSettingsService.layerTest({
+        providers: { opencode: { enabled: false } },
+      }),
+      makeRegistryLayer(adapter),
+    ).pipe(Layer.provideMerge(NodeServices.layer));
+    const testLayer = ProviderDiscoveryServiceLive.pipe(Layer.provideMerge(baseLayer));
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const discovery = yield* ProviderDiscoveryService;
+        const settings = yield* ServerSettingsService;
+        const disabledModels = yield* discovery.listModels({ provider: "opencode", cwd });
+        const disabledAgents = yield* discovery.listAgents({ provider: "opencode", cwd });
+        const disabledCommands = yield* discovery.listCommands({ provider: "opencode", cwd });
+
+        yield* settings.updateSettings({ providers: { opencode: { enabled: true } } });
+        const enabledModels = yield* discovery.listModels({ provider: "opencode", cwd });
+        const enabledAgents = yield* discovery.listAgents({ provider: "opencode", cwd });
+        const enabledCommands = yield* discovery.listCommands({ provider: "opencode", cwd });
+
+        return {
+          disabledModels,
+          disabledAgents,
+          disabledCommands,
+          enabledModels,
+          enabledAgents,
+          enabledCommands,
+        };
+      }).pipe(Effect.provide(testLayer)) as Effect.Effect<
+        {
+          disabledModels: ProviderListModelsResult;
+          disabledAgents: ProviderListAgentsResult;
+          disabledCommands: ProviderListCommandsResult;
+          enabledModels: ProviderListModelsResult;
+          enabledAgents: ProviderListAgentsResult;
+          enabledCommands: ProviderListCommandsResult;
+        },
+        never,
+        never
+      >,
+    );
+
+    expect(result.disabledModels).toMatchObject({ models: [], source: "disabled" });
+    expect(result.disabledAgents).toMatchObject({ agents: [], source: "disabled" });
+    expect(result.disabledCommands).toMatchObject({ commands: [], source: "disabled" });
+    expect(result.enabledModels.models).toHaveLength(1);
+    expect(result.enabledAgents.source).toBe("opencode");
+    expect(result.enabledCommands.source).toBe("opencode");
+    expect(adapterCalls).toEqual(["models", "agents", "commands"]);
+  });
+
   it("does not invoke the adapter for a disabled provider", async () => {
     let adapterCalls = 0;
     const result = await runListModels({

--- a/apps/server/src/provider/Layers/ProviderDiscoveryService.ts
+++ b/apps/server/src/provider/Layers/ProviderDiscoveryService.ts
@@ -89,6 +89,14 @@ const make = Effect.gen(function* () {
   const registry = yield* ProviderAdapterRegistry;
   const serverConfig = yield* ServerConfig;
   const serverSettings = yield* ServerSettingsService;
+  const providerIsEnabled = Effect.fn("providerIsEnabled")(function* (
+    provider: ProviderGetComposerCapabilitiesInput["provider"],
+  ) {
+    return yield* serverSettings.getSettings.pipe(
+      Effect.map((settings) => settings.providers[provider].enabled),
+      Effect.orElseSucceed(() => true),
+    );
+  });
 
   const getComposerCapabilities: ProviderDiscoveryServiceShape["getComposerCapabilities"] = (
     input,
@@ -99,6 +107,9 @@ const make = Effect.gen(function* () {
         schema: ProviderGetComposerCapabilitiesInput,
         payload: input,
       });
+      if (!(yield* providerIsEnabled(parsed.provider))) {
+        return disabledCapabilitiesForProvider(parsed.provider);
+      }
       const adapter = yield* registry.getByProvider(parsed.provider);
       const capabilities = adapter.getComposerCapabilities
         ? yield* adapter.getComposerCapabilities()
@@ -119,6 +130,13 @@ const make = Effect.gen(function* () {
         schema: ProviderListSkillsInput,
         payload: input,
       });
+      if (!(yield* providerIsEnabled(parsed.provider))) {
+        return {
+          skills: [],
+          source: "disabled",
+          cached: false,
+        };
+      }
       const adapter = yield* registry.getByProvider(parsed.provider);
       const nativeResult: ProviderListSkillsResult | null = adapter.listSkills
         ? yield* adapter
@@ -169,6 +187,13 @@ const make = Effect.gen(function* () {
         schema: ProviderListCommandsInput,
         payload: input,
       });
+      if (!(yield* providerIsEnabled(parsed.provider))) {
+        return {
+          commands: [],
+          source: "disabled",
+          cached: false,
+        };
+      }
       const adapter = yield* registry.getByProvider(parsed.provider);
       if (!adapter.listCommands) {
         return {
@@ -187,6 +212,16 @@ const make = Effect.gen(function* () {
         schema: ProviderListPluginsInput,
         payload: input,
       });
+      if (!(yield* providerIsEnabled(parsed.provider))) {
+        return {
+          marketplaces: [],
+          marketplaceLoadErrors: [],
+          remoteSyncError: null,
+          featuredPluginIds: [],
+          source: "disabled",
+          cached: false,
+        };
+      }
       const adapter = yield* registry.getByProvider(parsed.provider);
       if (!adapter.listPlugins) {
         return {
@@ -208,6 +243,12 @@ const make = Effect.gen(function* () {
         schema: ProviderReadPluginInput,
         payload: input,
       });
+      if (!(yield* providerIsEnabled(parsed.provider))) {
+        return yield* new ProviderValidationError({
+          operation: "ProviderDiscoveryService.readPlugin",
+          issue: `Provider '${parsed.provider}' is disabled in Synara settings.`,
+        });
+      }
       const adapter = yield* registry.getByProvider(parsed.provider);
       if (!adapter.readPlugin) {
         return yield* new ProviderValidationError({
@@ -225,14 +266,7 @@ const make = Effect.gen(function* () {
         schema: ProviderListModelsInput,
         payload: input,
       });
-      // The enabled check is a short-circuit, not a precondition, and
-      // ServerSettingsError is outside this operation's error channel. An
-      // unreadable settings file falls back to discovering models, which is
-      // what this call did before the gate existed.
-      const settings = yield* serverSettings.getSettings.pipe(
-        Effect.catch(() => Effect.succeed(null)),
-      );
-      if (settings !== null && !settings.providers[parsed.provider].enabled) {
+      if (!(yield* providerIsEnabled(parsed.provider))) {
         return {
           models: [],
           source: "disabled",
@@ -261,6 +295,13 @@ const make = Effect.gen(function* () {
         schema: ProviderListAgentsInput,
         payload: input,
       });
+      if (!(yield* providerIsEnabled(parsed.provider))) {
+        return {
+          agents: [],
+          source: "disabled",
+          cached: false,
+        };
+      }
       const adapter = yield* registry.getByProvider(parsed.provider);
       if (!adapter.listAgents) {
         return {

--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -120,6 +120,7 @@ function failingSpawnerLayer(description: string) {
 
 function hangingSpawnerLayer(input: {
   readonly onKill: () => void;
+  readonly onHang?: () => void;
   readonly shouldHang: (args: ReadonlyArray<string>, command: string) => boolean;
 }) {
   const handle = ChildProcessSpawner.makeHandle({
@@ -141,9 +142,11 @@ function hangingSpawnerLayer(input: {
         command: string;
         args: ReadonlyArray<string>;
       };
-      return input.shouldHang(cmd.args, cmd.command)
-        ? Effect.succeed(handle)
-        : Effect.succeed(mockHandle({ stdout: "", stderr: "", code: 0 }));
+      if (!input.shouldHang(cmd.args, cmd.command)) {
+        return Effect.succeed(mockHandle({ stdout: "", stderr: "", code: 0 }));
+      }
+      input.onHang?.();
+      return Effect.succeed(handle);
     }),
   );
 }
@@ -396,6 +399,84 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
         assert.strictEqual(
           kilo?.updateState?.message,
           "Update timed out after 20 milliseconds. The provider process was stopped.",
+        );
+      }),
+    );
+
+    it.effect("stops a running provider update when the provider is disabled", () =>
+      Effect.gen(function* () {
+        let killed = false;
+        let markStarted!: () => void;
+        const started = new Promise<void>((resolve) => {
+          markStarted = resolve;
+        });
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "provider-update-disable-",
+        });
+        yield* writeProviderStatusCache({
+          filePath: resolveProviderStatusCachePath({
+            stateDir: path.join(baseDir, "userdata"),
+            provider: "kilo",
+          }),
+          provider: {
+            provider: "kilo",
+            status: "ready",
+            available: true,
+            authStatus: "authenticated",
+            checkedAt: "2026-07-15T12:00:00.000Z",
+            message: "Kilo CLI is installed and authenticated.",
+            version: "7.3.46",
+          },
+        });
+        const settings = {
+          ...allProvidersDisabledServerSettings,
+          providers: {
+            ...allProvidersDisabledServerSettings.providers,
+            kilo: {
+              ...DEFAULT_SERVER_SETTINGS.providers.kilo,
+              enabled: true,
+              binaryPath:
+                "/Users/test/.nvm/versions/node/v24.13.0/lib/node_modules/@kilocode/cli/bin/kilo",
+            },
+          },
+        } satisfies typeof DEFAULT_SERVER_SETTINGS;
+        const serverSettingsLayer = ServerSettingsService.layerTest(settings);
+        const layer = makeProviderHealthLive({ providerUpdateTimeoutMs: 10_000 }).pipe(
+          Layer.provideMerge(serverSettingsLayer),
+          Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
+          Layer.provideMerge(
+            hangingSpawnerLayer({
+              onKill: () => (killed = true),
+              onHang: markStarted,
+              shouldHang: (args, command) =>
+                command === "npm" &&
+                args.join(" ") ===
+                  "install -g --prefix /Users/test/.nvm/versions/node/v24.13.0 @kilocode/cli@latest",
+            }),
+          ),
+        );
+
+        const result = yield* TestClock.withLive(
+          Effect.gen(function* () {
+            const providerHealth = yield* ProviderHealth;
+            const serverSettings = yield* ServerSettingsService;
+            const updateFiber = yield* providerHealth
+              .updateProvider({ provider: "kilo" })
+              .pipe(Effect.forkChild);
+            yield* Effect.promise(() => started);
+            yield* serverSettings.updateSettings({ providers: { kilo: { enabled: false } } });
+            return yield* Fiber.join(updateFiber);
+          }).pipe(Effect.provide(layer)),
+        );
+        const kilo = result.providers.find((provider) => provider.provider === "kilo");
+
+        assert.strictEqual(killed, true);
+        assert.strictEqual(kilo?.updateState?.status, "failed");
+        assert.strictEqual(
+          kilo?.updateState?.message,
+          "Update stopped because the provider was disabled.",
         );
       }),
     );

--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -2,7 +2,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import type { ServerProviderStatus } from "@synara/contracts";
 import { DEFAULT_SERVER_SETTINGS, ServerProviderUpdateError } from "@synara/contracts";
 import { describe, it, assert } from "@effect/vitest";
-import { Effect, FileSystem, Layer, Path, Sink, Stream } from "effect";
+import { Effect, Fiber, FileSystem, Layer, Path, Sink, Stream } from "effect";
 import { TestClock } from "effect/testing";
 import * as PlatformError from "effect/PlatformError";
 import { ChildProcessSpawner } from "effect/unstable/process";
@@ -49,10 +49,13 @@ import { resolvePackageManagedProviderMaintenance } from "../providerMaintenance
 
 const encoder = new TextEncoder();
 
-function mockHandle(result: { stdout: string; stderr: string; code: number }) {
+function mockHandle(
+  result: { stdout: string; stderr: string; code: number },
+  options?: { readonly exitCode?: Effect.Effect<ChildProcessSpawner.ExitCode> },
+) {
   return ChildProcessSpawner.makeHandle({
     pid: ChildProcessSpawner.ProcessId(1),
-    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(result.code)),
+    exitCode: options?.exitCode ?? Effect.succeed(ChildProcessSpawner.ExitCode(result.code)),
     isRunning: Effect.succeed(false),
     kill: () => Effect.void,
     stdin: Sink.drain,
@@ -562,6 +565,81 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
           assert.strictEqual(status.versionAdvisory?.updateCommand, null);
         }
       }).pipe(Effect.provide(disabledProviderHealthLayer)),
+    );
+
+    it.effect("retries a joined refresh after provider enablement changes its revision", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "provider-health-enable-race-",
+        });
+        const commands: string[] = [];
+        let releaseFirst!: () => void;
+        let markFirstStarted!: () => void;
+        const firstReleased = new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+        const firstStarted = new Promise<void>((resolve) => {
+          markFirstStarted = resolve;
+        });
+        let shouldBlock = true;
+        const spawnerLayer = Layer.succeed(
+          ChildProcessSpawner.ChildProcessSpawner,
+          ChildProcessSpawner.make((command) => {
+            const input = command as unknown as {
+              readonly command: string;
+              readonly args: ReadonlyArray<string>;
+            };
+            commands.push(input.command);
+            const result = input.args.includes("--version")
+              ? { stdout: `${input.command} 1.0.0\n`, stderr: "", code: 0 }
+              : { stdout: '{"authenticated":true}\n', stderr: "", code: 0 };
+            if (!shouldBlock) {
+              return Effect.succeed(mockHandle(result));
+            }
+            shouldBlock = false;
+            markFirstStarted();
+            return Effect.succeed(
+              mockHandle(result, {
+                exitCode: Effect.promise(() => firstReleased).pipe(
+                  Effect.as(ChildProcessSpawner.ExitCode(0)),
+                ),
+              }),
+            );
+          }),
+        );
+        const layer = ProviderHealthLive.pipe(
+          Layer.provideMerge(
+            ServerSettingsService.layerTest({
+              ...allProvidersDisabledSettings,
+              providers: {
+                ...allProvidersDisabledSettings.providers,
+                codex: { enabled: true },
+              },
+            }),
+          ),
+          Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
+          Layer.provideMerge(spawnerLayer),
+        );
+
+        yield* Effect.gen(function* () {
+          const providerHealth = yield* ProviderHealth;
+          const serverSettings = yield* ServerSettingsService;
+          const firstRefresh = yield* providerHealth.refresh.pipe(Effect.forkChild);
+          yield* Effect.promise(() => firstStarted);
+          yield* serverSettings.updateSettings({ providers: { opencode: { enabled: true } } });
+          const joinedRefresh = yield* providerHealth.refresh.pipe(Effect.forkChild);
+          releaseFirst();
+          const statuses = yield* Fiber.join(joinedRefresh);
+          yield* Fiber.join(firstRefresh);
+
+          assert.ok(commands.some((command) => command.includes("opencode")));
+          assert.notStrictEqual(
+            statuses.find((status) => status.provider === "opencode")?.message,
+            "Provider is disabled in Synara settings.",
+          );
+        }).pipe(Effect.provide(layer));
+      }),
     );
 
     it.effect("rejects one-click updates for disabled providers", () =>

--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -567,7 +567,7 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
       }).pipe(Effect.provide(disabledProviderHealthLayer)),
     );
 
-    it.effect("retries a joined refresh after provider enablement changes its revision", () =>
+    it.effect("runs a final probe when settings change during the bounded retry", () =>
       Effect.gen(function* () {
         const fileSystem = yield* FileSystem.FileSystem;
         const baseDir = yield* fileSystem.makeTempDirectoryScoped({
@@ -576,13 +576,21 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
         const commands: string[] = [];
         let releaseFirst!: () => void;
         let markFirstStarted!: () => void;
+        let releaseSecond!: () => void;
+        let markSecondStarted!: () => void;
         const firstReleased = new Promise<void>((resolve) => {
           releaseFirst = resolve;
         });
         const firstStarted = new Promise<void>((resolve) => {
           markFirstStarted = resolve;
         });
-        let shouldBlock = true;
+        const secondReleased = new Promise<void>((resolve) => {
+          releaseSecond = resolve;
+        });
+        const secondStarted = new Promise<void>((resolve) => {
+          markSecondStarted = resolve;
+        });
+        let codexVersionAttempts = 0;
         const spawnerLayer = Layer.succeed(
           ChildProcessSpawner.ChildProcessSpawner,
           ChildProcessSpawner.make((command) => {
@@ -594,16 +602,24 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
             const result = input.args.includes("--version")
               ? { stdout: `${input.command} 1.0.0\n`, stderr: "", code: 0 }
               : { stdout: '{"authenticated":true}\n', stderr: "", code: 0 };
-            if (!shouldBlock) {
+            if (input.command !== "codex" || !input.args.includes("--version")) {
               return Effect.succeed(mockHandle(result));
             }
-            shouldBlock = false;
-            markFirstStarted();
+            codexVersionAttempts += 1;
+            if (codexVersionAttempts > 2) {
+              return Effect.succeed(mockHandle(result));
+            }
+            const isFirstAttempt = codexVersionAttempts === 1;
+            if (isFirstAttempt) {
+              markFirstStarted();
+            } else {
+              markSecondStarted();
+            }
             return Effect.succeed(
               mockHandle(result, {
-                exitCode: Effect.promise(() => firstReleased).pipe(
-                  Effect.as(ChildProcessSpawner.ExitCode(0)),
-                ),
+                exitCode: Effect.promise(() =>
+                  isFirstAttempt ? firstReleased : secondReleased,
+                ).pipe(Effect.as(ChildProcessSpawner.ExitCode(0))),
               }),
             );
           }),
@@ -630,12 +646,20 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
           yield* serverSettings.updateSettings({ providers: { opencode: { enabled: true } } });
           const joinedRefresh = yield* providerHealth.refresh.pipe(Effect.forkChild);
           releaseFirst();
+          yield* Effect.promise(() => secondStarted);
+          yield* serverSettings.updateSettings({ providers: { pi: { enabled: true } } });
+          releaseSecond();
           const statuses = yield* Fiber.join(joinedRefresh);
           yield* Fiber.join(firstRefresh);
 
           assert.ok(commands.some((command) => command.includes("opencode")));
+          assert.ok(commands.some((command) => command.includes("pi")));
           assert.notStrictEqual(
             statuses.find((status) => status.provider === "opencode")?.message,
+            "Provider is disabled in Synara settings.",
+          );
+          assert.notStrictEqual(
+            statuses.find((status) => status.provider === "pi")?.message,
             "Provider is disabled in Synara settings.",
           );
         }).pipe(Effect.provide(layer));

--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -2,7 +2,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import type { ServerProviderStatus } from "@synara/contracts";
 import { DEFAULT_SERVER_SETTINGS, ServerProviderUpdateError } from "@synara/contracts";
 import { describe, it, assert } from "@effect/vitest";
-import { Effect, Fiber, FileSystem, Layer, Path, Sink, Stream } from "effect";
+import { Duration, Effect, Fiber, FileSystem, Layer, Path, Sink, Stream } from "effect";
 import { TestClock } from "effect/testing";
 import * as PlatformError from "effect/PlatformError";
 import { ChildProcessSpawner } from "effect/unstable/process";
@@ -567,29 +567,25 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
       }).pipe(Effect.provide(disabledProviderHealthLayer)),
     );
 
-    it.effect("runs a final probe when settings change during the bounded retry", () =>
+    it.effect("queues another bounded refresh when the follow-up also becomes stale", () =>
       Effect.gen(function* () {
         const fileSystem = yield* FileSystem.FileSystem;
         const baseDir = yield* fileSystem.makeTempDirectoryScoped({
           prefix: "provider-health-enable-race-",
         });
         const commands: string[] = [];
-        let releaseFirst!: () => void;
-        let markFirstStarted!: () => void;
-        let releaseSecond!: () => void;
-        let markSecondStarted!: () => void;
-        const firstReleased = new Promise<void>((resolve) => {
-          releaseFirst = resolve;
-        });
-        const firstStarted = new Promise<void>((resolve) => {
-          markFirstStarted = resolve;
-        });
-        const secondReleased = new Promise<void>((resolve) => {
-          releaseSecond = resolve;
-        });
-        const secondStarted = new Promise<void>((resolve) => {
-          markSecondStarted = resolve;
-        });
+        const makeProbeGate = () => {
+          let release!: () => void;
+          let markStarted!: () => void;
+          const released = new Promise<void>((resolve) => {
+            release = resolve;
+          });
+          const started = new Promise<void>((resolve) => {
+            markStarted = resolve;
+          });
+          return { release, released, markStarted, started };
+        };
+        const probeGates = Array.from({ length: 5 }, makeProbeGate);
         let codexVersionAttempts = 0;
         const spawnerLayer = Layer.succeed(
           ChildProcessSpawner.ChildProcessSpawner,
@@ -605,21 +601,18 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
             if (input.command !== "codex" || !input.args.includes("--version")) {
               return Effect.succeed(mockHandle(result));
             }
+            const attemptIndex = codexVersionAttempts;
             codexVersionAttempts += 1;
-            if (codexVersionAttempts > 2) {
+            const gate = probeGates[attemptIndex];
+            gate?.markStarted();
+            if (!gate || attemptIndex >= 4) {
               return Effect.succeed(mockHandle(result));
-            }
-            const isFirstAttempt = codexVersionAttempts === 1;
-            if (isFirstAttempt) {
-              markFirstStarted();
-            } else {
-              markSecondStarted();
             }
             return Effect.succeed(
               mockHandle(result, {
-                exitCode: Effect.promise(() =>
-                  isFirstAttempt ? firstReleased : secondReleased,
-                ).pipe(Effect.as(ChildProcessSpawner.ExitCode(0))),
+                exitCode: Effect.promise(() => gate.released).pipe(
+                  Effect.as(ChildProcessSpawner.ExitCode(0)),
+                ),
               }),
             );
           }),
@@ -642,24 +635,40 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
           const providerHealth = yield* ProviderHealth;
           const serverSettings = yield* ServerSettingsService;
           const firstRefresh = yield* providerHealth.refresh.pipe(Effect.forkChild);
-          yield* Effect.promise(() => firstStarted);
+          yield* Effect.promise(() => probeGates[0]!.started);
           yield* serverSettings.updateSettings({ providers: { opencode: { enabled: true } } });
           const joinedRefresh = yield* providerHealth.refresh.pipe(Effect.forkChild);
-          releaseFirst();
-          yield* Effect.promise(() => secondStarted);
+          probeGates[0]!.release();
+          yield* Effect.promise(() => probeGates[1]!.started);
           yield* serverSettings.updateSettings({ providers: { pi: { enabled: true } } });
-          releaseSecond();
-          const statuses = yield* Fiber.join(joinedRefresh);
+          probeGates[1]!.release();
+          yield* Effect.promise(() => probeGates[2]!.started);
+          yield* serverSettings.updateSettings({ providers: { grok: { enabled: true } } });
+          probeGates[2]!.release();
+          yield* Effect.promise(() => probeGates[3]!.started);
+          yield* serverSettings.updateSettings({ providers: { droid: { enabled: true } } });
+          probeGates[3]!.release();
+          yield* Fiber.join(joinedRefresh);
           yield* Fiber.join(firstRefresh);
+          yield* Effect.yieldNow;
+          yield* TestClock.adjust(Duration.millis(100));
+          yield* Effect.promise(() => probeGates[4]!.started);
+          const statuses = yield* providerHealth.refresh;
 
           assert.ok(commands.some((command) => command.includes("opencode")));
           assert.ok(commands.some((command) => command.includes("pi")));
+          assert.ok(commands.some((command) => command.includes("grok")));
+          assert.ok(commands.some((command) => command.includes("droid")));
           assert.notStrictEqual(
             statuses.find((status) => status.provider === "opencode")?.message,
             "Provider is disabled in Synara settings.",
           );
           assert.notStrictEqual(
             statuses.find((status) => status.provider === "pi")?.message,
+            "Provider is disabled in Synara settings.",
+          );
+          assert.notStrictEqual(
+            statuses.find((status) => status.provider === "droid")?.message,
             "Provider is disabled in Synara settings.",
           );
         }).pipe(Effect.provide(layer));

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -144,6 +144,7 @@ const providerCommandEnv = (provider: ProviderKind): NodeJS.ProcessEnv =>
 
 const UPDATE_OUTPUT_MAX_BYTES = 10_000;
 const MAX_REFRESH_REVISION_RETRIES = 1;
+const REFRESH_REVISION_RESCHEDULE_DELAY_MS = 100;
 export const PROVIDER_UPDATE_TIMEOUT_MS = 2 * 60_000;
 
 function formatProviderUpdateTimeout(timeoutMs: number): string {
@@ -2504,8 +2505,8 @@ export function makeProviderHealthLive(options?: { readonly providerUpdateTimeou
 
       // Keep a single refresh in flight so repeated config reads do not spawn
       // overlapping CLI probes while the cache already gives us a usable answer.
-      const ensureRefreshFiber: Effect.Effect<Fiber.Fiber<ProviderStatuses, never>> = Effect.gen(
-        function* () {
+      function ensureRefreshFiber(): Effect.Effect<Fiber.Fiber<ProviderStatuses, never>> {
+        return Effect.gen(function* () {
           const inFlight = yield* Ref.get(refreshFiberRef);
           if (inFlight) {
             return inFlight;
@@ -2527,18 +2528,36 @@ export function makeProviderHealthLive(options?: { readonly providerUpdateTimeou
             // foreground refresh fails after startup.
             const rawStatuses = yield* Ref.get(statusesRef);
             return yield* projectStatusesForCurrentSettings(rawStatuses);
-          }).pipe(Effect.ensuring(Ref.set(refreshFiberRef, null)), Effect.forkIn(refreshScope));
+          }).pipe(
+            Effect.ensuring(
+              Effect.gen(function* () {
+                yield* Ref.set(refreshFiberRef, null);
+                if (!(yield* Ref.getAndSet(refreshNeedsFollowUpRef, false))) {
+                  return;
+                }
+                // The bounded follow-up was dirtied too. Debounce one more
+                // shared refresh so a sustained settings burst cannot keep the
+                // current callers stuck or spin CLI probes without a pause.
+                yield* Effect.sleep(Duration.millis(REFRESH_REVISION_RESCHEDULE_DELAY_MS)).pipe(
+                  Effect.andThen(ensureRefreshFiber().pipe(Effect.asVoid)),
+                  Effect.forkIn(refreshScope),
+                  Effect.asVoid,
+                );
+              }),
+            ),
+            Effect.forkIn(refreshScope),
+          );
           yield* Ref.set(refreshFiberRef, refreshFiber);
           return refreshFiber;
-        },
-      );
+        });
+      }
 
       yield* serverSettings.streamChanges.pipe(
         Stream.runForEach(() => publishProjectedStatuses().pipe(Effect.asVoid)),
         Effect.forkIn(refreshScope),
       );
 
-      const refresh: Effect.Effect<ProviderStatuses> = ensureRefreshFiber.pipe(
+      const refresh: Effect.Effect<ProviderStatuses> = ensureRefreshFiber().pipe(
         Effect.flatMap(Fiber.join),
       );
 

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -2456,34 +2456,38 @@ export function makeProviderHealthLive(options?: { readonly providerUpdateTimeou
         );
 
       const refreshNow = Effect.gen(function* () {
-        const refreshRevision = (yield* serverSettings.getSnapshot).revision;
-        // Drop the cached Claude subscription probe so switching accounts (login
-        // / logout / add account outside the app) is reflected on the next
-        // refresh instead of being pinned to the old account for up to 5 minutes.
-        yield* Cache.invalidate(claudeSubscriptionCache, "claude");
-        const loadedStatuses = yield* loadProviderStatuses;
-        if ((yield* serverSettings.getSnapshot).revision !== refreshRevision) {
-          const currentStatuses = yield* Ref.get(statusesRef);
-          return yield* projectStatusesForCurrentSettings(currentStatuses);
-        }
-        const previousRawStatuses = yield* Ref.get(statusesRef);
-        const previousStatuses = yield* projectStatusesForCurrentSettings(previousRawStatuses);
-        const stabilizedLoadedStatuses = stabilizeProviderStatusesAgainstTransientTimeouts(
-          previousRawStatuses,
-          loadedStatuses,
-        );
-        const nextRawStatuses = mergeProviderStatusUpdates(
-          previousRawStatuses,
-          stabilizedLoadedStatuses,
-        );
-        const nextStatuses = yield* projectStatusesForCurrentSettings(nextRawStatuses);
-        yield* Ref.set(statusesRef, nextRawStatuses);
-        if (providerStatusesEqual(previousStatuses, nextStatuses)) {
+        while (true) {
+          const refreshRevision = (yield* serverSettings.getSnapshot).revision;
+          // Drop the cached Claude subscription probe so switching accounts (login
+          // / logout / add account outside the app) is reflected on the next
+          // refresh instead of being pinned to the old account for up to 5 minutes.
+          yield* Cache.invalidate(claudeSubscriptionCache, "claude");
+          const loadedStatuses = yield* loadProviderStatuses;
+          if ((yield* serverSettings.getSnapshot).revision !== refreshRevision) {
+            // A caller that joined this refresh expects the settings mutation it
+            // just made to be reflected. Retry in the same shared fiber so an
+            // enable cannot resolve with the stale pre-mutation probe.
+            continue;
+          }
+          const previousRawStatuses = yield* Ref.get(statusesRef);
+          const previousStatuses = yield* projectStatusesForCurrentSettings(previousRawStatuses);
+          const stabilizedLoadedStatuses = stabilizeProviderStatusesAgainstTransientTimeouts(
+            previousRawStatuses,
+            loadedStatuses,
+          );
+          const nextRawStatuses = mergeProviderStatusUpdates(
+            previousRawStatuses,
+            stabilizedLoadedStatuses,
+          );
+          const nextStatuses = yield* projectStatusesForCurrentSettings(nextRawStatuses);
+          yield* Ref.set(statusesRef, nextRawStatuses);
+          if (providerStatusesEqual(previousStatuses, nextStatuses)) {
+            return nextStatuses;
+          }
+          yield* persistStatuses(nextRawStatuses);
+          yield* PubSub.publish(changesPubSub, nextStatuses);
           return nextStatuses;
         }
-        yield* persistStatuses(nextRawStatuses);
-        yield* PubSub.publish(changesPubSub, nextStatuses);
-        return nextStatuses;
       });
 
       // Keep a single refresh in flight so repeated config reads do not spawn

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -143,6 +143,7 @@ const providerCommandEnv = (provider: ProviderKind): NodeJS.ProcessEnv =>
   buildProviderChildEnvironment({ provider: providerChildKind(provider) });
 
 const UPDATE_OUTPUT_MAX_BYTES = 10_000;
+const MAX_REFRESH_REVISION_RETRIES = 1;
 export const PROVIDER_UPDATE_TIMEOUT_MS = 2 * 60_000;
 
 function formatProviderUpdateTimeout(timeoutMs: number): string {
@@ -2456,6 +2457,7 @@ export function makeProviderHealthLive(options?: { readonly providerUpdateTimeou
         );
 
       const refreshNow = Effect.gen(function* () {
+        let revisionRetries = 0;
         while (true) {
           const refreshRevision = (yield* serverSettings.getSnapshot).revision;
           // Drop the cached Claude subscription probe so switching accounts (login
@@ -2467,7 +2469,12 @@ export function makeProviderHealthLive(options?: { readonly providerUpdateTimeou
             // A caller that joined this refresh expects the settings mutation it
             // just made to be reflected. Retry in the same shared fiber so an
             // enable cannot resolve with the stale pre-mutation probe.
-            continue;
+            if (revisionRetries < MAX_REFRESH_REVISION_RETRIES) {
+              revisionRetries += 1;
+              continue;
+            }
+            const currentStatuses = yield* Ref.get(statusesRef);
+            return yield* projectStatusesForCurrentSettings(currentStatuses);
           }
           const previousRawStatuses = yield* Ref.get(statusesRef);
           const previousStatuses = yield* projectStatusesForCurrentSettings(previousRawStatuses);
@@ -2607,12 +2614,17 @@ export function makeProviderHealthLive(options?: { readonly providerUpdateTimeou
             provider,
             reason: reason instanceof Error ? reason.message : String(reason),
           });
-        const settings = yield* serverSettings.getSettings.pipe(Effect.mapError(toUpdateError));
-        if (!isProviderEnabledForSettings(provider, settings)) {
-          return yield* new ServerProviderUpdateError({
+        const providerIsEnabled = serverSettings.getSettings.pipe(
+          Effect.mapError(toUpdateError),
+          Effect.map((settings) => isProviderEnabledForSettings(provider, settings)),
+        );
+        const disabledError = () =>
+          new ServerProviderUpdateError({
             provider,
             reason: "Provider is disabled in Synara settings.",
           });
+        if (!(yield* providerIsEnabled)) {
+          return yield* disabledError();
         }
         const capabilities = yield* getProviderMaintenanceCapabilities(provider).pipe(
           Effect.mapError(toUpdateError),
@@ -2626,6 +2638,19 @@ export function makeProviderHealthLive(options?: { readonly providerUpdateTimeou
         }
 
         const run = Effect.gen(function* () {
+          if (!(yield* providerIsEnabled)) {
+            const finishedAt = yield* nowIso;
+            yield* setProviderUpdateState(
+              provider,
+              makeUpdateState({
+                status: "failed",
+                startedAt: null,
+                finishedAt,
+                message: "Provider was disabled before its queued update could start.",
+              }),
+            );
+            return yield* disabledError();
+          }
           const startedAt = yield* nowIso;
           yield* setProviderUpdateState(
             provider,

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -2165,6 +2165,7 @@ export function makeProviderHealthLive(options?: { readonly providerUpdateTimeou
         new Map(),
       );
       const refreshFiberRef = yield* Ref.make<Fiber.Fiber<ProviderStatuses, never> | null>(null);
+      const refreshNeedsFollowUpRef = yield* Ref.make(false);
       const commandCoordinator = yield* makeProviderMaintenanceCommandCoordinator({
         makeAlreadyRunningError: (provider) =>
           new ServerProviderUpdateError({
@@ -2473,6 +2474,10 @@ export function makeProviderHealthLive(options?: { readonly providerUpdateTimeou
               revisionRetries += 1;
               continue;
             }
+            // Keep the joined refresh bounded, but queue one final cycle so a
+            // second settings mutation cannot leave the newest provider state
+            // waiting for an unrelated future refresh.
+            yield* Ref.set(refreshNeedsFollowUpRef, true);
             const currentStatuses = yield* Ref.get(statusesRef);
             return yield* projectStatusesForCurrentSettings(currentStatuses);
           }
@@ -2506,7 +2511,15 @@ export function makeProviderHealthLive(options?: { readonly providerUpdateTimeou
             return inFlight;
           }
           const refreshFiber = yield* Effect.gen(function* () {
-            const refreshExit = yield* Effect.exit(refreshNow);
+            const refreshExit = yield* Effect.exit(
+              Effect.gen(function* () {
+                const statuses = yield* refreshNow;
+                if (!(yield* Ref.getAndSet(refreshNeedsFollowUpRef, false))) {
+                  return statuses;
+                }
+                return yield* refreshNow;
+              }),
+            );
             if (Exit.isSuccess(refreshExit)) {
               return refreshExit.value;
             }

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -145,6 +145,7 @@ const providerCommandEnv = (provider: ProviderKind): NodeJS.ProcessEnv =>
 const UPDATE_OUTPUT_MAX_BYTES = 10_000;
 const MAX_REFRESH_REVISION_RETRIES = 1;
 const REFRESH_REVISION_RESCHEDULE_DELAY_MS = 100;
+const PROVIDER_UPDATE_ENABLEMENT_POLL_MS = 100;
 export const PROVIDER_UPDATE_TIMEOUT_MS = 2 * 60_000;
 
 function formatProviderUpdateTimeout(timeoutMs: number): string {
@@ -2694,17 +2695,39 @@ export function makeProviderHealthLive(options?: { readonly providerUpdateTimeou
             }),
           );
 
-          const commandResult = yield* runUpdateCommand({
-            provider,
-            command: update.executable,
-            args: update.args,
-            ...(update.pathPrepend ? { pathPrepend: update.pathPrepend } : {}),
-          }).pipe(
-            Effect.scoped,
-            Effect.timeoutOption(Duration.millis(providerUpdateTimeoutMs)),
-            Effect.result,
+          const waitForProviderDisablement = Effect.gen(function* () {
+            while (yield* providerIsEnabled.pipe(Effect.catch(() => Effect.succeed(true)))) {
+              yield* Effect.sleep(Duration.millis(PROVIDER_UPDATE_ENABLEMENT_POLL_MS));
+            }
+          });
+          const commandOutcome = yield* Effect.raceFirst(
+            runUpdateCommand({
+              provider,
+              command: update.executable,
+              args: update.args,
+              ...(update.pathPrepend ? { pathPrepend: update.pathPrepend } : {}),
+            }).pipe(
+              Effect.scoped,
+              Effect.timeoutOption(Duration.millis(providerUpdateTimeoutMs)),
+              Effect.result,
+              Effect.map((result) => ({ _tag: "completed" as const, result })),
+            ),
+            waitForProviderDisablement.pipe(Effect.as({ _tag: "disabled" as const })),
           );
           const finishedAt = yield* nowIso;
+          if (commandOutcome._tag === "disabled") {
+            const providers = yield* setProviderUpdateState(
+              provider,
+              makeUpdateState({
+                status: "failed",
+                startedAt,
+                finishedAt,
+                message: "Update stopped because the provider was disabled.",
+              }),
+            );
+            return { providers };
+          }
+          const commandResult = commandOutcome.result;
           if (Result.isFailure(commandResult)) {
             const providers = yield* setProviderUpdateState(
               provider,

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -5189,6 +5189,40 @@ disabledProviderStart.layer("ProviderServiceLive enablement", (it) => {
   );
 });
 
+let providerEnabledDuringStart = true;
+const providerDisabledAfterInitialCheck = makeProviderServiceLayer({
+  providerIsEnabled: () =>
+    Effect.sync(() => {
+      const enabled = providerEnabledDuringStart;
+      providerEnabledDuringStart = false;
+      return enabled;
+    }),
+});
+providerDisabledAfterInitialCheck.layer("ProviderServiceLive enablement race", (it) => {
+  it.effect("rechecks provider enablement immediately before adapter startup", () =>
+    Effect.gen(function* () {
+      providerEnabledDuringStart = true;
+      providerDisabledAfterInitialCheck.codex.startSession.mockClear();
+      const provider = yield* ProviderService;
+      const threadId = asThreadId("thread-disabled-during-start");
+
+      const failure = yield* Effect.result(
+        provider.startSession(threadId, {
+          provider: "codex",
+          threadId,
+          runtimeMode: "full-access",
+        }),
+      );
+
+      assert.equal(failure._tag, "Failure");
+      if (failure._tag !== "Failure") return;
+      assert.equal(failure.failure._tag, "ProviderValidationError");
+      assert.equal(failure.failure.message.includes("disabled"), true);
+      assert.equal(providerDisabledAfterInitialCheck.codex.startSession.mock.calls.length, 0);
+    }),
+  );
+});
+
 const boundedFanout = makeProviderServiceLayer({ runtimeEventBufferCapacity: 1 });
 it.effect("ProviderServiceLive backpressures slow subscribers and completes fanout shutdown", () =>
   Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -5139,6 +5139,30 @@ validation.layer("ProviderServiceLive validation", (it) => {
   );
 });
 
+const disabledProviderStart = makeProviderServiceLayer({
+  providerIsEnabled: (provider) => Effect.succeed(provider !== "codex"),
+});
+disabledProviderStart.layer("ProviderServiceLive enablement", (it) => {
+  it.effect("rejects session starts for disabled providers before reaching the adapter", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const failure = yield* Effect.result(
+        provider.startSession(asThreadId("thread-disabled-provider"), {
+          provider: "codex",
+          threadId: asThreadId("thread-disabled-provider"),
+          runtimeMode: "full-access",
+        }),
+      );
+
+      assert.equal(failure._tag, "Failure");
+      if (failure._tag !== "Failure") return;
+      assert.equal(failure.failure._tag, "ProviderValidationError");
+      assert.equal(failure.failure.message.includes("disabled"), true);
+      assert.equal(disabledProviderStart.codex.startSession.mock.calls.length, 0);
+    }),
+  );
+});
+
 const boundedFanout = makeProviderServiceLayer({ runtimeEventBufferCapacity: 1 });
 it.effect("ProviderServiceLive backpressures slow subscribers and completes fanout shutdown", () =>
   Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -5161,6 +5161,32 @@ disabledProviderStart.layer("ProviderServiceLive enablement", (it) => {
       assert.equal(disabledProviderStart.codex.startSession.mock.calls.length, 0);
     }),
   );
+
+  it.effect("rejects recovery-triggered provider starts while disabled", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("thread-disabled-provider-recovery");
+      disabledProviderStart.codex.startSession.mockClear();
+      disabledProviderStart.codex.compactThread.mockClear();
+      yield* directory.upsert({
+        threadId,
+        provider: "codex",
+        status: "stopped",
+        resumeCursor: { opaque: "resume-disabled-provider" },
+        runtimeMode: "full-access",
+      });
+
+      const failure = yield* Effect.result(provider.compactThread({ threadId }));
+
+      assert.equal(failure._tag, "Failure");
+      if (failure._tag !== "Failure") return;
+      assert.equal(failure.failure._tag, "ProviderValidationError");
+      assert.equal(failure.failure.message.includes("disabled"), true);
+      assert.equal(disabledProviderStart.codex.startSession.mock.calls.length, 0);
+      assert.equal(disabledProviderStart.codex.compactThread.mock.calls.length, 0);
+    }),
+  );
 });
 
 const boundedFanout = makeProviderServiceLayer({ runtimeEventBufferCapacity: 1 });

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -30,6 +30,7 @@ import {
   ProviderStartOptions,
   TurnId,
   type ProviderRuntimeEvent,
+  type ProviderKind,
   type ProviderSession,
 } from "@synara/contracts";
 import {
@@ -101,6 +102,10 @@ export interface ProviderServiceLiveOptions {
   /** Test override for supervised event retry timing. */
   readonly runtimeEventRetryBaseDelayMs?: number;
   readonly runtimeEventRetryMaxDelayMs?: number;
+  /** Server-authoritative start gate. Omit only in isolated tests and embedded callers. */
+  readonly providerIsEnabled?: (
+    provider: ProviderKind,
+  ) => Effect.Effect<boolean, ProviderValidationError>;
 }
 
 const DEFAULT_PROVIDER_RUNTIME_IDLE_STOP_MS = 10 * 60 * 1000;
@@ -1621,6 +1626,14 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           threadId,
           provider: parsed.provider ?? "codex",
         };
+        if (options?.providerIsEnabled && !(yield* options.providerIsEnabled(input.provider))) {
+          return yield* Effect.fail(
+            new ProviderValidationError({
+              operation: "ProviderService.startSession",
+              issue: `${input.provider} is disabled in Settings > Providers.`,
+            }),
+          );
+        }
         yield* validateAutoRuntimeMode(
           "ProviderService.startSession",
           input.provider,

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -1681,6 +1681,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             const adapter = yield* registry.getByProvider(input.provider);
             let replacementStarted = false;
             const startAndPersistReplacement = Effect.gen(function* () {
+              yield* ensureProviderEnabled(input.provider, "ProviderService.startSession");
               // A provider start that never returns holds this thread's
               // lifecycle lock and the caller's command slot forever. Bound it,
               // retire whatever the adapter may have half-spawned, and fail

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -384,6 +384,21 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
 
     const registry = yield* ProviderAdapterRegistry;
     const directory = yield* ProviderSessionDirectory;
+    const ensureProviderEnabled = (provider: ProviderKind, operation: string) =>
+      options?.providerIsEnabled
+        ? options.providerIsEnabled(provider).pipe(
+            Effect.flatMap((enabled) =>
+              enabled
+                ? Effect.void
+                : Effect.fail(
+                    new ProviderValidationError({
+                      operation,
+                      issue: `${provider} is disabled in Settings > Providers.`,
+                    }),
+                  ),
+            ),
+          )
+        : Effect.void;
     const lifecycle = makeProviderLifecycleCoordinator();
     for (const binding of yield* directory.listBindings()) {
       if (binding.lifecycleGeneration !== undefined) {
@@ -1417,6 +1432,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               binding.provider,
               binding.runtimeMode ?? "full-access",
             );
+            yield* ensureProviderEnabled(binding.provider, input.operation);
 
             const resumed = yield* adapter.startSession({
               threadId,
@@ -1558,6 +1574,9 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           // the provider binding, but the adapter already owns a live session.
           const liveAdapter = yield* findLiveSessionAdapter(input.threadId);
           if (liveAdapter) {
+            if (input.allowRecovery) {
+              yield* ensureProviderEnabled(liveAdapter.provider, input.operation);
+            }
             return {
               adapter: liveAdapter,
               isActive: true,
@@ -1570,6 +1589,9 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           );
         }
         const adapter = yield* registry.getByProvider(binding.provider);
+        if (input.allowRecovery) {
+          yield* ensureProviderEnabled(binding.provider, input.operation);
+        }
 
         const hasActiveSession = yield* adapter.hasSession(input.threadId);
         const requiresCredentialRotation =
@@ -1626,14 +1648,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           threadId,
           provider: parsed.provider ?? "codex",
         };
-        if (options?.providerIsEnabled && !(yield* options.providerIsEnabled(input.provider))) {
-          return yield* Effect.fail(
-            new ProviderValidationError({
-              operation: "ProviderService.startSession",
-              issue: `${input.provider} is disabled in Settings > Providers.`,
-            }),
-          );
-        }
+        yield* ensureProviderEnabled(input.provider, "ProviderService.startSession");
         yield* validateAutoRuntimeMode(
           "ProviderService.startSession",
           input.provider,

--- a/apps/server/src/provider/claudeCredentialKeepalive.test.ts
+++ b/apps/server/src/provider/claudeCredentialKeepalive.test.ts
@@ -11,6 +11,7 @@ import {
   isClaudeCredentialKeepaliveEnabled,
   resolveClaudeCredentialKeepaliveBinaryPath,
   resolveClaudeCredentialKeepaliveIntervalMs,
+  startClaudeCredentialKeepalive,
 } from "./claudeCredentialKeepalive.ts";
 
 describe("claudeCredentialKeepalive", () => {
@@ -74,24 +75,64 @@ describe("claudeCredentialKeepalive", () => {
     assert.equal(resolveClaudeCredentialKeepaliveIntervalMs({}), 30 * 60 * 1000);
   });
 
-  it("stops and restarts the keepalive as Claude is disabled and re-enabled", () => {
+  it("stops and restarts the keepalive as Claude is disabled and re-enabled", async () => {
     const started: string[] = [];
     const stopped: string[] = [];
     const controller = createClaudeCredentialKeepaliveController({
       start: (input) => {
         const binaryPath = resolveClaudeCredentialKeepaliveBinaryPath(input?.binaryPath);
         started.push(binaryPath);
-        return { stop: () => stopped.push(binaryPath) };
+        return {
+          stop: async () => {
+            stopped.push(binaryPath);
+          },
+        };
       },
     });
 
-    controller.reconcile({ enabled: true, binaryPath: "/one/claude" });
-    controller.reconcile({ enabled: true, binaryPath: "/one/claude" });
-    controller.reconcile({ enabled: false, binaryPath: "/one/claude" });
-    controller.reconcile({ enabled: true, binaryPath: "/two/claude" });
-    controller.stop();
+    await controller.reconcile({ enabled: true, binaryPath: "/one/claude" });
+    await controller.reconcile({ enabled: true, binaryPath: "/one/claude" });
+    await controller.reconcile({ enabled: false, binaryPath: "/one/claude" });
+    await controller.reconcile({ enabled: true, binaryPath: "/two/claude" });
+    await controller.stop();
 
     assert.deepEqual(started, ["/one/claude", "/two/claude"]);
     assert.deepEqual(stopped, ["/one/claude", "/two/claude"]);
+  });
+
+  it("aborts and waits for an in-flight auth probe when stopped", async () => {
+    let markStarted: () => void = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    let aborted = false;
+    let settled = false;
+    const handle = startClaudeCredentialKeepalive({
+      platform: "darwin",
+      env: { SYNARA_CLAUDE_KEEPALIVE: "1" },
+      runAuthStatus: ({ signal }) =>
+        new Promise<void>((resolve) => {
+          markStarted();
+          signal.addEventListener(
+            "abort",
+            () => {
+              aborted = true;
+              setTimeout(() => {
+                settled = true;
+                resolve();
+              }, 0);
+            },
+            { once: true },
+          );
+        }),
+    });
+
+    await started;
+    const stopping = handle.stop();
+
+    assert.equal(aborted, true);
+    assert.equal(settled, false);
+    await stopping;
+    assert.equal(settled, true);
   });
 });

--- a/apps/server/src/provider/claudeCredentialKeepalive.test.ts
+++ b/apps/server/src/provider/claudeCredentialKeepalive.test.ts
@@ -7,6 +7,7 @@ import { describe, it, assert } from "@effect/vitest";
 import {
   CLAUDE_CREDENTIAL_KEEPALIVE_AUTH_STATUS_ARGS,
   CLAUDE_CREDENTIAL_KEEPALIVE_MAX_INTERVAL_MS,
+  createClaudeCredentialKeepaliveController,
   isClaudeCredentialKeepaliveEnabled,
   resolveClaudeCredentialKeepaliveBinaryPath,
   resolveClaudeCredentialKeepaliveIntervalMs,
@@ -71,5 +72,26 @@ describe("claudeCredentialKeepalive", () => {
       30 * 60 * 1000,
     );
     assert.equal(resolveClaudeCredentialKeepaliveIntervalMs({}), 30 * 60 * 1000);
+  });
+
+  it("stops and restarts the keepalive as Claude is disabled and re-enabled", () => {
+    const started: string[] = [];
+    const stopped: string[] = [];
+    const controller = createClaudeCredentialKeepaliveController({
+      start: (input) => {
+        const binaryPath = resolveClaudeCredentialKeepaliveBinaryPath(input?.binaryPath);
+        started.push(binaryPath);
+        return { stop: () => stopped.push(binaryPath) };
+      },
+    });
+
+    controller.reconcile({ enabled: true, binaryPath: "/one/claude" });
+    controller.reconcile({ enabled: true, binaryPath: "/one/claude" });
+    controller.reconcile({ enabled: false, binaryPath: "/one/claude" });
+    controller.reconcile({ enabled: true, binaryPath: "/two/claude" });
+    controller.stop();
+
+    assert.deepEqual(started, ["/one/claude", "/two/claude"]);
+    assert.deepEqual(stopped, ["/one/claude", "/two/claude"]);
   });
 });

--- a/apps/server/src/provider/claudeCredentialKeepalive.ts
+++ b/apps/server/src/provider/claudeCredentialKeepalive.ts
@@ -90,6 +90,11 @@ export interface ClaudeCredentialKeepaliveHandle {
   readonly stop: () => void;
 }
 
+export interface ClaudeCredentialKeepaliveController {
+  readonly reconcile: (input: { readonly enabled: boolean; readonly binaryPath?: string }) => void;
+  readonly stop: () => void;
+}
+
 export function startClaudeCredentialKeepalive(input?: {
   readonly platform?: NodeJS.Platform;
   readonly env?: NodeJS.ProcessEnv;
@@ -143,5 +148,49 @@ export function startClaudeCredentialKeepalive(input?: {
   log(`[claude-keepalive] started (every ${intervalMs / 60_000}m, macOS)`);
   return {
     stop: () => clearInterval(timer),
+  };
+}
+
+export function createClaudeCredentialKeepaliveController(input?: {
+  readonly platform?: NodeJS.Platform;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly homeDir?: string;
+  readonly log?: (message: string) => void;
+  readonly start?: typeof startClaudeCredentialKeepalive;
+}): ClaudeCredentialKeepaliveController {
+  const start = input?.start ?? startClaudeCredentialKeepalive;
+  let active: {
+    readonly binaryPath: string;
+    readonly handle: ClaudeCredentialKeepaliveHandle;
+  } | null = null;
+
+  const stop = (): void => {
+    active?.handle.stop();
+    active = null;
+  };
+
+  return {
+    reconcile: (settings) => {
+      if (!settings.enabled) {
+        stop();
+        return;
+      }
+      const binaryPath = resolveClaudeCredentialKeepaliveBinaryPath(settings.binaryPath);
+      if (active?.binaryPath === binaryPath) {
+        return;
+      }
+      stop();
+      active = {
+        binaryPath,
+        handle: start({
+          ...(input?.platform ? { platform: input.platform } : {}),
+          ...(input?.env ? { env: input.env } : {}),
+          binaryPath,
+          ...(input?.homeDir ? { homeDir: input.homeDir } : {}),
+          ...(input?.log ? { log: input.log } : {}),
+        }),
+      };
+    },
+    stop,
   };
 }

--- a/apps/server/src/provider/claudeCredentialKeepalive.ts
+++ b/apps/server/src/provider/claudeCredentialKeepalive.ts
@@ -74,11 +74,13 @@ export function resolveClaudeCredentialKeepaliveIntervalMs(env: NodeJS.ProcessEn
 async function nudgeClaudeTokenRefresh(
   binaryPath: string,
   homeDir: string | undefined,
+  signal: AbortSignal,
 ): Promise<void> {
-  const release = await acquireClaudeAuthStatusLock();
+  const release = await acquireClaudeAuthStatusLockWithSignal(signal);
   try {
     await execFileAsync(binaryPath, [...CLAUDE_CREDENTIAL_KEEPALIVE_AUTH_STATUS_ARGS], {
       timeout: COMMAND_TIMEOUT_MS,
+      signal,
       env: buildClaudeProcessEnv(homeDir ? { homeDir } : undefined),
     });
   } finally {
@@ -86,13 +88,49 @@ async function nudgeClaudeTokenRefresh(
   }
 }
 
+function acquireClaudeAuthStatusLockWithSignal(signal: AbortSignal): Promise<() => void> {
+  if (signal.aborted) {
+    return Promise.reject(signal.reason);
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    void acquireClaudeAuthStatusLock().then(
+      (release) => {
+        if (settled) {
+          release();
+          return;
+        }
+        settled = true;
+        signal.removeEventListener("abort", onAbort);
+        resolve(release);
+      },
+      (cause) => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener("abort", onAbort);
+        reject(cause);
+      },
+    );
+  });
+}
+
 export interface ClaudeCredentialKeepaliveHandle {
-  readonly stop: () => void;
+  readonly stop: () => Promise<void>;
 }
 
 export interface ClaudeCredentialKeepaliveController {
-  readonly reconcile: (input: { readonly enabled: boolean; readonly binaryPath?: string }) => void;
-  readonly stop: () => void;
+  readonly reconcile: (input: {
+    readonly enabled: boolean;
+    readonly binaryPath?: string;
+  }) => Promise<void>;
+  readonly stop: () => Promise<void>;
 }
 
 export function startClaudeCredentialKeepalive(input?: {
@@ -101,40 +139,52 @@ export function startClaudeCredentialKeepalive(input?: {
   readonly binaryPath?: string;
   readonly homeDir?: string;
   readonly log?: (message: string) => void;
+  readonly runAuthStatus?: (input: {
+    readonly binaryPath: string;
+    readonly homeDir: string | undefined;
+    readonly signal: AbortSignal;
+  }) => Promise<void>;
 }): ClaudeCredentialKeepaliveHandle {
   const platform = input?.platform ?? process.platform;
   const env = input?.env ?? process.env;
   const binaryPath = resolveClaudeCredentialKeepaliveBinaryPath(input?.binaryPath);
   const homeDir = input?.homeDir;
   const log = input?.log ?? (() => {});
+  const runAuthStatus =
+    input?.runAuthStatus ??
+    ((input) => nudgeClaudeTokenRefresh(input.binaryPath, input.homeDir, input.signal));
 
   // Only run when explicitly enabled. The check touches Claude Code auth data, so
   // Synara should not do it as background work merely because the app opened.
   if (!isClaudeCredentialKeepaliveEnabled({ platform, env })) {
-    return { stop: () => {} };
+    return { stop: async () => {} };
   }
 
   const intervalMs = resolveClaudeCredentialKeepaliveIntervalMs(env);
-  let inFlight = false;
+  const abortController = new AbortController();
+  let stopped = false;
+  let activeTick: Promise<void> | null = null;
+  let stopPromise: Promise<void> | null = null;
 
-  const tick = async (): Promise<void> => {
-    if (inFlight) {
-      return;
+  const tick = (): Promise<void> => {
+    if (stopped || activeTick) {
+      return activeTick ?? Promise.resolve();
     }
-    inFlight = true;
-    try {
-      await nudgeClaudeTokenRefresh(binaryPath, homeDir);
-    } catch (cause) {
-      // Best-effort: a missing binary, a genuinely logged-out user, or a transient failure
-      // must never crash the server. Keep it quiet since it self-heals on the next tick.
-      log(
-        `[claude-keepalive] token refresh nudge failed (non-fatal): ${
-          cause instanceof Error ? cause.message : String(cause)
-        }`,
-      );
-    } finally {
-      inFlight = false;
-    }
+    activeTick = runAuthStatus({ binaryPath, homeDir, signal: abortController.signal })
+      .catch((cause) => {
+        if (abortController.signal.aborted) return;
+        // Best-effort: a missing binary, a genuinely logged-out user, or a transient failure
+        // must never crash the server. Keep it quiet since it self-heals on the next tick.
+        log(
+          `[claude-keepalive] token refresh nudge failed (non-fatal): ${
+            cause instanceof Error ? cause.message : String(cause)
+          }`,
+        );
+      })
+      .finally(() => {
+        activeTick = null;
+      });
+    return activeTick;
   };
 
   const timer = setInterval(() => void tick(), intervalMs);
@@ -147,7 +197,15 @@ export function startClaudeCredentialKeepalive(input?: {
   void tick();
   log(`[claude-keepalive] started (every ${intervalMs / 60_000}m, macOS)`);
   return {
-    stop: () => clearInterval(timer),
+    stop: () => {
+      if (stopPromise) return stopPromise;
+      stopped = true;
+      clearInterval(timer);
+      const inFlight = activeTick;
+      abortController.abort();
+      stopPromise = inFlight ?? Promise.resolve();
+      return stopPromise;
+    },
   };
 }
 
@@ -163,34 +221,46 @@ export function createClaudeCredentialKeepaliveController(input?: {
     readonly binaryPath: string;
     readonly handle: ClaudeCredentialKeepaliveHandle;
   } | null = null;
+  let transitionQueue = Promise.resolve();
 
-  const stop = (): void => {
-    active?.handle.stop();
+  const stopActive = async (): Promise<void> => {
+    const handle = active?.handle;
     active = null;
+    await handle?.stop();
+  };
+
+  const enqueueTransition = (transition: () => Promise<void>): Promise<void> => {
+    const queued = transitionQueue.then(transition, transition);
+    transitionQueue = queued.then(
+      () => undefined,
+      () => undefined,
+    );
+    return queued;
   };
 
   return {
-    reconcile: (settings) => {
-      if (!settings.enabled) {
-        stop();
-        return;
-      }
-      const binaryPath = resolveClaudeCredentialKeepaliveBinaryPath(settings.binaryPath);
-      if (active?.binaryPath === binaryPath) {
-        return;
-      }
-      stop();
-      active = {
-        binaryPath,
-        handle: start({
-          ...(input?.platform ? { platform: input.platform } : {}),
-          ...(input?.env ? { env: input.env } : {}),
+    reconcile: (settings) =>
+      enqueueTransition(async () => {
+        if (!settings.enabled) {
+          await stopActive();
+          return;
+        }
+        const binaryPath = resolveClaudeCredentialKeepaliveBinaryPath(settings.binaryPath);
+        if (active?.binaryPath === binaryPath) {
+          return;
+        }
+        await stopActive();
+        active = {
           binaryPath,
-          ...(input?.homeDir ? { homeDir: input.homeDir } : {}),
-          ...(input?.log ? { log: input.log } : {}),
-        }),
-      };
-    },
-    stop,
+          handle: start({
+            ...(input?.platform ? { platform: input.platform } : {}),
+            ...(input?.env ? { env: input.env } : {}),
+            binaryPath,
+            ...(input?.homeDir ? { homeDir: input.homeDir } : {}),
+            ...(input?.log ? { log: input.log } : {}),
+          }),
+        };
+      }),
+    stop: () => enqueueTransition(stopActive),
   };
 }

--- a/apps/server/src/provider/enabledProviderAdapter.ts
+++ b/apps/server/src/provider/enabledProviderAdapter.ts
@@ -1,0 +1,40 @@
+/**
+ * Resolve a provider adapter only while the provider is enabled in server settings.
+ *
+ * Voice entry points live on different transports, so this gate stays shared to
+ * prevent either the WebSocket fallback or the primary HTTP upload path from
+ * bypassing provider disablement.
+ */
+import { PROVIDER_DISPLAY_NAMES, type ProviderKind } from "@synara/contracts";
+import { Effect } from "effect";
+
+import type { ServerSettingsShape } from "../serverSettings";
+import type { ProviderAdapterRegistryShape } from "./Services/ProviderAdapterRegistry";
+
+export class ProviderDisabledError extends Error {
+  readonly status = 409;
+}
+
+export function getEnabledProviderAdapter(
+  provider: ProviderKind,
+  serverSettings: ServerSettingsShape,
+  providerAdapterRegistry: ProviderAdapterRegistryShape,
+) {
+  return providerAdapterRegistry
+    .getByProvider(provider)
+    .pipe(
+      Effect.flatMap((adapter) =>
+        serverSettings.getSettings.pipe(
+          Effect.flatMap((settings) =>
+            settings.providers[adapter.provider].enabled
+              ? Effect.succeed(adapter)
+              : Effect.fail(
+                  new ProviderDisabledError(
+                    `${PROVIDER_DISPLAY_NAMES[adapter.provider]} is disabled in Settings > Providers.`,
+                  ),
+                ),
+          ),
+        ),
+      ),
+    );
+}

--- a/apps/server/src/provider/enabledProviderAdapter.ts
+++ b/apps/server/src/provider/enabledProviderAdapter.ts
@@ -15,26 +15,26 @@ export class ProviderDisabledError extends Error {
   readonly status = 409;
 }
 
+export function ensureProviderEnabled(provider: ProviderKind, serverSettings: ServerSettingsShape) {
+  return serverSettings.getSettings.pipe(
+    Effect.flatMap((settings) =>
+      settings.providers[provider].enabled
+        ? Effect.void
+        : Effect.fail(
+            new ProviderDisabledError(
+              `${PROVIDER_DISPLAY_NAMES[provider]} is disabled in Settings > Providers.`,
+            ),
+          ),
+    ),
+  );
+}
+
 export function getEnabledProviderAdapter(
   provider: ProviderKind,
   serverSettings: ServerSettingsShape,
   providerAdapterRegistry: ProviderAdapterRegistryShape,
 ) {
-  return providerAdapterRegistry
-    .getByProvider(provider)
-    .pipe(
-      Effect.flatMap((adapter) =>
-        serverSettings.getSettings.pipe(
-          Effect.flatMap((settings) =>
-            settings.providers[adapter.provider].enabled
-              ? Effect.succeed(adapter)
-              : Effect.fail(
-                  new ProviderDisabledError(
-                    `${PROVIDER_DISPLAY_NAMES[adapter.provider]} is disabled in Settings > Providers.`,
-                  ),
-                ),
-          ),
-        ),
-      ),
-    );
+  return ensureProviderEnabled(provider, serverSettings).pipe(
+    Effect.andThen(providerAdapterRegistry.getByProvider(provider)),
+  );
 }

--- a/apps/server/src/provider/enabledProviderAdapter.ts
+++ b/apps/server/src/provider/enabledProviderAdapter.ts
@@ -15,16 +15,16 @@ export class ProviderDisabledError extends Error {
   readonly status = 409;
 }
 
+export function providerDisabledSettingsMessage(provider: ProviderKind): string {
+  return `${PROVIDER_DISPLAY_NAMES[provider]} is disabled in Settings > Providers.`;
+}
+
 export function ensureProviderEnabled(provider: ProviderKind, serverSettings: ServerSettingsShape) {
   return serverSettings.getSettings.pipe(
     Effect.flatMap((settings) =>
       settings.providers[provider].enabled
         ? Effect.void
-        : Effect.fail(
-            new ProviderDisabledError(
-              `${PROVIDER_DISPLAY_NAMES[provider]} is disabled in Settings > Providers.`,
-            ),
-          ),
+        : Effect.fail(new ProviderDisabledError(providerDisabledSettingsMessage(provider))),
     ),
   );
 }

--- a/apps/server/src/provider/runtimeLayer.ts
+++ b/apps/server/src/provider/runtimeLayer.ts
@@ -7,7 +7,7 @@ import {
   ProviderCredentials,
   ProviderCredentialsLive,
 } from "../providerCredentials";
-import { ServerSettingsLive, ServerSettingsService } from "../serverSettings";
+import { ServerSettingsService } from "../serverSettings";
 import { ProviderValidationError } from "./Errors";
 import { makeClaudeAdapterLive } from "./Layers/ClaudeAdapter";
 import { makeCodexAdapterLive } from "./Layers/CodexAdapter";
@@ -118,9 +118,6 @@ export function makeServerProviderLayer(
     );
     const providerDiscoveryLayer = ProviderDiscoveryServiceLive.pipe(
       Layer.provide(adapterRegistryLayer),
-      // Skill toggles live in server settings; the shared ServerSettingsLive
-      // layer is memoized so this reuses the instance built at the top level.
-      Layer.provide(ServerSettingsLive),
     );
     return Layer.mergeAll(
       providerServiceLayer,
@@ -128,9 +125,5 @@ export function makeServerProviderLayer(
       adapterRegistryLayer,
       providerSessionDirectoryLayer,
     );
-  }).pipe(
-    Effect.provide(ProviderCredentialsLive.pipe(Layer.orDie)),
-    Effect.provide(ServerSettingsLive),
-    Layer.unwrap,
-  );
+  }).pipe(Effect.provide(ProviderCredentialsLive.pipe(Layer.orDie)), Layer.unwrap);
 }

--- a/apps/server/src/provider/runtimeLayer.ts
+++ b/apps/server/src/provider/runtimeLayer.ts
@@ -7,7 +7,8 @@ import {
   ProviderCredentials,
   ProviderCredentialsLive,
 } from "../providerCredentials";
-import { ServerSettingsLive } from "../serverSettings";
+import { ServerSettingsLive, ServerSettingsService } from "../serverSettings";
+import { ProviderValidationError } from "./Errors";
 import { makeClaudeAdapterLive } from "./Layers/ClaudeAdapter";
 import { makeCodexAdapterLive } from "./Layers/CodexAdapter";
 import { makeCursorAdapterLive } from "./Layers/CursorAdapter";
@@ -31,6 +32,7 @@ export function makeServerProviderLayer(
 ) {
   return Effect.gen(function* () {
     const credentials = yield* ProviderCredentials;
+    const serverSettings = yield* ServerSettingsService;
     const resolveProviderServerPassword = makeProviderServerPasswordResolver(credentials);
     const { logProviderEvents, providerEventLogPath } = yield* ServerConfig;
     const nativeEventLogger = logProviderEvents
@@ -95,9 +97,21 @@ export function makeServerProviderLayer(
       Layer.provide(piAdapterLayer),
       Layer.provideMerge(providerSessionDirectoryLayer),
     );
-    const providerServiceLayer = makeDurableProviderServiceLive(
-      canonicalEventLogger ? { canonicalEventLogger } : undefined,
-    ).pipe(
+    const providerServiceLayer = makeDurableProviderServiceLive({
+      ...(canonicalEventLogger ? { canonicalEventLogger } : {}),
+      providerIsEnabled: (provider) =>
+        serverSettings.getSettings.pipe(
+          Effect.map((settings) => settings.providers[provider].enabled),
+          Effect.mapError(
+            (cause) =>
+              new ProviderValidationError({
+                operation: "ProviderService.startSession",
+                issue: "Failed to read provider enablement settings.",
+                cause,
+              }),
+          ),
+        ),
+    }).pipe(
       Layer.provide(adapterRegistryLayer),
       Layer.provide(providerSessionDirectoryLayer),
       Layer.provide(ProviderRuntimeEventRepositoryLive),
@@ -114,5 +128,9 @@ export function makeServerProviderLayer(
       adapterRegistryLayer,
       providerSessionDirectoryLayer,
     );
-  }).pipe(Effect.provide(ProviderCredentialsLive.pipe(Layer.orDie)), Layer.unwrap);
+  }).pipe(
+    Effect.provide(ProviderCredentialsLive.pipe(Layer.orDie)),
+    Effect.provide(ServerSettingsLive),
+    Layer.unwrap,
+  );
 }

--- a/apps/server/src/providerUsage/index.test.ts
+++ b/apps/server/src/providerUsage/index.test.ts
@@ -3,11 +3,19 @@
 // of concurrent requests, forceRefresh bypass, and the shorter expiry for degraded snapshots —
 // so UI surfaces polling in parallel can't stampede the provider fetchers.
 
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { Effect, Layer } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ServerProviderUsageSnapshot } from "@synara/contracts";
 
-import { __resetProviderUsageCacheForTests, collectProviderUsageSnapshots } from "./index";
+import { ServerConfig } from "../config";
+import { ServerSettingsService } from "../serverSettings";
+import {
+  __resetProviderUsageCacheForTests,
+  collectProviderUsageSnapshots,
+  listProviderUsage,
+} from "./index";
 import type { ProviderUsageContext, ProviderUsageFetcher } from "./types";
 
 const fetchMock = vi.fn<(ctx: ProviderUsageContext) => Promise<ServerProviderUsageSnapshot>>();
@@ -239,6 +247,37 @@ describe("collectProviderUsageSnapshots caching", () => {
     await collectProviderUsageSnapshots(makeCtx(NOW_MS));
     await collectProviderUsageSnapshots(makeCtx(NOW_MS + 90_000));
 
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("omits disabled providers and invalidates their cached snapshots", async () => {
+    fetchMock.mockImplementation(async (ctx) => okSnapshot(ctx.nowMs));
+    const configLayer = ServerConfig.layerTest(process.cwd(), process.cwd()).pipe(
+      Layer.provide(NodeServices.layer),
+    );
+    const layer = Layer.mergeAll(
+      NodeServices.layer,
+      configLayer,
+      ServerSettingsService.layerTest(),
+    );
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const serverSettings = yield* ServerSettingsService;
+        const first = yield* listProviderUsage({});
+
+        yield* serverSettings.updateSettings({ providers: { codex: { enabled: false } } });
+        const disabled = yield* listProviderUsage({ forceRefresh: true });
+
+        yield* serverSettings.updateSettings({ providers: { codex: { enabled: true } } });
+        const reenabled = yield* listProviderUsage({});
+        return { first, disabled, reenabled };
+      }).pipe(Effect.provide(layer), Effect.scoped),
+    );
+
+    expect(result.first).toHaveLength(1);
+    expect(result.disabled).toEqual([]);
+    expect(result.reenabled).toHaveLength(1);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/server/src/providerUsage/index.ts
+++ b/apps/server/src/providerUsage/index.ts
@@ -94,6 +94,7 @@ interface InFlightSnapshot {
 
 const snapshotCache = new Map<ProviderKind, CachedSnapshot>();
 const inFlightFetches = new Map<ProviderKind, InFlightSnapshot>();
+const snapshotCacheGenerations = new Map<ProviderKind, number>();
 
 const snapshotCacheTtlMs = (snapshot: ServerProviderUsageSnapshot): number =>
   snapshot.stale === true
@@ -121,6 +122,15 @@ async function resolveCredentialKey(
 export function __resetProviderUsageCacheForTests(): void {
   snapshotCache.clear();
   inFlightFetches.clear();
+  snapshotCacheGenerations.clear();
+}
+
+function invalidateProviderUsageSnapshots(providers: ReadonlyArray<ProviderKind>): void {
+  for (const provider of providers) {
+    snapshotCache.delete(provider);
+    inFlightFetches.delete(provider);
+    snapshotCacheGenerations.set(provider, (snapshotCacheGenerations.get(provider) ?? 0) + 1);
+  }
 }
 
 async function getProviderUsageSnapshot(
@@ -128,6 +138,7 @@ async function getProviderUsageSnapshot(
   ctx: ProviderUsageContext,
   forceRefresh: boolean,
 ): Promise<ServerProviderUsageSnapshot | null> {
+  const cacheGeneration = snapshotCacheGenerations.get(provider) ?? 0;
   const providerContext = buildProviderContext(provider, ctx);
   const credentialKey = await resolveCredentialKey(provider, providerContext);
   const pending = inFlightFetches.get(provider);
@@ -150,7 +161,12 @@ async function getProviderUsageSnapshot(
     const snapshot = await fetchProviderUsage(provider, providerContext);
     const enriched = snapshot ? await enrichWithLocalUsage(snapshot, ctx) : null;
     const refreshedCredentialKey = await resolveCredentialKey(provider, providerContext);
-    if (enriched && credentialKey !== null && refreshedCredentialKey === credentialKey) {
+    if (
+      enriched &&
+      credentialKey !== null &&
+      refreshedCredentialKey === credentialKey &&
+      (snapshotCacheGenerations.get(provider) ?? 0) === cacheGeneration
+    ) {
       const current = snapshotCache.get(provider);
       const hasFreshHealthySnapshot =
         current?.credentialKey === credentialKey &&
@@ -200,13 +216,19 @@ async function enrichWithLocalUsage(
 /** Plain async batch fetch for supported providers. Never throws. */
 export async function collectProviderUsageSnapshots(
   ctx: ProviderUsageContext,
-  options: { forceRefresh?: boolean; provider?: ProviderKind } = {},
+  options: {
+    forceRefresh?: boolean;
+    provider?: ProviderKind;
+    providers?: ReadonlyArray<ProviderKind>;
+  } = {},
 ): Promise<ServerProviderUsageSnapshot[]> {
   const providers = options.provider
     ? ([options.provider] as ProviderKind[])
-    : PROVIDER_USAGE_PROVIDERS.filter(
-        (provider) => PROVIDER_USAGE_FETCHERS[provider] !== undefined,
-      );
+    : options.providers
+      ? [...options.providers]
+      : PROVIDER_USAGE_PROVIDERS.filter(
+          (provider) => PROVIDER_USAGE_FETCHERS[provider] !== undefined,
+        );
   const settled = await Promise.allSettled(
     providers.map((provider) =>
       getProviderUsageSnapshot(provider, ctx, options.forceRefresh === true),
@@ -222,6 +244,20 @@ export const listProviderUsage = Effect.fn(function* (input: ServerListProviderU
   const serverConfig = yield* ServerConfig;
   const serverSettings = yield* ServerSettingsService;
   const settings = yield* serverSettings.getSettings;
+  const supportedProviders = PROVIDER_USAGE_PROVIDERS.filter(
+    (provider) => PROVIDER_USAGE_FETCHERS[provider] !== undefined,
+  );
+  const enabledProviders = supportedProviders.filter(
+    (provider) => settings.providers[provider].enabled,
+  );
+  invalidateProviderUsageSnapshots(
+    supportedProviders.filter((provider) => !settings.providers[provider].enabled),
+  );
+
+  if (input.provider && !settings.providers[input.provider].enabled) {
+    return [];
+  }
+
   return yield* Effect.tryPromise({
     try: () =>
       collectProviderUsageSnapshots(
@@ -233,6 +269,7 @@ export const listProviderUsage = Effect.fn(function* (input: ServerListProviderU
         {
           forceRefresh: input.forceRefresh === true,
           ...(input.provider ? { provider: input.provider } : {}),
+          ...(!input.provider ? { providers: enabledProviders } : {}),
         },
       ),
     catch: () => [] as unknown as ServerListProviderUsageResult,

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -256,10 +256,17 @@ export function makeServerRuntimeServicesLayer(
  */
 export function makeServerApplicationLayers() {
   const agentGatewayCredentialsLayer = AgentGatewayCredentialsWithSecretsLive;
+  const runtimeServicesLayer = makeServerRuntimeServicesLayer({
+    agentGatewayCredentialsLayer,
+  });
+  // Provider start/discovery gates must observe the same settings instance as
+  // the RPC layer. Reusing this layer in the final graph lets Effect memoize a
+  // single ServerSettings service instead of capturing private defaults.
+  const providerLayer = makeServerProviderLayer({ agentGatewayCredentialsLayer }).pipe(
+    Layer.provideMerge(ServerSettingsLive),
+  );
   return {
-    runtimeServicesLayer: makeServerRuntimeServicesLayer({
-      agentGatewayCredentialsLayer,
-    }),
-    providerLayer: makeServerProviderLayer({ agentGatewayCredentialsLayer }),
+    runtimeServicesLayer,
+    providerLayer,
   } as const;
 }

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -149,75 +149,55 @@ describe("ServerSettingsService", () => {
     expect(result.persisted).not.toContain("opencode-secret");
   });
 
-  it("resolves text generation selection away from disabled providers", async () => {
+  it.each([
+    {
+      name: "resolves text generation selection away from disabled providers",
+      overrides: {
+        textGenerationModelSelection: {
+          provider: "antigravity" as const,
+          model: DEFAULT_MODEL_BY_PROVIDER.antigravity,
+        },
+        providers: { antigravity: { enabled: false } },
+      },
+      expectedProvider: "codex" as const,
+    },
+    {
+      name: "falls back only to providers with dedicated Git text generation",
+      overrides: {
+        textGenerationModelSelection: {
+          provider: "codex" as const,
+          model: DEFAULT_MODEL_BY_PROVIDER.codex,
+        },
+        providers: {
+          codex: { enabled: false },
+          claudeAgent: { enabled: true },
+          cursor: { enabled: false },
+          kilo: { enabled: true },
+        },
+      },
+      expectedProvider: "kilo" as const,
+    },
+    {
+      name: "normalizes enabled but unsupported Git text generation selections",
+      overrides: {
+        textGenerationModelSelection: {
+          provider: "claudeAgent" as const,
+          model: DEFAULT_MODEL_BY_PROVIDER.claudeAgent,
+        },
+      },
+      expectedProvider: "codex" as const,
+    },
+  ])("$name", async ({ overrides, expectedProvider }) => {
     const settings = await Effect.runPromise(
       Effect.gen(function* () {
         const service = yield* ServerSettingsService;
         return yield* service.getSettings;
-      }).pipe(
-        Effect.provide(
-          ServerSettingsService.layerTest({
-            textGenerationModelSelection: {
-              provider: "antigravity",
-              model: DEFAULT_MODEL_BY_PROVIDER.antigravity,
-            },
-            providers: {
-              antigravity: { enabled: false },
-            },
-          }),
-        ),
-      ),
+      }).pipe(Effect.provide(ServerSettingsService.layerTest(overrides))),
     );
 
-    expect(settings.textGenerationModelSelection.provider).toBe("codex");
-    expect(settings.textGenerationModelSelection.model).toBe(DEFAULT_MODEL_BY_PROVIDER.codex);
-  });
-
-  it("falls back only to providers with dedicated Git text generation", async () => {
-    const settings = await Effect.runPromise(
-      Effect.gen(function* () {
-        const service = yield* ServerSettingsService;
-        return yield* service.getSettings;
-      }).pipe(
-        Effect.provide(
-          ServerSettingsService.layerTest({
-            textGenerationModelSelection: {
-              provider: "codex",
-              model: DEFAULT_MODEL_BY_PROVIDER.codex,
-            },
-            providers: {
-              codex: { enabled: false },
-              claudeAgent: { enabled: true },
-              cursor: { enabled: false },
-              kilo: { enabled: true },
-            },
-          }),
-        ),
-      ),
+    expect(settings.textGenerationModelSelection.provider).toBe(expectedProvider);
+    expect(settings.textGenerationModelSelection.model).toBe(
+      DEFAULT_MODEL_BY_PROVIDER[expectedProvider],
     );
-
-    expect(settings.textGenerationModelSelection.provider).toBe("kilo");
-    expect(settings.textGenerationModelSelection.model).toBe(DEFAULT_MODEL_BY_PROVIDER.kilo);
-  });
-
-  it("normalizes enabled but unsupported Git text generation selections", async () => {
-    const settings = await Effect.runPromise(
-      Effect.gen(function* () {
-        const service = yield* ServerSettingsService;
-        return yield* service.getSettings;
-      }).pipe(
-        Effect.provide(
-          ServerSettingsService.layerTest({
-            textGenerationModelSelection: {
-              provider: "claudeAgent",
-              model: DEFAULT_MODEL_BY_PROVIDER.claudeAgent,
-            },
-          }),
-        ),
-      ),
-    );
-
-    expect(settings.textGenerationModelSelection.provider).toBe("codex");
-    expect(settings.textGenerationModelSelection.model).toBe(DEFAULT_MODEL_BY_PROVIDER.codex);
   });
 });

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -45,6 +45,7 @@ describe("ServerSettingsService", () => {
           enableProviderUpdateChecks: false,
           providers: {
             codex: {
+              enabled: false,
               binaryPath: "/usr/local/bin/codex",
               customModels: ["gpt-custom"],
             },
@@ -57,6 +58,7 @@ describe("ServerSettingsService", () => {
 
     expect(result.updated.enableAssistantStreaming).toBe(true);
     expect(result.updated.enableProviderUpdateChecks).toBe(false);
+    expect(result.updated.providers.codex.enabled).toBe(false);
     expect(result.updated.providers.codex.binaryPath).toBe("/usr/local/bin/codex");
     expect(result.parsed).toMatchObject({
       revision: 1,
@@ -66,6 +68,7 @@ describe("ServerSettingsService", () => {
         enableProviderUpdateChecks: false,
         providers: {
           codex: {
+            enabled: false,
             binaryPath: "/usr/local/bin/codex",
             customModels: ["gpt-custom"],
           },

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -172,4 +172,31 @@ describe("ServerSettingsService", () => {
     expect(settings.textGenerationModelSelection.provider).toBe("codex");
     expect(settings.textGenerationModelSelection.model).toBe(DEFAULT_MODEL_BY_PROVIDER.codex);
   });
+
+  it("falls back only to providers with dedicated Git text generation", async () => {
+    const settings = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* ServerSettingsService;
+        return yield* service.getSettings;
+      }).pipe(
+        Effect.provide(
+          ServerSettingsService.layerTest({
+            textGenerationModelSelection: {
+              provider: "codex",
+              model: DEFAULT_MODEL_BY_PROVIDER.codex,
+            },
+            providers: {
+              codex: { enabled: false },
+              claudeAgent: { enabled: true },
+              cursor: { enabled: false },
+              kilo: { enabled: true },
+            },
+          }),
+        ),
+      ),
+    );
+
+    expect(settings.textGenerationModelSelection.provider).toBe("kilo");
+    expect(settings.textGenerationModelSelection.model).toBe(DEFAULT_MODEL_BY_PROVIDER.kilo);
+  });
 });

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -199,4 +199,25 @@ describe("ServerSettingsService", () => {
     expect(settings.textGenerationModelSelection.provider).toBe("kilo");
     expect(settings.textGenerationModelSelection.model).toBe(DEFAULT_MODEL_BY_PROVIDER.kilo);
   });
+
+  it("normalizes enabled but unsupported Git text generation selections", async () => {
+    const settings = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* ServerSettingsService;
+        return yield* service.getSettings;
+      }).pipe(
+        Effect.provide(
+          ServerSettingsService.layerTest({
+            textGenerationModelSelection: {
+              provider: "claudeAgent",
+              model: DEFAULT_MODEL_BY_PROVIDER.claudeAgent,
+            },
+          }),
+        ),
+      ),
+    );
+
+    expect(settings.textGenerationModelSelection.provider).toBe("codex");
+    expect(settings.textGenerationModelSelection.model).toBe(DEFAULT_MODEL_BY_PROVIDER.codex);
+  });
 });

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -34,7 +34,10 @@ import {
 import * as Semaphore from "effect/Semaphore";
 import { writeFileStringAtomically } from "./atomicWrite";
 import { ServerConfig } from "./config";
-import { GIT_TEXT_GENERATION_PROVIDER_ORDER } from "./git/textGenerationSelection";
+import {
+  GIT_TEXT_GENERATION_PROVIDER_ORDER,
+  hasDedicatedTextGenerationProvider,
+} from "./git/textGenerationSelection";
 import {
   ProviderCredentials,
   ProviderCredentialsLive,
@@ -152,7 +155,10 @@ export class ServerSettingsService extends ServiceMap.Service<
 
 function resolveTextGenerationProvider(settings: ServerSettings): ServerSettings {
   const selection = settings.textGenerationModelSelection;
-  if (settings.providers[selection.provider].enabled) {
+  if (
+    hasDedicatedTextGenerationProvider(selection.provider) &&
+    settings.providers[selection.provider].enabled
+  ) {
     return settings;
   }
 

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -10,7 +10,6 @@ import {
   DEFAULT_MODEL_BY_PROVIDER,
   DEFAULT_SERVER_SETTINGS,
   type ModelSelection,
-  type ProviderWithDefaultModel,
   ServerSettings,
   ServerSettingsError,
   type ServerSettingsPatch,
@@ -35,6 +34,7 @@ import {
 import * as Semaphore from "effect/Semaphore";
 import { writeFileStringAtomically } from "./atomicWrite";
 import { ServerConfig } from "./config";
+import { GIT_TEXT_GENERATION_PROVIDER_ORDER } from "./git/textGenerationSelection";
 import {
   ProviderCredentials,
   ProviderCredentialsLive,
@@ -150,20 +150,15 @@ export class ServerSettingsService extends ServiceMap.Service<
     );
 }
 
-const PROVIDER_ORDER: readonly ProviderWithDefaultModel[] = [
-  "codex",
-  "claudeAgent",
-  "kilo",
-  "opencode",
-];
-
 function resolveTextGenerationProvider(settings: ServerSettings): ServerSettings {
   const selection = settings.textGenerationModelSelection;
   if (settings.providers[selection.provider].enabled) {
     return settings;
   }
 
-  const fallback = PROVIDER_ORDER.find((provider) => settings.providers[provider].enabled);
+  const fallback = GIT_TEXT_GENERATION_PROVIDER_ORDER.find(
+    (provider) => settings.providers[provider].enabled,
+  );
   if (!fallback) {
     return settings;
   }

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -17,7 +17,6 @@ import {
   WsFeatureRpcGroup,
   WsRpcError,
   PullRequestsUnavailableError,
-  PROVIDER_DISPLAY_NAMES,
   type DeviceEvent,
   type GitActionProgressEvent,
   type GitHubProjectProvisionProgressEvent,
@@ -25,7 +24,6 @@ import {
   type OrchestrationCommand,
   type OrchestrationEvent,
   type ProjectDevServerEvent,
-  type ProviderKind,
   type OrchestrationShellStreamEvent,
   type OrchestrationShellStreamItem,
   type OrchestrationThreadDetailSnapshot,
@@ -102,6 +100,7 @@ import { ProviderDiscoveryService } from "./provider/Services/ProviderDiscoveryS
 import { discoverSkillsCatalog, synaraSkillsDir } from "./provider/skillsCatalog";
 import { recoverUnregisteredGitHubCheckout } from "./project/githubProjectRegistration";
 import { ProviderAdapterRegistry } from "./provider/Services/ProviderAdapterRegistry";
+import { getEnabledProviderAdapter } from "./provider/enabledProviderAdapter";
 import { ProviderHealth } from "./provider/Services/ProviderHealth";
 import { ProviderService } from "./provider/Services/ProviderService";
 import { listProviderUsage } from "./providerUsage";
@@ -365,18 +364,6 @@ const makeWsRpcHandlersLayer = () =>
       const runtimeStartup = yield* ServerRuntimeStartup;
       const serverEnvironment = yield* ServerEnvironment;
       const serverSettings = yield* ServerSettingsService;
-      const getEnabledProviderAdapter = (provider: ProviderKind) =>
-        serverSettings.getSettings.pipe(
-          Effect.flatMap((settings) =>
-            settings.providers[provider].enabled
-              ? providerAdapterRegistry.getByProvider(provider)
-              : Effect.fail(
-                  new Error(
-                    `${PROVIDER_DISPLAY_NAMES[provider]} is disabled in Settings > Providers.`,
-                  ),
-                ),
-          ),
-        );
       const terminalManager = yield* TerminalManager;
       const textGeneration = yield* TextGeneration;
       const workspaceEntries = yield* WorkspaceEntries;
@@ -1751,7 +1738,7 @@ const makeWsRpcHandlersLayer = () =>
           ),
         [WS_METHODS.serverPrewarmVoice]: (input) =>
           rpcEffect(
-            getEnabledProviderAdapter(input.provider).pipe(
+            getEnabledProviderAdapter(input.provider, serverSettings, providerAdapterRegistry).pipe(
               Effect.flatMap((adapter) =>
                 adapter.prewarmVoice
                   ? adapter.prewarmVoice(input)
@@ -1767,7 +1754,11 @@ const makeWsRpcHandlersLayer = () =>
         [WS_METHODS.serverTranscribeVoice]: (input) =>
           rpcEffect(
             voiceUploadAdmissionGate.run(
-              getEnabledProviderAdapter(input.provider).pipe(
+              getEnabledProviderAdapter(
+                input.provider,
+                serverSettings,
+                providerAdapterRegistry,
+              ).pipe(
                 Effect.flatMap((adapter) =>
                   adapter.transcribeVoice
                     ? adapter.transcribeVoice(input)

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -17,6 +17,7 @@ import {
   WsFeatureRpcGroup,
   WsRpcError,
   PullRequestsUnavailableError,
+  PROVIDER_DISPLAY_NAMES,
   type DeviceEvent,
   type GitActionProgressEvent,
   type GitHubProjectProvisionProgressEvent,
@@ -24,6 +25,7 @@ import {
   type OrchestrationCommand,
   type OrchestrationEvent,
   type ProjectDevServerEvent,
+  type ProviderKind,
   type OrchestrationShellStreamEvent,
   type OrchestrationShellStreamItem,
   type OrchestrationThreadDetailSnapshot,
@@ -363,6 +365,18 @@ const makeWsRpcHandlersLayer = () =>
       const runtimeStartup = yield* ServerRuntimeStartup;
       const serverEnvironment = yield* ServerEnvironment;
       const serverSettings = yield* ServerSettingsService;
+      const getEnabledProviderAdapter = (provider: ProviderKind) =>
+        serverSettings.getSettings.pipe(
+          Effect.flatMap((settings) =>
+            settings.providers[provider].enabled
+              ? providerAdapterRegistry.getByProvider(provider)
+              : Effect.fail(
+                  new Error(
+                    `${PROVIDER_DISPLAY_NAMES[provider]} is disabled in Settings > Providers.`,
+                  ),
+                ),
+          ),
+        );
       const terminalManager = yield* TerminalManager;
       const textGeneration = yield* TextGeneration;
       const workspaceEntries = yield* WorkspaceEntries;
@@ -1737,12 +1751,26 @@ const makeWsRpcHandlersLayer = () =>
           ),
         [WS_METHODS.serverPrewarmVoice]: (input) =>
           rpcEffect(
-            providerAdapterRegistry
-              .getByProvider(input.provider)
-              .pipe(
+            getEnabledProviderAdapter(input.provider).pipe(
+              Effect.flatMap((adapter) =>
+                adapter.prewarmVoice
+                  ? adapter.prewarmVoice(input)
+                  : Effect.fail(
+                      new Error(
+                        `Voice transcription is unavailable for provider '${input.provider}'.`,
+                      ),
+                    ),
+              ),
+            ),
+            "Voice transcription prewarm failed",
+          ),
+        [WS_METHODS.serverTranscribeVoice]: (input) =>
+          rpcEffect(
+            voiceUploadAdmissionGate.run(
+              getEnabledProviderAdapter(input.provider).pipe(
                 Effect.flatMap((adapter) =>
-                  adapter.prewarmVoice
-                    ? adapter.prewarmVoice(input)
+                  adapter.transcribeVoice
+                    ? adapter.transcribeVoice(input)
                     : Effect.fail(
                         new Error(
                           `Voice transcription is unavailable for provider '${input.provider}'.`,
@@ -1750,24 +1778,6 @@ const makeWsRpcHandlersLayer = () =>
                       ),
                 ),
               ),
-            "Voice transcription prewarm failed",
-          ),
-        [WS_METHODS.serverTranscribeVoice]: (input) =>
-          rpcEffect(
-            voiceUploadAdmissionGate.run(
-              providerAdapterRegistry
-                .getByProvider(input.provider)
-                .pipe(
-                  Effect.flatMap((adapter) =>
-                    adapter.transcribeVoice
-                      ? adapter.transcribeVoice(input)
-                      : Effect.fail(
-                          new Error(
-                            `Voice transcription is unavailable for provider '${input.provider}'.`,
-                          ),
-                        ),
-                  ),
-                ),
             ),
             "Voice transcription failed",
           ),

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -608,6 +608,7 @@ const makeWsRpcHandlersLayer = () =>
         projectionSnapshotQuery: projectionReadModelQuery,
         providerAdapterRegistry,
         providerService,
+        serverSettings,
       });
 
       const dispatchOrchestrationCommand = (command: OrchestrationCommand) =>

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -83,6 +83,25 @@ describe("server-backed provider enablement", () => {
     });
   });
 
+  it("sends sparse enablement patches against the latest server view", () => {
+    const currentSettings = {
+      ...DEFAULT_SERVER_SETTINGS_VIEW,
+      providers: {
+        ...DEFAULT_SERVER_SETTINGS_VIEW.providers,
+        opencode: {
+          ...DEFAULT_SERVER_SETTINGS_VIEW.providers.opencode,
+          enabled: false,
+        },
+      },
+    };
+    const patch = appSettingsPatchToServerSettingsPatch(
+      { disabledProviders: ["opencode", "pi"] },
+      currentSettings,
+    );
+
+    expect(patch.providers).toEqual({ pi: { enabled: false } });
+  });
+
   it("invalidates discovery for initial and changed streamed provider settings", () => {
     const disabledOpenCode = {
       ...DEFAULT_SERVER_SETTINGS_VIEW,

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   AppSettingsSchema,
+  applyLocalAppSettingsPatch,
   appSettingsPatchToServerSettingsPatch,
   CUSTOM_MODEL_EDITOR_PROVIDER_SETTINGS,
   DEFAULT_CHAT_FONT_SIZE_PX,
@@ -59,6 +60,27 @@ describe("server-backed provider enablement", () => {
         },
       }),
     ).toEqual(["opencode", "pi"]);
+  });
+
+  it("keeps server-backed provider disablement out of local settings", () => {
+    const stored = AppSettingsSchema.makeUnsafe({
+      disabledProviders: ["opencode"],
+      hiddenProviders: ["pi"],
+    });
+
+    expect(normalizeStoredAppSettings(stored)).toMatchObject({
+      disabledProviders: [],
+      hiddenProviders: ["pi"],
+    });
+    expect(
+      applyLocalAppSettingsPatch(stored, {
+        disabledProviders: ["codex", "opencode"],
+        hiddenProviders: ["kilo"],
+      }),
+    ).toMatchObject({
+      disabledProviders: [],
+      hiddenProviders: ["kilo"],
+    });
   });
 
   it("persists disable and re-enable patches for every provider", () => {

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -4,10 +4,12 @@
 // Exports: Vitest suites for appSettings.ts
 
 import { Schema } from "effect";
+import { DEFAULT_SERVER_SETTINGS_VIEW } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
 import {
   AppSettingsSchema,
+  appSettingsPatchToServerSettingsPatch,
   CUSTOM_MODEL_EDITOR_PROVIDER_SETTINGS,
   DEFAULT_CHAT_FONT_SIZE_PX,
   DEFAULT_FOLLOW_UP_BEHAVIOR,
@@ -23,6 +25,7 @@ import {
   getCustomModelsForProvider,
   getDefaultCustomModelsForProvider,
   getGitTextGenerationModelOptions,
+  getServerDisabledProviders,
   isGitTextGenerationSettingsDirty,
   getProviderStartOptions,
   MODEL_PROVIDER_SETTINGS,
@@ -36,6 +39,49 @@ import {
   resolveFollowUpDispatchMode,
   resolveTerminalFontFamilyStack,
 } from "./appSettings";
+
+describe("server-backed provider enablement", () => {
+  it("reads disabled providers from the server settings view", () => {
+    expect(
+      getServerDisabledProviders({
+        ...DEFAULT_SERVER_SETTINGS_VIEW,
+        providers: {
+          ...DEFAULT_SERVER_SETTINGS_VIEW.providers,
+          opencode: {
+            ...DEFAULT_SERVER_SETTINGS_VIEW.providers.opencode,
+            enabled: false,
+          },
+          pi: {
+            ...DEFAULT_SERVER_SETTINGS_VIEW.providers.pi,
+            enabled: false,
+          },
+        },
+      }),
+    ).toEqual(["opencode", "pi"]);
+  });
+
+  it("persists disable and re-enable patches for every provider", () => {
+    const disabledPatch = appSettingsPatchToServerSettingsPatch({
+      disabledProviders: ["opencode", "pi"],
+    });
+    expect(disabledPatch.providers?.opencode?.enabled).toBe(false);
+    expect(disabledPatch.providers?.pi?.enabled).toBe(false);
+    expect(disabledPatch.providers?.codex?.enabled).toBe(true);
+
+    const reenabledPatch = appSettingsPatchToServerSettingsPatch({ disabledProviders: [] });
+    expect(reenabledPatch.providers?.opencode?.enabled).toBe(true);
+    expect(reenabledPatch.providers?.pi?.enabled).toBe(true);
+
+    const combinedPatch = appSettingsPatchToServerSettingsPatch({
+      disabledProviders: [],
+      openCodeBinaryPath: "/custom/opencode",
+    });
+    expect(combinedPatch.providers?.opencode).toMatchObject({
+      binaryPath: "/custom/opencode",
+      enabled: true,
+    });
+  });
+});
 
 describe("normalizeCustomModelSlugs", () => {
   it("normalizes aliases, removes built-ins, and deduplicates values", () => {

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -102,6 +102,18 @@ describe("server-backed provider enablement", () => {
     expect(patch.providers).toEqual({ pi: { enabled: false } });
   });
 
+  it("omits unchanged provider defaults from a reset patch", () => {
+    const patch = appSettingsPatchToServerSettingsPatch(
+      {
+        disabledProviders: [],
+        openCodeBinaryPath: DEFAULT_SERVER_SETTINGS_VIEW.providers.opencode.binaryPath,
+      },
+      DEFAULT_SERVER_SETTINGS_VIEW,
+    );
+
+    expect(patch.providers).toBeUndefined();
+  });
+
   it("invalidates discovery for initial and changed streamed provider settings", () => {
     const disabledOpenCode = {
       ...DEFAULT_SERVER_SETTINGS_VIEW,

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_TERMINAL_FONT_SIZE_PX,
   DEFAULT_SIDEBAR_THREAD_SORT_ORDER,
   DEFAULT_TIMESTAMP_FORMAT,
+  didProviderEnablementChange,
   getAppModelOptions,
   getCustomBinaryPathForProvider,
   getDefaultNativeFontSmoothing,
@@ -80,6 +81,25 @@ describe("server-backed provider enablement", () => {
       binaryPath: "/custom/opencode",
       enabled: true,
     });
+  });
+
+  it("invalidates discovery for initial and changed streamed provider settings", () => {
+    const disabledOpenCode = {
+      ...DEFAULT_SERVER_SETTINGS_VIEW,
+      providers: {
+        ...DEFAULT_SERVER_SETTINGS_VIEW.providers,
+        opencode: {
+          ...DEFAULT_SERVER_SETTINGS_VIEW.providers.opencode,
+          enabled: false,
+        },
+      },
+    };
+
+    expect(didProviderEnablementChange(undefined, disabledOpenCode)).toBe(true);
+    expect(
+      didProviderEnablementChange(DEFAULT_SERVER_SETTINGS_VIEW, DEFAULT_SERVER_SETTINGS_VIEW),
+    ).toBe(false);
+    expect(didProviderEnablementChange(DEFAULT_SERVER_SETTINGS_VIEW, disabledOpenCode)).toBe(true);
   });
 });
 

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -669,6 +669,7 @@ function touchesProviderDiscoverySettings(patch: Partial<AppSettings>): boolean 
 
 export function appSettingsPatchToServerSettingsPatch(
   patch: Partial<AppSettings>,
+  currentSettings?: Pick<ServerSettingsView, "providers">,
 ): ServerSettingsPatch {
   const providers: MutableServerSettingsProvidersPatch = {};
   const serverPatch: MutableServerSettingsPatch = {};
@@ -803,16 +804,16 @@ export function appSettingsPatchToServerSettingsPatch(
   }
   if (hasOwn(patch, "disabledProviders")) {
     const disabledProviders = new Set(normalizeHiddenProviders(patch.disabledProviders ?? []));
-    const enabledPatches = Object.fromEntries(
-      DEFAULT_PROVIDER_ORDER.map((provider) => [
-        provider,
-        {
-          ...providers[provider],
-          enabled: !disabledProviders.has(provider),
-        },
-      ]),
-    ) as MutableServerSettingsProvidersPatch;
-    Object.assign(providers, enabledPatches);
+    for (const provider of DEFAULT_PROVIDER_ORDER) {
+      const enabled = !disabledProviders.has(provider);
+      if (currentSettings?.providers[provider].enabled === enabled) {
+        continue;
+      }
+      providers[provider] = {
+        ...providers[provider],
+        enabled,
+      };
+    }
   }
 
   if (Object.keys(providers).length > 0) {
@@ -1341,7 +1342,7 @@ export function useAppSettings() {
           : {}),
       }),
     );
-    const serverPatch = appSettingsPatchToServerSettingsPatch(patch);
+    const serverPatch = appSettingsPatchToServerSettingsPatch(patch, serverSettingsQuery.data);
     if (isServerSettingsPatchEmpty(serverPatch)) {
       return;
     }
@@ -1375,7 +1376,7 @@ export function useAppSettings() {
 
   const resetSettings = async (): Promise<void> => {
     setSettings(DEFAULT_APP_SETTINGS);
-    const serverPatch = appSettingsPatchToServerSettingsPatch(defaults);
+    const serverPatch = appSettingsPatchToServerSettingsPatch(defaults, serverSettingsQuery.data);
     try {
       const nextSettings = await ensureNativeApi().server.updateSettings(serverPatch);
       queryClient.setQueryData(serverQueryKeys.settings(), nextSettings);

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -589,6 +589,18 @@ export function getServerDisabledProviders(
   return DEFAULT_PROVIDER_ORDER.filter((provider) => !settings.providers[provider].enabled);
 }
 
+export function didProviderEnablementChange(
+  previous: Pick<ServerSettingsView, "providers"> | undefined,
+  next: Pick<ServerSettingsView, "providers">,
+): boolean {
+  return (
+    previous === undefined ||
+    DEFAULT_PROVIDER_ORDER.some(
+      (provider) => previous.providers[provider].enabled !== next.providers[provider].enabled,
+    )
+  );
+}
+
 function serverSettingsToAppSettings(settings: ServerSettingsView): Partial<AppSettings> {
   return {
     claudeBinaryPath: settings.providers.claudeAgent.binaryPath,
@@ -1305,7 +1317,18 @@ export function useAppSettings() {
       });
   }, [localSettings, queryClient, serverSettingsQuery.data]);
 
-  const updateSettings = (patch: Partial<AppSettings>) => {
+  const refreshProvidersAfterEnablementChange = async () => {
+    const api = ensureNativeApi();
+    await api.server
+      .refreshProviders()
+      .then((result) => reconcileServerProviderStatuses(queryClient, result.providers))
+      .catch(() => queryClient.invalidateQueries({ queryKey: serverQueryKeys.config() }));
+    await queryClient
+      .invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all })
+      .catch(() => undefined);
+  };
+
+  const updateSettingsAndWait = async (patch: Partial<AppSettings>): Promise<void> => {
     setSettings((prev) =>
       normalizeAppSettings({
         ...prev,
@@ -1324,46 +1347,54 @@ export function useAppSettings() {
     }
 
     const api = ensureNativeApi();
-    void api.server
-      .updateSettings(serverPatch)
-      .then((nextSettings) => {
-        queryClient.setQueryData(serverQueryKeys.settings(), nextSettings);
-        if (hasOwn(patch, "disabledProviders")) {
-          void api.server
-            .refreshProviders()
-            .then((result) => reconcileServerProviderStatuses(queryClient, result.providers))
-            .catch(() => queryClient.invalidateQueries({ queryKey: serverQueryKeys.config() }));
-        }
-        if (touchesProviderDiscoverySettings(patch)) {
-          void queryClient.invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all });
-        }
-      })
-      .catch(() => {
-        void queryClient.invalidateQueries({ queryKey: serverQueryKeys.settings() });
-        if (touchesProviderDiscoverySettings(patch)) {
-          void queryClient.invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all });
-        }
-      });
+    try {
+      const nextSettings = await api.server.updateSettings(serverPatch);
+      queryClient.setQueryData(serverQueryKeys.settings(), nextSettings);
+      if (hasOwn(patch, "disabledProviders")) {
+        await refreshProvidersAfterEnablementChange();
+      } else if (touchesProviderDiscoverySettings(patch)) {
+        await queryClient
+          .invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all })
+          .catch(() => undefined);
+      }
+    } catch {
+      await queryClient
+        .invalidateQueries({ queryKey: serverQueryKeys.settings() })
+        .catch(() => undefined);
+      if (touchesProviderDiscoverySettings(patch)) {
+        await queryClient
+          .invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all })
+          .catch(() => undefined);
+      }
+    }
   };
 
-  const resetSettings = () => {
+  const updateSettings = (patch: Partial<AppSettings>): void => {
+    void updateSettingsAndWait(patch);
+  };
+
+  const resetSettings = async (): Promise<void> => {
     setSettings(DEFAULT_APP_SETTINGS);
-    void queryClient.invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all });
     const serverPatch = appSettingsPatchToServerSettingsPatch(defaults);
-    void ensureNativeApi()
-      .server.updateSettings(serverPatch)
-      .then((nextSettings) => {
-        queryClient.setQueryData(serverQueryKeys.settings(), nextSettings);
-      })
-      .catch(() => {
-        void queryClient.invalidateQueries({ queryKey: serverQueryKeys.settings() });
-      });
+    try {
+      const nextSettings = await ensureNativeApi().server.updateSettings(serverPatch);
+      queryClient.setQueryData(serverQueryKeys.settings(), nextSettings);
+      await refreshProvidersAfterEnablementChange();
+    } catch {
+      await queryClient
+        .invalidateQueries({ queryKey: serverQueryKeys.settings() })
+        .catch(() => undefined);
+      await queryClient
+        .invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all })
+        .catch(() => undefined);
+    }
   };
 
   return {
     settings,
     serverSettings: serverSettingsQuery.data,
     updateSettings,
+    updateSettingsAndWait,
     resetSettings,
     defaults,
   } as const;

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -40,7 +40,11 @@ import {
 } from "./providerOrdering";
 import { ensureNativeApi } from "./nativeApi";
 import { providerDiscoveryQueryKeys } from "./lib/providerDiscoveryReactQuery";
-import { serverQueryKeys, serverSettingsQueryOptions } from "./lib/serverReactQuery";
+import {
+  reconcileServerProviderStatuses,
+  serverQueryKeys,
+  serverSettingsQueryOptions,
+} from "./lib/serverReactQuery";
 import {
   DEFAULT_UI_DENSITY,
   UI_DENSITY_MODES,
@@ -291,6 +295,9 @@ export const AppSettingsSchema = Schema.Struct({
   // The active/locked provider for a thread is always shown regardless, so users
   // never get stuck on a thread whose provider they later chose to hide.
   hiddenProviders: Schema.Array(PersistedProviderKind).pipe(withDefaults(() => [])),
+  // Server-backed provider shutdown policy. Unlike `hiddenProviders`, entries here
+  // cannot run discovery, health checks, updates, or new turns until re-enabled.
+  disabledProviders: Schema.Array(PersistedProviderKind).pipe(withDefaults(() => [])),
   // Local-only UI preference: top-level provider order in Settings and the composer picker.
   providerOrder: Schema.Array(PersistedProviderKind).pipe(
     withDefaults(() => [...DEFAULT_PROVIDER_ORDER]),
@@ -570,9 +577,16 @@ function normalizeAppSettings(settings: AppSettings): AppSettings {
     customOpenCodeModels: normalizeCustomModelSlugs(settings.customOpenCodeModels, "opencode"),
     customPiModels: normalizeCustomModelSlugs(settings.customPiModels, "pi"),
     hiddenProviders: normalizeHiddenProviders(settings.hiddenProviders),
+    disabledProviders: normalizeHiddenProviders(settings.disabledProviders),
     providerOrder: normalizeProviderOrder(settings.providerOrder),
     hiddenModels: [],
   };
+}
+
+export function getServerDisabledProviders(
+  settings: Pick<ServerSettingsView, "providers">,
+): ProviderKind[] {
+  return DEFAULT_PROVIDER_ORDER.filter((provider) => !settings.providers[provider].enabled);
 }
 
 function serverSettingsToAppSettings(settings: ServerSettingsView): Partial<AppSettings> {
@@ -606,6 +620,7 @@ function serverSettingsToAppSettings(settings: ServerSettingsView): Partial<AppS
     customKiloModels: settings.providers.kilo.customModels,
     customOpenCodeModels: settings.providers.opencode.customModels,
     customPiModels: settings.providers.pi.customModels,
+    disabledProviders: getServerDisabledProviders(settings),
     textGenerationProvider: settings.textGenerationModelSelection.provider,
     textGenerationModel: settings.textGenerationModelSelection.model,
   };
@@ -635,11 +650,14 @@ function touchesProviderDiscoverySettings(patch: Partial<AppSettings>): boolean 
     hasOwn(patch, "openCodeExperimentalWebSockets") ||
     hasOwn(patch, "openCodeServerPassword") ||
     hasOwn(patch, "openCodeServerUrl") ||
-    hasOwn(patch, "piAgentDir")
+    hasOwn(patch, "piAgentDir") ||
+    hasOwn(patch, "disabledProviders")
   );
 }
 
-function appSettingsPatchToServerSettingsPatch(patch: Partial<AppSettings>): ServerSettingsPatch {
+export function appSettingsPatchToServerSettingsPatch(
+  patch: Partial<AppSettings>,
+): ServerSettingsPatch {
   const providers: MutableServerSettingsProvidersPatch = {};
   const serverPatch: MutableServerSettingsPatch = {};
 
@@ -664,7 +682,6 @@ function appSettingsPatchToServerSettingsPatch(patch: Partial<AppSettings>): Ser
       model,
     };
   }
-
   if (
     hasOwn(patch, "codexBinaryPath") ||
     hasOwn(patch, "codexHomePath") ||
@@ -771,6 +788,19 @@ function appSettingsPatchToServerSettingsPatch(patch: Partial<AppSettings>): Ser
       ...(hasOwn(patch, "piBinaryPath") ? { binaryPath: patch.piBinaryPath ?? "" } : {}),
       ...(hasOwn(patch, "customPiModels") ? { customModels: patch.customPiModels ?? [] } : {}),
     };
+  }
+  if (hasOwn(patch, "disabledProviders")) {
+    const disabledProviders = new Set(normalizeHiddenProviders(patch.disabledProviders ?? []));
+    const enabledPatches = Object.fromEntries(
+      DEFAULT_PROVIDER_ORDER.map((provider) => [
+        provider,
+        {
+          ...providers[provider],
+          enabled: !disabledProviders.has(provider),
+        },
+      ]),
+    ) as MutableServerSettingsProvidersPatch;
+    Object.assign(providers, enabledPatches);
   }
 
   if (Object.keys(providers).length > 0) {
@@ -1288,22 +1318,33 @@ export function useAppSettings() {
           : {}),
       }),
     );
-    if (touchesProviderDiscoverySettings(patch)) {
-      void queryClient.invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all });
-    }
-
     const serverPatch = appSettingsPatchToServerSettingsPatch(patch);
     if (isServerSettingsPatchEmpty(serverPatch)) {
       return;
     }
 
-    void ensureNativeApi()
-      .server.updateSettings(serverPatch)
+    const api = ensureNativeApi();
+    void api.server
+      .updateSettings(serverPatch)
       .then((nextSettings) => {
         queryClient.setQueryData(serverQueryKeys.settings(), nextSettings);
+        if (hasOwn(patch, "disabledProviders")) {
+          void api.server
+            .refreshProviders()
+            .then((result) => reconcileServerProviderStatuses(queryClient, result.providers))
+            .catch(() =>
+              queryClient.invalidateQueries({ queryKey: serverQueryKeys.config() }),
+            );
+        }
+        if (touchesProviderDiscoverySettings(patch)) {
+          void queryClient.invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all });
+        }
       })
       .catch(() => {
         void queryClient.invalidateQueries({ queryKey: serverQueryKeys.settings() });
+        if (touchesProviderDiscoverySettings(patch)) {
+          void queryClient.invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all });
+        }
       });
   };
 

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -1332,9 +1332,7 @@ export function useAppSettings() {
           void api.server
             .refreshProviders()
             .then((result) => reconcileServerProviderStatuses(queryClient, result.providers))
-            .catch(() =>
-              queryClient.invalidateQueries({ queryKey: serverQueryKeys.config() }),
-            );
+            .catch(() => queryClient.invalidateQueries({ queryKey: serverQueryKeys.config() }));
         }
         if (touchesProviderDiscoverySettings(patch)) {
           void queryClient.invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all });

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -925,7 +925,29 @@ function buildInitialServerSettingsMigrationPatch(settings: AppSettings): Server
 }
 
 export function normalizeStoredAppSettings(settings: AppSettings): AppSettings {
-  return normalizeAppSettings(settings);
+  return {
+    ...normalizeAppSettings(settings),
+    // Provider enablement belongs to the connected server. Scrub legacy values
+    // so a browser profile cannot project one server's shutdown state onto another.
+    disabledProviders: [],
+  };
+}
+
+export function applyLocalAppSettingsPatch(
+  settings: AppSettings,
+  patch: Partial<AppSettings>,
+): AppSettings {
+  const { disabledProviders: _disabledProviders, ...localPatch } = patch;
+  return normalizeStoredAppSettings({
+    ...settings,
+    ...localPatch,
+    ...(hasOwn(patch, "kiloServerPassword")
+      ? { kiloServerPasswordConfigured: Boolean(patch.kiloServerPassword?.trim()) }
+      : {}),
+    ...(hasOwn(patch, "openCodeServerPassword")
+      ? { openCodeServerPasswordConfigured: Boolean(patch.openCodeServerPassword?.trim()) }
+      : {}),
+  });
 }
 
 export function getCustomModelsForProvider(
@@ -1312,8 +1334,9 @@ export function useAppSettings() {
     ...serverSettingsToAppSettings(DEFAULT_SERVER_SETTINGS_VIEW),
   });
 
+  const normalizedLocalSettings = normalizeStoredAppSettings(localSettings);
   const settings = normalizeAppSettings({
-    ...localSettings,
+    ...normalizedLocalSettings,
     ...(serverSettingsQuery.data ? serverSettingsToAppSettings(serverSettingsQuery.data) : {}),
   });
 
@@ -1381,18 +1404,7 @@ export function useAppSettings() {
   };
 
   const updateSettingsAndWait = async (patch: Partial<AppSettings>): Promise<void> => {
-    setSettings((prev) =>
-      normalizeAppSettings({
-        ...prev,
-        ...patch,
-        ...(hasOwn(patch, "kiloServerPassword")
-          ? { kiloServerPasswordConfigured: Boolean(patch.kiloServerPassword?.trim()) }
-          : {}),
-        ...(hasOwn(patch, "openCodeServerPassword")
-          ? { openCodeServerPasswordConfigured: Boolean(patch.openCodeServerPassword?.trim()) }
-          : {}),
-      }),
-    );
+    setSettings((prev) => applyLocalAppSettingsPatch(prev, patch));
     await enqueueServerSettingsMutation(async () => {
       const currentServerSettings =
         queryClient.getQueryData<ServerSettingsView>(serverQueryKeys.settings()) ??

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -667,6 +667,38 @@ function touchesProviderDiscoverySettings(patch: Partial<AppSettings>): boolean 
   );
 }
 
+function serverSettingValuesEqual(left: unknown, right: unknown): boolean {
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return left.length === right.length && left.every((value, index) => value === right[index]);
+  }
+  return left === right;
+}
+
+function pruneProviderPatchAgainstCurrentSettings(
+  providers: MutableServerSettingsProvidersPatch,
+  currentSettings: Pick<ServerSettingsView, "providers">,
+): void {
+  for (const provider of DEFAULT_PROVIDER_ORDER) {
+    const providerPatch = providers[provider];
+    if (!providerPatch) continue;
+
+    const patchRecord = providerPatch as Record<string, unknown>;
+    const currentRecord = currentSettings.providers[provider] as unknown as Record<string, unknown>;
+    for (const [key, value] of Object.entries(patchRecord)) {
+      const matchesCurrent =
+        key === "serverPassword"
+          ? value === "" && currentRecord.serverPasswordConfigured === false
+          : serverSettingValuesEqual(value, currentRecord[key]);
+      if (matchesCurrent) {
+        delete patchRecord[key];
+      }
+    }
+    if (Object.keys(patchRecord).length === 0) {
+      delete providers[provider];
+    }
+  }
+}
+
 export function appSettingsPatchToServerSettingsPatch(
   patch: Partial<AppSettings>,
   currentSettings?: Pick<ServerSettingsView, "providers">,
@@ -814,6 +846,10 @@ export function appSettingsPatchToServerSettingsPatch(
         enabled,
       };
     }
+  }
+
+  if (currentSettings) {
+    pruneProviderPatchAgainstCurrentSettings(providers, currentSettings);
   }
 
   if (Object.keys(providers).length > 0) {
@@ -1269,6 +1305,7 @@ export function useAppSettings() {
     AppSettingsSchema,
   );
   const normalizedStoredSettingsRef = useRef(false);
+  const serverSettingsMutationQueueRef = useRef<Promise<void>>(Promise.resolve());
 
   const defaults = normalizeAppSettings({
     ...DEFAULT_APP_SETTINGS,
@@ -1329,6 +1366,20 @@ export function useAppSettings() {
       .catch(() => undefined);
   };
 
+  const enqueueServerSettingsMutation = <Result>(
+    mutation: () => Promise<Result>,
+  ): Promise<Result> => {
+    const queued = serverSettingsMutationQueueRef.current.then(
+      () => mutation(),
+      () => mutation(),
+    );
+    serverSettingsMutationQueueRef.current = queued.then(
+      () => undefined,
+      () => undefined,
+    );
+    return queued;
+  };
+
   const updateSettingsAndWait = async (patch: Partial<AppSettings>): Promise<void> => {
     setSettings((prev) =>
       normalizeAppSettings({
@@ -1342,32 +1393,37 @@ export function useAppSettings() {
           : {}),
       }),
     );
-    const serverPatch = appSettingsPatchToServerSettingsPatch(patch, serverSettingsQuery.data);
-    if (isServerSettingsPatchEmpty(serverPatch)) {
-      return;
-    }
+    await enqueueServerSettingsMutation(async () => {
+      const currentServerSettings =
+        queryClient.getQueryData<ServerSettingsView>(serverQueryKeys.settings()) ??
+        serverSettingsQuery.data;
+      const serverPatch = appSettingsPatchToServerSettingsPatch(patch, currentServerSettings);
+      if (isServerSettingsPatchEmpty(serverPatch)) {
+        return;
+      }
 
-    const api = ensureNativeApi();
-    try {
-      const nextSettings = await api.server.updateSettings(serverPatch);
-      queryClient.setQueryData(serverQueryKeys.settings(), nextSettings);
-      if (hasOwn(patch, "disabledProviders")) {
-        await refreshProvidersAfterEnablementChange();
-      } else if (touchesProviderDiscoverySettings(patch)) {
+      const api = ensureNativeApi();
+      try {
+        const nextSettings = await api.server.updateSettings(serverPatch);
+        queryClient.setQueryData(serverQueryKeys.settings(), nextSettings);
+        if (hasOwn(patch, "disabledProviders")) {
+          await refreshProvidersAfterEnablementChange();
+        } else if (touchesProviderDiscoverySettings(patch)) {
+          await queryClient
+            .invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all })
+            .catch(() => undefined);
+        }
+      } catch {
         await queryClient
-          .invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all })
+          .invalidateQueries({ queryKey: serverQueryKeys.settings() })
           .catch(() => undefined);
+        if (touchesProviderDiscoverySettings(patch)) {
+          await queryClient
+            .invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all })
+            .catch(() => undefined);
+        }
       }
-    } catch {
-      await queryClient
-        .invalidateQueries({ queryKey: serverQueryKeys.settings() })
-        .catch(() => undefined);
-      if (touchesProviderDiscoverySettings(patch)) {
-        await queryClient
-          .invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all })
-          .catch(() => undefined);
-      }
-    }
+    });
   };
 
   const updateSettings = (patch: Partial<AppSettings>): void => {
@@ -1376,19 +1432,34 @@ export function useAppSettings() {
 
   const resetSettings = async (): Promise<void> => {
     setSettings(DEFAULT_APP_SETTINGS);
-    const serverPatch = appSettingsPatchToServerSettingsPatch(defaults, serverSettingsQuery.data);
-    try {
-      const nextSettings = await ensureNativeApi().server.updateSettings(serverPatch);
-      queryClient.setQueryData(serverQueryKeys.settings(), nextSettings);
-      await refreshProvidersAfterEnablementChange();
-    } catch {
-      await queryClient
-        .invalidateQueries({ queryKey: serverQueryKeys.settings() })
-        .catch(() => undefined);
-      await queryClient
-        .invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all })
-        .catch(() => undefined);
-    }
+    await enqueueServerSettingsMutation(async () => {
+      const currentServerSettings =
+        queryClient.getQueryData<ServerSettingsView>(serverQueryKeys.settings()) ??
+        serverSettingsQuery.data;
+      const serverPatch = appSettingsPatchToServerSettingsPatch(defaults, currentServerSettings);
+      const providerSettingsChanged = Boolean(
+        serverPatch.providers && Object.keys(serverPatch.providers).length > 0,
+      );
+      if (isServerSettingsPatchEmpty(serverPatch)) {
+        return;
+      }
+      try {
+        const nextSettings = await ensureNativeApi().server.updateSettings(serverPatch);
+        queryClient.setQueryData(serverQueryKeys.settings(), nextSettings);
+        if (providerSettingsChanged) {
+          await refreshProvidersAfterEnablementChange();
+        }
+      } catch {
+        await queryClient
+          .invalidateQueries({ queryKey: serverQueryKeys.settings() })
+          .catch(() => undefined);
+        if (providerSettingsChanged) {
+          await queryClient
+            .invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all })
+            .catch(() => undefined);
+        }
+      }
+    });
   };
 
   return {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4068,6 +4068,7 @@ export default function ChatView({
             status,
             customBinaryPath,
             confirmedCustomBinaryPath: confirmedCustomBinaryPathsByProvider[status.provider],
+            disabled: settings.disabledProviders.includes(status.provider),
           });
         })
         .flatMap((status) => (status ? [status] : [])),

--- a/apps/web/src/components/settings/ProvidersSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProvidersSettingsPanel.tsx
@@ -971,9 +971,7 @@ export function ProvidersSettingsPanel({
             disabledProviderSet.size > 0 ? (
               <SettingResetButton
                 label="enabled providers"
-                onClick={() =>
-                  updateSettings({ disabledProviders: defaults.disabledProviders })
-                }
+                onClick={() => updateSettings({ disabledProviders: defaults.disabledProviders })}
               />
             ) : null
           }

--- a/apps/web/src/components/settings/ProvidersSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProvidersSettingsPanel.tsx
@@ -27,7 +27,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { type MouseEvent, type ReactNode, useCallback, useMemo, useState } from "react";
+import { type MouseEvent, type ReactNode, useCallback, useMemo, useRef, useState } from "react";
 
 import type { AppSettings, AppSettingsBinding } from "~/appSettings";
 import { useProviderStatusesForLocalConfig } from "~/hooks/useProviderStatusesForLocalConfig";
@@ -807,12 +807,14 @@ function ProviderToolRow(props: {
 export type ProvidersSettingsPanelProps = AppSettingsBinding & {
   readonly active: boolean;
   readonly resetEpoch: number;
+  readonly updateSettingsAndWait: (patch: Partial<AppSettings>) => Promise<void>;
 };
 
 export function ProvidersSettingsPanel({
   settings,
   defaults,
   updateSettings,
+  updateSettingsAndWait,
   active,
   resetEpoch,
 }: ProvidersSettingsPanelProps) {
@@ -827,6 +829,8 @@ export function ProvidersSettingsPanel({
   const [updatingProviders, setUpdatingProviders] = useState<ReadonlySet<ProviderKind>>(
     () => new Set(),
   );
+  const providerEnablementMutationInFlightRef = useRef(false);
+  const [providerEnablementMutationPending, setProviderEnablementMutationPending] = useState(false);
   const hiddenProviderSet = useMemo(
     () => new Set<ProviderKind>(settings.hiddenProviders),
     [settings.hiddenProviders],
@@ -891,6 +895,21 @@ export function ProvidersSettingsPanel({
   );
   const outdatedProviderCount = outdatedProviderStatuses.length;
   const installSettingsDirty = isProviderInstallSettingsDirty(settings, defaults);
+
+  const updateProviderEnablement = useCallback(
+    async (disabledProviders: ProviderKind[]) => {
+      if (providerEnablementMutationInFlightRef.current) return;
+      providerEnablementMutationInFlightRef.current = true;
+      setProviderEnablementMutationPending(true);
+      try {
+        await updateSettingsAndWait({ disabledProviders });
+      } finally {
+        providerEnablementMutationInFlightRef.current = false;
+        setProviderEnablementMutationPending(false);
+      }
+    },
+    [updateSettingsAndWait],
+  );
 
   useSettingsRestoreSignal(resetEpoch, () => {
     setOpenInstallProviders(createClosedProviderInstallDisclosureState());
@@ -966,12 +985,16 @@ export function ProvidersSettingsPanel({
         <SettingsRow
           title="Enabled providers"
           description="Disabling a provider stops its background health checks, model and command discovery, updates, and new turns. Existing threads stay visible and continue after you re-enable it; a turn already running is not interrupted."
-          status={`${enabledProviderCount} of ${PROVIDER_VISIBILITY_OPTIONS.length} enabled`}
+          status={
+            providerEnablementMutationPending
+              ? "Saving provider activity"
+              : `${enabledProviderCount} of ${PROVIDER_VISIBILITY_OPTIONS.length} enabled`
+          }
           resetAction={
-            disabledProviderSet.size > 0 ? (
+            disabledProviderSet.size > 0 && !providerEnablementMutationPending ? (
               <SettingResetButton
                 label="enabled providers"
-                onClick={() => updateSettings({ disabledProviders: defaults.disabledProviders })}
+                onClick={() => void updateProviderEnablement([...defaults.disabledProviders])}
               />
             ) : null
           }
@@ -998,15 +1021,15 @@ export function ProvidersSettingsPanel({
                   actions={
                     <Switch
                       checked={enabled}
-                      disabled={serverSettingsQuery.isPending}
+                      disabled={serverSettingsQuery.isPending || providerEnablementMutationPending}
                       onCheckedChange={(checked) =>
-                        updateSettings({
-                          disabledProviders: setProviderDisabled(
+                        void updateProviderEnablement(
+                          setProviderDisabled(
                             settings.disabledProviders,
                             option.provider,
                             !Boolean(checked),
                           ),
-                        })
+                        )
                       }
                       aria-label={`${enabled ? "Disable" : "Enable"} ${option.title}`}
                     />

--- a/apps/web/src/components/settings/ProvidersSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProvidersSettingsPanel.tsx
@@ -1021,7 +1021,7 @@ export function ProvidersSettingsPanel({
                   actions={
                     <Switch
                       checked={enabled}
-                      disabled={serverSettingsQuery.isPending || providerEnablementMutationPending}
+                      disabled={!serverSettingsQuery.data || providerEnablementMutationPending}
                       onCheckedChange={(checked) =>
                         void updateProviderEnablement(
                           setProviderDisabled(

--- a/apps/web/src/components/settings/ProvidersSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProvidersSettingsPanel.tsx
@@ -445,6 +445,15 @@ function setProviderHidden(
   return hidden ? [...withoutTarget, provider] : withoutTarget;
 }
 
+function setProviderDisabled(
+  current: ReadonlyArray<ProviderKind>,
+  provider: ProviderKind,
+  disabled: boolean,
+): ProviderKind[] {
+  const withoutTarget = current.filter((entry) => entry !== provider);
+  return disabled ? [...withoutTarget, provider] : withoutTarget;
+}
+
 function isProviderPickerProviderEnabled(
   providerStatus: Pick<ServerProviderStatus, "available"> | null | undefined,
   isHidden: boolean,
@@ -823,6 +832,11 @@ export function ProvidersSettingsPanel({
     [settings.hiddenProviders],
   );
   const hiddenProviderCount = hiddenProviderSet.size;
+  const disabledProviderSet = useMemo(
+    () => new Set<ProviderKind>(settings.disabledProviders),
+    [settings.disabledProviders],
+  );
+  const enabledProviderCount = PROVIDER_VISIBILITY_OPTIONS.length - disabledProviderSet.size;
   const providerVisibilityOptionsByProvider = useMemo(
     () => new Map(PROVIDER_VISIBILITY_OPTIONS.map((option) => [option.provider, option])),
     [],
@@ -948,10 +962,68 @@ export function ProvidersSettingsPanel({
 
   return (
     <div className="space-y-6">
+      <SettingsSection title="Provider activity">
+        <SettingsRow
+          title="Enabled providers"
+          description="Disabling a provider stops its background health checks, model and command discovery, updates, and new turns. Existing threads stay visible and continue after you re-enable it; a turn already running is not interrupted."
+          status={`${enabledProviderCount} of ${PROVIDER_VISIBILITY_OPTIONS.length} enabled`}
+          resetAction={
+            disabledProviderSet.size > 0 ? (
+              <SettingResetButton
+                label="enabled providers"
+                onClick={() =>
+                  updateSettings({ disabledProviders: defaults.disabledProviders })
+                }
+              />
+            ) : null
+          }
+        >
+          <div
+            className={cn(
+              "mt-4",
+              SETTINGS_INSET_LIST_CLASS_NAME,
+              SETTINGS_STACKED_ROWS_DIVIDER_CLASS_NAME,
+            )}
+          >
+            {orderedProviderVisibilityOptions.map((option) => {
+              const enabled = !disabledProviderSet.has(option.provider);
+              return (
+                <SettingsListRow
+                  key={option.provider}
+                  title={
+                    <span className="flex items-center gap-2">
+                      <ProviderIcon provider={option.provider} className="size-4 shrink-0" />
+                      <span>{option.title}</span>
+                    </span>
+                  }
+                  description={enabled ? "Background activity allowed" : "Disabled on the server"}
+                  actions={
+                    <Switch
+                      checked={enabled}
+                      disabled={serverSettingsQuery.isPending}
+                      onCheckedChange={(checked) =>
+                        updateSettings({
+                          disabledProviders: setProviderDisabled(
+                            settings.disabledProviders,
+                            option.provider,
+                            !Boolean(checked),
+                          ),
+                        })
+                      }
+                      aria-label={`${enabled ? "Disable" : "Enable"} ${option.title}`}
+                    />
+                  }
+                />
+              );
+            })}
+          </div>
+        </SettingsRow>
+      </SettingsSection>
+
       <SettingsSection title="Provider picker">
         <SettingsRow
           title="Available CLIs"
-          description="Installed providers appear in the picker. Turn off any you don't want to see, and drag them into your preferred order."
+          description="Show or hide installed providers in the picker and drag them into your preferred order. Hiding a provider here does not disable its server activity."
           status={
             serverConfigQuery.isPending || hasPendingProviderStatuses
               ? "Checking installed CLIs"

--- a/apps/web/src/components/settings/ProvidersSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProvidersSettingsPanel.tsx
@@ -436,22 +436,13 @@ export function createProviderInstallResetPatch(defaults: AppSettings): Partial<
   ) as Partial<AppSettings>;
 }
 
-function setProviderHidden(
+function setProviderListMembership(
   current: ReadonlyArray<ProviderKind>,
   provider: ProviderKind,
-  hidden: boolean,
+  included: boolean,
 ): ProviderKind[] {
   const withoutTarget = current.filter((entry) => entry !== provider);
-  return hidden ? [...withoutTarget, provider] : withoutTarget;
-}
-
-function setProviderDisabled(
-  current: ReadonlyArray<ProviderKind>,
-  provider: ProviderKind,
-  disabled: boolean,
-): ProviderKind[] {
-  const withoutTarget = current.filter((entry) => entry !== provider);
-  return disabled ? [...withoutTarget, provider] : withoutTarget;
+  return included ? [...withoutTarget, provider] : withoutTarget;
 }
 
 function isProviderPickerProviderEnabled(
@@ -1024,7 +1015,7 @@ export function ProvidersSettingsPanel({
                       disabled={!serverSettingsQuery.data || providerEnablementMutationPending}
                       onCheckedChange={(checked) =>
                         void updateProviderEnablement(
-                          setProviderDisabled(
+                          setProviderListMembership(
                             settings.disabledProviders,
                             option.provider,
                             !Boolean(checked),
@@ -1090,7 +1081,7 @@ export function ProvidersSettingsPanel({
                     isHidden={hiddenProviderSet.has(option.provider)}
                     onHiddenChange={(hidden) =>
                       updateSettings({
-                        hiddenProviders: setProviderHidden(
+                        hiddenProviders: setProviderListMembership(
                           settings.hiddenProviders,
                           option.provider,
                           hidden,

--- a/apps/web/src/hooks/useProviderStatusesForLocalConfig.ts
+++ b/apps/web/src/hooks/useProviderStatusesForLocalConfig.ts
@@ -15,6 +15,7 @@ const EMPTY_PROVIDER_STATUSES: ServerProviderStatus[] = [];
 export function useProviderStatusesForLocalConfig(): readonly ServerProviderStatus[] {
   const { settings } = useAppSettings();
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
+  const disabledProviders = new Set(settings.disabledProviders);
 
   return (serverConfigQuery.data?.providers ?? EMPTY_PROVIDER_STATUSES)
     .map((status) =>
@@ -22,6 +23,7 @@ export function useProviderStatusesForLocalConfig(): readonly ServerProviderStat
         provider: status.provider,
         status,
         customBinaryPath: getCustomBinaryPathForProvider(settings, status.provider),
+        disabled: disabledProviders.has(status.provider),
       }),
     )
     .flatMap((status) => (status ? [status] : []));

--- a/apps/web/src/lib/providerAvailability.test.ts
+++ b/apps/web/src/lib/providerAvailability.test.ts
@@ -63,6 +63,21 @@ describe("normalizeProviderStatusForLocalConfig", () => {
     });
   });
 
+  it("keeps a disabled custom-path provider unavailable", () => {
+    expect(
+      normalizeProviderStatusForLocalConfig({
+        provider: "opencode",
+        status: { ...BASE_STATUS, provider: "opencode", message: "OpenCode is disabled." },
+        customBinaryPath: "/custom/bin/opencode",
+        disabled: true,
+      }),
+    ).toEqual({
+      ...BASE_STATUS,
+      provider: "opencode",
+      message: "OpenCode is disabled.",
+    });
+  });
+
   it("marks a custom-path provider ready after a successful session confirms it", () => {
     expect(
       normalizeProviderStatusForLocalConfig({

--- a/apps/web/src/lib/providerAvailability.test.ts
+++ b/apps/web/src/lib/providerAvailability.test.ts
@@ -63,18 +63,25 @@ describe("normalizeProviderStatusForLocalConfig", () => {
     });
   });
 
-  it("keeps a disabled custom-path provider unavailable", () => {
+  it("makes a disabled provider unavailable before its health status refreshes", () => {
     expect(
       normalizeProviderStatusForLocalConfig({
         provider: "opencode",
-        status: { ...BASE_STATUS, provider: "opencode", message: "OpenCode is disabled." },
+        status: {
+          ...READY_STATUS,
+          provider: "opencode",
+          message: "OpenCode is ready.",
+        },
         customBinaryPath: "/custom/bin/opencode",
         disabled: true,
       }),
     ).toEqual({
-      ...BASE_STATUS,
       provider: "opencode",
-      message: "OpenCode is disabled.",
+      status: "warning",
+      available: false,
+      authStatus: "unknown",
+      checkedAt: BASE_STATUS.checkedAt,
+      message: "Provider is disabled in Synara settings.",
     });
   });
 

--- a/apps/web/src/lib/providerAvailability.ts
+++ b/apps/web/src/lib/providerAvailability.ts
@@ -35,7 +35,14 @@ export function normalizeProviderStatusForLocalConfig(input: {
     return null;
   }
   if (input.disabled) {
-    return status;
+    return {
+      provider: input.provider,
+      status: "warning",
+      available: false,
+      authStatus: "unknown",
+      checkedAt: status.checkedAt,
+      message: "Provider is disabled in Synara settings.",
+    };
   }
 
   const customBinaryPath = normalizeCustomBinaryPath(input.customBinaryPath);

--- a/apps/web/src/lib/providerAvailability.ts
+++ b/apps/web/src/lib/providerAvailability.ts
@@ -28,10 +28,14 @@ export function normalizeProviderStatusForLocalConfig(input: {
   status: ServerProviderStatus | null | undefined;
   customBinaryPath?: string | null | undefined;
   confirmedCustomBinaryPath?: string | null | undefined;
+  disabled?: boolean | undefined;
 }): ServerProviderStatus | null {
   const status = input.status ?? null;
   if (!status) {
     return null;
+  }
+  if (input.disabled) {
+    return status;
   }
 
   const customBinaryPath = normalizeCustomBinaryPath(input.customBinaryPath);

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -7,6 +7,7 @@ import {
   type OrchestrationThread,
   type ServerConfig,
   type ServerProviderStatus,
+  type ServerSettingsView,
   type WsCompatibilityError,
 } from "@synara/contracts";
 import { defaultTerminalTitleForCliKind } from "@synara/shared/terminalThreads";
@@ -129,7 +130,7 @@ import { resolveVisibleDockSidechatThreadIds } from "../rightDockStore.logic";
 import { arraysShallowEqual } from "../storeNormalization";
 import { providerModelDiscoveryInvalidationFingerprint } from "../lib/providerDiscoveryInvalidation";
 import { providerDiscoveryQueryKeys } from "../lib/providerDiscoveryReactQuery";
-import { useAppSettings } from "../appSettings";
+import { didProviderEnablementChange, useAppSettings } from "../appSettings";
 import { getNavigatorPlatform } from "../lib/utils";
 import {
   getNotifiableProviderUpdateStatuses,
@@ -2164,7 +2165,13 @@ function EventRouter() {
       { replayCurrent: true },
     );
     const unsubServerSettingsUpdated = onServerSettingsUpdated((payload) => {
+      const previousSettings = queryClient.getQueryData<ServerSettingsView>(
+        serverQueryKeys.settings(),
+      );
       queryClient.setQueryData(serverQueryKeys.settings(), payload.settings);
+      if (didProviderEnablementChange(previousSettings, payload.settings)) {
+        void queryClient.invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all });
+      }
       void queryClient.invalidateQueries({
         queryKey: serverSettingsQueryOptions().queryKey,
       });

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -1303,7 +1303,6 @@ function SettingsRouteView() {
                   settings={settings}
                   defaults={defaults}
                   updateSettings={updateSettings}
-                  updateSettingsAndWait={updateSettingsAndWait}
                   resetEpoch={resetEpoch}
                 />
                 <ProvidersSettingsPanel
@@ -1311,6 +1310,7 @@ function SettingsRouteView() {
                   settings={settings}
                   defaults={defaults}
                   updateSettings={updateSettings}
+                  updateSettingsAndWait={updateSettingsAndWait}
                   resetEpoch={resetEpoch}
                 />
                 <ExternalMcpSettingsPanel active={activeSection === "integrations"} />

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -209,7 +209,8 @@ function SettingsRouteView() {
     systemUiFont,
     setSystemUiFont,
   } = useTheme();
-  const { settings, defaults, updateSettings, resetSettings } = useAppSettings();
+  const { settings, defaults, updateSettings, updateSettingsAndWait, resetSettings } =
+    useAppSettings();
   const desktopTopBarTrafficLightGutterClassName = useDesktopTopBarTrafficLightGutterClassName();
   const [releaseHistoryOpen, setReleaseHistoryOpen] = useState(false);
   const [resetEpoch, setResetEpoch] = useState(0);
@@ -285,6 +286,11 @@ function SettingsRouteView() {
   const isInstallSettingsDirty = isProviderInstallSettingsDirty(settings, defaults);
   const hiddenProviderCount = new Set(settings.hiddenProviders).size;
   const isProviderOrderDirty = !sameProviderOrder(settings.providerOrder, defaults.providerOrder);
+  const isProviderActivityDirty =
+    settings.disabledProviders.length !== defaults.disabledProviders.length ||
+    settings.disabledProviders.some(
+      (provider, index) => provider !== defaults.disabledProviders[index],
+    );
 
   // Deep links and sidebar search targets all resolve to stable DOM ids in the active panel.
   useEffect(() => {
@@ -370,6 +376,7 @@ function SettingsRouteView() {
       ? ["Custom models"]
       : []),
     ...(isInstallSettingsDirty ? ["Provider installs"] : []),
+    ...(isProviderActivityDirty ? ["Provider activity"] : []),
     ...(hiddenProviderCount > 0 ? ["Provider visibility"] : []),
     ...(isProviderOrderDirty ? ["Provider order"] : []),
   ];
@@ -393,7 +400,7 @@ function SettingsRouteView() {
 
     setTheme("system");
     resetAllThemes();
-    resetSettings();
+    await resetSettings();
     setResetEpoch((current) => current + 1);
   }
 
@@ -1296,6 +1303,7 @@ function SettingsRouteView() {
                   settings={settings}
                   defaults={defaults}
                   updateSettings={updateSettings}
+                  updateSettingsAndWait={updateSettingsAndWait}
                   resetEpoch={resetEpoch}
                 />
                 <ProvidersSettingsPanel


### PR DESCRIPTION
## Summary
- add a distinct server-backed Provider activity switch for every provider while keeping picker visibility cosmetic
- persist provider enablement through settings and refresh provider status/model discovery after changes
- short-circuit all provider discovery before adapter calls when disabled, preventing OpenCode discovery servers from spawning
- keep existing threads readable, reject new turns with a direct re-enable message, and resume normally after re-enabling

## Behavior
- disabling does not interrupt a turn already in progress
- disabled providers skip health checks, updates, model/agent/command/skill/plugin discovery, and new turn startup
- hidden providers remain enabled unless explicitly disabled in Provider activity

## Verification
- bun run --cwd apps/web test -- src/appSettings.test.ts src/components/settings/ProvidersSettingsPanel.test.ts src/lib/serverReactQuery.test.ts
- bun run --cwd apps/server test -- src/provider/Layers/ProviderDiscoveryService.test.ts src/provider/Layers/ProviderHealth.test.ts src/serverSettings.test.ts src/orchestration/Layers/ProviderCommandReactor.test.ts
- git diff --check

Closes #792

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide changes to orchestration, automations, and provider startup paths; mis-gating could block turns or leave stale discovery, but behavior is covered by extensive tests and fails closed with explicit errors.
> 
> **Overview**
> **Provider activity is now authoritative on the server.** Disabling a provider in Settings persists via `providers.*.enabled`, blocks adapter access through a shared `getEnabledProviderAdapter` / `ensureProviderEnabled` gate (HTTP voice upload, WebSocket voice, thread import), and returns consistent **409** / validation errors with a Settings > Providers message.
> 
> **Runtime behavior while disabled:** `ProviderService` refuses new sessions and recovery starts; discovery/health/usage skip or return empty **disabled** results; one-click updates abort if the provider is turned off mid-run; Git text generation and automations pause, skip, or defer (including AI stop checks) until a supported provider is enabled again, with settings-stream reconciliation when re-enabled.
> 
> **Web app** maps `disabledProviders` from streamed server settings (scrubbed from localStorage), sends sparse enablement patches, queues settings mutations, and refreshes provider status plus discovery after toggles. Claude credential keepalive now **reconciles** start/stop with Claude Agent enablement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d7b3f46a0d5c9810d965bdfdbbb9c1f07228f10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->