### PR TITLE
fix(shared): ignore empty agent mention tasks

### DIFF
--- a/packages/shared/src/agentMentions.test.ts
+++ b/packages/shared/src/agentMentions.test.ts
@@ -33,6 +33,11 @@ describe("parseAgentMentionInvocations", () => {
     expect(parsed[0]?.task).toBe("check fn(a, b) and the SQL migration");
     expect(parsed[0]?.definition.kind).toBe("claude-subagent");
   });
+
+  it("ignores empty and whitespace-only agent tasks", () => {
+    expect(parseAgentMentionInvocations("Please @review()", "claudeAgent")).toEqual([]);
+    expect(parseAgentMentionInvocations("Please @review(   )", "claudeAgent")).toEqual([]);
+  });
 });
 
 describe("buildClaudeSubagentPrompt", () => {
@@ -41,6 +46,11 @@ describe("buildClaudeSubagentPrompt", () => {
       prompt: "Just answer directly",
       invocations: [],
     });
+  });
+
+  it("leaves empty Claude directives untouched instead of creating an empty Agent task", () => {
+    const prompt = "Please @review()";
+    expect(buildClaudeSubagentPrompt(prompt)).toEqual({ prompt, invocations: [] });
   });
 
   it("rewrites Claude mentions into explicit Agent-tool instructions", () => {

--- a/packages/shared/src/agentMentions.ts
+++ b/packages/shared/src/agentMentions.ts
@@ -81,10 +81,15 @@ export function parseAgentMentionInvocations(
     if (!taskMatch) {
       continue;
     }
+    const task = taskMatch.task.trim();
+    if (task.length === 0) {
+      index = taskMatch.end - 1;
+      continue;
+    }
 
     invocations.push({
       alias,
-      task: taskMatch.task.trim(),
+      task,
       raw: text.slice(index, taskMatch.end),
       start: index,
       end: taskMatch.end,


### PR DESCRIPTION
## What Changed

- require inline `@alias(task)` directives to contain a non-whitespace task;
- leave empty directives in the ordinary prompt instead of generating an explicit empty Agent-tool instruction;
- add focused parser and Claude prompt regressions.

## Why

`@review()` and `@review(   )` were recognized as valid subagent invocations. Claude prompt rewriting then instructed the Agent tool to run the named subagent with an empty task, which is not an actionable delegation and can produce arbitrary or failed work.

## UI Changes

None.

## Verification

Extended the focused shared-unit tests. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes