### PR TITLE
fix(grok): render Muse xhigh and max reasoning efforts

### DIFF
--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -28,8 +28,17 @@ export const PI_THINKING_LEVEL_OPTIONS = [
 ] as const;
 export type PiThinkingLevel = (typeof PI_THINKING_LEVEL_OPTIONS)[number];
 // Union of every Grok CLI ladder. Per-model capabilities pick a subset:
-// grok-build keeps none/low/medium/high, Grok 4.5 drops none, Grok 4.6 adds xhigh.
-export const GROK_REASONING_EFFORT_OPTIONS = ["none", "low", "medium", "high", "xhigh"] as const;
+// grok-build keeps none/low/medium/high, Grok 4.5 drops none, Grok 4.6 adds xhigh,
+// and Muse custom models add minimal/max.
+export const GROK_REASONING_EFFORT_OPTIONS = [
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
 export type GrokReasoningEffort = (typeof GROK_REASONING_EFFORT_OPTIONS)[number];
 export const DROID_REASONING_EFFORT_OPTIONS = [
   "off",
@@ -238,11 +247,22 @@ const CODEX_GPT_5_5_CAPABILITIES: ModelCapabilities = {
 };
 
 const GROK_CLI_EFFORT_DESCRIPTIONS = {
+  minimal: "Shortest reasoning pass",
   low: "Quick, fast implementations",
   medium: "Balanced effort with standard implementation and testing",
   high: "Higher implementation quality with extensive reasoning",
   xhigh: "Highest effort and reasoning level",
+  max: "Extended reasoning",
 } as const;
+
+const GROK_CLI_EFFORT_LABELS: Record<Exclude<GrokReasoningEffort, "none">, string> = {
+  minimal: "Minimal",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "Extra High",
+  max: "Max",
+};
 
 function grokCliEffortOption(
   value: Exclude<GrokReasoningEffort, "none">,
@@ -250,7 +270,7 @@ function grokCliEffortOption(
 ): EffortOption {
   return {
     value,
-    label: value === "xhigh" ? "Extra High" : `${value.charAt(0).toUpperCase()}${value.slice(1)}`,
+    label: GROK_CLI_EFFORT_LABELS[value],
     description: GROK_CLI_EFFORT_DESCRIPTIONS[value],
     ...options,
   };
@@ -280,6 +300,23 @@ const GROK_4_5_CAPABILITIES = grokCapabilities([
 ]);
 
 const GROK_4_6_CAPABILITIES = grokCapabilities([
+  grokCliEffortOption("low"),
+  grokCliEffortOption("medium"),
+  grokCliEffortOption("high", { isDefault: true }),
+  grokCliEffortOption("xhigh"),
+]);
+
+const GROK_MUSE_CAPABILITIES = grokCapabilities([
+  grokCliEffortOption("minimal"),
+  grokCliEffortOption("low"),
+  grokCliEffortOption("medium"),
+  grokCliEffortOption("high", { isDefault: true }),
+  grokCliEffortOption("xhigh"),
+  grokCliEffortOption("max"),
+]);
+
+const GROK_MUSE_CONTRIBUTOR_CAPABILITIES = grokCapabilities([
+  grokCliEffortOption("minimal"),
   grokCliEffortOption("low"),
   grokCliEffortOption("medium"),
   grokCliEffortOption("high", { isDefault: true }),
@@ -1325,6 +1362,10 @@ Object.assign(MODEL_CAPABILITIES_INDEX.grok, {
   "grok-build-0.1": GROK_BUILD_CAPABILITIES,
   "grok-build": GROK_BUILD_CAPABILITIES,
   "grok-4.5": GROK_4_5_CAPABILITIES,
+  muse: GROK_MUSE_CAPABILITIES,
+  "muse-contributor": GROK_MUSE_CONTRIBUTOR_CAPABILITIES,
+  "muse-spark-1.3": GROK_MUSE_CAPABILITIES,
+  "muse-spark-1.3-contributor": GROK_MUSE_CONTRIBUTOR_CAPABILITIES,
 });
 
 // ── Provider display names ────────────────────────────────────────────

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -440,6 +440,32 @@ describe("getModelCapabilities reasoningEffortLevels", () => {
     expect(values("grok", "grok-4.7")).toEqual(["low", "medium", "high", "xhigh"]);
   });
 
+  it("returns Muse custom-model effort ladders including xhigh and max", () => {
+    expect(values("grok", "muse-spark-1.3")).toEqual([
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+    expect(values("grok", "muse-spark-1.3-contributor")).toEqual([
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+    expect(values("grok", "muse-spark-1.4")).toEqual([
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+  });
+
   it("co-locates labels with effort values", () => {
     const levels = getModelCapabilities("claudeAgent", "claude-opus-4-6").reasoningEffortLevels;
     const high = levels.find((l) => l.value === "high");
@@ -518,6 +544,8 @@ describe("resolveGrokEffortFamily", () => {
     expect(resolveGrokEffortFamily("grok-4.6")).toBe("4.6");
     expect(resolveGrokEffortFamily("grok-4.7")).toBe("4.6");
     expect(resolveGrokEffortFamily("custom/grok-fast")).toBe("build");
+    expect(resolveGrokEffortFamily("muse-spark-1.3")).toBe("muse");
+    expect(resolveGrokEffortFamily("muse-spark-1.3-contributor")).toBe("muse-contributor");
   });
 });
 
@@ -1119,6 +1147,15 @@ describe("normalizeGrokModelOptions", () => {
       reasoningEffort: "xhigh",
     });
     expect(normalizeGrokModelOptions("grok-4.6", { reasoningEffort: "none" })).toBeUndefined();
+    expect(normalizeGrokModelOptions("muse-spark-1.3", { reasoningEffort: "xhigh" })).toEqual({
+      reasoningEffort: "xhigh",
+    });
+    expect(normalizeGrokModelOptions("muse-spark-1.3", { reasoningEffort: "max" })).toEqual({
+      reasoningEffort: "max",
+    });
+    expect(
+      normalizeGrokModelOptions("muse-spark-1.3-contributor", { reasoningEffort: "max" }),
+    ).toBeUndefined();
   });
 });
 

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -497,8 +497,13 @@ export function getModelCapabilities(
   return EMPTY_MODEL_CAPABILITIES;
 }
 
-export function resolveGrokEffortFamily(model: string): "build" | "4.5" | "4.6" {
+export function resolveGrokEffortFamily(
+  model: string,
+): "build" | "4.5" | "4.6" | "muse" | "muse-contributor" {
   const slug = model.trim().toLowerCase();
+  if (slug.includes("muse")) {
+    return slug.includes("contributor") ? "muse-contributor" : "muse";
+  }
   if (
     slug.includes("build") ||
     slug.includes("code-fast") ||
@@ -527,13 +532,25 @@ export function resolveGrokEffortFamily(model: string): "build" | "4.5" | "4.6" 
   return "4.6";
 }
 
-function grokCapabilitiesForFamily(family: "build" | "4.5" | "4.6"): ModelCapabilities {
+function grokCapabilitiesForFamily(
+  family: "build" | "4.5" | "4.6" | "muse" | "muse-contributor",
+): ModelCapabilities {
   const grokCaps = MODEL_CAPABILITIES_INDEX.grok;
   if (family === "build") {
     return grokCaps["grok-build"] ?? EMPTY_MODEL_CAPABILITIES;
   }
   if (family === "4.5") {
     return grokCaps["grok-4.5"] ?? grokCaps["grok-4.6"] ?? EMPTY_MODEL_CAPABILITIES;
+  }
+  if (family === "muse") {
+    return grokCaps.muse ?? grokCaps["muse-spark-1.3"] ?? EMPTY_MODEL_CAPABILITIES;
+  }
+  if (family === "muse-contributor") {
+    return (
+      grokCaps["muse-contributor"] ??
+      grokCaps["muse-spark-1.3-contributor"] ??
+      EMPTY_MODEL_CAPABILITIES
+    );
   }
   return grokCaps["grok-4.6"] ?? EMPTY_MODEL_CAPABILITIES;
 }


### PR DESCRIPTION
## Summary

Grok custom models such as `muse-spark-1.3` show up in Synara via `grok models`, but the effort picker never listed **Extra High** (`xhigh`) or **Max**.

`resolveGrokEffortFamily()` only recognizes `grok-X.Y` slugs. Anything else, including Muse, falls through to the **grok-build** ladder (`none` / `low` / `medium` / `high`). Discovery then stamps that truncated list onto the runtime model, so the composer cannot render the extra levels even though they are configured in `~/.grok/config.toml`.

This change:

- Maps `muse*` slugs to a Muse ladder (`minimal`, `low`, `medium`, `high`, `xhigh`, `max`)
- Maps `muse*-contributor` slugs to the same ladder without `max` (standard-tier only)
- Adds `minimal` and `max` to `GROK_REASONING_EFFORT_OPTIONS` so the picker can persist and send those values through `--reasoning-effort`

Unclassified custom Grok aliases still use the grok-build ladder.

## Test plan

- [x] `packages/shared` `src/model.test.ts` (103 tests)
- [x] `apps/server` GrokAdapter + GrokAcpSupport tests
- [ ] In Synara, select Grok → Muse Spark 1.3 and confirm the effort menu includes Minimal, Extra High, and Max
- [ ] Select Muse Spark 1.3 Contributor and confirm Extra High is present and Max is not
- [ ] Selecting Extra High / Max starts the session with `--reasoning-effort xhigh|max`