### PR TITLE
fix(web): sync hooks after localStorage clear

### DIFF
--- a/apps/web/src/hooks/useLocalStorage.browser.tsx
+++ b/apps/web/src/hooks/useLocalStorage.browser.tsx
@@ -1,0 +1,34 @@
+// FILE: useLocalStorage.browser.tsx
+// Purpose: Verifies cross-window localStorage clear events reset subscribed hook state.
+
+import * as Schema from "effect/Schema";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "vitest-browser-react";
+
+import { useLocalStorage } from "~/hooks/useLocalStorage";
+
+const STORAGE_KEY = "synara:test:use-local-storage-clear";
+
+beforeEach(() => {
+  window.localStorage.removeItem(STORAGE_KEY);
+});
+
+afterEach(() => {
+  window.localStorage.removeItem(STORAGE_KEY);
+});
+
+describe("useLocalStorage cross-window synchronization", () => {
+  it("returns to its fallback after another window clears localStorage", async () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify("persisted"));
+    const hook = await renderHook(() =>
+      useLocalStorage(STORAGE_KEY, "fallback", Schema.String),
+    );
+    expect(hook.result.current[0]).toBe("persisted");
+
+    window.localStorage.removeItem(STORAGE_KEY);
+    window.dispatchEvent(new StorageEvent("storage", { key: null }));
+
+    await vi.waitFor(() => expect(hook.result.current[0]).toBe("fallback"));
+    await hook.unmount();
+  });
+});

--- a/apps/web/src/hooks/useLocalStorage.browser.tsx
+++ b/apps/web/src/hooks/useLocalStorage.browser.tsx
@@ -20,9 +20,7 @@ afterEach(() => {
 describe("useLocalStorage cross-window synchronization", () => {
   it("returns to its fallback after another window clears localStorage", async () => {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify("persisted"));
-    const hook = await renderHook(() =>
-      useLocalStorage(STORAGE_KEY, "fallback", Schema.String),
-    );
+    const hook = await renderHook(() => useLocalStorage(STORAGE_KEY, "fallback", Schema.String));
     expect(hook.result.current[0]).toBe("persisted");
 
     window.localStorage.removeItem(STORAGE_KEY);

--- a/apps/web/src/hooks/useLocalStorage.ts
+++ b/apps/web/src/hooks/useLocalStorage.ts
@@ -140,7 +140,10 @@ export function useLocalStorage<T, E>(
     };
 
     const handleStorageChange = (event: StorageEvent) => {
-      if (event.key === key) {
+      const affectsLocalStorage =
+        event.storageArea === null || event.storageArea === isomorphicLocalStorage;
+      // Browsers report localStorage.clear() with key === null; every subscribed key must reset.
+      if (affectsLocalStorage && (event.key === null || event.key === key)) {
         syncFromStorage();
       }
     };


### PR DESCRIPTION
## What Changed

- treat `StorageEvent.key === null` as a clear-all notification for every subscribed local-storage hook;
- ignore events explicitly associated with a different storage area;
- add a real-browser hook regression.

## Why

Browsers emit cross-document `storage` events with a null key when `localStorage.clear()` is called. The shared hook listened only for an exact key match, so already-open Synara windows retained stale settings and preferences until another write or reload.

## UI Changes

None. Existing settings now synchronize correctly across open windows after storage is cleared.

## Verification

Added a Chromium hook test that hydrates a persisted value, simulates another window clearing storage, and verifies the hook returns to its fallback. Repository CI will run the full workspace checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes