### PR TITLE
fix(server): accept generated images in dot-prefixed directories

### DIFF
--- a/apps/server/src/studioGeneratedImages.dot-prefix.test.ts
+++ b/apps/server/src/studioGeneratedImages.dot-prefix.test.ts
@@ -1,0 +1,49 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { Effect } from "effect";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { copyGeneratedImageToStudioWorkspace } from "./studioGeneratedImages";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { recursive: true })));
+});
+
+describe("Studio generated-image path containment", () => {
+  it("accepts dot-prefixed children without accepting parent escapes", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "synara-studio-dot-image-"));
+    temporaryRoots.push(root);
+    const trustedRoot = path.join(root, "generated_images");
+    const sourceDirectory = path.join(trustedRoot, "..session");
+    const sourcePath = path.join(sourceDirectory, "image.png");
+    const outsidePath = path.join(root, "outside.png");
+    await mkdir(sourceDirectory, { recursive: true });
+    await writeFile(sourcePath, "trusted image");
+    await writeFile(outsidePath, "outside image");
+
+    const copied = await Effect.runPromise(
+      copyGeneratedImageToStudioWorkspace({
+        sourcePath,
+        workspaceRoot: path.join(root, "Studio"),
+        createdAt: "2026-08-31T12:00:00.000Z",
+        trustedSourceRoots: [trustedRoot],
+      }),
+    );
+    const escaped = await Effect.runPromise(
+      copyGeneratedImageToStudioWorkspace({
+        sourcePath: outsidePath,
+        workspaceRoot: path.join(root, "Other Studio"),
+        createdAt: "2026-08-31T12:00:00.000Z",
+        trustedSourceRoots: [trustedRoot],
+      }),
+    );
+
+    expect(copied).not.toBeNull();
+    expect(await readFile(copied!.fullPath, "utf8")).toBe("trusted image");
+    expect(escaped).toBeNull();
+  });
+});

--- a/apps/server/src/studioGeneratedImages.ts
+++ b/apps/server/src/studioGeneratedImages.ts
@@ -65,7 +65,10 @@ function isErrorWithCode(error: unknown, code: string): boolean {
 
 function isPathInside(candidate: string, root: string): boolean {
   const relative = path.relative(root, candidate);
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+  return (
+    relative === "" ||
+    (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+  );
 }
 
 /**


### PR DESCRIPTION
## What Changed

- narrow trusted generated-image containment to reject only real parent traversal;
- allow a valid generated-image child directory such as `..session`;
- add a regression that also proves a sibling outside the trusted root remains rejected.

## Why

Studio image copying used `relative.startsWith("..")`, so safe image paths below dot-prefixed children were rejected before copying. `path.relative` exposes an actual escape as exactly `..` or `..${path.sep}...`, allowing the check to remain strict without this false positive.

## UI Changes

None.

## Verification

Added focused Studio image-copy coverage. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes