### PR TITLE
fix(server): isolate concurrent credential temp files

### DIFF
--- a/apps/server/src/providerUsage/credentials.atomic.test.ts
+++ b/apps/server/src/providerUsage/credentials.atomic.test.ts
@@ -1,0 +1,44 @@
+// FILE: providerUsage/credentials.atomic.test.ts
+// Purpose: Verifies concurrent credential rotations use isolated atomic temp files.
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { writeJsonFileAtomic } from "./credentials.ts";
+
+const tempDirectories: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(
+    tempDirectories.splice(0).map((directory) =>
+      fs.rm(directory, { recursive: true, force: true }),
+    ),
+  );
+});
+
+describe("writeJsonFileAtomic", () => {
+  it("keeps same-millisecond concurrent writes independent", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "synara-credential-write-"));
+    tempDirectories.push(directory);
+    const credentialPath = path.join(directory, "auth.json");
+
+    // The former temp name used Date.now, so every write below targeted the same file.
+    vi.spyOn(Date, "now").mockReturnValue(1_789_000_000_000);
+    const results = await Promise.allSettled(
+      Array.from({ length: 16 }, (_, index) =>
+        writeJsonFileAtomic(credentialPath, { account: index }),
+      ),
+    );
+
+    expect(results.filter((result) => result.status === "rejected")).toEqual([]);
+    const persisted = JSON.parse(await fs.readFile(credentialPath, "utf8")) as {
+      account?: unknown;
+    };
+    expect(persisted.account).toEqual(expect.any(Number));
+    expect(await fs.readdir(directory)).toEqual(["auth.json"]);
+  });
+});

--- a/apps/server/src/providerUsage/credentials.atomic.test.ts
+++ b/apps/server/src/providerUsage/credentials.atomic.test.ts
@@ -14,9 +14,9 @@ const tempDirectories: string[] = [];
 afterEach(async () => {
   vi.restoreAllMocks();
   await Promise.all(
-    tempDirectories.splice(0).map((directory) =>
-      fs.rm(directory, { recursive: true, force: true }),
-    ),
+    tempDirectories
+      .splice(0)
+      .map((directory) => fs.rm(directory, { recursive: true, force: true })),
   );
 });
 

--- a/apps/server/src/providerUsage/credentials.ts
+++ b/apps/server/src/providerUsage/credentials.ts
@@ -6,7 +6,7 @@
 // rotation (a rotated refresh token that wasn't persisted invalidates the CLI's login).
 
 import { execFile } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import nodePath from "node:path";
 import { promisify } from "node:util";
@@ -56,11 +56,11 @@ export async function writeJsonFileAtomic(path: string, value: unknown): Promise
   const directory = nodePath.dirname(path);
   const tempPath = nodePath.join(
     directory,
-    `.${nodePath.basename(path)}.tmp-${process.pid}-${Date.now().toString(36)}`,
+    `.${nodePath.basename(path)}.tmp-${process.pid}-${randomUUID()}`,
   );
   const text = `${JSON.stringify(value, null, 2)}\n`;
   try {
-    await fs.writeFile(tempPath, text, { encoding: "utf8", mode: 0o600 });
+    await fs.writeFile(tempPath, text, { encoding: "utf8", mode: 0o600, flag: "wx" });
     await fs.rename(tempPath, path);
   } catch (cause) {
     await fs.rm(tempPath, { force: true }).catch(() => {});


### PR DESCRIPTION
## What Changed

- give every atomic credential write a UUID-scoped temporary filename;
- create temporary files exclusively with owner-only permissions;
- add a same-millisecond concurrent-write regression.

## Why

The previous temporary filename used only the process id and `Date.now()`. Two token rotations targeting the same credential file within one millisecond therefore shared one temp path. Their writes and renames could interfere, causing one rotation to fail or commit bytes written by another call.

## UI Changes

None.

## Verification

Added a focused filesystem regression that launches 16 concurrent writes under a fixed clock, requires every write to settle successfully, verifies the final JSON, and confirms no temporary files remain. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes