### PR TITLE
fix(server): allow dot-prefixed preview directories

### DIFF
--- a/apps/server/src/localImageFiles.dot-prefix.test.ts
+++ b/apps/server/src/localImageFiles.dot-prefix.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, it } from "vitest";
+
+import { resolveAllowedLocalPreviewFile } from "./localImageFiles.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const directory of tempDirs.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("local preview dot-prefixed directories", () => {
+  it("allows workspace files below a child directory beginning with two dots", async () => {
+    const workspace = mkdtempSync(path.join(os.tmpdir(), "synara-dot-preview-"));
+    tempDirs.push(workspace);
+    writeFileSync(path.join(workspace, ".git"), "gitdir: .git");
+    const previewDirectory = path.join(workspace, "..assets");
+    const previewPath = path.join(previewDirectory, "spec.pdf");
+    mkdirSync(previewDirectory);
+    writeFileSync(previewPath, Buffer.from("%PDF-1.4"));
+
+    const result = await resolveAllowedLocalPreviewFile({
+      requestedPath: previewPath,
+      cwd: workspace,
+    });
+
+    assert.equal(result?.path, realpathSync(previewPath));
+  });
+});

--- a/apps/server/src/localImageFiles.ts
+++ b/apps/server/src/localImageFiles.ts
@@ -65,7 +65,10 @@ export function resolveLocalPreviewGrantRealPath(input: {
 
 function isPathInside(candidate: string, root: string): boolean {
   const relative = path.relative(root, candidate);
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+  return (
+    relative === "" ||
+    (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+  );
 }
 
 async function realpathOrNull(candidate: string | undefined): Promise<string | null> {


### PR DESCRIPTION
## What Changed

- distinguish real parent traversal from ordinary child names beginning with two dots;
- keep absolute and `../` paths outside the preview allowlist;
- add a focused PDF workspace regression using a `..assets` directory.

## Why

The local preview containment helper rejected every relative path beginning with `..`, including a valid child such as `..assets/spec.pdf`. `path.relative` exposes actual parent traversal as either exactly `..` or `..${path.sep}...`, so the check can remain fail-closed without rejecting unrelated names.

## UI Changes

None.

## Verification

Added a focused server regression. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes