### PR TITLE
fix(server): preserve full provider prerelease versions

### DIFF
--- a/apps/server/src/provider/providerMaintenance.prerelease.test.ts
+++ b/apps/server/src/provider/providerMaintenance.prerelease.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, assert } from "@effect/vitest";
+
+import { compareSemverVersions, parseGenericCliVersion } from "./providerMaintenance";
+
+describe("provider maintenance prerelease versions", () => {
+  it("preserves hyphens inside a prerelease suffix", () => {
+    assert.strictEqual(
+      parseGenericCliVersion("provider-cli 0.124.0-alpha-beta\n"),
+      "0.124.0-alpha-beta",
+    );
+    assert.strictEqual(parseGenericCliVersion("provider 2.1-alpha-beta"), "2.1.0-alpha-beta");
+  });
+
+  it("keeps distinct hyphenated prereleases distinguishable", () => {
+    assert.ok(compareSemverVersions("0.124.0-alpha-beta", "0.124.0-alpha-gamma") < 0);
+  });
+});

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -90,9 +90,20 @@ function nonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+function splitPrerelease(version: string): { main: string; prerelease: string | undefined } {
+  const separatorIndex = version.indexOf("-");
+  if (separatorIndex === -1) {
+    return { main: version, prerelease: undefined };
+  }
+  return {
+    main: version.slice(0, separatorIndex),
+    prerelease: version.slice(separatorIndex + 1),
+  };
+}
+
 function normalizeSemverVersion(version: string): string {
-  const [main, prerelease] = version.trim().replace(/^v/, "").split("-", 2);
-  const segments = (main ?? "")
+  const { main, prerelease } = splitPrerelease(version.trim().replace(/^v/, ""));
+  const segments = main
     .split(".")
     .map((segment) => segment.trim())
     .filter((segment) => segment.length > 0);
@@ -105,7 +116,7 @@ function normalizeSemverVersion(version: string): string {
 }
 
 function parseSemver(value: string): ParsedSemver | null {
-  const [main = "", prerelease] = normalizeSemverVersion(value).split("-", 2);
+  const { main, prerelease } = splitPrerelease(normalizeSemverVersion(value));
   const segments = main.split(".");
   if (segments.length !== 3) {
     return null;


### PR DESCRIPTION
## What Changed

- split semantic versions at the first prerelease separator without dropping the remaining suffix;
- use the same split operation during normalization and comparison;
- add focused regressions for hyphenated prereleases, including two-component versions.

## Why

The generic provider version parser accepts prerelease suffixes containing hyphens, but normalization and comparison used `split("-", 2)`. JavaScript discards later segments in that form, so `0.124.0-alpha-beta` became `0.124.0-alpha` and distinct provider versions could compare as equal.

## UI Changes

None.

## Verification

Added focused server tests. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes