### PR TITLE
fix(web): clear legacy workspace path fallback

### DIFF
--- a/apps/web/src/workspacePathsStore.clearLegacy.test.ts
+++ b/apps/web/src/workspacePathsStore.clearLegacy.test.ts
@@ -57,7 +57,8 @@ describe("workspace path storage clearing", () => {
 
     vi.resetModules();
     workspaceModule = await import("./workspacePathsStore");
-    expect(workspaceModule.useWorkspacePathsStore.getState().homeDir).toBeNull();
-    expect(workspaceModule.useWorkspacePathsStore.getState().chatWorkspaceRoot).toBeNull();
+    const reloadedState = workspaceModule.useWorkspacePathsStore.getState();
+    expect(reloadedState.homeDir ?? null).toBeNull();
+    expect(reloadedState.chatWorkspaceRoot ?? null).toBeNull();
   });
 });

--- a/apps/web/src/workspacePathsStore.clearLegacy.test.ts
+++ b/apps/web/src/workspacePathsStore.clearLegacy.test.ts
@@ -1,0 +1,63 @@
+// FILE: workspacePathsStore.clearLegacy.test.ts
+// Purpose: Verifies clearing cached workspace paths cannot resurrect the legacy fallback.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const CURRENT_STORAGE_KEY = "synara:workspace-paths:v1";
+const LEGACY_STORAGE_KEY = "synara:workspace-pages:v2";
+
+function installMemoryLocalStorage() {
+  const entries = new Map<string, string>();
+
+  vi.stubGlobal("localStorage", {
+    getItem: vi.fn((key: string) => entries.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      entries.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      entries.delete(key);
+    }),
+    clear: vi.fn(() => {
+      entries.clear();
+    }),
+    key: vi.fn((index: number) => Array.from(entries.keys())[index] ?? null),
+    get length() {
+      return entries.size;
+    },
+  });
+}
+
+describe("workspace path storage clearing", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("removes the legacy fallback when cached paths are cleared", async () => {
+    installMemoryLocalStorage();
+    localStorage.setItem(
+      LEGACY_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          homeDir: "/Users/legacy",
+          chatWorkspaceRoot: "/Users/legacy/Documents/Synara",
+        },
+        version: 2,
+      }),
+    );
+    vi.resetModules();
+
+    let workspaceModule = await import("./workspacePathsStore");
+    expect(workspaceModule.useWorkspacePathsStore.getState().homeDir).toBe("/Users/legacy");
+
+    await workspaceModule.useWorkspacePathsStore.persist.clearStorage();
+
+    expect(localStorage.getItem(CURRENT_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem(LEGACY_STORAGE_KEY)).toBeNull();
+
+    vi.resetModules();
+    workspaceModule = await import("./workspacePathsStore");
+    expect(workspaceModule.useWorkspacePathsStore.getState().homeDir).toBeNull();
+    expect(workspaceModule.useWorkspacePathsStore.getState().chatWorkspaceRoot).toBeNull();
+  });
+});

--- a/apps/web/src/workspacePathsStore.ts
+++ b/apps/web/src/workspacePathsStore.ts
@@ -34,6 +34,7 @@ function createWorkspacePathsStorage(): StateStorage {
     },
     removeItem: (name) => {
       localStorage.removeItem(name);
+      localStorage.removeItem(LEGACY_WORKSPACE_PAGES_STORAGE_KEY);
     },
   };
 }


### PR DESCRIPTION
## What Changed

- remove the retired `synara:workspace-pages:v2` fallback whenever the current workspace-path store is cleared;
- add a regression that clears hydrated legacy data and reloads the store.

## Why

The storage adapter read the legacy key whenever the current key was absent, but `removeItem` deleted only the current key. Calling Zustand's `clearStorage()` therefore appeared to clear cached workspace paths, yet the next app load hydrated the same paths again from the legacy fallback.

## UI Changes

None.

## Verification

Added focused web-store coverage proving both storage keys are removed and a fresh module load starts with empty paths. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes