### PR TITLE
fix(sidebar): persist activity grouping

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -5807,6 +5807,38 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("keeps the selected Activity grouping after switching back from classic view", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: withActiveHomeChatThread(
+        createSnapshotForTargetUser({
+          targetMessageId: "msg-user-activity-grouping" as MessageId,
+          targetText: "activity grouping",
+        }),
+      ),
+    });
+
+    try {
+      await page.getByRole("button", { name: "Switch to activity view" }).click();
+      await page.getByRole("button", { name: "Activity options", exact: true }).click();
+      await page.getByRole("menuitemradio", { name: "Project" }).click();
+      await userEvent.keyboard("{Escape}");
+      await vi.waitFor(() => {
+        expect(document.querySelector('[role="menu"]')).toBeNull();
+      });
+
+      await page.getByRole("button", { name: "Switch to classic view" }).click();
+      await page.getByRole("button", { name: "Switch to activity view" }).click();
+      await page.getByRole("button", { name: "Activity options", exact: true }).click();
+
+      await expect
+        .element(page.getByRole("menuitemradio", { name: "Project" }))
+        .toHaveAttribute("aria-checked", "true");
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("uses the latest ordinary project from Home for the command-palette New thread action", async () => {
     useLatestProjectStore.setState({ latestProjectId: PROJECT_ID });
     const mounted = await mountChatView({

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -203,7 +203,10 @@ import {
   createThreadHoverCardAnchor,
 } from "./sidebarHoverCardAnchors";
 import { PreviewCard, PreviewCardPopup, PreviewCardTrigger } from "./ui/preview-card";
-import { hasUnreadActivity as hasUnreadActivityOutsideActiveThread } from "./SidebarActivityView.logic";
+import {
+  hasUnreadActivity as hasUnreadActivityOutsideActiveThread,
+  type ActivityGroupMode,
+} from "./SidebarActivityView.logic";
 import { SidebarActivityView } from "./SidebarActivityView";
 import { SidebarIconButton, sidebarIconButtonSlotClass } from "./SidebarIconButton";
 import { SidebarLeadingIcon } from "./SidebarLeadingIcon";
@@ -1620,6 +1623,9 @@ export default function Sidebar() {
   const [activityViewEnabled, setActivityViewEnabled] = useState(
     () => readSidebarUiState().activityViewEnabled,
   );
+  const [activityGroupMode, setActivityGroupMode] = useState<ActivityGroupMode>(
+    () => readSidebarUiState().activityGroupMode,
+  );
   const [activityVisibleThreadIds, setActivityVisibleThreadIds] = useState<readonly ThreadId[]>([]);
   const handleActivityVisibleThreadIdsChange = useCallback((threadIds: readonly ThreadId[]) => {
     setActivityVisibleThreadIds((current) => {
@@ -1646,6 +1652,7 @@ export default function Sidebar() {
         setDismissedThreadStatusKeyByThreadId(state.dismissedThreadStatusKeyByThreadId);
         setLastThreadRoute(state.lastThreadRoute);
         setActivityViewEnabled(state.activityViewEnabled);
+        setActivityGroupMode(state.activityGroupMode);
       }),
     [],
   );
@@ -3300,10 +3307,12 @@ export default function Sidebar() {
         dismissedThreadStatusKeyByThreadId,
         lastThreadRoute: nextLastThreadRoute,
         activityViewEnabled,
+        activityGroupMode,
       });
     },
     [
       activityViewEnabled,
+      activityGroupMode,
       chatSectionExpanded,
       chatThreadListExtraPages,
       dismissedThreadStatusKeyByThreadId,
@@ -4120,8 +4129,10 @@ export default function Sidebar() {
       dismissedThreadStatusKeyByThreadId,
       lastThreadRoute,
       activityViewEnabled,
+      activityGroupMode,
     });
   }, [
+    activityGroupMode,
     activityViewEnabled,
     chatSectionExpanded,
     chatThreadListExtraPages,
@@ -6152,6 +6163,8 @@ export default function Sidebar() {
                     onProjectContextMenu={handleProjectContextMenu}
                     prByThreadId={prByThreadId}
                     onVisibleThreadIdsChange={handleActivityVisibleThreadIdsChange}
+                    groupMode={activityGroupMode}
+                    onChangeGroupMode={setActivityGroupMode}
                     renderThreadHoverCard={(thread, anchorId) =>
                       renderThreadHoverCardPopup(
                         thread,

--- a/apps/web/src/components/Sidebar.uiState.test.ts
+++ b/apps/web/src/components/Sidebar.uiState.test.ts
@@ -42,6 +42,7 @@ describe("Sidebar.uiState", () => {
       dismissedThreadStatusKeyByThreadId: {},
       lastThreadRoute: null,
       activityViewEnabled: false,
+      activityGroupMode: "time",
     });
   });
 
@@ -62,6 +63,7 @@ describe("Sidebar.uiState", () => {
         splitViewId: "split-456",
       },
       activityViewEnabled: true,
+      activityGroupMode: "project",
     });
 
     expect(readSidebarUiState()).toEqual({
@@ -80,6 +82,7 @@ describe("Sidebar.uiState", () => {
         splitViewId: "split-456",
       },
       activityViewEnabled: true,
+      activityGroupMode: "project",
     });
   });
 
@@ -105,6 +108,7 @@ describe("Sidebar.uiState", () => {
           threadId: "thread-123",
           splitViewId: 42,
         },
+        activityGroupMode: "invalid",
       }),
     );
 
@@ -121,6 +125,7 @@ describe("Sidebar.uiState", () => {
         threadId: "thread-123",
       },
       activityViewEnabled: false,
+      activityGroupMode: "time",
     });
   });
 
@@ -161,6 +166,7 @@ describe("Sidebar.uiState", () => {
       dismissedThreadStatusKeyByThreadId: {},
       lastThreadRoute: null,
       activityViewEnabled: false,
+      activityGroupMode: "time",
     });
   });
 });

--- a/apps/web/src/components/Sidebar.uiState.ts
+++ b/apps/web/src/components/Sidebar.uiState.ts
@@ -5,6 +5,7 @@
 
 import { normalizeWorkspaceRootForComparison } from "@synara/shared/threadWorkspace";
 import type { LastThreadRoute } from "../chatRouteRestore";
+import type { ActivityGroupMode } from "./SidebarActivityView.logic";
 
 const SIDEBAR_UI_STATE_STORAGE_KEY = "synara:sidebar-ui:v1";
 
@@ -16,6 +17,8 @@ export type SidebarUiState = {
   lastThreadRoute: LastThreadRoute | null;
   /** Swaps the Projects surface for the flat task-feed Activity view. */
   activityViewEnabled: boolean;
+  /** Keeps the Activity feed grouped the same way across remounts and reloads. */
+  activityGroupMode: ActivityGroupMode;
 };
 
 const DEFAULT_SIDEBAR_UI_STATE: SidebarUiState = {
@@ -25,6 +28,7 @@ const DEFAULT_SIDEBAR_UI_STATE: SidebarUiState = {
   dismissedThreadStatusKeyByThreadId: {},
   lastThreadRoute: null,
   activityViewEnabled: false,
+  activityGroupMode: "time",
 };
 
 // Persisted paging is a request, not a promise: render-time clamping trims it to the real
@@ -85,6 +89,7 @@ export function readSidebarUiState(): SidebarUiState {
         splitViewId?: unknown;
       } | null;
       activityViewEnabled?: boolean;
+      activityGroupMode?: unknown;
     };
 
     const lastThreadRoute =
@@ -133,6 +138,7 @@ export function readSidebarUiState(): SidebarUiState {
       ),
       lastThreadRoute,
       activityViewEnabled: parsed.activityViewEnabled === true,
+      activityGroupMode: parsed.activityGroupMode === "project" ? "project" : "time",
     };
   } catch {
     return DEFAULT_SIDEBAR_UI_STATE;
@@ -185,6 +191,7 @@ export function persistSidebarUiState(input: SidebarUiState): void {
             }
           : null,
         activityViewEnabled: input.activityViewEnabled,
+        activityGroupMode: input.activityGroupMode,
       }),
     );
   } catch {

--- a/apps/web/src/components/SidebarActivityView.browser.tsx
+++ b/apps/web/src/components/SidebarActivityView.browser.tsx
@@ -5,7 +5,7 @@
 import "../index.css";
 
 import { ProjectId, ThreadId, type OrchestrationThreadPullRequest } from "@synara/contracts";
-import type { PointerEvent as ReactPointerEvent } from "react";
+import { useState, type PointerEvent as ReactPointerEvent } from "react";
 import { page, userEvent } from "vitest/browser";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
@@ -13,6 +13,7 @@ import { render } from "vitest-browser-react";
 import type { Project, SidebarThreadSummary } from "../types";
 import type { ThreadStatusPill } from "./Sidebar.logic";
 import { SidebarActivityView } from "./SidebarActivityView";
+import type { ActivityGroupMode } from "./SidebarActivityView.logic";
 
 const PROJECT_A = ProjectId.makeUnsafe("activity-project-a");
 const PROJECT_B = ProjectId.makeUnsafe("activity-project-b");
@@ -66,7 +67,7 @@ function makeThread(
   };
 }
 
-function renderActivity(input: {
+type RenderActivityInput = {
   threads: readonly SidebarThreadSummary[];
   projects?: readonly Project[];
   activeThreadId?: ThreadId | null;
@@ -82,7 +83,10 @@ function renderActivity(input: {
   onThreadContextMenu?: (threadId: ThreadId, position: { x: number; y: number }) => void;
   onProjectContextMenu?: (projectId: ProjectId, position: { x: number; y: number }) => void;
   resolveThreadStatus?: (thread: SidebarThreadSummary) => ThreadStatusPill | null;
-}) {
+};
+
+function ActivityViewHarness(input: RenderActivityInput) {
+  const [groupMode, setGroupMode] = useState<ActivityGroupMode>("time");
   const projects = input.projects ?? [makeProject(PROJECT_A, "Project A")];
   return (
     <SidebarActivityView
@@ -94,6 +98,8 @@ function renderActivity(input: {
       threadsHydrated
       prByThreadId={input.prByThreadId ?? new Map()}
       onVisibleThreadIdsChange={input.onVisibleThreadIdsChange ?? (() => {})}
+      groupMode={groupMode}
+      onChangeGroupMode={setGroupMode}
       resolveThreadStatus={input.resolveThreadStatus ?? (() => null)}
       onOpenThread={input.onOpenThread ?? (() => {})}
       onSetThreadSettled={input.onSetThreadSettled ?? (() => {})}
@@ -109,6 +115,10 @@ function renderActivity(input: {
       onAddProject={() => {}}
     />
   );
+}
+
+function renderActivity(input: RenderActivityInput) {
+  return <ActivityViewHarness {...input} />;
 }
 
 describe("SidebarActivityView", () => {

--- a/apps/web/src/components/SidebarActivityView.tsx
+++ b/apps/web/src/components/SidebarActivityView.tsx
@@ -536,6 +536,8 @@ export function SidebarActivityView({
   renderThreadHoverCard,
   prByThreadId,
   onVisibleThreadIdsChange,
+  groupMode,
+  onChangeGroupMode,
   onCreateChat,
   onAddProject,
 }: {
@@ -547,6 +549,8 @@ export function SidebarActivityView({
   threadsHydrated: boolean;
   prByThreadId: ReadonlyMap<ThreadId, OrchestrationThreadPullRequest | null>;
   onVisibleThreadIdsChange: (threadIds: readonly ThreadId[]) => void;
+  groupMode: ActivityGroupMode;
+  onChangeGroupMode: (mode: ActivityGroupMode) => void;
   resolveThreadStatus: (thread: SidebarThreadSummary) => ThreadStatusPill | null;
   onOpenThread: (threadId: ThreadId) => void;
   onSetThreadSettled: (threadId: ThreadId, settled: boolean) => void;
@@ -570,7 +574,6 @@ export function SidebarActivityView({
   onAddProject: () => void;
 }) {
   const [scopeSelection, setScopeSelection] = useState<ActivityScopeSelection>(null);
-  const [groupMode, setGroupMode] = useState<ActivityGroupMode>("time");
   const [pinnedOpen, setPinnedOpen] = useState(true);
   const [earlierOpen, setEarlierOpen] = useState(false);
   const [earlierExtraPages, setEarlierExtraPages] = useState(0);
@@ -784,7 +787,7 @@ export function SidebarActivityView({
         </SidebarSectionToolbar>
         <ActivityFilterMenu
           groupMode={groupMode}
-          onChangeGroupMode={setGroupMode}
+          onChangeGroupMode={onChangeGroupMode}
           markAllReadDisabled={unreadThreads.length === 0}
           onMarkAllRead={markAllRead}
         />


### PR DESCRIPTION
## What Changed

- Persist the selected Activity `Group by` mode in sidebar UI state.
- Restore the selection when Activity view is remounted or the page reloads.
- Keep the setting synchronized across storage events.
- Add unit and browser regression coverage.

## Why

Switching from Activity view to classic view unmounted the Activity sidebar and reset its local grouping state to `Time`. Moving that state into the existing persisted sidebar UI state preserves the selected option predictably.

## UI Changes

No visual styling changes. The existing `Time` / `Project` selection now remains active after leaving and reopening Activity view.

## Verification

- `Sidebar.uiState.test.ts`: 5 passed.
- Browser regression for switching Activity → classic → Activity: passed on Chromium.
- Focused verification passed after rebasing onto the latest `official/main`.
- Full workspace run: 4142 passed, 16 skipped, 1 unrelated failure in `GitCore.test.ts` because the installed Git version returns different pull-blocked wording.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No screenshot required; there is no visual change
- [x] No animation change
