### PR TITLE
fix(server): preserve Unicode boundaries in handoff bootstrap

### DIFF
--- a/apps/server/src/agentGateway/threadSummary.ts
+++ b/apps/server/src/agentGateway/threadSummary.ts
@@ -13,6 +13,7 @@ import type {
   OrchestrationThread,
   OrchestrationThreadShell,
 } from "@synara/contracts";
+import { splitsSurrogatePair, unicodeSafeEndOffset } from "@synara/shared/text";
 
 export type AgentThreadStatus =
   | "working"
@@ -219,24 +220,6 @@ function readMessageCoordinates(input: {
     messageId: input.messageId,
     messageVersion: input.messageVersion,
   };
-}
-
-function splitsSurrogatePair(text: string, offsetChars: number): boolean {
-  if (offsetChars <= 0 || offsetChars >= text.length) return false;
-  const previousCodeUnit = text.charCodeAt(offsetChars - 1);
-  const nextCodeUnit = text.charCodeAt(offsetChars);
-  return (
-    previousCodeUnit >= 0xd800 &&
-    previousCodeUnit <= 0xdbff &&
-    nextCodeUnit >= 0xdc00 &&
-    nextCodeUnit <= 0xdfff
-  );
-}
-
-function unicodeSafeEndOffset(text: string, requestedEndOffsetChars: number): number {
-  return splitsSurrogatePair(text, requestedEndOffsetChars)
-    ? requestedEndOffsetChars - 1
-    : requestedEndOffsetChars;
 }
 
 function paginateSingleMessage(input: {

--- a/apps/server/src/orchestration/handoff.test.ts
+++ b/apps/server/src/orchestration/handoff.test.ts
@@ -3,10 +3,10 @@
 // Layer: Orchestration mapping tests
 // Depends on: handoff.
 
-import { MessageId, type OrchestrationMessage } from "@synara/contracts";
+import { MessageId, type OrchestrationMessage, ThreadId } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
-import { buildPriorTranscriptBootstrapText } from "./handoff.ts";
+import { buildHandoffBootstrapText, buildPriorTranscriptBootstrapText } from "./handoff.ts";
 
 const message = (
   index: number,
@@ -28,6 +28,47 @@ const thread = (messages: ReadonlyArray<OrchestrationMessage>) => ({
   branch: null,
   worktreePath: null,
   messages,
+});
+
+function hasUnpairedSurrogate(text: string): boolean {
+  for (let index = 0; index < text.length; index += 1) {
+    const codeUnit = text.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const nextCodeUnit = text.charCodeAt(index + 1);
+      if (!(nextCodeUnit >= 0xdc00 && nextCodeUnit <= 0xdfff)) return true;
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+describe("buildHandoffBootstrapText", () => {
+  it("does not split a surrogate pair at the earlier-message summary boundary", () => {
+    const boundaryMessage = {
+      ...message(0, "assistant", `${"a".repeat(316)}📌 reminder`),
+      source: "handoff-import" as const,
+    };
+    const recentMessages = Array.from({ length: 6 }, (_, index) => ({
+      ...message(index + 1, index % 2 === 0 ? "user" : "assistant", `recent-${index}`),
+      source: "handoff-import" as const,
+    }));
+    const text = buildHandoffBootstrapText({
+      ...thread([boundaryMessage, ...recentMessages]),
+      handoff: {
+        sourceThreadId: ThreadId.makeUnsafe("source-thread"),
+        sourceProvider: "claudeAgent",
+        importedAt: "2026-07-08T00:00:00.000Z",
+        bootstrapStatus: "pending",
+      },
+    });
+
+    expect(text).not.toBeNull();
+    expect(text!.length).toBeLessThanOrEqual(32_000);
+    expect(text).toContain(`${"a".repeat(316)}...`);
+    expect(hasUnpairedSurrogate(text!)).toBe(false);
+  });
 });
 
 describe("buildPriorTranscriptBootstrapText", () => {

--- a/apps/server/src/orchestration/handoff.ts
+++ b/apps/server/src/orchestration/handoff.ts
@@ -1,4 +1,5 @@
 import type { OrchestrationMessage, OrchestrationThread } from "@synara/contracts";
+import { unicodeSafeEndOffset } from "@synara/shared/text";
 
 const RECENT_MESSAGE_COUNT = 6;
 const EARLIER_MESSAGE_CHAR_LIMIT = 320;
@@ -18,7 +19,9 @@ function truncateText(value: string, maxChars: number): string {
   if (value.length <= maxChars) {
     return value;
   }
-  return `${value.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
+  const requestedEndOffset = Math.max(0, maxChars - 3);
+  const endOffset = unicodeSafeEndOffset(value, requestedEndOffset);
+  return `${value.slice(0, endOffset).trimEnd()}...`;
 }
 
 function roleLabel(message: Pick<OrchestrationMessage, "role">): "User" | "Assistant" {

--- a/packages/shared/src/text.test.ts
+++ b/packages/shared/src/text.test.ts
@@ -4,7 +4,25 @@
 // Depends on: Vitest and text helpers
 
 import { describe, expect, it } from "vitest";
-import { pluralize } from "./text";
+import { pluralize, splitsSurrogatePair, unicodeSafeEndOffset } from "./text";
+
+describe("UTF-16 boundaries", () => {
+  const text = "a📌b";
+
+  it("detects only offsets inside a surrogate pair", () => {
+    expect(splitsSurrogatePair(text, 1)).toBe(false);
+    expect(splitsSurrogatePair(text, 2)).toBe(true);
+    expect(splitsSurrogatePair(text, 3)).toBe(false);
+  });
+
+  it("moves an end offset back only when it splits a surrogate pair", () => {
+    expect(unicodeSafeEndOffset(text, 0)).toBe(0);
+    expect(unicodeSafeEndOffset(text, 1)).toBe(1);
+    expect(unicodeSafeEndOffset(text, 2)).toBe(1);
+    expect(unicodeSafeEndOffset(text, 3)).toBe(3);
+    expect(unicodeSafeEndOffset(text, text.length)).toBe(text.length);
+  });
+});
 
 describe("pluralize", () => {
   it("returns the singular form for a count of one", () => {

--- a/packages/shared/src/text.ts
+++ b/packages/shared/src/text.ts
@@ -2,7 +2,30 @@
 // Purpose: Small, dependency-free text helpers shared across server and web so
 // repeated string semantics (count pluralization, etc.) live in one place.
 // Layer: Shared runtime utility
-// Exports: pluralize, nonEmptyTrimmed
+// Exports: pluralize, nonEmptyTrimmed, splitsSurrogatePair, unicodeSafeEndOffset
+
+// Reports whether a UTF-16 offset falls between the high and low surrogate of
+// one Unicode code point. JavaScript string lengths and slice offsets count
+// UTF-16 code units, so bounded text must account for this boundary explicitly.
+export function splitsSurrogatePair(text: string, offsetChars: number): boolean {
+  if (offsetChars <= 0 || offsetChars >= text.length) return false;
+  const previousCodeUnit = text.charCodeAt(offsetChars - 1);
+  const nextCodeUnit = text.charCodeAt(offsetChars);
+  return (
+    previousCodeUnit >= 0xd800 &&
+    previousCodeUnit <= 0xdbff &&
+    nextCodeUnit >= 0xdc00 &&
+    nextCodeUnit <= 0xdfff
+  );
+}
+
+// Keeps a prefix within its existing UTF-16 budget without leaving an
+// unpaired high surrogate at the end. At most one code unit is removed.
+export function unicodeSafeEndOffset(text: string, requestedEndOffsetChars: number): number {
+  return splitsSurrogatePair(text, requestedEndOffsetChars)
+    ? requestedEndOffsetChars - 1
+    : requestedEndOffsetChars;
+}
 
 // Normalizes an optional string to "present and meaningful" or absent.
 //


### PR DESCRIPTION
## What Changed

- Added shared UTF-16 surrogate-boundary helpers in `@synara/shared/text`.
- Made handoff/bootstrap prefix truncation step back by one code unit when its requested end offset would split a surrogate pair.
- Reused the shared helpers in agent-gateway single-message pagination instead of keeping a duplicate implementation.
- Added focused helper tests and a handoff regression test with `📌` crossing the 320-code-unit earlier-message boundary.

## Why

Fixes #932.

Raw JavaScript slicing can leave an unpaired high surrogate when a supplementary Unicode character crosses the handoff summary boundary. `JSON.stringify` then emits a lone `\ud83d` escape, which Codex app-server rejects without replying to `turn/start`; Synara eventually surfaces only a timeout.

The fix preserves the existing UTF-16 budgets and truncation marker. It changes output only at a split surrogate boundary, where it retains the longest well-formed prefix within the existing budget.

## Verification

- `git diff --check`
- Imported the shared helper directly with Node and confirmed the observed boundary moves from offset 317 to 316, produces a 319-code-unit result, and leaves no unpaired surrogate.
- Sent source-generated failing and corrected JSON-RPC frames to Codex app-server: the lone surrogate reproduces `unexpected end of hex escape`; the complete pair parses normally.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes
- [x] No animation or interaction changes
