### PR TITLE
Fix thread-specific pull request attribution

### DIFF
--- a/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
@@ -34,6 +34,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 
 import { AutomationService } from "../../automation/Services/AutomationService.ts";
 import { GitCore } from "../../git/Services/GitCore.ts";
+import { GitManager } from "../../git/Services/GitManager.ts";
 import { OrchestrationEngineService } from "../../orchestration/Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
 import { ProjectionTurnRepository } from "../../persistence/Services/ProjectionTurns.ts";
@@ -779,6 +780,28 @@ function makeHarnessLayer(
       ),
   } as unknown as (typeof GitCore)["Service"]);
 
+  const gitManagerLayer = Layer.succeed(GitManager, {
+    resolvePullRequest: ({ reference }: { reference: string }) =>
+      Effect.succeed({
+        pullRequest: {
+          number: 841,
+          title: "Fix created-at thread ordering",
+          url:
+            reference.startsWith("http://") || reference.startsWith("https://")
+              ? reference
+              : "https://github.com/Emanuele-web04/synara/pull/841",
+          baseBranch: "main",
+          headBranch: "fix/created-at-thread-order",
+          state: "open",
+          isDraft: false,
+          mergeability: "mergeable",
+          additions: 12,
+          deletions: 4,
+          changedFiles: 2,
+        },
+      }),
+  } as unknown as (typeof GitManager)["Service"]);
+
   const providerDiscoveryLayer = Layer.succeed(ProviderDiscoveryService, {
     listModels: ({ provider }: { provider: string }) => {
       const modelsByProvider: Record<string, ReadonlyArray<Record<string, unknown>>> = {
@@ -1130,6 +1153,7 @@ function makeHarnessLayer(
     Layer.provide(engineLayer),
     Layer.provide(automationLayer),
     Layer.provide(gitLayer),
+    Layer.provide(gitManagerLayer),
     Layer.provide(providerDiscoveryLayer),
     Layer.provide(providerHealthLayer),
     Layer.provide(ServerSettingsService.layerTest()),
@@ -1437,7 +1461,7 @@ describe("AgentGateway", () => {
             tools: Array<{
               name: string;
               description?: string;
-              inputSchema: { properties?: Record<string, unknown> };
+              inputSchema: { properties?: Record<string, unknown>; required?: string[] };
             }>;
           };
         }
@@ -1459,6 +1483,7 @@ describe("AgentGateway", () => {
         "synara_send_message",
         "synara_interrupt_thread",
         "synara_set_thread_title",
+        "synara_set_thread_pull_request",
         "synara_set_thread_archived",
         "synara_set_thread_goal",
         "synara_create_automation",
@@ -1529,6 +1554,13 @@ describe("AgentGateway", () => {
       assert.property(setThreadGoal?.inputSchema.properties, "blocked");
       assert.include(setThreadGoal?.description ?? "", "achieved: true");
       assert.include(setThreadGoal?.description ?? "", "blocked: true");
+
+      const setThreadPullRequest = tools.find(
+        (tool) => tool.name === "synara_set_thread_pull_request",
+      );
+      assert.include(setThreadPullRequest?.description ?? "", "own deliverable");
+      assert.include(setThreadPullRequest?.description ?? "", "only reviews");
+      assert.deepEqual(setThreadPullRequest?.inputSchema.required, ["reference"]);
 
       const createAutomation = tools.find((tool) => tool.name === "synara_create_automation");
       assert.include(createAutomation?.description ?? "", "self-contained brief");
@@ -4834,6 +4866,37 @@ describe("AgentGateway", () => {
         type: "thread.meta.update",
         threadId: "thread-child",
         goal: "",
+      });
+    }).pipe(Effect.provide(gatewayLayer));
+  });
+
+  it.effect("associates a resolved pull request with the calling thread", () => {
+    const { gatewayLayer, makeHarness } = makeHarnessLayer(baseThreads);
+    return Effect.gen(function* () {
+      const harness = yield* makeHarness;
+      const response = yield* harness.callTool({
+        token: "token-parent",
+        name: "synara_set_thread_pull_request",
+        args: { reference: "https://github.com/Emanuele-web04/synara/pull/841" },
+      });
+
+      assert.isFalse(isToolError(response.result), toolErrorText(response.result));
+      const result = toolResultJson(response.result);
+      assert.equal(result.threadId, "thread-parent");
+      assert.deepInclude(result.pullRequest as Record<string, unknown>, {
+        number: 841,
+        headBranch: "fix/created-at-thread-order",
+        state: "open",
+      });
+      const dispatched = harness.dispatched[0] as unknown as Record<string, unknown>;
+      assert.deepInclude(dispatched, {
+        type: "thread.meta.update",
+        threadId: "thread-parent",
+      });
+      assert.deepInclude(dispatched.lastKnownPr as Record<string, unknown>, {
+        number: 841,
+        headBranch: "fix/created-at-thread-order",
+        state: "open",
       });
     }).pipe(Effect.provide(gatewayLayer));
   });

--- a/apps/server/src/agentGateway/Layers/AgentGateway.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.ts
@@ -30,6 +30,7 @@ import { runtimeModeEscalatesPrivilege } from "@synara/shared/runtimeMode";
 import { Effect, Layer, Option } from "effect";
 
 import { GitCore } from "../../git/Services/GitCore.ts";
+import { GitManager } from "../../git/Services/GitManager.ts";
 import { ServerConfig } from "../../config.ts";
 import { OrchestrationEngineService } from "../../orchestration/Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
@@ -112,6 +113,7 @@ export const makeAgentGateway = Effect.gen(function* () {
   const orchestrationEngine = yield* OrchestrationEngineService;
   const automationService = yield* AutomationService;
   const git = yield* GitCore;
+  const gitManager = yield* GitManager;
   const providerDiscovery = yield* ProviderDiscoveryService;
   const providerHealth = yield* ProviderHealth;
   const serverSettings = yield* ServerSettingsService;
@@ -544,6 +546,70 @@ export const makeAgentGateway = Effect.gen(function* () {
       }).pipe(Effect.catch((error) => Effect.succeed(mcpToolResultError(errorText(error))))),
   };
 
+  const setThreadPullRequest: ToolEntry = {
+    requiredCapability: "thread:write",
+    requiresActiveTurn: true,
+    definition: {
+      name: "synara_set_thread_pull_request",
+      description:
+        "Associate a pull request with a Synara thread. Use this after successfully creating the pull request that represents that thread's own deliverable. Do not associate pull requests that the thread only reviews, references, or discusses. Defaults to your own thread when threadId is omitted.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          threadId: {
+            type: "string",
+            description: "Thread that owns the pull request. Defaults to your own thread.",
+          },
+          reference: {
+            type: "string",
+            description: "GitHub pull request URL or number resolvable from the thread repository.",
+          },
+        },
+        required: ["reference"],
+        additionalProperties: false,
+      },
+      annotations: { title: "Associate a pull request", ...WRITE_TOOL_ANNOTATIONS },
+    },
+    handler: (args, context) =>
+      Effect.gen(function* () {
+        const threadId = readStringArg(args, "threadId") ?? context.callerThreadId;
+        const reference = readStringArg(args, "reference", { required: true })!;
+        const caller = yield* requireThreadShell(context.callerThreadId);
+        const target = yield* requireThreadShell(threadId);
+        yield* assertCallerMayDriveThread(caller, target);
+
+        const project = Option.getOrUndefined(
+          yield* snapshotQuery
+            .getProjectShellById(target.projectId)
+            .pipe(Effect.mapError((error) => new ToolInputError(errorText(error)))),
+        );
+        if (!project) {
+          return yield* Effect.fail(
+            new ToolInputError(`Project for thread "${threadId}" was not found.`),
+          );
+        }
+        const cwd = resolveThreadWorkspaceCwd({ thread: target, projects: [project] });
+        if (!cwd) {
+          return yield* Effect.fail(
+            new ToolInputError(`Git workspace for thread "${threadId}" is unavailable.`),
+          );
+        }
+
+        const { pullRequest } = yield* gitManager
+          .resolvePullRequest({ cwd, reference })
+          .pipe(Effect.mapError((error) => new ToolInputError(errorText(error))));
+        yield* orchestrationEngine
+          .dispatch({
+            type: "thread.meta.update",
+            commandId: CommandId.makeUnsafe(`agent:${randomUUID()}:pull-request`),
+            threadId: target.id,
+            lastKnownPr: pullRequest,
+          })
+          .pipe(Effect.mapError((error) => new ToolInputError(errorText(error))));
+        return mcpToolResultJson({ threadId: target.id, pullRequest });
+      }).pipe(Effect.catch((error) => Effect.succeed(mcpToolResultError(errorText(error))))),
+  };
+
   const setThreadArchived: ToolEntry = {
     requiredCapability: "thread:write",
     requiresActiveTurn: true,
@@ -725,6 +791,7 @@ export const makeAgentGateway = Effect.gen(function* () {
     sendMessage,
     interruptThread,
     setThreadTitle,
+    setThreadPullRequest,
     setThreadArchived,
     setThreadGoal,
     ...automationTools,

--- a/apps/server/src/agentGateway/harnessPolicy.test.ts
+++ b/apps/server/src/agentGateway/harnessPolicy.test.ts
@@ -16,6 +16,9 @@ describe("Synara harness policy", () => {
     assert.include(policy, "one exact synara_create_threads plan");
     assert.include(policy, "before returning an operationId");
     assert.include(policy, "synara_wait_for_threads");
+    assert.include(policy, "synara_set_thread_pull_request");
+    assert.include(policy, "current thread's own deliverable");
+    assert.include(policy, "only reviews, references, or discusses");
     assert.include(policy, "Use the browser_* tools");
     assert.include(policy, "exact thread-scoped Electron page Synara surfaces to the user");
     assert.include(policy, "continue in the background");

--- a/apps/server/src/agentGateway/harnessPolicy.ts
+++ b/apps/server/src/agentGateway/harnessPolicy.ts
@@ -3,7 +3,7 @@ import type { ProviderKind } from "@synara/contracts";
 import { AUTOMATION_AUTHORING_GUIDANCE } from "./automationAuthoringGuidance.ts";
 
 /** Canonical, versioned host policy delivered to every supported provider. */
-export const SYNARA_HARNESS_POLICY_VERSION = "2026-08-25.2";
+export const SYNARA_HARNESS_POLICY_VERSION = "2026-08-30.1";
 export const SYNARA_HARNESS_POLICY_MARKER = `[Synara harness policy ${SYNARA_HARNESS_POLICY_VERSION}]`;
 
 export interface SynaraHarnessCapabilities {
@@ -32,6 +32,7 @@ export function renderSynaraHarnessPolicy(capabilities: SynaraHarnessCapabilitie
         'If device_boot returns kind "boot-limit-reached", Synara has hit its cap on simulators it booted: relay the listed devices and ask the user which to shut down rather than retrying. device_open_url always requires explicit user approval. If a device tool reports DeviceApprovalRequired, the action was refused before it ran because this session has no approval gate: explain that the user must do it from the device pane and do not retry it.',
         "A simulator is not a real device: Settings omits hardware-backed panes such as Airplane Mode, Cellular, and Face ID enrollment, and Developer options appear only once the runtime exposes them. If a toggle the user asked for does not exist in the tree, say so plainly instead of hunting for it or substituting a different setting.",
         "For thread discovery and diagnosis, use synara_list_threads, synara_read_thread, synara_read_thread_activity, synara_read_thread_events, synara_read_thread_runtime_events, and synara_diagnose_thread before inspecting Synara's SQLite files or process logs. Fall back to host storage only when a tool's coverage metadata says the required evidence is unavailable.",
+        "After successfully creating a pull request for the current thread's own deliverable, call synara_set_thread_pull_request with its URL. Never associate a pull request that the thread only reviews, references, or discusses.",
         "Provider-native subagent or Task tools are implementation details: they do not create Synara threads and must not substitute for an explicit request to create Synara threads.",
         "For a plural thread request, submit one exact synara_create_threads plan. The array length is the exact requested count.",
         "If synara_create_threads rejects the plan during validation or preflight before returning an operationId, correct that same plan and retry it with the same requestId. This is safe because no durable operation, thread, or worktree was created.",

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -193,7 +193,7 @@ export function makeServerRuntimeServicesLayer(
     Layer.provideMerge(agentGatewayCredentialsLayer),
     Layer.provideMerge(automationServiceLayer),
     Layer.provideMerge(runtimeServicesLayer),
-    Layer.provideMerge(GitCoreLive),
+    Layer.provideMerge(GitLayerLive),
     Layer.provideMerge(ProjectionTurnRepositoryLive),
     Layer.provideMerge(AgentGatewayOperationRepositoryLive),
     Layer.provideMerge(OrchestrationEventDeliveryRepositoryLive),

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -136,7 +136,7 @@ describe("shouldUseLivePullRequestForSidebarThread", () => {
     ).toBe(true);
   });
 
-  it("still requires a branch match for a shared project root", () => {
+  it("never attributes live PR data from a shared project root", () => {
     expect(
       shouldUseLivePullRequestForSidebarThread({
         threadBranch: "feature/another-thread",
@@ -150,7 +150,7 @@ describe("shouldUseLivePullRequestForSidebarThread", () => {
         liveBranch: "feat/agent-created-branch",
         hasDedicatedWorktree: false,
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("does not use live PR data for a detached worktree", () => {
@@ -193,6 +193,33 @@ describe("resolveSidebarThreadPullRequest", () => {
         persistedPullRequest: persisted,
       }),
     ).toBe(persisted);
+  });
+
+  it("keeps the thread-associated PR instead of the live PR from a shared checkout", () => {
+    const persisted = openPr(841, "fix/created-at-thread-order");
+    expect(
+      resolveSidebarThreadPullRequest({
+        threadBranch: "feat/environment-all-provider-usage",
+        liveBranch: "feat/environment-all-provider-usage",
+        hasLiveStatus: true,
+        hasDedicatedWorktree: false,
+        livePullRequest: openPr(842, "feat/environment-all-provider-usage"),
+        persistedPullRequest: persisted,
+      }),
+    ).toBe(persisted);
+  });
+
+  it("does not claim an unrelated live PR for an unassociated shared-checkout thread", () => {
+    expect(
+      resolveSidebarThreadPullRequest({
+        threadBranch: "feat/environment-all-provider-usage",
+        liveBranch: "feat/environment-all-provider-usage",
+        hasLiveStatus: true,
+        hasDedicatedWorktree: false,
+        livePullRequest: openPr(842, "feat/environment-all-provider-usage"),
+        persistedPullRequest: null,
+      }),
+    ).toBeNull();
   });
 
   it("prefers live metadata for the worktree's current branch", () => {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -103,11 +103,10 @@ export function pullRequestRepositoryConfigFingerprint(
 }
 
 /**
- * Shared project roots can serve several threads, so their live Git status only belongs to a
- * thread when the checked-out branch matches the persisted thread branch. A materialized
- * worktree is thread-scoped, though, and coding agents may checkout or create a new branch
- * without going through Synara's branch picker. In that case the worktree's checked-out branch
- * is authoritative even when the persisted branch metadata is stale.
+ * Shared project roots can serve several threads, so their live Git status is environment state,
+ * not thread ownership. Only a materialized worktree is thread-scoped: coding agents may checkout
+ * or create a new branch there without going through Synara's branch picker, so its checked-out
+ * branch is authoritative even when the persisted branch metadata is stale.
  */
 export function shouldUseLivePullRequestForSidebarThread(input: {
   readonly threadBranch: string | null;
@@ -117,10 +116,7 @@ export function shouldUseLivePullRequestForSidebarThread(input: {
   if (input.liveBranch === null) {
     return false;
   }
-  if (input.hasDedicatedWorktree) {
-    return true;
-  }
-  return input.threadBranch !== null && input.threadBranch === input.liveBranch;
+  return input.hasDedicatedWorktree;
 }
 
 export function resolveSidebarThreadPullRequest<
@@ -133,6 +129,12 @@ export function resolveSidebarThreadPullRequest<
   readonly livePullRequest: T | null;
   readonly persistedPullRequest: T | null;
 }): T | null {
+  // A shared local checkout can move because another thread is working in the same project root.
+  // Its live PR must never overwrite the durable PR explicitly associated with this thread.
+  if (!input.hasDedicatedWorktree) {
+    return input.persistedPullRequest;
+  }
+
   // A settled (merged/closed) PR is the thread's outcome, not a claim about the current
   // checkout, so it stays visible after the checkout moves on — e.g. switching back to
   // main after merging must flip the badge to "merged", not drop it and let stale

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -32,11 +32,7 @@ import {
   XIcon,
 } from "~/lib/icons";
 import { createCentralIconComponent } from "~/lib/central-icons";
-import {
-  PR_STATE_PRESENTATION_ICONS,
-  resolvePrStatePresentation,
-  type PrStatePresentation,
-} from "~/components/pullRequest/pullRequestStatePresentation";
+import { ThreadPrStatusBadge } from "~/components/pullRequest/ThreadPrStatusBadge";
 import { PinStatusIcon, pinActionLabel } from "~/lib/pin";
 import { ensureNativeApi } from "~/nativeApi";
 import { autoAnimate } from "@formkit/auto-animate";
@@ -133,7 +129,7 @@ import {
   isSidebarThreadVisible,
 } from "../storeSelectors";
 import { derivePendingApprovals, derivePendingUserInputs } from "../session-logic";
-import { useThreadPullRequests, type ThreadPullRequest } from "../hooks/useThreadPullRequests";
+import { useThreadPullRequests } from "../hooks/useThreadPullRequests";
 import {
   providerComposerCapabilitiesQueryOptions,
   supportsThreadImport,
@@ -705,16 +701,6 @@ function resolveThreadRowMetaChips(input: {
   return chips;
 }
 
-interface PrStatusIndicator {
-  label: PrStatePresentation["label"];
-  colorClass: string;
-  icon: LucideIcon;
-  tooltip: string;
-  url: string;
-}
-
-type ThreadPr = ThreadPullRequest;
-
 function terminalStatusFromThreadState(input: {
   runningTerminalIds: string[];
   terminalAttentionStatesById: Record<string, "attention" | "review">;
@@ -742,50 +728,6 @@ function terminalStatusFromThreadState(input: {
     };
   }
   return null;
-}
-
-function prStatusIndicator(pr: ThreadPr): PrStatusIndicator | null {
-  if (!pr) return null;
-  const presentation = resolvePrStatePresentation(pr);
-  return {
-    label: presentation.label,
-    colorClass: presentation.colorClass,
-    icon: PR_STATE_PRESENTATION_ICONS[presentation.iconKind],
-    tooltip: `#${pr.number} ${presentation.label}: ${pr.title}`,
-    url: pr.url,
-  };
-}
-
-function ThreadPrStatusBadge({
-  prStatus,
-  onOpen,
-  className,
-}: {
-  prStatus: PrStatusIndicator;
-  onOpen: (event: MouseEvent<HTMLElement>, prUrl: string) => void;
-  className?: string;
-}) {
-  return (
-    <Tooltip>
-      <TooltipTrigger
-        render={
-          <button
-            type="button"
-            aria-label={prStatus.tooltip}
-            className={cn(
-              "inline-flex size-4 shrink-0 cursor-pointer items-center justify-center rounded-sm outline-hidden transition-colors focus-visible:ring-1 focus-visible:ring-ring",
-              prStatus.colorClass,
-              className,
-            )}
-            onClick={(event) => onOpen(event, prStatus.url)}
-          >
-            <SidebarGlyph icon={prStatus.icon} variant="meta" className="size-3.5" />
-          </button>
-        }
-      />
-      <TooltipPopup side="top">{prStatus.tooltip}</TooltipPopup>
-    </Tooltip>
-  );
 }
 
 type SortableProjectHandleProps = Pick<
@@ -4377,11 +4319,11 @@ export default function Sidebar() {
     });
     const threadStatus = resolveThreadStatusForSidebar(thread);
     const isSubagentThread = Boolean(thread.parentThreadId);
-    const prStatus = prStatusIndicator(prByThreadId.get(thread.id) ?? null);
-    const leadingPrStatus =
+    const pr = prByThreadId.get(thread.id) ?? null;
+    const leadingPr =
       isSubagentThread || thread.forkSourceThreadId || thread.sidechatSourceThreadId
         ? null
-        : prStatus;
+        : pr;
     const threadJumpLabel = visibleThreadJumpLabelByThreadId.get(thread.id) ?? null;
     const threadJumpLabelParts =
       visibleThreadJumpLabelPartsByThreadId.get(thread.id) ?? EMPTY_SHORTCUT_PARTS;
@@ -4405,11 +4347,11 @@ export default function Sidebar() {
             />
           }
         >
-          {leadingPrStatus ? (
+          {leadingPr ? (
             <ThreadPrStatusBadge
-              prStatus={leadingPrStatus}
+              pr={leadingPr}
               onOpen={openPrLink}
-              className="pointer-events-auto absolute left-1.5 top-1/2 z-30 size-5 -translate-y-1/2"
+              className="pointer-events-auto absolute left-1.5 top-1/2 z-30 h-5 w-6 -translate-y-1/2"
             />
           ) : null}
           <div
@@ -4423,7 +4365,7 @@ export default function Sidebar() {
               // present — instead of a rigid grid that permanently fenced off a
               // timestamp-era column and squeezed the title/project even when wide.
               "relative gap-1.5 transition-colors",
-              leadingPrStatus && "pl-8",
+              leadingPr && "pl-8",
               resolveThreadRowTrailingReserveClass({
                 metaChipCount: rightMetaChips.length,
                 hasTrailingGlyph: hasTrailingStatusGlyph,
@@ -4523,7 +4465,7 @@ export default function Sidebar() {
     const isSelected = selectedThreadIds.has(thread.id);
     const isHighlighted = isActive || isSelected;
     const threadStatus = resolveThreadStatusForSidebar(thread);
-    const prStatus = prStatusIndicator(prByThreadId.get(thread.id) ?? null);
+    const pr = prByThreadId.get(thread.id) ?? null;
     const terminalStatus = terminalStatusFromThreadState({
       runningTerminalIds: threadTerminalState.runningTerminalIds,
       terminalAttentionStatesById: threadTerminalState.terminalAttentionStatesById,
@@ -4545,10 +4487,10 @@ export default function Sidebar() {
       threadAutomations: automationsByThreadId.get(thread.id),
     });
     const isSubagentThread = Boolean(thread.parentThreadId);
-    const leadingPrStatus =
+    const leadingPr =
       isSubagentThread || thread.forkSourceThreadId || thread.sidechatSourceThreadId
         ? null
-        : prStatus;
+        : pr;
     const subagentIndentPx = Math.max(0, Math.min(depth - 1, 3) * 10);
     const showCompactMeta = !isSubagentThread;
     const showTemporaryThreadIcon =
@@ -4568,11 +4510,11 @@ export default function Sidebar() {
         className="group/thread-row w-full"
         data-thread-item
       >
-        {leadingPrStatus ? (
+        {leadingPr ? (
           <ThreadPrStatusBadge
-            prStatus={leadingPrStatus}
+            pr={leadingPr}
             onOpen={openPrLink}
-            className="pointer-events-auto absolute left-1.5 top-1/2 z-30 size-5 -translate-y-1/2"
+            className="pointer-events-auto absolute left-1.5 top-1/2 z-30 h-5 w-6 -translate-y-1/2"
           />
         ) : null}
         <Tooltip>
@@ -4589,7 +4531,7 @@ export default function Sidebar() {
                     isActive,
                     isSelected,
                   }),
-                  leadingPrStatus ? "pl-8" : topLevel && !isSubagentThread ? "pl-2" : null,
+                  leadingPr ? "pl-8" : topLevel && !isSubagentThread ? "pl-2" : null,
                   isSubagentThread
                     ? "pr-7.5"
                     : resolveThreadRowTrailingReserveClass({

--- a/apps/web/src/components/SidebarActivityView.tsx
+++ b/apps/web/src/components/SidebarActivityView.tsx
@@ -710,6 +710,7 @@ export function SidebarActivityView({
           ? (prByThreadId.get(thread.id) ?? null)
           : resolveThreadPullRequestFallback({
               branch: thread.branch,
+              hasDedicatedWorktree: thread.worktreePath !== null,
               lastKnownPr: thread.lastKnownPr ?? null,
             })
       }

--- a/apps/web/src/components/kanban/KanbanCardView.tsx
+++ b/apps/web/src/components/kanban/KanbanCardView.tsx
@@ -120,6 +120,7 @@ function KanbanCardViewComponent({
       ? (prByThreadId.get(card.threadId) ?? null)
       : resolveThreadPullRequestFallback({
           branch: card.thread.branch,
+          hasDedicatedWorktree: card.thread.worktreePath !== null,
           lastKnownPr: card.thread.lastKnownPr ?? null,
         })
     : null;

--- a/apps/web/src/components/pullRequest/ThreadPrStatusBadge.browser.tsx
+++ b/apps/web/src/components/pullRequest/ThreadPrStatusBadge.browser.tsx
@@ -1,0 +1,53 @@
+// FILE: ThreadPrStatusBadge.browser.tsx
+// Purpose: Guards the always-visible compact PR number and its clickable destination.
+// Layer: Pull request presentation test
+
+import "../../index.css";
+
+import { page } from "vitest/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { ThreadPrStatusBadge } from "./ThreadPrStatusBadge";
+
+describe("ThreadPrStatusBadge", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("keeps the PR number visible without spending space on the hash prefix", async () => {
+    const onOpen = vi.fn();
+    await render(
+      <ThreadPrStatusBadge
+        pr={{
+          number: 841,
+          title: "Fix created-at thread ordering",
+          url: "https://github.com/acme/synara/pull/841",
+          state: "open",
+          isDraft: false,
+          mergeability: "mergeable",
+        }}
+        onOpen={onOpen}
+      />,
+    );
+
+    const number = page.getByText("841", { exact: true });
+    const button = page.getByRole("button", {
+      name: "#841 PR open: Fix created-at thread ordering",
+    });
+    await expect.element(number).toBeVisible();
+
+    const numberElement = document.querySelector<HTMLElement>("[data-pr-number='841']");
+    const buttonElement = document.querySelector<HTMLButtonElement>("button");
+    if (!numberElement || !buttonElement) {
+      throw new Error("Expected the compact PR badge to render its number and button");
+    }
+    expect(getComputedStyle(numberElement).fontSize).toBe("8px");
+    expect(Math.round(buttonElement.getBoundingClientRect().width)).toBe(24);
+
+    await button.click();
+
+    expect(onOpen).toHaveBeenCalledOnce();
+    expect(onOpen.mock.calls[0]?.[1]).toBe("https://github.com/acme/synara/pull/841");
+  });
+});

--- a/apps/web/src/components/pullRequest/ThreadPrStatusBadge.tsx
+++ b/apps/web/src/components/pullRequest/ThreadPrStatusBadge.tsx
@@ -1,0 +1,67 @@
+// FILE: ThreadPrStatusBadge.tsx
+// Purpose: Renders the compact, clickable PR marker shown before classic sidebar rows.
+// Layer: Pull request presentation
+// Exports: ThreadPrStatusBadge
+
+import type { OrchestrationThreadPullRequest } from "@synara/contracts";
+import type { MouseEvent } from "react";
+
+import { cn } from "~/lib/utils";
+import { SidebarGlyph } from "../sidebarGlyphs";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import {
+  PR_STATE_PRESENTATION_ICONS,
+  resolvePrStatePresentation,
+} from "./pullRequestStatePresentation";
+
+type ThreadPrStatusBadgePullRequest = Pick<
+  OrchestrationThreadPullRequest,
+  "number" | "title" | "url" | "state" | "isDraft" | "mergeability"
+>;
+
+export function ThreadPrStatusBadge({
+  pr,
+  onOpen,
+  className,
+}: {
+  pr: ThreadPrStatusBadgePullRequest;
+  onOpen: (event: MouseEvent<HTMLElement>, prUrl: string) => void;
+  className?: string;
+}) {
+  const presentation = resolvePrStatePresentation(pr);
+  const PrIcon = PR_STATE_PRESENTATION_ICONS[presentation.iconKind];
+  const tooltip = `#${pr.number} ${presentation.label}: ${pr.title}`;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            aria-label={tooltip}
+            className={cn(
+              "relative inline-flex h-4 w-6 shrink-0 cursor-pointer items-center rounded-sm outline-hidden transition-colors focus-visible:ring-1 focus-visible:ring-ring",
+              presentation.colorClass,
+              className,
+            )}
+            onClick={(event) => onOpen(event, pr.url)}
+          >
+            <SidebarGlyph
+              icon={PrIcon}
+              variant="meta"
+              className="absolute left-0.5 top-1/2 size-3.5 -translate-y-1/2"
+            />
+            <span
+              aria-hidden
+              data-pr-number={pr.number}
+              className="pointer-events-none absolute bottom-0 right-0 rounded-[2px] bg-sidebar px-px text-[8px] font-semibold leading-[9px] tabular-nums tracking-[-0.06em]"
+            >
+              {pr.number}
+            </span>
+          </button>
+        }
+      />
+      <TooltipPopup side="top">{tooltip}</TooltipPopup>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/hooks/useThreadPullRequests.test.ts
+++ b/apps/web/src/hooks/useThreadPullRequests.test.ts
@@ -1,0 +1,30 @@
+import type { OrchestrationThreadPullRequest } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+
+import { resolveThreadPullRequestFallback } from "./useThreadPullRequests";
+
+const staleOpenPullRequest: OrchestrationThreadPullRequest = {
+  number: 841,
+  title: "Previous branch pull request",
+  url: "https://github.com/acme/synara/pull/841",
+  baseBranch: "main",
+  headBranch: "feat/previous-branch",
+  state: "open",
+  isDraft: false,
+  mergeability: "mergeable",
+  additions: 12,
+  deletions: 4,
+  changedFiles: 2,
+};
+
+describe("resolveThreadPullRequestFallback", () => {
+  it("rejects a stale open PR for a dedicated worktree on another branch", () => {
+    expect(
+      resolveThreadPullRequestFallback({
+        branch: "feat/current-branch",
+        hasDedicatedWorktree: true,
+        lastKnownPr: staleOpenPullRequest,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/hooks/useThreadPullRequests.ts
+++ b/apps/web/src/hooks/useThreadPullRequests.ts
@@ -71,13 +71,14 @@ export function toThreadPullRequest(
  */
 export function resolveThreadPullRequestFallback(input: {
   readonly branch: string | null;
+  readonly hasDedicatedWorktree: boolean;
   readonly lastKnownPr: OrchestrationThreadPullRequest | null | undefined;
 }): ThreadPullRequest {
   return resolveSidebarThreadPullRequest({
     threadBranch: input.branch,
     liveBranch: null,
     hasLiveStatus: false,
-    hasDedicatedWorktree: false,
+    hasDedicatedWorktree: input.hasDedicatedWorktree,
     livePullRequest: null,
     persistedPullRequest: input.lastKnownPr ? toThreadPullRequest(input.lastKnownPr) : null,
   });

--- a/apps/web/src/hooks/useThreadPullRequests.ts
+++ b/apps/web/src/hooks/useThreadPullRequests.ts
@@ -85,8 +85,9 @@ export function resolveThreadPullRequestFallback(input: {
 
 /**
  * Resolves the PR badge for each given thread. Callers pass only the rows they render:
- * every distinct checkout behind them gets a polled git-status query and every stored PR
- * reference a polled lookup, so hidden history must stay out of the input.
+ * every distinct thread-owned worktree gets a polled git-status query and every stored PR
+ * reference a polled lookup. Shared local checkouts intentionally use only the durable thread PR:
+ * their live branch may belong to another concurrent thread.
  */
 export function useThreadPullRequests(input: {
   readonly threads: readonly ThreadPullRequestSource[];
@@ -112,7 +113,7 @@ export function useThreadPullRequests(input: {
     () => [
       ...new Set(
         threadGitTargets
-          .filter((target) => target.branch !== null || target.hasDedicatedWorktree)
+          .filter((target) => target.hasDedicatedWorktree)
           .map((target) => target.cwd)
           .filter((cwd): cwd is string => cwd !== null),
       ),


### PR DESCRIPTION
## What Changed

- Stop treating the live pull request from a shared local checkout as the pull request owned by every matching thread row.
- Use durable per-thread pull request metadata for shared checkouts while keeping live Git detection authoritative for dedicated worktrees.
- Add `synara_set_thread_pull_request` so an agent can persist the pull request created as its thread's own deliverable.
- Instruct providers to associate only pull requests that represent the current thread's deliverable, not pull requests they merely review or discuss.
- Show the pull request number inside the existing sidebar status badge so the corrected association is identifiable without opening its tooltip.
- Add focused attribution coverage and a browser test for the compact, clickable pull request badge.

## Why

Multiple local threads can share one project checkout. When another thread opened PR #842 from the currently checked-out branch, every matching local thread displayed #842, including the thread that had opened #841 from an isolated worktree. The sidebar was showing shared environment state as if it were thread ownership.

Shared-checkout rows now use durable per-thread pull request metadata. Dedicated worktrees continue to use their live Git state because those checkouts are thread-scoped. Agents that create a pull request from an external worktree can explicitly persist that association. Showing the number alongside its state makes the resulting thread-to-PR association directly verifiable in the sidebar.

## UI Changes

**Before**

Shared-checkout rows could inherit the same live pull request, and the status badge did not expose the pull request number directly.

<img width="900" alt="Before: sidebar rows inherited the shared checkout pull request and badges did not show pull request numbers" src="https://github.com/user-attachments/assets/8a991847-fe74-458a-b7f6-f6a46208beb5" />

**After**

Rows use their thread-owned pull request association, and each badge includes its pull request number.

<img width="900" alt="After: sidebar rows show their thread-owned pull request" src="https://github.com/user-attachments/assets/b45962fb-2bfc-481e-a605-55fdb69ca425" />

**Numbered badge detail**

<img width="682" alt="Focused detail of the thread-owned pull request badge showing PR number 841" src="https://raw.githubusercontent.com/NachoooLK/synara/8f418088e26b99cfb6b15e645394e2aee664eed7/pr-844/after-numbered-pr-badge-detail.png" />

An interaction video has not yet been attached.

## Verification

- `apps/web`: 125 Sidebar logic tests passed.
- `apps/server`: 103 Agent Gateway and harness policy tests passed.
- `apps/server`: server layer composition test passed.
- `git diff --check` passed.

Not run: the new `apps/web/src/components/pullRequest/ThreadPrStatusBadge.browser.tsx` browser test.

`bun fmt`, `bun lint`, and `bun typecheck` were not run because repository instructions require an explicit user request for those heavyweight checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
