### PR TITLE
fix(server): allow dot-prefixed Factory plugin directories

### DIFF
--- a/apps/server/src/provider/FactoryPluginDiscovery.dot-prefix.test.ts
+++ b/apps/server/src/provider/FactoryPluginDiscovery.dot-prefix.test.ts
@@ -1,0 +1,58 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { listFactoryPlugins } from "./FactoryPluginDiscovery.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((directory) => fs.rm(directory, { recursive: true })));
+});
+
+describe("Factory plugin path containment", () => {
+  it("accepts dot-prefixed children without allowing parent traversal", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "synara-factory-dot-plugin-"));
+    tempDirs.push(homeDir);
+    const factoryDir = path.join(homeDir, ".factory");
+    const marketplacePath = path.join(factoryDir, "plugins", "marketplaces", "official");
+    const pluginPath = path.join(marketplacePath, "..reviewer");
+    const escapedPluginPath = path.join(marketplacePath, "..", "outside");
+
+    await fs.mkdir(path.join(marketplacePath, ".factory-plugin"), { recursive: true });
+    await fs.mkdir(path.join(pluginPath, ".factory-plugin"), { recursive: true });
+    await fs.mkdir(path.join(escapedPluginPath, ".factory-plugin"), { recursive: true });
+    await fs.writeFile(
+      path.join(factoryDir, "plugins", "known_marketplaces.json"),
+      JSON.stringify({ official: { installLocation: marketplacePath } }),
+    );
+    await fs.writeFile(
+      path.join(marketplacePath, ".factory-plugin", "marketplace.json"),
+      JSON.stringify({
+        plugins: [
+          { name: "reviewer", source: "./..reviewer" },
+          { name: "outside", source: "../outside" },
+        ],
+      }),
+    );
+    await fs.writeFile(
+      path.join(pluginPath, ".factory-plugin", "plugin.json"),
+      JSON.stringify({ name: "Reviewer" }),
+    );
+    await fs.writeFile(
+      path.join(escapedPluginPath, ".factory-plugin", "plugin.json"),
+      JSON.stringify({ name: "Outside" }),
+    );
+
+    const result = await listFactoryPlugins(homeDir);
+
+    expect(result.marketplaces[0]?.plugins).toEqual([
+      expect.objectContaining({
+        name: "reviewer",
+        source: { type: "local", path: pluginPath },
+      }),
+    ]);
+  });
+});

--- a/apps/server/src/provider/FactoryPluginDiscovery.ts
+++ b/apps/server/src/provider/FactoryPluginDiscovery.ts
@@ -121,7 +121,10 @@ function resolvePluginPath(marketplacePath: string, source: string): string | nu
   const resolvedMarketplace = nodePath.resolve(marketplacePath);
   const resolvedPlugin = nodePath.resolve(resolvedMarketplace, source);
   const relative = nodePath.relative(resolvedMarketplace, resolvedPlugin);
-  return relative === "" || relative.startsWith("..") || nodePath.isAbsolute(relative)
+  return relative === "" ||
+    relative === ".." ||
+    relative.startsWith(`..${nodePath.sep}`) ||
+    nodePath.isAbsolute(relative)
     ? null
     : resolvedPlugin;
 }


### PR DESCRIPTION
## What Changed

- distinguish actual parent traversal from plugin directory names that merely begin with two dots;
- preserve rejection of the marketplace root, absolute escapes, and `../...` sources;
- add a focused marketplace fixture containing both an accepted `..reviewer` child and a rejected escaping entry.

## Why

Factory plugin discovery used `relative.startsWith("..")` for containment. That rejected a legitimate marketplace child such as `..reviewer` even though `path.relative` represents a real escape as exactly `..` or `..${path.sep}...`.

## UI Changes

None.

## Verification

Added focused provider-discovery coverage. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes