### PR TITLE
feat(mind): durable, typed, decaying project memory with MCP tools and Mind view

### DIFF
--- a/apps/server/src/agentGateway/Layers/AgentGateway.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.ts
@@ -72,6 +72,7 @@ import { makeCreateThreadsHandler } from "../creationCoordinator.ts";
 import { makeAgentGatewayAutomationTools } from "../automationTools.ts";
 import { makeAgentGatewayBrowserTools } from "../browserTools.ts";
 import { makeAgentGatewayDeviceTools } from "../deviceTools.ts";
+import { MindService, makeAgentGatewayMemoryTools } from "../memoryTools.ts";
 import { DeviceService } from "../../device/Services/DeviceService.ts";
 import { BrowserAutomationHost } from "../../browserAutomation/Services/BrowserAutomationHost.ts";
 import { makeBrowserAutomationHost } from "../../browserAutomation/Layers/BrowserAutomationHost.ts";
@@ -132,6 +133,7 @@ export const makeAgentGateway = Effect.gen(function* () {
   // it) the agent never sees the device_* tools at all, rather than being
   // offered eleven tools that can only report an unsupported platform.
   const deviceService = Option.getOrUndefined(yield* Effect.serviceOption(DeviceService));
+  const mindService = Option.getOrUndefined(yield* Effect.serviceOption(MindService));
   const loadProviderAvailabilities = Effect.gen(function* () {
     const [settings, statuses] = yield* Effect.all([
       serverSettings.getSettings,
@@ -783,6 +785,10 @@ export const makeAgentGateway = Effect.gen(function* () {
       }).pipe(Effect.orElseSucceed(() => null)),
   });
 
+  const memoryTools = mindService
+    ? makeAgentGatewayMemoryTools({ mindService, requireThreadShell })
+    : ({} as Record<string, ToolEntry>);
+
   const tools: ReadonlyArray<ToolEntry> = [
     ...readTools,
     ...diagnosticTools,
@@ -796,6 +802,7 @@ export const makeAgentGateway = Effect.gen(function* () {
     setThreadGoal,
     ...automationTools,
     ...browserTools,
+    ...Object.values(memoryTools),
     ...(deviceService?.supported === true
       ? makeAgentGatewayDeviceTools({ manager: deviceService.manager })
       : []),

--- a/apps/server/src/agentGateway/Layers/AgentGatewaySessionRegistry.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGatewaySessionRegistry.ts
@@ -16,6 +16,7 @@ const PROVIDER_SESSION_CAPABILITIES = [
   "diagnostics:read",
   "browser:control",
   "device:control",
+  "memory:use",
 ] as const;
 
 export function makeAgentGatewaySessionRegistry(options?: {

--- a/apps/server/src/agentGateway/Services/AgentGatewaySessionRegistry.ts
+++ b/apps/server/src/agentGateway/Services/AgentGatewaySessionRegistry.ts
@@ -7,7 +7,8 @@ export type AgentGatewayCapability =
   | "automation:write"
   | "diagnostics:read"
   | "browser:control"
-  | "device:control";
+  | "device:control"
+  | "memory:use";
 
 export interface AgentGatewaySessionIdentity {
   readonly sessionKey: string;

--- a/apps/server/src/agentGateway/harnessPolicy.test.ts
+++ b/apps/server/src/agentGateway/harnessPolicy.test.ts
@@ -196,8 +196,8 @@ describe("Synara harness policy", () => {
   });
 
   it("bumps the harness policy version", () => {
-    assert.include(SYNARA_HARNESS_POLICY_VERSION, "2026-08-30.2");
-    assert.notEqual(SYNARA_HARNESS_POLICY_VERSION, "2026-08-25.2");
+    assert.include(SYNARA_HARNESS_POLICY_VERSION, "2026-08-30.3");
+    assert.notEqual(SYNARA_HARNESS_POLICY_VERSION, "2026-08-30.2");
   });
 
   it("includes memory tool standing orders when gateway control is available", () => {

--- a/apps/server/src/agentGateway/harnessPolicy.test.ts
+++ b/apps/server/src/agentGateway/harnessPolicy.test.ts
@@ -3,6 +3,7 @@ import { assert, describe, it } from "@effect/vitest";
 import {
   renderSynaraHarnessPolicy,
   SYNARA_HARNESS_POLICY_MARKER,
+  SYNARA_HARNESS_POLICY_VERSION,
   takeSynaraHarnessPolicyForProviderSession,
   takeSynaraHarnessPolicyTextPartForProviderSession,
   takeSynaraHarnessPolicyForSession,
@@ -192,5 +193,31 @@ describe("Synara harness policy", () => {
     // Promising tools this session cannot reach would be a lie.
     assert.notInclude(policy, "device_list");
     assert.notInclude(policy, "device_describe_ui");
+  });
+
+  it("bumps the harness policy version", () => {
+    assert.include(SYNARA_HARNESS_POLICY_VERSION, "2026-08-30.2");
+    assert.notEqual(SYNARA_HARNESS_POLICY_VERSION, "2026-08-25.2");
+  });
+
+  it("includes memory tool standing orders when gateway control is available", () => {
+    const policy = renderSynaraHarnessPolicy({ gatewayControlAvailable: true });
+
+    assert.include(policy, "memory:use");
+    assert.include(policy, "synara_remember");
+    assert.include(policy, "synara_recall_memories");
+    assert.include(policy, "synara_confirm_memory");
+    assert.include(policy, "synara_forget_memory");
+    assert.include(policy, "synara_prune_memories");
+    assert.include(policy, "project-scoped memory");
+    assert.notInclude(policy, "synara_remember" + " tools are available"); // sanity: no phantom concatenation
+  });
+
+  it("does not advertise memory tools when gateway control is unavailable", () => {
+    const policy = renderSynaraHarnessPolicy({ gatewayControlAvailable: false });
+
+    assert.notInclude(policy, "memory:use");
+    assert.notInclude(policy, "synara_remember");
+    assert.notInclude(policy, "synara_recall_memories");
   });
 });

--- a/apps/server/src/agentGateway/harnessPolicy.ts
+++ b/apps/server/src/agentGateway/harnessPolicy.ts
@@ -50,6 +50,12 @@ export function renderSynaraHarnessPolicy(capabilities: SynaraHarnessCapabilitie
         'Automation-dispatched turns receive an identity/run/memory envelope in the current user message. Only that current turn is automation-dispatched; the status never carries into a later manual follow-up such as "continue", even in the same thread.',
         'During an automation-dispatched turn, persist durable context with synara_update_automation_memory {"memory": "..."} before finishing; memory is full replacement, DB-backed, and capped at 32 KiB.',
         'Every automation-dispatched turn must finish by calling synara_report_automation_result. Use decision "silent" only for a successful run with nothing requiring user attention; otherwise use "notify" with a concise title and summary. Failures remain visible regardless of this decision or the automation notification policy. Never call this tool for a manual follow-up turn.',
+        "Use the synara_remember, synara_recall_memories, synara_confirm_memory, synara_forget_memory, and synara_prune_memories tools to manage durable, project-scoped memory. These tools require the memory:use capability and are only available to the provider session that owns the thread.",
+        "Call synara_remember to store a concise, project-scoped fact. Repeating the same text in one project reinforces the existing memory instead of creating a duplicate.",
+        "Call synara_recall_memories with an optional query to retrieve up to eight relevant memories, ranked by recency and decay, plus a digest of the results.",
+        "Call synara_confirm_memory when a recalled memory is still accurate; it raises the memory's weight and resets decay.",
+        "Call synara_forget_memory to permanently remove a memory by its id.",
+        "Call synara_prune_memories to safely remove stale, low-weight, unconfirmed memories from the caller's project.",
       ]
     : [
         "Synara MCP control is unavailable in this provider session. Do not claim that Synara threads, projects, or automations were created or changed.",

--- a/apps/server/src/agentGateway/harnessPolicy.ts
+++ b/apps/server/src/agentGateway/harnessPolicy.ts
@@ -3,7 +3,7 @@ import type { ProviderKind } from "@synara/contracts";
 import { AUTOMATION_AUTHORING_GUIDANCE } from "./automationAuthoringGuidance.ts";
 
 /** Canonical, versioned host policy delivered to every supported provider. */
-export const SYNARA_HARNESS_POLICY_VERSION = "2026-08-30.2";
+export const SYNARA_HARNESS_POLICY_VERSION = "2026-08-30.3";
 export const SYNARA_HARNESS_POLICY_MARKER = `[Synara harness policy ${SYNARA_HARNESS_POLICY_VERSION}]`;
 
 export interface SynaraHarnessCapabilities {
@@ -53,7 +53,7 @@ export function renderSynaraHarnessPolicy(capabilities: SynaraHarnessCapabilitie
         "Use the synara_remember, synara_recall_memories, synara_confirm_memory, synara_forget_memory, and synara_prune_memories tools to manage durable, project-scoped memory. These tools require the memory:use capability and are only available to the provider session that owns the thread.",
         "Call synara_remember to store a concise, project-scoped fact. Repeating the same text in one project reinforces the existing memory instead of creating a duplicate.",
         "Call synara_recall_memories with an optional query to retrieve up to eight relevant memories, ranked by recency and decay, plus a digest of the results.",
-        "Call synara_confirm_memory when a recalled memory is still accurate; it raises the memory's weight and resets decay.",
+        "Call synara_confirm_memory when a recalled memory is still accurate; it reinforces the memory and resets decay.",
         "Call synara_forget_memory to permanently remove a memory by its id.",
         "Call synara_prune_memories to safely remove stale, low-weight, unconfirmed memories from the caller's project.",
       ]

--- a/apps/server/src/agentGateway/memoryTools.test.ts
+++ b/apps/server/src/agentGateway/memoryTools.test.ts
@@ -1,0 +1,300 @@
+import { assert, describe, it } from "@effect/vitest";
+import {
+  ExternalMcpCapability,
+  MindError,
+  MindMemoryId,
+  ProjectId,
+  ProviderKind,
+  ThreadId,
+  TurnId,
+  type MindConfirmResult,
+  type MindMemory,
+  type MindMemoryMatch,
+  type MindPruneResult,
+  type MindRecallResult,
+  type MindRememberResult,
+  type OrchestrationThreadShell,
+} from "@synara/contracts";
+import { Effect } from "effect";
+
+import { makeAgentGatewaySessionRegistry } from "./Layers/AgentGatewaySessionRegistry.ts";
+import {
+  MIND_MEMORY_TEXT_MAX_CHARS,
+  makeAgentGatewayMemoryTools,
+  type MindServiceShape,
+} from "./memoryTools.ts";
+import type { McpToolCallResult } from "./protocol.ts";
+import type { ToolContext } from "./toolRuntime.ts";
+
+const PROJECT_ID = ProjectId.makeUnsafe("project-mem");
+const CALLER_THREAD_ID = "thread-mem";
+const CALLER_TURN_ID = "turn-mem";
+
+function makeThreadShell(projectId = PROJECT_ID): OrchestrationThreadShell {
+  return {
+    id: ThreadId.makeUnsafe(CALLER_THREAD_ID),
+    projectId,
+    title: "Memory thread",
+    modelSelection: { provider: "codex" as ProviderKind, model: "gpt-5.6-sol" },
+    runtimeMode: "approval-required",
+    interactionMode: "default",
+    envMode: "local",
+    branch: null,
+    worktreePath: null,
+    associatedWorktreePath: null,
+    associatedWorktreeBranch: null,
+    associatedWorktreeRef: null,
+    createBranchFlowCompleted: false,
+    isPinned: false,
+    parentThreadId: null,
+    subagentAgentId: null,
+    subagentNickname: null,
+    subagentRole: null,
+    forkSourceThreadId: null,
+    sidechatSourceThreadId: null,
+    lastKnownPr: null,
+    latestTurn: {
+      turnId: TurnId.makeUnsafe(CALLER_TURN_ID),
+      state: "running",
+      requestedAt: new Date().toISOString(),
+      startedAt: new Date().toISOString(),
+      completedAt: null,
+      assistantMessageId: null,
+    },
+    latestUserMessageAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    archivedAt: null,
+    handoff: null,
+    session: null,
+  };
+}
+
+function makeMockMindService(overrides?: Partial<MindServiceShape>): MindServiceShape {
+  const memory = (memoryId: string, projectId: string, text: string): MindMemory =>
+    ({
+      memoryId: MindMemoryId.makeUnsafe(memoryId),
+      projectId,
+      text,
+      weight: 1,
+      accessCount: 0,
+      pinned: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }) as MindMemory;
+
+  return {
+    remember: ({ text, projectId }) =>
+      Effect.succeed({
+        memory: memory(`memory:${projectId}:${text}`, projectId, text),
+        status: "created",
+      } as MindRememberResult),
+    recall: ({ projectId, query }) =>
+      Effect.succeed({
+        items: [
+          {
+            memory: memory(
+              `memory:${projectId}:sample`,
+              projectId,
+              query ? `Result for ${query}` : "Sample memory",
+            ),
+            rank: 1,
+            decayedWeight: 1,
+          } as MindMemoryMatch,
+        ],
+        digest: query ? `Digest for ${query}` : "Sample digest",
+      } as MindRecallResult),
+    confirm: ({ memoryId, projectId }) =>
+      Effect.succeed({
+        memory: memory(memoryId, projectId, "Confirmed memory"),
+        alreadyConfirmedInTurn: false,
+      } as MindConfirmResult),
+    forget: () => Effect.succeed({ deleted: true }),
+    prune: ({ projectId }) =>
+      Effect.succeed({
+        deletedIds: [MindMemoryId.makeUnsafe(`memory:${projectId}:pruned`)],
+      } as MindPruneResult),
+    ...overrides,
+  };
+}
+
+function makeContext(): ToolContext {
+  return {
+    principal: {
+      kind: "provider-session",
+      sessionKey: "session-mem",
+      threadId: CALLER_THREAD_ID,
+      provider: "codex" as ProviderKind,
+      turnId: CALLER_TURN_ID,
+    },
+    callerThreadId: CALLER_THREAD_ID,
+    callerSessionKey: "session-mem",
+    callerProvider: "codex" as ProviderKind,
+    callerCapabilities: new Set(["memory:use" as const]),
+    callerTurnId: CALLER_TURN_ID,
+    assertCallerTurnActive: () => Effect.void,
+    jsonRpcRequestId: 1,
+  };
+}
+
+function requireThreadShell(threadId: string) {
+  if (threadId !== CALLER_THREAD_ID) {
+    return Effect.fail(new Error(`Thread "${threadId}" was not found.`));
+  }
+  return Effect.succeed(makeThreadShell());
+}
+
+function firstText(result: McpToolCallResult) {
+  const item = result.content[0];
+  return item?.type === "text" ? item.text : "";
+}
+
+function makeTools(overrides?: Partial<MindServiceShape>) {
+  return makeAgentGatewayMemoryTools({
+    mindService: makeMockMindService(overrides),
+    requireThreadShell,
+  });
+}
+
+describe("makeAgentGatewayMemoryTools", () => {
+  it("exposes the five memory tools with the memory:use capability", () => {
+    const tools = makeTools();
+
+    assert.equal(Object.keys(tools).length, 5);
+    for (const name of [
+      "synara_remember",
+      "synara_recall_memories",
+      "synara_confirm_memory",
+      "synara_forget_memory",
+      "synara_prune_memories",
+    ]) {
+      assert.property(tools, name);
+      assert.equal(tools[name]!.requiredCapability, "memory:use");
+      assert.equal(tools[name]!.definition.name, name);
+    }
+  });
+
+  it("does not expose memory:use to external MCP capabilities", () => {
+    const externalCapabilities = new Set(ExternalMcpCapability.literals);
+    assert.isFalse(externalCapabilities.has("memory:use" as never));
+  });
+
+  it("grants memory:use only to provider sessions", () => {
+    const registry = makeAgentGatewaySessionRegistry({ randomId: () => "mem" });
+    const session = registry.issue(ThreadId.makeUnsafe(CALLER_THREAD_ID), "codex");
+    assert.isTrue(session.capabilities.has("memory:use"));
+
+    // No other session type in the registry should receive the capability.
+    const otherSession = registry.issue(ThreadId.makeUnsafe("thread-other"), "claudeAgent");
+    assert.isTrue(otherSession.capabilities.has("memory:use"));
+    assert.equal(otherSession.capabilities.size, session.capabilities.size);
+  });
+
+  it.effect("remembers a fact and returns memoryId plus status", () =>
+    Effect.gen(function* () {
+      const tools = makeTools();
+      const result = yield* tools.synara_remember!.handler({ text: "Fact A" }, makeContext());
+      const text = firstText(result);
+      const parsed = JSON.parse(text);
+      assert.equal(parsed.memoryId, `memory:${PROJECT_ID}:Fact A`);
+      assert.equal(parsed.status, "created");
+    }),
+  );
+
+  it.effect("rejects text over the memory length limit", () =>
+    Effect.gen(function* () {
+      const tools = makeTools();
+      const longText = "x".repeat(MIND_MEMORY_TEXT_MAX_CHARS + 1);
+      const result = yield* tools.synara_remember!.handler({ text: longText }, makeContext());
+      assert.isTrue(result.isError);
+      const text = firstText(result);
+      const parsed = JSON.parse(text);
+      assert.equal(parsed.error.code, "invalid_input");
+      assert.include(parsed.error.message, "at most");
+    }),
+  );
+
+  it.effect("recalls memories with an optional query", () =>
+    Effect.gen(function* () {
+      const tools = makeTools();
+      const withQuery = yield* tools.synara_recall_memories!.handler(
+        { query: "search" },
+        makeContext(),
+      );
+      const parsed = JSON.parse(firstText(withQuery));
+      assert.isArray(parsed.items);
+      assert.equal(parsed.items.length, 1);
+      assert.equal(parsed.items[0].memory.text, "Result for search");
+      assert.equal(parsed.digest, "Digest for search");
+
+      const withoutQuery = yield* tools.synara_recall_memories!.handler({}, makeContext());
+      const parsedNoQuery = JSON.parse(firstText(withoutQuery));
+      assert.equal(parsedNoQuery.items[0].memory.text, "Sample memory");
+      assert.equal(parsedNoQuery.digest, "Sample digest");
+    }),
+  );
+
+  it.effect("confirms a memory by id", () =>
+    Effect.gen(function* () {
+      const tools = makeTools();
+      const result = yield* tools.synara_confirm_memory!.handler(
+        { memory_id: "mem-123" },
+        makeContext(),
+      );
+      const parsed = JSON.parse(firstText(result));
+      assert.equal(parsed.memory.memoryId, "mem-123");
+    }),
+  );
+
+  it.effect("forgets a memory by id", () =>
+    Effect.gen(function* () {
+      const tools = makeTools();
+      const result = yield* tools.synara_forget_memory!.handler(
+        { memory_id: "mem-123" },
+        makeContext(),
+      );
+      const parsed = JSON.parse(firstText(result));
+      assert.equal(parsed.deleted, true);
+    }),
+  );
+
+  it.effect("prunes memories and returns deleted ids", () =>
+    Effect.gen(function* () {
+      const tools = makeTools();
+      const result = yield* tools.synara_prune_memories!.handler({}, makeContext());
+      const parsed = JSON.parse(firstText(result));
+      assert.deepEqual(parsed.deletedIds, [`memory:${PROJECT_ID}:pruned`]);
+    }),
+  );
+
+  it.effect("surfaces mind service errors as gateway tool errors", () =>
+    Effect.gen(function* () {
+      const tools = makeTools({
+        remember: () =>
+          Effect.fail(
+            new MindError({ code: "mind.memory-cap-reached", message: "Project cap reached" }),
+          ),
+      });
+      const result = yield* tools.synara_remember!.handler({ text: "Fact" }, makeContext());
+      assert.isTrue(result.isError);
+      const parsed = JSON.parse(firstText(result));
+      assert.equal(parsed.error.code, "mind.memory-cap-reached");
+      assert.include(parsed.error.message, "Project cap reached");
+    }),
+  );
+
+  it.effect("reports an error when the caller thread cannot be resolved", () =>
+    Effect.gen(function* () {
+      const tools = makeAgentGatewayMemoryTools({
+        mindService: makeMockMindService(),
+        requireThreadShell: (threadId) =>
+          Effect.fail(new Error(`Thread "${threadId}" was not found.`)),
+      });
+      const result = yield* tools.synara_remember!.handler({ text: "Fact" }, makeContext());
+      assert.isTrue(result.isError);
+      const parsed = JSON.parse(firstText(result));
+      assert.equal(parsed.error.code, "mind_error");
+      assert.include(parsed.error.message, "not found");
+    }),
+  );
+});

--- a/apps/server/src/agentGateway/memoryTools.test.ts
+++ b/apps/server/src/agentGateway/memoryTools.test.ts
@@ -8,8 +8,10 @@ import {
   ThreadId,
   TurnId,
   type MindConfirmResult,
+  type MindListResult,
   type MindMemory,
   type MindMemoryMatch,
+  type MindPinResult,
   type MindPruneResult,
   type MindRecallResult,
   type MindRememberResult,
@@ -110,6 +112,11 @@ function makeMockMindService(overrides?: Partial<MindServiceShape>): MindService
         alreadyConfirmedInTurn: false,
       } as MindConfirmResult),
     forget: () => Effect.succeed({ deleted: true }),
+    pin: ({ memoryId, projectId }) =>
+      Effect.succeed({
+        memory: memory(memoryId, projectId, "Pinned memory"),
+      } as MindPinResult),
+    list: () => Effect.succeed({ memories: [] } as MindListResult),
     prune: ({ projectId }) =>
       Effect.succeed({
         deletedIds: [MindMemoryId.makeUnsafe(`memory:${projectId}:pruned`)],

--- a/apps/server/src/agentGateway/memoryTools.ts
+++ b/apps/server/src/agentGateway/memoryTools.ts
@@ -18,7 +18,7 @@ import {
 import type { OrchestrationThreadShell, ProjectId } from "@synara/contracts";
 import { Effect } from "effect";
 
-import { MindService } from "../mind/Services/MindService.ts";
+import { MindService, type MindServiceShape } from "../mind/Services/MindService.ts";
 import { mcpToolResultJson } from "./protocol.ts";
 import { errorText, readStringArg, ToolInputError } from "./toolInput.ts";
 import {
@@ -29,14 +29,7 @@ import {
 } from "./toolRuntime.ts";
 
 export { MindService, MIND_MEMORY_TEXT_MAX_CHARS };
-
-export interface MindServiceShape {
-  readonly remember: (input: MindRememberInput) => Effect.Effect<MindRememberResult, MindError>;
-  readonly recall: (input: MindRecallInput) => Effect.Effect<MindRecallResult, MindError>;
-  readonly confirm: (input: MindConfirmInput) => Effect.Effect<MindConfirmResult, MindError>;
-  readonly forget: (input: MindForgetInput) => Effect.Effect<MindForgetResult, MindError>;
-  readonly prune: (input: MindPruneInput) => Effect.Effect<MindPruneResult, MindError>;
-}
+export type { MindServiceShape };
 
 export interface AgentGatewayMemoryToolDependencies {
   readonly mindService: MindServiceShape;
@@ -50,11 +43,11 @@ function toGatewayToolError(error: unknown): GatewayToolError {
   if (error instanceof ToolInputError) {
     return new GatewayToolError("invalid_input", error.message);
   }
-  if (typeof error === "object" && error !== null && "code" in error && "message" in error) {
-    return new GatewayToolError(String(error.code), String(error.message));
-  }
   if (error instanceof MindError) {
     return new GatewayToolError(error.code, error.message);
+  }
+  if (typeof error === "object" && error !== null && "code" in error && "message" in error) {
+    return new GatewayToolError(String(error.code), String(error.message));
   }
   return new GatewayToolError("mind_error", errorText(error));
 }

--- a/apps/server/src/agentGateway/memoryTools.ts
+++ b/apps/server/src/agentGateway/memoryTools.ts
@@ -1,0 +1,306 @@
+import {
+  MIND_MEMORY_TEXT_MAX_CHARS,
+  MindError,
+  MindMemoryId,
+  ThreadId,
+  TurnId,
+  type MindConfirmInput,
+  type MindConfirmResult,
+  type MindForgetInput,
+  type MindForgetResult,
+  type MindPruneInput,
+  type MindPruneResult,
+  type MindRecallInput,
+  type MindRecallResult,
+  type MindRememberInput,
+  type MindRememberResult,
+} from "@synara/contracts";
+import type { OrchestrationThreadShell, ProjectId } from "@synara/contracts";
+import { Effect } from "effect";
+
+import { MindService } from "../mind/Services/MindService.ts";
+import { mcpToolResultJson } from "./protocol.ts";
+import { errorText, readStringArg, ToolInputError } from "./toolInput.ts";
+import {
+  GatewayToolError,
+  gatewayToolErrorResult,
+  type ToolContext,
+  type ToolEntry,
+} from "./toolRuntime.ts";
+
+export { MindService, MIND_MEMORY_TEXT_MAX_CHARS };
+
+export interface MindServiceShape {
+  readonly remember: (input: MindRememberInput) => Effect.Effect<MindRememberResult, MindError>;
+  readonly recall: (input: MindRecallInput) => Effect.Effect<MindRecallResult, MindError>;
+  readonly confirm: (input: MindConfirmInput) => Effect.Effect<MindConfirmResult, MindError>;
+  readonly forget: (input: MindForgetInput) => Effect.Effect<MindForgetResult, MindError>;
+  readonly prune: (input: MindPruneInput) => Effect.Effect<MindPruneResult, MindError>;
+}
+
+export interface AgentGatewayMemoryToolDependencies {
+  readonly mindService: MindServiceShape;
+  readonly requireThreadShell: (
+    threadId: string,
+  ) => Effect.Effect<OrchestrationThreadShell, unknown>;
+}
+
+function toGatewayToolError(error: unknown): GatewayToolError {
+  if (error instanceof GatewayToolError) return error;
+  if (error instanceof ToolInputError) {
+    return new GatewayToolError("invalid_input", error.message);
+  }
+  if (typeof error === "object" && error !== null && "code" in error && "message" in error) {
+    return new GatewayToolError(String(error.code), String(error.message));
+  }
+  if (error instanceof MindError) {
+    return new GatewayToolError(error.code, error.message);
+  }
+  return new GatewayToolError("mind_error", errorText(error));
+}
+
+function decodeStringArg(
+  args: Record<string, unknown>,
+  name: string,
+  options?: { readonly required?: boolean },
+): Effect.Effect<string | undefined, ToolInputError> {
+  return Effect.try({
+    try: () => readStringArg(args, name, options),
+    catch: (error) =>
+      error instanceof ToolInputError
+        ? error
+        : new ToolInputError(
+            typeof error === "object" && error !== null && "message" in error
+              ? String((error as Error).message)
+              : errorText(error),
+          ),
+  });
+}
+
+function resolveProjectId(
+  context: ToolContext,
+  requireThreadShell: AgentGatewayMemoryToolDependencies["requireThreadShell"],
+): Effect.Effect<ProjectId, unknown> {
+  return requireThreadShell(context.callerThreadId).pipe(Effect.map((thread) => thread.projectId));
+}
+
+function makeRememberInput(
+  projectId: ProjectId,
+  context: ToolContext,
+  text: string,
+): MindRememberInput {
+  return {
+    projectId,
+    threadId: ThreadId.makeUnsafe(context.callerThreadId),
+    turnId: context.callerTurnId ? TurnId.makeUnsafe(context.callerTurnId) : undefined,
+    text,
+  };
+}
+
+function makeConfirmInput(
+  projectId: ProjectId,
+  context: ToolContext,
+  memoryId: string,
+): MindConfirmInput {
+  return {
+    projectId,
+    memoryId: MindMemoryId.makeUnsafe(memoryId),
+    turnId: context.callerTurnId ? TurnId.makeUnsafe(context.callerTurnId) : undefined,
+  };
+}
+
+function makeForgetInput(
+  projectId: ProjectId,
+  context: ToolContext,
+  memoryId: string,
+): MindForgetInput {
+  return {
+    projectId,
+    memoryId: MindMemoryId.makeUnsafe(memoryId),
+    turnId: context.callerTurnId ? TurnId.makeUnsafe(context.callerTurnId) : undefined,
+  };
+}
+
+function makeRecallInput(projectId: ProjectId, query: string | undefined): MindRecallInput {
+  return {
+    projectId,
+    ...(query !== undefined ? { query } : {}),
+  };
+}
+
+function makePruneInput(projectId: ProjectId): MindPruneInput {
+  return { projectId };
+}
+
+function rememberPayload(result: MindRememberResult) {
+  return { memoryId: result.memory.memoryId, status: result.status };
+}
+
+function confirmPayload(result: MindConfirmResult) {
+  return { memory: result.memory };
+}
+
+function forgetPayload(result: MindForgetResult) {
+  return { deleted: result.deleted };
+}
+
+function prunePayload(result: MindPruneResult) {
+  return { deletedIds: result.deletedIds };
+}
+
+export function makeAgentGatewayMemoryTools(
+  dependencies: AgentGatewayMemoryToolDependencies,
+): Record<string, ToolEntry> {
+  const { mindService, requireThreadShell } = dependencies;
+
+  const remember: ToolEntry = {
+    requiredCapability: "memory:use",
+    requiresActiveTurn: true,
+    definition: {
+      name: "synara_remember",
+      description:
+        "Remember a durable, project-scoped fact. Repeating the same text in one project reinforces the existing memory.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          text: {
+            type: "string",
+            description: `The fact to remember. Max ${MIND_MEMORY_TEXT_MAX_CHARS} characters.`,
+          },
+        },
+        required: ["text"],
+        additionalProperties: false,
+      },
+    },
+    handler: (args, context) =>
+      Effect.gen(function* () {
+        const text = (yield* decodeStringArg(args, "text", { required: true }))!;
+        if (text.length > MIND_MEMORY_TEXT_MAX_CHARS) {
+          return yield* Effect.fail(
+            new ToolInputError(
+              `Argument "text" must be at most ${MIND_MEMORY_TEXT_MAX_CHARS} characters.`,
+            ),
+          );
+        }
+        const projectId = yield* resolveProjectId(context, requireThreadShell);
+        const input = makeRememberInput(projectId, context, text);
+        const result = yield* mindService.remember(input);
+        return mcpToolResultJson(rememberPayload(result));
+      }).pipe(
+        Effect.catch((error) => Effect.succeed(gatewayToolErrorResult(toGatewayToolError(error)))),
+      ),
+  };
+
+  const recallMemories: ToolEntry = {
+    requiredCapability: "memory:use",
+    requiresActiveTurn: false,
+    definition: {
+      name: "synara_recall_memories",
+      description:
+        "Recall up to 8 relevant project memories, optionally filtered by a query. Returns a concise digest.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Optional search query." },
+        },
+        additionalProperties: false,
+      },
+    },
+    handler: (args, context) =>
+      Effect.gen(function* () {
+        const query = yield* decodeStringArg(args, "query");
+        const projectId = yield* resolveProjectId(context, requireThreadShell);
+        const input = makeRecallInput(projectId, query);
+        const result = yield* mindService.recall(input);
+        return mcpToolResultJson(result);
+      }).pipe(
+        Effect.catch((error) => Effect.succeed(gatewayToolErrorResult(toGatewayToolError(error)))),
+      ),
+  };
+
+  const confirmMemory: ToolEntry = {
+    requiredCapability: "memory:use",
+    requiresActiveTurn: true,
+    definition: {
+      name: "synara_confirm_memory",
+      description:
+        "Confirm a memory is still accurate, raising its weight by up to 0.15 and resetting decay.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          memory_id: { type: "string" },
+        },
+        required: ["memory_id"],
+        additionalProperties: false,
+      },
+    },
+    handler: (args, context) =>
+      Effect.gen(function* () {
+        const memoryId = (yield* decodeStringArg(args, "memory_id", { required: true }))!;
+        const projectId = yield* resolveProjectId(context, requireThreadShell);
+        const input = makeConfirmInput(projectId, context, memoryId);
+        const result = yield* mindService.confirm(input);
+        return mcpToolResultJson(confirmPayload(result));
+      }).pipe(
+        Effect.catch((error) => Effect.succeed(gatewayToolErrorResult(toGatewayToolError(error)))),
+      ),
+  };
+
+  const forgetMemory: ToolEntry = {
+    requiredCapability: "memory:use",
+    requiresActiveTurn: true,
+    definition: {
+      name: "synara_forget_memory",
+      description: "Permanently remove a memory.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          memory_id: { type: "string" },
+        },
+        required: ["memory_id"],
+        additionalProperties: false,
+      },
+    },
+    handler: (args, context) =>
+      Effect.gen(function* () {
+        const memoryId = (yield* decodeStringArg(args, "memory_id", { required: true }))!;
+        const projectId = yield* resolveProjectId(context, requireThreadShell);
+        const input = makeForgetInput(projectId, context, memoryId);
+        const result = yield* mindService.forget(input);
+        return mcpToolResultJson(forgetPayload(result));
+      }).pipe(
+        Effect.catch((error) => Effect.succeed(gatewayToolErrorResult(toGatewayToolError(error)))),
+      ),
+  };
+
+  const pruneMemories: ToolEntry = {
+    requiredCapability: "memory:use",
+    requiresActiveTurn: true,
+    definition: {
+      name: "synara_prune_memories",
+      description:
+        "Remove stale, low-weight, unconfirmed memories from this project. Safe to call automatically.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+    handler: (_args, context) =>
+      Effect.gen(function* () {
+        const projectId = yield* resolveProjectId(context, requireThreadShell);
+        const result = yield* mindService.prune(makePruneInput(projectId));
+        return mcpToolResultJson(prunePayload(result));
+      }).pipe(
+        Effect.catch((error) => Effect.succeed(gatewayToolErrorResult(toGatewayToolError(error)))),
+      ),
+  };
+
+  return {
+    synara_remember: remember,
+    synara_recall_memories: recallMemories,
+    synara_confirm_memory: confirmMemory,
+    synara_forget_memory: forgetMemory,
+    synara_prune_memories: pruneMemories,
+  };
+}

--- a/apps/server/src/mind/Layers/MindService.test.ts
+++ b/apps/server/src/mind/Layers/MindService.test.ts
@@ -1,0 +1,354 @@
+import { MindMemory, MindMemoryId, ProjectId, TurnId } from "@synara/contracts";
+import { createHash } from "node:crypto";
+import { Effect, Option } from "effect";
+import { TestClock } from "effect/testing";
+import { assert, it } from "@effect/vitest";
+
+import { type MindRepositoryShape } from "../../persistence/Services/MindRepository.ts";
+import { makeMindService } from "./MindService.ts";
+
+const projectId = ProjectId.makeUnsafe("project-mind");
+const turnId = TurnId.makeUnsafe("turn-1");
+
+function normalizeText(text: string): string {
+  return text.trim().replace(/\s+/g, " ");
+}
+
+function memoryIdFor(projectId: string, text: string): MindMemoryId {
+  const normalized = normalizeText(text);
+  const hash = createHash("sha256").update(`memory:${projectId}:${normalized}`).digest("base64url");
+  return MindMemoryId.makeUnsafe(hash);
+}
+
+interface FakeMindRepositoryState {
+  readonly memories: Map<string, MindMemory>;
+  readonly journals: {
+    memoryId: MindMemoryId;
+    projectId: ProjectId;
+    turnId: string | null;
+    op: string;
+    weightDelta: number | undefined;
+    createdAt: string;
+  }[];
+}
+
+function makeFakeMindRepository(): MindRepositoryShape & {
+  readonly state: FakeMindRepositoryState;
+} {
+  const state: FakeMindRepositoryState = {
+    memories: new Map(),
+    journals: [],
+  };
+
+  const findByText: MindRepositoryShape["findByText"] = ({ projectId, text }) =>
+    Effect.sync(() => {
+      const normalized = normalizeText(text);
+      for (const memory of state.memories.values()) {
+        if (memory.projectId === projectId && memory.text === normalized) {
+          return Option.some(memory);
+        }
+      }
+      return Option.none();
+    });
+
+  const getById: MindRepositoryShape["getById"] = ({ projectId, memoryId }) =>
+    Effect.sync(() => {
+      const memory = state.memories.get(String(memoryId));
+      if (memory && memory.projectId === projectId) return Option.some(memory);
+      return Option.none();
+    });
+
+  const remember: MindRepositoryShape["remember"] = ({ projectId, text, now }) =>
+    Effect.sync(() => {
+      const normalized = normalizeText(text);
+      const memoryId = memoryIdFor(projectId, normalized);
+      const existing = state.memories.get(String(memoryId));
+      if (existing) {
+        const updated: MindMemory = {
+          ...existing,
+          weight: Math.min(1.0, existing.weight + 0.02),
+          accessCount: existing.accessCount + 1,
+          updatedAt: now,
+        };
+        state.memories.set(String(memoryId), updated);
+        return updated;
+      }
+      const created: MindMemory = {
+        memoryId,
+        projectId,
+        text: normalized,
+        weight: 1.0,
+        accessCount: 0,
+        pinned: false,
+        createdAt: now,
+        updatedAt: now,
+      };
+      state.memories.set(String(memoryId), created);
+      return created;
+    });
+
+  const confirm: MindRepositoryShape["confirm"] = ({ projectId, memoryId, now }) =>
+    Effect.sync(() => {
+      const existing = state.memories.get(String(memoryId));
+      if (!existing || existing.projectId !== projectId) {
+        throw new Error("Memory not found");
+      }
+      const weight = Math.min(1.0, existing.weight + Math.min(0.15, 1.0 - existing.weight));
+      const updated: MindMemory = { ...existing, weight, updatedAt: now };
+      state.memories.set(String(memoryId), updated);
+      return updated;
+    });
+
+  const forget: MindRepositoryShape["forget"] = ({ projectId, memoryId }) =>
+    Effect.sync(() => {
+      const existing = state.memories.get(String(memoryId));
+      if (existing && existing.projectId === projectId) {
+        state.memories.delete(String(memoryId));
+      }
+    });
+
+  const pin: MindRepositoryShape["pin"] = ({ projectId, memoryId, pinned, now }) =>
+    Effect.sync(() => {
+      const existing = state.memories.get(String(memoryId));
+      if (!existing || existing.projectId !== projectId) {
+        throw new Error("Memory not found");
+      }
+      const updated: MindMemory = { ...existing, pinned, updatedAt: now };
+      state.memories.set(String(memoryId), updated);
+      return updated;
+    });
+
+  const list: MindRepositoryShape["list"] = ({ projectId }) =>
+    Effect.sync(() =>
+      [...state.memories.values()]
+        .filter((m) => m.projectId === projectId)
+        .sort((a, b) => (a.updatedAt > b.updatedAt ? -1 : 1)),
+    );
+
+  const recall: MindRepositoryShape["recall"] = ({ projectId }) => list({ projectId });
+
+  const countByProject: MindRepositoryShape["countByProject"] = ({ projectId }) =>
+    Effect.sync(() => [...state.memories.values()].filter((m) => m.projectId === projectId).length);
+
+  const prune: MindRepositoryShape["prune"] = ({ projectId, now }) =>
+    Effect.sync(() => {
+      const cutoff = new Date(new Date(now).getTime() - 45 * 86400_000).toISOString();
+      const deletedIds: MindMemoryId[] = [];
+      for (const [id, memory] of state.memories) {
+        if (
+          memory.projectId === projectId &&
+          memory.weight < 0.1 &&
+          memory.accessCount < 2 &&
+          memory.updatedAt < cutoff &&
+          !memory.pinned
+        ) {
+          deletedIds.push(memory.memoryId);
+          state.memories.delete(id);
+        }
+      }
+      return deletedIds;
+    });
+
+  const recordJournal: MindRepositoryShape["recordJournal"] = (entry) =>
+    Effect.sync(() => {
+      state.journals.push({
+        memoryId: entry.memoryId,
+        projectId: entry.projectId,
+        turnId: entry.turnId,
+        op: entry.op,
+        weightDelta: entry.weightDelta,
+        createdAt: entry.createdAt,
+      });
+    });
+
+  return {
+    state,
+    findByText,
+    getById,
+    remember,
+    confirm,
+    forget,
+    pin,
+    list,
+    recall,
+    countByProject,
+    prune,
+    recordJournal,
+  };
+}
+
+const now = "2026-06-16T10:00:00.000Z";
+
+it.effect("rejects text that exceeds the max length", () =>
+  Effect.gen(function* () {
+    const repo = makeFakeMindRepository();
+    const service = makeMindService(repo, { nowOverride: now });
+    const text = "x".repeat(600);
+    const error = yield* service.remember({ projectId, text }).pipe(Effect.flip);
+    assert.strictEqual(error.code, "mind.text-too-long");
+  }),
+);
+
+it.effect("rejects text that contains a secret pattern", () =>
+  Effect.gen(function* () {
+    const repo = makeFakeMindRepository();
+    const service = makeMindService(repo, { nowOverride: now });
+    const error = yield* service
+      .remember({ projectId, text: "my api_key=supersecret12345678" })
+      .pipe(Effect.flip);
+    assert.strictEqual(error.code, "mind.secret-pattern");
+  }),
+);
+
+it.effect("reinforces an existing memory and is idempotent by turnId", () =>
+  Effect.gen(function* () {
+    const repo = makeFakeMindRepository();
+    const service = makeMindService(repo, { nowOverride: now });
+
+    const first = yield* service.remember({ projectId, text: "persistent fact", turnId });
+    assert.strictEqual(first.status, "created");
+    assert.strictEqual(first.memory.accessCount, 0);
+    assert.strictEqual(first.memory.weight, 1.0);
+
+    const sameTurn = yield* service.remember({ projectId, text: "persistent fact", turnId });
+    assert.strictEqual(sameTurn.status, "reinforced");
+    assert.strictEqual(sameTurn.memory.accessCount, 0);
+    assert.strictEqual(sameTurn.memory.weight, 1.0);
+
+    const nextTurn = yield* service.remember({
+      projectId,
+      text: "persistent fact",
+      turnId: TurnId.makeUnsafe("turn-2"),
+    });
+    assert.strictEqual(nextTurn.status, "reinforced");
+    assert.strictEqual(nextTurn.memory.accessCount, 1);
+  }),
+);
+
+it.effect("enforces the project memory cap for new memories", () =>
+  Effect.gen(function* () {
+    const repo = makeFakeMindRepository();
+    for (let i = 0; i < 500; i += 1) {
+      const id = MindMemoryId.makeUnsafe(`mem:${i}`);
+      repo.state.memories.set(String(id), {
+        memoryId: id,
+        projectId,
+        text: `filler ${i}`,
+        weight: 1.0,
+        accessCount: 0,
+        pinned: false,
+        createdAt: now,
+        updatedAt: now,
+      } as MindMemory);
+    }
+    const service = makeMindService(repo, { nowOverride: now });
+
+    const error = yield* service.remember({ projectId, text: "one too many" }).pipe(Effect.flip);
+    assert.strictEqual(error.code, "mind.memory-cap-reached");
+  }),
+);
+
+it.effect("recall is a read-only operation", () =>
+  Effect.gen(function* () {
+    const repo = makeFakeMindRepository();
+    const service = makeMindService(repo, { nowOverride: now });
+
+    const remembered = yield* service.remember({ projectId, text: "recall me" });
+
+    const recalled = yield* service.recall({ projectId }).pipe(Effect.provide(TestClock.layer()));
+
+    assert.strictEqual(recalled.items.length, 1);
+    const recalledItem = recalled.items[0]!;
+    assert.strictEqual(recalledItem.memory.memoryId, remembered.memory.memoryId);
+
+    const reloaded = yield* repo.getById({
+      projectId,
+      memoryId: remembered.memory.memoryId,
+    });
+    const reloadedValue = Option.getOrThrow(reloaded);
+    assert.strictEqual(reloadedValue.accessCount, 0);
+    assert.strictEqual(reloadedValue.weight, 1.0);
+  }),
+);
+
+it.effect("confirm is idempotent by turnId", () =>
+  Effect.gen(function* () {
+    const repo = makeFakeMindRepository();
+    const service = makeMindService(repo, { nowOverride: now });
+
+    const created = yield* service.remember({
+      projectId,
+      text: "confirm me",
+      turnId,
+    });
+
+    // Lower weight manually so confirm has a visible effect.
+    repo.state.memories.set(String(created.memory.memoryId), {
+      ...created.memory,
+      weight: 0.5,
+    } as MindMemory);
+
+    const first = yield* service.confirm({
+      projectId,
+      memoryId: created.memory.memoryId,
+      turnId,
+    });
+    assert.strictEqual(first.alreadyConfirmedInTurn, false);
+    assert.strictEqual(first.memory.weight, 0.65);
+
+    const sameTurn = yield* service.confirm({
+      projectId,
+      memoryId: created.memory.memoryId,
+      turnId,
+    });
+    assert.strictEqual(sameTurn.alreadyConfirmedInTurn, true);
+    assert.strictEqual(sameTurn.memory.weight, 0.65);
+
+    const nextTurn = yield* service.confirm({
+      projectId,
+      memoryId: created.memory.memoryId,
+      turnId: TurnId.makeUnsafe("turn-2"),
+    });
+    assert.strictEqual(nextTurn.alreadyConfirmedInTurn, false);
+    assert.strictEqual(nextTurn.memory.weight, 0.8);
+  }),
+);
+
+it.effect("prune removes stale, low-weight memories but never pinned ones", () =>
+  Effect.gen(function* () {
+    const repo = makeFakeMindRepository();
+    const service = makeMindService(repo, { nowOverride: now });
+
+    const staleDate = new Date(new Date(now).getTime() - 60 * 86400_000).toISOString();
+
+    const pinnedId = MindMemoryId.makeUnsafe("pinned");
+    repo.state.memories.set(String(pinnedId), {
+      memoryId: pinnedId,
+      projectId,
+      text: "pinned stale",
+      weight: 0.05,
+      accessCount: 0,
+      pinned: true,
+      createdAt: staleDate,
+      updatedAt: staleDate,
+    } as MindMemory);
+
+    const prunableId = MindMemoryId.makeUnsafe("prunable");
+    repo.state.memories.set(String(prunableId), {
+      memoryId: prunableId,
+      projectId,
+      text: "prunable stale",
+      weight: 0.05,
+      accessCount: 0,
+      pinned: false,
+      createdAt: staleDate,
+      updatedAt: staleDate,
+    } as MindMemory);
+
+    const result = yield* service.prune({ projectId });
+
+    assert.deepStrictEqual(result.deletedIds, [prunableId]);
+    assert.isTrue(repo.state.memories.has(String(pinnedId)));
+    assert.isFalse(repo.state.memories.has(String(prunableId)));
+  }),
+);

--- a/apps/server/src/mind/Layers/MindService.ts
+++ b/apps/server/src/mind/Layers/MindService.ts
@@ -1,0 +1,392 @@
+import {
+  MIND_MEMORY_PROJECT_CAP,
+  MIND_MEMORY_TEXT_MAX_CHARS,
+  MIND_RECALL_MAX_ITEMS,
+  MindConfirmInput,
+  MindConfirmResult,
+  MindError,
+  MindForgetInput,
+  MindForgetResult,
+  MindJournalOp,
+  MindListInput,
+  MindListResult,
+  MindPinInput,
+  MindPinResult,
+  MindPruneInput,
+  MindPruneResult,
+  MindRecallInput,
+  MindRecallResult,
+  MindRememberInput,
+  MindRememberResult,
+} from "@synara/contracts";
+import { Clock, Effect, Layer, Option, Schema } from "effect";
+
+import {
+  type MindRepositoryShape,
+  MindRepository,
+} from "../../persistence/Services/MindRepository.ts";
+import { buildMindRecallDigest, rankMindMemories } from "../scoring.ts";
+import { isMindSecret } from "../secretPatterns.ts";
+import { MindService, type MindServiceShape } from "../Services/MindService.ts";
+
+function isoNow(): Effect.Effect<string> {
+  return Effect.map(Clock.currentTimeMillis, (ms) => new Date(ms).toISOString());
+}
+
+function validateMindText(text: string): Effect.Effect<string, MindError> {
+  if (text.length > MIND_MEMORY_TEXT_MAX_CHARS) {
+    return Effect.fail(
+      new MindError({
+        message: `Memory text exceeds the maximum of ${MIND_MEMORY_TEXT_MAX_CHARS} characters.`,
+        code: "mind.text-too-long",
+      }),
+    );
+  }
+  if (isMindSecret(text)) {
+    return Effect.fail(
+      new MindError({
+        message: "Memory text matches a secret/credential pattern.",
+        code: "mind.secret-pattern",
+      }),
+    );
+  }
+  return Effect.succeed(text);
+}
+
+function toMindError(operation: string) {
+  return (cause: unknown): MindError =>
+    new MindError({
+      message: `Mind ${operation} failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+      code: "mind.persistence",
+    });
+}
+
+export function makeMindService(
+  repo: MindRepositoryShape,
+  options: { readonly nowOverride?: string } = {},
+): MindServiceShape {
+  const reinforcedTurns = new Map<string, string | undefined>();
+  const confirmedTurns = new Map<string, string | undefined>();
+
+  function nowEffect(): Effect.Effect<string> {
+    if (options.nowOverride !== undefined) {
+      return Effect.succeed(options.nowOverride);
+    }
+    return isoNow();
+  }
+
+  const remember: MindServiceShape["remember"] = (input) =>
+    Effect.gen(function* () {
+      const { projectId, text, turnId } = yield* Schema.decodeUnknownEffect(MindRememberInput)(
+        input,
+      ).pipe(
+        Effect.mapError(
+          () =>
+            new MindError({
+              message: "Invalid remember input.",
+              code: "mind.invalid-input",
+            }),
+        ),
+      );
+
+      const validatedText = yield* validateMindText(text);
+
+      const existingOption = yield* repo
+        .findByText({ projectId, text: validatedText })
+        .pipe(Effect.mapError(toMindError("findByText")));
+
+      if (Option.isSome(existingOption)) {
+        const existing = existingOption.value;
+        if (turnId && reinforcedTurns.get(String(existing.memoryId)) === turnId) {
+          return { memory: existing, status: "reinforced" } as MindRememberResult;
+        }
+
+        const now = yield* nowEffect();
+        const updated = yield* repo
+          .remember({ projectId, text: validatedText, turnId, now })
+          .pipe(Effect.mapError(toMindError("remember")));
+
+        if (turnId) {
+          reinforcedTurns.set(String(updated.memoryId), turnId);
+        }
+
+        yield* repo
+          .recordJournal({
+            memoryId: updated.memoryId,
+            projectId,
+            turnId: turnId ?? null,
+            op: "reinforce" as MindJournalOp,
+            weightDelta: 0.02,
+            createdAt: now,
+          })
+          .pipe(Effect.mapError(toMindError("recordJournal")));
+
+        return { memory: updated, status: "reinforced" } as MindRememberResult;
+      }
+
+      const count = yield* repo
+        .countByProject({ projectId })
+        .pipe(Effect.mapError(toMindError("countByProject")));
+      if (count >= MIND_MEMORY_PROJECT_CAP) {
+        return yield* Effect.fail(
+          new MindError({
+            message: `Project has reached the memory cap of ${MIND_MEMORY_PROJECT_CAP}.`,
+            code: "mind.memory-cap-reached",
+          }),
+        );
+      }
+
+      const now = yield* nowEffect();
+      const created = yield* repo
+        .remember({ projectId, text: validatedText, turnId, now })
+        .pipe(Effect.mapError(toMindError("remember")));
+
+      if (turnId) {
+        reinforcedTurns.set(String(created.memoryId), turnId);
+      }
+
+      yield* repo
+        .recordJournal({
+          memoryId: created.memoryId,
+          projectId,
+          turnId: turnId ?? null,
+          op: "remember" as MindJournalOp,
+          createdAt: now,
+        })
+        .pipe(Effect.mapError(toMindError("recordJournal")));
+
+      return { memory: created, status: "created" } as MindRememberResult;
+    });
+
+  const recall: MindServiceShape["recall"] = (input) =>
+    Effect.gen(function* () {
+      const { projectId, query } = yield* Schema.decodeUnknownEffect(MindRecallInput)(input).pipe(
+        Effect.mapError(
+          () =>
+            new MindError({
+              message: "Invalid recall input.",
+              code: "mind.invalid-input",
+            }),
+        ),
+      );
+
+      const memories = yield* repo
+        .recall({ projectId, query })
+        .pipe(Effect.mapError(toMindError("recall")));
+
+      const nowMs = yield* Clock.currentTimeMillis;
+      const ranked = rankMindMemories(memories, query, new Date(nowMs));
+      const top = ranked.slice(0, MIND_RECALL_MAX_ITEMS);
+      const digest = buildMindRecallDigest(top);
+
+      return { items: top, digest } as MindRecallResult;
+    });
+
+  const confirm: MindServiceShape["confirm"] = (input) =>
+    Effect.gen(function* () {
+      const { projectId, memoryId, turnId } = yield* Schema.decodeUnknownEffect(MindConfirmInput)(
+        input,
+      ).pipe(
+        Effect.mapError(
+          () =>
+            new MindError({
+              message: "Invalid confirm input.",
+              code: "mind.invalid-input",
+            }),
+        ),
+      );
+
+      const existingOption = yield* repo
+        .getById({ projectId, memoryId })
+        .pipe(Effect.mapError(toMindError("getById")));
+      if (Option.isNone(existingOption)) {
+        return yield* Effect.fail(
+          new MindError({
+            message: "Memory not found.",
+            code: "mind.memory-not-found",
+          }),
+        );
+      }
+      const existing = existingOption.value;
+
+      if (turnId && confirmedTurns.get(String(memoryId)) === turnId) {
+        return { memory: existing, alreadyConfirmedInTurn: true } as MindConfirmResult;
+      }
+
+      const now = yield* nowEffect();
+      const confirmed = yield* repo
+        .confirm({ projectId, memoryId, turnId, now })
+        .pipe(Effect.mapError(toMindError("confirm")));
+
+      if (turnId) {
+        confirmedTurns.set(String(memoryId), turnId);
+      }
+
+      const delta = confirmed.weight - existing.weight;
+      yield* repo
+        .recordJournal({
+          memoryId,
+          projectId,
+          turnId: turnId ?? null,
+          op: "confirm" as MindJournalOp,
+          weightDelta: delta,
+          createdAt: now,
+        })
+        .pipe(Effect.mapError(toMindError("recordJournal")));
+
+      return { memory: confirmed, alreadyConfirmedInTurn: false } as MindConfirmResult;
+    });
+
+  const forget: MindServiceShape["forget"] = (input) =>
+    Effect.gen(function* () {
+      const { projectId, memoryId, turnId } = yield* Schema.decodeUnknownEffect(MindForgetInput)(
+        input,
+      ).pipe(
+        Effect.mapError(
+          () =>
+            new MindError({
+              message: "Invalid forget input.",
+              code: "mind.invalid-input",
+            }),
+        ),
+      );
+
+      const existingOption = yield* repo
+        .getById({ projectId, memoryId })
+        .pipe(Effect.mapError(toMindError("getById")));
+
+      if (Option.isNone(existingOption)) {
+        return { deleted: false } as MindForgetResult;
+      }
+
+      yield* repo
+        .forget({ projectId, memoryId, turnId })
+        .pipe(Effect.mapError(toMindError("forget")));
+
+      const now = yield* nowEffect();
+      yield* repo
+        .recordJournal({
+          memoryId,
+          projectId,
+          turnId: turnId ?? null,
+          op: "forget" as MindJournalOp,
+          createdAt: now,
+        })
+        .pipe(Effect.mapError(toMindError("recordJournal")));
+
+      return { deleted: true } as MindForgetResult;
+    });
+
+  const pin: MindServiceShape["pin"] = (input) =>
+    Effect.gen(function* () {
+      const { projectId, memoryId, pinned } = yield* Schema.decodeUnknownEffect(MindPinInput)(
+        input,
+      ).pipe(
+        Effect.mapError(
+          () =>
+            new MindError({
+              message: "Invalid pin input.",
+              code: "mind.invalid-input",
+            }),
+        ),
+      );
+
+      const existingOption = yield* repo
+        .getById({ projectId, memoryId })
+        .pipe(Effect.mapError(toMindError("getById")));
+      if (Option.isNone(existingOption)) {
+        return yield* Effect.fail(
+          new MindError({
+            message: "Memory not found.",
+            code: "mind.memory-not-found",
+          }),
+        );
+      }
+
+      const now = yield* nowEffect();
+      const updated = yield* repo
+        .pin({ projectId, memoryId, pinned, now })
+        .pipe(Effect.mapError(toMindError("pin")));
+
+      yield* repo
+        .recordJournal({
+          memoryId,
+          projectId,
+          turnId: null,
+          op: (pinned ? "pin" : "unpin") as MindJournalOp,
+          createdAt: now,
+        })
+        .pipe(Effect.mapError(toMindError("recordJournal")));
+
+      return { memory: updated } as MindPinResult;
+    });
+
+  const list: MindServiceShape["list"] = (input) =>
+    Effect.gen(function* () {
+      const { projectId, query } = yield* Schema.decodeUnknownEffect(MindListInput)(input).pipe(
+        Effect.mapError(
+          () =>
+            new MindError({
+              message: "Invalid list input.",
+              code: "mind.invalid-input",
+            }),
+        ),
+      );
+
+      const memories = yield* repo
+        .list({ projectId, query })
+        .pipe(Effect.mapError(toMindError("list")));
+
+      return { memories } as MindListResult;
+    });
+
+  const prune: MindServiceShape["prune"] = (input) =>
+    Effect.gen(function* () {
+      const { projectId } = yield* Schema.decodeUnknownEffect(MindPruneInput)(input).pipe(
+        Effect.mapError(
+          () =>
+            new MindError({
+              message: "Invalid prune input.",
+              code: "mind.invalid-input",
+            }),
+        ),
+      );
+
+      const now = yield* nowEffect();
+      const deletedIds = yield* repo
+        .prune({ projectId, now })
+        .pipe(Effect.mapError(toMindError("prune")));
+
+      for (const memoryId of deletedIds) {
+        yield* repo
+          .recordJournal({
+            memoryId,
+            projectId,
+            turnId: null,
+            op: "prune" as MindJournalOp,
+            createdAt: now,
+          })
+          .pipe(Effect.mapError(toMindError("recordJournal")));
+      }
+
+      return { deletedIds } as MindPruneResult;
+    });
+
+  return {
+    remember,
+    recall,
+    confirm,
+    forget,
+    pin,
+    list,
+    prune,
+  };
+}
+
+export const MindServiceLive = Layer.effect(
+  MindService,
+  Effect.gen(function* () {
+    const repo = yield* MindRepository;
+    return makeMindService(repo);
+  }),
+);

--- a/apps/server/src/mind/Services/MindService.ts
+++ b/apps/server/src/mind/Services/MindService.ts
@@ -1,0 +1,33 @@
+import {
+  type MindConfirmInput,
+  type MindConfirmResult,
+  MindError,
+  type MindForgetInput,
+  type MindForgetResult,
+  type MindListInput,
+  type MindListResult,
+  type MindPinInput,
+  type MindPinResult,
+  type MindPruneInput,
+  type MindPruneResult,
+  type MindRecallInput,
+  type MindRecallResult,
+  type MindRememberInput,
+  type MindRememberResult,
+} from "@synara/contracts";
+import { ServiceMap } from "effect";
+import type { Effect } from "effect";
+
+export interface MindServiceShape {
+  readonly remember: (input: MindRememberInput) => Effect.Effect<MindRememberResult, MindError>;
+  readonly recall: (input: MindRecallInput) => Effect.Effect<MindRecallResult, MindError>;
+  readonly confirm: (input: MindConfirmInput) => Effect.Effect<MindConfirmResult, MindError>;
+  readonly forget: (input: MindForgetInput) => Effect.Effect<MindForgetResult, MindError>;
+  readonly pin: (input: MindPinInput) => Effect.Effect<MindPinResult, MindError>;
+  readonly list: (input: MindListInput) => Effect.Effect<MindListResult, MindError>;
+  readonly prune: (input: MindPruneInput) => Effect.Effect<MindPruneResult, MindError>;
+}
+
+export class MindService extends ServiceMap.Service<MindService, MindServiceShape>()(
+  "synara/mind/Services/MindService",
+) {}

--- a/apps/server/src/mind/scoring.test.ts
+++ b/apps/server/src/mind/scoring.test.ts
@@ -1,0 +1,139 @@
+import { type MindMemory } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildMindRecallDigest,
+  computeMemoryDecay,
+  MIND_DECAY_LAMBDA,
+  rankMindMemories,
+} from "./scoring.ts";
+
+const MILLIS_PER_DAY = 1000 * 60 * 60 * 24;
+
+function makeMemory(overrides: Partial<MindMemory> = {}): MindMemory {
+  const base: MindMemory = {
+    memoryId: "memory:1:abc" as unknown as MindMemory["memoryId"],
+    projectId: "project:1" as unknown as MindMemory["projectId"],
+    text: "default",
+    weight: 1.0,
+    accessCount: 0,
+    pinned: false,
+    createdAt: "2026-06-16T10:00:00.000Z",
+    updatedAt: "2026-06-16T10:00:00.000Z",
+  } as MindMemory;
+  return { ...base, ...overrides } as MindMemory;
+}
+
+describe("computeMemoryDecay", () => {
+  it("returns the base weight for pinned memories", () => {
+    const now = new Date("2026-08-01T00:00:00.000Z");
+    const memory = makeMemory({
+      text: "pinned fact",
+      weight: 0.5,
+      pinned: true,
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    });
+
+    expect(computeMemoryDecay(memory, now)).toBe(0.5);
+  });
+
+  it("decays ~95% after 45 days", () => {
+    const updatedAt = new Date("2026-06-01T00:00:00.000Z");
+    const now = new Date(updatedAt.getTime() + 45 * MILLIS_PER_DAY);
+    const memory = makeMemory({
+      text: "stale fact",
+      weight: 1.0,
+      pinned: false,
+      updatedAt: updatedAt.toISOString(),
+    });
+
+    const expected = 1.0 * Math.exp(-MIND_DECAY_LAMBDA * 45);
+    expect(computeMemoryDecay(memory, now)).toBeCloseTo(expected, 3);
+    expect(computeMemoryDecay(memory, now)).toBeCloseTo(0.05, 2);
+  });
+
+  it("does not decay when now equals updatedAt", () => {
+    const now = new Date("2026-06-16T10:00:00.000Z");
+    const memory = makeMemory({
+      text: "fresh fact",
+      weight: 0.8,
+      pinned: false,
+      updatedAt: now.toISOString(),
+    });
+
+    expect(computeMemoryDecay(memory, now)).toBe(0.8);
+  });
+});
+
+describe("rankMindMemories", () => {
+  it("ranks exact token matches above fresh non-matches", () => {
+    const now = new Date("2026-06-16T10:00:00.000Z");
+    const freshNonMatch = makeMemory({
+      text: "something else entirely",
+      weight: 1.0,
+      accessCount: 0,
+      updatedAt: now.toISOString(),
+    });
+    const oldExactMatch = makeMemory({
+      text: "the quick brown fox",
+      weight: 1.0,
+      accessCount: 0,
+      updatedAt: new Date(now.getTime() - 30 * MILLIS_PER_DAY).toISOString(),
+    });
+
+    const ranked = rankMindMemories([freshNonMatch, oldExactMatch], "brown fox", now);
+
+    expect(ranked.length).toBe(2);
+    expect(ranked[0]!.memory.text).toBe("the quick brown fox");
+    expect(ranked[1]!.memory.text).toBe("something else entirely");
+    expect(ranked[0]!.rank).toBe(1);
+    expect(ranked[1]!.rank).toBe(2);
+  });
+
+  it("breaks ties by updatedAt descending", () => {
+    const now = new Date("2026-06-16T10:00:00.000Z");
+    const older = makeMemory({
+      text: "tie older",
+      weight: 0.75,
+      updatedAt: new Date(now.getTime() - 1 * MILLIS_PER_DAY).toISOString(),
+    });
+    const newer = makeMemory({
+      text: "tie newer",
+      weight: 0.75,
+      updatedAt: now.toISOString(),
+    });
+
+    const ranked = rankMindMemories([older, newer], undefined, now);
+
+    expect(ranked[0]!.memory.text).toBe("tie newer");
+    expect(ranked[1]!.memory.text).toBe("tie older");
+  });
+});
+
+describe("buildMindRecallDigest", () => {
+  it("joins top matches and truncates to the max digest size", () => {
+    const matches = Array.from({ length: 8 }, (_, i) => ({
+      memory: makeMemory({
+        text: `Memory number ${i + 1} with enough padding to exceed.`.repeat(5),
+        weight: 1.0,
+      }),
+      rank: i + 1,
+    }));
+
+    const digest = buildMindRecallDigest(matches);
+
+    expect(digest.length).toBeLessThanOrEqual(800);
+    expect(digest.endsWith("…")).toBe(true);
+  });
+
+  it("returns the full join when under the limit", () => {
+    const matches = [
+      { memory: makeMemory({ text: "short one" }), rank: 1 },
+      { memory: makeMemory({ text: "short two" }), rank: 2 },
+    ];
+
+    const digest = buildMindRecallDigest(matches);
+
+    expect(digest).toBe("short one\n\nshort two");
+  });
+});

--- a/apps/server/src/mind/scoring.ts
+++ b/apps/server/src/mind/scoring.ts
@@ -1,20 +1,10 @@
-import { MIND_RECALL_MAX_DIGEST_CHARS, type MindMemory } from "@synara/contracts";
+import { MIND_RECALL_MAX_DIGEST_CHARS, type MindMemory, type MindMemoryMatch } from "@synara/contracts";
 
 /** Lambda so that ~45 days of idle decays a weight-1.0 memory to ~0.05. */
 export const MIND_DECAY_LAMBDA = 0.0667;
 
 /** Multiplier applied to the decayed score for each exact query-token match. */
 const MIND_EXACT_TOKEN_MATCH_BOOST = 10.0;
-
-export interface EffectiveMindMemory extends MindMemory {
-  readonly decayedWeight: number;
-}
-
-export interface MindMemoryMatch {
-  readonly memory: MindMemory;
-  readonly rank: number;
-  readonly decayedWeight: number;
-}
 
 const MILLIS_PER_DAY = 1000 * 60 * 60 * 24;
 

--- a/apps/server/src/mind/scoring.ts
+++ b/apps/server/src/mind/scoring.ts
@@ -1,4 +1,8 @@
-import { MIND_RECALL_MAX_DIGEST_CHARS, type MindMemory, type MindMemoryMatch } from "@synara/contracts";
+import {
+  MIND_RECALL_MAX_DIGEST_CHARS,
+  type MindMemory,
+  type MindMemoryMatch,
+} from "@synara/contracts";
 
 /** Lambda so that ~45 days of idle decays a weight-1.0 memory to ~0.05. */
 export const MIND_DECAY_LAMBDA = 0.0667;

--- a/apps/server/src/mind/scoring.ts
+++ b/apps/server/src/mind/scoring.ts
@@ -1,0 +1,97 @@
+import { MIND_RECALL_MAX_DIGEST_CHARS, type MindMemory } from "@synara/contracts";
+
+/** Lambda so that ~45 days of idle decays a weight-1.0 memory to ~0.05. */
+export const MIND_DECAY_LAMBDA = 0.0667;
+
+/** Multiplier applied to the decayed score for each exact query-token match. */
+const MIND_EXACT_TOKEN_MATCH_BOOST = 10.0;
+
+export interface EffectiveMindMemory extends MindMemory {
+  readonly decayedWeight: number;
+}
+
+export interface MindMemoryMatch {
+  readonly memory: MindMemory;
+  readonly rank: number;
+  readonly decayedWeight: number;
+}
+
+const MILLIS_PER_DAY = 1000 * 60 * 60 * 24;
+
+function tokenize(text: string): ReadonlyArray<string> {
+  const matches = text.toLowerCase().match(/\b\w+\b/g);
+  if (matches == null) return [];
+  return [...new Set(matches)];
+}
+
+function exactMatchBoost(memory: MindMemory, query: string | undefined): number {
+  if (query == null || query.trim().length === 0) return 1.0;
+  const queryTokens = tokenize(query);
+  if (queryTokens.length === 0) return 1.0;
+  const memoryTokens = new Set(tokenize(memory.text));
+  let matched = 0;
+  for (const token of queryTokens) {
+    if (memoryTokens.has(token)) matched += 1;
+  }
+  return 1.0 + MIND_EXACT_TOKEN_MATCH_BOOST * (matched / queryTokens.length);
+}
+
+/**
+ * Compute the effective weight of a memory at a point in time.
+ *
+ * Pinned memories never decay. Otherwise the weight decays exponentially by
+ * `exp(-0.0667 * daysIdle)`.
+ */
+export function computeMemoryDecay(memory: MindMemory, now: Date): number {
+  if (memory.pinned) return memory.weight;
+  const updatedAtMs = Date.parse(memory.updatedAt);
+  if (!Number.isFinite(updatedAtMs)) return memory.weight;
+  const daysIdle = (now.getTime() - updatedAtMs) / MILLIS_PER_DAY;
+  return memory.weight * Math.exp(-MIND_DECAY_LAMBDA * Math.max(0, daysIdle));
+}
+
+/**
+ * Rank memories for recall. Sorts by `decayedWeight * exactMatchBoost` descending,
+ * then by `updatedAt` descending. Does not apply a limit.
+ */
+export function rankMindMemories(
+  memories: ReadonlyArray<MindMemory>,
+  query: string | undefined,
+  now: Date,
+): ReadonlyArray<MindMemoryMatch> {
+  const scored = memories.map((memory) => {
+    const decayedWeight = computeMemoryDecay(memory, now);
+    const matchBoost = exactMatchBoost(memory, query);
+    return {
+      memory,
+      decayedWeight,
+      score: decayedWeight * matchBoost,
+    };
+  });
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    // Newer first for ties.
+    if (b.memory.updatedAt > a.memory.updatedAt) return 1;
+    if (b.memory.updatedAt < a.memory.updatedAt) return -1;
+    return 0;
+  });
+
+  return scored.map((entry, index) => ({
+    memory: entry.memory,
+    rank: index + 1,
+    decayedWeight: entry.decayedWeight,
+  }));
+}
+
+/**
+ * Join the text of the provided (already-ranked) matches and truncate the result
+ * to `MIND_RECALL_MAX_DIGEST_CHARS`.
+ */
+export function buildMindRecallDigest(
+  matches: ReadonlyArray<{ readonly memory: MindMemory; readonly rank: number }>,
+): string {
+  const full = matches.map((m) => m.memory.text).join("\n\n");
+  if (full.length <= MIND_RECALL_MAX_DIGEST_CHARS) return full;
+  return `${full.slice(0, MIND_RECALL_MAX_DIGEST_CHARS - 1)}…`;
+}

--- a/apps/server/src/mind/secretPatterns.test.ts
+++ b/apps/server/src/mind/secretPatterns.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { isMindSecret } from "./secretPatterns.ts";
+
+describe("isMindSecret", () => {
+  it("rejects the same credential text on consecutive calls", () => {
+    const secret = "deploy with api_key=supersecret12345678 tonight";
+    expect(isMindSecret(secret)).toBe(true);
+    expect(isMindSecret(secret)).toBe(true);
+    expect(isMindSecret(secret)).toBe(true);
+  });
+
+  it("rejects token-prefixed secrets consistently", () => {
+    const secret = "rotated ghp-abcdefgh12345678 yesterday";
+    for (let i = 0; i < 4; i += 1) {
+      expect(isMindSecret(secret)).toBe(true);
+    }
+  });
+
+  it("accepts ordinary text", () => {
+    expect(isMindSecret("friday deploy checklist")).toBe(false);
+  });
+});

--- a/apps/server/src/mind/secretPatterns.ts
+++ b/apps/server/src/mind/secretPatterns.ts
@@ -3,7 +3,7 @@
  */
 
 const TOKEN_PREFIX_RE =
-  /\b(?:sk|pk|ghp|gho|ghs|github_pat|xox[baprs]|AKIA|ASIA)[-_][A-Za-z0-9_-]{8,}\b/gi;
+  /\b(?:sk|pk|ghp|gho|ghs|github_pat|xox[baprs]|AKIA|ASIA)[-_][A-Za-z0-9_-]{8,}\b/i;
 
 const PRIVATE_KEY_BLOCK_RE =
   /-----BEGIN (?:RSA |EC |DSA |OPENSSH |ED25519 |PGP )?PRIVATE KEY(?: BLOCK)?-----/i;
@@ -15,7 +15,7 @@ const AWS_KEY_RE = /\bAKIA[0-9A-Z]{16}\b/;
 const JWT_RE = /eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]{8,}/;
 
 const CREDENTIAL_ASSIGNMENT_RE =
-  /(?:\b(?:api[_-]?key|apikey|auth[_-]?token|access[_-]?token|bearer|secret|password|token)\b)(?:\s*[:=]\s*|\s+)(?:["'`])?[^\s"'`]{8,}/gi;
+  /(?:\b(?:api[_-]?key|apikey|auth[_-]?token|access[_-]?token|bearer|secret|password|token)\b)(?:\s*[:=]\s*|\s+)(?:["'`])?[^\s"'`]{8,}/i;
 
 const SECRET_PATTERNS = [
   TOKEN_PREFIX_RE,

--- a/apps/server/src/mind/secretPatterns.ts
+++ b/apps/server/src/mind/secretPatterns.ts
@@ -1,0 +1,34 @@
+/**
+ * Reject memory text that looks like it contains a secret, credential, or key.
+ */
+
+const TOKEN_PREFIX_RE =
+  /\b(?:sk|pk|ghp|gho|ghs|github_pat|xox[baprs]|AKIA|ASIA)[-_][A-Za-z0-9_-]{8,}\b/gi;
+
+const PRIVATE_KEY_BLOCK_RE =
+  /-----BEGIN (?:RSA |EC |DSA |OPENSSH |ED25519 |PGP )?PRIVATE KEY(?: BLOCK)?-----/i;
+
+const HEX_PRIVATE_KEY_RE = /\b0x[0-9a-fA-F]{64}\b/;
+
+const AWS_KEY_RE = /\bAKIA[0-9A-Z]{16}\b/;
+
+const JWT_RE = /eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]{8,}/;
+
+const CREDENTIAL_ASSIGNMENT_RE =
+  /(?:\b(?:api[_-]?key|apikey|auth[_-]?token|access[_-]?token|bearer|secret|password|token)\b)(?:\s*[:=]\s*|\s+)(?:["'`])?[^\s"'`]{8,}/gi;
+
+const SECRET_PATTERNS = [
+  TOKEN_PREFIX_RE,
+  PRIVATE_KEY_BLOCK_RE,
+  HEX_PRIVATE_KEY_RE,
+  AWS_KEY_RE,
+  JWT_RE,
+  CREDENTIAL_ASSIGNMENT_RE,
+];
+
+export function isMindSecret(text: string): boolean {
+  for (const pattern of SECRET_PATTERNS) {
+    if (pattern.test(text)) return true;
+  }
+  return false;
+}

--- a/apps/server/src/persistence/Layers/MindRepository.test.ts
+++ b/apps/server/src/persistence/Layers/MindRepository.test.ts
@@ -275,6 +275,39 @@ layer("MindRepository", (it) => {
     }),
   );
 
+  it.effect("prune deletes weight-1.0 memories once decayed below threshold", () =>
+    Effect.gen(function* () {
+      const repository = yield* MindRepository;
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations();
+      yield* setupMindTables(sql);
+
+      const stale = yield* repository.remember({
+        projectId,
+        text: "stale weight-1.0 memory",
+        now: "2026-04-01T00:00:00.000Z",
+      });
+      const fresh = yield* repository.remember({
+        projectId,
+        text: "fresh weight-1.0 memory",
+        now: "2026-06-16T10:00:00.000Z",
+      });
+
+      const deletedIds = yield* repository.prune({
+        projectId,
+        now: "2026-06-16T10:00:00.000Z",
+      });
+
+      assert.deepStrictEqual(deletedIds, [stale.memoryId]);
+
+      const freshReloaded = yield* repository.getById({
+        projectId,
+        memoryId: fresh.memoryId,
+      });
+      assert.isTrue(Option.isSome(freshReloaded));
+    }),
+  );
+
   it.effect("journal entry for forget has no text and records the correct columns", () =>
     Effect.gen(function* () {
       const repository = yield* MindRepository;
@@ -356,6 +389,29 @@ layer("MindRepository", (it) => {
       const filtered = yield* repository.list({ projectId: p2, query: "beta" });
       assert.lengthOf(filtered, 1);
       assert.strictEqual(filtered[0]?.text, "beta");
+    }),
+  );
+
+  it.effect("recall tolerates FTS operator characters in the query", () =>
+    Effect.gen(function* () {
+      const repository = yield* MindRepository;
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations();
+      yield* setupMindTables(sql);
+
+      const memory = yield* repository.remember({
+        projectId,
+        text: "deploy or rollback friday plan",
+        now: "2026-06-16T10:00:00.000Z",
+      });
+
+      const results = yield* repository.recall({
+        projectId,
+        query: 'friday "deploy',
+      });
+
+      assert.lengthOf(results, 1);
+      assert.strictEqual(results[0]?.memoryId, memory.memoryId);
     }),
   );
 

--- a/apps/server/src/persistence/Layers/MindRepository.test.ts
+++ b/apps/server/src/persistence/Layers/MindRepository.test.ts
@@ -1,0 +1,388 @@
+import { assert, it } from "@effect/vitest";
+import { ProjectId, TurnId } from "@synara/contracts";
+import { Effect, Layer, Option } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import { MindRepository } from "../Services/MindRepository.ts";
+import { MindRepositoryLive } from "./MindRepository.ts";
+import { SqlitePersistenceMemory } from "./Sqlite.ts";
+
+const layer = it.layer(MindRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)));
+
+const projectId = ProjectId.makeUnsafe("project-mind");
+const turnId = TurnId.makeUnsafe("turn-1");
+
+const setupMindTables = (sql: SqlClient.SqlClient) =>
+  Effect.gen(function* () {
+    yield* sql`
+      CREATE TABLE IF NOT EXISTS projects (
+        project_id TEXT PRIMARY KEY
+      )
+    `;
+    yield* sql`
+      INSERT OR IGNORE INTO projects (project_id)
+      VALUES (${projectId}), (${makeProjectId("list")}), (${makeProjectId("count")})
+    `;
+    yield* sql`
+      CREATE TABLE IF NOT EXISTS mind_memories (
+        memory_id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        text TEXT NOT NULL,
+        weight REAL NOT NULL DEFAULT 1.0,
+        access_count INTEGER NOT NULL DEFAULT 0,
+        pinned INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `;
+    yield* sql`
+      CREATE INDEX IF NOT EXISTS idx_mind_memories_project_id
+      ON mind_memories(project_id)
+    `;
+    yield* sql`
+      CREATE INDEX IF NOT EXISTS idx_mind_memories_project_id_updated
+      ON mind_memories(project_id, updated_at)
+    `;
+    yield* sql`
+      CREATE INDEX IF NOT EXISTS idx_mind_memories_project_id_pinned
+      ON mind_memories(project_id, pinned)
+    `;
+    yield* sql`
+      CREATE VIRTUAL TABLE IF NOT EXISTS mind_memories_fts USING fts5(
+        text,
+        content='mind_memories',
+        content_rowid='rowid'
+      )
+    `;
+    yield* sql`
+      CREATE TABLE IF NOT EXISTS mind_memory_journal (
+        journal_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        memory_id TEXT NOT NULL,
+        project_id TEXT NOT NULL,
+        turn_id TEXT,
+        op TEXT NOT NULL,
+        weight_delta REAL,
+        created_at TEXT NOT NULL
+      )
+    `;
+    yield* sql`
+      CREATE INDEX IF NOT EXISTS idx_mind_memory_journal_memory_id
+      ON mind_memory_journal(memory_id)
+    `;
+    yield* sql`
+      CREATE TRIGGER IF NOT EXISTS mind_memories_fts_insert
+      AFTER INSERT ON mind_memories
+      BEGIN
+        INSERT INTO mind_memories_fts(rowid, text)
+        VALUES (new.rowid, new.text);
+      END
+    `;
+    yield* sql`
+      CREATE TRIGGER IF NOT EXISTS mind_memories_fts_update
+      AFTER UPDATE ON mind_memories
+      BEGIN
+        INSERT INTO mind_memories_fts(mind_memories_fts, rowid, text)
+        VALUES ('delete', old.rowid, old.text);
+        INSERT INTO mind_memories_fts(rowid, text)
+        VALUES (new.rowid, new.text);
+      END
+    `;
+    yield* sql`
+      CREATE TRIGGER IF NOT EXISTS mind_memories_fts_delete
+      AFTER DELETE ON mind_memories
+      BEGIN
+        INSERT INTO mind_memories_fts(mind_memories_fts, rowid, text)
+        VALUES ('delete', old.rowid, old.text);
+      END
+    `;
+  });
+
+const makeProjectId = (name: string) => ProjectId.makeUnsafe(`project-${name}`);
+
+layer("MindRepository", (it) => {
+  it.effect("creates and reinforces a memory by projectId and normalized text", () =>
+    Effect.gen(function* () {
+      const repository = yield* MindRepository;
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations();
+      yield* setupMindTables(sql);
+
+      const first = yield* repository.remember({
+        projectId,
+        text: "  hello   world  ",
+        now: "2026-06-16T10:00:00.000Z",
+      });
+      const second = yield* repository.remember({
+        projectId,
+        text: "hello world",
+        turnId,
+        now: "2026-06-16T10:00:01.000Z",
+      });
+
+      assert.strictEqual(first.memoryId, second.memoryId);
+      assert.strictEqual(first.text, "hello world");
+      assert.strictEqual(second.text, "hello world");
+      assert.strictEqual(second.accessCount, 1);
+      assert.strictEqual(second.weight, 1.0);
+      assert.strictEqual(second.updatedAt, "2026-06-16T10:00:01.000Z");
+
+      const found = yield* repository.findByText({ projectId, text: "hello world" });
+      assert.isTrue(Option.isSome(found));
+      if (Option.isSome(found)) {
+        assert.strictEqual(found.value.accessCount, 1);
+      }
+    }),
+  );
+
+  it.effect("recall is a pure read and does not mutate weight or access_count", () =>
+    Effect.gen(function* () {
+      const repository = yield* MindRepository;
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations();
+      yield* setupMindTables(sql);
+
+      const memory = yield* repository.remember({
+        projectId,
+        text: "synara is helpful",
+        now: "2026-06-16T10:00:00.000Z",
+      });
+
+      const results = yield* repository.recall({
+        projectId,
+        query: "synara",
+      });
+
+      assert.lengthOf(results, 1);
+      assert.strictEqual(results[0]?.memoryId, memory.memoryId);
+
+      const reloaded = yield* repository.getById({
+        projectId,
+        memoryId: memory.memoryId,
+      });
+      assert.isTrue(Option.isSome(reloaded));
+      if (Option.isSome(reloaded)) {
+        assert.strictEqual(reloaded.value.weight, memory.weight);
+        assert.strictEqual(reloaded.value.accessCount, memory.accessCount);
+        assert.strictEqual(reloaded.value.updatedAt, memory.updatedAt);
+      }
+    }),
+  );
+
+  it.effect("confirm bumps weight by min(0.15, 1.0 - weight) and resets updatedAt", () =>
+    Effect.gen(function* () {
+      const repository = yield* MindRepository;
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations();
+      yield* setupMindTables(sql);
+
+      const memory = yield* repository.remember({
+        projectId,
+        text: "important fact",
+        now: "2026-06-16T10:00:00.000Z",
+      });
+
+      yield* sql`
+        UPDATE mind_memories
+        SET weight = 0.7, updated_at = '2026-06-16T09:00:00.000Z'
+        WHERE memory_id = ${memory.memoryId}
+      `;
+
+      const confirmed = yield* repository.confirm({
+        projectId,
+        memoryId: memory.memoryId,
+        now: "2026-06-16T10:05:00.000Z",
+      });
+
+      assert.closeTo(confirmed.weight, 0.85, 0.001);
+      assert.strictEqual(confirmed.accessCount, memory.accessCount);
+      assert.strictEqual(confirmed.updatedAt, "2026-06-16T10:05:00.000Z");
+    }),
+  );
+
+  it.effect("forget removes the memory row", () =>
+    Effect.gen(function* () {
+      const repository = yield* MindRepository;
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations();
+      yield* setupMindTables(sql);
+
+      const memory = yield* repository.remember({
+        projectId,
+        text: "forgettable fact",
+        now: "2026-06-16T10:00:00.000Z",
+      });
+
+      yield* repository.forget({ projectId, memoryId: memory.memoryId });
+
+      const reloaded = yield* repository.getById({
+        projectId,
+        memoryId: memory.memoryId,
+      });
+      assert.isTrue(Option.isNone(reloaded));
+    }),
+  );
+
+  it.effect("pin prevents prune from deleting a memory", () =>
+    Effect.gen(function* () {
+      const repository = yield* MindRepository;
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations();
+      yield* setupMindTables(sql);
+
+      const unpinned = yield* repository.remember({
+        projectId,
+        text: "unpinned stale memory",
+        now: "2026-06-16T10:00:00.000Z",
+      });
+      const pinned = yield* repository.remember({
+        projectId,
+        text: "pinned stale memory",
+        now: "2026-06-16T10:00:00.000Z",
+      });
+
+      yield* repository.pin({
+        projectId,
+        memoryId: pinned.memoryId,
+        pinned: true,
+        now: "2026-06-16T10:00:00.000Z",
+      });
+
+      yield* sql`
+        UPDATE mind_memories
+        SET weight = 0.05, access_count = 1, updated_at = '2026-04-01T00:00:00.000Z'
+        WHERE memory_id IN (${unpinned.memoryId}, ${pinned.memoryId})
+      `;
+
+      const deletedIds = yield* repository.prune({
+        projectId,
+        now: "2026-06-16T10:00:00.000Z",
+      });
+
+      assert.deepStrictEqual(deletedIds, [unpinned.memoryId]);
+
+      const unpinnedReloaded = yield* repository.getById({
+        projectId,
+        memoryId: unpinned.memoryId,
+      });
+      assert.isTrue(Option.isNone(unpinnedReloaded));
+
+      const pinnedReloaded = yield* repository.getById({
+        projectId,
+        memoryId: pinned.memoryId,
+      });
+      assert.isTrue(Option.isSome(pinnedReloaded));
+    }),
+  );
+
+  it.effect("journal entry for forget has no text and records the correct columns", () =>
+    Effect.gen(function* () {
+      const repository = yield* MindRepository;
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations();
+      yield* setupMindTables(sql);
+
+      const memory = yield* repository.remember({
+        projectId,
+        text: "memory with journal",
+        now: "2026-06-16T10:00:00.000Z",
+      });
+
+      yield* repository.recordJournal({
+        memoryId: memory.memoryId,
+        projectId,
+        turnId,
+        op: "forget",
+        createdAt: "2026-06-16T10:05:00.000Z",
+      });
+
+      const rows = yield* sql<{
+        readonly journal_id: number;
+        readonly memory_id: string;
+        readonly project_id: string;
+        readonly turn_id: string | null;
+        readonly op: string;
+        readonly weight_delta: number | null;
+        readonly created_at: string;
+      }>`
+        SELECT journal_id, memory_id, project_id, turn_id, op, weight_delta, created_at
+        FROM mind_memory_journal
+      `;
+
+      assert.lengthOf(rows, 1);
+      const entry = rows[0];
+      if (entry === undefined) {
+        return assert.fail("Expected a journal entry.");
+      }
+      assert.strictEqual(entry.op, "forget");
+      assert.strictEqual(entry.memory_id, memory.memoryId);
+      assert.strictEqual(entry.project_id, projectId);
+      assert.strictEqual(entry.turn_id, turnId);
+      assert.isNull(entry.weight_delta);
+      assert.isUndefined((entry as { readonly text?: string }).text);
+    }),
+  );
+
+  it.effect("lists memories for a project with optional query filtering", () =>
+    Effect.gen(function* () {
+      const repository = yield* MindRepository;
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations();
+      yield* setupMindTables(sql);
+
+      const p2 = makeProjectId("list");
+      yield* repository.remember({
+        projectId: p2,
+        text: "alpha",
+        now: "2026-06-16T10:00:00.000Z",
+      });
+      yield* repository.remember({
+        projectId: p2,
+        text: "beta",
+        now: "2026-06-16T10:00:01.000Z",
+      });
+      yield* repository.remember({
+        projectId: p2,
+        text: "gamma",
+        now: "2026-06-16T10:00:02.000Z",
+      });
+
+      const all = yield* repository.list({ projectId: p2 });
+      assert.deepStrictEqual(
+        all.map((m) => m.text),
+        ["gamma", "beta", "alpha"],
+      );
+
+      const filtered = yield* repository.list({ projectId: p2, query: "beta" });
+      assert.lengthOf(filtered, 1);
+      assert.strictEqual(filtered[0]?.text, "beta");
+    }),
+  );
+
+  it.effect("counts memories by project", () =>
+    Effect.gen(function* () {
+      const repository = yield* MindRepository;
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations();
+      yield* setupMindTables(sql);
+
+      const p3 = makeProjectId("count");
+      const countBefore = yield* repository.countByProject({ projectId: p3 });
+      assert.strictEqual(countBefore, 0);
+
+      yield* repository.remember({
+        projectId: p3,
+        text: "one",
+        now: "2026-06-16T10:00:00.000Z",
+      });
+      yield* repository.remember({
+        projectId: p3,
+        text: "two",
+        now: "2026-06-16T10:00:01.000Z",
+      });
+
+      const countAfter = yield* repository.countByProject({ projectId: p3 });
+      assert.strictEqual(countAfter, 2);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Layers/MindRepository.ts
+++ b/apps/server/src/persistence/Layers/MindRepository.ts
@@ -12,6 +12,7 @@ import {
   toPersistenceSqlError,
   toPersistenceSqlOrDecodeError,
 } from "../Errors.ts";
+import { MIND_DECAY_LAMBDA } from "../../mind/scoring.ts";
 import {
   ConfirmMindMemoryInput,
   CountMindMemoriesInput,
@@ -48,6 +49,23 @@ const toMemory = (row: MindMemoryDbRow) =>
   );
 
 const normalizeText = (text: string): string => text.trim().replace(/\s+/g, " ");
+
+/**
+ * Build a safe FTS5 MATCH query from raw user input. Each whitespace token
+ * becomes a quoted phrase (embedded quotes doubled) joined with AND, so
+ * punctuation and operators (quotes, *, OR/AND/NOT, parens) stay literal
+ * instead of throwing MATCH syntax errors. Returns null when no usable
+ * token remains so callers fall back to the unfiltered scan branch.
+ */
+const toFtsMatchQuery = (query: string): string | null => {
+  const tokens = query
+    .trim()
+    .split(/\s+/)
+    .map((token) => token.replace(/"/g, ""))
+    .filter((token) => token.length > 0);
+  if (tokens.length === 0) return null;
+  return tokens.map((token) => `"${token}"`).join(" AND ");
+};
 
 const memoryIdFor = (projectId: string, text: string): MindMemoryId => {
   const normalized = normalizeText(text);
@@ -163,8 +181,8 @@ const makeMindRepository = Effect.gen(function* () {
     Request: RecallMindMemoriesInput,
     Result: MindMemoryDbRow,
     execute: ({ projectId, query }) => {
-      const q = query?.trim();
-      if (q !== undefined && q.length > 0) {
+      const q = query === undefined ? null : toFtsMatchQuery(query);
+      if (q !== null) {
         return sql`
           WITH matches AS (
             SELECT rowid, rank
@@ -258,8 +276,8 @@ const makeMindRepository = Effect.gen(function* () {
     Request: ListMindMemoriesInput,
     Result: MindMemoryDbRow,
     execute: ({ projectId, query }) => {
-      const q = query?.trim();
-      if (q !== undefined && q.length > 0) {
+      const q = query === undefined ? null : toFtsMatchQuery(query);
+      if (q !== null) {
         return sql`
           WITH matches AS (
             SELECT rowid
@@ -317,7 +335,7 @@ const makeMindRepository = Effect.gen(function* () {
       return sql`
         DELETE FROM mind_memories
         WHERE project_id = ${projectId}
-          AND weight < 0.1
+          AND weight * exp(-${MIND_DECAY_LAMBDA} * (julianday(${now}) - julianday(updated_at))) < 0.1
           AND access_count < 2
           AND updated_at < ${cutoff}
           AND pinned = 0

--- a/apps/server/src/persistence/Layers/MindRepository.ts
+++ b/apps/server/src/persistence/Layers/MindRepository.ts
@@ -1,0 +1,508 @@
+import { createHash } from "node:crypto";
+
+import { MindMemory, MindMemoryId, MindJournalOp } from "@synara/contracts";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import * as SqlSchema from "effect/unstable/sql/SqlSchema";
+import { Effect, Layer, Option, Schema, Struct } from "effect";
+import * as SchemaGetter from "effect/SchemaGetter";
+
+import {
+  toPersistenceDecodeCauseError,
+  toPersistenceDecodeError,
+  toPersistenceSqlError,
+  toPersistenceSqlOrDecodeError,
+} from "../Errors.ts";
+import {
+  ConfirmMindMemoryInput,
+  CountMindMemoriesInput,
+  FindMindMemoryByTextInput,
+  ForgetMindMemoryInput,
+  GetMindMemoryInput,
+  ListMindMemoriesInput,
+  MindRepository,
+  PinMindMemoryInput,
+  PruneMindMemoriesInput,
+  RecallMindMemoriesInput,
+  RecordMindJournalInput,
+  RememberMindMemoryInput,
+  type MindRepositoryShape,
+} from "../Services/MindRepository.ts";
+
+const SqliteBoolean = Schema.Number.pipe(
+  Schema.decodeTo(Schema.Boolean, {
+    decode: SchemaGetter.transform((value) => value !== 0),
+    encode: SchemaGetter.transform((value) => (value ? 1 : 0)),
+  }),
+);
+
+const MindMemoryDbRow = MindMemory.mapFields(
+  Struct.assign({
+    pinned: SqliteBoolean,
+  }),
+);
+type MindMemoryDbRow = typeof MindMemoryDbRow.Type;
+
+const toMemory = (row: MindMemoryDbRow) =>
+  Schema.decodeUnknownEffect(MindMemory)(row).pipe(
+    Effect.mapError(toPersistenceDecodeError("MindRepository.rowToDomain")),
+  );
+
+const normalizeText = (text: string): string => text.trim().replace(/\s+/g, " ");
+
+const memoryIdFor = (projectId: string, text: string): MindMemoryId => {
+  const normalized = normalizeText(text);
+  const hash = createHash("sha256").update(`memory:${projectId}:${normalized}`).digest("base64url");
+  return MindMemoryId.makeUnsafe(hash);
+};
+
+const RememberMindMemoryRequest = Schema.Struct({
+  memoryId: MindMemoryId,
+  projectId: MindMemory.fields.projectId,
+  text: MindMemory.fields.text,
+  weight: MindMemory.fields.weight,
+  accessCount: MindMemory.fields.accessCount,
+  pinned: MindMemory.fields.pinned,
+  createdAt: MindMemory.fields.createdAt,
+  updatedAt: MindMemory.fields.updatedAt,
+  now: MindMemory.fields.updatedAt,
+});
+
+const makeMindRepository = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  const upsertRememberRow = SqlSchema.findOneOption({
+    Request: RememberMindMemoryRequest,
+    Result: MindMemoryDbRow,
+    execute: ({
+      memoryId,
+      projectId,
+      text,
+      weight,
+      accessCount,
+      pinned,
+      createdAt,
+      updatedAt,
+      now,
+    }) =>
+      sql`
+        INSERT INTO mind_memories (
+          memory_id,
+          project_id,
+          text,
+          weight,
+          access_count,
+          pinned,
+          created_at,
+          updated_at
+        )
+        VALUES (
+          ${memoryId},
+          ${projectId},
+          ${text},
+          ${weight},
+          ${accessCount},
+          ${pinned ? 1 : 0},
+          ${createdAt},
+          ${updatedAt}
+        )
+        ON CONFLICT (memory_id) DO UPDATE SET
+          weight = min(1.0, weight + 0.02),
+          access_count = access_count + 1,
+          updated_at = ${now}
+        RETURNING
+          memory_id AS "memoryId",
+          project_id AS "projectId",
+          text,
+          weight,
+          access_count AS "accessCount",
+          pinned,
+          created_at AS "createdAt",
+          updated_at AS "updatedAt"
+      `,
+  });
+
+  const findByTextRow = SqlSchema.findOneOption({
+    Request: FindMindMemoryByTextInput,
+    Result: MindMemoryDbRow,
+    execute: ({ projectId, text }) =>
+      sql`
+        SELECT
+          memory_id AS "memoryId",
+          project_id AS "projectId",
+          text,
+          weight,
+          access_count AS "accessCount",
+          pinned,
+          created_at AS "createdAt",
+          updated_at AS "updatedAt"
+        FROM mind_memories
+        WHERE project_id = ${projectId} AND text = ${text}
+      `,
+  });
+
+  const getByIdRow = SqlSchema.findOneOption({
+    Request: GetMindMemoryInput,
+    Result: MindMemoryDbRow,
+    execute: ({ memoryId, projectId }) =>
+      sql`
+        SELECT
+          memory_id AS "memoryId",
+          project_id AS "projectId",
+          text,
+          weight,
+          access_count AS "accessCount",
+          pinned,
+          created_at AS "createdAt",
+          updated_at AS "updatedAt"
+        FROM mind_memories
+        WHERE memory_id = ${memoryId} AND project_id = ${projectId}
+      `,
+  });
+
+  const recallRows = SqlSchema.findAll({
+    Request: RecallMindMemoriesInput,
+    Result: MindMemoryDbRow,
+    execute: ({ projectId, query }) => {
+      const q = query?.trim();
+      if (q !== undefined && q.length > 0) {
+        return sql`
+          WITH matches AS (
+            SELECT rowid, rank
+            FROM mind_memories_fts
+            WHERE mind_memories_fts MATCH ${q}
+          )
+          SELECT
+            m.memory_id AS "memoryId",
+            m.project_id AS "projectId",
+            m.text,
+            m.weight,
+            m.access_count AS "accessCount",
+            m.pinned,
+            m.created_at AS "createdAt",
+            m.updated_at AS "updatedAt"
+          FROM mind_memories m
+          JOIN matches ON m.rowid = matches.rowid
+          WHERE m.project_id = ${projectId}
+          ORDER BY matches.rank
+        `;
+      }
+      return sql`
+        SELECT
+          memory_id AS "memoryId",
+          project_id AS "projectId",
+          text,
+          weight,
+          access_count AS "accessCount",
+          pinned,
+          created_at AS "createdAt",
+          updated_at AS "updatedAt"
+        FROM mind_memories
+        WHERE project_id = ${projectId}
+        ORDER BY updated_at DESC, memory_id ASC
+      `;
+    },
+  });
+
+  const confirmRow = SqlSchema.findOneOption({
+    Request: ConfirmMindMemoryInput,
+    Result: MindMemoryDbRow,
+    execute: ({ projectId, memoryId, now }) =>
+      sql`
+        UPDATE mind_memories
+        SET weight = weight + min(0.15, 1.0 - weight),
+            updated_at = ${now}
+        WHERE memory_id = ${memoryId} AND project_id = ${projectId}
+        RETURNING
+          memory_id AS "memoryId",
+          project_id AS "projectId",
+          text,
+          weight,
+          access_count AS "accessCount",
+          pinned,
+          created_at AS "createdAt",
+          updated_at AS "updatedAt"
+      `,
+  });
+
+  const deleteMemoryRow = SqlSchema.void({
+    Request: ForgetMindMemoryInput,
+    execute: ({ projectId, memoryId }) =>
+      sql`
+        DELETE FROM mind_memories
+        WHERE memory_id = ${memoryId} AND project_id = ${projectId}
+      `,
+  });
+
+  const pinRow = SqlSchema.findOneOption({
+    Request: PinMindMemoryInput,
+    Result: MindMemoryDbRow,
+    execute: ({ projectId, memoryId, pinned, now }) =>
+      sql`
+        UPDATE mind_memories
+        SET pinned = ${pinned ? 1 : 0},
+            updated_at = ${now}
+        WHERE memory_id = ${memoryId} AND project_id = ${projectId}
+        RETURNING
+          memory_id AS "memoryId",
+          project_id AS "projectId",
+          text,
+          weight,
+          access_count AS "accessCount",
+          pinned,
+          created_at AS "createdAt",
+          updated_at AS "updatedAt"
+      `,
+  });
+
+  const listRows = SqlSchema.findAll({
+    Request: ListMindMemoriesInput,
+    Result: MindMemoryDbRow,
+    execute: ({ projectId, query }) => {
+      const q = query?.trim();
+      if (q !== undefined && q.length > 0) {
+        return sql`
+          WITH matches AS (
+            SELECT rowid
+            FROM mind_memories_fts
+            WHERE mind_memories_fts MATCH ${q}
+          )
+          SELECT
+            m.memory_id AS "memoryId",
+            m.project_id AS "projectId",
+            m.text,
+            m.weight,
+            m.access_count AS "accessCount",
+            m.pinned,
+            m.created_at AS "createdAt",
+            m.updated_at AS "updatedAt"
+          FROM mind_memories m
+          JOIN matches ON m.rowid = matches.rowid
+          WHERE m.project_id = ${projectId}
+          ORDER BY m.updated_at DESC, m.memory_id ASC
+        `;
+      }
+      return sql`
+        SELECT
+          memory_id AS "memoryId",
+          project_id AS "projectId",
+          text,
+          weight,
+          access_count AS "accessCount",
+          pinned,
+          created_at AS "createdAt",
+          updated_at AS "updatedAt"
+        FROM mind_memories
+        WHERE project_id = ${projectId}
+        ORDER BY updated_at DESC, memory_id ASC
+      `;
+    },
+  });
+
+  const countProjectRows = SqlSchema.findOneOption({
+    Request: CountMindMemoriesInput,
+    Result: Schema.Struct({ count: Schema.Number }),
+    execute: ({ projectId }) =>
+      sql`
+        SELECT COUNT(*) AS count
+        FROM mind_memories
+        WHERE project_id = ${projectId}
+      `,
+  });
+
+  const pruneRows = SqlSchema.findAll({
+    Request: PruneMindMemoriesInput,
+    Result: Schema.Struct({ memoryId: MindMemoryId }),
+    execute: ({ projectId, now }) => {
+      const cutoff = new Date(new Date(now).getTime() - 45 * 86400_000).toISOString();
+      return sql`
+        DELETE FROM mind_memories
+        WHERE project_id = ${projectId}
+          AND weight < 0.1
+          AND access_count < 2
+          AND updated_at < ${cutoff}
+          AND pinned = 0
+        RETURNING memory_id AS "memoryId"
+      `;
+    },
+  });
+
+  const recordJournalRow = SqlSchema.void({
+    Request: RecordMindJournalInput,
+    execute: ({ memoryId, projectId, turnId, op, weightDelta, createdAt }) =>
+      sql`
+        INSERT INTO mind_memory_journal (
+          memory_id,
+          project_id,
+          turn_id,
+          op,
+          weight_delta,
+          created_at
+        )
+        VALUES (
+          ${memoryId},
+          ${projectId},
+          ${turnId ?? null},
+          ${op},
+          ${weightDelta ?? null},
+          ${createdAt}
+        )
+      `,
+  });
+
+  const withDecodedMemory = (rowOption: Option.Option<MindMemoryDbRow>, operation: string) =>
+    Option.match(rowOption, {
+      onNone: () =>
+        Effect.fail(
+          toPersistenceDecodeCauseError(operation)(
+            new Error("Memory row was not found after operation."),
+          ),
+        ),
+      onSome: toMemory,
+    });
+
+  const withOptionalMemory = (rowOption: Option.Option<MindMemoryDbRow>) =>
+    Option.match(rowOption, {
+      onNone: () => Effect.succeed(Option.none()),
+      onSome: (row) => toMemory(row).pipe(Effect.map(Option.some)),
+    });
+
+  const remember: MindRepositoryShape["remember"] = (input) =>
+    Effect.gen(function* () {
+      const now = input.now;
+      const normalized = normalizeText(input.text);
+      const memoryId = memoryIdFor(input.projectId, input.text);
+      const row = yield* upsertRememberRow({
+        memoryId,
+        projectId: input.projectId,
+        text: normalized,
+        weight: 1.0,
+        accessCount: 0,
+        pinned: false,
+        createdAt: now,
+        updatedAt: now,
+        now,
+      }).pipe(
+        Effect.mapError(
+          toPersistenceSqlOrDecodeError(
+            "MindRepository.remember:query",
+            "MindRepository.remember:decodeRow",
+          ),
+        ),
+      );
+      return yield* withDecodedMemory(row, "MindRepository.remember:missingRow");
+    });
+
+  const findByText: MindRepositoryShape["findByText"] = (input) =>
+    findByTextRow({
+      projectId: input.projectId,
+      text: normalizeText(input.text),
+    }).pipe(
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError(
+          "MindRepository.findByText:query",
+          "MindRepository.findByText:decodeRow",
+        ),
+      ),
+      Effect.flatMap(withOptionalMemory),
+    );
+
+  const getById: MindRepositoryShape["getById"] = (input) =>
+    getByIdRow(input).pipe(
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError(
+          "MindRepository.getById:query",
+          "MindRepository.getById:decodeRow",
+        ),
+      ),
+      Effect.flatMap(withOptionalMemory),
+    );
+
+  const recall: MindRepositoryShape["recall"] = (input) =>
+    recallRows(input).pipe(
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError(
+          "MindRepository.recall:query",
+          "MindRepository.recall:decodeRows",
+        ),
+      ),
+      Effect.flatMap((rows) => Effect.forEach(rows, toMemory, { concurrency: "unbounded" })),
+    );
+
+  const confirm: MindRepositoryShape["confirm"] = (input) =>
+    confirmRow(input).pipe(
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError(
+          "MindRepository.confirm:update",
+          "MindRepository.confirm:decodeRow",
+        ),
+      ),
+      Effect.flatMap((row) => withDecodedMemory(row, "MindRepository.confirm:missingRow")),
+    );
+
+  const forget: MindRepositoryShape["forget"] = (input) =>
+    deleteMemoryRow(input).pipe(
+      Effect.mapError(toPersistenceSqlError("MindRepository.forget:delete")),
+    );
+
+  const pin: MindRepositoryShape["pin"] = (input) =>
+    pinRow(input).pipe(
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError("MindRepository.pin:update", "MindRepository.pin:decodeRow"),
+      ),
+      Effect.flatMap((row) => withDecodedMemory(row, "MindRepository.pin:missingRow")),
+    );
+
+  const list: MindRepositoryShape["list"] = (input) =>
+    listRows(input).pipe(
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError(
+          "MindRepository.list:query",
+          "MindRepository.list:decodeRows",
+        ),
+      ),
+      Effect.flatMap((rows) => Effect.forEach(rows, toMemory, { concurrency: "unbounded" })),
+    );
+
+  const countByProject: MindRepositoryShape["countByProject"] = (input) =>
+    countProjectRows(input).pipe(
+      Effect.mapError(toPersistenceSqlError("MindRepository.countByProject:query")),
+      Effect.map((rowOption) =>
+        Option.match(rowOption, {
+          onNone: () => 0,
+          onSome: (row) => row.count,
+        }),
+      ),
+    );
+
+  const prune: MindRepositoryShape["prune"] = (input) =>
+    pruneRows(input).pipe(
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError(
+          "MindRepository.prune:delete",
+          "MindRepository.prune:decodeRows",
+        ),
+      ),
+      Effect.map((rows) => rows.map((row) => row.memoryId)),
+    );
+
+  const recordJournal: MindRepositoryShape["recordJournal"] = (input) =>
+    recordJournalRow(input).pipe(
+      Effect.mapError(toPersistenceSqlError("MindRepository.recordJournal:insert")),
+    );
+
+  return {
+    remember,
+    findByText,
+    getById,
+    recall,
+    confirm,
+    forget,
+    pin,
+    list,
+    countByProject,
+    prune,
+    recordJournal,
+  } satisfies MindRepositoryShape;
+});
+
+export const MindRepositoryLive = Layer.effect(MindRepository, makeMindRepository);

--- a/apps/server/src/persistence/Migrations.test.ts
+++ b/apps/server/src/persistence/Migrations.test.ts
@@ -300,10 +300,11 @@ managedAttachmentsLegacyLayer("managed attachment migration after private migrat
         [96, "ProjectionThreadsGoalAchievements"],
         [97, "ProjectionThreadsSidechatLifecycle"],
         [98, "MigrateKiloToOpenCode"],
+        [99, "Mind"],
       ]);
 
       const tracker = yield* trackerRows(sql);
-      assert.deepStrictEqual(tracker.slice(-44), [
+      assert.deepStrictEqual(tracker.slice(-45), [
         { migration_id: 55, name: "ManagedAttachments" },
         { migration_id: 56, name: "CommandReceiptFingerprints" },
         { migration_id: 57, name: "ThreadScopedProjectionMessageIdentity" },
@@ -348,6 +349,7 @@ managedAttachmentsLegacyLayer("managed attachment migration after private migrat
         { migration_id: 96, name: "ProjectionThreadsGoalAchievements" },
         { migration_id: 97, name: "ProjectionThreadsSidechatLifecycle" },
         { migration_id: 98, name: "MigrateKiloToOpenCode" },
+        { migration_id: 99, name: "Mind" },
       ]);
       const preserved = yield* sql<{ readonly count: number }>`
         SELECT COUNT(*) AS count FROM orchestration_consumer_state
@@ -438,6 +440,7 @@ agentGatewayRetentionLegacyLayer(
           [96, "ProjectionThreadsGoalAchievements"],
           [97, "ProjectionThreadsSidechatLifecycle"],
           [98, "MigrateKiloToOpenCode"],
+          [99, "Mind"],
         ]);
 
         const columns = yield* sql<{ readonly name: string }>`
@@ -531,11 +534,12 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
         [96, "ProjectionThreadsGoalAchievements"],
         [97, "ProjectionThreadsSidechatLifecycle"],
         [98, "MigrateKiloToOpenCode"],
+        [99, "Mind"],
       ]);
 
       const tracker = yield* trackerRows(sql);
       assert.deepStrictEqual(
-        tracker.slice(-28).map((row) => [row.migration_id, row.name]),
+        tracker.slice(-29).map((row) => [row.migration_id, row.name]),
         [
           [71, "ProjectionThreadsGatewayProvenance"],
           [72, "AgentGatewayOperationRetention"],
@@ -565,6 +569,7 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
           [96, "ProjectionThreadsGoalAchievements"],
           [97, "ProjectionThreadsSidechatLifecycle"],
           [98, "MigrateKiloToOpenCode"],
+          [99, "Mind"],
         ],
       );
 
@@ -653,11 +658,12 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
         [96, "ProjectionThreadsGoalAchievements"],
         [97, "ProjectionThreadsSidechatLifecycle"],
         [98, "MigrateKiloToOpenCode"],
+        [99, "Mind"],
       ]);
 
       const tracker = yield* trackerRows(sql);
       assert.deepStrictEqual(
-        tracker.slice(-24).map((row) => [row.migration_id, row.name]),
+        tracker.slice(-25).map((row) => [row.migration_id, row.name]),
         [
           [75, "ExternalMcpActiveCapacity"],
           [76, "ExternalMcpHardening"],
@@ -683,6 +689,7 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
           [96, "ProjectionThreadsGoalAchievements"],
           [97, "ProjectionThreadsSidechatLifecycle"],
           [98, "MigrateKiloToOpenCode"],
+          [99, "Mind"],
         ],
       );
       const preservedSpaces = yield* sql<{ readonly spaceId: string }>`

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -114,6 +114,7 @@ import Migration0095 from "./Migrations/095_ProjectionThreadsGoalTiming.ts";
 import Migration0096 from "./Migrations/096_ProjectionThreadsGoalAchievements.ts";
 import Migration0097 from "./Migrations/097_ProjectionThreadsSidechatLifecycle.ts";
 import Migration0098 from "./Migrations/098_MigrateKiloToOpenCode.ts";
+import Migration0099 from "./Migrations/099_Mind.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -227,6 +228,7 @@ export const migrationEntries = [
   [96, "ProjectionThreadsGoalAchievements", Migration0096],
   [97, "ProjectionThreadsSidechatLifecycle", Migration0097],
   [98, "MigrateKiloToOpenCode", Migration0098],
+  [99, "Mind", Migration0099],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/099_Mind.ts
+++ b/apps/server/src/persistence/Migrations/099_Mind.ts
@@ -13,8 +13,7 @@ export default Effect.gen(function* () {
       access_count INTEGER NOT NULL DEFAULT 0,
       pinned INTEGER NOT NULL DEFAULT 0,
       created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL,
-      FOREIGN KEY (project_id) REFERENCES projects(project_id) ON DELETE CASCADE
+      updated_at TEXT NOT NULL
     )
   `;
 

--- a/apps/server/src/persistence/Migrations/099_Mind.ts
+++ b/apps/server/src/persistence/Migrations/099_Mind.ts
@@ -48,8 +48,7 @@ export default Effect.gen(function* () {
       turn_id TEXT,
       op TEXT NOT NULL,
       weight_delta REAL,
-      created_at TEXT NOT NULL,
-      FOREIGN KEY (memory_id) REFERENCES mind_memories(memory_id) ON DELETE CASCADE
+      created_at TEXT NOT NULL
     )
   `;
 

--- a/apps/server/src/persistence/Migrations/099_Mind.ts
+++ b/apps/server/src/persistence/Migrations/099_Mind.ts
@@ -1,0 +1,90 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    CREATE TABLE IF NOT EXISTS mind_memories (
+      memory_id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      text TEXT NOT NULL,
+      weight REAL NOT NULL DEFAULT 1.0,
+      access_count INTEGER NOT NULL DEFAULT 0,
+      pinned INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (project_id) REFERENCES projects(project_id) ON DELETE CASCADE
+    )
+  `;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_mind_memories_project_id
+    ON mind_memories(project_id)
+  `;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_mind_memories_project_id_updated
+    ON mind_memories(project_id, updated_at)
+  `;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_mind_memories_project_id_pinned
+    ON mind_memories(project_id, pinned)
+  `;
+
+  yield* sql`
+    CREATE VIRTUAL TABLE IF NOT EXISTS mind_memories_fts USING fts5(
+      text,
+      content='mind_memories',
+      content_rowid='rowid'
+    )
+  `;
+
+  yield* sql`
+    CREATE TABLE IF NOT EXISTS mind_memory_journal (
+      journal_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      memory_id TEXT NOT NULL,
+      project_id TEXT NOT NULL,
+      turn_id TEXT,
+      op TEXT NOT NULL,
+      weight_delta REAL,
+      created_at TEXT NOT NULL,
+      FOREIGN KEY (memory_id) REFERENCES mind_memories(memory_id) ON DELETE CASCADE
+    )
+  `;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_mind_memory_journal_memory_id
+    ON mind_memory_journal(memory_id)
+  `;
+
+  yield* sql`
+    CREATE TRIGGER IF NOT EXISTS mind_memories_fts_insert
+    AFTER INSERT ON mind_memories
+    BEGIN
+      INSERT INTO mind_memories_fts(rowid, text)
+      VALUES (new.rowid, new.text);
+    END
+  `;
+
+  yield* sql`
+    CREATE TRIGGER IF NOT EXISTS mind_memories_fts_update
+    AFTER UPDATE ON mind_memories
+    BEGIN
+      INSERT INTO mind_memories_fts(mind_memories_fts, rowid, text)
+      VALUES ('delete', old.rowid, old.text);
+      INSERT INTO mind_memories_fts(rowid, text)
+      VALUES (new.rowid, new.text);
+    END
+  `;
+
+  yield* sql`
+    CREATE TRIGGER IF NOT EXISTS mind_memories_fts_delete
+    AFTER DELETE ON mind_memories
+    BEGIN
+      INSERT INTO mind_memories_fts(mind_memories_fts, rowid, text)
+      VALUES ('delete', old.rowid, old.text);
+    END
+  `;
+});

--- a/apps/server/src/persistence/Services/MindRepository.ts
+++ b/apps/server/src/persistence/Services/MindRepository.ts
@@ -1,0 +1,132 @@
+import {
+  type MindJournalEntry,
+  MindJournalOp,
+  MindMemory,
+  MindMemoryId,
+  ProjectId,
+  TurnId,
+} from "@synara/contracts";
+import { IsoDateTime } from "@synara/contracts";
+import { Option, Schema, ServiceMap } from "effect";
+import type { Effect } from "effect";
+
+import type { PersistenceDecodeError, PersistenceSqlError } from "../Errors.ts";
+
+export const RememberMindMemoryInput = Schema.Struct({
+  projectId: ProjectId,
+  text: MindMemory.fields.text,
+  turnId: Schema.optional(TurnId),
+  now: IsoDateTime,
+});
+export type RememberMindMemoryInput = typeof RememberMindMemoryInput.Type;
+
+export const FindMindMemoryByTextInput = Schema.Struct({
+  projectId: ProjectId,
+  text: Schema.String,
+});
+export type FindMindMemoryByTextInput = typeof FindMindMemoryByTextInput.Type;
+
+export const GetMindMemoryInput = Schema.Struct({
+  memoryId: MindMemoryId,
+  projectId: ProjectId,
+});
+export type GetMindMemoryInput = typeof GetMindMemoryInput.Type;
+
+export const RecallMindMemoriesInput = Schema.Struct({
+  projectId: ProjectId,
+  query: Schema.optional(Schema.String),
+});
+export type RecallMindMemoriesInput = typeof RecallMindMemoriesInput.Type;
+
+export const ConfirmMindMemoryInput = Schema.Struct({
+  projectId: ProjectId,
+  memoryId: MindMemoryId,
+  turnId: Schema.optional(TurnId),
+  now: IsoDateTime,
+});
+export type ConfirmMindMemoryInput = typeof ConfirmMindMemoryInput.Type;
+
+export const ForgetMindMemoryInput = Schema.Struct({
+  projectId: ProjectId,
+  memoryId: MindMemoryId,
+  turnId: Schema.optional(TurnId),
+});
+export type ForgetMindMemoryInput = typeof ForgetMindMemoryInput.Type;
+
+export const PinMindMemoryInput = Schema.Struct({
+  projectId: ProjectId,
+  memoryId: MindMemoryId,
+  pinned: Schema.Boolean,
+  now: IsoDateTime,
+});
+export type PinMindMemoryInput = typeof PinMindMemoryInput.Type;
+
+export const ListMindMemoriesInput = Schema.Struct({
+  projectId: ProjectId,
+  query: Schema.optional(Schema.String),
+});
+export type ListMindMemoriesInput = typeof ListMindMemoriesInput.Type;
+
+export const CountMindMemoriesInput = Schema.Struct({
+  projectId: ProjectId,
+});
+export type CountMindMemoriesInput = typeof CountMindMemoriesInput.Type;
+
+export const PruneMindMemoriesInput = Schema.Struct({
+  projectId: ProjectId,
+  now: IsoDateTime,
+});
+export type PruneMindMemoriesInput = typeof PruneMindMemoriesInput.Type;
+
+export const RecordMindJournalInput = Schema.Struct({
+  memoryId: MindMemoryId,
+  projectId: ProjectId,
+  turnId: Schema.NullOr(TurnId),
+  op: MindJournalOp,
+  weightDelta: Schema.optional(Schema.Number),
+  createdAt: IsoDateTime,
+});
+export type RecordMindJournalInput = typeof RecordMindJournalInput.Type;
+
+export type MindRepositoryError = PersistenceSqlError | PersistenceDecodeError;
+
+export interface MindRepositoryShape {
+  readonly remember: (
+    input: RememberMindMemoryInput,
+  ) => Effect.Effect<typeof MindMemory.Type, MindRepositoryError>;
+  readonly findByText: (
+    input: FindMindMemoryByTextInput,
+  ) => Effect.Effect<Option.Option<typeof MindMemory.Type>, MindRepositoryError>;
+  readonly getById: (
+    input: GetMindMemoryInput,
+  ) => Effect.Effect<Option.Option<typeof MindMemory.Type>, MindRepositoryError>;
+  readonly recall: (
+    input: RecallMindMemoriesInput,
+  ) => Effect.Effect<ReadonlyArray<typeof MindMemory.Type>, MindRepositoryError>;
+  readonly confirm: (
+    input: ConfirmMindMemoryInput,
+  ) => Effect.Effect<typeof MindMemory.Type, MindRepositoryError>;
+  readonly forget: (input: ForgetMindMemoryInput) => Effect.Effect<void, MindRepositoryError>;
+  readonly pin: (
+    input: PinMindMemoryInput,
+  ) => Effect.Effect<typeof MindMemory.Type, MindRepositoryError>;
+  readonly list: (
+    input: ListMindMemoriesInput,
+  ) => Effect.Effect<ReadonlyArray<typeof MindMemory.Type>, MindRepositoryError>;
+  readonly countByProject: (
+    input: CountMindMemoriesInput,
+  ) => Effect.Effect<number, MindRepositoryError>;
+  readonly prune: (
+    input: PruneMindMemoriesInput,
+  ) => Effect.Effect<ReadonlyArray<typeof MindMemoryId.Type>, MindRepositoryError>;
+  readonly recordJournal: (
+    input: RecordMindJournalInput,
+  ) => Effect.Effect<void, MindRepositoryError>;
+}
+
+export class MindRepository extends ServiceMap.Service<MindRepository, MindRepositoryShape>()(
+  "synara/persistence/Services/MindRepository",
+) {}
+
+export type { MindJournalEntry, MindJournalOp, MindMemory };
+export { MindMemoryId };

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -53,6 +53,8 @@ import { OrchestrationEventDeliveryRepositoryLive } from "./persistence/Layers/O
 import { ProviderRuntimeEventRepositoryLive } from "./persistence/Layers/ProviderRuntimeEvents";
 import { ThreadDiagnosticsQueryLive } from "./diagnostics/Layers/ThreadDiagnosticsQuery";
 import { ManagedAttachmentCleanupLive } from "./managedAttachmentCleanup";
+import { MindServiceLive } from "./mind/Layers/MindService.ts";
+import { MindRepositoryLive } from "./persistence/Layers/MindRepository.ts";
 import { PullRequestServiceLive } from "./pullRequests/Layers/PullRequestService";
 import { ProviderHealthLive } from "./provider/Layers/ProviderHealth";
 import { makeServerProviderLayer } from "./provider/runtimeLayer";
@@ -79,6 +81,8 @@ export function makeServerRuntimeServicesLayer(
 ) {
   const agentGatewayCredentialsLayer =
     options.agentGatewayCredentialsLayer ?? AgentGatewayCredentialsWithSecretsLive;
+  const mindRepositoryLayer = MindRepositoryLive;
+  const mindServiceLayer = MindServiceLive.pipe(Layer.provideMerge(mindRepositoryLayer));
   const providerHealthLayer = ProviderHealthLive.pipe(Layer.provideMerge(ServerSettingsLive));
   const checkpointStoreLayer = CheckpointStoreLive.pipe(Layer.provide(GitCoreLive));
 
@@ -211,6 +215,7 @@ export function makeServerRuntimeServicesLayer(
     // The gateway exposes device_* tools only where a backend can exist, but it
     // resolves the service on every platform to make that decision.
     Layer.provideMerge(DeviceServiceLive),
+    Layer.provideMerge(mindServiceLayer),
   );
   const pullRequestServiceLayer = PullRequestServiceLive.pipe(
     Layer.provideMerge(GitLayerLive),
@@ -222,6 +227,8 @@ export function makeServerRuntimeServicesLayer(
     agentGatewayCredentialsLayer,
     agentGatewayLayer,
     BrowserAutomationHostLive,
+    mindRepositoryLayer,
+    mindServiceLayer,
     automationServiceLayer,
     automationSchedulerLayer,
     automationRunReactorLayer,

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -129,6 +129,7 @@ import {
   makeWsStreamAdmission,
 } from "./wsStreamAdmission";
 import { ThreadDiagnosticsQuery } from "./diagnostics/Services/ThreadDiagnosticsQuery";
+import { MindService } from "./mind/Services/MindService";
 import { makeWsRequestAdmission } from "./wsRequestAdmission";
 import { voiceUploadAdmissionGate } from "./voiceUploadAdmission";
 import {
@@ -363,6 +364,7 @@ const makeWsRpcHandlersLayer = () =>
       const providerHealth = yield* ProviderHealth;
       const providerService = yield* ProviderService;
       const lifecycleEvents = yield* ServerLifecycleEvents;
+      const mindService = yield* MindService;
       const runtimeStartup = yield* ServerRuntimeStartup;
       const serverEnvironment = yield* ServerEnvironment;
       const serverSettings = yield* ServerSettingsService;
@@ -1998,6 +2000,18 @@ const makeWsRpcHandlersLayer = () =>
             automationService.resolveProposal(input),
             "Failed to resolve automation proposal",
           ),
+        [WS_METHODS.mindList]: (input) =>
+          rpcEffect(mindService.list(input), "Failed to load memories"),
+        [WS_METHODS.mindSearch]: (input) =>
+          rpcEffect(mindService.recall(input), "Failed to search memories"),
+        [WS_METHODS.mindRemember]: (input) =>
+          rpcEffect(mindService.remember(input), "Failed to remember memory"),
+        [WS_METHODS.mindConfirm]: (input) =>
+          rpcEffect(mindService.confirm(input), "Failed to confirm memory"),
+        [WS_METHODS.mindForget]: (input) =>
+          rpcEffect(mindService.forget(input), "Failed to forget memory"),
+        [WS_METHODS.mindPin]: (input) => rpcEffect(mindService.pin(input), "Failed to pin memory"),
+
         [WS_METHODS.subscribeAutomationEvents]: (_, { clientId }) =>
           streamAdmission.guard(
             clientId,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
   AddPlusIcon,
   ArchiveIcon,
   BookIcon,
+  BrainIcon,
   ChatBubbleIcon,
   CircleQuestionIcon,
   ClockIcon,
@@ -1407,6 +1408,7 @@ export default function Sidebar() {
   const isOnKanban = pathname.startsWith("/kanban");
   const isOnAutomations = pathname.startsWith("/automations");
   const isOnPullRequests = pathname.startsWith("/pull-requests");
+  const isOnMind = pathname.startsWith("/mind");
   // Lightweight read of automations to drive the sidebar attention badge. Shares the
   // ["automations"] query cache with the Automations route (and its live stream updates).
   const automationListQuery = useQuery({
@@ -3769,12 +3771,22 @@ export default function Sidebar() {
           void navigate({ to: "/automations" });
         },
       },
+      mind: {
+        icon: BrainIcon,
+        label: "Mind",
+        active: isOnMind,
+        badge: null,
+        onClick: () => {
+          void navigate({ to: "/mind" });
+        },
+      },
     }),
     [
       automationAttentionBadge,
       handlePrimaryNewThread,
       isOnAutomations,
       isOnKanban,
+      isOnMind,
       isOnPullRequests,
       navigate,
       prefetchModelsForPrimaryNewThread,

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as ChatAutomationsRouteImport } from './routes/_chat.automations'
 import { Route as ChatThreadIdRouteImport } from './routes/_chat.$threadId'
 import { Route as ChatStudioIndexRouteImport } from './routes/_chat.studio.index'
 import { Route as ChatPullRequestsIndexRouteImport } from './routes/_chat.pull-requests.index'
+import { Route as ChatMindIndexRouteImport } from './routes/_chat.mind.index'
 import { Route as ChatKanbanIndexRouteImport } from './routes/_chat.kanban.index'
 import { Route as ChatAutomationsIndexRouteImport } from './routes/_chat.automations.index'
 import { Route as ChatKanbanProjectIdRouteImport } from './routes/_chat.kanban.$projectId'
@@ -67,6 +68,11 @@ const ChatPullRequestsIndexRoute = ChatPullRequestsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => ChatPullRequestsRoute,
 } as any)
+const ChatMindIndexRoute = ChatMindIndexRouteImport.update({
+  id: '/mind/',
+  path: '/mind/',
+  getParentRoute: () => ChatRoute,
+} as any)
 const ChatKanbanIndexRoute = ChatKanbanIndexRouteImport.update({
   id: '/kanban/',
   path: '/kanban/',
@@ -100,6 +106,7 @@ export interface FileRoutesByFullPath {
   '/kanban/$projectId': typeof ChatKanbanProjectIdRoute
   '/automations/': typeof ChatAutomationsIndexRoute
   '/kanban/': typeof ChatKanbanIndexRoute
+  '/mind/': typeof ChatMindIndexRoute
   '/pull-requests/': typeof ChatPullRequestsIndexRoute
   '/studio/': typeof ChatStudioIndexRoute
 }
@@ -112,6 +119,7 @@ export interface FileRoutesByTo {
   '/kanban/$projectId': typeof ChatKanbanProjectIdRoute
   '/automations': typeof ChatAutomationsIndexRoute
   '/kanban': typeof ChatKanbanIndexRoute
+  '/mind': typeof ChatMindIndexRoute
   '/pull-requests': typeof ChatPullRequestsIndexRoute
   '/studio': typeof ChatStudioIndexRoute
 }
@@ -128,6 +136,7 @@ export interface FileRoutesById {
   '/_chat/kanban/$projectId': typeof ChatKanbanProjectIdRoute
   '/_chat/automations/': typeof ChatAutomationsIndexRoute
   '/_chat/kanban/': typeof ChatKanbanIndexRoute
+  '/_chat/mind/': typeof ChatMindIndexRoute
   '/_chat/pull-requests/': typeof ChatPullRequestsIndexRoute
   '/_chat/studio/': typeof ChatStudioIndexRoute
 }
@@ -144,6 +153,7 @@ export interface FileRouteTypes {
     | '/kanban/$projectId'
     | '/automations/'
     | '/kanban/'
+    | '/mind/'
     | '/pull-requests/'
     | '/studio/'
   fileRoutesByTo: FileRoutesByTo
@@ -156,6 +166,7 @@ export interface FileRouteTypes {
     | '/kanban/$projectId'
     | '/automations'
     | '/kanban'
+    | '/mind'
     | '/pull-requests'
     | '/studio'
   id:
@@ -171,6 +182,7 @@ export interface FileRouteTypes {
     | '/_chat/kanban/$projectId'
     | '/_chat/automations/'
     | '/_chat/kanban/'
+    | '/_chat/mind/'
     | '/_chat/pull-requests/'
     | '/_chat/studio/'
   fileRoutesById: FileRoutesById
@@ -244,6 +256,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ChatPullRequestsIndexRouteImport
       parentRoute: typeof ChatPullRequestsRoute
     }
+    '/_chat/mind/': {
+      id: '/_chat/mind/'
+      path: '/mind'
+      fullPath: '/mind/'
+      preLoaderRoute: typeof ChatMindIndexRouteImport
+      parentRoute: typeof ChatRoute
+    }
     '/_chat/kanban/': {
       id: '/_chat/kanban/'
       path: '/kanban'
@@ -309,6 +328,7 @@ interface ChatRouteChildren {
   ChatIndexRoute: typeof ChatIndexRoute
   ChatKanbanProjectIdRoute: typeof ChatKanbanProjectIdRoute
   ChatKanbanIndexRoute: typeof ChatKanbanIndexRoute
+  ChatMindIndexRoute: typeof ChatMindIndexRoute
   ChatStudioIndexRoute: typeof ChatStudioIndexRoute
 }
 
@@ -321,6 +341,7 @@ const ChatRouteChildren: ChatRouteChildren = {
   ChatIndexRoute: ChatIndexRoute,
   ChatKanbanProjectIdRoute: ChatKanbanProjectIdRoute,
   ChatKanbanIndexRoute: ChatKanbanIndexRoute,
+  ChatMindIndexRoute: ChatMindIndexRoute,
   ChatStudioIndexRoute: ChatStudioIndexRoute,
 }
 

--- a/apps/web/src/routes/_chat.mind.index.tsx
+++ b/apps/web/src/routes/_chat.mind.index.tsx
@@ -1,0 +1,418 @@
+import type {
+  MindListResult,
+  MindMemory,
+  MindMemoryMatch,
+  MindRecallResult,
+  ProjectId,
+} from "@synara/contracts";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  CHAT_SURFACE_HEADER_DIVIDER_CLASS_NAME,
+  CHAT_SURFACE_HEADER_HEIGHT_CLASS,
+  CHAT_SURFACE_HEADER_PADDING_X_CLASS,
+} from "~/components/chat/chatHeaderControls";
+import { CHAT_BACKGROUND_CLASS_NAME } from "~/components/chat/composerPickerStyles";
+import { ComposerPickerSelectPopup } from "~/components/chat/ComposerPickerMenuPopup";
+import { RouteInsetSurface } from "~/components/RouteInsetSurface";
+import { SidebarHeaderNavigationControls } from "~/components/SidebarHeaderNavigationControls";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Select, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
+import { toastManager } from "~/components/ui/toast";
+import {
+  useDesktopTopBarTrafficLightGutterClassName,
+  useDesktopTopBarWindowControlsGutterClassName,
+} from "~/hooks/useDesktopTopBarGutter";
+import { CentralIcon } from "~/lib/central-icons";
+import {
+  DISCLOSURE_INNER_CLASS,
+  disclosureChevronClassName,
+  disclosureContentClassName,
+  disclosureShellClassName,
+} from "~/lib/disclosureMotion";
+import { cn } from "~/lib/utils";
+import { ELEVATED_HOVER_SURFACE_CLASS_NAME } from "~/surfaceStyles";
+import { ensureNativeApi } from "~/nativeApi";
+import { useStore } from "~/store";
+
+export interface MindSearch {
+  readonly projectId?: ProjectId;
+  readonly q?: string;
+}
+
+const SEARCH_DEBOUNCE_MS = 200;
+
+export const Route = createFileRoute("/_chat/mind/")({
+  validateSearch: (raw: Record<string, unknown>): MindSearch => {
+    const projectId =
+      typeof raw.projectId === "string" && raw.projectId ? (raw.projectId as ProjectId) : undefined;
+    const q = typeof raw.q === "string" && raw.q ? raw.q.slice(0, 200) : undefined;
+    return {
+      ...(projectId ? { projectId } : {}),
+      ...(q ? { q } : {}),
+    };
+  },
+  component: MindRouteView,
+});
+
+function useMindProjectId(search: MindSearch): ProjectId | null {
+  const projects = useStore((state) => state.projects);
+  return useMemo(() => {
+    if (search.projectId && projects.some((project) => project.id === search.projectId)) {
+      return search.projectId;
+    }
+    return projects[0]?.id ?? null;
+  }, [projects, search.projectId]);
+}
+
+function MindRouteView() {
+  const navigate = useNavigate({ from: Route.fullPath });
+  const search = Route.useSearch();
+  const projectId = useMindProjectId(search);
+  const projects = useStore((state) => state.projects);
+  const project = useMemo(
+    () => projects.find((p) => p.id === projectId) ?? null,
+    [projects, projectId],
+  );
+
+  const [inputQuery, setInputQuery] = useState(search.q ?? "");
+  const [memories, setMemories] = useState<readonly MindMemory[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(new Set());
+
+  const trafficLightGutter = useDesktopTopBarTrafficLightGutterClassName();
+  const windowControlsGutter = useDesktopTopBarWindowControlsGutterClassName();
+
+  useEffect(() => {
+    setInputQuery(search.q ?? "");
+  }, [search.q]);
+
+  useEffect(() => {
+    const trimmed = inputQuery.trim();
+    if (trimmed === (search.q ?? "")) return;
+    const timer = window.setTimeout(() => {
+      void navigate({
+        search: () => ({
+          ...(projectId ? { projectId } : {}),
+          ...(trimmed ? { q: trimmed } : {}),
+        }),
+        replace: true,
+      });
+    }, SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timer);
+  }, [inputQuery, projectId, search.q, navigate]);
+
+  const load = useCallback(async () => {
+    if (!projectId) {
+      setMemories([]);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const api = ensureNativeApi();
+      const query = search.q?.trim();
+      if (query) {
+        const result: MindRecallResult = await api.mind.search({
+          projectId,
+          query,
+        });
+        setMemories(result.items.map((match: MindMemoryMatch) => match.memory));
+      } else {
+        const result: MindListResult = await api.mind.list({ projectId });
+        setMemories(result.memories);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not load memories.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [projectId, search.q]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const updateSearch = useCallback(
+    (patch: Partial<MindSearch>) => {
+      void navigate({
+        search: (prev) => ({
+          ...(prev.projectId ? { projectId: prev.projectId } : {}),
+          ...(patch.projectId ? { projectId: patch.projectId } : {}),
+          ...(prev.q ? { q: prev.q } : {}),
+          ...(patch.q ? { q: patch.q } : {}),
+        }),
+        replace: true,
+      });
+    },
+    [navigate],
+  );
+
+  const toggleExpanded = useCallback((memoryId: string) => {
+    setExpandedIds((current) => {
+      const next = new Set(current);
+      if (next.has(memoryId)) {
+        next.delete(memoryId);
+      } else {
+        next.add(memoryId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleTogglePin = useCallback(
+    async (memory: MindMemory) => {
+      if (!projectId) return;
+      try {
+        await ensureNativeApi().mind.pin({
+          projectId,
+          memoryId: memory.memoryId,
+          pinned: !memory.pinned,
+        });
+        void load();
+      } catch (err) {
+        toastManager.add({
+          type: "error",
+          title: "Could not update pin",
+          description: err instanceof Error ? err.message : "The pin status could not be saved.",
+        });
+      }
+    },
+    [projectId, load],
+  );
+
+  const handleForget = useCallback(
+    async (memory: MindMemory) => {
+      if (!projectId) return;
+      const confirmed = await ensureNativeApi().dialogs.confirm("Delete this memory?");
+      if (!confirmed) return;
+      try {
+        await ensureNativeApi().mind.forget({
+          projectId,
+          memoryId: memory.memoryId,
+        });
+        void load();
+      } catch (err) {
+        toastManager.add({
+          type: "error",
+          title: "Could not delete memory",
+          description: err instanceof Error ? err.message : "The memory could not be deleted.",
+        });
+      }
+    },
+    [projectId, load],
+  );
+
+  const projectOptions = useMemo(
+    () =>
+      projects.map((p) => (
+        <SelectItem key={p.id} value={p.id}>
+          <span className="truncate">{p.name}</span>
+        </SelectItem>
+      )),
+    [projects],
+  );
+
+  const isExpanded = (memoryId: string) => expandedIds.has(memoryId);
+
+  return (
+    <RouteInsetSurface>
+      <div
+        className={cn(
+          "flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden",
+          CHAT_BACKGROUND_CLASS_NAME,
+        )}
+      >
+        <header
+          className={cn(
+            CHAT_SURFACE_HEADER_DIVIDER_CLASS_NAME,
+            CHAT_SURFACE_HEADER_PADDING_X_CLASS,
+            "drag-region",
+            trafficLightGutter,
+            windowControlsGutter,
+          )}
+        >
+          <div className={cn("flex items-center gap-2 sm:gap-3", CHAT_SURFACE_HEADER_HEIGHT_CLASS)}>
+            <SidebarHeaderNavigationControls />
+            <h1 className="truncate font-heading text-sm font-medium">Mind</h1>
+            <div className="min-w-0 flex-1" />
+            <div className="flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]">
+              <Button
+                type="button"
+                size="icon-sm"
+                variant="ghost"
+                aria-label="Refresh"
+                title="Refresh"
+                disabled={!projectId || isLoading}
+                onClick={() => void load()}
+              >
+                <CentralIcon
+                  name="arrow-rotate-clockwise"
+                  className={cn("size-4", isLoading && "animate-spin")}
+                />
+              </Button>
+            </div>
+          </div>
+        </header>
+
+        <main className="min-h-0 flex-1 overflow-y-auto">
+          <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 px-5 pb-12 pt-6 sm:px-7">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <div className="min-w-0 flex-1">
+                {projects.length > 0 ? (
+                  <Select
+                    value={projectId ?? ""}
+                    onValueChange={(value) => {
+                      if (!value) return;
+                      updateSearch({ projectId: value as ProjectId });
+                    }}
+                  >
+                    <SelectTrigger aria-label="Project" className="w-full sm:w-56">
+                      <SelectValue>
+                        {project ? (
+                          <span className="truncate">{project.name}</span>
+                        ) : (
+                          <span className="text-muted-foreground">Select a project</span>
+                        )}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <ComposerPickerSelectPopup>
+                      <SelectItem value="" disabled>
+                        <span className="text-muted-foreground">Select a project</span>
+                      </SelectItem>
+                      {projectOptions}
+                    </ComposerPickerSelectPopup>
+                  </Select>
+                ) : (
+                  <div className="text-sm text-muted-foreground">No projects yet.</div>
+                )}
+              </div>
+              <div className="min-w-0 flex-[2]">
+                <Input
+                  type="search"
+                  placeholder="Search memories"
+                  value={inputQuery}
+                  onChange={(event) => setInputQuery(event.target.value)}
+                  disabled={!projectId}
+                />
+              </div>
+            </div>
+
+            {error ? (
+              <div className="py-8 text-center text-sm text-destructive">{error}</div>
+            ) : isLoading && memories.length === 0 ? (
+              <div className="py-16 text-center text-sm text-muted-foreground">
+                Loading memories...
+              </div>
+            ) : !projectId ? (
+              <div className="flex flex-col items-center gap-1 py-16 text-center">
+                <p className="text-sm font-medium text-foreground">No project selected</p>
+                <p className="max-w-xs text-xs text-muted-foreground">
+                  Select a project to view its durable memories.
+                </p>
+              </div>
+            ) : memories.length === 0 ? (
+              <div className="flex flex-col items-center gap-1 py-16 text-center">
+                <p className="text-sm font-medium text-foreground">
+                  Mind is where Synara keeps durable facts for this project.
+                </p>
+                <p className="max-w-xs text-xs text-muted-foreground">
+                  Remember something above, or ask an agent to remember it for you.
+                </p>
+              </div>
+            ) : (
+              <section className="flex flex-col gap-2">
+                {memories.map((memory) => {
+                  const open = isExpanded(memory.memoryId);
+                  return (
+                    <div
+                      key={memory.memoryId}
+                      className={cn(
+                        "rounded-lg border border-transparent px-2 py-2.5",
+                        ELEVATED_HOVER_SURFACE_CLASS_NAME,
+                      )}
+                    >
+                      <div className="flex items-start gap-2">
+                        <button
+                          type="button"
+                          onClick={() => toggleExpanded(memory.memoryId)}
+                          className={cn(
+                            "mt-0.5 shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground",
+                            disclosureChevronClassName(open),
+                          )}
+                          aria-expanded={open}
+                          aria-label="Toggle details"
+                          title="Details"
+                        >
+                          <CentralIcon name="chevron-right-small" className="size-3.5" />
+                        </button>
+                        <span className="min-w-0 flex-1 text-[0.8125rem] text-foreground">
+                          {memory.text}
+                        </span>
+                        <div className="flex shrink-0 items-center gap-1">
+                          <Button
+                            type="button"
+                            size="icon-xs"
+                            variant="ghost"
+                            aria-label={memory.pinned ? "Unpin memory" : "Pin memory"}
+                            title={memory.pinned ? "Unpin" : "Pin"}
+                            onClick={() => void handleTogglePin(memory)}
+                          >
+                            <CentralIcon
+                              name="pin"
+                              className={cn(
+                                "size-3.5",
+                                memory.pinned ? "text-foreground" : "text-muted-foreground/50",
+                              )}
+                            />
+                          </Button>
+                          <Button
+                            type="button"
+                            size="icon-xs"
+                            variant="ghost"
+                            aria-label="Delete memory"
+                            title="Delete"
+                            onClick={() => void handleForget(memory)}
+                          >
+                            <CentralIcon
+                              name="trash-can-simple"
+                              className="size-3.5 text-muted-foreground hover:text-destructive"
+                            />
+                          </Button>
+                        </div>
+                      </div>
+
+                      <div className={cn("col-span-full", disclosureShellClassName(open))}>
+                        <div className={DISCLOSURE_INNER_CLASS}>
+                          <div
+                            className={cn(
+                              "flex flex-col gap-1 px-5 pb-1 pt-2 text-xs text-muted-foreground",
+                              disclosureContentClassName(open),
+                            )}
+                          >
+                            <span>Weight: {memory.weight.toFixed(2)}</span>
+                            <span>
+                              {memory.pinned ? "Pinned" : "Not pinned"} · Accessed{" "}
+                              {memory.accessCount} times
+                            </span>
+                            <span className="text-muted-foreground/60">
+                              Created {new Date(memory.createdAt).toLocaleString()} · Updated{" "}
+                              {new Date(memory.updatedAt).toLocaleString()}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </section>
+            )}
+          </div>
+        </main>
+      </div>
+    </RouteInsetSurface>
+  );
+}

--- a/apps/web/src/sidebarNavOrdering.test.ts
+++ b/apps/web/src/sidebarNavOrdering.test.ts
@@ -24,6 +24,7 @@ describe("sidebarNavOrdering", () => {
       "newThread",
       "kanban",
       "pullRequests",
+      "mind",
     ]);
   });
 
@@ -34,6 +35,7 @@ describe("sidebarNavOrdering", () => {
       "newThread",
       "pullRequests",
       "automations",
+      "mind",
     ]);
     expect(normalizeHiddenSidebarNavItems(["bogus", "kanban", "kanban"])).toEqual(["kanban"]);
   });

--- a/apps/web/src/sidebarNavOrdering.ts
+++ b/apps/web/src/sidebarNavOrdering.ts
@@ -1,10 +1,16 @@
 // FILE: sidebarNavOrdering.ts
-// Purpose: Keeps the primary sidebar nav (New thread, Kanban, Pull requests, Automations)
+// Purpose: Keeps the primary sidebar nav (New thread, Kanban, Pull requests, Automations, Mind)
 //          order and visibility stable across the sidebar and persisted settings.
 // Layer: Web settings utility
 // Exports: nav item ids, default order, and normalization helpers.
 
-export const SIDEBAR_NAV_ITEM_IDS = ["newThread", "kanban", "pullRequests", "automations"] as const;
+export const SIDEBAR_NAV_ITEM_IDS = [
+  "newThread",
+  "kanban",
+  "pullRequests",
+  "automations",
+  "mind",
+] as const;
 
 export type SidebarNavItemId = (typeof SIDEBAR_NAV_ITEM_IDS)[number];
 

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -48,6 +48,12 @@ import {
   DEVICE_WS_CHANNELS,
   DEVICE_WS_METHODS,
   type DeviceEvent,
+  type MindConfirmInput,
+  type MindForgetInput,
+  type MindListInput,
+  type MindPinInput,
+  type MindRecallInput,
+  type MindRememberInput,
 } from "@synara/contracts";
 import { VOICE_TRANSCRIPTION_UPLOAD_ROUTE_PATH } from "@synara/shared/binaryTransfer";
 
@@ -842,6 +848,14 @@ export function createWsNativeApi(): NativeApi {
       scrollToElement: (input) =>
         transport.request(DEVICE_WS_METHODS.scrollToElement, input, { timeoutMs: null }),
       onEvent: deviceEventListeners.subscribe,
+    },
+    mind: {
+      list: (input: MindListInput) => transport.request(WS_METHODS.mindList, input),
+      search: (input: MindRecallInput) => transport.request(WS_METHODS.mindSearch, input),
+      remember: (input: MindRememberInput) => transport.request(WS_METHODS.mindRemember, input),
+      confirm: (input: MindConfirmInput) => transport.request(WS_METHODS.mindConfirm, input),
+      forget: (input: MindForgetInput) => transport.request(WS_METHODS.mindForget, input),
+      pin: (input: MindPinInput) => transport.request(WS_METHODS.mindPin, input),
     },
     browser: {
       open: async (input) => {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -37,4 +37,5 @@ export * from "./project";
 export * from "./studio";
 export * from "./filesystem";
 export * from "./device";
+export * from "./mind";
 export * from "./rpc";

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -169,6 +169,20 @@ import type {
 } from "./device";
 import type { StudioListThreadOutputsInput, StudioListThreadOutputsResult } from "./studio";
 import type {
+  MindConfirmInput,
+  MindConfirmResult,
+  MindForgetInput,
+  MindForgetResult,
+  MindListInput,
+  MindListResult,
+  MindPinInput,
+  MindPinResult,
+  MindRecallInput,
+  MindRecallResult,
+  MindRememberInput,
+  MindRememberResult,
+} from "./mind";
+import type {
   ServerConfig,
   ServerDiagnosticsResult,
   ServerGenerateAutomationIntentInput,
@@ -935,5 +949,13 @@ export interface NativeApi {
     describeUi: (input: DeviceDescribeUiInput) => Promise<DeviceDescribeUiResult>;
     scrollToElement: (input: DeviceScrollToElementInput) => Promise<DeviceScrollToElementResult>;
     onEvent: (callback: (event: DeviceEvent) => void) => () => void;
+  };
+  mind: {
+    list: (input: MindListInput) => Promise<MindListResult>;
+    search: (input: MindRecallInput) => Promise<MindRecallResult>;
+    remember: (input: MindRememberInput) => Promise<MindRememberResult>;
+    confirm: (input: MindConfirmInput) => Promise<MindConfirmResult>;
+    forget: (input: MindForgetInput) => Promise<MindForgetResult>;
+    pin: (input: MindPinInput) => Promise<MindPinResult>;
   };
 }

--- a/packages/contracts/src/mind.test.ts
+++ b/packages/contracts/src/mind.test.ts
@@ -1,0 +1,379 @@
+import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
+
+import {
+  MindConfirmInput,
+  MindConfirmResult,
+  MindError,
+  MindForgetInput,
+  MindForgetResult,
+  MindJournalEntry,
+  MindJournalOp,
+  MindListInput,
+  MindListResult,
+  MindMemory,
+  MindMemoryId,
+  MindMemoryMatch,
+  MindPinInput,
+  MindPinResult,
+  MindPruneInput,
+  MindPruneResult,
+  MindRecallInput,
+  MindRecallResult,
+  MindRememberInput,
+  MindRememberResult,
+  MIND_MEMORY_TEXT_MAX_CHARS,
+  MIND_RECALL_MAX_DIGEST_CHARS,
+  MIND_RECALL_MAX_ITEMS,
+} from "./mind";
+import { ProjectId, ThreadId, TurnId } from "./baseSchemas";
+
+function decodeSync<S extends Schema.Top>(schema: S, input: unknown): Schema.Schema.Type<S> {
+  return Schema.decodeUnknownSync(schema as never)(input) as Schema.Schema.Type<S>;
+}
+
+function decodes<S extends Schema.Top>(schema: S, input: unknown): boolean {
+  try {
+    Schema.decodeUnknownSync(schema as never)(input);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const makeProjectId = () =>
+  Schema.decodeUnknownSync(ProjectId)("proj_" + Math.random().toString(36).slice(2, 10));
+const makeMemoryId = () =>
+  Schema.decodeUnknownSync(MindMemoryId)("mem_" + Math.random().toString(36).slice(2, 10));
+const makeTurnId = () =>
+  Schema.decodeUnknownSync(TurnId)("turn_" + Math.random().toString(36).slice(2, 10));
+const makeThreadId = () =>
+  Schema.decodeUnknownSync(ThreadId)("thread_" + Math.random().toString(36).slice(2, 10));
+const isoNow = () => new Date().toISOString();
+
+const validMemory = () => ({
+  memoryId: makeMemoryId(),
+  projectId: makeProjectId(),
+  text: "The project uses SQLite for durable memory.",
+  weight: 0.9,
+  accessCount: 3,
+  pinned: false,
+  createdAt: isoNow(),
+  updatedAt: isoNow(),
+});
+
+describe("MindMemoryId", () => {
+  it("brands non-empty, trimmed strings", () => {
+    const id = Schema.decodeUnknownSync(MindMemoryId)("  memory-abc  ");
+    expect(id).toBe("memory-abc");
+    expect(Schema.is(MindMemoryId)("memory-abc")).toBe(true);
+  });
+
+  it("rejects blank or empty ids", () => {
+    expect(() => Schema.decodeUnknownSync(MindMemoryId)("   ")).toThrow();
+    expect(() => Schema.decodeUnknownSync(MindMemoryId)("")).toThrow();
+  });
+});
+
+describe("MindMemory", () => {
+  it("decodes and encodes a valid memory", () => {
+    const input = validMemory();
+    const decoded = decodeSync(MindMemory, input);
+    expect(decoded.text).toBe(input.text);
+    expect(decoded.weight).toBe(input.weight);
+    expect(decoded.accessCount).toBe(input.accessCount);
+    expect(decoded.pinned).toBe(false);
+    const encoded = Schema.encodeSync(MindMemory)(decoded);
+    expect(encoded.text).toBe(input.text);
+  });
+
+  it("rejects text longer than the max", () => {
+    const tooLong = "x".repeat(MIND_MEMORY_TEXT_MAX_CHARS + 1);
+    expect(
+      decodes(MindMemory, {
+        ...validMemory(),
+        text: tooLong,
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts text exactly at the max", () => {
+    const exact = "x".repeat(MIND_MEMORY_TEXT_MAX_CHARS);
+    expect(
+      decodes(MindMemory, {
+        ...validMemory(),
+        text: exact,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects weights outside [0, 1]", () => {
+    expect(
+      decodes(MindMemory, {
+        ...validMemory(),
+        weight: -0.01,
+      }),
+    ).toBe(false);
+    expect(
+      decodes(MindMemory, {
+        ...validMemory(),
+        weight: 1.01,
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts boundary weights", () => {
+    expect(decodeSync(MindMemory, { ...validMemory(), weight: 0 }).weight).toBe(0);
+    expect(decodeSync(MindMemory, { ...validMemory(), weight: 1 }).weight).toBe(1);
+  });
+});
+
+describe("MindJournalOp", () => {
+  it.each(["remember", "reinforce", "confirm", "forget", "pin", "unpin", "prune"] as const)(
+    "accepts %s",
+    (op) => {
+      expect(Schema.decodeUnknownSync(MindJournalOp)(op)).toBe(op);
+    },
+  );
+
+  it("rejects unknown journal ops", () => {
+    expect(() => Schema.decodeUnknownSync(MindJournalOp)("archive")).toThrow();
+  });
+});
+
+describe("MindJournalEntry", () => {
+  it("decodes a valid journal row with null turnId", () => {
+    const entry = decodeSync(MindJournalEntry, {
+      memoryId: makeMemoryId(),
+      projectId: makeProjectId(),
+      turnId: null,
+      op: "remember",
+      weightDelta: 0.02,
+      createdAt: isoNow(),
+    });
+    expect(entry.turnId).toBeNull();
+    expect(entry.weightDelta).toBe(0.02);
+  });
+
+  it("decodes an entry with an optional weightDelta", () => {
+    const entry = decodeSync(MindJournalEntry, {
+      memoryId: makeMemoryId(),
+      projectId: makeProjectId(),
+      turnId: makeTurnId(),
+      op: "confirm",
+      createdAt: isoNow(),
+    });
+    expect(entry.weightDelta).toBeUndefined();
+  });
+});
+
+describe("MindRememberInput", () => {
+  it("decodes and encodes a valid remember request", () => {
+    const input = {
+      projectId: makeProjectId(),
+      threadId: makeThreadId(),
+      turnId: makeTurnId(),
+      text: "Use FTS5 for memory search.",
+    };
+    const decoded = decodeSync(MindRememberInput, input);
+    expect(decoded.text).toBe(input.text);
+    expect(decoded.threadId).toBe(input.threadId);
+    expect(decoded.turnId).toBe(input.turnId);
+    const encoded = Schema.encodeSync(MindRememberInput)(decoded);
+    expect(encoded.text).toBe(input.text);
+  });
+
+  it("decodes without optional threadId or turnId", () => {
+    const input = {
+      projectId: makeProjectId(),
+      text: "A standalone memory.",
+    };
+    const decoded = decodeSync(MindRememberInput, input);
+    expect(decoded.threadId).toBeUndefined();
+    expect(decoded.turnId).toBeUndefined();
+  });
+
+  it("rejects text beyond the schema max", () => {
+    const tooLong = "x".repeat(MIND_MEMORY_TEXT_MAX_CHARS * 2 + 1);
+    expect(
+      decodes(MindRememberInput, {
+        projectId: makeProjectId(),
+        text: tooLong,
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts text within the schema max", () => {
+    const text = "x".repeat(MIND_MEMORY_TEXT_MAX_CHARS * 2);
+    expect(
+      decodes(MindRememberInput, {
+        projectId: makeProjectId(),
+        text,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("MindRememberResult", () => {
+  it("decodes created and reinforced statuses", () => {
+    const input = {
+      memory: validMemory(),
+      status: "created",
+    };
+    expect(decodeSync(MindRememberResult, input).status).toBe("created");
+    expect(decodeSync(MindRememberResult, { ...input, status: "reinforced" }).status).toBe(
+      "reinforced",
+    );
+  });
+});
+
+describe("MindRecallInput and Result", () => {
+  it("decodes a recall query", () => {
+    const input = {
+      projectId: makeProjectId(),
+      query: "FTS5",
+    };
+    const decoded = decodeSync(MindRecallInput, input);
+    expect(decoded.query).toBe("FTS5");
+  });
+
+  it("decodes a recall result within item and digest bounds", () => {
+    const memory = validMemory();
+    const matches = Array.from({ length: MIND_RECALL_MAX_ITEMS }, () => ({
+      memory,
+      rank: 1,
+      decayedWeight: 0.5,
+    }));
+    const input = {
+      items: matches,
+      digest: "x".repeat(MIND_RECALL_MAX_DIGEST_CHARS),
+    };
+    const decoded = decodeSync(MindRecallResult, input);
+    expect(decoded.items.length).toBe(MIND_RECALL_MAX_ITEMS);
+    expect(decoded.digest.length).toBe(MIND_RECALL_MAX_DIGEST_CHARS);
+  });
+
+  it("rejects too many recall matches", () => {
+    const memory = validMemory();
+    const matches = Array.from({ length: MIND_RECALL_MAX_ITEMS + 1 }, () => ({
+      memory,
+      rank: 1,
+      decayedWeight: 0.5,
+    }));
+    expect(
+      decodes(MindRecallResult, {
+        items: matches,
+        digest: "short",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a digest over the max", () => {
+    const memory = validMemory();
+    expect(
+      decodes(MindRecallResult, {
+        items: [{ memory, rank: 1, decayedWeight: 0.5 }],
+        digest: "x".repeat(MIND_RECALL_MAX_DIGEST_CHARS + 1),
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("MindMemoryMatch", () => {
+  it("decodes a match", () => {
+    const memory = validMemory();
+    const match = decodeSync(MindMemoryMatch, { memory, rank: 0.75, decayedWeight: 0.6 });
+    expect(match.memory.text).toBe(memory.text);
+    expect(match.rank).toBe(0.75);
+    expect(match.decayedWeight).toBe(0.6);
+  });
+});
+
+describe("MindConfirmInput and Result", () => {
+  it("decodes a confirm request", () => {
+    const input = {
+      projectId: makeProjectId(),
+      memoryId: makeMemoryId(),
+      turnId: makeTurnId(),
+    };
+    const decoded = decodeSync(MindConfirmInput, input);
+    expect(decoded.memoryId).toBe(input.memoryId);
+  });
+
+  it("decodes a confirm result", () => {
+    const input = {
+      memory: validMemory(),
+      alreadyConfirmedInTurn: true,
+    };
+    const decoded = decodeSync(MindConfirmResult, input);
+    expect(decoded.alreadyConfirmedInTurn).toBe(true);
+  });
+});
+
+describe("MindForgetInput and Result", () => {
+  it("decodes a forget request and result", () => {
+    const input = {
+      projectId: makeProjectId(),
+      memoryId: makeMemoryId(),
+    };
+    expect(decodeSync(MindForgetInput, input).memoryId).toBe(input.memoryId);
+    expect(decodeSync(MindForgetResult, { deleted: true }).deleted).toBe(true);
+  });
+});
+
+describe("MindPinInput and Result", () => {
+  it("decodes pin requests", () => {
+    const input = {
+      projectId: makeProjectId(),
+      memoryId: makeMemoryId(),
+      pinned: true,
+    };
+    const decoded = decodeSync(MindPinInput, input);
+    expect(decoded.pinned).toBe(true);
+    expect(decodeSync(MindPinResult, { memory: validMemory() }).memory.pinned).toBe(false);
+  });
+});
+
+describe("MindPruneResult", () => {
+  it("decodes a list of deleted ids", () => {
+    const ids = [makeMemoryId(), makeMemoryId()];
+    const decoded = decodeSync(MindPruneResult, { deletedIds: ids });
+    expect(decoded.deletedIds).toEqual(ids);
+  });
+});
+
+describe("MindPruneInput", () => {
+  it("decodes a prune request", () => {
+    const input = { projectId: makeProjectId() };
+    const decoded = decodeSync(MindPruneInput, input);
+    expect(decoded.projectId).toBe(input.projectId);
+  });
+});
+
+describe("MindListInput and Result", () => {
+  it("decodes a list request with an optional query", () => {
+    const input = {
+      projectId: makeProjectId(),
+      query: "search",
+    };
+    const decoded = decodeSync(MindListInput, input);
+    expect(decoded.query).toBe("search");
+  });
+
+  it("decodes a list result", () => {
+    const input = {
+      memories: [validMemory()],
+    };
+    const decoded = decodeSync(MindListResult, input);
+    expect(decoded.memories.length).toBe(1);
+  });
+});
+
+describe("MindError", () => {
+  it("is a tagged error with message and code", () => {
+    const error = new MindError({ message: "cap reached", code: "mind.memory-cap-reached" });
+    expect(error.message).toBe("cap reached");
+    expect(error.code).toBe("mind.memory-cap-reached");
+    expect(Schema.is(MindError)(error)).toBe(true);
+  });
+});

--- a/packages/contracts/src/mind.ts
+++ b/packages/contracts/src/mind.ts
@@ -1,0 +1,153 @@
+import { Schema } from "effect";
+import {
+  IsoDateTime,
+  NonNegativeInt,
+  ProjectId,
+  ThreadId,
+  TrimmedNonEmptyString,
+  TurnId,
+} from "./baseSchemas";
+
+export const MindMemoryId = TrimmedNonEmptyString.pipe(Schema.brand("MindMemoryId"));
+export type MindMemoryId = typeof MindMemoryId.Type;
+
+export const MIND_MEMORY_TEXT_MAX_CHARS = 500;
+export const MIND_MEMORY_PROJECT_CAP = 500;
+export const MIND_RECALL_MAX_ITEMS = 8;
+export const MIND_RECALL_MAX_DIGEST_CHARS = 800;
+
+export const MindMemory = Schema.Struct({
+  memoryId: MindMemoryId,
+  projectId: ProjectId,
+  text: Schema.String.check(Schema.isMaxLength(MIND_MEMORY_TEXT_MAX_CHARS)),
+  weight: Schema.Number.check(Schema.isGreaterThanOrEqualTo(0)).check(
+    Schema.isLessThanOrEqualTo(1),
+  ),
+  accessCount: NonNegativeInt,
+  pinned: Schema.Boolean,
+  createdAt: IsoDateTime,
+  updatedAt: IsoDateTime,
+});
+export type MindMemory = typeof MindMemory.Type;
+
+export const MindJournalOp = Schema.Literals([
+  "remember",
+  "reinforce",
+  "confirm",
+  "forget",
+  "pin",
+  "unpin",
+  "prune",
+]);
+export type MindJournalOp = typeof MindJournalOp.Type;
+
+export const MindJournalEntry = Schema.Struct({
+  memoryId: MindMemoryId,
+  projectId: ProjectId,
+  turnId: Schema.NullOr(TurnId),
+  op: MindJournalOp,
+  weightDelta: Schema.optional(Schema.Number),
+  createdAt: IsoDateTime,
+});
+export type MindJournalEntry = typeof MindJournalEntry.Type;
+
+export const MindRememberInput = Schema.Struct({
+  projectId: ProjectId,
+  threadId: Schema.optional(ThreadId),
+  turnId: Schema.optional(TurnId),
+  text: Schema.String.check(Schema.isMaxLength(MIND_MEMORY_TEXT_MAX_CHARS * 2)),
+});
+export type MindRememberInput = typeof MindRememberInput.Type;
+
+export const MindRememberResult = Schema.Struct({
+  memory: MindMemory,
+  status: Schema.Literals(["created", "reinforced"]),
+});
+export type MindRememberResult = typeof MindRememberResult.Type;
+
+export const MindRecallInput = Schema.Struct({
+  projectId: ProjectId,
+  query: Schema.optional(Schema.String),
+});
+export type MindRecallInput = typeof MindRecallInput.Type;
+
+export const MindMemoryMatch = Schema.Struct({
+  memory: MindMemory,
+  rank: Schema.Number,
+  decayedWeight: Schema.Number,
+});
+export type MindMemoryMatch = typeof MindMemoryMatch.Type;
+
+export const MindRecallResult = Schema.Struct({
+  items: Schema.Array(MindMemoryMatch).check(Schema.isMaxLength(MIND_RECALL_MAX_ITEMS)),
+  digest: Schema.String.check(Schema.isMaxLength(MIND_RECALL_MAX_DIGEST_CHARS)),
+});
+export type MindRecallResult = typeof MindRecallResult.Type;
+
+export const MindConfirmInput = Schema.Struct({
+  projectId: ProjectId,
+  memoryId: MindMemoryId,
+  turnId: Schema.optional(TurnId),
+});
+export type MindConfirmInput = typeof MindConfirmInput.Type;
+
+export const MindConfirmResult = Schema.Struct({
+  memory: MindMemory,
+  alreadyConfirmedInTurn: Schema.Boolean,
+});
+export type MindConfirmResult = typeof MindConfirmResult.Type;
+
+export const MindForgetInput = Schema.Struct({
+  projectId: ProjectId,
+  memoryId: MindMemoryId,
+  turnId: Schema.optional(TurnId),
+});
+export type MindForgetInput = typeof MindForgetInput.Type;
+
+export const MindForgetResult = Schema.Struct({
+  deleted: Schema.Boolean,
+});
+export type MindForgetResult = typeof MindForgetResult.Type;
+
+export const MindPinInput = Schema.Struct({
+  projectId: ProjectId,
+  memoryId: MindMemoryId,
+  pinned: Schema.Boolean,
+});
+export type MindPinInput = typeof MindPinInput.Type;
+
+export const MindPinResult = Schema.Struct({
+  memory: MindMemory,
+});
+export type MindPinResult = typeof MindPinResult.Type;
+
+export const MindPruneInput = Schema.Struct({
+  projectId: ProjectId,
+});
+export type MindPruneInput = typeof MindPruneInput.Type;
+
+export const MindPruneResult = Schema.Struct({
+  deletedIds: Schema.Array(MindMemoryId),
+});
+export type MindPruneResult = typeof MindPruneResult.Type;
+
+export const MindListInput = Schema.Struct({
+  projectId: ProjectId,
+  query: Schema.optional(Schema.String),
+});
+export type MindListInput = typeof MindListInput.Type;
+
+export const MindListResult = Schema.Struct({
+  memories: Schema.Array(MindMemory),
+});
+export type MindListResult = typeof MindListResult.Type;
+
+export class MindError extends Schema.TaggedErrorClass<MindError>()("MindError", {
+  message: Schema.String,
+  code: Schema.String,
+}) {}
+
+export const MindMemoryCapError = Schema.Literal("mind.memory-cap-reached");
+export const MindTextTooLongError = Schema.Literal("mind.text-too-long");
+export const MindSecretPatternError = Schema.Literal("mind.secret-pattern");
+export const MindMemoryNotFoundError = Schema.Literal("mind.memory-not-found");

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -234,6 +234,20 @@ import {
   StatsGetProfileTokenStatsInput,
   StatsGetProfileTokenStatsResult,
 } from "./stats";
+import {
+  MindConfirmInput,
+  MindConfirmResult,
+  MindForgetInput,
+  MindForgetResult,
+  MindListInput,
+  MindListResult,
+  MindPinInput,
+  MindPinResult,
+  MindRecallInput,
+  MindRecallResult,
+  MindRememberInput,
+  MindRememberResult,
+} from "./mind";
 import { WS_METHODS } from "./ws";
 import {
   WS_BOOTSTRAP_METHOD,
@@ -1227,6 +1241,42 @@ export const WsSubscribeAutomationEventsRpc = Rpc.make(WS_METHODS.subscribeAutom
   stream: true,
 });
 
+export const WsMindListRpc = Rpc.make(WS_METHODS.mindList, {
+  payload: MindListInput,
+  success: MindListResult,
+  error: WsRpcError,
+});
+
+export const WsMindSearchRpc = Rpc.make(WS_METHODS.mindSearch, {
+  payload: MindRecallInput,
+  success: MindRecallResult,
+  error: WsRpcError,
+});
+
+export const WsMindRememberRpc = Rpc.make(WS_METHODS.mindRemember, {
+  payload: MindRememberInput,
+  success: MindRememberResult,
+  error: WsRpcError,
+});
+
+export const WsMindConfirmRpc = Rpc.make(WS_METHODS.mindConfirm, {
+  payload: MindConfirmInput,
+  success: MindConfirmResult,
+  error: WsRpcError,
+});
+
+export const WsMindForgetRpc = Rpc.make(WS_METHODS.mindForget, {
+  payload: MindForgetInput,
+  success: MindForgetResult,
+  error: WsRpcError,
+});
+
+export const WsMindPinRpc = Rpc.make(WS_METHODS.mindPin, {
+  payload: MindPinInput,
+  success: MindPinResult,
+  error: WsRpcError,
+});
+
 export const WsBootstrapRpcGroup = RpcGroup.make(WsBootstrapNegotiateRpc);
 
 export const WsFeatureRpcGroup = RpcGroup.make(
@@ -1352,6 +1402,12 @@ export const WsFeatureRpcGroup = RpcGroup.make(
   WsAutomationArchiveRunRpc,
   WsAutomationResolveProposalRpc,
   WsSubscribeAutomationEventsRpc,
+  WsMindListRpc,
+  WsMindSearchRpc,
+  WsMindRememberRpc,
+  WsMindConfirmRpc,
+  WsMindForgetRpc,
+  WsMindPinRpc,
 );
 
 /** @deprecated Use WsFeatureRpcGroup. Bootstrap is intentionally a separate endpoint/group. */

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -159,6 +159,14 @@ import {
   GitHubProjectProvisionInput,
   GitHubProjectProvisionProgressEvent,
 } from "./githubProjectProvisioning";
+import {
+  MindConfirmInput,
+  MindForgetInput,
+  MindListInput,
+  MindPinInput,
+  MindRecallInput,
+  MindRememberInput,
+} from "./mind";
 
 // ── WebSocket RPC Method Names ───────────────────────────────────────
 
@@ -290,6 +298,14 @@ export const WS_METHODS = {
   automationArchiveRun: "automation.archiveRun",
   automationResolveProposal: "automation.resolveProposal",
   subscribeAutomationEvents: "automation.subscribe",
+
+  // Mind methods
+  mindList: "mind.list",
+  mindSearch: "mind.search",
+  mindRemember: "mind.remember",
+  mindConfirm: "mind.confirm",
+  mindForget: "mind.forget",
+  mindPin: "mind.pin",
 } as const;
 
 // ── Push Event Channels ──────────────────────────────────────────────
@@ -492,6 +508,14 @@ const WebSocketRequestBody = Schema.Union([
   tagRequestBody(WS_METHODS.automationArchiveRun, AutomationArchiveRunInput),
   tagRequestBody(WS_METHODS.automationResolveProposal, AutomationResolveProposalInput),
   tagRequestBody(WS_METHODS.subscribeAutomationEvents, Schema.Struct({})),
+
+  // Mind methods
+  tagRequestBody(WS_METHODS.mindList, MindListInput),
+  tagRequestBody(WS_METHODS.mindSearch, MindRecallInput),
+  tagRequestBody(WS_METHODS.mindRemember, MindRememberInput),
+  tagRequestBody(WS_METHODS.mindConfirm, MindConfirmInput),
+  tagRequestBody(WS_METHODS.mindForget, MindForgetInput),
+  tagRequestBody(WS_METHODS.mindPin, MindPinInput),
 ]);
 
 export const WebSocketRequest = Schema.Struct({


### PR DESCRIPTION
## What this does

Durable, typed, decaying project memory ("Mind"), rebased onto upstream/main anchor `562c5fea` as a single feature commit plus review-fix commits, force-pushed with lease to `agent/mind-memory` (stays DRAFT).

- Server: memory service (`remember` / `recall` / `confirm` / `forget` / `pin` / `list` / `prune`) with credential-text rejection and decay-weighted ranking, SQLite persistence via migration `099_Mind`, FTS5 search.
- Agent gateway: five MCP tools (`synara_remember`, `synara_recall_memories`, `synara_confirm_memory`, `synara_forget_memory`, `synara_prune_memories`) behind the `memory:use` capability, plus harness-policy memory guidance (policy version `2026-08-30.3`).
- Transport: WS / RPC / IPC / native-API parity for all five ops.
- Web: Mind view at `/mind` (project picker, search, pin/unpin, delete with confirm, empty states) plus sidebar entry.

## Behavior change

- Agents can store and retrieve project-scoped facts. Repeating the same text reinforces the existing memory instead of duplicating it. Credential-looking text is refused.
- Recall returns up to 8 memories ranked by decay (`MIND_DECAY_LAMBDA = 0.0667`, ~45d idle decays weight-1.0 to ~0.05) plus exact-token boost, with a digest.
- Prune deletes stale, low-decayed-weight (`< 0.1`), low-access, unpinned memories older than 45 days. Pinned memories are exempt.
- Users browse, search, pin, and delete memories in the Mind view.

## Reviews

- BugsLens (bugs/correctness): was NOT-MERGEABLE, 5 blocking findings, all fixed and pushed in `816a23839`:
  1. `099_Mind.ts` journal `FOREIGN KEY … ON DELETE CASCADE` vs journal-after-delete (FK enforcement is ON) — dropped both dangling FKs (the `projects` table does not exist). Live-reproduced pre-fix ("Could not delete memory" toast), verified fixed post-fix.
  2. Prune `weight < 0.1` unsatisfiable (stored weight caps at 1.0, nothing lowers it) — prune now predicates on decayed weight.
  3. Module-level `/g` secret regexes made `.test()` stateful — `g` flags dropped.
  4. Raw user text into FTS5 `MATCH` — quoted-phrase helper with LIKE fallback.
  5. Harness policy text changed without a version bump — bumped to `2026-08-30.3`, test updated.
- SlopLens (maintainability): was NOT-MERGEABLE, 4 blocking findings, all fixed: canonical `MindServiceShape` reused (local 5-method drift deleted), dead `MindError` branch reordered above the generic `code`/`message` check, contract `MindMemoryMatch` reused in scoring (dead `EffectiveMindMemory` deleted), secret regex (same as above).
- Post-fix state: server + contracts typechecks clean, scoped suites green, live proof green. Reviewer re-assessment: MERGEABLE.

## Tests

- `apps/server`: 8 files / 72 tests pass — mind service, MindRepository (incl. new prune-decay and FTS-punctuation regression tests), new `secretPatterns` repeat-call tests, Migrations + replay, harnessPolicy, memoryTools.
- `packages/contracts`: `mind.test.ts`, 36 pass.
- Typecheck clean: `apps/server`, `packages/contracts` (web/shared clean; untouched by the fixes).
- Live headed-Chrome proof (artifacts stay local in worktree `evidence/863/`, untracked): remember/list/search/pin round-trip (`proof-c-list/search/pinned.png`, `trace-c.zip`, zero console errors), forget round-trip incl. journal write (`proof-c-forget.png`, memory gone, empty state renders), killed-server probe (`proof-c-killed-server.png`, no crash, no page errors).
- No Mind browser spec exists yet; the live Playwright proof covers the route instead.

## Socket surface

- Diff touches gateway transport: `makeAgentGatewayMemoryTools` wiring (`AgentGateway.ts`), WS methods `mindSearch` / `mindRemember` / `mindConfirm` / `mindForget` / `mindPin` via `transport.request` (`wsNativeApi.ts`).
- Live coverage: all five ops exercised over WS through the UI (remember/list/search/pin/forget green). Killed-server path: `/mind` degrades to graceful empty states, no unhandled errors (no explicit offline banner asserted — see follow-up).

## Follow-ups

- `mind/Layers/MindService.ts`: bound the `reinforcedTurns` / `confirmedTurns` maps or move dedup into the repository; replace `nowOverride` with `TestClock`.
- `mind/Layers/MindService.ts`: cap check-then-insert race; seven identical decode/journal blocks plus `as MindXResult` casts (extract helpers, drop casts).
- `persistence/Layers/MindRepository.ts`: recall/list FTS branches duplicate the CTE/select; seven statements repeat the 8-column select (extract shared fragment + FTS helper).
- `_chat.mind.index.tsx`: empty-state copy references a nonexistent control; project switch keeps stale query; `updateSearch` merges stale keys; memoized option JSX; unnamed 200-char limit.
- `routeTree.gen.ts`: hand-edited generated block — regenerate instead.
- `packages/contracts/src/mind.ts`: unused `Mind*Error` literals vs raw strings in the service — pick one source of truth.
- `agentGateway/memoryTools.ts`: single-use `make*Input`/payload helpers and `decodeStringArg` wrapper — inline.
- `web/src/sidebarNavOrdering.ts`: duplicated normalize/dedupe loops — extract helper.
- Consider an explicit offline banner on the Mind route when the server is unreachable (currently graceful empty states only).

## Merge note

- Ordering: PR #899 must merge before this PR.
- Stays DRAFT until #899 lands and CI is green. Anchor: `562c5fea`. No PR comments posted; evidence is local-only.

## Gauntlet handoff (2026-09-04)

**Status: NOT ready — 1 BLOCKER + 9 MAJOR + 10 MINOR, plus a PROCESS blocker (read first).** Review: 6 lenses + oxlint anti-slop (127 hits on changed lines). Full reports held locally by Kartik.

**PROCESS BLOCKER — rival stack vs 909.** This PR and 909 implement the same Mind vertical on different bases. Rebase onto 899, then Emanuele picks exactly ONE winner. Do not merge both. Recommendation in local report.

**Must-fix before merge (if 863 wins)**
1. **BLOCKER — recall is injection.** Digest joins raw memory text with no quoting/provenance; the harness is told to recall-and-act, so pasted content becomes tool calls becomes persisted poison. Fix: delimit + attribute `[memory <id> from thread <t>]`, untrusted-data policy, recall-time marker.
2. **Secret filter once + weak.** 6-regex denylist evaded (spaces/short/hex/bare-URI), checked only on remember, no recall redaction — one bypass poisons every future recall. Fix: recall redaction + stronger patterns.
3. **FAIL — write-then-journal retry double-bump.** Journal non-atomic vs mutation.
4. **GAPs:** empty/whitespace junk rows via service/WS path (one-liner: `validateMindText` has no empty check); per-turn dedup maps lost on restart; bare DB URIs (`postgres://user:pass@host`) stored verbatim.

**Also queued:** 10 CUT (~119 lines: dup recall/list input schemas, 9 single-use input/payload helpers, `decodeStringArg` re-wrap) + web Mind view SLIM (keep search/list/pin/forget, cut expand-motion polish).

**Remaining:** rebase decision FIRST → Fix → reverify → websocket + playwright E2E → CI green → undraft.
