### PR TITLE
ci: exclude all .github images from the docs-only filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,14 +53,16 @@ jobs:
               # Directory exclusions stay scoped to code-free trees: marketing
               # src ships .tsx under docs/ dirs and web ships a .ts module
               # under assets/, so '**/docs/**' / '**/assets/**' would let real
-              # code skip the gate. Runtime images stay on the code path:
-              # browser tests validate app icon transparency and layout.
+              # code skip the gate. Every image under .github/ is code-free
+              # (PR evidence screenshots, docs assets). Runtime images stay on
+              # the code path: browser tests validate app icon transparency
+              # and layout.
               - '**'
               - '!**/*.md'
               - '!docs/**'
               - '!**/*.mdx'
               - '!apps/marketing/content/**'
-              - '!.github/assets/**/*.{png,jpg,jpeg,gif,svg,webp,ico}'
+              - '!.github/**/*.{png,jpg,jpeg,gif,svg,webp,ico}'
 
   # Phase 1b: the old static lane split. Fast checks (no special runtime) stay
   # unblocked so docs-only PRs get a signal in ~1min.


### PR DESCRIPTION
# ci: exclude all `.github` images from the docs-only filter

## Problem

#1012 scoped the docs-only image exclusion from `!**/*.png` (all images) to `!.github/assets/**` to keep runtime images on the full validation path. That is the right call for runtime images, but it left one code-free image tree uncovered: `.github/pr-assets/`, which holds PR evidence screenshots (currently `gateway-schema-fix/*.png`).

A PR that only adds a screenshot under `.github/pr-assets/` now classifies as a code change and runs the full heavy CI matrix, which contradicts the filter's stated intent that doc-image-only PRs run static-fast + gate only.

## Fix

Widen the exclusion from `.github/assets/**` to all of `.github/**`:

```yaml
- '!.github/**/*.{png,jpg,jpeg,gif,svg,webp,ico}'
```

Every image currently under `.github/` is code-free:

- `.github/pr-assets/gateway-schema-fix/` — 4 before/after PR screenshots
- `.github/assets/pi-model-discovery/` — 3 docs/README screenshots

Runtime images are unaffected: app icons live in `apps/desktop/resources/` and `apps/marketing/public/`, which stay on the code path, so browser tests still validate app icon transparency and layout.

## Verification

- `git ls-tree -r upstream/main --name-only | grep -E '^\.github/.*\.(png|jpg|...)$'` lists only the two directories above — no runtime assets under `.github/`
- Runtime icon locations confirmed outside `.github/`: `apps/desktop/resources/icon.{png,ico,icns}`, `dock-icon.png`, `apps/marketing/public/synara-icon.png`
- The `predicate-quantifier: "every"` semantics are unchanged; this only widens an existing exclusion
