### PR TITLE
fix: preserve activity ordering across live updates and snapshots

### DIFF
--- a/apps/web/src/storeEventReducer.test.ts
+++ b/apps/web/src/storeEventReducer.test.ts
@@ -1518,14 +1518,14 @@ describe("store event reducer", () => {
     expect(threadsOf(batched)[0]?.updatedAt).toBe("2026-07-09T00:00:02.000Z");
   });
 
-  it("replaces provider-local activity sequences with durable orchestration sequences", () => {
+  it("preserves canonical activity sequences in sequential and batched live updates", () => {
     const threadId = ThreadId.makeUnsafe("thread-1");
     const events = [
       makeDomainEvent(
         "thread.activity-appended",
         {
           threadId,
-          activity: makeActivity({ id: "activity-before-restart", sequence: 99 }),
+          activity: makeActivity({ id: "activity-first", sequence: 99 }),
         },
         { sequence: 40 },
       ),
@@ -1533,7 +1533,7 @@ describe("store event reducer", () => {
         "thread.activity-appended",
         {
           threadId,
-          activity: makeActivity({ id: "activity-after-restart", sequence: 0 }),
+          activity: makeActivity({ id: "activity-second", sequence: 100 }),
         },
         { sequence: 41 },
       ),
@@ -1547,10 +1547,10 @@ describe("store event reducer", () => {
     const batched = applyOrchestrationEventsHotPath(initialState, events);
 
     expect(threadsOf(sequential)[0]?.activities.map((activity) => activity.sequence)).toEqual([
-      40, 41,
+      99, 100,
     ]);
     expect(threadsOf(batched)[0]?.activities.map((activity) => activity.sequence)).toEqual([
-      40, 41,
+      99, 100,
     ]);
   });
 

--- a/apps/web/src/storeNormalization.ts
+++ b/apps/web/src/storeNormalization.ts
@@ -1272,7 +1272,10 @@ export function withOrchestrationEventSequence(
   activity: OrchestrationThreadActivity,
   sequence: number,
 ): OrchestrationThreadActivity {
-  return { ...activity, sequence };
+  // Match the read-model projection: runtime journal activity sequences and
+  // orchestration envelope sequences are different counters. Overwriting the
+  // former only on live updates reorders snapshot history into the new turn.
+  return { ...activity, sequence: activity.sequence ?? sequence };
 }
 
 /**

--- a/apps/web/src/storeTimelineSequence.test.ts
+++ b/apps/web/src/storeTimelineSequence.test.ts
@@ -1,0 +1,179 @@
+import { MessageId, TurnId } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+import { applyOrchestrationEventsHotPath } from "./storeEventReducer";
+import { withOrchestrationEventSequence } from "./storeNormalization";
+import { syncServerThreadDetailHotPath } from "./storeProjection";
+import {
+  makeActivity,
+  makeDomainEvent,
+  makeState,
+  makeThread,
+  makeReadModelThread,
+  threadsOf,
+} from "./storeTestFixtures";
+import { deriveTimelineEntries, deriveWorkLogEntries } from "./workLog";
+import { deriveMessagesTimelineRows } from "./components/chat/MessagesTimeline.logic";
+import type { ChatMessage } from "./types";
+
+const at = (second: number) => new Date(Date.UTC(2026, 8, 5, 0, 0, second)).toISOString();
+const oldTurn = TurnId.makeUnsafe("old-turn");
+const newTurn = TurnId.makeUnsafe("new-turn");
+const message = (
+  id: string,
+  role: "user" | "assistant",
+  second: number,
+  turnId: TurnId,
+): ChatMessage => ({
+  id: MessageId.makeUnsafe(id),
+  role,
+  text: id,
+  createdAt: at(second),
+  turnId,
+  streaming: false,
+});
+
+describe("snapshot and live activity sequence parity", () => {
+  it.each([0, 2000])("preserves canonical activity sequence %s", (sequence) => {
+    expect(withOrchestrationEventSequence(makeActivity({ sequence }), 100).sequence).toBe(sequence);
+  });
+
+  it("falls back to the orchestration sequence for an activity without one", () => {
+    expect(withOrchestrationEventSequence(makeActivity({}), 100).sequence).toBe(100);
+  });
+
+  it.each(["batched", "sequential"] as const)(
+    "keeps historical tools and compaction in their original response after %s live events",
+    (mode) => {
+      // Runtime journal and orchestration log counters are both durable but
+      // not interchangeable. History arrived in a snapshot; only the new
+      // printf calls go through the live event reducer.
+      const historical = [
+        makeActivity({
+          id: "old-tool",
+          turnId: oldTurn,
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Old command",
+          createdAt: at(2),
+          sequence: 1000,
+        }),
+        makeActivity({
+          id: "old-compaction",
+          kind: "context-compaction",
+          tone: "info",
+          summary: "Context compacted",
+          createdAt: at(3),
+          sequence: 1001,
+        }),
+      ];
+      const current = [
+        makeActivity({
+          id: "printf-a",
+          turnId: newTurn,
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "printf H1-A",
+          createdAt: at(12),
+          sequence: 2000,
+        }),
+        makeActivity({
+          id: "printf-b",
+          turnId: newTurn,
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "printf H1-B",
+          createdAt: at(14),
+          sequence: 2001,
+        }),
+      ];
+      const messages = [
+        message("old-user", "user", 0, oldTurn),
+        { ...message("old-answer", "assistant", 4, oldTurn), completedAt: at(5) },
+        message("new-user", "user", 10, newTurn),
+        message("H1-PRE", "assistant", 11, newTurn),
+        message("H1-MID", "assistant", 13, newTurn),
+      ];
+      const thread = makeThread({ messages, activities: historical });
+      const events = current.map((activity, index) =>
+        makeDomainEvent(
+          "thread.activity-appended",
+          { threadId: thread.id, activity },
+          { sequence: 100 + index },
+        ),
+      );
+      const initial = makeState(thread);
+      const state =
+        mode === "batched"
+          ? applyOrchestrationEventsHotPath(initial, events)
+          : events.reduce(
+              (previous, event) => applyOrchestrationEventsHotPath(previous, [event]),
+              initial,
+            );
+      const liveActivities = threadsOf(state)[0]!.activities;
+      const derive = (activities: typeof liveActivities) =>
+        deriveTimelineEntries(
+          messages,
+          [],
+          deriveWorkLogEntries(activities, newTurn, {
+            visibleTurnIds: new Set([oldTurn, newTurn]),
+            activeTurnId: newTurn,
+          }),
+        );
+      const timeline = derive(liveActivities);
+      const snapshotTimeline = derive([...historical, ...current]);
+      const refreshed = syncServerThreadDetailHotPath(
+        state,
+        makeReadModelThread({
+          id: thread.id,
+          activities: [...historical, ...current],
+          updatedAt: at(15),
+        }),
+      );
+      expect(timeline.map((entry) => entry.id)).toEqual([
+        "old-user",
+        "old-tool",
+        "old-compaction",
+        "old-answer",
+        "new-user",
+        "H1-PRE",
+        "printf-a",
+        "H1-MID",
+        "printf-b",
+      ]);
+      expect(timeline).toEqual(snapshotTimeline);
+      expect(derive(threadsOf(refreshed)[0]!.activities)).toEqual(timeline);
+      for (const active of [true, false]) {
+        const rows = deriveMessagesTimelineRows({
+          timelineEntries: timeline,
+          isWorking: active,
+          activeTurnInProgress: active,
+          activeTurnId: newTurn,
+          activeTurnStartedAt: at(10),
+          worktreeSetup: null,
+          worktreeSetupOpen: false,
+          turnDiffSummaryByAssistantMessageId: new Map(),
+          revertTurnCountByUserMessageId: new Map(),
+        });
+        const oldAnswer = rows.find((row) => row.id === "old-answer");
+        expect(
+          oldAnswer?.kind === "message" && oldAnswer.collapsedTurnItems?.map((item) => item.id),
+        ).toEqual(["old-tool", "old-compaction"]);
+        const newBoundary = rows.findIndex((row) => row.id === "new-user");
+        expect(JSON.stringify(rows.slice(newBoundary + 1))).not.toContain("old-tool");
+        expect(JSON.stringify(rows.slice(newBoundary + 1))).not.toContain("old-compaction");
+        const workIds = rows.slice(newBoundary + 1).flatMap((row) => {
+          if (row.kind === "work") return row.groupedEntries.map((entry) => entry.id);
+          if (row.kind !== "message") return [];
+          return [
+            ...(row.leadingWorkEntries ?? []),
+            ...(row.inlineWorkEntries ?? []),
+            ...(row.collapsedTurnItems ?? []).flatMap((item) =>
+              item.kind === "work" ? [item.entry] : [],
+            ),
+          ].map((entry) => entry.id);
+        });
+        expect(workIds).toEqual(["printf-a", "printf-b"]);
+      }
+    },
+  );
+});

--- a/apps/web/src/storeTimelineSequence.test.ts
+++ b/apps/web/src/storeTimelineSequence.test.ts
@@ -41,6 +41,80 @@ describe("snapshot and live activity sequence parity", () => {
     expect(withOrchestrationEventSequence(makeActivity({}), 100).sequence).toBe(100);
   });
 
+  it("keeps a background tool in its original response while its new turn owns its state", () => {
+    const historical = [
+      makeActivity({
+        id: "background-tool",
+        turnId: oldTurn,
+        kind: "tool.started",
+        summary: "Read file",
+        createdAt: at(2),
+        sequence: 1000,
+        payload: { itemType: "dynamic_tool_call", data: { toolCallId: "background" } },
+      }),
+      makeActivity({
+        id: "old-turn-complete",
+        turnId: oldTurn,
+        kind: "turn.completed",
+        createdAt: at(5),
+        sequence: 1001,
+      }),
+    ];
+    const messages = [
+      message("old-user", "user", 0, oldTurn),
+      { ...message("old-answer", "assistant", 4, oldTurn), completedAt: at(5) },
+      message("new-user", "user", 10, newTurn),
+    ];
+    for (const kind of ["tool.updated", "tool.completed"] as const) {
+      const entries = deriveWorkLogEntries(
+        [
+          ...historical,
+          makeActivity({
+            ...historical[0],
+            id: "background-update",
+            kind,
+            turnId: newTurn,
+            createdAt: at(12),
+            sequence: 2000,
+          }),
+        ],
+        newTurn,
+        { visibleTurnIds: new Set([oldTurn, newTurn]), activeTurnId: newTurn },
+      );
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        id: "background-tool",
+        turnId: newTurn,
+        liveActivity: { state: kind === "tool.updated" ? "running_tool" : "completed" },
+      });
+      const timeline = deriveTimelineEntries(messages, [], entries);
+      expect(timeline.map((entry) => entry.id)).toEqual([
+        "old-user",
+        "background-tool",
+        "old-answer",
+        "new-user",
+      ]);
+      const rows = deriveMessagesTimelineRows({
+        timelineEntries: timeline,
+        isWorking: true,
+        activeTurnInProgress: true,
+        activeTurnId: newTurn,
+        activeTurnStartedAt: at(10),
+        worktreeSetup: null,
+        worktreeSetupOpen: false,
+        turnDiffSummaryByAssistantMessageId: new Map(),
+        revertTurnCountByUserMessageId: new Map(),
+      });
+      const oldAnswer = rows.find((row) => row.id === "old-answer");
+      expect(
+        oldAnswer?.kind === "message" && oldAnswer.collapsedTurnItems?.map((item) => item.id),
+      ).toEqual(["background-tool"]);
+      expect(
+        JSON.stringify(rows.slice(rows.findIndex((row) => row.id === "new-user") + 1)),
+      ).not.toContain("background-tool");
+    }
+  });
+
   it.each(["batched", "sequential"] as const)(
     "keeps historical tools and compaction in their original response after %s live events",
     (mode) => {

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -1059,7 +1059,7 @@ describe("deriveWorkLogEntries", () => {
       id: "codex-command-start",
       createdAt: "2026-02-23T00:00:01.000Z",
       sequence: 10,
-      turnId: TurnId.makeUnsafe("turn-1"),
+      turnId: TurnId.makeUnsafe("turn-2"),
       activityKind: "tool.updated",
       detail: "Process exited with code 0",
     });
@@ -1068,6 +1068,71 @@ describe("deriveWorkLogEntries", () => {
       "intervening-warning",
     ]);
   });
+
+  it.each([
+    ["completed", "turn.completed", "info"],
+    ["cancelled", "turn.aborted", "info"],
+    ["failed", "turn.completed", "error"],
+  ] as const)(
+    "keeps a cross-turn tool running after its original turn %s",
+    (_state, terminalKind, terminalTone) => {
+      const oldTurn = TurnId.makeUnsafe("turn-1");
+      const activeTurn = TurnId.makeUnsafe("turn-2");
+      const at = (second: number) => new Date(Date.UTC(2026, 8, 8, 0, 0, second)).toISOString();
+      const tool = (
+        id: string,
+        second: number,
+        kind: OrchestrationThreadActivity["kind"],
+        turnId: TurnId | null,
+      ) =>
+        makeActivity({
+          id,
+          createdAt: at(second),
+          sequence: second,
+          kind,
+          turnId,
+          summary: "Read file",
+          payload: { itemType: "dynamic_tool_call", data: { toolCallId: "background-tool" } },
+        });
+      const activities = [
+        tool("tool-start", 1, "tool.started", oldTurn),
+        makeActivity({
+          id: "turn-terminal",
+          createdAt: at(2),
+          sequence: 2,
+          turnId: oldTurn,
+          kind: terminalKind,
+          tone: terminalTone,
+        }),
+        tool("tool-next-turn", 3, "tool.updated", activeTurn),
+        tool("tool-progress", 4, "tool.updated", activeTurn),
+        // Some provider updates omit ownership; retain the latest known turn.
+        tool("tool-turnless-progress", 5, "tool.updated", null),
+      ];
+      const options = { activeTurnId: activeTurn, activeTurnStartedAt: at(3) };
+      const findTool = (input: OrchestrationThreadActivity[]) =>
+        deriveWorkLogEntries(input, undefined, options).find((entry) => entry.id === "tool-start");
+      const running = findTool(activities);
+      expect(running).toMatchObject({
+        id: "tool-start",
+        createdAt: at(1),
+        sequence: 1,
+        turnId: activeTurn,
+        toolStatus: "running",
+        liveActivity: { state: "running_tool", lastActivityAt: at(5) },
+      });
+
+      const completed = findTool([...activities, tool("tool-complete", 6, "tool.completed", null)]);
+      expect(completed).toMatchObject({
+        id: "tool-start",
+        createdAt: at(1),
+        sequence: 1,
+        turnId: activeTurn,
+        toolStatus: "completed",
+        liveActivity: { state: "completed", lastActivityAt: at(6) },
+      });
+    },
+  );
 
   it("keeps distinct calls of the same tool separate by tool-call id", () => {
     const activities: OrchestrationThreadActivity[] = [

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -1090,7 +1090,7 @@ describe("deriveWorkLogEntries", () => {
           createdAt: at(second),
           sequence: second,
           kind,
-          turnId,
+          ...(turnId !== null ? { turnId } : {}),
           summary: "Read file",
           payload: { itemType: "dynamic_tool_call", data: { toolCallId: "background-tool" } },
         });

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -101,11 +101,13 @@ describe("deriveWorkLogEntries", () => {
     const taskListActivity = (
       id: string,
       createdAt: string,
+      sequence: number,
       tasks: Array<{ task: string; status: string }>,
     ) =>
       makeActivity({
         id,
         createdAt,
+        sequence,
         kind: "turn.tasks.updated",
         summary: "Tasks updated",
         tone: "info",
@@ -113,22 +115,23 @@ describe("deriveWorkLogEntries", () => {
         payload: { tasks },
       });
     const activities: OrchestrationThreadActivity[] = [
-      taskListActivity("tasks-1", "2026-02-23T00:00:01.000Z", [
+      taskListActivity("tasks-1", "2026-02-23T00:00:01.000Z", 1, [
         { task: "Implement inline editing", status: "inProgress" },
         { task: "Run verification", status: "pending" },
       ]),
       makeActivity({
         id: "tool-between",
         createdAt: "2026-02-23T00:00:02.000Z",
+        sequence: 2,
         kind: "tool.started",
         summary: "Tool call",
         turnId: "turn-1",
       }),
-      taskListActivity("tasks-2", "2026-02-23T00:00:03.000Z", [
+      taskListActivity("tasks-2", "2026-02-23T00:00:03.000Z", 3, [
         { task: "Implement inline editing", status: "completed" },
         { task: "Run verification", status: "inProgress" },
       ]),
-      taskListActivity("tasks-3", "2026-02-23T00:00:04.000Z", [
+      taskListActivity("tasks-3", "2026-02-23T00:00:04.000Z", 4, [
         { task: "Implement inline editing", status: "completed" },
         { task: "Run verification", status: "completed" },
       ]),
@@ -140,6 +143,7 @@ describe("deriveWorkLogEntries", () => {
     // Anchored at the first snapshot (stable id/createdAt), showing the latest state.
     expect(taskListEntries[0]?.id).toBe("tasks-1");
     expect(taskListEntries[0]?.createdAt).toBe("2026-02-23T00:00:01.000Z");
+    expect(taskListEntries[0]?.sequence).toBe(1);
     expect(taskListEntries[0]?.label).toBe("2 out of 2 tasks completed");
     expect(taskListEntries[0]?.detail).toBeUndefined();
     expect(entries.map((entry) => entry.id)).toEqual(["tasks-1", "tool-between"]);
@@ -633,6 +637,7 @@ describe("deriveWorkLogEntries", () => {
       makeActivity({
         id: "opencode-retry-1",
         createdAt: "2026-02-23T00:00:01.000Z",
+        sequence: 1,
         kind: "runtime.warning",
         summary: "OpenCode retrying",
         tone: "info",
@@ -643,6 +648,7 @@ describe("deriveWorkLogEntries", () => {
       makeActivity({
         id: "opencode-retry-2",
         createdAt: "2026-02-23T00:00:02.000Z",
+        sequence: 2,
         kind: "runtime.warning",
         summary: "OpenCode retrying",
         tone: "info",
@@ -653,6 +659,7 @@ describe("deriveWorkLogEntries", () => {
       makeActivity({
         id: "opencode-retry-3",
         createdAt: "2026-02-23T00:00:03.000Z",
+        sequence: 3,
         kind: "runtime.warning",
         summary: "OpenCode retrying",
         tone: "info",
@@ -665,7 +672,9 @@ describe("deriveWorkLogEntries", () => {
     const entries = deriveWorkLogEntries(activities, undefined);
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
-      id: "opencode-retry-3",
+      id: "opencode-retry-1",
+      createdAt: "2026-02-23T00:00:01.000Z",
+      sequence: 1,
       label: "OpenCode retrying",
       detail: "3 notices - Provider request failed; retrying.",
       preview: "3 notices - Provider request failed; retrying.",
@@ -936,6 +945,7 @@ describe("deriveWorkLogEntries", () => {
       makeActivity({
         id: "a-started",
         createdAt: "2026-02-23T00:00:00.000Z",
+        sequence: 10,
         kind: "tool.started",
         summary: "Tool call",
         payload: {
@@ -947,6 +957,7 @@ describe("deriveWorkLogEntries", () => {
       makeActivity({
         id: "b-started",
         createdAt: "2026-02-23T00:00:01.000Z",
+        sequence: 20,
         kind: "tool.started",
         summary: "Tool call",
         payload: {
@@ -958,6 +969,7 @@ describe("deriveWorkLogEntries", () => {
       makeActivity({
         id: "a-completed",
         createdAt: "2026-02-23T00:00:02.000Z",
+        sequence: 30,
         kind: "tool.completed",
         summary: "Tool call",
         payload: {
@@ -969,6 +981,7 @@ describe("deriveWorkLogEntries", () => {
       makeActivity({
         id: "b-completed",
         createdAt: "2026-02-23T00:00:03.000Z",
+        sequence: 40,
         kind: "tool.completed",
         summary: "Tool call",
         payload: {
@@ -982,8 +995,78 @@ describe("deriveWorkLogEntries", () => {
     // Without id-based collapse this is 4 rows (a started, b started, a completed,
     // b completed); each tool call must merge to one row, kept at its start position.
     const entries = deriveWorkLogEntries(activities, undefined);
-    expect(entries.map((entry) => entry.id)).toEqual(["a-completed", "b-completed"]);
+    expect(entries.map((entry) => entry.id)).toEqual(["a-started", "b-started"]);
+    expect(entries.map((entry) => entry.createdAt)).toEqual([
+      "2026-02-23T00:00:00.000Z",
+      "2026-02-23T00:00:01.000Z",
+    ]);
+    expect(entries.map((entry) => entry.sequence)).toEqual([10, 20]);
     expect(entries.map((entry) => entry.toolName)).toEqual(["Workflow", "WebFetch"]);
+  });
+
+  it("keeps a tool at its original timeline anchor when a later turn updates it", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "codex-command-start",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        sequence: 10,
+        turnId: "turn-1",
+        kind: "tool.started",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: "background-command",
+            command: "sleep 10",
+          },
+        },
+      }),
+      makeActivity({
+        id: "intervening-warning",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        sequence: 15,
+        turnId: "turn-1",
+        kind: "runtime.warning",
+        summary: "Runtime warning",
+        tone: "info",
+        payload: { message: "The command is still running." },
+      }),
+      makeActivity({
+        id: "codex-command-update",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        sequence: 20,
+        turnId: "turn-2",
+        kind: "tool.updated",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          detail: "Process exited with code 0",
+          data: {
+            toolCallId: "background-command",
+            summary: "Process exited with code 0",
+          },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined, {
+      visibleTurnIds: new Set([TurnId.makeUnsafe("turn-1"), TurnId.makeUnsafe("turn-2")]),
+    });
+
+    expect(entries[0]).toMatchObject({
+      id: "codex-command-start",
+      createdAt: "2026-02-23T00:00:01.000Z",
+      sequence: 10,
+      turnId: TurnId.makeUnsafe("turn-1"),
+      activityKind: "tool.updated",
+      detail: "Process exited with code 0",
+    });
+    expect(deriveTimelineEntries([], [], entries).map((entry) => entry.id)).toEqual([
+      "codex-command-start",
+      "intervening-warning",
+    ]);
   });
 
   it("keeps distinct calls of the same tool separate by tool-call id", () => {
@@ -1035,7 +1118,7 @@ describe("deriveWorkLogEntries", () => {
     ];
 
     const entries = deriveWorkLogEntries(activities, undefined);
-    expect(entries.map((entry) => entry.id)).toEqual(["first-completed", "second-completed"]);
+    expect(entries.map((entry) => entry.id)).toEqual(["first-started", "second-started"]);
   });
 
   it("orders work log by activity sequence when present", () => {
@@ -1184,7 +1267,7 @@ describe("deriveWorkLogEntries", () => {
     ];
 
     const [entry] = deriveWorkLogEntries(activities, undefined);
-    expect(entry?.id).toBe("command-complete");
+    expect(entry?.id).toBe("command-start");
     expect(entry?.toolDetails).toMatchObject({
       kind: "command",
       command: "bun run --cwd apps/web test session-logic.test.ts",
@@ -1376,7 +1459,7 @@ describe("deriveWorkLogEntries", () => {
 
     expect(deriveWorkLogEntries(activities, undefined)).toMatchObject([
       {
-        id: "cursor-searched",
+        id: "cursor-searching",
         toolTitle: "Searched",
         detail: "52 files found",
         itemType: "dynamic_tool_call",
@@ -1423,7 +1506,7 @@ describe("deriveWorkLogEntries", () => {
 
     expect(deriveWorkLogEntries(activities, undefined)).toMatchObject([
       {
-        id: "cursor-command-complete",
+        id: "cursor-command-start",
         command: "git diff --stat",
         detail: "done",
         itemType: "command_execution",
@@ -1686,7 +1769,7 @@ describe("deriveWorkLogEntries", () => {
 
     expect(deriveWorkLogEntries(activities, undefined)).toMatchObject([
       {
-        id: "codex-completed-rich",
+        id: "codex-start-generic",
         command: "git status --short",
         rawCommand: "/bin/zsh -lc 'git status --short'",
         toolTitle: "Checked",
@@ -2303,8 +2386,8 @@ describe("deriveWorkLogEntries", () => {
 
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
-      id: "tool-complete",
-      createdAt: "2026-02-23T00:00:03.000Z",
+      id: "tool-update-1",
+      createdAt: "2026-02-23T00:00:01.000Z",
       label: "Tool call completed",
       detail: 'Read: {"file_path":"/tmp/app.ts"}',
       command: "sed -n 1,40p /tmp/app.ts",
@@ -2993,7 +3076,7 @@ describe("deriveWorkLogEntries", () => {
 
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
-      id: "claude-complete",
+      id: "claude-update-1",
       label: "Read file",
       detail: 'Read: {"file_path":"/tmp/app.ts"}',
       itemType: "dynamic_tool_call",
@@ -3054,7 +3137,7 @@ describe("deriveWorkLogEntries", () => {
 
     const entries = deriveWorkLogEntries(activities, undefined);
 
-    expect(entries.map((entry) => entry.id)).toEqual(["tool-1-complete", "tool-2-complete"]);
+    expect(entries.map((entry) => entry.id)).toEqual(["tool-1-update", "tool-2-update"]);
   });
 
   it("collapses same-timestamp lifecycle rows even when completed sorts before updated by id", () => {
@@ -3097,7 +3180,7 @@ describe("deriveWorkLogEntries", () => {
     const entries = deriveWorkLogEntries(activities, undefined);
 
     expect(entries).toHaveLength(1);
-    expect(entries[0]?.id).toBe("a-complete-same-timestamp");
+    expect(entries[0]?.id).toBe("z-update-earlier");
   });
 
   it("omits routed collab subagent tool lifecycle rows from the transcript", () => {
@@ -3383,7 +3466,7 @@ describe("deriveWorkLogEntries", () => {
     expect(entries).toHaveLength(1);
     expect(entries[0]).toEqual(
       expect.objectContaining({
-        id: "opencode-task-complete",
+        id: "opencode-task-started",
         itemType: "collab_agent_tool_call",
         toolTitle: "Find changelog implementation",
         detail: "Full changelog report\nwith file references.",
@@ -3456,7 +3539,7 @@ describe("deriveWorkLogEntries", () => {
     expect(entries).toHaveLength(2);
     expect(entries.find((entry) => entry.itemType === "collab_agent_tool_call")).toEqual(
       expect.objectContaining({
-        id: "opencode-task-complete",
+        id: "opencode-task-update",
         itemType: "collab_agent_tool_call",
         toolTitle: "Find changelog implementation",
         detail: "Tool execution aborted",

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -1117,6 +1117,9 @@ function mergeRuntimeWarningEntries(
   return {
     ...previous,
     ...next,
+    id: previous.id,
+    createdAt: previous.createdAt,
+    ...(previous.sequence !== undefined ? { sequence: previous.sequence } : {}),
     runtimeWarningRepeatCount: repeatCount,
     ...(runtimeWarningMessage ? { runtimeWarningMessage } : {}),
     detail: repeatPreview,
@@ -1138,7 +1141,12 @@ function mergeTaskListEntries(
   if (previous.taskListHasTasks && !next.taskListHasTasks) {
     return previous;
   }
-  return { ...next, id: previous.id, createdAt: previous.createdAt };
+  return {
+    ...next,
+    id: previous.id,
+    createdAt: previous.createdAt,
+    ...(previous.sequence !== undefined ? { sequence: previous.sequence } : {}),
+  };
 }
 
 // Ingestion emits compaction progress ("Compacting conversation...") and its
@@ -1238,10 +1246,13 @@ function mergeDerivedWorkLogEntries(
     : (next.toolStatus ?? previous.toolStatus);
   const liveActivity = mergeWorkLogLiveActivity(previous.liveActivity, next.liveActivity);
   const toolDetails = mergeWorkLogToolDetails(previous.toolDetails, next.toolDetails);
-  const turnId = next.turnId ?? previous.turnId;
+  const turnId = previous.turnId ?? next.turnId;
   return {
     ...previous,
     ...next,
+    id: previous.id,
+    createdAt: previous.createdAt,
+    ...(previous.sequence !== undefined ? { sequence: previous.sequence } : {}),
     ...(turnId !== undefined ? { turnId } : {}),
     ...(detail ? { detail } : {}),
     ...(command ? { command } : {}),

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -1246,7 +1246,9 @@ function mergeDerivedWorkLogEntries(
     : (next.toolStatus ?? previous.toolStatus);
   const liveActivity = mergeWorkLogLiveActivity(previous.liveActivity, next.liveActivity);
   const toolDetails = mergeWorkLogToolDetails(previous.toolDetails, next.toolDetails);
-  const turnId = previous.turnId ?? next.turnId;
+  // Keep the visual anchor below, but let the latest known turn own lifecycle
+  // settlement and live composer state when a background tool spans turns.
+  const turnId = next.turnId ?? previous.turnId;
   return {
     ...previous,
     ...next,


### PR DESCRIPTION
Preserve runtime activity sequence numbers when applying live orchestration events. Runtime and orchestration sequence counters are different; replacing one with the other can move existing timeline entries when a later turn arrives or a snapshot reloads.

Merged work-log updates now retain the first entry's identity, timestamp, sequence and turn ownership, so task, warning and tool updates stay in their original timeline position.

Validation: 163 tests passed across `storeTimelineSequence`, `storeEventReducer` and `workLog`; web typecheck passed.
