### PR TITLE
[codex] Fix Windows Cursor and Devin detection

### DIFF
--- a/apps/server/src/provider/acp/CursorAcpCommand.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.test.ts
@@ -31,6 +31,29 @@ describe("resolveCursorAgentBinaryPath", () => {
     expect(resolveCursorAgentBinaryPath("cursor-agent")).toBe("cursor-agent");
     expect(resolveCursorAgentBinaryPath("/usr/local/bin/agent")).toBe("/usr/local/bin/agent");
   });
+
+  it("discovers native Windows Cursor Agent installs outside PATH", () => {
+    const installedPath = "C:\\Users\\me\\AppData\\Local\\cursor-agent\\agent.exe";
+    expect(
+      resolveCursorAgentBinaryPath(undefined, {
+        platform: "win32",
+        env: { LOCALAPPDATA: "C:\\Users\\me\\AppData\\Local", PATH: "C:\\Windows" },
+        pathExists: (path) => path === installedPath,
+      }),
+    ).toBe(installedPath);
+  });
+
+  it("keeps PATH precedence over the native Windows fallback", () => {
+    expect(
+      resolveCursorAgentBinaryPath(undefined, {
+        platform: "win32",
+        env: { LOCALAPPDATA: "C:\\Users\\me\\AppData\\Local", PATH: "C:\\Tools" },
+        pathExists: (path) =>
+          path.replaceAll("/", "\\") === "C:\\Tools\\cursor-agent.CMD" ||
+          path === "C:\\Users\\me\\AppData\\Local\\cursor-agent\\agent.exe",
+      }),
+    ).toBe("cursor-agent");
+  });
 });
 
 describe("buildCursorAgentCommand", () => {

--- a/apps/server/src/provider/acp/CursorAcpCommand.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.ts
@@ -11,6 +11,11 @@ import * as path from "node:path";
 
 import { executableCandidates, executableNameCandidates } from "@synara/shared/executable";
 import { buildProviderChildEnvironment } from "../../providerChildEnvironment.ts";
+import {
+  commandExistsOnPath,
+  type ProviderBinaryResolutionOptions,
+  resolveWindowsLocalAppDataBinary,
+} from "../providerBinaryResolution.ts";
 
 export const DEFAULT_CURSOR_AGENT_BINARY = "cursor-agent";
 export const LEGACY_CURSOR_AGENT_BINARY = "agent";
@@ -53,6 +58,14 @@ interface CursorCommandPathParts {
 
 const POWERSHELL_EXECUTABLE = "powershell.exe";
 const WINDOWS_CURSOR_SIBLING_EXTENSIONS = [".exe", ".cmd", ".bat", ".ps1"] as const;
+const WINDOWS_CURSOR_AGENT_RELATIVE_PATHS = [
+  ["cursor-agent", "cursor-agent.exe"],
+  ["cursor-agent", "agent.exe"],
+  ["cursor-agent", "cursor-agent.cmd"],
+  ["cursor-agent", "agent.cmd"],
+  ["cursor-agent", "cursor-agent.ps1"],
+  ["cursor-agent", "agent.ps1"],
+] as const;
 
 function splitCursorCommandPath(command: string): CursorCommandPathParts {
   const trimmed = command.trim();
@@ -223,11 +236,25 @@ function wrapPowerShellCommand(command: string, args: ReadonlyArray<string>): Cu
 }
 
 // Resolves persisted/default Cursor binary settings into the executable Synara should spawn.
-export function resolveCursorAgentBinaryPath(binaryPath: string | null | undefined): string {
+export function resolveCursorAgentBinaryPath(
+  binaryPath: string | null | undefined,
+  options: ProviderBinaryResolutionOptions = {},
+): string {
   const configuredBinaryPath = binaryPath?.trim();
-  return !configuredBinaryPath || configuredBinaryPath === LEGACY_CURSOR_AGENT_BINARY
-    ? DEFAULT_CURSOR_AGENT_BINARY
-    : configuredBinaryPath;
+  if (
+    configuredBinaryPath &&
+    configuredBinaryPath !== LEGACY_CURSOR_AGENT_BINARY &&
+    configuredBinaryPath !== DEFAULT_CURSOR_AGENT_BINARY
+  ) {
+    return configuredBinaryPath;
+  }
+  if (commandExistsOnPath(DEFAULT_CURSOR_AGENT_BINARY, options)) {
+    return DEFAULT_CURSOR_AGENT_BINARY;
+  }
+  return (
+    resolveWindowsLocalAppDataBinary(WINDOWS_CURSOR_AGENT_RELATIVE_PATHS, options) ??
+    DEFAULT_CURSOR_AGENT_BINARY
+  );
 }
 
 // Builds Cursor Agent invocations from either `cursor-agent` or the `cursor` editor launcher.
@@ -236,13 +263,13 @@ export function buildCursorAgentCommand(
   args: ReadonlyArray<string>,
   options: CursorAgentCommandOptions = {},
 ): CursorAgentCommand {
-  const command = resolveCursorAgentBinaryPath(binaryPath);
   const commandOptions = {
     env: options.env ?? process.env,
     platform: options.platform ?? process.platform,
     pathExists: options.pathExists ?? existsSync,
     realpath: options.realpath ?? realpathSync.native,
   };
+  const command = resolveCursorAgentBinaryPath(binaryPath, commandOptions);
   const editorLauncher = resolveCursorEditorLauncherCommand(command, commandOptions);
   const resolvedCommand = editorLauncher
     ? { command: editorLauncher.command, args: [...editorLauncher.args, ...args] }

--- a/apps/server/src/provider/acp/DevinAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/DevinAcpSupport.test.ts
@@ -18,6 +18,7 @@ import {
   mapDevinAcpCommands,
   normalizeDevinGetOutputToolCall,
   parseDevinCredentialsToml,
+  resolveDevinBinaryPath,
   resolveDevinAcpAuthMethodId,
   resolveDevinCredentialsPath,
   runDevinAcpCompactionCommand,
@@ -25,6 +26,33 @@ import {
 } from "./DevinAcpSupport.ts";
 
 const textEncoder = new TextEncoder();
+
+describe("resolveDevinBinaryPath", () => {
+  it("discovers native Windows Devin installs outside PATH", () => {
+    const installedPath = "C:\\Users\\me\\AppData\\Local\\devin\\cli\\bin\\devin.exe";
+    expect(
+      resolveDevinBinaryPath(undefined, {
+        platform: "win32",
+        env: { LOCALAPPDATA: "C:\\Users\\me\\AppData\\Local", PATH: "C:\\Windows" },
+        pathExists: (path) => path === installedPath,
+      }),
+    ).toBe(installedPath);
+  });
+
+  it("keeps explicit and PATH-resolved Devin commands ahead of the Windows fallback", () => {
+    const options = {
+      platform: "win32" as const,
+      env: { LOCALAPPDATA: "C:\\Users\\me\\AppData\\Local", PATH: "C:\\Tools" },
+      pathExists: (path: string) =>
+        path.replaceAll("/", "\\") === "C:\\Tools\\devin.EXE" ||
+        path === "C:\\Users\\me\\AppData\\Local\\devin\\cli\\bin\\devin.exe",
+    };
+    expect(resolveDevinBinaryPath(undefined, options)).toBe("devin");
+    expect(resolveDevinBinaryPath("C:\\Custom\\devin.exe", options)).toBe(
+      "C:\\Custom\\devin.exe",
+    );
+  });
+});
 
 type GetOutputArguments = {
   readonly shell_id: string;

--- a/apps/server/src/provider/acp/DevinAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/DevinAcpSupport.test.ts
@@ -48,9 +48,7 @@ describe("resolveDevinBinaryPath", () => {
         path === "C:\\Users\\me\\AppData\\Local\\devin\\cli\\bin\\devin.exe",
     };
     expect(resolveDevinBinaryPath(undefined, options)).toBe("devin");
-    expect(resolveDevinBinaryPath("C:\\Custom\\devin.exe", options)).toBe(
-      "C:\\Custom\\devin.exe",
-    );
+    expect(resolveDevinBinaryPath("C:\\Custom\\devin.exe", options)).toBe("C:\\Custom\\devin.exe");
   });
 });
 

--- a/apps/server/src/provider/acp/DevinAcpSupport.ts
+++ b/apps/server/src/provider/acp/DevinAcpSupport.ts
@@ -24,6 +24,11 @@ import {
   type AcpSessionRuntimeShape,
   type AcpSpawnInput,
 } from "./AcpSessionRuntime.ts";
+import {
+  commandExistsOnPath,
+  type ProviderBinaryResolutionOptions,
+  resolveWindowsLocalAppDataBinary,
+} from "../providerBinaryResolution.ts";
 
 export interface DevinAcpRuntimeSettings {
   readonly binaryPath?: string;
@@ -128,9 +133,19 @@ export function hasDevinApiKeyEnv(env: NodeJS.ProcessEnv = process.env): boolean
   return getDevinApiKeyEnv(env) !== undefined;
 }
 
-export function resolveDevinBinaryPath(binaryPath?: string | null | undefined): string {
+const WINDOWS_DEVIN_RELATIVE_PATHS = [
+  ["devin", "cli", "bin", "devin.exe"],
+  ["devin", "bin", "devin.exe"],
+] as const;
+
+export function resolveDevinBinaryPath(
+  binaryPath?: string | null | undefined,
+  options: ProviderBinaryResolutionOptions = {},
+): string {
   const trimmed = binaryPath?.trim();
-  return trimmed || "devin";
+  if (trimmed && trimmed !== "devin") return trimmed;
+  if (commandExistsOnPath("devin", options)) return "devin";
+  return resolveWindowsLocalAppDataBinary(WINDOWS_DEVIN_RELATIVE_PATHS, options) ?? "devin";
 }
 
 export function getDevinApiServerUrlEnv(env: NodeJS.ProcessEnv = process.env): string | undefined {
@@ -336,7 +351,7 @@ export function buildDevinAcpSpawnInput(
   const overrides: NodeJS.ProcessEnv = apiKey ? { WINDSURF_API_KEY: apiKey } : {};
 
   return {
-    command: devinSettings?.binaryPath || "devin",
+    command: resolveDevinBinaryPath(devinSettings?.binaryPath, { env: baseEnv }),
     args,
     cwd,
     env: buildProviderChildEnvironment({ provider: "devin", baseEnv, overrides }),

--- a/apps/server/src/provider/providerBinaryResolution.ts
+++ b/apps/server/src/provider/providerBinaryResolution.ts
@@ -1,0 +1,62 @@
+// FILE: providerBinaryResolution.ts
+// Purpose: Resolves provider CLI binaries from PATH and vendor-owned Windows install folders.
+// Layer: Server provider runtime
+
+import { existsSync } from "node:fs";
+import { win32 } from "node:path";
+
+import { executableCandidates } from "@synara/shared/executable";
+
+export interface ProviderBinaryResolutionOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly platform?: NodeJS.Platform;
+  readonly pathExists?: (path: string) => boolean;
+}
+
+interface ResolvedProviderBinaryResolutionOptions {
+  readonly env: NodeJS.ProcessEnv;
+  readonly platform: NodeJS.Platform;
+  readonly pathExists: (path: string) => boolean;
+}
+
+function resolveOptions(
+  options: ProviderBinaryResolutionOptions,
+): ResolvedProviderBinaryResolutionOptions {
+  return {
+    env: options.env ?? process.env,
+    platform: options.platform ?? process.platform,
+    pathExists: options.pathExists ?? existsSync,
+  };
+}
+
+export function commandExistsOnPath(
+  command: string,
+  options: ProviderBinaryResolutionOptions = {},
+): boolean {
+  const resolved = resolveOptions(options);
+  for (const candidate of executableCandidates(command, resolved)) {
+    if (resolved.pathExists(candidate.path)) return true;
+  }
+  return false;
+}
+
+export function resolveWindowsLocalAppDataBinary(
+  relativeCandidates: ReadonlyArray<ReadonlyArray<string>>,
+  options: ProviderBinaryResolutionOptions = {},
+): string | undefined {
+  const resolved = resolveOptions(options);
+  if (resolved.platform !== "win32") return undefined;
+
+  const localAppData =
+    resolved.env.LOCALAPPDATA?.trim() ||
+    (resolved.env.USERPROFILE?.trim()
+      ? win32.join(resolved.env.USERPROFILE.trim(), "AppData", "Local")
+      : undefined);
+  if (!localAppData) return undefined;
+
+  for (const relativePath of relativeCandidates) {
+    const candidate = win32.join(localAppData, ...relativePath);
+    if (resolved.pathExists(candidate)) return candidate;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Issue

On native Windows, Synara could report Cursor Agent and Devin CLI as not installed even when the official installers had placed them in their vendor-owned per-user directories.

This prevented affected users from enabling those providers in the picker and starting provider sessions unless they manually configured an absolute binary path or the desktop process happened to inherit the updated user `PATH`.

## Root cause

Provider discovery only attempted the configured command name through `PATH`. Windows GUI processes can retain a stale environment after a CLI installer updates the user `PATH`, while the official installers place stable entry points under `%LOCALAPPDATA%`.

Cursor currently installs launchers under `%LOCALAPPDATA%\cursor-agent`. Devin currently installs `%LOCALAPPDATA%\devin\cli\bin\devin.exe`, with `%LOCALAPPDATA%\devin\bin\devin.exe` used by the preceding layout.

## Fix

- Add one shared provider-binary resolver for normal `PATH` discovery and vendor-owned Windows `%LOCALAPPDATA%` fallbacks.
- Preserve explicit custom binary paths as the highest-priority choice.
- Preserve a working `PATH` command ahead of the Windows fallback.
- Resolve Cursor's supported `.exe`, `.cmd`, and `.ps1` launchers from its native install directory.
- Resolve both the current and preceding native Devin install layouts.
- Use the resolved Devin executable consistently for health checks, model discovery, and ACP session spawning.

## Verification

- `bun run --cwd apps/server test -- src/provider/acp/CursorAcpCommand.test.ts src/provider/acp/DevinAcpSupport.test.ts src/provider/Layers/ProviderHealth.test.ts src/provider/Layers/CursorAdapter.test.ts src/provider/Layers/DevinAdapter.test.ts`
  - 5 test files passed
  - 210 tests passed
- `git diff --check`

Full workspace formatting, lint, and typecheck were not run because repository instructions require explicit user authorization for those heavyweight checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only how provider CLI paths are resolved before spawn; explicit paths and PATH precedence are preserved, with no auth or data-handling changes.
> 
> **Overview**
> Fixes false “not installed” detection on Windows when official Cursor Agent and Devin installers put binaries under `%LOCALAPPDATA%` while the GUI process still has a stale `PATH`.
> 
> Adds shared **`providerBinaryResolution`** helpers for PATH checks and Windows `%LOCALAPPDATA%` fallbacks. **`resolveCursorAgentBinaryPath`** now probes `PATH` for `cursor-agent`, then known launchers under `%LOCALAPPDATA%\cursor-agent\` (`.exe`, `.cmd`, `.ps1`), while still honoring explicit custom paths and legacy `agent` → `cursor-agent` mapping. **`resolveDevinBinaryPath`** follows the same precedence (explicit path → `PATH` → `%LOCALAPPDATA%\devin\...`), and **`buildDevinAcpSpawnInput`** uses that resolver so ACP spawning matches discovery.
> 
> Tests cover Windows fallback discovery and that a working `PATH` entry wins over the native install path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 444425ff5b1aab8b1b81a5b2d93a6da1f96b6072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->