### PR TITLE
fix(sidebar): show chat shortcuts in activity view

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -8292,10 +8292,10 @@ describe("ChatView timeline estimator parity (full app)", () => {
         taskListCard!.getBoundingClientRect().top + 1,
       );
       // Active plan activity shares the centered queued-follow-up rail, intentionally inset to
-      // eleven twelfths of the composer width while the input keeps its rounded top corners.
+      // fourteen fifteenths of the composer width while the input keeps its rounded top corners.
       const taskRect = taskListCard!.getBoundingClientRect();
       const composerRect = composerShell!.getBoundingClientRect();
-      expect(Math.abs(taskRect.width - (composerRect.width * 11) / 12)).toBeLessThanOrEqual(2);
+      expect(Math.abs(taskRect.width - (composerRect.width * 14) / 15)).toBeLessThanOrEqual(2);
       expect(
         Math.abs(taskRect.left + taskRect.width / 2 - (composerRect.left + composerRect.width / 2)),
       ).toBeLessThanOrEqual(1);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -6151,6 +6151,7 @@ export default function Sidebar() {
                     }}
                     onProjectContextMenu={handleProjectContextMenu}
                     prByThreadId={prByThreadId}
+                    threadJumpLabelByThreadId={visibleThreadJumpLabelByThreadId}
                     onVisibleThreadIdsChange={handleActivityVisibleThreadIdsChange}
                     renderThreadHoverCard={(thread, anchorId) =>
                       renderThreadHoverCardPopup(

--- a/apps/web/src/components/SidebarActivityView.browser.tsx
+++ b/apps/web/src/components/SidebarActivityView.browser.tsx
@@ -73,6 +73,7 @@ function renderActivity(input: {
   pinnedThreadIdSet?: ReadonlySet<ThreadId>;
   settledOverrideByThreadId?: ReadonlyMap<ThreadId, boolean>;
   prByThreadId?: ReadonlyMap<ThreadId, OrchestrationThreadPullRequest | null>;
+  threadJumpLabelByThreadId?: ReadonlyMap<ThreadId, string>;
   onVisibleThreadIdsChange?: (threadIds: readonly ThreadId[]) => void;
   onOpenThread?: (threadId: ThreadId) => void;
   onSetThreadSettled?: (threadId: ThreadId, settled: boolean) => void;
@@ -93,6 +94,7 @@ function renderActivity(input: {
       settledOverrideByThreadId={input.settledOverrideByThreadId ?? new Map()}
       threadsHydrated
       prByThreadId={input.prByThreadId ?? new Map()}
+      threadJumpLabelByThreadId={input.threadJumpLabelByThreadId ?? new Map()}
       onVisibleThreadIdsChange={input.onVisibleThreadIdsChange ?? (() => {})}
       resolveThreadStatus={input.resolveThreadStatus ?? (() => null)}
       onOpenThread={input.onOpenThread ?? (() => {})}
@@ -114,6 +116,20 @@ function renderActivity(input: {
 describe("SidebarActivityView", () => {
   afterEach(() => {
     document.body.innerHTML = "";
+  });
+
+  it("shows an assigned thread jump shortcut in its activity row", async () => {
+    const thread = makeThread(0);
+    const mounted = await render(
+      renderActivity({
+        threads: [thread],
+        threadJumpLabelByThreadId: new Map([[thread.id, "⌘1"]]),
+      }),
+    );
+
+    expect(page.getByText("⌘")).toBeVisible();
+    expect(page.getByText("1")).toBeVisible();
+    await mounted.unmount();
   });
 
   it("pages project groups, reports only mounted rows, and prefers live PR state", async () => {

--- a/apps/web/src/components/SidebarActivityView.tsx
+++ b/apps/web/src/components/SidebarActivityView.tsx
@@ -27,6 +27,7 @@ import {
   WorktreeIcon,
 } from "~/lib/icons";
 import { cn } from "~/lib/utils";
+import { splitShortcutLabel } from "../keybindings";
 import {
   SIDEBAR_ROW_ACTIVE_CLASS_NAME,
   SIDEBAR_ROW_FOCUS_CLASS_NAME,
@@ -78,6 +79,7 @@ import { ThreadArchiveActionButton } from "./ThreadArchiveActionButton";
 import { ThreadPinToggleButton } from "./ThreadPinToggleButton";
 import { DisclosureChevron } from "./ui/DisclosureChevron";
 import { DisclosureRegion } from "./ui/DisclosureRegion";
+import { Kbd, KbdGroup } from "./ui/kbd";
 import {
   Menu,
   MenuGroup,
@@ -107,6 +109,7 @@ function ActivityThreadRow({
   isPinned,
   pr,
   status,
+  threadJumpLabel,
   onOpen,
   onSetSettled,
   onTogglePinned,
@@ -123,6 +126,7 @@ function ActivityThreadRow({
   isPinned: boolean;
   pr: OrchestrationThreadPullRequest | null;
   status: ThreadStatusPill | null;
+  threadJumpLabel: string | null;
   onOpen: () => void;
   onSetSettled: (settled: boolean) => void;
   onTogglePinned: () => void;
@@ -148,7 +152,12 @@ function ActivityThreadRow({
   // One trailing slot, top-right, shared by every status: the accent dot for an
   // unread completion and the running spinner (or state dot) for everything
   // else — same rule and same glyphs the classic thread/project rows use.
-  const trailingStatus = resolveThreadStatusTrailingIndicator({ status, isActive });
+  const trailingStatus = resolveThreadStatusTrailingIndicator({
+    status,
+    isActive,
+    slotOccupied: Boolean(threadJumpLabel),
+  });
+  const threadJumpLabelParts = threadJumpLabel ? splitShortcutLabel(threadJumpLabel) : [];
   // Rename/context-menu gestures live on the row wrapper (not the title button) so
   // they also fire over the trailing status and hover-action cluster, which are
   // absolutely positioned siblings of the button.
@@ -186,6 +195,7 @@ function ActivityThreadRow({
           <span
             className={cn(
               "flex min-w-0 items-center gap-1.5 overflow-hidden pr-5 transition-[padding] duration-150 ease-out",
+              threadJumpLabel && "pr-12",
               // Yield the title row to the hover action cluster (pin + archive + done).
               "group-hover/activity-row:pr-[4.25rem] group-focus-within/activity-row:pr-[4.25rem]",
             )}
@@ -225,6 +235,18 @@ function ActivityThreadRow({
             </span>
           </span>
         </button>
+        {threadJumpLabel ? (
+          <KbdGroup
+            className={cn(
+              "pointer-events-none absolute top-1 right-1",
+              sidebarHoverRevealHideClassName("activity-row"),
+            )}
+          >
+            {threadJumpLabelParts.map((part) => (
+              <Kbd key={part}>{part}</Kbd>
+            ))}
+          </KbdGroup>
+        ) : null}
         {trailingStatus ? (
           <span
             data-slot="activity-completion-status"
@@ -535,6 +557,7 @@ export function SidebarActivityView({
   onProjectContextMenu,
   renderThreadHoverCard,
   prByThreadId,
+  threadJumpLabelByThreadId,
   onVisibleThreadIdsChange,
   onCreateChat,
   onAddProject,
@@ -546,6 +569,7 @@ export function SidebarActivityView({
   settledOverrideByThreadId: ReadonlyMap<ThreadId, boolean>;
   threadsHydrated: boolean;
   prByThreadId: ReadonlyMap<ThreadId, OrchestrationThreadPullRequest | null>;
+  threadJumpLabelByThreadId: ReadonlyMap<ThreadId, string>;
   onVisibleThreadIdsChange: (threadIds: readonly ThreadId[]) => void;
   resolveThreadStatus: (thread: SidebarThreadSummary) => ThreadStatusPill | null;
   onOpenThread: (threadId: ThreadId) => void;
@@ -715,6 +739,7 @@ export function SidebarActivityView({
             })
       }
       status={resolveThreadStatus(thread)}
+      threadJumpLabel={threadJumpLabelByThreadId.get(thread.id) ?? null}
       onOpen={() => onOpenThread(thread.id)}
       onSetSettled={(settled) => {
         if (settled) onMarkThreadRead(thread.id, thread.latestTurn?.completedAt ?? undefined);


### PR DESCRIPTION
## Summary
- show numbered chat jump shortcuts while holding the primary modifier in Activity view
- reuse the existing shortcut labels and trailing status slot from the classic sidebar
- cover the Activity row behavior with a Chromium browser regression test

## Verification
- `VITEST_BROWSER_API_PORT=51137 bun run --cwd apps/web test:browser SidebarActivityView.browser.tsx` (9 passed)
- `bun run --cwd apps/web test SidebarActivityView.logic.test.ts keybindings.test.ts` (119 passed)

Full `fmt`, `lint`, and `typecheck` were not run because repository instructions require an explicit request.