### PR TITLE
fix(web): restore orchestrator approval cards

### DIFF
--- a/apps/web/src/components/EventRouter.browser.tsx
+++ b/apps/web/src/components/EventRouter.browser.tsx
@@ -970,9 +970,7 @@ describe("EventRouter scoped orchestration sync", () => {
 
       await vi.waitFor(
         () => {
-          expect(getThreadDetailSnapshotRequestCount).toBeGreaterThan(
-            requestCountBeforeApproval,
-          );
+          expect(getThreadDetailSnapshotRequestCount).toBeGreaterThan(requestCountBeforeApproval);
           expect(document.body.textContent).toContain("Approve this command?");
           expect(
             getThreadFromState(useStore.getState(), THREAD_ID)?.pendingInteractions?.[0]?.requestId,

--- a/apps/web/src/components/EventRouter.browser.tsx
+++ b/apps/web/src/components/EventRouter.browser.tsx
@@ -1,6 +1,7 @@
 import "../index.css";
 
 import {
+  ApprovalRequestId,
   EventId,
   MessageId,
   DEVICE_WS_METHODS,
@@ -794,6 +795,87 @@ describe("EventRouter scoped orchestration sync", () => {
       );
       expect(replayRequestCursors).toContain(1);
     } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("hydrates a pending approval for an orchestrator thread with no session detail", async () => {
+    fixture = {
+      ...fixture,
+      snapshot: createSnapshot({
+        creationSource: "synara_mcp",
+        sourceThreadId: OTHER_THREAD_ID,
+        messages: [],
+        session: null,
+      }),
+    };
+    const mounted = await mountApp();
+
+    try {
+      const requestId = ApprovalRequestId.makeUnsafe("approval-orchestrator-thread");
+      const approvalActivity = {
+        id: EventId.makeUnsafe("event-orchestrator-approval"),
+        createdAt: "2026-03-04T12:00:05.000Z",
+        tone: "approval",
+        kind: "approval.requested",
+        summary: "Command approval requested",
+        payload: {
+          requestId,
+          requestKind: "command",
+          requestType: "command_execution_approval",
+          detail: "Command: git status",
+        },
+        turnId: null,
+        sequence: 2,
+      } as const;
+      fixture = {
+        ...fixture,
+        snapshot: {
+          ...fixture.snapshot,
+          snapshotSequence: 2,
+          threads: fixture.snapshot.threads.map((thread) => ({
+            ...thread,
+            updatedAt: "2026-03-04T12:00:05.000Z",
+            hasPendingApprovals: true,
+            activities: [approvalActivity],
+            pendingInteractions: [
+              {
+                interactionKind: "approval" as const,
+                requestId,
+                threadId: THREAD_ID,
+                turnId: null,
+                lifecycleGeneration: null,
+                status: "pending" as const,
+                decision: null,
+                responseCommandId: null,
+                responseRequestedAt: null,
+                createdAt: approvalActivity.createdAt,
+                resolvedAt: null,
+              },
+            ],
+          })),
+          updatedAt: "2026-03-04T12:00:05.000Z",
+        },
+      };
+
+      sendShellEventPush({
+        kind: "thread-upserted",
+        sequence: 2,
+        thread: createShellSnapshotFromReadModel(fixture.snapshot).threads[0]!,
+      });
+
+      await vi.waitFor(
+        () => {
+          expect(getThreadDetailSnapshotRequestCount).toBeGreaterThan(0);
+          expect(document.body.textContent).toContain("Approve this command?");
+          expect(
+            getThreadFromState(useStore.getState(), THREAD_ID)?.pendingInteractions?.[0]?.requestId,
+          ).toBe(requestId);
+        },
+        { timeout: 4_000, interval: 16 },
+      );
+    } finally {
+      fixture = buildFixture();
       await mounted.cleanup();
     }
   });

--- a/apps/web/src/components/EventRouter.browser.tsx
+++ b/apps/web/src/components/EventRouter.browser.tsx
@@ -2,6 +2,7 @@ import "../index.css";
 
 import {
   ApprovalRequestId,
+  CommandId,
   EventId,
   MessageId,
   DEVICE_WS_METHODS,
@@ -172,6 +173,57 @@ function createSnapshot(overrides?: Partial<OrchestrationReadModel["threads"][nu
     ],
     updatedAt: NOW_ISO,
   } satisfies OrchestrationReadModel;
+}
+
+function withApprovalRequest(
+  thread: OrchestrationThread,
+  input: {
+    readonly requestId: ApprovalRequestId;
+    readonly status?: "pending" | "responding" | "uncertain";
+  },
+): OrchestrationThread {
+  const createdAt = "2026-03-04T12:00:05.000Z";
+  const lifecycleGeneration = `generation:${input.requestId}`;
+  const status = input.status ?? "pending";
+  return {
+    ...thread,
+    updatedAt: createdAt,
+    hasPendingApprovals: true,
+    activities: [
+      {
+        id: EventId.makeUnsafe(`event:${input.requestId}`),
+        createdAt,
+        tone: "approval",
+        kind: "approval.requested",
+        summary: "Command approval requested",
+        payload: {
+          requestId: input.requestId,
+          lifecycleGeneration,
+          requestKind: "command",
+          requestType: "command_execution_approval",
+          detail: "Command: git status",
+        },
+        turnId: null,
+        sequence: 2,
+      },
+    ],
+    pendingInteractions: [
+      {
+        interactionKind: "approval",
+        requestId: input.requestId,
+        threadId: thread.id,
+        turnId: null,
+        lifecycleGeneration,
+        status,
+        decision: status === "pending" ? null : "accept",
+        responseCommandId:
+          status === "pending" ? null : CommandId.makeUnsafe(`response:${input.requestId}`),
+        responseRequestedAt: status === "pending" ? null : createdAt,
+        createdAt,
+        resolvedAt: null,
+      },
+    ],
+  };
 }
 
 function buildFixture(): TestFixture {
@@ -813,47 +865,14 @@ describe("EventRouter scoped orchestration sync", () => {
 
     try {
       const requestId = ApprovalRequestId.makeUnsafe("approval-orchestrator-thread");
-      const approvalActivity = {
-        id: EventId.makeUnsafe("event-orchestrator-approval"),
-        createdAt: "2026-03-04T12:00:05.000Z",
-        tone: "approval",
-        kind: "approval.requested",
-        summary: "Command approval requested",
-        payload: {
-          requestId,
-          requestKind: "command",
-          requestType: "command_execution_approval",
-          detail: "Command: git status",
-        },
-        turnId: null,
-        sequence: 2,
-      } as const;
       fixture = {
         ...fixture,
         snapshot: {
           ...fixture.snapshot,
           snapshotSequence: 2,
-          threads: fixture.snapshot.threads.map((thread) => ({
-            ...thread,
-            updatedAt: "2026-03-04T12:00:05.000Z",
-            hasPendingApprovals: true,
-            activities: [approvalActivity],
-            pendingInteractions: [
-              {
-                interactionKind: "approval" as const,
-                requestId,
-                threadId: THREAD_ID,
-                turnId: null,
-                lifecycleGeneration: null,
-                status: "pending" as const,
-                decision: null,
-                responseCommandId: null,
-                responseRequestedAt: null,
-                createdAt: approvalActivity.createdAt,
-                resolvedAt: null,
-              },
-            ],
-          })),
+          threads: fixture.snapshot.threads.map((thread) =>
+            withApprovalRequest(thread, { requestId }),
+          ),
           updatedAt: "2026-03-04T12:00:05.000Z",
         },
       };
@@ -879,6 +898,124 @@ describe("EventRouter scoped orchestration sync", () => {
       await mounted.cleanup();
     }
   });
+
+  it("queues a pending approval repair behind an older projection read", async () => {
+    fixture = {
+      ...fixture,
+      snapshot: createSnapshot({
+        creationSource: "synara_mcp",
+        sourceThreadId: OTHER_THREAD_ID,
+        messages: [],
+        latestTurn: null,
+        session: {
+          threadId: THREAD_ID,
+          status: "starting",
+          providerName: "codex",
+          runtimeMode: "full-access",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: NOW_ISO,
+        },
+      }),
+    };
+    const mounted = await mountApp();
+
+    try {
+      delayNextThreadDetailSnapshotResponse = true;
+      await vi.waitFor(
+        () => {
+          expect(getThreadDetailSnapshotRequestCount).toBeGreaterThan(0);
+          expect(pendingThreadDetailSnapshotResponse).not.toBeNull();
+        },
+        { timeout: 10_000, interval: 16 },
+      );
+
+      const delayedResponse = pendingThreadDetailSnapshotResponse!;
+      const staleThread = {
+        ...fixture.snapshot.threads[0]!,
+        session: null,
+        hasPendingApprovals: false,
+      };
+      pendingThreadDetailSnapshotResponse = {
+        ...delayedResponse,
+        result: {
+          snapshotSequence: 1,
+          thread: staleThread,
+        },
+      };
+
+      const requestId = ApprovalRequestId.makeUnsafe("approval-after-stale-projection");
+      const currentThread = withApprovalRequest(staleThread, { requestId });
+      fixture = {
+        ...fixture,
+        snapshot: {
+          ...fixture.snapshot,
+          snapshotSequence: 2,
+          threads: [currentThread],
+          updatedAt: currentThread.updatedAt,
+        },
+      };
+      const requestCountBeforeApproval = getThreadDetailSnapshotRequestCount;
+
+      sendShellEventPush({
+        kind: "thread-upserted",
+        sequence: 2,
+        thread: createShellSnapshotFromReadModel(fixture.snapshot).threads[0]!,
+      });
+      await vi.waitFor(() =>
+        expect(getThreadFromState(useStore.getState(), THREAD_ID)?.hasPendingApprovals).toBe(true),
+      );
+
+      sendPendingThreadDetailSnapshotResponse();
+
+      await vi.waitFor(
+        () => {
+          expect(getThreadDetailSnapshotRequestCount).toBeGreaterThan(
+            requestCountBeforeApproval,
+          );
+          expect(document.body.textContent).toContain("Approve this command?");
+          expect(
+            getThreadFromState(useStore.getState(), THREAD_ID)?.pendingInteractions?.[0]?.requestId,
+          ).toBe(requestId);
+        },
+        { timeout: 4_000, interval: 16 },
+      );
+    } finally {
+      fixture = buildFixture();
+      await mounted.cleanup();
+    }
+  }, 60_000);
+
+  it("does not poll a hydrated non-actionable approval", async () => {
+    const baseSnapshot = createSnapshot({
+      creationSource: "synara_mcp",
+      sourceThreadId: OTHER_THREAD_ID,
+      messages: [],
+      session: null,
+    });
+    fixture = {
+      ...fixture,
+      snapshot: {
+        ...baseSnapshot,
+        threads: [
+          withApprovalRequest(baseSnapshot.threads[0]!, {
+            requestId: ApprovalRequestId.makeUnsafe("approval-response-uncertain"),
+            status: "uncertain",
+          }),
+        ],
+      },
+    };
+    const mounted = await mountApp();
+
+    try {
+      await new Promise<void>((resolve) => window.setTimeout(resolve, 5_200));
+      expect(getThreadDetailSnapshotRequestCount).toBe(0);
+      expect(document.body.textContent).not.toContain("Approve this command?");
+    } finally {
+      fixture = buildFixture();
+      await mounted.cleanup();
+    }
+  }, 60_000);
 
   it("polls a subscribed running thread to recover missed detail events", async () => {
     const runningTurnId = TurnId.makeUnsafe("turn-catchup-running");

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -99,6 +99,10 @@ import {
   setThreadDetailResumeCursor,
 } from "../threadDetailResumeCursors";
 import { hasPendingTurnDispatch } from "../pendingTurnDispatch";
+import {
+  derivePendingApprovals,
+  derivePendingUserInputs,
+} from "../pendingInteractionDerivation";
 import { canApplyThreadSnapshot, selectOrphanedThreadDetailIds } from "./-threadDetailOwnership";
 import {
   doesSnapshotSatisfyTerminalFence,
@@ -985,6 +989,28 @@ function shouldPollThreadDetailCatchup(threadId: ThreadId): boolean {
   );
 }
 
+function isPendingInteractionDetailMissing(threadId: ThreadId): boolean {
+  const thread = getThreadFromState(useStore.getState(), threadId);
+  if (!thread) {
+    return false;
+  }
+  const options = {
+    latestTurnId: thread.latestTurn?.turnId,
+  };
+  return (
+    (thread.hasPendingApprovals === true &&
+      derivePendingApprovals(thread.activities, thread.pendingInteractions, {
+        ...options,
+        authoritativeHasPending: true,
+      }).length === 0) ||
+    (thread.hasPendingUserInput === true &&
+      derivePendingUserInputs(thread.activities, thread.pendingInteractions, {
+        ...options,
+        authoritativeHasPending: true,
+      }).length === 0)
+  );
+}
+
 function shouldReconcileThreadProjection(threadId: ThreadId): boolean {
   const thread = getThreadFromState(useStore.getState(), threadId);
   return (
@@ -993,6 +1019,7 @@ function shouldReconcileThreadProjection(threadId: ThreadId): boolean {
     thread?.latestTurn?.state === "running" ||
     thread?.messages.some((message) => message.role === "assistant" && message.streaming) ===
       true ||
+    isPendingInteractionDetailMissing(threadId) ||
     hasPendingTurnDispatch(threadId)
   );
 }
@@ -1933,6 +1960,17 @@ function EventRouter() {
         // projection directly instead of restarting that stream on every shell
         // update; repeated ready/running/meta updates can otherwise keep
         // cancelling hydration before a snapshot reaches the renderer.
+        void reconcileThreadProjection(item.thread.id).catch(() => undefined);
+      }
+      if (
+        item.kind === "thread-upserted" &&
+        subscribedThreadIds.has(item.thread.id) &&
+        isPendingInteractionDetailMissing(item.thread.id)
+      ) {
+        // A shell summary can expose an approval before its detail event reaches
+        // the client (notably for orchestrator-created threads with no projected
+        // session or turn yet). Fetch the authoritative detail immediately so
+        // the composer does not remain an empty, unactionable conversation.
         void reconcileThreadProjection(item.thread.id).catch(() => undefined);
       }
       if (item.kind === "thread-upserted" && subscribedThreadIds.has(item.thread.id)) {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -99,10 +99,7 @@ import {
   setThreadDetailResumeCursor,
 } from "../threadDetailResumeCursors";
 import { hasPendingTurnDispatch } from "../pendingTurnDispatch";
-import {
-  derivePendingApprovals,
-  derivePendingUserInputs,
-} from "../pendingInteractionDerivation";
+import { derivePendingApprovals, derivePendingUserInputs } from "../pendingInteractionDerivation";
 import { canApplyThreadSnapshot, selectOrphanedThreadDetailIds } from "./-threadDetailOwnership";
 import {
   doesSnapshotSatisfyTerminalFence,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1828,11 +1828,7 @@ function EventRouter() {
       options?: { readonly queueIfInFlight?: boolean },
     ): Promise<void> => {
       const subscriptionGeneration = threadSubscriptionGenerationById.get(threadId);
-      if (
-        disposed ||
-        !subscribedThreadIds.has(threadId) ||
-        subscriptionGeneration === undefined
-      ) {
+      if (disposed || !subscribedThreadIds.has(threadId) || subscriptionGeneration === undefined) {
         return;
       }
       if (threadProjectionReconcileInFlight.has(threadId)) {
@@ -1922,9 +1918,7 @@ function EventRouter() {
           threadProjectionReconcileInFlight.delete(threadId);
         }
         if (threadSubscriptionGenerationById.get(threadId) === subscriptionGeneration) {
-          if (
-            threadProjectionReconcilePendingById.get(threadId) === subscriptionGeneration
-          ) {
+          if (threadProjectionReconcilePendingById.get(threadId) === subscriptionGeneration) {
             threadProjectionReconcilePendingById.delete(threadId);
             void reconcileThreadProjection(threadId).catch(() => undefined);
             return;

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -994,18 +994,64 @@ function isPendingInteractionDetailMissing(threadId: ThreadId): boolean {
   const options = {
     latestTurnId: thread.latestTurn?.turnId,
   };
-  return (
-    (thread.hasPendingApprovals === true &&
-      derivePendingApprovals(thread.activities, thread.pendingInteractions, {
+  const hasMatchingSettlement = (
+    interactionKind: "approval" | "userInput",
+    request: { readonly requestId: string; readonly lifecycleGeneration?: string },
+  ) =>
+    thread.pendingInteractions?.some(
+      (interaction) =>
+        interaction.interactionKind === interactionKind &&
+        interaction.requestId === request.requestId &&
+        (interaction.lifecycleGeneration ?? undefined) === request.lifecycleGeneration,
+    ) === true;
+
+  if (thread.hasPendingApprovals === true) {
+    const actionableApprovals = derivePendingApprovals(
+      thread.activities,
+      thread.pendingInteractions,
+      {
         ...options,
         authoritativeHasPending: true,
-      }).length === 0) ||
-    (thread.hasPendingUserInput === true &&
-      derivePendingUserInputs(thread.activities, thread.pendingInteractions, {
+      },
+    );
+    if (actionableApprovals.length === 0) {
+      const replayedApprovals = derivePendingApprovals(thread.activities, undefined, {
         ...options,
         authoritativeHasPending: true,
-      }).length === 0)
-  );
+      });
+      if (
+        replayedApprovals.length === 0 ||
+        replayedApprovals.some((request) => !hasMatchingSettlement("approval", request))
+      ) {
+        return true;
+      }
+    }
+  }
+
+  if (thread.hasPendingUserInput === true) {
+    const actionableUserInputs = derivePendingUserInputs(
+      thread.activities,
+      thread.pendingInteractions,
+      {
+        ...options,
+        authoritativeHasPending: true,
+      },
+    );
+    if (actionableUserInputs.length === 0) {
+      const replayedUserInputs = derivePendingUserInputs(thread.activities, undefined, {
+        ...options,
+        authoritativeHasPending: true,
+      });
+      if (
+        replayedUserInputs.length === 0 ||
+        replayedUserInputs.some((request) => !hasMatchingSettlement("userInput", request))
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 function shouldReconcileThreadProjection(threadId: ThreadId): boolean {
@@ -1163,6 +1209,7 @@ function EventRouter() {
     const threadSnapshotNotFoundRetryAttempted = new Set<ThreadId>();
     const threadReplayRequestInFlight = new Set<ThreadId>();
     const threadProjectionReconcileInFlight = new Map<ThreadId, number>();
+    const threadProjectionReconcilePendingById = new Map<ThreadId, number>();
     const threadProjectionTerminalFencePending = new Set<ThreadId>();
     // Sequence of the session-set / shell upsert that armed each terminal fence.
     // Cleared only once a detail snapshot proves post-settle assistant finals
@@ -1282,6 +1329,7 @@ function EventRouter() {
       threadSnapshotRefreshPending.delete(threadId);
       threadSnapshotNotFoundRetryAttempted.delete(threadId);
       threadProjectionReconcileInFlight.delete(threadId);
+      threadProjectionReconcilePendingById.delete(threadId);
       clearThreadProjectionTerminalFence(threadId);
       threadCatchupBackoffById.delete(threadId);
       nextThreadSubscriptionGeneration += 1;
@@ -1363,6 +1411,7 @@ function EventRouter() {
         threadSnapshotNotFoundRetryAttempted.delete(threadId);
         threadReplayRequestInFlight.delete(threadId);
         threadProjectionReconcileInFlight.delete(threadId);
+        threadProjectionReconcilePendingById.delete(threadId);
         clearThreadProjectionTerminalFence(threadId);
         threadSubscriptionGenerationById.delete(threadId);
         nextThreadProjectionReconcileAtById.delete(threadId);
@@ -1774,14 +1823,22 @@ function EventRouter() {
         });
     };
 
-    const reconcileThreadProjection = async (threadId: ThreadId): Promise<void> => {
+    const reconcileThreadProjection = async (
+      threadId: ThreadId,
+      options?: { readonly queueIfInFlight?: boolean },
+    ): Promise<void> => {
       const subscriptionGeneration = threadSubscriptionGenerationById.get(threadId);
       if (
         disposed ||
         !subscribedThreadIds.has(threadId) ||
-        subscriptionGeneration === undefined ||
-        threadProjectionReconcileInFlight.has(threadId)
+        subscriptionGeneration === undefined
       ) {
+        return;
+      }
+      if (threadProjectionReconcileInFlight.has(threadId)) {
+        if (options?.queueIfInFlight === true) {
+          threadProjectionReconcilePendingById.set(threadId, subscriptionGeneration);
+        }
         return;
       }
       threadProjectionReconcileInFlight.set(threadId, subscriptionGeneration);
@@ -1865,6 +1922,13 @@ function EventRouter() {
           threadProjectionReconcileInFlight.delete(threadId);
         }
         if (threadSubscriptionGenerationById.get(threadId) === subscriptionGeneration) {
+          if (
+            threadProjectionReconcilePendingById.get(threadId) === subscriptionGeneration
+          ) {
+            threadProjectionReconcilePendingById.delete(threadId);
+            void reconcileThreadProjection(threadId).catch(() => undefined);
+            return;
+          }
           if (projectionAttemptFailed) {
             // A failed reconcile is not evidence of a quiet healthy stream.
             // Retry it at the base cadence, while preserving backoff when the
@@ -1968,7 +2032,9 @@ function EventRouter() {
         // the client (notably for orchestrator-created threads with no projected
         // session or turn yet). Fetch the authoritative detail immediately so
         // the composer does not remain an empty, unactionable conversation.
-        void reconcileThreadProjection(item.thread.id).catch(() => undefined);
+        void reconcileThreadProjection(item.thread.id, { queueIfInFlight: true }).catch(
+          () => undefined,
+        );
       }
       if (item.kind === "thread-upserted" && subscribedThreadIds.has(item.thread.id)) {
         void replayThreadEvents(item.thread.id, item.sequence).catch(() => undefined);


### PR DESCRIPTION
## Summary

- Reconcile thread detail when the shell reports a pending approval/request but the client cannot derive an actionable card.
- Keep the repair narrowly gated so settled threads are not polled continuously once the card is available.
- Add focused EventRouter browser coverage for the orchestrator-created thread shape with no session, turn, messages, or activity.

## Verification

- Focused Chromium EventRouter suite: 18/18 passed.
- git diff --check passed.

Closes #918

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes thread-detail reconciliation and shell upsert handling in the root EventRouter; behavior is gated on pending-interaction derivation, but incorrect gating could cause extra snapshot traffic or missed repairs.
> 
> **Overview**
> **Restores command approval UI** when the shell thread summary shows a pending approval or user-input request but the client still lacks enough thread detail to render an actionable card (common on orchestrator-created threads with little or no session/turn projection).
> 
> The **EventRouter** now treats that mismatch as a repair signal: `isPendingInteractionDetailMissing` uses `derivePendingApprovals` / `derivePendingUserInputs` against activities and `pendingInteractions`, and folds it into `shouldReconcileThreadProjection` so periodic detail snapshot reconciliation can run. On **`thread-upserted`**, it triggers an immediate `getThreadDetailSnapshot` reconcile (with **`queueIfInFlight`** so a follow-up fetch runs after an in-flight reconcile finishes, avoiding a stale projection wiping the approval).
> 
> **Browser tests** add an approval fixture helper and cover hydration without session detail, repair after a delayed stale snapshot, and no extra polling when the approval is already non-actionable (`uncertain`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49df2dec6fdf287695f782a41328f9043b700053. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->