### PR TITLE
fix(shared): require a delivery-block detail boundary

### DIFF
--- a/packages/shared/src/providerDeliveryBlock.test.ts
+++ b/packages/shared/src/providerDeliveryBlock.test.ts
@@ -27,4 +27,12 @@ describe("providerDeliveryBlock", () => {
       ),
     ).toBe(false);
   });
+
+  it("does not match unrelated details that only share the summary prefix", () => {
+    expect(isProviderDeliveryBlockDetail(PROVIDER_DELIVERY_BLOCK_SUMMARY)).toBe(true);
+    expect(isProviderDeliveryBlockDetail(`${PROVIDER_DELIVERY_BLOCK_SUMMARY}: blocked`)).toBe(true);
+    expect(isProviderDeliveryBlockDetail(`${PROVIDER_DELIVERY_BLOCK_SUMMARY} elsewhere`)).toBe(
+      false,
+    );
+  });
 });

--- a/packages/shared/src/providerDeliveryBlock.ts
+++ b/packages/shared/src/providerDeliveryBlock.ts
@@ -9,10 +9,11 @@
  * recovery action, so server and client must never drift apart.
  */
 export const PROVIDER_DELIVERY_BLOCK_SUMMARY = "Thread is blocked by an earlier provider failure";
+const PROVIDER_DELIVERY_BLOCK_DETAIL_PREFIX = `${PROVIDER_DELIVERY_BLOCK_SUMMARY}:`;
 
 /** Session error detail written for a quarantined thread, e.g. "<summary>: <blocker>". */
 export function formatProviderDeliveryBlockDetail(blockerDetail: string): string {
-  return `${PROVIDER_DELIVERY_BLOCK_SUMMARY}: ${blockerDetail}`;
+  return `${PROVIDER_DELIVERY_BLOCK_DETAIL_PREFIX} ${blockerDetail}`;
 }
 
 /**
@@ -20,7 +21,10 @@ export function formatProviderDeliveryBlockDetail(blockerDetail: string): string
  * meaning the thread can be recovered by reconciling its blocking deliveries.
  */
 export function isProviderDeliveryBlockDetail(detail: string | null | undefined): boolean {
+  if (typeof detail !== "string") return false;
+  const normalized = detail.trimStart();
   return (
-    typeof detail === "string" && detail.trimStart().startsWith(PROVIDER_DELIVERY_BLOCK_SUMMARY)
+    normalized === PROVIDER_DELIVERY_BLOCK_SUMMARY ||
+    normalized.startsWith(PROVIDER_DELIVERY_BLOCK_DETAIL_PREFIX)
   );
 }


### PR DESCRIPTION
## What Changed

- centralize the formatted delivery-block detail prefix;
- make the recovery matcher accept only the exact summary or the documented colon-delimited detail shape;
- add a regression for unrelated messages that merely begin with the same words.

## Why

`isProviderDeliveryBlockDetail` previously used an unrestricted `startsWith` check. A different provider error such as `Thread is blocked by an earlier provider failure elsewhere` was therefore misclassified as a delivery quarantine and could expose a recovery action that does not apply to that failure.

## UI Changes

None.

## Verification

Extended the focused shared-unit tests. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes