### PR TITLE
ci: parallelize the quality job into static, unit, browser, and build

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -20,12 +20,10 @@ runs:
       with:
         node-version-file: package.json
 
-    - name: Cache Bun and Turbo
+    - name: Cache Bun install
       uses: actions/cache@v5
       with:
-        path: |
-          ~/.bun/install/cache
-          .turbo
+        path: ~/.bun/install/cache
         key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}-${{ hashFiles('turbo.json') }}
         restore-keys: |
           ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}-
@@ -36,8 +34,6 @@ runs:
       with:
         path: ~/.cache/electron
         key: ${{ runner.os }}-electron-${{ hashFiles('bun.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-electron-
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -1,0 +1,50 @@
+name: Setup workspace
+description: Shared checkout, tool setup, dependency install, and caches for Synara CI jobs
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version-file: package.json
+
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version-file: package.json
+
+    - name: Cache Bun and Turbo
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.bun/install/cache
+          .turbo
+        key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}-${{ hashFiles('turbo.json') }}
+        restore-keys: |
+          ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}-
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-playwright-
+
+    - name: Cache Electron runtime
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/electron
+        key: ${{ runner.os }}-electron-${{ hashFiles('bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-electron-
+
+    - name: Install dependencies
+      shell: bash
+      env:
+        ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+      run: bun install --frozen-lockfile

--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -3,7 +3,7 @@ description: Shared tool setup, dependency install, and caches for Synara CI job
 
 inputs:
   electron:
-    description: Install the Electron runtime binary ('true' or 'false').
+    description: Install the Electron runtime binary.
     required: false
     default: "false"
 
@@ -41,8 +41,6 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      # The Electron binary is deliberately skipped here even when the electron
-      # input is true; the gated step below fetches it separately from cache.
       env:
         ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
       run: bun install --frozen-lockfile

--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -4,7 +4,6 @@ description: Shared tool setup, dependency install, and caches for Synara CI job
 inputs:
   electron:
     description: Install the Electron runtime binary.
-    required: false
     default: "false"
 
 runs:
@@ -24,7 +23,7 @@ runs:
       uses: actions/cache@v5
       with:
         path: ~/.bun/install/cache
-        key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}-${{ hashFiles('turbo.json') }}
+        key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
         restore-keys: |
           ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}-
 

--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -1,12 +1,15 @@
 name: Setup workspace
-description: Shared checkout, tool setup, dependency install, and caches for Synara CI jobs
+description: Shared tool setup, dependency install, and caches for Synara CI jobs
+
+inputs:
+  electron:
+    description: Install the Electron runtime binary ('true' or 'false').
+    required: false
+    default: "false"
 
 runs:
   using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
       with:
@@ -27,15 +30,8 @@ runs:
         restore-keys: |
           ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}-
 
-    - name: Cache Playwright browsers
-      uses: actions/cache@v5
-      with:
-        path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-playwright-
-
     - name: Cache Electron runtime
+      if: ${{ inputs.electron == 'true' }}
       uses: actions/cache@v5
       with:
         path: ~/.cache/electron
@@ -45,6 +41,22 @@ runs:
 
     - name: Install dependencies
       shell: bash
+      # The Electron binary is deliberately skipped here even when the electron
+      # input is true; the gated step below fetches it separately from cache.
       env:
         ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
       run: bun install --frozen-lockfile
+
+    - name: Install Electron test runtime
+      if: ${{ inputs.electron == 'true' }}
+      shell: bash
+      run: |
+        for attempt in 1 2 3; do
+          if node apps/desktop/node_modules/electron/install.js; then
+            exit 0
+          fi
+          if [ "$attempt" -eq 3 ]; then
+            exit 1
+          fi
+          sleep $((attempt * 5))
+        done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,6 @@ jobs:
   browser:
     name: Browser Tests
     runs-on: ubuntu-24.04
-    # Step caps sum to 45 (15+20+10); the job cap stays above that so a stall in
-    # the non-blocking geometry step can never be converted into a job failure.
     timeout-minutes: 55
     steps:
       - name: Checkout
@@ -125,8 +123,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     needs: [static, unit, browser, build]
-    # always() + the explicit result check below keep the gate fail-closed: a
-    # cancelled or skipped dependency must fail the gate, never silently pass it.
     if: always()
     steps:
       - name: Check quality results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,6 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
 
       # Run the workspace-local playwright binary directly: bunx stalled after
       # the chromium download on hosted runners. The step timeout stops any
@@ -109,6 +107,15 @@ jobs:
         uses: ./.github/actions/setup-workspace
         with:
           electron: "true"
+
+      # Only the build job produces a meaningful .turbo cache, so it is cached
+      # here rather than in the shared setup action. Exact key only: build
+      # outputs must never be restored from a prefix-matched key.
+      - name: Cache Turbo build outputs
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-build-${{ github.sha }}
 
       - name: Build desktop pipeline
         run: bun run build:desktop
@@ -231,6 +238,7 @@ jobs:
   release_smoke:
     name: Release Smoke
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# Lane rule: static is fast checks with no special runtime, unit is bun test, browser owns Playwright and is the long pole, build owns Electron and desktop output.
+# Gate (quality) aggregates only: add no run steps there. A new fast check with no runtime goes to static.
+# Setup-workspace runs once per lane, not once for all: never put checks in the shared action.
 name: CI
 
 on:
@@ -6,6 +9,7 @@ on:
     branches:
       - main
 
+# Stale runs cancelled by a newer push show the gate red, not grey. Main never cancels.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -49,7 +53,6 @@ jobs:
         uses: ./.github/actions/setup-workspace
 
       - name: Verify Linux terminal PTY native dependency
-        if: runner.os == 'Linux'
         run: node scripts/node-pty-smoke.mjs
 
       - name: Test
@@ -98,7 +101,7 @@ jobs:
   build:
     name: Desktop Build
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -108,15 +111,6 @@ jobs:
         with:
           electron: "true"
 
-      # Only the build job produces a meaningful .turbo cache, so it is cached
-      # here rather than in the shared setup action. Exact key only: build
-      # outputs must never be restored from a prefix-matched key.
-      - name: Cache Turbo build outputs
-        uses: actions/cache@v5
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-build-${{ github.sha }}
-
       - name: Build desktop pipeline
         run: bun run build:desktop
 
@@ -125,6 +119,7 @@ jobs:
           test -f apps/desktop/dist-electron/preload.js
           grep -nE "desktopBridge|getWsUrl|PICK_FOLDER_CHANNEL|wsUrl" apps/desktop/dist-electron/preload.js
 
+  # Aggregate only: no checkout, no run steps. Keep the old display name for branch protection. if: always() is intended, do not remove.
   quality:
     name: Format, Lint, Typecheck, Test, Browser Test, Build
     runs-on: ubuntu-24.04
@@ -132,8 +127,7 @@ jobs:
     needs: [static, unit, browser, build]
     if: always()
     steps:
-      - name: Check quality results
-        shell: bash
+      - name: Aggregate lane results
         env:
           STATIC: ${{ needs.static.result }}
           UNIT: ${{ needs.unit.result }}
@@ -142,6 +136,7 @@ jobs:
         run: |
           if [ "$STATIC" != "success" ] || [ "$UNIT" != "success" ] || [ "$BROWSER" != "success" ] || [ "$BUILD" != "success" ]; then
             echo "static=$STATIC unit=$UNIT browser=$BROWSER build=$BUILD"
+            echo "Open the red lane above, not this gate."
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
           grep -nE "desktopBridge|getWsUrl|PICK_FOLDER_CHANNEL|wsUrl" apps/desktop/dist-electron/preload.js
 
   quality:
-    name: Quality Gate
+    name: Format, Lint, Typecheck, Test, Browser Test, Build
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     needs: [static, unit, browser, build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,72 +6,18 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
-  quality:
-    name: Format, Lint, Typecheck, Test, Browser Test, Build
+  static:
+    name: Format, Lint, Typecheck, Brand
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version-file: package.json
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: package.json
-
-      - name: Cache Bun and Turbo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.bun/install/cache
-            .turbo
-          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}-${{ hashFiles('turbo.json') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}-
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-
-      - name: Cache Electron runtime
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/electron
-          key: ${{ runner.os }}-electron-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-electron-
-
-      - name: Install dependencies
-        env:
-          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
-        run: bun install --frozen-lockfile
-
-      - name: Install Electron test runtime
-        shell: bash
-        run: |
-          for attempt in 1 2 3; do
-            if node apps/desktop/node_modules/electron/install.js; then
-              exit 0
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              exit 1
-            fi
-            sleep $((attempt * 5))
-          done
-
-      - name: Verify Linux terminal PTY native dependency
-        if: runner.os == 'Linux'
-        run: node scripts/node-pty-smoke.mjs
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
 
       - name: Verify Synara identity
         run: bun run brand:check
@@ -88,8 +34,28 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
+
+      - name: Verify Linux terminal PTY native dependency
+        if: runner.os == 'Linux'
+        run: node scripts/node-pty-smoke.mjs
+
       - name: Test
         run: bun run test
+
+  browser:
+    name: Browser Tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
 
       # Run the workspace-local playwright binary directly: bunx stalled after
       # the chromium download on hosted runners. The step timeout stops any
@@ -114,6 +80,27 @@ jobs:
         timeout-minutes: 10
         run: bun run --cwd apps/web test:browser:geometry
 
+  build:
+    name: Build Desktop
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
+
+      - name: Install Electron test runtime
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if node apps/desktop/node_modules/electron/install.js; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
+
       - name: Build desktop pipeline
         run: bun run build:desktop
 
@@ -121,6 +108,26 @@ jobs:
         run: |
           test -f apps/desktop/dist-electron/preload.js
           grep -nE "desktopBridge|getWsUrl|PICK_FOLDER_CHANNEL|wsUrl" apps/desktop/dist-electron/preload.js
+
+  quality:
+    name: Quality
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: [static, unit, browser, build]
+    if: always()
+    steps:
+      - name: Check quality results
+        shell: bash
+        env:
+          STATIC: ${{ needs.static.result }}
+          UNIT: ${{ needs.unit.result }}
+          BROWSER: ${{ needs.browser.result }}
+          BUILD: ${{ needs.build.result }}
+        run: |
+          if [ "$STATIC" != "success" ] || [ "$UNIT" != "success" ] || [ "$BROWSER" != "success" ] || [ "$BUILD" != "success" ]; then
+            echo "static=$STATIC unit=$UNIT browser=$BROWSER build=$BUILD"
+            exit 1
+          fi
 
   windows_process:
     name: Windows Process Regression

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,13 @@ concurrency:
 
 jobs:
   static:
-    name: Format, Lint, Typecheck, Brand
+    name: Static Checks
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 15
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
 
@@ -37,8 +40,11 @@ jobs:
   unit:
     name: Unit Tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
 
@@ -52,10 +58,23 @@ jobs:
   browser:
     name: Browser Tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    # Step caps sum to 45 (15+20+10); the job cap stays above that so a stall in
+    # the non-blocking geometry step can never be converted into a job failure.
+    timeout-minutes: 55
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       # Run the workspace-local playwright binary directly: bunx stalled after
       # the chromium download on hosted runners. The step timeout stops any
@@ -81,25 +100,17 @@ jobs:
         run: bun run --cwd apps/web test:browser:geometry
 
   build:
-    name: Build Desktop
+    name: Desktop Build
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
-
-      - name: Install Electron test runtime
-        shell: bash
-        run: |
-          for attempt in 1 2 3; do
-            if node apps/desktop/node_modules/electron/install.js; then
-              exit 0
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              exit 1
-            fi
-            sleep $((attempt * 5))
-          done
+        with:
+          electron: "true"
 
       - name: Build desktop pipeline
         run: bun run build:desktop
@@ -110,10 +121,12 @@ jobs:
           grep -nE "desktopBridge|getWsUrl|PICK_FOLDER_CHANNEL|wsUrl" apps/desktop/dist-electron/preload.js
 
   quality:
-    name: Quality
+    name: Quality Gate
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     needs: [static, unit, browser, build]
+    # always() + the explicit result check below keep the gate fail-closed: a
+    # cancelled or skipped dependency must fail the gate, never silently pass it.
     if: always()
     steps:
       - name: Check quality results


### PR DESCRIPTION
## What this does

Splits the single sequential `quality` job in `.github/workflows/ci.yml` into four parallel jobs — `static`, `unit`, `browser`, `build` — fronted by a fail-closed aggregate `quality` gate that keeps the exact required-check name `Format, Lint, Typecheck, Test, Browser Test, Build`, so no upstream branch protection needs to change. Shared setup (Bun/Node toolchain, Bun cache, frozen install) is factored into one composite action, `.github/actions/setup-workspace`, instead of being pasted into four jobs.

## Behavior change (user-visible)

None for contributors beyond speed: same steps, same commands, same env, same coverage, only the schedule changes. One deliberate CI-behavior change: a `concurrency` block (`cancel-in-progress` on non-`main` refs) cancels superseded PR runs so stale greens cannot land. `main` pushes are never cancelled.

| job | before (sequential `quality`) | after (this PR, run 33690723606) |
|---|---|---|
| Static Checks (fmt, lint, typecheck, brand, windows-boundary) | inside one ~20–22 min job | pass, 3m29s |
| Unit Tests (`bun run test` + node-pty smoke) | inside one ~20–22 min job | pass, 10m17s |
| Browser Tests (stable blocking; geometry quarantine stays `continue-on-error`) | inside one ~20–22 min job | pass, 12m35s |
| Desktop Build (`build:desktop` + preload verify) | inside one ~20–22 min job | pass, 3m36s |
| Aggregate gate (name unchanged) | n/a (was the job itself) | pass, 3s |
| Wall clock | ~20–22 min (main baselines 22m16s, 20m25s) | ~12.5 min (browser is the long pole) |
| Windows Process Regression / Migration Lineage / Release Smoke | pass | pass, untouched |

## Reviews

- **Ponytail ultra: keep.** The composite action earns its existence: it replaces 4 copies of an identical ~15-line setup with one 56-line action plus 2-line call sites, and per-job self-containment is a hard requirement for parallel scheduling, not abstraction for its own sake. Challenged the split width (why 4 jobs, why an alias gate job): 4 matches the natural failure-attribution boundaries, and the 3-second alias gate is the only way to preserve the required-check name without upstream admin changing branch protection. No deletion or simplification survived the challenge; nothing further to cut.
- **Thermos lens 1 (bugs/security/breakage): clean, zero blocking.** Every step of the old `quality` job was traced to exactly one split job — no step dropped, no command or env changed (step-by-step mapping verified against `main:.github/workflows/ci.yml`). `windows_process`, `migration_lineage`, `release_smoke` are byte-identical apart from a `timeout-minutes: 10` added to `release_smoke` (previously the 360-min default). Secrets: `ci.yml` references zero secrets and still triggers on `pull_request`, so fork PRs get no secret access. Fail-closed aggregate (`needs` all four + `if: always()` + strict `success` comparison) cannot go green on a partial run. Electron retry loop and `shell: bash` preserved verbatim in the composite action.
- **Thermos lens 2 (maintainability): clean, nits deferred below.** Cache scoping is intentional and reviewed: Turbo cache moved out of the shared setup into the build job with an exact key (build outputs must never restore from a prefix match); Playwright/Electron caches dropped their prefix `restore-keys` fallbacks, so a lock change now cold-starts instead of restoring a stale-prefix cache — safer, marginally slower on rotation days.

## Tests

| command | result |
|---|---|
| `gh pr checks 903` — all split jobs on this PR's own head `19c5f1eaf` (run 33690723606, event `pull_request`) | pass: Static 3m29s, Unit 10m17s, Browser 12m35s, Build 3m36s, aggregate 3s; Windows Regression 4m38s, Migration Lineage, Release Smoke pass; zero fail/cancel/pending |
| YAML parse of both touched files (`yaml.parse` via Bun) | OK |
| Live UI proof | n/a — CI-config-only PR with no UI surface; the split jobs going green on this PR's own run is the proof |

## Socket surface

None. The diff touches only `.github/workflows/ci.yml` and `.github/actions/setup-workspace/action.yml`. A diff grep for `ws|socket|gateway|transport` hits only the substring inside the `Browser Tests` job name — no socket code added, moved, or configured.

## Follow-ups

- `windows_process` still inlines its own Bun/Node setup plus uncached install; it could call `setup-workspace` for a free Bun cache. Deferred: touches the Windows job, out of scope for the split.
- Playwright/Electron exact-only cache keys mean cold downloads on `bun.lock` rotation; if rotation-day CI gets slow, re-add prefix `restore-keys`. Deferred: observe first.
- Superseded (concurrency-cancelled) PR runs report the aggregate gate red instead of grey-cancelled. Cosmetic only; `main` is exempt from cancellation. Deferred: only matters if it confuses contributors.

## Merge note

Rebased on upstream `main` `562c5fea`; `mergeable` MERGEABLE, `mergeStateStatus` CLEAN, all checks pass on head `19c5f1eaf`. **Ready-for-undraft-first: this CI PR undrafts before the feature PRs** so the wave-2 lanes inherit the faster graph. Still DRAFT — Main undrafts in merge-safe order at the end.

## Gauntlet handoff (2026-09-04)

**Status: fixes pushed + reverified, pending final CI-green confirm.** Fix commit `720d6f4ed` (+9/-15, same 2 files). YAML parses locally.

**Fixed**
- Cut write-only Turbo cache block, dead Linux `if`, gate shell, redundant `required:false`, turbo.json key fragment.
- Build timeout 30 → 15; added lane-rule header, stale-run note, gate aggregate-only note, step rename, lane-first echo.

**Deliberately rejected:** toJSON gate rewrite — gate stays fail-closed as-is (security lens proved it line by line; restructure deferred).

**Remaining:** confirm CI fully green → undraft. No E2E yet (needs live run).
