### PR TITLE
fix(server): ignore empty chunks at the stream limit

### DIFF
--- a/apps/server/src/stream/collectUint8StreamText.test.ts
+++ b/apps/server/src/stream/collectUint8StreamText.test.ts
@@ -34,6 +34,38 @@ describe("collectUint8StreamText", () => {
     });
   });
 
+  it("does not mark an exact-limit stream truncated for a trailing empty chunk", async () => {
+    const result = await Effect.runPromise(
+      collectUint8StreamText({
+        stream: Stream.fromIterable([encoder.encode("hello"), new Uint8Array()]),
+        maxBytes: 5,
+      }),
+    );
+
+    expect(result).toEqual({
+      text: "hello",
+      truncated: false,
+    });
+  });
+
+  it("still marks a later non-empty chunk truncated after an empty chunk", async () => {
+    const result = await Effect.runPromise(
+      collectUint8StreamText({
+        stream: Stream.fromIterable([
+          encoder.encode("hello"),
+          new Uint8Array(),
+          encoder.encode("!"),
+        ]),
+        maxBytes: 5,
+      }),
+    );
+
+    expect(result).toEqual({
+      text: "hello",
+      truncated: true,
+    });
+  });
+
   it("does not emit a replacement character when truncation splits a UTF-8 sequence", async () => {
     const result = await Effect.runPromise(
       collectUint8StreamText({

--- a/apps/server/src/stream/collectUint8StreamText.ts
+++ b/apps/server/src/stream/collectUint8StreamText.ts
@@ -43,7 +43,7 @@ export function collectUint8StreamText<E>(input: {
     input.stream,
     (): CollectState => ({ chunks: [], byteLength: 0, truncated: false }),
     (state, chunk) => {
-      if (state.truncated) {
+      if (state.truncated || chunk.byteLength === 0) {
         return state;
       }
 


### PR DESCRIPTION
## What Changed

- ignore zero-byte stream chunks before deciding that the byte limit has been exceeded;
- preserve truncation when any later non-empty chunk actually exceeds the limit;
- add focused exact-limit regressions for both stream shapes.

## Why

A stream containing exactly `maxBytes` followed by an empty chunk was reported as truncated even though no bytes were omitted. Empty chunks are valid stream values and do not prove that additional content exists.

## UI Changes

None.

## Verification

Added focused stream-collector coverage. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes