### PR TITLE
fix(web): keep Git writing picker on dedicated backends

### DIFF
--- a/apps/server/src/git/textGenerationSelection.ts
+++ b/apps/server/src/git/textGenerationSelection.ts
@@ -1,17 +1,15 @@
-import type { ModelSelection, ProviderKind, ProviderStartOptions } from "@synara/contracts";
+import {
+  GIT_TEXT_GENERATION_PROVIDERS,
+  type GitTextGenerationProvider,
+  type ModelSelection,
+  type ProviderKind,
+  type ProviderStartOptions,
+} from "@synara/contracts";
 
-export const GIT_TEXT_GENERATION_PROVIDER_ORDER = [
-  "codex",
-  "cursor",
-  "opencode",
-  "droid",
-] as const satisfies readonly ProviderKind[];
+export const GIT_TEXT_GENERATION_PROVIDER_ORDER = GIT_TEXT_GENERATION_PROVIDERS;
+export type { GitTextGenerationProvider };
 
-export type GitTextGenerationProvider = (typeof GIT_TEXT_GENERATION_PROVIDER_ORDER)[number];
-
-const GIT_TEXT_GENERATION_PROVIDER_SET = new Set<ProviderKind>([
-  ...GIT_TEXT_GENERATION_PROVIDER_ORDER,
-]);
+const GIT_TEXT_GENERATION_PROVIDER_SET = new Set<ProviderKind>(GIT_TEXT_GENERATION_PROVIDERS);
 
 export interface TextGenerationProviderInput {
   readonly modelSelection: ModelSelection;

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -338,7 +338,7 @@ describe("getGitTextGenerationModelOptions", () => {
     });
   });
 
-  it("offers built-in Droid models to a user currently on Codex", () => {
+  it("offers built-in Droid and Cursor models to a user currently on Codex", () => {
     const options = getGitTextGenerationModelOptions({
       customCodexModels: [],
       customOpenCodeModels: [],
@@ -349,7 +349,43 @@ describe("getGitTextGenerationModelOptions", () => {
     expect(options.some((option) => option.provider === "droid" && option.slug === "auto")).toBe(
       true,
     );
+    expect(
+      options.some((option) => option.provider === "cursor" && option.slug === "composer-2.5"),
+    ).toBe(true);
     expect(options.some((option) => option.provider === "codex")).toBe(true);
+  });
+
+  it("includes custom Cursor models in the git writing picker", () => {
+    const options = getGitTextGenerationModelOptions({
+      customCodexModels: [],
+      customCursorModels: ["cursor/custom-composer"],
+      customOpenCodeModels: [],
+      textGenerationModel: "gpt-5.6-luna",
+      textGenerationProvider: "codex",
+    });
+
+    expect(
+      options.some(
+        (option) => option.provider === "cursor" && option.slug === "cursor/custom-composer",
+      ),
+    ).toBe(true);
+  });
+
+  it("omits chat-only providers that have no Git text-generation backend", () => {
+    const options = getGitTextGenerationModelOptions({
+      customCodexModels: [],
+      customClaudeModels: ["claude-opus-4-8"],
+      customGrokModels: ["grok-4.6"],
+      customOpenCodeModels: [],
+      textGenerationModel: "gpt-5.6-luna",
+      textGenerationProvider: "codex",
+    });
+
+    expect(options.some((option) => option.provider === "claudeAgent")).toBe(false);
+    expect(options.some((option) => option.provider === "grok")).toBe(false);
+    expect(options.some((option) => option.provider === "antigravity")).toBe(false);
+    expect(options.some((option) => option.provider === "pi")).toBe(false);
+    expect(options.some((option) => option.provider === "devin")).toBe(false);
   });
 });
 

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -12,8 +12,10 @@ import {
   DEFAULT_GIT_TEXT_GENERATION_MODEL,
   DEFAULT_SERVER_SETTINGS,
   DEFAULT_SERVER_SETTINGS_VIEW,
+  GIT_TEXT_GENERATION_PROVIDERS,
   TrimmedNonEmptyString,
   ProviderKind,
+  type GitTextGenerationProvider,
   type ProviderStartOptions,
   type ServerSettingsView,
   type ServerSettingsPatch,
@@ -1085,10 +1087,8 @@ export function getAppModelOptions(
   return options;
 }
 
-type GitTextGenerationDiscoveredProvider = "codex" | "droid" | "opencode";
-
 export function mapCatalogModelOptionsToAppModelOptions(
-  provider: GitTextGenerationDiscoveredProvider,
+  provider: GitTextGenerationProvider,
   options: ReadonlyArray<ProviderModelOption & { isCustom?: boolean }>,
 ): AppModelOption[] {
   return options.map((option) => ({
@@ -1099,28 +1099,20 @@ export function mapCatalogModelOptionsToAppModelOptions(
 }
 
 export function getGitTextGenerationModelOptions(
-  settings: Pick<
-    AppSettings,
-    "customCodexModels" | "customOpenCodeModels" | "textGenerationModel" | "textGenerationProvider"
-  >,
+  settings: Pick<AppSettings, "textGenerationModel" | "textGenerationProvider"> &
+    Partial<Pick<AppSettings, CustomModelSettingsKey>>,
   discoveredOptionsByProvider?: Partial<
-    Record<
-      GitTextGenerationDiscoveredProvider,
-      ReadonlyArray<ProviderModelOption & { isCustom?: boolean }>
-    >
+    Record<GitTextGenerationProvider, ReadonlyArray<ProviderModelOption & { isCustom?: boolean }>>
   >,
 ): AppModelOption[] {
-  const options = [
-    ...(discoveredOptionsByProvider?.codex
-      ? mapCatalogModelOptionsToAppModelOptions("codex", discoveredOptionsByProvider.codex)
-      : getAppModelOptions("codex", settings.customCodexModels)),
-    ...(discoveredOptionsByProvider?.opencode
-      ? mapCatalogModelOptionsToAppModelOptions("opencode", discoveredOptionsByProvider.opencode)
-      : getAppModelOptions("opencode", settings.customOpenCodeModels)),
-    ...(discoveredOptionsByProvider?.droid
-      ? mapCatalogModelOptionsToAppModelOptions("droid", discoveredOptionsByProvider.droid)
-      : getAppModelOptions("droid", [])),
-  ];
+  const options = GIT_TEXT_GENERATION_PROVIDERS.flatMap((provider) => {
+    const discovered = discoveredOptionsByProvider?.[provider];
+    if (discovered !== undefined) {
+      return mapCatalogModelOptionsToAppModelOptions(provider, discovered);
+    }
+    const customModels = settings[PROVIDER_CUSTOM_MODEL_CONFIG[provider].settingsKey] ?? [];
+    return getAppModelOptions(provider, customModels);
+  });
   const deduped: AppModelOption[] = [];
   const seen = new Set<string>();
 

--- a/apps/web/src/components/settings/ModelsSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ModelsSettingsPanel.tsx
@@ -4,7 +4,9 @@
 
 import {
   DEFAULT_GIT_TEXT_GENERATION_MODEL,
+  GIT_TEXT_GENERATION_PROVIDERS,
   PROVIDER_DISPLAY_NAMES,
+  type GitTextGenerationProvider,
   type ProviderKind,
 } from "@synara/contracts";
 import { getModelOptions, normalizeModelSlug } from "@synara/shared/model";
@@ -45,8 +47,6 @@ import { SettingsRow, SettingsSection, SettingsSelectPopup } from "./SettingsPan
 type CustomModelValidationResult =
   | { readonly model: string; readonly error?: never }
   | { readonly model?: never; readonly error: string };
-
-const GIT_WRITING_DISCOVERY_PROVIDERS = ["codex", "droid", "opencode"] as const;
 
 export function validateCustomModelInput(input: {
   readonly provider: ProviderKind;
@@ -98,8 +98,7 @@ export function ModelsSettingsPanel({
     setShowAllCustomModels(false);
   });
 
-  const { customCodexModels, customOpenCodeModels, textGenerationModel, textGenerationProvider } =
-    settings;
+  const { textGenerationModel, textGenerationProvider } = settings;
   const currentGitTextGenerationProvider = textGenerationProvider ?? "codex";
   const currentGitTextGenerationModel = textGenerationModel ?? DEFAULT_GIT_TEXT_GENERATION_MODEL;
   const gitWritingModelHintByProvider = useMemo<Partial<Record<ProviderKind, string | null>>>(
@@ -116,33 +115,18 @@ export function ModelsSettingsPanel({
     discoveryEnabled: active,
     cwd: providerModelDiscoveryCwd,
     modelHintByProvider: gitWritingModelHintByProvider,
-    prefetchProviders: GIT_WRITING_DISCOVERY_PROVIDERS,
+    prefetchProviders: GIT_TEXT_GENERATION_PROVIDERS,
   });
-  const gitTextGenerationModelOptions = useMemo(
-    () =>
-      getGitTextGenerationModelOptions(
-        {
-          customCodexModels,
-          customOpenCodeModels,
-          textGenerationModel,
-          textGenerationProvider,
-        },
-        {
-          codex: gitWritingCatalogOptionsByProvider.codex,
-          droid: gitWritingCatalogOptionsByProvider.droid,
-          opencode: gitWritingCatalogOptionsByProvider.opencode,
-        },
-      ),
-    [
-      customCodexModels,
-      customOpenCodeModels,
-      gitWritingCatalogOptionsByProvider.codex,
-      gitWritingCatalogOptionsByProvider.droid,
-      gitWritingCatalogOptionsByProvider.opencode,
-      textGenerationModel,
-      textGenerationProvider,
-    ],
-  );
+  const gitTextGenerationModelOptions = useMemo(() => {
+    const discoveredOptionsByProvider = {} as Record<
+      GitTextGenerationProvider,
+      (typeof gitWritingCatalogOptionsByProvider)[GitTextGenerationProvider]
+    >;
+    for (const provider of GIT_TEXT_GENERATION_PROVIDERS) {
+      discoveredOptionsByProvider[provider] = gitWritingCatalogOptionsByProvider[provider];
+    }
+    return getGitTextGenerationModelOptions(settings, discoveredOptionsByProvider);
+  }, [gitWritingCatalogOptionsByProvider, settings]);
   const currentGitTextGenerationValue = `${currentGitTextGenerationProvider}:${currentGitTextGenerationModel}`;
   const isGitTextGenerationModelDirty = isGitTextGenerationSettingsDirty(settings, defaults);
   const selectedGitTextGenerationModelLabel =

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -1128,6 +1128,21 @@ export const DEFAULT_MODEL = DEFAULT_MODEL_BY_PROVIDER.codex;
 export const DEFAULT_GIT_TEXT_GENERATION_MODEL = "gpt-5.6-luna" as const;
 export const DEFAULT_GIT_TEXT_GENERATION_REASONING_EFFORT = "high" as const;
 
+/**
+ * Providers with a dedicated Git text-generation backend. Keep the Settings
+ * picker in sync with this list — do not add chat-only agents (Claude, Grok,
+ * Antigravity, Pi, Devin). Those CLIs have no one-shot git-writing path, and
+ * driving them as coding agents for commit/PR text can run with write access
+ * or violate provider terms.
+ */
+export const GIT_TEXT_GENERATION_PROVIDERS = [
+  "codex",
+  "cursor",
+  "opencode",
+  "droid",
+] as const satisfies readonly ProviderKind[];
+export type GitTextGenerationProvider = (typeof GIT_TEXT_GENERATION_PROVIDERS)[number];
+
 export const MODEL_SLUG_ALIASES_BY_PROVIDER: Record<ProviderKind, Record<string, ModelSlug>> = {
   codex: {
     "5.5": "gpt-5.5",


### PR DESCRIPTION
## What Changed

The Git writing model picker now lists every provider that already has a dedicated git-writing backend: Codex, Cursor, OpenCode, and Droid. Settings and the server share one `GIT_TEXT_GENERATION_PROVIDERS` list so the UI cannot drift again.

Claude, Grok, Antigravity, Pi, and Devin stay out of the picker. They have no one-shot git-writing path; driving those coding CLIs for commit/PR text can run with write access or violate provider terms.

## Why

Settings hardcoded `codex | droid | opencode` even though the server already routes Cursor. Users only saw Codex, OpenCode, and Droid. Adding every chat agent would offer models that cannot actually generate git text without spinning up a full coding session.

## UI Changes

The Git writing dropdown now includes Cursor models (for example Composer) next to Codex, OpenCode, and Droid. Chat-only providers remain absent.

I do not have a live after screenshot from this environment. Before this change the menu stopped at Codex / OpenCode / Droid.

## Verification

- `bun run test:web:focused src/appSettings.test.ts` (74 passed)
- `bun run --cwd apps/server test src/git/Layers/ProviderTextGeneration.test.ts` (11 passed)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Made with [Cursor](https://cursor.com)