### PR TITLE
fix(server): preserve sidechat view leases after unarchive

### DIFF
--- a/apps/server/src/orchestration/Layers/SidechatExpiryReactor.ts
+++ b/apps/server/src/orchestration/Layers/SidechatExpiryReactor.ts
@@ -65,6 +65,7 @@ export const makeSidechatExpiryReactor = <TimerHandle>(
     const orchestrationEngine = yield* OrchestrationEngineService;
     const providerService = yield* ProviderService;
     const knownThreadIds = new Set<ThreadId>();
+    const knownSidechatIds = new Set<ThreadId>();
 
     let timer: ReturnType<typeof createSidechatExpiryTimer<TimerHandle>>;
 
@@ -155,6 +156,7 @@ export const makeSidechatExpiryReactor = <TimerHandle>(
           case "thread.created": {
             knownThreadIds.add(event.payload.threadId);
             if (!event.payload.sidechatSourceThreadId) return;
+            knownSidechatIds.add(event.payload.threadId);
             timer.restore({
               threadId: event.payload.threadId,
               lastActivityAtMs:
@@ -205,6 +207,10 @@ export const makeSidechatExpiryReactor = <TimerHandle>(
             );
             return;
           case "thread.deleted":
+            timer.remove(event.payload.threadId);
+            knownThreadIds.delete(event.payload.threadId);
+            knownSidechatIds.delete(event.payload.threadId);
+            return;
           case "thread.archived":
             timer.remove(event.payload.threadId);
             return;
@@ -214,6 +220,7 @@ export const makeSidechatExpiryReactor = <TimerHandle>(
               (candidate) => candidate.id === event.payload.threadId,
             );
             if (!thread?.sidechatSourceThreadId || thread.deletedAt) return;
+            knownSidechatIds.add(thread.id);
             const expired = Boolean(thread.sidechatExpiredAt);
             const restoredActivityAtMs = expired
               ? lastActivityAtMs(thread, runtime.now())
@@ -239,11 +246,11 @@ export const makeSidechatExpiryReactor = <TimerHandle>(
       const readModel = yield* orchestrationEngine.getReadModel();
       for (const thread of readModel.threads) {
         knownThreadIds.add(thread.id);
-        if (
-          !thread.sidechatSourceThreadId ||
-          thread.deletedAt !== null ||
-          thread.archivedAt !== null
-        ) {
+        if (!thread.sidechatSourceThreadId) {
+          continue;
+        }
+        knownSidechatIds.add(thread.id);
+        if (thread.deletedAt !== null || thread.archivedAt !== null) {
           continue;
         }
         timer.restore({
@@ -281,7 +288,11 @@ export const makeSidechatExpiryReactor = <TimerHandle>(
       Effect.gen(function* () {
         const now = runtime.now();
         let updated = viewed ? timer.beginView(threadId, now) : timer.endView(threadId, now);
-        if (viewed && !updated && !knownThreadIds.has(threadId)) {
+        if (
+          viewed &&
+          !updated &&
+          (!knownThreadIds.has(threadId) || knownSidechatIds.has(threadId))
+        ) {
           // Shell publication and this reactor consume the same committed event on
           // separate streams. A client can subscribe in that narrow gap, so seed
           // from the authoritative read model instead of losing the view lease.
@@ -294,6 +305,7 @@ export const makeSidechatExpiryReactor = <TimerHandle>(
             !thread.deletedAt &&
             !thread.archivedAt
           ) {
+            knownSidechatIds.add(threadId);
             timer.restore({
               threadId,
               lastActivityAtMs: lastActivityAtMs(thread, runtime.now()),

--- a/apps/server/src/orchestration/Layers/SidechatExpiryReactor.unarchive-race.test.ts
+++ b/apps/server/src/orchestration/Layers/SidechatExpiryReactor.unarchive-race.test.ts
@@ -1,0 +1,118 @@
+import {
+  DEFAULT_PROVIDER_INTERACTION_MODE,
+  ProjectId,
+  ThreadId,
+  type OrchestrationCommand,
+  type OrchestrationReadModel,
+  type OrchestrationThread,
+} from "@synara/contracts";
+import { Effect, Exit, Layer, ManagedRuntime, Scope, Stream } from "effect";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ProviderService,
+  type ProviderServiceShape,
+} from "../../provider/Services/ProviderService.ts";
+import {
+  OrchestrationEngineService,
+  type OrchestrationEngineShape,
+} from "../Services/OrchestrationEngine.ts";
+import { SidechatExpiryReactor } from "../Services/SidechatExpiryReactor.ts";
+import { makeSidechatExpiryReactor } from "./SidechatExpiryReactor.ts";
+
+function makeArchivedSidechat(nowMs: number): OrchestrationThread {
+  const timestamp = new Date(nowMs).toISOString();
+  return {
+    id: ThreadId.makeUnsafe("sidechat-unarchive-view-race"),
+    projectId: ProjectId.makeUnsafe("project-sidechat-unarchive-view-race"),
+    title: "Side investigation",
+    modelSelection: { provider: "codex", model: "gpt-5-codex" },
+    interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+    runtimeMode: "full-access",
+    branch: null,
+    worktreePath: null,
+    sidechatSourceThreadId: ThreadId.makeUnsafe("sidechat-source"),
+    sidechatLastActivityAt: timestamp,
+    sidechatExpiredAt: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    latestTurn: null,
+    handoff: null,
+    messages: [],
+    session: null,
+    activities: [],
+    proposedPlans: [],
+    checkpoints: [],
+    archivedAt: timestamp,
+    deletedAt: null,
+  };
+}
+
+function makeReadModel(thread: OrchestrationThread): OrchestrationReadModel {
+  return {
+    snapshotSequence: 1,
+    updatedAt: thread.updatedAt,
+    spaces: [],
+    projects: [],
+    threads: [thread],
+  };
+}
+
+describe("SidechatExpiryReactor unarchive view race", () => {
+  it("acquires a view lease before the unarchive event stream catches up", async () => {
+    const nowMs = 10_000;
+    let thread = makeArchivedSidechat(nowMs);
+    const commands: OrchestrationCommand[] = [];
+    const dispatch = vi.fn<OrchestrationEngineShape["dispatch"]>((command) =>
+      Effect.sync(() => {
+        commands.push(command);
+        return { sequence: commands.length };
+      }),
+    );
+    const orchestrationEngine = {
+      dispatch,
+      getReadModel: () => Effect.succeed(makeReadModel(thread)),
+      subscribeDomainEvents: Effect.succeed(Stream.empty),
+    } as unknown as OrchestrationEngineShape;
+    const providerService = {
+      stopSession: () => Effect.void,
+    } as unknown as ProviderServiceShape;
+    const layer = Layer.effect(
+      SidechatExpiryReactor,
+      makeSidechatExpiryReactor({
+        now: () => nowMs,
+        schedule: (callback, delayMs) => setTimeout(callback, delayMs),
+        cancel: clearTimeout,
+        runFork: (effect) => {
+          Effect.runFork(effect);
+        },
+      }),
+    ).pipe(
+      Layer.provideMerge(Layer.succeed(OrchestrationEngineService, orchestrationEngine)),
+      Layer.provideMerge(Layer.succeed(ProviderService, providerService)),
+    );
+    const runtime = ManagedRuntime.make(layer);
+    const scope = await Effect.runPromise(Scope.make("sequential"));
+
+    try {
+      const reactor = await runtime.runPromise(Effect.service(SidechatExpiryReactor));
+      await Effect.runPromise(reactor.start.pipe(Scope.provide(scope)));
+
+      // The shell can publish the unarchived projection before this reactor sees
+      // the matching domain event. The view must still seed from that projection.
+      thread = { ...thread, archivedAt: null };
+      await Effect.runPromise(reactor.viewStarted(thread.id));
+
+      expect(commands).toContainEqual(
+        expect.objectContaining({
+          type: "thread.sidechat.activity.record",
+          threadId: thread.id,
+          activityAt: new Date(nowMs).toISOString(),
+        }),
+      );
+    } finally {
+      await Effect.runPromise(Scope.close(scope, Exit.void));
+      await runtime.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## What Changed

- track known sidechat identities separately from the generic thread cache;
- let a missing sidechat timer re-seed from the authoritative read model even when the thread itself was already known;
- add a focused regression for a view opening after the unarchived projection publishes but before the expiry reactor consumes the unarchive event.

## Why

Archived sidechats remain in `knownThreadIds` while their expiry timer is removed. During the cross-stream unarchive race, `viewStarted` therefore failed `timer.beginView` but skipped read-model recovery because the thread was already known. The later unarchive event could restore the timer without the active viewer lease, allowing a visible sidechat to age toward expiry.

## UI Changes

None.

## Verification

Added a focused reactor race regression. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes