### PR TITLE
fix(server): allow dot-prefixed attachment directories

### DIFF
--- a/apps/server/src/attachmentPaths.test.ts
+++ b/apps/server/src/attachmentPaths.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+import {
+  normalizeAttachmentRelativePath,
+  resolveAttachmentRelativePath,
+} from "./attachmentPaths.ts";
+
+describe("attachmentPaths", () => {
+  it("allows child names that merely begin with two dots", () => {
+    assert.equal(normalizeAttachmentRelativePath("..assets/image.png"), "..assets/image.png");
+    assert.equal(
+      resolveAttachmentRelativePath({
+        attachmentsDir: "/tmp/synara-attachments",
+        relativePath: "..assets/image.png",
+      }),
+      path.resolve("/tmp/synara-attachments", "..assets/image.png"),
+    );
+  });
+
+  it("rejects parent traversal with either path separator", () => {
+    assert.equal(normalizeAttachmentRelativePath(".."), null);
+    assert.equal(normalizeAttachmentRelativePath("../outside.bin"), null);
+    assert.equal(normalizeAttachmentRelativePath("..\\outside.bin"), null);
+  });
+});

--- a/apps/server/src/attachmentPaths.ts
+++ b/apps/server/src/attachmentPaths.ts
@@ -3,11 +3,19 @@ import path from "node:path";
 export const ATTACHMENTS_ROUTE_PREFIX = "/attachments";
 
 export function normalizeAttachmentRelativePath(rawRelativePath: string): string | null {
-  const normalized = path.normalize(rawRelativePath).replace(/^[/\\]+/, "");
-  if (normalized.length === 0 || normalized.startsWith("..") || normalized.includes("\0")) {
+  const normalized = path
+    .normalize(rawRelativePath)
+    .replace(/^[/\\]+/, "")
+    .replace(/\\/g, "/");
+  if (
+    normalized.length === 0 ||
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    normalized.includes("\0")
+  ) {
     return null;
   }
-  return normalized.replace(/\\/g, "/");
+  return normalized;
 }
 
 export function resolveAttachmentRelativePath(input: {


### PR DESCRIPTION
## What Changed

- normalize attachment separators before traversal validation;
- reject exact parent segments (`..`, `../...`, and `..\\...`) without rejecting ordinary names such as `..assets`;
- add focused regressions for the accepted and rejected path shapes.

## Why

`normalizeAttachmentRelativePath` used `startsWith("..")`, so safe child paths whose first segment merely began with two dots were rejected. Narrowing the check without normalizing separators would make `..\\outside` unsafe on POSIX, so the validation now canonicalizes separators first and remains fail-closed for both forms of parent traversal.

## UI Changes

None.

## Verification

Added a focused Vitest file for attachment path normalization. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes