### PR TITLE
fix: gracefully stop POSIX backend before updates

### DIFF
--- a/apps/desktop/src/backendShutdown.posix.integration.test.ts
+++ b/apps/desktop/src/backendShutdown.posix.integration.test.ts
@@ -1,0 +1,169 @@
+import * as ChildProcess from "node:child_process";
+import * as Crypto from "node:crypto";
+import * as Fs from "node:fs";
+import * as FsPromises from "node:fs/promises";
+import * as OS from "node:os";
+import * as Path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { stopPosixBackendAndWait, type BackendShutdownProcess } from "./backendShutdown";
+
+const FIXTURE_PATH = fileURLToPath(new URL("./fixtures/posixBackendShutdown.mjs", import.meta.url));
+const describePosix = process.platform === "win32" ? describe.skip : describe;
+
+interface FixtureState {
+  readonly port: number;
+  readonly providerPid: number | null;
+}
+
+function hasExited(child: ChildProcess.ChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+function processIsRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+async function waitFor<T>(
+  read: () => T | null,
+  timeoutMs: number,
+  description: string,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = read();
+    if (value !== null) return value;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out waiting for ${description}.`);
+}
+
+async function readFixtureState(path: string): Promise<FixtureState> {
+  return await waitFor(
+    () => {
+      try {
+        return JSON.parse(Fs.readFileSync(path, "utf8")) as FixtureState;
+      } catch {
+        return null;
+      }
+    },
+    5_000,
+    "the POSIX backend fixture",
+  );
+}
+
+async function stopOwnedProcess(pid: number | null | undefined): Promise<void> {
+  if (!pid || !processIsRunning(pid)) return;
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+    throw error;
+  }
+  await waitFor(() => (processIsRunning(pid) ? null : true), 2_000, `process ${pid} exit`);
+}
+
+async function disposeFixture(
+  child: ChildProcess.ChildProcess,
+  providerPid: number | null,
+): Promise<void> {
+  if (!hasExited(child)) {
+    const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+    child.kill("SIGKILL");
+    await exited;
+  }
+  await stopOwnedProcess(providerPid);
+  child.stderr?.destroy();
+}
+
+function launchFixture(input: {
+  readonly mode: "graceful" | "stubborn";
+  readonly shutdownToken: string;
+  readonly readyPath: string;
+  readonly signalPath: string;
+}): ChildProcess.ChildProcess {
+  return ChildProcess.spawn(
+    process.execPath,
+    [FIXTURE_PATH, input.mode, input.shutdownToken, input.readyPath, input.signalPath],
+    { stdio: ["ignore", "ignore", "pipe"] },
+  );
+}
+
+describePosix("POSIX desktop backend shutdown integration", () => {
+  it("reaps an owned provider descendant through the authenticated graceful path", async () => {
+    const directory = await FsPromises.mkdtemp(Path.join(OS.tmpdir(), "synara-posix-shutdown-"));
+    const readyPath = Path.join(directory, "ready.json");
+    const signalPath = Path.join(directory, "signals.log");
+    const shutdownToken = Crypto.randomBytes(32).toString("hex");
+    const child = launchFixture({ mode: "graceful", shutdownToken, readyPath, signalPath });
+    let providerPid: number | null = null;
+
+    try {
+      const state = await readFixtureState(readyPath);
+      providerPid = state.providerPid;
+      expect(providerPid).not.toBeNull();
+
+      await expect(
+        stopPosixBackendAndWait({
+          child: child as BackendShutdownProcess,
+          backendHttpUrl: `http://127.0.0.1:${state.port}`,
+          shutdownToken,
+          terminateDelayMs: 1_000,
+          forceKillDelayMs: 2_000,
+          timeoutMs: 3_000,
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(child.exitCode).toBe(0);
+      expect(child.signalCode).toBeNull();
+      await waitFor(
+        () => (providerPid !== null && !processIsRunning(providerPid) ? true : null),
+        2_000,
+        "the provider descendant to exit",
+      );
+      expect(await FsPromises.readFile(signalPath, "utf8")).toBe("PROVIDER_SIGTERM\n");
+    } finally {
+      await disposeFixture(child, providerPid);
+      await FsPromises.rm(directory, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it("bounds a stubborn backend with TERM followed by KILL", async () => {
+    const directory = await FsPromises.mkdtemp(Path.join(OS.tmpdir(), "synara-posix-stubborn-"));
+    const readyPath = Path.join(directory, "ready.json");
+    const signalPath = Path.join(directory, "signals.log");
+    const shutdownToken = Crypto.randomBytes(32).toString("hex");
+    const child = launchFixture({ mode: "stubborn", shutdownToken, readyPath, signalPath });
+
+    try {
+      const state = await readFixtureState(readyPath);
+      const startedAt = performance.now();
+
+      await expect(
+        stopPosixBackendAndWait({
+          child: child as BackendShutdownProcess,
+          backendHttpUrl: `http://127.0.0.1:${state.port}`,
+          shutdownToken,
+          terminateDelayMs: 100,
+          forceKillDelayMs: 250,
+          timeoutMs: 1_000,
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(performance.now() - startedAt).toBeLessThan(1_000);
+      expect(child.exitCode).toBeNull();
+      expect(child.signalCode).toBe("SIGKILL");
+      expect(await FsPromises.readFile(signalPath, "utf8")).toBe("SIGTERM\n");
+    } finally {
+      await disposeFixture(child, null);
+      await FsPromises.rm(directory, { recursive: true, force: true });
+    }
+  }, 15_000);
+});

--- a/apps/desktop/src/backendShutdown.test.ts
+++ b/apps/desktop/src/backendShutdown.test.ts
@@ -122,6 +122,65 @@ describe("stopPosixBackendAndWait", () => {
     expect(pendingRequest.cancel).toHaveBeenCalledOnce();
   });
 
+  it("retries transport failures while the backend is still starting", async () => {
+    const child = makeTestBackendShutdownProcess();
+    const failedRequest = makePendingRequest(Promise.resolve({ type: "error" }));
+    const acceptedRequest = makePendingRequest(
+      Promise.resolve({ type: "response", statusCode: 202 }),
+    );
+    const startRequest = vi
+      .fn()
+      .mockReturnValueOnce(failedRequest)
+      .mockImplementationOnce(() => {
+        child.exit(0);
+        return acceptedRequest;
+      });
+    const shutdown = stopPosixBackendAndWait({
+      child,
+      backendHttpUrl: "http://127.0.0.1:3773",
+      shutdownToken: "desktop-only-token",
+      terminateDelayMs: 6_000,
+      forceKillDelayMs: 8_000,
+      timeoutMs: 10_000,
+      startRequest,
+    });
+
+    await vi.advanceTimersByTimeAsync(249);
+    expect(startRequest).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(shutdown).resolves.toBeUndefined();
+    expect(startRequest).toHaveBeenCalledTimes(2);
+    expect(child.killSignals).toEqual([]);
+    expect(acceptedRequest.cancel).toHaveBeenCalledOnce();
+  });
+
+  it("stops retrying transport failures when TERM fallback begins", async () => {
+    const child = makeTestBackendShutdownProcess();
+    child.exitOnKill = true;
+    const startRequest = vi.fn(() => makePendingRequest(Promise.resolve({ type: "error" })));
+    const shutdown = stopPosixBackendAndWait({
+      child,
+      backendHttpUrl: "http://127.0.0.1:3773",
+      shutdownToken: "desktop-only-token",
+      terminateDelayMs: 600,
+      forceKillDelayMs: 800,
+      timeoutMs: 1_000,
+      startRequest,
+    });
+
+    await vi.advanceTimersByTimeAsync(599);
+    expect(startRequest).toHaveBeenCalledTimes(3);
+    expect(child.killSignals).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(shutdown).resolves.toBeUndefined();
+    expect(startRequest).toHaveBeenCalledTimes(3);
+    expect(child.killSignals).toEqual(["SIGTERM"]);
+  });
+
   it("escalates from graceful shutdown to TERM and KILL while still requiring exit", async () => {
     const child = makeTestBackendShutdownProcess();
     const shutdown = stopPosixBackendAndWait({

--- a/apps/desktop/src/backendShutdown.test.ts
+++ b/apps/desktop/src/backendShutdown.test.ts
@@ -94,33 +94,51 @@ describe("stopPosixBackendAndWait", () => {
     vi.useRealTimers();
   });
 
-  it("resolves only after the child exits", async () => {
+  it("requests graceful shutdown and resolves only after the child exits", async () => {
     const child = makeTestBackendShutdownProcess();
+    const pendingRequest = makePendingRequest(
+      Promise.resolve({ type: "response", statusCode: 202 }),
+    );
+    const startRequest = vi.fn(() => pendingRequest);
     const shutdown = stopPosixBackendAndWait({
       child,
+      backendHttpUrl: "http://127.0.0.1:3773",
+      shutdownToken: "desktop-only-token",
+      terminateDelayMs: 6_000,
       forceKillDelayMs: 8_000,
       timeoutMs: 10_000,
+      startRequest,
     });
 
-    expect(child.killSignals).toEqual(["SIGTERM"]);
-    await vi.advanceTimersByTimeAsync(7_999);
+    expect(startRequest).toHaveBeenCalledOnce();
+    expect(child.killSignals).toEqual([]);
+    await vi.advanceTimersByTimeAsync(5_999);
     await expectPromisePending(shutdown);
 
     child.exit(0);
 
     await expect(shutdown).resolves.toBeUndefined();
-    expect(child.killSignals).toEqual(["SIGTERM"]);
+    expect(child.killSignals).toEqual([]);
+    expect(pendingRequest.cancel).toHaveBeenCalledOnce();
   });
 
-  it("force-kills a surviving child and still requires an exit event", async () => {
+  it("escalates from graceful shutdown to TERM and KILL while still requiring exit", async () => {
     const child = makeTestBackendShutdownProcess();
     const shutdown = stopPosixBackendAndWait({
       child,
+      backendHttpUrl: "http://127.0.0.1:3773",
+      shutdownToken: "desktop-only-token",
+      terminateDelayMs: 6_000,
       forceKillDelayMs: 8_000,
       timeoutMs: 10_000,
+      startRequest: () => makePendingRequest(),
     });
 
-    await vi.advanceTimersByTimeAsync(8_000);
+    await vi.advanceTimersByTimeAsync(5_999);
+    expect(child.killSignals).toEqual([]);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(child.killSignals).toEqual(["SIGTERM"]);
+    await vi.advanceTimersByTimeAsync(2_000);
     expect(child.killSignals).toEqual(["SIGTERM", "SIGKILL"]);
     await expectPromisePending(shutdown);
 
@@ -132,8 +150,12 @@ describe("stopPosixBackendAndWait", () => {
     const child = makeTestBackendShutdownProcess();
     const shutdown = stopPosixBackendAndWait({
       child,
+      backendHttpUrl: "http://127.0.0.1:3773",
+      shutdownToken: "desktop-only-token",
+      terminateDelayMs: 6_000,
       forceKillDelayMs: 8_000,
       timeoutMs: 10_000,
+      startRequest: () => makePendingRequest(),
     });
 
     const rejection = expect(shutdown).rejects.toMatchObject({
@@ -149,14 +171,19 @@ describe("stopPosixBackendAndWait", () => {
     const child = makeTestBackendShutdownProcess();
     const input = {
       child,
+      backendHttpUrl: "http://127.0.0.1:3773",
+      shutdownToken: "desktop-only-token",
+      terminateDelayMs: 6_000,
       forceKillDelayMs: 8_000,
       timeoutMs: 10_000,
+      startRequest: vi.fn(() => makePendingRequest()),
     };
 
     const first = stopPosixBackendAndWait(input);
     const second = stopPosixBackendAndWait(input);
     expect(second).toBe(first);
-    expect(child.killSignals).toEqual(["SIGTERM"]);
+    expect(child.killSignals).toEqual([]);
+    expect(input.startRequest).toHaveBeenCalledOnce();
 
     child.exit(0);
     await expect(first).resolves.toBeUndefined();
@@ -168,6 +195,9 @@ describe("stopPosixBackendAndWait", () => {
     await expect(
       stopPosixBackendAndWait({
         child,
+        backendHttpUrl: "http://127.0.0.1:3773",
+        shutdownToken: "desktop-only-token",
+        terminateDelayMs: 8_000,
         forceKillDelayMs: 10_000,
         timeoutMs: 10_000,
       }),
@@ -179,13 +209,39 @@ describe("stopPosixBackendAndWait", () => {
     const child = makeTestBackendShutdownProcess();
     const shutdown = stopPosixBackendAndWait({
       child,
+      backendHttpUrl: "http://127.0.0.1:3773",
+      shutdownToken: "desktop-only-token",
+      terminateDelayMs: 6_000,
       forceKillDelayMs: 8_000,
       timeoutMs: 10_000,
+      startRequest: () => makePendingRequest(),
     });
 
     const rejection = expect(shutdown).rejects.toBeInstanceOf(PosixBackendShutdownTimeoutError);
     await vi.advanceTimersByTimeAsync(10_000);
     await rejection;
+  });
+
+  it("cancels a request created during a synchronous child-exit race", async () => {
+    const child = makeTestBackendShutdownProcess();
+    const pendingRequest = makePendingRequest();
+
+    const shutdown = stopPosixBackendAndWait({
+      child,
+      backendHttpUrl: "http://127.0.0.1:3773",
+      shutdownToken: "desktop-only-token",
+      terminateDelayMs: 6_000,
+      forceKillDelayMs: 8_000,
+      timeoutMs: 10_000,
+      startRequest: () => {
+        child.exit(0);
+        return pendingRequest;
+      },
+    });
+
+    await expect(shutdown).resolves.toBeUndefined();
+    expect(pendingRequest.cancel).toHaveBeenCalledOnce();
+    expect(child.killSignals).toEqual([]);
   });
 });
 

--- a/apps/desktop/src/backendShutdown.ts
+++ b/apps/desktop/src/backendShutdown.ts
@@ -191,8 +191,12 @@ function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
 
 function runPosixBackendShutdown(input: {
   readonly child: BackendShutdownProcess;
+  readonly backendHttpUrl: string;
+  readonly shutdownToken: string;
+  readonly terminateDelayMs: number;
   readonly forceKillDelayMs: number;
   readonly timeoutMs: number;
+  readonly startRequest: StartDesktopBackendShutdownRequest;
 }): Promise<void> {
   if (hasExited(input.child)) {
     return Promise.resolve();
@@ -201,13 +205,21 @@ function runPosixBackendShutdown(input: {
   return new Promise<void>((resolve, reject) => {
     let settled = false;
     let forced = false;
-    let forceTimer: ReturnType<typeof setTimeout> | null = null;
+    let pendingRequest: PendingDesktopBackendShutdownRequest | null = null;
+    let terminateTimer: ReturnType<typeof setTimeout> | null = null;
+    let forceKillTimer: ReturnType<typeof setTimeout> | null = null;
     let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
 
     const cleanup = (): void => {
       input.child.off("exit", onExit);
-      if (forceTimer) clearTimeout(forceTimer);
+      if (terminateTimer) clearTimeout(terminateTimer);
+      if (forceKillTimer) clearTimeout(forceKillTimer);
       if (deadlineTimer) clearTimeout(deadlineTimer);
+      try {
+        pendingRequest?.cancel();
+      } catch {
+        // Request cleanup must not delay or invalidate process-exit proof.
+      }
     };
     const settle = (error?: Error): void => {
       if (settled) return;
@@ -222,16 +234,18 @@ function runPosixBackendShutdown(input: {
     const onExit = (): void => {
       settle();
     };
-    const forceIfRunning = (): void => {
+    const signalIfRunning = (signal: "SIGTERM" | "SIGKILL"): void => {
       if (settled || hasExited(input.child)) {
         if (hasExited(input.child)) onExit();
         return;
       }
-      forced = true;
+      if (signal === "SIGKILL") {
+        forced = true;
+      }
       try {
-        input.child.kill("SIGKILL");
+        input.child.kill(signal);
       } catch {
-        // The absolute deadline below still fails closed if the process survives.
+        // Later escalation and the absolute deadline still bound shutdown.
       }
       if (hasExited(input.child)) {
         onExit();
@@ -240,9 +254,19 @@ function runPosixBackendShutdown(input: {
 
     input.child.once("exit", onExit);
     try {
-      input.child.kill("SIGTERM");
+      pendingRequest = input.startRequest({
+        backendHttpUrl: input.backendHttpUrl,
+        shutdownToken: input.shutdownToken,
+      });
+      if (settled) {
+        pendingRequest.cancel();
+        return;
+      }
+      void pendingRequest.outcome.catch(() => {
+        // Transport failure cannot shorten or reset the fallback schedule.
+      });
     } catch {
-      // A failed graceful signal still gets the bounded force-kill attempt.
+      pendingRequest = null;
     }
 
     if (hasExited(input.child)) {
@@ -250,14 +274,17 @@ function runPosixBackendShutdown(input: {
       return;
     }
 
-    if (input.forceKillDelayMs === 0) {
-      forceIfRunning();
+    if (input.terminateDelayMs === 0) {
+      signalIfRunning("SIGTERM");
     } else {
-      forceTimer = setTimeout(forceIfRunning, input.forceKillDelayMs);
-      unrefTimer(forceTimer);
+      terminateTimer = setTimeout(() => signalIfRunning("SIGTERM"), input.terminateDelayMs);
+      unrefTimer(terminateTimer);
     }
 
     if (settled) return;
+
+    forceKillTimer = setTimeout(() => signalIfRunning("SIGKILL"), input.forceKillDelayMs);
+    unrefTimer(forceKillTimer);
 
     deadlineTimer = setTimeout(() => {
       if (hasExited(input.child)) {
@@ -271,30 +298,47 @@ function runPosixBackendShutdown(input: {
 }
 
 /**
- * Stops a macOS/Linux backend and resolves only after the OS reports child exit.
- * A signal being sent is not proof of exit: updater handoff must fail closed or
- * a surviving old backend can retain the database lifecycle lock.
+ * Requests scoped macOS/Linux backend shutdown, then escalates to TERM and KILL.
+ * Resolves only after the OS reports child exit: a response or sent signal is not
+ * proof that provider descendants were finalized before updater handoff.
  */
 export function stopPosixBackendAndWait(input: {
   readonly child: BackendShutdownProcess;
+  readonly backendHttpUrl: string;
+  readonly shutdownToken: string;
+  readonly terminateDelayMs: number;
   readonly forceKillDelayMs: number;
   readonly timeoutMs: number;
+  readonly startRequest?: StartDesktopBackendShutdownRequest;
 }): Promise<void> {
+  if (!Number.isFinite(input.terminateDelayMs) || input.terminateDelayMs < 0) {
+    return Promise.reject(new RangeError("terminateDelayMs must be a non-negative number."));
+  }
   if (!Number.isFinite(input.forceKillDelayMs) || input.forceKillDelayMs < 0) {
     return Promise.reject(new RangeError("forceKillDelayMs must be a non-negative number."));
   }
   if (!Number.isFinite(input.timeoutMs) || input.timeoutMs <= 0) {
     return Promise.reject(new RangeError("timeoutMs must be a positive number."));
   }
-  if (input.forceKillDelayMs >= input.timeoutMs) {
-    return Promise.reject(new RangeError("forceKillDelayMs must be less than timeoutMs."));
+  if (
+    input.terminateDelayMs >= input.forceKillDelayMs ||
+    input.forceKillDelayMs >= input.timeoutMs
+  ) {
+    return Promise.reject(
+      new RangeError(
+        "Shutdown delays must satisfy terminateDelayMs < forceKillDelayMs < timeoutMs.",
+      ),
+    );
   }
 
   const key = input.child as object;
   const existing = posixShutdownsByProcess.get(key);
   if (existing) return existing;
 
-  const shutdown = runPosixBackendShutdown(input).finally(() => {
+  const shutdown = runPosixBackendShutdown({
+    ...input,
+    startRequest: input.startRequest ?? startDesktopBackendShutdownRequest,
+  }).finally(() => {
     if (posixShutdownsByProcess.get(key) === shutdown) {
       posixShutdownsByProcess.delete(key);
     }

--- a/apps/desktop/src/backendShutdown.ts
+++ b/apps/desktop/src/backendShutdown.ts
@@ -86,6 +86,7 @@ export function shouldDeferDesktopWindowClose(input: {
 
 const shutdownsByProcess = new WeakMap<object, Promise<WindowsBackendShutdownResult>>();
 const posixShutdownsByProcess = new WeakMap<object, Promise<void>>();
+const POSIX_SHUTDOWN_REQUEST_RETRY_DELAY_MS = 250;
 
 function isLoopbackShutdownUrl(url: URL): boolean {
   return (
@@ -205,13 +206,16 @@ function runPosixBackendShutdown(input: {
   return new Promise<void>((resolve, reject) => {
     let settled = false;
     let forced = false;
+    let terminationStarted = false;
     let pendingRequest: PendingDesktopBackendShutdownRequest | null = null;
+    let requestRetryTimer: ReturnType<typeof setTimeout> | null = null;
     let terminateTimer: ReturnType<typeof setTimeout> | null = null;
     let forceKillTimer: ReturnType<typeof setTimeout> | null = null;
     let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
 
     const cleanup = (): void => {
       input.child.off("exit", onExit);
+      if (requestRetryTimer) clearTimeout(requestRetryTimer);
       if (terminateTimer) clearTimeout(terminateTimer);
       if (forceKillTimer) clearTimeout(forceKillTimer);
       if (deadlineTimer) clearTimeout(deadlineTimer);
@@ -239,6 +243,13 @@ function runPosixBackendShutdown(input: {
         if (hasExited(input.child)) onExit();
         return;
       }
+      if (signal === "SIGTERM") {
+        terminationStarted = true;
+        if (requestRetryTimer) {
+          clearTimeout(requestRetryTimer);
+          requestRetryTimer = null;
+        }
+      }
       if (signal === "SIGKILL") {
         forced = true;
       }
@@ -251,23 +262,43 @@ function runPosixBackendShutdown(input: {
         onExit();
       }
     };
-
-    input.child.once("exit", onExit);
-    try {
-      pendingRequest = input.startRequest({
-        backendHttpUrl: input.backendHttpUrl,
-        shutdownToken: input.shutdownToken,
-      });
-      if (settled) {
-        pendingRequest.cancel();
+    const scheduleRequestRetry = (): void => {
+      if (settled || terminationStarted || hasExited(input.child) || requestRetryTimer) return;
+      requestRetryTimer = setTimeout(() => {
+        requestRetryTimer = null;
+        startRequestAttempt();
+      }, POSIX_SHUTDOWN_REQUEST_RETRY_DELAY_MS);
+      unrefTimer(requestRetryTimer);
+    };
+    const startRequestAttempt = (): void => {
+      if (settled || terminationStarted || hasExited(input.child)) return;
+      let request: PendingDesktopBackendShutdownRequest;
+      try {
+        request = input.startRequest({
+          backendHttpUrl: input.backendHttpUrl,
+          shutdownToken: input.shutdownToken,
+        });
+      } catch {
+        scheduleRequestRetry();
         return;
       }
-      void pendingRequest.outcome.catch(() => {
-        // Transport failure cannot shorten or reset the fallback schedule.
-      });
-    } catch {
-      pendingRequest = null;
-    }
+      if (settled) {
+        request.cancel();
+        return;
+      }
+      pendingRequest = request;
+      void request.outcome.then(
+        (outcome) => {
+          if (outcome.type === "error") {
+            scheduleRequestRetry();
+          }
+        },
+        () => scheduleRequestRetry(),
+      );
+    };
+
+    input.child.once("exit", onExit);
+    startRequestAttempt();
 
     if (hasExited(input.child)) {
       onExit();

--- a/apps/desktop/src/fixtures/posixBackendShutdown.mjs
+++ b/apps/desktop/src/fixtures/posixBackendShutdown.mjs
@@ -1,0 +1,101 @@
+import * as ChildProcess from "node:child_process";
+import * as Fs from "node:fs";
+import * as Http from "node:http";
+
+const [mode, shutdownToken, readyPath, signalPath] = process.argv.slice(2);
+
+if (!mode || !shutdownToken || !readyPath || !signalPath) {
+  throw new Error("Expected mode, shutdown token, ready path, and signal path.");
+}
+
+const writeSignal = (signal) => {
+  Fs.appendFileSync(signalPath, `${signal}\n`, "utf8");
+};
+
+if (mode === "stubborn") {
+  process.on("SIGTERM", () => writeSignal("SIGTERM"));
+}
+
+let provider = null;
+
+const spawnProvider = () =>
+  ChildProcess.spawn(
+    process.execPath,
+    [
+      "-e",
+      [
+        'const Fs = require("node:fs");',
+        `const signalPath = ${JSON.stringify(signalPath)};`,
+        'process.once("SIGTERM", () => {',
+        '  Fs.appendFileSync(signalPath, "PROVIDER_SIGTERM\\n", "utf8");',
+        "  process.exit(0);",
+        "});",
+        'process.send?.("ready");',
+        "setInterval(() => {}, 1_000);",
+      ].join("\n"),
+    ],
+    { stdio: ["ignore", "ignore", "ignore", "ipc"] },
+  );
+
+async function stopProvider() {
+  if (!provider || provider.exitCode !== null || provider.signalCode !== null) return;
+  const exited = new Promise((resolve) => provider.once("exit", () => resolve()));
+  provider.kill("SIGTERM");
+  await exited;
+}
+
+let shutdownStarted = false;
+const server = Http.createServer((request, response) => {
+  if (request.method !== "POST" || request.url !== "/api/desktop/shutdown") {
+    response.writeHead(404).end();
+    return;
+  }
+  if (request.headers.authorization !== `Bearer ${shutdownToken}`) {
+    response.writeHead(401).end();
+    return;
+  }
+
+  response.writeHead(202, { "Content-Type": "application/json" });
+  response.end('{"accepted":true}');
+  if (mode === "stubborn" || shutdownStarted) return;
+  shutdownStarted = true;
+  void stopProvider().then(() => server.close(() => process.exit(0)));
+});
+
+server.listen(0, "127.0.0.1", () => {
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Fixture did not receive a loopback port.");
+  }
+  const publishReady = () => {
+    try {
+      Fs.writeFileSync(
+        readyPath,
+        JSON.stringify({ port: address.port, providerPid: provider?.pid ?? null }),
+        "utf8",
+      );
+    } catch (error) {
+      provider?.kill("SIGKILL");
+      throw error;
+    }
+  };
+
+  if (mode !== "graceful") {
+    publishReady();
+    return;
+  }
+
+  provider = spawnProvider();
+  let providerReady = false;
+  const failBeforeReady = () => {
+    if (providerReady) return;
+    server.close(() => process.exit(1));
+  };
+  provider.once("error", failBeforeReady);
+  provider.once("exit", failBeforeReady);
+  provider.once("message", (message) => {
+    if (message !== "ready") return;
+    providerReady = true;
+    publishReady();
+  });
+});

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -333,6 +333,11 @@ const UPDATE_CHECK_REASON_MIGRATION_RECOVERY = "migration recovery";
 const UPDATE_INSTALL_MARKER_FILE_NAME = "pending-update-install.json";
 const BACKEND_FORCE_KILL_DELAY_MS = 8_000;
 const BACKEND_SHUTDOWN_TIMEOUT_MS = 10_000;
+// Provider finalizers stop every owned runtime concurrently, but POSIX leaves
+// extra headroom for the rest of the Effect scope to close cleanly.
+const POSIX_BACKEND_TERMINATE_DELAY_MS = 15_000;
+const POSIX_BACKEND_FORCE_KILL_DELAY_MS = 18_000;
+const POSIX_BACKEND_SHUTDOWN_TIMEOUT_MS = 20_000;
 const BACKEND_MAX_OLD_SPACE_ENV_KEYS = ["SYNARA_BACKEND_MAX_OLD_SPACE_MB"] as const;
 const DESKTOP_UPDATE_ALLOW_PRERELEASE = false;
 const BROWSER_PERF_SAMPLE_INTERVAL_MS = 5_000;
@@ -1382,13 +1387,7 @@ function handleFatalStartupError(stage: string, error: unknown): void {
     isQuitting = true;
     dialog.showErrorBox("Synara failed to start", `Stage: ${stage}\n${message}${detail}`);
   }
-  if (process.platform === "win32") {
-    requestGracefulAppQuit(`fatal startup (${stage})`);
-    return;
-  }
-  stopBackend();
-  restoreStdIoCapture?.();
-  app.quit();
+  requestGracefulAppQuit(`fatal startup (${stage})`);
 }
 
 function registerDesktopProtocol(): void {
@@ -3816,35 +3815,20 @@ function takeBackendProcessForShutdown(): ChildProcess.ChildProcess | null {
   return child;
 }
 
-function stopBackend(): void {
-  const child = takeBackendProcessForShutdown();
-  if (!child) return;
-
-  if (child.exitCode === null && child.signalCode === null) {
-    child.kill("SIGTERM");
-    setTimeout(() => {
-      if (child.exitCode === null && child.signalCode === null) {
-        child.kill("SIGKILL");
-      }
-    }, BACKEND_FORCE_KILL_DELAY_MS).unref();
-  }
-}
-
-async function stopBackendAndWaitForExit(timeoutMs = BACKEND_SHUTDOWN_TIMEOUT_MS): Promise<void> {
+async function stopBackendAndWaitForExit(): Promise<void> {
   const child = takeBackendProcessForShutdown();
   if (!child) return;
   const backendChild = child;
   if (backendChild.exitCode !== null || backendChild.signalCode !== null) return;
 
   if (process.platform === "win32") {
-    const forceKillDelayMs = Math.min(BACKEND_FORCE_KILL_DELAY_MS, Math.max(0, timeoutMs - 500));
     try {
       const result = await stopWindowsBackendAndWait({
         child: backendChild,
         backendHttpUrl,
         shutdownToken: DESKTOP_BACKEND_SHUTDOWN_TOKEN,
-        forceKillDelayMs,
-        timeoutMs,
+        forceKillDelayMs: BACKEND_FORCE_KILL_DELAY_MS,
+        timeoutMs: BACKEND_SHUTDOWN_TIMEOUT_MS,
       });
       requireWindowsBackendExit(result);
     } catch (error) {
@@ -3854,12 +3838,14 @@ async function stopBackendAndWaitForExit(timeoutMs = BACKEND_SHUTDOWN_TIMEOUT_MS
     return;
   }
 
-  const forceKillDelayMs = Math.min(BACKEND_FORCE_KILL_DELAY_MS, Math.max(0, timeoutMs - 500));
   try {
     await stopPosixBackendAndWait({
       child: backendChild,
-      forceKillDelayMs,
-      timeoutMs,
+      backendHttpUrl,
+      shutdownToken: DESKTOP_BACKEND_SHUTDOWN_TOKEN,
+      terminateDelayMs: POSIX_BACKEND_TERMINATE_DELAY_MS,
+      forceKillDelayMs: POSIX_BACKEND_FORCE_KILL_DELAY_MS,
+      timeoutMs: POSIX_BACKEND_SHUTDOWN_TIMEOUT_MS,
     });
   } catch (error) {
     backendProcess = retainLiveBackendAfterShutdownFailure(backendProcess, backendChild);

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -55,6 +55,7 @@ import {
 } from "../Services/ProviderAdapter.ts";
 import { appendFileAttachmentsPromptBlock } from "../attachmentProjection.ts";
 import { makeBoundedCallbackIngress } from "../boundedCallbackIngress.ts";
+import { settleConcurrentTeardowns } from "../settleConcurrentTeardowns.ts";
 import {
   compactProviderRuntimeEventForIngress,
   isTerminalProviderRuntimeEvent,
@@ -2431,11 +2432,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           }),
       });
 
-    const stopAll = () =>
-      Effect.forEach([...sessions.keys()], (threadId) => stopSession(threadId), {
-        concurrency: "unbounded",
-        discard: true,
-      }).pipe(Effect.asVoid);
+    const stopAll = () => settleConcurrentTeardowns(sessions.keys(), stopSession);
 
     yield* Effect.addFinalizer(() =>
       stopAll().pipe(

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -100,6 +100,7 @@ import {
   withAgentGatewayTurnCancellation,
 } from "../../agentGateway/sessionLease.ts";
 import { resolveProviderAttachmentPath } from "../providerAttachmentPaths.ts";
+import { settleConcurrentTeardowns } from "../settleConcurrentTeardowns.ts";
 import { ServerConfig } from "../../config.ts";
 import { buildFileAttachmentsPromptBlock } from "../attachmentProjection.ts";
 import { loadClaudeAgentSdk } from "../claudeAgentSdk.ts";
@@ -6236,40 +6237,32 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
       } satisfies ProviderListSkillsResult);
 
     const stopAll: ClaudeAdapterShape["stopAll"] = () =>
-      Effect.gen(function* () {
-        yield* Effect.forEach(
-          sessions,
-          ([, context]) =>
-            stopSessionInternal(context, {
-              emitExitEvent: true,
-            }),
-          { discard: true },
-        );
-        yield* Effect.forEach(
-          failedStartupProcessOwners,
-          ([threadId, owner]) => teardownFailedStartupProcess(threadId, owner),
-          { discard: true },
-        );
-        yield* teardownFailedDiscoveryProcesses();
-      });
+      settleConcurrentTeardowns(
+        [
+          settleConcurrentTeardowns([...sessions.values()], (context) =>
+            stopSessionInternal(context, { emitExitEvent: true }),
+          ),
+          settleConcurrentTeardowns([...failedStartupProcessOwners], ([threadId, owner]) =>
+            teardownFailedStartupProcess(threadId, owner),
+          ),
+          teardownFailedDiscoveryProcesses(),
+        ],
+        (teardown) => teardown,
+      );
 
     yield* Effect.addFinalizer(() =>
-      Effect.gen(function* () {
-        yield* Effect.forEach(
-          sessions,
-          ([, context]) =>
-            stopSessionInternal(context, {
-              emitExitEvent: false,
-            }),
-          { discard: true },
-        );
-        yield* Effect.forEach(
-          failedStartupProcessOwners,
-          ([threadId, owner]) => teardownFailedStartupProcess(threadId, owner),
-          { discard: true },
-        );
-        yield* teardownFailedDiscoveryProcesses();
-      }).pipe(Effect.ignore, Effect.andThen(Queue.shutdown(runtimeEventQueue))),
+      settleConcurrentTeardowns(
+        [
+          settleConcurrentTeardowns([...sessions.values()], (context) =>
+            stopSessionInternal(context, { emitExitEvent: false }),
+          ),
+          settleConcurrentTeardowns([...failedStartupProcessOwners], ([threadId, owner]) =>
+            teardownFailedStartupProcess(threadId, owner),
+          ),
+          teardownFailedDiscoveryProcesses(),
+        ],
+        (teardown) => teardown,
+      ).pipe(Effect.ignore, Effect.andThen(Queue.shutdown(runtimeEventQueue))),
     );
 
     const composerCapabilities: ProviderComposerCapabilities = {

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -1806,8 +1806,7 @@ export function makeCursorAdapter(
         ),
       );
 
-    const stopAll: CursorAdapterShape["stopAll"] = () =>
-      settleConcurrentTeardowns(sessions.values(), stopSessionInternal);
+    const stopAll = () => settleConcurrentTeardowns(sessions.values(), stopSessionInternal);
 
     yield* Effect.addFinalizer(() =>
       stopAll().pipe(

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -57,6 +57,7 @@ import {
 import { ServerConfig, type ServerConfigShape } from "../../config.ts";
 import { appendFileAttachmentsPromptBlock } from "../attachmentProjection.ts";
 import { loadProviderPromptImageBlocks } from "../promptAttachments.ts";
+import { settleConcurrentTeardowns } from "../settleConcurrentTeardowns.ts";
 import {
   ProviderAdapterProcessError,
   ProviderAdapterRequestError,
@@ -1806,10 +1807,10 @@ export function makeCursorAdapter(
       );
 
     const stopAll: CursorAdapterShape["stopAll"] = () =>
-      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true });
+      settleConcurrentTeardowns(sessions.values(), stopSessionInternal);
 
     yield* Effect.addFinalizer(() =>
-      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true }).pipe(
+      stopAll().pipe(
         Effect.tap(() => PubSub.shutdown(runtimeEventPubSub)),
         Effect.tap(() => managedNativeEventLogger?.close() ?? Effect.void),
       ),

--- a/apps/server/src/provider/Layers/DroidAdapter.ts
+++ b/apps/server/src/provider/Layers/DroidAdapter.ts
@@ -2258,8 +2258,7 @@ export function makeDroidAdapter(
         ),
       );
 
-    const stopAll: DroidAdapterShape["stopAll"] = () =>
-      settleConcurrentTeardowns(sessions.values(), stopSessionInternal);
+    const stopAll = () => settleConcurrentTeardowns(sessions.values(), stopSessionInternal);
 
     yield* Effect.addFinalizer(() =>
       stopAll().pipe(

--- a/apps/server/src/provider/Layers/DroidAdapter.ts
+++ b/apps/server/src/provider/Layers/DroidAdapter.ts
@@ -56,6 +56,7 @@ import {
 import { ServerConfig, type ServerConfigShape } from "../../config.ts";
 import { appendFileAttachmentsPromptBlock } from "../attachmentProjection.ts";
 import { loadProviderPromptImageBlocks } from "../promptAttachments.ts";
+import { settleConcurrentTeardowns } from "../settleConcurrentTeardowns.ts";
 import { listFactoryPlugins, readFactoryPlugin } from "../FactoryPluginDiscovery.ts";
 import { readFactorySessionHistory } from "../FactorySessionHistory.ts";
 import { appendProviderReferencesPromptBlock } from "../promptReferenceProjection.ts";
@@ -2258,14 +2259,10 @@ export function makeDroidAdapter(
       );
 
     const stopAll: DroidAdapterShape["stopAll"] = () =>
-      Effect.forEach(Array.from(sessions.values()), (ctx) => stopSessionInternal(ctx), {
-        discard: true,
-      });
+      settleConcurrentTeardowns(sessions.values(), stopSessionInternal);
 
     yield* Effect.addFinalizer(() =>
-      Effect.forEach(Array.from(sessions.values()), (ctx) => stopSessionInternal(ctx), {
-        discard: true,
-      }).pipe(
+      stopAll().pipe(
         Effect.tap(() => PubSub.shutdown(runtimeEventPubSub)),
         Effect.tap(() => managedNativeEventLogger?.close() ?? Effect.void),
       ),

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -2651,8 +2651,7 @@ export function makeGrokAdapter(
         ),
       );
 
-    const stopAll: GrokAdapterShape["stopAll"] = () =>
-      settleConcurrentTeardowns(sessions.values(), stopSessionInternal);
+    const stopAll = () => settleConcurrentTeardowns(sessions.values(), stopSessionInternal);
 
     yield* Effect.addFinalizer(() =>
       stopAll().pipe(

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -64,6 +64,7 @@ import { ServerConfig, type ServerConfigShape } from "../../config.ts";
 import { buildProviderChildEnvironment } from "../../providerChildEnvironment.ts";
 import { appendFileAttachmentsPromptBlock } from "../attachmentProjection.ts";
 import { loadProviderPromptImageBlocks } from "../promptAttachments.ts";
+import { settleConcurrentTeardowns } from "../settleConcurrentTeardowns.ts";
 import {
   ProviderAdapterProcessError,
   ProviderAdapterRequestError,
@@ -2651,10 +2652,10 @@ export function makeGrokAdapter(
       );
 
     const stopAll: GrokAdapterShape["stopAll"] = () =>
-      Effect.forEach(Array.from(sessions.values()), stopSessionInternal, { discard: true });
+      settleConcurrentTeardowns(sessions.values(), stopSessionInternal);
 
     yield* Effect.addFinalizer(() =>
-      Effect.forEach(Array.from(sessions.values()), stopSessionInternal, { discard: true }).pipe(
+      stopAll().pipe(
         Effect.tap(() => PubSub.shutdown(runtimeEventPubSub)),
         Effect.tap(() => managedNativeEventLogger?.close() ?? Effect.void),
       ),

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -74,6 +74,7 @@ import {
 } from "../Services/ProviderAdapter.ts";
 import { appendFileAttachmentsPromptBlock } from "../attachmentProjection.ts";
 import { makeBoundedCallbackIngress } from "../boundedCallbackIngress.ts";
+import { settleConcurrentTeardowns } from "../settleConcurrentTeardowns.ts";
 import { classifyPiTurnFailure } from "../piTurnFailure.ts";
 import {
   compactProviderRuntimeEventForIngress,
@@ -2718,10 +2719,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       );
 
     const stopAll: PiAdapterShape["stopAll"] = () =>
-      Effect.forEach(Array.from(sessions.keys()), (threadId) => stopSession(threadId), {
-        concurrency: "unbounded",
-        discard: true,
-      }).pipe(Effect.asVoid);
+      settleConcurrentTeardowns(sessions.keys(), stopSession);
 
     const listModels: NonNullable<PiAdapterShape["listModels"]> = (input) =>
       Effect.tryPromise({

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -612,7 +612,8 @@ type ShutdownCursorOrderingScenario =
   | "ignored-runtime-event"
   | "cursorless-runtime-write"
   | "mid-list-runtime-write"
-  | "blocked-runtime-write";
+  | "blocked-runtime-write"
+  | "queued-runtime-write";
 
 function verifyShutdownCursorOrdering(scenario: ShutdownCursorOrderingScenario) {
   return Effect.gen(function* () {
@@ -636,16 +637,22 @@ function verifyShutdownCursorOrdering(scenario: ShutdownCursorOrderingScenario) 
         const directory = yield* ProviderSessionDirectory;
         return {
           ...directory,
-          getBinding: (threadId) =>
-            directory
-              .getBinding(threadId)
-              .pipe(
-                Effect.tap(() =>
-                  scenario === "ignored-runtime-event" && shutdownStarted
-                    ? Deferred.succeed(runtimeEventObserved, undefined).pipe(Effect.asVoid)
-                    : Effect.void,
-                ),
+          getBinding: (threadId) => {
+            const read =
+              scenario === "queued-runtime-write" && shutdownRequested
+                ? Deferred.succeed(runtimeWriteStarted, undefined).pipe(
+                    Effect.andThen(Deferred.await(providerTeardownStarted)),
+                    Effect.andThen(directory.getBinding(threadId)),
+                  )
+                : directory.getBinding(threadId);
+            return read.pipe(
+              Effect.tap(() =>
+                scenario === "ignored-runtime-event" && shutdownStarted
+                  ? Deferred.succeed(runtimeEventObserved, undefined).pipe(Effect.asVoid)
+                  : Effect.void,
               ),
+            );
+          },
           listThreadIds: () =>
             Deferred.await(releaseStoppedSessionSweep).pipe(
               Effect.andThen(directory.listThreadIds()),
@@ -684,7 +691,8 @@ function verifyShutdownCursorOrdering(scenario: ShutdownCursorOrderingScenario) 
     const expectedCursor =
       scenario === "newer-runtime-write" ||
       scenario === "mid-list-runtime-write" ||
-      scenario === "blocked-runtime-write"
+      scenario === "blocked-runtime-write" ||
+      scenario === "queued-runtime-write"
         ? terminalCursor
         : shutdownSnapshotCursor;
     const registry: typeof ProviderAdapterRegistry.Service = {
@@ -714,7 +722,7 @@ function verifyShutdownCursorOrdering(scenario: ShutdownCursorOrderingScenario) 
       });
     };
 
-    if (scenario === "mid-list-runtime-write") {
+    if (scenario === "mid-list-runtime-write" || scenario === "queued-runtime-write") {
       const listSessions = codex.listSessions.getMockImplementation();
       assert.ok(listSessions);
       let emittedDuringShutdownList = false;
@@ -728,7 +736,9 @@ function verifyShutdownCursorOrdering(scenario: ShutdownCursorOrderingScenario) 
           const staleSessions = (yield* currentSessions).map((session) => ({ ...session }));
           updateSessionWithTerminalCursor();
           emitTerminalTurn();
-          yield* Deferred.await(runtimeEventObserved);
+          yield* Deferred.await(
+            scenario === "queued-runtime-write" ? runtimeWriteStarted : runtimeEventObserved,
+          );
           return staleSessions;
         });
       });
@@ -754,6 +764,9 @@ function verifyShutdownCursorOrdering(scenario: ShutdownCursorOrderingScenario) 
             payload: { exitKind: "graceful" },
           });
         } else if (scenario === "blocked-runtime-write") {
+          yield* Deferred.succeed(providerTeardownStarted, undefined);
+        } else if (scenario === "queued-runtime-write") {
+          yield* codex.stopSession(threadId);
           yield* Deferred.succeed(providerTeardownStarted, undefined);
         }
         yield* Deferred.await(runtimeEventObserved);
@@ -820,6 +833,10 @@ it.effect("ProviderServiceLive refreshes a session snapshot after a mid-list cur
 
 it.effect("ProviderServiceLive starts teardown while an earlier binding write is blocked", () =>
   verifyShutdownCursorOrdering("blocked-runtime-write"),
+);
+
+it.effect("ProviderServiceLive preserves a cursor from a writer queued before shutdown", () =>
+  verifyShutdownCursorOrdering("queued-runtime-write"),
 );
 
 it.effect(

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -611,7 +611,8 @@ type ShutdownCursorOrderingScenario =
   | "newer-runtime-write"
   | "ignored-runtime-event"
   | "cursorless-runtime-write"
-  | "mid-list-runtime-write";
+  | "mid-list-runtime-write"
+  | "blocked-runtime-write";
 
 function verifyShutdownCursorOrdering(scenario: ShutdownCursorOrderingScenario) {
   return Effect.gen(function* () {
@@ -624,6 +625,7 @@ function verifyShutdownCursorOrdering(scenario: ShutdownCursorOrderingScenario) 
     const directoryLayer = ProviderSessionDirectoryLive.pipe(Layer.provide(runtimeRepositoryLayer));
     const releaseStoppedSessionSweep = yield* Deferred.make<void>();
     const runtimeEventObserved = yield* Deferred.make<void>();
+    const runtimeWriteStarted = yield* Deferred.make<void>();
     const providerTeardownStarted = yield* Deferred.make<void>();
     let shutdownStarted = false;
     let shutdownRequested = false;
@@ -657,7 +659,12 @@ function verifyShutdownCursorOrdering(scenario: ShutdownCursorOrderingScenario) 
                 ? Deferred.await(providerTeardownStarted).pipe(
                     Effect.andThen(directory.upsert(binding)),
                   )
-                : directory.upsert(binding);
+                : scenario === "blocked-runtime-write" && lastRuntimeEvent === "turn.completed"
+                  ? Deferred.succeed(runtimeWriteStarted, undefined).pipe(
+                      Effect.andThen(Deferred.await(providerTeardownStarted)),
+                      Effect.andThen(directory.upsert(binding)),
+                    )
+                  : directory.upsert(binding);
             return persist.pipe(
               Effect.tap(() =>
                 scenario !== "ignored-runtime-event" && lastRuntimeEvent === "turn.completed"
@@ -675,7 +682,9 @@ function verifyShutdownCursorOrdering(scenario: ShutdownCursorOrderingScenario) 
     const shutdownSnapshotCursor = { resume: "shutdown-snapshot" };
     const terminalCursor = { resume: "terminal-cursor" };
     const expectedCursor =
-      scenario === "newer-runtime-write" || scenario === "mid-list-runtime-write"
+      scenario === "newer-runtime-write" ||
+      scenario === "mid-list-runtime-write" ||
+      scenario === "blocked-runtime-write"
         ? terminalCursor
         : shutdownSnapshotCursor;
     const registry: typeof ProviderAdapterRegistry.Service = {
@@ -744,6 +753,8 @@ function verifyShutdownCursorOrdering(scenario: ShutdownCursorOrderingScenario) 
             threadId,
             payload: { exitKind: "graceful" },
           });
+        } else if (scenario === "blocked-runtime-write") {
+          yield* Deferred.succeed(providerTeardownStarted, undefined);
         }
         yield* Deferred.await(runtimeEventObserved);
         yield* Deferred.succeed(releaseStoppedSessionSweep, undefined);
@@ -768,6 +779,11 @@ function verifyShutdownCursorOrdering(scenario: ShutdownCursorOrderingScenario) 
         resumeCursor: shutdownSnapshotCursor,
       }));
       yield* codex.waitForRuntimeSubscribers();
+      if (scenario === "blocked-runtime-write") {
+        updateSessionWithTerminalCursor();
+        emitTerminalTurn();
+        yield* Deferred.await(runtimeWriteStarted);
+      }
       shutdownRequested = true;
     }).pipe(Effect.provide(providerLayer));
 
@@ -800,6 +816,10 @@ it.effect("ProviderServiceLive preserves its snapshot across a cursorless shutdo
 
 it.effect("ProviderServiceLive refreshes a session snapshot after a mid-list cursor write", () =>
   verifyShutdownCursorOrdering("mid-list-runtime-write"),
+);
+
+it.effect("ProviderServiceLive starts teardown while an earlier binding write is blocked", () =>
+  verifyShutdownCursorOrdering("blocked-runtime-write"),
 );
 
 it.effect(
@@ -5362,6 +5382,40 @@ it.effect("ProviderServiceLive starts independent provider teardown concurrently
       20,
       "all provider teardown operations to start",
     ).pipe(Effect.ensuring(Deferred.succeed(releaseStops, undefined)));
+    yield* Fiber.join(closing);
+  }),
+);
+
+it.effect("ProviderServiceLive starts adapter teardown when a queued session refresh fails", () =>
+  Effect.gen(function* () {
+    const shutdown = makeProviderServiceLayer();
+    const scope = yield* Scope.make("sequential");
+    const services = yield* Layer.buildWithScope(shutdown.rawLayer, scope);
+    const provider = yield* Effect.service(ProviderService).pipe(Effect.provide(services));
+    const threadId = asThreadId("thread-stopall-refresh-failure");
+    const teardownStarted = yield* Deferred.make<void>();
+
+    yield* provider.startSession(threadId, {
+      provider: "codex",
+      threadId,
+      runtimeMode: "full-access",
+    });
+
+    const listSessions = shutdown.codex.listSessions.getMockImplementation();
+    assert.ok(listSessions);
+    let shutdownListCalls = 0;
+    shutdown.codex.listSessions.mockImplementation(() => {
+      shutdownListCalls += 1;
+      return shutdownListCalls === 2
+        ? Effect.fail(new ProviderAdapterSessionNotFoundError({ provider: "codex", threadId }))
+        : listSessions();
+    });
+    shutdown.codex.stopAll.mockImplementation(() =>
+      Deferred.succeed(teardownStarted, undefined).pipe(Effect.asVoid),
+    );
+
+    const closing = yield* Scope.close(scope, Exit.void).pipe(Effect.forkChild);
+    yield* Deferred.await(teardownStarted);
     yield* Fiber.join(closing);
   }),
 );

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -607,7 +607,13 @@ it.effect(
     }).pipe(Effect.provide(NodeServices.layer)),
 );
 
-function verifyShutdownCursorOrdering(scenario: "newer-runtime-write" | "ignored-runtime-event") {
+type ShutdownCursorOrderingScenario =
+  | "newer-runtime-write"
+  | "ignored-runtime-event"
+  | "cursorless-runtime-write"
+  | "mid-list-runtime-write";
+
+function verifyShutdownCursorOrdering(scenario: ShutdownCursorOrderingScenario) {
   return Effect.gen(function* () {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "synara-provider-stopall-race-"));
     const dbPath = path.join(tempDir, "orchestration.sqlite");
@@ -618,7 +624,9 @@ function verifyShutdownCursorOrdering(scenario: "newer-runtime-write" | "ignored
     const directoryLayer = ProviderSessionDirectoryLive.pipe(Layer.provide(runtimeRepositoryLayer));
     const releaseStoppedSessionSweep = yield* Deferred.make<void>();
     const runtimeEventObserved = yield* Deferred.make<void>();
+    const providerTeardownStarted = yield* Deferred.make<void>();
     let shutdownStarted = false;
+    let shutdownRequested = false;
 
     const delayedDirectoryLayer = Layer.effect(
       ProviderSessionDirectory,
@@ -640,18 +648,24 @@ function verifyShutdownCursorOrdering(scenario: "newer-runtime-write" | "ignored
             Deferred.await(releaseStoppedSessionSweep).pipe(
               Effect.andThen(directory.listThreadIds()),
             ),
-          upsert: (binding) =>
-            directory
-              .upsert(binding)
-              .pipe(
-                Effect.tap(() =>
-                  scenario === "newer-runtime-write" &&
-                  asRuntimePayloadRecord(binding.runtimePayload).lastRuntimeEvent ===
-                    "turn.completed"
-                    ? Deferred.succeed(runtimeEventObserved, undefined).pipe(Effect.asVoid)
-                    : Effect.void,
-                ),
+          upsert: (binding) => {
+            const lastRuntimeEvent = asRuntimePayloadRecord(
+              binding.runtimePayload,
+            ).lastRuntimeEvent;
+            const persist =
+              scenario === "cursorless-runtime-write" && lastRuntimeEvent === "provider.stopAll"
+                ? Deferred.await(providerTeardownStarted).pipe(
+                    Effect.andThen(directory.upsert(binding)),
+                  )
+                : directory.upsert(binding);
+            return persist.pipe(
+              Effect.tap(() =>
+                scenario !== "ignored-runtime-event" && lastRuntimeEvent === "turn.completed"
+                  ? Deferred.succeed(runtimeEventObserved, undefined).pipe(Effect.asVoid)
+                  : Effect.void,
               ),
+            );
+          },
         } satisfies ProviderSessionDirectoryShape;
       }),
     ).pipe(Layer.provide(directoryLayer));
@@ -661,7 +675,9 @@ function verifyShutdownCursorOrdering(scenario: "newer-runtime-write" | "ignored
     const shutdownSnapshotCursor = { resume: "shutdown-snapshot" };
     const terminalCursor = { resume: "terminal-cursor" };
     const expectedCursor =
-      scenario === "newer-runtime-write" ? terminalCursor : shutdownSnapshotCursor;
+      scenario === "newer-runtime-write" || scenario === "mid-list-runtime-write"
+        ? terminalCursor
+        : shutdownSnapshotCursor;
     const registry: typeof ProviderAdapterRegistry.Service = {
       getByProvider: (provider) =>
         provider === "codex"
@@ -670,31 +686,68 @@ function verifyShutdownCursorOrdering(scenario: "newer-runtime-write" | "ignored
       listProviders: () => Effect.succeed(["codex"]),
     };
 
+    const updateSessionWithTerminalCursor = (): void => {
+      codex.updateSession(threadId, (session) => ({
+        ...session,
+        status: "closed",
+        resumeCursor: terminalCursor,
+        updatedAt: new Date().toISOString(),
+      }));
+    };
+    const emitTerminalTurn = (): void => {
+      codex.emit({
+        type: "turn.completed",
+        eventId: asEventId("event-stopall-terminal-race"),
+        provider: "codex",
+        createdAt: new Date().toISOString(),
+        threadId,
+        payload: { state: "completed" },
+      });
+    };
+
+    if (scenario === "mid-list-runtime-write") {
+      const listSessions = codex.listSessions.getMockImplementation();
+      assert.ok(listSessions);
+      let emittedDuringShutdownList = false;
+      codex.listSessions.mockImplementation(() => {
+        const currentSessions = listSessions();
+        if (!shutdownRequested || emittedDuringShutdownList) {
+          return currentSessions;
+        }
+        emittedDuringShutdownList = true;
+        return Effect.gen(function* () {
+          const staleSessions = (yield* currentSessions).map((session) => ({ ...session }));
+          updateSessionWithTerminalCursor();
+          emitTerminalTurn();
+          yield* Deferred.await(runtimeEventObserved);
+          return staleSessions;
+        });
+      });
+    }
+
     codex.stopAll.mockImplementation(() =>
-      Effect.sync(() => {
+      Effect.gen(function* () {
         shutdownStarted = true;
         if (scenario === "newer-runtime-write") {
-          codex.updateSession(threadId, (session) => ({
-            ...session,
-            status: "closed",
-            resumeCursor: terminalCursor,
-            updatedAt: new Date().toISOString(),
-          }));
+          updateSessionWithTerminalCursor();
+          emitTerminalTurn();
+        } else if (scenario === "cursorless-runtime-write") {
+          yield* Deferred.succeed(providerTeardownStarted, undefined);
+          yield* codex.stopSession(threadId);
+          emitTerminalTurn();
+        } else if (scenario === "ignored-runtime-event") {
+          codex.emit({
+            type: "session.exited",
+            eventId: asEventId("event-stopall-terminal-race"),
+            provider: "claudeAgent",
+            createdAt: new Date().toISOString(),
+            threadId,
+            payload: { exitKind: "graceful" },
+          });
         }
-        codex.emit({
-          type: scenario === "newer-runtime-write" ? "turn.completed" : "session.exited",
-          eventId: asEventId("event-stopall-terminal-race"),
-          provider: scenario === "newer-runtime-write" ? "codex" : "claudeAgent",
-          createdAt: new Date().toISOString(),
-          threadId,
-          payload:
-            scenario === "newer-runtime-write" ? { state: "completed" } : { exitKind: "graceful" },
-        });
-      }).pipe(
-        Effect.andThen(Deferred.await(runtimeEventObserved)),
-        Effect.andThen(Deferred.succeed(releaseStoppedSessionSweep, undefined)),
-        Effect.asVoid,
-      ),
+        yield* Deferred.await(runtimeEventObserved);
+        yield* Deferred.succeed(releaseStoppedSessionSweep, undefined);
+      }),
     );
 
     const providerLayer = makeProviderServiceLive().pipe(
@@ -715,6 +768,7 @@ function verifyShutdownCursorOrdering(scenario: "newer-runtime-write" | "ignored
         resumeCursor: shutdownSnapshotCursor,
       }));
       yield* codex.waitForRuntimeSubscribers();
+      shutdownRequested = true;
     }).pipe(Effect.provide(providerLayer));
 
     const persisted = yield* Effect.gen(function* () {
@@ -738,6 +792,14 @@ it.effect("ProviderServiceLive preserves a terminal cursor newer than its shutdo
 
 it.effect("ProviderServiceLive retains its shutdown snapshot after an ignored runtime event", () =>
   verifyShutdownCursorOrdering("ignored-runtime-event"),
+);
+
+it.effect("ProviderServiceLive preserves its snapshot across a cursorless shutdown event", () =>
+  verifyShutdownCursorOrdering("cursorless-runtime-write"),
+);
+
+it.effect("ProviderServiceLive refreshes a session snapshot after a mid-list cursor write", () =>
+  verifyShutdownCursorOrdering("mid-list-runtime-write"),
 );
 
 it.effect(

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -613,7 +613,8 @@ type ShutdownCursorOrderingScenario =
   | "cursorless-runtime-write"
   | "mid-list-runtime-write"
   | "blocked-runtime-write"
-  | "queued-runtime-write";
+  | "queued-runtime-write"
+  | "late-nonterminal-runtime-write";
 
 function verifyShutdownCursorOrdering(scenario: ShutdownCursorOrderingScenario) {
   return Effect.gen(function* () {
@@ -627,6 +628,7 @@ function verifyShutdownCursorOrdering(scenario: ShutdownCursorOrderingScenario) 
     const releaseStoppedSessionSweep = yield* Deferred.make<void>();
     const runtimeEventObserved = yield* Deferred.make<void>();
     const runtimeWriteStarted = yield* Deferred.make<void>();
+    const runtimeCursorCaptureStarted = yield* Deferred.make<void>();
     const providerTeardownStarted = yield* Deferred.make<void>();
     let shutdownStarted = false;
     let shutdownRequested = false;
@@ -722,20 +724,46 @@ function verifyShutdownCursorOrdering(scenario: ShutdownCursorOrderingScenario) 
       });
     };
 
-    if (scenario === "mid-list-runtime-write" || scenario === "queued-runtime-write") {
+    if (
+      scenario === "mid-list-runtime-write" ||
+      scenario === "queued-runtime-write" ||
+      scenario === "late-nonterminal-runtime-write"
+    ) {
       const listSessions = codex.listSessions.getMockImplementation();
       assert.ok(listSessions);
       let emittedDuringShutdownList = false;
+      let runtimeCursorCapturePending = false;
       codex.listSessions.mockImplementation(() => {
         const currentSessions = listSessions();
+        if (runtimeCursorCapturePending) {
+          runtimeCursorCapturePending = false;
+          return Deferred.succeed(runtimeCursorCaptureStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(providerTeardownStarted)),
+            Effect.andThen(listSessions()),
+          );
+        }
         if (!shutdownRequested || emittedDuringShutdownList) {
           return currentSessions;
         }
         emittedDuringShutdownList = true;
         return Effect.gen(function* () {
           const staleSessions = (yield* currentSessions).map((session) => ({ ...session }));
-          updateSessionWithTerminalCursor();
-          emitTerminalTurn();
+          if (scenario === "late-nonterminal-runtime-write") {
+            runtimeCursorCapturePending = true;
+            codex.emit({
+              type: "turn.tasks.updated",
+              eventId: asEventId("event-stopall-late-nonterminal-race"),
+              provider: "codex",
+              createdAt: new Date().toISOString(),
+              threadId,
+              payload: { tasks: [{ task: "Finishing shutdown", status: "inProgress" }] },
+            });
+            yield* Deferred.await(runtimeCursorCaptureStarted);
+            return staleSessions;
+          } else {
+            updateSessionWithTerminalCursor();
+            emitTerminalTurn();
+          }
           yield* Deferred.await(
             scenario === "queued-runtime-write" ? runtimeWriteStarted : runtimeEventObserved,
           );
@@ -768,6 +796,11 @@ function verifyShutdownCursorOrdering(scenario: ShutdownCursorOrderingScenario) 
         } else if (scenario === "queued-runtime-write") {
           yield* codex.stopSession(threadId);
           yield* Deferred.succeed(providerTeardownStarted, undefined);
+        } else if (scenario === "late-nonterminal-runtime-write") {
+          yield* codex.stopSession(threadId);
+          yield* Deferred.succeed(providerTeardownStarted, undefined);
+          yield* Deferred.succeed(releaseStoppedSessionSweep, undefined);
+          return;
         }
         yield* Deferred.await(runtimeEventObserved);
         yield* Deferred.succeed(releaseStoppedSessionSweep, undefined);
@@ -837,6 +870,10 @@ it.effect("ProviderServiceLive starts teardown while an earlier binding write is
 
 it.effect("ProviderServiceLive preserves a cursor from a writer queued before shutdown", () =>
   verifyShutdownCursorOrdering("queued-runtime-write"),
+);
+
+it.effect("ProviderServiceLive keeps a late nonterminal shutdown write stopped", () =>
+  verifyShutdownCursorOrdering("late-nonterminal-runtime-write"),
 );
 
 it.effect(

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -54,7 +54,10 @@ import {
 import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
 import { ProviderAdapterRegistry } from "../Services/ProviderAdapterRegistry.ts";
 import { ProviderService } from "../Services/ProviderService.ts";
-import { ProviderSessionDirectory } from "../Services/ProviderSessionDirectory.ts";
+import {
+  ProviderSessionDirectory,
+  type ProviderSessionDirectoryShape,
+} from "../Services/ProviderSessionDirectory.ts";
 import {
   makeProviderServiceLive,
   PROVIDER_RUNTIME_QUARANTINE_CAUSE_MAX_BYTES,
@@ -530,7 +533,7 @@ it.effect("ProviderServiceLive keeps persisted resumable sessions on startup", (
 );
 
 it.effect(
-  "ProviderServiceLive persists active sessions as stopped before adapter cleanup runs",
+  "ProviderServiceLive persists active sessions as stopped when adapter cleanup fails",
   () =>
     Effect.gen(function* () {
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "synara-provider-service-stopall-"));
@@ -602,6 +605,139 @@ it.effect(
 
       fs.rmSync(tempDir, { recursive: true, force: true });
     }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+function verifyShutdownCursorOrdering(scenario: "newer-runtime-write" | "ignored-runtime-event") {
+  return Effect.gen(function* () {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "synara-provider-stopall-race-"));
+    const dbPath = path.join(tempDir, "orchestration.sqlite");
+    const persistenceLayer = makeSqlitePersistenceLive(dbPath);
+    const runtimeRepositoryLayer = ProviderSessionRuntimeRepositoryLive.pipe(
+      Layer.provide(persistenceLayer),
+    );
+    const directoryLayer = ProviderSessionDirectoryLive.pipe(Layer.provide(runtimeRepositoryLayer));
+    const releaseStoppedSessionSweep = yield* Deferred.make<void>();
+    const runtimeEventObserved = yield* Deferred.make<void>();
+    let shutdownStarted = false;
+
+    const delayedDirectoryLayer = Layer.effect(
+      ProviderSessionDirectory,
+      Effect.gen(function* () {
+        const directory = yield* ProviderSessionDirectory;
+        return {
+          ...directory,
+          getBinding: (threadId) =>
+            directory
+              .getBinding(threadId)
+              .pipe(
+                Effect.tap(() =>
+                  scenario === "ignored-runtime-event" && shutdownStarted
+                    ? Deferred.succeed(runtimeEventObserved, undefined).pipe(Effect.asVoid)
+                    : Effect.void,
+                ),
+              ),
+          listThreadIds: () =>
+            Deferred.await(releaseStoppedSessionSweep).pipe(
+              Effect.andThen(directory.listThreadIds()),
+            ),
+          upsert: (binding) =>
+            directory
+              .upsert(binding)
+              .pipe(
+                Effect.tap(() =>
+                  scenario === "newer-runtime-write" &&
+                  asRuntimePayloadRecord(binding.runtimePayload).lastRuntimeEvent ===
+                    "turn.completed"
+                    ? Deferred.succeed(runtimeEventObserved, undefined).pipe(Effect.asVoid)
+                    : Effect.void,
+                ),
+              ),
+        } satisfies ProviderSessionDirectoryShape;
+      }),
+    ).pipe(Layer.provide(directoryLayer));
+
+    const codex = makeFakeCodexAdapter();
+    const threadId = asThreadId("thread-stopall-terminal-race");
+    const shutdownSnapshotCursor = { resume: "shutdown-snapshot" };
+    const terminalCursor = { resume: "terminal-cursor" };
+    const expectedCursor =
+      scenario === "newer-runtime-write" ? terminalCursor : shutdownSnapshotCursor;
+    const registry: typeof ProviderAdapterRegistry.Service = {
+      getByProvider: (provider) =>
+        provider === "codex"
+          ? Effect.succeed(codex.adapter)
+          : Effect.fail(new ProviderUnsupportedError({ provider })),
+      listProviders: () => Effect.succeed(["codex"]),
+    };
+
+    codex.stopAll.mockImplementation(() =>
+      Effect.sync(() => {
+        shutdownStarted = true;
+        if (scenario === "newer-runtime-write") {
+          codex.updateSession(threadId, (session) => ({
+            ...session,
+            status: "closed",
+            resumeCursor: terminalCursor,
+            updatedAt: new Date().toISOString(),
+          }));
+        }
+        codex.emit({
+          type: scenario === "newer-runtime-write" ? "turn.completed" : "session.exited",
+          eventId: asEventId("event-stopall-terminal-race"),
+          provider: scenario === "newer-runtime-write" ? "codex" : "claudeAgent",
+          createdAt: new Date().toISOString(),
+          threadId,
+          payload:
+            scenario === "newer-runtime-write" ? { state: "completed" } : { exitKind: "graceful" },
+        });
+      }).pipe(
+        Effect.andThen(Deferred.await(runtimeEventObserved)),
+        Effect.andThen(Deferred.succeed(releaseStoppedSessionSweep, undefined)),
+        Effect.asVoid,
+      ),
+    );
+
+    const providerLayer = makeProviderServiceLive().pipe(
+      Layer.provide(Layer.succeed(ProviderAdapterRegistry, registry)),
+      Layer.provide(delayedDirectoryLayer),
+    );
+
+    yield* Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        cwd: "/tmp/project",
+        runtimeMode: "full-access",
+        threadId,
+      });
+      codex.updateSession(threadId, (session) => ({
+        ...session,
+        resumeCursor: shutdownSnapshotCursor,
+      }));
+      yield* codex.waitForRuntimeSubscribers();
+    }).pipe(Effect.provide(providerLayer));
+
+    const persisted = yield* Effect.gen(function* () {
+      const repository = yield* ProviderSessionRuntimeRepository;
+      return yield* repository.getByThreadId({ threadId });
+    }).pipe(Effect.provide(runtimeRepositoryLayer));
+
+    assert.equal(Option.isSome(persisted), true);
+    if (Option.isSome(persisted)) {
+      assert.equal(persisted.value.status, "stopped");
+      assert.deepEqual(persisted.value.resumeCursor, expectedCursor);
+    }
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }).pipe(Effect.provide(NodeServices.layer));
+}
+
+it.effect("ProviderServiceLive preserves a terminal cursor newer than its shutdown snapshot", () =>
+  verifyShutdownCursorOrdering("newer-runtime-write"),
+);
+
+it.effect("ProviderServiceLive retains its shutdown snapshot after an ignored runtime event", () =>
+  verifyShutdownCursorOrdering("ignored-runtime-event"),
 );
 
 it.effect(
@@ -5140,6 +5276,34 @@ validation.layer("ProviderServiceLive validation", (it) => {
 });
 
 const boundedFanout = makeProviderServiceLayer({ runtimeEventBufferCapacity: 1 });
+it.effect("ProviderServiceLive starts independent provider teardown concurrently", () =>
+  Effect.gen(function* () {
+    const shutdown = makeProviderServiceLayer();
+    const scope = yield* Scope.make("sequential");
+    const releaseStops = yield* Deferred.make<void>();
+    const startedProviders = new Set<ProviderKind>();
+
+    for (const adapter of [shutdown.codex, shutdown.claude, shutdown.antigravity]) {
+      adapter.stopAll.mockImplementation(() =>
+        Effect.sync(() => {
+          startedProviders.add(adapter.adapter.provider);
+        }).pipe(Effect.andThen(Deferred.await(releaseStops))),
+      );
+    }
+
+    yield* Layer.buildWithScope(shutdown.rawLayer, scope);
+    const closing = yield* Scope.close(scope, Exit.void).pipe(Effect.forkChild);
+
+    yield* waitUntil(
+      () => startedProviders.size === 3,
+      500,
+      20,
+      "all provider teardown operations to start",
+    ).pipe(Effect.ensuring(Deferred.succeed(releaseStops, undefined)));
+    yield* Fiber.join(closing);
+  }),
+);
+
 it.effect("ProviderServiceLive backpressures slow subscribers and completes fanout shutdown", () =>
   Effect.gen(function* () {
     const scope = yield* Scope.make("sequential");

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -5407,7 +5407,7 @@ it.effect("ProviderServiceLive starts adapter teardown when a queued session ref
     shutdown.codex.listSessions.mockImplementation(() => {
       shutdownListCalls += 1;
       return shutdownListCalls === 2
-        ? Effect.fail(new ProviderAdapterSessionNotFoundError({ provider: "codex", threadId }))
+        ? Effect.die(new Error("injected queued listSessions failure"))
         : listSessions();
     });
     shutdown.codex.stopAll.mockImplementation(() =>

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -759,29 +759,35 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             ),
           );
 
-    // Runtime events are where adapters surface provider-native ids; refresh
-    // from the live session before idle stop/recovery freezes an old cursor.
-    const refreshResumeCursorFromActiveSession = (
+    let runtimeCursorWriteVersion = 0;
+    const latestRuntimeCursorWriteByThread = new Map<
+      ThreadId,
+      { readonly version: number; readonly resumeCursor: unknown }
+    >();
+
+    // Runtime events are where adapters surface provider-native ids. Capture
+    // the live cursor before queueing the durable write so shutdown cannot
+    // delete the adapter session while an earlier event is waiting on SQLite.
+    const captureResumeCursorFromActiveSession = (
       event: ProviderRuntimeEvent,
-      binding: ProviderRuntimeBinding,
     ): Effect.Effect<unknown | null | undefined> => {
       if (!shouldRefreshResumeCursorForEvent(event)) {
-        return Effect.succeed(binding.resumeCursor);
+        return Effect.succeed(undefined);
       }
 
       return Effect.gen(function* () {
-        const adapter = yield* registry.getByProvider(binding.provider);
+        const adapter = yield* registry.getByProvider(event.provider);
         const sessions = yield* adapter.listSessions();
         const activeSession = sessions.find((session) => session.threadId === event.threadId);
-        return activeSession?.resumeCursor ?? binding.resumeCursor;
+        return activeSession?.resumeCursor;
       }).pipe(
         Effect.catchCause((cause) =>
           Effect.logWarning("provider.session.resume_cursor_refresh_failed", {
             threadId: event.threadId,
-            provider: binding.provider,
+            provider: event.provider,
             eventType: event.type,
             cause: Cause.pretty(cause),
-          }).pipe(Effect.as(binding.resumeCursor)),
+          }).pipe(Effect.as(undefined)),
         ),
       );
     };
@@ -1046,144 +1052,154 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           return Effect.sync(() => reconcileRuntimeIdleTimer(event));
       }
 
-      return withBindingWriteLock(
-        event.threadId,
-        Effect.gen(function* () {
-          if (event.type === "turn.started" && event.turnId !== undefined) {
-            getDispatchState(event.threadId).outstandingTurnIds.add(String(event.turnId));
-          }
-          if (
-            (event.type === "turn.completed" || event.type === "turn.aborted") &&
-            event.turnId !== undefined &&
-            (dispatchStateByThread.get(event.threadId)?.inFlightGenerations.size ?? 0) > 0
-          ) {
-            recordRecentlyCompletedTurn(event.threadId, String(event.turnId));
-          }
-          const binding = Option.getOrUndefined(yield* directory.getBinding(event.threadId));
-          if (!binding) {
-            reconcileRuntimeIdleTimer(event);
-            return;
-          }
-          if (binding.provider !== event.provider) {
-            return;
-          }
-          if (
-            event.lifecycleGeneration !== undefined &&
-            binding.lifecycleGeneration !== event.lifecycleGeneration
-          ) {
-            // The pump gate lets a stale terminal event through only when it
-            // can safely settle the thread: no current generation exists, or
-            // the event still names the turn the binding has active. Mirror
-            // that acceptance here, otherwise the accepted event is journaled
-            // and published but the durable binding keeps the dead turn active
-            // forever and the thread stays a reconciliation candidate.
-            const staleTerminalSettlesThread =
-              isTerminalRuntimeEvent(event) &&
-              (lifecycle.currentGeneration(event.threadId) === undefined ||
-                (event.turnId !== undefined &&
-                  runtimeActiveTurnId(binding.runtimePayload) === String(event.turnId)));
-            if (!staleTerminalSettlesThread) {
+      return Effect.gen(function* () {
+        const liveResumeCursor = yield* captureResumeCursorFromActiveSession(event);
+        yield* withBindingWriteLock(
+          event.threadId,
+          Effect.gen(function* () {
+            if (event.type === "turn.started" && event.turnId !== undefined) {
+              getDispatchState(event.threadId).outstandingTurnIds.add(String(event.turnId));
+            }
+            if (
+              (event.type === "turn.completed" || event.type === "turn.aborted") &&
+              event.turnId !== undefined &&
+              (dispatchStateByThread.get(event.threadId)?.inFlightGenerations.size ?? 0) > 0
+            ) {
+              recordRecentlyCompletedTurn(event.threadId, String(event.turnId));
+            }
+            const binding = Option.getOrUndefined(yield* directory.getBinding(event.threadId));
+            if (!binding) {
+              reconcileRuntimeIdleTimer(event);
               return;
             }
-          }
+            if (binding.provider !== event.provider) {
+              return;
+            }
+            if (
+              event.lifecycleGeneration !== undefined &&
+              binding.lifecycleGeneration !== event.lifecycleGeneration
+            ) {
+              // The pump gate lets a stale terminal event through only when it
+              // can safely settle the thread: no current generation exists, or
+              // the event still names the turn the binding has active. Mirror
+              // that acceptance here, otherwise the accepted event is journaled
+              // and published but the durable binding keeps the dead turn active
+              // forever and the thread stays a reconciliation candidate.
+              const staleTerminalSettlesThread =
+                isTerminalRuntimeEvent(event) &&
+                (lifecycle.currentGeneration(event.threadId) === undefined ||
+                  (event.turnId !== undefined &&
+                    runtimeActiveTurnId(binding.runtimePayload) === String(event.turnId)));
+              if (!staleTerminalSettlesThread) {
+                return;
+              }
+            }
 
-          const currentActiveTurnId = runtimeActiveTurnId(binding.runtimePayload);
-          if (
-            event.type === "turn.started" &&
-            !isStartedTurnApplicable({
-              activeTurnId: currentActiveTurnId,
-              eventTurnId: event.turnId === undefined ? undefined : String(event.turnId),
-            })
-          ) {
-            return;
-          }
-          if (event.type === "turn.completed" || event.type === "turn.aborted") {
-            const applicability = classifyTerminalTurnApplicability({
-              activeTurnId: currentActiveTurnId,
-              eventTurnId: event.turnId === undefined ? undefined : String(event.turnId),
-              hasAmbiguousTurns: hasAmbiguousTerminalTurn(event.threadId),
-            });
-            if (!applicability.applicable) {
-              if (event.turnId !== undefined) {
+            const currentActiveTurnId = runtimeActiveTurnId(binding.runtimePayload);
+            if (
+              event.type === "turn.started" &&
+              !isStartedTurnApplicable({
+                activeTurnId: currentActiveTurnId,
+                eventTurnId: event.turnId === undefined ? undefined : String(event.turnId),
+              })
+            ) {
+              return;
+            }
+            if (event.type === "turn.completed" || event.type === "turn.aborted") {
+              const applicability = classifyTerminalTurnApplicability({
+                activeTurnId: currentActiveTurnId,
+                eventTurnId: event.turnId === undefined ? undefined : String(event.turnId),
+                hasAmbiguousTurns: hasAmbiguousTerminalTurn(event.threadId),
+              });
+              if (!applicability.applicable) {
+                if (event.turnId !== undefined) {
+                  dispatchStateByThread
+                    .get(event.threadId)
+                    ?.outstandingTurnIds.delete(String(event.turnId));
+                  cleanupDispatchState(event.threadId);
+                }
+                if (applicability.reason === "ambiguous-missing-turn-id") {
+                  yield* Effect.logWarning("provider.session.ambiguous_terminal_event_ignored", {
+                    threadId: event.threadId,
+                    eventType: event.type,
+                  });
+                }
+                return;
+              }
+              if (event.turnId === undefined && applicability.resolvedTurnId !== undefined) {
+                recordRecentlyCompletedTurn(event.threadId, applicability.resolvedTurnId);
+              }
+              if (applicability.resolvedTurnId !== undefined) {
                 dispatchStateByThread
                   .get(event.threadId)
-                  ?.outstandingTurnIds.delete(String(event.turnId));
+                  ?.outstandingTurnIds.delete(applicability.resolvedTurnId);
                 cleanupDispatchState(event.threadId);
               }
-              if (applicability.reason === "ambiguous-missing-turn-id") {
-                yield* Effect.logWarning("provider.session.ambiguous_terminal_event_ignored", {
-                  threadId: event.threadId,
-                  eventType: event.type,
-                });
+            }
+            const activeTurnId =
+              event.type === "turn.started"
+                ? (event.turnId ?? null)
+                : event.type === "thread.state.changed" && event.payload.state === "compacted"
+                  ? (event.turnId ?? currentActiveTurnId)
+                  : event.type === "turn.completed" ||
+                      event.type === "turn.aborted" ||
+                      (event.type === "thread.state.changed" &&
+                        (event.payload.state === "archived" ||
+                          event.payload.state === "closed" ||
+                          event.payload.state === "error")) ||
+                      event.type === "session.exited" ||
+                      event.type === "runtime.error" ||
+                      (event.type === "session.state.changed" &&
+                        (event.payload.state === "ready" ||
+                          event.payload.state === "stopped" ||
+                          event.payload.state === "error"))
+                    ? null
+                    : currentActiveTurnId;
+            const lastError = runtimeLastErrorForEvent(event);
+            const resumeCursor = liveResumeCursor ?? binding.resumeCursor;
+
+            yield* directory.upsert({
+              threadId: event.threadId,
+              provider: binding.provider,
+              ...(binding.adapterKey !== undefined ? { adapterKey: binding.adapterKey } : {}),
+              ...(binding.runtimeMode !== undefined ? { runtimeMode: binding.runtimeMode } : {}),
+              status: runtimeStatusForEvent(event, activeTurnId),
+              ...(resumeCursor !== undefined ? { resumeCursor } : {}),
+              runtimePayload: {
+                activeTurnId,
+                lastRuntimeEvent: event.type,
+                lastRuntimeEventAt: event.createdAt,
+                ...(lastError !== undefined ? { lastError } : {}),
+                ...(runtimeEventRetiredGatewayTurnAuthority(event)
+                  ? { [AGENT_GATEWAY_CREDENTIAL_ROTATION_REQUIRED]: true }
+                  : {}),
+              },
+            });
+            if (liveResumeCursor !== undefined && liveResumeCursor !== null) {
+              runtimeCursorWriteVersion += 1;
+              latestRuntimeCursorWriteByThread.set(event.threadId, {
+                version: runtimeCursorWriteVersion,
+                resumeCursor: liveResumeCursor,
+              });
+            }
+            if (event.type === "session.exited") {
+              const dispatchState = dispatchStateByThread.get(event.threadId);
+              if (dispatchState) {
+                // Invalidate adapter calls that were already in flight when the
+                // session exited, then retain only the generations needed for
+                // their eventual settlement/cleanup.
+                dispatchState.latestGeneration = dispatchState.nextGeneration + 1;
+                dispatchState.nextGeneration = dispatchState.latestGeneration;
+                dispatchState.outstandingTurnIds.clear();
+                dispatchState.successfulResults.clear();
               }
-              return;
-            }
-            if (event.turnId === undefined && applicability.resolvedTurnId !== undefined) {
-              recordRecentlyCompletedTurn(event.threadId, applicability.resolvedTurnId);
-            }
-            if (applicability.resolvedTurnId !== undefined) {
-              dispatchStateByThread
-                .get(event.threadId)
-                ?.outstandingTurnIds.delete(applicability.resolvedTurnId);
+              recentlyCompletedTurnsByThread.delete(event.threadId);
               cleanupDispatchState(event.threadId);
             }
-          }
-          const activeTurnId =
-            event.type === "turn.started"
-              ? (event.turnId ?? null)
-              : event.type === "thread.state.changed" && event.payload.state === "compacted"
-                ? (event.turnId ?? currentActiveTurnId)
-                : event.type === "turn.completed" ||
-                    event.type === "turn.aborted" ||
-                    (event.type === "thread.state.changed" &&
-                      (event.payload.state === "archived" ||
-                        event.payload.state === "closed" ||
-                        event.payload.state === "error")) ||
-                    event.type === "session.exited" ||
-                    event.type === "runtime.error" ||
-                    (event.type === "session.state.changed" &&
-                      (event.payload.state === "ready" ||
-                        event.payload.state === "stopped" ||
-                        event.payload.state === "error"))
-                  ? null
-                  : currentActiveTurnId;
-          const lastError = runtimeLastErrorForEvent(event);
-          const resumeCursor = yield* refreshResumeCursorFromActiveSession(event, binding);
-
-          yield* directory.upsert({
-            threadId: event.threadId,
-            provider: binding.provider,
-            ...(binding.adapterKey !== undefined ? { adapterKey: binding.adapterKey } : {}),
-            ...(binding.runtimeMode !== undefined ? { runtimeMode: binding.runtimeMode } : {}),
-            status: runtimeStatusForEvent(event, activeTurnId),
-            ...(resumeCursor !== undefined ? { resumeCursor } : {}),
-            runtimePayload: {
-              activeTurnId,
-              lastRuntimeEvent: event.type,
-              lastRuntimeEventAt: event.createdAt,
-              ...(lastError !== undefined ? { lastError } : {}),
-              ...(runtimeEventRetiredGatewayTurnAuthority(event)
-                ? { [AGENT_GATEWAY_CREDENTIAL_ROTATION_REQUIRED]: true }
-                : {}),
-            },
-          });
-          if (event.type === "session.exited") {
-            const dispatchState = dispatchStateByThread.get(event.threadId);
-            if (dispatchState) {
-              // Invalidate adapter calls that were already in flight when the
-              // session exited, then retain only the generations needed for
-              // their eventual settlement/cleanup.
-              dispatchState.latestGeneration = dispatchState.nextGeneration + 1;
-              dispatchState.nextGeneration = dispatchState.latestGeneration;
-              dispatchState.outstandingTurnIds.clear();
-              dispatchState.successfulResults.clear();
-            }
-            recentlyCompletedTurnsByThread.delete(event.threadId);
-            cleanupDispatchState(event.threadId);
-          }
-          reconcileRuntimeIdleTimer(event);
-        }),
-      ).pipe(
+            reconcileRuntimeIdleTimer(event);
+          }),
+        );
+      }).pipe(
         Effect.catchCause((cause) =>
           Effect.logWarning("provider.session.runtime_binding_update_failed", {
             threadId: event.threadId,
@@ -2806,6 +2822,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     const runStopAll = () =>
       Effect.gen(function* () {
         const stoppedAt = new Date().toISOString();
+        const runtimeCursorWriteBaseline = runtimeCursorWriteVersion;
         const activeSessionByThreadId = new Map(
           (yield* Effect.forEach(adapters, (adapter) =>
             adapter
@@ -2829,7 +2846,22 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                 const latestSession = (yield* adapter.listSessions()).find(
                   (candidate) => candidate.threadId === session.threadId,
                 );
-                yield* markThreadStopped(session.threadId, stoppedAt, latestSession ?? session);
+                const queuedCursorWrite = latestRuntimeCursorWriteByThread.get(session.threadId);
+                const queuedResumeCursor =
+                  queuedCursorWrite !== undefined &&
+                  queuedCursorWrite.version > runtimeCursorWriteBaseline
+                    ? queuedCursorWrite.resumeCursor
+                    : undefined;
+                const stoppedSession = latestSession ?? session;
+                const resumeCursor =
+                  latestSession?.resumeCursor ?? queuedResumeCursor ?? session.resumeCursor;
+                yield* markThreadStopped(
+                  session.threadId,
+                  stoppedAt,
+                  resumeCursor !== undefined && resumeCursor !== stoppedSession.resumeCursor
+                    ? { ...stoppedSession, resumeCursor }
+                    : stoppedSession,
+                );
               }),
               started,
             ),

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -760,6 +760,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           );
 
     let runtimeCursorWriteVersion = 0;
+    let shutdownStartedAt: string | undefined;
     const latestRuntimeCursorWriteByThread = new Map<
       ThreadId,
       { readonly version: number; readonly resumeCursor: unknown }
@@ -1157,18 +1158,24 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                     : currentActiveTurnId;
             const lastError = runtimeLastErrorForEvent(event);
             const resumeCursor = liveResumeCursor ?? binding.resumeCursor;
+            const eventStatus = runtimeStatusForEvent(event, activeTurnId);
+            // Cursor capture happens before the write lock. An event that began
+            // before shutdown can therefore queue behind the stopped snapshot;
+            // retain its cursor without reviving the durable runtime state.
+            const preserveShutdownStop =
+              shutdownStartedAt !== undefined && eventStatus === "running";
 
             yield* directory.upsert({
               threadId: event.threadId,
               provider: binding.provider,
               ...(binding.adapterKey !== undefined ? { adapterKey: binding.adapterKey } : {}),
               ...(binding.runtimeMode !== undefined ? { runtimeMode: binding.runtimeMode } : {}),
-              status: runtimeStatusForEvent(event, activeTurnId),
+              status: preserveShutdownStop ? "stopped" : eventStatus,
               ...(resumeCursor !== undefined ? { resumeCursor } : {}),
               runtimePayload: {
-                activeTurnId,
-                lastRuntimeEvent: event.type,
-                lastRuntimeEventAt: event.createdAt,
+                activeTurnId: preserveShutdownStop ? null : activeTurnId,
+                lastRuntimeEvent: preserveShutdownStop ? "provider.stopAll" : event.type,
+                lastRuntimeEventAt: preserveShutdownStop ? shutdownStartedAt : event.createdAt,
                 ...(lastError !== undefined ? { lastError } : {}),
                 ...(runtimeEventRetiredGatewayTurnAuthority(event)
                   ? { [AGENT_GATEWAY_CREDENTIAL_ROTATION_REQUIRED]: true }
@@ -2822,6 +2829,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     const runStopAll = () =>
       Effect.gen(function* () {
         const stoppedAt = new Date().toISOString();
+        shutdownStartedAt = stoppedAt;
         const runtimeCursorWriteBaseline = runtimeCursorWriteVersion;
         const activeSessionByThreadId = new Map(
           (yield* Effect.forEach(adapters, (adapter) =>

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -53,7 +53,7 @@ import {
 } from "effect";
 import { nonEmptyTrimmed } from "@synara/shared/text";
 
-import { ProviderValidationError } from "../Errors.ts";
+import { type ProviderAdapterError, ProviderValidationError } from "../Errors.ts";
 import { ProviderAdapterRegistry } from "../Services/ProviderAdapterRegistry.ts";
 import { ProviderService, type ProviderServiceShape } from "../Services/ProviderService.ts";
 import {
@@ -2857,13 +2857,13 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           // Persist durable stopped state and reap independent process trees at
           // the same time. Slow/locked SQLite must not consume the desktop's
           // graceful-shutdown budget before provider teardown even begins.
-          yield* settleConcurrentTeardowns(
-            [
-              persistStoppedSessions,
-              settleConcurrentTeardowns(adapters, (adapter) => adapter.stopAll()),
-            ],
-            (teardown) => teardown,
-          );
+          const shutdownWork: ReadonlyArray<
+            Effect.Effect<void, ProviderAdapterError | ProviderSessionDirectoryWriteError, never>
+          > = [
+            persistStoppedSessions,
+            settleConcurrentTeardowns(adapters, (adapter) => adapter.stopAll()),
+          ];
+          yield* settleConcurrentTeardowns(shutdownWork, (teardown) => teardown);
         }).pipe(
           Effect.ensuring(
             Effect.sync(() => {

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -74,6 +74,7 @@ import {
 import { makeProviderLifecycleCoordinator } from "../providerLifecycleCoordinator.ts";
 import { makeKeyedLock } from "../keyedLock.ts";
 import { carryProviderAttachmentPaths } from "../providerAttachmentPaths.ts";
+import { settleConcurrentTeardowns } from "../settleConcurrentTeardowns.ts";
 import {
   makeProviderRuntimeEventPumpHealthRegistry,
   runProviderRuntimeEventPump,
@@ -722,36 +723,37 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         runtimePayload: toRuntimePayloadFromSession(session, extra),
       });
 
-    const markThreadStopped = (
-      threadId: ThreadId,
-      stoppedAt: string,
-      session?: ProviderSession,
-    ): Effect.Effect<void, ProviderSessionDirectoryWriteError> =>
-      session
+    const markThreadStopped = (input: {
+      readonly threadId: ThreadId;
+      readonly stoppedAt: string;
+      readonly session?: ProviderSession;
+      readonly resumeCursor?: unknown;
+    }): Effect.Effect<void, ProviderSessionDirectoryWriteError> =>
+      input.session
         ? directory.upsert({
-            threadId,
-            provider: session.provider,
-            runtimeMode: session.runtimeMode,
+            threadId: input.threadId,
+            provider: input.session.provider,
+            runtimeMode: input.session.runtimeMode,
             status: "stopped",
-            ...(session.resumeCursor !== undefined ? { resumeCursor: session.resumeCursor } : {}),
+            ...(input.resumeCursor !== undefined ? { resumeCursor: input.resumeCursor } : {}),
             runtimePayload: {
-              ...toRuntimePayloadFromSession(session, {
+              ...toRuntimePayloadFromSession(input.session, {
                 lastRuntimeEvent: "provider.stopAll",
-                lastRuntimeEventAt: stoppedAt,
+                lastRuntimeEventAt: input.stoppedAt,
               }),
               activeTurnId: null,
             },
           })
-        : directory.getProvider(threadId).pipe(
+        : directory.getProvider(input.threadId).pipe(
             Effect.flatMap((provider) =>
               directory.upsert({
-                threadId,
+                threadId: input.threadId,
                 provider,
                 status: "stopped",
                 runtimePayload: {
                   activeTurnId: null,
                   lastRuntimeEvent: "provider.stopAll",
-                  lastRuntimeEventAt: stoppedAt,
+                  lastRuntimeEventAt: input.stoppedAt,
                 },
               }),
             ),
@@ -822,6 +824,13 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     // mutex adds no meaningful contention. Creation is synchronous
     // (Semaphore.makeUnsafe), so concurrent callers cannot mint two locks.
     const withBindingWriteLock = makeKeyedLock<ThreadId>().withLock;
+    let shutdownBindingWriteVersions: Map<ThreadId, number> | undefined;
+    const recordRuntimeBindingWriteDuringShutdown = (threadId: ThreadId): void => {
+      const versions = shutdownBindingWriteVersions;
+      if (versions !== undefined) {
+        versions.set(threadId, (versions.get(threadId) ?? 0) + 1);
+      }
+    };
 
     interface StartedTurnPersistenceInput {
       readonly threadId: ThreadId;
@@ -1164,6 +1173,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                 : {}),
             },
           });
+          recordRuntimeBindingWriteDuringShutdown(event.threadId);
           if (event.type === "session.exited") {
             const dispatchState = dispatchStateByThread.get(event.threadId);
             if (dispatchState) {
@@ -2801,20 +2811,68 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
       });
 
     const runStopAll = () =>
-      Effect.gen(function* () {
-        const stoppedAt = new Date().toISOString();
-        const threadIds = yield* directory.listThreadIds();
-        const activeSessionByThreadId = new Map(
-          (yield* Effect.forEach(adapters, (adapter) => adapter.listSessions()))
-            .flatMap((sessions) => sessions)
-            .map((session) => [session.threadId, session] as const),
+      Effect.suspend(() => {
+        const bindingWriteVersions = new Map<ThreadId, number>();
+        shutdownBindingWriteVersions = bindingWriteVersions;
+        return Effect.gen(function* () {
+          const stoppedAt = new Date().toISOString();
+          const activeSessionByThreadId = new Map(
+            (yield* Effect.forEach(adapters, (adapter) => adapter.listSessions()))
+              .flatMap((sessions) => sessions)
+              .map(
+                (session) =>
+                  [
+                    session.threadId,
+                    {
+                      session,
+                      bindingWriteVersion: bindingWriteVersions.get(session.threadId) ?? 0,
+                    },
+                  ] as const,
+              ),
+          );
+          const persistStoppedSessions = Effect.gen(function* () {
+            const threadIds = yield* directory.listThreadIds();
+            yield* Effect.forEach(
+              new Set([...threadIds, ...activeSessionByThreadId.keys()]),
+              (threadId) => {
+                const snapshot = activeSessionByThreadId.get(threadId);
+                return withBindingWriteLock(
+                  threadId,
+                  Effect.suspend(() =>
+                    markThreadStopped({
+                      threadId,
+                      stoppedAt,
+                      ...(snapshot === undefined ? {} : { session: snapshot.session }),
+                      ...(snapshot !== undefined &&
+                      (bindingWriteVersions.get(threadId) ?? 0) === snapshot.bindingWriteVersion
+                        ? { resumeCursor: snapshot.session.resumeCursor }
+                        : {}),
+                    }),
+                  ),
+                );
+              },
+            );
+          });
+
+          // Persist durable stopped state and reap independent process trees at
+          // the same time. Slow/locked SQLite must not consume the desktop's
+          // graceful-shutdown budget before provider teardown even begins.
+          yield* settleConcurrentTeardowns(
+            [
+              persistStoppedSessions,
+              settleConcurrentTeardowns(adapters, (adapter) => adapter.stopAll()),
+            ],
+            (teardown) => teardown,
+          );
+        }).pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              if (shutdownBindingWriteVersions === bindingWriteVersions) {
+                shutdownBindingWriteVersions = undefined;
+              }
+            }),
+          ),
         );
-        yield* Effect.forEach(
-          new Set([...threadIds, ...activeSessionByThreadId.keys()]),
-          (threadId) =>
-            markThreadStopped(threadId, stoppedAt, activeSessionByThreadId.get(threadId)),
-        );
-        yield* Effect.forEach(adapters, (adapter) => adapter.stopAll());
       });
 
     const awaitRuntimeEventFanoutDrained: Effect.Effect<void> = Effect.suspend(() =>

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -821,9 +821,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     // and sendTurn's post-dispatch write. Without it a terminal event could
     // land between sendTurn's settled-turn check and its "running" upsert and
     // still be overwritten. Lifecycle events are low-frequency, so a per-thread
-    // mutex adds no meaningful contention. Creation is synchronous
-    // (Semaphore.makeUnsafe), so concurrent callers cannot mint two locks.
-    const withBindingWriteLock = makeKeyedLock<ThreadId>().withLock;
+    // mutex adds no meaningful contention. Queue registration is synchronous,
+    // so concurrent callers cannot mint two locks or overtake an earlier write.
+    const bindingWriteLock = makeKeyedLock<ThreadId>();
+    const withBindingWriteLock = bindingWriteLock.withLock;
 
     interface StartedTurnPersistenceInput {
       readonly threadId: ThreadId;
@@ -2822,15 +2823,15 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         const persistActiveSessions = settleConcurrentTeardowns(
           activeSessionWrites,
           ({ adapter, session, started }) =>
-            withBindingWriteLock(
+            bindingWriteLock.withLockQueued(
               session.threadId,
               Effect.gen(function* () {
                 const latestSession = (yield* adapter.listSessions()).find(
                   (candidate) => candidate.threadId === session.threadId,
                 );
-                yield* Deferred.succeed(started, undefined);
                 yield* markThreadStopped(session.threadId, stoppedAt, latestSession ?? session);
               }),
+              started,
             ),
         );
         const persistInactiveSessions = Effect.gen(function* () {
@@ -2846,9 +2847,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           { concurrency: "unbounded", discard: true },
         ).pipe(Effect.andThen(settleConcurrentTeardowns(adapters, (adapter) => adapter.stopAll())));
 
-        // The active-session write signals after acquiring its per-thread lock,
-        // before touching SQLite. Provider teardown can therefore begin even if
-        // persistence is slow, while terminal events still serialize afterward.
+        // Each active-session write signals after it is queued on its per-thread
+        // lock. Provider teardown can therefore begin without waiting for an
+        // earlier slow write, while terminal events still queue behind the stop
+        // snapshot and become the final writer.
         const shutdownWork: ReadonlyArray<
           Effect.Effect<void, ProviderAdapterError | ProviderSessionDirectoryWriteError, never>
         > = [persistActiveSessions, persistInactiveSessions, stopAdapters];

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -40,6 +40,7 @@ import { createHash, randomUUID } from "node:crypto";
 import {
   Array as EffectArray,
   Cause,
+  Deferred,
   Duration,
   Effect,
   Exit,
@@ -723,37 +724,36 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         runtimePayload: toRuntimePayloadFromSession(session, extra),
       });
 
-    const markThreadStopped = (input: {
-      readonly threadId: ThreadId;
-      readonly stoppedAt: string;
-      readonly session?: ProviderSession;
-      readonly resumeCursor?: unknown;
-    }): Effect.Effect<void, ProviderSessionDirectoryWriteError> =>
-      input.session
+    const markThreadStopped = (
+      threadId: ThreadId,
+      stoppedAt: string,
+      session?: ProviderSession,
+    ): Effect.Effect<void, ProviderSessionDirectoryWriteError> =>
+      session
         ? directory.upsert({
-            threadId: input.threadId,
-            provider: input.session.provider,
-            runtimeMode: input.session.runtimeMode,
+            threadId,
+            provider: session.provider,
+            runtimeMode: session.runtimeMode,
             status: "stopped",
-            ...(input.resumeCursor !== undefined ? { resumeCursor: input.resumeCursor } : {}),
+            ...(session.resumeCursor !== undefined ? { resumeCursor: session.resumeCursor } : {}),
             runtimePayload: {
-              ...toRuntimePayloadFromSession(input.session, {
+              ...toRuntimePayloadFromSession(session, {
                 lastRuntimeEvent: "provider.stopAll",
-                lastRuntimeEventAt: input.stoppedAt,
+                lastRuntimeEventAt: stoppedAt,
               }),
               activeTurnId: null,
             },
           })
-        : directory.getProvider(input.threadId).pipe(
+        : directory.getProvider(threadId).pipe(
             Effect.flatMap((provider) =>
               directory.upsert({
-                threadId: input.threadId,
+                threadId,
                 provider,
                 status: "stopped",
                 runtimePayload: {
                   activeTurnId: null,
                   lastRuntimeEvent: "provider.stopAll",
-                  lastRuntimeEventAt: input.stoppedAt,
+                  lastRuntimeEventAt: stoppedAt,
                 },
               }),
             ),
@@ -824,13 +824,6 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     // mutex adds no meaningful contention. Creation is synchronous
     // (Semaphore.makeUnsafe), so concurrent callers cannot mint two locks.
     const withBindingWriteLock = makeKeyedLock<ThreadId>().withLock;
-    let shutdownBindingWriteVersions: Map<ThreadId, number> | undefined;
-    const recordRuntimeBindingWriteDuringShutdown = (threadId: ThreadId): void => {
-      const versions = shutdownBindingWriteVersions;
-      if (versions !== undefined) {
-        versions.set(threadId, (versions.get(threadId) ?? 0) + 1);
-      }
-    };
 
     interface StartedTurnPersistenceInput {
       readonly threadId: ThreadId;
@@ -1173,7 +1166,6 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                 : {}),
             },
           });
-          recordRuntimeBindingWriteDuringShutdown(event.threadId);
           if (event.type === "session.exited") {
             const dispatchState = dispatchStateByThread.get(event.threadId);
             if (dispatchState) {
@@ -2811,68 +2803,56 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
       });
 
     const runStopAll = () =>
-      Effect.suspend(() => {
-        const bindingWriteVersions = new Map<ThreadId, number>();
-        shutdownBindingWriteVersions = bindingWriteVersions;
-        return Effect.gen(function* () {
-          const stoppedAt = new Date().toISOString();
-          const activeSessionByThreadId = new Map(
-            (yield* Effect.forEach(adapters, (adapter) => adapter.listSessions()))
-              .flatMap((sessions) => sessions)
-              .map(
-                (session) =>
-                  [
-                    session.threadId,
-                    {
-                      session,
-                      bindingWriteVersion: bindingWriteVersions.get(session.threadId) ?? 0,
-                    },
-                  ] as const,
-              ),
-          );
-          const persistStoppedSessions = Effect.gen(function* () {
-            const threadIds = yield* directory.listThreadIds();
-            yield* Effect.forEach(
-              new Set([...threadIds, ...activeSessionByThreadId.keys()]),
-              (threadId) => {
-                const snapshot = activeSessionByThreadId.get(threadId);
-                return withBindingWriteLock(
-                  threadId,
-                  Effect.suspend(() =>
-                    markThreadStopped({
-                      threadId,
-                      stoppedAt,
-                      ...(snapshot === undefined ? {} : { session: snapshot.session }),
-                      ...(snapshot !== undefined &&
-                      (bindingWriteVersions.get(threadId) ?? 0) === snapshot.bindingWriteVersion
-                        ? { resumeCursor: snapshot.session.resumeCursor }
-                        : {}),
-                    }),
-                  ),
-                );
-              },
-            );
-          });
-
-          // Persist durable stopped state and reap independent process trees at
-          // the same time. Slow/locked SQLite must not consume the desktop's
-          // graceful-shutdown budget before provider teardown even begins.
-          const shutdownWork: ReadonlyArray<
-            Effect.Effect<void, ProviderAdapterError | ProviderSessionDirectoryWriteError, never>
-          > = [
-            persistStoppedSessions,
-            settleConcurrentTeardowns(adapters, (adapter) => adapter.stopAll()),
-          ];
-          yield* settleConcurrentTeardowns(shutdownWork, (teardown) => teardown);
-        }).pipe(
-          Effect.ensuring(
-            Effect.sync(() => {
-              if (shutdownBindingWriteVersions === bindingWriteVersions) {
-                shutdownBindingWriteVersions = undefined;
-              }
-            }),
-          ),
+      Effect.gen(function* () {
+        const stoppedAt = new Date().toISOString();
+        const activeSessionByThreadId = new Map(
+          (yield* Effect.forEach(adapters, (adapter) =>
+            adapter
+              .listSessions()
+              .pipe(Effect.map((sessions) => sessions.map((session) => ({ adapter, session })))),
+          ))
+            .flatMap((sessions) => sessions)
+            .map(({ adapter, session }) => [session.threadId, { adapter, session }] as const),
         );
+        const activeSessionWrites = yield* Effect.forEach(
+          activeSessionByThreadId.values(),
+          ({ adapter, session }) =>
+            Deferred.make<void>().pipe(Effect.map((started) => ({ adapter, session, started }))),
+        );
+        const persistActiveSessions = settleConcurrentTeardowns(
+          activeSessionWrites,
+          ({ adapter, session, started }) =>
+            withBindingWriteLock(
+              session.threadId,
+              Effect.gen(function* () {
+                const latestSession = (yield* adapter.listSessions()).find(
+                  (candidate) => candidate.threadId === session.threadId,
+                );
+                yield* Deferred.succeed(started, undefined);
+                yield* markThreadStopped(session.threadId, stoppedAt, latestSession ?? session);
+              }),
+            ),
+        );
+        const persistInactiveSessions = Effect.gen(function* () {
+          const threadIds = yield* directory.listThreadIds();
+          yield* Effect.forEach(
+            threadIds.filter((threadId) => !activeSessionByThreadId.has(threadId)),
+            (threadId) => withBindingWriteLock(threadId, markThreadStopped(threadId, stoppedAt)),
+          );
+        });
+        const stopAdapters = Effect.forEach(
+          activeSessionWrites,
+          ({ started }) => Deferred.await(started),
+          { concurrency: "unbounded", discard: true },
+        ).pipe(Effect.andThen(settleConcurrentTeardowns(adapters, (adapter) => adapter.stopAll())));
+
+        // The active-session write signals after acquiring its per-thread lock,
+        // before touching SQLite. Provider teardown can therefore begin even if
+        // persistence is slow, while terminal events still serialize afterward.
+        const shutdownWork: ReadonlyArray<
+          Effect.Effect<void, ProviderAdapterError | ProviderSessionDirectoryWriteError, never>
+        > = [persistActiveSessions, persistInactiveSessions, stopAdapters];
+        yield* settleConcurrentTeardowns(shutdownWork, (teardown) => teardown);
       });
 
     const awaitRuntimeEventFanoutDrained: Effect.Effect<void> = Effect.suspend(() =>

--- a/apps/server/src/provider/keyedLock.test.ts
+++ b/apps/server/src/provider/keyedLock.test.ts
@@ -79,4 +79,47 @@ describe("makeKeyedLock", () => {
     expect(order).toEqual(["second", "third"]);
     expect(lock.activeKeyCount()).toBe(0);
   });
+
+  it("interrupts a queued waiter without letting later callers overtake the holder", async () => {
+    const lock = makeKeyedLock<string>();
+    const release = await Effect.runPromise(Deferred.make<void>());
+    const order: string[] = [];
+
+    const first = Effect.runFork(
+      lock.withLock(
+        "thread-1",
+        Effect.sync(() => order.push("first-start")).pipe(
+          Effect.andThen(Deferred.await(release)),
+          Effect.andThen(Effect.sync(() => order.push("first-end"))),
+        ),
+      ),
+    );
+    await Effect.runPromise(Effect.yieldNow);
+    const second = Effect.runFork(lock.withLock("thread-1", Effect.void));
+    await Effect.runPromise(Effect.yieldNow);
+
+    const interrupted = Effect.runPromise(Fiber.interrupt(second));
+    await expect(
+      Promise.race([
+        interrupted.then(() => "interrupted"),
+        new Promise<string>((resolve) => setTimeout(() => resolve("timed-out"), 500)),
+      ]),
+    ).resolves.toBe("interrupted");
+
+    const third = Effect.runFork(
+      lock.withLock(
+        "thread-1",
+        Effect.sync(() => order.push("third")),
+      ),
+    );
+    await Effect.runPromise(Effect.yieldNow);
+    expect(order).toEqual(["first-start"]);
+
+    await Effect.runPromise(Deferred.succeed(release, undefined));
+    await Effect.runPromise(Fiber.join(first));
+    await Effect.runPromise(Fiber.join(third));
+
+    expect(order).toEqual(["first-start", "first-end", "third"]);
+    expect(lock.activeKeyCount()).toBe(0);
+  });
 });

--- a/apps/server/src/provider/keyedLock.test.ts
+++ b/apps/server/src/provider/keyedLock.test.ts
@@ -45,4 +45,38 @@ describe("makeKeyedLock", () => {
 
     expect(lock.activeKeyCount()).toBe(0);
   });
+
+  it("signals after a waiter is queued without waiting for the current holder", async () => {
+    const lock = makeKeyedLock<string>();
+    const release = await Effect.runPromise(Deferred.make<void>());
+    const queued = await Effect.runPromise(Deferred.make<void>());
+    const order: string[] = [];
+
+    const first = Effect.runFork(lock.withLock("thread-1", Deferred.await(release)));
+    await Effect.runPromise(Effect.yieldNow);
+    const second = Effect.runFork(
+      lock.withLockQueued(
+        "thread-1",
+        Effect.sync(() => order.push("second")),
+        queued,
+      ),
+    );
+
+    await Effect.runPromise(Deferred.await(queued));
+    const third = Effect.runFork(
+      lock.withLock(
+        "thread-1",
+        Effect.sync(() => order.push("third")),
+      ),
+    );
+    expect(order).toEqual([]);
+
+    await Effect.runPromise(Deferred.succeed(release, undefined));
+    await Effect.runPromise(Fiber.join(first));
+    await Effect.runPromise(Fiber.join(second));
+    await Effect.runPromise(Fiber.join(third));
+
+    expect(order).toEqual(["second", "third"]);
+    expect(lock.activeKeyCount()).toBe(0);
+  });
 });

--- a/apps/server/src/provider/keyedLock.ts
+++ b/apps/server/src/provider/keyedLock.ts
@@ -1,7 +1,12 @@
-import { Effect, Semaphore } from "effect";
+import { Deferred, Effect } from "effect";
 
 export interface KeyedLock<Key> {
   readonly withLock: <A, E, R>(key: Key, effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>;
+  readonly withLockQueued: <A, E, R>(
+    key: Key,
+    effect: Effect.Effect<A, E, R>,
+    queued: Deferred.Deferred<void>,
+  ) => Effect.Effect<A, E, R>;
   readonly activeKeyCount: () => number;
 }
 
@@ -11,33 +16,52 @@ export interface KeyedLock<Key> {
  * or waiter to leave the critical section.
  */
 export function makeKeyedLock<Key>(): KeyedLock<Key> {
-  const entries = new Map<Key, { readonly semaphore: Semaphore.Semaphore; users: number }>();
+  const entries = new Map<Key, { tail: Deferred.Deferred<void>; users: number }>();
 
-  const withLock: KeyedLock<Key>["withLock"] = (key, effect) =>
+  const queueWithLock = <A, E, R>(
+    key: Key,
+    effect: Effect.Effect<A, E, R>,
+    queued?: Deferred.Deferred<void>,
+  ): Effect.Effect<A, E, R> =>
     Effect.suspend(() => {
       let entry = entries.get(key);
       if (entry === undefined) {
-        entry = { semaphore: Semaphore.makeUnsafe(1), users: 0 };
+        const available = Deferred.makeUnsafe<void>();
+        Deferred.doneUnsafe(available, Effect.void);
+        entry = { tail: available, users: 0 };
         entries.set(key, entry);
       }
+      const previous = entry.tail;
+      const completed = Deferred.makeUnsafe<void>();
+      entry.tail = completed;
       entry.users += 1;
       const acquiredEntry = entry;
-      return acquiredEntry.semaphore
-        .withPermits(1)(effect)
-        .pipe(
+      if (queued !== undefined) {
+        Deferred.doneUnsafe(queued, Effect.void);
+      }
+      return Effect.uninterruptibleMask((restore) =>
+        Deferred.await(previous).pipe(
+          Effect.andThen(restore(effect)),
           Effect.ensuring(
             Effect.sync(() => {
+              Deferred.doneUnsafe(completed, Effect.void);
               acquiredEntry.users -= 1;
               if (acquiredEntry.users === 0 && entries.get(key) === acquiredEntry) {
                 entries.delete(key);
               }
             }),
           ),
-        );
+        ),
+      );
     });
+
+  const withLock: KeyedLock<Key>["withLock"] = (key, effect) => queueWithLock(key, effect);
+  const withLockQueued: KeyedLock<Key>["withLockQueued"] = (key, effect, queued) =>
+    queueWithLock(key, effect, queued);
 
   return {
     withLock,
+    withLockQueued,
     activeKeyCount: () => entries.size,
   };
 }

--- a/apps/server/src/provider/keyedLock.ts
+++ b/apps/server/src/provider/keyedLock.ts
@@ -39,12 +39,20 @@ export function makeKeyedLock<Key>(): KeyedLock<Key> {
       if (queued !== undefined) {
         Deferred.doneUnsafe(queued, Effect.void);
       }
+      let acquired = false;
       return Effect.uninterruptibleMask((restore) =>
-        Deferred.await(previous).pipe(
+        restore(Deferred.await(previous)).pipe(
+          Effect.tap(() =>
+            Effect.sync(() => {
+              acquired = true;
+            }),
+          ),
           Effect.andThen(restore(effect)),
           Effect.ensuring(
             Effect.sync(() => {
-              Deferred.doneUnsafe(completed, Effect.void);
+              // An interrupted waiter still owns its FIFO node. Link that node
+              // to its predecessor so later callers cannot overtake the holder.
+              Deferred.doneUnsafe(completed, acquired ? Effect.void : Deferred.await(previous));
               acquiredEntry.users -= 1;
               if (acquiredEntry.users === 0 && entries.get(key) === acquiredEntry) {
                 entries.delete(key);

--- a/apps/server/src/provider/settleConcurrentTeardowns.test.ts
+++ b/apps/server/src/provider/settleConcurrentTeardowns.test.ts
@@ -1,0 +1,37 @@
+import { Effect, Exit } from "effect";
+import { describe, expect, it, vi } from "vitest";
+
+import { settleConcurrentTeardowns } from "./settleConcurrentTeardowns.ts";
+
+describe("settleConcurrentTeardowns", () => {
+  it("starts every teardown and waits for settlement before reporting a failure", async () => {
+    const failure = new Error("synthetic teardown failure");
+    const started: number[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const result = Effect.runPromiseExit(
+      settleConcurrentTeardowns([1, 2, 3], (item) =>
+        Effect.tryPromise({
+          try: async () => {
+            started.push(item);
+            await gate;
+            if (item === 2) throw failure;
+          },
+          catch: (cause) => cause as Error,
+        }),
+      ),
+    );
+
+    await vi.waitFor(() => expect(started).toHaveLength(3));
+    release();
+
+    const exit = await result;
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      expect(String(exit.cause)).toContain(failure.message);
+    }
+  });
+});

--- a/apps/server/src/provider/settleConcurrentTeardowns.ts
+++ b/apps/server/src/provider/settleConcurrentTeardowns.ts
@@ -1,0 +1,20 @@
+// Runs independent shutdown work together without letting one failure cancel the rest.
+
+import { Effect, Exit } from "effect";
+
+export function settleConcurrentTeardowns<Item, E, R>(
+  items: Iterable<Item>,
+  teardown: (item: Item) => Effect.Effect<void, E, R>,
+): Effect.Effect<void, E, R> {
+  return Effect.gen(function* () {
+    const results = yield* Effect.forEach(
+      Array.from(items),
+      (item) => Effect.exit(teardown(item)),
+      { concurrency: "unbounded" },
+    );
+    const failed = results.find(Exit.isFailure);
+    if (failed) {
+      return yield* Effect.failCause(failed.cause);
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- route macOS/Linux updater and fatal-startup shutdown through the authenticated graceful backend endpoint before using bounded TERM/KILL fallback
- wait for the real backend child exit before handing control to the installer
- tear down independent provider sessions concurrently while preserving the newest durable resume cursor

## Verification

- `bun run --cwd apps/desktop test -- backendShutdown.test.ts backendShutdown.posix.integration.test.ts backendShutdown.windows.integration.test.ts` — 38 passed, 5 Windows-only skipped
- `bun run --cwd apps/server test -- src/provider/settleConcurrentTeardowns.test.ts src/provider/Layers/ProviderService.test.ts src/provider/Layers/AntigravityAdapter.test.ts src/provider/Layers/ClaudeAdapter.test.ts src/provider/Layers/CursorAdapter.test.ts src/provider/Layers/DroidAdapter.test.ts src/provider/Layers/GrokAdapter.test.ts src/provider/Layers/PiAdapter.test.ts serverShutdown.test.ts http.test.ts effectServer.lifecycle.test.ts` — 386 passed
- `bun run --cwd apps/desktop build`
- `node --check apps/desktop/src/fixtures/posixBackendShutdown.mjs`
- changed-file `oxfmt --check`
- `git diff --check`

`bun fmt`, `bun lint`, and `bun typecheck` were not run locally because the delegated task explicitly prohibited them.

Closes #789

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authenticated shutdown, process lifecycle before updates, and durable session cursor ordering during concurrent teardown—mistakes could leave backends or provider children alive or corrupt resume state.
> 
> **Overview**
> Aligns **macOS/Linux desktop quit/update** with Windows by calling the authenticated `/api/desktop/shutdown` endpoint first, retrying transport errors until a **TERM** fallback window, then **SIGTERM** and **SIGKILL** on bounded timers. Shutdown still **resolves only on child exit**; POSIX timings are lengthened (15s / 18s / 20s). **Fatal startup** on all platforms goes through `requestGracefulAppQuit` instead of POSIX-only `stopBackend` + `app.quit`. The old fire-and-forget `stopBackend()` path is removed in favor of `stopBackendAndWaitForExit`.
> 
> On the **server**, provider shutdown is reworked so **resume cursors are captured before** per-thread binding writes, shutdown marks sessions **stopped** without letting late “running” events revive state, and **active-session persistence can queue on the lock** while **adapter `stopAll` runs concurrently** via `settleConcurrentTeardowns`. Per-thread locks become a **FIFO deferred queue** with `withLockQueued` for early teardown signaling; provider adapters adopt the shared concurrent teardown helper.
> 
> **Tests**: expanded unit tests for POSIX shutdown, new POSIX integration fixture, keyed-lock queue behavior, `settleConcurrentTeardowns`, and many `ProviderService` shutdown race scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37e952e4f23c4ca9ee17544719f5924dd5634875. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->