### PR TITLE
[codex] Fix copy path actions

### DIFF
--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -399,31 +399,54 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
     }),
   );
 
-  it.effect("maps file-manager editor to OS open commands", () =>
+  it.effect("reveals macOS files in Finder while opening directories", () =>
     Effect.gen(function* () {
-      const launch1 = yield* resolveEditorLaunch(
-        { cwd: "/tmp/workspace", editor: "file-manager" },
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const parentPath = yield* fs.makeTempDirectoryScoped({
+        prefix: "synara-file-manager-",
+      });
+      const directoryPath = path.join(parentPath, "Project Folder");
+      const filePath = path.join(directoryPath, "source file.ts");
+      yield* fs.makeDirectory(directoryPath);
+      yield* fs.writeFileString(filePath, "");
+
+      const fileLaunch = yield* resolveEditorLaunch(
+        { cwd: filePath, editor: "file-manager" },
         "darwin",
       );
-      assert.deepEqual(launch1, {
+      assert.deepEqual(fileLaunch, {
         command: "open",
-        args: ["/tmp/workspace"],
+        args: ["-R", filePath],
       });
 
-      const launch2 = yield* resolveEditorLaunch(
+      const directoryLaunch = yield* resolveEditorLaunch(
+        { cwd: directoryPath, editor: "file-manager" },
+        "darwin",
+      );
+      assert.deepEqual(directoryLaunch, {
+        command: "open",
+        args: [directoryPath],
+      });
+    }),
+  );
+
+  it.effect("maps file-manager editor to Windows and Linux open commands", () =>
+    Effect.gen(function* () {
+      const windowsLaunch = yield* resolveEditorLaunch(
         { cwd: "C:\\workspace", editor: "file-manager" },
         "win32",
       );
-      assert.deepEqual(launch2, {
+      assert.deepEqual(windowsLaunch, {
         command: "explorer",
         args: ["C:\\workspace"],
       });
 
-      const launch3 = yield* resolveEditorLaunch(
+      const linuxLaunch = yield* resolveEditorLaunch(
         { cwd: "/tmp/workspace", editor: "file-manager" },
         "linux",
       );
-      assert.deepEqual(launch3, {
+      assert.deepEqual(linuxLaunch, {
         command: "xdg-open",
         args: ["/tmp/workspace"],
       });

--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -431,6 +431,21 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
     }),
   );
 
+  it.effect("falls back to opening macOS targets when metadata lookup fails", () =>
+    Effect.gen(function* () {
+      const targetPath = `/${"unavailable".repeat(500)}`;
+      const launch = yield* resolveEditorLaunch(
+        { cwd: targetPath, editor: "file-manager" },
+        "darwin",
+      );
+
+      assert.deepEqual(launch, {
+        command: "open",
+        args: [targetPath],
+      });
+    }),
+  );
+
   it.effect("maps file-manager editor to Windows and Linux open commands", () =>
     Effect.gen(function* () {
       const windowsLaunch = yield* resolveEditorLaunch(

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -147,6 +147,15 @@ function fileManagerCommandForPlatform(platform: NodeJS.Platform): string {
   }
 }
 
+function resolveFileManagerLaunch(target: string, platform: NodeJS.Platform): EditorLaunch {
+  const command = fileManagerCommandForPlatform(platform);
+  const shouldReveal =
+    platform === "darwin" &&
+    statSync(target, { throwIfNoEntry: false })?.isDirectory() === false;
+
+  return { command, args: shouldReveal ? ["-R", target] : [target] };
+}
+
 // Terminal integrations should receive a directory even when the source target is file:line:column.
 function resolveTerminalWorkingDirectory(target: string): string {
   const targetPath = parseTargetPathAndPosition(target)?.path ?? target;
@@ -402,7 +411,7 @@ export const resolveEditorLaunch = Effect.fnUntraced(function* (
     return yield* new OpenError({ message: `Unsupported editor: ${input.editor}` });
   }
 
-  return { command: fileManagerCommandForPlatform(platform), args: [input.cwd] };
+  return resolveFileManagerLaunch(input.cwd, platform);
 });
 
 function editorLaunchesEqual(left: EditorLaunch, right: EditorLaunch): boolean {

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -150,8 +150,7 @@ function fileManagerCommandForPlatform(platform: NodeJS.Platform): string {
 function resolveFileManagerLaunch(target: string, platform: NodeJS.Platform): EditorLaunch {
   const command = fileManagerCommandForPlatform(platform);
   const shouldReveal =
-    platform === "darwin" &&
-    statSync(target, { throwIfNoEntry: false })?.isDirectory() === false;
+    platform === "darwin" && statSync(target, { throwIfNoEntry: false })?.isDirectory() === false;
 
   return { command, args: shouldReveal ? ["-R", target] : [target] };
 }

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -147,10 +147,17 @@ function fileManagerCommandForPlatform(platform: NodeJS.Platform): string {
   }
 }
 
+function shouldRevealInFinder(target: string): boolean {
+  try {
+    return statSync(target, { throwIfNoEntry: false })?.isDirectory() === false;
+  } catch {
+    return false;
+  }
+}
+
 function resolveFileManagerLaunch(target: string, platform: NodeJS.Platform): EditorLaunch {
   const command = fileManagerCommandForPlatform(platform);
-  const shouldReveal =
-    platform === "darwin" && statSync(target, { throwIfNoEntry: false })?.isDirectory() === false;
+  const shouldReveal = platform === "darwin" && shouldRevealInFinder(target);
 
   return { command, args: shouldReveal ? ["-R", target] : [target] };
 }

--- a/apps/web/src/components/CopyPathActions.browser.tsx
+++ b/apps/web/src/components/CopyPathActions.browser.tsx
@@ -1,0 +1,169 @@
+// FILE: CopyPathActions.browser.tsx
+// Purpose: Verifies copy-path menus preserve path semantics and clipboard fallbacks.
+// Layer: Browser UI test
+
+import "../index.css";
+
+import type { FileDiffMetadata } from "@pierre/diffs/react";
+import type { PropsWithChildren, ReactNode } from "react";
+import { page } from "vitest/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+const harness = vi.hoisted(() => ({
+  toastAdd: vi.fn(),
+}));
+
+vi.mock("./ui/toast", () => ({
+  toastManager: { add: harness.toastAdd },
+}));
+
+vi.mock("./chat/OpenInPicker", () => ({
+  OpenInPicker: ({ openInTarget }: { openInTarget: string | null }) => (
+    <output data-testid="open-in-target">{openInTarget}</output>
+  ),
+}));
+
+vi.mock("./chat/FileDiffView", () => ({
+  FileDiffSurface: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  FileDiffCard: ({ renderHeaderTrailing }: { renderHeaderTrailing?: () => ReactNode }) => (
+    <div data-diff-file-header>{renderHeaderTrailing?.()}</div>
+  ),
+}));
+
+vi.mock("./LocalImagePreview", () => ({
+  LocalImagePreview: () => null,
+}));
+
+import { DiffPanelFileList } from "./DiffPanelFileList";
+import { WorkspaceFilePreviewHeader } from "./chat/WorkspaceFilePreviewHeader";
+
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+const originalExecCommandDescriptor = Object.getOwnPropertyDescriptor(document, "execCommand");
+
+function setClipboard(clipboard: Pick<Clipboard, "writeText"> | undefined): void {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: clipboard,
+  });
+}
+
+function installSuccessfulFallbackCopy(): ReturnType<typeof vi.fn> {
+  const execCommand = vi.fn().mockReturnValue(true);
+  Object.defineProperty(document, "execCommand", {
+    configurable: true,
+    value: execCommand,
+  });
+  return execCommand;
+}
+
+function restoreProperty(
+  target: object,
+  property: string,
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor) {
+    Object.defineProperty(target, property, descriptor);
+    return;
+  }
+  Reflect.deleteProperty(target, property);
+}
+
+function fileDiff(path: string): FileDiffMetadata {
+  return {
+    cacheKey: `diff:${path}`,
+    name: `b/${path}`,
+    prevName: `a/${path}`,
+  } as FileDiffMetadata;
+}
+
+function workspaceFilePreviewHeader(filePath: string, workspaceRoot: string) {
+  return (
+    <WorkspaceFilePreviewHeader
+      workspaceRoot={workspaceRoot}
+      filePath={filePath}
+      isMarkdown={false}
+      markdownPreviewEnabled={false}
+      onMarkdownPreviewChange={vi.fn()}
+    />
+  );
+}
+
+async function expectPathCopied(path: string): Promise<void> {
+  await vi.waitFor(() => {
+    expect(harness.toastAdd).toHaveBeenCalledWith({
+      type: "success",
+      title: "Path copied",
+      description: path,
+    });
+  });
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  harness.toastAdd.mockReset();
+  restoreProperty(navigator, "clipboard", originalClipboardDescriptor);
+  restoreProperty(document, "execCommand", originalExecCommandDescriptor);
+  vi.restoreAllMocks();
+});
+
+describe("copy-path actions", () => {
+  it("preserves a diff-relative path when the Clipboard API is unavailable", async () => {
+    setClipboard(undefined);
+    const execCommand = installSuccessfulFallbackCopy();
+    const path = "apps/web/src/example.ts";
+
+    await render(
+      <DiffPanelFileList
+        renderableFiles={[fileDiff(path)]}
+        resolvedTheme="light"
+        diffRenderMode="stacked"
+        diffWordWrap={false}
+        workspaceRoot="/workspace"
+        collapsedFiles={new Set()}
+        onToggleFileCollapsed={vi.fn()}
+        chatActions={{ onReferenceInChat: vi.fn(), onAskWhyChanged: vi.fn() }}
+      />,
+    );
+
+    await page.getByLabelText("File actions").click();
+    await page.getByText("Copy path").click();
+
+    await expectPathCopied(path);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("copies the resolved absolute workspace path after Clipboard API rejection", async () => {
+    const writeText = vi
+      .fn()
+      .mockRejectedValue(new DOMException("Document is not focused", "NotAllowedError"));
+    setClipboard({ writeText });
+    const execCommand = installSuccessfulFallbackCopy();
+    const expectedPath = "/workspace/apps/web/src/example.ts";
+
+    await render(workspaceFilePreviewHeader("apps/web/src/example.ts", "/workspace"));
+
+    expect(page.getByTestId("open-in-target").element().textContent).toBe(expectedPath);
+    await page.getByLabelText("More actions").click();
+    await page.getByText("Copy path").click();
+
+    await expectPathCopied(expectedPath);
+    expect(writeText).toHaveBeenCalledWith(expectedPath);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("keeps the menu available when an outside-workspace path is its only action", async () => {
+    setClipboard(undefined);
+    const execCommand = installSuccessfulFallbackCopy();
+    const path = "/tmp/synara scratch/example.ts";
+
+    await render(workspaceFilePreviewHeader(path, "/workspace"));
+
+    expect(page.getByTestId("open-in-target").element().textContent).toBe(path);
+    await page.getByLabelText("More actions").click();
+    await page.getByText("Copy path").click();
+
+    await expectPathCopied(path);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+});

--- a/apps/web/src/components/DiffPanelFileList.tsx
+++ b/apps/web/src/components/DiffPanelFileList.tsx
@@ -5,6 +5,7 @@
 import type { FileDiffMetadata } from "@pierre/diffs/react";
 import { isSupportedLocalImagePath } from "@synara/shared/localPreviewFiles";
 import { type MouseEvent as ReactMouseEvent } from "react";
+import { useCopyPathToClipboard } from "~/hooks/useCopyToClipboard";
 import { ChevronDownIcon, CopyIcon, EllipsisIcon, MessageCircleIcon } from "~/lib/icons";
 
 import { buildFileDiffRenderKey, resolveFileDiffPath } from "~/lib/diffRendering";
@@ -28,6 +29,8 @@ const DIFF_FILE_ACTIONS_MENU_ICON_CLASS_NAME = "size-3.5 shrink-0 text-muted-for
 // the collapse chevron. Marked with data-diff-header-menu so header clicks on
 // it do not toggle the file collapse state.
 function DiffFileHeaderActionsMenu(props: { filePath: string; chatActions: DiffFileChatActions }) {
+  const copyPathToClipboard = useCopyPathToClipboard();
+
   return (
     <Menu>
       <MenuTrigger
@@ -60,11 +63,7 @@ function DiffFileHeaderActionsMenu(props: { filePath: string; chatActions: DiffF
           <MessageCircleIcon className={DIFF_FILE_ACTIONS_MENU_ICON_CLASS_NAME} />
           <span>Ask why this changed</span>
         </MenuItem>
-        <MenuItem
-          onClick={() => {
-            void navigator.clipboard?.writeText(props.filePath);
-          }}
-        >
+        <MenuItem onClick={() => copyPathToClipboard(props.filePath)}>
           <CopyIcon className={DIFF_FILE_ACTIONS_MENU_ICON_CLASS_NAME} />
           <span>Copy path</span>
         </MenuItem>

--- a/apps/web/src/components/chat/WorkspaceFilePreviewHeader.tsx
+++ b/apps/web/src/components/chat/WorkspaceFilePreviewHeader.tsx
@@ -17,10 +17,7 @@ import { isWorkspaceRelativePathSafe, joinWorkspaceRelativePath } from "@synara/
 import { Fragment, useLayoutEffect, useRef, useState } from "react";
 
 import { basenameOfPath } from "~/file-icons";
-import {
-  useCopyFileContentsToClipboard,
-  useCopyPathToClipboard,
-} from "~/hooks/useCopyToClipboard";
+import { useCopyFileContentsToClipboard, useCopyPathToClipboard } from "~/hooks/useCopyToClipboard";
 import type { ChatFileReference } from "~/lib/chatReferences";
 import { ChevronRightIcon, CodeIcon, CopyIcon, EllipsisIcon, EyeOpenIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";

--- a/apps/web/src/components/chat/WorkspaceFilePreviewHeader.tsx
+++ b/apps/web/src/components/chat/WorkspaceFilePreviewHeader.tsx
@@ -17,9 +17,12 @@ import { isWorkspaceRelativePathSafe, joinWorkspaceRelativePath } from "@synara/
 import { Fragment, useLayoutEffect, useRef, useState } from "react";
 
 import { basenameOfPath } from "~/file-icons";
-import { useCopyFileContentsToClipboard } from "~/hooks/useCopyToClipboard";
+import {
+  useCopyFileContentsToClipboard,
+  useCopyPathToClipboard,
+} from "~/hooks/useCopyToClipboard";
 import type { ChatFileReference } from "~/lib/chatReferences";
-import { ChevronRightIcon, CodeIcon, EllipsisIcon, EyeOpenIcon } from "~/lib/icons";
+import { ChevronRightIcon, CodeIcon, CopyIcon, EllipsisIcon, EyeOpenIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
 import { Menu, MenuItem, MenuTrigger } from "../ui/menu";
 import { CHAT_SURFACE_HEADER_DIVIDER_CLASS_NAME, ChatHeaderIconButton } from "./chatHeaderControls";
@@ -260,9 +263,13 @@ export const WorkspaceFilePreviewHeader = function WorkspaceFilePreviewHeader(
     onAskWhyInChat?.({ path: filePath });
   };
   const copyFileContents = useCopyFileContentsToClipboard();
+  const copyPathToClipboard = useCopyPathToClipboard();
 
   const canCopyContents = contentsForCopy != null;
-  const hasOverflowMenu = canCopyContents || Boolean(onReferenceInChat || onAskWhyInChat);
+  const openInTarget =
+    fileIsOutsideWorkspace || !workspaceRoot
+      ? filePath
+      : joinWorkspaceRelativePath(workspaceRoot, filePath);
 
   return (
     <div
@@ -323,43 +330,39 @@ export const WorkspaceFilePreviewHeader = function WorkspaceFilePreviewHeader(
           </div>
         ) : null}
 
-        {hasOverflowMenu ? (
-          <Menu>
-            <MenuTrigger render={<ChatHeaderIconButton label="More actions" tone="plain" />}>
-              <EllipsisIcon aria-hidden="true" className="size-3.5" />
-            </MenuTrigger>
-            <ComposerPickerMenuPopup align="end" side="bottom" className="w-52 min-w-52">
-              {canCopyContents ? (
-                <MenuItem
-                  onClick={() =>
-                    copyFileContents(contentsForCopy ?? "", fileSegment, {
-                      partial: props.truncated ?? false,
-                    })
-                  }
-                >
-                  Copy contents
-                </MenuItem>
-              ) : null}
-              {onReferenceInChat ? (
-                <MenuItem onClick={referenceWholeFile}>Reference in chat</MenuItem>
-              ) : null}
-              {onAskWhyInChat ? (
-                <MenuItem onClick={askWhyWholeFile}>Ask why this changed</MenuItem>
-              ) : null}
-            </ComposerPickerMenuPopup>
-          </Menu>
-        ) : null}
+        <Menu>
+          <MenuTrigger render={<ChatHeaderIconButton label="More actions" tone="plain" />}>
+            <EllipsisIcon aria-hidden="true" className="size-3.5" />
+          </MenuTrigger>
+          <ComposerPickerMenuPopup align="end" side="bottom" className="w-52 min-w-52">
+            <MenuItem onClick={() => copyPathToClipboard(openInTarget)}>
+              <CopyIcon className="size-3.5 shrink-0 text-muted-foreground" />
+              <span>Copy path</span>
+            </MenuItem>
+            {canCopyContents ? (
+              <MenuItem
+                onClick={() =>
+                  copyFileContents(contentsForCopy ?? "", fileSegment, {
+                    partial: props.truncated ?? false,
+                  })
+                }
+              >
+                Copy contents
+              </MenuItem>
+            ) : null}
+            {onReferenceInChat ? (
+              <MenuItem onClick={referenceWholeFile}>Reference in chat</MenuItem>
+            ) : null}
+            {onAskWhyInChat ? (
+              <MenuItem onClick={askWhyWholeFile}>Ask why this changed</MenuItem>
+            ) : null}
+          </ComposerPickerMenuPopup>
+        </Menu>
 
         {/* Responsive (default) mode: the "Open" label rides the same
             `header-actions` container declared on this header, so it shows on a
             wide pane and collapses to the editor icon when the pane is narrow. */}
-        <OpenInPicker
-          openInTarget={
-            fileIsOutsideWorkspace || !workspaceRoot
-              ? filePath
-              : joinWorkspaceRelativePath(workspaceRoot, filePath)
-          }
-        />
+        <OpenInPicker openInTarget={openInTarget} />
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #803
Closes #804

Stacked on #825 (base: codex/issue-802-finder-reveal).

Summary:
- route the diff menu through the shared path-copy helper while preserving its repository-relative path
- add Copy path to the file-preview overflow menu using the same absolute target as Open in
- keep the preview menu available when Copy path is its only action
- cover unavailable and rejected Clipboard API paths, fallback behavior, and in/out-of-workspace targets

Verification:
- bun run --cwd apps/web test:browser src/components/CopyPathActions.browser.tsx
- bun run --cwd apps/web test src/hooks/useCopyToClipboard.test.ts
- git diff --cached --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only clipboard and menu behavior with existing shared hook; covered by new browser tests.
> 
> **Overview**
> **Copy path** in the diff panel and file-preview header now goes through `useCopyPathToClipboard` instead of calling `navigator.clipboard` directly, so users get the same success/error toasts and `execCommand` fallback when the Clipboard API is missing or rejected.
> 
> In the **diff file actions** menu, the copied string stays the repository-relative path. In the **workspace file preview** header, a new **Copy path** item copies the same resolved target as **Open in** (absolute path under the workspace root, or the raw path when outside the workspace). The preview overflow menu is always shown so **Copy path** remains available even when it is the only action (e.g. scratch files outside the workspace).
> 
> Adds browser tests in `CopyPathActions.browser.tsx` for relative diff paths, clipboard rejection, and in/out-of-workspace targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9552427b422243892d9c1e1c3eaca3e2861e6eee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->