### PR TITLE
Hide routine provider hook lifecycle events

### DIFF
--- a/apps/server/src/orchestration/providerRuntimeActivityProjection.test.ts
+++ b/apps/server/src/orchestration/providerRuntimeActivityProjection.test.ts
@@ -743,4 +743,121 @@ describe("provider runtime activity projection", () => {
       ),
     ).toEqual([]);
   });
+
+  it("keeps routine hook lifecycle internal and surfaces only consequential completions", () => {
+    expect(
+      projectProviderRuntimeActivities(
+        runtimeEvent({
+          type: "hook.started",
+          eventId: "hook-started",
+          turnId: TURN_ID,
+          payload: {
+            hookId: "hook-run-1",
+            hookName: "/Users/example/.codex/hooks.json",
+            hookEvent: "preToolUse",
+          },
+        }),
+      ),
+    ).toEqual([]);
+    expect(
+      projectProviderRuntimeActivities(
+        runtimeEvent({
+          type: "hook.progress",
+          eventId: "hook-progress",
+          turnId: TURN_ID,
+          payload: {
+            hookId: "hook-run-1",
+            stdout: "Still running.",
+          },
+        }),
+      ),
+    ).toEqual([]);
+    expect(
+      projectProviderRuntimeActivities(
+        runtimeEvent({
+          type: "hook.completed",
+          eventId: "hook-success",
+          turnId: TURN_ID,
+          payload: {
+            hookId: "hook-run-1",
+            hookName: "/Users/example/.codex/hooks.json",
+            hookEvent: "preToolUse",
+            outcome: "success",
+            status: "completed",
+            durationMs: 8,
+          },
+        }),
+      ),
+    ).toEqual([]);
+    expect(
+      projectProviderRuntimeActivities(
+        runtimeEvent({
+          type: "hook.completed",
+          eventId: "hook-cancelled",
+          turnId: TURN_ID,
+          payload: {
+            hookId: "hook-run-2",
+            outcome: "cancelled",
+          },
+        }),
+      ),
+    ).toEqual([]);
+
+    const [failed] = projectProviderRuntimeActivities(
+      runtimeEvent({
+        type: "hook.completed",
+        eventId: "hook-failed",
+        turnId: TURN_ID,
+        payload: {
+          hookId: "hook-run-3",
+          hookName: "/Users/example/.codex/hooks.json",
+          hookEvent: "postToolUse",
+          outcome: "error",
+          status: "failed",
+          statusMessage: "Hook process exited with code 1.",
+          durationMs: 20,
+        },
+      }),
+    );
+    expect(failed).toMatchObject({
+      tone: "error",
+      kind: "runtime.warning",
+      summary: "postToolUse hook failed",
+      payload: {
+        message: "Hook process exited with code 1.",
+        hookId: "hook-run-3",
+        hookEvent: "postToolUse",
+        outcome: "error",
+        status: "failed",
+        durationMs: 20,
+      },
+    });
+    expect(() => decodeActivityAppendCommand(failed!)).not.toThrow();
+
+    const [blocked] = projectProviderRuntimeActivities(
+      runtimeEvent({
+        type: "hook.completed",
+        eventId: "hook-blocked",
+        turnId: TURN_ID,
+        payload: {
+          hookId: "hook-run-4",
+          hookEvent: "preToolUse",
+          outcome: "cancelled",
+          status: "blocked",
+          statusMessage: "Policy blocked the command.",
+        },
+      }),
+    );
+    expect(blocked).toMatchObject({
+      tone: "info",
+      kind: "runtime.warning",
+      summary: "preToolUse hook blocked an action",
+      payload: {
+        message: "Policy blocked the command.",
+        outcome: "cancelled",
+        status: "blocked",
+      },
+    });
+    expect(() => decodeActivityAppendCommand(blocked!)).not.toThrow();
+  });
 });

--- a/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
+++ b/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
@@ -1078,6 +1078,63 @@ export function projectProviderRuntimeActivities(
       ];
     }
 
+    case "hook.started":
+    case "hook.progress":
+      // Hook lifecycle is operational evidence, not transcript content. The
+      // canonical runtime journal retains it for replay and diagnostics.
+      return [];
+
+    case "hook.completed": {
+      const status = event.payload.status;
+      // Successful hooks are routine, and cancelled hooks normally reflect an
+      // interrupted turn. Neither should add rows or transcript height churn.
+      if (
+        event.payload.outcome === "success" ||
+        (event.payload.outcome === "cancelled" && !status)
+      ) {
+        return [];
+      }
+      const hookLabel = event.payload.hookEvent ?? "Lifecycle";
+      const summary =
+        status === "blocked"
+          ? `${hookLabel} hook blocked an action`
+          : status === "stopped"
+            ? `${hookLabel} hook stopped execution`
+            : `${hookLabel} hook failed`;
+      const message = truncateDetail(
+        event.payload.statusMessage ??
+          event.payload.stderr ??
+          event.payload.output ??
+          event.payload.stdout ??
+          summary,
+        500,
+      );
+      return [
+        {
+          id: event.eventId,
+          createdAt: event.createdAt,
+          tone:
+            status === "failed" || event.payload.outcome === "error" ? "error" : "info",
+          kind: "runtime.warning",
+          summary,
+          payload: toActivityPayload({
+            message,
+            detail: message,
+            hookId: event.payload.hookId,
+            ...(event.payload.hookName ? { hookName: event.payload.hookName } : {}),
+            ...(event.payload.hookEvent ? { hookEvent: event.payload.hookEvent } : {}),
+            outcome: event.payload.outcome,
+            ...(status ? { status } : {}),
+            ...(event.payload.durationMs !== undefined
+              ? { durationMs: event.payload.durationMs }
+              : {}),
+          }),
+          turnId: toTurnId(event.turnId) ?? null,
+          ...maybeSequence,
+        },
+      ];
+    }
+
     case "account.rate-limits.updated": {
       const rawRateLimits = event.payload.rateLimits;
       if (!rawRateLimits || typeof rawRateLimits !== "object") {

--- a/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
+++ b/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
@@ -1113,8 +1113,7 @@ export function projectProviderRuntimeActivities(
         {
           id: event.eventId,
           createdAt: event.createdAt,
-          tone:
-            status === "failed" || event.payload.outcome === "error" ? "error" : "info",
+          tone: status === "failed" || event.payload.outcome === "error" ? "error" : "info",
           kind: "runtime.warning",
           summary,
           payload: toActivityPayload({

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -1592,6 +1592,103 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
     }),
   );
 
+  it.effect("maps Codex hook notifications to bounded canonical lifecycle events", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const eventsFiber = yield* Stream.take(adapter.streamEvents, 2).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      const commonRun = {
+        id: "hook-run-1",
+        eventName: "preToolUse",
+        executionMode: "sync",
+        handlerType: "command",
+        scope: "turn",
+        source: "user",
+        sourcePath: "/Users/example/.codex/hooks.json",
+        displayOrder: 0,
+        startedAt: 100,
+      };
+
+      lifecycleManager.emit("event", {
+        id: asEventId("evt-codex-hook-started"),
+        kind: "notification",
+        provider: "codex",
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-1"),
+        createdAt: new Date().toISOString(),
+        method: "hook/started",
+        payload: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          run: {
+            ...commonRun,
+            status: "running",
+            statusMessage: null,
+            completedAt: null,
+            durationMs: null,
+            entries: [],
+          },
+        },
+      } satisfies ProviderEvent);
+      lifecycleManager.emit("event", {
+        id: asEventId("evt-codex-hook-completed"),
+        kind: "notification",
+        provider: "codex",
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-1"),
+        createdAt: new Date().toISOString(),
+        method: "hook/completed",
+        payload: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          run: {
+            ...commonRun,
+            status: "blocked",
+            statusMessage: "api_key=private-hook-secret blocked this action",
+            completedAt: 112,
+            durationMs: 12,
+            entries: [
+              { kind: "error", text: "Authorization: Bearer private-hook-token" },
+            ],
+          },
+        },
+      } satisfies ProviderEvent);
+
+      const events = Array.from(yield* Fiber.join(eventsFiber));
+      assert.equal(events.length, 2);
+      const [started, completed] = events;
+      assert.equal(started?.type, "hook.started");
+      if (started?.type !== "hook.started") return;
+      assert.deepEqual(started.payload, {
+        hookId: "hook-run-1",
+        hookName: "/Users/example/.codex/hooks.json",
+        hookEvent: "preToolUse",
+        data: {
+          ...commonRun,
+          status: "running",
+          statusMessage: null,
+          completedAt: null,
+          durationMs: null,
+          entries: [],
+        },
+      });
+      assert.deepEqual(started.raw?.payload, { synaraSanitized: true });
+
+      assert.equal(completed?.type, "hook.completed");
+      if (completed?.type !== "hook.completed") return;
+      assert.equal(completed.payload.outcome, "cancelled");
+      assert.equal(completed.payload.status, "blocked");
+      assert.equal(completed.payload.durationMs, 12);
+      const serialized = JSON.stringify(completed);
+      assert.equal(serialized.includes("private-hook-secret"), false);
+      assert.equal(serialized.includes("private-hook-token"), false);
+      assert.equal(serialized.includes("[REDACTED]"), true);
+      assert.deepEqual(completed.raw?.payload, { synaraSanitized: true });
+    }),
+  );
+
   it.effect(
     "surfaces previously-unmapped native events with bounded redacted diagnostics instead of raw payloads",
     () =>

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -1649,9 +1649,7 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
             statusMessage: "api_key=private-hook-secret blocked this action",
             completedAt: 112,
             durationMs: 12,
-            entries: [
-              { kind: "error", text: "Authorization: Bearer private-hook-token" },
-            ],
+            entries: [{ kind: "error", text: "Authorization: Bearer private-hook-token" }],
           },
         },
       } satisfies ProviderEvent);

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -910,6 +910,114 @@ function mapItemLifecycle(
   };
 }
 
+type CodexHookRunStatus = "completed" | "failed" | "blocked" | "stopped";
+
+function toCodexHookRunStatus(value: unknown): CodexHookRunStatus | undefined {
+  return value === "completed" ||
+    value === "failed" ||
+    value === "blocked" ||
+    value === "stopped"
+    ? value
+    : undefined;
+}
+
+function toHookOutcome(
+  status: CodexHookRunStatus | undefined,
+): "success" | "error" | "cancelled" {
+  if (status === "completed") return "success";
+  if (status === "blocked" || status === "stopped") return "cancelled";
+  return "error";
+}
+
+function hookRunOutput(run: Record<string, unknown>): string | undefined {
+  if (!Array.isArray(run.entries)) {
+    return undefined;
+  }
+  const output = run.entries
+    .flatMap((entry) => {
+      const record = asObject(entry);
+      const text = asTrimmedString(record?.text);
+      if (!text) return [];
+      const kind = asTrimmedString(record?.kind);
+      return [kind ? `${kind}: ${text}` : text];
+    })
+    .join("\n");
+  return output ? sanitizeUnmappedProviderDetail(output) : undefined;
+}
+
+function withSanitizedHookRaw(
+  event: ProviderEvent,
+  canonicalThreadId: ThreadId,
+): Omit<ProviderRuntimeEvent, "type" | "payload"> {
+  return {
+    ...runtimeEventBase(event, canonicalThreadId),
+    raw: {
+      source: eventRawSource(event),
+      method: event.method,
+      payload: { synaraSanitized: true },
+    },
+  };
+}
+
+function mapCodexHookEvent(
+  event: ProviderEvent,
+  canonicalThreadId: ThreadId,
+): ProviderRuntimeEvent | undefined {
+  if (event.method !== "hook/started" && event.method !== "hook/completed") {
+    return undefined;
+  }
+  const run = asObject(asObject(event.payload)?.run);
+  const hookId = asTrimmedString(run?.id);
+  const hookEvent = asTrimmedString(run?.eventName);
+  if (!run || !hookId || !hookEvent) {
+    return undefined;
+  }
+  const hookName =
+    asTrimmedString(run.sourcePath) ?? asTrimmedString(run.handlerType) ?? hookEvent;
+  const statusMessage = sanitizeUnmappedProviderDetail(asTrimmedString(run.statusMessage));
+  const data = sanitizeUnmappedProviderData(run);
+  const base = withSanitizedHookRaw(event, canonicalThreadId);
+
+  if (event.method === "hook/started") {
+    return {
+      ...base,
+      type: "hook.started",
+      payload: {
+        hookId,
+        hookName,
+        hookEvent,
+        ...(statusMessage ? { statusMessage } : {}),
+        data,
+      },
+    };
+  }
+
+  const status = toCodexHookRunStatus(run.status);
+  const durationCandidate = asNumber(run.durationMs);
+  const durationMs =
+    durationCandidate !== undefined &&
+    Number.isInteger(durationCandidate) &&
+    durationCandidate >= 0
+      ? durationCandidate
+      : undefined;
+  const output = hookRunOutput(run);
+  return {
+    ...base,
+    type: "hook.completed",
+    payload: {
+      hookId,
+      hookName,
+      hookEvent,
+      outcome: toHookOutcome(status),
+      ...(status ? { status } : {}),
+      ...(statusMessage ? { statusMessage } : {}),
+      ...(durationMs !== undefined ? { durationMs } : {}),
+      ...(output ? { output } : {}),
+      data,
+    },
+  };
+}
+
 function mapUnmappedCodexEvent(
   event: ProviderEvent,
   canonicalThreadId: ThreadId,
@@ -951,6 +1059,10 @@ function mapToRuntimeEvents(
   const generatedImageEndEvent = mapGeneratedImageEndEvent(event, canonicalThreadId);
   if (generatedImageEndEvent) {
     return [generatedImageEndEvent];
+  }
+  const hookEvent = mapCodexHookEvent(event, canonicalThreadId);
+  if (hookEvent) {
+    return [hookEvent];
   }
 
   if (event.kind === "error") {

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -913,17 +913,12 @@ function mapItemLifecycle(
 type CodexHookRunStatus = "completed" | "failed" | "blocked" | "stopped";
 
 function toCodexHookRunStatus(value: unknown): CodexHookRunStatus | undefined {
-  return value === "completed" ||
-    value === "failed" ||
-    value === "blocked" ||
-    value === "stopped"
+  return value === "completed" || value === "failed" || value === "blocked" || value === "stopped"
     ? value
     : undefined;
 }
 
-function toHookOutcome(
-  status: CodexHookRunStatus | undefined,
-): "success" | "error" | "cancelled" {
+function toHookOutcome(status: CodexHookRunStatus | undefined): "success" | "error" | "cancelled" {
   if (status === "completed") return "success";
   if (status === "blocked" || status === "stopped") return "cancelled";
   return "error";
@@ -972,8 +967,7 @@ function mapCodexHookEvent(
   if (!run || !hookId || !hookEvent) {
     return undefined;
   }
-  const hookName =
-    asTrimmedString(run.sourcePath) ?? asTrimmedString(run.handlerType) ?? hookEvent;
+  const hookName = asTrimmedString(run.sourcePath) ?? asTrimmedString(run.handlerType) ?? hookEvent;
   const statusMessage = sanitizeUnmappedProviderDetail(asTrimmedString(run.statusMessage));
   const data = sanitizeUnmappedProviderData(run);
   const base = withSanitizedHookRaw(event, canonicalThreadId);
@@ -995,9 +989,7 @@ function mapCodexHookEvent(
   const status = toCodexHookRunStatus(run.status);
   const durationCandidate = asNumber(run.durationMs);
   const durationMs =
-    durationCandidate !== undefined &&
-    Number.isInteger(durationCandidate) &&
-    durationCandidate >= 0
+    durationCandidate !== undefined && Number.isInteger(durationCandidate) && durationCandidate >= 0
       ? durationCandidate
       : undefined;
   const output = hookRunOutput(run);

--- a/packages/contracts/src/providerRuntime.test.ts
+++ b/packages/contracts/src/providerRuntime.test.ts
@@ -57,6 +57,35 @@ describe("ProviderRuntimeEvent", () => {
     expect(parsed.payload.planMarkdown).toBe("# Ship it");
   });
 
+  it("decodes canonical hook completion diagnostics", () => {
+    const parsed = decodeRuntimeEvent({
+      type: "hook.completed",
+      eventId: "event-hook-1",
+      provider: "codex",
+      createdAt: "2026-02-28T00:00:00.000Z",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      payload: {
+        hookId: "hook-run-1",
+        hookName: "/Users/example/.codex/hooks.json",
+        hookEvent: "preToolUse",
+        outcome: "cancelled",
+        status: "blocked",
+        statusMessage: "Destructive command blocked.",
+        durationMs: 12,
+        data: { handlerType: "command" },
+      },
+    });
+
+    expect(parsed.type).toBe("hook.completed");
+    if (parsed.type !== "hook.completed") {
+      throw new Error("expected hook.completed");
+    }
+    expect(parsed.payload.status).toBe("blocked");
+    expect(parsed.payload.hookEvent).toBe("preToolUse");
+    expect(parsed.payload.durationMs).toBe(12);
+  });
+
   it("decodes user-input.requested with structured questions", () => {
     const parsed = decodeRuntimeEvent({
       type: "user-input.requested",

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -621,6 +621,8 @@ const HookStartedPayload = Schema.Struct({
   hookId: TrimmedNonEmptyStringSchema,
   hookName: TrimmedNonEmptyStringSchema,
   hookEvent: TrimmedNonEmptyStringSchema,
+  statusMessage: Schema.optional(TrimmedNonEmptyStringSchema),
+  data: Schema.optional(Schema.Unknown),
 });
 export type HookStartedPayload = typeof HookStartedPayload.Type;
 
@@ -634,11 +636,19 @@ export type HookProgressPayload = typeof HookProgressPayload.Type;
 
 const HookCompletedPayload = Schema.Struct({
   hookId: TrimmedNonEmptyStringSchema,
+  hookName: Schema.optional(TrimmedNonEmptyStringSchema),
+  hookEvent: Schema.optional(TrimmedNonEmptyStringSchema),
   outcome: Schema.Literals(["success", "error", "cancelled"]),
+  status: Schema.optional(
+    Schema.Literals(["completed", "failed", "blocked", "stopped"]),
+  ),
+  statusMessage: Schema.optional(TrimmedNonEmptyStringSchema),
+  durationMs: Schema.optional(NonNegativeInt),
   output: Schema.optional(Schema.String),
   stdout: Schema.optional(Schema.String),
   stderr: Schema.optional(Schema.String),
   exitCode: Schema.optional(Schema.Int),
+  data: Schema.optional(Schema.Unknown),
 });
 export type HookCompletedPayload = typeof HookCompletedPayload.Type;
 

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -639,9 +639,7 @@ const HookCompletedPayload = Schema.Struct({
   hookName: Schema.optional(TrimmedNonEmptyStringSchema),
   hookEvent: Schema.optional(TrimmedNonEmptyStringSchema),
   outcome: Schema.Literals(["success", "error", "cancelled"]),
-  status: Schema.optional(
-    Schema.Literals(["completed", "failed", "blocked", "stopped"]),
-  ),
+  status: Schema.optional(Schema.Literals(["completed", "failed", "blocked", "stopped"])),
   statusMessage: Schema.optional(TrimmedNonEmptyStringSchema),
   durationMs: Schema.optional(NonNegativeInt),
   output: Schema.optional(Schema.String),


### PR DESCRIPTION
## What Changed

- Map Codex hook lifecycle notifications to canonical provider runtime hook events.
- Retain bounded, redacted hook diagnostics in the runtime journal without producing transcript activities for routine starts, progress, successes, or plain cancellations.
- Surface failed, blocked, and stopped hook completions as one actionable runtime warning.
- Extend the canonical hook payloads and cover mapping, redaction, and projection behavior.

## Why

Without a first-class mapping, Codex hook notifications follow the generic unmapped-event path. Routine hook execution can therefore create transcript noise, while the projection lacks structured outcome and status fields for distinguishing successful hooks from failures or policy blocks.

Hook lifecycle remains available as operational evidence in the runtime journal, but the transcript now demands attention only when a hook fails, blocks an action, or stops execution. Diagnostic content is bounded and redacted before it is retained or surfaced.

## UI Changes

| Before | After |
| --- | --- |
| <img width="410" alt="Before: routine hook start and completion create two transcript rows" src="https://raw.githubusercontent.com/NachoooLK/synara/8f418088e26b99cfb6b15e645394e2aee664eed7/pr-850/before-routine-hooks.png" /> | <img width="410" alt="After: routine hook start and successful completion create no transcript rows" src="https://raw.githubusercontent.com/NachoooLK/synara/8f418088e26b99cfb6b15e645394e2aee664eed7/pr-850/after-routine-hooks.png" /> |

**Actionable outcome remains visible**

<img width="820" alt="After: a blocked hook produces one actionable transcript warning" src="https://raw.githubusercontent.com/NachoooLK/synara/8f418088e26b99cfb6b15e645394e2aee664eed7/pr-850/after-blocked-hook.png" />

The captures use the exact PR test fixtures, passed through the real provider-runtime projection and transcript work-row component. No animation or direct interaction behavior changed.

## Verification

- `bun run test src/providerRuntime.test.ts` in `packages/contracts` — 10 passed
- `bun run test src/provider/Layers/CodexAdapter.test.ts src/orchestration/providerRuntimeActivityProjection.test.ts` in `apps/server` — 53 passed
- Focused visual fixture: 3 browser cases passed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes — not applicable; no animation or direct interaction behavior changed
