### PR TITLE
fix(server): hide Windows Effect child processes

### DIFF
--- a/apps/server/src/platform/effectProcessRuntime.test.ts
+++ b/apps/server/src/platform/effectProcessRuntime.test.ts
@@ -16,14 +16,7 @@ describe("makeEffectProcessCommand", () => {
     expect(command).toMatchObject({
       _tag: "StandardCommand",
       command: "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
-      args: [
-        "-NoProfile",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-File",
-        "cursor-agent.ps1",
-        "--version",
-      ],
+      args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "cursor-agent.ps1", "--version"],
       options: {
         shell: false,
         windowsHide: true,

--- a/apps/server/src/platform/effectProcessRuntime.test.ts
+++ b/apps/server/src/platform/effectProcessRuntime.test.ts
@@ -1,0 +1,33 @@
+// FILE: effectProcessRuntime.test.ts
+// Purpose: Verifies shared Windows launch decisions reach Effect child-process commands.
+// Layer: Server platform runtime test
+
+import { describe, expect, it } from "vitest";
+
+import { makeEffectProcessCommand } from "./effectProcessRuntime";
+
+describe("makeEffectProcessCommand", () => {
+  it("keeps PowerShell provider probes hidden on Windows", () => {
+    const command = makeEffectProcessCommand("cursor-agent.ps1", ["--version"], {
+      platform: "win32",
+      env: { SystemRoot: "C:\\Windows" },
+    });
+
+    expect(command).toMatchObject({
+      _tag: "StandardCommand",
+      command: "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+      args: [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        "cursor-agent.ps1",
+        "--version",
+      ],
+      options: {
+        shell: false,
+        windowsHide: true,
+      },
+    });
+  });
+});

--- a/apps/server/src/platform/effectProcessRuntime.ts
+++ b/apps/server/src/platform/effectProcessRuntime.ts
@@ -7,6 +7,13 @@ import { ChildProcess } from "effect/unstable/process";
 
 type ProcessPlanningOptions = Pick<ProcessLaunchInput, "platform">;
 
+// The pinned Effect revision predates these Node-only Windows options. The
+// tracked platform-node-shared patch reads them from the command at runtime.
+type EffectWindowsCommandOptions = ChildProcess.CommandOptions & {
+  readonly windowsHide?: boolean;
+  readonly windowsVerbatimArguments?: boolean;
+};
+
 export type EffectProcessRuntimeOptions = Omit<
   ChildProcess.CommandOptions,
   "shell" | "windowsVerbatimArguments"
@@ -14,8 +21,9 @@ export type EffectProcessRuntimeOptions = Omit<
   ProcessPlanningOptions;
 
 /**
- * Creates an Effect command without leaking `.cmd`, `cmd.exe`, WSL, or
- * windowsVerbatimArguments decisions into provider/application code.
+ * Creates an Effect command without leaking `.cmd`, `cmd.exe`, WSL,
+ * windowsHide, or windowsVerbatimArguments decisions into
+ * provider/application code.
  *
  * Unlike the Node runtime there is deliberately no `requireExecutable`: the
  * Effect spawner is injectable, so a missing executable surfaces as the
@@ -49,9 +57,12 @@ export function makeEffectProcessCommand(
     ...(env !== undefined ? { env } : {}),
   });
 
-  return ChildProcess.make(plan.command, plan.args, {
+  const effectOptions: EffectWindowsCommandOptions = {
     ...commandOptions,
     shell: false,
+    ...(plan.windowsHide ? { windowsHide: true } : {}),
     ...(plan.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
-  });
+  };
+
+  return ChildProcess.make(plan.command, plan.args, effectOptions);
 }

--- a/patches/@effect%2Fplatform-node-shared@8881a9b.patch
+++ b/patches/@effect%2Fplatform-node-shared@8881a9b.patch
@@ -2,12 +2,13 @@ diff --git a/dist/NodeChildProcessSpawner.js b/dist/NodeChildProcessSpawner.js
 index ff15212e4..e7cf12c4d 100644
 --- a/dist/NodeChildProcessSpawner.js
 +++ b/dist/NodeChildProcessSpawner.js
-@@ -314,7 +314,8 @@ const make = /*#__PURE__*/Effect.gen(function* () {
+@@ -314,7 +314,9 @@ const make = /*#__PURE__*/Effect.gen(function* () {
              env,
              stdio,
              detached: cmd.options.detached ?? process.platform !== "win32",
 -            shell: cmd.options.shell
 +            shell: cmd.options.shell,
++            windowsHide: cmd.options.windowsHide,
 +            windowsVerbatimArguments: cmd.options.windowsVerbatimArguments
            }), Effect.fnUntraced(function* ([childProcess, exitSignal]) {
              const exited = yield* Deferred.isDone(exitSignal);
@@ -16,12 +17,17 @@ diff --git a/src/NodeChildProcessSpawner.ts b/src/NodeChildProcessSpawner.ts
 index dc53bafb7..fe867fbfc 100644
 --- a/src/NodeChildProcessSpawner.ts
 +++ b/src/NodeChildProcessSpawner.ts
-@@ -430,7 +430,12 @@ const make = Effect.gen(function*() {
+@@ -430,7 +430,17 @@ const make = Effect.gen(function*() {
              env,
              stdio,
              detached: cmd.options.detached ?? process.platform !== "win32",
 -            shell: cmd.options.shell
 +            shell: cmd.options.shell,
++            windowsHide: (
++              cmd.options as ChildProcess.CommandOptions & {
++                readonly windowsHide?: boolean | undefined
++              }
++            ).windowsHide,
 +            windowsVerbatimArguments: (
 +              cmd.options as ChildProcess.CommandOptions & {
 +                readonly windowsVerbatimArguments?: boolean | undefined


### PR DESCRIPTION
## What Changed

- Preserve the shared Windows launch plan's `windowsHide` flag when building Effect commands.
- Extend the tracked `@effect/platform-node-shared` patch so the flag reaches Node's `spawn` options.
- Add a focused regression test for a Cursor-style `.ps1 --version` provider probe.

## Why

`prepareProcess` correctly marks PowerShell scripts as hidden, but `makeEffectProcessCommand` dropped that decision and the pinned Effect spawner did not forward it. Background provider probes could therefore create a visible PowerShell window and steal focus on Windows.

Fixes #943.

Related upstream fix: Effect-TS/effect#7154.

## Verification

- `bun run windows-runtime:check`
- `bun run --cwd apps/server test src/platform/effectProcessRuntime.test.ts src/windowsProcessEffect.test.ts`
- `bun run --cwd packages/shared test src/platformProcess.test.ts`
- Reinstalled dependencies with the updated tracked patch and confirmed the installed Effect spawner contains both `windowsHide` and `windowsVerbatimArguments` forwarding.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes; screenshots are not applicable
- [x] No animation or interaction changes; video is not applicable