### PR TITLE
fix(server): ship zod as a runtime dependency

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -41,7 +41,8 @@
     "node-pty": "^1.1.0",
     "open": "^10.1.0",
     "tree-kill": "^1.2.2",
-    "ws": "^8.21.0"
+    "ws": "^8.21.0",
+    "zod": "4.3.6"
   },
   "devDependencies": {
     "@effect/language-service": "catalog:",
@@ -54,8 +55,7 @@
     "@types/ws": "^8.5.13",
     "tsdown": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:",
-    "zod": "4.3.6"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": "^22.19 || ^23.11 || >=24.10"

--- a/bun.lock
+++ b/bun.lock
@@ -93,6 +93,7 @@
         "open": "^10.1.0",
         "tree-kill": "^1.2.2",
         "ws": "^8.21.0",
+        "zod": "4.3.6",
       },
       "devDependencies": {
         "@effect/language-service": "catalog:",
@@ -106,7 +107,6 @@
         "tsdown": "catalog:",
         "typescript": "catalog:",
         "vitest": "catalog:",
-        "zod": "4.3.6",
       },
     },
     "apps/web": {


### PR DESCRIPTION
# fix(server): ship zod as a runtime dependency

## The bug

Packaged desktop apps (confirmed on the v0.8.2 macOS build) crash when starting any session on an ACP-based provider — reported with Devin SWE 1.7:

```
Error: Cannot find package 'zod' imported from
app.asar/node_modules/@agentclientprotocol/sdk/dist/schema-deserialize.js
```

## Root cause

`@agentclientprotocol/sdk` declares `zod` as a **peerDependency** and imports it at runtime. The app's `apps/server` declared `zod` only under `devDependencies`:

- Dev installs have zod, so local runs and CI never see the problem.
- The release pipeline stages production dependencies with `bun install --frozen-lockfile --omit=dev --linker hoisted` (see `installFrozenStageDependencies` in `scripts/build-desktop-artifact.ts`), which omits devDependencies — and nothing in the workspace depends on zod at runtime, so the staged `node_modules` ships without it.
- The packaged app then cannot resolve the SDK's zod import at first use.

The same exposure applies to the other staged packages whose runtime code imports zod as a peer: `@anthropic-ai/claude-agent-sdk`, `@modelcontextprotocol/sdk`, and `zod-to-json-schema`.

## The fix

Move `zod` from `devDependencies` to `dependencies` in `apps/server/package.json` (one line + lockfile entry). No version change: `4.3.6` already satisfies every peer range.

## Verification

Reproduced the exact packaging step in a clean stage (workspace manifests + `bun.lock` + `bun install --frozen-lockfile --omit=dev --ignore-scripts --linker hoisted`):

- Before the fix: the staged tree contains **zero** zod files (verified by listing the shipped v0.8.2 `app.asar` — `node_modules/zod` is absent while `@agentclientprotocol/sdk@1.2.1` is present).
- After the fix: the staged tree ships `zod@4.3.6`.
- `bun install --frozen-lockfile` validates the hand-moved lockfile entry without rewriting anything else (no unrelated churn).

## Suggested follow-ups (not in this PR)

- Cut a patch release (v0.8.3) once this merges — every packaged build since the ACP SDK landed is affected for ACP-provider users.
- A staged peer-dependency verification in the release build (fail the build when any staged package's non-optional peer is missing) would have caught this; happy to send that as a follow-up PR.
