### PR TITLE
fix: preserve bracketed math and numeric inline formulas

### DIFF
--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -105,6 +105,49 @@ describe("ChatMarkdown", () => {
     expect(markup.match(/class="katex"/g) ?? []).toHaveLength(1);
   });
 
+  it("keeps bracketed display formulas intact without swallowing subsequent prose and tables", async () => {
+    const markup = await renderMarkdown(String.raw`- **Decay gate**:
+
+$$
+\alpha_t
+=
+\exp\left[-\exp(A)\operatorname{softplus}(W_\alpha x_t+b_\alpha)\right],
+$$
+
+正常正文 **仍然加粗**。
+
+$$
+o_t
+=
+W_o\left[\sigma(W_zx_t)\odot\operatorname{RMSNorm}(y_t)\right].
+$$
+
+| Operation | FLOPs |
+|---|---:|
+| Read | $d_kd_v$ |
+
+[route](/src/_chat.$threadId.tsx)`);
+
+    expect(markup.match(/class="katex-display"/g) ?? []).toHaveLength(2);
+    expect(markup).not.toContain("katex-error");
+    expect(markup).not.toMatch(/<h[12][ >]/);
+    expect(markup).toContain("<strong>仍然加粗</strong>");
+    expect(markup).toContain("<table>");
+    expect(markup).toContain('href="/src/_chat.$threadId.tsx"');
+  });
+
+  it("preserves brackets inside inline math and ordinary prose beside links", async () => {
+    const markup = await renderMarkdown(
+      String.raw`[note] $x[0]+y[1]$ and $\left[f(x)\right]$; [route](/src/$id.tsx). Price $5.`,
+    );
+
+    expect(markup.match(/class="katex"/g) ?? []).toHaveLength(2);
+    expect(markup).not.toContain("katex-error");
+    expect(markup).toContain("[note]");
+    expect(markup).toContain('href="/src/$id.tsx"');
+    expect(markup).toContain("Price $5.");
+  });
+
   it("renders external assistant links with the shared favicon icon slot", async () => {
     const markup = await renderMarkdown(
       "Closest source: [OpenAI benchmark](https://openai.com/research).",
@@ -154,6 +197,31 @@ describe("ChatMarkdown", () => {
     expect(markup).toContain("$USD$");
     expect(markup).toContain("$PATH$");
     expect(markup).not.toContain('class="katex"');
+  });
+
+  it("renders numeric coefficients in every table row", async () => {
+    const markup = await renderMarkdown(String.raw`| Operation | FLOPs |
+|---|---:|
+| Decay | $d_kd_v$ |
+| Read | $2d_kd_v$ |
+| Write | $2d_kd_v$ |
+| Output | $2d_kd_v$ |`);
+    expect(markup.match(/class="katex"/g) ?? []).toHaveLength(4);
+    expect(markup).not.toContain("katex-error");
+    expect(markup).not.toContain("$2d_kd_v$");
+  });
+
+  it("renders numeric expressions while keeping prices and code literal", async () => {
+    const markup = await renderMarkdown(
+      String.raw`Prices $5, $5 to $10, $5-$10 and $29.470. Math $2x$, $2.5x$, $2 + 3 = 5$, $2^{10}$ and $2\pi$.` +
+        " Code `$2d_kd_v$`.",
+    );
+    expect(markup.match(/class="katex"/g) ?? []).toHaveLength(5);
+    expect(markup).not.toContain("katex-error");
+    expect(markup).toContain("$5 to $10");
+    expect(markup).toContain("$5-$10");
+    expect(markup).toContain("$29.470");
+    expect(markup).toContain("<code>$2d_kd_v$</code>");
   });
 
   it("renders a table whose delimiter row is missing cells", async () => {

--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -173,6 +173,61 @@ $$
     expect(markup).not.toContain("CHATMARKDOWNLITERALDOLLARPLACEHOLDER");
   });
 
+  it.each([
+    ["Use $PATH and [route](/src/$id.tsx).", "Use $PATH and", "/src/$id.tsx"],
+    ["Price $5/month; [plan](/pricing/$tier).", "Price $5/month;", "/pricing/$tier"],
+    [
+      "Use $threadId with [_chat.$threadId.tsx](/src/_chat.$threadId.tsx:42).",
+      "Use $threadId with",
+      "/src/_chat.$threadId.tsx:42",
+    ],
+  ])("keeps literal dollars before Markdown links: %s", async (text, literal, href) => {
+    const markup = await renderMarkdown(text);
+
+    expect(markup).toContain(literal);
+    expect(markup).toContain(`href="${href}"`);
+    expect(markup).not.toContain('class="katex"');
+  });
+
+  it("keeps literal dollars before Markdown images without consuming their URLs", async () => {
+    const markup = await renderMarkdown(
+      "Use $ASSET for ![preview](https://example.com/assets/$variant.png).",
+    );
+
+    expect(markup).toContain("Use $ASSET for");
+    expect(markup).toContain('src="https://example.com/assets/$variant.png"');
+    expect(markup).not.toContain('class="katex"');
+  });
+
+  it("preserves bracketed TeX that also resembles a dollar-free Markdown link", async () => {
+    const markup = await renderMarkdown("Math $[f](x)$ and $2[f](x)$.");
+
+    expect(markup.match(/class="katex"/g) ?? []).toHaveLength(2);
+    expect(markup).not.toContain("katex-error");
+    expect(markup).not.toContain('href="x"');
+  });
+
+  it.each([
+    ["$x[0]+y[", "$x[0]+y[1]$"],
+    ["$$\n\\left[x[0]", "$$\n\\left[x[0]\\right]\n$$"],
+  ])(
+    "renders partial and completed bracketed formulas beside links: %s",
+    async (partial, complete) => {
+      const prefix = "Use $PATH and [route](/src/$id.tsx).\n\n";
+      const partialMarkup = await renderMarkdown(prefix + partial);
+      const completeMarkup = await renderMarkdown(prefix + complete + "\n\n**Still prose.**");
+
+      expect(partialMarkup).not.toContain('class="katex"');
+      expect(completeMarkup.match(/class="katex"/g) ?? []).toHaveLength(1);
+      expect(completeMarkup).toContain("<strong>Still prose.</strong>");
+      for (const markup of [partialMarkup, completeMarkup]) {
+        expect(markup).toContain("Use $PATH and");
+        expect(markup).toContain('href="/src/$id.tsx"');
+        expect(markup).not.toContain("katex-error");
+      }
+    },
+  );
+
   it("does not turn ordinary dollar text or escaped dollars into math", async () => {
     const markup = await renderMarkdown(
       "It costs $5 to $10 per seat. Escape \\$E=mc^2\\$ when you want literal TeX.",
@@ -376,7 +431,7 @@ $$
   it("keeps marker offsets aligned when an escaped dollar precedes the marker", async () => {
     // `\$` is two raw characters that render as one `$`; the dollar-protection transform must stay
     // length-preserving or every offset after it shifts and the marker wraps the wrong substring.
-    const text = "Cost is \\$5 here. Highlight this phrase.";
+    const text = "Cost is \\$5 here. Use $PATH and [route](/src/$id.tsx). Highlight this phrase.";
     const startOffset = text.indexOf("Highlight");
     const selectedText = "Highlight this phrase";
     const marker: ThreadMarker = {
@@ -397,6 +452,8 @@ $$
     expect(markup).toContain('data-thread-marker-id="marker-escaped-dollar"');
     expect(markup).toContain(">Highlight this phrase</span>");
     expect(markup).toContain("Cost is $5 here.");
+    expect(markup).toContain("Use $PATH and");
+    expect(markup).toContain('href="/src/$id.tsx"');
     expect(markup).not.toContain('class="katex"');
   });
 

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -624,14 +624,24 @@ function looksLikeInlineMath(content: string): boolean {
   if (INLINE_MATH_HINT_REGEX.test(trimmed)) {
     return true;
   }
-  return /^[A-Za-z][A-Za-z0-9]{0,15}$/.test(trimmed);
+  return /^(?:\d+(?:\.\d+)?)?[A-Za-z][A-Za-z0-9]{0,15}$/.test(trimmed);
 }
 
 // Reject obvious literal/currency dollars before searching for a closing math delimiter.
 function canOpenInlineMath(value: string, index: number): boolean {
   const next = value[index + 1];
-  if (!next || /\s|\d/.test(next)) {
+  if (!next || /\s/.test(next)) {
     return false;
+  }
+  if (/\d/.test(next)) {
+    const closingIndex = findInlineMathClosingDollar(value, index + 1);
+    if (closingIndex === -1 || /\d/.test(value[closingIndex + 1] ?? "")) {
+      return false;
+    }
+    // A numeric prefix can be a coefficient. Require a complete expression
+    // on this line; do not pair prices across lines or consume `$5-$10`.
+    const content = value.slice(index + 1, closingIndex);
+    return !/[\r\n]/.test(content) && looksLikeInlineMath(content);
   }
   return true;
 }
@@ -660,7 +670,7 @@ function findInlineMathClosingDollar(value: string, index: number): number {
   return -1;
 }
 
-function protectLiteralDollarsInPlainText(value: string): string {
+function protectLiteralDollarsInMarkdownLinks(value: string): string {
   let result = "";
   let cursor = 0;
 
@@ -668,6 +678,16 @@ function protectLiteralDollarsInPlainText(value: string): string {
     if (value[cursor] === "\\" && value[cursor + 1] === "$") {
       result += ESCAPED_DOLLAR_PLACEHOLDER;
       cursor += 2;
+      continue;
+    }
+
+    // Scan links and math together: splitting at every `[` breaks TeX such as
+    // \left[...\right] before its closing dollars can be found. A math span is
+    // consumed whole below, so brackets inside it never enter link detection.
+    const linkEnd = findInlineMarkdownLinkEnd(value, cursor);
+    if (linkEnd !== -1) {
+      result += value.slice(cursor, linkEnd).replaceAll("$", LITERAL_DOLLAR_PLACEHOLDER);
+      cursor = linkEnd;
       continue;
     }
 
@@ -771,38 +791,6 @@ function findInlineMarkdownLinkEnd(value: string, index: number): number {
 
   const parenEnd = findMarkdownParenEnd(value, bracketEnd + 1);
   return parenEnd === -1 ? -1 : parenEnd + 1;
-}
-
-function protectLiteralDollarsInMarkdownLinks(value: string): string {
-  let result = "";
-  let cursor = 0;
-
-  while (cursor < value.length) {
-    const isLinkStart =
-      value[cursor] === "[" || (value[cursor] === "!" && value[cursor + 1] === "[");
-    if (!isLinkStart) {
-      const nextLinkStart = value.indexOf("[", cursor);
-      const nextImageStart = value.indexOf("![", cursor);
-      const candidates = [nextLinkStart, nextImageStart].filter((candidate) => candidate >= 0);
-      const nextIndex = candidates.length > 0 ? Math.min(...candidates) : value.length;
-      result += protectLiteralDollarsInPlainText(value.slice(cursor, nextIndex));
-      cursor = nextIndex;
-      continue;
-    }
-
-    const linkEnd = findInlineMarkdownLinkEnd(value, cursor);
-    if (linkEnd === -1) {
-      result += protectLiteralDollarsInPlainText(value[cursor] ?? "");
-      cursor += 1;
-      continue;
-    }
-
-    // Inline links are parsed after math, so protect route params like `_chat.$threadId.tsx`.
-    result += value.slice(cursor, linkEnd).replaceAll("$", LITERAL_DOLLAR_PLACEHOLDER);
-    cursor = linkEnd;
-  }
-
-  return result;
 }
 
 // Tighten single-dollar math so currency and escaped dollars stay literal without touching code spans.

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -662,6 +662,16 @@ function findInlineMathClosingDollar(value: string, index: number): number {
       cursor += 2;
       continue;
     }
+    const linkEnd = findInlineMarkdownLinkEnd(value, cursor);
+    if (linkEnd !== -1) {
+      // Dollars in Markdown links/images cannot close preceding literal text.
+      // Dollar-free [f](x) remains valid inside a TeX expression.
+      if (value.slice(cursor, linkEnd).includes("$")) {
+        return -1;
+      }
+      cursor = linkEnd;
+      continue;
+    }
     if (value[cursor] === "$") {
       return canCloseInlineMath(value, cursor) ? cursor : -1;
     }


### PR DESCRIPTION
Keep bracketed TeX expressions intact while protecting literal dollars in Markdown links. Splitting plain text at every `[` could break a display formula and cause subsequent prose or tables to be parsed as math.

Recognize numeric coefficients in complete inline expressions (including table cells) while preserving currency, code and route parameters literally. Regression cases cover bracketed formulas, numeric expressions and prices.

Validation: ChatMarkdown test suite and web typecheck passed. This PR does not include Wiki links or preview layout changes.
