### PR TITLE
fix(windows): accept PID zero in process snapshots

### DIFF
--- a/apps/server/src/platform/windowsProcessSnapshot.ts
+++ b/apps/server/src/platform/windowsProcessSnapshot.ts
@@ -138,7 +138,9 @@ export function parseWindowsProcessSnapshotLine(
   if (!encodedCommand) return null;
   const pid = Number(pidRaw);
   const ppid = Number(ppidRaw);
-  if (!Number.isInteger(pid) || pid <= 0 || !Number.isInteger(ppid) || ppid < 0) return null;
+  // Win32_Process includes the System Idle Process as PID 0. Root process-tree
+  // APIs still require a positive PID, but rejecting this row invalidates every snapshot.
+  if (!Number.isInteger(pid) || pid < 0 || !Number.isInteger(ppid) || ppid < 0) return null;
   const command = decodeSnapshotCommand(encodedCommand);
   if (command === null) return null;
   const startedAt = startedAtRaw?.trim();

--- a/apps/server/src/terminal/windowsProcessSnapshot.test.ts
+++ b/apps/server/src/terminal/windowsProcessSnapshot.test.ts
@@ -52,6 +52,21 @@ describe("Windows process snapshots", () => {
     expect(parseWindowsProcessSnapshotLine("42\t7\tnot-base64")).toBeNull();
   });
 
+  it("accepts the Windows System Idle Process row", () => {
+    const idleProcess = "System Idle Process";
+    const startedAt = "20260903100453.000000+120";
+    expect(
+      parseWindowsProcessSnapshotLine(
+        `0\t0\t${startedAt}\t${Buffer.from(idleProcess, "utf8").toString("base64")}`,
+      ),
+    ).toEqual({
+      pid: 0,
+      ppid: 0,
+      command: idleProcess,
+      startedAt,
+    });
+  });
+
   it("coalesces concurrent terminal requests and reuses one worker across snapshots", async () => {
     const firstCapture = deferred<ProcessChildrenMap>();
     const firstSnapshot = snapshot([


### PR DESCRIPTION
## Summary
- accept the Windows System Idle Process (PID 0) in CIM snapshot parsing
- preserve positive root PID validation at process-tree boundaries
- add regression coverage for the real four-field PID 0 row

Fixes #941.

## Verification
- npx --yes bun@1.3.12 run --cwd apps/server test -- src/terminal/windowsProcessSnapshot.test.ts src/platform/processTreeController.test.ts src/provider/supervisedProcessTeardown.test.ts (25 passed)
- npx --yes bun@1.3.12 run windows-runtime:check
- structured autoreview: clean, no actionable findings

Formatting, lint, and typecheck were not run locally, in accordance with the repository AGENTS.md instructions; the PR CI is authoritative for those checks.