### PR TITLE
feat(voice): configurable Groq speech-to-text independent of the coding harness

### DIFF
--- a/apps/server/src/authEffectRoute.test.ts
+++ b/apps/server/src/authEffectRoute.test.ts
@@ -396,6 +396,60 @@ describe("binaryUploadEffectRouteLayer", () => {
     );
   });
 
+  it("transcribes through Groq when Codex is disabled", async () => {
+    vi.stubEnv("GROQ_API_KEY", "gsk_test");
+    const transcribeVoice = vi.fn(() => Effect.succeed({ text: "unexpected" }));
+    const { outboundHttp } = await import("@synara/shared/outboundHttp");
+    const request = vi.spyOn(outboundHttp, "request").mockResolvedValue({
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      body: new TextEncoder().encode(JSON.stringify({ text: "groq dictation" })),
+      url: "https://api.groq.com/openai/v1/audio/transcriptions",
+    });
+    try {
+      await withAuthEffectServer(
+        { host: "127.0.0.1", publicUrl: undefined } as ServerConfigShape,
+        makeServerAuth({ count: 0 }),
+        async (serverOrigin) => {
+          const params = new URLSearchParams({
+            provider: "codex",
+            cwd: "/tmp/project",
+            mimeType: "audio/wav",
+            sampleRateHz: "24000",
+            durationMs: "1000",
+          });
+          const response = await fetch(
+            `${serverOrigin}${VOICE_TRANSCRIPTION_UPLOAD_ROUTE_PATH}?${params.toString()}`,
+            {
+              method: "POST",
+              headers: { Authorization: "Bearer bearer-token" },
+              body: Buffer.from("RIFF0000WAVE", "ascii"),
+            },
+          );
+
+          expect(response.status).toBe(200);
+          await expect(response.json()).resolves.toEqual({ text: "groq dictation" });
+          expect(transcribeVoice).not.toHaveBeenCalled();
+          expect(request).toHaveBeenCalledTimes(1);
+        },
+        binaryUploadEffectRouteLayer,
+        {
+          providerAdapterRegistry: {
+            getByProvider: () => Effect.succeed({ provider: "codex", transcribeVoice } as never),
+            listProviders: () => Effect.succeed(["codex"]),
+          },
+          serverSettingsLayer: ServerSettingsService.layerTest({
+            voiceTranscription: { provider: "groq" },
+            providers: { codex: { enabled: false } },
+          }),
+        },
+      );
+    } finally {
+      vi.unstubAllEnvs();
+      request.mockRestore();
+    }
+  });
+
   it("allows credentialed Canary attachment upload preflights", async () => {
     const config = {
       host: "127.0.0.1",

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -39,7 +39,7 @@ import { ProjectFaviconResolver } from "./project/Services/ProjectFaviconResolve
 import { OrchestrationEngineService } from "./orchestration/Services/OrchestrationEngine";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery";
 import { ProviderAdapterRegistry } from "./provider/Services/ProviderAdapterRegistry";
-import { getEnabledProviderAdapter } from "./provider/enabledProviderAdapter";
+import { transcribeConfiguredVoice } from "./voiceTranscriptionDispatch";
 import { threadArchiveChunks, threadArchiveFileName } from "./orchestration/exportThreadArchive";
 import type { ServerReadiness } from "./server/readiness";
 import { ServerSettingsService } from "./serverSettings";
@@ -997,22 +997,19 @@ const binaryUploadEffectHandler = Effect.gen(function* () {
       const bytes = yield* readEffectBinary(request, SERVER_VOICE_TRANSCRIPTION_MAX_AUDIO_BYTES);
       const registry = yield* ProviderAdapterRegistry;
       const serverSettings = yield* ServerSettingsService;
-      const adapter = yield* getEnabledProviderAdapter(provider as never, serverSettings, registry);
-      if (!adapter.transcribeVoice) {
-        return HttpServerResponse.jsonUnsafe(
-          { error: `Voice transcription is unavailable for provider '${provider}'.` },
-          { status: 400, headers: corsHeaders },
-        );
-      }
-      const result = yield* adapter.transcribeVoice({
-        provider: provider as never,
-        cwd,
-        ...(threadId ? { threadId: ThreadId.makeUnsafe(threadId) } : {}),
-        mimeType,
-        sampleRateHz,
-        durationMs,
-        audioBase64: Buffer.from(bytes).toString("base64"),
-      });
+      const result = yield* transcribeConfiguredVoice(
+        {
+          provider: provider as never,
+          cwd,
+          ...(threadId ? { threadId: ThreadId.makeUnsafe(threadId) } : {}),
+          mimeType,
+          sampleRateHz,
+          durationMs,
+          audioBase64: Buffer.from(bytes).toString("base64"),
+        },
+        serverSettings,
+        registry,
+      );
       return HttpServerResponse.jsonUnsafe(result, { status: 200, headers: corsHeaders });
     }).pipe(Effect.ensuring(Effect.sync(releaseUpload)));
   }

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -204,6 +204,44 @@ describe("ServerSettingsService", () => {
     expect(result.persisted).not.toContain("opencode-secret");
   });
 
+  it("keeps the Groq voice API key server-only and independent of coding providers", async () => {
+    const result = await runWithSettings(
+      Effect.gen(function* () {
+        const service = yield* ServerSettingsService;
+        const { settingsPath } = yield* ServerConfig;
+        const fs = yield* FileSystem.FileSystem;
+        yield* service.start;
+        const view = yield* service.updateSettingsView({
+          voiceTranscription: {
+            provider: "groq",
+            groqModel: "whisper-large-v3",
+            groqApiKey: "gsk_voice_secret",
+          },
+        });
+        const internal = yield* service.getSettings;
+        const groqApiKey = yield* service.getVoiceTranscriptionGroqApiKey;
+        const persisted = yield* fs.readFileString(settingsPath);
+        return { view, internal, groqApiKey, persisted };
+      }),
+    );
+
+    expect(result.internal.voiceTranscription).toMatchObject({
+      provider: "groq",
+      groqModel: "whisper-large-v3",
+      groqApiKeyConfigured: true,
+    });
+    expect(result.view.voiceTranscription).toMatchObject({
+      provider: "groq",
+      groqModel: "whisper-large-v3",
+      groqApiKeyConfigured: true,
+    });
+    expect(result.groqApiKey).toBe("gsk_voice_secret");
+    expect(JSON.stringify(result.internal)).not.toContain("gsk_voice_secret");
+    expect(JSON.stringify(result.view)).not.toContain("gsk_voice_secret");
+    expect(JSON.stringify(result.view)).not.toContain('"groqApiKey"');
+    expect(result.persisted).not.toContain("gsk_voice_secret");
+  });
+
   it.each([
     {
       name: "resolves text generation selection away from disabled providers",

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -44,6 +44,10 @@ import {
   ProviderCredentialsLive,
   type ExternalProviderServer,
 } from "./providerCredentials";
+import {
+  VoiceTranscriptionCredentials,
+  VoiceTranscriptionCredentialsLive,
+} from "./voiceTranscriptionCredentials";
 
 export interface ServerSettingsShape {
   readonly start: Effect.Effect<void, ServerSettingsError>;
@@ -59,6 +63,7 @@ export interface ServerSettingsShape {
   ) => Effect.Effect<ServerSettingsView, ServerSettingsError>;
   readonly streamChanges: Stream.Stream<ServerSettings>;
   readonly streamViews: Stream.Stream<ServerSettingsView>;
+  readonly getVoiceTranscriptionGroqApiKey: Effect.Effect<string | null, ServerSettingsError>;
 }
 
 export interface ServerSettingsSnapshot {
@@ -149,6 +154,9 @@ export class ServerSettingsService extends ServiceMap.Service<
               Stream.map(toServerSettingsView),
             );
           },
+          getVoiceTranscriptionGroqApiKey: Effect.sync(
+            () => process.env.GROQ_API_KEY?.trim() || null,
+          ),
         } satisfies ServerSettingsShape;
       }),
     );
@@ -229,6 +237,19 @@ function omitProviderPasswords(patch: ServerSettingsPatch): ServerSettingsPatch 
       ...(patch.providers.opencode ? { opencode } : {}),
     },
   };
+}
+
+function omitVoiceTranscriptionSecrets(patch: ServerSettingsPatch): ServerSettingsPatch {
+  if (!patch.voiceTranscription) return patch;
+  const { groqApiKey: _groqApiKey, ...voiceTranscription } = patch.voiceTranscription;
+  return {
+    ...patch,
+    voiceTranscription,
+  };
+}
+
+function omitSecretSettings(patch: ServerSettingsPatch): ServerSettingsPatch {
+  return omitVoiceTranscriptionSecrets(omitProviderPasswords(patch));
 }
 
 // Migrate only portable Kilo state. Its model/options shape and enabled flag
@@ -337,6 +358,7 @@ function decodeSettingsFromJson(settingsPath: string, raw: string) {
 const makeServerSettings = Effect.gen(function* () {
   const { settingsPath } = yield* ServerConfig;
   const providerCredentials = yield* ProviderCredentials;
+  const voiceTranscriptionCredentials = yield* VoiceTranscriptionCredentials;
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const writeSemaphore = yield* Semaphore.make(1);
@@ -352,6 +374,7 @@ const makeServerSettings = Effect.gen(function* () {
   const withCredentialState = (settings: ServerSettings) =>
     Effect.all({
       opencode: providerCredentials.isServerPasswordConfigured("opencode"),
+      groqVoice: voiceTranscriptionCredentials.isGroqApiKeyConfigured(),
     }).pipe(
       Effect.map(
         (configured): ServerSettings => ({
@@ -362,6 +385,10 @@ const makeServerSettings = Effect.gen(function* () {
               ...settings.providers.opencode,
               serverPasswordConfigured: configured.opencode,
             },
+          },
+          voiceTranscription: {
+            ...settings.voiceTranscription,
+            groqApiKeyConfigured: configured.groqVoice,
           },
         }),
       ),
@@ -522,10 +549,24 @@ const makeServerSettings = Effect.gen(function* () {
             );
           }
         }
+        if (patch.voiceTranscription?.groqApiKey !== undefined) {
+          yield* voiceTranscriptionCredentials
+            .replaceGroqApiKey(patch.voiceTranscription.groqApiKey)
+            .pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ServerSettingsError({
+                    settingsPath,
+                    detail: "failed to update Groq voice transcription API key",
+                    cause,
+                  }),
+              ),
+            );
+        }
         const normalized = yield* normalizeSettings(
           settingsPath,
           current,
-          omitProviderPasswords(patch),
+          omitSecretSettings(patch),
         );
         const next = yield* withCredentialState(normalized);
         const nextRevision = Math.max(disk.revision, yield* Ref.get(revisionRef)) + 1;
@@ -564,9 +605,20 @@ const makeServerSettings = Effect.gen(function* () {
         Stream.map(toServerSettingsView),
       );
     },
+    getVoiceTranscriptionGroqApiKey: voiceTranscriptionCredentials.getGroqApiKey().pipe(
+      Effect.mapError(
+        (cause) =>
+          new ServerSettingsError({
+            settingsPath,
+            detail: "failed to read Groq voice transcription API key",
+            cause,
+          }),
+      ),
+    ),
   } satisfies ServerSettingsShape;
 });
 
 export const ServerSettingsLive = Layer.effect(ServerSettingsService, makeServerSettings).pipe(
   Layer.provide(ProviderCredentialsLive),
+  Layer.provide(VoiceTranscriptionCredentialsLive),
 );

--- a/apps/server/src/voiceTranscription.test.ts
+++ b/apps/server/src/voiceTranscription.test.ts
@@ -8,7 +8,7 @@ import type { ServerVoiceTranscriptionInput } from "@synara/contracts";
 import { outboundHttp, type OutboundHttpResponse } from "@synara/shared/outboundHttp";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { transcribeVoiceWithChatGptSession } from "./voiceTranscription";
+import { transcribeVoiceWithChatGptSession, transcribeVoiceWithGroq } from "./voiceTranscription";
 
 const WAV_BASE64 = Buffer.from("RIFF0000WAVE", "ascii").toString("base64");
 
@@ -79,5 +79,40 @@ describe("transcribeVoiceWithChatGptSession", () => {
         }),
       }),
     ).rejects.toThrow(/not allowed/u);
+  });
+});
+
+describe("transcribeVoiceWithGroq", () => {
+  it("uploads the WAV clip to Groq with the selected model", async () => {
+    const request = vi
+      .spyOn(outboundHttp, "request")
+      .mockResolvedValue(outboundJson({ text: "hello from groq" }, 200));
+
+    const result = await transcribeVoiceWithGroq({
+      request: baseRequest,
+      apiKey: "gsk_test",
+      model: "whisper-large-v3-turbo",
+    });
+
+    expect(result).toEqual({ text: "hello from groq" });
+    const outbound = request.mock.calls[0]?.[0];
+    expect(outbound?.url).toBe("https://api.groq.com/openai/v1/audio/transcriptions");
+    expect(outbound?.headers).toEqual(
+      expect.objectContaining({ Authorization: "Bearer gsk_test" }),
+    );
+    const body = new TextDecoder().decode(outbound?.body as Uint8Array);
+    expect(body).toContain("whisper-large-v3-turbo");
+  });
+
+  it("maps Groq auth failures to a settings-facing API key error", async () => {
+    vi.spyOn(outboundHttp, "request").mockResolvedValue(outboundJson({}, 401));
+
+    await expect(
+      transcribeVoiceWithGroq({
+        request: baseRequest,
+        apiKey: "gsk_bad",
+        model: "whisper-large-v3-turbo",
+      }),
+    ).rejects.toThrow("The Groq API key is invalid. Update it in Settings > General.");
   });
 });

--- a/apps/server/src/voiceTranscription.ts
+++ b/apps/server/src/voiceTranscription.ts
@@ -1,8 +1,8 @@
 // FILE: voiceTranscription.ts
-// Purpose: Validates Remodex-style WAV payloads and proxies them to ChatGPT transcription.
+// Purpose: Validates Remodex-style WAV payloads and proxies them to the selected STT backend.
 // Layer: Server utility
-// Exports: transcribeVoiceWithChatGptSession
-// Depends on: ChatGPT session auth supplied by Codex app-server callers.
+// Exports: transcribeVoiceWithChatGptSession, transcribeVoiceWithGroq
+// Depends on: ChatGPT session auth supplied by Codex app-server callers, or a Groq API key.
 
 import { Buffer } from "node:buffer";
 
@@ -12,6 +12,7 @@ import type {
 } from "@synara/contracts";
 import { SERVER_VOICE_TRANSCRIPTION_MAX_AUDIO_BYTES } from "@synara/contracts";
 import { requestChatGptVoiceTranscription } from "@synara/shared/chatGptVoiceTranscription";
+import { requestGroqVoiceTranscription } from "@synara/shared/groqVoiceTranscription";
 import { decodeOutboundJson, type OutboundHttpResponse } from "@synara/shared/outboundHttp";
 
 const MAX_DURATION_MS = 120_000;
@@ -50,6 +51,42 @@ export async function transcribeVoiceWithChatGptSession(input: {
 
   if (response.status < 200 || response.status >= 300) {
     throw new Error(readTranscriptionErrorMessage(response));
+  }
+
+  let payload: { text?: unknown; transcript?: unknown } | null = null;
+  try {
+    payload = decodeOutboundJson(response, { maxDepth: 16, maxNodes: 1_000 }) as {
+      text?: unknown;
+      transcript?: unknown;
+    };
+  } catch {
+    payload = null;
+  }
+  const text = readString(payload?.text) ?? readString(payload?.transcript);
+  if (!text) {
+    throw new Error("The transcription response did not include any text.");
+  }
+
+  return { text };
+}
+
+export async function transcribeVoiceWithGroq(input: {
+  readonly request: ServerVoiceTranscriptionInput;
+  readonly apiKey: string;
+  readonly model: string;
+  readonly signal?: AbortSignal;
+}): Promise<ServerVoiceTranscriptionResult> {
+  const audioBuffer = decodeVoiceAudio(input.request);
+  const response = await requestGroqVoiceTranscription({
+    audio: audioBuffer,
+    mimeType: input.request.mimeType,
+    apiKey: input.apiKey,
+    model: input.model,
+    ...(input.signal ? { signal: input.signal } : {}),
+  });
+
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(readGroqTranscriptionErrorMessage(response));
   }
 
   let payload: { text?: unknown; transcript?: unknown } | null = null;
@@ -137,6 +174,32 @@ function readTranscriptionErrorMessage(response: OutboundHttpResponse): string {
 
   if (response.status === 401 || response.status === 403) {
     return "Your ChatGPT login has expired. Sign in again.";
+  }
+
+  return errorMessage;
+}
+
+function readGroqTranscriptionErrorMessage(response: OutboundHttpResponse): string {
+  let errorMessage = `Transcription failed with status ${response.status}.`;
+  try {
+    const payload = decodeOutboundJson(response, { maxDepth: 16, maxNodes: 1_000 }) as {
+      error?: { message?: unknown };
+      message?: unknown;
+    } | null;
+    const providerMessage =
+      readString(payload?.error?.message) ?? readString(payload?.message) ?? null;
+    if (providerMessage) {
+      errorMessage = providerMessage;
+    }
+  } catch {
+    // Keep the generic status-based message when the provider body is empty or invalid.
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    return "The Groq API key is invalid. Update it in Settings > General.";
+  }
+  if (response.status === 429) {
+    return "Groq rate-limited the transcription request. Try again in a moment.";
   }
 
   return errorMessage;

--- a/apps/server/src/voiceTranscriptionCredentials.ts
+++ b/apps/server/src/voiceTranscriptionCredentials.ts
@@ -1,0 +1,62 @@
+// FILE: voiceTranscriptionCredentials.ts
+// Purpose: Owns the server-only Groq speech-to-text API key.
+// Layer: Server voice-transcription security boundary
+
+import { Effect, Layer, ServiceMap } from "effect";
+
+import { readGroqApiKeyFromEnv } from "@synara/shared/groqVoiceTranscription";
+
+import { ServerSecretStoreLive } from "./auth/Layers/ServerSecretStore";
+import { ServerSecretStore, type SecretStoreError } from "./auth/Services/ServerSecretStore";
+
+const GROQ_API_KEY_SECRET = "voice-transcription-groq-api-key";
+
+export interface VoiceTranscriptionCredentialsShape {
+  readonly getGroqApiKey: () => Effect.Effect<string | null, SecretStoreError>;
+  readonly replaceGroqApiKey: (apiKey: string | null) => Effect.Effect<void, SecretStoreError>;
+  readonly isGroqApiKeyConfigured: () => Effect.Effect<boolean, SecretStoreError>;
+}
+
+export class VoiceTranscriptionCredentials extends ServiceMap.Service<
+  VoiceTranscriptionCredentials,
+  VoiceTranscriptionCredentialsShape
+>()("synara/voiceTranscription/VoiceTranscriptionCredentials") {}
+
+const makeVoiceTranscriptionCredentials = Effect.gen(function* () {
+  const secrets = yield* ServerSecretStore;
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+
+  const getStoredGroqApiKey: VoiceTranscriptionCredentialsShape["getGroqApiKey"] = () =>
+    secrets.get(GROQ_API_KEY_SECRET).pipe(
+      Effect.map((value) => {
+        if (!value || value.byteLength === 0) return null;
+        const apiKey = decoder.decode(value);
+        return apiKey.length > 0 ? apiKey : null;
+      }),
+    );
+
+  const getGroqApiKey: VoiceTranscriptionCredentialsShape["getGroqApiKey"] = () =>
+    getStoredGroqApiKey().pipe(Effect.map((stored) => stored ?? readGroqApiKeyFromEnv()));
+
+  const replaceGroqApiKey: VoiceTranscriptionCredentialsShape["replaceGroqApiKey"] = (apiKey) => {
+    const normalized = apiKey?.trim() ?? "";
+    return normalized.length > 0
+      ? secrets.set(GROQ_API_KEY_SECRET, encoder.encode(normalized))
+      : secrets.remove(GROQ_API_KEY_SECRET);
+  };
+
+  const isGroqApiKeyConfigured: VoiceTranscriptionCredentialsShape["isGroqApiKeyConfigured"] = () =>
+    getGroqApiKey().pipe(Effect.map((apiKey) => apiKey !== null));
+
+  return {
+    getGroqApiKey,
+    replaceGroqApiKey,
+    isGroqApiKeyConfigured,
+  } satisfies VoiceTranscriptionCredentialsShape;
+});
+
+export const VoiceTranscriptionCredentialsLive = Layer.effect(
+  VoiceTranscriptionCredentials,
+  makeVoiceTranscriptionCredentials,
+).pipe(Layer.provide(ServerSecretStoreLive));

--- a/apps/server/src/voiceTranscriptionDispatch.test.ts
+++ b/apps/server/src/voiceTranscriptionDispatch.test.ts
@@ -1,0 +1,103 @@
+// FILE: voiceTranscriptionDispatch.test.ts
+// Purpose: Verifies STT routing uses Groq independently of the coding-agent harness.
+
+import { Effect } from "effect";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { outboundHttp, type OutboundHttpResponse } from "@synara/shared/outboundHttp";
+
+import { ServerSettingsService } from "./serverSettings";
+import { transcribeConfiguredVoice } from "./voiceTranscriptionDispatch";
+
+const WAV_BYTES = Buffer.from("RIFF0000WAVE", "ascii");
+
+function outboundJson(body: unknown, status = 200): OutboundHttpResponse {
+  return {
+    status,
+    headers: new Headers({ "content-type": "application/json" }),
+    body: new TextEncoder().encode(JSON.stringify(body)),
+    url: "https://api.groq.com/openai/v1/audio/transcriptions",
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("transcribeConfiguredVoice", () => {
+  it("uses Groq even when Codex is disabled", async () => {
+    vi.stubEnv("GROQ_API_KEY", "gsk_test");
+    const request = vi
+      .spyOn(outboundHttp, "request")
+      .mockResolvedValue(outboundJson({ text: "independent groq" }));
+    const transcribeVoice = vi.fn(() => Effect.succeed({ text: "codex should not run" }));
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const serverSettings = yield* ServerSettingsService;
+        return yield* transcribeConfiguredVoice(
+          {
+            provider: "codex",
+            cwd: "/tmp/project",
+            mimeType: "audio/wav",
+            sampleRateHz: 24_000,
+            durationMs: 1_000,
+            audioBase64: WAV_BYTES.toString("base64"),
+          },
+          serverSettings,
+          {
+            getByProvider: () => Effect.succeed({ provider: "codex", transcribeVoice } as never),
+            listProviders: () => Effect.succeed(["codex"]),
+          },
+        );
+      }).pipe(
+        Effect.provide(
+          ServerSettingsService.layerTest({
+            voiceTranscription: { provider: "auto" },
+            providers: { codex: { enabled: false } },
+          }),
+        ),
+      ),
+    );
+
+    expect(result).toEqual({ text: "independent groq" });
+    expect(transcribeVoice).not.toHaveBeenCalled();
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when Groq is selected without an API key", async () => {
+    const transcribeVoice = vi.fn(() => Effect.succeed({ text: "codex should not run" }));
+
+    await expect(
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const serverSettings = yield* ServerSettingsService;
+          return yield* transcribeConfiguredVoice(
+            {
+              provider: "codex",
+              cwd: "/tmp/project",
+              mimeType: "audio/wav",
+              sampleRateHz: 24_000,
+              durationMs: 1_000,
+              audioBase64: WAV_BYTES.toString("base64"),
+            },
+            serverSettings,
+            {
+              getByProvider: () => Effect.succeed({ provider: "codex", transcribeVoice } as never),
+              listProviders: () => Effect.succeed(["codex"]),
+            },
+          );
+        }).pipe(
+          Effect.provide(
+            ServerSettingsService.layerTest({
+              voiceTranscription: { provider: "groq" },
+            }),
+          ),
+        ),
+      ),
+    ).rejects.toThrow("Add a Groq API key in Settings > General, or set GROQ_API_KEY.");
+
+    expect(transcribeVoice).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/voiceTranscriptionDispatch.ts
+++ b/apps/server/src/voiceTranscriptionDispatch.ts
@@ -1,0 +1,101 @@
+// FILE: voiceTranscriptionDispatch.ts
+// Purpose: Routes voice prewarm/transcribe to the configured STT backend.
+// Layer: Server voice transcription
+// Groq is independent of the coding-agent harness; ChatGPT still uses Codex.
+
+import type {
+  ServerVoicePrewarmInput,
+  ServerVoicePrewarmResult,
+  ServerVoiceTranscriptionInput,
+  ServerVoiceTranscriptionResult,
+} from "@synara/contracts";
+import { prewarmGroqVoiceTranscriptionConnection } from "@synara/shared/groqVoiceTranscription";
+import { resolveVoiceTranscriptionBackend } from "@synara/shared/voiceTranscription";
+import { Effect } from "effect";
+
+import { getEnabledProviderAdapter } from "./provider/enabledProviderAdapter";
+import type { ProviderAdapterRegistryShape } from "./provider/Services/ProviderAdapterRegistry";
+import type { ServerSettingsShape } from "./serverSettings";
+import { transcribeVoiceWithGroq } from "./voiceTranscription.ts";
+
+export const MISSING_GROQ_VOICE_KEY_MESSAGE =
+  "Add a Groq API key in Settings > General, or set GROQ_API_KEY.";
+
+export function transcribeConfiguredVoice(
+  input: ServerVoiceTranscriptionInput,
+  serverSettings: ServerSettingsShape,
+  providerAdapterRegistry: ProviderAdapterRegistryShape,
+) {
+  return Effect.gen(function* () {
+    const settings = yield* serverSettings.getSettings;
+    const groqApiKey = yield* serverSettings.getVoiceTranscriptionGroqApiKey;
+    const backend = resolveVoiceTranscriptionBackend({
+      provider: settings.voiceTranscription.provider,
+      groqApiKey,
+    });
+    if (backend.kind === "missing-groq-key") {
+      return yield* Effect.fail(new Error(MISSING_GROQ_VOICE_KEY_MESSAGE));
+    }
+    if (backend.kind === "groq") {
+      return yield* Effect.tryPromise({
+        try: () =>
+          transcribeVoiceWithGroq({
+            request: input,
+            apiKey: backend.apiKey,
+            model: settings.voiceTranscription.groqModel,
+          }),
+        catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+      });
+    }
+    return yield* transcribeChatGptVoice(input, serverSettings, providerAdapterRegistry);
+  });
+}
+
+export function prewarmConfiguredVoice(
+  input: ServerVoicePrewarmInput,
+  serverSettings: ServerSettingsShape,
+  providerAdapterRegistry: ProviderAdapterRegistryShape,
+) {
+  return Effect.gen(function* () {
+    const settings = yield* serverSettings.getSettings;
+    const groqApiKey = yield* serverSettings.getVoiceTranscriptionGroqApiKey;
+    const backend = resolveVoiceTranscriptionBackend({
+      provider: settings.voiceTranscription.provider,
+      groqApiKey,
+    });
+    if (backend.kind === "missing-groq-key") {
+      return yield* Effect.fail(new Error(MISSING_GROQ_VOICE_KEY_MESSAGE));
+    }
+    if (backend.kind === "groq") {
+      yield* Effect.ignore(Effect.tryPromise(() => prewarmGroqVoiceTranscriptionConnection()));
+      return { ready: true } satisfies ServerVoicePrewarmResult;
+    }
+    const adapter = yield* getEnabledProviderAdapter(
+      input.provider,
+      serverSettings,
+      providerAdapterRegistry,
+    );
+    if (!adapter.prewarmVoice) {
+      return yield* Effect.fail(
+        new Error(`Voice transcription is unavailable for provider '${input.provider}'.`),
+      );
+    }
+    return yield* adapter.prewarmVoice(input);
+  });
+}
+
+function transcribeChatGptVoice(
+  input: ServerVoiceTranscriptionInput,
+  serverSettings: ServerSettingsShape,
+  providerAdapterRegistry: ProviderAdapterRegistryShape,
+): Effect.Effect<ServerVoiceTranscriptionResult, unknown> {
+  return getEnabledProviderAdapter(input.provider, serverSettings, providerAdapterRegistry).pipe(
+    Effect.flatMap((adapter) =>
+      adapter.transcribeVoice
+        ? adapter.transcribeVoice(input)
+        : Effect.fail(
+            new Error(`Voice transcription is unavailable for provider '${input.provider}'.`),
+          ),
+    ),
+  );
+}

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -101,7 +101,7 @@ import { ProviderDiscoveryService } from "./provider/Services/ProviderDiscoveryS
 import { discoverSkillsCatalog, synaraSkillsDir } from "./provider/skillsCatalog";
 import { recoverUnregisteredGitHubCheckout } from "./project/githubProjectRegistration";
 import { ProviderAdapterRegistry } from "./provider/Services/ProviderAdapterRegistry";
-import { getEnabledProviderAdapter } from "./provider/enabledProviderAdapter";
+import { prewarmConfiguredVoice, transcribeConfiguredVoice } from "./voiceTranscriptionDispatch";
 import { ProviderHealth } from "./provider/Services/ProviderHealth";
 import { ProviderService } from "./provider/Services/ProviderService";
 import { listProviderUsage } from "./providerUsage";
@@ -1775,37 +1775,13 @@ const makeWsRpcHandlersLayer = () =>
           ),
         [WS_METHODS.serverPrewarmVoice]: (input) =>
           rpcEffect(
-            getEnabledProviderAdapter(input.provider, serverSettings, providerAdapterRegistry).pipe(
-              Effect.flatMap((adapter) =>
-                adapter.prewarmVoice
-                  ? adapter.prewarmVoice(input)
-                  : Effect.fail(
-                      new Error(
-                        `Voice transcription is unavailable for provider '${input.provider}'.`,
-                      ),
-                    ),
-              ),
-            ),
+            prewarmConfiguredVoice(input, serverSettings, providerAdapterRegistry),
             "Voice transcription prewarm failed",
           ),
         [WS_METHODS.serverTranscribeVoice]: (input) =>
           rpcEffect(
             voiceUploadAdmissionGate.run(
-              getEnabledProviderAdapter(
-                input.provider,
-                serverSettings,
-                providerAdapterRegistry,
-              ).pipe(
-                Effect.flatMap((adapter) =>
-                  adapter.transcribeVoice
-                    ? adapter.transcribeVoice(input)
-                    : Effect.fail(
-                        new Error(
-                          `Voice transcription is unavailable for provider '${input.provider}'.`,
-                        ),
-                      ),
-                ),
-              ),
+              transcribeConfiguredVoice(input, serverSettings, providerAdapterRegistry),
             ),
             "Voice transcription failed",
           ),

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -136,6 +136,27 @@ describe("server-backed provider enablement", () => {
     expect(patch.providers).toBeUndefined();
   });
 
+  it("maps independent voice transcription settings into the server patch", () => {
+    const patch = appSettingsPatchToServerSettingsPatch({
+      voiceTranscriptionProvider: "groq",
+      voiceTranscriptionGroqModel: "whisper-large-v3",
+      voiceTranscriptionGroqApiKey: "gsk_test",
+    });
+    expect(patch.voiceTranscription).toEqual({
+      provider: "groq",
+      groqModel: "whisper-large-v3",
+      groqApiKey: "gsk_test",
+    });
+  });
+
+  it("omits an empty Groq API key when none is configured", () => {
+    const patch = appSettingsPatchToServerSettingsPatch(
+      { voiceTranscriptionGroqApiKey: "" },
+      DEFAULT_SERVER_SETTINGS_VIEW,
+    );
+    expect(patch.voiceTranscription).toBeUndefined();
+  });
+
   it("invalidates discovery for initial and changed streamed provider settings", () => {
     const disabledOpenCode = {
       ...DEFAULT_SERVER_SETTINGS_VIEW,

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -10,8 +10,12 @@ import {
   type AssistantDeliveryMode,
   DesktopAppIcon,
   DEFAULT_GIT_TEXT_GENERATION_MODEL,
+  DEFAULT_GROQ_VOICE_TRANSCRIPTION_MODEL,
   DEFAULT_SERVER_SETTINGS,
   DEFAULT_SERVER_SETTINGS_VIEW,
+  DEFAULT_VOICE_TRANSCRIPTION_PROVIDER,
+  GroqVoiceTranscriptionModel,
+  VoiceTranscriptionProviderKind,
   GIT_TEXT_GENERATION_PROVIDERS,
   TrimmedNonEmptyString,
   ProviderKind,
@@ -325,6 +329,16 @@ export const AppSettingsSchema = Schema.Struct({
   showEnvironmentInstructions: Schema.Boolean.pipe(withDefaults(() => false)),
   showEnvironmentNotepad: Schema.Boolean.pipe(withDefaults(() => false)),
   followUpBehavior: FollowUpBehavior.pipe(withDefaults(() => DEFAULT_FOLLOW_UP_BEHAVIOR)),
+  voiceTranscriptionProvider: VoiceTranscriptionProviderKind.pipe(
+    withDefaults(() => DEFAULT_VOICE_TRANSCRIPTION_PROVIDER),
+  ),
+  voiceTranscriptionGroqModel: GroqVoiceTranscriptionModel.pipe(
+    withDefaults(() => DEFAULT_GROQ_VOICE_TRANSCRIPTION_MODEL),
+  ),
+  voiceTranscriptionGroqApiKey: Schema.String.check(Schema.isMaxLength(4096)).pipe(
+    withDefaults(() => ""),
+  ),
+  voiceTranscriptionGroqApiKeyConfigured: Schema.Boolean.pipe(withDefaults(() => false)),
   enableAssistantStreaming: Schema.Boolean.pipe(withDefaults(() => true)),
   autoOpenDevicePane: Schema.Boolean.pipe(withDefaults(() => true)),
   enableProviderUpdateChecks: Schema.Boolean.pipe(withDefaults(() => true)),
@@ -611,6 +625,7 @@ function normalizeAppSettings(settings: AppSettings): AppSettings {
     // Password fields are accepted only as write-only update patches. Never retain
     // reusable provider credentials in browser state or localStorage.
     openCodeServerPassword: "",
+    voiceTranscriptionGroqApiKey: "",
     claudeBinaryPath: normalizeProviderBinaryPathOverride("claudeAgent", settings.claudeBinaryPath),
     codexBinaryPath: normalizeProviderBinaryPathOverride("codex", settings.codexBinaryPath),
     cursorBinaryPath: normalizeProviderBinaryPathOverride("cursor", settings.cursorBinaryPath),
@@ -681,6 +696,9 @@ function serverSettingsToAppSettings(settings: ServerSettingsView): Partial<AppS
     defaultThreadEnvMode: settings.defaultThreadEnvMode,
     enableAssistantStreaming: settings.enableAssistantStreaming,
     enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+    voiceTranscriptionProvider: settings.voiceTranscription.provider,
+    voiceTranscriptionGroqModel: settings.voiceTranscription.groqModel,
+    voiceTranscriptionGroqApiKeyConfigured: settings.voiceTranscription.groqApiKeyConfigured,
     antigravityBinaryPath: settings.providers.antigravity.binaryPath,
     grokBinaryPath: settings.providers.grok.binaryPath,
     droidBinaryPath: settings.providers.droid.binaryPath,
@@ -767,11 +785,43 @@ function pruneProviderPatchAgainstCurrentSettings(
 
 export function appSettingsPatchToServerSettingsPatch(
   patch: Partial<AppSettings>,
-  currentSettings?: Pick<ServerSettingsView, "providers">,
+  currentSettings?: Pick<ServerSettingsView, "providers" | "voiceTranscription">,
 ): ServerSettingsPatch {
   const providers: MutableServerSettingsProvidersPatch = {};
   const serverPatch: MutableServerSettingsPatch = {};
 
+  if (
+    hasOwn(patch, "voiceTranscriptionProvider") ||
+    hasOwn(patch, "voiceTranscriptionGroqModel") ||
+    hasOwn(patch, "voiceTranscriptionGroqApiKey")
+  ) {
+    const voiceTranscription: Mutable<NonNullable<ServerSettingsPatch["voiceTranscription"]>> = {};
+    if (hasOwn(patch, "voiceTranscriptionProvider") && patch.voiceTranscriptionProvider) {
+      voiceTranscription.provider = patch.voiceTranscriptionProvider;
+    }
+    if (hasOwn(patch, "voiceTranscriptionGroqModel") && patch.voiceTranscriptionGroqModel) {
+      voiceTranscription.groqModel = patch.voiceTranscriptionGroqModel;
+    }
+    if (hasOwn(patch, "voiceTranscriptionGroqApiKey")) {
+      const groqApiKey = patch.voiceTranscriptionGroqApiKey ?? "";
+      const skipEmptyClear =
+        groqApiKey === "" && currentSettings?.voiceTranscription.groqApiKeyConfigured === false;
+      if (!skipEmptyClear) {
+        voiceTranscription.groqApiKey = groqApiKey;
+      }
+    }
+    if (currentSettings) {
+      if (voiceTranscription.provider === currentSettings.voiceTranscription.provider) {
+        delete voiceTranscription.provider;
+      }
+      if (voiceTranscription.groqModel === currentSettings.voiceTranscription.groqModel) {
+        delete voiceTranscription.groqModel;
+      }
+    }
+    if (Object.keys(voiceTranscription).length > 0) {
+      serverPatch.voiceTranscription = voiceTranscription;
+    }
+  }
   if (hasOwn(patch, "enableAssistantStreaming")) {
     serverPatch.enableAssistantStreaming = Boolean(patch.enableAssistantStreaming);
   }
@@ -1000,6 +1050,13 @@ export function applyLocalAppSettingsPatch(
     ...localPatch,
     ...(hasOwn(patch, "openCodeServerPassword")
       ? { openCodeServerPasswordConfigured: Boolean(patch.openCodeServerPassword?.trim()) }
+      : {}),
+    ...(hasOwn(patch, "voiceTranscriptionGroqApiKey")
+      ? {
+          voiceTranscriptionGroqApiKeyConfigured: Boolean(
+            patch.voiceTranscriptionGroqApiKey?.trim(),
+          ),
+        }
       : {}),
   });
 }

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -963,6 +963,21 @@ describe("voice helpers", () => {
       canStartVoiceNotes: false,
       showVoiceNotesControl: true,
     });
+
+    expect(
+      deriveComposerVoiceState({
+        authStatus: "unauthenticated",
+        voiceTranscriptionAvailable: false,
+        isRecording: false,
+        isTranscribing: false,
+        voiceTranscriptionProvider: "auto",
+        groqApiKeyConfigured: true,
+      }),
+    ).toEqual({
+      canRenderVoiceNotes: true,
+      canStartVoiceNotes: true,
+      showVoiceNotesControl: true,
+    });
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -12,7 +12,9 @@ import {
   type RuntimeMode,
   type ServerProviderAuthStatus,
   type ThreadId as ThreadIdType,
+  type VoiceTranscriptionProviderKind,
 } from "@synara/contracts";
+import { isIndependentVoiceTranscriptionReady } from "@synara/shared/voiceTranscription";
 import { getDefaultModel, normalizeModelSlug } from "@synara/shared/model";
 import { buildSynaraBranchName } from "@synara/shared/git";
 import { isGenericChatThreadTitle } from "@synara/shared/chatThreads";
@@ -938,13 +940,25 @@ export function deriveComposerVoiceState(input: {
   voiceTranscriptionAvailable: boolean | undefined;
   isRecording: boolean;
   isTranscribing: boolean;
+  voiceTranscriptionProvider?: VoiceTranscriptionProviderKind;
+  groqApiKeyConfigured?: boolean;
 }): {
   canRenderVoiceNotes: boolean;
   canStartVoiceNotes: boolean;
   showVoiceNotesControl: boolean;
 } {
-  const canRenderVoiceNotes = input.authStatus !== "unauthenticated";
-  const canStartVoiceNotes = canRenderVoiceNotes && input.voiceTranscriptionAvailable !== false;
+  const voiceTranscriptionProvider = input.voiceTranscriptionProvider ?? "auto";
+  const groqReady = isIndependentVoiceTranscriptionReady({
+    provider: voiceTranscriptionProvider,
+    groqApiKeyConfigured: input.groqApiKeyConfigured === true,
+  });
+  const chatgptReady =
+    voiceTranscriptionProvider !== "groq" &&
+    input.authStatus !== "unauthenticated" &&
+    input.voiceTranscriptionAvailable !== false;
+  const canStartVoiceNotes = groqReady || chatgptReady;
+  const canRenderVoiceNotes =
+    groqReady || voiceTranscriptionProvider === "groq" || input.authStatus !== "unauthenticated";
 
   return {
     canRenderVoiceNotes,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4537,6 +4537,8 @@ export default function ChatView({
     threadId,
     selectedProvider,
     activeProviderStatus: voiceProviderStatus,
+    voiceTranscriptionProvider: settings.voiceTranscriptionProvider,
+    groqApiKeyConfigured: settings.voiceTranscriptionGroqApiKeyConfigured,
     pendingUserInputCount: pendingUserInputs.length,
     onTranscriptReady: appendVoiceTranscriptToComposer,
     refreshVoiceStatus: refreshProviderStatuses,

--- a/apps/web/src/components/chat/useComposerVoiceController.ts
+++ b/apps/web/src/components/chat/useComposerVoiceController.ts
@@ -3,7 +3,12 @@
 // Layer: Chat composer hook
 // Depends on: useVoiceRecorder, ChatView voice helper logic, and the native API voice endpoint.
 
-import { type ProviderKind, type ServerProviderStatus, type ThreadId } from "@synara/contracts";
+import {
+  type ProviderKind,
+  type ServerProviderStatus,
+  type ThreadId,
+  type VoiceTranscriptionProviderKind,
+} from "@synara/contracts";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import type { Project } from "../../types";
@@ -40,6 +45,8 @@ export interface UseComposerVoiceControllerOptions {
   threadId: ThreadId;
   selectedProvider: ProviderKind;
   activeProviderStatus: ServerProviderStatus | null;
+  voiceTranscriptionProvider?: VoiceTranscriptionProviderKind;
+  groqApiKeyConfigured?: boolean;
   pendingUserInputCount: number;
   onTranscriptReady: (transcript: string) => void;
   refreshVoiceStatus: RefreshProviderStatusesNow;
@@ -78,6 +85,8 @@ export function useComposerVoiceController(
     threadId,
     selectedProvider,
     activeProviderStatus,
+    voiceTranscriptionProvider,
+    groqApiKeyConfigured,
     pendingUserInputCount,
     onTranscriptReady,
     refreshVoiceStatus,
@@ -116,6 +125,8 @@ export function useComposerVoiceController(
     voiceTranscriptionAvailable: activeProviderStatus?.voiceTranscriptionAvailable,
     isRecording: isVoiceRecording,
     isTranscribing: isVoiceTranscribing,
+    ...(voiceTranscriptionProvider ? { voiceTranscriptionProvider } : {}),
+    ...(groqApiKeyConfigured !== undefined ? { groqApiKeyConfigured } : {}),
   });
 
   useEffect(() => {
@@ -183,17 +194,15 @@ export function useComposerVoiceController(
     if (!activeProject) {
       return;
     }
-    if (activeProviderStatus?.authStatus === "unauthenticated") {
-      toastManager.add({
-        type: "error",
-        title: "Sign in to ChatGPT in Codex before using voice notes.",
-      });
-      return;
-    }
     if (!canStartVoiceNotes) {
       toastManager.add({
         type: "error",
-        title: "Voice notes require a ChatGPT-authenticated Codex session.",
+        title:
+          voiceTranscriptionProvider === "groq"
+            ? "Add a Groq API key in Settings before using voice notes."
+            : groqApiKeyConfigured
+              ? "Voice notes are unavailable for the selected transcription provider."
+              : "Voice notes require a Groq API key or a ChatGPT-authenticated Codex session.",
       });
       return;
     }

--- a/apps/web/src/components/kanban/KanbanNewTaskDialog.tsx
+++ b/apps/web/src/components/kanban/KanbanNewTaskDialog.tsx
@@ -369,6 +369,8 @@ export function KanbanNewTaskDialog({
     threadId: scratchThreadId,
     selectedProvider,
     activeProviderStatus: voiceProviderStatus,
+    voiceTranscriptionProvider: settings.voiceTranscriptionProvider,
+    groqApiKeyConfigured: settings.voiceTranscriptionGroqApiKeyConfigured,
     pendingUserInputCount: 0,
     onTranscriptReady: handleTranscriptReady,
     refreshVoiceStatus: refreshProviderStatuses,

--- a/apps/web/src/components/settings/VoiceDictationSettingsPanel.tsx
+++ b/apps/web/src/components/settings/VoiceDictationSettingsPanel.tsx
@@ -1,0 +1,146 @@
+// FILE: VoiceDictationSettingsPanel.tsx
+// Purpose: Configure the speech-to-text backend independently of the coding agent.
+// Layer: Settings UI components
+
+import {
+  DEFAULT_GROQ_VOICE_TRANSCRIPTION_MODEL,
+  DEFAULT_VOICE_TRANSCRIPTION_PROVIDER,
+  GROQ_VOICE_TRANSCRIPTION_MODELS,
+  type GroqVoiceTranscriptionModel,
+  type VoiceTranscriptionProviderKind,
+} from "@synara/contracts";
+
+import type { AppSettingsBinding } from "~/appSettings";
+import { SelectItem } from "~/components/ui/select";
+import { DebouncedSettingTextInput } from "./DebouncedSettingTextInput";
+import {
+  SettingResetButton,
+  SettingsSegmentedControl,
+  SettingsSelectControl,
+} from "./SettingControls";
+import { SettingsRow, SettingsSection } from "./SettingsPanelPrimitives";
+
+const VOICE_PROVIDER_OPTIONS: ReadonlyArray<{
+  value: VoiceTranscriptionProviderKind;
+  label: string;
+}> = [
+  { value: "auto", label: "Auto" },
+  { value: "groq", label: "Groq" },
+  { value: "chatgpt", label: "ChatGPT" },
+];
+
+const GROQ_VOICE_MODEL_LABELS: Record<GroqVoiceTranscriptionModel, string> = {
+  "whisper-large-v3-turbo": "Turbo",
+  "whisper-large-v3": "Large v3",
+  "distil-whisper-large-v3-en": "Distil English",
+};
+
+const VOICE_PROVIDER_DESCRIPTIONS: Record<VoiceTranscriptionProviderKind, string> = {
+  auto: "Use Groq when an API key is available; otherwise ChatGPT via a Codex login. Independent of the coding agent in the current chat.",
+  groq: "Send dictation to Groq Whisper. Works with any coding agent once an API key is set.",
+  chatgpt: "Use ChatGPT transcription through a Codex ChatGPT session.",
+};
+
+export function VoiceDictationSettingsPanel({
+  settings,
+  defaults,
+  updateSettings,
+}: AppSettingsBinding) {
+  const showGroqFields = settings.voiceTranscriptionProvider !== "chatgpt";
+
+  return (
+    <SettingsSection title="Voice dictation">
+      <SettingsRow
+        title="Transcription provider"
+        description={VOICE_PROVIDER_DESCRIPTIONS[settings.voiceTranscriptionProvider]}
+        resetAction={
+          settings.voiceTranscriptionProvider !== defaults.voiceTranscriptionProvider ? (
+            <SettingResetButton
+              label="transcription provider"
+              onClick={() =>
+                updateSettings({
+                  voiceTranscriptionProvider: DEFAULT_VOICE_TRANSCRIPTION_PROVIDER,
+                })
+              }
+            />
+          ) : null
+        }
+        control={
+          <SettingsSegmentedControl
+            value={settings.voiceTranscriptionProvider}
+            onValueChange={(value) => updateSettings({ voiceTranscriptionProvider: value })}
+            ariaLabel="Voice transcription provider"
+            options={VOICE_PROVIDER_OPTIONS}
+          />
+        }
+      />
+
+      {showGroqFields ? (
+        <>
+          <SettingsRow
+            title="Groq model"
+            description="Whisper model used for Groq speech-to-text."
+            resetAction={
+              settings.voiceTranscriptionGroqModel !== defaults.voiceTranscriptionGroqModel ? (
+                <SettingResetButton
+                  label="Groq voice model"
+                  onClick={() =>
+                    updateSettings({
+                      voiceTranscriptionGroqModel: DEFAULT_GROQ_VOICE_TRANSCRIPTION_MODEL,
+                    })
+                  }
+                />
+              ) : null
+            }
+            control={
+              <SettingsSelectControl
+                value={settings.voiceTranscriptionGroqModel}
+                onValueChange={(value) => {
+                  if (!isGroqVoiceModel(value)) return;
+                  updateSettings({ voiceTranscriptionGroqModel: value });
+                }}
+                ariaLabel="Groq voice transcription model"
+                valueContent={GROQ_VOICE_MODEL_LABELS[settings.voiceTranscriptionGroqModel]}
+              >
+                {GROQ_VOICE_TRANSCRIPTION_MODELS.map((model) => (
+                  <SelectItem hideIndicator key={model} value={model}>
+                    {GROQ_VOICE_MODEL_LABELS[model]}
+                  </SelectItem>
+                ))}
+              </SettingsSelectControl>
+            }
+          />
+
+          <SettingsRow
+            title="Groq API key"
+            description="Stored on the server. You can also set GROQ_API_KEY in the environment. Get a key from console.groq.com."
+            control={
+              <DebouncedSettingTextInput
+                size="sm"
+                variant="soft"
+                className="w-full sm:w-56"
+                value=""
+                onCommit={(nextValue) =>
+                  updateSettings({ voiceTranscriptionGroqApiKey: nextValue })
+                }
+                placeholder={
+                  settings.voiceTranscriptionGroqApiKeyConfigured
+                    ? "Configured — enter a replacement or leave blank"
+                    : "gsk_..."
+                }
+                type="password"
+                autoComplete="new-password"
+                spellCheck={false}
+                aria-label="Groq API key"
+              />
+            }
+          />
+        </>
+      ) : null}
+    </SettingsSection>
+  );
+}
+
+function isGroqVoiceModel(value: string): value is GroqVoiceTranscriptionModel {
+  return (GROQ_VOICE_TRANSCRIPTION_MODELS as readonly string[]).includes(value);
+}

--- a/apps/web/src/providerUpdates.test.ts
+++ b/apps/web/src/providerUpdates.test.ts
@@ -59,6 +59,11 @@ function serverSettings(overrides: Partial<ServerSettings["providers"]> = {}): S
     defaultThreadEnvMode: "local",
     addProjectBaseDirectory: "",
     textGenerationModelSelection: { provider: "codex", model: "gpt-5.4-mini" },
+    voiceTranscription: {
+      provider: "auto",
+      groqModel: "whisper-large-v3-turbo",
+      groqApiKeyConfigured: false,
+    },
     providers: {
       codex: { ...provider, binaryPath: "codex", homePath: "" },
       claudeAgent: { ...provider, binaryPath: "claude", launchArgs: "" },

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -59,6 +59,7 @@ import {
   SettingsSectionShell,
 } from "../components/settings/SettingsPanelPrimitives";
 import { SkillsSettingsPanel } from "../components/settings/SkillsSettingsPanel";
+import { VoiceDictationSettingsPanel } from "../components/settings/VoiceDictationSettingsPanel";
 import { ThemeModePicker } from "../components/settings/ThemeModePicker";
 import { ThemePackEditor } from "../components/ThemePackEditor";
 import {
@@ -309,6 +310,16 @@ function SettingsRouteView() {
     ...(!isDefaultActiveTheme ? [`${resolvedTheme === "dark" ? "Dark" : "Light"} theme pack`] : []),
     ...(settings.defaultProvider !== defaults.defaultProvider ? ["Default provider"] : []),
     ...(settings.defaultThreadEnvMode !== defaults.defaultThreadEnvMode ? ["New thread mode"] : []),
+    ...(settings.voiceTranscriptionProvider !== defaults.voiceTranscriptionProvider
+      ? ["Transcription provider"]
+      : []),
+    ...(settings.voiceTranscriptionGroqModel !== defaults.voiceTranscriptionGroqModel
+      ? ["Groq voice model"]
+      : []),
+    ...(settings.voiceTranscriptionGroqApiKeyConfigured !==
+    defaults.voiceTranscriptionGroqApiKeyConfigured
+      ? ["Groq API key"]
+      : []),
     ...(settings.sidebarProjectSortOrder !== defaults.sidebarProjectSortOrder
       ? ["Project sort order"]
       : []),
@@ -538,6 +549,12 @@ function SettingsRouteView() {
           }
         />
       </SettingsSection>
+
+      <VoiceDictationSettingsPanel
+        settings={settings}
+        defaults={defaults}
+        updateSettings={updateSettings}
+      />
 
       <SettingsSection title="Sidebar organization">
         <SettingsRow

--- a/apps/web/src/settingsSearchIndex.ts
+++ b/apps/web/src/settingsSearchIndex.ts
@@ -54,6 +54,25 @@ export const SETTINGS_SEARCH_ENTRIES: readonly SettingsSearchEntry[] = [
       "Replay the first-run setup: feature tour, provider selection, appearance, and first project. onboarding welcome wizard getting started setup",
   },
   {
+    id: "general:transcription-provider",
+    section: "general",
+    title: "Transcription provider",
+    keywords:
+      "Voice dictation speech-to-text groq whisper chatgpt independent of coding agent harness microphone",
+  },
+  {
+    id: "general:groq-model",
+    section: "general",
+    title: "Groq model",
+    keywords: "whisper-large-v3-turbo groq speech to text voice dictation model",
+  },
+  {
+    id: "general:groq-api-key",
+    section: "general",
+    title: "Groq API key",
+    keywords: "GROQ_API_KEY groq console speech to text voice dictation credential",
+  },
+  {
     id: "general:project-order",
     section: "general",
     title: "Project order",

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -303,6 +303,11 @@ describe("wsNativeApi", () => {
         defaultThreadEnvMode: "local",
         addProjectBaseDirectory: "",
         textGenerationModelSelection: { provider: "codex", model: "gpt-5.4-mini" },
+        voiceTranscription: {
+          provider: "auto",
+          groqModel: "whisper-large-v3-turbo",
+          groqApiKeyConfigured: false,
+        },
         providers: {
           codex: { enabled: true, binaryPath: "codex", homePath: "", customModels: [] },
           claudeAgent: { enabled: true, binaryPath: "claude", launchArgs: "", customModels: [] },

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -88,6 +88,31 @@ export const SkillsServerSettings = Schema.Struct({
 });
 export type SkillsServerSettings = typeof SkillsServerSettings.Type;
 
+export const VoiceTranscriptionProviderKind = Schema.Literals(["auto", "groq", "chatgpt"]);
+export type VoiceTranscriptionProviderKind = typeof VoiceTranscriptionProviderKind.Type;
+export const DEFAULT_VOICE_TRANSCRIPTION_PROVIDER: VoiceTranscriptionProviderKind = "auto";
+
+export const GROQ_VOICE_TRANSCRIPTION_MODELS = [
+  "whisper-large-v3-turbo",
+  "whisper-large-v3",
+  "distil-whisper-large-v3-en",
+] as const;
+export const GroqVoiceTranscriptionModel = Schema.Literals([...GROQ_VOICE_TRANSCRIPTION_MODELS]);
+export type GroqVoiceTranscriptionModel = typeof GroqVoiceTranscriptionModel.Type;
+export const DEFAULT_GROQ_VOICE_TRANSCRIPTION_MODEL: GroqVoiceTranscriptionModel =
+  "whisper-large-v3-turbo";
+
+export const VoiceTranscriptionServerSettings = Schema.Struct({
+  provider: VoiceTranscriptionProviderKind.pipe(
+    Schema.withDecodingDefault(() => DEFAULT_VOICE_TRANSCRIPTION_PROVIDER),
+  ),
+  groqModel: GroqVoiceTranscriptionModel.pipe(
+    Schema.withDecodingDefault(() => DEFAULT_GROQ_VOICE_TRANSCRIPTION_MODEL),
+  ),
+  groqApiKeyConfigured: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
+});
+export type VoiceTranscriptionServerSettings = typeof VoiceTranscriptionServerSettings.Type;
+
 export const ServerSettings = Schema.Struct({
   enableAssistantStreaming: Schema.Boolean.pipe(Schema.withDecodingDefault(() => true)),
   enableProviderUpdateChecks: Schema.Boolean.pipe(Schema.withDecodingDefault(() => true)),
@@ -99,6 +124,7 @@ export const ServerSettings = Schema.Struct({
       model: DEFAULT_GIT_TEXT_GENERATION_MODEL,
     })),
   ),
+  voiceTranscription: VoiceTranscriptionServerSettings.pipe(Schema.withDecodingDefault(() => ({}))),
   providers: Schema.Struct({
     codex: CodexServerProviderSettings.pipe(Schema.withDecodingDefault(() => ({}))),
     claudeAgent: ClaudeServerProviderSettings.pipe(Schema.withDecodingDefault(() => ({}))),
@@ -146,6 +172,13 @@ export const ServerSettingsPatch = Schema.Struct({
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvironmentMode),
   addProjectBaseDirectory: Schema.optionalKey(StringSetting),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
+  voiceTranscription: Schema.optionalKey(
+    Schema.Struct({
+      provider: Schema.optionalKey(VoiceTranscriptionProviderKind),
+      groqModel: Schema.optionalKey(GroqVoiceTranscriptionModel),
+      groqApiKey: Schema.optionalKey(StringSetting),
+    }),
+  ),
   providers: Schema.optionalKey(
     Schema.Struct({
       codex: Schema.optionalKey(

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -240,6 +240,14 @@
       "types": "./src/chatGptVoiceTranscription.ts",
       "import": "./src/chatGptVoiceTranscription.ts"
     },
+    "./groqVoiceTranscription": {
+      "types": "./src/groqVoiceTranscription.ts",
+      "import": "./src/groqVoiceTranscription.ts"
+    },
+    "./voiceTranscription": {
+      "types": "./src/voiceTranscription.ts",
+      "import": "./src/voiceTranscription.ts"
+    },
     "./composerSlashCommands": {
       "types": "./src/composerSlashCommands.ts",
       "import": "./src/composerSlashCommands.ts"

--- a/packages/shared/src/groqVoiceTranscription.test.ts
+++ b/packages/shared/src/groqVoiceTranscription.test.ts
@@ -1,0 +1,83 @@
+// FILE: groqVoiceTranscription.test.ts
+// Purpose: Verifies Groq STT transport origin pinning and multipart fields.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  GROQ_VOICE_TRANSCRIPTION_URL,
+  prewarmGroqVoiceTranscriptionConnection,
+  readGroqApiKeyFromEnv,
+  requestGroqVoiceTranscription,
+} from "./groqVoiceTranscription";
+import { outboundHttp } from "./outboundHttp";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("readGroqApiKeyFromEnv", () => {
+  it("returns a trimmed key and ignores blanks", () => {
+    expect(readGroqApiKeyFromEnv({ GROQ_API_KEY: "  gsk_test  " })).toBe("gsk_test");
+    expect(readGroqApiKeyFromEnv({ GROQ_API_KEY: "   " })).toBeNull();
+    expect(readGroqApiKeyFromEnv({})).toBeNull();
+  });
+});
+
+describe("prewarmGroqVoiceTranscriptionConnection", () => {
+  it("opens the Groq HTTPS origin with a bounded HEAD request", async () => {
+    const request = vi.spyOn(outboundHttp, "request").mockResolvedValue({
+      status: 200,
+      headers: new Headers(),
+      body: new Uint8Array(),
+      url: "https://api.groq.com/",
+    });
+
+    await prewarmGroqVoiceTranscriptionConnection();
+
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: new URL("/", GROQ_VOICE_TRANSCRIPTION_URL),
+        method: "HEAD",
+        policy: expect.objectContaining({
+          service: "groq-voice-transcription",
+          timeoutMs: 10_000,
+          maxResponseBytes: 64 * 1024,
+          maxConcurrent: 2,
+        }),
+      }),
+    );
+  });
+});
+
+describe("requestGroqVoiceTranscription", () => {
+  it("posts WAV audio and the selected model to Groq transcriptions", async () => {
+    const request = vi.spyOn(outboundHttp, "request").mockResolvedValue({
+      status: 200,
+      headers: new Headers(),
+      body: new Uint8Array(),
+      url: GROQ_VOICE_TRANSCRIPTION_URL,
+    });
+
+    await requestGroqVoiceTranscription({
+      audio: Uint8Array.from([1, 2, 3]),
+      mimeType: "audio/wav",
+      apiKey: "gsk_test",
+      model: "whisper-large-v3-turbo",
+    });
+
+    const outbound = request.mock.calls[0]?.[0];
+    expect(outbound?.url).toBe(GROQ_VOICE_TRANSCRIPTION_URL);
+    expect(outbound?.method).toBe("POST");
+    expect(outbound?.headers).toEqual(
+      expect.objectContaining({
+        Authorization: "Bearer gsk_test",
+      }),
+    );
+    const body = new TextDecoder().decode(outbound?.body as Uint8Array);
+    expect(body).toContain('filename="voice.wav"');
+    expect(body).toContain('name="model"');
+    expect(body).toContain("whisper-large-v3-turbo");
+    expect(body).toContain('name="response_format"');
+    expect(body).toContain("json");
+  });
+});

--- a/packages/shared/src/groqVoiceTranscription.ts
+++ b/packages/shared/src/groqVoiceTranscription.ts
@@ -1,0 +1,88 @@
+// FILE: groqVoiceTranscription.ts
+// Purpose: Owns the Groq speech-to-text origin, multipart, and resource policy.
+// Layer: Shared Node/Electron provider transport
+
+import { SERVER_VOICE_TRANSCRIPTION_MAX_AUDIO_BYTES } from "@synara/contracts";
+
+import { encodeOutboundMultipart, outboundHttp, type OutboundHttpResponse } from "./outboundHttp";
+
+export const GROQ_VOICE_TRANSCRIPTION_URL = "https://api.groq.com/openai/v1/audio/transcriptions";
+
+const MAX_MULTIPART_BYTES = SERVER_VOICE_TRANSCRIPTION_MAX_AUDIO_BYTES + 64 * 1024;
+const MAX_RESPONSE_BYTES = 1024 * 1024;
+const GROQ_VOICE_ORIGIN = new URL(GROQ_VOICE_TRANSCRIPTION_URL).origin;
+
+export function readGroqApiKeyFromEnv(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): string | null {
+  const value = env.GROQ_API_KEY?.trim() ?? "";
+  return value.length > 0 ? value : null;
+}
+
+export async function prewarmGroqVoiceTranscriptionConnection(): Promise<void> {
+  await outboundHttp.request({
+    policy: {
+      service: "groq-voice-transcription",
+      allowedOrigins: [GROQ_VOICE_ORIGIN],
+      timeoutMs: 10_000,
+      maxRequestBytes: 1,
+      maxResponseBytes: 64 * 1024,
+      maxRedirects: 0,
+      maxConcurrent: 2,
+      maxQueued: 4,
+      requirePublicAddress: true,
+    },
+    url: new URL("/", GROQ_VOICE_TRANSCRIPTION_URL),
+    method: "HEAD",
+  });
+}
+
+export function requestGroqVoiceTranscription(input: {
+  readonly audio: Uint8Array;
+  readonly mimeType: string;
+  readonly apiKey: string;
+  readonly model: string;
+  readonly signal?: AbortSignal;
+}): Promise<OutboundHttpResponse> {
+  const multipart = encodeOutboundMultipart(
+    [
+      {
+        name: "file",
+        filename: "voice.wav",
+        contentType: input.mimeType,
+        body: input.audio,
+      },
+      {
+        name: "model",
+        body: input.model,
+      },
+      {
+        name: "response_format",
+        body: "json",
+      },
+    ],
+    { maxBytes: MAX_MULTIPART_BYTES },
+  );
+
+  return outboundHttp.request({
+    policy: {
+      service: "groq-voice-transcription",
+      allowedOrigins: [GROQ_VOICE_ORIGIN],
+      timeoutMs: 30_000,
+      maxRequestBytes: MAX_MULTIPART_BYTES,
+      maxResponseBytes: MAX_RESPONSE_BYTES,
+      maxRedirects: 0,
+      maxConcurrent: 2,
+      maxQueued: 4,
+      requirePublicAddress: true,
+    },
+    url: GROQ_VOICE_TRANSCRIPTION_URL,
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${input.apiKey}`,
+      "Content-Type": multipart.contentType,
+    },
+    body: multipart.body,
+    ...(input.signal ? { signal: input.signal } : {}),
+  });
+}

--- a/packages/shared/src/voiceTranscription.test.ts
+++ b/packages/shared/src/voiceTranscription.test.ts
@@ -1,0 +1,56 @@
+// FILE: voiceTranscription.test.ts
+// Purpose: Locks independent STT routing so Groq does not depend on the coding harness.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  isIndependentVoiceTranscriptionReady,
+  resolveVoiceTranscriptionBackend,
+} from "./voiceTranscription";
+
+describe("isIndependentVoiceTranscriptionReady", () => {
+  it("is ready for auto and groq only when a Groq key is configured", () => {
+    expect(
+      isIndependentVoiceTranscriptionReady({ provider: "auto", groqApiKeyConfigured: true }),
+    ).toBe(true);
+    expect(
+      isIndependentVoiceTranscriptionReady({ provider: "groq", groqApiKeyConfigured: true }),
+    ).toBe(true);
+    expect(
+      isIndependentVoiceTranscriptionReady({ provider: "auto", groqApiKeyConfigured: false }),
+    ).toBe(false);
+    expect(
+      isIndependentVoiceTranscriptionReady({
+        provider: "chatgpt",
+        groqApiKeyConfigured: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveVoiceTranscriptionBackend", () => {
+  it("prefers Groq in auto mode when a key is present", () => {
+    expect(resolveVoiceTranscriptionBackend({ provider: "auto", groqApiKey: "gsk_test" })).toEqual({
+      kind: "groq",
+      apiKey: "gsk_test",
+    });
+  });
+
+  it("falls back to ChatGPT in auto mode without a Groq key", () => {
+    expect(resolveVoiceTranscriptionBackend({ provider: "auto", groqApiKey: null })).toEqual({
+      kind: "chatgpt",
+    });
+  });
+
+  it("requires a Groq key when Groq is selected explicitly", () => {
+    expect(resolveVoiceTranscriptionBackend({ provider: "groq", groqApiKey: null })).toEqual({
+      kind: "missing-groq-key",
+    });
+  });
+
+  it("keeps ChatGPT when that provider is selected even if a Groq key exists", () => {
+    expect(
+      resolveVoiceTranscriptionBackend({ provider: "chatgpt", groqApiKey: "gsk_test" }),
+    ).toEqual({ kind: "chatgpt" });
+  });
+});

--- a/packages/shared/src/voiceTranscription.ts
+++ b/packages/shared/src/voiceTranscription.ts
@@ -1,0 +1,35 @@
+// FILE: voiceTranscription.ts
+// Purpose: Pure routing helpers for the configurable voice-to-text backend.
+// Layer: Shared settings/runtime helper
+// The coding-agent harness is not the STT provider; Groq can run while Codex,
+// Claude, or any other agent is selected.
+
+import type { VoiceTranscriptionProviderKind } from "@synara/contracts";
+
+export type ResolvedVoiceTranscriptionBackend =
+  | { readonly kind: "groq"; readonly apiKey: string }
+  | { readonly kind: "chatgpt" }
+  | { readonly kind: "missing-groq-key" };
+
+export function isIndependentVoiceTranscriptionReady(input: {
+  readonly provider: VoiceTranscriptionProviderKind;
+  readonly groqApiKeyConfigured: boolean;
+}): boolean {
+  return input.provider !== "chatgpt" && input.groqApiKeyConfigured;
+}
+
+export function resolveVoiceTranscriptionBackend(input: {
+  readonly provider: VoiceTranscriptionProviderKind;
+  readonly groqApiKey: string | null;
+}): ResolvedVoiceTranscriptionBackend {
+  if (input.provider === "chatgpt") {
+    return { kind: "chatgpt" };
+  }
+  if (input.groqApiKey) {
+    return { kind: "groq", apiKey: input.groqApiKey };
+  }
+  if (input.provider === "groq") {
+    return { kind: "missing-groq-key" };
+  }
+  return { kind: "chatgpt" };
+}


### PR DESCRIPTION
## Problem

Voice dictation is tied to a ChatGPT-authenticated Codex session. The composer always sends `provider: "codex"` and hides or rejects the mic unless that Codex ChatGPT login is present, so dictation is unavailable when the current chat uses Claude, Grok, or any other harness.

There is no existing Groq STT integration in the product, and no open PR covering this.

## Solution

Make speech-to-text a configurable server setting, independent of the coding-agent provider:

- New `voiceTranscription` setting: `auto` | `groq` | `chatgpt` (default `auto`)
- Groq Whisper as the first independent STT backend (`whisper-large-v3-turbo` default)
- Groq API key stored in the server secret store (never in the settings view). `GROQ_API_KEY` in the environment is also accepted
- HTTP `/api/voice/transcribe` and `server.transcribeVoice` / `server.prewarmVoice` dispatch to Groq without requiring Codex to be enabled
- Settings > General > Voice dictation: provider, Groq model, API key
- Composer/kanban mic works with Groq even when Codex is unauthenticated

`auto` uses Groq when a key is present, otherwise the existing ChatGPT/Codex path.

## Tests

- Shared Groq transport and routing helpers
- Server Groq transcription, secret redaction, dispatch with Codex disabled, missing-key fail-closed
- HTTP upload uses Groq when Codex is disabled
- App settings mapping and composer availability when only Groq is configured

`bun fmt`, `bun lint`, and `bun typecheck` passed.

## Reviewer notes

- Settings UI: General → Voice dictation
- Set a Groq key (or `GROQ_API_KEY`) and record a voice note in a non-Codex thread
- ChatGPT path is unchanged when no Groq key is configured