### PR TITLE
fix(antigravity): capture cumulative usage from CLI JSON results

### DIFF
--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -2451,3 +2451,108 @@ describe("Antigravity background task helpers (#752)", () => {
     }
   });
 });
+
+describe("Antigravity print result telemetry", () => {
+  it.each([false, true])(
+    "drains JSON after stop and unwraps responses (error=%s)",
+    async (failed) => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-agy-json-"));
+      let teardownCalls = 0;
+      const spawnProcess: NonNullable<AntigravityAdapterDependencies["spawnProcess"]> = (
+        _command,
+        args,
+        options,
+      ) => {
+        expect(args).toEqual(expect.arrayContaining(["--output-format", "json"]));
+        const child = new EventEmitter() as ReturnType<
+          NonNullable<AntigravityAdapterDependencies["spawnProcess"]>
+        >;
+        const stdout = new PassThrough();
+        Object.assign(child, {
+          stdout,
+          stderr: new PassThrough(),
+          killed: false,
+          kill: () => true,
+        });
+        fsSync.appendFileSync(options.env!.SYNARA_ANTIGRAVITY_EVENTS!, "stop\t{}\n");
+        // The hook is observed first. A normal CLI then flushes its envelope.
+        setTimeout(() => {
+          stdout.end(
+            JSON.stringify({
+              conversation_id: "json-conversation",
+              status: failed ? "ERROR" : "SUCCESS",
+              response: "visible answer",
+              ...(failed ? { error: "provider failed" } : {}),
+              usage: { input_tokens: 80, output_tokens: 20, total_tokens: 100 },
+            }),
+          );
+          child.emit("close", 0, null);
+        }, 600);
+        return child;
+      };
+      try {
+        await Effect.runPromise(
+          Effect.gen(function* () {
+            const adapter = yield* AntigravityAdapter;
+            const eventsFiber = yield* adapter.streamEvents.pipe(
+              Stream.takeUntil((event) => event.type === "turn.completed"),
+              Stream.runCollect,
+              Effect.forkChild,
+            );
+            const threadId = ThreadId.makeUnsafe("thread-json-output");
+            yield* adapter.startSession({
+              provider: "antigravity",
+              threadId,
+              runtimeMode: "full-access",
+              cwd: root,
+              providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+            });
+            yield* adapter.sendTurn({ threadId, input: "reply", attachments: [] });
+            const events = Array.from(
+              yield* Fiber.join(eventsFiber).pipe(Effect.timeout("3 seconds")),
+            );
+            const tokens = events.filter((event) => event.type === "thread.token-usage.updated");
+            expect(tokens).toHaveLength(1);
+            expect(tokens[0]).toMatchObject({
+              threadId,
+              payload: { usage: { usedTokens: 0, totalProcessedTokens: 100 } },
+            });
+            expect(events.at(-1)).toMatchObject({
+              type: "turn.completed",
+              payload: {
+                state: failed ? "failed" : "completed",
+                ...(failed ? { errorMessage: "provider failed" } : {}),
+              },
+            });
+            expect(
+              events
+                .filter((event) => event.type === "content.delta")
+                .map((event) => event.payload.delta),
+            ).toEqual(["visible answer"]);
+            expect(teardownCalls).toBe(0);
+            expect((yield* adapter.listSessions())[0]?.resumeCursor).toBe("json-conversation");
+            yield* adapter.stopSession(threadId);
+          }).pipe(
+            Effect.provide(
+              makeAntigravityAdapterLive({
+                ensurePlugin: async () => undefined,
+                spawnProcess,
+                teardownProcessTree: async () => {
+                  teardownCalls++;
+                  return completeProcessTeardown();
+                },
+              }).pipe(
+                Layer.provideMerge(
+                  ServerConfig.layerTest(root, { prefix: "antigravity-json-test-" }),
+                ),
+                Layer.provideMerge(NodeServices.layer),
+              ),
+            ),
+          ),
+        );
+      } finally {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -2453,6 +2453,104 @@ describe("Antigravity background task helpers (#752)", () => {
 });
 
 describe("Antigravity print result telemetry", () => {
+  it.each([true, false])(
+    "persists the usage baseline across restarts (legacy=%s)",
+    async (legacy) => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), "synara-agy-baseline-"));
+      const totals = [10_000, 10_300, 10_500];
+      const spawnProcess: NonNullable<AntigravityAdapterDependencies["spawnProcess"]> = () => {
+        const child = new EventEmitter() as ReturnType<
+          NonNullable<AntigravityAdapterDependencies["spawnProcess"]>
+        >;
+        const stdout = new PassThrough();
+        Object.assign(child, {
+          stdout,
+          stderr: new PassThrough(),
+          killed: false,
+          kill: () => true,
+        });
+        setTimeout(() => {
+          stdout.end(
+            JSON.stringify({
+              conversation_id: "existing-conversation",
+              status: "SUCCESS",
+              response: "answer",
+              usage: { total_tokens: totals.shift() },
+            }),
+          );
+          child.emit("close", 0, null);
+        }, 20);
+        return child;
+      };
+      try {
+        await Effect.runPromise(
+          Effect.gen(function* () {
+            const adapter = yield* AntigravityAdapter;
+            const threadId = ThreadId.makeUnsafe("thread-usage-baseline");
+            let resumeCursor: unknown = legacy ? "existing-conversation" : undefined;
+            for (let index = 0; index < 3; index++) {
+              yield* adapter.startSession({
+                provider: "antigravity",
+                threadId,
+                runtimeMode: "full-access",
+                cwd: root,
+                ...(resumeCursor !== undefined ? { resumeCursor } : {}),
+                providerOptions: { antigravity: { binaryPath: "/fake/agy" } },
+              });
+              const eventsFiber = yield* adapter.streamEvents.pipe(
+                Stream.takeUntil((event) => event.type === "turn.completed"),
+                Stream.runCollect,
+                Effect.forkChild,
+              );
+              yield* adapter.sendTurn({ threadId, input: "reply", attachments: [] });
+              const events = Array.from(
+                yield* Fiber.join(eventsFiber).pipe(Effect.timeout("3 seconds")),
+              );
+              const tokens = events.filter((event) => event.type === "thread.token-usage.updated");
+              if (legacy && index === 0) {
+                expect(tokens).toHaveLength(0);
+              } else {
+                expect(tokens).toHaveLength(1);
+                expect(tokens[0]).toMatchObject({
+                  payload: {
+                    usage: {
+                      totalProcessedTokens: legacy
+                        ? [0, 300, 500][index]
+                        : [10_000, 10_300, 10_500][index],
+                    },
+                  },
+                });
+              }
+              resumeCursor = JSON.parse(
+                JSON.stringify((yield* adapter.listSessions())[0]?.resumeCursor),
+              );
+              expect(resumeCursor).toEqual({
+                conversationId: "existing-conversation",
+                usageBaseline: legacy ? 10_000 : 0,
+              });
+              yield* adapter.stopSession(threadId);
+            }
+          }).pipe(
+            Effect.provide(
+              makeAntigravityAdapterLive({
+                ensurePlugin: async () => undefined,
+                spawnProcess,
+                teardownProcessTree: async () => completeProcessTeardown(),
+              }).pipe(
+                Layer.provideMerge(
+                  ServerConfig.layerTest(root, { prefix: "antigravity-baseline-test-" }),
+                ),
+                Layer.provideMerge(NodeServices.layer),
+              ),
+            ),
+          ),
+        );
+      } finally {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
   it.each([false, true])(
     "drains JSON after stop and unwraps responses (error=%s)",
     async (failed) => {
@@ -2530,7 +2628,10 @@ describe("Antigravity print result telemetry", () => {
                 .map((event) => event.payload.delta),
             ).toEqual(["visible answer"]);
             expect(teardownCalls).toBe(0);
-            expect((yield* adapter.listSessions())[0]?.resumeCursor).toBe("json-conversation");
+            expect((yield* adapter.listSessions())[0]?.resumeCursor).toEqual({
+              conversationId: "json-conversation",
+              usageBaseline: 0,
+            });
             yield* adapter.stopSession(threadId);
           }).pipe(
             Effect.provide(

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -70,6 +70,7 @@ import {
 import { signalOwnedChildProcess } from "../../platform/processTreeController.ts";
 import { teardownChildProcessTree } from "../supervisedProcessTeardown.ts";
 
+import { nonNegativeInteger } from "../tokenUsage.ts";
 import { parseAntigravityPrintOutput } from "../antigravityPrintOutput.ts";
 
 const PROVIDER = "antigravity" as const;
@@ -140,6 +141,7 @@ type AntigravitySessionContext = ToolSurfaceCounters & {
   eventFile?: string | undefined;
   transcriptPath?: string | undefined;
   conversationId?: string | undefined;
+  usageBaseline: number | undefined;
   modelName?: string | undefined;
   modelOptions?: AntigravityModelOptions | undefined;
   processedHookBytes: number;
@@ -211,6 +213,15 @@ function resumeConversationId(value: unknown): string | undefined {
     if (typeof record[key] === "string" && record[key].trim()) return record[key].trim();
   }
   return undefined;
+}
+
+// Keep the baseline in the opaque resume cursor so a server restart cannot
+// turn pre-upgrade history into newly attributed usage.
+function antigravityResumeCursor(context: AntigravitySessionContext) {
+  return {
+    conversationId: context.conversationId,
+    ...(context.usageBaseline !== undefined ? { usageBaseline: context.usageBaseline } : {}),
+  };
 }
 
 function transcriptPathForConversation(conversationId: string): string {
@@ -1289,7 +1300,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
       context.session = {
         ...inactiveSession,
         status: failed ? "error" : "ready",
-        ...(context.conversationId ? { resumeCursor: context.conversationId } : {}),
+        ...(context.conversationId ? { resumeCursor: antigravityResumeCursor(context) } : {}),
         updatedAt: new Date().toISOString(),
         ...(failed && input.errorMessage ? { lastError: input.errorMessage } : {}),
       };
@@ -1756,7 +1767,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         if (learnedConversation) {
           context.session = {
             ...context.session,
-            resumeCursor: conversationId,
+            resumeCursor: antigravityResumeCursor(context),
             updatedAt: new Date().toISOString(),
           };
           offer({
@@ -1980,6 +1991,13 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         }
         const now = new Date().toISOString();
         const conversationId = resumeConversationId(input.resumeCursor);
+        const usageBaseline = conversationId
+          ? nonNegativeInteger(
+              typeof input.resumeCursor === "object" && input.resumeCursor !== null
+                ? (input.resumeCursor as Record<string, unknown>).usageBaseline
+                : undefined,
+            )
+          : 0;
         const modelSelection =
           input.modelSelection?.provider === PROVIDER ? input.modelSelection : undefined;
         const model = modelSelection?.model ?? DEFAULT_MODEL;
@@ -1990,7 +2008,14 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           cwd: trim(input.cwd) ?? serverConfig.cwd,
           model,
           threadId: input.threadId,
-          ...(conversationId ? { resumeCursor: conversationId } : {}),
+          ...(conversationId
+            ? {
+                resumeCursor: {
+                  conversationId,
+                  ...(usageBaseline !== undefined ? { usageBaseline } : {}),
+                },
+              }
+            : {}),
           createdAt: now,
           updatedAt: now,
         };
@@ -2000,6 +2025,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
             ? { lifecycleGeneration: input.lifecycleGeneration }
             : {}),
           binaryPath,
+          usageBaseline,
           turns: [],
           ...(conversationId ? { conversationId } : {}),
           ...(modelSelection?.options ? { modelOptions: modelSelection.options } : {}),
@@ -2293,11 +2319,24 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
               return;
             }
             if (printOutput.usage) {
-              offer({
-                ...base(context),
-                type: "thread.token-usage.updated",
-                payload: { usage: printOutput.usage },
-              } satisfies ProviderRuntimeEvent);
+              const total = printOutput.usage.totalProcessedTokens!;
+              // A legacy resume has no trustworthy pre-turn counter. Its first
+              // result establishes the baseline, including that first turn;
+              // only later increments can be attributed without guessing.
+              context.usageBaseline ??= total;
+              const trackedTotal = total - context.usageBaseline;
+              if (trackedTotal > 0) {
+                offer({
+                  ...base(context),
+                  type: "thread.token-usage.updated",
+                  payload: {
+                    usage:
+                      context.usageBaseline === 0
+                        ? printOutput.usage
+                        : { usedTokens: 0, totalProcessedTokens: trackedTotal },
+                  },
+                } satisfies ProviderRuntimeEvent);
+              }
             }
             const interrupted = context.interrupted || signal !== null;
             const failed = !interrupted && ((code ?? 1) !== 0 || printOutput.error !== undefined);
@@ -2328,7 +2367,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         return {
           threadId: input.threadId,
           turnId,
-          ...(context.conversationId ? { resumeCursor: context.conversationId } : {}),
+          ...(context.conversationId ? { resumeCursor: antigravityResumeCursor(context) } : {}),
         };
       });
 
@@ -2432,6 +2471,7 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           context.turns.splice(Math.max(0, context.turns.length - Math.max(0, numTurns)));
           // Antigravity has no rollback cursor; ProviderService will rebuild local context.
           delete context.conversationId;
+          context.usageBaseline = 0;
           delete context.transcriptPath;
           delete context.processedTranscriptPath;
           context.processedTranscriptBytes = 0;

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -70,6 +70,8 @@ import {
 import { signalOwnedChildProcess } from "../../platform/processTreeController.ts";
 import { teardownChildProcessTree } from "../supervisedProcessTeardown.ts";
 
+import { parseAntigravityPrintOutput } from "../antigravityPrintOutput.ts";
+
 const PROVIDER = "antigravity" as const;
 const DEFAULT_MODEL = "Gemini 3.5 Flash";
 const PRINT_TIMEOUT = "30m";
@@ -1217,13 +1219,27 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
         return;
       }
       const child = context.activeProcess;
-      void teardownProcessTree(child).catch(() => {
-        try {
-          child.kill("SIGKILL");
-        } catch {
-          // Process may already be gone.
-        }
-      });
+      // The stop hook runs before print mode writes its final JSON envelope.
+      // Allow a normal exit to flush response/usage; still bound lingering CLI
+      // processes, and never tear down a later turn or new background work.
+      const timer = setTimeout(() => {
+        if (
+          context.activeProcess !== child ||
+          context.turnTerminalEmitted ||
+          context.pendingBackgroundTasks.size > 0 ||
+          context.pendingAnonymousBackgroundTasks > 0
+        )
+          return;
+        void teardownProcessTree(child).catch(() => {
+          try {
+            child.kill("SIGKILL");
+          } catch {
+            /* Process may already be gone. */
+          }
+        });
+      }, 1_000);
+      timer.unref();
+      child.once("close", () => clearTimeout(timer));
     };
 
     /**
@@ -2156,6 +2172,8 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
           logFile,
           "--print-timeout",
           PRINT_TIMEOUT,
+          "--output-format",
+          "json",
           "-p",
           providerPrompt,
         ];
@@ -2253,13 +2271,17 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
               await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
               return;
             }
-            if (!context.sawAssistant && stdout.trim()) {
+            const printOutput = parseAntigravityPrintOutput(stdout);
+            if (!context.conversationId && printOutput.conversationId) {
+              context.conversationId = printOutput.conversationId;
+            }
+            if (!context.sawAssistant && printOutput.response) {
               emitTextItem(
                 context,
                 {
                   step_index: Number.MAX_SAFE_INTEGER,
                   type: "PRINT_OUTPUT",
-                  content: stdout.trim(),
+                  content: printOutput.response,
                 },
                 "assistant_message",
                 "assistant_text",
@@ -2270,8 +2292,15 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
               await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
               return;
             }
+            if (printOutput.usage) {
+              offer({
+                ...base(context),
+                type: "thread.token-usage.updated",
+                payload: { usage: printOutput.usage },
+              } satisfies ProviderRuntimeEvent);
+            }
             const interrupted = context.interrupted || signal !== null;
-            const failed = !interrupted && (code ?? 1) !== 0;
+            const failed = !interrupted && ((code ?? 1) !== 0 || printOutput.error !== undefined);
             if (failed && stderr.trim()) {
               offer({
                 ...base(context, { includeTurn: false }),
@@ -2285,7 +2314,10 @@ const makeAntigravityAdapter = (dependencies: AntigravityAdapterDependencies = {
               stopReason: interrupted ? "interrupted" : failed ? "error" : "model_stop",
               ...(failed
                 ? {
-                    errorMessage: stderr.trim() || `Antigravity CLI exited with code ${code ?? 1}.`,
+                    errorMessage:
+                      printOutput.error ||
+                      stderr.trim() ||
+                      `Antigravity CLI exited with code ${code ?? 1}.`,
                   }
                 : {}),
               raw: raw("process-exit", { code, signal, stdout, stderr }),

--- a/apps/server/src/provider/antigravityPrintOutput.test.ts
+++ b/apps/server/src/provider/antigravityPrintOutput.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { parseAntigravityPrintOutput } from "./antigravityPrintOutput.ts";
+
+// Sanitized agy 1.1.27 JSON results from two real turns, the second resumed.
+const firstUsage = {
+  input_tokens: 5952,
+  output_tokens: 473,
+  thinking_tokens: 465,
+  cache_read_tokens: 8131,
+  total_tokens: 6425,
+};
+const secondUsage = {
+  input_tokens: 13420,
+  output_tokens: 549,
+  thinking_tokens: 536,
+  cache_read_tokens: 16297,
+  total_tokens: 13969,
+};
+const envelope = (usage: unknown, extra: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    conversation_id: "test-conversation",
+    status: "SUCCESS",
+    response: "hello\n",
+    usage,
+    ...extra,
+  });
+
+describe("parseAntigravityPrintOutput", () => {
+  it("unwraps the response and preserves native cumulative totals across resume", () => {
+    const first = parseAntigravityPrintOutput(envelope(firstUsage));
+    const second = parseAntigravityPrintOutput(envelope(secondUsage, { num_turns: 2 }));
+    expect(first).toEqual({
+      response: "hello",
+      conversationId: "test-conversation",
+      usage: {
+        usedTokens: 0,
+        inputTokens: 5952,
+        outputTokens: 473,
+        reasoningOutputTokens: 465,
+        cachedInputTokens: 8131,
+        totalProcessedTokens: 6425,
+      },
+    });
+    expect(second.usage?.totalProcessedTokens).toBe(13969);
+    expect(second.usage?.totalProcessedTokens! - first.usage?.totalProcessedTokens!).toBe(7544);
+    expect(first.usage?.maxTokens).toBeUndefined();
+    expect(first.usage?.usedPercent).toBeUndefined();
+  });
+
+  it.each([
+    undefined,
+    null,
+    {},
+    { total_tokens: 0 },
+    { total_tokens: -1 },
+    { total_tokens: 1.5 },
+    { total_tokens: "100" },
+  ])("does not fabricate usage for %j", (usage) => {
+    expect(parseAntigravityPrintOutput(envelope(usage)).usage).toBeUndefined();
+  });
+
+  it("ignores invalid optional dimensions without losing a valid total", () => {
+    expect(
+      parseAntigravityPrintOutput(
+        envelope({ total_tokens: 100, input_tokens: -1, output_tokens: "20" }),
+      ).usage,
+    ).toEqual({ usedTokens: 0, totalProcessedTokens: 100 });
+  });
+
+  it("preserves plain output from older wrappers and arbitrary JSON responses", () => {
+    for (const text of ["hello", '{"answer":42}', "{truncated", "[]"]) {
+      expect(parseAntigravityPrintOutput(text)).toEqual({ response: text });
+    }
+  });
+
+  it("surfaces envelope errors while retaining any reported consumption", () => {
+    expect(
+      parseAntigravityPrintOutput(
+        envelope(firstUsage, { status: "ERROR", response: "", error: "model unavailable" }),
+      ),
+    ).toMatchObject({
+      response: "",
+      error: "model unavailable",
+      usage: { totalProcessedTokens: 6425 },
+    });
+  });
+});

--- a/apps/server/src/provider/antigravityPrintOutput.ts
+++ b/apps/server/src/provider/antigravityPrintOutput.ts
@@ -1,0 +1,67 @@
+import type { ThreadTokenUsageSnapshot } from "@synara/contracts";
+
+import { nonNegativeInteger, positiveInteger } from "./tokenUsage.ts";
+
+interface AntigravityPrintOutput {
+  readonly response: string;
+  readonly conversationId?: string;
+  readonly error?: string;
+  readonly usage?: ThreadTokenUsageSnapshot;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// The headless result's usage is cumulative over the conversation, including
+// resumed invocations. Forward total_tokens unchanged: thinking is already in
+// output_tokens, and cache_read_tokens must not be added to the reported total.
+// https://antigravity.google/docs/cli/headless/#read-the-results
+export function parseAntigravityPrintOutput(stdout: string): AntigravityPrintOutput {
+  let result: unknown;
+  try {
+    result = JSON.parse(stdout);
+  } catch {
+    return { response: stdout.trim() };
+  }
+  if (
+    !isRecord(result) ||
+    typeof result.response !== "string" ||
+    typeof result.status !== "string"
+  ) {
+    return { response: stdout.trim() };
+  }
+  const usage = isRecord(result.usage) ? result.usage : {};
+  const totalProcessedTokens = positiveInteger(usage.total_tokens);
+  const inputTokens = nonNegativeInteger(usage.input_tokens);
+  const outputTokens = nonNegativeInteger(usage.output_tokens);
+  const cachedInputTokens = nonNegativeInteger(usage.cache_read_tokens);
+  const reasoningOutputTokens = nonNegativeInteger(usage.thinking_tokens);
+  return {
+    response: result.response.trim(),
+    ...(typeof result.conversation_id === "string" && result.conversation_id.trim()
+      ? { conversationId: result.conversation_id.trim() }
+      : {}),
+    ...(result.status !== "SUCCESS"
+      ? {
+          error:
+            typeof result.error === "string" && result.error.trim()
+              ? result.error.trim()
+              : `Antigravity CLI returned ${result.status}.`,
+        }
+      : {}),
+    ...(totalProcessedTokens !== undefined
+      ? {
+          usage: {
+            // These are processed-token counters, not context occupancy.
+            usedTokens: 0,
+            totalProcessedTokens,
+            ...(inputTokens !== undefined ? { inputTokens } : {}),
+            ...(outputTokens !== undefined ? { outputTokens } : {}),
+            ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
+            ...(reasoningOutputTokens !== undefined ? { reasoningOutputTokens } : {}),
+          },
+        }
+      : {}),
+  };
+}


### PR DESCRIPTION
## What Changed

Refs #898 (Antigravity only; Cursor remains open).

Antigravity completed turns currently produce no token-usage activity because Synara launches `agy -p` with the default text output. Request the documented JSON envelope, unwrap its response, and publish its native cumulative counters through the existing `thread.token-usage.updated` path. This makes the existing Profile statistics include Antigravity usage without changing the UI or estimating tokens from message text.

The stop hook runs before the CLI flushes the final envelope. Give normal process exit a one-second grace period before the existing lingering-process teardown, with ownership and pending-background-work checks. Surface JSON error results even if the process exits with code zero.

## Why

The CLI's `usage` is cumulative over the conversation, including resumed invocations. For conversations created with this adapter, forward `total_tokens` unchanged; do not add cache or thinking counters again. Legacy resume cursors have no reliable usage baseline: suppress their first usable result and persist its total in the opaque resume cursor, then publish only cumulative usage above that baseline. This intentionally excludes the first resumed turn as well as older history rather than attributing historical tokens to today. Legacy baselined results omit the optional token breakdown, whose pre-upgrade components are not known. A zero baseline marks newly tracked conversations and survives restarts. Missing or zero totals emit no usage event. See the [Antigravity headless result contract](https://antigravity.google/docs/cli/headless/#read-the-results).

## Verification

Validation (macOS arm64, Node 24.13.1, Bun 1.4.2):

- Initial full format, lint, typecheck, brand identity and Windows runtime boundary checks pass. Review follow-up: 158 targeted tests pass (Antigravity parser/adapter and ProviderService), server typecheck passes, and changed-file formatting/lint passes (lint reports warnings, no errors).
- Before the review follow-up, full workspace tests: 10,540 passed, 30 skipped (`bun run test --concurrency=1`; serialized workspace scheduling avoids contention on the local Mac).
- Desktop build passes.
- Before the review follow-up, real agy 1.1.27 E2E through Synara: initial turn, server restart/resume, model switch, response display, archive and hard deletion. The final conversation reports 45,975 tokens; 29,484 remain attributed to the first model and 16,491 to the second. Both totals survive hard deletion, verified via the API and durable SQLite archive.
- Browser suite: 377 passed, 13 skipped, 4 failed across three frontend files. The tail-anchor failure reproduces unchanged on upstream 362db910 (same 356px assertion). The other three tests pass when rerun on both upstream and this branch. No frontend files changed. The full browser run is not claimed as green; logs and baseline comparisons are retained locally.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- UI screenshots and animation video: not applicable; no UI changes.
