### PR TITLE
fix(server): stop mirroring Codex SQLite state into the home overlay

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -8,6 +8,7 @@ import {
   readFileSync,
   readlinkSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
@@ -1195,18 +1196,39 @@ describe("buildCodexProcessEnv", () => {
     }
   });
 
-  it("repairs stale real files in Synara's Codex home overlay", async () => {
+  it("keeps Codex SQLite state out of Synara's Codex home overlay", async () => {
     const tempDir = mkdtempSync(path.join(os.tmpdir(), "synara-codex-env-"));
     const runtimeHome = mkdtempSync(path.join(os.tmpdir(), "synara-runtime-home-"));
+    const lstatOrUndefined = (target: string) => {
+      try {
+        return lstatSync(target);
+      } catch {
+        return undefined;
+      }
+    };
     try {
-      const sourceMemoryPath = path.join(tempDir, "memories_1.sqlite");
       writeFileSync(path.join(tempDir, "config.toml"), 'model = "gpt-5.5"', "utf8");
-      writeFileSync(sourceMemoryPath, "fresh-source-db", "utf8");
+      writeFileSync(path.join(tempDir, "history.jsonl"), "", "utf8");
+      const sourceSqliteEntries = [
+        "state_5.sqlite",
+        "state_5.sqlite-wal",
+        "state_5.sqlite-shm",
+        "memories_1.sqlite",
+      ];
+      for (const entry of sourceSqliteEntries) {
+        writeFileSync(path.join(tempDir, entry), "source-db", "utf8");
+      }
 
       const overlayHome = path.join(runtimeHome, "codex-home-overlay");
-      const overlayMemoryPath = path.join(overlayHome, "memories_1.sqlite");
       mkdirSync(overlayHome, { recursive: true });
-      writeFileSync(overlayMemoryPath, "stale-overlay-db", "utf8");
+      // Links left behind by releases that mirrored SQLite state per file,
+      // including a WAL sidecar whose source Codex has since checkpointed away.
+      const legacyLinks = ["state_5.sqlite", "thread_history_1.sqlite-wal"];
+      for (const entry of legacyLinks) {
+        symlinkSync(path.join(tempDir, entry), path.join(overlayHome, entry), "file");
+      }
+      const staleOverlayDbPath = path.join(overlayHome, "memories_1.sqlite");
+      writeFileSync(staleOverlayDbPath, "stale-overlay-db", "utf8");
 
       const env = await buildCodexProcessEnv({
         env: { SYNARA_HOME: runtimeHome },
@@ -1215,8 +1237,17 @@ describe("buildCodexProcessEnv", () => {
       });
 
       expect(env.CODEX_HOME).toBe(overlayHome);
-      expect(lstatSync(overlayMemoryPath).isSymbolicLink()).toBe(true);
-      expect(readlinkSync(overlayMemoryPath)).toBe(sourceMemoryPath);
+      expect(env.CODEX_SQLITE_HOME).toBe(tempDir);
+      for (const entry of [...sourceSqliteEntries, ...legacyLinks]) {
+        if (entry === "memories_1.sqlite") continue;
+        expect(lstatOrUndefined(path.join(overlayHome, entry))).toBeUndefined();
+      }
+      // A regular database file in the overlay is not Synara's to destroy.
+      expect(lstatSync(staleOverlayDbPath).isSymbolicLink()).toBe(false);
+      expect(readFileSync(staleOverlayDbPath, "utf8")).toBe("stale-overlay-db");
+      const overlayHistoryPath = path.join(overlayHome, "history.jsonl");
+      expect(lstatSync(overlayHistoryPath).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(overlayHistoryPath)).toBe(path.join(tempDir, "history.jsonl"));
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
       rmSync(runtimeHome, { recursive: true, force: true });

--- a/apps/server/src/codexProcessEnv.test.ts
+++ b/apps/server/src/codexProcessEnv.test.ts
@@ -112,6 +112,28 @@ describe("buildCodexProcessEnv", () => {
     }
   });
 
+  it("keeps a user-provided CODEX_SQLITE_HOME for the session overlay", async () => {
+    const codexHome = mkdtempSync(path.join(os.tmpdir(), "synara-codex-sqlite-home-"));
+    const runtimeHome = mkdtempSync(path.join(os.tmpdir(), "synara-runtime-home-"));
+    const sqliteHome = mkdtempSync(path.join(os.tmpdir(), "synara-user-sqlite-home-"));
+    writeFileSync(path.join(codexHome, "config.toml"), 'model = "gpt-5.5"', "utf8");
+
+    try {
+      const env = await buildCodexProcessEnv({
+        env: { SYNARA_HOME: runtimeHome, CODEX_SQLITE_HOME: sqliteHome },
+        homePath: codexHome,
+        platform: "win32",
+      });
+
+      expect(env.CODEX_HOME).toBe(path.join(runtimeHome, "codex-home-overlay"));
+      expect(env.CODEX_SQLITE_HOME).toBe(sqliteHome);
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true });
+      rmSync(runtimeHome, { recursive: true, force: true });
+      rmSync(sqliteHome, { recursive: true, force: true });
+    }
+  });
+
   it("replaces a user-defined Synara MCP table only inside the session overlay", async () => {
     const sourceHome = mkdtempSync(path.join(os.tmpdir(), "synara-codex-source-"));
     const runtimeHome = mkdtempSync(path.join(os.tmpdir(), "synara-codex-runtime-"));

--- a/apps/server/src/codexProcessEnv.ts
+++ b/apps/server/src/codexProcessEnv.ts
@@ -22,6 +22,14 @@ import {
 
 const CODEX_PROCESS_SHELL_ENV_NAMES = ["PATH", "SSH_AUTH_SOCK"] as const;
 const CODEX_OVERLAY_SHARED_STATE_FILES = new Set(["auth.json"]);
+// SQLite databases and their WAL/SHM/journal sidecars are never mirrored into
+// the overlay. SQLite derives sidecar paths from the path it opened the
+// database through, and on Windows deleting a sidecar through a symlink only
+// removes the link, so a per-file mirror lets Synara's app-server and an
+// external `codex` CLI end up with two WALs on one database. The overlay
+// instead points CODEX_SQLITE_HOME at the source home so every process opens
+// the same files through the same path.
+const CODEX_SQLITE_STATE_ENTRY_PATTERN = /^.+\.sqlite(?:-(?:wal|shm|journal))?$/;
 const SYNARA_CONFIG_SUPPRESSIONS_FILE = "synara-config-suppressions-v1.json";
 const SYNARA_MANAGED_MCP_TABLE_HEADER = "[mcp_servers.synara]";
 export const SYNARA_COMPETING_BROWSER_PLUGIN_SECTION_HEADERS = [
@@ -207,13 +215,9 @@ async function ensureCodexOverlaySymlink(input: {
       return;
     }
 
-    if (
-      targetStat.isSymbolicLink() ||
-      /^.+\.sqlite(?:-(?:wal|shm|journal))?$/.test(input.entryName) ||
-      CODEX_OVERLAY_SHARED_STATE_FILES.has(input.entryName)
-    ) {
-      // SQLite files must stay generation-matched, and auth must mirror the
-      // user's real Codex home so external `codex login` changes are visible.
+    if (targetStat.isSymbolicLink() || CODEX_OVERLAY_SHARED_STATE_FILES.has(input.entryName)) {
+      // Auth must mirror the user's real Codex home so external `codex login`
+      // changes are visible.
       await fs.rm(input.targetPath, { recursive: true, force: true });
     } else {
       return;
@@ -221,6 +225,27 @@ async function ensureCodexOverlaySymlink(input: {
   }
 
   await linkOrCopyCodexOverlayEntry(input);
+}
+
+function isCodexSqliteStateEntry(entryName: string): boolean {
+  return CODEX_SQLITE_STATE_ENTRY_PATTERN.test(entryName);
+}
+
+/**
+ * Removes SQLite links that earlier Synara releases mirrored into the overlay.
+ * Only symlinks are removed: a regular database file in the overlay is left
+ * untouched because Synara no longer owns or reads it.
+ */
+async function removeLegacyCodexOverlaySqliteLinks(overlayHomePath: string): Promise<void> {
+  for (const entry of await fs.readdir(overlayHomePath)) {
+    if (!isCodexSqliteStateEntry(entry)) {
+      continue;
+    }
+    const targetPath = path.join(overlayHomePath, entry);
+    if ((await fs.lstat(targetPath)).isSymbolicLink()) {
+      await fs.rm(targetPath, { force: true });
+    }
+  }
 }
 
 export function appendCodexConfigSection(config: string, section: string): string {
@@ -620,8 +645,9 @@ async function prepareSynaraCodexHomeOverlayUnlocked(input: {
   try {
     // Auth must get a best-effort link/copy before optional entries whose
     // symlinks may fail on restricted Windows installs.
+    await removeLegacyCodexOverlaySqliteLinks(overlayHomePath);
     for (const entry of prioritizeCodexOverlayEntries(await fs.readdir(sourceHomePath))) {
-      if (entry === "config.toml") {
+      if (entry === "config.toml" || isCodexSqliteStateEntry(entry)) {
         continue;
       }
       const sourcePath = path.join(sourceHomePath, entry);
@@ -714,6 +740,12 @@ export async function buildCodexProcessEnv(
     overlayHomePath || input.homePath
       ? { ...baseEnv, CODEX_HOME: overlayHomePath ?? input.homePath }
       : baseEnv;
+  if (overlayHomePath && !configuredEnv.CODEX_SQLITE_HOME?.trim()) {
+    // Keep every Codex process (Synara's app-server, the user's own `codex`
+    // CLI) on one SQLite home reached through one path; see
+    // CODEX_SQLITE_STATE_ENTRY_PATTERN. A user-provided value wins.
+    configuredEnv.CODEX_SQLITE_HOME = resolveBaseCodexHomePath(baseEnv, input.homePath);
+  }
   const platform = input.platform ?? process.platform;
   const effectiveEnv = buildProviderChildEnvironment({
     provider: "codex",


### PR DESCRIPTION
## What Changed

`apps/server/src/codexProcessEnv.ts`:

- Overlay preparation no longer symlinks `*.sqlite` databases or their `-wal` / `-shm` / `-journal` sidecars into `codex-home-overlay`. Links created by earlier releases are removed (regular files in the overlay are left untouched).
- `buildCodexProcessEnv` sets `CODEX_SQLITE_HOME` to the source Codex home whenever it hands Codex the overlay as `CODEX_HOME`. A `CODEX_SQLITE_HOME` already present in the environment is kept.

Tests: the "repairs stale real files" overlay test now asserts the new contract (no SQLite entries in the overlay, legacy links gone, `CODEX_SQLITE_HOME` = source home, other entries still linked); a new test covers a user-provided `CODEX_SQLITE_HOME`.

## Why

Synara starts the Codex app-server with `CODEX_HOME=<SYNARA_HOME>/codex-home-overlay`, where every entry of the user's real Codex home is symlinked one file at a time, including SQLite databases and their WAL/SHM sidecars.

SQLite derives sidecar paths from the path it opened the database through, and on Windows deleting a sidecar through a symlink removes the link, not the target. Whenever a WAL gets checkpointed and deleted (a normal close by either process), the overlay loses its `-wal` link. The next open from the app-server creates a private WAL inside the overlay while an external `codex` CLI keeps writing the real one. Two WALs on one database corrupt it:

```
thread/resume failed: failed to list thread history: thread-store internal error:
failed to open thread history database: failed to open thread history DB at
C:\Users\<me>\.synara\codex-home-overlay\thread_history_1.sqlite:
error returned from database: (code: 11) database disk image is malformed
```

The same corruption then breaks `codex resume` in the CLI, since both processes share the file. Reproduced on Synara 0.8.3 / Codex CLI 0.153.4 / Windows 11; the overlay held dangling `thread_history_1.sqlite-wal` / `-shm` links and `codex doctor` reported the thread history DB as malformed while all other DBs were fine.

This is the "one canonical home, not per-file links" expectation from #393. #409's fix re-links SQLite entries on each preparation, which does not cover a WAL deleted between preparations. #396 takes a different route (process-owned SQLite state inside the overlay, plus `-c sqlite_home=`); this PR keeps one shared SQLite home so threads created from the CLI and from Synara stay in the same index and archive/unarchive cannot desync two databases, and stays small on purpose.

`CODEX_SQLITE_HOME` is honored by the Codex CLI (verified with `codex doctor` on 0.153.4, which reports it as "sqlite home"; also referenced in openai/codex#39422).

## Verification

- `bunx vitest run src/codexProcessEnv.test.ts src/codexAppServerManager.test.ts` in `apps/server` (Windows 11, bun 1.3.6): 138 passed, 2 skipped.
- `bun run typecheck:legacy` in `apps/server`: clean.
- `oxlint` on the three files: same 4 pre-existing warnings as `main`, 0 errors. `oxfmt --check`: clean.
- Manually: with `CODEX_SQLITE_HOME` pointed at the real home, `codex doctor` lists the state / log / thread history DBs under that path and the overlay no longer receives SQLite entries.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (no UI change)
- [ ] I included a video for animation/interaction changes (no UI change)
