### PR TITLE
fix(web): migrate Kilo model favorites to OpenCode

### DIFF
--- a/apps/web/src/lib/modelFavorites.migration.test.ts
+++ b/apps/web/src/lib/modelFavorites.migration.test.ts
@@ -31,15 +31,8 @@ function makeMemoryStorage(initial: Record<string, string>): Storage {
 describe("migrateLegacyKiloFavoriteModelSlugs", () => {
   it("merges Kilo favorites into OpenCode without duplicates", () => {
     const storage = makeMemoryStorage({
-      [FAVORITE_MODEL_STORAGE_KEYS.opencode]: JSON.stringify([
-        "openai/gpt-5",
-        "shared/model",
-      ]),
-      [LEGACY_KILO_KEY]: JSON.stringify([
-        "shared/model",
-        "anthropic/claude-sonnet",
-        "",
-      ]),
+      [FAVORITE_MODEL_STORAGE_KEYS.opencode]: JSON.stringify(["openai/gpt-5", "shared/model"]),
+      [LEGACY_KILO_KEY]: JSON.stringify(["shared/model", "anthropic/claude-sonnet", ""]),
     });
 
     migrateLegacyKiloFavoriteModelSlugs(storage);

--- a/apps/web/src/lib/modelFavorites.migration.test.ts
+++ b/apps/web/src/lib/modelFavorites.migration.test.ts
@@ -3,10 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import {
-  FAVORITE_MODEL_STORAGE_KEYS,
-  migrateLegacyKiloFavoriteModelSlugs,
-} from "./modelFavorites";
+import { FAVORITE_MODEL_STORAGE_KEYS, migrateLegacyKiloFavoriteModelSlugs } from "./modelFavorites";
 
 const LEGACY_KILO_KEY = "synara:kilo-favourite-models:v1";
 

--- a/apps/web/src/lib/modelFavorites.migration.test.ts
+++ b/apps/web/src/lib/modelFavorites.migration.test.ts
@@ -3,7 +3,10 @@
 
 import { describe, expect, it } from "vitest";
 
-import { FAVORITE_MODEL_STORAGE_KEYS, migrateLegacyKiloFavoriteModelSlugs } from "./modelFavorites";
+import {
+  FAVORITE_MODEL_STORAGE_KEYS,
+  migrateLegacyKiloFavoriteModelSlugs,
+} from "./modelFavorites";
 
 const LEGACY_KILO_KEY = "synara:kilo-favourite-models:v1";
 

--- a/apps/web/src/lib/modelFavorites.migration.test.ts
+++ b/apps/web/src/lib/modelFavorites.migration.test.ts
@@ -1,0 +1,63 @@
+// FILE: modelFavorites.migration.test.ts
+// Purpose: Verifies Kilo favorite models survive the provider migration to OpenCode.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  FAVORITE_MODEL_STORAGE_KEYS,
+  migrateLegacyKiloFavoriteModelSlugs,
+} from "./modelFavorites";
+
+const LEGACY_KILO_KEY = "synara:kilo-favourite-models:v1";
+
+function makeMemoryStorage(initial: Record<string, string>): Storage {
+  const values = new Map(Object.entries(initial));
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key) => {
+      values.delete(key);
+    },
+    setItem: (key, value) => {
+      values.set(key, value);
+    },
+  };
+}
+
+describe("migrateLegacyKiloFavoriteModelSlugs", () => {
+  it("merges Kilo favorites into OpenCode without duplicates", () => {
+    const storage = makeMemoryStorage({
+      [FAVORITE_MODEL_STORAGE_KEYS.opencode]: JSON.stringify([
+        "openai/gpt-5",
+        "shared/model",
+      ]),
+      [LEGACY_KILO_KEY]: JSON.stringify([
+        "shared/model",
+        "anthropic/claude-sonnet",
+        "",
+      ]),
+    });
+
+    migrateLegacyKiloFavoriteModelSlugs(storage);
+
+    expect(JSON.parse(storage.getItem(FAVORITE_MODEL_STORAGE_KEYS.opencode) ?? "null")).toEqual([
+      "openai/gpt-5",
+      "shared/model",
+      "anthropic/claude-sonnet",
+    ]);
+    expect(storage.getItem(LEGACY_KILO_KEY)).toBeNull();
+  });
+
+  it("keeps invalid legacy data for a later recovery attempt", () => {
+    const storage = makeMemoryStorage({ [LEGACY_KILO_KEY]: "not-json" });
+
+    migrateLegacyKiloFavoriteModelSlugs(storage);
+
+    expect(storage.getItem(LEGACY_KILO_KEY)).toBe("not-json");
+    expect(storage.getItem(FAVORITE_MODEL_STORAGE_KEYS.opencode)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/modelFavorites.ts
+++ b/apps/web/src/lib/modelFavorites.ts
@@ -11,9 +11,50 @@ export const FAVORITE_MODEL_STORAGE_KEYS = {
   pi: "synara:pi-favourite-models:v1",
 } as const;
 
+const LEGACY_KILO_FAVORITE_MODEL_STORAGE_KEY = "synara:kilo-favourite-models:v1";
+
 export type FavoriteModelProvider = keyof typeof FAVORITE_MODEL_STORAGE_KEYS;
 
 const FavoriteModelSlugsSchema = Schema.Array(Schema.String);
+
+function getLocalStorage(): Storage | null {
+  try {
+    return typeof globalThis.localStorage === "undefined" ? null : globalThis.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function decodeFavoriteModelSlugs(raw: string): string[] | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    const decoded = Schema.decodeUnknownSync(FavoriteModelSlugsSchema)(parsed);
+    return Array.from(new Set(decoded.filter((entry) => entry.trim().length > 0)));
+  } catch {
+    return null;
+  }
+}
+
+/** Preserve Kilo picker preferences after its provider data is migrated to OpenCode. */
+export function migrateLegacyKiloFavoriteModelSlugs(
+  storage: Storage | null = getLocalStorage(),
+): void {
+  if (!storage) return;
+  try {
+    const legacyRaw = storage.getItem(LEGACY_KILO_FAVORITE_MODEL_STORAGE_KEY);
+    if (!legacyRaw) return;
+    const legacyFavorites = decodeFavoriteModelSlugs(legacyRaw);
+    if (!legacyFavorites) return;
+
+    const currentRaw = storage.getItem(FAVORITE_MODEL_STORAGE_KEYS.opencode);
+    const currentFavorites = currentRaw ? (decodeFavoriteModelSlugs(currentRaw) ?? []) : [];
+    const mergedFavorites = Array.from(new Set([...currentFavorites, ...legacyFavorites]));
+    storage.setItem(FAVORITE_MODEL_STORAGE_KEYS.opencode, JSON.stringify(mergedFavorites));
+    storage.removeItem(LEGACY_KILO_FAVORITE_MODEL_STORAGE_KEY);
+  } catch {
+    // Best-effort preference migration; leave the legacy value for a later retry.
+  }
+}
 
 export function supportsModelFavorites(provider: ProviderKind): provider is FavoriteModelProvider {
   return provider === "cursor" || provider === "opencode" || provider === "pi";
@@ -21,16 +62,16 @@ export function supportsModelFavorites(provider: ProviderKind): provider is Favo
 
 // Read favorite slugs for cycle order. Failures (SSR, parse errors) return [].
 export function readFavoriteModelSlugs(provider: ProviderKind): string[] {
-  if (!supportsModelFavorites(provider) || typeof globalThis.localStorage === "undefined") {
+  const storage = getLocalStorage();
+  if (!supportsModelFavorites(provider) || !storage) {
     return [];
   }
   try {
-    const raw = globalThis.localStorage.getItem(FAVORITE_MODEL_STORAGE_KEYS[provider]);
-    if (!raw) return [];
-    const parsed: unknown = JSON.parse(raw);
-    const decoded = Schema.decodeUnknownSync(FavoriteModelSlugsSchema)(parsed);
-    return decoded.filter((entry) => entry.trim().length > 0);
+    const raw = storage.getItem(FAVORITE_MODEL_STORAGE_KEYS[provider]);
+    return raw ? (decodeFavoriteModelSlugs(raw) ?? []) : [];
   } catch {
     return [];
   }
 }
+
+migrateLegacyKiloFavoriteModelSlugs();


### PR DESCRIPTION
## What Changed

- migrate the retired Kilo favorite-model key into OpenCode before picker stores hydrate;
- merge with existing OpenCode favorites while preserving order and removing duplicates;
- remove the legacy key only after the new value is written successfully;
- add focused migration coverage.

## Why

The Kilo-to-OpenCode migration moved durable provider selections, but the web favorite-model key was removed without migration. Users upgrading with saved Kilo favorites therefore lost that picker preference even though the underlying provider family moved to OpenCode.

## UI Changes

No visual redesign. Existing Kilo favorites now remain starred under OpenCode after upgrade.

## Verification

Added focused tests for merge/deduplication and fail-safe handling of invalid legacy data. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes