### PR TITLE
fix(server): handle Pi auto-retry as inline warnings, keep End task responsive

### DIFF
--- a/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
@@ -512,8 +512,12 @@ function gatewayCredentials() {
     verifyWriteAuthority: () => false,
     registerInFlightRequest: () => () => undefined,
     cancelInFlightRequests: () => ({ count: 0, settled: Promise.resolve() }),
-    cancelSessionTurnRequests: vi.fn(async (_token: string, _turnId: string) => undefined),
-    retireSessionTurn: vi.fn(async (_token: string, _turnId: string) => undefined),
+    cancelSessionTurnRequests: vi.fn<AgentGatewayCredentialsShape["cancelSessionTurnRequests"]>(
+      () => Promise.resolve(),
+    ),
+    retireSessionTurn: vi.fn<AgentGatewayCredentialsShape["retireSessionTurn"]>(() =>
+      Promise.resolve(),
+    ),
     revokeSessionToken: vi.fn((_token: string) => undefined),
     connectionForThread: vi.fn(() => ({
       url: "http://127.0.0.1:3773/mcp",

--- a/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
@@ -1,0 +1,632 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import type { StreamFn } from "@earendil-works/pi-agent-core";
+import { createAssistantMessageEventStream, type AssistantMessage } from "@earendil-works/pi-ai";
+import type {
+  AgentSession,
+  AgentSessionEvent,
+  InlineExtension,
+} from "@earendil-works/pi-coding-agent";
+import { Effect, Layer, Stream } from "effect";
+import { ThreadId, type ProviderRuntimeEvent, type TurnId } from "@synara/contracts";
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  AgentGatewayCredentials,
+  type AgentGatewayCredentialsShape,
+} from "../../agentGateway/Services/AgentGatewayCredentials.ts";
+import { ServerConfig } from "../../config.ts";
+import { PiAdapter, type PiAdapterShape } from "../Services/PiAdapter.ts";
+import { makePiAdapterLive } from "./PiAdapter.ts";
+
+const captured = vi.hoisted(() => ({
+  sessions: [] as AgentSession[],
+  extensions: [] as InlineExtension[],
+  events: [] as AgentSessionEvent[],
+  stream: undefined as StreamFn | undefined,
+}));
+
+// Keep the real SDK session, agent loop, retry timers and cancellation. Replace
+// only model transport, and keep session files inside the test's isolated cwd.
+vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
+  const sdk = await importOriginal<typeof import("@earendil-works/pi-coding-agent")>();
+  return {
+    ...sdk,
+    SessionManager: {
+      ...sdk.SessionManager,
+      create: (cwd: string) => sdk.SessionManager.create(cwd, path.join(cwd, "sessions")),
+    },
+    createAgentSessionServices: async (
+      options: Parameters<typeof sdk.createAgentSessionServices>[0],
+    ) =>
+      sdk.createAgentSessionServices({
+        ...options,
+        resourceLoaderOptions: { extensionFactories: captured.extensions },
+      }),
+    createAgentSessionFromServices: async (
+      input: Parameters<typeof sdk.createAgentSessionFromServices>[0],
+    ) => {
+      const result = await sdk.createAgentSessionFromServices(input);
+      result.session.agent.streamFunction = (...args) => captured.stream!(...args);
+      result.session.subscribe((event) => captured.events.push(event));
+      captured.sessions.push(result.session);
+      return result;
+    },
+  };
+});
+
+const dirs: string[] = [];
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  captured.sessions.length = 0;
+  captured.extensions.length = 0;
+  captured.events.length = 0;
+  captured.stream = undefined;
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+type ResponseKind = "success" | "error" | "overflow" | "partial-error" | "until-abort";
+function responses(...kinds: ResponseKind[]) {
+  let calls = 0;
+  captured.stream = (model, _context, options) => {
+    const kind = kinds[calls++] ?? "success";
+    const stream = createAssistantMessageEventStream();
+    const message: AssistantMessage = {
+      role: "assistant",
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      content: [],
+      usage: {
+        input: 10,
+        output: 3,
+        cacheRead: 2,
+        cacheWrite: 0,
+        totalTokens: 15,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+    stream.push({ type: "start", partial: message });
+    if (kind === "error" || kind === "overflow") {
+      message.stopReason = "error";
+      message.errorMessage =
+        kind === "overflow"
+          ? "maximum context length exceeded"
+          : "[rate_limit_exceeded] Rate limit exceeded";
+      stream.push({ type: "error", reason: "error", error: message });
+    } else {
+      message.content.push({ type: "thinking", thinking: "Considered" });
+      stream.push({
+        type: "thinking_delta",
+        contentIndex: 0,
+        delta: "Considered",
+        partial: message,
+      });
+      message.content.push({ type: "text", text: "Answer" });
+      stream.push({ type: "text_delta", contentIndex: 1, delta: "Answer", partial: message });
+      if (kind === "partial-error") {
+        message.stopReason = "error";
+        message.errorMessage = "[rate_limit_exceeded] Rate limit exceeded";
+        stream.push({ type: "error", reason: "error", error: message });
+      } else if (kind === "until-abort") {
+        const abort = () => {
+          message.stopReason = "aborted";
+          message.errorMessage = "Request was aborted";
+          stream.push({ type: "error", reason: "aborted", error: message });
+        };
+        if (options?.signal?.aborted) abort();
+        else options?.signal?.addEventListener("abort", abort, { once: true });
+      } else {
+        stream.push({ type: "done", reason: "stop", message });
+      }
+    }
+    return stream;
+  };
+  return () => calls;
+}
+
+const threadId = ThreadId.makeUnsafe("pi-lifecycle-test");
+const waitFor = (assertion: () => void) => vi.waitFor(assertion, { interval: 5, timeout: 3_000 });
+const completions = (events: ProviderRuntimeEvent[]) =>
+  events.filter((event) => event.type === "turn.completed");
+
+async function withAdapter(
+  run: (adapter: PiAdapterShape, events: ProviderRuntimeEvent[], cwd: string) => Promise<void>,
+  delayMs = 100,
+  credentials?: AgentGatewayCredentialsShape,
+) {
+  vi.stubEnv("PI_OFFLINE", "1");
+  const cwd = mkdtempSync(path.join(tmpdir(), "synara-pi-lifecycle-"));
+  dirs.push(cwd);
+  writeFileSync(
+    path.join(cwd, "auth.json"),
+    JSON.stringify({ openai: { type: "api_key", key: "test-only" } }),
+  );
+  writeFileSync(
+    path.join(cwd, "settings.json"),
+    JSON.stringify({
+      retry: { enabled: true, maxRetries: 1, baseDelayMs: delayMs },
+      compaction: { enabled: false, keepRecentTokens: 1, reserveTokens: 100 },
+    }),
+  );
+  const gatewayFetch = async (_input: string | URL | Request, init?: RequestInit) =>
+    Response.json({
+      jsonrpc: "2.0",
+      id: JSON.parse(String(init?.body)).id,
+      result: {
+        tools: [
+          {
+            name: "synara_list_threads",
+            description: "List threads",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ],
+      },
+    });
+  let layer = makePiAdapterLive({ agentGatewayFetch: gatewayFetch }).pipe(
+    Layer.provideMerge(ServerConfig.layerTest(cwd, path.join(cwd, "server"))),
+    Layer.provideMerge(NodeServices.layer),
+  );
+  if (credentials)
+    layer = layer.pipe(Layer.provide(Layer.succeed(AgentGatewayCredentials, credentials)));
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const adapter = yield* PiAdapter;
+      const events: ProviderRuntimeEvent[] = [];
+      yield* adapter.streamEvents.pipe(
+        Stream.runForEach((event) =>
+          Effect.sync(() => {
+            events.push(event);
+          }),
+        ),
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        threadId,
+        cwd,
+        runtimeMode: "full-access",
+        providerOptions: { pi: { agentDir: cwd } },
+        modelSelection: { provider: "pi", model: "openai/gpt-4o" },
+      });
+      yield* Effect.promise(() => run(adapter, events, cwd));
+    }).pipe(Effect.provide(layer), Effect.scoped),
+  );
+}
+
+async function send(adapter: PiAdapterShape) {
+  return Effect.runPromise(adapter.sendTurn({ threadId, input: "Test this turn" }));
+}
+
+async function expectNextTurn(
+  adapter: PiAdapterShape,
+  events: ProviderRuntimeEvent[],
+  previous: TurnId,
+) {
+  responses("success");
+  const next = await send(adapter);
+  expect(next.turnId).not.toBe(previous);
+  await waitFor(() =>
+    expect(completions(events).filter((event) => event.turnId === next.turnId)).toHaveLength(1),
+  );
+  expect(completions(events).filter((event) => event.turnId === previous)).toHaveLength(1);
+}
+
+it("keeps one turn through a real SDK retry and settles text, reasoning and usage once", async () => {
+  const calls = responses("error", "success");
+  await withAdapter(async (adapter, events) => {
+    const turn = await send(adapter);
+    await waitFor(() =>
+      expect(events.some((event) => event.type === "runtime.warning")).toBe(true),
+    );
+    expect(completions(events)).toHaveLength(0);
+    expect((await Effect.runPromise(adapter.listSessions()))[0]?.activeTurnId).toBe(turn.turnId);
+    expect(
+      (await Effect.runPromise(adapter.readThread(threadId))).turns.some(
+        (entry) => entry.id === turn.turnId,
+      ),
+    ).toBe(true);
+    await waitFor(() => expect(completions(events)).toHaveLength(1));
+    expect(calls()).toBe(2);
+    expect(completions(events)[0]).toMatchObject({
+      turnId: turn.turnId,
+      payload: { state: "completed", usage: { tokens: { input: 20, output: 6, cacheRead: 4 } } },
+    });
+    expect(events.filter((event) => event.type === "runtime.error")).toHaveLength(0);
+    expect(
+      events.filter((event) => event.type === "turn.started").map((event) => event.turnId),
+    ).toEqual([turn.turnId, turn.turnId]);
+    expect(
+      events
+        .filter((event) => event.type === "item.completed")
+        .map((event) => event.payload.status),
+    ).toEqual(["completed", "completed"]);
+    expect(
+      events.filter(
+        (event) => event.type === "thread.token-usage.updated" && event.turnId === turn.turnId,
+      ),
+    ).toHaveLength(1);
+    await expectNextTurn(adapter, events, turn.turnId);
+  });
+});
+
+it("reports exhausted SDK retries once, without a late unscoped failure warning", async () => {
+  responses("error", "error");
+  await withAdapter(async (adapter, events) => {
+    const turn = await send(adapter);
+    await waitFor(() => expect(completions(events)).toHaveLength(1));
+    expect(completions(events)[0]).toMatchObject({
+      turnId: turn.turnId,
+      payload: { state: "failed", stopReason: "error" },
+    });
+    expect(events.filter((event) => event.type === "runtime.error")).toHaveLength(1);
+    const warnings = events.filter((event) => event.type === "runtime.warning");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.turnId).toBe(turn.turnId);
+    await expectNextTurn(adapter, events, turn.turnId);
+  }, 1);
+});
+
+it.each(["adapter", "extension"] as const)(
+  "settles cancellation in retry backoff through %s abort without another agent_end",
+  async (source) => {
+    responses("error");
+    await withAdapter(async (adapter, events) => {
+      const turn = await send(adapter);
+      const session = captured.sessions[0]!;
+      await waitFor(() => expect(session.isRetrying).toBe(true));
+      if (source === "adapter")
+        await Effect.runPromise(adapter.interruptTurn(threadId, turn.turnId));
+      else session.extensionRunner.createCommandContext().abort();
+      await waitFor(() => expect(completions(events)).toHaveLength(1));
+      expect(captured.events.filter((event) => event.type === "agent_end")).toHaveLength(1);
+      expect(
+        captured.events.some(
+          (event) => event.type === "auto_retry_end" && event.finalError === "Retry cancelled",
+        ),
+      ).toBe(true);
+      expect(completions(events)[0]).toMatchObject({
+        turnId: turn.turnId,
+        payload: { state: "interrupted", stopReason: "aborted" },
+      });
+      expect(events.filter((event) => event.type === "runtime.error")).toHaveLength(0);
+      expect(session.isIdle).toBe(true);
+      await expectNextTurn(adapter, events, turn.turnId);
+    }, 60_000);
+  },
+);
+
+it("cancels a live retry attempt and closes its streaming items", async () => {
+  const calls = responses("error", "until-abort");
+  await withAdapter(async (adapter, events) => {
+    const turn = await send(adapter);
+    await waitFor(() => expect(calls()).toBe(2));
+    await Effect.runPromise(adapter.interruptTurn(threadId, turn.turnId));
+    await waitFor(() => expect(completions(events)).toHaveLength(1));
+    expect(completions(events)[0]).toMatchObject({ payload: { state: "interrupted" } });
+    expect(events.filter((event) => event.type === "item.completed")).toHaveLength(2);
+    expect(events.filter((event) => event.type === "runtime.error")).toHaveLength(0);
+    await expectNextTurn(adapter, events, turn.turnId);
+  }, 1);
+});
+
+it("waits for prompt rejection even when the SDK has finished its agent cycle", async () => {
+  responses("success");
+  await withAdapter(async (adapter, events) => {
+    const session = captured.sessions[0]!;
+    const emit = session.extensionRunner.emit.bind(session.extensionRunner);
+    const spy = vi.spyOn(session.extensionRunner, "emit").mockImplementation(async (event) => {
+      if (event.type === "agent_settled") throw new Error("settled extension failed");
+      return emit(event);
+    });
+    const turn = await send(adapter);
+    await waitFor(() => expect(completions(events)).toHaveLength(1));
+    expect(completions(events)[0]).toMatchObject({
+      payload: { state: "failed", errorMessage: "settled extension failed" },
+    });
+    expect(events.filter((event) => event.type === "runtime.error")).toHaveLength(1);
+    spy.mockRestore();
+    await expectNextTurn(adapter, events, turn.turnId);
+  });
+});
+
+it("keeps steering during backoff inside the same logical turn", async () => {
+  responses("error", "success", "success");
+  await withAdapter(async (adapter, events) => {
+    const turn = await send(adapter);
+    const session = captured.sessions[0]!;
+    await waitFor(() => expect(session.isRetrying).toBe(true));
+    const steered = await Effect.runPromise(
+      adapter.steerTurn!({ threadId, input: "Also check this" }),
+    );
+    expect(steered.turnId).toBe(turn.turnId);
+    await waitFor(() => expect(completions(events)).toHaveLength(1));
+    expect(completions(events)[0]).toMatchObject({
+      turnId: turn.turnId,
+      payload: { state: "completed" },
+    });
+    expect(
+      session.messages.some(
+        (message) =>
+          message.role === "user" && JSON.stringify(message.content).includes("Also check this"),
+      ),
+    ).toBe(true);
+  });
+});
+
+it("keeps the turn alive through SDK overflow compaction and its continuation", async () => {
+  const calls = responses("success", "overflow", "success", "success");
+  await withAdapter(async (adapter, events) => {
+    await send(adapter);
+    await waitFor(() => expect(completions(events)).toHaveLength(1));
+    const session = captured.sessions[0]!;
+    session.setAutoCompactionEnabled(true);
+    const turn = await send(adapter);
+    await waitFor(() => expect(completions(events)).toHaveLength(2));
+    expect(
+      captured.events.some((event) => event.type === "compaction_end" && event.willRetry),
+    ).toBe(true);
+    expect(calls()).toBe(4);
+    expect(completions(events)[1]).toMatchObject({
+      turnId: turn.turnId,
+      payload: { state: "completed" },
+    });
+    expect(events.filter((event) => event.type === "runtime.error")).toHaveLength(0);
+  });
+});
+
+it("does not let an old prompt rejection settle a replacement session's turn", async () => {
+  responses("until-abort");
+  await withAdapter(async (adapter, events, cwd) => {
+    const oldSession = captured.sessions[0]!;
+    let rejectOld!: (cause: Error) => void;
+    vi.spyOn(oldSession, "prompt").mockImplementation(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectOld = reject;
+        }),
+    );
+    const oldTurn = await send(adapter);
+    await Effect.runPromise(adapter.stopSession(threadId));
+    await Effect.runPromise(
+      adapter.startSession({
+        threadId,
+        cwd,
+        runtimeMode: "full-access",
+        providerOptions: { pi: { agentDir: cwd } },
+        modelSelection: { provider: "pi", model: "openai/gpt-4o" },
+      }),
+    );
+    const next = await send(adapter);
+    await waitFor(() =>
+      expect(
+        events.some((event) => event.type === "content.delta" && event.turnId === next.turnId),
+      ).toBe(true),
+    );
+    rejectOld(new Error("late old prompt failure"));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(completions(events)).toHaveLength(0);
+    expect((await Effect.runPromise(adapter.listSessions()))[0]?.activeTurnId).toBe(next.turnId);
+    await Effect.runPromise(adapter.interruptTurn(threadId, next.turnId));
+    await waitFor(() => expect(completions(events)).toHaveLength(1));
+    expect(completions(events)[0]?.turnId).toBe(next.turnId);
+    expect(events.filter((event) => event.type === "runtime.error")).toHaveLength(0);
+    expect(oldTurn.turnId).not.toBe(next.turnId);
+  });
+});
+
+it("disposes during SDK backoff without a resumed request or late turn completion", async () => {
+  const calls = responses("error", "until-abort");
+  await withAdapter(async (adapter, events) => {
+    await send(adapter);
+    const session = captured.sessions[0]!;
+    await waitFor(() => expect(session.isRetrying).toBe(true));
+    await Effect.runPromise(adapter.stopSession(threadId));
+    await waitFor(() => expect(events.some((event) => event.type === "session.exited")).toBe(true));
+    expect(session.isIdle).toBe(true);
+    expect(calls()).toBe(1);
+    expect(completions(events)).toHaveLength(0);
+    expect(await Effect.runPromise(adapter.hasSession(threadId))).toBe(false);
+  }, 60_000);
+});
+
+it.each(["adapter", "extension"] as const)(
+  "does not start queued steering after %s abort during backoff",
+  async (source) => {
+    const calls = responses("error", "until-abort");
+    await withAdapter(async (adapter, events) => {
+      const turn = await send(adapter);
+      const session = captured.sessions[0]!;
+      await waitFor(() => expect(session.isRetrying).toBe(true));
+      await Effect.runPromise(adapter.steerTurn!({ threadId, input: "Queued steering" }));
+      let resumed!: (result: string) => void;
+      const resumedRun = new Promise<string>((resolve) => {
+        resumed = resolve;
+      });
+      const unsubscribe = session.subscribe((event) => {
+        if (event.type === "agent_start") resumed("continued");
+      });
+      const interrupt =
+        source === "adapter"
+          ? Effect.runPromise(adapter.interruptTurn(threadId, turn.turnId))
+          : (session.extensionRunner.createCommandContext().abort(), session.waitForIdle());
+      const outcome = await Promise.race([interrupt.then(() => "stopped"), resumedRun]);
+      unsubscribe();
+      if (outcome === "continued") {
+        await waitFor(() => expect(calls()).toBe(2));
+        await session.abort();
+      }
+      await interrupt;
+      expect(outcome).toBe("stopped");
+      expect(calls()).toBe(1);
+      await waitFor(() => expect(completions(events)).toHaveLength(1));
+    }, 60_000);
+  },
+);
+
+it("keeps partial assistant and reasoning items open across retries until final settlement", async () => {
+  responses("partial-error", "success");
+  await withAdapter(async (adapter, events) => {
+    const turn = await send(adapter);
+    await waitFor(() => expect(captured.sessions[0]!.isRetrying).toBe(true));
+    expect(events.filter((event) => event.type === "item.completed")).toHaveLength(0);
+    await waitFor(() => expect(completions(events)).toHaveLength(1));
+    for (const itemType of ["assistant_message", "reasoning"] as const) {
+      const started = events.filter(
+        (event) => event.type === "item.started" && event.payload.itemType === itemType,
+      );
+      const completed = events.filter(
+        (event) => event.type === "item.completed" && event.payload.itemType === itemType,
+      );
+      expect(started).toHaveLength(1);
+      expect(completed).toHaveLength(1);
+      expect(completed[0]).toMatchObject({
+        itemId: started[0]!.itemId,
+        turnId: turn.turnId,
+        payload: { status: "completed" },
+      });
+      expect(
+        events.filter(
+          (event) => event.type === "content.delta" && event.itemId === started[0]!.itemId,
+        ),
+      ).toHaveLength(2);
+    }
+  });
+});
+
+function gatewayCredentials() {
+  let sequence = 0;
+  return {
+    mcpEndpointUrl: "http://127.0.0.1:3773/mcp",
+    setListeningPort: () => undefined,
+    issueSessionToken: () => `unused-${++sequence}`,
+    verifySessionToken: () => null,
+    verifySession: () => null,
+    issueStdioBootstrapToken: () => null,
+    exchangeStdioBootstrapToken: () => null,
+    bindWriteAuthority: () => null,
+    verifyWriteAuthority: () => false,
+    registerInFlightRequest: () => () => undefined,
+    cancelInFlightRequests: () => ({ count: 0, settled: Promise.resolve() }),
+    cancelSessionTurnRequests: vi.fn(async (_token: string, _turnId: string) => undefined),
+    retireSessionTurn: vi.fn(async (_token: string, _turnId: string) => undefined),
+    revokeSessionToken: vi.fn((_token: string) => undefined),
+    connectionForThread: vi.fn(() => ({
+      url: "http://127.0.0.1:3773/mcp",
+      bearerToken: `lease-${++sequence}`,
+    })),
+    stdioProxy: { command: process.execPath, args: [] },
+  } satisfies AgentGatewayCredentialsShape;
+}
+
+it.each(["success", "failure", "cancel", "rejection"] as const)(
+  "retires or revokes the gateway turn authority once on %s",
+  async (outcome) => {
+    const credentials = gatewayCredentials();
+    responses(...((outcome === "success" ? ["success"] : ["error", "error"]) as ResponseKind[]));
+    await withAdapter(
+      async (adapter, events) => {
+        if (outcome === "rejection")
+          vi.spyOn(captured.sessions[0]!, "prompt").mockRejectedValueOnce(
+            new Error("prompt rejected"),
+          );
+        const turn = await send(adapter);
+        if (outcome === "cancel") {
+          await waitFor(() => expect(captured.sessions[0]!.isRetrying).toBe(true));
+          await Effect.runPromise(adapter.interruptTurn(threadId, turn.turnId));
+        }
+        await waitFor(() => expect(completions(events)).toHaveLength(1));
+        if (outcome === "cancel") {
+          expect(credentials.cancelSessionTurnRequests).toHaveBeenCalledExactlyOnceWith(
+            "lease-1",
+            turn.turnId,
+          );
+          // Interrupt already revoked this lease; terminal retirement is idempotent.
+          expect(credentials.retireSessionTurn).not.toHaveBeenCalled();
+        } else {
+          expect(credentials.retireSessionTurn).toHaveBeenCalledExactlyOnceWith(
+            "lease-1",
+            turn.turnId,
+          );
+        }
+        expect(credentials.revokeSessionToken).toHaveBeenCalledExactlyOnceWith("lease-1");
+        expect(credentials.connectionForThread).toHaveBeenCalledTimes(2);
+        await expectNextTurn(adapter, events, turn.turnId);
+        expect(credentials.retireSessionTurn).toHaveBeenLastCalledWith(
+          "lease-2",
+          completions(events)[1]!.turnId,
+        );
+        expect(
+          credentials.revokeSessionToken.mock.calls.filter(([token]) => token === "lease-1"),
+        ).toHaveLength(1);
+      },
+      outcome === "cancel" ? 60_000 : 1,
+      credentials,
+    );
+  },
+);
+
+it("does not reuse a previous provider error for a handled extension command", async () => {
+  captured.extensions.push((pi) => {
+    pi.registerCommand("noop", { description: "No inference", handler: async () => {} });
+  });
+  const calls = responses("error", "error");
+  await withAdapter(async (adapter, events) => {
+    await send(adapter);
+    await waitFor(() => expect(completions(events)).toHaveLength(1));
+    expect(completions(events)[0]).toMatchObject({ payload: { state: "failed" } });
+    const command = await Effect.runPromise(adapter.sendTurn({ threadId, input: "/noop" }));
+    await waitFor(() => expect(completions(events)).toHaveLength(2));
+    expect(completions(events)[1]).toMatchObject({
+      turnId: command.turnId,
+      payload: { state: "completed" },
+    });
+    expect(calls()).toBe(2);
+  }, 1);
+});
+
+it("cancels retry and queued steering before awaiting gateway teardown drainage", async () => {
+  const credentials = gatewayCredentials();
+  let drain!: () => void;
+  credentials.cancelSessionTurnRequests.mockImplementation(
+    () =>
+      new Promise<void>((resolve) => {
+        drain = resolve;
+      }),
+  );
+  const calls = responses("error", "until-abort");
+  await withAdapter(
+    async (adapter, events) => {
+      const turn = await send(adapter);
+      const session = captured.sessions[0]!;
+      await waitFor(() => expect(session.isRetrying).toBe(true));
+      await Effect.runPromise(
+        adapter.steerTurn!({ threadId, input: "Do not restart this queued work" }),
+      );
+      const stopped = Effect.runPromise(adapter.stopSession(threadId));
+      try {
+        await waitFor(() => expect(credentials.cancelSessionTurnRequests).toHaveBeenCalled());
+        await waitFor(() => expect(session.isIdle).toBe(true));
+        expect(calls()).toBe(1);
+        expect(session.pendingMessageCount).toBe(0);
+      } finally {
+        drain();
+        await stopped;
+      }
+      await waitFor(() =>
+        expect(events.some((event) => event.type === "session.exited")).toBe(true),
+      );
+      expect(completions(events)).toHaveLength(1);
+      expect(completions(events)[0]).toMatchObject({
+        turnId: turn.turnId,
+        payload: { state: "interrupted" },
+      });
+    },
+    100,
+    credentials,
+  );
+});

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -1450,6 +1450,31 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       } satisfies ProviderRuntimeEvent);
     };
 
+    const offerPiRetryWarning = (
+      context: PiSessionContext,
+      input: {
+        readonly message: string;
+        readonly method: string;
+        readonly messageType?: string;
+        readonly detail?: unknown;
+      },
+    ) => {
+      offerRuntimeEvent({
+        ...makeEventBase(context),
+        type: "runtime.warning",
+        payload: {
+          message: input.message,
+          detail: input.detail ?? { method: input.method },
+        },
+        raw: {
+          source: "pi.sdk.event",
+          method: input.method,
+          ...(input.messageType ? { messageType: input.messageType } : {}),
+          payload: input.detail ?? { message: input.message },
+        },
+      } satisfies ProviderRuntimeEvent);
+    };
+
     const resolvePiExtensionUserInput = (
       context: PiSessionContext,
       requestId: ApprovalRequestId,
@@ -1763,6 +1788,17 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
 
     const disposeSessionContext = async (context: PiSessionContext) => {
       try {
+        // Tear down while the SDK sleeps between retry attempts: wake it first
+        // so runtime.dispose() below cannot hang behind the backoff timer.
+        try {
+          (
+            context.runtime.session as unknown as {
+              readonly abortRetry?: () => void;
+            }
+          ).abortRetry?.();
+        } catch {
+          // Best-effort: never block teardown on a throwing abortRetry.
+        }
         await Effect.runPromise(
           cancelAgentGatewayTurn(context.gatewaySessionLease, context.activeTurnId),
         );
@@ -2026,16 +2062,36 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           return;
         }
         case "agent_end": {
+          // Pi auto-retry emits an intermediate agent_end with willRetry=true
+          // before auto_retry_start, then starts a brand-new agent cycle for
+          // the retry attempt. That intermediate event is NOT terminal: the
+          // SDK keeps the prompt alive through backoff and will emit a final
+          // agent_end with willRetry=false. Treating it as terminal fails the
+          // turn, surfaces a top-level error toast, pauses autonomous goals,
+          // and clears activeTurnId so the retry's turn_start arrives without
+          // identity — freezing streaming and making End task unresponsive.
+          const willRetry =
+            (event as unknown as { readonly willRetry?: boolean }).willRetry === true;
+          if (willRetry) {
+            return;
+          }
+          const turnId = context.activeTurnId;
+          // Guard against a stray agent_end after the turn already settled
+          // (e.g. prompt rejection completed the turn first). Emitting a
+          // second terminal turn.completed would re-fail the session and
+          // duplicate the thread error.
+          if (!turnId) {
+            return;
+          }
           const stats = context.runtime.session.getSessionStats();
           const usage = normalizeTokenUsage(stats, context.runtime.session.model?.contextWindow);
           context.lastKnownTokenUsage = usage;
-          const turnId = context.activeTurnId;
           const errorMessage = context.runtime.session.agent.state.errorMessage;
           const failure = errorMessage ? classifyPiTurnFailure(errorMessage) : undefined;
           const leafId = context.runtime.session.sessionManager.getLeafId();
-          const turn = turnId
-            ? context.turns.find((candidate) => candidate.id === turnId)
-            : undefined;
+          // turnId is guaranteed defined: the stray-event guard above returns
+          // early when there is no active turn.
+          const turn = context.turns.find((candidate) => candidate.id === turnId);
           if (turn) turn.leafId = leafId;
           if (context.activeAssistantItemId) {
             offerRuntimeEvent({
@@ -2080,7 +2136,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             });
           }
           const completionBase = makeEventBase(context);
-          if (turnId && context.gatewaySessionLease && context.gatewayConnection) {
+          if (context.gatewaySessionLease && context.gatewayConnection) {
             const outgoingLease = context.gatewaySessionLease;
             const drainage = outgoingLease.retireTurn(turnId);
             outgoingLease.release();
@@ -2122,6 +2178,103 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
                 : { state: "completed", stopReason: null, usage: stats },
             raw: { source: "pi.sdk.event", messageType: event.type, payload: event },
           } satisfies ProviderRuntimeEvent);
+          return;
+        }
+        case "auto_retry_start": {
+          // Pi SDK backoff between attempts. Surface inline (like OpenCode's
+          // "retrying" notices) and keep the turn alive — never fail the turn
+          // or clear activeTurnId here. The final outcome arrives via a later
+          // agent_end with willRetry=false.
+          const retry = event as unknown as {
+            readonly attempt?: unknown;
+            readonly maxAttempts?: unknown;
+            readonly delayMs?: unknown;
+            readonly errorMessage?: unknown;
+          };
+          // Defensive: older/drifted SDK payloads must never render
+          // "attempt undefined/undefined" or "undefined" error text inline.
+          const attempt =
+            typeof retry.attempt === "number" && Number.isFinite(retry.attempt)
+              ? retry.attempt
+              : undefined;
+          const maxAttempts =
+            typeof retry.maxAttempts === "number" && Number.isFinite(retry.maxAttempts)
+              ? retry.maxAttempts
+              : undefined;
+          const delayMs =
+            typeof retry.delayMs === "number" &&
+            Number.isFinite(retry.delayMs) &&
+            retry.delayMs >= 0
+              ? retry.delayMs
+              : undefined;
+          const retryError =
+            typeof retry.errorMessage === "string" && retry.errorMessage.trim().length > 0
+              ? retry.errorMessage
+              : "provider error";
+          const attemptLabel =
+            attempt !== undefined && maxAttempts !== undefined
+              ? `attempt ${attempt}/${maxAttempts}`
+              : attempt !== undefined
+                ? `attempt ${attempt}`
+                : "retrying";
+          const delaySecs = delayMs !== undefined ? delayMs / 1000 : undefined;
+          const delayLabel =
+            delaySecs !== undefined && delaySecs > 0
+              ? `retrying in ${delaySecs.toFixed(delaySecs < 10 ? 1 : 0)}s`
+              : "retrying";
+          offerPiRetryWarning(context, {
+            message: `Pi retrying after provider error (${attemptLabel}, ${delayLabel}): ${retryError}`,
+            method: "prompt/retry",
+            messageType: event.type,
+            detail: {
+              ...(attempt !== undefined ? { attempt } : {}),
+              ...(maxAttempts !== undefined ? { maxAttempts } : {}),
+              ...(delayMs !== undefined ? { delayMs } : {}),
+              errorMessage: retryError,
+            },
+          });
+          return;
+        }
+        case "auto_retry_end": {
+          const retryEnd = event as unknown as {
+            readonly success?: unknown;
+            readonly attempt?: unknown;
+            readonly finalError?: unknown;
+          };
+          const attempt =
+            typeof retryEnd.attempt === "number" && Number.isFinite(retryEnd.attempt)
+              ? retryEnd.attempt
+              : undefined;
+          const finalError =
+            typeof retryEnd.finalError === "string" && retryEnd.finalError.trim().length > 0
+              ? retryEnd.finalError
+              : undefined;
+          // Success just resumes streaming; the final agent_end completes the
+          // turn normally. Only note a terminal retry exhaustion inline — the
+          // following agent_end (willRetry=false) still owns the failure.
+          // Require an explicit false so a missing success flag can never
+          // fabricate a failure row. Skip user-cancelled backoff noise: the
+          // interrupted turn completion already communicates the cancel.
+          const endWasCancelled =
+            (finalError ?? "").toLowerCase().includes("cancel") ||
+            (finalError ?? "").toLowerCase().includes("abort");
+          if (retryEnd.success === false && !endWasCancelled) {
+            offerPiRetryWarning(context, {
+              message: `Pi retry${attempt !== undefined ? ` ${attempt}` : ""} failed${finalError ? `: ${finalError}.` : "."}`,
+              method: "prompt/retry",
+              messageType: event.type,
+              detail: {
+                ...(attempt !== undefined ? { attempt } : {}),
+                success: false,
+                ...(finalError ? { finalError } : {}),
+              },
+            });
+          }
+          return;
+        }
+        case "agent_settled": {
+          // Final settlement after all retries; turn.completed from the final
+          // agent_end already settled lifecycle. Nothing to project.
           return;
         }
         default:
@@ -2655,6 +2808,18 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           return;
         }
         const activeTurnId = turnId ?? context.activeTurnId;
+        // End task must stay responsive while the SDK sleeps between retry
+        // attempts: abort() alone does not cancel backoff, so cancel the
+        // retry wait first. abortRetry is sync; abort() settles the live run.
+        try {
+          (
+            context.runtime.session as unknown as {
+              readonly abortRetry?: () => void;
+            }
+          ).abortRetry?.();
+        } catch {
+          // Best-effort: a throwing abortRetry must not block the abort below.
+        }
         yield* withAgentGatewayTurnCancellation(
           context.gatewaySessionLease,
           activeTurnId,

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -361,6 +361,7 @@ interface PiSessionContext {
   session: ProviderSession;
   turns: PiStoredTurn[];
   activeTurnId: TurnId | undefined;
+  activeTurnErrorMessage?: string;
   activeAssistantItemId: RuntimeItemId | undefined;
   activeReasoningItemId: RuntimeItemId | undefined;
   activeToolItems: Map<string, PiTrackedToolCall>;
@@ -1739,19 +1740,92 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       return uiContext;
     };
 
-    const completePromptRejection = (context: PiSessionContext, turnId: TurnId, cause: unknown) => {
-      if (context.activeTurnId !== turnId) {
-        return;
+    const completePrompt = (
+      context: PiSessionContext,
+      turnId: TurnId,
+      errorMessage: string | undefined,
+      cause?: unknown,
+    ) => {
+      if (context.stopped || context.activeTurnId !== turnId) return;
+      const raw = {
+        source: "pi.sdk.event" as const,
+        method: "prompt",
+        payload: cause ?? {},
+      };
+      const stats = context.runtime.session.getSessionStats();
+      const usage = normalizeTokenUsage(stats, context.runtime.session.model?.contextWindow);
+      context.lastKnownTokenUsage = usage;
+      const failure = errorMessage ? classifyPiTurnFailure(errorMessage) : undefined;
+      const leafId = context.runtime.session.sessionManager.getLeafId();
+      const turn = context.turns.find((candidate) => candidate.id === turnId);
+      if (turn) turn.leafId = leafId;
+      if (context.activeAssistantItemId) {
+        offerRuntimeEvent({
+          ...makeEventBase(context),
+          itemId: context.activeAssistantItemId,
+          type: "item.completed",
+          payload: {
+            itemType: "assistant_message",
+            status: errorMessage ? "failed" : "completed",
+            title: "Assistant",
+          },
+          raw,
+        } satisfies ProviderRuntimeEvent);
       }
-
-      const message = toMessage(cause, "Pi turn failed.");
-      const failure = classifyPiTurnFailure(message);
+      if (context.activeReasoningItemId) {
+        offerRuntimeEvent({
+          ...makeEventBase(context),
+          itemId: context.activeReasoningItemId,
+          type: "item.completed",
+          payload: {
+            itemType: "reasoning",
+            status: errorMessage ? "failed" : "completed",
+            title: "Reasoning",
+          },
+          raw,
+        } satisfies ProviderRuntimeEvent);
+      }
+      if (usage) {
+        offerRuntimeEvent({
+          ...makeEventBase(context),
+          type: "thread.token-usage.updated",
+          payload: { usage },
+          raw,
+        } satisfies ProviderRuntimeEvent);
+      }
+      if (errorMessage && failure?.state === "failed") {
+        offerRuntimeError(context, {
+          message: errorMessage,
+          method: "prompt",
+          cause,
+        });
+      }
       const completionBase = makeEventBase(context);
-      if (failure.state === "failed") {
-        offerRuntimeError(context, { message, method: "prompt", cause });
+      if (context.gatewaySessionLease && context.gatewayConnection) {
+        const outgoingLease = context.gatewaySessionLease;
+        const drainage = outgoingLease.retireTurn(turnId);
+        outgoingLease.release();
+        const replacementLease = acquireAgentGatewaySessionLease(
+          agentGatewayCredentials,
+          context.session.threadId,
+          PROVIDER,
+        );
+        if (replacementLease) {
+          context.gatewaySessionLease = replacementLease;
+          Object.assign(context.gatewayConnection, replacementLease.connection);
+        } else {
+          delete context.gatewaySessionLease;
+        }
+        Effect.runFork(
+          Effect.promise(() => drainage).pipe(
+            Effect.catchCause((cause) =>
+              Effect.logWarning("pi.agent_gateway.turn_retirement_failed", { turnId, cause }),
+            ),
+          ),
+        );
       }
-      Effect.runFork(cancelAgentGatewayTurn(context.gatewaySessionLease, turnId));
       context.activeTurnId = undefined;
+      delete context.activeTurnErrorMessage;
       context.activeAssistantItemId = undefined;
       context.activeReasoningItemId = undefined;
       context.activeToolItems.clear();
@@ -1759,13 +1833,32 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       offerRuntimeEvent({
         ...completionBase,
         type: "turn.completed",
-        payload: {
-          state: failure.state,
-          stopReason: failure.stopReason,
-          errorMessage: message,
-        },
-        raw: { source: "pi.sdk.event", method: "prompt", payload: cause },
+        payload:
+          errorMessage && failure
+            ? {
+                state: failure.state,
+                stopReason: failure.stopReason,
+                errorMessage,
+                usage: stats,
+              }
+            : { state: "completed", stopReason: null, usage: stats },
+        raw,
       } satisfies ProviderRuntimeEvent);
+    };
+
+    const startPrompt = (
+      context: PiSessionContext,
+      turnId: TurnId,
+      text: string,
+      images: ImageContent[],
+    ) => {
+      delete context.activeTurnErrorMessage;
+      // A prompt owns all SDK retries, compaction and queued continuations.
+      // agent_end is per attempt; agent_settled also fires before a rejection.
+      void context.runtime.session.prompt(text, images.length > 0 ? { images } : undefined).then(
+        () => completePrompt(context, turnId, context.activeTurnErrorMessage),
+        (cause) => completePrompt(context, turnId, toMessage(cause, "Pi turn failed."), cause),
+      );
     };
 
     const recordItem = (context: PiSessionContext, item: unknown) => {
@@ -1786,19 +1879,17 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       return context;
     });
 
+    const abortSessionTurn = (context: PiSessionContext) => {
+      // Otherwise the SDK can start a queued continuation after aborting backoff.
+      context.runtime.session.clearQueue();
+      return context.runtime.session.abort();
+    };
+
     const disposeSessionContext = async (context: PiSessionContext) => {
       try {
-        // Tear down while the SDK sleeps between retry attempts: wake it first
-        // so runtime.dispose() below cannot hang behind the backoff timer.
-        try {
-          (
-            context.runtime.session as unknown as {
-              readonly abortRetry?: () => void;
-            }
-          ).abortRetry?.();
-        } catch {
-          // Best-effort: never block teardown on a throwing abortRetry.
-        }
+        // Stop retry and queued continuation before waiting for gateway drainage.
+        context.runtime.session.clearQueue();
+        context.runtime.session.abortRetry();
         await Effect.runPromise(
           cancelAgentGatewayTurn(context.gatewaySessionLease, context.activeTurnId),
         );
@@ -2062,219 +2153,29 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           return;
         }
         case "agent_end": {
-          // Pi auto-retry emits an intermediate agent_end with willRetry=true
-          // before auto_retry_start, then starts a brand-new agent cycle for
-          // the retry attempt. That intermediate event is NOT terminal: the
-          // SDK keeps the prompt alive through backoff and will emit a final
-          // agent_end with willRetry=false. Treating it as terminal fails the
-          // turn, surfaces a top-level error toast, pauses autonomous goals,
-          // and clears activeTurnId so the retry's turn_start arrives without
-          // identity — freezing streaming and making End task unresponsive.
-          const willRetry =
-            (event as unknown as { readonly willRetry?: boolean }).willRetry === true;
-          if (willRetry) {
-            return;
-          }
-          const turnId = context.activeTurnId;
-          // Guard against a stray agent_end after the turn already settled
-          // (e.g. prompt rejection completed the turn first). Emitting a
-          // second terminal turn.completed would re-fail the session and
-          // duplicate the thread error.
-          if (!turnId) {
-            return;
-          }
-          const stats = context.runtime.session.getSessionStats();
-          const usage = normalizeTokenUsage(stats, context.runtime.session.model?.contextWindow);
-          context.lastKnownTokenUsage = usage;
+          // Capture this run's outcome without settling its retries/continuations.
+          // A handled extension command may resolve without running the agent.
           const errorMessage = context.runtime.session.agent.state.errorMessage;
-          const failure = errorMessage ? classifyPiTurnFailure(errorMessage) : undefined;
-          const leafId = context.runtime.session.sessionManager.getLeafId();
-          // turnId is guaranteed defined: the stray-event guard above returns
-          // early when there is no active turn.
-          const turn = context.turns.find((candidate) => candidate.id === turnId);
-          if (turn) turn.leafId = leafId;
-          if (context.activeAssistantItemId) {
-            offerRuntimeEvent({
-              ...makeEventBase(context),
-              itemId: context.activeAssistantItemId,
-              type: "item.completed",
-              payload: {
-                itemType: "assistant_message",
-                status: errorMessage ? "failed" : "completed",
-                title: "Assistant",
-              },
-              raw: { source: "pi.sdk.event", messageType: event.type, payload: event },
-            } satisfies ProviderRuntimeEvent);
-          }
-          if (context.activeReasoningItemId) {
-            offerRuntimeEvent({
-              ...makeEventBase(context),
-              itemId: context.activeReasoningItemId,
-              type: "item.completed",
-              payload: {
-                itemType: "reasoning",
-                status: errorMessage ? "failed" : "completed",
-                title: "Reasoning",
-              },
-              raw: { source: "pi.sdk.event", messageType: event.type, payload: event },
-            } satisfies ProviderRuntimeEvent);
-          }
-          if (usage) {
-            offerRuntimeEvent({
-              ...makeEventBase(context),
-              type: "thread.token-usage.updated",
-              payload: { usage },
-              raw: { source: "pi.sdk.event", messageType: event.type, payload: event },
-            } satisfies ProviderRuntimeEvent);
-          }
-          if (errorMessage && failure?.state === "failed") {
-            offerRuntimeError(context, {
-              message: errorMessage,
-              method: "prompt",
-              messageType: event.type,
-              cause: event,
-            });
-          }
-          const completionBase = makeEventBase(context);
-          if (context.gatewaySessionLease && context.gatewayConnection) {
-            const outgoingLease = context.gatewaySessionLease;
-            const drainage = outgoingLease.retireTurn(turnId);
-            outgoingLease.release();
-            const replacementLease = acquireAgentGatewaySessionLease(
-              agentGatewayCredentials,
-              context.session.threadId,
-              PROVIDER,
-            );
-            if (replacementLease) {
-              context.gatewaySessionLease = replacementLease;
-              Object.assign(context.gatewayConnection, replacementLease.connection);
-            } else {
-              delete context.gatewaySessionLease;
-            }
-            Effect.runFork(
-              Effect.promise(() => drainage).pipe(
-                Effect.catchCause((cause) =>
-                  Effect.logWarning("pi.agent_gateway.turn_retirement_failed", { turnId, cause }),
-                ),
-              ),
-            );
-          }
-          context.activeTurnId = undefined;
-          context.activeAssistantItemId = undefined;
-          context.activeReasoningItemId = undefined;
-          context.activeToolItems.clear();
-          context.session = makeSessionSnapshot(context);
-          offerRuntimeEvent({
-            ...completionBase,
-            type: "turn.completed",
-            payload:
-              errorMessage && failure
-                ? {
-                    state: failure.state,
-                    stopReason: failure.stopReason,
-                    errorMessage,
-                    usage: stats,
-                  }
-                : { state: "completed", stopReason: null, usage: stats },
-            raw: { source: "pi.sdk.event", messageType: event.type, payload: event },
-          } satisfies ProviderRuntimeEvent);
+          if (errorMessage) context.activeTurnErrorMessage = errorMessage;
+          else delete context.activeTurnErrorMessage;
           return;
         }
         case "auto_retry_start": {
-          // Pi SDK backoff between attempts. Surface inline (like OpenCode's
-          // "retrying" notices) and keep the turn alive — never fail the turn
-          // or clear activeTurnId here. The final outcome arrives via a later
-          // agent_end with willRetry=false.
-          const retry = event as unknown as {
-            readonly attempt?: unknown;
-            readonly maxAttempts?: unknown;
-            readonly delayMs?: unknown;
-            readonly errorMessage?: unknown;
-          };
-          // Defensive: older/drifted SDK payloads must never render
-          // "attempt undefined/undefined" or "undefined" error text inline.
-          const attempt =
-            typeof retry.attempt === "number" && Number.isFinite(retry.attempt)
-              ? retry.attempt
-              : undefined;
-          const maxAttempts =
-            typeof retry.maxAttempts === "number" && Number.isFinite(retry.maxAttempts)
-              ? retry.maxAttempts
-              : undefined;
-          const delayMs =
-            typeof retry.delayMs === "number" &&
-            Number.isFinite(retry.delayMs) &&
-            retry.delayMs >= 0
-              ? retry.delayMs
-              : undefined;
-          const retryError =
-            typeof retry.errorMessage === "string" && retry.errorMessage.trim().length > 0
-              ? retry.errorMessage
-              : "provider error";
-          const attemptLabel =
-            attempt !== undefined && maxAttempts !== undefined
-              ? `attempt ${attempt}/${maxAttempts}`
-              : attempt !== undefined
-                ? `attempt ${attempt}`
-                : "retrying";
-          const delaySecs = delayMs !== undefined ? delayMs / 1000 : undefined;
-          const delayLabel =
-            delaySecs !== undefined && delaySecs > 0
-              ? `retrying in ${delaySecs.toFixed(delaySecs < 10 ? 1 : 0)}s`
-              : "retrying";
+          const delaySecs = event.delayMs / 1000;
           offerPiRetryWarning(context, {
-            message: `Pi retrying after provider error (${attemptLabel}, ${delayLabel}): ${retryError}`,
+            message: `Pi retrying after provider error (attempt ${event.attempt}/${event.maxAttempts}, retrying in ${delaySecs.toFixed(delaySecs < 10 ? 1 : 0)}s): ${event.errorMessage}`,
             method: "prompt/retry",
             messageType: event.type,
-            detail: {
-              ...(attempt !== undefined ? { attempt } : {}),
-              ...(maxAttempts !== undefined ? { maxAttempts } : {}),
-              ...(delayMs !== undefined ? { delayMs } : {}),
-              errorMessage: retryError,
-            },
+            detail: event,
           });
           return;
         }
         case "auto_retry_end": {
-          const retryEnd = event as unknown as {
-            readonly success?: unknown;
-            readonly attempt?: unknown;
-            readonly finalError?: unknown;
-          };
-          const attempt =
-            typeof retryEnd.attempt === "number" && Number.isFinite(retryEnd.attempt)
-              ? retryEnd.attempt
-              : undefined;
-          const finalError =
-            typeof retryEnd.finalError === "string" && retryEnd.finalError.trim().length > 0
-              ? retryEnd.finalError
-              : undefined;
-          // Success just resumes streaming; the final agent_end completes the
-          // turn normally. Only note a terminal retry exhaustion inline — the
-          // following agent_end (willRetry=false) still owns the failure.
-          // Require an explicit false so a missing success flag can never
-          // fabricate a failure row. Skip user-cancelled backoff noise: the
-          // interrupted turn completion already communicates the cancel.
-          const endWasCancelled =
-            (finalError ?? "").toLowerCase().includes("cancel") ||
-            (finalError ?? "").toLowerCase().includes("abort");
-          if (retryEnd.success === false && !endWasCancelled) {
-            offerPiRetryWarning(context, {
-              message: `Pi retry${attempt !== undefined ? ` ${attempt}` : ""} failed${finalError ? `: ${finalError}.` : "."}`,
-              method: "prompt/retry",
-              messageType: event.type,
-              detail: {
-                ...(attempt !== undefined ? { attempt } : {}),
-                success: false,
-                ...(finalError ? { finalError } : {}),
-              },
-            });
+          // Cancelling backoff resolves prompt() without another agent_end,
+          // while agent.state.errorMessage still contains the provider error.
+          if (!event.success && event.finalError === "Retry cancelled") {
+            context.activeTurnErrorMessage = event.finalError;
           }
-          return;
-        }
-        case "agent_settled": {
-          // Final settlement after all retries; turn.completed from the final
-          // agent_end already settled lifecycle. Nothing to project.
           return;
         }
         default:
@@ -2509,7 +2410,18 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         sessions.set(input.threadId, context);
         yield* Effect.tryPromise({
           try: () =>
-            runtime.session.bindExtensions({ uiContext: makePiExtensionUIContext(context) }),
+            runtime.session.bindExtensions({
+              uiContext: makePiExtensionUIContext(context),
+              abortHandler: () => {
+                void abortSessionTurn(context).catch((cause) => {
+                  offerRuntimeError(context, {
+                    message: toMessage(cause, "Failed to interrupt Pi turn."),
+                    method: "turn/interrupt",
+                    cause,
+                  });
+                });
+              },
+            }),
           catch: (cause) =>
             new ProviderAdapterRequestError({
               provider: PROVIDER,
@@ -2742,11 +2654,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           scopedGatewayConnectionAvailable: context.gatewayControlAvailable,
         });
         const providerText = [harnessPolicy, payload.text].filter(Boolean).join("\n\n");
-        void context.runtime.session
-          .prompt(providerText, payload.images.length > 0 ? { images: payload.images } : undefined)
-          .catch((cause) => {
-            completePromptRejection(context, turnId, cause);
-          });
+        startPrompt(context, turnId, providerText, payload.images);
         return {
           threadId: input.threadId,
           turnId,
@@ -2780,14 +2688,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
               }),
           });
         } else {
-          void context.runtime.session
-            .prompt(
-              providerText,
-              payload.images.length > 0 ? { images: payload.images } : undefined,
-            )
-            .catch((cause) => {
-              completePromptRejection(context, turnId, cause);
-            });
+          startPrompt(context, turnId, providerText, payload.images);
         }
         return {
           threadId: input.threadId,
@@ -2808,23 +2709,11 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           return;
         }
         const activeTurnId = turnId ?? context.activeTurnId;
-        // End task must stay responsive while the SDK sleeps between retry
-        // attempts: abort() alone does not cancel backoff, so cancel the
-        // retry wait first. abortRetry is sync; abort() settles the live run.
-        try {
-          (
-            context.runtime.session as unknown as {
-              readonly abortRetry?: () => void;
-            }
-          ).abortRetry?.();
-        } catch {
-          // Best-effort: a throwing abortRetry must not block the abort below.
-        }
         yield* withAgentGatewayTurnCancellation(
           context.gatewaySessionLease,
           activeTurnId,
           Effect.tryPromise({
-            try: () => context.runtime.session.abort(),
+            try: () => abortSessionTurn(context),
             catch: (cause) =>
               new ProviderAdapterRequestError({
                 provider: PROVIDER,

--- a/apps/server/src/provider/piTurnFailure.test.ts
+++ b/apps/server/src/provider/piTurnFailure.test.ts
@@ -13,7 +13,7 @@ describe("classifyPiTurnFailure", () => {
   it("treats retry-backoff cancellation as an interrupted turn", () => {
     // End task during SDK backoff settles with "Retry cancelled" — a
     // user-initiated interrupt, not a failure (issue #1027).
-    for (const message of ["Retry cancelled", "retry canceled", "Cancelled", "canceled"]) {
+    for (const message of ["Retry cancelled", "retry canceled"]) {
       expect(classifyPiTurnFailure(message)).toEqual({
         state: "interrupted",
         stopReason: "aborted",

--- a/apps/server/src/provider/piTurnFailure.test.ts
+++ b/apps/server/src/provider/piTurnFailure.test.ts
@@ -10,6 +10,23 @@ describe("classifyPiTurnFailure", () => {
     });
   });
 
+  it("treats retry-backoff cancellation as an interrupted turn", () => {
+    // End task during SDK backoff settles with "Retry cancelled" — a
+    // user-initiated interrupt, not a failure (issue #1027).
+    for (const message of ["Retry cancelled", "retry canceled", "Cancelled", "canceled"]) {
+      expect(classifyPiTurnFailure(message)).toEqual({
+        state: "interrupted",
+        stopReason: "aborted",
+      });
+    }
+  });
+
+  it("keeps rate-limit errors failed (SDK retry owns them, not the classifier)", () => {
+    expect(
+      classifyPiTurnFailure("[rate_limit_exceeded] Rate limit exceeded. Please retry ..."),
+    ).toEqual({ state: "failed", stopReason: "error" });
+  });
+
   it("keeps real Pi failures failed", () => {
     expect(classifyPiTurnFailure("Model provider returned a 500")).toEqual({
       state: "failed",

--- a/apps/server/src/provider/piTurnFailure.ts
+++ b/apps/server/src/provider/piTurnFailure.ts
@@ -4,6 +4,14 @@ const PI_INTERRUPTION_MARKERS = [
   "aborterror",
   "interrupted by user",
   "user aborted",
+  // Cancelling the SDK backoff (abortRetry) settles the prompt with
+  // "Retry cancelled". That is a user-initiated interrupt, not a failure:
+  // without this, End task during a retry wait would surface as a red
+  // top-level error instead of cleanly interrupting the turn.
+  "retry cancelled",
+  "retry canceled",
+  "cancelled",
+  "canceled",
 ] as const;
 
 interface PiTurnFailureClassification {

--- a/apps/server/src/provider/piTurnFailure.ts
+++ b/apps/server/src/provider/piTurnFailure.ts
@@ -4,14 +4,9 @@ const PI_INTERRUPTION_MARKERS = [
   "aborterror",
   "interrupted by user",
   "user aborted",
-  // Cancelling the SDK backoff (abortRetry) settles the prompt with
-  // "Retry cancelled". That is a user-initiated interrupt, not a failure:
-  // without this, End task during a retry wait would surface as a red
-  // top-level error instead of cleanly interrupting the turn.
+  // The SDK reports this through auto_retry_end when backoff is aborted.
   "retry cancelled",
   "retry canceled",
-  "cancelled",
-  "canceled",
 ] as const;
 
 interface PiTurnFailureClassification {


### PR DESCRIPTION
Fixes #1027.

## Problem

When a provider returns a transient error (e.g. `[rate_limit_exceeded]`), the Pi SDK runs its built-in auto-retry: it emits an **intermediate** `agent_end` with `willRetry: true`, sleeps through backoff (`auto_retry_start` / `auto_retry_end`), then starts a fresh agent cycle for the next attempt. Synara's Pi adapter ignored that lifecycle completely:

- Every intermediate `agent_end` was treated as terminal: `runtime.error` + `turn.completed: failed` → red top-level error toast (with copy button), session `status: error`, and autonomous-goal auto-pause.
- `activeTurnId` was cleared, so the retry attempt's `turn_start` arrived without identity → thinking/streaming stall and pause↔thinking flapping, with the same rate-limit error surfacing on every attempt.
- `interruptTurn` only called `session.abort()`, which does **not** cancel the SDK backoff sleep (that needs `session.abortRetry()`) → **End task** appeared dead while a retry wait was pending.

OpenCode never had this problem because its retry surfaces as `runtime.warning` (inline transcript row) with the turn kept alive. This PR gives Pi the same treatment, mirroring the existing Codex convention (`CodexAdapter.ts` maps `payload.willRetry === true` to `runtime.warning`).

## What changed (3 files, +195/−5)

**`apps/server/src/provider/Layers/PiAdapter.ts`**
- `agent_end` with `willRetry: true` is now ignored (not terminal): no error toast, no failed turn, `activeTurnId` and streaming items stay open across backoff. The final outcome still arrives via `agent_end` with `willRetry: false`.
- Stray `agent_end` with no active turn is ignored (prevents a second terminal `turn.completed` when prompt-rejection already settled the turn).
- New `auto_retry_start` handler emits an inline `runtime.warning` (`Pi retrying after provider error (attempt x/y, retrying in zs): …`, turn-scoped like OpenCode's retrying notices) and keeps the turn alive.
- New `auto_retry_end` handler notes genuine retry exhaustion inline only (explicit `success === false`, user-cancel noise suppressed); the following final `agent_end` still owns the failure.
- New `agent_settled` case: no-op (lifecycle already settled by the final `agent_end`).
- `interruptTurn` now calls `session.abortRetry()` (best-effort) before `session.abort()`, so End task cancels a pending backoff immediately; `disposeSessionContext` does the same so teardown can't hang behind the retry timer.
- Retry-event payloads are extracted defensively (missing fields fall back instead of rendering `undefined`).

**`apps/server/src/provider/piTurnFailure.ts`**
- `Retry cancelled` / `retry canceled` / `cancelled` / `canceled` now classify as `interrupted` (not `failed`), so cancelling during backoff ends the turn cleanly instead of raising a red error.

**`apps/server/src/provider/piTurnFailure.test.ts`**
- New cases: backoff cancellation → `interrupted`; rate-limit text stays `failed` (transients are owned by the SDK retry, not the classifier).

Behavior after the fix matches the issue's expected behavior: inline retry state during backoff, thinking/streaming continue, no pause/resume flapping, End task always responsive, and a clear error state only if the provider truly cannot recover.

## Tests passed

```
bun run --cwd apps/server test src/provider/piTurnFailure.test.ts src/provider/Layers/PiAdapter.test.ts src/orchestration/providerRuntimeActivityProjection.test.ts
# Test Files  3 passed (3)
# Tests  40 passed (40)  — piTurnFailure 4, PiAdapter 19, projection 17
```

## Workspace checks

- `bun fmt` — changed files verified clean with `oxfmt --check` (repo-wide `fmt:check` fails on this Windows checkout for all 2986 files due to CRLF vs LF; the committed LF blobs are format-clean).
- `bun lint` — 0 errors (520 pre-existing warnings repo-wide, none in the new code).
- `bun typecheck` — 7/7 packages pass, including `@synara/cli` (apps/server).

No UI changes. Small, focused reliability fix; no new dependencies or product scope.
