### PR TITLE
Sidebar visibility pass: persistent status, counted show-more, inline timestamps, live elapsed

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -27,17 +27,22 @@ import {
   getVisibleThreadsForProject,
   getProjectSortTimestamp,
   hasUnseenCompletion,
+  formatThreadElapsed,
   partitionSidebarThreadsByProjectIds,
   isLatestPinnedThreadMutation,
   isLoopbackHostname,
   isDuplicateProjectCreateError,
   pruneProjectThreadListPagingForCollapsedProjects,
+  pruneProjectThreadListExtraPagesById,
   recoverExistingAddProjectTarget,
   runExclusiveProjectAddition,
   runProjectProvisionWithCancellationRecovery,
   resolvePullRequestReviewBadge,
   resolveSidebarThreadPullRequest,
   resolveThreadDisplayBranch,
+  resolveThreadElapsedMs,
+  resolveUrgentThreadTimeLabel,
+  shouldShowThreadStartingLabel,
   resolveSidebarThreadListPaging,
   resolveProjectEmptyState,
   resolveSettingsBackTarget,
@@ -372,6 +377,144 @@ describe("hasUnseenCompletion", () => {
   });
 });
 
+function makeRunningTurn(
+  startedAt: string | null,
+  requestedAt = "2026-03-09T10:00:00.000Z",
+): Thread["latestTurn"] {
+  return {
+    turnId: "turn-1" as never,
+    state: "running",
+    assistantMessageId: null,
+    requestedAt,
+    startedAt,
+    completedAt: null,
+  };
+}
+
+describe("resolveThreadElapsedMs", () => {
+  const nowMs = Date.parse("2026-03-09T10:12:00.000Z");
+
+  it("measures from the turn start while the turn is unfinished", () => {
+    expect(
+      resolveThreadElapsedMs({ latestTurn: makeRunningTurn("2026-03-09T10:00:00.000Z") }, nowMs),
+    ).toBe(12 * 60 * 1000);
+  });
+
+  it("falls back to the request time when the turn never started", () => {
+    expect(
+      resolveThreadElapsedMs(
+        { latestTurn: makeRunningTurn(null, "2026-03-09T10:10:00.000Z") },
+        nowMs,
+      ),
+    ).toBe(2 * 60 * 1000);
+  });
+
+  it("returns null for finished turns and threads without turns", () => {
+    expect(resolveThreadElapsedMs({ latestTurn: makeLatestTurn() }, nowMs)).toBeNull();
+    expect(resolveThreadElapsedMs({ latestTurn: null }, nowMs)).toBeNull();
+  });
+
+  it("clamps future start timestamps to zero", () => {
+    expect(
+      resolveThreadElapsedMs(
+        {
+          latestTurn: makeRunningTurn("2026-03-09T10:30:00.000Z", "2026-03-09T10:30:00.000Z"),
+        },
+        nowMs,
+      ),
+    ).toBe(0);
+  });
+});
+
+describe("formatThreadElapsed", () => {
+  it("matches the chat Working-for clock (seconds under a minute)", () => {
+    expect(formatThreadElapsed(45_000)).toBe("45s");
+  });
+
+  it("keeps seconds past the minute like the chat clock", () => {
+    expect(formatThreadElapsed(90_000)).toBe("1m 30s");
+    expect(formatThreadElapsed(12 * 60 * 1000)).toBe("12m");
+  });
+
+  it("renders hours with minutes only when nonzero", () => {
+    expect(formatThreadElapsed(60 * 60 * 1000)).toBe("1h");
+    expect(formatThreadElapsed(65 * 60 * 1000)).toBe("1h 5m");
+  });
+});
+
+describe("resolveUrgentThreadTimeLabel", () => {
+  it("prefers the live elapsed over recency", () => {
+    expect(
+      resolveUrgentThreadTimeLabel({
+        elapsedMs: 12 * 60 * 1000,
+        isStarting: true,
+        recencyLabel: "6m",
+      }),
+    ).toEqual({ text: "12m", title: "Running for 12m" });
+  });
+
+  it("reads as starting while the new turn has not arrived yet", () => {
+    expect(
+      resolveUrgentThreadTimeLabel({ elapsedMs: null, isStarting: true, recencyLabel: "6m" }),
+    ).toEqual({ text: "0s", title: "Starting…" });
+  });
+
+  it("falls back to recency when the thread is not running", () => {
+    expect(
+      resolveUrgentThreadTimeLabel({ elapsedMs: null, isStarting: false, recencyLabel: "6m" }),
+    ).toEqual({ text: "6m" });
+  });
+
+  it("shows nothing without elapsed, start, or recency", () => {
+    expect(
+      resolveUrgentThreadTimeLabel({ elapsedMs: null, isStarting: false, recencyLabel: null }),
+    ).toBeNull();
+  });
+});
+
+describe("shouldShowThreadStartingLabel", () => {
+  const runningSession: Thread["session"] = {
+    provider: "codex" as const,
+    status: "running" as const,
+    createdAt: "2026-03-09T10:00:00.000Z",
+    updatedAt: "2026-03-09T10:11:00.000Z",
+    orchestrationStatus: "running" as const,
+  };
+  const idleSession: Thread["session"] = {
+    provider: "codex" as const,
+    status: "closed" as const,
+    createdAt: "2026-03-09T10:00:00.000Z",
+    updatedAt: "2026-03-09T10:11:00.000Z",
+    orchestrationStatus: "running" as const,
+  };
+
+  it("starts while the new turn has not arrived yet", () => {
+    expect(shouldShowThreadStartingLabel({ latestTurn: null, session: runningSession })).toBe(true);
+  });
+
+  it("never starts off a finished turn, even when running flags lag behind", () => {
+    expect(
+      shouldShowThreadStartingLabel({ latestTurn: makeLatestTurn(), session: runningSession }),
+    ).toBe(false);
+    expect(
+      shouldShowThreadStartingLabel({
+        latestTurn: makeLatestTurn(),
+        hasLiveTailWork: true,
+        session: runningSession,
+      }),
+    ).toBe(false);
+  });
+
+  it("stays quiet on idle threads", () => {
+    expect(
+      shouldShowThreadStartingLabel({
+        latestTurn: makeRunningTurn("2026-03-09T10:00:00.000Z"),
+        session: idleSession,
+      }),
+    ).toBe(false);
+  });
+});
+
 describe("shouldClearThreadSelectionOnMouseDown", () => {
   it("preserves selection for thread items", () => {
     const child = {
@@ -649,6 +792,36 @@ describe("pruneProjectThreadListPagingForCollapsedProjects", () => {
       threadListExtraPagesByProjectCwd: current,
       projects: [{ cwd: "/Users/tester/Code/one", expanded: true }],
       normalizeProjectCwd: (cwd) => cwd.replace(/\/+$/, ""),
+    });
+
+    expect(next).toBe(current);
+  });
+});
+
+describe("pruneProjectThreadListExtraPagesById", () => {
+  it("clears remembered show-more paging when a project is collapsed", () => {
+    const current = new Map([
+      ["project-one" as ProjectId, 2],
+      ["project-two" as ProjectId, 1],
+    ]);
+
+    const next = pruneProjectThreadListExtraPagesById({
+      threadListExtraPagesByProjectId: current,
+      projects: [
+        { id: "project-one" as ProjectId, expanded: false },
+        { id: "project-two" as ProjectId, expanded: true },
+      ],
+    });
+
+    expect([...next]).toEqual([["project-two", 1]]);
+  });
+
+  it("preserves the existing map when no collapsed project needs pruning", () => {
+    const current = new Map([["project-one" as ProjectId, 1]]);
+
+    const next = pruneProjectThreadListExtraPagesById({
+      threadListExtraPagesByProjectId: current,
+      projects: [{ id: "project-one" as ProjectId, expanded: true }],
     });
 
     expect(next).toBe(current);

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -31,6 +31,7 @@ import {
 import { isDuplicateProjectCreateError } from "../lib/projectCreateRecovery";
 import {
   canSessionAnswerPendingRequests,
+  formatClockDuration,
   hasLiveLatestTurn,
   findLatestProposedPlan,
   hasActionableProposedPlan,
@@ -526,6 +527,35 @@ export function pruneProjectThreadListPagingForCollapsedProjects<
   return changed ? nextThreadListExtraPagesByProjectCwd : threadListExtraPagesByProjectCwd;
 }
 
+// Id-keyed twin of the cwd prune above: drops remembered "show more" paging for
+// projects that are currently collapsed. Entries for unknown ids are kept, matching
+// the legacy behavior for cwds that no longer match a project.
+export function pruneProjectThreadListExtraPagesById(input: {
+  threadListExtraPagesByProjectId: ReadonlyMap<Project["id"], number>;
+  projects: readonly Pick<Project, "id" | "expanded">[];
+}): ReadonlyMap<Project["id"], number> {
+  const { projects, threadListExtraPagesByProjectId } = input;
+  const collapsedProjectIds = new Set(
+    projects.filter((project) => !project.expanded).map((project) => project.id),
+  );
+
+  if (collapsedProjectIds.size === 0) {
+    return threadListExtraPagesByProjectId;
+  }
+
+  let changed = false;
+  const nextThreadListExtraPagesByProjectId = new Map<Project["id"], number>();
+  for (const [projectId, extraPages] of threadListExtraPagesByProjectId) {
+    if (collapsedProjectIds.has(projectId)) {
+      changed = true;
+      continue;
+    }
+    nextThreadListExtraPagesByProjectId.set(projectId, extraPages);
+  }
+
+  return changed ? nextThreadListExtraPagesByProjectId : threadListExtraPagesByProjectId;
+}
+
 /**
  * Trailing padding that protects the title from the absolutely-positioned
  * trailing cluster, sized to what the slot ACTUALLY shows so the title runs as
@@ -603,6 +633,79 @@ export function isThreadActivelyWorking(thread: {
     session?.status === "running" &&
     (thread.latestTurn == null || hasLiveLatestTurn(thread.latestTurn, session))
   );
+}
+
+/**
+ * Elapsed wall-clock time of the thread's unfinished turn, for "running for Xm"
+ * row labels. Null once the turn completes (recency labels take over) or when
+ * no start timestamp exists — callers fall back to the recency label.
+ */
+export function resolveThreadElapsedMs(
+  thread: Pick<Thread, "latestTurn">,
+  nowMs: number,
+): number | null {
+  const turn = thread.latestTurn;
+  if (turn == null || turn.completedAt != null) {
+    return null;
+  }
+  const startIso = turn.startedAt ?? turn.requestedAt ?? null;
+  if (startIso == null) {
+    return null;
+  }
+  const startMs = Date.parse(startIso);
+  if (Number.isNaN(startMs)) {
+    return null;
+  }
+  return Math.max(0, nowMs - startMs);
+}
+
+/** Compact elapsed label; same formatter the chat "Working for" header uses. */
+export function formatThreadElapsed(elapsedMs: number): string {
+  return formatClockDuration(elapsedMs);
+}
+
+/**
+ * Whether a running row is still waiting for its new turn (shows "Starting…").
+ * A finished latest turn means the run is over even if the running flags lag a
+ * frame behind — without this gate the row flashes "0s" on completion instead
+ * of simply dropping the elapsed label.
+ */
+export function shouldShowThreadStartingLabel(thread: {
+  hasLiveTailWork?: boolean | undefined;
+  session?: Thread["session"] | undefined;
+  latestTurn?: Thread["latestTurn"] | undefined;
+}): boolean {
+  const turn = thread.latestTurn;
+  if (turn != null && turn.completedAt != null) {
+    return false;
+  }
+  return isThreadActivelyWorking(thread) || thread.session?.status === "connecting";
+}
+
+export type UrgentThreadTimeLabel = {
+  text: string;
+  title?: string | undefined;
+};
+
+/**
+ * Which time label an urgent row shows. A running thread whose new turn has
+ * not arrived yet (stale finished turn still in the summary) must not flash
+ * the old recency ("6m") for a frame and then jump to "0s" — it reads as
+ * starting instead.
+ */
+export function resolveUrgentThreadTimeLabel(input: {
+  elapsedMs: number | null;
+  isStarting: boolean;
+  recencyLabel: string | null;
+}): UrgentThreadTimeLabel | null {
+  if (input.elapsedMs !== null) {
+    const text = formatThreadElapsed(input.elapsedMs);
+    return { text, title: `Running for ${text}` };
+  }
+  if (input.isStarting) {
+    return { text: "0s", title: "Starting…" };
+  }
+  return input.recencyLabel !== null ? { text: input.recencyLabel } : null;
 }
 
 export function resolveThreadStatusPill(input: {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -209,8 +209,9 @@ import { SidebarIconButton, sidebarIconButtonSlotClass } from "./SidebarIconButt
 import { SidebarLeadingIcon } from "./SidebarLeadingIcon";
 import { SidebarMetaChipStack } from "./SidebarMetaChip";
 import { SidebarRowHoverActions } from "./SidebarRowHoverActions";
+import { SidebarElapsedTimeLabel } from "./SidebarElapsedTimeLabel";
 import { SidebarSectionToolbar } from "./SidebarSectionToolbar";
-import { SidebarGlyph, sidebarGlyphClass, SIDEBAR_TRAILING_ICON_CLASS } from "./sidebarGlyphs";
+import { SidebarGlyph, sidebarGlyphClass } from "./sidebarGlyphs";
 import { SidebarStatusTrailingGlyph } from "./SidebarStatusTrailingGlyph";
 import { ThreadArchiveActionButton } from "./ThreadArchiveActionButton";
 import { ThreadPinToggleButton } from "./ThreadPinToggleButton";
@@ -241,6 +242,7 @@ import {
   normalizeSidebarProjectThreadListCwd,
   persistSidebarUiState,
   readSidebarUiState,
+  resolveProjectThreadListExtraPages,
   subscribeSidebarUiState,
 } from "./Sidebar.uiState";
 import {
@@ -316,7 +318,9 @@ import {
   partitionSidebarThreadsByProjectIds,
   isLatestPinnedProjectMutation,
   isProjectsSidebarSurface,
-  pruneProjectThreadListPagingForCollapsedProjects,
+  isThreadActivelyWorking,
+  isUrgentThreadStatusPill,
+  pruneProjectThreadListExtraPagesById,
   recoverExistingAddProjectTarget,
   runExclusiveProjectAddition,
   runProjectProvisionWithCancellationRecovery,
@@ -610,8 +614,9 @@ const THREAD_ROW_META_CHIP_HOVER_FADE_CLASS_NAME = cn(
 /** Status glyph slot; matches the 15px meta-chip column so trailing icons stay compact. */
 function threadRowStatusSlotClassName(isSubagentThread: boolean, toneClassName?: string): string {
   return cn(
+    // The status glyph stays visible on hover (only the meta chips fade), so the
+    // hover-action overlay carries its own solid background to sit above it.
     "flex w-[15px] shrink-0 items-center justify-center leading-none tabular-nums",
-    sidebarHoverRevealHideClassName("thread-row"),
     isSubagentThread
       ? "text-[10px]"
       : // Nudge the timestamp a hair above the meta scale while still tracking the user's
@@ -1601,8 +1606,20 @@ export default function Sidebar() {
   const [renameProjectDialogId, setRenameProjectDialogId] = useState<ProjectId | null>(null);
   const [projectContextMenuState, setProjectContextMenuState] =
     useState<ProjectContextMenuState | null>(null);
-  // "Show more" paging state: extra pages of THREAD_PREVIEW_PAGE_SIZE rows per project cwd.
-  const [threadListExtraPagesByProjectCwd, setThreadListExtraPagesByProjectCwd] = useState<
+  // "Show more" paging state: extra pages of THREAD_PREVIEW_PAGE_SIZE rows per project id.
+  const [threadListExtraPagesByProjectId, setThreadListExtraPagesByProjectId] = useState<
+    ReadonlyMap<ProjectId, number>
+  >(
+    () =>
+      new Map<ProjectId, number>(
+        Object.entries(readSidebarUiState().projectThreadListExtraPagesById) as Array<
+          [ProjectId, number]
+        >,
+      ),
+  );
+  // Pre-migration paging keyed by normalized cwd: read-only fallback for the id-first
+  // lookup, preserved verbatim on persist but never written by the paging handlers.
+  const [legacyThreadListExtraPagesByCwd, setLegacyThreadListExtraPagesByCwd] = useState<
     ReadonlyMap<string, number>
   >(() => new Map(Object.entries(readSidebarUiState().projectThreadListExtraPagesByCwd)));
   const [chatSectionExpanded, setChatSectionExpanded] = useState(
@@ -1640,7 +1657,12 @@ export default function Sidebar() {
       subscribeSidebarUiState((state) => {
         setChatSectionExpanded(state.chatSectionExpanded);
         setChatThreadListExtraPages(state.chatThreadListExtraPages);
-        setThreadListExtraPagesByProjectCwd(
+        setThreadListExtraPagesByProjectId(
+          new Map<ProjectId, number>(
+            Object.entries(state.projectThreadListExtraPagesById) as Array<[ProjectId, number]>,
+          ),
+        );
+        setLegacyThreadListExtraPagesByCwd(
           new Map(Object.entries(state.projectThreadListExtraPagesByCwd)),
         );
         setDismissedThreadStatusKeyByThreadId(state.dismissedThreadStatusKeyByThreadId);
@@ -3308,7 +3330,8 @@ export default function Sidebar() {
       persistSidebarUiState({
         chatSectionExpanded,
         chatThreadListExtraPages,
-        projectThreadListExtraPagesByCwd: Object.fromEntries(threadListExtraPagesByProjectCwd),
+        projectThreadListExtraPagesByCwd: Object.fromEntries(legacyThreadListExtraPagesByCwd),
+        projectThreadListExtraPagesById: Object.fromEntries(threadListExtraPagesByProjectId),
         dismissedThreadStatusKeyByThreadId,
         lastThreadRoute: nextLastThreadRoute,
         activityViewEnabled,
@@ -3319,7 +3342,8 @@ export default function Sidebar() {
       chatSectionExpanded,
       chatThreadListExtraPages,
       dismissedThreadStatusKeyByThreadId,
-      threadListExtraPagesByProjectCwd,
+      legacyThreadListExtraPagesByCwd,
+      threadListExtraPagesByProjectId,
     ],
   );
   const { activateThreadFromSidebarIntent } = useThreadActivationController({
@@ -3946,6 +3970,8 @@ export default function Sidebar() {
     canShowLessChatThreads,
     canShowMoreChatThreads,
     chatThreadListEffectiveExtraPages,
+    hiddenChatThreadCount,
+    chatShowMoreCount,
     renderedChatEntries,
   } = useMemo(() => {
     const paging = resolveSidebarThreadListPaging({
@@ -3959,6 +3985,7 @@ export default function Sidebar() {
       activeEntryId: activeChatPreviewEntry?.rowId,
       previewLimit: paging.previewLimit,
     });
+    const hiddenThreadCount = Math.max(0, visibleChatPreviewEntries.length - paging.previewLimit);
     return {
       // Mirror deriveSidebarProjectData: the active-chat reveal can force rows past the page
       // cap, so only offer "Show more" while rows are genuinely hidden.
@@ -3966,6 +3993,8 @@ export default function Sidebar() {
         paging.canShowMore && visibleEntries.length < visibleChatPreviewEntries.length,
       canShowLessChatThreads: paging.canShowLess,
       chatThreadListEffectiveExtraPages: paging.effectiveExtraPages,
+      hiddenChatThreadCount: hiddenThreadCount,
+      chatShowMoreCount: Math.min(THREAD_PREVIEW_PAGE_SIZE, hiddenThreadCount),
       renderedChatEntries: visibleEntries,
     };
   }, [activeChatPreviewEntry?.rowId, chatThreadListExtraPages, visibleChatPreviewEntries]);
@@ -4020,6 +4049,33 @@ export default function Sidebar() {
     () => orderPinnedProjectsForSidebar(standardProjectsBase, pinnedProjectIds),
     [pinnedProjectIds, standardProjectsBase],
   );
+  // deriveSidebarProjectData still pages by normalized cwd, so resolve every surface
+  // project through the id-first lookup (stable id wins, legacy cwd map backfills).
+  const threadListExtraPagesByProjectCwd = useMemo(() => {
+    const resolved = new Map<string, number>();
+    for (const project of [...standardProjects, ...studioProjects]) {
+      const extraPages = resolveProjectThreadListExtraPages({
+        extraPagesById: threadListExtraPagesByProjectId,
+        legacyExtraPagesByCwd: legacyThreadListExtraPagesByCwd,
+        projectId: project.id,
+        projectCwd: project.cwd,
+      });
+      if (extraPages <= 0) {
+        continue;
+      }
+      const cwdKey = normalizeSidebarProjectThreadListCwd(project.cwd);
+      if (cwdKey.length === 0) {
+        continue;
+      }
+      resolved.set(cwdKey, Math.max(resolved.get(cwdKey) ?? 0, extraPages));
+    }
+    return resolved;
+  }, [
+    legacyThreadListExtraPagesByCwd,
+    standardProjects,
+    studioProjects,
+    threadListExtraPagesByProjectId,
+  ]);
   const projectEmptyState = resolveProjectEmptyState({
     projectCount: standardProjects.length,
     shouldShowProjectPathEntry: createProjectDialogOpen,
@@ -4089,11 +4145,10 @@ export default function Sidebar() {
   // Reset per-project preview paging when a folder closes so reopening starts at five rows again.
   useEffect(() => {
     const settle = window.setTimeout(() => {
-      setThreadListExtraPagesByProjectCwd((current) =>
-        pruneProjectThreadListPagingForCollapsedProjects({
-          threadListExtraPagesByProjectCwd: current,
+      setThreadListExtraPagesByProjectId((current) =>
+        pruneProjectThreadListExtraPagesById({
+          threadListExtraPagesByProjectId: current,
           projects: standardProjects,
-          normalizeProjectCwd: normalizeSidebarProjectThreadListCwd,
         }),
       );
     }, 0);
@@ -4127,7 +4182,8 @@ export default function Sidebar() {
     persistSidebarUiState({
       chatSectionExpanded,
       chatThreadListExtraPages,
-      projectThreadListExtraPagesByCwd: Object.fromEntries(threadListExtraPagesByProjectCwd),
+      projectThreadListExtraPagesByCwd: Object.fromEntries(legacyThreadListExtraPagesByCwd),
+      projectThreadListExtraPagesById: Object.fromEntries(threadListExtraPagesByProjectId),
       dismissedThreadStatusKeyByThreadId,
       lastThreadRoute,
       activityViewEnabled,
@@ -4137,7 +4193,8 @@ export default function Sidebar() {
     chatSectionExpanded,
     chatThreadListExtraPages,
     dismissedThreadStatusKeyByThreadId,
-    threadListExtraPagesByProjectCwd,
+    legacyThreadListExtraPagesByCwd,
+    threadListExtraPagesByProjectId,
     lastThreadRoute,
   ]);
 
@@ -4353,7 +4410,13 @@ export default function Sidebar() {
     const includePinToggle = input.includePinToggle !== false;
 
     return (
-      <SidebarRowHoverActions threadId={input.threadId}>
+      <SidebarRowHoverActions
+        threadId={input.threadId}
+        testId={`thread-hover-actions-${input.threadId}`}
+        // Solid background so the actions read as an overlay above the status
+        // glyph, which no longer fades out on hover.
+        className="rounded-md bg-[var(--sidebar-background,var(--background))]"
+      >
         <div className="pointer-events-auto inline-flex items-center gap-2">
           {includePinToggle ? (
             <ThreadPinToggleButton
@@ -4719,6 +4782,16 @@ export default function Sidebar() {
     const threadJumpLabel = visibleThreadJumpLabelByThreadId.get(thread.id) ?? null;
     const threadJumpLabelParts =
       visibleThreadJumpLabelPartsByThreadId.get(thread.id) ?? EMPTY_SHORTCUT_PARTS;
+    // Urgent rows keep a short time label in normal flow (next to the title, which
+    // truncates first) now that the trailing status slot is always visible.
+    // Running rows render a live "running for" elapsed via SidebarElapsedTimeLabel
+    // (1s tick scoped to the row); settled rows fall back to recency here.
+    const threadIsRunning =
+      isThreadActivelyWorking(thread) || thread.session?.status === "connecting";
+    const urgentThreadRecency =
+      threadStatus !== null && isUrgentThreadStatusPill(threadStatus)
+        ? formatRelativeTime(thread.latestTurn?.completedAt ?? thread.updatedAt ?? thread.createdAt)
+        : null;
     const hoverAnchorId = createSidebarThreadHoverAnchorId({
       scope: topLevel ? "chat" : "project",
       threadId: thread.id,
@@ -4826,18 +4899,23 @@ export default function Sidebar() {
                 threadStatus?.label === "Pending Approval" ? threadStatus.colorClass : null
               }
               suffix={
-                showTemporaryThreadIcon ? (
+                showTemporaryThreadIcon || threadIsRunning || urgentThreadRecency !== null ? (
                   <div className="ml-auto flex shrink-0 items-center gap-1.5 pr-1">
-                    <Tooltip>
-                      <TooltipTrigger
-                        render={
-                          <span className="inline-flex shrink-0 items-center text-muted-foreground/55">
-                            <TemporaryThreadIcon />
-                          </span>
-                        }
-                      />
-                      <TooltipPopup side="top">Temporary chat</TooltipPopup>
-                    </Tooltip>
+                    {threadIsRunning || urgentThreadRecency !== null ? (
+                      <SidebarElapsedTimeLabel thread={thread} recencyLabel={urgentThreadRecency} />
+                    ) : null}
+                    {showTemporaryThreadIcon ? (
+                      <Tooltip>
+                        <TooltipTrigger
+                          render={
+                            <span className="inline-flex shrink-0 items-center text-muted-foreground/55">
+                              <TemporaryThreadIcon />
+                            </span>
+                          }
+                        />
+                        <TooltipPopup side="top">Temporary chat</TooltipPopup>
+                      </Tooltip>
+                    ) : null}
                   </div>
                 ) : undefined
               }
@@ -4887,6 +4965,14 @@ export default function Sidebar() {
       canShowMoreThreads,
       canShowLessThreads,
     } = projectSidebarData;
+    // "Show more" reveals one page; the label names that page and the total still hidden.
+    const projectPreviewLimit =
+      THREAD_PREVIEW_LIMIT + threadListExtraPages * THREAD_PREVIEW_PAGE_SIZE;
+    const hiddenProjectThreadCount = Math.max(
+      0,
+      orderedProjectThreadIds.length - projectPreviewLimit,
+    );
+    const projectShowMoreCount = Math.min(THREAD_PREVIEW_PAGE_SIZE, hiddenProjectThreadCount);
     const projectFolderIconClassName = isProjectPinned
       ? "opacity-0"
       : sidebarHoverRevealHideClassName("project-header");
@@ -5026,7 +5112,12 @@ export default function Sidebar() {
             >
               <PinStatusIcon pinned={isProjectPinned} className="size-3.5" />
             </button>
-            <SidebarSectionToolbar placement="overlay" revealOnHover>
+            <SidebarSectionToolbar
+              placement="overlay"
+              revealOnHover
+              // Solid background so the toolbar reads as an overlay above the row content.
+              className="rounded-md bg-[var(--sidebar-background,var(--background))]"
+            >
               <SidebarIconButton
                 icon={IoIosGitCompare}
                 label={`View pull requests for ${project.name}`}
@@ -5122,10 +5213,12 @@ export default function Sidebar() {
                         className="h-7 flex-1 translate-x-0 justify-start rounded-lg pr-2 pl-8 text-left text-[length:var(--app-font-size-ui,12px)] text-muted-foreground/79 hover:bg-transparent hover:text-foreground active:bg-transparent active:text-foreground"
                         onMouseDown={preventFocusOnMouseDown}
                         onClick={() => {
-                          showMoreThreadsForProject(project.cwd, threadListExtraPages);
+                          showMoreThreadsForProject(project.id, threadListExtraPages);
                         }}
                       >
-                        <span>Show more</span>
+                        <span>
+                          Show {projectShowMoreCount} more ({hiddenProjectThreadCount})
+                        </span>
                       </SidebarMenuSubButton>
                     )}
                     {canShowLessThreads && (
@@ -5140,7 +5233,7 @@ export default function Sidebar() {
                         )}
                         onMouseDown={preventFocusOnMouseDown}
                         onClick={() => {
-                          showLessThreadsForProject(project.cwd, threadListExtraPages);
+                          showLessThreadsForProject(project.id, threadListExtraPages);
                         }}
                       >
                         <span>Show less</span>
@@ -5824,17 +5917,15 @@ export default function Sidebar() {
   // Both handlers step from the *effective* (clamped) page count reported by the derived
   // project data, so stale/oversized stored paging self-heals on the very next click.
   const setThreadListExtraPagesForProject = useCallback(
-    (projectCwd: string, nextExtraPages: number) => {
-      const cwdKey = normalizeSidebarProjectThreadListCwd(projectCwd);
-      if (cwdKey.length === 0) return;
-      setThreadListExtraPagesByProjectCwd((current) => {
+    (projectId: ProjectId, nextExtraPages: number) => {
+      setThreadListExtraPagesByProjectId((current) => {
         const clampedExtraPages = Math.max(0, nextExtraPages);
-        if ((current.get(cwdKey) ?? 0) === clampedExtraPages) return current;
+        if ((current.get(projectId) ?? 0) === clampedExtraPages) return current;
         const next = new Map(current);
         if (clampedExtraPages === 0) {
-          next.delete(cwdKey);
+          next.delete(projectId);
         } else {
-          next.set(cwdKey, clampedExtraPages);
+          next.set(projectId, clampedExtraPages);
         }
         return next;
       });
@@ -5843,15 +5934,15 @@ export default function Sidebar() {
   );
 
   const showMoreThreadsForProject = useCallback(
-    (projectCwd: string, currentExtraPages: number) => {
-      setThreadListExtraPagesForProject(projectCwd, currentExtraPages + 1);
+    (projectId: ProjectId, currentExtraPages: number) => {
+      setThreadListExtraPagesForProject(projectId, currentExtraPages + 1);
     },
     [setThreadListExtraPagesForProject],
   );
 
   const showLessThreadsForProject = useCallback(
-    (projectCwd: string, currentExtraPages: number) => {
-      setThreadListExtraPagesForProject(projectCwd, currentExtraPages - 1);
+    (projectId: ProjectId, currentExtraPages: number) => {
+      setThreadListExtraPagesForProject(projectId, currentExtraPages - 1);
     },
     [setThreadListExtraPagesForProject],
   );
@@ -6147,6 +6238,7 @@ export default function Sidebar() {
                     projectById={projectById}
                     activeThreadId={visualActiveSidebarThreadId}
                     pinnedThreadIdSet={pinnedThreadIdSet}
+                    timestampFormat={appSettings.timestampFormat}
                     settledOverrideByThreadId={settledOverrideByThreadId}
                     threadsHydrated={threadsHydrated}
                     resolveThreadStatus={resolveThreadStatusForSidebar}
@@ -6390,7 +6482,9 @@ export default function Sidebar() {
                                 setChatThreadListExtraPages(chatThreadListEffectiveExtraPages + 1)
                               }
                             >
-                              <span>Show more</span>
+                              <span>
+                                Show {chatShowMoreCount} more ({hiddenChatThreadCount})
+                              </span>
                             </SidebarMenuButton>
                           ) : null}
                           {canShowLessChatThreads ? (

--- a/apps/web/src/components/Sidebar.uiState.test.ts
+++ b/apps/web/src/components/Sidebar.uiState.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeSidebarProjectThreadListCwd,
   persistSidebarUiState,
   readSidebarUiState,
+  resolveProjectThreadListExtraPages,
 } from "./Sidebar.uiState";
 
 describe("Sidebar.uiState", () => {
@@ -39,6 +40,7 @@ describe("Sidebar.uiState", () => {
       chatSectionExpanded: false,
       chatThreadListExtraPages: 0,
       projectThreadListExtraPagesByCwd: {},
+      projectThreadListExtraPagesById: {},
       dismissedThreadStatusKeyByThreadId: {},
       lastThreadRoute: null,
       activityViewEnabled: false,
@@ -53,6 +55,9 @@ describe("Sidebar.uiState", () => {
         "/Users/tester/Code/demo": 1,
         "/Users/tester/Code/demo/": 3,
         "/Users/tester/Code/other": 2,
+      },
+      projectThreadListExtraPagesById: {
+        "project-demo": 2,
       },
       dismissedThreadStatusKeyByThreadId: {
         "thread-123": "Plan Ready:turn-1",
@@ -71,6 +76,9 @@ describe("Sidebar.uiState", () => {
         // Duplicate cwds that normalize to the same key keep the deepest paging.
         [normalizeSidebarProjectThreadListCwd("/Users/tester/Code/demo")]: 3,
         [normalizeSidebarProjectThreadListCwd("/Users/tester/Code/other")]: 2,
+      },
+      projectThreadListExtraPagesById: {
+        "project-demo": 2,
       },
       dismissedThreadStatusKeyByThreadId: {
         "thread-123": "Plan Ready:turn-1",
@@ -114,6 +122,7 @@ describe("Sidebar.uiState", () => {
       projectThreadListExtraPagesByCwd: {
         [normalizeSidebarProjectThreadListCwd("/Users/tester/Code/demo")]: 2,
       },
+      projectThreadListExtraPagesById: {},
       dismissedThreadStatusKeyByThreadId: {
         "thread-123": "Awaiting Input:turn-2",
       },
@@ -158,9 +167,45 @@ describe("Sidebar.uiState", () => {
       chatSectionExpanded: false,
       chatThreadListExtraPages: 0,
       projectThreadListExtraPagesByCwd: {},
+      projectThreadListExtraPagesById: {},
       dismissedThreadStatusKeyByThreadId: {},
       lastThreadRoute: null,
       activityViewEnabled: false,
     });
+  });
+
+  it("prefers project-id paging over legacy cwd paging", () => {
+    const legacyCwd = normalizeSidebarProjectThreadListCwd("/Users/tester/Code/demo");
+    expect(
+      resolveProjectThreadListExtraPages({
+        extraPagesById: { "project-demo": 3 },
+        legacyExtraPagesByCwd: { [legacyCwd]: 1 },
+        projectId: "project-demo",
+        projectCwd: "/Users/tester/Code/demo",
+      }),
+    ).toBe(3);
+  });
+
+  it("falls back to legacy cwd paging when no id entry exists", () => {
+    const legacyCwd = normalizeSidebarProjectThreadListCwd("/Users/tester/Code/demo");
+    expect(
+      resolveProjectThreadListExtraPages({
+        extraPagesById: {},
+        legacyExtraPagesByCwd: { [legacyCwd]: 2 },
+        projectId: "project-demo",
+        projectCwd: "/Users/tester/Code/demo/",
+      }),
+    ).toBe(2);
+  });
+
+  it("returns zero paging when neither id nor cwd entries exist", () => {
+    expect(
+      resolveProjectThreadListExtraPages({
+        extraPagesById: new Map(),
+        legacyExtraPagesByCwd: new Map(),
+        projectId: "project-demo",
+        projectCwd: "/Users/tester/Code/demo",
+      }),
+    ).toBe(0);
   });
 });

--- a/apps/web/src/components/Sidebar.uiState.ts
+++ b/apps/web/src/components/Sidebar.uiState.ts
@@ -12,6 +12,8 @@ export type SidebarUiState = {
   chatSectionExpanded: boolean;
   chatThreadListExtraPages: number;
   projectThreadListExtraPagesByCwd: Record<string, number>;
+  /** Paging keyed by stable project id; preferred over the legacy cwd map. */
+  projectThreadListExtraPagesById: Record<string, number>;
   dismissedThreadStatusKeyByThreadId: Record<string, string>;
   lastThreadRoute: LastThreadRoute | null;
   /** Swaps the Projects surface for the flat task-feed Activity view. */
@@ -22,6 +24,7 @@ const DEFAULT_SIDEBAR_UI_STATE: SidebarUiState = {
   chatSectionExpanded: false,
   chatThreadListExtraPages: 0,
   projectThreadListExtraPagesByCwd: {},
+  projectThreadListExtraPagesById: {},
   dismissedThreadStatusKeyByThreadId: {},
   lastThreadRoute: null,
   activityViewEnabled: false,
@@ -40,6 +43,54 @@ function sanitizeThreadListExtraPages(value: unknown): number {
     return 0;
   }
   return Math.min(Math.max(0, Math.floor(value)), MAX_PERSISTED_THREAD_LIST_EXTRA_PAGES);
+}
+
+function sanitizeProjectThreadListExtraPagesById(
+  value: Record<string, unknown> | undefined,
+): Record<string, number> {
+  const extraPagesById: Record<string, number> = {};
+  for (const [projectId, rawExtraPages] of Object.entries(value ?? {})) {
+    if (projectId.length === 0) {
+      continue;
+    }
+    const extraPages = sanitizeThreadListExtraPages(rawExtraPages);
+    if (extraPages <= 0) {
+      continue;
+    }
+    extraPagesById[projectId] = Math.max(extraPagesById[projectId] ?? 0, extraPages);
+  }
+  return extraPagesById;
+}
+
+/**
+ * Paging lookup that survives project rename/move: the stable project id wins,
+ * and pre-migration entries persisted by normalized cwd still apply as fallback.
+ */
+function isExtraPagesMap(
+  value: Readonly<Record<string, number>> | ReadonlyMap<string, number>,
+): value is ReadonlyMap<string, number> {
+  return value instanceof Map;
+}
+
+export function resolveProjectThreadListExtraPages(input: {
+  extraPagesById: Readonly<Record<string, number>> | ReadonlyMap<string, number>;
+  legacyExtraPagesByCwd: Readonly<Record<string, number>> | ReadonlyMap<string, number>;
+  projectId: string;
+  projectCwd: string;
+}): number {
+  const byId = isExtraPagesMap(input.extraPagesById)
+    ? (input.extraPagesById.get(input.projectId) ?? 0)
+    : (input.extraPagesById[input.projectId] ?? 0);
+  if (byId > 0) {
+    return byId;
+  }
+  const normalizedCwd = normalizeSidebarProjectThreadListCwd(input.projectCwd);
+  if (normalizedCwd.length === 0) {
+    return 0;
+  }
+  return isExtraPagesMap(input.legacyExtraPagesByCwd)
+    ? (input.legacyExtraPagesByCwd.get(normalizedCwd) ?? 0)
+    : (input.legacyExtraPagesByCwd[normalizedCwd] ?? 0);
 }
 
 function sanitizeProjectThreadListExtraPagesByCwd(
@@ -76,6 +127,7 @@ export function readSidebarUiState(): SidebarUiState {
       chatSectionExpanded?: boolean;
       chatThreadListExtraPages?: number;
       projectThreadListExtraPagesByCwd?: Record<string, unknown>;
+      projectThreadListExtraPagesById?: Record<string, unknown>;
       /** Legacy (pre-paging) all-or-nothing "Show more" flags, migrated to one extra page. */
       chatThreadListExpanded?: boolean;
       expandedProjectThreadListCwds?: string[];
@@ -122,6 +174,9 @@ export function readSidebarUiState(): SidebarUiState {
           ? 1
           : sanitizeThreadListExtraPages(parsed.chatThreadListExtraPages),
       projectThreadListExtraPagesByCwd,
+      projectThreadListExtraPagesById: sanitizeProjectThreadListExtraPagesById(
+        parsed.projectThreadListExtraPagesById,
+      ),
       dismissedThreadStatusKeyByThreadId: Object.fromEntries(
         Object.entries(parsed.dismissedThreadStatusKeyByThreadId ?? {}).filter(
           ([threadId, statusKey]) =>
@@ -170,6 +225,9 @@ export function persistSidebarUiState(input: SidebarUiState): void {
         chatThreadListExtraPages: sanitizeThreadListExtraPages(input.chatThreadListExtraPages),
         projectThreadListExtraPagesByCwd: sanitizeProjectThreadListExtraPagesByCwd(
           input.projectThreadListExtraPagesByCwd,
+        ),
+        projectThreadListExtraPagesById: sanitizeProjectThreadListExtraPagesById(
+          input.projectThreadListExtraPagesById,
         ),
         dismissedThreadStatusKeyByThreadId: Object.fromEntries(
           Object.entries(input.dismissedThreadStatusKeyByThreadId).filter(

--- a/apps/web/src/components/SidebarActivityView.browser.tsx
+++ b/apps/web/src/components/SidebarActivityView.browser.tsx
@@ -158,7 +158,7 @@ describe("SidebarActivityView", () => {
     });
     expect(document.querySelector('[title="#42 PR merged: Live merged PR"]')).not.toBeNull();
 
-    await page.getByRole("button", { name: "Show more" }).click();
+    await page.getByRole("button", { name: /Show \d+ more \(\d+\)/ }).click();
     await vi.waitFor(() => {
       expect(document.querySelectorAll("[data-testid^='activity-thread-']")).toHaveLength(40);
       expect(onVisibleThreadIdsChange.mock.lastCall?.[0]).toHaveLength(40);
@@ -274,14 +274,15 @@ describe("SidebarActivityView", () => {
       }),
     );
 
-    const completedDot = page
-      .getByTestId(`activity-thread-${unseen.id}`)
-      .element()
-      .parentElement?.querySelector('[aria-label="Unread completion"]');
+    const unseenRowButton = page.getByTestId(`activity-thread-${unseen.id}`).element();
+    const completedDot = unseenRowButton.parentElement?.querySelector(
+      '[aria-label="Unread completion"]',
+    );
     expect(completedDot).not.toBeNull();
-    expect(completedDot?.parentElement?.dataset.slot).toBe("activity-completion-status");
-    const completedStatusSlot = completedDot?.parentElement;
-    const completedStatusLeft = completedStatusSlot?.getBoundingClientRect().left;
+    // The status glyph lives inline in the row's second line (next to PR/branch),
+    // not in an absolutely-positioned slot that hovers actions would cover.
+    expect(unseenRowButton.contains(completedDot ?? null)).toBe(true);
+    const completedStatusLeft = completedDot?.getBoundingClientRect().left;
 
     const pinnedRow = page.getByTestId(`activity-thread-${pinned.id}`).element();
     pinnedRow.focus();
@@ -293,9 +294,11 @@ describe("SidebarActivityView", () => {
 
     page.getByTestId(`activity-thread-${unseen.id}`).element().focus();
     await vi.waitFor(() => {
-      expect(getComputedStyle(completedStatusSlot!).opacity).toBe("0");
+      // The inline status stays visible while hover actions appear (it no longer
+      // fades out) and the row must not shift around it.
+      expect(getComputedStyle(completedDot!).opacity).not.toBe("0");
     });
-    expect(completedStatusSlot?.getBoundingClientRect().left).toBe(completedStatusLeft);
+    expect(completedDot?.getBoundingClientRect().left).toBe(completedStatusLeft);
     await page.getByRole("button", { name: "Done" }).click();
     expect(onMarkThreadRead).toHaveBeenCalledWith(
       unseen.id,

--- a/apps/web/src/components/SidebarActivityView.tsx
+++ b/apps/web/src/components/SidebarActivityView.tsx
@@ -33,7 +33,6 @@ import {
   SIDEBAR_ROW_HOVER_CLASS_NAME,
   SIDEBAR_ROW_LABEL_TEXT_CLASS_NAME,
   SIDEBAR_SECTION_LABEL_CLASS_NAME,
-  sidebarHoverRevealHideClassName,
 } from "../sidebarRowStyles";
 import { resolveThreadPullRequestFallback } from "../hooks/useThreadPullRequests";
 import type { Project, SidebarThreadSummary } from "../types";
@@ -54,6 +53,7 @@ import {
   collectActivityScopeOptions,
   collectUnreadActivityThreads,
   collectVisibleActivityThreadIds,
+  formatActivityRowTime,
   groupActivityThreadsByProject,
   isThreadSettledForActivity,
   resolveActivityScope,
@@ -65,6 +65,7 @@ import {
   type ActivityScopeOption,
   type ActivityScopeSelection,
 } from "./SidebarActivityView.logic";
+import { DEFAULT_TIMESTAMP_FORMAT, type TimestampFormat } from "../appSettings";
 import { SIDEBAR_TRAILING_ICON_CLASS, sidebarGlyphClass } from "./sidebarGlyphs";
 import { SIDEBAR_HOVER_CARD_TRIGGER_PROPS } from "./sidebarHoverCardStyles";
 import {
@@ -107,6 +108,7 @@ function ActivityThreadRow({
   isPinned,
   pr,
   status,
+  rowTime,
   onOpen,
   onSetSettled,
   onTogglePinned,
@@ -123,6 +125,8 @@ function ActivityThreadRow({
   isPinned: boolean;
   pr: OrchestrationThreadPullRequest | null;
   status: ThreadStatusPill | null;
+  /** Pre-computed by the parent so every row in a section shares one clock. */
+  rowTime: string;
   onOpen: () => void;
   onSetSettled: (settled: boolean) => void;
   onTogglePinned: () => void;
@@ -145,10 +149,13 @@ function ActivityThreadRow({
     threadId: thread.id,
   });
   const actionToneClassName = "text-muted-foreground/42";
-  // One trailing slot, top-right, shared by every status: the accent dot for an
-  // unread completion and the running spinner (or state dot) for everything
-  // else — same rule and same glyphs the classic thread/project rows use.
-  const trailingStatus = resolveThreadStatusTrailingIndicator({ status, isActive });
+  // The status glyph lives inline in the second line (next to PR/branch) instead
+  // of the absolute top-right slot, so it stays visible while the hover actions
+  // appear — the classic rows fade it out exactly when it is most needed.
+  const trailingStatus = resolveThreadStatusTrailingIndicator({
+    status,
+    isActive,
+  });
   // Rename/context-menu gestures live on the row wrapper (not the title button) so
   // they also fire over the trailing status and hover-action cluster, which are
   // absolutely positioned siblings of the button.
@@ -180,7 +187,9 @@ function ActivityThreadRow({
             "flex w-full min-w-0 cursor-pointer flex-col gap-1 rounded-lg px-2.5 py-2 text-left select-none",
             SIDEBAR_ROW_FOCUS_CLASS_NAME,
             isActive ? SIDEBAR_ROW_ACTIVE_CLASS_NAME : SIDEBAR_ROW_HOVER_CLASS_NAME,
-            isSettled && "opacity-55 transition-opacity hover:opacity-85",
+            // Pinned rows never dim: dimming means "settled/done" in this feed,
+            // and a pinned-but-settled thread must not read as finished.
+            isSettled && !isPinned && "opacity-55 transition-opacity hover:opacity-85",
           )}
         >
           <span
@@ -222,20 +231,13 @@ function ActivityThreadRow({
                   <span className="max-w-36 truncate">{branch}</span>
                 </span>
               ) : null}
+              {trailingStatus ? <SidebarStatusTrailingGlyph status={trailingStatus} /> : null}
+              <span className="shrink-0 text-[length:var(--app-font-size-ui-sm,11px)] tabular-nums text-muted-foreground/60">
+                {rowTime}
+              </span>
             </span>
           </span>
         </button>
-        {trailingStatus ? (
-          <span
-            data-slot="activity-completion-status"
-            className={cn(
-              "pointer-events-none absolute top-1 right-1 inline-flex size-5 items-center justify-center",
-              sidebarHoverRevealHideClassName("activity-row"),
-            )}
-          >
-            <SidebarStatusTrailingGlyph status={trailingStatus} />
-          </span>
-        ) : null}
         <span
           className="absolute top-1 right-1 inline-flex items-center gap-1 opacity-0 transition-opacity group-hover/activity-row:opacity-100 group-focus-within/activity-row:opacity-100"
           // Double-clicking an action button toggles it twice; it must not also open
@@ -485,22 +487,31 @@ function ActivityFilterMenu({
 function ActivityShowMoreRow({
   canShowMore,
   canShowLess,
+  hiddenCount,
+  pageSize,
   onShowMore,
   onShowLess,
 }: {
   canShowMore: boolean;
   canShowLess: boolean;
+  /** Rows still hidden; drives the "Show N more (M)" label. */
+  hiddenCount: number;
+  pageSize: number;
   onShowMore: () => void;
   onShowLess: () => void;
 }) {
   if (!canShowMore && !canShowLess) return null;
+  const visibleHiddenCount = Math.max(0, hiddenCount);
+  const nextPageCount = Math.min(pageSize, visibleHiddenCount);
+  const moreLabel =
+    nextPageCount > 0 ? `Show ${nextPageCount} more (${visibleHiddenCount})` : "Show more";
   const buttonClassName =
     "h-7 cursor-pointer rounded-lg px-2.5 text-left text-[length:var(--app-font-size-ui,12px)] text-muted-foreground/79 hover:text-foreground";
   return (
     <div className="flex w-full items-center gap-1">
       {canShowMore ? (
         <button type="button" className={cn(buttonClassName, "flex-1")} onClick={onShowMore}>
-          Show more
+          {moreLabel}
         </button>
       ) : null}
       {canShowLess ? (
@@ -538,6 +549,7 @@ export function SidebarActivityView({
   onVisibleThreadIdsChange,
   onCreateChat,
   onAddProject,
+  timestampFormat: timestampFormatProp,
 }: {
   threads: readonly SidebarThreadSummary[];
   projectById: ReadonlyMap<ProjectId, Project>;
@@ -568,7 +580,12 @@ export function SidebarActivityView({
   onCreateChat: () => void;
   /** Same "Add project" action the Projects section header runs. */
   onAddProject: () => void;
+  /** Clock format for row timestamps; defaults to the app locale setting. */
+  timestampFormat?: TimestampFormat;
 }) {
+  // Default resolved in the body, not the destructuring pattern: an
+  // AssignmentPattern in the parameter list makes React Compiler bail out.
+  const timestampFormat = timestampFormatProp ?? DEFAULT_TIMESTAMP_FORMAT;
   const [scopeSelection, setScopeSelection] = useState<ActivityScopeSelection>(null);
   const [groupMode, setGroupMode] = useState<ActivityGroupMode>("time");
   const [pinnedOpen, setPinnedOpen] = useState(true);
@@ -715,6 +732,7 @@ export function SidebarActivityView({
             })
       }
       status={resolveThreadStatus(thread)}
+      rowTime={formatActivityRowTime({ thread, nowMs, timestampFormat })}
       onOpen={() => onOpenThread(thread.id)}
       onSetSettled={(settled) => {
         if (settled) onMarkThreadRead(thread.id, thread.latestTurn?.completedAt ?? undefined);
@@ -815,6 +833,8 @@ export function SidebarActivityView({
               <ActivityShowMoreRow
                 canShowMore={paging.canShowMore}
                 canShowLess={paging.canShowLess}
+                hiddenCount={group.threads.length - paging.previewLimit}
+                pageSize={ACTIVITY_LIST_PAGE_SIZE}
                 onShowMore={() => {
                   setProjectExtraPagesByKey((current) => {
                     const next = new Map(current);
@@ -870,6 +890,8 @@ export function SidebarActivityView({
               <ActivityShowMoreRow
                 canShowMore={earlierPaging.canShowMore}
                 canShowLess={earlierPaging.canShowLess}
+                hiddenCount={dateBuckets.earlier.length - earlierPaging.previewLimit}
+                pageSize={ACTIVITY_LIST_PAGE_SIZE}
                 onShowMore={() => setEarlierExtraPages(earlierPaging.effectiveExtraPages + 1)}
                 onShowLess={() =>
                   setEarlierExtraPages(Math.max(0, earlierPaging.effectiveExtraPages - 1))
@@ -892,6 +914,8 @@ export function SidebarActivityView({
           <ActivityShowMoreRow
             canShowMore={settledPaging.canShowMore}
             canShowLess={settledPaging.canShowLess}
+            hiddenCount={model.settled.length - settledPaging.previewLimit}
+            pageSize={ACTIVITY_LIST_PAGE_SIZE}
             onShowMore={() => setSettledExtraPages(settledPaging.effectiveExtraPages + 1)}
             onShowLess={() =>
               setSettledExtraPages(Math.max(0, settledPaging.effectiveExtraPages - 1))

--- a/apps/web/src/components/SidebarElapsedTimeLabel.tsx
+++ b/apps/web/src/components/SidebarElapsedTimeLabel.tsx
@@ -1,0 +1,39 @@
+// FILE: SidebarElapsedTimeLabel.tsx
+// Purpose: Live "running for" label for sidebar thread rows. Ticks at 1s like the
+// chat "Working for" header (same start timestamp, same formatter) so both agree;
+// the clock only runs while its own row is working, never for idle rows.
+// Exports: SidebarElapsedTimeLabel
+
+import { useNowMs } from "~/hooks/useNowMs";
+import type { SidebarThreadSummary } from "../types";
+import {
+  isThreadActivelyWorking,
+  resolveThreadElapsedMs,
+  resolveUrgentThreadTimeLabel,
+  shouldShowThreadStartingLabel,
+} from "./Sidebar.logic";
+
+export function SidebarElapsedTimeLabel({
+  thread,
+  recencyLabel,
+}: {
+  thread: SidebarThreadSummary;
+  /** Static relative-time fallback once the thread stops running. */
+  recencyLabel: string | null;
+}) {
+  const running = isThreadActivelyWorking(thread) || thread.session?.status === "connecting";
+  const nowMs = useNowMs(running, 1_000);
+  const label = resolveUrgentThreadTimeLabel({
+    elapsedMs: running ? resolveThreadElapsedMs(thread, nowMs) : null,
+    isStarting: shouldShowThreadStartingLabel(thread),
+    recencyLabel,
+  });
+  if (label === null) {
+    return null;
+  }
+  return (
+    <span className="shrink-0 text-muted-foreground/60 tabular-nums" title={label.title}>
+      {label.text}
+    </span>
+  );
+}

--- a/apps/web/src/components/SidebarRowHoverActions.tsx
+++ b/apps/web/src/components/SidebarRowHoverActions.tsx
@@ -8,17 +8,22 @@ import { cn } from "~/lib/utils";
 
 export function SidebarRowHoverActions({
   threadId,
+  testId,
+  className,
   children,
 }: {
   threadId: string;
+  testId?: string;
+  className?: string;
   children: ReactNode;
 }) {
   return (
     <div
-      data-testid={`thread-hover-actions-${threadId}`}
+      data-testid={testId ?? `thread-hover-actions-${threadId}`}
       className={cn(
         "pointer-events-none absolute inset-y-0 right-0 my-auto inline-flex items-center",
         "opacity-0 transition-opacity group-hover/thread-row:pointer-events-auto group-hover/thread-row:opacity-100 group-focus-within/thread-row:pointer-events-auto group-focus-within/thread-row:opacity-100",
+        className,
       )}
     >
       {children}


### PR DESCRIPTION
Scoped sidebar visibility/organization pass (normal + activity views).

- Normal view: status glyph no longer fades under hover (actions overlay with solid bg, no title reflow), Show-more labels with counts, paging keyed by projectId with legacy cwd fallback, short recency on urgent rows, live per-row elapsed ticker reusing the chat Working-for clock (no 0s flash on completion).
- Activity view: inline row timestamps, inline status glyph, no-dim pins, counted Show-more.
- Hover-actions primitive gains optional testId/className (backward compatible).

Verified: web typecheck clean, 186 unit + 8 browser sidebar tests green, fmt/lint clean.