### PR TITLE
fix(web): restore the last-used model and options for new chats

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -49,6 +49,7 @@ import { isMacNavigatorPlatform } from "../lib/utils";
 import { readNativeApi } from "../nativeApi";
 import { resetHomeChatProjectPrewarmStateForTests } from "../lib/chatProjects";
 import { resetStudioProjectPrewarmStateForTests } from "../lib/studioProjects";
+import { hasReconciledServerProviderStatuses } from "../lib/serverReactQuery";
 import { getRouter } from "../router";
 import { useSplitViewStore } from "../splitViewStore";
 import { useSpacesUiStore } from "../spacesUiStore";
@@ -113,6 +114,7 @@ interface WsRequestEnvelope {
 interface TestFixture {
   snapshot: OrchestrationReadModel;
   serverConfig: ServerConfig;
+  providerStatusesSnapshot: ServerConfig["providers"] | null;
   welcome: WsWelcomePayload;
   gitBranchByCwd: Record<string, string>;
 }
@@ -495,6 +497,7 @@ function buildFixture(snapshot: OrchestrationReadModel): TestFixture {
   return {
     snapshot,
     serverConfig: createBaseServerConfig(),
+    providerStatusesSnapshot: null,
     gitBranchByCwd: {},
     welcome: {
       cwd: "/repo/project",
@@ -1422,8 +1425,15 @@ const worker = setupWorker(
         });
         return;
       }
+      if (method === WS_METHODS.subscribeServerProviderStatuses) {
+        if (fixture.providerStatusesSnapshot) {
+          sendEffectRpcChunk(client, parsed.request.id, {
+            providers: fixture.providerStatusesSnapshot,
+          });
+        }
+        return;
+      }
       if (
-        method === WS_METHODS.subscribeServerProviderStatuses ||
         method === WS_METHODS.subscribeServerSettings ||
         method === WS_METHODS.subscribeTerminalEvents ||
         method === WS_METHODS.subscribeOrchestrationDomainEvents ||
@@ -7342,23 +7352,30 @@ describe("ChatView timeline estimator parity (full app)", () => {
         targetText: "sticky claude model test",
       }),
       configureFixture: (nextFixture) => {
+        const providers: ServerConfig["providers"] = [
+          ...nextFixture.serverConfig.providers,
+          {
+            provider: "claudeAgent",
+            status: "ready",
+            available: true,
+            authStatus: "authenticated",
+            checkedAt: NOW_ISO,
+          },
+        ];
         nextFixture.serverConfig = {
           ...nextFixture.serverConfig,
-          providers: [
-            ...nextFixture.serverConfig.providers,
-            {
-              provider: "claudeAgent",
-              status: "ready",
-              available: true,
-              authStatus: "authenticated",
-              checkedAt: NOW_ISO,
-            },
-          ],
+          providers,
         };
+        nextFixture.providerStatusesSnapshot = providers;
       },
     });
 
     try {
+      await vi.waitFor(() => {
+        expect(
+          hasReconciledServerProviderStatuses(mounted.router.options.context.queryClient),
+        ).toBe(true);
+      });
       const newThreadButton = page.getByTestId("new-thread-button");
       await expect.element(newThreadButton).toBeInTheDocument();
 
@@ -7411,23 +7428,30 @@ describe("ChatView timeline estimator parity (full app)", () => {
         targetText: "unavailable sticky claude test",
       }),
       configureFixture: (nextFixture) => {
+        const providers: ServerConfig["providers"] = [
+          ...nextFixture.serverConfig.providers,
+          {
+            provider: "claudeAgent",
+            status: "warning",
+            available: true,
+            authStatus: "unauthenticated",
+            checkedAt: NOW_ISO,
+          },
+        ];
         nextFixture.serverConfig = {
           ...nextFixture.serverConfig,
-          providers: [
-            ...nextFixture.serverConfig.providers,
-            {
-              provider: "claudeAgent",
-              status: "warning",
-              available: true,
-              authStatus: "unauthenticated",
-              checkedAt: NOW_ISO,
-            },
-          ],
+          providers,
         };
+        nextFixture.providerStatusesSnapshot = providers;
       },
     });
 
     try {
+      await vi.waitFor(() => {
+        expect(
+          hasReconciledServerProviderStatuses(mounted.router.options.context.queryClient),
+        ).toBe(true);
+      });
       const newThreadButton = page.getByTestId("new-thread-button");
       await expect.element(newThreadButton).toBeInTheDocument();
 

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -6788,7 +6788,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
-  it("applies the project model over sticky codex settings on a new thread", async () => {
+  it("restores the sticky codex model on a new thread", async () => {
     useComposerDraftStore.setState({
       stickyModelSelectionByProvider: {
         codex: {
@@ -6828,7 +6828,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
         modelSelectionByProvider: {
           codex: {
             provider: "codex",
-            model: "gpt-5",
+            model: "gpt-5.3-codex",
           },
         },
         activeProvider: "codex",
@@ -6838,7 +6838,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
-  it("does not inherit sticky codex options onto a fresh project default", async () => {
+  it("restores sticky codex options on a new thread", async () => {
     useComposerDraftStore.setState({
       stickyModelSelectionByProvider: {
         codex: {
@@ -6878,17 +6878,15 @@ describe("ChatView timeline estimator parity (full app)", () => {
         modelSelectionByProvider: {
           codex: {
             provider: "codex",
-            model: "gpt-5",
+            model: "gpt-5.3-codex",
+            options: {
+              reasoningEffort: "medium",
+              fastMode: true,
+            },
           },
         },
         activeProvider: "codex",
       });
-      // The fresh project default must not inherit the sticky codex fastMode or
-      // reasoningEffort options through same-provider option preservation.
-      expect(
-        useComposerDraftStore.getState().draftsByThreadId[newThreadId]?.modelSelectionByProvider
-          .codex,
-      ).not.toHaveProperty("options");
     } finally {
       await mounted.cleanup();
     }
@@ -7322,7 +7320,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
-  it("prefers the project model over a sticky claude model on fresh chat", async () => {
+  it("restores a usable sticky claude model on fresh chat", async () => {
     useComposerDraftStore.setState({
       stickyModelSelectionByProvider: {
         claudeAgent: {
@@ -7343,6 +7341,21 @@ describe("ChatView timeline estimator parity (full app)", () => {
         targetMessageId: "msg-user-sticky-claude-model-test" as MessageId,
         targetText: "sticky claude model test",
       }),
+      configureFixture: (nextFixture) => {
+        nextFixture.serverConfig = {
+          ...nextFixture.serverConfig,
+          providers: [
+            ...nextFixture.serverConfig.providers,
+            {
+              provider: "claudeAgent",
+              status: "ready",
+              available: true,
+              authStatus: "authenticated",
+              checkedAt: NOW_ISO,
+            },
+          ],
+        };
+      },
     });
 
     try {
@@ -7360,6 +7373,75 @@ describe("ChatView timeline estimator parity (full app)", () => {
 
       expect(useComposerDraftStore.getState().draftsByThreadId[newThreadId]).toMatchObject({
         modelSelectionByProvider: {
+          claudeAgent: {
+            provider: "claudeAgent",
+            model: "claude-opus-4-6",
+            options: {
+              effort: "max",
+              fastMode: true,
+            },
+          },
+        },
+        activeProvider: "claudeAgent",
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("falls back from an unauthenticated sticky provider on fresh chat", async () => {
+    useComposerDraftStore.setState({
+      stickyModelSelectionByProvider: {
+        claudeAgent: {
+          provider: "claudeAgent",
+          model: "claude-opus-4-6",
+          options: {
+            effort: "max",
+            fastMode: true,
+          },
+        },
+      },
+      stickyActiveProvider: "claudeAgent",
+    });
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-unavailable-sticky-claude-test" as MessageId,
+        targetText: "unavailable sticky claude test",
+      }),
+      configureFixture: (nextFixture) => {
+        nextFixture.serverConfig = {
+          ...nextFixture.serverConfig,
+          providers: [
+            ...nextFixture.serverConfig.providers,
+            {
+              provider: "claudeAgent",
+              status: "warning",
+              available: true,
+              authStatus: "unauthenticated",
+              checkedAt: NOW_ISO,
+            },
+          ],
+        };
+      },
+    });
+
+    try {
+      const newThreadButton = page.getByTestId("new-thread-button");
+      await expect.element(newThreadButton).toBeInTheDocument();
+
+      await newThreadButton.click();
+
+      const newThreadPath = await waitForURL(
+        mounted.router,
+        (path) => UUID_ROUTE_RE.test(path),
+        "Route should have changed to a healthy fallback draft thread UUID.",
+      );
+      const newThreadId = newThreadPath.slice(1) as ThreadId;
+
+      expect(useComposerDraftStore.getState().draftsByThreadId[newThreadId]).toMatchObject({
+        modelSelectionByProvider: {
           codex: {
             provider: "codex",
             model: "gpt-5",
@@ -7372,7 +7454,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
-  it("materializes the project default when no sticky composer settings exist", async () => {
+  it("leaves the project default implicit when no sticky composer settings exist", async () => {
     const mounted = await mountChatView({
       viewport: DEFAULT_VIEWPORT,
       snapshot: createSnapshotForTargetUser({
@@ -7394,15 +7476,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
       );
       const newThreadId = newThreadPath.slice(1) as ThreadId;
 
-      expect(useComposerDraftStore.getState().draftsByThreadId[newThreadId]).toMatchObject({
-        modelSelectionByProvider: {
-          codex: {
-            provider: "codex",
-            model: "gpt-5",
-          },
-        },
-        activeProvider: "codex",
-      });
+      expect(useComposerDraftStore.getState().draftsByThreadId[newThreadId]).toBeUndefined();
     } finally {
       await mounted.cleanup();
     }
@@ -7448,7 +7522,11 @@ describe("ChatView timeline estimator parity (full app)", () => {
         modelSelectionByProvider: {
           codex: {
             provider: "codex",
-            model: "gpt-5",
+            model: "gpt-5.3-codex",
+            options: {
+              reasoningEffort: "medium",
+              fastMode: true,
+            },
           },
         },
         activeProvider: "codex",

--- a/apps/web/src/composerDraftModels.ts
+++ b/apps/web/src/composerDraftModels.ts
@@ -757,28 +757,22 @@ export function resolvePreferredComposerModelSelection(input: {
   threadModelSelection: ModelSelection | null | undefined;
   projectModelSelection: ModelSelection | null | undefined;
   defaultProvider?: ProviderKind | null | undefined;
-  // Fresh bootstrap: the draft has no thread history yet, so its model state is
-  // only sticky-seeded carry-over. An explicit persisted default (or an explicit
-  // thread/project selection) must beat that stale sticky provider.
-  fresh?: boolean;
 }): ModelSelection {
+  // The draft's selection is the user's most recently used target: a fresh draft
+  // is seeded from the sticky (last-used) state, so this precedence is what
+  // makes a new chat reopen with the model and options used last time. Project
+  // and global defaults only apply when nothing has been used yet.
   const draftProviderWithSelection =
     COMPOSER_PROVIDER_KINDS.find(
       (provider) => input.draft?.modelSelectionByProvider?.[provider] !== undefined,
     ) ?? null;
-  const preferredProvider = input.fresh
-    ? (input.threadModelSelection?.provider ??
-      input.projectModelSelection?.provider ??
-      input.defaultProvider ??
-      input.draft?.activeProvider ??
-      draftProviderWithSelection ??
-      "codex")
-    : (input.draft?.activeProvider ??
-      draftProviderWithSelection ??
-      input.threadModelSelection?.provider ??
-      input.projectModelSelection?.provider ??
-      input.defaultProvider ??
-      "codex");
+  const preferredProvider =
+    input.draft?.activeProvider ??
+    draftProviderWithSelection ??
+    input.threadModelSelection?.provider ??
+    input.projectModelSelection?.provider ??
+    input.defaultProvider ??
+    "codex";
 
   const persistedSelection =
     (input.threadModelSelection?.provider === preferredProvider
@@ -790,9 +784,8 @@ export function resolvePreferredComposerModelSelection(input: {
   const draftSelection = input.draft?.modelSelectionByProvider?.[preferredProvider] ?? null;
 
   return (
-    (input.fresh
-      ? (persistedSelection ?? draftSelection)
-      : (draftSelection ?? persistedSelection)) ?? {
+    draftSelection ??
+    persistedSelection ?? {
       provider: preferredProvider === "pi" ? "codex" : preferredProvider,
       model: getDefaultModel(preferredProvider === "pi" ? "codex" : preferredProvider),
     }

--- a/apps/web/src/composerDraftStore.models.test.ts
+++ b/apps/web/src/composerDraftStore.models.test.ts
@@ -67,75 +67,22 @@ describe("resolvePreferredComposerModelSelection", () => {
     ).toEqual(cursorSelection);
   });
 
-  it("prefers the persisted default provider over a stale sticky draft on fresh bootstrap", () => {
+  it("restores the last-used selection for a fresh bootstrap ahead of project and global defaults", () => {
+    const lastUsed = modelSelection("claudeAgent", "claude-opus-4-6", { effort: "max" });
     expect(
       resolvePreferredComposerModelSelection({
-        fresh: true,
         draft: {
-          modelSelectionByProvider: {
-            pi: modelSelection("pi", "pi-auto"),
-          },
-          activeProvider: "pi",
+          modelSelectionByProvider: { claudeAgent: lastUsed },
+          activeProvider: "claudeAgent",
         },
         threadModelSelection: null,
-        projectModelSelection: null,
-        defaultProvider: "devin",
+        projectModelSelection: modelSelection("codex", "gpt-5.5"),
+        defaultProvider: "codex",
       }),
-    ).toEqual(modelSelection("devin", "adaptive"));
+    ).toEqual(lastUsed);
   });
 
-  it("lets an explicit thread selection win over a stale sticky draft on fresh bootstrap", () => {
-    expect(
-      resolvePreferredComposerModelSelection({
-        fresh: true,
-        draft: {
-          modelSelectionByProvider: {
-            pi: modelSelection("pi", "pi-auto"),
-          },
-          activeProvider: "pi",
-        },
-        threadModelSelection: modelSelection("codex", "gpt-5"),
-        projectModelSelection: null,
-        defaultProvider: "devin",
-      }),
-    ).toEqual(modelSelection("codex", "gpt-5"));
-  });
-
-  it("lets an explicit project selection win over a stale sticky draft on fresh bootstrap", () => {
-    expect(
-      resolvePreferredComposerModelSelection({
-        fresh: true,
-        draft: {
-          modelSelectionByProvider: {
-            pi: modelSelection("pi", "pi-auto"),
-          },
-          activeProvider: "pi",
-        },
-        threadModelSelection: null,
-        projectModelSelection: modelSelection("codex", "gpt-5.4"),
-        defaultProvider: "devin",
-      }),
-    ).toEqual(modelSelection("codex", "gpt-5.4"));
-  });
-
-  it("prefers a same-provider project model over stale sticky state on fresh bootstrap", () => {
-    expect(
-      resolvePreferredComposerModelSelection({
-        fresh: true,
-        draft: {
-          modelSelectionByProvider: {
-            codex: modelSelection("codex", "gpt-5"),
-          },
-          activeProvider: "codex",
-        },
-        threadModelSelection: null,
-        projectModelSelection: modelSelection("codex", "gpt-5.4"),
-        defaultProvider: "devin",
-      }),
-    ).toEqual(modelSelection("codex", "gpt-5.4"));
-  });
-
-  it("keeps a non-fresh draft preference ahead of the persisted default", () => {
+  it("keeps the draft preference ahead of the persisted default", () => {
     expect(
       resolvePreferredComposerModelSelection({
         draft: {

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -13,8 +13,14 @@ import {
 import {
   type ComposerThreadDraftState,
   type DraftThreadState,
+  resolvePreferredComposerModelSelection,
   useComposerDraftStore,
 } from "../composerDraftStore";
+import {
+  findProviderStatus,
+  isProviderUsable,
+  resolveAvailableProviderPreference,
+} from "../lib/providerAvailability";
 import {
   buildDraftThreadContextPatch,
   createActiveDraftThreadSnapshot,
@@ -184,6 +190,46 @@ export function useHandleNewThread() {
     const projectDefaultModelSelection =
       useStore.getState().projects.find((project) => project.id === projectId)
         ?.defaultModelSelection ?? null;
+    const applyUsableStickyState = (threadId: ThreadId) => {
+      applyStickyState(threadId);
+      if (options?.provider || providerStatuses.length === 0) {
+        return;
+      }
+
+      const draft = useComposerDraftStore.getState().draftsByThreadId[threadId] ?? null;
+      const stickyProvider = draft?.activeProvider ?? null;
+      if (
+        !stickyProvider ||
+        isProviderUsable(findProviderStatus(providerStatuses, stickyProvider))
+      ) {
+        return;
+      }
+
+      const fallbackProvider = resolveAvailableProviderPreference({
+        preferredProvider: projectDefaultModelSelection?.provider ?? settings.defaultProvider,
+        statuses: providerStatuses,
+        providerOrder: settings.providerOrder,
+        hiddenProviders: settings.hiddenProviders,
+      });
+      if (!isProviderUsable(findProviderStatus(providerStatuses, fallbackProvider))) {
+        return;
+      }
+
+      setModelSelection(
+        threadId,
+        resolvePreferredComposerModelSelection({
+          draft: draft
+            ? {
+                modelSelectionByProvider: draft.modelSelectionByProvider,
+                activeProvider: fallbackProvider,
+              }
+            : null,
+          threadModelSelection: null,
+          projectModelSelection: projectDefaultModelSelection,
+          defaultProvider: fallbackProvider,
+        }),
+      );
+    };
     const activeThreadSnapshot = createActiveThreadSnapshot(activeThread, projectId);
     const activeDraftThreadSnapshot = createActiveDraftThreadSnapshot(activeDraftThread, projectId);
     const resolveCreationState = (
@@ -329,7 +375,7 @@ export function useHandleNewThread() {
           activateThreadEntryPoint(threadId);
           // Seed the draft from the sticky (last-used) selection so a new chat
           // reopens with the model and options used most recently.
-          applyStickyState(threadId);
+          applyUsableStickyState(threadId);
           applyProviderOverride(threadId);
         },
         // Mark the draft-landing navigation as a transition so the new route

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -13,7 +13,6 @@ import {
 import {
   type ComposerThreadDraftState,
   type DraftThreadState,
-  resolvePreferredComposerModelSelection,
   useComposerDraftStore,
 } from "../composerDraftStore";
 import {
@@ -120,46 +119,6 @@ export function useHandleNewThread() {
         model: defaultModel,
       });
     };
-    // Fresh chat drafts carry only sticky-seeded composer state, so resolve the
-    // draft model selection against the full precedence (explicit provider >
-    // project default > global default > sticky) instead of overwriting the
-    // sticky provider with the global default alone.
-    const applyResolvedDefault = (threadId: ThreadId) => {
-      if (options?.provider) {
-        return;
-      }
-      const draftComposerState =
-        useComposerDraftStore.getState().draftsByThreadId[threadId] ?? null;
-      const modelSelection = resolvePreferredComposerModelSelection({
-        draft: draftComposerState,
-        threadModelSelection: null,
-        projectModelSelection: projectDefaultModelSelection,
-        defaultProvider: settings.defaultProvider,
-        fresh: true,
-      });
-      // A fresh chat draft was seeded with sticky composer state, so the
-      // resolved project/global default would otherwise get the sticky model's
-      // same-provider options merged back onto it by setModelSelection's option
-      // preservation. Drop the resolved provider's sticky-seeded entry first so
-      // only the resolved selection lands in the draft. When resolution fell
-      // back to the sticky draft selection, that selection already carries its
-      // own options.
-      useComposerDraftStore.setState((state) => {
-        const draft = state.draftsByThreadId[threadId];
-        if (!draft) {
-          return state;
-        }
-        const modelSelectionByProvider = { ...draft.modelSelectionByProvider };
-        delete modelSelectionByProvider[modelSelection.provider];
-        return {
-          draftsByThreadId: {
-            ...state.draftsByThreadId,
-            [threadId]: { ...draft, modelSelectionByProvider },
-          },
-        };
-      });
-      setModelSelection(threadId, modelSelection);
-    };
     const restoreComposerDraft = (
       threadId: ThreadId,
       draftState: ComposerThreadDraftState | null,
@@ -221,11 +180,6 @@ export function useHandleNewThread() {
       projectId,
       routeThreadId: focusedThreadId,
     });
-    // A fresh bootstrap (explicit options.fresh or a plan with no reusable draft)
-    // means the new draft's composer state is only sticky-seeded carry-over, so
-    // resolve its model selection against explicit thread/project/default
-    // providers instead of that stale sticky provider.
-    const freshBootstrap = options?.fresh === true || bootstrapPlan.kind === "fresh";
     // Read from the store at call time so post-sync sidebar flows can use the latest project defaults.
     const projectDefaultModelSelection =
       useStore.getState().projects.find((project) => project.id === projectId)
@@ -244,7 +198,6 @@ export function useHandleNewThread() {
         draftComposerState:
           useComposerDraftStore.getState().draftsByThreadId[targetThreadId] ?? null,
         draftThread,
-        fresh: freshBootstrap,
         options: creationOptions,
         projectDefaultModelSelection,
         projectId,
@@ -374,9 +327,10 @@ export function useHandleNewThread() {
         stage: () => {
           registerDraftThread(threadId, { projectId, ...draftSeed });
           activateThreadEntryPoint(threadId);
+          // Seed the draft from the sticky (last-used) selection so a new chat
+          // reopens with the model and options used most recently.
           applyStickyState(threadId);
           applyProviderOverride(threadId);
-          applyResolvedDefault(threadId);
         },
         // Mark the draft-landing navigation as a transition so the new route
         // subtree renders interruptibly and the browser can paint the chat

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -192,7 +192,7 @@ export function useHandleNewThread() {
         ?.defaultModelSelection ?? null;
     const applyUsableStickyState = (threadId: ThreadId) => {
       applyStickyState(threadId);
-      if (options?.provider || providerStatuses.length === 0) {
+      if (options?.provider || !hasReconciledServerProviderStatuses(queryClient)) {
         return;
       }
 

--- a/apps/web/src/lib/providerAvailability.test.ts
+++ b/apps/web/src/lib/providerAvailability.test.ts
@@ -235,6 +235,22 @@ describe("resolveAvailableProviderPreference", () => {
     ).toBe("cursor");
   });
 
+  it("falls back when the preferred provider is installed but unauthenticated", () => {
+    expect(
+      resolveAvailableProviderPreference({
+        preferredProvider: "claudeAgent",
+        statuses: [
+          {
+            ...READY_STATUS,
+            provider: "claudeAgent",
+            authStatus: "unauthenticated",
+          },
+          { ...READY_STATUS, provider: "codex" },
+        ],
+      }),
+    ).toBe("codex");
+  });
+
   it("preserves the preference while provider status is loading", () => {
     expect(
       resolveAvailableProviderPreference({

--- a/apps/web/src/lib/providerAvailability.ts
+++ b/apps/web/src/lib/providerAvailability.ts
@@ -128,7 +128,7 @@ export function resolveAvailableProviderPreference(input: {
   }
 
   const preferredStatus = findProviderStatus(input.statuses, input.preferredProvider);
-  if (preferredStatus?.available) {
+  if (isProviderUsable(preferredStatus)) {
     return input.preferredProvider;
   }
 

--- a/apps/web/src/lib/threadBootstrap.test.ts
+++ b/apps/web/src/lib/threadBootstrap.test.ts
@@ -373,24 +373,22 @@ describe("threadBootstrap", () => {
     });
   });
 
-  it("prefers the persisted default provider over a stale sticky draft on a fresh bootstrap", () => {
+  it("restores the last-used model and options for a fresh bootstrap ahead of project and global defaults", () => {
+    const lastUsed = modelSelection("claudeAgent", "claude-opus-4-6", { effort: "max" });
     expect(
       resolveTerminalThreadCreationState({
         activeDraftThread: null,
         activeThread: null,
-        defaultProvider: "devin",
+        defaultProvider: "codex",
         draftComposerState: makeComposerDraftState({
-          modelSelectionByProvider: {
-            pi: modelSelection("pi", "pi-auto"),
-          },
-          activeProvider: "pi",
+          modelSelectionByProvider: { claudeAgent: lastUsed },
+          activeProvider: "claudeAgent",
         }),
         draftThread: makeDraftThread(),
         options: undefined,
-        fresh: true,
-        projectDefaultModelSelection: null,
+        projectDefaultModelSelection: modelSelection("codex", "gpt-5.5"),
         projectId: PROJECT_ID,
       }).modelSelection,
-    ).toEqual(modelSelection("devin", "adaptive"));
+    ).toEqual(lastUsed);
   });
 });

--- a/apps/web/src/lib/threadBootstrap.ts
+++ b/apps/web/src/lib/threadBootstrap.ts
@@ -107,7 +107,6 @@ interface ResolveTerminalThreadCreationStateInput {
   defaultProvider?: ProviderKind | null | undefined;
   draftComposerState: ComposerThreadDraftState | null;
   draftThread: DraftThreadState | null;
-  fresh?: boolean;
   options: NewThreadOptions | undefined;
   projectDefaultModelSelection: ModelSelection | null;
   projectId: ProjectId;
@@ -311,7 +310,6 @@ export function resolveTerminalThreadCreationState(
           : null,
       projectModelSelection: input.projectDefaultModelSelection,
       defaultProvider: input.defaultProvider,
-      ...(input.fresh !== undefined ? { fresh: input.fresh } : {}),
     }),
     runtimeMode:
       input.draftThread?.runtimeMode ??

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -448,7 +448,7 @@ function SettingsRouteView() {
       <SettingsSection title="Core defaults">
         <SettingsRow
           title="Default provider"
-          description="Choose the provider used for new chats."
+          description="Provider used for new chats until you pick a model. New chats then reuse your most recent model and options."
           resetAction={
             settings.defaultProvider !== defaults.defaultProvider ? (
               <SettingResetButton


### PR DESCRIPTION
## Root cause

Commit 8b428c474 (Devin ACP provider integration, #772) changed `resolvePreferredComposerModelSelection` to take a `fresh` flag. On a fresh bootstrap it resolved the provider as `thread > project default > settings.defaultProvider > sticky`, and `useHandleNewThread` gained an `applyResolvedDefault` step that deleted the sticky-seeded entry for the resolved provider and overwrote the draft with that default.

`settings.defaultProvider` is always populated (it defaults to `codex`) and every project gets an auto-seeded `defaultModelSelection`, so the sticky last-used selection could never win on a new chat. Every new chat therefore landed on Codex gpt-5.5 with no options, which the composer shows as low effort.

## Fix

- `composerDraftModels.ts`: drop the `fresh` precedence. The draft's sticky-seeded (last-used) selection wins, with thread, project default and global default as fallbacks only when nothing has been used yet. This is the behaviour before #772.
- `useHandleNewThread.ts`: remove `applyResolvedDefault` and `freshBootstrap`; a fresh draft is seeded from sticky state and left alone unless an explicit provider override is requested.
- `threadBootstrap.ts`: remove the `fresh` passthrough.
- `_chat.settings.tsx`: clarify the Default provider copy so it reads as the fallback for new chats rather than an override.
- Tests: add regression tests for the fresh-bootstrap case (last-used selection with options beats project and global defaults) in `threadBootstrap.test.ts` and `composerDraftStore.models.test.ts`; remove the #772 tests that asserted the opposite.

This restores last-used restoration per provider for home chats, temporary chats and project-scoped new chats, since all of them go through the same fresh-draft path.

## Verification

- `bun fmt`, `bun lint` (0 errors), `bun typecheck`: pass
- `bun run test` for threadBootstrap, composerDraftStore, ChatView.logic and kanbanDispatch: 318 tests pass

Closes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes composer model/provider resolution on every new-thread path; incorrect fallback could send users to the wrong provider, but behavior is largely a revert with added auth-aware fallback and broad test updates.
> 
> **Overview**
> Fixes a regression where **new chats ignored sticky (last-used) model and options** and always resolved to project/global Codex defaults.
> 
> **Model precedence** in `resolvePreferredComposerModelSelection` drops the `fresh` flag: sticky-seeded draft selection wins again; thread, project, and settings defaults apply only when there is no last-used state. `useHandleNewThread` removes the `applyResolvedDefault` overwrite path and seeds new drafts via **`applyUsableStickyState`**, which keeps sticky restoration unless the sticky provider is **unauthenticated/unusable**—then it falls back through `resolveAvailableProviderPreference` (now treating unauthenticated as unusable, not merely “unavailable”).
> 
> **Tests and copy** align with the restored behavior (including ChatView browser mocks for `subscribeServerProviderStatuses`), and settings text clarifies that default provider is a fallback until the user picks a model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 185b4d2ab35b4149500b8e7cf212f9c91ed13684. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->