### PR TITLE
fix(web): resolve numeric PDF destinations

### DIFF
--- a/apps/web/src/lib/pdf/pdfLinks.test.ts
+++ b/apps/web/src/lib/pdf/pdfLinks.test.ts
@@ -65,9 +65,7 @@ describe("extractPageLinks", () => {
       viewport,
     });
 
-    expect(links).toEqual([
-      expect.objectContaining({ id: "1:0", targetPageNumber: 3 }),
-    ]);
+    expect(links).toEqual([expect.objectContaining({ id: "1:0", targetPageNumber: 3 })]);
     expect(doc.getPageIndex).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/lib/pdf/pdfLinks.test.ts
+++ b/apps/web/src/lib/pdf/pdfLinks.test.ts
@@ -48,6 +48,29 @@ describe("extractPageLinks", () => {
     expect(links[1]).not.toHaveProperty("url");
   });
 
+  it("resolves numeric page-index destinations and drops out-of-range indexes", async () => {
+    const doc = {
+      numPages: 4,
+      getDestination: vi.fn(),
+      getPageIndex: vi.fn(),
+    } as unknown as PDFDocumentProxy;
+
+    const links = await extractPageLinks({
+      doc,
+      page: makePage([
+        { subtype: "Link", rect: [0, 0, 10, 10], dest: [2, { name: "Fit" }] },
+        { subtype: "Link", rect: [0, 20, 10, 30], dest: [-1, { name: "Fit" }] },
+        { subtype: "Link", rect: [0, 40, 10, 50], dest: [4, { name: "Fit" }] },
+      ]),
+      viewport,
+    });
+
+    expect(links).toEqual([
+      expect.objectContaining({ id: "1:0", targetPageNumber: 3 }),
+    ]);
+    expect(doc.getPageIndex).not.toHaveBeenCalled();
+  });
+
   it("memoizes named destinations per document so repeats resolve once", async () => {
     const ref = { num: 3, gen: 0 };
     const doc = {

--- a/apps/web/src/lib/pdf/pdfLinks.ts
+++ b/apps/web/src/lib/pdf/pdfLinks.ts
@@ -50,6 +50,10 @@ async function resolveDestinationToPage(
       return undefined;
     }
     const ref = explicitDest[0];
+    if (typeof ref === "number" && Number.isInteger(ref)) {
+      const pageNumber = ref + 1;
+      return pageNumber >= 1 && pageNumber <= doc.numPages ? pageNumber : undefined;
+    }
     if (ref == null || typeof ref !== "object") {
       return undefined;
     }


### PR DESCRIPTION
## What Changed

- resolve explicit PDF destinations whose first element is a zero-based numeric page index;
- reject negative and out-of-range numeric indexes without calling `getPageIndex`;
- add focused coverage for valid and invalid numeric destinations.

## Why

PDF.js supports both page-reference objects and numeric page indexes in explicit destinations. Synara handled only object references, so valid internal links using numeric destinations were silently dropped as inert annotations.

## UI Changes

No visual redesign. Existing internal PDF links now work for this additional valid destination form.

## Verification

Added focused PDF-link coverage. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes