### PR TITLE
feat: expose provider usage to agents (with review fixes)

### DIFF
--- a/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
@@ -351,6 +351,7 @@ function makeHarnessLayer(
                     "thread:write",
                     "automation:write",
                     "diagnostics:read",
+                    "usage:read",
                   ] as const),
           }
         : null;
@@ -1716,6 +1717,72 @@ describe("AgentGateway", () => {
     }).pipe(Effect.provide(gatewayLayer));
   });
 
+  it.effect("requires the explicit usage capability for quota tools", () => {
+    const { gatewayLayer, makeHarness } = makeHarnessLayer(baseThreads);
+    return Effect.gen(function* () {
+      const harness = yield* makeHarness;
+      const response = yield* harness.callTool({
+        token: "token-parent-readonly",
+        name: "synara_get_usage",
+        args: {},
+      });
+      const error = toolResultJson(response.result).error as {
+        code: string;
+        details: { requiredCapability: string };
+      };
+      assert.equal(error.code, "capability_denied");
+      assert.equal(error.details.requiredCapability, "usage:read");
+    }).pipe(Effect.provide(gatewayLayer));
+  });
+
+  it.effect("scopes usage reads and context summaries to caller authority", () => {
+    const { gatewayLayer, makeHarness } = makeHarnessLayer(baseThreads);
+    return Effect.gen(function* () {
+      const harness = yield* makeHarness;
+      const usageResponse = yield* harness.callTool({
+        token: "token-parent",
+        name: "synara_get_usage",
+        args: {},
+      });
+      const usage = toolResultJson(usageResponse.result).usage as {
+        provider: string;
+        availability: string;
+        unavailableReason?: string;
+        snapshot: unknown;
+        quotaWindows: unknown[];
+      };
+      assert.equal(usage.provider, "codex");
+      assert.include(["available", "partial", "unavailable"], usage.availability);
+      assert.isArray(usage.quotaWindows);
+      assert.notProperty(usage, "credential");
+      assert.notProperty(usage, "token");
+
+      const contextResponse = yield* harness.callTool({
+        token: "token-parent",
+        name: "synara_context",
+        args: {},
+      });
+      const context = toolResultJson(contextResponse.result) as {
+        capabilities: { usageRead: boolean };
+        usage: { provider: string; availability: string };
+      };
+      assert.isTrue(context.capabilities.usageRead);
+      assert.equal(context.usage.provider, "codex");
+
+      const readonlyContextResponse = yield* harness.callTool({
+        token: "token-parent-readonly",
+        name: "synara_context",
+        args: {},
+      });
+      const readonlyContext = toolResultJson(readonlyContextResponse.result) as {
+        capabilities: { usageRead: boolean };
+        usage: { unavailableReason: string };
+      };
+      assert.isFalse(readonlyContext.capabilities.usageRead);
+      assert.equal(readonlyContext.usage.unavailableReason, "not-authorized");
+    }).pipe(Effect.provide(gatewayLayer));
+  });
+
   it.effect("rejects oversized and duplicate-id JSON-RPC batches before dispatch", () => {
     const { gatewayLayer, makeHarness } = makeHarnessLayer(baseThreads);
     return Effect.gen(function* () {
@@ -1802,6 +1869,8 @@ describe("AgentGateway", () => {
         "synara_read_thread_runtime_events",
         "synara_diagnose_thread",
         "synara_wait_for_threads",
+        "synara_get_usage",
+        "synara_list_provider_usage",
         "synara_create_threads",
         "synara_create_thread",
         "synara_send_message",

--- a/apps/server/src/agentGateway/Layers/AgentGateway.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.ts
@@ -26,6 +26,7 @@ import {
   type ServerProviderStatus,
   type TurnDispatchMode,
 } from "@synara/contracts";
+import { PROVIDER_USAGE_PROVIDERS } from "@synara/shared/providerUsage";
 import { runtimeModeEscalatesPrivilege } from "@synara/shared/runtimeMode";
 import { Effect, Layer, Option } from "effect";
 
@@ -46,6 +47,11 @@ import { AgentGatewayCredentials } from "../Services/AgentGatewayCredentials.ts"
 import { AgentGatewayOperationRepository } from "../Services/AgentGatewayOperationRepository.ts";
 import { ProviderDiscoveryService } from "../../provider/Services/ProviderDiscoveryService.ts";
 import { ProviderHealth } from "../../provider/Services/ProviderHealth.ts";
+import {
+  summarizeProviderUsageForAgent,
+  summarizeProviderUsageListForAgent,
+} from "../../providerUsage/agent.ts";
+import { collectProviderUsageSnapshots } from "../../providerUsage/index.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import {
   AGENT_GATEWAY_TARGET_OPTIONS_DESCRIPTION,
@@ -77,6 +83,7 @@ import { BrowserAutomationHost } from "../../browserAutomation/Services/BrowserA
 import { makeBrowserAutomationHost } from "../../browserAutomation/Layers/BrowserAutomationHost.ts";
 import { makeThreadReadTools } from "../threadReadTools.ts";
 import { makeThreadDiagnosticTools } from "../threadDiagnosticTools.ts";
+import { makeAgentGatewayUsageTools } from "../usageTools.ts";
 import { pruneProjectedArchivedManagedWorktrees } from "../../managedWorktrees.ts";
 import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
 
@@ -159,6 +166,49 @@ export const makeAgentGateway = Effect.gen(function* () {
       }),
     );
   });
+  const loadProviderUsage = (provider?: ProviderKind) =>
+    Effect.gen(function* () {
+      const settings = yield* serverSettings.getSettings;
+      const nowMs = Date.now();
+      const enabledProviders = new Set(
+        PROVIDER_USAGE_PROVIDERS.filter((kind) => settings.providers[kind].enabled),
+      );
+      const requestedProviders = provider
+        ? [provider]
+        : PROVIDER_USAGE_PROVIDERS.filter((kind) => enabledProviders.has(kind));
+      const providersToFetch = requestedProviders.filter((kind) => enabledProviders.has(kind));
+      const snapshots =
+        providersToFetch.length === 0
+          ? []
+          : yield* Effect.promise(() =>
+              collectProviderUsageSnapshots(
+                {
+                  homeDir: serverConfig.homeDir,
+                  env: process.env,
+                  platform: process.platform,
+                  nowMs,
+                  claudeBinaryPath: settings.providers.claudeAgent.binaryPath,
+                },
+                { providers: providersToFetch },
+              ),
+            );
+      if (provider) {
+        return [
+          summarizeProviderUsageForAgent({
+            provider,
+            enabled: enabledProviders.has(provider),
+            snapshot: snapshots[0] ?? null,
+            checkedAtMs: nowMs,
+          }),
+        ];
+      }
+      return summarizeProviderUsageListForAgent({
+        providers: requestedProviders,
+        enabledProviders,
+        snapshots,
+        checkedAtMs: nowMs,
+      });
+    });
 
   yield* recoverInterruptedAgentGatewayOperations({
     operationRepository,
@@ -217,6 +267,7 @@ export const makeAgentGateway = Effect.gen(function* () {
       homeDir: serverConfig.homeDir,
       chatWorkspaceRoot: serverConfig.chatWorkspaceRoot,
     },
+    loadProviderUsage,
   });
   const diagnosticTools = makeThreadDiagnosticTools({
     snapshotQuery,
@@ -746,6 +797,7 @@ export const makeAgentGateway = Effect.gen(function* () {
       }).pipe(Effect.catch((error) => Effect.succeed(mcpToolResultError(errorText(error))))),
   };
 
+  const usageTools = makeAgentGatewayUsageTools({ loadProviderUsage });
   const automationTools = makeAgentGatewayAutomationTools({
     automationService,
     requireThreadShell,
@@ -786,6 +838,7 @@ export const makeAgentGateway = Effect.gen(function* () {
   const tools: ReadonlyArray<ToolEntry> = [
     ...readTools,
     ...diagnosticTools,
+    ...usageTools,
     createThreads,
     createThread,
     sendMessage,

--- a/apps/server/src/agentGateway/Layers/AgentGatewaySessionRegistry.test.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGatewaySessionRegistry.test.ts
@@ -14,6 +14,7 @@ describe("AgentGatewaySessionRegistry", () => {
     assert.equal(registry.verify(second.token)?.threadId, "thread-1");
     assert.equal(registry.verify(first.token)?.provider, "codex");
     assert.equal(registry.verify(second.token)?.provider, "claudeAgent");
+    assert.isTrue(registry.verify(first.token)?.capabilities.has("usage:read"));
   });
 
   it("keeps replacement runtime credentials independent from outgoing-session revocation", () => {

--- a/apps/server/src/agentGateway/Layers/AgentGatewaySessionRegistry.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGatewaySessionRegistry.ts
@@ -14,6 +14,7 @@ const PROVIDER_SESSION_CAPABILITIES = [
   "thread:write",
   "automation:write",
   "diagnostics:read",
+  "usage:read",
   "browser:control",
   "device:control",
 ] as const;

--- a/apps/server/src/agentGateway/Services/AgentGatewaySessionRegistry.ts
+++ b/apps/server/src/agentGateway/Services/AgentGatewaySessionRegistry.ts
@@ -6,6 +6,7 @@ export type AgentGatewayCapability =
   | "thread:write"
   | "automation:write"
   | "diagnostics:read"
+  | "usage:read"
   | "browser:control"
   | "device:control";
 

--- a/apps/server/src/agentGateway/harnessPolicy.test.ts
+++ b/apps/server/src/agentGateway/harnessPolicy.test.ts
@@ -16,6 +16,8 @@ describe("Synara harness policy", () => {
     assert.include(policy, "one exact synara_create_threads plan");
     assert.include(policy, "before returning an operationId");
     assert.include(policy, "synara_wait_for_threads");
+    assert.include(policy, "synara_get_usage");
+    assert.include(policy, "only fresh, available quotaWindows count");
     assert.include(policy, "synara_set_thread_pull_request");
     assert.include(policy, "current thread's own deliverable");
     assert.include(policy, "only reviews, references, or discusses");

--- a/apps/server/src/agentGateway/harnessPolicy.ts
+++ b/apps/server/src/agentGateway/harnessPolicy.ts
@@ -3,7 +3,7 @@ import type { ProviderKind } from "@synara/contracts";
 import { AUTOMATION_AUTHORING_GUIDANCE } from "./automationAuthoringGuidance.ts";
 
 /** Canonical, versioned host policy delivered to every supported provider. */
-export const SYNARA_HARNESS_POLICY_VERSION = "2026-09-03.1";
+export const SYNARA_HARNESS_POLICY_VERSION = "2026-09-08.1";
 export const SYNARA_HARNESS_POLICY_MARKER = `[Synara harness policy ${SYNARA_HARNESS_POLICY_VERSION}]`;
 
 export interface SynaraHarnessCapabilities {
@@ -19,6 +19,7 @@ export function renderSynaraHarnessPolicy(capabilities: SynaraHarnessCapabilitie
   const controlPolicy = capabilities.gatewayControlAvailable
     ? [
         "Use the synara_* tools for Synara threads, projects, automations, and coordination.",
+        "Use synara_get_usage for usage budgets; only fresh, available quotaWindows count.",
         "For any-language requests involving Synara's integrated, embedded, or in-app browser, use browser_* autonomously as its canonical, complete control surface; never substitute Chrome, Computer Use, Playwright, OS-automation tools/skills, or change the user's active chat. Detailed rules live in each tool description.",
         "For any-language iOS app or simulator request, call device_* directly and autonomously as the canonical, complete control surface; never use xcrun simctl, AppleScript, Appium, idb, open Simulator.app, or substitute mobile/OS-automation tools/skills, because the user watches the streamed pane. Detailed rules live in each tool description.",
         "For thread discovery and diagnosis, use synara_list_threads, synara_read_thread, synara_read_thread_activity, synara_read_thread_events, synara_read_thread_runtime_events, and synara_diagnose_thread before SQLite or process logs. Use host storage only when tool coverage says required evidence is unavailable.",
@@ -31,7 +32,7 @@ export function renderSynaraHarnessPolicy(capabilities: SynaraHarnessCapabilitie
         "When results are requested, call synara_wait_for_threads for the created thread ids, wait for every requested result, then synthesize all outcomes.",
         "After synara_create_threads returns an operationId, retries must keep the same requestId and exact plan. Report terminal operation failures as outcomes; do not create replacement threads unless the user gives a new instruction.",
         "Synara automations support heartbeat, standalone, and dedicated modes plus interval, once, daily, weekdays, weekly, and cron schedules. Existing everyMinutes heartbeat calls remain supported. Use fastInterval: true only when the user explicitly accepts a sub-minute bounded loop.",
-        "Mode controls execution: heartbeat appends to an idle target thread; standalone opens a fresh thread per independent run; dedicated reuses one automation-owned thread so runs build on each other without writing into another thread.",
+        "Mode controls execution: heartbeat appends to an idle target; standalone opens a fresh thread per run; dedicated reuses its own thread across runs.",
         "Prefer dedicated for ongoing observation or tracking: standalone runs cannot see prior runs beyond memory, while dedicated keeps one growing thread.",
         'Mode does not restrict stop conditions. completionPolicy {"type":"ai-evaluated","stopWhen":"..."} works in both modes and disables the automation when the clause matches a successful run; prefer it over encoding the stop condition in the prompt. maxIterations remains the backstop, and an automation-dispatched run may always call synara_cancel_automation on its own automation.',
         AUTOMATION_AUTHORING_GUIDANCE,

--- a/apps/server/src/agentGateway/threadReadTools.ts
+++ b/apps/server/src/agentGateway/threadReadTools.ts
@@ -4,6 +4,7 @@ import {
   TurnId,
   type OrchestrationThreadShell,
   type ProviderKind,
+  type ServerAgentProviderUsage,
 } from "@synara/contracts";
 import { Effect, Option } from "effect";
 
@@ -14,6 +15,7 @@ import {
 import type { ProjectionSnapshotQueryShape } from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import type { ProjectionTurnRepositoryShape } from "../persistence/Services/ProjectionTurns.ts";
 import type { ProviderDiscoveryServiceShape } from "../provider/Services/ProviderDiscoveryService.ts";
+import { AGENT_PROVIDER_USAGE_MAX_AGE_MS } from "../providerUsage/agent.ts";
 import { SYNARA_HARNESS_POLICY_VERSION } from "./harnessPolicy.ts";
 import { mcpToolResultError, mcpToolResultJson } from "./protocol.ts";
 import {
@@ -64,6 +66,9 @@ export interface ThreadReadToolsInput {
     threadId: string,
   ) => Effect.Effect<OrchestrationThreadShell, unknown, never>;
   readonly workspacePaths: SpaceAssignmentWorkspacePaths;
+  readonly loadProviderUsage: (
+    provider: ProviderKind,
+  ) => Effect.Effect<ReadonlyArray<ServerAgentProviderUsage>, unknown, never>;
 }
 
 export function makeThreadReadTools(input: ThreadReadToolsInput): ReadonlyArray<ToolEntry> {
@@ -74,6 +79,7 @@ export function makeThreadReadTools(input: ThreadReadToolsInput): ReadonlyArray<
     loadProviderAvailabilities,
     requireThreadShell,
     workspacePaths,
+    loadProviderUsage,
   } = input;
 
   const contextTool: ToolEntry = {
@@ -95,6 +101,28 @@ export function makeThreadReadTools(input: ThreadReadToolsInput): ReadonlyArray<
       Effect.gen(function* () {
         const caller = yield* requireThreadShell(context.callerThreadId);
         const turnId = caller.latestTurn?.state === "running" ? caller.latestTurn.turnId : null;
+        const usageRead = context.callerCapabilities.has("usage:read");
+        const usage = usageRead
+          ? yield* loadProviderUsage(context.callerProvider).pipe(
+              Effect.timeout("3 seconds"),
+              Effect.match({
+                onFailure: () => ({
+                  provider: context.callerProvider,
+                  availability: "unavailable" as const,
+                  unavailableReason: "timed-out" as const,
+                  checkedAt: new Date().toISOString(),
+                  freshness: {
+                    stale: true,
+                    ageMs: 0,
+                    maxAgeMs: AGENT_PROVIDER_USAGE_MAX_AGE_MS,
+                  },
+                  snapshot: null,
+                  quotaWindows: [],
+                }),
+                onSuccess: (results) => results[0] ?? null,
+              }),
+            )
+          : null;
         return mcpToolResultJson({
           harness: { name: "Synara", policyVersion: SYNARA_HARNESS_POLICY_VERSION },
           caller: {
@@ -108,8 +136,28 @@ export function makeThreadReadTools(input: ThreadReadToolsInput): ReadonlyArray<
             threadCreate: turnId !== null && context.callerCapabilities.has("thread:write"),
             threadWait: context.callerCapabilities.has("thread:read"),
             diagnostics: context.callerCapabilities.has("diagnostics:read"),
+            usageRead,
             automations: turnId !== null && context.callerCapabilities.has("automation:write"),
           },
+          usage:
+            usage === null
+              ? {
+                  provider: context.callerProvider,
+                  availability: "unavailable",
+                  unavailableReason: usageRead ? "missing-snapshot" : "not-authorized",
+                }
+              : {
+                  provider: usage.provider,
+                  availability: usage.availability,
+                  ...(usage.unavailableReason
+                    ? { unavailableReason: usage.unavailableReason }
+                    : {}),
+                  checkedAt: usage.checkedAt,
+                  freshness: usage.freshness,
+                  ...(usage.snapshot?.planName ? { planName: usage.snapshot.planName } : {}),
+                  ...(usage.snapshot?.source ? { source: usage.snapshot.source } : {}),
+                  quotaWindows: usage.quotaWindows,
+                },
         });
       }).pipe(Effect.catch((error) => Effect.succeed(mcpToolResultError(errorText(error))))),
   };

--- a/apps/server/src/agentGateway/usageTools.test.ts
+++ b/apps/server/src/agentGateway/usageTools.test.ts
@@ -1,0 +1,96 @@
+import type { ServerAgentProviderUsage } from "@synara/contracts";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+import type { ToolContext } from "./toolRuntime";
+import { makeAgentGatewayUsageTools } from "./usageTools";
+
+const usage: ServerAgentProviderUsage = {
+  provider: "codex",
+  availability: "available",
+  checkedAt: "2026-09-08T18:00:00.000Z",
+  freshness: { stale: false, ageMs: 0, maxAgeMs: 300_000 },
+  snapshot: {
+    provider: "codex",
+    updatedAt: "2026-09-08T18:00:00.000Z",
+    limits: [{ window: "Weekly", usedPercent: 75 }],
+    usageLines: [],
+    source: "codex-usage-api",
+    status: "ok",
+  },
+  quotaWindows: [
+    {
+      window: "Weekly",
+      availability: "available",
+      usedPercent: 75,
+      remainingPercent: 25,
+      source: "codex-usage-api",
+      observedAt: "2026-09-08T18:00:00.000Z",
+    },
+  ],
+};
+
+const context = {
+  principal: {
+    kind: "provider-session",
+    sessionKey: "session",
+    threadId: "thread",
+    provider: "codex",
+    turnId: "turn",
+  },
+  callerThreadId: "thread",
+  callerSessionKey: "session",
+  callerProvider: "codex",
+  callerCapabilities: new Set(["usage:read"]),
+  callerTurnId: "turn",
+  assertCallerTurnActive: () => Effect.void,
+  jsonRpcRequestId: "request",
+} as ToolContext;
+
+function resultJson(result: unknown) {
+  const text = (result as { content: Array<{ text: string }> }).content[0]?.text ?? "null";
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+describe("makeAgentGatewayUsageTools", () => {
+  it("registers both tools behind usage:read", () => {
+    const tools = makeAgentGatewayUsageTools({ loadProviderUsage: () => Effect.succeed([usage]) });
+
+    expect(tools.map((tool) => tool.definition.name)).toEqual([
+      "synara_get_usage",
+      "synara_list_provider_usage",
+    ]);
+    expect(tools.every((tool) => tool.requiredCapability === "usage:read")).toBe(true);
+    expect(tools.every((tool) => tool.definition.annotations?.readOnlyHint === true)).toBe(true);
+  });
+
+  it("scopes synara_get_usage to authenticated caller provider", async () => {
+    let requestedProvider: string | undefined;
+    const [tool] = makeAgentGatewayUsageTools({
+      loadProviderUsage: (provider) => {
+        requestedProvider = provider;
+        return Effect.succeed([usage]);
+      },
+    });
+
+    const result = await Effect.runPromise(tool!.handler({}, context));
+
+    expect(requestedProvider).toBe("codex");
+    expect(resultJson(result).usage).toEqual(usage);
+  });
+
+  it("lists enabled provider results without a caller-selected provider", async () => {
+    let requestedProvider: string | undefined = "not-called";
+    const tools = makeAgentGatewayUsageTools({
+      loadProviderUsage: (provider) => {
+        requestedProvider = provider;
+        return Effect.succeed([usage]);
+      },
+    });
+
+    const result = await Effect.runPromise(tools[1]!.handler({}, context));
+
+    expect(requestedProvider).toBeUndefined();
+    expect(resultJson(result).usage).toEqual([usage]);
+  });
+});

--- a/apps/server/src/agentGateway/usageTools.test.ts
+++ b/apps/server/src/agentGateway/usageTools.test.ts
@@ -1,5 +1,5 @@
 import type { ServerAgentProviderUsage } from "@synara/contracts";
-import { Effect } from "effect";
+import { Duration, Effect } from "effect";
 import { describe, expect, it } from "vitest";
 
 import type { ToolContext } from "./toolRuntime";
@@ -92,5 +92,41 @@ describe("makeAgentGatewayUsageTools", () => {
 
     expect(requestedProvider).toBeUndefined();
     expect(resultJson(result).usage).toEqual([usage]);
+  });
+
+  it("returns timed-out unavailable usage when the caller load stalls", async () => {
+    const [tool] = makeAgentGatewayUsageTools({
+      loadProviderUsage: () => Effect.never,
+      timeout: Duration.millis(10),
+    });
+
+    const result = await Effect.runPromise(tool!.handler({}, context));
+    const timedOut = resultJson(result).usage as Record<string, unknown>;
+
+    expect(timedOut.provider).toBe("codex");
+    expect(timedOut.availability).toBe("unavailable");
+    expect(timedOut.unavailableReason).toBe("timed-out");
+    expect(timedOut.quotaWindows).toEqual([]);
+  });
+
+  it("returns an error result when the list load stalls", async () => {
+    const tools = makeAgentGatewayUsageTools({
+      loadProviderUsage: () => Effect.never,
+      timeout: Duration.millis(10),
+    });
+
+    const result = await Effect.runPromise(tools[1]!.handler({}, context));
+
+    expect(result.isError).toBe(true);
+  });
+
+  it("returns an error result when the load fails", async () => {
+    const [tool] = makeAgentGatewayUsageTools({
+      loadProviderUsage: () => Effect.fail(new Error("boom")),
+    });
+
+    const result = await Effect.runPromise(tool!.handler({}, context));
+
+    expect(result.isError).toBe(true);
   });
 });

--- a/apps/server/src/agentGateway/usageTools.ts
+++ b/apps/server/src/agentGateway/usageTools.ts
@@ -1,0 +1,56 @@
+// FILE: agentGateway/usageTools.ts
+// Purpose: Expose cached, normalized provider quota through caller-scoped read-only MCP tools.
+// Fetching and quota interpretation stay in providerUsage; gateway code only applies authority.
+
+import type { ProviderKind, ServerAgentProviderUsage } from "@synara/contracts";
+import { Effect } from "effect";
+
+import { mcpToolResultError, mcpToolResultJson } from "./protocol.ts";
+import { errorText } from "./toolInput.ts";
+import { READ_ONLY_TOOL_ANNOTATIONS, type ToolEntry } from "./toolRuntime.ts";
+
+export interface AgentGatewayUsageToolsInput {
+  readonly loadProviderUsage: (
+    provider?: ProviderKind,
+  ) => Effect.Effect<ReadonlyArray<ServerAgentProviderUsage>, unknown, never>;
+}
+
+export function makeAgentGatewayUsageTools(
+  input: AgentGatewayUsageToolsInput,
+): ReadonlyArray<ToolEntry> {
+  const getUsage: ToolEntry = {
+    requiredCapability: "usage:read",
+    definition: {
+      name: "synara_get_usage",
+      description:
+        "Read current provider account quota for your own provider. Actionable remaining percentages appear only for fresh authoritative quota windows; unavailable, stale, token, and spend data are never treated as remaining quota.",
+      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      annotations: { title: "Get provider usage", ...READ_ONLY_TOOL_ANNOTATIONS },
+    },
+    handler: (_args, context) =>
+      input.loadProviderUsage(context.callerProvider).pipe(
+        // Caller-scoped load always requests exactly one provider.
+        // Keep an explicit null fallback defensive against future loader changes.
+        Effect.map((usage) => mcpToolResultJson({ usage: usage[0] ?? null })),
+        Effect.catch((error) => Effect.succeed(mcpToolResultError(errorText(error)))),
+      ),
+  };
+
+  const listUsage: ToolEntry = {
+    requiredCapability: "usage:read",
+    definition: {
+      name: "synara_list_provider_usage",
+      description:
+        "List current account-quota snapshots for enabled providers. Each provider and quota window carries provenance, freshness, and explicit unavailable states. Informational token or spend lines are not account quota.",
+      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      annotations: { title: "List provider usage", ...READ_ONLY_TOOL_ANNOTATIONS },
+    },
+    handler: () =>
+      input.loadProviderUsage().pipe(
+        Effect.map((usage) => mcpToolResultJson({ usage })),
+        Effect.catch((error) => Effect.succeed(mcpToolResultError(errorText(error)))),
+      ),
+  };
+
+  return [getUsage, listUsage];
+}

--- a/apps/server/src/agentGateway/usageTools.ts
+++ b/apps/server/src/agentGateway/usageTools.ts
@@ -3,8 +3,9 @@
 // Fetching and quota interpretation stay in providerUsage; gateway code only applies authority.
 
 import type { ProviderKind, ServerAgentProviderUsage } from "@synara/contracts";
-import { Effect } from "effect";
+import { Duration, Effect, Option } from "effect";
 
+import { AGENT_PROVIDER_USAGE_MAX_AGE_MS } from "../providerUsage/agent.ts";
 import { mcpToolResultError, mcpToolResultJson } from "./protocol.ts";
 import { errorText } from "./toolInput.ts";
 import { READ_ONLY_TOOL_ANNOTATIONS, type ToolEntry } from "./toolRuntime.ts";
@@ -13,11 +14,30 @@ export interface AgentGatewayUsageToolsInput {
   readonly loadProviderUsage: (
     provider?: ProviderKind,
   ) => Effect.Effect<ReadonlyArray<ServerAgentProviderUsage>, unknown, never>;
+  /** Override for the stall bound. Production default is {@link USAGE_TOOL_TIMEOUT}. */
+  readonly timeout?: Duration.Input;
+}
+
+// Same bound as synara_context so a stalled provider lookup reports
+// unavailable usage instead of holding the MCP call open.
+const USAGE_TOOL_TIMEOUT = "3 seconds" as const;
+
+function timedOutUsage(provider: ProviderKind): ServerAgentProviderUsage {
+  return {
+    provider,
+    availability: "unavailable",
+    unavailableReason: "timed-out",
+    checkedAt: new Date().toISOString(),
+    freshness: { stale: true, ageMs: 0, maxAgeMs: AGENT_PROVIDER_USAGE_MAX_AGE_MS },
+    snapshot: null,
+    quotaWindows: [],
+  };
 }
 
 export function makeAgentGatewayUsageTools(
   input: AgentGatewayUsageToolsInput,
 ): ReadonlyArray<ToolEntry> {
+  const timeout = input.timeout ?? USAGE_TOOL_TIMEOUT;
   const getUsage: ToolEntry = {
     requiredCapability: "usage:read",
     definition: {
@@ -29,9 +49,17 @@ export function makeAgentGatewayUsageTools(
     },
     handler: (_args, context) =>
       input.loadProviderUsage(context.callerProvider).pipe(
+        Effect.timeoutOption(timeout),
         // Caller-scoped load always requests exactly one provider.
         // Keep an explicit null fallback defensive against future loader changes.
-        Effect.map((usage) => mcpToolResultJson({ usage: usage[0] ?? null })),
+        Effect.map((usage) =>
+          mcpToolResultJson({
+            usage: Option.match(usage, {
+              onNone: () => timedOutUsage(context.callerProvider),
+              onSome: (results) => results[0] ?? null,
+            }),
+          }),
+        ),
         Effect.catch((error) => Effect.succeed(mcpToolResultError(errorText(error)))),
       ),
   };
@@ -47,7 +75,13 @@ export function makeAgentGatewayUsageTools(
     },
     handler: () =>
       input.loadProviderUsage().pipe(
-        Effect.map((usage) => mcpToolResultJson({ usage })),
+        Effect.timeoutOption(timeout),
+        Effect.map((usage) =>
+          Option.match(usage, {
+            onNone: () => mcpToolResultError("Provider usage lookup timed out."),
+            onSome: (results) => mcpToolResultJson({ usage: results }),
+          }),
+        ),
         Effect.catch((error) => Effect.succeed(mcpToolResultError(errorText(error)))),
       ),
   };

--- a/apps/server/src/providerUsage/agent.test.ts
+++ b/apps/server/src/providerUsage/agent.test.ts
@@ -1,0 +1,189 @@
+import type { ProviderKind, ServerProviderUsageSnapshot } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+  AGENT_PROVIDER_USAGE_MAX_AGE_MS,
+  summarizeProviderUsageForAgent,
+  summarizeProviderUsageListForAgent,
+} from "./agent";
+
+const NOW_MS = Date.parse("2026-09-08T18:00:00.000Z");
+
+function snapshot(
+  overrides: Partial<ServerProviderUsageSnapshot> = {},
+): ServerProviderUsageSnapshot {
+  return {
+    provider: "codex",
+    updatedAt: new Date(NOW_MS).toISOString(),
+    limits: [
+      { window: "5h", usedPercent: 40, resetsAt: "2026-09-08T20:00:00.000Z" },
+      { window: "Weekly", usedPercent: 75, resetsAt: "2026-09-12T00:00:00.000Z" },
+    ],
+    usageLines: [{ label: "24h", value: "10K tokens" }],
+    source: "codex-usage-api",
+    status: "ok",
+    ...overrides,
+  };
+}
+
+describe("summarizeProviderUsageForAgent", () => {
+  it("keeps quota windows separate and derives remaining percent with provenance", () => {
+    const result = summarizeProviderUsageForAgent({
+      provider: "codex",
+      enabled: true,
+      snapshot: snapshot(),
+      checkedAtMs: NOW_MS,
+    });
+
+    expect(result.availability).toBe("available");
+    expect(result.quotaWindows).toEqual([
+      {
+        window: "5h",
+        availability: "available",
+        usedPercent: 40,
+        remainingPercent: 60,
+        resetsAt: "2026-09-08T20:00:00.000Z",
+        source: "codex-usage-api",
+        observedAt: "2026-09-08T18:00:00.000Z",
+      },
+      {
+        window: "Weekly",
+        availability: "available",
+        usedPercent: 75,
+        remainingPercent: 25,
+        resetsAt: "2026-09-12T00:00:00.000Z",
+        source: "codex-usage-api",
+        observedAt: "2026-09-08T18:00:00.000Z",
+      },
+    ]);
+    expect(result.snapshot?.usageLines[0]).toMatchObject({
+      value: "10K tokens",
+      source: "codex-usage-api",
+      observedAt: "2026-09-08T18:00:00.000Z",
+    });
+  });
+
+  it("never promotes informational token or spend lines into quota", () => {
+    const result = summarizeProviderUsageForAgent({
+      provider: "codex",
+      enabled: true,
+      snapshot: snapshot({ limits: [] }),
+      checkedAtMs: NOW_MS,
+    });
+
+    expect(result.availability).toBe("unavailable");
+    expect(result.unavailableReason).toBe("missing-quota");
+    expect(result.quotaWindows).toEqual([]);
+    expect(result.snapshot?.usageLines).toHaveLength(1);
+  });
+
+  it("marks unknown and expired limits unavailable instead of exposing percentages", () => {
+    const result = summarizeProviderUsageForAgent({
+      provider: "codex",
+      enabled: true,
+      snapshot: snapshot({
+        limits: [
+          { window: "Unknown", resetsAt: "2026-09-10T00:00:00.000Z" },
+          { window: "Expired", usedPercent: 50, resetsAt: "2026-09-08T17:00:00.000Z" },
+          { window: "Weekly", usedPercent: 10 },
+        ],
+      }),
+      checkedAtMs: NOW_MS,
+    });
+
+    expect(result.availability).toBe("partial");
+    expect(result.quotaWindows[0]).toMatchObject({
+      availability: "unavailable",
+      unavailableReason: "missing-quota",
+    });
+    expect(result.quotaWindows[1]).toMatchObject({
+      availability: "unavailable",
+      unavailableReason: "expired-window",
+    });
+    expect(result.quotaWindows[1]).not.toHaveProperty("remainingPercent");
+    expect(result.quotaWindows[2]).toMatchObject({
+      availability: "available",
+      remainingPercent: 90,
+    });
+  });
+
+  it.each([
+    [{ status: "needs-auth" as const }, "needs-auth"],
+    [{ status: "unsupported" as const }, "unsupported"],
+    [{ status: "error" as const }, "provider-error"],
+    [{ stale: true }, "stale"],
+  ])("maps unavailable snapshot state %j to %s", (overrides, reason) => {
+    const result = summarizeProviderUsageForAgent({
+      provider: "codex",
+      enabled: true,
+      snapshot: snapshot(overrides),
+      checkedAtMs: NOW_MS,
+    });
+
+    expect(result.availability).toBe("unavailable");
+    expect(result.unavailableReason).toBe(reason);
+    expect(result.quotaWindows).toEqual([]);
+  });
+
+  it("rejects snapshots beyond the actionable freshness bound", () => {
+    const result = summarizeProviderUsageForAgent({
+      provider: "codex",
+      enabled: true,
+      snapshot: snapshot({
+        updatedAt: new Date(NOW_MS - AGENT_PROVIDER_USAGE_MAX_AGE_MS - 1).toISOString(),
+      }),
+      checkedAtMs: NOW_MS,
+    });
+
+    expect(result.availability).toBe("unavailable");
+    expect(result.unavailableReason).toBe("stale");
+    expect(result.quotaWindows).toEqual([]);
+  });
+
+  it("reports disabled, missing, and timed-out reads explicitly", () => {
+    expect(
+      summarizeProviderUsageForAgent({
+        provider: "codex",
+        enabled: false,
+        snapshot: null,
+        checkedAtMs: NOW_MS,
+      }).unavailableReason,
+    ).toBe("disabled");
+    expect(
+      summarizeProviderUsageForAgent({
+        provider: "codex",
+        enabled: true,
+        snapshot: null,
+        checkedAtMs: NOW_MS,
+      }).unavailableReason,
+    ).toBe("missing-snapshot");
+    expect(
+      summarizeProviderUsageForAgent({
+        provider: "codex",
+        enabled: true,
+        snapshot: null,
+        timedOut: true,
+        checkedAtMs: NOW_MS,
+      }).unavailableReason,
+    ).toBe("timed-out");
+  });
+});
+
+describe("summarizeProviderUsageListForAgent", () => {
+  it("preserves requested provider order and missing coverage", () => {
+    const providers: ProviderKind[] = ["codex", "claudeAgent", "cursor"];
+    const result = summarizeProviderUsageListForAgent({
+      providers,
+      enabledProviders: new Set(providers),
+      snapshots: [snapshot()],
+      checkedAtMs: NOW_MS,
+    });
+
+    expect(result.map((entry) => entry.provider)).toEqual(providers);
+    expect(result.map((entry) => entry.unavailableReason ?? "available")).toEqual([
+      "available",
+      "missing-snapshot",
+      "missing-snapshot",
+    ]);
+  });
+});

--- a/apps/server/src/providerUsage/agent.ts
+++ b/apps/server/src/providerUsage/agent.ts
@@ -144,7 +144,9 @@ export function summarizeProviderUsageForAgent(input: {
       remainingPercent: Math.max(0, Math.min(100, 100 - limit.usedPercent)),
     };
   });
-  const availableCount = quotaWindows.filter((window) => window.availability === "available").length;
+  const availableCount = quotaWindows.filter(
+    (window) => window.availability === "available",
+  ).length;
   if (availableCount === 0) {
     return {
       provider: input.provider,

--- a/apps/server/src/providerUsage/agent.ts
+++ b/apps/server/src/providerUsage/agent.ts
@@ -1,0 +1,188 @@
+// FILE: providerUsage/agent.ts
+// Purpose: Interpret existing provider-usage snapshots for agents without creating a second
+// accounting source. Only fresh, authoritative percentage limits become actionable quota windows;
+// token totals, spend lines, missing data, and stale observations remain explicitly unavailable.
+
+import type {
+  AgentProviderUsageUnavailableReason,
+  ProviderKind,
+  ServerAgentProviderUsage,
+  ServerAgentProviderUsageWindow,
+  ServerProviderUsageSnapshot,
+} from "@synara/contracts";
+
+export const AGENT_PROVIDER_USAGE_MAX_AGE_MS = 5 * 60 * 1000;
+
+function snapshotUnavailableReason(
+  snapshot: ServerProviderUsageSnapshot,
+): AgentProviderUsageUnavailableReason | null {
+  switch (snapshot.status ?? "ok") {
+    case "needs-auth":
+      return "needs-auth";
+    case "unsupported":
+      return "unsupported";
+    case "error":
+      return "provider-error";
+    case "ok":
+      return null;
+  }
+}
+
+function unavailableResult(input: {
+  provider: ProviderKind;
+  checkedAt: string;
+  reason: AgentProviderUsageUnavailableReason;
+  snapshot: ServerProviderUsageSnapshot | null;
+  ageMs?: number;
+}): ServerAgentProviderUsage {
+  return {
+    provider: input.provider,
+    availability: "unavailable",
+    unavailableReason: input.reason,
+    checkedAt: input.checkedAt,
+    freshness: {
+      stale: input.reason === "stale" || input.snapshot === null,
+      ageMs: input.ageMs ?? 0,
+      maxAgeMs: AGENT_PROVIDER_USAGE_MAX_AGE_MS,
+    },
+    snapshot: input.snapshot,
+    quotaWindows: [],
+  };
+}
+
+/** Pure conversion kept separate from fetching so every transport applies identical safety rules. */
+export function summarizeProviderUsageForAgent(input: {
+  provider: ProviderKind;
+  enabled: boolean;
+  snapshot: ServerProviderUsageSnapshot | null;
+  checkedAtMs?: number;
+  timedOut?: boolean;
+}): ServerAgentProviderUsage {
+  const checkedAtMs = input.checkedAtMs ?? Date.now();
+  const checkedAt = new Date(checkedAtMs).toISOString();
+  if (!input.enabled) {
+    return unavailableResult({
+      provider: input.provider,
+      checkedAt,
+      reason: "disabled",
+      snapshot: null,
+    });
+  }
+  if (input.timedOut) {
+    return unavailableResult({
+      provider: input.provider,
+      checkedAt,
+      reason: "timed-out",
+      snapshot: null,
+    });
+  }
+  if (!input.snapshot) {
+    return unavailableResult({
+      provider: input.provider,
+      checkedAt,
+      reason: "missing-snapshot",
+      snapshot: null,
+    });
+  }
+
+  const originalSnapshot = input.snapshot;
+  const observedAtMs = Date.parse(originalSnapshot.updatedAt);
+  const ageMs = Number.isFinite(observedAtMs) ? Math.max(0, checkedAtMs - observedAtMs) : 0;
+  const snapshot: ServerProviderUsageSnapshot = {
+    ...originalSnapshot,
+    usageLines: originalSnapshot.usageLines.map((line) => ({
+      ...line,
+      source: line.source ?? originalSnapshot.source,
+      observedAt: line.observedAt ?? originalSnapshot.updatedAt,
+    })),
+  };
+  const statusReason = snapshotUnavailableReason(snapshot);
+  if (statusReason) {
+    return unavailableResult({
+      provider: input.provider,
+      checkedAt,
+      reason: statusReason,
+      snapshot,
+      ageMs,
+    });
+  }
+  if (
+    snapshot.stale === true ||
+    !Number.isFinite(observedAtMs) ||
+    ageMs > AGENT_PROVIDER_USAGE_MAX_AGE_MS
+  ) {
+    return unavailableResult({
+      provider: input.provider,
+      checkedAt,
+      reason: "stale",
+      snapshot,
+      ageMs,
+    });
+  }
+
+  const quotaWindows: ServerAgentProviderUsageWindow[] = snapshot.limits.map((limit) => {
+    const common = {
+      window: limit.window,
+      ...(limit.resetsAt ? { resetsAt: limit.resetsAt } : {}),
+      ...(limit.windowDurationMins !== undefined
+        ? { windowDurationMins: limit.windowDurationMins }
+        : {}),
+      source: snapshot.source,
+      observedAt: snapshot.updatedAt,
+    };
+    const resetAtMs = limit.resetsAt ? Date.parse(limit.resetsAt) : null;
+    if (resetAtMs !== null && Number.isFinite(resetAtMs) && resetAtMs <= checkedAtMs) {
+      return { ...common, availability: "unavailable", unavailableReason: "expired-window" };
+    }
+    if (limit.usedPercent === undefined) {
+      return { ...common, availability: "unavailable", unavailableReason: "missing-quota" };
+    }
+    return {
+      ...common,
+      availability: "available",
+      usedPercent: limit.usedPercent,
+      remainingPercent: Math.max(0, Math.min(100, 100 - limit.usedPercent)),
+    };
+  });
+  const availableCount = quotaWindows.filter((window) => window.availability === "available").length;
+  if (availableCount === 0) {
+    return {
+      provider: input.provider,
+      availability: "unavailable",
+      unavailableReason:
+        quotaWindows[0]?.unavailableReason === "expired-window"
+          ? "expired-window"
+          : "missing-quota",
+      checkedAt,
+      freshness: { stale: false, ageMs, maxAgeMs: AGENT_PROVIDER_USAGE_MAX_AGE_MS },
+      snapshot,
+      quotaWindows,
+    };
+  }
+
+  return {
+    provider: input.provider,
+    availability: availableCount === quotaWindows.length ? "available" : "partial",
+    checkedAt,
+    freshness: { stale: false, ageMs, maxAgeMs: AGENT_PROVIDER_USAGE_MAX_AGE_MS },
+    snapshot,
+    quotaWindows,
+  };
+}
+
+export function summarizeProviderUsageListForAgent(input: {
+  providers: ReadonlyArray<ProviderKind>;
+  enabledProviders: ReadonlySet<ProviderKind>;
+  snapshots: ReadonlyArray<ServerProviderUsageSnapshot>;
+  checkedAtMs?: number;
+}): ServerAgentProviderUsage[] {
+  const byProvider = new Map(input.snapshots.map((snapshot) => [snapshot.provider, snapshot]));
+  return input.providers.map((provider) =>
+    summarizeProviderUsageForAgent({
+      provider,
+      enabled: input.enabledProviders.has(provider),
+      snapshot: byProvider.get(provider) ?? null,
+      ...(input.checkedAtMs === undefined ? {} : { checkedAtMs: input.checkedAtMs }),
+    }),
+  );
+}

--- a/apps/server/src/providerUsageSnapshot.ts
+++ b/apps/server/src/providerUsageSnapshot.ts
@@ -658,9 +658,11 @@ async function loadCodexUsageSnapshot(input: {
   const recent7d = sessionSummaries.filter((summary) => summary.timestampMs >= cutoff7d);
   const recent30d = sessionSummaries.filter((summary) => summary.timestampMs >= cutoff30d);
 
+  const updatedAt = toIsoString(latestSummary.timestampMs);
+  const source = "codex-session-archive";
   return {
     provider: "codex",
-    updatedAt: toIsoString(latestSummary.timestampMs),
+    updatedAt,
     limits: latestSummary.limits,
     usageLines: buildUsageLines({
       tokens24h: recent24h.reduce((total, summary) => total + summary.totalTokens, 0),
@@ -669,8 +671,8 @@ async function loadCodexUsageSnapshot(input: {
       sessions24h: recent24h.length,
       sessions7d: recent7d.length,
       sessions30d: recent30d.length,
-    }),
-    source: "codex-session-archive",
+    }).map((line) => ({ ...line, source, observedAt: updatedAt })),
+    source,
   };
 }
 
@@ -704,9 +706,11 @@ async function loadClaudeUsageSnapshot(input: { homeDir: string }): Promise<Usag
     current.timestampMs > latest.timestampMs ? current : latest,
   );
 
+  const updatedAt = toIsoString(latestSample.timestampMs);
+  const source = "claude-project-transcripts";
   return {
     provider: "claudeAgent",
-    updatedAt: toIsoString(latestSample.timestampMs),
+    updatedAt,
     limits: [],
     usageLines: buildUsageLines({
       tokens24h: recent24h.reduce((total, sample) => total + sample.totalTokens, 0),
@@ -715,8 +719,8 @@ async function loadClaudeUsageSnapshot(input: { homeDir: string }): Promise<Usag
       sessions24h: new Set(recent24h.map((sample) => sample.sessionId)).size,
       sessions7d: new Set(recent7d.map((sample) => sample.sessionId)).size,
       sessions30d: new Set(recent30d.map((sample) => sample.sessionId)).size,
-    }),
-    source: "claude-project-transcripts",
+    }).map((line) => ({ ...line, source, observedAt: updatedAt })),
+    source,
   };
 }
 

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -131,6 +131,8 @@ export const ServerProviderUsageLine = Schema.Struct({
   label: TrimmedNonEmptyString,
   value: TrimmedNonEmptyString,
   subtitle: Schema.optional(TrimmedNonEmptyString),
+  source: Schema.optional(TrimmedNonEmptyString),
+  observedAt: Schema.optional(IsoDateTime),
 });
 export type ServerProviderUsageLine = typeof ServerProviderUsageLine.Type;
 
@@ -157,6 +159,61 @@ export const ServerProviderUsageSnapshot = Schema.Struct({
   stale: Schema.optional(Schema.Boolean),
 });
 export type ServerProviderUsageSnapshot = typeof ServerProviderUsageSnapshot.Type;
+
+export const AgentProviderUsageAvailability = Schema.Literals([
+  "available",
+  "partial",
+  "unavailable",
+]);
+export type AgentProviderUsageAvailability = typeof AgentProviderUsageAvailability.Type;
+
+export const AgentProviderUsageUnavailableReason = Schema.Literals([
+  "disabled",
+  "needs-auth",
+  "unsupported",
+  "provider-error",
+  "missing-snapshot",
+  "missing-quota",
+  "stale",
+  "expired-window",
+  "timed-out",
+]);
+export type AgentProviderUsageUnavailableReason = typeof AgentProviderUsageUnavailableReason.Type;
+
+// Agent-facing interpretation of one provider snapshot. The original snapshot remains attached so
+// agents see the same normalized data as Settings, while quotaWindows marks only authoritative
+// account-quota percentages as actionable. usageLines are informational and never become quota.
+export const ServerAgentProviderUsageWindow = Schema.Struct({
+  window: TrimmedNonEmptyString,
+  availability: Schema.Literals(["available", "unavailable"]),
+  usedPercent: Schema.optional(
+    Schema.Number.check(Schema.isGreaterThanOrEqualTo(0)).check(Schema.isLessThanOrEqualTo(100)),
+  ),
+  remainingPercent: Schema.optional(
+    Schema.Number.check(Schema.isGreaterThanOrEqualTo(0)).check(Schema.isLessThanOrEqualTo(100)),
+  ),
+  resetsAt: Schema.optional(IsoDateTime),
+  windowDurationMins: Schema.optional(NonNegativeInt),
+  unavailableReason: Schema.optional(AgentProviderUsageUnavailableReason),
+  source: TrimmedNonEmptyString,
+  observedAt: IsoDateTime,
+});
+export type ServerAgentProviderUsageWindow = typeof ServerAgentProviderUsageWindow.Type;
+
+export const ServerAgentProviderUsage = Schema.Struct({
+  provider: ProviderKind,
+  availability: AgentProviderUsageAvailability,
+  unavailableReason: Schema.optional(AgentProviderUsageUnavailableReason),
+  checkedAt: IsoDateTime,
+  freshness: Schema.Struct({
+    stale: Schema.Boolean,
+    ageMs: NonNegativeInt,
+    maxAgeMs: NonNegativeInt,
+  }),
+  snapshot: Schema.NullOr(ServerProviderUsageSnapshot),
+  quotaWindows: Schema.Array(ServerAgentProviderUsageWindow),
+});
+export type ServerAgentProviderUsage = typeof ServerAgentProviderUsage.Type;
 
 export const ServerGetProviderUsageSnapshotInput = Schema.Struct({
   provider: ProviderKind,


### PR DESCRIPTION
Superseded by #1076, which now includes this PR's review-fix commit with its original authorship preserved. The original feature and these fixes are delivered together on the original contributor PR.

The consolidated implementation also fixes partial-list timeout handling, validates quota freshness at response time, and rejects future-dated observations. See #1076 for the current code, regression tests, review, and CI results.

This draft is closed to avoid merging the same feature twice. Closing it does not indicate that #1076 has merged.
