### PR TITLE
fix(web): abbreviate Windows home paths

### DIFF
--- a/apps/web/src/components/sidebarHoverCardAnchors.test.ts
+++ b/apps/web/src/components/sidebarHoverCardAnchors.test.ts
@@ -8,10 +8,21 @@ describe("abbreviateHomePath", () => {
     expect(abbreviateHomePath("/Users/me", "/Users/me")).toBe("~");
   });
 
+  it("collapses Windows home paths case-insensitively", () => {
+    expect(abbreviateHomePath("C:\\Users\\Me\\project", "c:\\users\\me")).toBe(
+      "~\\project",
+    );
+    expect(abbreviateHomePath("C:/Users/Me/project", "c:\\users\\me")).toBe("~/project");
+    expect(abbreviateHomePath("C:\\Users\\Me", "c:\\users\\me\\")).toBe("~");
+  });
+
   it("leaves unrelated paths unchanged", () => {
     expect(abbreviateHomePath("/Volumes/work/project", "/Users/me")).toBe("/Volumes/work/project");
     expect(abbreviateHomePath("/Users/me-other/project", "/Users/me")).toBe(
       "/Users/me-other/project",
+    );
+    expect(abbreviateHomePath("C:\\Users\\Me-other\\project", "C:\\Users\\Me")).toBe(
+      "C:\\Users\\Me-other\\project",
     );
   });
 });

--- a/apps/web/src/components/sidebarHoverCardAnchors.test.ts
+++ b/apps/web/src/components/sidebarHoverCardAnchors.test.ts
@@ -9,9 +9,7 @@ describe("abbreviateHomePath", () => {
   });
 
   it("collapses Windows home paths case-insensitively", () => {
-    expect(abbreviateHomePath("C:\\Users\\Me\\project", "c:\\users\\me")).toBe(
-      "~\\project",
-    );
+    expect(abbreviateHomePath("C:\\Users\\Me\\project", "c:\\users\\me")).toBe("~\\project");
     expect(abbreviateHomePath("C:/Users/Me/project", "c:\\users\\me")).toBe("~/project");
     expect(abbreviateHomePath("C:\\Users\\Me", "c:\\users\\me\\")).toBe("~");
   });

--- a/apps/web/src/components/sidebarHoverCardAnchors.ts
+++ b/apps/web/src/components/sidebarHoverCardAnchors.ts
@@ -31,9 +31,44 @@ export function createProjectHoverCardAnchor(projectId: string) {
   return createSidebarEdgeRowAnchor(`[data-project-hover-anchor="${projectId}"]`);
 }
 
-export function abbreviateHomePath(cwd: string, homeDir: string | null): string {
-  if (homeDir && (cwd === homeDir || cwd.startsWith(`${homeDir}/`))) {
-    return `~${cwd.slice(homeDir.length)}`;
+function isWindowsPath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/u.test(value) || value.startsWith("\\\\");
+}
+
+function trimHomePathTrailingSeparators(value: string): string {
+  if (value === "/" || /^[A-Za-z]:[\\/]$/u.test(value)) {
+    return value;
   }
-  return cwd;
+  return value.replace(/[\\/]+$/u, "");
+}
+
+export function abbreviateHomePath(cwd: string, homeDir: string | null): string {
+  if (!homeDir) {
+    return cwd;
+  }
+
+  const normalizedHomeDir = trimHomePathTrailingSeparators(homeDir);
+  const windowsStyle = isWindowsPath(normalizedHomeDir) || isWindowsPath(cwd);
+  const comparisonCwd = cwd.replaceAll("\\", "/");
+  const comparisonHomeDir = normalizedHomeDir.replaceAll("\\", "/");
+  const comparableCwd = windowsStyle ? comparisonCwd.toLowerCase() : comparisonCwd;
+  const comparableHomeDir = windowsStyle
+    ? comparisonHomeDir.toLowerCase()
+    : comparisonHomeDir;
+  const childPrefix = comparableHomeDir.endsWith("/")
+    ? comparableHomeDir
+    : `${comparableHomeDir}/`;
+
+  if (comparableCwd === comparableHomeDir) {
+    return "~";
+  }
+  if (!comparableCwd.startsWith(childPrefix)) {
+    return cwd;
+  }
+
+  let suffix = cwd.slice(normalizedHomeDir.length);
+  if (comparisonHomeDir.endsWith("/") && suffix.length > 0 && !/^[\\/]/u.test(suffix)) {
+    suffix = `/${suffix}`;
+  }
+  return `~${suffix}`;
 }

--- a/apps/web/src/components/sidebarHoverCardAnchors.ts
+++ b/apps/web/src/components/sidebarHoverCardAnchors.ts
@@ -52,12 +52,8 @@ export function abbreviateHomePath(cwd: string, homeDir: string | null): string 
   const comparisonCwd = cwd.replaceAll("\\", "/");
   const comparisonHomeDir = normalizedHomeDir.replaceAll("\\", "/");
   const comparableCwd = windowsStyle ? comparisonCwd.toLowerCase() : comparisonCwd;
-  const comparableHomeDir = windowsStyle
-    ? comparisonHomeDir.toLowerCase()
-    : comparisonHomeDir;
-  const childPrefix = comparableHomeDir.endsWith("/")
-    ? comparableHomeDir
-    : `${comparableHomeDir}/`;
+  const comparableHomeDir = windowsStyle ? comparisonHomeDir.toLowerCase() : comparisonHomeDir;
+  const childPrefix = comparableHomeDir.endsWith("/") ? comparableHomeDir : `${comparableHomeDir}/`;
 
   if (comparableCwd === comparableHomeDir) {
     return "~";


### PR DESCRIPTION
## What Changed

- recognize Windows drive and UNC path styles when abbreviating sidebar paths;
- compare Windows paths case-insensitively and across slash styles;
- tolerate trailing separators on the configured home directory;
- preserve the original path separator in the displayed suffix;
- add focused Windows and sibling-boundary regressions.

## Why

The sidebar helper hard-coded the POSIX `/` separator and a case-sensitive prefix check. A Windows path such as `C:\\Users\\Me\\project` therefore remained fully expanded instead of displaying as `~\\project`, while mixed slash/case forms also failed to match.

## UI Changes

Windows project paths under the user's home now use the same compact tilde presentation as macOS/Linux.

## Verification

Extended the focused hover-card helper tests for Windows backslashes, mixed separators, case differences, trailing separators, and unrelated sibling paths. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes