### PR TITLE
feat: polish session restart / context-loss rail markers

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -4139,6 +4139,81 @@ describe("ProviderCommandReactor", () => {
     expect(followUpInput?.input).toBe("Continue after interrupt escalation");
   });
 
+  it("attributes context-loss markers to interrupt escalation when history is gone", async () => {
+    const harness = await createHarness({
+      interruptTurn: () =>
+        Effect.fail(
+          new ProviderAdapterRequestError({
+            provider: "codex",
+            method: "turn/interrupt",
+            detail: "connection closed after request write",
+          }),
+        ),
+    });
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const now = new Date().toISOString();
+
+    await dispatchHarnessUserTurn(harness, {
+      messageId: "interrupt-escalation-context-seed",
+      text: "Remember that the release train is amber.",
+      createdAt: now,
+    });
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    harness.setRuntimeSessionTurnState({
+      threadId,
+      status: "running",
+      activeTurnId: asTurnId("turn-1"),
+    });
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.interrupt",
+        commandId: CommandId.makeUnsafe("cmd-interrupt-escalation-context-loss"),
+        threadId,
+        turnId: asTurnId("turn-1"),
+        createdAt: now,
+      }),
+    );
+    await waitFor(async () => (await readHarnessThread(harness))?.session?.status === "stopped");
+    expect(harness.stopRuntimeSession).toHaveBeenCalledWith({ threadId });
+
+    // Simulate residual cursor loss after the escalated stop (e.g. provider-side wipe).
+    await Effect.runPromise(harness.clearSessionResumeCursor({ threadId }));
+
+    await dispatchHarnessUserTurn(harness, {
+      messageId: "interrupt-escalation-context-follow-up",
+      text: "What release train did we pick?",
+      createdAt: new Date().toISOString(),
+    });
+    await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+    const followUpInput = harness.sendTurn.mock.calls[1]?.[0] as { readonly input?: string };
+    expect(followUpInput.input).toBe("What release train did we pick?");
+
+    await waitFor(async () => {
+      const lifecycleActivities = (await readHarnessThread(harness))?.activities.filter(
+        (activity) => activity.kind === "provider.context.changed",
+      );
+      return lifecycleActivities?.length === 1;
+    });
+    const [lifecycleActivity] = (await readHarnessThread(harness))?.activities.filter(
+      (activity) => activity.kind === "provider.context.changed",
+    ) ?? [undefined];
+    expect(lifecycleActivity).toMatchObject({
+      tone: "error",
+      summary: "The turn could not be stopped cleanly, so the session was restarted.",
+      payload: {
+        provider: "codex",
+        nativeHistory: "unavailable",
+        sessionRestarted: true,
+        restartReason: "interrupt-escalation",
+        recapInjected: false,
+        recapCharacters: 0,
+        recapPreview: null,
+        recapPreviewTruncated: false,
+      },
+    });
+  });
+
   it("rolls back provider conversation state for message edits", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();
@@ -9786,7 +9861,7 @@ describe("ProviderCommandReactor", () => {
       ) ?? [undefined];
       expect(lifecycleActivity).toMatchObject({
         tone: "error",
-        summary: "Native session history was unavailable, so the model continued from a recap.",
+        summary: "The session's history was lost, so the model continues from a summary.",
         turnId: asTurnId("turn-1"),
         payload: {
           provider,
@@ -10095,7 +10170,7 @@ describe("ProviderCommandReactor", () => {
     ) ?? [undefined];
     expect(lifecycleActivity).toMatchObject({
       tone: "error",
-      summary: "The session restarted without its native history.",
+      summary: "The session restarted without its previous history.",
       turnId: asTurnId("turn-1"),
       payload: {
         provider: "codex",

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -4655,9 +4655,9 @@ describe("ProviderCommandReactor", () => {
           turnId,
         });
         await waitFor(async () => (await readContextActivities(harness)).length === 1);
-        expect((await readContextActivities(harness))[0]?.payload?.restartReason).not.toBe(
-          "interrupt-escalation",
-        );
+        expect((await readContextActivities(harness))[0]).not.toMatchObject({
+          payload: { restartReason: "interrupt-escalation" },
+        });
       },
     );
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -965,6 +965,7 @@ describe("ProviderCommandReactor", () => {
       readonly messageId: string;
       readonly text: string;
       readonly createdAt: string;
+      readonly attachments?: ReadonlyArray<ChatAttachment>;
     },
   ) {
     await Effect.runPromise(
@@ -976,7 +977,7 @@ describe("ProviderCommandReactor", () => {
           messageId: asMessageId(input.messageId),
           role: "user",
           text: input.text,
-          attachments: [],
+          attachments: input.attachments ?? [],
         },
         interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
         runtimeMode: "approval-required",
@@ -4211,6 +4212,293 @@ describe("ProviderCommandReactor", () => {
         recapPreview: null,
         recapPreviewTruncated: false,
       },
+    });
+  });
+
+  describe("interrupt escalation recovery", () => {
+    async function createEscalatedHarness(
+      provider: "codex" | "claudeAgent" | "opencode" = "codex",
+    ) {
+      const harness = await createHarness({
+        threadModelSelection: {
+          provider,
+          model:
+            provider === "codex"
+              ? "gpt-5-codex"
+              : provider === "claudeAgent"
+                ? "claude-opus-4-8"
+                : "openai/gpt-5",
+        },
+        interruptTurn: () =>
+          Effect.fail(
+            new ProviderAdapterRequestError({
+              provider,
+              method: "turn/interrupt",
+              detail: "connection closed after request write",
+            }),
+          ),
+      });
+      const threadId = ThreadId.makeUnsafe("thread-1");
+      await dispatchHarnessUserTurn(harness, {
+        messageId: "escalation-seed",
+        text: "Remember that the release train is amber.",
+        createdAt: new Date().toISOString(),
+      });
+      await harness.drain();
+      harness.setRuntimeSessionTurnState({
+        threadId,
+        status: "running",
+        activeTurnId: asTurnId("turn-1"),
+      });
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.interrupt",
+          commandId: CommandId.makeUnsafe("cmd-escalation-stop"),
+          threadId,
+          turnId: asTurnId("turn-1"),
+          createdAt: new Date().toISOString(),
+        }),
+      );
+      await harness.drain();
+      expect((await readHarnessThread(harness))?.session?.status).toBe("stopped");
+      return { harness, threadId };
+    }
+
+    async function readContextActivities(harness: Awaited<ReturnType<typeof createHarness>>) {
+      return (
+        (await readHarnessThread(harness))?.activities.filter(
+          (activity) => activity.kind === "provider.context.changed",
+        ) ?? []
+      );
+    }
+
+    it.each(["attachment", "send"] as const)(
+      "retains observed context loss after a failed %s dispatch",
+      async (failure) => {
+        const { harness, threadId } = await createEscalatedHarness();
+        await Effect.runPromise(harness.clearSessionResumeCursor({ threadId }));
+        const attachment = {
+          type: "image",
+          id: `att_v2_${"a1b2c3d4".repeat(4)}`,
+          name: "vanishes.png",
+          mimeType: "image/png",
+          sizeBytes: 3,
+        } as const;
+        if (failure === "attachment") {
+          const attachmentPath = await harness.stageAttachment(attachment);
+          const startSession = harness.startSession.getMockImplementation()!;
+          // Initial command preflight succeeds; the file disappears while the
+          // replacement session starts, before dispatch resolves attachments again.
+          harness.startSession.mockImplementationOnce((...args) =>
+            startSession(...args).pipe(
+              Effect.tap(() => Effect.sync(() => fs.rmSync(attachmentPath))),
+            ),
+          );
+        } else {
+          harness.sendTurn.mockImplementationOnce(() =>
+            Effect.fail(
+              new ProviderAdapterValidationError({
+                provider: "codex",
+                operation: "turn/start",
+                issue: "preflight rejected",
+              }),
+            ),
+          );
+        }
+        await dispatchHarnessUserTurn(harness, {
+          messageId: "escalation-failed-recovery",
+          text: "Which release train did we pick?",
+          createdAt: new Date().toISOString(),
+          ...(failure === "attachment" ? { attachments: [attachment] } : {}),
+        });
+        await harness.drain();
+        expect(harness.startSessionWithOutcome).toHaveBeenCalledTimes(2);
+        expect(harness.sendTurn).toHaveBeenCalledTimes(failure === "attachment" ? 1 : 2);
+        expect(await readContextActivities(harness)).toEqual([]);
+        harness.sendTurn.mockImplementationOnce(() =>
+          Effect.succeed({ threadId, turnId: asTurnId("recovery-accepted") }),
+        );
+        await dispatchHarnessUserTurn(harness, {
+          messageId: "escalation-retry",
+          text: "Retry the question.",
+          createdAt: new Date().toISOString(),
+        });
+        await harness.drain();
+        expect(harness.startSessionWithOutcome).toHaveBeenCalledTimes(2);
+        expect(await readContextActivities(harness)).toEqual([
+          expect.objectContaining({
+            turnId: asTurnId("recovery-accepted"),
+            payload: expect.objectContaining({
+              restartReason: "interrupt-escalation",
+              nativeHistory: "unavailable",
+              sessionRestarted: true,
+              recapInjected: false,
+            }),
+          }),
+        ]);
+      },
+    );
+
+    it("keeps a clean native resume quiet across a rejected send and clears later attribution", async () => {
+      const { harness, threadId } = await createEscalatedHarness();
+      harness.sendTurn.mockImplementationOnce(() =>
+        Effect.fail(
+          new ProviderAdapterValidationError({
+            provider: "codex",
+            operation: "turn/start",
+            issue: "preflight rejected",
+          }),
+        ),
+      );
+      for (const messageId of ["clean-resume-failed", "clean-resume-retry"]) {
+        await dispatchHarnessUserTurn(harness, {
+          messageId,
+          text: "Continue with the saved history.",
+          createdAt: new Date().toISOString(),
+        });
+        await harness.drain();
+      }
+      expect(harness.startSessionWithOutcome).toHaveBeenCalledTimes(2);
+      expect(await readContextActivities(harness)).toEqual([]);
+      await Effect.runPromise(harness.clearSessionResumeCursor({ threadId }));
+      await dispatchHarnessUserTurn(harness, {
+        messageId: "unrelated-history-loss",
+        text: "A later unrelated restart.",
+        createdAt: new Date().toISOString(),
+      });
+      await harness.drain();
+      expect(await readContextActivities(harness)).toEqual([
+        expect.objectContaining({
+          payload: expect.objectContaining({ restartReason: "native-history-unavailable" }),
+        }),
+      ]);
+    });
+
+    it("preserves escalation attribution through Claude late stale-resume recovery", async () => {
+      const { harness, threadId } = await createEscalatedHarness("claudeAgent");
+      const staleResumeFailure = () =>
+        Effect.fail(
+          new ProviderAdapterRequestError({
+            provider: "claudeAgent",
+            method: "turn/setModel",
+            detail:
+              "Claude Code returned an error result: No conversation found with session ID: missing-session",
+          }),
+        );
+      harness.sendTurn
+        .mockImplementationOnce(staleResumeFailure)
+        .mockImplementationOnce(staleResumeFailure)
+        .mockImplementationOnce(() =>
+          Effect.succeed({ threadId, turnId: asTurnId("claude-recovered") }),
+        );
+      await dispatchHarnessUserTurn(harness, {
+        messageId: "claude-escalation-recovery",
+        text: "Which release train did we pick?",
+        createdAt: new Date().toISOString(),
+      });
+      await harness.drain();
+      expect(harness.sendTurn).toHaveBeenCalledTimes(4);
+      expect(harness.sendTurn.mock.calls[3]?.[0].input).toContain(
+        "Remember that the release train is amber.",
+      );
+      expect(await readContextActivities(harness)).toEqual([
+        expect.objectContaining({
+          turnId: asTurnId("claude-recovered"),
+          payload: expect.objectContaining({
+            restartReason: "interrupt-escalation",
+            recapInjected: true,
+          }),
+        }),
+      ]);
+    });
+
+    it("discards pending escalation context when the user explicitly stops recovery", async () => {
+      const { harness, threadId } = await createEscalatedHarness("opencode");
+      await Effect.runPromise(harness.clearSessionResumeCursor({ threadId }));
+      harness.sendTurn.mockImplementationOnce(() =>
+        Effect.fail(
+          new ProviderAdapterValidationError({
+            provider: "opencode",
+            operation: "session/prompt",
+            issue: "preflight rejected",
+          }),
+        ),
+      );
+      await dispatchHarnessUserTurn(harness, {
+        messageId: "discarded-recovery",
+        text: "Try to recover.",
+        createdAt: new Date().toISOString(),
+      });
+      await harness.drain();
+      expect(harness.sendTurn.mock.calls[1]?.[0].input).toContain(
+        "Remember that the release train is amber.",
+      );
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.session.stop",
+          commandId: CommandId.makeUnsafe("cmd-explicit-recovery-stop"),
+          threadId,
+          createdAt: new Date().toISOString(),
+        }),
+      );
+      await harness.drain();
+      await dispatchHarnessUserTurn(harness, {
+        messageId: "after-explicit-recovery-stop",
+        text: "Continue without the discarded summary.",
+        createdAt: new Date().toISOString(),
+      });
+      await harness.drain();
+      expect(harness.sendTurn.mock.calls.at(-1)?.[0].input).toBe(
+        "Continue without the discarded summary.",
+      );
+      expect(await readContextActivities(harness)).toEqual([]);
+    });
+
+    it("retains escalation and summary until asynchronous recovery completes", async () => {
+      const { harness, threadId } = await createEscalatedHarness("opencode");
+      await Effect.runPromise(harness.clearSessionResumeCursor({ threadId }));
+      for (const [index, turnId] of [
+        asTurnId("async-aborted"),
+        asTurnId("async-recovered"),
+      ].entries()) {
+        harness.sendTurn.mockImplementationOnce(() => Effect.succeed({ threadId, turnId }));
+        await dispatchHarnessUserTurn(harness, {
+          messageId: `async-recovery-${index}`,
+          text: "Which release train did we pick?",
+          createdAt: new Date().toISOString(),
+        });
+        await harness.drain();
+        expect(harness.sendTurn.mock.calls[index + 1]?.[0].input).toContain(
+          "Remember that the release train is amber.",
+        );
+        expect(await readContextActivities(harness)).toEqual([]);
+        await emitHarnessTurnTerminal(harness, {
+          provider: "opencode",
+          type: index === 0 ? "aborted" : "completed",
+          eventId: `terminal-${turnId}`,
+          turnId,
+        });
+        await harness.drain();
+      }
+      await waitFor(async () => (await readContextActivities(harness)).length === 1);
+      const activities = await readContextActivities(harness);
+      expect(activities).toEqual([
+        expect.objectContaining({
+          turnId: asTurnId("async-recovered"),
+          payload: expect.objectContaining({
+            restartReason: "interrupt-escalation",
+            recapInjected: true,
+          }),
+        }),
+      ]);
+      await dispatchHarnessUserTurn(harness, {
+        messageId: "after-async-recovery",
+        text: "Continue normally.",
+        createdAt: new Date().toISOString(),
+      });
+      await harness.drain();
+      expect(harness.sendTurn.mock.calls.at(-1)?.[0].input).toBe("Continue normally.");
+      expect(await readContextActivities(harness)).toEqual(activities);
     });
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -12,6 +12,7 @@ import type {
   OrchestrationCommand,
   OrchestrationEvent,
   ProviderForkThreadResult,
+  ProviderKind,
   ProviderRuntimeEvent,
   ProviderSession,
   ServerSettings,
@@ -990,8 +991,8 @@ describe("ProviderCommandReactor", () => {
     harness: Awaited<ReturnType<typeof createHarness>>,
     input: {
       readonly eventId: string;
-      readonly provider: "opencode" | "devin";
-      readonly type: "completed" | "aborted";
+      readonly provider: ProviderKind;
+      readonly type: "completed" | "aborted" | "failed" | "cancelled";
       readonly threadId?: ThreadId;
       readonly turnId?: TurnId;
     },
@@ -1005,11 +1006,11 @@ describe("ProviderCommandReactor", () => {
       providerRefs: {},
     } as const;
     await harness.emitRuntimeEvent(
-      input.type === "completed"
+      input.type !== "aborted"
         ? ({
             ...eventBase,
             type: "turn.completed",
-            payload: { state: "completed" },
+            payload: { state: input.type },
           } as ProviderRuntimeEvent)
         : ({
             ...eventBase,
@@ -4216,9 +4217,7 @@ describe("ProviderCommandReactor", () => {
   });
 
   describe("interrupt escalation recovery", () => {
-    async function createEscalatedHarness(
-      provider: "codex" | "claudeAgent" | "opencode" = "codex",
-    ) {
+    async function createEscalatedHarness(provider: ProviderKind = "codex") {
       const harness = await createHarness({
         threadModelSelection: {
           provider,
@@ -4374,43 +4373,69 @@ describe("ProviderCommandReactor", () => {
       ]);
     });
 
-    it("preserves escalation attribution through Claude late stale-resume recovery", async () => {
-      const { harness, threadId } = await createEscalatedHarness("claudeAgent");
-      const staleResumeFailure = () =>
-        Effect.fail(
-          new ProviderAdapterRequestError({
-            provider: "claudeAgent",
-            method: "turn/setModel",
-            detail:
-              "Claude Code returned an error result: No conversation found with session ID: missing-session",
-          }),
-        );
-      harness.sendTurn
-        .mockImplementationOnce(staleResumeFailure)
-        .mockImplementationOnce(staleResumeFailure)
-        .mockImplementationOnce(() =>
-          Effect.succeed({ threadId, turnId: asTurnId("claude-recovered") }),
-        );
-      await dispatchHarnessUserTurn(harness, {
-        messageId: "claude-escalation-recovery",
-        text: "Which release train did we pick?",
-        createdAt: new Date().toISOString(),
-      });
-      await harness.drain();
-      expect(harness.sendTurn).toHaveBeenCalledTimes(4);
-      expect(harness.sendTurn.mock.calls[3]?.[0].input).toContain(
-        "Remember that the release train is amber.",
-      );
-      expect(await readContextActivities(harness)).toEqual([
-        expect.objectContaining({
-          turnId: asTurnId("claude-recovered"),
-          payload: expect.objectContaining({
-            restartReason: "interrupt-escalation",
-            recapInjected: true,
-          }),
+    const staleResumeFailure = () =>
+      Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: "claudeAgent",
+          method: "turn/setModel",
+          detail:
+            "Claude Code returned an error result: No conversation found with session ID: missing-session",
         }),
-      ]);
-    });
+      );
+    it.each(["before", "after"] as const)(
+      "preserves escalation attribution when Claude recovery completes %s send returns",
+      async (completionTiming) => {
+        const { harness, threadId } = await createEscalatedHarness("claudeAgent");
+        harness.sendTurn
+          .mockImplementationOnce(staleResumeFailure)
+          .mockImplementationOnce(staleResumeFailure)
+          .mockImplementationOnce(() =>
+            Effect.promise(async () => {
+              if (completionTiming === "before") {
+                await emitHarnessTurnTerminal(harness, {
+                  provider: "claudeAgent",
+                  type: "completed",
+                  eventId: "claude-early-completion",
+                  turnId: asTurnId("claude-recovered"),
+                });
+                // Let the runtime consumer record completion while send still owns
+                // the attempt and has not returned its provider turn id.
+                await new Promise((resolve) => setTimeout(resolve, 20));
+              }
+              return { threadId, turnId: asTurnId("claude-recovered") };
+            }),
+          );
+        await dispatchHarnessUserTurn(harness, {
+          messageId: "claude-escalation-recovery",
+          text: "Which release train did we pick?",
+          createdAt: new Date().toISOString(),
+        });
+        await harness.drain();
+        expect(harness.sendTurn).toHaveBeenCalledTimes(4);
+        expect(harness.sendTurn.mock.calls[3]?.[0].input).toContain(
+          "Remember that the release train is amber.",
+        );
+        if (completionTiming === "after") {
+          expect(await readContextActivities(harness)).toEqual([]);
+          await emitHarnessTurnTerminal(harness, {
+            provider: "claudeAgent",
+            type: "completed",
+            eventId: "claude-late-completion",
+            turnId: asTurnId("claude-recovered"),
+          });
+        }
+        await waitFor(async () => (await readContextActivities(harness)).length === 1);
+        expect(await readContextActivities(harness)).toEqual([
+          expect.objectContaining({
+            turnId: asTurnId("claude-recovered"),
+            payload: expect.objectContaining({
+              restartReason: "interrupt-escalation",
+              recapInjected: true,
+            }),
+          }),
+        ]);
+      },
+    );
 
     it("discards pending escalation context when the user explicitly stops recovery", async () => {
       const { harness, threadId } = await createEscalatedHarness("opencode");
@@ -4453,6 +4478,188 @@ describe("ProviderCommandReactor", () => {
       );
       expect(await readContextActivities(harness)).toEqual([]);
     });
+
+    it.each(["pi", "claudeAgent"] as const)(
+      "retains %s escalation and skips duplicate summaries during native steer",
+      async (provider) => {
+        const { harness, threadId } = await createEscalatedHarness(provider);
+        if (provider === "claudeAgent") {
+          harness.sendTurn
+            .mockImplementationOnce(staleResumeFailure)
+            .mockImplementationOnce(staleResumeFailure);
+        } else {
+          await Effect.runPromise(harness.clearSessionResumeCursor({ threadId }));
+        }
+        const recoveryTurnId = asTurnId("recovery-before-steer");
+        harness.sendTurn.mockImplementationOnce(() =>
+          Effect.succeed({ threadId, turnId: recoveryTurnId }),
+        );
+        await dispatchHarnessUserTurn(harness, {
+          messageId: "recovery-before-steer",
+          text: "Recover the previous context.",
+          createdAt: new Date().toISOString(),
+        });
+        await harness.drain();
+        expect(await readContextActivities(harness)).toEqual([]);
+        harness.setRuntimeSessionTurnState({
+          threadId,
+          status: "running",
+          activeTurnId: recoveryTurnId,
+        });
+        await Effect.runPromise(
+          harness.engine.dispatch({
+            type: "thread.turn.start",
+            commandId: CommandId.makeUnsafe("cmd-recovery-steer"),
+            threadId,
+            message: {
+              messageId: asMessageId("recovery-steer"),
+              role: "user",
+              text: "Focus on the release train.",
+              attachments: [],
+            },
+            dispatchMode: "steer",
+            runtimeMode: "approval-required",
+            interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+            createdAt: new Date().toISOString(),
+          }),
+        );
+        await harness.drain();
+        expect(harness.steerTurn).toHaveBeenCalledTimes(1);
+        const steerInput = harness.steerTurn.mock.calls[0]?.[0] as { readonly input?: string };
+        expect(steerInput.input).not.toContain("<thread_context>");
+        harness.setRuntimeSessionTurnState({ threadId, status: "ready" });
+        await emitHarnessTurnTerminal(harness, {
+          provider,
+          type: "failed",
+          eventId: "steered-recovery-failed",
+          turnId: recoveryTurnId,
+        });
+        await harness.drain();
+        const retryTurnId = asTurnId("recovery-after-steer");
+        harness.sendTurn.mockImplementationOnce(() =>
+          Effect.succeed({ threadId, turnId: retryTurnId }),
+        );
+        await dispatchHarnessUserTurn(harness, {
+          messageId: "recovery-after-steer",
+          text: "Retry after the failed steered recovery.",
+          createdAt: new Date().toISOString(),
+        });
+        await harness.drain();
+        await emitHarnessTurnTerminal(harness, {
+          provider,
+          type: "completed",
+          eventId: "steered-recovery-completed",
+          turnId: retryTurnId,
+        });
+        await waitFor(async () => (await readContextActivities(harness)).length === 1);
+        expect(await readContextActivities(harness)).toEqual([
+          expect.objectContaining({
+            turnId: retryTurnId,
+            payload: expect.objectContaining({ restartReason: "interrupt-escalation" }),
+          }),
+        ]);
+      },
+    );
+
+    const asynchronousProviders = [
+      "claudeAgent",
+      "cursor",
+      "grok",
+      "droid",
+      "devin",
+      "opencode",
+      "pi",
+      "antigravity",
+    ] as const;
+
+    it.each(asynchronousProviders)(
+      "retains %s escalation through failed and cancelled prompts until terminal success",
+      async (provider) => {
+        const { harness, threadId } = await createEscalatedHarness(provider);
+        await Effect.runPromise(harness.clearSessionResumeCursor({ threadId }));
+        for (const state of ["failed", "cancelled", "completed"] as const) {
+          const turnId = asTurnId(`${provider}-${state}`);
+          harness.sendTurn.mockImplementationOnce(() => Effect.succeed({ threadId, turnId }));
+          await dispatchHarnessUserTurn(harness, {
+            messageId: `recover-${state}`,
+            text: "Recover the interrupted session.",
+            createdAt: new Date().toISOString(),
+          });
+          await harness.drain();
+          expect(await readContextActivities(harness)).toEqual([]);
+          await emitHarnessTurnTerminal(harness, {
+            provider,
+            type: state,
+            eventId: `terminal-${turnId}`,
+            turnId,
+          });
+          await harness.drain();
+        }
+        await waitFor(async () => (await readContextActivities(harness)).length === 1);
+        const activities = await readContextActivities(harness);
+        expect(activities).toEqual([
+          expect.objectContaining({
+            turnId: asTurnId(`${provider}-completed`),
+            payload: expect.objectContaining({
+              nativeHistory: "unavailable",
+              restartReason: "interrupt-escalation",
+            }),
+          }),
+        ]);
+        await dispatchHarnessUserTurn(harness, {
+          messageId: "normal-followup",
+          text: "Continue normally.",
+          createdAt: new Date().toISOString(),
+        });
+        await harness.drain();
+        expect(harness.sendTurn.mock.calls.at(-1)?.[0].input).toBe("Continue normally.");
+        expect(await readContextActivities(harness)).toEqual(activities);
+      },
+    );
+
+    it.each(asynchronousProviders)(
+      "keeps a clean %s resume quiet after async failure and retires the cause on success",
+      async (provider) => {
+        const { harness, threadId } = await createEscalatedHarness(provider);
+        for (const state of ["failed", "completed"] as const) {
+          const turnId = asTurnId(`clean-${state}`);
+          harness.sendTurn.mockImplementationOnce(() => Effect.succeed({ threadId, turnId }));
+          await dispatchHarnessUserTurn(harness, {
+            messageId: `clean-resume-${state}`,
+            text: "Resume the existing history.",
+            createdAt: new Date().toISOString(),
+          });
+          await harness.drain();
+          await emitHarnessTurnTerminal(harness, {
+            provider,
+            type: state,
+            eventId: `terminal-${turnId}`,
+            turnId,
+          });
+          await harness.drain();
+          expect(await readContextActivities(harness)).toEqual([]);
+        }
+        await Effect.runPromise(harness.clearSessionResumeCursor({ threadId }));
+        const turnId = asTurnId("unrelated-loss");
+        harness.sendTurn.mockImplementationOnce(() => Effect.succeed({ threadId, turnId }));
+        await dispatchHarnessUserTurn(harness, {
+          messageId: "unrelated-history-loss",
+          text: "Recover an unrelated lost session.",
+          createdAt: new Date().toISOString(),
+        });
+        await harness.drain();
+        await emitHarnessTurnTerminal(harness, {
+          provider,
+          type: "completed",
+          eventId: "unrelated-completed",
+          turnId,
+        });
+        await waitFor(async () => (await readContextActivities(harness)).length === 1);
+        expect((await readContextActivities(harness))[0]?.payload?.restartReason).not.toBe(
+          "interrupt-escalation",
+        );
+      },
+    );
 
     it("retains escalation and summary until asynchronous recovery completes", async () => {
       const { harness, threadId } = await createEscalatedHarness("opencode");

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -306,6 +306,7 @@ const SESSION_CONTEXT_RECAP_PREVIEW_MAX_CHARS = 600;
 type ProviderContextLifecycleReason =
   | "conversation-rebuilt"
   | "fresh-session"
+  | "interrupt-escalation"
   | "native-history-unavailable"
   | "native-resume-failed";
 
@@ -350,18 +351,23 @@ function recapTailPreview(recapText: string): string {
 }
 
 function providerContextLifecycleSummary(evidence: ProviderContextLifecycleEvidence): string {
+  if (evidence.reason === "interrupt-escalation") {
+    return evidence.recapText !== null
+      ? "The turn could not be stopped cleanly, so the session was restarted and your message included a summary."
+      : "The turn could not be stopped cleanly, so the session was restarted.";
+  }
   if (evidence.recapText !== null && evidence.nativeHistory === "unavailable") {
-    return "Native session history was unavailable, so the model continued from a recap.";
+    return "The session's history was lost, so the model continues from a summary.";
   }
   if (evidence.recapText !== null && evidence.sessionRestarted) {
-    return "The session restarted, so the model received a recap.";
+    return "The session was restarted, so your message included a summary.";
   }
   if (evidence.recapText !== null) {
-    return "The model received a recap while recovering its session context.";
+    return "Your message included a summary while the session recovered its context.";
   }
   return evidence.sessionRestarted
-    ? "The session restarted without its native history."
-    : "Native session history was unavailable for this turn.";
+    ? "The session restarted without its previous history."
+    : "The session's history was unavailable for this turn.";
 }
 
 const turnStartKeyForEvent = (event: ProviderIntentEvent): string =>
@@ -809,6 +815,10 @@ const make = Effect.gen(function* () {
   // Providers without native rewind restart after rollback and receive the
   // retained projection transcript once on their next prompt.
   const rollbackContextBootstrapThreadIds = new Set<string>();
+  // Interrupt escalation settled the turn by stopping the runtime. Remember
+  // that until the next turn so a consequential context loss can name the
+  // cause instead of a generic fresh-session reason.
+  const interruptEscalatedThreadIds = new Set<string>();
   // Retry state keeps only the bounded derived record; the full recap text is
   // never retained here after the provider turn has been accepted.
   const pendingProviderContextLifecycleActivities = new Map<
@@ -1390,6 +1400,7 @@ const make = Effect.gen(function* () {
       // thread while the first is still running.
       suppressContextBootstrapOnNextStartThreadIds.delete(threadId);
       clearPendingContextBootstraps(threadId);
+      interruptEscalatedThreadIds.delete(threadId);
       const lifecyclePrefix = `${threadId}:`;
       for (const activityKey of pendingProviderContextLifecycleActivities.keys()) {
         if (activityKey.startsWith(lifecyclePrefix)) {
@@ -2196,13 +2207,16 @@ const make = Effect.gen(function* () {
             priorTranscriptBootstrapAvailableChars,
           )
         : null;
-    const restartReason: ProviderContextLifecycleReason = nativeResumeFailed
-      ? "native-resume-failed"
-      : rollbackContextBootstrapThreadIds.has(input.threadId)
-        ? "conversation-rebuilt"
-        : freshSessionContextBootstrapThreadIds.has(input.threadId)
-          ? "fresh-session"
-          : "native-history-unavailable";
+    const interruptedEscalationPending = interruptEscalatedThreadIds.has(input.threadId);
+    const restartReason: ProviderContextLifecycleReason = interruptedEscalationPending
+      ? "interrupt-escalation"
+      : nativeResumeFailed
+        ? "native-resume-failed"
+        : rollbackContextBootstrapThreadIds.has(input.threadId)
+          ? "conversation-rebuilt"
+          : freshSessionContextBootstrapThreadIds.has(input.threadId)
+            ? "fresh-session"
+            : "native-history-unavailable";
     let providerContextLifecycleEvidence: ProviderContextLifecycleEvidence | null =
       input.reviewTarget === undefined &&
       input.dispatchMode !== "steer" &&
@@ -2217,6 +2231,11 @@ const make = Effect.gen(function* () {
             sessionRestarted: nativeSessionRestarted,
           }
         : null;
+    // Consume the escalation marker on the next turn whether or not a
+    // consequential context-loss activity is emitted (clean resumes stay quiet).
+    if (interruptedEscalationPending) {
+      interruptEscalatedThreadIds.delete(input.threadId);
+    }
     // The guards above make the three bootstrap flavors mutually exclusive, so
     // a turn carries at most one context block.
     const selectedBootstrapContext: BootstrapContextSelection | null =
@@ -3655,6 +3674,7 @@ const make = Effect.gen(function* () {
           ? `${result.detail} Stopping the provider session to settle the turn.`
           : `${result.outcome.detail}\nStopping the provider session to settle the turn.`;
       yield* reportInterruptFailure(detail, "uncertain");
+      interruptEscalatedThreadIds.add(input.threadId);
       return yield* processThreadSessionStop({
         threadId: input.threadId,
         createdAt: input.createdAt,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1012,7 +1012,7 @@ const make = Effect.gen(function* () {
     readonly clearFreshSessionTranscript: boolean;
     readonly clearRollbackTranscript: boolean;
     readonly completeDurablePriorTranscript: boolean;
-    readonly lifecycleEvidence: ProviderContextLifecycleEvidence | null;
+    lifecycleEvidence: ProviderContextLifecycleEvidence | null;
     readonly lifecycleEvidenceCreatedAt: string;
     readonly interruptEscalation?: PendingInterruptEscalation;
   };
@@ -2148,7 +2148,7 @@ const make = Effect.gen(function* () {
     const hasPendingPriorTranscriptBootstrap =
       hasPendingFreshSessionTranscriptBootstrap ||
       hasPendingRollbackTranscriptBootstrap ||
-      priorEscalationEvidence?.recapText != null;
+      (input.dispatchMode !== "steer" && priorEscalationEvidence?.recapText != null);
     const shouldBootstrapSidechatContext =
       thread.sidechatSourceThreadId !== null &&
       sidechatContextBootstrapThreadIds.has(input.threadId) &&
@@ -2437,11 +2437,11 @@ const make = Effect.gen(function* () {
           (priorTranscriptBootstrapRetiresOnAcceptedTurn ||
             specializedBootstrapCompletesFreshSessionContext)) ||
           (hasPendingRollbackTranscriptBootstrap && priorTranscriptBootstrapRetiresOnAcceptedTurn));
+      // Only Codex awaits a provider turn/start acknowledgement. The other
+      // adapters enqueue/fork prompts or launch a process before acceptance;
+      // their matching terminal success confirms that recovery was consumed.
       const tracksEscalationAcceptance =
-        interruptEscalation !== undefined &&
-        (selectedProvider === "droid" ||
-          selectedProvider === "opencode" ||
-          selectedProvider === "devin");
+        interruptEscalation !== undefined && selectedProvider !== "codex";
       pendingContextBootstrapAttempt =
         tracksDroidContextAcceptance || tracksDurableContextAcceptance || tracksEscalationAcceptance
           ? {
@@ -2589,6 +2589,9 @@ const make = Effect.gen(function* () {
         completeInterruptEscalation(input.threadId, interruptEscalation);
       }
       if (pendingContextBootstrapAttempt) {
+        // Claude can replace recovery evidence while retrying a stale resume.
+        // Refresh it before reconciling a terminal event that preceded send's return.
+        pendingContextBootstrapAttempt.lifecycleEvidence = providerContextLifecycleEvidence;
         pendingContextBootstrapAttempt.turnId = sentTurn.turnId;
         const terminalEvent = pendingContextBootstrapAttempt.terminalEvent;
         if (terminalEvent?.turnId === sentTurn.turnId) {
@@ -2621,7 +2624,9 @@ const make = Effect.gen(function* () {
         );
       }
     }
-    if (input.reviewTarget !== undefined || input.dispatchMode === "steer") {
+    // A native steer belongs to the still-pending recovery turn; its terminal
+    // event, not the steering acknowledgement, retires escalation evidence.
+    if (input.reviewTarget !== undefined) {
       completeInterruptEscalation(input.threadId, interruptEscalation);
     }
     if (handoffBootstrapText && thread.handoff !== null && input.reviewTarget === undefined) {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -815,10 +815,18 @@ const make = Effect.gen(function* () {
   // Providers without native rewind restart after rollback and receive the
   // retained projection transcript once on their next prompt.
   const rollbackContextBootstrapThreadIds = new Set<string>();
-  // Interrupt escalation settled the turn by stopping the runtime. Remember
-  // that until the next turn so a consequential context loss can name the
-  // cause instead of a generic fresh-session reason.
-  const interruptEscalatedThreadIds = new Set<string>();
+  // Keep observed context loss until recovery is accepted: a failed dispatch
+  // can leave a replacement runtime alive without its previous history.
+  type PendingInterruptEscalation = { evidence: ProviderContextLifecycleEvidence | null };
+  const pendingInterruptEscalations = new Map<string, PendingInterruptEscalation>();
+  const completeInterruptEscalation = (
+    threadId: string,
+    escalation: PendingInterruptEscalation | undefined,
+  ) => {
+    if (escalation && pendingInterruptEscalations.get(threadId) === escalation) {
+      pendingInterruptEscalations.delete(threadId);
+    }
+  };
   // Retry state keeps only the bounded derived record; the full recap text is
   // never retained here after the provider turn has been accepted.
   const pendingProviderContextLifecycleActivities = new Map<
@@ -1006,6 +1014,7 @@ const make = Effect.gen(function* () {
     readonly completeDurablePriorTranscript: boolean;
     readonly lifecycleEvidence: ProviderContextLifecycleEvidence | null;
     readonly lifecycleEvidenceCreatedAt: string;
+    readonly interruptEscalation?: PendingInterruptEscalation;
   };
   const pendingContextBootstrapAttempts = new Map<string, PendingContextBootstrapAttempt>();
   // Explicit stop resets context once: the next successful session start must
@@ -1074,6 +1083,7 @@ const make = Effect.gen(function* () {
     if (event.type !== "turn.completed" || event.payload.state !== "completed") {
       return;
     }
+    completeInterruptEscalation(threadId, attempt.interruptEscalation);
     // Retain the bounded, idempotent evidence before retiring bootstrap state.
     // Persistence retries independently so a marker write cannot block queue
     // draining after the provider has already accepted this turn.
@@ -1400,7 +1410,7 @@ const make = Effect.gen(function* () {
       // thread while the first is still running.
       suppressContextBootstrapOnNextStartThreadIds.delete(threadId);
       clearPendingContextBootstraps(threadId);
-      interruptEscalatedThreadIds.delete(threadId);
+      pendingInterruptEscalations.delete(threadId);
       const lifecyclePrefix = `${threadId}:`;
       for (const activityKey of pendingProviderContextLifecycleActivities.keys()) {
         if (activityKey.startsWith(lifecyclePrefix)) {
@@ -2127,6 +2137,8 @@ const make = Effect.gen(function* () {
         issue: providerPromptOverflowIssue(goalPromptOverheadChars),
       });
     }
+    const interruptEscalation = pendingInterruptEscalations.get(input.threadId);
+    const priorEscalationEvidence = interruptEscalation?.evidence;
     const hasPendingFreshSessionTranscriptBootstrap = freshSessionContextBootstrapThreadIds.has(
       input.threadId,
     );
@@ -2134,7 +2146,9 @@ const make = Effect.gen(function* () {
       input.threadId,
     );
     const hasPendingPriorTranscriptBootstrap =
-      hasPendingFreshSessionTranscriptBootstrap || hasPendingRollbackTranscriptBootstrap;
+      hasPendingFreshSessionTranscriptBootstrap ||
+      hasPendingRollbackTranscriptBootstrap ||
+      priorEscalationEvidence?.recapText != null;
     const shouldBootstrapSidechatContext =
       thread.sidechatSourceThreadId !== null &&
       sidechatContextBootstrapThreadIds.has(input.threadId) &&
@@ -2207,8 +2221,7 @@ const make = Effect.gen(function* () {
             priorTranscriptBootstrapAvailableChars,
           )
         : null;
-    const interruptedEscalationPending = interruptEscalatedThreadIds.has(input.threadId);
-    const restartReason: ProviderContextLifecycleReason = interruptedEscalationPending
+    const restartReason: ProviderContextLifecycleReason = interruptEscalation
       ? "interrupt-escalation"
       : nativeResumeFailed
         ? "native-resume-failed"
@@ -2223,18 +2236,21 @@ const make = Effect.gen(function* () {
       !shouldBootstrapHandoff &&
       !shouldBootstrapSidechatContext &&
       priorTranscriptMessages.length > 0 &&
-      (priorTranscriptBootstrapText !== null || (nativeSessionRestarted && !nativeResumeSucceeded))
+      (priorTranscriptBootstrapText !== null ||
+        (nativeSessionRestarted && !nativeResumeSucceeded) ||
+        priorEscalationEvidence != null)
         ? {
-            nativeHistory: nativeResumeSucceeded ? "available" : "unavailable",
+            nativeHistory:
+              priorEscalationEvidence?.nativeHistory ??
+              (nativeResumeSucceeded ? "available" : "unavailable"),
             recapText: priorTranscriptBootstrapText,
             reason: restartReason,
-            sessionRestarted: nativeSessionRestarted,
+            sessionRestarted:
+              nativeSessionRestarted || priorEscalationEvidence?.sessionRestarted === true,
           }
         : null;
-    // Consume the escalation marker on the next turn whether or not a
-    // consequential context-loss activity is emitted (clean resumes stay quiet).
-    if (interruptedEscalationPending) {
-      interruptEscalatedThreadIds.delete(input.threadId);
+    if (interruptEscalation && providerContextLifecycleEvidence !== null) {
+      interruptEscalation.evidence = providerContextLifecycleEvidence;
     }
     // The guards above make the three bootstrap flavors mutually exclusive, so
     // a turn carries at most one context block.
@@ -2421,8 +2437,13 @@ const make = Effect.gen(function* () {
           (priorTranscriptBootstrapRetiresOnAcceptedTurn ||
             specializedBootstrapCompletesFreshSessionContext)) ||
           (hasPendingRollbackTranscriptBootstrap && priorTranscriptBootstrapRetiresOnAcceptedTurn));
+      const tracksEscalationAcceptance =
+        interruptEscalation !== undefined &&
+        (selectedProvider === "droid" ||
+          selectedProvider === "opencode" ||
+          selectedProvider === "devin");
       pendingContextBootstrapAttempt =
-        tracksDroidContextAcceptance || tracksDurableContextAcceptance
+        tracksDroidContextAcceptance || tracksDurableContextAcceptance || tracksEscalationAcceptance
           ? {
               clearSidechat:
                 sidechatBootstrapText !== null || priorTranscriptBootstrapText !== null,
@@ -2436,6 +2457,7 @@ const make = Effect.gen(function* () {
                 tracksDurableContextAcceptance && hasPendingFreshSessionTranscriptBootstrap,
               lifecycleEvidence: providerContextLifecycleEvidence,
               lifecycleEvidenceCreatedAt: input.createdAt,
+              ...(interruptEscalation ? { interruptEscalation } : {}),
             }
           : undefined;
       if (pendingContextBootstrapAttempt) {
@@ -2471,9 +2493,12 @@ const make = Effect.gen(function* () {
           providerContextLifecycleEvidence = {
             nativeHistory: "unavailable",
             recapText: retryBootstrapText,
-            reason: "native-resume-failed",
+            reason: interruptEscalation ? "interrupt-escalation" : "native-resume-failed",
             sessionRestarted: !preserveActiveRuntime,
           };
+          if (interruptEscalation) {
+            interruptEscalation.evidence = providerContextLifecycleEvidence;
+          }
           const retryNormalizedInput = finalizeProviderInput(
             retryBootstrapText !== null
               ? {
@@ -2560,6 +2585,9 @@ const make = Effect.gen(function* () {
         ),
       );
       startedTurn = sentTurn;
+      if (!pendingContextBootstrapAttempt) {
+        completeInterruptEscalation(input.threadId, interruptEscalation);
+      }
       if (pendingContextBootstrapAttempt) {
         pendingContextBootstrapAttempt.turnId = sentTurn.turnId;
         const terminalEvent = pendingContextBootstrapAttempt.terminalEvent;
@@ -2592,6 +2620,9 @@ const make = Effect.gen(function* () {
           }),
         );
       }
+    }
+    if (input.reviewTarget !== undefined || input.dispatchMode === "steer") {
+      completeInterruptEscalation(input.threadId, interruptEscalation);
     }
     if (handoffBootstrapText && thread.handoff !== null && input.reviewTarget === undefined) {
       yield* orchestrationEngine.dispatch({
@@ -3674,10 +3705,10 @@ const make = Effect.gen(function* () {
           ? `${result.detail} Stopping the provider session to settle the turn.`
           : `${result.outcome.detail}\nStopping the provider session to settle the turn.`;
       yield* reportInterruptFailure(detail, "uncertain");
-      interruptEscalatedThreadIds.add(input.threadId);
       return yield* processThreadSessionStop({
         threadId: input.threadId,
         createdAt: input.createdAt,
+        interruptEscalated: true,
       });
     }
 
@@ -4226,6 +4257,7 @@ const make = Effect.gen(function* () {
   const processThreadSessionStop = Effect.fnUntraced(function* (input: {
     readonly threadId: ThreadId;
     readonly createdAt: string;
+    readonly interruptEscalated?: boolean;
   }) {
     const thread = yield* resolveThread(input.threadId);
     const providerThread = yield* resolveProviderSessionThread(input.threadId);
@@ -4265,6 +4297,11 @@ const make = Effect.gen(function* () {
       }
     }
     clearPendingContextBootstraps(thread.id);
+    if (input.interruptEscalated) {
+      pendingInterruptEscalations.set(thread.id, { evidence: null });
+    } else {
+      pendingInterruptEscalations.delete(thread.id);
+    }
     suppressContextBootstrapOnNextStartThreadIds.add(thread.id);
     const stoppedProvider = Schema.is(ProviderKind)(thread.session?.providerName)
       ? thread.session.providerName

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -209,7 +209,7 @@ describe("MessagesTimeline", () => {
             entry: {
               id: "context-restart-entry",
               createdAt: "2026-03-17T19:12:28.000Z",
-              label: "Native session history was unavailable, so the model continued from a recap.",
+              label: "The session's history was lost, so the model continues from a summary.",
               tone: "error",
               activityKind: "provider.context.changed",
               providerContextLifecycle: {
@@ -219,7 +219,7 @@ describe("MessagesTimeline", () => {
                 sessionRestarted: true,
                 recapInjected: true,
                 recapCharacters: 4_200,
-                recapPreview: "Bounded recap preview",
+                recapPreview: "Bounded summary preview",
                 recapPreviewTruncated: true,
               },
             },
@@ -228,10 +228,10 @@ describe("MessagesTimeline", () => {
       />,
     );
 
-    expect(markup).toContain("Native session history was unavailable");
+    expect(markup).toContain("history was lost, so the model continues from a summary.");
     expect(markup).toContain('data-tool-detail-trigger="true"');
     expect(markup).not.toContain('data-provider-context-lifecycle-details="true"');
-    expect(markup).not.toContain("Bounded recap preview");
+    expect(markup).not.toContain("Bounded summary preview");
   });
 
   it("keeps small transcripts on the simple non-virtualized path", async () => {

--- a/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
+++ b/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
@@ -887,13 +887,15 @@ function providerContextLifecycleReasonLabel(
 ): string {
   switch (reason) {
     case "conversation-rebuilt":
-      return "Conversation rebuilt";
+      return "Conversation rebuilt from a summary";
     case "fresh-session":
-      return "Fresh provider session";
+      return "New session started";
+    case "interrupt-escalation":
+      return "Turn stop escalated to a session restart";
     case "native-history-unavailable":
-      return "Native history unavailable";
+      return "Previous history unavailable";
     case "native-resume-failed":
-      return "Native resume failed";
+      return "Could not resume the previous session";
   }
 }
 
@@ -909,24 +911,24 @@ function ProviderContextLifecycleDetails(props: {
       <dl className="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-3 gap-y-1.5 rounded-lg border border-border/45 bg-background/60 px-3 py-2.5 text-[11px]">
         <dt className="text-muted-foreground/56">Provider</dt>
         <dd className="text-foreground/84">{provider}</dd>
-        <dt className="text-muted-foreground/56">Native history</dt>
+        <dt className="text-muted-foreground/56">Previous history</dt>
         <dd className="text-foreground/84">
-          {info.nativeHistory === "available" ? "Available" : "Unavailable"}
+          {info.nativeHistory === "available" ? "Available" : "Lost"}
         </dd>
-        <dt className="text-muted-foreground/56">Restart</dt>
+        <dt className="text-muted-foreground/56">Session restarted</dt>
         <dd className="text-foreground/84">{info.sessionRestarted ? "Yes" : "No"}</dd>
-        <dt className="text-muted-foreground/56">Context change</dt>
+        <dt className="text-muted-foreground/56">Why</dt>
         <dd className="text-foreground/84">
           {providerContextLifecycleReasonLabel(info.restartReason)}
         </dd>
-        <dt className="text-muted-foreground/56">Recap</dt>
+        <dt className="text-muted-foreground/56">Summary included</dt>
         <dd className="text-foreground/84">
-          {info.recapInjected ? `${info.recapCharacters.toLocaleString()} characters` : "Not sent"}
+          {info.recapInjected ? `${info.recapCharacters.toLocaleString()} characters` : "No"}
         </dd>
       </dl>
       {info.recapPreview ? (
         <section className="space-y-2">
-          <h3 className="text-[11px] font-medium text-muted-foreground/56">Recap preview</h3>
+          <h3 className="text-[11px] font-medium text-muted-foreground/56">Summary preview</h3>
           <pre
             className="max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/45 bg-background/60 px-3 py-2.5 font-chat-code text-[11px] leading-relaxed text-foreground/84"
             data-session-context-recap-preview="true"
@@ -935,7 +937,7 @@ function ProviderContextLifecycleDetails(props: {
           </pre>
           {info.recapPreviewTruncated ? (
             <p className="text-[10px] text-muted-foreground/56">
-              Showing a bounded preview of the recap sent to the model.
+              Showing a short preview of the summary sent with your message.
             </p>
           ) : null}
         </section>

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -362,7 +362,7 @@ describe("deriveWorkLogEntries", () => {
         id: "context-restart",
         turnId: "turn-hidden",
         kind: "provider.context.changed",
-        summary: "Native session history was unavailable.",
+        summary: "The session's history was lost, so the model continues from a summary.",
         tone: "error",
         payload: {
           provider: "opencode",
@@ -411,7 +411,7 @@ describe("deriveWorkLogEntries", () => {
           id: "context-restart-without-recap",
           turnId: "turn-2",
           kind: "provider.context.changed",
-          summary: "The session restarted without its native history.",
+          summary: "The session restarted without its previous history.",
           tone: "error",
           payload: {
             provider: "codex",
@@ -436,6 +436,43 @@ describe("deriveWorkLogEntries", () => {
       recapInjected: false,
       recapCharacters: 0,
       recapPreview: null,
+      recapPreviewTruncated: false,
+    });
+  });
+
+  it("keeps interrupt-escalation context-loss markers visible", () => {
+    const [entry] = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "interrupt-escalation-context",
+          turnId: "turn-3",
+          kind: "provider.context.changed",
+          summary:
+            "The turn could not be stopped cleanly, so the session was restarted and your message included a summary.",
+          tone: "error",
+          payload: {
+            provider: "opencode",
+            nativeHistory: "unavailable",
+            sessionRestarted: true,
+            restartReason: "interrupt-escalation",
+            recapInjected: true,
+            recapCharacters: 900,
+            recapPreview: "Earlier conversation summary",
+            recapPreviewTruncated: false,
+          },
+        }),
+      ],
+      TurnId.makeUnsafe("turn-3"),
+    );
+
+    expect(entry?.providerContextLifecycle).toEqual({
+      provider: "opencode",
+      nativeHistory: "unavailable",
+      sessionRestarted: true,
+      restartReason: "interrupt-escalation",
+      recapInjected: true,
+      recapCharacters: 900,
+      recapPreview: "Earlier conversation summary",
       recapPreviewTruncated: false,
     });
   });

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -53,6 +53,7 @@ const SESSION_CONTEXT_RECAP_PREVIEW_MAX_CHARS = 600;
 export type ProviderContextLifecycleReason =
   | "conversation-rebuilt"
   | "fresh-session"
+  | "interrupt-escalation"
   | "native-history-unavailable"
   | "native-resume-failed";
 
@@ -522,6 +523,7 @@ function isProviderContextLifecycleReason(value: unknown): value is ProviderCont
   return (
     value === "conversation-rebuilt" ||
     value === "fresh-session" ||
+    value === "interrupt-escalation" ||
     value === "native-history-unavailable" ||
     value === "native-resume-failed"
   );


### PR DESCRIPTION
## Summary

Closes #798.

#840 already landed durable `provider.context.changed` activities for consequential session restarts and transcript summaries. This follow-up finishes remaining user-facing gaps:

- Plain-language activity summaries ("summary" / "history was lost" instead of "recap" / "native history")
- Attribute context-loss markers to `interrupt-escalation` when an escalated interrupt preceded lost history
- Soften expandable rail details to the same vocabulary
- Keep related consequences collapsed into one activity per turn

## Test plan

- [x] focused ProviderCommandReactor interrupt + context-loss tests
- [x] focused web workLog + MessagesTimeline tests
- [x] bun fmt / lint / typecheck