### PR TITLE
test: fix KeybindingsToast cold-shard flake and AntigravityAdapter teardown race

### DIFF
--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -823,8 +823,21 @@ describe("Antigravity CLI integration helpers", () => {
             },
           ]);
 
+          const turnTerminalFiber = yield* adapter.streamEvents.pipe(
+            Stream.filter((event) => event.type === "turn.completed"),
+            Stream.take(1),
+            Stream.runCollect,
+            Effect.forkChild,
+          );
           child?.emit("close", 0, null);
-          yield* Effect.sleep("25 millis");
+          // The close handler settles the turn asynchronously (gateway cancel,
+          // hook-file drain, run-dir cleanup) and clears activeProcess before
+          // emitting turn.completed. Wait for that event instead of a fixed
+          // sleep so stopSession cannot race the pid-less fake into teardown.
+          const terminalEvents = Array.from(
+            yield* Fiber.join(turnTerminalFiber).pipe(Effect.timeout("2 seconds")),
+          );
+          expect(terminalEvents).toHaveLength(1);
           yield* adapter.stopSession(threadId);
         }).pipe(
           Effect.provide(

--- a/apps/web/src/components/KeybindingsToast.browser.tsx
+++ b/apps/web/src/components/KeybindingsToast.browser.tsx
@@ -44,8 +44,28 @@ interface TestFixture {
 let fixture: TestFixture;
 let serverConfigStreamClient: EffectRpcWebSocketClient | null = null;
 let serverConfigStreamRequestId: string | null = null;
+// Subscription budget stays generous: slow CI still needs tens of seconds for
+// WS sequencing after a cold start. Route-chunk warming happens in beforeAll
+// below, so this is a backstop, not the cold path.
+const COLD_MOUNT_SUBSCRIPTION_TIMEOUT_MS = 60_000;
+const SUBSCRIPTION_POLL_INTERVAL_MS = 16;
+// Warmup budget: absorbs the bulk of a cold chunk transform so the real
+// mounts start warm. Sized under the 90s hook budget with room for worker
+// start and the interception probe.
+const WARMUP_MOUNT_SUBSCRIPTION_TIMEOUT_MS = 80_000;
 
 const wsLink = ws.link(/ws(s)?:\/\/.*/);
+
+// The mock Service Worker activates asynchronously after worker.start()
+// resolves. A WebSocket opened before activation bypasses the mock, so the
+// first mount's subscribeServerConfig request never arrives and no wait
+// budget can save it. Probing a dummy socket proves the interception path is
+// live before any mount. Full runs hide this because an earlier file warms
+// the origin's registration; a shard can run this file cold.
+const WS_INTERCEPTION_PROBE_PATH = "/__mock-interception-probe";
+const WS_MOCK_ACTIVATION_TIMEOUT_MS = 30_000;
+const WS_PROBE_SETTLE_MS = 1_000;
+const WS_PROBE_RETRY_INTERVAL_MS = 250;
 
 function createBaseServerConfig(): ServerConfig {
   return createBrowserTestServerConfig(NOW_ISO);
@@ -273,6 +293,34 @@ async function sendServerConfigUpdatedPush(
   });
 }
 
+async function probeWsMockInterception(): Promise<boolean> {
+  const socket = new WebSocket(`ws://${window.location.host}${WS_INTERCEPTION_PROBE_PATH}`);
+  try {
+    await vi.waitFor(
+      () => {
+        expect(wsLink.clients.size).toBeGreaterThan(0);
+      },
+      { timeout: WS_PROBE_SETTLE_MS, interval: SUBSCRIPTION_POLL_INTERVAL_MS },
+    );
+    return true;
+  } catch {
+    // The probe bypassed the mock: activation is still in flight. The caller
+    // retries until the activation budget runs out, then fails loudly.
+    return false;
+  } finally {
+    socket.close();
+  }
+}
+
+async function waitForWsMockInterception(): Promise<void> {
+  await vi.waitFor(
+    async () => {
+      expect(await probeWsMockInterception()).toBe(true);
+    },
+    { timeout: WS_MOCK_ACTIVATION_TIMEOUT_MS, interval: WS_PROBE_RETRY_INTERVAL_MS },
+  );
+}
+
 function queryToastTitles(): string[] {
   return Array.from(document.querySelectorAll('[data-slot="toast-title"]')).map(
     (el) => el.textContent ?? "",
@@ -298,7 +346,9 @@ async function waitForNoToast(title: string): Promise<void> {
   );
 }
 
-async function mountApp(): Promise<{ cleanup: () => Promise<void> }> {
+async function mountApp(
+  subscriptionTimeoutMs = COLD_MOUNT_SUBSCRIPTION_TIMEOUT_MS,
+): Promise<{ cleanup: () => Promise<void> }> {
   const host = createFullscreenTestHost();
 
   const router = getRouter(createMemoryHistory({ initialEntries: [`/${THREAD_ID}`] }));
@@ -310,7 +360,8 @@ async function mountApp(): Promise<{ cleanup: () => Promise<void> }> {
         expect(serverConfigStreamRequestId).toBeTruthy();
         expect(serverConfigStreamClient).toBeTruthy();
       },
-      { timeout: 20_000, interval: 16 },
+      // Generous backstop for slow CI; chunk warming happens in beforeAll.
+      { timeout: subscriptionTimeoutMs, interval: SUBSCRIPTION_POLL_INTERVAL_MS },
     );
   } catch (cause) {
     await screen.unmount();
@@ -337,6 +388,21 @@ describe("Keybindings update toast", () => {
       quiet: true,
       serviceWorker: { url: "/mockServiceWorker.js" },
     });
+    await waitForWsMockInterception();
+    // Warm the code-split thread route before any test mounts. On a cold dev
+    // cache the first mount suspends on chunk transform; warming it here pays
+    // that cost once in the hook budget instead of failing the first test.
+    // Full runs hide this because an earlier file warms the cache; a shard
+    // can run this file cold. The warmup mount shows no toasts (clean mount,
+    // no pushes) and beforeEach resets all module state, so it cannot leak
+    // into assertions. A warmup timeout is deliberately ignored: the chunks
+    // it did fetch stay cached, and a still-cold mount fails loudly below.
+    try {
+      const warmup = await mountApp(WARMUP_MOUNT_SUBSCRIPTION_TIMEOUT_MS);
+      await warmup.cleanup();
+    } catch {
+      // Deliberate ignore, reason above; still-cold mounts fail loudly below.
+    }
   });
 
   afterAll(async () => {

--- a/apps/web/src/components/KeybindingsToast.browser.tsx
+++ b/apps/web/src/components/KeybindingsToast.browser.tsx
@@ -380,6 +380,10 @@ async function mountApp(
   };
 }
 
+// beforeAll worst case (30s activation + 80s warmup + worker start) exceeds the
+// 90s hookTimeout in vitest.browser.config.ts, so raise it for this file.
+vi.setConfig({ hookTimeout: 150_000 });
+
 describe("Keybindings update toast", () => {
   beforeAll(async () => {
     fixture = buildFixture();


### PR DESCRIPTION
## Summary

Ports two test-stability fixes from the beta mirror (validated there across ~15 CI runs today, including cold shards):

- **KeybindingsToast cold-shard flake** (`apps/web/src/components/KeybindingsToast.browser.tsx`): the mock Service Worker activates asynchronously after `worker.start()` resolves, so a WebSocket opened before activation bypasses the mock and the first mount's `subscribeServerConfig` request never arrives — no wait budget can save it. Full runs hide this because an earlier test file warms the origin's registration; a shard can run this file cold. Fix: probe a dummy socket to prove WS interception is live before any mount, and give the cold/warmup mount paths explicit, separately-sized budgets. This exact test failed in #1012's first CI run ("does not show success toasts for passive keybinding reloads", 100s timeout, `expected null to be truthy`).
- **AntigravityAdapter teardown race** (`apps/server/src/provider/Layers/AntigravityAdapter.test.ts`): replaces a fixed 25ms sleep with waiting for the actual `turn.completed` event, so `stopSession` cannot race the pid-less fake into teardown.

Both are test-only changes; no production code touched.

## Test plan

- [x] Running green on the beta mirror across ~15 CI runs today, including cold shards (the exact failure mode: a shard running this file cold).
- [ ] This PR's CI exercises both files on this repo (browser shard 1/3 runs the KeybindingsToast file cold).
