### PR TITLE
[codex] Use compaction icon in provider tool rows

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1214,6 +1214,7 @@ describe("MessagesTimeline", () => {
               createdAt: "2026-03-17T19:12:28.000Z",
               label: "Context compacted manually",
               tone: "info",
+              activityKind: "context-compaction",
             },
           },
         ]}
@@ -1234,6 +1235,7 @@ describe("MessagesTimeline", () => {
     );
 
     expect(markup).toContain("Context compacted manually");
+    expect(markup).toContain("/central-icons-reversed/arrows-hide.svg");
     expect(markup).not.toContain("Work log");
   });
 
@@ -1255,6 +1257,7 @@ describe("MessagesTimeline", () => {
               createdAt: "2026-03-17T19:12:28.000Z",
               label: "Compacting conversation...",
               tone: "info",
+              activityKind: "context-compaction",
             },
           },
         ]}
@@ -1275,6 +1278,7 @@ describe("MessagesTimeline", () => {
     );
 
     expect(markup).toContain("Compacting conversation...");
+    expect(markup).toContain("/central-icons-reversed/arrows-hide.svg");
     expect(markup).toContain("Working for");
     expect(markup).not.toContain("h-px flex-1 bg-border");
   });

--- a/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
+++ b/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
@@ -26,6 +26,7 @@ import {
   CheckIcon,
   CircleAlertIcon,
   CircleQuestionIcon,
+  ContextCompactionIcon,
   EyeIcon,
   GitHubIcon,
   GlobeIcon,
@@ -235,6 +236,7 @@ function workEntryIcon(workEntry: TimelineWorkEntry): LucideIcon {
   // (answer submitted) rather than the generic "info" checkmark.
   if (workEntry.activityKind === "user-input.requested") return CircleQuestionIcon;
   if (workEntry.activityKind === "user-input.resolved") return ArrowUpCircleIcon;
+  if (workEntry.activityKind === "context-compaction") return ContextCompactionIcon;
   // "Moved to background" notices read as a tray drop, not a warning check.
   if (workEntry.nativeEventType === "background_tasks_changed") return BackgroundTrayIcon;
   if (workEntry.providerContextLifecycle) {

--- a/apps/web/src/lib/icons.tsx
+++ b/apps/web/src/lib/icons.tsx
@@ -97,6 +97,7 @@ export const AppsIcon: LucideIcon = (props) => (
 );
 // Composer stacked-panel glyphs (subagent strip / workflow run card).
 export const BackgroundTrayIcon: LucideIcon = centralIconWrapper("arrow-down-wall");
+export const ContextCompactionIcon: LucideIcon = centralIconWrapper("arrows-hide");
 export const PanelExpandIcon: LucideIcon = centralIconWrapper("expand-45");
 export const PanelCollapseIcon: LucideIcon = centralIconWrapper("minimize-45");
 export const BackToParentIcon: LucideIcon = centralIconWrapper("arrow-share-left");


### PR DESCRIPTION
## Issue

Provider context-compaction activity appears in the transcript as a tool/work row, but it currently falls back to the generic informational checkmark. That makes compaction visually indistinguishable from unrelated informational events.

## Root cause

The timeline icon resolver already receives the provider-agnostic `context-compaction` activity kind, but it has no kind-specific icon mapping.

## Fix

Expose the existing Central `arrows-hide` asset through the shared icon module and select it whenever a work entry has the `context-compaction` activity kind. This covers both active compaction progress and completed compaction rows across providers without matching provider-specific labels.

## Verification

- `bun run --cwd apps/web test -- src/components/chat/MessagesTimeline.test.tsx` — 56 tests passed
- `git diff --check` — passed
- Added render assertions for active and completed compaction rows using `/central-icons-reversed/arrows-hide.svg`

The heavyweight workspace `bun fmt`, `bun lint`, and `bun typecheck` checks were not run because the repository instructions require explicit user authorization for them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only icon mapping and test updates in the chat timeline; no auth, data, or backend behavior changes.
> 
> **Overview**
> Context compaction events in the chat transcript no longer use the generic info checkmark. **Work rows** with `activityKind: "context-compaction"` now show the Central **arrows-hide** glyph (via new `ContextCompactionIcon` in the shared icons module), wired in `workEntryIcon` alongside other activity-kind-specific icons.
> 
> This applies to both finished compaction lines (e.g. “Context compacted manually”) and in-progress ones (“Compacting conversation…”) without relying on provider-specific labels. Tests assert the rendered SVG path `/central-icons-reversed/arrows-hide.svg` for those scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb5250828e67a5079e84c3333e1b7f8d11d75404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->