### PR TITLE
fix(shared): preserve Windows drive-root identity

### DIFF
--- a/packages/shared/src/threadWorkspace.test.ts
+++ b/packages/shared/src/threadWorkspace.test.ts
@@ -7,7 +7,9 @@ import { describe, expect, it } from "vitest";
 import {
   isScratchWorkspacePath,
   isWorkspaceRootWithin,
+  normalizeWorkspaceRootForComparison,
   SCRATCH_WORKSPACES_DIRNAME,
+  workspaceRootsEqual,
 } from "./threadWorkspace";
 
 describe("isWorkspaceRootWithin", () => {
@@ -33,6 +35,14 @@ describe("isWorkspaceRootWithin", () => {
 
   it("does not match when the candidate is an ancestor of the root", () => {
     expect(isWorkspaceRootWithin("/Users/dev", "/Users/dev/app")).toBe(false);
+  });
+
+  it("keeps a Windows drive root distinct from a drive-relative path", () => {
+    const options = { platform: "win32" } as const;
+    expect(normalizeWorkspaceRootForComparison("C:\\", options)).toBe("c:/");
+    expect(normalizeWorkspaceRootForComparison("C:", options)).toBe("c:");
+    expect(workspaceRootsEqual("C:", "C:\\", options)).toBe(false);
+    expect(isWorkspaceRootWithin("C:\\repo", "C:\\", options)).toBe(true);
   });
 
   it("returns false for empty inputs", () => {

--- a/packages/shared/src/threadWorkspace.ts
+++ b/packages/shared/src/threadWorkspace.ts
@@ -40,12 +40,17 @@ export function normalizeWorkspaceRootForComparison(
   }
 
   const withForwardSlashes = trimmed.replace(/\\/g, "/");
+  const isWindowsDriveRoot = /^[a-z]:\/+$/i.test(withForwardSlashes);
   const hasUncPrefix = withForwardSlashes.startsWith("//");
   const prefix = hasUncPrefix ? "//" : withForwardSlashes.startsWith("/") ? "/" : "";
   const body = withForwardSlashes.slice(prefix.length).replace(/\/+/g, "/");
   const normalized =
     prefix.length > 0 ? `${prefix}${body.replace(/\/+$/g, "")}` : body.replace(/\/+$/g, "");
-  let finalValue = normalized.length > 0 ? normalized : prefix;
+  let finalValue = isWindowsDriveRoot
+    ? `${withForwardSlashes.slice(0, 2)}/`
+    : normalized.length > 0
+      ? normalized
+      : prefix;
 
   // macOS commonly surfaces the same temp/workspace location through both
   // `/var/...` and `/private/var/...` (likewise `/tmp/...` vs `/private/tmp/...`).


### PR DESCRIPTION
## What Changed

- preserve the trailing separator when normalizing a Windows drive root;
- keep drive-relative values such as `C:` distinct from the absolute root `C:\\`;
- add focused equality and containment regressions.

## Why

Workspace normalization stripped the slash from `C:\\`, reducing both `C:\\` and Windows' drive-relative `C:` form to `c:`. Project, import, and workspace-association code could therefore treat an ambiguous drive-relative location as the drive root.

## UI Changes

None.

## Verification

Extended the focused workspace-root tests. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes