### PR TITLE
fix(shared): reject expanded IPv4-mapped addresses

### DIFF
--- a/packages/shared/src/outboundHttpPolicy.test.ts
+++ b/packages/shared/src/outboundHttpPolicy.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { isPublicIpAddress } from "./outboundHttpPolicy";
+
+describe("isPublicIpAddress", () => {
+  it("rejects every textual form of an IPv4-mapped IPv6 address", () => {
+    expect(isPublicIpAddress("::ffff:8.8.8.8")).toBe(false);
+    expect(isPublicIpAddress("0:0:0:0:0:ffff:8.8.8.8")).toBe(false);
+    expect(isPublicIpAddress("::ffff:0808:0808")).toBe(false);
+    expect(isPublicIpAddress("0:0:0:0:0:ffff:0808:0808")).toBe(false);
+  });
+
+  it("still accepts ordinary public IPv4 and IPv6 addresses", () => {
+    expect(isPublicIpAddress("8.8.8.8")).toBe(true);
+    expect(isPublicIpAddress("2001:4860:4860::8888")).toBe(true);
+  });
+});

--- a/packages/shared/src/outboundHttpPolicy.ts
+++ b/packages/shared/src/outboundHttpPolicy.ts
@@ -22,6 +22,8 @@ export class OutboundPolicyError extends Error {
 }
 
 const blockedAddresses = new Net.BlockList();
+const ipv4MappedAddresses = new Net.BlockList();
+ipv4MappedAddresses.addSubnet("0.0.0.0", 0, "ipv4");
 
 for (const [network, prefix] of [
   ["0.0.0.0", 8],
@@ -62,7 +64,7 @@ export function isPublicIpAddress(address: string): boolean {
     return !blockedAddresses.check(address, "ipv4");
   }
   if (family === 6) {
-    if (address.toLowerCase().startsWith("::ffff:")) return false;
+    if (ipv4MappedAddresses.check(address, "ipv6")) return false;
     return !blockedAddresses.check(address, "ipv6");
   }
   return false;


### PR DESCRIPTION
## What Changed

- detect IPv4-mapped IPv6 addresses with Node's address-aware `BlockList` instead of a textual `::ffff:` prefix check;
- reject compressed, expanded, dotted-quad, and hexadecimal mapped forms consistently;
- add focused coverage while preserving ordinary public IPv4 and IPv6 addresses.

## Why

The existing check rejected `::ffff:8.8.8.8` but accepted equivalent expanded forms such as `0:0:0:0:0:ffff:8.8.8.8`. Address policy must classify equivalent network addresses identically; otherwise an alternate spelling can bypass the mapped-address restriction used by outbound transports.

## UI Changes

None.

## Verification

Added focused shared-unit coverage. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes