### PR TITLE
[codex] Gate transcript bootstrap on native resume

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -231,7 +231,7 @@ describe("ProviderCommandReactor", () => {
       provider: "codex",
       model: "gpt-5-codex",
     };
-    const startSession = vi.fn((_: unknown, input: unknown) => {
+    const startSession = vi.fn<ProviderServiceShape["startSession"]>((_, input) => {
       const sessionIndex = nextSessionIndex++;
       const sessionModelSelection =
         typeof input === "object" && input !== null && "modelSelection" in input

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -214,6 +214,7 @@ describe("ProviderCommandReactor", () => {
     readonly gitWritingModelSelection?: ModelSelection;
     readonly omitStopRuntimeSession?: boolean;
     readonly serverSettings?: DeepPartial<ServerSettings>;
+    readonly confirmNativeResume?: (resumeCursor: unknown) => boolean;
   }) {
     const now = new Date().toISOString();
     const baseDir = input?.baseDir ?? fs.mkdtempSync(path.join(os.tmpdir(), "synara-reactor-"));
@@ -275,17 +276,19 @@ describe("ProviderCommandReactor", () => {
     >((threadId, sessionInput, outcomeOptions) => {
       const effectiveResumeCursor =
         sessionInput.resumeCursor ?? persistedResumeCursors.get(threadId);
-      const nativeResumeAttempted =
-        effectiveResumeCursor !== undefined && effectiveResumeCursor !== null;
+      const nativeResumeSucceeded =
+        effectiveResumeCursor !== undefined &&
+        effectiveResumeCursor !== null &&
+        (input?.confirmNativeResume?.(effectiveResumeCursor) ?? true);
       if (
         outcomeOptions?.registerPriorTranscriptBootstrapOnFreshStart === true &&
-        !nativeResumeAttempted
+        !nativeResumeSucceeded
       ) {
         pendingPriorTranscriptBootstraps.add(threadId);
       }
       return startSession(threadId, sessionInput).pipe(
         Effect.map((session) => {
-          const resolvedSession = nativeResumeAttempted
+          const resolvedSession = nativeResumeSucceeded
             ? { ...session, resumeCursor: effectiveResumeCursor }
             : session;
           const runtimeIndex = runtimeSessions.findIndex(
@@ -297,7 +300,7 @@ describe("ProviderCommandReactor", () => {
           persistedResumeCursors.set(threadId, resolvedSession.resumeCursor);
           return {
             session: resolvedSession,
-            nativeResumeAttempted,
+            nativeResumeSucceeded,
             priorTranscriptBootstrapPending: pendingPriorTranscriptBootstraps.has(threadId),
           };
         }),
@@ -8303,6 +8306,40 @@ describe("ProviderCommandReactor", () => {
       expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
       const resumedInput = harness.sendTurn.mock.calls[1]?.[0] as { readonly input?: string };
       expect(resumedInput.input).toBe("What did we call the module?");
+    },
+  );
+
+  it.each(["opencode", "kilo"] as const)(
+    "injects transcript context when %s rejects the persisted resume cursor",
+    async (provider) => {
+      const harness = await createHarness({
+        threadModelSelection: { provider, model: "openai/gpt-5" },
+        confirmNativeResume: () => false,
+      });
+      const now = new Date().toISOString();
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-rejected-resume-seed`,
+        text: "The retained codename is heliotrope.",
+        createdAt: now,
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+      await Effect.runPromise(
+        harness.stopRuntimeSession({ threadId: ThreadId.makeUnsafe("thread-1") }),
+      );
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-rejected-resume-follow-up`,
+        text: "What is the retained codename?",
+        createdAt: now,
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+
+      const followUpInput = harness.sendTurn.mock.calls[1]?.[0] as { readonly input?: string };
+      expect(followUpInput.input).toContain("<thread_context>");
+      expect(followUpInput.input).toContain("The retained codename is heliotrope.");
+      expect(followUpInput.input?.match(/What is the retained codename\?/g)).toHaveLength(1);
+      expect(harness.completePriorTranscriptBootstrap).toHaveBeenCalledTimes(1);
     },
   );
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -935,6 +935,39 @@ describe("ProviderCommandReactor", () => {
     );
   }
 
+  async function emitHarnessTurnTerminal(
+    harness: Awaited<ReturnType<typeof createHarness>>,
+    input: {
+      readonly eventId: string;
+      readonly provider: "opencode" | "kilo";
+      readonly type: "completed" | "aborted";
+      readonly threadId?: ThreadId;
+      readonly turnId?: TurnId;
+    },
+  ) {
+    const eventBase = {
+      eventId: asEventId(input.eventId),
+      provider: input.provider,
+      threadId: input.threadId ?? ThreadId.makeUnsafe("thread-1"),
+      createdAt: new Date().toISOString(),
+      turnId: input.turnId ?? asTurnId("turn-1"),
+      providerRefs: {},
+    } as const;
+    await harness.emitRuntimeEvent(
+      input.type === "completed"
+        ? ({
+            ...eventBase,
+            type: "turn.completed",
+            payload: { state: "completed" },
+          } as ProviderRuntimeEvent)
+        : ({
+            ...eventBase,
+            type: "turn.aborted",
+            payload: { reason: "prompt rejected after asynchronous submission" },
+          } as ProviderRuntimeEvent),
+    );
+  }
+
   it("REL-01B gate: delivers intents committed before the reactor subscribes", async () => {
     const harness = await createHarness({ startReactor: false });
     const now = new Date().toISOString();
@@ -8333,7 +8366,71 @@ describe("ProviderCommandReactor", () => {
 
       const sentInput = harness.sendTurn.mock.calls[0]?.[0] as { readonly input?: string };
       expect(sentInput.input).toBe("There is no earlier transcript left to restore.");
-      expect(harness.completePriorTranscriptBootstrap).toHaveBeenCalledTimes(1);
+      expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
+      await emitHarnessTurnTerminal(harness, {
+        eventId: `${provider}-empty-bootstrap-completed`,
+        provider,
+        type: "completed",
+      });
+      await waitFor(() => harness.completePriorTranscriptBootstrap.mock.calls.length === 1);
+      expect(harness.pendingPriorTranscriptBootstraps.has(threadId)).toBe(false);
+    },
+  );
+
+  it.each(["opencode", "kilo"] as const)(
+    "retains the %s transcript recap when async prompt submission aborts",
+    async (provider) => {
+      const harness = await createHarness({
+        threadModelSelection: { provider, model: "openai/gpt-5" },
+      });
+      const threadId = ThreadId.makeUnsafe("thread-1");
+      const rejectedTurnId = asTurnId(`${provider}-async-bootstrap-rejected`);
+      const retryTurnId = asTurnId(`${provider}-async-bootstrap-retry`);
+      const now = new Date().toISOString();
+      harness.pendingPriorTranscriptBootstraps.add(threadId);
+      harness.sendTurn
+        .mockImplementationOnce(() => Effect.succeed({ threadId, turnId: rejectedTurnId }))
+        .mockImplementationOnce(() => Effect.succeed({ threadId, turnId: retryTurnId }));
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-async-bootstrap-first-turn`,
+        text: "This message must survive asynchronous prompt rejection.",
+        createdAt: now,
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+      expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
+
+      await emitHarnessTurnTerminal(harness, {
+        eventId: `${provider}-async-bootstrap-aborted`,
+        provider,
+        type: "aborted",
+        turnId: rejectedTurnId,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
+      expect(harness.pendingPriorTranscriptBootstraps.has(threadId)).toBe(true);
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-async-bootstrap-retry-turn`,
+        text: "Retry after the asynchronous rejection.",
+        createdAt: now,
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+
+      const retryInput = harness.sendTurn.mock.calls[1]?.[0] as { readonly input?: string };
+      expect(retryInput.input).toContain("<thread_context>");
+      expect(retryInput.input).toContain(
+        "This message must survive asynchronous prompt rejection.",
+      );
+      expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
+
+      await emitHarnessTurnTerminal(harness, {
+        eventId: `${provider}-async-bootstrap-retry-completed`,
+        provider,
+        type: "completed",
+        turnId: retryTurnId,
+      });
+      await waitFor(() => harness.completePriorTranscriptBootstrap.mock.calls.length === 1);
       expect(harness.pendingPriorTranscriptBootstraps.has(threadId)).toBe(false);
     },
   );
@@ -8401,7 +8498,14 @@ describe("ProviderCommandReactor", () => {
       expect(sentInput.input).toContain("<sidechat_context>");
       expect(sentInput.input).not.toContain("<thread_context>");
       expect(sentInput.input).toContain("The imported sidechat color is amber.");
-      expect(harness.completePriorTranscriptBootstrap).toHaveBeenCalledTimes(1);
+      expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
+      await emitHarnessTurnTerminal(harness, {
+        eventId: `${provider}-sidechat-bootstrap-completed`,
+        provider,
+        type: "completed",
+        threadId,
+      });
+      await waitFor(() => harness.completePriorTranscriptBootstrap.mock.calls.length === 1);
       expect(harness.pendingPriorTranscriptBootstraps.has(threadId)).toBe(false);
     },
   );
@@ -8468,7 +8572,13 @@ describe("ProviderCommandReactor", () => {
       expect(followUpInput.input).toContain("<thread_context>");
       expect(followUpInput.input).toContain("The retained codename is heliotrope.");
       expect(followUpInput.input?.match(/What is the retained codename\?/g)).toHaveLength(1);
-      expect(harness.completePriorTranscriptBootstrap).toHaveBeenCalledTimes(1);
+      expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
+      await emitHarnessTurnTerminal(harness, {
+        eventId: `${provider}-rejected-resume-bootstrap-completed`,
+        provider,
+        type: "completed",
+      });
+      await waitFor(() => harness.completePriorTranscriptBootstrap.mock.calls.length === 1);
     },
   );
 
@@ -8502,7 +8612,13 @@ describe("ProviderCommandReactor", () => {
       expect(coldStartInput.input?.match(/Which deployment color did we choose\?/g)).toHaveLength(
         1,
       );
-      expect(harness.completePriorTranscriptBootstrap).toHaveBeenCalledTimes(1);
+      expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
+      await emitHarnessTurnTerminal(harness, {
+        eventId: `${provider}-cold-bootstrap-completed`,
+        provider,
+        type: "completed",
+      });
+      await waitFor(() => harness.completePriorTranscriptBootstrap.mock.calls.length === 1);
 
       await dispatchHarnessUserTurn(harness, {
         messageId: `${provider}-cold-next`,
@@ -8559,7 +8675,13 @@ describe("ProviderCommandReactor", () => {
       expect(retryInput.input).toContain("<thread_context>");
       expect(retryInput.input).toContain("Keep the release channel on delta.");
       expect(retryInput.input?.match(/Which release channel should we use\?/g)).toHaveLength(1);
-      expect(harness.completePriorTranscriptBootstrap).toHaveBeenCalledTimes(1);
+      expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
+      await emitHarnessTurnTerminal(harness, {
+        eventId: `${provider}-stale-resume-bootstrap-completed`,
+        provider,
+        type: "completed",
+      });
+      await waitFor(() => harness.completePriorTranscriptBootstrap.mock.calls.length === 1);
     },
   );
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -8348,6 +8348,57 @@ describe("ProviderCommandReactor", () => {
   );
 
   it.each(["opencode", "kilo"] as const)(
+    "keeps a fresh %s session usable while stopped-recap cleanup retries",
+    async (provider) => {
+      const harness = await createHarness({
+        threadModelSelection: { provider, model: "openai/gpt-5" },
+      });
+      const threadId = ThreadId.makeUnsafe("thread-1");
+      const now = new Date().toISOString();
+      const cleanupFailure = () =>
+        Effect.fail(
+          new ProviderValidationError({
+            operation: "test.completePriorTranscriptBootstrap",
+            issue: "injected transcript cleanup failure",
+          }),
+        );
+      harness.pendingPriorTranscriptBootstraps.add(threadId);
+      harness.completePriorTranscriptBootstrap
+        .mockImplementationOnce(cleanupFailure)
+        .mockImplementationOnce(cleanupFailure);
+
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.session.stop",
+          commandId: CommandId.makeUnsafe(`${provider}-failed-bootstrap-cleanup-stop`),
+          threadId,
+          createdAt: now,
+        }),
+      );
+      await waitFor(async () => (await readHarnessThread(harness))?.session?.status === "stopped");
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-cleanup-failure-fresh-turn`,
+        text: "Start even though durable cleanup is temporarily unavailable.",
+        createdAt: now,
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+      expect(harness.completePriorTranscriptBootstrap).toHaveBeenCalledTimes(2);
+      expect(harness.pendingPriorTranscriptBootstraps.has(threadId)).toBe(true);
+
+      await Effect.runPromise(harness.stopRuntimeSession({ threadId }));
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-cleanup-retry-fresh-turn`,
+        text: "Retry cleanup without replaying the stopped recap.",
+        createdAt: now,
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+      expect(harness.completePriorTranscriptBootstrap).toHaveBeenCalledTimes(3);
+      expect(harness.pendingPriorTranscriptBootstraps.has(threadId)).toBe(false);
+    },
+  );
+
+  it.each(["opencode", "kilo"] as const)(
     "completes an empty pending %s transcript recap after a bare turn",
     async (provider) => {
       const harness = await createHarness({

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -686,6 +686,7 @@ describe("ProviderCommandReactor", () => {
       startSession,
       startSessionWithOutcome,
       completePriorTranscriptBootstrap,
+      pendingPriorTranscriptBootstraps,
       listSessions,
       sendTurn,
       steerTurn,
@@ -8276,6 +8277,134 @@ describe("ProviderCommandReactor", () => {
     });
     expect(harness.startSession.mock.calls[1]?.[1]).not.toHaveProperty("resumeCursor");
   });
+
+  it.each(["opencode", "kilo"] as const)(
+    "discards a pending %s transcript recap on explicit session stop",
+    async (provider) => {
+      const harness = await createHarness({
+        threadModelSelection: { provider, model: "openai/gpt-5" },
+      });
+      const threadId = ThreadId.makeUnsafe("thread-1");
+      const now = new Date().toISOString();
+      harness.pendingPriorTranscriptBootstraps.add(threadId);
+
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.session.stop",
+          commandId: CommandId.makeUnsafe(`${provider}-pending-bootstrap-stop`),
+          threadId,
+          createdAt: now,
+        }),
+      );
+      await waitFor(async () => (await readHarnessThread(harness))?.session?.status === "stopped");
+
+      expect(harness.completePriorTranscriptBootstrap).toHaveBeenCalledTimes(1);
+      expect(harness.pendingPriorTranscriptBootstraps.has(threadId)).toBe(false);
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-post-stop-fresh-turn`,
+        text: "Start fresh after the explicit stop.",
+        createdAt: now,
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+      const sentInput = harness.sendTurn.mock.calls[0]?.[0] as { readonly input?: string };
+      expect(sentInput.input).toBe("Start fresh after the explicit stop.");
+      expect(harness.completePriorTranscriptBootstrap).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(["opencode", "kilo"] as const)(
+    "completes an empty pending %s transcript recap after a bare turn",
+    async (provider) => {
+      const harness = await createHarness({
+        threadModelSelection: { provider, model: "openai/gpt-5" },
+      });
+      const threadId = ThreadId.makeUnsafe("thread-1");
+      const now = new Date().toISOString();
+      harness.pendingPriorTranscriptBootstraps.add(threadId);
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-empty-bootstrap-turn`,
+        text: "There is no earlier transcript left to restore.",
+        createdAt: now,
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+      const sentInput = harness.sendTurn.mock.calls[0]?.[0] as { readonly input?: string };
+      expect(sentInput.input).toBe("There is no earlier transcript left to restore.");
+      expect(harness.completePriorTranscriptBootstrap).toHaveBeenCalledTimes(1);
+      expect(harness.pendingPriorTranscriptBootstraps.has(threadId)).toBe(false);
+    },
+  );
+
+  it.each(["opencode", "kilo"] as const)(
+    "lets the %s sidechat bootstrap satisfy the durable transcript recap",
+    async (provider) => {
+      const threadId = ThreadId.makeUnsafe(`thread-${provider}-sidechat-bootstrap`);
+      const harness = await createHarness();
+      const now = new Date().toISOString();
+
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.fork.create",
+          commandId: CommandId.makeUnsafe(`cmd-${provider}-sidechat-create`),
+          threadId,
+          sourceThreadId: ThreadId.makeUnsafe("thread-1"),
+          sidechatSourceThreadId: ThreadId.makeUnsafe("thread-1"),
+          projectId: asProjectId("project-1"),
+          title: `${provider} sidechat`,
+          modelSelection: { provider, model: "openai/gpt-5" },
+          runtimeMode: "approval-required",
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          envMode: "local",
+          branch: null,
+          worktreePath: null,
+          importedMessages: [
+            {
+              messageId: asMessageId(`${provider}-sidechat-imported-user`),
+              role: "user",
+              text: "The imported sidechat color is amber.",
+              createdAt: now,
+              updatedAt: now,
+            },
+            {
+              messageId: asMessageId(`${provider}-sidechat-imported-assistant`),
+              role: "assistant",
+              text: "I will retain amber for this sidechat.",
+              createdAt: now,
+              updatedAt: now,
+            },
+          ],
+          createdAt: now,
+        }),
+      );
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.makeUnsafe(`cmd-${provider}-sidechat-turn`),
+          threadId,
+          message: {
+            messageId: asMessageId(`${provider}-sidechat-native-user`),
+            role: "user",
+            text: "Which color did the sidechat retain?",
+            attachments: [],
+          },
+          runtimeMode: "approval-required",
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          createdAt: now,
+        }),
+      );
+      await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+      const sentInput = harness.sendTurn.mock.calls[0]?.[0] as { readonly input?: string };
+      expect(sentInput.input).toContain("<sidechat_context>");
+      expect(sentInput.input).not.toContain("<thread_context>");
+      expect(sentInput.input).toContain("The imported sidechat color is amber.");
+      expect(harness.completePriorTranscriptBootstrap).toHaveBeenCalledTimes(1);
+      expect(harness.pendingPriorTranscriptBootstraps.has(threadId)).toBe(false);
+    },
+  );
 
   it.each(["opencode", "kilo"] as const)(
     "sends the post-idle %s turn bare after native resume succeeds",

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -8542,6 +8542,52 @@ describe("ProviderCommandReactor", () => {
     },
   );
 
+  it("preserves pending transcript context for an idle-stopped OpenCode session", async () => {
+    const harness = await createHarness({
+      threadModelSelection: { provider: "opencode", model: "openai/gpt-5" },
+    });
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const now = new Date().toISOString();
+
+    await dispatchHarnessUserTurn(harness, {
+      messageId: "opencode-idle-stopped-seed",
+      text: "The idle-stopped session must retain cobalt.",
+      createdAt: now,
+    });
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    await Effect.runPromise(harness.clearSessionResumeCursor({ threadId }));
+    harness.pendingPriorTranscriptBootstraps.add(threadId);
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-opencode-idle-stopped"),
+        threadId,
+        session: {
+          threadId,
+          status: "stopped",
+          providerName: "opencode",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+
+    await dispatchHarnessUserTurn(harness, {
+      messageId: "opencode-idle-stopped-follow-up",
+      text: "Which color must the idle-stopped session retain?",
+      createdAt: now,
+    });
+    await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+
+    const resumedInput = harness.sendTurn.mock.calls[1]?.[0] as { readonly input?: string };
+    expect(resumedInput.input).toContain("<thread_context>");
+    expect(resumedInput.input).toContain("The idle-stopped session must retain cobalt.");
+    expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
+  });
+
   it.each(["opencode", "kilo"] as const)(
     "injects transcript context when %s rejects the persisted resume cursor",
     async (provider) => {
@@ -8684,6 +8730,105 @@ describe("ProviderCommandReactor", () => {
       await waitFor(() => harness.completePriorTranscriptBootstrap.mock.calls.length === 1);
     },
   );
+
+  it("does not retry a stale OpenCode resume when cursor cleanup fails", async () => {
+    const harness = await createHarness({
+      threadModelSelection: { provider: "opencode", model: "openai/gpt-5" },
+    });
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const now = new Date().toISOString();
+
+    await dispatchHarnessUserTurn(harness, {
+      messageId: "opencode-cleanup-failure-seed",
+      text: "Keep native context until cleanup succeeds.",
+      createdAt: now,
+    });
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    await Effect.runPromise(harness.stopRuntimeSession({ threadId }));
+    harness.startSession.mockImplementationOnce(() =>
+      Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: "opencode",
+          method: "session.update",
+          detail: "Session not found",
+        }),
+      ),
+    );
+    harness.clearSessionResumeCursor.mockImplementationOnce(() =>
+      Effect.fail(
+        new ProviderValidationError({
+          operation: "test.clearSessionResumeCursor",
+          issue: "injected cursor cleanup failure",
+        }),
+      ),
+    );
+
+    await dispatchHarnessUserTurn(harness, {
+      messageId: "opencode-cleanup-failure-follow-up",
+      text: "Do not retry past failed cleanup.",
+      createdAt: now,
+    });
+    await waitFor(async () => (await readHarnessThread(harness))?.session?.status === "error");
+
+    expect(harness.startSession).toHaveBeenCalledTimes(2);
+    expect(harness.clearSessionResumeCursor).toHaveBeenCalledTimes(1);
+    expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains OpenCode transcript bootstrap state when durable completion fails", async () => {
+    const harness = await createHarness({
+      threadModelSelection: { provider: "opencode", model: "openai/gpt-5" },
+    });
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const now = new Date().toISOString();
+
+    await dispatchHarnessUserTurn(harness, {
+      messageId: "opencode-completion-failure-seed",
+      text: "The durable bootstrap value is amber.",
+      createdAt: now,
+    });
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    await Effect.runPromise(harness.clearSessionResumeCursor({ threadId }));
+
+    await dispatchHarnessUserTurn(harness, {
+      messageId: "opencode-completion-failure-first",
+      text: "Restore the durable value.",
+      createdAt: now,
+    });
+    await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+    harness.completePriorTranscriptBootstrap.mockImplementationOnce(() =>
+      Effect.fail(
+        new ProviderValidationError({
+          operation: "test.completePriorTranscriptBootstrap",
+          issue: "injected durable completion failure",
+        }),
+      ),
+    );
+    await emitHarnessTurnTerminal(harness, {
+      eventId: "opencode-completion-failure-terminal",
+      provider: "opencode",
+      type: "completed",
+    });
+    await waitFor(() => harness.completePriorTranscriptBootstrap.mock.calls.length === 1);
+
+    await dispatchHarnessUserTurn(harness, {
+      messageId: "opencode-completion-failure-retry",
+      text: "Retry after durable completion failed.",
+      createdAt: now,
+    });
+    await waitFor(() => harness.sendTurn.mock.calls.length === 3);
+
+    const retryInput = harness.sendTurn.mock.calls[2]?.[0] as { readonly input?: string };
+    expect(retryInput.input).toContain("<thread_context>");
+    expect(retryInput.input).toContain("The durable bootstrap value is amber.");
+    await emitHarnessTurnTerminal(harness, {
+      eventId: "opencode-completion-retry-terminal",
+      provider: "opencode",
+      type: "completed",
+    });
+    await waitFor(() => harness.completePriorTranscriptBootstrap.mock.calls.length === 2);
+    expect(harness.pendingPriorTranscriptBootstraps.has(threadId)).toBe(false);
+  });
 
   it.each(["opencode", "kilo"] as const)(
     "does not discard the %s resume cursor for a transient session update failure",

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -224,6 +224,7 @@ describe("ProviderCommandReactor", () => {
     let nextSessionIndex = 1;
     const runtimeSessions: Array<ProviderSession> = [];
     const persistedResumeCursors = new Map<ThreadId, unknown>();
+    const pendingPriorTranscriptBootstraps = new Set<ThreadId>();
     const listSessions = vi.fn<ProviderServiceShape["listSessions"]>(() =>
       Effect.succeed(runtimeSessions),
     );
@@ -271,11 +272,17 @@ describe("ProviderCommandReactor", () => {
     });
     const startSessionWithOutcome = vi.fn<
       NonNullable<ProviderServiceShape["startSessionWithOutcome"]>
-    >((threadId, sessionInput) => {
+    >((threadId, sessionInput, outcomeOptions) => {
       const effectiveResumeCursor =
         sessionInput.resumeCursor ?? persistedResumeCursors.get(threadId);
       const nativeResumeAttempted =
         effectiveResumeCursor !== undefined && effectiveResumeCursor !== null;
+      if (
+        outcomeOptions?.registerPriorTranscriptBootstrapOnFreshStart === true &&
+        !nativeResumeAttempted
+      ) {
+        pendingPriorTranscriptBootstraps.add(threadId);
+      }
       return startSession(threadId, sessionInput).pipe(
         Effect.map((session) => {
           const resolvedSession = nativeResumeAttempted
@@ -288,10 +295,21 @@ describe("ProviderCommandReactor", () => {
             runtimeSessions[runtimeIndex] = resolvedSession;
           }
           persistedResumeCursors.set(threadId, resolvedSession.resumeCursor);
-          return { session: resolvedSession, nativeResumeAttempted };
+          return {
+            session: resolvedSession,
+            nativeResumeAttempted,
+            priorTranscriptBootstrapPending: pendingPriorTranscriptBootstraps.has(threadId),
+          };
         }),
       );
     });
+    const completePriorTranscriptBootstrap = vi.fn<
+      NonNullable<ProviderServiceShape["completePriorTranscriptBootstrap"]>
+    >(({ threadId }) =>
+      Effect.sync(() => {
+        pendingPriorTranscriptBootstraps.delete(threadId);
+      }),
+    );
     const sendTurn = vi.fn<ProviderServiceShape["sendTurn"]>((_: unknown) =>
       Effect.succeed({
         threadId: ThreadId.makeUnsafe("thread-1"),
@@ -405,6 +423,7 @@ describe("ProviderCommandReactor", () => {
           runtimeSessions.splice(index, 1);
         }
         persistedResumeCursors.delete(threadId);
+        pendingPriorTranscriptBootstraps.delete(threadId);
       }),
     );
     const stopRuntimeSession = vi.fn((input: unknown) =>
@@ -492,6 +511,7 @@ describe("ProviderCommandReactor", () => {
     const service: ProviderServiceShape = {
       startSession: startSession as ProviderServiceShape["startSession"],
       startSessionWithOutcome,
+      completePriorTranscriptBootstrap,
       sendTurn: sendTurn as ProviderServiceShape["sendTurn"],
       steerTurn: steerTurn as ProviderServiceShape["steerTurn"],
       startReview,
@@ -662,6 +682,7 @@ describe("ProviderCommandReactor", () => {
       serverSettings,
       startSession,
       startSessionWithOutcome,
+      completePriorTranscriptBootstrap,
       listSessions,
       sendTurn,
       steerTurn,
@@ -4756,7 +4777,7 @@ describe("ProviderCommandReactor", () => {
     if (!defaultStartSession) {
       throw new Error("Harness startSession mock has no implementation.");
     }
-    harness.startSession.mockImplementationOnce((threadId: unknown, input: unknown) =>
+    harness.startSession.mockImplementationOnce((threadId, input) =>
       Effect.promise(() => startSessionGate).pipe(
         Effect.flatMap(() => defaultStartSession(threadId, input)),
       ),
@@ -8279,6 +8300,7 @@ describe("ProviderCommandReactor", () => {
       await waitFor(() => harness.sendTurn.mock.calls.length === 2);
 
       expect(harness.startSessionWithOutcome).toHaveBeenCalledTimes(2);
+      expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
       const resumedInput = harness.sendTurn.mock.calls[1]?.[0] as { readonly input?: string };
       expect(resumedInput.input).toBe("What did we call the module?");
     },
@@ -8314,6 +8336,7 @@ describe("ProviderCommandReactor", () => {
       expect(coldStartInput.input?.match(/Which deployment color did we choose\?/g)).toHaveLength(
         1,
       );
+      expect(harness.completePriorTranscriptBootstrap).toHaveBeenCalledTimes(1);
 
       await dispatchHarnessUserTurn(harness, {
         messageId: `${provider}-cold-next`,
@@ -8348,7 +8371,7 @@ describe("ProviderCommandReactor", () => {
           new ProviderAdapterRequestError({
             provider,
             method: "session.update",
-            detail: "Session not found",
+            detail: provider === "opencode" ? "Session not found" : "status=404 body={}",
           }),
         ),
       );
@@ -8370,6 +8393,48 @@ describe("ProviderCommandReactor", () => {
       expect(retryInput.input).toContain("<thread_context>");
       expect(retryInput.input).toContain("Keep the release channel on delta.");
       expect(retryInput.input?.match(/Which release channel should we use\?/g)).toHaveLength(1);
+      expect(harness.completePriorTranscriptBootstrap).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(["opencode", "kilo"] as const)(
+    "does not discard the %s resume cursor for a transient session update failure",
+    async (provider) => {
+      const harness = await createHarness({
+        threadModelSelection: { provider, model: "openai/gpt-5" },
+      });
+      const now = new Date().toISOString();
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-transient-seed`,
+        text: "Keep this native context.",
+        createdAt: now,
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+      await Effect.runPromise(
+        harness.stopRuntimeSession({ threadId: ThreadId.makeUnsafe("thread-1") }),
+      );
+      harness.startSession.mockImplementationOnce(() =>
+        Effect.fail(
+          new ProviderAdapterRequestError({
+            provider,
+            method: "session.update",
+            detail: "status=503 body=temporarily unavailable",
+          }),
+        ),
+      );
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-transient-follow-up`,
+        text: "Retry later without losing it.",
+        createdAt: now,
+      });
+      await waitFor(async () => (await readHarnessThread(harness))?.session?.status === "error");
+
+      expect(harness.startSession).toHaveBeenCalledTimes(2);
+      expect(harness.clearSessionResumeCursor).not.toHaveBeenCalled();
+      expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+      expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
     },
   );
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -444,7 +444,9 @@ describe("ProviderCommandReactor", () => {
         }
       }),
     );
-    const clearSessionResumeCursor = vi.fn((input: unknown) =>
+    const clearSessionResumeCursor = vi.fn<
+      NonNullable<ProviderServiceShape["clearSessionResumeCursor"]>
+    >((input) =>
       Effect.sync(() => {
         const preserveActiveRuntime =
           typeof input === "object" &&
@@ -534,9 +536,7 @@ describe("ProviderCommandReactor", () => {
               ProviderServiceShape["stopRuntimeSession"]
             >,
           }),
-      clearSessionResumeCursor: clearSessionResumeCursor as NonNullable<
-        ProviderServiceShape["clearSessionResumeCursor"]
-      >,
+      clearSessionResumeCursor,
       listSessions,
       getCapabilities: (_provider) =>
         Effect.succeed({

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -8311,7 +8311,9 @@ describe("ProviderCommandReactor", () => {
       const coldStartInput = harness.sendTurn.mock.calls[1]?.[0] as { readonly input?: string };
       expect(coldStartInput.input).toContain("<thread_context>");
       expect(coldStartInput.input).toContain("The deployment color is violet.");
-      expect(coldStartInput.input?.match(/Which deployment color did we choose\?/g)).toHaveLength(1);
+      expect(coldStartInput.input?.match(/Which deployment color did we choose\?/g)).toHaveLength(
+        1,
+      );
 
       await dispatchHarnessUserTurn(harness, {
         messageId: `${provider}-cold-next`,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -223,6 +223,7 @@ describe("ProviderCommandReactor", () => {
     const runtimeEventPubSub = Effect.runSync(PubSub.unbounded<ProviderRuntimeEvent>());
     let nextSessionIndex = 1;
     const runtimeSessions: Array<ProviderSession> = [];
+    const persistedResumeCursors = new Map<ThreadId, unknown>();
     const listSessions = vi.fn<ProviderServiceShape["listSessions"]>(() =>
       Effect.succeed(runtimeSessions),
     );
@@ -267,6 +268,29 @@ describe("ProviderCommandReactor", () => {
       };
       runtimeSessions.push(session);
       return Effect.succeed(session);
+    });
+    const startSessionWithOutcome = vi.fn<
+      NonNullable<ProviderServiceShape["startSessionWithOutcome"]>
+    >((threadId, sessionInput) => {
+      const effectiveResumeCursor =
+        sessionInput.resumeCursor ?? persistedResumeCursors.get(threadId);
+      const nativeResumeAttempted =
+        effectiveResumeCursor !== undefined && effectiveResumeCursor !== null;
+      return startSession(threadId, sessionInput).pipe(
+        Effect.map((session) => {
+          const resolvedSession = nativeResumeAttempted
+            ? { ...session, resumeCursor: effectiveResumeCursor }
+            : session;
+          const runtimeIndex = runtimeSessions.findIndex(
+            (candidate) => candidate.threadId === threadId,
+          );
+          if (runtimeIndex >= 0) {
+            runtimeSessions[runtimeIndex] = resolvedSession;
+          }
+          persistedResumeCursors.set(threadId, resolvedSession.resumeCursor);
+          return { session: resolvedSession, nativeResumeAttempted };
+        }),
+      );
     });
     const sendTurn = vi.fn<ProviderServiceShape["sendTurn"]>((_: unknown) =>
       Effect.succeed({
@@ -380,6 +404,7 @@ describe("ProviderCommandReactor", () => {
         if (index >= 0) {
           runtimeSessions.splice(index, 1);
         }
+        persistedResumeCursors.delete(threadId);
       }),
     );
     const stopRuntimeSession = vi.fn((input: unknown) =>
@@ -414,6 +439,7 @@ describe("ProviderCommandReactor", () => {
         if (!threadId) {
           return;
         }
+        persistedResumeCursors.set(threadId, null);
         const index = runtimeSessions.findIndex((session) => session.threadId === threadId);
         if (index >= 0) {
           runtimeSessions.splice(index, 1);
@@ -465,6 +491,7 @@ describe("ProviderCommandReactor", () => {
     const unsupported = () => Effect.die(new Error("Unsupported provider call in test")) as never;
     const service: ProviderServiceShape = {
       startSession: startSession as ProviderServiceShape["startSession"],
+      startSessionWithOutcome,
       sendTurn: sendTurn as ProviderServiceShape["sendTurn"],
       steerTurn: steerTurn as ProviderServiceShape["steerTurn"],
       startReview,
@@ -634,6 +661,7 @@ describe("ProviderCommandReactor", () => {
       reactor,
       serverSettings,
       startSession,
+      startSessionWithOutcome,
       listSessions,
       sendTurn,
       steerTurn,
@@ -854,6 +882,32 @@ describe("ProviderCommandReactor", () => {
   ) {
     const readModel = await Effect.runPromise(harness.engine.getReadModel());
     return readModel.threads.find((thread) => thread.id === threadId);
+  }
+
+  async function dispatchHarnessUserTurn(
+    harness: Awaited<ReturnType<typeof createHarness>>,
+    input: {
+      readonly messageId: string;
+      readonly text: string;
+      readonly createdAt: string;
+    },
+  ) {
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe(`cmd-${input.messageId}`),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId(input.messageId),
+          role: "user",
+          text: input.text,
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: input.createdAt,
+      }),
+    );
   }
 
   it("REL-01B gate: delivers intents committed before the reactor subscribes", async () => {
@@ -8198,6 +8252,124 @@ describe("ProviderCommandReactor", () => {
     });
     expect(harness.startSession.mock.calls[1]?.[1]).not.toHaveProperty("resumeCursor");
   });
+
+  it.each(["opencode", "kilo"] as const)(
+    "sends the post-idle %s turn bare after native resume succeeds",
+    async (provider) => {
+      const harness = await createHarness({
+        threadModelSelection: { provider, model: "openai/gpt-5" },
+      });
+      const now = new Date().toISOString();
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-resume-seed`,
+        text: "Remember that the module is called zorblax.",
+        createdAt: now,
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+      await Effect.runPromise(
+        harness.stopRuntimeSession({ threadId: ThreadId.makeUnsafe("thread-1") }),
+      );
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-resume-follow-up`,
+        text: "What did we call the module?",
+        createdAt: now,
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+
+      expect(harness.startSessionWithOutcome).toHaveBeenCalledTimes(2);
+      const resumedInput = harness.sendTurn.mock.calls[1]?.[0] as { readonly input?: string };
+      expect(resumedInput.input).toBe("What did we call the module?");
+    },
+  );
+
+  it.each(["opencode", "kilo"] as const)(
+    "injects one transcript recap for a cursor-less %s cold start",
+    async (provider) => {
+      const harness = await createHarness({
+        threadModelSelection: { provider, model: "openai/gpt-5" },
+      });
+      const now = new Date().toISOString();
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-cold-seed`,
+        text: "The deployment color is violet.",
+        createdAt: now,
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+      await Effect.runPromise(
+        harness.clearSessionResumeCursor({ threadId: ThreadId.makeUnsafe("thread-1") }),
+      );
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-cold-follow-up`,
+        text: "Which deployment color did we choose?",
+        createdAt: now,
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+      const coldStartInput = harness.sendTurn.mock.calls[1]?.[0] as { readonly input?: string };
+      expect(coldStartInput.input).toContain("<thread_context>");
+      expect(coldStartInput.input).toContain("The deployment color is violet.");
+      expect(coldStartInput.input?.match(/Which deployment color did we choose\?/g)).toHaveLength(1);
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-cold-next`,
+        text: "Continue with that choice.",
+        createdAt: now,
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 3);
+      const nextInput = harness.sendTurn.mock.calls[2]?.[0] as { readonly input?: string };
+      expect(nextInput.input).toBe("Continue with that choice.");
+    },
+  );
+
+  it.each(["opencode", "kilo"] as const)(
+    "retries a stale %s resume once with transcript context and one user turn",
+    async (provider) => {
+      const harness = await createHarness({
+        threadModelSelection: { provider, model: "openai/gpt-5" },
+      });
+      const now = new Date().toISOString();
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-stale-seed`,
+        text: "Keep the release channel on delta.",
+        createdAt: now,
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+      await Effect.runPromise(
+        harness.stopRuntimeSession({ threadId: ThreadId.makeUnsafe("thread-1") }),
+      );
+      harness.startSession.mockImplementationOnce(() =>
+        Effect.fail(
+          new ProviderAdapterRequestError({
+            provider,
+            method: "session.update",
+            detail: "Session not found",
+          }),
+        ),
+      );
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-stale-follow-up`,
+        text: "Which release channel should we use?",
+        createdAt: now,
+      });
+      await waitFor(async () => {
+        const thread = await readHarnessThread(harness);
+        return harness.sendTurn.mock.calls.length === 2 || thread?.session?.status === "error";
+      });
+
+      expect(harness.startSession.mock.calls).toHaveLength(3);
+      expect(harness.clearSessionResumeCursor).toHaveBeenCalledTimes(1);
+      expect(harness.sendTurn.mock.calls).toHaveLength(2);
+      const retryInput = harness.sendTurn.mock.calls[1]?.[0] as { readonly input?: string };
+      expect(retryInput.input).toContain("<thread_context>");
+      expect(retryInput.input).toContain("Keep the release channel on delta.");
+      expect(retryInput.input?.match(/Which release channel should we use\?/g)).toHaveLength(1);
+    },
+  );
 
   it("starts a fresh session when only projected session state exists", async () => {
     const harness = await createHarness();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -718,14 +718,11 @@ const make = Effect.gen(function* () {
     return yield* providerService.completePriorTranscriptBootstrap({ threadId }).pipe(
       Effect.as(true),
       Effect.catchCause((cause) =>
-        Effect.logWarning(
-          "provider command reactor could not mark transcript bootstrap complete",
-          {
-            threadId,
-            provider,
-            cause: Cause.pretty(cause),
-          },
-        ).pipe(Effect.as(false)),
+        Effect.logWarning("provider command reactor could not mark transcript bootstrap complete", {
+          threadId,
+          provider,
+          cause: Cause.pretty(cause),
+        }).pipe(Effect.as(false)),
       ),
     );
   });
@@ -745,10 +742,7 @@ const make = Effect.gen(function* () {
       attempt.completeDurablePriorTranscript &&
       providerService.completePriorTranscriptBootstrap
     ) {
-      const completed = yield* persistPriorTranscriptBootstrapCompletion(
-        threadId,
-        event.provider,
-      );
+      const completed = yield* persistPriorTranscriptBootstrapCompletion(threadId, event.provider);
       if (!completed) {
         return;
       }

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1257,7 +1257,7 @@ const make = Effect.gen(function* () {
         : providerService.startSession(threadId, startInput).pipe(
             Effect.map((session) => ({
               session,
-              nativeResumeAttempted: resumeCursor !== undefined && resumeCursor !== null,
+              nativeResumeSucceeded: resumeCursor !== undefined && resumeCursor !== null,
               priorTranscriptBootstrapPending: registerPriorTranscriptBootstrapOnFreshStart,
             })),
           );
@@ -1332,7 +1332,7 @@ const make = Effect.gen(function* () {
         return {
           activeSessionBeforeEnsure,
           activeSession: reusableSession,
-          nativeResumeAttempted: false,
+          nativeResumeSucceeded: false,
         };
       }
 
@@ -1376,7 +1376,7 @@ const make = Effect.gen(function* () {
       return {
         activeSessionBeforeEnsure,
         activeSession: restartedSession,
-        nativeResumeAttempted: false,
+        nativeResumeSucceeded: false,
       };
     }
 
@@ -1414,7 +1414,7 @@ const make = Effect.gen(function* () {
         return {
           activeSessionBeforeEnsure,
           activeSession: forkedSession,
-          nativeResumeAttempted: false,
+          nativeResumeSucceeded: false,
         };
       }
       if (shouldRegisterContextBootstrap && !thread.sidechatSourceThreadId) {
@@ -1473,7 +1473,7 @@ const make = Effect.gen(function* () {
     return {
       activeSessionBeforeEnsure,
       activeSession: startedSession,
-      nativeResumeAttempted: startOutcome.nativeResumeAttempted,
+      nativeResumeSucceeded: startOutcome.nativeResumeSucceeded,
     };
   });
 
@@ -1607,7 +1607,7 @@ const make = Effect.gen(function* () {
     const registerPriorTranscriptBootstrapOnFreshStart =
       (selectedProvider === "kilo" || selectedProvider === "opencode") &&
       listPriorTranscriptMessages(thread, transcriptBoundaryMessageId).length > 0;
-    const { activeSessionBeforeEnsure, activeSession, nativeResumeAttempted } =
+    const { activeSessionBeforeEnsure, activeSession, nativeResumeSucceeded } =
       yield* ensureSessionForThread(input.threadId, input.createdAt, {
         ...(input.modelSelection !== undefined ? { modelSelection: input.modelSelection } : {}),
         ...(input.providerOptions !== undefined ? { providerOptions: input.providerOptions } : {}),
@@ -1694,7 +1694,7 @@ const make = Effect.gen(function* () {
     const shouldBootstrapPriorTranscriptContext =
       (((selectedProvider === "kilo" || selectedProvider === "opencode") &&
         activeSessionBeforeEnsure === undefined &&
-        !nativeResumeAttempted) ||
+        !nativeResumeSucceeded) ||
         hasPendingPriorTranscriptBootstrap) &&
       !shouldBootstrapHandoff &&
       !shouldBootstrapSidechatContext;

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -708,6 +708,28 @@ const make = Effect.gen(function* () {
     pendingContextBootstrapAttempts.delete(threadId);
   };
 
+  const persistPriorTranscriptBootstrapCompletion = Effect.fnUntraced(function* (
+    threadId: ThreadId,
+    provider: ProviderKind,
+  ) {
+    if (!providerService.completePriorTranscriptBootstrap) {
+      return false;
+    }
+    return yield* providerService.completePriorTranscriptBootstrap({ threadId }).pipe(
+      Effect.as(true),
+      Effect.catchCause((cause) =>
+        Effect.logWarning(
+          "provider command reactor could not mark transcript bootstrap complete",
+          {
+            threadId,
+            provider,
+            cause: Cause.pretty(cause),
+          },
+        ).pipe(Effect.as(false)),
+      ),
+    );
+  });
+
   const completePendingContextBootstrapAttempt = Effect.fnUntraced(function* (
     threadId: ThreadId,
     attempt: PendingContextBootstrapAttempt,
@@ -723,18 +745,13 @@ const make = Effect.gen(function* () {
       attempt.completeDurablePriorTranscript &&
       providerService.completePriorTranscriptBootstrap
     ) {
-      yield* providerService.completePriorTranscriptBootstrap({ threadId }).pipe(
-        Effect.catchCause((cause) =>
-          Effect.logWarning(
-            "provider command reactor could not mark transcript bootstrap complete",
-            {
-              threadId,
-              provider: event.provider,
-              cause: Cause.pretty(cause),
-            },
-          ),
-        ),
+      const completed = yield* persistPriorTranscriptBootstrapCompletion(
+        threadId,
+        event.provider,
       );
+      if (!completed) {
+        return;
+      }
     }
     if (attempt.clearSidechat) {
       sidechatContextBootstrapThreadIds.delete(threadId);
@@ -1021,16 +1038,12 @@ const make = Effect.gen(function* () {
     readonly preserveActiveRuntime?: boolean;
   }) {
     if (providerService.clearSessionResumeCursor) {
-      yield* providerService
-        .clearSessionResumeCursor({
-          threadId: input.threadId,
-          ...(input.preserveActiveRuntime === true ? { preserveActiveRuntime: true } : {}),
-        })
-        .pipe(Effect.catch(() => Effect.void));
+      yield* providerService.clearSessionResumeCursor({
+        threadId: input.threadId,
+        ...(input.preserveActiveRuntime === true ? { preserveActiveRuntime: true } : {}),
+      });
     } else if (input.preserveActiveRuntime !== true) {
-      yield* providerService
-        .stopSession({ threadId: input.threadId })
-        .pipe(Effect.catch(() => Effect.void));
+      yield* providerService.stopSession({ threadId: input.threadId });
     }
     yield* Effect.logWarning("provider command reactor cleared stale provider resume state", {
       threadId: input.threadId,
@@ -1204,7 +1217,6 @@ const make = Effect.gen(function* () {
       );
     }
     const shouldRegisterContextBootstrap =
-      thread.session?.status !== "stopped" &&
       !suppressContextBootstrapOnNextStartThreadIds.has(threadId);
 
     const desiredRuntimeMode = options?.runtimeMode ?? thread.runtimeMode;
@@ -2124,29 +2136,24 @@ const make = Effect.gen(function* () {
       input.reviewTarget === undefined &&
       pendingContextBootstrapAttempt === undefined;
     if (retiresPriorTranscriptBootstrap || completesSpecializedBootstrapImmediately) {
+      let durableCompletionSucceeded = true;
       if (
         hasPendingFreshSessionTranscriptBootstrap &&
         (selectedProvider === "opencode" || selectedProvider === "kilo") &&
         providerService.completePriorTranscriptBootstrap
       ) {
-        yield* providerService.completePriorTranscriptBootstrap({ threadId: input.threadId }).pipe(
-          Effect.catchCause((cause) =>
-            Effect.logWarning(
-              "provider command reactor could not mark transcript bootstrap complete",
-              {
-                threadId: input.threadId,
-                provider: selectedProvider,
-                cause: Cause.pretty(cause),
-              },
-            ),
-          ),
+        durableCompletionSucceeded = yield* persistPriorTranscriptBootstrapCompletion(
+          input.threadId,
+          selectedProvider,
         );
       }
-      freshSessionContextBootstrapThreadIds.delete(input.threadId);
-      if (retiresPriorTranscriptBootstrap) {
-        rollbackContextBootstrapThreadIds.delete(input.threadId);
+      if (durableCompletionSucceeded) {
+        freshSessionContextBootstrapThreadIds.delete(input.threadId);
+        if (retiresPriorTranscriptBootstrap) {
+          rollbackContextBootstrapThreadIds.delete(input.threadId);
+        }
+        sidechatContextBootstrapThreadIds.delete(input.threadId);
       }
-      sidechatContextBootstrapThreadIds.delete(input.threadId);
     }
     return startedTurn;
   });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -477,6 +477,14 @@ function isStaleClaudeResumeError(error: unknown): boolean {
   return String(error).toLowerCase().includes("no conversation found with session id");
 }
 
+function isOpenCodeCompatibleResumeError(error: unknown): boolean {
+  return (
+    Schema.is(ProviderAdapterRequestError)(error) &&
+    (error.provider === "opencode" || error.provider === "kilo") &&
+    error.method === "session.update"
+  );
+}
+
 function isRollbackStillInProgressError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   const normalized = message.toLowerCase();
@@ -1219,12 +1227,26 @@ const make = Effect.gen(function* () {
         .listSessions()
         .pipe(Effect.map((sessions) => sessions.find((session) => session.threadId === threadId)));
 
+    const providerSessionStartInput = (resumeCursor?: unknown) => ({
+      ...providerSessionOptions,
+      ...(preferredProvider ? { provider: preferredProvider } : {}),
+      ...(resumeCursor !== undefined ? { resumeCursor } : {}),
+    });
+
+    const startProviderSessionWithOutcome = (resumeCursor?: unknown) => {
+      const startInput = providerSessionStartInput(resumeCursor);
+      return providerService.startSessionWithOutcome
+        ? providerService.startSessionWithOutcome(threadId, startInput)
+        : providerService.startSession(threadId, startInput).pipe(
+            Effect.map((session) => ({
+              session,
+              nativeResumeAttempted: resumeCursor !== undefined && resumeCursor !== null,
+            })),
+          );
+    };
+
     const startProviderSession = (resumeCursor?: unknown) =>
-      providerService.startSession(threadId, {
-        ...providerSessionOptions,
-        ...(preferredProvider ? { provider: preferredProvider } : {}),
-        ...(resumeCursor !== undefined ? { resumeCursor } : {}),
-      });
+      startProviderSessionWithOutcome(resumeCursor).pipe(Effect.map(({ session }) => session));
 
     const bindSessionToThread = (session: ProviderSession) =>
       setThreadSession({
@@ -1292,6 +1314,7 @@ const make = Effect.gen(function* () {
         return {
           activeSessionBeforeEnsure,
           activeSession: reusableSession,
+          nativeResumeAttempted: false,
         };
       }
 
@@ -1335,6 +1358,7 @@ const make = Effect.gen(function* () {
       return {
         activeSessionBeforeEnsure,
         activeSession: restartedSession,
+        nativeResumeAttempted: false,
       };
     }
 
@@ -1372,6 +1396,7 @@ const make = Effect.gen(function* () {
         return {
           activeSessionBeforeEnsure,
           activeSession: forkedSession,
+          nativeResumeAttempted: false,
         };
       }
       if (shouldRegisterContextBootstrap && !thread.sidechatSourceThreadId) {
@@ -1387,7 +1412,28 @@ const make = Effect.gen(function* () {
       sidechatContextBootstrapThreadIds.add(threadId);
     }
 
-    const startedSession = yield* startProviderSession();
+    const startOutcome = yield* startProviderSessionWithOutcome().pipe(
+      Effect.catch((error) => {
+        if (!isOpenCodeCompatibleResumeError(error)) {
+          return Effect.fail(error);
+        }
+        return Effect.gen(function* () {
+          yield* clearStaleProviderResumeState({
+            threadId,
+            cause: error,
+          });
+          yield* Effect.logWarning(
+            "provider command reactor retrying OpenCode-compatible session without stale resume",
+            {
+              threadId,
+              provider: preferredProvider,
+            },
+          );
+          return yield* startProviderSessionWithOutcome();
+        });
+      }),
+    );
+    const startedSession = startOutcome.session;
     // Record the exact selection the session was spawned with so later
     // restart-necessity checks compare against the live spawn state even when
     // the spawning dispatch carried no explicit model selection.
@@ -1397,6 +1443,7 @@ const make = Effect.gen(function* () {
     return {
       activeSessionBeforeEnsure,
       activeSession: startedSession,
+      nativeResumeAttempted: startOutcome.nativeResumeAttempted,
     };
   });
 
@@ -1520,15 +1567,12 @@ const make = Effect.gen(function* () {
       });
       return;
     }
-    const { activeSessionBeforeEnsure, activeSession } = yield* ensureSessionForThread(
-      input.threadId,
-      input.createdAt,
-      {
+    const { activeSessionBeforeEnsure, activeSession, nativeResumeAttempted } =
+      yield* ensureSessionForThread(input.threadId, input.createdAt, {
         ...(input.modelSelection !== undefined ? { modelSelection: input.modelSelection } : {}),
         ...(input.providerOptions !== undefined ? { providerOptions: input.providerOptions } : {}),
         ...(input.runtimeMode !== undefined ? { runtimeMode: input.runtimeMode } : {}),
-      },
-    );
+      });
     if (input.providerOptions !== undefined) {
       threadProviderOptions.set(input.threadId, input.providerOptions);
     }
@@ -1613,7 +1657,8 @@ const make = Effect.gen(function* () {
     }
     const shouldBootstrapPriorTranscriptContext =
       (((selectedProvider === "kilo" || selectedProvider === "opencode") &&
-        activeSessionBeforeEnsure === undefined) ||
+        activeSessionBeforeEnsure === undefined &&
+        !nativeResumeAttempted) ||
         hasPendingPriorTranscriptBootstrap) &&
       !shouldBootstrapHandoff &&
       !shouldBootstrapSidechatContext;

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1461,7 +1461,17 @@ const make = Effect.gen(function* () {
       }),
     );
     if (startOutcome.priorTranscriptBootstrapPending) {
-      freshSessionContextBootstrapThreadIds.add(threadId);
+      if (shouldRegisterContextBootstrap) {
+        freshSessionContextBootstrapThreadIds.add(threadId);
+      } else if (
+        (preferredProvider === "opencode" || preferredProvider === "kilo") &&
+        providerService.completePriorTranscriptBootstrap
+      ) {
+        // An explicit stop intentionally discards pending synthetic context.
+        // If its best-effort persistence cleanup was interrupted, finish that
+        // cleanup before starting the fresh session instead of resurrecting it.
+        yield* providerService.completePriorTranscriptBootstrap({ threadId });
+      }
     }
     const startedSession = startOutcome.session;
     // Record the exact selection the session was spawned with so later
@@ -1658,15 +1668,23 @@ const make = Effect.gen(function* () {
         issue: providerPromptOverflowIssue(goalPromptOverheadChars),
       });
     }
+    const hasPendingFreshSessionTranscriptBootstrap = freshSessionContextBootstrapThreadIds.has(
+      input.threadId,
+    );
+    const hasPendingRollbackTranscriptBootstrap = rollbackContextBootstrapThreadIds.has(
+      input.threadId,
+    );
     const hasPendingPriorTranscriptBootstrap =
-      freshSessionContextBootstrapThreadIds.has(input.threadId) ||
-      rollbackContextBootstrapThreadIds.has(input.threadId);
+      hasPendingFreshSessionTranscriptBootstrap || hasPendingRollbackTranscriptBootstrap;
     const shouldBootstrapSidechatContext =
       thread.sidechatSourceThreadId !== null &&
       sidechatContextBootstrapThreadIds.has(input.threadId) &&
       !hasNativeAssistantMessagesBefore(thread, transcriptBoundaryMessageId) &&
       !shouldBootstrapHandoff &&
-      !hasPendingPriorTranscriptBootstrap;
+      !hasPendingRollbackTranscriptBootstrap &&
+      (!hasPendingFreshSessionTranscriptBootstrap ||
+        selectedProvider === "opencode" ||
+        selectedProvider === "kilo");
     const sidechatBootstrapAvailableChars = availableProviderContextChars({
       tag: "sidechat_context",
       messageText: bootstrapBudgetMessageText,
@@ -2056,14 +2074,18 @@ const make = Effect.gen(function* () {
     ) {
       sidechatContextBootstrapThreadIds.delete(input.threadId);
     }
-    if (
+    const retiresPriorTranscriptBootstrap =
       shouldBootstrapPriorTranscriptContext &&
       input.reviewTarget === undefined &&
       pendingContextBootstrapAttempt === undefined &&
-      (priorTranscriptBootstrapText !== null || !hasPriorTranscriptBootstrapContent)
-    ) {
+      (priorTranscriptBootstrapText !== null || !hasPriorTranscriptBootstrapContent);
+    const specializedBootstrapCompletesFreshSessionContext =
+      input.reviewTarget === undefined &&
+      pendingContextBootstrapAttempt === undefined &&
+      (handoffBootstrapText !== null || sidechatBootstrapText !== null);
+    if (retiresPriorTranscriptBootstrap || specializedBootstrapCompletesFreshSessionContext) {
       if (
-        priorTranscriptBootstrapText !== null &&
+        hasPendingFreshSessionTranscriptBootstrap &&
         (selectedProvider === "opencode" || selectedProvider === "kilo") &&
         providerService.completePriorTranscriptBootstrap
       ) {
@@ -2081,7 +2103,9 @@ const make = Effect.gen(function* () {
         );
       }
       freshSessionContextBootstrapThreadIds.delete(input.threadId);
-      rollbackContextBootstrapThreadIds.delete(input.threadId);
+      if (retiresPriorTranscriptBootstrap) {
+        rollbackContextBootstrapThreadIds.delete(input.threadId);
+      }
       sidechatContextBootstrapThreadIds.delete(input.threadId);
     }
     return startedTurn;
@@ -3692,6 +3716,26 @@ const make = Effect.gen(function* () {
     }
     clearPendingContextBootstraps(thread.id);
     suppressContextBootstrapOnNextStartThreadIds.add(thread.id);
+    const stoppedProvider = Schema.is(ProviderKind)(thread.session?.providerName)
+      ? thread.session.providerName
+      : thread.modelSelection.provider;
+    if (
+      (stoppedProvider === "opencode" || stoppedProvider === "kilo") &&
+      providerService.completePriorTranscriptBootstrap
+    ) {
+      yield* providerService.completePriorTranscriptBootstrap({ threadId: thread.id }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning(
+            "provider command reactor could not discard transcript bootstrap during session stop",
+            {
+              threadId: thread.id,
+              provider: stoppedProvider,
+              cause: Cause.pretty(cause),
+            },
+          ),
+        ),
+      );
+    }
 
     const providerThreadId =
       providerThread !== null

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -709,7 +709,7 @@ const make = Effect.gen(function* () {
   };
 
   const completePendingContextBootstrapAttempt = Effect.fnUntraced(function* (
-    threadId: string,
+    threadId: ThreadId,
     attempt: PendingContextBootstrapAttempt,
     event: ProviderQueueDrainEvent,
   ) {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1488,6 +1488,7 @@ const make = Effect.gen(function* () {
         });
       }),
     );
+    let retainContextBootstrapSuppression = false;
     if (startOutcome.priorTranscriptBootstrapPending) {
       if (shouldRegisterContextBootstrap) {
         freshSessionContextBootstrapThreadIds.add(threadId);
@@ -1498,7 +1499,11 @@ const make = Effect.gen(function* () {
         // An explicit stop intentionally discards pending synthetic context.
         // If its best-effort persistence cleanup was interrupted, finish that
         // cleanup before starting the fresh session instead of resurrecting it.
-        yield* providerService.completePriorTranscriptBootstrap({ threadId });
+        const completed = yield* persistPriorTranscriptBootstrapCompletion(
+          threadId,
+          preferredProvider,
+        );
+        retainContextBootstrapSuppression = !completed;
       }
     }
     const startedSession = startOutcome.session;
@@ -1507,7 +1512,9 @@ const make = Effect.gen(function* () {
     // the spawning dispatch carried no explicit model selection.
     threadSessionModelSelections.set(threadId, desiredModelSelection);
     yield* bindSessionToThread(startedSession);
-    suppressContextBootstrapOnNextStartThreadIds.delete(threadId);
+    if (!retainContextBootstrapSuppression) {
+      suppressContextBootstrapOnNextStartThreadIds.delete(threadId);
+    }
     return {
       activeSessionBeforeEnsure,
       activeSession: startedSession,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -478,10 +478,21 @@ function isStaleClaudeResumeError(error: unknown): boolean {
 }
 
 function isOpenCodeCompatibleResumeError(error: unknown): boolean {
+  if (
+    !Schema.is(ProviderAdapterRequestError)(error) ||
+    (error.provider !== "opencode" && error.provider !== "kilo") ||
+    error.method !== "session.update"
+  ) {
+    return false;
+  }
+  const detail = error.detail.toLowerCase();
   return (
-    Schema.is(ProviderAdapterRequestError)(error) &&
-    (error.provider === "opencode" || error.provider === "kilo") &&
-    error.method === "session.update"
+    /\bstatus(?:code)?[=: ]+404\b/u.test(detail) ||
+    ((detail.includes("session") || detail.includes("conversation")) &&
+      (detail.includes("not found") ||
+        detail.includes("unknown session") ||
+        detail.includes("does not exist") ||
+        detail.includes("invalid session")))
   );
 }
 
@@ -1161,6 +1172,7 @@ const make = Effect.gen(function* () {
       readonly modelSelection?: ModelSelection;
       readonly providerOptions?: ProviderStartOptions;
       readonly runtimeMode?: RuntimeMode;
+      readonly registerPriorTranscriptBootstrapOnFreshStart?: boolean;
     },
   ) {
     const thread = yield* resolveThread(threadId);
@@ -1233,14 +1245,20 @@ const make = Effect.gen(function* () {
       ...(resumeCursor !== undefined ? { resumeCursor } : {}),
     });
 
-    const startProviderSessionWithOutcome = (resumeCursor?: unknown) => {
+    const startProviderSessionWithOutcome = (
+      resumeCursor?: unknown,
+      registerPriorTranscriptBootstrapOnFreshStart = false,
+    ) => {
       const startInput = providerSessionStartInput(resumeCursor);
       return providerService.startSessionWithOutcome
-        ? providerService.startSessionWithOutcome(threadId, startInput)
+        ? providerService.startSessionWithOutcome(threadId, startInput, {
+            registerPriorTranscriptBootstrapOnFreshStart,
+          })
         : providerService.startSession(threadId, startInput).pipe(
             Effect.map((session) => ({
               session,
               nativeResumeAttempted: resumeCursor !== undefined && resumeCursor !== null,
+              priorTranscriptBootstrapPending: registerPriorTranscriptBootstrapOnFreshStart,
             })),
           );
     };
@@ -1412,7 +1430,13 @@ const make = Effect.gen(function* () {
       sidechatContextBootstrapThreadIds.add(threadId);
     }
 
-    const startOutcome = yield* startProviderSessionWithOutcome().pipe(
+    const registerPriorTranscriptBootstrapOnFreshStart =
+      shouldRegisterContextBootstrap &&
+      options?.registerPriorTranscriptBootstrapOnFreshStart === true;
+    const startOutcome = yield* startProviderSessionWithOutcome(
+      undefined,
+      registerPriorTranscriptBootstrapOnFreshStart,
+    ).pipe(
       Effect.catch((error) => {
         if (!isOpenCodeCompatibleResumeError(error)) {
           return Effect.fail(error);
@@ -1429,10 +1453,16 @@ const make = Effect.gen(function* () {
               provider: preferredProvider,
             },
           );
-          return yield* startProviderSessionWithOutcome();
+          return yield* startProviderSessionWithOutcome(
+            undefined,
+            registerPriorTranscriptBootstrapOnFreshStart,
+          );
         });
       }),
     );
+    if (startOutcome.priorTranscriptBootstrapPending) {
+      freshSessionContextBootstrapThreadIds.add(threadId);
+    }
     const startedSession = startOutcome.session;
     // Record the exact selection the session was spawned with so later
     // restart-necessity checks compare against the live spawn state even when
@@ -1567,11 +1597,24 @@ const make = Effect.gen(function* () {
       });
       return;
     }
+    const transcriptBoundaryMessageId =
+      input.turnKind === "goal-continuation" ? undefined : input.messageId;
+    const selectedProvider =
+      input.modelSelection?.provider ??
+      threadSessionModelSelections.get(input.threadId)?.provider ??
+      thread.session?.providerName ??
+      thread.modelSelection.provider;
+    const registerPriorTranscriptBootstrapOnFreshStart =
+      (selectedProvider === "kilo" || selectedProvider === "opencode") &&
+      listPriorTranscriptMessages(thread, transcriptBoundaryMessageId).length > 0;
     const { activeSessionBeforeEnsure, activeSession, nativeResumeAttempted } =
       yield* ensureSessionForThread(input.threadId, input.createdAt, {
         ...(input.modelSelection !== undefined ? { modelSelection: input.modelSelection } : {}),
         ...(input.providerOptions !== undefined ? { providerOptions: input.providerOptions } : {}),
         ...(input.runtimeMode !== undefined ? { runtimeMode: input.runtimeMode } : {}),
+        ...(registerPriorTranscriptBootstrapOnFreshStart
+          ? { registerPriorTranscriptBootstrapOnFreshStart: true }
+          : {}),
       });
     if (input.providerOptions !== undefined) {
       threadProviderOptions.set(input.threadId, input.providerOptions);
@@ -1588,8 +1631,6 @@ const make = Effect.gen(function* () {
       ? `<sidechat_boundary>\n${SIDECHAT_BOUNDARY_INSTRUCTION}\n</sidechat_boundary>\n\n<latest_user_message>\n${input.messageText}\n</latest_user_message>`
       : input.messageText;
     const bootstrapBudgetMessageText = `${boundaryMessageText}${mentionContextSuffix}`;
-    const transcriptBoundaryMessageId =
-      input.turnKind === "goal-continuation" ? undefined : input.messageId;
     const shouldBootstrapHandoff =
       thread.handoff?.bootstrapStatus === "pending" &&
       !hasNativeAssistantMessagesBefore(thread, transcriptBoundaryMessageId);
@@ -1603,11 +1644,6 @@ const make = Effect.gen(function* () {
       shouldBootstrapHandoff && handoffBootstrapAvailableChars > 0
         ? buildHandoffBootstrapText(thread, handoffBootstrapAvailableChars)
         : null;
-    const selectedProvider =
-      input.modelSelection?.provider ??
-      threadSessionModelSelections.get(input.threadId)?.provider ??
-      thread.session?.providerName ??
-      thread.modelSelection.provider;
     if (
       providerPromptOverheadChars > 0 &&
       withProviderThreadStatePrompts({
@@ -2026,6 +2062,24 @@ const make = Effect.gen(function* () {
       pendingContextBootstrapAttempt === undefined &&
       (priorTranscriptBootstrapText !== null || !hasPriorTranscriptBootstrapContent)
     ) {
+      if (
+        priorTranscriptBootstrapText !== null &&
+        (selectedProvider === "opencode" || selectedProvider === "kilo") &&
+        providerService.completePriorTranscriptBootstrap
+      ) {
+        yield* providerService.completePriorTranscriptBootstrap({ threadId: input.threadId }).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning(
+              "provider command reactor could not mark transcript bootstrap complete",
+              {
+                threadId: input.threadId,
+                provider: selectedProvider,
+                cause: Cause.pretty(cause),
+              },
+            ),
+          ),
+        );
+      }
       freshSessionContextBootstrapThreadIds.delete(input.threadId);
       rollbackContextBootstrapThreadIds.delete(input.threadId);
       sidechatContextBootstrapThreadIds.delete(input.threadId);

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -693,7 +693,9 @@ const make = Effect.gen(function* () {
     turnId?: TurnId;
     terminalEvent?: ProviderQueueDrainEvent;
     readonly clearSidechat: boolean;
-    readonly clearPriorTranscript: boolean;
+    readonly clearFreshSessionTranscript: boolean;
+    readonly clearRollbackTranscript: boolean;
+    readonly completeDurablePriorTranscript: boolean;
   };
   const pendingContextBootstrapAttempts = new Map<string, PendingContextBootstrapAttempt>();
   // Explicit stop resets context once: the next successful session start must
@@ -706,28 +708,48 @@ const make = Effect.gen(function* () {
     pendingContextBootstrapAttempts.delete(threadId);
   };
 
-  const completePendingContextBootstrapAttempt = (
+  const completePendingContextBootstrapAttempt = Effect.fnUntraced(function* (
     threadId: string,
     attempt: PendingContextBootstrapAttempt,
     event: ProviderQueueDrainEvent,
-  ) => {
+  ) {
     // Keep bootstrap flags after cancellation or failure even though Droid may
     // already have received the prompt. A bounded duplicate on retry is safer
     // than dropping the only model-visible copy of the retained transcript.
     if (event.type !== "turn.completed" || event.payload.state !== "completed") {
       return;
     }
+    if (
+      attempt.completeDurablePriorTranscript &&
+      providerService.completePriorTranscriptBootstrap
+    ) {
+      yield* providerService.completePriorTranscriptBootstrap({ threadId }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning(
+            "provider command reactor could not mark transcript bootstrap complete",
+            {
+              threadId,
+              provider: event.provider,
+              cause: Cause.pretty(cause),
+            },
+          ),
+        ),
+      );
+    }
     if (attempt.clearSidechat) {
       sidechatContextBootstrapThreadIds.delete(threadId);
     }
-    if (attempt.clearPriorTranscript) {
+    if (attempt.clearFreshSessionTranscript) {
       freshSessionContextBootstrapThreadIds.delete(threadId);
-      rollbackContextBootstrapThreadIds.delete(threadId);
-      sidechatContextBootstrapThreadIds.delete(threadId);
     }
-  };
+    if (attempt.clearRollbackTranscript) {
+      rollbackContextBootstrapThreadIds.delete(threadId);
+    }
+  });
 
-  const observePendingContextBootstrapTerminalEvent = (event: ProviderQueueDrainEvent) => {
+  const observePendingContextBootstrapTerminalEvent = Effect.fnUntraced(function* (
+    event: ProviderQueueDrainEvent,
+  ) {
     const attempt = pendingContextBootstrapAttempts.get(event.threadId);
     if (!attempt) {
       return;
@@ -740,8 +762,8 @@ const make = Effect.gen(function* () {
       return;
     }
     pendingContextBootstrapAttempts.delete(event.threadId);
-    completePendingContextBootstrapAttempt(event.threadId, attempt, event);
-  };
+    yield* completePendingContextBootstrapAttempt(event.threadId, attempt, event);
+  });
 
   const resolveConfiguredTextGenerationInput = Effect.fnUntraced(function* () {
     const settings = yield* serverSettings.getSettings;
@@ -1900,6 +1922,11 @@ const make = Effect.gen(function* () {
     const cancelPendingStudioBaseline = studioOutputReactor.cancelPendingTurnBaseline(
       input.threadId,
     );
+    const priorTranscriptBootstrapRetiresOnAcceptedTurn =
+      shouldBootstrapPriorTranscriptContext &&
+      (priorTranscriptBootstrapText !== null || !hasPriorTranscriptBootstrapContent);
+    const specializedBootstrapCompletesFreshSessionContext =
+      handoffBootstrapText !== null || sidechatBootstrapText !== null;
     let pendingContextBootstrapAttempt: PendingContextBootstrapAttempt | undefined;
     let startedTurn: ProviderTurnStartResult | undefined;
 
@@ -1918,12 +1945,26 @@ const make = Effect.gen(function* () {
       });
     } else {
       yield* capturePreTurnBaselines;
-      pendingContextBootstrapAttempt =
+      const tracksDroidContextAcceptance =
         activeSession?.provider === "droid" &&
-        (sidechatBootstrapText !== null || priorTranscriptBootstrapText !== null)
+        (sidechatBootstrapText !== null || priorTranscriptBootstrapText !== null);
+      const tracksDurableTranscriptAcceptance =
+        (selectedProvider === "opencode" || selectedProvider === "kilo") &&
+        hasPendingFreshSessionTranscriptBootstrap &&
+        (priorTranscriptBootstrapRetiresOnAcceptedTurn ||
+          specializedBootstrapCompletesFreshSessionContext);
+      pendingContextBootstrapAttempt =
+        tracksDroidContextAcceptance || tracksDurableTranscriptAcceptance
           ? {
-              clearSidechat: sidechatBootstrapText !== null,
-              clearPriorTranscript: priorTranscriptBootstrapText !== null,
+              clearSidechat:
+                sidechatBootstrapText !== null || priorTranscriptBootstrapText !== null,
+              clearFreshSessionTranscript:
+                priorTranscriptBootstrapText !== null || tracksDurableTranscriptAcceptance,
+              clearRollbackTranscript:
+                priorTranscriptBootstrapText !== null ||
+                (tracksDurableTranscriptAcceptance &&
+                  priorTranscriptBootstrapRetiresOnAcceptedTurn),
+              completeDurablePriorTranscript: tracksDurableTranscriptAcceptance,
             }
           : undefined;
       if (pendingContextBootstrapAttempt) {
@@ -2047,7 +2088,7 @@ const make = Effect.gen(function* () {
         const terminalEvent = pendingContextBootstrapAttempt.terminalEvent;
         if (terminalEvent?.turnId === sentTurn.turnId) {
           pendingContextBootstrapAttempts.delete(input.threadId);
-          completePendingContextBootstrapAttempt(
+          yield* completePendingContextBootstrapAttempt(
             input.threadId,
             pendingContextBootstrapAttempt,
             terminalEvent,
@@ -2075,15 +2116,14 @@ const make = Effect.gen(function* () {
       sidechatContextBootstrapThreadIds.delete(input.threadId);
     }
     const retiresPriorTranscriptBootstrap =
-      shouldBootstrapPriorTranscriptContext &&
+      priorTranscriptBootstrapRetiresOnAcceptedTurn &&
       input.reviewTarget === undefined &&
-      pendingContextBootstrapAttempt === undefined &&
-      (priorTranscriptBootstrapText !== null || !hasPriorTranscriptBootstrapContent);
-    const specializedBootstrapCompletesFreshSessionContext =
+      pendingContextBootstrapAttempt === undefined;
+    const completesSpecializedBootstrapImmediately =
+      specializedBootstrapCompletesFreshSessionContext &&
       input.reviewTarget === undefined &&
-      pendingContextBootstrapAttempt === undefined &&
-      (handoffBootstrapText !== null || sidechatBootstrapText !== null);
-    if (retiresPriorTranscriptBootstrap || specializedBootstrapCompletesFreshSessionContext) {
+      pendingContextBootstrapAttempt === undefined;
+    if (retiresPriorTranscriptBootstrap || completesSpecializedBootstrapImmediately) {
       if (
         hasPendingFreshSessionTranscriptBootstrap &&
         (selectedProvider === "opencode" || selectedProvider === "kilo") &&
@@ -3009,7 +3049,7 @@ const make = Effect.gen(function* () {
     );
 
   const processQueueDrainEvent = Effect.fnUntraced(function* (event: ProviderQueueDrainEvent) {
-    observePendingContextBootstrapTerminalEvent(event);
+    yield* observePendingContextBootstrapTerminalEvent(event);
     const sessionThreadId =
       (yield* resolveProviderSessionThread(event.threadId))?.id ?? event.threadId;
     const reservation = pendingQueuedDispatchBySessionThread.get(sessionThreadId);

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1763,6 +1763,37 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
     });
   });
 
+  it("reports no native resume when a supplied cursor has no session id", async () => {
+    const runtime = createMockOpenCodeRuntime();
+
+    const confirmed = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const input = {
+          provider: "opencode" as const,
+          threadId: asThreadId("thread-malformed-resume-cursor"),
+          runtimeMode: "full-access" as const,
+          resumeCursor: { cwd: "/repo/resume" },
+        };
+        const session = yield* adapter.startSession(input);
+        return adapter.didResumeSession?.(input, session) ?? false;
+      }).pipe(
+        Effect.provide(
+          makeOpenCodeAdapterLive({ runtime: runtime.runtime }).pipe(
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-adapter-test-" }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
+      ),
+    );
+
+    expect(confirmed).toBe(false);
+    expect(runtime.createCalls).toHaveLength(1);
+    expect(runtime.updateCalls).toEqual([]);
+  });
+
   it("applies fail-closed resume permissions and restores Full Access for a new turn", async () => {
     const runtime = createMockOpenCodeRuntime();
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1836,7 +1836,12 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           ),
         ),
       ),
-    ).rejects.toThrow("session.update unavailable during resume");
+    ).rejects.toMatchObject({
+      _tag: "ProviderAdapterRequestError",
+      provider: "opencode",
+      method: "session.update",
+      detail: "session.update unavailable during resume",
+    });
 
     expect(runtime.updateCalls).toEqual([
       { sessionID: "existing-session-1", permission: OPEN_CODE_PLAN_PERMISSION_RULES },

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -3687,10 +3687,15 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
                   }).pipe(Effect.provideService(Scope.Scope, sessionScope)),
                 );
                 if (Exit.isFailure(startedExit)) {
-                  return yield* toAdapterProcessError(
-                    input.threadId,
-                    Cause.squash(startedExit.cause),
-                  );
+                  const startError = Cause.squash(startedExit.cause);
+                  if (
+                    resumedSessionId &&
+                    OpenCodeRuntimeError.is(startError) &&
+                    startError.operation === "session.update"
+                  ) {
+                    return yield* toAdapterRequestError(startError);
+                  }
+                  return yield* toAdapterProcessError(input.threadId, startError);
                 }
 
                 const started = startedExit.value;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -4753,6 +4753,17 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           );
         });
 
+      const didResumeSession: NonNullable<OpenCodeAdapterShape["didResumeSession"]> = (
+        input,
+        session,
+      ) => {
+        const requestedSessionId = extractResumeSessionId(input.resumeCursor);
+        return (
+          requestedSessionId !== undefined &&
+          extractResumeSessionId(session.resumeCursor) === requestedSessionId
+        );
+      };
+
       return {
         provider,
         capabilities: {
@@ -4761,6 +4772,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           supportsNativeSlashCommandDiscovery: provider === "opencode",
         },
         startSession,
+        didResumeSession,
         sendTurn,
         interruptTurn,
         respondToRequest,

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -125,7 +125,12 @@ function asRuntimePayloadRecord(value: unknown): Record<string, unknown> {
 
 function makeFakeCodexAdapter(
   provider: ProviderKind = "codex",
-  options?: { readonly conversationRollback?: "native" | "restart-session" },
+  options?: {
+    readonly conversationRollback?: "native" | "restart-session";
+    readonly didResumeSession?: NonNullable<
+      ProviderAdapterShape<ProviderAdapterError>["didResumeSession"]
+    >;
+  },
 ) {
   const sessions = new Map<ThreadId, ProviderSession>();
   const runtimeEventPubSub = Effect.runSync(PubSub.unbounded<ProviderRuntimeEvent>());
@@ -285,6 +290,7 @@ function makeFakeCodexAdapter(
         : {}),
     },
     startSession,
+    ...(options?.didResumeSession ? { didResumeSession: options.didResumeSession } : {}),
     sendTurn,
     steerTurn,
     startReview,
@@ -390,9 +396,16 @@ function makeProviderServiceLayer(
   providers?: {
     readonly includeRestartRollbackDroid?: boolean;
     readonly includePi?: boolean;
+    readonly codexDidResumeSession?: NonNullable<
+      ProviderAdapterShape<ProviderAdapterError>["didResumeSession"]
+    >;
   },
 ) {
-  const codex = makeFakeCodexAdapter();
+  const codex = makeFakeCodexAdapter("codex", {
+    ...(providers?.codexDidResumeSession
+      ? { didResumeSession: providers.codexDidResumeSession }
+      : {}),
+  });
   const claude = makeFakeCodexAdapter("claudeAgent");
   const antigravity = makeFakeCodexAdapter("antigravity");
   const droid = makeFakeCodexAdapter("droid", { conversationRollback: "restart-session" });
@@ -469,6 +482,9 @@ const restartRollbackRouting = makeProviderServiceLayer(undefined, {
   includeRestartRollbackDroid: true,
 });
 const piInteractionRouting = makeProviderServiceLayer(undefined, { includePi: true });
+const adapterConfirmedFreshRouting = makeProviderServiceLayer(undefined, {
+  codexDidResumeSession: () => false,
+});
 it.effect("ProviderServiceLive keeps persisted resumable sessions on startup", () =>
   Effect.gen(function* () {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "synara-provider-service-"));
@@ -989,6 +1005,35 @@ it.effect(
     }).pipe(Effect.provide(NodeServices.layer)),
 );
 
+adapterConfirmedFreshRouting.layer("ProviderServiceLive resume confirmation", (it) => {
+  it.effect("keeps transcript bootstrap pending when the adapter rejects a supplied cursor", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const threadId = asThreadId("thread-adapter-rejected-resume");
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* provider.stopRuntimeSession!({ threadId });
+      const outcome = yield* provider.startSessionWithOutcome!(
+        threadId,
+        {
+          provider: "codex",
+          threadId,
+          runtimeMode: "full-access",
+        },
+        { registerPriorTranscriptBootstrapOnFreshStart: true },
+      );
+
+      assert.equal(outcome.nativeResumeSucceeded, false);
+      assert.equal(outcome.priorTranscriptBootstrapPending, true);
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+});
+
 routing.layer("ProviderServiceLive routing", (it) => {
   it.effect("reports native resume and persists bootstrap state until completion", () =>
     Effect.gen(function* () {
@@ -1011,9 +1056,9 @@ routing.layer("ProviderServiceLive routing", (it) => {
         runtimeMode: "full-access",
       });
 
-      assert.equal(initial.nativeResumeAttempted, false);
+      assert.equal(initial.nativeResumeSucceeded, false);
       assert.equal(initial.priorTranscriptBootstrapPending, true);
-      assert.equal(resumed.nativeResumeAttempted, true);
+      assert.equal(resumed.nativeResumeSucceeded, true);
       assert.equal(resumed.priorTranscriptBootstrapPending, true);
       assert.deepEqual(
         routing.codex.startSession.mock.calls.at(-1)?.[0]?.resumeCursor,
@@ -1027,7 +1072,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
         threadId,
         runtimeMode: "full-access",
       });
-      assert.equal(resumedAfterCompletion.nativeResumeAttempted, true);
+      assert.equal(resumedAfterCompletion.nativeResumeSucceeded, true);
       assert.equal(resumedAfterCompletion.priorTranscriptBootstrapPending, false);
 
       yield* provider.stopSession({ threadId });

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -990,16 +990,20 @@ it.effect(
 );
 
 routing.layer("ProviderServiceLive routing", (it) => {
-  it.effect("reports whether a successful session start restored native context", () =>
+  it.effect("reports native resume and persists bootstrap state until completion", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService;
       const threadId = asThreadId("thread-start-outcome");
 
-      const initial = yield* provider.startSessionWithOutcome!(threadId, {
-        provider: "codex",
+      const initial = yield* provider.startSessionWithOutcome!(
         threadId,
-        runtimeMode: "full-access",
-      });
+        {
+          provider: "codex",
+          threadId,
+          runtimeMode: "full-access",
+        },
+        { registerPriorTranscriptBootstrapOnFreshStart: true },
+      );
       yield* provider.stopRuntimeSession!({ threadId });
       const resumed = yield* provider.startSessionWithOutcome!(threadId, {
         provider: "codex",
@@ -1008,11 +1012,23 @@ routing.layer("ProviderServiceLive routing", (it) => {
       });
 
       assert.equal(initial.nativeResumeAttempted, false);
+      assert.equal(initial.priorTranscriptBootstrapPending, true);
       assert.equal(resumed.nativeResumeAttempted, true);
+      assert.equal(resumed.priorTranscriptBootstrapPending, true);
       assert.deepEqual(
         routing.codex.startSession.mock.calls.at(-1)?.[0]?.resumeCursor,
         initial.session.resumeCursor,
       );
+
+      yield* provider.completePriorTranscriptBootstrap!({ threadId });
+      yield* provider.stopRuntimeSession!({ threadId });
+      const resumedAfterCompletion = yield* provider.startSessionWithOutcome!(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      assert.equal(resumedAfterCompletion.nativeResumeAttempted, true);
+      assert.equal(resumedAfterCompletion.priorTranscriptBootstrapPending, false);
 
       yield* provider.stopSession({ threadId });
     }),

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -1038,7 +1038,9 @@ routing.layer("ProviderServiceLive routing", (it) => {
   it.effect("reports native resume and persists bootstrap state until completion", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
       const threadId = asThreadId("thread-start-outcome");
+      const upsertSpy = vi.spyOn(directory, "upsert");
 
       const initial = yield* provider.startSessionWithOutcome!(
         threadId,
@@ -1049,6 +1051,13 @@ routing.layer("ProviderServiceLive routing", (it) => {
         },
         { registerPriorTranscriptBootstrapOnFreshStart: true },
       );
+      assert.equal(upsertSpy.mock.calls.length, 1);
+      const initialBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+      assert.equal(
+        asRuntimePayloadRecord(initialBinding?.runtimePayload).priorTranscriptBootstrapPending,
+        true,
+      );
+      upsertSpy.mockRestore();
       yield* provider.stopRuntimeSession!({ threadId });
       const resumed = yield* provider.startSessionWithOutcome!(threadId, {
         provider: "codex",

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -990,6 +990,34 @@ it.effect(
 );
 
 routing.layer("ProviderServiceLive routing", (it) => {
+  it.effect("reports whether a successful session start restored native context", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const threadId = asThreadId("thread-start-outcome");
+
+      const initial = yield* provider.startSessionWithOutcome!(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* provider.stopRuntimeSession!({ threadId });
+      const resumed = yield* provider.startSessionWithOutcome!(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      assert.equal(initial.nativeResumeAttempted, false);
+      assert.equal(resumed.nativeResumeAttempted, true);
+      assert.deepEqual(
+        routing.codex.startSession.mock.calls.at(-1)?.[0]?.resumeCursor,
+        initial.session.resumeCursor,
+      );
+
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
   it.effect("reuses a deferred native fork binding and preserves its inherited cwd", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService;

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -735,6 +735,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         readonly providerOptions?: unknown;
         readonly lastRuntimeEvent?: string;
         readonly lastRuntimeEventAt?: string;
+        readonly runtimePayload?: Record<string, unknown>;
       },
     ) =>
       directory.upsert({
@@ -746,7 +747,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           ? { lifecycleGeneration: extra.lifecycleGeneration }
           : {}),
         ...(session.resumeCursor !== undefined ? { resumeCursor: session.resumeCursor } : {}),
-        runtimePayload: toRuntimePayloadFromSession(session, extra),
+        runtimePayload: {
+          ...toRuntimePayloadFromSession(session, extra),
+          ...extra?.runtimePayload,
+        },
       });
 
     const markThreadStopped = (
@@ -1785,18 +1789,11 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                   modelSelection: input.modelSelection,
                   providerOptions: effectiveProviderOptions,
                   lifecycleGeneration: lease.generation,
-                }).pipe(
-                  Effect.andThen(
-                    directory.upsert({
-                      threadId,
-                      provider: session.provider,
-                      runtimePayload: {
-                        [AGENT_GATEWAY_CREDENTIAL_ROTATION_REQUIRED]: false,
-                        [PRIOR_TRANSCRIPT_BOOTSTRAP_PENDING]: priorTranscriptBootstrapPending,
-                      },
-                    }),
-                  ),
-                ),
+                  runtimePayload: {
+                    [AGENT_GATEWAY_CREDENTIAL_ROTATION_REQUIRED]: false,
+                    [PRIOR_TRANSCRIPT_BOOTSTRAP_PENDING]: priorTranscriptBootstrapPending,
+                  },
+                }),
               );
               lease.commit();
               if (

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -166,6 +166,10 @@ const ClearSessionResumeCursorInput = Schema.Struct({
   preserveActiveRuntime: Schema.optional(Schema.Boolean),
 });
 
+const CompletePriorTranscriptBootstrapInput = Schema.Struct({
+  threadId: ThreadId,
+});
+
 type StopRuntimeSession = NonNullable<ProviderServiceShape["stopRuntimeSession"]>;
 type StopRuntimeSessionInput = Parameters<StopRuntimeSession>[0];
 type StopRuntimeSessionEffect = ReturnType<StopRuntimeSession>;
@@ -190,6 +194,7 @@ type InteractionResponse =
  */
 const PROVIDER_START_SESSION_TIMEOUT = Duration.seconds(60);
 const PROVIDER_STOP_SESSION_TIMEOUT = Duration.seconds(10);
+const PRIOR_TRANSCRIPT_BOOTSTRAP_PENDING = "priorTranscriptBootstrapPending";
 
 function toValidationError(
   operation: string,
@@ -1664,6 +1669,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     const startSessionWithOutcome: NonNullable<ProviderServiceShape["startSessionWithOutcome"]> = (
       threadId,
       rawInput,
+      outcomeOptions,
     ) =>
       Effect.gen(function* () {
         const parsed = yield* decodeInputOrValidationError({
@@ -1700,6 +1706,13 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                   (persistedBinding?.provider === input.provider
                     ? persistedBinding.resumeCursor
                     : undefined));
+            const priorTranscriptBootstrapPending =
+              (persistedBinding?.provider === input.provider &&
+                runtimePayloadRecord(persistedBinding.runtimePayload)[
+                  PRIOR_TRANSCRIPT_BOOTSTRAP_PENDING
+                ] === true) ||
+              (outcomeOptions?.registerPriorTranscriptBootstrapOnFreshStart === true &&
+                !hasResumeCursor(effectiveResumeCursor));
             const adapterStartInput = { ...input };
             delete adapterStartInput.resumeCursor;
             const effectiveProviderOptions =
@@ -1773,6 +1786,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                       provider: session.provider,
                       runtimePayload: {
                         [AGENT_GATEWAY_CREDENTIAL_ROTATION_REQUIRED]: false,
+                        [PRIOR_TRANSCRIPT_BOOTSTRAP_PENDING]: priorTranscriptBootstrapPending,
                       },
                     }),
                   ),
@@ -1789,6 +1803,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               return {
                 session,
                 nativeResumeAttempted: hasResumeCursor(effectiveResumeCursor),
+                priorTranscriptBootstrapPending,
               };
             });
 
@@ -1866,6 +1881,33 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
 
     const startSession: ProviderServiceShape["startSession"] = (threadId, input) =>
       startSessionWithOutcome(threadId, input).pipe(Effect.map(({ session }) => session));
+
+    const completePriorTranscriptBootstrap: NonNullable<
+      ProviderServiceShape["completePriorTranscriptBootstrap"]
+    > = (rawInput) =>
+      Effect.gen(function* () {
+        const input = yield* decodeInputOrValidationError({
+          operation: "ProviderService.completePriorTranscriptBootstrap",
+          schema: CompletePriorTranscriptBootstrapInput,
+          payload: rawInput,
+        });
+        yield* withBindingWriteLock(
+          input.threadId,
+          Effect.gen(function* () {
+            const binding = Option.getOrUndefined(yield* directory.getBinding(input.threadId));
+            if (!binding) {
+              return;
+            }
+            yield* directory.upsert({
+              threadId: input.threadId,
+              provider: binding.provider,
+              runtimePayload: {
+                [PRIOR_TRANSCRIPT_BOOTSTRAP_PENDING]: false,
+              },
+            });
+          }),
+        );
+      });
 
     const forkThread: NonNullable<ProviderServiceShape["forkThread"]> = (rawInput) =>
       Effect.gen(function* () {
@@ -2988,6 +3030,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     return {
       startSession,
       startSessionWithOutcome,
+      completePriorTranscriptBootstrap,
       forkThread,
       sendTurn,
       steerTurn,

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -1661,9 +1661,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         } as const;
       });
 
-    const startSessionWithOutcome: NonNullable<
-      ProviderServiceShape["startSessionWithOutcome"]
-    > = (threadId, rawInput) =>
+    const startSessionWithOutcome: NonNullable<ProviderServiceShape["startSessionWithOutcome"]> = (
+      threadId,
+      rawInput,
+    ) =>
       Effect.gen(function* () {
         const parsed = yield* decodeInputOrValidationError({
           operation: "ProviderService.startSession",

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -1706,13 +1706,11 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                   (persistedBinding?.provider === input.provider
                     ? persistedBinding.resumeCursor
                     : undefined));
-            const priorTranscriptBootstrapPending =
-              (persistedBinding?.provider === input.provider &&
-                runtimePayloadRecord(persistedBinding.runtimePayload)[
-                  PRIOR_TRANSCRIPT_BOOTSTRAP_PENDING
-                ] === true) ||
-              (outcomeOptions?.registerPriorTranscriptBootstrapOnFreshStart === true &&
-                !hasResumeCursor(effectiveResumeCursor));
+            const persistedPriorTranscriptBootstrapPending =
+              persistedBinding?.provider === input.provider &&
+              runtimePayloadRecord(persistedBinding.runtimePayload)[
+                PRIOR_TRANSCRIPT_BOOTSTRAP_PENDING
+              ] === true;
             const adapterStartInput = { ...input };
             delete adapterStartInput.resumeCursor;
             const effectiveProviderOptions =
@@ -1724,21 +1722,22 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             let replacementStarted = false;
             const startAndPersistReplacement = Effect.gen(function* () {
               yield* ensureProviderEnabled(input.provider, "ProviderService.startSession");
+              const resolvedAdapterStartInput = {
+                ...adapterStartInput,
+                lifecycleGeneration: lease.generation,
+                ...(effectiveProviderOptions !== undefined
+                  ? { providerOptions: effectiveProviderOptions }
+                  : {}),
+                ...(hasResumeCursor(effectiveResumeCursor)
+                  ? { resumeCursor: effectiveResumeCursor }
+                  : {}),
+              };
               // A provider start that never returns holds this thread's
               // lifecycle lock and the caller's command slot forever. Bound it,
               // retire whatever the adapter may have half-spawned, and fail
               // with text the caller can surface as a session error.
               const started = yield* adapter
-                .startSession({
-                  ...adapterStartInput,
-                  lifecycleGeneration: lease.generation,
-                  ...(effectiveProviderOptions !== undefined
-                    ? { providerOptions: effectiveProviderOptions }
-                    : {}),
-                  ...(hasResumeCursor(effectiveResumeCursor)
-                    ? { resumeCursor: effectiveResumeCursor }
-                    : {}),
-                })
+                .startSession(resolvedAdapterStartInput)
                 .pipe(Effect.timeoutOption(PROVIDER_START_SESSION_TIMEOUT));
               if (Option.isNone(started)) {
                 yield* Effect.logError("provider session start exceeded its deadline", {
@@ -1765,6 +1764,13 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               }
               const session = started.value;
               replacementStarted = true;
+              const nativeResumeSucceeded = hasResumeCursor(effectiveResumeCursor)
+                ? (adapter.didResumeSession?.(resolvedAdapterStartInput, session) ?? true)
+                : false;
+              const priorTranscriptBootstrapPending =
+                persistedPriorTranscriptBootstrapPending ||
+                (outcomeOptions?.registerPriorTranscriptBootstrapOnFreshStart === true &&
+                  !nativeResumeSucceeded);
 
               if (session.provider !== adapter.provider) {
                 return yield* toValidationError(
@@ -1802,7 +1808,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
 
               return {
                 session,
-                nativeResumeAttempted: hasResumeCursor(effectiveResumeCursor),
+                nativeResumeSucceeded,
                 priorTranscriptBootstrapPending,
               };
             });

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -1661,7 +1661,9 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         } as const;
       });
 
-    const startSession: ProviderServiceShape["startSession"] = (threadId, rawInput) =>
+    const startSessionWithOutcome: NonNullable<
+      ProviderServiceShape["startSessionWithOutcome"]
+    > = (threadId, rawInput) =>
       Effect.gen(function* () {
         const parsed = yield* decodeInputOrValidationError({
           operation: "ProviderService.startSession",
@@ -1719,7 +1721,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                   ...(effectiveProviderOptions !== undefined
                     ? { providerOptions: effectiveProviderOptions }
                     : {}),
-                  ...(effectiveResumeCursor !== undefined
+                  ...(hasResumeCursor(effectiveResumeCursor)
                     ? { resumeCursor: effectiveResumeCursor }
                     : {}),
                 })
@@ -1783,7 +1785,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                 providerInterruptionFences.delete(threadId);
               }
 
-              return session;
+              return {
+                session,
+                nativeResumeAttempted: hasResumeCursor(effectiveResumeCursor),
+              };
             });
 
             if (!persistedBinding || persistedBinding.provider === input.provider) {
@@ -1857,6 +1862,9 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           }),
         );
       });
+
+    const startSession: ProviderServiceShape["startSession"] = (threadId, input) =>
+      startSessionWithOutcome(threadId, input).pipe(Effect.map(({ session }) => session));
 
     const forkThread: NonNullable<ProviderServiceShape["forkThread"]> = (rawInput) =>
       Effect.gen(function* () {
@@ -2978,6 +2986,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
 
     return {
       startSession,
+      startSessionWithOutcome,
       forkThread,
       sendTurn,
       steerTurn,

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -110,6 +110,16 @@ export interface ProviderAdapterShape<TError> {
   ) => Effect.Effect<ProviderSession, TError>;
 
   /**
+   * Confirm that a successful start reused the provider-native session named
+   * by the supplied cursor. Adapters that can reject malformed cursors without
+   * failing startup should implement this instead of relying on cursor presence.
+   */
+  readonly didResumeSession?: (
+    input: ProviderSessionStartInput,
+    session: ProviderSession,
+  ) => boolean;
+
+  /**
    * Send a turn to an active provider session.
    */
   readonly sendTurn: (

--- a/apps/server/src/provider/Services/ProviderService.ts
+++ b/apps/server/src/provider/Services/ProviderService.ts
@@ -55,6 +55,16 @@ export interface ProviderRuntimeEventPumpHealth {
 export interface ProviderSessionStartOutcome {
   readonly session: ProviderSession;
   readonly nativeResumeAttempted: boolean;
+  readonly priorTranscriptBootstrapPending: boolean;
+}
+
+export interface ProviderSessionStartOutcomeOptions {
+  /**
+   * Persist a pending transcript bootstrap when this start cannot restore
+   * provider-native context. The caller clears it only after the provider has
+   * accepted the bootstrap turn.
+   */
+  readonly registerPriorTranscriptBootstrapOnFreshStart?: boolean;
 }
 
 /**
@@ -76,7 +86,13 @@ export interface ProviderServiceShape {
   readonly startSessionWithOutcome?: (
     threadId: ThreadId,
     input: ProviderSessionStartInput,
+    options?: ProviderSessionStartOutcomeOptions,
   ) => Effect.Effect<ProviderSessionStartOutcome, ProviderServiceError>;
+
+  /** Mark a persisted prior-transcript bootstrap as accepted by the provider. */
+  readonly completePriorTranscriptBootstrap?: (input: {
+    readonly threadId: ThreadId;
+  }) => Effect.Effect<void, ProviderServiceError>;
 
   /**
    * Send a provider turn.

--- a/apps/server/src/provider/Services/ProviderService.ts
+++ b/apps/server/src/provider/Services/ProviderService.ts
@@ -52,6 +52,11 @@ export interface ProviderRuntimeEventPumpHealth {
   readonly lastQuarantinedAt?: string;
 }
 
+export interface ProviderSessionStartOutcome {
+  readonly session: ProviderSession;
+  readonly nativeResumeAttempted: boolean;
+}
+
 /**
  * ProviderServiceShape - Service API for provider session and turn orchestration.
  */
@@ -63,6 +68,15 @@ export interface ProviderServiceShape {
     threadId: ThreadId,
     input: ProviderSessionStartInput,
   ) => Effect.Effect<ProviderSession, ProviderServiceError>;
+
+  /**
+   * Start a provider session and report whether it supplied a provider-native
+   * resume cursor to the adapter.
+   */
+  readonly startSessionWithOutcome?: (
+    threadId: ThreadId,
+    input: ProviderSessionStartInput,
+  ) => Effect.Effect<ProviderSessionStartOutcome, ProviderServiceError>;
 
   /**
    * Send a provider turn.

--- a/apps/server/src/provider/Services/ProviderService.ts
+++ b/apps/server/src/provider/Services/ProviderService.ts
@@ -54,7 +54,7 @@ export interface ProviderRuntimeEventPumpHealth {
 
 export interface ProviderSessionStartOutcome {
   readonly session: ProviderSession;
-  readonly nativeResumeAttempted: boolean;
+  readonly nativeResumeSucceeded: boolean;
   readonly priorTranscriptBootstrapPending: boolean;
 }
 
@@ -80,8 +80,8 @@ export interface ProviderServiceShape {
   ) => Effect.Effect<ProviderSession, ProviderServiceError>;
 
   /**
-   * Start a provider session and report whether it supplied a provider-native
-   * resume cursor to the adapter.
+   * Start a provider session and report whether the adapter confirmed that it
+   * restored the provider-native session named by the supplied cursor.
    */
   readonly startSessionWithOutcome?: (
     threadId: ThreadId,


### PR DESCRIPTION
Closes #796

OpenCode and Kilo idle stops preserve their durable native resume cursor, but `ProviderCommandReactor` previously decided whether to inject the lossy Synara transcript recap solely from the absence of an active in-memory session. The next dispatch therefore resumed the intact native session and still told the model to trust a compressed recap, downgrading context after every idle restart.

This change adds an adapter-level resume confirmation signal. OpenCode/Kilo confirms that the session returned by startup has the same native session ID as the persisted cursor; malformed or incomplete cursors that the adapter rejects no longer masquerade as a successful resume. The reactor sends the user message bare only after confirmed native resume, while retaining the existing one-time transcript bootstrap for genuine fresh starts.

Cold starts also persist a pending transcript-bootstrap marker alongside the provider binding before the fresh native session is exposed. The marker survives a process failure before turn dispatch, remains pending across native resume, and clears only after the matching provider turn completes successfully. A delayed async prompt rejection keeps the marker for the retry. Explicit session stops discard it, empty recaps complete after a successful bare turn, and specialized handoff/sidechat context satisfies it without forcing a redundant generic recap.

OpenCode-compatible resume startup failures remain typed `session.update` request failures. The reactor clears the cursor and retries once only for a confirmed missing session (404 or equivalent missing-session detail); transient transport, authentication, and policy-update failures surface normally without discarding valid native context. The fresh retry sends the original user turn once with the transcript recap.

Regression coverage exercises both OpenCode and Kilo for:

- successful post-idle native resume with a bare follow-up;
- cursor-less cold start with exactly one recap;
- failed native resume with one fresh-session recap and no duplicate user turn;
- transient resume failure without cursor deletion or retry;
- malformed/rejected cursors falling back to one recap instead of suppressing context;
- durable bootstrap state across runtime stop/resume until explicit completion;
- explicit-stop, empty-recap, and sidechat/handoff bootstrap lifecycle edges.
- delayed asynchronous prompt rejection retaining the recap until a successful retry.

Verification:

- `bun run --cwd apps/server test -- src/provider/Layers/ProviderService.test.ts` — 86 passed
- `bun run --cwd apps/server test -- src/provider/Layers/OpenCodeAdapter.test.ts` — 79 passed
- `bun run --cwd apps/server test -- src/orchestration/Layers/ProviderCommandReactor.test.ts` — 156 passed
- targeted formatter check on all eight changed files
- `git diff --check`

Per task constraints, `bun fmt`, `bun lint`, and `bun typecheck` were not run locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core provider session start, resume cursor handling, and what context is sent to models; mistakes could duplicate or drop conversation context, though behavior is heavily regression-tested.
> 
> **Overview**
> **OpenCode/Kilo** no longer inject a Synara `<thread_context>` recap when the provider **actually** resumed the native session. Session start now returns **`nativeResumeSucceeded`** (via optional adapter **`didResumeSession`**) and a durable **`priorTranscriptBootstrapPending`** flag; the reactor sends follow-up turns **bare** only after confirmed resume, and injects a **one-time** recap for cold starts, rejected cursors, or stale sessions.
> 
> **ProviderService** adds **`startSessionWithOutcome`** and **`completePriorTranscriptBootstrap`**, persisting bootstrap state in session bindings until a successful turn (or explicit session stop clears it). **OpenCode** surfaces **`session.update`** resume failures as typed request errors and implements resume confirmation; on **missing-session** 404-style failures the reactor **clears the stale cursor and retries once** with transcript context, without discarding cursors on transient errors.
> 
> Large **ProviderCommandReactor** regression suite covers idle resume, cold start, async prompt rejection, sidechat bootstrap, stop/cleanup retries, and failure edges for both providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27fb26a8d341bb8f130357b0940fc606c5f69e00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->