### PR TITLE
perf(tooling): add measured opt-in native TypeScript checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,21 @@ bun install
 bun run dev
 ```
 
+For faster development feedback, `bun run typecheck:native` checks all seven
+workspaces with TypeScript 7 and the native Effect checker. It uses separate
+incremental caches and leaves the existing TypeScript 5 compiler available for
+build and declaration tooling.
+
+This is an **additional development check, not a replacement for
+`bun run typecheck`**. The native Effect checker does not yet enforce every rule
+we use: in particular, `importFromBarrel` errors are currently missed. Keep the
+existing typecheck as the required pre-merge/CI check. Do not use a native-only
+pass to certify a change.
+
+Use those named scripts rather than a bare `tsc` from the repository root: the
+native package exposes that executable too. Each workspace's existing
+`typecheck` script still resolves its local TypeScript 5 compiler.
+
 ## Contributing
 
 Bug fixes, reliability improvements, performance work, documentation, and maintenance changes are welcome.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -10,6 +10,7 @@
     "build": "tsdown",
     "start": "bun run scripts/start-electron.mjs",
     "typecheck": "tsc --noEmit",
+    "typecheck:native": "node ../../node_modules/@typescript/native/bin/tsc --noEmit --tsBuildInfoFile node_modules/.cache/typescript-native.tsbuildinfo",
     "test": "vitest run --passWithNoTests",
     "smoke-test": "node scripts/smoke-test.mjs"
   },

--- a/apps/desktop/src/browserAnnotations/guestIdentity.ts
+++ b/apps/desktop/src/browserAnnotations/guestIdentity.ts
@@ -1,6 +1,6 @@
 export interface GuestCrypto {
   randomUUID?: () => string;
-  getRandomValues: <T extends ArrayBufferView>(array: T) => T;
+  getRandomValues: Crypto["getRandomValues"];
 }
 
 export function createGuestIdentifier(crypto: GuestCrypto): string {

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -17,6 +17,7 @@
     "test:a11y": "playwright test tests/a11y",
     "test:performance": "node scripts/performance-smoke.mjs",
     "typecheck": "tsc --noEmit",
+    "typecheck:native": "node ../../node_modules/@typescript/native/bin/tsc --noEmit --tsBuildInfoFile node_modules/.cache/typescript-native.tsbuildinfo",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "postinstall": "fumadocs-mdx"

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -21,6 +21,7 @@
     "start": "node dist/index.mjs",
     "prepare": "effect-language-service patch",
     "typecheck": "tsc --noEmit",
+    "typecheck:native": "node ../../node_modules/@typescript/native/bin/tsc --noEmit --tsBuildInfoFile node_modules/.cache/typescript-native.tsbuildinfo",
     "test": "vitest run --maxWorkers=1 --no-file-parallelism"
   },
   "dependencies": {

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -1764,11 +1764,11 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
 
       emit("remoteControl/status/changed");
       emit("skills/changed");
-      emit("session/threadOpenRequested", "lifecycle");
+      emit("session/threadOpenRequested", "session");
       // Real errors and useful unknown events must survive the filter.
       emit("session/threadOpenRequested", "error");
       emit("item/future/completed");
-      emit("session/started", "lifecycle");
+      emit("session/started", "session");
 
       const events = Array.from(yield* Fiber.join(eventsFiber));
       assert.deepEqual(

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
     "prepare": "effect-language-service patch",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
+    "typecheck:native": "node ../../node_modules/@typescript/native/bin/tsc --noEmit --tsBuildInfoFile node_modules/.cache/typescript-native.tsbuildinfo",
     "test": "vitest run --passWithNoTests",
     "test:browser": "vitest run --config vitest.browser.config.ts",
     "test:browser:stable": "vitest run --config vitest.browser.stable.config.ts",

--- a/apps/web/src/lib/threadBootstrap.test.ts
+++ b/apps/web/src/lib/threadBootstrap.test.ts
@@ -328,6 +328,37 @@ describe("threadBootstrap", () => {
     ).toBe("default");
   });
 
+  it.each([null, undefined])(
+    "inherits an active draft PR when the active PR is %s",
+    (lastKnownPr) => {
+      const pullRequest = {
+        number: 42,
+        title: "Keep PR context",
+        url: "https://github.com/example/repo/pull/42",
+        baseBranch: "main",
+        headBranch: "feature/context",
+        state: "open" as const,
+      };
+      expect(
+        resolveTerminalThreadCreationState({
+          activeDraftThread: makeDraftThread({ lastKnownPr: pullRequest }),
+          activeThread: {
+            projectId: PROJECT_ID,
+            modelSelection: modelSelection("codex", "gpt-5"),
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            ...(lastKnownPr === undefined ? {} : { lastKnownPr }),
+          },
+          draftComposerState: null,
+          draftThread: null,
+          options: undefined,
+          projectDefaultModelSelection: null,
+          projectId: PROJECT_ID,
+        }).lastKnownPr,
+      ).toEqual(pullRequest);
+    },
+  );
+
   it("preserves explicit draft plan mode when resolving terminal creation payloads", () => {
     expect(
       resolveTerminalThreadCreationState({

--- a/apps/web/src/lib/threadBootstrap.ts
+++ b/apps/web/src/lib/threadBootstrap.ts
@@ -324,11 +324,9 @@ export function resolveTerminalThreadCreationState(
       input.draftThread?.interactionMode ?? DEFAULT_INTERACTION_MODE,
     lastKnownPr:
       input.draftThread?.lastKnownPr ??
-      (input.activeThread?.projectId === input.projectId
-        ? (input.activeThread.lastKnownPr ?? null)
-        : null) ??
+      (input.activeThread?.projectId === input.projectId ? input.activeThread.lastKnownPr : null) ??
       (input.activeDraftThread?.projectId === input.projectId
-        ? (input.activeDraftThread.lastKnownPr ?? null)
+        ? input.activeDraftThread.lastKnownPr
         : null) ??
       null,
     envMode: hasExplicitEnvModeOverride

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,9 @@
     "": {
       "name": "@synara/monorepo",
       "devDependencies": {
+        "@effect/tsgo": "0.41.0",
         "@types/node": "catalog:",
+        "@typescript/native": "npm:typescript@7.0.2",
         "oxfmt": "^0.40.0",
         "oxlint": "^1.55.0",
         "turbo": "^2.9.14",
@@ -517,6 +519,22 @@
     "@effect/platform-node-shared": ["@effect/platform-node-shared@https://pkg.pr.new/Effect-TS/effect-smol/@effect/platform-node-shared@8881a9b606d84a6f5eb6615279138322984f5368", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.19.0" }, "peerDependencies": { "effect": "^4.0.0-beta.25" } }],
 
     "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@https://pkg.pr.new/Effect-TS/effect-smol/@effect/sql-sqlite-bun@8881a9b", { "peerDependencies": { "effect": "^4.0.0-beta.25" } }],
+
+    "@effect/tsgo": ["@effect/tsgo@0.41.0", "", { "optionalDependencies": { "@effect/tsgo-darwin-arm64": "0.41.0", "@effect/tsgo-darwin-x64": "0.41.0", "@effect/tsgo-linux-arm": "0.41.0", "@effect/tsgo-linux-arm64": "0.41.0", "@effect/tsgo-linux-x64": "0.41.0", "@effect/tsgo-win32-arm64": "0.41.0", "@effect/tsgo-win32-x64": "0.41.0" }, "bin": { "effect-tsgo": "dist/effect-tsgo.cjs" } }, "sha512-C/U7lFM0AXsfpqRilDOgwu+llBhAo8bcdIlzgbRWf1LWlU4KZKB2UsUvBPL3qPnm+wmbCvQLeTQc4BjV9oJrcg=="],
+
+    "@effect/tsgo-darwin-arm64": ["@effect/tsgo-darwin-arm64@0.41.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-3iEPtcHF72yDjv7T5YpnX+Io1LDLywJb1oGG3Fp/Fth4xmqiT1Vacyz5wnPCfEWGQ6CyrlyCZSSjUxPyJ70+DQ=="],
+
+    "@effect/tsgo-darwin-x64": ["@effect/tsgo-darwin-x64@0.41.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rrVVNacJ/Qh8DfdfgNJDuzcVmR3xPnqes3z+F1kio99umJwPIRB8iPWRAY0SrO+Y84A/y2SSb0AjMGqA5V3Aiw=="],
+
+    "@effect/tsgo-linux-arm": ["@effect/tsgo-linux-arm@0.41.0", "", { "os": "linux", "cpu": "arm" }, "sha512-JddS91IaupLa22oc4YQiYppe7iAZAEyx/2iR9sAAAhpVanWACsIAcyUy4RJrs8sPLLoLsZQaKQa+9rbQO1FLsg=="],
+
+    "@effect/tsgo-linux-arm64": ["@effect/tsgo-linux-arm64@0.41.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-RVI+7pG3tP56LfH06a2aq4KLp2RQ0HohW8mmoGmrBPyNEL9DnzFEGB98ZoMJ+ERYUJoIp74Jy3nKRVbnzVhxFw=="],
+
+    "@effect/tsgo-linux-x64": ["@effect/tsgo-linux-x64@0.41.0", "", { "os": "linux", "cpu": "x64" }, "sha512-U3+kMDVe2Opa5mxbN4B6PgOizWx5B4LXLN98CZDUl2vYtRGfwrRRhKQiB+de3ELaZ0MuDjPlCvU7S2mXQ8UiuQ=="],
+
+    "@effect/tsgo-win32-arm64": ["@effect/tsgo-win32-arm64@0.41.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-H6/xkn+B4B63OPKc0UAzQQFvLs0MXKigiD9dtvQeCU7czWGztOQILuLkyHnM1Dlc+uy4cJ5eXHiMXd+lwl+E8g=="],
+
+    "@effect/tsgo-win32-x64": ["@effect/tsgo-win32-x64@0.41.0", "", { "os": "win32", "cpu": "x64" }, "sha512-vRN/Mhi381xEGrvV68IN/VO4Lc0pnlVQzHSVmNCJXLwGLmJUvuvPoyZ7Lv4wwHRX9iZe8Rch21xUGu5jSQtUSw=="],
 
     "@effect/vitest": ["@effect/vitest@https://pkg.pr.new/Effect-TS/effect-smol/@effect/vitest@8881a9b", { "peerDependencies": { "effect": "^4.0.0-beta.25", "vitest": "^3.0.0 || ^4.0.0" } }],
 
@@ -1435,6 +1453,48 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.67.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.67.0", "@typescript-eslint/types": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA=="],
+
+    "@typescript/native": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 

--- a/docs/performance/2026-09-06/native-typecheck.json
+++ b/docs/performance/2026-09-06/native-typecheck.json
@@ -1,0 +1,38 @@
+{
+  "date": "2026-09-06",
+  "base": "55ff1f47c5ec831d2deec0c388b323ac5b9ce7fd",
+  "baselineFixtureRepair": "Replace the two invalid lifecycle event kinds with session in CodexAdapter.test.ts",
+  "hardware": { "model": "Mac17,2", "logicalCpus": 10, "ramGiB": 32, "os": "macOS 26.6.2" },
+  "versions": {
+    "node": "24.13.0",
+    "bun": "1.3.12",
+    "turbo": "2.10.5",
+    "legacyTypeScript": "5.9.3",
+    "legacyEffect": "0.75.1",
+    "nativeTypeScript": "7.0.2",
+    "nativeEffect": "0.41.0"
+  },
+  "unit": "milliseconds",
+  "taskCache": false,
+  "coldDefinition": "Compiler incremental caches cleared; OS cache not cleared",
+  "sameSourceAndDependencies": true,
+  "equivalentDiagnosticCoverage": false,
+  "knownNativeDiagnosticGap": "Configured importFromBarrel error: legacy TS12/nonzero exit, native no diagnostic/zero exit",
+  "allMeasuredRuns": { "exitCode": 0, "successfulWorkspaceTasks": 7, "totalWorkspaceTasks": 7 },
+  "samples": {
+    "legacyCold": [60643.836208, 53848.309958, 52545.192416],
+    "nativeCold": [14428.465875, 11914.368417, 11992.848875],
+    "legacyIncremental": [11500.284958, 11005.009709, 12787.781209],
+    "nativeIncremental": [3156.405667, 2840.553916, 3070.832792]
+  },
+  "sourceFileCountsBothCompilers": {
+    "server": 1135,
+    "web": 1322,
+    "desktop": 222,
+    "marketing": 112,
+    "contracts": 59,
+    "shared": 185,
+    "scripts": 95
+  },
+  "sourceFilesMissingOrAdded": 0
+}

--- a/docs/performance/2026-09-06/native-typecheck.md
+++ b/docs/performance/2026-09-06/native-typecheck.md
@@ -1,0 +1,151 @@
+# Opt-in native typechecking
+
+## Decision
+
+Keep `bun run typecheck` as the required legacy gate. Add
+`bun run typecheck:native` for faster development feedback, not as a CI
+replacement. The native checker visits the same source files and catches the
+tested TypeScript errors, but does not preserve every Effect diagnostic.
+
+In a controlled mutation, `import { NodeRuntime } from
+"@effect/platform-node"` fails the legacy checker with `effect(importFromBarrel)`
+(TS12). The native checker exits successfully with the same configured error
+severity. This is a verified coverage gap, not a waived finding in our code.
+Do not interpret the timing comparison below as equivalent diagnostic coverage.
+
+## Measurements
+
+Mac17,2, 10 logical CPUs, 32 GiB RAM, macOS 26.6.2. Both commands used Node
+24.13.0, Bun 1.3.12, the same worktree, installed dependencies, generated Next
+route/Fumadocs types, and source snapshot. Node is slightly below the declared
+24.13.1 minimum; this is a controlled local comparison, not platform certification.
+
+- Legacy: TypeScript 5.9.3 patched with `@effect/language-service` 0.75.1.
+- Native: TypeScript 7.0.2 patched with `@effect/tsgo` 0.41.0.
+- Turbo 2.10.5; task caching disabled for both commands, all seven tasks executed.
+- Three samples per command/cache state, alternating command order per round.
+- Cold means compiler incremental caches removed, **not** a cold OS/filesystem.
+  Incremental means the immediate unchanged rerun, with separate compiler caches.
+- Other coordinated benchmarks were paused. Wall time was measured around a
+  child-process invocation; no application speed, RSS, or energy claim is made.
+
+| Command/state       |      Min |   Median |      Max |
+| ------------------- | -------: | -------: | -------: |
+| Legacy, cold        | 52.545 s | 53.848 s | 60.644 s |
+| Native, cold        | 11.914 s | 11.993 s | 14.428 s |
+| Legacy, incremental | 11.005 s | 11.500 s | 12.788 s |
+| Native, incremental |  2.841 s |  3.071 s |  3.156 s |
+
+Median native command latency was 77.7% lower cold (4.49x) and 73.3% lower
+incrementally (3.75x). All twelve measured runs exited 0 with 7/7 successful
+workspace tasks. Individual samples are in [native-typecheck.json](./native-typecheck.json).
+
+The original base, `55ff1f47c`, had two invalid `"lifecycle"` event kinds in a
+Codex test fixture. Both comparison commands used the same prerequisite repair
+to `"session"`. The original failing run is excluded from the measurements.
+Both commands also used the same narrow compatibility changes: explicit Node
+types in contracts/shared, the standard `Crypto.getRandomValues` signature, and
+removal of redundant inner null fallbacks in thread bootstrap.
+
+## Correctness checks
+
+`--listFilesOnly` reported identical repository-owned source sets for each
+workspace, including tests and generated marketing types. Dependency/lib files
+were excluded from this comparison because compiler libraries differ by version.
+
+| Workspace | Source files in each checker | Missing/extra native files |
+| --------- | ---------------------------: | -------------------------: |
+| server    |                        1,135 |                      0 / 0 |
+| web       |                        1,322 |                      0 / 0 |
+| desktop   |                          222 |                      0 / 0 |
+| marketing |                          112 |                      0 / 0 |
+| contracts |                           59 |                      0 / 0 |
+| shared    |                          185 |                      0 / 0 |
+| scripts   |                           95 |                      0 / 0 |
+
+Incremental probes began with valid code, introduced errors, then restored valid
+code using separate cache files. Both compilers accepted the valid/restored
+fixture and rejected:
+
+- An explicit `undefined` assigned to `{ value?: number }` (TS2375).
+- An unchecked array element assigned to `number` (TS2322).
+- An unconsumed Effect (`floatingEffect`, legacy TS3 / native TS377001).
+
+The barrel-import probe is the exception described above. These targeted checks
+are not a claim of exhaustive compiler or plugin equivalence.
+
+The incremental invalidation check was also repeated through the actual web
+workspace scripts: adding a new included source file with the invalid optional
+property assignment failed both commands with TS2375; removing that temporary
+file restored a passing result. The probe is not shipped in the source tree.
+
+Focused runtime verification passed: 17 thread-bootstrap tests (including null
+and omitted PR fallback cases), and 8 desktop browser-annotation protocol tests.
+The contracts ESM/CJS and declaration build also passed through unchanged
+tsdown 0.20.3, whose compiler API still resolves TypeScript 5.9.3. No workspace
+CI, lint suite, or broad application test suite was run for this experiment.
+
+## Reproduce
+
+Use the pinned dependencies and a supported Node version. Generate marketing
+types once before either command, rather than comparing a prepared project with
+an unprepared checkout:
+
+```sh
+bun install --frozen-lockfile
+(cd apps/marketing && bun run postinstall && node node_modules/next/dist/bin/next typegen)
+bun run typecheck
+bun run typecheck:native
+```
+
+For the repeated measurements, run this from the repository root. It removes
+only generated compiler-cache files in the seven listed workspaces. It does not
+clear Turbo's shared worktree cache; both tasks already disable result caching.
+
+```js
+// Save outside the source tree and execute with Node.
+import { spawnSync } from "node:child_process";
+import { existsSync, unlinkSync } from "node:fs";
+import { performance } from "node:perf_hooks";
+
+const projects = [
+  "apps/server",
+  "apps/web",
+  "apps/desktop",
+  "apps/marketing",
+  "packages/contracts",
+  "packages/shared",
+  "scripts",
+];
+for (let sample = 1; sample <= 3; sample++) {
+  const tasks = sample % 2 ? ["typecheck", "typecheck:native"] : ["typecheck:native", "typecheck"];
+  for (const task of tasks) {
+    const cache =
+      task === "typecheck"
+        ? "tsconfig.tsbuildinfo"
+        : "node_modules/.cache/typescript-native.tsbuildinfo";
+    for (const project of projects) {
+      const file = `${project}/${cache}`;
+      if (existsSync(file)) unlinkSync(file);
+    }
+    for (const state of ["cold", "incremental"]) {
+      const start = performance.now();
+      const run = spawnSync("bun", ["run", task], {
+        encoding: "utf8",
+        maxBuffer: 20 * 1024 * 1024,
+      });
+      console.log({ sample, task, state, ms: performance.now() - start, exit: run.status });
+      if (run.status !== 0) throw new Error(run.stdout + run.stderr);
+    }
+  }
+}
+```
+
+The native package also exposes a root `tsc` executable. Use the named scripts
+above; the existing workspace scripts continue resolving their local legacy
+compiler. Existing build/editor tooling is not migrated by this change.
+
+References: [TypeScript 7 side-by-side installation](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/),
+[Effect native checker](https://github.com/Effect-TS/tsgo). This is a first step
+toward [#1002](https://github.com/Emanuele-web04/synara/issues/1002), not completion
+of the compiler migration.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "build:marketing": "turbo run build --filter=@synara/marketing",
     "build:desktop": "turbo run build --filter=@synara/desktop --filter=@synara/cli",
     "typecheck": "turbo run typecheck",
+    "typecheck:native": "effect-tsgo patch --typescript --typescript-package @typescript/native && turbo run typecheck:native",
     "lint": "oxlint --report-unused-disable-directives",
     "test": "turbo run test",
     "test:web:focused": "bun run --cwd apps/web test",
@@ -67,7 +68,9 @@
     "clean": "rm -rf node_modules apps/*/node_modules packages/*/node_modules scripts/node_modules apps/*/dist apps/*/dist-electron packages/*/dist .turbo apps/*/.turbo packages/*/.turbo"
   },
   "devDependencies": {
+    "@effect/tsgo": "0.41.0",
     "@types/node": "catalog:",
+    "@typescript/native": "npm:typescript@7.0.2",
     "oxfmt": "^0.40.0",
     "oxlint": "^1.55.0",
     "turbo": "^2.9.14",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -21,6 +21,7 @@
     "build": "tsdown src/index.ts --format esm,cjs --dts --clean",
     "prepare": "effect-language-service patch",
     "typecheck": "tsc --noEmit",
+    "typecheck:native": "node ../../node_modules/@typescript/native/bin/tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "types": ["node"],
     "plugins": [
       {
         "name": "@effect/language-service",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -316,6 +316,7 @@
   "scripts": {
     "prepare": "effect-language-service patch",
     "typecheck": "tsc --noEmit",
+    "typecheck:native": "node ../../node_modules/@typescript/native/bin/tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
   "include": ["src"]
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "prepare": "effect-language-service patch",
     "typecheck": "tsc --noEmit",
+    "typecheck:native": "node ../node_modules/@typescript/native/bin/tsc --noEmit --tsBuildInfoFile node_modules/.cache/typescript-native.tsbuildinfo",
     "test": "vitest run"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -39,6 +39,11 @@
       "outputs": [],
       "cache": false
     },
+    "typecheck:native": {
+      "dependsOn": ["^typecheck:native"],
+      "outputs": [],
+      "cache": false
+    },
     "test": {
       "dependsOn": ["^build"],
       "cache": false,


### PR DESCRIPTION
## What changed

Add `bun run typecheck:native` as an optional fast development check across the existing seven workspaces. Keep `bun run typecheck` and its TypeScript 5.9.3 / Effect diagnostics as the mandatory gate; leave build and editor tooling on their existing compiler.

- Pin the native compiler to TypeScript 7.0.2 and its Effect integration to `@effect/tsgo` 0.41.0, using explicit compiler paths and separate incremental caches.
- Add explicit Node types only where required, reuse the standard browser Crypto method signature, and simplify redundant null fallbacks without changing their behavior.
- Include regression coverage for null/omitted PR fallback values and a reproducible benchmark report under `docs/performance/2026-09-06/native-typecheck.md`.
- Include the separate two-line fix for invalid Codex test event kinds already on main. That same prerequisite is in #1003; merge #1003 first and rebase this branch to remove its duplicate diff.

Refs #1002. This is not completion of the TypeScript migration.

## Why

Measured development feedback is materially faster, but native Effect diagnostics are not equivalent yet: a mutation importing from `@effect/platform-node` is rejected by the existing `importFromBarrel` error rule and accepted by the native checker. This is documented prominently, not disabled or silently waived. **A native-only pass must not certify a change or replace CI.**

The native package adds a root `tsc` binary; supported use is through the named root scripts. Every existing workspace continues to resolve its own legacy compiler, and build-tool compiler API resolution remains TypeScript 5.9.3.

## Verification

Three alternating samples per command/cache state, same source/dependencies and fixed Node 24.13.0 / Bun 1.3.12 on macOS; all twelve measured runs passed all seven workspaces with Turbo result caching disabled:

| Compiler cache | Legacy median | Native median |
| --- | ---: | ---: |
| Cold | 53.848 s | 11.993 s |
| Incremental, unchanged | 11.500 s | 3.071 s |

These are command timings, not a claim of equivalent diagnostic coverage. The report includes individual samples, cache controls, source snapshot normalization and reproduction instructions.

- Identical repository-owned source-file coverage in all seven workspaces; no files dropped to obtain the speedup.
- Valid → invalid → restored probes verified exact optional properties, unchecked indexed access and floating Effect detection; an additional mutation in the actual web workspace verified incremental cache invalidation and recovery in both root commands.
- 25 focused tests passed, including the two new PR fallback cases.
- Contracts ESM/CJS/declaration build passed through unchanged tsdown and legacy TypeScript.
- Focused formatting and diff checks passed.
- Combined qualification with #1003 also passed: a temporary three-file Bun upgrade overlay, normal frozen install under actual Bun 1.4.2 / Bun types 1.4.1, then both legacy and native root commands completed all seven workspaces successfully with zero cached tasks. The overlay was removed to keep the two PRs separate.

## Limits

No replacement of the mandatory checker, no strictness suppression, no bundler/compiler API migration. Full CI, native Linux/Windows execution and whole-application tests were not run. The local Node patch version is slightly below the repository's declared 24.13.1 floor; timings are a controlled local comparison, not platform certification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly dev-tooling and documentation; legacy typecheck and builds are unchanged, with the native checker explicitly documented as non-certifying.
> 
> **Overview**
> Adds **`bun run typecheck:native`** as an optional, faster dev loop across all seven workspaces, wired through Turbo and pinned to **TypeScript 7.0.2** (`@typescript/native`) with **`@effect/tsgo` 0.41.0**, separate incremental cache files, and an root **`effect-tsgo patch`** step. **`bun run typecheck`** (TS 5 + `@effect/language-service`) stays the required CI/pre-merge gate; README and a new **`docs/performance/2026-09-06/`** report document that native checks are **not** equivalent—especially missing configured **`importFromBarrel`** errors—and record ~4.5× / ~3.8× median speedups on a controlled macOS run.
> 
> Supporting changes keep both compilers on the same sources: explicit **`types: ["node"]`** in contracts/shared, **`GuestCrypto.getRandomValues`** typed as **`Crypto["getRandomValues"]`**, simplified **`lastKnownPr`** fallbacks in **`resolveTerminalThreadCreationState`** (with new tests for null/omitted active PR), and Codex adapter test fixtures using valid **`"session"`** event kinds instead of **`"lifecycle"`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1107e3bb3df74498eb67ba9639f34160a42308a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->