### PR TITLE
fix(server): suppress ACP load replay centrally

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -31,10 +31,13 @@ const supportsSessionFork = process.env.SYNARA_ACP_SUPPORT_SESSION_FORK === "1";
 const emitAvailableCommands = process.env.SYNARA_ACP_EMIT_AVAILABLE_COMMANDS === "1";
 const loadReplayDelaysMs = (process.env.SYNARA_ACP_LOAD_REPLAY_DELAYS_MS ?? "")
   .split(",")
-  .map((value) => Number(value.trim()))
+  .map((value) => value.trim())
+  .filter((value) => value.length > 0)
+  .map(Number)
   .filter((value) => Number.isFinite(value) && value >= 0);
 const rejectPromptDuringLoadReplay =
   process.env.SYNARA_ACP_REJECT_PROMPT_DURING_LOAD_REPLAY === "1";
+const rejectForkDuringLoadReplay = process.env.SYNARA_ACP_REJECT_FORK_DURING_LOAD_REPLAY === "1";
 const modeConfigId = process.env.SYNARA_ACP_MODE_CONFIG_ID || "mode";
 const sessionId = "mock-session-1";
 
@@ -374,11 +377,16 @@ app.onRequest(OfficialAcp.methods.agent.session.resume, () => ({
   configOptions: configOptions(),
 }));
 
-app.onRequest(OfficialAcp.methods.agent.session.fork, () => ({
-  sessionId: "mock-session-fork-1",
-  modes: modeState(),
-  configOptions: configOptions(),
-}));
+app.onRequest(OfficialAcp.methods.agent.session.fork, () => {
+  if (rejectForkDuringLoadReplay && pendingLoadReplayUpdates > 0) {
+    throw new OfficialAcp.RequestError(-32603, "Fork arrived before load replay settled.");
+  }
+  return {
+    sessionId: "mock-session-fork-1",
+    modes: modeState(),
+    configOptions: configOptions(),
+  };
+});
 
 app.onRequest(OfficialAcp.methods.agent.session.setConfigOption, ({ params: request }) => {
   if (failSetConfigOption) {

--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -41,6 +41,7 @@ const rejectPromptDuringLoadReplay =
   process.env.SYNARA_ACP_REJECT_PROMPT_DURING_LOAD_REPLAY === "1";
 const rejectForkDuringLoadReplay = process.env.SYNARA_ACP_REJECT_FORK_DURING_LOAD_REPLAY === "1";
 const loadReplayModeId = process.env.SYNARA_ACP_LOAD_REPLAY_MODE_ID?.trim();
+const loadReplayAvailableCommands = process.env.SYNARA_ACP_LOAD_REPLAY_AVAILABLE_COMMANDS === "1";
 const modeConfigId = process.env.SYNARA_ACP_MODE_CONFIG_ID || "mode";
 const sessionId = "mock-session-1";
 
@@ -265,6 +266,18 @@ function scheduleLoadReplayUpdates(
               },
             })
           : Effect.void;
+      const commandsUpdate =
+        index === loadReplayDelaysMs.length - 1 && loadReplayAvailableCommands
+          ? client.sessionUpdate({
+              sessionId: requestedSessionId,
+              update: {
+                sessionUpdate: "available_commands_update",
+                availableCommands: [
+                  { name: "compact", description: "Compact the current context" },
+                ],
+              },
+            })
+          : Effect.void;
       void runEffect(
         client
           .sessionUpdate({
@@ -274,7 +287,7 @@ function scheduleLoadReplayUpdates(
               content: { type: "text", text: `late replay ${index + 1}` },
             },
           })
-          .pipe(Effect.andThen(modeUpdate)),
+          .pipe(Effect.andThen(modeUpdate), Effect.andThen(commandsUpdate)),
       ).finally(() => {
         pendingLoadReplayUpdates -= 1;
       });

--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -38,6 +38,7 @@ const loadReplayDelaysMs = (process.env.SYNARA_ACP_LOAD_REPLAY_DELAYS_MS ?? "")
 const rejectPromptDuringLoadReplay =
   process.env.SYNARA_ACP_REJECT_PROMPT_DURING_LOAD_REPLAY === "1";
 const rejectForkDuringLoadReplay = process.env.SYNARA_ACP_REJECT_FORK_DURING_LOAD_REPLAY === "1";
+const loadReplayModeId = process.env.SYNARA_ACP_LOAD_REPLAY_MODE_ID?.trim();
 const modeConfigId = process.env.SYNARA_ACP_MODE_CONFIG_ID || "mode";
 const sessionId = "mock-session-1";
 
@@ -252,14 +253,26 @@ function scheduleLoadReplayUpdates(
   pendingLoadReplayUpdates += loadReplayDelaysMs.length;
   loadReplayDelaysMs.forEach((delayMs, index) => {
     setTimeout(() => {
+      const modeUpdate =
+        index === loadReplayDelaysMs.length - 1 && loadReplayModeId
+          ? client.sessionUpdate({
+              sessionId: requestedSessionId,
+              update: {
+                sessionUpdate: "current_mode_update",
+                currentModeId: loadReplayModeId,
+              },
+            })
+          : Effect.void;
       void runEffect(
-        client.sessionUpdate({
-          sessionId: requestedSessionId,
-          update: {
-            sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text: `late replay ${index + 1}` },
-          },
-        }),
+        client
+          .sessionUpdate({
+            sessionId: requestedSessionId,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: `late replay ${index + 1}` },
+            },
+          })
+          .pipe(Effect.andThen(modeUpdate)),
       ).finally(() => {
         pendingLoadReplayUpdates -= 1;
       });

--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -24,6 +24,8 @@ const emitAskQuestion = process.env.SYNARA_ACP_EMIT_ASK_QUESTION === "1";
 const failSessionNewOnce = process.env.SYNARA_ACP_FAIL_SESSION_NEW_ONCE === "1";
 const failSetConfigOption = process.env.SYNARA_ACP_FAIL_SET_CONFIG_OPTION === "1";
 const exitOnSetConfigOption = process.env.SYNARA_ACP_EXIT_ON_SET_CONFIG_OPTION === "1";
+const rejectConfigDuringLoadReplay =
+  process.env.SYNARA_ACP_REJECT_CONFIG_DURING_LOAD_REPLAY === "1";
 const promptResponseText = process.env.SYNARA_ACP_PROMPT_RESPONSE_TEXT;
 const supportsSessionResume = process.env.SYNARA_ACP_SUPPORT_SESSION_RESUME === "1";
 const supportsSessionLoad = process.env.SYNARA_ACP_SUPPORT_SESSION_LOAD !== "0";
@@ -402,6 +404,12 @@ app.onRequest(OfficialAcp.methods.agent.session.fork, () => {
 });
 
 app.onRequest(OfficialAcp.methods.agent.session.setConfigOption, ({ params: request }) => {
+  if (rejectConfigDuringLoadReplay && pendingLoadReplayUpdates > 0) {
+    throw OfficialAcp.RequestError.invalidParams(
+      { method: "session/set_config_option", params: request },
+      "Session configuration arrived before session/load replay settled",
+    );
+  }
   if (failSetConfigOption) {
     throw OfficialAcp.RequestError.invalidParams(
       {

--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -29,6 +29,12 @@ const supportsSessionResume = process.env.SYNARA_ACP_SUPPORT_SESSION_RESUME === 
 const supportsSessionLoad = process.env.SYNARA_ACP_SUPPORT_SESSION_LOAD !== "0";
 const supportsSessionFork = process.env.SYNARA_ACP_SUPPORT_SESSION_FORK === "1";
 const emitAvailableCommands = process.env.SYNARA_ACP_EMIT_AVAILABLE_COMMANDS === "1";
+const loadReplayDelaysMs = (process.env.SYNARA_ACP_LOAD_REPLAY_DELAYS_MS ?? "")
+  .split(",")
+  .map((value) => Number(value.trim()))
+  .filter((value) => Number.isFinite(value) && value >= 0);
+const rejectPromptDuringLoadReplay =
+  process.env.SYNARA_ACP_REJECT_PROMPT_DURING_LOAD_REPLAY === "1";
 const modeConfigId = process.env.SYNARA_ACP_MODE_CONFIG_ID || "mode";
 const sessionId = "mock-session-1";
 
@@ -39,6 +45,7 @@ let currentReasoning = "medium";
 let currentContext = "272k";
 let currentFast = false;
 let sessionNewAttempts = 0;
+let pendingLoadReplayUpdates = 0;
 const cancelledSessions = new Set<string>();
 
 function logExit(reason: string): void {
@@ -235,6 +242,28 @@ function makeClient(context: OfficialAcp.AgentContext) {
   };
 }
 
+function scheduleLoadReplayUpdates(
+  client: ReturnType<typeof makeClient>,
+  requestedSessionId: string,
+): void {
+  pendingLoadReplayUpdates += loadReplayDelaysMs.length;
+  loadReplayDelaysMs.forEach((delayMs, index) => {
+    setTimeout(() => {
+      void runEffect(
+        client.sessionUpdate({
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: `late replay ${index + 1}` },
+          },
+        }),
+      ).finally(() => {
+        pendingLoadReplayUpdates -= 1;
+      });
+    }, delayMs);
+  });
+}
+
 function requestInput(): ReadableStream<Uint8Array> {
   const input = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
   if (!requestLogPath) return input;
@@ -320,16 +349,20 @@ app.onRequest(OfficialAcp.methods.agent.session.new, ({ client: context }) => {
 
 app.onRequest(OfficialAcp.methods.agent.session.load, ({ client: context, params: request }) => {
   const client = makeClient(context);
+  const requestedSessionId = String(request.sessionId ?? sessionId);
   return runEffect(
     client
       .sessionUpdate({
-        sessionId: String(request.sessionId ?? sessionId),
+        sessionId: requestedSessionId,
         update: {
           sessionUpdate: "user_message_chunk",
           content: { type: "text", text: "replay" },
         },
       })
       .pipe(
+        Effect.tap(() =>
+          Effect.sync(() => scheduleLoadReplayUpdates(client, requestedSessionId)),
+        ),
         Effect.as({
           modes: modeState(),
           configOptions: configOptions(),
@@ -393,6 +426,12 @@ app.onNotification(OfficialAcp.methods.agent.session.cancel, ({ params: { sessio
 });
 
 app.onRequest(OfficialAcp.methods.agent.session.prompt, ({ client: context, params: request }) => {
+  if (rejectPromptDuringLoadReplay && pendingLoadReplayUpdates > 0) {
+    throw OfficialAcp.RequestError.invalidParams(
+      { method: "session/prompt", params: request },
+      "Prompt arrived before session/load replay settled",
+    );
+  }
   const client = makeClient(context);
   return runEffect(
     Effect.gen(function* () {

--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -360,9 +360,7 @@ app.onRequest(OfficialAcp.methods.agent.session.load, ({ client: context, params
         },
       })
       .pipe(
-        Effect.tap(() =>
-          Effect.sync(() => scheduleLoadReplayUpdates(client, requestedSessionId)),
-        ),
+        Effect.tap(() => Effect.sync(() => scheduleLoadReplayUpdates(client, requestedSessionId))),
         Effect.as({
           modes: modeState(),
           configOptions: configOptions(),

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -671,7 +671,9 @@ export function makeCursorAdapter(
           yield* Fiber.interrupt(ctx.notificationFiber);
         }
         yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
-        sessions.delete(ctx.threadId);
+        if (sessions.get(ctx.threadId) === ctx) {
+          sessions.delete(ctx.threadId);
+        }
         yield* offerRuntimeEvent(ctx.lifecycleGeneration, {
           type: "session.exited",
           ...(yield* makeEventStamp()),

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -219,6 +219,10 @@ interface CursorSessionContext {
   // idle-progress watchdog that force-fails a silently hung turn.
   lastTurnActivityAt: number | undefined;
   latestSessionCostUsd: number | undefined;
+  // The runtime is registered before load replay settles so stop/restart can
+  // close it without waiting for the replay hard cap. Turns wait here until
+  // startup configuration has completed under the thread lock.
+  sessionConfigReady: Deferred.Deferred<void> | undefined;
   stopped: boolean;
 }
 
@@ -659,6 +663,10 @@ export function makeCursorAdapter(
         ctx.gatewaySessionLease?.release();
         yield* settleAcpPendingApprovalsAsCancelled(ctx.pendingApprovals);
         yield* settleAcpPendingUserInputsAsEmptyAnswers(ctx.pendingUserInputs);
+        if (ctx.sessionConfigReady !== undefined) {
+          yield* Deferred.succeed(ctx.sessionConfigReady, undefined);
+          ctx.sessionConfigReady = undefined;
+        }
         if (ctx.notificationFiber) {
           yield* Fiber.interrupt(ctx.notificationFiber);
         }
@@ -673,8 +681,9 @@ export function makeCursorAdapter(
         });
       });
 
-    const startSession: CursorAdapterShape["startSession"] = (input) =>
-      withThreadLock(
+    const startSession: CursorAdapterShape["startSession"] = (input) => {
+      let registeredCtx: CursorSessionContext | undefined;
+      const setup = withThreadLock(
         input.threadId,
         Effect.gen(function* () {
           if (input.provider !== undefined && input.provider !== PROVIDER) {
@@ -966,6 +975,7 @@ export function makeCursorAdapter(
             ),
           );
 
+          const sessionConfigReady = yield* Deferred.make<void>();
           const now = yield* nowIso;
           const session: ProviderSession = {
             provider: PROVIDER,
@@ -1004,6 +1014,7 @@ export function makeCursorAdapter(
             activePromptFiber: undefined,
             lastTurnActivityAt: undefined,
             latestSessionCostUsd: undefined,
+            sessionConfigReady,
             stopped: false,
           };
 
@@ -1138,57 +1149,103 @@ export function makeCursorAdapter(
 
           ctx.notificationFiber = nf;
 
-          // Fork the event drain before configuration can activate the shared
-          // load-replay gate. Keep the session unregistered until configuration
-          // settles so an immediate turn cannot race these state-dependent reads.
-          yield* applyRequestedSessionConfiguration({
-            runtime: acp,
-            runtimeMode: input.runtimeMode,
-            interactionMode: undefined,
-            modelSelection: cursorModelSelection,
-            mapError: ({ cause, method }) =>
-              mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
-            onModelSelectionNotice: (notice) =>
-              emitCursorModelSelectionNotice({
-                threadId: input.threadId,
-                lifecycleGeneration: input.lifecycleGeneration,
-                turnId: undefined,
-                notice,
-              }),
-          });
-
           sessions.set(input.threadId, ctx);
+          registeredCtx = ctx;
           sessionScopeTransferred = true;
 
-          yield* offerRuntimeEvent(input.lifecycleGeneration, {
-            type: "session.started",
-            ...(yield* makeEventStamp()),
-            provider: PROVIDER,
-            threadId: input.threadId,
-            payload: { resume: started.initializeResult },
-          });
-          yield* offerRuntimeEvent(input.lifecycleGeneration, {
-            type: "session.state.changed",
-            ...(yield* makeEventStamp()),
-            provider: PROVIDER,
-            threadId: input.threadId,
-            payload: { state: "ready", reason: "Cursor ACP session ready" },
-          });
-          yield* offerRuntimeEvent(input.lifecycleGeneration, {
-            type: "thread.started",
-            ...(yield* makeEventStamp()),
-            provider: PROVIDER,
-            threadId: input.threadId,
-            payload: { providerThreadId: started.sessionId },
-          });
-
-          return session;
+          return { ctx, session, started, cursorModelSelection, sessionConfigReady };
         }).pipe(Effect.scoped),
       );
+
+      return Effect.gen(function* () {
+        const { ctx, session, started, cursorModelSelection, sessionConfigReady } = yield* setup;
+        // The replay wait deliberately runs without the per-thread lock. The
+        // registered context lets stop/restart close the scope and release the
+        // gate immediately instead of waiting for its hard cap.
+        yield* ctx.acp.awaitLoadReplayReady.pipe(
+          Effect.mapError((cause) =>
+            ctx.stopped
+              ? new ProviderAdapterSessionNotFoundError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                })
+              : mapAcpToAdapterError(PROVIDER, input.threadId, "session/load", cause),
+          ),
+        );
+
+        yield* withThreadLock(
+          input.threadId,
+          Effect.gen(function* () {
+            if (ctx.stopped || sessions.get(input.threadId) !== ctx) {
+              return yield* new ProviderAdapterSessionNotFoundError({
+                provider: PROVIDER,
+                threadId: input.threadId,
+              });
+            }
+            yield* applyRequestedSessionConfiguration({
+              runtime: ctx.acp,
+              runtimeMode: input.runtimeMode,
+              interactionMode: undefined,
+              modelSelection: cursorModelSelection,
+              mapError: ({ cause, method }) =>
+                mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
+              onModelSelectionNotice: (notice) =>
+                emitCursorModelSelectionNotice({
+                  threadId: input.threadId,
+                  lifecycleGeneration: input.lifecycleGeneration,
+                  turnId: undefined,
+                  notice,
+                }),
+            });
+            yield* Deferred.succeed(sessionConfigReady, undefined);
+            ctx.sessionConfigReady = undefined;
+
+            yield* offerRuntimeEvent(input.lifecycleGeneration, {
+              type: "session.started",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              payload: { resume: started.initializeResult },
+            });
+            yield* offerRuntimeEvent(input.lifecycleGeneration, {
+              type: "session.state.changed",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              payload: { state: "ready", reason: "Cursor ACP session ready" },
+            });
+            yield* offerRuntimeEvent(input.lifecycleGeneration, {
+              type: "thread.started",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              payload: { providerThreadId: started.sessionId },
+            });
+          }),
+        );
+
+        return session;
+      }).pipe(
+        Effect.onExit((exit) =>
+          Exit.isSuccess(exit) || registeredCtx === undefined
+            ? Effect.void
+            : Effect.ignore(stopSessionInternal(registeredCtx)),
+        ),
+      );
+    };
 
     const sendTurn: CursorAdapterShape["sendTurn"] = (input) =>
       Effect.gen(function* () {
         const ctx = yield* requireSession(input.threadId);
+        if (ctx.sessionConfigReady !== undefined) {
+          yield* Deferred.await(ctx.sessionConfigReady);
+        }
+        if (ctx.stopped) {
+          return yield* new ProviderAdapterSessionNotFoundError({
+            provider: PROVIDER,
+            threadId: input.threadId,
+          });
+        }
         const turnId = TurnId.makeUnsafe(crypto.randomUUID());
         const turnModelSelection =
           input.modelSelection?.provider === PROVIDER ? input.modelSelection : undefined;

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -966,22 +966,6 @@ export function makeCursorAdapter(
             ),
           );
 
-          yield* applyRequestedSessionConfiguration({
-            runtime: acp,
-            runtimeMode: input.runtimeMode,
-            interactionMode: undefined,
-            modelSelection: cursorModelSelection,
-            mapError: ({ cause, method }) =>
-              mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
-            onModelSelectionNotice: (notice) =>
-              emitCursorModelSelectionNotice({
-                threadId: input.threadId,
-                lifecycleGeneration: input.lifecycleGeneration,
-                turnId: undefined,
-                notice,
-              }),
-          });
-
           const now = yield* nowIso;
           const session: ProviderSession = {
             provider: PROVIDER,
@@ -1153,6 +1137,26 @@ export function makeCursorAdapter(
           ).pipe(Effect.forkIn(sessionScope));
 
           ctx.notificationFiber = nf;
+
+          // Fork the event drain before configuration can activate the shared
+          // load-replay gate. Keep the session unregistered until configuration
+          // settles so an immediate turn cannot race these state-dependent reads.
+          yield* applyRequestedSessionConfiguration({
+            runtime: acp,
+            runtimeMode: input.runtimeMode,
+            interactionMode: undefined,
+            modelSelection: cursorModelSelection,
+            mapError: ({ cause, method }) =>
+              mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
+            onModelSelectionNotice: (notice) =>
+              emitCursorModelSelectionNotice({
+                threadId: input.threadId,
+                lifecycleGeneration: input.lifecycleGeneration,
+                turnId: undefined,
+                notice,
+              }),
+          });
+
           sessions.set(input.threadId, ctx);
           sessionScopeTransferred = true;
 

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -386,7 +386,14 @@ function applyRequestedSessionConfiguration<E>(input: {
     const requestedModeId = resolveRequestedAcpSessionModeId({
       interactionMode: input.interactionMode,
       runtimeMode: input.runtimeMode,
-      modeState: yield* input.runtime.getModeState,
+      modeState: yield* input.runtime.getModeState.pipe(
+        Effect.mapError((cause) =>
+          input.mapError({
+            cause,
+            method: "session/set_mode",
+          }),
+        ),
+      ),
       aliases: CURSOR_ACP_SESSION_MODE_ALIASES,
     });
     if (!requestedModeId) {

--- a/apps/server/src/provider/Layers/DroidAdapter.ts
+++ b/apps/server/src/provider/Layers/DroidAdapter.ts
@@ -592,7 +592,9 @@ export function makeDroidAdapter(
             yield* cancelAgentGatewayTurn(ctx.gatewaySessionLease, ctx.activeTurnId);
             ctx.gatewaySessionLease?.release();
             sessionTeardownGate.track(ctx.threadId, ctx.teardownComplete);
-            sessions.delete(ctx.threadId);
+            if (sessions.get(ctx.threadId) === ctx) {
+              sessions.delete(ctx.threadId);
+            }
             yield* settleAcpPendingApprovalsAsCancelled(ctx.pendingApprovals);
             yield* settleAcpPendingUserInputsAsEmptyAnswers(ctx.pendingUserInputs);
             if (ctx.sessionConfigReady !== undefined) {

--- a/apps/server/src/provider/Layers/DroidAdapter.ts
+++ b/apps/server/src/provider/Layers/DroidAdapter.ts
@@ -606,10 +606,7 @@ export function makeDroidAdapter(
         }),
       );
 
-    const noteSuppressedDroidRuntimeEvent = (
-      ctx: DroidSessionContext,
-      eventTag: string,
-    ) =>
+    const noteSuppressedDroidRuntimeEvent = (ctx: DroidSessionContext, eventTag: string) =>
       Effect.gen(function* () {
         if (!isDroidAcpDebugEnabled()) {
           return;

--- a/apps/server/src/provider/Layers/DroidAdapter.ts
+++ b/apps/server/src/provider/Layers/DroidAdapter.ts
@@ -153,6 +153,7 @@ const DROID_NESTED_TASK_IDLE_TIMEOUT_MS = 60 * 60_000;
 const DROID_CANCEL_GRACE_MS = 5_000;
 const DROID_PLAN_CAPTURE_CANCEL_FALLBACK_MS = 1_000;
 const DROID_ACP_REQUEST_TIMEOUT_MS = 30_000;
+const DROID_STARTUP_REPLAY_MAX_WAIT_MS = 3_000;
 const DROID_MODEL_DISCOVERY_CACHE_MS = 5 * 60_000;
 const DROID_MODEL_DISCOVERY_TIMEOUT_MS = 30_000;
 const DROID_DISCOVERY_CACHE_MAX_ENTRIES = 16;
@@ -1282,54 +1283,69 @@ export function makeDroidAdapter(
           sessions.set(input.threadId, ctx);
           sessionScopeTransferred = true;
 
-          // The consumer fork activates the shared replay gate; configuration
-          // waits for that gate before reading retained state or issuing RPCs.
-          // The session is already registered and the start-scope finalizer no
-          // longer owns its scope, so any remaining startup failure or
-          // interruption must tear the session down explicitly.
-          yield* runDroidAcpConfigurationAfterReplay({
-            runtime: acp,
-            threadId: input.threadId,
-            effect: Effect.gen(function* () {
-              if (droidModelSelection?.model) {
-                yield* applyDroidAcpModelSelection({
-                  runtime: acp,
-                  model: droidModelSelection.model,
-                  reasoningEffort: droidModelSelection.options?.reasoningEffort,
-                  mapError: ({ cause, method }) =>
-                    mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
-                });
-              }
-              // The requested model/effort are applied; turns gated on this
-              // deferred can now prompt without inheriting provider defaults.
-              yield* Deferred.succeed(sessionConfigReady, undefined);
-              ctx.sessionConfigReady = undefined;
+          // The consumer fork activates the shared replay gate. Configuration
+          // remains pending until replay settles, but startup only waits briefly
+          // while holding the thread lock so stop/restart stays responsive.
+          yield* Effect.gen(function* () {
+            const configurationFiber = yield* runDroidAcpConfigurationAfterReplay({
+              runtime: acp,
+              threadId: input.threadId,
+              effect: Effect.gen(function* () {
+                if (droidModelSelection?.model) {
+                  yield* applyDroidAcpModelSelection({
+                    runtime: acp,
+                    model: droidModelSelection.model,
+                    reasoningEffort: droidModelSelection.options?.reasoningEffort,
+                    mapError: ({ cause, method }) =>
+                      mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
+                  });
+                }
+                // Turns await this deferred, so none can inherit provider
+                // defaults while long replay/configuration work continues.
+                yield* Deferred.succeed(sessionConfigReady, undefined);
+                ctx.sessionConfigReady = undefined;
+              }),
+            }).pipe(
+              Effect.onError((cause) =>
+                stopSessionInternal(ctx, {
+                  exitKind: "error",
+                  reason: Cause.pretty(cause),
+                  awaitTermination: false,
+                }),
+              ),
+              Effect.forkIn(ctx.scope),
+            );
 
-              yield* offerRuntimeEvent(input.lifecycleGeneration, {
-                type: "session.started",
-                ...(yield* makeEventStamp()),
-                provider: PROVIDER,
-                threadId: input.threadId,
-                payload: { resume: started.initializeResult },
-              });
-              yield* offerRuntimeEvent(input.lifecycleGeneration, {
-                type: "session.state.changed",
-                ...(yield* makeEventStamp()),
-                provider: PROVIDER,
-                threadId: input.threadId,
-                payload: { state: "ready", reason: "Droid ACP session ready" },
-              });
-              yield* offerRuntimeEvent(input.lifecycleGeneration, {
-                type: "thread.started",
-                ...(yield* makeEventStamp()),
-                provider: PROVIDER,
-                threadId: input.threadId,
-                payload: { providerThreadId: started.sessionId },
-              });
-            }),
+            yield* Fiber.join(configurationFiber).pipe(
+              Effect.timeoutOption(DROID_STARTUP_REPLAY_MAX_WAIT_MS),
+            );
+
+            yield* offerRuntimeEvent(input.lifecycleGeneration, {
+              type: "session.started",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              payload: { resume: started.initializeResult },
+            });
+            yield* offerRuntimeEvent(input.lifecycleGeneration, {
+              type: "session.state.changed",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              payload: { state: "ready", reason: "Droid ACP session ready" },
+            });
+            yield* offerRuntimeEvent(input.lifecycleGeneration, {
+              type: "thread.started",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              payload: { providerThreadId: started.sessionId },
+            });
           }).pipe(
             Effect.onExit((exit) =>
-              Exit.isSuccess(exit) ? Effect.void : Effect.ignore(stopSessionInternal(ctx)),
+              Exit.isSuccess(exit)
+                ? Effect.void
+                : Effect.ignore(stopSessionInternal(ctx, { awaitTermination: false })),
             ),
           );
 

--- a/apps/server/src/provider/Layers/DroidAdapter.ts
+++ b/apps/server/src/provider/Layers/DroidAdapter.ts
@@ -137,11 +137,6 @@ const DROID_ACP_TRANSPORT_DEBUG_MARKER = "droid-acp-meta-stripper-v2";
 const DROID_ACP_LOG_PAYLOAD_LIMIT = 4_000;
 const DROID_ACP_DEBUG_ENV = "SYNARA_DROID_ACP_DEBUG";
 const LEGACY_DROID_ACP_DEBUG_ENV = "DP_DROID_ACP_DEBUG";
-const DROID_RESUME_REPLAY_QUIET_MS = 350;
-// Bounds how long startSession blocks on the replay settling; the background
-// settle loop keeps suppression alive past this until the hard timeout.
-const DROID_RESUME_REPLAY_MAX_WAIT_MS = 3_000;
-const DROID_RESUME_REPLAY_HARD_TIMEOUT_MS = 30_000;
 const DROID_TURN_SETTLE_DRAIN_MAX_WAIT_MS = 1_000;
 const DROID_TURN_SETTLE_DRAIN_POLL_MS = 25;
 // Backstop for an alive-but-silent droid child: if a turn produces no ACP
@@ -231,14 +226,12 @@ interface DroidSessionContext {
   // their parent tool rows so the watchdog can use a longer, still-finite cap.
   readonly activeNestedTaskToolCallIds: Set<string>;
   readonly nestedTaskLifecycleByToolCallId: Map<string, "active" | "completed">;
-  resumeReplayReady: Deferred.Deferred<void> | undefined;
-  resumeReplayLastSuppressedAt: number | undefined;
   // Pending until startSession has applied the requested model/effort config.
-  // The session is registered in `sessions` before the config RPCs run (so
-  // replay keeps draining), which means sendTurn can route to it mid-startup;
+  // The session is registered in `sessions` before the config RPCs run, which
+  // means sendTurn can route to it mid-startup;
   // turns await this gate so the first prompt never runs with provider
-  // defaults. Resolved by stopSessionInternal too, like resumeReplayReady, so
-  // a failed startup never strands waiters.
+  // defaults. Resolved by stopSessionInternal too, so a failed startup never
+  // strands waiters.
   sessionConfigReady: Deferred.Deferred<void> | undefined;
   // Resolves only after the ACP scope and its child process have fully closed.
   // Recovery awaits this gate before starting a replacement session.
@@ -579,11 +572,6 @@ export function makeDroidAdapter(
               yield* Deferred.succeed(ctx.sessionConfigReady, undefined);
               ctx.sessionConfigReady = undefined;
             }
-            if (ctx.resumeReplayReady !== undefined) {
-              yield* Deferred.succeed(ctx.resumeReplayReady, undefined);
-              ctx.resumeReplayReady = undefined;
-              ctx.resumeReplayLastSuppressedAt = undefined;
-            }
             if (ctx.notificationFiber) {
               yield* Fiber.interrupt(ctx.notificationFiber);
             }
@@ -621,12 +609,8 @@ export function makeDroidAdapter(
     const noteSuppressedDroidRuntimeEvent = (
       ctx: DroidSessionContext,
       eventTag: string,
-      reason: "resume-replay" | "orphan-turn-event",
     ) =>
       Effect.gen(function* () {
-        if (reason === "resume-replay") {
-          ctx.resumeReplayLastSuppressedAt = Date.now();
-        }
         if (!isDroidAcpDebugEnabled()) {
           return;
         }
@@ -634,7 +618,7 @@ export function makeDroidAdapter(
           threadId: ctx.threadId,
           turnId: ctx.activeTurnId,
           eventTag,
-          reason,
+          reason: "orphan-turn-event",
         });
       });
 
@@ -701,12 +685,8 @@ export function makeDroidAdapter(
 
     const activeTurnIdForDroidRuntimeEvent = (ctx: DroidSessionContext, eventTag: string) =>
       Effect.gen(function* () {
-        if (ctx.resumeReplayReady !== undefined) {
-          yield* noteSuppressedDroidRuntimeEvent(ctx, eventTag, "resume-replay");
-          return undefined;
-        }
         if (ctx.activeTurnId === undefined) {
-          yield* noteSuppressedDroidRuntimeEvent(ctx, eventTag, "orphan-turn-event");
+          yield* noteSuppressedDroidRuntimeEvent(ctx, eventTag);
           return undefined;
         }
         return ctx.activeTurnId;
@@ -730,44 +710,6 @@ export function makeDroidAdapter(
         ) {
           yield* Effect.sleep(DROID_TURN_SETTLE_DRAIN_POLL_MS);
         }
-      });
-
-    // On session/load, Droid can replay old ACP updates after the session is "ready".
-    // Keep suppression active until that stream actually goes quiet — clearing it
-    // on a fixed timeout lets late historical deltas leak into the first turn as
-    // its content. The hard cap only guards against a replay that never settles.
-    const settleDroidResumeReplayWhenQuiet = (ctx: DroidSessionContext) =>
-      Effect.gen(function* () {
-        const ready = ctx.resumeReplayReady;
-        if (ready === undefined) {
-          return;
-        }
-        const startedAt = Date.now();
-        ctx.resumeReplayLastSuppressedAt = startedAt;
-        while (ctx.resumeReplayReady !== undefined) {
-          const now = Date.now();
-          const lastSuppressedAt = ctx.resumeReplayLastSuppressedAt ?? startedAt;
-          const quietForMs = now - lastSuppressedAt;
-          const elapsedMs = now - startedAt;
-          if (
-            quietForMs >= DROID_RESUME_REPLAY_QUIET_MS ||
-            elapsedMs >= DROID_RESUME_REPLAY_HARD_TIMEOUT_MS
-          ) {
-            const timedOut = elapsedMs >= DROID_RESUME_REPLAY_HARD_TIMEOUT_MS;
-            ctx.resumeReplayReady = undefined;
-            ctx.resumeReplayLastSuppressedAt = undefined;
-            if (timedOut) {
-              yield* Effect.logWarning("droid.acp.resume_replay_quiet_wait_timeout", {
-                threadId: ctx.threadId,
-                elapsedMs,
-              });
-            }
-            yield* Deferred.succeed(ready, undefined);
-            return;
-          }
-          yield* Effect.sleep(Math.min(DROID_RESUME_REPLAY_QUIET_MS - quietForMs, 50));
-        }
-        yield* Deferred.succeed(ready, undefined);
       });
 
     const startSession: DroidAdapterShape["startSession"] = (input) =>
@@ -1037,10 +979,6 @@ export function makeDroidAdapter(
             });
           }
 
-          // `session/resume` does not replay history; only legacy `session/load`
-          // needs the replay-suppression gate below.
-          const resumeReplayReady =
-            started.sessionSetupMethod === "load" ? yield* Deferred.make<void>() : undefined;
           const sessionConfigReady = yield* Deferred.make<void>();
           const teardownComplete = yield* Deferred.make<void>();
           const now = yield* nowIso;
@@ -1084,8 +1022,6 @@ export function makeDroidAdapter(
             turnToolCallIds: new Map(),
             activeNestedTaskToolCallIds: new Set(),
             nestedTaskLifecycleByToolCallId: new Map(),
-            resumeReplayReady,
-            resumeReplayLastSuppressedAt: resumeReplayReady !== undefined ? Date.now() : undefined,
             sessionConfigReady,
             teardownComplete,
             latestSessionCostUsd: undefined,
@@ -1162,10 +1098,9 @@ export function makeDroidAdapter(
                       // A queued update for a tool call the just-settled turn
                       // already rendered belongs to that turn; emit it with the
                       // originating turn id so the existing tool row resolves in
-                      // place instead of being dropped as an orphan. Resume
-                      // replay stays suppressed like every other event.
+                      // place instead of being dropped as an orphan.
                       const lateTurnId =
-                        ctx.resumeReplayReady === undefined && ctx.activeTurnId === undefined
+                        ctx.activeTurnId === undefined
                           ? ctx.turnToolCallIds.get(event.toolCall.toolCallId)
                           : undefined;
                       if (lateTurnId !== undefined) {
@@ -1344,18 +1279,6 @@ export function makeDroidAdapter(
             yield* Deferred.succeed(sessionConfigReady, undefined);
             ctx.sessionConfigReady = undefined;
 
-            if (resumeReplayReady !== undefined) {
-              // Settle the replay in the background: suppression stays active until
-              // the stream is genuinely quiet, while startup only blocks briefly so
-              // a long replay cannot hold session startup hostage. sendTurn awaits
-              // the deferred, so the first turn stays gated until the replay has
-              // actually finished.
-              yield* settleDroidResumeReplayWhenQuiet(ctx).pipe(Effect.forkIn(ctx.scope));
-              yield* Deferred.await(resumeReplayReady).pipe(
-                Effect.timeoutOption(DROID_RESUME_REPLAY_MAX_WAIT_MS),
-              );
-            }
-
             yield* offerRuntimeEvent(input.lifecycleGeneration, {
               type: "session.started",
               ...(yield* makeEventStamp()),
@@ -1481,13 +1404,9 @@ export function makeDroidAdapter(
         if (ctx.sessionConfigReady !== undefined) {
           yield* Deferred.await(ctx.sessionConfigReady);
         }
-        if (ctx.resumeReplayReady !== undefined) {
-          yield* Deferred.await(ctx.resumeReplayReady);
-        }
-        // The gates above are resolved by stopSessionInternal too (a failed or
-        // stopped startup must not strand waiters); a turn that was blocked on
-        // them must fail here instead of emitting lifecycle events for a dead
-        // session.
+        // The setup gate above is resolved by stopSessionInternal too; a turn
+        // unblocked by a failed or stopped startup must fail here instead of
+        // emitting lifecycle events for a dead session.
         if (ctx.stopped) {
           return yield* new ProviderAdapterSessionNotFoundError({
             provider: PROVIDER,
@@ -1628,10 +1547,9 @@ export function makeDroidAdapter(
         });
 
         const runPrompt = Effect.suspend(() =>
-          // interruptTurn during the pre-prompt waits (resume replay, attachment
-          // reads) or between turn.started publishing and this fiber being
-          // registered sets pendingTurnInterrupted; honor it (and a concurrent
-          // stop) here so a cancelled turn is never prompted. Self-interrupting
+          // interruptTurn during attachment reads or between turn.started publishing
+          // and this fiber being registered sets pendingTurnInterrupted; honor it and
+          // a concurrent stop here so a cancelled turn is never prompted. Self-interrupting
           // routes through the onInterrupt branch below, which completes the
           // turn as cancelled rather than as a provider failure.
           ctx.pendingTurnInterrupted || ctx.stopped
@@ -1818,9 +1736,9 @@ export function makeDroidAdapter(
           return;
         }
         const activeTurnId = turnId ?? ctx.activeTurnId;
-        // A turn that is still starting has no prompt fiber to interrupt yet
-        // (it may be gated on resume replay); flag it so startDroidTurn aborts
-        // before prompting instead of running the cancelled turn anyway.
+        // A turn that is still starting has no prompt fiber to interrupt yet;
+        // flag it so startDroidTurn aborts before prompting instead of running
+        // the cancelled turn anyway.
         if (ctx.turnStarting && ctx.activePromptFiber === undefined) {
           ctx.pendingTurnInterrupted = true;
         }

--- a/apps/server/src/provider/Layers/DroidAdapter.ts
+++ b/apps/server/src/provider/Layers/DroidAdapter.ts
@@ -60,6 +60,7 @@ import { listFactoryPlugins, readFactoryPlugin } from "../FactoryPluginDiscovery
 import { readFactorySessionHistory } from "../FactorySessionHistory.ts";
 import { appendProviderReferencesPromptBlock } from "../promptReferenceProjection.ts";
 import {
+  type ProviderAdapterError,
   ProviderAdapterRequestError,
   ProviderAdapterProcessError,
   ProviderAdapterSessionClosedError,
@@ -170,6 +171,31 @@ function droidAcpTimeoutError(method: string): ProviderAdapterRequestError {
     method,
     detail: `Droid ACP did not respond to ${method} within ${DROID_ACP_REQUEST_TIMEOUT_MS / 1000}s.`,
   });
+}
+
+function runDroidAcpConfigurationAfterReplay<A, E>(input: {
+  readonly runtime: Pick<AcpSessionRuntimeShape, "awaitLoadReplayReady">;
+  readonly threadId: ThreadId;
+  readonly effect: Effect.Effect<A, E>;
+}): Effect.Effect<A, E | ProviderAdapterError> {
+  // Replay readiness owns its separate hard-cap budget. Only the actual
+  // configuration work consumes the ACP request timeout.
+  return input.runtime.awaitLoadReplayReady.pipe(
+    Effect.mapError((cause) =>
+      mapAcpToAdapterError(PROVIDER, input.threadId, "session/load", cause),
+    ),
+    Effect.andThen(
+      input.effect.pipe(
+        Effect.timeoutOption(DROID_ACP_REQUEST_TIMEOUT_MS),
+        Effect.flatMap(
+          Option.match({
+            onNone: () => Effect.fail(droidAcpTimeoutError("session/set_config_option")),
+            onSome: Effect.succeed,
+          }),
+        ),
+      ),
+    ),
+  );
 }
 
 function isDroidAcpDebugEnabled(): boolean {
@@ -1256,55 +1282,52 @@ export function makeDroidAdapter(
           sessions.set(input.threadId, ctx);
           sessionScopeTransferred = true;
 
-          // Config RPCs run after the consumer fork so replay emitted while they
-          // are in flight keeps draining. The session is already registered and
-          // the start-scope finalizer no longer owns the session scope, so any
-          // failure OR interruption of the remaining startup steps must tear the
-          // session down explicitly instead of leaking a live child.
-          yield* Effect.gen(function* () {
-            if (droidModelSelection?.model) {
-              yield* applyDroidAcpModelSelection({
-                runtime: acp,
-                model: droidModelSelection.model,
-                reasoningEffort: droidModelSelection.options?.reasoningEffort,
-                mapError: ({ cause, method }) =>
-                  mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
-              });
-            }
-            // The requested model/effort are applied; turns gated on this
-            // deferred can now prompt without inheriting provider defaults.
-            yield* Deferred.succeed(sessionConfigReady, undefined);
-            ctx.sessionConfigReady = undefined;
+          // The consumer fork activates the shared replay gate; configuration
+          // waits for that gate before reading retained state or issuing RPCs.
+          // The session is already registered and the start-scope finalizer no
+          // longer owns its scope, so any remaining startup failure or
+          // interruption must tear the session down explicitly.
+          yield* runDroidAcpConfigurationAfterReplay({
+            runtime: acp,
+            threadId: input.threadId,
+            effect: Effect.gen(function* () {
+              if (droidModelSelection?.model) {
+                yield* applyDroidAcpModelSelection({
+                  runtime: acp,
+                  model: droidModelSelection.model,
+                  reasoningEffort: droidModelSelection.options?.reasoningEffort,
+                  mapError: ({ cause, method }) =>
+                    mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
+                });
+              }
+              // The requested model/effort are applied; turns gated on this
+              // deferred can now prompt without inheriting provider defaults.
+              yield* Deferred.succeed(sessionConfigReady, undefined);
+              ctx.sessionConfigReady = undefined;
 
-            yield* offerRuntimeEvent(input.lifecycleGeneration, {
-              type: "session.started",
-              ...(yield* makeEventStamp()),
-              provider: PROVIDER,
-              threadId: input.threadId,
-              payload: { resume: started.initializeResult },
-            });
-            yield* offerRuntimeEvent(input.lifecycleGeneration, {
-              type: "session.state.changed",
-              ...(yield* makeEventStamp()),
-              provider: PROVIDER,
-              threadId: input.threadId,
-              payload: { state: "ready", reason: "Droid ACP session ready" },
-            });
-            yield* offerRuntimeEvent(input.lifecycleGeneration, {
-              type: "thread.started",
-              ...(yield* makeEventStamp()),
-              provider: PROVIDER,
-              threadId: input.threadId,
-              payload: { providerThreadId: started.sessionId },
-            });
+              yield* offerRuntimeEvent(input.lifecycleGeneration, {
+                type: "session.started",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                payload: { resume: started.initializeResult },
+              });
+              yield* offerRuntimeEvent(input.lifecycleGeneration, {
+                type: "session.state.changed",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                payload: { state: "ready", reason: "Droid ACP session ready" },
+              });
+              yield* offerRuntimeEvent(input.lifecycleGeneration, {
+                type: "thread.started",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                payload: { providerThreadId: started.sessionId },
+              });
+            }),
           }).pipe(
-            Effect.timeoutOption(DROID_ACP_REQUEST_TIMEOUT_MS),
-            Effect.flatMap(
-              Option.match({
-                onNone: () => Effect.fail(droidAcpTimeoutError("session/set_config_option")),
-                onSome: Effect.succeed,
-              }),
-            ),
             Effect.onExit((exit) =>
               Exit.isSuccess(exit) ? Effect.void : Effect.ignore(stopSessionInternal(ctx)),
             ),
@@ -1426,31 +1449,28 @@ export function makeDroidAdapter(
         // Selection changes normally arrive via a session restart, but a turn
         // can still carry an explicit selection; re-assert it over ACP (the
         // shared runtime skips the RPC when the value already matches).
-        yield* Effect.gen(function* () {
-          if (model !== undefined) {
-            yield* applyDroidAcpModelSelection({
+        yield* runDroidAcpConfigurationAfterReplay({
+          runtime: ctx.acp,
+          threadId: input.threadId,
+          effect: Effect.gen(function* () {
+            if (model !== undefined) {
+              yield* applyDroidAcpModelSelection({
+                runtime: ctx.acp,
+                model,
+                reasoningEffort: turnModelSelection?.options?.reasoningEffort,
+                mapError: ({ cause, method }) =>
+                  mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
+              });
+            }
+            yield* applyDroidAcpInteractionMode({
               runtime: ctx.acp,
-              model,
-              reasoningEffort: turnModelSelection?.options?.reasoningEffort,
+              interactionMode,
+              runtimeMode,
               mapError: ({ cause, method }) =>
                 mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
             });
-          }
-          yield* applyDroidAcpInteractionMode({
-            runtime: ctx.acp,
-            interactionMode,
-            runtimeMode,
-            mapError: ({ cause, method }) =>
-              mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
-          });
+          }),
         }).pipe(
-          Effect.timeoutOption(DROID_ACP_REQUEST_TIMEOUT_MS),
-          Effect.flatMap(
-            Option.match({
-              onNone: () => Effect.fail(droidAcpTimeoutError("session/set_config_option")),
-              onSome: Effect.succeed,
-            }),
-          ),
           Effect.onError((cause) =>
             stopSessionInternal(ctx, {
               exitKind: "error",

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -814,7 +814,9 @@ export function makeGrokAdapter(
           yield* Fiber.interrupt(ctx.notificationFiber);
         }
         yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
-        sessions.delete(ctx.threadId);
+        if (sessions.get(ctx.threadId) === ctx) {
+          sessions.delete(ctx.threadId);
+        }
         yield* offerRuntimeEvent(ctx.lifecycleGeneration, {
           type: "session.exited",
           ...(yield* makeEventStamp()),

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -2241,6 +2241,13 @@ export function makeGrokAdapter(
           if (Cause.hasInterruptsOnly(compactResult.cause)) {
             return yield* Effect.failCause(compactResult.cause);
           }
+          // Closing a load-resumed runtime releases the central replay gate.
+          // That release reaches the prompt as a request error rather than an
+          // interrupt, but teardown must retain the same interruption-only UI
+          // semantics and avoid publishing a stale compaction failure.
+          if (ctx.stopped) {
+            return yield* Effect.interrupt;
+          }
           const squashed = Cause.squash(compactResult.cause);
           const detail = squashed instanceof Error ? squashed.message : String(squashed);
           yield* emitGrokContextCompactionRuntimeEvent(ctx, {

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -987,8 +987,9 @@ export function makeGrokAdapter(
         }
       });
 
-    const startSession: GrokAdapterShape["startSession"] = (input) =>
-      withThreadLock(
+    const startSession: GrokAdapterShape["startSession"] = (input) => {
+      let registeredCtx: GrokSessionContext | undefined;
+      const setup = withThreadLock(
         input.threadId,
         Effect.gen(function* () {
           if (input.provider !== undefined && input.provider !== PROVIDER) {
@@ -1577,16 +1578,40 @@ export function makeGrokAdapter(
 
           ctx.notificationFiber = notificationFiber;
           sessions.set(input.threadId, ctx);
+          registeredCtx = ctx;
           sessionScopeTransferred = true;
 
-          // Startup finalization runs after the consumer fork so replay emitted
-          // while it is in flight keeps draining. The session is already registered,
-          // and the start-scope finalizer no longer owns the session scope, so any failure
-          // OR interruption of the remaining startup steps must tear the session
-          // down explicitly instead of leaking a live child.
-          yield* Effect.gen(function* () {
+          return { ctx, session, started, grokModelSelection, sessionConfigReady };
+        }).pipe(Effect.scoped),
+      );
+
+      return Effect.gen(function* () {
+        const { ctx, session, started, grokModelSelection, sessionConfigReady } = yield* setup;
+        // The replay wait deliberately runs without the per-thread lock. The
+        // registered context lets stop/restart close the scope and release the
+        // gate immediately instead of waiting for its hard cap.
+        yield* ctx.acp.awaitLoadReplayReady.pipe(
+          Effect.mapError((cause) =>
+            ctx.stopped
+              ? new ProviderAdapterSessionNotFoundError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                })
+              : mapAcpToAdapterError(PROVIDER, input.threadId, "session/load", cause),
+          ),
+        );
+
+        yield* withThreadLock(
+          input.threadId,
+          Effect.gen(function* () {
+            if (ctx.stopped || sessions.get(input.threadId) !== ctx) {
+              return yield* new ProviderAdapterSessionNotFoundError({
+                provider: PROVIDER,
+                threadId: input.threadId,
+              });
+            }
             yield* applyRequestedModelSelection({
-              runtime: acp,
+              runtime: ctx.acp,
               modelSelection: grokModelSelection,
               mapError: ({ cause, method }) =>
                 mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
@@ -1617,15 +1642,18 @@ export function makeGrokAdapter(
               threadId: input.threadId,
               payload: { providerThreadId: started.sessionId },
             });
-          }).pipe(
-            Effect.onExit((exit) =>
-              Exit.isSuccess(exit) ? Effect.void : Effect.ignore(stopSessionInternal(ctx)),
-            ),
-          );
+          }),
+        );
 
-          return session;
-        }).pipe(Effect.scoped),
+        return session;
+      }).pipe(
+        Effect.onExit((exit) =>
+          Exit.isSuccess(exit) || registeredCtx === undefined
+            ? Effect.void
+            : Effect.ignore(stopSessionInternal(registeredCtx)),
+        ),
       );
+    };
 
     // Idle-progress watchdog escape hatch: force-fail a turn whose grok child
     // is alive but has gone completely silent. Mirrors the prompt-fiber

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -854,10 +854,7 @@ export function makeGrokAdapter(
         }
       });
 
-    const noteSuppressedGrokRuntimeEvent = (
-      ctx: GrokSessionContext,
-      eventTag: string,
-    ) =>
+    const noteSuppressedGrokRuntimeEvent = (ctx: GrokSessionContext, eventTag: string) =>
       Effect.gen(function* () {
         if (!isGrokAcpDebugEnabled()) {
           return;

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -143,22 +143,14 @@ export const takeGrokSynaraHarnessPolicyTextPart = (
   });
 const GROK_RESUME_VERSION = 1 as const;
 const GROK_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
-// Forking a dead source session must first resume it, which replays history,
-// so the fork exchange shares the resume-replay budget.
+// Forking a dead source session must first reopen it, so leave enough time for
+// the shared ACP load-replay gate and the fork exchange.
 const GROK_ACP_FORK_TIMEOUT_MS = 30_000;
 const GROK_ACP_TRANSPORT_DEBUG_MARKER = "grok-acp-meta-stripper-v2";
 const GROK_ACP_LOG_PAYLOAD_LIMIT = 4_000;
 const GROK_ACP_DEBUG_ENV = "SYNARA_GROK_ACP_DEBUG";
 const SYNARA_GROK_ACP_DEBUG_ENV = "SYNARA_GROK_ACP_DEBUG";
 const LEGACY_GROK_ACP_DEBUG_ENV = "DP_GROK_ACP_DEBUG";
-const GROK_RESUME_REPLAY_QUIET_MS = 200;
-// Longest that startSession blocks waiting for the resume replay to settle.
-// Suppression stays active past this point; only the startup path is unblocked.
-const GROK_RESUME_REPLAY_MAX_WAIT_MS = 1_500;
-// Absolute cap on replay suppression. A replay still streaming after this long
-// is treated as pathological: give up, warn, and unblock turns rather than
-// gating the thread forever.
-const GROK_RESUME_REPLAY_HARD_TIMEOUT_MS = 30_000;
 // Backstop for an alive-but-silent grok child: if a turn produces no ACP
 // activity for this long, force-fail it instead of showing "Working" forever.
 // Generous by design so legitimate long, quiet tool runs are not killed;
@@ -378,21 +370,18 @@ interface GrokSessionContext {
   // in-flight handlers and stream chunk buffering included.
   sessionUpdatesProcessed: number;
   // Pending until startSession has completed its post-registration setup.
-  // The session is registered first so replay keeps draining, which means
-  // sendTurn/compactThread can route to it mid-startup; they await this gate
-  // until the remaining startup work has settled. Resolved by
-  // stopSessionInternal too, like
-  // resumeReplayReady, so a failed startup never strands waiters.
+  // The session is registered first, so sendTurn/compactThread can route to it
+  // mid-startup; they await this gate until the remaining startup work has
+  // settled. Resolved by stopSessionInternal too, so a failed startup never
+  // strands waiters.
   sessionConfigReady: Deferred.Deferred<void> | undefined;
-  resumeReplayReady: Deferred.Deferred<void> | undefined;
-  resumeReplayLastSuppressedAt: number | undefined;
   // True while sendTurn is between its compaction check and settling the turn;
   // compactThread reads it so a compaction prompt cannot slip into the gap
   // before ctx.activeTurnId is assigned.
   turnStarting: boolean;
   // Set by interruptTurn while a turn is still starting (no prompt fiber to
-  // interrupt yet, e.g. gated on resume replay); startGrokTurn re-checks it
-  // before dispatching so a cancelled turn is never prompted.
+  // interrupt yet); startGrokTurn re-checks it before dispatching so a
+  // cancelled turn is never prompted.
   pendingTurnInterrupted: boolean;
   compactingThread: boolean;
   // Failed compaction tool-call detail recorded while compactingThread is set;
@@ -821,11 +810,6 @@ export function makeGrokAdapter(
           yield* Deferred.succeed(ctx.sessionConfigReady, undefined);
           ctx.sessionConfigReady = undefined;
         }
-        if (ctx.resumeReplayReady !== undefined) {
-          yield* Deferred.succeed(ctx.resumeReplayReady, undefined);
-          ctx.resumeReplayReady = undefined;
-          ctx.resumeReplayLastSuppressedAt = undefined;
-        }
         if (ctx.notificationFiber) {
           yield* Fiber.interrupt(ctx.notificationFiber);
         }
@@ -873,12 +857,8 @@ export function makeGrokAdapter(
     const noteSuppressedGrokRuntimeEvent = (
       ctx: GrokSessionContext,
       eventTag: string,
-      reason: "resume-replay" | "orphan-turn-event",
     ) =>
       Effect.gen(function* () {
-        if (reason === "resume-replay") {
-          ctx.resumeReplayLastSuppressedAt = Date.now();
-        }
         if (!isGrokAcpDebugEnabled()) {
           return;
         }
@@ -886,21 +866,17 @@ export function makeGrokAdapter(
           threadId: ctx.threadId,
           turnId: ctx.activeTurnId,
           eventTag,
-          reason,
+          reason: "orphan-turn-event",
         });
       });
 
     const activeTurnIdForGrokRuntimeEvent = (ctx: GrokSessionContext, eventTag: string) =>
       Effect.gen(function* () {
-        if (ctx.resumeReplayReady !== undefined) {
-          yield* noteSuppressedGrokRuntimeEvent(ctx, eventTag, "resume-replay");
-          return undefined;
-        }
         if (ctx.compactingThread) {
           return undefined;
         }
         if (ctx.activeTurnId === undefined) {
-          yield* noteSuppressedGrokRuntimeEvent(ctx, eventTag, "orphan-turn-event");
+          yield* noteSuppressedGrokRuntimeEvent(ctx, eventTag);
           return undefined;
         }
         return ctx.activeTurnId;
@@ -1012,44 +988,6 @@ export function makeGrokAdapter(
           }
           ctx.compactionQuietUntil = undefined;
         }
-      });
-
-    // On session/load, Grok can replay old ACP updates after the session is "ready".
-    // Keep suppression active until that stream actually goes quiet — clearing it
-    // on a fixed timeout lets late historical deltas leak into the first turn as
-    // its content. The hard cap only guards against a replay that never settles.
-    const settleGrokResumeReplayWhenQuiet = (ctx: GrokSessionContext) =>
-      Effect.gen(function* () {
-        const ready = ctx.resumeReplayReady;
-        if (ready === undefined) {
-          return;
-        }
-        const startedAt = Date.now();
-        ctx.resumeReplayLastSuppressedAt = startedAt;
-        while (ctx.resumeReplayReady !== undefined) {
-          const now = Date.now();
-          const lastSuppressedAt = ctx.resumeReplayLastSuppressedAt ?? startedAt;
-          const quietForMs = now - lastSuppressedAt;
-          const elapsedMs = now - startedAt;
-          if (
-            quietForMs >= GROK_RESUME_REPLAY_QUIET_MS ||
-            elapsedMs >= GROK_RESUME_REPLAY_HARD_TIMEOUT_MS
-          ) {
-            const timedOut = elapsedMs >= GROK_RESUME_REPLAY_HARD_TIMEOUT_MS;
-            ctx.resumeReplayReady = undefined;
-            ctx.resumeReplayLastSuppressedAt = undefined;
-            if (timedOut) {
-              yield* Effect.logWarning("grok.acp.resume_replay_quiet_wait_timeout", {
-                threadId: ctx.threadId,
-                elapsedMs,
-              });
-            }
-            yield* Deferred.succeed(ready, undefined);
-            return;
-          }
-          yield* Effect.sleep(Math.min(GROK_RESUME_REPLAY_QUIET_MS - quietForMs, 50));
-        }
-        yield* Deferred.succeed(ready, undefined);
       });
 
     const startSession: GrokAdapterShape["startSession"] = (input) =>
@@ -1349,8 +1287,6 @@ export function makeGrokAdapter(
           );
           yield* startAgentGatewaySessionLeaseExitWatcher(gatewaySessionLease, acp.awaitExit);
 
-          const resumeReplayReady =
-            resumeSessionId !== undefined ? yield* Deferred.make<void>() : undefined;
           const sessionConfigReady = yield* Deferred.make<void>();
           const now = yield* nowIso;
           const session: ProviderSession = {
@@ -1393,8 +1329,6 @@ export function makeGrokAdapter(
             turnToolCallIds: new Map(),
             sessionUpdatesProcessed: 0,
             sessionConfigReady,
-            resumeReplayReady,
-            resumeReplayLastSuppressedAt: resumeReplayReady !== undefined ? Date.now() : undefined,
             turnStarting: false,
             pendingTurnInterrupted: false,
             compactingThread: false,
@@ -1484,19 +1418,16 @@ export function makeGrokAdapter(
                       // title mentions "compact"/"summarize" — a backlogged
                       // consumer must not reclassify it as auto-compaction.
                       const lateTurnId =
-                        ctx.resumeReplayReady === undefined &&
-                        ctx.activeTurnId === undefined &&
-                        !ctx.compactingThread
+                        ctx.activeTurnId === undefined && !ctx.compactingThread
                           ? ctx.turnToolCallIds.get(event.toolCall.toolCallId)
                           : undefined;
                       // The title heuristic only applies between turns (grok-initiated
                       // auto-compaction); a live turn's tool call may legitimately
                       // mention "compact"/"summarize" and must render normally, and
-                      // resume replay stays suppressed like every other event.
+                      // replay is already suppressed by the shared ACP runtime.
                       const treatAsCompaction =
                         ctx.compactingThread ||
-                        (ctx.resumeReplayReady === undefined &&
-                          ctx.activeTurnId === undefined &&
+                        (ctx.activeTurnId === undefined &&
                           lateTurnId === undefined &&
                           isGrokContextCompactionToolCall(event.toolCall));
                       if (treatAsCompaction) {
@@ -1668,18 +1599,6 @@ export function makeGrokAdapter(
             yield* Deferred.succeed(sessionConfigReady, undefined);
             ctx.sessionConfigReady = undefined;
 
-            if (resumeReplayReady !== undefined) {
-              // Settle the replay in the background: suppression stays active until
-              // the stream is genuinely quiet, while startup only blocks briefly so
-              // a long replay cannot hold session startup hostage. sendTurn and
-              // compactThread await the deferred, so the first turn stays gated
-              // until the replay has actually finished.
-              yield* settleGrokResumeReplayWhenQuiet(ctx).pipe(Effect.forkIn(ctx.scope));
-              yield* Deferred.await(resumeReplayReady).pipe(
-                Effect.timeoutOption(GROK_RESUME_REPLAY_MAX_WAIT_MS),
-              );
-            }
-
             yield* offerRuntimeEvent(input.lifecycleGeneration, {
               type: "session.started",
               ...(yield* makeEventStamp()),
@@ -1812,14 +1731,10 @@ export function makeGrokAdapter(
         if (ctx.sessionConfigReady !== undefined) {
           yield* Deferred.await(ctx.sessionConfigReady);
         }
-        if (ctx.resumeReplayReady !== undefined) {
-          yield* Deferred.await(ctx.resumeReplayReady);
-        }
         yield* waitForAbandonedGrokCompaction(ctx);
-        // The gates above are resolved by stopSessionInternal too (a failed or
-        // stopped startup must not strand waiters); a turn that was blocked on
-        // them must fail here instead of emitting lifecycle events for a dead
-        // session.
+        // The setup gate above is resolved by stopSessionInternal too; a turn
+        // unblocked by a failed or stopped startup must fail here instead of
+        // emitting lifecycle events for a dead session.
         if (ctx.stopped) {
           return yield* new ProviderAdapterSessionNotFoundError({
             provider: PROVIDER,
@@ -1893,10 +1808,10 @@ export function makeGrokAdapter(
             threadId: input.threadId,
           });
         }
-        // Interrupts that landed during the pre-prompt waits (resume replay,
-        // model selection, attachment reads) are honored by the prompt fiber's
-        // dispatch guard below, so the turn completes through the normal
-        // cancelled path instead of surfacing as a provider turn-start failure.
+        // Interrupts that landed during model selection or attachment reads are
+        // honored by the prompt fiber's dispatch guard below, so the turn completes
+        // through the normal cancelled path instead of surfacing as a provider
+        // turn-start failure.
         ctx.activeTurnId = turnId;
         ctx.activeTurnHadAssistantContent = false;
         ctx.activeAssistantItemsWithContent.clear();
@@ -1926,10 +1841,10 @@ export function makeGrokAdapter(
         });
 
         const runPrompt = Effect.suspend(() =>
-          // interruptTurn during the pre-prompt waits (resume replay, model
-          // selection, attachment reads) or between turn.started publishing and this
-          // fiber being registered sets pendingTurnInterrupted; honor it (and a
-          // concurrent stop) here so a cancelled turn is never prompted.
+          // interruptTurn during model selection or attachment reads, or between
+          // turn.started publishing and this fiber being registered, sets
+          // pendingTurnInterrupted; honor it (and a concurrent stop) here so a
+          // cancelled turn is never prompted.
           // Self-interrupting routes through the onInterrupt branch below, which
           // completes the turn as cancelled rather than as a provider failure.
           ctx.pendingTurnInterrupted || ctx.stopped
@@ -2125,9 +2040,9 @@ export function makeGrokAdapter(
           return;
         }
         const activeTurnId = turnId ?? ctx.activeTurnId;
-        // A turn that is still starting has no prompt fiber to interrupt yet
-        // (it may be gated on resume replay); flag it so startGrokTurn aborts
-        // before prompting instead of running the cancelled turn anyway.
+        // A turn that is still starting has no prompt fiber to interrupt yet;
+        // flag it so startGrokTurn aborts before prompting instead of running
+        // the cancelled turn anyway.
         if (ctx.turnStarting && ctx.activePromptFiber === undefined) {
           ctx.pendingTurnInterrupted = true;
         }
@@ -2243,16 +2158,11 @@ export function makeGrokAdapter(
 
     const compactThread: NonNullable<GrokAdapterShape["compactThread"]> = (threadId) =>
       Effect.gen(function* () {
-        // Wait for a settling resume replay before taking the thread lock:
-        // stopSession/startSession need that lock, and stopping the session is
-        // what resolves the deferred early, so awaiting under the lock would
-        // stall stop/restart until the replay quiets or the hard timeout fires.
+        // Startup registers the session before its configuration settles, so
+        // compaction must wait before taking the thread lock.
         const preLockCtx = yield* requireSession(threadId);
         if (preLockCtx.sessionConfigReady !== undefined) {
           yield* Deferred.await(preLockCtx.sessionConfigReady);
-        }
-        if (preLockCtx.resumeReplayReady !== undefined) {
-          yield* Deferred.await(preLockCtx.resumeReplayReady);
         }
         // Claim the compaction slot under the thread lock, but run the
         // (potentially long) /compact prompt outside it: stopSession/restart
@@ -2275,7 +2185,7 @@ export function makeGrokAdapter(
     const claimGrokCompactionSlot = (threadId: ThreadId, preLockCtx: GrokSessionContext) =>
       Effect.gen(function* () {
         const ctx = yield* requireSession(threadId);
-        // The pre-lock replay wait resolves early when the session is stopped;
+        // The pre-lock setup wait resolves early when the session is stopped;
         // if a restart won the lock first, this thread id now maps to a fresh
         // session that the original compaction request never targeted.
         if (ctx !== preLockCtx) {
@@ -2284,15 +2194,6 @@ export function makeGrokAdapter(
             operation: "compactThread",
             issue:
               "The Grok session was restarted while waiting to compact; retry once it settles.",
-          });
-        }
-        if (ctx.resumeReplayReady !== undefined) {
-          // The session was restarted while waiting above and its new replay
-          // window is still settling; reject instead of blocking the lock.
-          return yield* new ProviderAdapterValidationError({
-            provider: PROVIDER,
-            operation: "compactThread",
-            issue: "Cannot compact while the resumed Grok thread is still replaying history.",
           });
         }
         // The prompt runs outside the thread lock, so a concurrent /compact can

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -1729,6 +1729,19 @@ export function makeGrokAdapter(
           yield* Deferred.await(ctx.sessionConfigReady);
         }
         yield* waitForAbandonedGrokCompaction(ctx);
+        // Do not publish a working turn while session/load replay is still
+        // being suppressed. A concurrent stop releases the shared gate and is
+        // reported as the session disappearing before any turn lifecycle opens.
+        yield* ctx.acp.awaitLoadReplayReady.pipe(
+          Effect.mapError((cause) =>
+            ctx.stopped
+              ? new ProviderAdapterSessionNotFoundError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                })
+              : mapAcpToAdapterError(PROVIDER, input.threadId, "session/load", cause),
+          ),
+        );
         // The setup gate above is resolved by stopSessionInternal too; a turn
         // unblocked by a failed or stopped startup must fail here instead of
         // emitting lifecycle events for a dead session.

--- a/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
+++ b/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
@@ -217,6 +217,96 @@ describe("AcpSessionRuntime", () => {
     ),
   );
 
+  it.effect("settles load replay before checking whether a mode write is a no-op", () => {
+    const requestEvents: Array<AcpSessionRequestLogEvent> = [];
+    return TestClock.withLive(
+      Effect.gen(function* () {
+        const runtime = yield* AcpSessionRuntime;
+        yield* runtime.start();
+
+        // The load response starts in ask mode, then replay reports code mode.
+        // Waiting before reading retained state makes this ask request a real
+        // write instead of incorrectly treating it as an early no-op.
+        yield* runtime.setMode("ask");
+
+        const modeRequest = requestEvents.find(
+          (event) => event.method === "session/set_config_option" && event.status === "started",
+        );
+        expect(modeRequest?.payload).toMatchObject({ configId: "mode", value: "ask" });
+        expect(yield* runtime.getModeState).toMatchObject({ currentModeId: "ask" });
+      }).pipe(
+        Effect.provide(
+          AcpSessionRuntime.layer({
+            spawn: {
+              command: bunExe,
+              args: [mockAgentPath],
+              env: {
+                VITEST: "true",
+                SYNARA_ACP_LOAD_REPLAY_DELAYS_MS: "10,25",
+                SYNARA_ACP_LOAD_REPLAY_MODE_ID: "code",
+              },
+            },
+            cwd: process.cwd(),
+            resumeSessionId: "mock-session-1",
+            loadReplayPolicy: {
+              quietMs: 20,
+              hardTimeoutMs: 200,
+            },
+            clientInfo: { name: "synara-test", version: "0.0.0" },
+            authMethodId: "test",
+            requestLogger: (event) =>
+              Effect.sync(() => {
+                requestEvents.push(event);
+              }),
+          }),
+        ),
+        Effect.scoped,
+        Effect.provide(NodeServices.layer),
+      ),
+    );
+  });
+
+  it.effect("settles load replay before applying session configuration", () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const runtime = yield* AcpSessionRuntime;
+        yield* runtime.start();
+
+        yield* runtime.setModel("composer-2");
+
+        expect(yield* runtime.getConfigOptions).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: "model", currentValue: "composer-2" }),
+          ]),
+        );
+      }).pipe(
+        Effect.provide(
+          AcpSessionRuntime.layer({
+            spawn: {
+              command: bunExe,
+              args: [mockAgentPath],
+              env: {
+                VITEST: "true",
+                SYNARA_ACP_LOAD_REPLAY_DELAYS_MS: "10,25",
+                SYNARA_ACP_REJECT_CONFIG_DURING_LOAD_REPLAY: "1",
+              },
+            },
+            cwd: process.cwd(),
+            resumeSessionId: "mock-session-1",
+            loadReplayPolicy: {
+              quietMs: 20,
+              hardTimeoutMs: 200,
+            },
+            clientInfo: { name: "synara-test", version: "0.0.0" },
+            authMethodId: "test",
+          }),
+        ),
+        Effect.scoped,
+        Effect.provide(NodeServices.layer),
+      ),
+    ),
+  );
+
   it.effect("forwards provider session metadata when loading a session", () => {
     const requestEvents: Array<AcpSessionRequestLogEvent> = [];
     return Effect.gen(function* () {

--- a/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
+++ b/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
@@ -466,6 +466,55 @@ describe("AcpSessionRuntime", () => {
     ),
   );
 
+  it.effect("preserves the fork RPC timeout after replay reaches its hard cap", () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const runtime = yield* AcpSessionRuntime;
+        yield* runtime.start();
+
+        const result = yield* forkViaAcpRuntime({
+          provider: "test",
+          runtime,
+          targetCwd: process.cwd(),
+          unsupportedIssue: "fork unsupported",
+          requestTimeoutMs: 100,
+          timeoutError: (method) =>
+            new ProviderAdapterRequestError({
+              provider: "test",
+              method,
+              detail: "timed out",
+            }),
+        });
+
+        expect(result.sessionId).toBe("mock-session-fork-1");
+      }).pipe(
+        Effect.provide(
+          AcpSessionRuntime.layer({
+            spawn: {
+              command: bunExe,
+              args: [mockAgentPath],
+              env: {
+                VITEST: "true",
+                SYNARA_ACP_SUPPORT_SESSION_FORK: "1",
+                SYNARA_ACP_LOAD_REPLAY_DELAYS_MS: "0,50,100,150,199",
+              },
+            },
+            cwd: process.cwd(),
+            resumeSessionId: "mock-session-1",
+            loadReplayPolicy: {
+              quietMs: 1_000,
+              hardTimeoutMs: 200,
+            },
+            clientInfo: { name: "synara-test", version: "0.0.0" },
+            authMethodId: "test",
+          }),
+        ),
+        Effect.scoped,
+        Effect.provide(NodeServices.layer),
+      ),
+    ),
+  );
+
   it.effect(
     "assigns distinct fallback assistant item ids across separate runtime instances",
     () => {

--- a/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
+++ b/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
@@ -177,6 +177,7 @@ describe("AcpSessionRuntime", () => {
           prompt: [{ type: "text", text: "hi" }],
         });
         expect(promptResult).toMatchObject({ stopReason: "end_turn" });
+        expect(yield* runtime.getModeState).toMatchObject({ currentModeId: "code" });
 
         // The session/load replay chunks are dropped; only the immediate first
         // prompt's legitimate events arrive after the quiet gate opens.
@@ -194,7 +195,9 @@ describe("AcpSessionRuntime", () => {
               command: bunExe,
               args: [mockAgentPath],
               env: {
+                VITEST: "true",
                 SYNARA_ACP_LOAD_REPLAY_DELAYS_MS: "10,25",
+                SYNARA_ACP_LOAD_REPLAY_MODE_ID: "code",
                 SYNARA_ACP_REJECT_PROMPT_DURING_LOAD_REPLAY: "1",
               },
             },

--- a/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
+++ b/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
@@ -10,6 +10,7 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
 import { Effect, Exit, Fiber, Stream } from "effect";
+import { TestClock } from "effect/testing";
 import { describe, expect } from "vitest";
 
 import {
@@ -159,47 +160,57 @@ describe("AcpSessionRuntime", () => {
     );
   });
 
-  it.effect("loads a resumed session and still prompts normally", () =>
-    Effect.gen(function* () {
-      const runtime = yield* AcpSessionRuntime;
-      const started = yield* runtime.start();
-      expect(started.sessionId).toBe("mock-session-1");
+  it.effect("suppresses late load replay before an immediate first prompt", () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const runtime = yield* AcpSessionRuntime;
+        const started = yield* runtime.start();
+        expect(started.sessionId).toBe("mock-session-1");
 
-      // Resumed sessions drop session/update until a consumer attaches, so the
-      // events stream must be taken before prompting (mirrors the adapters,
-      // which fork the drain right after start()).
-      const eventsFiber = yield* Stream.runCollect(Stream.take(runtime.getEvents(), 4)).pipe(
-        Effect.forkChild,
-      );
-      const promptResult = yield* runtime.prompt({
-        prompt: [{ type: "text", text: "hi" }],
-      });
-      expect(promptResult).toMatchObject({ stopReason: "end_turn" });
+        // Resumed sessions drop session/update until a consumer attaches, so the
+        // events stream must be taken before prompting (mirrors the adapters,
+        // which fork the drain right after start()).
+        const eventsFiber = yield* Stream.runCollect(Stream.take(runtime.getEvents(), 4)).pipe(
+          Effect.forkChild,
+        );
+        const promptResult = yield* runtime.prompt({
+          prompt: [{ type: "text", text: "hi" }],
+        });
+        expect(promptResult).toMatchObject({ stopReason: "end_turn" });
 
-      // The session/load replay chunk emitted before the consumer attached is
-      // dropped; only the prompt's own events arrive.
-      const notes = Array.from(yield* Fiber.join(eventsFiber));
-      expect(notes.map((note) => note._tag)).toEqual([
-        "PlanUpdated",
-        "AssistantItemStarted",
-        "ContentDelta",
-        "AssistantItemCompleted",
-      ]);
-    }).pipe(
-      Effect.provide(
-        AcpSessionRuntime.layer({
-          spawn: {
-            command: bunExe,
-            args: [mockAgentPath],
-          },
-          cwd: process.cwd(),
-          resumeSessionId: "mock-session-1",
-          clientInfo: { name: "synara-test", version: "0.0.0" },
-          authMethodId: "test",
-        }),
+        // The session/load replay chunks are dropped; only the immediate first
+        // prompt's legitimate events arrive after the quiet gate opens.
+        const notes = Array.from(yield* Fiber.join(eventsFiber));
+        expect(notes.map((note) => note._tag)).toEqual([
+          "PlanUpdated",
+          "AssistantItemStarted",
+          "ContentDelta",
+          "AssistantItemCompleted",
+        ]);
+      }).pipe(
+        Effect.provide(
+          AcpSessionRuntime.layer({
+            spawn: {
+              command: bunExe,
+              args: [mockAgentPath],
+              env: {
+                SYNARA_ACP_LOAD_REPLAY_DELAYS_MS: "10,25",
+                SYNARA_ACP_REJECT_PROMPT_DURING_LOAD_REPLAY: "1",
+              },
+            },
+            cwd: process.cwd(),
+            resumeSessionId: "mock-session-1",
+            loadReplayPolicy: {
+              quietMs: 20,
+              hardTimeoutMs: 200,
+            },
+            clientInfo: { name: "synara-test", version: "0.0.0" },
+            authMethodId: "test",
+          }),
+        ),
+        Effect.scoped,
+        Effect.provide(NodeServices.layer),
       ),
-      Effect.scoped,
-      Effect.provide(NodeServices.layer),
     ),
   );
 
@@ -431,14 +442,16 @@ describe("AcpSessionRuntime", () => {
         return delta?._tag === "ContentDelta" ? delta.itemId : undefined;
       }).pipe(Effect.provide(runtimeLayer), Effect.scoped, Effect.provide(NodeServices.layer));
 
-      return Effect.gen(function* () {
-        const firstItemId = yield* collectFallbackAssistantItemId;
-        const secondItemId = yield* collectFallbackAssistantItemId;
-        const fallbackIdPattern = /^assistant:mock-session-1:[0-9a-f]{8}:segment:0$/;
-        expect(firstItemId).toMatch(fallbackIdPattern);
-        expect(secondItemId).toMatch(fallbackIdPattern);
-        expect(firstItemId).not.toBe(secondItemId);
-      });
+      return TestClock.withLive(
+        Effect.gen(function* () {
+          const firstItemId = yield* collectFallbackAssistantItemId;
+          const secondItemId = yield* collectFallbackAssistantItemId;
+          const fallbackIdPattern = /^assistant:mock-session-1:[0-9a-f]{8}:segment:0$/;
+          expect(firstItemId).toMatch(fallbackIdPattern);
+          expect(secondItemId).toMatch(fallbackIdPattern);
+          expect(firstItemId).not.toBe(secondItemId);
+        }),
+      );
     },
   );
 

--- a/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
+++ b/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
@@ -413,6 +413,56 @@ describe("AcpSessionRuntime", () => {
     );
   });
 
+  it.effect("forks a loaded session after replay settles without an event consumer", () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const runtime = yield* AcpSessionRuntime;
+        yield* runtime.start();
+
+        const result = yield* forkViaAcpRuntime({
+          provider: "test",
+          runtime,
+          targetCwd: process.cwd(),
+          unsupportedIssue: "fork unsupported",
+          requestTimeoutMs: 1_000,
+          timeoutError: (method) =>
+            new ProviderAdapterRequestError({
+              provider: "test",
+              method,
+              detail: "timed out",
+            }),
+        });
+
+        expect(result.sessionId).toBe("mock-session-fork-1");
+      }).pipe(
+        Effect.provide(
+          AcpSessionRuntime.layer({
+            spawn: {
+              command: bunExe,
+              args: [mockAgentPath],
+              env: {
+                VITEST: "true",
+                SYNARA_ACP_SUPPORT_SESSION_FORK: "1",
+                SYNARA_ACP_LOAD_REPLAY_DELAYS_MS: "10,25",
+                SYNARA_ACP_REJECT_FORK_DURING_LOAD_REPLAY: "1",
+              },
+            },
+            cwd: process.cwd(),
+            resumeSessionId: "mock-session-1",
+            loadReplayPolicy: {
+              quietMs: 20,
+              hardTimeoutMs: 200,
+            },
+            clientInfo: { name: "synara-test", version: "0.0.0" },
+            authMethodId: "test",
+          }),
+        ),
+        Effect.scoped,
+        Effect.provide(NodeServices.layer),
+      ),
+    ),
+  );
+
   it.effect(
     "assigns distinct fallback assistant item ids across separate runtime instances",
     () => {

--- a/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
+++ b/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
@@ -307,6 +307,43 @@ describe("AcpSessionRuntime", () => {
     ),
   );
 
+  it.effect("settles load replay before reading available commands", () =>
+    TestClock.withLive(
+      Effect.gen(function* () {
+        const runtime = yield* AcpSessionRuntime;
+        yield* runtime.start();
+
+        expect(yield* runtime.getAvailableCommands).toEqual([
+          { name: "compact", description: "Compact the current context" },
+        ]);
+      }).pipe(
+        Effect.provide(
+          AcpSessionRuntime.layer({
+            spawn: {
+              command: bunExe,
+              args: [mockAgentPath],
+              env: {
+                VITEST: "true",
+                SYNARA_ACP_LOAD_REPLAY_DELAYS_MS: "10,25",
+                SYNARA_ACP_LOAD_REPLAY_AVAILABLE_COMMANDS: "1",
+              },
+            },
+            cwd: process.cwd(),
+            resumeSessionId: "mock-session-1",
+            loadReplayPolicy: {
+              quietMs: 20,
+              hardTimeoutMs: 200,
+            },
+            clientInfo: { name: "synara-test", version: "0.0.0" },
+            authMethodId: "test",
+          }),
+        ),
+        Effect.scoped,
+        Effect.provide(NodeServices.layer),
+      ),
+    ),
+  );
+
   it.effect("forwards provider session metadata when loading a session", () => {
     const requestEvents: Array<AcpSessionRequestLogEvent> = [];
     return Effect.gen(function* () {

--- a/apps/server/src/provider/acp/AcpLoadReplayGate.test.ts
+++ b/apps/server/src/provider/acp/AcpLoadReplayGate.test.ts
@@ -1,0 +1,111 @@
+// FILE: AcpLoadReplayGate.test.ts
+// Purpose: Proves load-replay suppression waits for quiet, stays bounded, and releases waiters.
+// Layer: Provider ACP helper tests
+
+import { it } from "@effect/vitest";
+import { Effect, Fiber } from "effect";
+import { TestClock } from "effect/testing";
+import { describe, expect } from "vitest";
+
+import { makeAcpLoadReplayGate } from "./AcpLoadReplayGate.ts";
+
+describe("AcpLoadReplayGate", () => {
+  it.effect("keeps an immediate first operation blocked until late replay goes quiet", () =>
+    Effect.gen(function* () {
+      const gate = yield* makeAcpLoadReplayGate({
+        quietMs: 100,
+        hardTimeoutMs: 1_000,
+        onHardTimeout: () => Effect.void,
+      });
+      const settling = yield* gate.settle.pipe(Effect.forkChild);
+      const firstOperation = yield* gate.awaitReady.pipe(Effect.forkChild);
+      yield* gate.attachConsumer;
+
+      yield* TestClock.adjust("90 millis");
+      expect(yield* gate.isSuppressing).toBe(true);
+      expect(yield* gate.suppressUpdate).toBe(true);
+
+      yield* TestClock.adjust("90 millis");
+      expect(yield* gate.isSuppressing).toBe(true);
+      expect(yield* gate.suppressUpdate).toBe(true);
+
+      yield* TestClock.adjust("100 millis");
+      expect(yield* Fiber.join(firstOperation)).toBe("ready");
+      yield* Fiber.join(settling);
+
+      expect(yield* gate.isSuppressing).toBe(false);
+      expect(yield* gate.suppressUpdate).toBe(false);
+    }),
+  );
+
+  it.effect("opens at the hard cap and reports observable timeout evidence", () => {
+    const evidence: Array<{ readonly elapsedMs: number }> = [];
+    return Effect.gen(function* () {
+      const gate = yield* makeAcpLoadReplayGate({
+        quietMs: 1_000,
+        hardTimeoutMs: 300,
+        onHardTimeout: (timeout) =>
+          Effect.sync(() => {
+            evidence.push(timeout);
+          }),
+      });
+      const settling = yield* gate.settle.pipe(Effect.forkChild);
+      yield* gate.attachConsumer;
+
+      yield* TestClock.adjust("250 millis");
+      expect(yield* gate.suppressUpdate).toBe(true);
+      yield* TestClock.adjust("50 millis");
+      yield* Fiber.join(settling);
+
+      expect(yield* gate.isSuppressing).toBe(false);
+      expect(evidence).toEqual([{ elapsedMs: 300 }]);
+    });
+  });
+
+  it.effect("starts its quiet and hard-cap clocks only after the consumer attaches", () => {
+    const evidence: Array<{ readonly elapsedMs: number }> = [];
+    return Effect.gen(function* () {
+      const gate = yield* makeAcpLoadReplayGate({
+        quietMs: 100,
+        hardTimeoutMs: 300,
+        onHardTimeout: (timeout) =>
+          Effect.sync(() => {
+            evidence.push(timeout);
+          }),
+      });
+      const settling = yield* gate.settle.pipe(Effect.forkChild);
+
+      yield* TestClock.adjust("5 seconds");
+      expect(yield* gate.isSuppressing).toBe(true);
+
+      yield* gate.attachConsumer;
+      yield* TestClock.adjust("100 millis");
+      yield* Fiber.join(settling);
+
+      expect(evidence).toEqual([]);
+      expect(yield* gate.isSuppressing).toBe(false);
+    });
+  });
+
+  it.effect("releases every blocked waiter when startup fails or the session stops", () =>
+    Effect.gen(function* () {
+      const gate = yield* makeAcpLoadReplayGate({
+        quietMs: 100,
+        hardTimeoutMs: 1_000,
+        onHardTimeout: () => Effect.void,
+      });
+      const firstWaiter = yield* gate.awaitReady.pipe(Effect.forkChild);
+      const secondWaiter = yield* gate.awaitReady.pipe(Effect.forkChild);
+      const settling = yield* gate.settle.pipe(Effect.forkChild);
+
+      yield* gate.release;
+      expect(yield* Fiber.join(firstWaiter)).toBe("released");
+      expect(yield* Fiber.join(secondWaiter)).toBe("released");
+      yield* Fiber.join(settling);
+      yield* gate.release;
+
+      expect(yield* gate.isSuppressing).toBe(false);
+      expect(yield* gate.suppressUpdate).toBe(true);
+    }),
+  );
+});

--- a/apps/server/src/provider/acp/AcpLoadReplayGate.test.ts
+++ b/apps/server/src/provider/acp/AcpLoadReplayGate.test.ts
@@ -35,6 +35,8 @@ describe("AcpLoadReplayGate", () => {
 
       expect(yield* gate.isSuppressing).toBe(false);
       expect(yield* gate.suppressUpdate).toBe(false);
+      yield* gate.release;
+      expect(yield* gate.awaitReady).toBe("ready");
     }),
   );
 

--- a/apps/server/src/provider/acp/AcpLoadReplayGate.ts
+++ b/apps/server/src/provider/acp/AcpLoadReplayGate.ts
@@ -54,54 +54,70 @@ export const makeAcpLoadReplayGate = (
     const ready = yield* Deferred.make<"ready" | "released">();
     const state = yield* Ref.make<ReplayGateState>({ _tag: "WaitingForConsumer" });
 
-    const complete = (outcome: "ready" | "released") =>
-      Effect.gen(function* () {
-        const nextState =
-          outcome === "ready"
-            ? ({ _tag: "Ready" } satisfies ReplayReady)
-            : ({ _tag: "Released" } satisfies ReplayReleased);
-        const completed = yield* Ref.modify(state, (current) =>
-          current._tag === "Ready" || current._tag === "Released"
-            ? ([false, current] as const)
-            : ([true, nextState] as const),
-        );
-        if (completed) {
-          yield* Deferred.succeed(consumerAttached, undefined);
-          yield* Deferred.succeed(ready, outcome);
-        }
-        return completed;
-      });
-
-    const open = complete("ready");
+    const release = Effect.gen(function* () {
+      const completed = yield* Ref.modify(state, (current) =>
+        current._tag === "Ready" || current._tag === "Released"
+          ? ([false, current] as const)
+          : ([true, { _tag: "Released" } satisfies ReplayReleased] as const),
+      );
+      if (completed) {
+        yield* Deferred.succeed(consumerAttached, undefined);
+        yield* Deferred.succeed(ready, "released");
+      }
+    }).pipe(Effect.asVoid);
 
     const settle = Effect.gen(function* () {
       yield* Deferred.await(consumerAttached);
       while (true) {
-        const current = yield* Ref.get(state);
-        if (current._tag === "Ready" || current._tag === "Released") {
+        const now = yield* Clock.currentTimeMillis;
+        const decision = yield* Ref.modify(state, (current) => {
+          if (current._tag === "Ready" || current._tag === "Released") {
+            return [{ _tag: "Done" } as const, current] as const;
+          }
+          if (current._tag === "WaitingForConsumer") {
+            return [{ _tag: "Retry" } as const, current] as const;
+          }
+
+          const quietForMs = now - current.lastSuppressedAt;
+          const elapsedMs = now - current.startedAt;
+          const reachedHardTimeout = elapsedMs >= options.hardTimeoutMs;
+          if (quietForMs >= options.quietMs || reachedHardTimeout) {
+            return [
+              { _tag: "Opened", elapsedMs, reachedHardTimeout } as const,
+              { _tag: "Ready" } satisfies ReplayReady,
+            ] as const;
+          }
+
+          return [
+            {
+              _tag: "Wait",
+              delayMs: Math.max(
+                1,
+                Math.min(
+                  options.quietMs - quietForMs,
+                  options.hardTimeoutMs - elapsedMs,
+                  REPLAY_SETTLE_POLL_MAX_MS,
+                ),
+              ),
+            } as const,
+            current,
+          ] as const;
+        });
+
+        if (decision._tag === "Done") {
           return;
         }
-        if (current._tag !== "Suppressing") {
+        if (decision._tag === "Retry") {
           continue;
         }
-
-        const now = yield* Clock.currentTimeMillis;
-        const quietForMs = now - current.lastSuppressedAt;
-        const elapsedMs = now - current.startedAt;
-        const reachedHardTimeout = elapsedMs >= options.hardTimeoutMs;
-        if (quietForMs >= options.quietMs || reachedHardTimeout) {
-          const opened = yield* open;
-          if (opened && reachedHardTimeout) {
-            yield* options.onHardTimeout({ elapsedMs });
+        if (decision._tag === "Opened") {
+          yield* Deferred.succeed(ready, "ready");
+          if (decision.reachedHardTimeout) {
+            yield* options.onHardTimeout({ elapsedMs: decision.elapsedMs });
           }
           return;
         }
-
-        const untilQuietMs = options.quietMs - quietForMs;
-        const untilHardTimeoutMs = options.hardTimeoutMs - elapsedMs;
-        yield* Effect.sleep(
-          Math.max(1, Math.min(untilQuietMs, untilHardTimeoutMs, REPLAY_SETTLE_POLL_MAX_MS)),
-        );
+        yield* Effect.sleep(decision.delayMs);
       }
     });
 
@@ -147,6 +163,6 @@ export const makeAcpLoadReplayGate = (
       ),
       awaitReady: Deferred.await(ready),
       settle,
-      release: complete("released").pipe(Effect.asVoid),
+      release,
     };
   });

--- a/apps/server/src/provider/acp/AcpLoadReplayGate.ts
+++ b/apps/server/src/provider/acp/AcpLoadReplayGate.ts
@@ -66,15 +66,17 @@ export const makeAcpLoadReplayGate = (
 
     const release = Effect.gen(function* () {
       const completed = yield* Ref.modify(state, (current) =>
-        current._tag === "Ready" || current._tag === "Released"
+        current._tag === "Released"
           ? ([false, current] as const)
-          : ([true, { _tag: "Released" } satisfies ReplayReleased] as const),
+          : current._tag === "Ready"
+            ? ([true, current] as const)
+            : ([true, { _tag: "Released" } satisfies ReplayReleased] as const),
       );
       if (completed) {
         yield* Deferred.succeed(consumerAttached, undefined);
         yield* Deferred.succeed(ready, "released");
       }
-    }).pipe(Effect.asVoid);
+    }).pipe(Effect.asVoid, Effect.uninterruptible);
 
     const settle = Effect.gen(function* () {
       yield* Deferred.await(consumerAttached);
@@ -115,6 +117,15 @@ export const makeAcpLoadReplayGate = (
               current,
             ] as const;
           },
+        ).pipe(
+          Effect.flatMap((next) =>
+            next._tag === "Opened"
+              ? Deferred.succeed(ready, "ready").pipe(Effect.as(next))
+              : Effect.succeed(next),
+          ),
+          // State must never become Ready without completing its waiter: scope
+          // release uses that state to decide whether it still needs to unblock.
+          Effect.uninterruptible,
         );
 
         if (decision._tag === "Done") {
@@ -124,7 +135,6 @@ export const makeAcpLoadReplayGate = (
           continue;
         }
         if (decision._tag === "Opened") {
-          yield* Deferred.succeed(ready, "ready");
           if (decision.reachedHardTimeout) {
             yield* options.onHardTimeout({ elapsedMs: decision.elapsedMs });
           }

--- a/apps/server/src/provider/acp/AcpLoadReplayGate.ts
+++ b/apps/server/src/provider/acp/AcpLoadReplayGate.ts
@@ -81,6 +81,9 @@ export const makeAcpLoadReplayGate = (
         if (current._tag === "Ready" || current._tag === "Released") {
           return;
         }
+        if (current._tag !== "Suppressing") {
+          continue;
+        }
 
         const now = yield* Clock.currentTimeMillis;
         const quietForMs = now - current.lastSuppressedAt;

--- a/apps/server/src/provider/acp/AcpLoadReplayGate.ts
+++ b/apps/server/src/provider/acp/AcpLoadReplayGate.ts
@@ -1,0 +1,155 @@
+// FILE: AcpLoadReplayGate.ts
+// Purpose: Suppresses ACP session/load transcript replay until the inbound stream settles.
+// Layer: Provider ACP helper
+// Exports: makeAcpLoadReplayGate and its policy/evidence contracts.
+
+import { Clock, Deferred, Effect, Ref } from "effect";
+
+const REPLAY_SETTLE_POLL_MAX_MS = 50;
+
+export interface AcpLoadReplayTimeoutEvidence {
+  readonly elapsedMs: number;
+}
+
+export interface AcpLoadReplayGateOptions {
+  readonly quietMs: number;
+  readonly hardTimeoutMs: number;
+  readonly onHardTimeout: (
+    evidence: AcpLoadReplayTimeoutEvidence,
+  ) => Effect.Effect<void, never>;
+}
+
+export interface AcpLoadReplayGate {
+  readonly attachConsumer: Effect.Effect<void>;
+  readonly suppressUpdate: Effect.Effect<boolean>;
+  readonly isSuppressing: Effect.Effect<boolean>;
+  readonly awaitReady: Effect.Effect<"ready" | "released">;
+  readonly settle: Effect.Effect<void>;
+  readonly release: Effect.Effect<void>;
+}
+
+interface SuppressingReplay {
+  readonly _tag: "Suppressing";
+  readonly startedAt: number;
+  readonly lastSuppressedAt: number;
+}
+
+interface WaitingForConsumer {
+  readonly _tag: "WaitingForConsumer";
+}
+
+interface ReplayReady {
+  readonly _tag: "Ready";
+}
+
+interface ReplayReleased {
+  readonly _tag: "Released";
+}
+
+type ReplayGateState = WaitingForConsumer | SuppressingReplay | ReplayReady | ReplayReleased;
+
+export const makeAcpLoadReplayGate = (
+  options: AcpLoadReplayGateOptions,
+): Effect.Effect<AcpLoadReplayGate> =>
+  Effect.gen(function* () {
+    const consumerAttached = yield* Deferred.make<void>();
+    const ready = yield* Deferred.make<"ready" | "released">();
+    const state = yield* Ref.make<ReplayGateState>({ _tag: "WaitingForConsumer" });
+
+    const complete = (outcome: "ready" | "released") =>
+      Effect.gen(function* () {
+        const nextState =
+          outcome === "ready"
+            ? ({ _tag: "Ready" } satisfies ReplayReady)
+            : ({ _tag: "Released" } satisfies ReplayReleased);
+        const completed = yield* Ref.modify(state, (current) =>
+          current._tag === "Ready" || current._tag === "Released"
+            ? ([false, current] as const)
+            : ([true, nextState] as const),
+        );
+        if (completed) {
+          yield* Deferred.succeed(consumerAttached, undefined);
+          yield* Deferred.succeed(ready, outcome);
+        }
+        return completed;
+      });
+
+    const open = complete("ready");
+
+    const settle = Effect.gen(function* () {
+      yield* Deferred.await(consumerAttached);
+      while (true) {
+        const current = yield* Ref.get(state);
+        if (current._tag === "Ready" || current._tag === "Released") {
+          return;
+        }
+
+        const now = yield* Clock.currentTimeMillis;
+        const quietForMs = now - current.lastSuppressedAt;
+        const elapsedMs = now - current.startedAt;
+        const reachedHardTimeout = elapsedMs >= options.hardTimeoutMs;
+        if (quietForMs >= options.quietMs || reachedHardTimeout) {
+          const opened = yield* open;
+          if (opened && reachedHardTimeout) {
+            yield* options.onHardTimeout({ elapsedMs });
+          }
+          return;
+        }
+
+        const untilQuietMs = options.quietMs - quietForMs;
+        const untilHardTimeoutMs = options.hardTimeoutMs - elapsedMs;
+        yield* Effect.sleep(
+          Math.max(
+            1,
+            Math.min(untilQuietMs, untilHardTimeoutMs, REPLAY_SETTLE_POLL_MAX_MS),
+          ),
+        );
+      }
+    });
+
+    return {
+      attachConsumer: Clock.currentTimeMillis.pipe(
+        Effect.flatMap((now) =>
+          Ref.modify(state, (current) =>
+            current._tag === "WaitingForConsumer"
+              ? ([
+                  true,
+                  {
+                    _tag: "Suppressing",
+                    startedAt: now,
+                    lastSuppressedAt: now,
+                  } satisfies SuppressingReplay,
+                ] as const)
+              : ([false, current] as const),
+          ),
+        ),
+        Effect.flatMap((attached) =>
+          attached
+            ? Deferred.succeed(consumerAttached, undefined).pipe(Effect.asVoid)
+            : Effect.void,
+        ),
+      ),
+      suppressUpdate: Clock.currentTimeMillis.pipe(
+        Effect.flatMap((now) =>
+          Ref.modify(state, (current) =>
+            current._tag === "Ready"
+              ? ([false, current] as const)
+              : current._tag === "Released"
+                ? ([true, current] as const)
+                : current._tag === "WaitingForConsumer"
+                  ? ([true, current] as const)
+                  : ([true, { ...current, lastSuppressedAt: now }] as const),
+          ),
+        ),
+      ),
+      isSuppressing: Ref.get(state).pipe(
+        Effect.map(
+          (current) =>
+            current._tag === "WaitingForConsumer" || current._tag === "Suppressing",
+        ),
+      ),
+      awaitReady: Deferred.await(ready),
+      settle,
+      release: complete("released").pipe(Effect.asVoid),
+    };
+  });

--- a/apps/server/src/provider/acp/AcpLoadReplayGate.ts
+++ b/apps/server/src/provider/acp/AcpLoadReplayGate.ts
@@ -14,9 +14,7 @@ export interface AcpLoadReplayTimeoutEvidence {
 export interface AcpLoadReplayGateOptions {
   readonly quietMs: number;
   readonly hardTimeoutMs: number;
-  readonly onHardTimeout: (
-    evidence: AcpLoadReplayTimeoutEvidence,
-  ) => Effect.Effect<void, never>;
+  readonly onHardTimeout: (evidence: AcpLoadReplayTimeoutEvidence) => Effect.Effect<void, never>;
 }
 
 export interface AcpLoadReplayGate {
@@ -99,10 +97,7 @@ export const makeAcpLoadReplayGate = (
         const untilQuietMs = options.quietMs - quietForMs;
         const untilHardTimeoutMs = options.hardTimeoutMs - elapsedMs;
         yield* Effect.sleep(
-          Math.max(
-            1,
-            Math.min(untilQuietMs, untilHardTimeoutMs, REPLAY_SETTLE_POLL_MAX_MS),
-          ),
+          Math.max(1, Math.min(untilQuietMs, untilHardTimeoutMs, REPLAY_SETTLE_POLL_MAX_MS)),
         );
       }
     });
@@ -144,8 +139,7 @@ export const makeAcpLoadReplayGate = (
       ),
       isSuppressing: Ref.get(state).pipe(
         Effect.map(
-          (current) =>
-            current._tag === "WaitingForConsumer" || current._tag === "Suppressing",
+          (current) => current._tag === "WaitingForConsumer" || current._tag === "Suppressing",
         ),
       ),
       awaitReady: Deferred.await(ready),

--- a/apps/server/src/provider/acp/AcpLoadReplayGate.ts
+++ b/apps/server/src/provider/acp/AcpLoadReplayGate.ts
@@ -82,47 +82,48 @@ export const makeAcpLoadReplayGate = (
       yield* Deferred.await(consumerAttached);
       while (true) {
         const now = yield* Clock.currentTimeMillis;
-        const decision = yield* Ref.modify(
-          state,
-          (current): readonly [ReplaySettleDecision, ReplayGateState] => {
-            if (current._tag === "Ready" || current._tag === "Released") {
-              return [{ _tag: "Done" } as const, current] as const;
-            }
-            if (current._tag === "WaitingForConsumer") {
-              return [{ _tag: "Retry" } as const, current] as const;
-            }
+        const decision = yield* Effect.gen(function* () {
+          const next: ReplaySettleDecision = yield* Ref.modify(
+            state,
+            (current): readonly [ReplaySettleDecision, ReplayGateState] => {
+              if (current._tag === "Ready" || current._tag === "Released") {
+                return [{ _tag: "Done" } as const, current] as const;
+              }
+              if (current._tag === "WaitingForConsumer") {
+                return [{ _tag: "Retry" } as const, current] as const;
+              }
 
-            const quietForMs = now - current.lastSuppressedAt;
-            const elapsedMs = now - current.startedAt;
-            const reachedHardTimeout = elapsedMs >= options.hardTimeoutMs;
-            if (quietForMs >= options.quietMs || reachedHardTimeout) {
+              const quietForMs = now - current.lastSuppressedAt;
+              const elapsedMs = now - current.startedAt;
+              const reachedHardTimeout = elapsedMs >= options.hardTimeoutMs;
+              if (quietForMs >= options.quietMs || reachedHardTimeout) {
+                return [
+                  { _tag: "Opened", elapsedMs, reachedHardTimeout } as const,
+                  { _tag: "Ready" } satisfies ReplayReady,
+                ] as const;
+              }
+
               return [
-                { _tag: "Opened", elapsedMs, reachedHardTimeout } as const,
-                { _tag: "Ready" } satisfies ReplayReady,
-              ] as const;
-            }
-
-            return [
-              {
-                _tag: "Wait",
-                delayMs: Math.max(
-                  1,
-                  Math.min(
-                    options.quietMs - quietForMs,
-                    options.hardTimeoutMs - elapsedMs,
-                    REPLAY_SETTLE_POLL_MAX_MS,
+                {
+                  _tag: "Wait",
+                  delayMs: Math.max(
+                    1,
+                    Math.min(
+                      options.quietMs - quietForMs,
+                      options.hardTimeoutMs - elapsedMs,
+                      REPLAY_SETTLE_POLL_MAX_MS,
+                    ),
                   ),
-                ),
-              } as const,
-              current,
-            ] as const;
-          },
-        ).pipe(
-          Effect.flatMap((next) =>
-            next._tag === "Opened"
-              ? Deferred.succeed(ready, "ready").pipe(Effect.as(next))
-              : Effect.succeed(next),
-          ),
+                } as const,
+                current,
+              ] as const;
+            },
+          );
+          if (next._tag === "Opened") {
+            yield* Deferred.succeed(ready, "ready");
+          }
+          return next;
+        }).pipe(
           // State must never become Ready without completing its waiter: scope
           // release uses that state to decide whether it still needs to unblock.
           Effect.uninterruptible,
@@ -165,6 +166,7 @@ export const makeAcpLoadReplayGate = (
             ? Deferred.succeed(consumerAttached, undefined).pipe(Effect.asVoid)
             : Effect.void,
         ),
+        Effect.uninterruptible,
       ),
       suppressUpdate: Clock.currentTimeMillis.pipe(
         Effect.flatMap((now) =>

--- a/apps/server/src/provider/acp/AcpLoadReplayGate.ts
+++ b/apps/server/src/provider/acp/AcpLoadReplayGate.ts
@@ -46,6 +46,16 @@ interface ReplayReleased {
 
 type ReplayGateState = WaitingForConsumer | SuppressingReplay | ReplayReady | ReplayReleased;
 
+type ReplaySettleDecision =
+  | { readonly _tag: "Done" }
+  | { readonly _tag: "Retry" }
+  | {
+      readonly _tag: "Opened";
+      readonly elapsedMs: number;
+      readonly reachedHardTimeout: boolean;
+    }
+  | { readonly _tag: "Wait"; readonly delayMs: number };
+
 export const makeAcpLoadReplayGate = (
   options: AcpLoadReplayGateOptions,
 ): Effect.Effect<AcpLoadReplayGate> =>
@@ -70,39 +80,42 @@ export const makeAcpLoadReplayGate = (
       yield* Deferred.await(consumerAttached);
       while (true) {
         const now = yield* Clock.currentTimeMillis;
-        const decision = yield* Ref.modify(state, (current) => {
-          if (current._tag === "Ready" || current._tag === "Released") {
-            return [{ _tag: "Done" } as const, current] as const;
-          }
-          if (current._tag === "WaitingForConsumer") {
-            return [{ _tag: "Retry" } as const, current] as const;
-          }
+        const decision = yield* Ref.modify(
+          state,
+          (current): readonly [ReplaySettleDecision, ReplayGateState] => {
+            if (current._tag === "Ready" || current._tag === "Released") {
+              return [{ _tag: "Done" } as const, current] as const;
+            }
+            if (current._tag === "WaitingForConsumer") {
+              return [{ _tag: "Retry" } as const, current] as const;
+            }
 
-          const quietForMs = now - current.lastSuppressedAt;
-          const elapsedMs = now - current.startedAt;
-          const reachedHardTimeout = elapsedMs >= options.hardTimeoutMs;
-          if (quietForMs >= options.quietMs || reachedHardTimeout) {
+            const quietForMs = now - current.lastSuppressedAt;
+            const elapsedMs = now - current.startedAt;
+            const reachedHardTimeout = elapsedMs >= options.hardTimeoutMs;
+            if (quietForMs >= options.quietMs || reachedHardTimeout) {
+              return [
+                { _tag: "Opened", elapsedMs, reachedHardTimeout } as const,
+                { _tag: "Ready" } satisfies ReplayReady,
+              ] as const;
+            }
+
             return [
-              { _tag: "Opened", elapsedMs, reachedHardTimeout } as const,
-              { _tag: "Ready" } satisfies ReplayReady,
-            ] as const;
-          }
-
-          return [
-            {
-              _tag: "Wait",
-              delayMs: Math.max(
-                1,
-                Math.min(
-                  options.quietMs - quietForMs,
-                  options.hardTimeoutMs - elapsedMs,
-                  REPLAY_SETTLE_POLL_MAX_MS,
+              {
+                _tag: "Wait",
+                delayMs: Math.max(
+                  1,
+                  Math.min(
+                    options.quietMs - quietForMs,
+                    options.hardTimeoutMs - elapsedMs,
+                    REPLAY_SETTLE_POLL_MAX_MS,
+                  ),
                 ),
-              ),
-            } as const,
-            current,
-          ] as const;
-        });
+              } as const,
+              current,
+            ] as const;
+          },
+        );
 
         if (decision._tag === "Done") {
           return;

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -22,6 +22,10 @@ import {
 } from "effect";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import * as AcpErrors from "./AcpErrors.ts";
+import {
+  makeAcpLoadReplayGate,
+  type AcpLoadReplayGate,
+} from "./AcpLoadReplayGate.ts";
 import { loadAcpSdk, type AcpSdkModule } from "./AcpSdk.ts";
 import { SetSessionConfigOptionResponse as SetSessionConfigOptionResponseCodec } from "./AcpExtensions.ts";
 
@@ -45,6 +49,8 @@ import {
 
 const CONFIG_OPTION_UPDATE_TIMEOUT = "5 seconds";
 const ACP_INCOMING_CHUNK_QUEUE_CAPACITY = 64;
+const ACP_LOAD_REPLAY_QUIET_MS = 350;
+const ACP_LOAD_REPLAY_HARD_TIMEOUT_MS = 30_000;
 export const ACP_MAX_INCOMING_FRAME_BYTES = 8 * 1024 * 1024;
 
 export type AcpSessionStartupStep =
@@ -241,6 +247,11 @@ export interface AcpSessionRuntimeOptions {
   readonly freshSessionRetry?: AcpFreshSessionRetryPolicy;
   /** Overrides for {@link DEFAULT_ACP_SESSION_STARTUP_TIMEOUTS}. */
   readonly startupTimeouts?: Partial<AcpSessionStartupTimeouts>;
+  /** Test/provider policy overrides for session/load transcript replay suppression. */
+  readonly loadReplayPolicy?: {
+    readonly quietMs?: number;
+    readonly hardTimeoutMs?: number;
+  };
   readonly requestLogger?: (event: AcpSessionRequestLogEvent) => Effect.Effect<void, never>;
   readonly protocolLogging?: {
     readonly logIncoming?: boolean;
@@ -751,12 +762,27 @@ const makeAcpSessionRuntime = (
     );
     const startStateRef = yield* Ref.make<AcpStartState>({ _tag: "NotStarted" });
     // session/load can replay a large history before the consumer attaches; drop
-    // those notifications so they never accumulate in the unbounded queue. For
-    // resumed sessions the gate stays closed past start() and only opens once the
-    // adapter attaches a consumer via getEvents(), because the agent may keep
-    // replaying after replying to session/load. Plain mutable state (not a Ref)
-    // so getEvents() can open the gate synchronously at attach time.
+    // those notifications so they never accumulate in the bounded queue.
     let acceptingSessionUpdates = false;
+    let loadReplayGate: AcpLoadReplayGate | undefined;
+    const awaitLoadReplayReady = Effect.suspend(() => {
+      const gate = loadReplayGate;
+      if (gate === undefined) {
+        return Effect.void;
+      }
+      return gate.awaitReady.pipe(
+        Effect.flatMap((outcome) =>
+          outcome === "ready"
+            ? Effect.void
+            : Effect.fail(
+                new AcpErrors.AcpRequestError({
+                  code: -32603,
+                  errorMessage: "ACP runtime closed while waiting for session/load replay.",
+                }),
+              ),
+        ),
+      );
+    });
     // Counts every parsed event offered into eventQueue (see
     // sessionUpdatesEnqueuedCount on the shape). Plain mutable state: single
     // writer per offer, and readers only need a monotonic snapshot.
@@ -830,6 +856,9 @@ const makeAcpSessionRuntime = (
       );
 
     yield* Effect.addFinalizer(() => teardownAcpChildProcess(child, options.teardownProcessTree));
+    // Registered after child teardown so LIFO scope closure releases any first
+    // prompt/fork waiter before waiting for the child process to exit.
+    yield* Effect.addFinalizer(() => loadReplayGate?.release ?? Effect.void);
 
     const acp = yield* makeOfficialSdkClient(child, runtimeScope, options.protocolLogging);
 
@@ -870,24 +899,29 @@ const makeAcpSessionRuntime = (
               )
             : Effect.void;
         const rememberBoundedState = rememberCommands.pipe(Effect.andThen(rememberConfigOptions));
-        if (!acceptingSessionUpdates) {
+        const processUpdate = (suppress: boolean) => {
           // Command and configuration inventories are bounded state, not
           // transcript replay; retain them even while historical session
           // updates are being suppressed.
-          return rememberBoundedState;
-        }
-        return rememberBoundedState.pipe(
-          Effect.andThen(
-            handleSessionUpdate({
-              offer: offerSessionEvent,
-              modeStateRef,
-              toolCallsRef,
-              assistantSegmentRef,
-              runtimeInstanceId,
-              params: notification,
-            }),
-          ),
-        );
+          if (suppress) {
+            return rememberBoundedState;
+          }
+          return rememberBoundedState.pipe(
+            Effect.andThen(
+              handleSessionUpdate({
+                offer: offerSessionEvent,
+                modeStateRef,
+                toolCallsRef,
+                assistantSegmentRef,
+                runtimeInstanceId,
+                params: notification,
+              }),
+            ),
+          );
+        };
+        return loadReplayGate === undefined
+          ? processUpdate(!acceptingSessionUpdates)
+          : loadReplayGate.suppressUpdate.pipe(Effect.flatMap(processUpdate));
       }),
     );
 
@@ -1214,6 +1248,25 @@ const makeAcpSessionRuntime = (
         yield* Ref.set(assistantSegmentRef, { nextSegmentIndex: 0 });
       }
 
+      if (sessionSetupMethod === "load") {
+        const quietMs = options.loadReplayPolicy?.quietMs ?? ACP_LOAD_REPLAY_QUIET_MS;
+        const hardTimeoutMs =
+          options.loadReplayPolicy?.hardTimeoutMs ?? ACP_LOAD_REPLAY_HARD_TIMEOUT_MS;
+        loadReplayGate = yield* makeAcpLoadReplayGate({
+          quietMs,
+          hardTimeoutMs,
+          onHardTimeout: ({ elapsedMs }) =>
+            Effect.logWarning("acp.session_load_replay_quiet_wait_timeout", {
+              sessionId,
+              command: options.spawn.command,
+              elapsedMs,
+              quietMs,
+              hardTimeoutMs,
+            }),
+        });
+        yield* loadReplayGate.settle.pipe(Effect.forkIn(runtimeScope));
+      }
+
       const nextState = {
         sessionId,
         initializeResult,
@@ -1274,9 +1327,12 @@ const makeAcpSessionRuntime = (
       start: () => start,
       awaitExit: awaitAcpChildExit(child),
       getEvents: () => {
-        // Attaching a consumer opens the session/update gate: from here on the
-        // queue is drained, so accepting notifications can no longer grow it
-        // without bound (see acceptingSessionUpdates above).
+        const gate = loadReplayGate;
+        if (gate !== undefined) {
+          return Stream.fromEffect(gate.attachConsumer).pipe(
+            Stream.flatMap(() => Stream.fromQueue(eventQueue)),
+          );
+        }
         acceptingSessionUpdates = true;
         return Stream.fromQueue(eventQueue);
       },
@@ -1291,10 +1347,13 @@ const makeAcpSessionRuntime = (
               sessionId: started.sessionId,
               ...payload,
             } satisfies Acp.PromptRequest;
-            return closeActiveAssistantSegment({
-              offer: offerSessionEvent,
-              assistantSegmentRef,
-            }).pipe(
+            return awaitLoadReplayReady.pipe(
+              Effect.andThen(
+                closeActiveAssistantSegment({
+                  offer: offerSessionEvent,
+                  assistantSegmentRef,
+                }),
+              ),
               Effect.andThen(
                 runLoggedRequest(
                   "session/prompt",
@@ -1364,10 +1423,14 @@ const makeAcpSessionRuntime = (
               ...payload,
               sessionId: started.sessionId,
             } satisfies Acp.ForkSessionRequest;
-            return runLoggedRequest(
-              "session/fork",
-              requestPayload,
-              acp.agent.forkSession(requestPayload),
+            return awaitLoadReplayReady.pipe(
+              Effect.andThen(
+                runLoggedRequest(
+                  "session/fork",
+                  requestPayload,
+                  acp.agent.forkSession(requestPayload),
+                ),
+              ),
             );
           }),
         ),

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -334,8 +334,11 @@ export interface AcpSessionRuntimeShape {
   readonly supportsSessionFork: Effect.Effect<boolean, AcpErrors.AcpError>;
   /** Whether a persisted session id can be reopened through resume or load. */
   readonly supportsSessionRecovery: Effect.Effect<boolean, AcpErrors.AcpError>;
-  readonly getModeState: Effect.Effect<AcpSessionModeState | undefined>;
-  readonly getConfigOptions: Effect.Effect<ReadonlyArray<Acp.SessionConfigOption>>;
+  readonly getModeState: Effect.Effect<AcpSessionModeState | undefined, AcpErrors.AcpError>;
+  readonly getConfigOptions: Effect.Effect<
+    ReadonlyArray<Acp.SessionConfigOption>,
+    AcpErrors.AcpError
+  >;
   readonly getAvailableCommands: Effect.Effect<ReadonlyArray<Acp.AvailableCommand>>;
   /** Waits for session/load replay suppression to settle or reach its hard cap. */
   readonly awaitLoadReplayReady: Effect.Effect<void, AcpErrors.AcpError>;
@@ -783,6 +786,8 @@ const makeAcpSessionRuntime = (
         ),
       );
     });
+    const getModeState = awaitLoadReplayReady.pipe(Effect.andThen(Ref.get(modeStateRef)));
+    const getConfigOptions = awaitLoadReplayReady.pipe(Effect.andThen(Ref.get(configOptionsRef)));
     // Counts every parsed event offered into eventQueue (see
     // sessionUpdatesEnqueuedCount on the shape). Plain mutable state: single
     // writer per offer, and readers only need a monotonic snapshot.
@@ -1063,7 +1068,8 @@ const makeAcpSessionRuntime = (
       configId: string,
       value: string | boolean,
     ): Effect.Effect<Acp.SetSessionConfigOptionResponse, AcpErrors.AcpError> =>
-      validateConfigOptionValue(configId, value).pipe(
+      awaitLoadReplayReady.pipe(
+        Effect.andThen(validateConfigOptionValue(configId, value)),
         Effect.flatMap(() => getStartedState),
         Effect.flatMap((started) =>
           Ref.get(configOptionsRef).pipe(
@@ -1346,8 +1352,8 @@ const makeAcpSessionRuntime = (
         return Stream.fromQueue(eventQueue);
       },
       sessionUpdatesEnqueuedCount: Effect.sync(() => sessionUpdatesEnqueued),
-      getModeState: Ref.get(modeStateRef),
-      getConfigOptions: Ref.get(configOptionsRef),
+      getModeState,
+      getConfigOptions,
       getAvailableCommands: Ref.get(availableCommandsRef),
       awaitLoadReplayReady,
       prompt: (payload) =>
@@ -1384,12 +1390,12 @@ const makeAcpSessionRuntime = (
         Effect.flatMap((started) => acp.agent.cancel({ sessionId: started.sessionId })),
       ),
       setMode: (modeId) =>
-        Ref.get(modeStateRef).pipe(
+        getModeState.pipe(
           Effect.flatMap((modeState) => {
             if (modeState?.currentModeId === modeId) {
               return Effect.succeed({} satisfies Acp.SetSessionModeResponse);
             }
-            return Ref.get(configOptionsRef).pipe(
+            return getConfigOptions.pipe(
               Effect.map((options) =>
                 options.find(
                   (option) =>

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -896,9 +896,18 @@ const makeAcpSessionRuntime = (
                 Effect.andThen(resolveConfigOptionUpdateWaiters(update.configOptions)),
               )
             : Effect.void;
-        const rememberBoundedState = rememberCommands.pipe(Effect.andThen(rememberConfigOptions));
+        const rememberMode =
+          update.sessionUpdate === "current_mode_update"
+            ? Ref.update(modeStateRef, (current) =>
+                current === undefined ? current : updateModeState(current, update.currentModeId),
+              )
+            : Effect.void;
+        const rememberBoundedState = rememberCommands.pipe(
+          Effect.andThen(rememberConfigOptions),
+          Effect.andThen(rememberMode),
+        );
         const processUpdate = (suppress: boolean) => {
-          // Command and configuration inventories are bounded state, not
+          // Command, configuration, and mode inventories are bounded state, not
           // transcript replay; retain them even while historical session
           // updates are being suppressed.
           if (suppress) {

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -22,10 +22,7 @@ import {
 } from "effect";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import * as AcpErrors from "./AcpErrors.ts";
-import {
-  makeAcpLoadReplayGate,
-  type AcpLoadReplayGate,
-} from "./AcpLoadReplayGate.ts";
+import { makeAcpLoadReplayGate, type AcpLoadReplayGate } from "./AcpLoadReplayGate.ts";
 import { loadAcpSdk, type AcpSdkModule } from "./AcpSdk.ts";
 import { SetSessionConfigOptionResponse as SetSessionConfigOptionResponseCodec } from "./AcpExtensions.ts";
 

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -339,7 +339,10 @@ export interface AcpSessionRuntimeShape {
     ReadonlyArray<Acp.SessionConfigOption>,
     AcpErrors.AcpError
   >;
-  readonly getAvailableCommands: Effect.Effect<ReadonlyArray<Acp.AvailableCommand>>;
+  readonly getAvailableCommands: Effect.Effect<
+    ReadonlyArray<Acp.AvailableCommand>,
+    AcpErrors.AcpError
+  >;
   /** Waits for session/load replay suppression to settle or reach its hard cap. */
   readonly awaitLoadReplayReady: Effect.Effect<void, AcpErrors.AcpError>;
   readonly prompt: (
@@ -788,6 +791,9 @@ const makeAcpSessionRuntime = (
     });
     const getModeState = awaitLoadReplayReady.pipe(Effect.andThen(Ref.get(modeStateRef)));
     const getConfigOptions = awaitLoadReplayReady.pipe(Effect.andThen(Ref.get(configOptionsRef)));
+    const getAvailableCommands = awaitLoadReplayReady.pipe(
+      Effect.andThen(Ref.get(availableCommandsRef)),
+    );
     // Counts every parsed event offered into eventQueue (see
     // sessionUpdatesEnqueuedCount on the shape). Plain mutable state: single
     // writer per offer, and readers only need a monotonic snapshot.
@@ -1354,7 +1360,7 @@ const makeAcpSessionRuntime = (
       sessionUpdatesEnqueuedCount: Effect.sync(() => sessionUpdatesEnqueued),
       getModeState,
       getConfigOptions,
-      getAvailableCommands: Ref.get(availableCommandsRef),
+      getAvailableCommands,
       awaitLoadReplayReady,
       prompt: (payload) =>
         getStartedState.pipe(

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -337,6 +337,8 @@ export interface AcpSessionRuntimeShape {
   readonly getModeState: Effect.Effect<AcpSessionModeState | undefined>;
   readonly getConfigOptions: Effect.Effect<ReadonlyArray<Acp.SessionConfigOption>>;
   readonly getAvailableCommands: Effect.Effect<ReadonlyArray<Acp.AvailableCommand>>;
+  /** Waits for session/load replay suppression to settle or reach its hard cap. */
+  readonly awaitLoadReplayReady: Effect.Effect<void, AcpErrors.AcpError>;
   readonly prompt: (
     payload: Omit<Acp.PromptRequest, "sessionId">,
   ) => Effect.Effect<Acp.PromptResponse, AcpErrors.AcpError>;
@@ -1347,6 +1349,7 @@ const makeAcpSessionRuntime = (
       getModeState: Ref.get(modeStateRef),
       getConfigOptions: Ref.get(configOptionsRef),
       getAvailableCommands: Ref.get(availableCommandsRef),
+      awaitLoadReplayReady,
       prompt: (payload) =>
         getStartedState.pipe(
           Effect.flatMap((started) => {

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -767,7 +767,8 @@ const makeAcpSessionRuntime = (
       if (gate === undefined) {
         return Effect.void;
       }
-      return gate.awaitReady.pipe(
+      return gate.attachConsumer.pipe(
+        Effect.andThen(gate.awaitReady),
         Effect.flatMap((outcome) =>
           outcome === "ready"
             ? Effect.void

--- a/apps/server/src/provider/acp/CursorAcpSupport.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.ts
@@ -49,7 +49,7 @@ export interface CursorAcpRuntimeInput extends Omit<
 
 export interface CursorAcpModelSelectionErrorContext {
   readonly cause: AcpErrors.AcpError;
-  readonly step: "set-config-option" | "set-model";
+  readonly step: "read-config-options" | "set-config-option" | "set-model";
   readonly configId?: string;
 }
 
@@ -1533,8 +1533,11 @@ export function applyCursorAcpModelSelection<E>(input: {
 }): Effect.Effect<void, E> {
   const notify = (notice: CursorAcpModelSelectionNotice): Effect.Effect<void> =>
     input.onNotice ? input.onNotice(notice) : Effect.void;
+  const readConfigOptions = input.runtime.getConfigOptions.pipe(
+    Effect.mapError((cause) => input.mapError({ cause, step: "read-config-options" })),
+  );
   return Effect.gen(function* () {
-    const initialConfigOptions = yield* input.runtime.getConfigOptions;
+    const initialConfigOptions = yield* readConfigOptions;
     const choices = flattenCursorAcpModelChoices(initialConfigOptions);
     const baseModel = resolveCursorAcpBaseModelId(input.model);
     const mergedOptions = resolveCursorMergedSessionOptions({
@@ -1583,7 +1586,7 @@ export function applyCursorAcpModelSelection<E>(input: {
     // Re-read after setModel: Auto/default often has no fast/effort options,
     // so the first pass would drop fast=true and then write fast=false once
     // GPT/Grok's dedicated toggles appear.
-    const appliedConfigOptions = yield* input.runtime.getConfigOptions;
+    const appliedConfigOptions = yield* readConfigOptions;
     const appliedChoices = flattenCursorAcpModelChoices(appliedConfigOptions);
     const appliedOptions = resolveCursorMergedSessionOptions({
       configOptions: appliedConfigOptions,

--- a/apps/server/src/provider/acp/acpFork.ts
+++ b/apps/server/src/provider/acp/acpFork.ts
@@ -13,8 +13,9 @@ import { ProviderAdapterRequestError, ProviderAdapterValidationError } from "../
  * Fork the runtime's active session when the agent advertises `session/fork`.
  *
  * Fails with a `ProviderAdapterValidationError` when the capability is missing
- * so callers fall back to Synara's retained-transcript fork, and bounds the
- * whole probe+fork exchange with the adapter's request timeout.
+ * so callers fall back to Synara's retained-transcript fork. Replay readiness
+ * has its own bounded policy; the adapter timeout applies only after that gate
+ * opens, preserving the full RPC allowance even when replay hits its hard cap.
  */
 export function forkViaAcpRuntime(input: {
   readonly provider: string;
@@ -42,14 +43,15 @@ export function forkViaAcpRuntime(input: {
         issue: `This ${input.provider} ACP version advertises session/fork but cannot reopen the forked session; Synara will rebuild the fork from its retained transcript.`,
       });
     }
-    return yield* input.runtime.forkSession({ cwd: input.targetCwd, mcpServers: [] });
-  }).pipe(
-    Effect.timeoutOption(input.requestTimeoutMs),
-    Effect.flatMap(
-      Option.match({
-        onNone: () => Effect.fail(input.timeoutError("session/fork")),
-        onSome: Effect.succeed,
-      }),
-    ),
-  );
+    yield* input.runtime.awaitLoadReplayReady;
+    return yield* input.runtime.forkSession({ cwd: input.targetCwd, mcpServers: [] }).pipe(
+      Effect.timeoutOption(input.requestTimeoutMs),
+      Effect.flatMap(
+        Option.match({
+          onNone: () => Effect.fail(input.timeoutError("session/fork")),
+          onSome: Effect.succeed,
+        }),
+      ),
+    );
+  });
 }


### PR DESCRIPTION
## Summary

- centralize ACP `session/load` transcript replay suppression in the shared runtime
- wait for an attached event consumer and a quiet inbound window before allowing the first prompt or fork
- retain bounded command/config state during suppression, release waiters safely on shutdown, and warn with timeout evidence at the hard cap
- remove the duplicated Droid and Grok adapter-local replay gates so Cursor and future ACP adapters inherit the same behavior

## Verification

- `bun run --cwd apps/server test src/provider/acp/AcpLoadReplayGate.test.ts src/provider/acp/AcpSessionRuntime.test.ts src/provider/acp/AcpJsonRpcConnection.test.ts src/provider/acp/AcpSdkConformance.test.ts src/provider/acp/GrokAcpSupport.test.ts src/provider/acp/DroidAcpSupport.test.ts src/provider/acp/CursorAcpSupport.test.ts src/provider/Layers/DroidAdapter.test.ts src/provider/Layers/GrokAdapter.test.ts src/provider/Layers/CursorAdapter.test.ts` (154 passed)
- `git diff --check`

Closes #811

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session startup ordering, turn gating, and fork timing across multiple ACP providers; mistakes could leak replay into the first turn or strand/block sessions during resume.
> 
> **Overview**
> **Moves `session/load` transcript replay handling into the shared ACP runtime** so Cursor, Droid, and Grok no longer each implement quiet-window / hard-cap replay gates.
> 
> The new **`AcpLoadReplayGate`** drops historical `session/update` transcript events until an event consumer attaches and the inbound stream is quiet (with a hard timeout and warning evidence), while still applying bounded **mode, config, and available-commands** updates during suppression. **`awaitLoadReplayReady`** gates the first **prompt**, **fork**, **set_config_option**, and reads of mode/config/commands; scope teardown **releases** waiters so stop/restart does not block on the replay cap.
> 
> **Adapter startup changes:** Cursor and Grok split registration from configuration—replay wait runs **outside** the per-thread lock, then model/mode setup and lifecycle events run under lock behind **`sessionConfigReady`**. Droid removes adapter-local replay suppression and routes config through **`runDroidAcpConfigurationAfterReplay`**. **`forkViaAcpRuntime`** waits for replay before applying the fork RPC timeout.
> 
> The **ACP mock agent** gains env-driven delayed replay, late mode/commands updates, and errors for prompt/config/fork during replay for integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 460e0ffa6119bc9f25e507c825add5fd98ef3976. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
