### PR TITLE
fix(shared): block prototype mutation keys in deep merges

### DIFF
--- a/packages/shared/src/Struct.test.ts
+++ b/packages/shared/src/Struct.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { deepMerge } from "./Struct";
+
+describe("deepMerge", () => {
+  it("does not let __proto__ mutate the merged object prototype", () => {
+    const patch = JSON.parse('{"__proto__":{"polluted":true}}') as {
+      readonly __proto__: { readonly polluted: boolean };
+    };
+
+    const result = deepMerge({ safe: true }, patch);
+
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect(result).toEqual({ safe: true });
+    expect((result as { polluted?: unknown }).polluted).toBeUndefined();
+  });
+
+  it("ignores prototype mutation keys at nested merge boundaries", () => {
+    const patch = JSON.parse(
+      '{"settings":{"constructor":{"polluted":true},"prototype":{"polluted":true},"__proto__":{"polluted":true}}}',
+    ) as {
+      readonly settings: Record<string, unknown>;
+    };
+
+    const result = deepMerge({ settings: { enabled: true } }, patch);
+
+    expect(result).toEqual({ settings: { enabled: true } });
+    expect(Object.getPrototypeOf(result.settings)).toBe(Object.prototype);
+  });
+});

--- a/packages/shared/src/Struct.test.ts
+++ b/packages/shared/src/Struct.test.ts
@@ -4,27 +4,24 @@ import { deepMerge } from "./Struct";
 
 describe("deepMerge", () => {
   it("does not let __proto__ mutate the merged object prototype", () => {
-    const patch = JSON.parse('{"__proto__":{"polluted":true}}') as {
-      readonly __proto__: { readonly polluted: boolean };
-    };
+    const patch = JSON.parse('{"__proto__":{"polluted":true}}') as Record<string, unknown>;
 
-    const result = deepMerge({ safe: true }, patch);
+    const result = deepMerge<Record<string, unknown>>({ safe: true }, patch);
 
     expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
     expect(result).toEqual({ safe: true });
-    expect((result as { polluted?: unknown }).polluted).toBeUndefined();
+    expect(result.polluted).toBeUndefined();
   });
 
   it("ignores prototype mutation keys at nested merge boundaries", () => {
     const patch = JSON.parse(
       '{"settings":{"constructor":{"polluted":true},"prototype":{"polluted":true},"__proto__":{"polluted":true}}}',
-    ) as {
-      readonly settings: Record<string, unknown>;
-    };
+    ) as Record<string, unknown>;
 
-    const result = deepMerge({ settings: { enabled: true } }, patch);
+    const result = deepMerge<Record<string, unknown>>({ settings: { enabled: true } }, patch);
+    const settings = result.settings as Record<string, unknown>;
 
     expect(result).toEqual({ settings: { enabled: true } });
-    expect(Object.getPrototypeOf(result.settings)).toBe(Object.prototype);
+    expect(Object.getPrototypeOf(settings)).toBe(Object.prototype);
   });
 });

--- a/packages/shared/src/Struct.ts
+++ b/packages/shared/src/Struct.ts
@@ -4,6 +4,8 @@ export type DeepPartial<T> = T extends readonly (infer Item)[]
     ? { readonly [Key in keyof T]?: DeepPartial<T[Key]> }
     : T;
 
+const PROTOTYPE_MUTATION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
@@ -15,7 +17,7 @@ export function deepMerge<T>(base: T, patch: DeepPartial<T>): T {
 
   const next: Record<string, unknown> = { ...base };
   for (const [key, value] of Object.entries(patch)) {
-    if (value === undefined) {
+    if (value === undefined || PROTOTYPE_MUTATION_KEYS.has(key)) {
       continue;
     }
     const current = next[key];


### PR DESCRIPTION
## What Changed

- ignore `__proto__`, `constructor`, and `prototype` keys at every deep-merge boundary;
- preserve ordinary recursive merge behavior and undefined-value handling;
- add adversarial top-level and nested regression coverage.

## Why

`deepMerge` assigned every patch key onto an ordinary object. A JSON-derived `__proto__` key therefore invoked the inherited prototype setter and changed the merged result's prototype instead of producing normal data. The utility is used by server-settings patching, so the primitive should remain safe regardless of caller-side schema filtering.

## UI Changes

None.

## Verification

Added focused shared-utility coverage. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes