### PR TITLE
fix(shared): enforce project directory UTF-8 byte limits

### DIFF
--- a/packages/shared/src/projectDirectoryName.test.ts
+++ b/packages/shared/src/projectDirectoryName.test.ts
@@ -16,4 +16,11 @@ describe("normalizeProjectDirectoryName", () => {
   it.each(["", ".", "..", "a/b", "a\\b", "CON", "name."])("rejects %s", (name) => {
     expect(normalizeProjectDirectoryName(name)).toBeNull();
   });
+
+  it("enforces the filesystem component limit in UTF-8 bytes", () => {
+    expect(normalizeProjectDirectoryName("a".repeat(255))).toBe("a".repeat(255));
+    expect(normalizeProjectDirectoryName("a".repeat(256))).toBeNull();
+    expect(normalizeProjectDirectoryName("😀".repeat(63))).toBe("😀".repeat(63));
+    expect(normalizeProjectDirectoryName("😀".repeat(64))).toBeNull();
+  });
 });

--- a/packages/shared/src/projectDirectoryName.ts
+++ b/packages/shared/src/projectDirectoryName.ts
@@ -1,10 +1,11 @@
 const WINDOWS_RESERVED_DIRECTORY_NAME = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/i;
+const MAX_DIRECTORY_NAME_UTF8_BYTES = 255;
 
 export function normalizeProjectDirectoryName(value: string): string | null {
   const normalized = value.trim();
   if (
     normalized.length === 0 ||
-    normalized.length > 255 ||
+    Buffer.byteLength(normalized, "utf8") > MAX_DIRECTORY_NAME_UTF8_BYTES ||
     normalized === "." ||
     normalized === ".." ||
     normalized.endsWith(".") ||

--- a/packages/shared/src/projectDirectoryName.ts
+++ b/packages/shared/src/projectDirectoryName.ts
@@ -1,11 +1,12 @@
 const WINDOWS_RESERVED_DIRECTORY_NAME = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/i;
 const MAX_DIRECTORY_NAME_UTF8_BYTES = 255;
+const UTF8_ENCODER = new TextEncoder();
 
 export function normalizeProjectDirectoryName(value: string): string | null {
   const normalized = value.trim();
   if (
     normalized.length === 0 ||
-    Buffer.byteLength(normalized, "utf8") > MAX_DIRECTORY_NAME_UTF8_BYTES ||
+    UTF8_ENCODER.encode(normalized).byteLength > MAX_DIRECTORY_NAME_UTF8_BYTES ||
     normalized === "." ||
     normalized === ".." ||
     normalized.endsWith(".") ||


### PR DESCRIPTION
## What Changed

- validate project directory names against the 255-byte filesystem component limit rather than JavaScript UTF-16 length;
- preserve the existing Windows reserved-name and invalid-character checks;
- add regressions covering ASCII and multibyte emoji boundaries.

## Why

A name containing 64 emoji is only 128 UTF-16 code units, so it passed the previous `length <= 255` check, but it occupies 256 UTF-8 bytes and fails when created on common filesystems. Rejecting it during shared validation gives the UI and server the same deterministic result before filesystem mutation.

## UI Changes

None.

## Verification

Extended the focused shared-unit tests. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes