### PR TITLE
feat(web): "Add to chat" for selections in rendered Markdown preview

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -33,6 +33,7 @@ import {
   appendComposerPromptText,
   buildDiffSelectionReference,
   buildWhyChangedPrompt,
+  normalizeSelectionSnippet,
 } from "../lib/chatReferences";
 import { resolveDiffEnvironmentState } from "../lib/threadEnvironment";
 import { disclosureWidthClassName } from "../lib/disclosureMotion";
@@ -914,12 +915,10 @@ export default function DiffPanel({
       return null;
     }
     const filePath = anchorRow.getAttribute("data-diff-file-path") ?? "";
-    const text = selection
-      .toString()
-      .replace(/\r\n/g, "\n")
-      .replace(/^\n+|\n+$/g, "")
-      .trim();
-    if (filePath.length === 0 || text.length === 0) {
+    // Read the text from the selection rather than its range: ranges are
+    // retargeted at the shadow host, so `range.toString()` would be empty.
+    const text = normalizeSelectionSnippet(selection.toString());
+    if (filePath.length === 0 || text === null) {
       return null;
     }
     return { filePath, text };

--- a/apps/web/src/components/WorkspaceFilePreview.selection.browser.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.selection.browser.tsx
@@ -1,0 +1,145 @@
+// FILE: WorkspaceFilePreview.selection.browser.tsx
+// Purpose: Browser regressions for the highlight -> "Add to chat" flow in the
+//          rendered-markdown preview (snippet references) and source view.
+// Layer: Focused component integration tests
+
+import "../index.css";
+
+import type { NativeApi, ProjectReadFileResult } from "@synara/contracts";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { page } from "vitest/browser";
+import { afterEach, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import type { ChatFileReference } from "../lib/chatReferences";
+import { WorkspaceFilePreview } from "./WorkspaceFilePreview";
+
+const WORKSPACE_ROOT = "/Users/tester/project";
+const MARKDOWN_PATH = "docs/handoff.md";
+const MARKDOWN_CONTENTS = "# Handoff\n\n- Ship the **selection** toolbar\n- Then celebrate\n";
+
+function installNativeApi(api: NativeApi): () => void {
+  const previousDescriptor = Object.getOwnPropertyDescriptor(window, "nativeApi");
+  Object.defineProperty(window, "nativeApi", {
+    configurable: true,
+    value: api,
+  });
+  return () => {
+    if (previousDescriptor) {
+      Object.defineProperty(window, "nativeApi", previousDescriptor);
+    } else {
+      Reflect.deleteProperty(window, "nativeApi");
+    }
+  };
+}
+
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function loadedMarkdown(): ProjectReadFileResult {
+  return {
+    relativePath: MARKDOWN_PATH,
+    contents: MARKDOWN_CONTENTS,
+    truncated: false,
+    version: `sha256:${"1".repeat(64)}`,
+    encoding: "utf8",
+    lineEnding: "lf",
+  };
+}
+
+function selectNodeContentsAndRelease(node: Node): void {
+  const selection = window.getSelection();
+  if (!selection) {
+    throw new Error("window.getSelection() is unavailable");
+  }
+  const range = document.createRange();
+  range.selectNodeContents(node);
+  selection.removeAllRanges();
+  selection.addRange(range);
+  const rect = range.getBoundingClientRect();
+  node.dispatchEvent(
+    new MouseEvent("mouseup", {
+      bubbles: true,
+      cancelable: true,
+      clientX: rect.right,
+      clientY: rect.bottom,
+    }),
+  );
+}
+
+afterEach(() => {
+  window.getSelection()?.removeAllRanges();
+  document.body.innerHTML = "";
+});
+
+it("offers Add to chat for a rendered-markdown selection and references the snippet", async () => {
+  const readFile = vi.fn().mockResolvedValue(loadedMarkdown());
+  const restoreNativeApi = installNativeApi({ projects: { readFile } } as unknown as NativeApi);
+  const onReferenceInChat = vi.fn<(reference: ChatFileReference) => void>();
+
+  try {
+    await render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <WorkspaceFilePreview
+          workspaceRoot={WORKSPACE_ROOT}
+          filePath={MARKDOWN_PATH}
+          markdownPreviewDefault
+          onReferenceInChat={onReferenceInChat}
+        />
+      </QueryClientProvider>,
+    );
+
+    await expect.element(page.getByRole("heading", { name: "Handoff" })).toBeVisible();
+    const list = document.querySelector(".editor-markdown-preview ul");
+    if (!list) {
+      throw new Error("rendered markdown list not found");
+    }
+
+    selectNodeContentsAndRelease(list);
+
+    const addToChat = page.getByRole("button", { name: "Add to chat" });
+    await expect.element(addToChat).toBeVisible();
+    await addToChat.click();
+
+    expect(onReferenceInChat).toHaveBeenCalledTimes(1);
+    expect(onReferenceInChat).toHaveBeenCalledWith({
+      path: MARKDOWN_PATH,
+      snippet: "Ship the selection toolbar\nThen celebrate",
+    });
+    await vi.waitFor(() => expect(document.querySelector('[aria-label="Add to chat"]')).toBeNull());
+  } finally {
+    restoreNativeApi();
+  }
+});
+
+it("does not offer Add to chat in the markdown preview without a chat target", async () => {
+  const readFile = vi.fn().mockResolvedValue(loadedMarkdown());
+  const restoreNativeApi = installNativeApi({ projects: { readFile } } as unknown as NativeApi);
+
+  try {
+    await render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <WorkspaceFilePreview
+          workspaceRoot={WORKSPACE_ROOT}
+          filePath={MARKDOWN_PATH}
+          markdownPreviewDefault
+        />
+      </QueryClientProvider>,
+    );
+
+    await expect.element(page.getByRole("heading", { name: "Handoff" })).toBeVisible();
+    const list = document.querySelector(".editor-markdown-preview ul");
+    if (!list) {
+      throw new Error("rendered markdown list not found");
+    }
+
+    selectNodeContentsAndRelease(list);
+
+    // Give the deferred selection read a frame to settle before asserting.
+    await new Promise((resolve) => window.requestAnimationFrame(() => resolve(undefined)));
+    expect(document.querySelector('[aria-label="Add to chat"]')).toBeNull();
+  } finally {
+    restoreNativeApi();
+  }
+});

--- a/apps/web/src/components/WorkspaceFilePreview.selection.browser.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.selection.browser.tsx
@@ -73,7 +73,7 @@ afterEach(() => {
   document.body.innerHTML = "";
 });
 
-it("offers Add to chat for a rendered-markdown selection and references the snippet", async () => {
+it("offers Add to chat for an editable rendered-markdown selection", async () => {
   const readFile = vi.fn().mockResolvedValue(loadedMarkdown());
   const restoreNativeApi = installNativeApi({ projects: { readFile } } as unknown as NativeApi);
   const onReferenceInChat = vi.fn<(reference: ChatFileReference) => void>();
@@ -85,6 +85,7 @@ it("offers Add to chat for a rendered-markdown selection and references the snip
           workspaceRoot={WORKSPACE_ROOT}
           filePath={MARKDOWN_PATH}
           markdownPreviewDefault
+          editable
           onReferenceInChat={onReferenceInChat}
         />
       </QueryClientProvider>,

--- a/apps/web/src/components/WorkspaceFilePreview.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.tsx
@@ -638,7 +638,7 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
     }
   };
   const previewSelectionAction = useCodeSelectionAction({
-    enabled: Boolean(onReferenceInChat && filePath) && !editableDocument,
+    enabled: Boolean(onReferenceInChat && filePath) && (showMarkdownPreview || !editableDocument),
     readSelection: readPreviewSelection,
     onCommit: commitPreviewSelection,
   });

--- a/apps/web/src/components/WorkspaceFilePreview.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.tsx
@@ -36,7 +36,11 @@ import {
 
 import { basenameOfPath } from "~/file-icons";
 import { useTheme } from "~/hooks/useTheme";
-import { getSelectionWithin, type ChatFileReference } from "~/lib/chatReferences";
+import {
+  getSelectionSnippetWithin,
+  getSelectionWithin,
+  type ChatFileReference,
+} from "~/lib/chatReferences";
 import { resolveDiffThemeName, type DiffThemeName } from "~/lib/diffRendering";
 import { formatFileCommentRange, type FileCommentSelection } from "~/lib/fileComments";
 import { showFileReferenceContextMenu } from "~/lib/fileReferenceContextMenu";
@@ -620,23 +624,21 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
       });
   };
   // Highlight -> floating "Add to chat" -> reference that points at exactly what
-  // was selected, mirroring the transcript flow. This is offered only in the
-  // source view, where the DOM mirrors the file's lines/columns 1:1 so a
-  // selection resolves to an exact `line 12:5-12` span. The rendered-markdown
-  // view restructures the source (paragraphs, lists, headings), so a selection
-  // there cannot map back to an exact range — referencing a single word on a
-  // 3000-word line would pull in the whole line. The rendered view therefore
-  // stays read-only for references (browsing + task-list toggles only); use the
-  // Source toggle in the header to get a precise selection reference.
+  // was selected, mirroring the transcript flow. In the source view the DOM
+  // mirrors the file's lines/columns 1:1, so a selection resolves to an exact
+  // `line 12:5-12` span. The rendered-markdown view restructures the source
+  // (paragraphs, lists, headings), so a selection there cannot map back to a
+  // line range; it references the selected text verbatim instead, the same
+  // snippet shape the diff view uses.
   const readPreviewSelection = (container: HTMLElement): Omit<ChatFileReference, "path"> | null =>
-    showMarkdownPreview ? null : getSelectionWithin(container);
+    showMarkdownPreview ? getSelectionSnippetWithin(container) : getSelectionWithin(container);
   const commitPreviewSelection = (selection: Omit<ChatFileReference, "path">) => {
     if (filePath) {
       onReferenceInChat?.({ path: filePath, ...selection });
     }
   };
   const previewSelectionAction = useCodeSelectionAction({
-    enabled: Boolean(onReferenceInChat && filePath) && !showMarkdownPreview && !editableDocument,
+    enabled: Boolean(onReferenceInChat && filePath) && !editableDocument,
     readSelection: readPreviewSelection,
     onCommit: commitPreviewSelection,
   });
@@ -657,10 +659,8 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
       onCommentInChat?.({ path: filePath, ...selection });
     }
   };
-  // Right-click references the selected line range in the source view,
-  // otherwise the whole file. The rendered-markdown view yields no selection
-  // (readPreviewSelection returns null there), so it always falls back to the
-  // whole-file reference.
+  // Right-click references the selection (line range in the source view,
+  // quoted snippet in the rendered-markdown view), otherwise the whole file.
   const handleContentsContextMenu = (event: ReactMouseEvent<HTMLDivElement>) => {
     if (!filePath) {
       return;

--- a/apps/web/src/lib/chatReferences.browser.ts
+++ b/apps/web/src/lib/chatReferences.browser.ts
@@ -1,0 +1,95 @@
+// FILE: chatReferences.browser.ts
+// Purpose: Browser regressions for DOM-backed selection readers (line spans and
+//          verbatim snippets scoped to a container).
+// Layer: Web UI utility tests
+
+import { afterEach, expect, it } from "vitest";
+
+import { getSelectionSnippetWithin, getSelectionWithin } from "./chatReferences";
+
+function selectNodeContents(node: Node): void {
+  const selection = window.getSelection();
+  if (!selection) {
+    throw new Error("window.getSelection() is unavailable");
+  }
+  const range = document.createRange();
+  range.selectNodeContents(node);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+afterEach(() => {
+  window.getSelection()?.removeAllRanges();
+  document.body.innerHTML = "";
+});
+
+it("getSelectionSnippetWithin quotes the selected rendered text verbatim", () => {
+  document.body.innerHTML =
+    "<article><h1>Title</h1><ul><li>first item</li><li>second item</li></ul></article>";
+  const container = document.querySelector("article");
+  if (!(container instanceof HTMLElement)) {
+    throw new Error("missing container");
+  }
+  const list = container.querySelector("ul");
+  if (!list) {
+    throw new Error("missing list");
+  }
+
+  selectNodeContents(list);
+
+  expect(getSelectionSnippetWithin(container)).toEqual({ snippet: "first item\nsecond item" });
+});
+
+it("getSelectionSnippetWithin ignores selections outside the container or collapsed", () => {
+  document.body.innerHTML = "<article><p>inside</p></article><p id='outside'>outside</p>";
+  const container = document.querySelector("article");
+  const outside = document.querySelector("#outside");
+  if (!(container instanceof HTMLElement) || !outside) {
+    throw new Error("missing fixtures");
+  }
+
+  selectNodeContents(outside);
+  expect(getSelectionSnippetWithin(container)).toBeNull();
+
+  window.getSelection()?.removeAllRanges();
+  expect(getSelectionSnippetWithin(container)).toBeNull();
+});
+
+it("getSelectionSnippetWithin treats whitespace-only selections as no selection", () => {
+  document.body.innerHTML = "<article><p>   </p></article>";
+  const container = document.querySelector("article");
+  const paragraph = container?.querySelector("p");
+  if (!(container instanceof HTMLElement) || !paragraph) {
+    throw new Error("missing fixtures");
+  }
+
+  selectNodeContents(paragraph);
+
+  expect(getSelectionSnippetWithin(container)).toBeNull();
+});
+
+it("getSelectionWithin resolves the line and column span of a source selection", () => {
+  document.body.innerHTML = "<pre>alpha\nbeta gamma\ndelta\n</pre>";
+  const container = document.querySelector("pre");
+  const text = container?.firstChild;
+  if (!(container instanceof HTMLElement) || !(text instanceof Text)) {
+    throw new Error("missing fixtures");
+  }
+  const selection = window.getSelection();
+  if (!selection) {
+    throw new Error("window.getSelection() is unavailable");
+  }
+  const range = document.createRange();
+  // "gamma" on line 2 (columns 6-10).
+  range.setStart(text, "alpha\nbeta ".length);
+  range.setEnd(text, "alpha\nbeta gamma".length);
+  selection.removeAllRanges();
+  selection.addRange(range);
+
+  expect(getSelectionWithin(container)).toEqual({
+    startLine: 2,
+    endLine: 2,
+    startColumn: 6,
+    endColumn: 10,
+  });
+});

--- a/apps/web/src/lib/chatReferences.test.ts
+++ b/apps/web/src/lib/chatReferences.test.ts
@@ -11,6 +11,7 @@ import {
   computeSelectionColumns,
   computeSelectionLineRange,
   formatChatFileReference,
+  normalizeSelectionSnippet,
 } from "./chatReferences";
 
 describe("formatChatFileReference", () => {
@@ -134,6 +135,25 @@ describe("buildWhyLinesPrompt", () => {
     expect(prompt).toContain("lines 3-9");
     expect(prompt).toContain("@src/a.ts");
     expect(prompt).toContain("git blame");
+  });
+});
+
+describe("normalizeSelectionSnippet", () => {
+  it("returns the text unchanged when it is already clean", () => {
+    expect(normalizeSelectionSnippet("const a = 1;")).toBe("const a = 1;");
+  });
+
+  it("normalizes CRLF and strips blank edge lines and surrounding whitespace", () => {
+    expect(normalizeSelectionSnippet("\r\n  first\r\nsecond  \r\n\r\n")).toBe("first\nsecond");
+  });
+
+  it("keeps interior blank lines", () => {
+    expect(normalizeSelectionSnippet("first\n\nsecond")).toBe("first\n\nsecond");
+  });
+
+  it("returns null for empty or whitespace-only selections", () => {
+    expect(normalizeSelectionSnippet("")).toBeNull();
+    expect(normalizeSelectionSnippet(" \n\t\r\n ")).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/chatReferences.ts
+++ b/apps/web/src/lib/chatReferences.ts
@@ -183,11 +183,24 @@ export interface SelectionWithin {
   endColumn: number;
 }
 
+// Verbatim selection text ready to be quoted as a snippet reference: CRLF
+// collapsed to LF, blank edge lines and surrounding whitespace removed. Returns
+// null when nothing remains, so callers treat whitespace-only selections as
+// "no selection". Shared by every surface that references a selection by its
+// text rather than by source lines (diff rows, rendered markdown).
+export function normalizeSelectionSnippet(text: string): string | null {
+  const normalized = text
+    .replace(/\r\n/g, "\n")
+    .replace(/^\n+|\n+$/g, "")
+    .trim();
+  return normalized.length === 0 ? null : normalized;
+}
+
 // The current window selection scoped to `container`: null when collapsed,
 // reaching outside the container, or whitespace-only.
 function getSelectionRangeWithin(
   container: HTMLElement,
-): { range: Range; selectedText: string } | null {
+): { selection: Selection; range: Range; selectedText: string } | null {
   const selection = window.getSelection();
   if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
     return null;
@@ -200,7 +213,7 @@ function getSelectionRangeWithin(
   if (selectedText.trim().length === 0) {
     return null;
   }
-  return { range, selectedText };
+  return { selection, range, selectedText };
 }
 
 // Resolve the 1-based line+column span of the current selection inside
@@ -220,4 +233,20 @@ export function getSelectionWithin(container: HTMLElement): SelectionWithin | nu
     ...computeSelectionLineRange(prefixText, scoped.selectedText),
     ...computeSelectionColumns(prefixText, scoped.selectedText),
   };
+}
+
+// Snippet-only reference for the current selection inside `container`, for
+// surfaces whose DOM does not mirror the source lines 1:1 (rendered markdown):
+// the quoted text itself is the reference. Returns null when there is no
+// actionable selection.
+export function getSelectionSnippetWithin(container: HTMLElement): { snippet: string } | null {
+  const scoped = getSelectionRangeWithin(container);
+  if (!scoped) {
+    return null;
+  }
+  // `Selection.toString()` yields the text as laid out (a line break between
+  // block elements such as list items); `Range.toString()` would concatenate
+  // their text content with no separator.
+  const snippet = normalizeSelectionSnippet(scoped.selection.toString());
+  return snippet === null ? null : { snippet };
 }


### PR DESCRIPTION
## Summary

Selecting text in the right-dock Markdown preview (`.md` / `.mdx` / `.markdown`) now shows the floating **Add to chat** toolbar, matching the behavior of the source view, transcript, and diff view.

Rendered Markdown restructures the source (paragraphs, lists, headings), so a selection there cannot map back to an exact line/column span. Instead the reference quotes the selected text verbatim as a fenced snippet (`@docs/notes.md` followed by a code block), which `ChatFileReference` and `formatChatFileReference` already support and which `DiffPanel` already uses.

## Changes

- **`apps/web/src/lib/chatReferences.ts`**: new shared helpers
  - `normalizeSelectionSnippet(text)`: CRLF → LF, strip blank edge lines and surrounding whitespace, `null` when empty.
  - `getSelectionSnippetWithin(container)`: snippet-only reference for the current selection scoped to a container. Uses `Selection.toString()` rather than `Range.toString()` so block boundaries (list items, paragraphs) become line breaks instead of being concatenated.
- **`apps/web/src/components/DiffPanel.tsx`**: `readDiffSelection` reuses `normalizeSelectionSnippet` instead of its inline copy of the same normalization (no behavior change).
- **`apps/web/src/components/WorkspaceFilePreview.tsx`**: `useCodeSelectionAction` stays enabled in Markdown preview mode; `readPreviewSelection` uses `getSelectionWithin` in the source view and falls back to `getSelectionSnippetWithin` in the rendered view. The right-click "Reference selection in chat" menu item picks up the same snippet selection automatically. Toolbar rendering (`TranscriptSelectionAction`) is unchanged.

Task-list checkbox toggles and link clicks are unaffected: the hook already ignores collapsed selections, so single clicks never surface the toolbar.

## Tests

- `chatReferences.test.ts`: unit tests for `normalizeSelectionSnippet`.
- `chatReferences.browser.ts` (new): browser tests for `getSelectionSnippetWithin` (block boundaries, outside-container, collapsed, whitespace-only) and `getSelectionWithin` line/column resolution.
- `WorkspaceFilePreview.selection.browser.tsx` (new): end-to-end test that selecting rendered Markdown shows **Add to chat** and commits `{ path, snippet }`, plus a no-chat-target negative case.

## Verification

- `bun fmt`, `bun lint`, `bun typecheck`: pass
- `bun run test` (apps/web `src/lib` + `DiffPanel`): 125 files, 1113 tests pass
- `bun run test:browser` for `WorkspaceFilePreview*`, `ChatMarkdown.fileContextMenu`, `chatReferences.browser`: 6 files, 22 tests pass

Closes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only composer reference behavior with shared selection helpers and regression tests; no auth, persistence, or API contract changes.
> 
> **Overview**
> Rendered Markdown in the workspace file preview now supports the same highlight → **Add to chat** flow as source view, transcript, and diff. Because the preview DOM does not map 1:1 to file lines, selections there become **verbatim snippet** references (`{ path, snippet }`) instead of line/column spans—aligned with how diff selections are quoted.
> 
> Shared helpers in `chatReferences` add **`normalizeSelectionSnippet`** (CRLF/trim/empty handling) and **`getSelectionSnippetWithin`**, which reads text via **`Selection.toString()`** so block elements (e.g. list items) keep line breaks. **`DiffPanel`** reuses the normalizer instead of duplicating it. **`WorkspaceFilePreview`** enables the selection toolbar in markdown preview (including when editable) and uses snippet selection for context-menu references too.
> 
> Browser and unit tests cover the new selection readers and the preview **Add to chat** path (with and without `onReferenceInChat`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6e1be301a2f48eb745d30fe48c4b0a93de7000c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->