### PR TITLE
fix(web): migrate Kilo editor chat tabs

### DIFF
--- a/apps/web/src/editorViewState.kiloMigration.test.ts
+++ b/apps/web/src/editorViewState.kiloMigration.test.ts
@@ -1,0 +1,51 @@
+// FILE: editorViewState.kiloMigration.test.ts
+// Purpose: Verifies persisted editor tabs survive the Kilo-to-OpenCode migration.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { readEditorRailChatTabs } from "./editorViewState";
+
+const STORAGE_KEY = "synara.editor.railChatTabsByProjectId";
+
+function makeMemoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key) => {
+      values.delete(key);
+    },
+    setItem: (key, value) => {
+      values.set(key, value);
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("editor rail tab provider migration", () => {
+  it("keeps legacy Kilo tabs as OpenCode tabs", () => {
+    const storage = makeMemoryStorage();
+    vi.stubGlobal("window", { localStorage: storage });
+    storage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        "project-one": [
+          { id: "thread-kilo", title: "Legacy Kilo work", provider: "kilo" },
+          { id: "thread-codex", title: "Current work", provider: "codex" },
+        ],
+      }),
+    );
+
+    expect(readEditorRailChatTabs("project-one" as never)).toEqual([
+      { id: "thread-kilo", title: "Legacy Kilo work", provider: "opencode" },
+      { id: "thread-codex", title: "Current work", provider: "codex" },
+    ]);
+  });
+});

--- a/apps/web/src/editorViewState.ts
+++ b/apps/web/src/editorViewState.ts
@@ -124,11 +124,17 @@ function readEditorRailChatTabsMap(): PersistedEditorRailChatTabsMap {
             return [];
           }
           const candidate = rawTab as Record<string, unknown>;
+          const provider =
+            typeof candidate.provider === "string"
+              ? candidate.provider === "kilo"
+                ? "opencode"
+                : candidate.provider
+              : null;
           if (
             typeof candidate.id !== "string" ||
             typeof candidate.title !== "string" ||
-            typeof candidate.provider !== "string" ||
-            !isProviderKind(candidate.provider)
+            provider === null ||
+            !isProviderKind(provider)
           ) {
             return [];
           }
@@ -136,7 +142,7 @@ function readEditorRailChatTabsMap(): PersistedEditorRailChatTabsMap {
             {
               id: candidate.id as ThreadId,
               title: candidate.title,
-              provider: candidate.provider,
+              provider,
             },
           ];
         }),


### PR DESCRIPTION
## What Changed

- normalize persisted editor-rail tab providers from retired `kilo` to `opencode`;
- keep existing validation and deduplication for all other tab entries;
- add focused regression coverage.

## Why

The durable server migration moves Kilo threads to OpenCode, but editor-rail tabs are device-local browser state. After `kilo` was removed from `ProviderKind`, those stored tab entries failed validation and disappeared from the editor rail even though their threads still existed.

## UI Changes

No redesign. Previously open Kilo editor tabs remain available and display as OpenCode tabs after upgrade.

## Verification

Added focused web-state coverage with mixed legacy and current provider tabs. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes