### PR TITLE
fix(web): prevent simulator focus stealing and allow disabling auto-open

### DIFF
--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -1060,6 +1060,16 @@ describe("AppSettingsSchema", () => {
     ).toBe(true);
   });
 
+  it("preserves a disabled simulator auto-open preference across settings persistence", () => {
+    const codec = Schema.fromJsonString(AppSettingsSchema);
+    const decode = Schema.decodeSync(codec);
+    const defaults = decode("{}");
+    expect(defaults.autoOpenDevicePane).toBe(true);
+
+    const settings = applyLocalAppSettingsPatch(defaults, { autoOpenDevicePane: false });
+    expect(decode(Schema.encodeSync(codec)(settings)).autoOpenDevicePane).toBe(false);
+  });
+
   it("fills decoding defaults for persisted settings that predate newer keys", () => {
     const decode = Schema.decodeSync(Schema.fromJsonString(AppSettingsSchema));
 

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -324,6 +324,7 @@ export const AppSettingsSchema = Schema.Struct({
   showEnvironmentNotepad: Schema.Boolean.pipe(withDefaults(() => false)),
   followUpBehavior: FollowUpBehavior.pipe(withDefaults(() => DEFAULT_FOLLOW_UP_BEHAVIOR)),
   enableAssistantStreaming: Schema.Boolean.pipe(withDefaults(() => true)),
+  autoOpenDevicePane: Schema.Boolean.pipe(withDefaults(() => true)),
   enableProviderUpdateChecks: Schema.Boolean.pipe(withDefaults(() => true)),
   enableNativeFontSmoothing: Schema.Boolean.pipe(withDefaults(getDefaultNativeFontSmoothing)),
   desktopAppIcon: DesktopAppIcon.pipe(withDefaults(() => "default" as const)),

--- a/apps/web/src/components/chat/SingleChatSurface.deviceOpenRequest.test.ts
+++ b/apps/web/src/components/chat/SingleChatSurface.deviceOpenRequest.test.ts
@@ -1,5 +1,5 @@
 import { ThreadId } from "@synara/contracts";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { routeSingleDevicePaneOpenRequest } from "./devicePaneOpenRequest";
 
@@ -9,21 +9,18 @@ const REQUESTED_THREAD_ID = ThreadId.makeUnsafe("thread-requested");
 describe("routeSingleDevicePaneOpenRequest", () => {
   it("opens the current thread pane immediately without navigating", () => {
     const calls: string[] = [];
-    const navigateToThread = vi.fn();
 
     routeSingleDevicePaneOpenRequest({
       currentThreadId: CURRENT_THREAD_ID,
       requestedThreadId: CURRENT_THREAD_ID,
       requestImmediateDeviceHydration: () => calls.push("hydrate"),
       openDevicePane: (threadId) => calls.push(`open:${threadId}`),
-      navigateToThread,
     });
 
     expect(calls).toEqual(["hydrate", `open:${CURRENT_THREAD_ID}`]);
-    expect(navigateToThread).not.toHaveBeenCalled();
   });
 
-  it("seeds the requested thread's dock before navigating to it", () => {
+  it("remembers a background thread's pane without hydrating or navigating away", () => {
     const calls: string[] = [];
 
     routeSingleDevicePaneOpenRequest({
@@ -31,27 +28,8 @@ describe("routeSingleDevicePaneOpenRequest", () => {
       requestedThreadId: REQUESTED_THREAD_ID,
       requestImmediateDeviceHydration: () => calls.push("hydrate"),
       openDevicePane: (threadId) => calls.push(`open:${threadId}`),
-      navigateToThread: (threadId) => calls.push(`navigate:${threadId}`),
     });
 
-    expect(calls).toEqual([
-      "hydrate",
-      `open:${REQUESTED_THREAD_ID}`,
-      `navigate:${REQUESTED_THREAD_ID}`,
-    ]);
-  });
-
-  it("hydrates before opening so an agent request never waits on a suspended frame", () => {
-    const calls: string[] = [];
-
-    routeSingleDevicePaneOpenRequest({
-      currentThreadId: CURRENT_THREAD_ID,
-      requestedThreadId: CURRENT_THREAD_ID,
-      requestImmediateDeviceHydration: () => calls.push("hydrate"),
-      openDevicePane: () => calls.push("open"),
-      navigateToThread: () => calls.push("navigate"),
-    });
-
-    expect(calls[0]).toBe("hydrate");
+    expect(calls).toEqual([`open:${REQUESTED_THREAD_ID}`]);
   });
 });

--- a/apps/web/src/components/chat/SingleChatSurface.deviceOpenRequest.test.ts
+++ b/apps/web/src/components/chat/SingleChatSurface.deviceOpenRequest.test.ts
@@ -11,7 +11,6 @@ describe("routeSingleDevicePaneOpenRequest", () => {
     const calls: string[] = [];
 
     routeSingleDevicePaneOpenRequest({
-      autoOpenDevicePane: true,
       currentThreadId: CURRENT_THREAD_ID,
       requestedThreadId: CURRENT_THREAD_ID,
       requestImmediateDeviceHydration: () => calls.push("hydrate"),
@@ -25,7 +24,6 @@ describe("routeSingleDevicePaneOpenRequest", () => {
     const calls: string[] = [];
 
     routeSingleDevicePaneOpenRequest({
-      autoOpenDevicePane: true,
       currentThreadId: CURRENT_THREAD_ID,
       requestedThreadId: REQUESTED_THREAD_ID,
       requestImmediateDeviceHydration: () => calls.push("hydrate"),
@@ -34,21 +32,4 @@ describe("routeSingleDevicePaneOpenRequest", () => {
 
     expect(calls).toEqual([`open:${REQUESTED_THREAD_ID}`]);
   });
-
-  it.each([CURRENT_THREAD_ID, REQUESTED_THREAD_ID])(
-    "does not reopen or remember a pane for %s when automatic opening is disabled",
-    (requestedThreadId) => {
-      const calls: string[] = [];
-
-      routeSingleDevicePaneOpenRequest({
-        autoOpenDevicePane: false,
-        currentThreadId: CURRENT_THREAD_ID,
-        requestedThreadId,
-        requestImmediateDeviceHydration: () => calls.push("hydrate"),
-        openDevicePane: (threadId) => calls.push(`open:${threadId}`),
-      });
-
-      expect(calls).toEqual([]);
-    },
-  );
 });

--- a/apps/web/src/components/chat/SingleChatSurface.deviceOpenRequest.test.ts
+++ b/apps/web/src/components/chat/SingleChatSurface.deviceOpenRequest.test.ts
@@ -11,6 +11,7 @@ describe("routeSingleDevicePaneOpenRequest", () => {
     const calls: string[] = [];
 
     routeSingleDevicePaneOpenRequest({
+      autoOpenDevicePane: true,
       currentThreadId: CURRENT_THREAD_ID,
       requestedThreadId: CURRENT_THREAD_ID,
       requestImmediateDeviceHydration: () => calls.push("hydrate"),
@@ -24,6 +25,7 @@ describe("routeSingleDevicePaneOpenRequest", () => {
     const calls: string[] = [];
 
     routeSingleDevicePaneOpenRequest({
+      autoOpenDevicePane: true,
       currentThreadId: CURRENT_THREAD_ID,
       requestedThreadId: REQUESTED_THREAD_ID,
       requestImmediateDeviceHydration: () => calls.push("hydrate"),
@@ -32,4 +34,21 @@ describe("routeSingleDevicePaneOpenRequest", () => {
 
     expect(calls).toEqual([`open:${REQUESTED_THREAD_ID}`]);
   });
+
+  it.each([CURRENT_THREAD_ID, REQUESTED_THREAD_ID])(
+    "does not reopen or remember a pane for %s when automatic opening is disabled",
+    (requestedThreadId) => {
+      const calls: string[] = [];
+
+      routeSingleDevicePaneOpenRequest({
+        autoOpenDevicePane: false,
+        currentThreadId: CURRENT_THREAD_ID,
+        requestedThreadId,
+        requestImmediateDeviceHydration: () => calls.push("hydrate"),
+        openDevicePane: (threadId) => calls.push(`open:${threadId}`),
+      });
+
+      expect(calls).toEqual([]);
+    },
+  );
 });

--- a/apps/web/src/components/chat/SingleChatSurface.tsx
+++ b/apps/web/src/components/chat/SingleChatSurface.tsx
@@ -24,7 +24,7 @@ import { readEditorViewState, storeEditorViewState } from "../../editorViewState
 import { useBrowserPanelDesktopBridge } from "../../hooks/useBrowserPanelDesktopBridge";
 import { useDockPaneRuntimeActivation } from "../../hooks/useDockPaneRuntimeActivation";
 import { useHandleNewThread } from "../../hooks/useHandleNewThread";
-import { useDeviceEventBridge } from "../../hooks/useDeviceEventBridge";
+import { useDevicePaneOpenRequests } from "../../hooks/useDeviceEventBridge";
 import { useDeviceSupport } from "../../hooks/useDeviceSupport";
 import { useRepoDiffTotals } from "../../hooks/useRepoDiffTotals";
 import {
@@ -646,18 +646,18 @@ export function SingleChatSurface(props: {
     },
   });
 
-  useDeviceEventBridge({
-    onOpenPaneRequested: hasDeviceSupport
-      ? (event) => {
-          routeSingleDevicePaneOpenRequest({
-            autoOpenDevicePane: appSettings.autoOpenDevicePane,
-            currentThreadId: props.threadId,
-            requestedThreadId: event.threadId,
-            requestImmediateDeviceHydration: () => requestImmediateDockHydration("device"),
-            openDevicePane: (threadId) => openPane(threadId, { kind: "device" }),
-          });
-        }
-      : null,
+  useDevicePaneOpenRequests({
+    onOpenPaneRequested:
+      hasDeviceSupport && appSettings.autoOpenDevicePane
+        ? (event) => {
+            routeSingleDevicePaneOpenRequest({
+              currentThreadId: props.threadId,
+              requestedThreadId: event.threadId,
+              requestImmediateDeviceHydration: () => requestImmediateDockHydration("device"),
+              openDevicePane: (threadId) => openPane(threadId, { kind: "device" }),
+            });
+          }
+        : null,
   });
 
   const excludedThreadIds = new Set<ThreadId>([props.threadId]);

--- a/apps/web/src/components/chat/SingleChatSurface.tsx
+++ b/apps/web/src/components/chat/SingleChatSurface.tsx
@@ -650,6 +650,7 @@ export function SingleChatSurface(props: {
     onOpenPaneRequested: hasDeviceSupport
       ? (event) => {
           routeSingleDevicePaneOpenRequest({
+            autoOpenDevicePane: appSettings.autoOpenDevicePane,
             currentThreadId: props.threadId,
             requestedThreadId: event.threadId,
             requestImmediateDeviceHydration: () => requestImmediateDockHydration("device"),

--- a/apps/web/src/components/chat/SingleChatSurface.tsx
+++ b/apps/web/src/components/chat/SingleChatSurface.tsx
@@ -654,13 +654,6 @@ export function SingleChatSurface(props: {
             requestedThreadId: event.threadId,
             requestImmediateDeviceHydration: () => requestImmediateDockHydration("device"),
             openDevicePane: (threadId) => openPane(threadId, { kind: "device" }),
-            navigateToThread: (threadId) => {
-              void navigate({
-                to: "/$threadId",
-                params: { threadId },
-                replace: true,
-              });
-            },
           });
         }
       : null,

--- a/apps/web/src/components/chat/SplitChatSurface.tsx
+++ b/apps/web/src/components/chat/SplitChatSurface.tsx
@@ -30,7 +30,6 @@ import {
   useFloatingBrowserRequestStore,
 } from "./floatingBrowserRequestStore";
 import { useBrowserPanelDesktopBridge } from "../../hooks/useBrowserPanelDesktopBridge";
-import { useDeviceEventBridge } from "../../hooks/useDeviceEventBridge";
 import { useHandleNewChat } from "../../hooks/useHandleNewChat";
 import type { ChatRightPanel } from "../../diffRouteSearch";
 import { stripDiffSearchParams } from "../../diffRouteSearch";
@@ -769,12 +768,6 @@ export function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadI
         }
       : null,
   });
-
-  // Split view has no device panel yet: ChatRightPanel is browser|diff, so
-  // there is nowhere to open one. The bridge still runs with a null open
-  // handler because its other half keeps device state fresh, which the pane on
-  // a single-surface tab and the composer screenshot both read.
-  useDeviceEventBridge({ onOpenPaneRequested: null });
 
   const closeFloatingBrowser = (threadId: ThreadId) => {
     dismissFloatingBrowserForThread(threadId);

--- a/apps/web/src/components/chat/devicePaneOpenRequest.ts
+++ b/apps/web/src/components/chat/devicePaneOpenRequest.ts
@@ -5,25 +5,18 @@ interface SingleDevicePaneOpenRequestInput {
   readonly requestedThreadId: ThreadId;
   readonly requestImmediateDeviceHydration: () => void;
   readonly openDevicePane: (threadId: ThreadId) => void;
-  readonly navigateToThread: (threadId: ThreadId) => void;
 }
 
 /**
- * Mirrors routeSingleBrowserPanelOpenRequest. The event carries its own thread
- * so an agent launching an app on a background thread cannot yank the pane away
- * from whatever the user is currently reading — the dock is seeded there and the
- * route follows.
+ * Remember the pane on its owning thread so background simulator activity never
+ * changes the user's current chat. The device runtime stays attached server-side.
  */
 export function routeSingleDevicePaneOpenRequest(input: SingleDevicePaneOpenRequestInput): void {
-  // Agent-triggered opens must not wait for rAF, which Chromium suspends for
-  // backgrounded windows.
-  input.requestImmediateDeviceHydration();
-
   if (input.requestedThreadId === input.currentThreadId) {
-    input.openDevicePane(input.currentThreadId);
-    return;
+    // Only hydrate the visible thread. Same-thread requests must not wait for
+    // rAF, which Chromium suspends for backgrounded windows.
+    input.requestImmediateDeviceHydration();
   }
 
   input.openDevicePane(input.requestedThreadId);
-  input.navigateToThread(input.requestedThreadId);
 }

--- a/apps/web/src/components/chat/devicePaneOpenRequest.ts
+++ b/apps/web/src/components/chat/devicePaneOpenRequest.ts
@@ -1,7 +1,6 @@
 import type { ThreadId } from "@synara/contracts";
 
 interface SingleDevicePaneOpenRequestInput {
-  readonly autoOpenDevicePane: boolean;
   readonly currentThreadId: ThreadId;
   readonly requestedThreadId: ThreadId;
   readonly requestImmediateDeviceHydration: () => void;
@@ -13,10 +12,6 @@ interface SingleDevicePaneOpenRequestInput {
  * changes the user's current chat. The device runtime stays attached server-side.
  */
 export function routeSingleDevicePaneOpenRequest(input: SingleDevicePaneOpenRequestInput): void {
-  if (!input.autoOpenDevicePane) {
-    return;
-  }
-
   if (input.requestedThreadId === input.currentThreadId) {
     // Only hydrate the visible thread. Same-thread requests must not wait for
     // rAF, which Chromium suspends for backgrounded windows.

--- a/apps/web/src/components/chat/devicePaneOpenRequest.ts
+++ b/apps/web/src/components/chat/devicePaneOpenRequest.ts
@@ -1,6 +1,7 @@
 import type { ThreadId } from "@synara/contracts";
 
 interface SingleDevicePaneOpenRequestInput {
+  readonly autoOpenDevicePane: boolean;
   readonly currentThreadId: ThreadId;
   readonly requestedThreadId: ThreadId;
   readonly requestImmediateDeviceHydration: () => void;
@@ -12,6 +13,10 @@ interface SingleDevicePaneOpenRequestInput {
  * changes the user's current chat. The device runtime stays attached server-side.
  */
 export function routeSingleDevicePaneOpenRequest(input: SingleDevicePaneOpenRequestInput): void {
+  if (!input.autoOpenDevicePane) {
+    return;
+  }
+
   if (input.requestedThreadId === input.currentThreadId) {
     // Only hydrate the visible thread. Same-thread requests must not wait for
     // rAF, which Chromium suspends for backgrounded windows.

--- a/apps/web/src/deviceStateStore.test.ts
+++ b/apps/web/src/deviceStateStore.test.ts
@@ -1,4 +1,8 @@
-import type { DeviceUdid, ThreadDeviceState } from "@synara/contracts";
+import type {
+  DeviceOpenPaneRequestedEvent,
+  DeviceUdid,
+  ThreadDeviceState,
+} from "@synara/contracts";
 import { ThreadId } from "@synara/contracts";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -6,6 +10,18 @@ import { selectThreadDeviceState, useDeviceStateStore } from "./deviceStateStore
 
 const THREAD_ID = ThreadId.makeUnsafe("thread-device-1");
 const OTHER_THREAD_ID = ThreadId.makeUnsafe("thread-device-2");
+
+function openRequest(
+  overrides: Partial<DeviceOpenPaneRequestedEvent> = {},
+): DeviceOpenPaneRequestedEvent {
+  return {
+    type: "device.open-pane-requested",
+    threadId: THREAD_ID,
+    udid: "udid-1" as DeviceUdid,
+    reason: "agent-tool",
+    ...overrides,
+  };
+}
 
 function threadState(overrides: Partial<ThreadDeviceState> = {}): ThreadDeviceState {
   return {
@@ -106,5 +122,44 @@ describe("deviceStateStore version gating", () => {
     useDeviceStateStore.getState().upsertThreadState(threadState({ version: 1 }));
 
     expect(selectThreadDeviceState(THREAD_ID)(useDeviceStateStore.getState())?.version).toBe(1);
+  });
+});
+
+describe("deferred device pane requests", () => {
+  it("keeps the latest request per thread and consumes each once", () => {
+    const store = useDeviceStateStore.getState();
+    const latest = openRequest({ udid: "udid-2" as DeviceUdid });
+    const other = openRequest({ threadId: OTHER_THREAD_ID });
+    store.queueOpenRequest(openRequest());
+    store.queueOpenRequest(other);
+    store.queueOpenRequest(latest);
+
+    expect(store.takeOpenRequests()).toEqual([latest, other]);
+    expect(store.takeOpenRequests()).toEqual([]);
+  });
+
+  it("cancels a detached device's pending request but ignores stale detach snapshots", () => {
+    const store = useDeviceStateStore.getState();
+    store.upsertThreadState(
+      threadState({ version: 2, attachedDeviceUdid: "udid-1" as DeviceUdid }),
+    );
+    store.queueOpenRequest(openRequest());
+    store.upsertThreadState(threadState({ version: 1, attachedDeviceUdid: null }));
+    expect(useDeviceStateStore.getState().pendingOpenRequests[THREAD_ID]).toEqual(openRequest());
+
+    store.upsertThreadState(threadState({ version: 3, attachedDeviceUdid: null }));
+    expect(store.takeOpenRequests()).toEqual([]);
+  });
+
+  it("removes pending requests with their thread or server state", () => {
+    const store = useDeviceStateStore.getState();
+    store.queueOpenRequest(openRequest());
+    store.queueOpenRequest(openRequest({ threadId: OTHER_THREAD_ID }));
+    store.removeThreadState(THREAD_ID);
+    expect(useDeviceStateStore.getState().pendingOpenRequests[THREAD_ID]).toBeUndefined();
+    expect(useDeviceStateStore.getState().pendingOpenRequests[OTHER_THREAD_ID]).toBeDefined();
+
+    store.clear();
+    expect(store.takeOpenRequests()).toEqual([]);
   });
 });

--- a/apps/web/src/deviceStateStore.ts
+++ b/apps/web/src/deviceStateStore.ts
@@ -1,28 +1,44 @@
 /**
- * Thread-scoped device metadata cache.
+ * Thread-scoped device metadata and deferred pane requests.
  *
  * The live simulator surface is a canvas fed by binary frames; this store keeps
- * only the metadata the pane chrome needs (device list, attachment, agent
+ * the metadata the pane chrome needs (device list, attachment, agent
  * activity, availability) so a thread switch renders instantly and a late push
- * can never roll the pane back to an older generation.
+ * can never roll the pane back to an older generation. Open requests wait here
+ * until a chat surface can honor the user's automatic-opening preference.
  *
  * Deliberately not persisted: device boot state is only meaningful while the
  * server that reported it is alive, and a stale "Booted" from last week's
  * session would render a picker that lies.
  */
 
-import type { ThreadDeviceState, ThreadId } from "@synara/contracts";
+import type { DeviceOpenPaneRequestedEvent, ThreadDeviceState, ThreadId } from "@synara/contracts";
 import { create } from "zustand";
 
 interface DeviceStateStore {
   threadStatesByThreadId: Record<string, ThreadDeviceState | undefined>;
+  pendingOpenRequests: Record<string, DeviceOpenPaneRequestedEvent | undefined>;
+  queueOpenRequest: (event: DeviceOpenPaneRequestedEvent) => void;
+  takeOpenRequests: () => DeviceOpenPaneRequestedEvent[];
   upsertThreadState: (state: ThreadDeviceState) => void;
   removeThreadState: (threadId: ThreadId) => void;
   clear: () => void;
 }
 
-export const useDeviceStateStore = create<DeviceStateStore>()((set) => ({
+export const useDeviceStateStore = create<DeviceStateStore>()((set, get) => ({
   threadStatesByThreadId: {},
+  pendingOpenRequests: {},
+  queueOpenRequest: (event) =>
+    set((current) => ({
+      pendingOpenRequests: { ...current.pendingOpenRequests, [event.threadId]: event },
+    })),
+  takeOpenRequests: () => {
+    const requests = Object.values(get().pendingOpenRequests).filter(
+      (event) => event !== undefined,
+    );
+    if (requests.length > 0) set({ pendingOpenRequests: {} });
+    return requests;
+  },
   upsertThreadState: (state) =>
     set((current) => {
       const previousState = current.threadStatesByThreadId[state.threadId];
@@ -33,7 +49,15 @@ export const useDeviceStateStore = create<DeviceStateStore>()((set) => ({
       if (previousState && previousState.version >= state.version) {
         return current;
       }
+      // Detach, shutdown and thread removal cancel a deferred open. Keep this
+      // behind the version gate so a late snapshot cannot discard a new request.
+      let pendingOpenRequests = current.pendingOpenRequests;
+      if (state.attachedDeviceUdid === null && pendingOpenRequests[state.threadId]) {
+        pendingOpenRequests = { ...pendingOpenRequests };
+        delete pendingOpenRequests[state.threadId];
+      }
       return {
+        pendingOpenRequests,
         threadStatesByThreadId: {
           ...current.threadStatesByThreadId,
           [state.threadId]: state,
@@ -42,14 +66,19 @@ export const useDeviceStateStore = create<DeviceStateStore>()((set) => ({
     }),
   removeThreadState: (threadId) =>
     set((current) => {
-      if (!Object.hasOwn(current.threadStatesByThreadId, threadId)) {
+      if (
+        !Object.hasOwn(current.threadStatesByThreadId, threadId) &&
+        !Object.hasOwn(current.pendingOpenRequests, threadId)
+      ) {
         return current;
       }
       const nextThreadStatesByThreadId = { ...current.threadStatesByThreadId };
       delete nextThreadStatesByThreadId[threadId];
-      return { threadStatesByThreadId: nextThreadStatesByThreadId };
+      const pendingOpenRequests = { ...current.pendingOpenRequests };
+      delete pendingOpenRequests[threadId];
+      return { threadStatesByThreadId: nextThreadStatesByThreadId, pendingOpenRequests };
     }),
-  clear: () => set({ threadStatesByThreadId: {} }),
+  clear: () => set({ threadStatesByThreadId: {}, pendingOpenRequests: {} }),
 }));
 
 // Dev-only handle so the pane's availability and setup states — which otherwise

--- a/apps/web/src/hooks/useDeviceEventBridge.browser.tsx
+++ b/apps/web/src/hooks/useDeviceEventBridge.browser.tsx
@@ -1,0 +1,156 @@
+import type { DeviceEvent, DeviceUdid, ThreadDeviceState } from "@synara/contracts";
+import { ThreadId } from "@synara/contracts";
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+const transport = vi.hoisted(() => ({
+  listener: null as ((event: DeviceEvent) => void) | null,
+  unsubscribe: vi.fn(),
+}));
+
+vi.mock("~/nativeApi", () => ({
+  ensureNativeApi: () => ({
+    device: {
+      onEvent: (listener: (event: DeviceEvent) => void) => {
+        transport.listener = listener;
+        return () => {
+          transport.listener = null;
+          transport.unsubscribe();
+        };
+      },
+    },
+  }),
+}));
+
+import { routeSingleDevicePaneOpenRequest } from "~/components/chat/devicePaneOpenRequest";
+import { useDeviceStateStore } from "~/deviceStateStore";
+import { selectRightDockState, useRightDockStore } from "~/rightDockStore";
+import { useDeviceEventBridge, useDevicePaneOpenRequests } from "./useDeviceEventBridge";
+
+const THREAD_A = ThreadId.makeUnsafe("thread-a");
+const THREAD_B = ThreadId.makeUnsafe("thread-b");
+const hydrate = vi.fn();
+
+function ChatSurface({ enabled, threadId }: { enabled: boolean; threadId: ThreadId }) {
+  const dock = useRightDockStore(selectRightDockState(threadId));
+  const devicePane = dock.panes.find((pane) => pane.kind === "device");
+  useDevicePaneOpenRequests({
+    onOpenPaneRequested: enabled
+      ? (event) =>
+          routeSingleDevicePaneOpenRequest({
+            currentThreadId: threadId,
+            requestedThreadId: event.threadId,
+            requestImmediateDeviceHydration: hydrate,
+            openDevicePane: (owner) =>
+              useRightDockStore.getState().openPane(owner, { kind: "device" }),
+          })
+      : null,
+  });
+  return (
+    <>
+      <p>Current thread: {threadId}</p>
+      {dock.open && devicePane ? (
+        <button onClick={() => useRightDockStore.getState().closePane(threadId, devicePane.id)}>
+          Close simulator pane
+        </button>
+      ) : null}
+    </>
+  );
+}
+
+function Harness() {
+  useDeviceEventBridge();
+  const [enabled, setEnabled] = useState(false);
+  const [showChat, setShowChat] = useState(true);
+  const [threadId, setThreadId] = useState(THREAD_A);
+  return (
+    <>
+      <button onClick={() => setEnabled(!enabled)}>{enabled ? "Disable" : "Enable"}</button>
+      <button onClick={() => setShowChat(!showChat)}>
+        {showChat ? "Settings" : "Return to chat"}
+      </button>
+      <button onClick={() => setThreadId(THREAD_B)}>View thread B</button>
+      {showChat ? <ChatSurface enabled={enabled} threadId={threadId} /> : null}
+    </>
+  );
+}
+
+function emitOpen(threadId = THREAD_A) {
+  transport.listener?.({
+    type: "device.open-pane-requested",
+    threadId,
+    udid: "device-1" as DeviceUdid,
+    reason: "agent-launch",
+  });
+}
+
+beforeEach(() => {
+  useDeviceStateStore.getState().clear();
+  useRightDockStore.setState({ dockStateByThreadId: {} });
+  transport.unsubscribe.mockClear();
+  hydrate.mockClear();
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("device pane request delivery", () => {
+  it("replays an ignored request once after enabling and respects a later manual close", async () => {
+    const mounted = await render(<Harness />);
+    const state = {
+      threadId: THREAD_A,
+      version: 1,
+      attachedDeviceUdid: "device-1" as DeviceUdid,
+      devices: [],
+      agentActive: true,
+      availability: { kind: "available" },
+      lastError: null,
+    } satisfies ThreadDeviceState;
+    transport.listener?.({ type: "device.thread-state", state });
+    emitOpen();
+    expect(useDeviceStateStore.getState().threadStatesByThreadId[THREAD_A]).toEqual(state);
+    await expect
+      .element(mounted.getByRole("button", { name: "Close simulator pane" }))
+      .not.toBeInTheDocument();
+    expect(hydrate).not.toHaveBeenCalled();
+
+    // There is no second server request: DeviceManager suppresses it for this device.
+    await mounted.getByRole("button", { name: "Enable", exact: true }).click();
+    await expect
+      .element(mounted.getByRole("button", { name: "Close simulator pane" }))
+      .toBeVisible();
+    expect(hydrate).toHaveBeenCalledOnce();
+    await mounted.getByRole("button", { name: "Close simulator pane" }).click();
+    await mounted.getByRole("button", { name: "Disable", exact: true }).click();
+    await mounted.getByRole("button", { name: "Enable", exact: true }).click();
+    await mounted.getByRole("button", { name: "Settings", exact: true }).click();
+    await mounted.getByRole("button", { name: "Return to chat" }).click();
+    await expect
+      .element(mounted.getByRole("button", { name: "Close simulator pane" }))
+      .not.toBeInTheDocument();
+    expect(hydrate).toHaveBeenCalledOnce();
+    await mounted.unmount();
+    expect(transport.unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it("captures requests during settings and restores the owning thread without switching chats", async () => {
+    const mounted = await render(<Harness />);
+    await mounted.getByRole("button", { name: "Settings", exact: true }).click();
+    emitOpen(THREAD_B);
+    await mounted.getByRole("button", { name: "Enable", exact: true }).click();
+    await mounted.getByRole("button", { name: "Return to chat" }).click();
+    await expect.element(mounted.getByText("Current thread: thread-a")).toBeVisible();
+    await expect
+      .element(mounted.getByRole("button", { name: "Close simulator pane" }))
+      .not.toBeInTheDocument();
+    expect(hydrate).not.toHaveBeenCalled();
+
+    await mounted.getByRole("button", { name: "View thread B" }).click();
+    await expect
+      .element(mounted.getByRole("button", { name: "Close simulator pane" }))
+      .toBeVisible();
+    await mounted.unmount();
+  });
+});

--- a/apps/web/src/hooks/useDeviceEventBridge.ts
+++ b/apps/web/src/hooks/useDeviceEventBridge.ts
@@ -1,7 +1,7 @@
 // FILE: useDeviceEventBridge.ts
-// Purpose: Route the server's device.event push into the device state store and the dock.
+// Purpose: Capture device events globally and deliver deferred pane requests to a chat surface.
 // Layer: Web event bridge hook
-// Exports: useDeviceEventBridge
+// Exports: useDeviceEventBridge, useDevicePaneOpenRequests
 // Depends on: nativeApi device.onEvent, deviceStateStore
 //
 // The browser pane gets its open requests over desktop IPC; the device engine
@@ -14,29 +14,37 @@ import { useEffect, useEffectEvent } from "react";
 import { ensureNativeApi } from "~/nativeApi";
 import { useDeviceStateStore } from "../deviceStateStore";
 
-export function useDeviceEventBridge(input: {
-  /** Null while the surface cannot host a device pane (non-macOS server). */
+/** Mounted once by EventRouter, including while settings or split view is open. */
+export function useDeviceEventBridge(): void {
+  useEffect(() => {
+    const unsubscribe = ensureNativeApi().device.onEvent((event) => {
+      const store = useDeviceStateStore.getState();
+      if (event.type === "device.thread-state") {
+        store.upsertThreadState(event.state);
+      } else {
+        // The server sends this once per thread/device. Retain it until a
+        // surface can honor it, even if automatic opening is currently off.
+        store.queueOpenRequest(event);
+      }
+    });
+    return unsubscribe;
+  }, []);
+}
+
+export function useDevicePaneOpenRequests(input: {
+  /** Null while automatic opening is disabled or the surface cannot host a device pane. */
   readonly onOpenPaneRequested: ((event: DeviceOpenPaneRequestedEvent) => void) | null;
 }): void {
-  const { onOpenPaneRequested } = input;
-  const handleOpen = useEffectEvent((event: DeviceOpenPaneRequestedEvent) =>
-    onOpenPaneRequested?.(event),
-  );
-  const openEnabled = onOpenPaneRequested !== null;
+  const pendingOpenRequests = useDeviceStateStore((store) => store.pendingOpenRequests);
+  const openEnabled = input.onOpenPaneRequested !== null;
+  const deliverPendingRequests = useEffectEvent(() => {
+    const onOpen = input.onOpenPaneRequested;
+    if (!onOpen) return;
+    // Consume before delivery so remounting or closing a pane never replays it.
+    for (const event of useDeviceStateStore.getState().takeOpenRequests()) onOpen(event);
+  });
 
   useEffect(() => {
-    // The state half of the subscription runs regardless of whether this surface
-    // can open panes: a pane on another thread still needs fresh state, and the
-    // store is version-gated so duplicate delivery is harmless.
-    const unsubscribe = ensureNativeApi().device.onEvent((event) => {
-      if (event.type === "device.thread-state") {
-        useDeviceStateStore.getState().upsertThreadState(event.state);
-        return;
-      }
-      if (openEnabled) handleOpen(event);
-    });
-    return () => {
-      unsubscribe();
-    };
-  }, [openEnabled]);
+    if (openEnabled) deliverPendingRequests();
+  }, [openEnabled, pendingOpenRequests]);
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -123,6 +123,7 @@ import {
   runEmptyRouteRestoreRefresh,
 } from "../routeRestoreRefreshCoordinator";
 import { useDiffRouteSearch } from "../hooks/useDiffRouteSearch";
+import { useDeviceEventBridge } from "../hooks/useDeviceEventBridge";
 import {
   PROVIDER_AUTH_REFRESH_MIN_INTERVAL_MS,
   useProviderAuthRefreshOnFocus,
@@ -1061,6 +1062,7 @@ function releaseOrphanedThreadDetail(input: {
 }
 
 function EventRouter() {
+  useDeviceEventBridge();
   const syncServerShellSnapshot = useStore((store) => store.syncServerShellSnapshot);
   const syncServerThreadDetailHotPath = useStore((store) => store.syncServerThreadDetailHotPath);
   const applyShellEvent = useStore((store) => store.applyShellEvent);

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -342,6 +342,9 @@ function SettingsRouteView() {
       ? ["Assistant output"]
       : []),
     ...(settings.followUpBehavior !== defaults.followUpBehavior ? ["Follow-up behavior"] : []),
+    ...(settings.autoOpenDevicePane !== defaults.autoOpenDevicePane
+      ? ["Automatically open simulator"]
+      : []),
     ...(settings.enableAppSnap !== defaults.enableAppSnap ? ["AppSnap"] : []),
     ...(!sameAppSnapShortcut(settings.appSnapShortcut, defaults.appSnapShortcut)
       ? ["AppSnap shortcut"]
@@ -1146,6 +1149,15 @@ function SettingsRouteView() {
           description: "Show token-by-token output while a response is in progress.",
           resetLabel: "assistant output",
           ariaLabel: "Stream assistant messages",
+        })}
+
+        {renderBooleanSettingRow({
+          settingKey: "autoOpenDevicePane",
+          title: "Automatically open simulator",
+          description:
+            "Open the iOS Simulator pane when an agent uses a device. Turn this off to use Simulator.app without the mirrored pane reopening. You can still open the pane manually.",
+          resetLabel: "automatically open simulator",
+          ariaLabel: "Automatically open simulator",
         })}
       </SettingsSection>
 

--- a/apps/web/src/settingsSearchIndex.ts
+++ b/apps/web/src/settingsSearchIndex.ts
@@ -288,6 +288,13 @@ export const SETTINGS_SEARCH_ENTRIES: readonly SettingsSearchEntry[] = [
     keywords: "Show token-by-token output while a response is in progress. streaming",
   },
   {
+    id: "behavior:auto-open-simulator",
+    section: "behavior",
+    title: "Automatically open simulator",
+    keywords:
+      "Disable automatic iOS Simulator device pane opening. Use Simulator.app without the mirrored panel reopening. background launch",
+  },
+  {
     id: "behavior:diff-line-wrapping",
     section: "behavior",
     title: "Diff line wrapping",


### PR DESCRIPTION
## What Changed

Simulator activity no longer switches the active chat. A new **Settings → Chat behavior → Automatically open simulator** switch lets users stop Synara's mirrored pane from reopening while they use Simulator.app separately.

- Enabled: requests open the pane on their owning thread. Only the visible thread is hydrated immediately; background requests never navigate.
- Disabled: requests leave the dock alone while device metadata and server-side execution continue. Manual opening remains available.
- Re-enabled: the latest unhandled request for each thread is delivered once. Requests are captured at the app level, including while Settings or split view is open, because the server suppresses repeated requests for the same thread/device.
- Handled requests are consumed before opening, so manually closing the pane or revisiting Settings does not replay them. Detach, thread removal, and server reset cancel pending requests.

The preference defaults to enabled, persists locally across reloads, and supports settings search and reset.

## Why

The previous device handler navigated to the simulator thread before opening its dock. Removing that navigation prevents focus stealing. Separating the app-wide device subscription from pane delivery also avoids losing the server's one-time request when automatic opening is disabled or the chat surface is unmounted.

This behavior originated in merged PR #529. Open PR #820 refactors the same routing helpers and will need to preserve this behavior when resolving the overlap.

## Verification

- 115 focused web tests passed across device state, request routing, app settings, and dock state.
- Two Chromium integration tests passed for enabling without a second server request, manual close, Settings navigation, and background-thread ownership.
- Existing EventRouter Chromium suite: 21 passed, one skipped.
- All 70 device-manager tests passed, including one-time pane request suppression.
- Changed-file formatting and `git diff --check` passed.
- The setting was checked in a real, isolated app instance: it fits a narrow window and remains disabled after reload.
- On head `4f783a430`, CI format, lint, typecheck, desktop build, migration lineage, and release smoke passed. Full unit, browser, Windows regression, and Cursor review are pending.
- No live iOS Simulator reproduction was performed. Full workspace format, lint, and typecheck were run by CI rather than locally, per repository instructions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chat navigation, dock pane lifecycle, and global device event routing; behavior is well covered by new store/routing/browser tests but incorrect queue/consume logic could miss or duplicate one-time server open signals.
> 
> **Overview**
> Adds a persisted **Automatically open simulator** preference (`autoOpenDevicePane`, default on) under Chat behavior, with settings search/reset coverage and encode/decode tests.
> 
> **Focus and routing:** Agent-driven simulator opens no longer navigate to the owning thread. `routeSingleDevicePaneOpenRequest` only immediate-hydrates when the request targets the visible thread; background activity still seeds the device pane on its thread without pulling the user off their current chat.
> 
> **Event delivery:** Device WebSocket handling splits into a root `EventRouter` subscription (`useDeviceEventBridge`) that always updates thread state and **queues** one open request per thread, and chat-surface `useDevicePaneOpenRequests` that consumes the queue only when auto-open is enabled and the surface can host a pane. Pending requests replay once after re-enabling, are cleared on detach/thread removal, and are not replayed after manual close or settings trips. Split view drops its local bridge hook in favor of the global capture path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f783a43044f60708c5f1bbc9a8a89725d59cf04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->