### PR TITLE
feat: display Claude thinking summaries in the work timeline

### DIFF
--- a/apps/server/src/orchestration/providerRuntimeActivityProjection.test.ts
+++ b/apps/server/src/orchestration/providerRuntimeActivityProjection.test.ts
@@ -318,6 +318,21 @@ describe("provider runtime activity projection", () => {
     }
   });
 
+  it("preserves long readable thinking beyond activity metadata limits", () => {
+    const detail = "First paragraph.\n\n" + "Reasoning text. ".repeat(2000) + "Final paragraph.";
+    const [activity] = projectProviderRuntimeActivities(
+      runtimeEvent({
+        type: "item.completed",
+        eventId: "long-thinking",
+        provider: "claudeAgent",
+        turnId: TURN_ID,
+        itemId: RuntimeItemId.makeUnsafe("long-thinking"),
+        payload: { itemType: "reasoning", status: "completed", detail },
+      }),
+    );
+    expect(activity?.payload).toMatchObject({ detail });
+  });
+
   it("maps tool progress without losing call identity", () => {
     const event = runtimeEvent({
       type: "tool.progress",

--- a/apps/server/src/orchestration/providerRuntimeActivityProjection.test.ts
+++ b/apps/server/src/orchestration/providerRuntimeActivityProjection.test.ts
@@ -290,7 +290,7 @@ describe("provider runtime activity projection", () => {
     ];
     expect(absent.map(projectProviderRuntimeActivities)).toEqual([[], [], []]);
 
-    for (const provider of ["codex", "antigravity"] as const) {
+    for (const provider of ["codex", "antigravity", "claudeAgent"] as const) {
       const [activity] = projectProviderRuntimeActivities(
         runtimeEvent({
           type: "item.completed",

--- a/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
+++ b/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
@@ -528,7 +528,9 @@ export function projectProviderRuntimeActivities(
   // transcript rows. Waiting for the authoritative completion also avoids
   // per-token activity writes and transcript height churn.
   if (
-    (event.provider === "codex" || event.provider === "antigravity") &&
+    (event.provider === "codex" ||
+      event.provider === "antigravity" ||
+      event.provider === "claudeAgent") &&
     event.type === "item.completed" &&
     event.payload.itemType === "reasoning" &&
     event.itemId !== undefined &&

--- a/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
+++ b/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
@@ -547,7 +547,7 @@ export function projectProviderRuntimeActivities(
         summary: "Reasoning trace",
         payload: toActivityPayload({
           ...(event.payload.status ? { status: event.payload.status } : {}),
-          detail: truncateDetail(reasoningDetail, MAX_ACTIVITY_DATA_STRING_CHARS),
+          detail: reasoningDetail,
           data: { toolCallId: reasoningItemId },
         }),
         turnId: toTurnId(event.turnId) ?? null,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -725,6 +725,7 @@ describe("ClaudeAdapterLive", () => {
 
       const createInput = harness.getLastCreateQueryInput();
       assert.deepEqual(createInput?.options.settingSources, ["user", "project", "local"]);
+      assert.deepEqual(createInput?.options.extraArgs, { "thinking-display": "summarized" });
       assert.equal(createInput?.options.permissionMode, "bypassPermissions");
       assert.equal(createInput?.options.allowDangerouslySkipPermissions, true);
     }).pipe(
@@ -847,6 +848,7 @@ describe("ClaudeAdapterLive", () => {
 
       const createInput = harness.getLastCreateQueryInput();
       assert.deepEqual(createInput?.options.settingSources, ["user", "project", "local"]);
+      assert.deepEqual(createInput?.options.extraArgs, { "thinking-display": "summarized" });
       assert.equal(createInput?.options.permissionMode, undefined);
       assert.equal(createInput?.options.allowDangerouslySkipPermissions, undefined);
       const systemPrompt = createInput?.options.systemPrompt;
@@ -1815,12 +1817,69 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect(
+    "renders complete thinking snapshots and marks unavailable text without exposing signatures",
+    () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+        const eventsFiber = yield* adapter.streamEvents.pipe(
+          Stream.takeUntil((event) => event.type === "turn.completed"),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        const session = yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: "claudeAgent",
+          runtimeMode: "full-access",
+        });
+        yield* adapter.sendTurn({ threadId: session.threadId, input: "test", attachments: [] });
+        for (const [uuid, thinking] of [
+          ["visible-thinking", "Check the constraints."],
+          ["hidden-thinking", ""],
+        ]) {
+          harness.query.emit({
+            type: "assistant",
+            session_id: "thinking-session",
+            uuid,
+            parent_tool_use_id: null,
+            message: {
+              id: uuid,
+              content: [{ type: "thinking", thinking, signature: "private-signature" }],
+            },
+          } as unknown as SDKMessage);
+        }
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          errors: [],
+          session_id: "thinking-session",
+          uuid: "done",
+        } as unknown as SDKMessage);
+        const events = Array.from(yield* Fiber.join(eventsFiber));
+        const details = events.flatMap((event) =>
+          event.type === "item.completed" && event.payload.itemType === "reasoning"
+            ? [event.payload.detail]
+            : [],
+        );
+        assert.deepEqual(details, [
+          "Check the constraints.",
+          "Claude completed a thinking step but did not provide its text.",
+        ]);
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
   it.effect("maps Claude reasoning deltas, streamed tool inputs, and tool results", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
 
-      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 11).pipe(
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 12).pipe(
         Stream.runCollect,
         Effect.forkChild,
       );
@@ -1850,6 +1909,14 @@ describe("ClaudeAdapterLive", () => {
             thinking: "Let",
           },
         },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-tool-streams",
+        uuid: "thinking-stop",
+        parent_tool_use_id: null,
+        event: { type: "content_block_stop", index: 0 },
       } as unknown as SDKMessage);
 
       harness.query.emit({
@@ -1931,6 +1998,7 @@ describe("ClaudeAdapterLive", () => {
           "turn.started",
           "thread.started",
           "content.delta",
+          "item.completed",
           "item.started",
           "item.updated",
           "item.updated",
@@ -1947,6 +2015,14 @@ describe("ClaudeAdapterLive", () => {
         assert.equal(reasoningDelta.payload.delta, "Let");
         assert.equal(String(reasoningDelta.turnId), String(turn.turnId));
       }
+
+      const thinking = runtimeEvents.find(
+        (event) => event.type === "item.completed" && event.payload.itemType === "reasoning",
+      );
+      assert.equal(
+        thinking?.type === "item.completed" ? thinking.payload.detail : undefined,
+        "Let",
+      );
 
       const toolStarted = runtimeEvents.find((event) => event.type === "item.started");
       assert.equal(toolStarted?.type, "item.started");

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -204,6 +204,8 @@ interface ClaudeTurnState {
   readonly synthetic?: true;
   readonly items: Array<unknown>;
   readonly assistantTextBlocks: Map<number, AssistantTextBlockState>;
+  readonly thinkingBlocks: Map<number, { id: string; text: string }>;
+  readonly emittedThinkingTexts: Set<string>;
   readonly assistantTextBlockOrder: Array<AssistantTextBlockState>;
   readonly capturedProposedPlanKeys: Set<string>;
   readonly sawFileChange: boolean;
@@ -3226,6 +3228,14 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             if (deltaText.length === 0) {
               return;
             }
+            if (event.delta.type === "thinking_delta") {
+              const block = context.turnState.thinkingBlocks.get(event.index) ?? {
+                id: `claude-thinking:${context.turnState.turnId}:${message.uuid}`,
+                text: "",
+              };
+              block.text += deltaText;
+              context.turnState.thinkingBlocks.set(event.index, block);
+            }
             const streamKind = streamKindFromDeltaType(event.delta.type);
             const assistantBlockEntry =
               event.delta.type === "text_delta"
@@ -3376,6 +3386,30 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
 
         if (event.type === "content_block_stop") {
           const { index } = event;
+          const thinkingBlock = context.turnState?.thinkingBlocks.get(index);
+          if (thinkingBlock && context.turnState) {
+            context.turnState.thinkingBlocks.delete(index);
+            if (context.turnState.emittedThinkingTexts.has(thinkingBlock.text)) return;
+            context.turnState.emittedThinkingTexts.add(thinkingBlock.text);
+            const stamp = yield* makeEventStamp();
+            yield* offerRuntimeEvent(context, {
+              type: "item.completed",
+              eventId: stamp.eventId,
+              provider: PROVIDER,
+              createdAt: stamp.createdAt,
+              threadId: context.session.threadId,
+              turnId: context.turnState.turnId,
+              itemId: asRuntimeItemId(thinkingBlock.id),
+              payload: {
+                itemType: "reasoning",
+                status: "completed",
+                title: "Thinking",
+                detail: thinkingBlock.text,
+              },
+              providerRefs: nativeProviderRefs(context),
+            });
+            return;
+          }
           const assistantBlock = context.turnState?.assistantTextBlocks.get(index);
           if (assistantBlock) {
             assistantBlock.streamClosed = true;
@@ -3590,6 +3624,8 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           synthetic: true,
           items: [],
           assistantTextBlocks: new Map(),
+          thinkingBlocks: new Map(),
+          emittedThinkingTexts: new Set(),
           assistantTextBlockOrder: [],
           capturedProposedPlanKeys: new Set(),
           sawFileChange: false,
@@ -3682,6 +3718,31 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         if (Array.isArray(content)) {
           for (const block of content) {
             if (!block || typeof block !== "object") {
+              continue;
+            }
+            if (block.type === "thinking" && context.turnState) {
+              const text = typeof block.thinking === "string" ? block.thinking : "";
+              if (!context.turnState.emittedThinkingTexts.has(text)) {
+                context.turnState.emittedThinkingTexts.add(text);
+                const stamp = yield* makeEventStamp();
+                yield* offerRuntimeEvent(context, {
+                  type: "item.completed",
+                  eventId: stamp.eventId,
+                  provider: PROVIDER,
+                  createdAt: stamp.createdAt,
+                  threadId: context.session.threadId,
+                  turnId: context.turnState.turnId,
+                  itemId: asRuntimeItemId(`claude-thinking:${message.uuid}`),
+                  payload: {
+                    itemType: "reasoning",
+                    status: "completed",
+                    title: "Thinking",
+                    detail:
+                      text || "Claude completed a thinking step but did not provide its text.",
+                  },
+                  providerRefs: nativeProviderRefs(context),
+                });
+              }
               continue;
             }
             const toolUse = block as {
@@ -5343,6 +5404,8 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           ...(existingResumeSessionId ? { resume: existingResumeSessionId } : {}),
           ...(newSessionId ? { sessionId: newSessionId } : {}),
           includePartialMessages: true,
+          // Request readable summaries without changing the selected thinking budget or toggle.
+          extraArgs: { "thinking-display": "summarized" },
           // Forward full subagent conversations (text + thinking) tagged with
           // parent_tool_use_id so child threads can stream live.
           forwardSubagentText: true,
@@ -5831,6 +5894,8 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           interactionMode: effectiveInteractionMode,
           items: [],
           assistantTextBlocks: new Map(),
+          thinkingBlocks: new Map(),
+          emittedThinkingTexts: new Set(),
           assistantTextBlockOrder: [],
           capturedProposedPlanKeys: new Set(),
           sawFileChange: false,

--- a/apps/web/src/components/chat/AgentActivityDetailView.tsx
+++ b/apps/web/src/components/chat/AgentActivityDetailView.tsx
@@ -1,3 +1,4 @@
+import { ReasoningContent } from "./ReasoningContent";
 // FILE: AgentActivityDetailView.tsx
 // Purpose: Full-width transcript replacement for inspecting agent activity without opening side UI.
 // Layer: Chat presentation component
@@ -164,7 +165,9 @@ function AgentActivityEventRow(props: {
 }) {
   const preview = formatAgentActivityEntryPreview(props.entry);
   const title = formatAgentActivityEntryTitle(props.entry);
-  const body = isReasoningUpdateWorkEntry(props.entry) ? preview : (preview ?? props.entry.detail);
+  const body = isReasoningUpdateWorkEntry(props.entry)
+    ? (props.entry.detail ?? preview)
+    : (preview ?? props.entry.detail);
 
   return (
     <div className="py-3 first:pt-0 last:pb-0">
@@ -176,7 +179,9 @@ function AgentActivityEventRow(props: {
           {formatShortTimestamp(props.entry.createdAt, props.timestampFormat)}
         </p>
       </div>
-      {body ? (
+      {body && isReasoningUpdateWorkEntry(props.entry) ? (
+        <ReasoningContent text={body} cwd={props.markdownCwd} onImageExpand={props.onImageExpand} />
+      ) : body ? (
         <div className="mt-1 text-muted-foreground/70">
           <ChatMarkdown
             text={body}

--- a/apps/web/src/components/chat/MessageCopyButton.tsx
+++ b/apps/web/src/components/chat/MessageCopyButton.tsx
@@ -26,7 +26,15 @@ function showCopyToast(
   });
 }
 
-export function MessageCopyButton({ text, className }: { text: string; className?: string }) {
+export function MessageCopyButton({
+  text,
+  className,
+  label = "Copy message",
+}: {
+  text: string;
+  className?: string;
+  label?: string;
+}) {
   const ref = useRef<HTMLButtonElement>(null);
   const { copyToClipboard, isCopied } = useCopyToClipboard<void>({
     onCopy: () => showCopyToast(ref, "Copied!"),
@@ -37,7 +45,7 @@ export function MessageCopyButton({ text, className }: { text: string; className
   return (
     <MessageActionButton
       ref={ref}
-      label="Copy message"
+      label={label}
       tooltip="Copy to clipboard"
       disabled={isCopied}
       className={className}

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1825,7 +1825,7 @@ describe("MessagesTimeline", () => {
     expect(markup).not.toContain("+2 more tool calls");
   });
 
-  it("renders reasoning activity as iconless tool text while Thinking remains live", async () => {
+  it("renders collapsed thinking disclosures while Thinking remains live", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const activeTurnId = TurnId.makeUnsafe("turn-reasoning-live");
     const markup = renderToStaticMarkup(
@@ -1910,7 +1910,7 @@ describe("MessagesTimeline", () => {
       />,
     );
 
-    expect(markup.match(/data-codex-status-row="true"/g) ?? []).toHaveLength(3);
+    expect(markup.match(/data-codex-status-row="true"/g) ?? []).toHaveLength(1);
     expect(markup.match(/data-work-entry-icon="true"/g) ?? []).toHaveLength(1);
     expect(markup).toContain(">Thinking<");
     expect(markup).toContain("Inspecting apps/web/src/store.ts");

--- a/apps/web/src/components/chat/ReasoningContent.browser.tsx
+++ b/apps/web/src/components/chat/ReasoningContent.browser.tsx
@@ -1,0 +1,17 @@
+import "../../index.css";
+import { expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+import { ReasoningContent } from "./ReasoningContent";
+
+it("renders the whole thinking in a bounded scroll region with a full-copy action", async () => {
+  const text = "First paragraph\n\n" + "Readable reasoning. ".repeat(1000) + "\n\nFinal paragraph";
+  const screen = await render(
+    <ReasoningContent text={text} cwd={undefined} onImageExpand={() => {}} />,
+  );
+  await expect.element(screen.getByText("First paragraph", { exact: true })).toBeInTheDocument();
+  await expect.element(screen.getByText("Final paragraph", { exact: true })).toBeInTheDocument();
+  await expect.element(screen.getByRole("button", { name: "Copy full thinking" })).toBeVisible();
+  const scroller = document.querySelector("[data-reasoning-content] .overflow-y-auto")!;
+  expect(scroller.scrollHeight).toBeGreaterThan(scroller.clientHeight);
+  expect(scroller.clientHeight).toBeLessThanOrEqual(384);
+});

--- a/apps/web/src/components/chat/ReasoningContent.tsx
+++ b/apps/web/src/components/chat/ReasoningContent.tsx
@@ -1,0 +1,27 @@
+import ChatMarkdown from "../ChatMarkdown";
+import { MessageCopyButton } from "./MessageCopyButton";
+import type { ExpandedImagePreview } from "./ExpandedImagePreview";
+
+/** Full provider-readable text; only the collapsed label is a preview. */
+export function ReasoningContent(props: {
+  text: string;
+  cwd: string | undefined;
+  onImageExpand: (preview: ExpandedImagePreview) => void;
+}) {
+  return (
+    <div className="min-w-0" data-reasoning-content="true">
+      <div className="mb-2 flex items-center justify-between gap-2 text-xs text-muted-foreground">
+        <span>Provider thinking text · length differs from thinking token usage</span>
+        <MessageCopyButton text={props.text} label="Copy full thinking" />
+      </div>
+      <div className="max-h-96 overflow-y-auto overscroll-contain pr-2 [scrollbar-gutter:stable]">
+        <ChatMarkdown
+          text={props.text}
+          cwd={props.cwd}
+          isStreaming={false}
+          onImageExpand={props.onImageExpand}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/Thinking.browser.tsx
+++ b/apps/web/src/components/chat/Thinking.browser.tsx
@@ -1,0 +1,33 @@
+import "../../index.css";
+import { expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+import { TimelineWorkEntryRow } from "./TimelineWorkEntryRow";
+it("expands thinking independently from tool details", async () => {
+  const screen = await render(
+    <div style={{ width: 360 }}>
+      <TimelineWorkEntryRow
+        workEntry={{
+          id: "thinking",
+          createdAt: "2026-09-05T00:00:00Z",
+          tone: "tool",
+          label: "Reasoning trace",
+          detail: "Check the constraints before executing the command.",
+        }}
+        chatMetaFontSizePx={12}
+        markdownCwd={undefined}
+        onImageExpand={() => {}}
+        timestampFormat="locale"
+      />
+    </div>,
+  );
+  const trigger = screen.getByRole("button", { name: /Thinking/ });
+  await expect.element(trigger).toBeVisible();
+  await expect.element(trigger).toHaveAttribute("aria-expanded", "false");
+  await trigger.click();
+  await expect.element(trigger).toHaveAttribute("aria-expanded", "true");
+  await expect
+    .element(screen.getByText("Check the constraints before executing the command.").last())
+    .toBeVisible();
+  await trigger.click();
+  await expect.element(trigger).toHaveAttribute("aria-expanded", "false");
+});

--- a/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
+++ b/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
@@ -1,3 +1,4 @@
+import { ReasoningContent } from "./ReasoningContent";
 // FILE: TimelineWorkEntryRow.tsx
 // Purpose: Renders transcript work/tool rows and their inline details.
 // Layer: Web chat presentation component
@@ -611,10 +612,9 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
           compact={compact}
           timestampFormat={timestampFormat}
           detailContent={
-            <ChatMarkdown
-              text={preview ?? workEntry.detail ?? ""}
+            <ReasoningContent
+              text={workEntry.detail ?? preview ?? ""}
               cwd={markdownCwd}
-              isStreaming={false}
               onImageExpand={onImageExpand}
             />
           }

--- a/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
+++ b/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
@@ -23,6 +23,7 @@ import {
   ArrowUpCircleIcon,
   BackgroundTrayIcon,
   BotIcon,
+  BrainIcon,
   CheckIcon,
   CircleAlertIcon,
   CircleQuestionIcon,
@@ -603,6 +604,36 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
   // Use the text font size (matching the UI settings) for tool call rows
   const rowFontSizePx = textFontSizePx;
 
+  if (isReasoningUpdateWorkEntry(workEntry)) {
+    return (
+      <div className="my-1 rounded-lg border-l-2 border-violet-400/60 bg-violet-500/5 px-2 py-1 dark:border-violet-400/50">
+        <ToolDetailsDisclosure
+          compact={compact}
+          timestampFormat={timestampFormat}
+          detailContent={
+            <ChatMarkdown
+              text={preview ?? workEntry.detail ?? ""}
+              cwd={markdownCwd}
+              isStreaming={false}
+              onImageExpand={onImageExpand}
+            />
+          }
+        >
+          <BrainIcon className="size-4 shrink-0 text-violet-600 dark:text-violet-400" />
+          <span className="shrink-0 text-xs font-medium text-violet-700 dark:text-violet-300">
+            Thinking
+          </span>
+          <span
+            className="min-w-0 truncate text-muted-foreground"
+            style={{ fontSize: `${rowFontSizePx}px` }}
+          >
+            {preview}
+          </span>
+        </ToolDetailsDisclosure>
+      </div>
+    );
+  }
+
   return (
     <div className={cn(compact ? "py-0.5" : "rounded-lg py-1")}>
       {showEditedRows ? (
@@ -680,7 +711,7 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
                 <span
                   className={cn(
                     "flex shrink-0 items-center justify-center",
-                    WORK_ROW_MUTED_HOVER_TONE["tool-row"],
+                    "text-sky-600 dark:text-sky-400",
                     compact ? "size-4" : "size-5",
                   )}
                   data-tool-icon={leftIconKind}

--- a/apps/web/src/components/chat/agentActivity.logic.ts
+++ b/apps/web/src/components/chat/agentActivity.logic.ts
@@ -136,7 +136,11 @@ export function deriveAgentActivityTimelineState(
       label: "Reasoning trace",
       toolTitle: "Reasoning trace",
       tone: "tool",
-      ...(displayPreview ? { preview: displayPreview, detail: displayPreview } : {}),
+      ...(displayPreview ? { preview: displayPreview } : {}),
+      detail: groupEntries
+        .map((entry) => entry.detail ?? entry.preview ?? "")
+        .filter(Boolean)
+        .join("\n\n"),
     };
 
     timelineWorkEntries.push(displayEntry);
@@ -243,7 +247,8 @@ function cleanReasoningProgressText(value: string | undefined): string | null {
     .replace(/^reasoning(?:\s+(?:update|trace|summary))?\b[\s:.-]*/i, "")
     .trim();
   const withoutRunningPrefix = withoutReasoningPrefix.replace(/^running\b[\s:.-]*/i, "").trim();
-  return withoutRunningPrefix || withoutReasoningPrefix || null;
+  const preview = withoutRunningPrefix || withoutReasoningPrefix;
+  return preview ? (preview.length > 120 ? `${preview.slice(0, 117)}...` : preview) : null;
 }
 
 function normalizeOptionalText(value: string | undefined): string | null {

--- a/apps/web/src/components/chat/toolCallGroup.logic.ts
+++ b/apps/web/src/components/chat/toolCallGroup.logic.ts
@@ -1,3 +1,4 @@
+import { isReasoningUpdateWorkEntry } from "./agentActivity.logic";
 // FILE: toolCallGroup.logic.ts
 // Purpose: Summarizes a settled run of tool-call work entries into one compact
 //          label ("Ran 2 commands, Edited 2 files, Searched 3 files") for the
@@ -46,6 +47,7 @@ export interface ToolCallGroupSummary {
 export function isSummarizableToolCallEntry(entry: WorkLogEntry): boolean {
   return (
     entry.tone === "tool" &&
+    !isReasoningUpdateWorkEntry(entry) &&
     !entry.synaraThreadCreation &&
     !entry.automation &&
     !entry.subagentAction &&


### PR DESCRIPTION
Show Claude thinking in the work timeline and keep compact previews separate from the full provider-readable text.

- Request summarized thinking display from Claude Code and retain readable text from streaming blocks and completed snapshots. Do not expose signature payloads; explicitly indicate when the provider supplies no text.
- Use labeled violet thinking disclosures with a brain icon and blue tool icons to distinguish reasoning from tool activity.
- Keep the collapsed progress label short, but preserve the complete supplied text in both timeline details and agent activity details. Expanded content uses a bounded scrolling region with a "Copy full thinking" action.
- Remove the projection truncation that discarded longer reasoning details. Text length is distinct from provider-reported thinking token usage; this does not reconstruct text the provider has not supplied.

Validation: 183 server tests (ClaudeAdapter and providerRuntimeActivityProjection), 66 web logic/timeline tests, and Thinking/ReasoningContent browser tests passed. Browser coverage verifies the final paragraph of long reasoning remains available and expansion stays within a bounded scroll region. The combined PR integration passed formatting, lint, and full workspace typecheck.
