### PR TITLE
ci: shard unit and browser lanes, cache installs, add docs-only fast path

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -26,6 +26,38 @@ runs:
         key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
         restore-keys: |
           ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}-
+    # Phase 1c/3: node_modules survives across jobs keyed on the lockfile.
+    # bun install --frozen-lockfile still runs below (correctness), but a warm
+    # cache turns resolve + download into link. The key is scoped by the
+    # electron input: Install Electron test runtime extracts the binary into
+    # apps/desktop/node_modules/electron/dist INSIDE node_modules, so the
+    # electron lane's tree differs from other lanes and must not share a blob.
+    - name: Cache node_modules
+      uses: actions/cache@v5
+      with:
+        path: |
+          node_modules
+          apps/*/node_modules
+          packages/*/node_modules
+          scripts/node_modules
+        key: ${{ runner.os }}-bun-node-modules-electron-${{ inputs.electron }}-${{ hashFiles('bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-bun-node-modules-electron-${{ inputs.electron }}-
+
+    # Phase 3h: persist Turbo's local cache store so cacheable build outputs
+    # survive across jobs. Turbo verifies its own fingerprints on hit, so a
+    # broad key is safe: stale entries simply miss inside turbo. test and
+    # typecheck stay cache:false in turbo.json (inputs not proven airtight).
+    - name: Cache Turbo outputs
+      uses: actions/cache@v5
+      with:
+        path: |
+          .turbo
+          node_modules/.cache/turbo
+        key: ${{ runner.os }}-turbo-${{ hashFiles('bun.lock') }}-${{ hashFiles('.github/workflows/ci.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-${{ hashFiles('bun.lock') }}-
+          ${{ runner.os }}-turbo-
 
     - name: Cache Electron runtime
       if: ${{ inputs.electron == 'true' }}

--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -48,14 +48,17 @@ runs:
     # survive across jobs. Turbo verifies its own fingerprints on hit, so a
     # broad key is safe: stale entries simply miss inside turbo. test and
     # typecheck stay cache:false in turbo.json (inputs not proven airtight).
+    # GitHub caches are immutable: each job/shard saves new results per commit
+    # and restores its previous snapshot before falling back to other lanes.
     - name: Cache Turbo outputs
       uses: actions/cache@v5
       with:
         path: |
           .turbo
           node_modules/.cache/turbo
-        key: ${{ runner.os }}-turbo-${{ hashFiles('bun.lock') }}-${{ hashFiles('.github/workflows/ci.yml') }}
+        key: ${{ runner.os }}-turbo-${{ hashFiles('bun.lock') }}-${{ hashFiles('.github/workflows/ci.yml') }}-${{ github.job }}-${{ strategy.job-index || 0 }}-${{ github.sha }}
         restore-keys: |
+          ${{ runner.os }}-turbo-${{ hashFiles('bun.lock') }}-${{ hashFiles('.github/workflows/ci.yml') }}-${{ github.job }}-${{ strategy.job-index || 0 }}-
           ${{ runner.os }}-turbo-${{ hashFiles('bun.lock') }}-
           ${{ runner.os }}-turbo-
 

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -1,0 +1,55 @@
+# Nightly quarantine: pixel/font/layout comparisons tracked explicitly in
+# apps/web/BROWSER_TEST_QUARANTINE.md while their Linux rendering is fixed.
+# Moved out of the blocking CI lane (CI speedup Phase 1a) so the PR gate stays
+# green and fast. Steps are UNCHANGED from the old CI quarantine step, still
+# continue-on-error here so flakes never page anyone.
+name: CI Nightly
+
+on:
+  schedule:
+    # 02:00 UTC daily.
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+# Unlike CI (which spares main), nightly always cancels stale runs, including
+# scheduled main runs: only the newest quarantine signal matters.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  browser-geometry:
+    name: Browser Tests (Linux geometry quarantine)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}
+
+      # Run the workspace-local playwright binary directly: bunx stalled after
+      # the chromium download on hosted runners. The step timeout stops any
+      # remaining apt/download stalls from eating the whole job budget.
+      - name: Install browser test runtime
+        timeout-minutes: 15
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          cd apps/web
+          ./node_modules/.bin/playwright install --with-deps chromium
+
+      # All untagged browser tests run in the blocking stable shards in CI.
+      - name: Browser test (Linux geometry quarantine)
+        continue-on-error: true
+        timeout-minutes: 10
+        run: bun run --cwd apps/web test:browser:geometry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ env:
   NODE_OPTIONS: --max-old-space-size=4096
 
 jobs:
-  # Docs-only filter: PRs touching only prose, images, or marketing content
+  # Docs-only filter: PRs touching only prose, doc images, or marketing content
   # run static-fast + gate only. outputs.code is 'true' when any code file changed.
   changes:
     name: Detect code changes
@@ -53,19 +53,14 @@ jobs:
               # Directory exclusions stay scoped to code-free trees: marketing
               # src ships .tsx under docs/ dirs and web ships a .ts module
               # under assets/, so '**/docs/**' / '**/assets/**' would let real
-              # code skip the gate. Binaries are excluded by extension below.
+              # code skip the gate. Runtime images stay on the code path:
+              # browser tests validate app icon transparency and layout.
               - '**'
               - '!**/*.md'
               - '!docs/**'
               - '!**/*.mdx'
               - '!apps/marketing/content/**'
-              - '!**/*.png'
-              - '!**/*.jpg'
-              - '!**/*.jpeg'
-              - '!**/*.gif'
-              - '!**/*.svg'
-              - '!**/*.webp'
-              - '!**/*.ico'
+              - '!.github/assets/**/*.{png,jpg,jpeg,gif,svg,webp,ico}'
 
   # Phase 1b: the old static lane split. Fast checks (no special runtime) stay
   # unblocked so docs-only PRs get a signal in ~1min.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,16 @@ jobs:
     name: Format, Lint, Typecheck, Test, Browser Test, Build
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    needs: [changes, static-fast, static-typecheck, unit, browser, build]
+    needs:
+      - changes
+      - static-fast
+      - static-typecheck
+      - unit
+      - browser
+      - build
+      - windows_process
+      - migration_lineage
+      - release_smoke
     if: always()
     steps:
       - name: Aggregate lane results
@@ -240,6 +249,9 @@ jobs:
           UNIT: ${{ needs.unit.result }}
           BROWSER: ${{ needs.browser.result }}
           BUILD: ${{ needs.build.result }}
+          WINDOWS_PROCESS: ${{ needs.windows_process.result }}
+          MIGRATION_LINEAGE: ${{ needs.migration_lineage.result }}
+          RELEASE_SMOKE: ${{ needs.release_smoke.result }}
         run: |
           fail=0
           # The docs-only filter itself must have run: without it a skip proves nothing.
@@ -247,12 +259,16 @@ jobs:
             echo "changes=$CHANGES (filter must succeed)"
             fail=1
           fi
+          if [ "$CODE" != "true" ] && [ "$CODE" != "false" ]; then
+            echo "code=$CODE (filter must return true or false)"
+            fail=1
+          fi
           # Fast static always runs, docs-only or not.
           if [ "$STATIC_FAST" != "success" ]; then
             echo "static-fast=$STATIC_FAST"
             fail=1
           fi
-          for lane in "typecheck=$TYPECHECK" "unit=$UNIT" "browser=$BROWSER" "build=$BUILD"; do
+          for lane in "typecheck=$TYPECHECK" "unit=$UNIT" "browser=$BROWSER" "build=$BUILD" "windows-process=$WINDOWS_PROCESS" "migration-lineage=$MIGRATION_LINEAGE" "release-smoke=$RELEASE_SMOKE"; do
             name="${lane%%=*}"
             result="${lane#*=}"
             if [ "$CODE" != "true" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
-# Lane rule: static is fast checks with no special runtime, unit is bun test, browser owns Playwright and is the long pole, build owns Electron and desktop output.
-# Gate (quality) aggregates only: add no run steps there. A new fast check with no runtime goes to static.
+# Lane rule: static-fast is fast checks with no special runtime, static-typecheck is tsc,
+# unit is bun test per package, browser owns Playwright (stable only, sharded) and is the long pole,
+# build owns Electron and desktop output. Geometry quarantine lives in ci-nightly.yml.
+# Gate (quality) aggregates only: add no run steps there. A new fast check with no runtime goes to static-fast.
 # Setup-workspace runs once per lane, not once for all: never put checks in the shared action.
 name: CI
 
@@ -14,9 +16,61 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+# Single heap ceiling for every Node lane (typecheck OOM fix): set once here
+# instead of per job so a future bump cannot miss a lane.
+env:
+  NODE_OPTIONS: --max-old-space-size=4096
+
 jobs:
-  static:
-    name: Static Checks
+  # Docs-only filter: PRs touching only prose, images, or marketing content
+  # run static-fast + gate only. outputs.code is 'true' when any code file changed.
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    # dorny/paths-filter lists PR files via the API: it needs pull-requests
+    # scope on top of the checkout's contents scope (repo default is tighter).
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Filter docs-only changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          # Default quantifier is 'some': any matching pattern includes the file,
+          # so '!**/*.md' style exclusions never exclude anything and every PR
+          # classifies as code. 'every' requires all patterns to match, which is
+          # what makes the include-all + exclude-docs combination work.
+          predicate-quantifier: "every"
+          filters: |
+            code:
+              # Directory exclusions stay scoped to code-free trees: marketing
+              # src ships .tsx under docs/ dirs and web ships a .ts module
+              # under assets/, so '**/docs/**' / '**/assets/**' would let real
+              # code skip the gate. Binaries are excluded by extension below.
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!**/*.mdx'
+              - '!apps/marketing/content/**'
+              - '!**/*.png'
+              - '!**/*.jpg'
+              - '!**/*.jpeg'
+              - '!**/*.gif'
+              - '!**/*.svg'
+              - '!**/*.webp'
+              - '!**/*.ico'
+
+  # Phase 1b: the old static lane split. Fast checks (no special runtime) stay
+  # unblocked so docs-only PRs get a signal in ~1min.
+  static-fast:
+    name: Static Checks (fast)
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -38,13 +92,51 @@ jobs:
       - name: Lint
         run: bun run lint
 
+  static-typecheck:
+    name: Static Checks (typecheck)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
+
       - name: Typecheck
         run: bun run typecheck
 
+  # Phase 2f: one shard per workspace package via --filter. Going through turbo
+  # keeps the ^build contract (test dependsOn ^build) working per shard. The
+  # server package script keeps its serial flags (--maxWorkers=1
+  # --no-file-parallelism) inside its own shard.
   unit:
-    name: Unit Tests
+    name: Unit Tests (${{ matrix.pkg }})
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    strategy:
+      # Deliberate non-default: one shard's failure must not cancel the other
+      # shards, so every lane reports complete signal for the gate.
+      fail-fast: false
+      matrix:
+        include:
+          - pkg: contracts
+            filter: "@synara/contracts"
+          - pkg: shared
+            filter: "@synara/shared"
+          - pkg: scripts
+            filter: "@synara/scripts"
+          - pkg: desktop
+            filter: "@synara/desktop"
+          - pkg: web
+            filter: "@synara/web"
+          # Server lane tests the CLI package (package name @synara/cli).
+          - pkg: server
+            filter: "@synara/cli"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -53,15 +145,30 @@ jobs:
         uses: ./.github/actions/setup-workspace
 
       - name: Verify Linux terminal PTY native dependency
+        if: matrix.pkg == 'server'
         run: node scripts/node-pty-smoke.mjs
 
-      - name: Test
-        run: bun run test
+      - name: Test (${{ matrix.pkg }})
+        run: bunx turbo run test --filter=${{ matrix.filter }}
 
+  # Phase 2e: stable browser suite split 3 ways. fileParallelism:false stays in
+  # vitest.browser.stable.config.ts (untouched); --shard splits test FILES
+  # across shards, never parallelizes within a file. Each shard provisions its
+  # own chromium on its own runner.
   browser:
-    name: Browser Tests
+    name: Browser Tests (stable ${{ matrix.shard }}/3)
     runs-on: ubuntu-24.04
-    timeout-minutes: 55
+    timeout-minutes: 30
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    strategy:
+      # Deliberate non-default: one shard's failure must not cancel the other
+      # shards, so every lane reports complete signal for the gate.
+      fail-fast: false
+      matrix:
+        # Single source of the shard count: resharding must also update the /3
+        # in the job name above and the --shard arg in the run step below.
+        shard: [1, 2, 3]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -86,22 +193,16 @@ jobs:
           cd apps/web
           ./node_modules/.bin/playwright install --with-deps chromium
 
-      - name: Browser test (stable)
+      - name: Browser test (stable shard ${{ matrix.shard }}/3)
         timeout-minutes: 20
-        run: bun run --cwd apps/web test:browser:stable
-
-      # Pixel/font/layout comparisons are tracked explicitly in
-      # apps/web/BROWSER_TEST_QUARANTINE.md while their Linux rendering is fixed.
-      # All untagged browser tests run in the blocking stable step above.
-      - name: Browser test (Linux geometry quarantine)
-        continue-on-error: true
-        timeout-minutes: 10
-        run: bun run --cwd apps/web test:browser:geometry
+        run: bun run --cwd apps/web test:browser:stable -- --shard=${{ matrix.shard }}/3
 
   build:
     name: Desktop Build
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -120,22 +221,52 @@ jobs:
           grep -nE "desktopBridge|getWsUrl|PICK_FOLDER_CHANNEL|wsUrl" apps/desktop/dist-electron/preload.js
 
   # Aggregate only: no checkout, no run steps. Keep the old display name for branch protection. if: always() is intended, do not remove.
+  # Phase 2g: needs every required lane. Matrix jobs report one result covering
+  # all shards, so ANY failed shard fails the gate. Docs-only runs pass with
+  # heavy lanes skipped (static-fast must still succeed).
   quality:
     name: Format, Lint, Typecheck, Test, Browser Test, Build
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    needs: [static, unit, browser, build]
+    needs: [changes, static-fast, static-typecheck, unit, browser, build]
     if: always()
     steps:
       - name: Aggregate lane results
         env:
-          STATIC: ${{ needs.static.result }}
+          CHANGES: ${{ needs.changes.result }}
+          CODE: ${{ needs.changes.outputs.code }}
+          STATIC_FAST: ${{ needs.static-fast.result }}
+          TYPECHECK: ${{ needs.static-typecheck.result }}
           UNIT: ${{ needs.unit.result }}
           BROWSER: ${{ needs.browser.result }}
           BUILD: ${{ needs.build.result }}
         run: |
-          if [ "$STATIC" != "success" ] || [ "$UNIT" != "success" ] || [ "$BROWSER" != "success" ] || [ "$BUILD" != "success" ]; then
-            echo "static=$STATIC unit=$UNIT browser=$BROWSER build=$BUILD"
+          fail=0
+          # The docs-only filter itself must have run: without it a skip proves nothing.
+          if [ "$CHANGES" != "success" ]; then
+            echo "changes=$CHANGES (filter must succeed)"
+            fail=1
+          fi
+          # Fast static always runs, docs-only or not.
+          if [ "$STATIC_FAST" != "success" ]; then
+            echo "static-fast=$STATIC_FAST"
+            fail=1
+          fi
+          for lane in "typecheck=$TYPECHECK" "unit=$UNIT" "browser=$BROWSER" "build=$BUILD"; do
+            name="${lane%%=*}"
+            result="${lane#*=}"
+            if [ "$CODE" != "true" ]; then
+              # Docs-only run: heavy lanes must be skipped, never failed.
+              if [ "$result" != "skipped" ]; then
+                echo "$name=$result (docs-only run: expected skipped)"
+                fail=1
+              fi
+            elif [ "$result" != "success" ]; then
+              echo "$name=$result"
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
             echo "Open the red lane above, not this gate."
             exit 1
           fi
@@ -144,6 +275,8 @@ jobs:
     name: Windows Process Regression
     runs-on: windows-2022
     timeout-minutes: 15
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -222,6 +355,8 @@ jobs:
     name: Migration Lineage
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -240,6 +375,8 @@ jobs:
     name: Release Smoke
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Ports the CI speedup work from the beta mirror (where it has run on every PR today) into this repo. Same runner image, same test suites — only orchestration changes.

- **Sharding:** unit tests run one shard per workspace package (`bunx turbo run test --filter=<pkg>`, keeping the `^build` contract per shard; the server package keeps its serial flags inside its own shard). Browser tests split 3 ways with vitest `--shard` (`fileParallelism: false` untouched, so shards split files, never parallelize within one). `fail-fast: false` on both matrices so every lane reports complete signal to the gate.
- **Caching:** `setup-workspace` now caches `node_modules` (keyed on `bun.lock` + the electron input, since the electron lane extracts the binary into `node_modules`) and Turbo's local store. `bun install --frozen-lockfile` still runs; a warm cache turns resolve+download into link. `test` and `typecheck` stay `cache: false` in turbo.json.
- **Docs-only fast path:** a `changes` job classifies PRs with `dorny/paths-filter` using `predicate-quantifier: "every"` (the default `"some"` makes `!**/*.md`-style exclusions never exclude anything — every PR classifies as code). Docs-only PRs run static-fast + gate only; the gate enforces that heavy lanes were *skipped*, not failed.
- **Static split:** fast checks (no runtime) separate from typecheck, so docs-only PRs get signal in ~1 minute.
- **Heap:** single `NODE_OPTIONS=--max-old-space-size=4096` at the workflow level (typecheck OOM fix), instead of per-job values that a future bump could miss.
- **Geometry quarantine** moves out of the blocking browser lane into a new nightly workflow (`ci-nightly.yml`, unchanged steps, still `continue-on-error`), tracked in `apps/web/BROWSER_TEST_QUARANTINE.md` as before.

## Measured (beta mirror, same runner image, ~15 PRs today)

| | before | after |
|---|---|---|
| Code PR, wall | ~14-15 min (up to 42 min observed) | ~10 min (browser shard is the long pole) |
| Fast lanes (static-fast, small unit shards) | — | < 1 min |
| Docs-only PR | ~14 min | ~1-2 min |

Example: a server-only change ran static in 45s, unit shards 41s-7m39s, browser shards ~3-9.5 min, wall ~10 min. A docs-only PR ran the full gate in ~1 minute.

## Portability notes

- The three files are byte-portable from the mirror: no beta-specific references (verified by grep), and `apps/web/vitest.browser.stable.config.ts` + `apps/web/package.json` are identical between the repos, so `--shard` passthrough works unchanged.
- The PR's own CI run exercises the new workflow end to end (first run is cold-cache; steady-state timings land from the second run on).

## Test plan

- [x] Validated on the beta mirror across ~15 PRs, including docs-only fast-path runs and forced-failure gate checks.
- [ ] This PR's CI run exercises the new workflow on this repo (shards, caches, gate).
