### PR TITLE
feat(codex): add configurable CLI launch args for app-server

### DIFF
--- a/apps/marketing/content/docs/features/customization.mdx
+++ b/apps/marketing/content/docs/features/customization.mdx
@@ -18,6 +18,7 @@ UI density controls trade whitespace for information. Sidebar sections can be to
 - **Order**: drag providers into a custom order in settings — the composer, sidebar, and search palette follow it.
 - **Favorites**: star models in the picker to float your picks above large Codex/Cursor/OpenCode catalogs.
 - **Custom binaries**: point Synara at your own provider executable (a specific Codex or Claude Code install) instead of the default path.
+- **Codex launch args**: optional extra CLI flags inserted before `codex app-server`, for custom model providers or other Codex CLI overrides.
 - **Usage panels**: usage and pace appear in the chat Environment panel and settings for every enabled provider whose authenticated runtime exposes verifiable account data.
 - **Update checks**: background provider CLI version checks can be disabled with the `enableProviderUpdateChecks` setting.
 

--- a/apps/marketing/content/docs/providers/codex.mdx
+++ b/apps/marketing/content/docs/providers/codex.mdx
@@ -114,6 +114,8 @@ Codex keeps its own configuration, normally under `~/.codex/config.toml` or `$CO
 
 Changing the Codex model provider, authentication environment, sandbox rules, or approval settings can change what Synara sees. Keep provider configuration in Codex rather than duplicating secrets in Synara.
 
+To pass extra flags when Synara starts `codex app-server`, set **Codex launch args** in provider settings. Those tokens are inserted before `app-server`. An unquoted `--` sends the remaining tokens after `app-server`. Current Codex CLI builds reject `--profile` for `app-server`; use `-c` overrides instead, for example `-c model_provider="apitoken"`.
+
 ## Updating
 
 Update through the installation method you used:

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -38,6 +38,7 @@ import { prewarmChatGptVoiceTranscriptionConnection } from "@synara/shared/chatG
 import { getModelSelectionBooleanOptionValue, normalizeModelSlug } from "@synara/shared/model";
 import { decodeSubagentReceiverThreadIds } from "@synara/shared/subagents";
 import { spawnProcess } from "@synara/shared/processRuntime";
+import { buildCodexAppServerArgs } from "@synara/shared/providerLaunchArgs";
 import { Effect, ServiceMap } from "effect";
 
 import {
@@ -713,8 +714,9 @@ function spawnCodexAppServer(input: {
   readonly binaryPath: string;
   readonly cwd: string;
   readonly env: NodeJS.ProcessEnv;
+  readonly launchArgs?: string;
 }): ChildProcessWithoutNullStreams {
-  return spawnProcess(input.binaryPath, ["app-server"], {
+  return spawnProcess(input.binaryPath, buildCodexAppServerArgs(input.launchArgs), {
     requireExecutable: true,
     cwd: input.cwd,
     env: input.env,
@@ -1066,6 +1068,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       const codexOptions = readCodexProviderOptions(input);
       const codexBinaryPath = codexOptions.binaryPath ?? "codex";
       const codexHomePath = codexOptions.homePath;
+      const codexLaunchArgs = codexOptions.launchArgs;
       await this.assertSupportedCodexCliVersion({
         binaryPath: codexBinaryPath,
         cwd: resolvedCwd,
@@ -1082,6 +1085,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
           codexHomePath,
           gatewaySessionLease?.connection.bearerToken,
         ),
+        ...(codexLaunchArgs ? { launchArgs: codexLaunchArgs } : {}),
       });
 
       context = {
@@ -1867,6 +1871,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       });
       const codexBinaryPath = codexOptions.binaryPath ?? "codex";
       const codexHomePath = codexOptions.homePath;
+      const codexLaunchArgs = codexOptions.launchArgs;
       await this.assertSupportedCodexCliVersion({
         binaryPath: codexBinaryPath,
         cwd: resolvedCwd,
@@ -1883,6 +1888,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
           codexHomePath,
           gatewaySessionLease?.connection.bearerToken,
         ),
+        ...(codexLaunchArgs ? { launchArgs: codexLaunchArgs } : {}),
       });
 
       context = {
@@ -4077,6 +4083,7 @@ function normalizeProviderThreadId(value: string | undefined): string | undefine
 function readCodexProviderOptions(input: CodexAppServerStartSessionInput): {
   readonly binaryPath?: string;
   readonly homePath?: string;
+  readonly launchArgs?: string;
 } {
   const options = input.providerOptions?.codex;
   if (!options) {
@@ -4085,6 +4092,7 @@ function readCodexProviderOptions(input: CodexAppServerStartSessionInput): {
   return {
     ...(options.binaryPath ? { binaryPath: options.binaryPath } : {}),
     ...(options.homePath ? { homePath: options.homePath } : {}),
+    ...(options.launchArgs?.trim() ? { launchArgs: options.launchArgs.trim() } : {}),
   };
 }
 

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -31,6 +31,7 @@ describe("ServerSettingsService", () => {
     );
 
     expect(settings.providers.codex.binaryPath).toBe("codex");
+    expect(settings.providers.codex.launchArgs).toBe("");
     expect(settings.providers.grok.binaryPath).toBe("grok");
     expect(settings.defaultThreadEnvMode).toBe("local");
     expect(settings.enableProviderUpdateChecks).toBe(true);

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -136,6 +136,15 @@ describe("server-backed provider enablement", () => {
     expect(patch.providers).toBeUndefined();
   });
 
+  it("maps Codex launch args into the server provider patch", () => {
+    const patch = appSettingsPatchToServerSettingsPatch({
+      codexLaunchArgs: '-c model_provider="apitoken"',
+    });
+    expect(patch.providers?.codex).toEqual({
+      launchArgs: '-c model_provider="apitoken"',
+    });
+  });
+
   it("invalidates discovery for initial and changed streamed provider settings", () => {
     const disabledOpenCode = {
       ...DEFAULT_SERVER_SETTINGS_VIEW,
@@ -668,6 +677,7 @@ describe("getProviderStartOptions", () => {
         claudeBinaryPath: "/usr/local/bin/claude",
         codexBinaryPath: "",
         codexHomePath: "/Users/you/.codex",
+        codexLaunchArgs: "",
         cursorApiEndpoint: "http://localhost:3000",
         cursorBinaryPath: "/usr/local/bin/agent",
         antigravityBinaryPath: "/usr/local/bin/agy",
@@ -709,6 +719,7 @@ describe("getProviderStartOptions", () => {
         claudeBinaryPath: "",
         codexBinaryPath: "",
         codexHomePath: "",
+        codexLaunchArgs: "",
         cursorApiEndpoint: "",
         cursorBinaryPath: "",
         antigravityBinaryPath: "",
@@ -724,12 +735,39 @@ describe("getProviderStartOptions", () => {
     ).toBeUndefined();
   });
 
+  it("includes Codex launch args without requiring a custom binary", () => {
+    expect(
+      getProviderStartOptions({
+        claudeBinaryPath: "",
+        codexBinaryPath: "",
+        codexHomePath: "",
+        codexLaunchArgs: '-c model_provider="apitoken"',
+        cursorApiEndpoint: "",
+        cursorBinaryPath: "",
+        antigravityBinaryPath: "",
+        grokBinaryPath: "",
+        droidBinaryPath: "",
+        openCodeBinaryPath: "",
+        openCodeExperimentalWebSockets: false,
+        openCodeServerUrl: "",
+        piAgentDir: "",
+        piBinaryPath: "",
+        devinBinaryPath: "",
+      }),
+    ).toEqual({
+      codex: {
+        launchArgs: '-c model_provider="apitoken"',
+      },
+    });
+  });
+
   it("ignores default provider command names as custom binary overrides", () => {
     expect(
       getProviderStartOptions({
         claudeBinaryPath: "claude",
         codexBinaryPath: "codex",
         codexHomePath: "",
+        codexLaunchArgs: "",
         cursorApiEndpoint: "",
         cursorBinaryPath: "cursor-agent",
         antigravityBinaryPath: "agy",

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -264,6 +264,7 @@ export const AppSettingsSchema = Schema.Struct({
   ),
   codexBinaryPath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
   codexHomePath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
+  codexLaunchArgs: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
   cursorBinaryPath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
   cursorApiEndpoint: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
   devinBinaryPath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
@@ -673,6 +674,7 @@ function serverSettingsToAppSettings(settings: ServerSettingsView): Partial<AppS
     claudeBinaryPath: settings.providers.claudeAgent.binaryPath,
     codexBinaryPath: settings.providers.codex.binaryPath,
     codexHomePath: settings.providers.codex.homePath,
+    codexLaunchArgs: settings.providers.codex.launchArgs,
     cursorApiEndpoint: settings.providers.cursor.apiEndpoint,
     cursorBinaryPath: settings.providers.cursor.binaryPath,
     devinBinaryPath: settings.providers.devin.binaryPath,
@@ -793,11 +795,13 @@ export function appSettingsPatchToServerSettingsPatch(
   if (
     hasOwn(patch, "codexBinaryPath") ||
     hasOwn(patch, "codexHomePath") ||
+    hasOwn(patch, "codexLaunchArgs") ||
     hasOwn(patch, "customCodexModels")
   ) {
     providers.codex = {
       ...(hasOwn(patch, "codexBinaryPath") ? { binaryPath: patch.codexBinaryPath ?? "" } : {}),
       ...(hasOwn(patch, "codexHomePath") ? { homePath: patch.codexHomePath ?? "" } : {}),
+      ...(hasOwn(patch, "codexLaunchArgs") ? { launchArgs: patch.codexLaunchArgs ?? "" } : {}),
       ...(hasOwn(patch, "customCodexModels")
         ? { customModels: patch.customCodexModels ?? [] }
         : {}),
@@ -927,6 +931,7 @@ function buildInitialServerSettingsMigrationPatch(settings: AppSettings): Server
     "claudeBinaryPath",
     "codexBinaryPath",
     "codexHomePath",
+    "codexLaunchArgs",
     "cursorApiEndpoint",
     "cursorBinaryPath",
     "defaultThreadEnvMode",
@@ -1177,6 +1182,7 @@ export function getProviderStartOptions(
     | "claudeBinaryPath"
     | "codexBinaryPath"
     | "codexHomePath"
+    | "codexLaunchArgs"
     | "cursorApiEndpoint"
     | "cursorBinaryPath"
     | "devinBinaryPath"
@@ -1208,15 +1214,17 @@ export function getProviderStartOptions(
     settings.openCodeBinaryPath,
   );
   const piBinaryPath = normalizeProviderBinaryPathOverride("pi", settings.piBinaryPath);
+  const codexLaunchArgs = settings.codexLaunchArgs.trim();
   const hasOpenCodeStartOptions = Boolean(
     openCodeBinaryPath || settings.openCodeExperimentalWebSockets || settings.openCodeServerUrl,
   );
   const providerOptions: ProviderStartOptions = {
-    ...(codexBinaryPath || settings.codexHomePath
+    ...(codexBinaryPath || settings.codexHomePath || codexLaunchArgs
       ? {
           codex: {
             ...(codexBinaryPath ? { binaryPath: codexBinaryPath } : {}),
             ...(settings.codexHomePath ? { homePath: settings.codexHomePath } : {}),
+            ...(codexLaunchArgs ? { launchArgs: codexLaunchArgs } : {}),
           },
         }
       : {}),

--- a/apps/web/src/components/settings/ProvidersSettingsPanel.test.ts
+++ b/apps/web/src/components/settings/ProvidersSettingsPanel.test.ts
@@ -14,6 +14,7 @@ describe("isProviderInstallSettingsDirty", () => {
     const dirtyPatches = [
       { codexBinaryPath: "/opt/codex" },
       { codexHomePath: "/tmp/codex-home" },
+      { codexLaunchArgs: '-c model_provider="apitoken"' },
       { claudeBinaryPath: "/opt/claude" },
       { cursorBinaryPath: "/opt/cursor" },
       { cursorApiEndpoint: "https://cursor.example" },
@@ -60,6 +61,7 @@ describe("createProviderInstallResetPatch", () => {
         "claudeBinaryPath",
         "codexBinaryPath",
         "codexHomePath",
+        "codexLaunchArgs",
         "cursorApiEndpoint",
         "cursorBinaryPath",
         "devinBinaryPath",

--- a/apps/web/src/components/settings/ProvidersSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProvidersSettingsPanel.tsx
@@ -74,6 +74,7 @@ type ProviderInstallTextKey =
   | "claudeBinaryPath"
   | "codexBinaryPath"
   | "codexHomePath"
+  | "codexLaunchArgs"
   | "cursorBinaryPath"
   | "cursorApiEndpoint"
   | "devinBinaryPath"
@@ -151,6 +152,19 @@ const PROVIDER_INSTALL_SETTINGS: readonly ProviderInstallSettings[] = [
         label: "CODEX_HOME path",
         placeholder: "CODEX_HOME",
         description: "Optional custom Codex home and config directory.",
+      },
+      {
+        kind: "text",
+        settingsKey: "codexLaunchArgs",
+        label: "Codex launch args",
+        placeholder: '-c model_provider="apitoken"',
+        description: (
+          <>
+            Extra CLI flags inserted before <code>app-server</code>. Tokens after an unquoted{" "}
+            <code>--</code> are appended after <code>app-server</code>. Example:{" "}
+            <code>-c model_provider=&quot;apitoken&quot;</code>.
+          </>
+        ),
       },
     ],
   },

--- a/apps/web/src/providerUpdates.test.ts
+++ b/apps/web/src/providerUpdates.test.ts
@@ -60,7 +60,7 @@ function serverSettings(overrides: Partial<ServerSettings["providers"]> = {}): S
     addProjectBaseDirectory: "",
     textGenerationModelSelection: { provider: "codex", model: "gpt-5.4-mini" },
     providers: {
-      codex: { ...provider, binaryPath: "codex", homePath: "" },
+      codex: { ...provider, binaryPath: "codex", homePath: "", launchArgs: "" },
       claudeAgent: { ...provider, binaryPath: "claude", launchArgs: "" },
       cursor: { ...provider, binaryPath: "cursor-agent", apiEndpoint: "" },
       devin: { ...provider, binaryPath: "devin" },
@@ -220,7 +220,13 @@ describe("shouldShowProviderUpdateStatus", () => {
     const codex = providerStatus("codex");
     const hiddenPi = providerStatus("pi");
     const settings = serverSettings({
-      codex: { enabled: false, binaryPath: "codex", homePath: "", customModels: [] },
+      codex: {
+        enabled: false,
+        binaryPath: "codex",
+        homePath: "",
+        launchArgs: "",
+        customModels: [],
+      },
     });
 
     expect(

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -304,7 +304,13 @@ describe("wsNativeApi", () => {
         addProjectBaseDirectory: "",
         textGenerationModelSelection: { provider: "codex", model: "gpt-5.4-mini" },
         providers: {
-          codex: { enabled: true, binaryPath: "codex", homePath: "", customModels: [] },
+          codex: {
+            enabled: true,
+            binaryPath: "codex",
+            homePath: "",
+            launchArgs: "",
+            customModels: [],
+          },
           claudeAgent: { enabled: true, binaryPath: "claude", launchArgs: "", customModels: [] },
           cursor: { enabled: false, binaryPath: "agent", apiEndpoint: "", customModels: [] },
           devin: { enabled: true, binaryPath: "devin", customModels: [] },

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -189,6 +189,7 @@ export type ModelSelection = typeof ModelSelection.Type;
 export const CodexProviderStartOptions = Schema.Struct({
   binaryPath: Schema.optional(TrimmedNonEmptyString),
   homePath: Schema.optional(TrimmedNonEmptyString),
+  launchArgs: Schema.optional(TrimmedNonEmptyString),
 });
 
 export const ClaudeProviderStartOptions = Schema.Struct({

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -18,6 +18,9 @@ export const CodexServerProviderSettings = Schema.Struct({
   ...ProviderSettingsBase,
   binaryPath: StringSetting.pipe(Schema.withDecodingDefault(() => "codex")),
   homePath: StringSetting.pipe(Schema.withDecodingDefault(() => "")),
+  launchArgs: Schema.String.check(Schema.isMaxLength(4096)).pipe(
+    Schema.withDecodingDefault(() => ""),
+  ),
 });
 export type CodexServerProviderSettings = typeof CodexServerProviderSettings.Type;
 
@@ -149,6 +152,7 @@ export const ServerSettingsPatch = Schema.Struct({
         Schema.Struct({
           ...ProviderSettingsBasePatch,
           homePath: Schema.optionalKey(StringSetting),
+          launchArgs: Schema.optionalKey(Schema.String.check(Schema.isMaxLength(4096))),
         }),
       ),
       claudeAgent: Schema.optionalKey(

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -64,6 +64,10 @@
       "types": "./src/processRuntime.ts",
       "import": "./src/processRuntime.ts"
     },
+    "./providerLaunchArgs": {
+      "types": "./src/providerLaunchArgs.ts",
+      "import": "./src/providerLaunchArgs.ts"
+    },
     "./filesystemPlatform": {
       "types": "./src/filesystemPlatform.ts",
       "import": "./src/filesystemPlatform.ts"

--- a/packages/shared/src/providerLaunchArgs.test.ts
+++ b/packages/shared/src/providerLaunchArgs.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  ProviderLaunchArgsError,
+  buildCodexAppServerArgs,
+  parseProviderLaunchArgs,
+} from "./providerLaunchArgs";
+
+describe("parseProviderLaunchArgs", () => {
+  it("returns empty sides for blank input", () => {
+    expect(parseProviderLaunchArgs("")).toEqual({ prefix: [], suffix: [] });
+    expect(parseProviderLaunchArgs("   ")).toEqual({ prefix: [], suffix: [] });
+  });
+
+  it("tokenizes quoted values and escaped spaces", () => {
+    expect(
+      parseProviderLaunchArgs(`-c model_provider="apitoken" -c 'model="gpt-6-astra"'`),
+    ).toEqual({
+      prefix: ["-c", "model_provider=apitoken", "-c", 'model="gpt-6-astra"'],
+      suffix: [],
+    });
+    expect(parseProviderLaunchArgs(`--config model="gpt 6"`)).toEqual({
+      prefix: ["--config", "model=gpt 6"],
+      suffix: [],
+    });
+  });
+
+  it("splits unquoted -- into prefix and suffix", () => {
+    expect(parseProviderLaunchArgs(`--profile apitoken -- -c notify=[]`)).toEqual({
+      prefix: ["--profile", "apitoken"],
+      suffix: ["-c", "notify=[]"],
+    });
+  });
+
+  it("rejects unmatched quotes and dangling escapes", () => {
+    expect(() => parseProviderLaunchArgs(`-c model="gpt`)).toThrow(ProviderLaunchArgsError);
+    expect(() => parseProviderLaunchArgs(`-c model=gpt\\`)).toThrow(ProviderLaunchArgsError);
+  });
+});
+
+describe("buildCodexAppServerArgs", () => {
+  it("spawns a bare app-server when launch args are empty", () => {
+    expect(buildCodexAppServerArgs()).toEqual(["app-server"]);
+    expect(buildCodexAppServerArgs("")).toEqual(["app-server"]);
+  });
+
+  it("inserts global flags before app-server", () => {
+    expect(buildCodexAppServerArgs(`-c model_provider="apitoken"`)).toEqual([
+      "-c",
+      "model_provider=apitoken",
+      "app-server",
+    ]);
+  });
+
+  it("appends tokens after -- to the app-server subcommand", () => {
+    expect(buildCodexAppServerArgs(`-c model_provider="apitoken" -- --listen stdio://`)).toEqual([
+      "-c",
+      "model_provider=apitoken",
+      "app-server",
+      "--listen",
+      "stdio://",
+    ]);
+  });
+});

--- a/packages/shared/src/providerLaunchArgs.ts
+++ b/packages/shared/src/providerLaunchArgs.ts
@@ -1,0 +1,95 @@
+// FILE: providerLaunchArgs.ts
+// Purpose: Parse user-supplied provider CLI launch args into argv tokens.
+// Layer: Shared runtime utility
+// Exports: ProviderLaunchArgsError, parseProviderLaunchArgs, buildCodexAppServerArgs
+
+export class ProviderLaunchArgsError extends Error {
+  readonly _tag = "ProviderLaunchArgsError";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "ProviderLaunchArgsError";
+  }
+}
+
+export interface ParsedProviderLaunchArgs {
+  readonly prefix: readonly string[];
+  readonly suffix: readonly string[];
+}
+
+/**
+ * Tokenize a launch-args string with POSIX-style quoting.
+ *
+ * An unquoted `--` splits global flags (inserted before the provider subcommand)
+ * from subcommand flags (appended after it).
+ */
+export function parseProviderLaunchArgs(input: string): ParsedProviderLaunchArgs {
+  const tokens = tokenizeProviderLaunchArgs(input);
+  const separator = tokens.indexOf("--");
+  if (separator === -1) {
+    return { prefix: tokens, suffix: [] };
+  }
+  return {
+    prefix: tokens.slice(0, separator),
+    suffix: tokens.slice(separator + 1),
+  };
+}
+
+/** Build `codex <prefix> app-server <suffix>` from an optional launch-args string. */
+export function buildCodexAppServerArgs(launchArgs?: string): string[] {
+  const { prefix, suffix } = parseProviderLaunchArgs(launchArgs ?? "");
+  return [...prefix, "app-server", ...suffix];
+}
+
+function tokenizeProviderLaunchArgs(input: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escapeNext = false;
+
+  for (const char of input.trim()) {
+    if (escapeNext) {
+      current += char;
+      escapeNext = false;
+      continue;
+    }
+    if (char === "\\") {
+      escapeNext = quote !== "'";
+      if (!escapeNext) {
+        current += char;
+      }
+      continue;
+    }
+    if (quote !== null) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (escapeNext) {
+    throw new ProviderLaunchArgsError("Codex launch args end with a dangling backslash.");
+  }
+  if (quote !== null) {
+    throw new ProviderLaunchArgsError(`Codex launch args have an unmatched ${quote} quote.`);
+  }
+  if (current.length > 0) {
+    tokens.push(current);
+  }
+  return tokens;
+}

--- a/packages/shared/src/serverSettings.test.ts
+++ b/packages/shared/src/serverSettings.test.ts
@@ -14,6 +14,7 @@ describe("providerStartOptionsFromServerSettings", () => {
           ...DEFAULT_SERVER_SETTINGS.providers.codex,
           binaryPath: "",
           homePath: "",
+          launchArgs: "",
         },
         claudeAgent: {
           ...DEFAULT_SERVER_SETTINGS.providers.claudeAgent,
@@ -83,6 +84,7 @@ describe("providerStartOptionsFromServerSettings", () => {
           ...DEFAULT_SERVER_SETTINGS.providers.codex,
           binaryPath: "/custom/bin/codex",
           homePath: "/custom/codex-home",
+          launchArgs: '-c model_provider="apitoken"',
         },
         opencode: {
           ...DEFAULT_SERVER_SETTINGS.providers.opencode,
@@ -102,6 +104,7 @@ describe("providerStartOptionsFromServerSettings", () => {
     expect(providerOptions.codex).toEqual({
       binaryPath: "/custom/bin/codex",
       homePath: "/custom/codex-home",
+      launchArgs: '-c model_provider="apitoken"',
     });
     expect(providerOptions.opencode).toEqual({
       binaryPath: "/custom/bin/opencode",

--- a/packages/shared/src/serverSettings.ts
+++ b/packages/shared/src/serverSettings.ts
@@ -54,6 +54,9 @@ export function providerStartOptionsFromServerSettings(
     codex: {
       ...(providers.codex.binaryPath ? { binaryPath: providers.codex.binaryPath } : {}),
       ...(providers.codex.homePath ? { homePath: providers.codex.homePath } : {}),
+      ...(providers.codex.launchArgs.trim()
+        ? { launchArgs: providers.codex.launchArgs.trim() }
+        : {}),
     },
     claudeAgent: {
       ...(providers.claudeAgent.binaryPath ? { binaryPath: providers.claudeAgent.binaryPath } : {}),


### PR DESCRIPTION
## What Changed

Add a Codex **launch args** setting so Synara can start `codex app-server` with extra CLI flags.

- Persist `providers.codex.launchArgs` in server settings (same 4096-char string shape as Claude's unused `launchArgs` field).
- Parse the string with POSIX quoting. Tokens are inserted **before** `app-server`. An unquoted `--` sends the remaining tokens **after** `app-server`.
- Wire the value through provider start options into both Codex session start paths. Health probes and discovery sessions are unchanged.
- Surface the field in provider settings and document it.

Example:

```
-c model_provider="apitoken"
```

becomes:

```
codex -c model_provider=apitoken app-server
```

Invalid quoting fails the session start with a clear error instead of silently splitting tokens.

## Why

Synara currently has no extra-args field for Codex. The only workaround is a custom wrapper binary. Users who route Codex through a custom `model_provider` (or other `-c` overrides) need those flags on the `app-server` process Synara actually spawns.

Current Codex CLI builds reject `--profile` for `app-server` and `login`. This PR does not invent a profile workaround; it exposes the flags Codex does accept. `--profile` can still be typed, but it will fail at spawn until Codex supports it on `app-server`.

## UI Changes

Settings → Providers → Codex gains a **Codex launch args** text field under the existing binary path and `CODEX_HOME` fields. It uses the same debounced text input as the other provider install fields.

I could not capture a screenshot of this branch's settings UI from the packaged app in this environment. The control is a standard settings text row: label, placeholder `-c model_provider="apitoken"`, and a short description of the `--` split.

## Verification

- `bun run fmt`
- `bun run lint` (pre-existing warnings only)
- `bun run typecheck`
- `bun run --cwd packages/shared test src/providerLaunchArgs.test.ts src/serverSettings.test.ts`
- `bun run --cwd apps/server test src/serverSettings.test.ts`
- `bun run test:web:focused src/appSettings.test.ts src/components/settings/ProvidersSettingsPanel.test.ts src/providerUpdates.test.ts src/wsNativeApi.test.ts`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes — not applicable (static text field)