### PR TITLE
Add interactive first-run onboarding flow

### DIFF
--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -254,6 +254,8 @@ const PersistedHiddenModels = Schema.Array(
 
 export const AppSettingsSchema = Schema.Struct({
   claudeBinaryPath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
+  // Server-backed first-run marker; see ServerSettings.onboardingCompletedAt.
+  onboardingCompletedAt: Schema.NullOr(Schema.String).pipe(withDefaults((): string | null => null)),
   uiDensity: UiDensity.pipe(withDefaults(() => DEFAULT_UI_DENSITY)),
   chatWidth: ChatWidthMode.pipe(withDefaults(() => DEFAULT_CHAT_WIDTH)),
   chatFontSizePx: Schema.Number.pipe(withDefaults(() => DEFAULT_CHAT_FONT_SIZE_PX)),
@@ -700,6 +702,7 @@ function serverSettingsToAppSettings(settings: ServerSettingsView): Partial<AppS
     disabledProviders: getServerDisabledProviders(settings),
     textGenerationProvider: settings.textGenerationModelSelection.provider,
     textGenerationModel: settings.textGenerationModelSelection.model,
+    onboardingCompletedAt: settings.onboardingCompletedAt ?? null,
   };
 }
 
@@ -777,6 +780,9 @@ export function appSettingsPatchToServerSettingsPatch(
   }
   if (patch.defaultThreadEnvMode === "local" || patch.defaultThreadEnvMode === "worktree") {
     serverPatch.defaultThreadEnvMode = patch.defaultThreadEnvMode;
+  }
+  if (hasOwn(patch, "onboardingCompletedAt")) {
+    serverPatch.onboardingCompletedAt = patch.onboardingCompletedAt ?? null;
   }
   if (hasOwn(patch, "textGenerationModel") || hasOwn(patch, "textGenerationProvider")) {
     const model = patch.textGenerationModel ?? DEFAULT_GIT_TEXT_GENERATION_MODEL;

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -1482,12 +1482,21 @@ export function useAppSettings() {
   };
 
   const resetSettings = async (): Promise<void> => {
-    setSettings(DEFAULT_APP_SETTINGS);
+    // "Restore defaults" resets preferences, not lifecycle markers: clearing the
+    // onboarding completion timestamp would replay the first-run tour on the next launch.
+    const { onboardingCompletedAt: _keepOnboardingCompletedAt, ...resettableDefaults } = defaults;
+    setSettings((prev) => ({
+      ...DEFAULT_APP_SETTINGS,
+      onboardingCompletedAt: prev.onboardingCompletedAt,
+    }));
     await enqueueServerSettingsMutation(async () => {
       const currentServerSettings =
         queryClient.getQueryData<ServerSettingsView>(serverQueryKeys.settings()) ??
         serverSettingsQuery.data;
-      const serverPatch = appSettingsPatchToServerSettingsPatch(defaults, currentServerSettings);
+      const serverPatch = appSettingsPatchToServerSettingsPatch(
+        resettableDefaults,
+        currentServerSettings,
+      );
       const providerSettingsChanged = Boolean(
         serverPatch.providers && Object.keys(serverPatch.providers).length > 0,
       );

--- a/apps/web/src/components/AppSnapWelcomeDialog.tsx
+++ b/apps/web/src/components/AppSnapWelcomeDialog.tsx
@@ -16,6 +16,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 
 import { useLocalStorage } from "../hooks/useLocalStorage";
+import { useOnboardingDialogStore } from "../onboarding/onboardingDialogStore";
 import { CentralIcon } from "../lib/central-icons";
 import { Button } from "./ui/button";
 import {
@@ -45,6 +46,11 @@ export function AppSnapWelcomeDialog() {
   );
   const [open, setOpen] = useState(false);
   const sheetRef = useRef<HTMLDivElement>(null);
+  // Both startup dialogs probe asynchronously; without arbitration a fresh macOS install
+  // could stack this sheet on the welcome tour. Wait for the tour's gate and its close.
+  const onboardingBlocking = useOnboardingDialogStore(
+    (store) => !store.startupGateSettled || store.isOpen,
+  );
 
   useEffect(() => {
     if (storage.acknowledged) {
@@ -91,7 +97,7 @@ export function AppSnapWelcomeDialog() {
 
   // Derived instead of synced: acknowledging closes the dialog in the same
   // render, so the effect never needs a synchronous setOpen(false).
-  const dialogOpen = open && !storage.acknowledged;
+  const dialogOpen = open && !storage.acknowledged && !onboardingBlocking;
 
   return (
     <Dialog open={dialogOpen} onOpenChange={handleOpenChange}>

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -62,7 +62,11 @@ import {
   sendEffectRpcExit,
 } from "../test/effectRpcWebSocketMock";
 import { makeDomainEvent } from "../storeTestFixtures";
-import { createBrowserTestServerConfig, createFullscreenTestHost } from "../test/browserHarness";
+import {
+  createBrowserTestServerConfig,
+  createBrowserTestServerSettings,
+  createFullscreenTestHost,
+} from "../test/browserHarness";
 import { useTemporaryThreadStore } from "../temporaryThreadStore";
 import { useTerminalStateStore } from "../terminalStateStore";
 import { resetRetainedThreadDetailSubscriptionsForTests } from "../threadDetailSubscriptionRetention";
@@ -1194,6 +1198,9 @@ function resolveWsRpc(body: WsRequestEnvelope["body"]): unknown {
   }
   if (tag === WS_METHODS.automationCreate) {
     return createAutomationDefinitionFromCreateRequest(body);
+  }
+  if (tag === WS_METHODS.serverGetSettings) {
+    return createBrowserTestServerSettings(NOW_ISO);
   }
   if (tag === WS_METHODS.serverGetConfig) {
     return fixture.serverConfig;

--- a/apps/web/src/components/CreateProjectDialog.tsx
+++ b/apps/web/src/components/CreateProjectDialog.tsx
@@ -10,10 +10,7 @@ import { normalizeProjectDirectoryName } from "@synara/shared/projectDirectoryNa
 import { useCallback, useEffect, useId, useRef, useState, type KeyboardEvent } from "react";
 
 import { isElectron } from "../env";
-import {
-  isDroppedComposerDirectory,
-  resolveDroppedFileAbsolutePath,
-} from "../lib/composerDropPaths";
+import { useWindowFolderDrop } from "../hooks/useWindowFolderDrop";
 import { VOID_SPACE_KEY, spaceKey, toSpaceIconName } from "../lib/spaceGrouping";
 import { createSpace } from "../lib/spaces";
 import { readNativeApi } from "../nativeApi";
@@ -46,28 +43,6 @@ import { ComposerPickerSelectPopup } from "./chat/ComposerPickerMenuPopup";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "./ui/input-group";
 import { Select, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 import { CentralIcon } from "~/lib/central-icons";
-
-// Inputs share one fixed height + radius so every control in the dialog reads
-// as the same size (mirrors EditProfileDialog's field styling).
-function isFileDrag(event: globalThis.DragEvent): boolean {
-  return Array.from(event.dataTransfer?.types ?? []).includes("Files");
-}
-
-type DroppedFolderResult = { readonly path: string } | { readonly error: string };
-
-function resolveDroppedFolder(dataTransfer: DataTransfer): DroppedFolderResult | null {
-  const item = Array.from(dataTransfer.items).find((entry) => entry.kind === "file");
-  const file = item?.getAsFile() ?? dataTransfer.files[0] ?? null;
-  if (!item || !file) return null;
-  if (!isDroppedComposerDirectory(item)) {
-    return { error: "Drop a folder, not a file." };
-  }
-  const absolutePath = resolveDroppedFileAbsolutePath(file);
-  if (!absolutePath) {
-    return { error: "Could not read the folder's path. Use browse or type it instead." };
-  }
-  return { path: absolutePath };
-}
 
 interface CreateLocalProjectSubmitValue {
   readonly source: "local";
@@ -126,7 +101,6 @@ export function CreateProjectDialog(props: {
    */
   const [createdSpace, setCreatedSpace] = useState<Space | null>(null);
   const [isPickingFolder, setIsPickingFolder] = useState(false);
-  const [isDropTarget, setIsDropTarget] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   const openedRef = useRef(false);
@@ -161,7 +135,6 @@ export function CreateProjectDialog(props: {
     setSpaceEditorOpen(false);
     setCreatedSpace(null);
     setIsPickingFolder(false);
-    setIsDropTarget(false);
     setSubmitting(false);
     setFormError(null);
     // Deferred a frame: the dialog moves focus itself on open, so focusing the
@@ -243,52 +216,13 @@ export function CreateProjectDialog(props: {
     setIsPickingFolder(false);
   };
 
-  // While the dialog is open it is the only interactive surface, so accept a
-  // folder drop anywhere in the window (capture phase). A tiny drop zone is
-  // easy to miss and a stray drop outside it would otherwise vanish silently.
-  useEffect(() => {
-    if (!props.open || !isElectron || source !== "local") return;
-    let dragDepth = 0;
-    const handleDragEnter = (event: globalThis.DragEvent) => {
-      if (!isFileDrag(event)) return;
-      dragDepth += 1;
-      setIsDropTarget(true);
-    };
-    const handleDragOver = (event: globalThis.DragEvent) => {
-      if (!isFileDrag(event)) return;
-      event.preventDefault();
-      if (event.dataTransfer) event.dataTransfer.dropEffect = "copy";
-    };
-    const handleDragLeave = (event: globalThis.DragEvent) => {
-      if (!isFileDrag(event)) return;
-      dragDepth = Math.max(0, dragDepth - 1);
-      if (dragDepth === 0) setIsDropTarget(false);
-    };
-    const handleDrop = (event: globalThis.DragEvent) => {
-      if (!isFileDrag(event)) return;
-      event.preventDefault();
-      event.stopPropagation();
-      dragDepth = 0;
-      setIsDropTarget(false);
-      const dropped = event.dataTransfer ? resolveDroppedFolder(event.dataTransfer) : null;
-      if (!dropped) return;
-      if ("error" in dropped) {
-        setFormError(dropped.error);
-        return;
-      }
-      applyPickedFolder(dropped.path);
-    };
-    window.addEventListener("dragenter", handleDragEnter, true);
-    window.addEventListener("dragover", handleDragOver, true);
-    window.addEventListener("dragleave", handleDragLeave, true);
-    window.addEventListener("drop", handleDrop, true);
-    return () => {
-      window.removeEventListener("dragenter", handleDragEnter, true);
-      window.removeEventListener("dragover", handleDragOver, true);
-      window.removeEventListener("dragleave", handleDragLeave, true);
-      window.removeEventListener("drop", handleDrop, true);
-    };
-  }, [applyPickedFolder, props.open, source]);
+  // While the dialog is open it is the only interactive surface, so a folder dropped
+  // anywhere in the window counts (see useWindowFolderDrop).
+  const isDropTarget = useWindowFolderDrop({
+    enabled: props.open && isElectron && source === "local",
+    onFolder: applyPickedFolder,
+    onError: setFormError,
+  });
 
   const submit = async () => {
     if (submitting) return;

--- a/apps/web/src/components/EventRouter.browser.tsx
+++ b/apps/web/src/components/EventRouter.browser.tsx
@@ -59,7 +59,11 @@ import {
   sendEffectRpcExit,
   type EffectRpcWebSocketClient,
 } from "../test/effectRpcWebSocketMock";
-import { createBrowserTestServerConfig, createFullscreenTestHost } from "../test/browserHarness";
+import {
+  createBrowserTestServerConfig,
+  createBrowserTestServerSettings,
+  createFullscreenTestHost,
+} from "../test/browserHarness";
 import { getThreadFromState } from "../threadDerivation";
 import { resetThreadDetailResumeCursorsForTests } from "../threadDetailResumeCursors";
 import { useWorkspacePathsStore } from "../workspacePathsStore";
@@ -276,6 +280,9 @@ function resolveWsRpc(tag: string, body?: unknown): unknown {
       typeof request?.fromSequenceExclusive === "number" ? request.fromSequenceExclusive : 0;
     replayRequestCursors.push(fromSequenceExclusive);
     return replayEvents.filter((event) => event.sequence > fromSequenceExclusive);
+  }
+  if (tag === WS_METHODS.serverGetSettings) {
+    return createBrowserTestServerSettings(NOW_ISO);
   }
   if (tag === WS_METHODS.serverGetConfig) {
     return fixture.serverConfig;

--- a/apps/web/src/components/KeybindingsToast.browser.tsx
+++ b/apps/web/src/components/KeybindingsToast.browser.tsx
@@ -28,7 +28,11 @@ import {
   sendEffectRpcExit,
   type EffectRpcWebSocketClient,
 } from "../test/effectRpcWebSocketMock";
-import { createBrowserTestServerConfig, createFullscreenTestHost } from "../test/browserHarness";
+import {
+  createBrowserTestServerConfig,
+  createBrowserTestServerSettings,
+  createFullscreenTestHost,
+} from "../test/browserHarness";
 import { resetWsNativeApiForTest } from "../wsNativeApi";
 
 const THREAD_ID = "thread-kb-toast-test" as ThreadId;
@@ -169,6 +173,9 @@ function resolveWsRpc(tag: string): unknown {
   }
   if (tag === ORCHESTRATION_WS_METHODS.getSnapshot) {
     return fixture.snapshot;
+  }
+  if (tag === WS_METHODS.serverGetSettings) {
+    return createBrowserTestServerSettings(NOW_ISO);
   }
   if (tag === WS_METHODS.serverGetConfig) {
     return fixture.serverConfig;

--- a/apps/web/src/hooks/useOnboarding.browser.tsx
+++ b/apps/web/src/hooks/useOnboarding.browser.tsx
@@ -1,0 +1,109 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "vitest-browser-react";
+
+import { useOnboardingDialogStore } from "../onboarding/onboardingDialogStore";
+import { useOnboarding } from "../onboarding/useOnboarding";
+
+const mocks = vi.hoisted(() => ({ getConfig: vi.fn(), save: vi.fn() }));
+vi.mock("../appSettings", () => ({
+  useAppSettings: () => ({ updateSettingsAndWait: mocks.save }),
+}));
+vi.mock("../lib/serverReactQuery", () => ({
+  serverConfigQueryOptions: () => ({ queryKey: ["server", "config"], queryFn: mocks.getConfig }),
+  serverSettingsQueryOptions: () => ({
+    queryKey: ["server", "settings"],
+    queryFn: async () => ({ onboardingCompletedAt: null }),
+  }),
+}));
+vi.mock("../store", () => ({
+  useStore: (select: (state: { threadsHydrated: boolean; projects: never[] }) => unknown) =>
+    select({ threadsHydrated: true, projects: [] }),
+}));
+vi.mock("../workspacePathsStore", () => ({
+  useWorkspacePathsStore: (select: (state: Record<string, null>) => unknown) =>
+    select({ homeDir: null, chatWorkspaceRoot: null, studioWorkspaceRoot: null }),
+}));
+
+const clients: QueryClient[] = [];
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  localStorage.removeItem("synara:onboarding:v2");
+  mocks.getConfig.mockReset().mockResolvedValue({ worktreesDir: "/a/worktrees" });
+  // Keep the server marker absent to exercise the failed-write fallback.
+  mocks.save.mockReset().mockResolvedValue(false);
+  useOnboardingDialogStore.setState({
+    isOpen: false,
+    openReason: null,
+    engaged: false,
+    startupGateSettled: false,
+  });
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  for (const client of clients.splice(0)) client.clear();
+  localStorage.removeItem("synara:onboarding:v2");
+});
+
+async function renderOnboarding() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  clients.push(client);
+  const hook = await renderHook(() => useOnboarding(), {
+    wrapper: ({ children }: { children?: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    ),
+  });
+  return { client, hook };
+}
+
+describe("onboarding installation identity", () => {
+  it("keeps the intro open when a config refetch fails with a cached identity", async () => {
+    const { client, hook } = await renderOnboarding();
+    await vi.waitFor(() => expect(hook.result.current.isOpen).toBe(true));
+    mocks.getConfig.mockRejectedValue(new Error("temporary config failure"));
+    await act(async () => {
+      await client.refetchQueries({ queryKey: ["server", "config"] });
+    });
+    await vi.waitFor(() =>
+      expect(client.getQueryState(["server", "config"])?.status).toBe("error"),
+    );
+    await hook.rerender();
+    expect(hook.result.current.isOpen).toBe(true);
+    await hook.unmount();
+  });
+
+  it("keeps a completed replay dismissed as config arrives, but not on another installation", async () => {
+    let resolveConfig!: (config: { worktreesDir: string }) => void;
+    mocks.getConfig.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveConfig = resolve;
+        }),
+    );
+    const { client, hook } = await renderOnboarding();
+    await act(async () => {
+      useOnboardingDialogStore.getState().openDialog();
+    });
+    await vi.waitFor(() => expect(hook.result.current.isOpen).toBe(true));
+    await act(async () => {
+      hook.result.current.complete();
+    });
+    await act(async () => {
+      resolveConfig({ worktreesDir: "/a/worktrees" });
+    });
+    await vi.waitFor(() =>
+      expect(client.getQueryState(["server", "config"])?.status).toBe("success"),
+    );
+    await hook.rerender();
+    expect(hook.result.current.isOpen).toBe(false);
+    expect(
+      JSON.parse(localStorage.getItem("synara:onboarding:v2") ?? "null")?.completedAt ?? null,
+    ).toBeNull();
+    await act(async () => {
+      client.setQueryData(["server", "config"], { worktreesDir: "/b/worktrees" });
+    });
+    await vi.waitFor(() => expect(hook.result.current.isOpen).toBe(true));
+    await hook.unmount();
+  });
+});

--- a/apps/web/src/hooks/useWindowFolderDrop.ts
+++ b/apps/web/src/hooks/useWindowFolderDrop.ts
@@ -1,0 +1,70 @@
+// FILE: useWindowFolderDrop.ts
+// Purpose: Accept a folder dropped anywhere in the window while a modal surface is open.
+//          A small drop zone is easy to miss and a stray drop outside it would otherwise
+//          vanish silently, so listeners bind on `window` in the capture phase.
+// Layer: Web hook
+// Exports: useWindowFolderDrop
+
+import { useEffect, useRef, useState } from "react";
+
+import { isFileDrag, resolveDroppedFolder } from "../lib/folderDrop";
+
+export function useWindowFolderDrop(options: {
+  readonly enabled: boolean;
+  readonly onFolder: (path: string) => void;
+  readonly onError: (message: string) => void;
+}): boolean {
+  const [isDropTarget, setIsDropTarget] = useState(false);
+  // Latest callbacks through refs so the listeners bind once per `enabled` flip.
+  const onFolderRef = useRef(options.onFolder);
+  const onErrorRef = useRef(options.onError);
+  onFolderRef.current = options.onFolder;
+  onErrorRef.current = options.onError;
+
+  useEffect(() => {
+    if (!options.enabled) return;
+    let dragDepth = 0;
+    const handleDragEnter = (event: globalThis.DragEvent) => {
+      if (!isFileDrag(event)) return;
+      dragDepth += 1;
+      setIsDropTarget(true);
+    };
+    const handleDragOver = (event: globalThis.DragEvent) => {
+      if (!isFileDrag(event)) return;
+      event.preventDefault();
+      if (event.dataTransfer) event.dataTransfer.dropEffect = "copy";
+    };
+    const handleDragLeave = (event: globalThis.DragEvent) => {
+      if (!isFileDrag(event)) return;
+      dragDepth = Math.max(0, dragDepth - 1);
+      if (dragDepth === 0) setIsDropTarget(false);
+    };
+    const handleDrop = (event: globalThis.DragEvent) => {
+      if (!isFileDrag(event)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      dragDepth = 0;
+      setIsDropTarget(false);
+      const dropped = event.dataTransfer ? resolveDroppedFolder(event.dataTransfer) : null;
+      if (!dropped) return;
+      if ("error" in dropped) {
+        onErrorRef.current(dropped.error);
+        return;
+      }
+      onFolderRef.current(dropped.path);
+    };
+    window.addEventListener("dragenter", handleDragEnter, true);
+    window.addEventListener("dragover", handleDragOver, true);
+    window.addEventListener("dragleave", handleDragLeave, true);
+    window.addEventListener("drop", handleDrop, true);
+    return () => {
+      setIsDropTarget(false);
+      window.removeEventListener("dragenter", handleDragEnter, true);
+      window.removeEventListener("dragover", handleDragOver, true);
+      window.removeEventListener("dragleave", handleDragLeave, true);
+      window.removeEventListener("drop", handleDrop, true);
+    };
+  }, [options.enabled]);
+
+  return isDropTarget;
+}

--- a/apps/web/src/lib/folderDrop.ts
+++ b/apps/web/src/lib/folderDrop.ts
@@ -1,0 +1,27 @@
+// FILE: folderDrop.ts
+// Purpose: Pure helpers for accepting an OS folder drop (Create Project dialog, onboarding).
+// Layer: Web domain helper (no React)
+// Exports: isFileDrag, resolveDroppedFolder, DroppedFolderResult
+
+import { isDroppedComposerDirectory, resolveDroppedFileAbsolutePath } from "./composerDropPaths";
+
+export type DroppedFolderResult = { readonly path: string } | { readonly error: string };
+
+export function isFileDrag(event: globalThis.DragEvent): boolean {
+  return Array.from(event.dataTransfer?.types ?? []).includes("Files");
+}
+
+/** Resolves the first dropped item to an absolute folder path, or a user-facing error. */
+export function resolveDroppedFolder(dataTransfer: DataTransfer): DroppedFolderResult | null {
+  const item = Array.from(dataTransfer.items).find((entry) => entry.kind === "file");
+  const file = item?.getAsFile() ?? dataTransfer.files[0] ?? null;
+  if (!item || !file) return null;
+  if (!isDroppedComposerDirectory(item)) {
+    return { error: "Drop a folder, not a file." };
+  }
+  const absolutePath = resolveDroppedFileAbsolutePath(file);
+  if (!absolutePath) {
+    return { error: "Could not read the folder's path. Use browse or type it instead." };
+  }
+  return { path: absolutePath };
+}

--- a/apps/web/src/onboarding/OnboardingDialog.tsx
+++ b/apps/web/src/onboarding/OnboardingDialog.tsx
@@ -70,7 +70,11 @@ function plural(count: number, noun: string): string {
   return `${count} ${noun}${count === 1 ? "" : "s"}`;
 }
 
-function OnboardingFlow(props: { onComplete: () => void }) {
+function OnboardingFlow(props: {
+  onComplete: () => void;
+  projectBusy: boolean;
+  onProjectBusyChange: (busy: boolean) => void;
+}) {
   const [step, setStep] = useState<OnboardingStep>("welcome");
   const [projectResults, setProjectResults] = useState<ReadonlyArray<OnboardingProjectResult>>([]);
   const { settings } = useAppSettings();
@@ -172,6 +176,7 @@ function OnboardingFlow(props: { onComplete: () => void }) {
         {step === "project" ? (
           <ProjectStep
             results={projectResults}
+            onBusyChange={props.onProjectBusyChange}
             onResult={(result) =>
               setProjectResults((current) =>
                 current.some((entry) => entry.projectId === result.projectId)
@@ -189,6 +194,8 @@ function OnboardingFlow(props: { onComplete: () => void }) {
         onSkip={props.onComplete}
         primaryLabel={primaryAction.label}
         onPrimary={primaryAction.onPrimary}
+        primaryBusy={step === "project" && props.projectBusy}
+        navigationLocked={props.projectBusy}
       />
     </div>
   );
@@ -199,11 +206,24 @@ export function OnboardingDialog(props: {
   onOpenChange: (open: boolean) => void;
   onComplete: () => void;
 }) {
+  // Project creation cannot be aborted: closing the tour mid-create would report a skip
+  // while a project still appears afterwards, so dismissal waits for it to settle.
+  const [projectBusy, setProjectBusy] = useState(false);
+  const handleOpenChange = (open: boolean) => {
+    if (!open && projectBusy) return;
+    props.onOpenChange(open);
+  };
   return (
-    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+    <Dialog open={props.open} onOpenChange={handleOpenChange}>
       <DialogPopup showCloseButton className="h-[540px] max-h-full max-w-[800px]">
         {/* Remount per open so a replay from Settings starts at the first step. */}
-        {props.open ? <OnboardingFlow onComplete={props.onComplete} /> : null}
+        {props.open ? (
+          <OnboardingFlow
+            onComplete={props.onComplete}
+            projectBusy={projectBusy}
+            onProjectBusyChange={setProjectBusy}
+          />
+        ) : null}
       </DialogPopup>
     </Dialog>
   );

--- a/apps/web/src/onboarding/OnboardingDialog.tsx
+++ b/apps/web/src/onboarding/OnboardingDialog.tsx
@@ -1,0 +1,156 @@
+// FILE: OnboardingDialog.tsx
+// Purpose: First-run welcome tour: intro → feature tour → providers → theme → project → done.
+//          Owns step navigation and the per-run results the final summary reads.
+// Layer: Web UI overlay (mounted once from the root route)
+
+import { PROVIDER_DESCRIPTORS } from "@synara/shared/providerMetadata";
+import { useState } from "react";
+
+import { useAppSettings } from "~/appSettings";
+import { APP_BASE_NAME } from "~/branding";
+import { SynaraLogo } from "~/components/SynaraLogo";
+import {
+  Dialog,
+  DialogDescription,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "~/components/ui/dialog";
+import { useProviderStatusesForLocalConfig } from "~/hooks/useProviderStatusesForLocalConfig";
+import { findProviderStatus } from "~/lib/providerAvailability";
+import {
+  classifyProviderSetup,
+  nextOnboardingStep,
+  previousOnboardingStep,
+  summarizeProviderSetup,
+  type OnboardingStep,
+} from "./logic";
+import { OnboardingStepFooter } from "./OnboardingStepFooter";
+import { DoneStep } from "./steps/DoneStep";
+import { FeatureTourStep } from "./steps/FeatureTourStep";
+import { ProjectStep, type OnboardingProjectResult } from "./steps/ProjectStep";
+import { ProvidersStep } from "./steps/ProvidersStep";
+import { ThemeStep } from "./steps/ThemeStep";
+import { WelcomeStep } from "./steps/WelcomeStep";
+
+const STEP_TITLES: Record<OnboardingStep, string> = {
+  welcome: `Welcome to ${APP_BASE_NAME}`,
+  tour: `What ${APP_BASE_NAME} can do`,
+  providers: "Choose your agents",
+  theme: "Pick an appearance",
+  project: "Add your first project",
+  done: "You're all set",
+};
+
+const STEP_DESCRIPTIONS: Record<OnboardingStep, string> = {
+  welcome: "",
+  tour: "A quick look at the workspace before you set it up.",
+  providers: "Synara detected these runtimes on this machine. Uncheck any you do not want to use.",
+  theme: "You can change this anytime in Settings → Appearance.",
+  project: "Point Synara at a folder, preferably a Git repository.",
+  done: "Your agents, appearance, and first project are ready.",
+};
+
+function OnboardingFlow(props: { onComplete: () => void }) {
+  const [step, setStep] = useState<OnboardingStep>("welcome");
+  const [projectResults, setProjectResults] = useState<ReadonlyArray<OnboardingProjectResult>>([]);
+  const { settings } = useAppSettings();
+  const statuses = useProviderStatusesForLocalConfig();
+
+  const goBack = () => setStep(previousOnboardingStep(step));
+  const goNext = () => setStep(nextOnboardingStep(step));
+
+  const providerSummary = summarizeProviderSetup(
+    PROVIDER_DESCRIPTORS.map((descriptor) => ({
+      provider: descriptor.kind,
+      state: classifyProviderSetup({
+        status: findProviderStatus(statuses, descriptor.kind),
+        disabled: settings.disabledProviders.includes(descriptor.kind),
+      }),
+    })),
+  );
+
+  const primaryAction = (() => {
+    switch (step) {
+      case "welcome":
+        return { label: "Get started", onPrimary: goNext };
+      case "tour":
+        return { label: "Set up", onPrimary: goNext };
+      case "providers":
+      case "theme":
+        return { label: "Continue", onPrimary: goNext };
+      case "project":
+        return projectResults.length > 0
+          ? { label: "Continue", onPrimary: goNext }
+          : { label: "Skip for now", onPrimary: goNext };
+      case "done":
+        return { label: `Start using ${APP_BASE_NAME}`, onPrimary: props.onComplete };
+    }
+  })();
+
+  return (
+    <div className="flex flex-col outline-none" tabIndex={-1}>
+      <DialogHeader className={step === "welcome" ? "px-6 pt-6 pb-3" : "px-5 pt-5"}>
+        {step === "welcome" ? (
+          <div className="flex items-center gap-4 pr-8">
+            <SynaraLogo aria-hidden className="size-9" />
+            <DialogTitle>{STEP_TITLES[step]}</DialogTitle>
+          </div>
+        ) : (
+          <>
+            <DialogTitle>{STEP_TITLES[step]}</DialogTitle>
+            <DialogDescription>{STEP_DESCRIPTIONS[step]}</DialogDescription>
+          </>
+        )}
+      </DialogHeader>
+      <DialogPanel className={step === "welcome" ? "px-6 pt-2 pb-5" : "px-5 py-4"}>
+        {step === "welcome" ? <WelcomeStep /> : null}
+        {step === "tour" ? <FeatureTourStep /> : null}
+        {step === "providers" ? <ProvidersStep /> : null}
+        {step === "theme" ? <ThemeStep /> : null}
+        {step === "project" ? (
+          <ProjectStep
+            results={projectResults}
+            onResult={(result) =>
+              setProjectResults((current) =>
+                current.some((entry) => entry.projectId === result.projectId)
+                  ? current
+                  : [...current, result],
+              )
+            }
+          />
+        ) : null}
+        {step === "done" ? (
+          <DoneStep
+            enabledProviders={providerSummary.enabled}
+            connectedProviders={providerSummary.connected}
+            projectsAdded={projectResults.length}
+          />
+        ) : null}
+      </DialogPanel>
+      <OnboardingStepFooter
+        step={step}
+        onBack={goBack}
+        onSkip={props.onComplete}
+        primaryLabel={primaryAction.label}
+        onPrimary={primaryAction.onPrimary}
+      />
+    </div>
+  );
+}
+
+export function OnboardingDialog(props: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onComplete: () => void;
+}) {
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogPopup showCloseButton className="max-w-2xl">
+        {/* Remount per open so a replay from Settings starts at the first step. */}
+        {props.open ? <OnboardingFlow onComplete={props.onComplete} /> : null}
+      </DialogPopup>
+    </Dialog>
+  );
+}

--- a/apps/web/src/onboarding/OnboardingDialog.tsx
+++ b/apps/web/src/onboarding/OnboardingDialog.tsx
@@ -4,7 +4,7 @@
 // Layer: Web UI overlay (mounted once from the root route)
 
 import { PROVIDER_DESCRIPTORS } from "@synara/shared/providerMetadata";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useAppSettings } from "~/appSettings";
 import { APP_BASE_NAME } from "~/branding";
@@ -21,11 +21,13 @@ import { useProviderStatusesForLocalConfig } from "~/hooks/useProviderStatusesFo
 import { findProviderStatus } from "~/lib/providerAvailability";
 import {
   classifyProviderSetup,
+  isOnboardingSetupStep,
   nextOnboardingStep,
   previousOnboardingStep,
   summarizeProviderSetup,
   type OnboardingStep,
 } from "./logic";
+import { useOnboardingDialogStore } from "./onboardingDialogStore";
 import { OnboardingStepFooter } from "./OnboardingStepFooter";
 import { DoneStep } from "./steps/DoneStep";
 import { FeatureTourStep } from "./steps/FeatureTourStep";
@@ -60,6 +62,12 @@ function OnboardingFlow(props: { onComplete: () => void }) {
 
   const goBack = () => setStep(previousOnboardingStep(step));
   const goNext = () => setStep(nextOnboardingStep(step));
+
+  // Once the user reaches a setup step the first-run gate must not auto-close the dialog.
+  const markEngaged = useOnboardingDialogStore((store) => store.markEngaged);
+  useEffect(() => {
+    if (isOnboardingSetupStep(step)) markEngaged();
+  }, [markEngaged, step]);
 
   const providerSummary = summarizeProviderSetup(
     PROVIDER_DESCRIPTORS.map((descriptor) => ({

--- a/apps/web/src/onboarding/OnboardingDialog.tsx
+++ b/apps/web/src/onboarding/OnboardingDialog.tsx
@@ -1,7 +1,10 @@
 // FILE: OnboardingDialog.tsx
-// Purpose: First-run welcome tour: intro → feature tour → providers → theme → project → done.
+// Purpose: First-run welcome tour: intro → feature tour → agents → appearance → project → done.
 //          Owns step navigation and the per-run results the final summary reads.
 // Layer: Web UI overlay (mounted once from the root route)
+//
+// The popup is a fixed 800×540 frame for every step so the window never resizes as the
+// user moves through the tour; hero steps (welcome, done) center their content in it.
 
 import { PROVIDER_DESCRIPTORS } from "@synara/shared/providerMetadata";
 import { useEffect, useState } from "react";
@@ -13,16 +16,21 @@ import {
   Dialog,
   DialogDescription,
   DialogHeader,
-  DialogPanel,
   DialogPopup,
   DialogTitle,
 } from "~/components/ui/dialog";
 import { useProviderStatusesForLocalConfig } from "~/hooks/useProviderStatusesForLocalConfig";
+import { useTheme } from "~/hooks/useTheme";
+import { CheckIcon } from "~/lib/icons";
 import { findProviderStatus } from "~/lib/providerAvailability";
+import { cn } from "~/lib/utils";
+import { CODE_THEME_OPTIONS } from "~/theme/theme.logic";
+import { ONBOARDING_INSET_CLASS_NAME } from "./layout";
 import {
   classifyProviderSetup,
   isOnboardingSetupStep,
   nextOnboardingStep,
+  ONBOARDING_STEPS,
   previousOnboardingStep,
   summarizeProviderSetup,
   type OnboardingStep,
@@ -45,20 +53,29 @@ const STEP_TITLES: Record<OnboardingStep, string> = {
   done: "You're all set",
 };
 
-const STEP_DESCRIPTIONS: Record<OnboardingStep, string> = {
-  welcome: "",
-  tour: "A quick look at the workspace before you set it up.",
-  providers: "Synara detected these runtimes on this machine. Uncheck any you do not want to use.",
-  theme: "You can change this anytime in Settings → Appearance.",
-  project: "Point Synara at a folder, preferably a Git repository.",
-  done: "Your agents, appearance, and first project are ready.",
+const STEP_DESCRIPTIONS: Record<Exclude<OnboardingStep, "done">, string> = {
+  welcome: "A local-first workspace for coding agents. Setup takes about a minute.",
+  tour: "",
+  providers: `Detected on this machine. Uncheck any you don't want ${APP_BASE_NAME} to use.`,
+  theme: "Applies live behind this window. Change it anytime in Settings → Appearance.",
+  project: `A project is a folder ${APP_BASE_NAME} works in. Git repositories unlock branches, worktrees, diffs and pull requests.`,
 };
+
+/** Welcome and Done are hero steps: centered header, no step counter, centered body. */
+function isHeroStep(step: OnboardingStep): boolean {
+  return step === "welcome" || step === "done";
+}
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
 
 function OnboardingFlow(props: { onComplete: () => void }) {
   const [step, setStep] = useState<OnboardingStep>("welcome");
   const [projectResults, setProjectResults] = useState<ReadonlyArray<OnboardingProjectResult>>([]);
   const { settings } = useAppSettings();
   const statuses = useProviderStatusesForLocalConfig();
+  const { activeTheme } = useTheme();
 
   const goBack = () => setStep(previousOnboardingStep(step));
   const goNext = () => setStep(nextOnboardingStep(step));
@@ -78,6 +95,20 @@ function OnboardingFlow(props: { onComplete: () => void }) {
       }),
     })),
   );
+  const themeLabel =
+    CODE_THEME_OPTIONS.find((option) => option.id === activeTheme.codeThemeId)?.label ??
+    activeTheme.codeThemeId;
+  const doneSummary = [
+    `${plural(providerSummary.connected, "agent")} connected`,
+    `${themeLabel} theme`,
+    projectResults.length > 0
+      ? `${plural(projectResults.length, "project")} added`
+      : "No project yet",
+  ].join(" · ");
+
+  const description = step === "done" ? doneSummary : STEP_DESCRIPTIONS[step];
+  const stepIndex = ONBOARDING_STEPS.indexOf(step);
+  const hero = isHeroStep(step);
 
   const primaryAction = (() => {
     switch (step) {
@@ -98,21 +129,42 @@ function OnboardingFlow(props: { onComplete: () => void }) {
   })();
 
   return (
-    <div className="flex flex-col outline-none" tabIndex={-1}>
-      <DialogHeader className={step === "welcome" ? "px-6 pt-6 pb-3" : "px-5 pt-5"}>
-        {step === "welcome" ? (
-          <div className="flex items-center gap-4 pr-8">
-            <SynaraLogo aria-hidden className="size-9" />
-            <DialogTitle>{STEP_TITLES[step]}</DialogTitle>
-          </div>
-        ) : (
-          <>
-            <DialogTitle>{STEP_TITLES[step]}</DialogTitle>
-            <DialogDescription>{STEP_DESCRIPTIONS[step]}</DialogDescription>
-          </>
+    <div className="flex min-h-0 flex-1 flex-col outline-none" tabIndex={-1}>
+      <DialogHeader
+        className={cn(
+          "gap-1.5 pt-8 pb-0",
+          ONBOARDING_INSET_CLASS_NAME,
+          hero && "items-center text-center",
         )}
+      >
+        {step === "welcome" ? <SynaraLogo aria-hidden className="mb-3.5 size-11" /> : null}
+        {step === "done" ? (
+          <span
+            aria-hidden
+            className="mb-3.5 flex size-11 items-center justify-center rounded-full bg-success/8 text-success dark:bg-success/16"
+          >
+            <CheckIcon className="size-5" />
+          </span>
+        ) : null}
+        {hero ? null : (
+          <span className="text-[length:var(--app-font-size-ui-sm,11px)] font-medium tracking-[0.04em] text-muted-foreground/70 uppercase">
+            Step {stepIndex + 1} of {ONBOARDING_STEPS.length}
+          </span>
+        )}
+        <DialogTitle className="text-[22px] tracking-[-0.01em]">{STEP_TITLES[step]}</DialogTitle>
+        {description ? (
+          <DialogDescription className="max-w-[560px] text-[length:var(--app-font-size-ui-lg,13px)] leading-normal">
+            {description}
+          </DialogDescription>
+        ) : null}
       </DialogHeader>
-      <DialogPanel className={step === "welcome" ? "px-6 pt-2 pb-5" : "px-5 py-4"}>
+      <div
+        className={cn(
+          "flex min-h-0 flex-1 flex-col overflow-y-auto pt-6",
+          ONBOARDING_INSET_CLASS_NAME,
+          hero && "justify-center pb-6",
+        )}
+      >
         {step === "welcome" ? <WelcomeStep /> : null}
         {step === "tour" ? <FeatureTourStep /> : null}
         {step === "providers" ? <ProvidersStep /> : null}
@@ -129,14 +181,8 @@ function OnboardingFlow(props: { onComplete: () => void }) {
             }
           />
         ) : null}
-        {step === "done" ? (
-          <DoneStep
-            enabledProviders={providerSummary.enabled}
-            connectedProviders={providerSummary.connected}
-            projectsAdded={projectResults.length}
-          />
-        ) : null}
-      </DialogPanel>
+        {step === "done" ? <DoneStep /> : null}
+      </div>
       <OnboardingStepFooter
         step={step}
         onBack={goBack}
@@ -155,7 +201,7 @@ export function OnboardingDialog(props: {
 }) {
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
-      <DialogPopup showCloseButton className="max-w-2xl">
+      <DialogPopup showCloseButton className="h-[540px] max-h-full max-w-[800px]">
         {/* Remount per open so a replay from Settings starts at the first step. */}
         {props.open ? <OnboardingFlow onComplete={props.onComplete} /> : null}
       </DialogPopup>

--- a/apps/web/src/onboarding/OnboardingStepFooter.tsx
+++ b/apps/web/src/onboarding/OnboardingStepFooter.tsx
@@ -20,6 +20,8 @@ export function OnboardingStepFooter(props: {
   onPrimary: () => void;
   primaryDisabled?: boolean;
   primaryBusy?: boolean;
+  /** Blocks Back and Skip as well as the primary (a non-abortable operation is running). */
+  navigationLocked?: boolean;
   /** Optional secondary action rendered next to the primary (e.g. "Skip for now"). */
   secondaryLabel?: string;
   onSecondary?: () => void;
@@ -58,7 +60,8 @@ export function OnboardingStepFooter(props: {
         {showSkip ? (
           <button
             type="button"
-            className="text-[length:var(--app-font-size-ui,12px)] text-muted-foreground transition-colors hover:text-foreground motion-reduce:transition-none"
+            disabled={props.navigationLocked}
+            className="text-[length:var(--app-font-size-ui,12px)] text-muted-foreground transition-colors hover:text-foreground disabled:opacity-60 motion-reduce:transition-none"
             onClick={props.onSkip}
           >
             Skip setup
@@ -70,6 +73,7 @@ export function OnboardingStepFooter(props: {
           variant="ghost"
           shape="capsule"
           className={FOOTER_BUTTON_CLASS_NAME}
+          disabled={props.navigationLocked}
           onClick={props.onBack}
         >
           Back
@@ -89,7 +93,7 @@ export function OnboardingStepFooter(props: {
         variant="prominent"
         shape="capsule"
         className={cn(FOOTER_BUTTON_CLASS_NAME, "hover:scale-100")}
-        disabled={props.primaryDisabled || props.primaryBusy}
+        disabled={props.primaryDisabled || props.primaryBusy || props.navigationLocked}
         onClick={props.onPrimary}
       >
         {props.primaryBusy ? "Working…" : props.primaryLabel}

--- a/apps/web/src/onboarding/OnboardingStepFooter.tsx
+++ b/apps/web/src/onboarding/OnboardingStepFooter.tsx
@@ -1,0 +1,73 @@
+// FILE: OnboardingStepFooter.tsx
+// Purpose: Shared footer for every welcome-tour step: progress dots, Skip, Back, primary.
+// Layer: Web UI component
+
+import { Button } from "~/components/ui/button";
+import { DialogFooter } from "~/components/ui/dialog";
+import { cn } from "~/lib/utils";
+import { ONBOARDING_STEPS, type OnboardingStep } from "./logic";
+
+export function OnboardingStepFooter(props: {
+  step: OnboardingStep;
+  onBack: () => void;
+  onSkip: () => void;
+  primaryLabel: string;
+  onPrimary: () => void;
+  primaryDisabled?: boolean;
+  primaryBusy?: boolean;
+  /** Optional secondary action rendered next to the primary (e.g. "Skip for now"). */
+  secondaryLabel?: string;
+  onSecondary?: () => void;
+}) {
+  const stepIndex = ONBOARDING_STEPS.indexOf(props.step);
+  return (
+    <DialogFooter className="items-center gap-2 border-t border-border/70 px-5 py-3">
+      <div className="flex flex-1 items-center gap-3">
+        <div
+          className="flex items-center gap-1.5"
+          role="progressbar"
+          aria-label="Setup progress"
+          aria-valuemin={1}
+          aria-valuemax={ONBOARDING_STEPS.length}
+          aria-valuenow={stepIndex + 1}
+        >
+          {ONBOARDING_STEPS.map((step, index) => (
+            <span
+              key={step}
+              className={cn(
+                "size-1.5 rounded-full transition-colors motion-reduce:transition-none",
+                index === stepIndex
+                  ? "bg-foreground"
+                  : index < stepIndex
+                    ? "bg-foreground/50"
+                    : "bg-muted-foreground/30",
+              )}
+            />
+          ))}
+        </div>
+        {props.step !== "done" ? (
+          <button
+            type="button"
+            className="text-xs text-muted-foreground transition-colors hover:text-foreground motion-reduce:transition-none"
+            onClick={props.onSkip}
+          >
+            Skip setup
+          </button>
+        ) : null}
+      </div>
+      {props.step !== "welcome" && props.step !== "done" ? (
+        <Button variant="ghost" onClick={props.onBack}>
+          Back
+        </Button>
+      ) : null}
+      {props.secondaryLabel && props.onSecondary ? (
+        <Button variant="outline" onClick={props.onSecondary}>
+          {props.secondaryLabel}
+        </Button>
+      ) : null}
+      <Button disabled={props.primaryDisabled || props.primaryBusy} onClick={props.onPrimary}>
+        {props.primaryBusy ? "Working…" : props.primaryLabel}
+      </Button>
+    </DialogFooter>
+  );
+}

--- a/apps/web/src/onboarding/OnboardingStepFooter.tsx
+++ b/apps/web/src/onboarding/OnboardingStepFooter.tsx
@@ -1,11 +1,16 @@
 // FILE: OnboardingStepFooter.tsx
 // Purpose: Shared footer for every welcome-tour step: progress dots, Skip, Back, primary.
+//          No divider — space alone separates the footer from the body.
 // Layer: Web UI component
 
 import { Button } from "~/components/ui/button";
 import { DialogFooter } from "~/components/ui/dialog";
 import { cn } from "~/lib/utils";
+import { ONBOARDING_INSET_CLASS_NAME } from "./layout";
 import { ONBOARDING_STEPS, type OnboardingStep } from "./logic";
+
+const FOOTER_BUTTON_CLASS_NAME =
+  "px-4 text-[length:var(--app-font-size-ui-lg,13px)] sm:text-[length:var(--app-font-size-ui-lg,13px)]";
 
 export function OnboardingStepFooter(props: {
   step: OnboardingStep;
@@ -20,9 +25,14 @@ export function OnboardingStepFooter(props: {
   onSecondary?: () => void;
 }) {
   const stepIndex = ONBOARDING_STEPS.indexOf(props.step);
+  const showBack = props.step !== "welcome" && props.step !== "done";
+  const showSkip = props.step !== "done";
   return (
-    <DialogFooter className="items-center gap-2 border-t border-border/70 px-5 py-3">
-      <div className="flex flex-1 items-center gap-3">
+    <DialogFooter
+      variant="bare"
+      className={cn("items-center gap-2 pt-5 pb-6", ONBOARDING_INSET_CLASS_NAME)}
+    >
+      <div className="flex flex-1 items-center gap-4">
         <div
           className="flex items-center gap-1.5"
           role="progressbar"
@@ -45,27 +55,43 @@ export function OnboardingStepFooter(props: {
             />
           ))}
         </div>
-        {props.step !== "done" ? (
+        {showSkip ? (
           <button
             type="button"
-            className="text-xs text-muted-foreground transition-colors hover:text-foreground motion-reduce:transition-none"
+            className="text-[length:var(--app-font-size-ui,12px)] text-muted-foreground transition-colors hover:text-foreground motion-reduce:transition-none"
             onClick={props.onSkip}
           >
             Skip setup
           </button>
         ) : null}
       </div>
-      {props.step !== "welcome" && props.step !== "done" ? (
-        <Button variant="ghost" onClick={props.onBack}>
+      {showBack ? (
+        <Button
+          variant="ghost"
+          shape="capsule"
+          className={FOOTER_BUTTON_CLASS_NAME}
+          onClick={props.onBack}
+        >
           Back
         </Button>
       ) : null}
       {props.secondaryLabel && props.onSecondary ? (
-        <Button variant="outline" onClick={props.onSecondary}>
+        <Button
+          variant="outline"
+          shape="capsule"
+          className={FOOTER_BUTTON_CLASS_NAME}
+          onClick={props.onSecondary}
+        >
           {props.secondaryLabel}
         </Button>
       ) : null}
-      <Button disabled={props.primaryDisabled || props.primaryBusy} onClick={props.onPrimary}>
+      <Button
+        variant="prominent"
+        shape="capsule"
+        className={cn(FOOTER_BUTTON_CLASS_NAME, "hover:scale-100")}
+        disabled={props.primaryDisabled || props.primaryBusy}
+        onClick={props.onPrimary}
+      >
         {props.primaryBusy ? "Working…" : props.primaryLabel}
       </Button>
     </DialogFooter>

--- a/apps/web/src/onboarding/layout.ts
+++ b/apps/web/src/onboarding/layout.ts
@@ -1,0 +1,9 @@
+// FILE: layout.ts
+// Purpose: Layout tokens shared by the welcome tour's shell, footer, and steps.
+// Layer: Web UI constants (no React)
+
+/** Horizontal inset shared by header, body and footer of the onboarding popup. */
+export const ONBOARDING_INSET_CLASS_NAME = "px-8";
+
+/** Quiet bordered tile used for the welcome points and provider cards. */
+export const ONBOARDING_TILE_CLASS_NAME = "rounded-xl border border-foreground/7 bg-popover";

--- a/apps/web/src/onboarding/logic.test.ts
+++ b/apps/web/src/onboarding/logic.test.ts
@@ -6,6 +6,7 @@ import {
   isOnboardingSetupStep,
   nextOnboardingStep,
   previousOnboardingStep,
+  resolveLocalOnboardingCompletion,
   resolveOnboardingCompletionToReconcile,
   resolveOnboardingGate,
   summarizeProviderSetup,
@@ -75,6 +76,29 @@ describe("resolveOnboardingGate", () => {
   it("is re-evaluated, not latched: a later non-empty snapshot flips show to hidden", () => {
     expect(resolveOnboardingGate(GATE_BASE)).toBe("show");
     expect(resolveOnboardingGate({ ...GATE_BASE, projectCount: 2 })).toBe("hidden");
+  });
+});
+
+describe("resolveLocalOnboardingCompletion", () => {
+  it("returns nothing without a local marker", () => {
+    expect(
+      resolveLocalOnboardingCompletion({ completedAt: null, installationKey: "/a" }, "/a"),
+    ).toBeNull();
+  });
+
+  it("only counts a marker recorded against the current installation", () => {
+    const local = { completedAt: COMPLETED_AT, installationKey: "/home/a/.synara/worktrees" };
+    expect(resolveLocalOnboardingCompletion(local, "/home/a/.synara/worktrees")).toBe(COMPLETED_AT);
+    expect(resolveLocalOnboardingCompletion(local, "/home/b/.synara/worktrees")).toBeNull();
+  });
+
+  it("falls back to the marker when either installation identity is unknown", () => {
+    expect(
+      resolveLocalOnboardingCompletion({ completedAt: COMPLETED_AT, installationKey: "/a" }, null),
+    ).toBe(COMPLETED_AT);
+    expect(
+      resolveLocalOnboardingCompletion({ completedAt: COMPLETED_AT, installationKey: null }, "/a"),
+    ).toBe(COMPLETED_AT);
   });
 });
 

--- a/apps/web/src/onboarding/logic.test.ts
+++ b/apps/web/src/onboarding/logic.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ONBOARDING_STEPS,
+  classifyProviderSetup,
+  nextOnboardingStep,
+  previousOnboardingStep,
+  resolveOnboardingGate,
+  summarizeProviderSetup,
+  toggleSelection,
+} from "./logic";
+
+const GATE_BASE = {
+  threadsHydrated: true,
+  settingsSettled: true,
+  settingsAvailable: true,
+  projectCount: 0,
+  serverCompletedAt: null,
+  localCompletedAt: null,
+} as const;
+
+describe("onboarding steps", () => {
+  it("runs intro → tour → providers → theme → project → done", () => {
+    expect(ONBOARDING_STEPS).toEqual(["welcome", "tour", "providers", "theme", "project", "done"]);
+  });
+
+  it("clamps navigation at both ends", () => {
+    expect(nextOnboardingStep("welcome")).toBe("tour");
+    expect(nextOnboardingStep("done")).toBe("done");
+    expect(previousOnboardingStep("tour")).toBe("welcome");
+    expect(previousOnboardingStep("welcome")).toBe("welcome");
+  });
+});
+
+describe("resolveOnboardingGate", () => {
+  it("stays pending until projects and settings have loaded", () => {
+    expect(resolveOnboardingGate({ ...GATE_BASE, threadsHydrated: false })).toBe("pending");
+    expect(resolveOnboardingGate({ ...GATE_BASE, settingsSettled: false })).toBe("pending");
+  });
+
+  it("shows on a fresh install with no ordinary projects", () => {
+    expect(resolveOnboardingGate(GATE_BASE)).toBe("show");
+  });
+
+  it("hides once any ordinary project exists", () => {
+    expect(resolveOnboardingGate({ ...GATE_BASE, projectCount: 1 })).toBe("hidden");
+  });
+
+  it("prefers the server marker when settings are readable", () => {
+    expect(
+      resolveOnboardingGate({ ...GATE_BASE, serverCompletedAt: "2026-09-07T00:00:00.000Z" }),
+    ).toBe("hidden");
+    // A stale local marker must not suppress the tour on a reconfigured server.
+    expect(
+      resolveOnboardingGate({ ...GATE_BASE, localCompletedAt: "2026-09-07T00:00:00.000Z" }),
+    ).toBe("show");
+  });
+
+  it("falls back to the local marker when server settings are unavailable", () => {
+    expect(
+      resolveOnboardingGate({
+        ...GATE_BASE,
+        settingsAvailable: false,
+        localCompletedAt: "2026-09-07T00:00:00.000Z",
+      }),
+    ).toBe("hidden");
+    expect(resolveOnboardingGate({ ...GATE_BASE, settingsAvailable: false })).toBe("show");
+  });
+});
+
+describe("classifyProviderSetup", () => {
+  it("treats a disabled provider as disabled regardless of detection", () => {
+    expect(
+      classifyProviderSetup({
+        status: { available: true, authStatus: "authenticated" },
+        disabled: true,
+      }),
+    ).toBe("disabled");
+  });
+
+  it("reports missing or unavailable binaries as not installed", () => {
+    expect(classifyProviderSetup({ status: null, disabled: false })).toBe("not-installed");
+    expect(
+      classifyProviderSetup({
+        status: { available: false, authStatus: "unknown" },
+        disabled: false,
+      }),
+    ).toBe("not-installed");
+  });
+
+  it("only asks for sign-in when auth is known to be missing", () => {
+    expect(
+      classifyProviderSetup({
+        status: { available: true, authStatus: "unauthenticated" },
+        disabled: false,
+      }),
+    ).toBe("needs-sign-in");
+    expect(
+      classifyProviderSetup({
+        status: { available: true, authStatus: "unknown" },
+        disabled: false,
+      }),
+    ).toBe("connected");
+    expect(
+      classifyProviderSetup({
+        status: { available: true, authStatus: "authenticated" },
+        disabled: false,
+      }),
+    ).toBe("connected");
+  });
+});
+
+describe("summarizeProviderSetup", () => {
+  it("counts each state and excludes disabled providers from enabled", () => {
+    expect(
+      summarizeProviderSetup([
+        { provider: "codex", state: "connected" },
+        { provider: "claudeAgent", state: "needs-sign-in" },
+        { provider: "cursor", state: "not-installed" },
+        { provider: "pi", state: "disabled" },
+      ]),
+    ).toEqual({ enabled: 3, connected: 1, needsSignIn: 1, notInstalled: 1 });
+  });
+});
+
+describe("toggleSelection", () => {
+  it("adds and removes without mutating the input", () => {
+    const initial: ReadonlySet<string> = new Set(["a"]);
+    const added = toggleSelection(initial, "b");
+    expect([...added]).toEqual(["a", "b"]);
+    expect([...initial]).toEqual(["a"]);
+    expect([...toggleSelection(added, "a")]).toEqual(["b"]);
+  });
+});

--- a/apps/web/src/onboarding/logic.test.ts
+++ b/apps/web/src/onboarding/logic.test.ts
@@ -3,20 +3,33 @@ import { describe, expect, it } from "vitest";
 import {
   ONBOARDING_STEPS,
   classifyProviderSetup,
+  isOnboardingSetupStep,
   nextOnboardingStep,
   previousOnboardingStep,
+  resolveOnboardingCompletionToReconcile,
   resolveOnboardingGate,
   summarizeProviderSetup,
   toggleSelection,
 } from "./logic";
 
+const COMPLETED_AT = "2026-09-07T00:00:00.000Z";
+const NOW = "2026-09-08T00:00:00.000Z";
+
 const GATE_BASE = {
   threadsHydrated: true,
   settingsSettled: true,
+  projectCount: 0,
+  serverCompletedAt: null,
+  localCompletedAt: null,
+} as const;
+
+const RECONCILE_BASE = {
+  threadsHydrated: true,
   settingsAvailable: true,
   projectCount: 0,
   serverCompletedAt: null,
   localCompletedAt: null,
+  now: NOW,
 } as const;
 
 describe("onboarding steps", () => {
@@ -29,6 +42,13 @@ describe("onboarding steps", () => {
     expect(nextOnboardingStep("done")).toBe("done");
     expect(previousOnboardingStep("tour")).toBe("welcome");
     expect(previousOnboardingStep("welcome")).toBe("welcome");
+  });
+
+  it("treats everything after the tour as a setup step", () => {
+    expect(isOnboardingSetupStep("welcome")).toBe(false);
+    expect(isOnboardingSetupStep("tour")).toBe(false);
+    expect(isOnboardingSetupStep("providers")).toBe(true);
+    expect(isOnboardingSetupStep("done")).toBe(true);
   });
 });
 
@@ -46,25 +66,58 @@ describe("resolveOnboardingGate", () => {
     expect(resolveOnboardingGate({ ...GATE_BASE, projectCount: 1 })).toBe("hidden");
   });
 
-  it("prefers the server marker when settings are readable", () => {
-    expect(
-      resolveOnboardingGate({ ...GATE_BASE, serverCompletedAt: "2026-09-07T00:00:00.000Z" }),
-    ).toBe("hidden");
-    // A stale local marker must not suppress the tour on a reconfigured server.
-    expect(
-      resolveOnboardingGate({ ...GATE_BASE, localCompletedAt: "2026-09-07T00:00:00.000Z" }),
-    ).toBe("show");
+  it("hides when either completion marker is set", () => {
+    expect(resolveOnboardingGate({ ...GATE_BASE, serverCompletedAt: COMPLETED_AT })).toBe("hidden");
+    // A local marker covers a completion whose server write failed.
+    expect(resolveOnboardingGate({ ...GATE_BASE, localCompletedAt: COMPLETED_AT })).toBe("hidden");
   });
 
-  it("falls back to the local marker when server settings are unavailable", () => {
+  it("is re-evaluated, not latched: a later non-empty snapshot flips show to hidden", () => {
+    expect(resolveOnboardingGate(GATE_BASE)).toBe("show");
+    expect(resolveOnboardingGate({ ...GATE_BASE, projectCount: 2 })).toBe("hidden");
+  });
+});
+
+describe("resolveOnboardingCompletionToReconcile", () => {
+  it("does nothing before hydration, without readable settings, or once the server has a marker", () => {
     expect(
-      resolveOnboardingGate({
-        ...GATE_BASE,
-        settingsAvailable: false,
-        localCompletedAt: "2026-09-07T00:00:00.000Z",
+      resolveOnboardingCompletionToReconcile({
+        ...RECONCILE_BASE,
+        threadsHydrated: false,
+        localCompletedAt: COMPLETED_AT,
       }),
-    ).toBe("hidden");
-    expect(resolveOnboardingGate({ ...GATE_BASE, settingsAvailable: false })).toBe("show");
+    ).toBeNull();
+    expect(
+      resolveOnboardingCompletionToReconcile({
+        ...RECONCILE_BASE,
+        settingsAvailable: false,
+        localCompletedAt: COMPLETED_AT,
+      }),
+    ).toBeNull();
+    expect(
+      resolveOnboardingCompletionToReconcile({
+        ...RECONCILE_BASE,
+        serverCompletedAt: COMPLETED_AT,
+        localCompletedAt: COMPLETED_AT,
+        projectCount: 3,
+      }),
+    ).toBeNull();
+  });
+
+  it("replays a local completion whose server write failed", () => {
+    expect(
+      resolveOnboardingCompletionToReconcile({ ...RECONCILE_BASE, localCompletedAt: COMPLETED_AT }),
+    ).toBe(COMPLETED_AT);
+  });
+
+  it("exempts an installation that predates the tour", () => {
+    expect(resolveOnboardingCompletionToReconcile({ ...RECONCILE_BASE, projectCount: 1 })).toBe(
+      NOW,
+    );
+  });
+
+  it("writes nothing on a genuine fresh install", () => {
+    expect(resolveOnboardingCompletionToReconcile(RECONCILE_BASE)).toBeNull();
   });
 });
 

--- a/apps/web/src/onboarding/logic.test.ts
+++ b/apps/web/src/onboarding/logic.test.ts
@@ -17,6 +17,7 @@ const COMPLETED_AT = "2026-09-07T00:00:00.000Z";
 const NOW = "2026-09-08T00:00:00.000Z";
 
 const GATE_BASE = {
+  installationKeyStatus: "success",
   threadsHydrated: true,
   settingsSettled: true,
   projectCount: 0,
@@ -59,6 +60,17 @@ describe("resolveOnboardingGate", () => {
     expect(resolveOnboardingGate({ ...GATE_BASE, settingsSettled: false })).toBe("pending");
   });
 
+  it("waits for the installation identity before offering first-run completion", () => {
+    expect(resolveOnboardingGate({ ...GATE_BASE, installationKeyStatus: "pending" })).toBe(
+      "pending",
+    );
+  });
+
+  it("leaves the app usable after config failure and offers the tour after recovery", () => {
+    expect(resolveOnboardingGate({ ...GATE_BASE, installationKeyStatus: "error" })).toBe("hidden");
+    expect(resolveOnboardingGate(GATE_BASE)).toBe("show");
+  });
+
   it("shows on a fresh install with no ordinary projects", () => {
     expect(resolveOnboardingGate(GATE_BASE)).toBe("show");
   });
@@ -92,17 +104,28 @@ describe("resolveLocalOnboardingCompletion", () => {
     expect(resolveLocalOnboardingCompletion(local, "/home/b/.synara/worktrees")).toBeNull();
   });
 
-  it("falls back to the marker when either installation identity is unknown", () => {
+  it("ignores a marker when either installation identity is unknown", () => {
     expect(
       resolveLocalOnboardingCompletion({ completedAt: COMPLETED_AT, installationKey: "/a" }, null),
-    ).toBe(COMPLETED_AT);
+    ).toBeNull();
     expect(
       resolveLocalOnboardingCompletion({ completedAt: COMPLETED_AT, installationKey: null }, "/a"),
-    ).toBe(COMPLETED_AT);
+    ).toBeNull();
   });
 });
 
 describe("resolveOnboardingCompletionToReconcile", () => {
+  it("does not copy an unscoped completion onto a fresh installation", () => {
+    const localCompletedAt = resolveLocalOnboardingCompletion(
+      { completedAt: COMPLETED_AT, installationKey: null },
+      "/new-installation/worktrees",
+    );
+    expect(
+      resolveOnboardingCompletionToReconcile({ ...RECONCILE_BASE, localCompletedAt }),
+    ).toBeNull();
+    expect(resolveOnboardingGate({ ...GATE_BASE, localCompletedAt })).toBe("show");
+  });
+
   it("does nothing before hydration, without readable settings, or once the server has a marker", () => {
     expect(
       resolveOnboardingCompletionToReconcile({

--- a/apps/web/src/onboarding/logic.ts
+++ b/apps/web/src/onboarding/logic.ts
@@ -2,7 +2,8 @@
 // Purpose: Pure step, gate, and provider-classification rules for the first-run welcome tour.
 // Layer: Web domain helper (no React, no I/O)
 // Exports: ONBOARDING_STEPS, nextOnboardingStep, previousOnboardingStep, resolveOnboardingGate,
-//          classifyProviderSetup, summarizeProviderSetup, toggleSelection
+//          resolveOnboardingCompletionToReconcile, classifyProviderSetup, summarizeProviderSetup,
+//          toggleSelection
 
 import type { ProviderKind, ServerProviderStatus } from "@synara/contracts";
 
@@ -26,6 +27,11 @@ export function previousOnboardingStep(step: OnboardingStep): OnboardingStep {
   return ONBOARDING_STEPS[Math.max(index - 1, 0)] ?? "welcome";
 }
 
+/** Steps where the user has started making setup choices; the tour must not auto-close past here. */
+export function isOnboardingSetupStep(step: OnboardingStep): boolean {
+  return step !== "welcome" && step !== "tour";
+}
+
 export type OnboardingGate = "pending" | "show" | "hidden";
 
 export interface OnboardingGateInputs {
@@ -33,8 +39,6 @@ export interface OnboardingGateInputs {
   readonly threadsHydrated: boolean;
   /** The server settings query has settled (success or error). */
   readonly settingsSettled: boolean;
-  /** The server settings query succeeded, so `serverCompletedAt` is authoritative. */
-  readonly settingsAvailable: boolean;
   /** Count of ordinary (non-container) projects. */
   readonly projectCount: number;
   readonly serverCompletedAt: string | null;
@@ -42,19 +46,51 @@ export interface OnboardingGateInputs {
 }
 
 /**
- * The tour shows exactly once: on a fresh install (no ordinary projects) that has not
- * recorded completion. The server marker wins whenever it is readable so a cleared
- * browser profile cannot replay setup on an already configured machine; the local
- * marker only covers the case where server settings are unreachable.
+ * The tour shows on a fresh install (no ordinary projects) that has not recorded
+ * completion anywhere. Either marker counts: the server one is durable across browser
+ * profiles, the local one covers a completion whose server write failed and is
+ * reconciled back to the server on the next launch (see
+ * `resolveOnboardingCompletionToReconcile`).
+ *
+ * The result is *not* authoritative until the inputs are: callers re-evaluate as
+ * snapshots and settings arrive instead of latching the first non-pending answer.
  */
 export function resolveOnboardingGate(input: OnboardingGateInputs): OnboardingGate {
   if (!input.threadsHydrated || !input.settingsSettled) {
     return "pending";
   }
-  const alreadyCompleted = input.settingsAvailable
-    ? input.serverCompletedAt !== null
-    : input.localCompletedAt !== null;
-  return !alreadyCompleted && input.projectCount === 0 ? "show" : "hidden";
+  const completed = input.serverCompletedAt !== null || input.localCompletedAt !== null;
+  return !completed && input.projectCount === 0 ? "show" : "hidden";
+}
+
+export interface OnboardingReconcileInputs {
+  readonly threadsHydrated: boolean;
+  /** Server settings are readable, so a null marker is a real absence, not a fetch error. */
+  readonly settingsAvailable: boolean;
+  readonly projectCount: number;
+  readonly serverCompletedAt: string | null;
+  readonly localCompletedAt: string | null;
+  /** ISO timestamp used when an existing install is exempted without a local marker. */
+  readonly now: string;
+}
+
+/**
+ * Returns the completion timestamp to write to the server, or null when nothing is owed.
+ * Two cases need the marker persisted after the fact:
+ * - a completion whose server write failed (only the local marker exists), and
+ * - an installation that predates the tour (projects exist, no marker anywhere), which
+ *   must never see the "first run" tour just because its last project is later removed.
+ */
+export function resolveOnboardingCompletionToReconcile(
+  input: OnboardingReconcileInputs,
+): string | null {
+  if (!input.threadsHydrated || !input.settingsAvailable || input.serverCompletedAt !== null) {
+    return null;
+  }
+  if (input.localCompletedAt !== null) {
+    return input.localCompletedAt;
+  }
+  return input.projectCount > 0 ? input.now : null;
 }
 
 export type ProviderSetupState = "connected" | "needs-sign-in" | "not-installed" | "disabled";

--- a/apps/web/src/onboarding/logic.ts
+++ b/apps/web/src/onboarding/logic.ts
@@ -2,8 +2,8 @@
 // Purpose: Pure step, gate, and provider-classification rules for the first-run welcome tour.
 // Layer: Web domain helper (no React, no I/O)
 // Exports: ONBOARDING_STEPS, nextOnboardingStep, previousOnboardingStep, resolveOnboardingGate,
-//          resolveOnboardingCompletionToReconcile, classifyProviderSetup, summarizeProviderSetup,
-//          toggleSelection
+//          resolveOnboardingCompletionToReconcile, resolveLocalOnboardingCompletion,
+//          classifyProviderSetup, summarizeProviderSetup, toggleSelection
 
 import type { ProviderKind, ServerProviderStatus } from "@synara/contracts";
 
@@ -32,6 +32,32 @@ export function isOnboardingSetupStep(step: OnboardingStep): boolean {
   return step !== "welcome" && step !== "tour";
 }
 
+export interface LocalOnboardingCompletion {
+  readonly completedAt: string | null;
+  /**
+   * Identity of the server installation the completion was recorded against (its
+   * worktrees directory). A browser origin can be pointed at a different server state or
+   * home directory later; a marker from another installation must not hide its tour.
+   */
+  readonly installationKey: string | null;
+}
+
+/**
+ * The local marker is a pending write for one installation, not unconditional completion.
+ * It only counts when it was recorded against the current server (or when the server's
+ * identity is unknown because its config could not be read).
+ */
+export function resolveLocalOnboardingCompletion(
+  local: LocalOnboardingCompletion,
+  currentInstallationKey: string | null,
+): string | null {
+  if (local.completedAt === null) return null;
+  if (currentInstallationKey === null || local.installationKey === null) {
+    return local.completedAt;
+  }
+  return local.installationKey === currentInstallationKey ? local.completedAt : null;
+}
+
 export type OnboardingGate = "pending" | "show" | "hidden";
 
 export interface OnboardingGateInputs {
@@ -42,6 +68,7 @@ export interface OnboardingGateInputs {
   /** Count of ordinary (non-container) projects. */
   readonly projectCount: number;
   readonly serverCompletedAt: string | null;
+  /** Already scoped to this installation via `resolveLocalOnboardingCompletion`. */
   readonly localCompletedAt: string | null;
 }
 

--- a/apps/web/src/onboarding/logic.ts
+++ b/apps/web/src/onboarding/logic.ts
@@ -44,8 +44,7 @@ export interface LocalOnboardingCompletion {
 
 /**
  * The local marker is a pending write for one installation, not unconditional completion.
- * It only counts when it was recorded against the current server (or when the server's
- * identity is unknown because its config could not be read).
+ * It only counts when both identities are known and match the current server.
  */
 export function resolveLocalOnboardingCompletion(
   local: LocalOnboardingCompletion,
@@ -53,7 +52,7 @@ export function resolveLocalOnboardingCompletion(
 ): string | null {
   if (local.completedAt === null) return null;
   if (currentInstallationKey === null || local.installationKey === null) {
-    return local.completedAt;
+    return null;
   }
   return local.installationKey === currentInstallationKey ? local.completedAt : null;
 }
@@ -61,6 +60,8 @@ export function resolveLocalOnboardingCompletion(
 export type OnboardingGate = "pending" | "show" | "hidden";
 
 export interface OnboardingGateInputs {
+  /** Wait for an installation identity; config failures defer the tour without blocking the app. */
+  readonly installationKeyStatus: "pending" | "success" | "error";
   /** Local project state has been hydrated from the server at least once. */
   readonly threadsHydrated: boolean;
   /** The server settings query has settled (success or error). */
@@ -83,9 +84,14 @@ export interface OnboardingGateInputs {
  * snapshots and settings arrive instead of latching the first non-pending answer.
  */
 export function resolveOnboardingGate(input: OnboardingGateInputs): OnboardingGate {
-  if (!input.threadsHydrated || !input.settingsSettled) {
+  if (
+    input.installationKeyStatus === "pending" ||
+    !input.threadsHydrated ||
+    !input.settingsSettled
+  ) {
     return "pending";
   }
+  if (input.installationKeyStatus === "error") return "hidden";
   const completed = input.serverCompletedAt !== null || input.localCompletedAt !== null;
   return !completed && input.projectCount === 0 ? "show" : "hidden";
 }

--- a/apps/web/src/onboarding/logic.ts
+++ b/apps/web/src/onboarding/logic.ts
@@ -1,0 +1,104 @@
+// FILE: logic.ts
+// Purpose: Pure step, gate, and provider-classification rules for the first-run welcome tour.
+// Layer: Web domain helper (no React, no I/O)
+// Exports: ONBOARDING_STEPS, nextOnboardingStep, previousOnboardingStep, resolveOnboardingGate,
+//          classifyProviderSetup, summarizeProviderSetup, toggleSelection
+
+import type { ProviderKind, ServerProviderStatus } from "@synara/contracts";
+
+export const ONBOARDING_STEPS = [
+  "welcome",
+  "tour",
+  "providers",
+  "theme",
+  "project",
+  "done",
+] as const;
+export type OnboardingStep = (typeof ONBOARDING_STEPS)[number];
+
+export function nextOnboardingStep(step: OnboardingStep): OnboardingStep {
+  const index = ONBOARDING_STEPS.indexOf(step);
+  return ONBOARDING_STEPS[Math.min(index + 1, ONBOARDING_STEPS.length - 1)] ?? "done";
+}
+
+export function previousOnboardingStep(step: OnboardingStep): OnboardingStep {
+  const index = ONBOARDING_STEPS.indexOf(step);
+  return ONBOARDING_STEPS[Math.max(index - 1, 0)] ?? "welcome";
+}
+
+export type OnboardingGate = "pending" | "show" | "hidden";
+
+export interface OnboardingGateInputs {
+  /** Local project state has been hydrated from the server at least once. */
+  readonly threadsHydrated: boolean;
+  /** The server settings query has settled (success or error). */
+  readonly settingsSettled: boolean;
+  /** The server settings query succeeded, so `serverCompletedAt` is authoritative. */
+  readonly settingsAvailable: boolean;
+  /** Count of ordinary (non-container) projects. */
+  readonly projectCount: number;
+  readonly serverCompletedAt: string | null;
+  readonly localCompletedAt: string | null;
+}
+
+/**
+ * The tour shows exactly once: on a fresh install (no ordinary projects) that has not
+ * recorded completion. The server marker wins whenever it is readable so a cleared
+ * browser profile cannot replay setup on an already configured machine; the local
+ * marker only covers the case where server settings are unreachable.
+ */
+export function resolveOnboardingGate(input: OnboardingGateInputs): OnboardingGate {
+  if (!input.threadsHydrated || !input.settingsSettled) {
+    return "pending";
+  }
+  const alreadyCompleted = input.settingsAvailable
+    ? input.serverCompletedAt !== null
+    : input.localCompletedAt !== null;
+  return !alreadyCompleted && input.projectCount === 0 ? "show" : "hidden";
+}
+
+export type ProviderSetupState = "connected" | "needs-sign-in" | "not-installed" | "disabled";
+
+export function classifyProviderSetup(input: {
+  readonly status: Pick<ServerProviderStatus, "available" | "authStatus"> | null | undefined;
+  readonly disabled: boolean;
+}): ProviderSetupState {
+  if (input.disabled) return "disabled";
+  if (!input.status || !input.status.available) return "not-installed";
+  // Providers whose auth is not probed report "unknown"; treat a detected binary as
+  // usable rather than nagging for a sign-in Synara cannot verify.
+  return input.status.authStatus === "unauthenticated" ? "needs-sign-in" : "connected";
+}
+
+export interface ProviderSetupSummary {
+  readonly enabled: number;
+  readonly connected: number;
+  readonly needsSignIn: number;
+  readonly notInstalled: number;
+}
+
+export function summarizeProviderSetup(
+  states: ReadonlyArray<{ readonly provider: ProviderKind; readonly state: ProviderSetupState }>,
+): ProviderSetupSummary {
+  let enabled = 0;
+  let connected = 0;
+  let needsSignIn = 0;
+  let notInstalled = 0;
+  for (const entry of states) {
+    if (entry.state !== "disabled") enabled += 1;
+    if (entry.state === "connected") connected += 1;
+    if (entry.state === "needs-sign-in") needsSignIn += 1;
+    if (entry.state === "not-installed") notInstalled += 1;
+  }
+  return { enabled, connected, needsSignIn, notInstalled };
+}
+
+export function toggleSelection<T>(selection: ReadonlySet<T>, id: T): ReadonlySet<T> {
+  const next = new Set(selection);
+  if (next.has(id)) {
+    next.delete(id);
+  } else {
+    next.add(id);
+  }
+  return next;
+}

--- a/apps/web/src/onboarding/onboardingDialogStore.ts
+++ b/apps/web/src/onboarding/onboardingDialogStore.ts
@@ -1,0 +1,18 @@
+// FILE: onboardingDialogStore.ts
+// Purpose: Imperative "open the welcome tour" signal so Settings can replay it without
+//          threading callbacks through the router tree.
+// Layer: Web UI store
+
+import { create } from "zustand";
+
+interface OnboardingDialogStore {
+  isOpen: boolean;
+  openDialog: () => void;
+  setOpen: (open: boolean) => void;
+}
+
+export const useOnboardingDialogStore = create<OnboardingDialogStore>((set) => ({
+  isOpen: false,
+  openDialog: () => set({ isOpen: true }),
+  setOpen: (open) => set({ isOpen: open }),
+}));

--- a/apps/web/src/onboarding/onboardingDialogStore.ts
+++ b/apps/web/src/onboarding/onboardingDialogStore.ts
@@ -9,6 +9,11 @@ export type OnboardingOpenReason = "first-run" | "replay";
 
 interface OnboardingDialogStore {
   isOpen: boolean;
+  /**
+   * True once the first-run gate has produced a non-pending answer at least once. Other
+   * startup dialogs (AppSnap's announcement) wait for this so two modals never stack.
+   */
+  startupGateSettled: boolean;
   /** Why the dialog is open; null when closed. */
   openReason: OnboardingOpenReason | null;
   /**
@@ -23,14 +28,17 @@ interface OnboardingDialogStore {
   openDialog: () => void;
   close: () => void;
   markEngaged: () => void;
+  markStartupGateSettled: () => void;
 }
 
 export const useOnboardingDialogStore = create<OnboardingDialogStore>((set) => ({
   isOpen: false,
+  startupGateSettled: false,
   openReason: null,
   engaged: false,
   open: (reason) => set({ isOpen: true, openReason: reason, engaged: false }),
   openDialog: () => set({ isOpen: true, openReason: "replay", engaged: false }),
   close: () => set({ isOpen: false, openReason: null, engaged: false }),
   markEngaged: () => set({ engaged: true }),
+  markStartupGateSettled: () => set({ startupGateSettled: true }),
 }));

--- a/apps/web/src/onboarding/onboardingDialogStore.ts
+++ b/apps/web/src/onboarding/onboardingDialogStore.ts
@@ -1,18 +1,36 @@
 // FILE: onboardingDialogStore.ts
-// Purpose: Imperative "open the welcome tour" signal so Settings can replay it without
-//          threading callbacks through the router tree.
+// Purpose: Open/close state for the welcome tour shared between the first-run gate, the
+//          Settings "replay" button, and the dialog itself.
 // Layer: Web UI store
 
 import { create } from "zustand";
 
+export type OnboardingOpenReason = "first-run" | "replay";
+
 interface OnboardingDialogStore {
   isOpen: boolean;
+  /** Why the dialog is open; null when closed. */
+  openReason: OnboardingOpenReason | null;
+  /**
+   * True once the user reached a setup step. A first-run dialog opened from a
+   * provisional (possibly transient) empty snapshot may be auto-closed when later
+   * authoritative data proves the install is not new, but never once the user has
+   * started making choices in it.
+   */
+  engaged: boolean;
+  open: (reason: OnboardingOpenReason) => void;
+  /** Settings → "Open welcome tour". */
   openDialog: () => void;
-  setOpen: (open: boolean) => void;
+  close: () => void;
+  markEngaged: () => void;
 }
 
 export const useOnboardingDialogStore = create<OnboardingDialogStore>((set) => ({
   isOpen: false,
-  openDialog: () => set({ isOpen: true }),
-  setOpen: (open) => set({ isOpen: open }),
+  openReason: null,
+  engaged: false,
+  open: (reason) => set({ isOpen: true, openReason: reason, engaged: false }),
+  openDialog: () => set({ isOpen: true, openReason: "replay", engaged: false }),
+  close: () => set({ isOpen: false, openReason: null, engaged: false }),
+  markEngaged: () => set({ engaged: true }),
 }));

--- a/apps/web/src/onboarding/onboardingTerminalScope.ts
+++ b/apps/web/src/onboarding/onboardingTerminalScope.ts
@@ -1,12 +1,20 @@
 // FILE: onboardingTerminalScope.ts
 // Purpose: Synthetic terminal scope ids for the provider sign-in terminals shown during
-//          the welcome tour, so they never collide with a real thread's terminal state.
+//          the welcome tour, so they never collide with a real thread's terminal state nor
+//          with another window's sign-in terminal on the same server.
 // Layer: Web domain helper
 
 import type { ProviderKind, ThreadId } from "@synara/contracts";
 
 export const ONBOARDING_TERMINAL_SCOPE_PREFIX = "onboarding-terminal:";
 
+/**
+ * Terminal sessions are keyed server-side by thread and terminal id. Two tabs or windows
+ * signing in to the same provider would otherwise share one PTY, so each client gets a
+ * nonce for the lifetime of the page.
+ */
+const CLIENT_NONCE = globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+
 export function onboardingTerminalThreadId(provider: ProviderKind): ThreadId {
-  return `${ONBOARDING_TERMINAL_SCOPE_PREFIX}${provider}` as ThreadId;
+  return `${ONBOARDING_TERMINAL_SCOPE_PREFIX}${CLIENT_NONCE}:${provider}` as ThreadId;
 }

--- a/apps/web/src/onboarding/onboardingTerminalScope.ts
+++ b/apps/web/src/onboarding/onboardingTerminalScope.ts
@@ -1,0 +1,12 @@
+// FILE: onboardingTerminalScope.ts
+// Purpose: Synthetic terminal scope ids for the provider sign-in terminals shown during
+//          the welcome tour, so they never collide with a real thread's terminal state.
+// Layer: Web domain helper
+
+import type { ProviderKind, ThreadId } from "@synara/contracts";
+
+export const ONBOARDING_TERMINAL_SCOPE_PREFIX = "onboarding-terminal:";
+
+export function onboardingTerminalThreadId(provider: ProviderKind): ThreadId {
+  return `${ONBOARDING_TERMINAL_SCOPE_PREFIX}${provider}` as ThreadId;
+}

--- a/apps/web/src/onboarding/steps/DoneStep.tsx
+++ b/apps/web/src/onboarding/steps/DoneStep.tsx
@@ -1,51 +1,17 @@
 // FILE: DoneStep.tsx
-// Purpose: Closing summary of the welcome tour plus the day-one shortcuts.
+// Purpose: Closing step of the welcome tour: the day-one shortcuts. The run summary lives
+//          in the dialog header.
 // Layer: Web UI component
 
-import { CircleCheckIcon } from "~/lib/icons";
-import { SYNARA_DOCS_URL } from "../tourContent";
 import { TourShortcutList } from "./FeatureTourStep";
 
-export function DoneStep(props: {
-  enabledProviders: number;
-  connectedProviders: number;
-  projectsAdded: number;
-}) {
-  const lines = [
-    `${props.enabledProviders} ${props.enabledProviders === 1 ? "provider" : "providers"} enabled, ${props.connectedProviders} connected`,
-    props.projectsAdded > 0
-      ? `${props.projectsAdded} ${props.projectsAdded === 1 ? "project" : "projects"} added`
-      : "No project yet: add one from the sidebar whenever you are ready",
-  ];
+export function DoneStep() {
   return (
-    <div className="space-y-5">
-      <ul className="space-y-1.5">
-        {lines.map((line) => (
-          <li key={line} className="flex items-center gap-2 text-sm text-foreground">
-            <CircleCheckIcon className="size-4 shrink-0 text-success" aria-hidden />
-            {line}
-          </li>
-        ))}
-      </ul>
-      <div className="rounded-2xl border border-border/70 bg-muted/20 p-4">
-        <p className="mb-3 text-xs font-medium tracking-wide text-muted-foreground">
-          Shortcuts worth learning today
-        </p>
-        <TourShortcutList />
-      </div>
-      <p className="text-xs text-muted-foreground">
-        Next: open a project, press New task, choose a provider and model, and give it a verifiable
-        objective. The five-minute quickstart is at{" "}
-        <a
-          href={`${SYNARA_DOCS_URL}/getting-started/quickstart`}
-          target="_blank"
-          rel="noreferrer"
-          className="text-foreground underline underline-offset-2"
-        >
-          trysynara.com/docs
-        </a>
-        .
+    <div className="flex flex-col gap-3.5 px-[120px]">
+      <p className="text-[length:var(--app-font-size-ui-sm,11px)] font-medium tracking-[0.04em] text-muted-foreground/70 uppercase">
+        Shortcuts worth learning today
       </p>
+      <TourShortcutList />
     </div>
   );
 }

--- a/apps/web/src/onboarding/steps/DoneStep.tsx
+++ b/apps/web/src/onboarding/steps/DoneStep.tsx
@@ -1,0 +1,51 @@
+// FILE: DoneStep.tsx
+// Purpose: Closing summary of the welcome tour plus the day-one shortcuts.
+// Layer: Web UI component
+
+import { CircleCheckIcon } from "~/lib/icons";
+import { SYNARA_DOCS_URL } from "../tourContent";
+import { TourShortcutList } from "./FeatureTourStep";
+
+export function DoneStep(props: {
+  enabledProviders: number;
+  connectedProviders: number;
+  projectsAdded: number;
+}) {
+  const lines = [
+    `${props.enabledProviders} ${props.enabledProviders === 1 ? "provider" : "providers"} enabled, ${props.connectedProviders} connected`,
+    props.projectsAdded > 0
+      ? `${props.projectsAdded} ${props.projectsAdded === 1 ? "project" : "projects"} added`
+      : "No project yet: add one from the sidebar whenever you are ready",
+  ];
+  return (
+    <div className="space-y-5">
+      <ul className="space-y-1.5">
+        {lines.map((line) => (
+          <li key={line} className="flex items-center gap-2 text-sm text-foreground">
+            <CircleCheckIcon className="size-4 shrink-0 text-success" aria-hidden />
+            {line}
+          </li>
+        ))}
+      </ul>
+      <div className="rounded-2xl border border-border/70 bg-muted/20 p-4">
+        <p className="mb-3 text-xs font-medium tracking-wide text-muted-foreground">
+          Shortcuts worth learning today
+        </p>
+        <TourShortcutList />
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Next: open a project, press New task, choose a provider and model, and give it a verifiable
+        objective. The five-minute quickstart is at{" "}
+        <a
+          href={`${SYNARA_DOCS_URL}/getting-started/quickstart`}
+          target="_blank"
+          rel="noreferrer"
+          className="text-foreground underline underline-offset-2"
+        >
+          trysynara.com/docs
+        </a>
+        .
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/onboarding/steps/FeatureTourStep.tsx
+++ b/apps/web/src/onboarding/steps/FeatureTourStep.tsx
@@ -1,0 +1,126 @@
+// FILE: FeatureTourStep.tsx
+// Purpose: Tabbed "what Synara can do" tour built from TOUR_CARDS, with a docs link per card
+//          and live shortcut chips on the shortcuts card.
+// Layer: Web UI component
+
+import type { ResolvedKeybindingsConfig } from "@synara/contracts";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+
+import { ShortcutKbd } from "~/components/ui/shortcut-kbd";
+import { shortcutLabelForCommand } from "~/keybindings";
+import { ExternalLinkIcon } from "~/lib/icons";
+import { serverConfigQueryOptions } from "~/lib/serverReactQuery";
+import { cn } from "~/lib/utils";
+import { TOUR_CARDS, TOUR_SHORTCUT_COMMANDS } from "../tourContent";
+
+const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
+
+export function TourShortcutList(props: { className?: string }) {
+  const keybindingsQuery = useQuery({
+    ...serverConfigQueryOptions(),
+    select: (config) => config.keybindings,
+  });
+  const keybindings = keybindingsQuery.data ?? EMPTY_KEYBINDINGS;
+  return (
+    <dl className={cn("grid grid-cols-1 gap-x-6 gap-y-2 sm:grid-cols-2", props.className)}>
+      {TOUR_SHORTCUT_COMMANDS.map((entry) => {
+        const label = shortcutLabelForCommand(keybindings, entry.command);
+        if (!label) return null;
+        return (
+          <div key={entry.command} className="flex items-center justify-between gap-3">
+            <dt className="text-sm text-muted-foreground">{entry.label}</dt>
+            <dd>
+              <ShortcutKbd shortcutLabel={label} />
+            </dd>
+          </div>
+        );
+      })}
+    </dl>
+  );
+}
+
+export function FeatureTourStep() {
+  const [selectedId, setSelectedId] = useState<string>(TOUR_CARDS[0]?.id ?? "");
+  const selectedCard = TOUR_CARDS.find((card) => card.id === selectedId) ?? TOUR_CARDS[0];
+  if (!selectedCard) return null;
+  const SelectedIcon = selectedCard.icon;
+
+  return (
+    <section aria-labelledby="onboarding-tour-title" className="space-y-3">
+      <p id="onboarding-tour-title" className="sr-only">
+        Synara capabilities
+      </p>
+
+      <div className="flex flex-wrap gap-1.5" role="tablist" aria-label="Synara capabilities">
+        {TOUR_CARDS.map((card) => {
+          const Icon = card.icon;
+          const selected = card.id === selectedCard.id;
+          return (
+            <button
+              key={card.id}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              aria-controls="onboarding-tour-panel"
+              id={`onboarding-tour-tab-${card.id}`}
+              className={cn(
+                "flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs outline-none transition-colors motion-reduce:transition-none",
+                "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-popover",
+                selected
+                  ? "border-foreground/20 bg-foreground/[0.07] text-foreground"
+                  : "border-border/70 bg-muted/15 text-muted-foreground hover:border-border hover:bg-muted/40 hover:text-foreground",
+              )}
+              onClick={() => setSelectedId(card.id)}
+            >
+              <Icon className="size-3.5" aria-hidden />
+              <span className="font-medium">{card.label}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        id="onboarding-tour-panel"
+        role="tabpanel"
+        aria-labelledby={`onboarding-tour-tab-${selectedCard.id}`}
+        className="min-h-56 rounded-2xl border border-border/70 bg-muted/20 p-4"
+      >
+        <div className="flex gap-3">
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-foreground text-background">
+            <SelectedIcon className="size-4" aria-hidden />
+          </div>
+          <div className="min-w-0 flex-1 space-y-1">
+            <h3 className="text-sm font-semibold text-foreground">{selectedCard.title}</h3>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              {selectedCard.description}
+            </p>
+          </div>
+        </div>
+        {selectedCard.id === "shortcuts" ? (
+          <TourShortcutList className="mt-4 pl-12" />
+        ) : (
+          <div className="mt-4 flex flex-wrap gap-1.5 pl-12">
+            {selectedCard.highlights.map((highlight) => (
+              <span
+                key={highlight}
+                className="rounded-full border border-border/70 bg-background/50 px-2.5 py-1 text-[11px] text-foreground/80"
+              >
+                {highlight}
+              </span>
+            ))}
+          </div>
+        )}
+        <a
+          href={selectedCard.docsHref}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-4 inline-flex items-center gap-1 pl-12 text-xs text-muted-foreground transition-colors hover:text-foreground motion-reduce:transition-none"
+        >
+          Read the guide
+          <ExternalLinkIcon className="size-3" aria-hidden />
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/onboarding/steps/FeatureTourStep.tsx
+++ b/apps/web/src/onboarding/steps/FeatureTourStep.tsx
@@ -1,6 +1,7 @@
 // FILE: FeatureTourStep.tsx
-// Purpose: Tabbed "what Synara can do" tour built from TOUR_CARDS, with a docs link per card
-//          and live shortcut chips on the shortcuts card.
+// Purpose: "What Synara can do" tour built from TOUR_CARDS: a vertical list of topics on the
+//          left, the selected topic's text on the right, with a docs link per topic and live
+//          shortcut chips on the shortcuts topic.
 // Layer: Web UI component
 
 import type { ResolvedKeybindingsConfig } from "@synara/contracts";
@@ -23,13 +24,15 @@ export function TourShortcutList(props: { className?: string }) {
   });
   const keybindings = keybindingsQuery.data ?? EMPTY_KEYBINDINGS;
   return (
-    <dl className={cn("grid grid-cols-1 gap-x-6 gap-y-2 sm:grid-cols-2", props.className)}>
+    <dl className={cn("grid grid-cols-1 gap-x-10 gap-y-2.5 sm:grid-cols-2", props.className)}>
       {TOUR_SHORTCUT_COMMANDS.map((entry) => {
         const label = shortcutLabelForCommand(keybindings, entry.command);
         if (!label) return null;
         return (
           <div key={entry.command} className="flex items-center justify-between gap-3">
-            <dt className="text-sm text-muted-foreground">{entry.label}</dt>
+            <dt className="text-[length:var(--app-font-size-ui-lg,13px)] text-foreground/85">
+              {entry.label}
+            </dt>
             <dd>
               <ShortcutKbd shortcutLabel={label} />
             </dd>
@@ -44,15 +47,10 @@ export function FeatureTourStep() {
   const [selectedId, setSelectedId] = useState<string>(TOUR_CARDS[0]?.id ?? "");
   const selectedCard = TOUR_CARDS.find((card) => card.id === selectedId) ?? TOUR_CARDS[0];
   if (!selectedCard) return null;
-  const SelectedIcon = selectedCard.icon;
 
   return (
-    <section aria-labelledby="onboarding-tour-title" className="space-y-3">
-      <p id="onboarding-tour-title" className="sr-only">
-        Synara capabilities
-      </p>
-
-      <div className="flex flex-wrap gap-1.5" role="tablist" aria-label="Synara capabilities">
+    <div className="grid min-h-0 flex-1 grid-cols-[220px_minmax(0,1fr)] gap-8">
+      <div className="flex flex-col gap-0.5" role="tablist" aria-label="Synara capabilities">
         {TOUR_CARDS.map((card) => {
           const Icon = card.icon;
           const selected = card.id === selectedCard.id;
@@ -65,16 +63,22 @@ export function FeatureTourStep() {
               aria-controls="onboarding-tour-panel"
               id={`onboarding-tour-tab-${card.id}`}
               className={cn(
-                "flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs outline-none transition-colors motion-reduce:transition-none",
-                "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-popover",
+                "flex h-[34px] items-center gap-2.5 rounded-lg px-2.5 text-start text-[length:var(--app-font-size-ui-lg,13px)] outline-none transition-colors motion-reduce:transition-none",
+                "focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset",
                 selected
-                  ? "border-foreground/20 bg-foreground/[0.07] text-foreground"
-                  : "border-border/70 bg-muted/15 text-muted-foreground hover:border-border hover:bg-muted/40 hover:text-foreground",
+                  ? "bg-foreground/4 text-foreground"
+                  : "text-foreground/70 hover:bg-foreground/3 hover:text-foreground",
               )}
               onClick={() => setSelectedId(card.id)}
             >
-              <Icon className="size-3.5" aria-hidden />
-              <span className="font-medium">{card.label}</span>
+              <Icon
+                className={cn(
+                  "size-[15px] shrink-0",
+                  selected ? "text-foreground" : "text-muted-foreground/80",
+                )}
+                aria-hidden
+              />
+              <span className="truncate">{card.label}</span>
             </button>
           );
         })}
@@ -84,43 +88,39 @@ export function FeatureTourStep() {
         id="onboarding-tour-panel"
         role="tabpanel"
         aria-labelledby={`onboarding-tour-tab-${selectedCard.id}`}
-        className="min-h-56 rounded-2xl border border-border/70 bg-muted/20 p-4"
+        className="flex min-w-0 flex-col gap-3.5 pt-1.5"
       >
-        <div className="flex gap-3">
-          <div className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-foreground text-background">
-            <SelectedIcon className="size-4" aria-hidden />
-          </div>
-          <div className="min-w-0 flex-1 space-y-1">
-            <h3 className="text-sm font-semibold text-foreground">{selectedCard.title}</h3>
-            <p className="text-sm leading-relaxed text-muted-foreground">
-              {selectedCard.description}
-            </p>
-          </div>
-        </div>
+        <h3 className="text-base font-medium tracking-[-0.005em] text-foreground">
+          {selectedCard.title}
+        </h3>
+        <p className="text-[length:var(--app-font-size-ui-lg,13px)] leading-relaxed text-muted-foreground">
+          {selectedCard.description}
+        </p>
         {selectedCard.id === "shortcuts" ? (
-          <TourShortcutList className="mt-4 pl-12" />
+          <TourShortcutList className="mt-1 max-w-[440px]" />
         ) : (
-          <div className="mt-4 flex flex-wrap gap-1.5 pl-12">
+          <ul className="mt-1 flex flex-col gap-2">
             {selectedCard.highlights.map((highlight) => (
-              <span
+              <li
                 key={highlight}
-                className="rounded-full border border-border/70 bg-background/50 px-2.5 py-1 text-[11px] text-foreground/80"
+                className="flex items-center gap-2.5 text-[length:var(--app-font-size-ui-lg,13px)] text-foreground/85"
               >
+                <span aria-hidden className="size-1 shrink-0 rounded-full bg-foreground/40" />
                 {highlight}
-              </span>
+              </li>
             ))}
-          </div>
+          </ul>
         )}
         <a
           href={selectedCard.docsHref}
           target="_blank"
           rel="noreferrer"
-          className="mt-4 inline-flex items-center gap-1 pl-12 text-xs text-muted-foreground transition-colors hover:text-foreground motion-reduce:transition-none"
+          className="mt-2 inline-flex items-center gap-1.5 self-start text-[length:var(--app-font-size-ui,12px)] text-muted-foreground transition-colors hover:text-foreground motion-reduce:transition-none"
         >
           Read the guide
           <ExternalLinkIcon className="size-3" aria-hidden />
         </a>
       </div>
-    </section>
+    </div>
   );
 }

--- a/apps/web/src/onboarding/steps/ProjectStep.tsx
+++ b/apps/web/src/onboarding/steps/ProjectStep.tsx
@@ -1,0 +1,151 @@
+// FILE: ProjectStep.tsx
+// Purpose: First-project step of the welcome tour: browse (desktop) or type a folder path,
+//          create the project through the shared create-or-recover flow, and list what was
+//          added. Multiple folders can be added before continuing.
+// Layer: Web UI component
+
+import type { ProjectId } from "@synara/contracts";
+import { useState, type FormEvent } from "react";
+
+import { useAppSettings } from "~/appSettings";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { isElectron } from "~/env";
+import { FolderOpenIcon } from "~/lib/icons";
+import { createOrRecoverProjectFromPath } from "~/lib/projectCreation";
+import { expandProjectHomePath } from "~/lib/projectPaths";
+import { readNativeApi } from "~/nativeApi";
+import { useStore } from "~/store";
+import { useWorkspacePathsStore } from "~/workspacePathsStore";
+
+export interface OnboardingProjectResult {
+  readonly projectId: ProjectId;
+  readonly workspaceRoot: string;
+  readonly created: boolean;
+}
+
+export function ProjectStep(props: {
+  results: ReadonlyArray<OnboardingProjectResult>;
+  onResult: (result: OnboardingProjectResult) => void;
+}) {
+  const { settings } = useAppSettings();
+  const homeDir = useWorkspacePathsStore((store) => store.homeDir);
+  const syncServerShellSnapshot = useStore((store) => store.syncServerShellSnapshot);
+  const [path, setPath] = useState("");
+  const [picking, setPicking] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const addProject = async (rawPath: string) => {
+    const api = readNativeApi();
+    const workspaceRoot = expandProjectHomePath(rawPath.trim(), homeDir);
+    if (!api || workspaceRoot.length === 0) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await createOrRecoverProjectFromPath({
+        api,
+        workspaceRoot,
+        // Files the project in Void; the sidebar follows it once the tour closes.
+        spaceId: null,
+        defaultProvider: settings.defaultProvider,
+        loadSnapshot: () => api.orchestration.getShellSnapshot().catch(() => null),
+      });
+      if (result.snapshot) {
+        syncServerShellSnapshot(result.snapshot);
+      }
+      props.onResult({
+        projectId: result.projectId,
+        workspaceRoot: result.project?.workspaceRoot ?? workspaceRoot,
+        created: result.created,
+      });
+      setPath("");
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not add the project.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const browse = async () => {
+    const api = readNativeApi();
+    if (!api) return;
+    setPicking(true);
+    try {
+      const picked = await api.dialogs.pickFolder();
+      if (picked) {
+        await addProject(picked);
+      }
+    } finally {
+      setPicking(false);
+    }
+  };
+
+  const onSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    void addProject(path);
+  };
+
+  return (
+    <div className="space-y-4">
+      <form onSubmit={onSubmit} className="flex items-center gap-2">
+        <Input
+          value={path}
+          onChange={(event) => setPath(event.target.value)}
+          placeholder={homeDir ? `${homeDir}/code/my-repo` : "/path/to/repository"}
+          aria-label="Project folder path"
+          disabled={submitting}
+          className="flex-1"
+        />
+        {isElectron ? (
+          <Button
+            type="button"
+            variant="outline"
+            disabled={picking || submitting}
+            onClick={() => void browse()}
+          >
+            <FolderOpenIcon className="size-4" aria-hidden />
+            Browse
+          </Button>
+        ) : null}
+        <Button type="submit" disabled={submitting || path.trim().length === 0}>
+          Add
+        </Button>
+      </form>
+
+      {error ? (
+        <p
+          role="alert"
+          className="rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      {props.results.length > 0 ? (
+        <ul className="space-y-1" aria-label="Added projects">
+          {props.results.map((result) => (
+            <li
+              key={result.projectId}
+              className="flex items-center gap-3 rounded-lg border border-border/70 bg-muted/20 px-3 py-2"
+            >
+              <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+                {result.workspaceRoot}
+              </span>
+              <Badge variant={result.created ? "success" : "outline"}>
+                {result.created ? "Added" : "Already linked"}
+              </Badge>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      <p className="text-xs text-muted-foreground">
+        A project is the folder Synara works with. A Git repository is strongly recommended: it
+        unlocks branches, worktrees, diffs, commits, pushes, and pull requests. You can add more
+        projects or clone one from GitHub later from the sidebar.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/onboarding/steps/ProjectStep.tsx
+++ b/apps/web/src/onboarding/steps/ProjectStep.tsx
@@ -6,7 +6,7 @@
 // Layer: Web UI component
 
 import type { ProjectId } from "@synara/contracts";
-import { useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 
 import { useAppSettings } from "~/appSettings";
 import { Button } from "~/components/ui/button";
@@ -33,6 +33,8 @@ const FIELD_CONTROL_CLASS_NAME = "h-9 rounded-lg border-foreground/12";
 export function ProjectStep(props: {
   results: ReadonlyArray<OnboardingProjectResult>;
   onResult: (result: OnboardingProjectResult) => void;
+  /** Project creation is not abortable; the dialog blocks navigation while it runs. */
+  onBusyChange: (busy: boolean) => void;
 }) {
   const { settings } = useAppSettings();
   const homeDir = useWorkspacePathsStore((store) => store.homeDir);
@@ -41,6 +43,13 @@ export function ProjectStep(props: {
   const [picking, setPicking] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const { onBusyChange } = props;
+  const busy = picking || submitting;
+  useEffect(() => {
+    onBusyChange(busy);
+  }, [busy, onBusyChange]);
+  useEffect(() => () => onBusyChange(false), [onBusyChange]);
 
   const addProject = async (rawPath: string) => {
     const api = readNativeApi();
@@ -82,6 +91,8 @@ export function ProjectStep(props: {
       if (picked) {
         await addProject(picked);
       }
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not open the folder picker.");
     } finally {
       setPicking(false);
     }

--- a/apps/web/src/onboarding/steps/ProjectStep.tsx
+++ b/apps/web/src/onboarding/steps/ProjectStep.tsx
@@ -1,20 +1,23 @@
 // FILE: ProjectStep.tsx
-// Purpose: First-project step of the welcome tour: browse (desktop) or type a folder path,
-//          create the project through the shared create-or-recover flow, and list what was
-//          added. Multiple folders can be added before continuing.
+// Purpose: First-project step of the welcome tour: drop a folder (anywhere in the window),
+//          browse (desktop) or type a path, create the project through the shared
+//          create-or-recover flow, and list what was added. Several folders can be added
+//          before continuing.
 // Layer: Web UI component
 
 import type { ProjectId } from "@synara/contracts";
 import { useState, type FormEvent } from "react";
 
 import { useAppSettings } from "~/appSettings";
-import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
-import { Input } from "~/components/ui/input";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "~/components/ui/input-group";
 import { isElectron } from "~/env";
-import { FolderOpenIcon } from "~/lib/icons";
+import { useWindowFolderDrop } from "~/hooks/useWindowFolderDrop";
+import { CentralIcon } from "~/lib/central-icons";
+import { CheckIcon, FolderIcon } from "~/lib/icons";
 import { createOrRecoverProjectFromPath } from "~/lib/projectCreation";
 import { expandProjectHomePath } from "~/lib/projectPaths";
+import { cn } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
 import { useStore } from "~/store";
 import { useWorkspacePathsStore } from "~/workspacePathsStore";
@@ -24,6 +27,8 @@ export interface OnboardingProjectResult {
   readonly workspaceRoot: string;
   readonly created: boolean;
 }
+
+const FIELD_CONTROL_CLASS_NAME = "h-9 rounded-lg border-foreground/12";
 
 export function ProjectStep(props: {
   results: ReadonlyArray<OnboardingProjectResult>;
@@ -82,70 +87,106 @@ export function ProjectStep(props: {
     }
   };
 
+  const isDropTarget = useWindowFolderDrop({
+    enabled: isElectron && !submitting,
+    onFolder: (dropped) => void addProject(dropped),
+    onError: setError,
+  });
+
   const onSubmit = (event: FormEvent) => {
     event.preventDefault();
     void addProject(path);
   };
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col gap-4">
+      {isElectron ? (
+        <button
+          type="button"
+          disabled={picking || submitting}
+          className={cn(
+            "flex h-[168px] w-full cursor-pointer flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-foreground/18 text-[length:var(--app-font-size-ui-lg,13px)] text-foreground transition-colors outline-none hover:bg-foreground/3 focus-visible:border-foreground/40 disabled:opacity-50 motion-reduce:transition-none",
+            isDropTarget && "border-solid border-[color:var(--color-border-focus)] bg-foreground/5",
+          )}
+          onClick={() => void browse()}
+        >
+          <CentralIcon
+            name="folder-add-left"
+            className="size-[22px] text-foreground/70"
+            aria-hidden="true"
+          />
+          {picking ? (
+            <span>Opening the folder picker…</span>
+          ) : (
+            <span>
+              Drop a folder here, or{" "}
+              <span className="underline decoration-dotted decoration-[1.5px] underline-offset-[5px]">
+                browse
+              </span>
+            </span>
+          )}
+        </button>
+      ) : null}
+
       <form onSubmit={onSubmit} className="flex items-center gap-2">
-        <Input
-          value={path}
-          onChange={(event) => setPath(event.target.value)}
-          placeholder={homeDir ? `${homeDir}/code/my-repo` : "/path/to/repository"}
-          aria-label="Project folder path"
-          disabled={submitting}
-          className="flex-1"
-        />
-        {isElectron ? (
-          <Button
-            type="button"
-            variant="outline"
-            disabled={picking || submitting}
-            onClick={() => void browse()}
-          >
-            <FolderOpenIcon className="size-4" aria-hidden />
-            Browse
-          </Button>
-        ) : null}
-        <Button type="submit" disabled={submitting || path.trim().length === 0}>
+        <InputGroup className={cn(FIELD_CONTROL_CLASS_NAME, "min-w-0 flex-1")}>
+          <InputGroupAddon className="w-10 self-stretch border-e border-foreground/12 ps-0">
+            <FolderIcon className="size-4 text-muted-foreground/70" aria-hidden />
+          </InputGroupAddon>
+          <InputGroupInput
+            value={path}
+            onChange={(event) => {
+              setPath(event.target.value);
+              setError(null);
+            }}
+            placeholder={homeDir ? `${homeDir}/code/my-repo` : "/path/to/repository"}
+            aria-label="Project folder path"
+            spellCheck={false}
+            autoCorrect="off"
+            autoCapitalize="off"
+            disabled={submitting}
+          />
+        </InputGroup>
+        <Button
+          type="submit"
+          variant="outline"
+          className={cn(FIELD_CONTROL_CLASS_NAME, "shrink-0 px-4")}
+          disabled={submitting || path.trim().length === 0}
+        >
           Add
         </Button>
       </form>
 
       {error ? (
-        <p
-          role="alert"
-          className="rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 text-sm text-destructive"
-        >
+        <p role="alert" className="text-[length:var(--app-font-size-ui,12px)] text-destructive">
           {error}
         </p>
       ) : null}
 
       {props.results.length > 0 ? (
-        <ul className="space-y-1" aria-label="Added projects">
+        <ul className="flex flex-col gap-1.5" aria-label="Added projects">
           {props.results.map((result) => (
             <li
               key={result.projectId}
-              className="flex items-center gap-3 rounded-lg border border-border/70 bg-muted/20 px-3 py-2"
+              className="flex h-10 items-center gap-3 rounded-lg bg-foreground/3 px-3.5"
             >
-              <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+              <FolderIcon className="size-[15px] shrink-0 text-foreground/70" aria-hidden />
+              <span className="min-w-0 flex-1 truncate text-[length:var(--app-font-size-ui,12px)] text-foreground">
                 {result.workspaceRoot}
               </span>
-              <Badge variant={result.created ? "success" : "outline"}>
+              <span
+                className={cn(
+                  "flex items-center gap-1.5 text-[length:var(--app-font-size-ui-sm,11px)]",
+                  result.created ? "text-success" : "text-muted-foreground",
+                )}
+              >
+                <CheckIcon className="size-3" aria-hidden />
                 {result.created ? "Added" : "Already linked"}
-              </Badge>
+              </span>
             </li>
           ))}
         </ul>
       ) : null}
-
-      <p className="text-xs text-muted-foreground">
-        A project is the folder Synara works with. A Git repository is strongly recommended: it
-        unlocks branches, worktrees, diffs, commits, pushes, and pull requests. You can add more
-        projects or clone one from GitHub later from the sidebar.
-      </p>
     </div>
   );
 }

--- a/apps/web/src/onboarding/steps/ProviderConnectTerminal.tsx
+++ b/apps/web/src/onboarding/steps/ProviderConnectTerminal.tsx
@@ -1,0 +1,109 @@
+// FILE: ProviderConnectTerminal.tsx
+// Purpose: Inline terminal that runs a provider's sign-in command inside the welcome tour.
+//          Uses a synthetic thread scope so nothing leaks into real thread terminal state,
+//          and disposes every session on unmount.
+// Layer: Web UI component
+
+import type { ProviderKind } from "@synara/contracts";
+import { useEffect, useRef } from "react";
+
+import ThreadTerminalDrawer from "~/components/ThreadTerminalDrawer";
+import { disposeAndCloseTerminalSession } from "~/components/terminal/terminalSession";
+import { useTerminalSurfaceController } from "~/hooks/useTerminalSurfaceController";
+import { readNativeApi } from "~/nativeApi";
+import { runProjectCommandInTerminal } from "~/projectTerminalRunner";
+import { useTerminalStateStore } from "~/terminalStateStore";
+import { onboardingTerminalThreadId } from "../onboardingTerminalScope";
+
+const CONNECT_TERMINAL_HEIGHT = 280;
+
+export function ProviderConnectTerminal(props: {
+  provider: ProviderKind;
+  signInCommand: string;
+  cwd: string;
+}) {
+  const scopeId = onboardingTerminalThreadId(props.provider);
+  const terminal = useTerminalSurfaceController(scopeId);
+  const { terminalState, openTerminalThreadPage } = terminal;
+  const clearTerminalState = useTerminalStateStore((state) => state.clearTerminalState);
+  const terminalIdsRef = useRef(terminalState.terminalIds);
+  terminalIdsRef.current = terminalState.terminalIds;
+
+  useEffect(
+    () => () => {
+      const api = readNativeApi();
+      for (const terminalId of terminalIdsRef.current) {
+        disposeAndCloseTerminalSession({ api, threadId: scopeId, terminalId });
+      }
+      clearTerminalState(scopeId);
+    },
+    [clearTerminalState, scopeId],
+  );
+
+  useEffect(() => {
+    if (terminalState.terminalOpen) {
+      return;
+    }
+    openTerminalThreadPage(scopeId, { terminalOnly: true });
+  }, [openTerminalThreadPage, scopeId, terminalState.terminalOpen]);
+
+  const commandStartedRef = useRef(false);
+  const activeTerminalId = terminalState.activeTerminalId || terminalState.terminalIds[0];
+  useEffect(() => {
+    if (commandStartedRef.current || !terminalState.terminalOpen || !activeTerminalId) {
+      return;
+    }
+    const api = readNativeApi();
+    if (!api || props.cwd.length === 0) {
+      return;
+    }
+    commandStartedRef.current = true;
+    void runProjectCommandInTerminal({
+      api,
+      threadId: scopeId,
+      terminalId: activeTerminalId,
+      project: { cwd: props.cwd },
+      cwd: props.cwd,
+      command: props.signInCommand,
+    }).catch(() => {
+      commandStartedRef.current = false;
+    });
+  }, [activeTerminalId, props.cwd, props.signInCommand, scopeId, terminalState.terminalOpen]);
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border/70">
+      <ThreadTerminalDrawer
+        key={scopeId}
+        threadId={scopeId}
+        cwd={props.cwd}
+        runtimeEnv={{}}
+        height={CONNECT_TERMINAL_HEIGHT}
+        presentationMode="workspace"
+        isVisible
+        terminalIds={terminalState.terminalIds}
+        terminalLabelsById={terminalState.terminalLabelsById}
+        terminalTitleOverridesById={terminalState.terminalTitleOverridesById}
+        terminalCliKindsById={terminalState.terminalCliKindsById}
+        terminalAttentionStatesById={terminalState.terminalAttentionStatesById ?? {}}
+        runningTerminalIds={terminalState.runningTerminalIds}
+        activeTerminalId={terminalState.activeTerminalId}
+        terminalGroups={terminalState.terminalGroups}
+        activeTerminalGroupId={terminalState.activeTerminalGroupId}
+        focusRequestId={terminal.focusRequestId}
+        onSplitTerminal={terminal.splitRight}
+        onSplitTerminalDown={terminal.splitDown}
+        onNewTerminal={terminal.newTerminalGroup}
+        onNewTerminalTab={terminal.createTerminalTab}
+        onMoveTerminalToGroup={terminal.moveTerminalToNewGroup}
+        onActiveTerminalChange={terminal.activateTerminal}
+        onCloseTerminal={terminal.closeTerminal}
+        onTerminalSessionExited={terminal.handleTerminalSessionExited}
+        onCloseTerminalGroup={terminal.closeTerminalGroup}
+        onHeightChange={terminal.setTerminalHeight}
+        onResizeTerminalSplit={terminal.resizeTerminalSplit}
+        onTerminalMetadataChange={terminal.setTerminalMetadata}
+        onTerminalActivityChange={terminal.setTerminalActivity}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/onboarding/steps/ProvidersStep.tsx
+++ b/apps/web/src/onboarding/steps/ProvidersStep.tsx
@@ -1,0 +1,219 @@
+// FILE: ProvidersStep.tsx
+// Purpose: Provider checklist for the welcome tour: detection status per runtime, an
+//          enable/disable checkbox bound to the server-backed `disabledProviders` setting,
+//          inline sign-in for detected-but-unauthenticated CLIs, and a setup-guide link.
+// Layer: Web UI component
+
+import type { ProviderKind, ServerProviderStatus } from "@synara/contracts";
+import { PROVIDER_DESCRIPTORS } from "@synara/shared/providerMetadata";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { getCustomBinaryPathForProvider, useAppSettings } from "~/appSettings";
+import { ProviderIcon } from "~/components/ProviderIcon";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import { Checkbox } from "~/components/ui/checkbox";
+import { DisclosureRegion } from "~/components/ui/DisclosureRegion";
+import { useRefreshProviderStatusesNow } from "~/hooks/useProviderStatusRefresh";
+import { RefreshCwIcon } from "~/lib/icons";
+import {
+  findProviderStatus,
+  normalizeProviderStatusForLocalConfig,
+} from "~/lib/providerAvailability";
+import { serverConfigQueryOptions } from "~/lib/serverReactQuery";
+import { cn } from "~/lib/utils";
+import { useWorkspacePathsStore } from "~/workspacePathsStore";
+import { classifyProviderSetup, summarizeProviderSetup, type ProviderSetupState } from "../logic";
+import { ProviderConnectTerminal } from "./ProviderConnectTerminal";
+
+const EMPTY_STATUSES: readonly ServerProviderStatus[] = [];
+
+const STATE_BADGE: Record<
+  ProviderSetupState,
+  { label: string; variant: "success" | "warning" | "outline" | "secondary" }
+> = {
+  connected: { label: "Connected", variant: "success" },
+  "needs-sign-in": { label: "Needs sign-in", variant: "warning" },
+  "not-installed": { label: "Not installed", variant: "outline" },
+  disabled: { label: "Disabled", variant: "secondary" },
+};
+
+/**
+ * Raw detection statuses with custom-binary overrides applied but *without* folding the
+ * disabled flag in: this step must keep showing "installed" for a provider the user just
+ * unchecked, otherwise the row appears to lose its CLI.
+ */
+function useDetectedProviderStatuses(): readonly ServerProviderStatus[] {
+  const { settings } = useAppSettings();
+  const serverConfigQuery = useQuery(serverConfigQueryOptions());
+  const providers = serverConfigQuery.data?.providers ?? EMPTY_STATUSES;
+  return useMemo(
+    () =>
+      providers.flatMap((status) => {
+        const normalized = normalizeProviderStatusForLocalConfig({
+          provider: status.provider,
+          status,
+          customBinaryPath: getCustomBinaryPathForProvider(settings, status.provider),
+        });
+        return normalized ? [normalized] : [];
+      }),
+    [providers, settings],
+  );
+}
+
+function setDisabled(
+  current: ReadonlyArray<ProviderKind>,
+  provider: ProviderKind,
+  disabled: boolean,
+): ProviderKind[] {
+  const without = current.filter((entry) => entry !== provider);
+  return disabled ? [...without, provider] : without;
+}
+
+export function ProvidersStep() {
+  const { settings, updateSettings } = useAppSettings();
+  const statuses = useDetectedProviderStatuses();
+  const refreshProviderStatuses = useRefreshProviderStatusesNow();
+  const homeDir = useWorkspacePathsStore((store) => store.homeDir);
+  const [connectingProvider, setConnectingProvider] = useState<ProviderKind | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const disabledSet = useMemo(
+    () => new Set<ProviderKind>(settings.disabledProviders),
+    [settings.disabledProviders],
+  );
+
+  const refresh = async () => {
+    setRefreshing(true);
+    try {
+      await refreshProviderStatuses({ silent: true });
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  // Probe once on entry so a CLI installed while the intro was open shows up.
+  const refreshedOnEntryRef = useRef(false);
+  useEffect(() => {
+    if (refreshedOnEntryRef.current) return;
+    refreshedOnEntryRef.current = true;
+    void refreshProviderStatuses({ silent: true });
+  }, [refreshProviderStatuses]);
+
+  const rows = PROVIDER_DESCRIPTORS.map((descriptor) => {
+    const status = findProviderStatus(statuses, descriptor.kind);
+    const state = classifyProviderSetup({
+      status,
+      disabled: disabledSet.has(descriptor.kind),
+    });
+    return { descriptor, status, state };
+  });
+  const summary = summarizeProviderSetup(
+    rows.map((row) => ({ provider: row.descriptor.kind, state: row.state })),
+  );
+
+  const toggleConnect = (provider: ProviderKind) => {
+    if (connectingProvider === provider) {
+      setConnectingProvider(null);
+      void refresh();
+      return;
+    }
+    setConnectingProvider(provider);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-muted-foreground">
+          {summary.connected} connected · {summary.needsSignIn} need sign-in ·{" "}
+          {summary.notInstalled} not installed · {summary.enabled} of {rows.length} enabled
+        </p>
+        <Button size="sm" variant="ghost" disabled={refreshing} onClick={() => void refresh()}>
+          <RefreshCwIcon className={cn("size-3.5", refreshing && "animate-spin")} aria-hidden />
+          Re-detect
+        </Button>
+      </div>
+
+      <div className="max-h-[22rem] space-y-0.5 overflow-y-auto pr-1">
+        {rows.map(({ descriptor, status, state }) => {
+          const badge = STATE_BADGE[state];
+          const enabled = state !== "disabled";
+          const signInCommand = descriptor.usage?.signInCommand;
+          const canConnectInline =
+            state === "needs-sign-in" && signInCommand !== undefined && homeDir !== null;
+          const isConnecting = connectingProvider === descriptor.kind;
+          return (
+            <div key={descriptor.kind} className="rounded-lg">
+              <div className="flex items-center gap-3 px-2 py-2">
+                <Checkbox
+                  checked={enabled}
+                  aria-label={`${enabled ? "Disable" : "Enable"} ${descriptor.displayName}`}
+                  onCheckedChange={(checked) =>
+                    updateSettings({
+                      disabledProviders: setDisabled(
+                        settings.disabledProviders,
+                        descriptor.kind,
+                        !Boolean(checked),
+                      ),
+                    })
+                  }
+                />
+                <ProviderIcon
+                  provider={descriptor.kind}
+                  className={cn("size-5 shrink-0", !enabled && "opacity-50")}
+                />
+                <span className="flex min-w-0 flex-1 flex-col">
+                  <span
+                    className={cn("text-sm", enabled ? "text-foreground" : "text-muted-foreground")}
+                  >
+                    {descriptor.displayName}
+                  </span>
+                  {status?.version ? (
+                    <span className="text-xs text-muted-foreground">v{status.version}</span>
+                  ) : null}
+                </span>
+                <Badge variant={badge.variant}>{badge.label}</Badge>
+                {canConnectInline ? (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => toggleConnect(descriptor.kind)}
+                  >
+                    {isConnecting ? "Done" : "Sign in"}
+                  </Button>
+                ) : null}
+                {state === "not-installed" ? (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    render={<a href={descriptor.setupDocsHref} target="_blank" rel="noreferrer" />}
+                  >
+                    Setup guide
+                  </Button>
+                ) : null}
+              </div>
+              {canConnectInline ? (
+                <DisclosureRegion open={isConnecting} contentClassName="px-2 pb-2">
+                  {isConnecting && signInCommand !== undefined && homeDir !== null ? (
+                    <ProviderConnectTerminal
+                      provider={descriptor.kind}
+                      signInCommand={signInCommand}
+                      cwd={homeDir}
+                    />
+                  ) : null}
+                </DisclosureRegion>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        Unchecked providers are disabled on the server: no discovery, health checks, or new turns
+        until you re-enable them in Settings → Providers. Install a missing CLI, sign in from a
+        fresh terminal, then re-detect.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/onboarding/steps/ProvidersStep.tsx
+++ b/apps/web/src/onboarding/steps/ProvidersStep.tsx
@@ -1,7 +1,8 @@
 // FILE: ProvidersStep.tsx
-// Purpose: Provider checklist for the welcome tour: detection status per runtime, an
-//          enable/disable checkbox bound to the server-backed `disabledProviders` setting,
-//          inline sign-in for detected-but-unauthenticated CLIs, and a setup-guide link.
+// Purpose: Provider grid for the welcome tour: one card per runtime with its detection
+//          status, an enable/disable checkbox bound to the server-backed `disabledProviders`
+//          setting, inline sign-in for detected-but-unauthenticated CLIs, and a setup-guide
+//          link for missing ones.
 // Layer: Web UI component
 
 import type { ProviderKind, ServerProviderStatus } from "@synara/contracts";
@@ -11,8 +12,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { getCustomBinaryPathForProvider, useAppSettings } from "~/appSettings";
 import { ProviderIcon } from "~/components/ProviderIcon";
-import { Badge } from "~/components/ui/badge";
-import { Button } from "~/components/ui/button";
 import { Checkbox } from "~/components/ui/checkbox";
 import { DisclosureRegion } from "~/components/ui/DisclosureRegion";
 import { useRefreshProviderStatusesNow } from "~/hooks/useProviderStatusRefresh";
@@ -24,25 +23,27 @@ import {
 import { serverConfigQueryOptions } from "~/lib/serverReactQuery";
 import { cn } from "~/lib/utils";
 import { useWorkspacePathsStore } from "~/workspacePathsStore";
+import { ONBOARDING_TILE_CLASS_NAME } from "../layout";
 import { classifyProviderSetup, summarizeProviderSetup, type ProviderSetupState } from "../logic";
 import { ProviderConnectTerminal } from "./ProviderConnectTerminal";
 
 const EMPTY_STATUSES: readonly ServerProviderStatus[] = [];
 
-const STATE_BADGE: Record<
-  ProviderSetupState,
-  { label: string; variant: "success" | "warning" | "outline" | "secondary" }
-> = {
-  connected: { label: "Connected", variant: "success" },
-  "needs-sign-in": { label: "Needs sign-in", variant: "warning" },
-  "not-installed": { label: "Not installed", variant: "outline" },
-  disabled: { label: "Disabled", variant: "secondary" },
+/** Status as a dot + word; the dot carries the colour, the copy stays muted. */
+const STATE_PRESENTATION: Record<ProviderSetupState, { label: string; dotClassName: string }> = {
+  connected: { label: "Connected", dotClassName: "bg-status-success" },
+  "needs-sign-in": { label: "Needs sign-in", dotClassName: "bg-warning" },
+  "not-installed": { label: "Not installed", dotClassName: "bg-muted-foreground/40" },
+  disabled: { label: "Disabled", dotClassName: "bg-muted-foreground/40" },
 };
+
+const INLINE_ACTION_CLASS_NAME =
+  "cursor-pointer text-foreground underline decoration-foreground/40 underline-offset-[3px] transition-colors hover:decoration-foreground motion-reduce:transition-none";
 
 /**
  * Raw detection statuses with custom-binary overrides applied but *without* folding the
  * disabled flag in: this step must keep showing "installed" for a provider the user just
- * unchecked, otherwise the row appears to lose its CLI.
+ * unchecked, otherwise the card appears to lose its CLI.
  */
 function useDetectedProviderStatuses(): readonly ServerProviderStatus[] {
   const { settings } = useAppSettings();
@@ -142,6 +143,10 @@ export function ProvidersStep() {
   const summary = summarizeProviderSetup(
     rows.map((row) => ({ provider: row.descriptor.kind, state: row.state })),
   );
+  const connecting = connectingProvider
+    ? rows.find((row) => row.descriptor.kind === connectingProvider)
+    : undefined;
+  const connectingSignInCommand = connecting?.descriptor.usage?.signInCommand;
 
   const toggleConnect = (provider: ProviderKind) => {
     if (connectingProvider === provider) {
@@ -153,91 +158,104 @@ export function ProvidersStep() {
   };
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-xs text-muted-foreground">
-          {summary.connected} connected · {summary.needsSignIn} need sign-in ·{" "}
-          {summary.notInstalled} not installed · {summary.enabled} of {rows.length} enabled
-        </p>
-        <Button size="sm" variant="ghost" disabled={refreshing} onClick={() => void refresh()}>
-          <RefreshCwIcon className={cn("size-3.5", refreshing && "animate-spin")} aria-hidden />
-          Re-detect
-        </Button>
-      </div>
-
-      <div className="max-h-[22rem] space-y-0.5 overflow-y-auto pr-1">
-        {rows.map(({ descriptor, status, state }) => {
-          const badge = STATE_BADGE[state];
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-3 gap-2.5">
+        {rows.map(({ descriptor, state }) => {
+          const presentation = STATE_PRESENTATION[state];
           const enabled = state !== "disabled";
-          const signInCommand = descriptor.usage?.signInCommand;
           const canConnectInline =
-            state === "needs-sign-in" && signInCommand !== undefined && homeDir !== null;
+            state === "needs-sign-in" &&
+            descriptor.usage?.signInCommand !== undefined &&
+            homeDir !== null;
           const isConnecting = connectingProvider === descriptor.kind;
+          const checkboxId = `onboarding-provider-${descriptor.kind}`;
           return (
-            <div key={descriptor.kind} className="rounded-lg">
-              <div className="flex items-center gap-3 px-2 py-2">
-                <Checkbox
-                  checked={enabled}
-                  aria-label={`${enabled ? "Disable" : "Enable"} ${descriptor.displayName}`}
-                  onCheckedChange={(checked) =>
-                    setProviderDisabled(descriptor.kind, checked !== true)
-                  }
-                />
-                <ProviderIcon
-                  provider={descriptor.kind}
-                  className={cn("size-5 shrink-0", !enabled && "opacity-50")}
-                />
-                <span className="flex min-w-0 flex-1 flex-col">
+            <div
+              key={descriptor.kind}
+              className={cn(
+                "flex h-[60px] items-center gap-3 px-3.5 transition-opacity motion-reduce:transition-none",
+                ONBOARDING_TILE_CLASS_NAME,
+                !enabled && "opacity-50",
+              )}
+            >
+              <ProviderIcon provider={descriptor.kind} className="size-5 shrink-0" />
+              <label
+                htmlFor={checkboxId}
+                className="flex min-w-0 flex-1 cursor-pointer flex-col gap-0.5"
+              >
+                <span className="truncate text-[length:var(--app-font-size-ui-lg,13px)] font-medium text-foreground">
+                  {descriptor.displayName}
+                </span>
+                <span className="flex items-center gap-1.5 text-[length:var(--app-font-size-ui-sm,11px)] text-muted-foreground">
                   <span
-                    className={cn("text-sm", enabled ? "text-foreground" : "text-muted-foreground")}
-                  >
-                    {descriptor.displayName}
-                  </span>
-                  {status?.version ? (
-                    <span className="text-xs text-muted-foreground">v{status.version}</span>
+                    aria-hidden
+                    className={cn("size-1.5 shrink-0 rounded-full", presentation.dotClassName)}
+                  />
+                  {presentation.label}
+                  {canConnectInline ? (
+                    <button
+                      type="button"
+                      className={cn("ml-1", INLINE_ACTION_CLASS_NAME)}
+                      onClick={(event) => {
+                        event.preventDefault();
+                        toggleConnect(descriptor.kind);
+                      }}
+                    >
+                      {isConnecting ? "Done" : "Sign in"}
+                    </button>
+                  ) : null}
+                  {state === "not-installed" ? (
+                    <a
+                      href={descriptor.setupDocsHref}
+                      target="_blank"
+                      rel="noreferrer"
+                      className={cn("ml-1", INLINE_ACTION_CLASS_NAME)}
+                      onClick={(event) => event.stopPropagation()}
+                    >
+                      Guide
+                    </a>
                   ) : null}
                 </span>
-                <Badge variant={badge.variant}>{badge.label}</Badge>
-                {canConnectInline ? (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => toggleConnect(descriptor.kind)}
-                  >
-                    {isConnecting ? "Done" : "Sign in"}
-                  </Button>
-                ) : null}
-                {state === "not-installed" ? (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    render={<a href={descriptor.setupDocsHref} target="_blank" rel="noreferrer" />}
-                  >
-                    Setup guide
-                  </Button>
-                ) : null}
-              </div>
-              {canConnectInline ? (
-                <DisclosureRegion open={isConnecting} contentClassName="px-2 pb-2">
-                  {isConnecting && signInCommand !== undefined && homeDir !== null ? (
-                    <ProviderConnectTerminal
-                      provider={descriptor.kind}
-                      signInCommand={signInCommand}
-                      cwd={homeDir}
-                    />
-                  ) : null}
-                </DisclosureRegion>
-              ) : null}
+              </label>
+              <Checkbox
+                id={checkboxId}
+                checked={enabled}
+                aria-label={`${enabled ? "Disable" : "Enable"} ${descriptor.displayName}`}
+                onCheckedChange={(checked) =>
+                  setProviderDisabled(descriptor.kind, checked !== true)
+                }
+              />
             </div>
           );
         })}
       </div>
 
-      <p className="text-xs text-muted-foreground">
-        Unchecked providers are disabled on the server: no discovery, health checks, or new turns
-        until you re-enable them in Settings → Providers. Install a missing CLI, sign in from a
-        fresh terminal, then re-detect.
-      </p>
+      <div className="flex items-center justify-between gap-3 text-[length:var(--app-font-size-ui,12px)] text-muted-foreground">
+        <span>
+          {summary.connected} connected · {summary.needsSignIn} need sign-in ·{" "}
+          {summary.notInstalled} not installed
+        </span>
+        <button
+          type="button"
+          disabled={refreshing}
+          className="inline-flex cursor-pointer items-center gap-1.5 text-foreground/70 transition-colors hover:text-foreground disabled:opacity-60 motion-reduce:transition-none"
+          onClick={() => void refresh()}
+        >
+          <RefreshCwIcon className={cn("size-3.5", refreshing && "animate-spin")} aria-hidden />
+          Re-detect
+        </button>
+      </div>
+
+      <DisclosureRegion open={connecting !== undefined}>
+        {connecting && connectingSignInCommand !== undefined && homeDir !== null ? (
+          <ProviderConnectTerminal
+            key={connecting.descriptor.kind}
+            provider={connecting.descriptor.kind}
+            signInCommand={connectingSignInCommand}
+            cwd={homeDir}
+          />
+        ) : null}
+      </DisclosureRegion>
     </div>
   );
 }

--- a/apps/web/src/onboarding/steps/ProvidersStep.tsx
+++ b/apps/web/src/onboarding/steps/ProvidersStep.tsx
@@ -62,27 +62,57 @@ function useDetectedProviderStatuses(): readonly ServerProviderStatus[] {
   );
 }
 
-function setDisabled(
-  current: ReadonlyArray<ProviderKind>,
-  provider: ProviderKind,
-  disabled: boolean,
-): ProviderKind[] {
-  const without = current.filter((entry) => entry !== provider);
-  return disabled ? [...without, provider] : without;
+/**
+ * Optimistic disabled-provider selection. `disabledProviders` is server-owned and is not
+ * applied to local settings until the round-trip completes, so deriving each write from
+ * `settings.disabledProviders` would let a second toggle rebuild the list without the
+ * first change. Every write instead comes from this draft, and the draft only resyncs
+ * from the server once no write is in flight (e.g. after a failed request is rolled back).
+ */
+function useDisabledProvidersDraft(): {
+  readonly disabled: ReadonlySet<ProviderKind>;
+  readonly setProviderDisabled: (provider: ProviderKind, disabled: boolean) => void;
+} {
+  const { settings, updateSettingsAndWait } = useAppSettings();
+  const [draft, setDraft] = useState<ReadonlySet<ProviderKind>>(
+    () => new Set(settings.disabledProviders),
+  );
+  const draftRef = useRef(draft);
+  const pendingWritesRef = useRef(0);
+  const serverDisabledProviders = settings.disabledProviders;
+
+  useEffect(() => {
+    if (pendingWritesRef.current > 0) return;
+    const next = new Set(serverDisabledProviders);
+    draftRef.current = next;
+    setDraft(next);
+  }, [serverDisabledProviders]);
+
+  const setProviderDisabled = (provider: ProviderKind, disabled: boolean) => {
+    const next = new Set(draftRef.current);
+    if (disabled) {
+      next.add(provider);
+    } else {
+      next.delete(provider);
+    }
+    draftRef.current = next;
+    setDraft(next);
+    pendingWritesRef.current += 1;
+    void updateSettingsAndWait({ disabledProviders: [...next] }).finally(() => {
+      pendingWritesRef.current -= 1;
+    });
+  };
+
+  return { disabled: draft, setProviderDisabled };
 }
 
 export function ProvidersStep() {
-  const { settings, updateSettings } = useAppSettings();
   const statuses = useDetectedProviderStatuses();
   const refreshProviderStatuses = useRefreshProviderStatusesNow();
   const homeDir = useWorkspacePathsStore((store) => store.homeDir);
   const [connectingProvider, setConnectingProvider] = useState<ProviderKind | null>(null);
   const [refreshing, setRefreshing] = useState(false);
-
-  const disabledSet = useMemo(
-    () => new Set<ProviderKind>(settings.disabledProviders),
-    [settings.disabledProviders],
-  );
+  const { disabled: disabledSet, setProviderDisabled } = useDisabledProvidersDraft();
 
   const refresh = async () => {
     setRefreshing(true);
@@ -150,13 +180,7 @@ export function ProvidersStep() {
                   checked={enabled}
                   aria-label={`${enabled ? "Disable" : "Enable"} ${descriptor.displayName}`}
                   onCheckedChange={(checked) =>
-                    updateSettings({
-                      disabledProviders: setDisabled(
-                        settings.disabledProviders,
-                        descriptor.kind,
-                        !Boolean(checked),
-                      ),
-                    })
+                    setProviderDisabled(descriptor.kind, checked !== true)
                   }
                 />
                 <ProviderIcon

--- a/apps/web/src/onboarding/steps/ProvidersStep.tsx
+++ b/apps/web/src/onboarding/steps/ProvidersStep.tsx
@@ -15,7 +15,7 @@ import { ProviderIcon } from "~/components/ProviderIcon";
 import { Checkbox } from "~/components/ui/checkbox";
 import { DisclosureRegion } from "~/components/ui/DisclosureRegion";
 import { useRefreshProviderStatusesNow } from "~/hooks/useProviderStatusRefresh";
-import { RefreshCwIcon } from "~/lib/icons";
+import { RefreshCwIcon, XIcon } from "~/lib/icons";
 import {
   findProviderStatus,
   normalizeProviderStatusForLocalConfig,
@@ -79,15 +79,18 @@ function useDisabledProvidersDraft(): {
     () => new Set(settings.disabledProviders),
   );
   const draftRef = useRef(draft);
-  const pendingWritesRef = useRef(0);
+  // State, not a ref: a rejected write refetches settings *before* the count drops, so the
+  // resync must run again once the final write settles or the draft would stay rolled
+  // forward on the rejected value.
+  const [pendingWrites, setPendingWrites] = useState(0);
   const serverDisabledProviders = settings.disabledProviders;
 
   useEffect(() => {
-    if (pendingWritesRef.current > 0) return;
+    if (pendingWrites > 0) return;
     const next = new Set(serverDisabledProviders);
     draftRef.current = next;
     setDraft(next);
-  }, [serverDisabledProviders]);
+  }, [pendingWrites, serverDisabledProviders]);
 
   const setProviderDisabled = (provider: ProviderKind, disabled: boolean) => {
     const next = new Set(draftRef.current);
@@ -98,9 +101,9 @@ function useDisabledProvidersDraft(): {
     }
     draftRef.current = next;
     setDraft(next);
-    pendingWritesRef.current += 1;
+    setPendingWrites((count) => count + 1);
     void updateSettingsAndWait({ disabledProviders: [...next] }).finally(() => {
-      pendingWritesRef.current -= 1;
+      setPendingWrites((count) => count - 1);
     });
   };
 
@@ -118,7 +121,7 @@ export function ProvidersStep() {
   const refresh = async () => {
     setRefreshing(true);
     try {
-      await refreshProviderStatuses({ silent: true });
+      await refreshProviderStatuses();
     } finally {
       setRefreshing(false);
     }
@@ -148,14 +151,28 @@ export function ProvidersStep() {
     : undefined;
   const connectingSignInCommand = connecting?.descriptor.usage?.signInCommand;
 
+  const finishConnect = () => {
+    setConnectingProvider(null);
+    void refreshProviderStatuses({ silent: true });
+  };
   const toggleConnect = (provider: ProviderKind) => {
     if (connectingProvider === provider) {
-      setConnectingProvider(null);
-      void refresh();
+      finishConnect();
       return;
     }
     setConnectingProvider(provider);
   };
+
+  // The terminal mounts below the provider grid in a fixed-height dialog; bring it into
+  // view so the sign-in prompt is not left under the scroll fold.
+  const terminalRegionRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!connectingProvider) return;
+    const frame = window.requestAnimationFrame(() => {
+      terminalRegionRef.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [connectingProvider]);
 
   return (
     <div className="flex flex-col gap-3">
@@ -248,12 +265,30 @@ export function ProvidersStep() {
 
       <DisclosureRegion open={connecting !== undefined}>
         {connecting && connectingSignInCommand !== undefined && homeDir !== null ? (
-          <ProviderConnectTerminal
-            key={connecting.descriptor.kind}
-            provider={connecting.descriptor.kind}
-            signInCommand={connectingSignInCommand}
-            cwd={homeDir}
-          />
+          <div ref={terminalRegionRef} className="flex flex-col gap-1.5">
+            {/* Always-available close: the card's "Done" link disappears once the
+                provider is detected as connected, but the terminal stays mounted. */}
+            <div className="flex items-center justify-between text-[length:var(--app-font-size-ui,12px)] text-muted-foreground">
+              <span>
+                Signing in to {connecting.descriptor.displayName} ·{" "}
+                <code className="text-foreground/80">{connectingSignInCommand}</code>
+              </span>
+              <button
+                type="button"
+                className="inline-flex cursor-pointer items-center gap-1 text-foreground/70 transition-colors hover:text-foreground motion-reduce:transition-none"
+                onClick={finishConnect}
+              >
+                <XIcon className="size-3.5" aria-hidden />
+                Done
+              </button>
+            </div>
+            <ProviderConnectTerminal
+              key={connecting.descriptor.kind}
+              provider={connecting.descriptor.kind}
+              signInCommand={connectingSignInCommand}
+              cwd={homeDir}
+            />
+          </div>
         ) : null}
       </DisclosureRegion>
     </div>

--- a/apps/web/src/onboarding/steps/ThemeStep.tsx
+++ b/apps/web/src/onboarding/steps/ThemeStep.tsx
@@ -1,0 +1,20 @@
+// FILE: ThemeStep.tsx
+// Purpose: Appearance step of the welcome tour: pick System / Light / Dark with the shared
+//          theme-mode picker. Changes apply live so the user sees the result behind the dialog.
+// Layer: Web UI component
+
+import { ThemeModePicker } from "~/components/settings/ThemeModePicker";
+import { useTheme } from "~/hooks/useTheme";
+
+export function ThemeStep() {
+  const { theme, setTheme } = useTheme();
+  return (
+    <div className="space-y-4">
+      <ThemeModePicker value={theme} onValueChange={setTheme} ariaLabel="Theme preference" />
+      <p className="text-xs text-muted-foreground">
+        Custom color packs, fonts, density, and the app icon live in Settings → Appearance. Terminal
+        colors follow the theme automatically.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/onboarding/steps/ThemeStep.tsx
+++ b/apps/web/src/onboarding/steps/ThemeStep.tsx
@@ -43,9 +43,14 @@ export function ThemeStep() {
   const selectPack = (codeThemeId: string) => {
     for (const variant of THEME_VARIANTS) setCodeThemeId(variant, codeThemeId);
   };
+  // A single-variant pack (chosen earlier in Settings) is not in this list; fall back to
+  // the first option as the roving tab stop so the group stays reachable by keyboard.
+  const rovingValue = ONBOARDING_THEME_PACK_IDS.includes(selectedPackId)
+    ? selectedPackId
+    : (ONBOARDING_THEME_PACK_IDS[0] ?? selectedPackId);
   const radioItemProps = useRadioGroupKeyboardNav({
     values: ONBOARDING_THEME_PACK_IDS,
-    value: selectedPackId,
+    value: rovingValue,
     onValueChange: selectPack,
   });
 

--- a/apps/web/src/onboarding/steps/ThemeStep.tsx
+++ b/apps/web/src/onboarding/steps/ThemeStep.tsx
@@ -1,20 +1,108 @@
 // FILE: ThemeStep.tsx
-// Purpose: Appearance step of the welcome tour: pick System / Light / Dark with the shared
-//          theme-mode picker. Changes apply live so the user sees the result behind the dialog.
+// Purpose: Appearance step of the welcome tour: System / Light / Dark with the shared
+//          theme-mode picker, then the theme pack. Changes apply live behind the dialog.
 // Layer: Web UI component
 
 import { ThemeModePicker } from "~/components/settings/ThemeModePicker";
+import { useRadioGroupKeyboardNav } from "~/hooks/useRadioGroupKeyboardNav";
 import { useTheme } from "~/hooks/useTheme";
+import { cn } from "~/lib/utils";
+import { CODE_THEME_OPTIONS, getCodeThemeSeed, type ThemeVariant } from "~/theme/theme.logic";
+
+/**
+ * Packs that ship both a light and a dark variant. Picking one here sets it for both
+ * variants so the choice holds whichever mode the system lands on; single-variant packs
+ * stay in Settings → Appearance where each variant is edited on its own.
+ */
+const ONBOARDING_THEME_PACKS = CODE_THEME_OPTIONS.filter(
+  (option) => option.variants.includes("light") && option.variants.includes("dark"),
+);
+const ONBOARDING_THEME_PACK_IDS = ONBOARDING_THEME_PACKS.map((option) => option.id);
+const THEME_VARIANTS: readonly ThemeVariant[] = ["light", "dark"];
+
+/** Surface disc with the pack's accent as a corner dot, in the variant the app resolves to. */
+function ThemePackSwatch(props: { codeThemeId: string; variant: ThemeVariant }) {
+  const seed = getCodeThemeSeed(props.codeThemeId, props.variant);
+  return (
+    <span
+      aria-hidden
+      className="relative inline-block size-[18px] shrink-0 rounded-full border"
+      style={{ backgroundColor: seed.surface, borderColor: `${seed.ink}40` }}
+    >
+      <span
+        className="absolute -right-px -bottom-px size-2 rounded-full border-[1.5px] border-popover"
+        style={{ backgroundColor: seed.accent }}
+      />
+    </span>
+  );
+}
 
 export function ThemeStep() {
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, activeTheme, resolvedTheme, setCodeThemeId } = useTheme();
+  const selectedPackId = activeTheme.codeThemeId;
+  const selectPack = (codeThemeId: string) => {
+    for (const variant of THEME_VARIANTS) setCodeThemeId(variant, codeThemeId);
+  };
+  const radioItemProps = useRadioGroupKeyboardNav({
+    values: ONBOARDING_THEME_PACK_IDS,
+    value: selectedPackId,
+    onValueChange: selectPack,
+  });
+
   return (
-    <div className="space-y-4">
-      <ThemeModePicker value={theme} onValueChange={setTheme} ariaLabel="Theme preference" />
-      <p className="text-xs text-muted-foreground">
-        Custom color packs, fonts, density, and the app icon live in Settings → Appearance. Terminal
-        colors follow the theme automatically.
-      </p>
+    <div className="flex flex-col gap-[22px]">
+      <div className="px-[100px]">
+        <ThemeModePicker value={theme} onValueChange={setTheme} ariaLabel="Theme preference" />
+      </div>
+      <div className="flex flex-col gap-2.5">
+        <div className="flex items-baseline justify-between">
+          <span
+            id="onboarding-theme-pack-label"
+            className="text-[length:var(--app-font-size-ui,12px)] font-medium text-foreground/80"
+          >
+            Theme
+          </span>
+          <span className="text-[length:var(--app-font-size-ui-sm,11px)] text-muted-foreground/80">
+            Applies to both light and dark
+          </span>
+        </div>
+        <div
+          role="radiogroup"
+          aria-labelledby="onboarding-theme-pack-label"
+          className="grid grid-cols-5 gap-2"
+        >
+          {ONBOARDING_THEME_PACKS.map((option) => {
+            const selected = option.id === selectedPackId;
+            return (
+              <button
+                key={option.id}
+                type="button"
+                role="radio"
+                aria-checked={selected}
+                className={cn(
+                  "flex h-9 min-w-0 cursor-pointer items-center gap-2.5 rounded-[10px] border bg-popover px-2.5 text-start outline-none transition-colors motion-reduce:transition-none",
+                  "focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset",
+                  selected
+                    ? "border-foreground ring-1 ring-foreground ring-inset"
+                    : "border-foreground/9 hover:border-foreground/25",
+                )}
+                onClick={() => selectPack(option.id)}
+                {...radioItemProps(option.id)}
+              >
+                <ThemePackSwatch codeThemeId={option.id} variant={resolvedTheme} />
+                <span
+                  className={cn(
+                    "truncate text-[length:var(--app-font-size-ui,12px)] text-foreground",
+                    selected && "font-medium",
+                  )}
+                >
+                  {option.label}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/onboarding/steps/WelcomeStep.tsx
+++ b/apps/web/src/onboarding/steps/WelcomeStep.tsx
@@ -1,0 +1,76 @@
+// FILE: WelcomeStep.tsx
+// Purpose: Intro card of the welcome tour: what Synara is and the three ideas that shape
+//          everything that follows (local-first, bring your own agents, verify before done).
+// Layer: Web UI component
+
+import { APP_BASE_NAME } from "~/branding";
+import { BotIcon, CircleCheckIcon, FolderIcon, type LucideIcon } from "~/lib/icons";
+import { SYNARA_DOCS_URL } from "../tourContent";
+
+const WELCOME_POINTS: ReadonlyArray<{
+  readonly title: string;
+  readonly description: string;
+  readonly icon: LucideIcon;
+}> = [
+  {
+    title: "Local-first, no account required",
+    description:
+      "Workspace data stays on this machine. Synara is the control surface, not a proxy for your provider traffic.",
+    icon: FolderIcon,
+  },
+  {
+    title: "Bring the agents you already use",
+    description:
+      "Synara does not include a model subscription. It drives the provider CLIs, accounts, and API keys already configured here.",
+    icon: BotIcon,
+  },
+  {
+    title: "Verification is part of the job",
+    description:
+      "Every task keeps its diff, terminal, browser, and pull-request delivery in one loop so you can check the result before calling it done.",
+    icon: CircleCheckIcon,
+  },
+];
+
+export function WelcomeStep() {
+  return (
+    <div className="space-y-5">
+      <p className="text-sm leading-relaxed text-muted-foreground">
+        {APP_BASE_NAME} is a free, open-source, local-first workspace and control plane for coding
+        agents. It brings provider sessions, tasks, terminals, browser work, diffs, Git worktrees,
+        handoffs, automations, and pull-request delivery into one application.
+      </p>
+      <ul className="space-y-3">
+        {WELCOME_POINTS.map((point) => {
+          const Icon = point.icon;
+          return (
+            <li key={point.title} className="flex gap-3">
+              <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted/60 text-foreground">
+                <Icon className="size-4" aria-hidden />
+              </span>
+              <span className="min-w-0 space-y-0.5">
+                <span className="block text-sm font-medium text-foreground">{point.title}</span>
+                <span className="block text-sm leading-relaxed text-muted-foreground">
+                  {point.description}
+                </span>
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+      <p className="text-xs text-muted-foreground">
+        This setup takes about a minute. You can replay it later from Settings, and the full guide
+        lives at{" "}
+        <a
+          href={SYNARA_DOCS_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="text-foreground underline underline-offset-2"
+        >
+          trysynara.com/docs
+        </a>
+        .
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/onboarding/steps/WelcomeStep.tsx
+++ b/apps/web/src/onboarding/steps/WelcomeStep.tsx
@@ -1,11 +1,11 @@
 // FILE: WelcomeStep.tsx
-// Purpose: Intro card of the welcome tour: what Synara is and the three ideas that shape
-//          everything that follows (local-first, bring your own agents, verify before done).
+// Purpose: Intro of the welcome tour: the three ideas that shape everything that follows
+//          (local-first, bring your own agents, verify before done), one quiet tile each.
 // Layer: Web UI component
 
-import { APP_BASE_NAME } from "~/branding";
 import { BotIcon, CircleCheckIcon, FolderIcon, type LucideIcon } from "~/lib/icons";
-import { SYNARA_DOCS_URL } from "../tourContent";
+import { cn } from "~/lib/utils";
+import { ONBOARDING_TILE_CLASS_NAME } from "../layout";
 
 const WELCOME_POINTS: ReadonlyArray<{
   readonly title: string;
@@ -13,64 +13,42 @@ const WELCOME_POINTS: ReadonlyArray<{
   readonly icon: LucideIcon;
 }> = [
   {
-    title: "Local-first, no account required",
-    description:
-      "Workspace data stays on this machine. Synara is the control surface, not a proxy for your provider traffic.",
+    title: "Local-first",
+    description: "No account. Workspace data stays on this machine.",
     icon: FolderIcon,
   },
   {
-    title: "Bring the agents you already use",
-    description:
-      "Synara does not include a model subscription. It drives the provider CLIs, accounts, and API keys already configured here.",
+    title: "Your own agents",
+    description: "Drives the CLIs, accounts and keys already set up here.",
     icon: BotIcon,
   },
   {
-    title: "Verification is part of the job",
-    description:
-      "Every task keeps its diff, terminal, browser, and pull-request delivery in one loop so you can check the result before calling it done.",
+    title: "Verify before done",
+    description: "Diff, terminal, browser and PR stay in one loop.",
     icon: CircleCheckIcon,
   },
 ];
 
 export function WelcomeStep() {
   return (
-    <div className="space-y-5">
-      <p className="text-sm leading-relaxed text-muted-foreground">
-        {APP_BASE_NAME} is a free, open-source, local-first workspace and control plane for coding
-        agents. It brings provider sessions, tasks, terminals, browser work, diffs, Git worktrees,
-        handoffs, automations, and pull-request delivery into one application.
-      </p>
-      <ul className="space-y-3">
-        {WELCOME_POINTS.map((point) => {
-          const Icon = point.icon;
-          return (
-            <li key={point.title} className="flex gap-3">
-              <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted/60 text-foreground">
-                <Icon className="size-4" aria-hidden />
-              </span>
-              <span className="min-w-0 space-y-0.5">
-                <span className="block text-sm font-medium text-foreground">{point.title}</span>
-                <span className="block text-sm leading-relaxed text-muted-foreground">
-                  {point.description}
-                </span>
-              </span>
-            </li>
-          );
-        })}
-      </ul>
-      <p className="text-xs text-muted-foreground">
-        This setup takes about a minute. You can replay it later from Settings, and the full guide
-        lives at{" "}
-        <a
-          href={SYNARA_DOCS_URL}
-          target="_blank"
-          rel="noreferrer"
-          className="text-foreground underline underline-offset-2"
-        >
-          trysynara.com/docs
-        </a>
-        .
-      </p>
-    </div>
+    <ul className="grid grid-cols-3 gap-4">
+      {WELCOME_POINTS.map((point) => {
+        const Icon = point.icon;
+        return (
+          <li
+            key={point.title}
+            className={cn("flex flex-col gap-2.5 p-5", ONBOARDING_TILE_CLASS_NAME)}
+          >
+            <Icon className="size-[18px] text-foreground/80" aria-hidden />
+            <span className="text-[length:var(--app-font-size-ui-lg,13px)] font-medium text-foreground">
+              {point.title}
+            </span>
+            <span className="text-[length:var(--app-font-size-ui,12px)] leading-normal text-muted-foreground">
+              {point.description}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
   );
 }

--- a/apps/web/src/onboarding/tourContent.ts
+++ b/apps/web/src/onboarding/tourContent.ts
@@ -1,0 +1,122 @@
+// FILE: tourContent.ts
+// Purpose: Copy and links for the "what Synara can do" tour. Wording mirrors the public
+//          docs (trysynara.com/docs) and changelog so onboarding and docs stay consistent.
+// Layer: Web content (no React)
+
+import type { LucideIcon } from "~/lib/icons";
+import {
+  BotIcon,
+  ClockIcon,
+  GitForkIcon,
+  GitPullRequestIcon,
+  GlobeIcon,
+  KeyboardIcon,
+  TerminalIcon,
+} from "~/lib/icons";
+
+export const SYNARA_DOCS_URL = "https://trysynara.com/docs";
+
+export interface TourCard {
+  readonly id: string;
+  /** Short tab label. */
+  readonly label: string;
+  readonly title: string;
+  readonly description: string;
+  readonly highlights: ReadonlyArray<string>;
+  readonly docsHref: string;
+  readonly icon: LucideIcon;
+}
+
+export const TOUR_CARDS: ReadonlyArray<TourCard> = [
+  {
+    id: "agents",
+    label: "Any agent",
+    title: "Run every coding agent in one workspace",
+    description:
+      "Synara sits around the agent runtimes you already trust: Claude Code, Codex, Cursor, Devin, Antigravity, Grok, Factory Droid, OpenCode, and Pi. The provider keeps its account, models, and limits. Synara owns the durable task, environment, transcript, and delivery workflow around it.",
+    highlights: [
+      "Switch models mid-thread",
+      "Hand a thread to another provider",
+      "Usage for every provider",
+    ],
+    docsHref: `${SYNARA_DOCS_URL}/getting-started/providers`,
+    icon: BotIcon,
+  },
+  {
+    id: "tasks",
+    label: "Tasks & worktrees",
+    title: "One task, one isolated environment",
+    description:
+      "Each task owns one body of work: its conversation, provider session, working environment, tool activity, and Git changes. Run tasks in parallel on managed Git worktrees so two agents never edit the same checkout.",
+    highlights: ["Managed worktrees", "Forks from any message", "Subagents and side chats"],
+    docsHref: `${SYNARA_DOCS_URL}/workflows/worktrees`,
+    icon: GitForkIcon,
+  },
+  {
+    id: "review",
+    label: "Review & PRs",
+    title: "From objective to evidence",
+    description:
+      "A task is complete only after you understand and verify its result, not when the provider reports it is finished. Inspect diffs, run terminals, then commit, push, and open a pull request without leaving the workspace.",
+    highlights: [
+      "Diff review with file tree",
+      "Commit → push → PR",
+      "Native pull-request workspace",
+    ],
+    docsHref: `${SYNARA_DOCS_URL}/workflows/pull-requests`,
+    icon: GitPullRequestIcon,
+  },
+  {
+    id: "browser",
+    label: "Browser & devices",
+    title: "Verify in a real browser or simulator",
+    description:
+      "Agents drive a visible, task-owned browser you can watch and annotate. On macOS, an iOS Simulator pane streams the device so agents can build, launch, and tap through an app while you follow along.",
+    highlights: ["Shared Chromium surface", "Element annotations", "iOS Simulator pane"],
+    docsHref: `${SYNARA_DOCS_URL}/workflows/browser-verification`,
+    icon: GlobeIcon,
+  },
+  {
+    id: "automations",
+    label: "Automations & goals",
+    title: "Hand off work that should keep moving",
+    description:
+      "Schedule recurring runs, attach a persistent goal to a thread so it keeps going after each clean turn, and let Synara bring you back when something needs attention. Scheduled does not mean autonomous approval.",
+    highlights: [
+      "Interval, daily, cron schedules",
+      "Natural-language stop conditions",
+      "Thread goals",
+    ],
+    docsHref: `${SYNARA_DOCS_URL}/workflows/automations`,
+    icon: ClockIcon,
+  },
+  {
+    id: "gateway",
+    label: "Agent Gateway",
+    title: "Let agents operate Synara itself",
+    description:
+      "A built-in MCP surface lets a supported provider session create tasks, wait on them, read transcripts, and steer other threads. Pair Codex, Claude Code, or Claude Desktop from outside with scoped, revocable credentials.",
+    highlights: ["Parallel task batches", "External MCP pairing", "Approval boundaries"],
+    docsHref: `${SYNARA_DOCS_URL}/workflows/agent-gateway`,
+    icon: TerminalIcon,
+  },
+  {
+    id: "shortcuts",
+    label: "Shortcuts",
+    title: "Keep your hands on the keyboard",
+    description:
+      "Everything in the workspace has a shortcut, and the keymap is editable from Settings. A few worth learning on day one:",
+    highlights: [],
+    docsHref: `${SYNARA_DOCS_URL}/reference/keyboard-shortcuts`,
+    icon: KeyboardIcon,
+  },
+];
+
+/** Keybinding commands surfaced on the shortcuts card and the final step. */
+export const TOUR_SHORTCUT_COMMANDS = [
+  { command: "chat.new", label: "New task" },
+  { command: "sidebar.addProject", label: "Add project" },
+  { command: "sidebar.search", label: "Search sidebar" },
+  { command: "terminal.toggle", label: "Toggle terminal" },
+  { command: "diff.toggle", label: "Toggle diff" },
+] as const;

--- a/apps/web/src/onboarding/useOnboarding.ts
+++ b/apps/web/src/onboarding/useOnboarding.ts
@@ -1,12 +1,13 @@
 // FILE: useOnboarding.ts
-// Purpose: Decide when the welcome tour opens (first run with no ordinary projects) and
-//          persist completion to both server settings and local storage.
+// Purpose: Decide when the welcome tour opens (first run with no ordinary projects), keep that
+//          decision revisable until authoritative data lands, and persist completion to the
+//          server with a local fallback that is reconciled on later launches.
 // Layer: Web hook
 // Depends on: app settings, server settings query, orchestration store, spaces membership rule.
 
 import { useQuery } from "@tanstack/react-query";
 import { Schema } from "effect";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 
 import { useAppSettings } from "../appSettings";
 import { useLocalStorage } from "../hooks/useLocalStorage";
@@ -14,7 +15,7 @@ import { serverSettingsQueryOptions } from "../lib/serverReactQuery";
 import { isOrdinarySpaceProject } from "../lib/spaces";
 import { useStore } from "../store";
 import { useWorkspacePathsStore } from "../workspacePathsStore";
-import { resolveOnboardingGate, type OnboardingGate } from "./logic";
+import { resolveOnboardingCompletionToReconcile, resolveOnboardingGate } from "./logic";
 import { useOnboardingDialogStore } from "./onboardingDialogStore";
 
 const ONBOARDING_STORAGE_KEY = "synara:onboarding:v1";
@@ -39,7 +40,7 @@ export function useOnboarding(): UseOnboardingResult {
     INITIAL_STORAGE,
     OnboardingStorageSchema,
   );
-  const { settings, updateSettings } = useAppSettings();
+  const { updateSettingsAndWait } = useAppSettings();
   const settingsQuery = useQuery(serverSettingsQueryOptions());
   const threadsHydrated = useStore((store) => store.threadsHydrated);
   const homeDir = useWorkspacePathsStore((store) => store.homeDir);
@@ -53,65 +54,78 @@ export function useOnboarding(): UseOnboardingResult {
         isOrdinarySpaceProject(project, { homeDir, chatWorkspaceRoot, studioWorkspaceRoot }),
       ).length,
   );
-  const imperativeOpen = useOnboardingDialogStore((store) => store.isOpen);
-  const setImperativeOpen = useOnboardingDialogStore((store) => store.setOpen);
-
-  const [gate, setGate] = useState<OnboardingGate>("pending");
-  // Latch the first non-pending decision: projects created during the tour (or by the
-  // desktop bootstrap) must not flip the dialog closed mid-flow.
-  const latchedRef = useRef(false);
+  const isOpen = useOnboardingDialogStore((store) => store.isOpen);
+  const openReason = useOnboardingDialogStore((store) => store.openReason);
+  const engaged = useOnboardingDialogStore((store) => store.engaged);
+  const openStore = useOnboardingDialogStore((store) => store.open);
+  const closeStore = useOnboardingDialogStore((store) => store.close);
 
   const settingsSettled = settingsQuery.isSuccess || settingsQuery.isError;
+  const settingsAvailable = settingsQuery.isSuccess;
   const serverCompletedAt = settingsQuery.data?.onboardingCompletedAt ?? null;
   const localCompletedAt = storage.completedAt;
 
-  useEffect(() => {
-    if (latchedRef.current) {
-      return;
-    }
-    const resolved = resolveOnboardingGate({
-      threadsHydrated,
-      settingsSettled,
-      settingsAvailable: settingsQuery.isSuccess,
-      projectCount,
-      serverCompletedAt,
-      localCompletedAt,
-    });
-    if (resolved === "pending") {
-      return;
-    }
-    latchedRef.current = true;
-    setGate(resolved);
-  }, [
+  const gate = resolveOnboardingGate({
     threadsHydrated,
     settingsSettled,
-    settingsQuery.isSuccess,
     projectCount,
     serverCompletedAt,
     localCompletedAt,
-  ]);
+  });
+
+  // Open on the first "show"; revise a first-run open back to closed if authoritative data
+  // later proves the install is configured (desktop can hydrate from a transient empty
+  // startup snapshot, and an errored settings query can recover with a server marker), but
+  // only while the user is still reading the intro/tour and has made no setup choices.
+  useEffect(() => {
+    if (gate === "show" && !isOpen) {
+      openStore("first-run");
+      return;
+    }
+    if (gate === "hidden" && isOpen && openReason === "first-run" && !engaged) {
+      closeStore();
+    }
+  }, [closeStore, engaged, gate, isOpen, openReason, openStore]);
+
+  // Reconcile the server marker once per session: a completion whose write failed, or an
+  // installation that predates the tour. Failures leave the local marker in place so the
+  // next launch retries.
+  const reconcileAttemptedRef = useRef(false);
+  const completedAtToReconcile = resolveOnboardingCompletionToReconcile({
+    threadsHydrated,
+    settingsAvailable,
+    projectCount,
+    serverCompletedAt,
+    localCompletedAt,
+    now: new Date().toISOString(),
+  });
+  useEffect(() => {
+    if (completedAtToReconcile === null || reconcileAttemptedRef.current) {
+      return;
+    }
+    reconcileAttemptedRef.current = true;
+    void updateSettingsAndWait({ onboardingCompletedAt: completedAtToReconcile });
+  }, [completedAtToReconcile, updateSettingsAndWait]);
 
   const complete = () => {
     const completedAt = new Date().toISOString();
+    // Local first so the gate flips to hidden synchronously; the server write is awaited
+    // through the settings mutation queue and, if it fails, reconciled on the next launch.
     setStorage({ completedAt });
-    if (settings.onboardingCompletedAt === null) {
-      updateSettings({ onboardingCompletedAt: completedAt });
+    closeStore();
+    if (serverCompletedAt === null) {
+      void updateSettingsAndWait({ onboardingCompletedAt: completedAt });
     }
-    latchedRef.current = true;
-    setGate("hidden");
-    setImperativeOpen(false);
   };
 
   const onOpenChange = (open: boolean) => {
-    if (open) {
-      setImperativeOpen(true);
-      return;
+    if (!open) {
+      complete();
     }
-    complete();
   };
 
   return {
-    isOpen: gate === "show" || imperativeOpen,
+    isOpen,
     complete,
     onOpenChange,
   };

--- a/apps/web/src/onboarding/useOnboarding.ts
+++ b/apps/web/src/onboarding/useOnboarding.ts
@@ -1,9 +1,9 @@
 // FILE: useOnboarding.ts
 // Purpose: Decide when the welcome tour opens (first run with no ordinary projects), keep that
 //          decision revisable until authoritative data lands, and persist completion to the
-//          server with a local fallback that is reconciled on later launches.
+//          server with an installation-scoped local fallback reconciled on later launches.
 // Layer: Web hook
-// Depends on: app settings, server settings query, orchestration store, spaces membership rule.
+// Depends on: app settings, server settings/config queries, orchestration store, spaces rule.
 
 import { useQuery } from "@tanstack/react-query";
 import { Schema } from "effect";
@@ -11,21 +11,27 @@ import { useEffect, useRef } from "react";
 
 import { useAppSettings } from "../appSettings";
 import { useLocalStorage } from "../hooks/useLocalStorage";
-import { serverSettingsQueryOptions } from "../lib/serverReactQuery";
+import { serverConfigQueryOptions, serverSettingsQueryOptions } from "../lib/serverReactQuery";
 import { isOrdinarySpaceProject } from "../lib/spaces";
 import { useStore } from "../store";
 import { useWorkspacePathsStore } from "../workspacePathsStore";
-import { resolveOnboardingCompletionToReconcile, resolveOnboardingGate } from "./logic";
+import {
+  resolveLocalOnboardingCompletion,
+  resolveOnboardingCompletionToReconcile,
+  resolveOnboardingGate,
+  type LocalOnboardingCompletion,
+} from "./logic";
 import { useOnboardingDialogStore } from "./onboardingDialogStore";
 
-const ONBOARDING_STORAGE_KEY = "synara:onboarding:v1";
+// v2: the marker carries the installation it was recorded against.
+const ONBOARDING_STORAGE_KEY = "synara:onboarding:v2";
 
 const OnboardingStorageSchema = Schema.Struct({
   completedAt: Schema.NullOr(Schema.String),
+  installationKey: Schema.NullOr(Schema.String),
 });
-type OnboardingStorage = typeof OnboardingStorageSchema.Type;
 
-const INITIAL_STORAGE: OnboardingStorage = { completedAt: null };
+const INITIAL_STORAGE: LocalOnboardingCompletion = { completedAt: null, installationKey: null };
 
 export interface UseOnboardingResult {
   readonly isOpen: boolean;
@@ -42,6 +48,13 @@ export function useOnboarding(): UseOnboardingResult {
   );
   const { updateSettingsAndWait } = useAppSettings();
   const settingsQuery = useQuery(serverSettingsQueryOptions());
+  // The worktrees directory lives under the server's state directory, so it identifies
+  // the installation this browser is currently talking to.
+  const installationKeyQuery = useQuery({
+    ...serverConfigQueryOptions(),
+    select: (config) => config.worktreesDir,
+  });
+  const installationKey = installationKeyQuery.data ?? null;
   const threadsHydrated = useStore((store) => store.threadsHydrated);
   const homeDir = useWorkspacePathsStore((store) => store.homeDir);
   const chatWorkspaceRoot = useWorkspacePathsStore((store) => store.chatWorkspaceRoot);
@@ -59,11 +72,12 @@ export function useOnboarding(): UseOnboardingResult {
   const engaged = useOnboardingDialogStore((store) => store.engaged);
   const openStore = useOnboardingDialogStore((store) => store.open);
   const closeStore = useOnboardingDialogStore((store) => store.close);
+  const markStartupGateSettled = useOnboardingDialogStore((store) => store.markStartupGateSettled);
 
   const settingsSettled = settingsQuery.isSuccess || settingsQuery.isError;
   const settingsAvailable = settingsQuery.isSuccess;
   const serverCompletedAt = settingsQuery.data?.onboardingCompletedAt ?? null;
-  const localCompletedAt = storage.completedAt;
+  const localCompletedAt = resolveLocalOnboardingCompletion(storage, installationKey);
 
   const gate = resolveOnboardingGate({
     threadsHydrated,
@@ -78,6 +92,8 @@ export function useOnboarding(): UseOnboardingResult {
   // startup snapshot, and an errored settings query can recover with a server marker), but
   // only while the user is still reading the intro/tour and has made no setup choices.
   useEffect(() => {
+    if (gate === "pending") return;
+    markStartupGateSettled();
     if (gate === "show" && !isOpen) {
       openStore("first-run");
       return;
@@ -85,7 +101,7 @@ export function useOnboarding(): UseOnboardingResult {
     if (gate === "hidden" && isOpen && openReason === "first-run" && !engaged) {
       closeStore();
     }
-  }, [closeStore, engaged, gate, isOpen, openReason, openStore]);
+  }, [closeStore, engaged, gate, isOpen, markStartupGateSettled, openReason, openStore]);
 
   // Reconcile the server marker once per session: a completion whose write failed, or an
   // installation that predates the tour. Failures leave the local marker in place so the
@@ -111,7 +127,7 @@ export function useOnboarding(): UseOnboardingResult {
     const completedAt = new Date().toISOString();
     // Local first so the gate flips to hidden synchronously; the server write is awaited
     // through the settings mutation queue and, if it fails, reconciled on the next launch.
-    setStorage({ completedAt });
+    setStorage({ completedAt, installationKey });
     closeStore();
     if (serverCompletedAt === null) {
       void updateSettingsAndWait({ onboardingCompletedAt: completedAt });

--- a/apps/web/src/onboarding/useOnboarding.ts
+++ b/apps/web/src/onboarding/useOnboarding.ts
@@ -7,7 +7,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { Schema } from "effect";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useAppSettings } from "../appSettings";
 import { useLocalStorage } from "../hooks/useLocalStorage";
@@ -46,6 +46,8 @@ export function useOnboarding(): UseOnboardingResult {
     INITIAL_STORAGE,
     OnboardingStorageSchema,
   );
+  const [sessionCompletion, setSessionCompletion] =
+    useState<LocalOnboardingCompletion>(INITIAL_STORAGE);
   const { updateSettingsAndWait } = useAppSettings();
   const settingsQuery = useQuery(serverSettingsQueryOptions());
   // The worktrees directory lives under the server's state directory, so it identifies
@@ -55,6 +57,21 @@ export function useOnboarding(): UseOnboardingResult {
     select: (config) => config.worktreesDir,
   });
   const installationKey = installationKeyQuery.data ?? null;
+  // A Settings replay can finish before config arrives. Keep that dismissal in memory,
+  // then bind it to the first known identity so another installation can still open its tour.
+  useEffect(() => {
+    if (
+      installationKey !== null &&
+      sessionCompletion.completedAt !== null &&
+      sessionCompletion.installationKey === null
+    ) {
+      setSessionCompletion({ ...sessionCompletion, installationKey });
+    }
+  }, [installationKey, sessionCompletion]);
+  const sessionCompletedAt =
+    sessionCompletion.installationKey === null
+      ? sessionCompletion.completedAt
+      : resolveLocalOnboardingCompletion(sessionCompletion, installationKey);
   const threadsHydrated = useStore((store) => store.threadsHydrated);
   const homeDir = useWorkspacePathsStore((store) => store.homeDir);
   const chatWorkspaceRoot = useWorkspacePathsStore((store) => store.chatWorkspaceRoot);
@@ -80,12 +97,12 @@ export function useOnboarding(): UseOnboardingResult {
   const localCompletedAt = resolveLocalOnboardingCompletion(storage, installationKey);
 
   const gate = resolveOnboardingGate({
-    installationKeyStatus: installationKeyQuery.status,
+    installationKeyStatus: installationKey !== null ? "success" : installationKeyQuery.status,
     threadsHydrated,
     settingsSettled,
     projectCount,
     serverCompletedAt,
-    localCompletedAt,
+    localCompletedAt: localCompletedAt ?? sessionCompletedAt,
   });
 
   // Open on the first "show"; revise a first-run open back to closed if authoritative data
@@ -126,6 +143,7 @@ export function useOnboarding(): UseOnboardingResult {
 
   const complete = () => {
     const completedAt = new Date().toISOString();
+    setSessionCompletion({ completedAt, installationKey });
     // Keep the fallback scoped even when Settings manually opens the tour before config
     // arrives. Only a known installation can safely retain a failed server write.
     if (installationKey !== null) {

--- a/apps/web/src/onboarding/useOnboarding.ts
+++ b/apps/web/src/onboarding/useOnboarding.ts
@@ -80,6 +80,7 @@ export function useOnboarding(): UseOnboardingResult {
   const localCompletedAt = resolveLocalOnboardingCompletion(storage, installationKey);
 
   const gate = resolveOnboardingGate({
+    installationKeyStatus: installationKeyQuery.status,
     threadsHydrated,
     settingsSettled,
     projectCount,
@@ -125,9 +126,11 @@ export function useOnboarding(): UseOnboardingResult {
 
   const complete = () => {
     const completedAt = new Date().toISOString();
-    // Local first so the gate flips to hidden synchronously; the server write is awaited
-    // through the settings mutation queue and, if it fails, reconciled on the next launch.
-    setStorage({ completedAt, installationKey });
+    // Keep the fallback scoped even when Settings manually opens the tour before config
+    // arrives. Only a known installation can safely retain a failed server write.
+    if (installationKey !== null) {
+      setStorage({ completedAt, installationKey });
+    }
     closeStore();
     if (serverCompletedAt === null) {
       void updateSettingsAndWait({ onboardingCompletedAt: completedAt });

--- a/apps/web/src/onboarding/useOnboarding.ts
+++ b/apps/web/src/onboarding/useOnboarding.ts
@@ -1,0 +1,118 @@
+// FILE: useOnboarding.ts
+// Purpose: Decide when the welcome tour opens (first run with no ordinary projects) and
+//          persist completion to both server settings and local storage.
+// Layer: Web hook
+// Depends on: app settings, server settings query, orchestration store, spaces membership rule.
+
+import { useQuery } from "@tanstack/react-query";
+import { Schema } from "effect";
+import { useEffect, useRef, useState } from "react";
+
+import { useAppSettings } from "../appSettings";
+import { useLocalStorage } from "../hooks/useLocalStorage";
+import { serverSettingsQueryOptions } from "../lib/serverReactQuery";
+import { isOrdinarySpaceProject } from "../lib/spaces";
+import { useStore } from "../store";
+import { useWorkspacePathsStore } from "../workspacePathsStore";
+import { resolveOnboardingGate, type OnboardingGate } from "./logic";
+import { useOnboardingDialogStore } from "./onboardingDialogStore";
+
+const ONBOARDING_STORAGE_KEY = "synara:onboarding:v1";
+
+const OnboardingStorageSchema = Schema.Struct({
+  completedAt: Schema.NullOr(Schema.String),
+});
+type OnboardingStorage = typeof OnboardingStorageSchema.Type;
+
+const INITIAL_STORAGE: OnboardingStorage = { completedAt: null };
+
+export interface UseOnboardingResult {
+  readonly isOpen: boolean;
+  /** Marks the tour finished (or skipped) and closes it. */
+  readonly complete: () => void;
+  readonly onOpenChange: (open: boolean) => void;
+}
+
+export function useOnboarding(): UseOnboardingResult {
+  const [storage, setStorage] = useLocalStorage(
+    ONBOARDING_STORAGE_KEY,
+    INITIAL_STORAGE,
+    OnboardingStorageSchema,
+  );
+  const { settings, updateSettings } = useAppSettings();
+  const settingsQuery = useQuery(serverSettingsQueryOptions());
+  const threadsHydrated = useStore((store) => store.threadsHydrated);
+  const homeDir = useWorkspacePathsStore((store) => store.homeDir);
+  const chatWorkspaceRoot = useWorkspacePathsStore((store) => store.chatWorkspaceRoot);
+  const studioWorkspaceRoot = useWorkspacePathsStore((store) => store.studioWorkspaceRoot);
+  // The Home chat and Studio containers are created automatically, so "no projects yet"
+  // must count ordinary projects only or the tour would never show.
+  const projectCount = useStore(
+    (store) =>
+      store.projects.filter((project) =>
+        isOrdinarySpaceProject(project, { homeDir, chatWorkspaceRoot, studioWorkspaceRoot }),
+      ).length,
+  );
+  const imperativeOpen = useOnboardingDialogStore((store) => store.isOpen);
+  const setImperativeOpen = useOnboardingDialogStore((store) => store.setOpen);
+
+  const [gate, setGate] = useState<OnboardingGate>("pending");
+  // Latch the first non-pending decision: projects created during the tour (or by the
+  // desktop bootstrap) must not flip the dialog closed mid-flow.
+  const latchedRef = useRef(false);
+
+  const settingsSettled = settingsQuery.isSuccess || settingsQuery.isError;
+  const serverCompletedAt = settingsQuery.data?.onboardingCompletedAt ?? null;
+  const localCompletedAt = storage.completedAt;
+
+  useEffect(() => {
+    if (latchedRef.current) {
+      return;
+    }
+    const resolved = resolveOnboardingGate({
+      threadsHydrated,
+      settingsSettled,
+      settingsAvailable: settingsQuery.isSuccess,
+      projectCount,
+      serverCompletedAt,
+      localCompletedAt,
+    });
+    if (resolved === "pending") {
+      return;
+    }
+    latchedRef.current = true;
+    setGate(resolved);
+  }, [
+    threadsHydrated,
+    settingsSettled,
+    settingsQuery.isSuccess,
+    projectCount,
+    serverCompletedAt,
+    localCompletedAt,
+  ]);
+
+  const complete = () => {
+    const completedAt = new Date().toISOString();
+    setStorage({ completedAt });
+    if (settings.onboardingCompletedAt === null) {
+      updateSettings({ onboardingCompletedAt: completedAt });
+    }
+    latchedRef.current = true;
+    setGate("hidden");
+    setImperativeOpen(false);
+  };
+
+  const onOpenChange = (open: boolean) => {
+    if (open) {
+      setImperativeOpen(true);
+      return;
+    }
+    complete();
+  };
+
+  return {
+    isOpen: gate === "show" || imperativeOpen,
+    complete,
+    onOpenChange,
+  };
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -29,6 +29,8 @@ import { DesktopWindowControls } from "../components/DesktopWindowControls";
 import { RunningChatsQuitCoordinator } from "../components/RunningChatsQuitCoordinator";
 import { AppSnapCoordinator } from "../components/AppSnapCoordinator";
 import { AppSnapWelcomeDialog } from "../components/AppSnapWelcomeDialog";
+import { OnboardingDialog } from "../onboarding/OnboardingDialog";
+import { useOnboarding } from "../onboarding/useOnboarding";
 import { QueuedComposerDrainCoordinator } from "../components/QueuedComposerDrainCoordinator";
 import { FeedbackDialog } from "../components/FeedbackDialog";
 import { SETTINGS_TARGETS } from "../settingsNavigation";
@@ -307,6 +309,7 @@ function RootRouteView() {
           <TaskCompletionNotifications />
           <QueuedComposerDrainCoordinator />
           <AppSnapWelcomeDialog />
+          <GlobalOnboardingDialog />
           <AppSnapCoordinator />
           <DesktopProjectBootstrap />
           <Outlet />
@@ -772,6 +775,17 @@ function GlobalFeedbackDialog() {
   };
 
   return <FeedbackDialog open={isOpen} context={context} onOpenChange={setOpen} />;
+}
+
+function GlobalOnboardingDialog() {
+  const onboarding = useOnboarding();
+  return (
+    <OnboardingDialog
+      open={onboarding.isOpen}
+      onOpenChange={onboarding.onOpenChange}
+      onComplete={onboarding.complete}
+    />
+  );
 }
 
 function GlobalWhatsNewSurface() {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -20,7 +20,16 @@ import {
   useParams,
   useRouterState,
 } from "@tanstack/react-router";
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  Suspense,
+  lazy,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { QueryClient, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Throttler } from "@tanstack/react-pacer";
 
@@ -29,7 +38,6 @@ import { DesktopWindowControls } from "../components/DesktopWindowControls";
 import { RunningChatsQuitCoordinator } from "../components/RunningChatsQuitCoordinator";
 import { AppSnapCoordinator } from "../components/AppSnapCoordinator";
 import { AppSnapWelcomeDialog } from "../components/AppSnapWelcomeDialog";
-import { OnboardingDialog } from "../onboarding/OnboardingDialog";
 import { useOnboarding } from "../onboarding/useOnboarding";
 import { QueuedComposerDrainCoordinator } from "../components/QueuedComposerDrainCoordinator";
 import { FeedbackDialog } from "../components/FeedbackDialog";
@@ -777,14 +785,31 @@ function GlobalFeedbackDialog() {
   return <FeedbackDialog open={isOpen} context={context} onOpenChange={setOpen} />;
 }
 
+// The dialog pulls in the provider sign-in terminal (xterm and addons), so it stays out
+// of the eager router graph and only loads the first time the tour actually opens.
+const OnboardingDialog = lazy(() =>
+  import("../onboarding/OnboardingDialog").then((module) => ({
+    default: module.OnboardingDialog,
+  })),
+);
+
 function GlobalOnboardingDialog() {
   const onboarding = useOnboarding();
+  // Stay mounted after the first open so the close animation can play and a replay
+  // from Settings does not re-suspend.
+  const [hasOpened, setHasOpened] = useState(false);
+  useEffect(() => {
+    if (onboarding.isOpen) setHasOpened(true);
+  }, [onboarding.isOpen]);
+  if (!hasOpened) return null;
   return (
-    <OnboardingDialog
-      open={onboarding.isOpen}
-      onOpenChange={onboarding.onOpenChange}
-      onComplete={onboarding.complete}
-    />
+    <Suspense fallback={null}>
+      <OnboardingDialog
+        open={onboarding.isOpen}
+        onOpenChange={onboarding.onOpenChange}
+        onComplete={onboarding.complete}
+      />
+    </Suspense>
   );
 }
 

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -78,6 +78,7 @@ import {
   AutocompletePopup,
 } from "../components/ui/autocomplete";
 import { Button } from "../components/ui/button";
+import { useOnboardingDialogStore } from "../onboarding/onboardingDialogStore";
 import { Input } from "../components/ui/input";
 import { SelectItem } from "../components/ui/select";
 import { Switch } from "../components/ui/switch";
@@ -521,6 +522,19 @@ function SettingsRouteView() {
                 New worktree
               </SelectItem>
             </SettingsSelectControl>
+          }
+        />
+
+        <SettingsRow
+          title="Welcome tour"
+          description="Replay the first-run setup: feature tour, provider selection, appearance, and first project."
+          control={
+            <Button
+              variant="outline"
+              onClick={() => useOnboardingDialogStore.getState().openDialog()}
+            >
+              Open welcome tour
+            </Button>
           }
         />
       </SettingsSection>

--- a/apps/web/src/settingsSearchIndex.ts
+++ b/apps/web/src/settingsSearchIndex.ts
@@ -47,6 +47,13 @@ export const SETTINGS_SEARCH_ENTRIES: readonly SettingsSearchEntry[] = [
       "Pick the default workspace mode for newly created draft threads. local worktree environment",
   },
   {
+    id: "general:welcome-tour",
+    section: "general",
+    title: "Welcome tour",
+    keywords:
+      "Replay the first-run setup: feature tour, provider selection, appearance, and first project. onboarding welcome wizard getting started setup",
+  },
+  {
     id: "general:project-order",
     section: "general",
     title: "Project order",

--- a/apps/web/src/test/browserHarness.ts
+++ b/apps/web/src/test/browserHarness.ts
@@ -1,4 +1,8 @@
-import type { ServerConfig } from "@synara/contracts";
+import {
+  DEFAULT_SERVER_SETTINGS_VIEW,
+  type ServerConfig,
+  type ServerSettingsView,
+} from "@synara/contracts";
 
 export function createBrowserTestServerConfig(checkedAt: string): ServerConfig {
   return {
@@ -19,6 +23,15 @@ export function createBrowserTestServerConfig(checkedAt: string): ServerConfig {
     ],
     availableEditors: [],
   };
+}
+
+/**
+ * Server settings for full-app browser fixtures. The onboarding marker is set so the
+ * first-run welcome tour (which gates on "no projects and never completed") does not open
+ * over the surface under test; the tour has its own coverage.
+ */
+export function createBrowserTestServerSettings(completedAt: string): ServerSettingsView {
+  return { ...DEFAULT_SERVER_SETTINGS_VIEW, onboardingCompletedAt: completedAt };
 }
 
 export function createFullscreenTestHost(): HTMLDivElement {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -1,5 +1,5 @@
 import { Schema } from "effect";
-import { TrimmedString } from "./baseSchemas";
+import { IsoDateTime, TrimmedString } from "./baseSchemas";
 import { DEFAULT_GIT_TEXT_GENERATION_MODEL } from "./model";
 import { ModelSelection, ProviderKind, ThreadEnvironmentMode } from "./orchestration";
 
@@ -111,6 +111,9 @@ export const ServerSettings = Schema.Struct({
     pi: PiServerProviderSettings.pipe(Schema.withDecodingDefault(() => ({}))),
   }).pipe(Schema.withDecodingDefault(() => ({}))),
   skills: SkillsServerSettings.pipe(Schema.withDecodingDefault(() => ({}))),
+  // When the first-run welcome tour was completed or skipped. Server-backed so a
+  // browser-storage reset does not replay setup on an already configured install.
+  onboardingCompletedAt: Schema.optionalKey(Schema.NullOr(IsoDateTime)),
 });
 export type ServerSettings = typeof ServerSettings.Type;
 
@@ -189,6 +192,7 @@ export const ServerSettingsPatch = Schema.Struct({
       disabled: Schema.optionalKey(Schema.Array(Schema.String.check(Schema.isMaxLength(256)))),
     }),
   ),
+  onboardingCompletedAt: Schema.optionalKey(Schema.NullOr(IsoDateTime)),
 });
 export type ServerSettingsPatch = typeof ServerSettingsPatch.Type;
 

--- a/packages/shared/src/providerMetadata.ts
+++ b/packages/shared/src/providerMetadata.ts
@@ -15,6 +15,8 @@ export interface ProviderDescriptor {
    * can route steers without a runtime round-trip; keep the two in sync.
    */
   readonly supportsNativeTurnSteering: boolean;
+  /** Synara docs page covering install, sign-in, and verification for this runtime. */
+  readonly setupDocsHref: string;
   readonly usage: {
     readonly signInCommand: string;
     readonly learnMoreHref: string;
@@ -35,6 +37,7 @@ export const PROVIDER_DESCRIPTORS = defineProviderDescriptors([
     kind: "codex",
     displayName: PROVIDER_DISPLAY_NAMES.codex,
     available: true,
+    setupDocsHref: "https://trysynara.com/docs/providers/codex",
     supportsNativeTurnSteering: true,
     usage: {
       signInCommand: "codex login",
@@ -45,6 +48,7 @@ export const PROVIDER_DESCRIPTORS = defineProviderDescriptors([
     kind: "claudeAgent",
     displayName: PROVIDER_DISPLAY_NAMES.claudeAgent,
     available: true,
+    setupDocsHref: "https://trysynara.com/docs/providers/claude-code",
     supportsNativeTurnSteering: true,
     usage: {
       signInCommand: "claude",
@@ -55,6 +59,7 @@ export const PROVIDER_DESCRIPTORS = defineProviderDescriptors([
     kind: "cursor",
     displayName: PROVIDER_DISPLAY_NAMES.cursor,
     available: true,
+    setupDocsHref: "https://trysynara.com/docs/providers/cursor",
     supportsNativeTurnSteering: false,
     usage: {
       signInCommand: "cursor-agent login",
@@ -65,6 +70,7 @@ export const PROVIDER_DESCRIPTORS = defineProviderDescriptors([
     kind: "antigravity",
     displayName: PROVIDER_DISPLAY_NAMES.antigravity,
     available: true,
+    setupDocsHref: "https://trysynara.com/docs/providers/antigravity",
     supportsNativeTurnSteering: false,
     usage: {
       signInCommand: "agy",
@@ -75,6 +81,7 @@ export const PROVIDER_DESCRIPTORS = defineProviderDescriptors([
     kind: "grok",
     displayName: PROVIDER_DISPLAY_NAMES.grok,
     available: true,
+    setupDocsHref: "https://trysynara.com/docs/providers/grok",
     supportsNativeTurnSteering: false,
     usage: {
       signInCommand: "grok login",
@@ -85,6 +92,7 @@ export const PROVIDER_DESCRIPTORS = defineProviderDescriptors([
     kind: "droid",
     displayName: PROVIDER_DISPLAY_NAMES.droid,
     available: true,
+    setupDocsHref: "https://trysynara.com/docs/providers/factory-droid",
     supportsNativeTurnSteering: false,
     usage: {
       signInCommand: "droid",
@@ -95,6 +103,7 @@ export const PROVIDER_DESCRIPTORS = defineProviderDescriptors([
     kind: "opencode",
     displayName: PROVIDER_DISPLAY_NAMES.opencode,
     available: true,
+    setupDocsHref: "https://trysynara.com/docs/providers/opencode",
     supportsNativeTurnSteering: false,
     usage: {
       signInCommand: "opencode auth login",
@@ -105,6 +114,7 @@ export const PROVIDER_DESCRIPTORS = defineProviderDescriptors([
     kind: "pi",
     displayName: PROVIDER_DISPLAY_NAMES.pi,
     available: true,
+    setupDocsHref: "https://trysynara.com/docs/providers/pi",
     supportsNativeTurnSteering: true,
     usage: {
       signInCommand: "pi",
@@ -115,6 +125,7 @@ export const PROVIDER_DESCRIPTORS = defineProviderDescriptors([
     kind: "devin",
     displayName: PROVIDER_DISPLAY_NAMES.devin,
     available: true,
+    setupDocsHref: "https://trysynara.com/docs/providers/devin",
     supportsNativeTurnSteering: false,
     usage: {
       signInCommand: "devin auth login",


### PR DESCRIPTION
## What Changed

- Added a six-step first-run onboarding dialog covering welcome, feature tour, providers, theme, project setup, and completion.
- Added provider detection, enable/disable controls, inline sign-in terminals, project creation, and appearance setup.
- Added persistent server-backed onboarding completion state with a local fallback.
- Added reusable onboarding logic and focused unit tests for navigation, gating, provider classification, summaries, and selection toggling.
- Added a Settings entry point to replay onboarding.

## Why

New installations now receive guided setup before entering the main workspace. The flow helps users configure available agents, choose an appearance, add an initial project, and understand key Synara capabilities while preserving safe behavior across reloads and server reconfiguration.

## UI Changes

- Added the interactive onboarding modal and progress footer.
- Added feature-tour tabs, provider setup status, inline authentication terminals, project folder selection, and completion summary.
- Screenshots and interaction video are not included in this draft.

## Verification

- Added focused tests in `apps/web/src/onboarding/logic.test.ts`.
- After the Cursor findings were repaired, all 23 focused onboarding logic tests passed. The first regression run had 4 failures on the pre-fix source.
- Both hook-level browser regressions passed: a config refetch failure preserves the intro when identity is cached; completing a Settings replay before config arrives stays dismissed, while changing installations still opens the new tour. Both tests failed before the second fix.
- Local browser fixtures mock config/settings responses; live provider sign-in was not exercised locally. Browser runs emitted React act-environment warnings despite passing assertions.
- Current-head Cursor review and complete hosted CI must pass before merge.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches first-launch UX, server settings persistence, and provider sign-in terminals scoped away from real threads; incorrect gating could hide or replay onboarding across installations.
> 
> **Overview**
> Adds a **six-step welcome tour** (intro, feature tabs, agent setup, appearance, first project, done) mounted lazily from the root route, with a Settings control to **replay** it and search indexing for that entry.
> 
> **Completion is persisted** via new server field `onboardingCompletedAt` (contracts + app settings sync/patch), plus an installation-scoped local fallback keyed off `worktreesDir`. Pure gate/reconcile logic decides when to show the tour (fresh install with no ordinary projects), auto-dismiss before the user engages if later data proves the install is already configured, and backfills the server marker for legacy installs or failed writes. **Restore defaults** no longer clears the onboarding timestamp so setup does not replay.
> 
> The tour includes provider detection, enable/disable with optimistic drafts, **inline sign-in terminals** (isolated synthetic thread scope), live theme picking, and project add via shared create/recover. **AppSnap’s welcome sheet** waits on the onboarding startup gate so modals do not stack. Folder drop handling is **factored** into `folderDrop` + `useWindowFolderDrop` (Create Project dialog and onboarding). Browser fixtures stub `serverGetSettings` with completion set so existing UI tests stay unobstructed; unit/browser tests cover gate logic and installation identity edge cases. Provider metadata gains **setup docs links** for missing runtimes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8544b938a0dcb6f0761f175b46f4b7b57e170545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
