### PR TITLE
feat: surface consequential provider context changes

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -9127,6 +9127,11 @@ describe("ProviderCommandReactor", () => {
     });
     await waitFor(() => harness.sendTurn.mock.calls.length === 1);
     await Effect.runPromise(harness.clearSessionResumeCursor({ threadId }));
+    const firstBootstrapTurnId = asTurnId("opencode-completion-failure-first-turn");
+    const retryBootstrapTurnId = asTurnId("opencode-completion-failure-retry-turn");
+    harness.sendTurn
+      .mockImplementationOnce(() => Effect.succeed({ threadId, turnId: firstBootstrapTurnId }))
+      .mockImplementationOnce(() => Effect.succeed({ threadId, turnId: retryBootstrapTurnId }));
 
     await dispatchHarnessUserTurn(harness, {
       messageId: "opencode-completion-failure-first",
@@ -9146,6 +9151,7 @@ describe("ProviderCommandReactor", () => {
       eventId: "opencode-completion-failure-terminal",
       provider: "opencode",
       type: "completed",
+      turnId: firstBootstrapTurnId,
     });
     await waitFor(() => harness.completePriorTranscriptBootstrap.mock.calls.length === 1);
 
@@ -9163,6 +9169,7 @@ describe("ProviderCommandReactor", () => {
       eventId: "opencode-completion-retry-terminal",
       provider: "opencode",
       type: "completed",
+      turnId: retryBootstrapTurnId,
     });
     await waitFor(() => harness.completePriorTranscriptBootstrap.mock.calls.length === 2);
     expect(harness.pendingPriorTranscriptBootstraps.has(threadId)).toBe(false);

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -276,10 +276,10 @@ describe("ProviderCommandReactor", () => {
     >((threadId, sessionInput, outcomeOptions) => {
       const effectiveResumeCursor =
         sessionInput.resumeCursor ?? persistedResumeCursors.get(threadId);
+      const nativeResumeAttempted =
+        effectiveResumeCursor !== undefined && effectiveResumeCursor !== null;
       const nativeResumeSucceeded =
-        effectiveResumeCursor !== undefined &&
-        effectiveResumeCursor !== null &&
-        (input?.confirmNativeResume?.(effectiveResumeCursor) ?? true);
+        nativeResumeAttempted && (input?.confirmNativeResume?.(effectiveResumeCursor) ?? true);
       if (
         outcomeOptions?.registerPriorTranscriptBootstrapOnFreshStart === true &&
         !nativeResumeSucceeded
@@ -300,6 +300,7 @@ describe("ProviderCommandReactor", () => {
           persistedResumeCursors.set(threadId, resolvedSession.resumeCursor);
           return {
             session: resolvedSession,
+            nativeResumeAttempted,
             nativeResumeSucceeded,
             priorTranscriptBootstrapPending: pendingPriorTranscriptBootstraps.has(threadId),
           };
@@ -3826,6 +3827,150 @@ describe("ProviderCommandReactor", () => {
     expect(resent?.input).toContain("edited prompt");
     expect(resent?.input).not.toContain("old prompt");
   });
+
+  it.each(["opencode", "kilo"] as const)(
+    "keeps the %s edit recap pending until the replay turn completes",
+    async (provider) => {
+      const harness = await createHarness({
+        threadModelSelection: { provider, model: "openai/gpt-5" },
+        conversationRollback: "restart-session",
+      });
+      const threadId = ThreadId.makeUnsafe("thread-1");
+      const rejectedTurnId = asTurnId(`${provider}-edit-replay-rejected`);
+      const retryTurnId = asTurnId(`${provider}-edit-replay-retry`);
+      const now = new Date().toISOString();
+
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.messages.import",
+          commandId: CommandId.makeUnsafe(`cmd-import-${provider}-edit-context`),
+          threadId,
+          messages: [
+            {
+              messageId: asMessageId(`${provider}-edit-earlier-user`),
+              role: "user",
+              text: "Earlier question",
+              createdAt: now,
+              updatedAt: now,
+            },
+            {
+              messageId: asMessageId(`${provider}-edit-earlier-assistant`),
+              role: "assistant",
+              text: "Earlier answer",
+              createdAt: now,
+              updatedAt: now,
+            },
+          ],
+          createdAt: now,
+        }),
+      );
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-edit-target`,
+        text: "old prompt",
+        createdAt: now,
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+      harness.sendTurn.mockClear();
+      harness.sendTurn
+        .mockImplementationOnce(() => Effect.succeed({ threadId, turnId: rejectedTurnId }))
+        .mockImplementationOnce(() => Effect.succeed({ threadId, turnId: retryTurnId }));
+      harness.setRuntimeSessionTurnState({
+        threadId,
+        status: "running",
+        activeTurnId: asTurnId(`${provider}-edit-active`),
+      });
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.session.set",
+          commandId: CommandId.makeUnsafe(`cmd-${provider}-edit-session-running`),
+          threadId,
+          session: {
+            threadId,
+            status: "running",
+            providerName: provider,
+            runtimeMode: "approval-required",
+            activeTurnId: asTurnId(`${provider}-edit-active`),
+            lastError: null,
+            updatedAt: now,
+          },
+          createdAt: now,
+        }),
+      );
+
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.message.edit-and-resend",
+          commandId: CommandId.makeUnsafe(`cmd-${provider}-edit-and-resend`),
+          threadId,
+          messageId: asMessageId(`${provider}-edit-target`),
+          text: "edited prompt",
+          runtimeMode: "approval-required",
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          createdAt: now,
+        }),
+      );
+      await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+      const rejectedInput = harness.sendTurn.mock.calls[0]?.[0] as { readonly input?: string };
+      expect(rejectedInput.input).toContain("<thread_context>");
+      expect(rejectedInput.input).toContain("Earlier answer");
+      expect(rejectedInput.input).toContain("edited prompt");
+      expect(
+        (await readHarnessThread(harness))?.activities.filter(
+          (activity) => activity.kind === "provider.context.changed",
+        ),
+      ).toEqual([]);
+
+      await emitHarnessTurnTerminal(harness, {
+        eventId: `${provider}-edit-replay-aborted`,
+        provider,
+        type: "aborted",
+        turnId: rejectedTurnId,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(
+        (await readHarnessThread(harness))?.activities.filter(
+          (activity) => activity.kind === "provider.context.changed",
+        ),
+      ).toEqual([]);
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: `${provider}-edit-replay-retry-message`,
+        text: "Retry the edited request.",
+        createdAt: now,
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+      const retryInput = harness.sendTurn.mock.calls[1]?.[0] as { readonly input?: string };
+      expect(retryInput.input).toContain("<thread_context>");
+      expect(retryInput.input).toContain("edited prompt");
+
+      await emitHarnessTurnTerminal(harness, {
+        eventId: `${provider}-edit-replay-completed`,
+        provider,
+        type: "completed",
+        turnId: retryTurnId,
+      });
+      await waitFor(async () => {
+        const lifecycleActivities = (await readHarnessThread(harness))?.activities.filter(
+          (activity) => activity.kind === "provider.context.changed",
+        );
+        return lifecycleActivities?.length === 1;
+      });
+      const [lifecycleActivity] = (await readHarnessThread(harness))?.activities.filter(
+        (activity) => activity.kind === "provider.context.changed",
+      ) ?? [undefined];
+      expect(lifecycleActivity).toMatchObject({
+        turnId: retryTurnId,
+        payload: {
+          provider,
+          nativeHistory: "unavailable",
+          sessionRestarted: false,
+          restartReason: "conversation-rebuilt",
+          recapInjected: true,
+        },
+      });
+    },
+  );
 
   it("keeps queued-message edits queued while an active provider turn continues", async () => {
     const harness = await createHarness();
@@ -8460,6 +8605,11 @@ describe("ProviderCommandReactor", () => {
       await new Promise((resolve) => setTimeout(resolve, 20));
       expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
       expect(harness.pendingPriorTranscriptBootstraps.has(threadId)).toBe(true);
+      expect(
+        (await readHarnessThread(harness))?.activities.filter(
+          (activity) => activity.kind === "provider.context.changed",
+        ),
+      ).toEqual([]);
 
       await dispatchHarnessUserTurn(harness, {
         messageId: `${provider}-async-bootstrap-retry-turn`,
@@ -8483,6 +8633,25 @@ describe("ProviderCommandReactor", () => {
       });
       await waitFor(() => harness.completePriorTranscriptBootstrap.mock.calls.length === 1);
       expect(harness.pendingPriorTranscriptBootstraps.has(threadId)).toBe(false);
+      await waitFor(async () => {
+        const lifecycleActivities = (await readHarnessThread(harness))?.activities.filter(
+          (activity) => activity.kind === "provider.context.changed",
+        );
+        return lifecycleActivities?.length === 1;
+      });
+      const [lifecycleActivity] = (await readHarnessThread(harness))?.activities.filter(
+        (activity) => activity.kind === "provider.context.changed",
+      ) ?? [undefined];
+      expect(lifecycleActivity).toMatchObject({
+        turnId: retryTurnId,
+        payload: {
+          provider,
+          nativeHistory: "unavailable",
+          sessionRestarted: false,
+          restartReason: "fresh-session",
+          recapInjected: true,
+        },
+      });
     },
   );
 
@@ -8590,6 +8759,12 @@ describe("ProviderCommandReactor", () => {
       expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
       const resumedInput = harness.sendTurn.mock.calls[1]?.[0] as { readonly input?: string };
       expect(resumedInput.input).toBe("What did we call the module?");
+      const resumedThread = await readHarnessThread(harness);
+      expect(
+        resumedThread?.activities.filter(
+          (activity) => activity.kind === "provider.context.changed",
+        ),
+      ).toEqual([]);
     },
   );
 
@@ -8670,12 +8845,29 @@ describe("ProviderCommandReactor", () => {
       expect(followUpInput.input).toContain("The retained codename is heliotrope.");
       expect(followUpInput.input?.match(/What is the retained codename\?/g)).toHaveLength(1);
       expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
+      expect(
+        (await readHarnessThread(harness))?.activities.filter(
+          (activity) => activity.kind === "provider.context.changed",
+        ),
+      ).toEqual([]);
       await emitHarnessTurnTerminal(harness, {
         eventId: `${provider}-rejected-resume-bootstrap-completed`,
         provider,
         type: "completed",
       });
       await waitFor(() => harness.completePriorTranscriptBootstrap.mock.calls.length === 1);
+      const [lifecycleActivity] = (await readHarnessThread(harness))?.activities.filter(
+        (activity) => activity.kind === "provider.context.changed",
+      ) ?? [undefined];
+      expect(lifecycleActivity).toMatchObject({
+        payload: {
+          provider,
+          nativeHistory: "unavailable",
+          sessionRestarted: true,
+          restartReason: "native-resume-failed",
+          recapInjected: true,
+        },
+      });
     },
   );
 
@@ -8686,10 +8878,30 @@ describe("ProviderCommandReactor", () => {
         threadModelSelection: { provider, model: "openai/gpt-5" },
       });
       const now = new Date().toISOString();
+      const coldHistory = `The deployment color is violet. ${"Retained detail. ".repeat(80)}`;
+      let lifecycleDispatchAttempts = 0;
+      let allowLifecycleDispatch = false;
+      harness.interceptEngineDispatch((command) => {
+        if (
+          command.type !== "thread.activity.append" ||
+          command.activity.kind !== "provider.context.changed"
+        ) {
+          return undefined;
+        }
+        lifecycleDispatchAttempts += 1;
+        return allowLifecycleDispatch
+          ? undefined
+          : Effect.fail(
+              new OrchestrationCommandInvariantError({
+                commandType: command.type,
+                detail: "Injected transient accepted-bootstrap lifecycle failure.",
+              }),
+            );
+      });
 
       await dispatchHarnessUserTurn(harness, {
         messageId: `${provider}-cold-seed`,
-        text: "The deployment color is violet.",
+        text: coldHistory,
         createdAt: now,
       });
       await waitFor(() => harness.sendTurn.mock.calls.length === 1);
@@ -8710,21 +8922,71 @@ describe("ProviderCommandReactor", () => {
         1,
       );
       expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
-      await emitHarnessTurnTerminal(harness, {
-        eventId: `${provider}-cold-bootstrap-completed`,
-        provider,
-        type: "completed",
+      expect(
+        (await readHarnessThread(harness))?.activities.filter(
+          (activity) => activity.kind === "provider.context.changed",
+        ),
+      ).toEqual([]);
+      harness.setRuntimeSessionTurnState({
+        threadId: "thread-1",
+        status: "running",
+        activeTurnId: asTurnId("turn-1"),
       });
-      await waitFor(() => harness.completePriorTranscriptBootstrap.mock.calls.length === 1);
-
       await dispatchHarnessUserTurn(harness, {
         messageId: `${provider}-cold-next`,
         text: "Continue with that choice.",
         createdAt: now,
       });
+      await harness.drain();
+      expect(harness.sendTurn).toHaveBeenCalledTimes(2);
+      harness.setRuntimeSessionTurnState({ threadId: "thread-1", status: "ready" });
+      await emitHarnessTurnTerminal(harness, {
+        eventId: `${provider}-cold-bootstrap-completed`,
+        provider,
+        type: "completed",
+      });
+      await waitFor(() => lifecycleDispatchAttempts >= 2);
+      expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
+      allowLifecycleDispatch = true;
+      await waitFor(() => harness.completePriorTranscriptBootstrap.mock.calls.length === 1);
+      await waitFor(async () => {
+        const lifecycleActivities = (await readHarnessThread(harness))?.activities.filter(
+          (activity) => activity.kind === "provider.context.changed",
+        );
+        return lifecycleActivities?.length === 1;
+      });
+      expect(lifecycleDispatchAttempts).toBe(3);
+      const [lifecycleActivity] = (await readHarnessThread(harness))?.activities.filter(
+        (activity) => activity.kind === "provider.context.changed",
+      ) ?? [undefined];
+      expect(lifecycleActivity).toMatchObject({
+        tone: "error",
+        summary: "Native session history was unavailable, so the model continued from a recap.",
+        turnId: asTurnId("turn-1"),
+        payload: {
+          provider,
+          nativeHistory: "unavailable",
+          sessionRestarted: true,
+          restartReason: "fresh-session",
+          recapInjected: true,
+          recapPreviewTruncated: true,
+        },
+      });
+      const lifecyclePayload = lifecycleActivity?.payload as
+        | { recapCharacters?: number; recapPreview?: string }
+        | undefined;
+      expect(lifecyclePayload?.recapCharacters).toBeGreaterThan(600);
+      expect(lifecyclePayload?.recapPreview?.length).toBeLessThanOrEqual(600);
+      expect(lifecyclePayload?.recapPreview).toContain("Retained detail.");
+
       await waitFor(() => harness.sendTurn.mock.calls.length === 3);
       const nextInput = harness.sendTurn.mock.calls[2]?.[0] as { readonly input?: string };
       expect(nextInput.input).toBe("Continue with that choice.");
+      expect(
+        (await readHarnessThread(harness))?.activities.filter(
+          (activity) => activity.kind === "provider.context.changed",
+        ),
+      ).toHaveLength(1);
     },
   );
 
@@ -8773,12 +9035,37 @@ describe("ProviderCommandReactor", () => {
       expect(retryInput.input).toContain("Keep the release channel on delta.");
       expect(retryInput.input?.match(/Which release channel should we use\?/g)).toHaveLength(1);
       expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
+      expect(
+        (await readHarnessThread(harness))?.activities.filter(
+          (activity) => activity.kind === "provider.context.changed",
+        ),
+      ).toEqual([]);
       await emitHarnessTurnTerminal(harness, {
         eventId: `${provider}-stale-resume-bootstrap-completed`,
         provider,
         type: "completed",
       });
       await waitFor(() => harness.completePriorTranscriptBootstrap.mock.calls.length === 1);
+      await waitFor(async () => {
+        const lifecycleActivities = (await readHarnessThread(harness))?.activities.filter(
+          (activity) => activity.kind === "provider.context.changed",
+        );
+        return lifecycleActivities?.length === 1;
+      });
+      const [lifecycleActivity] = (await readHarnessThread(harness))?.activities.filter(
+        (activity) => activity.kind === "provider.context.changed",
+      ) ?? [undefined];
+      expect(lifecycleActivity).toMatchObject({
+        tone: "error",
+        turnId: asTurnId("turn-1"),
+        payload: {
+          provider,
+          nativeHistory: "unavailable",
+          sessionRestarted: true,
+          restartReason: "native-resume-failed",
+          recapInjected: true,
+        },
+      });
     },
   );
 
@@ -8921,6 +9208,75 @@ describe("ProviderCommandReactor", () => {
       expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
     },
   );
+
+  it("records a consequential cold start when no recap is available for the provider", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+    let lifecycleDispatchAttempts = 0;
+    harness.interceptEngineDispatch((command) => {
+      if (
+        command.type !== "thread.activity.append" ||
+        command.activity.kind !== "provider.context.changed"
+      ) {
+        return undefined;
+      }
+      lifecycleDispatchAttempts += 1;
+      return lifecycleDispatchAttempts === 1
+        ? Effect.fail(
+            new OrchestrationCommandInvariantError({
+              commandType: command.type,
+              detail: "Injected transient lifecycle activity failure.",
+            }),
+          )
+        : undefined;
+    });
+
+    await dispatchHarnessUserTurn(harness, {
+      messageId: "codex-context-seed",
+      text: "Keep the migration order stable.",
+      createdAt: now,
+    });
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    await Effect.runPromise(
+      harness.clearSessionResumeCursor({ threadId: ThreadId.makeUnsafe("thread-1") }),
+    );
+
+    await dispatchHarnessUserTurn(harness, {
+      messageId: "codex-context-cold-start",
+      text: "What should stay stable?",
+      createdAt: now,
+    });
+    await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+    const coldStartInput = harness.sendTurn.mock.calls[1]?.[0] as { readonly input?: string };
+    expect(coldStartInput.input).toBe("What should stay stable?");
+
+    await waitFor(async () => {
+      const lifecycleActivities = (await readHarnessThread(harness))?.activities.filter(
+        (activity) => activity.kind === "provider.context.changed",
+      );
+      return lifecycleActivities?.length === 1;
+    });
+    expect(lifecycleDispatchAttempts).toBe(2);
+
+    const [lifecycleActivity] = (await readHarnessThread(harness))?.activities.filter(
+      (activity) => activity.kind === "provider.context.changed",
+    ) ?? [undefined];
+    expect(lifecycleActivity).toMatchObject({
+      tone: "error",
+      summary: "The session restarted without its native history.",
+      turnId: asTurnId("turn-1"),
+      payload: {
+        provider: "codex",
+        nativeHistory: "unavailable",
+        sessionRestarted: true,
+        restartReason: "native-history-unavailable",
+        recapInjected: false,
+        recapCharacters: 0,
+        recapPreview: null,
+        recapPreviewTruncated: false,
+      },
+    });
+  });
 
   it("starts a fresh session when only projected session state exists", async () => {
     const harness = await createHarness();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -831,9 +831,16 @@ const make = Effect.gen(function* () {
   });
   const retainAndAppendProviderContextLifecycleActivity = Effect.fnUntraced(function* (
     input: ProviderContextLifecycleActivityRecord,
+    options: { readonly retryExisting?: boolean } = {},
   ) {
     const activityKey = providerContextLifecycleActivityKey(input);
-    pendingProviderContextLifecycleActivities.set(activityKey, input);
+    if (options.retryExisting === true) {
+      if (pendingProviderContextLifecycleActivities.get(activityKey) !== input) {
+        return "discarded" as const;
+      }
+    } else {
+      pendingProviderContextLifecycleActivities.set(activityKey, input);
+    }
     const activityAppended = yield* appendProviderContextLifecycleActivity(input).pipe(
       Effect.as(true),
       Effect.catchCause((cause) =>
@@ -852,6 +859,11 @@ const make = Effect.gen(function* () {
               .pipe(Effect.as(false)),
       ),
     );
+    // Thread deletion clears retained activity records. Do not let an
+    // in-flight initial append or retry resurrect work after that cleanup.
+    if (pendingProviderContextLifecycleActivities.get(activityKey) !== input) {
+      return "discarded" as const;
+    }
     if (!activityAppended) {
       return "activity-pending" as const;
     }
@@ -899,7 +911,9 @@ const make = Effect.gen(function* () {
             // idempotent activity append succeeds, the same attempt may safely
             // retire the durable marker. A marker failure itself is not queued:
             // that keeps the recap pending for the next accepted turn.
-            const persistence = yield* retainAndAppendProviderContextLifecycleActivity(pending);
+            const persistence = yield* retainAndAppendProviderContextLifecycleActivity(pending, {
+              retryExisting: true,
+            });
             if (persistence === "completed") {
               const attempt = pendingContextBootstrapAttempts.get(pending.threadId);
               if (attempt?.turnId === pending.turnId) {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -834,39 +834,54 @@ const make = Effect.gen(function* () {
   ) {
     const activityKey = providerContextLifecycleActivityKey(input);
     pendingProviderContextLifecycleActivities.set(activityKey, input);
-    yield* Effect.gen(function* () {
-      yield* appendProviderContextLifecycleActivity(input);
-      if (
-        input.completeDurablePriorTranscript &&
-        providerService.completePriorTranscriptBootstrap
-      ) {
-        // The durable bootstrap marker is the process-restart recovery path
-        // for this evidence. Retire it only after the idempotent activity has
-        // committed; if either write fails, retry both in order.
-        yield* providerService.completePriorTranscriptBootstrap({ threadId: input.threadId });
-      }
-    }).pipe(
-      Effect.tap(() =>
-        Effect.sync(() => {
-          if (pendingProviderContextLifecycleActivities.get(activityKey) === input) {
-            pendingProviderContextLifecycleActivities.delete(activityKey);
-          }
-        }),
-      ),
+    const activityAppended = yield* appendProviderContextLifecycleActivity(input).pipe(
+      Effect.as(true),
       Effect.catchCause((cause) =>
         Cause.hasInterruptsOnly(cause)
           ? Effect.failCause(cause)
-          : scheduleProviderContextLifecycleActivityRetry(activityKey).pipe(
-              Effect.andThen(
-                Effect.logWarning("queued provider context lifecycle activity for retry", {
-                  threadId: input.threadId,
-                  turnId: input.turnId,
-                  cause: Cause.pretty(cause),
-                }),
-              ),
-            ),
+          : scheduleProviderContextLifecycleActivityRetry(activityKey)
+              .pipe(
+                Effect.andThen(
+                  Effect.logWarning("queued provider context lifecycle activity for retry", {
+                    threadId: input.threadId,
+                    turnId: input.turnId,
+                    cause: Cause.pretty(cause),
+                  }),
+                ),
+              )
+              .pipe(Effect.as(false)),
       ),
     );
+    if (!activityAppended) {
+      return "activity-pending" as const;
+    }
+    if (pendingProviderContextLifecycleActivities.get(activityKey) === input) {
+      pendingProviderContextLifecycleActivities.delete(activityKey);
+    }
+    if (input.completeDurablePriorTranscript && providerService.completePriorTranscriptBootstrap) {
+      // The durable bootstrap marker is the process-restart recovery path for
+      // this evidence. Retire it only after the idempotent activity committed.
+      // A failed marker write deliberately keeps the recap pending for the next
+      // accepted turn instead of completing it later without another delivery.
+      return yield* providerService
+        .completePriorTranscriptBootstrap({ threadId: input.threadId })
+        .pipe(
+          Effect.as("completed" as const),
+          Effect.catchCause((cause) =>
+            Cause.hasInterruptsOnly(cause)
+              ? Effect.failCause(cause)
+              : Effect.logWarning(
+                  "provider context lifecycle activity could not retire transcript bootstrap",
+                  {
+                    threadId: input.threadId,
+                    turnId: input.turnId,
+                    cause: Cause.pretty(cause),
+                  },
+                ).pipe(Effect.as("durable-pending" as const)),
+          ),
+        );
+    }
+    return "completed" as const;
   });
   const runProviderContextLifecycleActivityRetries = Stream.fromQueue(
     providerContextLifecycleActivityRetryQueue,
@@ -880,7 +895,22 @@ const make = Effect.gen(function* () {
             if (!pending) {
               return;
             }
-            yield* retainAndAppendProviderContextLifecycleActivity(pending);
+            // The provider already accepted this recap turn. Once its
+            // idempotent activity append succeeds, the same attempt may safely
+            // retire the durable marker. A marker failure itself is not queued:
+            // that keeps the recap pending for the next accepted turn.
+            const persistence = yield* retainAndAppendProviderContextLifecycleActivity(pending);
+            if (persistence === "completed") {
+              const attempt = pendingContextBootstrapAttempts.get(pending.threadId);
+              if (attempt?.turnId === pending.turnId) {
+                retirePendingContextBootstrapAttempt(pending.threadId, attempt);
+              }
+            } else if (persistence === "durable-pending") {
+              const attempt = pendingContextBootstrapAttempts.get(pending.threadId);
+              if (attempt?.turnId === pending.turnId) {
+                pendingContextBootstrapAttempts.delete(pending.threadId);
+              }
+            }
           }),
         ),
       ),
@@ -905,6 +935,32 @@ const make = Effect.gen(function* () {
     sidechatContextBootstrapThreadIds.delete(threadId);
     freshSessionContextBootstrapThreadIds.delete(threadId);
     rollbackContextBootstrapThreadIds.delete(threadId);
+    pendingContextBootstrapAttempts.delete(threadId);
+  };
+
+  const clearPendingContextBootstrapAttemptFlags = (
+    threadId: string,
+    attempt: PendingContextBootstrapAttempt,
+  ) => {
+    if (attempt.clearSidechat) {
+      sidechatContextBootstrapThreadIds.delete(threadId);
+    }
+    if (attempt.clearFreshSessionTranscript) {
+      freshSessionContextBootstrapThreadIds.delete(threadId);
+    }
+    if (attempt.clearRollbackTranscript) {
+      rollbackContextBootstrapThreadIds.delete(threadId);
+    }
+  };
+
+  const retirePendingContextBootstrapAttempt = (
+    threadId: string,
+    attempt: PendingContextBootstrapAttempt,
+  ) => {
+    if (pendingContextBootstrapAttempts.get(threadId) !== attempt) {
+      return;
+    }
+    clearPendingContextBootstrapAttemptFlags(threadId, attempt);
     pendingContextBootstrapAttempts.delete(threadId);
   };
 
@@ -944,7 +1000,7 @@ const make = Effect.gen(function* () {
     let lifecyclePersistenceOwnsDurableBootstrap = false;
     if (attempt.lifecycleEvidence !== null && attempt.turnId !== undefined) {
       lifecyclePersistenceOwnsDurableBootstrap = true;
-      yield* retainAndAppendProviderContextLifecycleActivity(
+      const lifecyclePersistence = yield* retainAndAppendProviderContextLifecycleActivity(
         toProviderContextLifecycleActivityRecord({
           threadId,
           turnId: attempt.turnId,
@@ -954,6 +1010,16 @@ const make = Effect.gen(function* () {
           completeDurablePriorTranscript: attempt.completeDurablePriorTranscript,
         }),
       );
+      if (lifecyclePersistence === "activity-pending") {
+        // The accepted provider turn already received this recap, so current
+        // in-memory state can advance while the durable marker remains as the
+        // crash-recovery source until the idempotent activity retry succeeds.
+        clearPendingContextBootstrapAttemptFlags(threadId, attempt);
+        return;
+      }
+      if (lifecyclePersistence === "durable-pending") {
+        return;
+      }
     }
     if (pendingContextBootstrapAttempts.get(threadId) !== attempt) {
       return;
@@ -971,15 +1037,7 @@ const make = Effect.gen(function* () {
     if (pendingContextBootstrapAttempts.get(threadId) !== attempt) {
       return;
     }
-    if (attempt.clearSidechat) {
-      sidechatContextBootstrapThreadIds.delete(threadId);
-    }
-    if (attempt.clearFreshSessionTranscript) {
-      freshSessionContextBootstrapThreadIds.delete(threadId);
-    }
-    if (attempt.clearRollbackTranscript) {
-      rollbackContextBootstrapThreadIds.delete(threadId);
-    }
+    retirePendingContextBootstrapAttempt(threadId, attempt);
   });
 
   const observePendingContextBootstrapTerminalEvent = Effect.fnUntraced(function* (
@@ -996,10 +1054,13 @@ const make = Effect.gen(function* () {
     if (attempt.turnId !== event.turnId) {
       return;
     }
-    yield* completePendingContextBootstrapAttempt(event.threadId, attempt, event);
-    if (pendingContextBootstrapAttempts.get(event.threadId) === attempt) {
-      pendingContextBootstrapAttempts.delete(event.threadId);
+    if (event.type !== "turn.completed" || event.payload.state !== "completed") {
+      if (pendingContextBootstrapAttempts.get(event.threadId) === attempt) {
+        pendingContextBootstrapAttempts.delete(event.threadId);
+      }
+      return;
     }
+    yield* completePendingContextBootstrapAttempt(event.threadId, attempt, event);
   });
 
   const resolveConfiguredTextGenerationInput = Effect.fnUntraced(function* () {
@@ -2387,15 +2448,17 @@ const make = Effect.gen(function* () {
         pendingContextBootstrapAttempt.turnId = sentTurn.turnId;
         const terminalEvent = pendingContextBootstrapAttempt.terminalEvent;
         if (terminalEvent?.turnId === sentTurn.turnId) {
-          yield* completePendingContextBootstrapAttempt(
-            input.threadId,
-            pendingContextBootstrapAttempt,
-            terminalEvent,
-          );
           if (
-            pendingContextBootstrapAttempts.get(input.threadId) === pendingContextBootstrapAttempt
+            terminalEvent.type !== "turn.completed" ||
+            terminalEvent.payload.state !== "completed"
           ) {
             pendingContextBootstrapAttempts.delete(input.threadId);
+          } else {
+            yield* completePendingContextBootstrapAttempt(
+              input.threadId,
+              pendingContextBootstrapAttempt,
+              terminalEvent,
+            );
           }
         }
       }

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -293,6 +293,70 @@ function attachmentTitleSeed(attachment: ChatAttachment | undefined): string {
 const serverCommandId = (tag: string): CommandId =>
   CommandId.makeUnsafe(`server:${tag}:${crypto.randomUUID()}`);
 
+const PROVIDER_CONTEXT_LIFECYCLE_ACTIVITY_KIND = "provider.context.changed";
+const SESSION_CONTEXT_RECAP_PREVIEW_MAX_CHARS = 600;
+
+type ProviderContextLifecycleReason =
+  | "conversation-rebuilt"
+  | "fresh-session"
+  | "native-history-unavailable"
+  | "native-resume-failed";
+
+interface ProviderContextLifecycleEvidence {
+  readonly nativeHistory: "available" | "unavailable";
+  readonly recapText: string | null;
+  readonly reason: ProviderContextLifecycleReason;
+  readonly sessionRestarted: boolean;
+}
+
+interface ProviderContextLifecycleActivityInput {
+  readonly threadId: ThreadId;
+  readonly turnId: TurnId;
+  readonly provider: ProviderKind;
+  readonly evidence: ProviderContextLifecycleEvidence;
+  readonly createdAt: string;
+  readonly completeDurablePriorTranscript?: boolean;
+}
+
+interface ProviderContextLifecycleActivityRecord {
+  readonly threadId: ThreadId;
+  readonly turnId: TurnId;
+  readonly provider: ProviderKind;
+  readonly nativeHistory: "available" | "unavailable";
+  readonly sessionRestarted: boolean;
+  readonly restartReason: ProviderContextLifecycleReason;
+  readonly recapInjected: boolean;
+  readonly recapCharacters: number;
+  readonly recapPreview: string | null;
+  readonly recapPreviewTruncated: boolean;
+  readonly summary: string;
+  readonly createdAt: string;
+  readonly completeDurablePriorTranscript: boolean;
+}
+
+function recapTailPreview(recapText: string): string {
+  const normalized = recapText.trim();
+  if (normalized.length <= SESSION_CONTEXT_RECAP_PREVIEW_MAX_CHARS) {
+    return normalized;
+  }
+  return `…${normalized.slice(-(SESSION_CONTEXT_RECAP_PREVIEW_MAX_CHARS - 1)).trimStart()}`;
+}
+
+function providerContextLifecycleSummary(evidence: ProviderContextLifecycleEvidence): string {
+  if (evidence.recapText !== null && evidence.nativeHistory === "unavailable") {
+    return "Native session history was unavailable, so the model continued from a recap.";
+  }
+  if (evidence.recapText !== null && evidence.sessionRestarted) {
+    return "The session restarted, so the model received a recap.";
+  }
+  if (evidence.recapText !== null) {
+    return "The model received a recap while recovering its session context.";
+  }
+  return evidence.sessionRestarted
+    ? "The session restarted without its native history."
+    : "Native session history was unavailable for this turn.";
+}
+
 const turnStartKeyForEvent = (event: ProviderIntentEvent): string =>
   event.commandId !== null ? `command:${event.commandId}` : `event:${event.eventId}`;
 
@@ -689,6 +753,140 @@ const make = Effect.gen(function* () {
   // Providers without native rewind restart after rollback and receive the
   // retained projection transcript once on their next prompt.
   const rollbackContextBootstrapThreadIds = new Set<string>();
+  // Retry state keeps only the bounded derived record; the full recap text is
+  // never retained here after the provider turn has been accepted.
+  const pendingProviderContextLifecycleActivities = new Map<
+    string,
+    ProviderContextLifecycleActivityRecord
+  >();
+  const queuedProviderContextLifecycleActivityRetries = new Set<string>();
+  const providerContextLifecycleActivityRetryQueue = yield* Queue.unbounded<string>();
+  const providerContextLifecycleActivityKey = (
+    input: Pick<ProviderContextLifecycleActivityRecord, "threadId" | "turnId">,
+  ) => `${input.threadId}:${input.turnId}`;
+  const toProviderContextLifecycleActivityRecord = (
+    input: ProviderContextLifecycleActivityInput,
+  ): ProviderContextLifecycleActivityRecord => {
+    const recapCharacters = input.evidence.recapText?.length ?? 0;
+    const recapPreview =
+      input.evidence.recapText === null ? null : recapTailPreview(input.evidence.recapText);
+    return {
+      threadId: input.threadId,
+      turnId: input.turnId,
+      provider: input.provider,
+      nativeHistory: input.evidence.nativeHistory,
+      sessionRestarted: input.evidence.sessionRestarted,
+      restartReason: input.evidence.reason,
+      recapInjected: input.evidence.recapText !== null,
+      recapCharacters,
+      recapPreview,
+      recapPreviewTruncated:
+        input.evidence.recapText !== null &&
+        input.evidence.recapText.trim().length > (recapPreview?.length ?? 0),
+      summary: providerContextLifecycleSummary(input.evidence),
+      createdAt: input.createdAt,
+      completeDurablePriorTranscript: input.completeDurablePriorTranscript ?? false,
+    };
+  };
+  const appendProviderContextLifecycleActivity = (
+    input: ProviderContextLifecycleActivityRecord,
+  ) => {
+    const activityKey = providerContextLifecycleActivityKey(input);
+    return orchestrationEngine.dispatch({
+      type: "thread.activity.append",
+      commandId: CommandId.makeUnsafe(`server:provider-context-lifecycle:${activityKey}`),
+      threadId: input.threadId,
+      activity: {
+        id: EventId.makeUnsafe(`provider-context-lifecycle:${activityKey}`),
+        tone: input.nativeHistory === "unavailable" ? "error" : "info",
+        kind: PROVIDER_CONTEXT_LIFECYCLE_ACTIVITY_KIND,
+        summary: input.summary,
+        payload: {
+          provider: input.provider,
+          nativeHistory: input.nativeHistory,
+          sessionRestarted: input.sessionRestarted,
+          restartReason: input.restartReason,
+          recapInjected: input.recapInjected,
+          recapCharacters: input.recapCharacters,
+          recapPreview: input.recapPreview,
+          recapPreviewTruncated: input.recapPreviewTruncated,
+        },
+        turnId: input.turnId,
+        createdAt: input.createdAt,
+      },
+      createdAt: input.createdAt,
+    });
+  };
+  const scheduleProviderContextLifecycleActivityRetry = Effect.fnUntraced(function* (
+    activityKey: string,
+  ) {
+    if (
+      !pendingProviderContextLifecycleActivities.has(activityKey) ||
+      queuedProviderContextLifecycleActivityRetries.has(activityKey)
+    ) {
+      return;
+    }
+    queuedProviderContextLifecycleActivityRetries.add(activityKey);
+    yield* Queue.offer(providerContextLifecycleActivityRetryQueue, activityKey);
+  });
+  const retainAndAppendProviderContextLifecycleActivity = Effect.fnUntraced(function* (
+    input: ProviderContextLifecycleActivityRecord,
+  ) {
+    const activityKey = providerContextLifecycleActivityKey(input);
+    pendingProviderContextLifecycleActivities.set(activityKey, input);
+    yield* Effect.gen(function* () {
+      yield* appendProviderContextLifecycleActivity(input);
+      if (
+        input.completeDurablePriorTranscript &&
+        providerService.completePriorTranscriptBootstrap
+      ) {
+        // The durable bootstrap marker is the process-restart recovery path
+        // for this evidence. Retire it only after the idempotent activity has
+        // committed; if either write fails, retry both in order.
+        yield* providerService.completePriorTranscriptBootstrap({ threadId: input.threadId });
+      }
+    }).pipe(
+      Effect.tap(() =>
+        Effect.sync(() => {
+          if (pendingProviderContextLifecycleActivities.get(activityKey) === input) {
+            pendingProviderContextLifecycleActivities.delete(activityKey);
+          }
+        }),
+      ),
+      Effect.catchCause((cause) =>
+        Cause.hasInterruptsOnly(cause)
+          ? Effect.failCause(cause)
+          : scheduleProviderContextLifecycleActivityRetry(activityKey).pipe(
+              Effect.andThen(
+                Effect.logWarning("queued provider context lifecycle activity for retry", {
+                  threadId: input.threadId,
+                  turnId: input.turnId,
+                  cause: Cause.pretty(cause),
+                }),
+              ),
+            ),
+      ),
+    );
+  });
+  const runProviderContextLifecycleActivityRetries = Stream.fromQueue(
+    providerContextLifecycleActivityRetryQueue,
+  ).pipe(
+    Stream.runForEach((activityKey) =>
+      Effect.sleep(Duration.millis(250)).pipe(
+        Effect.andThen(
+          Effect.gen(function* () {
+            queuedProviderContextLifecycleActivityRetries.delete(activityKey);
+            const pending = pendingProviderContextLifecycleActivities.get(activityKey);
+            if (!pending) {
+              return;
+            }
+            yield* retainAndAppendProviderContextLifecycleActivity(pending);
+          }),
+        ),
+      ),
+    ),
+  );
+
   type PendingContextBootstrapAttempt = {
     turnId?: TurnId;
     terminalEvent?: ProviderQueueDrainEvent;
@@ -696,6 +894,8 @@ const make = Effect.gen(function* () {
     readonly clearFreshSessionTranscript: boolean;
     readonly clearRollbackTranscript: boolean;
     readonly completeDurablePriorTranscript: boolean;
+    readonly lifecycleEvidence: ProviderContextLifecycleEvidence | null;
+    readonly lifecycleEvidenceCreatedAt: string;
   };
   const pendingContextBootstrapAttempts = new Map<string, PendingContextBootstrapAttempt>();
   // Explicit stop resets context once: the next successful session start must
@@ -738,14 +938,38 @@ const make = Effect.gen(function* () {
     if (event.type !== "turn.completed" || event.payload.state !== "completed") {
       return;
     }
+    // Retain the bounded, idempotent evidence before retiring bootstrap state.
+    // Persistence retries independently so a marker write cannot block queue
+    // draining after the provider has already accepted this turn.
+    let lifecyclePersistenceOwnsDurableBootstrap = false;
+    if (attempt.lifecycleEvidence !== null && attempt.turnId !== undefined) {
+      lifecyclePersistenceOwnsDurableBootstrap = true;
+      yield* retainAndAppendProviderContextLifecycleActivity(
+        toProviderContextLifecycleActivityRecord({
+          threadId,
+          turnId: attempt.turnId,
+          provider: event.provider,
+          evidence: attempt.lifecycleEvidence,
+          createdAt: attempt.lifecycleEvidenceCreatedAt,
+          completeDurablePriorTranscript: attempt.completeDurablePriorTranscript,
+        }),
+      );
+    }
+    if (pendingContextBootstrapAttempts.get(threadId) !== attempt) {
+      return;
+    }
     if (
       attempt.completeDurablePriorTranscript &&
+      !lifecyclePersistenceOwnsDurableBootstrap &&
       providerService.completePriorTranscriptBootstrap
     ) {
       const completed = yield* persistPriorTranscriptBootstrapCompletion(threadId, event.provider);
       if (!completed) {
         return;
       }
+    }
+    if (pendingContextBootstrapAttempts.get(threadId) !== attempt) {
+      return;
     }
     if (attempt.clearSidechat) {
       sidechatContextBootstrapThreadIds.delete(threadId);
@@ -772,8 +996,10 @@ const make = Effect.gen(function* () {
     if (attempt.turnId !== event.turnId) {
       return;
     }
-    pendingContextBootstrapAttempts.delete(event.threadId);
     yield* completePendingContextBootstrapAttempt(event.threadId, attempt, event);
+    if (pendingContextBootstrapAttempts.get(event.threadId) === attempt) {
+      pendingContextBootstrapAttempts.delete(event.threadId);
+    }
   });
 
   const resolveConfiguredTextGenerationInput = Effect.fnUntraced(function* () {
@@ -1024,6 +1250,12 @@ const make = Effect.gen(function* () {
       // thread while the first is still running.
       suppressContextBootstrapOnNextStartThreadIds.delete(threadId);
       clearPendingContextBootstraps(threadId);
+      const lifecyclePrefix = `${threadId}:`;
+      for (const activityKey of pendingProviderContextLifecycleActivities.keys()) {
+        if (activityKey.startsWith(lifecyclePrefix)) {
+          pendingProviderContextLifecycleActivities.delete(activityKey);
+        }
+      }
     });
 
   const clearStaleProviderResumeState = Effect.fnUntraced(function* (input: {
@@ -1285,14 +1517,12 @@ const make = Effect.gen(function* () {
         : providerService.startSession(threadId, startInput).pipe(
             Effect.map((session) => ({
               session,
+              nativeResumeAttempted: resumeCursor !== undefined && resumeCursor !== null,
               nativeResumeSucceeded: resumeCursor !== undefined && resumeCursor !== null,
               priorTranscriptBootstrapPending: registerPriorTranscriptBootstrapOnFreshStart,
             })),
           );
     };
-
-    const startProviderSession = (resumeCursor?: unknown) =>
-      startProviderSessionWithOutcome(resumeCursor).pipe(Effect.map(({ session }) => session));
 
     const bindSessionToThread = (session: ProviderSession) =>
       setThreadSession({
@@ -1361,6 +1591,8 @@ const make = Effect.gen(function* () {
           activeSessionBeforeEnsure,
           activeSession: reusableSession,
           nativeResumeSucceeded: false,
+          nativeResumeFailed: false,
+          nativeSessionRestarted: false,
         };
       }
 
@@ -1382,7 +1614,8 @@ const make = Effect.gen(function* () {
         shouldRestartForModelSelectionChange,
         hasResumeCursor: resumeCursor !== undefined,
       });
-      const restartedSession = yield* startProviderSession(resumeCursor);
+      const restartedOutcome = yield* startProviderSessionWithOutcome(resumeCursor);
+      const restartedSession = restartedOutcome.session;
       if (
         shouldRegisterContextBootstrap &&
         currentProvider === "droid" &&
@@ -1404,7 +1637,10 @@ const make = Effect.gen(function* () {
       return {
         activeSessionBeforeEnsure,
         activeSession: restartedSession,
-        nativeResumeSucceeded: false,
+        nativeResumeSucceeded: restartedOutcome.nativeResumeSucceeded,
+        nativeResumeFailed:
+          restartedOutcome.nativeResumeAttempted && !restartedOutcome.nativeResumeSucceeded,
+        nativeSessionRestarted: true,
       };
     }
 
@@ -1443,6 +1679,8 @@ const make = Effect.gen(function* () {
           activeSessionBeforeEnsure,
           activeSession: forkedSession,
           nativeResumeSucceeded: false,
+          nativeResumeFailed: false,
+          nativeSessionRestarted: false,
         };
       }
       if (shouldRegisterContextBootstrap && !thread.sidechatSourceThreadId) {
@@ -1465,6 +1703,10 @@ const make = Effect.gen(function* () {
       undefined,
       registerPriorTranscriptBootstrapOnFreshStart,
     ).pipe(
+      Effect.map((outcome) => ({
+        ...outcome,
+        nativeResumeFailed: outcome.nativeResumeAttempted && !outcome.nativeResumeSucceeded,
+      })),
       Effect.catch((error) => {
         if (!isOpenCodeCompatibleResumeError(error)) {
           return Effect.fail(error);
@@ -1481,10 +1723,11 @@ const make = Effect.gen(function* () {
               provider: preferredProvider,
             },
           );
-          return yield* startProviderSessionWithOutcome(
+          const recoveryOutcome = yield* startProviderSessionWithOutcome(
             undefined,
             registerPriorTranscriptBootstrapOnFreshStart,
           );
+          return { ...recoveryOutcome, nativeResumeFailed: true };
         });
       }),
     );
@@ -1519,6 +1762,8 @@ const make = Effect.gen(function* () {
       activeSessionBeforeEnsure,
       activeSession: startedSession,
       nativeResumeSucceeded: startOutcome.nativeResumeSucceeded,
+      nativeResumeFailed: startOutcome.nativeResumeFailed,
+      nativeSessionRestarted: true,
     };
   });
 
@@ -1652,15 +1897,20 @@ const make = Effect.gen(function* () {
     const registerPriorTranscriptBootstrapOnFreshStart =
       (selectedProvider === "kilo" || selectedProvider === "opencode") &&
       listPriorTranscriptMessages(thread, transcriptBoundaryMessageId).length > 0;
-    const { activeSessionBeforeEnsure, activeSession, nativeResumeSucceeded } =
-      yield* ensureSessionForThread(input.threadId, input.createdAt, {
-        ...(input.modelSelection !== undefined ? { modelSelection: input.modelSelection } : {}),
-        ...(input.providerOptions !== undefined ? { providerOptions: input.providerOptions } : {}),
-        ...(input.runtimeMode !== undefined ? { runtimeMode: input.runtimeMode } : {}),
-        ...(registerPriorTranscriptBootstrapOnFreshStart
-          ? { registerPriorTranscriptBootstrapOnFreshStart: true }
-          : {}),
-      });
+    const {
+      activeSessionBeforeEnsure,
+      activeSession,
+      nativeResumeSucceeded,
+      nativeResumeFailed,
+      nativeSessionRestarted,
+    } = yield* ensureSessionForThread(input.threadId, input.createdAt, {
+      ...(input.modelSelection !== undefined ? { modelSelection: input.modelSelection } : {}),
+      ...(input.providerOptions !== undefined ? { providerOptions: input.providerOptions } : {}),
+      ...(input.runtimeMode !== undefined ? { runtimeMode: input.runtimeMode } : {}),
+      ...(registerPriorTranscriptBootstrapOnFreshStart
+        ? { registerPriorTranscriptBootstrapOnFreshStart: true }
+        : {}),
+    });
     if (input.providerOptions !== undefined) {
       threadProviderOptions.set(input.threadId, input.providerOptions);
     }
@@ -1751,9 +2001,12 @@ const make = Effect.gen(function* () {
         hasPendingPriorTranscriptBootstrap) &&
       !shouldBootstrapHandoff &&
       !shouldBootstrapSidechatContext;
+    const priorTranscriptMessages = listPriorTranscriptMessages(
+      thread,
+      transcriptBoundaryMessageId,
+    );
     const hasPriorTranscriptBootstrapContent =
-      shouldBootstrapPriorTranscriptContext &&
-      listPriorTranscriptMessages(thread, transcriptBoundaryMessageId).length > 0;
+      shouldBootstrapPriorTranscriptContext && priorTranscriptMessages.length > 0;
     const priorTranscriptBootstrapAvailableChars = availableProviderContextChars({
       tag: "thread_context",
       messageText: bootstrapBudgetMessageText,
@@ -1781,6 +2034,27 @@ const make = Effect.gen(function* () {
             transcriptBoundaryMessageId,
             priorTranscriptBootstrapAvailableChars,
           )
+        : null;
+    const restartReason: ProviderContextLifecycleReason = nativeResumeFailed
+      ? "native-resume-failed"
+      : rollbackContextBootstrapThreadIds.has(input.threadId)
+        ? "conversation-rebuilt"
+        : freshSessionContextBootstrapThreadIds.has(input.threadId)
+          ? "fresh-session"
+          : "native-history-unavailable";
+    let providerContextLifecycleEvidence: ProviderContextLifecycleEvidence | null =
+      input.reviewTarget === undefined &&
+      input.dispatchMode !== "steer" &&
+      !shouldBootstrapHandoff &&
+      !shouldBootstrapSidechatContext &&
+      priorTranscriptMessages.length > 0 &&
+      (priorTranscriptBootstrapText !== null || (nativeSessionRestarted && !nativeResumeSucceeded))
+        ? {
+            nativeHistory: nativeResumeSucceeded ? "available" : "unavailable",
+            recapText: priorTranscriptBootstrapText,
+            reason: restartReason,
+            sessionRestarted: nativeSessionRestarted,
+          }
         : null;
     // The guards above make the three bootstrap flavors mutually exclusive, so
     // a turn carries at most one context block.
@@ -1961,23 +2235,30 @@ const make = Effect.gen(function* () {
       const tracksDroidContextAcceptance =
         activeSession?.provider === "droid" &&
         (sidechatBootstrapText !== null || priorTranscriptBootstrapText !== null);
-      const tracksDurableTranscriptAcceptance =
+      const tracksOpenCodeCompatibleContextAcceptance =
         (selectedProvider === "opencode" || selectedProvider === "kilo") &&
-        hasPendingFreshSessionTranscriptBootstrap &&
-        (priorTranscriptBootstrapRetiresOnAcceptedTurn ||
-          specializedBootstrapCompletesFreshSessionContext);
+        ((hasPendingFreshSessionTranscriptBootstrap &&
+          (priorTranscriptBootstrapRetiresOnAcceptedTurn ||
+            specializedBootstrapCompletesFreshSessionContext)) ||
+          (hasPendingRollbackTranscriptBootstrap && priorTranscriptBootstrapRetiresOnAcceptedTurn));
       pendingContextBootstrapAttempt =
-        tracksDroidContextAcceptance || tracksDurableTranscriptAcceptance
+        tracksDroidContextAcceptance || tracksOpenCodeCompatibleContextAcceptance
           ? {
               clearSidechat:
                 sidechatBootstrapText !== null || priorTranscriptBootstrapText !== null,
               clearFreshSessionTranscript:
-                priorTranscriptBootstrapText !== null || tracksDurableTranscriptAcceptance,
+                priorTranscriptBootstrapText !== null ||
+                (tracksOpenCodeCompatibleContextAcceptance &&
+                  hasPendingFreshSessionTranscriptBootstrap),
               clearRollbackTranscript:
                 priorTranscriptBootstrapText !== null ||
-                (tracksDurableTranscriptAcceptance &&
+                (tracksOpenCodeCompatibleContextAcceptance &&
                   priorTranscriptBootstrapRetiresOnAcceptedTurn),
-              completeDurablePriorTranscript: tracksDurableTranscriptAcceptance,
+              completeDurablePriorTranscript:
+                tracksOpenCodeCompatibleContextAcceptance &&
+                hasPendingFreshSessionTranscriptBootstrap,
+              lifecycleEvidence: providerContextLifecycleEvidence,
+              lifecycleEvidenceCreatedAt: input.createdAt,
             }
           : undefined;
       if (pendingContextBootstrapAttempt) {
@@ -2010,6 +2291,12 @@ const make = Effect.gen(function* () {
                   priorTranscriptBootstrapAvailableChars,
                 )
               : null;
+          providerContextLifecycleEvidence = {
+            nativeHistory: "unavailable",
+            recapText: retryBootstrapText,
+            reason: "native-resume-failed",
+            sessionRestarted: !preserveActiveRuntime,
+          };
           const retryNormalizedInput = finalizeProviderInput(
             retryBootstrapText !== null
               ? {
@@ -2100,13 +2387,31 @@ const make = Effect.gen(function* () {
         pendingContextBootstrapAttempt.turnId = sentTurn.turnId;
         const terminalEvent = pendingContextBootstrapAttempt.terminalEvent;
         if (terminalEvent?.turnId === sentTurn.turnId) {
-          pendingContextBootstrapAttempts.delete(input.threadId);
           yield* completePendingContextBootstrapAttempt(
             input.threadId,
             pendingContextBootstrapAttempt,
             terminalEvent,
           );
+          if (
+            pendingContextBootstrapAttempts.get(input.threadId) === pendingContextBootstrapAttempt
+          ) {
+            pendingContextBootstrapAttempts.delete(input.threadId);
+          }
         }
+      }
+      if (
+        providerContextLifecycleEvidence !== null &&
+        pendingContextBootstrapAttempt === undefined
+      ) {
+        yield* retainAndAppendProviderContextLifecycleActivity(
+          toProviderContextLifecycleActivityRecord({
+            threadId: input.threadId,
+            turnId: sentTurn.turnId,
+            provider: selectedProvider as ProviderKind,
+            evidence: providerContextLifecycleEvidence,
+            createdAt: input.createdAt,
+          }),
+        );
       }
     }
     if (handoffBootstrapText && thread.handoff !== null && input.reviewTarget === undefined) {
@@ -4837,6 +5142,7 @@ const make = Effect.gen(function* () {
           return processQueueDrainEventSafely(event);
         }).pipe(Effect.forkScoped),
         runBlockedGoalContinuationRetries.pipe(Effect.forkScoped),
+        runProviderContextLifecycleActivityRetries.pipe(Effect.forkScoped),
       ]).pipe(Effect.asVoid),
     ),
     Effect.orDie,

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -1027,6 +1027,7 @@ adapterConfirmedFreshRouting.layer("ProviderServiceLive resume confirmation", (i
         { registerPriorTranscriptBootstrapOnFreshStart: true },
       );
 
+      assert.equal(outcome.nativeResumeAttempted, true);
       assert.equal(outcome.nativeResumeSucceeded, false);
       assert.equal(outcome.priorTranscriptBootstrapPending, true);
       yield* provider.stopSession({ threadId });
@@ -1065,8 +1066,10 @@ routing.layer("ProviderServiceLive routing", (it) => {
         runtimeMode: "full-access",
       });
 
+      assert.equal(initial.nativeResumeAttempted, false);
       assert.equal(initial.nativeResumeSucceeded, false);
       assert.equal(initial.priorTranscriptBootstrapPending, true);
+      assert.equal(resumed.nativeResumeAttempted, true);
       assert.equal(resumed.nativeResumeSucceeded, true);
       assert.equal(resumed.priorTranscriptBootstrapPending, true);
       assert.deepEqual(
@@ -1081,6 +1084,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
         threadId,
         runtimeMode: "full-access",
       });
+      assert.equal(resumedAfterCompletion.nativeResumeAttempted, true);
       assert.equal(resumedAfterCompletion.nativeResumeSucceeded, true);
       assert.equal(resumedAfterCompletion.priorTranscriptBootstrapPending, false);
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -1768,7 +1768,8 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               }
               const session = started.value;
               replacementStarted = true;
-              const nativeResumeSucceeded = hasResumeCursor(effectiveResumeCursor)
+              const nativeResumeAttempted = hasResumeCursor(effectiveResumeCursor);
+              const nativeResumeSucceeded = nativeResumeAttempted
                 ? (adapter.didResumeSession?.(resolvedAdapterStartInput, session) ?? true)
                 : false;
               const priorTranscriptBootstrapPending =
@@ -1805,6 +1806,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
 
               return {
                 session,
+                nativeResumeAttempted,
                 nativeResumeSucceeded,
                 priorTranscriptBootstrapPending,
               };

--- a/apps/server/src/provider/Services/ProviderService.ts
+++ b/apps/server/src/provider/Services/ProviderService.ts
@@ -54,6 +54,7 @@ export interface ProviderRuntimeEventPumpHealth {
 
 export interface ProviderSessionStartOutcome {
   readonly session: ProviderSession;
+  readonly nativeResumeAttempted: boolean;
   readonly nativeResumeSucceeded: boolean;
   readonly priorTranscriptBootstrapPending: boolean;
 }

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -196,6 +196,44 @@ describe("MessagesTimeline", () => {
     );
   });
 
+  it("renders session-context lifecycle evidence as a compact expandable row", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...makeTimelineBaseProps()}
+        timelineEntries={[
+          {
+            id: "context-restart-row",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "context-restart-entry",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Native session history was unavailable, so the model continued from a recap.",
+              tone: "error",
+              activityKind: "provider.context.changed",
+              providerContextLifecycle: {
+                provider: "opencode",
+                nativeHistory: "unavailable",
+                restartReason: "native-resume-failed",
+                sessionRestarted: true,
+                recapInjected: true,
+                recapCharacters: 4_200,
+                recapPreview: "Bounded recap preview",
+                recapPreviewTruncated: true,
+              },
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Native session history was unavailable");
+    expect(markup).toContain('data-tool-detail-trigger="true"');
+    expect(markup).not.toContain('data-provider-context-lifecycle-details="true"');
+    expect(markup).not.toContain("Bounded recap preview");
+  });
+
   it("keeps small transcripts on the simple non-virtualized path", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const markup = renderToStaticMarkup(

--- a/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
+++ b/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
@@ -4,6 +4,7 @@
 // Exports: TimelineWorkEntryRow, EditedFileRowContent, prefersCompactWorkEntryRow
 
 import type { TurnId } from "@synara/contracts";
+import { PROVIDER_DESCRIPTORS } from "@synara/shared/providerMetadata";
 import {
   createElement,
   memo,
@@ -29,6 +30,7 @@ import {
   GitHubIcon,
   GlobeIcon,
   HammerIcon,
+  HistoryIcon,
   type LucideIcon,
   McpIcon,
   PencilIcon,
@@ -235,6 +237,11 @@ function workEntryIcon(workEntry: TimelineWorkEntry): LucideIcon {
   if (workEntry.activityKind === "user-input.resolved") return ArrowUpCircleIcon;
   // "Moved to background" notices read as a tray drop, not a warning check.
   if (workEntry.nativeEventType === "background_tasks_changed") return BackgroundTrayIcon;
+  if (workEntry.providerContextLifecycle) {
+    return workEntry.providerContextLifecycle.nativeHistory === "unavailable"
+      ? CircleAlertIcon
+      : HistoryIcon;
+  }
 
   if (workEntry.requestKind === "command") return commandWorkEntryIcon(workEntry);
   if (workEntry.requestKind === "file-read") return SearchIcon;
@@ -532,6 +539,7 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
     ? () => onOpenAgentActivity?.(workEntry.id)
     : undefined;
   const hasToolDetails = Boolean(workEntry.toolDetails);
+  const providerContextLifecycle = workEntry.providerContextLifecycle;
   // File-read rows open the referenced file in the in-app viewer when the
   // hosting surface provides an opener (right-dock file pane / editor pane).
   const opener = useWorkspaceFileOpener();
@@ -579,7 +587,11 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
   const canOpenReadFile = readFilePath !== null;
   const canOpenToolDetails =
     !canOpenAgentActivity &&
-    Boolean(workEntry.toolDetails || (workEntry.liveActivity && !canOpenReadFile));
+    Boolean(
+      providerContextLifecycle ||
+      workEntry.toolDetails ||
+      (workEntry.liveActivity && !canOpenReadFile),
+    );
   const openReadFile = readFilePath
     ? () => openWorkspaceFileReference(opener, readFilePath)
     : undefined;
@@ -737,6 +749,11 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
               <ToolDetailsDisclosure
                 details={workEntry.toolDetails}
                 activity={workEntry.liveActivity}
+                detailContent={
+                  providerContextLifecycle ? (
+                    <ProviderContextLifecycleDetails info={providerContextLifecycle} />
+                  ) : undefined
+                }
                 compact={compact}
                 timestampFormat={timestampFormat}
                 tooltip={toolRowTooltipContent(rawCommand, displayText, displayText)}
@@ -863,12 +880,75 @@ function AgentActivityOpenSurface(props: {
   return <ToolRowTooltip content={props.tooltip}>{surface}</ToolRowTooltip>;
 }
 
+function providerContextLifecycleReasonLabel(
+  reason: NonNullable<TimelineWorkEntry["providerContextLifecycle"]>["restartReason"],
+): string {
+  switch (reason) {
+    case "conversation-rebuilt":
+      return "Conversation rebuilt";
+    case "fresh-session":
+      return "Fresh provider session";
+    case "native-history-unavailable":
+      return "Native history unavailable";
+    case "native-resume-failed":
+      return "Native resume failed";
+  }
+}
+
+function ProviderContextLifecycleDetails(props: {
+  info: NonNullable<TimelineWorkEntry["providerContextLifecycle"]>;
+}) {
+  const { info } = props;
+  const provider =
+    PROVIDER_DESCRIPTORS.find((descriptor) => descriptor.kind === info.provider)?.displayName ??
+    info.provider;
+  return (
+    <div className="space-y-3" data-provider-context-lifecycle-details="true">
+      <dl className="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-3 gap-y-1.5 rounded-lg border border-border/45 bg-background/60 px-3 py-2.5 text-[11px]">
+        <dt className="text-muted-foreground/56">Provider</dt>
+        <dd className="text-foreground/84">{provider}</dd>
+        <dt className="text-muted-foreground/56">Native history</dt>
+        <dd className="text-foreground/84">
+          {info.nativeHistory === "available" ? "Available" : "Unavailable"}
+        </dd>
+        <dt className="text-muted-foreground/56">Restart</dt>
+        <dd className="text-foreground/84">{info.sessionRestarted ? "Yes" : "No"}</dd>
+        <dt className="text-muted-foreground/56">Context change</dt>
+        <dd className="text-foreground/84">
+          {providerContextLifecycleReasonLabel(info.restartReason)}
+        </dd>
+        <dt className="text-muted-foreground/56">Recap</dt>
+        <dd className="text-foreground/84">
+          {info.recapInjected ? `${info.recapCharacters.toLocaleString()} characters` : "Not sent"}
+        </dd>
+      </dl>
+      {info.recapPreview ? (
+        <section className="space-y-2">
+          <h3 className="text-[11px] font-medium text-muted-foreground/56">Recap preview</h3>
+          <pre
+            className="max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/45 bg-background/60 px-3 py-2.5 font-chat-code text-[11px] leading-relaxed text-foreground/84"
+            data-session-context-recap-preview="true"
+          >
+            {info.recapPreview}
+          </pre>
+          {info.recapPreviewTruncated ? (
+            <p className="text-[10px] text-muted-foreground/56">
+              Showing a bounded preview of the recap sent to the model.
+            </p>
+          ) : null}
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
 function ToolDetailsDisclosure(props: {
   children: ReactNode;
   compact: boolean;
   dataFileChangeRow?: boolean | undefined;
   details?: TimelineWorkEntry["toolDetails"] | undefined;
   activity?: TimelineWorkEntry["liveActivity"] | undefined;
+  detailContent?: ReactNode;
   summaryClassName?: string | undefined;
   timestampFormat: TimestampFormat;
   tooltip?: ReactNode;
@@ -951,11 +1031,13 @@ function ToolDetailsDisclosure(props: {
           contentClassName={cn("min-w-0 pt-2", props.compact ? "ml-5" : "ml-7")}
         >
           <div data-tool-details-inline="true">
-            <ToolCallDetailsContent
-              details={props.details}
-              activity={props.activity}
-              timestampFormat={props.timestampFormat}
-            />
+            {props.detailContent ?? (
+              <ToolCallDetailsContent
+                details={props.details}
+                activity={props.activity}
+                timestampFormat={props.timestampFormat}
+              />
+            )}
           </div>
         </DisclosureRegion>
       ) : null}

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -356,6 +356,90 @@ describe("deriveWorkLogEntries", () => {
     ]);
   });
 
+  it("keeps durable session-context evidence when its turn is outside the visibility filter", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "context-restart",
+        turnId: "turn-hidden",
+        kind: "provider.context.changed",
+        summary: "Native session history was unavailable.",
+        tone: "error",
+        payload: {
+          provider: "opencode",
+          nativeHistory: "unavailable",
+          sessionRestarted: true,
+          restartReason: "native-resume-failed",
+          recapInjected: true,
+          recapCharacters: 12_000,
+          recapPreview: "x".repeat(1_000),
+          recapPreviewTruncated: false,
+        },
+      }),
+      makeActivity({
+        id: "hidden-tool",
+        turnId: "turn-hidden",
+        kind: "tool.completed",
+        summary: "Hidden tool",
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, TurnId.makeUnsafe("turn-visible"), {
+      visibleTurnIds: new Set([TurnId.makeUnsafe("turn-visible")]),
+    });
+
+    expect(entry).toMatchObject({
+      id: "context-restart",
+      turnId: TurnId.makeUnsafe("turn-hidden"),
+      tone: "error",
+      providerContextLifecycle: {
+        provider: "opencode",
+        nativeHistory: "unavailable",
+        sessionRestarted: true,
+        restartReason: "native-resume-failed",
+        recapInjected: true,
+        recapCharacters: 12_000,
+        recapPreviewTruncated: true,
+      },
+    });
+    expect(entry?.providerContextLifecycle?.recapPreview?.length).toBeLessThanOrEqual(600);
+  });
+
+  it("keeps native-history loss visible when the provider sent no recap", () => {
+    const [entry] = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "context-restart-without-recap",
+          turnId: "turn-2",
+          kind: "provider.context.changed",
+          summary: "The session restarted without its native history.",
+          tone: "error",
+          payload: {
+            provider: "codex",
+            nativeHistory: "unavailable",
+            sessionRestarted: true,
+            restartReason: "native-history-unavailable",
+            recapInjected: false,
+            recapCharacters: 0,
+            recapPreview: null,
+            recapPreviewTruncated: false,
+          },
+        }),
+      ],
+      TurnId.makeUnsafe("turn-2"),
+    );
+
+    expect(entry?.providerContextLifecycle).toEqual({
+      provider: "codex",
+      nativeHistory: "unavailable",
+      sessionRestarted: true,
+      restartReason: "native-history-unavailable",
+      recapInjected: false,
+      recapCharacters: 0,
+      recapPreview: null,
+      recapPreviewTruncated: false,
+    });
+  });
+
   it("falls back to the latest-turn filter when visible turn ids are empty", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({ id: "turn-1", turnId: "turn-1", summary: "First tool", kind: "tool.started" }),

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -44,6 +44,25 @@ export type WorkLogRequestKind = ApprovalRequestKind;
 // apps/server/src/orchestration/commandInvariants.ts, which the web app cannot
 // import.
 const CHECKPOINT_REVERT_FAILED_ACTIVITY_KIND = "checkpoint.revert.failed";
+export const PROVIDER_CONTEXT_LIFECYCLE_ACTIVITY_KIND = "provider.context.changed";
+const SESSION_CONTEXT_RECAP_PREVIEW_MAX_CHARS = 600;
+
+export type ProviderContextLifecycleReason =
+  | "conversation-rebuilt"
+  | "fresh-session"
+  | "native-history-unavailable"
+  | "native-resume-failed";
+
+export interface ProviderContextLifecycleInfo {
+  provider: ProviderKind;
+  nativeHistory: "available" | "unavailable";
+  restartReason: ProviderContextLifecycleReason;
+  sessionRestarted: boolean;
+  recapInjected: boolean;
+  recapCharacters: number;
+  recapPreview: string | null;
+  recapPreviewTruncated: boolean;
+}
 
 export interface WorkLogEntry {
   id: string;
@@ -70,6 +89,7 @@ export interface WorkLogEntry {
   subagentAction?: WorkLogSubagentAction;
   automation?: WorkLogAutomation;
   synaraThreadCreation?: WorkLogSynaraThreadCreation;
+  providerContextLifecycle?: ProviderContextLifecycleInfo;
   // Source activity kind, kept so the timeline can pick a kind-specific icon
   // (e.g. user-input.requested -> question glyph) instead of the generic
   // tone fallback. Same rationale as `toolName` below.
@@ -323,6 +343,12 @@ function shouldKeepActivityForWorkLog(
   latestTurnId: TurnId | undefined,
   visibleTurnIds: ReadonlySet<TurnId | string> | undefined,
 ): boolean {
+  // Context lifecycle evidence must survive message visibility filters. It is
+  // the durable explanation for why a turn may behave differently after reload.
+  if (activity.kind === PROVIDER_CONTEXT_LIFECYCLE_ACTIVITY_KIND) {
+    return true;
+  }
+
   // Thread-level compaction progress has no provider turn id but should stay visible.
   if (activity.kind === "context-compaction" && activity.turnId === null) {
     return true;
@@ -489,6 +515,61 @@ export function parseTaskListTasks(payload: unknown): TaskListTaskSnapshot[] | n
   return tasks;
 }
 
+function isProviderContextLifecycleReason(value: unknown): value is ProviderContextLifecycleReason {
+  return (
+    value === "conversation-rebuilt" ||
+    value === "fresh-session" ||
+    value === "native-history-unavailable" ||
+    value === "native-resume-failed"
+  );
+}
+
+function extractProviderContextLifecycleInfo(
+  payload: Record<string, unknown> | null,
+): ProviderContextLifecycleInfo | null {
+  const provider = PROVIDER_DESCRIPTORS.find(
+    (descriptor) => descriptor.kind === payload?.provider,
+  )?.kind;
+  const nativeHistory = payload?.nativeHistory;
+  const restartReason = payload?.restartReason;
+  const sessionRestarted = payload?.sessionRestarted;
+  const recapInjected = payload?.recapInjected;
+  const recapCharacters = payload?.recapCharacters;
+  const recapPreview = payload?.recapPreview;
+  const recapPreviewTruncated = payload?.recapPreviewTruncated;
+  if (
+    !provider ||
+    (nativeHistory !== "available" && nativeHistory !== "unavailable") ||
+    !isProviderContextLifecycleReason(restartReason) ||
+    typeof sessionRestarted !== "boolean" ||
+    typeof recapInjected !== "boolean" ||
+    typeof recapCharacters !== "number" ||
+    !Number.isInteger(recapCharacters) ||
+    recapCharacters < 0 ||
+    (recapPreview !== null && typeof recapPreview !== "string") ||
+    typeof recapPreviewTruncated !== "boolean"
+  ) {
+    return null;
+  }
+  const boundedPreview =
+    typeof recapPreview === "string" &&
+    recapPreview.length > SESSION_CONTEXT_RECAP_PREVIEW_MAX_CHARS
+      ? `…${recapPreview.slice(-(SESSION_CONTEXT_RECAP_PREVIEW_MAX_CHARS - 1)).trimStart()}`
+      : recapPreview;
+  return {
+    provider,
+    nativeHistory,
+    restartReason,
+    sessionRestarted,
+    recapInjected,
+    recapCharacters,
+    recapPreview: boundedPreview,
+    recapPreviewTruncated:
+      recapPreviewTruncated ||
+      (typeof recapPreview === "string" && recapPreview.length > (boundedPreview?.length ?? 0)),
+  };
+}
+
 function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWorkLogEntry {
   const payload =
     activity.payload && typeof activity.payload === "object"
@@ -614,6 +695,12 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
     const synaraThreadCreation = extractWorkLogSynaraThreadCreation(payload);
     if (synaraThreadCreation) {
       entry.synaraThreadCreation = synaraThreadCreation;
+    }
+  }
+  if (activity.kind === PROVIDER_CONTEXT_LIFECYCLE_ACTIVITY_KIND) {
+    const providerContextLifecycle = extractProviderContextLifecycleInfo(payload);
+    if (providerContextLifecycle) {
+      entry.providerContextLifecycle = providerContextLifecycle;
     }
   }
   const readableTitle =


### PR DESCRIPTION
Closes #798.

## Stack

- Parent: #832, `codex/fix-796-resume-aware-bootstrap` at `34e9159f55d95e4bdcb8ae0a54e971abe629d553`
- This PR: `codex/issue-798-context-lifecycle`

This PR intentionally targets the #796 branch because its activity evidence consumes the parent’s confirmed native-resume outcome and confirmed transcript-bootstrap completion path.

## What changed

- Append one durable, idempotent `provider.context.changed` activity for a turn that actually loses provider-native history or receives a transcript recap.
- Retain the bounded activity record and retry transient append failures without resending the accepted provider turn.
- Keep a clean provider-native resume invisible.
- For OpenCode, Kilo, and Droid bootstrap paths, wait for a matching successful provider terminal event before recording the lifecycle outcome. An aborted asynchronous prompt produces no false marker; the successful retry produces exactly one.
- Persist bounded evidence only: provider, native-history availability, restart fact/reason, recap presence and character count, and a tail preview capped at 600 characters.
- Render the activity as a compact expandable transcript-rail row with plain-language details and recap preview.
- Preserve lifecycle activities through reload reconstruction and transcript visibility filtering.

The branch does not change ACP/Cursor replay suppression and does not depend on the separate #811 work.

## Verification

- `bun run --cwd apps/server test src/provider/Layers/ProviderService.test.ts src/orchestration/Layers/ProviderCommandReactor.test.ts` — 245 passed
- `bun run --cwd apps/web test src/workLog.test.ts src/components/chat/MessagesTimeline.test.tsx` — 161 passed
- `./node_modules/.bin/oxfmt <9 changed TypeScript files>` — passed
- `git diff --check` — passed
- Merge-base with the parent head is exactly `34e9159f55d95e4bdcb8ae0a54e971abe629d553`

Per task constraints, `bun fmt`, `bun lint`, and `bun typecheck` were not run locally. The parent head is fully green; this PR’s own CI is the authoritative heavyweight verification for this upper diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider session bootstrap, transcript recap timing, and durable marker completion in `ProviderCommandReactor`; incorrect gating could mis-record context loss or complete bootstrap too early, but behavior is heavily test-covered.
> 
> **Overview**
> Adds durable **`provider.context.changed`** thread activities when a turn loses native provider history or gets a transcript recap, so users see why behavior changed after reload.
> 
> **Server:** `ProviderCommandReactor` builds bounded evidence (restart reason, native history availability, recap size, 600-char tail preview), appends idempotent activities after the matching **completed** bootstrap/replay turn (aborted async turns stay silent until a successful retry), retries failed activity writes without resending the turn, and ties OpenCode/Kilo durable transcript bootstrap retirement to successful activity persistence. Session start outcomes now expose **`nativeResumeAttempted`** separately from **`nativeResumeSucceeded`**.
> 
> **Web:** Work log derivation keeps lifecycle rows visible across turn filters, maps activity payloads into **`providerContextLifecycle`**, and renders a compact expandable timeline row with details and recap preview.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6f65c90100e25564ecf4bf53ac92e4206b2302b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->