### PR TITLE
fix(server): resolve favicons in dot-prefixed directories

### DIFF
--- a/apps/server/src/project/Layers/ProjectFaviconResolver.test.ts
+++ b/apps/server/src/project/Layers/ProjectFaviconResolver.test.ts
@@ -55,6 +55,20 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
       }),
     );
 
+    it.effect("resolves icon hrefs below dot-prefixed child directories", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "index.html", '<link rel="icon" href="..assets/logo.svg">');
+        yield* writeTextFile(cwd, "..assets/logo.svg", "<svg>brand</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("..assets/logo.svg");
+      }),
+    );
+
     it.effect("returns null when no icon is present", () =>
       Effect.gen(function* () {
         const resolver = yield* ProjectFaviconResolver;

--- a/apps/server/src/project/Layers/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/Layers/ProjectFaviconResolver.ts
@@ -62,7 +62,10 @@ export const makeProjectFaviconResolver = Effect.gen(function* () {
 
   const isPathWithinProject = (projectCwd: string, candidatePath: string): boolean => {
     const relative = path.relative(path.resolve(projectCwd), path.resolve(candidatePath));
-    return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+    return (
+      relative === "" ||
+      (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+    );
   };
 
   const findExistingFile = Effect.fn(function* (


### PR DESCRIPTION
## What Changed

- narrow project-path rejection to actual parent traversal;
- allow linked favicon assets below child directories whose names begin with two dots;
- add an Effect-layer regression for an `index.html` icon href targeting `..assets/logo.svg`.

## Why

The favicon resolver used `relative.startsWith("..")` as its containment condition. A safe project child such as `..assets/logo.svg` therefore looked like an escape and was silently skipped, even though `path.relative` represents real parent traversal as exactly `..` or `..${path.sep}...`.

## UI Changes

None.

## Verification

Extended the focused `ProjectFaviconResolverLive` tests. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes