### PR TITLE
Allow retries after confirmed Codex startup failures

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -597,7 +597,7 @@ describe("Codex app-server teardown", () => {
     expect(manager.hasSession(threadId)).toBe(false);
   });
 
-  it("releases the session lease once when the app-server exits spontaneously", () => {
+  it("releases the session lease once when the app-server exits spontaneously", async () => {
     class FakeCodexChild extends EventEmitter {
       readonly pid = 5252;
       exitCode: number | null = null;
@@ -607,7 +607,12 @@ describe("Codex app-server teardown", () => {
       readonly stderr = new PassThrough();
     }
     const child = new FakeCodexChild();
-    const manager = new CodexAppServerManager();
+    const teardownProcessTree = vi.fn(async () => ({
+      escalated: false,
+      signalErrors: [],
+      capturedBeforeRootExit: false,
+    }));
+    const manager = new CodexAppServerManager(undefined, { teardownProcessTree });
     const threadId = asThreadId("thread-codex-spontaneous-exit");
     const revokeSessionToken = vi.fn();
     const gatewaySessionLease = acquireAgentGatewaySessionLease(
@@ -651,11 +656,14 @@ describe("Codex app-server teardown", () => {
     internals.sessions.set(threadId, context);
     internals.attachProcessListeners(context);
 
+    child.exitCode = 1;
     child.emit("exit", 1, null);
     child.emit("exit", 1, null);
 
     expect(revokeSessionToken).toHaveBeenCalledOnce();
     expect(manager.hasSession(threadId)).toBe(false);
+    await vi.waitFor(() => expect(internals.sessions.has(threadId)).toBe(false));
+    expect(teardownProcessTree).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -56,7 +56,7 @@ import {
   AGENT_GATEWAY_TURN_AUTHORITY_RETIRED,
   type AgentGatewaySessionLease,
 } from "./agentGateway/sessionLease.ts";
-import { isNonFatalCodexErrorMessage } from "./codexErrorClassification.ts";
+import { CodexSessionStartError, isNonFatalCodexErrorMessage } from "./codexErrorClassification.ts";
 import { buildCodexProcessEnv } from "./codexProcessEnv.ts";
 import { assertCodexWorkingDirectoryExists } from "./codexWorkingDirectory.ts";
 import { executableIdentity, resolveExecutable } from "./executableLookup.ts";
@@ -179,6 +179,7 @@ interface CodexSessionContext {
     | undefined;
   nextRequestId: number;
   stopping: boolean;
+  transportError?: Error;
   stopPromise?: Promise<void>;
   discovery?: boolean;
 }
@@ -1032,6 +1033,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         extraRoots: [this.synaraSkillsDir],
       });
     } catch (error) {
+      if (!this.isContextRoutable(context)) throw error;
       // Older codex builds (< extra-roots support) keep working; Synara-only
       // skills simply stay invisible to codex on those versions.
       log.warn("skills/extraRoots/set unavailable", { error });
@@ -1043,12 +1045,14 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     const now = new Date().toISOString();
     let context: CodexSessionContext | undefined;
     let gatewaySessionLease: AgentGatewaySessionLease | undefined;
+    let previousSessionStopped = false;
 
     try {
       const existing = this.sessions.get(threadId);
       if (existing) {
         await this.stopSession(threadId);
       }
+      previousSessionStopped = true;
 
       const resolvedCwd = resolveScratchWorkspaceCwd(threadId, input.cwd);
 
@@ -1130,6 +1134,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
           sparkEnabled: context.account.sparkEnabled,
         });
       } catch (error) {
+        if (!this.isContextRoutable(context)) throw error;
         log.warn("account/read failed", { error });
       }
 
@@ -1274,7 +1279,8 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       }).pipe(this.runPromise);
       return { ...context.session };
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Failed to start Codex session.";
+      const cause = context?.transportError ?? error;
+      const message = cause instanceof Error ? cause.message : "Failed to start Codex session.";
       if (context) {
         this.updateSession(context, {
           status: "error",
@@ -1297,7 +1303,11 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
           message,
         });
       }
-      throw new Error(message, { cause: error });
+      // Reaching here proves cleanup succeeded. A failed replacement barrier or
+      // teardown must remain an uncertain process failure, never a safe rejection.
+      throw previousSessionStopped
+        ? new CodexSessionStartError(message, { cause })
+        : new Error(message, { cause });
     }
   }
 
@@ -2975,9 +2985,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         if (discoveryKey) {
           this.discoverySessions.delete(discoveryKey);
         }
-      } else {
-        this.sessions.delete(context.session.threadId);
       }
+      // Keep normal sessions as non-routable replacement barriers. The root's
+      // exit alone does not prove its descendants stopped; startup cleanup or
+      // the next stop/start must still await stopSession's process-tree proof.
     });
   }
 
@@ -2989,6 +3000,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       error instanceof CodexAppServerTransportError
         ? error.message
         : `Codex app-server transport failed: ${error.message}`;
+    // Startup can report the original cause after cleanup. Pending requests
+    // keep stopSession's uncertain outcome: this error may belong to a different
+    // write, or a frame that reached the provider before the pipe closed.
+    context.transportError = error;
     this.updateSession(context, { status: "error", lastError: message });
     this.emitErrorEvent(context, "protocol/transportError", message);
 

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -181,6 +181,7 @@ interface CodexSessionContext {
   stopping: boolean;
   transportError?: Error;
   stopPromise?: Promise<void>;
+  teardownCapturedBeforeExit?: boolean;
   discovery?: boolean;
 }
 
@@ -1287,7 +1288,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
           lastError: message,
         });
         this.emitErrorEvent(context, "session/startFailed", message);
-        await this.stopSession(threadId);
+        await (context.stopPromise ?? this.stopSession(threadId));
       } else {
         gatewaySessionLease?.release();
         this.emitEvent({
@@ -1303,9 +1304,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
           message,
         });
       }
-      // Reaching here proves cleanup succeeded. A failed replacement barrier or
-      // teardown must remain an uncertain process failure, never a safe rejection.
-      throw previousSessionStopped
+      // A post-exit snapshot can miss reparented children even when cleanup
+      // succeeds. Only pre-exit capture can certify a safe startup rejection.
+      throw previousSessionStopped && (!context || context.teardownCapturedBeforeExit === true)
         ? new CodexSessionStartError(message, { cause })
         : new Error(message, { cause });
     }
@@ -2275,7 +2276,8 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
 
   private async teardownContextProcess(context: CodexSessionContext): Promise<void> {
     try {
-      await teardownChildProcessTree(context.child, this.teardownProcessTree);
+      const result = await teardownChildProcessTree(context.child, this.teardownProcessTree);
+      context.teardownCapturedBeforeExit = result.capturedBeforeRootExit === true;
     } catch (cause) {
       const detail = cause instanceof Error ? cause.message : String(cause);
       throw new Error(
@@ -2964,31 +2966,19 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         return;
       }
 
-      context.detachStdout?.();
-      this.clearTaskCompleteFallback(context);
-      context.gatewaySessionLease?.release();
       const message = `codex app-server exited (code=${code ?? "null"}, signal=${signal ?? "null"}).`;
       const exitError = new Error(message);
       context.stdinWriter.close(exitError);
       this.rejectPendingRequests(context, exitError);
-      // The child is gone, so the responses cannot land; settling still clears
-      // the maps and emits the resolutions that close the pending UI cards.
-      void this.settlePendingHumanRequests(context, "session exited");
       this.updateSession(context, {
         status: "closed",
         activeTurnId: undefined,
         lastError: code === 0 ? context.session.lastError : message,
       });
       this.emitLifecycleEvent(context, "session/exited", message);
-      if (context.discovery) {
-        const discoveryKey = context.session.cwd ?? "";
-        if (discoveryKey) {
-          this.discoverySessions.delete(discoveryKey);
-        }
-      }
-      // Keep normal sessions as non-routable replacement barriers. The root's
-      // exit alone does not prove its descendants stopped; startup cleanup or
-      // the next stop/start must still await stopSession's process-tree proof.
+      // Retire resources promptly while retaining the replacement barrier until
+      // teardown settles. Post-exit capture keeps startup failures uncertain.
+      this.stopFailedContext(context);
     });
   }
 
@@ -3007,11 +2997,15 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     this.updateSession(context, { status: "error", lastError: message });
     this.emitErrorEvent(context, "protocol/transportError", message);
 
+    this.stopFailedContext(context);
+  }
+
+  private stopFailedContext(context: CodexSessionContext): void {
     const stopping = context.discovery
       ? this.stopDiscoverySession(context.session.cwd ?? "")
       : this.stopSession(context.session.threadId);
     void stopping.catch((stopError) => {
-      log.error("failed to stop Codex session after transport error", {
+      log.error("failed to stop Codex session after process or transport failure", {
         threadId: context.session.threadId,
         error: stopError,
       });

--- a/apps/server/src/codexErrorClassification.ts
+++ b/apps/server/src/codexErrorClassification.ts
@@ -1,6 +1,11 @@
 // FILE: codexErrorClassification.ts
 // Purpose: Centralizes Codex runtime error classification shared across manager and adapter layers.
-// Exports: helpers for non-fatal Codex error messages that should remain warnings
+// Exports: startup failure evidence and helpers for non-fatal Codex error messages
+
+/** Startup failed before a turn could be sent, and process cleanup completed. */
+export class CodexSessionStartError extends Error {
+  override readonly name = "CodexSessionStartError";
+}
 
 const NON_FATAL_CODEX_ERROR_SNIPPETS = [
   "write_stdin failed: stdin is closed for this session",

--- a/apps/server/src/codexSessionStartup.test.ts
+++ b/apps/server/src/codexSessionStartup.test.ts
@@ -1,0 +1,187 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { ThreadId } from "@synara/contracts";
+import { spawnProcess } from "@synara/shared/processRuntime";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { Effect, Exit, Layer } from "effect";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CodexAppServerManager } from "./codexAppServerManager.ts";
+import { CodexSessionStartError } from "./codexErrorClassification.ts";
+import { ServerConfig } from "./config.ts";
+import { classifyProviderAttemptOutcome } from "./orchestration/Layers/ProviderCommandReactor.ts";
+import { makeCodexAdapterLive } from "./provider/Layers/CodexAdapter.ts";
+import { CodexAdapter } from "./provider/Services/CodexAdapter.ts";
+
+vi.mock("@synara/shared/processRuntime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@synara/shared/processRuntime")>()),
+  spawnProcess: vi.fn(),
+}));
+
+class FakeCodexChild extends EventEmitter {
+  readonly pid = 42424;
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+
+  exit() {
+    this.exitCode = 0;
+    this.emit("exit", 0, null);
+  }
+}
+
+function createStartupHarness(failingMethod?: string, failure: "error" | "exit" = "error") {
+  const child = new FakeCodexChild();
+  const requests: string[] = [];
+  const transportError = new Error("Codex pipe failed during startup: ECONNRESET");
+  child.stdin.on("data", (chunk: Buffer) => {
+    const request = JSON.parse(chunk.toString()) as { id?: number; method: string };
+    requests.push(request.method);
+    if (request.method === failingMethod) {
+      queueMicrotask(() => {
+        if (failure === "exit") child.exit();
+        else child.emit("error", transportError);
+      });
+    } else if (request.id !== undefined) {
+      queueMicrotask(() => {
+        const result = request.method === "thread/resume" ? { thread: { id: "native-thread" } } : {};
+        child.stdout.write(`${JSON.stringify({ id: request.id, result })}\n`);
+      });
+    }
+  });
+  vi.mocked(spawnProcess)
+    .mockReset()
+    .mockReturnValue(child as unknown as ChildProcessWithoutNullStreams);
+  const teardownProcessTree = vi.fn(async () => {
+    child.exit();
+    return { escalated: false, signalErrors: [] };
+  });
+  const manager = new CodexAppServerManager(undefined, { teardownProcessTree });
+  const internals = manager as unknown as {
+    assertSupportedCodexCliVersion: () => Promise<void>;
+    buildSessionProcessEnv: () => Promise<NodeJS.ProcessEnv>;
+  };
+  vi.spyOn(internals, "assertSupportedCodexCliVersion").mockResolvedValue(undefined);
+  vi.spyOn(internals, "buildSessionProcessEnv").mockResolvedValue({});
+  const input = {
+    threadId: ThreadId.makeUnsafe("thread-startup-failed"),
+    cwd: process.cwd(),
+    runtimeMode: "full-access" as const,
+    resumeCursor: { threadId: "codex-existing-thread" },
+  };
+  const expectedErrorMessage =
+    failure === "exit"
+      ? "codex app-server exited (code=0, signal=null)."
+      : transportError.message;
+  return { manager, child, input, requests, teardownProcessTree, expectedErrorMessage };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("Codex session startup failures", () => {
+  it.each([
+    ["initialize", "error"],
+    ["account/read", "error"],
+    ["thread/resume", "error"],
+    ["initialize", "exit"],
+    ["thread/resume", "exit"],
+  ] as const)(
+    "preserves the cause during %s/%s and confirms cleanup before rejecting",
+    async (method, failure) => {
+      const { manager, child, input, requests, teardownProcessTree, expectedErrorMessage } =
+        createStartupHarness(method, failure);
+      let proveExit: (() => void) | undefined;
+      const exitProof = new Promise<void>((resolve) => {
+        proveExit = resolve;
+      });
+      teardownProcessTree.mockImplementation(async () => {
+        await exitProof;
+        child.exit();
+        return { escalated: false, signalErrors: [] };
+      });
+      let settled = false;
+      const result = manager.startSession(input).catch((error: unknown) => error);
+      void result.then(() => {
+        settled = true;
+      });
+      try {
+        await vi.waitFor(() => expect(teardownProcessTree).toHaveBeenCalledTimes(1));
+        expect(settled).toBe(false);
+        expect(manager.hasSession(input.threadId)).toBe(false);
+      } finally {
+        proveExit?.();
+      }
+      const error = await result;
+      expect(error).toBeInstanceOf(CodexSessionStartError);
+      expect(error).toMatchObject({
+        message: expectedErrorMessage,
+        cause: { message: expectedErrorMessage },
+      });
+      expect(requests).not.toContain("turn/start");
+      expect(requests).not.toContain("thread/start");
+      expect(manager.listSessions()).toEqual([]);
+    },
+  );
+
+  it.each(["error", "exit"] as const)(
+    "keeps failed cleanup and failed replacement barriers uncertain after %s",
+    async (failure) => {
+      const { manager, child, input, teardownProcessTree } = createStartupHarness(
+        "initialize",
+        failure,
+      );
+      teardownProcessTree.mockRejectedValue(
+        new Error(`rootExited=${failure === "exit"}; surviving descendant remains`),
+      );
+      try {
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+          const error = await manager.startSession(input).catch((error: unknown) => error);
+          expect(error).toBeInstanceOf(Error);
+          expect(error).not.toBeInstanceOf(CodexSessionStartError);
+          expect(error).toMatchObject({
+            message: expect.stringContaining("Failed to prove Codex app-server process-tree exit"),
+          });
+        }
+        expect(spawnProcess).toHaveBeenCalledTimes(1);
+      } finally {
+        teardownProcessTree.mockImplementation(async () => {
+          child.exit();
+          return { escalated: false, signalErrors: [] };
+        });
+        await manager.stopAll();
+      }
+    },
+  );
+
+  it("keeps a turn uncertain when stdin closes after accepting its frame", async () => {
+    const { manager, child, input } = createStartupHarness();
+    await manager.startSession(input);
+    let acceptedFrame: unknown;
+    vi.spyOn(child.stdin, "write").mockImplementation((frame) => {
+      acceptedFrame = JSON.parse(String(frame));
+      // The provider can receive the frame before the stream's write callback
+      // confirms it. Closing here loses acknowledgement, not proof of delivery.
+      queueMicrotask(() => child.stdin.emit("close"));
+      return true;
+    });
+    const layer = makeCodexAdapterLive({ manager }).pipe(
+      Layer.provide(ServerConfig.layerTest(process.cwd(), { prefix: "codex-write-uncertain-" })),
+      Layer.provide(NodeServices.layer),
+    );
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* CodexAdapter;
+        return yield* adapter
+          .sendTurn({ threadId: input.threadId, input: "Apply the change", attachments: [] })
+          .pipe(Effect.result);
+      }).pipe(Effect.provide(layer)),
+    );
+    expect(acceptedFrame).toMatchObject({ method: "turn/start" });
+    if (result._tag !== "Failure") throw new Error("Expected lost acknowledgement");
+    expect(result.failure._tag).toBe("ProviderAdapterRequestError");
+    expect(classifyProviderAttemptOutcome(Exit.fail(result.failure))._tag).toBe("uncertain");
+  });
+});

--- a/apps/server/src/codexSessionStartup.test.ts
+++ b/apps/server/src/codexSessionStartup.test.ts
@@ -47,7 +47,8 @@ function createStartupHarness(failingMethod?: string, failure: "error" | "exit" 
       });
     } else if (request.id !== undefined) {
       queueMicrotask(() => {
-        const result = request.method === "thread/resume" ? { thread: { id: "native-thread" } } : {};
+        const result =
+          request.method === "thread/resume" ? { thread: { id: "native-thread" } } : {};
         child.stdout.write(`${JSON.stringify({ id: request.id, result })}\n`);
       });
     }
@@ -56,8 +57,9 @@ function createStartupHarness(failingMethod?: string, failure: "error" | "exit" 
     .mockReset()
     .mockReturnValue(child as unknown as ChildProcessWithoutNullStreams);
   const teardownProcessTree = vi.fn(async () => {
+    const capturedBeforeRootExit = child.exitCode === null;
     child.exit();
-    return { escalated: false, signalErrors: [] };
+    return { escalated: false, signalErrors: [], capturedBeforeRootExit };
   });
   const manager = new CodexAppServerManager(undefined, { teardownProcessTree });
   const internals = manager as unknown as {
@@ -73,9 +75,7 @@ function createStartupHarness(failingMethod?: string, failure: "error" | "exit" 
     resumeCursor: { threadId: "codex-existing-thread" },
   };
   const expectedErrorMessage =
-    failure === "exit"
-      ? "codex app-server exited (code=0, signal=null)."
-      : transportError.message;
+    failure === "exit" ? "codex app-server exited (code=0, signal=null)." : transportError.message;
   return { manager, child, input, requests, teardownProcessTree, expectedErrorMessage };
 }
 
@@ -89,7 +89,7 @@ describe("Codex session startup failures", () => {
     ["initialize", "exit"],
     ["thread/resume", "exit"],
   ] as const)(
-    "preserves the cause during %s/%s and confirms cleanup before rejecting",
+    "preserves the cause during %s/%s and requires pre-exit capture for a safe rejection",
     async (method, failure) => {
       const { manager, child, input, requests, teardownProcessTree, expectedErrorMessage } =
         createStartupHarness(method, failure);
@@ -98,9 +98,10 @@ describe("Codex session startup failures", () => {
         proveExit = resolve;
       });
       teardownProcessTree.mockImplementation(async () => {
+        const capturedBeforeRootExit = child.exitCode === null;
         await exitProof;
         child.exit();
-        return { escalated: false, signalErrors: [] };
+        return { escalated: false, signalErrors: [], capturedBeforeRootExit };
       });
       let settled = false;
       const result = manager.startSession(input).catch((error: unknown) => error);
@@ -115,7 +116,8 @@ describe("Codex session startup failures", () => {
         proveExit?.();
       }
       const error = await result;
-      expect(error).toBeInstanceOf(CodexSessionStartError);
+      expect(error).toBeInstanceOf(Error);
+      expect(error instanceof CodexSessionStartError).toBe(failure === "error");
       expect(error).toMatchObject({
         message: expectedErrorMessage,
         cause: { message: expectedErrorMessage },
@@ -149,12 +151,37 @@ describe("Codex session startup failures", () => {
       } finally {
         teardownProcessTree.mockImplementation(async () => {
           child.exit();
-          return { escalated: false, signalErrors: [] };
+          return { escalated: false, signalErrors: [], capturedBeforeRootExit: false };
         });
         await manager.stopAll();
       }
     },
   );
+
+  it("retires an idle session after spontaneous exit only when teardown completes", async () => {
+    const { manager, child, input, teardownProcessTree } = createStartupHarness();
+    await manager.startSession(input);
+    const sessions = (manager as unknown as { sessions: Map<ThreadId, unknown> }).sessions;
+    let finishTeardown: (() => void) | undefined;
+    teardownProcessTree.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishTeardown = () =>
+            resolve({
+              escalated: false,
+              signalErrors: [],
+              capturedBeforeRootExit: false,
+            });
+        }),
+    );
+
+    child.exit();
+    expect(teardownProcessTree).toHaveBeenCalledOnce();
+    expect(manager.hasSession(input.threadId)).toBe(false);
+    expect(sessions.has(input.threadId)).toBe(true);
+    finishTeardown?.();
+    await vi.waitFor(() => expect(sessions.has(input.threadId)).toBe(false));
+  });
 
   it("keeps a turn uncertain when stdin closes after accepting its frame", async () => {
     const { manager, child, input } = createStartupHarness();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -116,6 +116,20 @@ const asMessageId = (value: string): MessageId => MessageId.makeUnsafe(value);
 const asTurnId = (value: string): TurnId => TurnId.makeUnsafe(value);
 
 describe("legacy provider blocker recovery", () => {
+  it("rejects a startup failure only when process cleanup was confirmed", () => {
+    const outcome = classifyProviderAttemptOutcome(
+      Exit.fail(
+        new ProviderAdapterProcessError({
+          provider: "codex",
+          threadId: ThreadId.makeUnsafe("thread-start-failed"),
+          reason: "startup-failed",
+          detail: "Codex stdout closed during initialization.",
+        }),
+      ),
+    );
+    expect(outcome._tag).toBe("rejected");
+  });
+
   it("keeps process lifecycle failures uncertain", () => {
     const outcome = classifyProviderAttemptOutcome(
       Exit.fail(
@@ -150,6 +164,7 @@ describe("legacy provider blocker recovery", () => {
       ),
     ).toBe(false);
     expect(isSafeLegacyProviderBlocker("Provider process tree did not prove exit.")).toBe(false);
+    expect(isSafeLegacyProviderBlocker("Session stopped before request completed.")).toBe(false);
     expect(isSafeLegacyProviderBlocker("The provider rejected the prompt.")).toBe(false);
   });
 });
@@ -1854,6 +1869,55 @@ describe("ProviderCommandReactor", () => {
       harness.deliveryRepository.getConsumerState("provider-command-reactor.v1"),
     );
     expect(consumerState.pipe(Option.getOrThrow).lastAckedSequence).toBe(events.at(-1)!.sequence);
+  });
+
+  it("accepts a new message after a failed Codex startup without reconciliation", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    harness.startSession.mockImplementationOnce(() =>
+      Effect.fail(
+        new ProviderAdapterProcessError({
+          provider: "codex",
+          threadId,
+          reason: "startup-failed",
+          detail: "Codex stdout closed during initialization.",
+        }),
+      ),
+    );
+
+    await dispatchHarnessUserTurn(harness, {
+      messageId: "startup-failed-message",
+      text: "First attempt",
+      createdAt: now,
+    });
+    await harness.drain();
+    expect((await readHarnessThread(harness))?.session).toMatchObject({
+      status: "error",
+      lastError: expect.stringContaining("Codex stdout closed during initialization."),
+    });
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+    const blockers = await Effect.runPromise(
+      harness.deliveryRepository.listBlockingDeliveries({
+        consumerName: PROVIDER_COMMAND_REACTOR_CONSUMER,
+        threadId,
+        limit: 10,
+      }),
+    );
+    expect(blockers).toEqual([]);
+
+    await dispatchHarnessUserTurn(harness, {
+      messageId: "startup-retry-message",
+      text: "Retry after startup failure",
+      createdAt: now,
+    });
+    await harness.drain();
+    expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({
+      threadId,
+      input: "Retry after startup failure",
+    });
+    expect(harness.startSession).toHaveBeenCalledTimes(2);
   });
 
   // The ambiguous command here is a conversation rollback whose provider

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -144,6 +144,36 @@ describe("legacy provider blocker recovery", () => {
     expect(outcome._tag).toBe("uncertain");
   });
 
+  it.each(["failure", "defect"] as const)(
+    "keeps startup rejection uncertain when provider restoration adds a %s",
+    async (kind) => {
+      const startupError = new ProviderAdapterProcessError({
+        provider: "codex",
+        threadId: ThreadId.makeUnsafe("thread-switch-start-failed"),
+        reason: "startup-failed",
+        detail: "Codex startup failed after confirmed cleanup.",
+      });
+      const restorationError = new ProviderAdapterProcessError({
+        provider: "claudeAgent",
+        threadId: startupError.threadId,
+        detail: "Previous provider restoration did not prove process-tree exit.",
+      });
+      const exit = await Effect.runPromise(
+        Effect.fail(startupError).pipe(
+          Effect.onExit(() =>
+            kind === "failure" ? Effect.fail(restorationError) : Effect.die(restorationError),
+          ),
+          Effect.exit,
+        ),
+      );
+
+      expect(classifyProviderAttemptOutcome(exit)).toMatchObject({
+        _tag: "uncertain",
+        detail: expect.stringContaining(restorationError.detail),
+      });
+    },
+  );
+
   it("accepts only failures that prove the command frame was not written", () => {
     expect(
       isSafeLegacyProviderBlocker(

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -73,6 +73,7 @@ import { CheckpointStore } from "../../checkpointing/Services/CheckpointStore.ts
 import { AgentGatewayOperationRepository } from "../../agentGateway/Services/AgentGatewayOperationRepository.ts";
 import { GitCore } from "../../git/Services/GitCore.ts";
 import {
+  type ProviderAdapterProcessError,
   ProviderAdapterRequestError,
   ProviderAdapterValidationError,
   ProviderServiceError,
@@ -188,6 +189,10 @@ export function classifyProviderAttemptOutcome(
     case "ProviderUnsupportedError":
     case "ProviderSessionNotFoundError":
       return { _tag: "rejected", detail };
+    case "ProviderAdapterProcessError":
+      return (failure.value as ProviderAdapterProcessError).reason === "startup-failed"
+        ? { _tag: "rejected", detail }
+        : { _tag: "uncertain", detail };
     case "PersistenceSqlError":
     case "PersistenceDecodeError":
       return { _tag: "safe_retry", detail };

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -177,6 +177,9 @@ export function classifyProviderAttemptOutcome(
 ): ProviderAttemptOutcome {
   if (Exit.isSuccess(exit)) return { _tag: "accepted" };
   const detail = Cause.pretty(exit.cause);
+  // A finalizer may add a failed cleanup/restoration after a safe rejection.
+  // Evidence for the first failure cannot establish the entire attempt's outcome.
+  if (exit.cause.reasons.length !== 1) return { _tag: "uncertain", detail };
   const failure = Cause.findErrorOption(exit.cause);
   if (Option.isNone(failure)) return { _tag: "uncertain", detail };
 

--- a/apps/server/src/platform/processLiveness.test.ts
+++ b/apps/server/src/platform/processLiveness.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { spawnProcessSync } = vi.hoisted(() => ({ spawnProcessSync: vi.fn() }));
+vi.mock("@synara/shared/processRuntime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@synara/shared/processRuntime")>()),
+  spawnProcessSync,
+}));
+
+import { isProcessRunning } from "./processTreeController";
+
+describe("native process liveness", () => {
+  it.each(["R", "S+", "D", "I", "T", "t", "U", "W"])(
+    "recognizes a live POSIX process in state %s",
+    async (state) => {
+      spawnProcessSync.mockReturnValue({ status: 0, stdout: `${state}\n` });
+      expect(await isProcessRunning(91, { platform: "linux" })).toBe(true);
+    },
+  );
+
+  it.each(["Z", "Z+", "X", "", "?"])(
+    "does not certify an exited or unknown POSIX process in state %s",
+    async (state) => {
+      spawnProcessSync.mockReturnValue({ status: 0, stdout: `${state}\n` });
+      expect(await isProcessRunning(91, { platform: "darwin" })).toBe(false);
+    },
+  );
+
+  it("treats absent PIDs, failed probes and unreadable process tables as unproven", async () => {
+    spawnProcessSync.mockReturnValue({ status: 1, stdout: "" });
+    expect(await isProcessRunning(91, { platform: "linux" })).toBe(false);
+    spawnProcessSync.mockReturnValue({ status: null, stdout: "S", error: new Error("timeout") });
+    expect(await isProcessRunning(91, { platform: "linux" })).toBe(false);
+    spawnProcessSync.mockImplementation(() => {
+      throw new Error("ps unavailable");
+    });
+    expect(await isProcessRunning(91, { platform: "linux" })).toBe(false);
+  });
+
+  it("checks the Windows root itself, not a reparented descendant", async () => {
+    const root = { pid: 91, command: "codex.exe", startedAt: "20260908090000" };
+    expect(
+      await isProcessRunning(91, {
+        platform: "win32",
+        captureWindowsChildren: async () => new Map([[1, [root]]]),
+      }),
+    ).toBe(true);
+    expect(
+      await isProcessRunning(91, {
+        platform: "win32",
+        captureWindowsChildren: async () => new Map([[1, [{ ...root, pid: 92 }]]]),
+      }),
+    ).toBe(false);
+    expect(
+      await isProcessRunning(91, {
+        platform: "win32",
+        captureWindowsChildren: async () => null,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/server/src/platform/processTreeController.ts
+++ b/apps/server/src/platform/processTreeController.ts
@@ -309,6 +309,32 @@ export async function captureProcessTree(
   };
 }
 
+/** A fresh OS observation, independent of Node's potentially delayed exit notification. */
+export async function isProcessRunning(
+  rootPid: number,
+  options: PlatformProcessTreeOptions = {},
+): Promise<boolean> {
+  if (!Number.isInteger(rootPid) || rootPid <= 0) return false;
+  try {
+    if ((options.platform ?? process.platform) === "win32") {
+      const snapshot = await (options.captureWindowsChildren ?? captureWindowsProcessChildrenMap)();
+      if (snapshot === null) return false;
+      return processesByPid(snapshot).has(rootPid);
+    }
+    const result = spawnProcessSync("ps", ["-p", String(rootPid), "-o", "stat="], {
+      encoding: "utf8",
+      maxBuffer: 1024,
+      timeout: PROCESS_TREE_SCAN_TIMEOUT_MS,
+    });
+    if (result.error || result.status !== 0) return false;
+    // kill(pid, 0) also succeeds for zombies. Accept only live POSIX process states;
+    // Z (zombie), X (dead), missing output, and unknown states cannot prove liveness.
+    return /^[RSDITUWt]/.test(result.stdout.trim());
+  } catch {
+    return false;
+  }
+}
+
 /** Inspect the exact captured identities; snapshot failure is never interpreted as exit. */
 export async function inspectProcessTree(
   tree: CapturedProcessTree,

--- a/apps/server/src/platform/supervisedProcessTeardown.ts
+++ b/apps/server/src/platform/supervisedProcessTeardown.ts
@@ -49,6 +49,8 @@ export interface EffectProcessExitHandle {
 export interface SupervisedProcessTeardownResult {
   readonly escalated: boolean;
   readonly signalErrors: ReadonlyArray<Error>;
+  /** Only true when the initial descendant snapshot completed before root exit. */
+  readonly capturedBeforeRootExit?: boolean;
 }
 
 export interface SupervisedProcessTeardownDependencies {
@@ -205,6 +207,10 @@ export async function teardownProviderProcessTree(
 
   try {
     const tree = await captureTree(input.rootPid);
+    // PPID traversal after root exit can miss reparented descendants. Cleanup
+    // can still retire the observed tree, but callers must not treat that as
+    // proof that an interrupted provider command had no surviving side effects.
+    const capturedBeforeRootExit = !rootExited;
     const signalErrors: Error[] = [];
 
     const signal = (
@@ -278,7 +284,7 @@ export async function teardownProviderProcessTree(
     const graceful = await waitForExitProof(
       positiveDuration(input.termGraceMs, DEFAULT_TERM_GRACE_MS),
     );
-    if (graceful.proven) return { escalated: false, signalErrors };
+    if (graceful.proven) return { escalated: false, signalErrors, capturedBeforeRootExit };
 
     let forceTree = tree;
     let forceDescendantsVerified = false;
@@ -310,7 +316,7 @@ export async function teardownProviderProcessTree(
     const forced = await waitForExitProof(
       positiveDuration(input.forceExitMs, DEFAULT_FORCE_EXIT_MS),
     );
-    if (forced.proven) return { escalated: true, signalErrors };
+    if (forced.proven) return { escalated: true, signalErrors, capturedBeforeRootExit };
 
     throw new ProviderProcessExitUnprovenError({
       rootPid: input.rootPid,

--- a/apps/server/src/platform/supervisedProcessTeardown.ts
+++ b/apps/server/src/platform/supervisedProcessTeardown.ts
@@ -8,6 +8,7 @@ import {
   captureProcessTree,
   defaultProcessTreeKiller,
   inspectProcessTree,
+  isProcessRunning,
   type CapturedProcess,
   type CapturedProcessTree,
   type CapturedProcessTreeInspection,
@@ -60,6 +61,8 @@ export interface SupervisedProcessTeardownDependencies {
   readonly inspectProcessTree: (
     tree: CapturedProcessTree,
   ) => Promise<CapturedProcessTreeInspection>;
+  /** Fresh native liveness observation, taken after the descendant snapshot. */
+  readonly isRootRunning: (rootPid: number) => Promise<boolean>;
   readonly now: () => number;
   readonly sleep: (milliseconds: number) => Promise<void>;
 }
@@ -210,7 +213,22 @@ export async function teardownProviderProcessTree(
     // PPID traversal after root exit can miss reparented descendants. Cleanup
     // can still retire the observed tree, but callers must not treat that as
     // proof that an interrupted provider command had no surviving side effects.
-    const capturedBeforeRootExit = !rootExited;
+    // The exit promise alone is insufficient: native exit can precede its callback.
+    const rootRunningAfterCapture =
+      !rootExited &&
+      (await (
+        dependencies.isRootRunning?.(input.rootPid) ??
+        isProcessRunning(input.rootPid, {
+          platform,
+          ...(windowsObserver
+            ? {
+                captureWindowsChildren: () =>
+                  windowsObserver.captureWithin(FINAL_PROOF_INSPECTION_MAX_MS),
+              }
+            : {}),
+        })
+      ).catch(() => false));
+    const capturedBeforeRootExit = rootRunningAfterCapture && !rootExited;
     const signalErrors: Error[] = [];
 
     const signal = (

--- a/apps/server/src/provider/Errors.ts
+++ b/apps/server/src/provider/Errors.ts
@@ -77,7 +77,8 @@ export class ProviderAdapterProcessError extends Schema.TaggedErrorClass<Provide
     provider: Schema.String,
     threadId: Schema.String,
     detail: Schema.String,
-    reason: Schema.optional(Schema.Literal("resume-state-unavailable")),
+    // startup-failed is only valid after cleanup proves the process stopped.
+    reason: Schema.optional(Schema.Literals(["resume-state-unavailable", "startup-failed"])),
     cause: Schema.optional(Schema.Defect),
   },
 ) {

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -176,36 +176,38 @@ const validationLayer = it.layer(
 );
 
 validationLayer("CodexAdapterLive validation", (it) => {
-  it.effect("preserves startup cleanup evidence without reclassifying unknown process failures", () =>
-    Effect.gen(function* () {
-      const adapter = yield* CodexAdapter;
-      for (const cause of [
-        new CodexSessionStartError("Codex stdout closed during initialization."),
-        new Error("Failed to prove Codex app-server process-tree exit."),
-      ]) {
-        validationManager.startSessionImpl.mockRejectedValueOnce(cause);
-        const result = yield* adapter
-          .startSession({
-            provider: "codex",
-            threadId: asThreadId("thread-start-failed"),
-            runtimeMode: "full-access",
-          })
-          .pipe(Effect.result);
+  it.effect(
+    "preserves startup cleanup evidence without reclassifying unknown process failures",
+    () =>
+      Effect.gen(function* () {
+        const adapter = yield* CodexAdapter;
+        for (const cause of [
+          new CodexSessionStartError("Codex stdout closed during initialization."),
+          new Error("Failed to prove Codex app-server process-tree exit."),
+        ]) {
+          validationManager.startSessionImpl.mockRejectedValueOnce(cause);
+          const result = yield* adapter
+            .startSession({
+              provider: "codex",
+              threadId: asThreadId("thread-start-failed"),
+              runtimeMode: "full-access",
+            })
+            .pipe(Effect.result);
 
-        assert.equal(result._tag, "Failure");
-        if (result._tag !== "Failure") throw new Error("Expected startup failure");
-        assert.equal(result.failure._tag, "ProviderAdapterProcessError");
-        if (result.failure._tag !== "ProviderAdapterProcessError") {
-          throw new Error("Expected process failure");
+          assert.equal(result._tag, "Failure");
+          if (result._tag !== "Failure") throw new Error("Expected startup failure");
+          assert.equal(result.failure._tag, "ProviderAdapterProcessError");
+          if (result.failure._tag !== "ProviderAdapterProcessError") {
+            throw new Error("Expected process failure");
+          }
+          assert.equal(
+            result.failure.reason,
+            cause instanceof CodexSessionStartError ? "startup-failed" : undefined,
+          );
+          assert.equal(result.failure.cause, cause);
+          assert.equal(result.failure.detail, cause.message);
         }
-        assert.equal(
-          result.failure.reason,
-          cause instanceof CodexSessionStartError ? "startup-failed" : undefined,
-        );
-        assert.equal(result.failure.cause, cause);
-        assert.equal(result.failure.detail, cause.message);
-      }
-    }),
+      }),
   );
 
   it.effect("returns validation error for non-codex provider on startSession", () =>

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -23,6 +23,7 @@ import {
   type CodexAppServerSendTurnInput,
 } from "../../codexAppServerManager.ts";
 import { ServerConfig } from "../../config.ts";
+import { CodexSessionStartError } from "../../codexErrorClassification.ts";
 import { ProviderAdapterValidationError } from "../Errors.ts";
 import { CodexAdapter } from "../Services/CodexAdapter.ts";
 import { ProviderSessionDirectory } from "../Services/ProviderSessionDirectory.ts";
@@ -175,8 +176,41 @@ const validationLayer = it.layer(
 );
 
 validationLayer("CodexAdapterLive validation", (it) => {
+  it.effect("preserves startup cleanup evidence without reclassifying unknown process failures", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      for (const cause of [
+        new CodexSessionStartError("Codex stdout closed during initialization."),
+        new Error("Failed to prove Codex app-server process-tree exit."),
+      ]) {
+        validationManager.startSessionImpl.mockRejectedValueOnce(cause);
+        const result = yield* adapter
+          .startSession({
+            provider: "codex",
+            threadId: asThreadId("thread-start-failed"),
+            runtimeMode: "full-access",
+          })
+          .pipe(Effect.result);
+
+        assert.equal(result._tag, "Failure");
+        if (result._tag !== "Failure") throw new Error("Expected startup failure");
+        assert.equal(result.failure._tag, "ProviderAdapterProcessError");
+        if (result.failure._tag !== "ProviderAdapterProcessError") {
+          throw new Error("Expected process failure");
+        }
+        assert.equal(
+          result.failure.reason,
+          cause instanceof CodexSessionStartError ? "startup-failed" : undefined,
+        );
+        assert.equal(result.failure.cause, cause);
+        assert.equal(result.failure.detail, cause.message);
+      }
+    }),
+  );
+
   it.effect("returns validation error for non-codex provider on startSession", () =>
     Effect.gen(function* () {
+      validationManager.startSessionImpl.mockClear();
       const adapter = yield* CodexAdapter;
       const result = yield* adapter
         .startSession({

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -2055,7 +2055,9 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
             provider: PROVIDER,
             threadId: input.threadId,
             detail: toMessage(cause, "Failed to start Codex adapter session."),
-            ...(cause instanceof CodexSessionStartError ? { reason: "startup-failed" as const } : {}),
+            ...(cause instanceof CodexSessionStartError
+              ? { reason: "startup-failed" as const }
+              : {}),
             cause,
           }),
       }).pipe(Effect.map((session) => session));

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -64,7 +64,10 @@ import {
   isCodexGeneratedImageItemType,
   sanitizeNestedCodexGeneratedImagePayloads,
 } from "../../codexGeneratedImages.ts";
-import { isNonFatalCodexErrorMessage } from "../../codexErrorClassification.ts";
+import {
+  CodexSessionStartError,
+  isNonFatalCodexErrorMessage,
+} from "../../codexErrorClassification.ts";
 import { ServerConfig } from "../../config.ts";
 import { makeRuntimeTaskListItem } from "../runtimeTaskList.ts";
 import { extractProposedPlanMarkdown } from "../planMode.ts";
@@ -2052,6 +2055,7 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
             provider: PROVIDER,
             threadId: input.threadId,
             detail: toMessage(cause, "Failed to start Codex adapter session."),
+            ...(cause instanceof CodexSessionStartError ? { reason: "startup-failed" as const } : {}),
             cause,
           }),
       }).pipe(Effect.map((session) => session));

--- a/apps/server/src/provider/supervisedProcessTeardown.test.ts
+++ b/apps/server/src/provider/supervisedProcessTeardown.test.ts
@@ -31,6 +31,47 @@ function deferred<T>() {
 
 describe("teardownProviderProcessTree", () => {
   it.each(["linux", "win32"] as const)(
+    "does not certify cleanup when the OS root is gone before its exit notification on %s",
+    async (platform) => {
+      const rootExit = deferred<void>();
+      const tree: CapturedProcessTree = { descendants: [], captureComplete: true };
+      const result = await teardownProviderProcessTree(
+        { rootPid: 91, rootExited: rootExit.promise },
+        {
+          platform,
+          isRootRunning: async () => false,
+          processTreeKiller: {
+            capture: () => tree,
+            inspect: () => ({ verified: true, survivors: [] }),
+            signal: () => rootExit.resolve(undefined),
+          },
+          ...deterministicClock(),
+        },
+      );
+      expect(result.capturedBeforeRootExit).toBe(false);
+    },
+  );
+
+  it("does not certify cleanup if the native liveness probe fails", async () => {
+    const rootExit = deferred<void>();
+    const result = await teardownProviderProcessTree(
+      { rootPid: 91, rootExited: rootExit.promise },
+      {
+        isRootRunning: async () => {
+          throw new Error("process table unavailable");
+        },
+        processTreeKiller: {
+          capture: () => ({ descendants: [], captureComplete: true }),
+          inspect: () => ({ verified: true, survivors: [] }),
+          signal: () => rootExit.resolve(undefined),
+        },
+        ...deterministicClock(),
+      },
+    );
+    expect(result.capturedBeforeRootExit).toBe(false);
+  });
+
+  it.each(["linux", "win32"] as const)(
     "does not certify a pre-exit capture when the root exits during the initial snapshot on %s",
     async (platform) => {
       const tree: CapturedProcessTree = { descendants: [], captureComplete: true };
@@ -119,6 +160,7 @@ describe("teardownProviderProcessTree", () => {
       teardownProviderProcessTree(
         { rootPid: 101, rootExited, termGraceMs: 10, forceExitMs: 10, pollMs: 5 },
         {
+          isRootRunning: async () => true,
           processTreeKiller,
           ...clock,
         },
@@ -159,6 +201,7 @@ describe("teardownProviderProcessTree", () => {
       teardownProviderProcessTree(
         { rootPid: 201, rootExited, termGraceMs: 10, forceExitMs: 10, pollMs: 5 },
         {
+          isRootRunning: async () => true,
           processTreeKiller,
           ...clock,
         },
@@ -213,6 +256,7 @@ describe("teardownProviderProcessTree", () => {
         { rootPid: 801, rootExited, termGraceMs: 5, forceExitMs: 5, pollMs: 5 },
         {
           platform: "win32",
+          isRootRunning: async () => true,
           processTreeKiller,
           captureProcessTree: async () => tree,
           inspectProcessTree: async () => ({

--- a/apps/server/src/provider/supervisedProcessTeardown.test.ts
+++ b/apps/server/src/provider/supervisedProcessTeardown.test.ts
@@ -30,38 +30,65 @@ function deferred<T>() {
 }
 
 describe("teardownProviderProcessTree", () => {
-  it("does not signal a root that exited during the initial snapshot", async () => {
-    const tree: CapturedProcessTree = { descendants: [], captureComplete: true };
-    const captureStarted = deferred<void>();
-    const capturedTree = deferred<CapturedProcessTree>();
-    const rootExit = deferred<void>();
-    const signals: Array<{ signal: TerminalKillSignal; includeRootTree: boolean | undefined }> = [];
-    const clock = deterministicClock();
+  it.each(["linux", "win32"] as const)(
+    "does not certify a pre-exit capture when the root exits during the initial snapshot on %s",
+    async (platform) => {
+      const tree: CapturedProcessTree = { descendants: [], captureComplete: true };
+      const captureStarted = deferred<void>();
+      const capturedTree = deferred<CapturedProcessTree>();
+      const rootExit = deferred<void>();
+      const signals: Array<{ signal: TerminalKillSignal; includeRootTree: boolean | undefined }> =
+        [];
+      const clock = deterministicClock();
 
-    const teardown = teardownProviderProcessTree(
-      { rootPid: 91, rootExited: rootExit.promise, termGraceMs: 5, forceExitMs: 5, pollMs: 1 },
-      {
-        platform: "win32",
-        captureProcessTree: async () => {
-          captureStarted.resolve(undefined);
-          return capturedTree.promise;
+      const teardown = teardownProviderProcessTree(
+        { rootPid: 91, rootExited: rootExit.promise, termGraceMs: 5, forceExitMs: 5, pollMs: 1 },
+        {
+          platform,
+          captureProcessTree: async () => {
+            captureStarted.resolve(undefined);
+            return capturedTree.promise;
+          },
+          inspectProcessTree: async () => ({ verified: true, survivors: [] }),
+          processTreeKiller: {
+            capture: () => tree,
+            signal: ({ signal, includeRootTree }) => signals.push({ signal, includeRootTree }),
+          },
+          ...clock,
         },
-        inspectProcessTree: async () => ({ verified: true, survivors: [] }),
+      );
+
+      await captureStarted.promise;
+      rootExit.resolve(undefined);
+      await Promise.resolve();
+      capturedTree.resolve(tree);
+
+      await expect(teardown).resolves.toEqual({
+        escalated: false,
+        signalErrors: [],
+        capturedBeforeRootExit: false,
+      });
+      expect(signals).toEqual([{ signal: "SIGTERM", includeRootTree: false }]);
+    },
+  );
+
+  it("does not certify an empty PPID snapshot collected after root exit", async () => {
+    // An orphan can still run under init even though PPID traversal from the
+    // former provider root returns an empty, complete snapshot.
+    const tree: CapturedProcessTree = { descendants: [], captureComplete: true };
+    const result = await teardownProviderProcessTree(
+      { rootPid: 91, rootExited: Promise.resolve() },
+      {
+        platform: "linux",
         processTreeKiller: {
           capture: () => tree,
-          signal: ({ signal, includeRootTree }) => signals.push({ signal, includeRootTree }),
+          inspect: () => ({ verified: true, survivors: [] }),
+          signal: () => undefined,
         },
-        ...clock,
+        ...deterministicClock(),
       },
     );
-
-    await captureStarted.promise;
-    rootExit.resolve(undefined);
-    await Promise.resolve();
-    capturedTree.resolve(tree);
-
-    await expect(teardown).resolves.toEqual({ escalated: false, signalErrors: [] });
-    expect(signals).toEqual([{ signal: "SIGTERM", includeRootTree: false }]);
+    expect(result.capturedBeforeRootExit).toBe(false);
   });
 
   it("escalates ignored TERM and returns only after root and descendants prove exit", async () => {
@@ -96,7 +123,7 @@ describe("teardownProviderProcessTree", () => {
           ...clock,
         },
       ),
-    ).resolves.toEqual({ escalated: true, signalErrors: [] });
+    ).resolves.toEqual({ escalated: true, signalErrors: [], capturedBeforeRootExit: true });
     expect(signals).toEqual([
       { signal: "SIGTERM", includeRootTree: true },
       { signal: "SIGKILL", includeRootTree: true },
@@ -136,7 +163,7 @@ describe("teardownProviderProcessTree", () => {
           ...clock,
         },
       ),
-    ).resolves.toEqual({ escalated: true, signalErrors: [] });
+    ).resolves.toEqual({ escalated: true, signalErrors: [], capturedBeforeRootExit: true });
     expect(signals.at(-1)).toEqual({ signal: "SIGKILL", includeRootTree: false });
   });
 
@@ -197,7 +224,7 @@ describe("teardownProviderProcessTree", () => {
           ...clock,
         },
       ),
-    ).resolves.toEqual({ escalated: true, signalErrors: [] });
+    ).resolves.toEqual({ escalated: true, signalErrors: [], capturedBeforeRootExit: true });
 
     expect(signals.at(-1)).toEqual({
       signal: "SIGKILL",
@@ -405,7 +432,7 @@ describe("teardownProviderProcessTree", () => {
           },
         },
       ),
-    ).resolves.toEqual({ escalated: false, signalErrors: [] });
+    ).resolves.toEqual({ escalated: false, signalErrors: [], capturedBeforeRootExit: false });
     expect(signals).toEqual(["SIGTERM"]);
   });
 


### PR DESCRIPTION
## Summary
- Preserve Codex startup and transport failure causes through adapter error classification.
- Treat startup failures as rejected only after process-tree cleanup is confirmed.
- Keep uncertain teardown and lost-write failures blocked from unsafe retries.
- Add coverage for startup failures, retry behavior, cleanup barriers, and uncertain turns.

## Testing
- Added and updated unit tests for Codex session startup and provider command recovery.
- Cursor repair: a fresh native root-liveness observation after descendant capture is required before certifying a safe retry; delayed Node exit notifications alone are not proof. POSIX zombies, missing roots and failed probes remain unproven; Windows uses a fresh process snapshot.
- Focused verification: 394 tests passed across process liveness, teardown, Codex manager/adapter and provider command recovery; 2 existing tests requiring CODEX_BINARY_PATH were skipped.
- Regression evidence: all 3 delayed-exit/unavailable-probe cases failed on the pre-fix source and passed after repair.
- Native macOS smoke: a running process is recognized; an exited fixture process is rejected even when its exit promise is intentionally delayed. No live authenticated Codex session was exercised locally.
- Current-head CI and Cursor review remain the merge gates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes affect Codex process lifecycle, supervised teardown certification, and provider attempt classification—areas where incorrect certainty could allow unsafe retries or block legitimate ones.
> 
> **Overview**
> This PR tightens **when Codex startup failures are safe to retry** by distinguishing confirmed process cleanup from uncertain teardown.
> 
> **Process-tree teardown** now records `capturedBeforeRootExit` using a new native `isProcessRunning` probe (POSIX `ps` stat / Windows snapshot), so post-exit or failed snapshots are not treated as proof that a command had no side effects. **Codex session lifecycle** routes spontaneous exit and transport failures through `stopFailedContext`, keeps the replacement barrier until teardown finishes, and throws **`CodexSessionStartError`** only when a prior session was stopped and cleanup was captured before root exit.
> 
> **Orchestration** maps that signal through the adapter as `ProviderAdapterProcessError` with `reason: "startup-failed"`, classifies it as **rejected** (enabling retry without reconciliation), and stays **uncertain** when cleanup/restoration adds a second failure cause or when teardown cannot be proven. Extensive tests cover startup barriers, spontaneous exit timing, provider reactor retry, and liveness/teardown edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90896f4be9b0481976e0c0c5de1814073076b31e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
