### PR TITLE
Fix created-at thread ordering

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -2250,6 +2250,40 @@ describe("sortThreadsForSidebar", () => {
     ]);
   });
 
+  it("keeps createdAt order stable across live and unread completion states", () => {
+    const sorted = sortThreadsForSidebar(
+      [
+        makeThread({
+          id: ThreadId.makeUnsafe("thread-newest-plain"),
+          createdAt: "2026-03-09T11:00:00.000Z",
+          updatedAt: "2026-03-09T11:00:00.000Z",
+        }),
+        makeThread({
+          id: ThreadId.makeUnsafe("thread-middle-unread"),
+          createdAt: "2026-03-09T10:00:00.000Z",
+          updatedAt: "2026-03-09T10:00:00.000Z",
+          latestTurn: makeLatestTurn({ completedAt: "2026-03-09T10:05:00.000Z" }),
+          lastVisitedAt: "2026-03-09T10:01:00.000Z",
+        }),
+        {
+          ...makeThread({
+            id: ThreadId.makeUnsafe("thread-oldest-working"),
+            createdAt: "2026-03-09T09:00:00.000Z",
+            updatedAt: "2026-03-09T09:00:00.000Z",
+          }),
+          hasLiveTailWork: true,
+        },
+      ],
+      "created_at",
+    );
+
+    expect(sorted.map((thread) => thread.id)).toEqual([
+      ThreadId.makeUnsafe("thread-newest-plain"),
+      ThreadId.makeUnsafe("thread-middle-unread"),
+      ThreadId.makeUnsafe("thread-oldest-working"),
+    ]);
+  });
+
   it("floats a finished thread the user has not opened above newer threads", () => {
     const sorted = sortThreadsForSidebar(
       [

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -1436,8 +1436,10 @@ export function sortThreadsForSidebar<T extends { id: Thread["id"] } & SidebarTh
   sortOrder: SidebarThreadSortOrder,
 ): T[] {
   return threads.toSorted((left, right) => {
-    const byAttentionRank = threadSortAttentionRank(right) - threadSortAttentionRank(left);
-    if (byAttentionRank !== 0) return byAttentionRank;
+    if (sortOrder !== "created_at") {
+      const byAttentionRank = threadSortAttentionRank(right) - threadSortAttentionRank(left);
+      if (byAttentionRank !== 0) return byAttentionRank;
+    }
     const rightTimestamp = getThreadSortTimestamp(right, sortOrder);
     const leftTimestamp = getThreadSortTimestamp(left, sortOrder);
     const byTimestamp =


### PR DESCRIPTION
## What Changed

- Make the **Created at** sidebar option sort threads strictly by creation timestamp.
- Preserve live-work and unread-completion priority for the **Last user message** sort mode.
- Add regression coverage for live and unread-completed threads.

## Why

The **Created at** mode previously applied attention priority before comparing creation timestamps. As a result, live or unread-completed threads could jump ahead of newer threads, and opening a completed thread could change its position.

Skipping attention priority only for **Created at** makes that mode match its label without changing the existing attention behavior of **Last user message**.

## UI Changes

The styling, layout, and active/unread indicators are unchanged. Only the ordering behavior changes.

| Before | After |
| --- | --- |
| <img width="380" alt="Before: Created at incorrectly puts a 10:00 completed thread above newer 14:00 through 11:00 threads" src="https://raw.githubusercontent.com/NachoooLK/synara/8f418088e26b99cfb6b15e645394e2aee664eed7/pr-841/before-created-at.png" /> | <img width="370" alt="After: Created at is strictly ordered from 14:00 to 09:00 while completion remains visible" src="https://raw.githubusercontent.com/NachoooLK/synara/8f418088e26b99cfb6b15e645394e2aee664eed7/pr-841/after-created-at.png" /> |

The Before image is an isolated app capture at the PR baseline. The focused After fixture uses the PR's exact `sortThreadsForSidebar` implementation and preserves the completed-state badge without letting it change creation order.

A short interaction video showing that opening a completed thread no longer changes the order is still pending.

## Verification

- `bun run test:web:focused src/components/Sidebar.logic.test.ts` — 124 tests passed
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
