### PR TITLE
Fix Command-number shortcuts in terminal threads

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -662,6 +662,69 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
+  it.effect("migrates numbered terminal workspace defaults without changing custom rules", () =>
+    Effect.gen(function* () {
+      const { keybindingsConfigPath } = yield* ServerConfig;
+      yield* writeKeybindingsConfig(keybindingsConfigPath, [
+        {
+          key: "mod+1",
+          command: "terminal.workspace.terminal",
+          when: "terminalWorkspaceOpen",
+        },
+        { key: "mod+2", command: "terminal.workspace.chat", when: "terminalWorkspaceOpen" },
+        {
+          key: "mod+1",
+          command: "thread.jump.1",
+          when: "!terminalFocus && !terminalWorkspaceOpen",
+        },
+        {
+          key: "mod+shift+3",
+          command: "thread.jump.3",
+          when: "!terminalFocus && !terminalWorkspaceOpen",
+        },
+      ]);
+
+      yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings;
+        yield* keybindings.syncDefaultKeybindingsOnStartup;
+      });
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      assert.isTrue(
+        persisted.some(
+          (entry) =>
+            entry.key === "ctrl+1" &&
+            entry.command === "terminal.workspace.terminal" &&
+            entry.when === "terminalWorkspaceOpen",
+        ),
+      );
+      assert.isTrue(
+        persisted.some(
+          (entry) =>
+            entry.key === "ctrl+2" &&
+            entry.command === "terminal.workspace.chat" &&
+            entry.when === "terminalWorkspaceOpen",
+        ),
+      );
+      assert.isTrue(
+        persisted.some(
+          (entry) =>
+            entry.key === "mod+1" &&
+            entry.command === "thread.jump.1" &&
+            entry.when === "(!terminalFocus && !terminalWorkspaceOpen) || isMac",
+        ),
+      );
+      assert.isTrue(
+        persisted.some(
+          (entry) =>
+            entry.key === "mod+shift+3" &&
+            entry.command === "thread.jump.3" &&
+            entry.when === "!terminalFocus && !terminalWorkspaceOpen",
+        ),
+      );
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
   it.effect("accepts synced composer picker keybindings without startup issues", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -104,8 +104,10 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+w", command: "terminal.close", when: "terminalFocus" },
   { key: "mod+shift+j", command: "terminal.workspace.newFullWidth" },
   { key: "mod+w", command: "terminal.workspace.closeActive", when: "terminalWorkspaceOpen" },
-  { key: "mod+1", command: "terminal.workspace.terminal", when: "terminalWorkspaceOpen" },
-  { key: "mod+2", command: "terminal.workspace.chat", when: "terminalWorkspaceOpen" },
+  // Keep workspace tabs on literal Ctrl so Cmd+1…9 remains consistent app navigation
+  // on macOS even when a thread was opened directly as a full-width terminal.
+  { key: "ctrl+1", command: "terminal.workspace.terminal", when: "terminalWorkspaceOpen" },
+  { key: "ctrl+2", command: "terminal.workspace.chat", when: "terminalWorkspaceOpen" },
   { key: "mod+shift+b", command: "browser.toggle", when: "!terminalFocus" },
   { key: "mod+d", command: "diff.toggle", when: "!terminalFocus" },
   // Cmd-only instead of mod so Ctrl+L remains available to shells on non-macOS.
@@ -138,15 +140,51 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   // app-level even with terminal focus; the web route captures it before xterm input.
   { key: "ctrl+tab", command: "view.recent.next" },
   { key: "ctrl+shift+tab", command: "view.recent.previous" },
-  { key: "mod+1", command: "thread.jump.1", when: "!terminalFocus && !terminalWorkspaceOpen" },
-  { key: "mod+2", command: "thread.jump.2", when: "!terminalFocus && !terminalWorkspaceOpen" },
-  { key: "mod+3", command: "thread.jump.3", when: "!terminalFocus && !terminalWorkspaceOpen" },
-  { key: "mod+4", command: "thread.jump.4", when: "!terminalFocus && !terminalWorkspaceOpen" },
-  { key: "mod+5", command: "thread.jump.5", when: "!terminalFocus && !terminalWorkspaceOpen" },
-  { key: "mod+6", command: "thread.jump.6", when: "!terminalFocus && !terminalWorkspaceOpen" },
-  { key: "mod+7", command: "thread.jump.7", when: "!terminalFocus && !terminalWorkspaceOpen" },
-  { key: "mod+8", command: "thread.jump.8", when: "!terminalFocus && !terminalWorkspaceOpen" },
-  { key: "mod+9", command: "thread.jump.9", when: "!terminalFocus && !terminalWorkspaceOpen" },
+  {
+    key: "mod+1",
+    command: "thread.jump.1",
+    when: "(!terminalFocus && !terminalWorkspaceOpen) || isMac",
+  },
+  {
+    key: "mod+2",
+    command: "thread.jump.2",
+    when: "(!terminalFocus && !terminalWorkspaceOpen) || isMac",
+  },
+  {
+    key: "mod+3",
+    command: "thread.jump.3",
+    when: "(!terminalFocus && !terminalWorkspaceOpen) || isMac",
+  },
+  {
+    key: "mod+4",
+    command: "thread.jump.4",
+    when: "(!terminalFocus && !terminalWorkspaceOpen) || isMac",
+  },
+  {
+    key: "mod+5",
+    command: "thread.jump.5",
+    when: "(!terminalFocus && !terminalWorkspaceOpen) || isMac",
+  },
+  {
+    key: "mod+6",
+    command: "thread.jump.6",
+    when: "(!terminalFocus && !terminalWorkspaceOpen) || isMac",
+  },
+  {
+    key: "mod+7",
+    command: "thread.jump.7",
+    when: "(!terminalFocus && !terminalWorkspaceOpen) || isMac",
+  },
+  {
+    key: "mod+8",
+    command: "thread.jump.8",
+    when: "(!terminalFocus && !terminalWorkspaceOpen) || isMac",
+  },
+  {
+    key: "mod+9",
+    command: "thread.jump.9",
+    when: "(!terminalFocus && !terminalWorkspaceOpen) || isMac",
+  },
   // Copying the active thread id is not terminal input on macOS, but Ctrl+Shift+C is the
   // terminal copy chord on Linux/Windows, so it keeps the same `|| isMac` escape hatch.
   { key: "mod+shift+c", command: "thread.copyId", when: "!terminalFocus || isMac" },
@@ -630,6 +668,14 @@ const RECENT_VIEW_SHORTCUT_BY_COMMAND: Partial<Record<KeybindingRule["command"],
 // regardless of focus while Linux/Windows keep yielding Ctrl-chords to the shell.
 const OUTDATED_CREATION_TERMINAL_GUARD = "!terminalFocus";
 const RELAXED_CREATION_TERMINAL_GUARD = "!terminalFocus || isMac";
+const OUTDATED_THREAD_JUMP_GUARD = "!terminalFocus && !terminalWorkspaceOpen";
+const RELAXED_THREAD_JUMP_GUARD = "(!terminalFocus && !terminalWorkspaceOpen) || isMac";
+const OUTDATED_WORKSPACE_TAB_SHORTCUT_BY_COMMAND: Partial<
+  Record<KeybindingRule["command"], string>
+> = {
+  "terminal.workspace.terminal": "mod+1",
+  "terminal.workspace.chat": "mod+2",
+};
 const CREATION_COMMANDS_WITH_TERMINAL_ESCAPE = new Set<KeybindingRule["command"]>([
   "chat.new",
   "chat.newLatestProject",
@@ -751,6 +797,41 @@ function relaxCreationCommandTerminalGuards(rules: readonly KeybindingRule[]): {
     }
     migratedCount += 1;
     return { ...rule, when: RELAXED_CREATION_TERMINAL_GUARD };
+  });
+  return { rules: next, migratedCount };
+}
+
+// The original full-width workspace reused mod+1/mod+2 for its terminal/chat tabs and
+// disabled all numbered thread jumps while the workspace was open. That made Cmd+1…9
+// stop being app navigation when a macOS thread opened as a terminal. Move only the exact
+// shipped tab defaults to literal Ctrl, and relax only the exact shipped thread-jump guard;
+// custom keys and conditions remain untouched.
+function migrateNumberedTerminalWorkspaceDefaults(rules: readonly KeybindingRule[]): {
+  readonly rules: KeybindingRule[];
+  readonly migratedCount: number;
+} {
+  let migratedCount = 0;
+  const next = rules.map((rule) => {
+    const outdatedWorkspaceShortcut = OUTDATED_WORKSPACE_TAB_SHORTCUT_BY_COMMAND[rule.command];
+    if (
+      outdatedWorkspaceShortcut !== undefined &&
+      rule.key === outdatedWorkspaceShortcut &&
+      rule.when === "terminalWorkspaceOpen"
+    ) {
+      migratedCount += 1;
+      return { ...rule, key: rule.command === "terminal.workspace.terminal" ? "ctrl+1" : "ctrl+2" };
+    }
+
+    if (
+      /^thread\.jump\.[1-9]$/.test(rule.command) &&
+      rule.key === `mod+${rule.command.slice(-1)}` &&
+      rule.when === OUTDATED_THREAD_JUMP_GUARD
+    ) {
+      migratedCount += 1;
+      return { ...rule, when: RELAXED_THREAD_JUMP_GUARD };
+    }
+
+    return rule;
   });
   return { rules: next, migratedCount };
 }
@@ -1010,9 +1091,13 @@ const makeKeybindings = Effect.gen(function* () {
     migratedDefaultRuleCount += sidebarSearchMigration.migratedCount;
     const relaxed = relaxCreationCommandTerminalGuards(sidebarSearchMigration.rules);
     migratedDefaultRuleCount += relaxed.migratedCount;
+    const numberedTerminalWorkspaceMigration = migrateNumberedTerminalWorkspaceDefaults(
+      relaxed.rules,
+    );
+    migratedDefaultRuleCount += numberedTerminalWorkspaceMigration.migratedCount;
 
     return {
-      keybindings: relaxed.rules,
+      keybindings: numberedTerminalWorkspaceMigration.rules,
       issues,
       migratedLegacyCommandCount,
       migratedDefaultRuleCount,

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -273,12 +273,12 @@ const DEFAULT_BINDINGS = compile([
     whenAst: whenIdentifier("terminalWorkspaceOpen"),
   },
   {
-    shortcut: modShortcut("1"),
+    shortcut: ctrlShortcut("1"),
     command: "terminal.workspace.terminal",
     whenAst: whenIdentifier("terminalWorkspaceOpen"),
   },
   {
-    shortcut: modShortcut("2"),
+    shortcut: ctrlShortcut("2"),
     command: "terminal.workspace.chat",
     whenAst: whenIdentifier("terminalWorkspaceOpen"),
   },
@@ -385,78 +385,17 @@ const DEFAULT_BINDINGS = compile([
     command: `space.jump.${index + 1}` as KeybindingCommand,
     whenAst: whenModChordAllowed,
   })),
-  {
-    shortcut: modShortcut("1"),
-    command: "thread.jump.1",
-    whenAst: whenAnd(
-      whenNot(whenIdentifier("terminalFocus")),
-      whenNot(whenIdentifier("terminalWorkspaceOpen")),
+  ...Array.from({ length: 9 }, (_, index) => ({
+    shortcut: modShortcut(String(index + 1)),
+    command: `thread.jump.${index + 1}` as KeybindingCommand,
+    whenAst: whenOr(
+      whenAnd(
+        whenNot(whenIdentifier("terminalFocus")),
+        whenNot(whenIdentifier("terminalWorkspaceOpen")),
+      ),
+      whenIdentifier("isMac"),
     ),
-  },
-  {
-    shortcut: modShortcut("2"),
-    command: "thread.jump.2",
-    whenAst: whenAnd(
-      whenNot(whenIdentifier("terminalFocus")),
-      whenNot(whenIdentifier("terminalWorkspaceOpen")),
-    ),
-  },
-  {
-    shortcut: modShortcut("3"),
-    command: "thread.jump.3",
-    whenAst: whenAnd(
-      whenNot(whenIdentifier("terminalFocus")),
-      whenNot(whenIdentifier("terminalWorkspaceOpen")),
-    ),
-  },
-  {
-    shortcut: modShortcut("4"),
-    command: "thread.jump.4",
-    whenAst: whenAnd(
-      whenNot(whenIdentifier("terminalFocus")),
-      whenNot(whenIdentifier("terminalWorkspaceOpen")),
-    ),
-  },
-  {
-    shortcut: modShortcut("5"),
-    command: "thread.jump.5",
-    whenAst: whenAnd(
-      whenNot(whenIdentifier("terminalFocus")),
-      whenNot(whenIdentifier("terminalWorkspaceOpen")),
-    ),
-  },
-  {
-    shortcut: modShortcut("6"),
-    command: "thread.jump.6",
-    whenAst: whenAnd(
-      whenNot(whenIdentifier("terminalFocus")),
-      whenNot(whenIdentifier("terminalWorkspaceOpen")),
-    ),
-  },
-  {
-    shortcut: modShortcut("7"),
-    command: "thread.jump.7",
-    whenAst: whenAnd(
-      whenNot(whenIdentifier("terminalFocus")),
-      whenNot(whenIdentifier("terminalWorkspaceOpen")),
-    ),
-  },
-  {
-    shortcut: modShortcut("8"),
-    command: "thread.jump.8",
-    whenAst: whenAnd(
-      whenNot(whenIdentifier("terminalFocus")),
-      whenNot(whenIdentifier("terminalWorkspaceOpen")),
-    ),
-  },
-  {
-    shortcut: modShortcut("9"),
-    command: "thread.jump.9",
-    whenAst: whenAnd(
-      whenNot(whenIdentifier("terminalFocus")),
-      whenNot(whenIdentifier("terminalWorkspaceOpen")),
-    ),
-  },
+  })),
   {
     shortcut: modShortcut("c", { shiftKey: true }),
     command: "thread.copyId",
@@ -809,13 +748,13 @@ describe("thread jump shortcuts", () => {
     );
   });
 
-  it("preserves terminal workspace shortcuts when the workspace is open", () => {
+  it("keeps macOS numbered thread jumps active when the terminal workspace is open", () => {
     assert.strictEqual(
       resolveShortcutCommand(event({ key: "1", metaKey: true }), DEFAULT_BINDINGS, {
         platform: "MacIntel",
-        context: { terminalFocus: false, terminalWorkspaceOpen: true },
+        context: { terminalFocus: true, terminalWorkspaceOpen: true },
       }),
-      "terminal.workspace.terminal",
+      "thread.jump.1",
     );
   });
 
@@ -832,7 +771,7 @@ describe("thread jump shortcuts", () => {
         context: { terminalWorkspaceOpen: false },
       }),
     );
-    assert.isFalse(
+    assert.isTrue(
       shouldShowThreadJumpHints(event({ key: "Meta", metaKey: true }), DEFAULT_BINDINGS, {
         platform: "MacIntel",
         context: { terminalWorkspaceOpen: true },
@@ -972,13 +911,20 @@ describe("workspace terminal tab shortcuts", () => {
     );
   });
 
-  it("prefers workspace tab shortcuts while open and thread jumps otherwise", () => {
+  it("keeps Ctrl for workspace tabs and Cmd for thread jumps on macOS", () => {
     assert.strictEqual(
-      resolveShortcutCommand(event({ key: "1", metaKey: true }), DEFAULT_BINDINGS, {
+      resolveShortcutCommand(event({ key: "1", ctrlKey: true }), DEFAULT_BINDINGS, {
         platform: "MacIntel",
-        context: { terminalWorkspaceOpen: true },
+        context: { terminalWorkspaceOpen: true, terminalFocus: true },
       }),
       "terminal.workspace.terminal",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "2", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalWorkspaceOpen: true, terminalFocus: true },
+      }),
+      "thread.jump.2",
     );
     assert.strictEqual(
       resolveShortcutCommand(event({ key: "2", ctrlKey: true }), DEFAULT_BINDINGS, {
@@ -986,13 +932,6 @@ describe("workspace terminal tab shortcuts", () => {
         context: { terminalWorkspaceOpen: true },
       }),
       "terminal.workspace.chat",
-    );
-    assert.strictEqual(
-      resolveShortcutCommand(event({ key: "1", metaKey: true }), DEFAULT_BINDINGS, {
-        platform: "MacIntel",
-        context: { terminalWorkspaceOpen: false },
-      }),
-      "thread.jump.1",
     );
   });
 
@@ -1019,7 +958,7 @@ describe("workspace terminal tab shortcuts", () => {
       "terminal.workspace.closeActive",
     );
     assert.strictEqual(
-      resolveShortcutCommand(event({ key: "1", metaKey: true }), legacyBindings, {
+      resolveShortcutCommand(event({ key: "1", ctrlKey: true }), legacyBindings, {
         platform: "MacIntel",
         context: { terminalWorkspaceOpen: true },
       }),
@@ -1127,7 +1066,7 @@ describe("shortcutLabelForCommand", () => {
     assert.strictEqual(shortcutLabelForCommand(DEFAULT_BINDINGS, "chat.find", "Win32"), "Ctrl+F");
     assert.strictEqual(
       shortcutLabelForCommand(DEFAULT_BINDINGS, "terminal.workspace.terminal", "MacIntel"),
-      "⌘1",
+      "⌃1",
     );
     assert.strictEqual(
       shortcutLabelForCommand(DEFAULT_BINDINGS, "terminal.workspace.newFullWidth", "MacIntel"),

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -70,9 +70,12 @@ function whenOr(left: KeybindingWhenNode, right: KeybindingWhenNode): Keybinding
 }
 
 const whenNotTerminalFocus = whenNot(whenIdentifier("terminalFocus"));
-const whenThreadJumpAvailable = whenAnd(
-  whenNotTerminalFocus,
-  whenNot(whenIdentifier("terminalWorkspaceOpen")),
+// Cmd+1…9 is app navigation on macOS, including from a focused/full-width terminal.
+// On Linux/Windows `mod` is Ctrl, so keep yielding the chord to the shell and to the
+// terminal workspace's Ctrl+1/Ctrl+2 tabs while that surface is open.
+const whenThreadJumpAvailable = whenOr(
+  whenAnd(whenNotTerminalFocus, whenNot(whenIdentifier("terminalWorkspaceOpen"))),
+  whenIdentifier("isMac"),
 );
 // App-level `mod` chords (new chat/terminal/provider chat/split, copy thread id) bind to
 // `mod`, which is Cmd on macOS. xterm never forwards a Cmd-chord to the PTY, so a bare
@@ -270,12 +273,12 @@ export const DEFAULT_SHORTCUT_FALLBACKS: ResolvedKeybindingsConfig = [
   },
   {
     command: "terminal.workspace.terminal",
-    shortcut: commandShortcut("1"),
+    shortcut: commandShortcut("1", { ctrlKey: true, modKey: false }),
     whenAst: whenIdentifier("terminalWorkspaceOpen"),
   },
   {
     command: "terminal.workspace.chat",
-    shortcut: commandShortcut("2"),
+    shortcut: commandShortcut("2", { ctrlKey: true, modKey: false }),
     whenAst: whenIdentifier("terminalWorkspaceOpen"),
   },
 ];

--- a/apps/web/src/shortcutsSheet.test.ts
+++ b/apps/web/src/shortcutsSheet.test.ts
@@ -68,11 +68,11 @@ describe("buildShortcutSheetSections", () => {
     expect(sections[2]?.entries[0]?.shortcutLabel).toBe("⌘R");
   });
 
-  it("switches to workspace shortcuts when the workspace is open", () => {
+  it("separates macOS workspace tabs from thread jumps while the workspace is open", () => {
     const sections = buildShortcutSheetSections({
       keybindings: [],
       projectScripts: [],
-      platform: "Linux",
+      platform: "MacIntel",
       context: {
         terminalFocus: false,
         terminalOpen: true,
@@ -82,13 +82,13 @@ describe("buildShortcutSheetSections", () => {
 
     expect(
       sections[0]?.entries.some(
-        (entry) => entry.id === "terminal.workspace.terminal" && entry.shortcutLabel === "Ctrl+1",
+        (entry) => entry.id === "terminal.workspace.terminal" && entry.shortcutLabel === "⌃1",
       ),
     ).toBe(true);
     expect(sections[1]?.title).toBe("Outside workspace mode");
     expect(
       sections[1]?.entries.some(
-        (entry) => entry.id === "thread.jump.1" && entry.shortcutLabel === "Ctrl+1",
+        (entry) => entry.id === "thread.jump.1" && entry.shortcutLabel === "⌘1",
       ),
     ).toBe(true);
   });


### PR DESCRIPTION
## What Changed

- Keep `Command+1` through `Command+9` available for visible-thread navigation on macOS, including when xterm is focused or a thread opens as a full-width terminal.
- Move terminal/chat workspace tab switching to literal `Control+1` and `Control+2`, so it no longer shadows thread navigation.
- Migrate only the exact shipped defaults in existing keybinding files while preserving custom keys and conditions.
- Update shortcut labels and focused coverage for macOS and Linux behavior.

## Why

On macOS, `Command+1` through `Command+9` is app-level thread navigation, but the terminal workspace reused `mod+1` and `mod+2` for its tabs and disabled numbered thread jumps while that workspace was open. This made the same shortcut behave differently when xterm had focus or a thread opened as a full-width terminal.

Using literal Control for terminal workspace tabs keeps Command-number navigation consistent on macOS while preserving existing Linux and Windows behavior, where Control-number chords continue to yield to the shell when appropriate. The migration is limited to the exact shipped defaults so custom keybindings are not rewritten.

## UI Changes

The shortcuts sheet now shows `⌃1` for the terminal tab while retaining `⌘1` for visible-thread navigation.

| Before | After |
| --- | --- |
| <img width="506" alt="Before: terminal tab uses Command 1 and numbered thread navigation is unavailable in terminal workspace mode" src="https://raw.githubusercontent.com/NachoooLK/synara/8f418088e26b99cfb6b15e645394e2aee664eed7/pr-843/before-keybindings.png" /> | <img width="506" alt="After: terminal tab uses Control 1 and Command 1 remains available for visible-thread navigation" src="https://raw.githubusercontent.com/NachoooLK/synara/8f418088e26b99cfb6b15e645394e2aee664eed7/pr-843/after-keybindings.png" /> |

These are focused Chromium captures of the real `ShortcutsDialog` component before and after the change. A terminal-focus interaction video is still pending.

## Verification

- `apps/web`: `bun run test src/keybindings.test.ts src/shortcutsSheet.test.ts` — 83 passed
- `apps/server`: `bun run test src/keybindings.test.ts` — 37 passed
- Targeted `oxfmt` check passed.
- Targeted `oxlint` completed with 0 errors and 1 pre-existing `no-map-spread` warning.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
