### PR TITLE
fix(gateway): expose Claude context windows to MCP agents

### DIFF
--- a/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
@@ -1,4 +1,5 @@
 import { assert, describe, it } from "@effect/vitest";
+import type { ModelInfo, Options as ClaudeQueryOptions } from "@anthropic-ai/claude-agent-sdk";
 import type {
   AutomationCreateInput,
   AutomationDefinition,
@@ -38,6 +39,12 @@ import { GitManager } from "../../git/Services/GitManager.ts";
 import { OrchestrationEngineService } from "../../orchestration/Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
 import { ProjectionTurnRepository } from "../../persistence/Services/ProjectionTurns.ts";
+import {
+  ProjectionThread,
+  ProjectionThreadRepository,
+} from "../../persistence/Services/ProjectionThreads.ts";
+import { ProjectionThreadRepositoryLive } from "../../persistence/Layers/ProjectionThreads.ts";
+import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
 import { OrchestrationEventStore } from "../../persistence/Services/OrchestrationEventStore.ts";
 import { OrchestrationEventDeliveryRepository } from "../../persistence/Services/OrchestrationEventDeliveries.ts";
 import {
@@ -51,6 +58,10 @@ import type {
 } from "../../diagnostics/Services/ThreadDiagnosticsQuery.ts";
 import type { ProviderBlockingDeliveryEvidence } from "../../persistence/Services/OrchestrationEventDeliveries.ts";
 import { ProviderDiscoveryService } from "../../provider/Services/ProviderDiscoveryService.ts";
+import { ProviderAdapterRegistry } from "../../provider/Services/ProviderAdapterRegistry.ts";
+import { ClaudeAdapter } from "../../provider/Services/ClaudeAdapter.ts";
+import { makeClaudeAdapterLive } from "../../provider/Layers/ClaudeAdapter.ts";
+import { ProviderDiscoveryServiceLive } from "../../provider/Layers/ProviderDiscoveryService.ts";
 import { ProviderHealth } from "../../provider/Services/ProviderHealth.ts";
 import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
@@ -235,6 +246,7 @@ function makeHarnessLayer(
   threads: ReadonlyArray<OrchestrationThreadShell>,
   automationDefinitions: ReadonlyArray<AutomationDefinition> = [],
   options: {
+    readonly listModels?: (typeof ProviderDiscoveryService)["Service"]["listModels"];
     readonly threadDetails?: ReadonlyMap<string, OrchestrationThread>;
     readonly failDispatch?: (command: OrchestrationCommand) => boolean;
     readonly dispatchDelayMs?: number;
@@ -804,43 +816,45 @@ function makeHarnessLayer(
   } as unknown as (typeof GitManager)["Service"]);
 
   const providerDiscoveryLayer = Layer.succeed(ProviderDiscoveryService, {
-    listModels: ({ provider }: { provider: string }) => {
-      const modelsByProvider: Record<string, ReadonlyArray<Record<string, unknown>>> = {
-        codex: [
-          { slug: "gpt-5.5", name: "GPT-5.5" },
-          {
-            slug: "gpt-5.6-terra",
-            name: "GPT-5.6 Terra",
-            supportedReasoningEfforts: [
-              { value: "low", label: "Low" },
-              { value: "high", label: "High" },
-            ],
-          },
-        ],
-        claudeAgent: [
-          {
-            slug: "claude-sonnet-5",
-            name: "Claude Sonnet 5",
-          },
-        ],
-        cursor: [{ slug: "auto", name: "Auto" }],
-        antigravity: [
-          {
-            slug: "Gemini 3.5 Flash",
-            name: "Gemini 3.5 Flash",
-            supportedReasoningEfforts: [
-              { value: "low", label: "Low" },
-              { value: "high", label: "High" },
-            ],
-          },
-        ],
-        grok: [{ slug: DEFAULT_MODEL_BY_PROVIDER.grok, name: "Grok 4.6" }],
-        droid: [{ slug: "claude-opus-4-8", name: "Claude Opus 4.8" }],
-        opencode: [{ slug: "openai/gpt-5", name: "OpenAI GPT-5" }],
-        pi: [{ slug: "test-pi", name: "Test Pi" }],
-      };
-      return Effect.succeed({ models: modelsByProvider[provider] ?? [], source: "test" });
-    },
+    listModels:
+      options.listModels ??
+      (({ provider }: { provider: string }) => {
+        const modelsByProvider: Record<string, ReadonlyArray<Record<string, unknown>>> = {
+          codex: [
+            { slug: "gpt-5.5", name: "GPT-5.5" },
+            {
+              slug: "gpt-5.6-terra",
+              name: "GPT-5.6 Terra",
+              supportedReasoningEfforts: [
+                { value: "low", label: "Low" },
+                { value: "high", label: "High" },
+              ],
+            },
+          ],
+          claudeAgent: [
+            {
+              slug: "claude-sonnet-5",
+              name: "Claude Sonnet 5",
+            },
+          ],
+          cursor: [{ slug: "auto", name: "Auto" }],
+          antigravity: [
+            {
+              slug: "Gemini 3.5 Flash",
+              name: "Gemini 3.5 Flash",
+              supportedReasoningEfforts: [
+                { value: "low", label: "Low" },
+                { value: "high", label: "High" },
+              ],
+            },
+          ],
+          grok: [{ slug: DEFAULT_MODEL_BY_PROVIDER.grok, name: "Grok 4.6" }],
+          droid: [{ slug: "claude-opus-4-8", name: "Claude Opus 4.8" }],
+          opencode: [{ slug: "openai/gpt-5", name: "OpenAI GPT-5" }],
+          pi: [{ slug: "test-pi", name: "Test Pi" }],
+        };
+        return Effect.succeed({ models: modelsByProvider[provider] ?? [], source: "test" });
+      }),
   } as unknown as (typeof ProviderDiscoveryService)["Service"]);
 
   const providerKinds: ReadonlyArray<ProviderKind> = [
@@ -1253,12 +1267,322 @@ function toolErrorText(result: Record<string, unknown> | undefined): string {
   return content[0]?.text ?? "";
 }
 
+function makeClaudeGatewayRuntime(models: ModelInfo[]) {
+  const queries: Array<{
+    options: ClaudeQueryOptions;
+    modelChanges: Array<string | undefined>;
+    settingsChanges: Array<Record<string, unknown>>;
+  }> = [];
+  const layer = makeClaudeAdapterLive({
+    createQuery: ({ options }) => {
+      const captured = {
+        options,
+        modelChanges: [] as Array<string | undefined>,
+        settingsChanges: [] as Array<Record<string, unknown>>,
+      };
+      queries.push(captured);
+      const closed = Promise.withResolvers<void>();
+      return {
+        [Symbol.asyncIterator]: () => ({
+          next: async () => {
+            await closed.promise;
+            return { done: true as const, value: undefined };
+          },
+        }),
+        close: () => closed.resolve(),
+        interrupt: async () => {},
+        stopTask: async () => {},
+        backgroundTasks: async () => false,
+        setModel: async (model) => {
+          captured.modelChanges.push(model);
+        },
+        setPermissionMode: async () => {},
+        setMaxThinkingTokens: async () => {},
+        applyFlagSettings: async (settings) => {
+          captured.settingsChanges.push(settings);
+        },
+        getContextUsage: async () => {
+          throw new Error("No live context usage in this test");
+        },
+        supportedCommands: async () => [],
+        supportedModels: async () => models,
+        supportedAgents: async () => [],
+      };
+    },
+  }).pipe(
+    Layer.provideMerge(ServerConfig.layerTest("/tmp/claude-gateway-test", "/tmp")),
+    Layer.provideMerge(NodeServices.layer),
+  );
+  return {
+    queries,
+    layer: ProviderDiscoveryServiceLive.pipe(
+      Layer.provideMerge(
+        Layer.effect(
+          ProviderAdapterRegistry,
+          Effect.gen(function* () {
+            const adapter = yield* ClaudeAdapter;
+            return {
+              getByProvider: () => Effect.succeed(adapter),
+              listProviders: () => Effect.succeed(["claudeAgent"] as const),
+            };
+          }),
+        ),
+      ),
+      Layer.provide(ServerSettingsService.layerTest()),
+      Layer.provideMerge(layer),
+    ),
+  };
+}
+
 describe("AgentGateway", () => {
   const baseThreads = [
     makeThreadShell("thread-parent"),
     makeThreadShell("thread-child", { parentThreadId: ThreadId.makeUnsafe("thread-parent") }),
     makeThreadShell("thread-archived", { archivedAt: NOW }),
   ];
+
+  for (const model of [
+    { value: "sonnet" },
+    { value: "fable" },
+    { value: "claude-sonnet-5" },
+    { value: "claude-fable-5" },
+    { value: "claude-fable-5-1[1m]" },
+    { value: "sonnet[1m]", resolvedModel: "claude-sonnet-5" },
+    { value: "sonnet-4.6", resolvedModel: "claude-sonnet-4-6-20251117" },
+    { value: "fable", resolvedModel: "claude-fable-5-1[1m]" },
+    { value: "team-model", resolvedModel: "claude-fable-5-1" },
+  ]) {
+    it.effect(
+      `carries discovered Claude context windows through MCP and runtime: ${model.value} -> ${model.resolvedModel ?? model.value}`,
+      () => {
+        const runtime = makeClaudeGatewayRuntime([
+          { ...model, displayName: model.value, description: "SDK-discovered model" },
+        ]);
+        return Effect.gen(function* () {
+          const adapter = yield* ClaudeAdapter;
+          const discovery = yield* ProviderDiscoveryService;
+          const threads = yield* ProjectionThreadRepository;
+          const { gatewayLayer, makeHarness } = makeHarnessLayer(baseThreads, [], {
+            listModels: (input) =>
+              input.provider === "claudeAgent"
+                ? discovery.listModels(input)
+                : Effect.succeed({ models: [], source: "test" }),
+          });
+          yield* Effect.gen(function* () {
+            const harness = yield* makeHarness;
+            const capabilities = toolResultJson(
+              (yield* harness.callTool({
+                token: "token-parent",
+                name: "synara_capabilities",
+                args: {},
+              })).result,
+            );
+            const construction = (
+              capabilities.targetConstruction as Record<
+                string,
+                {
+                  providerOptions: Array<{ key: string }>;
+                  optionsByModel: Record<string, Array<{ key: string; allowedValues: unknown[] }>>;
+                }
+              >
+            ).claudeAgent!;
+            assert.notInclude(
+              construction.providerOptions.map((rule) => rule.key),
+              "autoCompactWindow",
+            );
+            assert.deepEqual(
+              construction.optionsByModel[model.value]?.find(
+                (rule) => rule.key === "autoCompactWindow",
+              )?.allowedValues,
+              ["auto", "200k", "1m"],
+            );
+
+            // A rejected window must fail before creating a thread or starting a turn.
+            const invalid = yield* harness.callTool({
+              token: "token-parent",
+              name: "synara_create_thread",
+              args: {
+                requestId: "invalid-window",
+                prompt: "work",
+                target: {
+                  provider: "claudeAgent",
+                  model: model.value,
+                  options: { autoCompactWindow: "2m" },
+                },
+              },
+            });
+            assert.isTrue(isToolError(invalid.result));
+            assert.lengthOf(harness.dispatched, 0);
+
+            for (const options of [
+              undefined,
+              { autoCompactWindow: "auto" },
+              { autoCompactWindow: "200k" },
+              { autoCompactWindow: "1m" },
+              { contextWindow: "1m" },
+            ]) {
+              const parent = makeThreadDetail(baseThreads[0]!);
+              harness.setThreadDetail({
+                ...parent,
+                latestTurn: {
+                  ...parent.latestTurn!,
+                  turnId: TurnId.makeUnsafe(`parent-${JSON.stringify(options)}`),
+                },
+              });
+              const response = yield* harness.callTool({
+                token: "token-parent",
+                name: "synara_create_thread",
+                args: {
+                  requestId: `window-${JSON.stringify(options)}`,
+                  prompt: "work",
+                  target: {
+                    provider: "claudeAgent",
+                    model: model.value,
+                    ...(options ? { options } : {}),
+                  },
+                },
+              });
+              assert.isFalse(isToolError(response.result), toolErrorText(response.result));
+              const creates = harness.dispatched.filter(
+                (command) => command.type === "thread.create",
+              );
+              const turns = harness.dispatched.filter(
+                (command) => command.type === "thread.turn.start",
+              );
+              const create = creates.at(-1)!;
+              const turn = turns.at(-1)!;
+              assert.deepEqual(create.modelSelection.options, options);
+              assert.deepEqual(turn.modelSelection, create.modelSelection);
+              yield* threads.upsert(
+                Schema.decodeUnknownSync(ProjectionThread)({
+                  ...makeThreadDetail(makeThreadShell(create.threadId)),
+                  threadId: create.threadId,
+                  modelSelection: create.modelSelection,
+                  latestTurnId: null,
+                  notes: null,
+                  goal: null,
+                  pendingApprovalCount: 0,
+                  pendingUserInputCount: 0,
+                  hasActionableProposedPlan: 0,
+                }),
+              );
+              const saved = Option.getOrThrow(
+                yield* threads.getById({ threadId: create.threadId }),
+              );
+              assert.deepEqual(saved.modelSelection, create.modelSelection);
+              yield* adapter.startSession({
+                threadId: create.threadId,
+                provider: "claudeAgent",
+                runtimeMode: "full-access",
+                modelSelection: saved.modelSelection,
+              });
+              yield* adapter.sendTurn({
+                threadId: create.threadId,
+                input: turn.message.text,
+                modelSelection: turn.modelSelection,
+              });
+              const query = runtime.queries.at(-1)!;
+              const window = options?.autoCompactWindow ?? options?.contextWindow;
+              const expectedModel =
+                options && model.resolvedModel
+                  ? `${model.resolvedModel}${model.value.endsWith("[1m]") ? "[1m]" : ""}`
+                  : model.value;
+              assert.equal(
+                query.options.model,
+                window === "1m" && !expectedModel.endsWith("[1m]")
+                  ? `${expectedModel}[1m]`
+                  : expectedModel,
+              );
+              const settings = query.options.settings as { autoCompactWindow?: number };
+              assert.equal(
+                settings.autoCompactWindow,
+                window === "1m" ? 1_000_000 : window === "200k" ? 200_000 : undefined,
+              );
+              assert.deepEqual(query.modelChanges, []);
+              assert.deepEqual(query.settingsChanges, []);
+              yield* adapter.stopSession(create.threadId);
+            }
+          }).pipe(Effect.provide(gatewayLayer));
+        }).pipe(
+          Effect.provide(
+            Layer.merge(
+              runtime.layer,
+              ProjectionThreadRepositoryLive.pipe(
+                Layer.provide(SqlitePersistenceMemory),
+                Layer.provide(NodeServices.layer),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  for (const model of [
+    { value: "claude-haiku-4-5" },
+    { value: "claude-opus-4-5" },
+    { value: "unknown-model" },
+    { value: "sonnet", resolvedModel: "claude-haiku-4-5" },
+  ]) {
+    it.effect(
+      `does not advertise or accept unsupported discovered Claude windows: ${model.value}`,
+      () => {
+        const runtime = makeClaudeGatewayRuntime([
+          { ...model, displayName: model.value, description: "SDK-discovered model" },
+        ]);
+        return Effect.gen(function* () {
+          const discovery = yield* ProviderDiscoveryService;
+          const { gatewayLayer, makeHarness } = makeHarnessLayer(baseThreads, [], {
+            listModels: (input) =>
+              input.provider === "claudeAgent"
+                ? discovery.listModels(input)
+                : Effect.succeed({ models: [] }),
+          });
+          yield* Effect.gen(function* () {
+            const harness = yield* makeHarness;
+            const capabilities = toolResultJson(
+              (yield* harness.callTool({
+                token: "token-parent",
+                name: "synara_capabilities",
+                args: {},
+              })).result,
+            );
+            const construction = (
+              capabilities.targetConstruction as Record<
+                string,
+                {
+                  optionsByModel: Record<string, Array<{ key: string }>>;
+                }
+              >
+            ).claudeAgent!;
+            assert.notInclude(
+              construction.optionsByModel[model.value]?.map((rule) => rule.key),
+              "autoCompactWindow",
+            );
+            for (const key of ["autoCompactWindow", "contextWindow"]) {
+              const response = yield* harness.callTool({
+                token: "token-parent",
+                name: "synara_create_thread",
+                args: {
+                  requestId: key,
+                  prompt: "work",
+                  target: {
+                    provider: "claudeAgent",
+                    model: model.value,
+                    options: { [key]: "1m" },
+                  },
+                },
+              });
+              assert.isTrue(isToolError(response.result));
+              assert.include(toolErrorText(response.result), "model_option_unavailable");
+            }
+            assert.lengthOf(harness.dispatched, 0);
+            assert.lengthOf(harness.worktreeCreates, 0);
+          }).pipe(Effect.provide(gatewayLayer));
+        }).pipe(Effect.provide(runtime.layer));
+      },
+    );
+  }
 
   it.effect("rejects requests without a valid bearer token", () => {
     const { gatewayLayer, makeHarness } = makeHarnessLayer(baseThreads);

--- a/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
@@ -1555,8 +1555,9 @@ describe("AgentGateway", () => {
                 }
               >
             ).claudeAgent!;
+            assert.property(construction.optionsByModel, model.value);
             assert.notInclude(
-              construction.optionsByModel[model.value]?.map((rule) => rule.key),
+              construction.optionsByModel[model.value]!.map((rule) => rule.key),
               "autoCompactWindow",
             );
             for (const key of ["autoCompactWindow", "contextWindow"]) {

--- a/apps/server/src/agentGateway/targetResolver.ts
+++ b/apps/server/src/agentGateway/targetResolver.ts
@@ -11,6 +11,7 @@ import {
   type ProviderModelDescriptor,
   type ServerProviderAuthStatus,
 } from "@synara/contracts";
+import { getClaudeContextWindowSuffix } from "@synara/shared/model";
 import { Effect } from "effect";
 
 import type { ProviderDiscoveryServiceShape } from "../provider/Services/ProviderDiscoveryService.ts";
@@ -97,7 +98,7 @@ type ProviderOptionValidation =
   | { readonly kind: "non-empty-string" };
 
 interface ProviderTargetOptionRuleSpec extends Omit<AgentGatewayTargetOptionRule, "key"> {
-  readonly advertised: boolean;
+  readonly advertised: boolean | "when-discovered";
   readonly validation: ProviderOptionValidation;
 }
 
@@ -130,7 +131,7 @@ function providerOptionRule(
   allowedValues: ReadonlyArray<AgentGatewayTargetOptionValue>,
   allowedValuesSource: AgentGatewayTargetOptionRule["allowedValuesSource"] = "provider-contract",
   options?: {
-    readonly advertised?: boolean;
+    readonly advertised?: boolean | "when-discovered";
     readonly validation?: ProviderOptionValidation;
     readonly allowsCustomValue?: boolean;
   },
@@ -199,7 +200,7 @@ const PROVIDER_TARGET_OPTION_RULES = {
         validation: { kind: "boolean-capability", capability: "supportsThinkingToggle" },
       }),
       autoCompactWindow: providerOptionRule("string", [], "model-discovery", {
-        advertised: false,
+        advertised: "when-discovered",
         validation: { kind: "context-window" },
       }),
       contextWindow: providerOptionRule("string", [], "model-discovery", {
@@ -317,7 +318,7 @@ function providerTargetOptionRules(
   provider: ProviderKind,
 ): ReadonlyArray<AgentGatewayTargetOptionRule> {
   return Object.entries(providerTargetOptionConfig(provider).options)
-    .filter(([, option]) => option.advertised)
+    .filter(([, option]) => option.advertised === true)
     .map(([key, { valueType, allowedValues, allowedValuesSource, allowsCustomValue }]) => ({
       key,
       valueType,
@@ -383,6 +384,15 @@ function modelTargetOptionRules(
   }
 
   for (const descriptor of model.optionDescriptors ?? []) {
+    const spec = providerOptionRuleSpec(provider, descriptor.id);
+    if (spec?.advertised === "when-discovered") {
+      rules.push({
+        key: spec.key,
+        valueType: spec.valueType,
+        allowedValues: [],
+        allowedValuesSource: "model-discovery",
+      });
+    }
     const rule = rules.find((candidate) => candidate.key === descriptor.id);
     if (!rule) continue;
     if (descriptor.type === "select") {
@@ -594,7 +604,13 @@ function validateKnownProviderOption(
     case "context-window": {
       const available = descriptor.contextWindowOptions?.map((entry) => entry.value) ?? [];
       if (available.includes(String(value))) return;
-      validateDiscoveredDescriptorOption(target, descriptor, rule.key, value);
+      const optionId =
+        target.provider === "claudeAgent" &&
+        rule.key === "contextWindow" &&
+        descriptor.optionDescriptors?.some((option) => option.id === "autoCompactWindow")
+          ? "autoCompactWindow"
+          : rule.key;
+      validateDiscoveredDescriptorOption(target, descriptor, optionId, value);
       return;
     }
     case "non-empty-string": {
@@ -701,6 +717,21 @@ export function resolveAgentGatewayTarget(input: {
     } catch (error) {
       if (error instanceof AgentGatewayTargetError) return yield* Effect.fail(error);
       throw error;
+    }
+    // Explicit Claude windows must reach the runtime with the same concrete model
+    // whose capabilities were discovered; custom SDK aliases have no static caps.
+    if (
+      input.target.provider === "claudeAgent" &&
+      (input.target.options?.autoCompactWindow !== undefined ||
+        input.target.options?.contextWindow !== undefined) &&
+      descriptor?.resolvedModel
+    ) {
+      const suffix =
+        getClaudeContextWindowSuffix(input.target.model) === "1m" &&
+        getClaudeContextWindowSuffix(descriptor.resolvedModel) === null
+          ? "[1m]"
+          : "";
+      return { ...input.target, model: `${descriptor.resolvedModel}${suffix}` };
     }
     return input.target;
   });

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -5441,18 +5441,34 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         provider: "claudeAgent",
         cwd: "/tmp/project",
       });
-      assert.deepEqual(discovered, {
-        models: [
-          {
-            slug: "claude-fable-5[1m]",
-            resolvedModel: "claude-fable-5[1m]",
-            name: "Fable",
-            supportsAutoMode: true,
-          },
-        ],
-        source: "sdk",
-        cached: false,
+      assert.equal(discovered.source, "sdk");
+      assert.equal(discovered.cached, false);
+      assert.lengthOf(discovered.models, 1);
+      const { optionDescriptors, ...model } = discovered.models[0]!;
+      assert.deepEqual(model, {
+        slug: "claude-fable-5[1m]",
+        resolvedModel: "claude-fable-5[1m]",
+        name: "Fable",
+        supportsAutoMode: true,
       });
+      assert.deepEqual(
+        optionDescriptors?.map((option) => option.id),
+        ["effort", "autoCompactWindow"],
+      );
+      assert.deepEqual(
+        optionDescriptors?.find((option) => option.id === "autoCompactWindow"),
+        {
+          id: "autoCompactWindow",
+          label: "Auto-compact",
+          type: "select",
+          currentValue: "auto",
+          options: [
+            { id: "auto", label: "Auto (Claude Code)", isDefault: true },
+            { id: "200k", label: "200k" },
+            { id: "1m", label: "1M" },
+          ],
+        },
+      );
       assert.equal(query.closeCalls, 1);
       assert.equal(createQueryCalls, 1);
 

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -67,6 +67,7 @@ import {
   getDefaultModel,
   getEffectiveClaudeCodeEffort,
   getModelCapabilities,
+  getProviderOptionDescriptors,
   hasEffortLevel,
   resolveApiModelId,
   stripClaudeContextWindowSuffix,
@@ -897,10 +898,15 @@ function toPermissionMode(value: unknown): PermissionMode | undefined {
 }
 
 function mapClaudeModelInfo(model: ModelInfo): ProviderListModelsResult["models"][number] {
+  const optionDescriptors = getProviderOptionDescriptors({
+    provider: PROVIDER,
+    caps: getModelCapabilities(PROVIDER, model.resolvedModel ?? model.value),
+  });
   return {
     slug: model.value,
     ...(model.resolvedModel ? { resolvedModel: model.resolvedModel } : {}),
     name: model.displayName,
+    ...(optionDescriptors.length > 0 ? { optionDescriptors } : {}),
     ...(typeof model.supportsAutoMode === "boolean"
       ? { supportsAutoMode: model.supportsAutoMode }
       : {}),


### PR DESCRIPTION
Claude children created through Synara MCP reject `autoCompactWindow: "1m"` before creation, although the shared model picker supports it. Claude's SDK model discovery omitted the shared option descriptors, and the gateway excluded the window from its per-model guidance.

- Populate discovered Claude models with the existing shared descriptors, using the SDK's resolved model when present. Keep the full descriptor set so the composer retains its effort controls.
- Advertise `autoCompactWindow` only for models whose discovery includes it, with the shared `auto`, `200k`, and `1m` choices. Validate the legacy `contextWindow` key against the same choices and keep unknown/unsupported models rejected.
- For explicit window selections on SDK aliases, persist the resolved model (preserving an explicit `[1m]` qualifier), so the runtime applies the same capabilities that validation checked. Auto remains unpinned; explicit 200k/1M settings and the #956 runtime behavior remain intact.

Regression coverage follows the real Claude adapter and discovery service through `synara_capabilities`, `synara_create_thread`, creation/turn dispatch, SQLite save/reload, and Claude SDK query options. It covers Sonnet/Fable aliases and canonical models, resolved/datestamped models, `[1m]` variants, both option keys, Auto/200k/1M, invalid windows, and unsupported models. The new integration cases fail against the original production code because the window guidance is absent.

Validation: 323 focused server tests, 102 shared model tests, and 22 composer/runtime-capability tests passed (447 total). Targeted formatting checks and `git diff --check` passed; targeted oxlint reported no errors. Final [CI run](https://github.com/Emanuele-web04/synara/actions/runs/33997225264) passed on `a8d74cf8ac31743a8d2f5ebcaa5ba2a1d6fbb6c2`: all 8 jobs and 79 steps succeeded, including Windows regression, desktop build, format/lint/typecheck, and both browser lanes. Unit tests: 10,547 passed / 30 skipped. Browser stable: 381 passed / 13 skipped. Linux geometry quarantine: 12 passed (the other tests are filtered out); its raw log contains no masked test failure. Cursor Bugbot completed with `SUCCESS` and an explicit "no issues found" result on that same commit.

No live Claude account or long-context inference was started: the tests verify that Synara accepts, persists, and forwards supported selections. Actual 1M availability remains subject to the provider/account.

Closes #896

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model-selection validation, MCP capability advertising, and how Claude alias models are rewritten before orchestration—incorrect rules could reject valid threads or pass wrong models to the SDK.
> 
> **Overview**
> **Claude context-window options (`autoCompactWindow` / legacy `contextWindow`) are now visible and enforceable for MCP-created threads when SDK discovery includes them.**
> 
> Discovered Claude models gain shared `optionDescriptors` (including auto/200k/1m compact window choices) in the adapter’s `listModels` mapping. The gateway advertises `autoCompactWindow` only per discovered model via a new **`when-discovered`** rule, fills allowed values from discovery, validates `contextWindow` against the same descriptor set, and rejects unsupported models or invalid windows before dispatch. When users pick an explicit window on an SDK alias, resolution rewrites the target to the **resolved model id** (keeping an explicit `[1m]` suffix when needed) so runtime capabilities match what was validated.
> 
> Regression tests wire a fake Claude SDK runtime through `synara_capabilities`, `synara_create_thread`, persistence, and query `model` / `settings.autoCompactWindow` forwarding; adapter discovery tests assert the new descriptors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8d74cf8ac31743a8d2f5ebcaa5ba2a1d6fbb6c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->