### PR TITLE
fix(server): keep Bun close listener objects distinct

### DIFF
--- a/apps/server/src/bunWebSocketCompatibility.test.ts
+++ b/apps/server/src/bunWebSocketCompatibility.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { patchCloseEventTarget } from "./bunWebSocketCompatibility.ts";
+
+type CloseEventLike = {
+  readonly code: number;
+  readonly reason: string;
+  readonly wasClean: boolean;
+};
+
+class FakeCloseEventTarget {
+  readonly listeners = new Set<(...args: ReadonlyArray<unknown>) => void>();
+
+  addEventListener(_type: string, listener: unknown): void {
+    if (typeof listener === "function") {
+      this.listeners.add(listener as (...args: ReadonlyArray<unknown>) => void);
+    }
+  }
+
+  removeEventListener(_type: string, listener: unknown): void {
+    if (typeof listener === "function") {
+      this.listeners.delete(listener as (...args: ReadonlyArray<unknown>) => void);
+    }
+  }
+
+  emitClose(code: number, reason: string): void {
+    for (const listener of this.listeners) {
+      listener(code, reason);
+    }
+  }
+}
+
+class ObjectListener {
+  readonly events: CloseEventLike[] = [];
+
+  handleEvent(event: CloseEventLike): void {
+    this.events.push(event);
+  }
+}
+
+describe("Bun WebSocket close-event compatibility", () => {
+  it("keeps listener objects with a shared prototype method distinct", () => {
+    const target = new FakeCloseEventTarget();
+    patchCloseEventTarget(target);
+    const first = new ObjectListener();
+    const second = new ObjectListener();
+
+    target.addEventListener("close", first);
+    target.addEventListener("close", second);
+    target.emitClose(1000, "done");
+
+    expect(first.events).toEqual([{ code: 1000, reason: "done", wasClean: true }]);
+    expect(second.events).toEqual([{ code: 1000, reason: "done", wasClean: true }]);
+
+    target.removeEventListener("close", second);
+    target.emitClose(1001, "away");
+
+    expect(first.events).toHaveLength(2);
+    expect(second.events).toHaveLength(1);
+  });
+});

--- a/apps/server/src/bunWebSocketCompatibility.ts
+++ b/apps/server/src/bunWebSocketCompatibility.ts
@@ -65,7 +65,7 @@ export function patchBunWebSocketCloseEventCompatibility() {
   });
 }
 
-function patchCloseEventTarget(target: CloseEventTarget) {
+export function patchCloseEventTarget(target: CloseEventTarget) {
   const socket = target as CloseEventTarget & { readonly [PATCHED]?: true };
   if (socket[PATCHED]) return;
 
@@ -82,7 +82,7 @@ function patchCloseEventTarget(target: CloseEventTarget) {
       return originalAddEventListener.call(this, type, listener as RawListener, options);
     }
 
-    const listenerKey = typeof listener === "function" ? listener : listener.handleEvent;
+    const listenerKey: object = listener;
     let wrapped = wrappedCloseListeners.get(listenerKey);
     if (!wrapped) {
       wrapped = function patchedCloseListener(this: WebSocket, first: unknown, second: unknown) {
@@ -108,7 +108,7 @@ function patchCloseEventTarget(target: CloseEventTarget) {
       return originalRemoveEventListener.call(this, type, listener as RawListener, options);
     }
 
-    const listenerKey = typeof listener === "function" ? listener : listener.handleEvent;
+    const listenerKey: object = listener;
     return originalRemoveEventListener.call(
       this,
       type,


### PR DESCRIPTION
## What Changed

- key wrapped Bun close listeners by the listener object itself rather than its `handleEvent` method;
- preserve independent add/remove behavior for distinct listener objects that share a prototype method;
- add a focused regression using two listener instances with the same prototype handler.

## Why

The compatibility shim used `listener.handleEvent` as the `WeakMap` key for object listeners. Two instances of the same listener class therefore reused one wrapper closure, which captured the first instance. The second listener received no close event, and removing it could remove the first listener's wrapper instead.

## UI Changes

None.

## Verification

Added focused server coverage. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes