### PR TITLE
fix(shared): reject drive-relative Windows paths

### DIFF
--- a/packages/shared/src/path.test.ts
+++ b/packages/shared/src/path.test.ts
@@ -78,6 +78,10 @@ describe("isLocalAbsolutePath", () => {
     expect(isLocalAbsolutePath("C:\\Users\\dev\\file.txt")).toBe(true);
   });
 
+  it("rejects a drive-relative Windows path", () => {
+    expect(isLocalAbsolutePath("C:")).toBe(false);
+  });
+
   it("can disable Windows path recognition for native POSIX server reads", () => {
     expect(isLocalAbsolutePath("C:\\Users\\dev\\file.txt", { allowWindowsPaths: false })).toBe(
       false,

--- a/packages/shared/src/path.ts
+++ b/packages/shared/src/path.ts
@@ -4,7 +4,7 @@
 // Exports: absolute-path predicates plus safe workspace relative path helpers
 
 export function isWindowsDrivePath(value: string): boolean {
-  return /^[a-zA-Z]:([/\\]|$)/.test(value);
+  return /^[a-zA-Z]:[/\\]/.test(value);
 }
 
 export function isUncPath(value: string): boolean {


### PR DESCRIPTION
## What Changed

- require a slash or backslash after a Windows drive designator before classifying it as absolute;
- keep ordinary drive-root and drive-absolute paths supported;
- add focused coverage proving bare `C:` remains drive-relative.

## Why

Windows treats `C:` as the current directory on drive C, not as `C:\\`. The shared classifier treated it as absolute, which could route an ambiguous drive-relative value into absolute local-file and project-path handling.

## UI Changes

None.

## Verification

Extended the focused shared path tests. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes