### PR TITLE
fix(models): normalize provider model display names

### DIFF
--- a/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -1,10 +1,14 @@
 import { type ModelSlug, type ProviderKind, type ServerProviderStatus } from "@synara/contracts";
-import { page } from "vitest/browser";
+import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { page } from "vitest/browser";
 import { render } from "vitest-browser-react";
 
 import { ProviderModelPicker } from "./ProviderModelPicker";
-import type { ProviderModelOption } from "../../providerModelOptions";
+import {
+  mergeDynamicModelOptions,
+  type ProviderModelOption,
+} from "../../providerModelOptions";
 import { FAVORITE_MODEL_STORAGE_KEYS } from "../../lib/modelFavorites";
 
 const MODEL_OPTIONS_BY_PROVIDER = {
@@ -145,6 +149,25 @@ const PI_FAVORITE_SORT_MODELS = [
   },
 ] satisfies ReadonlyArray<ProviderModelOption & { slug: ModelSlug }>;
 
+const PI_BRANDED_MODELS = mergeDynamicModelOptions({
+  provider: "pi",
+  staticOptions: [],
+  dynamicModels: [
+    {
+      slug: "zai/glm-5.3-flash",
+      name: "GLM-5.3-Flash",
+      upstreamProviderId: "zai",
+      upstreamProviderName: "Z.AI",
+    },
+    {
+      slug: "deepseek/deepseek-v4-flash",
+      name: "Deepseek V4 Flash",
+      upstreamProviderId: "deepseek",
+      upstreamProviderName: "DeepSeek",
+    },
+  ],
+}) satisfies ReadonlyArray<ProviderModelOption & { slug: ModelSlug }>;
+
 async function mountPicker(props: {
   provider: ProviderKind;
   model: ModelSlug;
@@ -266,6 +289,40 @@ describe("ProviderModelPicker", () => {
       );
     } finally {
       await mounted.cleanup();
+    }
+  });
+
+  it("keeps branded Pi model labels stable after selection", async () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+
+    function ControlledPiPicker() {
+      const [model, setModel] = useState<ModelSlug>("deepseek/deepseek-v4-flash");
+      return (
+        <ProviderModelPicker
+          provider="pi"
+          model={model}
+          lockedProvider="pi"
+          modelOptionsByProvider={{
+            ...MODEL_OPTIONS_BY_PROVIDER,
+            pi: PI_BRANDED_MODELS,
+          }}
+          onProviderModelChange={(_provider, nextModel) => setModel(nextModel)}
+        />
+      );
+    }
+
+    const screen = await render(<ControlledPiPicker />, { container: host });
+    try {
+      await expect.element(page.getByRole("button", { name: /DeepSeek V4 Flash/u })).toBeVisible();
+      await page.getByRole("button", { name: /DeepSeek V4 Flash/u }).click();
+      await page.getByRole("menuitemradio", { name: "GLM 5.3 Flash" }).click();
+
+      await expect.element(page.getByRole("button", { name: /GLM 5.3 Flash/u })).toBeVisible();
+      expect(document.body.textContent ?? "").not.toContain("Glm 5.3 Flash");
+    } finally {
+      await screen.unmount();
+      host.remove();
     }
   });
 

--- a/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -5,10 +5,7 @@ import { page } from "vitest/browser";
 import { render } from "vitest-browser-react";
 
 import { ProviderModelPicker } from "./ProviderModelPicker";
-import {
-  mergeDynamicModelOptions,
-  type ProviderModelOption,
-} from "../../providerModelOptions";
+import { mergeDynamicModelOptions, type ProviderModelOption } from "../../providerModelOptions";
 import { FAVORITE_MODEL_STORAGE_KEYS } from "../../lib/modelFavorites";
 
 const MODEL_OPTIONS_BY_PROVIDER = {

--- a/apps/web/src/providerModelOptions.test.ts
+++ b/apps/web/src/providerModelOptions.test.ts
@@ -4,6 +4,7 @@
 // Depends on: providerModelOptions shared formatting helpers.
 
 import { describe, expect, it } from "vitest";
+import { getAppModelOptions } from "./appSettings";
 
 import {
   buildModelSelection,
@@ -90,6 +91,38 @@ describe("formatProviderModelOptionName", () => {
 });
 
 describe("mergeDynamicModelOptions", () => {
+  it.each(["pi", "opencode"] as const)(
+    "preserves %s discovery names when selection adds a placeholder",
+    (provider) => {
+      const dynamicModels = [
+        { slug: "zai/glm-5.3-flash", name: "GLM-5.3-Flash", expected: "GLM 5.3 Flash" },
+        { slug: "zai/glm-5.3-fast", name: "GLM-5.3 Highspeed", expected: "GLM 5.3 Highspeed" },
+        {
+          slug: "deepseek/deepseek-v4-flash",
+          name: "DeepSeek V4 Flash",
+          expected: "DeepSeek V4 Flash",
+        },
+        {
+          slug: "opencode/minimax-m2.5-free",
+          name: "MiniMax M2.5 Free",
+          expected: "MiniMax M2.5 Free",
+        },
+        { slug: "kimi-for-coding/k2p6", name: "K2P6", expected: "K2P6" },
+        { slug: "custom/MyModel", name: "MyModel", expected: "MyModel" },
+      ];
+      for (const model of dynamicModels) {
+        for (const selected of [undefined, model.slug]) {
+          const options = mergeDynamicModelOptions({
+            provider,
+            staticOptions: getAppModelOptions(provider, [], selected),
+            dynamicModels,
+          });
+          expect(options.find((option) => option.slug === model.slug)?.name).toBe(model.expected);
+        }
+      }
+    },
+  );
+
   it("normalizes slug-shaped Pi display names", () => {
     expect(
       mergeDynamicModelOptions({

--- a/apps/web/src/providerModelOptions.test.ts
+++ b/apps/web/src/providerModelOptions.test.ts
@@ -46,6 +46,21 @@ describe("Claude model selections", () => {
 });
 
 describe("formatProviderModelOptionName", () => {
+  it("uses branded humanized labels for qualified Pi model slugs", () => {
+    expect(
+      formatProviderModelOptionName({
+        provider: "pi",
+        slug: "zai/glm-5.3-flash",
+      }),
+    ).toBe("GLM 5.3 Flash");
+    expect(
+      formatProviderModelOptionName({
+        provider: "pi",
+        slug: "deepseek/deepseek-v4-flash",
+      }),
+    ).toBe("DeepSeek V4 Flash");
+  });
+
   it("humanizes unknown OpenCode runtime model slugs using the model identifier", () => {
     expect(
       formatProviderModelOptionName({
@@ -75,6 +90,19 @@ describe("formatProviderModelOptionName", () => {
 });
 
 describe("mergeDynamicModelOptions", () => {
+  it("normalizes slug-shaped Pi display names", () => {
+    expect(
+      mergeDynamicModelOptions({
+        provider: "pi",
+        staticOptions: [],
+        dynamicModels: [
+          { slug: "zai/glm-5.3-flash", name: "GLM-5.3-Flash" },
+          { slug: "deepseek/deepseek-v4-flash", name: "Deepseek V4 Flash" },
+        ],
+      }).map((option) => option.name),
+    ).toEqual(["GLM 5.3 Flash", "DeepSeek V4 Flash"]);
+  });
+
   it("does not offer Pi Anthropic models when discovery only returns local models", () => {
     expect(
       mergeDynamicModelOptions({

--- a/apps/web/src/providerModelOptions.ts
+++ b/apps/web/src/providerModelOptions.ts
@@ -46,6 +46,12 @@ export interface ProviderModelOptionGroup {
   options: ProviderModelOption[];
 }
 
+// Catalog names that differ from their model id only by separators or casing
+// are still id-derived labels rather than intentional presentation metadata.
+function modelDisplayIdentity(value: string): string {
+  return value.trim().toLowerCase().replace(/[-_\s]+/gu, "");
+}
+
 /**
  * Returns the provider provenance shown when a model is detached from its
  * normal upstream-provider group (for example, inside Favourites).
@@ -162,6 +168,11 @@ export function mergeDynamicModelOptions(input: {
 
     const normalizedSlug = normalizeDynamicModelSlug(input.provider, dynamicModel.slug);
     const rawSlug = dynamicModel.slug.trim().toLowerCase();
+    const modelIdentifier = normalizedSlug.includes("/")
+      ? normalizedSlug.slice(normalizedSlug.lastIndexOf("/") + 1)
+      : normalizedSlug;
+    const rawNameIsIdentifier =
+      rawName.length > 0 && modelDisplayIdentity(rawName) === modelDisplayIdentity(modelIdentifier);
     const displayNameFallback = formatProviderModelOptionName({
       provider: input.provider,
       slug: normalizedSlug,
@@ -176,7 +187,8 @@ export function mergeDynamicModelOptions(input: {
         staticNameBySlug.get(normalizedSlug) ??
         (rawName.length > 0 &&
         rawName.toLowerCase() !== rawSlug &&
-        rawName.toLowerCase() !== normalizedSlug.toLowerCase()
+        rawName.toLowerCase() !== normalizedSlug.toLowerCase() &&
+        !rawNameIsIdentifier
           ? rawName
           : displayNameFallback),
       ...(dynamicModel.description?.trim() ? { description: dynamicModel.description.trim() } : {}),

--- a/apps/web/src/providerModelOptions.ts
+++ b/apps/web/src/providerModelOptions.ts
@@ -46,10 +46,13 @@ export interface ProviderModelOptionGroup {
   options: ProviderModelOption[];
 }
 
-// Catalog names that differ from their model id only by separators or casing
-// are still id-derived labels rather than intentional presentation metadata.
-function modelDisplayIdentity(value: string): string {
-  return value.trim().toLowerCase().replace(/[-_\s]+/gu, "");
+// Normalize only known families, keeping the provider's variant wording and casing.
+function normalizeCatalogModelName(name: string): string {
+  return name.replace(
+    /^(glm|deepseek)([-_\s]+)([^()]*)/iu,
+    (_, family: string, _separator: string, suffix: string) =>
+      `${family.toLowerCase() === "glm" ? "GLM" : "DeepSeek"} ${suffix.replace(/[-_]+/gu, " ")}`,
+  );
 }
 
 /**
@@ -151,7 +154,10 @@ export function mergeDynamicModelOptions(input: {
     upstreamProviderName?: string | null | undefined;
   }>;
 }): ReadonlyArray<ProviderModelOption & { isCustom?: boolean }> {
-  const staticNameBySlug = new Map(input.staticOptions.map((model) => [model.slug, model.name]));
+  // Custom and selected-model placeholders have generated names, not curated metadata.
+  const staticNameBySlug = new Map(
+    input.staticOptions.filter((model) => !model.isCustom).map((model) => [model.slug, model.name]),
+  );
   const dynamicNormalizedSlugs = new Set<string>();
   const normalizedDynamicOptions: ProviderModelOption[] = [];
 
@@ -167,12 +173,7 @@ export function mergeDynamicModelOptions(input: {
     }
 
     const normalizedSlug = normalizeDynamicModelSlug(input.provider, dynamicModel.slug);
-    const rawSlug = dynamicModel.slug.trim().toLowerCase();
-    const modelIdentifier = normalizedSlug.includes("/")
-      ? normalizedSlug.slice(normalizedSlug.lastIndexOf("/") + 1)
-      : normalizedSlug;
-    const rawNameIsIdentifier =
-      rawName.length > 0 && modelDisplayIdentity(rawName) === modelDisplayIdentity(modelIdentifier);
+    const modelIdentifier = normalizedSlug.slice(normalizedSlug.lastIndexOf("/") + 1);
     const displayNameFallback = formatProviderModelOptionName({
       provider: input.provider,
       slug: normalizedSlug,
@@ -186,10 +187,10 @@ export function mergeDynamicModelOptions(input: {
       name:
         staticNameBySlug.get(normalizedSlug) ??
         (rawName.length > 0 &&
-        rawName.toLowerCase() !== rawSlug &&
-        rawName.toLowerCase() !== normalizedSlug.toLowerCase() &&
-        !rawNameIsIdentifier
-          ? rawName
+        rawName !== dynamicModel.slug.trim() &&
+        rawName !== normalizedSlug &&
+        rawName !== modelIdentifier
+          ? normalizeCatalogModelName(rawName)
           : displayNameFallback),
       ...(dynamicModel.description?.trim() ? { description: dynamicModel.description.trim() } : {}),
       ...(dynamicModel.upstreamProviderId?.trim()

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -820,17 +820,17 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
     },
     {
       slug: "glm-5.2",
-      name: "GLM-5.2",
+      name: "GLM 5.2",
       capabilities: DROID_CORE_HIGH_CAPABILITIES,
     },
     {
       slug: "glm-5.2-fast",
-      name: "GLM-5.2 Fast",
+      name: "GLM 5.2 Fast",
       capabilities: DROID_CORE_HIGH_CAPABILITIES,
     },
     {
       slug: "glm-5.1",
-      name: "GLM-5.1",
+      name: "GLM 5.1",
       capabilities: DROID_CORE_HIGH_CAPABILITIES,
     },
     {
@@ -1072,7 +1072,7 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
     },
     {
       slug: "glm-5.2",
-      name: "GLM-5.2",
+      name: "GLM 5.2",
       capabilities: cursorCapabilities({ efforts: ["high", "max"] }),
     },
   ],

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -756,6 +756,11 @@ describe("formatModelDisplayName", () => {
     expect(formatModelDisplayName("deepseek-v4-flash")).toBe("DeepSeek V4 Flash");
   });
 
+  it("humanizes model tokens that match inherited object properties", () => {
+    expect(formatModelDisplayName("constructor-v1")).toBe("Constructor V1");
+    expect(formatModelDisplayName("gpt-5-constructor")).toBe("GPT-5 Constructor");
+  });
+
   it("leaves non-GPT custom slugs unchanged", () => {
     expect(formatModelDisplayName("custom/internal-model")).toBe("custom/internal-model");
   });

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -743,11 +743,17 @@ describe("formatModelDisplayName", () => {
     expect(formatModelDisplayName("gpt-5.3-codex")).toBe("GPT-5.3 Codex");
     expect(formatModelDisplayName("claude-sonnet-5")).toBe("Claude Sonnet 5");
     expect(formatModelDisplayName("claude-opus-5")).toBe("Claude Opus 5");
+    expect(formatModelDisplayName("glm-5.2")).toBe("GLM 5.2");
   });
 
   it("humanizes unknown GPT model slugs", () => {
     expect(formatModelDisplayName("gpt-5.1-codex-max")).toBe("GPT-5.1 Codex Max");
     expect(formatModelDisplayName("gpt-5.1-codex-mini")).toBe("GPT-5.1 Codex Mini");
+  });
+
+  it("restores known model-family casing while humanizing non-GPT slugs", () => {
+    expect(formatModelDisplayName("glm-5.3-flash")).toBe("GLM 5.3 Flash");
+    expect(formatModelDisplayName("deepseek-v4-flash")).toBe("DeepSeek V4 Flash");
   });
 
   it("leaves non-GPT custom slugs unchanged", () => {

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -85,9 +85,11 @@ const MODEL_TOKEN_DISPLAY_NAMES: Readonly<Record<string, string>> = {
 };
 
 function humanizeModelToken(token: string): string {
-  return (
-    MODEL_TOKEN_DISPLAY_NAMES[token.toLowerCase()] ?? token.charAt(0).toUpperCase() + token.slice(1)
-  );
+  const key = token.toLowerCase();
+  const displayName = Object.prototype.hasOwnProperty.call(MODEL_TOKEN_DISPLAY_NAMES, key)
+    ? MODEL_TOKEN_DISPLAY_NAMES[key]
+    : undefined;
+  return displayName ?? token.charAt(0).toUpperCase() + token.slice(1);
 }
 
 // Turns a raw model slug into a readable label when no built-in name exists.

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -79,19 +79,32 @@ const MODEL_NAME_BY_SLUG = new Map(
     .map((option) => [option.slug.toLowerCase(), option.name] as const),
 );
 
+const MODEL_TOKEN_DISPLAY_NAMES: Readonly<Record<string, string>> = {
+  deepseek: "DeepSeek",
+  glm: "GLM",
+};
+
+function humanizeModelToken(token: string): string {
+  return (
+    MODEL_TOKEN_DISPLAY_NAMES[token.toLowerCase()] ??
+    token.charAt(0).toUpperCase() + token.slice(1)
+  );
+}
+
 // Turns a raw model slug into a readable label when no built-in name exists.
 // GPT slugs keep their canonical "GPT-x" casing; provider-scoped custom ids
-// ("vendor/model") stay verbatim; everything else is title-cased on -/_ .
+// ("vendor/model") stay verbatim; everything else is title-cased on -/_ with
+// known model-family brands restored to their canonical casing.
 export function humanizeModelSlug(slug: string): string {
   if (slug.toLowerCase().startsWith("gpt-")) {
     const [, version, ...rest] = slug.split("-");
     if (rest.length === 0) return `GPT-${version}`;
-    return `GPT-${version} ${rest.map((s) => s.charAt(0).toUpperCase() + s.slice(1)).join(" ")}`;
+    return `GPT-${version} ${rest.map(humanizeModelToken).join(" ")}`;
   }
   if (slug.includes("/")) {
     return slug;
   }
-  return slug.replace(/[-_]+/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+  return slug.split(/[-_]+/g).map(humanizeModelToken).join(" ");
 }
 
 export function formatModelDisplayName(model: string | null | undefined): string | undefined {

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -86,8 +86,7 @@ const MODEL_TOKEN_DISPLAY_NAMES: Readonly<Record<string, string>> = {
 
 function humanizeModelToken(token: string): string {
   return (
-    MODEL_TOKEN_DISPLAY_NAMES[token.toLowerCase()] ??
-    token.charAt(0).toUpperCase() + token.slice(1)
+    MODEL_TOKEN_DISPLAY_NAMES[token.toLowerCase()] ?? token.charAt(0).toUpperCase() + token.slice(1)
   );
 }
 


### PR DESCRIPTION
## What Changed

- Fix catalog name precedence so generated custom and selected-model entries no longer override provider-supplied display names.
- Replace broad identifier-equivalence matching with GLM/DeepSeek-specific name normalization, preserving variant wording such as `Highspeed` and other brands’ casing such as `MiniMax M2.5 Free` and `K2P6`.
- Restore brand casing in `humanizeModelSlug` via a small token map (`glm` -> `GLM`, `deepseek` -> `DeepSeek`).
- Rename static contracts entries `GLM-5.2` / `GLM-5.2 Fast` / `GLM-5.1` to space style (`GLM 5.2`, etc.) for consistency.

## Why

Pi provides display names such as `GLM-5.3-Flash`. Selecting a model that is absent from the static catalog adds a generated fallback entry to the local options. During catalog merging, that generated name previously took precedence over the discovered name, changing `GLM-5.3-Flash` to `Glm 5.3 Flash` after selection.

The fix prevents generated entries from overriding discovered names and applies explicit GLM/DeepSeek formatting rules. This keeps labels stable while preserving provider-supplied branding for other models, including MiniMax and K2P6. The shared catalog merge correction applies to both Pi and OpenCode, as well as other providers using this path.

## UI Changes

Text-only label change in the model picker, no layout change:

- Before: `Glm 5.3 Flash`, `Deepseek V4 Flash` (mixed brand casing, label style changes after clicking)
- After: `GLM 5.3 Flash`, `DeepSeek V4 Flash` (consistent brand casing, label stays stable after selection)
- Preserve variant wording such as `Highspeed` and branded names such as `MiniMax M2.5 Free` and `K2P6`.

| Before | After |
| --- | --- |
| <img width="400" alt="Before - Pi model picker showing old labels" src="https://github.com/user-attachments/assets/38a3a3df-2b23-4583-b8cb-95e4c84cb0ea" /> | <img width="400" alt="After - Pi model picker showing normalized labels" src="https://github.com/user-attachments/assets/7a125f91-0f82-401c-b175-aeb16453bca5" /> |

## Verification

- From `apps/web`: `bun run test -- src/providerModelOptions.test.ts src/appSettings.test.ts` — 102 tests passed, including selected-model placeholder regression coverage for Pi and OpenCode.
- From `packages/shared`: `bun run test -- src/model.test.ts` — 103 tests passed.
- From `apps/web`: `bun run test:browser -- src/components/chat/ProviderModelPicker.browser.tsx` — 18 tests passed.
- Changed-file formatting checks passed, including the three files flagged by CI.
- Full-workspace lint and typecheck have not been rerun locally.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
