### PR TITLE
feat(web): Cmd+F find in file preview with jump-to-match

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -73,14 +73,22 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }),
   );
 
-  it.effect("defaults chat.find to mod+F outside terminal focus", () =>
+  it.effect("defaults chat.find to mod+F outside terminal and file-preview focus", () =>
     Effect.sync(() => {
       assert.deepEqual(
         DEFAULT_KEYBINDINGS.find((rule) => rule.command === "chat.find"),
         {
           key: "mod+f",
           command: "chat.find",
-          when: "!terminalFocus",
+          when: "!terminalFocus && !filePreviewFocus",
+        },
+      );
+      assert.deepEqual(
+        DEFAULT_KEYBINDINGS.find((rule) => rule.command === "file.find"),
+        {
+          key: "mod+f",
+          command: "file.find",
+          when: "filePreviewFocus",
         },
       );
     }),

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -112,7 +112,8 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+d", command: "diff.toggle", when: "!terminalFocus" },
   // Cmd-only instead of mod so Ctrl+L remains available to shells on non-macOS.
   { key: "cmd+l", command: "composer.focus.toggle", when: "!terminalFocus" },
-  { key: "mod+f", command: "chat.find", when: "!terminalFocus" },
+  { key: "mod+f", command: "chat.find", when: "!terminalFocus && !filePreviewFocus" },
+  { key: "mod+f", command: "file.find", when: "filePreviewFocus" },
   { key: "mod+shift+m", command: "modelPicker.toggle", when: "!terminalFocus" },
   // Cycle models within the active provider (favorites first, then remaining list).
   { key: "alt+]", command: "model.next", when: "!terminalFocus" },

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -377,6 +377,10 @@ import {
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { isEditableEventTarget } from "../lib/editableEventTarget";
 import {
+  isFilePreviewFocused,
+  openFocusedFilePreviewFind,
+} from "./filePreviewFind.logic";
+import {
   type ComposerFileAttachment,
   type ComposerImageAttachment,
   type ComposerAssistantSelectionAttachment,
@@ -6669,6 +6673,7 @@ export default function ChatView({
         !isVoiceTranscribing &&
         !isComposerApprovalState &&
         canHandleComposerPickerShortcut(event, composerFormRef.current);
+      const filePreviewFocus = isFilePreviewFocused();
       const shortcutContext = {
         terminalFocus: isTerminalFocused(),
         terminalOpen: Boolean(terminalState.terminalOpen),
@@ -6676,6 +6681,7 @@ export default function ChatView({
         terminalWorkspaceTerminalOnly: terminalState.workspaceLayout === "terminal-only",
         terminalWorkspaceTerminalTabActive,
         terminalWorkspaceChatTabActive,
+        filePreviewFocus,
       };
 
       const command = resolveShortcutCommand(event, keybindings, {
@@ -6691,12 +6697,22 @@ export default function ChatView({
         return;
       }
 
+      if (command === "file.find") {
+        if (!openFocusedFilePreviewFind()) {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
       if (command === "chat.find") {
         if (
           !shouldCaptureChatFindShortcut({
             shouldRenderChatPaneContent,
             terminalWorkspaceTerminalTabActive,
             inAppBrowserFocused: eventTargetsInAppBrowser(event.target),
+            filePreviewFocused: filePreviewFocus,
           })
         ) {
           return;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -376,10 +376,7 @@ import {
 } from "../appSettings";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { isEditableEventTarget } from "../lib/editableEventTarget";
-import {
-  isFilePreviewFocused,
-  openFocusedFilePreviewFind,
-} from "./filePreviewFind.logic";
+import { isFilePreviewFocused, openFocusedFilePreviewFind } from "./filePreviewFind.logic";
 import {
   type ComposerFileAttachment,
   type ComposerImageAttachment,

--- a/apps/web/src/components/FilePreviewFindBar.browser.tsx
+++ b/apps/web/src/components/FilePreviewFindBar.browser.tsx
@@ -1,0 +1,76 @@
+// FILE: FilePreviewFindBar.browser.tsx
+// Purpose: Browser regressions for deferred matching and Enter/Shift+Enter stepping.
+// Layer: Vitest browser tests
+
+import { page, userEvent } from "vitest/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { FilePreviewFindBar } from "./FilePreviewFindBar";
+
+const CONTENTS = "Error one. Error two.";
+
+describe("FilePreviewFindBar interactions", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("echoes input before deferred matching publishes the final query", async () => {
+    const onMatchesChange = vi.fn();
+    await render(
+      <FilePreviewFindBar
+        open
+        focusNonce={1}
+        contents={CONTENTS}
+        onClose={() => {}}
+        onMatchesChange={onMatchesChange}
+        onActiveMatchChange={() => {}}
+      />,
+    );
+    onMatchesChange.mockClear();
+    const input = page.getByRole("textbox", { name: "Find in file" });
+
+    const inputElement = input.element() as HTMLInputElement;
+    const nativeValueSetter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    nativeValueSetter?.call(inputElement, "err");
+    inputElement.dispatchEvent(
+      new InputEvent("input", { bubbles: true, data: "err", inputType: "insertText" }),
+    );
+
+    expect(input.element()).toHaveValue("err");
+    expect(onMatchesChange.mock.calls.at(-1)?.[1]).not.toBe("err");
+    await expect.poll(() => onMatchesChange.mock.calls.at(-1)?.[1]).toBe("err");
+  });
+
+  it("steps through matches with Enter without republishing the query", async () => {
+    const onMatchesChange = vi.fn();
+    const onActiveMatchChange = vi.fn();
+    await render(
+      <FilePreviewFindBar
+        open
+        focusNonce={1}
+        contents={CONTENTS}
+        onClose={() => {}}
+        onMatchesChange={onMatchesChange}
+        onActiveMatchChange={onActiveMatchChange}
+      />,
+    );
+    const input = page.getByRole("textbox", { name: "Find in file" });
+    await input.fill("error");
+    await expect.poll(() => onMatchesChange.mock.calls.at(-1)?.[1]).toBe("error");
+    onMatchesChange.mockClear();
+    onActiveMatchChange.mockClear();
+
+    await userEvent.keyboard("{Enter}");
+
+    expect(onMatchesChange).not.toHaveBeenCalled();
+    expect(onActiveMatchChange).toHaveBeenCalledWith(
+      { index: 1, startOffset: 11, endOffset: 16 },
+      "error",
+      1,
+    );
+  });
+});

--- a/apps/web/src/components/FilePreviewFindBar.tsx
+++ b/apps/web/src/components/FilePreviewFindBar.tsx
@@ -1,0 +1,261 @@
+// FILE: FilePreviewFindBar.tsx
+// Purpose: Compact in-file-preview find panel — field + close on top, prev/next
+//   + match count below. Mirrors ThreadFindBar layout for a consistent find UX.
+// Layer: File preview presentation
+
+import {
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+
+import { IconButton } from "~/components/ui/icon-button";
+import { ArrowDownIcon, ArrowUpIcon, SearchIcon, XIcon } from "~/lib/icons";
+import { cn } from "~/lib/utils";
+import { MUTED_LABEL_TEXT_CLASS_NAME } from "~/surfaceStyles";
+import { DisclosureRegion } from "./ui/DisclosureRegion";
+import {
+  FILE_PREVIEW_FIND_MAX_MATCHES,
+  FILE_PREVIEW_FIND_QUERY_MAX_LENGTH,
+  anchorFilePreviewMatchIndex,
+  collectFilePreviewMatches,
+  filePreviewMatchCountLabel,
+  stepFilePreviewFindIndex,
+  type FilePreviewFindMatch,
+} from "./filePreviewFind.logic";
+
+interface FilePreviewFindBarProps {
+  open: boolean;
+  focusNonce: number;
+  contents: string;
+  onClose: () => void;
+  onMatchesChange: (matches: readonly FilePreviewFindMatch[], query: string, activeIndex: number) => void;
+  onActiveMatchChange: (match: FilePreviewFindMatch | null, query: string, activeIndex: number) => void;
+}
+
+const FIND_STEP_BUTTON_CLASS_NAME =
+  "size-6 rounded-md border-transparent bg-transparent text-muted-foreground shadow-none hover:bg-muted-foreground/15 hover:text-foreground sm:size-6";
+
+export function FilePreviewFindBar({
+  open,
+  focusNonce,
+  contents,
+  onClose,
+  onMatchesChange,
+  onActiveMatchChange,
+}: FilePreviewFindBarProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const matchesRef = useRef<FilePreviewFindMatch[]>([]);
+  const activeIndexRef = useRef(0);
+  const previousMatchRef = useRef<FilePreviewFindMatch | null>(null);
+  const contentsEpochRef = useRef(contents);
+  const onMatchesChangeRef = useRef(onMatchesChange);
+  const onActiveMatchChangeRef = useRef(onActiveMatchChange);
+  onMatchesChangeRef.current = onMatchesChange;
+  onActiveMatchChangeRef.current = onActiveMatchChange;
+
+  const [query, setQuery] = useState("");
+  const deferredQuery = useDeferredValue(query);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const matchPass = useMemo(() => {
+    if (!open) {
+      return { matches: [] as FilePreviewFindMatch[], capped: false };
+    }
+    const all = collectFilePreviewMatches(contents, deferredQuery, FILE_PREVIEW_FIND_MAX_MATCHES + 1);
+    const capped = all.length > FILE_PREVIEW_FIND_MAX_MATCHES;
+    return {
+      matches: capped ? all.slice(0, FILE_PREVIEW_FIND_MAX_MATCHES) : all,
+      capped,
+    };
+  }, [contents, deferredQuery, open]);
+
+  const matches = matchPass.matches;
+  matchesRef.current = matches;
+  const matchCount = matches.length;
+  const safeIndex = matchCount === 0 ? -1 : Math.min(Math.max(activeIndex, 0), matchCount - 1);
+
+  // Live reload: re-anchor the active hit by offset instead of yanking to zero.
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const contentsChanged = contentsEpochRef.current !== contents;
+    contentsEpochRef.current = contents;
+    if (!contentsChanged) {
+      return;
+    }
+    const nextIndex = anchorFilePreviewMatchIndex(matches, previousMatchRef.current);
+    activeIndexRef.current = nextIndex;
+    setActiveIndex(nextIndex < 0 ? 0 : nextIndex);
+  }, [contents, matches, open]);
+
+  useEffect(() => {
+    if (!open) {
+      onMatchesChangeRef.current([], "", -1);
+      onActiveMatchChangeRef.current(null, "", -1);
+      previousMatchRef.current = null;
+      return;
+    }
+    const currentIndex =
+      matches.length === 0 ? -1 : Math.min(Math.max(activeIndexRef.current, 0), matches.length - 1);
+    const match = currentIndex >= 0 ? (matches[currentIndex] ?? null) : null;
+    previousMatchRef.current = match;
+    onMatchesChangeRef.current(matches, deferredQuery, currentIndex);
+    onActiveMatchChangeRef.current(match, deferredQuery, currentIndex);
+  }, [deferredQuery, matches, open]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const input = inputRef.current;
+    if (!input) {
+      return;
+    }
+    if (document.activeElement !== input && input.value.trim().length === 0) {
+      const selected = window.getSelection()?.toString().trim() ?? "";
+      if (selected.length > 0) {
+        setQuery(selected.slice(0, FILE_PREVIEW_FIND_QUERY_MAX_LENGTH));
+        activeIndexRef.current = 0;
+        setActiveIndex(0);
+      }
+    }
+    input.focus();
+    input.select();
+  }, [focusNonce, open]);
+
+  const handleQueryChange = (nextQuery: string) => {
+    setQuery(nextQuery.slice(0, FILE_PREVIEW_FIND_QUERY_MAX_LENGTH));
+    activeIndexRef.current = 0;
+    setActiveIndex(0);
+  };
+
+  const handleStep = (direction: "next" | "previous") => {
+    if (deferredQuery !== query || matchCount === 0) {
+      return;
+    }
+    const nextIndex = stepFilePreviewFindIndex(matchCount, safeIndex, direction);
+    const match = matches[nextIndex] ?? null;
+    activeIndexRef.current = nextIndex;
+    setActiveIndex(nextIndex);
+    previousMatchRef.current = match;
+    onActiveMatchChangeRef.current(match, deferredQuery, nextIndex);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      onClose();
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      event.stopPropagation();
+      handleStep(event.shiftKey ? "previous" : "next");
+    }
+  };
+
+  const resultsRowVisible = query.trim().length > 0;
+
+  return (
+    <div
+      role="search"
+      data-testid="file-preview-find-bar"
+      data-file-preview-find-layout="panel"
+      className="flex w-80 max-w-[calc(100%-1.5rem)] flex-col rounded-3xl border border-border/60 bg-[var(--color-background-elevated-primary-opaque)] shadow-lg"
+    >
+      <div className="flex items-center gap-2.5 px-4">
+        <SearchIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(event) => handleQueryChange(event.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Find in file..."
+          aria-label="Find in file"
+          autoComplete="off"
+          spellCheck={false}
+          className="font-system-ui h-11 min-w-0 flex-1 bg-transparent text-[length:var(--app-font-size-ui,12px)] text-foreground placeholder:text-muted-foreground focus:outline-none"
+        />
+        <div aria-hidden="true" className="h-5 w-px shrink-0 bg-border" />
+        <IconButton
+          onClick={onClose}
+          className={FIND_STEP_BUTTON_CLASS_NAME}
+          label="Close find (Esc)"
+        >
+          <XIcon className="size-4" />
+        </IconButton>
+      </div>
+      <DisclosureRegion open={resultsRowVisible}>
+        <div className="flex items-center justify-between gap-2 border-t border-border/60 px-3 py-2">
+          <div className="flex shrink-0 items-center gap-1">
+            <IconButton
+              onClick={() => handleStep("previous")}
+              disabled={matchCount === 0}
+              className={FIND_STEP_BUTTON_CLASS_NAME}
+              label="Previous match (Shift+Enter)"
+            >
+              <ArrowUpIcon className="size-4" />
+            </IconButton>
+            <IconButton
+              onClick={() => handleStep("next")}
+              disabled={matchCount === 0}
+              className={FIND_STEP_BUTTON_CLASS_NAME}
+              label="Next match (Enter)"
+            >
+              <ArrowDownIcon className="size-4" />
+            </IconButton>
+          </div>
+          <span
+            className={cn(
+              "min-w-0 truncate pr-1 text-right text-[length:var(--app-font-size-ui-sm,11px)] tabular-nums",
+              MUTED_LABEL_TEXT_CLASS_NAME,
+            )}
+            aria-live="polite"
+          >
+            {filePreviewMatchCountLabel({
+              query: deferredQuery,
+              matchCount,
+              activeIndex: safeIndex,
+              capped: matchPass.capped,
+            })}
+          </span>
+        </div>
+      </DisclosureRegion>
+    </div>
+  );
+}
+
+export function FilePreviewFindHost({
+  open,
+  focusNonce,
+  contents,
+  className,
+  onClose,
+  onMatchesChange,
+  onActiveMatchChange,
+}: FilePreviewFindBarProps & { className?: string }) {
+  return (
+    <div
+      data-file-preview-find-host="true"
+      className={cn("pointer-events-none absolute right-0 top-0 z-40", className)}
+    >
+      <DisclosureRegion open={open} contentClassName="pointer-events-auto p-3">
+        <FilePreviewFindBar
+          open={open}
+          focusNonce={focusNonce}
+          contents={contents}
+          onClose={onClose}
+          onMatchesChange={onMatchesChange}
+          onActiveMatchChange={onActiveMatchChange}
+        />
+      </DisclosureRegion>
+    </div>
+  );
+}

--- a/apps/web/src/components/FilePreviewFindBar.tsx
+++ b/apps/web/src/components/FilePreviewFindBar.tsx
@@ -3,14 +3,7 @@
 //   + match count below. Mirrors ThreadFindBar layout for a consistent find UX.
 // Layer: File preview presentation
 
-import {
-  useDeferredValue,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type KeyboardEvent,
-} from "react";
+import { useDeferredValue, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 
 import { IconButton } from "~/components/ui/icon-button";
 import { ArrowDownIcon, ArrowUpIcon, SearchIcon, XIcon } from "~/lib/icons";
@@ -32,8 +25,16 @@ interface FilePreviewFindBarProps {
   focusNonce: number;
   contents: string;
   onClose: () => void;
-  onMatchesChange: (matches: readonly FilePreviewFindMatch[], query: string, activeIndex: number) => void;
-  onActiveMatchChange: (match: FilePreviewFindMatch | null, query: string, activeIndex: number) => void;
+  onMatchesChange: (
+    matches: readonly FilePreviewFindMatch[],
+    query: string,
+    activeIndex: number,
+  ) => void;
+  onActiveMatchChange: (
+    match: FilePreviewFindMatch | null,
+    query: string,
+    activeIndex: number,
+  ) => void;
 }
 
 const FIND_STEP_BUTTON_CLASS_NAME =
@@ -65,7 +66,11 @@ export function FilePreviewFindBar({
     if (!open) {
       return { matches: [] as FilePreviewFindMatch[], capped: false };
     }
-    const all = collectFilePreviewMatches(contents, deferredQuery, FILE_PREVIEW_FIND_MAX_MATCHES + 1);
+    const all = collectFilePreviewMatches(
+      contents,
+      deferredQuery,
+      FILE_PREVIEW_FIND_MAX_MATCHES + 1,
+    );
     const capped = all.length > FILE_PREVIEW_FIND_MAX_MATCHES;
     return {
       matches: capped ? all.slice(0, FILE_PREVIEW_FIND_MAX_MATCHES) : all,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -361,6 +361,7 @@ import {
   resolveThreadHandoffBadgeLabel,
 } from "../lib/threadHandoff";
 import { isTerminalFocused } from "../lib/terminalFocus";
+import { isFilePreviewFocused } from "./filePreviewFind.logic";
 import { useDiffRouteSearch } from "../hooks/useDiffRouteSearch";
 import { normalizeSettingsSection } from "../settingsNavigation";
 import {
@@ -4269,6 +4270,7 @@ export default function Sidebar() {
       terminalFocus: isTerminalFocused(),
       terminalOpen,
       terminalWorkspaceOpen,
+      filePreviewFocus: isFilePreviewFocused(),
     }),
     [terminalOpen, terminalWorkspaceOpen],
   );

--- a/apps/web/src/components/WorkspaceFilePreview.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.tsx
@@ -76,6 +76,14 @@ import { useFileLineCommenting } from "./chat/useFileLineCommenting";
 import { WorkspaceFilePreviewHeader } from "./chat/WorkspaceFilePreviewHeader";
 import { TranscriptSelectionAction } from "./chat/TranscriptSelectionAction";
 import { useCodeSelectionAction } from "./chat/useCodeSelectionAction";
+import { FilePreviewFindHost } from "./FilePreviewFindBar";
+import {
+  applyFilePreviewFindHighlights,
+  clearFilePreviewFindHighlights,
+  registerFilePreviewFindController,
+  scrollFilePreviewMatchIntoView,
+  type FilePreviewFindMatch,
+} from "./filePreviewFind.logic";
 import { LocalImagePreview } from "./LocalImagePreview";
 import { PdfFilePreview } from "./PdfFilePreview";
 import { Skeleton } from "./ui/skeleton";
@@ -366,15 +374,35 @@ function readFileSaveError(error: unknown): string {
     : "Could not save this file.";
 }
 
+function hasFileContentsReadyForFind(input: {
+  hasFileContents: boolean;
+  fileIsImage: boolean;
+  fileIsPdf: boolean;
+  editableSourceOpen: boolean;
+}): boolean {
+  return (
+    input.hasFileContents &&
+    !input.fileIsImage &&
+    !input.fileIsPdf &&
+    !input.editableSourceOpen
+  );
+}
+
 export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
   const liveRevalidationEnabled = props.liveRevalidationEnabled ?? true;
   const { resolvedTheme } = useTheme();
   const diffThemeName = resolveDiffThemeName(resolvedTheme);
+  const previewRootRef = useRef<HTMLDivElement>(null);
   const contentsRef = useRef<HTMLDivElement>(null);
   const taskWriteQueueRef = useRef<Promise<void>>(Promise.resolve());
   const latestTaskWriteVersionRef = useRef({ next: 0, byFile: new Map<string, number>() });
   const taskFileDiskVersionRef = useRef(new Map<string, string>());
   const [editBuffer, setEditBuffer] = useState<FileEditBuffer | null>(null);
+  const [findOpen, setFindOpen] = useState(false);
+  const [findFocusNonce, setFindFocusNonce] = useState(0);
+  const findMatchesRef = useRef<readonly FilePreviewFindMatch[]>([]);
+  const findQueryRef = useRef("");
+  const findActiveIndexRef = useRef(-1);
   const {
     filePath: requestedFilePath,
     onAskWhyInChat,
@@ -861,6 +889,120 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
     fileQuery.data.lineEnding !== "mixed" &&
     !editBufferDirty;
 
+  // Find covers the read-only code and rendered-markdown paths only — not the
+  // editable textarea, images, or PDFs.
+  const findAvailable =
+    hasFileContentsReadyForFind({
+      hasFileContents: fileQuery.data !== undefined,
+      fileIsImage,
+      fileIsPdf,
+      editableSourceOpen: Boolean(activeEditBuffer && editableDocument && !showMarkdownPreview),
+    });
+
+  const openFileFind = useCallback(() => {
+    if (!findAvailable) return;
+    setFindOpen(true);
+    setFindFocusNonce((current) => current + 1);
+  }, [findAvailable]);
+
+  useEffect(() => {
+    if (!findAvailable && findOpen) {
+      setFindOpen(false);
+    }
+  }, [findAvailable, findOpen]);
+
+  useEffect(() => {
+    const root = previewRootRef.current;
+    if (!root || !findAvailable) {
+      return;
+    }
+    return registerFilePreviewFindController({
+      root,
+      open: openFileFind,
+    });
+  }, [findAvailable, openFileFind, filePath]);
+
+  useEffect(() => {
+    if (findOpen) {
+      return;
+    }
+    clearFilePreviewFindHighlights(contentsRef.current);
+    findMatchesRef.current = [];
+    findQueryRef.current = "";
+    findActiveIndexRef.current = -1;
+  }, [findOpen]);
+
+  useEffect(() => {
+    return () => {
+      clearFilePreviewFindHighlights(contentsRef.current);
+    };
+  }, []);
+
+  const handleFindMatchesChange = useCallback(
+    (matches: readonly FilePreviewFindMatch[], query: string, activeIndex: number) => {
+      findMatchesRef.current = matches;
+      findQueryRef.current = query;
+      findActiveIndexRef.current = activeIndex;
+      const root = contentsRef.current;
+      if (!root) return;
+      applyFilePreviewFindHighlights({
+        root,
+        contents: displayedFileContents,
+        query,
+        activeIndex,
+        matches,
+      });
+    },
+    [displayedFileContents],
+  );
+
+  const handleFindActiveMatchChange = useCallback(
+    (match: FilePreviewFindMatch | null, query: string, activeIndex: number) => {
+      findActiveIndexRef.current = activeIndex;
+      findQueryRef.current = query;
+      const root = contentsRef.current;
+      if (!root) return;
+      applyFilePreviewFindHighlights({
+        root,
+        contents: displayedFileContents,
+        query,
+        activeIndex,
+        matches: findMatchesRef.current,
+      });
+      if (match) {
+        scrollFilePreviewMatchIntoView({
+          root,
+          contents: displayedFileContents,
+          query,
+          activeIndex,
+          matches: findMatchesRef.current,
+        });
+      }
+    },
+    [displayedFileContents],
+  );
+
+  // Re-apply highlights after Shiki/markdown paint catches up to a live reload.
+  useEffect(() => {
+    if (!findOpen) {
+      return;
+    }
+    const root = contentsRef.current;
+    if (!root || findMatchesRef.current.length === 0) {
+      return;
+    }
+    const frame = window.requestAnimationFrame(() => {
+      applyFilePreviewFindHighlights({
+        root,
+        contents: displayedFileContents,
+        query: findQueryRef.current,
+        activeIndex: findActiveIndexRef.current,
+        matches: findMatchesRef.current,
+      });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [displayedFileContents, findOpen, showMarkdownPreview, filePath]);
+
   if (!props.workspaceRoot && !fileIsLocalAbsolute && !fileIsScratchBinaryPreview) {
     return (
       <PanelStateMessage density="compact" fill="flex">
@@ -928,7 +1070,32 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
     hasFileContents && fileReadError !== null && !activeEditBuffer?.error;
 
   return (
-    <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col bg-[var(--color-background-surface)]">
+    <div
+      ref={previewRootRef}
+      data-file-preview="true"
+      tabIndex={findAvailable ? 0 : undefined}
+      className="relative flex h-full min-h-0 min-w-0 flex-1 flex-col bg-[var(--color-background-surface)] outline-none"
+      onMouseDown={(event) => {
+        if (!findAvailable) return;
+        if (!(event.target instanceof HTMLElement)) return;
+        // Keep native focus for find-field / header controls; otherwise claim
+        // focus so Cmd+F resolves to file.find for this preview.
+        if (event.target.closest("input, textarea, button, a, [contenteditable='true']")) {
+          return;
+        }
+        previewRootRef.current?.focus({ preventScroll: true });
+      }}
+    >
+      {findAvailable ? (
+        <FilePreviewFindHost
+          open={findOpen}
+          focusNonce={findFocusNonce}
+          contents={displayedFileContents}
+          onClose={() => setFindOpen(false)}
+          onMatchesChange={handleFindMatchesChange}
+          onActiveMatchChange={handleFindActiveMatchChange}
+        />
+      ) : null}
       <WorkspaceFilePreviewHeader
         workspaceRoot={props.workspaceRoot}
         filePath={filePath}

--- a/apps/web/src/components/WorkspaceFilePreview.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.tsx
@@ -381,10 +381,7 @@ function hasFileContentsReadyForFind(input: {
   editableSourceOpen: boolean;
 }): boolean {
   return (
-    input.hasFileContents &&
-    !input.fileIsImage &&
-    !input.fileIsPdf &&
-    !input.editableSourceOpen
+    input.hasFileContents && !input.fileIsImage && !input.fileIsPdf && !input.editableSourceOpen
   );
 }
 
@@ -891,13 +888,12 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
 
   // Find covers the read-only code and rendered-markdown paths only — not the
   // editable textarea, images, or PDFs.
-  const findAvailable =
-    hasFileContentsReadyForFind({
-      hasFileContents: fileQuery.data !== undefined,
-      fileIsImage,
-      fileIsPdf,
-      editableSourceOpen: Boolean(activeEditBuffer && editableDocument && !showMarkdownPreview),
-    });
+  const findAvailable = hasFileContentsReadyForFind({
+    hasFileContents: fileQuery.data !== undefined,
+    fileIsImage,
+    fileIsPdf,
+    editableSourceOpen: Boolean(activeEditBuffer && editableDocument && !showMarkdownPreview),
+  });
 
   const openFileFind = useCallback(() => {
     if (!findAvailable) return;

--- a/apps/web/src/components/chat/threadFind.logic.test.ts
+++ b/apps/web/src/components/chat/threadFind.logic.test.ts
@@ -381,7 +381,7 @@ describe("shouldCaptureChatFindShortcut", () => {
     ).toBe(true);
   });
 
-  it("does not steal Ctrl+F from a focused terminal tab or in-app browser", () => {
+  it("does not steal Ctrl+F from a focused terminal tab, in-app browser, or file preview", () => {
     expect(
       shouldCaptureChatFindShortcut({
         shouldRenderChatPaneContent: true,
@@ -394,6 +394,14 @@ describe("shouldCaptureChatFindShortcut", () => {
         shouldRenderChatPaneContent: true,
         terminalWorkspaceTerminalTabActive: false,
         inAppBrowserFocused: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldCaptureChatFindShortcut({
+        shouldRenderChatPaneContent: true,
+        terminalWorkspaceTerminalTabActive: false,
+        inAppBrowserFocused: false,
+        filePreviewFocused: true,
       }),
     ).toBe(false);
     expect(

--- a/apps/web/src/components/chat/threadFind.logic.ts
+++ b/apps/web/src/components/chat/threadFind.logic.ts
@@ -505,11 +505,13 @@ export function shouldCaptureChatFindShortcut(input: {
   shouldRenderChatPaneContent: boolean;
   terminalWorkspaceTerminalTabActive: boolean;
   inAppBrowserFocused: boolean;
+  filePreviewFocused?: boolean;
 }): boolean {
   return (
     input.shouldRenderChatPaneContent &&
     !input.terminalWorkspaceTerminalTabActive &&
-    !input.inAppBrowserFocused
+    !input.inAppBrowserFocused &&
+    !input.filePreviewFocused
   );
 }
 

--- a/apps/web/src/components/filePreviewFind.logic.test.ts
+++ b/apps/web/src/components/filePreviewFind.logic.test.ts
@@ -37,15 +37,11 @@ describe("anchorFilePreviewMatchIndex", () => {
   const matches = collectFilePreviewMatches("one two one", "one");
 
   it("keeps the exact prior offset when still present", () => {
-    expect(
-      anchorFilePreviewMatchIndex(matches, { startOffset: 8, endOffset: 11 }),
-    ).toBe(1);
+    expect(anchorFilePreviewMatchIndex(matches, { startOffset: 8, endOffset: 11 })).toBe(1);
   });
 
   it("falls back to the nearest offset after a live edit", () => {
-    expect(
-      anchorFilePreviewMatchIndex(matches, { startOffset: 7, endOffset: 10 }),
-    ).toBe(1);
+    expect(anchorFilePreviewMatchIndex(matches, { startOffset: 7, endOffset: 10 })).toBe(1);
   });
 
   it("returns -1 when there are no matches", () => {

--- a/apps/web/src/components/filePreviewFind.logic.test.ts
+++ b/apps/web/src/components/filePreviewFind.logic.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  FILE_PREVIEW_FIND_MAX_MATCHES,
+  anchorFilePreviewMatchIndex,
+  collectFilePreviewMatches,
+  filePreviewMatchCountLabel,
+  lineIndexForOffset,
+  stepFilePreviewFindIndex,
+} from "./filePreviewFind.logic";
+
+describe("collectFilePreviewMatches", () => {
+  it("finds case-insensitive substrings with stable indexes", () => {
+    expect(collectFilePreviewMatches("Error: failed with error", "ERROR")).toEqual([
+      { index: 0, startOffset: 0, endOffset: 5 },
+      { index: 1, startOffset: 19, endOffset: 24 },
+    ]);
+  });
+
+  it("caps reported matches", () => {
+    const contents = "aa".repeat(FILE_PREVIEW_FIND_MAX_MATCHES + 5);
+    const matches = collectFilePreviewMatches(contents, "aa");
+    expect(matches).toHaveLength(FILE_PREVIEW_FIND_MAX_MATCHES);
+    expect(matches.at(-1)?.index).toBe(FILE_PREVIEW_FIND_MAX_MATCHES - 1);
+  });
+});
+
+describe("stepFilePreviewFindIndex", () => {
+  it("wraps next and previous", () => {
+    expect(stepFilePreviewFindIndex(3, 0, "next")).toBe(1);
+    expect(stepFilePreviewFindIndex(3, 2, "next")).toBe(0);
+    expect(stepFilePreviewFindIndex(3, 0, "previous")).toBe(2);
+  });
+});
+
+describe("anchorFilePreviewMatchIndex", () => {
+  const matches = collectFilePreviewMatches("one two one", "one");
+
+  it("keeps the exact prior offset when still present", () => {
+    expect(
+      anchorFilePreviewMatchIndex(matches, { startOffset: 8, endOffset: 11 }),
+    ).toBe(1);
+  });
+
+  it("falls back to the nearest offset after a live edit", () => {
+    expect(
+      anchorFilePreviewMatchIndex(matches, { startOffset: 7, endOffset: 10 }),
+    ).toBe(1);
+  });
+
+  it("returns -1 when there are no matches", () => {
+    expect(anchorFilePreviewMatchIndex([], { startOffset: 0, endOffset: 1 })).toBe(-1);
+  });
+});
+
+describe("lineIndexForOffset", () => {
+  it("counts newlines before the offset", () => {
+    expect(lineIndexForOffset("a\nb\nc", 0)).toBe(0);
+    expect(lineIndexForOffset("a\nb\nc", 2)).toBe(1);
+    expect(lineIndexForOffset("a\nb\nc", 4)).toBe(2);
+  });
+});
+
+describe("filePreviewMatchCountLabel", () => {
+  it("formats empty, miss, hit, and capped counts", () => {
+    expect(
+      filePreviewMatchCountLabel({
+        query: "",
+        matchCount: 0,
+        activeIndex: -1,
+        capped: false,
+      }),
+    ).toBe("");
+    expect(
+      filePreviewMatchCountLabel({
+        query: "x",
+        matchCount: 0,
+        activeIndex: -1,
+        capped: false,
+      }),
+    ).toBe("No results");
+    expect(
+      filePreviewMatchCountLabel({
+        query: "x",
+        matchCount: 3,
+        activeIndex: 1,
+        capped: false,
+      }),
+    ).toBe("2 / 3");
+    expect(
+      filePreviewMatchCountLabel({
+        query: "x",
+        matchCount: FILE_PREVIEW_FIND_MAX_MATCHES,
+        activeIndex: 0,
+        capped: true,
+      }),
+    ).toBe(`1 / ${FILE_PREVIEW_FIND_MAX_MATCHES}+`);
+  });
+});

--- a/apps/web/src/components/filePreviewFind.logic.ts
+++ b/apps/web/src/components/filePreviewFind.logic.ts
@@ -1,0 +1,400 @@
+// FILE: filePreviewFind.logic.ts
+// Purpose: In-preview find matching, focus detection, highlight/scroll helpers,
+//   and a small opener registry so Cmd+F can target the focused file preview.
+// Layer: File preview presentation-adjacent logic (unit-tested)
+
+import {
+  collectCaseInsensitiveSubstringRanges,
+  normalizeFindQuery,
+  stepThreadFindIndex,
+  type ThreadFindRange,
+} from "./chat/threadFind.logic";
+
+export const FILE_PREVIEW_FIND_MAX_MATCHES = 1000;
+export const FILE_PREVIEW_FIND_QUERY_MAX_LENGTH = 200;
+
+export const FILE_PREVIEW_FIND_MATCH_HIGHLIGHT = "file-find-match";
+export const FILE_PREVIEW_FIND_ACTIVE_HIGHLIGHT = "file-find-match-active";
+export const FILE_PREVIEW_FIND_LINE_MATCH_CLASS = "file-find-line-match";
+export const FILE_PREVIEW_FIND_LINE_ACTIVE_CLASS = "file-find-line-match-active";
+
+export type FilePreviewFindRange = ThreadFindRange;
+
+export interface FilePreviewFindMatch extends FilePreviewFindRange {
+  index: number;
+}
+
+export type FilePreviewFindStepDirection = "next" | "previous";
+
+export function collectFilePreviewMatches(
+  contents: string,
+  query: string,
+  maxMatches = FILE_PREVIEW_FIND_MAX_MATCHES,
+): FilePreviewFindMatch[] {
+  const ranges = collectCaseInsensitiveSubstringRanges(contents, query);
+  const limited = ranges.length > maxMatches ? ranges.slice(0, maxMatches) : ranges;
+  return limited.map((range, index) => ({
+    index,
+    startOffset: range.startOffset,
+    endOffset: range.endOffset,
+  }));
+}
+
+export function filePreviewMatchCountLabel(input: {
+  query: string;
+  matchCount: number;
+  activeIndex: number;
+  capped: boolean;
+}): string {
+  if (normalizeFindQuery(input.query).length === 0) {
+    return "";
+  }
+  if (input.matchCount === 0) {
+    return "No results";
+  }
+  const total = input.capped
+    ? `${FILE_PREVIEW_FIND_MAX_MATCHES}+`
+    : String(input.matchCount);
+  const current =
+    input.activeIndex < 0 ? 0 : Math.min(input.activeIndex + 1, input.matchCount);
+  return `${current} / ${total}`;
+}
+
+export function stepFilePreviewFindIndex(
+  matchCount: number,
+  currentIndex: number,
+  direction: FilePreviewFindStepDirection,
+): number {
+  return stepThreadFindIndex(matchCount, currentIndex, direction);
+}
+
+/**
+ * Keep the current hit stable across live reloads by preferring the same
+ * absolute offset, then the nearest later offset, then the nearest earlier one.
+ */
+export function anchorFilePreviewMatchIndex(
+  matches: readonly FilePreviewFindMatch[],
+  previous: FilePreviewFindRange | null,
+): number {
+  if (matches.length === 0) {
+    return -1;
+  }
+  if (previous === null) {
+    return 0;
+  }
+  const exact = matches.findIndex(
+    (match) =>
+      match.startOffset === previous.startOffset && match.endOffset === previous.endOffset,
+  );
+  if (exact >= 0) {
+    return exact;
+  }
+  const atOffset = matches.findIndex((match) => match.startOffset === previous.startOffset);
+  if (atOffset >= 0) {
+    return atOffset;
+  }
+  let nearest = 0;
+  let nearestDistance = Number.POSITIVE_INFINITY;
+  for (let index = 0; index < matches.length; index += 1) {
+    const match = matches[index];
+    if (!match) continue;
+    const distance = Math.abs(match.startOffset - previous.startOffset);
+    if (distance < nearestDistance) {
+      nearest = index;
+      nearestDistance = distance;
+    }
+  }
+  return nearest;
+}
+
+export function lineIndexForOffset(text: string, offset: number): number {
+  const clamped = Math.max(0, Math.min(offset, text.length));
+  let line = 0;
+  for (let index = 0; index < clamped; index += 1) {
+    if (text[index] === "\n") {
+      line += 1;
+    }
+  }
+  return line;
+}
+
+export function supportsCssCustomHighlight(): boolean {
+  return (
+    typeof CSS !== "undefined" &&
+    "highlights" in CSS &&
+    typeof Highlight !== "undefined"
+  );
+}
+
+interface DomTextNodeSpan {
+  node: Text;
+  start: number;
+  end: number;
+}
+
+function collectDomTextNodeSpans(root: Node): DomTextNodeSpan[] {
+  const spans: DomTextNodeSpan[] = [];
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let offset = 0;
+  let current = walker.nextNode();
+  while (current) {
+    if (current.nodeType === Node.TEXT_NODE) {
+      const textNode = current as Text;
+      const length = textNode.data.length;
+      if (length > 0) {
+        spans.push({ node: textNode, start: offset, end: offset + length });
+        offset += length;
+      }
+    }
+    current = walker.nextNode();
+  }
+  return spans;
+}
+
+function createRangeFromDomOffsets(
+  spans: readonly DomTextNodeSpan[],
+  startOffset: number,
+  endOffset: number,
+): Range | null {
+  if (endOffset <= startOffset || spans.length === 0) {
+    return null;
+  }
+  let startNode: Text | null = null;
+  let startNodeOffset = 0;
+  let endNode: Text | null = null;
+  let endNodeOffset = 0;
+  for (const span of spans) {
+    if (startNode === null && startOffset >= span.start && startOffset <= span.end) {
+      startNode = span.node;
+      startNodeOffset = startOffset - span.start;
+    }
+    if (endOffset >= span.start && endOffset <= span.end) {
+      endNode = span.node;
+      endNodeOffset = endOffset - span.start;
+      break;
+    }
+  }
+  if (startNode === null || endNode === null) {
+    return null;
+  }
+  try {
+    const range = document.createRange();
+    range.setStart(startNode, startNodeOffset);
+    range.setEnd(endNode, endNodeOffset);
+    return range;
+  } catch {
+    return null;
+  }
+}
+
+export function collectDomHighlightRanges(
+  root: HTMLElement,
+  query: string,
+  maxMatches = FILE_PREVIEW_FIND_MAX_MATCHES,
+): Range[] {
+  const needle = normalizeFindQuery(query);
+  if (needle.length === 0) {
+    return [];
+  }
+  const spans = collectDomTextNodeSpans(root);
+  if (spans.length === 0) {
+    return [];
+  }
+  const haystack = spans.map((span) => span.node.data).join("");
+  const matches = collectCaseInsensitiveSubstringRanges(haystack, needle);
+  const limited = matches.length > maxMatches ? matches.slice(0, maxMatches) : matches;
+  const ranges: Range[] = [];
+  for (const match of limited) {
+    const range = createRangeFromDomOffsets(spans, match.startOffset, match.endOffset);
+    if (range) {
+      ranges.push(range);
+    }
+  }
+  return ranges;
+}
+
+export function clearFilePreviewFindHighlights(root: HTMLElement | null): void {
+  if (typeof CSS !== "undefined" && "highlights" in CSS) {
+    CSS.highlights.delete(FILE_PREVIEW_FIND_MATCH_HIGHLIGHT);
+    CSS.highlights.delete(FILE_PREVIEW_FIND_ACTIVE_HIGHLIGHT);
+  }
+  if (!root) {
+    return;
+  }
+  for (const element of root.querySelectorAll(
+    `.${FILE_PREVIEW_FIND_LINE_MATCH_CLASS}, .${FILE_PREVIEW_FIND_LINE_ACTIVE_CLASS}`,
+  )) {
+    element.classList.remove(
+      FILE_PREVIEW_FIND_LINE_MATCH_CLASS,
+      FILE_PREVIEW_FIND_LINE_ACTIVE_CLASS,
+    );
+  }
+}
+
+export function applyFilePreviewFindHighlights(input: {
+  root: HTMLElement;
+  contents: string;
+  query: string;
+  activeIndex: number;
+  matches: readonly FilePreviewFindMatch[];
+}): void {
+  clearFilePreviewFindHighlights(input.root);
+  const needle = normalizeFindQuery(input.query);
+  if (needle.length === 0 || input.matches.length === 0) {
+    return;
+  }
+
+  const safeIndex =
+    input.activeIndex < 0
+      ? -1
+      : Math.min(input.activeIndex, input.matches.length - 1);
+
+  if (supportsCssCustomHighlight()) {
+    const domRanges = collectDomHighlightRanges(input.root, needle);
+    if (domRanges.length > 0) {
+      const activeDomIndex =
+        safeIndex < 0 ? -1 : Math.min(safeIndex, domRanges.length - 1);
+      const inactive = new Highlight();
+      const active = new Highlight();
+      for (let index = 0; index < domRanges.length; index += 1) {
+        const range = domRanges[index];
+        if (!range) continue;
+        if (index === activeDomIndex) {
+          active.add(range);
+        } else {
+          inactive.add(range);
+        }
+      }
+      CSS.highlights.set(FILE_PREVIEW_FIND_MATCH_HIGHLIGHT, inactive);
+      if (activeDomIndex >= 0) {
+        CSS.highlights.set(FILE_PREVIEW_FIND_ACTIVE_HIGHLIGHT, active);
+      }
+      return;
+    }
+  }
+
+  // Line-level fallback for engines without CSS Custom Highlight (or when the
+  // rendered markdown DOM cannot host source-aligned ranges).
+  const lineElements = input.root.querySelectorAll(".line");
+  if (lineElements.length === 0) {
+    return;
+  }
+  const activeMatch = safeIndex >= 0 ? input.matches[safeIndex] : null;
+  const highlightedLines = new Set<number>();
+  for (const match of input.matches) {
+    highlightedLines.add(lineIndexForOffset(input.contents, match.startOffset));
+  }
+  for (const lineIndex of highlightedLines) {
+    const element = lineElements[lineIndex];
+    if (!(element instanceof HTMLElement)) continue;
+    element.classList.add(FILE_PREVIEW_FIND_LINE_MATCH_CLASS);
+  }
+  if (activeMatch) {
+    const activeLine = lineIndexForOffset(input.contents, activeMatch.startOffset);
+    const element = lineElements[activeLine];
+    if (element instanceof HTMLElement) {
+      element.classList.add(FILE_PREVIEW_FIND_LINE_ACTIVE_CLASS);
+    }
+  }
+}
+
+export function scrollFilePreviewMatchIntoView(input: {
+  root: HTMLElement;
+  contents: string;
+  query: string;
+  activeIndex: number;
+  matches: readonly FilePreviewFindMatch[];
+}): void {
+  if (input.matches.length === 0 || input.activeIndex < 0) {
+    return;
+  }
+  const safeIndex = Math.min(input.activeIndex, input.matches.length - 1);
+  const match = input.matches[safeIndex];
+  if (!match) {
+    return;
+  }
+
+  const needle = normalizeFindQuery(input.query);
+  if (needle.length > 0 && supportsCssCustomHighlight()) {
+    const domRanges = collectDomHighlightRanges(input.root, needle);
+    const range = domRanges[Math.min(safeIndex, Math.max(domRanges.length - 1, 0))];
+    if (range) {
+      const anchor = range.startContainer instanceof Element
+        ? range.startContainer
+        : range.startContainer.parentElement;
+      anchor?.scrollIntoView({ block: "center", inline: "nearest" });
+      return;
+    }
+  }
+
+  const lineElements = input.root.querySelectorAll(".line");
+  const lineIndex = lineIndexForOffset(input.contents, match.startOffset);
+  const lineElement = lineElements[lineIndex];
+  if (lineElement instanceof HTMLElement) {
+    lineElement.scrollIntoView({ block: "center", inline: "nearest" });
+    return;
+  }
+
+  // Markdown / non-line DOM: scroll the first element that contains the hit text.
+  const snippet = input.contents.slice(match.startOffset, match.endOffset);
+  if (snippet.length === 0) {
+    return;
+  }
+  const walker = document.createTreeWalker(input.root, NodeFilter.SHOW_TEXT);
+  let current = walker.nextNode();
+  while (current) {
+    if (
+      current.nodeType === Node.TEXT_NODE &&
+      current.nodeValue &&
+      current.nodeValue.toLowerCase().includes(snippet.toLowerCase())
+    ) {
+      const parent = current.parentElement;
+      parent?.scrollIntoView({ block: "center", inline: "nearest" });
+      return;
+    }
+    current = walker.nextNode();
+  }
+}
+
+export function isFilePreviewFocused(): boolean {
+  const activeElement = document.activeElement;
+  if (!(activeElement instanceof HTMLElement) || !activeElement.isConnected) {
+    return false;
+  }
+  return activeElement.closest("[data-file-preview='true']") !== null;
+}
+
+export function eventTargetsFilePreview(target: EventTarget | null): boolean {
+  if (typeof Element === "undefined" || !(target instanceof Element)) {
+    return false;
+  }
+  return target.closest("[data-file-preview='true']") !== null;
+}
+
+interface FilePreviewFindController {
+  root: HTMLElement;
+  open: () => void;
+}
+
+const filePreviewFindControllers = new Set<FilePreviewFindController>();
+
+export function registerFilePreviewFindController(controller: FilePreviewFindController): () => void {
+  filePreviewFindControllers.add(controller);
+  return () => {
+    filePreviewFindControllers.delete(controller);
+  };
+}
+
+export function openFocusedFilePreviewFind(): boolean {
+  const activeElement = document.activeElement;
+  for (const controller of filePreviewFindControllers) {
+    if (
+      controller.root === activeElement ||
+      (activeElement instanceof Node && controller.root.contains(activeElement))
+    ) {
+      controller.open();
+      return true;
+    }
+  }
+  return false;
+}

--- a/apps/web/src/components/filePreviewFind.logic.ts
+++ b/apps/web/src/components/filePreviewFind.logic.ts
@@ -52,11 +52,8 @@ export function filePreviewMatchCountLabel(input: {
   if (input.matchCount === 0) {
     return "No results";
   }
-  const total = input.capped
-    ? `${FILE_PREVIEW_FIND_MAX_MATCHES}+`
-    : String(input.matchCount);
-  const current =
-    input.activeIndex < 0 ? 0 : Math.min(input.activeIndex + 1, input.matchCount);
+  const total = input.capped ? `${FILE_PREVIEW_FIND_MAX_MATCHES}+` : String(input.matchCount);
+  const current = input.activeIndex < 0 ? 0 : Math.min(input.activeIndex + 1, input.matchCount);
   return `${current} / ${total}`;
 }
 
@@ -83,8 +80,7 @@ export function anchorFilePreviewMatchIndex(
     return 0;
   }
   const exact = matches.findIndex(
-    (match) =>
-      match.startOffset === previous.startOffset && match.endOffset === previous.endOffset,
+    (match) => match.startOffset === previous.startOffset && match.endOffset === previous.endOffset,
   );
   if (exact >= 0) {
     return exact;
@@ -119,11 +115,7 @@ export function lineIndexForOffset(text: string, offset: number): number {
 }
 
 export function supportsCssCustomHighlight(): boolean {
-  return (
-    typeof CSS !== "undefined" &&
-    "highlights" in CSS &&
-    typeof Highlight !== "undefined"
-  );
+  return typeof CSS !== "undefined" && "highlights" in CSS && typeof Highlight !== "undefined";
 }
 
 interface DomTextNodeSpan {
@@ -245,15 +237,12 @@ export function applyFilePreviewFindHighlights(input: {
   }
 
   const safeIndex =
-    input.activeIndex < 0
-      ? -1
-      : Math.min(input.activeIndex, input.matches.length - 1);
+    input.activeIndex < 0 ? -1 : Math.min(input.activeIndex, input.matches.length - 1);
 
   if (supportsCssCustomHighlight()) {
     const domRanges = collectDomHighlightRanges(input.root, needle);
     if (domRanges.length > 0) {
-      const activeDomIndex =
-        safeIndex < 0 ? -1 : Math.min(safeIndex, domRanges.length - 1);
+      const activeDomIndex = safeIndex < 0 ? -1 : Math.min(safeIndex, domRanges.length - 1);
       const inactive = new Highlight();
       const active = new Highlight();
       for (let index = 0; index < domRanges.length; index += 1) {
@@ -319,9 +308,10 @@ export function scrollFilePreviewMatchIntoView(input: {
     const domRanges = collectDomHighlightRanges(input.root, needle);
     const range = domRanges[Math.min(safeIndex, Math.max(domRanges.length - 1, 0))];
     if (range) {
-      const anchor = range.startContainer instanceof Element
-        ? range.startContainer
-        : range.startContainer.parentElement;
+      const anchor =
+        range.startContainer instanceof Element
+          ? range.startContainer
+          : range.startContainer.parentElement;
       anchor?.scrollIntoView({ block: "center", inline: "nearest" });
       return;
     }
@@ -378,7 +368,9 @@ interface FilePreviewFindController {
 
 const filePreviewFindControllers = new Set<FilePreviewFindController>();
 
-export function registerFilePreviewFindController(controller: FilePreviewFindController): () => void {
+export function registerFilePreviewFindController(
+  controller: FilePreviewFindController,
+): () => void {
   filePreviewFindControllers.add(controller);
   return () => {
     filePreviewFindControllers.delete(controller);

--- a/apps/web/src/components/settings/KeyboardShortcutsSettingsPanel.tsx
+++ b/apps/web/src/components/settings/KeyboardShortcutsSettingsPanel.tsx
@@ -46,6 +46,7 @@ const SETTINGS_SHORTCUT_CONTEXT: ShortcutSheetContext = {
   terminalFocus: false,
   terminalOpen: false,
   terminalWorkspaceOpen: false,
+  filePreviewFocus: false,
 };
 
 const EDITABLE_SHORTCUT_DEFINITIONS = listEditableShortcutDefinitions();

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -848,6 +848,25 @@ label:has(> select#reasoning-effort) select {
   border-bottom-right-radius: 0;
 }
 
+/* File preview find: CSS Custom Highlight API (preferred) + line-level fallback. */
+::highlight(file-find-match) {
+  background-color: color-mix(in srgb, var(--color-amber-400) 55%, transparent);
+  color: var(--color-stone-900);
+}
+
+::highlight(file-find-match-active) {
+  background-color: color-mix(in srgb, var(--color-orange-500) 68%, transparent);
+  color: var(--color-stone-950);
+}
+
+.editor-file-viewer .file-find-line-match {
+  background-color: color-mix(in srgb, var(--color-amber-400) 22%, transparent);
+}
+
+.editor-file-viewer .file-find-line-match-active {
+  background-color: color-mix(in srgb, var(--color-orange-500) 28%, transparent);
+}
+
 /* Markdown can split one marker across inline nodes; only outer edges keep padding/radius. */
 .chat-markdown .thread-marker-highlight.thread-marker-continues-before {
   padding-left: 0;

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -311,7 +311,15 @@ const DEFAULT_BINDINGS = compile([
   {
     shortcut: modShortcut("f"),
     command: "chat.find",
-    whenAst: whenNot(whenIdentifier("terminalFocus")),
+    whenAst: whenAnd(
+      whenNot(whenIdentifier("terminalFocus")),
+      whenNot(whenIdentifier("filePreviewFocus")),
+    ),
+  },
+  {
+    shortcut: modShortcut("f"),
+    command: "file.find",
+    whenAst: whenIdentifier("filePreviewFocus"),
   },
   {
     shortcut: modShortcut("u", { shiftKey: true }),
@@ -626,38 +634,64 @@ describe("Activity shortcut", () => {
 });
 
 describe("in-thread find shortcuts", () => {
-  it("opens chat.find with Cmd/Ctrl+F outside terminal focus", () => {
+  it("opens chat.find with Cmd/Ctrl+F outside terminal and file-preview focus", () => {
     assert.equal(
       resolveShortcutCommand(event({ key: "f", metaKey: true }), DEFAULT_BINDINGS, {
         platform: "MacIntel",
-        context: { terminalFocus: false },
+        context: { terminalFocus: false, filePreviewFocus: false },
       }),
       "chat.find",
     );
     assert.equal(
       resolveShortcutCommand(event({ key: "f", ctrlKey: true }), DEFAULT_BINDINGS, {
         platform: "Win32",
-        context: { terminalFocus: false },
+        context: { terminalFocus: false, filePreviewFocus: false },
       }),
       "chat.find",
     );
     assert.isNull(
       resolveShortcutCommand(event({ key: "f", metaKey: true }), DEFAULT_BINDINGS, {
         platform: "MacIntel",
-        context: { terminalFocus: true },
+        context: { terminalFocus: true, filePreviewFocus: false },
       }),
     );
   });
 
+  it("opens file.find with Cmd/Ctrl+F when the file preview is focused", () => {
+    assert.equal(
+      resolveShortcutCommand(event({ key: "f", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false, filePreviewFocus: true },
+      }),
+      "file.find",
+    );
+    assert.equal(
+      resolveShortcutCommand(event({ key: "f", ctrlKey: true }), DEFAULT_BINDINGS, {
+        platform: "Win32",
+        context: { terminalFocus: false, filePreviewFocus: true },
+      }),
+      "file.find",
+    );
+  });
+
   it("falls back to chat.find when runtime config is missing it", () => {
-    const legacyBindings = DEFAULT_BINDINGS.filter((binding) => binding.command !== "chat.find");
+    const legacyBindings = DEFAULT_BINDINGS.filter(
+      (binding) => binding.command !== "chat.find" && binding.command !== "file.find",
+    );
 
     assert.strictEqual(
       resolveShortcutCommand(event({ key: "f", metaKey: true }), legacyBindings, {
         platform: "MacIntel",
-        context: { terminalFocus: false },
+        context: { terminalFocus: false, filePreviewFocus: false },
       }),
       "chat.find",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "f", metaKey: true }), legacyBindings, {
+        platform: "MacIntel",
+        context: { terminalFocus: false, filePreviewFocus: true },
+      }),
+      "file.find",
     );
   });
 });

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -26,6 +26,7 @@ export interface ShortcutEventLike {
 export interface ShortcutMatchContext {
   terminalFocus: boolean;
   terminalOpen: boolean;
+  filePreviewFocus: boolean;
   [key: string]: boolean;
 }
 
@@ -70,6 +71,11 @@ function whenOr(left: KeybindingWhenNode, right: KeybindingWhenNode): Keybinding
 }
 
 const whenNotTerminalFocus = whenNot(whenIdentifier("terminalFocus"));
+const whenFilePreviewFocus = whenIdentifier("filePreviewFocus");
+const whenChatFindAvailable = whenAnd(
+  whenNotTerminalFocus,
+  whenNot(whenIdentifier("filePreviewFocus")),
+);
 // Cmd+1…9 is app navigation on macOS, including from a focused/full-width terminal.
 // On Linux/Windows `mod` is Ctrl, so keep yielding the chord to the shell and to the
 // terminal workspace's Ctrl+1/Ctrl+2 tabs while that surface is open.
@@ -184,7 +190,12 @@ export const DEFAULT_SHORTCUT_FALLBACKS: ResolvedKeybindingsConfig = [
   {
     command: "chat.find",
     shortcut: commandShortcut("f"),
-    whenAst: whenNotTerminalFocus,
+    whenAst: whenChatFindAvailable,
+  },
+  {
+    command: "file.find",
+    shortcut: commandShortcut("f"),
+    whenAst: whenFilePreviewFocus,
   },
   {
     command: "settings.usage",
@@ -383,6 +394,7 @@ function resolveContext(options: ShortcutMatchOptions | undefined): ShortcutMatc
   return {
     terminalFocus: false,
     terminalOpen: false,
+    filePreviewFocus: false,
     isMac: isMacPlatform(resolvePlatform(options)),
     ...options?.context,
   };

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -46,6 +46,7 @@ import { useFocusedChatContext } from "../focusedChatContext";
 import { useFeedbackDialogStore } from "../feedbackDialogStore";
 import type { FeedbackThreadContext } from "../feedback";
 import { isTerminalFocused } from "../lib/terminalFocus";
+import { isFilePreviewFocused } from "../components/filePreviewFind.logic";
 import {
   invalidateProviderUsageQueries,
   reconcileServerProviderStatuses,
@@ -745,6 +746,7 @@ function GlobalShortcutsDialog() {
         terminalFocus: isTerminalFocused(),
         terminalOpen,
         terminalWorkspaceOpen,
+        filePreviewFocus: isFilePreviewFocused(),
       }}
     />
   );

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -27,6 +27,7 @@ import {
 } from "../lib/projectShortcutTargets";
 import { resolveInheritedThreadContext } from "../lib/threadBootstrap";
 import { isTerminalFocused } from "../lib/terminalFocus";
+import { isFilePreviewFocused } from "../components/filePreviewFind.logic";
 import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 import { startFreshChatForActiveSurface } from "../lib/startContainerChat";
 import { isOrdinarySpaceProject } from "../lib/spaces";
@@ -332,6 +333,7 @@ function ChatRouteGlobalShortcuts() {
         terminalFocus: isTerminalFocused(),
         terminalOpen,
         terminalWorkspaceOpen,
+        filePreviewFocus: isFilePreviewFocused(),
       };
 
       if (recentSwitcherState && event.key === "Escape") {
@@ -538,6 +540,7 @@ function ChatRouteGlobalShortcuts() {
           terminalFocus: isTerminalFocused(),
           terminalOpen,
           terminalWorkspaceOpen,
+          filePreviewFocus: isFilePreviewFocused(),
         }}
       />
       {recentSwitcherState ? (

--- a/apps/web/src/shortcutsSheet.test.ts
+++ b/apps/web/src/shortcutsSheet.test.ts
@@ -61,6 +61,11 @@ describe("buildShortcutSheetSections", () => {
     ).toBe(true);
     expect(
       sections[0]?.entries.some(
+        (entry) => entry.id === "file.find" && entry.shortcutLabel === "⌘F",
+      ),
+    ).toBe(true);
+    expect(
+      sections[0]?.entries.some(
         (entry) => entry.id === "sidebar.activity" && entry.shortcutLabel === "⌥⌘U",
       ),
     ).toBe(true);

--- a/apps/web/src/shortcutsSheet.ts
+++ b/apps/web/src/shortcutsSheet.ts
@@ -179,6 +179,11 @@ const AVAILABLE_NOW_DEFINITIONS: readonly ShortcutDefinition[] = [
     description: "Search the current transcript and jump to each matching message.",
   },
   {
+    command: "file.find",
+    label: "Find in file",
+    description: "Search the focused file preview and jump to each match.",
+  },
+  {
     command: "terminal.toggle",
     label: "Toggle terminal",
     description: "Show or hide the terminal surface for the active thread.",
@@ -319,6 +324,21 @@ export function shortcutSheetCommandLabel(command: KeybindingCommand): string | 
   return null;
 }
 
+function sheetLookupContextForCommand(
+  command: KeybindingCommand,
+  context: ShortcutSheetContext,
+): ShortcutSheetContext {
+  // Scoped find chords share mod+F. Force the matching focus flag so the sheet
+  // can still show each command's shortcut even when that surface isn't focused.
+  if (command === "file.find") {
+    return { ...context, filePreviewFocus: true };
+  }
+  if (command === "chat.find") {
+    return { ...context, filePreviewFocus: false, terminalFocus: false };
+  }
+  return context;
+}
+
 function definitionToEntry(
   definition: ShortcutDefinition,
   keybindings: ResolvedKeybindingsConfig,
@@ -328,7 +348,11 @@ function definitionToEntry(
   const commands = Array.isArray(definition.command) ? definition.command : [definition.command];
   const binding = commands.reduce<ResolvedKeybindingRule | null>(
     (resolved, command) =>
-      resolved ?? resolveKeybindingForCommand(keybindings, command, { platform, context }),
+      resolved ??
+      resolveKeybindingForCommand(keybindings, command, {
+        platform,
+        context: sheetLookupContextForCommand(command, context),
+      }),
     null,
   );
   if (!binding) return null;

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -131,6 +131,12 @@ it.effect("parses keybinding rules", () =>
     });
     assert.strictEqual(parsedChatFind.command, "chat.find");
 
+    const parsedFileFind = yield* decode(KeybindingRule, {
+      key: "mod+f",
+      command: "file.find",
+    });
+    assert.strictEqual(parsedFileFind.command, "file.find");
+
     const parsedNewChat = yield* decode(KeybindingRule, {
       key: "mod+alt+n",
       command: "chat.newChat",

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -41,6 +41,7 @@ export const STATIC_KEYBINDING_COMMANDS = [
   "diff.toggle",
   "composer.focus.toggle",
   "chat.find",
+  "file.find",
   "modelPicker.toggle",
   "model.next",
   "model.previous",


### PR DESCRIPTION
## Summary

Adds in-preview find for WorkspaceFilePreview (dock + editor), fixing #800.

- Find bar when preview focused (Cmd/Ctrl+F)
- Case-insensitive substring over loaded contents; match count + prev/next
- CSS Custom Highlight API with line-level fallback; scroll-to-match
- Live-reload re-anchors matches; `file.find` keybinding scoped to preview focus
- Code + markdown paths only (not PDF/images)

## Test plan

- [x] Focused logic + keybinding tests
- [ ] Open source/markdown in dock or editor, Cmd/Ctrl+F, Enter/Shift+Enter, Esc
- [ ] Chat find still works when preview is not focused