### PR TITLE
fix(agent): keep final responses self-contained

### DIFF
--- a/apps/server/src/agentGateway/harnessPolicy.test.ts
+++ b/apps/server/src/agentGateway/harnessPolicy.test.ts
@@ -52,6 +52,20 @@ describe("Synara harness policy", () => {
     }
   });
 
+  it("keeps final answers self-contained when intermediate progress is collapsed", () => {
+    const gateway = renderSynaraHarnessPolicy({ gatewayControlAvailable: true });
+    const identityOnly = renderSynaraHarnessPolicy({ gatewayControlAvailable: false });
+
+    for (const policy of [gateway, identityOnly]) {
+      assert.include(policy, 'under a "Worked for..." disclosure');
+      assert.include(policy, "Make every final response self-contained");
+      assert.include(policy, "restate the essential context concisely in the final response");
+      assert.include(policy, 'Never ask them to approve "this", "that", "the above"');
+      assert.include(policy, "structured user-input tool");
+      assert.include(policy, "contain all context the user needs to decide");
+    }
+  });
+
   it("never advertises gateway mutation to providers without scoped MCP", () => {
     const policy = renderSynaraHarnessPolicy({ gatewayControlAvailable: false });
     assert.include(policy, "Synara MCP control is unavailable");

--- a/apps/server/src/agentGateway/harnessPolicy.ts
+++ b/apps/server/src/agentGateway/harnessPolicy.ts
@@ -3,7 +3,7 @@ import type { ProviderKind } from "@synara/contracts";
 import { AUTOMATION_AUTHORING_GUIDANCE } from "./automationAuthoringGuidance.ts";
 
 /** Canonical, versioned host policy delivered to every supported provider. */
-export const SYNARA_HARNESS_POLICY_VERSION = "2026-08-25.2";
+export const SYNARA_HARNESS_POLICY_VERSION = "2026-08-30.1";
 export const SYNARA_HARNESS_POLICY_MARKER = `[Synara harness policy ${SYNARA_HARNESS_POLICY_VERSION}]`;
 
 export interface SynaraHarnessCapabilities {
@@ -59,6 +59,8 @@ export function renderSynaraHarnessPolicy(capabilities: SynaraHarnessCapabilitie
     SYNARA_HARNESS_POLICY_MARKER,
     "You are running inside Synara. Synara is the host and harness for this session.",
     "When referencing a known local file in user-facing Markdown, use a readable label and an absolute file URL, for example [config.ts](file:///absolute/path/config.ts). Relative links are only for files inside the session working directory. If the absolute path is unknown, keep the name as plain text. Do not invent a path.",
+    'Synara collapses intermediate assistant progress updates and tool activity under a "Worked for..." disclosure after a turn settles. Make every final response self-contained: never rely on scope, plans, decisions, results, caveats, instructions, or questions stated only in progress updates or tool output. If the user must understand or approve something, restate the essential context concisely in the final response. Never ask them to approve "this", "that", "the above", or equivalent wording when the referent would exist only in collapsed work.',
+    "When a structured user-input tool is available and a genuine decision is required, prefer it; its question or card must also contain all context the user needs to decide.",
     ...controlPolicy,
   ].join("\n");
 }

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -80,6 +80,8 @@ describe("Codex Synara harness policy", () => {
       expect(instructions).toContain(SYNARA_HARNESS_POLICY_MARKER);
       expect(instructions.split(SYNARA_HARNESS_POLICY_MARKER)).toHaveLength(2);
       expect(instructions).toContain("Synara is the host and harness");
+      expect(instructions).toContain("Make every final response self-contained");
+      expect(instructions).toContain("contain all context the user needs to decide");
       expect(instructions).toContain("one exact synara_create_threads plan");
       expect(instructions).toContain("tools.mcp__synara__browser_open");
       for (const name of BROWSER_TOOL_NAMES) {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -667,6 +667,8 @@ describe("Claude Synara harness policy", () => {
   it("advertises scoped MCP additively when credentials are available", () => {
     const text = buildEmbeddedClaudeSystemPromptAppend(true);
     assert.include(text, SYNARA_HARNESS_POLICY_MARKER);
+    assert.include(text, "Make every final response self-contained");
+    assert.include(text, "contain all context the user needs to decide");
     assert.include(text, "Use the synara_* tools");
     assert.notInclude(text, "Synara MCP control is unavailable");
   });
@@ -674,6 +676,8 @@ describe("Claude Synara harness policy", () => {
   it("stays truthful when scoped MCP credentials are absent", () => {
     const text = buildEmbeddedClaudeSystemPromptAppend(false);
     assert.include(text, SYNARA_HARNESS_POLICY_MARKER);
+    assert.include(text, "Make every final response self-contained");
+    assert.include(text, "contain all context the user needs to decide");
     assert.include(text, "Synara MCP control is unavailable");
   });
 });


### PR DESCRIPTION
## What Changed

- Teach the shared Synara harness policy that intermediate progress is collapsed under “Worked for”.
- Require final responses to repeat any scope, plan, decision, result, caveat, instruction, or question the user still needs.
- Prefer structured user-input surfaces when available and require their decision context to be self-contained.
- Bump the harness policy version so provider sessions receive the updated contract.

## Why

A settled turn can fold user-relevant progress text into “Worked for” while leaving a terminal reply such as “Do you approve that scope?” visible on its own. The result is a dangling question whose referent is hidden.

This preserves the compact transcript while ensuring the provider's terminal response remains understandable without opening the collapsed work details.

## Verification

- `bun run test --run src/agentGateway/harnessPolicy.test.ts src/codexAppServerManager.test.ts src/provider/Layers/ClaudeAdapter.test.ts -t "Synara harness policy"` — 13 passed
- `git diff --check`

Full `bun fmt`, `bun lint`, and `bun typecheck` were not run because repository instructions require an explicit user request.

### Visual verification evidence

This is a server-only provider-policy change; no web or desktop UI files changed. The screenshot records the exact added contract and a fresh focused test run rather than fabricating a nondeterministic transcript comparison.

<img width="900" alt="Server-only harness policy contract requiring self-contained final responses, with 13 focused tests passed" src="https://raw.githubusercontent.com/NachoooLK/synara/8f418088e26b99cfb6b15e645394e2aee664eed7/pr-846/policy-contract-and-verification.png" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes — not applicable; this PR does not change UI
- [x] I included a video for animation/interaction changes — not applicable; this PR does not change animation or interaction
