### PR TITLE
docs: add ATTRIBUTION.md

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -1,31 +1,20 @@
 # Attribution
 
-Synara adapts ideas and, occasionally, code from other open-source projects. This file
-records the significant ones so credit is visible in one place.
+Synara adapts ideas and sometimes code from other open source projects. This file credits the ones that shaped a feature.
 
-What belongs here:
+What belongs here: code, constants, or prose Synara copied or adapted, and features materially shaped with no code copied.
 
-- Projects whose code, designs, constants, or prose Synara copied or adapted.
-- Projects that materially shaped a Synara feature, even when no code was copied.
+What does not belong here: ordinary dependencies, even large ones (Effect, Pi). `package.json` and `bun.lock` already record those with their licenses.
 
-What does not belong here:
-
-- Ordinary dependencies. `package.json` and `bun.lock` already record those, and each
-  package ships its own license.
-
-Attribution complements licenses; it never replaces them. If code or prose is copied or
-derived from an MIT/BSD-style project, carry the upstream copyright and permission notice
-alongside the copied portions as the license requires. A row in this table is not a
-substitute.
-
-## Adapted work
-
-| Project | Author   | Source                           | License | Used in                                                                                                                        | Nature                                                                                                      |
-| ------- | -------- | -------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
-| mind    | Da7-Tech | https://github.com/Da7-Tech/mind | MIT     | Mind memory feature — storage foundation in https://github.com/Emanuele-web04/synara/pull/899, feature integration in progress | Adapted — memory lifecycle concepts, scoring constants, and near-verbatim standing-order prose are adapted. |
+Credit is not a license notice. If you copy code or prose, carry the upstream notice with it.
+<!-- Style: no em dashes in this file. Use commas or colons. -->
+## Adapted work (license notice required)
+| Project | Author | Source | License | Used in + How |
+| ------- | ------ | ------ | ------- | ------------- |
+| mind | Da7-Tech | https://github.com/Da7-Tech/mind | MIT | Mind memory feature: storage foundation (PR #899: memory tables, scoring constants; upstream snapshot 2026-09-04) and standing-order prose (PR #909). Adapted: scoring constants, near-verbatim standing-order prose. |
 
 ### License notice for mind
-
+<!-- DO NOT EDIT below. Byte-match with upstream Da7-Tech/mind LICENSE. Do not move behind a link or details tag. -->
 ```text
 MIT License
 
@@ -50,9 +39,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-## Inspiration and reference (no code copied)
-
-| Project      | Author                      | Source                                    | License    | Used in                                                                         | Nature                                                                 |
-| ------------ | --------------------------- | ----------------------------------------- | ---------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| codex        | OpenAI                      | https://github.com/openai/codex           | Apache-2.0 | Codex app-server protocol handling (`apps/server/src/codexAppServerManager.ts`) | Inspired. Protocol and behavior reference.                             |
-| CodexMonitor | Thomas Ricouard (Dimillian) | https://github.com/Dimillian/CodexMonitor | MIT        | Agent-session UX flows and operational safeguards                               | Inspired. Reference implementation, per `AGENTS.md` "Reference Repos". |
+## Inspiration and reference (no code copied, no notice needed)
+| Project | Author | Source | License | Used in + How |
+| ------- | ------ | ------ | ------- | ------------- |
+| codex | OpenAI | https://github.com/openai/codex | Apache-2.0 | Codex app-server protocol handling (`apps/server/src/codexAppServerManager.ts`). Inspired: protocol reference. |
+| CodexMonitor | Thomas Ricouard (Dimillian) | https://github.com/Dimillian/CodexMonitor | MIT | Agent-session UX flows and operational safeguards (AGENTS.md "Reference Repos"). Inspired: reference implementation. |

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -8,13 +8,17 @@ What does not belong here: ordinary dependencies, even large ones (Effect, Pi). 
 
 Credit is not a license notice. If you copy code or prose, carry the upstream notice with it.
 <!-- Style: no em dashes in this file. Use commas or colons. -->
+
 ## Adapted work (license notice required)
-| Project | Author | Source | License | Used in + How |
-| ------- | ------ | ------ | ------- | ------------- |
-| mind | Da7-Tech | https://github.com/Da7-Tech/mind | MIT | Mind memory feature: storage foundation (PR #899: memory tables, scoring constants; upstream snapshot 2026-09-04) and standing-order prose (PR #909). Adapted: scoring constants, near-verbatim standing-order prose. |
+
+| Project | Author   | Source                           | License | Used in + How                                                                                                                                                                                                         |
+| ------- | -------- | -------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| mind    | Da7-Tech | https://github.com/Da7-Tech/mind | MIT     | Mind memory feature: storage foundation (PR #899: memory tables, scoring constants; upstream snapshot 2026-09-04) and standing-order prose (PR #909). Adapted: scoring constants, near-verbatim standing-order prose. |
 
 ### License notice for mind
+
 <!-- DO NOT EDIT below. Byte-match with upstream Da7-Tech/mind LICENSE. Do not move behind a link or details tag. -->
+
 ```text
 MIT License
 
@@ -40,7 +44,8 @@ SOFTWARE.
 ```
 
 ## Inspiration and reference (no code copied, no notice needed)
-| Project | Author | Source | License | Used in + How |
-| ------- | ------ | ------ | ------- | ------------- |
-| codex | OpenAI | https://github.com/openai/codex | Apache-2.0 | Codex app-server protocol handling (`apps/server/src/codexAppServerManager.ts`). Inspired: protocol reference. |
-| CodexMonitor | Thomas Ricouard (Dimillian) | https://github.com/Dimillian/CodexMonitor | MIT | Agent-session UX flows and operational safeguards (AGENTS.md "Reference Repos"). Inspired: reference implementation. |
+
+| Project      | Author                      | Source                                    | License    | Used in + How                                                                                                        |
+| ------------ | --------------------------- | ----------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------- |
+| codex        | OpenAI                      | https://github.com/openai/codex           | Apache-2.0 | Codex app-server protocol handling (`apps/server/src/codexAppServerManager.ts`). Inspired: protocol reference.       |
+| CodexMonitor | Thomas Ricouard (Dimillian) | https://github.com/Dimillian/CodexMonitor | MIT        | Agent-session UX flows and operational safeguards (AGENTS.md "Reference Repos"). Inspired: reference implementation. |

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -15,14 +15,14 @@ What does not belong here:
 
 Attribution complements licenses; it never replaces them. If code or prose is copied or
 derived from an MIT/BSD-style project, carry the upstream copyright and permission notice
-alongside the copied portions as the license requires — a row in this table is not a
+alongside the copied portions as the license requires. A row in this table is not a
 substitute.
 
 ## Adapted work
 
-| Project | Author   | Source                           | License | Used in             | Nature                                                                                                    |
-| ------- | -------- | -------------------------------- | ------- | ------------------- | --------------------------------------------------------------------------------------------------------- |
-| mind    | Da7-Tech | https://github.com/Da7-Tech/mind | MIT     | Mind memory feature | Adapted — memory lifecycle concepts; scoring constants and near-verbatim standing-order prose are adapted |
+| Project | Author   | Source                           | License | Used in                                                                | Nature                                                                                                    |
+| ------- | -------- | -------------------------------- | ------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| mind    | Da7-Tech | https://github.com/Da7-Tech/mind | MIT     | Mind memory feature, https://github.com/Emanuele-web04/synara/pull/863 | Adapted in the linked PR. Memory lifecycle concepts, confirm-driven reinforcement, and exponential decay. |
 
 ### License notice for mind
 
@@ -54,5 +54,5 @@ SOFTWARE.
 
 | Project      | Author                      | Source                                    | License    | Used in                                                                         | Nature                                                                 |
 | ------------ | --------------------------- | ----------------------------------------- | ---------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| codex        | OpenAI                      | https://github.com/openai/codex           | Apache-2.0 | Codex app-server protocol handling (`apps/server/src/codexAppServerManager.ts`) | Inspired — protocol and behavior reference                             |
-| CodexMonitor | Thomas Ricouard (Dimillian) | https://github.com/Dimillian/CodexMonitor | MIT        | Agent-session UX flows and operational safeguards                               | Inspired — reference implementation, per `AGENTS.md` "Reference Repos" |
+| codex        | OpenAI                      | https://github.com/openai/codex           | Apache-2.0 | Codex app-server protocol handling (`apps/server/src/codexAppServerManager.ts`) | Inspired. Protocol and behavior reference.                             |
+| CodexMonitor | Thomas Ricouard (Dimillian) | https://github.com/Dimillian/CodexMonitor | MIT        | Agent-session UX flows and operational safeguards                               | Inspired. Reference implementation, per `AGENTS.md` "Reference Repos". |

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -7,6 +7,7 @@ What belongs here: code, constants, or prose Synara copied or adapted, and featu
 What does not belong here: ordinary dependencies, even large ones (Effect, Pi). `package.json` and `bun.lock` already record those with their licenses.
 
 Credit is not a license notice. If you copy code or prose, carry the upstream notice with it.
+
 <!-- Style: no em dashes in this file. Use commas or colons. -->
 
 ## Adapted work (license notice required)

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -20,8 +20,8 @@ substitute.
 
 ## Adapted work
 
-| Project | Author   | Source                           | License | Used in                                                                | Nature                                                                                                    |
-| ------- | -------- | -------------------------------- | ------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Project | Author   | Source                           | License | Used in                                                                                                                        | Nature                                                                                                      |
+| ------- | -------- | -------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
 | mind    | Da7-Tech | https://github.com/Da7-Tech/mind | MIT     | Mind memory feature — storage foundation in https://github.com/Emanuele-web04/synara/pull/899, feature integration in progress | Adapted — memory lifecycle concepts, scoring constants, and near-verbatim standing-order prose are adapted. |
 
 ### License notice for mind

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -1,0 +1,58 @@
+# Attribution
+
+Synara adapts ideas and, occasionally, code from other open-source projects. This file
+records the significant ones so credit is visible in one place.
+
+What belongs here:
+
+- Projects whose code, designs, constants, or prose Synara copied or adapted.
+- Projects that materially shaped a Synara feature, even when no code was copied.
+
+What does not belong here:
+
+- Ordinary dependencies. `package.json` and `bun.lock` already record those, and each
+  package ships its own license.
+
+Attribution complements licenses; it never replaces them. If code or prose is copied or
+derived from an MIT/BSD-style project, carry the upstream copyright and permission notice
+alongside the copied portions as the license requires — a row in this table is not a
+substitute.
+
+## Adapted work
+
+| Project | Author   | Source                           | License | Used in             | Nature                                                                                                    |
+| ------- | -------- | -------------------------------- | ------- | ------------------- | --------------------------------------------------------------------------------------------------------- |
+| mind    | Da7-Tech | https://github.com/Da7-Tech/mind | MIT     | Mind memory feature | Adapted — memory lifecycle concepts; scoring constants and near-verbatim standing-order prose are adapted |
+
+### License notice for mind
+
+```text
+MIT License
+
+Copyright (c) 2026 Da7-Tech
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## Inspiration and reference (no code copied)
+
+| Project      | Author                      | Source                                    | License    | Used in                                                                         | Nature                                                                 |
+| ------------ | --------------------------- | ----------------------------------------- | ---------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| codex        | OpenAI                      | https://github.com/openai/codex           | Apache-2.0 | Codex app-server protocol handling (`apps/server/src/codexAppServerManager.ts`) | Inspired — protocol and behavior reference                             |
+| CodexMonitor | Thomas Ricouard (Dimillian) | https://github.com/Dimillian/CodexMonitor | MIT        | Agent-session UX flows and operational safeguards                               | Inspired — reference implementation, per `AGENTS.md` "Reference Repos" |

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -22,7 +22,7 @@ substitute.
 
 | Project | Author   | Source                           | License | Used in                                                                | Nature                                                                                                    |
 | ------- | -------- | -------------------------------- | ------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| mind    | Da7-Tech | https://github.com/Da7-Tech/mind | MIT     | Mind memory feature, https://github.com/Emanuele-web04/synara/pull/863 | Adapted in the linked PR. Memory lifecycle concepts, confirm-driven reinforcement, and exponential decay. |
+| mind    | Da7-Tech | https://github.com/Da7-Tech/mind | MIT     | Mind memory feature — storage foundation in https://github.com/Emanuele-web04/synara/pull/899, feature integration in progress | Adapted — memory lifecycle concepts, scoring constants, and near-verbatim standing-order prose are adapted. |
 
 ### License notice for mind
 

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -12,8 +12,8 @@ Credit is not a license notice. If you copy code or prose, carry the upstream no
 
 ## Adapted work (license notice required)
 
-| Project | Author   | Source                           | License | Used in + How                                                                                                                                                                                                         |
-| ------- | -------- | -------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Project | Author   | Source                           | License | Used in + How                                                                                                                                                                                                                    |
+| ------- | -------- | -------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | mind    | Da7-Tech | https://github.com/Da7-Tech/mind | MIT     | Mind memory feature (PR #909, which supersedes closed #863/#899/#900): memory tables, scoring constants, and standing-order prose; upstream snapshot 2026-09-04. Adapted: scoring constants, near-verbatim standing-order prose. |
 
 ### License notice for mind

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -14,7 +14,7 @@ Credit is not a license notice. If you copy code or prose, carry the upstream no
 
 | Project | Author   | Source                           | License | Used in + How                                                                                                                                                                                                         |
 | ------- | -------- | -------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| mind    | Da7-Tech | https://github.com/Da7-Tech/mind | MIT     | Mind memory feature: storage foundation (PR #899: memory tables, scoring constants; upstream snapshot 2026-09-04) and standing-order prose (PR #909). Adapted: scoring constants, near-verbatim standing-order prose. |
+| mind    | Da7-Tech | https://github.com/Da7-Tech/mind | MIT     | Mind memory feature (PR #909, which supersedes closed #863/#899/#900): memory tables, scoring constants, and standing-order prose; upstream snapshot 2026-09-04. Adapted: scoring constants, near-verbatim standing-order prose. |
 
 ### License notice for mind
 

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -12,9 +12,9 @@ Credit is not a license notice. If you copy code or prose, carry the upstream no
 
 ## Adapted work (license notice required)
 
-| Project | Author   | Source                           | License | Used in + How                                                                                                                                                                                                                    |
-| ------- | -------- | -------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| mind    | Da7-Tech | https://github.com/Da7-Tech/mind | MIT     | Mind memory feature (PR #909, which supersedes closed #863/#899/#900): memory tables, scoring constants, and standing-order prose; upstream snapshot 2026-09-04. Adapted: scoring constants, near-verbatim standing-order prose. |
+| Project | Author   | Source                           | License | Used in + How                                                                                                                                                                                                                          |
+| ------- | -------- | -------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| mind    | Da7-Tech | https://github.com/Da7-Tech/mind | MIT     | Mind memory feature (PR #1148, which supersedes closed #863/#899/#900/#909): memory tables, scoring constants, and standing-order prose; upstream snapshot 2026-09-04. Adapted: scoring constants, near-verbatim standing-order prose. |
 
 ### License notice for mind
 

--- a/README.md
+++ b/README.md
@@ -141,3 +141,5 @@ Read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a pull request. For a r
 ## License
 
 Synara is licensed under the [MIT License](./LICENSE).
+
+Third-party attributions live in [ATTRIBUTION.md](./ATTRIBUTION.md).


### PR DESCRIPTION
## What this does

Adds root-level `ATTRIBUTION.md` (58 lines, 1 file, zero code): credits `Da7-Tech/mind` as Adapted work with the full MIT notice, and `openai/codex` + `Dimillian/CodexMonitor` as inspiration/reference (no code copied). Gives the Mind PRs a visible credit file to point to before they land.

## Behavior change (user-visible)

None. Docs-only. No runtime, UI, config, dependency, or migration change.

## Reviews

- Ponytail ultra (prose accuracy + stale-reference sweep): pass, no blocking findings. Verified against the tree: `AGENTS.md` "Reference Repos" lists both `openai/codex` and `Dimillian/CodexMonitor` (matches the reference section and its qualifier); `apps/server/src/codexAppServerManager.ts` exists (codex row's "Used in" is accurate); the mind row now points at PR #909 (the PR that carries the whole Mind feature; #899 is closed-superseded), fixed in `a108a77f4`; `oxfmt --check ATTRIBUTION.md` is clean.
- Thermos dual lens, run inline (docs-only single file, no code surface for fan-out): security lens, no secrets or credentials, only public URLs plus standard MIT template text; carrying the full MIT notice alongside an honest "near-verbatim prose adapted" label is the compliant posture. Maintainability lens, zero code coupling (repo-wide search: nothing references this file); rot risk is limited to the two nits below. No blocking findings, zero new commits.
- Upstream `Da7-Tech/mind` LICENSE byte-match is author-claimed (fetched at authoring time); not independently re-fetched in this lane. Re-verification welcome at merge time (Follow-ups 4).

## Tests

| Command | Result |
| --- | --- |
| `gh pr checks 864` on head `a108a77f4` | see live checks below (prior head `ae8320c4e` was all-green: Format/Lint/Typecheck/Test/Browser/Build, Windows Process Regression, Migration Lineage, Release Smoke, Label jobs) |
| `bunx oxfmt --check ATTRIBUTION.md` (worktree plan-09) | pass |
| typecheck+build scoped | n/a, single root markdown no package consumes (repo-wide search: zero references); CI quality + build jobs on this exact head are the proof |
| live proof | n/a, docs-only, no UI surface; Playwright e2e not run (no e2e/browser-MCP surface) |

## Socket surface

None. Keyword sweep of the diff hits once: the substring "ws" inside the English word "flows" (CodexMonitor row, prose only). No code, no transport.

## Follow-ups (deferred nits, no commits per lane rule)

1. Line 25 still carries two em dashes ("feature -- storage", "Adapted -- memory") despite the "remove em dashes" commit. Swap for commas/colons.
2. "Feature integration in progress" goes stale once the Mind PRs land. Reword to timeless phrasing.
3. Open design questions for Emanuele (carried over): (a) DESIGN.md/VISION.md, recommendation is do not create for now, `AGENTS.md` already encodes conventions; (b) keep the "Inspiration and reference" section? Recommendation yes, honest and legally neutral, deleting it is a two-row cut.
4. Upstream LICENSE re-verification welcome at merge time (author-claimed byte-match, see Reviews).

## Merge note

HEAD `a108a77f4` == fork `agent/docs-attribution` == PR head. Undrafted. Should land with or before #909 — #909 contains the adapted `Da7-Tech/mind` code this file credits, and the superseded Mind PRs (#863/#899/#900) are closed.

## Gauntlet handoff (2026-09-04)

**Status: ready for maintainer review.** Latest fix `a108a77f4` repoints the mind row from closed #899 to #909. E2E N/A (docs-only, no app surface; render proved by oxfmt + CI).

**What review found and fixed**
- Prose pointer: the mind row now cites #909 (the live Mind PR); #899 is closed-superseded.
- README License link bundled; MIT block byte-identical; zero em dashes.
- Lesson: never `bunx` a formatter — repo pins oxfmt `^0.40.0`; always `bun install` then `bun run fmt:check`.

**Remaining:** maintainer review; merge with or before #909.

