### PR TITLE
feat(web): let Side chats pick provider/model before first turn

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -70,7 +70,11 @@ import {
 import { applySpaceMetadataProjection } from "../spaceMetadataProjection.ts";
 import { resolveStableMessageTurnId } from "../messageTurnId.ts";
 import { maxIso, settleTurnStateFromSession } from "../turnLifecycle.ts";
-import { deriveTurnStartModelSelection, deriveTurnStartSession } from "../turnStartSession.ts";
+import {
+  canAdoptFirstTurnProvider,
+  deriveTurnStartModelSelection,
+  deriveTurnStartSession,
+} from "../turnStartSession.ts";
 import {
   attachmentRelativePath,
   parseAttachmentIdFromRelativePath,
@@ -825,14 +829,14 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
               threadId: event.payload.threadId,
             }),
           ]);
-          const canAdoptFirstTurnProvider =
-            existingRow.value.latestTurnId === null &&
-            Option.isNone(session) &&
-            messages.length <= 1;
           const projectedModelSelection = deriveTurnStartModelSelection({
             currentModelSelection: existingRow.value.modelSelection,
             requestedModelSelection: event.payload.modelSelection,
-            canAdoptRequestedProvider: canAdoptFirstTurnProvider,
+            canAdoptRequestedProvider: canAdoptFirstTurnProvider({
+              hasLatestTurn: existingRow.value.latestTurnId !== null,
+              hasSession: Option.isSome(session),
+              messages,
+            }),
           });
           // Automation-dispatched turns run with the automation's modes but must not
           // repaint the thread's persisted modes: on a heartbeat target thread the

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -57,7 +57,11 @@ import {
 } from "./Schemas.ts";
 import { resolveStableMessageTurnId } from "./messageTurnId.ts";
 import { maxIso, settleTurnStateFromSession } from "./turnLifecycle.ts";
-import { deriveTurnStartModelSelection, deriveTurnStartSession } from "./turnStartSession.ts";
+import {
+  canAdoptFirstTurnProvider,
+  deriveTurnStartModelSelection,
+  deriveTurnStartSession,
+} from "./turnStartSession.ts";
 
 type ThreadPatch = Partial<Omit<OrchestrationThread, "id" | "projectId">>;
 const MAX_THREAD_MESSAGES = 2_000;
@@ -968,12 +972,14 @@ export function projectEvent(
           if (!thread) {
             return nextBase;
           }
-          const canAdoptFirstTurnProvider =
-            thread.latestTurn === null && thread.session === null && thread.messages.length <= 1;
           const projectedModelSelection = deriveTurnStartModelSelection({
             currentModelSelection: thread.modelSelection,
             requestedModelSelection: payload.modelSelection,
-            canAdoptRequestedProvider: canAdoptFirstTurnProvider,
+            canAdoptRequestedProvider: canAdoptFirstTurnProvider({
+              hasLatestTurn: thread.latestTurn !== null,
+              hasSession: thread.session !== null,
+              messages: thread.messages,
+            }),
           });
           const modelSelectionPatch =
             projectedModelSelection !== thread.modelSelection

--- a/apps/server/src/orchestration/turnStartSession.test.ts
+++ b/apps/server/src/orchestration/turnStartSession.test.ts
@@ -1,7 +1,11 @@
 import { ThreadId, type OrchestrationSession } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
-import { deriveTurnStartModelSelection, deriveTurnStartSession } from "./turnStartSession.ts";
+import {
+  canAdoptFirstTurnProvider,
+  deriveTurnStartModelSelection,
+  deriveTurnStartSession,
+} from "./turnStartSession.ts";
 
 const THREAD_ID = ThreadId.makeUnsafe("thread-turn-start-session");
 const REQUESTED_AT = "2026-07-21T00:00:00.000Z";
@@ -47,6 +51,32 @@ describe("deriveTurnStartSession", () => {
         canAdoptRequestedProvider: true,
       }),
     ).toEqual({ provider: "pi", model: "openai/gpt-5" });
+  });
+
+  it("ignores fork-import history when deciding first-turn provider adoption", () => {
+    expect(
+      canAdoptFirstTurnProvider({
+        hasLatestTurn: false,
+        hasSession: false,
+        messages: [{ source: "fork-import" }, { source: "fork-import" }, { source: "native" }],
+      }),
+    ).toBe(true);
+
+    expect(
+      canAdoptFirstTurnProvider({
+        hasLatestTurn: false,
+        hasSession: false,
+        messages: [{ source: "fork-import" }, { source: "native" }, { source: "native" }],
+      }),
+    ).toBe(false);
+
+    expect(
+      canAdoptFirstTurnProvider({
+        hasLatestTurn: true,
+        hasSession: false,
+        messages: [{ source: "fork-import" }],
+      }),
+    ).toBe(false);
   });
 
   it("creates a starting session when no session exists", () => {

--- a/apps/server/src/orchestration/turnStartSession.ts
+++ b/apps/server/src/orchestration/turnStartSession.ts
@@ -18,6 +18,30 @@ export function deriveTurnStartModelSelection(input: {
     : input.currentModelSelection;
 }
 
+// Sidechats import source transcript as `fork-import` rows for provider context.
+// Those imports must not freeze the first-turn provider the way native history does.
+export function countNativeTurnStartMessages(
+  messages: ReadonlyArray<{ readonly source?: string | null }>,
+): number {
+  let count = 0;
+  for (const message of messages) {
+    if ((message.source ?? "native") !== "fork-import") {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+export function canAdoptFirstTurnProvider(input: {
+  readonly hasLatestTurn: boolean;
+  readonly hasSession: boolean;
+  readonly messages: ReadonlyArray<{ readonly source?: string | null }>;
+}): boolean {
+  return (
+    !input.hasLatestTurn && !input.hasSession && countNativeTurnStartMessages(input.messages) <= 1
+  );
+}
+
 export function deriveTurnStartSession(input: {
   readonly threadId: ThreadId;
   readonly currentSession: OrchestrationSession | null;

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -25,6 +25,8 @@ import {
   derivePromptHistoryFromMessages,
   failWorktreeSetupSnapshot,
   filterSidechatTranscriptMessages,
+  threadHasProviderLockingActivity,
+  threadHasProviderLockingMessages,
   hasFileUndoSettled,
   isComposerCursorOnFirstLine,
   isComposerCursorOnLastLine,
@@ -845,6 +847,56 @@ describe("voice helpers", () => {
       "message-imported",
       "message-native",
     ]);
+  });
+
+  it("does not lock Side chat providers on fork-import history alone", () => {
+    const importedOnly = {
+      sidechatSourceThreadId: ThreadId.makeUnsafe("source-thread"),
+      latestTurn: null,
+      session: null,
+      messages: [
+        {
+          id: "message-imported" as never,
+          role: "assistant" as const,
+          text: "Previous context",
+          turnId: null,
+          streaming: false,
+          source: "fork-import" as const,
+          createdAt: "2026-05-02T10:00:00.000Z",
+          completedAt: "2026-05-02T10:00:00.000Z",
+        },
+      ],
+    };
+
+    expect(threadHasProviderLockingMessages(importedOnly)).toBe(false);
+    expect(threadHasProviderLockingActivity(importedOnly)).toBe(false);
+
+    const withNative = {
+      ...importedOnly,
+      messages: [
+        ...importedOnly.messages,
+        {
+          id: "message-native" as never,
+          role: "user" as const,
+          text: "Fresh side question",
+          turnId: null,
+          streaming: false,
+          source: "native" as const,
+          createdAt: "2026-05-02T10:01:00.000Z",
+          completedAt: "2026-05-02T10:01:00.000Z",
+        },
+      ],
+    };
+
+    expect(threadHasProviderLockingMessages(withNative)).toBe(true);
+    expect(threadHasProviderLockingActivity(withNative)).toBe(true);
+
+    expect(
+      threadHasProviderLockingMessages({
+        sidechatSourceThreadId: null,
+        messages: importedOnly.messages,
+      }),
+    ).toBe(true);
   });
 
   it("appends a transcript to the existing prompt without disturbing spacing", () => {

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -813,6 +813,26 @@ export function filterSidechatTranscriptMessages(
     : [...messages];
 }
 
+// Imported fork history should not lock a Side chat's provider before its first native turn.
+export function threadHasProviderLockingMessages(
+  thread: Pick<Thread, "messages" | "sidechatSourceThreadId">,
+): boolean {
+  if (!thread.sidechatSourceThreadId) {
+    return thread.messages.length > 0;
+  }
+  return thread.messages.some((message) => (message.source ?? "native") !== "fork-import");
+}
+
+export function threadHasProviderLockingActivity(
+  thread: Pick<Thread, "messages" | "sidechatSourceThreadId" | "latestTurn" | "session">,
+): boolean {
+  return (
+    thread.latestTurn !== null ||
+    thread.session !== null ||
+    threadHasProviderLockingMessages(thread)
+  );
+}
+
 export function revokeBlobPreviewUrl(previewUrl: string | undefined): void {
   if (!previewUrl || typeof URL === "undefined" || !previewUrl.startsWith("blob:")) {
     return;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -252,6 +252,7 @@ import {
 import { buildThreadSubscribeInput } from "../threadDetailResumeCursors";
 import { retainThreadDetailSubscription } from "../threadDetailSubscriptionRetention";
 import {
+  canExecuteSideSlashCommand,
   canOfferForkSlashCommand,
   canOfferSideSlashCommand,
   canOfferReviewSlashCommand,
@@ -602,6 +603,7 @@ import {
   filterSidechatTranscriptMessages,
   hasLiveTurnTakenOver,
   hasServerAcknowledgedLocalDispatch,
+  threadHasProviderLockingActivity,
   LOCAL_DISPATCH_ACK_TIMEOUT_MS,
   LOCAL_DISPATCH_TURN_TAKEOVER_TIMEOUT_MS,
   resolveNextLocalDispatchSnapshot,
@@ -2312,7 +2314,12 @@ export default function ChatView({
       activeThread.messages.length > 0 ||
       activeThread.session !== null),
   );
-  const lockedProvider: ProviderKind | null = hasThreadStarted
+  // Side chats import source history as fork-import rows. Those imports must not lock the
+  // provider picker before the Side produces its first native turn (#810).
+  const hasProviderLockingActivity = Boolean(
+    activeThread && threadHasProviderLockingActivity(activeThread),
+  );
+  const lockedProvider: ProviderKind | null = hasProviderLockingActivity
     ? (sessionProvider ?? threadProvider ?? selectedProviderByThreadId ?? null)
     : null;
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
@@ -3895,17 +3902,24 @@ export default function ChatView({
       selectedMentionCount: selectedComposerMentions.length,
       interactionMode,
     });
+  const sideSlashCommandContext = {
+    imageCount: composerImages.length,
+    terminalContextCount: composerTerminalContexts.length,
+    selectedSkillCount: selectedComposerSkills.length,
+    selectedMentionCount: selectedComposerMentions.length,
+    interactionMode,
+    isSidechat: Boolean(activeThread?.sidechatSourceThreadId),
+  } as const;
+  const canExecuteSideCommand =
+    isServerThread &&
+    activeThread !== undefined &&
+    canExecuteSideSlashCommand(sideSlashCommandContext);
   const canOfferSideCommand =
     isServerThread &&
     activeThread !== undefined &&
     canOfferSideSlashCommand({
       prompt: composerPromptWithoutActiveSlashTrigger,
-      imageCount: composerImages.length,
-      terminalContextCount: composerTerminalContexts.length,
-      selectedSkillCount: selectedComposerSkills.length,
-      selectedMentionCount: selectedComposerMentions.length,
-      interactionMode,
-      isSidechat: Boolean(activeThread.sidechatSourceThreadId),
+      ...sideSlashCommandContext,
     });
   // Export is hidden while the thread is running so archives cannot capture a
   // partial assistant response. Same shared predicate as the server's 409
@@ -10660,7 +10674,7 @@ export default function ChatView({
       isServerThread &&
       activeThread?.session !== null &&
       activeThread?.session?.status !== "closed",
-    canOfferSideCommand,
+    canExecuteSideCommand,
     sidechatTargetProviders: handoffTargetProviders,
     canOfferExportCommand,
     supportsTextNativeReviewCommand,

--- a/apps/web/src/composerSlashCommands.test.ts
+++ b/apps/web/src/composerSlashCommands.test.ts
@@ -4,6 +4,7 @@ import { THREAD_GOAL_MAX_CHARS } from "@synara/contracts";
 import {
   buildReviewPrompt,
   buildSubagentsPrompt,
+  canExecuteSideSlashCommand,
   canOfferForkSlashCommand,
   canOfferReviewSlashCommand,
   canOfferSideSlashCommand,
@@ -237,6 +238,42 @@ describe("composerSlashCommands", () => {
         selectedMentionCount: 0,
         interactionMode: "default",
         isSidechat: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("still executes /side when the composer holds provider args", () => {
+    expect(
+      canExecuteSideSlashCommand({
+        imageCount: 0,
+        terminalContextCount: 0,
+        selectedSkillCount: 0,
+        selectedMentionCount: 0,
+        interactionMode: "default",
+        isSidechat: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      canOfferSideSlashCommand({
+        prompt: "Codex",
+        imageCount: 0,
+        terminalContextCount: 0,
+        selectedSkillCount: 0,
+        selectedMentionCount: 0,
+        interactionMode: "default",
+        isSidechat: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      canExecuteSideSlashCommand({
+        imageCount: 1,
+        terminalContextCount: 0,
+        selectedSkillCount: 0,
+        selectedMentionCount: 0,
+        interactionMode: "default",
+        isSidechat: false,
       }),
     ).toBe(false);
   });

--- a/apps/web/src/composerSlashCommands.ts
+++ b/apps/web/src/composerSlashCommands.ts
@@ -328,6 +328,27 @@ export function canOfferForkSlashCommand(input: {
   );
 }
 
+// Structural Side availability: attachments/mode/thread kind. Prompt emptiness is only
+// required when offering `/side` in the composer menu — executing `/side <provider>
+// [prompt]` intentionally carries args in the composer text.
+export function canExecuteSideSlashCommand(input: {
+  imageCount: number;
+  terminalContextCount: number;
+  selectedSkillCount: number;
+  selectedMentionCount: number;
+  interactionMode: ProviderInteractionMode;
+  isSidechat: boolean;
+}): boolean {
+  return (
+    input.imageCount === 0 &&
+    input.terminalContextCount === 0 &&
+    input.selectedSkillCount === 0 &&
+    input.selectedMentionCount === 0 &&
+    input.interactionMode === "default" &&
+    !input.isSidechat
+  );
+}
+
 export function canOfferSideSlashCommand(input: {
   prompt: string;
   imageCount: number;
@@ -339,12 +360,14 @@ export function canOfferSideSlashCommand(input: {
 }): boolean {
   return (
     !hasMeaningfulComposerText(input.prompt) &&
-    input.imageCount === 0 &&
-    input.terminalContextCount === 0 &&
-    input.selectedSkillCount === 0 &&
-    input.selectedMentionCount === 0 &&
-    input.interactionMode === "default" &&
-    !input.isSidechat
+    canExecuteSideSlashCommand({
+      imageCount: input.imageCount,
+      terminalContextCount: input.terminalContextCount,
+      selectedSkillCount: input.selectedSkillCount,
+      selectedMentionCount: input.selectedMentionCount,
+      interactionMode: input.interactionMode,
+      isSidechat: input.isSidechat,
+    })
   );
 }
 

--- a/apps/web/src/hooks/useComposerSlashCommands.ts
+++ b/apps/web/src/hooks/useComposerSlashCommands.ts
@@ -78,7 +78,7 @@ export function useComposerSlashCommands(input: {
   isLocalDraftThread: boolean;
   supportsFastSlashCommand: boolean;
   canOfferCompactCommand: boolean;
-  canOfferSideCommand: boolean;
+  canExecuteSideCommand: boolean;
   sidechatTargetProviders: ReadonlyArray<ProviderKind>;
   canOfferExportCommand: boolean;
   supportsTextNativeReviewCommand: boolean;
@@ -131,7 +131,7 @@ export function useComposerSlashCommands(input: {
     isLocalDraftThread,
     supportsFastSlashCommand,
     canOfferCompactCommand,
-    canOfferSideCommand,
+    canExecuteSideCommand,
     sidechatTargetProviders,
     canOfferExportCommand,
     supportsTextNativeReviewCommand,
@@ -1012,7 +1012,9 @@ export function useComposerSlashCommands(input: {
         return true;
       }
       if (slashInvocation.command === "side") {
-        if (!canOfferSideCommand) {
+        // Execute allows `/side <provider> [prompt]` even though the menu offer still
+        // requires an otherwise-empty composer (the args are meaningful prompt text).
+        if (!canExecuteSideCommand) {
           toastManager.add({
             type: "warning",
             title: "Side is unavailable",
@@ -1057,7 +1059,7 @@ export function useComposerSlashCommands(input: {
     },
     [
       availableBuiltInSlashCommands,
-      canOfferSideCommand,
+      canExecuteSideCommand,
       checkClaudeFastSlashCommandAvailability,
       compactProviderThread,
       createForkThreadFromSlashCommand,


### PR DESCRIPTION
## Summary

Fixes #810

Side chats import the source transcript as `fork-import` rows. That history previously made the thread look “started,” so the composer provider picker locked immediately and first-turn provider adoption on the server refused a different provider.

This change:

- Unlocks the Side chat provider/model picker until the first Side-native turn (latest turn, session, or non-import message)
- Lets the server adopt the requested first-turn provider even when fork-import history is present
- Keeps `/side <provider> [prompt]` as a shortcut by separating menu offer (empty composer) from execute (attachments/mode only)

Guarded Side relationship and imported transcript behavior are unchanged.

## Test plan

- [x] `bun run --cwd apps/web test src/composerSlashCommands.test.ts src/components/ChatView.logic.test.ts src/lib/sidechatCreation.test.ts`
- [x] `bun run --cwd apps/server test src/orchestration/turnStartSession.test.ts`
- [x] `bun fmt`, `bun lint` (0 errors), `bun typecheck`
- [ ] Open Side from a Claude thread with bare `/side` or the dock action → picker allows switching to Codex (or another eligible provider) before sending
- [ ] Send the first Side prompt after switching provider → turn runs on the selected provider/model
- [ ] After the first Side-native turn, provider stays locked; model changes still follow provider rules
- [ ] `/side Codex is this safe?` no longer shows “Side is unavailable” solely because of the provider args text