### PR TITLE
Plan 02: truthful model picker discovery states + resilient catalog cache

### DIFF
--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -244,6 +244,7 @@ describe("getAppModelOptions", () => {
       name: "custom/selected-model",
       provider: "codex",
       isCustom: true,
+      isSelectionHint: true,
     });
   });
 

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -1081,6 +1081,7 @@ export function getAppModelOptions(
       slug: normalizedSelectedModel,
       name: formatProviderModelOptionName({ provider, slug: normalizedSelectedModel }),
       isCustom: true,
+      isSelectionHint: true,
     });
   }
 

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -6788,6 +6788,121 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("uses a saved global Devin default for a fresh chat and first send", async () => {
+    localStorage.setItem("synara:app-settings:v1", JSON.stringify({ defaultProvider: "devin" }));
+    useComposerDraftStore.setState({
+      stickyModelSelectionByProvider: {
+        codex: { provider: "codex", model: "gpt-5.5" },
+      },
+      stickyActiveProvider: "codex",
+    });
+    const snapshot = createSnapshotForTargetUser({
+      targetMessageId: "msg-user-global-devin-default-test" as MessageId,
+      targetText: "global Devin default test",
+    });
+    const project = snapshot.projects[0];
+    if (!project) {
+      throw new Error("Expected the test snapshot to contain a project.");
+    }
+    const snapshotWithoutProjectDefault = {
+      ...snapshot,
+      projects: snapshot.projects.map((item) =>
+        item.id === project.id ? { ...item, defaultModelSelection: null } : item,
+      ),
+    };
+    const restoreNativeApi = installDeterministicSendNativeApi();
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: snapshotWithoutProjectDefault,
+      configureFixture: (nextFixture) => {
+        nextFixture.serverConfig = {
+          ...nextFixture.serverConfig,
+          providers: [
+            ...nextFixture.serverConfig.providers,
+            {
+              provider: "devin",
+              status: "ready",
+              available: true,
+              authStatus: "authenticated",
+              supportsAutoRuntimeMode: false,
+              checkedAt: NOW_ISO,
+            },
+          ],
+        };
+      },
+    });
+
+    try {
+      await page.getByTestId("new-thread-button").click();
+      const newThreadPath = await waitForURL(
+        mounted.router,
+        (path) => UUID_ROUTE_RE.test(path),
+        "Route should change to a Devin draft thread.",
+      );
+      const newThreadId = newThreadPath.slice(1) as ThreadId;
+
+      await vi.waitFor(
+        () => {
+          expect(
+            useComposerDraftStore.getState().getDraftThreadByProjectId(PROJECT_ID)?.threadId,
+          ).toBe(newThreadId);
+          expect(mounted.router.state.location.pathname).toBe(newThreadPath);
+          expect(mounted.router.state.status).toBe("idle");
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+      expect(useComposerDraftStore.getState().draftsByThreadId[newThreadId]).toMatchObject({
+        modelSelectionByProvider: {
+          devin: { provider: "devin", model: "adaptive" },
+        },
+        activeProvider: "devin",
+      });
+      await expect.element(page.getByText("Adaptive", { exact: true })).toBeInTheDocument();
+
+      useComposerDraftStore.getState().setPrompt(newThreadId, "Use the saved Devin default");
+      const composerEditor = await waitForComposerEditor();
+      await vi.waitFor(() =>
+        expect(composerEditor.textContent ?? "").toContain("Use the saved Devin default"),
+      );
+      wsRequests.length = 0;
+      const sendButton = await waitForSendButton();
+      const composerForm = document.querySelector<HTMLFormElement>(
+        'form[data-chat-composer-form="true"]',
+      );
+      expect(composerForm).not.toBeNull();
+      await vi.waitFor(() => expect(sendButton.disabled).toBe(false), {
+        timeout: 8_000,
+        interval: 16,
+      });
+      composerForm!.requestSubmit();
+
+      await vi.waitFor(() => {
+        const commands = wsRequests
+          .map(readDispatchedCommand)
+          .filter((command) => command !== null);
+        expect(commands).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: "thread.create",
+              threadId: newThreadId,
+              modelSelection: expect.objectContaining({ provider: "devin", model: "adaptive" }),
+            }),
+            expect.objectContaining({
+              type: "thread.turn.start",
+              threadId: newThreadId,
+              modelSelection: expect.objectContaining({ provider: "devin", model: "adaptive" }),
+            }),
+          ]),
+        );
+        expect(mounted.router.state.location.pathname).toBe(newThreadPath);
+        expect(document.body.textContent).toContain("Use the saved Devin default");
+      });
+    } finally {
+      restoreNativeApi();
+      await mounted.cleanup();
+    }
+  });
+
   it("applies the project model over sticky codex settings on a new thread", async () => {
     useComposerDraftStore.setState({
       stickyModelSelectionByProvider: {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -637,7 +637,11 @@ import {
   resolveDiffEnvironmentState,
   resolveThreadEnvironmentMode,
 } from "../lib/threadEnvironment";
-import { buildModelSelection, buildNextProviderOptions } from "../providerModelOptions";
+import {
+  DISCOVERY_OWNED_MODEL_PROVIDERS,
+  buildModelSelection,
+  buildNextProviderOptions,
+} from "../providerModelOptions";
 import {
   isDuplicateProjectCreateError,
   waitForRecoverableProjectForDuplicateCreate,
@@ -2321,7 +2325,6 @@ export default function ChatView({
   const selectedProvider = useMemo<ProviderKind>(
     () =>
       lockedProvider ??
-      // Keep an unstarted draft pinned to its explicit provider; availability is validated at send time.
       selectedProviderByThreadId ??
       resolveAvailableProviderPreference({
         preferredProvider: preferredDraftProvider,
@@ -2363,9 +2366,9 @@ export default function ChatView({
       antigravity: resolveHint("antigravity"),
       grok: resolveHint("grok"),
       droid: resolveHint("droid"),
+      devin: resolveHint("devin"),
       opencode: resolveHint("opencode"),
       pi: resolveHint("pi"),
-      devin: resolveHint("devin"),
     };
   }, [
     activeProject?.defaultModelSelection,
@@ -2380,11 +2383,9 @@ export default function ChatView({
   const {
     customModelsByProvider,
     modelOptionsByProvider,
-    loadingModelProviders,
-    discoveryErrorsByProvider,
+    modelDiscoveryByProvider,
     runtimeModelsByProvider,
     selectedRuntimeAgents: dynamicAgents,
-    selectedProviderModelsLoading,
     selectedProviderRuntimeModelDiscoveryPending,
   } = useProviderModelCatalog({
     selectedProvider,
@@ -2482,14 +2483,9 @@ export default function ChatView({
         ? activeProject.defaultModelSelection
         : null
       : (activeThread?.modelSelection ?? activeProject?.defaultModelSelection ?? null);
-  const providerModelsLoading = selectedProviderModelsLoading;
+  const providerModelsLoading = selectedProviderRuntimeModelDiscoveryPending;
   const selectedProviderRequiresRuntimeModels =
-    selectedProvider === "cursor" ||
-    selectedProvider === "antigravity" ||
-    selectedProvider === "droid" ||
-    selectedProvider === "opencode" ||
-    selectedProvider === "pi" ||
-    selectedProvider === "devin";
+    DISCOVERY_OWNED_MODEL_PROVIDERS.has(selectedProvider);
   const showComposerModelBootstrapSkeleton = shouldShowComposerModelBootstrapSkeleton({
     selectedProvider,
     selectedModel,
@@ -7918,6 +7914,9 @@ export default function ChatView({
         getDefaultModel(selectedModelSelectionForSend.provider) ||
         DEFAULT_MODEL_BY_PROVIDER.codex,
       selectedModelSelectionForSend.options,
+      selectedModelSelectionForSend.provider === "claudeAgent"
+        ? selectedModelSelectionForSend.supportsAutoMode
+        : undefined,
     );
     const firstSendTarget = resolveFirstSendTarget({
       activeProject,
@@ -9811,8 +9810,7 @@ export default function ChatView({
         lockedProvider={lockedProvider}
         providers={providerStatuses}
         modelOptionsByProvider={modelOptionsByProvider}
-        loadingModelProviders={loadingModelProviders}
-        discoveryErrorsByProvider={discoveryErrorsByProvider}
+        modelDiscoveryByProvider={modelDiscoveryByProvider}
         hiddenProviders={settings.hiddenProviders}
         providerOrder={settings.providerOrder}
         onProviderModelChange={onProviderModelSelect}
@@ -9848,8 +9846,7 @@ export default function ChatView({
       lockedProvider={lockedProvider}
       providers={providerStatuses}
       modelOptionsByProvider={modelOptionsByProvider}
-      loadingModelProviders={loadingModelProviders}
-      discoveryErrorsByProvider={discoveryErrorsByProvider}
+      modelDiscoveryByProvider={modelDiscoveryByProvider}
       hiddenProviders={settings.hiddenProviders}
       providerOrder={settings.providerOrder}
       threadId={threadId}

--- a/apps/web/src/components/chat/ComposerModelEffortPicker.tsx
+++ b/apps/web/src/components/chat/ComposerModelEffortPicker.tsx
@@ -18,6 +18,7 @@ import { useState } from "react";
 import { ChevronDownIcon, FastModeIcon, SettingsIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
 import { type ProviderModelOption } from "../../providerModelOptions";
+import type { ProviderModelDiscoveryState } from "../../hooks/useProviderModelCatalog";
 import { Button } from "../ui/button";
 import { Menu, MenuSeparator, MenuSub, MenuSubTrigger, MenuTrigger } from "../ui/menu";
 import { ShortcutKbd } from "../ui/shortcut-kbd";
@@ -49,8 +50,7 @@ type ComposerModelEffortPickerProps = {
   lockedProvider: ProviderKind | null;
   providers?: ReadonlyArray<ServerProviderStatus>;
   modelOptionsByProvider: Record<ProviderKind, ReadonlyArray<ProviderModelOption>>;
-  loadingModelProviders?: Partial<Record<ProviderKind, boolean>>;
-  discoveryErrorsByProvider?: Partial<Record<ProviderKind, string | undefined>>;
+  modelDiscoveryByProvider?: Record<ProviderKind, ProviderModelDiscoveryState>;
   hiddenProviders?: ReadonlyArray<ProviderKind>;
   providerOrder?: ReadonlyArray<ProviderKind>;
   compact?: boolean;
@@ -253,11 +253,8 @@ export function ComposerModelEffortPicker(props: ComposerModelEffortPickerProps)
               lockedProvider={props.lockedProvider}
               {...(props.providers ? { providers: props.providers } : {})}
               modelOptionsByProvider={props.modelOptionsByProvider}
-              {...(props.loadingModelProviders
-                ? { loadingModelProviders: props.loadingModelProviders }
-                : {})}
-              {...(props.discoveryErrorsByProvider
-                ? { discoveryErrorsByProvider: props.discoveryErrorsByProvider }
+              {...(props.modelDiscoveryByProvider
+                ? { modelDiscoveryByProvider: props.modelDiscoveryByProvider }
                 : {})}
               {...(props.hiddenProviders ? { hiddenProviders: props.hiddenProviders } : {})}
               {...(props.providerOrder ? { providerOrder: props.providerOrder } : {})}

--- a/apps/web/src/components/chat/ProviderModelOptionGroupList.tsx
+++ b/apps/web/src/components/chat/ProviderModelOptionGroupList.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 import { StarFilledIcon, StarIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
 import {
+  DISCOVERY_OWNED_MODEL_PROVIDERS,
   resolveModelGroupDefaultOpen,
   shouldUseCollapsibleModelGroups,
   providerModelCostMultiplierLabel,
@@ -16,6 +17,7 @@ import {
   type ProviderModelOptionGroup,
 } from "../../providerModelOptions";
 import type { ProviderKind } from "@synara/contracts";
+import type { FavoriteModelProvider } from "../../lib/modelFavorites";
 import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from "../ui/collapsible";
 import { DisclosureChevron } from "../ui/DisclosureChevron";
 import { MenuGroup, MenuGroupLabel, MenuRadioItem } from "../ui/menu";
@@ -25,8 +27,6 @@ import {
   COMPOSER_PICKER_RADIUS_CLASS_NAME,
 } from "./composerPickerStyles";
 
-type FavoriteModelProvider = "cursor" | "opencode" | "pi";
-
 type ProviderModelOptionGroupListProps = {
   groupedOptions: ReadonlyArray<ProviderModelOptionGroup>;
   provider: ProviderKind;
@@ -35,7 +35,6 @@ type ProviderModelOptionGroupListProps = {
   favoriteProvider: FavoriteModelProvider | null;
   favoriteModelSlugSet: ReadonlySet<string> | undefined;
   onToggleFavorite: (provider: FavoriteModelProvider, slug: string) => void;
-  onAfterSelection?: () => void;
 };
 
 function ProviderModelRadioItem(
@@ -46,18 +45,10 @@ function ProviderModelRadioItem(
     isFavorite: boolean;
     showProvenance: boolean;
     onToggleFavorite: (provider: FavoriteModelProvider, slug: string) => void;
-    onAfterSelection?: () => void;
   }>,
 ) {
-  const {
-    provider,
-    modelOption,
-    favoriteProvider,
-    isFavorite,
-    showProvenance,
-    onToggleFavorite,
-    onAfterSelection,
-  } = props;
+  const { provider, modelOption, favoriteProvider, isFavorite, showProvenance, onToggleFavorite } =
+    props;
   const supportsFavorites = favoriteProvider !== null;
   const costMultiplierLabel =
     provider === "droid" ? providerModelCostMultiplierLabel(modelOption.description) : null;
@@ -65,15 +56,33 @@ function ProviderModelRadioItem(
   const provenanceLabel = showProvenance
     ? providerModelOptionProvenanceLabel({ provider, option: modelOption })
     : null;
-  const accessibleModelName = provenanceLabel
-    ? `${modelOption.name} — ${provenanceLabel}`
-    : modelOption.name;
+  const showUnavailableBadge =
+    modelOption.isSelectionHint === true && DISCOVERY_OWNED_MODEL_PROVIDERS.has(provider);
+
+  const accessibleModelName = [
+    modelOption.name,
+    showUnavailableBadge ? "Unavailable?" : null,
+    provenanceLabel,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(" — ");
+
+  const nameWithBadge = (
+    <span className="flex min-w-0 items-center gap-1.5">
+      <span className="block min-w-0 truncate">{modelOption.name}</span>
+      {showUnavailableBadge ? (
+        <span className="shrink-0 rounded bg-muted px-1 py-px text-[10px] text-muted-foreground/70">
+          Unavailable?
+        </span>
+      ) : null}
+    </span>
+  );
 
   return (
     <MenuRadioItem
       key={`${provider}:${modelOption.slug}`}
       value={modelOption.slug}
-      {...(provenanceLabel ? { "aria-label": accessibleModelName } : {})}
+      {...(provenanceLabel || showUnavailableBadge ? { "aria-label": accessibleModelName } : {})}
       preserveChildLayout={preserveChildLayout}
       className={costMultiplierLabel ? "grid-cols-[minmax(0,1fr)_auto]" : undefined}
       trailing={
@@ -115,9 +124,6 @@ function ProviderModelRadioItem(
           </span>
         ) : null
       }
-      onClick={() => {
-        onAfterSelection?.();
-      }}
     >
       {preserveChildLayout ? (
         <span
@@ -126,7 +132,7 @@ function ProviderModelRadioItem(
             supportsFavorites && COMPOSER_PICKER_MODEL_ROW_LABEL_INDENT_CLASS_NAME,
           )}
         >
-          <span className="block min-w-0 truncate">{modelOption.name}</span>
+          {nameWithBadge}
           {provenanceLabel ? (
             <span
               aria-hidden="true"
@@ -137,7 +143,7 @@ function ProviderModelRadioItem(
           ) : null}
         </span>
       ) : (
-        modelOption.name
+        nameWithBadge
       )}
     </MenuRadioItem>
   );
@@ -191,7 +197,6 @@ export function ProviderModelOptionGroupList(props: ProviderModelOptionGroupList
             isFavorite={props.favoriteModelSlugSet?.has(modelOption.slug) ?? false}
             showProvenance={group.key === "__favorites__"}
             onToggleFavorite={props.onToggleFavorite}
-            {...(props.onAfterSelection ? { onAfterSelection: props.onAfterSelection } : {})}
           />
         ));
 

--- a/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -821,8 +821,13 @@ describe("ProviderModelPicker", () => {
     try {
       await page.getByRole("button").click();
 
+      // The droid cost description ("0.4x Factory token rate") lands in the
+      // row's accessible name via an sr-only span, so an exact name match
+      // can never hit. Match by substring plus checked state instead: only
+      // the selected row is checked, which also disambiguates it from the
+      // "Custom GPT-5.6 Luna" row below.
       await expect
-        .element(page.getByRole("menuitemradio", { name: "GPT-5.6 Luna", exact: true }))
+        .element(page.getByRole("menuitemradio", { name: "GPT-5.6 Luna", checked: true }))
         .toBeInTheDocument();
       // The user's own custom model stays selectable offline; the static
       // built-in that discovery owns stays hidden.

--- a/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -2,10 +2,13 @@ import { type ModelSlug, type ProviderKind, type ServerProviderStatus } from "@s
 import { page } from "vitest/browser";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
+import { QueryClient, QueryClientProvider, QueryObserver } from "@tanstack/react-query";
 
 import { ProviderModelPicker } from "./ProviderModelPicker";
 import type { ProviderModelOption } from "../../providerModelOptions";
+import type { ProviderModelDiscoveryState } from "../../hooks/useProviderModelCatalog";
 import { FAVORITE_MODEL_STORAGE_KEYS } from "../../lib/modelFavorites";
+import { providerDiscoveryQueryKeys } from "../../lib/providerDiscoveryReactQuery";
 
 const MODEL_OPTIONS_BY_PROVIDER = {
   claudeAgent: [
@@ -145,39 +148,66 @@ const PI_FAVORITE_SORT_MODELS = [
   },
 ] satisfies ReadonlyArray<ProviderModelOption & { slug: ModelSlug }>;
 
+const DEFAULT_MODEL_DISCOVERY: ProviderModelDiscoveryState = {
+  status: "never-loaded",
+  hasDynamicList: false,
+  refreshing: false,
+};
+
+const DEFAULT_MODEL_DISCOVERY_BY_PROVIDER: Record<ProviderKind, ProviderModelDiscoveryState> = {
+  antigravity: DEFAULT_MODEL_DISCOVERY,
+  claudeAgent: { status: "success", hasDynamicList: false, refreshing: false },
+  codex: { status: "success", hasDynamicList: false, refreshing: false },
+  cursor: DEFAULT_MODEL_DISCOVERY,
+  devin: DEFAULT_MODEL_DISCOVERY,
+  droid: DEFAULT_MODEL_DISCOVERY,
+  grok: DEFAULT_MODEL_DISCOVERY,
+  opencode: DEFAULT_MODEL_DISCOVERY,
+  pi: DEFAULT_MODEL_DISCOVERY,
+};
+
 async function mountPicker(props: {
   provider: ProviderKind;
   model: ModelSlug;
   lockedProvider: ProviderKind | null;
   providers?: ReadonlyArray<ServerProviderStatus>;
-  loadingModelProviders?: Partial<Record<ProviderKind, boolean>>;
+  modelDiscoveryByProvider?: Partial<Record<ProviderKind, ProviderModelDiscoveryState>>;
   onSelectionCommitted?: () => void;
   modelOptionsByProvider?: Record<
     ProviderKind,
     ReadonlyArray<ProviderModelOption & { slug: ModelSlug }>
   >;
+  queryClient?: QueryClient;
 }) {
   const host = document.createElement("div");
   document.body.append(host);
   const onProviderModelChange = vi.fn();
+  const queryClient = props.queryClient ?? new QueryClient();
+  const modelDiscoveryByProvider: Record<ProviderKind, ProviderModelDiscoveryState> = {
+    ...DEFAULT_MODEL_DISCOVERY_BY_PROVIDER,
+    ...props.modelDiscoveryByProvider,
+  };
   const screen = await render(
-    <ProviderModelPicker
-      provider={props.provider}
-      model={props.model}
-      lockedProvider={props.lockedProvider}
-      modelOptionsByProvider={props.modelOptionsByProvider ?? MODEL_OPTIONS_BY_PROVIDER}
-      {...(props.loadingModelProviders
-        ? { loadingModelProviders: props.loadingModelProviders }
-        : {})}
-      {...(props.providers ? { providers: props.providers } : {})}
-      {...(props.onSelectionCommitted ? { onSelectionCommitted: props.onSelectionCommitted } : {})}
-      onProviderModelChange={onProviderModelChange}
-    />,
+    <QueryClientProvider client={queryClient}>
+      <ProviderModelPicker
+        provider={props.provider}
+        model={props.model}
+        lockedProvider={props.lockedProvider}
+        modelOptionsByProvider={props.modelOptionsByProvider ?? MODEL_OPTIONS_BY_PROVIDER}
+        modelDiscoveryByProvider={modelDiscoveryByProvider}
+        {...(props.providers ? { providers: props.providers } : {})}
+        {...(props.onSelectionCommitted
+          ? { onSelectionCommitted: props.onSelectionCommitted }
+          : {})}
+        onProviderModelChange={onProviderModelChange}
+      />
+    </QueryClientProvider>,
     { container: host },
   );
 
   return {
     onProviderModelChange,
+    queryClient,
     cleanup: async () => {
       await screen.unmount();
       host.remove();
@@ -598,7 +628,13 @@ describe("ProviderModelPicker", () => {
       provider: "cursor",
       model: "auto",
       lockedProvider: "cursor",
-      loadingModelProviders: { cursor: true },
+      modelDiscoveryByProvider: {
+        cursor: {
+          status: "loading",
+          hasDynamicList: false,
+          refreshing: false,
+        } satisfies ProviderModelDiscoveryState,
+      },
     });
 
     try {
@@ -717,6 +753,301 @@ describe("ProviderModelPicker", () => {
 
       await expect.element(page.getByText("Sign in")).not.toBeInTheDocument();
       await expect.element(page.getByText("Unavailable")).not.toBeInTheDocument();
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("shows the selected model with a failure row when OpenCode discovery failed without a cache", async () => {
+    const mounted = await mountPicker({
+      provider: "opencode",
+      model: "openai/gpt-5",
+      lockedProvider: "opencode",
+      modelDiscoveryByProvider: {
+        opencode: {
+          status: "failed",
+          hasDynamicList: false,
+          refreshing: false,
+        } satisfies ProviderModelDiscoveryState,
+      },
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await expect.element(page.getByRole("menuitemradio", { name: "GPT-5" })).toBeInTheDocument();
+      await expect
+        .element(page.getByRole("menuitemradio", { name: "Nemotron 3 Super Free" }))
+        .not.toBeInTheDocument();
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? "";
+        expect(text).toContain("Couldn\u2019t load models");
+        expect(text).toContain("Retry");
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("applies the same restricted failure row to every discovery-owned provider", async () => {
+    const mounted = await mountPicker({
+      provider: "droid",
+      model: "gpt-5.6-luna",
+      lockedProvider: "droid",
+      modelDiscoveryByProvider: {
+        droid: {
+          status: "failed",
+          hasDynamicList: false,
+          refreshing: false,
+        } satisfies ProviderModelDiscoveryState,
+      },
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await expect
+        .element(page.getByRole("menuitemradio", { name: "GPT-5.6 Luna" }))
+        .toBeInTheDocument();
+      await expect
+        .element(page.getByRole("menuitemradio", { name: "Custom GPT-5.6 Luna" }))
+        .not.toBeInTheDocument();
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? "";
+        expect(text).toContain("Couldn\u2019t load models");
+        expect(text).toContain("Retry");
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("shows the cached list and a 'Couldn\u2019t refresh \u2014 Retry' footer when discovery failed with a cache", async () => {
+    const mounted = await mountPicker({
+      provider: "opencode",
+      model: "openai/gpt-5",
+      lockedProvider: "opencode",
+      modelDiscoveryByProvider: {
+        opencode: {
+          status: "failed",
+          hasDynamicList: true,
+          refreshing: false,
+          fetchedAt: Date.now(),
+        } satisfies ProviderModelDiscoveryState,
+      },
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await expect.element(page.getByRole("menuitemradio", { name: "GPT-5" })).toBeInTheDocument();
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? "";
+        expect(text).toContain("Couldn\u2019t refresh");
+        expect(text).toContain("Retry");
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("shows the selected model with an empty OpenCode row without fallback models", async () => {
+    const mounted = await mountPicker({
+      provider: "opencode",
+      model: "openai/gpt-5",
+      lockedProvider: "opencode",
+      modelDiscoveryByProvider: {
+        opencode: {
+          status: "empty",
+          hasDynamicList: false,
+          refreshing: false,
+          fetchedAt: Date.now(),
+        } satisfies ProviderModelDiscoveryState,
+      },
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await expect.element(page.getByRole("menuitemradio", { name: "GPT-5" })).toBeInTheDocument();
+      await expect
+        .element(page.getByRole("menuitemradio", { name: "Nemotron 3 Super Free" }))
+        .not.toBeInTheDocument();
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? "";
+        expect(text).toContain("No models available from OpenCode");
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("shows the OpenCode list and a 'Refreshing\u2026' footer while a refresh is in flight", async () => {
+    const mounted = await mountPicker({
+      provider: "opencode",
+      model: "openai/gpt-5",
+      lockedProvider: "opencode",
+      modelDiscoveryByProvider: {
+        opencode: {
+          status: "success",
+          hasDynamicList: true,
+          refreshing: true,
+          fetchedAt: Date.now(),
+        } satisfies ProviderModelDiscoveryState,
+      },
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await expect.element(page.getByRole("menuitemradio", { name: "GPT-5" })).toBeInTheDocument();
+      await expect.element(page.getByText("Refreshing\u2026")).toBeInTheDocument();
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("fires a single model query refetch when the refresh footer is clicked", async () => {
+    const queryClient = new QueryClient();
+    const modelsQueryKey = providerDiscoveryQueryKeys.models("opencode", null, null, null, null);
+    // refetchQueries only refetches active queries, so the observer must be enabled.
+    const modelsObserver = new QueryObserver(queryClient, {
+      queryKey: modelsQueryKey,
+      queryFn: () =>
+        Promise.resolve({ models: [], source: "opencode" as const, cached: false as const }),
+    });
+    const unsubscribeObserver = modelsObserver.subscribe(() => undefined);
+    const modelsQuery = queryClient.getQueryCache().find({ queryKey: modelsQueryKey })!;
+    const fetchSpy = vi.spyOn(modelsQuery, "fetch").mockImplementation(() => Promise.resolve());
+    const mounted = await mountPicker({
+      queryClient,
+      provider: "opencode",
+      model: "openai/gpt-5",
+      lockedProvider: "opencode",
+      modelDiscoveryByProvider: {
+        opencode: {
+          status: "success",
+          hasDynamicList: true,
+          refreshing: false,
+          fetchedAt: Date.now(),
+        } satisfies ProviderModelDiscoveryState,
+      },
+    });
+
+    try {
+      await page.getByRole("button").click();
+      await page.getByRole("button", { name: "Refresh models" }).click();
+
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      unsubscribeObserver();
+      await mounted.cleanup();
+    }
+  });
+
+  it("disables the refresh action while a refetch is already in flight", async () => {
+    const queryClient = new QueryClient();
+    const mounted = await mountPicker({
+      queryClient,
+      provider: "opencode",
+      model: "openai/gpt-5",
+      lockedProvider: "opencode",
+      modelDiscoveryByProvider: {
+        opencode: {
+          status: "success",
+          hasDynamicList: true,
+          refreshing: true,
+          fetchedAt: Date.now(),
+        } satisfies ProviderModelDiscoveryState,
+      },
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      const footer = page.getByRole("button", { name: /Refresh models/ });
+      await expect.element(footer).toBeInTheDocument();
+      await expect.element(footer).toBeDisabled();
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("shows an 'Unavailable?' badge on a selection hint in a successful list", async () => {
+    const mounted = await mountPicker({
+      provider: "opencode",
+      model: "opencode/unknown-model",
+      lockedProvider: "opencode",
+      modelDiscoveryByProvider: {
+        opencode: {
+          status: "success",
+          hasDynamicList: true,
+          refreshing: false,
+          fetchedAt: Date.now(),
+        } satisfies ProviderModelDiscoveryState,
+      },
+      modelOptionsByProvider: {
+        ...MODEL_OPTIONS_BY_PROVIDER,
+        opencode: [
+          ...MODEL_OPTIONS_BY_PROVIDER.opencode,
+          {
+            slug: "opencode/unknown-model" as ModelSlug,
+            name: "Unknown Model",
+            isSelectionHint: true,
+          },
+        ],
+      },
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await expect.element(page.getByText("Unavailable?")).toBeInTheDocument();
+      await page.getByRole("menuitemradio", { name: /Unknown Model/ }).click();
+      expect(mounted.onProviderModelChange).toHaveBeenCalledWith(
+        "opencode",
+        "opencode/unknown-model",
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+  it("marks a stale Devin GLM selection instead of presenting it as discovered", async () => {
+    const mounted = await mountPicker({
+      provider: "devin",
+      model: "glm-5.3",
+      lockedProvider: "devin",
+      modelDiscoveryByProvider: {
+        devin: {
+          status: "success",
+          hasDynamicList: true,
+          refreshing: false,
+          fetchedAt: Date.now(),
+        },
+      },
+      modelOptionsByProvider: {
+        ...MODEL_OPTIONS_BY_PROVIDER,
+        devin: [
+          { slug: "adaptive" as ModelSlug, name: "Adaptive" },
+          { slug: "swe-1-7" as ModelSlug, name: "SWE 1.7" },
+          { slug: "glm-5.3" as ModelSlug, name: "GLM 5.3", isSelectionHint: true },
+        ],
+      },
+    });
+
+    try {
+      await page.getByRole("button").click();
+      await expect
+        .element(page.getByRole("menuitemradio", { name: "GLM 5.3 — Unavailable?" }))
+        .toBeInTheDocument();
+      await expect
+        .element(page.getByRole("menuitemradio", { name: "Adaptive" }))
+        .toBeInTheDocument();
+      await expect
+        .element(page.getByRole("menuitemradio", { name: "SWE 1.7" }))
+        .toBeInTheDocument();
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -34,7 +34,7 @@ const MODEL_OPTIONS_BY_PROVIDER = {
       name: "GPT-5.6 Luna",
       description: "0.4x Factory token rate",
     },
-    { slug: "custom:GPT-5.6-Luna-0", name: "Custom GPT-5.6 Luna" },
+    { slug: "custom:GPT-5.6-Luna-0", name: "Custom GPT-5.6 Luna", isCustom: true },
   ],
   opencode: [
     {
@@ -72,7 +72,10 @@ const MODEL_OPTIONS_BY_PROVIDER = {
       name: "Gemini 3.5 Flash",
     },
   ],
-} as const satisfies Record<ProviderKind, ReadonlyArray<ProviderModelOption & { slug: ModelSlug }>>;
+} as const satisfies Record<
+  ProviderKind,
+  ReadonlyArray<ProviderModelOption & { slug: ModelSlug; isCustom?: boolean }>
+>;
 
 const MANY_OPENCODE_MODELS = Array.from({ length: 16 }, (_, index) => ({
   slug: `${index % 2 === 0 ? "openai" : "anthropic"}/model-${index + 1}` as ModelSlug,
@@ -175,7 +178,7 @@ async function mountPicker(props: {
   onSelectionCommitted?: () => void;
   modelOptionsByProvider?: Record<
     ProviderKind,
-    ReadonlyArray<ProviderModelOption & { slug: ModelSlug }>
+    ReadonlyArray<ProviderModelOption & { slug: ModelSlug; isCustom?: boolean }>
   >;
   queryClient?: QueryClient;
 }) {
@@ -794,6 +797,18 @@ describe("ProviderModelPicker", () => {
       provider: "droid",
       model: "gpt-5.6-luna",
       lockedProvider: "droid",
+      modelOptionsByProvider: {
+        ...MODEL_OPTIONS_BY_PROVIDER,
+        droid: [
+          {
+            slug: "gpt-5.6-luna",
+            name: "GPT-5.6 Luna",
+            description: "0.4x Factory token rate",
+          },
+          { slug: "custom:GPT-5.6-Luna-0", name: "Custom GPT-5.6 Luna", isCustom: true },
+          { slug: "gpt-5.6-flash", name: "GPT-5.6 Flash" },
+        ],
+      },
       modelDiscoveryByProvider: {
         droid: {
           status: "failed",
@@ -807,10 +822,15 @@ describe("ProviderModelPicker", () => {
       await page.getByRole("button").click();
 
       await expect
-        .element(page.getByRole("menuitemradio", { name: "GPT-5.6 Luna" }))
+        .element(page.getByRole("menuitemradio", { name: "GPT-5.6 Luna", exact: true }))
+        .toBeInTheDocument();
+      // The user's own custom model stays selectable offline; the static
+      // built-in that discovery owns stays hidden.
+      await expect
+        .element(page.getByRole("menuitemradio", { name: "Custom GPT-5.6 Luna", exact: true }))
         .toBeInTheDocument();
       await expect
-        .element(page.getByRole("menuitemradio", { name: "Custom GPT-5.6 Luna" }))
+        .element(page.getByRole("menuitemradio", { name: "GPT-5.6 Flash", exact: true }))
         .not.toBeInTheDocument();
       await vi.waitFor(() => {
         const text = document.body.textContent ?? "";

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -3,10 +3,17 @@
 // Layer: Chat composer presentation
 // Depends on: provider availability metadata, shared menu primitives, and picker trigger styling.
 
-import { type ModelSlug, type ProviderKind, type ServerProviderStatus } from "@synara/contracts";
+import {
+  type ModelSlug,
+  type ProviderKind,
+  type ServerProviderStatus,
+  PROVIDER_DISPLAY_NAMES,
+} from "@synara/contracts";
 import { resolveSelectableModel } from "@synara/shared/model";
 import * as Schema from "effect/Schema";
 import { useDeferredValue, useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { providerDiscoveryQueryKeys } from "../../lib/providerDiscoveryReactQuery";
 import { type ProviderPickerKind, PROVIDER_OPTIONS } from "../../session-logic";
 import { appHistory } from "../../appNavigation";
 import { formatProviderModelOptionName } from "../../providerModelOptions";
@@ -30,10 +37,12 @@ import {
   COMPOSER_PICKER_MODEL_LIST_MAX_HEIGHT_CLASS_NAME,
   COMPOSER_PICKER_MODEL_LIST_SCROLL_CLASS_NAME,
   COMPOSER_PICKER_MODEL_SUBMENU_HEIGHT_CLASS_NAME,
+  COMPOSER_PICKER_MENU_OPTION_CLASS_NAME,
 } from "./composerPickerStyles";
 import { ShortcutKbd } from "../ui/shortcut-kbd";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import {
+  DISCOVERY_OWNED_MODEL_PROVIDERS,
   groupProviderModelOptions,
   groupProviderModelOptionsWithFavorites,
   shouldUseCollapsibleModelGroups,
@@ -46,66 +55,10 @@ import {
   type FavoriteModelProvider,
 } from "../../lib/modelFavorites";
 import { Skeleton } from "../ui/skeleton";
-import { PlusIcon } from "~/lib/icons";
+import { PlusIcon, RefreshCwIcon } from "~/lib/icons";
+import type { ProviderModelDiscoveryState } from "../../hooks/useProviderModelCatalog";
 
-function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {
-  value: ProviderKind;
-  label: string;
-  available: true;
-} {
-  return option.available;
-}
-
-function resolveLiveProviderAvailability(provider: ServerProviderStatus | undefined): {
-  disabled: boolean;
-  label: string | null;
-} {
-  if (!provider) {
-    return {
-      disabled: true,
-      label: "Checking",
-    };
-  }
-
-  if (!provider.available) {
-    return {
-      disabled: true,
-      label: provider.authStatus === "unauthenticated" ? "Sign in" : "Unavailable",
-    };
-  }
-
-  if (provider.authStatus === "unauthenticated") {
-    return {
-      disabled: true,
-      label: "Sign in",
-    };
-  }
-
-  return {
-    disabled: false,
-    label: null,
-  };
-}
-
-export const AVAILABLE_PROVIDER_OPTIONS = PROVIDER_OPTIONS.filter(isAvailableProviderOption);
-
-// Removes user-hidden providers from a provider option list while always
-// preserving any providers the caller marks as protected (the active and
-// locked provider for the current thread). Without that carve-out, hiding the
-// provider you're already using would erase the entry that lets you switch
-// away from it.
-function filterProviderOptionsByVisibility<T extends { value: ProviderKind }>(
-  options: ReadonlyArray<T>,
-  hiddenProviders: ReadonlySet<ProviderKind>,
-  protectedProviders: ReadonlySet<ProviderKind>,
-): ReadonlyArray<T> {
-  if (hiddenProviders.size === 0) {
-    return options;
-  }
-  return options.filter(
-    (option) => protectedProviders.has(option.value) || !hiddenProviders.has(option.value),
-  );
-}
+export const AVAILABLE_PROVIDER_OPTIONS = PROVIDER_OPTIONS.filter((option) => option.available);
 
 function providerIconClassName(
   provider: ProviderKind | ProviderPickerKind,
@@ -137,12 +90,9 @@ function resolveSelectedModelLabel(input: {
   model: string;
   options: ReadonlyArray<ProviderModelOption>;
 }): string {
-  const resolvedSlug = resolveSelectableModel(input.provider, input.model, input.options);
-  if (resolvedSlug) {
-    const resolvedOption = input.options.find((option) => option.slug === resolvedSlug);
-    if (resolvedOption) {
-      return resolvedOption.name;
-    }
+  const exact = input.options.find((option) => option.slug === input.model);
+  if (exact) {
+    return exact.name;
   }
   if (input.provider === "cursor") {
     const baseModel = stripParameterizedModelSuffix(input.model);
@@ -172,26 +122,111 @@ function buildModelSearchText(option: ProviderModelOption): string {
     .toLowerCase();
 }
 
+function formatCatalogAgeLabel(fetchedAt: number | undefined): string {
+  if (!fetchedAt || Date.now() - fetchedAt < 60_000) return fetchedAt ? "Updated just now" : "";
+  const minutes = Math.floor((Date.now() - fetchedAt) / 60_000);
+  const [amount, unit] =
+    minutes < 60
+      ? [minutes, "minute"]
+      : minutes < 1440
+        ? [Math.floor(minutes / 60), "hour"]
+        : [Math.floor(minutes / 1440), "day"];
+  return `Updated ${new Intl.RelativeTimeFormat("en", { style: "narrow", numeric: "always" }).format(-amount, unit as Intl.RelativeTimeFormatUnit)}`;
+}
+
+function DiscoveryStatusRow({
+  provider,
+  discovery,
+  onRefresh,
+}: {
+  provider: ProviderKind;
+  discovery: ProviderModelDiscoveryState;
+  onRefresh: () => void;
+}) {
+  if (discovery.status === "never-loaded" || discovery.status === "loading") return null;
+  const busy = discovery.refreshing;
+  const displayName = PROVIDER_DISPLAY_NAMES[provider];
+  const noList = discovery.status === "failed" && !discovery.hasDynamicList;
+  const title =
+    discovery.status === "empty"
+      ? `No models available from ${displayName}`
+      : noList
+        ? "Couldn’t load models"
+        : discovery.status === "failed"
+          ? "Couldn’t refresh"
+          : "Refresh models";
+  const detail =
+    discovery.status === "empty"
+      ? `Check the ${displayName} configuration and authentication, then retry.`
+      : noList
+        ? `${displayName} discovery failed`
+        : null;
+  const action = busy
+    ? "Refreshing…"
+    : discovery.status === "success"
+      ? formatCatalogAgeLabel(discovery.fetchedAt)
+      : "Retry";
+  return (
+    <button
+      type="button"
+      disabled={busy}
+      className={cn(
+        COMPOSER_PICKER_MENU_OPTION_CLASS_NAME,
+        "w-full justify-between gap-2 text-[length:var(--app-font-size-ui,12px)] text-foreground hover:bg-[var(--color-background-button-secondary-hover)] disabled:cursor-not-allowed disabled:opacity-60",
+      )}
+      onClick={(event) => {
+        event.stopPropagation();
+        onRefresh();
+      }}
+      onPointerDown={(event) => event.stopPropagation()}
+    >
+      <span
+        className={
+          detail
+            ? "flex min-w-0 flex-col items-start text-left"
+            : "inline-flex items-center gap-1.5"
+        }
+      >
+        {!detail ? (
+          <RefreshCwIcon
+            aria-hidden="true"
+            className={cn("size-3 shrink-0", busy && "animate-spin motion-reduce:animate-none")}
+          />
+        ) : null}
+        <span>{title}</span>
+        {detail ? (
+          <span className="text-[length:var(--app-font-size-ui-2xs,10px)] text-muted-foreground/70">
+            {detail}
+          </span>
+        ) : null}
+      </span>
+      <span
+        className={cn(
+          "shrink-0",
+          discovery.status === "success" &&
+            "text-[length:var(--app-font-size-ui-2xs,10px)] text-muted-foreground/70",
+        )}
+      >
+        {action}
+      </span>
+    </button>
+  );
+}
+
 type ProviderModelMenuItemsProps = {
   provider: ProviderKind;
   model: ModelSlug;
   lockedProvider: ProviderKind | null;
   providers?: ReadonlyArray<ServerProviderStatus>;
   modelOptionsByProvider: Record<ProviderKind, ReadonlyArray<ProviderModelOption>>;
-  loadingModelProviders?: Partial<Record<ProviderKind, boolean>>;
-  discoveryErrorsByProvider?: Partial<Record<ProviderKind, string | undefined>>;
+  modelDiscoveryByProvider?: Record<ProviderKind, ProviderModelDiscoveryState>;
   hiddenProviders?: ReadonlyArray<ProviderKind>;
   providerOrder?: ReadonlyArray<ProviderKind>;
   disabled?: boolean;
   onProviderModelChange: (provider: ProviderKind, model: ModelSlug) => void;
-  // Invoked after a model selection commits so callers can close ancestor
-  // menus and refocus the composer.
   onAfterSelection?: () => void;
 };
 
-// Renders only the popup body of the provider/model picker. Designed to be
-// dropped into any shared picker popup or submenu so the same selection logic can
-// be reused by the standalone picker and the combined composer trait picker.
 export const ProviderModelMenuItems = function ProviderModelMenuItems(
   props: ProviderModelMenuItemsProps,
 ) {
@@ -214,29 +249,23 @@ export const ProviderModelMenuItems = function ProviderModelMenuItems(
   );
   const deferredModelSearchQuery = useDeferredValue(modelSearchQuery);
   const activeProvider = props.lockedProvider ?? props.provider;
-  const hiddenProviders = props.hiddenProviders;
-  const providerOrder = props.providerOrder;
-  const hiddenProviderSet = new Set<ProviderKind>(hiddenProviders ?? []);
+  const hiddenProviderSet = new Set<ProviderKind>(props.hiddenProviders ?? []);
   const protectedProviderSet = new Set<ProviderKind>([props.provider]);
   if (props.lockedProvider !== null) {
     protectedProviderSet.add(props.lockedProvider);
   }
-  const visibleAvailableProviderOptions = filterProviderOptionsByVisibility(
-    AVAILABLE_PROVIDER_OPTIONS.toSorted((left, right) =>
-      compareProvidersByOrder(providerOrder ?? [], left.value, right.value),
-    ).filter((option) =>
-      props.providers?.some((provider) => provider.provider === option.value && provider.available),
-    ),
-    hiddenProviderSet,
-    protectedProviderSet,
+  const availableProviderOptions = AVAILABLE_PROVIDER_OPTIONS.toSorted((left, right) =>
+    compareProvidersByOrder(props.providerOrder ?? [], left.value, right.value),
+  ).filter((option) =>
+    props.providers?.some((provider) => provider.provider === option.value && provider.available),
   );
-  const openCodeFavoriteModelSlugSet = new Set(openCodeFavoriteModelSlugs);
-  const cursorFavoriteModelSlugSet = new Set(cursorFavoriteModelSlugs);
-  const piFavoriteModelSlugSet = new Set(piFavoriteModelSlugs);
+  const visibleAvailableProviderOptions = availableProviderOptions.filter(
+    (option) => protectedProviderSet.has(option.value) || !hiddenProviderSet.has(option.value),
+  );
   const favoriteModelSlugSets = {
-    cursor: cursorFavoriteModelSlugSet,
-    opencode: openCodeFavoriteModelSlugSet,
-    pi: piFavoriteModelSlugSet,
+    cursor: new Set(cursorFavoriteModelSlugs),
+    opencode: new Set(openCodeFavoriteModelSlugs),
+    pi: new Set(piFavoriteModelSlugs),
   };
   const handleModelChange = (provider: ProviderKind, value: string) => {
     if (props.disabled) return;
@@ -250,18 +279,22 @@ export const ProviderModelMenuItems = function ProviderModelMenuItems(
     props.onProviderModelChange(provider, resolvedModel);
     onAfterSelection?.();
   };
+  const favoriteSetters = {
+    cursor: setCursorFavoriteModelSlugs,
+    opencode: setOpenCodeFavoriteModelSlugs,
+    pi: setPiFavoriteModelSlugs,
+  };
   const toggleFavoriteModel = (provider: FavoriteModelProvider, slug: string) => {
-    const setFavoriteModelSlugs =
-      provider === "cursor"
-        ? setCursorFavoriteModelSlugs
-        : provider === "pi"
-          ? setPiFavoriteModelSlugs
-          : setOpenCodeFavoriteModelSlugs;
-    setFavoriteModelSlugs((current) => toggleFavoriteModelSlug(current, slug));
+    favoriteSetters[provider]((current) => toggleFavoriteModelSlug(current, slug));
   };
 
+  const queryClient = useQueryClient();
+
   const renderModelRadioGroup = (provider: ProviderKind) => {
-    if (props.loadingModelProviders?.[provider]) {
+    const discovery = props.modelDiscoveryByProvider?.[provider];
+    const isDiscoveryOwned = DISCOVERY_OWNED_MODEL_PROVIDERS.has(provider);
+
+    if (isDiscoveryOwned && discovery?.status === "loading") {
       return (
         <div className="space-y-2 px-2 py-2" aria-label="Loading models">
           {Array.from({ length: 6 }, (_, index) => (
@@ -275,12 +308,7 @@ export const ProviderModelMenuItems = function ProviderModelMenuItems(
     }
 
     const providerOptions = props.modelOptionsByProvider[provider];
-    const shouldShowSearch =
-      (provider === "opencode" ||
-        provider === "cursor" ||
-        provider === "devin" ||
-        provider === "pi") &&
-      providerOptions.length >= SEARCHABLE_MODEL_PICKER_THRESHOLD;
+    const shouldShowSearch = providerOptions.length >= SEARCHABLE_MODEL_PICKER_THRESHOLD;
     const normalizedModelSearchQuery = deferredModelSearchQuery.trim().toLowerCase();
     const filteredOptions =
       shouldShowSearch && normalizedModelSearchQuery.length > 0
@@ -299,11 +327,6 @@ export const ProviderModelMenuItems = function ProviderModelMenuItems(
           })
         : groupProviderModelOptions(filteredOptions);
 
-    const discoveryError = props.discoveryErrorsByProvider?.[provider];
-    const discoveryErrorElement = discoveryError ? (
-      <div className="px-2 py-1.5 text-xs text-destructive">{discoveryError}</div>
-    ) : null;
-
     const content =
       groupedOptions.length > 0 ? (
         <MenuRadioGroup
@@ -318,7 +341,6 @@ export const ProviderModelMenuItems = function ProviderModelMenuItems(
             favoriteProvider={favoriteProvider}
             favoriteModelSlugSet={favoriteModelSlugSet}
             onToggleFavorite={toggleFavoriteModel}
-            {...(onAfterSelection ? { onAfterSelection } : {})}
           />
         </MenuRadioGroup>
       ) : (
@@ -329,32 +351,81 @@ export const ProviderModelMenuItems = function ProviderModelMenuItems(
         </div>
       );
 
+    const discoveryStatusRow =
+      isDiscoveryOwned && discovery !== undefined ? (
+        <DiscoveryStatusRow
+          provider={provider}
+          discovery={discovery}
+          onRefresh={() => {
+            // refetchQueries defaults to active queries, so only mounted
+            // pickers trigger discovery work.
+            void queryClient
+              .refetchQueries({
+                queryKey: providerDiscoveryQueryKeys.modelsForProvider(provider),
+              })
+              .catch(() => undefined);
+          }}
+        />
+      ) : null;
+
+    if (
+      isDiscoveryOwned &&
+      ((discovery?.status === "failed" && discovery?.hasDynamicList === false) ||
+        discovery?.status === "empty")
+    ) {
+      // Discovery owns this catalog, so a failed or empty live list must not
+      // fall back to the static catalog: show only the selected model and
+      // selection hints, plus the retry row.
+      const selectedOptions = providerOptions.filter(
+        (option) => option.isSelectionHint === true || option.slug === props.model,
+      );
+      if (selectedOptions.length === 0) return discoveryStatusRow;
+      return (
+        <>
+          <MenuRadioGroup
+            value={activeProvider === provider ? props.model : ""}
+            onValueChange={(value) => handleModelChange(provider, value)}
+          >
+            <ProviderModelOptionGroupList
+              groupedOptions={groupProviderModelOptions(selectedOptions)}
+              provider={provider}
+              activeModel={props.model}
+              isSearching={false}
+              favoriteProvider={null}
+              favoriteModelSlugSet={undefined}
+              onToggleFavorite={toggleFavoriteModel}
+            />
+          </MenuRadioGroup>
+          {discoveryStatusRow}
+        </>
+      );
+    }
+
+    const listWithFooter = (
+      <>
+        {content}
+        {discoveryStatusRow}
+      </>
+    );
+
     if (!shouldShowSearch) {
       const needsScrollContainer =
         filteredOptions.length >= SEARCHABLE_MODEL_PICKER_THRESHOLD ||
         shouldUseCollapsibleModelGroups(groupedOptions.length, false);
       if (needsScrollContainer) {
         return (
-          <>
-            {discoveryErrorElement}
-            <div
-              className={cn(
-                "overflow-y-auto overscroll-contain py-0.5",
-                COMPOSER_PICKER_MODEL_LIST_SCROLL_CLASS_NAME,
-                COMPOSER_PICKER_MODEL_LIST_MAX_HEIGHT_CLASS_NAME,
-              )}
-            >
-              {content}
-            </div>
-          </>
+          <div
+            className={cn(
+              "overflow-y-auto overscroll-contain py-0.5",
+              COMPOSER_PICKER_MODEL_LIST_SCROLL_CLASS_NAME,
+              COMPOSER_PICKER_MODEL_LIST_MAX_HEIGHT_CLASS_NAME,
+            )}
+          >
+            {listWithFooter}
+          </div>
         );
       }
-      return (
-        <>
-          {discoveryErrorElement}
-          {content}
-        </>
-      );
+      return listWithFooter;
     }
 
     return (
@@ -367,8 +438,8 @@ export const ProviderModelMenuItems = function ProviderModelMenuItems(
         widthClassName="w-full"
         bleedParentPadding
         listMaxHeightClassName={COMPOSER_PICKER_MODEL_LIST_MAX_HEIGHT_CLASS_NAME}
+        footer={discoveryStatusRow}
       >
-        {discoveryErrorElement}
         {content}
       </PickerPanelShell>
     );
@@ -383,7 +454,16 @@ export const ProviderModelMenuItems = function ProviderModelMenuItems(
       {visibleAvailableProviderOptions.map((option) => {
         const OptionIcon = PROVIDER_ICON_COMPONENT_BY_PROVIDER[option.value];
         const liveProvider = props.providers?.find((entry) => entry.provider === option.value);
-        const availability = resolveLiveProviderAvailability(liveProvider);
+        const availability: { disabled: boolean; label: string | null } = !liveProvider
+          ? { disabled: true, label: "Checking" }
+          : !liveProvider.available
+            ? {
+                disabled: true,
+                label: liveProvider.authStatus === "unauthenticated" ? "Sign in" : "Unavailable",
+              }
+            : liveProvider.authStatus === "unauthenticated"
+              ? { disabled: true, label: "Sign in" }
+              : { disabled: false, label: null };
         if (availability.disabled) {
           return (
             <MenuItem key={option.value} disabled>
@@ -431,6 +511,7 @@ export const ProviderModelMenuItems = function ProviderModelMenuItems(
   );
 };
 
+// Resolves the human-readable label for the currently selected model.
 export function resolveProviderModelLabel(input: {
   provider: ProviderKind;
   lockedProvider: ProviderKind | null;
@@ -458,8 +539,7 @@ type ProviderModelPickerProps = {
   lockedProvider: ProviderKind | null;
   providers?: ReadonlyArray<ServerProviderStatus>;
   modelOptionsByProvider: Record<ProviderKind, ReadonlyArray<ProviderModelOption>>;
-  loadingModelProviders?: Partial<Record<ProviderKind, boolean>>;
-  discoveryErrorsByProvider?: Partial<Record<ProviderKind, string | undefined>>;
+  modelDiscoveryByProvider?: Record<ProviderKind, ProviderModelDiscoveryState>;
   hiddenProviders?: ReadonlyArray<ProviderKind>;
   providerOrder?: ReadonlyArray<ProviderKind>;
   activeProviderIconClassName?: string;
@@ -579,11 +659,8 @@ export const ProviderModelPicker = function ProviderModelPicker(props: ProviderM
           lockedProvider={props.lockedProvider}
           {...(props.providers ? { providers: props.providers } : {})}
           modelOptionsByProvider={props.modelOptionsByProvider}
-          {...(props.loadingModelProviders
-            ? { loadingModelProviders: props.loadingModelProviders }
-            : {})}
-          {...(props.discoveryErrorsByProvider
-            ? { discoveryErrorsByProvider: props.discoveryErrorsByProvider }
+          {...(props.modelDiscoveryByProvider
+            ? { modelDiscoveryByProvider: props.modelDiscoveryByProvider }
             : {})}
           {...(props.hiddenProviders ? { hiddenProviders: props.hiddenProviders } : {})}
           {...(props.providerOrder ? { providerOrder: props.providerOrder } : {})}

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -374,10 +374,14 @@ export const ProviderModelMenuItems = function ProviderModelMenuItems(
         discovery?.status === "empty")
     ) {
       // Discovery owns this catalog, so a failed or empty live list must not
-      // fall back to the static catalog: show only the selected model and
-      // selection hints, plus the retry row.
+      // fall back to the static catalog: show only rows that stay meaningful
+      // offline — the selected model, the user's own custom models, and
+      // selection hints — plus the retry row.
       const selectedOptions = providerOptions.filter(
-        (option) => option.isSelectionHint === true || option.slug === props.model,
+        (option) =>
+          option.isSelectionHint === true ||
+          ("isCustom" in option && option.isCustom === true) ||
+          option.slug === props.model,
       );
       if (selectedOptions.length === 0) return discoveryStatusRow;
       return (

--- a/apps/web/src/components/kanban/KanbanNewTaskDialog.tsx
+++ b/apps/web/src/components/kanban/KanbanNewTaskDialog.tsx
@@ -198,8 +198,7 @@ export function KanbanNewTaskDialog({
   );
   const {
     modelOptionsByProvider,
-    loadingModelProviders,
-    discoveryErrorsByProvider,
+    modelDiscoveryByProvider,
     runtimeModelsByProvider,
     selectedRuntimeModel,
     selectedRuntimeAgents,
@@ -597,8 +596,7 @@ export function KanbanNewTaskDialog({
                     lockedProvider={null}
                     providers={providerStatuses}
                     modelOptionsByProvider={modelOptionsByProvider}
-                    loadingModelProviders={loadingModelProviders}
-                    discoveryErrorsByProvider={discoveryErrorsByProvider}
+                    modelDiscoveryByProvider={modelDiscoveryByProvider}
                     hiddenProviders={settings.hiddenProviders}
                     providerOrder={settings.providerOrder}
                     onProviderModelChange={handleProviderModelChange}

--- a/apps/web/src/hooks/useProviderModelCatalog.test.tsx
+++ b/apps/web/src/hooks/useProviderModelCatalog.test.tsx
@@ -12,7 +12,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ProviderModelCatalog } from "./useProviderModelCatalog";
-import { useProviderModelCatalog } from "./useProviderModelCatalog";
+import {
+  deriveProviderModelDiscoveryState,
+  useProviderModelCatalog,
+} from "./useProviderModelCatalog";
 
 const mocks = vi.hoisted(() => ({
   useAppSettings: vi.fn(),
@@ -38,19 +41,23 @@ interface QueryResultLike {
   readonly data?: {
     readonly agents?: ReadonlyArray<{ name: string; displayName: string }>;
     readonly cached?: boolean;
-    readonly error?: string;
     readonly models?: ReadonlyArray<ProviderModelDescriptor>;
     readonly source?: string;
   };
+  readonly dataUpdatedAt?: number;
   readonly isFetching: boolean;
   readonly isLoading: boolean;
   readonly isPlaceholderData: boolean;
+  readonly status?: "error" | "pending" | "success";
 }
 
 const EMPTY_QUERY: QueryResultLike = {
+  data: { models: [], source: "empty", cached: false },
+  dataUpdatedAt: 0,
   isFetching: false,
   isLoading: false,
   isPlaceholderData: false,
+  status: "pending",
 };
 const modelQueries = new Map<ProviderKind, QueryResultLike>();
 const agentQueries = new Map<ProviderKind, QueryResultLike>();
@@ -64,10 +71,12 @@ const SETTINGS = {
   customCodexModels: [],
   customCursorModels: ["cursor-custom"],
   customDroidModels: [],
+  customDevinModels: [],
   customGrokModels: [],
   customOpenCodeModels: [],
   customPiModels: [],
   droidBinaryPath: "",
+  devinBinaryPath: "",
   grokBinaryPath: "",
   hiddenProviders: [],
   openCodeBinaryPath: "",
@@ -139,7 +148,7 @@ describe("useProviderModelCatalog", () => {
     expect(second).toBe(first);
     expect(second?.customModelsByProvider).toBe(first?.customModelsByProvider);
     expect(second?.modelOptionsByProvider).toBe(first?.modelOptionsByProvider);
-    expect(second?.loadingModelProviders).toBe(first?.loadingModelProviders);
+    expect(second?.modelDiscoveryByProvider).toBe(first?.modelDiscoveryByProvider);
     expect(second?.runtimeModelsByProvider).toBe(first?.runtimeModelsByProvider);
     expect(second?.selectedRuntimeAgents).toBe(first?.selectedRuntimeAgents);
   });
@@ -242,27 +251,17 @@ describe("useProviderModelCatalog", () => {
     expect(readModelQueryEnabled("antigravity")).toBe(false);
   });
 
-  it("warms droid discovery only when a surface explicitly prefetches it", () => {
+  it("prefetches Droid discovery when a prefetch surface requests it", () => {
+    // The git-writing settings panel passes GIT_TEXT_GENERATION_PROVIDERS, which
+    // includes Droid; its ACP-session cost is bounded by the query's retry=0,
+    // 5-minute staleTime, and disabled focus refetch.
     readCatalogRenders({
       selectedProvider: "codex",
       discoveryEnabled: true,
-      prefetchProviders: ["codex", "droid", "opencode"],
+      prefetchProviders: ["codex", "droid"],
     });
+
     expect(readModelQueryEnabled("droid")).toBe(true);
-
-    mocks.useQuery.mockClear();
-    readCatalogRenders({ selectedProvider: "codex", discoveryEnabled: true });
-    expect(readModelQueryEnabled("droid")).toBe(false);
-  });
-
-  it("keeps droid cold when the surface is inactive even if it prefetches droid", () => {
-    readCatalogRenders({
-      selectedProvider: "opencode",
-      discoveryEnabled: false,
-      prefetchProviders: ["codex", "droid", "opencode"],
-    });
-
-    expect(readModelQueryEnabled("droid")).toBe(false);
   });
 
   it("merges a settled runtime catalog with custom models without reporting loading", () => {
@@ -272,9 +271,11 @@ describe("useProviderModelCatalog", () => {
         source: "cursor.cli",
         cached: false,
       },
+      dataUpdatedAt: 1_000,
       isFetching: true,
       isLoading: false,
-      isPlaceholderData: true,
+      isPlaceholderData: false,
+      status: "success",
     });
 
     const catalog = readCatalogRenders({
@@ -287,31 +288,262 @@ describe("useProviderModelCatalog", () => {
       "composer-2",
       "cursor-custom",
     ]);
-    expect(catalog?.loadingModelProviders.cursor).toBe(false);
-    expect(catalog?.selectedProviderModelsLoading).toBe(false);
+    expect(catalog?.selectedProviderRuntimeModelDiscoveryPending).toBe(false);
     expect(catalog?.runtimeModelsByProvider.cursor).toEqual([
       { slug: "composer-2", name: "Composer 2" },
     ]);
   });
 
-  it("surfaces devin discovery errors even when the result falls back to devin.static", () => {
+  it("treats a selected GLM model as an unavailable hint after Devin discovery", () => {
     modelQueries.set("devin", {
       data: {
-        models: [],
-        source: "devin.static",
+        models: [
+          { slug: "adaptive", name: "Adaptive" },
+          { slug: "swe-1.7", name: "SWE 1.7" },
+        ],
+        source: "devin-acp",
         cached: false,
-        error: "Devin CLI failed",
       },
+      dataUpdatedAt: 1_000,
       isFetching: false,
       isLoading: false,
       isPlaceholderData: false,
+      status: "success",
     });
 
     const catalog = readCatalogRenders({
-      selectedProvider: "codex",
+      selectedProvider: "devin",
+      discoveryEnabled: true,
+      modelHintByProvider: { devin: "glm-5.3" },
+    }).at(-1);
+
+    expect(catalog?.modelOptionsByProvider.devin).toEqual([
+      expect.objectContaining({ slug: "adaptive" }),
+      expect.objectContaining({ slug: "swe-1-7" }),
+      expect.objectContaining({ slug: "glm-5.3", isSelectionHint: true }),
+    ]);
+    expect(catalog?.modelDiscoveryByProvider.devin).toMatchObject({
+      status: "success",
+      hasDynamicList: true,
+    });
+  });
+
+  it("exposes a truthful per-provider discovery state table", () => {
+    const now = 1_000_000;
+    modelQueries.set("opencode", {
+      data: {
+        models: [{ slug: "openai/gpt-5", name: "GPT-5" }],
+        source: "opencode",
+        cached: false,
+      },
+      dataUpdatedAt: now,
+      isFetching: false,
+      isLoading: false,
+      isPlaceholderData: false,
+      status: "success",
+    });
+
+    const catalog = readCatalogRenders({
+      selectedProvider: "opencode",
       discoveryEnabled: true,
     }).at(-1);
 
-    expect(catalog?.discoveryErrorsByProvider.devin).toBe("Devin CLI failed");
+    expect(catalog?.modelDiscoveryByProvider.opencode).toMatchObject({
+      status: "success",
+      hasDynamicList: true,
+      refreshing: false,
+      fetchedAt: now,
+    });
+    // Non-discovery-owned providers stay in static-success so the picker falls through.
+    expect(catalog?.modelDiscoveryByProvider.codex).toEqual({
+      status: "success",
+      hasDynamicList: false,
+      refreshing: false,
+    });
+  });
+});
+
+describe("deriveProviderModelDiscoveryState", () => {
+  const emptyResult = {
+    models: [] as ProviderModelDescriptor[],
+    source: "empty" as const,
+    cached: false as const,
+  };
+  const realResult = {
+    models: [{ slug: "x", name: "X" }] as ProviderModelDescriptor[],
+    source: "opencode" as const,
+    cached: false as const,
+  };
+
+  it("returns never-loaded when discovery has not run", () => {
+    expect(
+      deriveProviderModelDiscoveryState({
+        data: undefined,
+        isFetching: false,
+        isLoading: false,
+        isPlaceholderData: false,
+        status: "pending",
+      }),
+    ).toEqual({ status: "never-loaded", hasDynamicList: false, refreshing: false });
+  });
+
+  it("returns loading for the initial fetch with no usable list", () => {
+    expect(
+      deriveProviderModelDiscoveryState({
+        data: emptyResult,
+        isFetching: true,
+        isLoading: true,
+        isPlaceholderData: true,
+        status: "pending",
+      }),
+    ).toEqual({ status: "loading", hasDynamicList: false, refreshing: false });
+  });
+
+  it("keeps the failed row refreshing while a no-cache retry is in flight", () => {
+    expect(
+      deriveProviderModelDiscoveryState({
+        data: emptyResult,
+        errorUpdatedAt: 5_000,
+        isFetching: true,
+        isLoading: false,
+        isPlaceholderData: true,
+        status: "pending",
+      }),
+    ).toEqual({ status: "failed", hasDynamicList: false, refreshing: true });
+  });
+
+  it("returns success with a real dynamic list", () => {
+    const state = deriveProviderModelDiscoveryState({
+      data: realResult,
+      dataUpdatedAt: 1234,
+      isFetching: false,
+      isLoading: false,
+      isPlaceholderData: false,
+      status: "success",
+    });
+    expect(state).toMatchObject({
+      status: "success",
+      hasDynamicList: true,
+      refreshing: false,
+      fetchedAt: 1234,
+    });
+  });
+
+  it("propagates a background refetch as refreshing for settled states", () => {
+    const successState = deriveProviderModelDiscoveryState({
+      data: realResult,
+      dataUpdatedAt: 1234,
+      isFetching: true,
+      isLoading: false,
+      isPlaceholderData: false,
+      status: "success",
+    });
+    expect(successState).toMatchObject({ status: "success", refreshing: true, fetchedAt: 1234 });
+
+    const failedWithCacheState = deriveProviderModelDiscoveryState({
+      data: realResult,
+      dataUpdatedAt: 1234,
+      isFetching: true,
+      isLoading: false,
+      isPlaceholderData: false,
+      status: "error",
+    });
+    expect(failedWithCacheState).toMatchObject({
+      status: "failed",
+      hasDynamicList: true,
+      refreshing: true,
+    });
+  });
+
+  it("reports placeholder data carried over from a previous query key as refreshing success", () => {
+    const state = deriveProviderModelDiscoveryState({
+      data: realResult,
+      dataUpdatedAt: 0,
+      isFetching: true,
+      isLoading: false,
+      isPlaceholderData: true,
+      status: "success",
+    });
+    expect(state).toMatchObject({
+      status: "success",
+      hasDynamicList: true,
+      refreshing: true,
+      fetchedAt: undefined,
+    });
+  });
+
+  it("leaves fetchedAt undefined when the query carries no dataUpdatedAt", () => {
+    const state = deriveProviderModelDiscoveryState({
+      data: realResult,
+      isFetching: false,
+      isLoading: false,
+      isPlaceholderData: false,
+      status: "success",
+    });
+    expect(state).toMatchObject({ status: "success", hasDynamicList: true, fetchedAt: undefined });
+  });
+
+  it("returns empty for a real source with zero models", () => {
+    const state = deriveProviderModelDiscoveryState({
+      data: {
+        models: [] as ProviderModelDescriptor[],
+        source: "opencode" as const,
+        cached: false as const,
+      },
+      dataUpdatedAt: 1234,
+      isFetching: false,
+      isLoading: false,
+      isPlaceholderData: false,
+      status: "success",
+    });
+    expect(state).toMatchObject({
+      status: "empty",
+      hasDynamicList: false,
+      refreshing: false,
+      fetchedAt: 1234,
+    });
+  });
+
+  it("returns failed when there is no usable list", () => {
+    expect(
+      deriveProviderModelDiscoveryState({
+        data: undefined,
+        isFetching: false,
+        isLoading: false,
+        isPlaceholderData: false,
+        status: "error",
+      }),
+    ).toEqual({ status: "failed", hasDynamicList: false, refreshing: false });
+  });
+
+  it("returns failed-with-cache when a stale list exists", () => {
+    const state = deriveProviderModelDiscoveryState({
+      data: realResult,
+      dataUpdatedAt: 1234,
+      isFetching: false,
+      isLoading: false,
+      isPlaceholderData: false,
+      status: "error",
+    });
+    expect(state).toMatchObject({
+      status: "failed",
+      hasDynamicList: true,
+      refreshing: false,
+      fetchedAt: 1234,
+    });
+  });
+
+  it("treats disabled/unsupported sources as never-loaded", () => {
+    for (const source of ["disabled", "unsupported"] as const) {
+      expect(
+        deriveProviderModelDiscoveryState({
+          data: { models: [] as ProviderModelDescriptor[], source, cached: false as const },
+          isFetching: false,
+          isLoading: false,
+          isPlaceholderData: false,
+          status: "success",
+        }),
+      ).toEqual({ status: "never-loaded", hasDynamicList: false, refreshing: false });
+    }
   });
 });

--- a/apps/web/src/hooks/useProviderModelCatalog.test.tsx
+++ b/apps/web/src/hooks/useProviderModelCatalog.test.tsx
@@ -264,6 +264,14 @@ describe("useProviderModelCatalog", () => {
     expect(readModelQueryEnabled("droid")).toBe(true);
   });
 
+  it("keeps Droid discovery cold for non-prefetch surfaces", () => {
+    // Droid discovery costs a disposable ACP session per model, so only an
+    // explicit prefetch (the git-writing settings panel) may warm it.
+    readCatalogRenders({ selectedProvider: "codex", discoveryEnabled: true });
+
+    expect(readModelQueryEnabled("droid")).toBe(false);
+  });
+
   it("merges a settled runtime catalog with custom models without reporting loading", () => {
     modelQueries.set("cursor", {
       data: {

--- a/apps/web/src/hooks/useProviderModelCatalog.ts
+++ b/apps/web/src/hooks/useProviderModelCatalog.ts
@@ -208,13 +208,14 @@ export function useProviderModelCatalog(input: {
     }
     return prefetchProviderSet?.has(provider) ?? !hiddenProviderSet.has(provider);
   };
-
+  // ponytail: explicit prefetch only; picker surfaces stay cold (see droid query comment below).
+  const droidPrefetchRequested = discoveryEnabled && (prefetchProviderSet?.has("droid") ?? false);
   const claudeModelDiscoveryEnabled = shouldDiscoverProvider("claudeAgent");
   const codexModelDiscoveryEnabled = shouldDiscoverProvider("codex");
   const cursorModelDiscoveryEnabled = shouldDiscoverProvider("cursor");
   const antigravityModelDiscoveryEnabled = shouldDiscoverProvider("antigravity");
   const grokModelDiscoveryEnabled = shouldDiscoverProvider("grok");
-  const droidModelDiscoveryEnabled = shouldDiscoverProvider("droid");
+  const droidModelDiscoveryEnabled = shouldDiscoverProvider("droid", droidPrefetchRequested);
   const openCodeModelDiscoveryEnabled = shouldDiscoverProvider("opencode");
   const piModelDiscoveryEnabled = shouldDiscoverProvider("pi");
   const devinModelDiscoveryEnabled = shouldDiscoverProvider("devin");

--- a/apps/web/src/hooks/useProviderModelCatalog.ts
+++ b/apps/web/src/hooks/useProviderModelCatalog.ts
@@ -7,6 +7,7 @@
 import type {
   ProviderAgentDescriptor,
   ProviderKind,
+  ProviderListModelsResult,
   ProviderModelDescriptor,
 } from "@synara/contracts";
 import { useQuery } from "@tanstack/react-query";
@@ -15,6 +16,7 @@ import { useMemo } from "react";
 import { getAppModelOptions, getCustomModelsByProvider, useAppSettings } from "../appSettings";
 import { resolveRuntimeModelDescriptor } from "../components/chat/runtimeModelCapabilities";
 import { collapseCursorModelVariants } from "../cursorModelVariants";
+import { isUsableModelSource } from "../lib/providerModelCatalogCache";
 import {
   isInitialModelDiscoveryPending,
   providerAgentsQueryOptions,
@@ -22,53 +24,159 @@ import {
 } from "../lib/providerDiscoveryReactQuery";
 import { mergeDynamicModelOptions, type ProviderModelOption } from "../providerModelOptions";
 
+interface ProviderModelDiscoveryQueryLike {
+  readonly status: "error" | "pending" | "success";
+  readonly isLoading: boolean;
+  readonly isFetching: boolean;
+  readonly isPlaceholderData: boolean;
+  readonly data: ProviderListModelsResult | undefined;
+  readonly dataUpdatedAt?: number | undefined;
+  readonly errorUpdatedAt?: number | undefined;
+}
+
+export type ProviderModelDiscoveryState =
+  | { status: "never-loaded"; hasDynamicList: false; refreshing: false }
+  | { status: "loading"; hasDynamicList: false; refreshing: boolean }
+  | {
+      status: "success";
+      hasDynamicList: boolean;
+      refreshing: boolean;
+      fetchedAt?: number | undefined;
+    }
+  | {
+      status: "empty";
+      hasDynamicList: false;
+      refreshing: boolean;
+      fetchedAt?: number | undefined;
+    }
+  | {
+      status: "failed";
+      hasDynamicList: boolean;
+      refreshing: boolean;
+      fetchedAt?: number | undefined;
+    };
+
+// Claude and Codex keep their curated static catalogs; runtime discovery never
+// owns them, so their discovery state is permanently settled success.
+const STATIC_CATALOG_DISCOVERY_SUCCESS: ProviderModelDiscoveryState = {
+  status: "success",
+  hasDynamicList: false,
+  refreshing: false,
+};
+
+export function deriveProviderModelDiscoveryState(
+  query: ProviderModelDiscoveryQueryLike,
+): ProviderModelDiscoveryState {
+  const data = query.data;
+  const hasList = data !== undefined && isUsableModelSource(data.source) && data.models.length > 0;
+  const fetchedAt =
+    query.dataUpdatedAt && query.dataUpdatedAt > 0 ? query.dataUpdatedAt : undefined;
+
+  if (!hasList && isInitialModelDiscoveryPending(query)) {
+    if ((query.errorUpdatedAt ?? 0) > 0) {
+      return { status: "failed", hasDynamicList: false, refreshing: true };
+    }
+    return { status: "loading", hasDynamicList: false, refreshing: false };
+  }
+
+  if (query.status === "error") {
+    if (hasList) {
+      return {
+        status: "failed",
+        hasDynamicList: true,
+        refreshing: query.isFetching,
+        fetchedAt,
+      };
+    }
+    return { status: "failed", hasDynamicList: false, refreshing: query.isFetching };
+  }
+
+  if (query.status === "success" && data !== undefined) {
+    if (hasList) {
+      return {
+        status: "success",
+        hasDynamicList: true,
+        refreshing: query.isFetching,
+        fetchedAt,
+      };
+    }
+    if (data.models.length === 0 && isUsableModelSource(data.source)) {
+      return {
+        status: "empty",
+        hasDynamicList: false,
+        refreshing: query.isFetching,
+        fetchedAt,
+      };
+    }
+  }
+
+  return { status: "never-loaded", hasDynamicList: false, refreshing: false };
+}
+
+function useProviderModelDiscoveryState(query: ProviderModelDiscoveryQueryLike) {
+  const { data, dataUpdatedAt, errorUpdatedAt, status, isLoading, isFetching, isPlaceholderData } =
+    query;
+  return useMemo(
+    () =>
+      deriveProviderModelDiscoveryState({
+        data,
+        dataUpdatedAt,
+        errorUpdatedAt,
+        status,
+        isLoading,
+        isFetching,
+        isPlaceholderData,
+      }),
+    [data, dataUpdatedAt, errorUpdatedAt, status, isLoading, isFetching, isPlaceholderData],
+  );
+}
+
 export interface ProviderModelCatalog {
   customModelsByProvider: ReturnType<typeof getCustomModelsByProvider>;
   modelOptionsByProvider: Record<
     ProviderKind,
     ReadonlyArray<ProviderModelOption & { isCustom?: boolean }>
   >;
-  /** Providers whose runtime model discovery is still pending (no usable list yet). */
-  loadingModelProviders: Partial<Record<ProviderKind, boolean>>;
-  /**
-   * Runtime-discovered model descriptors per provider. Composer-style trait
-   * controls (effort, fast mode, thinking, context window) are sourced from
-   * these for cursor/codex/etc., so any surface that wants the effort picker
-   * must feed them through (see {@link selectedRuntimeModel}).
-   */
+  modelDiscoveryByProvider: Record<ProviderKind, ProviderModelDiscoveryState>;
   runtimeModelsByProvider: Record<ProviderKind, ReadonlyArray<ProviderModelDescriptor>>;
-  /** The runtime descriptor matching `selectedProvider` + its selected-model hint. */
   selectedRuntimeModel: ProviderModelDescriptor | undefined;
-  /** Runtime-discovered agents/modes for the selected provider (opencode/claude/codex). */
   selectedRuntimeAgents: ReadonlyArray<ProviderAgentDescriptor>;
-  /** Loading state used by the selected provider's bootstrap skeleton. */
-  selectedProviderModelsLoading: boolean;
-  /** Whether the selected provider requires and is still waiting on runtime models. */
   selectedProviderRuntimeModelDiscoveryPending: boolean;
-  /** Discovery failure detail per provider (268 passthrough). */
-  discoveryErrorsByProvider: Partial<Record<ProviderKind, string | undefined>>;
 }
 
-const EMPTY_PROVIDER_AGENTS: ReadonlyArray<ProviderAgentDescriptor> = [];
+function useProviderModelsQuery(
+  provider: ProviderKind,
+  input: {
+    binaryPath?: string | null;
+    apiEndpoint?: string | null;
+    agentDir?: string | null;
+    cwd?: string | null;
+    enabled?: boolean;
+  },
+) {
+  const { binaryPath, apiEndpoint, agentDir, cwd, enabled } = input;
+  return useQuery(
+    useMemo(
+      () =>
+        providerModelsQueryOptions({
+          provider,
+          binaryPath,
+          apiEndpoint,
+          agentDir,
+          cwd,
+          enabled,
+        }),
+      [provider, binaryPath, apiEndpoint, agentDir, cwd, enabled],
+    ),
+  );
+}
 
 export function useProviderModelCatalog(input: {
   selectedProvider: ProviderKind;
-  /**
-   * Enables discovery for the on-demand providers (cursor/grok/droid/opencode/pi)
-   * even when they are not selected — pass the picker's open state so their lists
-   * are warm by the time the user browses them.
-   */
   discoveryEnabled: boolean;
-  /** Effective cwd for providers whose model catalog can be extended by project resources. */
   cwd?: string | null;
-  /** Per-provider selected-model hints so an unknown selection still lists itself. */
   modelHintByProvider?: Partial<Record<ProviderKind, string | null>>;
-  /**
-   * Restrict background discovery to the providers used by a non-picker surface.
-   * Picker surfaces can omit this to use the visible-provider list from settings.
-   */
   prefetchProviders?: ReadonlyArray<ProviderKind>;
-  /** Preserve eager Claude/Codex agent discovery on surfaces that already prefetch both. */
   agentDiscoveryPolicy?: "selected" | "eager-core";
 }): ProviderModelCatalog {
   const { selectedProvider, discoveryEnabled, modelHintByProvider } = input;
@@ -89,12 +197,6 @@ export function useProviderModelCatalog(input: {
     provider: ProviderKind,
     prefetchRequested = discoveryEnabled,
   ): boolean => {
-    // The enabled flag is a short-circuit, not a precondition. `serverSettings` is
-    // undefined while the settings query is in flight and stays undefined if it
-    // fails — and it never refetches on its own (`staleTime: Infinity`). Treating
-    // that as "disabled" would silence discovery for every provider, including the
-    // selected one, which is precisely the "my model disappeared" symptom. Mirrors
-    // the server-side fallback in ProviderDiscoveryService.listModels.
     if (serverSettings?.providers[provider]?.enabled === false) {
       return false;
     }
@@ -112,86 +214,54 @@ export function useProviderModelCatalog(input: {
   const cursorModelDiscoveryEnabled = shouldDiscoverProvider("cursor");
   const antigravityModelDiscoveryEnabled = shouldDiscoverProvider("antigravity");
   const grokModelDiscoveryEnabled = shouldDiscoverProvider("grok");
-  // ponytail: explicit prefetch only; picker surfaces stay cold (see droid query comment below).
-  const droidPrefetchRequested = discoveryEnabled && (prefetchProviderSet?.has("droid") ?? false);
-  const droidModelDiscoveryEnabled = shouldDiscoverProvider("droid", droidPrefetchRequested);
+  const droidModelDiscoveryEnabled = shouldDiscoverProvider("droid");
   const openCodeModelDiscoveryEnabled = shouldDiscoverProvider("opencode");
   const piModelDiscoveryEnabled = shouldDiscoverProvider("pi");
   const devinModelDiscoveryEnabled = shouldDiscoverProvider("devin");
 
-  const claudeDynamicModelsQuery = useQuery(
-    providerModelsQueryOptions({
-      provider: "claudeAgent",
-      binaryPath: settings.claudeBinaryPath || null,
-      enabled: claudeModelDiscoveryEnabled,
-    }),
-  );
-  const codexDynamicModelsQuery = useQuery(
-    providerModelsQueryOptions({
-      provider: "codex",
-      enabled: codexModelDiscoveryEnabled,
-    }),
-  );
-  const cursorDynamicModelsQuery = useQuery(
-    providerModelsQueryOptions({
-      provider: "cursor",
-      binaryPath: settings.cursorBinaryPath || null,
-      apiEndpoint: settings.cursorApiEndpoint || null,
-      enabled: cursorModelDiscoveryEnabled,
-    }),
-  );
-  const antigravityModelsQuery = useQuery(
-    providerModelsQueryOptions({
-      provider: "antigravity",
-      binaryPath: settings.antigravityBinaryPath || null,
-      cwd: discoveryCwd,
-      enabled: antigravityModelDiscoveryEnabled,
-    }),
-  );
-  const grokDynamicModelsQuery = useQuery(
-    providerModelsQueryOptions({
-      provider: "grok",
-      binaryPath: settings.grokBinaryPath || null,
-      enabled: grokModelDiscoveryEnabled,
-    }),
-  );
-  const droidDynamicModelsQuery = useQuery(
-    providerModelsQueryOptions({
-      provider: "droid",
-      binaryPath: settings.droidBinaryPath || null,
-      cwd: discoveryCwd,
-      // Droid probes every model through a disposable ACP session. Keep it
-      // provider-scoped instead of warming it from unrelated picker/settings UI.
-      enabled: droidModelDiscoveryEnabled,
-    }),
-  );
-  const openCodeDynamicModelsQuery = useQuery(
-    providerModelsQueryOptions({
-      provider: "opencode",
-      binaryPath: settings.openCodeBinaryPath || null,
-      cwd: discoveryCwd,
-      enabled: openCodeModelDiscoveryEnabled,
-    }),
-  );
-  const piDynamicModelsQuery = useQuery(
-    providerModelsQueryOptions({
-      provider: "pi",
-      binaryPath: settings.piBinaryPath || null,
-      agentDir: settings.piAgentDir || null,
-      cwd: discoveryCwd,
-      enabled: piModelDiscoveryEnabled,
-    }),
-  );
-  const devinDynamicModelsQuery = useQuery(
-    providerModelsQueryOptions({
-      provider: "devin",
-      binaryPath: settings.devinBinaryPath || null,
-      cwd: discoveryCwd,
-      enabled: devinModelDiscoveryEnabled,
-    }),
-  );
+  const claudeDynamicModelsQuery = useProviderModelsQuery("claudeAgent", {
+    binaryPath: settings.claudeBinaryPath || null,
+    enabled: claudeModelDiscoveryEnabled,
+  });
+  const codexDynamicModelsQuery = useProviderModelsQuery("codex", {
+    enabled: codexModelDiscoveryEnabled,
+  });
+  const cursorDynamicModelsQuery = useProviderModelsQuery("cursor", {
+    binaryPath: settings.cursorBinaryPath || null,
+    apiEndpoint: settings.cursorApiEndpoint || null,
+    enabled: cursorModelDiscoveryEnabled,
+  });
+  const antigravityModelsQuery = useProviderModelsQuery("antigravity", {
+    binaryPath: settings.antigravityBinaryPath || null,
+    cwd: discoveryCwd,
+    enabled: antigravityModelDiscoveryEnabled,
+  });
+  const grokDynamicModelsQuery = useProviderModelsQuery("grok", {
+    binaryPath: settings.grokBinaryPath || null,
+    enabled: grokModelDiscoveryEnabled,
+  });
+  const droidDynamicModelsQuery = useProviderModelsQuery("droid", {
+    binaryPath: settings.droidBinaryPath || null,
+    cwd: discoveryCwd,
+    enabled: droidModelDiscoveryEnabled,
+  });
+  const openCodeDynamicModelsQuery = useProviderModelsQuery("opencode", {
+    binaryPath: settings.openCodeBinaryPath || null,
+    cwd: discoveryCwd,
+    enabled: openCodeModelDiscoveryEnabled,
+  });
+  const piDynamicModelsQuery = useProviderModelsQuery("pi", {
+    binaryPath: settings.piBinaryPath || null,
+    agentDir: settings.piAgentDir || null,
+    cwd: discoveryCwd,
+    enabled: piModelDiscoveryEnabled,
+  });
+  const devinDynamicModelsQuery = useProviderModelsQuery("devin", {
+    binaryPath: settings.devinBinaryPath || null,
+    cwd: discoveryCwd,
+    enabled: devinModelDiscoveryEnabled,
+  });
 
-  // Agent/mode discovery (opencode "Agent" picker, claude/codex subagents).
   const claudeDynamicAgentsQuery = useQuery(
     providerAgentsQueryOptions({
       provider: "claudeAgent",
@@ -218,54 +288,36 @@ export function useProviderModelCatalog(input: {
     [cursorDynamicModelsQuery.data?.models],
   );
 
-  const hasResolvedCursorModelDiscovery =
-    (cursorDynamicModelsQuery.data?.source === "cursor.cli" ||
-      cursorDynamicModelsQuery.data?.source === "cursor.acp") &&
-    (cursorDynamicModelsQuery.data.models.length ?? 0) > 0;
-  const cursorModelDiscoveryPending =
-    cursorModelDiscoveryEnabled &&
-    !hasResolvedCursorModelDiscovery &&
-    isInitialModelDiscoveryPending(cursorDynamicModelsQuery);
-  const hasResolvedDroidModelDiscovery =
-    droidDynamicModelsQuery.data?.source === "droid-acp" &&
-    (droidDynamicModelsQuery.data.models.length ?? 0) > 0;
-  const droidModelDiscoveryPending =
-    droidModelDiscoveryEnabled &&
-    !hasResolvedDroidModelDiscovery &&
-    isInitialModelDiscoveryPending(droidDynamicModelsQuery);
-  const hasResolvedOpenCodeModelDiscovery =
-    (openCodeDynamicModelsQuery.data?.source === "opencode-cli" ||
-      openCodeDynamicModelsQuery.data?.source === "opencode") &&
-    (openCodeDynamicModelsQuery.data.models.length ?? 0) > 0;
-  const openCodeModelDiscoveryPending =
-    openCodeModelDiscoveryEnabled &&
-    !hasResolvedOpenCodeModelDiscovery &&
-    isInitialModelDiscoveryPending(openCodeDynamicModelsQuery);
-  const hasResolvedPiModelDiscovery =
-    piDynamicModelsQuery.data?.source?.startsWith("pi.sdk") === true &&
-    (piDynamicModelsQuery.data.models.length ?? 0) > 0;
-  const piModelDiscoveryPending =
-    piModelDiscoveryEnabled &&
-    !hasResolvedPiModelDiscovery &&
-    isInitialModelDiscoveryPending(piDynamicModelsQuery);
-  const hasResolvedDevinModelDiscovery =
-    (devinDynamicModelsQuery.data?.source === "devin-cli" ||
-      // Static fallback descriptors are a valid resolved catalog: the adapter
-      // serves its built-in matrix when CLI discovery is unavailable, so the
-      // picker must render them instead of spinning (or banner-ing) forever.
-      devinDynamicModelsQuery.data?.source === "devin.static") &&
-    (devinDynamicModelsQuery.data.models.length ?? 0) > 0;
-  const devinModelDiscoveryPending =
-    devinModelDiscoveryEnabled &&
-    !hasResolvedDevinModelDiscovery &&
-    isInitialModelDiscoveryPending(devinDynamicModelsQuery);
-  const antigravityModelDiscoveryPending =
-    antigravityModelDiscoveryEnabled &&
-    !(
-      antigravityModelsQuery.data?.source === "antigravity.cli" &&
-      (antigravityModelsQuery.data.models.length ?? 0) > 0
-    ) &&
-    isInitialModelDiscoveryPending(antigravityModelsQuery);
+  const antigravityDiscovery = useProviderModelDiscoveryState(antigravityModelsQuery);
+  const cursorDiscovery = useProviderModelDiscoveryState(cursorDynamicModelsQuery);
+  const droidDiscovery = useProviderModelDiscoveryState(droidDynamicModelsQuery);
+  const grokDiscovery = useProviderModelDiscoveryState(grokDynamicModelsQuery);
+  const openCodeDiscovery = useProviderModelDiscoveryState(openCodeDynamicModelsQuery);
+  const piDiscovery = useProviderModelDiscoveryState(piDynamicModelsQuery);
+  const devinDiscovery = useProviderModelDiscoveryState(devinDynamicModelsQuery);
+
+  const modelDiscoveryByProvider = useMemo<Record<ProviderKind, ProviderModelDiscoveryState>>(
+    () => ({
+      antigravity: antigravityDiscovery,
+      claudeAgent: STATIC_CATALOG_DISCOVERY_SUCCESS,
+      codex: STATIC_CATALOG_DISCOVERY_SUCCESS,
+      cursor: cursorDiscovery,
+      devin: devinDiscovery,
+      droid: droidDiscovery,
+      grok: grokDiscovery,
+      opencode: openCodeDiscovery,
+      pi: piDiscovery,
+    }),
+    [
+      antigravityDiscovery,
+      cursorDiscovery,
+      devinDiscovery,
+      droidDiscovery,
+      grokDiscovery,
+      openCodeDiscovery,
+      piDiscovery,
+    ],
+  );
 
   const modelOptionsByProvider = useMemo(() => {
     const staticOptions: Record<ProviderKind, ReturnType<typeof getAppModelOptions>> = {
@@ -287,13 +339,13 @@ export function useProviderModelCatalog(input: {
       ),
       grok: getAppModelOptions("grok", customModelsByProvider.grok, modelHintByProvider?.grok),
       droid: getAppModelOptions("droid", customModelsByProvider.droid, modelHintByProvider?.droid),
+      devin: getAppModelOptions("devin", customModelsByProvider.devin, modelHintByProvider?.devin),
       opencode: getAppModelOptions(
         "opencode",
         customModelsByProvider.opencode,
         modelHintByProvider?.opencode,
       ),
       pi: getAppModelOptions("pi", customModelsByProvider.pi, modelHintByProvider?.pi),
-      devin: getAppModelOptions("devin", customModelsByProvider.devin, modelHintByProvider?.devin),
     };
     const result: Record<
       ProviderKind,
@@ -309,9 +361,9 @@ export function useProviderModelCatalog(input: {
       antigravity: antigravityModelsQuery.data,
       grok: grokDynamicModelsQuery.data,
       droid: droidDynamicModelsQuery.data,
+      devin: devinDynamicModelsQuery.data,
       opencode: openCodeDynamicModelsQuery.data,
       pi: piDynamicModelsQuery.data,
-      devin: devinDynamicModelsQuery.data,
     };
     for (const provider of [
       "claudeAgent",
@@ -320,16 +372,20 @@ export function useProviderModelCatalog(input: {
       "antigravity",
       "grok",
       "droid",
+      "devin",
       "opencode",
       "pi",
-      "devin",
     ] as const) {
-      const dynamicModels = dynamicSources[provider]?.models;
-      if (dynamicModels && dynamicModels.length > 0) {
+      const dynamicSource = dynamicSources[provider];
+      if (
+        dynamicSource &&
+        isUsableModelSource(dynamicSource.source) &&
+        dynamicSource.models.length > 0
+      ) {
         result[provider] = mergeDynamicModelOptions({
           provider,
           staticOptions: staticOptions[provider],
-          dynamicModels,
+          dynamicModels: dynamicSource.models,
         });
       }
     }
@@ -341,32 +397,13 @@ export function useProviderModelCatalog(input: {
     cursorDynamicModelsQuery.data,
     cursorRuntimeModels,
     customModelsByProvider,
+    devinDynamicModelsQuery.data,
     droidDynamicModelsQuery.data,
     grokDynamicModelsQuery.data,
     modelHintByProvider,
     openCodeDynamicModelsQuery.data,
     piDynamicModelsQuery.data,
-    devinDynamicModelsQuery.data,
   ]);
-
-  const loadingModelProviders = useMemo<Partial<Record<ProviderKind, boolean>>>(
-    () => ({
-      antigravity: antigravityModelDiscoveryPending,
-      cursor: cursorModelDiscoveryPending,
-      droid: droidModelDiscoveryPending,
-      opencode: openCodeModelDiscoveryPending,
-      pi: piModelDiscoveryPending,
-      devin: devinModelDiscoveryPending,
-    }),
-    [
-      antigravityModelDiscoveryPending,
-      cursorModelDiscoveryPending,
-      droidModelDiscoveryPending,
-      openCodeModelDiscoveryPending,
-      piModelDiscoveryPending,
-      devinModelDiscoveryPending,
-    ],
-  );
 
   const runtimeModelsByProvider = useMemo<
     Record<ProviderKind, ReadonlyArray<ProviderModelDescriptor>>
@@ -378,20 +415,20 @@ export function useProviderModelCatalog(input: {
       antigravity: antigravityModelsQuery.data?.models ?? [],
       grok: grokDynamicModelsQuery.data?.models ?? [],
       droid: droidDynamicModelsQuery.data?.models ?? [],
+      devin: devinDynamicModelsQuery.data?.models ?? [],
       opencode: openCodeDynamicModelsQuery.data?.models ?? [],
       pi: piDynamicModelsQuery.data?.models ?? [],
-      devin: devinDynamicModelsQuery.data?.models ?? [],
     }),
     [
       antigravityModelsQuery.data?.models,
       claudeDynamicModelsQuery.data?.models,
       codexDynamicModelsQuery.data?.models,
       cursorRuntimeModels,
+      devinDynamicModelsQuery.data?.models,
       droidDynamicModelsQuery.data?.models,
       grokDynamicModelsQuery.data?.models,
       openCodeDynamicModelsQuery.data?.models,
       piDynamicModelsQuery.data?.models,
-      devinDynamicModelsQuery.data?.models,
     ],
   );
 
@@ -405,15 +442,15 @@ export function useProviderModelCatalog(input: {
     [modelHintByProvider, runtimeModelsByProvider, selectedProvider],
   );
 
-  const selectedDynamicAgents =
-    selectedProvider === "claudeAgent"
-      ? (claudeDynamicAgentsQuery.data?.agents ?? EMPTY_PROVIDER_AGENTS)
-      : selectedProvider === "opencode"
-        ? (openCodeDynamicAgentsQuery.data?.agents ?? EMPTY_PROVIDER_AGENTS)
-        : (codexDynamicAgentsQuery.data?.agents ?? EMPTY_PROVIDER_AGENTS);
+  const agentQueriesByProvider: Partial<Record<ProviderKind, typeof claudeDynamicAgentsQuery>> = {
+    claudeAgent: claudeDynamicAgentsQuery,
+    codex: codexDynamicAgentsQuery,
+    opencode: openCodeDynamicAgentsQuery,
+  };
+  const selectedDynamicAgents = agentQueriesByProvider[selectedProvider]?.data?.agents;
   const selectedRuntimeAgents = useMemo<ReadonlyArray<ProviderAgentDescriptor>>(
     () =>
-      selectedDynamicAgents.map((agent) =>
+      (selectedDynamicAgents ?? []).map((agent) =>
         agent.description
           ? { name: agent.name, displayName: agent.displayName, description: agent.description }
           : { name: agent.name, displayName: agent.displayName },
@@ -421,79 +458,24 @@ export function useProviderModelCatalog(input: {
     [selectedDynamicAgents],
   );
 
-  // Discovery failures per provider, surfaced as a subtle inline note by the
-  // model pickers.
-  const discoveryErrorsByProvider = useMemo(
-    () => ({
-      claudeAgent: claudeDynamicModelsQuery.data?.error,
-      codex: codexDynamicModelsQuery.data?.error,
-      cursor: cursorDynamicModelsQuery.data?.error,
-      devin: devinDynamicModelsQuery.data?.error,
-      antigravity: antigravityModelsQuery.data?.error,
-      grok: grokDynamicModelsQuery.data?.error,
-      droid: droidDynamicModelsQuery.data?.error,
-      opencode: openCodeDynamicModelsQuery.data?.error,
-      pi: piDynamicModelsQuery.data?.error,
-    }),
-    [
-      antigravityModelsQuery.data?.error,
-      claudeDynamicModelsQuery.data?.error,
-      codexDynamicModelsQuery.data?.error,
-      cursorDynamicModelsQuery.data?.error,
-      devinDynamicModelsQuery.data?.error,
-      droidDynamicModelsQuery.data?.error,
-      grokDynamicModelsQuery.data?.error,
-      openCodeDynamicModelsQuery.data?.error,
-      piDynamicModelsQuery.data?.error,
-    ],
-  );
-
   const selectedProviderRuntimeModelDiscoveryPending =
-    loadingModelProviders[selectedProvider] ?? false;
-  const selectedProviderModelsQuery =
-    selectedProvider === "claudeAgent"
-      ? claudeDynamicModelsQuery
-      : selectedProvider === "codex"
-        ? codexDynamicModelsQuery
-        : selectedProvider === "cursor"
-          ? cursorDynamicModelsQuery
-          : selectedProvider === "antigravity"
-            ? antigravityModelsQuery
-            : selectedProvider === "grok"
-              ? grokDynamicModelsQuery
-              : selectedProvider === "droid"
-                ? droidDynamicModelsQuery
-                : selectedProvider === "opencode"
-                  ? openCodeDynamicModelsQuery
-                  : selectedProvider === "pi"
-                    ? piDynamicModelsQuery
-                    : devinDynamicModelsQuery;
-  const selectedProviderModelsLoading =
-    selectedProviderRuntimeModelDiscoveryPending ||
-    (loadingModelProviders[selectedProvider] === undefined &&
-      (selectedProviderModelsQuery.isLoading ||
-        (selectedProviderModelsQuery.isFetching &&
-          selectedProviderModelsQuery.data === undefined)));
+    modelDiscoveryByProvider[selectedProvider].status === "loading";
 
   return useMemo(
     () => ({
       customModelsByProvider,
       modelOptionsByProvider,
-      loadingModelProviders,
+      modelDiscoveryByProvider,
       runtimeModelsByProvider,
       selectedRuntimeModel,
       selectedRuntimeAgents,
-      selectedProviderModelsLoading,
       selectedProviderRuntimeModelDiscoveryPending,
-      discoveryErrorsByProvider,
     }),
     [
       customModelsByProvider,
-      discoveryErrorsByProvider,
-      loadingModelProviders,
+      modelDiscoveryByProvider,
       modelOptionsByProvider,
       runtimeModelsByProvider,
-      selectedProviderModelsLoading,
       selectedProviderRuntimeModelDiscoveryPending,
       selectedRuntimeAgents,
       selectedRuntimeModel,

--- a/apps/web/src/lib/providerDiscoveryReactQuery.test.ts
+++ b/apps/web/src/lib/providerDiscoveryReactQuery.test.ts
@@ -3,24 +3,61 @@
 //          stale-catalog preservation, and initial-vs-background pending (#103).
 // Layer: Web data fetching tests
 
-import type { NativeApi } from "@synara/contracts";
-import { QueryClient } from "@tanstack/react-query";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import * as providerModelCatalogCache from "./providerModelCatalogCache";
 import {
   isInitialModelDiscoveryPending,
   providerModelsQueryOptions,
 } from "./providerDiscoveryReactQuery";
 import * as nativeApi from "../nativeApi";
 
+const baseInputs: {
+  binaryPath: string | null;
+  apiEndpoint: string | null;
+  agentDir: string | null;
+  cwd: string | null;
+} = {
+  binaryPath: "/usr/local/bin/opencode",
+  apiEndpoint: null,
+  agentDir: "/tmp/opencode",
+  cwd: "/ignored",
+};
+
 function mockListModels(listModels: ReturnType<typeof vi.fn>) {
-  vi.spyOn(nativeApi, "ensureNativeApi").mockReturnValue({
-    provider: { listModels },
-  } as unknown as NativeApi);
+  vi.spyOn(nativeApi, "ensureNativeApi").mockReturnValue(
+    // @ts-expect-error test-only partial NativeApi mock; only provider.listModels is used
+    { provider: { listModels } },
+  );
   return listModels;
 }
 
+function installMemoryLocalStorage(): void {
+  const entries = new Map<string, string>();
+
+  vi.stubGlobal("localStorage", {
+    getItem: vi.fn((key: string) => entries.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      entries.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      entries.delete(key);
+    }),
+    clear: vi.fn(() => {
+      entries.clear();
+    }),
+    key: vi.fn((index: number) => Array.from(entries.keys())[index] ?? null),
+    get length() {
+      return entries.size;
+    },
+  });
+}
+
+beforeEach(installMemoryLocalStorage);
+
 afterEach(() => {
+  vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
 
@@ -74,14 +111,67 @@ describe("providerModelsQueryOptions", () => {
     expect(queryClient.getQueryState(options.queryKey)?.status).toBe("error");
   });
 
-  it("fails fast only for cursor and droid, and devin uses the standard on-demand policy", () => {
+  it("uses the provider-specific retry counts", () => {
     expect(providerModelsQueryOptions({ provider: "codex" }).retry).toBe(3);
-    expect(providerModelsQueryOptions({ provider: "devin" }).retry).toBe(3);
-    expect(providerModelsQueryOptions({ provider: "devin" }).staleTime).toBe(30_000);
+    expect(providerModelsQueryOptions({ provider: "claudeAgent" }).retry).toBe(3);
     expect(providerModelsQueryOptions({ provider: "droid" }).retry).toBe(0);
-    expect(providerModelsQueryOptions({ provider: "droid" }).staleTime).toBe(5 * 60_000);
     expect(providerModelsQueryOptions({ provider: "cursor" }).retry).toBe(0);
-    expect(providerModelsQueryOptions({ provider: "cursor" }).staleTime).toBe(30_000);
+    expect(providerModelsQueryOptions({ provider: "opencode" }).retry).toBe(1);
+    expect(providerModelsQueryOptions({ provider: "devin" }).retry).toBe(2);
+  });
+
+  it("bounds retry delay and revalidates after reconnect", () => {
+    const options = providerModelsQueryOptions({ provider: "devin" });
+    const retryDelay = options.retryDelay;
+    expect(typeof retryDelay).toBe("function");
+    if (typeof retryDelay !== "function") {
+      throw new Error("Expected model discovery retry delay to be a function.");
+    }
+
+    expect(retryDelay(0, new Error("transient"))).toBe(200);
+    expect(retryDelay(8, new Error("transient"))).toBe(2_000);
+    expect(options.refetchOnReconnect).toBe(true);
+  });
+
+  it("treats an errored fallback result as a failure for every provider", async () => {
+    mockListModels(
+      vi.fn().mockResolvedValue({
+        models: [{ slug: "claude-sonnet-5", name: "Claude Sonnet 5" }],
+        source: "claude.cli",
+        cached: false,
+        error: "Claude CLI discovery failed; serving static fallback",
+      }),
+    );
+    const options = providerModelsQueryOptions({ provider: "claudeAgent", enabled: true });
+    Object.assign(options, { retry: 0 });
+
+    const queryClient = new QueryClient();
+    await expect(queryClient.fetchQuery(options)).rejects.toThrow(
+      "Claude CLI discovery failed; serving static fallback",
+    );
+    expect(queryClient.getQueryData(options.queryKey)).toBeUndefined();
+  });
+
+  it("recovers Devin discovery after a transient failure without duplicate requests", async () => {
+    const catalog = {
+      models: [{ slug: "adaptive", name: "Adaptive" }],
+      source: "devin-acp",
+      cached: false,
+    };
+    const listModels = mockListModels(
+      vi
+        .fn()
+        .mockRejectedValueOnce(new Error("temporary ACP startup failure"))
+        .mockResolvedValue(catalog),
+    );
+    const options = providerModelsQueryOptions({ provider: "devin", enabled: true });
+    Object.assign(options, { retryDelay: 0 });
+    const queryClient = new QueryClient();
+
+    await expect(
+      Promise.all([queryClient.fetchQuery(options), queryClient.fetchQuery(options)]),
+    ).resolves.toEqual([catalog, catalog]);
+    expect(listModels).toHaveBeenCalledTimes(2);
   });
 
   it("keeps Droid discovery cached for five minutes and ignores focus", () => {
@@ -145,5 +235,97 @@ describe("providerModelsQueryOptions", () => {
 
     const queryClient = new QueryClient();
     await expect(queryClient.fetchQuery(options)).resolves.toEqual(catalog);
+  });
+
+  it("sets initialData and initialDataUpdatedAt from the persisted cache for a discovery-owned provider", () => {
+    const catalog = {
+      models: [{ slug: "openai/gpt-5", name: "GPT-5" }],
+      source: "opencode",
+      cached: false,
+    };
+    const inputsKey = providerModelCatalogCache.buildCatalogCacheInputsKey(baseInputs);
+    providerModelCatalogCache.writeCatalogCache("opencode", inputsKey, catalog);
+
+    const cached = providerModelCatalogCache.readCatalogCacheEntry("opencode", inputsKey);
+    expect(cached).toBeDefined();
+
+    const options = providerModelsQueryOptions({
+      provider: "opencode",
+      ...baseInputs,
+      enabled: true,
+    });
+
+    expect(typeof options.initialData).toBe("function");
+    expect((options.initialData as () => typeof catalog)()).toEqual(catalog);
+    expect(options.initialDataUpdatedAt).toBe(cached!.fetchedAt);
+
+    // With a fresh cached entry and staleTime set to Infinity, the observer should
+    // hydrate from initialData and never call listModels.
+    const listModels = mockListModels(vi.fn().mockResolvedValue(catalog));
+    const queryClient = new QueryClient();
+    const observer = new QueryObserver(queryClient, {
+      ...options,
+      staleTime: Number.POSITIVE_INFINITY,
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+
+    const current = observer.getCurrentResult();
+    expect(current.isPlaceholderData).toBe(false);
+    expect(current.data).toEqual(catalog);
+    expect(listModels).not.toHaveBeenCalled();
+
+    unsubscribe();
+  });
+
+  it("omits initialData when no persisted cache entry exists", () => {
+    const options = providerModelsQueryOptions({
+      provider: "opencode",
+      ...baseInputs,
+      enabled: true,
+    });
+
+    expect(options.initialData).toBeUndefined();
+    expect(options.initialDataUpdatedAt).toBeUndefined();
+  });
+
+  it("writes real-source results to the cache for discovery-owned providers only", async () => {
+    const writeCache = vi
+      .spyOn(providerModelCatalogCache, "writeCatalogCache")
+      .mockImplementation(() => undefined);
+    vi.spyOn(providerModelCatalogCache, "readCatalogCacheEntry").mockReturnValue(undefined);
+
+    const opencodeCatalog = {
+      models: [{ slug: "openai/gpt-5", name: "GPT-5" }],
+      source: "opencode",
+      cached: false,
+    };
+    const opencodeListModels = mockListModels(vi.fn().mockResolvedValue(opencodeCatalog));
+
+    const opencodeOptions = providerModelsQueryOptions({ provider: "opencode", enabled: true });
+    const queryClient = new QueryClient();
+    await expect(queryClient.fetchQuery(opencodeOptions)).resolves.toEqual(opencodeCatalog);
+
+    expect(opencodeListModels).toHaveBeenCalledTimes(1);
+    expect(writeCache).toHaveBeenCalledTimes(1);
+    expect(writeCache).toHaveBeenLastCalledWith(
+      "opencode",
+      providerModelCatalogCache.buildCatalogCacheInputsKey({}),
+      opencodeCatalog,
+    );
+
+    vi.clearAllMocks();
+
+    const codexCatalog = {
+      models: [{ slug: "gpt-5.4", name: "GPT-5.4" }],
+      source: "codex",
+      cached: false,
+    };
+    const codexListModels = mockListModels(vi.fn().mockResolvedValue(codexCatalog));
+
+    const codexOptions = providerModelsQueryOptions({ provider: "codex", enabled: true });
+    await expect(queryClient.fetchQuery(codexOptions)).resolves.toEqual(codexCatalog);
+
+    expect(codexListModels).toHaveBeenCalledTimes(1);
+    expect(writeCache).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/providerDiscoveryReactQuery.ts
+++ b/apps/web/src/lib/providerDiscoveryReactQuery.ts
@@ -9,7 +9,13 @@ import type {
   ProviderSkillsCatalogResult,
 } from "@synara/contracts";
 import { queryOptions } from "@tanstack/react-query";
+import { DISCOVERY_OWNED_MODEL_PROVIDERS } from "~/providerModelOptions";
 import { ensureNativeApi } from "~/nativeApi";
+import {
+  buildCatalogCacheInputsKey,
+  readCatalogCacheEntry,
+  writeCatalogCache,
+} from "./providerModelCatalogCache";
 
 const EMPTY_SKILLS_RESULT: ProviderListSkillsResult = {
   skills: [],
@@ -44,6 +50,18 @@ const EMPTY_PLUGINS_RESULT: ProviderListPluginsResult = {
   cached: false,
 };
 
+const PROVIDER_MODEL_RETRY_COUNTS: Record<ProviderKind, number> = {
+  antigravity: 3,
+  claudeAgent: 3,
+  codex: 3,
+  cursor: 0,
+  devin: 2,
+  droid: 0,
+  grok: 3,
+  opencode: 1,
+  pi: 3,
+};
+
 export const providerDiscoveryQueryKeys = {
   all: ["provider-discovery"] as const,
   composerCapabilities: (provider: ProviderKind) =>
@@ -76,6 +94,8 @@ export const providerDiscoveryQueryKeys = {
     agentDir: string | null,
     cwd: string | null,
   ) => ["provider-discovery", "models", provider, binaryPath, apiEndpoint, agentDir, cwd] as const,
+  modelsForProvider: (provider: ProviderKind) =>
+    ["provider-discovery", "models", provider] as const,
   agentsForProvider: (provider: ProviderKind) =>
     ["provider-discovery", "agents", provider] as const,
   agents: (provider: ProviderKind, binaryPath: string | null, cwd: string | null) =>
@@ -199,12 +219,21 @@ export function isInitialModelDiscoveryPending(query: {
 
 export function providerModelsQueryOptions(input: {
   provider: ProviderKind;
-  binaryPath?: string | null;
-  apiEndpoint?: string | null;
-  agentDir?: string | null;
-  cwd?: string | null;
-  enabled?: boolean;
+  binaryPath?: string | null | undefined;
+  apiEndpoint?: string | null | undefined;
+  agentDir?: string | null | undefined;
+  cwd?: string | null | undefined;
+  enabled?: boolean | undefined;
 }) {
+  const inputsKey = buildCatalogCacheInputsKey({
+    binaryPath: input.binaryPath,
+    apiEndpoint: input.apiEndpoint,
+    agentDir: input.agentDir,
+    cwd: input.cwd,
+  });
+  const isDiscoveryOwned = DISCOVERY_OWNED_MODEL_PROVIDERS.has(input.provider);
+  const cached = isDiscoveryOwned ? readCatalogCacheEntry(input.provider, inputsKey) : undefined;
+
   return queryOptions({
     queryKey: providerDiscoveryQueryKeys.models(
       input.provider,
@@ -215,25 +244,42 @@ export function providerModelsQueryOptions(input: {
     ),
     queryFn: async (): Promise<ProviderListModelsResult> => {
       const api = ensureNativeApi();
-      return api.provider.listModels({
+      const result = await api.provider.listModels({
         provider: input.provider,
         ...(input.binaryPath ? { binaryPath: input.binaryPath } : {}),
         ...(input.apiEndpoint ? { apiEndpoint: input.apiEndpoint } : {}),
         ...(input.agentDir ? { agentDir: input.agentDir } : {}),
         ...(input.cwd ? { cwd: input.cwd } : {}),
       });
+      // An errored result is a failed discovery for every provider — including
+      // claudeAgent/codex, whose static fallback must not masquerade as success.
+      if (result.error !== undefined) {
+        throw new Error(result.error);
+      }
+      if (isDiscoveryOwned) {
+        writeCatalogCache(input.provider, inputsKey, result);
+      }
+      return result;
     },
     enabled: input.enabled ?? true,
     // Cached catalogs paint immediately while stale entries revalidate in the
     // background. Droid discovery starts a disposable ACP session, so retain its
     // longer cache and never repeat that work merely because the window regained focus.
-    retry: input.provider === "droid" || input.provider === "cursor" ? 0 : 3,
+    retry: PROVIDER_MODEL_RETRY_COUNTS[input.provider],
+    retryDelay: (attempt) => Math.min(2_000, 200 * 2 ** attempt),
+    refetchOnReconnect: true,
     staleTime: input.provider === "droid" ? 5 * 60_000 : 30_000,
     ...(input.provider === "droid" ? { refetchOnWindowFocus: false } : {}),
     // 30min — matches NEW_THREAD_MODEL_PREFETCH_STALE_TIME_MS in
     // providerModelPrefetch.ts (not imported: that module imports from here).
     gcTime: 30 * 60_000,
     placeholderData: (previous) => previous ?? EMPTY_MODELS_RESULT,
+    ...(cached
+      ? {
+          initialData: () => cached.result,
+          initialDataUpdatedAt: cached.fetchedAt,
+        }
+      : {}),
   });
 }
 

--- a/apps/web/src/lib/providerModelCatalogCache.test.ts
+++ b/apps/web/src/lib/providerModelCatalogCache.test.ts
@@ -1,0 +1,166 @@
+// FILE: providerModelCatalogCache.test.ts
+// Purpose: Unit tests for the persisted provider model catalog cache.
+// Layer: Web local storage / discovery cache tests
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildCatalogCacheInputsKey,
+  CATALOG_CACHE_TTL_MS,
+  CATALOG_CACHE_VERSION,
+  readCatalogCacheEntry,
+  writeCatalogCache,
+} from "./providerModelCatalogCache";
+
+function catalogCacheKey(provider: string) {
+  return `synara:provider-models-cache:${CATALOG_CACHE_VERSION}:${provider}`;
+}
+
+const baseInputs = {
+  binaryPath: "/usr/local/bin/opencode",
+  apiEndpoint: null as string | null,
+  agentDir: "/tmp/opencode",
+  cwd: "/ignored" as string | null,
+};
+const inputsKey = buildCatalogCacheInputsKey(baseInputs);
+
+const nonEmptyResult = {
+  models: [{ slug: "openai/gpt-5", name: "GPT-5" }],
+  source: "opencode",
+  cached: false,
+};
+
+function installMemoryLocalStorage(): void {
+  const entries = new Map<string, string>();
+
+  vi.stubGlobal("localStorage", {
+    getItem: vi.fn((key: string) => entries.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      entries.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      entries.delete(key);
+    }),
+    clear: vi.fn(() => {
+      entries.clear();
+    }),
+    key: vi.fn((index: number) => Array.from(entries.keys())[index] ?? null),
+    get length() {
+      return entries.size;
+    },
+  });
+}
+
+beforeEach(installMemoryLocalStorage);
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("providerModelCatalogCache", () => {
+  it("round-trips a non-empty catalog for a matching inputsKey", () => {
+    writeCatalogCache("opencode", inputsKey, nonEmptyResult);
+    expect(readCatalogCacheEntry("opencode", inputsKey)?.result).toEqual(nonEmptyResult);
+  });
+
+  it("rejects entries older than 7 days", () => {
+    const expired = {
+      inputsKey,
+      fetchedAt: Date.now() - CATALOG_CACHE_TTL_MS - 1,
+      result: nonEmptyResult,
+    };
+    globalThis.localStorage.setItem(catalogCacheKey("opencode"), JSON.stringify(expired));
+
+    expect(readCatalogCacheEntry("opencode", inputsKey)).toBeUndefined();
+  });
+
+  it("rejects entries with a mismatched inputsKey", () => {
+    writeCatalogCache("opencode", inputsKey, nonEmptyResult);
+
+    const otherKey = buildCatalogCacheInputsKey({
+      ...baseInputs,
+      binaryPath: "/other/opencode",
+    });
+    expect(readCatalogCacheEntry("opencode", otherKey)).toBeUndefined();
+  });
+
+  it("ignores malformed localStorage values", () => {
+    globalThis.localStorage.setItem(catalogCacheKey("opencode"), "not-json");
+    expect(readCatalogCacheEntry("opencode", inputsKey)).toBeUndefined();
+
+    globalThis.localStorage.setItem(catalogCacheKey("opencode"), JSON.stringify({ wrong: true }));
+    expect(readCatalogCacheEntry("opencode", inputsKey)).toBeUndefined();
+  });
+
+  it("ignores entries whose fetchedAt is not a positive finite number", () => {
+    writeCatalogCache("opencode", inputsKey, nonEmptyResult);
+    const raw = globalThis.localStorage.getItem(catalogCacheKey("opencode"));
+    expect(raw).not.toBeNull();
+    const payload = JSON.parse(raw!) as { fetchedAt: number | null };
+    globalThis.localStorage.setItem(
+      catalogCacheKey("opencode"),
+      JSON.stringify({ ...payload, fetchedAt: null }),
+    );
+    expect(readCatalogCacheEntry("opencode", inputsKey)).toBeUndefined();
+
+    globalThis.localStorage.setItem(
+      catalogCacheKey("opencode"),
+      JSON.stringify({ ...payload, fetchedAt: 0 }),
+    );
+    expect(readCatalogCacheEntry("opencode", inputsKey)).toBeUndefined();
+  });
+
+  it("never persists a fallback-populated result", () => {
+    globalThis.localStorage.removeItem(catalogCacheKey("opencode"));
+    writeCatalogCache("opencode", inputsKey, { ...nonEmptyResult, error: "discovery failed" });
+    expect(globalThis.localStorage.getItem(catalogCacheKey("opencode"))).toBeNull();
+  });
+
+  it("refuses to cache empty, disabled, or unsupported sources and preserves the previous value", () => {
+    writeCatalogCache("opencode", inputsKey, nonEmptyResult);
+
+    const badResults = [
+      { models: [{ slug: "x", name: "X" }], source: "empty" as const, cached: false },
+      { models: [{ slug: "x", name: "X" }], source: "disabled" as const, cached: false },
+      { models: [{ slug: "x", name: "X" }], source: "unsupported" as const, cached: false },
+      { models: [], source: "empty" as const, cached: false },
+      { models: [], source: "disabled" as const, cached: false },
+      { models: [], source: "unsupported" as const, cached: false },
+    ];
+
+    for (const bad of badResults) {
+      writeCatalogCache("opencode", inputsKey, bad);
+      expect(readCatalogCacheEntry("opencode", inputsKey)?.result).toEqual(nonEmptyResult);
+    }
+  });
+
+  it("refuses to cache a result with an undefined source even when models are non-empty", () => {
+    writeCatalogCache("opencode", inputsKey, {
+      models: [{ slug: "openai/gpt-5", name: "GPT-5" }],
+      source: undefined,
+      cached: false,
+    });
+
+    expect(readCatalogCacheEntry("opencode", inputsKey)).toBeUndefined();
+  });
+
+  it("refuses to cache a result with an empty source even when models are non-empty", () => {
+    writeCatalogCache("opencode", inputsKey, {
+      models: [{ slug: "openai/gpt-5", name: "GPT-5" }],
+      source: "",
+      cached: false,
+    });
+
+    expect(readCatalogCacheEntry("opencode", inputsKey)).toBeUndefined();
+  });
+
+  it("swallows localStorage write errors so the picker stays usable", () => {
+    globalThis.localStorage.setItem = () => {
+      throw new Error("quota exceeded");
+    };
+
+    expect(() => writeCatalogCache("opencode", inputsKey, nonEmptyResult)).not.toThrow();
+    expect(readCatalogCacheEntry("opencode", inputsKey)).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/providerModelCatalogCache.ts
+++ b/apps/web/src/lib/providerModelCatalogCache.ts
@@ -5,6 +5,17 @@ export const CATALOG_CACHE_VERSION = "v1";
 export const CATALOG_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const CACHE_KEY_PREFIX = `synara:provider-models-cache:${CATALOG_CACHE_VERSION}:`;
 
+function getCatalogStorage(): Storage | undefined {
+  try {
+    return globalThis.localStorage;
+  } catch (error) {
+    // Storage access itself throws when cookies are blocked or the page runs
+    // without a DOM. The catalog cache is best-effort, so skip it audibly.
+    console.warn("[providerModelCatalogCache] storage unavailable, skipping cache", error);
+    return undefined;
+  }
+}
+
 const UNCACHEABLE_SOURCES = new Set(["empty", "disabled", "unsupported"]);
 function isCacheableModelSource(source: string | undefined): source is string {
   return typeof source === "string" && source.length > 0 && !UNCACHEABLE_SOURCES.has(source);
@@ -38,7 +49,7 @@ export function readCatalogCacheEntry(
   provider: ProviderKind,
   inputsKey: string,
 ): typeof CatalogCachePayloadSchema.Type | undefined {
-  const storage = globalThis.localStorage;
+  const storage = getCatalogStorage();
   if (!storage) return undefined;
   try {
     const raw = storage.getItem(`${CACHE_KEY_PREFIX}${provider}`);
@@ -51,7 +62,10 @@ export function readCatalogCacheEntry(
       return undefined;
 
     return cached;
-  } catch {
+  } catch (error) {
+    // A corrupt or foreign entry must never break the picker: drop it audibly
+    // so the next successful discovery overwrites it.
+    console.warn("[providerModelCatalogCache] dropping unreadable cache entry", error);
     return undefined;
   }
 }
@@ -68,12 +82,16 @@ export function writeCatalogCache(
   )
     return;
 
-  const storage = globalThis.localStorage;
+  const storage = getCatalogStorage();
   if (!storage) return;
   try {
     storage.setItem(
       `${CACHE_KEY_PREFIX}${provider}`,
       JSON.stringify({ inputsKey, fetchedAt: Date.now(), result }),
     );
-  } catch {}
+  } catch (error) {
+    // Quota or a blocked store must never break discovery: the next mount
+    // simply refetches.
+    console.warn("[providerModelCatalogCache] could not persist cache entry", error);
+  }
 }

--- a/apps/web/src/lib/providerModelCatalogCache.ts
+++ b/apps/web/src/lib/providerModelCatalogCache.ts
@@ -1,0 +1,79 @@
+import { ProviderListModelsResult, type ProviderKind } from "@synara/contracts";
+import { Schema } from "effect";
+
+export const CATALOG_CACHE_VERSION = "v1";
+export const CATALOG_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const CACHE_KEY_PREFIX = `synara:provider-models-cache:${CATALOG_CACHE_VERSION}:`;
+
+const UNCACHEABLE_SOURCES = new Set(["empty", "disabled", "unsupported"]);
+function isCacheableModelSource(source: string | undefined): source is string {
+  return typeof source === "string" && source.length > 0 && !UNCACHEABLE_SOURCES.has(source);
+}
+
+export function isUsableModelSource(source: string | undefined): boolean {
+  return isCacheableModelSource(source);
+}
+
+const CatalogCachePayloadSchema = Schema.Struct({
+  inputsKey: Schema.String,
+  fetchedAt: Schema.Number.check(Schema.isFinite(), Schema.isGreaterThan(0)),
+  result: ProviderListModelsResult,
+});
+
+export function buildCatalogCacheInputsKey(input: {
+  binaryPath?: string | null | undefined;
+  apiEndpoint?: string | null | undefined;
+  agentDir?: string | null | undefined;
+  cwd?: string | null | undefined;
+}): string {
+  return JSON.stringify({
+    binaryPath: input.binaryPath ?? null,
+    apiEndpoint: input.apiEndpoint ?? null,
+    agentDir: input.agentDir ?? null,
+    cwd: input.cwd ?? null,
+  });
+}
+
+export function readCatalogCacheEntry(
+  provider: ProviderKind,
+  inputsKey: string,
+): typeof CatalogCachePayloadSchema.Type | undefined {
+  const storage = globalThis.localStorage;
+  if (!storage) return undefined;
+  try {
+    const raw = storage.getItem(`${CACHE_KEY_PREFIX}${provider}`);
+    if (!raw) return undefined;
+
+    const parsed: unknown = JSON.parse(raw);
+    const cached = Schema.decodeUnknownSync(CatalogCachePayloadSchema)(parsed);
+
+    if (cached.inputsKey !== inputsKey || Date.now() - cached.fetchedAt > CATALOG_CACHE_TTL_MS)
+      return undefined;
+
+    return cached;
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeCatalogCache(
+  provider: ProviderKind,
+  inputsKey: string,
+  result: ProviderListModelsResult,
+): void {
+  if (
+    result.error !== undefined ||
+    !isCacheableModelSource(result.source) ||
+    result.models.length === 0
+  )
+    return;
+
+  const storage = globalThis.localStorage;
+  if (!storage) return;
+  try {
+    storage.setItem(
+      `${CACHE_KEY_PREFIX}${provider}`,
+      JSON.stringify({ inputsKey, fetchedAt: Date.now(), result }),
+    );
+  } catch {}
+}

--- a/apps/web/src/providerModelOptions.test.ts
+++ b/apps/web/src/providerModelOptions.test.ts
@@ -9,6 +9,7 @@ import {
   buildModelSelection,
   buildNextProviderOptions,
   buildProviderOptionPatch,
+  DISCOVERY_OWNED_MODEL_PROVIDERS,
   formatProviderModelOptionName,
   groupProviderModelOptions,
   groupProviderModelOptionsWithFavorites,
@@ -41,6 +42,17 @@ describe("Claude model selections", () => {
       provider: "claudeAgent",
       model: "claude-haiku-4-5",
       supportsAutoMode: false,
+    });
+  });
+
+  it("never adds supportsAutoMode to selections of providers that do not declare it", () => {
+    expect(buildModelSelection("codex", "gpt-5.6-sol", undefined, true)).toEqual({
+      provider: "codex",
+      model: "gpt-5.6-sol",
+    });
+    expect(buildModelSelection("droid", "gpt-5.6-luna", undefined, false)).toEqual({
+      provider: "droid",
+      model: "gpt-5.6-luna",
     });
   });
 });
@@ -255,6 +267,72 @@ describe("mergeDynamicModelOptions", () => {
       { slug: "custom/grok-fast", name: "custom/grok-fast", isCustom: true },
     ]);
   });
+
+  it("treats the live OpenCode catalog as authoritative and preserves custom hints", () => {
+    expect(
+      mergeDynamicModelOptions({
+        provider: "opencode",
+        staticOptions: [
+          { slug: "openai/gpt-5", name: "GPT-5" },
+          { slug: "opencode-go/kimi", name: "Kimi" },
+          {
+            slug: "openai/gpt-5",
+            name: "GPT-5",
+            isCustom: true,
+            isSelectionHint: true,
+          },
+        ],
+        dynamicModels: [{ slug: "opencode-go/kimi", name: "Kimi" }],
+      }),
+    ).toEqual([
+      { slug: "opencode-go/kimi", name: "Kimi" },
+      {
+        slug: "openai/gpt-5",
+        name: "GPT-5",
+        isCustom: true,
+        isSelectionHint: true,
+      },
+    ]);
+  });
+
+  it("treats the live OpenCode catalog as authoritative", () => {
+    expect(
+      mergeDynamicModelOptions({
+        provider: "opencode",
+        staticOptions: [
+          { slug: "openai/gpt-5", name: "GPT-5" },
+          { slug: "opencode/internal", name: "OpenCode Internal" },
+        ],
+        dynamicModels: [{ slug: "opencode/internal", name: "OpenCode Internal" }],
+      }),
+    ).toEqual([{ slug: "opencode/internal", name: "OpenCode Internal" }]);
+  });
+
+  it("preserves isSelectionHint on custom-only entries missing from discovery", () => {
+    const options = mergeDynamicModelOptions({
+      provider: "opencode",
+      staticOptions: [
+        { slug: "openai/gpt-5", name: "GPT-5" },
+        {
+          slug: "custom/hint",
+          name: "Custom hint",
+          isCustom: true,
+          isSelectionHint: true,
+        },
+      ],
+      dynamicModels: [{ slug: "opencode-go/kimi", name: "Kimi" }],
+    });
+
+    expect(options).toEqual([
+      { slug: "opencode-go/kimi", name: "Kimi" },
+      {
+        slug: "custom/hint",
+        name: "Custom hint",
+        isCustom: true,
+        isSelectionHint: true,
+      },
+    ]);
+  });
 });
 
 describe("providerModelCostMultiplierLabel", () => {
@@ -368,6 +446,41 @@ describe("groupProviderModelOptionsWithFavorites", () => {
     expect(groupedOptions.flatMap((group) => group.options.map((option) => option.slug))).toEqual([
       "openai/gpt-5",
       "anthropic/claude-sonnet",
+    ]);
+  });
+
+  it("always emits non-favourite groups below the favourites group", () => {
+    const options = [
+      {
+        slug: "openai/gpt-5",
+        name: "GPT-5",
+        upstreamProviderId: "openai",
+        upstreamProviderName: "OpenAI",
+      },
+      {
+        slug: "anthropic/claude-sonnet",
+        name: "Claude Sonnet",
+        upstreamProviderId: "anthropic",
+        upstreamProviderName: "Anthropic",
+      },
+      {
+        slug: "opencode-go/kimi",
+        name: "Kimi",
+        upstreamProviderId: "opencode-go",
+        upstreamProviderName: "OpenCode Go",
+      },
+    ] satisfies ProviderModelOption[];
+
+    const groupedOptions = groupProviderModelOptionsWithFavorites({
+      options,
+      favoriteSlugs: new Set(["openai/gpt-5", "anthropic/claude-sonnet"]),
+    });
+
+    expect(groupedOptions.map((group) => group.label)).toEqual(["Favourites", "OpenCode Go"]);
+    expect(groupedOptions.flatMap((group) => group.options.map((option) => option.slug))).toEqual([
+      "openai/gpt-5",
+      "anthropic/claude-sonnet",
+      "opencode-go/kimi",
     ]);
   });
 });

--- a/apps/web/src/providerModelOptions.ts
+++ b/apps/web/src/providerModelOptions.ts
@@ -16,8 +16,6 @@ import {
   type CursorModelSelection,
   type DroidModelOptions,
   type DroidModelSelection,
-  type DevinModelOptions,
-  type DevinModelSelection,
   type GrokModelOptions,
   type GrokModelSelection,
   type ModelSelection,
@@ -38,6 +36,7 @@ export interface ProviderModelOption {
   description?: string;
   upstreamProviderId?: string;
   upstreamProviderName?: string;
+  isSelectionHint?: boolean;
 }
 
 export interface ProviderModelOptionGroup {
@@ -45,6 +44,20 @@ export interface ProviderModelOptionGroup {
   label: string | null;
   options: ProviderModelOption[];
 }
+
+/**
+ * Providers whose runtime discovery owns the catalog: when live models are
+ * returned, the static built-in list is dropped rather than mixed in.
+ */
+export const DISCOVERY_OWNED_MODEL_PROVIDERS: ReadonlySet<ProviderKind> = new Set([
+  "antigravity",
+  "cursor",
+  "devin",
+  "droid",
+  "grok",
+  "opencode",
+  "pi",
+] as const);
 
 /**
  * Returns the provider provenance shown when a model is detached from its
@@ -130,7 +143,7 @@ function orderClaudeModelOptions<T extends ProviderModelOption>(
  * Folds runtime-discovered models into the static option list for a provider:
  * discovered models lead (with display names recovered from the static list when
  * possible), static built-ins fill gaps unless discovery fully owns the catalog
- * (antigravity/opencode/cursor/grok), and user-defined custom models always survive.
+ * (see `DISCOVERY_OWNED_MODEL_PROVIDERS`), and user-defined custom models always survive.
  * Claude is the exception: its discovered and static built-in models are merged
  * into the curated catalog order.
  */
@@ -191,9 +204,15 @@ export function mergeDynamicModelOptions(input: {
 
   // Droid validates model values against its live ACP select options, so an
   // arbitrary custom slug is guaranteed to fail at session configuration.
+  // The selected-model hint (isSelectionHint) is kept so a previously selected
+  // Droid model that is not currently in the dynamic list still appears.
   const customOnlyModels =
     input.provider === "droid"
-      ? []
+      ? input.staticOptions.filter(
+          (model) =>
+            model.isSelectionHint === true &&
+            !dynamicNormalizedSlugs.has(normalizeDynamicModelSlug(input.provider, model.slug)),
+        )
       : input.staticOptions.filter(
           (model) =>
             "isCustom" in model &&
@@ -203,14 +222,9 @@ export function mergeDynamicModelOptions(input: {
   const staticBuiltInModels = input.staticOptions.filter(
     (model) => !("isCustom" in model) || model.isCustom !== true,
   );
+  const isDiscoveryOwned = DISCOVERY_OWNED_MODEL_PROVIDERS.has(input.provider);
   const missingStaticBuiltIns =
-    (input.provider === "antigravity" ||
-      input.provider === "opencode" ||
-      input.provider === "cursor" ||
-      input.provider === "droid" ||
-      input.provider === "grok" ||
-      input.provider === "devin") &&
-    normalizedDynamicOptions.length > 0
+    isDiscoveryOwned && normalizedDynamicOptions.length > 0
       ? []
       : staticBuiltInModels.filter((model) => !dynamicNormalizedSlugs.has(model.slug));
 
@@ -224,6 +238,7 @@ export function mergeDynamicModelOptions(input: {
   return [...normalizedDynamicOptions, ...missingStaticBuiltIns, ...customOnlyModels];
 }
 
+/** Returns a compact label for provider descriptions that begin with an `Nx` cost multiplier. */
 export function providerModelCostMultiplierLabel(description?: string): string | null {
   const multiplier = description?.trim().match(/^(\d+(?:\.\d+)?)x(?:\s|$)/i)?.[1];
   return multiplier ? `${multiplier}×` : null;
@@ -314,54 +329,12 @@ export function resolveModelGroupDefaultOpen(input: {
   return input.options.some((option) => option.slug === input.activeModel);
 }
 
-export function buildNextProviderOptions(
-  provider: ProviderKind,
-  modelOptions: ProviderOptions | null | undefined,
+export function buildNextProviderOptions<P extends ProviderKind>(
+  provider: P,
+  modelOptions: ProviderModelOptions[P] | null | undefined,
   patch: Record<string, unknown>,
-): ProviderOptions {
-  if (provider === "codex") {
-    return { ...(modelOptions as CodexModelOptions | undefined), ...patch } as CodexModelOptions;
-  }
-  if (provider === "claudeAgent") {
-    return { ...(modelOptions as ClaudeModelOptions | undefined), ...patch } as ClaudeModelOptions;
-  }
-  if (provider === "cursor") {
-    return { ...(modelOptions as CursorModelOptions | undefined), ...patch } as CursorModelOptions;
-  }
-  if (provider === "antigravity") {
-    return {
-      ...(modelOptions as AntigravityModelOptions | undefined),
-      ...patch,
-    } as AntigravityModelOptions;
-  }
-  if (provider === "grok") {
-    return {
-      ...(modelOptions as GrokModelOptions | undefined),
-      ...patch,
-    } as GrokModelOptions;
-  }
-  if (provider === "droid") {
-    return {
-      ...(modelOptions as DroidModelOptions | undefined),
-      ...patch,
-    } as DroidModelOptions;
-  }
-  if (provider === "devin") {
-    return {
-      ...(modelOptions as DevinModelOptions | undefined),
-      ...patch,
-    } as DevinModelOptions;
-  }
-  if (provider === "opencode") {
-    return {
-      ...(modelOptions as OpenCodeModelOptions | undefined),
-      ...patch,
-    } as OpenCodeModelOptions;
-  }
-  return {
-    ...(modelOptions as PiModelOptions | undefined),
-    ...patch,
-  } as PiModelOptions;
+): ProviderModelOptions[P] {
+  return { ...modelOptions, ...patch } as ProviderModelOptions[P];
 }
 
 export function buildProviderOptionPatch(
@@ -414,11 +387,6 @@ export function buildModelSelection(
   options?: PiModelOptions | null | undefined,
 ): PiModelSelection;
 export function buildModelSelection(
-  provider: "devin",
-  model: string,
-  options?: DevinModelOptions | null | undefined,
-): DevinModelSelection;
-export function buildModelSelection(
   provider: ProviderKind,
   model: string,
   options?: ProviderOptions | null | undefined,
@@ -430,77 +398,14 @@ export function buildModelSelection(
   options?: ProviderOptions | null | undefined,
   supportsAutoMode?: boolean | undefined,
 ): ModelSelection {
-  switch (provider) {
-    case "antigravity":
-      return options
-        ? {
-            provider,
-            model,
-            options: options as AntigravityModelOptions,
-          }
-        : { provider, model };
-    case "codex":
-      return options
-        ? {
-            provider,
-            model,
-            options: options as CodexModelOptions,
-          }
-        : { provider, model };
-    case "claudeAgent":
-      return {
-        provider,
-        model,
-        ...(options ? { options: options as ClaudeModelOptions } : {}),
-        ...(typeof supportsAutoMode === "boolean" ? { supportsAutoMode } : {}),
-      };
-    case "cursor":
-      return options
-        ? {
-            provider,
-            model,
-            options: options as CursorModelOptions,
-          }
-        : { provider, model };
-    case "devin":
-      return options
-        ? {
-            provider,
-            model,
-            options: options as DevinModelOptions,
-          }
-        : { provider, model };
-    case "grok":
-      return options
-        ? {
-            provider,
-            model,
-            options: options as GrokModelOptions,
-          }
-        : { provider, model };
-    case "droid":
-      return options
-        ? {
-            provider,
-            model,
-            options: options as DroidModelOptions,
-          }
-        : { provider, model };
-    case "opencode":
-      return options
-        ? {
-            provider,
-            model,
-            options: options as OpenCodeModelOptions,
-          }
-        : { provider, model };
-    case "pi":
-      return options
-        ? {
-            provider,
-            model,
-            options: options as PiModelOptions,
-          }
-        : { provider, model };
-  }
+  return {
+    provider,
+    model,
+    ...(options !== undefined && options !== null ? { options } : {}),
+    // Only ClaudeModelSelection declares supportsAutoMode; never leak it onto
+    // other providers' selections even when a runtime descriptor carries it.
+    ...(provider === "claudeAgent" && typeof supportsAutoMode === "boolean"
+      ? { supportsAutoMode }
+      : {}),
+  } as ModelSelection;
 }

--- a/apps/web/src/routes/-automations.shared.tsx
+++ b/apps/web/src/routes/-automations.shared.tsx
@@ -905,8 +905,7 @@ export function AutomationModelPicker({
   });
   const {
     modelOptionsByProvider,
-    loadingModelProviders,
-    discoveryErrorsByProvider,
+    modelDiscoveryByProvider,
     runtimeModelsByProvider,
     selectedRuntimeModel,
   } = useProviderModelCatalog({
@@ -941,8 +940,7 @@ export function AutomationModelPicker({
       lockedProvider={null}
       providers={providerStatuses}
       modelOptionsByProvider={modelOptionsByProvider}
-      loadingModelProviders={loadingModelProviders}
-      discoveryErrorsByProvider={discoveryErrorsByProvider}
+      modelDiscoveryByProvider={modelDiscoveryByProvider}
       hiddenProviders={settings.hiddenProviders}
       providerOrder={settings.providerOrder}
       disabled={disabled ?? false}


### PR DESCRIPTION
## What this does

Truthful model-discovery states in the provider model picker, plus a resilient catalog cache:

- Per-provider discovery status (`never-loaded` / `loading` / `success` / `failed` / `empty`) surfaced in the picker: loading skeletons while discovery runs, a `Couldn't load models — Retry` row on failure, and a `Couldn't refresh — Retry` footer when a stale cache exists.
- A failed/empty discovery-owned catalog no longer falls back to the static list. The failure view shows only rows that stay meaningful offline: the selected model, the user's own custom models, and selection hints — plus retry.
- Catalog cache is versioned (`v1`), TTL-gated (7 days), skips uncacheable sources and empty lists, and degrades to warn-and-skip when storage itself throws (blocked cookies, no DOM).
- Droid discovery stays cold unless the settings panel explicitly prefetches it — no disposable droid ACP session per picker surface.
- Review cuts: generic `buildModelSelection` (per-provider switch collapsed), static availability via `PROVIDER_OPTIONS.filter(available)`, exact-slug label resolution, `AutomationModelPicker` on the renamed `modelDiscoveryByProvider` map.

## Behavior change (user-visible)

- Opening the model picker during discovery shows skeletons instead of a silently stale list.
- If model loading fails with no cache, the menu keeps the current model and custom models selectable (offline-safe) and hides static built-ins discovery owns, with an explicit Retry row.
- If model loading fails with a cache, the cached list stays with a `Couldn't refresh — Retry` footer.
- Droid users: no behavior change when prefetched; non-prefetch surfaces no longer warm droid.

## Reviews

- Thermos bugs lens (subagent, conf 0.82): 2 P1 blockers, both fixed in `dbf9a71b8` — (1) droid prefetch gate restored in `useProviderModelCatalog.ts` with a droid-stays-cold regression test; (2) custom models kept visible in the failure view (`ProviderModelPicker.tsx`). P2 storage guard implemented as warn-and-skip in `providerModelCatalogCache.ts` (no empty catch).
- Thermos quality lens (subagent, conf 0.85): 9 P2/P3 findings, none breakage-grade — deferred to Follow-ups.
- CI-found failure (exact-name test assertion vs droid sr-only cost description in the accessible name): fixed in `4ff6e6289` by matching the selected row on name substring plus `checked: true`, which also disambiguates it from the custom row.
- Ponytail ultra: deletion-heavy pass applied in-diff (switch collapse, caller migration, dead-filter removal); remaining simplification nits in Follow-ups, none committed.

## Tests

| Command | Result |
|---|---|
| `gh pr checks 858` full graph on head `4ff6e6289` (Format/Lint/Typecheck/Test/Browser/Stable/Build 19m14s, Windows 6m25s, Migration Lineage, Release Smoke, labels) | all pass, zero fail/cancel/pending |
| `bun run --cwd apps/web test -- src/appSettings.test.ts src/hooks/useProviderModelCatalog.test.tsx src/lib/providerModelCatalogCache.test.ts src/providerModelOptions.test.ts` | 4 files, 136/136 pass |
| Picker browser spec via Devin swe-1-7 (`test:browser:stable src/components/chat/ProviderModelPicker.browser.tsx`, post-fix head) | 1 file, 26/26 pass — incl. new restricted-failure-row test |
| ChatView Devin-default browser test via Devin swe-1-7 (`ChatView.browser.tsx -t "saved global Devin default"`) | 1 passed, 102 skipped (103); one unrelated client console `TypeError (_nonReactive)` noted |
| Headed live proof (full dev stack server `:3773` + web `:5733`, `SYNARA_HOME=/tmp/synara-858-home` seeded 19 projects / 4 threads, headed system Chrome via agent-browser, worktree `evidence/858/`) | DONE: picker open in 3 live states, every screenshot pixel-verified genuine app UI — loading skeletons (`picker-loading-skeletons.png`), `Couldn't load models — Retry` failure (`picker-antigravity-failure.png`), live Cursor catalog + `Updated just now` footer (`picker-cursor-live.png`), Grok success (`picker-grok-success.png`), provider menu (`picker-providers.png`); `picker-live.webm` 249s recording. CDP trace unavailable on this engine (start/end state inconsistent), the recording stands in. |

## Socket surface

None. Zero `ws|socket|gateway|transport` code lines in the diff (only English substrings in comments: "catalog", "blocked"). No live connect/send/receive path touched.

## Follow-ups (deferred nits, uncommitted)

- Decompose `ProviderModelRadioItem` (4 jobs in one component).
- Nine `useProviderModelsQuery` call sites in `useProviderModelCatalog.ts` — consider a loop/factory.
- `isUsableModelSource` alias vs `isCacheableModelSource` — merge or document the split.
- `formatCatalogAgeLabel`, `DiscoveryStatusRow` ternary, `resolveLiveProviderAvailability` simplifications.
- Dedupe `installMemoryLocalStorage` in catalog-cache tests; name `PROVIDER_MODEL_RETRY_COUNTS` bare numbers; merge overlapping `providerModelOptions` tests.

## Merge note

Rebased on `upstream/main` `562c5fea77cff1dacb29d5e6216ed94a05f1b6a1` (merge-base verified). `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`, all checks green on `4ff6e6289`. Stays DRAFT until live-proof evidence lands. Merge-safe position: last in the Wave-2 feature order (858 after 859/857/909/861/862/860).

