### PR TITLE
Recover stale Devin sessions before prompt dispatch

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -285,7 +285,8 @@ describe("ProviderCommandReactor", () => {
       const nativeResumeSucceeded =
         nativeResumeAttempted && (input?.confirmNativeResume?.(effectiveResumeCursor) ?? true);
       if (
-        outcomeOptions?.registerPriorTranscriptBootstrapOnFreshStart === true &&
+        (outcomeOptions?.registerPriorTranscriptBootstrapOnFreshStart === true ||
+          (sessionInput.provider === "devin" && nativeResumeAttempted)) &&
         !nativeResumeSucceeded
       ) {
         pendingPriorTranscriptBootstraps.add(threadId);
@@ -8763,7 +8764,7 @@ describe("ProviderCommandReactor", () => {
     expect(harness.startSession.mock.calls[1]?.[1]).not.toHaveProperty("resumeCursor");
   });
 
-  it.each(["opencode"] as const)(
+  it.each(["opencode", "devin"] as const)(
     "discards a pending %s transcript recap on explicit session stop",
     async (provider) => {
       const harness = await createHarness({
@@ -8880,7 +8881,7 @@ describe("ProviderCommandReactor", () => {
     },
   );
 
-  it.each(["opencode"] as const)(
+  it.each(["opencode", "devin"] as const)(
     "retains the %s transcript recap when async prompt submission aborts",
     async (provider) => {
       const harness = await createHarness({
@@ -9121,7 +9122,7 @@ describe("ProviderCommandReactor", () => {
     expect(harness.completePriorTranscriptBootstrap).not.toHaveBeenCalled();
   });
 
-  it.each(["opencode"] as const)(
+  it.each(["opencode", "devin"] as const)(
     "injects transcript context when %s rejects the persisted resume cursor",
     async (provider) => {
       const harness = await createHarness({

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -953,7 +953,7 @@ describe("ProviderCommandReactor", () => {
     harness: Awaited<ReturnType<typeof createHarness>>,
     input: {
       readonly eventId: string;
-      readonly provider: "opencode";
+      readonly provider: "opencode" | "devin";
       readonly type: "completed" | "aborted";
       readonly threadId?: ThreadId;
       readonly turnId?: TurnId;

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1846,7 +1846,7 @@ const make = Effect.gen(function* () {
       if (shouldRegisterContextBootstrap) {
         freshSessionContextBootstrapThreadIds.add(threadId);
       } else if (
-        preferredProvider === "opencode" &&
+        (preferredProvider === "opencode" || preferredProvider === "devin") &&
         providerService.completePriorTranscriptBootstrap
       ) {
         // An explicit stop intentionally discards pending synthetic context.
@@ -2343,28 +2343,25 @@ const make = Effect.gen(function* () {
       const tracksDroidContextAcceptance =
         activeSession?.provider === "droid" &&
         (sidechatBootstrapText !== null || priorTranscriptBootstrapText !== null);
-      const tracksOpenCodeCompatibleContextAcceptance =
-        selectedProvider === "opencode" &&
+      const tracksDurableContextAcceptance =
+        (selectedProvider === "opencode" || selectedProvider === "devin") &&
         ((hasPendingFreshSessionTranscriptBootstrap &&
           (priorTranscriptBootstrapRetiresOnAcceptedTurn ||
             specializedBootstrapCompletesFreshSessionContext)) ||
           (hasPendingRollbackTranscriptBootstrap && priorTranscriptBootstrapRetiresOnAcceptedTurn));
       pendingContextBootstrapAttempt =
-        tracksDroidContextAcceptance || tracksOpenCodeCompatibleContextAcceptance
+        tracksDroidContextAcceptance || tracksDurableContextAcceptance
           ? {
               clearSidechat:
                 sidechatBootstrapText !== null || priorTranscriptBootstrapText !== null,
               clearFreshSessionTranscript:
                 priorTranscriptBootstrapText !== null ||
-                (tracksOpenCodeCompatibleContextAcceptance &&
-                  hasPendingFreshSessionTranscriptBootstrap),
+                (tracksDurableContextAcceptance && hasPendingFreshSessionTranscriptBootstrap),
               clearRollbackTranscript:
                 priorTranscriptBootstrapText !== null ||
-                (tracksOpenCodeCompatibleContextAcceptance &&
-                  priorTranscriptBootstrapRetiresOnAcceptedTurn),
+                (tracksDurableContextAcceptance && priorTranscriptBootstrapRetiresOnAcceptedTurn),
               completeDurablePriorTranscript:
-                tracksOpenCodeCompatibleContextAcceptance &&
-                hasPendingFreshSessionTranscriptBootstrap,
+                tracksDurableContextAcceptance && hasPendingFreshSessionTranscriptBootstrap,
               lifecycleEvidence: providerContextLifecycleEvidence,
               lifecycleEvidenceCreatedAt: input.createdAt,
             }
@@ -2555,7 +2552,7 @@ const make = Effect.gen(function* () {
       let durableCompletionSucceeded = true;
       if (
         hasPendingFreshSessionTranscriptBootstrap &&
-        selectedProvider === "opencode" &&
+        (selectedProvider === "opencode" || selectedProvider === "devin") &&
         providerService.completePriorTranscriptBootstrap
       ) {
         durableCompletionSucceeded = yield* persistPriorTranscriptBootstrapCompletion(
@@ -4190,7 +4187,10 @@ const make = Effect.gen(function* () {
     const stoppedProvider = Schema.is(ProviderKind)(thread.session?.providerName)
       ? thread.session.providerName
       : thread.modelSelection.provider;
-    if (stoppedProvider === "opencode" && providerService.completePriorTranscriptBootstrap) {
+    if (
+      (stoppedProvider === "opencode" || stoppedProvider === "devin") &&
+      providerService.completePriorTranscriptBootstrap
+    ) {
       yield* providerService.completePriorTranscriptBootstrap({ threadId: thread.id }).pipe(
         Effect.catchCause((cause) =>
           Effect.logWarning(

--- a/apps/server/src/provider/Errors.ts
+++ b/apps/server/src/provider/Errors.ts
@@ -77,6 +77,7 @@ export class ProviderAdapterProcessError extends Schema.TaggedErrorClass<Provide
     provider: Schema.String,
     threadId: Schema.String,
     detail: Schema.String,
+    reason: Schema.optional(Schema.Literal("resume-state-unavailable")),
     cause: Schema.optional(Schema.Defect),
   },
 ) {

--- a/apps/server/src/provider/Layers/DevinAdapter.test.ts
+++ b/apps/server/src/provider/Layers/DevinAdapter.test.ts
@@ -9,6 +9,8 @@ import { ThreadId, TurnId } from "@synara/contracts";
 import { Deferred, Effect, Exit, Layer, Queue, Scope, Semaphore, Stream } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { AcpRequestError, AcpTransportError } from "../acp/AcpErrors.ts";
+import { ProviderAdapterProcessError } from "../Errors.ts";
 import { ServerConfig } from "../../config.ts";
 import type { AcpSessionRuntimeShape } from "../acp/AcpSessionRuntime.ts";
 import type { AcpParsedSessionEvent } from "../acp/AcpRuntimeModel.ts";
@@ -1155,5 +1157,75 @@ describe("closeDevinSessionResources", () => {
 
     expect(calls).toEqual(["scope", "config"]);
     expect(await Effect.runPromise(Scope.close(scope, Exit.void))).toBeUndefined();
+  });
+});
+
+describe("Devin stale resume classification", () => {
+  it.each([
+    {
+      name: "exact resume rejection",
+      resume: true,
+      message: "Failed to load session data",
+      recoverable: true,
+    },
+    {
+      name: "normalized resume rejection",
+      resume: true,
+      message: " FAILED TO LOAD SESSION DATA ",
+      recoverable: true,
+    },
+    {
+      name: "fresh startup failure",
+      resume: false,
+      message: "Failed to load session data",
+      recoverable: false,
+    },
+    {
+      name: "auth error containing the phrase",
+      resume: true,
+      message: "Authentication failed: failed to load session data",
+      recoverable: false,
+    },
+    {
+      name: "unknown suffixed error",
+      resume: true,
+      message: "Failed to load session data: permission denied",
+      recoverable: false,
+    },
+    {
+      name: "transport failure",
+      resume: true,
+      message: "Failed to load session data",
+      transport: true,
+      recoverable: false,
+    },
+  ])("classifies $name without leaving a live session", async (testCase) => {
+    const cause = testCase.transport
+      ? new AcpTransportError({ detail: testCase.message, cause: new Error(testCase.message) })
+      : new AcpRequestError({ code: -32603, errorMessage: testCase.message });
+    const runtime = { ...makeLifecycleAcpRuntime(), start: () => Effect.fail(cause) };
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* DevinAdapter;
+        const threadId = ThreadId.makeUnsafe("thread-devin-classify-stale");
+        const error = yield* adapter
+          .startSession({
+            provider: "devin",
+            threadId,
+            runtimeMode: "full-access",
+            cwd: process.cwd(),
+            ...(testCase.resume
+              ? { resumeCursor: { schemaVersion: 1, sessionId: "old-session" } }
+              : {}),
+          })
+          .pipe(Effect.flip);
+        expect(error).toBeInstanceOf(ProviderAdapterProcessError);
+        expect(error).toMatchObject({ cause });
+        expect((error as ProviderAdapterProcessError).reason).toBe(
+          testCase.recoverable ? "resume-state-unavailable" : undefined,
+        );
+        expect(yield* adapter.hasSession(threadId)).toBe(false);
+      }).pipe(Effect.provide(makeDevinAdapterTestLayer(runtime))),
+    );
   });
 });

--- a/apps/server/src/provider/Layers/DevinAdapter.ts
+++ b/apps/server/src/provider/Layers/DevinAdapter.ts
@@ -80,6 +80,7 @@ import {
   ProviderAdapterSessionNotFoundError,
   ProviderAdapterValidationError,
 } from "../Errors.ts";
+import { AcpRequestError } from "../acp/AcpErrors.ts";
 import {
   classifyAcpPromptTurnCompletion,
   mapAcpToAdapterError,
@@ -1878,7 +1879,21 @@ export function makeDevinAdapter(
               ),
             );
 
-            return yield* acp.start().pipe(Effect.mapError(acpToAdapterError(input.threadId)));
+            return yield* acp.start().pipe(
+              Effect.mapError((cause) =>
+                resumeSessionId !== undefined &&
+                cause instanceof AcpRequestError &&
+                cause.errorMessage.trim().toLowerCase() === "failed to load session data"
+                  ? new ProviderAdapterProcessError({
+                      provider: PROVIDER,
+                      threadId: input.threadId,
+                      detail: cause.message,
+                      reason: "resume-state-unavailable",
+                      cause,
+                    })
+                  : acpToAdapterError(input.threadId)(cause),
+              ),
+            );
           });
 
           const resumeReplayReady =

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -2608,7 +2608,8 @@ routing.layer("ProviderServiceLive routing", (it) => {
             new ProviderAdapterProcessError({
               provider: "devin",
               threadId,
-              detail: "FAILED TO LOAD SESSION DATA for persisted cursor",
+              detail: "Failed to load session data",
+              reason: "resume-state-unavailable",
             }),
           );
         }
@@ -2653,6 +2654,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
           provider: "devin",
           threadId,
           resumeCursor: staleCursor,
+          cwd: "/tmp/devin-stale-project",
           runtimeMode: "full-access",
         });
         const directory = yield* ProviderSessionDirectory;
@@ -2669,6 +2671,10 @@ routing.layer("ProviderServiceLive routing", (it) => {
       assert.deepEqual(binding?.resumeCursor, freshCursor);
       assert.equal(outcome.nativeResumeAttempted, true);
       assert.equal(outcome.nativeResumeSucceeded, false);
+      assert.equal(outcome.priorTranscriptBootstrapPending, true);
+      assert.equal(binding?.runtimePayload?.priorTranscriptBootstrapPending, true);
+      const { resumeCursor: _cursor, ...resumedInput } = devin.startSession.mock.calls[0]![0];
+      assert.deepEqual(devin.startSession.mock.calls[1]![0], resumedInput);
     }),
   );
 
@@ -2679,7 +2685,8 @@ routing.layer("ProviderServiceLive routing", (it) => {
       const freshFailure = new ProviderAdapterProcessError({
         provider: "devin",
         threadId,
-        detail: "Fresh Devin startup failed",
+        detail: "Failed to load session data",
+        reason: "resume-state-unavailable",
       });
       const devin = makeFakeCodexAdapter("devin");
       let live = false;
@@ -2691,6 +2698,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
                 provider: "devin",
                 threadId,
                 detail: "Failed to load session data",
+                reason: "resume-state-unavailable",
               }),
             )
           : Effect.fail(freshFailure),
@@ -2728,7 +2736,12 @@ routing.layer("ProviderServiceLive routing", (it) => {
       const { exit, binding } = yield* Effect.gen(function* () {
         const provider = yield* ProviderService;
         const exit = yield* Effect.exit(
-          provider.sendTurn({ threadId, input: "must not dispatch", attachments: [] }),
+          provider.startSession(threadId, {
+            provider: "devin",
+            threadId,
+            resumeCursor: staleCursor,
+            runtimeMode: "full-access",
+          }),
         );
         const directory = yield* ProviderSessionDirectory;
         const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
@@ -2753,6 +2766,11 @@ routing.layer("ProviderServiceLive routing", (it) => {
   it.effect("fails closed for non-stale Devin startup errors", () =>
     Effect.gen(function* () {
       const cases = [
+        { provider: "devin" as const, detail: "Failed to load session data" },
+        {
+          provider: "devin" as const,
+          detail: "Authentication failed: failed to load session data",
+        },
         { provider: "devin" as const, detail: "Authentication failed while loading session" },
         { provider: "devin" as const, detail: "Session startup timed out" },
         { provider: "devin" as const, detail: "Failed to load user data" },
@@ -2865,6 +2883,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
         provider: "devin",
         threadId,
         detail: "Failed to load session data",
+        reason: "resume-state-unavailable",
       });
       devin.startSession.mockImplementation(() => Effect.fail(failure));
       devin.hasSession.mockImplementation(() => Effect.succeed(true));
@@ -2905,7 +2924,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
     }),
   );
 
-  it.effect("serializes concurrent stale Devin recovery before sending turns", () =>
+  it.effect("does not silently replace stale history during concurrent prompt dispatch", () =>
     Effect.gen(function* () {
       const threadId = asThreadId("thread-devin-stale-concurrent");
       const staleCursor = { sessionId: "stale-concurrent" };
@@ -2936,6 +2955,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
                   provider: "devin",
                   threadId,
                   detail: "Failed to load session data",
+                  reason: "resume-state-unavailable",
                 }),
               ),
             ),
@@ -2979,15 +2999,15 @@ routing.layer("ProviderServiceLive routing", (it) => {
         const provider = yield* ProviderService;
         const first = yield* provider
           .sendTurn({ threadId, input: "first", attachments: [] })
-          .pipe(Effect.forkChild);
+          .pipe(Effect.exit, Effect.forkChild);
         yield* Deferred.await(staleStarted);
         const second = yield* provider
           .sendTurn({ threadId, input: "second", attachments: [] })
-          .pipe(Effect.forkChild);
+          .pipe(Effect.exit, Effect.forkChild);
         assert.equal(devin.sendTurn.mock.calls.length, 0);
         yield* Deferred.succeed(releaseStale, undefined);
-        yield* Fiber.join(first);
-        yield* Fiber.join(second);
+        assert.equal(Exit.isFailure(yield* Fiber.join(first)), true);
+        assert.equal(Exit.isFailure(yield* Fiber.join(second)), true);
       }).pipe(Effect.provide(layer));
       const binding = yield* Effect.gen(function* () {
         const directory = yield* ProviderSessionDirectory;
@@ -2996,11 +3016,11 @@ routing.layer("ProviderServiceLive routing", (it) => {
 
       assert.deepEqual(
         devin.startSession.mock.calls.map(([input]) => input.resumeCursor),
-        [staleCursor, undefined],
+        [staleCursor, staleCursor],
       );
-      assert.equal(devin.sendTurn.mock.calls.length, 2);
-      assert.deepEqual(adoptedSessions, [liveSession, liveSession]);
-      assert.deepEqual(binding?.resumeCursor, freshCursor);
+      assert.equal(devin.sendTurn.mock.calls.length, 0);
+      assert.deepEqual(adoptedSessions, []);
+      assert.deepEqual(binding?.resumeCursor, staleCursor);
       assert.equal(devin.hasSession.mock.calls.length >= 2, true);
     }),
   );

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -45,6 +45,8 @@ import { TestClock } from "effect/testing";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
   ProviderAdapterSessionNotFoundError,
   ProviderSessionDirectoryPersistenceError,
   ProviderUnsupportedError,
@@ -117,6 +119,24 @@ function requireReleaseListSessions(release: ReleaseListSessions | undefined): R
 function withoutResumeCursor(session: ProviderSession): ProviderSession {
   const { resumeCursor: _omittedResumeCursor, ...rest } = session;
   return rest;
+}
+
+function makeSession(
+  threadId: ThreadId,
+  provider: ProviderKind,
+  resumeCursor: unknown,
+): ProviderSession {
+  const now = new Date().toISOString();
+  return {
+    provider,
+    status: "ready",
+    runtimeMode: "full-access",
+    threadId,
+    resumeCursor,
+    cwd: process.cwd(),
+    createdAt: now,
+    updatedAt: now,
+  };
 }
 
 function asRuntimePayloadRecord(value: unknown): Record<string, unknown> {
@@ -2571,6 +2591,417 @@ routing.layer("ProviderServiceLive routing", (it) => {
         assert.equal(startPayload.provider, "claudeAgent");
         assert.equal(startPayload.cwd, "/tmp/project-claude");
       }
+    }),
+  );
+
+  it.effect("retries a stale Devin cursor once as a fresh start", () =>
+    Effect.gen(function* () {
+      const threadId = asThreadId("thread-devin-stale-cursor");
+      const staleCursor = { sessionId: "stale-devin-session" };
+      const freshCursor = { sessionId: "fresh-devin-session" };
+      const devin = makeFakeCodexAdapter("devin");
+      let live = false;
+      devin.hasSession.mockImplementation(() => Effect.succeed(live));
+      devin.startSession.mockImplementation((input) => {
+        if (input.resumeCursor !== undefined) {
+          return Effect.fail(
+            new ProviderAdapterProcessError({
+              provider: "devin",
+              threadId,
+              detail: "FAILED TO LOAD SESSION DATA for persisted cursor",
+            }),
+          );
+        }
+        live = true;
+        const now = new Date().toISOString();
+        return Effect.succeed({
+          provider: "devin",
+          status: "ready",
+          runtimeMode: input.runtimeMode,
+          threadId,
+          resumeCursor: freshCursor,
+          cwd: input.cwd ?? process.cwd(),
+          createdAt: now,
+          updatedAt: now,
+        });
+      });
+      const registry: typeof ProviderAdapterRegistry.Service = {
+        getByProvider: (provider) =>
+          provider === "devin"
+            ? Effect.succeed(devin.adapter)
+            : Effect.fail(new ProviderUnsupportedError({ provider })),
+        listProviders: () => Effect.succeed(["devin"]),
+      };
+      const runtimeRepositoryLayer = ProviderSessionRuntimeRepositoryLive.pipe(
+        Layer.provide(SqlitePersistenceMemory),
+      );
+      const directoryLayer = ProviderSessionDirectoryLive.pipe(
+        Layer.provide(runtimeRepositoryLayer),
+      );
+      const layer = Layer.merge(
+        makeProviderServiceLive().pipe(
+          Layer.provide(Layer.succeed(ProviderAdapterRegistry, registry)),
+          Layer.provide(directoryLayer),
+          Layer.provide(NodeServices.layer),
+        ),
+        directoryLayer,
+      );
+
+      const { outcome, binding } = yield* Effect.gen(function* () {
+        const provider = yield* ProviderService;
+        const outcome = yield* provider.startSessionWithOutcome!(threadId, {
+          provider: "devin",
+          threadId,
+          resumeCursor: staleCursor,
+          runtimeMode: "full-access",
+        });
+        const directory = yield* ProviderSessionDirectory;
+        const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+        return { outcome, binding };
+      }).pipe(Effect.provide(layer));
+
+      assert.equal(devin.startSession.mock.calls.length, 2);
+      assert.deepEqual(devin.startSession.mock.calls[0]?.[0].resumeCursor, staleCursor);
+      assert.equal(devin.startSession.mock.calls[1]?.[0].resumeCursor, undefined);
+      assert.equal(devin.hasSession.mock.calls.length, 1);
+      assert.equal(devin.sendTurn.mock.calls.length, 0);
+      assert.deepEqual(outcome.session.resumeCursor, freshCursor);
+      assert.deepEqual(binding?.resumeCursor, freshCursor);
+      assert.equal(outcome.nativeResumeAttempted, true);
+      assert.equal(outcome.nativeResumeSucceeded, false);
+    }),
+  );
+
+  it.effect("leaves stale binding unchanged when Devin fresh retry fails", () =>
+    Effect.gen(function* () {
+      const threadId = asThreadId("thread-devin-fresh-retry-fails");
+      const staleCursor = { sessionId: "stale-retry-failure" };
+      const freshFailure = new ProviderAdapterProcessError({
+        provider: "devin",
+        threadId,
+        detail: "Fresh Devin startup failed",
+      });
+      const devin = makeFakeCodexAdapter("devin");
+      let live = false;
+      devin.hasSession.mockImplementation(() => Effect.succeed(live));
+      devin.startSession.mockImplementation((input) =>
+        input.resumeCursor !== undefined
+          ? Effect.fail(
+              new ProviderAdapterProcessError({
+                provider: "devin",
+                threadId,
+                detail: "Failed to load session data",
+              }),
+            )
+          : Effect.fail(freshFailure),
+      );
+      const registry: typeof ProviderAdapterRegistry.Service = {
+        getByProvider: () => Effect.succeed(devin.adapter),
+        listProviders: () => Effect.succeed(["devin"]),
+      };
+      const runtimeRepositoryLayer = ProviderSessionRuntimeRepositoryLive.pipe(
+        Layer.provide(SqlitePersistenceMemory),
+      );
+      const directoryLayer = ProviderSessionDirectoryLive.pipe(
+        Layer.provide(runtimeRepositoryLayer),
+      );
+      const layer = Layer.merge(
+        makeProviderServiceLive().pipe(
+          Layer.provide(Layer.succeed(ProviderAdapterRegistry, registry)),
+          Layer.provide(directoryLayer),
+          Layer.provide(NodeServices.layer),
+        ),
+        directoryLayer,
+      );
+
+      yield* Effect.gen(function* () {
+        const directory = yield* ProviderSessionDirectory;
+        yield* directory.upsert({
+          threadId,
+          provider: "devin",
+          runtimeMode: "full-access",
+          status: "stopped",
+          resumeCursor: staleCursor,
+        });
+      }).pipe(Effect.provide(directoryLayer));
+
+      const { exit, binding } = yield* Effect.gen(function* () {
+        const provider = yield* ProviderService;
+        const exit = yield* Effect.exit(
+          provider.sendTurn({ threadId, input: "must not dispatch", attachments: [] }),
+        );
+        const directory = yield* ProviderSessionDirectory;
+        const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+        return { exit, binding };
+      }).pipe(Effect.provide(layer));
+
+      assert.equal(Exit.isFailure(exit), true);
+      if (Exit.isFailure(exit)) {
+        assert.equal(Cause.findErrorOption(exit.cause).pipe(Option.getOrUndefined), freshFailure);
+      }
+      assert.deepEqual(
+        devin.startSession.mock.calls.map(([input]) => input.resumeCursor),
+        [staleCursor, undefined],
+      );
+      assert.equal(devin.sendTurn.mock.calls.length, 0);
+      assert.deepEqual(binding?.resumeCursor, staleCursor);
+      assert.equal(live, false);
+      assert.equal(yield* devin.hasSession(threadId), false);
+    }),
+  );
+
+  it.effect("fails closed for non-stale Devin startup errors", () =>
+    Effect.gen(function* () {
+      const cases = [
+        { provider: "devin" as const, detail: "Authentication failed while loading session" },
+        { provider: "devin" as const, detail: "Session startup timed out" },
+        { provider: "devin" as const, detail: "Failed to load user data" },
+        { provider: "devin" as const, detail: "Transport validation rejected session data" },
+        { provider: "codex" as const, detail: "Failed to load session data" },
+      ];
+
+      for (const [index, testCase] of cases.entries()) {
+        const threadId = asThreadId(`thread-devin-fail-closed-${index}`);
+        const adapter = makeFakeCodexAdapter(testCase.provider);
+        const failure = new ProviderAdapterProcessError({
+          provider: testCase.provider,
+          threadId,
+          detail: testCase.detail,
+        });
+        adapter.startSession.mockImplementation(() => Effect.fail(failure));
+        const registry: typeof ProviderAdapterRegistry.Service = {
+          getByProvider: (provider) =>
+            provider === testCase.provider
+              ? Effect.succeed(adapter.adapter)
+              : Effect.fail(new ProviderUnsupportedError({ provider })),
+          listProviders: () => Effect.succeed([testCase.provider]),
+        };
+        const runtimeRepositoryLayer = ProviderSessionRuntimeRepositoryLive.pipe(
+          Layer.provide(SqlitePersistenceMemory),
+        );
+        const directoryLayer = ProviderSessionDirectoryLive.pipe(
+          Layer.provide(runtimeRepositoryLayer),
+        );
+        const layer = makeProviderServiceLive().pipe(
+          Layer.provide(Layer.succeed(ProviderAdapterRegistry, registry)),
+          Layer.provide(directoryLayer),
+          Layer.provide(NodeServices.layer),
+        );
+
+        const exit = yield* Effect.gen(function* () {
+          const provider = yield* ProviderService;
+          return yield* Effect.exit(
+            provider.startSession(threadId, {
+              provider: testCase.provider,
+              threadId,
+              resumeCursor: { sessionId: "stale" },
+              runtimeMode: "full-access",
+            }),
+          );
+        }).pipe(Effect.provide(layer));
+
+        assert.equal(Exit.isFailure(exit), true);
+        if (Exit.isFailure(exit)) {
+          assert.equal(Cause.findErrorOption(exit.cause).pipe(Option.getOrUndefined), failure);
+        }
+        assert.equal(adapter.startSession.mock.calls.length, 1);
+        assert.equal(adapter.hasSession.mock.calls.length, 0);
+      }
+    }),
+  );
+
+  it.effect("does not retry the exact stale text from another error class", () =>
+    Effect.gen(function* () {
+      const threadId = asThreadId("thread-devin-wrong-error-class");
+      const devin = makeFakeCodexAdapter("devin");
+      const failure = new ProviderAdapterRequestError({
+        provider: "devin",
+        method: "session.start",
+        detail: "Failed to load session data",
+      });
+      devin.startSession.mockImplementation(() => Effect.fail(failure));
+      const registry: typeof ProviderAdapterRegistry.Service = {
+        getByProvider: () => Effect.succeed(devin.adapter),
+        listProviders: () => Effect.succeed(["devin"]),
+      };
+      const runtimeRepositoryLayer = ProviderSessionRuntimeRepositoryLive.pipe(
+        Layer.provide(SqlitePersistenceMemory),
+      );
+      const directoryLayer = ProviderSessionDirectoryLive.pipe(
+        Layer.provide(runtimeRepositoryLayer),
+      );
+      const layer = makeProviderServiceLive().pipe(
+        Layer.provide(Layer.succeed(ProviderAdapterRegistry, registry)),
+        Layer.provide(directoryLayer),
+        Layer.provide(NodeServices.layer),
+      );
+
+      const exit = yield* Effect.gen(function* () {
+        const provider = yield* ProviderService;
+        return yield* Effect.exit(
+          provider.startSession(threadId, {
+            provider: "devin",
+            threadId,
+            resumeCursor: { sessionId: "stale" },
+            runtimeMode: "full-access",
+          }),
+        );
+      }).pipe(Effect.provide(layer));
+
+      assert.equal(Exit.isFailure(exit), true);
+      if (Exit.isFailure(exit)) {
+        assert.equal(Cause.findErrorOption(exit.cause).pipe(Option.getOrUndefined), failure);
+      }
+      assert.equal(devin.startSession.mock.calls.length, 1);
+      assert.equal(devin.hasSession.mock.calls.length, 0);
+    }),
+  );
+
+  it.effect("does not retry stale Devin load failure when startup left a live session", () =>
+    Effect.gen(function* () {
+      const threadId = asThreadId("thread-devin-stale-live");
+      const devin = makeFakeCodexAdapter("devin");
+      const failure = new ProviderAdapterProcessError({
+        provider: "devin",
+        threadId,
+        detail: "Failed to load session data",
+      });
+      devin.startSession.mockImplementation(() => Effect.fail(failure));
+      devin.hasSession.mockImplementation(() => Effect.succeed(true));
+      const registry: typeof ProviderAdapterRegistry.Service = {
+        getByProvider: () => Effect.succeed(devin.adapter),
+        listProviders: () => Effect.succeed(["devin"]),
+      };
+      const runtimeRepositoryLayer = ProviderSessionRuntimeRepositoryLive.pipe(
+        Layer.provide(SqlitePersistenceMemory),
+      );
+      const directoryLayer = ProviderSessionDirectoryLive.pipe(
+        Layer.provide(runtimeRepositoryLayer),
+      );
+      const layer = makeProviderServiceLive().pipe(
+        Layer.provide(Layer.succeed(ProviderAdapterRegistry, registry)),
+        Layer.provide(directoryLayer),
+        Layer.provide(NodeServices.layer),
+      );
+
+      const exit = yield* Effect.gen(function* () {
+        const provider = yield* ProviderService;
+        return yield* Effect.exit(
+          provider.startSession(threadId, {
+            provider: "devin",
+            threadId,
+            resumeCursor: { sessionId: "stale" },
+            runtimeMode: "full-access",
+          }),
+        );
+      }).pipe(Effect.provide(layer));
+
+      assert.equal(Exit.isFailure(exit), true);
+      if (Exit.isFailure(exit)) {
+        assert.equal(Cause.findErrorOption(exit.cause).pipe(Option.getOrUndefined), failure);
+      }
+      assert.equal(devin.startSession.mock.calls.length, 1);
+      assert.equal(devin.hasSession.mock.calls.length, 1);
+    }),
+  );
+
+  it.effect("serializes concurrent stale Devin recovery before sending turns", () =>
+    Effect.gen(function* () {
+      const threadId = asThreadId("thread-devin-stale-concurrent");
+      const staleCursor = { sessionId: "stale-concurrent" };
+      const freshCursor = { sessionId: "fresh-concurrent" };
+      const staleStarted = yield* Deferred.make<void>();
+      const releaseStale = yield* Deferred.make<void>();
+      const devin = makeFakeCodexAdapter("devin");
+      let live = false;
+      const liveSession = makeSession(threadId, "devin", freshCursor);
+      const adoptedSessions: ProviderSession[] = [];
+      devin.hasSession.mockImplementation(() => Effect.succeed(live));
+      devin.sendTurn.mockImplementation((input) =>
+        live
+          ? Effect.sync(() => {
+              adoptedSessions.push(liveSession);
+              return { threadId: input.threadId, turnId: asTurnId(`turn-${input.input}`) };
+            })
+          : Effect.fail(new ProviderAdapterSessionNotFoundError({ provider: "devin", threadId })),
+      );
+      devin.listSessions.mockImplementation(() => Effect.succeed(live ? [liveSession] : []));
+      devin.startSession.mockImplementation((input) => {
+        if (input.resumeCursor !== undefined) {
+          return Deferred.succeed(staleStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(releaseStale)),
+            Effect.andThen(
+              Effect.fail(
+                new ProviderAdapterProcessError({
+                  provider: "devin",
+                  threadId,
+                  detail: "Failed to load session data",
+                }),
+              ),
+            ),
+          );
+        }
+        live = true;
+        return Effect.succeed(liveSession);
+      });
+      const registry: typeof ProviderAdapterRegistry.Service = {
+        getByProvider: () => Effect.succeed(devin.adapter),
+        listProviders: () => Effect.succeed(["devin"]),
+      };
+      const runtimeRepositoryLayer = ProviderSessionRuntimeRepositoryLive.pipe(
+        Layer.provide(SqlitePersistenceMemory),
+      );
+      const directoryLayer = ProviderSessionDirectoryLive.pipe(
+        Layer.provide(runtimeRepositoryLayer),
+      );
+      const layer = Layer.merge(
+        makeProviderServiceLive().pipe(
+          Layer.provide(Layer.succeed(ProviderAdapterRegistry, registry)),
+          Layer.provide(directoryLayer),
+          Layer.provide(NodeServices.layer),
+        ),
+        directoryLayer,
+      );
+
+      yield* Effect.gen(function* () {
+        const directory = yield* ProviderSessionDirectory;
+        yield* directory.upsert({
+          threadId,
+          provider: "devin",
+          runtimeMode: "full-access",
+          status: "stopped",
+          resumeCursor: staleCursor,
+          runtimePayload: { cwd: "/tmp/devin-concurrent" },
+        });
+      }).pipe(Effect.provide(directoryLayer));
+
+      yield* Effect.gen(function* () {
+        const provider = yield* ProviderService;
+        const first = yield* provider
+          .sendTurn({ threadId, input: "first", attachments: [] })
+          .pipe(Effect.forkChild);
+        yield* Deferred.await(staleStarted);
+        const second = yield* provider
+          .sendTurn({ threadId, input: "second", attachments: [] })
+          .pipe(Effect.forkChild);
+        assert.equal(devin.sendTurn.mock.calls.length, 0);
+        yield* Deferred.succeed(releaseStale, undefined);
+        yield* Fiber.join(first);
+        yield* Fiber.join(second);
+      }).pipe(Effect.provide(layer));
+      const binding = yield* Effect.gen(function* () {
+        const directory = yield* ProviderSessionDirectory;
+        return Option.getOrUndefined(yield* directory.getBinding(threadId));
+      }).pipe(Effect.provide(directoryLayer));
+
+      assert.deepEqual(
+        devin.startSession.mock.calls.map(([input]) => input.resumeCursor),
+        [staleCursor, undefined],
+      );
+      assert.equal(devin.sendTurn.mock.calls.length, 2);
+      assert.deepEqual(adoptedSessions, [liveSession, liveSession]);
+      assert.deepEqual(binding?.resumeCursor, freshCursor);
+      assert.equal(devin.hasSession.mock.calls.length >= 2, true);
     }),
   );
 

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -2672,7 +2672,11 @@ routing.layer("ProviderServiceLive routing", (it) => {
       assert.equal(outcome.nativeResumeAttempted, true);
       assert.equal(outcome.nativeResumeSucceeded, false);
       assert.equal(outcome.priorTranscriptBootstrapPending, true);
-      assert.equal(binding?.runtimePayload?.priorTranscriptBootstrapPending, true);
+      assert.equal(
+        (binding?.runtimePayload as Record<string, unknown> | undefined)
+          ?.priorTranscriptBootstrapPending,
+        true,
+      );
       const { resumeCursor: _cursor, ...resumedInput } = devin.startSession.mock.calls[0]![0];
       assert.deepEqual(devin.startSession.mock.calls[1]![0], resumedInput);
     }),

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -98,7 +98,7 @@ const isStaleDevinSessionLoadError = (
 ): error is ProviderAdapterProcessError =>
   provider === "devin" &&
   error instanceof ProviderAdapterProcessError &&
-  error.detail.toLowerCase().includes("failed to load session data");
+  error.reason === "resume-state-unavailable";
 
 export interface ProviderServiceLiveOptions {
   readonly canonicalEventLogPath?: string;
@@ -1520,10 +1520,9 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               ...(hasPersistedResumeCursor ? { resumeCursor: binding.resumeCursor } : {}),
               runtimeMode: binding.runtimeMode ?? "full-access",
             };
-            const { session: resumed } = yield* startAdapterWithStaleDevinFallback(
-              adapter,
-              resumeStartInput,
-            );
+            // Prompt construction has already happened here. Only explicit startup
+            // may replace lost native history and request a transcript recap.
+            const resumed = yield* adapter.startSession(resumeStartInput);
             if (resumed.provider !== adapter.provider) {
               return yield* toValidationError(
                 input.operation,
@@ -1850,6 +1849,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                   : false;
               const priorTranscriptBootstrapPending =
                 persistedPriorTranscriptBootstrapPending ||
+                staleDevinFallbackOccurred ||
                 (outcomeOptions?.registerPriorTranscriptBootstrapOnFreshStart === true &&
                   !nativeResumeSucceeded);
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -55,7 +55,12 @@ import {
 } from "effect";
 import { nonEmptyTrimmed } from "@synara/shared/text";
 
-import { type ProviderAdapterError, ProviderValidationError } from "../Errors.ts";
+import {
+  type ProviderAdapterError,
+  ProviderAdapterProcessError,
+  ProviderValidationError,
+} from "../Errors.ts";
+import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
 import { ProviderAdapterRegistry } from "../Services/ProviderAdapterRegistry.ts";
 import { ProviderService, type ProviderServiceShape } from "../Services/ProviderService.ts";
 import {
@@ -86,6 +91,14 @@ import {
   AGENT_GATEWAY_CREDENTIAL_ROTATION_REQUIRED,
   AGENT_GATEWAY_TURN_AUTHORITY_RETIRED,
 } from "../../agentGateway/sessionLease.ts";
+
+const isStaleDevinSessionLoadError = (
+  provider: ProviderKind,
+  error: ProviderAdapterError,
+): error is ProviderAdapterProcessError =>
+  provider === "devin" &&
+  error instanceof ProviderAdapterProcessError &&
+  error.detail.toLowerCase().includes("failed to load session data");
 
 export interface ProviderServiceLiveOptions {
   readonly canonicalEventLogPath?: string;
@@ -392,6 +405,33 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
 
     const registry = yield* ProviderAdapterRegistry;
     const directory = yield* ProviderSessionDirectory;
+    type ResolvedProviderSessionStartInput = ProviderSessionStartInput & {
+      readonly provider: ProviderKind;
+    };
+    const startAdapterWithStaleDevinFallback = (
+      adapter: ProviderAdapterShape<ProviderAdapterError>,
+      startInput: ResolvedProviderSessionStartInput,
+    ) =>
+      adapter.startSession(startInput).pipe(
+        Effect.map((session) => ({ session, staleDevinFallbackOccurred: false })),
+        Effect.catchIf(
+          (error) =>
+            hasResumeCursor(startInput.resumeCursor) &&
+            isStaleDevinSessionLoadError(startInput.provider, error),
+          (error) =>
+            adapter.hasSession(startInput.threadId).pipe(
+              Effect.flatMap((hasLiveSession) => {
+                if (hasLiveSession) {
+                  return Effect.fail(error);
+                }
+                const { resumeCursor: _staleResumeCursor, ...freshStartInput } = startInput;
+                return adapter
+                  .startSession(freshStartInput)
+                  .pipe(Effect.map((session) => ({ session, staleDevinFallbackOccurred: true })));
+              }),
+            ),
+        ),
+      );
     const ensureProviderEnabled = (provider: ProviderKind, operation: string) =>
       options?.providerIsEnabled
         ? options.providerIsEnabled(provider).pipe(
@@ -1470,7 +1510,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             );
             yield* ensureProviderEnabled(binding.provider, input.operation);
 
-            const resumed = yield* adapter.startSession({
+            const resumeStartInput = {
               threadId,
               provider: binding.provider,
               lifecycleGeneration: lease.generation,
@@ -1479,7 +1519,11 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               ...(persistedProviderOptions ? { providerOptions: persistedProviderOptions } : {}),
               ...(hasPersistedResumeCursor ? { resumeCursor: binding.resumeCursor } : {}),
               runtimeMode: binding.runtimeMode ?? "full-access",
-            });
+            };
+            const { session: resumed } = yield* startAdapterWithStaleDevinFallback(
+              adapter,
+              resumeStartInput,
+            );
             if (resumed.provider !== adapter.provider) {
               return yield* toValidationError(
                 input.operation,
@@ -1723,8 +1767,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               runtimePayloadRecord(persistedBinding.runtimePayload)[
                 PRIOR_TRANSCRIPT_BOOTSTRAP_PENDING
               ] === true;
-            const adapterStartInput = { ...input };
-            delete adapterStartInput.resumeCursor;
+            const { resumeCursor: _inputResumeCursor, ...adapterStartInput } = input;
             const effectiveProviderOptions =
               input.providerOptions ??
               (persistedBinding?.provider === input.provider
@@ -1754,7 +1797,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               // The lifecycle is updated inside observeProviderStartup; these taps
               // only log the already-recorded outcome.
               const started = yield* observeProviderStartup(
-                adapter.startSession(resolvedAdapterStartInput),
+                startAdapterWithStaleDevinFallback(adapter, resolvedAdapterStartInput),
                 { lifecycle: startupLifecycle, timeout: PROVIDER_START_SESSION_TIMEOUT },
               ).pipe(
                 Effect.tapError((cause) =>
@@ -1797,13 +1840,14 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                   )}ms for thread '${threadId}'.`,
                 );
               }
-              const session = started.value;
+              const { session, staleDevinFallbackOccurred } = started.value;
               startupLifecycle.transition("ready");
               replacementStarted = true;
               const nativeResumeAttempted = hasResumeCursor(effectiveResumeCursor);
-              const nativeResumeSucceeded = nativeResumeAttempted
-                ? (adapter.didResumeSession?.(resolvedAdapterStartInput, session) ?? true)
-                : false;
+              const nativeResumeSucceeded =
+                nativeResumeAttempted && !staleDevinFallbackOccurred
+                  ? (adapter.didResumeSession?.(resolvedAdapterStartInput, session) ?? true)
+                  : false;
               const priorTranscriptBootstrapPending =
                 persistedPriorTranscriptBootstrapPending ||
                 (outcomeOptions?.registerPriorTranscriptBootstrapOnFreshStart === true &&


### PR DESCRIPTION
## What this does

Recover stale Devin sessions before prompt dispatch. When resuming a Devin thread whose remote session data is gone, the Devin CLI fails the resume with a "failed to load session data" error. This change detects that specific failure, verifies no live session still exists for the thread, and retries as a fresh start instead of failing the dispatch.

## Behavior change

- `startSession` path: adapter start is wrapped in `startAdapterWithStaleDevinFallback` inside the existing `observeProviderStartup` observer, so lifecycle taps (`provider.session.start_failed` / `provider.session.start_cancelled`) and the start timeout are preserved. The timeout now covers both attempts (failed resume + fresh start), still bounded.
- On fallback the result is marked `nativeResumeSucceeded: false`, so prior-transcript bootstrap re-runs against the fresh session.
- `recoverSessionForThread` (resume path) gets the same fallback.
- No change for non-Devin providers, for Devin errors with different text, or when `hasSession` reports a live session (original error propagates in all three cases).

## Reviews

- ponytail-ultra: PASS. One predicate + one thin wrapper reusing existing patterns (destructuring omit, `Effect.catchIf`); no new abstractions.
- thermos bugs/security: PASS. Timeout covers both attempts; the retry error (not the swallowed stale error) is what surfaces on total failure; strictly Devin-gated; no secrets or new attack surface.
- thermos maintainability: PASS. Small, named, typed, 431 lines of new tests. No blocking findings.

## Tests

- `bunx tsc --noEmit` (apps/server): clean.
- `bunx vitest run src/provider/Layers/ProviderService.test.ts`: 106/106 pass, including stale-fallback success, live-session passthrough, non-Devin passthrough, case-insensitive match, unmatched-text passthrough, and prior-transcript bootstrap on fresh start.
- Headed live proof (local only, `evidence/895/` untracked): full dev stack booted on the rebased code (server migrations + orchestration engine up, web connected), app shell renders, New-thread flow opens the Create-project dialog, provider-update banner live, zero page errors. 2 screenshots + Playwright trace; OS screen recording TCC-blocked so trace stands in for the recording.

## Socket surface

None. The diff touches provider session startup only; a `ws|socket|gateway|transport` grep over the diff hits only pre-existing import context and one test string literal.

## Follow-ups

- The stale-session detector string-matches Devin CLI wording ("failed to load session data"). If Devin ever emits a structured error code for this case, prefer matching on that.

## Merge note

Rebased onto upstream/main anchor `562c5fea`. One conflict in `ProviderService.ts` (ours: `observeProviderStartup` lifecycle wrapper; theirs: stale-fallback call) resolved by composing the fallback inside the observer. Lane worker-895; stays DRAFT until CI is green.

## Gauntlet handoff (2026-09-04)

**Status: NOT ready — 1 BLOCKER + 8 MAJOR + 5 MINOR (prod diff is lean: +64/-10).** Review: 6 lenses + oxlint anti-slop (4 hits on changed lines). Full reports held locally by Kartik.

**Must-fix before merge**
1. **BLOCKER — prose predicate.** `includes("failed to load session data")` matches free-text upstream detail: any transient error embedding the magic words forces silent amnesia (resume cursor dropped, blank session, billed 2 starts, caller told success). A Devin rewording silently disables recovery. Fix: structured stale marker from the Devin adapter (exported constant/code) + adapter-level contract test.
2. **Hidden recovery + poisoned binding** on the resume path (details in local report — resume discards the stale-session context the replacement start needs).
3. **Tests only (no prod change):** stale-again exactly-once (scariest — no third try pinned), fresh-retry field preservation (cwd/providerOptions/generation), resume-path live guard.

**Also queued:** 2 CUT (~18 lines: drop the `provider` param — the caught error already carries it; delete `ResolvedProviderSessionStartInput` alias) + substring-match slimming post-land.

**Remaining:** Fix → reverify → websocket + playwright E2E → rebase onto `562c5fea` → CI green → undraft.
