### PR TITLE
feat: show turn usage and account quotas in context details

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -361,6 +361,33 @@ describe("ProviderRuntimeIngestion", () => {
     };
   }
 
+  it("records thinking arrival once before later assistant text", async () => {
+    const harness = await createHarness();
+    const base = {
+      provider: "codex" as const,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("first-output-turn"),
+    };
+    for (const [index, streamKind] of (["reasoning_text", "assistant_text"] as const).entries()) {
+      harness.emit({
+        ...base,
+        type: "content.delta",
+        eventId: asEventId(`first-output-${index}`),
+        createdAt: `2026-07-14T00:00:0${index + 1}.000Z`,
+        payload: { streamKind, delta: "Readable output" },
+      });
+    }
+    const thread = await waitForThread(harness.engine, (thread) =>
+      thread.messages.some((message) => message.text.includes("Readable output")),
+    );
+    const markers = thread.activities.filter(
+      (activity) => activity.kind === "provider.first-output",
+    );
+    expect(markers).toHaveLength(1);
+    expect(markers[0]?.createdAt).toBe("2026-07-14T00:00:01.000Z");
+    expect(markers[0]?.payload).toMatchObject({ streamKind: "reasoning_text" });
+  });
+
   it("REL-01C gate: replays output persisted before subscription without duplicate acceptance", async () => {
     const harness = await createHarness({ startIngestion: false });
     const event: ProviderRuntimeEvent = {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1898,6 +1898,8 @@ const make = Effect.gen(function* () {
   >();
   const bufferedTextSpilledByMessageKey = new Set<string>();
 
+  const firstOutputRecorded = new Set<string>();
+
   const processRuntimeEvent = (event: ProviderRuntimeEvent, runtimeSequence: number) =>
     Effect.gen(function* () {
       const now = event.createdAt;
@@ -2342,6 +2344,43 @@ const make = Effect.gen(function* () {
             runtimeMode: inferredRuntimeMode,
             createdAt: now,
           });
+        }
+      }
+
+      // Record one real model-output arrival per turn, including reasoning.
+      // Receipt lookup makes replay/restart idempotent without overwriting the first timestamp.
+      if (
+        event.type === "content.delta" &&
+        event.turnId &&
+        event.payload.delta.length > 0 &&
+        ["assistant_text", "reasoning_text", "reasoning_summary_text"].includes(
+          event.payload.streamKind,
+        )
+      ) {
+        const key = `provider:first-output:${thread.id}:${event.turnId}`;
+        if (!firstOutputRecorded.has(key)) {
+          const commandId = CommandId.makeUnsafe(key);
+          const receipt = yield* commandReceipts.getByCommandId({ commandId });
+          if (Option.isNone(receipt)) {
+            yield* orchestrationEngine.dispatch({
+              type: "thread.activity.append",
+              commandId,
+              threadId: thread.id,
+              activity: {
+                id: EventId.makeUnsafe(key),
+                turnId: toTurnId(event.turnId) ?? null,
+                kind: "provider.first-output",
+                tone: "info",
+                summary: "First model output",
+                createdAt: event.createdAt,
+                payload: { streamKind: event.payload.streamKind },
+              },
+              createdAt: event.createdAt,
+            });
+          }
+          firstOutputRecorded.add(key);
+          if (firstOutputRecorded.size > 10000)
+            firstOutputRecorded.delete(firstOutputRecorded.values().next().value!);
         }
       }
 

--- a/apps/server/src/providerUsage/http.ts
+++ b/apps/server/src/providerUsage/http.ts
@@ -1,3 +1,4 @@
+import { resolveUsageLocalProxy } from "./localProxy";
 // FILE: providerUsage/http.ts
 // Purpose: Bounded JSON helper for provider usage, backed by the pinned outbound authority.
 
@@ -30,7 +31,9 @@ export async function fetchJson(input: {
       : input.bodyFormat === "form"
         ? new URLSearchParams(input.body as Record<string, string>).toString()
         : JSON.stringify(input.body);
+  const localProxyUrl = await resolveUsageLocalProxy();
   const response = await outboundHttp.request({
+    ...(localProxyUrl ? { localProxyUrl } : {}),
     policy: {
       service: input.service,
       allowedOrigins: input.allowedOrigins,

--- a/apps/server/src/providerUsage/localProxy.test.ts
+++ b/apps/server/src/providerUsage/localProxy.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { parseMacHttpsProxy } from "./localProxy";
+describe("system usage proxy", () => {
+  it("honors an enabled local HTTPS proxy", () => {
+    expect(parseMacHttpsProxy("HTTPSEnable : 1\nHTTPSProxy : 127.0.0.1\nHTTPSPort : 7897")).toBe(
+      "http://127.0.0.1:7897",
+    );
+  });
+  it("ignores disabled, remote, invalid and PAC-only configurations", () => {
+    for (const source of [
+      "HTTPSEnable : 0\nHTTPSProxy : 127.0.0.1\nHTTPSPort : 7897",
+      "HTTPSEnable : 1\nHTTPSProxy : remote.test\nHTTPSPort : 7897",
+      "HTTPSEnable : 1\nHTTPSProxy : 127.0.0.1\nHTTPSPort : 99999",
+      "ProxyAutoConfigEnable : 1",
+    ])
+      expect(parseMacHttpsProxy(source)).toBeUndefined();
+  });
+});

--- a/apps/server/src/providerUsage/localProxy.ts
+++ b/apps/server/src/providerUsage/localProxy.ts
@@ -1,0 +1,32 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const exec = promisify(execFile);
+let cached: { until: number; value: string | undefined } | undefined;
+let pending: Promise<string | undefined> | undefined;
+
+export function parseMacHttpsProxy(output: string): string | undefined {
+  if (!/^\s*HTTPSEnable\s*:\s*1\s*$/m.test(output)) return;
+  const host = output.match(/^\s*HTTPSProxy\s*:\s*(\S+)\s*$/m)?.[1];
+  const port = Number(output.match(/^\s*HTTPSPort\s*:\s*(\d+)\s*$/m)?.[1]);
+  if (host !== "127.0.0.1" || !Number.isInteger(port) || port < 1 || port > 65535) return;
+  return `http://${host}:${port}`;
+}
+
+/** Only quota fetches opt in; preserve the user's existing system proxy selection. */
+export async function resolveUsageLocalProxy(): Promise<string | undefined> {
+  if (process.platform !== "darwin") return;
+  if (cached && cached.until > Date.now()) return cached.value;
+  if (pending) return pending;
+  pending = exec("/usr/sbin/scutil", ["--proxy"], { timeout: 2000, maxBuffer: 32768 })
+    .then(({ stdout }) => parseMacHttpsProxy(stdout))
+    .catch(() => undefined)
+    .then((value) => {
+      cached = { until: Date.now() + 60000, value };
+      return value;
+    })
+    .finally(() => {
+      pending = undefined;
+    });
+  return pending;
+}

--- a/apps/server/src/providerUsage/providers/antigravity.test.ts
+++ b/apps/server/src/providerUsage/providers/antigravity.test.ts
@@ -8,6 +8,7 @@ import nodePath from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { outboundHttp } from "@synara/shared/outboundHttp";
+import * as credentials from "../credentials";
 
 import { antigravityUsageFetcher, parseAntigravityQuota } from "./antigravity";
 
@@ -64,23 +65,25 @@ describe("parseAntigravityQuota", () => {
         cloudaicompanionProject: "gen-lang-client-1",
       },
       quota: {
-        buckets: [
-          {
-            modelId: "gemini-2.5-pro",
-            remainingFraction: 0.4,
-            resetTime: "2026-09-01T00:00:00Z",
-          },
-          {
-            modelId: "gemini-2.5-pro-preview",
-            remainingFraction: 0.1,
-            resetTime: "2026-09-01T00:00:00Z",
-          },
-          {
-            modelId: "gemini-2.5-flash",
-            remainingFraction: 0.8,
-            resetTime: "2026-08-20T12:00:00Z",
-          },
-        ],
+        models: Object.fromEntries(
+          [
+            {
+              modelId: "gemini-2.5-pro",
+              remainingFraction: 0.4,
+              resetTime: "2026-09-01T00:00:00Z",
+            },
+            {
+              modelId: "gemini-2.5-pro-preview",
+              remainingFraction: 0.1,
+              resetTime: "2026-09-01T00:00:00Z",
+            },
+            {
+              modelId: "gemini-2.5-flash",
+              remainingFraction: 0.8,
+              resetTime: "2026-08-20T12:00:00Z",
+            },
+          ].map(({ modelId, ...quotaInfo }) => [modelId, { quotaInfo }]),
+        ),
       },
       nowMs: NOW_MS,
     });
@@ -92,6 +95,88 @@ describe("parseAntigravityQuota", () => {
 });
 
 describe("antigravityUsageFetcher", () => {
+  it("does not reuse a Gemini CLI login as an Antigravity account", async () => {
+    const { homeDir } = makeGeminiHome(".gemini/oauth_creds.json", {
+      access_token: "unrelated-gemini-token",
+    });
+    const snapshot = await antigravityUsageFetcher.fetch({
+      homeDir,
+      env: {},
+      platform: "linux",
+      nowMs: NOW_MS,
+    });
+    expect(snapshot.status).toBe("needs-auth");
+  });
+
+  it("reads the agy keychain account before fallback files, including Go keyring encoding", async () => {
+    const { homeDir } = makeGeminiHome(".gemini/antigravity-cli/antigravity-oauth-token", {
+      access_token: "old-file",
+    });
+    const record = {
+      auth_method: "consumer",
+      token: { access_token: "keychain-token", expiry: new Date(NOW_MS + 3600000).toISOString() },
+    };
+    const keychain = vi
+      .spyOn(credentials, "readKeychainPassword")
+      .mockResolvedValue(
+        "go-keyring-base64:" + Buffer.from(JSON.stringify(record)).toString("base64"),
+      );
+    stubOutboundFetch(async (_url, init) => {
+      expect((init?.headers as Record<string, string> | undefined)?.Authorization).toBe(
+        "Bearer keychain-token",
+      );
+      return jsonResponse({
+        models: {
+          "claude-sonnet": { quotaInfo: { remainingFraction: 0.6 } },
+          tab_flash: { quotaInfo: { remainingFraction: 0 } },
+        },
+      });
+    });
+    const snapshot = await antigravityUsageFetcher.fetch({
+      homeDir,
+      env: {},
+      platform: "darwin",
+      nowMs: NOW_MS,
+    });
+    expect(keychain).toHaveBeenCalledWith({
+      service: "gemini",
+      account: "antigravity",
+      platform: "darwin",
+    });
+    expect(snapshot.limits).toEqual([{ window: "Claude", usedPercent: 40 }]);
+  });
+
+  it("refreshes keychain tokens in memory without writing credentials back", async () => {
+    const { homeDir } = makeGeminiHome(".gemini/oauth_creds.json", { access_token: "unrelated" });
+    vi.spyOn(credentials, "readKeychainPassword").mockResolvedValue(
+      JSON.stringify({
+        auth_method: "consumer",
+        token: {
+          access_token: "expired-keychain",
+          refresh_token: "keychain-refresh",
+          expiry: new Date(NOW_MS - 1000).toISOString(),
+        },
+      }),
+    );
+    const write = vi.spyOn(credentials, "writeJsonFileAtomic");
+    let refreshCount = 0;
+    stubOutboundFetch(async (url, init) => {
+      if (String(url).includes("oauth2.googleapis.com")) {
+        refreshCount++;
+        expect(new URLSearchParams(String(init?.body)).get("client_id")).toMatch(/^1071006060591-/);
+        return jsonResponse({ access_token: "refreshed-keychain", expires_in: 3600 });
+      }
+      expect((init?.headers as Record<string, string> | undefined)?.Authorization).toBe(
+        "Bearer refreshed-keychain",
+      );
+      return jsonResponse({ models: { "gemini-pro": { quotaInfo: { remainingFraction: 1 } } } });
+    });
+    const ctx = { homeDir, env: {}, platform: "darwin" as const, nowMs: Date.now() };
+    expect((await antigravityUsageFetcher.fetch(ctx)).status).toBe("ok");
+    expect((await antigravityUsageFetcher.fetch(ctx)).status).toBe("ok");
+    expect(refreshCount).toBe(1);
+    expect(write).not.toHaveBeenCalled();
+  });
   it("returns needs-auth when no Gemini/agy credential is present", async () => {
     const homeDir = mkdtempSync(nodePath.join(os.tmpdir(), "synara-agy-empty-"));
     tempDirs.push(homeDir);
@@ -117,16 +202,17 @@ describe("antigravityUsageFetcher", () => {
       const target = String(url);
       const headers = init?.headers as Record<string, string>;
       expect(headers.Authorization).toBe("Bearer ya29-access");
+      expect(headers["User-Agent"]).toMatch(/^antigravity\//);
       if (target.includes("loadCodeAssist")) {
         return jsonResponse({
           currentTier: { id: "standard-tier", name: "Paid" },
           cloudaicompanionProject: "gen-lang-client-9",
         });
       }
-      if (target.includes("retrieveUserQuota")) {
+      if (target.includes("fetchAvailableModels")) {
         expect(String(init?.body)).toContain("gen-lang-client-9");
         return jsonResponse({
-          buckets: [{ modelId: "gemini-2.5-pro", remainingFraction: 0.75 }],
+          models: { "gemini-2.5-pro": { quotaInfo: { remainingFraction: 0.75 } } },
         });
       }
       throw new Error(`unexpected url ${target}`);
@@ -164,6 +250,7 @@ describe("antigravityUsageFetcher", () => {
         const body = new URLSearchParams(String(init?.body));
         expect(body.get("grant_type")).toBe("refresh_token");
         expect(body.get("refresh_token")).toBe("1//old-refresh");
+        expect(body.get("client_id")).toMatch(/^1071006060591-/);
         expect(body.get("client_secret")).toBeTruthy();
         return jsonResponse({
           access_token: "ya29-new",
@@ -176,8 +263,8 @@ describe("antigravityUsageFetcher", () => {
       if (target.includes("loadCodeAssist")) {
         return jsonResponse({ currentTier: { id: "free-tier" } });
       }
-      if (target.includes("retrieveUserQuota")) {
-        return jsonResponse({ buckets: [] });
+      if (target.includes("fetchAvailableModels")) {
+        return jsonResponse({ models: {} });
       }
       throw new Error(`unexpected url ${target}`);
     });

--- a/apps/server/src/providerUsage/providers/antigravity.ts
+++ b/apps/server/src/providerUsage/providers/antigravity.ts
@@ -1,7 +1,6 @@
 // FILE: providerUsage/providers/antigravity.ts
-// Purpose: Live Antigravity usage fetcher. Reads Gemini CLI OAuth (`oauth_creds.json`) or
-// the agy token file (`antigravity-cli/antigravity-oauth-token`), refreshes through Google's
-// public Gemini-CLI client, then calls Cloud Code loadCodeAssist + retrieveUserQuota.
+// Purpose: Read the agy consumer login and fetch Antigravity model quotas.
+// Keychain credentials are read-only; refreshed keychain access tokens stay in memory.
 
 import nodePath from "node:path";
 
@@ -9,6 +8,8 @@ import type { ServerProviderUsageLimit } from "@synara/contracts";
 
 import {
   credentialFingerprint,
+  readKeychainPassword,
+  decodeKeychainJson,
   readJsonFile,
   refreshOAuthAccessToken,
   writeJsonFileAtomic,
@@ -31,37 +32,34 @@ import type { ProviderUsageContext, ProviderUsageFetcher } from "../types";
 
 const SOURCE = "antigravity-cloudcode";
 const LOAD_URL = "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist";
-const QUOTA_URL = "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota";
+const QUOTA_URL = "https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels";
 const REFRESH_URL = "https://oauth2.googleapis.com/token";
 const CLOUD_CODE_ORIGIN = new URL(LOAD_URL).origin;
-// Public Gemini CLI installed-app OAuth client (not a Synara-issued secret).
+// Public Antigravity installed-app OAuth client (not a Synara-issued secret).
 // Assembled so GitHub push protection does not treat the published CLI client as a leak.
-const GEMINI_OAUTH_CLIENT_ID = [
-  "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j",
+const ANTIGRAVITY_OAUTH_CLIENT_ID = [
+  "1071006060591-tmhssin2h21lcre235vtolojh4g403ep",
   "apps.googleusercontent.com",
 ].join(".");
-const GEMINI_OAUTH_CLIENT_SECRET = ["GOCSPX", "4uHgMPm-1o7Sk-geV6Cu5clXFsxl"].join("-");
+const ANTIGRAVITY_OAUTH_CLIENT_SECRET = ["GOCSPX", "K58FWR486LdLJ1mLB8sXC4z6qDAf"].join("-");
 const REFRESH_BUFFER_MS = 5 * 60 * 1000;
 const MAX_QUOTA_WINDOWS = 4;
 
-interface GeminiOAuthCreds {
-  path: string;
+interface AntigravityOAuthCreds {
+  path: string | null;
   record: Record<string, unknown>;
   accessToken: string;
   refreshToken?: string;
   expiresAtMs?: number;
 }
 
-function geminiCredPaths(ctx: ProviderUsageContext): string[] {
+function antigravityCredPaths(ctx: ProviderUsageContext): string[] {
   const geminiHome = ctx.env.GEMINI_CONFIG_DIR?.trim() || nodePath.join(ctx.homeDir, ".gemini");
   return [
     nodePath.join(geminiHome, "antigravity-cli", "antigravity-oauth-token"),
     nodePath.join(geminiHome, "antigravity-cli", "oauth_creds.json"),
-    nodePath.join(geminiHome, "oauth_creds.json"),
     nodePath.join(ctx.homeDir, ".gemini", "antigravity-cli", "antigravity-oauth-token"),
     nodePath.join(ctx.homeDir, ".gemini", "antigravity-cli", "oauth_creds.json"),
-    nodePath.join(ctx.homeDir, ".gemini", "oauth_creds.json"),
-    nodePath.join(ctx.homeDir, ".config", "gemini", "oauth_creds.json"),
   ].filter((value, index, all) => all.indexOf(value) === index);
 }
 
@@ -77,9 +75,10 @@ function expiryMsFromUnknown(value: unknown): number | undefined {
   return Number.isNaN(parsed) ? undefined : parsed;
 }
 
-function readGeminiCreds(path: string, value: unknown): GeminiOAuthCreds | null {
+function readAntigravityCreds(path: string | null, value: unknown): AntigravityOAuthCreds | null {
   const record = asRecord(value);
-  if (!record) return null;
+  if (!record || (record.auth_method !== undefined && record.auth_method !== "consumer"))
+    return null;
   const tokenRecord = asRecord(record.token) ?? record;
   const accessToken = asString(tokenRecord.access_token);
   if (!accessToken) return null;
@@ -98,9 +97,35 @@ function readGeminiCreds(path: string, value: unknown): GeminiOAuthCreds | null 
   };
 }
 
-async function resolveGeminiCreds(ctx: ProviderUsageContext): Promise<GeminiOAuthCreds | null> {
-  for (const credPath of geminiCredPaths(ctx)) {
-    const creds = readGeminiCreds(credPath, await readJsonFile(credPath));
+let refreshedKeychain: { fingerprint: string; creds: AntigravityOAuthCreds } | undefined;
+
+async function resolveAntigravityCreds(
+  ctx: ProviderUsageContext,
+): Promise<AntigravityOAuthCreds | null> {
+  const raw = await readKeychainPassword({
+    service: "gemini",
+    account: "antigravity",
+    platform: ctx.platform,
+  });
+  if (raw) {
+    const json = raw.startsWith("go-keyring-base64:")
+      ? decodeKeychainJson(
+          Buffer.from(raw.slice("go-keyring-base64:".length), "base64").toString("utf8"),
+        )
+      : decodeKeychainJson(raw);
+    const creds = readAntigravityCreds(null, json);
+    if (creds) {
+      const fingerprint = credentialFingerprint(creds.accessToken);
+      if (
+        refreshedKeychain?.fingerprint === fingerprint &&
+        !credsNeedRefresh(refreshedKeychain.creds, ctx.nowMs)
+      )
+        return refreshedKeychain.creds;
+      return creds;
+    }
+  }
+  for (const credPath of antigravityCredPaths(ctx)) {
+    const creds = readAntigravityCreds(credPath, await readJsonFile(credPath));
     if (creds) return creds;
   }
   return null;
@@ -110,18 +135,25 @@ function googleHeaders(accessToken: string): Record<string, string> {
   return {
     Authorization: `Bearer ${accessToken}`,
     "Content-Type": "application/json",
+    "User-Agent": `antigravity/1.104.0 ${process.platform}/${process.arch}`,
   };
 }
 
-function geminiOAuthClient(ctx: ProviderUsageContext): { clientId: string; clientSecret: string } {
+function antigravityOAuthClient(ctx: ProviderUsageContext): {
+  clientId: string;
+  clientSecret: string;
+} {
   return {
-    clientId: ctx.env.GEMINI_OAUTH_CLIENT_ID?.trim() || GEMINI_OAUTH_CLIENT_ID,
-    clientSecret: ctx.env.GEMINI_OAUTH_CLIENT_SECRET?.trim() || GEMINI_OAUTH_CLIENT_SECRET,
+    clientId: ctx.env.ANTIGRAVITY_OAUTH_CLIENT_ID?.trim() || ANTIGRAVITY_OAUTH_CLIENT_ID,
+    clientSecret:
+      ctx.env.ANTIGRAVITY_OAUTH_CLIENT_SECRET?.trim() || ANTIGRAVITY_OAUTH_CLIENT_SECRET,
   };
 }
 
 function quotaWindowLabel(modelId: string): string {
   const lower = modelId.toLowerCase();
+  if (lower.startsWith("claude")) return "Claude";
+  if (lower.startsWith("gpt-oss")) return "GPT-OSS";
   if (lower.includes("pro")) return "Pro";
   if (lower.includes("flash")) return "Flash";
   return modelId;
@@ -149,7 +181,14 @@ export function parseAntigravityQuota(input: {
 }) {
   const planName = antigravityPlanName(input.loadAssist);
   const quota = asRecord(input.quota);
-  const buckets = Array.isArray(quota?.buckets) ? quota.buckets : [];
+  const models = asRecord(quota?.models);
+  const buckets = models
+    ? Object.entries(models).flatMap(([modelId, value]) => {
+        const info = asRecord(asRecord(value)?.quotaInfo);
+        // Editor completion models are not chat quotas.
+        return info && /^(gemini|claude|gpt-oss)-/u.test(modelId) ? [{ ...info, modelId }] : [];
+      })
+    : [];
   const grouped = new Map<string, ServerProviderUsageLimit>();
   for (const bucket of buckets) {
     const record = asRecord(bucket);
@@ -194,7 +233,7 @@ export function parseAntigravityQuota(input: {
 }
 
 function applyRefreshedTokens(
-  creds: GeminiOAuthCreds,
+  creds: AntigravityOAuthCreds,
   refreshed: Extract<OAuthRefreshResult, { ok: true }>,
 ): Record<string, unknown> {
   const tokenPatch: Record<string, unknown> = {
@@ -214,12 +253,12 @@ function applyRefreshedTokens(
   return { ...creds.record, ...tokenPatch };
 }
 
-async function refreshGeminiCreds(
-  creds: GeminiOAuthCreds,
+async function refreshAntigravityCreds(
+  creds: AntigravityOAuthCreds,
   ctx: ProviderUsageContext,
-): Promise<GeminiOAuthCreds | "dead" | null> {
+): Promise<AntigravityOAuthCreds | "dead" | null> {
   if (!creds.refreshToken) return null;
-  const client = geminiOAuthClient(ctx);
+  const client = antigravityOAuthClient(ctx);
   const refreshed = await refreshOAuthAccessToken({
     service: "provider-usage-antigravity-refresh",
     refreshUrl: REFRESH_URL,
@@ -233,57 +272,39 @@ async function refreshGeminiCreds(
     return refreshed.status && refreshed.status >= 400 && refreshed.status < 500 ? "dead" : null;
   }
   const nextRecord = applyRefreshedTokens(creds, refreshed);
-  await writeJsonFileAtomic(creds.path, nextRecord);
+  if (creds.path) await writeJsonFileAtomic(creds.path, nextRecord);
   const refreshToken = refreshed.refreshToken ?? creds.refreshToken;
-  return {
+  const nextCreds = {
     ...creds,
     record: nextRecord,
     accessToken: refreshed.accessToken,
     ...(refreshToken ? { refreshToken } : {}),
     ...(refreshed.expiresAtMs !== undefined ? { expiresAtMs: refreshed.expiresAtMs } : {}),
   };
+  if (!creds.path)
+    refreshedKeychain = { fingerprint: credentialFingerprint(creds.accessToken), creds: nextCreds };
+  return nextCreds;
 }
 
-function credsNeedRefresh(creds: GeminiOAuthCreds, nowMs: number): boolean {
+function credsNeedRefresh(creds: AntigravityOAuthCreds, nowMs: number): boolean {
   return creds.expiresAtMs !== undefined && creds.expiresAtMs <= nowMs + REFRESH_BUFFER_MS;
-}
-
-function apiKeySnapshot(nowMs: number) {
-  return buildSnapshot({
-    provider: "antigravity",
-    nowMs,
-    status: "ok",
-    source: SOURCE,
-    usageLines: [
-      {
-        label: "Credits",
-        value:
-          "This Gemini API key has no Cloud Code quota window; remaining limits stay in `agy`.",
-      },
-    ],
-    planName: "API key",
-  });
 }
 
 export const antigravityUsageFetcher: ProviderUsageFetcher = {
   provider: "antigravity",
   async cacheKey(ctx) {
-    const creds = await resolveGeminiCreds(ctx);
+    const creds = await resolveAntigravityCreds(ctx);
     if (creds) return credentialFingerprint(creds.accessToken);
-    const apiKey = ctx.env.GEMINI_API_KEY?.trim();
-    return apiKey ? `api:${credentialFingerprint(apiKey)}` : `${ctx.homeDir}:none`;
+    return `${ctx.homeDir}:none`;
   },
   async fetch(ctx) {
-    let creds = await resolveGeminiCreds(ctx);
+    let creds = await resolveAntigravityCreds(ctx);
     if (!creds) {
-      if (ctx.env.GEMINI_API_KEY?.trim()) {
-        return apiKeySnapshot(ctx.nowMs);
-      }
       return needsAuthSnapshot("antigravity", ctx.nowMs, SOURCE);
     }
     if (credsNeedRefresh(creds, ctx.nowMs)) {
       try {
-        const refreshed = await refreshGeminiCreds(creds, ctx);
+        const refreshed = await refreshAntigravityCreds(creds, ctx);
         if (refreshed === "dead") {
           return needsAuthSnapshot("antigravity", ctx.nowMs, SOURCE);
         }
@@ -307,7 +328,7 @@ export const antigravityUsageFetcher: ProviderUsageFetcher = {
         headers: googleHeaders(creds.accessToken),
         body: {
           metadata: {
-            ideType: "GEMINI_CLI",
+            ideType: "ANTIGRAVITY",
             platform: "PLATFORM_UNSPECIFIED",
             pluginType: "GEMINI",
           },
@@ -340,9 +361,22 @@ export const antigravityUsageFetcher: ProviderUsageFetcher = {
           headers: googleHeaders(creds.accessToken),
           body: projectId ? { project: projectId } : {},
         });
-        if (quotaResult.ok) quotaJson = quotaResult.json;
+        if (!quotaResult.ok) {
+          return errorSnapshot(
+            "antigravity",
+            ctx.nowMs,
+            SOURCE,
+            `Antigravity quota request failed (${quotaResult.status}).`,
+          );
+        }
+        quotaJson = quotaResult.json;
       } catch {
-        quotaJson = undefined;
+        return errorSnapshot(
+          "antigravity",
+          ctx.nowMs,
+          SOURCE,
+          "Could not reach the Antigravity quota endpoint.",
+        );
       }
 
       return parseAntigravityQuota({

--- a/apps/server/src/providerUsage/providers/codex.ts
+++ b/apps/server/src/providerUsage/providers/codex.ts
@@ -368,7 +368,7 @@ export function parseCodexUsage(input: {
       return;
     }
     limits.push({
-      window: label,
+      window: windowDurationMins === 10080 ? "Weekly" : windowDurationMins === 300 ? "5h" : label,
       ...(usedPercent !== undefined ? { usedPercent } : {}),
       ...(resetsAt ? { resetsAt } : {}),
       windowDurationMins,

--- a/apps/server/src/providerUsage/providers/codexWindow.test.ts
+++ b/apps/server/src/providerUsage/providers/codexWindow.test.ts
@@ -1,0 +1,9 @@
+import { expect, it } from "vitest";
+import { parseCodexUsage } from "./codex";
+it("labels a weekly primary window by duration instead of its position", () => {
+  const result = parseCodexUsage({
+    nowMs: Date.now(),
+    json: { rate_limit: { primary_window: { used_percent: 84, limit_window_seconds: 604800 } } },
+  });
+  expect(result.limits).toEqual([{ window: "Weekly", usedPercent: 84, windowDurationMins: 10080 }]);
+});

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1,3 +1,4 @@
+import { deriveConversationUsage } from "~/lib/messageUsage";
 import {
   type AutomationDefinition,
   type AutomationSchedule,
@@ -1972,6 +1973,10 @@ export default function ChatView({
   const activeLatestTurnState = activeLatestTurn?.state ?? null;
   const activeLatestTurnCompletedAt = activeLatestTurn?.completedAt ?? null;
   const threadActivities = activeThread?.activities ?? EMPTY_ACTIVITIES;
+  const { byTurnId: usageByTurnId, cumulative: conversationUsage } = useMemo(
+    () => deriveConversationUsage(threadActivities),
+    [threadActivities],
+  );
   const hasLiveTurnTail = hasLiveTurnTailWork({
     latestTurn: activeLatestTurn,
     messages: activeThread?.messages ?? EMPTY_MESSAGES,
@@ -12088,30 +12093,19 @@ export default function ChatView({
                     <div
                       data-chat-composer-actions="right"
                       className={cn(
-                        "flex items-center gap-2",
-                        isVoiceRecording || isVoiceTranscribing ? "min-w-0 flex-1" : "shrink-0",
+                        "flex min-w-0 flex-wrap items-center justify-end gap-2",
+                        isVoiceRecording || isVoiceTranscribing ? "min-w-0 flex-1" : "min-w-0",
                       )}
                     >
                       {!isVoiceRecording &&
                       !isVoiceTranscribing &&
-                      runtimeUsageContextWindow &&
-                      composerFooterControlsPlan.showContextMeter ? (
+                      (runtimeUsageContextWindow || conversationUsage.length > 0) ? (
                         <ContextWindowMeter
+                          provider={selectedProvider}
                           usage={runtimeUsageContextWindow}
-                          {...(activeCumulativeCostUsd != null
-                            ? { cumulativeCostUsd: activeCumulativeCostUsd }
-                            : {})}
-                          {...(contextWindowSelectionStatus.activeLabel !== undefined
-                            ? {
-                                activeWindowLabel: contextWindowSelectionStatus.activeLabel,
-                              }
-                            : {})}
-                          {...(contextWindowSelectionStatus.pendingSelectedLabel !== undefined
-                            ? {
-                                pendingWindowLabel:
-                                  contextWindowSelectionStatus.pendingSelectedLabel,
-                              }
-                            : {})}
+                          sessionUsage={conversationUsage}
+                          activeWindowLabel={contextWindowSelectionStatus.activeLabel}
+                          pendingWindowLabel={contextWindowSelectionStatus.pendingSelectedLabel}
                         />
                       ) : null}
                       {!isVoiceRecording && !isVoiceTranscribing ? composerPickerControls : null}
@@ -12587,6 +12581,7 @@ export default function ChatView({
               <div className="flex min-h-0 flex-1 flex-col">
                 <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
                   <ChatTranscriptPane
+                    usageByTurnId={usageByTurnId}
                     activeThreadId={activeThread.id}
                     activeTurnId={activeTurnIdForTranscript}
                     agentActivityDetail={openAgentActivityDetail}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1973,9 +1973,10 @@ export default function ChatView({
   const activeLatestTurnState = activeLatestTurn?.state ?? null;
   const activeLatestTurnCompletedAt = activeLatestTurn?.completedAt ?? null;
   const threadActivities = activeThread?.activities ?? EMPTY_ACTIVITIES;
+  const usageMessages = activeThread?.messages ?? EMPTY_MESSAGES;
   const { byTurnId: usageByTurnId, cumulative: conversationUsage } = useMemo(
-    () => deriveConversationUsage(threadActivities),
-    [threadActivities],
+    () => deriveConversationUsage(threadActivities, usageMessages),
+    [threadActivities, usageMessages],
   );
   const hasLiveTurnTail = hasLiveTurnTailWork({
     latestTurn: activeLatestTurn,

--- a/apps/web/src/components/chat/ChatTranscriptPane.tsx
+++ b/apps/web/src/components/chat/ChatTranscriptPane.tsx
@@ -99,6 +99,7 @@ interface ChatTranscriptPaneProps {
   revertTurnCountByUserMessageId: Map<MessageId, number>;
   scrollButtonVisible: boolean;
   terminalWorkspaceTerminalTabActive: boolean;
+  usageByTurnId?: ComponentProps<typeof MessagesTimeline>["usageByTurnId"];
   timelineEntries: ComponentProps<typeof MessagesTimeline>["timelineEntries"];
   timestampFormat: TimestampFormat;
   turnDiffSummaryByAssistantMessageId: Map<MessageId, TurnDiffSummary>;
@@ -174,6 +175,7 @@ export function ChatTranscriptPane({
   revertTurnCountByUserMessageId,
   scrollButtonVisible,
   terminalWorkspaceTerminalTabActive,
+  usageByTurnId,
   timelineEntries,
   timestampFormat,
   turnDiffSummaryByAssistantMessageId,
@@ -240,6 +242,7 @@ export function ChatTranscriptPane({
           />
         ) : (
           <MessagesTimeline
+            usageByTurnId={usageByTurnId}
             key={activeThreadId}
             hasMessages={hasMessages}
             isWorking={isWorking}

--- a/apps/web/src/components/chat/ContextWindowMeter.browser.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.browser.tsx
@@ -1,0 +1,52 @@
+import "../../index.css";
+import { expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { ContextWindowMeter } from "./ContextWindowMeter";
+vi.mock("@tanstack/react-query", async (load) => ({
+  ...(await load<object>()),
+  useQuery: () => ({
+    isPending: false,
+    data: [{ provider: "claudeAgent", updatedAt: "2026-09-06T00:00:00Z" }],
+  }),
+}));
+vi.mock("../ProviderUsageMenuControl", () => ({
+  useProviderUsageMenuModel: () => ({
+    rows: [
+      {
+        id: "5h",
+        label: "5h",
+        remainingPercent: 72,
+        remainingLabel: "72%",
+        remainingTone: "healthy",
+        resetText: "Resets in 2h",
+      },
+      {
+        id: "week",
+        label: "Weekly",
+        remainingPercent: 18,
+        remainingLabel: "18%",
+        remainingTone: "warning",
+        resetText: "Resets in 3d",
+      },
+    ],
+  }),
+}));
+it("shows account limit bars beside session usage inside the context popover", async () => {
+  const screen = await render(
+    <ContextWindowMeter
+      provider="claudeAgent"
+      usage={null}
+      sessionUsage={[{ label: "↑", value: "45k", detail: "Session input" }]}
+    />,
+  );
+  await screen
+    .getByRole("button", { name: "Context window and session usage", exact: true })
+    .click();
+  await expect.element(screen.getByText("5h limit", { exact: true })).toBeVisible();
+  await expect.element(screen.getByText("Weekly limit", { exact: true })).toBeVisible();
+  await expect.element(screen.getByText("72% left", { exact: true })).toBeVisible();
+  await expect.element(screen.getByText("Session usage", { exact: true })).toBeVisible();
+  await expect
+    .element(screen.getByRole("meter", { name: "Weekly remaining", exact: true }))
+    .toHaveAttribute("aria-valuenow", "18");
+});

--- a/apps/web/src/components/chat/ContextWindowMeter.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.tsx
@@ -1,3 +1,6 @@
+import type { ProviderKind } from "@synara/contracts";
+import { ProviderQuotaSummary } from "./ProviderQuotaSummary";
+import type { MessageUsageMetric } from "~/lib/messageUsage";
 import {
   type ContextWindowSnapshot,
   deriveContextWindowMeterDisplay,
@@ -7,16 +10,18 @@ import {
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 
 export function ContextWindowMeter(props: {
-  usage: ContextWindowSnapshot;
+  usage: ContextWindowSnapshot | null;
+  provider?: ProviderKind;
+  sessionUsage?: readonly MessageUsageMetric[];
   cumulativeCostUsd?: number | null | undefined;
   activeWindowLabel?: string | null | undefined;
   pendingWindowLabel?: string | null | undefined;
 }) {
   const { usage, cumulativeCostUsd, activeWindowLabel, pendingWindowLabel } = props;
-  const display = deriveContextWindowMeterDisplay(usage);
+  const display = usage ? deriveContextWindowMeterDisplay(usage) : null;
   const radius = 6;
   const circumference = 2 * Math.PI * radius;
-  const dashOffset = circumference - (display.normalizedPercentage / 100) * circumference;
+  const dashOffset = circumference - ((display?.normalizedPercentage ?? 0) / 100) * circumference;
 
   return (
     <Popover>
@@ -28,7 +33,7 @@ export function ContextWindowMeter(props: {
           <button
             type="button"
             className="group inline-flex shrink-0 items-center justify-center rounded-full p-0.5 transition-opacity hover:opacity-80"
-            aria-label={display.ariaLabel}
+            aria-label={display?.ariaLabel ?? "Context window and session usage"}
           >
             <span className="relative flex h-4 w-4 items-center justify-center">
               <svg
@@ -62,58 +67,88 @@ export function ContextWindowMeter(props: {
           </button>
         }
       />
-      <PopoverPopup tooltipStyle side="top" align="end" className="w-max max-w-none px-3 py-2">
+      <PopoverPopup
+        tooltipStyle
+        side="top"
+        align="end"
+        className="w-80 max-w-[calc(100vw-2rem)] px-4 py-3"
+      >
         <div className="space-y-1.5 leading-tight">
           <div className="text-[11px] font-medium text-muted-foreground">Context window</div>
-          {pendingWindowLabel ? (
-            <div className="text-xs text-muted-foreground">
-              Current session: {activeWindowLabel ?? "Unknown"}
-            </div>
-          ) : null}
-          {display.usedPercentageLabel ? (
-            <div className="whitespace-nowrap text-xs font-medium text-foreground">
-              <span>{display.usedPercentageLabel}</span>
-              {display.hasReliableTokenRatio ? (
-                <>
-                  <span className="mx-1">⋅</span>
-                  <span>{display.tokenUsageLabel}</span>
-                  <span>/</span>
-                  <span>{formatContextWindowTokens(usage.maxTokens)} context used</span>
-                </>
+          {usage && display ? (
+            <>
+              {pendingWindowLabel ? (
+                <div className="text-xs text-muted-foreground">
+                  Current session: {activeWindowLabel ?? "Unknown"}
+                </div>
+              ) : null}
+              {display.usedPercentageLabel ? (
+                <div className="whitespace-nowrap text-xs font-medium text-foreground">
+                  <span>{display.usedPercentageLabel}</span>
+                  {display.hasReliableTokenRatio ? (
+                    <>
+                      <span className="mx-1">⋅</span>
+                      <span>{display.tokenUsageLabel}</span>
+                      <span>/</span>
+                      <span>{formatContextWindowTokens(usage.maxTokens)} context used</span>
+                    </>
+                  ) : (
+                    <span className="ml-1">context used</span>
+                  )}
+                </div>
               ) : (
-                <span className="ml-1">context used</span>
+                <div className="text-sm text-foreground">
+                  {display.tokenUsageLabel} tokens used so far
+                </div>
               )}
-            </div>
+              {usage.maxTokens !== null ? (
+                <div className="text-xs text-muted-foreground">
+                  Model window: {formatContextWindowTokens(usage.maxTokens)} tokens
+                </div>
+              ) : null}
+              {pendingWindowLabel ? (
+                <div className="text-xs text-muted-foreground">Next turn: {pendingWindowLabel}</div>
+              ) : null}
+              {(usage.totalProcessedTokens ?? null) !== null &&
+              (usage.totalProcessedTokens ?? 0) > usage.usedTokens ? (
+                <div className="text-xs text-muted-foreground">
+                  Total processed: {formatContextWindowTokens(usage.totalProcessedTokens ?? null)}{" "}
+                  tokens
+                </div>
+              ) : null}
+              {usage.compactsAutomatically ? (
+                <div className="text-xs text-muted-foreground">
+                  Automatically compacts its context when needed.
+                </div>
+              ) : null}
+            </>
           ) : (
-            <div className="text-sm text-foreground">
-              {display.tokenUsageLabel} tokens used so far
-            </div>
+            <div className="text-xs text-muted-foreground">Context usage unavailable</div>
           )}
-          {usage.maxTokens !== null ? (
-            <div className="text-xs text-muted-foreground">
-              Model window: {formatContextWindowTokens(usage.maxTokens)} tokens
-            </div>
-          ) : null}
-          {pendingWindowLabel ? (
-            <div className="text-xs text-muted-foreground">Next turn: {pendingWindowLabel}</div>
-          ) : null}
-          {(usage.totalProcessedTokens ?? null) !== null &&
-          (usage.totalProcessedTokens ?? 0) > usage.usedTokens ? (
-            <div className="text-xs text-muted-foreground">
-              Total processed: {formatContextWindowTokens(usage.totalProcessedTokens ?? null)}{" "}
-              tokens
-            </div>
-          ) : null}
-          {usage.compactsAutomatically ? (
-            <div className="text-xs text-muted-foreground">
-              Automatically compacts its context when needed.
-            </div>
-          ) : null}
           {cumulativeCostUsd !== null && cumulativeCostUsd !== undefined ? (
             <div className="text-xs text-muted-foreground">
               Session cost: {formatCostUsd(cumulativeCostUsd)}
             </div>
           ) : null}
+          {props.sessionUsage && props.sessionUsage.length > 0 ? (
+            <div className="mt-2 space-y-1.5 border-t border-border/50 pt-2">
+              <div className="text-[11px] font-medium text-muted-foreground">Session usage</div>
+              <div className="flex flex-wrap gap-x-1.5 gap-y-1 text-xs tabular-nums">
+                {props.sessionUsage.map((metric, index) => (
+                  <span key={metric.label} className="whitespace-nowrap" title={metric.detail}>
+                    {index > 0 ? (
+                      <span aria-hidden="true" className="mr-1.5 text-muted-foreground/50">
+                        ·
+                      </span>
+                    ) : null}
+                    <span className="text-muted-foreground">{metric.label}</span>{" "}
+                    <span className="font-medium">{metric.value}</span>
+                  </span>
+                ))}
+              </div>
+            </div>
+          ) : null}
+          {props.provider ? <ProviderQuotaSummary provider={props.provider} /> : null}
         </div>
       </PopoverPopup>
     </Popover>

--- a/apps/web/src/components/chat/MessageUsage.browser.tsx
+++ b/apps/web/src/components/chat/MessageUsage.browser.tsx
@@ -1,0 +1,108 @@
+import "../../index.css";
+
+import { EventId, MessageId, TurnId, type OrchestrationThreadActivity } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+import { deriveMessageUsageByTurnId } from "~/lib/messageUsage";
+import { MessageUsage } from "./MessageUsage";
+import { MessagesTimeline } from "./MessagesTimeline";
+import type { TimelineEntry } from "../../session-logic";
+
+const turnId = TurnId.makeUnsafe("usage-turn");
+const assistant: TimelineEntry = {
+  id: "reply",
+  kind: "message",
+  createdAt: "2026-09-05T00:00:00.000Z",
+  message: {
+    id: MessageId.makeUnsafe("reply"),
+    role: "assistant",
+    text: "The changes are ready for testing.",
+    turnId,
+    createdAt: "2026-09-05T00:00:00.000Z",
+    streaming: false,
+  },
+};
+function fixture(outputTokens: number): OrchestrationThreadActivity[] {
+  return [
+    {
+      id: EventId.makeUnsafe("usage"),
+      tone: "info",
+      kind: "context-window.updated",
+      summary: "Usage",
+      turnId,
+      createdAt: "2026-09-05T00:00:01.000Z",
+      payload: {
+        provider: "codex",
+        usedTokens: 100_000,
+        maxTokens: 256_000,
+        inputTokens: 90_000,
+        outputTokens,
+        cachedInputTokens: 81_000,
+        reasoningOutputTokens: 300,
+        compactsAutomatically: true,
+      },
+    },
+  ];
+}
+function Timeline({ output, live = false }: { output: number; live?: boolean }) {
+  return (
+    <div style={{ width: 360, height: 600 }}>
+      <MessagesTimeline
+        hasMessages
+        isWorking={live}
+        activeTurnInProgress={live}
+        activeTurnStartedAt={live ? "2026-09-05T00:00:00.000Z" : null}
+        activeTurnId={live ? turnId : null}
+        timelineEntries={[assistant]}
+        usageByTurnId={deriveMessageUsageByTurnId(fixture(output))}
+        turnDiffSummaryByAssistantMessageId={new Map()}
+        onOpenTurnDiff={() => {}}
+        revertTurnCountByUserMessageId={new Map()}
+        onRevertUserMessage={() => {}}
+        isRevertingCheckpoint={false}
+        onImageExpand={() => {}}
+        markdownCwd={undefined}
+        resolvedTheme="dark"
+        timestampFormat="locale"
+        workspaceRoot={undefined}
+      />
+    </div>
+  );
+}
+
+describe("message usage footer", () => {
+  it("renders in the timeline, updates when only usage changes and opens details", async () => {
+    const screen = await render(<Timeline output={1000} />);
+    const button = screen.getByRole("button", { name: "Message usage details" });
+    await expect.element(button).toBeVisible();
+    await expect.element(button).toHaveTextContent("1k");
+    await screen.rerender(<Timeline output={2000} />);
+    await expect.element(button).toHaveTextContent("2k");
+    await button.click();
+    await expect.element(screen.getByText("Turn usage")).toBeVisible();
+    const element = document.querySelector('[aria-label="Message usage details"]')!;
+    expect(element.scrollWidth).toBeLessThanOrEqual(element.clientWidth);
+  });
+  it("uses the same compact notation for conversation totals at narrow widths", async () => {
+    const metrics = deriveMessageUsageByTurnId(fixture(1000)).get(turnId)!;
+    const screen = await render(
+      <div style={{ width: 280 }}>
+        <MessageUsage scope="conversation" metrics={metrics} />
+      </div>,
+    );
+    const button = screen.getByRole("button", { name: "Conversation usage details" });
+    await expect
+      .element(button)
+      .toHaveTextContent(/↑\s*90k\s*·\s*↓\s*1k\s*·\s*R\s*81k\s*·\s*W\s*—\s*·\s*CH\s*90\.0%/);
+    await button.click();
+    await expect.element(screen.getByText("Conversation usage", { exact: true })).toBeVisible();
+    const element = document.querySelector('[aria-label="Conversation usage details"]')!;
+    expect(element.scrollWidth).toBeLessThanOrEqual(element.clientWidth);
+  });
+  it("does not show the footer during an active turn", async () => {
+    const screen = await render(<Timeline output={1000} live />);
+    await expect
+      .element(screen.getByRole("button", { name: "Message usage details" }))
+      .not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/chat/MessageUsage.browser.tsx
+++ b/apps/web/src/components/chat/MessageUsage.browser.tsx
@@ -3,7 +3,7 @@ import "../../index.css";
 import { EventId, MessageId, TurnId, type OrchestrationThreadActivity } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 import { render } from "vitest-browser-react";
-import { deriveMessageUsageByTurnId } from "~/lib/messageUsage";
+import { deriveConversationUsage, deriveMessageUsageByTurnId } from "~/lib/messageUsage";
 import { MessageUsage } from "./MessageUsage";
 import { MessagesTimeline } from "./MessagesTimeline";
 import type { TimelineEntry } from "../../session-logic";
@@ -105,4 +105,38 @@ describe("message usage footer", () => {
       .element(screen.getByRole("button", { name: "Message usage details" }))
       .not.toBeInTheDocument();
   });
+});
+
+it("shows turn TPS with units and its wall-time explanation at narrow widths", async () => {
+  const usage = deriveConversationUsage(
+    [
+      {
+        ...fixture(1000)[0]!,
+        kind: "turn.completed",
+        payload: {
+          provider: "antigravity",
+          usage: { inputTokens: 2000, outputTokens: 25 },
+        },
+      },
+    ],
+    [
+      { role: "user", createdAt: "2026-09-05T00:00:00.000Z" },
+      { role: "assistant", turnId, createdAt: "2026-09-05T00:00:00.500Z" },
+    ],
+  );
+  const screen = await render(
+    <div style={{ width: 280 }}>
+      <MessageUsage metrics={usage.byTurnId.get(turnId)!} />
+    </div>,
+  );
+  const button = screen.getByRole("button", { name: "Message usage details" });
+  await expect.element(button).toHaveTextContent(/TPS\s*25\.0 tok\/s/);
+  const element = document.querySelector('[aria-label="Message usage details"]')!;
+  expect(element.scrollWidth).toBeLessThanOrEqual(element.clientWidth);
+  await button.click();
+  await expect
+    .element(
+      screen.getByText("TPS = output ÷ turn wall time, including thinking, tools and waiting."),
+    )
+    .toBeVisible();
 });

--- a/apps/web/src/components/chat/MessageUsage.browser.tsx
+++ b/apps/web/src/components/chat/MessageUsage.browser.tsx
@@ -107,9 +107,16 @@ describe("message usage footer", () => {
   });
 });
 
-it("shows turn TPS with units and its wall-time explanation at narrow widths", async () => {
+it("shows TPS and thinking-aware TTFT with units at narrow widths", async () => {
   const usage = deriveConversationUsage(
     [
+      {
+        ...fixture(1000)[0]!,
+        id: EventId.makeUnsafe("first-output"),
+        kind: "provider.first-output",
+        createdAt: "2026-09-05T00:00:00.250Z",
+        payload: { streamKind: "reasoning_text" },
+      },
       {
         ...fixture(1000)[0]!,
         kind: "turn.completed",
@@ -130,7 +137,7 @@ it("shows turn TPS with units and its wall-time explanation at narrow widths", a
     </div>,
   );
   const button = screen.getByRole("button", { name: "Message usage details" });
-  await expect.element(button).toHaveTextContent(/TPS\s*25\.0 tok\/s/);
+  await expect.element(button).toHaveTextContent(/TPS\s*25\.0 tok\/s.*TTFT\s*0\.3 s/);
   const element = document.querySelector('[aria-label="Message usage details"]')!;
   expect(element.scrollWidth).toBeLessThanOrEqual(element.clientWidth);
   await button.click();

--- a/apps/web/src/components/chat/MessageUsage.tsx
+++ b/apps/web/src/components/chat/MessageUsage.tsx
@@ -8,6 +8,7 @@ const names: Record<string, string> = {
   R: "Cache read",
   W: "Cache write",
   CH: "Cache hit",
+  TPS: "Average output speed",
 };
 
 export function MessageUsage({
@@ -88,6 +89,9 @@ export function MessageUsage({
         <div className="space-y-1.5 border-t border-border/50 bg-muted/20 px-4 py-3 text-[11px] leading-relaxed text-muted-foreground">
           <p>Input includes cache reads and writes. Cache hit = reads ÷ input.</p>
           <p>— means the provider did not report this metric.</p>
+          {metrics.some((metric) => metric.label === "TPS") ? (
+            <p>TPS = output ÷ turn wall time, including thinking, tools and waiting.</p>
+          ) : null}
           {context ? (
             <p>
               Context: {context.usedTokens.toLocaleString("en-US")} tokens

--- a/apps/web/src/components/chat/MessageUsage.tsx
+++ b/apps/web/src/components/chat/MessageUsage.tsx
@@ -9,6 +9,7 @@ const names: Record<string, string> = {
   W: "Cache write",
   CH: "Cache hit",
   TPS: "Average output speed",
+  TTFT: "Time to first token",
 };
 
 export function MessageUsage({

--- a/apps/web/src/components/chat/MessageUsage.tsx
+++ b/apps/web/src/components/chat/MessageUsage.tsx
@@ -1,0 +1,104 @@
+import type { MessageUsageMetric } from "~/lib/messageUsage";
+import type { ContextWindowSnapshot } from "~/lib/contextWindow";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
+
+const names: Record<string, string> = {
+  "↑": "Input",
+  "↓": "Output",
+  R: "Cache read",
+  W: "Cache write",
+  CH: "Cache hit",
+};
+
+export function MessageUsage({
+  metrics,
+  scope = "turn",
+  context,
+}: {
+  metrics: readonly MessageUsageMetric[];
+  scope?: "turn" | "conversation";
+  context?: ContextWindowSnapshot | null;
+}) {
+  if (metrics.length === 0) return null;
+  const conversation = scope === "conversation";
+  const partial = metrics.some((metric) => /only;|some historical/.test(metric.detail));
+  return (
+    <Popover>
+      <PopoverTrigger
+        openOnHover
+        delay={150}
+        render={
+          <button
+            type="button"
+            aria-label={conversation ? "Conversation usage details" : "Message usage details"}
+            className={`${conversation ? "rounded-md border border-border/40 bg-muted/20 px-2 py-1" : "mt-2 rounded-md px-1 py-0.5"} flex max-w-full flex-wrap items-center gap-x-1.5 gap-y-1 text-left font-system-ui text-[11px] leading-5 tabular-nums text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground focus-visible:outline-2 focus-visible:outline-ring`}
+          >
+            {metrics.map((metric, index) => (
+              <span
+                key={metric.label}
+                className="inline-flex items-baseline gap-1 whitespace-nowrap"
+              >
+                {index > 0 ? (
+                  <span aria-hidden="true" className="mr-1 text-muted-foreground/35">
+                    ·
+                  </span>
+                ) : null}
+                <span className="text-[10px] text-muted-foreground/60">{metric.label}</span>
+                <span className={metric.value === "—" ? "text-muted-foreground/40" : "font-medium"}>
+                  {metric.value}
+                </span>
+              </span>
+            ))}
+          </button>
+        }
+      />
+      <PopoverPopup
+        tooltipStyle
+        side="top"
+        align={conversation ? "end" : "start"}
+        className="w-72 max-w-[calc(100vw-2rem)] p-0 [&_[data-slot=popover-viewport]]:max-h-[min(28rem,calc(var(--available-height)-2rem))] [&_[data-slot=popover-viewport]]:overflow-y-auto"
+      >
+        <div className="border-b border-border/50 px-4 py-3">
+          <p className="text-xs font-medium">
+            {conversation ? "Conversation usage" : "Turn usage"}
+          </p>
+          <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+            {partial
+              ? "Some historical request totals were not saved."
+              : conversation
+                ? "All recorded model requests in this conversation."
+                : "All model requests in this turn, including tools and subagents."}
+          </p>
+        </div>
+        <dl className="space-y-2 px-4 py-3 text-xs">
+          {metrics.map((metric) => (
+            <div
+              key={metric.label}
+              className="flex items-baseline justify-between gap-4"
+              title={metric.detail}
+            >
+              <dt className="text-muted-foreground">{names[metric.label] ?? metric.label}</dt>
+              <dd className="font-medium tabular-nums">
+                {metric.exactValue ?? metric.value}
+                <span className="sr-only"> — {metric.detail}</span>
+              </dd>
+            </div>
+          ))}
+        </dl>
+        <div className="space-y-1.5 border-t border-border/50 bg-muted/20 px-4 py-3 text-[11px] leading-relaxed text-muted-foreground">
+          <p>Input includes cache reads and writes. Cache hit = reads ÷ input.</p>
+          <p>— means the provider did not report this metric.</p>
+          {context ? (
+            <p>
+              Context: {context.usedTokens.toLocaleString("en-US")} tokens
+              {context.maxTokens != null
+                ? ` · Capacity: ${context.maxTokens.toLocaleString("en-US")}`
+                : ""}
+              {context.compactsAutomatically ? " · Auto compaction" : ""}
+            </p>
+          ) : null}
+        </div>
+      </PopoverPopup>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -82,6 +82,8 @@ import { InlineSlashCommandChip } from "./InlineSlashCommandChip";
 import { InlineAgentChip } from "./InlineAgentChip";
 import { EditedFileRow } from "./EditedFileRow";
 import { MessageActionButton, MESSAGE_ACTION_ICON_CLASS_NAME } from "./MessageActionButton";
+import type { MessageUsageMetric } from "~/lib/messageUsage";
+import { MessageUsage } from "./MessageUsage";
 import { MessageCopyButton } from "./MessageCopyButton";
 import { AssistantSelectionsSummaryChip } from "./AssistantSelectionsSummaryChip";
 import { FileAttachmentChip } from "./FileAttachmentChip";
@@ -469,6 +471,7 @@ interface MessagesTimelineProps {
   forkSource?: ForkSourceReference | null;
   /** Marks the transcript as a temporary chat so user bubbles render the dashed primary outline. */
   isTemporaryThread?: boolean;
+  usageByTurnId?: ReadonlyMap<TurnId, readonly MessageUsageMetric[]> | undefined;
   timelineEntries: ReturnType<typeof deriveTimelineEntries>;
   turnDiffSummaryByAssistantMessageId: Map<MessageId, TurnDiffSummary>;
   nowIso?: string;
@@ -559,6 +562,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   forkSource: forkSourceProp,
   isTemporaryThread: isTemporaryThreadProp,
   timelineEntries,
+  usageByTurnId,
   turnDiffSummaryByAssistantMessageId,
   nowIso,
   expandedWorkGroups,
@@ -946,6 +950,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       submittingEditedUserMessageId,
       threadMarkersByMessageId,
       toolGroupSummaryOverrides,
+      usageByTurnId,
     }),
     [
       crossTaskOrigin,
@@ -965,6 +970,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       submittingEditedUserMessageId,
       threadMarkersByMessageId,
       toolGroupSummaryOverrides,
+      usageByTurnId,
     ],
   );
   // Latest rows kept in a ref so the imperative scroll controller can look up a message's
@@ -1947,6 +1953,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
           // signal (see deriveTerminalAssistantMessageIds).
           const isTerminalAssistantMessage =
             row.showAssistantCopyButton && !row.assistantTurnInProgress;
+          const messageUsage =
+            isTerminalAssistantMessage && row.message.turnId
+              ? usageByTurnId?.get(row.message.turnId)
+              : undefined;
           const goalAchievement =
             isTerminalAssistantMessage && row.message.turnId
               ? (goalAchievementByTurnId.get(row.message.turnId) ?? null)
@@ -2555,6 +2565,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                     ) : null}
                   </div>
                 )}
+                {messageUsage ? <MessageUsage metrics={messageUsage} /> : null}
               </div>
             </>
           );

--- a/apps/web/src/components/chat/ProviderQuotaSummary.tsx
+++ b/apps/web/src/components/chat/ProviderQuotaSummary.tsx
@@ -1,0 +1,62 @@
+import { PROVIDER_DISPLAY_NAMES, type ProviderKind } from "@synara/contracts";
+import { useQuery } from "@tanstack/react-query";
+import { serverAllProviderUsageQueryOptions } from "~/lib/serverReactQuery";
+import { providerUsageToneClassName } from "~/lib/providerUsageDisplay";
+import { useProviderUsageMenuModel } from "../ProviderUsageMenuControl";
+
+export function ProviderQuotaSummary({ provider }: { provider: ProviderKind }) {
+  const query = useQuery(serverAllProviderUsageQueryOptions());
+  const snapshot = query.data?.find((entry) => entry.provider === provider);
+  const model = useProviderUsageMenuModel(provider, { providerSnapshot: snapshot });
+  return (
+    <section className="mt-3 space-y-3 border-t border-border/50 pt-3" aria-label="Account limits">
+      <div className="flex items-center justify-between gap-3 text-[11px]">
+        <span className="font-medium text-muted-foreground">Account limits</span>
+        <span className="font-medium text-foreground">{PROVIDER_DISPLAY_NAMES[provider]}</span>
+      </div>
+      {model.rows.map((row) => (
+        <div key={row.id} className="space-y-1.5">
+          <div className="flex items-baseline justify-between gap-4 text-xs">
+            <span className="text-muted-foreground">{row.label} limit</span>
+            <span className="font-medium tabular-nums">{row.remainingLabel} left</span>
+          </div>
+          <div
+            role="meter"
+            aria-label={`${row.label} remaining`}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={row.remainingPercent}
+            className="h-1.5 overflow-hidden rounded-full bg-muted/70"
+          >
+            <div
+              className={`h-full rounded-full ${providerUsageToneClassName(row.remainingTone)}`}
+              style={{ width: `${row.remainingPercent}%` }}
+            />
+          </div>
+          {row.resetText ? (
+            <div className="text-right text-[10px] text-muted-foreground">{row.resetText}</div>
+          ) : null}
+        </div>
+      ))}
+      {!model.rows.length ? (
+        <div className="text-xs leading-relaxed text-muted-foreground">
+          {query.isPending || model.isLoading
+            ? "Checking account limits…"
+            : (model.emptyMessage ?? snapshot?.detail ?? "Account limits could not be retrieved.")}
+        </div>
+      ) : null}
+      <div className="flex justify-between gap-3 text-[10px] text-muted-foreground/80">
+        <span>Shared across conversations</span>
+        {snapshot?.updatedAt ? (
+          <span title={new Date(snapshot.updatedAt).toLocaleString()}>
+            {snapshot.stale ? "Last known · " : "Updated · "}
+            {new Date(snapshot.updatedAt).toLocaleTimeString([], {
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
+          </span>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/hooks/useProviderUsageSummary.test.tsx
+++ b/apps/web/src/hooks/useProviderUsageSummary.test.tsx
@@ -11,7 +11,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { ProviderRateLimit } from "~/lib/rateLimits";
 import { openUsageProviderSnapshotQueryOptions } from "~/lib/openUsageReactQuery";
 import { serverQueryKeys } from "~/lib/serverReactQuery";
-import { useProviderUsageSummary } from "./useProviderUsageSummary";
+import { resolveProviderUsageSummary, useProviderUsageSummary } from "./useProviderUsageSummary";
 
 vi.mock("~/lib/openUsageReactQuery", async (importOriginal) => {
   const actual = await importOriginal<typeof import("~/lib/openUsageReactQuery")>();
@@ -94,6 +94,54 @@ function createQueryClient() {
 }
 
 describe("useProviderUsageSummary", () => {
+  it("keeps the live weekly-only account at 15% left despite newer historical 100% windows", () => {
+    const live = snapshot({
+      provider: "codex",
+      status: "ok",
+      limits: [{ window: "Weekly", usedPercent: 85, windowDurationMins: 10080 }],
+    });
+    const historical = {
+      provider: "codex" as const,
+      updatedAt: "2099-01-01T00:00:00Z",
+      limits: [
+        { window: "5h", usedPercent: 0 },
+        { window: "Weekly", usedPercent: 0 },
+      ],
+    };
+    const summary = resolveProviderUsageSummary({
+      provider: "codex",
+      authoritativeLiveSnapshot: live,
+      accountRateLimits: [historical],
+      localUsageSnapshot: snapshot({ ...historical }),
+    });
+    expect(summary.rateLimits).toHaveLength(1);
+    expect(summary.rateLimits[0]?.limits).toEqual(live.limits);
+  });
+
+  it("does not manufacture windows when a live account has none", () => {
+    const summary = resolveProviderUsageSummary({
+      provider: "codex",
+      authoritativeLiveSnapshot: snapshot({ provider: "codex", status: "ok" }),
+      accountRateLimits: [
+        {
+          provider: "codex",
+          updatedAt: "2099-01-01T00:00:00Z",
+          limits: [{ window: "5h", usedPercent: 0 }],
+        },
+      ],
+    });
+    expect(summary.rateLimits).toEqual([]);
+  });
+
+  it("prefers the explicit surface snapshot over an existing query cache entry", () => {
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(serverQueryKeys.allProviderUsage(), [
+      snapshot({ limits: [{ window: "5h", usedPercent: 0 }] }),
+    ]);
+    const live = snapshot({ status: "ok", limits: [{ window: "Weekly", usedPercent: 85 }] });
+    const summary = readProviderUsageSummary({ queryClient, providerSnapshot: live });
+    expect(summary.rateLimits[0]?.limits).toEqual(live.limits);
+  });
   it("can keep OpenUsage polling disabled while using the server batch query", () => {
     const queryClient = createQueryClient();
 

--- a/apps/web/src/hooks/useProviderUsageSummary.ts
+++ b/apps/web/src/hooks/useProviderUsageSummary.ts
@@ -62,16 +62,23 @@ export function resolveProviderUsageSummary(input: {
   const liveUsageRateLimit = normalizeServerProviderUsageRateLimit(input.authoritativeLiveSnapshot);
   const localUsageRateLimit = normalizeServerProviderUsageRateLimit(input.localUsageSnapshot);
   const openUsageRateLimit = normalizeOpenUsageSnapshot(input.openUsageSnapshot, input.provider);
-  const rateLimits = mergeProviderRateLimits(
-    derivedRateLimits,
-    mergeProviderRateLimits(
-      liveUsageRateLimit ? [liveUsageRateLimit] : [],
-      mergeProviderRateLimits(
-        localUsageRateLimit ? [localUsageRateLimit] : [],
-        openUsageRateLimit ? [openUsageRateLimit] : [],
-      ),
-    ),
-  );
+  // A live account response owns the complete window set. Thread/archive events
+  // may belong to an old account or carry replay timestamps; never merge them
+  // into an authoritative snapshot, even when they appear newer.
+  const rateLimits = input.authoritativeLiveSnapshot
+    ? liveUsageRateLimit
+      ? [liveUsageRateLimit]
+      : []
+    : mergeProviderRateLimits(
+        derivedRateLimits,
+        mergeProviderRateLimits(
+          liveUsageRateLimit ? [liveUsageRateLimit] : [],
+          mergeProviderRateLimits(
+            localUsageRateLimit ? [localUsageRateLimit] : [],
+            openUsageRateLimit ? [openUsageRateLimit] : [],
+          ),
+        ),
+      );
 
   const liveUsageLines = normalizeServerProviderUsageLines(input.authoritativeLiveSnapshot);
   const localUsageLines = normalizeServerProviderUsageLines(input.localUsageSnapshot);
@@ -123,7 +130,7 @@ export function useProviderUsageSummary(input: {
   const liveProviderSnapshot = (allProviderUsageQuery.data ?? []).find(
     (snapshot) => snapshot.provider === provider,
   );
-  const authoritativeLiveSnapshot = liveProviderSnapshot ?? input.providerSnapshot ?? null;
+  const authoritativeLiveSnapshot = input.providerSnapshot ?? liveProviderSnapshot ?? null;
   const accountRateLimits = input.threadRateLimits ?? deriveAccountRateLimits(input.threads ?? []);
   const summary = resolveProviderUsageSummary({
     provider,

--- a/apps/web/src/lib/contextWindow.ts
+++ b/apps/web/src/lib/contextWindow.ts
@@ -21,7 +21,10 @@ function asContextWindowPercent(value: unknown): number | null {
 }
 
 type NullableContextWindowUsage = {
-  readonly [Key in keyof ThreadTokenUsageSnapshot]: undefined extends ThreadTokenUsageSnapshot[Key]
+  readonly [Key in keyof Omit<
+    ThreadTokenUsageSnapshot,
+    "cumulativeUsage"
+  >]: undefined extends ThreadTokenUsageSnapshot[Key]
     ? Exclude<ThreadTokenUsageSnapshot[Key], undefined> | null
     : ThreadTokenUsageSnapshot[Key];
 };

--- a/apps/web/src/lib/messageUsage.test.ts
+++ b/apps/web/src/lib/messageUsage.test.ts
@@ -1,0 +1,166 @@
+import { EventId, TurnId, type OrchestrationThreadActivity } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+import { deriveConversationUsage, deriveMessageUsageByTurnId } from "./messageUsage";
+const turn = TurnId.makeUnsafe("one");
+function event(
+  kind: string,
+  payload: OrchestrationThreadActivity["payload"],
+  turnId: TurnId | null = turn,
+): OrchestrationThreadActivity {
+  return {
+    id: EventId.makeUnsafe(`${kind}-${turnId}`),
+    kind,
+    payload,
+    turnId,
+    tone: "info",
+    summary: kind,
+    createdAt: "2026-09-05T00:00:00.000Z",
+  };
+}
+const codex = (input: number, output: number, read: number, turnId = turn, session = "c1") =>
+  event(
+    "context-window.updated",
+    {
+      provider: "codex",
+      usageSessionId: session,
+      usedTokens: 100,
+      inputTokens: 80,
+      outputTokens: 20,
+      cachedInputTokens: 0,
+      cumulativeUsage: { inputTokens: input, outputTokens: output, cachedInputTokens: read },
+    },
+    turnId,
+  );
+const values = (list: readonly { label: string; value: string }[]) =>
+  Object.fromEntries(list.map((metric) => [metric.label, metric.value]));
+const metrics = (events: OrchestrationThreadActivity[]) =>
+  deriveMessageUsageByTurnId(events).get(turn) ?? [];
+
+describe("turn and conversation usage", () => {
+  it("uses Codex cumulative differences across tool requests, not the latest request", () => {
+    const other = TurnId.makeUnsafe("two");
+    const events = [
+      codex(1000, 20, 0),
+      codex(3000, 60, 1800),
+      codex(3000, 60, 1800),
+      codex(7000, 100, 5400, other),
+    ];
+    const usage = deriveConversationUsage(events);
+    expect(values(usage.byTurnId.get(turn)!)).toEqual({
+      "↑": "3k",
+      "↓": "60",
+      R: "1.8k",
+      W: "—",
+      CH: "60.0%",
+    });
+    expect(values(usage.byTurnId.get(other)!)).toEqual({
+      "↑": "4k",
+      "↓": "40",
+      R: "3.6k",
+      W: "—",
+      CH: "90.0%",
+    });
+    expect(values(usage.cumulative)).toEqual({
+      "↑": "7k",
+      "↓": "100",
+      R: "5.4k",
+      W: "—",
+      CH: "77.1%",
+    });
+    expect(deriveConversationUsage(JSON.parse(JSON.stringify(events)))).toEqual(usage);
+  });
+  it("handles process counter resets and new provider sessions without negative usage", () => {
+    const two = TurnId.makeUnsafe("two"),
+      three = TurnId.makeUnsafe("three");
+    const usage = deriveConversationUsage([
+      codex(3000, 60, 1000),
+      codex(1000, 20, 0, two),
+      codex(5000, 100, 2000, three, "c2"),
+    ]);
+    expect(values(usage.byTurnId.get(two)!)["↑"]).toBe("1k");
+    expect(values(usage.byTurnId.get(three)!)["↑"]).toBe("5k");
+    expect(values(usage.cumulative)["↑"]).toBe("9k");
+  });
+  it("reports Claude input including reads/writes and weights the conversation cache ratio", () => {
+    const completion = (input: number, read: number, write: number, id = turn) =>
+      event(
+        "turn.completed",
+        {
+          modelUsage: {
+            primary: {
+              inputTokens: input,
+              outputTokens: 59,
+              cacheReadInputTokens: read,
+              cacheCreationInputTokens: write,
+            },
+          },
+        },
+        id,
+      );
+    const usage = deriveConversationUsage([
+      completion(38164, 0, 38162),
+      completion(40000, 38000, 0, TurnId.makeUnsafe("two")),
+    ]);
+    expect(values(usage.byTurnId.get(turn)!)).toEqual({
+      "↑": "38k",
+      "↓": "59",
+      R: "0",
+      W: "38k",
+      CH: "0.0%",
+    });
+    expect(values(usage.cumulative).CH).toBe("48.6%");
+    expect(values(usage.cumulative).W).toBe("38k");
+  });
+  it("does not combine incomplete model cache counters with unrelated context snapshots", () => {
+    const result = metrics([
+      codex(3000, 60, 1000),
+      event("turn.completed", {
+        modelUsage: {
+          main: { inputTokens: 1000, outputTokens: 40, cacheReadInputTokens: 800 },
+          agent: { inputTokens: 1000, outputTokens: 10 },
+        },
+      }),
+    ]);
+    expect(values(result)).toEqual({ "↑": "2k", "↓": "50", R: "—", W: "—", CH: "—" });
+  });
+  it("includes Antigravity turn totals without inventing cache writes or context", () => {
+    const result = metrics([
+      event("turn.completed", {
+        provider: "antigravity",
+        usage: { inputTokens: 10000, outputTokens: 20, cachedInputTokens: 9000 },
+      }),
+    ]);
+    expect(values(result)).toEqual({ "↑": "10k", "↓": "20", R: "9k", W: "—", CH: "90.0%" });
+  });
+  it("does not count repeated completion events or borrow unowned events", () => {
+    const result = event("turn.completed", {
+      provider: "antigravity",
+      usage: { inputTokens: 1000, outputTokens: 20, cachedInputTokens: 0 },
+    });
+    const usage = deriveConversationUsage([
+      result,
+      result,
+      codex(9999, 999, 9000, null as unknown as TurnId),
+    ]);
+    expect(values(usage.cumulative)["↑"]).toBe("1k");
+    expect(values(usage.cumulative).CH).toBe("0.0%");
+  });
+  it("explicitly labels legacy Codex request-only metrics and does not invent turn totals", () => {
+    const events = [
+      event("context-window.updated", {
+        provider: "codex",
+        usedTokens: 21812,
+        inputTokens: 21796,
+        outputTokens: 16,
+        cachedInputTokens: 0,
+      }),
+    ];
+    expect(metrics(events)[0]?.detail).toContain("Latest request only");
+    expect(deriveConversationUsage(events).cumulative).toEqual([]);
+  });
+  it("keeps usage even if context is compacted; omits a ratio for zero input", () => {
+    const result = metrics([codex(0, 10, 0), event("context-compaction", { state: "compacted" })]);
+    expect(values(result)).toEqual({ "↑": "0", "↓": "10", R: "0", W: "—", CH: "—" });
+    expect(metrics([event("turn.completed", {})])).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/messageUsage.test.ts
+++ b/apps/web/src/lib/messageUsage.test.ts
@@ -164,3 +164,83 @@ describe("turn and conversation usage", () => {
     expect(metrics([event("turn.completed", {})])).toEqual([]);
   });
 });
+
+describe("turn throughput", () => {
+  const messages = [
+    { role: "user" as const, createdAt: "2026-09-05T00:00:00.000Z" },
+    { role: "assistant" as const, turnId: turn, createdAt: "2026-09-05T00:00:02.000Z" },
+    { role: "assistant" as const, turnId: turn, createdAt: "2026-09-05T00:00:09.000Z" },
+  ];
+  const completed = {
+    ...event("turn.completed", {}),
+    createdAt: "2026-09-05T00:00:10.000Z",
+  };
+  it("uses full-turn output and wall time, without adding session TPS", () => {
+    const usage = deriveConversationUsage([codex(1000, 250, 900), completed], messages);
+    expect(values(usage.byTurnId.get(turn)!).TPS).toBe("25.0 tok/s");
+    expect(values(usage.cumulative).TPS).toBeUndefined();
+    expect(usage.byTurnId.get(turn)!.find((metric) => metric.label === "TPS")?.detail).toContain(
+      "including thinking, tools and waiting",
+    );
+  });
+  it("uses cumulative deltas for follow-up turns", () => {
+    const next = TurnId.makeUnsafe("next");
+    const usage = deriveConversationUsage(
+      [
+        codex(1000, 250, 900),
+        completed,
+        codex(2000, 350, 1800, next),
+        { ...completed, turnId: next, createdAt: "2026-09-05T00:01:05.000Z" },
+      ],
+      [
+        ...messages,
+        { role: "user", createdAt: "2026-09-05T00:01:00.000Z" },
+        { role: "assistant", turnId: next, createdAt: "2026-09-05T00:01:02.000Z" },
+      ],
+    );
+    expect(values(usage.byTurnId.get(next)!).TPS).toBe("20.0 tok/s");
+  });
+  it.each(["claude-code", "antigravity"])("supports %s output totals", (provider) => {
+    const payload =
+      provider === "antigravity"
+        ? { provider, usage: { inputTokens: 100, outputTokens: 300 } }
+        : {
+            modelUsage: {
+              a: { inputTokens: 100, outputTokens: 100 },
+              b: { inputTokens: 100, outputTokens: 200 },
+            },
+          };
+    const usage = deriveConversationUsage([{ ...completed, payload }], messages);
+    expect(values(usage.byTurnId.get(turn)!).TPS).toBe("30.0 tok/s");
+  });
+  it("omits speed for incomplete and legacy accounting", () => {
+    expect(
+      values(deriveConversationUsage([codex(100, 20, 50)], messages).byTurnId.get(turn)!).TPS,
+    ).toBeUndefined();
+    expect(
+      values(deriveConversationUsage([codex(100, 20, 50), completed]).byTurnId.get(turn)!).TPS,
+    ).toBeUndefined();
+    const legacy = event("context-window.updated", {
+      provider: "codex",
+      inputTokens: 100,
+      outputTokens: 20,
+    });
+    expect(
+      values(deriveConversationUsage([legacy, completed], messages).byTurnId.get(turn)!).TPS,
+    ).toBeUndefined();
+  });
+  it.each(["invalid", "2026-09-05T00:00:00.000Z", "2026-09-04T00:00:00.000Z"])(
+    "omits invalid elapsed time: %s",
+    (createdAt) => {
+      const usage = deriveConversationUsage(
+        [codex(100, 20, 50), { ...completed, createdAt }],
+        messages,
+      );
+      expect(values(usage.byTurnId.get(turn)!).TPS).toBeUndefined();
+    },
+  );
+  it("preserves reported zero output", () => {
+    const usage = deriveConversationUsage([codex(100, 0, 50), completed], messages);
+    expect(values(usage.byTurnId.get(turn)!).TPS).toBe("0.0 tok/s");
+  });
+});

--- a/apps/web/src/lib/messageUsage.test.ts
+++ b/apps/web/src/lib/messageUsage.test.ts
@@ -175,6 +175,27 @@ describe("turn throughput", () => {
     ...event("turn.completed", {}),
     createdAt: "2026-09-05T00:00:10.000Z",
   };
+  it("uses the first model output marker even when thinking precedes text", () => {
+    const first = {
+      ...event("provider.first-output", { streamKind: "reasoning_text" }),
+      createdAt: "2026-09-05T00:00:00.500Z",
+    };
+    const usage = deriveConversationUsage([first, codex(1000, 250, 900), completed], messages);
+    expect(values(usage.byTurnId.get(turn)!).TTFT).toBe("0.5 s");
+    expect(values(usage.cumulative).TTFT).toBeUndefined();
+    expect(
+      values(
+        deriveConversationUsage([codex(1000, 250, 900), completed], messages).byTurnId.get(turn)!,
+      ).TTFT,
+    ).toBeUndefined();
+    const invalid = { ...first, createdAt: "invalid" };
+    expect(
+      values(
+        deriveConversationUsage([invalid, codex(1000, 250, 900)], messages).byTurnId.get(turn)!,
+      ).TTFT,
+    ).toBeUndefined();
+  });
+
   it("uses full-turn output and wall time, without adding session TPS", () => {
     const usage = deriveConversationUsage([codex(1000, 250, 900), completed], messages);
     expect(values(usage.byTurnId.get(turn)!).TPS).toBe("25.0 tok/s");

--- a/apps/web/src/lib/messageUsage.ts
+++ b/apps/web/src/lib/messageUsage.ts
@@ -1,4 +1,5 @@
 import type { OrchestrationThreadActivity, TurnId } from "@synara/contracts";
+import type { ChatMessage } from "~/types";
 import { formatContextWindowTokens } from "./contextWindow";
 
 export interface MessageUsageMetric {
@@ -91,7 +92,18 @@ function metrics(tokens: Tokens, scope: string): MessageUsageMetric[] {
 }
 
 /** One accounting pass feeds both footers. Never sum context-window snapshots. */
-export function deriveConversationUsage(activities: readonly OrchestrationThreadActivity[]) {
+export function deriveConversationUsage(
+  activities: readonly OrchestrationThreadActivity[],
+  messages: readonly Pick<ChatMessage, "role" | "turnId" | "createdAt">[] = [],
+) {
+  // Preserve the first user boundary even when a turn has intermediate replies.
+  const starts = new Map<TurnId, number>();
+  let userStartedAt: number | undefined;
+  for (const message of messages) {
+    if (message.role === "user") userStartedAt = Date.parse(message.createdAt);
+    if (message.turnId && userStartedAt !== undefined && !starts.has(message.turnId))
+      starts.set(message.turnId, userStartedAt);
+  }
   const grouped = new Map<TurnId, OrchestrationThreadActivity[]>();
   for (const activity of activities) {
     if (!activity.turnId || !["context-window.updated", "turn.completed"].includes(activity.kind))
@@ -109,7 +121,8 @@ export function deriveConversationUsage(activities: readonly OrchestrationThread
     const raw = record(
       events.findLast((event) => event.kind === "context-window.updated")?.payload,
     );
-    const completion = record(events.findLast((event) => event.kind === "turn.completed")?.payload);
+    const completed = events.findLast((event) => event.kind === "turn.completed");
+    const completion = record(completed?.payload);
     const models = Object.values(record(completion.modelUsage)).map(record);
     let tokens = empty();
     let scope = "This turn";
@@ -155,6 +168,21 @@ export function deriveConversationUsage(activities: readonly OrchestrationThread
       seenSessions.add(session);
     }
     const values = metrics(tokens, scope);
+    const start = starts.get(turnId);
+    const seconds =
+      completed && start !== undefined ? (Date.parse(completed.createdAt) - start) / 1000 : NaN;
+    if (
+      scope === "This turn" &&
+      tokens.output !== null &&
+      Number.isFinite(seconds) &&
+      seconds > 0
+    ) {
+      values.push({
+        label: "TPS",
+        value: `${(tokens.output / seconds).toFixed(1)} tok/s`,
+        detail: `This turn · Average output throughput: ${tokens.output.toLocaleString("en-US")} tokens / ${seconds.toFixed(1)} seconds. Wall time from sending the message to turn completion, including thinking, tools and waiting; not decode-only speed.`,
+      });
+    }
     if (values.length) byTurnId.set(turnId, values);
     if (contribution && keys.some((key) => contribution![key] !== null))
       accounted.push(contribution);

--- a/apps/web/src/lib/messageUsage.ts
+++ b/apps/web/src/lib/messageUsage.ts
@@ -98,11 +98,21 @@ export function deriveConversationUsage(
 ) {
   // Preserve the first user boundary even when a turn has intermediate replies.
   const starts = new Map<TurnId, number>();
+  const firstReplies = new Map<TurnId, number>();
   let userStartedAt: number | undefined;
   for (const message of messages) {
     if (message.role === "user") userStartedAt = Date.parse(message.createdAt);
     if (message.turnId && userStartedAt !== undefined && !starts.has(message.turnId))
       starts.set(message.turnId, userStartedAt);
+  }
+  for (const activity of activities) {
+    if (activity.kind !== "provider.first-output" || !activity.turnId) continue;
+    const at = Date.parse(activity.createdAt);
+    if (Number.isFinite(at))
+      firstReplies.set(
+        activity.turnId,
+        Math.min(firstReplies.get(activity.turnId) ?? Infinity, at),
+      );
   }
   const grouped = new Map<TurnId, OrchestrationThreadActivity[]>();
   for (const activity of activities) {
@@ -181,6 +191,17 @@ export function deriveConversationUsage(
         label: "TPS",
         value: `${(tokens.output / seconds).toFixed(1)} tok/s`,
         detail: `This turn · Average output throughput: ${tokens.output.toLocaleString("en-US")} tokens / ${seconds.toFixed(1)} seconds. Wall time from sending the message to turn completion, including thinking, tools and waiting; not decode-only speed.`,
+      });
+    }
+    const firstReply = firstReplies.get(turnId);
+    const ttft =
+      start !== undefined && firstReply !== undefined ? (firstReply - start) / 1000 : NaN;
+    if (values.length && Number.isFinite(ttft) && ttft >= 0) {
+      values.push({
+        label: "TTFT",
+        value: `${ttft.toFixed(1)} s`,
+        detail:
+          "Time from sending the message to the first model output received: thinking or assistant text, whichever arrives first. Excludes connection events, heartbeats and status placeholders.",
       });
     }
     if (values.length) byTurnId.set(turnId, values);

--- a/apps/web/src/lib/messageUsage.ts
+++ b/apps/web/src/lib/messageUsage.ts
@@ -1,0 +1,179 @@
+import type { OrchestrationThreadActivity, TurnId } from "@synara/contracts";
+import { formatContextWindowTokens } from "./contextWindow";
+
+export interface MessageUsageMetric {
+  readonly label: string;
+  readonly value: string;
+  readonly detail: string;
+  readonly exactValue?: string;
+}
+
+type Tokens = {
+  input: number | null;
+  output: number | null;
+  read: number | null;
+  write: number | null;
+};
+const empty = (): Tokens => ({ input: null, output: null, read: null, write: null });
+const keys = ["input", "output", "read", "write"] as const;
+function record(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+function count(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
+}
+function fromUsage(value: Record<string, unknown>): Tokens {
+  return {
+    input: count(value.inputTokens),
+    output: count(value.outputTokens),
+    read: count(value.cachedInputTokens),
+    write: count(value.cacheCreationInputTokens),
+  };
+}
+function sum(values: readonly Tokens[]): Tokens {
+  const result = empty();
+  for (const key of keys) {
+    if (values.length && values.every((value) => value[key] !== null))
+      result[key] = values.reduce((total, value) => total + value[key]!, 0);
+  }
+  return result;
+}
+function difference(current: Tokens, before: Tokens | undefined): Tokens {
+  // A provider restart/compaction can reset all cumulative counters.
+  const reset =
+    before &&
+    keys.some(
+      (key) => current[key] !== null && before[key] !== null && current[key]! < before[key]!,
+    );
+  if (!before || reset) return current;
+  const result = empty();
+  for (const key of keys)
+    result[key] =
+      current[key] === null || before[key] === null ? null : current[key]! - before[key]!;
+  return result;
+}
+function metrics(tokens: Tokens, scope: string): MessageUsageMetric[] {
+  if (keys.every((key) => tokens[key] === null)) return [];
+  const definitions = [
+    [
+      "↑",
+      "input",
+      "Input",
+      "Includes cache reads and writes; instructions, tools, history and messages all contribute.",
+    ],
+    ["↓", "output", "Output", "Provider-reported generated tokens."],
+    ["R", "read", "Cache read", "Input tokens reused from cache."],
+    [
+      "W",
+      "write",
+      "Cache write",
+      "Input tokens written to cache. A first request may write cache without reading it.",
+    ],
+  ] as const;
+  const result = definitions.map(([label, key, name, explanation]) => ({
+    label,
+    exactValue: tokens[key] === null ? "—" : tokens[key]!.toLocaleString("en-US"),
+    value: tokens[key] === null ? "—" : formatContextWindowTokens(tokens[key]),
+    detail: `${scope} · ${name}: ${tokens[key] === null ? "not reported" : `${tokens[key]!.toLocaleString("en-US")} tokens`}. ${explanation}`,
+  }));
+  const ratio =
+    tokens.input !== null && tokens.input > 0 && tokens.read !== null && tokens.read <= tokens.input
+      ? tokens.read / tokens.input
+      : null;
+  return [
+    ...result,
+    {
+      label: "CH",
+      value: ratio === null ? "—" : `${(ratio * 100).toFixed(1)}%`,
+      detail: `${scope} · Cache hit: cache reads / total input (including cache reads and writes). ${ratio === null ? "Not enough reported data." : "Weighted by tokens, not an average of request percentages."}`,
+    },
+  ];
+}
+
+/** One accounting pass feeds both footers. Never sum context-window snapshots. */
+export function deriveConversationUsage(activities: readonly OrchestrationThreadActivity[]) {
+  const grouped = new Map<TurnId, OrchestrationThreadActivity[]>();
+  for (const activity of activities) {
+    if (!activity.turnId || !["context-window.updated", "turn.completed"].includes(activity.kind))
+      continue;
+    const group = grouped.get(activity.turnId);
+    if (group) group.push(activity);
+    else grouped.set(activity.turnId, [activity]);
+  }
+  const byTurnId = new Map<TurnId, readonly MessageUsageMetric[]>();
+  const baselines = new Map<string, Tokens>();
+  const seenSessions = new Set<string>();
+  const accounted: Tokens[] = [];
+  let incomplete = false;
+  for (const [turnId, events] of grouped) {
+    const raw = record(
+      events.findLast((event) => event.kind === "context-window.updated")?.payload,
+    );
+    const completion = record(events.findLast((event) => event.kind === "turn.completed")?.payload);
+    const models = Object.values(record(completion.modelUsage)).map(record);
+    let tokens = empty();
+    let scope = "This turn";
+    let contribution: Tokens | undefined;
+    if (
+      models.length &&
+      models.every(
+        (model) => count(model.inputTokens) !== null && count(model.outputTokens) !== null,
+      )
+    ) {
+      // Projection normalizes Claude model input to include cache reads/writes.
+      tokens = sum(
+        models.map((model) => {
+          const usage = fromUsage(model);
+          usage.read = count(model.cacheReadInputTokens);
+          return usage;
+        }),
+      );
+      contribution = tokens;
+    } else if (completion.provider === "antigravity") {
+      tokens = fromUsage(record(completion.usage));
+      contribution = tokens;
+    } else if (raw.provider === "codex") {
+      const session = `codex:${String(raw.usageSessionId ?? "legacy")}`;
+      const cumulative = fromUsage(record(raw.cumulativeUsage));
+      if (cumulative.input !== null && cumulative.output !== null) {
+        contribution = difference(cumulative, baselines.get(session));
+        tokens = contribution;
+        if (
+          !baselines.has(session) &&
+          (seenSessions.has(session) || seenSessions.has("codex:legacy"))
+        ) {
+          // Older app versions saved only the last request. The session total
+          // remains exact, but the boundary for this particular turn is unknown.
+          tokens = fromUsage(raw);
+          scope = "Latest request only; historical turn baseline unavailable";
+        }
+        baselines.set(session, cumulative);
+      } else {
+        tokens = fromUsage(raw);
+        scope = "Latest request only; legacy turn totals unavailable";
+      }
+      seenSessions.add(session);
+    }
+    const values = metrics(tokens, scope);
+    if (values.length) byTurnId.set(turnId, values);
+    if (contribution && keys.some((key) => contribution![key] !== null))
+      accounted.push(contribution);
+    else if (raw.provider !== "codex") incomplete = true;
+  }
+  // A later Codex cumulative snapshot covers its earlier legacy requests.
+  const hasLegacyCodexWithoutTotal = [...seenSessions].some((session) => !baselines.has(session));
+  incomplete ||= hasLegacyCodexWithoutTotal;
+  return {
+    byTurnId,
+    cumulative: metrics(
+      sum(accounted),
+      incomplete
+        ? "Recorded conversation usage; some historical turns have no totals"
+        : "Conversation total",
+    ),
+  };
+}
+
+export function deriveMessageUsageByTurnId(activities: readonly OrchestrationThreadActivity[]) {
+  return deriveConversationUsage(activities).byTurnId;
+}

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -307,7 +307,9 @@ export function deriveWorkLogEntries(
     .filter((activity) => activity.kind !== "account.rate-limits.updated")
     .filter(
       (activity) =>
-        activity.kind !== "context-window.updated" && activity.kind !== "context-window.configured",
+        activity.kind !== "context-window.updated" &&
+        activity.kind !== "context-window.configured" &&
+        activity.kind !== "provider.first-output",
     )
     .filter((activity) => activity.summary !== "Checkpoint captured")
     // Server-side Studio output attribution is environment-panel data, not transcript work.

--- a/bun.lock
+++ b/bun.lock
@@ -198,6 +198,7 @@
       "dependencies": {
         "@synara/contracts": "workspace:*",
         "effect": "catalog:",
+        "https-proxy-agent": "7.0.6",
       },
       "devDependencies": {
         "@effect/language-service": "catalog:",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -322,7 +322,8 @@
   },
   "dependencies": {
     "@synara/contracts": "workspace:*",
-    "effect": "catalog:"
+    "effect": "catalog:",
+    "https-proxy-agent": "7.0.6"
   },
   "devDependencies": {
     "@effect/language-service": "catalog:",

--- a/packages/shared/src/outboundHttp.test.ts
+++ b/packages/shared/src/outboundHttp.test.ts
@@ -155,3 +155,15 @@ describe("loopback HTTP transport", () => {
     }
   });
 });
+
+it("never accepts a remote or authenticated local proxy", async () => {
+  for (const localProxyUrl of [
+    "http://8.8.8.8:8080",
+    "http://user:pass@127.0.0.1:8080",
+    "https://127.0.0.1:8080",
+  ]) {
+    await expect(
+      outboundHttp.request({ url: "https://127.0.0.1:443", policy: policyFor(443), localProxyUrl }),
+    ).rejects.toThrow();
+  }
+});

--- a/packages/shared/src/outboundHttp.ts
+++ b/packages/shared/src/outboundHttp.ts
@@ -8,6 +8,7 @@ import * as Dns from "node:dns/promises";
 import * as Http from "node:http";
 import * as Https from "node:https";
 import * as Net from "node:net";
+import { HttpsProxyAgent } from "https-proxy-agent";
 
 import {
   assertExactLoopbackIpAddress,
@@ -57,6 +58,8 @@ export interface OutboundHttpPolicy {
 }
 
 export interface OutboundHttpRequest {
+  /** Trusted local system proxy; origin allowlists and TLS remain enforced. */
+  readonly localProxyUrl?: string;
   readonly policy: OutboundHttpPolicy;
   readonly url: string | URL;
   readonly method?: "GET" | "HEAD" | "POST" | "PUT" | "PATCH" | "DELETE";
@@ -333,6 +336,7 @@ export function invokePinnedDnsLookup(
 }
 
 async function requestHop(input: {
+  readonly localProxyUrl?: string | undefined;
   readonly url: URL;
   readonly method: string;
   readonly headers: Headers;
@@ -349,6 +353,22 @@ async function requestHop(input: {
     input.signal,
   );
 
+  let proxyAgent: HttpsProxyAgent<string> | undefined;
+  if (input.localProxyUrl && input.url.protocol === "https:") {
+    const proxy = new URL(input.localProxyUrl);
+    if (proxy.protocol !== "http:" || proxy.username || proxy.password) {
+      throw new OutboundHttpError(
+        "request",
+        "Only an unauthenticated local HTTP proxy is supported.",
+      );
+    }
+    assertExactLoopbackIpAddress(proxy.hostname);
+    proxyAgent = new HttpsProxyAgent(proxy);
+    // The user's trusted proxy resolves the allowlisted origin. Passing the
+    // locally resolved IP breaks hostname-based routing and proxy DNS policies.
+    // TLS still verifies the original hostname; redirects retain the same policy.
+  }
+
   return await new Promise<OutboundHttpResponse>((resolve, reject) => {
     let settled = false;
     const settle = (result: OutboundHttpResponse | Error) => {
@@ -361,6 +381,7 @@ async function requestHop(input: {
     const request = transport.request(
       input.url,
       {
+        ...(proxyAgent ? { agent: proxyAgent } : {}),
         method: input.method,
         headers: requestHeaders(input.headers),
         signal: input.signal,
@@ -505,6 +526,7 @@ export class OutboundHttpClient {
           url,
           method,
           headers,
+          localProxyUrl: input.localProxyUrl,
           ...(body ? { body } : {}),
           maxResponseBytes: policy.maxResponseBytes,
           requirePublicAddress: policy.requirePublicAddress ?? true,

--- a/turbo.json
+++ b/turbo.json
@@ -25,6 +25,16 @@
     "SYNARA_HOST",
     "SYNARA_AUTO_BOOTSTRAP_PROJECT_FROM_CWD"
   ],
+  "globalPassThroughEnv": [
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "no_proxy"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Show compact per-turn input/output/cache-read/cache-write/cache-hit metrics, TPS (tok/s), and TTFT below completed replies. The context meter exposes token-weighted conversation totals and account quota windows.

- TPS is provider-reported output across the turn divided by wall time from sending the user message to turn completion, including thinking, tools, and waiting. It is not decode-only throughput; thinking tokens contribute only as included in the provider's output accounting.
- TTFT measures sending the message to the first nonempty thinking or assistant-text delta received by the adapter. Connection events, heartbeats, and status placeholders do not count. Record the first arrival once with replay-safe receipts and hide that bookkeeping event from the work timeline.
- Preserve the first user boundary across intermediate replies. Omit unavailable/invalid timing; conversation totals do not show TPS or TTFT. Historical turns without a first-output marker do not receive an invented TTFT.
- Prefer authoritative live quota snapshots over historical thread events so absent windows cannot appear as fabricated 100% remaining limits. Refresh Antigravity credentials/model groups and classify Codex windows by their reported duration.
- Quota HTTP requests can opt into an enabled loopback HTTPS proxy from macOS system settings; origin admission and TLS verification remain in place. No credentials or personal proxy-node configuration are included.

Validation: 102 ProviderRuntimeIngestion tests, 133 message-usage/work-log/quota-summary tests, and 5 MessageUsage/ContextWindowMeter browser tests passed. Coverage includes thinking-first TTFT, idempotent first-output recording, missing timing, TPS accounting, and narrow-width layout. The combined PR integration passed formatting, lint, and full workspace typecheck. Previously validated: provider quota, localProxy, and outboundHttp suites. No new live-provider calls were made for this update.

Suggested merge order: after #1024 for complete per-turn accounting and retained cache data, and #1021 for Antigravity print-result usage. This branch builds and tests against its main baseline independently; unknown metrics remain unknown. TTFT reflects the adapter's first observable output, not a server-internal token-generation timestamp.
