### PR TITLE
fix(orchestration): prevent read chats from reappearing as unread after restart

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -82,6 +82,32 @@ const makeAppendAndProject =
       .append(event)
       .pipe(Effect.flatMap((savedEvent) => projectionPipeline.projectEvent(savedEvent)));
 
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
+
+// Scenario event appender: generates the event envelope (ids, causation,
+// metadata) so tests only spell the meaningful fields. `prefix` keeps ids
+// unique across the shared per-file test database.
+const makeScenarioAppender = (
+  appendAndProject: ReturnType<typeof makeAppendAndProject>,
+  prefix: string,
+) => {
+  let scenarioSequence = 0;
+  return (
+    event: DistributiveOmit<
+      Parameters<typeof appendAndProject>[0],
+      "eventId" | "commandId" | "correlationId" | "causationEventId" | "metadata"
+    >,
+  ) =>
+    appendAndProject({
+      ...event,
+      eventId: EventId.makeUnsafe(`evt-${prefix}-${++scenarioSequence}`),
+      commandId: CommandId.makeUnsafe(`cmd-${prefix}-${scenarioSequence}`),
+      correlationId: CommandId.makeUnsafe(`cmd-${prefix}-${scenarioSequence}`),
+      causationEventId: null,
+      metadata: {},
+    });
+};
+
 const exists = (filePath: string) =>
   Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;
@@ -653,23 +679,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
       const startedAt = "2026-09-01T00:00:02.000Z";
       const completedAt = "2026-09-01T00:00:03.000Z";
 
-      let scenarioSequence = 0;
-      type AppendEventInput = Parameters<typeof appendAndProject>[0];
-      type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
-      const appendScenarioEvent = (
-        event: DistributiveOmit<
-          AppendEventInput,
-          "eventId" | "commandId" | "correlationId" | "causationEventId" | "metadata"
-        >,
-      ) =>
-        appendAndProject({
-          ...event,
-          eventId: EventId.makeUnsafe(`evt-completion-updated-${++scenarioSequence}`),
-          commandId: CommandId.makeUnsafe(`cmd-completion-updated-${scenarioSequence}`),
-          correlationId: CommandId.makeUnsafe(`cmd-completion-updated-${scenarioSequence}`),
-          causationEventId: null,
-          metadata: {},
-        });
+      const appendScenarioEvent = makeScenarioAppender(appendAndProject, "completion-updated");
       const session = (
         status: "running" | "ready",
         activeTurnId: TurnId | null,
@@ -762,6 +772,133 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
       yield* projectionPipeline.bootstrap;
 
       assert.equal((yield* readThreadUpdatedAt)[0]!.updatedAt, completedAt);
+    }),
+  );
+
+  it.effect("keeps thread updatedAt monotonic across stale session events and replay", () =>
+    Effect.gen(function* () {
+      const projectionPipeline = yield* OrchestrationProjectionPipeline;
+      const eventStore = yield* OrchestrationEventStore;
+      const sql = yield* SqlClient.SqlClient;
+      const appendAndProject = makeAppendAndProject(eventStore, projectionPipeline);
+      const appendScenarioEvent = makeScenarioAppender(appendAndProject, "stale-session");
+      const threadId = ThreadId.makeUnsafe("thread-stale-session-updated-at");
+      const turnId = TurnId.makeUnsafe("turn-stale-session-updated-at");
+      const projectId = ProjectId.makeUnsafe("project-stale-session-updated");
+      const modelSelection = { provider: "codex", model: "gpt-5.6-sol" } as const;
+      const createdAt = "2026-09-01T00:00:00.000Z";
+      const requestedAt = "2026-09-01T00:00:01.000Z";
+      const startedAt = "2026-09-01T00:00:02.000Z";
+      const completedAt = "2026-09-01T00:00:03.000Z";
+
+      const session = (
+        status: "running" | "ready",
+        activeTurnId: TurnId | null,
+        updatedAt: string,
+      ) => ({
+        threadId,
+        status,
+        providerName: "codex",
+        runtimeMode: "full-access" as const,
+        activeTurnId,
+        lastError: null,
+        updatedAt,
+      });
+
+      yield* appendScenarioEvent({
+        type: "project.created",
+        aggregateKind: "project",
+        aggregateId: projectId,
+        occurredAt: createdAt,
+        payload: {
+          projectId,
+          title: "Stale session project",
+          workspaceRoot: "/tmp/project-stale-session",
+          defaultModelSelection: null,
+          scripts: [],
+          createdAt,
+          updatedAt: createdAt,
+        },
+      });
+      yield* appendScenarioEvent({
+        type: "thread.created",
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: createdAt,
+        payload: {
+          threadId,
+          projectId,
+          title: "Stale session thread",
+          modelSelection,
+          runtimeMode: "full-access",
+          branch: null,
+          worktreePath: null,
+          createdAt,
+          updatedAt: createdAt,
+        },
+      });
+      yield* appendScenarioEvent({
+        type: "thread.turn-start-requested",
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: requestedAt,
+        payload: {
+          threadId,
+          messageId: MessageId.makeUnsafe("message-stale-session"),
+          modelSelection,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          dispatchMode: "queue",
+          createdAt: requestedAt,
+        },
+      });
+      yield* appendScenarioEvent({
+        type: "thread.session-set",
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: startedAt,
+        payload: { threadId, session: session("running", turnId, startedAt) },
+      });
+      yield* appendScenarioEvent({
+        type: "thread.session-set",
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: completedAt,
+        payload: { threadId, session: session("ready", null, completedAt) },
+      });
+      // A late-arriving session event whose sequence follows completion but
+      // whose occurredAt precedes it (retry, import, reconciliation).
+      yield* appendScenarioEvent({
+        type: "thread.session-set",
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: startedAt,
+        payload: { threadId, session: session("running", turnId, startedAt) },
+      });
+
+      const readThreadUpdatedAt = sql<{ readonly updatedAt: string }>`
+        SELECT updated_at AS "updatedAt"
+        FROM projection_threads
+        WHERE thread_id = ${threadId}
+      `;
+      const readTurn = sql<{ readonly state: string; readonly completedAt: string | null }>`
+        SELECT state, completed_at AS "completedAt"
+        FROM projection_turns
+        WHERE thread_id = ${threadId} AND turn_id = ${turnId}
+      `;
+
+      assert.equal((yield* readThreadUpdatedAt)[0]!.updatedAt, completedAt);
+
+      // Projection repair resets projector cursors and replays from the journal;
+      // the stale event must not regress the thread row during the rebuild.
+      yield* sql`
+        DELETE FROM projection_state
+        WHERE projector = ${ORCHESTRATION_PROJECTOR_NAMES.threads}
+      `;
+      yield* projectionPipeline.bootstrap;
+
+      assert.equal((yield* readThreadUpdatedAt)[0]!.updatedAt, completedAt);
+      assert.deepEqual(yield* readTurn, [{ state: "completed", completedAt }]);
     }),
   );
 });

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -646,23 +646,51 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
       const appendAndProject = makeAppendAndProject(eventStore, projectionPipeline);
       const threadId = ThreadId.makeUnsafe("thread-completion-updated-at");
       const turnId = TurnId.makeUnsafe("turn-completion-updated-at");
+      const projectId = ProjectId.makeUnsafe("project-completion-updated");
+      const modelSelection = { provider: "codex", model: "gpt-5.6-sol" } as const;
       const createdAt = "2026-09-01T00:00:00.000Z";
       const requestedAt = "2026-09-01T00:00:01.000Z";
       const startedAt = "2026-09-01T00:00:02.000Z";
       const completedAt = "2026-09-01T00:00:03.000Z";
 
-      yield* appendAndProject({
+      let scenarioSequence = 0;
+      type AppendEventInput = Parameters<typeof appendAndProject>[0];
+      type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
+      const appendScenarioEvent = (
+        event: DistributiveOmit<
+          AppendEventInput,
+          "eventId" | "commandId" | "correlationId" | "causationEventId" | "metadata"
+        >,
+      ) =>
+        appendAndProject({
+          ...event,
+          eventId: EventId.makeUnsafe(`evt-completion-updated-${++scenarioSequence}`),
+          commandId: CommandId.makeUnsafe(`cmd-completion-updated-${scenarioSequence}`),
+          correlationId: CommandId.makeUnsafe(`cmd-completion-updated-${scenarioSequence}`),
+          causationEventId: null,
+          metadata: {},
+        });
+      const session = (
+        status: "running" | "ready",
+        activeTurnId: TurnId | null,
+        updatedAt: string,
+      ) => ({
+        threadId,
+        status,
+        providerName: "codex",
+        runtimeMode: "full-access" as const,
+        activeTurnId,
+        lastError: null,
+        updatedAt,
+      });
+
+      yield* appendScenarioEvent({
         type: "project.created",
-        eventId: EventId.makeUnsafe("evt-completion-updated-project"),
         aggregateKind: "project",
-        aggregateId: ProjectId.makeUnsafe("project-completion-updated"),
+        aggregateId: projectId,
         occurredAt: createdAt,
-        commandId: CommandId.makeUnsafe("cmd-completion-updated-project"),
-        causationEventId: null,
-        correlationId: CommandId.makeUnsafe("cmd-completion-updated-project"),
-        metadata: {},
         payload: {
-          projectId: ProjectId.makeUnsafe("project-completion-updated"),
+          projectId,
           title: "Completion updated project",
           workspaceRoot: "/tmp/project-completion-updated",
           defaultModelSelection: null,
@@ -671,21 +699,16 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
           updatedAt: createdAt,
         },
       });
-      yield* appendAndProject({
+      yield* appendScenarioEvent({
         type: "thread.created",
-        eventId: EventId.makeUnsafe("evt-completion-updated-thread"),
         aggregateKind: "thread",
         aggregateId: threadId,
         occurredAt: createdAt,
-        commandId: CommandId.makeUnsafe("cmd-completion-updated-thread"),
-        causationEventId: null,
-        correlationId: CommandId.makeUnsafe("cmd-completion-updated-thread"),
-        metadata: {},
         payload: {
           threadId,
-          projectId: ProjectId.makeUnsafe("project-completion-updated"),
+          projectId,
           title: "Completion updated thread",
-          modelSelection: { provider: "codex", model: "gpt-5.6-sol" },
+          modelSelection,
           runtimeMode: "full-access",
           branch: null,
           worktreePath: null,
@@ -693,71 +716,34 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
           updatedAt: createdAt,
         },
       });
-      yield* appendAndProject({
+      yield* appendScenarioEvent({
         type: "thread.turn-start-requested",
-        eventId: EventId.makeUnsafe("evt-completion-updated-start"),
         aggregateKind: "thread",
         aggregateId: threadId,
         occurredAt: requestedAt,
-        commandId: CommandId.makeUnsafe("cmd-completion-updated-start"),
-        causationEventId: null,
-        correlationId: CommandId.makeUnsafe("cmd-completion-updated-start"),
-        metadata: {},
         payload: {
           threadId,
           messageId: MessageId.makeUnsafe("message-completion-updated"),
-          modelSelection: { provider: "codex", model: "gpt-5.6-sol" },
+          modelSelection,
           runtimeMode: "full-access",
           interactionMode: "default",
           dispatchMode: "queue",
           createdAt: requestedAt,
         },
       });
-      yield* appendAndProject({
+      yield* appendScenarioEvent({
         type: "thread.session-set",
-        eventId: EventId.makeUnsafe("evt-completion-updated-running"),
         aggregateKind: "thread",
         aggregateId: threadId,
         occurredAt: startedAt,
-        commandId: CommandId.makeUnsafe("cmd-completion-updated-running"),
-        causationEventId: null,
-        correlationId: CommandId.makeUnsafe("cmd-completion-updated-running"),
-        metadata: {},
-        payload: {
-          threadId,
-          session: {
-            threadId,
-            status: "running",
-            providerName: "codex",
-            runtimeMode: "full-access",
-            activeTurnId: turnId,
-            lastError: null,
-            updatedAt: startedAt,
-          },
-        },
+        payload: { threadId, session: session("running", turnId, startedAt) },
       });
-      yield* appendAndProject({
+      yield* appendScenarioEvent({
         type: "thread.session-set",
-        eventId: EventId.makeUnsafe("evt-completion-updated-ready"),
         aggregateKind: "thread",
         aggregateId: threadId,
         occurredAt: completedAt,
-        commandId: CommandId.makeUnsafe("cmd-completion-updated-ready"),
-        causationEventId: null,
-        correlationId: CommandId.makeUnsafe("cmd-completion-updated-ready"),
-        metadata: {},
-        payload: {
-          threadId,
-          session: {
-            threadId,
-            status: "ready",
-            providerName: "codex",
-            runtimeMode: "full-access",
-            activeTurnId: null,
-            lastError: null,
-            updatedAt: completedAt,
-          },
-        },
+        payload: { threadId, session: session("ready", null, completedAt) },
       });
 
       const readThreadUpdatedAt = sql<{ readonly updatedAt: string }>`
@@ -765,7 +751,6 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
         FROM projection_threads
         WHERE thread_id = ${threadId}
       `;
-
       assert.equal((yield* readThreadUpdatedAt)[0]!.updatedAt, completedAt);
 
       // Projection repair resets projector cursors and replays from the journal;

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -637,6 +637,148 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
       assert.deepEqual(yield* readTerminalRows(), liveRows);
     }),
   );
+
+  it.effect("keeps thread updatedAt at turn completion across projection rebuilds", () =>
+    Effect.gen(function* () {
+      const projectionPipeline = yield* OrchestrationProjectionPipeline;
+      const eventStore = yield* OrchestrationEventStore;
+      const sql = yield* SqlClient.SqlClient;
+      const appendAndProject = makeAppendAndProject(eventStore, projectionPipeline);
+      const threadId = ThreadId.makeUnsafe("thread-completion-updated-at");
+      const turnId = TurnId.makeUnsafe("turn-completion-updated-at");
+      const createdAt = "2026-09-01T00:00:00.000Z";
+      const requestedAt = "2026-09-01T00:00:01.000Z";
+      const startedAt = "2026-09-01T00:00:02.000Z";
+      const completedAt = "2026-09-01T00:00:03.000Z";
+
+      yield* appendAndProject({
+        type: "project.created",
+        eventId: EventId.makeUnsafe("evt-completion-updated-project"),
+        aggregateKind: "project",
+        aggregateId: ProjectId.makeUnsafe("project-completion-updated"),
+        occurredAt: createdAt,
+        commandId: CommandId.makeUnsafe("cmd-completion-updated-project"),
+        causationEventId: null,
+        correlationId: CommandId.makeUnsafe("cmd-completion-updated-project"),
+        metadata: {},
+        payload: {
+          projectId: ProjectId.makeUnsafe("project-completion-updated"),
+          title: "Completion updated project",
+          workspaceRoot: "/tmp/project-completion-updated",
+          defaultModelSelection: null,
+          scripts: [],
+          createdAt,
+          updatedAt: createdAt,
+        },
+      });
+      yield* appendAndProject({
+        type: "thread.created",
+        eventId: EventId.makeUnsafe("evt-completion-updated-thread"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: createdAt,
+        commandId: CommandId.makeUnsafe("cmd-completion-updated-thread"),
+        causationEventId: null,
+        correlationId: CommandId.makeUnsafe("cmd-completion-updated-thread"),
+        metadata: {},
+        payload: {
+          threadId,
+          projectId: ProjectId.makeUnsafe("project-completion-updated"),
+          title: "Completion updated thread",
+          modelSelection: { provider: "codex", model: "gpt-5.6-sol" },
+          runtimeMode: "full-access",
+          branch: null,
+          worktreePath: null,
+          createdAt,
+          updatedAt: createdAt,
+        },
+      });
+      yield* appendAndProject({
+        type: "thread.turn-start-requested",
+        eventId: EventId.makeUnsafe("evt-completion-updated-start"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: requestedAt,
+        commandId: CommandId.makeUnsafe("cmd-completion-updated-start"),
+        causationEventId: null,
+        correlationId: CommandId.makeUnsafe("cmd-completion-updated-start"),
+        metadata: {},
+        payload: {
+          threadId,
+          messageId: MessageId.makeUnsafe("message-completion-updated"),
+          modelSelection: { provider: "codex", model: "gpt-5.6-sol" },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          dispatchMode: "queue",
+          createdAt: requestedAt,
+        },
+      });
+      yield* appendAndProject({
+        type: "thread.session-set",
+        eventId: EventId.makeUnsafe("evt-completion-updated-running"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: startedAt,
+        commandId: CommandId.makeUnsafe("cmd-completion-updated-running"),
+        causationEventId: null,
+        correlationId: CommandId.makeUnsafe("cmd-completion-updated-running"),
+        metadata: {},
+        payload: {
+          threadId,
+          session: {
+            threadId,
+            status: "running",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: turnId,
+            lastError: null,
+            updatedAt: startedAt,
+          },
+        },
+      });
+      yield* appendAndProject({
+        type: "thread.session-set",
+        eventId: EventId.makeUnsafe("evt-completion-updated-ready"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: completedAt,
+        commandId: CommandId.makeUnsafe("cmd-completion-updated-ready"),
+        causationEventId: null,
+        correlationId: CommandId.makeUnsafe("cmd-completion-updated-ready"),
+        metadata: {},
+        payload: {
+          threadId,
+          session: {
+            threadId,
+            status: "ready",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: completedAt,
+          },
+        },
+      });
+
+      const readThreadUpdatedAt = sql<{ readonly updatedAt: string }>`
+        SELECT updated_at AS "updatedAt"
+        FROM projection_threads
+        WHERE thread_id = ${threadId}
+      `;
+
+      assert.equal((yield* readThreadUpdatedAt)[0]!.updatedAt, completedAt);
+
+      // Projection repair resets projector cursors and replays from the journal;
+      // the rebuild must not regress the thread row back to the turn start.
+      yield* sql`
+        DELETE FROM projection_state
+        WHERE projector = ${ORCHESTRATION_PROJECTOR_NAMES.threads}
+      `;
+      yield* projectionPipeline.bootstrap;
+
+      assert.equal((yield* readThreadUpdatedAt)[0]!.updatedAt, completedAt);
+    }),
+  );
 });
 
 it.layer(Layer.fresh(makeProjectionPipelinePrefixedTestLayer("synara-message-identity-scope-")))(

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -861,11 +861,8 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
           return;
         }
 
-        // Turn completion advances the thread row in live operation (the shell
-        // summary projector and the in-memory projector both stamp it), so the
-        // replay filter must cover these events too — otherwise a cursor reset
-        // during projection repair regresses updated_at back to the turn start,
-        // which re-marks already-read chats as unread after a restart.
+        // Turn completion must advance updated_at here too, or projection repair
+        // replay regresses it to the turn start (re-marks read chats unread).
         case "thread.session-set":
         case "thread.turn-diff-completed":
           return yield* updateThreadProjection(event.payload.threadId, (thread) => ({

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -861,6 +861,18 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
           return;
         }
 
+        // Turn completion advances the thread row in live operation (the shell
+        // summary projector and the in-memory projector both stamp it), so the
+        // replay filter must cover these events too — otherwise a cursor reset
+        // during projection repair regresses updated_at back to the turn start,
+        // which re-marks already-read chats as unread after a restart.
+        case "thread.session-set":
+        case "thread.turn-diff-completed":
+          return yield* updateThreadProjection(event.payload.threadId, (thread) => ({
+            ...thread,
+            updatedAt: event.occurredAt,
+          }));
+
         case "thread.deleted": {
           attachmentSideEffects.deletedThreadIds.add(event.payload.threadId);
           return yield* updateThreadProjection(event.payload.threadId, (thread) => ({

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -69,7 +69,7 @@ import {
 } from "../projectMetadataProjection.ts";
 import { applySpaceMetadataProjection } from "../spaceMetadataProjection.ts";
 import { resolveStableMessageTurnId } from "../messageTurnId.ts";
-import { settleTurnStateFromSession } from "../turnLifecycle.ts";
+import { maxIso, settleTurnStateFromSession } from "../turnLifecycle.ts";
 import { deriveTurnStartModelSelection, deriveTurnStartSession } from "../turnStartSession.ts";
 import {
   attachmentRelativePath,
@@ -217,10 +217,6 @@ function shouldApplyPendingInteractionsProjection(event: OrchestrationEvent): bo
     (event.type === "thread.activity-appended" &&
       PENDING_INTERACTION_ACTIVITY_KINDS.has(event.payload.activity.kind))
   );
-}
-
-function maxIso(left: string | null, right: string): string {
-  return left === null || right > left ? right : left;
 }
 
 // Destructive history edits are rare and rebuild from bounded/indexed summary queries.
@@ -863,11 +859,12 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
 
         // Turn completion must advance updated_at here too, or projection repair
         // replay regresses it to the turn start (re-marks read chats unread).
+        // Monotonic: stale events (retries, imports) carry earlier occurredAt.
         case "thread.session-set":
         case "thread.turn-diff-completed":
           return yield* updateThreadProjection(event.payload.threadId, (thread) => ({
             ...thread,
-            updatedAt: event.occurredAt,
+            updatedAt: maxIso(thread.updatedAt, event.occurredAt),
           }));
 
         case "thread.deleted": {
@@ -978,7 +975,7 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
                   : event.payload.preserveLatestTurn
                     ? existingRow.value.latestTurnId
                     : event.payload.turnId,
-              updatedAt: event.occurredAt,
+              updatedAt: maxIso(existingRow.value.updatedAt, event.occurredAt),
             },
             projectionThreadProposedPlanRepository,
           });

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -1122,6 +1122,8 @@ describe("orchestration projector", () => {
       completedAt,
       assistantMessageId: null,
     });
+    // The stale event's earlier occurredAt must not regress the thread stamp.
+    expect(afterStaleRunningSession.threads[0]?.updatedAt).toBe(completedAt);
   });
 
   it("updates canonical thread runtime mode from thread.runtime-mode-set", async () => {

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -56,7 +56,7 @@ import {
   ThreadTurnStartRequestedPayload,
 } from "./Schemas.ts";
 import { resolveStableMessageTurnId } from "./messageTurnId.ts";
-import { settleTurnStateFromSession } from "./turnLifecycle.ts";
+import { maxIso, settleTurnStateFromSession } from "./turnLifecycle.ts";
 import { deriveTurnStartModelSelection, deriveTurnStartSession } from "./turnStartSession.ts";
 
 type ThreadPatch = Partial<Omit<OrchestrationThread, "id" | "projectId">>;
@@ -1167,7 +1167,7 @@ export function projectEvent(
                           : null,
                     }
                 : settleLatestTurnForSessionStatus(thread.latestTurn, session),
-            updatedAt: event.occurredAt,
+            updatedAt: maxIso(thread.updatedAt, event.occurredAt),
           }),
         };
       });
@@ -1296,7 +1296,7 @@ export function projectEvent(
           threads: updateThread(nextBase.threads, payload.threadId, {
             checkpoints,
             latestTurn,
-            updatedAt: event.occurredAt,
+            updatedAt: maxIso(thread.updatedAt, event.occurredAt),
           }),
         };
       });

--- a/apps/server/src/orchestration/threadShellEvents.ts
+++ b/apps/server/src/orchestration/threadShellEvents.ts
@@ -23,6 +23,8 @@ export const THREAD_PROJECTION_EVENT_TYPES = new Set<OrchestrationEvent["type"]>
   "thread.runtime-mode-set",
   "thread.interaction-mode-set",
   "thread.turn-start-requested",
+  "thread.session-set",
+  "thread.turn-diff-completed",
   "thread.deleted",
   "thread.archived",
   "thread.unarchived",

--- a/apps/server/src/orchestration/turnLifecycle.ts
+++ b/apps/server/src/orchestration/turnLifecycle.ts
@@ -32,3 +32,12 @@ export function settleTurnStateFromSession(
       return null;
   }
 }
+
+/**
+ * Later-arriving events can carry earlier timestamps (retries, imports,
+ * reconciliation), so thread timestamp advancement must be monotonic — a
+ * regressed `updatedAt` re-marks already-read chats as unread after restart.
+ */
+export function maxIso(left: string | null, right: string): string {
+  return left === null || right > left ? right : left;
+}

--- a/apps/server/src/persistence/Migrations.test.ts
+++ b/apps/server/src/persistence/Migrations.test.ts
@@ -300,10 +300,11 @@ managedAttachmentsLegacyLayer("managed attachment migration after private migrat
         [96, "ProjectionThreadsGoalAchievements"],
         [97, "ProjectionThreadsSidechatLifecycle"],
         [98, "MigrateKiloToOpenCode"],
+        [99, "InvalidateProjectionThreadsCursor"],
       ]);
 
       const tracker = yield* trackerRows(sql);
-      assert.deepStrictEqual(tracker.slice(-44), [
+      assert.deepStrictEqual(tracker.slice(-45), [
         { migration_id: 55, name: "ManagedAttachments" },
         { migration_id: 56, name: "CommandReceiptFingerprints" },
         { migration_id: 57, name: "ThreadScopedProjectionMessageIdentity" },
@@ -348,6 +349,7 @@ managedAttachmentsLegacyLayer("managed attachment migration after private migrat
         { migration_id: 96, name: "ProjectionThreadsGoalAchievements" },
         { migration_id: 97, name: "ProjectionThreadsSidechatLifecycle" },
         { migration_id: 98, name: "MigrateKiloToOpenCode" },
+        { migration_id: 99, name: "InvalidateProjectionThreadsCursor" },
       ]);
       const preserved = yield* sql<{ readonly count: number }>`
         SELECT COUNT(*) AS count FROM orchestration_consumer_state
@@ -438,6 +440,7 @@ agentGatewayRetentionLegacyLayer(
           [96, "ProjectionThreadsGoalAchievements"],
           [97, "ProjectionThreadsSidechatLifecycle"],
           [98, "MigrateKiloToOpenCode"],
+          [99, "InvalidateProjectionThreadsCursor"],
         ]);
 
         const columns = yield* sql<{ readonly name: string }>`
@@ -531,11 +534,12 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
         [96, "ProjectionThreadsGoalAchievements"],
         [97, "ProjectionThreadsSidechatLifecycle"],
         [98, "MigrateKiloToOpenCode"],
+        [99, "InvalidateProjectionThreadsCursor"],
       ]);
 
       const tracker = yield* trackerRows(sql);
       assert.deepStrictEqual(
-        tracker.slice(-28).map((row) => [row.migration_id, row.name]),
+        tracker.slice(-29).map((row) => [row.migration_id, row.name]),
         [
           [71, "ProjectionThreadsGatewayProvenance"],
           [72, "AgentGatewayOperationRetention"],
@@ -565,6 +569,7 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
           [96, "ProjectionThreadsGoalAchievements"],
           [97, "ProjectionThreadsSidechatLifecycle"],
           [98, "MigrateKiloToOpenCode"],
+          [99, "InvalidateProjectionThreadsCursor"],
         ],
       );
 
@@ -653,11 +658,12 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
         [96, "ProjectionThreadsGoalAchievements"],
         [97, "ProjectionThreadsSidechatLifecycle"],
         [98, "MigrateKiloToOpenCode"],
+        [99, "InvalidateProjectionThreadsCursor"],
       ]);
 
       const tracker = yield* trackerRows(sql);
       assert.deepStrictEqual(
-        tracker.slice(-24).map((row) => [row.migration_id, row.name]),
+        tracker.slice(-25).map((row) => [row.migration_id, row.name]),
         [
           [75, "ExternalMcpActiveCapacity"],
           [76, "ExternalMcpHardening"],
@@ -683,6 +689,7 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
           [96, "ProjectionThreadsGoalAchievements"],
           [97, "ProjectionThreadsSidechatLifecycle"],
           [98, "MigrateKiloToOpenCode"],
+          [99, "InvalidateProjectionThreadsCursor"],
         ],
       );
       const preservedSpaces = yield* sql<{ readonly spaceId: string }>`

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -114,6 +114,7 @@ import Migration0095 from "./Migrations/095_ProjectionThreadsGoalTiming.ts";
 import Migration0096 from "./Migrations/096_ProjectionThreadsGoalAchievements.ts";
 import Migration0097 from "./Migrations/097_ProjectionThreadsSidechatLifecycle.ts";
 import Migration0098 from "./Migrations/098_MigrateKiloToOpenCode.ts";
+import Migration0099 from "./Migrations/099_InvalidateProjectionThreadsCursor.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -227,6 +228,7 @@ export const migrationEntries = [
   [96, "ProjectionThreadsGoalAchievements", Migration0096],
   [97, "ProjectionThreadsSidechatLifecycle", Migration0097],
   [98, "MigrateKiloToOpenCode", Migration0098],
+  [99, "InvalidateProjectionThreadsCursor", Migration0099],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/099_InvalidateProjectionThreadsCursor.test.ts
+++ b/apps/server/src/persistence/Migrations/099_InvalidateProjectionThreadsCursor.test.ts
@@ -1,0 +1,265 @@
+import {
+  CommandId,
+  CorrelationId,
+  EventId,
+  MessageId,
+  ProjectId,
+  ThreadId,
+  TurnId,
+} from "@synara/contracts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { ServerConfig } from "../../config.ts";
+import { OrchestrationEventStoreLive } from "../../persistence/Layers/OrchestrationEventStore.ts";
+import {
+  OrchestrationEventStore,
+  type OrchestrationEventStoreShape,
+} from "../../persistence/Services/OrchestrationEventStore.ts";
+import {
+  ORCHESTRATION_PROJECTOR_NAMES,
+  OrchestrationProjectionPipelineLive,
+} from "../../orchestration/Layers/ProjectionPipeline.ts";
+import {
+  OrchestrationProjectionPipeline,
+  type OrchestrationProjectionPipelineShape,
+} from "../../orchestration/Services/ProjectionPipeline.ts";
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const testLayer = OrchestrationProjectionPipelineLive.pipe(
+  Layer.provideMerge(OrchestrationEventStoreLive),
+  Layer.provideMerge(
+    ServerConfig.layerTest(process.cwd(), { prefix: "099-projection-threads-cursor" }),
+  ),
+  Layer.provideMerge(NodeSqliteClient.layerMemory()),
+  Layer.provideMerge(NodeServices.layer),
+);
+
+const makeAppendAndProject =
+  (
+    eventStore: OrchestrationEventStoreShape,
+    projectionPipeline: OrchestrationProjectionPipelineShape,
+  ) =>
+  (event: Parameters<OrchestrationEventStoreShape["append"]>[0]) =>
+    eventStore
+      .append(event)
+      .pipe(Effect.flatMap((saved) => projectionPipeline.projectEvent(saved)));
+
+it.layer(Layer.fresh(testLayer))("099_InvalidateProjectionThreadsCursor", (it) => {
+  it.effect(
+    "deletes the projection.threads cursor so startup bootstrap heals regressed updatedAt",
+    () =>
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        const eventStore = yield* OrchestrationEventStore;
+        const projectionPipeline = yield* OrchestrationProjectionPipeline;
+
+        // Run all migrations before this one, simulating an installation that
+        // already has migration 98 applied and a projection.threads cursor at
+        // the journal head.
+        yield* runMigrations({ toMigrationInclusive: 98 });
+
+        const threadId = ThreadId.makeUnsafe("thread-099");
+        const projectId = ProjectId.makeUnsafe("project-099");
+        const turnId = TurnId.makeUnsafe("turn-099");
+        const messageId = MessageId.makeUnsafe("message-099");
+        const createdAt = "2026-09-01T00:00:00.000Z";
+        const requestedAt = "2026-09-01T00:00:01.000Z";
+        const startedAt = "2026-09-01T00:00:02.000Z";
+        const completedAt = "2026-09-01T00:00:03.000Z";
+
+        const appendAndProject = makeAppendAndProject(eventStore, projectionPipeline);
+        let sequence = 0;
+        const nextEventId = () => EventId.makeUnsafe(`evt-099-${++sequence}`);
+
+        yield* appendAndProject({
+          type: "project.created",
+          eventId: nextEventId(),
+          aggregateKind: "project",
+          aggregateId: projectId,
+          occurredAt: createdAt,
+          commandId: CommandId.makeUnsafe("cmd-099-project"),
+          causationEventId: null,
+          correlationId: CorrelationId.makeUnsafe("cmd-099-project"),
+          metadata: {},
+          payload: {
+            projectId,
+            title: "Project 099",
+            workspaceRoot: "/tmp/project-099",
+            defaultModelSelection: null,
+            scripts: [],
+            createdAt,
+            updatedAt: createdAt,
+          },
+        });
+
+        yield* appendAndProject({
+          type: "thread.created",
+          eventId: nextEventId(),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: createdAt,
+          commandId: CommandId.makeUnsafe("cmd-099-thread"),
+          causationEventId: null,
+          correlationId: CorrelationId.makeUnsafe("cmd-099-thread"),
+          metadata: {},
+          payload: {
+            threadId,
+            projectId,
+            title: "Thread 099",
+            modelSelection: { provider: "codex", model: "gpt-5-codex" },
+            runtimeMode: "full-access",
+            branch: null,
+            worktreePath: null,
+            workingDirectory: null,
+            associatedWorktreePath: null,
+            associatedWorktreeBranch: null,
+            associatedWorktreeRef: null,
+            createBranchFlowCompleted: false,
+            isPinned: false,
+            parentThreadId: null,
+            creationSource: null,
+            sourceThreadId: null,
+            sourceTurnId: null,
+            gatewayOperationId: null,
+            gatewayOperationIndex: null,
+            subagentAgentId: null,
+            subagentNickname: null,
+            subagentRole: null,
+            forkSourceThreadId: null,
+            sidechatSourceThreadId: null,
+            sidechatLastActivityAt: null,
+            sidechatExpiredAt: null,
+            lastKnownPr: null,
+            handoff: null,
+            createdAt,
+            updatedAt: createdAt,
+          },
+        });
+
+        yield* appendAndProject({
+          type: "thread.turn-start-requested",
+          eventId: nextEventId(),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: requestedAt,
+          commandId: CommandId.makeUnsafe("cmd-099-turn-start"),
+          causationEventId: null,
+          correlationId: CorrelationId.makeUnsafe("cmd-099-turn-start"),
+          metadata: {},
+          payload: {
+            threadId,
+            messageId,
+            modelSelection: { provider: "codex", model: "gpt-5-codex" },
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            dispatchMode: "queue",
+            dispatchOrigin: "user",
+            createdAt: requestedAt,
+          },
+        });
+
+        const session = (
+          status: "running" | "ready",
+          activeTurnId: TurnId | null,
+          updatedAt: string,
+        ) => ({
+          threadId,
+          status,
+          providerName: "codex",
+          runtimeMode: "full-access" as const,
+          activeTurnId,
+          lastError: null,
+          updatedAt,
+        });
+
+        yield* appendAndProject({
+          type: "thread.session-set",
+          eventId: nextEventId(),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: startedAt,
+          commandId: CommandId.makeUnsafe("cmd-099-session-start"),
+          causationEventId: null,
+          correlationId: CorrelationId.makeUnsafe("cmd-099-session-start"),
+          metadata: {},
+          payload: {
+            threadId,
+            session: session("running", turnId, startedAt),
+          },
+        });
+
+        yield* appendAndProject({
+          type: "thread.session-set",
+          eventId: nextEventId(),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: completedAt,
+          commandId: CommandId.makeUnsafe("cmd-099-session-end"),
+          causationEventId: null,
+          correlationId: CorrelationId.makeUnsafe("cmd-099-session-end"),
+          metadata: {},
+          payload: {
+            threadId,
+            session: session("ready", null, completedAt),
+          },
+        });
+
+        // The current projector sets updated_at to completion; regress it to the
+        // turn-start time to simulate a database upgraded from the buggy version.
+        const [before] = yield* sql<{ readonly updatedAt: string }>`
+          SELECT updated_at AS "updatedAt"
+          FROM projection_threads
+          WHERE thread_id = ${threadId}
+        `;
+        assert.equal(before!.updatedAt, completedAt);
+
+        yield* sql`
+          UPDATE projection_threads
+          SET updated_at = ${requestedAt}
+          WHERE thread_id = ${threadId}
+        `;
+
+        const [cursorBefore] = yield* sql<{ readonly lastAppliedSequence: number }>`
+          SELECT last_applied_sequence AS "lastAppliedSequence"
+          FROM projection_state
+          WHERE projector = ${ORCHESTRATION_PROJECTOR_NAMES.threads}
+        `;
+        assert.strictEqual(cursorBefore!.lastAppliedSequence, 5);
+
+        // Apply migration 99. This must delete the projection.threads cursor so
+        // the next bootstrap will replay with the updated event filter.
+        yield* runMigrations({ toMigrationInclusive: 99 });
+
+        const [cursorAfter] = yield* sql<{ readonly count: number }>`
+          SELECT COUNT(*) AS "count"
+          FROM projection_state
+          WHERE projector = ${ORCHESTRATION_PROJECTOR_NAMES.threads}
+        `;
+        assert.strictEqual(cursorAfter!.count, 0);
+
+        // Rerunning the migration with the cursor already absent must stay safe.
+        yield* runMigrations({ toMigrationInclusive: 99 });
+
+        const [cursorRerun] = yield* sql<{ readonly count: number }>`
+          SELECT COUNT(*) AS "count"
+          FROM projection_state
+          WHERE projector = ${ORCHESTRATION_PROJECTOR_NAMES.threads}
+        `;
+        assert.strictEqual(cursorRerun!.count, 0);
+
+        // First startup after upgrade: the bootstrap replay heals the stale row.
+        yield* projectionPipeline.bootstrap;
+
+        const [after] = yield* sql<{ readonly updatedAt: string }>`
+          SELECT updated_at AS "updatedAt"
+          FROM projection_threads
+          WHERE thread_id = ${threadId}
+        `;
+        assert.equal(after!.updatedAt, completedAt);
+      }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/099_InvalidateProjectionThreadsCursor.ts
+++ b/apps/server/src/persistence/Migrations/099_InvalidateProjectionThreadsCursor.ts
@@ -1,0 +1,18 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+// After the fix that adds `thread.session-set` and `thread.turn-diff-completed`
+// to the hot threads projector, an existing `projection.threads` cursor that is
+// already past those events will never backfill them. The next startup will
+// instead fast-forward the cursor and skip the newly covered history. Deleting
+// the cursor forces the bootstrap replay to re-apply the entire journal with the
+// updated replay filter, healing regressed `projection_threads.updated_at` values
+// to the turn completion time without needing the manual repairState path.
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    DELETE FROM projection_state
+    WHERE projector = 'projection.threads'
+  `;
+});


### PR DESCRIPTION
## What this does

Fixes read chats reappearing as unread after a restart. Two root causes, both in the orchestration projection:

1. `projection_threads.updatedAt` could regress: the completion path (`session-set` / `turn-diff-completed`) and the repair-replay path assigned `occurredAt` directly, so a stale completion or a repair replay over a rebuilt projection moved `updatedAt` backwards — and the unread computation reads that timestamp.
2. Existing installs already carry regressed rows: migration `099_InvalidateProjectionThreadsCursor` deletes the `projection.threads` cursor on upgrade so the next bootstrap replays the journal to head and heals every row (precedent: migration 062).

The fix makes all three write paths (`projector.ts`, `Layers/ProjectionPipeline.ts` live + deferred) monotonic via a shared `maxIso` helper hoisted into `turnLifecycle.ts`, and expands the hot-threads event filter so replay covers the completion events.

## Behavior change (user-visible)

- Threads you have read stay read across app restarts and projection rebuilds. No more phantom unread badges after upgrading or after a repair replay.
- One-time cost on first boot after upgrade: the threads projector does a full-journal rescan (batched, crash-safe, idempotent). No data loss, just a slower first boot on very large journals.

## Reviews

- **ponytail ultra: approve.** Minimal root-cause fix at the right rung: shared `maxIso` dedups instead of abstracting, the filter expansion is required for replay coverage, the migration is required for the upgrade path (repair is manual-only). No new dependencies, no new abstractions. Test additions are verbose but each asserts a distinct invariant (rebuild monotonicity, stale-event monotonicity, migration heal).
- **thermos bugs/breakage/security lens: approve, no BLOCKING.** Bootstrap replay verified idempotent and crash-safe; migration SQL fully parameterized; publish behavior unchanged. 5 NITs, all deferred to Follow-ups.
- **thermos maintainability lens: approve, no BLOCKING.** `maxIso` extraction is the right dedup, comments explain the why, tests readable. 8 NITs, all deferred to Follow-ups.
- Blocking findings: none. No fixing commits needed; branch untouched since `641e2c9d`.

## Tests

| Command | Result |
|---|---|
| `bun run test src/persistence/Migrations/099_InvalidateProjectionThreadsCursor.test.ts` (from `apps/server`) | 1 passed |
| `bun run test src/orchestration/projector.test.ts` | 27 passed |
| `bun run test src/orchestration/Layers/ProjectionPipeline.test.ts` | 41 passed |
| `bun run test src/persistence/Migrations.test.ts` | 19 passed |
| `bun run test:browser:stable src/components/SidebarThreadRowContent.browser.tsx` (from `apps/web`) | 2 passed |
| Live headed run: dev stack from this branch, created project + thread in the real UI, full server stop/restart, reloaded in a fresh profile | Thread persists with identical history, zero unread badges; `projection_threads.updated_at` bit-identical pre/post (`2026-09-03T17:44:58.654Z`); threads cursor advanced 38 → 40 by replay; 99 migrations applied |

Live captures (6 screenshots, run video, playwright trace) are local author evidence in the worktree `evidence/908/` dir, not attached here. OS-level screen recording is blocked machine-wide by TCC permissions, so the recording substitute is `run-video.webm` + `trace.zip` (playwright, full action/screenshot timeline).

## Socket surface

None. The diff's only `gateway*` matches are `projection_threads` data columns (`gatewayOperationId`, provenance fields) — no transport, WS, or gateway connect/send/receive logic is touched, so no killed-server failure path applies. The live run above exercised the app's normal WS-driven sync throughout with no connection errors.

## Follow-ups

Deferred NITs from the two thermos passes (no action needed before merge):

- Route the remaining direct `updatedAt` writes (e.g. `turn-start-requested` `createdAt`, deleted/archived paths) through `maxIso`, and add a module note stating which event families need monotonicity (retries/imports/reconciliation can arrive out of order).
- Consolidate the remaining private `maxIso` copy in `Layers/ProjectionSnapshotQuery.ts` onto the canonical `turnLifecycle.maxIso` (verified identical; pre-existing duplication).
- Document the normalized fixed-width ISO-8601 assumption behind lexicographic `maxIso`.
- Migration 099: pin the hardcoded `'projection.threads'` literal to `ORCHESTRATION_PROJECTOR_NAMES.threads` via comment, and note why `thread-shell-summaries` needs no invalidation.
- Tests: why-comment on `DistributiveOmit`, share the triplicated session factory, share the duplicated completion-scenario setup, standardize assert strictness, name the magic cursor count.

## Merge note

- At PR head `641e2c9d`, no rebase (Wave-1 lane). `MERGEABLE`, `CLEAN`, ready, all 9 checks green.
- Safe to merge when approved. Emanuele clicks merge.
