### PR TITLE
Show usage for all enabled providers

### DIFF
--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -41,6 +41,7 @@ import {
 import { ensureNativeApi } from "./nativeApi";
 import { providerDiscoveryQueryKeys } from "./lib/providerDiscoveryReactQuery";
 import {
+  invalidateProviderUsageQueries,
   reconcileServerProviderStatuses,
   serverQueryKeys,
   serverSettingsQueryOptions,
@@ -1387,6 +1388,7 @@ export function useAppSettings() {
     await queryClient
       .invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all })
       .catch(() => undefined);
+    await invalidateProviderUsageQueries(queryClient).catch(() => undefined);
   };
 
   const enqueueServerSettingsMutation = <Result>(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -12023,7 +12023,6 @@ export default function ChatView({
           activeThreadId={activeThread.id}
           activeThreadTitle={activeThreadDisplayTitle}
           activeThreadEntryPoint={terminalState.entryPoint}
-          activeProvider={activeThread.session?.provider ?? activeThread.modelSelection.provider}
           activeProjectName={isEditorRail ? undefined : activeProjectDisplayName}
           threadBreadcrumbs={threadBreadcrumbs}
           {...(isEditorRail

--- a/apps/web/src/components/ProviderUsageMenuControl.tsx
+++ b/apps/web/src/components/ProviderUsageMenuControl.tsx
@@ -10,7 +10,10 @@ import { providerUsageNeedsAuthDetail } from "@synara/shared/providerUsage";
 import { type ReactNode } from "react";
 
 import { useAppSettings } from "~/appSettings";
-import { useProviderUsageSummary } from "~/hooks/useProviderUsageSummary";
+import {
+  type ProviderUsageSummaryData,
+  useProviderUsageSummary,
+} from "~/hooks/useProviderUsageSummary";
 import {
   deriveProviderUsageDisplayRows,
   selectPrimaryProviderUsageDisplayRow,
@@ -37,6 +40,25 @@ export interface ProviderUsageMenuModel {
   notice: string | undefined;
   emptyMessage: string | undefined;
   isLoading: boolean;
+}
+
+export function buildProviderUsageMenuModel(input: {
+  provider: ProviderKind;
+  providerSnapshot?: ServerGetProviderUsageSnapshotResult | undefined;
+  usageSummary: ProviderUsageSummaryData & { readonly isLoading: boolean };
+}): ProviderUsageMenuModel {
+  const rows = deriveProviderUsageDisplayRows(input.usageSummary.rateLimits);
+
+  return {
+    menuTitle: `${PROVIDER_DISPLAY_NAMES[input.provider]} usage`,
+    primaryRow: selectPrimaryProviderUsageDisplayRow(rows),
+    rows,
+    rateLimits: input.usageSummary.rateLimits,
+    usageLines: input.usageSummary.usageLines,
+    notice: input.usageSummary.usageNotice,
+    emptyMessage: providerUsageEmptyMessage(input.provider, input.providerSnapshot),
+    isLoading: input.usageSummary.isLoading,
+  };
 }
 
 // Module-level: the selector memoizes on store slices, so recreating it per render would
@@ -74,30 +96,25 @@ export function useProviderUsageMenuModel(
     providerSnapshot: input.providerSnapshot,
     fetchOpenUsageData: false,
   });
-  const usageRows = deriveProviderUsageDisplayRows(usageSummary.rateLimits);
-  const primaryRow = selectPrimaryProviderUsageDisplayRow(usageRows);
 
-  return {
-    menuTitle: `${PROVIDER_DISPLAY_NAMES[provider]} usage`,
-    primaryRow,
-    rows: usageRows,
-    rateLimits: usageSummary.rateLimits,
-    usageLines: usageSummary.usageLines,
-    notice: usageSummary.usageNotice,
-    emptyMessage: providerUsageEmptyMessage(provider, input.providerSnapshot),
-    isLoading: usageSummary.isLoading,
-  };
+  return buildProviderUsageMenuModel({
+    provider,
+    providerSnapshot: input.providerSnapshot,
+    usageSummary,
+  });
 }
 
 export function ProviderUsageMenuPopup({
   provider,
   model,
   align: alignProp,
+  showUsageLines = false,
   children,
 }: {
   provider: ProviderKind;
   model: ProviderUsageMenuModel;
   align?: "start" | "end";
+  showUsageLines?: boolean;
   children: ReactNode;
 }) {
   const align = alignProp ?? "end";
@@ -112,7 +129,7 @@ export function ProviderUsageMenuPopup({
           notice={model.notice}
           emptyMessage={model.emptyMessage}
           isLoading={model.isLoading}
-          showUsageLines={false}
+          showUsageLines={showUsageLines}
           showTitle={false}
           className="px-2 pb-1 pt-1"
         />

--- a/apps/web/src/components/ProviderUsageMenuControl.tsx
+++ b/apps/web/src/components/ProviderUsageMenuControl.tsx
@@ -1,7 +1,12 @@
 // FILE: ProviderUsageMenuControl.tsx
 // Purpose: Shared provider-usage chip/menu used in the chat header and Environment panel.
 
-import { PROVIDER_DISPLAY_NAMES, type ProviderKind } from "@synara/contracts";
+import {
+  PROVIDER_DISPLAY_NAMES,
+  type ProviderKind,
+  type ServerGetProviderUsageSnapshotResult,
+} from "@synara/contracts";
+import { providerUsageNeedsAuthDetail } from "@synara/shared/providerUsage";
 import { type ReactNode } from "react";
 
 import { useAppSettings } from "~/appSettings";
@@ -25,10 +30,12 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 
 export interface ProviderUsageMenuModel {
   menuTitle: string;
-  primaryRow: ProviderUsageDisplayRow;
+  primaryRow: ProviderUsageDisplayRow | null;
+  rows: ReadonlyArray<ProviderUsageDisplayRow>;
   rateLimits: ReadonlyArray<ProviderRateLimit>;
   usageLines: ReadonlyArray<OpenUsageUsageLine>;
   notice: string | undefined;
+  emptyMessage: string | undefined;
   isLoading: boolean;
 }
 
@@ -36,28 +43,48 @@ export interface ProviderUsageMenuModel {
 // defeat the memo and rebuild every thread on each streaming flush.
 const selectAccountRateLimitThreads = createAccountRateLimitThreadsSelector();
 
-export function useProviderUsageMenuModel(provider: ProviderKind): ProviderUsageMenuModel | null {
+function providerUsageEmptyMessage(
+  provider: ProviderKind,
+  snapshot: ServerGetProviderUsageSnapshotResult | undefined,
+): string | undefined {
+  switch (snapshot?.status) {
+    case "needs-auth":
+      return snapshot.detail ?? providerUsageNeedsAuthDetail(provider);
+    case "unsupported":
+      return snapshot.detail ?? "Live usage is not available for this provider configuration.";
+    case "error":
+      return snapshot.detail ?? "Usage is currently unavailable.";
+    default:
+      return undefined;
+  }
+}
+
+export function useProviderUsageMenuModel(
+  provider: ProviderKind,
+  input: {
+    providerSnapshot?: ServerGetProviderUsageSnapshotResult | undefined;
+  } = {},
+): ProviderUsageMenuModel {
   const { settings } = useAppSettings();
   const threads = useStore(selectAccountRateLimitThreads);
   const usageSummary = useProviderUsageSummary({
     provider,
     threads,
     codexHomePath: settings.codexHomePath || null,
+    providerSnapshot: input.providerSnapshot,
     fetchOpenUsageData: false,
   });
   const usageRows = deriveProviderUsageDisplayRows(usageSummary.rateLimits);
   const primaryRow = selectPrimaryProviderUsageDisplayRow(usageRows);
 
-  if (!primaryRow) {
-    return null;
-  }
-
   return {
     menuTitle: `${PROVIDER_DISPLAY_NAMES[provider]} usage`,
     primaryRow,
+    rows: usageRows,
     rateLimits: usageSummary.rateLimits,
     usageLines: usageSummary.usageLines,
     notice: usageSummary.usageNotice,
+    emptyMessage: providerUsageEmptyMessage(provider, input.providerSnapshot),
     isLoading: usageSummary.isLoading,
   };
 }
@@ -83,6 +110,7 @@ export function ProviderUsageMenuPopup({
           rateLimits={model.rateLimits}
           usageLines={model.usageLines}
           notice={model.notice}
+          emptyMessage={model.emptyMessage}
           isLoading={model.isLoading}
           showUsageLines={false}
           showTitle={false}
@@ -96,7 +124,7 @@ export function ProviderUsageMenuPopup({
 export function ProviderUsageMenuControl({ provider }: { provider: ProviderKind }) {
   const model = useProviderUsageMenuModel(provider);
 
-  if (!model) {
+  if (!model.primaryRow) {
     return null;
   }
 

--- a/apps/web/src/components/ProviderUsagePanelContent.tsx
+++ b/apps/web/src/components/ProviderUsagePanelContent.tsx
@@ -25,6 +25,7 @@ export function ProviderUsagePanelContent(props: {
   rateLimits: ReadonlyArray<ProviderRateLimit>;
   usageLines?: ReadonlyArray<OpenUsageUsageLine> | undefined;
   notice?: string | null | undefined;
+  emptyMessage?: string | null | undefined;
   isLoading?: boolean | undefined;
   learnMoreHref?: string | null | undefined;
   showUsageLines?: boolean | undefined;
@@ -64,9 +65,10 @@ export function ProviderUsagePanelContent(props: {
         </p>
       ) : visibleRows.length === 0 ? (
         <p className="text-[length:var(--app-font-size-chat-meta,10px)] leading-relaxed text-muted-foreground">
-          {props.provider
-            ? "No local usage data was found yet for the selected provider."
-            : "No local usage data was found yet."}
+          {props.emptyMessage ??
+            (props.provider
+              ? "No local usage data was found yet for the selected provider."
+              : "No local usage data was found yet.")}
         </p>
       ) : null}
       {props.showLearnMore === true && learnMoreHref ? (

--- a/apps/web/src/components/chat/environment/EnvironmentPanel.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentPanel.tsx
@@ -14,7 +14,6 @@ import type {
   MessageId,
   PinnedMessage,
   ProjectId,
-  ProviderKind,
   ResolvedKeybindingsConfig,
   ThreadId,
   ThreadMarker,
@@ -96,8 +95,6 @@ export interface EnvironmentPanelProps {
   keybindings: ResolvedKeybindingsConfig;
   availableEditors: ReadonlyArray<EditorId>;
   activeThreadId: ThreadId | null;
-  /** Active provider for the usage row (same chip the header used to show). */
-  activeProvider: ProviderKind;
   /**
    * Whether the active thread is a Studio chat. Studio chats show the Output section:
    * the Outbox files THIS chat produced, so its output stays attached to the chat.
@@ -216,7 +213,6 @@ export function EnvironmentPanel({
   keybindings,
   availableEditors,
   activeThreadId,
-  activeProvider,
   isStudioChat,
   studioFolderPath: studioFolderPathProp,
   showGitActions,
@@ -375,7 +371,7 @@ export function EnvironmentPanel({
         actually shows, so toggling any section via the header gear menu never leaves a doubled or
         dangling rule. Visibility is gated on the per-section AppSettings flags.
       */}
-      {settings.showEnvironmentUsage ? <EnvironmentUsageSection provider={activeProvider} /> : null}
+      {settings.showEnvironmentUsage ? <EnvironmentUsageSection /> : null}
 
       {settings.showEnvironmentRepository && githubRepository && onOpenGithubRepository ? (
         <EnvironmentLabeledSection label="Repository">

--- a/apps/web/src/components/chat/environment/EnvironmentUsageSection.browser.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentUsageSection.browser.tsx
@@ -8,12 +8,16 @@ import {
   type ServerProviderUsageSnapshot,
 } from "@synara/contracts";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { page } from "vitest/browser";
+import { page, userEvent } from "vitest/browser";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 
+const appSettingsMocks = vi.hoisted(() => ({
+  useAppSettings: vi.fn(() => ({ settings: { codexHomePath: "" } })),
+}));
+
 vi.mock("~/appSettings", () => ({
-  useAppSettings: () => ({ settings: { codexHomePath: "" } }),
+  useAppSettings: appSettingsMocks.useAppSettings,
 }));
 
 import { serverQueryKeys } from "~/lib/serverReactQuery";
@@ -23,12 +27,13 @@ import { EnvironmentUsageSection } from "./EnvironmentUsageSection";
 function snapshot(
   provider: ServerProviderUsageSnapshot["provider"],
   limits: ServerProviderUsageSnapshot["limits"],
+  usageLines: ServerProviderUsageSnapshot["usageLines"] = [],
 ): ServerProviderUsageSnapshot {
   return {
     provider,
     updatedAt: "2026-08-30T12:00:00.000Z",
     limits,
-    usageLines: [],
+    usageLines,
     source: "test",
     status: "ok",
   };
@@ -50,6 +55,12 @@ describe("EnvironmentUsageSection", () => {
         { window: "Weekly", usedPercent: 54, windowDurationMins: 10_080 },
       ]),
       snapshot("cursor", [{ window: "Current", usedPercent: 30 }]),
+      snapshot("droid", [], [
+        {
+          label: "Limits",
+          value: "Remaining limits stay in the Droid CLI.",
+        },
+      ]),
     ]);
     queryClient.setQueryData(serverQueryKeys.settings(), {
       ...DEFAULT_SERVER_SETTINGS_VIEW,
@@ -71,9 +82,15 @@ describe("EnvironmentUsageSection", () => {
     const claude = page.getByRole("button", {
       name: "Claude usage: Weekly 46% remaining",
     });
+    const droid = page.getByRole("button", { name: "Droid usage: Connected" });
     await expect.element(codex).toBeVisible();
     await expect.element(claude).toBeVisible();
+    await expect.element(droid).toBeVisible();
     expect(document.querySelector('button[aria-label^="Cursor usage:"]')).toBeNull();
+    expect(appSettingsMocks.useAppSettings).not.toHaveBeenCalled();
+    expect(
+      queryClient.getQueryState(serverQueryKeys.providerUsage("codex", null)),
+    ).toBeUndefined();
     await expect.element(page.getByText("5h", { exact: true })).toBeVisible();
     await expect.element(page.getByText("Weekly", { exact: true }).first()).toBeVisible();
 
@@ -81,5 +98,12 @@ describe("EnvironmentUsageSection", () => {
 
     await expect.element(page.getByText("95% left", { exact: true })).toBeVisible();
     await expect.element(page.getByText("82% left", { exact: true })).toBeVisible();
+
+    await userEvent.keyboard("{Escape}");
+    await droid.click();
+
+    await expect
+      .element(page.getByText("Remaining limits stay in the Droid CLI.", { exact: true }))
+      .toBeVisible();
   });
 });

--- a/apps/web/src/components/chat/environment/EnvironmentUsageSection.browser.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentUsageSection.browser.tsx
@@ -1,0 +1,85 @@
+// FILE: EnvironmentUsageSection.browser.tsx
+// Purpose: Browser coverage for enabled-provider rows and multi-window usage summaries.
+
+import "../../../index.css";
+
+import {
+  DEFAULT_SERVER_SETTINGS_VIEW,
+  type ServerProviderUsageSnapshot,
+} from "@synara/contracts";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { page } from "vitest/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+vi.mock("~/appSettings", () => ({
+  useAppSettings: () => ({ settings: { codexHomePath: "" } }),
+}));
+
+import { serverQueryKeys } from "~/lib/serverReactQuery";
+
+import { EnvironmentUsageSection } from "./EnvironmentUsageSection";
+
+function snapshot(
+  provider: ServerProviderUsageSnapshot["provider"],
+  limits: ServerProviderUsageSnapshot["limits"],
+): ServerProviderUsageSnapshot {
+  return {
+    provider,
+    updatedAt: "2026-08-30T12:00:00.000Z",
+    limits,
+    usageLines: [],
+    source: "test",
+    status: "ok",
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("EnvironmentUsageSection", () => {
+  it("renders every enabled provider and every reported usage window", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(serverQueryKeys.allProviderUsage(), [
+      snapshot("codex", [
+        { window: "Weekly", usedPercent: 18, windowDurationMins: 10_080 },
+        { window: "5h", usedPercent: 5, windowDurationMins: 300 },
+      ]),
+      snapshot("claudeAgent", [
+        { window: "Weekly", usedPercent: 54, windowDurationMins: 10_080 },
+      ]),
+      snapshot("cursor", [{ window: "Current", usedPercent: 30 }]),
+    ]);
+    queryClient.setQueryData(serverQueryKeys.settings(), {
+      ...DEFAULT_SERVER_SETTINGS_VIEW,
+      providers: {
+        ...DEFAULT_SERVER_SETTINGS_VIEW.providers,
+        cursor: { ...DEFAULT_SERVER_SETTINGS_VIEW.providers.cursor, enabled: false },
+      },
+    });
+
+    await render(
+      <QueryClientProvider client={queryClient}>
+        <EnvironmentUsageSection />
+      </QueryClientProvider>,
+    );
+
+    const codex = page.getByRole("button", {
+      name: "Codex usage: 5h 95% remaining, Weekly 82% remaining",
+    });
+    const claude = page.getByRole("button", {
+      name: "Claude usage: Weekly 46% remaining",
+    });
+    await expect.element(codex).toBeVisible();
+    await expect.element(claude).toBeVisible();
+    expect(document.querySelector('button[aria-label^="Cursor usage:"]')).toBeNull();
+    await expect.element(page.getByText("5h", { exact: true })).toBeVisible();
+    await expect.element(page.getByText("Weekly", { exact: true }).first()).toBeVisible();
+
+    await codex.click();
+
+    await expect.element(page.getByText("95% left", { exact: true })).toBeVisible();
+    await expect.element(page.getByText("82% left", { exact: true })).toBeVisible();
+  });
+});

--- a/apps/web/src/components/chat/environment/EnvironmentUsageSection.logic.test.ts
+++ b/apps/web/src/components/chat/environment/EnvironmentUsageSection.logic.test.ts
@@ -39,6 +39,7 @@ describe("resolveEnvironmentProviderUsageSummary", () => {
       providerName: "Codex",
       rows,
       snapshot: providerSnapshot,
+      hasUsageLines: false,
     });
 
     expect(summary.rows.map((row) => [row.label, row.remainingLabel])).toEqual([
@@ -60,9 +61,26 @@ describe("resolveEnvironmentProviderUsageSummary", () => {
       providerName: "Codex",
       rows: [],
       snapshot: providerSnapshot,
+      hasUsageLines: false,
     });
 
     expect(summary.statusLabel).toBe(label);
     expect(summary.ariaLabel).toBe(`Codex usage: ${label}`);
+  });
+
+  it("reports connected when an ok provider only exposes usage text", () => {
+    const providerSnapshot = snapshot({
+      usageLines: [{ label: "Limits", value: "Remaining limits stay in the provider CLI." }],
+    });
+
+    const summary = resolveEnvironmentProviderUsageSummary({
+      providerName: "Droid",
+      rows: [],
+      snapshot: providerSnapshot,
+      hasUsageLines: true,
+    });
+
+    expect(summary.statusLabel).toBe("Connected");
+    expect(summary.ariaLabel).toBe("Droid usage: Connected");
   });
 });

--- a/apps/web/src/components/chat/environment/EnvironmentUsageSection.logic.test.ts
+++ b/apps/web/src/components/chat/environment/EnvironmentUsageSection.logic.test.ts
@@ -1,0 +1,68 @@
+import type { ServerProviderUsageSnapshot } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+
+import { deriveProviderUsageDisplayRows } from "~/lib/providerUsageDisplay";
+
+import { resolveEnvironmentProviderUsageSummary } from "./EnvironmentUsageSection.logic";
+
+function snapshot(
+  input: Partial<ServerProviderUsageSnapshot> = {},
+): ServerProviderUsageSnapshot {
+  return {
+    provider: "codex",
+    updatedAt: "2026-08-30T12:00:00.000Z",
+    limits: [],
+    usageLines: [],
+    source: "test",
+    status: "ok",
+    ...input,
+  };
+}
+
+describe("resolveEnvironmentProviderUsageSummary", () => {
+  it("keeps both the five-hour and weekly limits in compact display order", () => {
+    const providerSnapshot = snapshot({
+      limits: [
+        { window: "Weekly", usedPercent: 18, windowDurationMins: 10_080 },
+        { window: "5h", usedPercent: 5, windowDurationMins: 300 },
+      ],
+    });
+    const rows = deriveProviderUsageDisplayRows([
+      {
+        provider: providerSnapshot.provider,
+        updatedAt: providerSnapshot.updatedAt,
+        limits: providerSnapshot.limits,
+      },
+    ]);
+
+    const summary = resolveEnvironmentProviderUsageSummary({
+      providerName: "Codex",
+      rows,
+      snapshot: providerSnapshot,
+    });
+
+    expect(summary.rows.map((row) => [row.label, row.remainingLabel])).toEqual([
+      ["5h", "95%"],
+      ["Weekly", "82%"],
+    ]);
+    expect(summary.ariaLabel).toBe("Codex usage: 5h 95% remaining, Weekly 82% remaining");
+  });
+
+  it.each([
+    ["needs-auth", "Sign in"],
+    ["unsupported", "Unsupported"],
+    ["error", "Unavailable"],
+    ["ok", "No data"],
+  ] as const)("uses the %s fallback when no limit rows are available", (status, label) => {
+    const providerSnapshot = snapshot({ status });
+
+    const summary = resolveEnvironmentProviderUsageSummary({
+      providerName: "Codex",
+      rows: [],
+      snapshot: providerSnapshot,
+    });
+
+    expect(summary.statusLabel).toBe(label);
+    expect(summary.ariaLabel).toBe(`Codex usage: ${label}`);
+  });
+});

--- a/apps/web/src/components/chat/environment/EnvironmentUsageSection.logic.ts
+++ b/apps/web/src/components/chat/environment/EnvironmentUsageSection.logic.ts
@@ -10,7 +10,10 @@ export interface EnvironmentProviderUsageSummary {
   readonly ariaLabel: string;
 }
 
-function providerUsageStatusLabel(snapshot: ServerProviderUsageSnapshot): string {
+function providerUsageStatusLabel(
+  snapshot: ServerProviderUsageSnapshot,
+  hasUsageLines: boolean,
+): string {
   switch (snapshot.status) {
     case "needs-auth":
       return "Sign in";
@@ -19,7 +22,7 @@ function providerUsageStatusLabel(snapshot: ServerProviderUsageSnapshot): string
     case "error":
       return "Unavailable";
     default:
-      return "No data";
+      return hasUsageLines ? "Connected" : "No data";
   }
 }
 
@@ -27,8 +30,9 @@ export function resolveEnvironmentProviderUsageSummary(input: {
   readonly providerName: string;
   readonly rows: ReadonlyArray<ProviderUsageDisplayRow>;
   readonly snapshot: ServerProviderUsageSnapshot;
+  readonly hasUsageLines: boolean;
 }): EnvironmentProviderUsageSummary {
-  const statusLabel = providerUsageStatusLabel(input.snapshot);
+  const statusLabel = providerUsageStatusLabel(input.snapshot, input.hasUsageLines);
   const rowSummary = input.rows
     .map((row) => `${row.label} ${row.remainingLabel} remaining`)
     .join(", ");

--- a/apps/web/src/components/chat/environment/EnvironmentUsageSection.logic.ts
+++ b/apps/web/src/components/chat/environment/EnvironmentUsageSection.logic.ts
@@ -1,0 +1,41 @@
+// FILE: EnvironmentUsageSection.logic.ts
+// Purpose: Pure compact-summary decisions for provider rows in the Environment panel.
+
+import type { ServerProviderUsageSnapshot } from "@synara/contracts";
+import type { ProviderUsageDisplayRow } from "~/lib/providerUsageDisplay";
+
+export interface EnvironmentProviderUsageSummary {
+  readonly rows: ReadonlyArray<ProviderUsageDisplayRow>;
+  readonly statusLabel: string;
+  readonly ariaLabel: string;
+}
+
+function providerUsageStatusLabel(snapshot: ServerProviderUsageSnapshot): string {
+  switch (snapshot.status) {
+    case "needs-auth":
+      return "Sign in";
+    case "unsupported":
+      return "Unsupported";
+    case "error":
+      return "Unavailable";
+    default:
+      return "No data";
+  }
+}
+
+export function resolveEnvironmentProviderUsageSummary(input: {
+  readonly providerName: string;
+  readonly rows: ReadonlyArray<ProviderUsageDisplayRow>;
+  readonly snapshot: ServerProviderUsageSnapshot;
+}): EnvironmentProviderUsageSummary {
+  const statusLabel = providerUsageStatusLabel(input.snapshot);
+  const rowSummary = input.rows
+    .map((row) => `${row.label} ${row.remainingLabel} remaining`)
+    .join(", ");
+
+  return {
+    rows: input.rows,
+    statusLabel,
+    ariaLabel: `${input.providerName} usage: ${rowSummary || statusLabel}`,
+  };
+}

--- a/apps/web/src/components/chat/environment/EnvironmentUsageSection.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentUsageSection.tsx
@@ -3,18 +3,23 @@
 
 import type { ServerProviderUsageSnapshot } from "@synara/contracts";
 import { providerUsageDisplayName } from "@synara/shared/providerUsage";
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import {
+  buildProviderUsageMenuModel,
   ProviderUsageMenuPopup,
-  useProviderUsageMenuModel,
 } from "~/components/ProviderUsageMenuControl";
 import { ProviderIcon } from "~/components/ProviderIcon";
 import { MenuTrigger } from "~/components/ui/menu";
+import { resolveProviderUsageSummary } from "~/hooks/useProviderUsageSummary";
+import { deriveAccountRateLimits, type ProviderRateLimit } from "~/lib/rateLimits";
 import {
   serverAllProviderUsageQueryOptions,
   serverSettingsQueryOptions,
 } from "~/lib/serverReactQuery";
+import { useStore } from "~/store";
+import { createAccountRateLimitThreadsSelector } from "~/storeSelectors";
 
 import { resolveEnvironmentProviderUsageSummary } from "./EnvironmentUsageSection.logic";
 import {
@@ -25,20 +30,41 @@ import {
   EnvironmentRowChevron,
 } from "./EnvironmentRow";
 
-function EnvironmentProviderUsageRow({ snapshot }: { snapshot: ServerProviderUsageSnapshot }) {
+const selectAccountRateLimitThreads = createAccountRateLimitThreadsSelector();
+
+function EnvironmentProviderUsageRow({
+  snapshot,
+  threadRateLimits,
+}: {
+  snapshot: ServerProviderUsageSnapshot;
+  threadRateLimits: ReadonlyArray<ProviderRateLimit>;
+}) {
   const provider = snapshot.provider;
   const providerName = providerUsageDisplayName(provider);
-  // The parent owns the one batch query. Supplying its snapshot prevents every row from
-  // starting another batch plus provider-scoped request while retaining thread-derived fallback.
-  const model = useProviderUsageMenuModel(provider, { providerSnapshot: snapshot });
+  const usageSummary = resolveProviderUsageSummary({
+    provider,
+    accountRateLimits: threadRateLimits,
+    authoritativeLiveSnapshot: snapshot,
+  });
+  const model = buildProviderUsageMenuModel({
+    provider,
+    providerSnapshot: snapshot,
+    usageSummary: { ...usageSummary, isLoading: false },
+  });
   const summary = resolveEnvironmentProviderUsageSummary({
     providerName,
     rows: model.rows,
     snapshot,
+    hasUsageLines: model.usageLines.length > 0,
   });
 
   return (
-    <ProviderUsageMenuPopup provider={provider} model={model} align="start">
+    <ProviderUsageMenuPopup
+      provider={provider}
+      model={model}
+      align="start"
+      showUsageLines={true}
+    >
       <MenuTrigger
         render={
           <button
@@ -89,6 +115,8 @@ function EnvironmentProviderUsageRow({ snapshot }: { snapshot: ServerProviderUsa
 export function EnvironmentUsageSection() {
   const usageQuery = useQuery(serverAllProviderUsageQueryOptions());
   const settingsQuery = useQuery(serverSettingsQueryOptions());
+  const threads = useStore(selectAccountRateLimitThreads);
+  const threadRateLimits = useMemo(() => deriveAccountRateLimits(threads), [threads]);
   // The server already filters the batch. Rechecking the live settings projection prevents a
   // just-disabled provider from lingering while React Query refreshes the previous batch.
   const snapshots = (usageQuery.data ?? []).filter(
@@ -102,7 +130,11 @@ export function EnvironmentUsageSection() {
   return (
     <EnvironmentLabeledSection label="Usage">
       {snapshots.map((snapshot) => (
-        <EnvironmentProviderUsageRow key={snapshot.provider} snapshot={snapshot} />
+        <EnvironmentProviderUsageRow
+          key={snapshot.provider}
+          snapshot={snapshot}
+          threadRateLimits={threadRateLimits}
+        />
       ))}
     </EnvironmentLabeledSection>
   );

--- a/apps/web/src/components/chat/environment/EnvironmentUsageSection.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentUsageSection.tsx
@@ -1,7 +1,9 @@
 // FILE: EnvironmentUsageSection.tsx
-// Purpose: "Usage" section of the Environment panel — same menu as the header chip.
+// Purpose: "Usage" section of the Environment panel — one compact menu per enabled provider.
 
-import type { ProviderKind } from "@synara/contracts";
+import type { ServerProviderUsageSnapshot } from "@synara/contracts";
+import { providerUsageDisplayName } from "@synara/shared/providerUsage";
+import { useQuery } from "@tanstack/react-query";
 
 import {
   ProviderUsageMenuPopup,
@@ -9,7 +11,12 @@ import {
 } from "~/components/ProviderUsageMenuControl";
 import { ProviderIcon } from "~/components/ProviderIcon";
 import { MenuTrigger } from "~/components/ui/menu";
+import {
+  serverAllProviderUsageQueryOptions,
+  serverSettingsQueryOptions,
+} from "~/lib/serverReactQuery";
 
+import { resolveEnvironmentProviderUsageSummary } from "./EnvironmentUsageSection.logic";
 import {
   ENVIRONMENT_ROW_CLASS_NAME,
   ENVIRONMENT_ROW_ICON_CLASS_NAME,
@@ -18,38 +25,85 @@ import {
   EnvironmentRowChevron,
 } from "./EnvironmentRow";
 
-export function EnvironmentUsageSection({ provider }: { provider: ProviderKind }) {
-  const model = useProviderUsageMenuModel(provider);
+function EnvironmentProviderUsageRow({ snapshot }: { snapshot: ServerProviderUsageSnapshot }) {
+  const provider = snapshot.provider;
+  const providerName = providerUsageDisplayName(provider);
+  // The parent owns the one batch query. Supplying its snapshot prevents every row from
+  // starting another batch plus provider-scoped request while retaining thread-derived fallback.
+  const model = useProviderUsageMenuModel(provider, { providerSnapshot: snapshot });
+  const summary = resolveEnvironmentProviderUsageSummary({
+    providerName,
+    rows: model.rows,
+    snapshot,
+  });
 
-  if (!model) {
+  return (
+    <ProviderUsageMenuPopup provider={provider} model={model} align="start">
+      <MenuTrigger
+        render={
+          <button
+            type="button"
+            className={ENVIRONMENT_ROW_CLASS_NAME}
+            aria-label={summary.ariaLabel}
+          />
+        }
+      >
+        <EnvironmentRowBody
+          icon={
+            <ProviderIcon
+              provider={provider}
+              tone="header"
+              className={ENVIRONMENT_ROW_ICON_CLASS_NAME}
+            />
+          }
+          label={providerName}
+          trailing={
+            <span className="flex items-center gap-1.5">
+              {summary.rows.length > 0 ? (
+                <span className="flex flex-col items-end gap-0.5 text-[length:var(--app-font-size-chat-meta,10px)] leading-none">
+                  {summary.rows.map((row) => (
+                    <span key={row.id} className="flex items-baseline gap-1.5">
+                      <span className="text-[var(--color-text-foreground-secondary)]">
+                        {row.label}
+                      </span>
+                      <span className="min-w-7 text-right text-[var(--color-text-foreground)]">
+                        {row.remainingLabel}
+                      </span>
+                    </span>
+                  ))}
+                </span>
+              ) : (
+                <span className="text-[length:var(--app-font-size-chat-meta,10px)] text-[var(--color-text-foreground-secondary)]">
+                  {summary.statusLabel}
+                </span>
+              )}
+              <EnvironmentRowChevron />
+            </span>
+          }
+        />
+      </MenuTrigger>
+    </ProviderUsageMenuPopup>
+  );
+}
+
+export function EnvironmentUsageSection() {
+  const usageQuery = useQuery(serverAllProviderUsageQueryOptions());
+  const settingsQuery = useQuery(serverSettingsQueryOptions());
+  // The server already filters the batch. Rechecking the live settings projection prevents a
+  // just-disabled provider from lingering while React Query refreshes the previous batch.
+  const snapshots = (usageQuery.data ?? []).filter(
+    (snapshot) => settingsQuery.data?.providers[snapshot.provider].enabled !== false,
+  );
+
+  if (snapshots.length === 0) {
     return null;
   }
 
   return (
     <EnvironmentLabeledSection label="Usage">
-      <ProviderUsageMenuPopup provider={provider} model={model} align="start">
-        <MenuTrigger
-          render={
-            <button
-              type="button"
-              className={ENVIRONMENT_ROW_CLASS_NAME}
-              aria-label={model.menuTitle}
-            />
-          }
-        >
-          <EnvironmentRowBody
-            icon={
-              <ProviderIcon
-                provider={provider}
-                tone="header"
-                className={ENVIRONMENT_ROW_ICON_CLASS_NAME}
-              />
-            }
-            label={model.primaryRow.remainingLabel}
-            trailing={<EnvironmentRowChevron />}
-          />
-        </MenuTrigger>
-      </ProviderUsageMenuPopup>
+      {snapshots.map((snapshot) => (
+        <EnvironmentProviderUsageRow key={snapshot.provider} snapshot={snapshot} />
+      ))}
     </EnvironmentLabeledSection>
   );
 }

--- a/apps/web/src/hooks/useProviderUsageSummary.ts
+++ b/apps/web/src/hooks/useProviderUsageSummary.ts
@@ -12,6 +12,7 @@ import { useQuery } from "@tanstack/react-query";
 import {
   normalizeOpenUsageSnapshot,
   normalizeOpenUsageUsageLines,
+  type OpenUsageUsageLine,
 } from "~/lib/openUsageRateLimits";
 import { openUsageProviderSnapshotQueryOptions } from "~/lib/openUsageReactQuery";
 import {
@@ -30,6 +31,69 @@ import {
   serverAllProviderUsageQueryOptions,
   serverProviderUsageSnapshotQueryOptions,
 } from "~/lib/serverReactQuery";
+
+export interface ProviderUsageSummaryData {
+  readonly learnMoreHref: string | null;
+  readonly rateLimits: ReadonlyArray<ProviderRateLimit>;
+  readonly usageLines: ReadonlyArray<OpenUsageUsageLine>;
+  readonly usageNotice: string | undefined;
+}
+
+export function resolveProviderUsageSummary(input: {
+  provider: ProviderKind | null;
+  accountRateLimits: ReadonlyArray<ProviderRateLimit>;
+  authoritativeLiveSnapshot: ServerGetProviderUsageSnapshotResult;
+  localUsageSnapshot?: ServerGetProviderUsageSnapshotResult | undefined;
+  openUsageSnapshot?: unknown;
+}): ProviderUsageSummaryData {
+  const blocksFallback = isProviderUsageSnapshotNonOk(input.authoritativeLiveSnapshot);
+  if (blocksFallback) {
+    return {
+      learnMoreHref: deriveProviderUsageLearnMoreHref(input.provider),
+      rateLimits: [],
+      usageLines: [],
+      usageNotice: undefined,
+    };
+  }
+
+  const derivedRateLimits = input.accountRateLimits.filter((rateLimit) =>
+    input.provider ? rateLimit.provider === input.provider : true,
+  );
+  const liveUsageRateLimit = normalizeServerProviderUsageRateLimit(
+    input.authoritativeLiveSnapshot,
+  );
+  const localUsageRateLimit = normalizeServerProviderUsageRateLimit(input.localUsageSnapshot);
+  const openUsageRateLimit = normalizeOpenUsageSnapshot(input.openUsageSnapshot, input.provider);
+  const rateLimits = mergeProviderRateLimits(
+    derivedRateLimits,
+    mergeProviderRateLimits(
+      liveUsageRateLimit ? [liveUsageRateLimit] : [],
+      mergeProviderRateLimits(
+        localUsageRateLimit ? [localUsageRateLimit] : [],
+        openUsageRateLimit ? [openUsageRateLimit] : [],
+      ),
+    ),
+  );
+
+  const liveUsageLines = normalizeServerProviderUsageLines(input.authoritativeLiveSnapshot);
+  const localUsageLines = normalizeServerProviderUsageLines(input.localUsageSnapshot);
+  const usageLines =
+    liveUsageLines.length > 0
+      ? liveUsageLines
+      : localUsageLines.length > 0
+        ? localUsageLines
+        : normalizeOpenUsageUsageLines(input.openUsageSnapshot);
+  const detail = input.authoritativeLiveSnapshot?.detail?.trim();
+
+  return {
+    learnMoreHref:
+      deriveRateLimitLearnMoreHref(rateLimits) ??
+      deriveProviderUsageLearnMoreHref(input.provider),
+    rateLimits,
+    usageLines,
+    usageNotice: detail ? detail : undefined,
+  };
+}
 
 export function useProviderUsageSummary(input: {
   provider: ProviderKind | null | undefined;
@@ -63,68 +127,24 @@ export function useProviderUsageSummary(input: {
     (snapshot) => snapshot.provider === provider,
   );
   const authoritativeLiveSnapshot = liveProviderSnapshot ?? input.providerSnapshot ?? null;
-  // Explicit live failures are authoritative; only fall back when no live snapshot exists.
-  const blocksProviderUsageFallback = isProviderUsageSnapshotNonOk(authoritativeLiveSnapshot);
   const accountRateLimits = input.threadRateLimits ?? deriveAccountRateLimits(input.threads ?? []);
-
-  let rateLimits: ReadonlyArray<ProviderRateLimit> = [];
-  if (!blocksProviderUsageFallback) {
-    const localSnapshot = localUsageSnapshotQuery.data ?? null;
-    const derivedRateLimits = accountRateLimits.filter((rateLimit) =>
-      provider ? rateLimit.provider === provider : true,
-    );
-    const liveUsageRateLimit = normalizeServerProviderUsageRateLimit(authoritativeLiveSnapshot);
-    const localUsageRateLimit = normalizeServerProviderUsageRateLimit(localSnapshot);
-    const openUsageSnapshot = normalizeOpenUsageSnapshot(openUsageSnapshotQuery.data, provider);
-    rateLimits = mergeProviderRateLimits(
-      derivedRateLimits,
-      mergeProviderRateLimits(
-        liveUsageRateLimit ? [liveUsageRateLimit] : [],
-        mergeProviderRateLimits(
-          localUsageRateLimit ? [localUsageRateLimit] : [],
-          openUsageSnapshot ? [openUsageSnapshot] : [],
-        ),
-      ),
-    );
-  }
-
-  let usageLines: ReturnType<typeof normalizeServerProviderUsageLines> = [];
-  if (!blocksProviderUsageFallback) {
-    const liveUsageLines = normalizeServerProviderUsageLines(authoritativeLiveSnapshot);
-    if (liveUsageLines.length > 0) {
-      usageLines = liveUsageLines;
-    } else {
-      const localUsageLines = normalizeServerProviderUsageLines(localUsageSnapshotQuery.data);
-      usageLines =
-        localUsageLines.length > 0
-          ? localUsageLines
-          : normalizeOpenUsageUsageLines(openUsageSnapshotQuery.data);
-    }
-  }
-
-  // A throttle/staleness note the server rides on an otherwise-ok snapshot (e.g. Claude serving the
-  // last values while Anthropic rate-limits). Only surfaced when the snapshot is actually shown —
-  // non-ok snapshots hide the section entirely, so their `detail` would never be seen anyway.
-  const detail = blocksProviderUsageFallback
-    ? undefined
-    : authoritativeLiveSnapshot?.detail?.trim();
-  const usageNotice = detail ? detail : undefined;
-
-  const learnMoreHref =
-    deriveRateLimitLearnMoreHref(rateLimits) ?? deriveProviderUsageLearnMoreHref(provider);
+  const summary = resolveProviderUsageSummary({
+    provider,
+    accountRateLimits,
+    authoritativeLiveSnapshot,
+    localUsageSnapshot: localUsageSnapshotQuery.data ?? null,
+    openUsageSnapshot: openUsageSnapshotQuery.data,
+  });
 
   const isLoading =
     shouldFetchLiveProviderUsage &&
     allProviderUsageQuery.isPending &&
     localUsageSnapshotQuery.isPending &&
-    rateLimits.length === 0 &&
-    usageLines.length === 0;
+    summary.rateLimits.length === 0 &&
+    summary.usageLines.length === 0;
 
   return {
     isLoading,
-    learnMoreHref,
-    rateLimits,
-    usageLines,
-    usageNotice,
+    ...summary,
   } as const;
 }

--- a/apps/web/src/lib/serverReactQuery.test.ts
+++ b/apps/web/src/lib/serverReactQuery.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   hasReconciledServerProviderStatuses,
+  invalidateProviderUsageQueries,
   LOCAL_SERVERS_VISIBLE_REFETCH_INTERVAL_MS,
   reconcileServerProviderStatuses,
   refreshServerConfigAfterTransportOpen,
@@ -216,6 +217,21 @@ describe("serverAllProviderUsageQueryOptions", () => {
     const options = serverAllProviderUsageQueryOptions();
 
     expect(options.queryKey).toEqual(serverQueryKeys.allProviderUsage());
+  });
+
+  it("invalidates batch and provider-scoped caches after enablement changes", async () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(serverQueryKeys.allProviderUsage(), []);
+    queryClient.setQueryData(serverQueryKeys.providerUsage("codex", null), null);
+
+    await invalidateProviderUsageQueries(queryClient);
+
+    expect(
+      queryClient.getQueryState(serverQueryKeys.allProviderUsage())?.isInvalidated,
+    ).toBe(true);
+    expect(
+      queryClient.getQueryState(serverQueryKeys.providerUsage("codex", null))?.isInvalidated,
+    ).toBe(true);
   });
 });
 

--- a/apps/web/src/lib/serverReactQuery.ts
+++ b/apps/web/src/lib/serverReactQuery.ts
@@ -23,6 +23,7 @@ export const serverQueryKeys = {
   localServers: () => ["server", "localServers"] as const,
   providerUsage: (provider: ProviderKind | null | undefined, homePath?: string | null) =>
     ["server", "providerUsage", provider ?? null, homePath ?? null] as const,
+  providerUsageRoot: () => ["server", "providerUsage"] as const,
   allProviderUsage: () => ["server", "allProviderUsage"] as const,
   profileStats: (utcOffsetMinutes: number) =>
     ["server", "profileStats", "peak-hour-v2", utcOffsetMinutes] as const,
@@ -307,6 +308,15 @@ export function serverProviderUsageSnapshotQueryOptions(input: {
 export async function fetchAllProviderUsage(input: ServerListProviderUsageInput = {}) {
   const api = ensureNativeApi();
   return api.server.listProviderUsage(input);
+}
+
+/** Provider enablement changes alter the membership of the batch and invalidate any
+ * provider-scoped result that may otherwise survive after a provider is disabled. */
+export async function invalidateProviderUsageQueries(queryClient: QueryClient): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: serverQueryKeys.allProviderUsage() }),
+    queryClient.invalidateQueries({ queryKey: serverQueryKeys.providerUsageRoot() }),
+  ]);
 }
 
 // Local profile + shareable-card core statistics. The client passes its own fixed

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -47,6 +47,7 @@ import { useFeedbackDialogStore } from "../feedbackDialogStore";
 import type { FeedbackThreadContext } from "../feedback";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import {
+  invalidateProviderUsageQueries,
   reconcileServerProviderStatuses,
   refreshServerConfigAfterTransportOpen,
   serverConfigQueryOptions,
@@ -2171,6 +2172,7 @@ function EventRouter() {
       queryClient.setQueryData(serverQueryKeys.settings(), payload.settings);
       if (didProviderEnablementChange(previousSettings, payload.settings)) {
         void queryClient.invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all });
+        void invalidateProviderUsageQueries(queryClient);
       }
       void queryClient.invalidateQueries({
         queryKey: serverSettingsQueryOptions().queryKey,


### PR DESCRIPTION
## What Changed

- Render one Environment usage row for every server-enabled provider instead of only the active chat provider.
- Show every reported rate-limit window in each compact row, including 5-hour and weekly limits.
- Reuse the shared batch snapshot across provider rows to avoid per-provider request fan-out.
- Remove disabled providers promptly by invalidating both batch and provider-scoped usage caches when enablement changes.
- Preserve provider-specific sign-in, unsupported, unavailable, and no-data states in the row and popover.

## Why

The Environment panel previously showed usage only for the active thread provider and reduced its compact summary to one primary limit. This hid other enabled providers and secondary windows such as weekly limits.

The server already exposes a batch of enabled-provider usage snapshots. Using that batch as the panel source makes all configured usage visible while avoiding redundant provider requests.

## UI Changes

The Usage section now shows one compact row per enabled provider, including every available usage window. Selecting a row opens the provider-specific usage popover.

| Before | After |
| --- | --- |
| <img width="311" height="643" alt="Environment Usage section before: only one active-provider summary" src="https://github.com/user-attachments/assets/15065c35-bdb6-4809-92c4-cf826fc97c09" /> | <img width="322" height="620" alt="Environment Usage section after: separate Codex and Claude rows with all reported windows" src="https://github.com/user-attachments/assets/03d0fef0-4dc4-447c-babc-155f94adb8db" /> |

No new animation was introduced. A short video demonstrating the changed multi-provider row and popover interaction is still required and has not yet been attached.

## Verification

- `bun run --cwd apps/web test src/components/chat/environment/EnvironmentUsageSection.logic.test.ts src/lib/providerUsageDisplay.test.ts src/lib/serverReactQuery.test.ts src/hooks/useProviderUsageSummary.test.tsx`
- `bun run --cwd apps/web test:browser src/components/chat/environment/EnvironmentUsageSection.browser.tsx`
- `bun run --cwd apps/web build`
- `git diff --check`

Not run: `bun fmt`, `bun lint`, or `bun typecheck`.

The change is cohesive, but GitHub classifies it as `size:L`; the small-and-focused checkbox is therefore left unchecked rather than overstated.

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
