### PR TITLE
Add safe recovery for newer database schemas

### DIFF
--- a/apps/desktop/src/backendStartupBlock.test.ts
+++ b/apps/desktop/src/backendStartupBlock.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   createMigrationDivergenceConsentToken,
   serializeMigrationDivergenceConsentChallenge,
+  serializeMigrationSchemaTooNewStartupBlock,
   type MigrationDivergenceConsentChallenge,
+  type MigrationSchemaTooNewStartupBlock,
 } from "@synara/shared/migrationRecovery";
 
 import { BackendStartupBlockDetector } from "./backendStartupBlock";
@@ -22,6 +24,19 @@ const divergenceChallengeWithoutToken: Omit<MigrationDivergenceConsentChallenge,
 const divergenceChallenge: MigrationDivergenceConsentChallenge = {
   ...divergenceChallengeWithoutToken,
   consentToken: createMigrationDivergenceConsentToken(divergenceChallengeWithoutToken),
+};
+
+const schemaTooNewBlock: MigrationSchemaTooNewStartupBlock = {
+  version: 1,
+  databasePath: "/data/state.sqlite",
+  databaseMigrationId: 97,
+  latestSupportedMigrationId: 96,
+  recovery: {
+    kind: "restore-available",
+    backupPath: "/data/state.sqlite.backups/exact.sqlite",
+    provenancePath: "/data/state.sqlite.migration-backup.json",
+    backupMigrationId: 90,
+  },
 };
 
 describe("BackendStartupBlockDetector", () => {
@@ -142,6 +157,24 @@ describe("BackendStartupBlockDetector", () => {
     );
 
     expect(detector.read()).toEqual({ kind: "migration-runtime-identity-mismatch" });
+  });
+
+  it("extracts schema-too-new recovery before crash supervision retries", () => {
+    const detector = new BackendStartupBlockDetector();
+    const serialized = serializeMigrationSchemaTooNewStartupBlock(schemaTooNewBlock);
+
+    detector.push(`MigrationSchemaTooNewError: blocked\n${serialized.slice(0, 70)}`);
+    detector.push(`${serialized.slice(70)}\n    at migrate`);
+
+    expect(detector.read()).toEqual({ kind: "migration-schema-too-new", block: schemaTooNewBlock });
+  });
+
+  it("fails closed instead of retrying a malformed structured block", () => {
+    const detector = new BackendStartupBlockDetector();
+
+    detector.push("SYNARA_MIGRATION_SCHEMA_TOO_NEW={not-json}\n");
+
+    expect(detector.read()).toEqual({ kind: "migration-startup-block-invalid" });
   });
 
   it("ignores unrelated startup failures", () => {

--- a/apps/desktop/src/backendStartupBlock.test.ts
+++ b/apps/desktop/src/backendStartupBlock.test.ts
@@ -177,6 +177,21 @@ describe("BackendStartupBlockDetector", () => {
     expect(detector.read()).toEqual({ kind: "migration-startup-block-invalid" });
   });
 
+  it("rejects a valid structured block before parsing when it exceeds the safety cap", () => {
+    const detector = new BackendStartupBlockDetector();
+    const oversizedBlock: MigrationSchemaTooNewStartupBlock = {
+      ...schemaTooNewBlock,
+      recovery: {
+        ...schemaTooNewBlock.recovery,
+        backupPath: `/data/${"x".repeat(1_050_000)}.sqlite`,
+      },
+    };
+
+    detector.push(serializeMigrationSchemaTooNewStartupBlock(oversizedBlock));
+
+    expect(detector.read()).toEqual({ kind: "migration-startup-block-invalid" });
+  });
+
   it("ignores unrelated startup failures", () => {
     const detector = new BackendStartupBlockDetector();
 

--- a/apps/desktop/src/backendStartupBlock.test.ts
+++ b/apps/desktop/src/backendStartupBlock.test.ts
@@ -182,8 +182,10 @@ describe("BackendStartupBlockDetector", () => {
     const oversizedBlock: MigrationSchemaTooNewStartupBlock = {
       ...schemaTooNewBlock,
       recovery: {
-        ...schemaTooNewBlock.recovery,
+        kind: "restore-available",
         backupPath: `/data/${"x".repeat(1_050_000)}.sqlite`,
+        provenancePath: "/data/state.sqlite.migration-backup.json",
+        backupMigrationId: 90,
       },
     };
 

--- a/apps/desktop/src/backendStartupBlock.ts
+++ b/apps/desktop/src/backendStartupBlock.ts
@@ -92,6 +92,7 @@ export class BackendStartupBlockDetector {
   }
 
   read(): BackendStartupBlock | null {
+    if (this.block?.kind === "migration-startup-block-invalid") return this.block;
     const divergenceChallenge = parseMigrationDivergenceConsentChallenge(this.output);
     if (divergenceChallenge) {
       return {

--- a/apps/desktop/src/backendStartupBlock.ts
+++ b/apps/desktop/src/backendStartupBlock.ts
@@ -5,11 +5,19 @@ import { StringDecoder } from "node:string_decoder";
 
 import {
   MIGRATION_DIVERGENCE_CONSENT_REQUIRED_PREFIX,
+  MIGRATION_SCHEMA_TOO_NEW_BLOCK_PREFIX,
   parseMigrationDivergenceConsentChallenge,
+  parseMigrationSchemaTooNewStartupBlock,
   type MigrationDivergenceConsentChallenge,
+  type MigrationSchemaTooNewStartupBlock,
 } from "@synara/shared/migrationRecovery";
 
-const MAX_STARTUP_OUTPUT_CHARS = 16_384;
+const MAX_GENERIC_STARTUP_OUTPUT_CHARS = 16_384;
+const MAX_STRUCTURED_STARTUP_BLOCK_CHARS = 1_048_576;
+const STRUCTURED_STARTUP_BLOCK_PREFIXES = [
+  MIGRATION_DIVERGENCE_CONSENT_REQUIRED_PREFIX,
+  MIGRATION_SCHEMA_TOO_NEW_BLOCK_PREFIX,
+] as const;
 
 export type BackendStartupBlock =
   | {
@@ -25,6 +33,13 @@ export type BackendStartupBlock =
     }
   | {
       readonly kind: "migration-runtime-identity-mismatch";
+    }
+  | {
+      readonly kind: "migration-schema-too-new";
+      readonly block: MigrationSchemaTooNewStartupBlock;
+    }
+  | {
+      readonly kind: "migration-startup-block-invalid";
     };
 
 export class BackendStartupBlockDetector {
@@ -45,10 +60,12 @@ export class BackendStartupBlockDetector {
   }
 
   private append(text: string): void {
-    if (text.length === 0) return;
-    this.output = `${this.output}${text.replace(/\r/g, "")}`;
-
-    this.output = retainRelevantStartupOutput(this.output);
+    if (text.length === 0 || this.block?.kind === "migration-startup-block-invalid") return;
+    this.output = retainRelevantStartupOutput(`${this.output}${text.replace(/\r/g, "")}`);
+    if (this.output.length > MAX_STRUCTURED_STARTUP_BLOCK_CHARS) {
+      this.block = { kind: "migration-startup-block-invalid" };
+      return;
+    }
 
     if (this.block) return;
 
@@ -63,14 +80,10 @@ export class BackendStartupBlockDetector {
     }
 
     const lockErrorIndex = this.output.indexOf("DatabaseLifecycleLockedError:");
-    if (lockErrorIndex === -1) {
-      return;
-    }
+    if (lockErrorIndex === -1) return;
     const lockErrorOutput = this.output.slice(lockErrorIndex);
     const ownerPidMatch = lockErrorOutput.match(/owner pid (\d+) is live/);
-    if (!ownerPidMatch && !lockErrorOutput.includes("\n")) {
-      return;
-    }
+    if (!ownerPidMatch && !lockErrorOutput.includes("\n")) return;
     const parsedOwnerPid = ownerPidMatch?.[1] ? Number.parseInt(ownerPidMatch[1], 10) : Number.NaN;
     this.block = {
       kind: "database-locked",
@@ -86,20 +99,36 @@ export class BackendStartupBlockDetector {
         challenge: divergenceChallenge,
       };
     }
-    return this.block;
+    const schemaTooNewBlock = parseMigrationSchemaTooNewStartupBlock(this.output);
+    if (schemaTooNewBlock) {
+      return { kind: "migration-schema-too-new", block: schemaTooNewBlock };
+    }
+    if (this.block) return this.block;
+    return containsStructuredStartupBlock(this.output)
+      ? { kind: "migration-startup-block-invalid" }
+      : null;
   }
 }
 
 function retainRelevantStartupOutput(output: string): string {
-  let challengeStart = output.lastIndexOf(MIGRATION_DIVERGENCE_CONSENT_REQUIRED_PREFIX);
-  while (challengeStart > 0 && output[challengeStart - 1] !== "\n") {
-    challengeStart = output.lastIndexOf(
-      MIGRATION_DIVERGENCE_CONSENT_REQUIRED_PREFIX,
-      challengeStart - 1,
-    );
+  const structuredBlockIndex = earliestStructuredStartupBlockIndex(output);
+  return structuredBlockIndex === -1
+    ? output.slice(-MAX_GENERIC_STARTUP_OUTPUT_CHARS)
+    : output.slice(structuredBlockIndex);
+}
+
+function earliestStructuredStartupBlockIndex(output: string): number {
+  let earliest = -1;
+  for (const prefix of STRUCTURED_STARTUP_BLOCK_PREFIXES) {
+    let index = output.indexOf(prefix);
+    while (index > 0 && output[index - 1] !== "\n") {
+      index = output.indexOf(prefix, index + prefix.length);
+    }
+    if (index !== -1 && (earliest === -1 || index < earliest)) earliest = index;
   }
-  if (challengeStart !== -1) return output.slice(challengeStart);
-  return output.length > MAX_STARTUP_OUTPUT_CHARS
-    ? output.slice(-MAX_STARTUP_OUTPUT_CHARS)
-    : output;
+  return earliest;
+}
+
+function containsStructuredStartupBlock(output: string): boolean {
+  return earliestStructuredStartupBlockIndex(output) !== -1;
 }

--- a/apps/desktop/src/desktopMigrationRecovery.test.ts
+++ b/apps/desktop/src/desktopMigrationRecovery.test.ts
@@ -7,10 +7,12 @@ import { describe, expect, it, vi } from "vitest";
 import { MIGRATION_RECOVERY_MAX_RESUME_ATTEMPTS } from "@synara/shared/migrationRecovery";
 
 import {
+  hasVerifiedDesktopMigrationRestore,
   hasPendingDesktopMigrationRecovery,
   recoverDesktopMigrationIfRequired,
   requiresDesktopMigrationRecovery,
   resolveDesktopMigrationRecoveryPaths,
+  resolveDesktopMigrationRestoreCandidate,
   restoreDesktopMigrationBackup,
   type DesktopMigrationRecoveryPaths,
 } from "./desktopMigrationRecovery";
@@ -31,6 +33,13 @@ describe("desktop migration recovery", () => {
         "synara",
         "userdata",
         "state.sqlite.migration-recovery.json",
+      ),
+      provenancePath: Path.join(
+        Path.sep,
+        "home",
+        "synara",
+        "userdata",
+        "state.sqlite.migration-backup.json",
       ),
       restoreEntryPath: Path.join(
         Path.sep,
@@ -59,6 +68,7 @@ describe("desktop migration recovery", () => {
     const paths: DesktopMigrationRecoveryPaths = {
       dbPath,
       markerPath: `${dbPath}.migration-recovery.json`,
+      provenancePath: `${dbPath}.migration-backup.json`,
       restoreEntryPath: Path.join(directory, "restore.mjs"),
     };
     await FS.writeFile(paths.markerPath, "pending", "utf8");
@@ -86,6 +96,7 @@ describe("desktop migration recovery", () => {
     const paths: DesktopMigrationRecoveryPaths = {
       dbPath,
       markerPath: `${dbPath}.migration-recovery.json`,
+      provenancePath: `${dbPath}.migration-backup.json`,
       restoreEntryPath: Path.join(directory, "restore.mjs"),
     };
     await FS.writeFile(paths.markerPath, "pending", "utf8");
@@ -273,6 +284,126 @@ describe("desktop migration recovery", () => {
     // Downloading is not an answer to the prompt: the database is still blocked.
     expect(restore).not.toHaveBeenCalled();
     expect(choose).toHaveBeenCalledTimes(2);
+  });
+
+  it("opens logs without retrying the backend or restore", async () => {
+    const choose = vi.fn().mockResolvedValueOnce("open-logs").mockResolvedValueOnce("quit");
+    const openLogs = vi.fn();
+    const restore = vi.fn();
+
+    await expect(
+      recoverDesktopMigrationIfRequired({
+        requiresRecovery: () => true,
+        markerRemains: () => true,
+        choose,
+        restore,
+        installUpdate: vi.fn(),
+        openReleasePage: vi.fn(),
+        openLogs,
+        requestRestart: vi.fn(),
+        requestQuit: vi.fn(),
+        formatError: String,
+        log: vi.fn(),
+      }),
+    ).resolves.toBe("quit-requested");
+    expect(openLogs).toHaveBeenCalledTimes(1);
+    expect(restore).not.toHaveBeenCalled();
+  });
+
+  it("verifies that completed provenance records the exact restored backup", async () => {
+    const directory = await FS.mkdtemp(Path.join(OS.tmpdir(), "synara-desktop-provenance-"));
+    const paths = resolveDesktopMigrationRecoveryPaths({
+      baseDir: directory,
+      appRoot: directory,
+      isDevelopment: false,
+    });
+    const backupPath = Path.join(directory, "exact.sqlite");
+    await FS.mkdir(Path.dirname(paths.provenancePath), { recursive: true });
+    await FS.writeFile(
+      paths.provenancePath,
+      JSON.stringify({
+        databasePath: paths.dbPath,
+        backupPath,
+        phase: "migration-restored",
+        restoredAt: "2026-08-30T12:00:00.000Z",
+      }),
+    );
+
+    expect(hasVerifiedDesktopMigrationRestore(paths, backupPath)).toBe(true);
+    expect(hasVerifiedDesktopMigrationRestore(paths, `${backupPath}.other`)).toBe(false);
+  });
+
+  it("accepts a restore candidate only for the exact desktop database and provenance", () => {
+    const paths = resolveDesktopMigrationRecoveryPaths({
+      baseDir: Path.join(Path.sep, "home", "synara"),
+      appRoot: Path.join(Path.sep, "app"),
+      isDevelopment: false,
+    });
+    const block = {
+      version: 1 as const,
+      databasePath: paths.dbPath,
+      databaseMigrationId: 97,
+      latestSupportedMigrationId: 96,
+      recovery: {
+        kind: "restore-available" as const,
+        backupPath: `${paths.dbPath}.backups/exact.sqlite`,
+        provenancePath: paths.provenancePath,
+        backupMigrationId: 90,
+      },
+    };
+
+    expect(resolveDesktopMigrationRestoreCandidate(paths, block)).toEqual(block.recovery);
+    expect(
+      resolveDesktopMigrationRestoreCandidate(paths, {
+        ...block,
+        databasePath: `${paths.dbPath}.other`,
+      }),
+    ).toBeNull();
+    expect(
+      resolveDesktopMigrationRestoreCandidate(paths, {
+        ...block,
+        recovery: { ...block.recovery, provenancePath: `${paths.provenancePath}.other` },
+      }),
+    ).toBeNull();
+  });
+
+  it("relaunches only after the exact completed restore is verified", async () => {
+    const directory = await FS.mkdtemp(Path.join(OS.tmpdir(), "synara-desktop-relaunch-"));
+    const paths = resolveDesktopMigrationRecoveryPaths({
+      baseDir: directory,
+      appRoot: directory,
+      isDevelopment: false,
+    });
+    const backupPath = Path.join(directory, "exact.sqlite");
+    const events: Array<string> = [];
+
+    await expect(
+      recoverDesktopMigrationIfRequired({
+        requiresRecovery: () => true,
+        markerRemains: () => !hasVerifiedDesktopMigrationRestore(paths, backupPath),
+        choose: vi.fn().mockResolvedValue("restore"),
+        restore: async () => {
+          events.push("restore");
+          await FS.mkdir(Path.dirname(paths.provenancePath), { recursive: true });
+          await FS.writeFile(
+            paths.provenancePath,
+            JSON.stringify({
+              databasePath: paths.dbPath,
+              backupPath,
+              phase: "migration-restored",
+              restoredAt: "2026-08-30T12:00:00.000Z",
+            }),
+          );
+        },
+        installUpdate: vi.fn(),
+        openReleasePage: vi.fn(),
+        requestRestart: () => events.push("restart"),
+        requestQuit: () => events.push("quit"),
+        formatError: String,
+        log: vi.fn(),
+      }),
+    ).resolves.toBe("restart-requested");
+    expect(events).toEqual(["restore", "restart", "quit"]);
   });
 });
 

--- a/apps/desktop/src/desktopMigrationRecovery.test.ts
+++ b/apps/desktop/src/desktopMigrationRecovery.test.ts
@@ -9,6 +9,7 @@ import { MIGRATION_RECOVERY_MAX_RESUME_ATTEMPTS } from "@synara/shared/migration
 import {
   hasVerifiedDesktopMigrationRestore,
   hasPendingDesktopMigrationRecovery,
+  invalidMigrationStartupRecoveryChoices,
   recoverDesktopMigrationIfRequired,
   requiresDesktopMigrationRecovery,
   resolveDesktopMigrationRecoveryPaths,
@@ -18,6 +19,29 @@ import {
 } from "./desktopMigrationRecovery";
 
 describe("desktop migration recovery", () => {
+  it("offers safe updater escape hatches when structured recovery details are invalid", () => {
+    expect(
+      invalidMigrationStartupRecoveryChoices({
+        canInstallUpdate: true,
+        canOpenReleasePage: true,
+      }),
+    ).toEqual([
+      { label: "Update Synara and restart", decision: "install-update" },
+      { label: "Download latest release", decision: "open-release-page" },
+      { label: "Open logs", decision: "open-logs" },
+      { label: "Quit", decision: "quit" },
+    ]);
+    expect(
+      invalidMigrationStartupRecoveryChoices({
+        canInstallUpdate: false,
+        canOpenReleasePage: false,
+      }),
+    ).toEqual([
+      { label: "Open logs", decision: "open-logs" },
+      { label: "Quit", decision: "quit" },
+    ]);
+  });
+
   it("targets the same production database and bundled restore authority as the server", () => {
     expect(
       resolveDesktopMigrationRecoveryPaths({

--- a/apps/desktop/src/desktopMigrationRecovery.test.ts
+++ b/apps/desktop/src/desktopMigrationRecovery.test.ts
@@ -74,9 +74,10 @@ describe("desktop migration recovery", () => {
     await FS.writeFile(paths.markerPath, "pending", "utf8");
     await FS.writeFile(
       paths.restoreEntryPath,
-      'import fs from "node:fs/promises"; await fs.unlink(`${process.argv[2]}.migration-recovery.json`); console.log("restored");',
+      'import fs from "node:fs/promises"; await fs.writeFile(`${process.argv[2]}.restore-args.json`, JSON.stringify(process.argv.slice(3))); await fs.unlink(`${process.argv[2]}.migration-recovery.json`); console.log("restored");',
       "utf8",
     );
+    const expectedBackupPath = `${dbPath}.backups/exact.sqlite`;
 
     await expect(
       restoreDesktopMigrationBackup({
@@ -85,9 +86,19 @@ describe("desktop migration recovery", () => {
         paths,
         cwd: directory,
         env: process.env,
+        expectedBackupPath,
+        expectedProvenancePath: paths.provenancePath,
       }),
     ).resolves.toBe("restored");
     await expect(FS.access(paths.markerPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      FS.readFile(`${dbPath}.restore-args.json`, "utf8").then(JSON.parse),
+    ).resolves.toEqual([
+      "--backup-path",
+      expectedBackupPath,
+      "--provenance-path",
+      paths.provenancePath,
+    ]);
   });
 
   it("fails closed when a successful command leaves the recovery marker behind", async () => {

--- a/apps/desktop/src/desktopMigrationRecovery.ts
+++ b/apps/desktop/src/desktopMigrationRecovery.ts
@@ -221,6 +221,8 @@ export async function restoreDesktopMigrationBackup(input: {
   readonly paths: DesktopMigrationRecoveryPaths;
   readonly cwd: string;
   readonly env: NodeJS.ProcessEnv;
+  readonly expectedBackupPath?: string | undefined;
+  readonly expectedProvenancePath?: string | undefined;
   readonly verifyRestore?: (() => boolean) | undefined;
   readonly restoreVerificationFailure?: string | undefined;
 }): Promise<string> {
@@ -228,9 +230,21 @@ export async function restoreDesktopMigrationBackup(input: {
     throw new Error(`Migration recovery command is missing: ${input.paths.restoreEntryPath}`);
   }
 
+  if ((input.expectedBackupPath === undefined) !== (input.expectedProvenancePath === undefined)) {
+    throw new Error("Both expected migration backup and provenance paths are required.");
+  }
+  const restoreSelection =
+    input.expectedBackupPath && input.expectedProvenancePath
+      ? [
+          "--backup-path",
+          input.expectedBackupPath,
+          "--provenance-path",
+          input.expectedProvenancePath,
+        ]
+      : [];
   const { stdout, stderr } = await execFile(
     input.executablePath,
-    [...input.nodeArgs, input.paths.restoreEntryPath, input.paths.dbPath],
+    [...input.nodeArgs, input.paths.restoreEntryPath, input.paths.dbPath, ...restoreSelection],
     {
       cwd: input.cwd,
       env: {

--- a/apps/desktop/src/desktopMigrationRecovery.ts
+++ b/apps/desktop/src/desktopMigrationRecovery.ts
@@ -67,10 +67,7 @@ export function invalidMigrationStartupRecoveryChoices(input: {
   if (input.canOpenReleasePage) {
     choices.push({ label: "Download latest release", decision: "open-release-page" });
   }
-  choices.push(
-    { label: "Open logs", decision: "open-logs" },
-    { label: "Quit", decision: "quit" },
-  );
+  choices.push({ label: "Open logs", decision: "open-logs" }, { label: "Quit", decision: "quit" });
   return choices;
 }
 

--- a/apps/desktop/src/desktopMigrationRecovery.ts
+++ b/apps/desktop/src/desktopMigrationRecovery.ts
@@ -51,6 +51,29 @@ export type DesktopMigrationRecoveryDecision =
   | "open-release-page"
   | "open-logs";
 
+export interface DesktopMigrationRecoveryChoice {
+  readonly label: string;
+  readonly decision: DesktopMigrationRecoveryDecision;
+}
+
+export function invalidMigrationStartupRecoveryChoices(input: {
+  readonly canInstallUpdate: boolean;
+  readonly canOpenReleasePage: boolean;
+}): ReadonlyArray<DesktopMigrationRecoveryChoice> {
+  const choices: Array<DesktopMigrationRecoveryChoice> = [];
+  if (input.canInstallUpdate) {
+    choices.push({ label: "Update Synara and restart", decision: "install-update" });
+  }
+  if (input.canOpenReleasePage) {
+    choices.push({ label: "Download latest release", decision: "open-release-page" });
+  }
+  choices.push(
+    { label: "Open logs", decision: "open-logs" },
+    { label: "Quit", decision: "quit" },
+  );
+  return choices;
+}
+
 /**
  * Which recovery action failed, so the prompt can say what actually went wrong
  * instead of blaming the restore for an update that could not be installed.

--- a/apps/desktop/src/desktopMigrationRecovery.ts
+++ b/apps/desktop/src/desktopMigrationRecovery.ts
@@ -7,8 +7,10 @@ import * as FS from "node:fs";
 import * as Path from "node:path";
 import { promisify } from "node:util";
 import {
+  migrationBackupProvenancePath,
   migrationRecoveryMarkerPath,
   parseMigrationRecoveryResumeState,
+  type MigrationSchemaTooNewStartupBlock,
 } from "@synara/shared/migrationRecovery";
 
 const execFile = promisify(ChildProcess.execFile);
@@ -17,6 +19,7 @@ const RECOVERY_OUTPUT_LIMIT_BYTES = 64 * 1024;
 export interface DesktopMigrationRecoveryPaths {
   readonly dbPath: string;
   readonly markerPath: string;
+  readonly provenancePath: string;
   readonly restoreEntryPath: string;
 }
 
@@ -30,6 +33,7 @@ export function resolveDesktopMigrationRecoveryPaths(input: {
   return {
     dbPath,
     markerPath: migrationRecoveryMarkerPath(dbPath),
+    provenancePath: migrationBackupProvenancePath(dbPath),
     restoreEntryPath: Path.join(input.appRoot, "apps/server/dist/restoreMigrationBackup.mjs"),
   };
 }
@@ -44,7 +48,8 @@ export type DesktopMigrationRecoveryDecision =
   | "restore"
   | "quit"
   | "install-update"
-  | "open-release-page";
+  | "open-release-page"
+  | "open-logs";
 
 /**
  * Which recovery action failed, so the prompt can say what actually went wrong
@@ -85,6 +90,7 @@ export async function recoverDesktopMigrationIfRequired(input: {
    * them the download itself.
    */
   readonly openReleasePage: () => void;
+  readonly openLogs?: (() => Promise<void>) | undefined;
   readonly requestRestart: () => void;
   readonly requestQuit: (reason: string) => void;
   readonly formatError: (error: unknown) => string;
@@ -100,6 +106,11 @@ export async function recoverDesktopMigrationIfRequired(input: {
     if (decision === "open-release-page") {
       input.log("migration recovery: opening the release download page");
       input.openReleasePage();
+      continue;
+    }
+    if (decision === "open-logs") {
+      input.log("migration recovery: opening logs");
+      await input.openLogs?.();
       continue;
     }
     if (decision === "install-update") {
@@ -142,6 +153,48 @@ export function hasPendingDesktopMigrationRecovery(paths: DesktopMigrationRecove
   return FS.existsSync(paths.markerPath);
 }
 
+export function hasVerifiedDesktopMigrationRestore(
+  paths: DesktopMigrationRecoveryPaths,
+  expectedBackupPath: string,
+): boolean {
+  let provenanceText: string;
+  try {
+    provenanceText = FS.readFileSync(paths.provenancePath, "utf8");
+  } catch {
+    return false;
+  }
+
+  try {
+    const provenance = JSON.parse(provenanceText) as Record<string, unknown>;
+    return (
+      provenance.databasePath === paths.dbPath &&
+      provenance.backupPath === expectedBackupPath &&
+      provenance.phase === "migration-restored" &&
+      typeof provenance.restoredAt === "string" &&
+      provenance.restoredAt.length > 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+type DesktopMigrationRestoreCandidate = Extract<
+  MigrationSchemaTooNewStartupBlock["recovery"],
+  { readonly kind: "restore-available" }
+>;
+
+export function resolveDesktopMigrationRestoreCandidate(
+  paths: DesktopMigrationRecoveryPaths,
+  block: MigrationSchemaTooNewStartupBlock,
+): DesktopMigrationRestoreCandidate | null {
+  const recovery = block.recovery;
+  return block.databasePath === paths.dbPath &&
+    recovery.kind === "restore-available" &&
+    recovery.provenancePath === paths.provenancePath
+    ? recovery
+    : null;
+}
+
 /**
  * Whether startup must stop and ask the user to restore.
  *
@@ -168,6 +221,8 @@ export async function restoreDesktopMigrationBackup(input: {
   readonly paths: DesktopMigrationRecoveryPaths;
   readonly cwd: string;
   readonly env: NodeJS.ProcessEnv;
+  readonly verifyRestore?: (() => boolean) | undefined;
+  readonly restoreVerificationFailure?: string | undefined;
 }): Promise<string> {
   if (!FS.existsSync(input.paths.restoreEntryPath)) {
     throw new Error(`Migration recovery command is missing: ${input.paths.restoreEntryPath}`);
@@ -190,8 +245,14 @@ export async function restoreDesktopMigrationBackup(input: {
 
   // Exit zero is not sufficient: the server-owned command must have cleared
   // the durable marker before desktop startup is allowed to continue.
-  if (hasPendingDesktopMigrationRecovery(input.paths)) {
-    throw new Error("Migration recovery completed without clearing its recovery marker.");
+  const restoreVerified = input.verifyRestore
+    ? input.verifyRestore()
+    : !hasPendingDesktopMigrationRecovery(input.paths);
+  if (!restoreVerified) {
+    throw new Error(
+      input.restoreVerificationFailure ??
+        "Migration recovery completed without clearing its recovery marker.",
+    );
   }
 
   return [stdout, stderr]

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -3772,6 +3772,8 @@ async function handleDesktopSchemaTooNewRecovery(
         paths,
         cwd: resolveBackendCwd(),
         env: process.env,
+        expectedBackupPath: restoreCandidate.backupPath,
+        expectedProvenancePath: restoreCandidate.provenancePath,
         verifyRestore: () => hasVerifiedDesktopMigrationRestore(paths, restoreCandidate.backupPath),
         restoreVerificationFailure:
           "Migration restore completed without exact completed-provenance verification.",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -126,6 +126,7 @@ import {
 import {
   hasVerifiedDesktopMigrationRestore,
   hasPendingDesktopMigrationRecovery,
+  invalidMigrationStartupRecoveryChoices,
   requiresDesktopMigrationRecovery,
   recoverDesktopMigrationIfRequired,
   resolveDesktopMigrationRecoveryPaths,
@@ -3672,8 +3673,8 @@ function schemaTooNewRestoreDetail(
   if (restoreCandidate) {
     return (
       `Synara verified the exact pre-migration backup at:\n${restoreCandidate.backupPath}\n\n` +
-      `Its schema is migration ${restoreCandidate.backupMigrationId}, which is within this build's supported range, ` +
-      "and it passed SQLite integrity checking."
+      `Its tracker ends at migration ${restoreCandidate.backupMigrationId}; its shared lineage is compatible ` +
+      "with this build, and it passed SQLite integrity checking."
     );
   }
 
@@ -3797,26 +3798,50 @@ function handleBackendStartupBlock(block: BackendStartupBlock): void {
 
     if (block.kind === "migration-startup-block-invalid") {
       desktopStartupBlockedForDatabaseRestore = true;
-      for (;;) {
-        const result = await dialog.showMessageBox({
-          type: "error",
-          title: "Synara could not verify migration recovery",
-          message:
-            "The backend stopped for database safety, but its recovery details were invalid.",
-          detail:
-            "Synara will keep the backend and provider processes stopped. Open the logs for the original error, then update or reinstall Synara before trying again.",
-          buttons: ["Open logs", "Quit"],
-          defaultId: 0,
-          cancelId: 1,
-          noLink: true,
-        });
-        if (result.response === 0) {
-          await openDesktopLogDirectory();
-          continue;
-        }
-        requestGracefulAppQuit("invalid migration startup block");
-        return;
-      }
+      await recoverDesktopMigrationIfRequired({
+        requiresRecovery: () => true,
+        markerRemains: () => true,
+        choose: async ({ previousFailure }) => {
+          const releaseUrl = updateState.releaseUrl;
+          const choices = invalidMigrationStartupRecoveryChoices({
+            canInstallUpdate: canInstallUpdateFromRecovery(),
+            canOpenReleasePage: releaseUrl !== null,
+          });
+          const result = await dialog.showMessageBox({
+            type: "error",
+            title:
+              previousFailure === null
+                ? "Synara could not verify migration recovery"
+                : "Synara could not update itself",
+            message:
+              previousFailure === null
+                ? "The backend stopped for database safety, but its recovery details were invalid."
+                : "The newest Synara release could not be installed.",
+            detail:
+              `${previousFailure === null ? "" : `${previousFailure.message}\n\n`}` +
+              "Synara will keep the backend and provider processes stopped. The recovery record is not trusted, so restoring from it is disabled; choose one of the safe actions below.",
+            buttons: choices.map((choice) => choice.label),
+            defaultId: 0,
+            cancelId: choices.length - 1,
+            noLink: true,
+          });
+          return choices[result.response]?.decision ?? "quit";
+        },
+        installUpdate: installLatestUpdateForMigrationRecovery,
+        openReleasePage: () => {
+          const releaseUrl = updateState.releaseUrl;
+          if (releaseUrl !== null) void shell.openExternal(releaseUrl);
+        },
+        openLogs: openDesktopLogDirectory,
+        restore: async () => {
+          throw new Error("Invalid migration recovery details cannot authorize a restore.");
+        },
+        requestRestart: () => undefined,
+        requestQuit: (reason) => requestGracefulAppQuit(reason),
+        formatError: formatErrorMessage,
+        log: writeDesktopLogHeader,
+      });
+      return;
     }
 
     if (block.kind === "migration-divergence-consent-required") {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -67,6 +67,7 @@ import {
   MIGRATION_DIVERGENCE_CONSENT_ENV,
   MIGRATION_RUNTIME_SOURCE_DIGEST_ENV,
   type MigrationRuntimeIdentityMismatch,
+  type MigrationSchemaTooNewStartupBlock,
 } from "@synara/shared/migrationRecovery";
 import { ensureStaticSnapshot, findAsarArchivePath } from "@synara/shared/staticSnapshot";
 import { isBackendReadinessAborted, waitForHttpReady } from "./backendReadiness";
@@ -123,10 +124,12 @@ import {
   shouldPromptForRunningChatsBeforeQuit,
 } from "./runningChatsQuitGuard";
 import {
+  hasVerifiedDesktopMigrationRestore,
   hasPendingDesktopMigrationRecovery,
   requiresDesktopMigrationRecovery,
   recoverDesktopMigrationIfRequired,
   resolveDesktopMigrationRecoveryPaths,
+  resolveDesktopMigrationRestoreCandidate,
   restoreDesktopMigrationBackup,
   type DesktopMigrationRecoveryDecision,
   type DesktopMigrationRecoveryOutcome,
@@ -398,7 +401,7 @@ const updateInstallPreparation = makeUpdateInstallPreparationCoordinator();
 const deferredDesktopQuitIntent = makeDeferredDesktopQuitIntentCoordinator();
 const runningChatsQuitGuard = makeRunningChatsQuitGuard();
 let desktopShutdownPromise: Promise<void> | null = null;
-let desktopStartupBlockedForMigrationRecovery = false;
+let desktopStartupBlockedForDatabaseRestore = false;
 const migrationConsentHandoff = new MigrationConsentHandoff();
 let desktopShutdownComplete = false;
 let desktopProtocolRegistered = false;
@@ -1216,7 +1219,7 @@ function formatRecoveryOptionList(options: ReadonlyArray<string>): string {
 
 async function handleDesktopMigrationRecovery(): Promise<DesktopMigrationRecoveryOutcome> {
   const paths = desktopMigrationRecoveryPaths();
-  desktopStartupBlockedForMigrationRecovery = true;
+  desktopStartupBlockedForDatabaseRestore = true;
   const outcome = await recoverDesktopMigrationIfRequired({
     // The gate opens only once the backend has spent its resume budget, while
     // the post-restore verification checks the marker file itself.
@@ -1310,7 +1313,7 @@ async function handleDesktopMigrationRecovery(): Promise<DesktopMigrationRecover
     log: writeDesktopLogHeader,
   });
   if (outcome === "continue") {
-    desktopStartupBlockedForMigrationRecovery = false;
+    desktopStartupBlockedForDatabaseRestore = false;
   }
   return outcome;
 }
@@ -3662,10 +3665,158 @@ function presentBackendStartupGiveUp(reason: string): void {
   backendLifecycleDialogInFlight = task;
 }
 
+function schemaTooNewRestoreDetail(
+  block: MigrationSchemaTooNewStartupBlock,
+  restoreCandidate: ReturnType<typeof resolveDesktopMigrationRestoreCandidate>,
+): string {
+  if (restoreCandidate) {
+    return (
+      `Synara verified the exact pre-migration backup at:\n${restoreCandidate.backupPath}\n\n` +
+      `Its schema is migration ${restoreCandidate.backupMigrationId}, which is within this build's supported range, ` +
+      "and it passed SQLite integrity checking."
+    );
+  }
+
+  if (block.recovery.kind === "restore-available") {
+    return "The recorded backup does not match this desktop database exactly, so Synara will not restore it.";
+  }
+
+  switch (block.recovery.reason) {
+    case "missing-provenance":
+      return "No completed migration backup record exists for this database, so Synara cannot choose a backup safely.";
+    case "invalid-provenance":
+      return "The completed migration backup record does not describe this exact database state.";
+    case "invalid-backup":
+      return "The exact recorded backup is missing, unreadable, or failed SQLite integrity checking.";
+    case "incompatible-backup":
+      return "The exact recorded backup has a schema or migration lineage this Synara build cannot open safely.";
+  }
+}
+
+async function handleDesktopSchemaTooNewRecovery(
+  block: MigrationSchemaTooNewStartupBlock,
+): Promise<void> {
+  const paths = desktopMigrationRecoveryPaths();
+  const restoreCandidate = resolveDesktopMigrationRestoreCandidate(paths, block);
+  desktopStartupBlockedForDatabaseRestore = true;
+
+  await recoverDesktopMigrationIfRequired({
+    requiresRecovery: () => true,
+    markerRemains: () =>
+      restoreCandidate === null ||
+      !hasVerifiedDesktopMigrationRestore(paths, restoreCandidate.backupPath),
+    choose: async ({ previousFailure }) => {
+      const restoreFailed = previousFailure?.attempt === "restore";
+      const canInstallUpdate = canInstallUpdateFromRecovery();
+      const releaseUrl = updateState.releaseUrl;
+      const choices: Array<{
+        readonly label: string;
+        readonly decision: DesktopMigrationRecoveryDecision;
+      }> = [];
+
+      if (restoreCandidate) {
+        choices.push({
+          label: restoreFailed ? "Try restore again" : "Restore backup and restart",
+          decision: "restore",
+        });
+      }
+      if (canInstallUpdate) {
+        choices.push({ label: "Update Synara and restart", decision: "install-update" });
+      }
+      if (releaseUrl !== null) {
+        choices.push({ label: "Download latest release", decision: "open-release-page" });
+      }
+      choices.push(
+        { label: "Open logs", decision: "open-logs" },
+        { label: "Quit", decision: "quit" },
+      );
+
+      const result = await dialog.showMessageBox({
+        type: previousFailure === null ? "warning" : "error",
+        title:
+          previousFailure === null
+            ? "This database is newer than Synara"
+            : restoreFailed
+              ? "Database restore failed"
+              : "Synara could not update itself",
+        message:
+          previousFailure === null
+            ? `Database migration ${block.databaseMigrationId} is newer than this build supports (${block.latestSupportedMigrationId}).`
+            : restoreFailed
+              ? "The verified database backup could not be restored."
+              : "The newest Synara release could not be installed.",
+        detail:
+          `${previousFailure === null ? "" : `${previousFailure.message}\n\n`}` +
+          `${schemaTooNewRestoreDetail(block, restoreCandidate)}\n\n` +
+          "The backend and provider processes will remain stopped until you update, restore, or quit.",
+        buttons: choices.map((choice) => choice.label),
+        defaultId: 0,
+        cancelId: choices.length - 1,
+        noLink: true,
+      });
+      return choices[result.response]?.decision ?? "quit";
+    },
+    installUpdate: installLatestUpdateForMigrationRecovery,
+    openReleasePage: () => {
+      const releaseUrl = updateState.releaseUrl;
+      if (releaseUrl !== null) void shell.openExternal(releaseUrl);
+    },
+    openLogs: openDesktopLogDirectory,
+    restore: async () => {
+      if (!restoreCandidate) {
+        throw new Error("No exact compatible migration backup is available.");
+      }
+      await restoreDesktopMigrationBackup({
+        executablePath: process.execPath,
+        nodeArgs: backendNodeArgs(),
+        paths,
+        cwd: resolveBackendCwd(),
+        env: process.env,
+        verifyRestore: () => hasVerifiedDesktopMigrationRestore(paths, restoreCandidate.backupPath),
+        restoreVerificationFailure:
+          "Migration restore completed without exact completed-provenance verification.",
+      });
+    },
+    requestRestart: () => app.relaunch(),
+    requestQuit: (reason) => requestGracefulAppQuit(reason),
+    formatError: formatErrorMessage,
+    log: writeDesktopLogHeader,
+  });
+}
+
 function handleBackendStartupBlock(block: BackendStartupBlock): void {
   if (isQuitting || backendLifecycleDialogInFlight) return;
 
   const task = (async () => {
+    if (block.kind === "migration-schema-too-new") {
+      await handleDesktopSchemaTooNewRecovery(block.block);
+      return;
+    }
+
+    if (block.kind === "migration-startup-block-invalid") {
+      desktopStartupBlockedForDatabaseRestore = true;
+      for (;;) {
+        const result = await dialog.showMessageBox({
+          type: "error",
+          title: "Synara could not verify migration recovery",
+          message:
+            "The backend stopped for database safety, but its recovery details were invalid.",
+          detail:
+            "Synara will keep the backend and provider processes stopped. Open the logs for the original error, then update or reinstall Synara before trying again.",
+          buttons: ["Open logs", "Quit"],
+          defaultId: 0,
+          cancelId: 1,
+          noLink: true,
+        });
+        if (result.response === 0) {
+          await openDesktopLogDirectory();
+          continue;
+        }
+        requestGracefulAppQuit("invalid migration startup block");
+        return;
+      }
+    }
+
     if (block.kind === "migration-divergence-consent-required") {
       const challenge = block.challenge;
       const result = await dialog.showMessageBox({
@@ -3804,7 +3955,7 @@ function startBackend(trigger: BackendStartTrigger = "lifecycle"): void {
   // Recovery owns the database until it clears the marker. Callers that restart
   // the backend after an unrelated failure — a given-up update install, say —
   // must not hand it a database the user is being asked how to repair.
-  if (desktopStartupBlockedForMigrationRecovery) {
+  if (desktopStartupBlockedForDatabaseRestore) {
     writeDesktopLogHeader("backend start suppressed while migration recovery is pending");
     return;
   }
@@ -5100,7 +5251,7 @@ if (hasSingleInstanceLock) {
       });
 
       app.on("activate", () => {
-        if (desktopStartupBlockedForMigrationRecovery || isQuitting) {
+        if (desktopStartupBlockedForDatabaseRestore || isQuitting) {
           return;
         }
         handleDesktopAppForegrounded();

--- a/apps/server/src/persistence/Layers/Sqlite.ts
+++ b/apps/server/src/persistence/Layers/Sqlite.ts
@@ -2,6 +2,7 @@ import { Effect, Layer, FileSystem, Path } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import { runMigrations } from "../Migrations.ts";
+import { MigrationSchemaTooNewError } from "../Errors.ts";
 import {
   inspectPendingMigrationRecovery,
   reclaimOrphanedMigrationArtifacts,
@@ -9,6 +10,7 @@ import {
   runWithPreMigrationBackup,
   type MigrationRecoveryMarker,
 } from "../MigrationBackup.ts";
+import { createMigrationSchemaTooNewStartupBlockError } from "../MigrationSchemaTooNewStartupBlock.ts";
 import { ensurePrivateFileSync, repairPrivateFile } from "../../privatePathPermissions.ts";
 import { ServerConfig } from "../../config.ts";
 import {
@@ -138,7 +140,15 @@ const makeSetup = ({
           ? resumeMarkedMigration(dbPath, pendingRecovery, runMigrations())
           : runWithPreMigrationBackup(dbPath, runMigrations(), { divergenceConsent })
         : runMigrations();
-      yield* migrations;
+      yield* migrations.pipe(
+        Effect.catch((cause) =>
+          cause instanceof MigrationSchemaTooNewError && dbPath
+            ? Effect.promise(() =>
+                createMigrationSchemaTooNewStartupBlockError(dbPath, cause),
+              ).pipe(Effect.flatMap(Effect.fail))
+            : Effect.fail(cause),
+        ),
+      );
     }),
   );
 

--- a/apps/server/src/persistence/MigrationBackup.test.ts
+++ b/apps/server/src/persistence/MigrationBackup.test.ts
@@ -36,6 +36,14 @@ import { migrationEntries, runMigrations } from "./Migrations.ts";
 import * as NodeSqliteClient from "./NodeSqliteClient.ts";
 import { makeSqlitePersistenceLive } from "./Layers/Sqlite.ts";
 
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  return {
+    ...actual,
+    rename: vi.fn(actual.rename),
+  };
+});
+
 const tempDirectories: Array<string> = [];
 
 afterEach(async () => {
@@ -879,6 +887,54 @@ describe("migration backups", () => {
     ) as { readonly phase: string; readonly restoredAt?: string };
     expect(provenance.phase).toBe("migration-restored");
     expect(provenance.restoredAt).toBeTypeOf("string");
+  });
+
+  it("clears the restore marker when a completed-backup swap rolls back cleanly", async () => {
+    const dbPath = await makeDbPath();
+
+    await runWithDatabase(
+      dbPath,
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        yield* runMigrations({ toMigrationInclusive: 52 });
+        yield* sql`CREATE TABLE completed_restore_rollback_probe(value TEXT NOT NULL)`;
+        yield* sql`INSERT INTO completed_restore_rollback_probe(value) VALUES ('before-upgrade')`;
+        yield* runWithPreMigrationBackup(dbPath, runMigrations());
+        yield* sql`UPDATE completed_restore_rollback_probe SET value = 'after-upgrade'`;
+      }),
+    );
+
+    const realRename = nodeFs.promises.rename.bind(nodeFs.promises);
+    const rename = vi.mocked(fs.rename);
+    rename.mockImplementation((source, destination) => {
+      if (String(source) === dbPath) {
+        return Promise.reject(new Error("injected live database swap failure"));
+      }
+      return realRename(source, destination);
+    });
+    try {
+      await expect(Effect.runPromise(restoreMarkedMigrationBackup(dbPath))).rejects.toThrow(
+        "injected live database swap failure",
+      );
+    } finally {
+      rename.mockImplementation(realRename);
+    }
+
+    await expect(fs.stat(migrationRecoveryMarkerPath(dbPath))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    const live = new DatabaseSync(dbPath, { readOnly: true });
+    try {
+      expect(
+        live.prepare("SELECT value FROM completed_restore_rollback_probe").get(),
+      ).toMatchObject({ value: "after-upgrade" });
+    } finally {
+      live.close();
+    }
+    const provenance = JSON.parse(
+      await fs.readFile(migrationBackupProvenancePath(dbPath), "utf8"),
+    ) as { readonly phase: string };
+    expect(provenance.phase).toBe("migration-completed");
   });
 
   it("keeps an active restore marker until restored provenance is durable", async () => {

--- a/apps/server/src/persistence/MigrationBackup.ts
+++ b/apps/server/src/persistence/MigrationBackup.ts
@@ -1330,15 +1330,28 @@ export const restoreMarkedMigrationBackup = (
       ) {
         throw new Error("Both expected migration backup and provenance paths are required.");
       }
-      const activeMarker = hasExpectedCompletedBackup
-        ? null
-        : await readMigrationRecoveryMarker(dbPath);
+      let activeMarker: MigrationRecoveryMarker | null;
+      if (hasExpectedCompletedBackup) {
+        try {
+          activeMarker = await readMigrationRecoveryMarker(dbPath);
+        } catch {
+          activeMarker = null;
+        }
+      } else {
+        activeMarker = await readMigrationRecoveryMarker(dbPath);
+      }
       const completedProvenance =
         hasExpectedCompletedBackup || !activeMarker
           ? await readCompletedMigrationProvenance(dbPath)
           : null;
+      const matchingRestoreMarker =
+        hasExpectedCompletedBackup &&
+        activeMarker?.backupPath === options.expectedBackupPath &&
+        activeMarker.payload.phase === "migration-restore-in-progress"
+          ? activeMarker
+          : null;
       const record = hasExpectedCompletedBackup
-        ? completedProvenance
+        ? (matchingRestoreMarker ?? completedProvenance)
         : (activeMarker ?? completedProvenance);
       if (!record) {
         throw new Error(
@@ -1347,8 +1360,8 @@ export const restoreMarkedMigrationBackup = (
       }
       if (hasExpectedCompletedBackup) {
         if (
-          record.backupPath !== options.expectedBackupPath ||
-          record.markerPath !== options.expectedProvenancePath
+          completedProvenance?.backupPath !== options.expectedBackupPath ||
+          completedProvenance.markerPath !== options.expectedProvenancePath
         ) {
           throw new Error("Completed migration provenance no longer matches the selected backup.");
         }

--- a/apps/server/src/persistence/MigrationBackup.ts
+++ b/apps/server/src/persistence/MigrationBackup.ts
@@ -906,7 +906,7 @@ const restoreSqliteMigrationBackup = (input: {
 
 interface SqliteMigrationBackupInspection {
   readonly migrationId: number;
-  readonly lineageRestorable: boolean;
+  readonly lineage: "canonical" | "imported" | "incompatible";
 }
 
 async function inspectSqliteMigrationBackup(
@@ -1010,7 +1010,12 @@ function inspectMigrationRows(rows: ReadonlyArray<unknown>): SqliteMigrationBack
   const divergence = findFirstMigrationLineageDivergence(recordedNames, migrationId);
   return {
     migrationId,
-    lineageRestorable: divergence === undefined || divergence[0] > LAST_SHARED_LINEAGE_MIGRATION_ID,
+    lineage:
+      divergence === undefined
+        ? "canonical"
+        : divergence[0] > LAST_SHARED_LINEAGE_MIGRATION_ID
+          ? "imported"
+          : "incompatible",
   };
 }
 
@@ -1018,10 +1023,10 @@ function assertMigrationBackupCompatible(
   inspection: SqliteMigrationBackupInspection,
   latestSupportedMigrationId: number,
 ): void {
-  if (!inspection.lineageRestorable) {
+  if (inspection.lineage === "incompatible") {
     throw new Error("Migration backup has an unrecognized migration lineage.");
   }
-  if (inspection.migrationId > latestSupportedMigrationId) {
+  if (inspection.lineage === "canonical" && inspection.migrationId > latestSupportedMigrationId) {
     throw new Error(
       `Migration backup schema ${inspection.migrationId} is newer than this build ` +
         `(latest supported migration: ${latestSupportedMigrationId}).`,
@@ -1166,7 +1171,11 @@ export async function inspectCompletedMigrationBackupForSchemaTooNew(
   } catch {
     return { kind: "restore-unavailable", reason: "invalid-backup" };
   }
-  if (!inspection.lineageRestorable || inspection.migrationId > input.latestSupportedMigrationId) {
+  if (
+    inspection.lineage === "incompatible" ||
+    (inspection.lineage === "canonical" &&
+      inspection.migrationId > input.latestSupportedMigrationId)
+  ) {
     return { kind: "restore-unavailable", reason: "incompatible-backup" };
   }
   return {

--- a/apps/server/src/persistence/MigrationBackup.ts
+++ b/apps/server/src/persistence/MigrationBackup.ts
@@ -896,9 +896,9 @@ const restoreSqliteMigrationBackup = (input: {
       throw cause;
     }
 
-    // Make the database/WAL/SHM swap durable. The caller retains the active
-    // recovery marker until restored provenance is durably recorded, so a
-    // crash between these two phases still has a recoverable pointer.
+    // Make the database/WAL/SHM swap durable before the caller records the
+    // completed restore and clears the marker. Until both happen, a crash or
+    // cleanup failure remains an explicit, retryable recovery state.
     await syncDirectory(path.dirname(input.dbPath));
     await pruneFailedMigrationBundles(input.dbPath);
     await syncDirectory(path.dirname(input.dbPath));
@@ -1310,28 +1310,52 @@ export const resumeMarkedMigration = <A, E, R>(
  * completed migration provenance. The operator must stop every Synara process
  * before invoking it; startup itself deliberately never calls this function.
  */
-export const restoreMarkedMigrationBackup = (dbPath: string) =>
+export interface RestoreMarkedMigrationBackupOptions {
+  readonly expectedBackupPath?: string | undefined;
+  readonly expectedProvenancePath?: string | undefined;
+}
+
+export const restoreMarkedMigrationBackup = (
+  dbPath: string,
+  options: RestoreMarkedMigrationBackupOptions = {},
+) =>
   withDatabaseLifecycleLock(
     dbPath,
     attemptPromise(async () => {
-      const activeMarker = await readMigrationRecoveryMarker(dbPath);
-      const record = activeMarker ?? (await readCompletedMigrationProvenance(dbPath));
+      const hasExpectedCompletedBackup =
+        options.expectedBackupPath !== undefined || options.expectedProvenancePath !== undefined;
+      if (
+        hasExpectedCompletedBackup &&
+        (options.expectedBackupPath === undefined || options.expectedProvenancePath === undefined)
+      ) {
+        throw new Error("Both expected migration backup and provenance paths are required.");
+      }
+      const activeMarker = hasExpectedCompletedBackup
+        ? null
+        : await readMigrationRecoveryMarker(dbPath);
+      const completedProvenance =
+        hasExpectedCompletedBackup || !activeMarker
+          ? await readCompletedMigrationProvenance(dbPath)
+          : null;
+      const record = hasExpectedCompletedBackup
+        ? completedProvenance
+        : (activeMarker ?? completedProvenance);
       if (!record) {
         throw new Error(
           `No migration recovery marker or completed backup provenance exists for ${dbPath}.`,
         );
       }
-      if (activeMarker) {
-        // A restore is not a migration resume. Exhaust the automatic resume
-        // budget before replacing the live database so a crash or provenance
-        // write failure can only return to the explicit restore path.
-        await writePrivateJsonFile(record.markerPath, {
-          ...record.payload,
-          phase: "migration-restore-in-progress",
-          restoreStartedAt: new Date().toISOString(),
-          resumeAttempts: MIGRATION_RECOVERY_MAX_RESUME_ATTEMPTS,
-        });
-      } else {
+      if (hasExpectedCompletedBackup) {
+        if (
+          record.backupPath !== options.expectedBackupPath ||
+          record.markerPath !== options.expectedProvenancePath
+        ) {
+          throw new Error("Completed migration provenance no longer matches the selected backup.");
+        }
+      }
+
+      const restoringCompletedProvenance = record === completedProvenance;
+      if (restoringCompletedProvenance) {
         if (record.payload.phase !== "migration-completed") {
           throw new Error(`Migration backup provenance is not restorable: ${record.markerPath}`);
         }
@@ -1341,6 +1365,25 @@ export const restoreMarkedMigrationBackup = (dbPath: string) =>
             `Migration backup provenance does not describe the current database: ${record.markerPath}`,
           );
         }
+        await writePrivateJsonFile(migrationRecoveryMarkerPath(dbPath), {
+          ...record.payload,
+          version: 1,
+          databasePath: dbPath,
+          backupPath: record.backupPath,
+          phase: "migration-restore-in-progress",
+          restoreStartedAt: new Date().toISOString(),
+          resumeAttempts: MIGRATION_RECOVERY_MAX_RESUME_ATTEMPTS,
+        });
+      } else {
+        // A restore is not a migration resume. Exhaust the automatic resume
+        // budget before replacing the live database so a crash or provenance
+        // write failure can only return to the explicit restore path.
+        await writePrivateJsonFile(record.markerPath, {
+          ...record.payload,
+          phase: "migration-restore-in-progress",
+          restoreStartedAt: new Date().toISOString(),
+          resumeAttempts: MIGRATION_RECOVERY_MAX_RESUME_ATTEMPTS,
+        });
       }
       await Effect.runPromise(
         restoreSqliteMigrationBackup({
@@ -1356,11 +1399,9 @@ export const restoreMarkedMigrationBackup = (dbPath: string) =>
         phase: "migration-restored",
         restoredAt: new Date().toISOString(),
       });
-      if (record.markerPath === migrationRecoveryMarkerPath(dbPath)) {
-        await fs.unlink(record.markerPath).catch((cause) => {
-          if ((cause as NodeJS.ErrnoException).code !== "ENOENT") throw cause;
-        });
-        await syncDirectory(path.dirname(dbPath));
-      }
+      await fs.unlink(migrationRecoveryMarkerPath(dbPath)).catch((cause) => {
+        if ((cause as NodeJS.ErrnoException).code !== "ENOENT") throw cause;
+      });
+      await syncDirectory(path.dirname(dbPath));
     }),
   );

--- a/apps/server/src/persistence/MigrationBackup.ts
+++ b/apps/server/src/persistence/MigrationBackup.ts
@@ -1346,7 +1346,8 @@ export const restoreMarkedMigrationBackup = (
           : null;
       const matchingRestoreMarker =
         hasExpectedCompletedBackup &&
-        activeMarker?.backupPath === options.expectedBackupPath &&
+        activeMarker !== null &&
+        activeMarker.backupPath === options.expectedBackupPath &&
         activeMarker.payload.phase === "migration-restore-in-progress"
           ? activeMarker
           : null;
@@ -1360,7 +1361,8 @@ export const restoreMarkedMigrationBackup = (
       }
       if (hasExpectedCompletedBackup) {
         if (
-          completedProvenance?.backupPath !== options.expectedBackupPath ||
+          completedProvenance === null ||
+          completedProvenance.backupPath !== options.expectedBackupPath ||
           completedProvenance.markerPath !== options.expectedProvenancePath
         ) {
           throw new Error("Completed migration provenance no longer matches the selected backup.");

--- a/apps/server/src/persistence/MigrationBackup.ts
+++ b/apps/server/src/persistence/MigrationBackup.ts
@@ -11,6 +11,7 @@ import {
   migrationBackupProvenancePath,
   migrationRecoveryMarkerPath,
   parseMigrationRecoveryResumeState,
+  type MigrationSchemaTooNewRecovery,
 } from "@synara/shared/migrationRecovery";
 export {
   migrationBackupDirectory,
@@ -846,9 +847,11 @@ export const runWithPreMigrationBackup = <A, E, R>(
 const restoreSqliteMigrationBackup = (input: {
   readonly dbPath: string;
   readonly backupPath: string;
+  readonly latestSupportedMigrationId: number;
 }) =>
   attemptPromise(async () => {
-    await validateSqliteMigrationBackup(input.backupPath);
+    const sourceInspection = await inspectSqliteMigrationBackup(input.backupPath);
+    assertMigrationBackupCompatible(sourceInspection, input.latestSupportedMigrationId);
     const dbDirectory = path.dirname(input.dbPath);
     const dbBasename = path.basename(input.dbPath);
     await removeStaleRegularFiles(
@@ -856,9 +859,19 @@ const restoreSqliteMigrationBackup = (input: {
       (name) => name.startsWith(`${dbBasename}.`) && name.endsWith(".restore"),
     );
     const restoredTemporaryPath = `${input.dbPath}.${randomUUID()}.restore`;
-    await fs.copyFile(input.backupPath, restoredTemporaryPath, fsConstants.COPYFILE_EXCL);
-    await ensurePrivateRegularFile(restoredTemporaryPath);
-    await syncRegularFile(restoredTemporaryPath);
+    try {
+      await fs.copyFile(input.backupPath, restoredTemporaryPath, fsConstants.COPYFILE_EXCL);
+      await ensurePrivateRegularFile(restoredTemporaryPath);
+      await syncRegularFile(restoredTemporaryPath);
+      const copiedInspection = await inspectSqliteMigrationBackup(restoredTemporaryPath);
+      assertMigrationBackupCompatible(copiedInspection, input.latestSupportedMigrationId);
+      if (copiedInspection.migrationId !== sourceInspection.migrationId) {
+        throw new Error(`Migration backup changed while it was copied: ${input.backupPath}`);
+      }
+    } catch (cause) {
+      await fs.unlink(restoredTemporaryPath).catch(() => undefined);
+      throw cause;
+    }
 
     const failedSuffix = `.failed-migration-${compactTimestamp(new Date())}-${randomUUID()}`;
     const moved: Array<readonly [string, string]> = [];
@@ -891,18 +904,27 @@ const restoreSqliteMigrationBackup = (input: {
     await syncDirectory(path.dirname(input.dbPath));
   });
 
-async function validateSqliteMigrationBackup(backupPath: string): Promise<void> {
+interface SqliteMigrationBackupInspection {
+  readonly migrationId: number;
+  readonly lineageRestorable: boolean;
+}
+
+async function inspectSqliteMigrationBackup(
+  backupPath: string,
+): Promise<SqliteMigrationBackupInspection> {
   const backupStat = await fs.lstat(backupPath);
   if (!backupStat.isFile() || backupStat.isSymbolicLink()) {
     throw new Error(`Migration backup is not a regular file: ${backupPath}`);
   }
 
   let integrity: unknown;
+  let migration: SqliteMigrationBackupInspection;
   if (process.versions.bun !== undefined) {
     const { Database } = await import("bun:sqlite");
     const database = new Database(backupPath, { readonly: true });
     try {
       integrity = database.query("PRAGMA integrity_check").get();
+      migration = readBunMigrationInspection(database);
     } finally {
       database.close();
     }
@@ -911,6 +933,7 @@ async function validateSqliteMigrationBackup(backupPath: string): Promise<void> 
     const database = new DatabaseSync(backupPath, { readOnly: true });
     try {
       integrity = database.prepare("PRAGMA integrity_check").get();
+      migration = readNodeMigrationInspection(database);
     } finally {
       database.close();
     }
@@ -921,6 +944,88 @@ async function validateSqliteMigrationBackup(backupPath: string): Promise<void> 
     !Object.values(integrity as Record<string, unknown>).includes("ok")
   ) {
     throw new Error(`Migration backup failed SQLite integrity_check: ${backupPath}`);
+  }
+  return migration;
+}
+
+function readBunMigrationInspection(
+  database: import("bun:sqlite").Database,
+): SqliteMigrationBackupInspection {
+  const tracker = database
+    .query(
+      "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'effect_sql_migrations'",
+    )
+    .get();
+  if (!tracker) return inspectMigrationRows([]);
+  return inspectMigrationRows(
+    database
+      .query(
+        "SELECT migration_id AS migrationId, name FROM effect_sql_migrations ORDER BY migration_id ASC",
+      )
+      .all(),
+  );
+}
+
+function readNodeMigrationInspection(
+  database: import("node:sqlite").DatabaseSync,
+): SqliteMigrationBackupInspection {
+  const tracker = database
+    .prepare(
+      "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'effect_sql_migrations'",
+    )
+    .get();
+  if (!tracker) return inspectMigrationRows([]);
+  return inspectMigrationRows(
+    database
+      .prepare(
+        "SELECT migration_id AS migrationId, name FROM effect_sql_migrations ORDER BY migration_id ASC",
+      )
+      .all(),
+  );
+}
+
+function inspectMigrationRows(rows: ReadonlyArray<unknown>): SqliteMigrationBackupInspection {
+  const recordedNames = new Map<number, string>();
+  for (const row of rows) {
+    const migration = row as { readonly migrationId?: unknown; readonly name?: unknown };
+    if (
+      typeof migration.migrationId !== "number" ||
+      !Number.isSafeInteger(migration.migrationId) ||
+      migration.migrationId < 0 ||
+      typeof migration.name !== "string"
+    ) {
+      throw new Error("Migration backup has an unreadable migration tracker.");
+    }
+    recordedNames.set(migration.migrationId, migration.name);
+  }
+
+  for (const repair of planMigrationLineageAliasRepairs(recordedNames)) {
+    if (repair.kind === "rename") {
+      recordedNames.set(repair.migrationId, repair.name);
+    } else {
+      recordedNames.delete(repair.migrationId);
+    }
+  }
+  const migrationId = Math.max(...recordedNames.keys(), 0);
+  const divergence = findFirstMigrationLineageDivergence(recordedNames, migrationId);
+  return {
+    migrationId,
+    lineageRestorable: divergence === undefined || divergence[0] > LAST_SHARED_LINEAGE_MIGRATION_ID,
+  };
+}
+
+function assertMigrationBackupCompatible(
+  inspection: SqliteMigrationBackupInspection,
+  latestSupportedMigrationId: number,
+): void {
+  if (!inspection.lineageRestorable) {
+    throw new Error("Migration backup has an unrecognized migration lineage.");
+  }
+  if (inspection.migrationId > latestSupportedMigrationId) {
+    throw new Error(
+      `Migration backup schema ${inspection.migrationId} is newer than this build ` +
+        `(latest supported migration: ${latestSupportedMigrationId}).`,
+    );
   }
 }
 
@@ -1031,6 +1136,46 @@ const readCompletedMigrationProvenance = (dbPath: string) =>
     migrationBackupProvenancePath(dbPath),
     "migration backup provenance",
   );
+
+export async function inspectCompletedMigrationBackupForSchemaTooNew(
+  dbPath: string,
+  input: {
+    readonly databaseMigrationId: number;
+    readonly latestSupportedMigrationId: number;
+  },
+): Promise<MigrationSchemaTooNewRecovery> {
+  let record: MigrationRecoveryMarker | null;
+  try {
+    record = await readCompletedMigrationProvenance(dbPath);
+  } catch {
+    return { kind: "restore-unavailable", reason: "invalid-provenance" };
+  }
+  if (!record) {
+    return { kind: "restore-unavailable", reason: "missing-provenance" };
+  }
+  if (
+    record.payload.phase !== "migration-completed" ||
+    record.payload.targetVersion !== input.databaseMigrationId
+  ) {
+    return { kind: "restore-unavailable", reason: "invalid-provenance" };
+  }
+
+  let inspection: SqliteMigrationBackupInspection;
+  try {
+    inspection = await inspectSqliteMigrationBackup(record.backupPath);
+  } catch {
+    return { kind: "restore-unavailable", reason: "invalid-backup" };
+  }
+  if (!inspection.lineageRestorable || inspection.migrationId > input.latestSupportedMigrationId) {
+    return { kind: "restore-unavailable", reason: "incompatible-backup" };
+  }
+  return {
+    kind: "restore-available",
+    backupPath: record.backupPath,
+    provenancePath: record.markerPath,
+    backupMigrationId: inspection.migrationId,
+  };
+}
 
 /**
  * Reclaims stranded migration artifacts before startup can fail closed.
@@ -1169,15 +1314,14 @@ export const restoreMarkedMigrationBackup = (dbPath: string) =>
   withDatabaseLifecycleLock(
     dbPath,
     attemptPromise(async () => {
-      const record =
-        (await readMigrationRecoveryMarker(dbPath)) ??
-        (await readCompletedMigrationProvenance(dbPath));
+      const activeMarker = await readMigrationRecoveryMarker(dbPath);
+      const record = activeMarker ?? (await readCompletedMigrationProvenance(dbPath));
       if (!record) {
         throw new Error(
           `No migration recovery marker or completed backup provenance exists for ${dbPath}.`,
         );
       }
-      if (record.markerPath === migrationRecoveryMarkerPath(dbPath)) {
+      if (activeMarker) {
         // A restore is not a migration resume. Exhaust the automatic resume
         // budget before replacing the live database so a crash or provenance
         // write failure can only return to the explicit restore path.
@@ -1187,9 +1331,23 @@ export const restoreMarkedMigrationBackup = (dbPath: string) =>
           restoreStartedAt: new Date().toISOString(),
           resumeAttempts: MIGRATION_RECOVERY_MAX_RESUME_ATTEMPTS,
         });
+      } else {
+        if (record.payload.phase !== "migration-completed") {
+          throw new Error(`Migration backup provenance is not restorable: ${record.markerPath}`);
+        }
+        const liveInspection = await inspectSqliteMigrationBackup(dbPath);
+        if (record.payload.targetVersion !== liveInspection.migrationId) {
+          throw new Error(
+            `Migration backup provenance does not describe the current database: ${record.markerPath}`,
+          );
+        }
       }
       await Effect.runPromise(
-        restoreSqliteMigrationBackup({ dbPath, backupPath: record.backupPath }),
+        restoreSqliteMigrationBackup({
+          dbPath,
+          backupPath: record.backupPath,
+          latestSupportedMigrationId: latestMigrationId,
+        }),
       );
       await writePrivateJsonFile(migrationBackupProvenancePath(dbPath), {
         ...record.payload,

--- a/apps/server/src/persistence/MigrationBackup.ts
+++ b/apps/server/src/persistence/MigrationBackup.ts
@@ -806,6 +806,16 @@ const removeRecoveryMarker = (dbPath: string) =>
     await syncDirectory(path.dirname(dbPath));
   });
 
+const removeRecoveryMarkerIfPresent = async (dbPath: string): Promise<void> => {
+  try {
+    await fs.unlink(migrationRecoveryMarkerPath(dbPath));
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw cause;
+  }
+  await syncDirectory(path.dirname(dbPath));
+};
+
 export interface RunWithPreMigrationBackupOptions {
   readonly divergenceConsent?: string | undefined;
 }
@@ -848,6 +858,8 @@ const restoreSqliteMigrationBackup = (input: {
   readonly dbPath: string;
   readonly backupPath: string;
   readonly latestSupportedMigrationId: number;
+  readonly beforeLiveDatabaseSwap?: (() => Promise<void>) | undefined;
+  readonly afterLiveDatabaseRollback?: (() => Promise<void>) | undefined;
 }) =>
   attemptPromise(async () => {
     const sourceInspection = await inspectSqliteMigrationBackup(input.backupPath);
@@ -875,7 +887,10 @@ const restoreSqliteMigrationBackup = (input: {
 
     const failedSuffix = `.failed-migration-${compactTimestamp(new Date())}-${randomUUID()}`;
     const moved: Array<readonly [string, string]> = [];
+    let swapPrepared = false;
     try {
+      swapPrepared = true;
+      await input.beforeLiveDatabaseSwap?.();
       for (const suffix of ["", "-wal", "-shm"]) {
         const source = `${input.dbPath}${suffix}`;
         const destination = `${input.dbPath}${failedSuffix}${suffix}`;
@@ -890,8 +905,14 @@ const restoreSqliteMigrationBackup = (input: {
     } catch (cause) {
       // Rollback is valid only before the restored main database is installed.
       await fs.unlink(restoredTemporaryPath).catch(() => undefined);
+      let rollbackSucceeded = true;
       for (const [source, destination] of moved.reverse()) {
-        await fs.rename(destination, source).catch(() => undefined);
+        await fs.rename(destination, source).catch(() => {
+          rollbackSucceeded = false;
+        });
+      }
+      if (swapPrepared && rollbackSucceeded) {
+        await input.afterLiveDatabaseRollback?.();
       }
       throw cause;
     }
@@ -1389,31 +1410,30 @@ export const restoreMarkedMigrationBackup = (
             `Migration backup provenance does not describe the current database: ${record.markerPath}`,
           );
         }
-        await writePrivateJsonFile(migrationRecoveryMarkerPath(dbPath), {
-          ...record.payload,
-          version: 1,
-          databasePath: dbPath,
-          backupPath: record.backupPath,
-          phase: "migration-restore-in-progress",
-          restoreStartedAt: new Date().toISOString(),
-          resumeAttempts: MIGRATION_RECOVERY_MAX_RESUME_ATTEMPTS,
-        });
-      } else {
-        // A restore is not a migration resume. Exhaust the automatic resume
-        // budget before replacing the live database so a crash or provenance
-        // write failure can only return to the explicit restore path.
-        await writePrivateJsonFile(record.markerPath, {
-          ...record.payload,
-          phase: "migration-restore-in-progress",
-          restoreStartedAt: new Date().toISOString(),
-          resumeAttempts: MIGRATION_RECOVERY_MAX_RESUME_ATTEMPTS,
-        });
       }
+      const restoreMarkerPath = migrationRecoveryMarkerPath(dbPath);
+      const restoreMarkerPayload = {
+        ...record.payload,
+        version: 1,
+        databasePath: dbPath,
+        backupPath: record.backupPath,
+        phase: "migration-restore-in-progress",
+        restoreStartedAt: new Date().toISOString(),
+        resumeAttempts: MIGRATION_RECOVERY_MAX_RESUME_ATTEMPTS,
+      };
       await Effect.runPromise(
         restoreSqliteMigrationBackup({
           dbPath,
           backupPath: record.backupPath,
           latestSupportedMigrationId: latestMigrationId,
+          // Defer the fail-closed marker until the backup has been copied and
+          // verified. If the live swap then rolls back completely, restore the
+          // marker state that existed before this explicit attempt.
+          beforeLiveDatabaseSwap: () =>
+            writePrivateJsonFile(restoreMarkerPath, restoreMarkerPayload),
+          afterLiveDatabaseRollback: restoringCompletedProvenance
+            ? () => removeRecoveryMarkerIfPresent(dbPath)
+            : () => writePrivateJsonFile(record.markerPath, record.payload),
         }),
       );
       await writePrivateJsonFile(migrationBackupProvenancePath(dbPath), {

--- a/apps/server/src/persistence/MigrationSchemaTooNewRecovery.test.ts
+++ b/apps/server/src/persistence/MigrationSchemaTooNewRecovery.test.ts
@@ -1,0 +1,291 @@
+import { DatabaseSync } from "node:sqlite";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { Effect, Layer } from "effect";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  migrationBackupDirectory,
+  migrationBackupProvenancePath,
+  migrationRecoveryMarkerPath,
+  parseMigrationSchemaTooNewStartupBlock,
+} from "@synara/shared/migrationRecovery";
+
+import {
+  inspectCompletedMigrationBackupForSchemaTooNew,
+  restoreMarkedMigrationBackup,
+} from "./MigrationBackup.ts";
+import { MigrationSchemaTooNewError } from "./Errors.ts";
+import { makeSqlitePersistenceLive } from "./Layers/Sqlite.ts";
+import {
+  MigrationSchemaTooNewStartupBlockError,
+  createMigrationSchemaTooNewStartupBlockError,
+} from "./MigrationSchemaTooNewStartupBlock.ts";
+import { migrationEntries } from "./Migrations.ts";
+
+const tempDirectories: Array<string> = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true })),
+  );
+});
+
+async function makeDatabasePath(): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "synara-schema-too-new-"));
+  tempDirectories.push(directory);
+  return path.join(directory, "state.sqlite");
+}
+
+function writeTrackedDatabase(databasePath: string, migrationId: number): void {
+  const database = new DatabaseSync(databasePath);
+  try {
+    database.exec(
+      "CREATE TABLE effect_sql_migrations (migration_id INTEGER PRIMARY KEY, name TEXT NOT NULL)",
+    );
+    const insert = database.prepare(
+      "INSERT INTO effect_sql_migrations (migration_id, name) VALUES (?, ?)",
+    );
+    let latestWrittenMigrationId = 0;
+    for (const [knownMigrationId, name] of migrationEntries) {
+      if (knownMigrationId > migrationId) break;
+      insert.run(knownMigrationId, name);
+      latestWrittenMigrationId = knownMigrationId;
+    }
+    for (
+      let futureMigrationId = latestWrittenMigrationId + 1;
+      futureMigrationId <= migrationId;
+      futureMigrationId += 1
+    ) {
+      insert.run(futureMigrationId, `FutureMigration${futureMigrationId}`);
+    }
+  } finally {
+    database.close();
+  }
+}
+
+function writeFutureCanonicalDatabase(databasePath: string): number {
+  const database = new DatabaseSync(databasePath);
+  const latestMigrationId = Math.max(...migrationEntries.map(([migrationId]) => migrationId));
+  try {
+    database.exec(
+      "CREATE TABLE effect_sql_migrations (migration_id INTEGER PRIMARY KEY, name TEXT NOT NULL)",
+    );
+    const insert = database.prepare(
+      "INSERT INTO effect_sql_migrations (migration_id, name) VALUES (?, ?)",
+    );
+    for (const [migrationId, name] of migrationEntries) insert.run(migrationId, name);
+    insert.run(latestMigrationId + 1, "FutureMigration");
+  } finally {
+    database.close();
+  }
+  return latestMigrationId;
+}
+
+function generatedBackupPath(databasePath: string, suffix: string, targetVersion: number): string {
+  return path.join(
+    migrationBackupDirectory(databasePath),
+    `${path.basename(databasePath)}.pre-migration-v1-to-v${targetVersion}-20260830T120000000Z-${suffix}.sqlite`,
+  );
+}
+
+async function writeCompletedProvenance(input: {
+  readonly databasePath: string;
+  readonly backupPath: string;
+  readonly targetVersion: number;
+}): Promise<void> {
+  await fs.writeFile(
+    migrationBackupProvenancePath(input.databasePath),
+    `${JSON.stringify({
+      version: 1,
+      databasePath: input.databasePath,
+      backupPath: input.backupPath,
+      sourceVersion: "v1",
+      targetVersion: input.targetVersion,
+      phase: "migration-completed",
+      createdAt: "2026-08-30T12:00:00.000Z",
+      completedAt: "2026-08-30T12:01:00.000Z",
+      resumeAttempts: 0,
+    })}\n`,
+  );
+}
+
+const firstUuid = "00000000-0000-4000-8000-000000000001";
+const secondUuid = "00000000-0000-4000-8000-000000000002";
+
+describe("completed migration backup recovery", () => {
+  it("emits a structured block from the real persistence startup path", async () => {
+    const databasePath = await makeDatabasePath();
+    const latestMigrationId = writeFutureCanonicalDatabase(databasePath);
+    let startupError: unknown;
+
+    try {
+      await Effect.runPromise(
+        Layer.build(
+          makeSqlitePersistenceLive(databasePath).pipe(Layer.provide(NodeServices.layer)),
+        ).pipe(Effect.scoped),
+      );
+    } catch (cause) {
+      startupError = cause;
+    }
+
+    expect(startupError).toBeInstanceOf(MigrationSchemaTooNewStartupBlockError);
+    expect(parseMigrationSchemaTooNewStartupBlock((startupError as Error).message)).toEqual({
+      version: 1,
+      databasePath,
+      databaseMigrationId: latestMigrationId + 1,
+      latestSupportedMigrationId: latestMigrationId,
+      recovery: { kind: "restore-unavailable", reason: "missing-provenance" },
+    });
+  });
+
+  it("uses completed provenance when the successful migration removed its marker", async () => {
+    const databasePath = await makeDatabasePath();
+    await fs.mkdir(migrationBackupDirectory(databasePath));
+    const backupPath = generatedBackupPath(databasePath, firstUuid, 97);
+    writeTrackedDatabase(backupPath, 90);
+    await writeCompletedProvenance({ databasePath, backupPath, targetVersion: 97 });
+
+    await expect(fs.stat(migrationRecoveryMarkerPath(databasePath))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    const recovery = await inspectCompletedMigrationBackupForSchemaTooNew(databasePath, {
+      databaseMigrationId: 97,
+      latestSupportedMigrationId: 96,
+    });
+    expect(recovery).toEqual({
+      kind: "restore-available",
+      backupPath,
+      provenancePath: migrationBackupProvenancePath(databasePath),
+      backupMigrationId: 90,
+    });
+
+    const startupError = await createMigrationSchemaTooNewStartupBlockError(
+      databasePath,
+      new MigrationSchemaTooNewError({
+        databaseMigrationId: 97,
+        latestSupportedMigrationId: 96,
+      }),
+    );
+    expect(parseMigrationSchemaTooNewStartupBlock(startupError.message)).toMatchObject({
+      databasePath,
+      databaseMigrationId: 97,
+      latestSupportedMigrationId: 96,
+      recovery,
+    });
+  });
+
+  it("ignores newer-looking files and selects only the provenance-bound backup", async () => {
+    const databasePath = await makeDatabasePath();
+    await fs.mkdir(migrationBackupDirectory(databasePath));
+    const exactBackupPath = generatedBackupPath(databasePath, firstUuid, 97);
+    const unrelatedBackupPath = generatedBackupPath(databasePath, secondUuid, 99);
+    writeTrackedDatabase(exactBackupPath, 90);
+    writeTrackedDatabase(unrelatedBackupPath, 99);
+    await writeCompletedProvenance({
+      databasePath,
+      backupPath: exactBackupPath,
+      targetVersion: 97,
+    });
+
+    await expect(
+      inspectCompletedMigrationBackupForSchemaTooNew(databasePath, {
+        databaseMigrationId: 97,
+        latestSupportedMigrationId: 96,
+      }),
+    ).resolves.toMatchObject({ kind: "restore-available", backupPath: exactBackupPath });
+  });
+
+  it("withholds restore when the exact backup is newer than this build", async () => {
+    const databasePath = await makeDatabasePath();
+    await fs.mkdir(migrationBackupDirectory(databasePath));
+    const backupPath = generatedBackupPath(databasePath, firstUuid, 97);
+    writeTrackedDatabase(backupPath, 97);
+    await writeCompletedProvenance({ databasePath, backupPath, targetVersion: 98 });
+
+    await expect(
+      inspectCompletedMigrationBackupForSchemaTooNew(databasePath, {
+        databaseMigrationId: 98,
+        latestSupportedMigrationId: 96,
+      }),
+    ).resolves.toEqual({ kind: "restore-unavailable", reason: "incompatible-backup" });
+  });
+
+  it("withholds restore when the exact backup has an incompatible shared lineage", async () => {
+    const databasePath = await makeDatabasePath();
+    await fs.mkdir(migrationBackupDirectory(databasePath));
+    const backupPath = generatedBackupPath(databasePath, firstUuid, 97);
+    writeTrackedDatabase(backupPath, 90);
+    const backup = new DatabaseSync(backupPath);
+    try {
+      backup
+        .prepare("UPDATE effect_sql_migrations SET name = ? WHERE migration_id = ?")
+        .run("UnknownSharedMigration", migrationEntries[0]![0]);
+    } finally {
+      backup.close();
+    }
+    await writeCompletedProvenance({ databasePath, backupPath, targetVersion: 97 });
+
+    await expect(
+      inspectCompletedMigrationBackupForSchemaTooNew(databasePath, {
+        databaseMigrationId: 97,
+        latestSupportedMigrationId: 96,
+      }),
+    ).resolves.toEqual({ kind: "restore-unavailable", reason: "incompatible-backup" });
+  });
+
+  it("withholds restore when the provenance is missing or its exact backup is corrupt", async () => {
+    const databasePath = await makeDatabasePath();
+
+    await expect(
+      inspectCompletedMigrationBackupForSchemaTooNew(databasePath, {
+        databaseMigrationId: 97,
+        latestSupportedMigrationId: 96,
+      }),
+    ).resolves.toEqual({ kind: "restore-unavailable", reason: "missing-provenance" });
+
+    await fs.mkdir(migrationBackupDirectory(databasePath));
+    const backupPath = generatedBackupPath(databasePath, firstUuid, 97);
+    await fs.writeFile(backupPath, "not sqlite");
+    await writeCompletedProvenance({ databasePath, backupPath, targetVersion: 97 });
+
+    await expect(
+      inspectCompletedMigrationBackupForSchemaTooNew(databasePath, {
+        databaseMigrationId: 97,
+        latestSupportedMigrationId: 96,
+      }),
+    ).resolves.toEqual({ kind: "restore-unavailable", reason: "invalid-backup" });
+  });
+
+  it("revalidates compatibility before the restore mutates the live database", async () => {
+    const databasePath = await makeDatabasePath();
+    const latestMigrationId = Math.max(...migrationEntries.map(([migrationId]) => migrationId));
+    const newerMigrationId = latestMigrationId + 1;
+    writeTrackedDatabase(databasePath, newerMigrationId);
+    await fs.mkdir(migrationBackupDirectory(databasePath));
+    const backupPath = generatedBackupPath(databasePath, firstUuid, newerMigrationId);
+    writeTrackedDatabase(backupPath, newerMigrationId);
+    await writeCompletedProvenance({
+      databasePath,
+      backupPath,
+      targetVersion: newerMigrationId,
+    });
+
+    await expect(Effect.runPromise(restoreMarkedMigrationBackup(databasePath))).rejects.toThrow(
+      `Migration backup schema ${newerMigrationId} is newer than this build`,
+    );
+    const liveDatabase = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(
+        liveDatabase
+          .prepare("SELECT MAX(migration_id) AS migrationId FROM effect_sql_migrations")
+          .get(),
+      ).toMatchObject({ migrationId: newerMigrationId });
+    } finally {
+      liveDatabase.close();
+    }
+  });
+});

--- a/apps/server/src/persistence/MigrationSchemaTooNewRecovery.test.ts
+++ b/apps/server/src/persistence/MigrationSchemaTooNewRecovery.test.ts
@@ -430,7 +430,7 @@ describe("completed migration backup recovery", () => {
     });
   });
 
-  it("keeps an exhausted exact restore marker when completed-provenance restore fails", async () => {
+  it("keeps the live database usable when completed-provenance validation fails", async () => {
     const databasePath = await makeDatabasePath();
     const latestMigrationId = Math.max(...migrationEntries.map(([migrationId]) => migrationId));
     const databaseMigrationId = latestMigrationId + 1;
@@ -453,12 +453,14 @@ describe("completed migration backup recovery", () => {
       ),
     ).rejects.toThrow();
 
+    await expect(fs.stat(migrationRecoveryMarkerPath(databasePath))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
     await expect(
-      fs.readFile(migrationRecoveryMarkerPath(databasePath), "utf8").then(JSON.parse),
+      fs.readFile(migrationBackupProvenancePath(databasePath), "utf8").then(JSON.parse),
     ).resolves.toMatchObject({
       backupPath,
-      phase: "migration-restore-in-progress",
-      resumeAttempts: MIGRATION_RECOVERY_MAX_RESUME_ATTEMPTS,
+      phase: "migration-completed",
     });
     const live = new DatabaseSync(databasePath, { readOnly: true });
     try {

--- a/apps/server/src/persistence/MigrationSchemaTooNewRecovery.test.ts
+++ b/apps/server/src/persistence/MigrationSchemaTooNewRecovery.test.ts
@@ -296,7 +296,9 @@ describe("completed migration backup recovery", () => {
     const restored = new DatabaseSync(databasePath, { readOnly: true });
     try {
       expect(
-        restored.prepare("SELECT MAX(migration_id) AS migrationId FROM effect_sql_migrations").get(),
+        restored
+          .prepare("SELECT MAX(migration_id) AS migrationId FROM effect_sql_migrations")
+          .get(),
       ).toMatchObject({ migrationId: importedBackupMigrationId });
     } finally {
       restored.close();

--- a/apps/server/src/persistence/MigrationSchemaTooNewRecovery.test.ts
+++ b/apps/server/src/persistence/MigrationSchemaTooNewRecovery.test.ts
@@ -68,6 +68,31 @@ function writeTrackedDatabase(databasePath: string, migrationId: number): void {
   }
 }
 
+function writeImportedTrackedDatabase(databasePath: string, migrationId: number): void {
+  const database = new DatabaseSync(databasePath);
+  try {
+    database.exec(
+      "CREATE TABLE effect_sql_migrations (migration_id INTEGER PRIMARY KEY, name TEXT NOT NULL)",
+    );
+    const insert = database.prepare(
+      "INSERT INTO effect_sql_migrations (migration_id, name) VALUES (?, ?)",
+    );
+    for (const [knownMigrationId, name] of migrationEntries) {
+      if (knownMigrationId > 16) break;
+      insert.run(knownMigrationId, name);
+    }
+    for (
+      let importedMigrationId = 17;
+      importedMigrationId <= migrationId;
+      importedMigrationId += 1
+    ) {
+      insert.run(importedMigrationId, `ImportedMigration${importedMigrationId}`);
+    }
+  } finally {
+    database.close();
+  }
+}
+
 function writeFutureCanonicalDatabase(databasePath: string): number {
   const database = new DatabaseSync(databasePath);
   const latestMigrationId = Math.max(...migrationEntries.map(([migrationId]) => migrationId));
@@ -234,6 +259,48 @@ describe("completed migration backup recovery", () => {
         latestSupportedMigrationId: 96,
       }),
     ).resolves.toEqual({ kind: "restore-unavailable", reason: "incompatible-backup" });
+  });
+
+  it("allows a restorable imported lineage even when its numeric IDs exceed this build", async () => {
+    const databasePath = await makeDatabasePath();
+    const latestMigrationId = Math.max(...migrationEntries.map(([migrationId]) => migrationId));
+    const databaseMigrationId = latestMigrationId + 20;
+    const importedBackupMigrationId = latestMigrationId + 10;
+    writeTrackedDatabase(databasePath, databaseMigrationId);
+    await fs.mkdir(migrationBackupDirectory(databasePath));
+    const backupPath = generatedBackupPath(databasePath, firstUuid, databaseMigrationId);
+    writeImportedTrackedDatabase(backupPath, importedBackupMigrationId);
+    await writeCompletedProvenance({
+      databasePath,
+      backupPath,
+      targetVersion: databaseMigrationId,
+    });
+
+    await expect(
+      inspectCompletedMigrationBackupForSchemaTooNew(databasePath, {
+        databaseMigrationId,
+        latestSupportedMigrationId: latestMigrationId,
+      }),
+    ).resolves.toMatchObject({
+      kind: "restore-available",
+      backupPath,
+      backupMigrationId: importedBackupMigrationId,
+    });
+
+    await Effect.runPromise(
+      restoreMarkedMigrationBackup(databasePath, {
+        expectedBackupPath: backupPath,
+        expectedProvenancePath: migrationBackupProvenancePath(databasePath),
+      }),
+    );
+    const restored = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(
+        restored.prepare("SELECT MAX(migration_id) AS migrationId FROM effect_sql_migrations").get(),
+      ).toMatchObject({ migrationId: importedBackupMigrationId });
+    } finally {
+      restored.close();
+    }
   });
 
   it("withholds restore when the exact backup has an incompatible shared lineage", async () => {

--- a/apps/server/src/persistence/MigrationSchemaTooNewRecovery.test.ts
+++ b/apps/server/src/persistence/MigrationSchemaTooNewRecovery.test.ts
@@ -423,7 +423,12 @@ describe("completed migration backup recovery", () => {
     });
     await fs.rename(databasePath, `${databasePath}.stranded-after-restore-crash`);
 
-    await Effect.runPromise(restoreMarkedMigrationBackup(databasePath));
+    await Effect.runPromise(
+      restoreMarkedMigrationBackup(databasePath, {
+        expectedBackupPath: backupPath,
+        expectedProvenancePath: migrationBackupProvenancePath(databasePath),
+      }),
+    );
 
     const restored = new DatabaseSync(databasePath, { readOnly: true });
     try {

--- a/apps/server/src/persistence/MigrationSchemaTooNewRecovery.test.ts
+++ b/apps/server/src/persistence/MigrationSchemaTooNewRecovery.test.ts
@@ -8,6 +8,7 @@ import { Effect, Layer } from "effect";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  MIGRATION_RECOVERY_MAX_RESUME_ATTEMPTS,
   migrationBackupDirectory,
   migrationBackupProvenancePath,
   migrationRecoveryMarkerPath,
@@ -109,6 +110,27 @@ async function writeCompletedProvenance(input: {
       createdAt: "2026-08-30T12:00:00.000Z",
       completedAt: "2026-08-30T12:01:00.000Z",
       resumeAttempts: 0,
+    })}\n`,
+  );
+}
+
+async function writeActiveRecoveryMarker(input: {
+  readonly databasePath: string;
+  readonly backupPath: string;
+  readonly targetVersion: number;
+  readonly phase?: string;
+}): Promise<void> {
+  await fs.writeFile(
+    migrationRecoveryMarkerPath(input.databasePath),
+    `${JSON.stringify({
+      version: 1,
+      databasePath: input.databasePath,
+      backupPath: input.backupPath,
+      sourceVersion: "v1",
+      targetVersion: input.targetVersion,
+      phase: input.phase ?? "migration-in-progress",
+      createdAt: "2026-08-30T12:02:00.000Z",
+      resumeAttempts: MIGRATION_RECOVERY_MAX_RESUME_ATTEMPTS,
     })}\n`,
   );
 }
@@ -287,5 +309,134 @@ describe("completed migration backup recovery", () => {
     } finally {
       liveDatabase.close();
     }
+  });
+
+  it("restores the explicitly selected completed backup instead of a leftover active marker", async () => {
+    const databasePath = await makeDatabasePath();
+    const latestMigrationId = Math.max(...migrationEntries.map(([migrationId]) => migrationId));
+    const databaseMigrationId = latestMigrationId + 1;
+    const selectedBackupMigrationId = Math.max(latestMigrationId - 5, 0);
+    writeTrackedDatabase(databasePath, databaseMigrationId);
+    await fs.mkdir(migrationBackupDirectory(databasePath));
+    const selectedBackupPath = generatedBackupPath(databasePath, firstUuid, databaseMigrationId);
+    const activeBackupPath = generatedBackupPath(databasePath, secondUuid, databaseMigrationId);
+    writeTrackedDatabase(selectedBackupPath, selectedBackupMigrationId);
+    writeTrackedDatabase(activeBackupPath, latestMigrationId);
+    await writeCompletedProvenance({
+      databasePath,
+      backupPath: selectedBackupPath,
+      targetVersion: databaseMigrationId,
+    });
+    await writeActiveRecoveryMarker({
+      databasePath,
+      backupPath: activeBackupPath,
+      targetVersion: databaseMigrationId,
+    });
+
+    await Effect.runPromise(
+      restoreMarkedMigrationBackup(databasePath, {
+        expectedBackupPath: selectedBackupPath,
+        expectedProvenancePath: migrationBackupProvenancePath(databasePath),
+      }),
+    );
+
+    const restored = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(
+        restored
+          .prepare("SELECT MAX(migration_id) AS migrationId FROM effect_sql_migrations")
+          .get(),
+      ).toMatchObject({ migrationId: selectedBackupMigrationId });
+    } finally {
+      restored.close();
+    }
+    await expect(fs.stat(migrationRecoveryMarkerPath(databasePath))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(
+      fs.readFile(migrationBackupProvenancePath(databasePath), "utf8").then(JSON.parse),
+    ).resolves.toMatchObject({
+      backupPath: selectedBackupPath,
+      phase: "migration-restored",
+    });
+  });
+
+  it("keeps an exhausted exact restore marker when completed-provenance restore fails", async () => {
+    const databasePath = await makeDatabasePath();
+    const latestMigrationId = Math.max(...migrationEntries.map(([migrationId]) => migrationId));
+    const databaseMigrationId = latestMigrationId + 1;
+    writeTrackedDatabase(databasePath, databaseMigrationId);
+    await fs.mkdir(migrationBackupDirectory(databasePath));
+    const backupPath = generatedBackupPath(databasePath, firstUuid, databaseMigrationId);
+    await fs.writeFile(backupPath, "not sqlite");
+    await writeCompletedProvenance({
+      databasePath,
+      backupPath,
+      targetVersion: databaseMigrationId,
+    });
+
+    await expect(
+      Effect.runPromise(
+        restoreMarkedMigrationBackup(databasePath, {
+          expectedBackupPath: backupPath,
+          expectedProvenancePath: migrationBackupProvenancePath(databasePath),
+        }),
+      ),
+    ).rejects.toThrow();
+
+    await expect(
+      fs.readFile(migrationRecoveryMarkerPath(databasePath), "utf8").then(JSON.parse),
+    ).resolves.toMatchObject({
+      backupPath,
+      phase: "migration-restore-in-progress",
+      resumeAttempts: MIGRATION_RECOVERY_MAX_RESUME_ATTEMPTS,
+    });
+    const live = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(
+        live.prepare("SELECT MAX(migration_id) AS migrationId FROM effect_sql_migrations").get(),
+      ).toMatchObject({ migrationId: databaseMigrationId });
+    } finally {
+      live.close();
+    }
+  });
+
+  it("recovers an exact restore after a crash strands the live database mid-swap", async () => {
+    const databasePath = await makeDatabasePath();
+    const latestMigrationId = Math.max(...migrationEntries.map(([migrationId]) => migrationId));
+    const databaseMigrationId = latestMigrationId + 1;
+    const backupMigrationId = Math.max(latestMigrationId - 5, 0);
+    writeTrackedDatabase(databasePath, databaseMigrationId);
+    await fs.mkdir(migrationBackupDirectory(databasePath));
+    const backupPath = generatedBackupPath(databasePath, firstUuid, databaseMigrationId);
+    writeTrackedDatabase(backupPath, backupMigrationId);
+    await writeCompletedProvenance({
+      databasePath,
+      backupPath,
+      targetVersion: databaseMigrationId,
+    });
+    await writeActiveRecoveryMarker({
+      databasePath,
+      backupPath,
+      targetVersion: databaseMigrationId,
+      phase: "migration-restore-in-progress",
+    });
+    await fs.rename(databasePath, `${databasePath}.stranded-after-restore-crash`);
+
+    await Effect.runPromise(restoreMarkedMigrationBackup(databasePath));
+
+    const restored = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(
+        restored
+          .prepare("SELECT MAX(migration_id) AS migrationId FROM effect_sql_migrations")
+          .get(),
+      ).toMatchObject({ migrationId: backupMigrationId });
+    } finally {
+      restored.close();
+    }
+    await expect(fs.stat(migrationRecoveryMarkerPath(databasePath))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 });

--- a/apps/server/src/persistence/MigrationSchemaTooNewStartupBlock.ts
+++ b/apps/server/src/persistence/MigrationSchemaTooNewStartupBlock.ts
@@ -1,0 +1,31 @@
+import {
+  serializeMigrationSchemaTooNewStartupBlock,
+  type MigrationSchemaTooNewStartupBlock,
+} from "@synara/shared/migrationRecovery";
+
+import { MigrationSchemaTooNewError } from "./Errors.ts";
+import { inspectCompletedMigrationBackupForSchemaTooNew } from "./MigrationBackup.ts";
+
+export class MigrationSchemaTooNewStartupBlockError extends Error {
+  readonly block: MigrationSchemaTooNewStartupBlock;
+
+  constructor(cause: MigrationSchemaTooNewError, block: MigrationSchemaTooNewStartupBlock) {
+    super(`${cause.message}\n${serializeMigrationSchemaTooNewStartupBlock(block)}`, { cause });
+    this.name = "MigrationSchemaTooNewStartupBlockError";
+    this.block = block;
+  }
+}
+
+export async function createMigrationSchemaTooNewStartupBlockError(
+  dbPath: string,
+  cause: MigrationSchemaTooNewError,
+): Promise<MigrationSchemaTooNewStartupBlockError> {
+  const recovery = await inspectCompletedMigrationBackupForSchemaTooNew(dbPath, cause);
+  return new MigrationSchemaTooNewStartupBlockError(cause, {
+    version: 1,
+    databasePath: dbPath,
+    databaseMigrationId: cause.databaseMigrationId,
+    latestSupportedMigrationId: cause.latestSupportedMigrationId,
+    recovery,
+  });
+}

--- a/apps/server/src/restoreMigrationBackup.test.ts
+++ b/apps/server/src/restoreMigrationBackup.test.ts
@@ -42,4 +42,31 @@ describe("migration backup recovery CLI", () => {
     expect(capture.warnings.join("\n")).toContain("Stop every Synara process");
     expect(capture.logs).toEqual([]);
   });
+
+  it("requires a complete absolute backup selection", async () => {
+    const incomplete = captureOutput();
+    const relative = captureOutput();
+
+    await expect(
+      runRestoreMigrationBackupCli(
+        ["/data/state.sqlite", "--backup-path", "/data/exact.sqlite"],
+        incomplete.output,
+      ),
+    ).resolves.toBe(2);
+    expect(incomplete.errors.join("\n")).toContain("--provenance-path");
+
+    await expect(
+      runRestoreMigrationBackupCli(
+        [
+          "/data/state.sqlite",
+          "--backup-path",
+          "relative.sqlite",
+          "--provenance-path",
+          "/data/state.sqlite.migration-backup.json",
+        ],
+        relative.output,
+      ),
+    ).resolves.toBe(2);
+    expect(relative.errors.join("\n")).toContain("must be absolute");
+  });
 });

--- a/apps/server/src/restoreMigrationBackup.ts
+++ b/apps/server/src/restoreMigrationBackup.ts
@@ -2,9 +2,14 @@ import * as path from "node:path";
 
 import { Effect } from "effect";
 
-import { restoreMarkedMigrationBackup } from "./persistence/MigrationBackup.ts";
+import {
+  restoreMarkedMigrationBackup,
+  type RestoreMarkedMigrationBackupOptions,
+} from "./persistence/MigrationBackup.ts";
 
-const USAGE = "Usage: synara-restore-migration-backup <absolute-database-path>";
+const USAGE =
+  "Usage: synara-restore-migration-backup <absolute-database-path> " +
+  "[--backup-path <absolute-backup-path> --provenance-path <absolute-provenance-path>]";
 const STOP_PROCESSES_WARNING =
   "WARNING: Stop every Synara process before restoring a migration backup.";
 
@@ -30,8 +35,29 @@ export async function runRestoreMigrationBackupCli(
     return 2;
   }
 
+  let options: RestoreMarkedMigrationBackupOptions = {};
+  if (args.length > 1) {
+    const backupPath = args[2];
+    const provenancePath = args[4];
+    if (
+      args.length !== 5 ||
+      args[1] !== "--backup-path" ||
+      args[3] !== "--provenance-path" ||
+      !backupPath ||
+      !provenancePath
+    ) {
+      output.error(USAGE);
+      return 2;
+    }
+    if (!path.isAbsolute(backupPath) || !path.isAbsolute(provenancePath)) {
+      output.error(`Backup and provenance paths must be absolute.\n${USAGE}`);
+      return 2;
+    }
+    options = { expectedBackupPath: backupPath, expectedProvenancePath: provenancePath };
+  }
+
   try {
-    await Effect.runPromise(restoreMarkedMigrationBackup(dbPath));
+    await Effect.runPromise(restoreMarkedMigrationBackup(dbPath, options));
     output.log(`Restored migration backup for ${dbPath}`);
     return 0;
   } catch (cause) {

--- a/packages/shared/src/migrationRecovery.test.ts
+++ b/packages/shared/src/migrationRecovery.test.ts
@@ -4,6 +4,7 @@ import {
   createMigrationDivergenceConsentToken,
   MIGRATION_DIVERGENCE_CONSENT_REQUIRED_PREFIX,
   MIGRATION_RECOVERY_MAX_RESUME_ATTEMPTS,
+  MIGRATION_SCHEMA_TOO_NEW_BLOCK_PREFIX,
   findMigrationRuntimeIdentityMismatch,
   migrationBackupDirectory,
   migrationBackupProvenancePath,
@@ -11,8 +12,11 @@ import {
   migrationRuntimeSourceDigest,
   parseMigrationDivergenceConsentChallenge,
   parseMigrationRecoveryResumeState,
+  parseMigrationSchemaTooNewStartupBlock,
   serializeMigrationDivergenceConsentChallenge,
+  serializeMigrationSchemaTooNewStartupBlock,
   type MigrationDivergenceConsentChallenge,
+  type MigrationSchemaTooNewStartupBlock,
 } from "./migrationRecovery";
 
 const divergenceChallengeWithoutToken: Omit<MigrationDivergenceConsentChallenge, "consentToken"> = {
@@ -30,6 +34,19 @@ const divergenceChallengeWithoutToken: Omit<MigrationDivergenceConsentChallenge,
 const divergenceChallenge: MigrationDivergenceConsentChallenge = {
   ...divergenceChallengeWithoutToken,
   consentToken: createMigrationDivergenceConsentToken(divergenceChallengeWithoutToken),
+};
+
+const schemaTooNewBlock: MigrationSchemaTooNewStartupBlock = {
+  version: 1,
+  databasePath: "/data/state.sqlite",
+  databaseMigrationId: 97,
+  latestSupportedMigrationId: 96,
+  recovery: {
+    kind: "restore-available",
+    backupPath: "/data/state.sqlite.backups/state.sqlite.pre-migration.sqlite",
+    provenancePath: "/data/state.sqlite.migration-backup.json",
+    backupMigrationId: 90,
+  },
 };
 
 describe("migration recovery paths", () => {
@@ -142,6 +159,49 @@ describe("migration divergence consent challenge", () => {
           ...divergenceChallenge,
           databasePath: "/substituted/state.sqlite",
         }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("migration schema-too-new startup block", () => {
+  it("round-trips an exact compatible restore candidate", () => {
+    const serialized = serializeMigrationSchemaTooNewStartupBlock(schemaTooNewBlock);
+
+    expect(serialized.startsWith(MIGRATION_SCHEMA_TOO_NEW_BLOCK_PREFIX)).toBe(true);
+    expect(parseMigrationSchemaTooNewStartupBlock(`startup failed\n${serialized}\nstack`)).toEqual(
+      schemaTooNewBlock,
+    );
+  });
+
+  it("round-trips a fail-closed block without a restore candidate", () => {
+    const block: MigrationSchemaTooNewStartupBlock = {
+      ...schemaTooNewBlock,
+      recovery: { kind: "restore-unavailable", reason: "missing-provenance" },
+    };
+
+    expect(
+      parseMigrationSchemaTooNewStartupBlock(serializeMigrationSchemaTooNewStartupBlock(block)),
+    ).toEqual(block);
+  });
+
+  it("rejects malformed and incomplete recovery payloads", () => {
+    expect(
+      parseMigrationSchemaTooNewStartupBlock(
+        `${MIGRATION_SCHEMA_TOO_NEW_BLOCK_PREFIX}{"version":1}`,
+      ),
+    ).toBeNull();
+    expect(
+      parseMigrationSchemaTooNewStartupBlock(
+        `${MIGRATION_SCHEMA_TOO_NEW_BLOCK_PREFIX}${JSON.stringify({
+          ...schemaTooNewBlock,
+          recovery: {
+            kind: "restore-available",
+            backupPath: "",
+            provenancePath: "/data/state.sqlite.migration-backup.json",
+            backupMigrationId: 90,
+          },
+        })}`,
       ),
     ).toBeNull();
   });

--- a/packages/shared/src/migrationRecovery.ts
+++ b/packages/shared/src/migrationRecovery.ts
@@ -69,6 +69,7 @@ export const MIGRATION_RUNTIME_SOURCE_DIGEST_ENV = "SYNARA_MIGRATION_RUNTIME_SOU
 export const MIGRATION_RUNTIME_SOURCE_RELATIVE_PATH = "apps/server/src/persistence/Migrations.ts";
 export const MIGRATION_DIVERGENCE_CONSENT_REQUIRED_PREFIX =
   "SYNARA_MIGRATION_DIVERGENCE_CONSENT_REQUIRED=";
+export const MIGRATION_SCHEMA_TOO_NEW_BLOCK_PREFIX = "SYNARA_MIGRATION_SCHEMA_TOO_NEW=";
 
 export interface MigrationDivergenceConsentChallenge {
   readonly version: 1;
@@ -112,6 +113,30 @@ export interface MigrationRuntimeIdentityMismatch {
   readonly actualDigest: string;
 }
 
+export type MigrationSchemaTooNewRecovery =
+  | {
+      readonly kind: "restore-available";
+      readonly backupPath: string;
+      readonly provenancePath: string;
+      readonly backupMigrationId: number;
+    }
+  | {
+      readonly kind: "restore-unavailable";
+      readonly reason:
+        | "missing-provenance"
+        | "invalid-provenance"
+        | "invalid-backup"
+        | "incompatible-backup";
+    };
+
+export interface MigrationSchemaTooNewStartupBlock {
+  readonly version: 1;
+  readonly databasePath: string;
+  readonly databaseMigrationId: number;
+  readonly latestSupportedMigrationId: number;
+  readonly recovery: MigrationSchemaTooNewRecovery;
+}
+
 export function migrationRuntimeSourceDigest(source: string): string {
   return createHash("sha256").update(source, "utf8").digest("hex");
 }
@@ -150,13 +175,43 @@ export function serializeMigrationDivergenceConsentChallenge(
 export function parseMigrationDivergenceConsentChallenge(
   output: string,
 ): MigrationDivergenceConsentChallenge | null {
-  let searchFrom = 0;
-  let authoritativeChallenge: MigrationDivergenceConsentChallenge | null = null;
-  for (;;) {
-    const prefixIndex = output.indexOf(MIGRATION_DIVERGENCE_CONSENT_REQUIRED_PREFIX, searchFrom);
-    if (prefixIndex === -1) return authoritativeChallenge;
+  return parsePrefixedJsonLine(
+    output,
+    MIGRATION_DIVERGENCE_CONSENT_REQUIRED_PREFIX,
+    (value): value is MigrationDivergenceConsentChallenge =>
+      isMigrationDivergenceConsentChallenge(value) &&
+      value.consentToken === createMigrationDivergenceConsentToken(value),
+  );
+}
 
-    const payloadStart = prefixIndex + MIGRATION_DIVERGENCE_CONSENT_REQUIRED_PREFIX.length;
+export function serializeMigrationSchemaTooNewStartupBlock(
+  block: MigrationSchemaTooNewStartupBlock,
+): string {
+  return `${MIGRATION_SCHEMA_TOO_NEW_BLOCK_PREFIX}${JSON.stringify(block)}`;
+}
+
+export function parseMigrationSchemaTooNewStartupBlock(
+  output: string,
+): MigrationSchemaTooNewStartupBlock | null {
+  return parsePrefixedJsonLine(
+    output,
+    MIGRATION_SCHEMA_TOO_NEW_BLOCK_PREFIX,
+    isMigrationSchemaTooNewStartupBlock,
+  );
+}
+
+function parsePrefixedJsonLine<A>(
+  output: string,
+  prefix: string,
+  isValid: (value: unknown) => value is A,
+): A | null {
+  let searchFrom = 0;
+  let authoritativeRecord: A | null = null;
+  for (;;) {
+    const prefixIndex = output.indexOf(prefix, searchFrom);
+    if (prefixIndex === -1) return authoritativeRecord;
+
+    const payloadStart = prefixIndex + prefix.length;
     if (prefixIndex > 0 && output[prefixIndex - 1] !== "\n") {
       searchFrom = payloadStart;
       continue;
@@ -165,15 +220,12 @@ export function parseMigrationDivergenceConsentChallenge(
     const payload = output.slice(payloadStart, lineEnd === -1 ? undefined : lineEnd).trim();
     try {
       const parsed: unknown = JSON.parse(payload);
-      if (
-        isMigrationDivergenceConsentChallenge(parsed) &&
-        parsed.consentToken === createMigrationDivergenceConsentToken(parsed)
-      ) {
+      if (isValid(parsed)) {
         // The server emits its authoritative machine record after the human
         // error text. Migration names come from the database and may contain
         // an earlier lookalike prefix, so only the final valid record is safe
         // to present to the user.
-        authoritativeChallenge = parsed;
+        authoritativeRecord = parsed;
       }
     } catch {
       // Continue to a later machine-readable line if untrusted error text
@@ -181,6 +233,39 @@ export function parseMigrationDivergenceConsentChallenge(
     }
     searchFrom = payloadStart;
   }
+}
+
+function isMigrationSchemaTooNewStartupBlock(
+  value: unknown,
+): value is MigrationSchemaTooNewStartupBlock {
+  if (typeof value !== "object" || value === null) return false;
+  const block = value as Record<string, unknown>;
+  return (
+    block.version === 1 &&
+    isNonEmptyString(block.databasePath) &&
+    isNonNegativeInteger(block.databaseMigrationId) &&
+    isNonNegativeInteger(block.latestSupportedMigrationId) &&
+    isMigrationSchemaTooNewRecovery(block.recovery)
+  );
+}
+
+function isMigrationSchemaTooNewRecovery(value: unknown): value is MigrationSchemaTooNewRecovery {
+  if (typeof value !== "object" || value === null) return false;
+  const recovery = value as Record<string, unknown>;
+  if (recovery.kind === "restore-available") {
+    return (
+      isNonEmptyString(recovery.backupPath) &&
+      isNonEmptyString(recovery.provenancePath) &&
+      isNonNegativeInteger(recovery.backupMigrationId)
+    );
+  }
+  return (
+    recovery.kind === "restore-unavailable" &&
+    (recovery.reason === "missing-provenance" ||
+      recovery.reason === "invalid-provenance" ||
+      recovery.reason === "invalid-backup" ||
+      recovery.reason === "incompatible-backup")
+  );
 }
 
 function isMigrationDivergenceConsentChallenge(


### PR DESCRIPTION
Closes #814

## Summary

- emit a structured schema-too-new startup block before desktop crash supervision can retry the same deterministic failure
- bind recovery to the exact completed #813 provenance record and expose restore only when that backup passes path, SQLite integrity, schema, and lineage checks
- keep backend and provider startup gated through restore verification and relaunch, with update, logs, and quit as fail-closed alternatives
- extend the restore CLI to consume completed provenance and revalidate the copied backup before swapping the live database

## Stack

- base PR: #834
- base branch: `codex/issue-813-migration-consent`
- parent head: `b0e47acd9d0c14813fdb07245665ffd5b53720d0`

## Verification

- `bun run --cwd packages/shared test -- src/migrationRecovery.test.ts` (11 passed)
- `bun run --cwd apps/server test -- src/persistence/MigrationSchemaTooNewRecovery.test.ts src/persistence/MigrationBackup.test.ts src/persistence/Migrations.test.ts` (50 passed)
- `bun run --cwd apps/desktop test -- src/backendStartupBlock.test.ts src/desktopMigrationRecovery.test.ts src/backendSupervisionPolicy.test.ts` (46 passed)
- `bun run --cwd apps/server build`
- `bun run --cwd apps/desktop build`
- targeted `oxfmt --check`
- `git diff --check`

Per task constraints, I did not run `bun fmt`, `bun lint`, or `bun typecheck` locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes SQLite migration restore semantics, backup validation, and desktop startup gating on local database state; mistakes could block users or restore the wrong backup.
> 
> **Overview**
> Adds an end-to-end **schema-too-new** path when a database’s migration version exceeds what the running build supports, so desktop crash supervision does not keep retrying a deterministic failure.
> 
> The server now catches `MigrationSchemaTooNewError` during SQLite startup and fails with a **structured startup block** (`SYNARA_MIGRATION_SCHEMA_TOO_NEW=…`) that includes whether a **provenance-bound** pre-migration backup can be restored. Restore selection is tightened: completed provenance must match, backups get SQLite integrity and lineage checks, the restore CLI accepts explicit `--backup-path` / `--provenance-path`, and failed live DB swaps can roll back markers cleanly.
> 
> On desktop, `BackendStartupBlockDetector` parses that block (with size/malformed **fail-closed** handling), shows recovery UI (restore when verified, else update/download/logs/quit), keeps the backend stopped until recovery finishes, and only relaunches after **completed-provenance** verification—not just marker clearance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a6f66c952b0f5af92cff7b3123b28bdbf85e8fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->