### PR TITLE
Add edited-file Open split actions

### DIFF
--- a/apps/server/src/checkpointing/Diffs.test.ts
+++ b/apps/server/src/checkpointing/Diffs.test.ts
@@ -30,8 +30,8 @@ describe("parseTurnDiffFilesFromUnifiedDiff", () => {
     ].join("\n");
 
     expect(await Effect.runPromise(parseTurnDiffFilesFromUnifiedDiff(diff))).toEqual([
-      { path: "a.txt", additions: 2, deletions: 1 },
-      { path: "src/b.ts", additions: 0, deletions: 2 },
+      { path: "a.txt", kind: "modified", additions: 2, deletions: 1 },
+      { path: "src/b.ts", kind: "modified", additions: 0, deletions: 2 },
     ]);
   });
 
@@ -45,7 +45,7 @@ describe("parseTurnDiffFilesFromUnifiedDiff", () => {
     ].join("\n");
 
     expect(await Effect.runPromise(parseTurnDiffFilesFromUnifiedDiff(diff))).toEqual([
-      { path: "src/new.ts", additions: 0, deletions: 0 },
+      { path: "src/new.ts", kind: "renamed", additions: 0, deletions: 0 },
     ]);
   });
 
@@ -63,7 +63,7 @@ describe("parseTurnDiffFilesFromUnifiedDiff", () => {
     ].join("\r\n");
 
     expect(await Effect.runPromise(parseTurnDiffFilesFromUnifiedDiff(diff))).toEqual([
-      { path: "a.txt", additions: 2, deletions: 1 },
+      { path: "a.txt", kind: "modified", additions: 2, deletions: 1 },
     ]);
   });
 
@@ -88,7 +88,7 @@ describe("parseTurnDiffFilesFromUnifiedDiff", () => {
     ].join("\n");
 
     expect(await Effect.runPromise(parseTurnDiffFilesFromUnifiedDiff(diff))).toEqual([
-      { path: "CLAUDE.md", additions: 2, deletions: 3 },
+      { path: "CLAUDE.md", kind: "modified", additions: 2, deletions: 3 },
     ]);
   });
 
@@ -107,6 +107,23 @@ describe("parseTurnDiffFilesFromUnifiedDiff", () => {
 
     expect(await Effect.runPromise(parseCheckpointFilesFromUnifiedDiff(diff))).toEqual([
       { path: "src/app.ts", kind: "modified", additions: 2, deletions: 1 },
+    ]);
+  });
+
+  it("preserves deleted-file status in checkpoint summaries", async () => {
+    const diff = [
+      "diff --git a/src/removed.ts b/src/removed.ts",
+      "deleted file mode 100644",
+      "index 1111111..0000000",
+      "--- a/src/removed.ts",
+      "+++ /dev/null",
+      "@@ -1 +0,0 @@",
+      "-removed",
+      "",
+    ].join("\n");
+
+    expect(await Effect.runPromise(parseCheckpointFilesFromUnifiedDiff(diff))).toEqual([
+      { path: "src/removed.ts", kind: "deleted", additions: 0, deletions: 1 },
     ]);
   });
 });

--- a/apps/server/src/checkpointing/Diffs.ts
+++ b/apps/server/src/checkpointing/Diffs.ts
@@ -18,8 +18,25 @@ const loadPierreDiffs: () => Promise<PierreDiffsModule> = lazyModule(() => impor
 
 export interface TurnDiffFileSummary {
   readonly path: string;
+  readonly kind: string;
   readonly additions: number;
   readonly deletions: number;
+}
+
+function checkpointKindFromParsedFile(
+  type: ParsedPatches[number]["files"][number]["type"],
+): string {
+  switch (type) {
+    case "deleted":
+      return "deleted";
+    case "new":
+      return "added";
+    case "rename-pure":
+    case "rename-changed":
+      return "renamed";
+    case "change":
+      return "modified";
+  }
 }
 
 function summarizeParsedPatches(parsedPatches: ParsedPatches): ReadonlyArray<TurnDiffFileSummary> {
@@ -31,6 +48,7 @@ function summarizeParsedPatches(parsedPatches: ParsedPatches): ReadonlyArray<Tur
       const existing = filesByPath.get(file.name);
       filesByPath.set(file.name, {
         path: file.name,
+        kind: checkpointKindFromParsedFile(file.type),
         additions: (existing?.additions ?? 0) + additions,
         deletions: (existing?.deletions ?? 0) + deletions,
       });
@@ -68,7 +86,7 @@ export function parseCheckpointFilesFromUnifiedDiff(
     files.map(
       (file): OrchestrationCheckpointFile => ({
         path: file.path,
-        kind: "modified",
+        kind: file.kind,
         additions: file.additions,
         deletions: file.deletions,
       }),

--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -309,6 +309,9 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
       yield* fs.makeDirectory(path.join(home, "Applications", "Muxy.app"), {
         recursive: true,
       });
+      yield* fs.makeDirectory(path.join(home, "Applications", "iTerm.app"), {
+        recursive: true,
+      });
       yield* fs.makeDirectory(path.join(home, "Applications", "WebStorm.app"), {
         recursive: true,
       });
@@ -346,6 +349,16 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
         args: ["-a", "Terminal", "/tmp/workspace"],
       });
 
+      const itermLaunch = yield* resolveEditorLaunch(
+        { cwd: "/tmp/workspace", editor: "iterm" },
+        "darwin",
+        { HOME: home, PATH: "" },
+      );
+      assert.deepEqual(itermLaunch, {
+        command: "open",
+        args: ["-a", "iTerm", "/tmp/workspace"],
+      });
+
       const webstormLaunch = yield* resolveEditorLaunch(
         { cwd: "/tmp/workspace/src/open.ts:71:5", editor: "webstorm" },
         "darwin",
@@ -368,6 +381,7 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
       const availableEditors = resolveAvailableEditors("darwin", { HOME: home, PATH: "" });
       assert.equal(availableEditors.includes("ghostty"), true);
       assert.equal(availableEditors.includes("muxy"), true);
+      assert.equal(availableEditors.includes("iterm"), true);
       assert.equal(availableEditors.includes("webstorm"), true);
       assert.equal(availableEditors.includes("pycharm"), true);
     }),

--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -399,31 +399,54 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
     }),
   );
 
-  it.effect("maps file-manager editor to OS open commands", () =>
+  it.effect("reveals macOS files in Finder while opening directories", () =>
     Effect.gen(function* () {
-      const launch1 = yield* resolveEditorLaunch(
-        { cwd: "/tmp/workspace", editor: "file-manager" },
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const parentPath = yield* fs.makeTempDirectoryScoped({
+        prefix: "synara-file-manager-",
+      });
+      const directoryPath = path.join(parentPath, "Project Folder");
+      const filePath = path.join(directoryPath, "source file.ts");
+      yield* fs.makeDirectory(directoryPath);
+      yield* fs.writeFileString(filePath, "");
+
+      const fileLaunch = yield* resolveEditorLaunch(
+        { cwd: filePath, editor: "file-manager" },
         "darwin",
       );
-      assert.deepEqual(launch1, {
+      assert.deepEqual(fileLaunch, {
         command: "open",
-        args: ["/tmp/workspace"],
+        args: ["-R", filePath],
       });
 
-      const launch2 = yield* resolveEditorLaunch(
+      const directoryLaunch = yield* resolveEditorLaunch(
+        { cwd: directoryPath, editor: "file-manager" },
+        "darwin",
+      );
+      assert.deepEqual(directoryLaunch, {
+        command: "open",
+        args: [directoryPath],
+      });
+    }),
+  );
+
+  it.effect("maps file-manager editor to Windows and Linux open commands", () =>
+    Effect.gen(function* () {
+      const windowsLaunch = yield* resolveEditorLaunch(
         { cwd: "C:\\workspace", editor: "file-manager" },
         "win32",
       );
-      assert.deepEqual(launch2, {
+      assert.deepEqual(windowsLaunch, {
         command: "explorer",
         args: ["C:\\workspace"],
       });
 
-      const launch3 = yield* resolveEditorLaunch(
+      const linuxLaunch = yield* resolveEditorLaunch(
         { cwd: "/tmp/workspace", editor: "file-manager" },
         "linux",
       );
-      assert.deepEqual(launch3, {
+      assert.deepEqual(linuxLaunch, {
         command: "xdg-open",
         args: ["/tmp/workspace"],
       });

--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -431,6 +431,21 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
     }),
   );
 
+  it.effect("falls back to opening macOS targets when metadata lookup fails", () =>
+    Effect.gen(function* () {
+      const targetPath = `/${"unavailable".repeat(500)}`;
+      const launch = yield* resolveEditorLaunch(
+        { cwd: targetPath, editor: "file-manager" },
+        "darwin",
+      );
+
+      assert.deepEqual(launch, {
+        command: "open",
+        args: [targetPath],
+      });
+    }),
+  );
+
   it.effect("maps file-manager editor to Windows and Linux open commands", () =>
     Effect.gen(function* () {
       const windowsLaunch = yield* resolveEditorLaunch(

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -147,6 +147,15 @@ function fileManagerCommandForPlatform(platform: NodeJS.Platform): string {
   }
 }
 
+function resolveFileManagerLaunch(target: string, platform: NodeJS.Platform): EditorLaunch {
+  const command = fileManagerCommandForPlatform(platform);
+  const shouldReveal =
+    platform === "darwin" &&
+    statSync(target, { throwIfNoEntry: false })?.isDirectory() === false;
+
+  return { command, args: shouldReveal ? ["-R", target] : [target] };
+}
+
 // Terminal integrations should receive a directory even when the source target is file:line:column.
 function resolveTerminalWorkingDirectory(target: string): string {
   const targetPath = parseTargetPathAndPosition(target)?.path ?? target;
@@ -402,7 +411,7 @@ export const resolveEditorLaunch = Effect.fnUntraced(function* (
     return yield* new OpenError({ message: `Unsupported editor: ${input.editor}` });
   }
 
-  return { command: fileManagerCommandForPlatform(platform), args: [input.cwd] };
+  return resolveFileManagerLaunch(input.cwd, platform);
 });
 
 function editorLaunchesEqual(left: EditorLaunch, right: EditorLaunch): boolean {

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -150,8 +150,7 @@ function fileManagerCommandForPlatform(platform: NodeJS.Platform): string {
 function resolveFileManagerLaunch(target: string, platform: NodeJS.Platform): EditorLaunch {
   const command = fileManagerCommandForPlatform(platform);
   const shouldReveal =
-    platform === "darwin" &&
-    statSync(target, { throwIfNoEntry: false })?.isDirectory() === false;
+    platform === "darwin" && statSync(target, { throwIfNoEntry: false })?.isDirectory() === false;
 
   return { command, args: shouldReveal ? ["-R", target] : [target] };
 }

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -147,10 +147,17 @@ function fileManagerCommandForPlatform(platform: NodeJS.Platform): string {
   }
 }
 
+function shouldRevealInFinder(target: string): boolean {
+  try {
+    return statSync(target, { throwIfNoEntry: false })?.isDirectory() === false;
+  } catch {
+    return false;
+  }
+}
+
 function resolveFileManagerLaunch(target: string, platform: NodeJS.Platform): EditorLaunch {
   const command = fileManagerCommandForPlatform(platform);
-  const shouldReveal =
-    platform === "darwin" && statSync(target, { throwIfNoEntry: false })?.isDirectory() === false;
+  const shouldReveal = platform === "darwin" && shouldRevealInFinder(target);
 
   return { command, args: shouldReveal ? ["-R", target] : [target] };
 }

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -6052,7 +6052,7 @@ describe("ProviderRuntimeIngestion", () => {
       status: "missing",
       files: [
         { path: "file.txt", kind: "modified", additions: 2, deletions: 1 },
-        { path: "src/next.ts", kind: "modified", additions: 1, deletions: 0 },
+        { path: "src/next.ts", kind: "added", additions: 1, deletions: 0 },
       ],
     });
   });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -12302,6 +12302,8 @@ export default function ChatView({
                     chatFontSizePx={settings.chatFontSizePx}
                     timestampFormat={timestampFormat}
                     workspaceRoot={threadArtifactWorkspaceRoot ?? undefined}
+                    keybindings={keybindings}
+                    availableEditors={availableEditors}
                     emptyStateContent={transcriptEmptyStateContent}
                     emptyStateProjectName={activeProjectDisplayName}
                     terminalWorkspaceTerminalTabActive={terminalWorkspaceTerminalTabActive}

--- a/apps/web/src/components/CopyPathActions.browser.tsx
+++ b/apps/web/src/components/CopyPathActions.browser.tsx
@@ -1,0 +1,169 @@
+// FILE: CopyPathActions.browser.tsx
+// Purpose: Verifies copy-path menus preserve path semantics and clipboard fallbacks.
+// Layer: Browser UI test
+
+import "../index.css";
+
+import type { FileDiffMetadata } from "@pierre/diffs/react";
+import type { PropsWithChildren, ReactNode } from "react";
+import { page } from "vitest/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+const harness = vi.hoisted(() => ({
+  toastAdd: vi.fn(),
+}));
+
+vi.mock("./ui/toast", () => ({
+  toastManager: { add: harness.toastAdd },
+}));
+
+vi.mock("./chat/OpenInPicker", () => ({
+  OpenInPicker: ({ openInTarget }: { openInTarget: string | null }) => (
+    <output data-testid="open-in-target">{openInTarget}</output>
+  ),
+}));
+
+vi.mock("./chat/FileDiffView", () => ({
+  FileDiffSurface: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  FileDiffCard: ({ renderHeaderTrailing }: { renderHeaderTrailing?: () => ReactNode }) => (
+    <div data-diff-file-header>{renderHeaderTrailing?.()}</div>
+  ),
+}));
+
+vi.mock("./LocalImagePreview", () => ({
+  LocalImagePreview: () => null,
+}));
+
+import { DiffPanelFileList } from "./DiffPanelFileList";
+import { WorkspaceFilePreviewHeader } from "./chat/WorkspaceFilePreviewHeader";
+
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+const originalExecCommandDescriptor = Object.getOwnPropertyDescriptor(document, "execCommand");
+
+function setClipboard(clipboard: Pick<Clipboard, "writeText"> | undefined): void {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: clipboard,
+  });
+}
+
+function installSuccessfulFallbackCopy(): ReturnType<typeof vi.fn> {
+  const execCommand = vi.fn().mockReturnValue(true);
+  Object.defineProperty(document, "execCommand", {
+    configurable: true,
+    value: execCommand,
+  });
+  return execCommand;
+}
+
+function restoreProperty(
+  target: object,
+  property: string,
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor) {
+    Object.defineProperty(target, property, descriptor);
+    return;
+  }
+  Reflect.deleteProperty(target, property);
+}
+
+function fileDiff(path: string): FileDiffMetadata {
+  return {
+    cacheKey: `diff:${path}`,
+    name: `b/${path}`,
+    prevName: `a/${path}`,
+  } as FileDiffMetadata;
+}
+
+function workspaceFilePreviewHeader(filePath: string, workspaceRoot: string) {
+  return (
+    <WorkspaceFilePreviewHeader
+      workspaceRoot={workspaceRoot}
+      filePath={filePath}
+      isMarkdown={false}
+      markdownPreviewEnabled={false}
+      onMarkdownPreviewChange={vi.fn()}
+    />
+  );
+}
+
+async function expectPathCopied(path: string): Promise<void> {
+  await vi.waitFor(() => {
+    expect(harness.toastAdd).toHaveBeenCalledWith({
+      type: "success",
+      title: "Path copied",
+      description: path,
+    });
+  });
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  harness.toastAdd.mockReset();
+  restoreProperty(navigator, "clipboard", originalClipboardDescriptor);
+  restoreProperty(document, "execCommand", originalExecCommandDescriptor);
+  vi.restoreAllMocks();
+});
+
+describe("copy-path actions", () => {
+  it("preserves a diff-relative path when the Clipboard API is unavailable", async () => {
+    setClipboard(undefined);
+    const execCommand = installSuccessfulFallbackCopy();
+    const path = "apps/web/src/example.ts";
+
+    await render(
+      <DiffPanelFileList
+        renderableFiles={[fileDiff(path)]}
+        resolvedTheme="light"
+        diffRenderMode="stacked"
+        diffWordWrap={false}
+        workspaceRoot="/workspace"
+        collapsedFiles={new Set()}
+        onToggleFileCollapsed={vi.fn()}
+        chatActions={{ onReferenceInChat: vi.fn(), onAskWhyChanged: vi.fn() }}
+      />,
+    );
+
+    await page.getByLabelText("File actions").click();
+    await page.getByText("Copy path").click();
+
+    await expectPathCopied(path);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("copies the resolved absolute workspace path after Clipboard API rejection", async () => {
+    const writeText = vi
+      .fn()
+      .mockRejectedValue(new DOMException("Document is not focused", "NotAllowedError"));
+    setClipboard({ writeText });
+    const execCommand = installSuccessfulFallbackCopy();
+    const expectedPath = "/workspace/apps/web/src/example.ts";
+
+    await render(workspaceFilePreviewHeader("apps/web/src/example.ts", "/workspace"));
+
+    expect(page.getByTestId("open-in-target").element().textContent).toBe(expectedPath);
+    await page.getByLabelText("More actions").click();
+    await page.getByText("Copy path").click();
+
+    await expectPathCopied(expectedPath);
+    expect(writeText).toHaveBeenCalledWith(expectedPath);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("keeps the menu available when an outside-workspace path is its only action", async () => {
+    setClipboard(undefined);
+    const execCommand = installSuccessfulFallbackCopy();
+    const path = "/tmp/synara scratch/example.ts";
+
+    await render(workspaceFilePreviewHeader(path, "/workspace"));
+
+    expect(page.getByTestId("open-in-target").element().textContent).toBe(path);
+    await page.getByLabelText("More actions").click();
+    await page.getByText("Copy path").click();
+
+    await expectPathCopied(path);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+});

--- a/apps/web/src/components/DiffPanelFileList.tsx
+++ b/apps/web/src/components/DiffPanelFileList.tsx
@@ -5,6 +5,7 @@
 import type { FileDiffMetadata } from "@pierre/diffs/react";
 import { isSupportedLocalImagePath } from "@synara/shared/localPreviewFiles";
 import { type MouseEvent as ReactMouseEvent } from "react";
+import { useCopyPathToClipboard } from "~/hooks/useCopyToClipboard";
 import { ChevronDownIcon, CopyIcon, EllipsisIcon, MessageCircleIcon } from "~/lib/icons";
 
 import { buildFileDiffRenderKey, resolveFileDiffPath } from "~/lib/diffRendering";
@@ -28,6 +29,8 @@ const DIFF_FILE_ACTIONS_MENU_ICON_CLASS_NAME = "size-3.5 shrink-0 text-muted-for
 // the collapse chevron. Marked with data-diff-header-menu so header clicks on
 // it do not toggle the file collapse state.
 function DiffFileHeaderActionsMenu(props: { filePath: string; chatActions: DiffFileChatActions }) {
+  const copyPathToClipboard = useCopyPathToClipboard();
+
   return (
     <Menu>
       <MenuTrigger
@@ -60,11 +63,7 @@ function DiffFileHeaderActionsMenu(props: { filePath: string; chatActions: DiffF
           <MessageCircleIcon className={DIFF_FILE_ACTIONS_MENU_ICON_CLASS_NAME} />
           <span>Ask why this changed</span>
         </MenuItem>
-        <MenuItem
-          onClick={() => {
-            void navigator.clipboard?.writeText(props.filePath);
-          }}
-        >
+        <MenuItem onClick={() => copyPathToClipboard(props.filePath)}>
           <CopyIcon className={DIFF_FILE_ACTIONS_MENU_ICON_CLASS_NAME} />
           <span>Copy path</span>
         </MenuItem>

--- a/apps/web/src/components/chat/ChatTranscriptPane.tsx
+++ b/apps/web/src/components/chat/ChatTranscriptPane.tsx
@@ -102,6 +102,8 @@ interface ChatTranscriptPaneProps {
   timestampFormat: TimestampFormat;
   turnDiffSummaryByAssistantMessageId: Map<MessageId, TurnDiffSummary>;
   workspaceRoot: string | undefined;
+  keybindings?: ComponentProps<typeof MessagesTimeline>["keybindings"];
+  availableEditors?: ComponentProps<typeof MessagesTimeline>["availableEditors"];
   worktreeSetup: WorktreeSetupSnapshot | null;
   worktreeSetupPendingAction?: ComponentProps<
     typeof MessagesTimeline
@@ -174,6 +176,8 @@ export function ChatTranscriptPane({
   timestampFormat,
   turnDiffSummaryByAssistantMessageId,
   workspaceRoot,
+  keybindings,
+  availableEditors,
   worktreeSetup,
   worktreeSetupPendingAction,
   onResolveWorktreeSetup,
@@ -288,6 +292,8 @@ export function ChatTranscriptPane({
             chatFontSizePx={chatFontSizePx}
             timestampFormat={timestampFormat}
             workspaceRoot={workspaceRoot}
+            {...(keybindings ? { keybindings } : {})}
+            {...(availableEditors ? { availableEditors } : {})}
             contentInsetRightPx={contentInsetRightPx}
             contentInsetBottomPx={contentInsetBottomPx}
             contentInsetBottomClearancePx={contentInsetBottomClearancePx}

--- a/apps/web/src/components/chat/EditedFileRow.browser.tsx
+++ b/apps/web/src/components/chat/EditedFileRow.browser.tsx
@@ -108,6 +108,19 @@ afterEach(() => {
 });
 
 describe("EditedFileRow", () => {
+  it("defers editor preference listeners until its launcher menu is opened", async () => {
+    const addEventListener = vi.spyOn(window, "addEventListener");
+    await render(editedFileRow({ openFile: () => true, workspaceRoot: WORKSPACE_ROOT }));
+    const preferenceListenerCalls = () =>
+      addEventListener.mock.calls.filter(
+        ([eventName]) => eventName === "storage" || eventName === "synara:local_storage_change",
+      );
+
+    expect(preferenceListenerCalls()).toHaveLength(0);
+    await page.getByRole("button", { name: `Open ${FILE_PATH} options` }).click();
+    await vi.waitFor(() => expect(preferenceListenerCalls()).toHaveLength(2));
+  });
+
   it("keeps row review, Review, Open, and menu trigger as keyboard-reachable sibling buttons", async () => {
     const onReview = vi.fn();
     const openFile = vi.fn(() => true);
@@ -215,7 +228,18 @@ describe("EditedFileRow", () => {
     expect(openInEditor).not.toHaveBeenCalled();
   });
 
-  it("opens a workspace-relative missing file only in-app and stays contained when narrow", async () => {
+  it("does not fall back externally when the in-app opener reports a missing file", async () => {
+    const openFile = vi.fn(() => false);
+    const openInEditor = vi.fn().mockResolvedValue(undefined);
+    restoreNativeApi = installNativeApi(openInEditor);
+    await render(editedFileRow({ openFile, workspaceRoot: WORKSPACE_ROOT }));
+
+    await page.getByRole("button", { name: "Open", exact: true }).click();
+    expect(openFile).toHaveBeenCalledWith(FILE_PATH);
+    expect(openInEditor).not.toHaveBeenCalled();
+  });
+
+  it("disables relative Open actions without a workspace root and stays contained when narrow", async () => {
     const openFile = vi.fn(() => false);
     const openInEditor = vi.fn().mockResolvedValue(undefined);
     restoreNativeApi = installNativeApi(openInEditor);
@@ -231,10 +255,8 @@ describe("EditedFileRow", () => {
       { container: host },
     );
     try {
-      await page.getByRole("button", { name: "Open", exact: true }).click();
-      expect(openFile).toHaveBeenCalledWith(
-        "a/very/long/path/that/does/not/exist/EditedFileRow.tsx",
-      );
+      expect(page.getByRole("button", { name: "Open", exact: true }).element()).toBeDisabled();
+      expect(openFile).not.toHaveBeenCalled();
       expect(openInEditor).not.toHaveBeenCalled();
 
       const row = screen.container.querySelector<HTMLElement>("[data-edited-file-row='true']");

--- a/apps/web/src/components/chat/EditedFileRow.browser.tsx
+++ b/apps/web/src/components/chat/EditedFileRow.browser.tsx
@@ -249,9 +249,7 @@ describe("EditedFileRow", () => {
         })
         .click();
       expect(page.getByRole("menuitemradio", { name: "Finder" }).element()).toBeDisabled();
-      expect(
-        page.getByRole("menuitem", { name: "Copy absolute path" }).element(),
-      ).toBeDisabled();
+      expect(page.getByRole("menuitem", { name: "Copy absolute path" }).element()).toBeDisabled();
       expect(
         page.getByRole("menuitem", { name: "Copy relative path" }).element(),
       ).not.toBeDisabled();

--- a/apps/web/src/components/chat/EditedFileRow.browser.tsx
+++ b/apps/web/src/components/chat/EditedFileRow.browser.tsx
@@ -227,7 +227,6 @@ describe("EditedFileRow", () => {
       editedFileRow({
         openFile,
         filePath: "a/very/long/path/that/does/not/exist/EditedFileRow.tsx",
-        workspaceRoot: undefined,
       }),
       { container: host },
     );

--- a/apps/web/src/components/chat/EditedFileRow.browser.tsx
+++ b/apps/web/src/components/chat/EditedFileRow.browser.tsx
@@ -31,25 +31,28 @@ const AVAILABLE_EDITORS: ReadonlyArray<EditorId> = [
   "iterm",
 ];
 const FILE_PATH = "apps/web/src/components/chat/EditedFileRow.tsx";
+const ROOTLESS_FILE_PATH = "a/very/long/path/that/does/not/exist/EditedFileRow.tsx";
 const WORKSPACE_ROOT = "/workspace/synara";
 const FILE_MANAGER_LABEL = resolveEditorLabel("file-manager", navigator.platform);
 
 const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
 let restoreNativeApi: (() => void) | undefined;
 
-function installNativeApi(openInEditor: ReturnType<typeof vi.fn>): () => void {
+function mockOpenInEditor() {
   const previousDescriptor = Object.getOwnPropertyDescriptor(window, "nativeApi");
+  const openInEditor = vi.fn().mockResolvedValue(undefined);
   Object.defineProperty(window, "nativeApi", {
     configurable: true,
     value: { shell: { openInEditor } } as unknown as NativeApi,
   });
-  return () => {
+  restoreNativeApi = () => {
     if (previousDescriptor) {
       Object.defineProperty(window, "nativeApi", previousDescriptor);
     } else {
       Reflect.deleteProperty(window, "nativeApi");
     }
   };
+  return openInEditor;
 }
 
 function setClipboard(writeText: ReturnType<typeof vi.fn>): void {
@@ -93,6 +96,16 @@ function editedFileRow(props: {
   );
 }
 
+async function openFileOptions(filePath = FILE_PATH) {
+  const menuButton = page.getByRole("button", { name: `Open ${filePath} options` });
+  await menuButton.click();
+  return menuButton;
+}
+
+function fileManagerMenuItem() {
+  return page.getByRole("menuitemradio", { name: FILE_MANAGER_LABEL });
+}
+
 beforeEach(() => {
   localStorage.clear();
   harness.toastAdd.mockReset();
@@ -119,15 +132,14 @@ describe("EditedFileRow", () => {
       );
 
     expect(preferenceListenerCalls()).toHaveLength(0);
-    await page.getByRole("button", { name: `Open ${FILE_PATH} options` }).click();
+    await openFileOptions();
     await vi.waitFor(() => expect(preferenceListenerCalls()).toHaveLength(2));
   });
 
   it("keeps row review, Review, Open, and menu trigger as keyboard-reachable sibling buttons", async () => {
     const onReview = vi.fn();
     const openFile = vi.fn(() => true);
-    const openInEditor = vi.fn().mockResolvedValue(undefined);
-    restoreNativeApi = installNativeApi(openInEditor);
+    const openInEditor = mockOpenInEditor();
 
     const screen = await render(
       editedFileRow({ openFile, onReview, workspaceRoot: WORKSPACE_ROOT }),
@@ -163,14 +175,12 @@ describe("EditedFileRow", () => {
   });
 
   it("lists installed launchers in file-action order, then copies both path forms", async () => {
-    const openInEditor = vi.fn().mockResolvedValue(undefined);
+    const openInEditor = mockOpenInEditor();
     const writeText = vi.fn().mockResolvedValue(undefined);
-    restoreNativeApi = installNativeApi(openInEditor);
     setClipboard(writeText);
     await render(editedFileRow({ openFile: () => true, workspaceRoot: WORKSPACE_ROOT }));
 
-    const menuButton = page.getByRole("button", { name: `Open ${FILE_PATH} options` });
-    await menuButton.click();
+    const menuButton = await openFileOptions();
     expect(
       Array.from(document.querySelectorAll<HTMLElement>("[role='menuitemradio']"), (item) =>
         item.textContent?.trim(),
@@ -209,9 +219,8 @@ describe("EditedFileRow", () => {
 
   it("keeps copy actions usable while disabling opens for deleted files", async () => {
     const openFile = vi.fn(() => true);
-    const openInEditor = vi.fn().mockResolvedValue(undefined);
+    const openInEditor = mockOpenInEditor();
     const writeText = vi.fn().mockResolvedValue(undefined);
-    restoreNativeApi = installNativeApi(openInEditor);
     setClipboard(writeText);
     await render(
       editedFileRow({
@@ -222,8 +231,8 @@ describe("EditedFileRow", () => {
     );
 
     expect(page.getByRole("button", { name: "Open", exact: true }).element()).toBeDisabled();
-    await page.getByRole("button", { name: `Open ${FILE_PATH} options` }).click();
-    expect(page.getByRole("menuitemradio", { name: FILE_MANAGER_LABEL }).element()).toBeDisabled();
+    await openFileOptions();
+    expect(fileManagerMenuItem().element()).toBeDisabled();
     await page.getByText("Copy relative path", { exact: true }).click();
     await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith(FILE_PATH));
     expect(openFile).not.toHaveBeenCalled();
@@ -232,8 +241,7 @@ describe("EditedFileRow", () => {
 
   it("does not fall back externally when the in-app opener reports a missing file", async () => {
     const openFile = vi.fn(() => false);
-    const openInEditor = vi.fn().mockResolvedValue(undefined);
-    restoreNativeApi = installNativeApi(openInEditor);
+    const openInEditor = mockOpenInEditor();
     await render(editedFileRow({ openFile, workspaceRoot: WORKSPACE_ROOT }));
 
     await page.getByRole("button", { name: "Open", exact: true }).click();
@@ -243,8 +251,7 @@ describe("EditedFileRow", () => {
 
   it("disables relative Open actions without a workspace root and stays contained when narrow", async () => {
     const openFile = vi.fn(() => false);
-    const openInEditor = vi.fn().mockResolvedValue(undefined);
-    restoreNativeApi = installNativeApi(openInEditor);
+    mockOpenInEditor();
     const host = document.createElement("div");
     host.style.cssText = "width:250px;overflow:hidden;";
     document.body.append(host);
@@ -252,28 +259,21 @@ describe("EditedFileRow", () => {
     const screen = await render(
       editedFileRow({
         openFile,
-        filePath: "a/very/long/path/that/does/not/exist/EditedFileRow.tsx",
+        filePath: ROOTLESS_FILE_PATH,
       }),
       { container: host },
     );
     try {
       expect(page.getByRole("button", { name: "Open", exact: true }).element()).toBeDisabled();
       expect(openFile).not.toHaveBeenCalled();
-      expect(openInEditor).not.toHaveBeenCalled();
 
       const row = screen.container.querySelector<HTMLElement>("[data-edited-file-row='true']");
       expect(row).not.toBeNull();
       expect(row!.scrollWidth).toBeLessThanOrEqual(row!.clientWidth);
       expect(page.getByRole("button", { name: "Review", exact: true }).element()).toBeVisible();
 
-      await page
-        .getByRole("button", {
-          name: "Open a/very/long/path/that/does/not/exist/EditedFileRow.tsx options",
-        })
-        .click();
-      expect(
-        page.getByRole("menuitemradio", { name: FILE_MANAGER_LABEL }).element(),
-      ).toBeDisabled();
+      await openFileOptions(ROOTLESS_FILE_PATH);
+      expect(fileManagerMenuItem().element()).toBeDisabled();
       expect(page.getByRole("menuitem", { name: "Copy absolute path" }).element()).toBeDisabled();
       expect(
         page.getByRole("menuitem", { name: "Copy relative path" }).element(),

--- a/apps/web/src/components/chat/EditedFileRow.browser.tsx
+++ b/apps/web/src/components/chat/EditedFileRow.browser.tsx
@@ -1,0 +1,263 @@
+// FILE: EditedFileRow.browser.tsx
+// Purpose: Verify changed-file review/open actions remain independent, accessible, and path-safe.
+// Layer: Browser UI test
+
+import "../../index.css";
+
+import type { EditorId, NativeApi } from "@synara/contracts";
+import type { PropsWithChildren } from "react";
+import { page, userEvent } from "vitest/browser";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+const harness = vi.hoisted(() => ({
+  toastAdd: vi.fn(),
+}));
+
+vi.mock("../ui/toast", () => ({
+  toastManager: { add: harness.toastAdd },
+}));
+
+import { WorkspaceFileOpenerContext } from "~/lib/workspaceFileOpener";
+import { EditedFileRow } from "./EditedFileRow";
+
+const AVAILABLE_EDITORS: ReadonlyArray<EditorId> = [
+  "file-manager",
+  "vscode",
+  "cursor",
+  "webstorm",
+  "terminal",
+  "iterm",
+];
+const FILE_PATH = "apps/web/src/components/chat/EditedFileRow.tsx";
+const WORKSPACE_ROOT = "/workspace/synara";
+
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+let restoreNativeApi: (() => void) | undefined;
+
+function installNativeApi(openInEditor: ReturnType<typeof vi.fn>): () => void {
+  const previousDescriptor = Object.getOwnPropertyDescriptor(window, "nativeApi");
+  Object.defineProperty(window, "nativeApi", {
+    configurable: true,
+    value: { shell: { openInEditor } } as unknown as NativeApi,
+  });
+  return () => {
+    if (previousDescriptor) {
+      Object.defineProperty(window, "nativeApi", previousDescriptor);
+    } else {
+      Reflect.deleteProperty(window, "nativeApi");
+    }
+  };
+}
+
+function setClipboard(writeText: ReturnType<typeof vi.fn>): void {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+}
+
+function TestProviders(props: PropsWithChildren<{ openFile: (path: string) => boolean }>) {
+  return (
+    <WorkspaceFileOpenerContext.Provider value={{ openFile: props.openFile }}>
+      {props.children}
+    </WorkspaceFileOpenerContext.Provider>
+  );
+}
+
+function editedFileRow(props: {
+  openFile: (path: string) => boolean;
+  onReview?: () => void;
+  filePath?: string;
+  fileKind?: string;
+  workspaceRoot?: string;
+}) {
+  return (
+    <TestProviders openFile={props.openFile}>
+      <EditedFileRow
+        filePath={props.filePath ?? FILE_PATH}
+        fileKind={props.fileKind ?? "modified"}
+        additions={12}
+        deletions={3}
+        workspaceRoot={props.workspaceRoot}
+        keybindings={[]}
+        availableEditors={AVAILABLE_EDITORS}
+        resolvedTheme="light"
+        fontSize={13}
+        withFirstReset
+        onReview={props.onReview ?? vi.fn()}
+      />
+    </TestProviders>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  harness.toastAdd.mockReset();
+});
+
+afterEach(() => {
+  restoreNativeApi?.();
+  restoreNativeApi = undefined;
+  if (originalClipboardDescriptor) {
+    Object.defineProperty(navigator, "clipboard", originalClipboardDescriptor);
+  } else {
+    Reflect.deleteProperty(navigator, "clipboard");
+  }
+  vi.restoreAllMocks();
+});
+
+describe("EditedFileRow", () => {
+  it("keeps row review, Review, Open, and menu trigger as keyboard-reachable sibling buttons", async () => {
+    const onReview = vi.fn();
+    const openFile = vi.fn(() => true);
+    const openInEditor = vi.fn().mockResolvedValue(undefined);
+    restoreNativeApi = installNativeApi(openInEditor);
+
+    const screen = await render(
+      editedFileRow({ openFile, onReview, workspaceRoot: WORKSPACE_ROOT }),
+    );
+    const pathButton = page.getByRole("button", { name: `Review changes to ${FILE_PATH}` });
+    const reviewButton = page.getByRole("button", { name: "Review", exact: true });
+    const openButton = page.getByRole("button", { name: "Open", exact: true });
+    const menuButton = page.getByRole("button", {
+      name: `Open ${FILE_PATH} options`,
+      exact: true,
+    });
+
+    expect(screen.container.querySelector("button button")).toBeNull();
+    await pathButton.click();
+    await reviewButton.click();
+    expect(onReview).toHaveBeenCalledTimes(2);
+
+    await openButton.click();
+    expect(openFile).toHaveBeenCalledOnce();
+    expect(openFile).toHaveBeenCalledWith(FILE_PATH);
+    expect(openInEditor).not.toHaveBeenCalled();
+    expect(onReview).toHaveBeenCalledTimes(2);
+
+    pathButton.element().focus();
+    await userEvent.keyboard("{Tab}");
+    expect(document.activeElement).toBe(reviewButton.element());
+    await userEvent.keyboard("{Tab}");
+    expect(document.activeElement).toBe(openButton.element());
+    await userEvent.keyboard("{Tab}");
+    expect(document.activeElement).toBe(menuButton.element());
+    await userEvent.keyboard("{Enter}");
+    await expect.element(page.getByText("Finder", { exact: true })).toBeInTheDocument();
+  });
+
+  it("lists installed launchers in file-action order, then copies both path forms", async () => {
+    const openInEditor = vi.fn().mockResolvedValue(undefined);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    restoreNativeApi = installNativeApi(openInEditor);
+    setClipboard(writeText);
+    await render(editedFileRow({ openFile: () => true, workspaceRoot: WORKSPACE_ROOT }));
+
+    const menuButton = page.getByRole("button", { name: `Open ${FILE_PATH} options` });
+    await menuButton.click();
+    expect(
+      Array.from(document.querySelectorAll<HTMLElement>("[role='menuitemradio']"), (item) =>
+        item.textContent?.trim(),
+      ),
+    ).toEqual(["Finder", "VS Code", "Cursor", "WebStorm", "Terminal", "iTerm"]);
+    const menuTexts = Array.from(
+      document.querySelectorAll<HTMLElement>("[role='menu'] [role^='menuitem']"),
+      (item) => item.textContent?.trim(),
+    );
+    expect(menuTexts.slice(-2)).toEqual(["Copy absolute path", "Copy relative path"]);
+
+    await page.getByRole("menuitem", { name: "Copy absolute path" }).click();
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        "/workspace/synara/apps/web/src/components/chat/EditedFileRow.tsx",
+      );
+    });
+    await menuButton.click();
+    await page.getByRole("menuitem", { name: "Copy relative path" }).click();
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(FILE_PATH);
+    });
+    expect(harness.toastAdd).toHaveBeenLastCalledWith({
+      type: "success",
+      title: "Path copied",
+      description: FILE_PATH,
+    });
+
+    await menuButton.click();
+    await page.getByText("VS Code", { exact: true }).click();
+    expect(openInEditor).toHaveBeenCalledWith(
+      "/workspace/synara/apps/web/src/components/chat/EditedFileRow.tsx",
+      "vscode",
+    );
+  });
+
+  it("keeps copy actions usable while disabling opens for deleted files", async () => {
+    const openFile = vi.fn(() => true);
+    const openInEditor = vi.fn().mockResolvedValue(undefined);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    restoreNativeApi = installNativeApi(openInEditor);
+    setClipboard(writeText);
+    await render(
+      editedFileRow({
+        openFile,
+        fileKind: "deleted",
+        workspaceRoot: WORKSPACE_ROOT,
+      }),
+    );
+
+    expect(page.getByRole("button", { name: "Open", exact: true }).element()).toBeDisabled();
+    await page.getByRole("button", { name: `Open ${FILE_PATH} options` }).click();
+    expect(page.getByRole("menuitemradio", { name: "Finder" }).element()).toBeDisabled();
+    await page.getByText("Copy relative path", { exact: true }).click();
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith(FILE_PATH));
+    expect(openFile).not.toHaveBeenCalled();
+    expect(openInEditor).not.toHaveBeenCalled();
+  });
+
+  it("opens a workspace-relative missing file only in-app and stays contained when narrow", async () => {
+    const openFile = vi.fn(() => false);
+    const openInEditor = vi.fn().mockResolvedValue(undefined);
+    restoreNativeApi = installNativeApi(openInEditor);
+    const host = document.createElement("div");
+    host.style.cssText = "width:250px;overflow:hidden;";
+    document.body.append(host);
+
+    const screen = await render(
+      editedFileRow({
+        openFile,
+        filePath: "a/very/long/path/that/does/not/exist/EditedFileRow.tsx",
+        workspaceRoot: undefined,
+      }),
+      { container: host },
+    );
+    try {
+      await page.getByRole("button", { name: "Open", exact: true }).click();
+      expect(openFile).toHaveBeenCalledWith(
+        "a/very/long/path/that/does/not/exist/EditedFileRow.tsx",
+      );
+      expect(openInEditor).not.toHaveBeenCalled();
+
+      const row = screen.container.querySelector<HTMLElement>("[data-edited-file-row='true']");
+      expect(row).not.toBeNull();
+      expect(row!.scrollWidth).toBeLessThanOrEqual(row!.clientWidth);
+      expect(page.getByRole("button", { name: "Review", exact: true }).element()).toBeVisible();
+
+      await page
+        .getByRole("button", {
+          name: "Open a/very/long/path/that/does/not/exist/EditedFileRow.tsx options",
+        })
+        .click();
+      expect(page.getByRole("menuitemradio", { name: "Finder" }).element()).toBeDisabled();
+      expect(
+        page.getByRole("menuitem", { name: "Copy absolute path" }).element(),
+      ).toBeDisabled();
+      expect(
+        page.getByRole("menuitem", { name: "Copy relative path" }).element(),
+      ).not.toBeDisabled();
+    } finally {
+      await screen.unmount();
+      host.remove();
+    }
+  });
+});

--- a/apps/web/src/components/chat/EditedFileRow.browser.tsx
+++ b/apps/web/src/components/chat/EditedFileRow.browser.tsx
@@ -18,6 +18,7 @@ vi.mock("../ui/toast", () => ({
   toastManager: { add: harness.toastAdd },
 }));
 
+import { resolveEditorLabel } from "~/editorMetadata";
 import { WorkspaceFileOpenerContext } from "~/lib/workspaceFileOpener";
 import { EditedFileRow } from "./EditedFileRow";
 
@@ -31,6 +32,7 @@ const AVAILABLE_EDITORS: ReadonlyArray<EditorId> = [
 ];
 const FILE_PATH = "apps/web/src/components/chat/EditedFileRow.tsx";
 const WORKSPACE_ROOT = "/workspace/synara";
+const FILE_MANAGER_LABEL = resolveEditorLabel("file-manager", navigator.platform);
 
 const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
 let restoreNativeApi: (() => void) | undefined;
@@ -157,7 +159,7 @@ describe("EditedFileRow", () => {
     await userEvent.keyboard("{Tab}");
     expect(document.activeElement).toBe(menuButton.element());
     await userEvent.keyboard("{Enter}");
-    await expect.element(page.getByText("Finder", { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByText(FILE_MANAGER_LABEL, { exact: true })).toBeInTheDocument();
   });
 
   it("lists installed launchers in file-action order, then copies both path forms", async () => {
@@ -173,7 +175,7 @@ describe("EditedFileRow", () => {
       Array.from(document.querySelectorAll<HTMLElement>("[role='menuitemradio']"), (item) =>
         item.textContent?.trim(),
       ),
-    ).toEqual(["Finder", "VS Code", "Cursor", "WebStorm", "Terminal", "iTerm"]);
+    ).toEqual([FILE_MANAGER_LABEL, "VS Code", "Cursor", "WebStorm", "Terminal", "iTerm"]);
     const menuTexts = Array.from(
       document.querySelectorAll<HTMLElement>("[role='menu'] [role^='menuitem']"),
       (item) => item.textContent?.trim(),
@@ -221,7 +223,7 @@ describe("EditedFileRow", () => {
 
     expect(page.getByRole("button", { name: "Open", exact: true }).element()).toBeDisabled();
     await page.getByRole("button", { name: `Open ${FILE_PATH} options` }).click();
-    expect(page.getByRole("menuitemradio", { name: "Finder" }).element()).toBeDisabled();
+    expect(page.getByRole("menuitemradio", { name: FILE_MANAGER_LABEL }).element()).toBeDisabled();
     await page.getByText("Copy relative path", { exact: true }).click();
     await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith(FILE_PATH));
     expect(openFile).not.toHaveBeenCalled();
@@ -269,7 +271,9 @@ describe("EditedFileRow", () => {
           name: "Open a/very/long/path/that/does/not/exist/EditedFileRow.tsx options",
         })
         .click();
-      expect(page.getByRole("menuitemradio", { name: "Finder" }).element()).toBeDisabled();
+      expect(
+        page.getByRole("menuitemradio", { name: FILE_MANAGER_LABEL }).element(),
+      ).toBeDisabled();
       expect(page.getByRole("menuitem", { name: "Copy absolute path" }).element()).toBeDisabled();
       expect(
         page.getByRole("menuitem", { name: "Copy relative path" }).element(),

--- a/apps/web/src/components/chat/EditedFileRow.tsx
+++ b/apps/web/src/components/chat/EditedFileRow.tsx
@@ -50,8 +50,9 @@ export function EditedFileRow(props: EditedFileRowProps) {
   );
   const isDeleted = props.fileKind === "deleted";
   const launcherTarget = isDeleted ? null : absolutePath;
-  const canOpenInApp =
-    !isDeleted && workspaceFileOpener !== null && (relativePath !== null || absolutePath !== null);
+  const hasInAppTarget =
+    absolutePath !== null || (props.workspaceRoot !== undefined && relativePath !== null);
+  const canOpenInApp = !isDeleted && workspaceFileOpener !== null && hasInAppTarget;
   const hasDiffStat = props.additions + props.deletions > 0;
 
   return (

--- a/apps/web/src/components/chat/EditedFileRow.tsx
+++ b/apps/web/src/components/chat/EditedFileRow.tsx
@@ -1,0 +1,141 @@
+// FILE: EditedFileRow.tsx
+// Purpose: Render one changed-file row with sibling review and open actions.
+// Layer: Chat changed-files UI
+
+import type { EditorId, ResolvedKeybindingsConfig } from "@synara/contracts";
+import type { CSSProperties } from "react";
+
+import { useCopyPathToClipboard } from "~/hooks/useCopyToClipboard";
+import { CopyIcon, EyeOpenIcon } from "~/lib/icons";
+import { useWorkspaceFileOpener } from "~/lib/workspaceFileOpener";
+import { cn } from "~/lib/utils";
+
+import { MenuItem } from "../ui/menu";
+import { DiffStatLabel } from "./DiffStatLabel";
+import { FileEntryIcon } from "./FileEntryIcon";
+import { OpenInPicker } from "./OpenInPicker";
+import { ReviewChangesButton } from "./ReviewChangesButton";
+import { resolveEditedFilePathTargets } from "./editedFilePathActions";
+
+interface EditedFileRowProps {
+  filePath: string;
+  fileKind: string;
+  additions: number;
+  deletions: number;
+  workspaceRoot: string | undefined;
+  keybindings?: ResolvedKeybindingsConfig;
+  availableEditors?: ReadonlyArray<EditorId>;
+  resolvedTheme: "light" | "dark";
+  fontSize: CSSProperties["fontSize"];
+  withFirstReset: boolean;
+  onReview: () => void;
+}
+
+const MENU_ICON_CLASS_NAME = "size-3.5 shrink-0 text-muted-foreground";
+const EDITED_FILE_EDITOR_ORDER: ReadonlyArray<EditorId> = [
+  "file-manager",
+  "vscode",
+  "cursor",
+  "webstorm",
+  "terminal",
+  "iterm",
+];
+
+export function EditedFileRow(props: EditedFileRowProps) {
+  const workspaceFileOpener = useWorkspaceFileOpener();
+  const copyPathToClipboard = useCopyPathToClipboard();
+  const { absolutePath, relativePath } = resolveEditedFilePathTargets(
+    props.filePath,
+    props.workspaceRoot,
+  );
+  const isDeleted = props.fileKind === "deleted";
+  const launcherTarget = isDeleted ? null : absolutePath;
+  const canOpenInApp =
+    !isDeleted && workspaceFileOpener !== null && (relativePath !== null || absolutePath !== null);
+  const hasDiffStat = props.additions + props.deletions > 0;
+
+  return (
+    <div
+      data-edited-file-row="true"
+      className={cn(
+        "@container/header-actions flex w-full min-w-0 items-center gap-1.5 overflow-hidden border-t border-[color:var(--color-border-light)] bg-transparent py-1.5 pr-2 transition-colors hover:bg-[var(--color-background-button-secondary-hover)] dark:bg-transparent dark:hover:bg-transparent",
+        props.withFirstReset && "first:border-t-0",
+      )}
+    >
+      <button
+        type="button"
+        data-edited-file-path-trigger="true"
+        aria-label={`Review changes to ${props.filePath}`}
+        className="group/file-row flex min-w-0 flex-1 items-center gap-2 self-stretch bg-transparent py-1 pl-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+        onClick={props.onReview}
+      >
+        <FileEntryIcon
+          pathValue={props.filePath}
+          kind="file"
+          theme={props.resolvedTheme}
+          colorMode="inherit"
+          className="size-4 shrink-0 text-[var(--color-text-foreground)] opacity-70 dark:opacity-80"
+        />
+        <span
+          className="font-system-ui min-w-0 truncate font-normal text-[var(--color-text-foreground)] underline-offset-2 group-hover/file-row:underline group-focus-visible/file-row:underline"
+          style={{ fontSize: props.fontSize }}
+          title={props.filePath}
+        >
+          {props.filePath}
+        </span>
+        {hasDiffStat ? (
+          <span
+            className="font-system-ui ml-auto shrink-0 tabular-nums"
+            style={{ fontSize: props.fontSize }}
+          >
+            <DiffStatLabel additions={props.additions} deletions={props.deletions} />
+          </span>
+        ) : null}
+      </button>
+
+      <ReviewChangesButton
+        className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+        style={{ fontSize: props.fontSize }}
+        onClick={props.onReview}
+      />
+
+      <OpenInPicker
+        {...(props.keybindings ? { keybindings: props.keybindings } : {})}
+        {...(props.availableEditors ? { availableEditors: props.availableEditors } : {})}
+        openInTarget={launcherTarget}
+        menuEditorOrder={EDITED_FILE_EDITOR_ORDER}
+        groupLabel={`Open ${props.filePath}`}
+        menuLabel={`Open ${props.filePath} options`}
+        primaryAction={{
+          disabled: !canOpenInApp,
+          icon: <EyeOpenIcon aria-hidden="true" className="size-3.5" />,
+          onClick: () => {
+            workspaceFileOpener?.openFile(props.filePath);
+          },
+        }}
+        additionalMenuItems={
+          <>
+            <MenuItem
+              disabled={absolutePath === null}
+              onClick={() => {
+                if (absolutePath) copyPathToClipboard(absolutePath);
+              }}
+            >
+              <CopyIcon className={MENU_ICON_CLASS_NAME} />
+              <span>Copy absolute path</span>
+            </MenuItem>
+            <MenuItem
+              disabled={relativePath === null}
+              onClick={() => {
+                if (relativePath) copyPathToClipboard(relativePath);
+              }}
+            >
+              <CopyIcon className={MENU_ICON_CLASS_NAME} />
+              <span>Copy relative path</span>
+            </MenuItem>
+          </>
+        }
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/EditedFileRow.tsx
+++ b/apps/web/src/components/chat/EditedFileRow.tsx
@@ -65,7 +65,6 @@ export function EditedFileRow(props: EditedFileRowProps) {
     >
       <button
         type="button"
-        data-edited-file-path-trigger="true"
         aria-label={`Review changes to ${props.filePath}`}
         className="group/file-row flex min-w-0 flex-1 items-center gap-2 self-stretch bg-transparent py-1 pl-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
         onClick={props.onReview}

--- a/apps/web/src/components/chat/MessagesTimeline.changedFiles.browser.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.changedFiles.browser.tsx
@@ -16,10 +16,7 @@ const VISIBLE_FILE_PATHS = Array.from(
   { length: 5 },
   (_, index) => `apps/web/src/visible-${index + 1}.tsx`,
 );
-const OVERFLOW_FILE_PATHS = [
-  "apps/web/src/overflow-1.tsx",
-  "apps/web/src/overflow-2.tsx",
-];
+const OVERFLOW_FILE_PATHS = ["apps/web/src/overflow-1.tsx", "apps/web/src/overflow-2.tsx"];
 
 const TIMELINE_ENTRIES: TimelineEntry[] = [
   {

--- a/apps/web/src/components/chat/MessagesTimeline.changedFiles.browser.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.changedFiles.browser.tsx
@@ -1,0 +1,126 @@
+// FILE: MessagesTimeline.changedFiles.browser.tsx
+// Purpose: Browser regressions for the changed-files row cap and expansion.
+// Layer: Vitest browser tests
+
+import "../../index.css";
+
+import { MessageId, TurnId } from "@synara/contracts";
+import { afterEach, describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import type { TimelineEntry } from "../../session-logic";
+import { MessagesTimeline } from "./MessagesTimeline";
+
+const ASSISTANT_MESSAGE_ID = MessageId.makeUnsafe("changed-files-assistant");
+const VISIBLE_FILE_PATHS = Array.from(
+  { length: 5 },
+  (_, index) => `apps/web/src/visible-${index + 1}.tsx`,
+);
+const OVERFLOW_FILE_PATHS = [
+  "apps/web/src/overflow-1.tsx",
+  "apps/web/src/overflow-2.tsx",
+];
+
+const TIMELINE_ENTRIES: TimelineEntry[] = [
+  {
+    id: "changed-files-entry",
+    kind: "message",
+    createdAt: "2026-03-17T19:12:29.000Z",
+    message: {
+      id: ASSISTANT_MESSAGE_ID,
+      role: "assistant",
+      text: "done",
+      createdAt: "2026-03-17T19:12:29.000Z",
+      completedAt: "2026-03-17T19:12:30.000Z",
+      streaming: false,
+    },
+  },
+];
+
+function ChangedFilesTimeline() {
+  const files = [...VISIBLE_FILE_PATHS, ...OVERFLOW_FILE_PATHS].map((path) => ({
+    path,
+    additions: 1,
+    deletions: 0,
+  }));
+
+  return (
+    <MessagesTimeline
+      hasMessages
+      isWorking={false}
+      activeTurnInProgress={false}
+      activeTurnStartedAt={null}
+      timelineEntries={TIMELINE_ENTRIES}
+      turnDiffSummaryByAssistantMessageId={
+        new Map([
+          [
+            ASSISTANT_MESSAGE_ID,
+            {
+              turnId: TurnId.makeUnsafe("changed-files-turn"),
+              completedAt: "2026-03-17T19:12:30.000Z",
+              assistantMessageId: ASSISTANT_MESSAGE_ID,
+              files,
+            },
+          ],
+        ])
+      }
+      nowIso="2026-03-17T19:12:30.000Z"
+      expandedWorkGroups={{}}
+      onToggleWorkGroup={() => {}}
+      onOpenTurnDiff={() => {}}
+      revertTurnCountByUserMessageId={new Map()}
+      onRevertUserMessage={() => {}}
+      isRevertingCheckpoint={false}
+      onImageExpand={() => {}}
+      markdownCwd={undefined}
+      resolvedTheme="dark"
+      timestampFormat="locale"
+      workspaceRoot={undefined}
+    />
+  );
+}
+
+function createTimelineHost(): HTMLDivElement {
+  const host = document.createElement("div");
+  host.style.cssText = "display:flex;width:700px;height:520px;overflow:hidden;";
+  document.body.append(host);
+  return host;
+}
+
+describe("MessagesTimeline changed files", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("does not mount overflow rows until the user expands them", async () => {
+    const host = createTimelineHost();
+    const screen = await render(<ChangedFilesTimeline />, { container: host });
+
+    try {
+      await expect
+        .poll(() => document.querySelectorAll('[data-edited-file-row="true"]').length)
+        .toBe(VISIBLE_FILE_PATHS.length);
+      for (const path of OVERFLOW_FILE_PATHS) {
+        expect(document.body.textContent ?? "").not.toContain(path);
+      }
+
+      const expandButton = [...document.querySelectorAll<HTMLButtonElement>("button")].find(
+        (button) => (button.textContent ?? "").includes("Show 2 more files"),
+      );
+      expect(expandButton).toBeDefined();
+      expect(expandButton?.getAttribute("aria-expanded")).toBe("false");
+      expandButton?.click();
+
+      await expect
+        .poll(() => document.querySelectorAll('[data-edited-file-row="true"]').length)
+        .toBe(VISIBLE_FILE_PATHS.length + OVERFLOW_FILE_PATHS.length);
+      for (const path of OVERFLOW_FILE_PATHS) {
+        expect(document.body.textContent ?? "").toContain(path);
+      }
+      await expect.poll(() => expandButton?.getAttribute("aria-expanded")).toBe("true");
+    } finally {
+      await screen.unmount();
+      host.remove();
+    }
+  });
+});

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -3364,12 +3364,8 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('aria-expanded="true"');
     expect(markup).toContain('data-edited-file-row="true"');
     expect(markup).toContain('data-edited-file-path-trigger="true"');
-    expect(markup).toContain(
-      'aria-label="Review changes to apps/web/src/components/Sidebar.tsx"',
-    );
-    expect(markup).toContain(
-      'aria-label="Open apps/web/src/components/Sidebar.tsx options"',
-    );
+    expect(markup).toContain('aria-label="Review changes to apps/web/src/components/Sidebar.tsx"');
+    expect(markup).toContain('aria-label="Open apps/web/src/components/Sidebar.tsx options"');
     expect(markup).toContain("apps/web/src/components/Sidebar.tsx");
     expect(markup.indexOf('aria-label="Copy message"')).toBeGreaterThan(
       markup.indexOf("Edited 1 file"),

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -3363,8 +3363,6 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("Review");
     expect(markup).toContain('aria-expanded="true"');
     expect(markup).toContain('data-edited-file-row="true"');
-    expect(markup).toContain('data-edited-file-path-trigger="true"');
-    expect(markup).toContain('aria-label="Review changes to apps/web/src/components/Sidebar.tsx"');
     expect(markup).toContain('aria-label="Open apps/web/src/components/Sidebar.tsx options"');
     expect(markup).toContain("apps/web/src/components/Sidebar.tsx");
     expect(markup.indexOf('aria-label="Copy message"')).toBeGreaterThan(

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -3362,7 +3362,14 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("Undo");
     expect(markup).toContain("Review");
     expect(markup).toContain('aria-expanded="true"');
-    expect(markup).toContain("font-system-ui truncate font-normal");
+    expect(markup).toContain('data-edited-file-row="true"');
+    expect(markup).toContain('data-edited-file-path-trigger="true"');
+    expect(markup).toContain(
+      'aria-label="Review changes to apps/web/src/components/Sidebar.tsx"',
+    );
+    expect(markup).toContain(
+      'aria-label="Open apps/web/src/components/Sidebar.tsx options"',
+    );
     expect(markup).toContain("apps/web/src/components/Sidebar.tsx");
     expect(markup.indexOf('aria-label="Copy message"')).toBeGreaterThan(
       markup.indexOf("Edited 1 file"),

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -4,8 +4,10 @@
 // Exports: MessagesTimeline
 
 import {
+  type EditorId,
   type MessageId,
   type ProviderMentionReference,
+  type ResolvedKeybindingsConfig,
   ThreadId,
   type ThreadGoalAchievement,
   type ThreadMarker,
@@ -77,6 +79,7 @@ import { InlineMentionChip } from "./InlineMentionChip";
 import { InlineSkillChip } from "./InlineSkillChip";
 import { InlineSlashCommandChip } from "./InlineSlashCommandChip";
 import { InlineAgentChip } from "./InlineAgentChip";
+import { EditedFileRow } from "./EditedFileRow";
 import { MessageActionButton, MESSAGE_ACTION_ICON_CLASS_NAME } from "./MessageActionButton";
 import { MessageCopyButton } from "./MessageCopyButton";
 import { AssistantSelectionsSummaryChip } from "./AssistantSelectionsSummaryChip";
@@ -173,6 +176,8 @@ import {
 } from "./threadFind.logic";
 
 const MAX_VISIBLE_INLINE_TOOL_ENTRIES = 4;
+const EMPTY_EDITOR_KEYBINDINGS: ResolvedKeybindingsConfig = [];
+const EMPTY_AVAILABLE_EDITORS: ReadonlyArray<EditorId> = [];
 // Changed-files list in the per-turn card is capped so large turns stay compact;
 // the rest are revealed via an inline "Show more" row.
 const MAX_VISIBLE_CHANGED_FILES = 5;
@@ -507,6 +512,9 @@ interface MessagesTimelineProps {
   chatFontSizePx?: number;
   timestampFormat: TimestampFormat;
   workspaceRoot: string | undefined;
+  /** Already-loaded launcher config; avoids one config subscription per changed-file row. */
+  keybindings?: ResolvedKeybindingsConfig;
+  availableEditors?: ReadonlyArray<EditorId>;
   /**
    * Right padding (px) applied to the scroll viewport so transcript rows clear a right-edge
    * overlay (e.g. the docked Environment card). The scrollbar stays pinned to the viewport's
@@ -583,6 +591,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   chatFontSizePx: chatFontSizePxProp,
   timestampFormat,
   workspaceRoot,
+  keybindings,
+  availableEditors,
   emptyStateContent,
   contentInsetRightPx,
   contentInsetBottomPx,
@@ -603,6 +613,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   const forkSource = forkSourceProp ?? null;
   const isTemporaryThread = isTemporaryThreadProp ?? false;
   const findHighlight = findHighlightProp ?? null;
+  const editorKeybindings = keybindings ?? EMPTY_EDITOR_KEYBINDINGS;
+  const installedEditors = availableEditors ?? EMPTY_AVAILABLE_EDITORS;
   const userMessageBubbleBorderClass = userMessageBubbleBorderClassName(isTemporaryThread);
   // The timeline remounts per thread (and when the agent-activity detail view
   // closes), but the anchor lives above it and survives those remounts. An
@@ -2350,39 +2362,21 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                     // bail out ("Unexpected terminal kind `logical` for logical test block").
                     const additions = file.additions ?? 0;
                     const deletions = file.deletions ?? 0;
-                    const hasDiffStat = additions + deletions > 0;
                     return (
-                      <button
+                      <EditedFileRow
                         key={file.path}
-                        type="button"
-                        className={cn(
-                          "group/file-row flex w-full items-center gap-2 border-t border-[color:var(--color-border-light)] bg-transparent px-3 py-2.5 text-left transition-colors hover:bg-[var(--color-background-button-secondary-hover)] dark:bg-transparent dark:hover:bg-transparent",
-                          withFirstReset && "first:border-t-0",
-                        )}
-                        onClick={() => onOpenTurnDiff(turnSummary.turnId, file.path)}
-                      >
-                        <FileEntryIcon
-                          pathValue={file.path}
-                          kind="file"
-                          theme={resolvedTheme}
-                          colorMode="inherit"
-                          className="size-4 shrink-0 text-[var(--color-text-foreground)] opacity-70 dark:opacity-80"
-                        />
-                        <span
-                          className="font-system-ui truncate font-normal text-[var(--color-text-foreground)] underline-offset-2 group-hover/file-row:underline group-focus-visible/file-row:underline"
-                          style={{ fontSize: chatTypographyStyle.fontSize }}
-                        >
-                          {file.path}
-                        </span>
-                        {hasDiffStat && (
-                          <span
-                            className="font-system-ui ml-auto shrink-0 tabular-nums"
-                            style={{ fontSize: chatTypographyStyle.fontSize }}
-                          >
-                            <DiffStatLabel additions={additions} deletions={deletions} />
-                          </span>
-                        )}
-                      </button>
+                        filePath={file.path}
+                        fileKind={file.kind}
+                        additions={additions}
+                        deletions={deletions}
+                        workspaceRoot={workspaceRoot}
+                        keybindings={editorKeybindings}
+                        availableEditors={installedEditors}
+                        resolvedTheme={resolvedTheme}
+                        fontSize={chatTypographyStyle.fontSize}
+                        withFirstReset={withFirstReset}
+                        onReview={() => onOpenTurnDiff(turnSummary.turnId, file.path)}
+                      />
                     );
                   };
                   return (

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -2329,6 +2329,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                   const fileChangesExpanded =
                     expandedFileChangesByTurnId[turnSummary.turnId] ?? true;
                   const fileListExpanded = expandedFileListByTurnId[turnSummary.turnId] ?? false;
+                  const fileListHasMounted = Object.hasOwn(
+                    expandedFileListByTurnId,
+                    turnSummary.turnId,
+                  );
                   const checkpointTurnCount = turnSummary.checkpointTurnCount;
                   const checkpointTurnCounts =
                     turnSummary.checkpointTurnCounts ??
@@ -2455,7 +2459,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                       </div>
                       <DisclosureRegion open={fileChangesExpanded}>
                         {firstCheckpointFiles.map((file) => renderCheckpointFileRow(file, true))}
-                        {overflowCheckpointFiles.length > 0 ? (
+                        {overflowCheckpointFiles.length > 0 && fileListHasMounted ? (
                           <DisclosureRegion open={fileListExpanded}>
                             {overflowCheckpointFiles.map((file) =>
                               renderCheckpointFileRow(file, false),

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -2362,11 +2362,12 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                     // bail out ("Unexpected terminal kind `logical` for logical test block").
                     const additions = file.additions ?? 0;
                     const deletions = file.deletions ?? 0;
+                    const fileKind = file.kind ?? "modified";
                     return (
                       <EditedFileRow
                         key={file.path}
                         filePath={file.path}
-                        fileKind={file.kind}
+                        fileKind={fileKind}
                         additions={additions}
                         deletions={deletions}
                         workspaceRoot={workspaceRoot}

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -5,6 +5,7 @@
 
 import { type EditorId, type ResolvedKeybindingsConfig } from "@synara/contracts";
 import { useQuery } from "@tanstack/react-query";
+import { type ReactNode } from "react";
 import { useEditorLaunchers } from "~/hooks/useEditorLaunchers";
 import { ChevronDownIcon } from "~/lib/icons";
 import { serverConfigQueryOptions } from "~/lib/serverReactQuery";
@@ -16,6 +17,7 @@ import {
   MenuShortcut,
   MenuTrigger,
   MenuItem,
+  MenuSeparator,
 } from "../ui/menu";
 import { ComposerPickerMenuPopup } from "./ComposerPickerMenuPopup";
 import {
@@ -30,17 +32,10 @@ import {
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
 const EMPTY_AVAILABLE_EDITORS: ReadonlyArray<EditorId> = [];
 
-export function OpenInPicker({
-  keybindings: keybindingsProp,
-  availableEditors: availableEditorsProp,
-  openInTarget,
-  labelMode: labelModeProp,
-  defaultEditor,
-}: {
+interface OpenInPickerProps {
   // Editor config is optional: callers that already hold it (e.g. the chat
   // header) pass it through, while standalone surfaces (file-preview headers)
-  // omit it and let the picker self-fetch. react-query dedupes by key with an
-  // infinite stale time, so multiple self-fetching pickers share one request.
+  // omit it and let the picker self-fetch.
   keybindings?: ResolvedKeybindingsConfig;
   availableEditors?: ReadonlyArray<EditorId>;
   openInTarget: string | null;
@@ -53,14 +48,73 @@ export function OpenInPicker({
   // mutating the shared preferred-editor setting. The PDF viewer uses this to default
   // to the OS viewer (e.g. Preview) while still listing installed editors.
   defaultEditor?: EditorId;
-}) {
+  // Lets a file surface reuse the installed-editor menu while its main action
+  // stays in-app. Omitting this preserves the normal preferred-editor action.
+  primaryAction?: {
+    onClick: () => void;
+    disabled?: boolean;
+    icon?: ReactNode;
+  };
+  // Surface-specific actions appended after the shared installed-editor list.
+  // OpenInPicker owns the separator so callers cannot create malformed menus.
+  additionalMenuItems?: ReactNode;
+  /** Optional surface-specific display priority; unlisted installed editors follow in catalog order. */
+  menuEditorOrder?: ReadonlyArray<EditorId>;
+  groupLabel?: string;
+  menuLabel?: string;
+}
+
+type OpenInPickerContentProps = OpenInPickerProps & {
+  keybindings: ResolvedKeybindingsConfig;
+  availableEditors: ReadonlyArray<EditorId>;
+};
+
+export function OpenInPicker(props: OpenInPickerProps) {
+  if (props.keybindings !== undefined && props.availableEditors !== undefined) {
+    return (
+      <OpenInPickerContent
+        {...props}
+        keybindings={props.keybindings}
+        availableEditors={props.availableEditors}
+      />
+    );
+  }
+  return <OpenInPickerWithConfig {...props} />;
+}
+
+function OpenInPickerWithConfig(props: OpenInPickerProps) {
+  // The query-owning wrapper mounts only for standalone surfaces. Rows that
+  // receive config from ChatView avoid both the subscription and a QueryClient
+  // dependency in isolated rendering/tests.
+  const serverConfigQuery = useQuery(serverConfigQueryOptions());
+  return (
+    <OpenInPickerContent
+      {...props}
+      keybindings={props.keybindings ?? serverConfigQuery.data?.keybindings ?? EMPTY_KEYBINDINGS}
+      availableEditors={
+        props.availableEditors ??
+        serverConfigQuery.data?.availableEditors ??
+        EMPTY_AVAILABLE_EDITORS
+      }
+    />
+  );
+}
+
+function OpenInPickerContent({
+  keybindings,
+  availableEditors,
+  openInTarget,
+  labelMode: labelModeProp,
+  defaultEditor,
+  primaryAction,
+  additionalMenuItems,
+  menuEditorOrder,
+  groupLabel: groupLabelProp,
+  menuLabel: menuLabelProp,
+}: OpenInPickerContentProps) {
   const labelMode = labelModeProp ?? "responsive";
-  // Only subscribe to the config query when the caller did not supply config.
-  const needsConfig = keybindingsProp === undefined || availableEditorsProp === undefined;
-  const serverConfigQuery = useQuery({ ...serverConfigQueryOptions(), enabled: needsConfig });
-  const keybindings = keybindingsProp ?? serverConfigQuery.data?.keybindings ?? EMPTY_KEYBINDINGS;
-  const availableEditors =
-    availableEditorsProp ?? serverConfigQuery.data?.availableEditors ?? EMPTY_AVAILABLE_EDITORS;
+  const groupLabel = groupLabelProp ?? "Open in editor";
+  const menuLabel = menuLabelProp ?? "Editor options";
 
   const {
     options,
@@ -70,16 +124,33 @@ export function OpenInPicker({
     setDefaultEditor,
     openInEditor,
   } = useEditorLaunchers({ keybindings, availableEditors, openInTarget, defaultEditor });
+  const displayedOptions = menuEditorOrder
+    ? [
+        ...menuEditorOrder.flatMap((editorId) =>
+          options.filter(({ value }) => value === editorId),
+        ),
+        ...options.filter(({ value }) => !menuEditorOrder.includes(value)),
+      ]
+    : options;
+
+  const primaryDisabled = primaryAction
+    ? (primaryAction.disabled ?? false)
+    : !preferredEditor || !openInTarget;
+  const primaryIcon = primaryAction?.icon ??
+    (primaryOption?.Icon ? (
+      <primaryOption.Icon aria-hidden="true" className="size-3.5" />
+    ) : null);
+  const handlePrimaryOpen = primaryAction?.onClick ?? (() => openInEditor(preferredEditor));
 
   return (
-    <ChatHeaderSplitGroup label="Open in editor">
+    <ChatHeaderSplitGroup label={groupLabel}>
       <ChatHeaderButton
         tone="outline"
         className={CHAT_HEADER_SPLIT_LEADING_CLASS_NAME}
-        disabled={!preferredEditor || !openInTarget}
-        onClick={() => openInEditor(preferredEditor)}
+        disabled={primaryDisabled}
+        onClick={handlePrimaryOpen}
       >
-        {primaryOption?.Icon && <primaryOption.Icon aria-hidden="true" className="size-3.5" />}
+        {primaryIcon}
         <span
           className={cn(
             "font-normal",
@@ -96,7 +167,7 @@ export function OpenInPicker({
         <MenuTrigger
           render={
             <ChatHeaderIconButton
-              label="Editor options"
+              label={menuLabel}
               tone="outline"
               className={CHAT_HEADER_SPLIT_TRAILING_CLASS_NAME}
             />
@@ -105,12 +176,14 @@ export function OpenInPicker({
           <ChevronDownIcon aria-hidden="true" className="size-3.5" />
         </MenuTrigger>
         <ComposerPickerMenuPopup align="end" side="bottom" className="w-44 min-w-44">
-          {options.length === 0 && <MenuItem disabled>No installed editors found</MenuItem>}
+          {displayedOptions.length === 0 && (
+            <MenuItem disabled>No installed editors found</MenuItem>
+          )}
           <MenuRadioGroup
             value={preferredEditor ?? ""}
             onValueChange={(value) => setDefaultEditor(value as EditorId)}
           >
-            {options.map(({ label, Icon, value }) => (
+            {displayedOptions.map(({ label, Icon, value }) => (
               <MenuRadioItem
                 key={value}
                 preserveChildLayout
@@ -120,6 +193,7 @@ export function OpenInPicker({
                   ) : null
                 }
                 value={value}
+                disabled={!openInTarget}
                 onClick={() => openInEditor(value)}
               >
                 <span className="flex min-w-0 items-center gap-2">
@@ -131,6 +205,12 @@ export function OpenInPicker({
               </MenuRadioItem>
             ))}
           </MenuRadioGroup>
+          {additionalMenuItems ? (
+            <>
+              <MenuSeparator />
+              {additionalMenuItems}
+            </>
+          ) : null}
         </ComposerPickerMenuPopup>
       </Menu>
     </ChatHeaderSplitGroup>

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -5,8 +5,8 @@
 
 import { type EditorId, type ResolvedKeybindingsConfig } from "@synara/contracts";
 import { useQuery } from "@tanstack/react-query";
-import { type ReactNode } from "react";
-import { useEditorLaunchers } from "~/hooks/useEditorLaunchers";
+import { useState, type ReactNode } from "react";
+import { useEditorLaunchers, type EditorLaunchers } from "~/hooks/useEditorLaunchers";
 import { ChevronDownIcon } from "~/lib/icons";
 import { serverConfigQueryOptions } from "~/lib/serverReactQuery";
 import { cn } from "~/lib/utils";
@@ -100,7 +100,114 @@ function OpenInPickerWithConfig(props: OpenInPickerProps) {
   );
 }
 
-function OpenInPickerContent({
+function OpenInPickerContent({ primaryAction, ...props }: OpenInPickerContentProps) {
+  return primaryAction ? (
+    <PrimaryActionOpenInPicker {...props} primaryAction={primaryAction} />
+  ) : (
+    <EditorActionOpenInPicker {...props} />
+  );
+}
+
+interface OpenInPickerFrameProps {
+  labelMode: "responsive" | "always";
+  groupLabel: string;
+  menuLabel: string;
+  primaryDisabled: boolean;
+  primaryIcon: ReactNode;
+  onPrimaryOpen: () => void;
+  onMenuOpenChange?: (open: boolean) => void;
+  menuContent: ReactNode;
+}
+
+function OpenInPickerFrame(props: OpenInPickerFrameProps) {
+  return (
+    <ChatHeaderSplitGroup label={props.groupLabel}>
+      <ChatHeaderButton
+        tone="outline"
+        className={CHAT_HEADER_SPLIT_LEADING_CLASS_NAME}
+        disabled={props.primaryDisabled}
+        onClick={props.onPrimaryOpen}
+      >
+        {props.primaryIcon}
+        <span
+          className={cn(
+            "font-normal",
+            props.labelMode === "always"
+              ? "ml-0.5"
+              : "sr-only @sm/header-actions:not-sr-only @sm/header-actions:ml-0.5",
+          )}
+        >
+          Open
+        </span>
+      </ChatHeaderButton>
+      <ChatHeaderSplitDivider />
+      <Menu {...(props.onMenuOpenChange ? { onOpenChange: props.onMenuOpenChange } : {})}>
+        <MenuTrigger
+          render={
+            <ChatHeaderIconButton
+              label={props.menuLabel}
+              tone="outline"
+              className={CHAT_HEADER_SPLIT_TRAILING_CLASS_NAME}
+            />
+          }
+        >
+          <ChevronDownIcon aria-hidden="true" className="size-3.5" />
+        </MenuTrigger>
+        {props.menuContent}
+      </Menu>
+    </ChatHeaderSplitGroup>
+  );
+}
+
+function EditorActionOpenInPicker({
+  keybindings,
+  availableEditors,
+  openInTarget,
+  labelMode: labelModeProp,
+  defaultEditor,
+  additionalMenuItems,
+  menuEditorOrder,
+  groupLabel: groupLabelProp,
+  menuLabel: menuLabelProp,
+}: OpenInPickerContentProps) {
+  const labelMode = labelModeProp ?? "responsive";
+  const groupLabel = groupLabelProp ?? "Open in editor";
+  const menuLabel = menuLabelProp ?? "Editor options";
+  const launchers = useEditorLaunchers({
+    keybindings,
+    availableEditors,
+    openInTarget,
+    defaultEditor,
+  });
+  const primaryIcon = launchers.primaryOption?.Icon ? (
+    <launchers.primaryOption.Icon aria-hidden="true" className="size-3.5" />
+  ) : null;
+
+  return (
+    <OpenInPickerFrame
+      labelMode={labelMode}
+      groupLabel={groupLabel}
+      menuLabel={menuLabel}
+      primaryDisabled={!launchers.preferredEditor || !openInTarget}
+      primaryIcon={primaryIcon}
+      onPrimaryOpen={() => launchers.openInEditor(launchers.preferredEditor)}
+      menuContent={
+        <OpenInPickerMenuPopup
+          launchers={launchers}
+          openInTarget={openInTarget}
+          {...(additionalMenuItems !== undefined ? { additionalMenuItems } : {})}
+          {...(menuEditorOrder ? { menuEditorOrder } : {})}
+        />
+      }
+    />
+  );
+}
+
+type PrimaryActionOpenInPickerProps = Omit<OpenInPickerContentProps, "primaryAction"> & {
+  primaryAction: NonNullable<OpenInPickerProps["primaryAction"]>;
+};
+
+function PrimaryActionOpenInPicker({
   keybindings,
   availableEditors,
   openInTarget,
@@ -111,19 +218,82 @@ function OpenInPickerContent({
   menuEditorOrder,
   groupLabel: groupLabelProp,
   menuLabel: menuLabelProp,
-}: OpenInPickerContentProps) {
-  const labelMode = labelModeProp ?? "responsive";
-  const groupLabel = groupLabelProp ?? "Open in editor";
-  const menuLabel = menuLabelProp ?? "Editor options";
+}: PrimaryActionOpenInPickerProps) {
+  const [launcherMenuMounted, setLauncherMenuMounted] = useState(false);
+  const handleMenuOpenChange = (open: boolean) => {
+    if (open) setLauncherMenuMounted(true);
+  };
 
-  const {
-    options,
-    preferredEditor,
-    primaryOption,
-    openFavoriteShortcutLabel,
-    setDefaultEditor,
-    openInEditor,
-  } = useEditorLaunchers({ keybindings, availableEditors, openInTarget, defaultEditor });
+  return (
+    <OpenInPickerFrame
+      labelMode={labelModeProp ?? "responsive"}
+      groupLabel={groupLabelProp ?? "Open in editor"}
+      menuLabel={menuLabelProp ?? "Editor options"}
+      primaryDisabled={primaryAction.disabled ?? false}
+      primaryIcon={primaryAction.icon ?? null}
+      onPrimaryOpen={primaryAction.onClick}
+      onMenuOpenChange={handleMenuOpenChange}
+      menuContent={
+        launcherMenuMounted ? (
+          <OpenInPickerMenuWithLaunchers
+            keybindings={keybindings}
+            availableEditors={availableEditors}
+            openInTarget={openInTarget}
+            {...(defaultEditor ? { defaultEditor } : {})}
+            {...(additionalMenuItems !== undefined ? { additionalMenuItems } : {})}
+            {...(menuEditorOrder ? { menuEditorOrder } : {})}
+          />
+        ) : null
+      }
+    />
+  );
+}
+
+function OpenInPickerMenuWithLaunchers({
+  keybindings,
+  availableEditors,
+  openInTarget,
+  defaultEditor,
+  additionalMenuItems,
+  menuEditorOrder,
+}: Pick<
+  OpenInPickerContentProps,
+  | "keybindings"
+  | "availableEditors"
+  | "openInTarget"
+  | "defaultEditor"
+  | "additionalMenuItems"
+  | "menuEditorOrder"
+>) {
+  const launchers = useEditorLaunchers({
+    keybindings,
+    availableEditors,
+    openInTarget,
+    defaultEditor,
+  });
+  return (
+    <OpenInPickerMenuPopup
+      launchers={launchers}
+      openInTarget={openInTarget}
+      {...(additionalMenuItems !== undefined ? { additionalMenuItems } : {})}
+      {...(menuEditorOrder ? { menuEditorOrder } : {})}
+    />
+  );
+}
+
+function OpenInPickerMenuPopup({
+  launchers,
+  openInTarget,
+  additionalMenuItems,
+  menuEditorOrder,
+}: {
+  launchers: EditorLaunchers;
+  openInTarget: string | null;
+  additionalMenuItems?: ReactNode;
+  menuEditorOrder?: ReadonlyArray<EditorId>;
+}) {
+  const { options, preferredEditor, openFavoriteShortcutLabel, setDefaultEditor, openInEditor } =
+    launchers;
   const displayedOptions = menuEditorOrder
     ? [
         ...menuEditorOrder.flatMap((editorId) => options.filter(({ value }) => value === editorId)),
@@ -131,85 +301,41 @@ function OpenInPickerContent({
       ]
     : options;
 
-  const primaryDisabled = primaryAction
-    ? (primaryAction.disabled ?? false)
-    : !preferredEditor || !openInTarget;
-  const primaryIcon =
-    primaryAction?.icon ??
-    (primaryOption?.Icon ? <primaryOption.Icon aria-hidden="true" className="size-3.5" /> : null);
-  const handlePrimaryOpen = primaryAction?.onClick ?? (() => openInEditor(preferredEditor));
-
   return (
-    <ChatHeaderSplitGroup label={groupLabel}>
-      <ChatHeaderButton
-        tone="outline"
-        className={CHAT_HEADER_SPLIT_LEADING_CLASS_NAME}
-        disabled={primaryDisabled}
-        onClick={handlePrimaryOpen}
+    <ComposerPickerMenuPopup align="end" side="bottom" className="w-44 min-w-44">
+      {displayedOptions.length === 0 && <MenuItem disabled>No installed editors found</MenuItem>}
+      <MenuRadioGroup
+        value={preferredEditor ?? ""}
+        onValueChange={(value) => setDefaultEditor(value as EditorId)}
       >
-        {primaryIcon}
-        <span
-          className={cn(
-            "font-normal",
-            labelMode === "always"
-              ? "ml-0.5"
-              : "sr-only @sm/header-actions:not-sr-only @sm/header-actions:ml-0.5",
-          )}
-        >
-          Open
-        </span>
-      </ChatHeaderButton>
-      <ChatHeaderSplitDivider />
-      <Menu>
-        <MenuTrigger
-          render={
-            <ChatHeaderIconButton
-              label={menuLabel}
-              tone="outline"
-              className={CHAT_HEADER_SPLIT_TRAILING_CLASS_NAME}
-            />
-          }
-        >
-          <ChevronDownIcon aria-hidden="true" className="size-3.5" />
-        </MenuTrigger>
-        <ComposerPickerMenuPopup align="end" side="bottom" className="w-44 min-w-44">
-          {displayedOptions.length === 0 && (
-            <MenuItem disabled>No installed editors found</MenuItem>
-          )}
-          <MenuRadioGroup
-            value={preferredEditor ?? ""}
-            onValueChange={(value) => setDefaultEditor(value as EditorId)}
+        {displayedOptions.map(({ label, Icon, value }) => (
+          <MenuRadioItem
+            key={value}
+            preserveChildLayout
+            trailing={
+              value === preferredEditor && openFavoriteShortcutLabel ? (
+                <MenuShortcut>{openFavoriteShortcutLabel}</MenuShortcut>
+              ) : null
+            }
+            value={value}
+            disabled={!openInTarget}
+            onClick={() => openInEditor(value)}
           >
-            {displayedOptions.map(({ label, Icon, value }) => (
-              <MenuRadioItem
-                key={value}
-                preserveChildLayout
-                trailing={
-                  value === preferredEditor && openFavoriteShortcutLabel ? (
-                    <MenuShortcut>{openFavoriteShortcutLabel}</MenuShortcut>
-                  ) : null
-                }
-                value={value}
-                disabled={!openInTarget}
-                onClick={() => openInEditor(value)}
-              >
-                <span className="flex min-w-0 items-center gap-2">
-                  <span className="shrink-0">
-                    <Icon aria-hidden="true" className="size-3.5 text-muted-foreground" />
-                  </span>
-                  <span className="truncate">{label}</span>
-                </span>
-              </MenuRadioItem>
-            ))}
-          </MenuRadioGroup>
-          {additionalMenuItems ? (
-            <>
-              <MenuSeparator />
-              {additionalMenuItems}
-            </>
-          ) : null}
-        </ComposerPickerMenuPopup>
-      </Menu>
-    </ChatHeaderSplitGroup>
+            <span className="flex min-w-0 items-center gap-2">
+              <span className="shrink-0">
+                <Icon aria-hidden="true" className="size-3.5 text-muted-foreground" />
+              </span>
+              <span className="truncate">{label}</span>
+            </span>
+          </MenuRadioItem>
+        ))}
+      </MenuRadioGroup>
+      {additionalMenuItems ? (
+        <>
+          <MenuSeparator />
+          {additionalMenuItems}
+        </>
+      ) : null}
+    </ComposerPickerMenuPopup>
   );
 }

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -126,9 +126,7 @@ function OpenInPickerContent({
   } = useEditorLaunchers({ keybindings, availableEditors, openInTarget, defaultEditor });
   const displayedOptions = menuEditorOrder
     ? [
-        ...menuEditorOrder.flatMap((editorId) =>
-          options.filter(({ value }) => value === editorId),
-        ),
+        ...menuEditorOrder.flatMap((editorId) => options.filter(({ value }) => value === editorId)),
         ...options.filter(({ value }) => !menuEditorOrder.includes(value)),
       ]
     : options;
@@ -136,10 +134,9 @@ function OpenInPickerContent({
   const primaryDisabled = primaryAction
     ? (primaryAction.disabled ?? false)
     : !preferredEditor || !openInTarget;
-  const primaryIcon = primaryAction?.icon ??
-    (primaryOption?.Icon ? (
-      <primaryOption.Icon aria-hidden="true" className="size-3.5" />
-    ) : null);
+  const primaryIcon =
+    primaryAction?.icon ??
+    (primaryOption?.Icon ? <primaryOption.Icon aria-hidden="true" className="size-3.5" /> : null);
   const handlePrimaryOpen = primaryAction?.onClick ?? (() => openInEditor(preferredEditor));
 
   return (

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -32,6 +32,12 @@ import {
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
 const EMPTY_AVAILABLE_EDITORS: ReadonlyArray<EditorId> = [];
 
+interface OpenInPickerPrimaryAction {
+  onClick: () => void;
+  disabled?: boolean;
+  icon?: ReactNode;
+}
+
 interface OpenInPickerProps {
   // Editor config is optional: callers that already hold it (e.g. the chat
   // header) pass it through, while standalone surfaces (file-preview headers)
@@ -50,11 +56,7 @@ interface OpenInPickerProps {
   defaultEditor?: EditorId;
   // Lets a file surface reuse the installed-editor menu while its main action
   // stays in-app. Omitting this preserves the normal preferred-editor action.
-  primaryAction?: {
-    onClick: () => void;
-    disabled?: boolean;
-    icon?: ReactNode;
-  };
+  primaryAction?: OpenInPickerPrimaryAction;
   // Surface-specific actions appended after the shared installed-editor list.
   // OpenInPicker owns the separator so callers cannot create malformed menus.
   additionalMenuItems?: ReactNode;
@@ -112,9 +114,7 @@ interface OpenInPickerFrameProps {
   labelMode: "responsive" | "always";
   groupLabel: string;
   menuLabel: string;
-  primaryDisabled: boolean;
-  primaryIcon: ReactNode;
-  onPrimaryOpen: () => void;
+  primaryAction: OpenInPickerPrimaryAction;
   onMenuOpenChange?: (open: boolean) => void;
   menuContent: ReactNode;
 }
@@ -125,10 +125,10 @@ function OpenInPickerFrame(props: OpenInPickerFrameProps) {
       <ChatHeaderButton
         tone="outline"
         className={CHAT_HEADER_SPLIT_LEADING_CLASS_NAME}
-        disabled={props.primaryDisabled}
-        onClick={props.onPrimaryOpen}
+        disabled={props.primaryAction.disabled ?? false}
+        onClick={props.primaryAction.onClick}
       >
-        {props.primaryIcon}
+        {props.primaryAction.icon ?? null}
         <span
           className={cn(
             "font-normal",
@@ -159,124 +159,61 @@ function OpenInPickerFrame(props: OpenInPickerFrameProps) {
   );
 }
 
-function EditorActionOpenInPicker({
-  keybindings,
-  availableEditors,
-  openInTarget,
-  labelMode: labelModeProp,
-  defaultEditor,
-  additionalMenuItems,
-  menuEditorOrder,
-  groupLabel: groupLabelProp,
-  menuLabel: menuLabelProp,
-}: OpenInPickerContentProps) {
-  const labelMode = labelModeProp ?? "responsive";
-  const groupLabel = groupLabelProp ?? "Open in editor";
-  const menuLabel = menuLabelProp ?? "Editor options";
-  const launchers = useEditorLaunchers({
-    keybindings,
-    availableEditors,
-    openInTarget,
-    defaultEditor,
-  });
-  const primaryIcon = launchers.primaryOption?.Icon ? (
-    <launchers.primaryOption.Icon aria-hidden="true" className="size-3.5" />
-  ) : null;
+function EditorActionOpenInPicker(props: OpenInPickerContentProps) {
+  const launchers = useEditorLaunchers(props);
+  const PrimaryIcon = launchers.primaryOption?.Icon;
 
   return (
     <OpenInPickerFrame
-      labelMode={labelMode}
-      groupLabel={groupLabel}
-      menuLabel={menuLabel}
-      primaryDisabled={!launchers.preferredEditor || !openInTarget}
-      primaryIcon={primaryIcon}
-      onPrimaryOpen={() => launchers.openInEditor(launchers.preferredEditor)}
+      labelMode={props.labelMode ?? "responsive"}
+      groupLabel={props.groupLabel ?? "Open in editor"}
+      menuLabel={props.menuLabel ?? "Editor options"}
+      primaryAction={{
+        disabled: !launchers.preferredEditor || !props.openInTarget,
+        icon: PrimaryIcon ? <PrimaryIcon aria-hidden="true" className="size-3.5" /> : null,
+        onClick: () => launchers.openInEditor(launchers.preferredEditor),
+      }}
       menuContent={
         <OpenInPickerMenuPopup
           launchers={launchers}
-          openInTarget={openInTarget}
-          {...(additionalMenuItems !== undefined ? { additionalMenuItems } : {})}
-          {...(menuEditorOrder ? { menuEditorOrder } : {})}
+          openInTarget={props.openInTarget}
+          additionalMenuItems={props.additionalMenuItems}
+          menuEditorOrder={props.menuEditorOrder}
         />
       }
     />
   );
 }
 
-type PrimaryActionOpenInPickerProps = Omit<OpenInPickerContentProps, "primaryAction"> & {
-  primaryAction: NonNullable<OpenInPickerProps["primaryAction"]>;
+type PrimaryActionOpenInPickerProps = OpenInPickerContentProps & {
+  primaryAction: OpenInPickerPrimaryAction;
 };
 
-function PrimaryActionOpenInPicker({
-  keybindings,
-  availableEditors,
-  openInTarget,
-  labelMode: labelModeProp,
-  defaultEditor,
-  primaryAction,
-  additionalMenuItems,
-  menuEditorOrder,
-  groupLabel: groupLabelProp,
-  menuLabel: menuLabelProp,
-}: PrimaryActionOpenInPickerProps) {
+function PrimaryActionOpenInPicker({ primaryAction, ...props }: PrimaryActionOpenInPickerProps) {
   const [launcherMenuMounted, setLauncherMenuMounted] = useState(false);
-  const handleMenuOpenChange = (open: boolean) => {
-    if (open) setLauncherMenuMounted(true);
-  };
 
   return (
     <OpenInPickerFrame
-      labelMode={labelModeProp ?? "responsive"}
-      groupLabel={groupLabelProp ?? "Open in editor"}
-      menuLabel={menuLabelProp ?? "Editor options"}
-      primaryDisabled={primaryAction.disabled ?? false}
-      primaryIcon={primaryAction.icon ?? null}
-      onPrimaryOpen={primaryAction.onClick}
-      onMenuOpenChange={handleMenuOpenChange}
-      menuContent={
-        launcherMenuMounted ? (
-          <OpenInPickerMenuWithLaunchers
-            keybindings={keybindings}
-            availableEditors={availableEditors}
-            openInTarget={openInTarget}
-            {...(defaultEditor ? { defaultEditor } : {})}
-            {...(additionalMenuItems !== undefined ? { additionalMenuItems } : {})}
-            {...(menuEditorOrder ? { menuEditorOrder } : {})}
-          />
-        ) : null
-      }
+      labelMode={props.labelMode ?? "responsive"}
+      groupLabel={props.groupLabel ?? "Open in editor"}
+      menuLabel={props.menuLabel ?? "Editor options"}
+      primaryAction={primaryAction}
+      onMenuOpenChange={(open) => {
+        if (open) setLauncherMenuMounted(true);
+      }}
+      menuContent={launcherMenuMounted ? <OpenInPickerMenuWithLaunchers {...props} /> : null}
     />
   );
 }
 
-function OpenInPickerMenuWithLaunchers({
-  keybindings,
-  availableEditors,
-  openInTarget,
-  defaultEditor,
-  additionalMenuItems,
-  menuEditorOrder,
-}: Pick<
-  OpenInPickerContentProps,
-  | "keybindings"
-  | "availableEditors"
-  | "openInTarget"
-  | "defaultEditor"
-  | "additionalMenuItems"
-  | "menuEditorOrder"
->) {
-  const launchers = useEditorLaunchers({
-    keybindings,
-    availableEditors,
-    openInTarget,
-    defaultEditor,
-  });
+function OpenInPickerMenuWithLaunchers(props: OpenInPickerContentProps) {
+  const launchers = useEditorLaunchers(props);
   return (
     <OpenInPickerMenuPopup
       launchers={launchers}
-      openInTarget={openInTarget}
-      {...(additionalMenuItems !== undefined ? { additionalMenuItems } : {})}
-      {...(menuEditorOrder ? { menuEditorOrder } : {})}
+      openInTarget={props.openInTarget}
+      additionalMenuItems={props.additionalMenuItems}
+      menuEditorOrder={props.menuEditorOrder}
     />
   );
 }
@@ -289,8 +226,8 @@ function OpenInPickerMenuPopup({
 }: {
   launchers: EditorLaunchers;
   openInTarget: string | null;
-  additionalMenuItems?: ReactNode;
-  menuEditorOrder?: ReadonlyArray<EditorId>;
+  additionalMenuItems: ReactNode;
+  menuEditorOrder: ReadonlyArray<EditorId> | undefined;
 }) {
   const { options, preferredEditor, openFavoriteShortcutLabel, setDefaultEditor, openInEditor } =
     launchers;

--- a/apps/web/src/components/chat/WorkspaceFilePreviewHeader.tsx
+++ b/apps/web/src/components/chat/WorkspaceFilePreviewHeader.tsx
@@ -17,10 +17,7 @@ import { isWorkspaceRelativePathSafe, joinWorkspaceRelativePath } from "@synara/
 import { Fragment, useLayoutEffect, useRef, useState } from "react";
 
 import { basenameOfPath } from "~/file-icons";
-import {
-  useCopyFileContentsToClipboard,
-  useCopyPathToClipboard,
-} from "~/hooks/useCopyToClipboard";
+import { useCopyFileContentsToClipboard, useCopyPathToClipboard } from "~/hooks/useCopyToClipboard";
 import type { ChatFileReference } from "~/lib/chatReferences";
 import { ChevronRightIcon, CodeIcon, CopyIcon, EllipsisIcon, EyeOpenIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";

--- a/apps/web/src/components/chat/WorkspaceFilePreviewHeader.tsx
+++ b/apps/web/src/components/chat/WorkspaceFilePreviewHeader.tsx
@@ -17,9 +17,12 @@ import { isWorkspaceRelativePathSafe, joinWorkspaceRelativePath } from "@synara/
 import { Fragment, useLayoutEffect, useRef, useState } from "react";
 
 import { basenameOfPath } from "~/file-icons";
-import { useCopyFileContentsToClipboard } from "~/hooks/useCopyToClipboard";
+import {
+  useCopyFileContentsToClipboard,
+  useCopyPathToClipboard,
+} from "~/hooks/useCopyToClipboard";
 import type { ChatFileReference } from "~/lib/chatReferences";
-import { ChevronRightIcon, CodeIcon, EllipsisIcon, EyeOpenIcon } from "~/lib/icons";
+import { ChevronRightIcon, CodeIcon, CopyIcon, EllipsisIcon, EyeOpenIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
 import { Menu, MenuItem, MenuTrigger } from "../ui/menu";
 import { CHAT_SURFACE_HEADER_DIVIDER_CLASS_NAME, ChatHeaderIconButton } from "./chatHeaderControls";
@@ -260,9 +263,13 @@ export const WorkspaceFilePreviewHeader = function WorkspaceFilePreviewHeader(
     onAskWhyInChat?.({ path: filePath });
   };
   const copyFileContents = useCopyFileContentsToClipboard();
+  const copyPathToClipboard = useCopyPathToClipboard();
 
   const canCopyContents = contentsForCopy != null;
-  const hasOverflowMenu = canCopyContents || Boolean(onReferenceInChat || onAskWhyInChat);
+  const openInTarget =
+    fileIsOutsideWorkspace || !workspaceRoot
+      ? filePath
+      : joinWorkspaceRelativePath(workspaceRoot, filePath);
 
   return (
     <div
@@ -323,43 +330,39 @@ export const WorkspaceFilePreviewHeader = function WorkspaceFilePreviewHeader(
           </div>
         ) : null}
 
-        {hasOverflowMenu ? (
-          <Menu>
-            <MenuTrigger render={<ChatHeaderIconButton label="More actions" tone="plain" />}>
-              <EllipsisIcon aria-hidden="true" className="size-3.5" />
-            </MenuTrigger>
-            <ComposerPickerMenuPopup align="end" side="bottom" className="w-52 min-w-52">
-              {canCopyContents ? (
-                <MenuItem
-                  onClick={() =>
-                    copyFileContents(contentsForCopy ?? "", fileSegment, {
-                      partial: props.truncated ?? false,
-                    })
-                  }
-                >
-                  Copy contents
-                </MenuItem>
-              ) : null}
-              {onReferenceInChat ? (
-                <MenuItem onClick={referenceWholeFile}>Reference in chat</MenuItem>
-              ) : null}
-              {onAskWhyInChat ? (
-                <MenuItem onClick={askWhyWholeFile}>Ask why this changed</MenuItem>
-              ) : null}
-            </ComposerPickerMenuPopup>
-          </Menu>
-        ) : null}
+        <Menu>
+          <MenuTrigger render={<ChatHeaderIconButton label="More actions" tone="plain" />}>
+            <EllipsisIcon aria-hidden="true" className="size-3.5" />
+          </MenuTrigger>
+          <ComposerPickerMenuPopup align="end" side="bottom" className="w-52 min-w-52">
+            <MenuItem onClick={() => copyPathToClipboard(openInTarget)}>
+              <CopyIcon className="size-3.5 shrink-0 text-muted-foreground" />
+              <span>Copy path</span>
+            </MenuItem>
+            {canCopyContents ? (
+              <MenuItem
+                onClick={() =>
+                  copyFileContents(contentsForCopy ?? "", fileSegment, {
+                    partial: props.truncated ?? false,
+                  })
+                }
+              >
+                Copy contents
+              </MenuItem>
+            ) : null}
+            {onReferenceInChat ? (
+              <MenuItem onClick={referenceWholeFile}>Reference in chat</MenuItem>
+            ) : null}
+            {onAskWhyInChat ? (
+              <MenuItem onClick={askWhyWholeFile}>Ask why this changed</MenuItem>
+            ) : null}
+          </ComposerPickerMenuPopup>
+        </Menu>
 
         {/* Responsive (default) mode: the "Open" label rides the same
             `header-actions` container declared on this header, so it shows on a
             wide pane and collapses to the editor icon when the pane is narrow. */}
-        <OpenInPicker
-          openInTarget={
-            fileIsOutsideWorkspace || !workspaceRoot
-              ? filePath
-              : joinWorkspaceRelativePath(workspaceRoot, filePath)
-          }
-        />
+        <OpenInPicker openInTarget={openInTarget} />
       </div>
     </div>
   );

--- a/apps/web/src/components/chat/editedFilePathActions.test.ts
+++ b/apps/web/src/components/chat/editedFilePathActions.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveEditedFilePathTargets } from "./editedFilePathActions";
+
+describe("resolveEditedFilePathTargets", () => {
+  it("joins a workspace-relative path with POSIX and Windows roots", () => {
+    expect(resolveEditedFilePathTargets("src/file.ts", "/repo/app")).toEqual({
+      absolutePath: "/repo/app/src/file.ts",
+      relativePath: "src/file.ts",
+    });
+    expect(resolveEditedFilePathTargets("src/file.ts", "C:\\repo\\app")).toEqual({
+      absolutePath: "C:\\repo\\app\\src\\file.ts",
+      relativePath: "src/file.ts",
+    });
+  });
+
+  it("derives a relative path only for absolute files inside the workspace", () => {
+    expect(resolveEditedFilePathTargets("/repo/app/src/file.ts", "/repo/app")).toEqual({
+      absolutePath: "/repo/app/src/file.ts",
+      relativePath: "src/file.ts",
+    });
+    expect(resolveEditedFilePathTargets("/tmp/file.ts", "/repo/app")).toEqual({
+      absolutePath: "/tmp/file.ts",
+      relativePath: null,
+    });
+  });
+
+  it("keeps the relative action available when no workspace root exists", () => {
+    expect(resolveEditedFilePathTargets("src/file.ts", undefined)).toEqual({
+      absolutePath: null,
+      relativePath: "src/file.ts",
+    });
+  });
+
+  it("rejects empty and escaping paths", () => {
+    expect(resolveEditedFilePathTargets("  ", "/repo/app")).toEqual({
+      absolutePath: null,
+      relativePath: null,
+    });
+    expect(resolveEditedFilePathTargets("../outside.ts", "/repo/app")).toEqual({
+      absolutePath: null,
+      relativePath: null,
+    });
+  });
+});

--- a/apps/web/src/components/chat/editedFilePathActions.ts
+++ b/apps/web/src/components/chat/editedFilePathActions.ts
@@ -1,0 +1,46 @@
+// FILE: editedFilePathActions.ts
+// Purpose: Resolve the absolute and workspace-relative forms used by edited-file actions.
+// Layer: Chat changed-files UI logic
+
+import {
+  isLocalAbsolutePath,
+  isWorkspaceRelativePathSafe,
+  joinWorkspaceRelativePath,
+  workspaceRelativePathOf,
+} from "@synara/shared/path";
+
+export interface EditedFilePathTargets {
+  absolutePath: string | null;
+  relativePath: string | null;
+}
+
+export function resolveEditedFilePathTargets(
+  filePath: string,
+  workspaceRoot: string | undefined,
+): EditedFilePathTargets {
+  const trimmedPath = filePath.trim();
+  if (trimmedPath.length === 0) {
+    return { absolutePath: null, relativePath: null };
+  }
+
+  if (isLocalAbsolutePath(trimmedPath)) {
+    return {
+      absolutePath: trimmedPath,
+      relativePath: workspaceRoot
+        ? workspaceRelativePathOf(trimmedPath, workspaceRoot)
+        : null,
+    };
+  }
+
+  if (!isWorkspaceRelativePathSafe(trimmedPath)) {
+    return { absolutePath: null, relativePath: null };
+  }
+
+  const relativePath = trimmedPath.replace(/\\/g, "/");
+  return {
+    absolutePath: workspaceRoot
+      ? joinWorkspaceRelativePath(workspaceRoot, relativePath)
+      : null,
+    relativePath,
+  };
+}

--- a/apps/web/src/components/chat/editedFilePathActions.ts
+++ b/apps/web/src/components/chat/editedFilePathActions.ts
@@ -26,9 +26,7 @@ export function resolveEditedFilePathTargets(
   if (isLocalAbsolutePath(trimmedPath)) {
     return {
       absolutePath: trimmedPath,
-      relativePath: workspaceRoot
-        ? workspaceRelativePathOf(trimmedPath, workspaceRoot)
-        : null,
+      relativePath: workspaceRoot ? workspaceRelativePathOf(trimmedPath, workspaceRoot) : null,
     };
   }
 
@@ -38,9 +36,7 @@ export function resolveEditedFilePathTargets(
 
   const relativePath = trimmedPath.replace(/\\/g, "/");
   return {
-    absolutePath: workspaceRoot
-      ? joinWorkspaceRelativePath(workspaceRoot, relativePath)
-      : null,
+    absolutePath: workspaceRoot ? joinWorkspaceRelativePath(workspaceRoot, relativePath) : null,
     relativePath,
   };
 }

--- a/apps/web/src/editorMetadata.test.ts
+++ b/apps/web/src/editorMetadata.test.ts
@@ -28,6 +28,7 @@ describe("resolveAvailableEditorOptions", () => {
         "ghostty",
         "muxy",
         "terminal",
+        "iterm",
         "warp",
         "xcode",
         "webstorm",
@@ -55,6 +56,7 @@ describe("resolveAvailableEditorOptions", () => {
       "ghostty",
       "muxy",
       "terminal",
+      "iterm",
       "warp",
       "xcode",
       "idea",
@@ -76,6 +78,7 @@ describe("resolveAvailableEditorOptions", () => {
     expect(resolveEditorIcon("ghostty").name).toBe("GhosttyIcon");
     expect(resolveEditorIcon("muxy").name).toBe("TerminalAppIcon");
     expect(resolveEditorIcon("terminal").name).toBe("TerminalAppIcon");
+    expect(resolveEditorIcon("iterm").name).toBe("TerminalAppIcon");
     expect(resolveEditorIcon("xcode").name).toBe("SimpleIcon");
     expect(resolveEditorIcon("webstorm").name).toBe("SimpleIcon");
   });

--- a/apps/web/src/editorMetadata.ts
+++ b/apps/web/src/editorMetadata.ts
@@ -55,6 +55,7 @@ const EDITOR_ICONS: Partial<Record<EditorId, Icon>> = {
   ghostty: GhosttyIcon,
   muxy: TerminalAppIcon,
   terminal: TerminalAppIcon,
+  iterm: TerminalAppIcon,
   warp: WarpIcon,
   xcode: XcodeIcon,
   idea: IntelliJIdeaIcon,

--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -138,6 +138,13 @@ export const EDITORS = [
     launchStyle: "terminal-working-directory",
   },
   {
+    id: "iterm",
+    label: "iTerm",
+    commands: ["iterm2"],
+    macApplications: ["iTerm"],
+    launchStyle: "terminal-working-directory",
+  },
+  {
     id: "warp",
     label: "Warp",
     commands: ["warp"],


### PR DESCRIPTION
## Summary
- replace each edited-file button with sibling row, Review, and Open split controls
- keep row and Review actions opening the turn diff while primary Open stays in the in-app workspace preview
- reuse the shared installed-launcher picker and copy-path toast helper for Finder, VS Code, Cursor, WebStorm, Terminal, iTerm, absolute path, and relative path actions
- disable unavailable open/path actions for deleted files or missing workspace roots without losing valid copy actions

## Stack
- #825: Finder reveal support, base main
- #835: absolute/relative copy path actions, base codex/issue-802-finder-reveal
- this PR: edited-file Open split actions, base codex/issues-803-804-copy-path

## Verification
- bun run --cwd apps/web test -- src/components/chat/editedFilePathActions.test.ts src/editorMetadata.test.ts src/components/chat/MessagesTimeline.test.tsx (63 passed)
- bun run --cwd apps/server test -- src/open.test.ts (25 passed)
- bun run --cwd apps/web test:browser -- src/components/chat/EditedFileRow.browser.tsx (4 passed)
- git diff --check

Full-workspace bun fmt, bun lint, and bun typecheck were intentionally not run per task constraint.

Closes #805

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly chat UI and diff labeling; path resolution adds guards against escaping workspace roots, with broad browser test coverage.
> 
> **Overview**
> **Turn changed-files rows** now use a dedicated `EditedFileRow` with separate **Review** (turn diff), **Open** (in-app workspace preview), and an **Open options** menu instead of a single clickable row.
> 
> `OpenInPicker` is extended so surfaces can override the primary action (in-app open), append **copy absolute/relative path** items, and reorder installed launchers; editor config is passed once from `ChatView` so rows do not each subscribe to server config. Overflow files beyond five stay unmounted until **Show more** expands the list.
> 
> **Checkpoint/diff parsing** propagates a per-file **`kind`** (`modified`, `added`, `renamed`, `deleted`) from `@pierre/diffs` into turn and checkpoint summaries, and the UI disables external open actions for **deleted** files while copy actions still work. Path helpers reject unsafe relative paths.
> 
> **iTerm** is registered as a macOS terminal launcher in contracts/metadata, with server open tests updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39801f51a3918f75db15799ed13da3fd734fee61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->