### PR TITLE
fix(ci): run PR size label sync before labeling

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -57,7 +57,6 @@ jobs:
   sync-label-definitions:
     name: Sync PR size label definitions
     needs: prepare-config
-    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -113,7 +112,7 @@ jobs:
             }
   label:
     name: Label PR size
-    needs: prepare-config
+    needs: [prepare-config, sync-label-definitions]
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
Fixes #991

## Summary

- The `Sync PR size label definitions` job in `.github/workflows/pr-size.yml` is currently skipped because its `if: github.event_name != 'pull_request_target'` condition is impossible: the workflow only triggers on `pull_request_target`.
- This means the `size:*` labels are never created or updated by the workflow, so they drift from the definitions in the workflow file.
- The fix removes the impossible condition and makes `Label PR size` depend on `Sync PR size label definitions` so the labels are guaranteed to exist before the PR is labeled.

#### Test plan

- [x] `bun fmt`, `bun lint`, and `bun typecheck` passed in the worktree.
- [ ] After merge, the next pull request should show the `Sync PR size label definitions` job running and the `size:*` labels updating to match the workflow definitions.

Generated with [Devin](https://devin.ai)