### PR TITLE
feat(model): add Claude Fable 5.1 to the Claude and Pi catalogs

### DIFF
--- a/apps/server/src/provider/Layers/PiAdapter.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.test.ts
@@ -413,7 +413,7 @@ describe("ensurePiAnthropicCatalogModels", () => {
     expect(models.every((model) => model.provider !== "anthropic")).toBe(true);
   });
 
-  it("restores Fable 5 and Opus 4.8 when an oauth catalog omitted them", () => {
+  it("restores Fable 5.1, Fable 5, and Opus 4.8 when an oauth catalog omitted them", () => {
     const peer = {
       id: "claude-opus-4-7",
       name: "Claude Opus 4.7",
@@ -430,9 +430,17 @@ describe("ensurePiAnthropicCatalogModels", () => {
 
     expect(models.map((model) => model.id)).toEqual([
       "claude-opus-4-7",
+      "claude-fable-5-1",
       "claude-fable-5",
       "claude-opus-4-8",
     ]);
+    expect(models.find((model) => model.id === "claude-fable-5-1")).toMatchObject({
+      provider: "anthropic",
+      name: "Claude Fable 5.1",
+      reasoning: true,
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+    });
     expect(models.find((model) => model.id === "claude-fable-5")).toMatchObject({
       provider: "anthropic",
       name: "Claude Fable 5",

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -113,12 +113,17 @@ const PI_DEFAULT_SUPPORTED_THINKING_LEVELS = new Set<ThinkingLevel>([
   "medium",
   "high",
 ]);
-const PI_ANTHROPIC_ENSURED_MODEL_IDS = ["claude-fable-5", "claude-opus-4-8"] as const;
+const PI_ANTHROPIC_ENSURED_MODEL_IDS = [
+  "claude-fable-5-1",
+  "claude-fable-5",
+  "claude-opus-4-8",
+] as const;
 type PiAnthropicEnsuredModelId = (typeof PI_ANTHROPIC_ENSURED_MODEL_IDS)[number];
 
 /**
  * Metadata used when an OAuth/extension Anthropic catalog replaced Pi's built-ins
- * and omitted Fable / Opus 4.8. Values mirror `@earendil-works/pi-ai` Anthropic models.
+ * and omitted Fable 5.1 / Fable 5 / Opus 4.8. Values mirror `@earendil-works/pi-ai`
+ * Anthropic models; Fable 5.1 follows Anthropic's published pricing until pi-ai ships it.
  */
 const PI_ANTHROPIC_ENSURED_MODEL_TEMPLATES: Record<
   PiAnthropicEnsuredModelId,
@@ -134,6 +139,17 @@ const PI_ANTHROPIC_ENSURED_MODEL_TEMPLATES: Record<
     readonly maxTokens: number;
   }
 > = {
+  "claude-fable-5-1": {
+    id: "claude-fable-5-1",
+    name: "Claude Fable 5.1",
+    reasoning: true,
+    thinkingLevelMap: { off: null, xhigh: "xhigh", max: "max" },
+    compat: { forceAdaptiveThinking: true },
+    input: ["text", "image"],
+    cost: { input: 10, output: 50, cacheRead: 0.25, cacheWrite: 12.5 },
+    contextWindow: 1_000_000,
+    maxTokens: 128_000,
+  },
   "claude-fable-5": {
     id: "claude-fable-5",
     name: "Claude Fable 5",
@@ -542,8 +558,9 @@ export function getPiSupportedThinkingOptions(
 }
 
 /**
- * When Anthropic is already authenticated, ensure Fable 5 and Opus 4.8 appear even
- * if an older pi-anthropic-oauth extension replaced the built-in Anthropic catalog.
+ * When Anthropic is already authenticated, ensure Fable 5.1, Fable 5, and Opus 4.8
+ * appear even if an older pi-anthropic-oauth extension replaced the built-in
+ * Anthropic catalog.
  */
 export function ensurePiAnthropicCatalogModels(
   available: ReadonlyArray<Model<Api>>,

--- a/apps/web/src/cursorModelVariants.ts
+++ b/apps/web/src/cursorModelVariants.ts
@@ -114,6 +114,7 @@ function fallbackContextWindowOptionsForCursorBase(
     ];
   }
   if (
+    baseSlug === "claude-fable-5-1" ||
     baseSlug === "claude-fable-5" ||
     baseSlug === "claude-sonnet-5" ||
     baseSlug === "claude-opus-4-8" ||

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -497,6 +497,8 @@ const CLAUDE_NO_FAST_XHIGH_CAPABILITIES: ModelCapabilities = {
   contextWindowTokens: 1_000_000,
 };
 
+// Fable 5 and 5.1 share the ladder: thinking is always on (no toggle, no
+// ultrathink prompt mode), effort runs low..max, and there is no fast-mode lane.
 const CLAUDE_FABLE_CAPABILITIES: ModelCapabilities = CLAUDE_NO_FAST_XHIGH_CAPABILITIES;
 
 // Opus 5 keeps the Claude 5 ladder (thinking is adaptive, so no ultrathink prompt
@@ -601,6 +603,11 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
     },
   ],
   claudeAgent: [
+    {
+      slug: "claude-fable-5-1",
+      name: "Claude Fable 5.1",
+      capabilities: CLAUDE_FABLE_CAPABILITIES,
+    },
     {
       slug: "claude-fable-5",
       name: "Claude Fable 5",
@@ -1153,8 +1160,12 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Record<ProviderKind, Record<string,
     "gpt-5.3-spark": "gpt-5.3-codex-spark",
   },
   claudeAgent: {
-    fable: "claude-fable-5",
+    fable: "claude-fable-5-1",
+    "fable-5.1": "claude-fable-5-1",
+    "claude-fable-5.1": "claude-fable-5-1",
+    "claude-fable-5-1": "claude-fable-5-1",
     "fable-5": "claude-fable-5",
+    "claude-fable-5": "claude-fable-5",
     opus: "claude-opus-5",
     "opus-5": "claude-opus-5",
     "claude-opus-5": "claude-opus-5",

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -205,6 +205,12 @@ describe("resolveModelSlug", () => {
       DEFAULT_MODEL_BY_PROVIDER.claudeAgent,
     );
     expect(resolveModelSlugForProvider("claudeAgent", "sonnet")).toBe("claude-sonnet-5");
+    expect(resolveModelSlugForProvider("claudeAgent", "fable")).toBe("claude-fable-5-1");
+    expect(resolveModelSlugForProvider("claudeAgent", "fable-5.1")).toBe("claude-fable-5-1");
+    expect(resolveModelSlugForProvider("claudeAgent", "claude-fable-5-1[1m]")).toBe(
+      "claude-fable-5-1",
+    );
+    expect(resolveModelSlugForProvider("claudeAgent", "fable-5")).toBe("claude-fable-5");
     expect(resolveModelSlugForProvider("claudeAgent", "gpt-5.3-codex")).toBe(
       DEFAULT_MODEL_BY_PROVIDER.claudeAgent,
     );
@@ -1160,6 +1166,7 @@ describe("getModelCapabilities Claude capability flags", () => {
   it("only enables ultrathink keyword handling for Opus 4.6 and Sonnet 4.6", () => {
     const has = (m: string | undefined) =>
       getModelCapabilities("claudeAgent", m).promptInjectedEffortLevels.includes("ultrathink");
+    expect(has("claude-fable-5-1")).toBe(false);
     expect(has("claude-fable-5")).toBe(false);
     expect(has("claude-opus-5")).toBe(false);
     expect(has("claude-opus-4-8")).toBe(true);


### PR DESCRIPTION
## Summary

Adds Anthropic's new **Claude Fable 5.1** (`claude-fable-5-1`) to Synara.

- **Claude Agent catalog** (`packages/contracts/src/model.ts`): Fable 5.1 is listed first, above Fable 5, and reuses the shared Fable capability ladder — always-on thinking (no toggle, no ultrathink prompt mode), effort `low`…`max` plus Ultracode, no fast mode, 1M context.
- **Aliases**: `fable` now resolves to Fable 5.1; `fable-5.1`, `claude-fable-5.1`, and the bracketed `[1m]` variant resolve too. `fable-5` / `claude-fable-5` keep resolving to Fable 5, so persisted selections are unaffected.
- **Pi**: the Anthropic catalog repair (`ensurePiAnthropicCatalogModels`) now ensures Fable 5.1 alongside Fable 5 and Opus 4.8, so OAuth catalogs that predate the model still expose it. Pricing follows Anthropic's published rates ($10 / $50 per MTok, $0.25 cache read).
- **Cursor**: the 1M-variant context-window fallback treats Fable 5.1 like the other Claude 5 models, so the picker collapses variants correctly once Cursor ships it.

Not changed on purpose: the static Cursor, Droid, and Devin catalogs. Those mirror what each third-party CLI actually serves and are refreshed by live discovery; adding a slug there before the vendor exposes it would produce invalid-model errors. Release notes (`whatsNew/entries.ts`) are added at release time per the existing convention.

## Test plan

- [x] `bun fmt`, `bun lint`, `bun typecheck` pass
- [x] `packages/shared` model tests (alias resolution, effort ladder, ultrathink gating for Fable 5.1)
- [x] `apps/server` PiAdapter tests (ensured-model ordering and metadata)
- [x] `apps/web` providerModelOptions + cursorModelVariants tests
- [x] `packages/contracts` test suite
- [ ] Manual: pick Fable 5.1 in the Claude composer and start a turn on an up-to-date Claude Code CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3VSVxe9LuNS4X86fpCeNa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive catalog entries and Pi backfill templates; the only behavior shift is `fable` resolving to 5.1 instead of 5, with explicit aliases preserving Fable 5 selections.
> 
> **Overview**
> Adds **Claude Fable 5.1** (`claude-fable-5-1`) across Synara’s model surfaces so users can select it like other Claude Code models.
> 
> The **Claude Agent** catalog lists Fable 5.1 above Fable 5 with the same Fable capability profile (always-on thinking, low–max + Ultracode, no fast mode, 1M context). **Aliases** now treat bare `fable` and several `fable-5.1` forms as 5.1, while `fable-5` / `claude-fable-5` still map to Fable 5.
> 
> **Pi** extends `ensurePiAnthropicCatalogModels` to inject Fable 5.1 when OAuth/extension catalogs omit it, including interim pricing/metadata until `pi-ai` ships the model. **Cursor** variant collapsing treats `claude-fable-5-1` like other Claude 5 families for synthesized 300K/1M context options.
> 
> Tests cover ensured-model ordering, alias resolution (including `[1m]` bracket stripping), and ultrathink gating for Fable 5.1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1464d0f2b099adc20324d3813186e9af75e5d5c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->